### PR TITLE
security: harden system.run against env injection and shell-wrapper bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ When Node Mode is enabled in Settings, your Windows PC becomes a **node** that t
     
     > 🔒 **Exec Policy**: `system.run` is gated by an approval policy on the Windows node at `%LOCALAPPDATA%\OpenClawTray\exec-policy.json` (schema: `{ "defaultAction": "...", "rules": [...] }`). This is separate from gateway-side `~/.openclaw/exec-approvals.json`.
     >
-    > Rules are matched against the `command` token (`argv[0]`). If your call runs `powershell.exe -File script.ps1`, allow `powershell.exe`/`pwsh.exe` (not just the script path), or you'll get `No matching rule; default policy applied`.
+    > Rules are matched against the full command line. Known wrapper payloads such as `cmd /c ...`, `powershell -Command ...`, `pwsh -EncodedCommand ...`, and `bash -c ...` are also evaluated before execution. Dangerous environment overrides like `PATH`, `PATHEXT`, `NODE_OPTIONS`, `GIT_SSH_COMMAND`, `LD_*`, and `DYLD_*` are rejected.
     >
     > ```bash
     > openclaw nodes invoke --node <id> --command system.execApprovals.set --params '{"rules":[{"pattern":"powershell.exe","action":"allow"},{"pattern":"pwsh.exe","action":"allow"},{"pattern":"echo *","action":"allow"},{"pattern":"*","action":"deny"}],"defaultAction":"deny"}'

--- a/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
@@ -255,13 +255,22 @@ public class SystemCapability : NodeCapabilityBase
             request.Args.TryGetProperty("env", out var envEl) &&
             envEl.ValueKind == System.Text.Json.JsonValueKind.Object)
         {
-            env = new Dictionary<string, string>();
+            env = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (var prop in envEl.EnumerateObject())
             {
                 if (prop.Value.ValueKind == System.Text.Json.JsonValueKind.String)
                     env[prop.Name] = prop.Value.GetString() ?? "";
             }
         }
+
+        var envResult = ExecEnvSanitizer.Sanitize(env);
+        if (envResult.Blocked.Length > 0)
+        {
+            var blockedList = string.Join(", ", envResult.Blocked.OrderBy(n => n, StringComparer.OrdinalIgnoreCase));
+            Logger.Warn($"system.run DENIED: blocked environment overrides [{blockedList}]");
+            return Error($"Unsafe environment variable override blocked: {blockedList}");
+        }
+        env = envResult.Allowed;
         
         // Build the full command string for policy evaluation and logging.
         // When command arrives as an argv array, we must evaluate the entire
@@ -281,6 +290,23 @@ public class SystemCapability : NodeCapabilityBase
             {
                 Logger.Warn($"system.run DENIED: {fullCommand} ({approval.Reason})");
                 return Error($"Command denied by exec policy: {approval.Reason}");
+            }
+
+            var parseResult = ExecShellWrapperParser.Expand(fullCommand, shell);
+            if (!string.IsNullOrWhiteSpace(parseResult.Error))
+            {
+                Logger.Warn($"system.run DENIED: {fullCommand} ({parseResult.Error})");
+                return Error($"Command denied by exec policy: {parseResult.Error}");
+            }
+
+            foreach (var target in parseResult.Targets)
+            {
+                var innerApproval = _approvalPolicy.Evaluate(target.Command, target.Shell);
+                if (!innerApproval.Allowed)
+                {
+                    Logger.Warn($"system.run DENIED: {target.Command} ({innerApproval.Reason})");
+                    return Error($"Command denied by exec policy: {innerApproval.Reason}");
+                }
             }
         }
         

--- a/src/OpenClaw.Shared/ExecEnvSanitizer.cs
+++ b/src/OpenClaw.Shared/ExecEnvSanitizer.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+
+namespace OpenClaw.Shared;
+
+internal sealed class ExecEnvSanitizeResult
+{
+    public Dictionary<string, string>? Allowed { get; init; }
+    public string[] Blocked { get; init; } = Array.Empty<string>();
+}
+
+internal static class ExecEnvSanitizer
+{
+    private static readonly HashSet<string> _blockedNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "PATH",
+        "PATHEXT",
+        "ComSpec",
+        "PSModulePath",
+        "NODE_OPTIONS",
+        "NODE_PATH",
+        "PYTHONPATH",
+        "PYTHONSTARTUP",
+        "PYTHONUSERBASE",
+        "RUBYOPT",
+        "RUBYLIB",
+        "PERL5OPT",
+        "PERL5LIB",
+        "PERLIO",
+        "GIT_SSH",
+        "GIT_SSH_COMMAND",
+        "GIT_EXEC_PATH",
+        "GIT_PROXY_COMMAND",
+        "GIT_ASKPASS",
+        "BASH_ENV",
+        "ENV",
+        "CDPATH",
+        "PROMPT_COMMAND",
+        "ZDOTDIR",
+        "LD_PRELOAD",
+        "LD_LIBRARY_PATH",
+        "LD_AUDIT",
+        "DYLD_INSERT_LIBRARIES",
+        "DYLD_LIBRARY_PATH"
+    };
+
+    internal static ExecEnvSanitizeResult Sanitize(Dictionary<string, string>? env)
+    {
+        if (env is not { Count: > 0 })
+        {
+            return new ExecEnvSanitizeResult { Allowed = env };
+        }
+
+        var allowed = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var blocked = new List<string>();
+
+        foreach (var (name, value) in env)
+        {
+            if (IsBlocked(name))
+            {
+                blocked.Add(name);
+                continue;
+            }
+
+            allowed[name] = value;
+        }
+
+        return new ExecEnvSanitizeResult
+        {
+            Allowed = allowed.Count > 0 ? allowed : null,
+            Blocked = blocked.ToArray()
+        };
+    }
+
+    internal static bool IsBlocked(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return true;
+
+        if (name.IndexOfAny(['=', '\0', '\r', '\n']) >= 0)
+            return true;
+
+        foreach (var c in name)
+        {
+            if (char.IsControl(c) || char.IsWhiteSpace(c))
+                return true;
+        }
+
+        return _blockedNames.Contains(name)
+            || name.StartsWith("LD_", StringComparison.OrdinalIgnoreCase)
+            || name.StartsWith("DYLD_", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/OpenClaw.Shared/ExecShellWrapperParser.cs
+++ b/src/OpenClaw.Shared/ExecShellWrapperParser.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace OpenClaw.Shared;
+
+internal sealed class ExecShellEvaluationTarget
+{
+    public string Command { get; init; } = "";
+    public string? Shell { get; init; }
+}
+
+internal sealed class ExecShellParseResult
+{
+    public List<ExecShellEvaluationTarget> Targets { get; } = new();
+    public string? Error { get; init; }
+}
+
+internal static class ExecShellWrapperParser
+{
+    private const int MaxDepth = 4;
+
+    internal static ExecShellParseResult Expand(string command, string? shell = null)
+    {
+        var result = new ExecShellParseResult();
+
+        if (string.IsNullOrWhiteSpace(command))
+            return result;
+
+        var pending = new Queue<(string Command, string? Shell, int Depth)>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        pending.Enqueue((command, NormalizeShell(shell), 0));
+
+        while (pending.Count > 0)
+        {
+            var (current, currentShell, depth) = pending.Dequeue();
+            if (string.IsNullOrWhiteSpace(current) || depth > MaxDepth)
+                continue;
+
+            var segments = SplitTopLevelCommands(current);
+            var hasMultipleSegments = segments.Count > 1;
+
+            foreach (var rawSegment in segments)
+            {
+                var segment = TrimMatchingQuotes(rawSegment.Trim());
+                if (string.IsNullOrWhiteSpace(segment))
+                    continue;
+
+                if ((depth > 0 || hasMultipleSegments) && seen.Add($"{currentShell}|{segment}"))
+                {
+                    result.Targets.Add(new ExecShellEvaluationTarget
+                    {
+                        Command = segment,
+                        Shell = currentShell
+                    });
+                }
+
+                var wrapped = TryExtractWrappedPayload(segment);
+                if (wrapped.Error != null)
+                {
+                    return new ExecShellParseResult { Error = wrapped.Error };
+                }
+
+                if (!string.IsNullOrWhiteSpace(wrapped.Payload))
+                {
+                    pending.Enqueue((wrapped.Payload!, wrapped.Shell ?? currentShell, depth + 1));
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static (string? Payload, string? Shell, string? Error) TryExtractWrappedPayload(string command)
+    {
+        var tokens = Tokenize(command);
+        if (tokens.Count < 2)
+            return default;
+
+        var executable = Path.GetFileName(tokens[0]);
+        if (string.IsNullOrWhiteSpace(executable))
+            return default;
+
+        if (executable.Equals("cmd", StringComparison.OrdinalIgnoreCase) ||
+            executable.Equals("cmd.exe", StringComparison.OrdinalIgnoreCase))
+        {
+            for (var i = 1; i < tokens.Count; i++)
+            {
+                if (tokens[i].Equals("/c", StringComparison.OrdinalIgnoreCase) ||
+                    tokens[i].Equals("/k", StringComparison.OrdinalIgnoreCase))
+                {
+                    var payload = string.Join(" ", tokens.Skip(i + 1)).Trim();
+                    return string.IsNullOrWhiteSpace(payload)
+                        ? ("", "cmd", "Shell wrapper payload was empty")
+                        : (payload, "cmd", null);
+                }
+            }
+        }
+
+        if (executable.Equals("powershell", StringComparison.OrdinalIgnoreCase) ||
+            executable.Equals("powershell.exe", StringComparison.OrdinalIgnoreCase))
+        {
+            return ParsePowerShellPayload(tokens, "powershell");
+        }
+
+        if (executable.Equals("pwsh", StringComparison.OrdinalIgnoreCase) ||
+            executable.Equals("pwsh.exe", StringComparison.OrdinalIgnoreCase))
+        {
+            return ParsePowerShellPayload(tokens, "pwsh");
+        }
+
+        if (executable.Equals("bash", StringComparison.OrdinalIgnoreCase) ||
+            executable.Equals("bash.exe", StringComparison.OrdinalIgnoreCase) ||
+            executable.Equals("sh", StringComparison.OrdinalIgnoreCase) ||
+            executable.Equals("sh.exe", StringComparison.OrdinalIgnoreCase))
+        {
+            for (var i = 1; i < tokens.Count; i++)
+            {
+                if (tokens[i].Equals("-c", StringComparison.OrdinalIgnoreCase))
+                {
+                    var payload = string.Join(" ", tokens.Skip(i + 1)).Trim();
+                    return string.IsNullOrWhiteSpace(payload)
+                        ? ("", "sh", "Shell wrapper payload was empty")
+                        : (payload, "sh", null);
+                }
+            }
+        }
+
+        return default;
+    }
+
+    private static (string? Payload, string? Shell, string? Error) ParsePowerShellPayload(IReadOnlyList<string> tokens, string shell)
+    {
+        for (var i = 1; i < tokens.Count; i++)
+        {
+            var option = tokens[i];
+            if (option.Equals("-Command", StringComparison.OrdinalIgnoreCase) ||
+                option.Equals("-c", StringComparison.OrdinalIgnoreCase))
+            {
+                var payload = string.Join(" ", tokens.Skip(i + 1)).Trim();
+                return string.IsNullOrWhiteSpace(payload)
+                    ? ("", shell, "Shell wrapper payload was empty")
+                    : (payload, shell, null);
+            }
+
+            if (option.Equals("-EncodedCommand", StringComparison.OrdinalIgnoreCase) ||
+                option.Equals("-enc", StringComparison.OrdinalIgnoreCase) ||
+                option.Equals("-ec", StringComparison.OrdinalIgnoreCase))
+            {
+                var encoded = i + 1 < tokens.Count ? tokens[i + 1] : null;
+                if (string.IsNullOrWhiteSpace(encoded))
+                    return ("", shell, "Shell wrapper payload was empty");
+
+                try
+                {
+                    var bytes = Convert.FromBase64String(encoded);
+                    var payload = Encoding.Unicode.GetString(bytes).Trim();
+                    return string.IsNullOrWhiteSpace(payload)
+                        ? ("", shell, "EncodedCommand decoded to an empty payload")
+                        : (payload, shell, null);
+                }
+                catch (FormatException)
+                {
+                    return ("", shell, "EncodedCommand could not be decoded");
+                }
+            }
+        }
+
+        return default;
+    }
+
+    private static List<string> SplitTopLevelCommands(string command)
+    {
+        var parts = new List<string>();
+        var current = new StringBuilder();
+        var inSingleQuotes = false;
+        var inDoubleQuotes = false;
+
+        for (var i = 0; i < command.Length; i++)
+        {
+            var c = command[i];
+
+            if (c == '"' && !inSingleQuotes)
+            {
+                inDoubleQuotes = !inDoubleQuotes;
+                current.Append(c);
+                continue;
+            }
+
+            if (c == '\'' && !inDoubleQuotes)
+            {
+                inSingleQuotes = !inSingleQuotes;
+                current.Append(c);
+                continue;
+            }
+
+            if (!inSingleQuotes && !inDoubleQuotes)
+            {
+                if (c == ';' || c == '&')
+                {
+                    FlushCurrent(parts, current);
+                    if (c == '&' && i + 1 < command.Length && command[i + 1] == '&')
+                        i++;
+                    continue;
+                }
+
+                if (c == '|' && i + 1 < command.Length && command[i + 1] == '|')
+                {
+                    FlushCurrent(parts, current);
+                    i++;
+                    continue;
+                }
+            }
+
+            current.Append(c);
+        }
+
+        FlushCurrent(parts, current);
+        return parts;
+    }
+
+    private static List<string> Tokenize(string command)
+    {
+        var tokens = new List<string>();
+        var current = new StringBuilder();
+        var inSingleQuotes = false;
+        var inDoubleQuotes = false;
+        var escapeNext = false;
+
+        foreach (var c in command)
+        {
+            if (escapeNext)
+            {
+                current.Append(c);
+                escapeNext = false;
+                continue;
+            }
+
+            if (c == '\\' && inDoubleQuotes)
+            {
+                escapeNext = true;
+                continue;
+            }
+
+            if (c == '"' && !inSingleQuotes)
+            {
+                inDoubleQuotes = !inDoubleQuotes;
+                continue;
+            }
+
+            if (c == '\'' && !inDoubleQuotes)
+            {
+                inSingleQuotes = !inSingleQuotes;
+                continue;
+            }
+
+            if (!inSingleQuotes && !inDoubleQuotes && char.IsWhiteSpace(c))
+            {
+                FlushCurrent(tokens, current);
+                continue;
+            }
+
+            current.Append(c);
+        }
+
+        FlushCurrent(tokens, current);
+        return tokens;
+    }
+
+    private static string TrimMatchingQuotes(string value)
+    {
+        if (value.Length >= 2 &&
+            ((value[0] == '"' && value[^1] == '"') || (value[0] == '\'' && value[^1] == '\'')))
+        {
+            return value[1..^1];
+        }
+
+        return value;
+    }
+
+    private static string? NormalizeShell(string? shell) =>
+        string.IsNullOrWhiteSpace(shell) ? "powershell" : shell.ToLowerInvariant();
+
+    private static void FlushCurrent(List<string> parts, StringBuilder current)
+    {
+        if (current.Length == 0)
+            return;
+
+        parts.Add(current.ToString());
+        current.Clear();
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalPolicyTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalPolicyTests.cs
@@ -588,7 +588,72 @@ public class SystemCapabilityExecApprovalsTests
         var result = await cap.ExecuteAsync(request);
         Assert.True(result.Ok);
     }
-    
+
+    [Fact]
+    public async Task SystemRun_WithDefaultAllow_DeniesDangerousPowerShellWrapperPayload()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var policy = new ExecApprovalPolicy(tempDir, _logger);
+            policy.SetRules(
+                new[]
+                {
+                    new ExecApprovalRule { Pattern = "Remove-Item *", Action = ExecApprovalAction.Deny }
+                },
+                ExecApprovalAction.Allow);
+
+            var cap = CreateCapability(policy);
+            var request = new NodeInvokeRequest
+            {
+                Command = "system.run",
+                Args = JsonDocument.Parse("{\"command\":[\"powershell\",\"-Command\",\"Remove-Item -Recurse -Force C:\\\\important\"]}").RootElement
+            };
+
+            var result = await cap.ExecuteAsync(request);
+            Assert.False(result.Ok);
+            Assert.Contains("denied", result.Error!, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task SystemRun_WithCommandChain_DeniesBlockedSegment()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var policy = new ExecApprovalPolicy(tempDir, _logger);
+            policy.SetRules(
+                new[]
+                {
+                    new ExecApprovalRule { Pattern = "echo *", Action = ExecApprovalAction.Allow },
+                    new ExecApprovalRule { Pattern = "del *", Action = ExecApprovalAction.Deny }
+                },
+                ExecApprovalAction.Deny);
+
+            var cap = CreateCapability(policy);
+            var request = new NodeInvokeRequest
+            {
+                Command = "system.run",
+                Args = JsonDocument.Parse("{\"command\":\"echo ok & del /s /q C:\\\\important\\\\*\",\"shell\":\"cmd\"}").RootElement
+            };
+
+            var result = await cap.ExecuteAsync(request);
+            Assert.False(result.Ok);
+            Assert.Contains("denied", result.Error!, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { }
+        }
+    }
+
     [Fact]
     public async Task ExecApprovalsGet_ReturnsPolicy()
     {

--- a/tests/OpenClaw.Shared.Tests/SystemRunTests.cs
+++ b/tests/OpenClaw.Shared.Tests/SystemRunTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Json;
 using Xunit;
 using OpenClaw.Shared;
@@ -125,6 +126,46 @@ public class SystemRunTests
         Assert.NotNull(runner.LastRequest!.Env);
         Assert.Equal("bar", runner.LastRequest.Env!["FOO"]);
         Assert.Equal("qux", runner.LastRequest.Env["BAZ"]);
+    }
+
+    [Fact]
+    public async Task SystemRun_BlocksDangerousEnvOverride()
+    {
+        var runner = new FakeCommandRunner();
+        var cap = new SystemCapability(NullLogger.Instance);
+        cap.SetCommandRunner(runner);
+
+        var req = new NodeInvokeRequest
+        {
+            Id = "r5b",
+            Command = "system.run",
+            Args = Parse("""{"command":"test","env":{"PATH":"C:\\evil","FOO":"bar"}}""")
+        };
+
+        var res = await cap.ExecuteAsync(req);
+        Assert.False(res.Ok);
+        Assert.Contains("environment variable", res.Error!, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(runner.LastRequest);
+    }
+
+    [Fact]
+    public async Task SystemRun_BlocksInvalidEnvName()
+    {
+        var runner = new FakeCommandRunner();
+        var cap = new SystemCapability(NullLogger.Instance);
+        cap.SetCommandRunner(runner);
+
+        var req = new NodeInvokeRequest
+        {
+            Id = "r5c",
+            Command = "system.run",
+            Args = Parse("""{"command":"test","env":{"BAD NAME":"value"}}""")
+        };
+
+        var res = await cap.ExecuteAsync(req);
+        Assert.False(res.Ok);
+        Assert.Contains("environment variable", res.Error!, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(runner.LastRequest);
     }
 
     [Fact]
@@ -276,6 +317,45 @@ public class SystemRunTests
         Assert.NotNull(runner.LastRequest.Args);
         Assert.Equal(3, runner.LastRequest.Args!.Length);
         Assert.Equal("push", runner.LastRequest.Args[0]);
+    }
+
+    [Fact]
+    public async Task SystemRun_WithPolicy_DeniesEncodedPowerShellPayload()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var logger = new ExecTestLogger();
+            var policy = new ExecApprovalPolicy(tempDir, logger);
+            policy.SetRules(
+                new[]
+                {
+                    new ExecApprovalRule { Pattern = "Remove-Item *", Action = ExecApprovalAction.Deny }
+                },
+                ExecApprovalAction.Allow);
+
+            var cap = new SystemCapability(logger);
+            cap.SetCommandRunner(new FakeCommandRunner());
+            cap.SetApprovalPolicy(policy);
+
+            var encoded = Convert.ToBase64String(Encoding.Unicode.GetBytes("Remove-Item -Recurse -Force C:\\important"));
+            var req = new NodeInvokeRequest
+            {
+                Id = "r10",
+                Command = "system.run",
+                Args = Parse($$"""{"command":["powershell","-EncodedCommand","{{encoded}}"]}""")
+            };
+
+            var res = await cap.ExecuteAsync(req);
+            Assert.False(res.Ok);
+            Assert.Contains("denied", res.Error!, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- block dangerous system.run env overrides like PATH, NODE_OPTIONS, GIT_SSH_COMMAND, LD_*, and DYLD_*
- evaluate nested cmd /c, powershell -Command, pwsh -EncodedCommand, and chained statements against the exec policy
- add regression coverage for issue #184 and update the README guidance

Closes #184.

This complements PR #186 by covering the remaining wrapper-bypass portion as well.