### PR TITLE
feat: improve debug instrumentation across WinUI tray app

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Dialogs/QuickSendDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/QuickSendDialog.cs
@@ -123,6 +123,10 @@ public sealed class QuickSendDialog : WindowEx
             _messageTextBox.Focus(FocusState.Programmatic);
             TryBringToFront();
         };
+
+        Closed += (s, e) => Logger.Info("[QuickSend] Dialog closed");
+
+        Logger.Info($"[QuickSend] Dialog opened (prefill={!string.IsNullOrEmpty(prefillMessage)})");
     }
 
     private void TryBringToFront()
@@ -174,7 +178,7 @@ public sealed class QuickSendDialog : WindowEx
         try
         {
             await _client.SendChatMessageAsync(message);
-            Logger.Info($"Quick send: {message}");
+            Logger.Info($"[QuickSend] Message sent ({message.Length} chars)");
             new ToastContentBuilder()
                 .AddText(LocalizationHelper.GetString("QuickSend_ToastTitle"))
                 .AddText(LocalizationHelper.GetString("QuickSend_ToastBody"))

--- a/src/OpenClaw.Tray.WinUI/Dialogs/UpdateDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/UpdateDialog.cs
@@ -2,6 +2,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using OpenClawTray.Helpers;
+using OpenClawTray.Services;
 using System;
 using System.Threading.Tasks;
 using WinUIEx;
@@ -88,11 +89,11 @@ public sealed class UpdateDialog : WindowEx
         };
 
         var skipButton = new Button { Content = LocalizationHelper.GetString("Update_SkipButton") };
-        skipButton.Click += (s, e) => { _result = UpdateDialogResult.Skip; Close(); };
+        skipButton.Click += (s, e) => { Logger.Info("[Update] User clicked 'Skip'"); _result = UpdateDialogResult.Skip; Close(); };
         buttonPanel.Children.Add(skipButton);
 
         var laterButton = new Button { Content = LocalizationHelper.GetString("Update_RemindLaterButton") };
-        laterButton.Click += (s, e) => { _result = UpdateDialogResult.RemindLater; Close(); };
+        laterButton.Click += (s, e) => { Logger.Info("[Update] User clicked 'Remind Later'"); _result = UpdateDialogResult.RemindLater; Close(); };
         buttonPanel.Children.Add(laterButton);
 
         var downloadButton = new Button
@@ -100,7 +101,7 @@ public sealed class UpdateDialog : WindowEx
             Content = LocalizationHelper.GetString("Update_DownloadButton"),
             Style = (Style)Application.Current.Resources["AccentButtonStyle"]
         };
-        downloadButton.Click += (s, e) => { _result = UpdateDialogResult.Download; Close(); };
+        downloadButton.Click += (s, e) => { Logger.Info("[Update] User clicked 'Download'"); _result = UpdateDialogResult.Download; Close(); };
         buttonPanel.Children.Add(downloadButton);
 
         Grid.SetRow(buttonPanel, 2);
@@ -108,6 +109,8 @@ public sealed class UpdateDialog : WindowEx
 
         Content = root;
         Closed += (s, e) => _tcs.TrySetResult(_result);
+
+        Logger.Info($"[Update] Update dialog shown for version {version}");
     }
 
     public new Task<UpdateDialogResult> ShowAsync()

--- a/src/OpenClaw.Tray.WinUI/Dialogs/WelcomeDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/WelcomeDialog.cs
@@ -2,6 +2,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using OpenClawTray.Helpers;
+using OpenClawTray.Services;
 using System;
 using System.Threading.Tasks;
 using WinUIEx;
@@ -100,6 +101,7 @@ public sealed class WelcomeDialog : WindowEx
         var laterButton = new Button { Content = LocalizationHelper.GetString("Welcome_LaterButton") };
         laterButton.Click += (s, e) =>
         {
+            Logger.Info("[Welcome] User clicked 'Later'");
             _result = ContentDialogResult.None;
             Close();
         };
@@ -112,6 +114,7 @@ public sealed class WelcomeDialog : WindowEx
         };
         settingsButton.Click += (s, e) =>
         {
+            Logger.Info("[Welcome] User clicked 'Open Settings'");
             _result = ContentDialogResult.Primary;
             Close();
         };
@@ -123,6 +126,8 @@ public sealed class WelcomeDialog : WindowEx
         Content = root;
         
         Closed += (s, e) => _tcs.TrySetResult(_result);
+
+        Logger.Info("[Welcome] Welcome dialog shown");
     }
 
     public new Task<ContentDialogResult> ShowAsync()

--- a/src/OpenClaw.Tray.WinUI/Services/ActivityStreamService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ActivityStreamService.cs
@@ -40,9 +40,14 @@ public static class ActivityStreamService
 
             if (_items.Count > MaxItems)
             {
-                _items.RemoveRange(MaxItems, _items.Count - MaxItems);
+                var trimmed = _items.Count - MaxItems;
+                _items.RemoveRange(MaxItems, trimmed);
+                Logger.Debug($"[ActivityStream] Trimmed {trimmed} items (exceeded max {MaxItems})");
             }
         }
