### PR TITLE
fix: handle node pairing approval events safely

### DIFF
--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -25,6 +25,9 @@ public class WindowsNodeClient : WebSocketClientBase
     private string? _nodeId;
     private string? _pendingNonce;  // Store nonce from challenge for signing
     private bool _isPendingApproval;  // True when connected but awaiting pairing approval
+    private bool _isPaired;
+    // Bridges the gap between an approval event and the next hello-ok when the gateway omits auth.deviceToken.
+    private bool _pairingApprovedAwaitingReconnect;
     
     // Cached serialization/validation — reused on every message instead of allocating per-call
     private static readonly JsonSerializerOptions s_ignoreNullOptions = new()
@@ -46,8 +49,8 @@ public class WindowsNodeClient : WebSocketClientBase
     /// <summary>True if connected but waiting for pairing approval on gateway</summary>
     public bool IsPendingApproval => _isPendingApproval;
     
-    /// <summary>True if device is paired (has a device token)</summary>
-    public bool IsPaired => !string.IsNullOrEmpty(_deviceIdentity.DeviceToken);
+    /// <summary>True if device is paired via a stored token or an explicit gateway approval event.</summary>
+    public bool IsPaired => _isPaired || !string.IsNullOrEmpty(_deviceIdentity.DeviceToken);
     
     /// <summary>Device ID for display/approval (first 16 chars of full ID)</summary>
     public string ShortDeviceId => _deviceIdentity.DeviceId.Length > 16 
@@ -180,9 +183,90 @@ public class WindowsNodeClient : WebSocketClientBase
             case "connect.challenge":
                 await HandleConnectChallengeAsync(root);
                 break;
+            case "node.pair.requested":
+            case "device.pair.requested":
+                HandlePairingRequestedEvent(root, eventType);
+                break;
+            case "node.pair.resolved":
+            case "device.pair.resolved":
+                await HandlePairingResolvedEventAsync(root, eventType);
+                break;
             case "node.invoke.request":
                 await HandleNodeInvokeEventAsync(root);
                 break;
+        }
+    }
+
+    private void HandlePairingRequestedEvent(JsonElement root, string? eventType)
+    {
+        if (!root.TryGetProperty("payload", out var payload))
+        {
+            _logger.Warn($"[NODE] {eventType} has no payload");
+            return;
+        }
+
+        if (!PayloadTargetsCurrentDevice(payload) || _isPendingApproval)
+        {
+            return;
+        }
+
+        _isPendingApproval = true;
+        _isPaired = false;
+        _pairingApprovedAwaitingReconnect = false;
+
+        _logger.Info($"[NODE] Pairing requested for this device via {eventType}");
+        _logger.Info($"To approve, run: openclaw devices approve {_deviceIdentity.DeviceId}");
+        PairingStatusChanged?.Invoke(this, new PairingStatusEventArgs(
+            PairingStatus.Pending,
+            _deviceIdentity.DeviceId,
+            $"Run: openclaw devices approve {ShortDeviceId}..."));
+    }
+
+    private async Task HandlePairingResolvedEventAsync(JsonElement root, string? eventType)
+    {
+        if (!root.TryGetProperty("payload", out var payload))
+        {
+            _logger.Warn($"[NODE] {eventType} has no payload");
+            return;
+        }
+
+        if (!PayloadTargetsCurrentDevice(payload))
+        {
+            return;
+        }
+
+        var decision = payload.TryGetProperty("decision", out var decisionProp)
+            ? decisionProp.GetString()
+            : null;
+
+        _logger.Info($"[NODE] Pairing resolution received for this device: decision={decision ?? "unknown"}");
+
+        if (string.Equals(decision, "approved", StringComparison.OrdinalIgnoreCase))
+        {
+            _isPendingApproval = false;
+            _isPaired = true;
+            _pairingApprovedAwaitingReconnect = true;
+
+            PairingStatusChanged?.Invoke(this, new PairingStatusEventArgs(
+                PairingStatus.Paired,
+                _deviceIdentity.DeviceId,
+                "Pairing approved; reconnecting to refresh node state."));
+
+            _logger.Info("[NODE] Closing socket after pairing approval to refresh node connection...");
+            await CloseWebSocketAsync();
+            return;
+        }
+
+        if (string.Equals(decision, "rejected", StringComparison.OrdinalIgnoreCase))
+        {
+            _isPendingApproval = false;
+            _isPaired = false;
+            _pairingApprovedAwaitingReconnect = false;
+
+            PairingStatusChanged?.Invoke(this, new PairingStatusEventArgs(
+                PairingStatus.Rejected,
+                _deviceIdentity.DeviceId,
+                null));
         }
     }
     
