### PR TITLE
feat: add localization infrastructure with .resw resource files (en-US + zh-CN)

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -400,7 +400,7 @@ public partial class App : Application
         // Sessions
         if (_lastSessions.Length > 0)
         {
-            var sessionsMenu = new MenuFlyoutSubItem { Text = $"📋 Sessions ({_lastSessions.Length})" };
+            var sessionsMenu = new MenuFlyoutSubItem { Text = $"📋 {string.Format(LocalizationHelper.GetString("Menu_SessionsFormat"), _lastSessions.Length)}" };
             foreach (var session in _lastSessions.Take(5))
             {
                 var sessionItem = new MenuFlyoutItem { Text = session.DisplayText };
@@ -733,7 +733,7 @@ public partial class App : Application
 
         // Status
         var statusIcon = MenuDisplayHelper.GetStatusIcon(_currentStatus);
-        menu.AddMenuItem($"Status: {_currentStatus}", statusIcon, "status");
+        menu.AddMenuItem(string.Format(LocalizationHelper.GetString("Menu_StatusFormat"), LocalizationHelper.GetConnectionStatusText(_currentStatus)), statusIcon, "status");
 
         // Activity (if any)
         if (_currentActivity != null && _currentActivity.Kind != OpenClaw.Shared.ActivityKind.Idle)
@@ -745,14 +745,14 @@ public partial class App : Application
         if (_lastUsage != null || _lastUsageStatus != null || _lastUsageCost != null)
         {
             var usageText = _lastUsage?.DisplayText;
-            if (string.IsNullOrWhiteSpace(usageText) || string.Equals(usageText, "No usage data", StringComparison.Ordinal))
+            if (string.IsNullOrWhiteSpace(usageText) || string.Equals(usageText, "No usage data", StringComparison.Ordinal) || string.Equals(usageText, LocalizationHelper.GetString("Menu_NoUsageData"), StringComparison.Ordinal))
             {
                 usageText = _lastUsageStatus?.Providers.Count > 0
                     ? MenuDisplayHelper.FormatProviderSummary(_lastUsageStatus.Providers.Count)
-                    : "No usage data";
+                    : LocalizationHelper.GetString("Menu_NoUsageData");
             }
 
-            menu.AddMenuItem(usageText ?? "No usage data", "📊", "activity:usage");
+            menu.AddMenuItem(usageText ?? LocalizationHelper.GetString("Menu_NoUsageData"), "📊", "activity:usage");
 
             if (!string.IsNullOrWhiteSpace(_lastUsage?.ProviderSummary))
             {
@@ -793,20 +793,20 @@ public partial class App : Application
             
             if (_nodeService.IsPendingApproval)
             {
-                menu.AddMenuItem("⏳ Waiting for approval...", "", "", isEnabled: false, indent: true);
+                menu.AddMenuItem(LocalizationHelper.GetString("Menu_NodeWaitingApproval"), "", "", isEnabled: false, indent: true);
                 menu.AddMenuItem($"ID: {_nodeService.ShortDeviceId}...", "", "copydeviceid", indent: true);
             }
             else if (_nodeService.IsPaired && _nodeService.IsConnected)
             {
-                menu.AddMenuItem("✅ Paired & Connected", "", "", isEnabled: false, indent: true);
+                menu.AddMenuItem(LocalizationHelper.GetString("Menu_NodePairedConnected"), "", "", isEnabled: false, indent: true);
             }
             else if (_nodeService.IsConnected)
             {
-                menu.AddMenuItem("🔄 Connecting...", "", "", isEnabled: false, indent: true);
+                menu.AddMenuItem(LocalizationHelper.GetString("Menu_NodeConnecting"), "", "", isEnabled: false, indent: true);
             }
             else
             {
-                menu.AddMenuItem("⚪ Disconnected", "", "", isEnabled: false, indent: true);
+                menu.AddMenuItem(LocalizationHelper.GetString("Menu_NodeDisconnected"), "", "", isEnabled: false, indent: true);
             }
         }
 
@@ -814,7 +814,7 @@ public partial class App : Application
         if (_lastSessions.Length > 0)
         {
             menu.AddSeparator();
-            menu.AddMenuItem($"Sessions ({_lastSessions.Length})", "💬", "activity:sessions");
+            menu.AddMenuItem(string.Format(LocalizationHelper.GetString("Menu_SessionsFormat"), _lastSessions.Length), "💬", "activity:sessions");
 
             var visibleSessions = _lastSessions.Take(3).ToArray();
             foreach (var session in visibleSessions)
@@ -858,10 +858,10 @@ public partial class App : Application
                     "📝",
                     $"session-verbose|{nextVerbose}|{session.Key}",
                     indent: true);
-                menu.AddMenuItem("↳ Reset session", "♻️", $"session-reset|{session.Key}", indent: true);
-                menu.AddMenuItem("↳ Compact log", "🗜️", $"session-compact|{session.Key}", indent: true);
+                menu.AddMenuItem(LocalizationHelper.GetString("Menu_ResetSession"), "♻️", $"session-reset|{session.Key}", indent: true);
+                menu.AddMenuItem(LocalizationHelper.GetString("Menu_CompactLog"), "🗜️", $"session-compact|{session.Key}", indent: true);
                 if (!session.IsMain && !string.Equals(session.Key, "global", StringComparison.OrdinalIgnoreCase))
-                    menu.AddMenuItem("↳ Delete session", "🗑️", $"session-delete|{session.Key}", indent: true);
+                    menu.AddMenuItem(LocalizationHelper.GetString("Menu_DeleteSession"), "🗑️", $"session-delete|{session.Key}", indent: true);
             }
             if (_lastSessions.Length > visibleSessions.Length)
                 menu.AddMenuItem($"+{_lastSessions.Length - visibleSessions.Length} more...", "", "", isEnabled: false, indent: true);
@@ -885,7 +885,7 @@ public partial class App : Application
         if (_lastNodes.Length > 0)
         {
             menu.AddSeparator();
-            menu.AddMenuItem($"Nodes ({_lastNodes.Length})", "🖥️", "activity:nodes");
+            menu.AddMenuItem(string.Format(LocalizationHelper.GetString("Menu_NodesFormat"), _lastNodes.Length), "🖥️", "activity:nodes");
 
             var visibleNodes = _lastNodes.Take(3).ToArray();
             foreach (var node in visibleNodes)
@@ -898,7 +898,7 @@ public partial class App : Application
             if (_lastNodes.Length > visibleNodes.Length)
                 menu.AddMenuItem($"+{_lastNodes.Length - visibleNodes.Length} more...", "", "", isEnabled: false, indent: true);
 
-            menu.AddMenuItem("Copy node summary", "📋", "copynodesummary", indent: true);
+            menu.AddMenuItem(LocalizationHelper.GetString("Menu_CopyNodeSummary"), "📋", "copynodesummary", indent: true);
         }
 
         var recentActivity = GetRecentActivity(maxItems: 4);
@@ -906,7 +906,7 @@ public partial class App : Application
         {
             menu.AddSeparator();
             var totalActivity = ActivityStreamService.GetItems().Count;
-            menu.AddMenuItem($"Recent Activity ({totalActivity})", "⚡", "activity");
+            menu.AddMenuItem(string.Format(LocalizationHelper.GetString("Menu_RecentActivityFormat"), totalActivity), "⚡", "activity");
             foreach (var line in recentActivity)
             {
                 menu.AddMenuItem(TruncateMenuText(line, 94), "", "", isEnabled: false, indent: true);
@@ -916,24 +916,26 @@ public partial class App : Application
         menu.AddSeparator();
 
         // Actions
-        menu.AddMenuItem("Open Dashboard", "🌐", "dashboard");
-        menu.AddMenuItem("Open Web Chat", "💬", "webchat");
-        menu.AddMenuItem("Quick Send...", "📤", "quicksend");
-        menu.AddMenuItem("Activity Stream...", "⚡", "activity");
-        menu.AddMenuItem("Notification History...", "📋", "history");
-        menu.AddMenuItem("Run Health Check", "🔄", "healthcheck");
+        menu.AddMenuItem(LocalizationHelper.GetString("Menu_OpenDashboard"), "🌐", "dashboard");
+        menu.AddMenuItem(LocalizationHelper.GetString("Menu_OpenWebChat"), "💬", "webchat");
+        menu.AddMenuItem(LocalizationHelper.GetString("Menu_QuickSend"), "📤", "quicksend");
+        menu.AddMenuItem(LocalizationHelper.GetString("Menu_ActivityStream"), "⚡", "activity");
+        menu.AddMenuItem(LocalizationHelper.GetString("Menu_NotificationHistory"), "📋", "history");
+        menu.AddMenuItem(LocalizationHelper.GetString("Menu_RunHealthCheck"), "🔄", "healthcheck");
 
         menu.AddSeparator();
 
         // Settings
-        menu.AddMenuItem("Settings...", "⚙️", "settings");
-        var autoStartText = (_settings?.AutoStart ?? false) ? "Auto-start ✓" : "Auto-start";
+        menu.AddMenuItem(LocalizationHelper.GetString("Menu_Settings"), "⚙️", "settings");
+        var autoStartText = (_settings?.AutoStart ?? false)
+            ? LocalizationHelper.GetString("Menu_AutoStartEnabled")
+            : LocalizationHelper.GetString("Menu_AutoStart");
         menu.AddMenuItem(autoStartText, "🚀", "autostart");
 
         menu.AddSeparator();
 
-        menu.AddMenuItem("Open Log File", "📄", "log");
-        menu.AddMenuItem("Exit", "❌", "exit");
+        menu.AddMenuItem(LocalizationHelper.GetString("Menu_OpenLogFile"), "📄", "log");
+        menu.AddMenuItem(LocalizationHelper.GetString("Menu_Exit"), "❌", "exit");
     }
 
     // Keep the old MenuFlyout method for reference but it won't be used
@@ -985,7 +987,7 @@ public partial class App : Application
             flyout.Items.Add(new MenuFlyoutSeparator());
             var sessionsHeader = new MenuFlyoutItem
             {
-                Text = $"💬 Sessions ({_lastSessions.Length})"
+                Text = $"💬 {string.Format(LocalizationHelper.GetString("Menu_SessionsFormat"), _lastSessions.Length)}"
             };
             sessionsHeader.Click += (s, e) => OpenDashboard("sessions");
             flyout.Items.Add(sessionsHeader);

--- a/src/OpenClaw.Tray.WinUI/Dialogs/QuickSendDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/QuickSendDialog.cs
@@ -51,7 +51,7 @@ public sealed class QuickSendDialog : WindowEx
         _client = client;
         
         // Window setup
-        Title = "Settings — OpenClaw Tray";
+        Title = LocalizationHelper.GetString("WindowTitle_QuickSend");
         this.SetWindowSize(400, 200);
         this.CenterOnScreen();
         this.SetIcon(IconHelper.GetStatusIconPath(ConnectionStatus.Connected));
@@ -73,14 +73,14 @@ public sealed class QuickSendDialog : WindowEx
 
         var header = new TextBlock
         {
-            Text = "📤 Quick Send",
+            Text = LocalizationHelper.GetString("QuickSend_Header"),
             Style = (Style)Application.Current.Resources["SubtitleTextBlockStyle"]
         };
         root.Children.Add(header);
 
         _messageTextBox = new TextBox
         {
-            PlaceholderText = "Type your message...",
+            PlaceholderText = LocalizationHelper.GetString("QuickSend_Placeholder"),
             AcceptsReturn = false,
             Text = prefillMessage ?? ""
         };
@@ -101,13 +101,13 @@ public sealed class QuickSendDialog : WindowEx
         };
         buttonPanel.Children.Add(_statusText);
 
-        var cancelButton = new Button { Content = "Cancel" };
+        var cancelButton = new Button { Content = LocalizationHelper.GetString("QuickSend_CancelButton") };
         cancelButton.Click += (s, e) => Close();
         buttonPanel.Children.Add(cancelButton);
 
         _sendButton = new Button
         {
-            Content = "Send",
+            Content = LocalizationHelper.GetString("QuickSend_SendButton"),
             Style = (Style)Application.Current.Resources["AccentButtonStyle"]
         };
         _sendButton.Click += OnSendClick;
@@ -169,22 +169,22 @@ public sealed class QuickSendDialog : WindowEx
         _isSending = true;
         _sendButton.IsEnabled = false;
         _messageTextBox.IsEnabled = false;
-        _statusText.Text = "Sending...";
+        _statusText.Text = LocalizationHelper.GetString("QuickSend_Sending");
 
         try
         {
             await _client.SendChatMessageAsync(message);
             Logger.Info($"Quick send: {message}");
             new ToastContentBuilder()
-                .AddText("Message Sent")
-                .AddText("Your message was sent to OpenClaw.")
+                .AddText(LocalizationHelper.GetString("QuickSend_ToastTitle"))
+                .AddText(LocalizationHelper.GetString("QuickSend_ToastBody"))
                 .Show();
             Close();
         }
         catch (Exception ex)
         {
             Logger.Error($"Quick send failed: {ex.Message}");
-            _statusText.Text = "❌ Failed";
+            _statusText.Text = LocalizationHelper.GetString("QuickSend_Failed");
             _sendButton.IsEnabled = true;
             _messageTextBox.IsEnabled = true;
             _isSending = false;

--- a/src/OpenClaw.Tray.WinUI/Dialogs/UpdateDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/UpdateDialog.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using OpenClawTray.Helpers;
 using System;
 using System.Threading.Tasks;
 using WinUIEx;
@@ -25,7 +26,7 @@ public sealed class UpdateDialog : WindowEx
 
     public UpdateDialog(string version, string changelog)
     {
-        Title = "OpenClaw Update";
+        Title = LocalizationHelper.GetString("WindowTitle_Update");
         this.SetWindowSize(560, 420);
         this.CenterOnScreen();
         this.SetIcon("Assets\\openclaw.ico");
@@ -43,7 +44,7 @@ public sealed class UpdateDialog : WindowEx
         // Header
         var header = new TextBlock
         {
-            Text = $"🎉 Version {version} is available!",
+            Text = string.Format(LocalizationHelper.GetString("Update_VersionAvailable"), version),
             Style = (Style)Application.Current.Resources["SubtitleTextBlockStyle"]
         };
         Grid.SetRow(header, 0);
@@ -55,13 +56,13 @@ public sealed class UpdateDialog : WindowEx
         var currentVersion = typeof(UpdateDialog).Assembly.GetName().Version?.ToString() ?? "Unknown";
         content.Children.Add(new TextBlock
         {
-            Text = $"Current version: {currentVersion}",
+            Text = string.Format(LocalizationHelper.GetString("Update_CurrentVersion"), currentVersion),
             Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]
         });
 
         content.Children.Add(new TextBlock
         {
-            Text = "What's New:",
+            Text = LocalizationHelper.GetString("Update_WhatsNew"),
             FontWeight = Microsoft.UI.Text.FontWeights.SemiBold
         });
 
@@ -86,17 +87,17 @@ public sealed class UpdateDialog : WindowEx
             Spacing = 8
         };
 
-        var skipButton = new Button { Content = "Skip This Version" };
+        var skipButton = new Button { Content = LocalizationHelper.GetString("Update_SkipButton") };
         skipButton.Click += (s, e) => { _result = UpdateDialogResult.Skip; Close(); };
         buttonPanel.Children.Add(skipButton);
 
-        var laterButton = new Button { Content = "Remind Me Later" };
+        var laterButton = new Button { Content = LocalizationHelper.GetString("Update_RemindLaterButton") };
         laterButton.Click += (s, e) => { _result = UpdateDialogResult.RemindLater; Close(); };
         buttonPanel.Children.Add(laterButton);
 
         var downloadButton = new Button
         {
-            Content = "Download & Install",
+            Content = LocalizationHelper.GetString("Update_DownloadButton"),
             Style = (Style)Application.Current.Resources["AccentButtonStyle"]
         };
         downloadButton.Click += (s, e) => { _result = UpdateDialogResult.Download; Close(); };

--- a/src/OpenClaw.Tray.WinUI/Dialogs/WelcomeDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/WelcomeDialog.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using OpenClawTray.Helpers;
 using System;
 using System.Threading.Tasks;
 using WinUIEx;
@@ -17,7 +18,7 @@ public sealed class WelcomeDialog : WindowEx
 
     public WelcomeDialog()
     {
-        Title = "Welcome to OpenClaw";
+        Title = LocalizationHelper.GetString("WindowTitle_Welcome");
         this.SetWindowSize(480, 440);
         this.CenterOnScreen();
         this.SetIcon("Assets\\openclaw.ico");
@@ -49,7 +50,7 @@ public sealed class WelcomeDialog : WindowEx
         });
         headerPanel.Children.Add(new TextBlock
         {
-            Text = "Welcome to OpenClaw!",
+            Text = LocalizationHelper.GetString("Welcome_Title"),
             Style = (Style)Application.Current.Resources["TitleTextBlockStyle"],
             VerticalAlignment = VerticalAlignment.Center
         });
@@ -61,26 +62,26 @@ public sealed class WelcomeDialog : WindowEx
         
         content.Children.Add(new TextBlock
         {
-            Text = "OpenClaw Tray is your Windows companion for OpenClaw, the AI-powered personal assistant.",
+            Text = LocalizationHelper.GetString("Welcome_Description"),
             TextWrapping = TextWrapping.Wrap
         });
 
         var gettingStarted = new StackPanel { Spacing = 8 };
         gettingStarted.Children.Add(new TextBlock
         {
-            Text = "To get started, you'll need:",
+            Text = LocalizationHelper.GetString("Welcome_GettingStarted"),
             FontWeight = Microsoft.UI.Text.FontWeights.SemiBold
         });
 
         var bulletList = new StackPanel { Spacing = 4, Margin = new Thickness(16, 0, 0, 0) };
-        bulletList.Children.Add(new TextBlock { Text = "• A running OpenClaw gateway" });
-        bulletList.Children.Add(new TextBlock { Text = "• Your API token from the dashboard" });
+        bulletList.Children.Add(new TextBlock { Text = LocalizationHelper.GetString("Welcome_NeedGateway") });
+        bulletList.Children.Add(new TextBlock { Text = LocalizationHelper.GetString("Welcome_NeedToken") });
         gettingStarted.Children.Add(bulletList);
         content.Children.Add(gettingStarted);
 
         var docsButton = new HyperlinkButton
         {
-            Content = "📚 View Documentation",
+            Content = LocalizationHelper.GetString("Welcome_ViewDocs"),
             NavigateUri = new Uri("https://docs.molt.bot/web/dashboard")
         };
         content.Children.Add(docsButton);
@@ -96,7 +97,7 @@ public sealed class WelcomeDialog : WindowEx
             Spacing = 8
         };
 
