### PR TITLE
eng: handle repo-assist easy wins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.100",
-    "rollForward": "latestPatch"
+    "rollForward": "latestFeature"
   }
 }

--- a/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace OpenClaw.Shared.Capabilities;
@@ -122,8 +121,8 @@ public class SystemCapability : NodeCapabilityBase
         if (OperatingSystem.IsWindows())
         {
             var pathext = Environment.GetEnvironmentVariable("PATHEXT") ?? ".EXE;.CMD;.BAT;.COM";
-            extensions.AddRange(pathext.Split(';', StringSplitOptions.RemoveEmptyEntries)
-                .Select(e => e.ToLowerInvariant()));
+            foreach (var e in pathext.Split(';', StringSplitOptions.RemoveEmptyEntries))
+                extensions.Add(e.ToLowerInvariant());
         }
         else
         {
@@ -266,7 +265,9 @@ public class SystemCapability : NodeCapabilityBase
         var envResult = ExecEnvSanitizer.Sanitize(env);
         if (envResult.Blocked.Length > 0)
         {
-            var blockedList = string.Join(", ", envResult.Blocked.OrderBy(n => n, StringComparer.OrdinalIgnoreCase));
+            var blockedNames = (string[])envResult.Blocked.Clone();
+            Array.Sort(blockedNames, StringComparer.OrdinalIgnoreCase);
+            var blockedList = string.Join(", ", blockedNames);
             Logger.Warn($"system.run DENIED: blocked environment overrides [{blockedList}]");
             return Error($"Unsafe environment variable override blocked: {blockedList}");
         }
@@ -346,18 +347,26 @@ public class SystemCapability : NodeCapabilityBase
         }
         
         var data = _approvalPolicy.GetPolicyData();
-        return Success(new
+        var rules = data.Rules;
+        var rulesSummary = new object[rules.Count];
+        for (var i = 0; i < rules.Count; i++)
         {
-            enabled = true,
-            defaultAction = data.DefaultAction.ToString().ToLowerInvariant(),
-            rules = data.Rules.Select(r => new
+            var r = rules[i];
+            rulesSummary[i] = new
             {
                 pattern = r.Pattern,
                 action = r.Action.ToString().ToLowerInvariant(),
                 shells = r.Shells,
                 description = r.Description,
                 enabled = r.Enabled
-            }).ToArray()
+            };
+        }
+
+        return Success(new
+        {
+            enabled = true,
+            defaultAction = data.DefaultAction.ToString().ToLowerInvariant(),
+            rules = rulesSummary
         });
     }
     
@@ -403,10 +412,13 @@ public class SystemCapability : NodeCapabilityBase
                     
                     if (ruleEl.TryGetProperty("shells", out var shellsEl) && shellsEl.ValueKind == System.Text.Json.JsonValueKind.Array)
                     {
-                        rule.Shells = shellsEl.EnumerateArray()
-                            .Where(s => s.ValueKind == System.Text.Json.JsonValueKind.String)
-                            .Select(s => s.GetString() ?? "")
-                            .ToArray();
+                        var shellsList = new List<string>(shellsEl.GetArrayLength());
+                        foreach (var s in shellsEl.EnumerateArray())
+                        {
+                            if (s.ValueKind == System.Text.Json.JsonValueKind.String)
+                                shellsList.Add(s.GetString() ?? "");
+                        }
+                        rule.Shells = shellsList.ToArray();
                     }
                     
                     rules.Add(rule);

--- a/src/OpenClaw.Shared/ExecApprovalPolicy.cs
+++ b/src/OpenClaw.Shared/ExecApprovalPolicy.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
@@ -98,8 +97,7 @@ public class ExecApprovalPolicy
             };
         }
         
