### PR TITLE
ci: add NuGet cache to build-extension job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,13 @@ jobs:
       with:
         dotnet-version: 10.0.x
 
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+        restore-keys: nuget-${{ runner.os }}-
+
     - name: Restore Command Palette Extension
       run: dotnet restore src/OpenClaw.CommandPalette
 


### PR DESCRIPTION
Adds the missing NuGet package cache step to the \\uild-extension\\ CI job so it matches the other .NET jobs. This is a CI-only change with no product behavior impact.