-        var laterButton = new Button { Content = "Later" };
+        var laterButton = new Button { Content = LocalizationHelper.GetString("Welcome_LaterButton") };
         laterButton.Click += (s, e) =>
         {
             _result = ContentDialogResult.None;
@@ -106,7 +107,7 @@ public sealed class WelcomeDialog : WindowEx
 
         var settingsButton = new Button
         {
-            Content = "Open Settings",
+            Content = LocalizationHelper.GetString("Welcome_OpenSettingsButton"),
             Style = (Style)Application.Current.Resources["AccentButtonStyle"]
         };
         settingsButton.Click += (s, e) =>

--- a/src/OpenClaw.Tray.WinUI/Helpers/LocalizationHelper.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/LocalizationHelper.cs
@@ -1,0 +1,33 @@
+using Microsoft.Windows.ApplicationModel.Resources;
+using OpenClaw.Shared;
+
+namespace OpenClawTray.Helpers;
+
+public static class LocalizationHelper
+{
+    private static ResourceLoader? _loader;
+
+    private static ResourceLoader Loader => _loader ??= new ResourceLoader();
+
+    public static string GetString(string resourceKey)
+    {
+        try
+        {
+            var value = Loader.GetString(resourceKey);
+            return string.IsNullOrEmpty(value) ? resourceKey : value;
+        }
+        catch
+        {
+            return resourceKey;
+        }
+    }
+
+    public static string GetConnectionStatusText(ConnectionStatus status) => status switch
+    {
+        ConnectionStatus.Connected => GetString("StatusDisplay_Connected"),
+        ConnectionStatus.Connecting => GetString("StatusDisplay_Connecting"),
+        ConnectionStatus.Disconnected => GetString("StatusDisplay_Disconnected"),
+        ConnectionStatus.Error => GetString("StatusDisplay_Error"),
+        _ => GetString("StatusDisplay_Unknown")
+    };
+}

--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -10,6 +10,7 @@
     <ApplicationIcon>Assets\openclaw.ico</ApplicationIcon>
     <RootNamespace>OpenClawTray</RootNamespace>
     <Version>0.4.4</Version>
+    <DefaultLanguage>en-US</DefaultLanguage>
   </PropertyGroup>
 
   <!-- Unpackaged (default): traditional EXE distribution via Inno Setup -->

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -1,0 +1,469 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+
+  <!-- ==================== SettingsWindow.xaml ==================== -->
+
+  <!-- Section headers -->
+  <data name="SettingsConnectionHeader.Text" xml:space="preserve">
+    <value>CONNECTION</value>
+  </data>
+  <data name="SettingsStartupHeader.Text" xml:space="preserve">
+    <value>STARTUP</value>
+  </data>
+  <data name="SettingsNotificationsHeader.Text" xml:space="preserve">
+    <value>NOTIFICATIONS</value>
+  </data>
+  <data name="SettingsAdvancedHeader.Text" xml:space="preserve">
+    <value>ADVANCED (EXPERIMENTAL)</value>
+  </data>
+
+  <!-- TextBox headers and placeholders -->
+  <data name="SettingsGatewayUrlTextBox.Header" xml:space="preserve">
+    <value>Gateway URL</value>
+  </data>
+  <data name="SettingsGatewayUrlTextBox.PlaceholderText" xml:space="preserve">
+    <value>ws://localhost:18789 or https://host.tailnet.ts.net</value>
+  </data>
+  <data name="SettingsTokenTextBox.Header" xml:space="preserve">
+    <value>Token</value>
+  </data>
+  <data name="SettingsTokenTextBox.PlaceholderText" xml:space="preserve">
+    <value>Your API token</value>
+  </data>
+
+  <!-- Toggle headers -->
+  <data name="SettingsAutoStartToggle.Header" xml:space="preserve">
+    <value>Start automatically with Windows</value>
+  </data>
+  <data name="SettingsGlobalHotkeyToggle.Header" xml:space="preserve">
+    <value>Global hotkey (Ctrl+Alt+Shift+C → Quick Send)</value>
+  </data>
+  <data name="SettingsNotificationsToggle.Header" xml:space="preserve">
+    <value>Show notifications</value>
+  </data>
+  <data name="SettingsNodeModeToggle.Header" xml:space="preserve">
+    <value>Enable Node Mode</value>
+  </data>
+
+  <!-- ComboBox -->
+  <data name="SettingsSoundComboBox.Header" xml:space="preserve">
+    <value>Sound</value>
+  </data>
+  <data name="SettingsSoundDefault.Content" xml:space="preserve">
+    <value>Default</value>
+  </data>
+  <data name="SettingsSoundNone.Content" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="SettingsSoundSubtle.Content" xml:space="preserve">
+    <value>Subtle</value>
+  </data>
+
+  <!-- Notification filter labels -->
+  <data name="SettingsNotifyForLabel.Text" xml:space="preserve">
+    <value>Show notifications for:</value>
+  </data>
+  <data name="SettingsNotifyFilterHint.Text" xml:space="preserve">
+    <value>Filters by keywords in the message (e.g., 'email', 'reminder')</value>
+  </data>
+
+  <!-- Notification filter checkboxes -->
+  <data name="SettingsNotifyHealthCb.Content" xml:space="preserve">
+    <value>Health alerts</value>
+  </data>
+  <data name="SettingsNotifyUrgentCb.Content" xml:space="preserve">
+    <value>Urgent messages</value>
+  </data>
+  <data name="SettingsNotifyReminderCb.Content" xml:space="preserve">
+    <value>Reminders</value>
+  </data>
+  <data name="SettingsNotifyEmailCb.Content" xml:space="preserve">
+    <value>Email summaries</value>
+  </data>
+  <data name="SettingsNotifyCalendarCb.Content" xml:space="preserve">
+    <value>Calendar events</value>
+  </data>
+  <data name="SettingsNotifyBuildCb.Content" xml:space="preserve">
+    <value>Build notifications</value>
+  </data>
+  <data name="SettingsNotifyStockCb.Content" xml:space="preserve">
+    <value>Stock alerts</value>
+  </data>
+  <data name="SettingsNotifyInfoCb.Content" xml:space="preserve">
+    <value>Info messages</value>
+  </data>
+
+  <!-- Buttons -->
+  <data name="SettingsTestConnectionButton.Content" xml:space="preserve">
+    <value>Test</value>
+  </data>
+  <data name="SettingsTestNotificationButton.Content" xml:space="preserve">
+    <value>Send Test Notification</value>
+  </data>
+  <data name="SettingsSaveButton.Content" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="SettingsCancelButton.Content" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+
+  <!-- Node mode description -->
+  <data name="SettingsNodeModeDescription.Text" xml:space="preserve">
+    <value>When enabled, this PC can receive commands from the agent (canvas, screenshots, etc.)</value>
+  </data>
+
+  <!-- ==================== StatusDetailWindow.xaml ==================== -->
+
+  <!-- Section headers -->
+  <data name="StatusUsageHeader.Text" xml:space="preserve">
+    <value>USAGE</value>
+  </data>
+  <data name="StatusSessionsHeader.Text" xml:space="preserve">
+    <value>ACTIVE SESSIONS</value>
+  </data>
+  <data name="StatusChannelsHeader.Text" xml:space="preserve">
+    <value>CHANNELS</value>
+  </data>
+
+  <!-- Labels -->
+  <data name="StatusCostLabel.Text" xml:space="preserve">
+    <value>Cost (window):</value>
+  </data>
+  <data name="StatusRequestsLabel.Text" xml:space="preserve">
+    <value>Requests / Tokens:</value>
+  </data>
+  <data name="StatusProvidersLabel.Text" xml:space="preserve">
+    <value>Providers:</value>
+  </data>
+
+  <!-- Default values -->
+  <data name="StatusConnectedText.Text" xml:space="preserve">
+    <value>Connected</value>
+  </data>
+  <data name="StatusNoSessions.Text" xml:space="preserve">
+    <value>No active sessions</value>
+  </data>
+
+  <!-- Buttons -->
+  <data name="StatusRefreshButton.Content" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+
+  <!-- ==================== ActivityStreamWindow.xaml ==================== -->
+
+  <!-- Header -->
+  <data name="ActivityStreamTitle.Text" xml:space="preserve">
+    <value>⚡ Activity Stream</value>
+  </data>
+
+  <!-- Filter items -->
+  <data name="ActivityFilterAll.Content" xml:space="preserve">
+    <value>All activity</value>
+  </data>
+  <data name="ActivityFilterSessions.Content" xml:space="preserve">
+    <value>Sessions</value>
+  </data>
+  <data name="ActivityFilterUsage.Content" xml:space="preserve">
+    <value>Usage</value>
+  </data>
+  <data name="ActivityFilterNodes.Content" xml:space="preserve">
+    <value>Nodes</value>
+  </data>
+  <data name="ActivityFilterNotifications.Content" xml:space="preserve">
+    <value>Notifications</value>
+  </data>
+
+  <!-- Empty state -->
+  <data name="ActivityEmptyText.Text" xml:space="preserve">
+    <value>No activity yet</value>
+  </data>
+
+  <!-- Buttons -->
+  <data name="ActivityOpenDashboardButton.Content" xml:space="preserve">
+    <value>Open Dashboard</value>
+  </data>
+  <data name="ActivityClearAllButton.Content" xml:space="preserve">
+    <value>Clear All</value>
+  </data>
+  <data name="ActivityCloseButton.Content" xml:space="preserve">
+    <value>Close</value>
+  </data>
+
+  <!-- ==================== NotificationHistoryWindow.xaml ==================== -->
+
+  <!-- Header -->
+  <data name="NotificationHistoryTitle.Text" xml:space="preserve">
+    <value>📋 Notification History</value>
+  </data>
+
+  <!-- Empty state -->
+  <data name="NotificationEmptyText.Text" xml:space="preserve">
+    <value>No notifications yet</value>
+  </data>
+
+  <!-- Buttons -->
+  <data name="NotificationClearAllButton.Content" xml:space="preserve">
+    <value>Clear All</value>
+  </data>
+  <data name="NotificationCloseButton.Content" xml:space="preserve">
+    <value>Close</value>
+  </data>
+
+  <!-- ==================== Runtime strings (C# code) ==================== -->
+
+  <!-- Window titles -->
+  <data name="WindowTitle_Settings" xml:space="preserve">
+    <value>Settings — OpenClaw Tray</value>
+  </data>
+  <data name="WindowTitle_Status" xml:space="preserve">
+    <value>Status — OpenClaw Tray</value>
+  </data>
+  <data name="WindowTitle_ActivityStream" xml:space="preserve">
+    <value>Activity Stream — OpenClaw Tray</value>
+  </data>
+  <data name="WindowTitle_NotificationHistory" xml:space="preserve">
+    <value>Notification History — OpenClaw Tray</value>
+  </data>
+  <data name="WindowTitle_QuickSend" xml:space="preserve">
+    <value>Quick Send — OpenClaw</value>
+  </data>
+  <data name="WindowTitle_WebChat" xml:space="preserve">
+    <value>OpenClaw Chat</value>
+  </data>
+  <data name="WindowTitle_Welcome" xml:space="preserve">
+    <value>Welcome to OpenClaw</value>
+  </data>
+  <data name="WindowTitle_Update" xml:space="preserve">
+    <value>OpenClaw Update</value>
+  </data>
+
+  <!-- Settings runtime status -->
+  <data name="Status_Testing" xml:space="preserve">
+    <value>Testing...</value>
+  </data>
+  <data name="Status_Connected" xml:space="preserve">
+    <value>✅ Connected!</value>
+  </data>
+  <data name="Status_ConnectionFailed" xml:space="preserve">
+    <value>❌ Connection failed</value>
+  </data>
+
+  <!-- QuickSend dialog -->
+  <data name="QuickSend_Header" xml:space="preserve">
+    <value>📤 Quick Send</value>
+  </data>
+  <data name="QuickSend_Placeholder" xml:space="preserve">
+    <value>Type your message...</value>
+  </data>
+  <data name="QuickSend_SendButton" xml:space="preserve">
+    <value>Send</value>
+  </data>
+  <data name="QuickSend_CancelButton" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="QuickSend_Sending" xml:space="preserve">
+    <value>Sending...</value>
+  </data>
+  <data name="QuickSend_Failed" xml:space="preserve">
+    <value>❌ Failed</value>
+  </data>
+  <data name="QuickSend_ToastTitle" xml:space="preserve">
+    <value>Message Sent</value>
+  </data>
+  <data name="QuickSend_ToastBody" xml:space="preserve">
+    <value>Your message was sent to OpenClaw.</value>
+  </data>
+
+  <!-- WelcomeDialog -->
+  <data name="Welcome_Title" xml:space="preserve">
+    <value>Welcome to OpenClaw!</value>
+  </data>
+  <data name="Welcome_Description" xml:space="preserve">
+    <value>OpenClaw Tray is your Windows companion for OpenClaw, the AI-powered personal assistant.</value>
+  </data>
+  <data name="Welcome_GettingStarted" xml:space="preserve">
+    <value>To get started, you'll need:</value>
+  </data>
+  <data name="Welcome_NeedGateway" xml:space="preserve">
+    <value>• A running OpenClaw gateway</value>
+  </data>
+  <data name="Welcome_NeedToken" xml:space="preserve">
+    <value>• Your API token from the dashboard</value>
+  </data>
+  <data name="Welcome_ViewDocs" xml:space="preserve">
+    <value>📚 View Documentation</value>
+  </data>
+  <data name="Welcome_LaterButton" xml:space="preserve">
+    <value>Later</value>
+  </data>
+  <data name="Welcome_OpenSettingsButton" xml:space="preserve">
+    <value>Open Settings</value>
+  </data>
+
+  <!-- UpdateDialog -->
+  <data name="Update_VersionAvailable" xml:space="preserve">
+    <value>🎉 Version {0} is available!</value>
+  </data>
+  <data name="Update_CurrentVersion" xml:space="preserve">
+    <value>Current version: {0}</value>
+  </data>
+  <data name="Update_WhatsNew" xml:space="preserve">
+    <value>What's New:</value>
+  </data>
+  <data name="Update_SkipButton" xml:space="preserve">
+    <value>Skip This Version</value>
+  </data>
+  <data name="Update_RemindLaterButton" xml:space="preserve">
+    <value>Remind Me Later</value>
+  </data>
+  <data name="Update_DownloadButton" xml:space="preserve">
+    <value>Download &amp; Install</value>
+  </data>
+
+  <!-- Tray menu items -->
+  <data name="Menu_OpenDashboard" xml:space="preserve">
+    <value>Open Dashboard</value>
+  </data>
+  <data name="Menu_OpenWebChat" xml:space="preserve">
+    <value>Open Web Chat</value>
+  </data>
+  <data name="Menu_QuickSend" xml:space="preserve">
+    <value>Quick Send...</value>
+  </data>
+  <data name="Menu_ActivityStream" xml:space="preserve">
+    <value>Activity Stream...</value>
+  </data>
+  <data name="Menu_NotificationHistory" xml:space="preserve">
+    <value>Notification History...</value>
+  </data>
+  <data name="Menu_RunHealthCheck" xml:space="preserve">
+    <value>Run Health Check</value>
+  </data>
+  <data name="Menu_Settings" xml:space="preserve">
+    <value>Settings...</value>
+  </data>
+  <data name="Menu_AutoStart" xml:space="preserve">
+    <value>Auto-start</value>
+  </data>
+  <data name="Menu_AutoStartEnabled" xml:space="preserve">
+    <value>Auto-start ✓</value>
+  </data>
+  <data name="Menu_OpenLogFile" xml:space="preserve">
+    <value>Open Log File</value>
+  </data>
+  <data name="Menu_Exit" xml:space="preserve">
+    <value>Exit</value>
+  </data>
+  <data name="Menu_CopyNodeSummary" xml:space="preserve">
+    <value>Copy node summary</value>
+  </data>
+
+  <!-- Tray menu dynamic text -->
+  <data name="Menu_StatusFormat" xml:space="preserve">
+    <value>Status: {0}</value>
+  </data>
+  <data name="Menu_SessionsFormat" xml:space="preserve">
+    <value>Sessions ({0})</value>
+  </data>
+  <data name="Menu_NodesFormat" xml:space="preserve">
+    <value>Nodes ({0})</value>
+  </data>
+  <data name="Menu_RecentActivityFormat" xml:space="preserve">
+    <value>Recent Activity ({0})</value>
+  </data>
+  <data name="Menu_NoUsageData" xml:space="preserve">
+    <value>No usage data</value>
+  </data>
+  <data name="Menu_ResetSession" xml:space="preserve">
+    <value>↳ Reset session</value>
+  </data>
+  <data name="Menu_CompactLog" xml:space="preserve">
+    <value>↳ Compact log</value>
+  </data>
+  <data name="Menu_DeleteSession" xml:space="preserve">
+    <value>↳ Delete session</value>
+  </data>
+  <data name="Menu_NodeWaitingApproval" xml:space="preserve">
+    <value>⏳ Waiting for approval...</value>
+  </data>
+  <data name="Menu_NodePairedConnected" xml:space="preserve">
+    <value>✅ Paired &amp; Connected</value>
+  </data>
+  <data name="Menu_NodeConnecting" xml:space="preserve">
+    <value>🔄 Connecting...</value>
+  </data>
+  <data name="Menu_NodeDisconnected" xml:space="preserve">
+    <value>⚪ Disconnected</value>
+  </data>
+
+  <!-- Notification test -->
+  <data name="TestNotification_Title" xml:space="preserve">
+    <value>Test Notification</value>
+  </data>
+  <data name="TestNotification_Body" xml:space="preserve">
+    <value>This is a test notification from OpenClaw Tray.</value>
+  </data>
+
+  <!-- Status detail runtime -->
+  <data name="Status_LastCheckFormat" xml:space="preserve">
+    <value>Last check: {0}</value>
+  </data>
+
+  <!-- Time ago strings -->
+  <data name="TimeAgo_JustNow" xml:space="preserve">
+    <value>Just now</value>
+  </data>
+  <data name="TimeAgo_MinutesFormat" xml:space="preserve">
+    <value>{0}m ago</value>
+  </data>
+  <data name="TimeAgo_HoursFormat" xml:space="preserve">
+    <value>{0}h ago</value>
+  </data>
+
+  <!-- Activity stream runtime -->
+  <data name="Activity_ClickToOpen" xml:space="preserve">
+    <value>Click to open in dashboard</value>
+  </data>
+
+  <data name="TimeAgo_DaysFormat" xml:space="preserve">
+    <value>{0}d ago</value>
+  </data>
+
+  <!-- Status display text (plain, no emoji) -->
+  <data name="StatusDisplay_Connected" xml:space="preserve">
+    <value>Connected</value>
+  </data>
+  <data name="StatusDisplay_Connecting" xml:space="preserve">
+    <value>Connecting</value>
+  </data>
+  <data name="StatusDisplay_Disconnected" xml:space="preserve">
+    <value>Disconnected</value>
+  </data>
+  <data name="StatusDisplay_Error" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="StatusDisplay_Unknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="Status_NotAvailable" xml:space="preserve">
+    <value>n/a</value>
+  </data>
+
+</root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -1,0 +1,469 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+
+  <!-- ==================== SettingsWindow.xaml ==================== -->
+
+  <!-- Section headers -->
+  <data name="SettingsConnectionHeader.Text" xml:space="preserve">
+    <value>连接</value>
+  </data>
+  <data name="SettingsStartupHeader.Text" xml:space="preserve">
+    <value>启动</value>
+  </data>
+  <data name="SettingsNotificationsHeader.Text" xml:space="preserve">
+    <value>通知</value>
+  </data>
+  <data name="SettingsAdvancedHeader.Text" xml:space="preserve">
+    <value>高级（实验性）</value>
+  </data>
+
+  <!-- TextBox headers and placeholders -->
+  <data name="SettingsGatewayUrlTextBox.Header" xml:space="preserve">
+    <value>网关地址</value>
+  </data>
+  <data name="SettingsGatewayUrlTextBox.PlaceholderText" xml:space="preserve">
+    <value>ws://localhost:18789 或 https://host.tailnet.ts.net</value>
+  </data>
+  <data name="SettingsTokenTextBox.Header" xml:space="preserve">
+    <value>令牌</value>
+  </data>
+  <data name="SettingsTokenTextBox.PlaceholderText" xml:space="preserve">
+    <value>您的 API 令牌</value>
+  </data>
+
+  <!-- Toggle headers -->
+  <data name="SettingsAutoStartToggle.Header" xml:space="preserve">
+    <value>随 Windows 自动启动</value>
+  </data>
+  <data name="SettingsGlobalHotkeyToggle.Header" xml:space="preserve">
+    <value>全局快捷键 (Ctrl+Alt+Shift+C → 快速发送)</value>
+  </data>
+  <data name="SettingsNotificationsToggle.Header" xml:space="preserve">
+    <value>显示通知</value>
+  </data>
+  <data name="SettingsNodeModeToggle.Header" xml:space="preserve">
+    <value>启用节点模式</value>
+  </data>
+
+  <!-- ComboBox -->
+  <data name="SettingsSoundComboBox.Header" xml:space="preserve">
+    <value>提示音</value>
+  </data>
+  <data name="SettingsSoundDefault.Content" xml:space="preserve">
+    <value>默认</value>
+  </data>
+  <data name="SettingsSoundNone.Content" xml:space="preserve">
+    <value>无</value>
+  </data>
+  <data name="SettingsSoundSubtle.Content" xml:space="preserve">
+    <value>柔和</value>
+  </data>
+
+  <!-- Notification filter labels -->
+  <data name="SettingsNotifyForLabel.Text" xml:space="preserve">
+    <value>显示以下类型通知:</value>
+  </data>
+  <data name="SettingsNotifyFilterHint.Text" xml:space="preserve">
+    <value>按消息中的关键词过滤（例如"邮件"、"提醒"）</value>
+  </data>
+
+  <!-- Notification filter checkboxes -->
+  <data name="SettingsNotifyHealthCb.Content" xml:space="preserve">
+    <value>健康警报</value>
+  </data>
+  <data name="SettingsNotifyUrgentCb.Content" xml:space="preserve">
+    <value>紧急消息</value>
+  </data>
+  <data name="SettingsNotifyReminderCb.Content" xml:space="preserve">
+    <value>提醒</value>
+  </data>
+  <data name="SettingsNotifyEmailCb.Content" xml:space="preserve">
+    <value>邮件摘要</value>
+  </data>
+  <data name="SettingsNotifyCalendarCb.Content" xml:space="preserve">
+    <value>日历事件</value>
+  </data>
+  <data name="SettingsNotifyBuildCb.Content" xml:space="preserve">
+    <value>构建通知</value>
+  </data>
+  <data name="SettingsNotifyStockCb.Content" xml:space="preserve">
+    <value>股票提醒</value>
+  </data>
+  <data name="SettingsNotifyInfoCb.Content" xml:space="preserve">
+    <value>常规信息</value>
+  </data>
+
+  <!-- Buttons -->
+  <data name="SettingsTestConnectionButton.Content" xml:space="preserve">
+    <value>测试</value>
+  </data>
+  <data name="SettingsTestNotificationButton.Content" xml:space="preserve">
+    <value>发送测试通知</value>
+  </data>
+  <data name="SettingsSaveButton.Content" xml:space="preserve">
+    <value>保存</value>
+  </data>
+  <data name="SettingsCancelButton.Content" xml:space="preserve">
+    <value>取消</value>
+  </data>
+
+  <!-- Node mode description -->
+  <data name="SettingsNodeModeDescription.Text" xml:space="preserve">
+    <value>启用后，此电脑可以接收来自代理的命令（画布、截图等）</value>
+  </data>
+
+  <!-- ==================== StatusDetailWindow.xaml ==================== -->
+
+  <!-- Section headers -->
+  <data name="StatusUsageHeader.Text" xml:space="preserve">
+    <value>用量</value>
+  </data>
+  <data name="StatusSessionsHeader.Text" xml:space="preserve">
+    <value>活跃会话</value>
+  </data>
+  <data name="StatusChannelsHeader.Text" xml:space="preserve">
+    <value>频道</value>
+  </data>
+
+  <!-- Labels -->
+  <data name="StatusCostLabel.Text" xml:space="preserve">
+    <value>费用（窗口期）:</value>
+  </data>
+  <data name="StatusRequestsLabel.Text" xml:space="preserve">
+    <value>请求 / 令牌数:</value>
+  </data>
+  <data name="StatusProvidersLabel.Text" xml:space="preserve">
+    <value>提供者:</value>
+  </data>
+
+  <!-- Default values -->
+  <data name="StatusConnectedText.Text" xml:space="preserve">
+    <value>已连接</value>
+  </data>
+  <data name="StatusNoSessions.Text" xml:space="preserve">
+    <value>无活跃会话</value>
+  </data>
+
+  <!-- Buttons -->
+  <data name="StatusRefreshButton.Content" xml:space="preserve">
+    <value>刷新</value>
+  </data>
+
+  <!-- ==================== ActivityStreamWindow.xaml ==================== -->
+
+  <!-- Header -->
+  <data name="ActivityStreamTitle.Text" xml:space="preserve">
+    <value>⚡ 活动流</value>
+  </data>
+
+  <!-- Filter items -->
+  <data name="ActivityFilterAll.Content" xml:space="preserve">
+    <value>全部活动</value>
+  </data>
+  <data name="ActivityFilterSessions.Content" xml:space="preserve">
+    <value>会话</value>
+  </data>
+  <data name="ActivityFilterUsage.Content" xml:space="preserve">
+    <value>用量</value>
+  </data>
+  <data name="ActivityFilterNodes.Content" xml:space="preserve">
+    <value>节点</value>
+  </data>
+  <data name="ActivityFilterNotifications.Content" xml:space="preserve">
+    <value>通知</value>
+  </data>
+
+  <!-- Empty state -->
+  <data name="ActivityEmptyText.Text" xml:space="preserve">
+    <value>暂无活动</value>
+  </data>
+
+  <!-- Buttons -->
+  <data name="ActivityOpenDashboardButton.Content" xml:space="preserve">
+    <value>打开仪表板</value>
+  </data>
+  <data name="ActivityClearAllButton.Content" xml:space="preserve">
+    <value>全部清除</value>
+  </data>
+  <data name="ActivityCloseButton.Content" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+
+  <!-- ==================== NotificationHistoryWindow.xaml ==================== -->
+
+  <!-- Header -->
+  <data name="NotificationHistoryTitle.Text" xml:space="preserve">
+    <value>📋 通知历史</value>
+  </data>
+
+  <!-- Empty state -->
+  <data name="NotificationEmptyText.Text" xml:space="preserve">
+    <value>暂无通知</value>
+  </data>
+
+  <!-- Buttons -->
+  <data name="NotificationClearAllButton.Content" xml:space="preserve">
+    <value>全部清除</value>
+  </data>
+  <data name="NotificationCloseButton.Content" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+
+  <!-- ==================== Runtime strings (C# code) ==================== -->
+
+  <!-- Window titles -->
+  <data name="WindowTitle_Settings" xml:space="preserve">
+    <value>设置 — OpenClaw 托盘</value>
+  </data>
+  <data name="WindowTitle_Status" xml:space="preserve">
+    <value>状态 — OpenClaw 托盘</value>
+  </data>
+  <data name="WindowTitle_ActivityStream" xml:space="preserve">
+    <value>活动流 — OpenClaw 托盘</value>
+  </data>
+  <data name="WindowTitle_NotificationHistory" xml:space="preserve">
+    <value>通知历史 — OpenClaw 托盘</value>
+  </data>
+  <data name="WindowTitle_QuickSend" xml:space="preserve">
+    <value>快速发送 — OpenClaw</value>
+  </data>
+  <data name="WindowTitle_WebChat" xml:space="preserve">
+    <value>OpenClaw 聊天</value>
+  </data>
+  <data name="WindowTitle_Welcome" xml:space="preserve">
+    <value>欢迎使用 OpenClaw</value>
+  </data>
+  <data name="WindowTitle_Update" xml:space="preserve">
+    <value>OpenClaw 更新</value>
+  </data>
+
+  <!-- Settings runtime status -->
+  <data name="Status_Testing" xml:space="preserve">
+    <value>测试中...</value>
+  </data>
+  <data name="Status_Connected" xml:space="preserve">
+    <value>✅ 连接成功！</value>
+  </data>
+  <data name="Status_ConnectionFailed" xml:space="preserve">
+    <value>❌ 连接失败</value>
+  </data>
+
+  <!-- QuickSend dialog -->
+  <data name="QuickSend_Header" xml:space="preserve">
+    <value>📤 快速发送</value>
+  </data>
+  <data name="QuickSend_Placeholder" xml:space="preserve">
+    <value>输入您的消息...</value>
+  </data>
+  <data name="QuickSend_SendButton" xml:space="preserve">
+    <value>发送</value>
+  </data>
+  <data name="QuickSend_CancelButton" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="QuickSend_Sending" xml:space="preserve">
+    <value>发送中...</value>
+  </data>
+  <data name="QuickSend_Failed" xml:space="preserve">
+    <value>❌ 发送失败</value>
+  </data>
+  <data name="QuickSend_ToastTitle" xml:space="preserve">
+    <value>消息已发送</value>
+  </data>
+  <data name="QuickSend_ToastBody" xml:space="preserve">
+    <value>您的消息已发送至 OpenClaw。</value>
+  </data>
+
+  <!-- WelcomeDialog -->
+  <data name="Welcome_Title" xml:space="preserve">
+    <value>欢迎使用 OpenClaw！</value>
+  </data>
+  <data name="Welcome_Description" xml:space="preserve">
+    <value>OpenClaw 托盘是 OpenClaw 的 Windows 伴侣应用，一个 AI 驱动的个人助手。</value>
+  </data>
+  <data name="Welcome_GettingStarted" xml:space="preserve">
+    <value>开始使用前，您需要：</value>
+  </data>
+  <data name="Welcome_NeedGateway" xml:space="preserve">
+    <value>• 一个正在运行的 OpenClaw 网关</value>
+  </data>
+  <data name="Welcome_NeedToken" xml:space="preserve">
+    <value>• 从仪表板获取的 API 令牌</value>
+  </data>
+  <data name="Welcome_ViewDocs" xml:space="preserve">
+    <value>📚 查看文档</value>
+  </data>
+  <data name="Welcome_LaterButton" xml:space="preserve">
+    <value>稍后</value>
+  </data>
+  <data name="Welcome_OpenSettingsButton" xml:space="preserve">
+    <value>打开设置</value>
+  </data>
+
+  <!-- UpdateDialog -->
+  <data name="Update_VersionAvailable" xml:space="preserve">
+    <value>🎉 版本 {0} 已可用！</value>
+  </data>
+  <data name="Update_CurrentVersion" xml:space="preserve">
+    <value>当前版本: {0}</value>
+  </data>
+  <data name="Update_WhatsNew" xml:space="preserve">
+    <value>更新内容:</value>
+  </data>
+  <data name="Update_SkipButton" xml:space="preserve">
+    <value>跳过此版本</value>
+  </data>
+  <data name="Update_RemindLaterButton" xml:space="preserve">
+    <value>稍后提醒</value>
+  </data>
+  <data name="Update_DownloadButton" xml:space="preserve">
+    <value>下载并安装</value>
+  </data>
+
+  <!-- Tray menu items -->
+  <data name="Menu_OpenDashboard" xml:space="preserve">
+    <value>打开仪表板</value>
+  </data>
+  <data name="Menu_OpenWebChat" xml:space="preserve">
+    <value>打开网页聊天</value>
+  </data>
+  <data name="Menu_QuickSend" xml:space="preserve">
+    <value>快速发送...</value>
+  </data>
+  <data name="Menu_ActivityStream" xml:space="preserve">
+    <value>活动流...</value>
+  </data>
+  <data name="Menu_NotificationHistory" xml:space="preserve">
+    <value>通知历史...</value>
+  </data>
+  <data name="Menu_RunHealthCheck" xml:space="preserve">
+    <value>运行健康检查</value>
+  </data>
+  <data name="Menu_Settings" xml:space="preserve">
+    <value>设置...</value>
+  </data>
+  <data name="Menu_AutoStart" xml:space="preserve">
+    <value>自动启动</value>
+  </data>
+  <data name="Menu_AutoStartEnabled" xml:space="preserve">
+    <value>自动启动 ✓</value>
+  </data>
+  <data name="Menu_OpenLogFile" xml:space="preserve">
+    <value>打开日志文件</value>
+  </data>
+  <data name="Menu_Exit" xml:space="preserve">
+    <value>退出</value>
+  </data>
+  <data name="Menu_CopyNodeSummary" xml:space="preserve">
+    <value>复制节点摘要</value>
+  </data>
+
+  <!-- Tray menu dynamic text -->
+  <data name="Menu_StatusFormat" xml:space="preserve">
+    <value>状态: {0}</value>
+  </data>
+  <data name="Menu_SessionsFormat" xml:space="preserve">
+    <value>会话 ({0})</value>
+  </data>
+  <data name="Menu_NodesFormat" xml:space="preserve">
+    <value>节点 ({0})</value>
+  </data>
+  <data name="Menu_RecentActivityFormat" xml:space="preserve">
+    <value>最近活动 ({0})</value>
+  </data>
+  <data name="Menu_NoUsageData" xml:space="preserve">
+    <value>暂无用量数据</value>
+  </data>
+  <data name="Menu_ResetSession" xml:space="preserve">
+    <value>↳ 重置会话</value>
+  </data>
+  <data name="Menu_CompactLog" xml:space="preserve">
+    <value>↳ 压缩日志</value>
+  </data>
+  <data name="Menu_DeleteSession" xml:space="preserve">
+    <value>↳ 删除会话</value>
+  </data>
+  <data name="Menu_NodeWaitingApproval" xml:space="preserve">
+    <value>⏳ 等待批准...</value>
+  </data>
+  <data name="Menu_NodePairedConnected" xml:space="preserve">
+    <value>✅ 已配对并连接</value>
+  </data>
+  <data name="Menu_NodeConnecting" xml:space="preserve">
+    <value>🔄 连接中...</value>
+  </data>
+  <data name="Menu_NodeDisconnected" xml:space="preserve">
+    <value>⚪ 已断开</value>
+  </data>
+
+  <!-- Notification test -->
+  <data name="TestNotification_Title" xml:space="preserve">
+    <value>测试通知</value>
+  </data>
+  <data name="TestNotification_Body" xml:space="preserve">
+    <value>这是来自 OpenClaw 托盘的测试通知。</value>
+  </data>
+
+  <!-- Status detail runtime -->
+  <data name="Status_LastCheckFormat" xml:space="preserve">
+    <value>上次检查: {0}</value>
+  </data>
+
+  <!-- Time ago strings -->
+  <data name="TimeAgo_JustNow" xml:space="preserve">
+    <value>刚刚</value>
+  </data>
+  <data name="TimeAgo_MinutesFormat" xml:space="preserve">
+    <value>{0}分钟前</value>
+  </data>
+  <data name="TimeAgo_HoursFormat" xml:space="preserve">
+    <value>{0}小时前</value>
+  </data>
+
+  <!-- Activity stream runtime -->
+  <data name="Activity_ClickToOpen" xml:space="preserve">
+    <value>点击在仪表板中打开</value>
+  </data>
+
+  <data name="TimeAgo_DaysFormat" xml:space="preserve">
+    <value>{0}天前</value>
+  </data>
+
+  <!-- Status display text (plain, no emoji) -->
+  <data name="StatusDisplay_Connected" xml:space="preserve">
+    <value>已连接</value>
+  </data>
+  <data name="StatusDisplay_Connecting" xml:space="preserve">
+    <value>正在连接</value>
+  </data>
+  <data name="StatusDisplay_Disconnected" xml:space="preserve">
+    <value>已断开</value>
+  </data>
+  <data name="StatusDisplay_Error" xml:space="preserve">
+    <value>错误</value>
+  </data>
+  <data name="StatusDisplay_Unknown" xml:space="preserve">
+    <value>未知</value>
+  </data>
+  <data name="Status_NotAvailable" xml:space="preserve">
+    <value>无</value>
+  </data>
+
+</root>

--- a/src/OpenClaw.Tray.WinUI/Windows/ActivityStreamWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/ActivityStreamWindow.xaml
@@ -19,18 +19,18 @@
 
         <StackPanel Grid.Row="0" Spacing="10" Margin="0,0,0,12">
             <StackPanel Orientation="Horizontal" Spacing="10">
-                <TextBlock Text="⚡ Activity Stream" Style="{StaticResource SubtitleTextBlockStyle}"/>
+                <TextBlock x:Uid="ActivityStreamTitle" Text="⚡ Activity Stream" Style="{StaticResource SubtitleTextBlockStyle}"/>
                 <TextBlock x:Name="CountText" Text="(0)" VerticalAlignment="Center"
                            Style="{StaticResource CaptionTextBlockStyle}"
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
             </StackPanel>
 
             <ComboBox x:Name="FilterCombo" Width="180" SelectionChanged="OnFilterChanged">
-                <ComboBoxItem Content="All activity" Tag="all" />
-                <ComboBoxItem Content="Sessions" Tag="session" />
-                <ComboBoxItem Content="Usage" Tag="usage" />
-                <ComboBoxItem Content="Nodes" Tag="node" />
-                <ComboBoxItem Content="Notifications" Tag="notification" />
+                <ComboBoxItem x:Uid="ActivityFilterAll" Content="All activity" Tag="all" />
+                <ComboBoxItem x:Uid="ActivityFilterSessions" Content="Sessions" Tag="session" />
+                <ComboBoxItem x:Uid="ActivityFilterUsage" Content="Usage" Tag="usage" />
+                <ComboBoxItem x:Uid="ActivityFilterNodes" Content="Nodes" Tag="node" />
+                <ComboBoxItem x:Uid="ActivityFilterNotifications" Content="Notifications" Tag="notification" />
             </ComboBox>
         </StackPanel>
 
@@ -83,16 +83,16 @@
                     VerticalAlignment="Center" HorizontalAlignment="Center"
                     Visibility="Collapsed">
             <TextBlock Text="🧭" FontSize="48" HorizontalAlignment="Center"/>
-            <TextBlock Text="No activity yet"
+            <TextBlock x:Uid="ActivityEmptyText" Text="No activity yet"
                        Style="{StaticResource BodyTextBlockStyle}"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
         </StackPanel>
 
         <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="8"
                     HorizontalAlignment="Right" Margin="0,12,0,0">
-            <Button Content="Open Dashboard" Click="OnOpenDashboard"/>
-            <Button Content="Clear All" Click="OnClearAll"/>
-            <Button Content="Close" Click="OnClose"/>
+            <Button x:Uid="ActivityOpenDashboardButton" Content="Open Dashboard" Click="OnOpenDashboard"/>
+            <Button x:Uid="ActivityClearAllButton" Content="Clear All" Click="OnClearAll"/>
+            <Button x:Uid="ActivityCloseButton" Content="Close" Click="OnClose"/>
         </StackPanel>
     </Grid>
 </winex:WindowEx>

--- a/src/OpenClaw.Tray.WinUI/Windows/ActivityStreamWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/ActivityStreamWindow.xaml.cs
@@ -20,6 +20,7 @@ public sealed partial class ActivityStreamWindow : WindowEx
     public ActivityStreamWindow(Action<string?> openDashboard)
     {
         InitializeComponent();
+        Title = LocalizationHelper.GetString("WindowTitle_ActivityStream");
 
         _openDashboard = openDashboard;
 
@@ -110,7 +111,7 @@ public sealed partial class ActivityStreamWindow : WindowEx
             DetailText = detailText,
             DetailVisibility = string.IsNullOrWhiteSpace(detailText) ? Visibility.Collapsed : Visibility.Visible,
             DashboardPath = item.DashboardPath,
-            OpenHint = "Click to open in dashboard",
+            OpenHint = LocalizationHelper.GetString("Activity_ClickToOpen"),
             OpenHintVisibility = canOpen ? Visibility.Visible : Visibility.Collapsed
         };
     }
@@ -135,9 +136,10 @@ public sealed partial class ActivityStreamWindow : WindowEx
     {
         var diff = DateTime.Now - timestamp;
 
-        if (diff.TotalMinutes < 1) return "Just now";
-        if (diff.TotalMinutes < 60) return $"{(int)diff.TotalMinutes}m ago";
-        if (diff.TotalHours < 24) return $"{(int)diff.TotalHours}h ago";
+        if (diff.TotalMinutes < 1) return LocalizationHelper.GetString("TimeAgo_JustNow");
+        if (diff.TotalMinutes < 60) return string.Format(LocalizationHelper.GetString("TimeAgo_MinutesFormat"), (int)diff.TotalMinutes);
+        if (diff.TotalHours < 24) return string.Format(LocalizationHelper.GetString("TimeAgo_HoursFormat"), (int)diff.TotalHours);
+        if (diff.TotalDays < 7) return string.Format(LocalizationHelper.GetString("TimeAgo_DaysFormat"), (int)diff.TotalDays);
         return timestamp.ToString("MMM d, HH:mm");
     }
 

--- a/src/OpenClaw.Tray.WinUI/Windows/NotificationHistoryWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/NotificationHistoryWindow.xaml
@@ -19,7 +19,7 @@
 
         <!-- Header -->
         <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="12" Margin="0,0,0,16">
-            <TextBlock Text="📋 Notification History" Style="{StaticResource SubtitleTextBlockStyle}"/>
+            <TextBlock x:Uid="NotificationHistoryTitle" Text="📋 Notification History" Style="{StaticResource SubtitleTextBlockStyle}"/>
             <TextBlock x:Name="CountText" Text="(0)" VerticalAlignment="Center"
                        Style="{StaticResource CaptionTextBlockStyle}"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
@@ -72,7 +72,7 @@
                     VerticalAlignment="Center" HorizontalAlignment="Center"
                     Visibility="Collapsed">
             <TextBlock Text="📭" FontSize="48" HorizontalAlignment="Center"/>
-            <TextBlock Text="No notifications yet" 
+            <TextBlock x:Uid="NotificationEmptyText" Text="No notifications yet" 
                        Style="{StaticResource BodyTextBlockStyle}"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
         </StackPanel>
@@ -80,8 +80,8 @@
         <!-- Footer -->
         <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="8" 
                     HorizontalAlignment="Right" Margin="0,16,0,0">
-            <Button Content="Clear All" Click="OnClearAll"/>
-            <Button Content="Close" Click="OnClose"/>
+            <Button x:Uid="NotificationClearAllButton" Content="Clear All" Click="OnClearAll"/>
+            <Button x:Uid="NotificationCloseButton" Content="Close" Click="OnClose"/>
         </StackPanel>
     </Grid>
 </winex:WindowEx>

--- a/src/OpenClaw.Tray.WinUI/Windows/NotificationHistoryWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/NotificationHistoryWindow.xaml.cs
@@ -18,6 +18,7 @@ public sealed partial class NotificationHistoryWindow : WindowEx
     public NotificationHistoryWindow()
     {
         InitializeComponent();
+        Title = LocalizationHelper.GetString("WindowTitle_NotificationHistory");
         
         // Window configuration
         this.SetWindowSize(450, 600);
@@ -61,9 +62,10 @@ public sealed partial class NotificationHistoryWindow : WindowEx
     {
         var diff = DateTime.Now - timestamp;
         
-        if (diff.TotalMinutes < 1) return "Just now";
-        if (diff.TotalMinutes < 60) return $"{(int)diff.TotalMinutes}m ago";
-        if (diff.TotalHours < 24) return $"{(int)diff.TotalHours}h ago";
+        if (diff.TotalMinutes < 1) return LocalizationHelper.GetString("TimeAgo_JustNow");
+        if (diff.TotalMinutes < 60) return string.Format(LocalizationHelper.GetString("TimeAgo_MinutesFormat"), (int)diff.TotalMinutes);
+        if (diff.TotalHours < 24) return string.Format(LocalizationHelper.GetString("TimeAgo_HoursFormat"), (int)diff.TotalHours);
+        if (diff.TotalDays < 7) return string.Format(LocalizationHelper.GetString("TimeAgo_DaysFormat"), (int)diff.TotalDays);
         return timestamp.ToString("MMM d, HH:mm");
     }
 

--- a/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml
@@ -23,16 +23,16 @@
                 
                 <!-- Connection Section -->
                 <StackPanel Spacing="8">
-                    <TextBlock Text="CONNECTION" Style="{StaticResource CaptionTextBlockStyle}" 
+                    <TextBlock x:Uid="SettingsConnectionHeader" Text="CONNECTION" Style="{StaticResource CaptionTextBlockStyle}" 
                                Foreground="#E74C3C" FontWeight="Bold"/>
                     
-                    <TextBox x:Name="GatewayUrlTextBox" Header="Gateway URL" 
+                    <TextBox x:Name="GatewayUrlTextBox" x:Uid="SettingsGatewayUrlTextBox" Header="Gateway URL" 
                              PlaceholderText="ws://localhost:18789 or https://host.tailnet.ts.net"/>
                     
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <TextBox x:Name="TokenTextBox" Header="Token" 
+                        <TextBox x:Name="TokenTextBox" x:Uid="SettingsTokenTextBox" Header="Token" 
                                  PlaceholderText="Your API token" Width="300"/>
-                        <Button x:Name="TestConnectionButton" Content="Test" 
+                        <Button x:Name="TestConnectionButton" x:Uid="SettingsTestConnectionButton" Content="Test" 
                                 VerticalAlignment="Bottom" Click="OnTestConnection"/>
                     </StackPanel>
                     
@@ -42,55 +42,55 @@
 
                 <!-- Startup Section -->
                 <StackPanel Spacing="8">
-                    <TextBlock Text="STARTUP" Style="{StaticResource CaptionTextBlockStyle}"
+                    <TextBlock x:Uid="SettingsStartupHeader" Text="STARTUP" Style="{StaticResource CaptionTextBlockStyle}"
                                Foreground="#E74C3C" FontWeight="Bold"/>
                     
-                    <ToggleSwitch x:Name="AutoStartToggle" Header="Start automatically with Windows"/>
-                    <ToggleSwitch x:Name="GlobalHotkeyToggle" Header="Global hotkey (Ctrl+Alt+Shift+C → Quick Send)"/>
+                    <ToggleSwitch x:Name="AutoStartToggle" x:Uid="SettingsAutoStartToggle" Header="Start automatically with Windows"/>
+                    <ToggleSwitch x:Name="GlobalHotkeyToggle" x:Uid="SettingsGlobalHotkeyToggle" Header="Global hotkey (Ctrl+Alt+Shift+C → Quick Send)"/>
                 </StackPanel>
 
                 <!-- Notifications Section -->
                 <StackPanel Spacing="8">
-                    <TextBlock Text="NOTIFICATIONS" Style="{StaticResource CaptionTextBlockStyle}"
+                    <TextBlock x:Uid="SettingsNotificationsHeader" Text="NOTIFICATIONS" Style="{StaticResource CaptionTextBlockStyle}"
                                Foreground="#E74C3C" FontWeight="Bold"/>
                     
-                    <ToggleSwitch x:Name="NotificationsToggle" Header="Show notifications"/>
+                    <ToggleSwitch x:Name="NotificationsToggle" x:Uid="SettingsNotificationsToggle" Header="Show notifications"/>
                     
-                    <ComboBox x:Name="NotificationSoundComboBox" Header="Sound" Width="200">
-                        <ComboBoxItem Content="Default" Tag="Default"/>
-                        <ComboBoxItem Content="None" Tag="None"/>
-                        <ComboBoxItem Content="Subtle" Tag="Subtle"/>
+                    <ComboBox x:Name="NotificationSoundComboBox" x:Uid="SettingsSoundComboBox" Header="Sound" Width="200">
+                        <ComboBoxItem x:Uid="SettingsSoundDefault" Content="Default" Tag="Default"/>
+                        <ComboBoxItem x:Uid="SettingsSoundNone" Content="None" Tag="None"/>
+                        <ComboBoxItem x:Uid="SettingsSoundSubtle" Content="Subtle" Tag="Subtle"/>
                     </ComboBox>
                     
-                    <TextBlock Text="Show notifications for:" Margin="0,8,0,0"/>
-                    <TextBlock Text="Filters by keywords in the message (e.g., 'email', 'reminder')" 
+                    <TextBlock x:Uid="SettingsNotifyForLabel" Text="Show notifications for:" Margin="0,8,0,0"/>
+                    <TextBlock x:Uid="SettingsNotifyFilterHint" Text="Filters by keywords in the message (e.g., 'email', 'reminder')" 
                                Style="{StaticResource CaptionTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Margin="0,0,0,4"/>
                     
                     <StackPanel Spacing="4">
-                        <CheckBox x:Name="NotifyHealthCb" Content="Health alerts"/>
-                        <CheckBox x:Name="NotifyUrgentCb" Content="Urgent messages"/>
-                        <CheckBox x:Name="NotifyReminderCb" Content="Reminders"/>
-                        <CheckBox x:Name="NotifyEmailCb" Content="Email summaries"/>
-                        <CheckBox x:Name="NotifyCalendarCb" Content="Calendar events"/>
-                        <CheckBox x:Name="NotifyBuildCb" Content="Build notifications"/>
-                        <CheckBox x:Name="NotifyStockCb" Content="Stock alerts"/>
-                        <CheckBox x:Name="NotifyInfoCb" Content="Info messages"/>
+                        <CheckBox x:Name="NotifyHealthCb" x:Uid="SettingsNotifyHealthCb" Content="Health alerts"/>
+                        <CheckBox x:Name="NotifyUrgentCb" x:Uid="SettingsNotifyUrgentCb" Content="Urgent messages"/>
+                        <CheckBox x:Name="NotifyReminderCb" x:Uid="SettingsNotifyReminderCb" Content="Reminders"/>
+                        <CheckBox x:Name="NotifyEmailCb" x:Uid="SettingsNotifyEmailCb" Content="Email summaries"/>
+                        <CheckBox x:Name="NotifyCalendarCb" x:Uid="SettingsNotifyCalendarCb" Content="Calendar events"/>
+                        <CheckBox x:Name="NotifyBuildCb" x:Uid="SettingsNotifyBuildCb" Content="Build notifications"/>
+                        <CheckBox x:Name="NotifyStockCb" x:Uid="SettingsNotifyStockCb" Content="Stock alerts"/>
+                        <CheckBox x:Name="NotifyInfoCb" x:Uid="SettingsNotifyInfoCb" Content="Info messages"/>
                     </StackPanel>
                 </StackPanel>
 
                 <!-- Test Notification -->
-                <Button x:Name="TestNotificationButton" Content="Send Test Notification" 
+                <Button x:Name="TestNotificationButton" x:Uid="SettingsTestNotificationButton" Content="Send Test Notification" 
                         Click="OnTestNotification"/>
                 
                 <!-- Advanced Section -->
                 <StackPanel Spacing="8">
-                    <TextBlock Text="ADVANCED (EXPERIMENTAL)" Style="{StaticResource CaptionTextBlockStyle}"
+                    <TextBlock x:Uid="SettingsAdvancedHeader" Text="ADVANCED (EXPERIMENTAL)" Style="{StaticResource CaptionTextBlockStyle}"
                                Foreground="#E74C3C" FontWeight="Bold"/>
                     
-                    <ToggleSwitch x:Name="NodeModeToggle" Header="Enable Node Mode"/>
-                    <TextBlock Text="When enabled, this PC can receive commands from the agent (canvas, screenshots, etc.)" 
+                    <ToggleSwitch x:Name="NodeModeToggle" x:Uid="SettingsNodeModeToggle" Header="Enable Node Mode"/>
+                    <TextBlock x:Uid="SettingsNodeModeDescription" Text="When enabled, this PC can receive commands from the agent (canvas, screenshots, etc.)" 
                                Style="{StaticResource CaptionTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                TextWrapping="Wrap"
@@ -107,8 +107,8 @@
                 BorderThickness="0,1,0,0"
                 Padding="24,16">
             <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right">
-                <Button Content="Cancel" Click="OnCancel" Width="80"/>
-                <Button x:Name="SaveButton" Content="Save" 
+                <Button x:Uid="SettingsCancelButton" Content="Cancel" Click="OnCancel" Width="80"/>
+                <Button x:Name="SaveButton" x:Uid="SettingsSaveButton" Content="Save" 
                         Click="OnSave" Width="80" Style="{ThemeResource AccentButtonStyle}"/>
             </StackPanel>
         </Border>

--- a/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml.cs
@@ -21,6 +21,8 @@ public sealed partial class SettingsWindow : WindowEx
         _settings = settings;
         InitializeComponent();
         
+        Title = LocalizationHelper.GetString("WindowTitle_Settings");
+        
         // Window configuration
         this.SetWindowSize(480, 700);
         this.CenterOnScreen();
@@ -104,7 +106,7 @@ public sealed partial class SettingsWindow : WindowEx
             return;
         }
 
-        StatusLabel.Text = "Testing...";
+        StatusLabel.Text = LocalizationHelper.GetString("Status_Testing");
         TestConnectionButton.IsEnabled = false;
 
         try
@@ -139,7 +141,9 @@ public sealed partial class SettingsWindow : WindowEx
                 connected = false;
             }
 
-            StatusLabel.Text = connected ? "✅ Connected!" : "❌ Connection failed";
+            StatusLabel.Text = connected
+                ? LocalizationHelper.GetString("Status_Connected")
+                : LocalizationHelper.GetString("Status_ConnectionFailed");
             client.Dispose();
         }
         catch (Exception ex)
