### PR TITLE
fix: audit transitive packages and update System.Drawing.Common

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.100",
-    "rollForward": "latestPatch"
+    "rollForward": "latestFeature"
   }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,30 @@
+<Project>
+
+  <!--
+    Shared build configuration for OpenClaw.Shared, OpenClaw.Tray.WinUI, and OpenClaw.Cli.
+
+    OpenClaw.CommandPalette has its own Directory.Build.props one level deeper, so MSBuild
+    stops walking up at that file and this one does NOT apply to CommandPalette.
+
+    Properties here set a consistent quality baseline that matches the CommandPalette project's
+    existing settings and are safe defaults for all src projects:
+      - NET analyzers + Recommended rule set: catch common bugs and anti-patterns
+      - NuGetAudit covers transitive packages so CVEs in indirect deps surface during restore
+  -->
+
+  <PropertyGroup>
+    <!-- Enable the built-in .NET source analyzers (already the SDK default for net5+,
+         but made explicit here so the intent is clear and auditable). -->
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+
+    <!-- Recommended rule set: a superset of Default that enables additional quality rules
+         aligned with the CommandPalette project's AnalysisMode=Recommended setting.
+         Rules produce warnings only; src projects do not set TreatWarningsAsErrors. -->
+    <AnalysisMode>Recommended</AnalysisMode>
+
+    <!-- Audit all package dependencies (direct + transitive) for known CVEs during restore.
+         Defaults to "direct" in the SDK; "all" provides broader security coverage. -->
+    <NuGetAuditMode>all</NuGetAuditMode>
+  </PropertyGroup>
+
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,23 +5,9 @@
 
     OpenClaw.CommandPalette has its own Directory.Build.props one level deeper, so MSBuild
     stops walking up at that file and this one does NOT apply to CommandPalette.
-
-    Properties here set a consistent quality baseline that matches the CommandPalette project's
-    existing settings and are safe defaults for all src projects:
-      - NET analyzers + Recommended rule set: catch common bugs and anti-patterns
-      - NuGetAudit covers transitive packages so CVEs in indirect deps surface during restore
   -->
 
   <PropertyGroup>
-    <!-- Enable the built-in .NET source analyzers (already the SDK default for net5+,
-         but made explicit here so the intent is clear and auditable). -->
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-
-    <!-- Recommended rule set: a superset of Default that enables additional quality rules
-         aligned with the CommandPalette project's AnalysisMode=Recommended setting.
-         Rules produce warnings only; src projects do not set TreatWarningsAsErrors. -->
-    <AnalysisMode>Recommended</AnalysisMode>
-
     <!-- Audit all package dependencies (direct + transitive) for known CVEs during restore.
          Defaults to "direct" in the SDK; "all" provides broader security coverage. -->
     <NuGetAuditMode>all</NuGetAuditMode>

--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4654" />
     <PackageReference Include="WinUIEx" Version="2.9.0" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.7" />
     <PackageReference Include="Updatum" Version="1.3.4" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Takes the valuable part of Repo Assist #211 without enabling noisy analyzer policy:

- Add `src/Directory.Build.props` with `NuGetAuditMode=all` so direct and transitive package CVEs surface during restore
- Add an explicit `System.Drawing.Common` `10.0.7` reference to `OpenClaw.Tray.WinUI` so `Microsoft.Toolkit.Uwp.Notifications` no longer resolves vulnerable transitive `System.Drawing.Common` `4.7.0`
- Allow .NET SDK feature-band roll-forward so installed `10.0.201` can satisfy the repo's `10.0.100` baseline

Supersedes #211

## Validation

- `dotnet list ./src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj package --include-transitive --vulnerable` reports no vulnerable packages
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`