### PR TITLE
ci: collect coverage and upload test results in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,33 @@ jobs:
         dotnet build tests/OpenClaw.Shared.Tests -c Debug
         dotnet build tests/OpenClaw.Tray.Tests -c Debug
 
-    - name: Run Tests
-      run: |
-        dotnet test tests/OpenClaw.Shared.Tests --no-build -c Debug --verbosity normal
-        dotnet test tests/OpenClaw.Tray.Tests --no-build -c Debug --verbosity normal
+    - name: Run Shared Tests
+      run: >
+        dotnet test tests/OpenClaw.Shared.Tests
+        --no-build
+        -c Debug
+        --verbosity normal
+        --collect:"XPlat Code Coverage"
+        --results-directory TestResults\Shared
+        --logger "trx;LogFileName=OpenClaw.Shared.Tests.trx"
+
+    - name: Run Tray Tests
+      run: >
+        dotnet test tests/OpenClaw.Tray.Tests
+        --no-build
+        -c Debug
+        --verbosity normal
+        --collect:"XPlat Code Coverage"
+        --results-directory TestResults\Tray
+        --logger "trx;LogFileName=OpenClaw.Tray.Tests.trx"
+
+    - name: Upload Test Results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results
+        path: TestResults/
+        if-no-files-found: warn
 
     outputs:
       semVer: ${{ steps.gitversion.outputs.semVer }}


### PR DESCRIPTION
## Summary
- collect XPlat code coverage for both test projects in the CI test job
- emit TRX test result files into a shared TestResults artifact
- upload those results even when the job fails

Fixes #152