+
+        var truncatedTitle = title.Length > 50 ? title[..50] + "…" : title;
+        Logger.Info($"[ActivityStream] Item added: [{category}] {truncatedTitle}");
 
         Updated?.Invoke(null, EventArgs.Empty);
     }

--- a/src/OpenClaw.Tray.WinUI/Windows/ActivityStreamWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/ActivityStreamWindow.xaml.cs
@@ -33,6 +33,9 @@ public sealed partial class ActivityStreamWindow : WindowEx
 
         FilterCombo.SelectedIndex = 0;
         LoadActivity();
+
+        var initialCount = ActivityStreamService.GetItems(200).Count;
+        Logger.Info($"[ActivityStream] Window opened with {initialCount} items");
     }
 
     public void SetFilter(string? filter)
@@ -69,6 +72,9 @@ public sealed partial class ActivityStreamWindow : WindowEx
         {
             _currentFilter = item.Tag?.ToString() ?? "all";
             LoadActivity();
+            var category = _currentFilter == "all" ? null : _currentFilter;
+            var count = ActivityStreamService.GetItems(200, category).Count;
+            Logger.Info($"[ActivityStream] Filter changed to '{_currentFilter}', {count} items");
         }
     }
 
@@ -76,6 +82,7 @@ public sealed partial class ActivityStreamWindow : WindowEx
     {
         var category = _currentFilter == "all" ? null : _currentFilter;
         var items = ActivityStreamService.GetItems(200, category);
+        Logger.Debug($"[ActivityStream] Items loaded: {items.Count} (filter={_currentFilter})");
         CountText.Text = $"({items.Count})";
 
         if (items.Count == 0)

--- a/src/OpenClaw.Tray.WinUI/Windows/CanvasWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/CanvasWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.Web.WebView2.Core;
+using OpenClawTray.Services;
 using WinUIEx;
 using Windows.Storage.Streams;
 
@@ -111,7 +112,7 @@ public sealed partial class CanvasWindow : WindowEx
                 }
                 else
                 {
-                    System.Diagnostics.Debug.WriteLine($"[Canvas] Blocked pending URL: {url.Substring(0, Math.Min(50, url.Length))}...");
+                    Logger.Warn($"[Canvas] Blocked pending URL: {url.Substring(0, Math.Min(50, url.Length))}...");
                 }
             }
             else if (_pendingHtml != null)
@@ -223,8 +224,7 @@ public sealed partial class CanvasWindow : WindowEx
     /// </summary>
     public void LoadHtml(string html)
     {
-        // Log HTML loading for audit (truncated)
-        System.Diagnostics.Debug.WriteLine($"[Canvas] Loading HTML content ({html.Length} chars)");
+        Logger.Debug($"[Canvas] Loading HTML content ({html.Length} chars)");
         
         // Sanitize: strip iframes/objects/embeds that could bypass URL validation
         html = SanitizeHtml(html);
@@ -265,9 +265,8 @@ public sealed partial class CanvasWindow : WindowEx
         if (!_isWebViewInitialized)
             throw new InvalidOperationException("WebView2 not initialized");
         
-        // Log script execution for audit (truncated)
         var truncatedScript = script.Length > 100 ? script.Substring(0, 100) + "..." : script;
-        System.Diagnostics.Debug.WriteLine($"[Canvas] Executing script: {truncatedScript}");
+        Logger.Debug($"[Canvas] Executing script: {truncatedScript}");
         
         var result = await CanvasWebView.CoreWebView2.ExecuteScriptAsync(script);
         return result;

--- a/src/OpenClaw.Tray.WinUI/Windows/NotificationHistoryWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/NotificationHistoryWindow.xaml.cs
@@ -28,6 +28,11 @@ public sealed partial class NotificationHistoryWindow : WindowEx
         Closed += (s, e) => IsClosed = true;
         
         LoadNotifications();
+
+        var count = NotificationHistoryService.GetHistory().Count;
+        Logger.Info($"[NotificationHistory] Window opened with {count} notifications");
+        if (count == 0)
+            Logger.Warn("[NotificationHistory] Notification list is empty on open");
     }
 
     private void LoadNotifications()
@@ -86,6 +91,8 @@ public sealed partial class NotificationHistoryWindow : WindowEx
 
     private void OnClearAll(object sender, RoutedEventArgs e)
     {
+        var count = NotificationHistoryService.GetHistory().Count;
+        Logger.Info($"[NotificationHistory] Clear clicked — {count} notifications cleared");
         NotificationHistoryService.Clear();
         LoadNotifications();
     }

--- a/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml.cs
@@ -31,6 +31,8 @@ public sealed partial class SettingsWindow : WindowEx
         LoadSettings();
         
         Closed += (s, e) => IsClosed = true;
+        
+        Logger.Info("[Settings] Window opened");
     }
 
     private void LoadSettings()
