### PR TITLE
Title: fix(win10): tray popup positioning and global hotkey reliability

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -68,6 +68,7 @@ public partial class App : Application
     private NotificationHistoryWindow? _notificationHistoryWindow;
     private ActivityStreamWindow? _activityStreamWindow;
     private TrayMenuWindow? _trayMenuWindow;
+    private QuickSendDialog? _quickSendDialog;
     
     // Node service (optional, enabled in settings)
     private NodeService? _nodeService;
@@ -1668,9 +1669,41 @@ public partial class App : Application
 
     private void ShowQuickSend(string? prefillMessage = null)
     {
-        if (_gatewayClient == null) return;
-        var dialog = new QuickSendDialog(_gatewayClient, prefillMessage);
-        dialog.Activate();
+        if (_gatewayClient == null)
+        {
+            Logger.Warn("QuickSend blocked: gateway client not initialized");
+            return;
+        }
+
+        try
+        {
+            // Keep a strong reference to the window; otherwise the dialog can be GC'd
+            // and appear to not open (especially when triggered from a hotkey).
+            if (_quickSendDialog != null)
+            {
+                // If caller wants a prefill, re-create to apply it.
+                if (!string.IsNullOrEmpty(prefillMessage))
+                {
+                    try { _quickSendDialog.Close(); } catch { }
+                    _quickSendDialog = null;
+                }
+                else
+                {
+                    Logger.Info("QuickSend dialog already open; activating");
+                    _quickSendDialog.Activate();
+                    return;
+                }
+            }
+
+            Logger.Info("Showing QuickSend dialog");
+            _quickSendDialog = new QuickSendDialog(_gatewayClient, prefillMessage);
+            _quickSendDialog.Closed += (s, e) => _quickSendDialog = null;
+            _quickSendDialog.Activate();
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"Failed to show QuickSend dialog: {ex.Message}");
+        }
     }
 
     private void ShowStatusDetail()
@@ -1827,7 +1860,19 @@ public partial class App : Application
 
     private void OnGlobalHotkeyPressed(object? sender, EventArgs e)
     {
-        ShowQuickSend();
+        // Hotkey events are raised from a dedicated Win32 message-loop thread.
+        // Creating/activating WinUI windows must happen on the app's UI thread.
+        if (_dispatcherQueue == null)
+        {
+            Logger.Warn("Hotkey pressed but DispatcherQueue is null");
+            return;
+        }
+
+        var enqueued = _dispatcherQueue.TryEnqueue(() => ShowQuickSend());
+        if (!enqueued)
+        {
+            Logger.Warn("Hotkey pressed but failed to enqueue QuickSend on UI thread");
+        }
     }
 
     #endregion

--- a/src/OpenClaw.Tray.WinUI/Dialogs/QuickSendDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/QuickSendDialog.cs
@@ -7,6 +7,7 @@ using OpenClaw.Shared;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using System;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using WinUIEx;
 
@@ -23,6 +24,28 @@ public sealed class QuickSendDialog : WindowEx
     private readonly TextBlock _statusText;
     private bool _isSending;
 
+    [DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [DllImport("user32.dll")]
+    private static extern bool SetWindowPos(
+        IntPtr hWnd,
+        IntPtr hWndInsertAfter,
+        int X,
+        int Y,
+        int cx,
+        int cy,
+        uint uFlags);
+
+    private static readonly IntPtr HWND_TOPMOST = new(-1);
+    private const int SW_SHOWNORMAL = 1;
+    private const uint SWP_NOMOVE = 0x0002;
+    private const uint SWP_NOSIZE = 0x0001;
+    private const uint SWP_SHOWWINDOW = 0x0040;
+
     public QuickSendDialog(OpenClawGatewayClient client, string? prefillMessage = null)
     {
         _client = client;
@@ -33,8 +56,13 @@ public sealed class QuickSendDialog : WindowEx
         this.CenterOnScreen();
         this.SetIcon(IconHelper.GetStatusIconPath(ConnectionStatus.Connected));
         
-        // Apply Acrylic backdrop for transient dialog feel
-        SystemBackdrop = new DesktopAcrylicBackdrop();
+        // Apply Acrylic via controller to keep IsInputActive=true.
+        // This avoids focus/activation oddities on Windows 10 for hotkey-launched windows.
+        BackdropHelper.TrySetAcrylicBackdrop((Microsoft.UI.Xaml.Window)this);
+
+        // Hotkey-launched windows can fail to foreground on Windows 10 due to
+        // foreground activation restrictions. Ensure the window is topmost.
+        this.IsAlwaysOnTop = true;
         
         // Build UI programmatically (simple dialog)
         var root = new StackPanel
@@ -90,7 +118,29 @@ public sealed class QuickSendDialog : WindowEx
         Content = root;
 
         // Focus the text box when shown
-        Activated += (s, e) => _messageTextBox.Focus(FocusState.Programmatic);
+        Activated += (s, e) =>
+        {
+            _messageTextBox.Focus(FocusState.Programmatic);
+            TryBringToFront();
+        };
+    }
+
+    private void TryBringToFront()
+    {
+        try
+        {
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            if (hwnd == IntPtr.Zero) return;
+
+            // Make sure it's actually shown and promoted.
+            ShowWindow(hwnd, SW_SHOWNORMAL);
+            SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+            SetForegroundWindow(hwnd);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"QuickSend bring-to-front failed: {ex.Message}");
+        }
     }
 
     private async void OnKeyDown(object sender, KeyRoutedEventArgs e)

