### PR TITLE
fix: stop aggressive retry on auth failures, show setup nudge

### DIFF
--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -58,6 +58,7 @@ public class OpenClawGatewayClient : WebSocketClientBase
     private bool _nodeListUnsupported;
     private bool _operatorReadScopeUnavailable;
     private bool _pairingRequiredAwaitingApproval;
+    private bool _authFailed;
     private IReadOnlyList<UserNotificationRule>? _userRules;
     private bool _preferStructuredCategories = true;
 
@@ -103,7 +104,7 @@ public class OpenClawGatewayClient : WebSocketClientBase
 
     protected override bool ShouldAutoReconnect()
     {
-        return !_pairingRequiredAwaitingApproval;
+        return !_pairingRequiredAwaitingApproval && !_authFailed;
     }
 
     protected override void OnDisconnected()
@@ -665,6 +666,8 @@ public class OpenClawGatewayClient : WebSocketClientBase
         if (payload.TryGetProperty("type", out var t) && t.GetString() == "hello-ok")
         {
             _pairingRequiredAwaitingApproval = false;
+            _authFailed = false;
+            ResetReconnectAttempts();
             _operatorDeviceId = TryGetHandshakeDeviceId(payload);
             _grantedOperatorScopes = TryGetHandshakeScopes(payload);
             _mainSessionKey = TryGetHandshakeMainSessionKey(payload) ?? "main";
@@ -792,6 +795,9 @@ public class OpenClawGatewayClient : WebSocketClientBase
             }
 
             _logger.Warn("Gateway rejected device signature in all supported payload modes");
+            _authFailed = true;
+            RaiseAuthenticationFailed("device signature rejected in all modes — the gateway may require a different auth protocol version");
+            RaiseStatusChanged(ConnectionStatus.Error);
             return;
         }
 
@@ -800,6 +806,15 @@ public class OpenClawGatewayClient : WebSocketClientBase
         {
             _pairingRequiredAwaitingApproval = true;
             _logger.Warn("Pairing approval required for this device; auto-reconnect paused until manual reconnect or app restart");
+            RaiseStatusChanged(ConnectionStatus.Error);
+            return;
+        }
+
+        // Permanent auth failures — stop retrying and notify the app
+        if (method == "connect" && IsTerminalAuthError(message))
+        {
+            _authFailed = true;
+            RaiseAuthenticationFailed(message);
             RaiseStatusChanged(ConnectionStatus.Error);
             return;
         }
