### PR TITLE
fix: stabilize tray pairing and reconnect behavior

### DIFF
--- a/src/OpenClaw.Shared/WebSocketClientBase.cs
+++ b/src/OpenClaw.Shared/WebSocketClientBase.cs
@@ -186,12 +186,18 @@ public abstract class WebSocketClientBase : IDisposable
 
     protected async Task ReconnectWithBackoffAsync()
     {
+        var emittedConnecting = false;
+
         while (!_disposed)
         {
             var delay = BackoffMs[Math.Min(_reconnectAttempts, BackoffMs.Length - 1)];
             _reconnectAttempts++;
             _logger.Warn($"{ClientRole} reconnecting in {delay}ms (attempt {_reconnectAttempts})");
-            RaiseStatusChanged(ConnectionStatus.Connecting);
+            if (!emittedConnecting)
+            {
+                RaiseStatusChanged(ConnectionStatus.Connecting);
+                emittedConnecting = true;
+            }
 
             try
             {

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -563,11 +563,14 @@ public class WindowsNodeClient : WebSocketClientBase
             else if (_pairingApprovedAwaitingReconnect)
             {
                 _logger.Info("hello-ok arrived after pairing approval without auth.deviceToken; keeping local state paired.");
+                _pairingApprovedAwaitingReconnect = false;
             }
 
             _logger.Info($"Node registered successfully! ID: {_nodeId ?? _deviceIdentity.DeviceId.Substring(0, 16)}");
             _logger.Info($"[NODE] hello-ok auth present={hasAuthPayload}, receivedDeviceToken={receivedDeviceToken}, storedDeviceToken={!string.IsNullOrEmpty(_deviceIdentity.DeviceToken)}, pendingApproval={_isPendingApproval}, awaitingReconnect={_pairingApprovedAwaitingReconnect}");
             
+            // Current gateways only send hello-ok for approved/accepted nodes, even when
+            // auth.deviceToken is omitted, so treat handshake acceptance as paired state.
             _isPendingApproval = false;
             _isPaired = true;
             _logger.Info(string.IsNullOrEmpty(_deviceIdentity.DeviceToken)
@@ -575,10 +578,14 @@ public class WindowsNodeClient : WebSocketClientBase
                 : "Already paired with stored device token");
             if (!wasPairedBeforeHello)
             {
+                var pairingMessage = receivedDeviceToken
+                    ? "Pairing approved!"
+                    : "Node registration accepted";
+
                 PairingStatusChanged?.Invoke(this, new PairingStatusEventArgs(
                     PairingStatus.Paired,
                     _deviceIdentity.DeviceId,
-                    "Pairing approved!"));
+                    pairingMessage));
             }
             
             RaiseStatusChanged(ConnectionStatus.Connected);

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1609,6 +1609,7 @@ public partial class App : Application
         _gatewayClient?.Dispose();
         var oldNodeService = _nodeService;
         _nodeService = null;
+        _lastNodePairingStatus = null;
         try { oldNodeService?.Dispose(); } catch (Exception ex) { Logger.Warn($"Node dispose error: {ex.Message}"); }
         
         if (_settings?.EnableNodeMode == true)

--- a/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Reflection;
+using System.Text.Json;
 using OpenClaw.Shared;
 using Xunit;
 
@@ -33,5 +35,96 @@ public class WindowsNodeClientTests
                 Directory.Delete(dataPath, true);
             }
         }
+    }
+
+    [Fact]
+    public void HandleResponse_HelloOkWithoutDeviceTokenAfterApproval_ClearsAwaitingReconnect()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+            SetPrivateField(client, "_isPaired", true);
+            SetPrivateField(client, "_pairingApprovedAwaitingReconnect", true);
+
+            InvokeHandleResponse(client, """
+                {
+                  "type": "res",
+                  "ok": true,
+                  "payload": {
+                    "type": "hello-ok",
+                    "nodeId": "node-123"
+                  }
+                }
+                """);
+
+            Assert.False((bool)GetPrivateField(client, "_pairingApprovedAwaitingReconnect")!);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+            {
+                Directory.Delete(dataPath, true);
+            }
+        }
+    }
+
+    [Fact]
+    public void HandleResponse_HelloOkWithoutDeviceTokenWhenUnpaired_EmitsNeutralPairedMessage()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+            PairingStatusEventArgs? pairingEvent = null;
+            client.PairingStatusChanged += (_, args) => pairingEvent = args;
+
+            InvokeHandleResponse(client, """
+                {
+                  "type": "res",
+                  "ok": true,
+                  "payload": {
+                    "type": "hello-ok",
+                    "nodeId": "node-123"
+                  }
+                }
+                """);
+
+            Assert.NotNull(pairingEvent);
+            Assert.Equal(PairingStatus.Paired, pairingEvent!.Status);
+            Assert.Equal("Node registration accepted", pairingEvent.Message);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+            {
+                Directory.Delete(dataPath, true);
+            }
+        }
+    }
+
+    private static void InvokeHandleResponse(WindowsNodeClient client, string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var method = typeof(WindowsNodeClient).GetMethod(
+            "HandleResponse",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        method!.Invoke(client, new object[] { doc.RootElement.Clone() });
+    }
+
+    private static void SetPrivateField(object instance, string fieldName, object value)
+    {
+        var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+        field!.SetValue(instance, value);
+    }
+
+    private static object? GetPrivateField(object instance, string fieldName)
+    {
+        var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+        return field!.GetValue(instance);
     }
 }


### PR DESCRIPTION
# Summary
This updates the Windows tray node pairing flow to match current OpenClaw gateway behavior and fixes reconnect recovery after gateway restarts.

## Why
The tray previously assumed a node was only paired if `hello-ok` returned `auth.deviceToken` and that token was persisted locally.

In practice, current gateway behavior for Windows WS nodes looks like this:

- unapproved device -> `NOT_PAIRED`
- approved device -> `hello-ok`
- node commands work normally after approval
- `auth.deviceToken` is not always returned
- That left the tray in incorrect states like false `Pending`, false `Unknown`, and failed reconnect recovery after gateway restarts.

## Changes

- treat `NOT_PAIRED` as a real pairing-needed state instead of a generic registration error
- only show pending approval when the gateway explicitly indicates pairing is required
- treat an approved `hello-ok` as paired even when `auth.deviceToken` is absent
- fix websocket reconnect so the tray keeps retrying until the gateway is back
- suppress repeated pairing/connect notifications and duplicate activity noise on routine reconnects
- tighten pairing event matching so node pairing events use the actual node identity when available

## Validation
Tested locally against a real gateway:

- fresh tray state enters `Pending` on `NOT_PAIRED`
- approving the device in OpenClaw transitions the node to `Connected`
- node requests succeed after approval (`system.notify` verified)
- gateway restart disconnects the tray, retries through startup errors, and reconnects automatically