@@ -410,6 +494,13 @@ public class WindowsNodeClient : WebSocketClientBase
     
     private void HandleResponse(JsonElement root)
     {
+        if (root.TryGetProperty("ok", out var okProp) &&
+            okProp.ValueKind == JsonValueKind.False)
+        {
+            HandleRequestError(root);
+            return;
+        }
+
         if (!root.TryGetProperty("payload", out var payload))
         {
             _logger.Warn("[NODE] Response has no payload");
@@ -419,6 +510,7 @@ public class WindowsNodeClient : WebSocketClientBase
         // Handle hello-ok (successful registration)
         if (payload.TryGetProperty("type", out var t) && t.GetString() == "hello-ok")
         {
+            var reconnectingAfterApproval = _pairingApprovedAwaitingReconnect;
             _isConnected = true;
             
             // Extract node ID if returned
@@ -438,8 +530,10 @@ public class WindowsNodeClient : WebSocketClientBase
                 if (!string.IsNullOrEmpty(deviceToken))
                 {
                     gotNewToken = true;
-                    var wasWaiting = _isPendingApproval;
+                    var wasWaiting = _isPendingApproval || reconnectingAfterApproval;
                     _isPendingApproval = false;
+                    _isPaired = true;
+                    _pairingApprovedAwaitingReconnect = false;
                     _logger.Info("Received device token - we are now paired!");
                     _deviceIdentity.StoreDeviceToken(deviceToken);
                     PairingStatusChanged?.Invoke(this, new PairingStatusEventArgs(
@@ -457,17 +551,30 @@ public class WindowsNodeClient : WebSocketClientBase
             {
                 if (string.IsNullOrEmpty(_deviceIdentity.DeviceToken))
                 {
-                    _isPendingApproval = true;
-                    _logger.Info("Not yet paired - check 'openclaw devices list' for pending approval");
-                    _logger.Info($"To approve, run: openclaw devices approve {_deviceIdentity.DeviceId}");
-                    PairingStatusChanged?.Invoke(this, new PairingStatusEventArgs(
-                        PairingStatus.Pending, 
-                        _deviceIdentity.DeviceId,
-                        $"Run: openclaw devices approve {ShortDeviceId}..."));
+                    if (reconnectingAfterApproval)
+                    {
+                        _isPendingApproval = false;
+                        _isPaired = true;
+                        _pairingApprovedAwaitingReconnect = false;
+                        _logger.Info("Gateway accepted the node after pairing approval without returning a device token.");
+                    }
+                    else
+                    {
+                        _isPendingApproval = true;
+                        _isPaired = false;
+                        _logger.Info("Not yet paired - check 'openclaw devices list' for pending approval");
+                        _logger.Info($"To approve, run: openclaw devices approve {_deviceIdentity.DeviceId}");
+                        PairingStatusChanged?.Invoke(this, new PairingStatusEventArgs(
+                            PairingStatus.Pending, 
+                            _deviceIdentity.DeviceId,
+                            $"Run: openclaw devices approve {ShortDeviceId}..."));
+                    }
                 }
                 else
                 {
                     _isPendingApproval = false;
+                    _isPaired = true;
+                    _pairingApprovedAwaitingReconnect = false;
                     _logger.Info("Already paired with stored device token");
                     PairingStatusChanged?.Invoke(this, new PairingStatusEventArgs(
                         PairingStatus.Paired, 
@@ -477,26 +584,108 @@ public class WindowsNodeClient : WebSocketClientBase
             
             RaiseStatusChanged(ConnectionStatus.Connected);
         }
-        
-        // Handle errors
-        if (root.TryGetProperty("ok", out var okProp) && !okProp.GetBoolean())
+    }
+
+    private void HandleRequestError(JsonElement root)
+    {
+        var error = "Unknown error";
+        var errorCode = "none";
+        string? pairingReason = null;
+        string? pairingRequestId = null;
+
+        if (root.TryGetProperty("error", out var errorProp))
         {
-            var error = "Unknown error";
-            var errorCode = "none";
-            if (root.TryGetProperty("error", out var errorProp))
+            if (errorProp.TryGetProperty("message", out var msgProp))
             {
-                if (errorProp.TryGetProperty("message", out var msgProp))
+                error = msgProp.GetString() ?? error;
+            }
+            if (errorProp.TryGetProperty("code", out var codeProp))
+            {
+                errorCode = codeProp.ToString();
+            }
+            if (errorProp.TryGetProperty("details", out var detailsProp))
+            {
+                if (TryGetString(detailsProp, "reason", out var reason))
                 {
-                    error = msgProp.GetString() ?? error;
+                    pairingReason = reason;
                 }
-                if (errorProp.TryGetProperty("code", out var codeProp))
+                if (TryGetString(detailsProp, "requestId", out var requestId))
                 {
-                    errorCode = codeProp.ToString();
+                    pairingRequestId = requestId;
                 }
             }
-            _logger.Error($"Node registration failed: {error} (code: {errorCode})");
-            RaiseStatusChanged(ConnectionStatus.Error);
         }
+
+        if (string.Equals(errorCode, "NOT_PAIRED", StringComparison.OrdinalIgnoreCase))
+        {
+            if (_isPendingApproval)
+            {
+                return;
+            }
+
+            _isPendingApproval = true;
+            _isPaired = false;
+            _pairingApprovedAwaitingReconnect = false;
+
+            var detail = !string.IsNullOrWhiteSpace(pairingRequestId)
+                ? $"Device {ShortDeviceId} requires approval (request {pairingRequestId})"
+                : $"Run: openclaw devices approve {ShortDeviceId}...";
+            _logger.Info($"[NODE] Pairing required for this device; reason={pairingReason ?? "unknown"}, requestId={pairingRequestId ?? "none"}");
+            _logger.Info($"To approve, run: openclaw devices approve {_deviceIdentity.DeviceId}");
+            PairingStatusChanged?.Invoke(this, new PairingStatusEventArgs(
+                PairingStatus.Pending,
+                _deviceIdentity.DeviceId,
+                detail));
+            return;
+        }
+
+        _logger.Error($"Node registration failed: {error} (code: {errorCode})");
+        RaiseStatusChanged(ConnectionStatus.Error);
+    }
+
+    private bool PayloadTargetsCurrentDevice(JsonElement payload)
+    {
+        if (TryGetString(payload, "deviceId", out var deviceId) &&
+            string.Equals(deviceId, _deviceIdentity.DeviceId, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (TryGetString(payload, "nodeId", out var nodeId))
+        {
+            if (!string.IsNullOrEmpty(_nodeId))
+            {
+                return string.Equals(nodeId, _nodeId, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return string.Equals(nodeId, _deviceIdentity.DeviceId, StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (TryGetString(payload, "instanceId", out var instanceId) &&
+            string.Equals(instanceId, _deviceIdentity.DeviceId, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (payload.TryGetProperty("device", out var devicePayload))
+        {
+            return TryGetString(devicePayload, "id", out var nestedDeviceId) &&
+                string.Equals(nestedDeviceId, _deviceIdentity.DeviceId, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    private static bool TryGetString(JsonElement element, string propertyName, out string? value)
+    {
+        value = null;
+        if (!element.TryGetProperty(propertyName, out var prop) || prop.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        value = prop.GetString();
+        return !string.IsNullOrWhiteSpace(value);
     }
     
     private async Task HandleRequestAsync(JsonElement root)
@@ -648,11 +837,13 @@ public class WindowsNodeClient : WebSocketClientBase
     {
         _isConnected = false;
         _isPendingApproval = false;
+        _isPaired = false;
     }
 
     protected override void OnError(Exception ex)
     {
         _isConnected = false;
         _isPendingApproval = false;
+        _isPaired = false;
     }
 }

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1207,6 +1207,13 @@ public partial class App : Application
                     .AddText(LocalizationHelper.GetString("Toast_NodePaired"))
                     .AddText(LocalizationHelper.GetString("Toast_NodePairedDetail")));
             }
+            else if (args.Status == OpenClaw.Shared.PairingStatus.Rejected)
+            {
+                AddRecentActivity("Node pairing rejected", category: "node", dashboardPath: "nodes", nodeId: args.DeviceId, details: args.Message ?? LocalizationHelper.GetString("Toast_PairingRejectedDetail"));
+                ShowToast(new ToastContentBuilder()
+                    .AddText(LocalizationHelper.GetString("Toast_PairingRejected"))
+                    .AddText(LocalizationHelper.GetString("Toast_PairingRejectedDetail")));
+            }
         }
         catch { /* ignore */ }
     }

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -575,6 +575,12 @@ Use one of these options:
   <data name="Toast_NodePairedDetail" xml:space="preserve">
     <value>This PC can now receive commands from the agent</value>
   </data>
+  <data name="Toast_PairingRejected" xml:space="preserve">
+    <value>❌ Pairing Rejected</value>
+  </data>
+  <data name="Toast_PairingRejectedDetail" xml:space="preserve">
+    <value>The gateway rejected this device pairing request.</value>
+  </data>
 
   <!-- ==================== Toast: Health Check ==================== -->
 

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -575,6 +575,12 @@ Utilisez l'une de ces options :
   <data name="Toast_NodePairedDetail" xml:space="preserve">
     <value>Ce PC peut désormais recevoir des commandes de l'agent</value>
   </data>
+  <data name="Toast_PairingRejected" xml:space="preserve">
+    <value>❌ Appairage refusé</value>
+  </data>
+  <data name="Toast_PairingRejectedDetail" xml:space="preserve">
+    <value>La passerelle a rejeté la demande d'appairage de cet appareil.</value>
+  </data>
 
   <!-- ==================== Toast: Health Check ==================== -->
 

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -575,6 +575,12 @@ Gebruik een van deze opties:
   <data name="Toast_NodePairedDetail" xml:space="preserve">
     <value>Deze pc kan nu opdrachten ontvangen van de agent</value>
   </data>
+  <data name="Toast_PairingRejected" xml:space="preserve">
+    <value>&#x274C; Koppeling geweigerd</value>
+  </data>
+  <data name="Toast_PairingRejectedDetail" xml:space="preserve">
+    <value>De gateway heeft het koppelingsverzoek voor dit apparaat geweigerd.</value>
+  </data>
 
   <!-- ==================== Toast: Health Check ==================== -->
 

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -575,6 +575,12 @@
   <data name="Toast_NodePairedDetail" xml:space="preserve">
     <value>此电脑现在可以接收来自代理的命令</value>
   </data>
+  <data name="Toast_PairingRejected" xml:space="preserve">
+    <value>❌ 配对被拒绝</value>
+  </data>
+  <data name="Toast_PairingRejectedDetail" xml:space="preserve">
+    <value>网关拒绝了此设备的配对请求。</value>
+  </data>
 
   <!-- ==================== Toast: Health Check ==================== -->
 

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -575,6 +575,12 @@
   <data name="Toast_NodePairedDetail" xml:space="preserve">
     <value>此電腦現在可以接收來自代理的命令</value>
   </data>
+  <data name="Toast_PairingRejected" xml:space="preserve">
+    <value>❌ 節點配對遭拒</value>
+  </data>
+  <data name="Toast_PairingRejectedDetail" xml:space="preserve">
+    <value>閘道器拒絕了此裝置的配對請求。</value>
+  </data>
 
   <!-- ==================== Toast: Health Check ==================== -->
 

--- a/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
@@ -241,6 +241,100 @@ public class WindowsNodeClientTests
         }
     }
 
+    [Fact]
+    public void HandleResponse_NotPairedError_EmitsPendingPairingRequest()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+
+            var pairingEvents = new List<PairingStatusEventArgs>();
+            var statusChanges = new List<ConnectionStatus>();
+            client.PairingStatusChanged += (_, e) => pairingEvents.Add(e);
+            client.StatusChanged += (_, s) => statusChanges.Add(s);
+
+            var json = """
+                {
+                    "type": "res",
+                    "ok": false,
+                    "error": {
+                        "message": "Device approval required",
+                        "code": "NOT_PAIRED",
+                        "details": {
+                            "reason": "first-connect",
+                            "requestId": "req-123"
+                        }
+                    }
+                }
+                """;
+            var root = JsonDocument.Parse(json).RootElement;
+
+            var handleResponseMethod = typeof(WindowsNodeClient).GetMethod(
+                "HandleResponse",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            handleResponseMethod!.Invoke(client, [root]);
+
+            Assert.Single(pairingEvents);
+            Assert.Equal(PairingStatus.Pending, pairingEvents[0].Status);
+            Assert.Contains("req-123", pairingEvents[0].Message);
+            Assert.DoesNotContain(ConnectionStatus.Error, statusChanges);
+            Assert.True(client.IsPendingApproval);
+            Assert.False(client.IsPaired);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public void HandleResponse_NotPairedError_WhenAlreadyPending_DoesNotFireDuplicateEvent()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+
+            var isPendingField = typeof(WindowsNodeClient).GetField(
+                "_isPendingApproval",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            isPendingField!.SetValue(client, true);
+
+            var pairingEvents = new List<PairingStatusEventArgs>();
+            client.PairingStatusChanged += (_, e) => pairingEvents.Add(e);
+
+            var root = JsonDocument.Parse("""
+                {
+                    "type": "res",
+                    "ok": false,
+                    "error": {
+                        "message": "Device approval required",
+                        "code": "NOT_PAIRED"
+                    }
+                }
+                """).RootElement;
+
+            var handleResponseMethod = typeof(WindowsNodeClient).GetMethod(
+                "HandleResponse",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            handleResponseMethod!.Invoke(client, [root]);
+
+            Assert.Empty(pairingEvents);
+            Assert.True(client.IsPendingApproval);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
     /// <summary>
     /// HandleResponse with a payload that has no "type" key should not throw.
     /// </summary>
@@ -264,6 +358,287 @@ public class WindowsNodeClientTests
 
             var ex = Record.Exception(() => handleResponseMethod!.Invoke(client, [root]));
             Assert.Null(ex);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public async Task HandleEvent_NodePairRequestedForCurrentDevice_EmitsPending()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+
+            var pairingEvents = new List<PairingStatusEventArgs>();
+            client.PairingStatusChanged += (_, e) => pairingEvents.Add(e);
+
+            await InvokeHandleEventAsync(client, $$"""
+                {
+                    "type": "event",
+                    "event": "node.pair.requested",
+                    "payload": {
+                        "deviceId": "{{client.FullDeviceId}}"
+                    }
+                }
+                """);
+
+            Assert.Single(pairingEvents);
+            Assert.Equal(PairingStatus.Pending, pairingEvents[0].Status);
+            Assert.True(client.IsPendingApproval);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public async Task HandleEvent_NodePairRequestedForDifferentDevice_IsIgnored()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+
+            var pairingEvents = new List<PairingStatusEventArgs>();
+            client.PairingStatusChanged += (_, e) => pairingEvents.Add(e);
+
+            await InvokeHandleEventAsync(client, """
+                {
+                    "type": "event",
+                    "event": "node.pair.requested",
+                    "payload": {
+                        "deviceId": "some-other-device"
+                    }
+                }
+                """);
+
+            Assert.Empty(pairingEvents);
+            Assert.False(client.IsPendingApproval);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public async Task HandleEvent_NodePairResolvedApproved_ForCurrentDevice_EmitsPaired()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+
+            var pairingEvents = new List<PairingStatusEventArgs>();
+            client.PairingStatusChanged += (_, e) => pairingEvents.Add(e);
+
+            await InvokeHandleEventAsync(client, $$"""
+                {
+                    "type": "event",
+                    "event": "node.pair.resolved",
+                    "payload": {
+                        "deviceId": "{{client.FullDeviceId}}",
+                        "decision": "approved"
+                    }
+                }
+                """);
+
+            Assert.Single(pairingEvents);
+            Assert.Equal(PairingStatus.Paired, pairingEvents[0].Status);
+            Assert.Contains("reconnecting", pairingEvents[0].Message, StringComparison.OrdinalIgnoreCase);
+            Assert.True(client.IsPaired);
+            Assert.False(client.IsPendingApproval);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public async Task HandleEvent_NodePairResolvedRejected_ForCurrentDevice_EmitsRejected()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+
+            var pairingEvents = new List<PairingStatusEventArgs>();
+            client.PairingStatusChanged += (_, e) => pairingEvents.Add(e);
+
+            await InvokeHandleEventAsync(client, $$"""
+                {
+                    "type": "event",
+                    "event": "device.pair.resolved",
+                    "payload": {
+                        "deviceId": "{{client.FullDeviceId}}",
+                        "decision": "rejected"
+                    }
+                }
+                """);
+
+            Assert.Single(pairingEvents);
+            Assert.Equal(PairingStatus.Rejected, pairingEvents[0].Status);
+            Assert.False(client.IsPendingApproval);
+            Assert.False(client.IsPaired);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public async Task HandleEvent_NodePairResolvedForDifferentDevice_IsIgnored()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+
+            var pairingEvents = new List<PairingStatusEventArgs>();
+            client.PairingStatusChanged += (_, e) => pairingEvents.Add(e);
+
+            await InvokeHandleEventAsync(client, """
+                {
+                    "type": "event",
+                    "event": "device.pair.resolved",
+                    "payload": {
+                        "deviceId": "some-other-device",
+                        "decision": "approved"
+                    }
+                }
+                """);
+
+            Assert.Empty(pairingEvents);
+            Assert.False(client.IsPendingApproval);
+            Assert.False(client.IsPaired);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public async Task HandleResponse_HelloOkWithoutDeviceToken_AfterApprovalReconnect_DoesNotRevertToPending()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+
+            var pairingEvents = new List<PairingStatusEventArgs>();
+            client.PairingStatusChanged += (_, e) => pairingEvents.Add(e);
+
+            await InvokeHandleEventAsync(client, $$"""
+                {
+                    "type": "event",
+                    "event": "node.pair.resolved",
+                    "payload": {
+                        "deviceId": "{{client.FullDeviceId}}",
+                        "decision": "approved"
+                    }
+                }
+                """);
+
+            var onDisconnectedMethod = typeof(WindowsNodeClient).GetMethod(
+                "OnDisconnected",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            onDisconnectedMethod!.Invoke(client, null);
+
+            var helloOk = JsonDocument.Parse("""
+                {
+                    "type": "res",
+                    "ok": true,
+                    "payload": {
+                        "type": "hello-ok",
+                        "nodeId": "test-node-id"
+                    }
+                }
+                """).RootElement;
+
+            var handleResponseMethod = typeof(WindowsNodeClient).GetMethod(
+                "HandleResponse",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            handleResponseMethod!.Invoke(client, [helloOk]);
+
+            Assert.Single(pairingEvents);
+            Assert.Equal(PairingStatus.Paired, pairingEvents[0].Status);
+            Assert.True(client.IsPaired);
+            Assert.False(client.IsPendingApproval);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Theory]
+    [InlineData("OnDisconnected")]
+    [InlineData("OnError")]
+    public async Task EventOnlyPairedState_IsClearedByConnectionResetHooks(string hookName)
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+
+            await InvokeHandleEventAsync(client, $$"""
+                {
+                    "type": "event",
+                    "event": "node.pair.resolved",
+                    "payload": {
+                        "deviceId": "{{client.FullDeviceId}}",
+                        "decision": "approved"
+                    }
+                }
+                """);
+
+            Assert.True(client.IsPaired);
+
+            var method = typeof(WindowsNodeClient).GetMethod(
+                hookName,
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+
+            if (hookName == "OnError")
+            {
+                method!.Invoke(client, [new InvalidOperationException("test")]);
+            }
+            else
+            {
+                method!.Invoke(client, null);
+            }
+
+            Assert.False(client.IsPendingApproval);
+            Assert.False(client.IsPaired);
         }
         finally
         {
@@ -437,5 +812,18 @@ public class WindowsNodeClientTests
             if (Directory.Exists(dataPath))
                 Directory.Delete(dataPath, true);
         }
+    }
+
+    private static async Task InvokeHandleEventAsync(WindowsNodeClient client, string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var handleEventMethod = typeof(WindowsNodeClient).GetMethod(
+            "HandleEventAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(handleEventMethod);
+
+        var task = handleEventMethod!.Invoke(client, [doc.RootElement.Clone()]) as Task;
+        Assert.NotNull(task);
+        await task!;
     }
 }


### PR DESCRIPTION
## Summary
- semantically port the safe pairing-event support from #144 onto current master
- handle NOT_PAIRED registration responses and 
ode/device.pair.requested / pair.resolved events
- preserve the safer hello-ok fallback and keep the #150 logging cleanup intact
- add regression tests for approval, rejection, reconnect, and stale-state resets

Supersedes #144