### PR TITLE
[Repo Assist] fix: refresh channel list when channels are added/removed on gateway

### DIFF
--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -1086,11 +1086,10 @@ public class OpenClawGatewayClient : IDisposable
             healthList.Add(ch);
         }
 
-        if (healthList.Count > 0)
-        {
-            _logger.Info($"Channel health: {string.Join(", ", healthList.ConvertAll(c => $"{c.Name}={c.Status}"))}");
-            ChannelHealthUpdated?.Invoke(this, healthList.ToArray());
-        }
+        _logger.Info(healthList.Count > 0
+            ? $"Channel health: {string.Join(", ", healthList.ConvertAll(c => $"{c.Name}={c.Status}"))}"
+            : "Channel health: no channels");
+        ChannelHealthUpdated?.Invoke(this, healthList.ToArray());
     }
 
     private void ParseSessions(JsonElement sessions)

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1265,6 +1265,13 @@ public partial class App : Application
     private void OnChannelHealthUpdated(object? sender, ChannelHealth[] channels)
     {
         _lastChannels = channels;
+
+        _dispatcherQueue?.TryEnqueue(() =>
+        {
+            if (_statusDetailWindow != null && !_statusDetailWindow.IsClosed)
+                _statusDetailWindow.UpdateStatus(
+                    _currentStatus, _lastChannels, _lastSessions, _lastUsage, _lastCheckTime);
+        });
     }
 
     private void OnSessionsUpdated(object? sender, SessionInfo[] sessions)

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -140,6 +140,24 @@ public class OpenClawGatewayClientTests
             return parsed;
         }
 
+        public (ChannelHealth[] channels, bool eventFired) ParseChannelHealthPayload(string payloadJson)
+        {
+            ChannelHealth[]? parsed = null;
+            EventHandler<ChannelHealth[]> handler = (_, ch) => parsed = ch;
+            _client.ChannelHealthUpdated += handler;
+
+            try
+            {
+                InvokePrivatePayloadParser("ParseChannelHealth", payloadJson);
+            }
+            finally
+            {
+                _client.ChannelHealthUpdated -= handler;
+            }
+
+            return (parsed ?? Array.Empty<ChannelHealth>(), parsed != null);
+        }
+
         private void InvokePrivatePayloadParser(string methodName, string payloadJson)
         {
             using var doc = JsonDocument.Parse(payloadJson);
@@ -593,5 +611,44 @@ public class OpenClawGatewayClientTests
         Assert.False(flags.UsageCost);
         Assert.False(flags.SessionPreview);
         Assert.False(flags.NodeList);
+    }
+
+    [Fact]
+    public void ParseChannelHealth_WithChannels_FiresEventWithCorrectNames()
+    {
+        var helper = new GatewayClientTestHelper();
+        var json = """{"discord":{"status":"running","running":true},"telegram":{"status":"ready","configured":true}}""";
+
+        var (channels, fired) = helper.ParseChannelHealthPayload(json);
+
+        Assert.True(fired);
+        Assert.Equal(2, channels.Length);
+        Assert.Contains(channels, c => c.Name == "discord");
+        Assert.Contains(channels, c => c.Name == "telegram");
+    }
+
+    [Fact]
+    public void ParseChannelHealth_EmptyObject_FiresEventWithEmptyArray()
+    {
+        var helper = new GatewayClientTestHelper();
+        var json = "{}";
+
+        var (channels, fired) = helper.ParseChannelHealthPayload(json);
+
+        // Event must fire even when there are no channels so removed channels are cleared
+        Assert.True(fired, "ChannelHealthUpdated should fire even when channels is empty");
+        Assert.Empty(channels);
+    }
+
+    [Fact]
+    public void ParseChannelHealth_StatusField_TakesPriorityOverDerivedStatus()
+    {
+        var helper = new GatewayClientTestHelper();
+        var json = """{"discord":{"status":"degraded","running":true}}""";
+
+        var (channels, _) = helper.ParseChannelHealthPayload(json);
+
+        Assert.Single(channels);
+        Assert.Equal("degraded", channels[0].Status);
     }
 }


### PR DESCRIPTION
Fixes two bugs that together caused issue #55.

**Root causes:**

1. **Empty channel list suppressed in ParseChannelHealth** — the \if (healthList.Count > 0)\ guard prevented \ChannelHealthUpdated\ from firing when the gateway returned an empty channel map, so removing the last channel never cleared the UI.

2. **Open StatusDetailWindow not refreshed on channel update** — \_lastChannels\ was updated but an already-open \StatusDetailWindow\ was never pushed the updated list.

**Fix:**
- Remove the count guard so \ChannelHealthUpdated\ always fires
- Dispatch \StatusDetailWindow.UpdateStatus\ when the window is open

**Tests:** 3 new unit tests covering channel health parsing. 478/478 shared tests pass.

Closes #55