### PR TITLE
fix(winui): guard missing SendMessage deep link handler

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Services/DeepLinkHandler.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/DeepLinkHandler.cs
@@ -81,13 +81,13 @@ public static class DeepLinkHandler
 
             case "agent":
                 var agentMessage = GetQueryParam(query, "message");
-                if (!string.IsNullOrEmpty(agentMessage))
+                if (!string.IsNullOrEmpty(agentMessage) && actions.SendMessage != null)
                 {
                     _ = Task.Run(async () =>
                     {
                         try
                         {
-                            await actions.SendMessage!(agentMessage);
+                            await actions.SendMessage(agentMessage);
                             Logger.Info($"Sent message via deep link: {agentMessage}");
                         }
                         catch (Exception ex)
@@ -95,6 +95,10 @@ public static class DeepLinkHandler
                             Logger.Error($"Failed to send message: {ex.Message}");
                         }
                     });
+                }
+                else if (!string.IsNullOrEmpty(agentMessage))
+                {
+                    Logger.Warn("Deep link: agent message received but SendMessage handler is not registered");
                 }
                 break;
 


### PR DESCRIPTION
Fixes #47

## Summary
- guard the `agent` deep-link path when `DeepLinkActions.SendMessage` is not registered
- replace the null-forgiving invocation with a real nullable check before the fire-and-forget task runs
- log a warning so missing handler wiring is diagnosable instead of surfacing as an unobserved `NullReferenceException`

## Why
`DeepLinkActions.SendMessage` is declared as `Func<string, Task>?`. The existing `await actions.SendMessage!(agentMessage)` suppresses the compiler warning but still throws at runtime if the callback is missing. Because the call happens inside `Task.Run`, that failure is harder to diagnose than the other deep-link callbacks, which already use defensive null checks.

## Validation
- `git diff --check` on the final patch passed locally
- `dotnet` is not available in this environment, so I could not rerun the shared test suite here
- the generated issue reports `dotnet test tests/OpenClaw.Shared.Tests/` green, and the code change stays within `DeepLinkHandler.cs`