### PR TITLE
[Repo Assist] ci: add OpenClaw.Tray.Tests to the CI test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,14 @@ jobs:
       run: dotnet build src/OpenClaw.Tray.WinUI -c Debug -r win-x64
 
     - name: Build Tests
-      run: dotnet build tests/OpenClaw.Shared.Tests -c Debug
+      run: |
+        dotnet build tests/OpenClaw.Shared.Tests -c Debug
+        dotnet build tests/OpenClaw.Tray.Tests -c Debug
 
     - name: Run Tests
-      run: dotnet test tests/OpenClaw.Shared.Tests --no-build -c Debug --verbosity normal
+      run: |
+        dotnet test tests/OpenClaw.Shared.Tests --no-build -c Debug --verbosity normal
+        dotnet test tests/OpenClaw.Tray.Tests --no-build -c Debug --verbosity normal
 
     outputs:
       semVer: ${{ steps.gitversion.outputs.semVer }}


### PR DESCRIPTION
Adds the 93-test \OpenClaw.Tray.Tests\ suite (introduced in PR #45) to the CI workflow so it runs on every push and pull request alongside the existing shared tests.

**Change:** Expand the Build Tests and Run Tests steps in \ci.yml\ to include \	ests/OpenClaw.Tray.Tests\.

Expected post-merge: **571 tests** (478 shared + 93 tray) green on every CI run.

Closes #58

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>