### PR TITLE
perf: hoist shell normalisation and cache notification regex objects

### DIFF
--- a/src/OpenClaw.Shared/ExecApprovalPolicy.cs
+++ b/src/OpenClaw.Shared/ExecApprovalPolicy.cs
@@ -95,6 +95,9 @@ public class ExecApprovalPolicy
             };
         }
         
+        // Compute once; only used if any rule has shell filters.
+        var normalizedShell = (shell ?? "powershell").ToLowerInvariant();
+
         foreach (var rule in _rules)
         {
             if (!rule.Enabled) continue;
@@ -102,7 +105,6 @@ public class ExecApprovalPolicy
             // Check shell filter
             if (rule.Shells is { Length: > 0 })
             {
-                var normalizedShell = (shell ?? "powershell").ToLowerInvariant();
                 if (!rule.Shells.Any(s => s.Equals(normalizedShell, StringComparison.OrdinalIgnoreCase)))
                     continue;
             }

--- a/src/OpenClaw.Shared/NotificationCategorizer.cs
+++ b/src/OpenClaw.Shared/NotificationCategorizer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
@@ -113,19 +114,33 @@ public class NotificationCategorizer
         return ("🤖 OpenClaw", "info");
     }
 
+    // Regex cache: avoids recompiling the same pattern on every notification.
+    // The Regex instances are constructed with a 100ms match timeout to guard against ReDoS.
+    private static readonly ConcurrentDictionary<string, Regex?> _regexCache = new(StringComparer.Ordinal);
+
     private static bool MatchesRule(string text, UserNotificationRule rule)
     {
         if (string.IsNullOrEmpty(rule.Pattern)) return false;
 
         if (rule.IsRegex)
         {
+            var regex = _regexCache.GetOrAdd(rule.Pattern, static p =>
+            {
+                try
+                {
+                    return new Regex(p, RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
+                }
+                catch (RegexParseException)
+                {
+                    return null;
+                }
+            });
+
+            if (regex == null) return false;
+
             try
             {
-                return Regex.IsMatch(text, rule.Pattern, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100));
-            }
-            catch (RegexParseException)
-            {
-                return false;
+                return regex.IsMatch(text);
             }
             catch (RegexMatchTimeoutException)
             {


### PR DESCRIPTION
Two targeted performance improvements to hot-path code in OpenClaw.Shared, originally identified by Repo Assist (#34).

### 1. ExecApprovalPolicy.Evaluate — hoist shell normalisation
`normalizedShell` was allocated inside the foreach loop once per rule with a shell filter. Moved before the loop — one allocation instead of N.

### 2. NotificationCategorizer.MatchesRule — cache compiled Regex instances
The `Regex.IsMatch` overload with `matchTimeout` bypasses .NET's internal static regex cache. Replaced with a `ConcurrentDictionary<string, Regex?>` that caches compiled instances. ReDoS timeout (100ms) preserved. Invalid patterns stored as null so `RegexParseException` only thrown once.

All 432 tests pass. No behaviour changes.

Closes #34