@@ -106,6 +108,7 @@ public sealed partial class SettingsWindow : WindowEx
             return;
         }
 
+        Logger.Info("[Settings] Test connection initiated");
         StatusLabel.Text = LocalizationHelper.GetString("Status_Testing");
         TestConnectionButton.IsEnabled = false;
 
@@ -141,6 +144,11 @@ public sealed partial class SettingsWindow : WindowEx
                 connected = false;
             }
 
+            if (connected)
+                Logger.Info("[Settings] Test connection succeeded");
+            else
+                Logger.Warn("[Settings] Test connection failed or timed out");
+
             StatusLabel.Text = connected
                 ? LocalizationHelper.GetString("Status_Connected")
                 : LocalizationHelper.GetString("Status_ConnectionFailed");
@@ -148,6 +156,7 @@ public sealed partial class SettingsWindow : WindowEx
         }
         catch (Exception ex)
         {
+            Logger.Error($"[Settings] Test connection error: {ex.Message}");
             StatusLabel.Text = $"❌ {ex.Message}";
         }
         finally
@@ -176,17 +185,32 @@ public sealed partial class SettingsWindow : WindowEx
         var gatewayUrl = GatewayUrlTextBox.Text.Trim();
         if (!GatewayUrlHelper.IsValidGatewayUrl(gatewayUrl))
         {
+            Logger.Warn($"[Settings] Save blocked — invalid gateway URL");
             StatusLabel.Text = $"❌ {GatewayUrlHelper.ValidationMessage}";
             return;
         }
 
+        // Log key setting changes before saving
+        var oldGateway = _settings.GatewayUrl;
+        var oldAutoStart = _settings.AutoStart;
+        var oldNodeMode = _settings.EnableNodeMode;
         SaveSettings();
+
+        if (!string.Equals(oldGateway, _settings.GatewayUrl, StringComparison.Ordinal))
+            Logger.Info($"[Settings] GatewayUrl changed");
+        if (oldAutoStart != _settings.AutoStart)
+            Logger.Info($"[Settings] AutoStart changed to {_settings.AutoStart}");
+        if (oldNodeMode != _settings.EnableNodeMode)
+            Logger.Info($"[Settings] NodeMode changed to {_settings.EnableNodeMode}");
+
+        Logger.Info("[Settings] Settings saved");
         SettingsSaved?.Invoke(this, EventArgs.Empty);
         Close();
     }
 
     private void OnCancel(object sender, RoutedEventArgs e)
     {
+        Logger.Info("[Settings] Cancel clicked");
         Close();
     }
 

--- a/src/OpenClaw.Tray.WinUI/Windows/StatusDetailWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/StatusDetailWindow.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI;
 using OpenClaw.Shared;
 using OpenClawTray.Helpers;
+using OpenClawTray.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -34,6 +35,7 @@ public sealed partial class StatusDetailWindow : WindowEx
         
         Closed += (s, e) => IsClosed = true;
         
+        Logger.Info("[StatusDetail] Window opened");
         UpdateStatus(status, channels, sessions, usage, lastCheck);
     }
 
@@ -44,6 +46,12 @@ public sealed partial class StatusDetailWindow : WindowEx
         GatewayUsageInfo? usage,
         DateTime lastCheck)
     {
+        Logger.Info($"[StatusDetail] UpdateStatus: connection={status}, channels={channels?.Length ?? 0}, sessions={sessions?.Length ?? 0}");
+        if (channels == null || channels.Length == 0)
+            Logger.Warn("[StatusDetail] Channel list is null or empty");
+        if (sessions == null || sessions.Length == 0)
+            Logger.Warn("[StatusDetail] Session list is null or empty");
+
         // Status
         StatusText.Text = LocalizationHelper.GetConnectionStatusText(status);
         LastCheckText.Text = string.Format(LocalizationHelper.GetString("Status_LastCheckFormat"), lastCheck.ToString("HH:mm:ss"));
@@ -113,6 +121,7 @@ public sealed partial class StatusDetailWindow : WindowEx
 
     private void OnRefresh(object sender, RoutedEventArgs e)
     {
+        Logger.Info("[StatusDetail] Refresh requested");
         RefreshRequested?.Invoke(this, EventArgs.Empty);
     }
 


### PR DESCRIPTION
Add structured logging to 9 under-instrumented files. All logging goes through the `Logger` class with appropriate levels (ERROR/WARN/INFO/DEBUG).

| File | What |
|---|---|
| CanvasWindow | Replace raw Debug.WriteLine with Logger |
| StatusDetailWindow | Open, update, refresh, empty-data warnings |
| SettingsWindow | Open, save (change detection), cancel, test connection |
| ActivityStreamWindow | Open, filter changes, item counts |
| ActivityStreamService | Item added, trimmed |
| NotificationHistoryWindow | Open, clear, empty warning |
| QuickSendDialog | Open, send (length only for privacy), close |
| WelcomeDialog | Shown, user action |
| UpdateDialog | Shown, user action |

+73 lines, -10 lines. All 568 tests pass.

Closes #52