@@ -157,8 +161,8 @@ public sealed partial class SettingsWindow : WindowEx
         try
         {
             new ToastContentBuilder()
-                .AddText("Test Notification")
-                .AddText("This is a test notification from OpenClaw Tray.")
+                .AddText(LocalizationHelper.GetString("TestNotification_Title"))
+                .AddText(LocalizationHelper.GetString("TestNotification_Body"))
                 .Show();
         }
         catch (Exception ex)

--- a/src/OpenClaw.Tray.WinUI/Windows/StatusDetailWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/StatusDetailWindow.xaml
@@ -18,7 +18,7 @@
                 <FontIcon x:Name="StatusIcon" Glyph="&#xE8FB;" FontSize="32"
                           Foreground="#E74C3C"/>
                 <StackPanel>
-                    <TextBlock x:Name="StatusText" Text="Connected" 
+                    <TextBlock x:Name="StatusText" x:Uid="StatusConnectedText" Text="Connected" 
                                Style="{StaticResource SubtitleTextBlockStyle}"/>
                     <TextBlock x:Name="LastCheckText" Text="Last check: --"
                                Style="{StaticResource CaptionTextBlockStyle}"
@@ -28,7 +28,7 @@
 
             <!-- Usage Section -->
             <StackPanel x:Name="UsageSection" Spacing="8">