@@ -902,6 +917,13 @@ public class OpenClawGatewayClient : WebSocketClientBase
     private static bool IsUnknownMethodError(string errorMessage)
     {
         return errorMessage.Contains("unknown method", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsTerminalAuthError(string errorMessage)
+    {
+        return errorMessage.Contains("token mismatch", StringComparison.OrdinalIgnoreCase) ||
+               errorMessage.Contains("origin not allowed", StringComparison.OrdinalIgnoreCase) ||
+               errorMessage.Contains("too many failed", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsMissingScopeError(string errorMessage, string scope)

--- a/src/OpenClaw.Shared/WebSocketClientBase.cs
+++ b/src/OpenClaw.Shared/WebSocketClientBase.cs
@@ -40,6 +40,17 @@ public abstract class WebSocketClientBase : IDisposable
 
     // Events
     public event EventHandler<ConnectionStatus>? StatusChanged;
+    public event EventHandler<string>? AuthenticationFailed;
+
+    /// <summary>Reset reconnect backoff counter. Call after successful application-level handshake.</summary>
+    protected void ResetReconnectAttempts() => _reconnectAttempts = 0;
+
+    /// <summary>Fire AuthenticationFailed event and stop auto-reconnect.</summary>
+    protected void RaiseAuthenticationFailed(string message)
+    {
+        _logger.Warn($"{ClientRole} authentication failed: {message}");
+        AuthenticationFailed?.Invoke(this, message);
+    }
 
     // --- Abstract members (subclass MUST implement) ---
 
@@ -123,7 +134,9 @@ public abstract class WebSocketClientBase : IDisposable
 
             await _webSocket.ConnectAsync(uri, _cts.Token);
 
-            _reconnectAttempts = 0;
+            // Don't reset _reconnectAttempts here — TCP connect succeeding doesn't mean
+            // auth will succeed. Reset only after the full application-level handshake
+            // completes (subclass calls ResetReconnectAttempts after hello-ok).
             _logger.Info($"{ClientRole} connected, waiting for challenge...");
 
             await OnConnectedAsync();

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -530,6 +530,7 @@ public class WindowsNodeClient : WebSocketClientBase
         {
             var reconnectingAfterApproval = _pairingApprovedAwaitingReconnect;
             _isConnected = true;
+            ResetReconnectAttempts();
             
             // Extract node ID if returned
             if (payload.TryGetProperty("nodeId", out var nodeIdProp))

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -87,6 +87,7 @@ public partial class App : Application
     private ActivityStreamWindow? _activityStreamWindow;
     private TrayMenuWindow? _trayMenuWindow;
     private QuickSendDialog? _quickSendDialog;
+    private string? _authFailureMessage;
     
     // Node service (optional, enabled in settings)
     private NodeService? _nodeService;
@@ -753,6 +754,12 @@ public partial class App : Application
         var statusIcon = MenuDisplayHelper.GetStatusIcon(_currentStatus);
         menu.AddMenuItem(string.Format(LocalizationHelper.GetString("Menu_StatusFormat"), LocalizationHelper.GetConnectionStatusText(_currentStatus)), statusIcon, "status");
 
+        // Auth failure nudge
+        if (!string.IsNullOrEmpty(_authFailureMessage))
+        {
+            menu.AddMenuItem("⚠️ Auth failed — Run Setup", "🔧", "setup");
+        }
+
         // Activity (if any)
         if (_currentActivity != null && _currentActivity.Kind != OpenClaw.Shared.ActivityKind.Idle)
         {
@@ -1108,6 +1115,7 @@ public partial class App : Application
         _gatewayClient.SetUserRules(_settings.UserRules.Count > 0 ? _settings.UserRules : null);
         _gatewayClient.SetPreferStructuredCategories(_settings.PreferStructuredCategories);
         _gatewayClient.StatusChanged += OnConnectionStatusChanged;
+        _gatewayClient.AuthenticationFailed += OnAuthenticationFailed;
         _gatewayClient.ActivityChanged += OnActivityChanged;
         _gatewayClient.NotificationReceived += OnNotificationReceived;
         _gatewayClient.ChannelHealthUpdated += OnChannelHealthUpdated;
@@ -1126,6 +1134,7 @@ public partial class App : Application
         if (_gatewayClient != null)
         {
             _gatewayClient.StatusChanged -= OnConnectionStatusChanged;
+            _gatewayClient.AuthenticationFailed -= OnAuthenticationFailed;
             _gatewayClient.ActivityChanged -= OnActivityChanged;
             _gatewayClient.NotificationReceived -= OnNotificationReceived;
             _gatewayClient.ChannelHealthUpdated -= OnChannelHealthUpdated;
@@ -1245,12 +1254,22 @@ public partial class App : Application
     private void OnConnectionStatusChanged(object? sender, ConnectionStatus status)
     {
         _currentStatus = status;
+        if (status == ConnectionStatus.Connected)
+            _authFailureMessage = null;
         UpdateTrayIcon();
         
         if (status == ConnectionStatus.Connected)
         {
             _ = RunHealthCheckAsync();
         }
+    }
+
+    private void OnAuthenticationFailed(object? sender, string message)
+    {
+        _authFailureMessage = message;
+        Logger.Error($"Authentication failed: {message}");
+        AddRecentActivity($"Auth failed: {message}", category: "error");
+        UpdateTrayIcon();
     }
 
     private void OnActivityChanged(object? sender, AgentActivity? activity)


### PR DESCRIPTION
Fixes two related issues:

**#198 — Aggressive retry loop:** The reconnect counter was reset to 0 on every TCP connect, so auth failures (token mismatch, origin rejected) never progressed past 1-second backoff. Now resets only on successful hello-ok handshake.

**#199 — Setup nudge:** Terminal auth errors (token mismatch, origin not allowed, rate limited) now stop retrying entirely and show '⚠️ Auth failed — Run Setup' in the tray menu, linking directly to the Setup Wizard.

4 files, +54/-2. All 794 tests pass.

Fixes #198
Closes #199