### PR TITLE
ci: add NuGet package caching to test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,13 @@ jobs:
       with:
         dotnet-version: 10.0.x
 
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+        restore-keys: nuget-${{ runner.os }}-
+
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v4
       with:


### PR DESCRIPTION
Adds \ctions/cache@v4\ for \~/.nuget/packages\ keyed on csproj hashes.

- Saves ~30-60s on subsequent CI runs
- Uses csproj hash (not lock files) since this repo doesn't use \packages.lock.json\`n- Only added to \	est\ job (runs on every push/PR); build jobs run less frequently

Based on Repo Assist suggestion (#66).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>