--- a/src/OpenClaw.Tray.WinUI/Helpers/BackdropHelper.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/BackdropHelper.cs
@@ -63,7 +63,7 @@ public static class BackdropHelper
     /// <summary>
     /// Applies Desktop Acrylic backdrop to a window with IsInputActive always true.
     /// </summary>
-    public static DesktopAcrylicController? TrySetAcrylicBackdrop(Window window)
+    public static DesktopAcrylicController? TrySetAcrylicBackdrop(Microsoft.UI.Xaml.Window window)
     {
         if (!DesktopAcrylicController.IsSupported())
             return null;

--- a/src/OpenClaw.Tray.WinUI/Services/GlobalHotkeyService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/GlobalHotkeyService.cs
@@ -1,5 +1,7 @@
 using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace OpenClawTray.Services;
 
@@ -16,10 +18,10 @@ public class GlobalHotkeyService : IDisposable
     private const uint VK_C = 0x43;
     private const int WM_HOTKEY = 0x0312;
 
-    [DllImport("user32.dll")]
+    [DllImport("user32.dll", SetLastError = true)]
     private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
 
-    [DllImport("user32.dll")]
+    [DllImport("user32.dll", SetLastError = true)]
     private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
 
     [DllImport("user32.dll", SetLastError = true)]
@@ -52,8 +54,18 @@ public class GlobalHotkeyService : IDisposable
     [DllImport("user32.dll")]
     private static extern bool PostMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
 
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool PostThreadMessage(uint idThread, uint Msg, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("kernel32.dll")]
+    private static extern uint GetCurrentThreadId();
+
     private const uint WM_QUIT = 0x0012;
     private const uint WM_USER = 0x0400;
+    private const uint WM_APP_REGISTER = WM_USER + 1;
+    private const uint WM_APP_UNREGISTER = WM_USER + 2;
+
+    private const uint MOD_NOREPEAT = 0x4000;
 
     private delegate IntPtr WndProcDelegate(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
 
@@ -97,6 +109,10 @@ public class GlobalHotkeyService : IDisposable
     private WndProcDelegate? _wndProcDelegate; // prevent GC collection
     private volatile bool _running;
 
+    private uint _messageThreadId;
+    private readonly ManualResetEventSlim _windowReady = new(false);
+    private readonly ManualResetEventSlim _opCompleted = new(false);
+
     public event EventHandler? HotkeyPressed;
 
     public GlobalHotkeyService()
@@ -110,12 +126,13 @@ public class GlobalHotkeyService : IDisposable
         try
         {
             // Create message window on a dedicated thread with message loop
-            _running = true;
-            _messageThread = new Thread(MessageLoop) { IsBackground = true, Name = "HotkeyMessageLoop" };
-            _messageThread.Start();
+            EnsureMessageLoop();
 
-            // Wait briefly for window creation
-            Thread.Sleep(100);
+            if (!_windowReady.Wait(TimeSpan.FromSeconds(2)))
+            {
+                Logger.Warn("Timed out waiting for hotkey message window");
+                return false;
+            }
 
             if (_hwnd == IntPtr.Zero)
             {
@@ -123,15 +140,9 @@ public class GlobalHotkeyService : IDisposable
                 return false;
             }
 
-            _registered = RegisterHotKey(_hwnd, HOTKEY_ID, MOD_CONTROL | MOD_ALT | MOD_SHIFT, VK_C);
-            if (_registered)
-            {
-                Logger.Info("Global hotkey registered: Ctrl+Alt+Shift+C");
-            }
-            else
-            {
-                Logger.Warn("Failed to register global hotkey (may be in use by another app)");
-            }
+            _opCompleted.Reset();
+            PostMessage(_hwnd, WM_APP_REGISTER, IntPtr.Zero, IntPtr.Zero);
+            _opCompleted.Wait(TimeSpan.FromSeconds(2));
             return _registered;
         }
         catch (Exception ex)
@@ -141,10 +152,25 @@ public class GlobalHotkeyService : IDisposable
         }
     }
 