-                <TextBlock Text="USAGE" Style="{StaticResource CaptionTextBlockStyle}"
+                <TextBlock x:Uid="StatusUsageHeader" Text="USAGE" Style="{StaticResource CaptionTextBlockStyle}"
                            Foreground="#E74C3C" FontWeight="Bold"/>
                 
                 <Grid ColumnSpacing="16" RowSpacing="4">
@@ -42,15 +42,15 @@
                         <RowDefinition/>
                     </Grid.RowDefinitions>
                     
-                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Cost (window):"/>
+                    <TextBlock x:Uid="StatusCostLabel" Grid.Row="0" Grid.Column="0" Text="Cost (window):"/>
                     <TextBlock x:Name="TodayCostText" Grid.Row="0" Grid.Column="1" 
                                Text="$0.00" FontWeight="SemiBold"/>
                     
-                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Requests / Tokens:"/>
+                    <TextBlock x:Uid="StatusRequestsLabel" Grid.Row="1" Grid.Column="0" Text="Requests / Tokens:"/>
                     <TextBlock x:Name="TodayRequestsText" Grid.Row="1" Grid.Column="1" 
                                Text="0 / 0" FontWeight="SemiBold"/>
 
-                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Providers:"/>
+                    <TextBlock x:Uid="StatusProvidersLabel" Grid.Row="2" Grid.Column="0" Text="Providers:"/>
                     <TextBlock x:Name="ProviderSummaryText" Grid.Row="2" Grid.Column="1"
                                Text="n/a" FontWeight="SemiBold" TextWrapping="Wrap"/>
                 </Grid>
