### PR TITLE
feat: add WinUI test project with extracted shared helpers

### DIFF
--- a/moltbot-windows-hub.slnx
+++ b/moltbot-windows-hub.slnx
@@ -9,5 +9,6 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj" />
+    <Project Path="tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/OpenClaw.Shared/DeepLinkParser.cs
+++ b/src/OpenClaw.Shared/DeepLinkParser.cs
@@ -1,0 +1,57 @@
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Result of parsing an openclaw:// deep link URI.
+/// </summary>
+public record DeepLinkResult(string Path, string Query, Dictionary<string, string> Parameters);
+
+/// <summary>
+/// Pure parser for openclaw:// deep link URIs.
+/// </summary>
+public static class DeepLinkParser
+{
+    private const string Scheme = "openclaw://";
+
+    public static DeepLinkResult? ParseDeepLink(string? uri)
+    {
+        if (string.IsNullOrWhiteSpace(uri))
+            return null;
+
+        if (!uri.StartsWith(Scheme, StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var remainder = uri[Scheme.Length..].TrimEnd('/');
+        var queryIndex = remainder.IndexOf('?');
+        var query = queryIndex >= 0 ? remainder[(queryIndex + 1)..] : "";
+        var path = queryIndex >= 0 ? remainder[..queryIndex] : remainder;
+
+        var parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var part in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var kv = part.Split('=', 2);
+            if (kv.Length == 2)
+            {
+                parameters[Uri.UnescapeDataString(kv[0])] = Uri.UnescapeDataString(kv[1]);
+            }
+        }
+
+        return new DeepLinkResult(path, query, parameters);
+    }
+
+    public static string? GetQueryParam(string? query, string key)
+    {
+        if (string.IsNullOrEmpty(query) || string.IsNullOrEmpty(key))
+            return null;
+
+        foreach (var part in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var kv = part.Split('=', 2);
+            if (kv.Length == 2 && kv[0].Equals(key, StringComparison.OrdinalIgnoreCase))
+            {
+                return Uri.UnescapeDataString(kv[1]);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/OpenClaw.Shared/MenuDisplayHelper.cs
+++ b/src/OpenClaw.Shared/MenuDisplayHelper.cs
@@ -1,0 +1,40 @@
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Pure helper methods for tray menu display formatting.
+/// </summary>
+public static class MenuDisplayHelper
+{
+    public static string GetStatusIcon(ConnectionStatus status) => status switch
+    {
+        ConnectionStatus.Connected => "✅",
+        ConnectionStatus.Connecting => "🔄",
+        ConnectionStatus.Error => "❌",
+        _ => "⚪"
+    };
+
+    public static string GetChannelStatusIcon(string? status)
+    {
+        if (ChannelHealth.IsHealthyStatus(status)) return "🟢";
+        if (ChannelHealth.IsIntermediateStatus(status)) return "🟡";
+        if (string.IsNullOrEmpty(status)) return "⚪";
+        return "🔴";
+    }
+
+    public static string TruncateText(string? text, int maxLength = 96)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return text ?? "";
+        if (text.Length <= maxLength) return text;
+        return text[..(maxLength - 1)] + "…";
+    }
+
+    public static string FormatProviderSummary(int count)
+    {
+        return $"{count} provider{(count == 1 ? "" : "s")} active";
+    }
+
+    public static string GetNextToggleValue(string? current)
+    {
+        return string.Equals(current, "on", StringComparison.OrdinalIgnoreCase) ? "off" : "on";
+    }
+}

--- a/src/OpenClaw.Shared/MenuPositioner.cs
+++ b/src/OpenClaw.Shared/MenuPositioner.cs
@@ -1,0 +1,51 @@
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Pure positioning math for tray popup menus.
+/// </summary>
+public static class MenuPositioner
+{
+    /// <summary>
+    /// Calculates the top-left position for a popup menu given the cursor location,
+    /// the menu dimensions, and the monitor work area (excluding taskbar).
+    /// Prefers showing above the cursor (typical tray behaviour).
+    /// </summary>
+    public static (int x, int y) CalculatePosition(
+        int cursorX, int cursorY,
+        int menuWidth, int menuHeight,
+        int workLeft, int workTop, int workRight, int workBottom,
+        int margin = 8)
+    {
+        // Clamp X within work area
+        int maxX = workRight - menuWidth;
+        if (maxX < workLeft) maxX = workLeft;
+        int x = Math.Clamp(cursorX, workLeft, maxX);
+
+        // Clamp Y within work area
+        int maxY = workBottom - menuHeight;
+        if (maxY < workTop) maxY = workTop;
+
+        int yAbove = cursorY - menuHeight - margin;
+        int yBelow = cursorY + margin;
+
+        bool canShowAbove = yAbove >= workTop;
+        bool canShowBelow = yBelow <= maxY;
+
+        int y;
+        if (canShowAbove)
+        {
+            y = Math.Min(yAbove, maxY);
+        }
+        else if (canShowBelow)
+        {
+            y = Math.Max(yBelow, workTop);
+        }
+        else
+        {
+            // Worst case: clamp within the visible work area.
+            y = Math.Clamp(yAbove, workTop, maxY);
+        }
+
+        return (x, y);
+    }
+}

--- a/src/OpenClaw.Shared/SettingsData.cs
+++ b/src/OpenClaw.Shared/SettingsData.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Serializable settings data model. Used for JSON round-trip persistence.
+/// </summary>
+public class SettingsData
+{
+    public string? GatewayUrl { get; set; }
+    public string? Token { get; set; }
+    public bool AutoStart { get; set; }
+    public bool GlobalHotkeyEnabled { get; set; } = true;
+    public bool ShowNotifications { get; set; } = true;
+    public string? NotificationSound { get; set; }
+    public bool NotifyHealth { get; set; } = true;
+    public bool NotifyUrgent { get; set; } = true;
+    public bool NotifyReminder { get; set; } = true;
+    public bool NotifyEmail { get; set; } = true;
+    public bool NotifyCalendar { get; set; } = true;
+    public bool NotifyBuild { get; set; } = true;
+    public bool NotifyStock { get; set; } = true;
+    public bool NotifyInfo { get; set; } = true;
+    public bool EnableNodeMode { get; set; } = false;
+    public bool HasSeenActivityStreamTip { get; set; } = false;
+    public bool NotifyChatResponses { get; set; } = true;
+    public bool PreferStructuredCategories { get; set; } = true;
+    public List<UserNotificationRule>? UserRules { get; set; }
+
+    private static readonly JsonSerializerOptions s_options = new() { WriteIndented = true };
+
+    public string ToJson() => JsonSerializer.Serialize(this, s_options);
+
+    public static SettingsData? FromJson(string json)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<SettingsData>(json);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -370,13 +370,7 @@ public partial class App : Application
         flyout.Items.Add(new MenuFlyoutSeparator());
 
         // Status
-        var statusIcon = _currentStatus switch
-        {
-            ConnectionStatus.Connected => "✅",
-            ConnectionStatus.Connecting => "🔄",
-            ConnectionStatus.Error => "❌",
-            _ => "⚪"
-        };
+        var statusIcon = MenuDisplayHelper.GetStatusIcon(_currentStatus);
         var statusItem = new MenuFlyoutItem { Text = $"{statusIcon} Status: {_currentStatus}" };
         statusItem.Click += (s, e) => ShowStatusDetail();
         flyout.Items.Add(statusItem);
@@ -704,12 +698,8 @@ public partial class App : Application
         return result == ContentDialogResult.Primary;
     }
 
-    private static string TruncateMenuText(string text, int maxLength = 96)
-    {
-        if (string.IsNullOrWhiteSpace(text)) return text;
-        if (text.Length <= maxLength) return text;
-        return text[..(maxLength - 1)] + "…";
-    }
+    private static string TruncateMenuText(string text, int maxLength = 96) =>
+        MenuDisplayHelper.TruncateText(text, maxLength);
 
     private void AddRecentActivity(
         string line,
@@ -742,13 +732,7 @@ public partial class App : Application
         menu.AddSeparator();
 
         // Status
-        var statusIcon = _currentStatus switch
-        {
-            ConnectionStatus.Connected => "✅",
-            ConnectionStatus.Connecting => "🔄",
-            ConnectionStatus.Error => "❌",
-            _ => "⚪"
-        };
+        var statusIcon = MenuDisplayHelper.GetStatusIcon(_currentStatus);
         menu.AddMenuItem($"Status: {_currentStatus}", statusIcon, "status");
 
         // Activity (if any)
@@ -764,7 +748,7 @@ public partial class App : Application
             if (string.IsNullOrWhiteSpace(usageText) || string.Equals(usageText, "No usage data", StringComparison.Ordinal))
             {
                 usageText = _lastUsageStatus?.Providers.Count > 0
-                    ? $"{_lastUsageStatus.Providers.Count} provider{(_lastUsageStatus.Providers.Count == 1 ? "" : "s")} active"
+                    ? MenuDisplayHelper.FormatProviderSummary(_lastUsageStatus.Providers.Count)
                     : "No usage data";
             }
 
@@ -891,16 +875,7 @@ public partial class App : Application
 
             foreach (var channel in _lastChannels)
             {
-                var rawStatus = channel.Status?.ToLowerInvariant() ?? "";
-                
-                // Match status logic from WinForms version
-                var channelIcon = rawStatus switch
-                {
-                    "ok" or "connected" or "running" or "active" or "ready" => "🟢",
-                    "stopped" or "idle" or "paused" or "configured" or "pending" => "🟡",
-                    "error" or "disconnected" or "failed" => "🔴",
-                    _ => "⚪"
-                };
+                var channelIcon = MenuDisplayHelper.GetChannelStatusIcon(channel.Status);
                 
                 var channelName = char.ToUpper(channel.Name[0]) + channel.Name[1..];
                 menu.AddMenuItem(channelName, channelIcon, $"channel:{channel.Name}", indent: true);
@@ -974,13 +949,7 @@ public partial class App : Application
         flyout.Items.Add(new MenuFlyoutSeparator());
 
         // Status
-        var statusIcon = _currentStatus switch
-        {
-            ConnectionStatus.Connected => "✅",
-            ConnectionStatus.Connecting => "🔄",
-            ConnectionStatus.Error => "❌",
-            _ => "⚪"
-        };
+        var statusIcon = MenuDisplayHelper.GetStatusIcon(_currentStatus);
         var statusItem = new MenuFlyoutItem
         {
             Text = $"{statusIcon} Status: {_currentStatus}"
@@ -1045,12 +1014,7 @@ public partial class App : Application
 
             foreach (var channel in _lastChannels)
             {
-                var channelIcon = channel.Status?.ToLowerInvariant() switch
-                {
-                    _ when ChannelHealth.IsHealthyStatus(channel.Status) => "🟢",
-                    _ when ChannelHealth.IsIntermediateStatus(channel.Status) => "🟡",
-                    _ => "🔴"
-                };
+                var channelIcon = MenuDisplayHelper.GetChannelStatusIcon(channel.Status);
                 var channelItem = new MenuFlyoutItem
                 {
                     Text = $"   {channelIcon} {channel.Name}"

--- a/src/OpenClaw.Tray.WinUI/Services/DeepLinkHandler.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/DeepLinkHandler.cs
@@ -45,13 +45,12 @@ public static class DeepLinkHandler
 
     public static void Handle(string uri, DeepLinkActions actions)
     {
-        if (!uri.StartsWith("openclaw://", StringComparison.OrdinalIgnoreCase))
+        var result = OpenClaw.Shared.DeepLinkParser.ParseDeepLink(uri);
+        if (result == null)
             return;
 
-        var path = uri["openclaw://".Length..].TrimEnd('/');
-        var queryIndex = path.IndexOf('?');
-        var query = queryIndex >= 0 ? path[(queryIndex + 1)..] : "";
-        path = queryIndex >= 0 ? path[..queryIndex] : path;
+        var path = result.Path;
+        var query = result.Query;
 
         Logger.Info($"Handling deep link: {path}");
 
@@ -75,12 +74,12 @@ public static class DeepLinkHandler
                 break;
 
             case "send":
-                var sendMessage = GetQueryParam(query, "message");
+                var sendMessage = OpenClaw.Shared.DeepLinkParser.GetQueryParam(query, "message");
                 actions.OpenQuickSend?.Invoke(sendMessage);
                 break;
 
             case "agent":
-                var agentMessage = GetQueryParam(query, "message");
+                var agentMessage = OpenClaw.Shared.DeepLinkParser.GetQueryParam(query, "message");
                 if (!string.IsNullOrEmpty(agentMessage))
                 {
                     _ = Task.Run(async () =>
@@ -102,19 +101,6 @@ public static class DeepLinkHandler
                 Logger.Warn($"Unknown deep link path: {path}");
                 break;
         }
-    }
-
-    private static string? GetQueryParam(string query, string key)
-    {
-        foreach (var part in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
-        {
-            var kv = part.Split('=', 2);
-            if (kv.Length == 2 && kv[0].Equals(key, StringComparison.OrdinalIgnoreCase))
-            {
-                return Uri.UnescapeDataString(kv[1]);
-            }
-        }
-        return null;
     }
 }
 

--- a/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text.Json;
+using OpenClaw.Shared;
 
 namespace OpenClawTray.Services;
 
@@ -58,7 +59,7 @@ public class SettingsManager
             if (File.Exists(SettingsFilePath))
             {
                 var json = File.ReadAllText(SettingsFilePath);
-                var loaded = JsonSerializer.Deserialize<SettingsData>(json);
+                var loaded = SettingsData.FromJson(json);
                 if (loaded != null)
                 {
                     GatewayUrl = loaded.GatewayUrl ?? GatewayUrl;
@@ -119,8 +120,7 @@ public class SettingsManager
                 UserRules = UserRules
             };
 
-            var options = new JsonSerializerOptions { WriteIndented = true };
-            var json = JsonSerializer.Serialize(data, options);
+            var json = data.ToJson();
             File.WriteAllText(SettingsFilePath, json);
             
             Logger.Info("Settings saved");
@@ -129,28 +129,5 @@ public class SettingsManager
         {
             Logger.Error($"Failed to save settings: {ex.Message}");
         }
-    }
-
-    private class SettingsData
-    {
-        public string? GatewayUrl { get; set; }
-        public string? Token { get; set; }
-        public bool AutoStart { get; set; }
-        public bool GlobalHotkeyEnabled { get; set; } = true;
-        public bool ShowNotifications { get; set; } = true;
-        public string? NotificationSound { get; set; }
-        public bool NotifyHealth { get; set; } = true;
-        public bool NotifyUrgent { get; set; } = true;
-        public bool NotifyReminder { get; set; } = true;
-        public bool NotifyEmail { get; set; } = true;
-        public bool NotifyCalendar { get; set; } = true;
-        public bool NotifyBuild { get; set; } = true;
-        public bool NotifyStock { get; set; } = true;
-        public bool NotifyInfo { get; set; } = true;
-        public bool EnableNodeMode { get; set; } = false;
-        public bool HasSeenActivityStreamTip { get; set; } = false;
-        public bool NotifyChatResponses { get; set; } = true;
-        public bool PreferStructuredCategories { get; set; } = true;
-        public List<OpenClaw.Shared.UserNotificationRule>? UserRules { get; set; }
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
@@ -156,36 +156,11 @@ public sealed partial class TrayMenuWindow : WindowEx
 
             const int margin = 8;
 
-            int maxX = workArea.Right - menuWidthPx;
-            if (maxX < workArea.Left) maxX = workArea.Left;
-            int x = Math.Clamp(pt.X, workArea.Left, maxX);
-
-            int maxY = workArea.Bottom - menuHeightPx;
-            if (maxY < workArea.Top) maxY = workArea.Top;
-
-            // Candidate positions. Prefer above the cursor (typical tray behavior).
-            // On Windows 10 the cursor can be in the taskbar area, so clamp to rcWork
-            // to avoid the menu overflowing under the taskbar.
-            int yAbove = pt.Y - menuHeightPx - margin;
-            int yBelow = pt.Y + margin;
-
-            bool canShowAbove = yAbove >= workArea.Top;
-            bool canShowBelow = yBelow <= maxY;
-
-            int y;
-            if (canShowAbove)
-            {
-                y = Math.Min(yAbove, maxY);
-            }
-            else if (canShowBelow)
-            {
-                y = Math.Max(yBelow, workArea.Top);
-            }
-            else
-            {
-                // Worst case: clamp within the visible work area.
-                y = Math.Clamp(yAbove, workArea.Top, maxY);
-            }
+            var (x, y) = OpenClaw.Shared.MenuPositioner.CalculatePosition(
+                pt.X, pt.Y,
+                menuWidthPx, menuHeightPx,
+                workArea.Left, workArea.Top, workArea.Right, workArea.Bottom,
+                margin);
 
             this.Move(x, y);
         }

--- a/tests/OpenClaw.Tray.Tests/DeepLinkParserTests.cs
+++ b/tests/OpenClaw.Tray.Tests/DeepLinkParserTests.cs
@@ -1,0 +1,172 @@
+using OpenClaw.Shared;
+
+namespace OpenClaw.Tray.Tests;
+
+public class DeepLinkParserTests
+{
+    #region ParseDeepLink
+
+    [Fact]
+    public void ParseDeepLink_Settings()
+    {
+        var result = DeepLinkParser.ParseDeepLink("openclaw://settings");
+        Assert.NotNull(result);
+        Assert.Equal("settings", result.Path);
+        Assert.Empty(result.Query);
+        Assert.Empty(result.Parameters);
+    }
+
+    [Fact]
+    public void ParseDeepLink_Dashboard()
+    {
+        var result = DeepLinkParser.ParseDeepLink("openclaw://dashboard");
+        Assert.NotNull(result);
+        Assert.Equal("dashboard", result.Path);
+    }
+
+    [Fact]
+    public void ParseDeepLink_DashboardSubpath()
+    {
+        var result = DeepLinkParser.ParseDeepLink("openclaw://dashboard/sessions");
+        Assert.NotNull(result);
+        Assert.Equal("dashboard/sessions", result.Path);
+    }
+
+    [Fact]
+    public void ParseDeepLink_SendWithMessage()
+    {
+        var result = DeepLinkParser.ParseDeepLink("openclaw://send?message=hello");
+        Assert.NotNull(result);
+        Assert.Equal("send", result.Path);
+        Assert.Equal("hello", result.Parameters["message"]);
+    }
+
+    [Fact]
+    public void ParseDeepLink_SendWithEncodedMessage()
+    {
+        var result = DeepLinkParser.ParseDeepLink("openclaw://send?message=hello%20world");
+        Assert.NotNull(result);
+        Assert.Equal("hello world", result.Parameters["message"]);
+    }
+
+    [Fact]
+    public void ParseDeepLink_MultipleQueryParams()
+    {
+        var result = DeepLinkParser.ParseDeepLink("openclaw://agent?message=hi&key=abc");
+        Assert.NotNull(result);
+        Assert.Equal("agent", result.Path);
+        Assert.Equal("hi", result.Parameters["message"]);
+        Assert.Equal("abc", result.Parameters["key"]);
+    }
+
+    [Fact]
+    public void ParseDeepLink_TrailingSlash_IsStripped()
+    {
+        var result = DeepLinkParser.ParseDeepLink("openclaw://settings/");
+        Assert.NotNull(result);
+        Assert.Equal("settings", result.Path);
+    }
+
+    [Fact]
+    public void ParseDeepLink_CaseInsensitiveScheme()
+    {
+        var result = DeepLinkParser.ParseDeepLink("OPENCLAW://dashboard");
+        Assert.NotNull(result);
+        Assert.Equal("dashboard", result.Path);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ParseDeepLink_NullOrEmpty_ReturnsNull(string? uri)
+    {
+        Assert.Null(DeepLinkParser.ParseDeepLink(uri));
+    }
+
+    [Fact]
+    public void ParseDeepLink_NoProtocol_ReturnsNull()
+    {
+        Assert.Null(DeepLinkParser.ParseDeepLink("settings"));
+    }
+
+    [Fact]
+    public void ParseDeepLink_WrongProtocol_ReturnsNull()
+    {
+        Assert.Null(DeepLinkParser.ParseDeepLink("https://settings"));
+    }
+
+    [Fact]
+    public void ParseDeepLink_EmptyPath()
+    {
+        var result = DeepLinkParser.ParseDeepLink("openclaw://");
+        Assert.NotNull(result);
+        Assert.Equal("", result.Path);
+    }
+
+    [Fact]
+    public void ParseDeepLink_MalformedQuery_IgnoresKeyOnly()
+    {
+        var result = DeepLinkParser.ParseDeepLink("openclaw://send?message");
+        Assert.NotNull(result);
+        Assert.Empty(result.Parameters);
+    }
+
+    #endregion
+
+    #region GetQueryParam
+
+    [Fact]
+    public void GetQueryParam_ExtractsValue()
+    {
+        Assert.Equal("hello", DeepLinkParser.GetQueryParam("message=hello", "message"));
+    }
+
+    [Fact]
+    public void GetQueryParam_CaseInsensitiveKey()
+    {
+        Assert.Equal("hello", DeepLinkParser.GetQueryParam("MESSAGE=hello", "message"));
+    }
+
+    [Fact]
+    public void GetQueryParam_UrlDecodes()
+    {
+        Assert.Equal("hello world", DeepLinkParser.GetQueryParam("msg=hello%20world", "msg"));
+    }
+
+    [Fact]
+    public void GetQueryParam_MissingKey_ReturnsNull()
+    {
+        Assert.Null(DeepLinkParser.GetQueryParam("message=hello", "missing"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void GetQueryParam_NullOrEmptyQuery_ReturnsNull(string? query)
+    {
+        Assert.Null(DeepLinkParser.GetQueryParam(query, "key"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void GetQueryParam_NullOrEmptyKey_ReturnsNull(string? key)
+    {
+        Assert.Null(DeepLinkParser.GetQueryParam("message=hello", key!));
+    }
+
+    [Fact]
+    public void GetQueryParam_MultipleParams_FindsCorrect()
+    {
+        Assert.Equal("bar", DeepLinkParser.GetQueryParam("foo=baz&key=bar&x=1", "key"));
+    }
+
+    [Fact]
+    public void GetQueryParam_ValueWithEquals()
+    {
+        Assert.Equal("a=b", DeepLinkParser.GetQueryParam("token=a=b", "token"));
+    }
+
+    #endregion
+}

--- a/tests/OpenClaw.Tray.Tests/MenuDisplayHelperTests.cs
+++ b/tests/OpenClaw.Tray.Tests/MenuDisplayHelperTests.cs
@@ -1,0 +1,165 @@
+using OpenClaw.Shared;
+
+namespace OpenClaw.Tray.Tests;
+
+public class MenuDisplayHelperTests
+{
+    #region GetStatusIcon
+
+    [Theory]
+    [InlineData(ConnectionStatus.Connected, "✅")]
+    [InlineData(ConnectionStatus.Connecting, "🔄")]
+    [InlineData(ConnectionStatus.Error, "❌")]
+    [InlineData(ConnectionStatus.Disconnected, "⚪")]
+    public void GetStatusIcon_ReturnsExpectedEmoji(ConnectionStatus status, string expected)
+    {
+        Assert.Equal(expected, MenuDisplayHelper.GetStatusIcon(status));
+    }
+
+    [Fact]
+    public void GetStatusIcon_UndefinedEnumValue_ReturnsFallback()
+    {
+        Assert.Equal("⚪", MenuDisplayHelper.GetStatusIcon((ConnectionStatus)999));
+    }
+
+    #endregion
+
+    #region GetChannelStatusIcon
+
+    [Theory]
+    [InlineData("ok", "🟢")]
+    [InlineData("connected", "🟢")]
+    [InlineData("running", "🟢")]
+    [InlineData("active", "🟢")]
+    [InlineData("ready", "🟢")]
+    [InlineData("stopped", "🟡")]
+    [InlineData("idle", "🟡")]
+    [InlineData("paused", "🟡")]
+    [InlineData("configured", "🟡")]
+    [InlineData("pending", "🟡")]
+    [InlineData("connecting", "🟡")]
+    [InlineData("reconnecting", "🟡")]
+    [InlineData("error", "🔴")]
+    [InlineData("disconnected", "🔴")]
+    [InlineData("failed", "🔴")]
+    public void GetChannelStatusIcon_KnownStatuses(string status, string expected)
+    {
+        Assert.Equal(expected, MenuDisplayHelper.GetChannelStatusIcon(status));
+    }
+
+    [Theory]
+    [InlineData("OK")]
+    [InlineData("Connected")]
+    [InlineData("RUNNING")]
+    [InlineData("Error")]
+    [InlineData("Connecting")]
+    [InlineData("RECONNECTING")]
+    public void GetChannelStatusIcon_CaseInsensitive(string status)
+    {
+        // Should not return the neutral fallback
+        Assert.NotEqual("⚪", MenuDisplayHelper.GetChannelStatusIcon(status));
+    }
+
+    [Theory]
+    [InlineData(null, "⚪")]
+    [InlineData("", "⚪")]
+    [InlineData("unknown", "🔴")]
+    [InlineData("something-new", "🔴")]
+    [InlineData("timeout", "🔴")]
+    public void GetChannelStatusIcon_UnknownOrEmpty(string? status, string expected)
+    {
+        Assert.Equal(expected, MenuDisplayHelper.GetChannelStatusIcon(status));
+    }
+
+    #endregion
+
+    #region TruncateText
+
+    [Fact]
+    public void TruncateText_ShortText_ReturnsUnchanged()
+    {
+        Assert.Equal("hello", MenuDisplayHelper.TruncateText("hello", 10));
+    }
+
+    [Fact]
+    public void TruncateText_ExactLength_ReturnsUnchanged()
+    {
+        Assert.Equal("12345", MenuDisplayHelper.TruncateText("12345", 5));
+    }
+
+    [Fact]
+    public void TruncateText_OverLength_Truncates()
+    {
+        var result = MenuDisplayHelper.TruncateText("Hello, World!", 6);
+        Assert.Equal("Hello…", result);
+        Assert.Equal(6, result.Length);
+    }
+
+    [Fact]
+    public void TruncateText_DefaultMaxLength_Is96()
+    {
+        var input = new string('x', 100);
+        var result = MenuDisplayHelper.TruncateText(input);
+        Assert.Equal(96, result.Length);
+        Assert.EndsWith("…", result);
+    }
+
+    [Fact]
+    public void TruncateText_Null_ReturnsEmpty()
+    {
+        Assert.Equal("", MenuDisplayHelper.TruncateText(null));
+    }
+
+    [Fact]
+    public void TruncateText_Empty_ReturnsEmpty()
+    {
+        Assert.Equal("", MenuDisplayHelper.TruncateText(""));
+    }
+
+    [Fact]
+    public void TruncateText_Whitespace_ReturnsAsIs()
+    {
+        Assert.Equal("   ", MenuDisplayHelper.TruncateText("   "));
+    }
+
+    #endregion
+
+    #region FormatProviderSummary
+
+    [Theory]
+    [InlineData(0, "0 providers active")]
+    [InlineData(1, "1 provider active")]
+    [InlineData(2, "2 providers active")]
+    [InlineData(10, "10 providers active")]
+    public void FormatProviderSummary_FormatsCorrectly(int count, string expected)
+    {
+        Assert.Equal(expected, MenuDisplayHelper.FormatProviderSummary(count));
+    }
+
+    #endregion
+
+    #region GetNextToggleValue
+
+    [Theory]
+    [InlineData("on", "off")]
+    [InlineData("off", "on")]
+    [InlineData("ON", "off")]
+    [InlineData("On", "off")]
+    [InlineData("OFF", "on")]
+    [InlineData("Off", "on")]
+    public void GetNextToggleValue_TogglesCorrectly(string current, string expected)
+    {
+        Assert.Equal(expected, MenuDisplayHelper.GetNextToggleValue(current));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("maybe")]
+    public void GetNextToggleValue_NullEmptyOrUnknown_ReturnsOn(string? current)
+    {
+        Assert.Equal("on", MenuDisplayHelper.GetNextToggleValue(current));
+    }
+
+    #endregion
+}

--- a/tests/OpenClaw.Tray.Tests/MenuPositionerTests.cs
+++ b/tests/OpenClaw.Tray.Tests/MenuPositionerTests.cs
@@ -1,0 +1,148 @@
+using OpenClaw.Shared;
+
+namespace OpenClaw.Tray.Tests;
+
+public class MenuPositionerTests
+{
+    // Standard 1920x1080 work area with taskbar at bottom (~40px)
+    private const int WorkLeft = 0;
+    private const int WorkTop = 0;
+    private const int WorkRight = 1920;
+    private const int WorkBottom = 1040;
+
+    private const int MenuWidth = 280;
+    private const int MenuHeight = 400;
+
+    [Fact]
+    public void CursorNearBottomRight_ShowsAboveAndLeft()
+    {
+        // Cursor near bottom-right (typical tray icon click)
+        var (x, y) = MenuPositioner.CalculatePosition(
+            1900, 1030, MenuWidth, MenuHeight,
+            WorkLeft, WorkTop, WorkRight, WorkBottom);
+
+        // X should be clamped so menu fits within work area
+        Assert.True(x + MenuWidth <= WorkRight, $"Menu right edge {x + MenuWidth} exceeds work area {WorkRight}");
+        // Y should be above cursor
+        Assert.True(y < 1030, $"Menu Y {y} should be above cursor 1030");
+        Assert.True(y >= WorkTop, $"Menu Y {y} below work area top {WorkTop}");
+    }
+
+    [Fact]
+    public void CursorNearTopLeft_ShowsBelow()
+    {
+        // Cursor near top-left: can't show above, should show below
+        var (x, y) = MenuPositioner.CalculatePosition(
+            50, 10, MenuWidth, MenuHeight,
+            WorkLeft, WorkTop, WorkRight, WorkBottom);
+
+        // Y should be below cursor
+        Assert.True(y > 10, $"Menu Y {y} should be below cursor 10");
+        Assert.True(y + MenuHeight <= WorkBottom, $"Menu bottom {y + MenuHeight} exceeds work bottom {WorkBottom}");
+        Assert.True(x >= WorkLeft);
+    }
+
+    [Fact]
+    public void CursorInCenter_ShowsAboveByDefault()
+    {
+        // Cursor in center of screen: enough space above
+        var (x, y) = MenuPositioner.CalculatePosition(
+            960, 600, MenuWidth, MenuHeight,
+            WorkLeft, WorkTop, WorkRight, WorkBottom);
+
+        // Prefers above cursor
+        Assert.True(y < 600, $"Menu Y {y} should be above cursor 600");
+        Assert.True(y >= WorkTop);
+    }
+
+    [Fact]
+    public void WorkAreaSmallerThanMenu_ClampsToWorkArea()
+    {
+        // Tiny work area
+        var (x, y) = MenuPositioner.CalculatePosition(
+            100, 100, 500, 500,
+            0, 0, 200, 200);
+
+        Assert.True(x >= 0, "X must be >= 0");
+        Assert.True(y >= 0, "Y must be >= 0");
+    }
+
+    [Fact]
+    public void TaskbarAtBottom_TypicalScenario()
+    {
+        // Cursor in taskbar area (below work area bottom)
+        // work bottom = 1040, cursor at 1060 (in taskbar)
+        var (x, y) = MenuPositioner.CalculatePosition(
+            1800, 1060, MenuWidth, MenuHeight,
+            0, 0, 1920, 1040);
+
+        // Menu should be fully within work area
+        Assert.True(y >= 0);
+        Assert.True(y + MenuHeight <= 1040 || y >= 0,
+            "Menu should attempt to fit in work area");
+    }
+
+    [Fact]
+    public void TaskbarAtRight_Scenario()
+    {
+        // Taskbar on right side: work area is narrower
+        int workRight = 1880;
+        var (x, y) = MenuPositioner.CalculatePosition(
+            1870, 500, MenuWidth, MenuHeight,
+            0, 0, workRight, 1080);
+
+        Assert.True(x + MenuWidth <= workRight,
+            $"Menu right edge {x + MenuWidth} should not exceed work area {workRight}");
+    }
+
+    [Fact]
+    public void MarginIsApplied()
+    {
+        // With a large margin
+        var (_, y1) = MenuPositioner.CalculatePosition(
+            500, 600, MenuWidth, MenuHeight,
+            WorkLeft, WorkTop, WorkRight, WorkBottom, margin: 0);
+        var (_, y2) = MenuPositioner.CalculatePosition(
+            500, 600, MenuWidth, MenuHeight,
+            WorkLeft, WorkTop, WorkRight, WorkBottom, margin: 50);
+
+        // Larger margin -> menu is higher (further from cursor)
+        Assert.True(y2 < y1, "Larger margin should place menu further above cursor");
+    }
+
+    [Fact]
+    public void DefaultMarginIs8()
+    {
+        var (_, yDefault) = MenuPositioner.CalculatePosition(
+            500, 600, MenuWidth, MenuHeight,
+            WorkLeft, WorkTop, WorkRight, WorkBottom);
+        var (_, yExplicit) = MenuPositioner.CalculatePosition(
+            500, 600, MenuWidth, MenuHeight,
+            WorkLeft, WorkTop, WorkRight, WorkBottom, margin: 8);
+
+        Assert.Equal(yExplicit, yDefault);
+    }
+
+    [Fact]
+    public void XClampedWithinWorkArea()
+    {
+        // Cursor far to the right
+        var (x, _) = MenuPositioner.CalculatePosition(
+            2000, 500, MenuWidth, MenuHeight,
+            WorkLeft, WorkTop, WorkRight, WorkBottom);
+
+        Assert.True(x >= WorkLeft);
+        Assert.True(x + MenuWidth <= WorkRight);
+    }
+
+    [Fact]
+    public void XClampedToLeftBound()
+    {
+        // Cursor far to the left (negative-ish via offset work area)
+        var (x, _) = MenuPositioner.CalculatePosition(
+            50, 500, MenuWidth, MenuHeight,
+            100, WorkTop, WorkRight, WorkBottom);
+
+        Assert.True(x >= 100, "X should not be less than work area left");
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OpenClaw.Shared\OpenClaw.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/OpenClaw.Tray.Tests/SettingsRoundTripTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SettingsRoundTripTests.cs
@@ -1,0 +1,169 @@
+using System.Text.Json;
+using OpenClaw.Shared;
+
+namespace OpenClaw.Tray.Tests;
+
+public class SettingsRoundTripTests
+{
+    [Fact]
+    public void RoundTrip_AllFields_Preserved()
+    {
+        var original = new SettingsData
+        {
+            GatewayUrl = "ws://localhost:18789",
+            Token = "secret-token",
+            AutoStart = true,
+            GlobalHotkeyEnabled = false,
+            ShowNotifications = true,
+            NotificationSound = "Chime",
+            NotifyHealth = false,
+            NotifyUrgent = true,
+            NotifyReminder = false,
+            NotifyEmail = true,
+            NotifyCalendar = false,
+            NotifyBuild = true,
+            NotifyStock = false,
+            NotifyInfo = true,
+            EnableNodeMode = true,
+            HasSeenActivityStreamTip = true,
+            NotifyChatResponses = false,
+            PreferStructuredCategories = true,
+            UserRules = new List<UserNotificationRule>
+            {
+                new() { Pattern = "build.*fail", IsRegex = true, Category = "urgent", Enabled = true }
+            }
+        };
+
+        var json = original.ToJson();
+        var restored = SettingsData.FromJson(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal(original.GatewayUrl, restored.GatewayUrl);
+        Assert.Equal(original.Token, restored.Token);
+        Assert.Equal(original.AutoStart, restored.AutoStart);
+        Assert.Equal(original.GlobalHotkeyEnabled, restored.GlobalHotkeyEnabled);
+        Assert.Equal(original.ShowNotifications, restored.ShowNotifications);
+        Assert.Equal(original.NotificationSound, restored.NotificationSound);
+        Assert.Equal(original.NotifyHealth, restored.NotifyHealth);
+        Assert.Equal(original.NotifyUrgent, restored.NotifyUrgent);
+        Assert.Equal(original.NotifyReminder, restored.NotifyReminder);
+        Assert.Equal(original.NotifyEmail, restored.NotifyEmail);
+        Assert.Equal(original.NotifyCalendar, restored.NotifyCalendar);
+        Assert.Equal(original.NotifyBuild, restored.NotifyBuild);
+        Assert.Equal(original.NotifyStock, restored.NotifyStock);
+        Assert.Equal(original.NotifyInfo, restored.NotifyInfo);
+        Assert.Equal(original.EnableNodeMode, restored.EnableNodeMode);
+        Assert.Equal(original.HasSeenActivityStreamTip, restored.HasSeenActivityStreamTip);
+        Assert.Equal(original.NotifyChatResponses, restored.NotifyChatResponses);
+        Assert.Equal(original.PreferStructuredCategories, restored.PreferStructuredCategories);
+        Assert.NotNull(restored.UserRules);
+        Assert.Single(restored.UserRules);
+        Assert.Equal("build.*fail", restored.UserRules[0].Pattern);
+        Assert.True(restored.UserRules[0].IsRegex);
+    }
+
+    [Fact]
+    public void UnknownNotificationSound_DeserializesGracefully()
+    {
+        var json = """
+        {
+            "NotificationSound": "NonExistentBeep42"
+        }
+        """;
+
+        var settings = SettingsData.FromJson(json);
+        Assert.NotNull(settings);
+        Assert.Equal("NonExistentBeep42", settings.NotificationSound);
+    }
+
+    [Fact]
+    public void MissingFields_UseDefaults()
+    {
+        var json = "{}";
+        var settings = SettingsData.FromJson(json);
+
+        Assert.NotNull(settings);
+        Assert.Null(settings.GatewayUrl);
+        Assert.Null(settings.Token);
+        Assert.False(settings.AutoStart);
+        Assert.True(settings.GlobalHotkeyEnabled);
+        Assert.True(settings.ShowNotifications);
+        Assert.Null(settings.NotificationSound);
+        Assert.True(settings.NotifyHealth);
+        Assert.True(settings.NotifyUrgent);
+        Assert.True(settings.NotifyReminder);
+        Assert.True(settings.NotifyEmail);
+        Assert.True(settings.NotifyCalendar);
+        Assert.True(settings.NotifyBuild);
+        Assert.True(settings.NotifyStock);
+        Assert.True(settings.NotifyInfo);
+        Assert.False(settings.EnableNodeMode);
+        Assert.False(settings.HasSeenActivityStreamTip);
+        Assert.True(settings.NotifyChatResponses);
+        Assert.True(settings.PreferStructuredCategories);
+        Assert.Null(settings.UserRules);
+    }
+
+    [Fact]
+    public void BackwardCompatibility_OldSettingsWithoutNewFields()
+    {
+        // Simulate an old settings.json that predates NotifyChatResponses and PreferStructuredCategories
+        var json = """
+        {
+            "GatewayUrl": "ws://localhost:18789",
+            "Token": "abc",
+            "AutoStart": false,
+            "ShowNotifications": true,
+            "NotificationSound": "Default",
+            "NotifyHealth": true,
+            "NotifyUrgent": true,
+            "NotifyReminder": true,
+            "NotifyEmail": true,
+            "NotifyCalendar": true,
+            "NotifyBuild": true,
+            "NotifyStock": true,
+            "NotifyInfo": true
+        }
+        """;
+
+        var settings = SettingsData.FromJson(json);
+
+        Assert.NotNull(settings);
+        Assert.Equal("ws://localhost:18789", settings.GatewayUrl);
+        Assert.Equal("abc", settings.Token);
+        // New fields should have sensible defaults
+        Assert.True(settings.NotifyChatResponses);
+        Assert.True(settings.PreferStructuredCategories);
+        Assert.False(settings.EnableNodeMode);
+        Assert.False(settings.HasSeenActivityStreamTip);
+        Assert.True(settings.GlobalHotkeyEnabled);
+        Assert.Null(settings.UserRules);
+    }
+
+    [Fact]
+    public void InvalidJson_ReturnsNull()
+    {
+        Assert.Null(SettingsData.FromJson("not json at all"));
+    }
+
+    [Fact]
+    public void EmptyUserRules_RoundTrips()
+    {
+        var original = new SettingsData { UserRules = new List<UserNotificationRule>() };
+        var json = original.ToJson();
+        var restored = SettingsData.FromJson(json);
+
+        Assert.NotNull(restored);
+        Assert.NotNull(restored.UserRules);
+        Assert.Empty(restored.UserRules);
+    }
+
+    [Fact]
+    public void ToJson_ProducesIndentedOutput()
+    {
+        var data = new SettingsData { GatewayUrl = "ws://test" };
+        var json = data.ToJson();
+        Assert.Contains("\n", json);
+        Assert.Contains("  ", json);
+    }
+}


### PR DESCRIPTION
Extract testable pure logic from WinUI tray app into shared helpers and create comprehensive test coverage.

## New shared helpers (`src/OpenClaw.Shared/`)
- **MenuDisplayHelper** — status icons, channel icons (delegates to `ChannelHealth.IsHealthyStatus`/`IsIntermediateStatus`), text truncation, provider formatting, toggle logic
- **DeepLinkParser** — pure `openclaw://` URI parser with `DeepLinkResult` record
- **MenuPositioner** — tray popup positioning calculations (no Win32 deps)
- **SettingsData** — public serializable settings model with `ToJson()`/`FromJson()`

## New test project (`tests/OpenClaw.Tray.Tests/`)
93 tests across 4 files:
- **MenuDisplayHelperTests** — status icons, channel icons (all statuses + case insensitivity + edge cases), truncation, provider formatting, toggle
- **DeepLinkParserTests** — URI parsing, query params, edge cases
- **MenuPositionerTests** — positioning for all monitor/cursor scenarios
- **SettingsRoundTripTests** — JSON serialization, defaults, backward compat

## WinUI refactored to use shared helpers
Updated `App.xaml.cs`, `DeepLinkHandler.cs`, `TrayMenuWindow.xaml.cs`, `SettingsManager.cs`

## Review
Dual-model code review (Opus + Codex) — both found same issue (missing connecting/reconnecting in channel icons). Fixed by delegating to `ChannelHealth` helpers.

**All 568 tests pass** (475 shared + 93 tray).

Closes #43