-        // Compute once; only used if any rule has shell filters.
-        var normalizedShell = (shell ?? "powershell").ToLowerInvariant();
+        var shellSpan = (shell ?? "powershell").AsSpan();
 
         foreach (var rule in _rules)
         {
@@ -111,7 +109,7 @@ public class ExecApprovalPolicy
                 var shellMatched = false;
                 foreach (var s in rule.Shells)
                 {
-                    if (s.Equals(normalizedShell, StringComparison.OrdinalIgnoreCase))
+                    if (s.AsSpan().Equals(shellSpan, StringComparison.OrdinalIgnoreCase))
                     {
                         shellMatched = true;
                         break;

--- a/src/OpenClaw.Shared/GatewayUrlHelper.cs
+++ b/src/OpenClaw.Shared/GatewayUrlHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 
 namespace OpenClaw.Shared;
 
@@ -6,7 +7,8 @@ public static class GatewayUrlHelper
 {
     public const string ValidationMessage = "Gateway URL must be a valid URL (ws://, wss://, http://, or https://).";
 
-    private static readonly char[] s_authorityTerminators = { '/', '?', '#' };
+    private static readonly SearchValues<char> s_authorityTerminators =
+        SearchValues.Create("/?#");
 
     public static bool IsValidGatewayUrl(string? gatewayUrl) =>
         TryNormalizeWebSocketUrl(gatewayUrl, out _);
@@ -143,11 +145,8 @@ public static class GatewayUrlHelper
         }
 
         var authorityStart = schemeSeparator + 3;
-        var authorityEnd = url.IndexOfAny(s_authorityTerminators, authorityStart);
-        if (authorityEnd < 0)
-        {
-            authorityEnd = url.Length;
-        }
+        var relativeEnd = url.AsSpan(authorityStart).IndexOfAny(s_authorityTerminators);
+        var authorityEnd = relativeEnd < 0 ? url.Length : authorityStart + relativeEnd;
 
         var atIndex = url.IndexOf('@', authorityStart);
         if (atIndex < 0 || atIndex >= authorityEnd)

--- a/src/OpenClaw.Shared/LocalCommandRunner.cs
+++ b/src/OpenClaw.Shared/LocalCommandRunner.cs
@@ -164,9 +164,9 @@ public class LocalCommandRunner : ICommandRunner
     
     private static (string fileName, string arguments) BuildProcessArgs(CommandRequest request)
     {
-        var shell = (request.Shell ?? "powershell").ToLowerInvariant();
+        var shell = request.Shell ?? "powershell";
         var command = request.Command;
-        var isCmd = shell == "cmd";
+        var isCmd = shell.Equals("cmd", StringComparison.OrdinalIgnoreCase);
         
         if (request.Args is { Length: > 0 })
         {
@@ -176,12 +176,11 @@ public class LocalCommandRunner : ICommandRunner
             command = command + " " + string.Join(" ", quoted);
         }
         
-        return shell switch
-        {
-            "cmd" => ("cmd.exe", $"/C {command}"),
-            "pwsh" => ("pwsh.exe", $"-NoProfile -NonInteractive -Command {command}"),
-            _ => ("powershell.exe", $"-NoProfile -NonInteractive -Command {command}")
-        };
+        if (isCmd)
+            return ("cmd.exe", $"/C {command}");
+        if (shell.Equals("pwsh", StringComparison.OrdinalIgnoreCase))
+            return ("pwsh.exe", $"-NoProfile -NonInteractive -Command {command}");
+        return ("powershell.exe", $"-NoProfile -NonInteractive -Command {command}");
     }
     
     private void KillProcess(Process process)

--- a/src/OpenClaw.Shared/NotificationCategorizer.cs
+++ b/src/OpenClaw.Shared/NotificationCategorizer.cs
@@ -41,18 +41,18 @@ public class NotificationCategorizer
             ["error"] = ("⚠️ Error", "error"),
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
-    private static readonly FrozenDictionary<string, string> CategoryTitles =
-        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    private static readonly FrozenDictionary<string, (string title, string type)> CategoryTypeMap =
+        new Dictionary<string, (string title, string type)>(StringComparer.OrdinalIgnoreCase)
         {
-            ["health"] = "🩸 Blood Sugar Alert",
-            ["urgent"] = "🚨 Urgent Alert",
-            ["reminder"] = "⏰ Reminder",
-            ["stock"] = "📦 Stock Alert",
-            ["email"] = "📧 Email",
-            ["calendar"] = "📅 Calendar",
-            ["error"] = "⚠️ Error",
-            ["build"] = "🔨 Build",
-            ["info"] = "🤖 OpenClaw",
+            ["health"] = ("🩸 Blood Sugar Alert", "health"),
+            ["urgent"] = ("🚨 Urgent Alert", "urgent"),
+            ["reminder"] = ("⏰ Reminder", "reminder"),
+            ["stock"] = ("📦 Stock Alert", "stock"),
+            ["email"] = ("📧 Email", "email"),
+            ["calendar"] = ("📅 Calendar", "calendar"),
+            ["error"] = ("⚠️ Error", "error"),
+            ["build"] = ("🔨 Build", "build"),
+            ["info"] = ("🤖 OpenClaw", "info"),
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
@@ -83,9 +83,10 @@ public class NotificationCategorizer
                 if (!rule.Enabled) continue;
                 if (MatchesRule(searchText, rule))
                 {
+                    if (CategoryTypeMap.TryGetValue(rule.Category, out var categoryResult))
+                        return categoryResult;
                     var cat = rule.Category.ToLowerInvariant();
-                    var title = CategoryTitles.GetValueOrDefault(cat, "🤖 OpenClaw");
-                    return (title, cat);
+                    return ("🤖 OpenClaw", cat);
                 }
             }
         }

--- a/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
@@ -306,6 +306,216 @@ public class SystemCapabilityTests
         Assert.Null(SystemCapability.ResolveExecutable("C:\\Windows\\cmd"));
     }
 
+    [Fact]
+    public async Task RunPrepare_ReturnsCommandText_ForArray()
+    {
+        var cap = new SystemCapability(NullLogger.Instance);
+        var req = new NodeInvokeRequest
+        {
+            Id = "p1",
+            Command = "system.run.prepare",
+            Args = Parse("""{"command":["echo","hello world"]}""")
+        };
+
+        var res = await cap.ExecuteAsync(req);
+        Assert.True(res.Ok);
+        var payload = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(res.Payload));
+        Assert.True(payload.TryGetProperty("cmdText", out var cmdText));
+        Assert.Contains("echo", cmdText.GetString());
+    }
+
+    [Fact]
+    public async Task RunPrepare_ReturnsCommandText_ForString()
+    {
+        var cap = new SystemCapability(NullLogger.Instance);
+        var req = new NodeInvokeRequest
+        {
+            Id = "p2",
+            Command = "system.run.prepare",
+            Args = Parse("""{"command":"hostname","rawCommand":"hostname"}""")
+        };
+
+        var res = await cap.ExecuteAsync(req);
+        Assert.True(res.Ok);
+        var payload = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(res.Payload));
+        Assert.True(payload.TryGetProperty("cmdText", out var cmdText));
+        Assert.Equal("hostname", cmdText.GetString());
+    }
+
+    [Fact]
+    public async Task RunPrepare_ReturnsPlan_WithArgvAndCwd()
+    {
+        var cap = new SystemCapability(NullLogger.Instance);
+        var req = new NodeInvokeRequest
+        {
+            Id = "p3",
+            Command = "system.run.prepare",
+            Args = Parse("""{"command":["ls","-la"],"cwd":"/tmp","agentId":"agent1","sessionKey":"sk1"}""")
+        };
+
+        var res = await cap.ExecuteAsync(req);
+        Assert.True(res.Ok);
+        var payload = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(res.Payload));
+        Assert.True(payload.TryGetProperty("plan", out var plan));
+        Assert.True(plan.TryGetProperty("argv", out var argv));
+        Assert.Equal(2, argv.GetArrayLength());
+        Assert.True(plan.TryGetProperty("cwd", out var cwd));
+        Assert.Equal("/tmp", cwd.GetString());
+        Assert.True(plan.TryGetProperty("agentId", out var agentId));
+        Assert.Equal("agent1", agentId.GetString());
+    }
+
+    [Fact]
+    public async Task RunPrepare_ReturnsError_WhenMissingCommand()
+    {
+        var cap = new SystemCapability(NullLogger.Instance);
+        var req = new NodeInvokeRequest
+        {
+            Id = "p4",
+            Command = "system.run.prepare",
+            Args = Parse("""{}""")
+        };
+
+        var res = await cap.ExecuteAsync(req);
+        Assert.False(res.Ok);
+        Assert.Contains("Missing command", res.Error);
+    }
+
+    [Fact]
+    public async Task ExecApprovalsGet_WhenNoPolicyConfigured_ReturnsDisabled()
+    {
+        var cap = new SystemCapability(NullLogger.Instance);
+        var req = new NodeInvokeRequest
+        {
+            Id = "ea1",
+            Command = "system.execApprovals.get",
+            Args = Parse("""{}""")
+        };
+
+        var res = await cap.ExecuteAsync(req);
+        Assert.True(res.Ok);
+        var payload = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(res.Payload));
+        Assert.True(payload.TryGetProperty("enabled", out var enabled));
+        Assert.False(enabled.GetBoolean());
+    }
+
+    [Fact]
+    public async Task ExecApprovalsGet_WhenPolicySet_ReturnsRules()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var cap = new SystemCapability(NullLogger.Instance);
+            var policy = new ExecApprovalPolicy(tempDir, NullLogger.Instance);
+            cap.SetApprovalPolicy(policy);
+
+            var req = new NodeInvokeRequest
+            {
+                Id = "ea2",
+                Command = "system.execApprovals.get",
+                Args = Parse("""{}""")
+            };
+
+            var res = await cap.ExecuteAsync(req);
+            Assert.True(res.Ok);
+            var payload = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(res.Payload));
+            Assert.True(payload.TryGetProperty("enabled", out var enabled));
+            Assert.True(enabled.GetBoolean());
+            Assert.True(payload.TryGetProperty("rules", out _));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecApprovalsSet_WhenNoPolicyConfigured_ReturnsError()
+    {
+        var cap = new SystemCapability(NullLogger.Instance);
+        var req = new NodeInvokeRequest
+        {
+            Id = "ea3",
+            Command = "system.execApprovals.set",
+            Args = Parse("""{"rules":[]}""")
+        };
+
+        var res = await cap.ExecuteAsync(req);
+        Assert.False(res.Ok);
+        Assert.Contains("No exec policy configured", res.Error);
+    }
+
+    [Fact]
+    public async Task ExecApprovalsSet_UpdatesRules()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var cap = new SystemCapability(NullLogger.Instance);
+            var policy = new ExecApprovalPolicy(tempDir, NullLogger.Instance);
+            cap.SetApprovalPolicy(policy);
+
+            var req = new NodeInvokeRequest
+            {
+                Id = "ea4",
+                Command = "system.execApprovals.set",
+                Args = Parse("""{"rules":[{"pattern":"git *","action":"allow","description":"Allow git","enabled":true}],"defaultAction":"deny"}""")
+            };
+
+            var res = await cap.ExecuteAsync(req);
+            Assert.True(res.Ok);
+            var payload = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(res.Payload));
+            Assert.True(payload.TryGetProperty("updated", out var updated));
+            Assert.True(updated.GetBoolean());
+            Assert.True(payload.TryGetProperty("ruleCount", out var ruleCount));
+            Assert.Equal(1, ruleCount.GetInt32());
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task Run_BlockedEnvVar_ReturnsError()
+    {
+        var cap = new SystemCapability(NullLogger.Instance);
+        cap.SetCommandRunner(new FakeCommandRunner());
+
+        var req = new NodeInvokeRequest
+        {
+            Id = "e1",
+            Command = "system.run",
+            Args = Parse("""{"command":["echo","test"],"env":{"PATH":"C:\\evil"}}""")
+        };
+
+        var res = await cap.ExecuteAsync(req);
+        Assert.False(res.Ok);
+        Assert.Contains("PATH", res.Error);
+    }
+
+    [Fact]
+    public async Task Run_AllowedEnvVar_Passes()
+    {
+        var cap = new SystemCapability(NullLogger.Instance);
+        var runner = new FakeCommandRunner();
+        cap.SetCommandRunner(runner);
+
+        var req = new NodeInvokeRequest
+        {
+            Id = "e2",
+            Command = "system.run",
+            Args = Parse("""{"command":["echo","test"],"env":{"MY_CUSTOM_VAR":"hello"}}""")
+        };
+
+        var res = await cap.ExecuteAsync(req);
+        Assert.True(res.Ok);
+        Assert.NotNull(runner.LastRequest!.Env);
+        Assert.True(runner.LastRequest.Env!.ContainsKey("MY_CUSTOM_VAR"));
+    }
+
     private class FakeCommandRunner : ICommandRunner
     {
         public string Name => "fake";

--- a/tests/OpenClaw.Shared.Tests/ExecEnvSanitizerTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecEnvSanitizerTests.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+using OpenClaw.Shared;
+
+namespace OpenClaw.Shared.Tests;
+
+/// <summary>
+/// Unit tests for ExecEnvSanitizer — the security filter that blocks dangerous
+/// environment variable overrides before they reach the shell.
+/// </summary>
+public class ExecEnvSanitizerTests
+{
+    // ── null / empty input ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Sanitize_NullEnv_ReturnsNullAllowed_EmptyBlocked()
+    {
+        var result = ExecEnvSanitizer.Sanitize(null);
+        Assert.Null(result.Allowed);
+        Assert.Empty(result.Blocked);
+    }
+
+    [Fact]
+    public void Sanitize_EmptyDict_ReturnsAllowedPassthrough_EmptyBlocked()
+    {
+        // An empty dict has Count == 0, so the sanitizer returns it unchanged (no work to do).
+        var empty = new Dictionary<string, string>();
+        var result = ExecEnvSanitizer.Sanitize(empty);
+        Assert.Same(empty, result.Allowed);
+        Assert.Empty(result.Blocked);
+    }
+
+    // ── known-blocked names ───────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("PATH")]
+    [InlineData("PATHEXT")]
+    [InlineData("ComSpec")]
+    [InlineData("PSModulePath")]
+    [InlineData("NODE_OPTIONS")]
+    [InlineData("NODE_PATH")]
+    [InlineData("PYTHONPATH")]
+    [InlineData("PYTHONSTARTUP")]
+    [InlineData("PYTHONUSERBASE")]
+    [InlineData("RUBYOPT")]
+    [InlineData("RUBYLIB")]
+    [InlineData("PERL5OPT")]
+    [InlineData("PERL5LIB")]
+    [InlineData("PERLIO")]
+    [InlineData("GIT_SSH")]
+    [InlineData("GIT_SSH_COMMAND")]
+    [InlineData("GIT_EXEC_PATH")]
+    [InlineData("GIT_PROXY_COMMAND")]
+    [InlineData("GIT_ASKPASS")]
+    [InlineData("BASH_ENV")]
+    [InlineData("ENV")]
+    [InlineData("CDPATH")]
+    [InlineData("PROMPT_COMMAND")]
+    [InlineData("ZDOTDIR")]
+    [InlineData("LD_PRELOAD")]
+    [InlineData("LD_LIBRARY_PATH")]
+    [InlineData("LD_AUDIT")]
+    [InlineData("DYLD_INSERT_LIBRARIES")]
+    [InlineData("DYLD_LIBRARY_PATH")]
+    public void IsBlocked_KnownDangerousName_ReturnsTrue(string name)
+    {
+        Assert.True(ExecEnvSanitizer.IsBlocked(name));
+    }
+
+    [Theory]
+    [InlineData("PATH")]       // exact case
+    [InlineData("path")]       // lower
+    [InlineData("Path")]       // mixed
+    [InlineData("COMSPEC")]    // upper
+    [InlineData("comspec")]    // lower
+    public void IsBlocked_CaseInsensitive(string name)
+    {
+        Assert.True(ExecEnvSanitizer.IsBlocked(name));
+    }
+
+    // ── LD_ / DYLD_ prefix blocking ──────────────────────────────────────────
+
+    [Theory]
+    [InlineData("LD_CUSTOM")]
+    [InlineData("LD_")]
+    [InlineData("ld_custom")]          // case-insensitive
+    [InlineData("DYLD_CUSTOM")]
+    [InlineData("dyld_custom")]
+    public void IsBlocked_LdDyldPrefix_ReturnsTrue(string name)
+    {
+        Assert.True(ExecEnvSanitizer.IsBlocked(name));
+    }
+
+    // ── invalid / malformed names ─────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsBlocked_NullOrWhitespace_ReturnsTrue(string? name)
+    {
+        Assert.True(ExecEnvSanitizer.IsBlocked(name));
+    }
+
+    [Theory]
+    [InlineData("BAD=NAME")]       // contains '='
+    [InlineData("BAD\0NAME")]      // contains NUL
+    [InlineData("BAD\rNAME")]      // contains CR
+    [InlineData("BAD\nNAME")]      // contains LF
+    [InlineData("BAD NAME")]       // contains space
+    [InlineData("BAD\tNAME")]      // contains tab
+    public void IsBlocked_InvalidCharacters_ReturnsTrue(string name)
+    {
+        Assert.True(ExecEnvSanitizer.IsBlocked(name));
+    }
+
+    // ── allowed names ─────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("MY_CUSTOM_VAR")]
+    [InlineData("FOO")]
+    [InlineData("APP_ENV")]
+    [InlineData("TEST_OPENCLAW_VAR")]
+    [InlineData("SOME_123_VAR")]
+    public void IsBlocked_SafeName_ReturnsFalse(string name)
+    {
+        Assert.False(ExecEnvSanitizer.IsBlocked(name));
+    }
+
+    // ── Sanitize: mixed allowed + blocked ────────────────────────────────────
+
+    [Fact]
+    public void Sanitize_MixedDict_SeparatesAllowedAndBlocked()
+    {
+        var env = new Dictionary<string, string>
+        {
+            ["MY_VAR"] = "ok",
+            ["PATH"] = "evil",
+            ["ANOTHER_VAR"] = "also_ok",
+            ["LD_PRELOAD"] = "evil2",
+        };
+
+        var result = ExecEnvSanitizer.Sanitize(env);
+
+        Assert.NotNull(result.Allowed);
+        Assert.Equal(2, result.Allowed!.Count);
+        Assert.True(result.Allowed.ContainsKey("MY_VAR"));
+        Assert.True(result.Allowed.ContainsKey("ANOTHER_VAR"));
+
+        Assert.Equal(2, result.Blocked.Length);
+        Assert.Contains("PATH", result.Blocked, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("LD_PRELOAD", result.Blocked, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Sanitize_AllBlocked_ReturnsNullAllowed()
+    {
+        var env = new Dictionary<string, string>
+        {
+            ["PATH"] = "evil",
+            ["PATHEXT"] = "evil2",
+        };
+
+        var result = ExecEnvSanitizer.Sanitize(env);
+
+        Assert.Null(result.Allowed);
+        Assert.Equal(2, result.Blocked.Length);
+    }
+
+    [Fact]
+    public void Sanitize_AllAllowed_ReturnsEmptyBlocked()
+    {
+        var env = new Dictionary<string, string>
+        {
+            ["MY_VAR"] = "a",
+            ["OTHER_VAR"] = "b",
+        };
+
+        var result = ExecEnvSanitizer.Sanitize(env);
+
+        Assert.NotNull(result.Allowed);
+        Assert.Equal(2, result.Allowed!.Count);
+        Assert.Empty(result.Blocked);
+    }
+
+    [Fact]
+    public void Sanitize_PreservesValues()
+    {
+        var env = new Dictionary<string, string>
+        {
+            ["CUSTOM"] = "hello world",
+        };
+
+        var result = ExecEnvSanitizer.Sanitize(env);
+
+        Assert.Equal("hello world", result.Allowed!["CUSTOM"]);
+    }
+
+    // ── case-insensitive lookup in Sanitize ───────────────────────────────────
+
+    [Fact]
+    public void Sanitize_BlockedName_CaseInsensitive()
+    {
+        var env = new Dictionary<string, string>
+        {
+            ["path"] = "evil",        // lower-case PATH
+            ["SAFE_VAR"] = "ok",
+        };
+
+        var result = ExecEnvSanitizer.Sanitize(env);
+
+        Assert.Contains("path", result.Blocked, StringComparer.OrdinalIgnoreCase);
+        Assert.NotNull(result.Allowed);
+        Assert.True(result.Allowed!.ContainsKey("SAFE_VAR"));
+    }
+
+    // ── LD_ prefix in Sanitize ────────────────────────────────────────────────
+
+    [Fact]
+    public void Sanitize_LdPrefixVar_IsBlocked()
+    {
+        var env = new Dictionary<string, string>
+        {
+            ["LD_CUSTOM_EVIL"] = "val",
+            ["GOOD_VAR"] = "ok",
+        };
+
+        var result = ExecEnvSanitizer.Sanitize(env);
+
+        Assert.Contains("LD_CUSTOM_EVIL", result.Blocked, StringComparer.OrdinalIgnoreCase);
+        Assert.NotNull(result.Allowed);
+        Assert.False(result.Allowed!.ContainsKey("LD_CUSTOM_EVIL"));
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/ExecShellWrapperParserTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecShellWrapperParserTests.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Text;
+using Xunit;
+using OpenClaw.Shared;
+
+namespace OpenClaw.Shared.Tests;
+
+/// <summary>
+/// Unit tests for ExecShellWrapperParser.Expand — the security-critical parser
+/// that unwraps shell wrapper commands (cmd /c, powershell -Command, bash -c, etc.)
+/// to allow the approval policy to evaluate the actual underlying command.
+/// </summary>
+public class ExecShellWrapperParserTests
+{
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static ExecShellParseResult Expand(string command, string? shell = null)
+        => ExecShellWrapperParser.Expand(command, shell);
+
+    // ── empty / whitespace ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_EmptyString_ReturnsEmptyTargets()
+    {
+        var result = Expand("");
+        Assert.Empty(result.Targets);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public void Expand_WhitespaceOnly_ReturnsEmptyTargets()
+    {
+        var result = Expand("   ");
+        Assert.Empty(result.Targets);
+        Assert.Null(result.Error);
+    }
+
+    // ── plain commands (no shell wrappers) ────────────────────────────────────
+
+    [Fact]
+    public void Expand_PlainCommand_ReturnsNoTargets_NoError()
+    {
+        // A single non-wrapped command produces no extra targets and no error.
+        var result = Expand("echo hello");
+        Assert.Empty(result.Targets);
+        Assert.Null(result.Error);
+    }
+
+    // ── cmd.exe wrapping ─────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("cmd /c echo hello")]
+    [InlineData("cmd.exe /c echo hello")]
+    [InlineData("cmd /C echo hello")]          // case-insensitive flag
+    public void Expand_CmdSlashC_ExtractsPayload(string command)
+    {
+        var result = Expand(command);
+        Assert.Null(result.Error);
+        Assert.Contains(result.Targets, t => t.Command.Contains("echo hello") || t.Command == "echo hello");
+    }
+
+    [Fact]
+    public void Expand_CmdSlashK_ExtractsPayload()
+    {
+        var result = Expand("cmd /k dir C:\\");
+        Assert.Null(result.Error);
+        Assert.Contains(result.Targets, t => t.Command.Contains("dir"));
+    }
+
+    [Fact]
+    public void Expand_CmdSlashC_EmptyPayload_ReturnsError()
+    {
+        var result = Expand("cmd /c");
+        Assert.NotNull(result.Error);
+        Assert.Contains("empty", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Expand_CmdSlashC_SetsShell_ToCmd()
+    {
+        var result = Expand("cmd /c echo hello");
+        Assert.Null(result.Error);
+        // The extracted targets should have shell == "cmd"
+        Assert.All(result.Targets, t => Assert.Equal("cmd", t.Shell));
+    }
+
+    // ── PowerShell wrapping ───────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("powershell -Command Get-Process")]
+    [InlineData("powershell.exe -Command Get-Process")]
+    [InlineData("powershell -c Get-Process")]
+    public void Expand_Powershell_Command_ExtractsPayload(string command)
+    {
+        var result = Expand(command);
+        Assert.Null(result.Error);
+        Assert.Contains(result.Targets, t => t.Command.Contains("Get-Process"));
+    }
+
+    [Theory]
+    [InlineData("pwsh -Command Get-Date")]
+    [InlineData("pwsh.exe -Command Get-Date")]
+    [InlineData("pwsh -c Get-Date")]
+    public void Expand_Pwsh_Command_ExtractsPayload(string command)
+    {
+        var result = Expand(command);
+        Assert.Null(result.Error);
+        Assert.Contains(result.Targets, t => t.Command.Contains("Get-Date"));
+    }
+
+    [Fact]
+    public void Expand_Powershell_EncodedCommand_Decodes()
+    {
+        var payload = "Get-ChildItem";
+        var encoded = Convert.ToBase64String(Encoding.Unicode.GetBytes(payload));
+        var result = Expand($"powershell -EncodedCommand {encoded}");
+        Assert.Null(result.Error);
+        Assert.Contains(result.Targets, t => t.Command.Contains("Get-ChildItem"));
+    }
+
+    [Fact]
+    public void Expand_Powershell_ShortEncAlias_Decodes()
+    {
+        var payload = "Write-Output hello";
+        var encoded = Convert.ToBase64String(Encoding.Unicode.GetBytes(payload));
+        var result = Expand($"powershell -enc {encoded}");
+        Assert.Null(result.Error);
+        Assert.Contains(result.Targets, t => t.Command.Contains("Write-Output"));
+    }
+
+    [Fact]
+    public void Expand_Powershell_EcAlias_Decodes()
+    {
+        var payload = "Remove-Item test";
+        var encoded = Convert.ToBase64String(Encoding.Unicode.GetBytes(payload));
+        var result = Expand($"powershell -ec {encoded}");
+        Assert.Null(result.Error);
+        Assert.Contains(result.Targets, t => t.Command.Contains("Remove-Item"));
+    }
+
+    [Fact]
+    public void Expand_Powershell_EncodedCommand_EmptyPayload_ReturnsError()
+    {
+        var result = Expand("powershell -EncodedCommand");
+        Assert.NotNull(result.Error);
+    }
+
+    [Fact]
+    public void Expand_Powershell_EncodedCommand_InvalidBase64_ReturnsError()
+    {
+        var result = Expand("powershell -EncodedCommand NOT_VALID_BASE64!!!");
+        Assert.NotNull(result.Error);
+        Assert.Contains("decoded", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Expand_Powershell_Command_EmptyPayload_ReturnsError()
+    {
+        var result = Expand("powershell -Command");
+        Assert.NotNull(result.Error);
+        Assert.Contains("empty", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Expand_Powershell_SetsShell_ToPowershell()
+    {
+        var result = Expand("powershell -Command Get-Process");
+        Assert.Null(result.Error);
+        Assert.All(result.Targets, t => Assert.Equal("powershell", t.Shell));
+    }
+
+    [Fact]
+    public void Expand_Pwsh_SetsShell_ToPwsh()
+    {
+        var result = Expand("pwsh -Command Get-Date");
+        Assert.Null(result.Error);
+        Assert.All(result.Targets, t => Assert.Equal("pwsh", t.Shell));
+    }
+
+    // ── bash / sh wrapping ───────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("bash -c echo hello")]
+    [InlineData("bash.exe -c echo hello")]
+    [InlineData("sh -c echo hello")]
+    [InlineData("sh.exe -c echo hello")]
+    public void Expand_Bash_C_ExtractsPayload(string command)
+    {
+        var result = Expand(command);
+        Assert.Null(result.Error);
+        Assert.Contains(result.Targets, t => t.Command.Contains("echo hello") || t.Command == "echo hello");
+    }
+
+    [Fact]
+    public void Expand_Bash_SetsShell_ToSh()
+    {
+        var result = Expand("bash -c ls");
+        Assert.Null(result.Error);
+        Assert.All(result.Targets, t => Assert.Equal("sh", t.Shell));
+    }
+
+    // ── semicolon / chain splitting ───────────────────────────────────────────
+
+    [Fact]
+    public void Expand_SemicolonSeparated_ProducesMultipleTargets()
+    {
+        var result = Expand("echo a; echo b");
+        Assert.Null(result.Error);
+        Assert.Equal(2, result.Targets.Count);
+        Assert.Contains(result.Targets, t => t.Command.Contains("echo a") || t.Command == "echo a");
+        Assert.Contains(result.Targets, t => t.Command.Contains("echo b") || t.Command == "echo b");
+    }
+
+    [Fact]
+    public void Expand_AmpersandSeparated_ProducesMultipleTargets()
+    {
+        var result = Expand("echo a & echo b");
+        Assert.Null(result.Error);
+        Assert.Equal(2, result.Targets.Count);
+    }
+
+    [Fact]
+    public void Expand_DoubleAmpersandSeparated_ProducesMultipleTargets()
+    {
+        var result = Expand("echo a && echo b");
+        Assert.Null(result.Error);
+        Assert.Equal(2, result.Targets.Count);
+    }
+
+    [Fact]
+    public void Expand_DoublePipeSeparated_ProducesMultipleTargets()
+    {
+        var result = Expand("echo a || echo b");
+        Assert.Null(result.Error);
+        Assert.Equal(2, result.Targets.Count);
+    }
+
+    [Fact]
+    public void Expand_SemicolonInsideQuotes_NotSplit()
+    {
+        // The semicolon inside quotes should not be treated as a separator.
+        var result = Expand("echo 'a;b'");
+        Assert.Null(result.Error);
+        // Single non-wrapped command → no targets (depth 0, single segment)
+        Assert.Empty(result.Targets);
+    }
+
+    // ── depth limiting ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_DeepNesting_DoesNotInfiniteLoop()
+    {
+        // Four levels of cmd /c nesting should terminate cleanly.
+        var result = Expand("cmd /c cmd /c cmd /c cmd /c echo deep");
+        // Should not throw or hang; result may have targets or empty — just no exception.
+        Assert.NotNull(result);
+    }
+
+    // ── nested shell wrapping ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_CmdWrapsPs_ProducesBothTargets()
+    {
+        // cmd /c powershell -Command Get-Process
+        // → first extracts "powershell -Command Get-Process" (as cmd payload),
+        //   then recursively extracts "Get-Process" (as ps payload).
+        var result = Expand("cmd /c powershell -Command Get-Process");
+        Assert.Null(result.Error);
+        Assert.True(result.Targets.Count >= 1);
+    }
+
+    // ── shell normalisation ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Expand_NullShell_DefaultsToPowershell()
+    {
+        // When no shell is provided, targets inherit "powershell" as the default.
+        var result = Expand("cmd /c echo hello", null);
+        Assert.Null(result.Error);
+        // Targets produced from a cmd /c call should carry "cmd" shell.
+        Assert.All(result.Targets, t => Assert.Equal("cmd", t.Shell));
+    }
+
+    [Fact]
+    public void Expand_ExplicitShell_PropagatedToTargets()
+    {
+        // Non-wrapped semicolon-chained command with an explicit shell.
+        var result = Expand("echo a; echo b", "pwsh");
+        Assert.Null(result.Error);
+        Assert.All(result.Targets, t => Assert.Equal("pwsh", t.Shell));
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -288,6 +288,16 @@ public class OpenClawGatewayClientTests
             _client.StatusChanged += (_, s) => changes.Add(s);
             return changes;
         }
+
+        public bool GetAuthFailedFlag() =>
+            GetPrivateField<bool>("_authFailed");
+
+        public List<string> CaptureAuthenticationFailedEvents()
+        {
+            var events = new List<string>();
+            _client.AuthenticationFailed += (_, msg) => events.Add(msg);
+            return events;
+        }
     }
 
     private class TestLogger : IOpenClawLogger
@@ -1625,5 +1635,143 @@ public class OpenClawGatewayClientTests
 
         var flags = helper.GetUnsupportedMethodFlags();
         Assert.True(flags.NodeList);
+    }
+
+    // --- HandleRequestError: terminal auth errors (PR #206 fix) ---
+
+    [Theory]
+    [InlineData("token mismatch")]
+    [InlineData("origin not allowed")]
+    [InlineData("too many failed attempts")]
+    public void HandleRequestError_TerminalAuthError_SetsAuthFailedFlag(string errorMessage)
+    {
+        var helper = new GatewayClientTestHelper();
+        helper.TrackPendingRequest("req-auth-1", "connect");
+
+        helper.ProcessRawMessage($$"""
+        {
+            "type": "res",
+            "id": "req-auth-1",
+            "ok": false,
+            "error": "{{errorMessage}}"
+        }
+        """);
+
+        Assert.True(helper.GetAuthFailedFlag());
+    }
+
+    [Fact]
+    public void HandleRequestError_TerminalAuthError_RaisesAuthenticationFailedEvent()
+    {
+        var helper = new GatewayClientTestHelper();
+        var authEvents = helper.CaptureAuthenticationFailedEvents();
+        helper.TrackPendingRequest("req-auth-2", "connect");
+
+        helper.ProcessRawMessage("""
+        {
+            "type": "res",
+            "id": "req-auth-2",
+            "ok": false,
+            "error": "token mismatch — reconnect rejected"
+        }
+        """);
+
+        Assert.Single(authEvents);
+        Assert.Contains("token mismatch", authEvents[0], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HandleRequestError_TerminalAuthError_RaisesErrorStatus()
+    {
+        var helper = new GatewayClientTestHelper();
+        var statusChanges = helper.CaptureStatusChanges();
+        helper.TrackPendingRequest("req-auth-3", "connect");
+
+        helper.ProcessRawMessage("""
+        {
+            "type": "res",
+            "id": "req-auth-3",
+            "ok": false,
+            "error": "origin not allowed"
+        }
+        """);
+
+        Assert.Contains(ConnectionStatus.Error, statusChanges);
+    }
+
+    [Fact]
+    public void HandleRequestError_TerminalAuthError_OnNonConnectMethod_DoesNotSetAuthFailed()
+    {
+        // Terminal auth check only applies to "connect" method — other methods must not set the flag
+        var helper = new GatewayClientTestHelper();
+        helper.TrackPendingRequest("req-auth-4", "sessions.list");
+
+        helper.ProcessRawMessage("""
+        {
+            "type": "res",
+            "id": "req-auth-4",
+            "ok": false,
+            "error": "token mismatch"
+        }
+        """);
+
+        Assert.False(helper.GetAuthFailedFlag());
+    }
+
+    [Fact]
+    public void HandleHelloOk_AfterAuthFailed_ClearsAuthFailedFlag()
+    {
+        var helper = new GatewayClientTestHelper();
+
+        // First, trigger auth failure
+        helper.TrackPendingRequest("req-auth-5", "connect");
+        helper.ProcessRawMessage("""
+        {
+            "type": "res",
+            "id": "req-auth-5",
+            "ok": false,
+            "error": "token mismatch"
+        }
+        """);
+        Assert.True(helper.GetAuthFailedFlag());
+
+        // Now receive hello-ok — flag must be cleared
+        helper.ProcessRawMessage("""
+        {
+            "type": "res",
+            "id": "req-hello-1",
+            "payload": {
+                "type": "hello-ok"
+            }
+        }
+        """);
+
+        Assert.False(helper.GetAuthFailedFlag());
+    }
+
+    [Fact]
+    public void HandleRequestError_AllDeviceSignatureModesExhausted_SetsAuthFailed()
+    {
+        var logger = new TestLogger();
+        var helper = new GatewayClientTestHelper(logger);
+        var authEvents = helper.CaptureAuthenticationFailedEvents();
+
+        // Cycle through all 4 signature modes by sending 4 successive rejections
+        for (int i = 1; i <= 4; i++)
+        {
+            helper.TrackPendingRequest($"req-sig-exhaust-{i}", "connect");
+            helper.ProcessRawMessage($$"""
+            {
+                "type": "res",
+                "id": "req-sig-exhaust-{{i}}",
+                "ok": false,
+                "error": "device signature invalid"
+            }
+            """);
+        }
+
+        Assert.True(helper.GetAuthFailedFlag());
+        Assert.Single(authEvents);
+        Assert.Contains("device signature", authEvents[0], StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
## Summary

Handles the high-confidence Repo Assist easy wins in one human-reviewed branch:

- Add root `NuGet.Config` with package source mapping to `nuget.org`
- Add Dependabot coverage for GitHub Actions and NuGet
- Allow .NET SDK feature-band roll-forward so `10.0.201` satisfies the repo's `10.0.100` baseline
- Apply behavior-preserving allocation/LINQ cleanup from Repo Assist suggestions
- Add `SystemCapability` coverage for `system.run.prepare`, exec approvals get/set, and environment sanitization
- Add terminal auth-failure coverage for the PR #206 fix
- Add shell-wrapper parser and environment sanitizer unit coverage

Closes #208
Closes #214
Supersedes #207
Supersedes #209
Supersedes #212
Supersedes #213
Supersedes #217

## Validation

- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`