@@ -58,7 +58,7 @@
 
             <!-- Sessions Section -->
             <StackPanel x:Name="SessionsSection" Spacing="8">
-                <TextBlock Text="ACTIVE SESSIONS" Style="{StaticResource CaptionTextBlockStyle}"
+                <TextBlock x:Uid="StatusSessionsHeader" Text="ACTIVE SESSIONS" Style="{StaticResource CaptionTextBlockStyle}"
                            Foreground="#E74C3C" FontWeight="Bold"/>
                 
                 <ItemsControl x:Name="SessionsList">
@@ -83,7 +83,7 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
                 
-                <TextBlock x:Name="NoSessionsText" Text="No active sessions"
+                <TextBlock x:Name="NoSessionsText" x:Uid="StatusNoSessions" Text="No active sessions"
                            Style="{StaticResource CaptionTextBlockStyle}"
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                            Visibility="Collapsed"/>
@@ -91,7 +91,7 @@
 
             <!-- Channels Section -->
             <StackPanel x:Name="ChannelsSection" Spacing="8">
-                <TextBlock Text="CHANNELS" Style="{StaticResource CaptionTextBlockStyle}"
+                <TextBlock x:Uid="StatusChannelsHeader" Text="CHANNELS" Style="{StaticResource CaptionTextBlockStyle}"
                            Foreground="#E74C3C" FontWeight="Bold"/>
                 
                 <ItemsControl x:Name="ChannelsList">