+    private void EnsureMessageLoop()
+    {
+        if (_messageThread != null) return;
+
+        _running = true;
+        _messageThread = new Thread(MessageLoop)
+        {
+            IsBackground = true,
+            Name = "HotkeyMessageLoop"
+        };
+        _messageThread.Start();
+    }
+
     private void MessageLoop()
     {
         try
         {
+            _messageThreadId = GetCurrentThreadId();
+
             // Create window class
             _wndProcDelegate = WndProc;
             var wndClass = new WNDCLASS
@@ -161,6 +187,8 @@ public class GlobalHotkeyService : IDisposable
                 new IntPtr(-3), // HWND_MESSAGE
                 IntPtr.Zero, GetModuleHandle(null), IntPtr.Zero);
 
+            _windowReady.Set();
+
             // Message loop
             while (_running && GetMessage(out MSG msg, IntPtr.Zero, 0, 0))
             {
@@ -171,13 +199,59 @@ public class GlobalHotkeyService : IDisposable
         catch (Exception ex)
         {
             Logger.Error($"Hotkey message loop error: {ex.Message}");
+            _windowReady.Set();
         }
     }
 
     private IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
     {
+        if (msg == WM_APP_REGISTER)
+        {
+            // Register from the message-loop thread that owns hWnd.
+            _registered = RegisterHotKey(hWnd, HOTKEY_ID,
+                MOD_CONTROL | MOD_ALT | MOD_SHIFT | MOD_NOREPEAT,
+                VK_C);
+
+            if (_registered)
+            {
+                Logger.Info("Global hotkey registered: Ctrl+Alt+Shift+C");
+            }
+            else
+            {
+                var err = Marshal.GetLastWin32Error();
+                var errMsg = new Win32Exception(err).Message;
+                Logger.Warn($"Failed to register global hotkey (Win32Error={err}: {errMsg})");
+            }
+
+            _opCompleted.Set();
+            return IntPtr.Zero;
+        }
+
+        if (msg == WM_APP_UNREGISTER)
+        {
+            try
+            {
+                if (_registered)
+                {
+                    UnregisterHotKey(hWnd, HOTKEY_ID);
+                    _registered = false;
+                    Logger.Info("Global hotkey unregistered");
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn($"Hotkey unregistration error: {ex.Message}");
+            }
+            finally
+            {
+                _opCompleted.Set();
+            }
+            return IntPtr.Zero;
+        }
+
         if (msg == WM_HOTKEY && wParam.ToInt32() == HOTKEY_ID)
         {
+            Logger.Info("Hotkey pressed: Ctrl+Alt+Shift+C");
             OnHotkeyPressed();
         }
         return DefWindowProc(hWnd, msg, wParam, lParam);
@@ -189,12 +263,11 @@ public class GlobalHotkeyService : IDisposable
 
         try
         {
-            if (_hwnd != IntPtr.Zero)
-            {
-                UnregisterHotKey(_hwnd, HOTKEY_ID);
-            }
-            _registered = false;
-            Logger.Info("Global hotkey unregistered");
+            if (_hwnd == IntPtr.Zero) return;
+
+            _opCompleted.Reset();
+            PostMessage(_hwnd, WM_APP_UNREGISTER, IntPtr.Zero, IntPtr.Zero);
+            _opCompleted.Wait(TimeSpan.FromSeconds(2));
         }
         catch (Exception ex)
         {
@@ -215,10 +288,16 @@ public class GlobalHotkeyService : IDisposable
         Unregister();
 
         _running = false;
+
+        if (_messageThreadId != 0)
+        {
+            // WM_QUIT must be posted to the thread queue.
+            PostThreadMessage(_messageThreadId, WM_QUIT, IntPtr.Zero, IntPtr.Zero);
+        }
+
         if (_hwnd != IntPtr.Zero)
         {
-            PostMessage(_hwnd, WM_QUIT, IntPtr.Zero, IntPtr.Zero);
-            DestroyWindow(_hwnd);
+            try { DestroyWindow(_hwnd); } catch { }
             _hwnd = IntPtr.Zero;
         }
 

--- a/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
@@ -121,26 +121,71 @@ public sealed partial class TrayMenuWindow : WindowEx
 
         if (GetCursorPos(out POINT pt))
         {
-            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            uint dpi = GetDpiForWindow(hwnd);
-            if (dpi == 0) dpi = 96;
-            double scale = dpi / 96.0;
-
             // Get work area of monitor where cursor is
             var hMonitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
             var monitorInfo = new MONITORINFO { cbSize = Marshal.SizeOf<MONITORINFO>() };
             GetMonitorInfo(hMonitor, ref monitorInfo);
             var workArea = monitorInfo.rcWork;
 
-            // Scale menu dimensions
-            int menuWidthPhysical = (int)(280 * scale);
-            int menuHeightPhysical = (int)(_menuHeight * scale);
+            // Prefer using the AppWindow's actual pixel size. This is more reliable than
+            // estimating based on DPI and item counts, especially on Windows 10 when the
+            // cursor can be in the taskbar region (outside rcWork).
+            int menuWidthPx;
+            int menuHeightPx;
+            try
+            {
+                menuWidthPx = this.AppWindow.Size.Width;
+                menuHeightPx = this.AppWindow.Size.Height;
+            }
+            catch
+            {
+                menuWidthPx = 0;
+                menuHeightPx = 0;
+            }
 
-            // Position: keep on screen, prefer above cursor (tray is at bottom)
-            int x = Math.Clamp(pt.X, workArea.Left, workArea.Right - menuWidthPhysical);
-            int y = pt.Y - menuHeightPhysical - 10;
-            if (y < workArea.Top)
-                y = pt.Y + 10;
+            // Fallback to a conservative estimate if AppWindow size isn't available yet.
+            if (menuWidthPx <= 0 || menuHeightPx <= 0)
+            {
+                var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+                uint dpi = GetDpiForWindow(hwnd);
+                if (dpi == 0) dpi = 96;
+                double scale = dpi / 96.0;
+                menuWidthPx = (int)(280 * scale);
+                menuHeightPx = (int)(_menuHeight * scale);
+            }
+
+            const int margin = 8;
+
+            int maxX = workArea.Right - menuWidthPx;
+            if (maxX < workArea.Left) maxX = workArea.Left;
+            int x = Math.Clamp(pt.X, workArea.Left, maxX);
+
+            int maxY = workArea.Bottom - menuHeightPx;
+            if (maxY < workArea.Top) maxY = workArea.Top;
+
+            // Candidate positions. Prefer above the cursor (typical tray behavior).
+            // On Windows 10 the cursor can be in the taskbar area, so clamp to rcWork
+            // to avoid the menu overflowing under the taskbar.
+            int yAbove = pt.Y - menuHeightPx - margin;
+            int yBelow = pt.Y + margin;
+
+            bool canShowAbove = yAbove >= workArea.Top;
+            bool canShowBelow = yBelow <= maxY;
+
+            int y;
+            if (canShowAbove)
+            {
+                y = Math.Min(yAbove, maxY);
+            }
+            else if (canShowBelow)
+            {
+                y = Math.Max(yBelow, workArea.Top);
+            }
+            else
+            {
+                // Worst case: clamp within the visible work area.
+                y = Math.Clamp(yAbove, workArea.Top, maxY);
+            }
 
             this.Move(x, y);
         }


### PR DESCRIPTION
- Fix Windows 10 tray right-click popup positioning: clamp to the monitor work area so it doesn’t overflow under the taskbar and anchors correctly to the cursor.

- Fix Windows 10 global hotkey (Ctrl+Alt+Shift+C) not opening the floating Quick Send window: register hotkey on the message-loop thread, dispatch UI creation to the UI thread, and force the window to foreground/topmost.

- Tests: dotnet test -c Debug