### PR TITLE
eng: add --no-restore to CI build steps after dotnet restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,15 +40,15 @@ jobs:
       run: dotnet restore
 
     - name: Build Shared Library
-      run: dotnet build src/OpenClaw.Shared -c Debug
+      run: dotnet build src/OpenClaw.Shared -c Debug --no-restore
 
     - name: Build Tray App (WinUI)
       run: dotnet build src/OpenClaw.Tray.WinUI -c Debug -r win-x64
 
     - name: Build Tests
       run: |
-        dotnet build tests/OpenClaw.Shared.Tests -c Debug
-        dotnet build tests/OpenClaw.Tray.Tests -c Debug
+        dotnet build tests/OpenClaw.Shared.Tests -c Debug --no-restore
+        dotnet build tests/OpenClaw.Tray.Tests -c Debug --no-restore
 
     - name: Run Shared Tests
       env:
@@ -113,7 +113,7 @@ jobs:
       run: dotnet build src/OpenClaw.Tray.WinUI --no-restore -c Release -r ${{ matrix.rid }} -p:Version=${{ needs.test.outputs.semVer }}
 
     - name: Publish WinUI Tray App
-      run: dotnet publish src/OpenClaw.Tray.WinUI -c Release -r ${{ matrix.rid }} --self-contained -p:Version=${{ needs.test.outputs.semVer }} -o publish
+      run: dotnet publish src/OpenClaw.Tray.WinUI -c Release -r ${{ matrix.rid }} --self-contained --no-restore -p:Version=${{ needs.test.outputs.semVer }} -o publish
 
     - name: Azure Login for Signing
       if: startsWith(github.ref, 'refs/tags/v') && matrix.rid != 'win-arm64'
@@ -270,7 +270,7 @@ jobs:
       run: dotnet restore src/OpenClaw.CommandPalette
 
     - name: Build Command Palette Extension
-      run: dotnet build src/OpenClaw.CommandPalette -c Debug -p:Platform=${{ matrix.platform }}
+      run: dotnet build src/OpenClaw.CommandPalette -c Debug -p:Platform=${{ matrix.platform }} --no-restore
 
     - name: Upload Extension Artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Each `dotnet build` / `dotnet publish` step in the `test`, `build`, and `build-extension` jobs was redundantly re-checking NuGet dependencies even though `dotnet restore` had already run as an explicit prior step. Adding `--no-restore` eliminates that overhead.

Five commands updated:
- `test` job: Build Shared Library, Build Tests (both projects)
- `build` job: Publish WinUI Tray App
- `build-extension` job: Build Command Palette Extension

Note: the WinUI test build (`dotnet build src/OpenClaw.Tray.WinUI -c Debug -r win-x64`) is excluded — the generic `dotnet restore` in the test job runs without `-r win-x64`, so adding `--no-restore` there causes NETSDK1047.

No source changes. Existing test suite is unaffected.

Closes #195.