@@ -114,7 +114,7 @@
             </StackPanel>
 
             <!-- Refresh Button -->
-            <Button Content="Refresh" Click="OnRefresh" HorizontalAlignment="Center"/>
+            <Button x:Uid="StatusRefreshButton" Content="Refresh" Click="OnRefresh" HorizontalAlignment="Center"/>
             
         </StackPanel>
     </ScrollViewer>

--- a/src/OpenClaw.Tray.WinUI/Windows/StatusDetailWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/StatusDetailWindow.xaml.cs
@@ -25,6 +25,7 @@ public sealed partial class StatusDetailWindow : WindowEx
         DateTime lastCheck)
     {
         InitializeComponent();
+        Title = LocalizationHelper.GetString("WindowTitle_Status");
         
         // Window configuration
         this.SetWindowSize(420, 550);
@@ -44,8 +45,8 @@ public sealed partial class StatusDetailWindow : WindowEx
         DateTime lastCheck)
     {
         // Status
-        StatusText.Text = status.ToString();
-        LastCheckText.Text = $"Last check: {lastCheck:HH:mm:ss}";
+        StatusText.Text = LocalizationHelper.GetConnectionStatusText(status);
+        LastCheckText.Text = string.Format(LocalizationHelper.GetString("Status_LastCheckFormat"), lastCheck.ToString("HH:mm:ss"));
         
         var (glyph, color) = status switch
         {
@@ -66,7 +67,7 @@ public sealed partial class StatusDetailWindow : WindowEx
                 ? $"{usage.RequestCount:N0} / {usage.TotalTokens:N0}"
                 : $"{usage.TotalTokens:N0}";
             ProviderSummaryText.Text = string.IsNullOrWhiteSpace(usage.ProviderSummary)
-                ? "n/a"
+                ? LocalizationHelper.GetString("Status_NotAvailable")
                 : usage.ProviderSummary!;
         }
         else
@@ -79,7 +80,7 @@ public sealed partial class StatusDetailWindow : WindowEx
         {
             SessionsList.ItemsSource = sessions.Select(s => new
             {
-                Channel = s.Channel ?? "Unknown",
+                Channel = s.Channel ?? LocalizationHelper.GetString("StatusDisplay_Unknown"),
                 LastMessage = s.DisplayText
             }).ToList();
             SessionsList.Visibility = Visibility.Visible;
@@ -104,7 +105,7 @@ public sealed partial class StatusDetailWindow : WindowEx
             {
                 Name = c.Name,
                 StatusIcon = icon,
-                StatusText = c.Status ?? "Unknown",
+                StatusText = c.Status ?? LocalizationHelper.GetString("StatusDisplay_Unknown"),
                 StatusBrush = brush
             };
         }).ToList();


