### PR TITLE
fix: persist NotificationSound by stable key, not display text

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml
@@ -57,9 +57,9 @@
                     <ToggleSwitch x:Name="NotificationsToggle" Header="Show notifications"/>
                     
                     <ComboBox x:Name="NotificationSoundComboBox" Header="Sound" Width="200">
-                        <ComboBoxItem Content="Default"/>
-                        <ComboBoxItem Content="None"/>
-                        <ComboBoxItem Content="Subtle"/>
+                        <ComboBoxItem Content="Default" Tag="Default"/>
+                        <ComboBoxItem Content="None" Tag="None"/>
+                        <ComboBoxItem Content="Subtle" Tag="Subtle"/>
                     </ComboBox>
                     
                     <TextBlock Text="Show notifications for:" Margin="0,8,0,0"/>

--- a/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml.cs
@@ -39,11 +39,11 @@ public sealed partial class SettingsWindow : WindowEx
         GlobalHotkeyToggle.IsOn = _settings.GlobalHotkeyEnabled;
         NotificationsToggle.IsOn = _settings.ShowNotifications;
         
-        // Set sound combo
+        // Set sound combo — match by Tag (stable persistence key), not Content (display text)
         for (int i = 0; i < NotificationSoundComboBox.Items.Count; i++)
         {
             if (NotificationSoundComboBox.Items[i] is Microsoft.UI.Xaml.Controls.ComboBoxItem item &&
-                item.Content?.ToString() == _settings.NotificationSound)
+                item.Tag?.ToString() == _settings.NotificationSound)
             {
                 NotificationSoundComboBox.SelectedIndex = i;
                 break;
@@ -76,7 +76,7 @@ public sealed partial class SettingsWindow : WindowEx
         
         if (NotificationSoundComboBox.SelectedItem is Microsoft.UI.Xaml.Controls.ComboBoxItem item)
         {
-            _settings.NotificationSound = item.Content?.ToString() ?? "Default";
+            _settings.NotificationSound = item.Tag?.ToString() ?? "Default";
         }
 
         _settings.NotifyHealth = NotifyHealthCb.IsChecked ?? true;

--- a/src/OpenClaw.Tray/SettingsDialog.cs
+++ b/src/OpenClaw.Tray/SettingsDialog.cs
@@ -129,6 +129,8 @@ public partial class SettingsDialog : ModernForm
             ForeColor = ForegroundColor,
             FlatStyle = FlatStyle.Flat
         };
+        // Items are stable persistence keys (must match values in settings.json).
+        // Do not localize these strings — use a display/key mapping if localization is needed.
         _notificationSoundComboBox.Items.AddRange(new[] { "Default", "None", "Critical", "Information" });
         
         _testNotificationButton = CreateModernButton("Test");


### PR DESCRIPTION
Decouple `NotificationSound` display text from persisted settings values, fixing a culture-sensitivity bug that would break settings if display strings are ever localized or changed.

## Changes
- **SettingsWindow.xaml**: Add `Tag` attributes to ComboBoxItems (stable persistence keys)
- **SettingsWindow.xaml.cs**: Load/save by `Tag` instead of `Content`
- **SettingsDialog.cs** (WinForms): Document that combo items are persistence keys

Follows the `Tag` attribute pattern already used correctly in `ActivityStreamWindow.xaml`.

**Backward compatible** — existing `settings.json` files are unaffected since current values already match the Tag keys. Unknown values fall back to "Default" (index 0).

Prerequisite for localization work in #40.
Fixes #41
