### PR TITLE
Use native ARM64 runner for ARM64 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
   build:
     needs: test
-    runs-on: windows-latest
+    runs-on: ${{ matrix.rid == 'win-arm64' && 'windows-11-arm' || 'windows-latest' }}
     strategy:
       matrix:
         rid: [win-x64, win-arm64]
@@ -105,7 +105,7 @@ jobs:
 
   build-msix:
     needs: test
-    runs-on: windows-latest
+    runs-on: ${{ matrix.rid == 'win-arm64' && 'windows-11-arm' || 'windows-latest' }}
     continue-on-error: true
     strategy:
       fail-fast: false


### PR DESCRIPTION
The `build-msix (win-arm64)` job was failing with **MSB3030**: `Could not copy apphost.exe because it was not found` — the x64 GitHub Actions runner doesn't have the ARM64 app host for cross-compilation.

## Fix
Use the free `windows-11-arm` hosted runner for ARM64 matrix entries in both `build` and `build-msix` jobs, building natively instead of cross-compiling.

## References
- Failed run: https://github.com/openclaw/openclaw-windows-node/actions/runs/23171761200
- dotnet/msbuild#8596 — known cross-compile apphost issue
- [windows-11-arm runner availability](https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/) — free for public repos