### PR DESCRIPTION
Add proper WinUI localization infrastructure using `.resw` resource files, enabling any language to be added by contributing a single resource file — no source code changes needed.

## What's included

### Infrastructure
- **`Strings/en-us/Resources.resw`** — 100+ English resource entries covering all windows, dialogs, tray menu, and runtime strings
- **`Strings/zh-cn/Resources.resw`** — Complete Chinese Simplified translations (from @Kobe9312's work in #30)
- **`LocalizationHelper.cs`** — Static `GetString()` helper using `ResourceLoader` with fallback
- **`x:Uid`** attributes on all XAML elements with user-visible text (with English fallback values)
- **`DefaultLanguage`** set to `en-US` in .csproj

### Localized code paths
- **SettingsWindow** — all XAML labels + runtime status text (Testing.../Connected!/Failed)
- **StatusDetailWindow** — headers, labels, connection status display, time formatting
- **ActivityStreamWindow** — headers, filters, time-ago strings, dashboard hints
- **NotificationHistoryWindow** — headers, empty state, time-ago strings
- **QuickSendDialog** — title, placeholder, send button, status messages
- **WelcomeDialog / UpdateDialog** — titles, body text, button labels
- **App.xaml.cs tray menu** — status, sessions, nodes, activity headers, node mode states, session actions
- **Window titles** — all set via LocalizationHelper

### Settings persistence: safe
ComboBox values are saved/loaded by `Tag` attribute (from #42), not display text. Localized labels won't corrupt settings.

## Review
Dual-model review (Opus + Codex). Both found resources defined but not wired up in code-behind — all fixed. Opus caught a translation error (库存提醒→股票提醒) — fixed.

**Build passes, all 475 tests pass.**

## Adding a new language
Just create `Strings/{locale}/Resources.resw` with the same keys. Windows auto-selects based on OS locale.

Addresses #40
/cc @Kobe9312
