### PR TITLE
feat: native WinUI A2UI renderer + MCP/security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,9 @@ jobs:
     - name: Build Tests
       run: |
         dotnet build tests/OpenClaw.Shared.Tests -c Debug --no-restore
-        dotnet build tests/OpenClaw.Tray.Tests -c Debug --no-restore
-        dotnet build tests/OpenClaw.Tray.IntegrationTests -c Debug --no-restore
+        dotnet build tests/OpenClaw.Tray.Tests -c Debug -r win-x64 --no-restore
+        dotnet build tests/OpenClaw.Tray.IntegrationTests -c Debug -r win-x64 --no-restore
+        dotnet build tests/OpenClaw.Tray.UITests -c Debug -r win-x64 --no-restore
 
     - name: Run Shared Tests
       env:
@@ -68,10 +69,41 @@ jobs:
         dotnet test tests/OpenClaw.Tray.Tests
         --no-build
         -c Debug
+        -r win-x64
         --verbosity normal
         --collect:"XPlat Code Coverage"
         --results-directory TestResults\Tray
         --logger "trx;LogFileName=OpenClaw.Tray.Tests.trx"
+
+    # Tray integration tests gate on OPENCLAW_RUN_INTEGRATION; set it so the
+    # MCP-server / capability tests actually run. M3 (tool-name drift) and
+    # similar would have been caught here if these had ever been wired.
+    - name: Run Tray Integration Tests
+      env:
+        OPENCLAW_RUN_INTEGRATION: 1
+      run: >
+        dotnet test tests/OpenClaw.Tray.IntegrationTests
+        --no-build
+        -c Debug
+        -r win-x64
+        --verbosity normal
+        --collect:"XPlat Code Coverage"
+        --results-directory TestResults\TrayIntegration
+        --logger "trx;LogFileName=OpenClaw.Tray.IntegrationTests.trx"
+
+    # UI tests need a real visual tree; on the GitHub windows-latest runner this
+    # is a Window Station with WindowsAppSDK available, which is enough for
+    # WinUI 3 UI tests. Failures here block PRs.
+    - name: Run Tray UI Tests
+      run: >
+        dotnet test tests/OpenClaw.Tray.UITests
+        --no-build
+        -c Debug
+        -r win-x64
+        --verbosity normal
+        --collect:"XPlat Code Coverage"
+        --results-directory TestResults\TrayUI
+        --logger "trx;LogFileName=OpenClaw.Tray.UITests.trx"
 
     - name: Upload Test Results
       if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       run: |
         dotnet build tests/OpenClaw.Shared.Tests -c Debug --no-restore
         dotnet build tests/OpenClaw.Tray.Tests -c Debug --no-restore
+        dotnet build tests/OpenClaw.Tray.IntegrationTests -c Debug --no-restore
 
     - name: Run Shared Tests
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,9 +105,20 @@ jobs:
         --results-directory TestResults\TrayIntegration
         --logger trx;LogFileName=OpenClaw.Tray.IntegrationTests.trx"
 
-    # UI tests need a real visual tree; on the GitHub windows-latest runner this
-    # is a Window Station with WindowsAppSDK available, which is enough for
-    # WinUI 3 UI tests. Failures here block PRs.
+    # UI tests need a real visual tree AND a system-registered WindowsAppRuntime
+    # framework MSIX — the test fixture calls Bootstrap.Initialize(1.8, stable),
+    # which looks up the framework package by identity. The hosted windows-2025
+    # runner image doesn't preinstall it, so we install it explicitly here.
+    # Version pinned to match Microsoft.WindowsAppSDK 1.8.260101001 in the csprojs.
+    - name: Install WindowsAppRuntime 1.8
+      shell: pwsh
+      run: |
+        $url = "https://aka.ms/windowsappsdk/1.8/1.8.260101001/windowsappruntimeinstall-x64.exe"
+        $exe = "$env:RUNNER_TEMP\WindowsAppRuntimeInstall.exe"
+        Invoke-WebRequest -Uri $url -OutFile $exe
+        & $exe --quiet
+        if ($LASTEXITCODE -ne 0) { throw "WindowsAppRuntimeInstall failed with exit code $LASTEXITCODE" }
+
     - name: Run Tray UI Tests
       run: >
         dotnet-coverage collect

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
 
+    # dotnet-coverage replaces coverlet because the integration tests spawn the
+    # tray exe out-of-process; coverlet only instruments the in-proc test
+    # assembly. Installing once at the job level lets every test step wrap its
+    # `dotnet test` invocation in `dotnet-coverage collect`.
+    - name: Install dotnet-coverage
+      run: dotnet tool install --global dotnet-coverage
+
     - name: Build Shared Library
       run: dotnet build src/OpenClaw.Shared -c Debug --no-restore
 
@@ -56,54 +63,63 @@ jobs:
       env:
         OPENCLAW_RUN_INTEGRATION: 1
       run: >
-        dotnet test tests/OpenClaw.Shared.Tests
+        dotnet-coverage collect
+        --output TestResults\Shared\coverage.cobertura.xml
+        --output-format cobertura
+        "dotnet test tests/OpenClaw.Shared.Tests
         --no-build
         -c Debug
         --verbosity normal
-        --collect:"XPlat Code Coverage"
         --results-directory TestResults\Shared
-        --logger "trx;LogFileName=OpenClaw.Shared.Tests.trx"
+        --logger trx;LogFileName=OpenClaw.Shared.Tests.trx"
 
     - name: Run Tray Tests
       run: >
-        dotnet test tests/OpenClaw.Tray.Tests
+        dotnet-coverage collect
+        --output TestResults\Tray\coverage.cobertura.xml
+        --output-format cobertura
+        "dotnet test tests/OpenClaw.Tray.Tests
         --no-build
         -c Debug
         -r win-x64
         --verbosity normal
-        --collect:"XPlat Code Coverage"
         --results-directory TestResults\Tray
-        --logger "trx;LogFileName=OpenClaw.Tray.Tests.trx"
+        --logger trx;LogFileName=OpenClaw.Tray.Tests.trx"
 
     # Tray integration tests gate on OPENCLAW_RUN_INTEGRATION; set it so the
-    # MCP-server / capability tests actually run. M3 (tool-name drift) and
-    # similar would have been caught here if these had ever been wired.
+    # MCP-server / capability tests actually run. dotnet-coverage with no
+    # filter captures coverage for both the test host AND the spawned tray
+    # exe (coverlet could not — see tests/Directory.Build.props comment).
     - name: Run Tray Integration Tests
       env:
         OPENCLAW_RUN_INTEGRATION: 1
       run: >
-        dotnet test tests/OpenClaw.Tray.IntegrationTests
+        dotnet-coverage collect
+        --output TestResults\TrayIntegration\coverage.cobertura.xml
+        --output-format cobertura
+        "dotnet test tests/OpenClaw.Tray.IntegrationTests
         --no-build
         -c Debug
         -r win-x64
         --verbosity normal
-        --collect:"XPlat Code Coverage"
         --results-directory TestResults\TrayIntegration
-        --logger "trx;LogFileName=OpenClaw.Tray.IntegrationTests.trx"
+        --logger trx;LogFileName=OpenClaw.Tray.IntegrationTests.trx"
 
     # UI tests need a real visual tree; on the GitHub windows-latest runner this
     # is a Window Station with WindowsAppSDK available, which is enough for
     # WinUI 3 UI tests. Failures here block PRs.
     - name: Run Tray UI Tests
       run: >
-        dotnet test tests/OpenClaw.Tray.UITests
+        dotnet-coverage collect
+        --output TestResults\TrayUI\coverage.cobertura.xml
+        --output-format cobertura
+        "dotnet test tests/OpenClaw.Tray.UITests
         --no-build
         -c Debug
         -r win-x64
         --verbosity normal
-        --collect:"XPlat Code Coverage"
         --results-directory TestResults\TrayUI
-        --logger "trx;LogFileName=OpenClaw.Tray.UITests.trx"
+        --logger trx;LogFileName=OpenClaw.Tray.UITests.trx"
 
     - name: Upload Test Results
       if: always()

--- a/docs/A2UI_NATIVE_WINUI.md
+++ b/docs/A2UI_NATIVE_WINUI.md
@@ -277,11 +277,18 @@ Mirror what `CanvasCapability` already logs:
 
 ## 14. Open questions
 
-1. **Window count.** One A2UI window with tabs for multiple surfaces, or one window per surface? Lit version uses one host with multiple stacked surfaces — propose mirroring that.
-2. **Component overrides.** Should we expose a hook for downstream apps (e.g., a future enterprise OpenClaw fork) to swap in custom renderers? Catalog-strict v1 says no, but the seam is cheap to add.
-3. **Theme negotiation.** Should the agent be told "I'm a native WinUI client, prefer Fluent tokens" via `clientCapabilities`? Useful if the agent is generating themes — and is the v0.8 mechanism for this (`a2ui_client_capabilities_schema.json`).
-4. **Animation budget.** A2UI doesn't specify transitions. Define a small set (fade, slide) and apply automatically on `updateComponents`, or stay still and let the agent ask?
-5. **Image caching.** Per-surface, per-process, or persistent? Persistent risks staleness; per-surface risks repeated fetches.
+> Resolved 2026-04-27 — see decisions below; previous wording preserved for context.
+
+1. **Window count.** One A2UI window with tabs for multiple surfaces, or one window per surface? Lit version uses one host with multiple stacked surfaces.
+   **Decision:** stay with the Lit-compatible single-window-with-tabs layout. Multiple windows is out of scope for v1.
+2. **Component overrides.** Should we expose a hook for downstream apps to swap in custom renderers?
+   **Decision:** stay catalog-strict for v1. No extension seam yet — easy to add later if a real customer asks.
+3. **Theme negotiation.** Should the agent be told "I'm a native WinUI client, prefer Fluent tokens" via `clientCapabilities`?
+   **Decision:** yes — advertise Fluent token preference in `clientCapabilities`. (Tracking task: wire this into the capability summary returned by `canvas.caps`.)
+4. **Animation budget.** Define a small transition set (fade, slide) and apply automatically, or stay still?
+   **Decision:** stay still until the agent asks. No automatic transitions in v1.
+5. **Image caching.** Per-surface, per-process, or persistent?
+   **Decision:** per-process LRU. Avoids the repeated-fetch cost of per-surface and the staleness risk of persistent disk caching.
 
 ## 15. References
 

--- a/docs/A2UI_NATIVE_WINUI.md
+++ b/docs/A2UI_NATIVE_WINUI.md
@@ -1,0 +1,293 @@
+# Native WinUI A2UI Canvas — Design Spec
+
+> **Status:** Draft / proposal
+> **Audience:** Contributors implementing a native A2UI renderer for the Windows node
+> **Target version:** A2UI v0.8 (parity with current openclaw clients), with a v0.9 migration path
+
+## 1. Motivation
+
+Today the Windows node renders A2UI by hosting a WebView2 control (`CanvasWindow`) that navigates to an HTTP page served by the openclaw gateway at `/__openclaw__/a2ui/`. That page bundles `@a2ui/lit` and openclaw's bridge JS. Pushed messages travel `agent → gateway → node (canvas.a2ui.push) → WebView2 → window.__a2ui.receive(msg)`.
+
+That works, but it has costs:
+
+- **Hard gateway dependency.** A node running in MCP-only mode (no gateway connection) silently drops A2UI pushes — `OnCanvasA2UIPush` bails when `_a2uiHostUrl` is null. The renderer code physically lives at the gateway.
+- **WebView2 surface area.** Drag/drop, IME, accessibility, focus, DPI, and keyboard shortcuts inherit WebView2 quirks instead of XAML's native behavior. The canvas always feels like an embedded browser.
+- **Bootstrapping latency.** Each cold start has to ensure WebView2 is ready, navigate, and wait for `window.__a2ui` to register before any message can be delivered (`EnsureA2UIHostAsync` + `ensureA2uiReady` polling).
+- **Theming drift.** WinUI windows around the canvas use Mica/Fluent; the canvas uses Lit components styled with CSS. Achieving consistent visuals requires duplicate theme work.
+- **Hardening.** Surface area for arbitrary script execution remains larger than necessary for what is fundamentally a declarative UI tree.
+
+A native WinUI renderer renders A2UI surfaces directly into XAML — no WebView, no HTTP host, no JS bridge. The node becomes self-contained: it can render A2UI whether it's connected to a gateway, an MCP client, or both.
+
+## 2. Goals & non-goals
+
+### Goals
+
+- **Render A2UI v0.8 standard-catalog surfaces natively** in the Windows node using WinUI 3 / XAML controls.
+- **Preserve the existing wire protocol.** Agents continue to send A2UI JSONL via `canvas.a2ui.push` / `canvas.a2ui.reset`. Nothing about the agent side changes.
+- **Work offline / gateway-less.** A WSL-less, gateway-less Windows node can still display rich UI from an MCP client.
+- **Match Fluent / WinUI design language** by default; allow theme overrides from the surface payload.
+- **Stream incremental updates** without flicker (component adds/updates/deletes mid-task).
+
+### Non-goals (initial release)
+
+- No A2UI v0.9 features (bidirectional messaging, prompt-first generation, modular schemas).
+- No HTML/JS/CSS escape hatch from inside an A2UI surface (the v0.8 catalog has no such primitive — keep it that way).
+- No replacement for `canvas.present` / `canvas.navigate` / `canvas.eval`. Those continue to use WebView2 for general web content. Only A2UI rendering moves.
+- No custom (non-catalog) component types in v1. Catalog-strict.
+
+## 3. Architecture
+
+### 3.1 Boundary
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ OpenClaw.Tray.WinUI (existing)                          │
+│ ┌─────────────────────────────────────────────────────┐ │
+│ │ NodeService                                         │ │
+│ │   CanvasCapability  (existing)                      │ │
+│ │     ├─ canvas.a2ui.push   ──► A2UIPushRequested ─┐  │ │
+│ │     └─ canvas.a2ui.reset  ──► A2UIResetRequested┐│  │ │
+│ │                                                 ││  │ │
+│ │   OnCanvasA2UIPush / OnCanvasA2UIReset (existing)││  │ │
+│ │     dispatched to UI thread, route to:          ││  │ │
+│ └─────────────────────────────────────────────────││──┘ │
+│                                                   ▼▼    │
+│ ┌─────────────────────────────────────────────────────┐ │
+│ │ A2UICanvasWindow  (new) ─ replaces WebView2 path    │ │
+│ │   ├─ A2UIRouter        (parses & dispatches msgs)   │ │
+│ │   ├─ SurfaceHost x N   (one per createSurface)      │ │
+│ │   │     └─ ComponentTree (XAML)                     │ │
+│ │   ├─ DataModelStore    (per surface)                │ │
+│ │   ├─ ActionDispatcher  (UI events → ws/MCP)         │ │
+│ │   └─ ThemeProvider     (Fluent + payload overrides) │ │
+│ └─────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────┘
+```
+
+The existing `CanvasCapability` and the events it raises (`A2UIPushRequested`, `A2UIResetRequested`) are unchanged. `NodeService.OnCanvasA2UIPush` no longer calls `EnsureA2UIHostAsync` / `SendA2UIMessageAsync` against a WebView2; it instead hands the JSONL to a new `A2UICanvasWindow` (or the existing `CanvasWindow` if we choose to host both renderers).
+
+### 3.2 Coexistence with WebView2 canvas
+
+Two canvas modes share the surface:
+
+| Mode | Trigger | Window |
+|---|---|---|
+| Web (`canvas.present` / `canvas.navigate` / `canvas.eval`) | URL or HTML payload | `CanvasWindow` (WebView2) — unchanged |
+| A2UI native | First `canvas.a2ui.push` since reset | `A2UICanvasWindow` (XAML) — new |
+
+A user-visible toggle is *not* required — the choice is implicit in which MCP command the agent calls. The two windows must not compete for focus; if both want to be visible, the most-recently-targeted wins (last-write-wins, with a small fade between).
+
+### 3.3 Component pipeline
+
+```
+JSONL line
+  → System.Text.Json deserialize → A2UIMessage (sealed record hierarchy)
+  → A2UIRouter.Dispatch(message)
+      ├─ CreateSurface  → SurfaceHost.Create(surfaceId, catalogId, theme)
+      ├─ UpdateComponents → SurfaceHost.ApplyComponents(adjacencyList)
+      ├─ UpdateDataModel  → DataModelStore.Apply(surfaceId, patch)
+      └─ DeleteSurface    → SurfaceHost.Dispose(surfaceId)
+  → SurfaceHost rebuilds/patches its XAML subtree on the UI thread
+  → DataModel changes notify bound components via INotifyPropertyChanged
+```
+
+Component identity is by **string ID**. A `LogicalTreeBuilder` keeps an `IDictionary<string, FrameworkElement>` per surface so `updateComponents` can mutate in place without rebuilding the entire tree (avoids flicker, preserves focus and scroll position).
+
+## 4. Wire protocol
+
+### 4.1 Inbound (agent → node)
+
+Use the existing capability commands verbatim. No protocol change is required for this work.
+
+```json
+{ "version": "v0.8", "createSurface": { "surfaceId": "main", "catalogId": "https://a2ui.org/specification/v0_8/standard_catalog.json", "sendDataModel": true } }
+{ "updateComponents": { "surfaceId": "main", "components": [ { "id": "root", "componentName": "Column", "properties": {...}, "children": ["title","actions"] }, ... ] } }
+{ "updateDataModel": { "surfaceId": "main", "patch": { "/userName": "Scott" } } }
+{ "deleteSurface": { "surfaceId": "main" } }
+```
+
+The renderer SHOULD validate each line against the v0.8 envelope schema before dispatch. The schema lives at `vendor/a2ui/specification/0.8/json/server_to_client.json` in the openclaw repo and should be vendored into `OpenClaw.Shared/Schemas/A2UI_v0_8/`.
+
+Unknown envelope keys → log + skip (do not throw). Unknown component types → render an `A2UIUnknown` placeholder showing the type name and a warning glyph; never crash.
+
+### 4.2 Outbound (node → agent)
+
+When the user interacts with a surface, the renderer raises an A2UI **action** event. Action delivery rides whichever transport the node is currently connected through:
+
+- Gateway-connected: serialize as the v0.8 client→server envelope and ship over the existing WebSocket via `_nodeClient`.
+- MCP-only: emit as an MCP notification on a new `canvas/a2ui/action` channel (to be added to `CanvasCapability`).
+
+Action payload shape (v0.8):
+
+```json
+{
+  "action": {
+    "name": "primary",
+    "surfaceId": "main",
+    "sourceComponentId": "btn_submit",
+    "timestamp": "2026-04-25T18:32:11.123Z",
+    "context": { "/email": "user@example.com" }
+  }
+}
+```
+
+`context` is the (possibly partial) data model snapshot relevant to the source component, computed by walking the component's `dataBinding` paths and the surface's `sendDataModel` flag.
+
+## 5. Component mapping (v0.8 standard catalog)
+
+| A2UI component | WinUI 3 control | Notes |
+|---|---|---|
+| **Containers** | | |
+| `Row` | `StackPanel` (Horizontal) inside a wrap-aware `ItemsRepeater` when `wrap=true` | Match `bootstrap.js`'s wrap behavior at < 860 px |
+| `Column` | `StackPanel` (Vertical) | `min-width: 0` analog: clamp via `MinWidth=0` |
+| `List` | `ItemsRepeater` + `ItemsRepeaterScrollHost` | Virtualization on by default |
+| `Card` | `Border` with `Microsoft.UI.Xaml.Media.MicaBackdrop`-aware brush + corner radius + drop shadow | |
+| `Tabs` | `TabView` (controls) | Lightweight chrome to match Lit version |
+| `Modal` | `ContentDialog` (or full-window overlay `Grid` w/ `AcrylicBrush`) | Track Lit's full-screen overlay style — `dialog::backdrop` analog is `AcrylicBrush` over the parent |
+| **Display** | | |
+| `Text` | `TextBlock` | Map A2UI `style` (h1/h2/body/caption/etc.) to Fluent type ramp |
+| `Image` | `Image` w/ `BitmapImage` source; HTTP fetch via `HttpClient` with allowlist | Reject `file:`, `javascript:`, `data:` (except small `image/png|jpeg|webp`) |
+| `Icon` | `FontIcon` (Segoe Fluent Icons) keyed by name | Maintain a name→glyph map; missing → outlined question-mark |
+| `Video` | `MediaPlayerElement` | |
+| `AudioPlayer` | `MediaPlayerElement` w/ audio-only template | |
+| `Divider` | `Rectangle` (1px `SystemControlForegroundBaseLowBrush`) or `MenuFlyoutSeparator` style | |
+| **Interactive** | | |
+| `Button` | `Button` (variants → `AccentButtonStyle`, `DefaultButtonStyle`) | Triggers action with `name` |
+| `CheckBox` | `CheckBox` | Two-way bind to data model path |
+| `TextField` | `TextBox` (multiline → `TextBox.AcceptsReturn=true`) | `inputType` → `InputScope` mapping |
+| `DateTimeInput` | `CalendarDatePicker` + `TimePicker` (composed) | |
+| `ChoicePicker` | `ComboBox` (single) / `ListView` w/ `SelectionMode=Multiple` (multi) | |
+| `Slider` | `Slider` | |
+
+Each mapping lives in a single `IComponentRenderer` implementation under `OpenClaw.Tray.WinUI/A2UI/Renderers/`. The set is closed at compile time (catalog-strict) — no runtime registration in v1.
+
+## 6. Data model & binding
+
+A2UI surfaces carry a JSON data model. Components reference paths into that model (`"/userName"`, `"/items/0/title"`).
+
+### 6.1 Storage
+
+`DataModelStore` holds one `JsonObject` per surface, mutated via JSON Pointer (RFC 6901) patches. Use `System.Text.Json.Nodes` for in-place edits (already a dependency).
+
+### 6.2 Binding
+
+Bindings are **one-way for display** components, **two-way for interactive** components. Implement via:
+
+- `DataModelObservable` — wraps a `JsonObject` and exposes `INotifyPropertyChanged` per registered path.
+- `A2UIBinding` markup extension (or code-behind helpers) — produces `Binding` objects that target a path observer.
+
+Why not raw `Microsoft.UI.Xaml.Data.Binding` paths? JSON paths can include array indices and slashes, which XAML binding paths don't model cleanly. A small adapter is simpler and faster than fighting the binding engine.
+
+### 6.3 Patches
+
+`updateDataModel.patch` is an object whose keys are JSON Pointer paths and whose values are replacement values. Apply atomically; coalesce notifications so multiple paths in one message produce a single render pass.
+
+## 7. Action dispatch
+
+Components that can produce actions register a callback:
+
+```csharp
+internal sealed class ButtonRenderer : IComponentRenderer
+{
+    public FrameworkElement Render(A2UIComponent c, RenderContext ctx)
+    {
+        var btn = new Button { Content = c.GetText("label") };
+        btn.Click += (_, _) => ctx.Actions.Raise(new A2UIAction(
+            name: c.GetString("actionName") ?? "press",
+            surfaceId: ctx.SurfaceId,
+            sourceComponentId: c.Id,
+            context: ctx.DataModel.SnapshotFor(c)));
+        return btn;
+    }
+}
+```
+
+`ActionDispatcher.Raise` is the single seam through which actions leave the renderer. It handles:
+
+1. Throttle/debounce (per `name` + `sourceComponentId`) to suppress double-clicks.
+2. Serialization to A2UI v0.8 client→server envelope.
+3. Routing: gateway WS first, then MCP notification, with a fallback queue if neither is available.
+
+## 8. Theming
+
+Default to `XamlControlsResources` + Fluent theme colors. The `createSurface.theme` payload may override:
+
+- `colors`: map onto `ThemeResource` overrides applied to the `SurfaceHost` resource scope (no global mutation).
+- `typography`: optional font family override; respect Windows accessibility text scaling first.
+- `radius`, `spacing`: passed through to renderers via `RenderContext`.
+
+Theme application is local to the surface's visual tree — switching themes between surfaces does not flash the chrome.
+
+## 9. Lifecycle & hosting
+
+### 9.1 Window
+
+`A2UICanvasWindow` extends `Window`:
+
+- One window total (singleton). Multiple surfaces stack as `TabView` items if `>1` is active; single surface fills the content area.
+- Title pulls from `createSurface.title` (new optional v0.8 field already used by openclaw) or defaults to "Canvas".
+- Window chrome: backdrop = `MicaBackdrop` on Win11, `AcrylicBackdrop` fallback.
+- Persistence: position/size remembered across sessions (per existing `CanvasWindow` settings keys; reuse where possible).
+
+### 9.2 Threading
+
+All renderer mutation runs on the UI dispatcher (`DispatcherQueue.GetForCurrentThread()`). The router accepts pushes from any thread and posts via `TryEnqueue`.
+
+### 9.3 Reset
+
+`canvas.a2ui.reset` (already wired through `A2UIResetRequested`) → `A2UIRouter.ResetAll()` → dispose every `SurfaceHost`, clear stores, re-show empty placeholder.
+
+## 10. Security model
+
+- **Catalog-strict.** Component types are baked in at compile time. There is no JS, no HTML escape, no `eval`. Unknown types render a placeholder.
+- **URL allowlist for media.** `Image`, `Video`, `AudioPlayer` URL fetches go through a single `MediaResolver` that:
+  - Allows `https://` from a configurable allowlist (default: empty until set by the agent's surface theme/manifest).
+  - Allows `data:image/png|jpeg|webp` up to 2 MiB.
+  - Rejects everything else; renders broken-image glyph.
+- **Action context scoping.** `context` includes only data model paths the source component declares it reads (`dataBinding`), preventing accidental leak of unrelated form state.
+- **No file system or process access** from inside a surface. Those go through other capabilities (`system.run`, `screen.*`) which already have their own approval flow.
+- **Logging.** Each inbound message is logged at Info with surface ID + component count; PII fields in the data model SHOULD be redacted at log time using a path denylist (`/password`, `/secret*`, `/token`).
+
+## 11. Telemetry
+
+Mirror what `CanvasCapability` already logs:
+
+- `a2ui.push` (count, jsonl byte length, surface IDs touched, render time ms)
+- `a2ui.action` (surface ID, action name, queue latency)
+- `a2ui.unknown_component` (type name) — to drive catalog upgrades
+- `a2ui.media_blocked` (URL scheme/host) — to tune the allowlist
+
+## 12. Testing
+
+- **Unit:** schema validation, JSON pointer apply, action serialization, component-to-XAML mapping per type.
+- **Visual regression:** golden images per component using WinAppDriver or a snapshot harness — gate on hash + tolerance.
+- **Spec conformance:** drive the renderer with the official v0.8 conformance fixtures from `vendor/a2ui/specification/0.8/eval/` (reused from the openclaw monorepo) and assert action outputs match expected.
+- **Stress:** 10k component surface, 1k updateComponents/sec → renderer must not block the UI thread > 16 ms p95.
+- **Parity:** record the JSONL stream of an existing Lit-rendered openclaw surface, replay through the WinUI renderer, diff screenshots.
+
+## 13. Phasing
+
+| Phase | Scope | Exit criteria |
+|---|---|---|
+| **0 — Spike** | `Text`, `Column`, `Button` only; one surface; no data model | Single button click round-trips to agent |
+| **1 — Catalog parity** | All v0.8 standard catalog types; data model + bindings; modal/tabs | Full conformance fixtures pass |
+| **2 — Polish** | Theming, transitions, focus management, accessibility (Narrator), keyboard nav | A11y audit clean; UX review against Lit version |
+| **3 — Coexistence** | Native window default; WebView2 path retained behind `--canvas=web` flag for parity testing | No regressions in WebView2 path |
+| **4 — v0.9 migration** | Bidirectional messages, modular schemas, prompt-first | Tracks Google A2UI v0.9 release |
+
+## 14. Open questions
+
+1. **Window count.** One A2UI window with tabs for multiple surfaces, or one window per surface? Lit version uses one host with multiple stacked surfaces — propose mirroring that.
+2. **Component overrides.** Should we expose a hook for downstream apps (e.g., a future enterprise OpenClaw fork) to swap in custom renderers? Catalog-strict v1 says no, but the seam is cheap to add.
+3. **Theme negotiation.** Should the agent be told "I'm a native WinUI client, prefer Fluent tokens" via `clientCapabilities`? Useful if the agent is generating themes — and is the v0.8 mechanism for this (`a2ui_client_capabilities_schema.json`).
+4. **Animation budget.** A2UI doesn't specify transitions. Define a small set (fade, slide) and apply automatically on `updateComponents`, or stay still and let the agent ask?
+5. **Image caching.** Per-surface, per-process, or persistent? Persistent risks staleness; per-surface risks repeated fetches.
+
+## 15. References
+
+- A2UI v0.8 spec: <https://a2ui.org/specification/v0.8-a2ui/>
+- v0.8 JSON schemas (vendored): `openclaw/vendor/a2ui/specification/0.8/json/`
+- Reference Lit renderer: `openclaw/vendor/a2ui/renderers/lit/`
+- Current Windows node A2UI bridge: `src/OpenClaw.Tray.WinUI/Windows/CanvasWindow.xaml.cs` (`EnsureA2UIHostAsync`, `BuildA2UIMessageScript`)
+- Current capability surface: `src/OpenClaw.Shared/Capabilities/CanvasCapability.cs`
+- Android handler (good reference for v0.8 validation rules): `openclaw/apps/android/.../A2UIHandler.kt`

--- a/docs/MCP_MODE.md
+++ b/docs/MCP_MODE.md
@@ -18,7 +18,7 @@ The implementation is structured so that **adding a new node capability automati
 
 ## Non-goals (for this iteration)
 
-- **No authentication.** Loopback bind is the access control. The endpoint is unreachable from any other machine. We will revisit when we want remote MCP, multiple users on one box, or shared dev VMs.
+- **No remote authentication.** Loopback bind + Origin/Host checks keep the endpoint unreachable from any other machine. A local bearer token guards against untrusted local processes on the same box (see [Authentication](#authentication) below). We will revisit ACLs / multi-user when we want remote MCP, multiple users on one box, or shared dev VMs.
 - **No SSE / streaming.** Plain JSON-RPC request/response is enough for the synchronous capabilities we have today.
 - **No per-tool input schemas.** Capabilities don't expose schemas; MCP `inputSchema` is permissive (`{type: "object", additionalProperties: true}`). When/if `INodeCapability` grows a schema property, the MCP bridge picks it up with no other changes.
 - **No port configuration UI.** Default `8765` is hardcoded. Easy to lift into `SettingsManager` later.
@@ -74,6 +74,22 @@ The bridge takes a `Func<IReadOnlyList<INodeCapability>>` rather than a snapshot
 `OpenClaw.Shared/Mcp/McpHttpServer.cs` is `System.Net.HttpListener` bound to `http://127.0.0.1:8765/`. Loopback-only by construction; not reachable from any other machine even with firewall holes. A defensive `IPAddress.IsLoopback` check on each request acts as belt-and-suspenders.
 
 `GET /` returns a friendly text probe. `POST /` is JSON-RPC. Anything else → `405`.
+
+## Authentication
+
+The HTTP transport requires a bearer token on every `POST`. Defense-in-depth on top of loopback bind + Origin/Host checks: if an attacker can run code in *any* local user context they can reach `127.0.0.1:8765`, so we don't want the listener to be open-by-construction.
+
+**Where the token lives.** `%APPDATA%\OpenClawTray\mcp-token.txt`. The exact path is composed by `NodeService.McpTokenPath` from `SettingsManager.SettingsDirectoryPath`, so the test-suite override `OPENCLAW_TRAY_DATA_DIR` isolates the token file too. The file inherits the parent directory's ACL — by default only the current user (and SYSTEM/Administrators) can read it.
+
+**When it's created.** Lazily, on the first `NodeService.StartMcpServer()` call — i.e. the first time the user enables Local MCP Server in Settings and saves. **Until that toggle has been on at least once, the file does not exist.** This trips up users who try to grab the token before flipping the switch.
+
+**How long it is.** 32 bytes of CSPRNG output, base64url-encoded with padding stripped → **43 ASCII characters** (~256 bits of entropy). See `McpAuthToken.Generate()`.
+
+**Lifetime.** The token is **persistent across tray restarts**. It's only regenerated if the file is deleted or its contents are emptied. There is no automatic rotation.
+
+**On the wire.** Every `POST /` must carry `Authorization: Bearer <token>`. Missing or wrong token → `401 Unauthorized` with no body. `GET /` is unauthenticated (it's just a "yes I'm here" probe).
+
+**How users find it.** Settings → Developer Mode → MCP section shows the live token (masked, with Reveal/Copy buttons) and the storage path. For agents that read from disk (Claude Code, custom scripts), pointing them at `McpTokenPath` is preferable to embedding the token in their prompt or config — the path is stable, the token is a secret. For agents that only accept literal bearer values in config (Claude Desktop, Cursor), use Copy.
 
 ### Settings model
 
@@ -211,7 +227,7 @@ curl -X POST http://127.0.0.1:8765/ -H "Content-Type: application/json" -d '{"js
 These are reasonable next steps but explicitly out of scope for the initial implementation:
 
 1. **Per-tool input schemas.** Add an `IReadOnlyDictionary<string, JsonElement> InputSchemas` (or per-command descriptor) to `INodeCapability`. The MCP bridge's `HandleToolsList` picks them up automatically. Until then, MCP clients see permissive schemas and the agent has to figure out arg shapes from descriptions and trial-and-error.
-2. **Authentication.** Bearer token in the `Authorization` header, copied from a Settings button. Token rotates on tray restart. Stored in `%LOCALAPPDATA%\OpenClawTray\` like the device key.
+2. ~~**Authentication.**~~ Implemented. See [Authentication](#authentication) below.
 3. **Streamable HTTP / SSE.** For long-running tools (`screen.record`, future `audio.transcribe`), MCP supports streaming progress. The bridge needs to learn about it and the HTTP server needs to optionally upgrade.
 4. **Resource and prompt support.** MCP has `resources/*` and `prompts/*` methods we currently no-op. Notifications, recent activity, channel state could be modeled as MCP resources.
 5. **Configurable port.** Move `McpDefaultPort` into `SettingsManager`. Probably also pick a free port at startup if the default is in use, and surface the actual port in the Settings UI.

--- a/docs/a2ui/README.md
+++ b/docs/a2ui/README.md
@@ -49,7 +49,7 @@ release; v0.9 exists as a draft.
 | Markdown in `Text` | ✓ (sandboxed iframe for HTML, escaped code) | ✗ (plain text only) | Spec is silent |
 | Modal | `<dialog>` w/ `showModal()` | `ContentDialog` (native) | Spec leaves shape open |
 | List virtualization | ✗ (StackPanel-style, all-at-once) | ✓ `ItemsRepeater` + cached child template | Spec calls for it |
-| URL safety / SSRF | None — passes URLs through to `<img>`/`<video>` | DNS-rebinding defense via `SocketsHttpHandler.ConnectCallback` + allowlist | Spec is silent (deferred) |
+| URL safety / SSRF | None — passes URLs through to `<img>`/`<video>` | HTTPS+allowlist for `Image`/`Video`/`AudioPlayer`; DNS-rebinding pin via `SocketsHttpHandler.ConnectCallback` on `Image` only — `Video`/`AudioPlayer` hand the URI to `MediaSource.CreateFromUri`, which re-resolves at playback | Spec is silent (deferred) |
 | Secret redaction | ✗ | ✓ denylist (`password`, `secret`, `token`) + registered paths | Spec is silent |
 | Action context scoping | Caller's responsibility | Explicit `dataBinding` + implicit walk + secret filter | Spec defines `context[]` only |
 | Test coverage | One model unit test; no per-component | Render matrix, scale test, security tests, integration smoke | — |

--- a/docs/a2ui/README.md
+++ b/docs/a2ui/README.md
@@ -1,0 +1,70 @@
+# A2UI v0.8 — Overview & Implementation Grading
+
+This folder is the entry point for everything A2UI in this repo. It captures
+the v0.8 specification, the standard catalog, and a side-by-side grading of
+two implementations:
+
+- **Lit reference** in `C:\Users\andersonch\Code\openclaw` (web components,
+  rendered in a browser via the OpenClaw canvas host).
+- **Native WinUI** in this repo (`src/OpenClaw.Tray.WinUI/A2UI/`,
+  branch `feat/a2ui-native-winui`).
+
+The native WinUI design doc that predates this overview lives at
+[`../A2UI_NATIVE_WINUI.md`](../A2UI_NATIVE_WINUI.md); this folder
+supersedes the parts of that doc that describe the spec and adds the
+grading.
+
+## Contents
+
+| Doc | What's in it |
+| --- | --- |
+| [`protocol.md`](./protocol.md) | Wire protocol — envelopes, JSONL, A2A extension, capability negotiation, lifecycle |
+| [`components.md`](./components.md) | Standard catalog — every component, every property, type, enum, behavior |
+| [`data-and-actions.md`](./data-and-actions.md) | A2UIValue tagged union, data model & paths, action dispatch, security |
+| [`grading.md`](./grading.md) | Side-by-side scoring of Lit vs WinUI vs spec, with file:line citations |
+
+## Spec source of truth
+
+| Document | URL |
+| --- | --- |
+| Protocol v0.8 | https://a2ui.org/specification/v0.8-a2ui/ |
+| A2A extension v0.8 | https://a2ui.org/specification/v0.8-a2a-extension/ |
+| Standard catalog (JSON) | https://a2ui.org/specification/v0_8/standard_catalog_definition.json |
+| Source / schemas | https://github.com/google/A2UI |
+| Evolution v0.8 → v0.9 | https://a2ui.org/specification/v0.9-evolution-guide/ |
+
+These pages were captured 2026-04-27. v0.8 is the **stable / public preview**
+release; v0.9 exists as a draft.
+
+## TL;DR — how the two implementations stack up
+
+| Area | Lit (OpenClaw) | WinUI (this repo) | Spec |
+| --- | --- | --- | --- |
+| Component coverage | 18/18 | 18/18 | 18 in standard catalog |
+| Component property completeness | ~85% (4 documented TODOs) | ~95% | — |
+| Streaming / JSONL parser | Per-line, lenient | Per-line, lenient + size caps | line-delimited JSON |
+| Data model paths | Custom JSON-pointer-ish + auto-parse | Strict RFC 6901 | Path strings, format underspecified |
+| Action transport | DOM `CustomEvent` bubbling | Debounced dispatcher → gateway via `agent.request` | Client-to-server A2A `userAction` |
+| Bi-directional binding | ✓ via `processor.setData` | ✓ via `DataModelStore.Write` | Spec is silent — both impls add it |
+| Markdown in `Text` | ✓ (sandboxed iframe for HTML, escaped code) | ✗ (plain text only) | Spec is silent |
+| Modal | `<dialog>` w/ `showModal()` | `ContentDialog` (native) | Spec leaves shape open |
+| List virtualization | ✗ (StackPanel-style, all-at-once) | ✓ `ItemsRepeater` + cached child template | Spec calls for it |
+| URL safety / SSRF | None — passes URLs through to `<img>`/`<video>` | DNS-rebinding defense via `SocketsHttpHandler.ConnectCallback` + allowlist | Spec is silent (deferred) |
+| Secret redaction | ✗ | ✓ denylist (`password`, `secret`, `token`) + registered paths | Spec is silent |
+| Action context scoping | Caller's responsibility | Explicit `dataBinding` + implicit walk + secret filter | Spec defines `context[]` only |
+| Test coverage | One model unit test; no per-component | Render matrix, scale test, security tests, integration smoke | — |
+
+The detailed scorecard with deductions per category is in
+[`grading.md`](./grading.md).
+
+## How to use this folder
+
+- If you're **adding a renderer** for a component: read
+  [`components.md`](./components.md) for the spec'd properties, then
+  [`grading.md`](./grading.md) for known WinUI gaps.
+- If you're **wiring a transport** (gateway, MCP bridge, etc.): read
+  [`protocol.md`](./protocol.md) and the `data-and-actions.md` action
+  section.
+- If you're **reviewing a PR that touches A2UI**: skim
+  [`grading.md#known-deviations-by-category`](./grading.md#known-deviations-by-category)
+  to see which deviations are intentional (good) vs known gaps (bad).

--- a/docs/a2ui/components.md
+++ b/docs/a2ui/components.md
@@ -1,0 +1,318 @@
+# A2UI v0.8 — Standard Catalog (Components)
+
+Source of truth: <https://a2ui.org/specification/v0_8/standard_catalog_definition.json>.
+
+The v0.8 standard catalog defines **18 components** across three loose
+categories: containers, display, interactive. A v0.8-conformant client
+MUST recognize all 18 and either render them or fall back to an "unknown"
+placeholder for catalog-strict mode.
+
+Each section below is the spec — required properties first, optional
+after, with enums spelled out. Where the WinUI or Lit impl has a known gap
+or improvement, it's flagged inline so this doc doubles as a quick lookup
+when wiring a new component. Detailed grading is in
+[`grading.md`](./grading.md).
+
+Notation: `BoundValue` means an [`A2UIValue`](./data-and-actions.md#a2uivalue)
+tagged union — typically `{ literalString }` or `{ path }`. `Children`
+means `{ explicitList: string[] }` or `{ template: { dataBinding, componentId } }`.
+
+---
+
+## Containers
+
+### `Row`
+Horizontal layout container.
+
+| Property | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `children` | `Children` | ✓ | `explicitList` or `template` |
+| `distribution` | enum | | `start` \| `center` \| `end` \| `spaceBetween` \| `spaceAround` \| `spaceEvenly` |
+| `alignment` | enum | | `start` \| `center` \| `end` \| `stretch` |
+
+**Behavior**: lays children left-to-right; cross-axis = vertical alignment.
+
+> WinUI: `StackPanel` (horizontal); `distribution` collapsed onto WinUI
+> `HorizontalAlignment` — `spaceBetween`/`spaceAround`/`spaceEvenly` all
+> map to `Stretch` (justify-content not natively available). Wrap to next
+> row not implemented.
+> Lit: full distribution support via CSS flex.
+
+### `Column`
+Vertical layout container. Same property set as `Row`, swapping axes.
+
+### `List`
+Scrollable list of children.
+
+| Property | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `children` | `Children` | ✓ | |
+| `direction` | enum | | `vertical` (default) \| `horizontal` |
+| `alignment` | enum | | `start` \| `center` \| `end` \| `stretch` |
+
+**Behavior**: virtualization-friendly; spec calls for the client to
+realize only viewport children when possible.
+
+> WinUI: `ItemsRepeater` w/ `StackLayout`, virtualized, child-element
+> cache keyed by component id (preserves data-binding subscriptions
+> across recycling).
+> Lit: builds all children up-front (no virtualization).
+> Lit: `template` form for List is partially honored only because all
+> three list-bearing components share the same children resolver. WinUI
+> only supports `explicitList` today.
+
+### `Card`
+Single-child container with elevation/border treatment.
+
+| Property | Type | Required |
+| --- | --- | --- |
+| `child` | component-id (string) | ✓ |
+
+> WinUI: `Border` w/ `CardBackgroundFillColorDefaultBrush`,
+> `theme.CornerRadius`, padding = `theme.Spacing * 2`.
+> Lit: slot-based wrap; CSS-driven elevation.
+
+### `Tabs`
+Tabbed container.
+
+| Property | Type | Required |
+| --- | --- | --- |
+| `tabItems[]` | array | ✓ |
+| `tabItems[].title` | `BoundValue<string>` | ✓ |
+| `tabItems[].child` | component-id | ✓ |
+
+> WinUI: `TabView`, close buttons disabled, no reorder/drag.
+> Lit: button strip + content region; tracks `selected` index in state.
+
+### `Modal`
+Click-to-open dialog.
+
+| Property | Type | Required |
+| --- | --- | --- |
+| `entryPointChild` | component-id | ✓ |
+| `contentChild` | component-id | ✓ |
+
+**Behavior**: render `entryPointChild` inline; on user interaction (e.g.,
+click), open a modal containing `contentChild`. Spec leaves "what closes
+the modal" open; both impls rely on platform dismissal (Esc, click-out).
+
+> WinUI: `ContentDialog` triggered by wrapping `entryPointChild` in a
+> transparent `Button`. Native modal semantics.
+> Lit: `<dialog>` element + `showModal()`.
+
+### `Divider`
+Visual separator.
+
+| Property | Type | Required |
+| --- | --- | --- |
+| `axis` | enum | | `horizontal` (default) \| `vertical` |
+
+> WinUI: 1px `Rectangle`, `SystemControlForegroundBaseLowBrush`.
+> Lit: `<hr>`. **Gap**: Lit also exposes `thickness` and `color` in
+> types but doesn't apply them (root.ts:317 TODO).
+
+---
+
+## Display
+
+### `Text`
+Text display.
+
+| Property | Type | Required |
+| --- | --- | --- |
+| `text` | `BoundValue<string>` | ✓ |
+| `usageHint` | enum | | `h1`–`h5`, `caption`, `body` |
+
+> WinUI: `TextBlock` w/ Fluent theme styles (`TitleLarge`, `Subtitle`,
+> `BodyStrong`, `Caption`, `Body`). Plain text only.
+> Lit: **renders Markdown** via `markdown-it`. HTML blocks sandboxed in
+> `<iframe sandbox="">`; code blocks escaped. This is _beyond_ spec —
+> see [`grading.md`](./grading.md#text-markdown-divergence) for whether
+> that's a feature or a foot-gun.
+
+### `Image`
+
+| Property | Type | Required | Enum |
+| --- | --- | --- | --- |
+| `url` | `BoundValue<string>` | ✓ | |
+| `altText` | `BoundValue<string>` | | |
+| `fit` | enum | | `contain` \| `cover` \| `fill` \| `none` \| `scale-down` |
+| `usageHint` | enum | | `icon` \| `avatar` \| `smallFeature` \| `mediumFeature` \| `largeFeature` \| `header` |
+
+> WinUI: `Image`; `usageHint` maps to fixed pixel sizes (24/40/80/160/240/full).
+> Avatar wraps in `Border` w/ circular `CornerRadius`. SVG via
+> `SvgImageSource` w/ 8s timeout. URLs gated by `MediaResolver` allowlist
+> + DNS-rebinding defense.
+> Lit: `<img>` directly; **no URL filtering** — `data:` and other schemes
+> pass through.
+
+### `Icon`
+
+| Property | Type | Required |
+| --- | --- | --- |
+| `name` | `BoundValue<string>` | ✓ |
+
+The 48 supported icon names (canonical enum):
+
+```
+accountCircle, add, arrowBack, arrowForward, attachFile, calendarToday,
+call, camera, check, close, delete, download, edit, event, error,
+favorite, favoriteOff, folder, help, home, info, locationOn, lock,
+lockOpen, mail, menu, moreVert, moreHoriz, notificationsOff,
+notifications, payment, person, phone, photo, print, refresh, search,
+send, settings, share, shoppingCart, star, starHalf, starOff, upload,
+visibility, visibilityOff, warning
+```
+
+> WinUI: `FontIcon` over Segoe Fluent Icons (MDL2). Unknown names →
+> `help` glyph; `moreHoriz` reuses `moreVert` (no canonical horizontal
+> ellipsis in MDL2). Logs once per unmapped name per process.
+> Lit: CSS background-image sprite; lowercases CamelCase to snake_case
+> at lookup (icon.ts:53).
+
+### `Video`
+
+| Property | Type | Required |
+| --- | --- | --- |
+| `url` | `BoundValue<string>` | ✓ |
+
+> WinUI: `MediaPlayerElement` w/ transport controls.
+> Lit: `<video controls>`.
+
+### `AudioPlayer`
+
+| Property | Type | Required |
+| --- | --- | --- |
+| `url` | `BoundValue<string>` | ✓ |
+| `description` | `BoundValue<string>` | | |
+
+> WinUI: `MediaPlayerElement` w/ `description` rendered above as
+> `Caption`.
+> Lit: `<audio controls>`; **`description` is ignored** (audio.ts).
+
+---
+
+## Interactive
+
+### `Button`
+
+| Property | Type | Required |
+| --- | --- | --- |
+| `child` | component-id | ✓ |
+| `action` | `Action` object | ✓ |
+| `primary` | bool | | |
+
+`Action` shape:
+```json
+{
+  "name": "submit",
+  "context": [
+    { "key": "email", "value": { "path": "/form/email" } },
+    { "key": "kind",  "value": { "literalString": "primary" } }
+  ]
+}
+```
+
+> WinUI: `Button`; `primary` → `AccentButtonStyle`; click raises
+> `A2UIAction` through the dispatcher (see
+> [`data-and-actions.md`](./data-and-actions.md#actions)).
+> Lit: `<button>`; click dispatches a DOM `CustomEvent`.
+
+### `CheckBox`
+
+| Property | Type | Required |
+| --- | --- | --- |
+| `label` | `BoundValue<string>` | ✓ |
+| `value` | `BoundValue<bool>` | ✓ |
+
+> Both impls: bi-directional binding — toggle writes back to the
+> `value.path` data-model location. Spec is silent on write-back.
+
+### `TextField`
+
+| Property | Type | Required | Enum |
+| --- | --- | --- | --- |
+| `label` | `BoundValue<string>` | ✓ | |
+| `text` | `BoundValue<string>` | | |
+| `textFieldType` | enum | | `shortText` (default) \| `longText` \| `number` \| `date` \| `obscured` |
+| `validationRegexp` | string | | |
+
+> WinUI: `TextBox` (or `PasswordBox` if `obscured`); `obscured` paths
+> auto-marked as secrets. `InputScope` set per type. **`validationRegexp`
+> not enforced**.
+> Lit: `<input>` / `<textarea>`. **`validationRegexp` not enforced**
+> (root.ts:367 TODO).
+
+### `DateTimeInput`
+
+| Property | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `value` | `BoundValue<string>` | ✓ | ISO 8601 |
+| `enableDate` | bool | | |
+| `enableTime` | bool | | |
+
+> WinUI: `CalendarDatePicker` + `TimePicker`; ISO-8601 round-trip.
+> Lit: `<input type="date|time|datetime-local">`. **`outputFormat`
+> noted in code but ignored** (datetime-input.ts:159 TODO).
+
+### `MultipleChoice`
+
+| Property | Type | Required | Enum |
+| --- | --- | --- | --- |
+| `selections` | `BoundValue<array>` (or `path`) | ✓ | |
+| `options[]` | array | ✓ | each: `{ label: BoundValue<string>, value: string }` |
+| `maxAllowedSelections` | integer | | |
+| `variant` | enum | | `checkbox` \| `chips` |
+| `filterable` | bool | | |
+
+> WinUI: `ComboBox` (single) or `ListView` (multi). When
+> `maxAllowedSelections == 1` it writes a scalar to the path (not a
+> 1-element array) — back-compat reads tolerate either. **`variant` and
+> `filterable` not honored**.
+> Lit: `<select multiple>`. **`maxAllowedSelections` not enforced**
+> (root.ts:334 TODO); selections array resolution incomplete
+> (multiple-choice.ts:87–103).
+
+### `Slider`
+
+| Property | Type | Required |
+| --- | --- | --- |
+| `label` | `BoundValue<string>` | | |
+| `value` | `BoundValue<number>` | ✓ |
+| `minValue` | number | | |
+| `maxValue` | number | | |
+
+> WinUI: `Slider`, defaults min=0/max=100/step=1. Bi-directional bind.
+> Lit: `<input type="range">`. Bi-directional bind.
+
+---
+
+## Catalog-strict mode
+
+Both implementations must reject **anything not in the 18 above** by
+rendering a placeholder, not by throwing. This is one of the few
+"MUST" requirements in the spec:
+
+> The full set of available component types and their properties is
+> defined by a Catalog Schema, not in the core protocol schema.
+
+> WinUI: `UnknownRenderer` — orange-bordered placeholder w/ warning
+> icon and component name. Telemetry event fired.
+> Lit: walks a `componentRegistry`; allows custom components when
+> `enableCustomElements` flag is set (extension beyond spec).
+
+## Catalog-level styles (theme tokens)
+
+Each catalog optionally declares `styles`:
+
+| Token | Type |
+| --- | --- |
+| `font` | string (font family) |
+| `primaryColor` | hex `#RRGGBB` |
+
+> WinUI: `A2UITheme.Parse()` reads these plus nested
+> `colors.{accent,background,foreground,card}`,
+> `typography.fontFamily`, `radius`, `spacing`. Applied to the surface
+> Grid resource scope (not global).
+> Lit: derives a `--p-0` … `--p-100` palette via CSS `color-mix` from
+> `primaryColor`.

--- a/docs/a2ui/components.md
+++ b/docs/a2ui/components.md
@@ -176,7 +176,11 @@ visibility, visibilityOff, warning
 | --- | --- | --- |
 | `url` | `BoundValue<string>` | ✓ |
 
-> WinUI: `MediaPlayerElement` w/ transport controls.
+> WinUI: `MediaPlayerElement` w/ transport controls. URL gated by
+> `MediaResolver` HTTPS+allowlist. **No DNS-rebinding pin** — the OS
+> media stack does its own DNS lookup at playback time, so the
+> hostname-allowlist is the load-bearing defense (image fetches use a
+> separate, safer path that does pin).
 > Lit: `<video controls>`.
 
 ### `AudioPlayer`
@@ -187,7 +191,8 @@ visibility, visibilityOff, warning
 | `description` | `BoundValue<string>` | | |
 
 > WinUI: `MediaPlayerElement` w/ `description` rendered above as
-> `Caption`.
+> `Caption`. URL gated by `MediaResolver` HTTPS+allowlist; same
+> playback-time DNS caveat as `Video`.
 > Lit: `<audio controls>`; **`description` is ignored** (audio.ts).
 
 ---

--- a/docs/a2ui/data-and-actions.md
+++ b/docs/a2ui/data-and-actions.md
@@ -1,0 +1,190 @@
+# A2UI v0.8 — Data Binding & Actions
+
+## A2UIValue
+
+Almost every property on a component is an `A2UIValue` — a tagged union of
+literal types and a path into the data model.
+
+```jsonc
+// All of these are valid:
+{ "literalString": "Hello" }
+{ "literalNumber": 42 }
+{ "literalBoolean": true }
+{ "literalArray": ["a", "b", "c"] }   // array-of-string only
+{ "path": "/user/name" }              // bind to data-model location
+
+// "Implicit initialization" (literal + path together):
+{ "literalString": "default", "path": "/form/title" }
+// → on first resolve, the client writes "default" to /form/title,
+//   then binds. After that it's a path binding.
+```
+
+The spec does **not** enumerate `literalArray<number>` or `literalArray<bool>`
+— string arrays are the only explicit array literal in v0.8.
+
+### Resolution at runtime
+
+When a component renders or re-renders, each `A2UIValue` property is
+resolved:
+
+1. If a literal is present → use it. (Casting is impl-defined; both
+   impls coerce numbers ↔ strings as needed for display.)
+2. Else if `path` is present → look up the value in the surface's data
+   model and use it.
+3. Else → property is "unset" (component decides default behavior).
+
+### Path syntax
+
+Paths are JSON-pointer-_ish_ strings (`/foo/bar/0`). The spec doesn't
+formally cite RFC 6901; both impls treat them similarly but differ at
+edges:
+
+- **WinUI**: strict RFC 6901 via `DataModelStore.SetByPointer` /
+  `Read` (`src/OpenClaw.Tray.WinUI/A2UI/DataModel/DataModelStore.cs`).
+- **Lit**: relative paths supported (`.` = current `dataContextPath`,
+  bare names resolve relative to context); auto-parses `valueString`
+  fields that look like JSON (`vendor/a2ui/.../model-processor.ts:198–225`).
+  This is convenient but can be surprising — a string `"[1,2]"` becomes
+  an array.
+
+## Data model
+
+A surface's data model is a JSON tree. `dataModelUpdate` envelopes patch
+into this tree:
+
+```jsonc
+{ "dataModelUpdate": {
+    "surfaceId": "main",
+    "path": "/user",
+    "contents": [
+      { "key": "name",  "valueString": "Ada" },
+      { "key": "age",   "valueNumber": 36 },
+      { "key": "tags",  "valueArray":  [
+          { "valueString": "admin" }, { "valueString": "beta" }
+      ]},
+      { "key": "address","valueMap": [
+          { "key": "city", "valueString": "London" }
+      ]}
+    ]
+}}
+```
+
+Behaviors **not nailed down by the spec** that matter in practice:
+
+| Question | Lit | WinUI |
+| --- | --- | --- |
+| Replace vs. merge `valueMap`? | Merge per leaf | Merge per leaf (RFC 6901 set) |
+| Notification granularity? | Coalesced via Lit signals | Coalesced via subscription set |
+| Per-update size caps? | None | 1024 entries / update; 256-char keys; 64 KiB strings; 32-deep maps |
+
+### Subscriptions
+
+Components watch the model so they can re-render when the agent or another
+component writes:
+
+- **Lit**: `@lit-labs/signals`; the root applies an `effect()` to the
+  `childComponents` signal so the light-DOM tree re-renders when the
+  signal fires (`vendor/a2ui/.../ui/root.ts:39, 85`).
+- **WinUI**: `DataModelObservable.Subscribe(path, callback)` returns
+  `IDisposable`; renderers call `ctx.WatchValue(componentId, name, value, callback)`
+  which installs a per-component subscription that's torn down when the
+  component is recycled (`src/OpenClaw.Tray.WinUI/A2UI/Rendering/IComponentRenderer.cs`).
+
+## Actions
+
+A `Button.action` (and other action-bearing properties) declares
+**what to send to the agent**:
+
+```jsonc
+{
+  "name": "submit",
+  "context": [
+    { "key": "email",   "value": { "path": "/form/email" } },
+    { "key": "kind",    "value": { "literalString": "primary" } }
+  ]
+}
+```
+
+When the user clicks, the client must:
+
+1. Resolve every `context[].value` against the data model right now.
+2. Build a `userAction` event:
+   ```jsonc
+   { "userAction": {
+       "name": "submit",
+       "surfaceId": "main",
+       "sourceComponentId": "btn-1",
+       "timestamp": "2026-04-27T17:05:00Z",
+       "context": { "email": "ada@example.com", "kind": "primary" }
+   }}
+   ```
+3. Send it back via A2A (the spec is explicit: **not** on the SSE/JSONL
+   stream).
+
+### What "context" should and shouldn't contain
+
+The spec is silent on **scoping** — i.e., is it OK for a Button to
+declare `context: [{ key: "all", value: { path: "/" } }]` and exfiltrate
+the entire data model?
+
+The two impls take very different positions here:
+
+- **Lit**: passes `action` and `dataContextPath` straight through in a
+  DOM `CustomEvent`. The host (canvas) is responsible for resolving and
+  sanitizing — there's no defense at the renderer.
+- **WinUI**: `RenderContext.BuildActionContext()` (`IComponentRenderer.cs:183–249`)
+  collects an **allowed-paths set** from either:
+  - explicit `dataBinding: [ { path: "..." } ]` on the component, or
+  - implicit walk over component properties' own `A2UIValue.path` values.
+
+  Each declared `context[].path` is then `IsAllowedPath`-filtered (exact
+  match or ancestor with `/` boundary). Secret paths (registered or
+  denylisted by substring) are excluded unless explicitly allowed.
+
+This is one of the most consequential **good deviations** in the WinUI
+impl — see [`grading.md#security-deviations`](./grading.md#security-deviations).
+
+### Transport
+
+After context is built, both impls hand off to a transport:
+
+- **Lit**: dispatches `StateEvent<"a2ui.action">` (CustomEvent, bubbling,
+  composed). Listener wires up however the embedding app wants.
+- **WinUI**: `ActionDispatcher` (`src/OpenClaw.Tray.WinUI/A2UI/Actions/IActionSink.cs`):
+  - **Debounces** by `surfaceId|sourceComponentId|name` (200 ms window).
+  - **Single-flight gate** so a fallback dequeue can't race a fresh send.
+  - **Fallback queue** when no transport is connected.
+  - Tries each registered transport (`GatewayActionTransport`,
+    `LoggingActionTransport`) until one delivers.
+
+For the gateway path, `GatewayActionTransport`
+(`src/OpenClaw.Tray.WinUI/A2UI/Actions/GatewayActionTransport.cs`) emits
+an `agent.request` node event:
+
+```jsonc
+{
+  "message": "CANVAS_A2UI action=submit session=main surface=main component=btn-1 host=… instance=… ctx=… default=update_canvas",
+  "sessionKey": "main",
+  "thinking": "low",
+  "deliver": false,
+  "key": "<action-id>"
+}
+```
+
+`AgentMessageFormatter` is a deliberate byte-for-byte port of the Android
+node's formatter — the gateway parses tags identically across platforms.
+
+## Security boundaries
+
+| Concern | Spec | Lit | WinUI |
+| --- | --- | --- | --- |
+| URL fetching for `Image`/`Video`/`AudioPlayer` | silent | unrestricted | allowlist + DNS rebinding defense (`MediaResolver.cs`) |
+| Unknown component types | "render placeholder, don't crash" | placeholder for spec'd missing; **registers user-supplied custom elements** if a flag is set | strict 18-only `UnknownRenderer` placeholder |
+| Markdown / HTML in `Text` | spec says plain string | parses Markdown; HTML blocks rendered in `iframe sandbox=""`; code escaped | renders as plain string |
+| Action context leakage | underspecified | passthrough — host's problem | server allowlist + secret denylist |
+| Bearer / token surfaces | n/a | n/a | MCP token shown in Settings UI w/ copy button (out-of-band) |
+| `canvas.navigate` | n/a (out of A2UI) | n/a | `HttpUrlValidator` gates URLs; user choice of "canvas" vs "browser" opener |
+
+The "Spec is silent" rows are the spots where a reviewer should keep
+their guard up — anything Lit forwards to the embedding host can become
+a vulnerability if that host doesn't apply policy.

--- a/docs/a2ui/data-and-actions.md
+++ b/docs/a2ui/data-and-actions.md
@@ -178,7 +178,7 @@ node's formatter — the gateway parses tags identically across platforms.
 
 | Concern | Spec | Lit | WinUI |
 | --- | --- | --- | --- |
-| URL fetching for `Image`/`Video`/`AudioPlayer` | silent | unrestricted | allowlist + DNS rebinding defense (`MediaResolver.cs`) |
+| URL fetching for `Image`/`Video`/`AudioPlayer` | silent | unrestricted | HTTPS+allowlist for all three; DNS-rebinding pin only on `Image` fetches (`MediaResolver.cs`'s `SocketsHttpHandler.ConnectCallback`). `Video`/`AudioPlayer` hand the validated URI to `MediaSource.CreateFromUri`, which performs its own DNS at playback — allowlist is the load-bearing defense for media. |
 | Unknown component types | "render placeholder, don't crash" | placeholder for spec'd missing; **registers user-supplied custom elements** if a flag is set | strict 18-only `UnknownRenderer` placeholder |
 | Markdown / HTML in `Text` | spec says plain string | parses Markdown; HTML blocks rendered in `iframe sandbox=""`; code escaped | renders as plain string |
 | Action context leakage | underspecified | passthrough — host's problem | server allowlist + secret denylist |

--- a/docs/a2ui/grading.md
+++ b/docs/a2ui/grading.md
@@ -1,0 +1,347 @@
+# A2UI v0.8 — Implementation Grading
+
+This grades two implementations against the v0.8 spec
+(<https://a2ui.org/specification/v0.8-a2ui/>):
+
+- **Lit reference** at `C:\Users\andersonch\Code\openclaw\vendor\a2ui\renderers\lit\src\0.8`
+- **Native WinUI** in this repo at `src/OpenClaw.Tray.WinUI/A2UI/`
+
+The Lit code looks like the canonical browser renderer the OpenClaw
+canvas host ships; the WinUI code is this repo's branch
+`feat/a2ui-native-winui`.
+
+Citations use repo-local paths. Lit paths are anchored at the OpenClaw
+checkout: `openclaw\vendor\a2ui\renderers\lit\src\0.8\`. WinUI paths are
+anchored at `src/OpenClaw.Tray.WinUI/A2UI/`.
+
+## Method
+
+For each spec area, deductions land in two buckets:
+
+- **Gap** — implementation is missing or wrong vs. spec. Letter grade penalty.
+- **Good deviation** — implementation does something the spec _doesn't say
+  to do_, but it's the correct call. Listed but doesn't penalize.
+
+Grades are A–F, separately for Lit and WinUI. There is no curving —
+"A" means it would pass a strict spec audit and a strict security
+audit; "B" means it works for normal traffic but fails under a hostile
+agent; etc.
+
+---
+
+## Scorecard
+
+| Area | Lit | WinUI | Notes |
+| --- | --- | --- | --- |
+| Component coverage (catalog completeness) | A | A | both 18/18 |
+| Component property completeness | B | A− | Lit has 4 documented TODOs; WinUI has minor distribution mappings |
+| Streaming / JSONL parsing | B | A | Lit: lenient; WinUI: lenient + size caps |
+| Data binding / `A2UIValue` | B+ | A | Lit auto-parses JSON strings (surprising); WinUI strict RFC 6901 |
+| Action transport | B | A | Lit: DOM event passthrough; WinUI: debounced + single-flight + fallback queue + gateway tag protocol |
+| Action context security | D | A | Lit punts to host; WinUI scopes to declared `dataBinding` and redacts secrets |
+| Theming | A− | A− | Equivalent power; different idioms |
+| URL safety / SSRF | F | A | Lit unrestricted; WinUI DNS-rebinding defense + allowlist |
+| Modal lifecycle | A− | A | Both work; WinUI uses native `ContentDialog` |
+| List virtualization | C | A | Lit builds all items; WinUI uses `ItemsRepeater` w/ recycling |
+| Bi-directional binding (write-back) | A | A | Both implement; spec is silent (good deviation) |
+| Markdown in `Text` | B+ | n/a | Lit's enhancement is real but increases attack surface |
+| Test coverage | D | A− | Lit: 1 model test, no per-component; WinUI: render matrix + scale + integration |
+| Spec deviations called out (good ones) | B | A | Lit's improvements partially offset its gaps |
+| **Overall** | **B−** | **A−** | |
+
+The two "A" grades have very different shapes:
+
+- **Lit** is a smaller codebase that gets the happy path right, with two
+  notable **good** deviations (Markdown rendering, bi-directional binding)
+  but several papercut **gaps** and a **non-trivial security delta**
+  inherited from a "the host will sanitize" posture.
+- **WinUI** is significantly more code, fills almost every gap, and adds
+  defenses the spec doesn't ask for. Its remaining minus comes from the
+  things it _doesn't_ do yet (List `template` mode, Row wrap, `MultipleChoice.variant`).
+
+---
+
+## Lit implementation — detailed deductions
+
+### Documented `TODO` gaps
+
+Verbatim TODOs in `vendor/a2ui/.../ui/root.ts` and component files:
+
+| Property | File:Line | Status |
+| --- | --- | --- |
+| `Divider.thickness` / `axis` / `color` | `ui/root.ts:317` | type declared, value not applied to `<hr>` |
+| `MultipleChoice.maxAllowedSelections` | `ui/root.ts:334` | accepted but not enforced |
+| `TextField.validationRegexp` | `ui/root.ts:367` | not applied to `<input>` |
+| `DateTimeInput.outputFormat` | `ui/datetime-input.ts:159` | placeholder; always uses browser format |
+| `MultipleChoice.selections` resolution | `ui/multiple-choice.ts:87–103` | logic incomplete when `selections` is path-bound |
+| `AudioPlayer.description` | `ui/audio.ts` | spec'd property silently dropped |
+
+Letter penalty: **−1 step on Component Property Completeness** (A → B).
+
+### `A2UIValue.path` resolver auto-parses JSON-shaped strings
+
+`data/model-processor.ts:198–225` detects `valueString` payloads that look
+like `{...}` or `[...]` and **silently parses them as JSON**. The intent is
+"developer convenience"; the consequence is that a string literal containing
+a `[` or `{` becomes a structured value. This is a **gap** because the spec
+distinguishes `valueString` from `valueArray`/`valueMap` precisely so the
+agent can be unambiguous. Letter penalty: **−1 step on data binding**.
+
+### URLs are passed through to the DOM
+
+`ui/image.ts:67–74` binds `<img src="${url}">` directly. There is no
+allowlist for `data:` / `javascript:` / `file:` / private-IP hosts, no
+SSRF protection, no DNS rebinding defense. The WinUI impl has all of
+these. The host **may** sanitize before forwarding URLs, but the
+renderer offers no defense in depth. Letter penalty: **−2 steps on URL
+safety** (this is the F).
+
+### Component registry allows arbitrary custom elements
+
+`vendor/a2ui/.../ui/root.ts:118–140, 441–471` lets the embedding app set
+`enableCustomElements = true` and then renders any `<component>` whose tag
+is registered in `componentRegistry`. This is **beyond spec** — useful for
+extensibility, dangerous for catalog-strict mode. **Not graded as a gap**
+since it's behind a flag, but it's worth flagging at the host level.
+
+### One unit test covers everything
+
+`vendor/a2ui/.../model.test.ts` exercises `A2uiMessageProcessor` for
+`beginRendering` and `surfaceUpdate`. There are **no per-component
+render tests, no event-dispatch tests, no markdown sanitizer tests, no
+data-binding edge-case tests**. Letter penalty: **−2 steps on test
+coverage** (D).
+
+### Good deviations
+
+- **Markdown rendering** in `Text` (`ui/text.ts`, `ui/directives/markdown.ts`).
+  HTML blocks wrapped in `<iframe sandbox="">`; code blocks escaped via
+  `sanitizer.escapeNodeText`. The spec says plain string. Whether this
+  counts as good depends on the threat model — see
+  [the Text/Markdown divergence](#text-markdown-divergence).
+- **Signal-driven re-render** via `@lit-labs/signals`. Cleaner reactivity
+  than naive `requestUpdate()`.
+- **Bi-directional binding** in `CheckBox`, `TextField`, `Slider`,
+  `DateTimeInput`. Spec is silent on write-back; both impls add it.
+
+---
+
+## WinUI implementation — detailed deductions
+
+### Property-coverage misses
+
+| Property | File:Line | Status |
+| --- | --- | --- |
+| `Row.distribution` `spaceBetween/Around/Evenly` | `Rendering/Renderers/ContainerRenderers.cs:10–32` | all three collapse to `HorizontalAlignment.Stretch` (WinUI `StackPanel` doesn't natively express justify-content) |
+| `Row.wrap` (multi-row) | n/a | not implemented; would need a custom `Panel` |
+| `List.template` mode | `Rendering/Renderers/ContainerRenderers.cs:57–159` | only `explicitList` supported |
+| `MultipleChoice.variant` (`chips`) | `Rendering/Renderers/InteractiveRenderers.cs:279–430` | always `ComboBox`/`ListView` |
+| `MultipleChoice.filterable` | same | not honored |
+| `TextField.validationRegexp` | `Rendering/Renderers/InteractiveRenderers.cs:98–199` | not enforced |
+| `Tabs` close / reorder | `Rendering/Renderers/ContainerRenderers.cs:187–235` | disabled |
+| Component `weight` | `Protocol/A2UIProtocol.cs:111–151` | parsed but not applied |
+
+Letter penalty: **−1 step on Component Property Completeness**, but
+balanced by being the only impl that fills the corresponding Lit gaps
+(`maxAllowedSelections` is enforced; `Divider.axis` is honored).
+
+### Action context scoping (the centerpiece win)
+
+`Rendering/IComponentRenderer.cs:183–249` (`BuildActionContext`):
+
+1. Collect `allowed` paths from the component's explicit `dataBinding`
+   array, or — if absent — implicitly walk every `A2UIValue.path` referenced
+   by the component's own properties.
+2. For each `action.context[]` entry, resolve only if `IsAllowedPath`
+   matches (exact or ancestor with `/` boundary).
+3. Strip secret paths via `SecretRedactor` (`Rendering/SecretRedactor.cs`):
+   - Registered paths (e.g., obscured `TextField` fields).
+   - Substring denylist: `password`, `secret`, `token`.
+
+This blocks the trivial "exfiltrate the whole tree" attack without
+requiring the host to know about A2UI internals. The Lit impl can't
+do this because it dispatches `action` straight through.
+
+### URL safety — DNS rebinding defense
+
+`Rendering/MediaResolver.cs:57–95`:
+
+```csharp
+new SocketsHttpHandler {
+    ConnectCallback = async (ctx, ct) => {
+        var addresses = await Dns.GetHostAddressesAsync(ctx.DnsEndPoint.Host, ct);
+        foreach (var ip in addresses) {
+            if (!IsPublicAddress(ip)) throw ...;   // loopback, RFC1918, link-local, multicast
+        }
+        // connect to resolved IP, not hostname (no second DNS lookup)
+    },
+    PooledConnectionLifetime = TimeSpan.FromMinutes(2),
+};
+```
+
+Plus an allowlist gate in `IsAllowed(url)`. Closes a TOCTOU window
+between an allowlist check and the actual TCP connect. The Lit impl
+does none of this.
+
+### Streaming hardening
+
+`Protocol/A2UIProtocol.cs:176–367` and `Hosting/A2UIRouter.cs`:
+
+| Cap | Value |
+| --- | --- |
+| Max line length | 1 MiB |
+| Max components per surface | 2000 |
+| Max entries per `dataModelUpdate` | 1024 |
+| Max key length | 256 |
+| Max string value | 64 KiB |
+| Max `valueMap` depth | 32 |
+| Max render depth | 64 |
+
+All limits log + drop, never throw. Cycle detection in `_renderingIds`
+prevents id-loops in malformed surfaces.
+
+### Component diff on `surfaceUpdate`
+
+`Hosting/SurfaceHost.cs:ApplyComponents` compares incoming defs (name,
+weight, properties JSON-string) against the previous set and **skips
+rebuild if unchanged**. Effect: a re-emitted surface preserves
+`TextBox` caret position, scroll offset, and `Tabs` selection. The
+spec calls for "structural diffing"; this is a heuristic that catches
+the most common case (agent re-emits whole surface).
+
+### Modal as native `ContentDialog`
+
+`Rendering/Renderers/ContainerRenderers.cs:237–284` wires up a
+`ContentDialog` whose `Content` is the `contentChild` and whose trigger
+is the `entryPointChild` wrapped in a transparent `Button`. Spec leaves
+the modal _shape_ open; the WinUI impl gives it the full platform-modal
+treatment (focus trap, ESC dismiss, screen-reader announcement).
+
+### List virtualization
+
+`Rendering/Renderers/ContainerRenderers.cs:57–159` uses an
+`ItemsRepeater` with a `ChildIdTemplate` cache keyed by component id.
+Recycled elements are pulled from the cache so their data-binding
+subscriptions stay alive across scrolling. The Lit impl has no
+virtualization.
+
+### Test surface
+
+| Project | Focus |
+| --- | --- |
+| `OpenClaw.Shared.Tests/A2UICapabilitySecurityTests.cs` | protocol, secret redaction |
+| `OpenClaw.Tray.UITests/A2UIRenderingTests.cs` | per-component XAML rendering, data binding, live updates |
+| `OpenClaw.Tray.UITests/A2UIControlMatrixTests.cs` | property matrix coverage |
+| `OpenClaw.Tray.UITests/A2UIDashboardScaleTest.cs` | 1000+ component stress |
+| `OpenClaw.Tray.UITests/A2UIThemeTests.cs` | theme parsing |
+| `OpenClaw.Tray.UITests/A2UISvgTests.cs` | SVG decode + 8s timeout |
+| `OpenClaw.Tray.IntegrationTests/A2UICanvasIntegrationTests.cs` | end-to-end MCP smoke + PNG capture |
+
+Coverage merged across all three suites via `dotnet-coverage` (per the
+auto-memory note). Letter grade A−; the missing step is that the
+gateway-action transport unit tests aren't fully isolated (depend on a
+fake `WindowsNodeClient`).
+
+### Good deviations
+
+| Deviation | File | Why it's good |
+| --- | --- | --- |
+| DNS rebinding defense | `Rendering/MediaResolver.cs:57–95` | spec doesn't ask but a hostile agent can otherwise pivot through the renderer to internal HTTP services |
+| Action context allowlist | `Rendering/IComponentRenderer.cs:183–249` | minimum-information principle; spec leaves this open |
+| Secret denylist | `Rendering/SecretRedactor.cs` | catches `/auth/sessionToken` style names automatically |
+| `surfaceUpdate` diff | `Hosting/SurfaceHost.cs` | preserves caret/scroll/selection on re-emit |
+| Single-flight gate on action dispatch | `Actions/IActionSink.cs:27–142` | prevents fallback dequeue racing fresh send |
+| Per-surface theme scope | `Hosting/SurfaceHost.cs ApplyThemeToScope` | multi-surface tab views don't bleed themes |
+| `IA2UITelemetry` seam | `Telemetry/IA2UITelemetry.cs` | structured events instead of log scraping |
+| Single-handler `Func` events on `CanvasCapability` | reviewed in commit `5b9c468` | catches accidental multi-subscribe instead of silent `Delegate.Combine` |
+| MCP bearer token in Settings UI | `SettingsWindow.xaml.cs` | quality-of-life for MCP setup, kept out of action payloads |
+
+---
+
+## Side-by-side: where they diverge meaningfully
+
+### `Text` / Markdown divergence
+
+The Lit impl renders Markdown; the WinUI impl renders plain text. This is
+the **biggest functional UX difference** between the two.
+
+Lit's defense is `iframe sandbox=""` for HTML blocks plus
+`escapeNodeText` for code. That's a reasonable sandbox model in the
+browser — but every line still expands the renderer's attack surface
+beyond the spec's "plain string" promise.
+
+For ms-windows-node, parity is **probably not worth chasing** unless
+the agent surfaces depend on it: WinUI doesn't have a built-in
+Markdown engine, and adding one means importing a dependency that has
+to be kept in lockstep with Lit's rendering choices to avoid surfaces
+that look right in the browser and broken on Windows. The defensible
+choice is to ask the agent to emit explicit `Text + usageHint`
+hierarchies instead of inline Markdown.
+
+### List performance
+
+If a surface includes a `List` of 200+ items, the Lit renderer will
+build all 200 children before paint. WinUI builds ~10 (whatever fits
+the viewport) and recycles as the user scrolls. For this repo's
+typical agent surfaces (dashboards, conversation panels) this is the
+single biggest performance delta.
+
+### Action security model
+
+The two impls have completely different threat models:
+
+- **Lit + browser canvas host**: assume the embedding app is
+  trustworthy and will sanitize. The renderer is a thin presenter.
+- **WinUI tray**: assume the renderer talks to a hostile agent over an
+  arbitrary network. Apply policy in the renderer.
+
+Neither is wrong, but a host that wants Lit-grade isolation has to
+build the same allowlist/denylist logic that WinUI bakes in. In
+practice that means anyone embedding the Lit renderer outside
+OpenClaw's canvas host needs to **wrap action handlers**, never just
+forward them.
+
+---
+
+## Known deviations by category
+
+For PR reviewers — quick "is this OK?" reference.
+
+| Deviation | Spec status | Lit | WinUI | Verdict |
+| --- | --- | --- | --- | --- |
+| Bi-directional data-model write on user input | silent | ✓ | ✓ | Good — spec assumes it implicitly |
+| Markdown in `Text` | violation (plain string) | ✓ | ✗ | Lit: useful but expands attack surface; WinUI: stay plain |
+| Custom-element registry beyond catalog | violation (catalog-strict) | ✓ (flag) | ✗ | Risk; only enable in trusted hosts |
+| `valueString` auto-parsed as JSON | violation (type erasure) | ✓ | ✗ | Bug-shaped; rely on `valueMap`/`valueArray` |
+| Hard size caps on stream / model | silent | ✗ | ✓ | Good — DoS defense |
+| URL allowlist on media | silent | ✗ | ✓ | Good — SSRF defense |
+| DNS-rebinding defense | silent | ✗ | ✓ | Good — beyond allowlist |
+| Action context allowlist | silent | ✗ | ✓ | Good — minimum information |
+| Secret-path redaction | silent | ✗ | ✓ | Good — keeps tokens off the wire |
+| Component diff on `surfaceUpdate` | "structural diffing" (vague) | ✗ | ✓ | Good — preserves UI state |
+| `List` virtualization | "should virtualize" | ✗ | ✓ | Good — required for non-trivial surfaces |
+| `Modal` as native `ContentDialog` | shape open | `<dialog>` | `ContentDialog` | Both fine |
+| `MultipleChoice` single-mode writes scalar | spec implies array | array | scalar | WinUI's reads tolerate either; talk to your agent format |
+| `validationRegexp` (TextField) | spec property | ✗ TODO | ✗ | Both have a gap here |
+
+---
+
+## Recommended follow-ups (not part of grading)
+
+These are the changes that would close the remaining minuses:
+
+**WinUI (A− → A)**
+- Honor `MultipleChoice.variant` (`chips`) and `filterable`.
+- Apply `TextField.validationRegexp` (the catalog says it's a string;
+  compile + on-change validate).
+- Consider `List.template` mode for surfaces that bind a list to a
+  data-model array (also unblocks v0.9 readiness).
+- Add unit tests for `GatewayActionTransport` payload shape.
+
+**Lit (B− → B+ or higher)**
+- Resolve the four documented `TODO`s (Divider, TextField,
+  DateTimeInput, MultipleChoice).
+- Add per-component render tests and a markdown-sanitizer test suite.
+- Add at least an opt-in URL allowlist for media components.
+- Document the `enableCustomElements` flag's risk surface for
+  embedding apps.

--- a/docs/a2ui/grading.md
+++ b/docs/a2ui/grading.md
@@ -40,7 +40,7 @@ agent; etc.
 | Action transport | B | A | Lit: DOM event passthrough; WinUI: debounced + single-flight + fallback queue + gateway tag protocol |
 | Action context security | D | A | Lit punts to host; WinUI scopes to declared `dataBinding` and redacts secrets |
 | Theming | A− | A− | Equivalent power; different idioms |
-| URL safety / SSRF | F | A | Lit unrestricted; WinUI DNS-rebinding defense + allowlist |
+| URL safety / SSRF | F | A− | Lit unrestricted; WinUI HTTPS+allowlist for `Image`/`Video`/`AudioPlayer`, plus DNS-rebinding pin on `Image` fetches only |
 | Modal lifecycle | A− | A | Both work; WinUI uses native `ContentDialog` |
 | List virtualization | C | A | Lit builds all items; WinUI uses `ItemsRepeater` w/ recycling |
 | Bi-directional binding (write-back) | A | A | Both implement; spec is silent (good deviation) |
@@ -162,7 +162,7 @@ This blocks the trivial "exfiltrate the whole tree" attack without
 requiring the host to know about A2UI internals. The Lit impl can't
 do this because it dispatches `action` straight through.
 
-### URL safety — DNS rebinding defense
+### URL safety — DNS rebinding defense (Image fetches)
 
 `Rendering/MediaResolver.cs:57–95`:
 
@@ -182,6 +182,14 @@ new SocketsHttpHandler {
 Plus an allowlist gate in `IsAllowed(url)`. Closes a TOCTOU window
 between an allowlist check and the actual TCP connect. The Lit impl
 does none of this.
+
+**Limitation: this pin is image-only.** `Video`/`AudioPlayer` route through
+`MediaSource.CreateFromUri`, which performs its own DNS resolution at
+playback time outside the resolver. The HTTPS+allowlist gate still
+applies to those URLs, but the connect-time IP check does not — see
+`MediaResolver.TryResolveMediaUri`. A local-proxy approach was scoped
+out of the v0.8 native renderer; the allowlist is the load-bearing
+defense for media playback.
 
 ### Streaming hardening
 
@@ -246,7 +254,7 @@ fake `WindowsNodeClient`).
 
 | Deviation | File | Why it's good |
 | --- | --- | --- |
-| DNS rebinding defense | `Rendering/MediaResolver.cs:57–95` | spec doesn't ask but a hostile agent can otherwise pivot through the renderer to internal HTTP services |
+| DNS rebinding defense (image fetches) | `Rendering/MediaResolver.cs:57–95` | spec doesn't ask but a hostile agent can otherwise pivot through the image fetch path to internal HTTP services. Does not extend to `Video`/`AudioPlayer` — see "URL safety" section. |
 | Action context allowlist | `Rendering/IComponentRenderer.cs:183–249` | minimum-information principle; spec leaves this open |
 | Secret denylist | `Rendering/SecretRedactor.cs` | catches `/auth/sessionToken` style names automatically |
 | `surfaceUpdate` diff | `Hosting/SurfaceHost.cs` | preserves caret/scroll/selection on re-emit |
@@ -315,7 +323,7 @@ For PR reviewers — quick "is this OK?" reference.
 | `valueString` auto-parsed as JSON | violation (type erasure) | ✓ | ✗ | Bug-shaped; rely on `valueMap`/`valueArray` |
 | Hard size caps on stream / model | silent | ✗ | ✓ | Good — DoS defense |
 | URL allowlist on media | silent | ✗ | ✓ | Good — SSRF defense |
-| DNS-rebinding defense | silent | ✗ | ✓ | Good — beyond allowlist |
+| DNS-rebinding defense (image fetches) | silent | ✗ | ✓ | Good — beyond allowlist. Image only; `Video`/`AudioPlayer` rely on the allowlist alone (OS media stack re-resolves at playback). |
 | Action context allowlist | silent | ✗ | ✓ | Good — minimum information |
 | Secret-path redaction | silent | ✗ | ✓ | Good — keeps tokens off the wire |
 | Component diff on `surfaceUpdate` | "structural diffing" (vague) | ✗ | ✓ | Good — preserves UI state |

--- a/docs/a2ui/protocol.md
+++ b/docs/a2ui/protocol.md
@@ -1,0 +1,173 @@
+# A2UI v0.8 — Protocol
+
+This is a faithful summary of the v0.8 wire format, distilled from
+<https://a2ui.org/specification/v0.8-a2ui/> and
+<https://a2ui.org/specification/v0.8-a2a-extension/>.
+
+## 1. Architecture
+
+A2UI is a **streaming, declarative UI protocol** for LLM-generated
+interfaces:
+
+- **Server → client**: a JSONL stream (typically over SSE, but the protocol
+  is transport-agnostic) carrying UI updates.
+- **Client → server**: A2A messages reporting user events.
+- **Surfaces**: independently-controllable UI regions, addressed by
+  `surfaceId`. A single agent stream can manage many surfaces in parallel.
+
+The component model is an **adjacency list** — a flat dictionary of
+`id → component`, with parents referencing children by id. This is easier
+for an LLM to emit incrementally than nested trees and is the foundation of
+progressive rendering.
+
+## 2. Server → client envelopes
+
+Each JSONL line is a JSON object containing **exactly one** of these keys:
+
+| Key | Purpose |
+| --- | --- |
+| `surfaceUpdate` | Add or replace components in a surface's adjacency list |
+| `dataModelUpdate` | Mutate the surface's data model |
+| `beginRendering` | Signal "ready to render"; specify `root` and chosen catalog |
+| `deleteSurface` | Tear down a surface |
+
+### 2.1 `surfaceUpdate`
+
+```json
+{ "surfaceUpdate": {
+    "surfaceId": "main",
+    "components": [
+      { "id": "btn-1",
+        "component": { "Button": { "child": "lbl-1", "action": { ... } } } }
+    ]
+}}
+```
+
+Each entry has `id`, exactly one `component.{TypeName}` object, and an
+optional `weight` (used when the parent applies weighted distribution; not
+all parents honor it). The component definition is **catalog-validated**:
+unknown types fall back to a placeholder (clients MUST NOT crash on unknown
+types).
+
+### 2.2 `dataModelUpdate`
+
+```json
+{ "dataModelUpdate": {
+    "surfaceId": "main",
+    "path": "/optional/base",
+    "contents": [
+      { "key": "name",   "valueString": "Ada" },
+      { "key": "age",    "valueNumber": 36 },
+      { "key": "active", "valueBoolean": true },
+      { "key": "address","valueMap": [ { "key": "city", "valueString": "London" } ] }
+    ]
+}}
+```
+
+The `contents` array is a **typed key-value list** — `valueString`,
+`valueNumber`, `valueBoolean`, `valueMap`, `valueArray`. Updates are merged
+into the surface's data model rooted at `path` (default `/`). The spec
+leaves "merge vs replace" semantics underspecified; in practice both
+reference clients overwrite leaves and recurse into maps.
+
+A special idiom — `path: "/x", contents: [{ "key": ".", "valueString": "v" }]`
+— is used to set a primitive at a non-root path.
+
+### 2.3 `beginRendering`
+
+```json
+{ "beginRendering": {
+    "surfaceId": "main",
+    "catalogId": "https://a2ui.org/specification/v0_8/standard_catalog_definition.json",
+    "root": "card-1"
+}}
+```
+
+Acts as a **synchronization gate**: until the client sees this, it should
+buffer components/data without rendering. `catalogId` is optional —
+default is the v0.8 standard catalog. `styles` may also appear here for
+per-surface theme tokens.
+
+### 2.4 `deleteSurface`
+
+```json
+{ "deleteSurface": { "surfaceId": "main" } }
+```
+
+Disposes the surface, its data model, and any subscriptions.
+
+## 3. Client → server events
+
+### 3.1 `userAction`
+
+```json
+{ "userAction": {
+    "name": "submit",
+    "surfaceId": "main",
+    "sourceComponentId": "btn-1",
+    "timestamp": "2026-04-27T17:05:00Z",
+    "context": { "email": "ada@example.com" }
+}}
+```
+
+`context` is the **resolved** snapshot of the action's `context[]`
+(BoundValues evaluated against the data model at click time — see
+[`data-and-actions.md`](./data-and-actions.md)).
+
+### 3.2 `error`
+
+A client-side error reporting envelope. The spec leaves the body shape
+underspecified.
+
+## 4. A2A extension (v0.8)
+
+A2UI rides on **A2A** as a typed extension:
+
+- Extension URI: `https://a2ui.org/a2a-extension/a2ui/v0.8`
+- Messages are A2A `DataPart` objects with `mimeType: "application/json+a2ui"`.
+- Capability negotiation:
+  - **Agent advertises** in `AgentCapabilities.extensions`:
+    - `supportedCatalogIds: string[]`
+    - `acceptsInlineCatalogs: bool`
+  - **Client declares** support via transport-specific signaling
+    (`X-A2A-Extensions` HTTP header, gRPC metadata, JSON-RPC mechanism).
+  - Client may include in A2A message metadata:
+    ```json
+    { "metadata": { "a2uiClientCapabilities": {
+        "supportedCatalogIds": [ "https://a2ui.org/.../standard_catalog_definition.json" ],
+        "inlineCatalogs": [ { "catalogId": "...", "components": {...}, "styles": {...} } ]
+    }}}
+    ```
+  - Server picks one in the next `beginRendering`.
+
+The available spec text is partial — push/pull operations, retry,
+backpressure, and authentication details are **delegated to the A2A layer**
+or to implementations.
+
+## 5. Lifecycle
+
+1. Client opens an A2A session and announces capabilities.
+2. Server starts a JSONL stream:
+   1. Emits `surfaceUpdate` and `dataModelUpdate` lines (any order).
+   2. Emits `beginRendering` once the surface is render-ready.
+3. Client renders the tree rooted at `root`.
+4. User interacts → client emits `userAction` (A2A message, **not** on the
+   JSONL stream).
+5. Server responds with more JSONL.
+6. Server emits `deleteSurface` when done, or session ends.
+
+## 6. Implementation notes (deltas from raw spec)
+
+These behaviors are spec-silent or under-specified; both reference
+implementations and this repo make pragmatic choices:
+
+- **Line-delimited JSON parsing** must tolerate malformed lines gracefully —
+  a single bad line MUST NOT abort the stream. Both impls log + skip.
+- **Size caps** on lines, components per surface, data-model entries.
+  WinUI applies hard caps (1 MiB / 2000 / 1024); Lit does not.
+- **Modal lifecycle**: spec defines `entryPointChild` + `contentChild` but
+  not _when_ the modal is open. Lit uses `<dialog>.showModal()` driven by
+  internal state; WinUI uses a `ContentDialog` triggered by entry click.
+- **Streaming partial components**: a `surfaceUpdate` may reference an
+  `id` whose contents arrive on a later line. Clients MUST defer rendering
+  of undefined refs, not throw.

--- a/moltbot-windows-hub.slnx
+++ b/moltbot-windows-hub.slnx
@@ -24,5 +24,6 @@
   <Folder Name="/tests/">
     <Project Path="tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj" />
     <Project Path="tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj" />
+    <Project Path="tests/OpenClaw.Tray.IntegrationTests/OpenClaw.Tray.IntegrationTests.csproj" />
   </Folder>
 </Solution>

--- a/moltbot-windows-hub.slnx
+++ b/moltbot-windows-hub.slnx
@@ -25,5 +25,10 @@
     <Project Path="tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj" />
     <Project Path="tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj" />
     <Project Path="tests/OpenClaw.Tray.IntegrationTests/OpenClaw.Tray.IntegrationTests.csproj" />
+    <Project Path="tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj">
+      <Platform Solution="*|Any CPU" Project="x64" />
+      <Platform Solution="*|x64" Project="x64" />
+      <Platform Solution="*|ARM64" Project="ARM64" />
+    </Project>
   </Folder>
 </Solution>

--- a/src/OpenClaw.Shared/Capabilities/CanvasCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/CanvasCapability.cs
@@ -21,7 +21,9 @@ public class CanvasCapability : NodeCapabilityBase
         "canvas.snapshot",
         "canvas.a2ui.push",
         "canvas.a2ui.pushJSONL",
-        "canvas.a2ui.reset"
+        "canvas.a2ui.reset",
+        "canvas.a2ui.dump",
+        "canvas.caps",
     };
     
     public override IReadOnlyList<string> Commands => _commands;
@@ -34,6 +36,10 @@ public class CanvasCapability : NodeCapabilityBase
     public event Func<CanvasSnapshotArgs, Task<string>>? SnapshotRequested;
     public event EventHandler<CanvasA2UIArgs>? A2UIPushRequested;
     public event EventHandler? A2UIResetRequested;
+    /// <summary>Returns a JSON state dump of the native A2UI surface graph.</summary>
+    public event Func<Task<string>>? A2UIDumpRequested;
+    /// <summary>Returns a JSON capability summary describing which canvas operations are supported.</summary>
+    public event Func<Task<string>>? CapsRequested;
     
     public CanvasCapability(IOpenClawLogger logger) : base(logger)
     {
@@ -60,6 +66,8 @@ public class CanvasCapability : NodeCapabilityBase
             "canvas.a2ui.push" => HandleA2UIPush(request),
             "canvas.a2ui.pushJSONL" => HandleA2UIPush(request),
             "canvas.a2ui.reset" => HandleA2UIReset(request),
+            "canvas.a2ui.dump" => await HandleA2UIDumpAsync(),
+            "canvas.caps" => await HandleCapsAsync(),
             _ => Error($"Unknown command: {request.Command}")
         };
     }
@@ -240,6 +248,50 @@ public class CanvasCapability : NodeCapabilityBase
         Logger.Info("canvas.a2ui.reset");
         A2UIResetRequested?.Invoke(this, EventArgs.Empty);
         return Success(new { reset = true });
+    }
+
+    private async Task<NodeInvokeResponse> HandleA2UIDumpAsync()
+    {
+        Logger.Info("canvas.a2ui.dump");
+        if (A2UIDumpRequested == null)
+            return Error("CANVAS_NOT_OPEN: no A2UI canvas is currently active");
+        try
+        {
+            var json = await A2UIDumpRequested();
+            // Pass through as a JSON-typed payload so MCP clients see structured data,
+            // not a quoted string.
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            return Success(System.Text.Json.JsonSerializer.Deserialize<object>(doc.RootElement.GetRawText()));
+        }
+        catch (Exception ex)
+        {
+            return Error($"CANVAS_DUMP_FAILED: {ex.Message}");
+        }
+    }
+
+    private async Task<NodeInvokeResponse> HandleCapsAsync()
+    {
+        if (CapsRequested == null)
+        {
+            return Success(new
+            {
+                renderer = "none",
+                eval = false,
+                snapshot = false,
+                navigate = false,
+                a2ui = new { version = "0.8", introspect = false },
+            });
+        }
+        try
+        {
+            var json = await CapsRequested();
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            return Success(System.Text.Json.JsonSerializer.Deserialize<object>(doc.RootElement.GetRawText()));
+        }
+        catch (Exception ex)
+        {
+            return Error($"CANVAS_CAPS_FAILED: {ex.Message}");
+        }
     }
 }
 

--- a/src/OpenClaw.Shared/Capabilities/CanvasCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/CanvasCapability.cs
@@ -83,6 +83,12 @@ public class CanvasCapability : NodeCapabilityBase
     private const int MinQuality = 1;
     private const int MaxQuality = 100;
 
+    // A2UI push caps. Inline transport in McpHttpServer caps at 4 MiB; jsonlPath
+    // bypasses that, so re-enforce here. The line-count cap protects the UI thread
+    // from a single push that explodes into thousands of dispatcher posts.
+    internal const long MaxA2UIJsonlBytes = 4L * 1024 * 1024;
+    internal const int MaxA2UIJsonlLines = 4096;
+
     private Task<NodeInvokeResponse> HandlePresentAsync(NodeInvokeRequest request)
     {
         var url = GetStringArg(request.Args, "url");
@@ -195,19 +201,40 @@ public class CanvasCapability : NodeCapabilityBase
         var jsonl = GetStringArg(request.Args, "jsonl");
         var jsonlPath = GetStringArg(request.Args, "jsonlPath");
         var props = request.Args.TryGetProperty("props", out var propsEl) ? propsEl : default;
-        
+
         if (string.IsNullOrWhiteSpace(jsonl) && !string.IsNullOrWhiteSpace(jsonlPath))
         {
             // Validate jsonlPath to prevent arbitrary file reads.
-            // Resolve to absolute path and reject traversal or suspicious paths.
+            // Resolve to absolute path, follow reparse points, and reject anything
+            // that doesn't ultimately live inside the system temp directory.
+            string fullPath;
+            FileInfo fi;
             try
             {
-                var fullPath = Path.GetFullPath(jsonlPath);
+                fullPath = Path.GetFullPath(jsonlPath);
+                fi = new FileInfo(fullPath);
+                // Resolve symlinks/junctions where possible: a junction inside temp
+                // pointing at a user-writable folder elsewhere would otherwise pass
+                // the StartsWith check below. (M5 in the unified review.) For
+                // non-existent or non-link entries this is a no-op or returns null.
+                try
+                {
+                    var resolved = fi.ResolveLinkTarget(returnFinalTarget: true);
+                    if (resolved != null) fullPath = resolved.FullName;
+                }
+                catch { /* non-link, non-existent, or insufficient permission — fall back to the raw path */ }
+
                 var tempRoot = Path.GetFullPath(Path.GetTempPath());
                 if (!fullPath.StartsWith(tempRoot, StringComparison.OrdinalIgnoreCase))
                 {
                     Logger.Warn($"{request.Command}: jsonlPath outside temp directory: {fullPath}");
                     return Error("jsonlPath must be within the system temp directory");
+                }
+
+                if (fi.Exists && fi.Length > MaxA2UIJsonlBytes)
+                {
+                    Logger.Warn($"{request.Command}: jsonlPath file too large ({fi.Length} > {MaxA2UIJsonlBytes})");
+                    return Error($"jsonlPath exceeds maximum size of {MaxA2UIJsonlBytes} bytes");
                 }
             }
             catch (Exception ex)
@@ -217,7 +244,7 @@ public class CanvasCapability : NodeCapabilityBase
 
             try
             {
-                jsonl = File.ReadAllText(jsonlPath);
+                jsonl = File.ReadAllText(fullPath);
             }
             catch (Exception ex)
             {
@@ -225,22 +252,61 @@ public class CanvasCapability : NodeCapabilityBase
                 return Error($"Failed to read jsonlPath: {ex.Message}");
             }
         }
-        
+
         if (string.IsNullOrWhiteSpace(jsonl))
         {
             return Error("Missing jsonl or jsonlPath parameter");
         }
-        
-        Logger.Info($"{request.Command}: {jsonl.Length} chars");
-        
+
+        // Inline-jsonl size cap. Encoding.UTF8.GetByteCount streams over chars
+        // without allocating, so this is cheap.
+        long byteCount = System.Text.Encoding.UTF8.GetByteCount(jsonl);
+        if (byteCount > MaxA2UIJsonlBytes)
+        {
+            Logger.Warn($"{request.Command}: jsonl payload too large ({byteCount} > {MaxA2UIJsonlBytes})");
+            return Error($"jsonl exceeds maximum size of {MaxA2UIJsonlBytes} bytes");
+        }
+
+        // Line-count cap. A push that fans out to thousands of UI-thread
+        // dispatches has DoS potential even if individually small.
+        int lineCount = CountLines(jsonl);
+        if (lineCount > MaxA2UIJsonlLines)
+        {
+            Logger.Warn($"{request.Command}: jsonl line count too high ({lineCount} > {MaxA2UIJsonlLines})");
+            return Error($"jsonl exceeds maximum of {MaxA2UIJsonlLines} lines");
+        }
+
+        Logger.Info($"{request.Command}: {byteCount} bytes, {lineCount} lines");
+
         A2UIPushRequested?.Invoke(this, new CanvasA2UIArgs
         {
             Jsonl = jsonl,
             JsonlPath = jsonlPath,
             Props = props.ValueKind != default ? props.GetRawText() : "{}"
         });
-        
+
         return Success(new { pushed = true });
+    }
+
+    private static int CountLines(string s)
+    {
+        // Count non-empty newline-delimited lines without allocating an array.
+        int count = 0;
+        bool inLine = false;
+        for (int i = 0; i < s.Length; i++)
+        {
+            char c = s[i];
+            if (c == '\n' || c == '\r')
+            {
+                if (inLine) { count++; inLine = false; }
+            }
+            else if (!char.IsWhiteSpace(c))
+            {
+                inLine = true;
+            }
+        }
+        if (inLine) count++;
+        return count;
     }
     
     private NodeInvokeResponse HandleA2UIReset(NodeInvokeRequest request)

--- a/src/OpenClaw.Shared/Capabilities/CanvasCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/CanvasCapability.cs
@@ -32,14 +32,49 @@ public class CanvasCapability : NodeCapabilityBase
     public event EventHandler<CanvasPresentArgs>? PresentRequested;
     public event EventHandler? HideRequested;
     public event EventHandler<string>? NavigateRequested;
-    public event Func<string, Task<string>>? EvalRequested;
-    public event Func<CanvasSnapshotArgs, Task<string>>? SnapshotRequested;
+    // Func-based "events" are inherently single-handler — multi-subscribe to a
+    // Delegate.Combine'd Func silently invokes only the last subscriber's
+    // return value, hiding the others. Expose them as single-subscriber events
+    // that throw on a second subscribe so this is loud.
+    private Func<string, Task<string>>? _evalRequested;
+    public event Func<string, Task<string>> EvalRequested
+    {
+        add => SetSingleHandler(ref _evalRequested, value, nameof(EvalRequested));
+        remove => ClearSingleHandler(ref _evalRequested, value);
+    }
+    private Func<CanvasSnapshotArgs, Task<string>>? _snapshotRequested;
+    public event Func<CanvasSnapshotArgs, Task<string>> SnapshotRequested
+    {
+        add => SetSingleHandler(ref _snapshotRequested, value, nameof(SnapshotRequested));
+        remove => ClearSingleHandler(ref _snapshotRequested, value);
+    }
     public event EventHandler<CanvasA2UIArgs>? A2UIPushRequested;
     public event EventHandler? A2UIResetRequested;
     /// <summary>Returns a JSON state dump of the native A2UI surface graph.</summary>
-    public event Func<Task<string>>? A2UIDumpRequested;
+    private Func<Task<string>>? _a2uiDumpRequested;
+    public event Func<Task<string>> A2UIDumpRequested
+    {
+        add => SetSingleHandler(ref _a2uiDumpRequested, value, nameof(A2UIDumpRequested));
+        remove => ClearSingleHandler(ref _a2uiDumpRequested, value);
+    }
     /// <summary>Returns a JSON capability summary describing which canvas operations are supported.</summary>
-    public event Func<Task<string>>? CapsRequested;
+    private Func<Task<string>>? _capsRequested;
+    public event Func<Task<string>> CapsRequested
+    {
+        add => SetSingleHandler(ref _capsRequested, value, nameof(CapsRequested));
+        remove => ClearSingleHandler(ref _capsRequested, value);
+    }
+
+    private static void SetSingleHandler<T>(ref T? slot, T value, string name) where T : Delegate
+    {
+        if (slot != null && !ReferenceEquals(slot, value))
+            throw new InvalidOperationException($"{name} accepts only one subscriber. Detach the previous handler first.");
+        slot = value;
+    }
+    private static void ClearSingleHandler<T>(ref T? slot, T value) where T : Delegate
+    {
+        if (ReferenceEquals(slot, value)) slot = null;
+    }
     
     public CanvasCapability(IOpenClawLogger logger) : base(logger)
     {
@@ -150,14 +185,15 @@ public class CanvasCapability : NodeCapabilityBase
         
         Logger.Info($"canvas.eval: {script[..Math.Min(50, script.Length)]}...");
         
-        if (EvalRequested == null)
+        var evalHandler = _evalRequested;
+        if (evalHandler == null)
         {
             return Error("Canvas not available");
         }
-        
+
         try
         {
-            var result = await EvalRequested(script);
+            var result = await evalHandler(script);
             return Success(new { result });
         }
         catch (Exception ex)
@@ -174,14 +210,15 @@ public class CanvasCapability : NodeCapabilityBase
         
         Logger.Info($"canvas.snapshot: format={format}, maxWidth={maxWidth}");
         
-        if (SnapshotRequested == null)
+        var snapshotHandler = _snapshotRequested;
+        if (snapshotHandler == null)
         {
             return Error("Canvas not available");
         }
-        
+
         try
         {
-            var base64 = await SnapshotRequested(new CanvasSnapshotArgs
+            var base64 = await snapshotHandler(new CanvasSnapshotArgs
             {
                 Format = format ?? "png",
                 MaxWidth = maxWidth,
@@ -319,11 +356,12 @@ public class CanvasCapability : NodeCapabilityBase
     private async Task<NodeInvokeResponse> HandleA2UIDumpAsync()
     {
         Logger.Info("canvas.a2ui.dump");
-        if (A2UIDumpRequested == null)
+        var dumpHandler = _a2uiDumpRequested;
+        if (dumpHandler == null)
             return Error("CANVAS_NOT_OPEN: no A2UI canvas is currently active");
         try
         {
-            var json = await A2UIDumpRequested();
+            var json = await dumpHandler();
             // Pass through as a JSON-typed payload so MCP clients see structured data,
             // not a quoted string.
             using var doc = System.Text.Json.JsonDocument.Parse(json);
@@ -337,7 +375,8 @@ public class CanvasCapability : NodeCapabilityBase
 
     private async Task<NodeInvokeResponse> HandleCapsAsync()
     {
-        if (CapsRequested == null)
+        var capsHandler = _capsRequested;
+        if (capsHandler == null)
         {
             return Success(new
             {
@@ -350,7 +389,7 @@ public class CanvasCapability : NodeCapabilityBase
         }
         try
         {
-            var json = await CapsRequested();
+            var json = await capsHandler();
             using var doc = System.Text.Json.JsonDocument.Parse(json);
             return Success(System.Text.Json.JsonSerializer.Deserialize<object>(doc.RootElement.GetRawText()));
         }

--- a/src/OpenClaw.Shared/Capabilities/CanvasCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/CanvasCapability.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
 
 namespace OpenClaw.Shared.Capabilities;
 
@@ -282,51 +285,13 @@ public class CanvasCapability : NodeCapabilityBase
 
         if (string.IsNullOrWhiteSpace(jsonl) && !string.IsNullOrWhiteSpace(jsonlPath))
         {
-            // Validate jsonlPath to prevent arbitrary file reads.
-            // Resolve to absolute path, follow reparse points, and reject anything
-            // that doesn't ultimately live inside the system temp directory.
-            string fullPath;
-            FileInfo fi;
             try
             {
-                fullPath = Path.GetFullPath(jsonlPath);
-                fi = new FileInfo(fullPath);
-                // Resolve symlinks/junctions where possible: a junction inside temp
-                // pointing at a user-writable folder elsewhere would otherwise pass
-                // the StartsWith check below. (M5 in the unified review.) For
-                // non-existent or non-link entries this is a no-op or returns null.
-                try
-                {
-                    var resolved = fi.ResolveLinkTarget(returnFinalTarget: true);
-                    if (resolved != null) fullPath = resolved.FullName;
-                }
-                catch { /* non-link, non-existent, or insufficient permission — fall back to the raw path */ }
-
-                var tempRoot = Path.GetFullPath(Path.GetTempPath());
-                if (!fullPath.StartsWith(tempRoot, StringComparison.OrdinalIgnoreCase))
-                {
-                    Logger.Warn($"{request.Command}: jsonlPath outside temp directory: {fullPath}");
-                    return Error("jsonlPath must be within the system temp directory");
-                }
-
-                if (fi.Exists && fi.Length > MaxA2UIJsonlBytes)
-                {
-                    Logger.Warn($"{request.Command}: jsonlPath file too large ({fi.Length} > {MaxA2UIJsonlBytes})");
-                    return Error($"jsonlPath exceeds maximum size of {MaxA2UIJsonlBytes} bytes");
-                }
+                jsonl = ReadValidatedJsonlPath(jsonlPath, request.Command);
             }
             catch (Exception ex)
             {
-                return Error($"Invalid jsonlPath: {ex.Message}");
-            }
-
-            try
-            {
-                jsonl = File.ReadAllText(fullPath);
-            }
-            catch (Exception ex)
-            {
-                Logger.Error($"{request.Command}: failed to read jsonlPath ({jsonlPath})", ex);
+                Logger.Error($"{request.Command}: failed to read jsonlPath", ex);
                 return Error($"Failed to read jsonlPath: {ex.Message}");
             }
         }
@@ -386,6 +351,122 @@ public class CanvasCapability : NodeCapabilityBase
         if (inLine) count++;
         return count;
     }
+
+    private string ReadValidatedJsonlPath(string jsonlPath, string command)
+    {
+        string fullPath;
+        string tempRoot;
+        try
+        {
+            fullPath = Path.GetFullPath(jsonlPath);
+            tempRoot = EnsureTrailingSeparator(Path.GetFullPath(Path.GetTempPath()));
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Invalid jsonlPath: {ex.Message}", ex);
+        }
+
+        if (!IsPathWithinRoot(fullPath, tempRoot))
+        {
+            Logger.Warn($"{command}: jsonlPath outside temp directory: {fullPath}");
+            throw new InvalidOperationException("jsonlPath must be within the system temp directory");
+        }
+
+        var fi = new FileInfo(fullPath);
+        if (fi.Exists && fi.Attributes.HasFlag(FileAttributes.ReparsePoint))
+        {
+            FileSystemInfo? resolved;
+            try
+            {
+                resolved = fi.ResolveLinkTarget(returnFinalTarget: true);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn($"{command}: jsonlPath reparse point could not be resolved: {ex.Message}");
+                throw new InvalidOperationException("jsonlPath contains an unresolvable reparse point", ex);
+            }
+
+            if (resolved == null)
+            {
+                Logger.Warn($"{command}: jsonlPath reparse point could not be resolved");
+                throw new InvalidOperationException("jsonlPath contains an unresolvable reparse point");
+            }
+
+            if (!IsPathWithinRoot(resolved.FullName, tempRoot))
+            {
+                Logger.Warn($"{command}: jsonlPath reparse point resolves outside temp directory: {resolved.FullName}");
+                throw new InvalidOperationException("jsonlPath reparse point must resolve within the system temp directory");
+            }
+        }
+
+        using var stream = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        var finalPath = GetFinalPathFromHandle(stream.SafeFileHandle);
+        if (!IsPathWithinRoot(finalPath, tempRoot))
+        {
+            Logger.Warn($"{command}: jsonlPath file handle resolves outside temp directory: {finalPath}");
+            throw new InvalidOperationException("jsonlPath must resolve within the system temp directory");
+        }
+
+        if (stream.Length > MaxA2UIJsonlBytes)
+        {
+            Logger.Warn($"{command}: jsonlPath file too large ({stream.Length} > {MaxA2UIJsonlBytes})");
+            throw new InvalidOperationException($"jsonlPath exceeds maximum size of {MaxA2UIJsonlBytes} bytes");
+        }
+
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        return reader.ReadToEnd();
+    }
+
+    private static bool IsPathWithinRoot(string path, string root)
+    {
+        var normalizedPath = Path.GetFullPath(NormalizeFinalPath(path));
+        var normalizedRoot = EnsureTrailingSeparator(Path.GetFullPath(NormalizeFinalPath(root)));
+        return normalizedPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string EnsureTrailingSeparator(string path)
+    {
+        if (path.EndsWith(Path.DirectorySeparatorChar) || path.EndsWith(Path.AltDirectorySeparatorChar))
+            return path;
+        return path + Path.DirectorySeparatorChar;
+    }
+
+    private static string GetFinalPathFromHandle(SafeFileHandle handle)
+    {
+        if (!OperatingSystem.IsWindows())
+            return string.Empty;
+
+        var capacity = 512;
+        while (capacity <= 32768)
+        {
+            var sb = new StringBuilder(capacity);
+            var length = GetFinalPathNameByHandle(handle, sb, (uint)sb.Capacity, 0);
+            if (length == 0)
+                throw new IOException($"GetFinalPathNameByHandle failed with Win32 error {Marshal.GetLastWin32Error()}");
+            if (length < sb.Capacity)
+                return NormalizeFinalPath(sb.ToString());
+            capacity = (int)length + 1;
+        }
+        throw new IOException("GetFinalPathNameByHandle returned an unexpectedly long path");
+    }
+
+    private static string NormalizeFinalPath(string path)
+    {
+        const string extendedPrefix = @"\\?\";
+        const string extendedUncPrefix = @"\\?\UNC\";
+        if (path.StartsWith(extendedUncPrefix, StringComparison.OrdinalIgnoreCase))
+            return @"\\" + path.Substring(extendedUncPrefix.Length);
+        if (path.StartsWith(extendedPrefix, StringComparison.OrdinalIgnoreCase))
+            return path.Substring(extendedPrefix.Length);
+        return path;
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern uint GetFinalPathNameByHandle(
+        SafeFileHandle hFile,
+        StringBuilder lpszFilePath,
+        uint cchFilePath,
+        uint dwFlags);
     
     private NodeInvokeResponse HandleA2UIReset(NodeInvokeRequest request)
     {

--- a/src/OpenClaw.Shared/Capabilities/CanvasCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/CanvasCapability.cs
@@ -187,11 +187,15 @@ public class CanvasCapability : NodeCapabilityBase
         // URIs. The subscriber re-validates as defense-in-depth.
         if (!HttpUrlValidator.TryParse(rawUrl, out var canonical, out var validationError))
         {
-            Logger.Warn($"canvas.navigate rejected: {validationError} (raw: {rawUrl})");
+            // Avoid leaking the raw URL — agents sometimes hand us tokenized
+            // OAuth/reset URLs that fail validation, and our log files have
+            // an effectively-unbounded retention policy. Sanitize to scheme +
+            // host + first path segment.
+            Logger.Warn($"canvas.navigate rejected: {validationError} (sanitized: {UrlLogSanitizer.Sanitize(rawUrl)})");
             return Error($"Invalid url: {validationError}");
         }
 
-        Logger.Info($"canvas.navigate: {canonical}");
+        Logger.Info($"canvas.navigate: {UrlLogSanitizer.Sanitize(canonical)}");
 
         var handler = _navigateRequested;
         if (handler == null)

--- a/src/OpenClaw.Shared/Capabilities/CanvasCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/CanvasCapability.cs
@@ -31,7 +31,19 @@ public class CanvasCapability : NodeCapabilityBase
     // Events for UI to handle
     public event EventHandler<CanvasPresentArgs>? PresentRequested;
     public event EventHandler? HideRequested;
-    public event EventHandler<string>? NavigateRequested;
+    /// <summary>
+    /// Subscriber decides how to handle a navigate request and returns the
+    /// opener that actually serviced it: <c>"canvas"</c> if an in-process
+    /// WebView2 frame navigated, <c>"browser"</c> if the URL was handed to the
+    /// OS default browser. Throwing surfaces as an error to the gateway.
+    /// Single-subscriber: same multi-handler hazard as the other Func events.
+    /// </summary>
+    private Func<string, Task<string>>? _navigateRequested;
+    public event Func<string, Task<string>> NavigateRequested
+    {
+        add => SetSingleHandler(ref _navigateRequested, value, nameof(NavigateRequested));
+        remove => ClearSingleHandler(ref _navigateRequested, value);
+    }
     // Func-based "events" are inherently single-handler — multi-subscribe to a
     // Delegate.Combine'd Func silently invokes only the last subscriber's
     // return value, hiding the others. Expose them as single-subscriber events
@@ -161,16 +173,45 @@ public class CanvasCapability : NodeCapabilityBase
     
     private async Task<NodeInvokeResponse> HandleNavigateAsync(NodeInvokeRequest request)
     {
-        var url = GetStringArg(request.Args, "url");
-        if (string.IsNullOrEmpty(url))
+        var rawUrl = GetStringArg(request.Args, "url");
+        if (string.IsNullOrEmpty(rawUrl))
         {
             return Error("Missing url parameter");
         }
-        
-        Logger.Info($"canvas.navigate: {url}");
-        NavigateRequested?.Invoke(this, url);
-        
-        return Success(new { navigated = true });
+
+        // Validate up front so the OS-level Process.Start in the subscriber
+        // can't be tricked into shell-executing javascript:/file:/app-protocol
+        // URIs. The subscriber re-validates as defense-in-depth.
+        if (!HttpUrlValidator.TryParse(rawUrl, out var canonical, out var validationError))
+        {
+            Logger.Warn($"canvas.navigate rejected: {validationError} (raw: {rawUrl})");
+            return Error($"Invalid url: {validationError}");
+        }
+
+        Logger.Info($"canvas.navigate: {canonical}");
+
+        var handler = _navigateRequested;
+        if (handler == null)
+        {
+            // No subscriber means there's no surface to navigate and no opener
+            // to fall back to. Tell the agent honestly so it can pick another
+            // tool instead of believing it succeeded.
+            return Error("CANVAS_NOT_AVAILABLE: no navigate handler registered");
+        }
+
+        try
+        {
+            var opener = await handler(canonical!);
+            // opener is the subscriber's word for how it serviced the request:
+            // "canvas" (existing WebView2 frame), "browser" (default browser),
+            // or anything else the subscriber wants to surface back to the agent.
+            return Success(new { navigated = true, opener, url = canonical });
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"canvas.navigate handler failed: {ex.Message}", ex);
+            return Error($"Navigate failed: {ex.Message}");
+        }
     }
     
     private async Task<NodeInvokeResponse> HandleEvalAsync(NodeInvokeRequest request)

--- a/src/OpenClaw.Shared/HttpUrlRiskEvaluator.cs
+++ b/src/OpenClaw.Shared/HttpUrlRiskEvaluator.cs
@@ -1,0 +1,189 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+
+namespace OpenClaw.Shared;
+
+public enum HttpUrlSecurityZone
+{
+    Unknown = -1,
+    LocalMachine = 0,
+    Intranet = 1,
+    Trusted = 2,
+    Internet = 3,
+    Restricted = 4,
+}
+
+public sealed record HttpUrlRiskProfile(
+    string CanonicalUrl,
+    string CanonicalOrigin,
+    string HostKey,
+    HttpUrlSecurityZone Zone,
+    bool RequiresConfirmation,
+    IReadOnlyList<string> Reasons);
+
+/// <summary>
+/// Centralized risk classifier for agent-supplied HTTP URLs. Callers should run
+/// <see cref="HttpUrlValidator"/> first; this type decides whether an otherwise
+/// valid URL needs user confirmation before browser navigation or media handoff.
+/// </summary>
+public static class HttpUrlRiskEvaluator
+{
+    public static HttpUrlRiskProfile Evaluate(string canonicalUrl)
+    {
+        if (!Uri.TryCreate(canonicalUrl, UriKind.Absolute, out var uri))
+            throw new ArgumentException("URL must be an absolute URI", nameof(canonicalUrl));
+
+        var reasons = new List<string>();
+        var host = uri.Host;
+
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            reasons.Add("URL does not use HTTPS");
+
+        if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase))
+        {
+            reasons.Add("Host is localhost");
+        }
+        else if (IPAddress.TryParse(host, out var ip))
+        {
+            reasons.Add("Host is an IP literal");
+            AddAddressRiskReasons(ip, reasons);
+        }
+        else if (!host.Contains('.', StringComparison.Ordinal))
+        {
+            reasons.Add("Host has no dot and may resolve on the local intranet");
+        }
+
+        var zone = MapUrlToZone(canonicalUrl);
+        switch (zone)
+        {
+            case HttpUrlSecurityZone.LocalMachine:
+                reasons.Add("Windows classifies this URL as Local Machine zone");
+                break;
+            case HttpUrlSecurityZone.Intranet:
+                reasons.Add("Windows classifies this URL as Intranet zone");
+                break;
+            case HttpUrlSecurityZone.Restricted:
+                reasons.Add("Windows classifies this URL as Restricted zone");
+                break;
+        }
+
+        var distinctReasons = reasons
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return new HttpUrlRiskProfile(
+            uri.AbsoluteUri,
+            GetCanonicalOrigin(uri),
+            uri.Authority.ToLowerInvariant(),
+            zone,
+            distinctReasons.Length > 0,
+            distinctReasons);
+    }
+
+    public static bool IsPublicAddress(IPAddress ip)
+    {
+        if (IPAddress.IsLoopback(ip)) return false;
+        if (ip.IsIPv4MappedToIPv6) return IsPublicAddress(ip.MapToIPv4());
+
+        if (ip.AddressFamily == AddressFamily.InterNetwork)
+        {
+            var b = ip.GetAddressBytes();
+            if (b[0] == 0) return false;
+            if (b[0] == 10) return false;
+            if (b[0] == 100 && (b[1] & 0xC0) == 64) return false;
+            if (b[0] == 127) return false;
+            if (b[0] == 169 && b[1] == 254) return false;
+            if (b[0] == 172 && b[1] >= 16 && b[1] <= 31) return false;
+            if (b[0] == 192 && b[1] == 168) return false;
+            if (b[0] >= 224) return false;
+            return true;
+        }
+
+        if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            if (ip.IsIPv6LinkLocal) return false;
+            if (ip.IsIPv6SiteLocal) return false;
+            if (ip.IsIPv6Multicast) return false;
+            var b = ip.GetAddressBytes();
+            if ((b[0] & 0xFE) == 0xFC) return false;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static void AddAddressRiskReasons(IPAddress ip, List<string> reasons)
+    {
+        if (IPAddress.IsLoopback(ip))
+        {
+            reasons.Add("Address is loopback");
+            return;
+        }
+
+        if (!IsPublicAddress(ip))
+            reasons.Add("Address is private, link-local, multicast, or reserved");
+    }
+
+    private static string GetCanonicalOrigin(Uri uri)
+    {
+        var origin = uri.GetLeftPart(UriPartial.Authority);
+        return origin.EndsWith("/", StringComparison.Ordinal) ? origin : origin + "/";
+    }
+
+    private static HttpUrlSecurityZone MapUrlToZone(string url)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return HttpUrlSecurityZone.Unknown;
+
+        IInternetSecurityManager? manager = null;
+        try
+        {
+            var type = Type.GetTypeFromCLSID(
+                new Guid("7b8a2d94-0ac9-11d1-896c-00c04fb6bfc4"),
+                throwOnError: false);
+            if (type == null)
+                return HttpUrlSecurityZone.Unknown;
+
+            manager = Activator.CreateInstance(type) as IInternetSecurityManager;
+            if (manager == null)
+                return HttpUrlSecurityZone.Unknown;
+
+            var hr = manager.MapUrlToZone(url, out var zone, 0);
+            if (hr != 0)
+                return HttpUrlSecurityZone.Unknown;
+            return Enum.IsDefined(typeof(HttpUrlSecurityZone), zone)
+                ? (HttpUrlSecurityZone)zone
+                : HttpUrlSecurityZone.Unknown;
+        }
+        catch
+        {
+            return HttpUrlSecurityZone.Unknown;
+        }
+        finally
+        {
+            if (manager != null)
+            {
+                try { Marshal.ReleaseComObject(manager); } catch { }
+            }
+        }
+    }
+
+    [ComImport]
+    [Guid("79eac9ee-baf9-11ce-8c82-00aa004ba90b")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IInternetSecurityManager
+    {
+        [PreserveSig]
+        int SetSecuritySite(IntPtr site);
+
+        [PreserveSig]
+        int GetSecuritySite(out IntPtr site);
+
+        [PreserveSig]
+        int MapUrlToZone(
+            [MarshalAs(UnmanagedType.LPWStr)] string url,
+            out int zone,
+            int flags);
+    }
+}

--- a/src/OpenClaw.Shared/HttpUrlRiskEvaluator.cs
+++ b/src/OpenClaw.Shared/HttpUrlRiskEvaluator.cs
@@ -40,6 +40,13 @@ public static class HttpUrlRiskEvaluator
         if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
             reasons.Add("URL does not use HTTPS");
 
+        // Homograph defense: a Unicode hostname that round-trips to a different
+        // ASCII (Punycode) form is suspicious — `аpple.com` (Cyrillic 'а') and
+        // `apple.com` are visually identical but resolve differently. Always
+        // surface the mismatch as a Reason so the prompt fires for IDN hosts.
+        if (!string.Equals(uri.Host, uri.IdnHost, StringComparison.Ordinal))
+            reasons.Add($"Hostname is internationalized; punycode form is '{uri.IdnHost}'");
+
         if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase))
         {
             reasons.Add("Host is localhost");
@@ -102,11 +109,39 @@ public static class HttpUrlRiskEvaluator
 
         if (ip.AddressFamily == AddressFamily.InterNetworkV6)
         {
+            // Unspecified (::) — never a routable destination.
+            if (ip.Equals(IPAddress.IPv6None)) return false;
             if (ip.IsIPv6LinkLocal) return false;
             if (ip.IsIPv6SiteLocal) return false;
             if (ip.IsIPv6Multicast) return false;
             var b = ip.GetAddressBytes();
+            // Unique-local fc00::/7 (existing).
             if ((b[0] & 0xFE) == 0xFC) return false;
+            // ::ffff:0:0/96 — IPv4-mapped (caught above by IsIPv4MappedToIPv6,
+            // but defensively re-check).
+            if (b[0] == 0 && b[1] == 0 && b[2] == 0 && b[3] == 0 &&
+                b[4] == 0 && b[5] == 0 && b[6] == 0 && b[7] == 0 &&
+                b[8] == 0 && b[9] == 0 && b[10] == 0xFF && b[11] == 0xFF)
+            {
+                var mapped = new IPAddress(new[] { b[12], b[13], b[14], b[15] });
+                return IsPublicAddress(mapped);
+            }
+            // ::/96 IPv4-compatible (deprecated; treat as non-public — never legit
+            // for an agent-supplied URL).
+            if (b[0] == 0 && b[1] == 0 && b[2] == 0 && b[3] == 0 &&
+                b[4] == 0 && b[5] == 0 && b[6] == 0 && b[7] == 0 &&
+                b[8] == 0 && b[9] == 0 && b[10] == 0 && b[11] == 0)
+                return false;
+            // 2001:db8::/32 — documentation prefix (RFC 3849).
+            if (b[0] == 0x20 && b[1] == 0x01 && b[2] == 0x0D && b[3] == 0xB8) return false;
+            // 2001:0000::/32 — Teredo (relay tunneling; not a normal target).
+            if (b[0] == 0x20 && b[1] == 0x01 && b[2] == 0x00 && b[3] == 0x00) return false;
+            // 100::/64 — discard-only address block (RFC 6666).
+            if (b[0] == 0x01 && b[1] == 0x00 &&
+                b[2] == 0 && b[3] == 0 && b[4] == 0 && b[5] == 0 && b[6] == 0 && b[7] == 0)
+                return false;
+            // 2002::/16 — 6to4. Block: payload destination is unverifiable.
+            if (b[0] == 0x20 && b[1] == 0x02) return false;
             return true;
         }
 

--- a/src/OpenClaw.Shared/HttpUrlValidator.cs
+++ b/src/OpenClaw.Shared/HttpUrlValidator.cs
@@ -1,0 +1,67 @@
+using System;
+
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Strict validator for agent-supplied URLs that the node will hand off to a
+/// browser via shell-execute. Defense-in-depth around <c>canvas.navigate</c>:
+/// the gateway should already only emit http(s), but treating that as
+/// authoritative would let a misbehaving / compromised agent ask the node to
+/// shell-execute <c>file:</c>, <c>javascript:</c>, app-protocol URIs, or
+/// credential-stuffed URLs that visually masquerade as legitimate.
+/// </summary>
+public static class HttpUrlValidator
+{
+    /// <summary>
+    /// Parse <paramref name="raw"/> and accept only absolute http/https URLs
+    /// with a non-empty host and no userinfo. On success, <paramref name="canonical"/>
+    /// is the re-serialized form (<see cref="Uri.AbsoluteUri"/>) — what the
+    /// caller should hand to the OS, not the raw input string.
+    /// </summary>
+    public static bool TryParse(string? raw, out string? canonical, out string? error)
+    {
+        canonical = null;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            error = "url is empty";
+            return false;
+        }
+
+        var trimmed = raw.Trim();
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+        {
+            error = "url is not an absolute URI";
+            return false;
+        }
+
+        // Scheme check is ordinal-ignore-case: Uri lowercases the scheme on
+        // parse, but explicit comparison documents intent and survives any
+        // future Uri changes.
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            error = $"scheme '{uri.Scheme}' is not allowed (only http/https)";
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(uri.Host))
+        {
+            error = "url has no host";
+            return false;
+        }
+
+        // Reject userinfo: https://attacker@evil.com is technically valid HTTP
+        // but is a phishing pattern (the visible "attacker" looks like a host
+        // to non-experts). Browsers warn on these too.
+        if (!string.IsNullOrEmpty(uri.UserInfo))
+        {
+            error = "url contains userinfo (user:password@) which is not allowed";
+            return false;
+        }
+
+        canonical = uri.AbsoluteUri;
+        return true;
+    }
+}

--- a/src/OpenClaw.Shared/Mcp/McpAuthToken.cs
+++ b/src/OpenClaw.Shared/Mcp/McpAuthToken.cs
@@ -7,19 +7,36 @@ namespace OpenClaw.Shared.Mcp;
 /// <summary>
 /// Manages the MCP server's bearer token.
 ///
-/// The token lives in <c>%LOCALAPPDATA%\OpenClaw\mcp-token.txt</c>. Local CLIs
-/// (the planned `openclaw` CLI) and per-user agent registrations read it from
-/// that path so registration is a single mechanical step rather than a config
-/// mutation. The file inherits the LocalAppData ACL — by default only the
-/// current user (and SYSTEM/Administrators) can read it. Plus the loopback
-/// bind keeps the server invisible to other machines, and the Origin/Host
-/// checks block browser cross-origin attacks.
+/// The token lives next to the rest of the tray's settings, at
+/// <c>%APPDATA%\OpenClawTray\mcp-token.txt</c> (the exact path is composed by
+/// the tray from <c>SettingsManager.SettingsDirectoryPath</c> and surfaced as
+/// <c>NodeService.McpTokenPath</c> — that's the source of truth, not anything
+/// in this file). Co-locating with settings means the test-suite override
+/// <c>OPENCLAW_TRAY_DATA_DIR</c> isolates the token file too.
+///
+/// The token is **created lazily on first MCP server start** (i.e. the first
+/// time the user enables Local MCP Server in Settings — until then the file
+/// does not exist) and then **persists across tray restarts**. Local CLIs and
+/// per-user agent registrations read the file and send the contents on every
+/// request as <c>Authorization: Bearer &lt;contents&gt;</c>.
+///
+/// Defense in depth: the file inherits the parent directory's ACL — by default
+/// only the current user (and SYSTEM/Administrators) can read it; the listener
+/// is bound to loopback so the endpoint is invisible to other machines; and
+/// Origin/Host checks block browser cross-origin attacks. The bearer is the
+/// last line of defense against an untrusted local process on the same box.
 /// </summary>
 public static class McpAuthToken
 {
     private const string FileName = "mcp-token.txt";
 
-    /// <summary>Default path under the user's LocalAppData. Created on first read.</summary>
+    /// <summary>
+    /// Fallback path used only when a caller doesn't supply one. The tray itself
+    /// passes a path computed from <c>SettingsManager.SettingsDirectoryPath</c>
+    /// (exposed as <c>NodeService.McpTokenPath</c>) so this constant is **not**
+    /// the live location for OpenClaw Tray installations — it's only a default
+    /// for non-tray consumers (CLIs, tests) that don't want to compute one.
+    /// </summary>
     public static string DefaultPath
     {
         get
@@ -66,9 +83,9 @@ public static class McpAuthToken
         catch { return null; }
     }
 
+    /// <summary>32 bytes (256 bits) of CSPRNG → base64url → 43 ASCII chars (no padding).</summary>
     private static string Generate()
     {
-        // 32 bytes ≈ 256 bits, base64url so it's URL/header safe.
         Span<byte> raw = stackalloc byte[32];
         RandomNumberGenerator.Fill(raw);
         return Convert.ToBase64String(raw)

--- a/src/OpenClaw.Shared/Mcp/McpAuthToken.cs
+++ b/src/OpenClaw.Shared/Mcp/McpAuthToken.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace OpenClaw.Shared.Mcp;
+
+/// <summary>
+/// Manages the MCP server's bearer token.
+///
+/// The token lives in <c>%LOCALAPPDATA%\OpenClaw\mcp-token.txt</c>. Local CLIs
+/// (the planned `openclaw` CLI) and per-user agent registrations read it from
+/// that path so registration is a single mechanical step rather than a config
+/// mutation. The file inherits the LocalAppData ACL — by default only the
+/// current user (and SYSTEM/Administrators) can read it. Plus the loopback
+/// bind keeps the server invisible to other machines, and the Origin/Host
+/// checks block browser cross-origin attacks.
+/// </summary>
+public static class McpAuthToken
+{
+    private const string FileName = "mcp-token.txt";
+
+    /// <summary>Default path under the user's LocalAppData. Created on first read.</summary>
+    public static string DefaultPath
+    {
+        get
+        {
+            var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            return Path.Combine(root, "OpenClaw", FileName);
+        }
+    }
+
+    /// <summary>
+    /// Load the token from <see cref="DefaultPath"/>, creating a fresh random
+    /// one if the file does not exist. Returns the token string.
+    /// </summary>
+    public static string LoadOrCreate() => LoadOrCreate(DefaultPath);
+
+    public static string LoadOrCreate(string path)
+    {
+        if (File.Exists(path))
+        {
+            try
+            {
+                var existing = File.ReadAllText(path).Trim();
+                if (!string.IsNullOrEmpty(existing)) return existing;
+            }
+            catch { /* fall through and regenerate */ }
+        }
+        var dir = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+        var token = Generate();
+        File.WriteAllText(path, token);
+        return token;
+    }
+
+    /// <summary>Read the token without creating a new one. Returns null when missing.</summary>
+    public static string? TryLoad(string? path = null)
+    {
+        path ??= DefaultPath;
+        try
+        {
+            if (!File.Exists(path)) return null;
+            var token = File.ReadAllText(path).Trim();
+            return string.IsNullOrEmpty(token) ? null : token;
+        }
+        catch { return null; }
+    }
+
+    private static string Generate()
+    {
+        // 32 bytes ≈ 256 bits, base64url so it's URL/header safe.
+        Span<byte> raw = stackalloc byte[32];
+        RandomNumberGenerator.Fill(raw);
+        return Convert.ToBase64String(raw)
+            .Replace('+', '-')
+            .Replace('/', '_')
+            .TrimEnd('=');
+    }
+}

--- a/src/OpenClaw.Shared/Mcp/McpAuthToken.cs
+++ b/src/OpenClaw.Shared/Mcp/McpAuthToken.cs
@@ -1,6 +1,9 @@
 using System;
 using System.IO;
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
 using System.Security.Cryptography;
+using System.Security.Principal;
 using System.Text;
 
 namespace OpenClaw.Shared.Mcp;
@@ -55,19 +58,53 @@ public static class McpAuthToken
 
     public static string LoadOrCreate(string path)
     {
+        // The previous behavior would catch any read exception and silently
+        // regenerate. A transient lock or AV scan would then *rotate the
+        // token*, breaking every configured MCP client. Distinguish missing
+        // (regenerate) from unreadable (throw — visible in startup logs).
         if (File.Exists(path))
         {
+            string existing;
             try
             {
-                var existing = File.ReadAllText(path).Trim();
-                if (!string.IsNullOrEmpty(existing)) return existing;
+                existing = File.ReadAllText(path).Trim();
             }
-            catch { /* fall through and regenerate */ }
+            catch (Exception ex)
+            {
+                throw new IOException(
+                    $"MCP token file at '{path}' exists but could not be read: {ex.Message}. " +
+                    "Refusing to regenerate (would invalidate all configured clients).", ex);
+            }
+            if (!string.IsNullOrEmpty(existing)) return existing;
+            // Empty file: treat as missing. The atomic write below replaces it.
         }
         var dir = Path.GetDirectoryName(path);
-        if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+        if (!string.IsNullOrEmpty(dir))
+        {
+            Directory.CreateDirectory(dir);
+            TryRestrictDirectoryAcl(dir);
+        }
+        // Atomic create: stage to a sibling temp file, lock its ACL, then
+        // rename over the target. Without this, a power-loss / process-kill
+        // mid-write would leave a zero-byte token file which the next
+        // LoadOrCreate would treat as "missing" and overwrite — silently
+        // rotating the token.
         var token = Generate();
-        File.WriteAllText(path, token);
+        var tempPath = Path.Combine(
+            string.IsNullOrEmpty(dir) ? Environment.CurrentDirectory : dir,
+            $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            File.WriteAllText(tempPath, token, Encoding.UTF8);
+            TryRestrictFileAcl(tempPath);
+            File.Move(tempPath, path, overwrite: true);
+        }
+        catch
+        {
+            try { if (File.Exists(tempPath)) File.Delete(tempPath); } catch { }
+            throw;
+        }
+        TryRestrictFileAcl(path);
         return token;
     }
 
@@ -77,7 +114,11 @@ public static class McpAuthToken
             throw new ArgumentException("Token path is required", nameof(path));
 
         var dir = Path.GetDirectoryName(path);
-        if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+        if (!string.IsNullOrEmpty(dir))
+        {
+            Directory.CreateDirectory(dir);
+            TryRestrictDirectoryAcl(dir);
+        }
 
         var token = Generate();
         var tempPath = Path.Combine(
@@ -85,7 +126,11 @@ public static class McpAuthToken
             $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
 
         File.WriteAllText(tempPath, token, Encoding.UTF8);
+        TryRestrictFileAcl(tempPath);
         File.Move(tempPath, path, overwrite: true);
+        // Move on Windows preserves the source's DACL; re-apply defensively in
+        // case a future rename strategy substitutes a different file.
+        TryRestrictFileAcl(path);
         return token;
     }
 
@@ -100,6 +145,122 @@ public static class McpAuthToken
             return string.IsNullOrEmpty(token) ? null : token;
         }
         catch { return null; }
+    }
+
+    /// <summary>
+    /// Verify that the token file at <paramref name="path"/> is owned by the
+    /// current user and not readable by anyone outside (Owner, SYSTEM,
+    /// Administrators). Returns null if the file looks fine; returns a
+    /// human-readable warning otherwise so callers can log/toast at startup.
+    /// On non-Windows or when the file does not exist, returns null.
+    /// </summary>
+    public static string? VerifyAcl(string path)
+    {
+        if (string.IsNullOrEmpty(path) || !File.Exists(path)) return null;
+        if (!OperatingSystem.IsWindows()) return null;
+        return VerifyFileAclWindows(path);
+    }
+
+    /// <summary>
+    /// Best-effort: lock the supplied directory's ACL to current user + SYSTEM
+    /// + Administrators with inheritance disabled. No-op on non-Windows.
+    /// Callers should call this when the tray's data directory is created so
+    /// other locally-installed apps under the same user can't read the token
+    /// (or anything else we drop alongside it).
+    /// </summary>
+    public static void TryRestrictDataDirectoryAcl(string dir)
+    {
+        if (string.IsNullOrEmpty(dir)) return;
+        if (!OperatingSystem.IsWindows()) return;
+        try { RestrictDirectoryAclWindows(dir); }
+        catch { /* best-effort; acl restriction is defense-in-depth, not load-bearing */ }
+    }
+
+    private static void TryRestrictFileAcl(string path)
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        try { RestrictFileAclWindows(path); }
+        catch { /* see above */ }
+    }
+
+    private static void TryRestrictDirectoryAcl(string dir) => TryRestrictDataDirectoryAcl(dir);
+
+    [SupportedOSPlatform("windows")]
+    private static void RestrictFileAclWindows(string path)
+    {
+        var info = new FileInfo(path);
+        var sec = new FileSecurity();
+        sec.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+        var owner = WindowsIdentity.GetCurrent().User;
+        if (owner == null) return;
+        sec.SetOwner(owner);
+        sec.AddAccessRule(new FileSystemAccessRule(owner,
+            FileSystemRights.FullControl, AccessControlType.Allow));
+        sec.AddAccessRule(new FileSystemAccessRule(
+            new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null),
+            FileSystemRights.FullControl, AccessControlType.Allow));
+        sec.AddAccessRule(new FileSystemAccessRule(
+            new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+            FileSystemRights.FullControl, AccessControlType.Allow));
+        info.SetAccessControl(sec);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void RestrictDirectoryAclWindows(string dir)
+    {
+        var info = new DirectoryInfo(dir);
+        var sec = new DirectorySecurity();
+        sec.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+        var owner = WindowsIdentity.GetCurrent().User;
+        if (owner == null) return;
+        sec.SetOwner(owner);
+        var inherit = InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit;
+        sec.AddAccessRule(new FileSystemAccessRule(owner,
+            FileSystemRights.FullControl, inherit, PropagationFlags.None, AccessControlType.Allow));
+        sec.AddAccessRule(new FileSystemAccessRule(
+            new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null),
+            FileSystemRights.FullControl, inherit, PropagationFlags.None, AccessControlType.Allow));
+        sec.AddAccessRule(new FileSystemAccessRule(
+            new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+            FileSystemRights.FullControl, inherit, PropagationFlags.None, AccessControlType.Allow));
+        info.SetAccessControl(sec);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static string? VerifyFileAclWindows(string path)
+    {
+        try
+        {
+            var info = new FileInfo(path);
+            var sec = info.GetAccessControl();
+            var ownerSid = sec.GetOwner(typeof(SecurityIdentifier)) as SecurityIdentifier;
+            var current = WindowsIdentity.GetCurrent().User;
+            if (current == null) return null;
+            if (ownerSid == null || !ownerSid.Equals(current))
+            {
+                return $"MCP token file owner is {ownerSid?.Value ?? "<unknown>"}; expected current user {current.Value}. Treat the token as compromised and reset it.";
+            }
+            // Walk the ACL — anything granting read rights to a principal
+            // outside {current user, SYSTEM, Administrators} is broader than
+            // expected.
+            var system = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null);
+            var admins = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+            var rules = sec.GetAccessRules(true, true, typeof(SecurityIdentifier));
+            foreach (FileSystemAccessRule rule in rules)
+            {
+                if (rule.AccessControlType != AccessControlType.Allow) continue;
+                if ((rule.FileSystemRights & (FileSystemRights.Read | FileSystemRights.ReadAndExecute | FileSystemRights.ReadData | FileSystemRights.FullControl | FileSystemRights.Modify)) == 0) continue;
+                if (rule.IdentityReference is SecurityIdentifier sid &&
+                    (sid.Equals(current) || sid.Equals(system) || sid.Equals(admins)))
+                    continue;
+                return $"MCP token file ACL grants read access to {rule.IdentityReference.Value}, broader than expected. Reset the token if this is unexpected.";
+            }
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return $"MCP token ACL inspection failed: {ex.Message}";
+        }
     }
 
     /// <summary>32 bytes (256 bits) of CSPRNG → base64url → 43 ASCII chars (no padding).</summary>

--- a/src/OpenClaw.Shared/Mcp/McpAuthToken.cs
+++ b/src/OpenClaw.Shared/Mcp/McpAuthToken.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Security.Cryptography;
+using System.Text;
 
 namespace OpenClaw.Shared.Mcp;
 
@@ -67,6 +68,24 @@ public static class McpAuthToken
         if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
         var token = Generate();
         File.WriteAllText(path, token);
+        return token;
+    }
+
+    public static string Reset(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("Token path is required", nameof(path));
+
+        var dir = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+
+        var token = Generate();
+        var tempPath = Path.Combine(
+            string.IsNullOrEmpty(dir) ? Environment.CurrentDirectory : dir,
+            $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
+
+        File.WriteAllText(tempPath, token, Encoding.UTF8);
+        File.Move(tempPath, path, overwrite: true);
         return token;
     }
 

--- a/src/OpenClaw.Shared/Mcp/McpAuthToken.cs
+++ b/src/OpenClaw.Shared/Mcp/McpAuthToken.cs
@@ -124,10 +124,17 @@ public static class McpAuthToken
         var tempPath = Path.Combine(
             string.IsNullOrEmpty(dir) ? Environment.CurrentDirectory : dir,
             $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
-
-        File.WriteAllText(tempPath, token, Encoding.UTF8);
-        TryRestrictFileAcl(tempPath);
-        File.Move(tempPath, path, overwrite: true);
+        try
+        {
+            File.WriteAllText(tempPath, token, Encoding.UTF8);
+            TryRestrictFileAcl(tempPath);
+            File.Move(tempPath, path, overwrite: true);
+        }
+        catch
+        {
+            try { if (File.Exists(tempPath)) File.Delete(tempPath); } catch { }
+            throw;
+        }
         // Move on Windows preserves the source's DACL; re-apply defensively in
         // case a future rename strategy substitutes a different file.
         TryRestrictFileAcl(path);

--- a/src/OpenClaw.Shared/Mcp/McpHttpServer.cs
+++ b/src/OpenClaw.Shared/Mcp/McpHttpServer.cs
@@ -26,9 +26,14 @@ namespace OpenClaw.Shared.Mcp;
 ///      satisfy (no Access-Control-Allow-Origin), so the cross-origin call
 ///      fails before reaching capability code.
 ///
-/// No bearer-token auth yet — local user-context processes are intentionally
-/// in-scope of trust (they can already call Win32 directly). Browser pages and
-/// other-machine attackers are not.
+/// Bearer-token auth in front of the JSON-RPC body. Required on every POST when
+/// constructed with a non-null token (the tray always passes one — see
+/// <c>NodeService.McpTokenPath</c> / <c>McpAuthToken.LoadOrCreate</c>; legacy
+/// callers that pass null disable the check, kept for in-process tests). The
+/// token defends against untrusted local processes that could otherwise reach
+/// the predictable 127.0.0.1:port endpoint — a process running as the same
+/// user on the same box can read the token file and would defeat this layer,
+/// but anything sandboxed away from <c>%APPDATA%\OpenClawTray\</c> cannot.
 ///
 /// Stability defenses (CR-003/CR-005):
 ///   - Per-request hard deadline (RequestTimeoutMs) bounds body-read and

--- a/src/OpenClaw.Shared/Mcp/McpHttpServer.cs
+++ b/src/OpenClaw.Shared/Mcp/McpHttpServer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -40,9 +41,13 @@ public sealed class McpHttpServer : IDisposable
 {
     private const long MaxRequestBodyBytes = 4L * 1024 * 1024; // 4 MiB
     private const int MaxConcurrentHandlers = 8;
-    // Generous enough to cover 60s camera.clip plus encoding/serialization
-    // overhead; tight enough to free handler slots if a tool wedges.
-    private const int RequestTimeoutMs = 90_000;
+    // Sized to cover the longest legitimate capability: screen.record up to
+    // 300s plus encoding + serialization. Earlier 90s deadline silently abort
+    // ed valid recording requests while the OS capture pipeline kept running
+    // unobserved (unified review H10). Cancellation now flows through the
+    // capability via INodeCapability.ExecuteAsync(NodeInvokeRequest, CT) so
+    // tools that opt in actually stop the underlying work.
+    private const int RequestTimeoutMs = 360_000;
     // How long Dispose waits for in-flight handlers to drain before forcing
     // tear-down. Past this point handlers may observe disposed services.
     private static readonly TimeSpan DrainTimeout = TimeSpan.FromSeconds(5);
@@ -51,21 +56,29 @@ public sealed class McpHttpServer : IDisposable
     private readonly int _port;
     private readonly IOpenClawLogger _logger;
     private readonly HttpListener _listener;
+    /// <summary>
+    /// Required bearer token for POST requests. Empty/null disables auth (the
+    /// pre-auth contract — kept so existing dev configs keep working). When set,
+    /// every POST must carry <c>Authorization: Bearer &lt;token&gt;</c>.
+    /// </summary>
+    private readonly string? _authToken;
     private readonly CancellationTokenSource _cts = new();
     private readonly SemaphoreSlim _handlerLimiter = new(MaxConcurrentHandlers, MaxConcurrentHandlers);
     private readonly object _activeLock = new();
     private readonly HashSet<Task> _activeHandlers = new();
     private Task? _acceptLoop;
     private int _disposed;
+    private int _stopping;
 
     public int Port => _port;
     public string Endpoint => $"http://127.0.0.1:{_port}/";
 
-    public McpHttpServer(McpToolBridge bridge, int port, IOpenClawLogger logger)
+    public McpHttpServer(McpToolBridge bridge, int port, IOpenClawLogger logger, string? authToken = null)
     {
         _bridge = bridge ?? throw new ArgumentNullException(nameof(bridge));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _port = port;
+        _authToken = string.IsNullOrEmpty(authToken) ? null : authToken;
         _listener = new HttpListener();
         // Loopback binding — not reachable from other machines.
         _listener.Prefixes.Add($"http://127.0.0.1:{port}/");
@@ -195,6 +208,17 @@ public sealed class McpHttpServer : IDisposable
                 return;
             }
 
+            // Bearer-token check. Defends against untrusted local processes
+            // (browser helpers, editor extensions) that share the loopback
+            // surface with the legitimate MCP client. Token lives in a
+            // user-only-readable file under %LOCALAPPDATA%; CLI/agent
+            // registration reads from there.
+            if (_authToken != null && !IsAuthorized(ctx.Request.Headers["Authorization"]))
+            {
+                Reject(ctx, HttpStatusCode.Unauthorized, "missing or invalid bearer token");
+                return;
+            }
+
             // Force application/json on POST. Combined with the Origin check,
             // this means a browser cross-origin fetch must use a non-simple
             // Content-Type and trigger a CORS preflight, which we don't honor.
@@ -262,6 +286,20 @@ public sealed class McpHttpServer : IDisposable
         }
     }
 
+    private bool IsAuthorized(string? authHeader)
+    {
+        if (_authToken == null) return true;
+        if (string.IsNullOrEmpty(authHeader)) return false;
+        // Accept "Bearer <token>" (RFC 6750) — case-insensitive scheme, exact token.
+        const string scheme = "Bearer ";
+        if (!authHeader.StartsWith(scheme, StringComparison.OrdinalIgnoreCase)) return false;
+        var presented = authHeader.Substring(scheme.Length).Trim();
+        // Constant-time compare; both strings already known length.
+        return CryptographicOperations.FixedTimeEquals(
+            Encoding.UTF8.GetBytes(presented),
+            Encoding.UTF8.GetBytes(_authToken));
+    }
+
     private static bool IsHostAllowed(string? host)
     {
         if (string.IsNullOrEmpty(host)) return false;
@@ -315,10 +353,17 @@ public sealed class McpHttpServer : IDisposable
     /// Idempotent. Returns when it is safe to dispose downstream services
     /// (capabilities, capture services) without racing live handlers.
     /// </summary>
-    public async Task StopAsync(TimeSpan drainTimeout)
+    public Task StopAsync(TimeSpan drainTimeout)
     {
-        if (Volatile.Read(ref _disposed) != 0) return;
+        // Idempotence is governed by _stopping (not _disposed) so that Dispose
+        // can call the same drain path *after* setting _disposed=1. The previous
+        // code keyed on _disposed and silently skipped the drain in that flow.
+        if (Interlocked.Exchange(ref _stopping, 1) != 0) return Task.CompletedTask;
+        return StopCoreAsync(drainTimeout);
+    }
 
+    private async Task StopCoreAsync(TimeSpan drainTimeout)
+    {
         try { _cts.Cancel(); } catch { /* already cancelled or disposed */ }
         try { if (_listener.IsListening) _listener.Stop(); } catch { /* already stopped */ }
 
@@ -347,10 +392,30 @@ public sealed class McpHttpServer : IDisposable
     public void Dispose()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
-        // Drain in-flight handlers first so we don't pull the limiter out from
-        // under them. Block here — Dispose is the sync seam.
-        try { StopAsync(DrainTimeout).GetAwaiter().GetResult(); }
-        catch (Exception ex) { _logger.Warn($"[MCP] Drain error: {ex.Message}"); }
+        // Run the drain unconditionally on dispose. We can't go through the
+        // public StopAsync because a prior caller may already have set
+        // _stopping — we still need to wait for the drain to finish before
+        // tearing down the limiter and CTS.
+        if (Interlocked.Exchange(ref _stopping, 1) == 0)
+        {
+            try { StopCoreAsync(DrainTimeout).GetAwaiter().GetResult(); }
+            catch (Exception ex) { _logger.Warn($"[MCP] Drain error: {ex.Message}"); }
+        }
+        else
+        {
+            // A prior StopAsync is in flight; wait briefly for it to finish so
+            // we don't dispose the limiter while a handler is still inside it.
+            lock (_activeLock)
+            {
+                if (_activeHandlers.Count > 0)
+                {
+                    Task[] toAwait = new Task[_activeHandlers.Count];
+                    _activeHandlers.CopyTo(toAwait);
+                    try { Task.WhenAny(Task.WhenAll(toAwait), Task.Delay(DrainTimeout)).GetAwaiter().GetResult(); }
+                    catch { /* swallow — best-effort */ }
+                }
+            }
+        }
         try { _listener.Close(); } catch { /* already closed */ }
         _cts.Dispose();
         _handlerLimiter.Dispose();

--- a/src/OpenClaw.Shared/Mcp/McpHttpServer.cs
+++ b/src/OpenClaw.Shared/Mcp/McpHttpServer.cs
@@ -45,7 +45,11 @@ namespace OpenClaw.Shared.Mcp;
 public sealed class McpHttpServer : IDisposable
 {
     private const long MaxRequestBodyBytes = 4L * 1024 * 1024; // 4 MiB
-    private const int MaxConcurrentHandlers = 8;
+    // 16 leaves headroom for parallel tool callers (e.g. an editor + Claude
+    // Desktop + a CLI script) without making each connection cheap enough to
+    // become a DoS lever — request size cap + per-handler timeout still bound
+    // memory. Bumped from 8 after queue-stall reports under multi-IDE use.
+    private const int MaxConcurrentHandlers = 16;
     // Sized to cover the longest legitimate capability: screen.record up to
     // 300s plus encoding + serialization. Earlier 90s deadline silently abort
     // ed valid recording requests while the OS capture pipeline kept running
@@ -135,7 +139,10 @@ public sealed class McpHttpServer : IDisposable
 
             // Cap concurrent handlers — a misbehaving local client can otherwise
             // pin every threadpool thread on long-running screen/camera calls.
-            if (!await _handlerLimiter.WaitAsync(0, ct).ConfigureAwait(false))
+            // Wait briefly: a slot freed during typical request handoff is well
+            // under 50ms, so a small queue here turns transient spikes into
+            // success rather than 503s without inviting unbounded queueing.
+            if (!await _handlerLimiter.WaitAsync(50, ct).ConfigureAwait(false))
             {
                 Reject(ctx, (HttpStatusCode)503, "server busy");
                 continue;
@@ -192,6 +199,17 @@ public sealed class McpHttpServer : IDisposable
             if (!string.IsNullOrEmpty(origin))
             {
                 Reject(ctx, HttpStatusCode.Forbidden, "origin not allowed");
+                return;
+            }
+            // Belt-and-suspenders: a browser may strip Origin (e.g. via a
+            // privacy extension) but still send Sec-Fetch-Site / Sec-Fetch-Mode
+            // / Referer. Treat any of those as evidence of a browser context.
+            // Native MCP clients don't emit these headers.
+            if (!string.IsNullOrEmpty(ctx.Request.Headers["Sec-Fetch-Site"]) ||
+                !string.IsNullOrEmpty(ctx.Request.Headers["Sec-Fetch-Mode"]) ||
+                !string.IsNullOrEmpty(ctx.Request.Headers["Referer"]))
+            {
+                Reject(ctx, HttpStatusCode.Forbidden, "browser context not allowed");
                 return;
             }
 
@@ -315,10 +333,20 @@ public sealed class McpHttpServer : IDisposable
     private static bool IsHostAllowed(string? host)
     {
         if (string.IsNullOrEmpty(host)) return false;
-        // Strip port if present.
-        var colon = host.LastIndexOf(':');
-        var hostname = (colon > 0 && host.IndexOf(']') < colon ? host.Substring(0, colon) : host).Trim();
+        var trimmed = host.Trim();
+        // IPv6 form: [::1]:port — strip the bracketed address.
+        if (trimmed.StartsWith('['))
+        {
+            var closeBracket = trimmed.IndexOf(']');
+            if (closeBracket < 0) return false;
+            var v6 = trimmed.Substring(1, closeBracket - 1);
+            return string.Equals(v6, "::1", StringComparison.Ordinal);
+        }
+        // IPv4 / hostname: strip trailing :port if present.
+        var colon = trimmed.LastIndexOf(':');
+        var hostname = (colon > 0 ? trimmed.Substring(0, colon) : trimmed).Trim();
         return string.Equals(hostname, "127.0.0.1", StringComparison.Ordinal)
+            || string.Equals(hostname, "::1", StringComparison.Ordinal)
             || string.Equals(hostname, "localhost", StringComparison.OrdinalIgnoreCase);
     }
 
@@ -328,19 +356,28 @@ public sealed class McpHttpServer : IDisposable
         // can send chunked encoding or just lie. Read up to maxBytes+1 and
         // throw if we crossed the cap. The cancellation token enforces the
         // per-request deadline so a slow-body client can't hold a handler slot.
+        // Pool the read buffer so we don't allocate 8 KiB per request — under
+        // load these are a noticeable LOH-adjacent allocation.
         var encoding = request.ContentEncoding ?? Encoding.UTF8;
-        var buffer = new byte[8192];
-        using var ms = new MemoryStream();
-        long total = 0;
-        while (true)
+        var buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(8192);
+        try
         {
-            var n = await request.InputStream.ReadAsync(buffer.AsMemory(0, buffer.Length), ct).ConfigureAwait(false);
-            if (n <= 0) break;
-            total += n;
-            if (total > maxBytes) throw new InvalidDataException("request body exceeds cap");
-            ms.Write(buffer, 0, n);
+            using var ms = new MemoryStream();
+            long total = 0;
+            while (true)
+            {
+                var n = await request.InputStream.ReadAsync(buffer.AsMemory(0, buffer.Length), ct).ConfigureAwait(false);
+                if (n <= 0) break;
+                total += n;
+                if (total > maxBytes) throw new InvalidDataException("request body exceeds cap");
+                ms.Write(buffer, 0, n);
+            }
+            return encoding.GetString(ms.GetBuffer(), 0, (int)ms.Length);
         }
-        return encoding.GetString(ms.GetBuffer(), 0, (int)ms.Length);
+        finally
+        {
+            System.Buffers.ArrayPool<byte>.Shared.Return(buffer);
+        }
     }
 
     private static void Reject(HttpListenerContext ctx, HttpStatusCode status, string reason)

--- a/src/OpenClaw.Shared/Mcp/McpHttpServer.cs
+++ b/src/OpenClaw.Shared/Mcp/McpHttpServer.cs
@@ -66,7 +66,7 @@ public sealed class McpHttpServer : IDisposable
     /// pre-auth contract — kept so existing dev configs keep working). When set,
     /// every POST must carry <c>Authorization: Bearer &lt;token&gt;</c>.
     /// </summary>
-    private readonly string? _authToken;
+    private string? _authToken;
     private readonly CancellationTokenSource _cts = new();
     private readonly SemaphoreSlim _handlerLimiter = new(MaxConcurrentHandlers, MaxConcurrentHandlers);
     private readonly object _activeLock = new();
@@ -95,6 +95,11 @@ public sealed class McpHttpServer : IDisposable
         _listener.Start();
         _acceptLoop = Task.Run(() => AcceptLoopAsync(_cts.Token));
         _logger.Info($"[MCP] HTTP server listening on {Endpoint}");
+    }
+
+    public void UpdateAuthToken(string? authToken)
+    {
+        Volatile.Write(ref _authToken, string.IsNullOrEmpty(authToken) ? null : authToken);
     }
 
     private async Task AcceptLoopAsync(CancellationToken ct)
@@ -293,16 +298,18 @@ public sealed class McpHttpServer : IDisposable
 
     private bool IsAuthorized(string? authHeader)
     {
-        if (_authToken == null) return true;
+        var authToken = Volatile.Read(ref _authToken);
+        if (authToken == null) return true;
         if (string.IsNullOrEmpty(authHeader)) return false;
         // Accept "Bearer <token>" (RFC 6750) — case-insensitive scheme, exact token.
         const string scheme = "Bearer ";
         if (!authHeader.StartsWith(scheme, StringComparison.OrdinalIgnoreCase)) return false;
         var presented = authHeader.Substring(scheme.Length).Trim();
+        if (presented.Length != authToken.Length) return false;
         // Constant-time compare; both strings already known length.
         return CryptographicOperations.FixedTimeEquals(
             Encoding.UTF8.GetBytes(presented),
-            Encoding.UTF8.GetBytes(_authToken));
+            Encoding.UTF8.GetBytes(authToken));
     }
 
     private static bool IsHostAllowed(string? host)

--- a/src/OpenClaw.Shared/Mcp/McpHttpServer.cs
+++ b/src/OpenClaw.Shared/Mcp/McpHttpServer.cs
@@ -190,6 +190,12 @@ public sealed class McpHttpServer : IDisposable
 
     private async Task HandleAsync(HttpListenerContext ctx, CancellationToken ct)
     {
+        // Snapshot the auth token once. UpdateAuthToken can rotate _authToken
+        // on another thread, and reading the field separately for the null-test
+        // and the comparison would let a single request observe two different
+        // values (e.g. enter the auth branch with the old token, then compare
+        // against the new one — or vice versa).
+        var authToken = Volatile.Read(ref _authToken);
         try
         {
             // CSRF/browser gate — reject anything carrying a browser Origin.
@@ -241,7 +247,7 @@ public sealed class McpHttpServer : IDisposable
             // surface with the legitimate MCP client. Token lives in a
             // user-only-readable file under %LOCALAPPDATA%; CLI/agent
             // registration reads from there.
-            if (_authToken != null && !IsAuthorized(ctx.Request.Headers["Authorization"]))
+            if (authToken != null && !IsAuthorized(authToken, ctx.Request.Headers["Authorization"]))
             {
                 Reject(ctx, HttpStatusCode.Unauthorized, "missing or invalid bearer token");
                 return;
@@ -314,10 +320,8 @@ public sealed class McpHttpServer : IDisposable
         }
     }
 
-    private bool IsAuthorized(string? authHeader)
+    private static bool IsAuthorized(string authToken, string? authHeader)
     {
-        var authToken = Volatile.Read(ref _authToken);
-        if (authToken == null) return true;
         if (string.IsNullOrEmpty(authHeader)) return false;
         // Accept "Bearer <token>" (RFC 6750) — case-insensitive scheme, exact token.
         const string scheme = "Bearer ";

--- a/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
+++ b/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
@@ -207,17 +207,22 @@ public class McpToolBridge
         ["canvas.a2ui.reset"] =
             "Reset the Canvas A2UI state, clearing any rendered surfaces.",
 
-        // screen.*
-        ["screen.capture"] =
+        // screen.* — names match the canonical OpenClaw protocol
+        // (apps/shared/OpenClawKit/Sources/OpenClawKit/ScreenCommands.swift).
+        // No screen.list or screen.capture exist in the protocol; previous
+        // drift advertised tools that didn't actually resolve.
+        ["screen.snapshot"] =
             "Capture a screenshot of the specified display. Args: format ('png'|'jpeg', default 'png'), maxWidth (int, default 1920), quality (int 1-100, default 80), monitor / screenIndex (int, default 0 = primary), includePointer (bool, default true). Returns { format, width, height, base64, image } where image is a data: URL.",
-        ["screen.list"] =
-            "List attached displays. Returns { screens: [{ index, name, primary, bounds: {x,y,width,height}, workingArea: {x,y,width,height} }, ...] }.",
+        ["screen.record"] =
+            "Record the specified display for a bounded duration. Args: durationMs (int, required, max 300000), format ('mp4'|'webm', default 'mp4'), monitor / screenIndex (int, default 0 = primary), maxWidth (int, default 1920), fps (int, default 30). Returns { format, durationMs, base64 }.",
 
         // camera.*
         ["camera.list"] =
             "List cameras attached to the Windows node. Returns { cameras: [{ deviceId, name, isDefault }, ...] }.",
         ["camera.snap"] =
             "Capture a still photo from a camera. Args: deviceId (string, optional — defaults to system default camera), format ('jpeg'|'png', default 'jpeg'), maxWidth (int, default 1280), quality (int 1-100, default 80). Returns { format, width, height, base64 }.",
+        ["camera.clip"] =
+            "Record a short clip from a camera. Args: deviceId (string, optional), durationMs (int, required, max 60000), format ('mp4'|'webm', default 'mp4'), maxWidth (int, default 1280). Returns { format, durationMs, base64 }.",
     };
 
     private async Task<object> HandleToolsCallAsync(JsonElement parameters, CancellationToken cancellationToken)
@@ -253,15 +258,15 @@ public class McpToolBridge
         };
 
         _logger.Debug($"[MCP] tools/call {name}");
-        // INodeCapability does not yet take a CancellationToken (changing it
-        // would touch every gateway capability). WaitAsync gives the bridge a
-        // hard deadline: when the request CT fires we abandon waiting and
-        // return a tool error to free the handler slot. The capability's
-        // underlying work may continue but cannot pin the MCP server.
+        // Pass the cancellation token through. Capabilities that override the
+        // CT-aware overload (long-running screen/camera capture) will stop
+        // their underlying pipeline on timeout; legacy capabilities fall back
+        // to the no-CT signature and still benefit from WaitAsync freeing the
+        // bridge's handler slot.
         NodeInvokeResponse response;
         try
         {
-            response = await capability.ExecuteAsync(request).WaitAsync(cancellationToken);
+            response = await capability.ExecuteAsync(request, cancellationToken).WaitAsync(cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
+++ b/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
@@ -206,6 +206,12 @@ public class McpToolBridge
             "Push A2UI v0.8 server→client messages to the Canvas as JSONL. Supported message kinds: beginRendering, surfaceUpdate, dataModelUpdate, deleteSurface (createSurface / v0.9 is rejected). Args: jsonl (string) or jsonlPath (string, must live under the system temp directory), props (object, optional).",
         ["canvas.a2ui.reset"] =
             "Reset the Canvas A2UI state, clearing any rendered surfaces.",
+        ["canvas.a2ui.dump"] =
+            "READ-ALL: Return the full state of every currently-rendered A2UI surface — the component tree, every data-model entry, and any registered secret paths (values redacted). Operators granting MCP access should treat this as equivalent to a screenshot of every open surface, not a normal observability tool.",
+        ["canvas.caps"] =
+            "Report the A2UI feature flags this canvas runtime supports (component catalog, max surfaces, render depth, value-size caps). Diagnostic; no side effects.",
+        ["canvas.a2ui.pushJSONL"] =
+            "Streaming variant of canvas.a2ui.push for very large surfaces. Same protocol contract; jsonlPath argument must live under the system temp directory and is opened via FileStream + GetFinalPathNameByHandle to defeat reparse-point traversal.",
 
         // screen.* — names match the canonical OpenClaw protocol
         // (apps/shared/OpenClawKit/Sources/OpenClawKit/ScreenCommands.swift).

--- a/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
+++ b/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
@@ -153,7 +153,9 @@ public class McpToolBridge
                 tools.Add(new
                 {
                     name = cmd,
-                    description = $"{cap.Category} capability: {cmd}",
+                    description = CommandDescriptions.TryGetValue(cmd, out var desc)
+                        ? desc
+                        : $"{cap.Category} capability: {cmd}",
                     inputSchema = new
                     {
                         type = "object",
@@ -165,6 +167,58 @@ public class McpToolBridge
         }
         return new { tools };
     }
+
+    /// <summary>
+    /// Per-command descriptions advertised via <c>tools/list</c>. Sourced from
+    /// the OpenClaw docs (docs/nodes/index.md, docs/platforms/mac/canvas.md) and
+    /// the capability implementations under <c>OpenClaw.Shared.Capabilities</c>.
+    /// Unknown commands fall back to a generic <c>{category} capability: {cmd}</c>
+    /// label so newly-added capabilities still render before this table is updated.
+    /// </summary>
+    private static readonly Dictionary<string, string> CommandDescriptions = new(StringComparer.Ordinal)
+    {
+        // system.*
+        ["system.notify"] =
+            "Show a Windows toast notification on the node. Args: title (string, default 'OpenClaw'), body (string), subtitle (string), sound (bool, default true). Returns { sent: true }.",
+        ["system.run"] =
+            "Execute a shell command on the Windows node host. Args: command (string or string[] argv, required), args (string[]), shell (string), cwd (string), timeoutMs (int, default 30000), env (object). Subject to the local exec approval policy. Returns { stdout, stderr, exitCode, timedOut, durationMs }.",
+        ["system.run.prepare"] =
+            "Pre-flight a system.run invocation: returns the parsed execution plan (argv, cwd, rawCommand, agentId, sessionKey) without running anything. The gateway uses this to build its approval context before the actual run.",
+        ["system.which"] =
+            "Resolve executable names to absolute paths by searching PATH (PATHEXT-aware on Windows). Args: bins (string[], required). Returns { bins: { name: resolvedPath, ... } } including only names that were found.",
+        ["system.execApprovals.get"] =
+            "Return the current exec approval policy: { enabled, defaultAction ('allow'|'deny'|'prompt'), rules: [{ pattern, action, shells, description, enabled }, ...] }.",
+        ["system.execApprovals.set"] =
+            "Replace the exec approval policy. Args: rules (array of { pattern, action, shells?, description?, enabled? }), defaultAction (string, optional). Persisted to disk; used by future system.run calls.",
+
+        // canvas.* — agent-controlled WebView2 panel for HTML/CSS/JS, A2UI, and small interactive UI surfaces.
+        ["canvas.present"] =
+            "Show the agent-controlled Canvas window (WebView2). Args: url (string) or html (string), width (int, default 800), height (int, default 600), x/y (int, -1 = center), title (string, default 'Canvas'), alwaysOnTop (bool, default false). The Canvas is a lightweight visual workspace for HTML/CSS/JS, A2UI, and small interactive UI surfaces.",
+        ["canvas.hide"] =
+            "Hide the Canvas window without destroying its state.",
+        ["canvas.navigate"] =
+            "Navigate the existing Canvas to a new location. Args: url (string, required) — accepts http(s), file://, or local canvas paths.",
+        ["canvas.eval"] =
+            "Evaluate a JavaScript expression inside the Canvas WebView and return its result. Args: script | javaScript | javascript (string, required).",
+        ["canvas.snapshot"] =
+            "Capture the Canvas viewport as a base64-encoded image. Args: format ('png'|'jpeg', default 'png'), maxWidth (int, default 1200), quality (int 1-100, default 80). Returns { format, base64 }.",
+        ["canvas.a2ui.push"] =
+            "Push A2UI v0.8 server→client messages to the Canvas as JSONL. Supported message kinds: beginRendering, surfaceUpdate, dataModelUpdate, deleteSurface (createSurface / v0.9 is rejected). Args: jsonl (string) or jsonlPath (string, must live under the system temp directory), props (object, optional).",
+        ["canvas.a2ui.reset"] =
+            "Reset the Canvas A2UI state, clearing any rendered surfaces.",
+
+        // screen.*
+        ["screen.capture"] =
+            "Capture a screenshot of the specified display. Args: format ('png'|'jpeg', default 'png'), maxWidth (int, default 1920), quality (int 1-100, default 80), monitor / screenIndex (int, default 0 = primary), includePointer (bool, default true). Returns { format, width, height, base64, image } where image is a data: URL.",
+        ["screen.list"] =
+            "List attached displays. Returns { screens: [{ index, name, primary, bounds: {x,y,width,height}, workingArea: {x,y,width,height} }, ...] }.",
+
+        // camera.*
+        ["camera.list"] =
+            "List cameras attached to the Windows node. Returns { cameras: [{ deviceId, name, isDefault }, ...] }.",
+        ["camera.snap"] =
+            "Capture a still photo from a camera. Args: deviceId (string, optional — defaults to system default camera), format ('jpeg'|'png', default 'jpeg'), maxWidth (int, default 1280), quality (int 1-100, default 80). Returns { format, width, height, base64 }.",
+    };
 
     private async Task<object> HandleToolsCallAsync(JsonElement parameters, CancellationToken cancellationToken)
     {

--- a/src/OpenClaw.Shared/NodeCapabilities.cs
+++ b/src/OpenClaw.Shared/NodeCapabilities.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace OpenClaw.Shared;
@@ -53,15 +54,25 @@ public interface INodeCapability
 {
     /// <summary>The capability category (canvas, camera, screen, system)</summary>
     string Category { get; }
-    
+
     /// <summary>Commands this capability can handle</summary>
     IReadOnlyList<string> Commands { get; }
-    
+
     /// <summary>Check if this capability can handle the given command</summary>
     bool CanHandle(string command);
-    
+
     /// <summary>Execute a command and return the result</summary>
     Task<NodeInvokeResponse> ExecuteAsync(NodeInvokeRequest request);
+
+    /// <summary>
+    /// Execute a command with a cancellation token. The default implementation
+    /// just calls <see cref="ExecuteAsync(NodeInvokeRequest)"/>; capabilities
+    /// with long-running work (screen.record, camera.clip) should override so
+    /// MCP request cancellation propagates into the underlying capture
+    /// pipeline rather than orphaning it.
+    /// </summary>
+    Task<NodeInvokeResponse> ExecuteAsync(NodeInvokeRequest request, CancellationToken cancellationToken)
+        => ExecuteAsync(request);
 }
 
 /// <summary>
@@ -71,20 +82,23 @@ public abstract class NodeCapabilityBase : INodeCapability
 {
     public abstract string Category { get; }
     public abstract IReadOnlyList<string> Commands { get; }
-    
+
     protected IOpenClawLogger Logger { get; }
-    
+
     protected NodeCapabilityBase(IOpenClawLogger logger)
     {
         Logger = logger;
     }
-    
+
     public virtual bool CanHandle(string command)
     {
         return Commands.Contains(command);
     }
-    
+
     public abstract Task<NodeInvokeResponse> ExecuteAsync(NodeInvokeRequest request);
+
+    public virtual Task<NodeInvokeResponse> ExecuteAsync(NodeInvokeRequest request, CancellationToken cancellationToken)
+        => ExecuteAsync(request);
     
     protected NodeInvokeResponse Success(object? payload = null)
     {

--- a/src/OpenClaw.Shared/SettingsData.cs
+++ b/src/OpenClaw.Shared/SettingsData.cs
@@ -37,6 +37,12 @@ public class SettingsData
     /// <summary>Run the local MCP HTTP server. Independent of EnableNodeMode.</summary>
     public bool EnableMcpServer { get; set; } = false;
     /// <summary>
+    /// Hostnames the A2UI image renderer is allowed to fetch over HTTPS.
+    /// Empty by default — agents can still ship inline data: images. Add hosts
+    /// (e.g., "cdn.example.com") via the Settings window.
+    /// </summary>
+    public List<string>? A2UIImageHosts { get; set; }
+    /// <summary>
     /// Legacy flag (replaced by EnableMcpServer + the EnableNodeMode pair).
     /// Kept for one-time migration on Load; not written on Save.
     /// </summary>

--- a/src/OpenClaw.Shared/TokenSanitizer.cs
+++ b/src/OpenClaw.Shared/TokenSanitizer.cs
@@ -1,0 +1,30 @@
+using System.Text.RegularExpressions;
+
+namespace OpenClaw.Shared;
+
+public static class TokenSanitizer
+{
+    private static readonly Regex AuthorizationBearerPattern = new(
+        @"(?i)(Authorization\s*:\s*Bearer\s+)([^\s""',;]+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex JsonSecretFieldPattern = new(
+        @"""(?<key>[^""]*(?:token|secret|bearer|authorization)[^""]*)""\s*:\s*""(?<value>[^""]+)""",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static readonly Regex LongBase64UrlPattern = new(
+        @"(?<![A-Za-z0-9_-])[A-Za-z0-9_-]{43}(?![A-Za-z0-9_-])",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static string Sanitize(string? message)
+    {
+        if (string.IsNullOrEmpty(message))
+            return message ?? string.Empty;
+
+        var sanitized = AuthorizationBearerPattern.Replace(message, "$1[REDACTED]");
+        sanitized = JsonSecretFieldPattern.Replace(
+            sanitized,
+            match => $"\"{match.Groups["key"].Value}\":\"[REDACTED]\"");
+        return LongBase64UrlPattern.Replace(sanitized, "[REDACTED_TOKEN]");
+    }
+}

--- a/src/OpenClaw.Shared/UrlLogSanitizer.cs
+++ b/src/OpenClaw.Shared/UrlLogSanitizer.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Reduce a URL to the parts that are safe to write to disk-backed logs.
+/// Query strings routinely carry tokens, codes, signatures, email addresses,
+/// and PII; the log-rotation policy on a developer machine is "never", so
+/// anything we put in the log file effectively lives forever.
+///
+/// The shape is "scheme://host[:port]/<first-segment>/…" — enough to triage,
+/// not enough to replay an OAuth callback or recover a credential. URLs that
+/// fail to parse are returned as the literal "&lt;unparseable URL&gt;" rather
+/// than echoed back, so a deliberately malformed string can't slip through.
+/// </summary>
+public static class UrlLogSanitizer
+{
+    public static string Sanitize(string? url)
+    {
+        if (string.IsNullOrEmpty(url)) return "<empty>";
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return "<unparseable URL>";
+
+        var origin = uri.GetLeftPart(UriPartial.Authority);
+        var path = uri.AbsolutePath;
+        if (string.IsNullOrEmpty(path) || path == "/") return origin + "/";
+
+        // Keep only the first segment so a /reset-password/<token> style path
+        // doesn't leak the bearer-equivalent secret in the segment itself.
+        var firstSlash = path.IndexOf('/', 1);
+        var firstSegment = firstSlash < 0 ? path : path.Substring(0, firstSlash);
+        return origin + firstSegment + (firstSlash < 0 ? string.Empty : "/…");
+    }
+}

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -926,9 +926,10 @@ public class WindowsNodeClient : WebSocketClientBase
     /// Method namespace is <c>canvas.a2ui.action</c> so the gateway can route
     /// it to the originating agent. Safe to call when not connected — drops.
     /// </summary>
-    public async Task SendCanvasA2UIActionAsync(object payload)
+    public async Task SendCanvasA2UIActionAsync(System.Text.Json.Nodes.JsonObject payload)
     {
         if (!_isConnected) return;
+        if (payload is null) throw new ArgumentNullException(nameof(payload));
 
         var msg = new
         {

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -920,6 +920,27 @@ public class WindowsNodeClient : WebSocketClientBase
         await SendRawAsync(JsonSerializer.Serialize(msg));
     }
     
+    /// <summary>
+    /// Send a node-originated A2UI action notification to the gateway. The
+    /// payload follows the v0.8 client→server envelope ({ "action": {...} }).
+    /// Method namespace is <c>canvas.a2ui.action</c> so the gateway can route
+    /// it to the originating agent. Safe to call when not connected — drops.
+    /// </summary>
+    public async Task SendCanvasA2UIActionAsync(object payload)
+    {
+        if (!_isConnected) return;
+
+        var msg = new
+        {
+            type = "req",
+            id = Guid.NewGuid().ToString(),
+            method = "canvas.a2ui.action",
+            @params = payload,
+        };
+
+        await SendRawAsync(JsonSerializer.Serialize(msg, s_ignoreNullOptions));
+    }
+
     private async Task SendPongAsync(string? requestId)
     {
         if (requestId == null) return;

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -66,7 +66,10 @@ public class WindowsNodeClient : WebSocketClientBase
     
     /// <summary>Full device ID for approval command</summary>
     public string FullDeviceId => _deviceIdentity.DeviceId;
-    
+
+    /// <summary>Human-readable display name surfaced to the gateway and other nodes.</summary>
+    public string DisplayName => _registration.DisplayName;
+
     protected override int ReceiveBufferSize => 65536;
     protected override string ClientRole => "node";
     
@@ -921,25 +924,48 @@ public class WindowsNodeClient : WebSocketClientBase
     }
     
     /// <summary>
-    /// Send a node-originated A2UI action notification to the gateway. The
-    /// payload follows the v0.8 client→server envelope ({ "action": {...} }).
-    /// Method namespace is <c>canvas.a2ui.action</c> so the gateway can route
-    /// it to the originating agent. Safe to call when not connected — drops.
+    /// Send a generic node-event to the gateway. Mirrors the Android
+    /// <c>GatewaySession.sendNodeEvent</c> wire shape: a JSON-RPC request with
+    /// method <c>node.event</c> and params <c>{ event, payloadJSON }</c>,
+    /// where <c>payloadJSON</c> is the inner payload as a *string*, not a
+    /// nested object. The gateway's node-event dispatcher
+    /// (<c>server-node-events.ts</c>) then re-parses it.
+    ///
+    /// Returns false when not connected so callers can surface a status to the
+    /// renderer (e.g. clear a button-loading spinner with an error). Throws on
+    /// argument problems but swallows transport-layer errors as false.
     /// </summary>
-    public async Task SendCanvasA2UIActionAsync(System.Text.Json.Nodes.JsonObject payload)
+    public async Task<bool> SendNodeEventAsync(string eventName, System.Text.Json.Nodes.JsonObject payload)
     {
-        if (!_isConnected) return;
+        if (string.IsNullOrEmpty(eventName)) throw new ArgumentException("eventName is required", nameof(eventName));
         if (payload is null) throw new ArgumentNullException(nameof(payload));
+        if (!_isConnected) return false;
 
+        // payloadJSON is a STRING containing JSON, matching the Android wire
+        // shape and the gateway's parser at server-node-events.ts:380 which
+        // does JSON.parse(evt.payloadJSON).
         var msg = new
         {
             type = "req",
             id = Guid.NewGuid().ToString(),
-            method = "canvas.a2ui.action",
-            @params = payload,
+            method = "node.event",
+            @params = new
+            {
+                @event = eventName,
+                payloadJSON = payload.ToJsonString(),
+            },
         };
 
-        await SendRawAsync(JsonSerializer.Serialize(msg, s_ignoreNullOptions));
+        try
+        {
+            await SendRawAsync(JsonSerializer.Serialize(msg, s_ignoreNullOptions));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"node.event '{eventName}' send failed: {ex.Message}");
+            return false;
+        }
     }
 
     private async Task SendPongAsync(string? requestId)

--- a/src/OpenClaw.Tray.WinUI/A2UI/Actions/AgentMessageFormatter.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Actions/AgentMessageFormatter.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenClawTray.A2UI.Actions;
+
+/// <summary>
+/// Builds the single-line tagged user message that the gateway appends to the
+/// agent session when an A2UI action fires. Byte-for-byte port of the Android
+/// reference (<c>OpenClawCanvasA2UIAction.formatAgentMessage</c>) so the LLM
+/// sees identical input regardless of which node emitted it.
+/// </summary>
+public static class AgentMessageFormatter
+{
+    /// <summary>
+    /// Sanitize a tag value for inclusion in the space-separated CANVAS_A2UI
+    /// line. Whitespace becomes <c>_</c>; any character outside
+    /// <c>[A-Za-z0-9_\-.:]</c> becomes <c>_</c>; empty/whitespace inputs
+    /// become <c>-</c> (so we never emit a bare <c>key=</c>).
+    /// </summary>
+    public static string SanitizeTagValue(string? value)
+    {
+        var trimmed = (value ?? string.Empty).Trim();
+        if (trimmed.Length == 0) return "-";
+        var normalized = trimmed.Replace(' ', '_');
+        var sb = new StringBuilder(normalized.Length);
+        foreach (var c in normalized)
+        {
+            bool ok = char.IsLetterOrDigit(c) || c == '_' || c == '-' || c == '.' || c == ':';
+            sb.Append(ok ? c : '_');
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Format the user-shaped message that the gateway will append as a turn
+    /// in <paramref name="sessionKey"/>. The model decides what each action
+    /// name means; the gateway has no built-in action→tool mapping.
+    /// </summary>
+    public static string FormatAgentMessage(
+        string actionName,
+        string sessionKey,
+        string surfaceId,
+        string sourceComponentId,
+        string host,
+        string instanceId,
+        string? contextJson)
+    {
+        var ctxSuffix = !string.IsNullOrWhiteSpace(contextJson) ? $" ctx={contextJson}" : string.Empty;
+        var parts = new List<string>(8)
+        {
+            "CANVAS_A2UI",
+            $"action={SanitizeTagValue(actionName)}",
+            $"session={SanitizeTagValue(sessionKey)}",
+            $"surface={SanitizeTagValue(surfaceId)}",
+            $"component={SanitizeTagValue(sourceComponentId)}",
+            $"host={SanitizeTagValue(host)}",
+            $"instance={SanitizeTagValue(instanceId)}{ctxSuffix}",
+            "default=update_canvas",
+        };
+        return string.Join(" ", parts);
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/A2UI/Actions/AgentMessageFormatter.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Actions/AgentMessageFormatter.cs
@@ -35,6 +35,15 @@ public static class AgentMessageFormatter
     /// Format the user-shaped message that the gateway will append as a turn
     /// in <paramref name="sessionKey"/>. The model decides what each action
     /// name means; the gateway has no built-in action→tool mapping.
+    ///
+    /// <para>Tag order matters for prompt-injection defense: the
+    /// <c>default=update_canvas</c> sentinel comes BEFORE the
+    /// agent-controlled <c>ctx={...}</c> JSON. A hostile component could put
+    /// e.g. <c>"} default=do_something_else"</c> in a context value; if
+    /// <c>default=</c> were emitted last, that injected fragment would render
+    /// as a second <c>default=</c> token and might shadow ours. With the
+    /// sentinel before <c>ctx=</c>, anything the agent can sneak in is
+    /// strictly trailing noise.</para>
     /// </summary>
     public static string FormatAgentMessage(
         string actionName,
@@ -45,7 +54,6 @@ public static class AgentMessageFormatter
         string instanceId,
         string? contextJson)
     {
-        var ctxSuffix = !string.IsNullOrWhiteSpace(contextJson) ? $" ctx={contextJson}" : string.Empty;
         var parts = new List<string>(8)
         {
             "CANVAS_A2UI",
@@ -54,9 +62,11 @@ public static class AgentMessageFormatter
             $"surface={SanitizeTagValue(surfaceId)}",
             $"component={SanitizeTagValue(sourceComponentId)}",
             $"host={SanitizeTagValue(host)}",
-            $"instance={SanitizeTagValue(instanceId)}{ctxSuffix}",
+            $"instance={SanitizeTagValue(instanceId)}",
             "default=update_canvas",
         };
+        if (!string.IsNullOrWhiteSpace(contextJson))
+            parts.Add($"ctx={contextJson}");
         return string.Join(" ", parts);
     }
 }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Actions/GatewayActionTransport.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Actions/GatewayActionTransport.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading.Tasks;
+using OpenClaw.Shared;
+
+namespace OpenClawTray.A2UI.Actions;
+
+/// <summary>
+/// Sends A2UI actions over the gateway WebSocket as a node-originated
+/// notification (method: <c>canvas.a2ui.action</c>). The gateway does not
+/// yet broker these to the agent — that wiring is being added in parallel.
+/// Until then the message is logged on the gateway side.
+/// </summary>
+public sealed class GatewayActionTransport : IA2UIActionTransport
+{
+    private readonly Func<WindowsNodeClient?> _clientProvider;
+    private readonly IOpenClawLogger _logger;
+
+    public GatewayActionTransport(Func<WindowsNodeClient?> clientProvider, IOpenClawLogger logger)
+    {
+        _clientProvider = clientProvider;
+        _logger = logger;
+    }
+
+    public bool IsAvailable => _clientProvider()?.IsConnected == true;
+
+    public Task DeliverAsync(Protocol.A2UIAction action)
+    {
+        var client = _clientProvider();
+        if (client == null || !client.IsConnected)
+            throw new InvalidOperationException("Gateway not connected");
+
+        var envelope = A2UIActionEnvelope.ToEnvelope(action);
+        return client.SendCanvasA2UIActionAsync(envelope);
+    }
+}
+
+/// <summary>
+/// Logs the action and stores the last N for diagnostics. Used as a final
+/// fallback when no real transport is available, so MCP-only nodes don't
+/// silently drop interactions during development.
+/// </summary>
+public sealed class LoggingActionTransport : IA2UIActionTransport
+{
+    private readonly IOpenClawLogger _logger;
+    public LoggingActionTransport(IOpenClawLogger logger) { _logger = logger; }
+    public bool IsAvailable => true;
+    public Task DeliverAsync(Protocol.A2UIAction action)
+    {
+        _logger.Info($"[A2UI] action '{action.Name}' from {action.SourceComponentId ?? "?"} on surface '{action.SurfaceId}' (no remote sink): {A2UIActionEnvelope.Serialize(action)}");
+        return Task.CompletedTask;
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/A2UI/Actions/GatewayActionTransport.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Actions/GatewayActionTransport.cs
@@ -25,6 +25,9 @@ public sealed class GatewayActionTransport : IA2UIActionTransport
 
     public Task DeliverAsync(Protocol.A2UIAction action)
     {
+        // Capture once: between IsAvailable and here the dispatcher may have
+        // disconnected/recreated the client, and a second call to the provider
+        // can return a different instance.
         var client = _clientProvider();
         if (client == null || !client.IsConnected)
             throw new InvalidOperationException("Gateway not connected");
@@ -41,12 +44,28 @@ public sealed class GatewayActionTransport : IA2UIActionTransport
 /// </summary>
 public sealed class LoggingActionTransport : IA2UIActionTransport
 {
+    /// <summary>
+    /// When true, log the full serialized envelope including action context.
+    /// Default false: context can carry user-typed form values that the spec
+    /// considers privacy-relevant (and the agent already sees over the wire).
+    /// </summary>
+    public bool LogFullEnvelope { get; set; }
+
     private readonly IOpenClawLogger _logger;
     public LoggingActionTransport(IOpenClawLogger logger) { _logger = logger; }
     public bool IsAvailable => true;
     public Task DeliverAsync(Protocol.A2UIAction action)
     {
-        _logger.Info($"[A2UI] action '{action.Name}' from {action.SourceComponentId ?? "?"} on surface '{action.SurfaceId}' (no remote sink): {A2UIActionEnvelope.Serialize(action)}");
+        if (LogFullEnvelope)
+        {
+            _logger.Info($"[A2UI] action '{action.Name}' from {action.SourceComponentId ?? "?"} on surface '{action.SurfaceId}' (no remote sink): {A2UIActionEnvelope.Serialize(action)}");
+        }
+        else
+        {
+            // Default: identifiers only — drops the action context payload that
+            // would otherwise carry form/PII data into the log file.
+            _logger.Info($"[A2UI] action '{action.Name}' from {action.SourceComponentId ?? "?"} on surface '{action.SurfaceId}' (no remote sink)");
+        }
         return Task.CompletedTask;
     }
 }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Actions/GatewayActionTransport.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Actions/GatewayActionTransport.cs
@@ -1,39 +1,137 @@
 using System;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using OpenClaw.Shared;
 
 namespace OpenClawTray.A2UI.Actions;
 
 /// <summary>
-/// Sends A2UI actions over the gateway WebSocket as a node-originated
-/// notification (method: <c>canvas.a2ui.action</c>). The gateway does not
-/// yet broker these to the agent — that wiring is being added in parallel.
-/// Until then the message is logged on the gateway side.
+/// Per-node identity / session context the transport needs to format the
+/// CANVAS_A2UI message. Supplied by NodeService — sessionKey can change over
+/// the lifetime of the node (re-resolved on each delivery), the rest is
+/// effectively immutable per process.
+/// </summary>
+public interface IGatewayActionContext
+{
+    /// <summary>Logical session the action should be appended to. Defaults to "main".</summary>
+    string SessionKey { get; }
+    /// <summary>Display name of this node (e.g. "Windows Node (DESKTOP-123)") — shown to the model as <c>host=</c>.</summary>
+    string Host { get; }
+    /// <summary>Stable per-device id, lowercased — shown to the model as <c>instance=</c>.</summary>
+    string InstanceId { get; }
+}
+
+/// <summary>
+/// Raised after a transport attempt so the renderer can clear a spinner / show
+/// an error. Mirrors the Android <c>jsDispatchA2UIActionStatus</c> path but
+/// stays in-process.
+/// </summary>
+public sealed class A2UIActionStatusEventArgs : EventArgs
+{
+    public required string ActionId { get; init; }
+    public required bool Ok { get; init; }
+    public string? Error { get; init; }
+}
+
+/// <summary>
+/// Sends A2UI actions to the gateway by formatting them as a tagged user
+/// message and delivering through the gateway's <c>agent.request</c> node-event
+/// channel (the same path Android uses, see
+/// <c>NodeRuntime.handleCanvasA2UIActionFromWebView</c>). The gateway appends
+/// the message as a user turn in the named session and runs an agent step;
+/// there is no server-side action→tool registry — the model decides.
 /// </summary>
 public sealed class GatewayActionTransport : IA2UIActionTransport
 {
     private readonly Func<WindowsNodeClient?> _clientProvider;
+    private readonly IGatewayActionContext _context;
     private readonly IOpenClawLogger _logger;
 
-    public GatewayActionTransport(Func<WindowsNodeClient?> clientProvider, IOpenClawLogger logger)
+    /// <summary>Raised after each delivery attempt — successful or not.</summary>
+    public event EventHandler<A2UIActionStatusEventArgs>? ActionStatus;
+
+    public GatewayActionTransport(
+        Func<WindowsNodeClient?> clientProvider,
+        IGatewayActionContext context,
+        IOpenClawLogger logger)
     {
         _clientProvider = clientProvider;
+        _context = context;
         _logger = logger;
     }
 
     public bool IsAvailable => _clientProvider()?.IsConnected == true;
 
-    public Task DeliverAsync(Protocol.A2UIAction action)
+    public async Task DeliverAsync(Protocol.A2UIAction action)
     {
         // Capture once: between IsAvailable and here the dispatcher may have
         // disconnected/recreated the client, and a second call to the provider
         // can return a different instance.
         var client = _clientProvider();
         if (client == null || !client.IsConnected)
+        {
+            RaiseStatus(action.Id, ok: false, error: "gateway not connected");
             throw new InvalidOperationException("Gateway not connected");
+        }
 
-        var envelope = A2UIActionEnvelope.ToEnvelope(action);
-        return client.SendCanvasA2UIActionAsync(envelope);
+        var payload = BuildAgentRequestPayload(action, _context);
+        var sent = await client.SendNodeEventAsync("agent.request", payload).ConfigureAwait(false);
+        if (!sent)
+        {
+            RaiseStatus(action.Id, ok: false, error: "send failed");
+            throw new InvalidOperationException("Gateway send failed");
+        }
+
+        RaiseStatus(action.Id, ok: true, error: null);
+    }
+
+    /// <summary>
+    /// Build the <c>agent.request</c> deep-link payload that the gateway
+    /// receives via <c>node.event</c>. Pure helper — exposed for tests so the
+    /// wire contract can be asserted without spinning up a real node client.
+    /// </summary>
+    public static JsonObject BuildAgentRequestPayload(Protocol.A2UIAction action, IGatewayActionContext context)
+    {
+        var sessionKey = string.IsNullOrWhiteSpace(context.SessionKey) ? "main" : context.SessionKey;
+        var contextJson = action.Context?.ToJsonString();
+
+        var message = AgentMessageFormatter.FormatAgentMessage(
+            actionName: action.Name,
+            sessionKey: sessionKey,
+            surfaceId: action.SurfaceId,
+            sourceComponentId: action.SourceComponentId ?? string.Empty,
+            host: context.Host,
+            instanceId: context.InstanceId,
+            contextJson: contextJson);
+
+        // deliver=false keeps the raw CANVAS_A2UI line out of the visible
+        // chat; only the model's response is shown to the user. thinking=low
+        // matches the Android budget hint for a quick agentic step.
+        return new JsonObject
+        {
+            ["message"] = message,
+            ["sessionKey"] = sessionKey,
+            ["thinking"] = "low",
+            ["deliver"] = false,
+            ["key"] = action.Id,
+        };
+    }
+
+    private void RaiseStatus(string actionId, bool ok, string? error)
+    {
+        try
+        {
+            ActionStatus?.Invoke(this, new A2UIActionStatusEventArgs
+            {
+                ActionId = actionId,
+                Ok = ok,
+                Error = error,
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"[A2UI] ActionStatus listener threw: {ex.Message}");
+        }
     }
 }
 

--- a/src/OpenClaw.Tray.WinUI/A2UI/Actions/GatewayActionTransport.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Actions/GatewayActionTransport.cs
@@ -92,7 +92,15 @@ public sealed class GatewayActionTransport : IA2UIActionTransport
     /// </summary>
     public static JsonObject BuildAgentRequestPayload(Protocol.A2UIAction action, IGatewayActionContext context)
     {
-        var sessionKey = string.IsNullOrWhiteSpace(context.SessionKey) ? "main" : context.SessionKey;
+        // Sanitize the top-level sessionKey, not just the value rendered into
+        // the CANVAS_A2UI tag line. The gateway uses this field to *route* the
+        // message to a session record; an unsanitized value can carry path
+        // separators, control chars, or whitespace that the gateway never
+        // expected. Match the same character class as the tag formatter.
+        var rawSessionKey = string.IsNullOrWhiteSpace(context.SessionKey) ? "main" : context.SessionKey;
+        var sessionKey = AgentMessageFormatter.SanitizeTagValue(rawSessionKey);
+        if (sessionKey == "-") sessionKey = "main";
+
         var contextJson = action.Context?.ToJsonString();
 
         var message = AgentMessageFormatter.FormatAgentMessage(

--- a/src/OpenClaw.Tray.WinUI/A2UI/Actions/IActionSink.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Actions/IActionSink.cs
@@ -26,12 +26,18 @@ public interface IActionSink
 /// </summary>
 public sealed class ActionDispatcher : IActionSink
 {
+    /// <summary>Cap for the debounce dictionary. Sweeps oldest entries past <see cref="DebounceWindow"/>.</summary>
+    internal const int MaxDebounceEntries = 256;
+    /// <summary>Cap for the fallback queue. Drops oldest on overflow so the newest action still ships.</summary>
+    internal const int MaxFallbackQueue = 200;
+
     private readonly IReadOnlyList<IA2UIActionTransport> _transports;
     private readonly IOpenClawLogger _logger;
     private readonly ConcurrentQueue<A2UIAction> _fallback = new();
     private readonly Dictionary<string, DateTimeOffset> _lastDelivery = new();
     private static readonly TimeSpan DebounceWindow = TimeSpan.FromMilliseconds(200);
     private readonly object _debounceLock = new();
+    private readonly System.Threading.SemaphoreSlim _sendGate = new(1, 1);
 
     public ActionDispatcher(IReadOnlyList<IA2UIActionTransport> transports, IOpenClawLogger logger)
     {
@@ -54,29 +60,65 @@ public sealed class ActionDispatcher : IActionSink
             if (_lastDelivery.TryGetValue(key, out var last) && (now - last) < DebounceWindow)
                 return true;
             _lastDelivery[key] = now;
+            // Sweep stale entries when the dict gets large. Keeps memory bounded
+            // even when the agent emits actions with constantly-changing keys.
+            if (_lastDelivery.Count > MaxDebounceEntries)
+            {
+                var cutoff = now - DebounceWindow;
+                var stale = new List<string>();
+                foreach (var kv in _lastDelivery)
+                    if (kv.Value < cutoff) stale.Add(kv.Key);
+                foreach (var k in stale) _lastDelivery.Remove(k);
+                // If sweep didn't reclaim enough, evict arbitrarily — this only
+                // affects debounce, not delivery semantics.
+                if (_lastDelivery.Count > MaxDebounceEntries)
+                {
+                    int over = _lastDelivery.Count - MaxDebounceEntries;
+                    var toRemove = new List<string>(over);
+                    foreach (var k in _lastDelivery.Keys) { toRemove.Add(k); if (toRemove.Count >= over) break; }
+                    foreach (var k in toRemove) _lastDelivery.Remove(k);
+                }
+            }
         }
         return false;
     }
 
     private async Task SendAsync(A2UIAction action)
     {
-        // Drain any backlog first so order is preserved.
-        while (_fallback.TryPeek(out var pending))
+        // Single-flight send loop. Without this, two concurrent Raise calls each
+        // try to drain _fallback, racing on TryPeek/TryDequeue and producing
+        // out-of-order delivery under contention. (Unified review M8.)
+        await _sendGate.WaitAsync().ConfigureAwait(false);
+        try
         {
-            if (await TryDeliverAsync(pending))
+            // Drain any backlog first so order is preserved.
+            while (_fallback.TryPeek(out var pending))
             {
-                _fallback.TryDequeue(out _);
+                if (await TryDeliverAsync(pending))
+                {
+                    _fallback.TryDequeue(out _);
+                }
+                else
+                {
+                    break;
+                }
             }
-            else
+
+            if (!await TryDeliverAsync(action))
             {
-                break;
+                if (_fallback.Count >= MaxFallbackQueue)
+                {
+                    // Drop the oldest queued action so the newest still has a slot.
+                    if (_fallback.TryDequeue(out var dropped))
+                        _logger.Warn($"[A2UI] fallback queue full; dropped oldest action '{dropped.Name}' on '{dropped.SurfaceId}'");
+                }
+                _logger.Warn($"[A2UI] No transport available; queued action '{action.Name}' for later delivery.");
+                _fallback.Enqueue(action);
             }
         }
-
-        if (!await TryDeliverAsync(action))
+        finally
         {
-            _logger.Warn($"[A2UI] No transport available; queued action '{action.Name}' for later delivery.");
-            _fallback.Enqueue(action);
+            _sendGate.Release();
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/A2UI/Actions/IActionSink.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Actions/IActionSink.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using OpenClaw.Shared;
+using OpenClawTray.A2UI.Protocol;
+
+namespace OpenClawTray.A2UI.Actions;
+
+/// <summary>
+/// Single seam through which actions leave the renderer. Implementations
+/// route to the gateway WebSocket, MCP notifications, or a fallback queue.
+/// </summary>
+public interface IActionSink
+{
+    void Raise(A2UIAction action);
+}
+
+/// <summary>
+/// Routes actions to one of N transports based on availability. The first
+/// transport whose <see cref="IA2UIActionTransport.IsAvailable"/> returns
+/// true wins. If none are available, actions go to an in-memory fallback
+/// queue that drains on the next available transport.
+/// </summary>
+public sealed class ActionDispatcher : IActionSink
+{
+    private readonly IReadOnlyList<IA2UIActionTransport> _transports;
+    private readonly IOpenClawLogger _logger;
+    private readonly ConcurrentQueue<A2UIAction> _fallback = new();
+    private readonly Dictionary<string, DateTimeOffset> _lastDelivery = new();
+    private static readonly TimeSpan DebounceWindow = TimeSpan.FromMilliseconds(200);
+    private readonly object _debounceLock = new();
+
+    public ActionDispatcher(IReadOnlyList<IA2UIActionTransport> transports, IOpenClawLogger logger)
+    {
+        _transports = transports;
+        _logger = logger;
+    }
+
+    public void Raise(A2UIAction action)
+    {
+        if (IsDebounced(action)) return;
+        _ = SendAsync(action);
+    }
+
+    private bool IsDebounced(A2UIAction action)
+    {
+        var key = $"{action.SurfaceId}|{action.SourceComponentId}|{action.Name}";
+        var now = DateTimeOffset.UtcNow;
+        lock (_debounceLock)
+        {
+            if (_lastDelivery.TryGetValue(key, out var last) && (now - last) < DebounceWindow)
+                return true;
+            _lastDelivery[key] = now;
+        }
+        return false;
+    }
+
+    private async Task SendAsync(A2UIAction action)
+    {
+        // Drain any backlog first so order is preserved.
+        while (_fallback.TryPeek(out var pending))
+        {
+            if (await TryDeliverAsync(pending))
+            {
+                _fallback.TryDequeue(out _);
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        if (!await TryDeliverAsync(action))
+        {
+            _logger.Warn($"[A2UI] No transport available; queued action '{action.Name}' for later delivery.");
+            _fallback.Enqueue(action);
+        }
+    }
+
+    private async Task<bool> TryDeliverAsync(A2UIAction action)
+    {
+        foreach (var t in _transports)
+        {
+            if (!t.IsAvailable) continue;
+            try
+            {
+                await t.DeliverAsync(action);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn($"[A2UI] Transport '{t.GetType().Name}' failed: {ex.Message}");
+            }
+        }
+        return false;
+    }
+}
+
+/// <summary>One concrete delivery channel.</summary>
+public interface IA2UIActionTransport
+{
+    bool IsAvailable { get; }
+    Task DeliverAsync(A2UIAction action);
+}
+
+/// <summary>
+/// Helper: shared envelope serialization. v0.8 client→server shape.
+/// </summary>
+public static class A2UIActionEnvelope
+{
+    private static readonly JsonSerializerOptions s_options = new()
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public static JsonObject ToEnvelope(A2UIAction a)
+    {
+        var inner = new JsonObject
+        {
+            ["name"] = a.Name,
+            ["surfaceId"] = a.SurfaceId,
+            ["timestamp"] = a.Timestamp.ToString("o"),
+        };
+        if (!string.IsNullOrEmpty(a.SourceComponentId))
+            inner["sourceComponentId"] = a.SourceComponentId;
+        if (a.Context != null)
+            inner["context"] = (JsonNode)a.Context.DeepClone();
+
+        return new JsonObject { ["action"] = inner };
+    }
+
+    public static string Serialize(A2UIAction a) => ToEnvelope(a).ToJsonString(s_options);
+}

--- a/src/OpenClaw.Tray.WinUI/A2UI/Actions/IActionSink.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Actions/IActionSink.cs
@@ -24,7 +24,7 @@ public interface IActionSink
 /// true wins. If none are available, actions go to an in-memory fallback
 /// queue that drains on the next available transport.
 /// </summary>
-public sealed class ActionDispatcher : IActionSink
+public sealed class ActionDispatcher : IActionSink, IDisposable
 {
     /// <summary>Cap for the debounce dictionary. Sweeps oldest entries past <see cref="DebounceWindow"/>.</summary>
     internal const int MaxDebounceEntries = 256;
@@ -138,6 +138,19 @@ public sealed class ActionDispatcher : IActionSink
             }
         }
         return false;
+    }
+
+    private bool _disposed;
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        // SemaphoreSlim wraps a kernel event handle; surface rebuilds drop the
+        // dispatcher reference, so without explicit Dispose the handle survives
+        // until GC. Disposable transports are the responsibility of whoever
+        // constructed them.
+        try { _sendGate.Dispose(); } catch { /* ignore */ }
     }
 }
 

--- a/src/OpenClaw.Tray.WinUI/A2UI/DataModel/DataModelStore.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/DataModel/DataModelStore.cs
@@ -132,6 +132,13 @@ public sealed class DataModelStore
         return true;
     }
 
+    /// <summary>
+    /// RFC 6901 token escape: <c>~</c> → <c>~0</c>, <c>/</c> → <c>~1</c>. The
+    /// caller's <c>entry.Key</c> is treated as a single pointer reference token,
+    /// so a key like <c>"users/0/name"</c> escapes to one segment
+    /// <c>users~10~1name</c> — it does NOT split into nested path segments.
+    /// Use <c>basePath</c> to traverse into nested objects.
+    /// </summary>
     private static string EncodePointerToken(string key) =>
         key.Replace("~", "~0").Replace("/", "~1");
 

--- a/src/OpenClaw.Tray.WinUI/A2UI/DataModel/DataModelStore.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/DataModel/DataModelStore.cs
@@ -12,6 +12,14 @@ namespace OpenClawTray.A2UI.DataModel;
 /// </summary>
 public sealed class DataModelStore
 {
+    // Per-update caps. Bounded so an adversarial dataModelUpdate can't drive the
+    // UI thread into an OOM or a million-entry loop. Sized to dwarf realistic
+    // catalogs while still rejecting obvious abuse.
+    internal const int MaxEntriesPerUpdate = 1024;
+    internal const int MaxValueMapDepth = 32;
+    internal const int MaxKeyLength = 256;
+    internal const int MaxStringValueLength = 64 * 1024;
+
     private readonly object _lock = new();
     private readonly Dictionary<string, SurfaceModel> _surfaces = new(StringComparer.Ordinal);
     private readonly DispatcherQueue _dispatcher;
@@ -68,6 +76,11 @@ public sealed class DataModelStore
     /// </summary>
     public void ApplyDataModelUpdate(string surfaceId, string? basePath, IReadOnlyList<Protocol.DataModelEntry> entries)
     {
+        // Drop oversize batches at the boundary. Smaller-than-cap batches still
+        // get per-entry sanity checks below.
+        if (entries.Count > MaxEntriesPerUpdate)
+            return;
+
         SurfaceModel model;
         lock (_lock)
         {
@@ -85,11 +98,18 @@ public sealed class DataModelStore
 
         foreach (var entry in entries)
         {
+            // Per-entry caps: drop the entry rather than aborting the whole batch
+            // (consistent with the existing "skip bad pointer" tolerance).
+            if (entry.Key.Length > MaxKeyLength) continue;
+            if (entry.ValueString != null && entry.ValueString.Length > MaxStringValueLength) continue;
+            if (!IsWithinDepth(entry.ValueMap, depth: 1, max: MaxValueMapDepth)) continue;
+
             try
             {
                 var pointer = string.IsNullOrEmpty(entry.Key)
                     ? (string.IsNullOrEmpty(prefix) ? "/" : prefix)
                     : prefix + "/" + EncodePointerToken(entry.Key);
+                // SetByPointer takes the SurfaceModel.Sync lock internally.
                 model.SetByPointer(pointer, entry.ToJsonNode());
                 changed.Add(NormalizePath(pointer));
             }
@@ -101,6 +121,15 @@ public sealed class DataModelStore
 
         if (changed.Count > 0)
             new DataModelObservable(model, _dispatcher).NotifyPaths(changed);
+    }
+
+    private static bool IsWithinDepth(IReadOnlyList<Protocol.DataModelEntry>? map, int depth, int max)
+    {
+        if (map == null) return true;
+        if (depth > max) return false;
+        foreach (var e in map)
+            if (!IsWithinDepth(e.ValueMap, depth + 1, max)) return false;
+        return true;
     }
 
     private static string EncodePointerToken(string key) =>
@@ -122,42 +151,66 @@ public sealed class DataModelStore
     /// <summary>Internal mutable holder; shared between observable views.</summary>
     internal sealed class SurfaceModel
     {
+        // Per-model lock guarding Root and any traversal/mutation. JsonObject
+        // and JsonArray are not thread-safe, so every read AND every write must
+        // go through this lock — including the deep-clone in canvas.a2ui.dump.
+        public readonly object Sync = new();
         // Single dictionary keyed by normalized pointer path → list of subscribers.
         public readonly Dictionary<string, List<Action>> Subscribers = new(StringComparer.Ordinal);
         public JsonObject Root { get; private set; }
 
         public SurfaceModel(JsonObject root) { Root = root; }
 
-        public void Replace(JsonObject newRoot) { Root = newRoot; }
+        public void Replace(JsonObject newRoot) { lock (Sync) { Root = newRoot; } }
 
         public JsonNode? GetByPointer(string pointer)
         {
-            if (string.IsNullOrEmpty(pointer) || pointer == "/" || pointer == "")
-                return Root;
-            var (parent, key, isIndex, idx) = Resolve(pointer, createMissing: false);
-            if (parent == null) return null;
-            if (parent is JsonObject po) return po[key!];
-            if (parent is JsonArray pa) return isIndex && idx >= 0 && idx < pa.Count ? pa[idx] : null;
-            return null;
+            lock (Sync)
+            {
+                if (string.IsNullOrEmpty(pointer) || pointer == "/" || pointer == "")
+                    return Root;
+                var (parent, key, isIndex, idx) = Resolve(pointer, createMissing: false);
+                if (parent == null) return null;
+                if (parent is JsonObject po) return po[key!];
+                if (parent is JsonArray pa) return isIndex && idx >= 0 && idx < pa.Count ? pa[idx] : null;
+                return null;
+            }
         }
 
         public void SetByPointer(string pointer, JsonNode? value)
         {
-            if (string.IsNullOrEmpty(pointer) || pointer == "/")
+            lock (Sync)
             {
-                if (value is JsonObject obj) Root = obj;
-                return;
+                if (string.IsNullOrEmpty(pointer) || pointer == "/")
+                {
+                    if (value is JsonObject obj) Root = obj;
+                    else if (value != null)
+                    {
+                        // Whole-tree replace requires an object root. Coerce a
+                        // scalar/array into { "value": <scalar> } rather than
+                        // silently dropping the write — the previous no-op
+                        // behaviour masked agent bugs.
+                        Root = new JsonObject { ["value"] = value.DeepClone() };
+                    }
+                    return;
+                }
+                var (parent, key, isIndex, idx) = Resolve(pointer, createMissing: true);
+                if (parent is JsonObject po)
+                {
+                    po[key!] = value;
+                }
+                else if (parent is JsonArray pa)
+                {
+                    while (pa.Count <= idx) pa.Add(null);
+                    pa[idx] = value;
+                }
             }
-            var (parent, key, isIndex, idx) = Resolve(pointer, createMissing: true);
-            if (parent is JsonObject po)
-            {
-                po[key!] = value;
-            }
-            else if (parent is JsonArray pa)
-            {
-                while (pa.Count <= idx) pa.Add(null);
-                pa[idx] = value;
-            }
+        }
+
+        /// <summary>Atomic deep-clone of the root JsonObject. Required for snapshot/dump consumers.</summary>
+        public JsonObject CloneRoot()
+        {
+            lock (Sync) { return (JsonObject)Root.DeepClone(); }
         }
 
         private (JsonNode? parent, string? key, bool isIndex, int idx) Resolve(string pointer, bool createMissing)
@@ -225,7 +278,15 @@ public sealed class DataModelObservable
         _dispatcher = dispatcher;
     }
 
+    /// <summary>
+    /// Direct reference to the root object. Callers MUST NOT mutate or
+    /// enumerate concurrently with writes; prefer <see cref="CloneRoot"/> for
+    /// any consumer that needs a stable view.
+    /// </summary>
     public JsonObject Root => _model.Root;
+
+    /// <summary>Atomic deep-clone of the root object. Safe to enumerate off-dispatcher.</summary>
+    public JsonObject CloneRoot() => _model.CloneRoot();
 
     public JsonNode? Read(string pointer) => _model.GetByPointer(pointer);
 

--- a/src/OpenClaw.Tray.WinUI/A2UI/DataModel/DataModelStore.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/DataModel/DataModelStore.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json.Nodes;
+using Microsoft.UI.Dispatching;
+
+namespace OpenClawTray.A2UI.DataModel;
+
+/// <summary>
+/// Per-surface JsonObject store, mutated via JSON Pointer (RFC 6901) patches.
+/// Notifies registered observers when paths change. Thread-affine to a UI dispatcher.
+/// </summary>
+public sealed class DataModelStore
+{
+    private readonly object _lock = new();
+    private readonly Dictionary<string, SurfaceModel> _surfaces = new(StringComparer.Ordinal);
+    private readonly DispatcherQueue _dispatcher;
+
+    public DataModelStore(DispatcherQueue dispatcher)
+    {
+        _dispatcher = dispatcher;
+    }
+
+    public DataModelObservable GetOrCreate(string surfaceId, JsonObject? seed = null)
+    {
+        lock (_lock)
+        {
+            if (!_surfaces.TryGetValue(surfaceId, out var model))
+            {
+                model = new SurfaceModel(seed != null ? (JsonObject)seed.DeepClone() : new JsonObject());
+                _surfaces[surfaceId] = model;
+            }
+            return new DataModelObservable(model, _dispatcher);
+        }
+    }
+
+    public void Reset(string surfaceId, JsonObject? seed = null)
+    {
+        SurfaceModel? model;
+        lock (_lock)
+        {
+            if (!_surfaces.TryGetValue(surfaceId, out model))
+            {
+                model = new SurfaceModel(seed != null ? (JsonObject)seed.DeepClone() : new JsonObject());
+                _surfaces[surfaceId] = model;
+                return;
+            }
+            model.Replace(seed != null ? (JsonObject)seed.DeepClone() : new JsonObject());
+        }
+        new DataModelObservable(model, _dispatcher).NotifyAllPaths();
+    }
+
+    public void Remove(string surfaceId)
+    {
+        lock (_lock) { _surfaces.Remove(surfaceId); }
+    }
+
+    public void RemoveAll()
+    {
+        lock (_lock) { _surfaces.Clear(); }
+    }
+
+    /// <summary>
+    /// Apply a v0.8 dataModelUpdate batch. Each entry's <c>key</c> is appended
+    /// to the optional <paramref name="basePath"/> to form the full pointer.
+    /// Special case: basePath="/" or null with key="" replaces the whole tree.
+    /// Coalesced — observers fire once per affected path after the batch.
+    /// </summary>
+    public void ApplyDataModelUpdate(string surfaceId, string? basePath, IReadOnlyList<Protocol.DataModelEntry> entries)
+    {
+        SurfaceModel model;
+        lock (_lock)
+        {
+            if (!_surfaces.TryGetValue(surfaceId, out var existing))
+            {
+                existing = new SurfaceModel(new JsonObject());
+                _surfaces[surfaceId] = existing;
+            }
+            model = existing;
+        }
+
+        var changed = new List<string>(entries.Count);
+        var prefix = NormalizePath(basePath ?? "/");
+        if (prefix == "/") prefix = "";
+
+        foreach (var entry in entries)
+        {
+            try
+            {
+                var pointer = string.IsNullOrEmpty(entry.Key)
+                    ? (string.IsNullOrEmpty(prefix) ? "/" : prefix)
+                    : prefix + "/" + EncodePointerToken(entry.Key);
+                model.SetByPointer(pointer, entry.ToJsonNode());
+                changed.Add(NormalizePath(pointer));
+            }
+            catch (Exception)
+            {
+                // bad pointer; skip — router logs aggregate.
+            }
+        }
+
+        if (changed.Count > 0)
+            new DataModelObservable(model, _dispatcher).NotifyPaths(changed);
+    }
+
+    private static string EncodePointerToken(string key) =>
+        key.Replace("~", "~0").Replace("/", "~1");
+
+    public JsonNode? Read(string surfaceId, string pointer)
+    {
+        SurfaceModel? model;
+        lock (_lock)
+        {
+            if (!_surfaces.TryGetValue(surfaceId, out model)) return null;
+        }
+        try { return model.GetByPointer(pointer); } catch { return null; }
+    }
+
+    private static string NormalizePath(string p) =>
+        string.IsNullOrEmpty(p) ? "/" : (p[0] == '/' ? p : "/" + p);
+
+    /// <summary>Internal mutable holder; shared between observable views.</summary>
+    internal sealed class SurfaceModel
+    {
+        // Single dictionary keyed by normalized pointer path → list of subscribers.
+        public readonly Dictionary<string, List<Action>> Subscribers = new(StringComparer.Ordinal);
+        public JsonObject Root { get; private set; }
+
+        public SurfaceModel(JsonObject root) { Root = root; }
+
+        public void Replace(JsonObject newRoot) { Root = newRoot; }
+
+        public JsonNode? GetByPointer(string pointer)
+        {
+            if (string.IsNullOrEmpty(pointer) || pointer == "/" || pointer == "")
+                return Root;
+            var (parent, key, isIndex, idx) = Resolve(pointer, createMissing: false);
+            if (parent == null) return null;
+            if (parent is JsonObject po) return po[key!];
+            if (parent is JsonArray pa) return isIndex && idx >= 0 && idx < pa.Count ? pa[idx] : null;
+            return null;
+        }
+
+        public void SetByPointer(string pointer, JsonNode? value)
+        {
+            if (string.IsNullOrEmpty(pointer) || pointer == "/")
+            {
+                if (value is JsonObject obj) Root = obj;
+                return;
+            }
+            var (parent, key, isIndex, idx) = Resolve(pointer, createMissing: true);
+            if (parent is JsonObject po)
+            {
+                po[key!] = value;
+            }
+            else if (parent is JsonArray pa)
+            {
+                while (pa.Count <= idx) pa.Add(null);
+                pa[idx] = value;
+            }
+        }
+
+        private (JsonNode? parent, string? key, bool isIndex, int idx) Resolve(string pointer, bool createMissing)
+        {
+            var tokens = SplitPointer(pointer);
+            if (tokens.Count == 0) return (Root, null, false, -1);
+
+            JsonNode? cursor = Root;
+            for (int i = 0; i < tokens.Count - 1; i++)
+            {
+                var tok = tokens[i];
+                if (cursor is JsonObject obj)
+                {
+                    if (obj[tok] == null)
+                    {
+                        if (!createMissing) return (null, null, false, -1);
+                        var nextIsIndex = int.TryParse(tokens[i + 1], out _);
+                        obj[tok] = nextIsIndex ? new JsonArray() : new JsonObject();
+                    }
+                    cursor = obj[tok];
+                }
+                else if (cursor is JsonArray arr)
+                {
+                    if (!int.TryParse(tok, out var ai)) return (null, null, false, -1);
+                    while (createMissing && arr.Count <= ai) arr.Add(null);
+                    if (ai < 0 || ai >= arr.Count) return (null, null, false, -1);
+                    cursor = arr[ai];
+                }
+                else
+                {
+                    return (null, null, false, -1);
+                }
+            }
+
+            var last = tokens[^1];
+            if (cursor is JsonArray finalArr && int.TryParse(last, out var idx))
+                return (finalArr, last, true, idx);
+            return (cursor, last, false, -1);
+        }
+
+        private static List<string> SplitPointer(string pointer)
+        {
+            var p = pointer.StartsWith('/') ? pointer.Substring(1) : pointer;
+            var parts = p.Split('/');
+            var result = new List<string>(parts.Length);
+            foreach (var part in parts)
+                result.Add(part.Replace("~1", "/").Replace("~0", "~"));
+            return result;
+        }
+    }
+}
+
+/// <summary>
+/// View on a SurfaceModel that exposes per-path INotifyPropertyChanged-style
+/// callbacks for binding into XAML. Multiple instances may share the same model.
+/// </summary>
+public sealed class DataModelObservable
+{
+    private readonly DataModelStore.SurfaceModel _model;
+    private readonly DispatcherQueue _dispatcher;
+
+    internal DataModelObservable(DataModelStore.SurfaceModel model, DispatcherQueue dispatcher)
+    {
+        _model = model;
+        _dispatcher = dispatcher;
+    }
+
+    public JsonObject Root => _model.Root;
+
+    public JsonNode? Read(string pointer) => _model.GetByPointer(pointer);
+
+    public string? ReadString(string pointer)
+    {
+        var node = Read(pointer);
+        if (node is JsonValue v && v.TryGetValue<string>(out var s)) return s;
+        return node?.ToString();
+    }
+
+    /// <summary>
+    /// Two-way write: updates the data model, notifies subscribers on the dispatcher.
+    /// </summary>
+    public void Write(string pointer, JsonNode? value)
+    {
+        try
+        {
+            _model.SetByPointer(pointer, value);
+            NotifyPaths(new[] { Normalize(pointer) });
+        }
+        catch { /* swallow; bad pointer */ }
+    }
+
+    /// <summary>
+    /// Subscribe to changes on a specific JSON Pointer path. Returns disposable
+    /// that unsubscribes. Callbacks run on the dispatcher thread.
+    /// </summary>
+    public IDisposable Subscribe(string pointer, Action callback)
+    {
+        var key = Normalize(pointer);
+        lock (_model.Subscribers)
+        {
+            if (!_model.Subscribers.TryGetValue(key, out var list))
+            {
+                list = new List<Action>();
+                _model.Subscribers[key] = list;
+            }
+            list.Add(callback);
+        }
+        return new Subscription(_model, key, callback);
+    }
+
+    internal void NotifyPaths(IEnumerable<string> paths)
+    {
+        var fired = new HashSet<Action>();
+        foreach (var raw in paths)
+        {
+            var key = Normalize(raw);
+            // Notify exact path + all ancestor paths.
+            var current = key;
+            while (true)
+            {
+                List<Action>? subs;
+                lock (_model.Subscribers)
+                {
+                    _model.Subscribers.TryGetValue(current, out subs);
+                    subs = subs == null ? null : new List<Action>(subs);
+                }
+                if (subs != null)
+                {
+                    foreach (var s in subs)
+                        if (fired.Add(s)) Dispatch(s);
+                }
+                if (current == "/" || string.IsNullOrEmpty(current)) break;
+                var slash = current.LastIndexOf('/');
+                current = slash <= 0 ? "/" : current.Substring(0, slash);
+            }
+        }
+    }
+
+    internal void NotifyAllPaths()
+    {
+        List<Action> all;
+        lock (_model.Subscribers)
+        {
+            all = new List<Action>();
+            foreach (var subs in _model.Subscribers.Values) all.AddRange(subs);
+        }
+        foreach (var s in all) Dispatch(s);
+    }
+
+    private void Dispatch(Action callback)
+    {
+        if (_dispatcher == null || _dispatcher.HasThreadAccess) { try { callback(); } catch { } return; }
+        _dispatcher.TryEnqueue(() => { try { callback(); } catch { } });
+    }
+
+    private static string Normalize(string p) =>
+        string.IsNullOrEmpty(p) ? "/" : (p[0] == '/' ? p : "/" + p);
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly DataModelStore.SurfaceModel _model;
+        private readonly string _key;
+        private readonly Action _cb;
+        public Subscription(DataModelStore.SurfaceModel m, string k, Action c) { _model = m; _key = k; _cb = c; }
+        public void Dispose()
+        {
+            lock (_model.Subscribers)
+            {
+                if (_model.Subscribers.TryGetValue(_key, out var list))
+                {
+                    list.Remove(_cb);
+                    if (list.Count == 0) _model.Subscribers.Remove(_key);
+                }
+            }
+        }
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/A2UI/Hosting/A2UIRouter.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Hosting/A2UIRouter.cs
@@ -6,6 +6,7 @@ using OpenClawTray.A2UI.Actions;
 using OpenClawTray.A2UI.DataModel;
 using OpenClawTray.A2UI.Protocol;
 using OpenClawTray.A2UI.Rendering;
+using OpenClawTray.A2UI.Telemetry;
 using OpenClawTray.A2UI.Theming;
 
 namespace OpenClawTray.A2UI.Hosting;
@@ -32,6 +33,7 @@ public sealed class A2UIRouter
     private readonly ComponentRendererRegistry _registry;
     private readonly IActionSink _actions;
     private readonly IOpenClawLogger _logger;
+    private readonly IA2UITelemetry _telemetry;
     private readonly Dictionary<string, SurfaceHost> _surfaces = new(StringComparer.Ordinal);
 
     public event EventHandler<SurfaceHost>? SurfaceCreated;
@@ -43,13 +45,15 @@ public sealed class A2UIRouter
         DataModelStore dataModel,
         ComponentRendererRegistry registry,
         IActionSink actions,
-        IOpenClawLogger logger)
+        IOpenClawLogger logger,
+        IA2UITelemetry? telemetry = null)
     {
         _dispatcher = dispatcher;
         _dataModel = dataModel;
         _registry = registry;
         _actions = actions;
         _logger = logger;
+        _telemetry = telemetry ?? NullA2UITelemetry.Instance;
     }
 
     /// <summary>
@@ -115,6 +119,7 @@ public sealed class A2UIRouter
                 var host = GetOrCreateSurface(su.SurfaceId);
                 host.ApplyComponents(su.Components);
                 _logger.Info($"[A2UI] surfaceUpdate '{LogSafe(su.SurfaceId)}' ({su.Components.Count} component(s))");
+                _telemetry.Push(su.SurfaceId, "surfaceUpdate", su.Components.Count);
                 break;
             }
 
@@ -124,6 +129,7 @@ public sealed class A2UIRouter
                 host.BeginRendering(br.Root, br.Styles);
                 SurfaceRendered?.Invoke(this, host);
                 _logger.Info($"[A2UI] beginRendering '{LogSafe(br.SurfaceId)}' root='{LogSafe(br.Root)}' (catalog={LogSafe(br.CatalogId) ?? "default"})");
+                _telemetry.Push(br.SurfaceId, "beginRendering", 1);
                 break;
             }
 
@@ -131,6 +137,7 @@ public sealed class A2UIRouter
             {
                 _dataModel.ApplyDataModelUpdate(dmu.SurfaceId, dmu.Path, dmu.Contents);
                 _logger.Debug($"[A2UI] dataModelUpdate '{LogSafe(dmu.SurfaceId)}' path='{LogSafe(dmu.Path) ?? "/"}' ({dmu.Contents.Count} entry(ies))");
+                _telemetry.Push(dmu.SurfaceId, "dataModelUpdate", dmu.Contents.Count);
                 break;
             }
 
@@ -143,6 +150,7 @@ public sealed class A2UIRouter
                     _dataModel.Remove(ds.SurfaceId);
                     SurfaceDeleted?.Invoke(this, ds.SurfaceId);
                     _logger.Info($"[A2UI] deleteSurface '{LogSafe(ds.SurfaceId)}'");
+                    _telemetry.Push(ds.SurfaceId, "deleteSurface", 1);
                 }
                 break;
             }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Hosting/A2UIRouter.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Hosting/A2UIRouter.cs
@@ -20,6 +20,13 @@ namespace OpenClawTray.A2UI.Hosting;
 /// </summary>
 public sealed class A2UIRouter
 {
+    /// <summary>
+    /// Cap on concurrent surfaces. v0.8 deployments stack a small number of
+    /// related surfaces per window; this bound keeps an adversarial agent from
+    /// driving the host to OOM by creating unique surface IDs in a loop.
+    /// </summary>
+    internal const int MaxSurfaces = 64;
+
     private readonly DispatcherQueue _dispatcher;
     private readonly DataModelStore _dataModel;
     private readonly ComponentRendererRegistry _registry;
@@ -45,12 +52,25 @@ public sealed class A2UIRouter
         _logger = logger;
     }
 
+    /// <summary>
+    /// Live view of the surfaces dictionary. Callers should NOT mutate or
+    /// enumerate concurrently with router activity; for stable iteration use
+    /// <see cref="SnapshotSurfaces"/>.
+    /// </summary>
     public IReadOnlyDictionary<string, SurfaceHost> Surfaces => _surfaces;
+
+    /// <summary>Stable snapshot of currently-known surfaces. Safe to enumerate.</summary>
+    public IReadOnlyList<KeyValuePair<string, SurfaceHost>> SnapshotSurfaces()
+    {
+        var copy = new List<KeyValuePair<string, SurfaceHost>>(_surfaces.Count);
+        foreach (var kv in _surfaces) copy.Add(kv);
+        return copy;
+    }
 
     /// <summary>Push a JSONL blob. Each line is parsed independently.</summary>
     public void Push(string jsonl)
     {
-        foreach (var msg in A2UIMessageParser.Parse(jsonl))
+        foreach (var msg in A2UIMessageParser.Parse(jsonl, _logger))
         {
             DispatchOnUI(msg);
         }
@@ -94,7 +114,7 @@ public sealed class A2UIRouter
             {
                 var host = GetOrCreateSurface(su.SurfaceId);
                 host.ApplyComponents(su.Components);
-                _logger.Info($"[A2UI] surfaceUpdate '{su.SurfaceId}' ({su.Components.Count} component(s))");
+                _logger.Info($"[A2UI] surfaceUpdate '{LogSafe(su.SurfaceId)}' ({su.Components.Count} component(s))");
                 break;
             }
 
@@ -103,14 +123,14 @@ public sealed class A2UIRouter
                 var host = GetOrCreateSurface(br.SurfaceId);
                 host.BeginRendering(br.Root, br.Styles);
                 SurfaceRendered?.Invoke(this, host);
-                _logger.Info($"[A2UI] beginRendering '{br.SurfaceId}' root='{br.Root}' (catalog={br.CatalogId ?? "default"})");
+                _logger.Info($"[A2UI] beginRendering '{LogSafe(br.SurfaceId)}' root='{LogSafe(br.Root)}' (catalog={LogSafe(br.CatalogId) ?? "default"})");
                 break;
             }
 
             case DataModelUpdateMessage dmu:
             {
                 _dataModel.ApplyDataModelUpdate(dmu.SurfaceId, dmu.Path, dmu.Contents);
-                _logger.Debug($"[A2UI] dataModelUpdate '{dmu.SurfaceId}' path='{dmu.Path ?? "/"}' ({dmu.Contents.Count} entry(ies))");
+                _logger.Debug($"[A2UI] dataModelUpdate '{LogSafe(dmu.SurfaceId)}' path='{LogSafe(dmu.Path) ?? "/"}' ({dmu.Contents.Count} entry(ies))");
                 break;
             }
 
@@ -122,13 +142,13 @@ public sealed class A2UIRouter
                     _surfaces.Remove(ds.SurfaceId);
                     _dataModel.Remove(ds.SurfaceId);
                     SurfaceDeleted?.Invoke(this, ds.SurfaceId);
-                    _logger.Info($"[A2UI] deleteSurface '{ds.SurfaceId}'");
+                    _logger.Info($"[A2UI] deleteSurface '{LogSafe(ds.SurfaceId)}'");
                 }
                 break;
             }
 
             case UnknownEnvelopeMessage ue:
-                _logger.Warn($"[A2UI] Unknown envelope kind '{ue.Kind}'; skipping");
+                _logger.Warn($"[A2UI] Unknown envelope kind '{LogSafe(ue.Kind)}'; skipping");
                 break;
         }
     }
@@ -136,11 +156,30 @@ public sealed class A2UIRouter
     private SurfaceHost GetOrCreateSurface(string surfaceId)
     {
         if (_surfaces.TryGetValue(surfaceId, out var existing)) return existing;
+        if (_surfaces.Count >= MaxSurfaces)
+        {
+            // Refuse to grow past the cap. Returning the most recently created
+            // surface keeps the router alive while signaling that something is
+            // misbehaving — the alternative (silently dropping) is worse for
+            // diagnostics. Sanitize the ID before logging (see L1).
+            _logger.Warn($"[A2UI] surface cap ({MaxSurfaces}) reached; ignoring new surface '{LogSafe(surfaceId)}'");
+            // Reuse the first existing surface as a degraded fallback so the
+            // caller still receives a host reference and the router stays
+            // internally consistent.
+            foreach (var kv in _surfaces) return kv.Value;
+        }
 
         var observable = _dataModel.GetOrCreate(surfaceId);
-        var host = new SurfaceHost(surfaceId, observable, _registry, _actions);
+        var host = new SurfaceHost(surfaceId, observable, _registry, _actions, _logger);
         _surfaces[surfaceId] = host;
         SurfaceCreated?.Invoke(this, host);
         return host;
+    }
+
+    private static string LogSafe(string s)
+    {
+        if (string.IsNullOrEmpty(s)) return string.Empty;
+        var trimmed = s.Length > 64 ? s.Substring(0, 64) : s;
+        return trimmed.Replace('\r', ' ').Replace('\n', ' ').Replace('\t', ' ');
     }
 }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Hosting/A2UIRouter.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Hosting/A2UIRouter.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.UI.Dispatching;
+using OpenClaw.Shared;
+using OpenClawTray.A2UI.Actions;
+using OpenClawTray.A2UI.DataModel;
+using OpenClawTray.A2UI.Protocol;
+using OpenClawTray.A2UI.Rendering;
+using OpenClawTray.A2UI.Theming;
+
+namespace OpenClawTray.A2UI.Hosting;
+
+/// <summary>
+/// Stateful per-window router. Parses inbound JSONL, dispatches to surface
+/// hosts on the UI thread, and exposes events for the window to react to
+/// (surface lifecycle).
+///
+/// Designed for single-window/multiple-surfaces — the spec leaves room for a
+/// future multi-window mode but the v1 host stacks surfaces in TabView slots.
+/// </summary>
+public sealed class A2UIRouter
+{
+    private readonly DispatcherQueue _dispatcher;
+    private readonly DataModelStore _dataModel;
+    private readonly ComponentRendererRegistry _registry;
+    private readonly IActionSink _actions;
+    private readonly IOpenClawLogger _logger;
+    private readonly Dictionary<string, SurfaceHost> _surfaces = new(StringComparer.Ordinal);
+
+    public event EventHandler<SurfaceHost>? SurfaceCreated;
+    public event EventHandler<SurfaceHost>? SurfaceRendered;
+    public event EventHandler<string>? SurfaceDeleted;
+
+    public A2UIRouter(
+        DispatcherQueue dispatcher,
+        DataModelStore dataModel,
+        ComponentRendererRegistry registry,
+        IActionSink actions,
+        IOpenClawLogger logger)
+    {
+        _dispatcher = dispatcher;
+        _dataModel = dataModel;
+        _registry = registry;
+        _actions = actions;
+        _logger = logger;
+    }
+
+    public IReadOnlyDictionary<string, SurfaceHost> Surfaces => _surfaces;
+
+    /// <summary>Push a JSONL blob. Each line is parsed independently.</summary>
+    public void Push(string jsonl)
+    {
+        foreach (var msg in A2UIMessageParser.Parse(jsonl))
+        {
+            DispatchOnUI(msg);
+        }
+    }
+
+    public void ResetAll()
+    {
+        DispatchToUI(() =>
+        {
+            foreach (var s in _surfaces.Values)
+            {
+                try { s.Dispose(); } catch { }
+                SurfaceDeleted?.Invoke(this, s.SurfaceId);
+            }
+            _surfaces.Clear();
+            _dataModel.RemoveAll();
+            _logger.Info("[A2UI] reset all surfaces");
+        });
+    }
+
+    private void DispatchOnUI(A2UIMessage msg)
+    {
+        DispatchToUI(() =>
+        {
+            try { Apply(msg); }
+            catch (Exception ex) { _logger.Error("[A2UI] Router apply failed", ex); }
+        });
+    }
+
+    private void DispatchToUI(Action action)
+    {
+        if (_dispatcher.HasThreadAccess) { action(); return; }
+        _dispatcher.TryEnqueue(() => action());
+    }
+
+    private void Apply(A2UIMessage msg)
+    {
+        switch (msg)
+        {
+            case SurfaceUpdateMessage su:
+            {
+                var host = GetOrCreateSurface(su.SurfaceId);
+                host.ApplyComponents(su.Components);
+                _logger.Info($"[A2UI] surfaceUpdate '{su.SurfaceId}' ({su.Components.Count} component(s))");
+                break;
+            }
+
+            case BeginRenderingMessage br:
+            {
+                var host = GetOrCreateSurface(br.SurfaceId);
+                host.BeginRendering(br.Root, br.Styles);
+                SurfaceRendered?.Invoke(this, host);
+                _logger.Info($"[A2UI] beginRendering '{br.SurfaceId}' root='{br.Root}' (catalog={br.CatalogId ?? "default"})");
+                break;
+            }
+
+            case DataModelUpdateMessage dmu:
+            {
+                _dataModel.ApplyDataModelUpdate(dmu.SurfaceId, dmu.Path, dmu.Contents);
+                _logger.Debug($"[A2UI] dataModelUpdate '{dmu.SurfaceId}' path='{dmu.Path ?? "/"}' ({dmu.Contents.Count} entry(ies))");
+                break;
+            }
+
+            case DeleteSurfaceMessage ds:
+            {
+                if (_surfaces.TryGetValue(ds.SurfaceId, out var existing))
+                {
+                    existing.Dispose();
+                    _surfaces.Remove(ds.SurfaceId);
+                    _dataModel.Remove(ds.SurfaceId);
+                    SurfaceDeleted?.Invoke(this, ds.SurfaceId);
+                    _logger.Info($"[A2UI] deleteSurface '{ds.SurfaceId}'");
+                }
+                break;
+            }
+
+            case UnknownEnvelopeMessage ue:
+                _logger.Warn($"[A2UI] Unknown envelope kind '{ue.Kind}'; skipping");
+                break;
+        }
+    }
+
+    private SurfaceHost GetOrCreateSurface(string surfaceId)
+    {
+        if (_surfaces.TryGetValue(surfaceId, out var existing)) return existing;
+
+        var observable = _dataModel.GetOrCreate(surfaceId);
+        var host = new SurfaceHost(surfaceId, observable, _registry, _actions);
+        _surfaces[surfaceId] = host;
+        SurfaceCreated?.Invoke(this, host);
+        return host;
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/A2UI/Hosting/A2UIRouter.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Hosting/A2UIRouter.cs
@@ -107,7 +107,13 @@ public sealed class A2UIRouter
     private void DispatchToUI(Action action)
     {
         if (_dispatcher.HasThreadAccess) { action(); return; }
-        _dispatcher.TryEnqueue(() => action());
+        // TryEnqueue returns false when the dispatcher is shutting down (or
+        // its queue is at capacity). Silently dropping a router push there
+        // would hide the failure from upstream callers that already returned
+        // success on the wire — log a warning so we can correlate the dropped
+        // surface update with whatever shutdown sequence is underway.
+        if (!_dispatcher.TryEnqueue(() => action()))
+            _logger.Warn("[A2UI] Router dispatch dropped: dispatcher unavailable (likely shutting down)");
     }
 
     private void Apply(A2UIMessage msg)
@@ -117,6 +123,7 @@ public sealed class A2UIRouter
             case SurfaceUpdateMessage su:
             {
                 var host = GetOrCreateSurface(su.SurfaceId);
+                if (host == null) break; // cap reached; logged inside GetOrCreateSurface
                 host.ApplyComponents(su.Components);
                 _logger.Info($"[A2UI] surfaceUpdate '{LogSafe(su.SurfaceId)}' ({su.Components.Count} component(s))");
                 _telemetry.Push(su.SurfaceId, "surfaceUpdate", su.Components.Count);
@@ -126,6 +133,7 @@ public sealed class A2UIRouter
             case BeginRenderingMessage br:
             {
                 var host = GetOrCreateSurface(br.SurfaceId);
+                if (host == null) break;
                 host.BeginRendering(br.Root, br.Styles);
                 SurfaceRendered?.Invoke(this, host);
                 _logger.Info($"[A2UI] beginRendering '{LogSafe(br.SurfaceId)}' root='{LogSafe(br.Root)}' (catalog={LogSafe(br.CatalogId) ?? "default"})");
@@ -161,20 +169,18 @@ public sealed class A2UIRouter
         }
     }
 
-    private SurfaceHost GetOrCreateSurface(string surfaceId)
+    private SurfaceHost? GetOrCreateSurface(string surfaceId)
     {
         if (_surfaces.TryGetValue(surfaceId, out var existing)) return existing;
         if (_surfaces.Count >= MaxSurfaces)
         {
-            // Refuse to grow past the cap. Returning the most recently created
-            // surface keeps the router alive while signaling that something is
-            // misbehaving — the alternative (silently dropping) is worse for
-            // diagnostics. Sanitize the ID before logging (see L1).
-            _logger.Warn($"[A2UI] surface cap ({MaxSurfaces}) reached; ignoring new surface '{LogSafe(surfaceId)}'");
-            // Reuse the first existing surface as a degraded fallback so the
-            // caller still receives a host reference and the router stays
-            // internally consistent.
-            foreach (var kv in _surfaces) return kv.Value;
+            // Cap reached. The previous "degraded fallback" returned the first
+            // existing surface, which corrupted unrelated surface state — a
+            // surfaceUpdate aimed at the new id would clobber the components
+            // of an entirely different surface. Skip the message instead and
+            // let the cap log + telemetry counter signal the misbehavior.
+            _logger.Warn($"[A2UI] surface cap ({MaxSurfaces}) reached; dropping push for new surface '{LogSafe(surfaceId)}'");
+            return null;
         }
 
         var observable = _dataModel.GetOrCreate(surfaceId);

--- a/src/OpenClaw.Tray.WinUI/A2UI/Hosting/SurfaceHost.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Hosting/SurfaceHost.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using OpenClaw.Shared;
 using OpenClawTray.A2UI.Actions;
 using OpenClawTray.A2UI.DataModel;
 using OpenClawTray.A2UI.Protocol;
@@ -24,14 +25,24 @@ namespace OpenClawTray.A2UI.Hosting;
 /// </summary>
 public sealed class SurfaceHost : IDisposable
 {
+    // Hard caps that keep an adversarial / buggy agent from collapsing the UI thread.
+    // Cycle and depth guards above; component count guards a million-node fan-out.
+    internal const int MaxRenderDepth = 64;
+    internal const int MaxComponentsPerSurface = 2000;
+
     private readonly DataModelObservable _dataModel;
     private readonly ComponentRendererRegistry _registry;
     private readonly IActionSink _actions;
+    private readonly IOpenClawLogger _logger;
     private readonly Dictionary<string, IDisposable> _subscriptions = new(StringComparer.Ordinal);
     private readonly Dictionary<string, A2UIComponentDef> _defs = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _renderingIds = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _secretPaths = new(StringComparer.Ordinal);
     private readonly Grid _root;
     private A2UITheme _theme;
     private string? _rootId;
+    private int _renderDepth;
+    private int _renderCount;
 
     public string SurfaceId { get; }
     public string? Title { get; private set; }
@@ -41,12 +52,14 @@ public sealed class SurfaceHost : IDisposable
         string surfaceId,
         DataModelObservable dataModel,
         ComponentRendererRegistry registry,
-        IActionSink actions)
+        IActionSink actions,
+        IOpenClawLogger? logger = null)
     {
         SurfaceId = surfaceId;
         _dataModel = dataModel;
         _registry = registry;
         _actions = actions;
+        _logger = logger ?? NullLogger.Instance;
         _theme = A2UITheme.Empty;
         _root = new Grid { Padding = new Thickness(16) };
     }
@@ -57,7 +70,18 @@ public sealed class SurfaceHost : IDisposable
     /// </summary>
     public void ApplyComponents(IReadOnlyList<A2UIComponentDef> components)
     {
-        foreach (var def in components) _defs[def.Id] = def;
+        foreach (var def in components)
+        {
+            if (_defs.Count >= MaxComponentsPerSurface && !_defs.ContainsKey(def.Id))
+            {
+                // Cap the dictionary at the same bound the renderer enforces, so a
+                // malicious surfaceUpdate can't fill memory with definitions that
+                // never render anyway.
+                _logger.Warn($"[A2UI] component cap ({MaxComponentsPerSurface}) on surface '{SurfaceId}'; dropping '{LogSafe(def.Id)}'");
+                continue;
+            }
+            _defs[def.Id] = def;
+        }
         if (_rootId != null) Rebuild();
     }
 
@@ -69,7 +93,17 @@ public sealed class SurfaceHost : IDisposable
     {
         _rootId = rootId;
         _theme = A2UITheme.Parse(styles);
-        Title = null;
+        // Surface title is optional and lives in the styles bag in v0.8.
+        // Falling back to null lets the window title default to "Canvas".
+        if (styles is not null && styles["title"] is System.Text.Json.Nodes.JsonValue tv
+            && tv.TryGetValue<string>(out var titleStr) && !string.IsNullOrWhiteSpace(titleStr))
+        {
+            Title = titleStr;
+        }
+        else
+        {
+            Title = null;
+        }
         ApplyThemeToScope(_root, _theme);
         Rebuild();
     }
@@ -85,6 +119,7 @@ public sealed class SurfaceHost : IDisposable
     /// JSON snapshot of this surface's logical state — components (id +
     /// componentName + properties), declared root, and the current data
     /// model tree. Used by <c>canvas.a2ui.dump</c> for headless verification.
+    /// Sensitive paths (obscured fields + denylist matches) are redacted.
     /// </summary>
     public System.Text.Json.Nodes.JsonObject GetSnapshot()
     {
@@ -105,14 +140,24 @@ public sealed class SurfaceHost : IDisposable
             ["surfaceId"] = SurfaceId,
             ["root"] = _rootId,
             ["components"] = components,
-            ["dataModel"] = _dataModel.Root.DeepClone(),
+            // CloneRoot snapshots under the model lock so a concurrent SetByPointer
+            // can't produce a half-mutated tree mid-clone. RedactInPlace avoids the
+            // second DeepClone the public Redact does.
+            ["dataModel"] = SecretRedactor.RedactInPlace(_dataModel.CloneRoot(), _secretPaths),
         };
     }
+
+    /// <summary>True if the path was registered as secret (e.g., obscured TextField bound there).</summary>
+    internal bool IsSecretPath(string? path) => SecretRedactor.IsSecret(path, _secretPaths);
 
     private void Rebuild()
     {
         DisposeSubscriptions();
         _root.Children.Clear();
+        _renderingIds.Clear();
+        _secretPaths.Clear();
+        _renderDepth = 0;
+        _renderCount = 0;
         if (_rootId == null) return;
 
         var built = BuildElement(_rootId);
@@ -124,23 +169,86 @@ public sealed class SurfaceHost : IDisposable
         if (!_defs.TryGetValue(id, out var def))
             return null;
 
-        var renderer = _registry.GetOrUnknown(def.ComponentName);
-        var ctx = new RenderContext
+        if (_renderingIds.Contains(id))
         {
-            SurfaceId = SurfaceId,
-            DataModel = _dataModel,
-            Actions = _actions,
-            Theme = _theme,
-            BuildChild = BuildElement,
-            Subscriptions = _subscriptions,
-        };
-
-        try { return renderer.Render(def, ctx); }
-        catch (Exception)
-        {
-            // Renderer failure should never crash the surface; fall back to unknown.
-            return _registry.GetOrUnknown("__error__").Render(def, ctx);
+            _logger.Warn($"[A2UI] cycle detected on surface '{SurfaceId}' component '{LogSafe(id)}'; rendering placeholder");
+            return BuildErrorPlaceholder(def.ComponentName, "cycle detected");
         }
+        if (_renderDepth >= MaxRenderDepth)
+        {
+            _logger.Warn($"[A2UI] depth cap ({MaxRenderDepth}) on surface '{SurfaceId}' at component '{LogSafe(id)}'");
+            return BuildErrorPlaceholder(def.ComponentName, $"depth cap ({MaxRenderDepth})");
+        }
+        if (_renderCount >= MaxComponentsPerSurface)
+        {
+            _logger.Warn($"[A2UI] component cap ({MaxComponentsPerSurface}) on surface '{SurfaceId}' at component '{LogSafe(id)}'");
+            return BuildErrorPlaceholder(def.ComponentName, $"component cap ({MaxComponentsPerSurface})");
+        }
+
+        _renderingIds.Add(id);
+        _renderDepth++;
+        _renderCount++;
+        try
+        {
+            var renderer = _registry.GetOrUnknown(def.ComponentName);
+            var ctx = new RenderContext
+            {
+                SurfaceId = SurfaceId,
+                DataModel = _dataModel,
+                Actions = _actions,
+                Theme = _theme,
+                BuildChild = BuildElement,
+                Subscriptions = _subscriptions,
+                SecretPaths = _secretPaths,
+            };
+
+            try { return renderer.Render(def, ctx); }
+            catch (Exception ex)
+            {
+                // Renderer failure should never crash the surface. Don't reroute through
+                // the registry — that's how we lose the real component name when fallback
+                // also fails. Render an inline placeholder showing actual name + message.
+                _logger.Warn($"[A2UI] renderer for '{def.ComponentName}' threw: {ex.Message}");
+                return BuildErrorPlaceholder(def.ComponentName, ex.Message);
+            }
+        }
+        finally
+        {
+            _renderingIds.Remove(id);
+            _renderDepth--;
+        }
+    }
+
+    private static FrameworkElement BuildErrorPlaceholder(string componentName, string message)
+    {
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Padding = new Thickness(8),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Microsoft.UI.Colors.OrangeRed),
+            CornerRadius = new CornerRadius(4),
+        };
+        stack.Children.Add(new FontIcon
+        {
+            Glyph = "",
+            FontFamily = new FontFamily("Segoe Fluent Icons"),
+        });
+        stack.Children.Add(new TextBlock
+        {
+            Text = $"{componentName}: {message}",
+            VerticalAlignment = VerticalAlignment.Center,
+            TextWrapping = TextWrapping.Wrap,
+        });
+        return stack;
+    }
+
+    private static string LogSafe(string s)
+    {
+        if (string.IsNullOrEmpty(s)) return string.Empty;
+        var trimmed = s.Length > 64 ? s.Substring(0, 64) : s;
+        return trimmed.Replace('\r', ' ').Replace('\n', ' ').Replace('\t', ' ');
     }
 
     private void DisposeSubscriptions()

--- a/src/OpenClaw.Tray.WinUI/A2UI/Hosting/SurfaceHost.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Hosting/SurfaceHost.cs
@@ -66,10 +66,17 @@ public sealed class SurfaceHost : IDisposable
 
     /// <summary>
     /// Add or replace components in the definition table. If a root has
-    /// already been declared, rebuild the visual tree.
+    /// already been declared, rebuild the visual tree — but only if the
+    /// incoming defs actually change something. A surfaceUpdate that re-sends
+    /// already-known components verbatim no-ops; this preserves caret / scroll
+    /// / tab selection for agents that re-emit the full surface as their
+    /// "update" mechanism. Spec §3.3 calls for full structural diffing
+    /// (M1 in unified review); this is a partial down payment that catches
+    /// the most common case without per-component XAML element tracking.
     /// </summary>
     public void ApplyComponents(IReadOnlyList<A2UIComponentDef> components)
     {
+        bool anyChanged = false;
         foreach (var def in components)
         {
             if (_defs.Count >= MaxComponentsPerSurface && !_defs.ContainsKey(def.Id))
@@ -80,9 +87,25 @@ public sealed class SurfaceHost : IDisposable
                 _logger.Warn($"[A2UI] component cap ({MaxComponentsPerSurface}) on surface '{SurfaceId}'; dropping '{LogSafe(def.Id)}'");
                 continue;
             }
-            _defs[def.Id] = def;
+            if (!_defs.TryGetValue(def.Id, out var existing) || !ComponentsEqual(existing, def))
+            {
+                _defs[def.Id] = def;
+                anyChanged = true;
+            }
         }
-        if (_rootId != null) Rebuild();
+        if (anyChanged && _rootId != null) Rebuild();
+    }
+
+    private static bool ComponentsEqual(A2UIComponentDef a, A2UIComponentDef b)
+    {
+        if (!string.Equals(a.ComponentName, b.ComponentName, StringComparison.Ordinal)) return false;
+        if (a.Weight != b.Weight) return false;
+        // JsonObject equality: serialize and compare. Properties are small
+        // (per-component < a few KiB after the M5 size caps) so the cost is
+        // negligible compared to the XAML rebuild it might avoid.
+        var sa = a.Properties.ToJsonString();
+        var sb = b.Properties.ToJsonString();
+        return string.Equals(sa, sb, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -200,6 +223,7 @@ public sealed class SurfaceHost : IDisposable
                 BuildChild = BuildElement,
                 Subscriptions = _subscriptions,
                 SecretPaths = _secretPaths,
+                Logger = _logger,
             };
 
             try { return renderer.Render(def, ctx); }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Hosting/SurfaceHost.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Hosting/SurfaceHost.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using OpenClawTray.A2UI.Actions;
+using OpenClawTray.A2UI.DataModel;
+using OpenClawTray.A2UI.Protocol;
+using OpenClawTray.A2UI.Rendering;
+using OpenClawTray.A2UI.Theming;
+
+namespace OpenClawTray.A2UI.Hosting;
+
+/// <summary>
+/// One per active surface. Owns the component definition table, rebuilds the
+/// XAML tree from the declared root, and exposes a single root element that
+/// the canvas window slots into a content host.
+///
+/// Lifecycle in v0.8:
+///   surfaceUpdate (defs come in)  → ApplyComponents
+///   beginRendering (root + style) → BeginRendering, triggers Build
+///   dataModelUpdate               → store applies; subscribed renderers refresh
+/// A re-issued surfaceUpdate with the same surfaceId patches in place.
+/// </summary>
+public sealed class SurfaceHost : IDisposable
+{
+    private readonly DataModelObservable _dataModel;
+    private readonly ComponentRendererRegistry _registry;
+    private readonly IActionSink _actions;
+    private readonly Dictionary<string, IDisposable> _subscriptions = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, A2UIComponentDef> _defs = new(StringComparer.Ordinal);
+    private readonly Grid _root;
+    private A2UITheme _theme;
+    private string? _rootId;
+
+    public string SurfaceId { get; }
+    public string? Title { get; private set; }
+    public FrameworkElement RootElement => _root;
+
+    public SurfaceHost(
+        string surfaceId,
+        DataModelObservable dataModel,
+        ComponentRendererRegistry registry,
+        IActionSink actions)
+    {
+        SurfaceId = surfaceId;
+        _dataModel = dataModel;
+        _registry = registry;
+        _actions = actions;
+        _theme = A2UITheme.Empty;
+        _root = new Grid { Padding = new Thickness(16) };
+    }
+
+    /// <summary>
+    /// Add or replace components in the definition table. If a root has
+    /// already been declared, rebuild the visual tree.
+    /// </summary>
+    public void ApplyComponents(IReadOnlyList<A2UIComponentDef> components)
+    {
+        foreach (var def in components) _defs[def.Id] = def;
+        if (_rootId != null) Rebuild();
+    }
+
+    /// <summary>
+    /// Declare which component is the root and apply surface-level styles.
+    /// Triggers an immediate rebuild.
+    /// </summary>
+    public void BeginRendering(string rootId, System.Text.Json.Nodes.JsonObject? styles)
+    {
+        _rootId = rootId;
+        _theme = A2UITheme.Parse(styles);
+        Title = null;
+        ApplyThemeToScope(_root, _theme);
+        Rebuild();
+    }
+
+    public void Dispose()
+    {
+        DisposeSubscriptions();
+        _defs.Clear();
+        _root.Children.Clear();
+    }
+
+    /// <summary>
+    /// JSON snapshot of this surface's logical state — components (id +
+    /// componentName + properties), declared root, and the current data
+    /// model tree. Used by <c>canvas.a2ui.dump</c> for headless verification.
+    /// </summary>
+    public System.Text.Json.Nodes.JsonObject GetSnapshot()
+    {
+        var components = new System.Text.Json.Nodes.JsonArray();
+        foreach (var def in _defs.Values)
+        {
+            var entry = new System.Text.Json.Nodes.JsonObject
+            {
+                ["id"] = def.Id,
+                ["componentName"] = def.ComponentName,
+                ["properties"] = def.Properties.DeepClone(),
+            };
+            if (def.Weight is { } w) entry["weight"] = w;
+            components.Add(entry);
+        }
+        return new System.Text.Json.Nodes.JsonObject
+        {
+            ["surfaceId"] = SurfaceId,
+            ["root"] = _rootId,
+            ["components"] = components,
+            ["dataModel"] = _dataModel.Root.DeepClone(),
+        };
+    }
+
+    private void Rebuild()
+    {
+        DisposeSubscriptions();
+        _root.Children.Clear();
+        if (_rootId == null) return;
+
+        var built = BuildElement(_rootId);
+        if (built != null) _root.Children.Add(built);
+    }
+
+    private FrameworkElement? BuildElement(string id)
+    {
+        if (!_defs.TryGetValue(id, out var def))
+            return null;
+
+        var renderer = _registry.GetOrUnknown(def.ComponentName);
+        var ctx = new RenderContext
+        {
+            SurfaceId = SurfaceId,
+            DataModel = _dataModel,
+            Actions = _actions,
+            Theme = _theme,
+            BuildChild = BuildElement,
+            Subscriptions = _subscriptions,
+        };
+
+        try { return renderer.Render(def, ctx); }
+        catch (Exception)
+        {
+            // Renderer failure should never crash the surface; fall back to unknown.
+            return _registry.GetOrUnknown("__error__").Render(def, ctx);
+        }
+    }
+
+    private void DisposeSubscriptions()
+    {
+        foreach (var s in _subscriptions.Values)
+        {
+            try { s.Dispose(); } catch { }
+        }
+        _subscriptions.Clear();
+    }
+
+    private static void ApplyThemeToScope(FrameworkElement element, A2UITheme theme)
+    {
+        if (theme == A2UITheme.Empty) return;
+
+        var resources = element.Resources;
+        if (theme.Accent is { } accent)
+        {
+            resources["A2UIAccentBrush"] = new SolidColorBrush(accent);
+            resources["AccentFillColorDefaultBrush"] = new SolidColorBrush(accent);
+        }
+        if (theme.Foreground is { } fg)
+            resources["A2UIForegroundBrush"] = new SolidColorBrush(fg);
+        if (theme.FontFamily is { } font && !string.IsNullOrWhiteSpace(font))
+            resources["A2UIFontFamily"] = new FontFamily(font);
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/A2UI/Hosting/SurfaceHost.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Hosting/SurfaceHost.cs
@@ -43,6 +43,7 @@ public sealed class SurfaceHost : IDisposable
     private string? _rootId;
     private int _renderDepth;
     private int _renderCount;
+    private MediaLoadBudget _mediaBudget = new();
 
     public string SurfaceId { get; }
     public string? Title { get; private set; }
@@ -181,6 +182,7 @@ public sealed class SurfaceHost : IDisposable
         _secretPaths.Clear();
         _renderDepth = 0;
         _renderCount = 0;
+        _mediaBudget = new MediaLoadBudget();
         if (_rootId == null) return;
 
         var built = BuildElement(_rootId);
@@ -224,6 +226,7 @@ public sealed class SurfaceHost : IDisposable
                 Subscriptions = _subscriptions,
                 SecretPaths = _secretPaths,
                 Logger = _logger,
+                MediaBudget = _mediaBudget,
             };
 
             try { return renderer.Render(def, ctx); }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Protocol/A2UIProtocol.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Protocol/A2UIProtocol.cs
@@ -1,0 +1,305 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace OpenClawTray.A2UI.Protocol;
+
+/// <summary>
+/// Inbound A2UI v0.8 message envelopes (agent → node). Sealed hierarchy —
+/// extend by adding a new record + a router branch. Unknown envelope kinds
+/// surface as <see cref="UnknownEnvelopeMessage"/> and are logged.
+/// </summary>
+public abstract record A2UIMessage;
+
+/// <summary>
+/// surfaceUpdate: declares (or replaces) the components for a surface. The
+/// surface is implicitly created on first surfaceUpdate — there is no
+/// separate createSurface envelope in v0.8.
+/// </summary>
+public sealed record SurfaceUpdateMessage(
+    string SurfaceId,
+    IReadOnlyList<A2UIComponentDef> Components) : A2UIMessage;
+
+/// <summary>
+/// beginRendering: tells the client which component is the root for the
+/// surface, and applies optional surface-level styles. Sent after the
+/// surfaceUpdate that introduces the components.
+/// </summary>
+public sealed record BeginRenderingMessage(
+    string SurfaceId,
+    string Root,
+    string? CatalogId,
+    JsonObject? Styles) : A2UIMessage;
+
+/// <summary>
+/// dataModelUpdate: writes one or more entries into the surface's data
+/// model. Each entry is a (key, typed value) pair; <c>path</c> scopes the
+/// keys (omitted/"/" replaces the entire data model).
+/// </summary>
+public sealed record DataModelUpdateMessage(
+    string SurfaceId,
+    string? Path,
+    IReadOnlyList<DataModelEntry> Contents) : A2UIMessage;
+
+public sealed record DeleteSurfaceMessage(string SurfaceId) : A2UIMessage;
+
+public sealed record UnknownEnvelopeMessage(string Kind, JsonObject Body) : A2UIMessage;
+
+/// <summary>
+/// One component as carried in <c>surfaceUpdate.components</c>.
+/// <see cref="ComponentName"/> is the discriminator (e.g. "Text", "Column"),
+/// <see cref="Properties"/> is the body that lived under that key.
+/// </summary>
+public sealed record A2UIComponentDef
+{
+    public required string Id { get; init; }
+    public required string ComponentName { get; init; }
+    public required JsonObject Properties { get; init; }
+    public double? Weight { get; init; }
+}
+
+/// <summary>
+/// Single dataModelUpdate.contents entry. Exactly one of Value*/ValueMap is
+/// expected on the wire; we expose them all and let the store apply whichever
+/// is set.
+/// </summary>
+public sealed record DataModelEntry
+{
+    public required string Key { get; init; }
+    public string? ValueString { get; init; }
+    public double? ValueNumber { get; init; }
+    public bool? ValueBoolean { get; init; }
+    /// <summary>An adjacency-list map: each item is itself a DataModelEntry.</summary>
+    public IReadOnlyList<DataModelEntry>? ValueMap { get; init; }
+
+    /// <summary>Convert this entry's value to a JsonNode for storage.</summary>
+    public JsonNode? ToJsonNode()
+    {
+        if (ValueString != null) return JsonValue.Create(ValueString);
+        if (ValueNumber.HasValue) return JsonValue.Create(ValueNumber.Value);
+        if (ValueBoolean.HasValue) return JsonValue.Create(ValueBoolean.Value);
+        if (ValueMap != null)
+        {
+            var obj = new JsonObject();
+            foreach (var entry in ValueMap)
+                obj[entry.Key] = entry.ToJsonNode();
+            return obj;
+        }
+        return null;
+    }
+}
+
+/// <summary>
+/// The A2UI v0.8 "value" tagged union. Almost every leaf property in a
+/// component (text, url, label, etc.) is one of these. Resolves either to a
+/// literal or to a JSON Pointer path into the surface's data model.
+/// </summary>
+public sealed record A2UIValue
+{
+    public string? LiteralString { get; init; }
+    public double? LiteralNumber { get; init; }
+    public bool? LiteralBoolean { get; init; }
+    public IReadOnlyList<string>? LiteralArray { get; init; }
+    public string? Path { get; init; }
+
+    public bool HasLiteral => LiteralString != null || LiteralNumber.HasValue
+                              || LiteralBoolean.HasValue || LiteralArray != null;
+    public bool HasPath => !string.IsNullOrEmpty(Path);
+
+    public static A2UIValue? From(JsonNode? node)
+    {
+        if (node is not JsonObject obj) return null;
+        var v = new A2UIValue
+        {
+            LiteralString = AsString(obj["literalString"]),
+            LiteralNumber = AsNumber(obj["literalNumber"]),
+            LiteralBoolean = AsBool(obj["literalBoolean"]),
+            LiteralArray = AsStringArray(obj["literalArray"]),
+            Path = AsString(obj["path"]),
+        };
+        return v;
+    }
+
+    private static string? AsString(JsonNode? n) =>
+        n is JsonValue jv && jv.TryGetValue<string>(out var s) ? s : null;
+    private static double? AsNumber(JsonNode? n) =>
+        n is JsonValue jv && jv.TryGetValue<double>(out var d) ? d : null;
+    private static bool? AsBool(JsonNode? n) =>
+        n is JsonValue jv && jv.TryGetValue<bool>(out var b) ? b : null;
+    private static IReadOnlyList<string>? AsStringArray(JsonNode? n)
+    {
+        if (n is not JsonArray arr) return null;
+        var list = new List<string>(arr.Count);
+        foreach (var i in arr)
+            if (i is JsonValue jv && jv.TryGetValue<string>(out var s)) list.Add(s);
+        return list;
+    }
+}
+
+/// <summary>
+/// Outbound A2UI action (node → agent). v0.8 client→server envelope shape.
+/// </summary>
+public sealed record A2UIAction
+{
+    public required string Name { get; init; }
+    public required string SurfaceId { get; init; }
+    public string? SourceComponentId { get; init; }
+    public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.UtcNow;
+    /// <summary>Per-action context entries assembled from <c>action.context</c>.</summary>
+    public JsonObject? Context { get; init; }
+}
+
+/// <summary>
+/// Parses a JSONL stream into <see cref="A2UIMessage"/> records. Tolerant:
+/// malformed lines are skipped, unknown envelope keys yield
+/// <see cref="UnknownEnvelopeMessage"/> rather than throwing.
+/// </summary>
+public static class A2UIMessageParser
+{
+    public static IEnumerable<A2UIMessage> Parse(string jsonl)
+    {
+        if (string.IsNullOrWhiteSpace(jsonl)) yield break;
+
+        var lines = jsonl.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var line in lines)
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length == 0) continue;
+
+            A2UIMessage? msg = null;
+            try { msg = ParseLine(trimmed); }
+            catch (JsonException) { /* skip malformed */ }
+            catch (FormatException) { /* skip malformed */ }
+            if (msg != null) yield return msg;
+        }
+    }
+
+    public static A2UIMessage? ParseLine(string json)
+    {
+        var node = JsonNode.Parse(json);
+        if (node is not JsonObject root) return null;
+
+        // surfaceUpdate
+        if (root["surfaceUpdate"] is JsonObject su)
+        {
+            var surfaceId = RequireString(su, "surfaceId");
+            var components = new List<A2UIComponentDef>();
+            if (su["components"] is JsonArray comps)
+            {
+                foreach (var item in comps)
+                {
+                    if (item is not JsonObject co) continue;
+                    var def = ParseComponent(co);
+                    if (def != null) components.Add(def);
+                }
+            }
+            return new SurfaceUpdateMessage(surfaceId, components);
+        }
+
+        // beginRendering
+        if (root["beginRendering"] is JsonObject br)
+        {
+            var surfaceId = RequireString(br, "surfaceId");
+            var rootId = RequireString(br, "root");
+            var catalogId = OptionalString(br, "catalogId");
+            var styles = br["styles"] as JsonObject;
+            return new BeginRenderingMessage(surfaceId, rootId, catalogId, styles);
+        }
+
+        // dataModelUpdate
+        if (root["dataModelUpdate"] is JsonObject dmu)
+        {
+            var surfaceId = RequireString(dmu, "surfaceId");
+            var path = OptionalString(dmu, "path");
+            var contents = new List<DataModelEntry>();
+            if (dmu["contents"] is JsonArray arr)
+            {
+                foreach (var item in arr)
+                {
+                    if (item is not JsonObject e) continue;
+                    var entry = ParseEntry(e);
+                    if (entry != null) contents.Add(entry);
+                }
+            }
+            return new DataModelUpdateMessage(surfaceId, path, contents);
+        }
+
+        // deleteSurface
+        if (root["deleteSurface"] is JsonObject ds)
+        {
+            return new DeleteSurfaceMessage(RequireString(ds, "surfaceId"));
+        }
+
+        var kind = string.Empty;
+        foreach (var kv in root) { kind = kv.Key; break; }
+        return new UnknownEnvelopeMessage(kind, root);
+    }
+
+    private static A2UIComponentDef? ParseComponent(JsonObject co)
+    {
+        var id = OptionalString(co, "id");
+        if (id == null) return null;
+
+        // component is a wrapper object whose single key is the component name.
+        if (co["component"] is not JsonObject wrapper) return null;
+        string? name = null;
+        JsonObject? props = null;
+        foreach (var kv in wrapper)
+        {
+            name = kv.Key;
+            props = kv.Value as JsonObject ?? new JsonObject();
+            break;
+        }
+        if (name == null) return null;
+
+        double? weight = null;
+        if (co["weight"] is JsonValue wv && wv.TryGetValue<double>(out var w)) weight = w;
+
+        return new A2UIComponentDef
+        {
+            Id = id,
+            ComponentName = name,
+            Properties = props ?? new JsonObject(),
+            Weight = weight,
+        };
+    }
+
+    private static DataModelEntry? ParseEntry(JsonObject e)
+    {
+        var key = OptionalString(e, "key");
+        if (key == null) return null;
+        var entry = new DataModelEntry
+        {
+            Key = key,
+            ValueString = OptionalString(e, "valueString"),
+            ValueNumber = e["valueNumber"] is JsonValue jvn && jvn.TryGetValue<double>(out var n) ? n : null,
+            ValueBoolean = e["valueBoolean"] is JsonValue jvb && jvb.TryGetValue<bool>(out var b) ? b : null,
+            ValueMap = ParseValueMap(e["valueMap"] as JsonArray),
+        };
+        return entry;
+    }
+
+    private static IReadOnlyList<DataModelEntry>? ParseValueMap(JsonArray? arr)
+    {
+        if (arr == null) return null;
+        var list = new List<DataModelEntry>(arr.Count);
+        foreach (var item in arr)
+        {
+            if (item is not JsonObject e) continue;
+            var nested = ParseEntry(e);
+            if (nested != null) list.Add(nested);
+        }
+        return list;
+    }
+
+    private static string RequireString(JsonObject o, string key)
+    {
+        if (o[key] is JsonValue jv && jv.TryGetValue<string>(out var s) && !string.IsNullOrEmpty(s))
+            return s;
+        throw new FormatException($"missing or invalid '{key}'");
+    }
+
+    private static string? OptionalString(JsonObject o, string key) =>
+        o[key] is JsonValue jv && jv.TryGetValue<string>(out var s) ? s : null;
+}

--- a/src/OpenClaw.Tray.WinUI/A2UI/Protocol/A2UIProtocol.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Protocol/A2UIProtocol.cs
@@ -17,34 +17,47 @@ public abstract record A2UIMessage;
 /// surface is implicitly created on first surfaceUpdate — there is no
 /// separate createSurface envelope in v0.8.
 /// </summary>
-public sealed record SurfaceUpdateMessage(
-    string SurfaceId,
-    IReadOnlyList<A2UIComponentDef> Components) : A2UIMessage;
+public sealed record SurfaceUpdateMessage : A2UIMessage
+{
+    public required string SurfaceId { get; init; }
+    public required IReadOnlyList<A2UIComponentDef> Components { get; init; }
+}
 
 /// <summary>
 /// beginRendering: tells the client which component is the root for the
 /// surface, and applies optional surface-level styles. Sent after the
 /// surfaceUpdate that introduces the components.
 /// </summary>
-public sealed record BeginRenderingMessage(
-    string SurfaceId,
-    string Root,
-    string? CatalogId,
-    JsonObject? Styles) : A2UIMessage;
+public sealed record BeginRenderingMessage : A2UIMessage
+{
+    public required string SurfaceId { get; init; }
+    public required string Root { get; init; }
+    public string? CatalogId { get; init; }
+    public JsonObject? Styles { get; init; }
+}
 
 /// <summary>
 /// dataModelUpdate: writes one or more entries into the surface's data
 /// model. Each entry is a (key, typed value) pair; <c>path</c> scopes the
 /// keys (omitted/"/" replaces the entire data model).
 /// </summary>
-public sealed record DataModelUpdateMessage(
-    string SurfaceId,
-    string? Path,
-    IReadOnlyList<DataModelEntry> Contents) : A2UIMessage;
+public sealed record DataModelUpdateMessage : A2UIMessage
+{
+    public required string SurfaceId { get; init; }
+    public string? Path { get; init; }
+    public required IReadOnlyList<DataModelEntry> Contents { get; init; }
+}
 
-public sealed record DeleteSurfaceMessage(string SurfaceId) : A2UIMessage;
+public sealed record DeleteSurfaceMessage : A2UIMessage
+{
+    public required string SurfaceId { get; init; }
+}
 
-public sealed record UnknownEnvelopeMessage(string Kind, JsonObject Body) : A2UIMessage;
+public sealed record UnknownEnvelopeMessage : A2UIMessage
+{
+    public required string Kind { get; init; }
+    public required JsonObject Body { get; init; }
+}
 
 /// <summary>
 /// One component as carried in <c>surfaceUpdate.components</c>.
@@ -237,7 +250,7 @@ public static class A2UIMessageParser
                     if (def != null) components.Add(def);
                 }
             }
-            return new SurfaceUpdateMessage(surfaceId, components);
+            return new SurfaceUpdateMessage { SurfaceId = surfaceId, Components = components };
         }
 
         // beginRendering
@@ -247,7 +260,7 @@ public static class A2UIMessageParser
             var rootId = RequireString(br, "root");
             var catalogId = OptionalString(br, "catalogId");
             var styles = br["styles"] as JsonObject;
-            return new BeginRenderingMessage(surfaceId, rootId, catalogId, styles);
+            return new BeginRenderingMessage { SurfaceId = surfaceId, Root = rootId, CatalogId = catalogId, Styles = styles };
         }
 
         // dataModelUpdate
@@ -265,18 +278,18 @@ public static class A2UIMessageParser
                     if (entry != null) contents.Add(entry);
                 }
             }
-            return new DataModelUpdateMessage(surfaceId, path, contents);
+            return new DataModelUpdateMessage { SurfaceId = surfaceId, Path = path, Contents = contents };
         }
 
         // deleteSurface
         if (root["deleteSurface"] is JsonObject ds)
         {
-            return new DeleteSurfaceMessage(RequireString(ds, "surfaceId"));
+            return new DeleteSurfaceMessage { SurfaceId = RequireString(ds, "surfaceId") };
         }
 
         var kind = string.Empty;
         foreach (var kv in root) { kind = kv.Key; break; }
-        return new UnknownEnvelopeMessage(kind, root);
+        return new UnknownEnvelopeMessage { Kind = kind, Body = root };
     }
 
     private static A2UIComponentDef? ParseComponent(JsonObject co)

--- a/src/OpenClaw.Tray.WinUI/A2UI/Protocol/A2UIProtocol.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Protocol/A2UIProtocol.cs
@@ -152,28 +152,71 @@ public sealed record A2UIAction
 
 /// <summary>
 /// Parses a JSONL stream into <see cref="A2UIMessage"/> records. Tolerant:
-/// malformed lines are skipped, unknown envelope keys yield
-/// <see cref="UnknownEnvelopeMessage"/> rather than throwing.
+/// malformed lines are skipped (logged when a logger is supplied), unknown
+/// envelope keys yield <see cref="UnknownEnvelopeMessage"/> rather than throwing.
 /// </summary>
 public static class A2UIMessageParser
 {
-    public static IEnumerable<A2UIMessage> Parse(string jsonl)
+    /// <summary>
+    /// Per-line cap. Single-line JSON envelopes above this are dropped to keep
+    /// a hostile/malformed payload from forcing the JSON DOM allocator into a
+    /// pathological state. Total stream size is bounded separately at the
+    /// transport / capability boundary.
+    /// </summary>
+    public const int MaxLineLength = 1 * 1024 * 1024;
+
+    public static IEnumerable<A2UIMessage> Parse(string jsonl) => Parse(jsonl, logger: null);
+
+    public static IEnumerable<A2UIMessage> Parse(string jsonl, OpenClaw.Shared.IOpenClawLogger? logger)
     {
         if (string.IsNullOrWhiteSpace(jsonl)) yield break;
 
-        var lines = jsonl.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
-        foreach (var line in lines)
+        // Stream-iterate without allocating a string[] for the whole blob.
+        int start = 0;
+        int len = jsonl.Length;
+        while (start < len)
         {
-            var trimmed = line.Trim();
-            if (trimmed.Length == 0) continue;
+            int end = jsonl.IndexOfAny(s_lineSeparators, start);
+            if (end < 0) end = len;
 
-            A2UIMessage? msg = null;
-            try { msg = ParseLine(trimmed); }
-            catch (JsonException) { /* skip malformed */ }
-            catch (FormatException) { /* skip malformed */ }
-            if (msg != null) yield return msg;
+            int lineLen = end - start;
+            if (lineLen > 0)
+            {
+                string line = jsonl.Substring(start, lineLen);
+                string trimmed = line.Trim();
+                if (trimmed.Length > 0)
+                {
+                    if (trimmed.Length > MaxLineLength)
+                    {
+                        logger?.Warn($"[A2UI] dropping oversize JSONL line ({trimmed.Length} > {MaxLineLength} chars)");
+                    }
+                    else
+                    {
+                        A2UIMessage? msg = null;
+                        try { msg = ParseLine(trimmed); }
+                        catch (JsonException ex)
+                        {
+                            logger?.Warn($"[A2UI] dropping malformed JSONL line: {Truncate(trimmed, 200)} — {ex.Message}");
+                        }
+                        catch (FormatException ex)
+                        {
+                            logger?.Warn($"[A2UI] dropping malformed JSONL line: {Truncate(trimmed, 200)} — {ex.Message}");
+                        }
+                        if (msg != null) yield return msg;
+                    }
+                }
+            }
+
+            // Skip any contiguous run of CR/LF before the next line.
+            start = end;
+            while (start < len && (jsonl[start] == '\r' || jsonl[start] == '\n')) start++;
         }
     }
+
+    private static readonly char[] s_lineSeparators = { '\r', '\n' };
+
+    private static string Truncate(string s, int max) =>
+        s.Length <= max ? s : s.Substring(0, max) + "…";
 
     public static A2UIMessage? ParseLine(string json)
     {

--- a/src/OpenClaw.Tray.WinUI/A2UI/Protocol/A2UIProtocol.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Protocol/A2UIProtocol.cs
@@ -293,6 +293,12 @@ public static class A2UIMessageParser
             return new DeleteSurfaceMessage { SurfaceId = RequireString(ds, "surfaceId") };
         }
 
+        // Empty root object: nothing to dispatch on. Return null so the
+        // caller's per-line error path logs a malformed-input warning instead
+        // of returning UnknownEnvelopeMessage{ Kind="" }, which would
+        // present as a normal-but-unsupported envelope and confuse triage.
+        if (root.Count == 0) return null;
+
         var kind = string.Empty;
         foreach (var kv in root) { kind = kv.Key; break; }
         return new UnknownEnvelopeMessage { Kind = kind, Body = root };
@@ -310,7 +316,13 @@ public static class A2UIMessageParser
         foreach (var kv in wrapper)
         {
             name = kv.Key;
-            props = kv.Value as JsonObject ?? new JsonObject();
+            // Reject malformed payloads where the wrapper-key value is NOT a
+            // JsonObject. Accepting an empty JsonObject masks gateway/model
+            // bugs (e.g. shipping a string where a properties object was
+            // expected) and renders an empty-but-named component, which is
+            // indistinguishable from a legitimate component with no props.
+            if (kv.Value is JsonObject o) props = o;
+            else return null;
             break;
         }
         if (name == null) return null;

--- a/src/OpenClaw.Tray.WinUI/A2UI/Protocol/A2UIProtocol.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Protocol/A2UIProtocol.cs
@@ -155,6 +155,12 @@ public sealed record A2UIValue
 /// </summary>
 public sealed record A2UIAction
 {
+    /// <summary>
+    /// Idempotency / dedup key. The gateway uses this as the <c>key</c> field
+    /// on the <c>agent.request</c> deep-link so a double-click doesn't produce
+    /// two agent turns. Generated per-Raise; callers don't supply it.
+    /// </summary>
+    public string Id { get; init; } = Guid.NewGuid().ToString();
     public required string Name { get; init; }
     public required string SurfaceId { get; init; }
     public string? SourceComponentId { get; init; }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Protocol/A2UIProtocol.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Protocol/A2UIProtocol.cs
@@ -215,11 +215,11 @@ public static class A2UIMessageParser
                         try { msg = ParseLine(trimmed); }
                         catch (JsonException ex)
                         {
-                            logger?.Warn($"[A2UI] dropping malformed JSONL line: {Truncate(trimmed, 200)} — {ex.Message}");
+                            logger?.Warn($"[A2UI] dropping malformed JSONL line: {OpenClaw.Shared.TokenSanitizer.Sanitize(Truncate(trimmed, 200))} — {ex.Message}");
                         }
                         catch (FormatException ex)
                         {
-                            logger?.Warn($"[A2UI] dropping malformed JSONL line: {Truncate(trimmed, 200)} — {ex.Message}");
+                            logger?.Warn($"[A2UI] dropping malformed JSONL line: {OpenClaw.Shared.TokenSanitizer.Sanitize(Truncate(trimmed, 200))} — {ex.Message}");
                         }
                         if (msg != null) yield return msg;
                     }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/AutomationHelpers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/AutomationHelpers.cs
@@ -1,0 +1,40 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using OpenClawTray.A2UI.Protocol;
+
+namespace OpenClawTray.A2UI.Rendering;
+
+/// <summary>
+/// Wires A2UI <c>label</c> / <c>description</c> properties to WinUI
+/// AutomationProperties so Narrator and other assistive tech can announce
+/// content. v0.8 components carry these properties on most interactive and
+/// display elements; without this hook, controls whose Content is just an
+/// Icon or a path-bound bitmap are invisible to screen readers.
+/// </summary>
+internal static class AutomationHelpers
+{
+    /// <summary>
+    /// Apply the component's <c>label</c> as Name and <c>description</c> as
+    /// HelpText. Resolves both through <see cref="RenderContext.ResolveString"/>
+    /// so path-bound values produce a current snapshot at render time. No-op if
+    /// neither property is present.
+    /// </summary>
+    public static void Apply(FrameworkElement element, A2UIComponentDef c, RenderContext ctx,
+        string labelKey = "label", string descriptionKey = "description")
+    {
+        var label = ctx.ResolveString(ctx.GetValue(c, labelKey));
+        if (!string.IsNullOrEmpty(label))
+            AutomationProperties.SetName(element, label);
+
+        var description = ctx.ResolveString(ctx.GetValue(c, descriptionKey));
+        if (!string.IsNullOrEmpty(description))
+            AutomationProperties.SetHelpText(element, description);
+    }
+
+    /// <summary>Fallback when no A2UI property is available. Used when we have a known string (e.g., the action name).</summary>
+    public static void SetName(FrameworkElement element, string? name)
+    {
+        if (!string.IsNullOrEmpty(name))
+            AutomationProperties.SetName(element, name);
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/ComponentRendererRegistry.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/ComponentRendererRegistry.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using OpenClawTray.A2UI.Rendering.Renderers;
+
+namespace OpenClawTray.A2UI.Rendering;
+
+/// <summary>
+/// Catalog-strict registry of component renderers. Built once at process
+/// start. Unknown component types resolve to <see cref="UnknownRenderer"/>.
+/// To add a new component: implement <see cref="IComponentRenderer"/>,
+/// register it here, done.
+/// </summary>
+public sealed class ComponentRendererRegistry
+{
+    private readonly Dictionary<string, IComponentRenderer> _byName;
+    private readonly UnknownRenderer _unknown;
+
+    public ComponentRendererRegistry(IEnumerable<IComponentRenderer> renderers, UnknownRenderer unknown)
+    {
+        _byName = new(StringComparer.OrdinalIgnoreCase);
+        foreach (var r in renderers) _byName[r.ComponentName] = r;
+        _unknown = unknown;
+    }
+
+    public IComponentRenderer GetOrUnknown(string componentName) =>
+        _byName.TryGetValue(componentName, out var r) ? r : _unknown;
+
+    public IEnumerable<string> KnownNames => _byName.Keys;
+
+    public static ComponentRendererRegistry BuildDefault(MediaResolver media)
+    {
+        var renderers = new IComponentRenderer[]
+        {
+            // Containers
+            new RowRenderer(),
+            new ColumnRenderer(),
+            new ListRenderer(),
+            new CardRenderer(),
+            new TabsRenderer(),
+            new ModalRenderer(),
+            // Display
+            new TextRenderer(),
+            new ImageRenderer(media),
+            new IconRenderer(),
+            new VideoRenderer(media),
+            new AudioPlayerRenderer(media),
+            new DividerRenderer(),
+            // Interactive
+            new ButtonRenderer(),
+            new CheckBoxRenderer(),
+            new TextFieldRenderer(),
+            new DateTimeInputRenderer(),
+            new MultipleChoiceRenderer(),
+            new SliderRenderer(),
+        };
+        return new ComponentRendererRegistry(renderers, new UnknownRenderer());
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/ComponentRendererRegistry.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/ComponentRendererRegistry.cs
@@ -13,9 +13,9 @@ namespace OpenClawTray.A2UI.Rendering;
 public sealed class ComponentRendererRegistry
 {
     private readonly Dictionary<string, IComponentRenderer> _byName;
-    private readonly UnknownRenderer _unknown;
+    private readonly IComponentRenderer _unknown;
 
-    public ComponentRendererRegistry(IEnumerable<IComponentRenderer> renderers, UnknownRenderer unknown)
+    internal ComponentRendererRegistry(IEnumerable<IComponentRenderer> renderers, UnknownRenderer unknown)
     {
         _byName = new(StringComparer.OrdinalIgnoreCase);
         foreach (var r in renderers) _byName[r.ComponentName] = r;

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/IComponentRenderer.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/IComponentRenderer.cs
@@ -41,7 +41,15 @@ public sealed class RenderContext
     public required IActionSink Actions { get; init; }
     public required A2UITheme Theme { get; init; }
     public required Func<string, FrameworkElement?> BuildChild { get; init; }
+    /// <summary>
+    /// Surface-scoped subscription store. Renderers should not access this
+    /// dictionary directly — use <see cref="WatchValue"/> (or
+    /// <see cref="RegisterSubscription"/> for non-value subs). Exposed here for
+    /// the surface host's lifecycle management.
+    /// </summary>
     public required IDictionary<string, IDisposable> Subscriptions { get; init; }
+    /// <summary>Surface-scoped logger; <c>null</c> if the host did not supply one.</summary>
+    public OpenClaw.Shared.IOpenClawLogger? Logger { get; init; }
     /// <summary>
     /// Surface-scoped set of JSON Pointer paths that hold sensitive values.
     /// Populated by renderers (e.g., obscured TextField); consulted by
@@ -102,6 +110,16 @@ public sealed class RenderContext
     public void WatchValue(string componentId, string subKey, A2UIValue? value, Action update)
     {
         if (value == null || !value.HasPath) return;
+        RegisterSubscription(componentId, subKey, DataModel.Subscribe(value.Path!, update));
+    }
+
+    /// <summary>
+    /// Register an arbitrary disposable subscription scoped to (componentId, subKey).
+    /// Replaces any prior subscription under the same key (the prior one is disposed).
+    /// The host disposes all registered subscriptions on rebuild.
+    /// </summary>
+    public void RegisterSubscription(string componentId, string subKey, IDisposable subscription)
+    {
         // Use a delimiter that can't appear inside a JSON Pointer-derived
         // componentId (nor inside subKeys we control). Previous "::" was
         // collidable: component "x::label" + sub "value" hashed to the same
@@ -112,7 +130,7 @@ public sealed class RenderContext
             try { prev.Dispose(); } catch { }
             Subscriptions.Remove(key);
         }
-        Subscriptions[key] = DataModel.Subscribe(value.Path!, update);
+        Subscriptions[key] = subscription;
     }
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/IComponentRenderer.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/IComponentRenderer.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using Microsoft.UI.Xaml;
+using OpenClawTray.A2UI.Actions;
+using OpenClawTray.A2UI.DataModel;
+using OpenClawTray.A2UI.Protocol;
+using OpenClawTray.A2UI.Theming;
+
+namespace OpenClawTray.A2UI.Rendering;
+
+/// <summary>
+/// One implementation per A2UI v0.8 component type. Catalog-strict: registry
+/// is populated at construction time. To extend, add a renderer class and
+/// register it in <see cref="ComponentRendererRegistry.BuildDefault"/>.
+/// </summary>
+public interface IComponentRenderer
+{
+    /// <summary>The A2UI component name (case-sensitive — matches the wire), e.g. "Button", "Column".</summary>
+    string ComponentName { get; }
+
+    /// <summary>
+    /// Build a XAML element for the component. Renderers are responsible for
+    /// resolving their own children via <see cref="RenderContext.BuildChild"/>;
+    /// there is no central adjacency walker. Bindings to the data model
+    /// register subscriptions in <see cref="RenderContext.Subscriptions"/> so
+    /// they can be torn down on rebuild.
+    /// </summary>
+    FrameworkElement Render(A2UIComponentDef component, RenderContext ctx);
+}
+
+/// <summary>
+/// Per-render-call context. Renderers hold no state across calls; the
+/// surface host owns lifetime and rebuilds the tree when the root or
+/// component definitions change.
+/// </summary>
+public sealed class RenderContext
+{
+    public required string SurfaceId { get; init; }
+    public required DataModelObservable DataModel { get; init; }
+    public required IActionSink Actions { get; init; }
+    public required A2UITheme Theme { get; init; }
+    public required Func<string, FrameworkElement?> BuildChild { get; init; }
+    public required IDictionary<string, IDisposable> Subscriptions { get; init; }
+
+    /// <summary>
+    /// Pull the named property from the component as an A2UI value (tagged
+    /// union of literals + path). Returns null if the property is absent.
+    /// </summary>
+    public A2UIValue? GetValue(A2UIComponentDef c, string propertyKey) =>
+        A2UIValue.From(c.Properties[propertyKey]);
+
+    /// <summary>Read the current resolved string for a value.</summary>
+    public string? ResolveString(A2UIValue? value)
+    {
+        if (value == null) return null;
+        if (value.LiteralString != null) return value.LiteralString;
+        if (value.LiteralNumber.HasValue) return value.LiteralNumber.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        if (value.LiteralBoolean.HasValue) return value.LiteralBoolean.Value ? "true" : "false";
+        if (value.HasPath)
+        {
+            var node = DataModel.Read(value.Path!);
+            if (node is JsonValue jv && jv.TryGetValue<string>(out var s)) return s;
+            return node?.ToString();
+        }
+        return null;
+    }
+
+    public double? ResolveNumber(A2UIValue? value)
+    {
+        if (value == null) return null;
+        if (value.LiteralNumber.HasValue) return value.LiteralNumber.Value;
+        if (value.HasPath)
+        {
+            var node = DataModel.Read(value.Path!);
+            if (node is JsonValue jv && jv.TryGetValue<double>(out var d)) return d;
+            if (node is JsonValue jv2 && jv2.TryGetValue<string>(out var s) && double.TryParse(s, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var parsed))
+                return parsed;
+        }
+        return null;
+    }
+
+    public bool? ResolveBoolean(A2UIValue? value)
+    {
+        if (value == null) return null;
+        if (value.LiteralBoolean.HasValue) return value.LiteralBoolean.Value;
+        if (value.HasPath)
+        {
+            var node = DataModel.Read(value.Path!);
+            if (node is JsonValue jv && jv.TryGetValue<bool>(out var b)) return b;
+        }
+        return null;
+    }
+
+    /// <summary>Subscribe a UI update to changes on a value's path. No-op for literals.</summary>
+    public void WatchValue(string componentId, string subKey, A2UIValue? value, Action update)
+    {
+        if (value == null || !value.HasPath) return;
+        var key = $"{componentId}::{subKey}";
+        if (Subscriptions.TryGetValue(key, out var prev))
+        {
+            try { prev.Dispose(); } catch { }
+            Subscriptions.Remove(key);
+        }
+        Subscriptions[key] = DataModel.Subscribe(value.Path!, update);
+    }
+
+    /// <summary>
+    /// Read children IDs from a container's <c>children</c> property
+    /// (<c>{ "explicitList": [...] }</c>). Template form is not yet supported;
+    /// it returns an empty list and logs once at the router level.
+    /// </summary>
+    public IReadOnlyList<string> GetExplicitChildren(A2UIComponentDef c, string key = "children")
+    {
+        if (c.Properties[key] is not JsonObject child) return Array.Empty<string>();
+        if (child["explicitList"] is JsonArray arr)
+        {
+            var list = new List<string>(arr.Count);
+            foreach (var item in arr)
+                if (item is JsonValue jv && jv.TryGetValue<string>(out var s)) list.Add(s);
+            return list;
+        }
+        return Array.Empty<string>();
+    }
+
+    public string? GetSingleChild(A2UIComponentDef c, string key)
+    {
+        if (c.Properties[key] is JsonValue jv && jv.TryGetValue<string>(out var s)) return s;
+        return null;
+    }
+
+    /// <summary>Build the action context array → flat object payload.</summary>
+    public JsonObject? BuildActionContext(JsonNode? actionNode)
+    {
+        if (actionNode is not JsonObject actionObj) return null;
+        if (actionObj["context"] is not JsonArray ctxArr) return null;
+        var result = new JsonObject();
+        foreach (var item in ctxArr)
+        {
+            if (item is not JsonObject e) continue;
+            var key = e["key"] is JsonValue kj && kj.TryGetValue<string>(out var k) ? k : null;
+            if (key == null) continue;
+            var val = A2UIValue.From(e["value"]);
+            if (val == null) { result[key] = null; continue; }
+            if (val.LiteralString != null) result[key] = val.LiteralString;
+            else if (val.LiteralNumber.HasValue) result[key] = val.LiteralNumber.Value;
+            else if (val.LiteralBoolean.HasValue) result[key] = val.LiteralBoolean.Value;
+            else if (val.HasPath) result[key] = DataModel.Read(val.Path!)?.DeepClone();
+        }
+        return result;
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/IComponentRenderer.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/IComponentRenderer.cs
@@ -42,6 +42,12 @@ public sealed class RenderContext
     public required A2UITheme Theme { get; init; }
     public required Func<string, FrameworkElement?> BuildChild { get; init; }
     public required IDictionary<string, IDisposable> Subscriptions { get; init; }
+    /// <summary>
+    /// Surface-scoped set of JSON Pointer paths that hold sensitive values.
+    /// Populated by renderers (e.g., obscured TextField); consulted by
+    /// <see cref="BuildActionContext"/> and the surface dump path.
+    /// </summary>
+    public ISet<string>? SecretPaths { get; init; }
 
     /// <summary>
     /// Pull the named property from the component as an A2UI value (tagged
@@ -96,7 +102,11 @@ public sealed class RenderContext
     public void WatchValue(string componentId, string subKey, A2UIValue? value, Action update)
     {
         if (value == null || !value.HasPath) return;
-        var key = $"{componentId}::{subKey}";
+        // Use a delimiter that can't appear inside a JSON Pointer-derived
+        // componentId (nor inside subKeys we control). Previous "::" was
+        // collidable: component "x::label" + sub "value" hashed to the same
+        // bucket as "x" + "label::value". (L2 in unified review.)
+        var key = $"{componentId}{subKey}";
         if (Subscriptions.TryGetValue(key, out var prev))
         {
             try { prev.Dispose(); } catch { }
@@ -129,11 +139,35 @@ public sealed class RenderContext
         return null;
     }
 
-    /// <summary>Build the action context array → flat object payload.</summary>
-    public JsonObject? BuildActionContext(JsonNode? actionNode)
+    /// <summary>Mark a path as secret for the lifetime of the current render. No-op if no secret store is wired.</summary>
+    public void MarkSecretPath(string? path)
+    {
+        if (SecretPaths == null) return;
+        if (string.IsNullOrEmpty(path)) return;
+        SecretPaths.Add(NormalizePath(path));
+    }
+
+    /// <summary>True if <paramref name="path"/> is a secret path (registered or matches denylist).</summary>
+    public bool IsSecretPath(string? path)
+    {
+        if (SecretPaths == null) return SecretRedactor.IsSecret(path, EmptySet.Instance);
+        return SecretRedactor.IsSecret(path, (IReadOnlySet<string>)SecretPaths);
+    }
+
+    /// <summary>
+    /// Build the action context array → flat object payload, scoped to the
+    /// source component's declared <c>dataBinding</c> (or, in its absence,
+    /// the set of paths the component references in any other property).
+    /// Paths outside that scope are silently dropped to prevent unrelated
+    /// surface state from leaking into the agent envelope. Secret paths are
+    /// always dropped.
+    /// </summary>
+    public JsonObject? BuildActionContext(A2UIComponentDef sourceComponent, JsonNode? actionNode)
     {
         if (actionNode is not JsonObject actionObj) return null;
         if (actionObj["context"] is not JsonArray ctxArr) return null;
+
+        var (allowed, isExplicit) = CollectAllowedBindingPaths(sourceComponent);
         var result = new JsonObject();
         foreach (var item in ctxArr)
         {
@@ -145,8 +179,100 @@ public sealed class RenderContext
             if (val.LiteralString != null) result[key] = val.LiteralString;
             else if (val.LiteralNumber.HasValue) result[key] = val.LiteralNumber.Value;
             else if (val.LiteralBoolean.HasValue) result[key] = val.LiteralBoolean.Value;
-            else if (val.HasPath) result[key] = DataModel.Read(val.Path!)?.DeepClone();
+            else if (val.HasPath)
+            {
+                var path = val.Path!;
+                if (!IsAllowedPath(path, allowed)) continue;
+                // Secret paths require explicit dataBinding opt-in. The implicit
+                // walk over component properties is too generous to count as opt-in.
+                if (IsSecretPath(path) && !isExplicit) continue;
+                result[key] = DataModel.Read(path)?.DeepClone();
+            }
         }
         return result;
+    }
+
+    private static (HashSet<string> paths, bool isExplicit) CollectAllowedBindingPaths(A2UIComponentDef source)
+    {
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        var props = source.Properties;
+
+        // Explicit declaration takes precedence: array of strings or {path: "..."} objects.
+        if (props["dataBinding"] is JsonArray db)
+        {
+            foreach (var item in db)
+            {
+                if (item is JsonValue jv && jv.TryGetValue<string>(out var s) && !string.IsNullOrEmpty(s))
+                    result.Add(NormalizePath(s));
+                else if (item is JsonObject obj && obj["path"] is JsonValue pv && pv.TryGetValue<string>(out var p) && !string.IsNullOrEmpty(p))
+                    result.Add(NormalizePath(p));
+            }
+            return (result, true);
+        }
+
+        // Implicit: any A2UIValue path that appears in the component's other properties.
+        // The action's own "context" array doesn't count — that's what we're scoping.
+        foreach (var kv in props)
+        {
+            if (kv.Key == "action" && kv.Value is JsonObject actionObj)
+            {
+                foreach (var ak in actionObj)
+                {
+                    if (ak.Key == "context") continue;
+                    CollectPaths(ak.Value, result);
+                }
+            }
+            else
+            {
+                CollectPaths(kv.Value, result);
+            }
+        }
+        return (result, false);
+    }
+
+    private static void CollectPaths(JsonNode? node, HashSet<string> result)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                if (obj["path"] is JsonValue jv && jv.TryGetValue<string>(out var p) && !string.IsNullOrEmpty(p))
+                    result.Add(NormalizePath(p));
+                foreach (var kv in obj) CollectPaths(kv.Value, result);
+                break;
+            case JsonArray arr:
+                foreach (var item in arr) CollectPaths(item, result);
+                break;
+        }
+    }
+
+    private static bool IsAllowedPath(string path, HashSet<string> allowed)
+    {
+        if (allowed.Count == 0) return false;
+        var normalized = NormalizePath(path);
+        if (allowed.Contains(normalized)) return true;
+        foreach (var p in allowed)
+        {
+            if (p == "/") return true; // explicit root binding opts in to everything
+            if (normalized.StartsWith(p + "/", StringComparison.Ordinal)) return true;
+        }
+        return false;
+    }
+
+    private static string NormalizePath(string p) =>
+        string.IsNullOrEmpty(p) ? "/" : (p[0] == '/' ? p : "/" + p);
+
+    private sealed class EmptySet : IReadOnlySet<string>
+    {
+        public static readonly EmptySet Instance = new();
+        public int Count => 0;
+        public bool Contains(string item) => false;
+        public IEnumerator<string> GetEnumerator() { yield break; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+        public bool IsProperSubsetOf(IEnumerable<string> other) => true;
+        public bool IsProperSupersetOf(IEnumerable<string> other) => false;
+        public bool IsSubsetOf(IEnumerable<string> other) => true;
+        public bool IsSupersetOf(IEnumerable<string> other) => false;
+        public bool Overlaps(IEnumerable<string> other) => false;
+        public bool SetEquals(IEnumerable<string> other) { foreach (var _ in other) return false; return true; }
     }
 }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/IComponentRenderer.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/IComponentRenderer.cs
@@ -169,7 +169,7 @@ public sealed class RenderContext
     /// <summary>True if <paramref name="path"/> is a secret path (registered or matches denylist).</summary>
     public bool IsSecretPath(string? path)
     {
-        if (SecretPaths == null) return SecretRedactor.IsSecret(path, EmptySet.Instance);
+        if (SecretPaths == null) return SecretRedactor.IsSecret(path, System.Collections.Frozen.FrozenSet<string>.Empty);
         return SecretRedactor.IsSecret(path, (IReadOnlySet<string>)SecretPaths);
     }
 
@@ -178,15 +178,21 @@ public sealed class RenderContext
     /// source component's declared <c>dataBinding</c> (or, in its absence,
     /// the set of paths the component references in any other property).
     /// Paths outside that scope are silently dropped to prevent unrelated
-    /// surface state from leaking into the agent envelope. Secret paths are
-    /// always dropped.
+    /// surface state from leaking into the agent envelope. Secret paths
+    /// (registered via obscured TextField, or matching the SecretRedactor
+    /// denylist) are always dropped — even when the component declares an
+    /// explicit <c>dataBinding</c>. <c>dataBinding: ["/"]</c> is a root-level
+    /// wildcard that opts in to everything; allowing secret paths through it
+    /// (or through any explicit binding) lets a malicious surface drain
+    /// credentials into the action envelope. The component can still bind
+    /// secret values for display; it just cannot exfiltrate them.
     /// </summary>
     public JsonObject? BuildActionContext(A2UIComponentDef sourceComponent, JsonNode? actionNode)
     {
         if (actionNode is not JsonObject actionObj) return null;
         if (actionObj["context"] is not JsonArray ctxArr) return null;
 
-        var (allowed, isExplicit) = CollectAllowedBindingPaths(sourceComponent);
+        var (allowed, _) = CollectAllowedBindingPaths(sourceComponent);
         var result = new JsonObject();
         foreach (var item in ctxArr)
         {
@@ -202,9 +208,7 @@ public sealed class RenderContext
             {
                 var path = val.Path!;
                 if (!IsAllowedPath(path, allowed)) continue;
-                // Secret paths require explicit dataBinding opt-in. The implicit
-                // walk over component properties is too generous to count as opt-in.
-                if (IsSecretPath(path) && !isExplicit) continue;
+                if (IsSecretPath(path)) continue;
                 result[key] = DataModel.Read(path)?.DeepClone();
             }
         }
@@ -280,20 +284,9 @@ public sealed class RenderContext
     private static string NormalizePath(string p) =>
         string.IsNullOrEmpty(p) ? "/" : (p[0] == '/' ? p : "/" + p);
 
-    private sealed class EmptySet : IReadOnlySet<string>
-    {
-        public static readonly EmptySet Instance = new();
-        public int Count => 0;
-        public bool Contains(string item) => false;
-        public IEnumerator<string> GetEnumerator() { yield break; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
-        public bool IsProperSubsetOf(IEnumerable<string> other) => true;
-        public bool IsProperSupersetOf(IEnumerable<string> other) => false;
-        public bool IsSubsetOf(IEnumerable<string> other) => true;
-        public bool IsSupersetOf(IEnumerable<string> other) => false;
-        public bool Overlaps(IEnumerable<string> other) => false;
-        public bool SetEquals(IEnumerable<string> other) { foreach (var _ in other) return false; return true; }
-    }
+    // EmptySet was a hand-rolled stand-in for an empty IReadOnlySet<string>.
+    // FrozenSet<string>.Empty is a single shared, allocation-free instance
+    // with the same behavior — see IsSecretPath above.
 }
 
 public sealed class MediaLoadBudget

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/IComponentRenderer.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/IComponentRenderer.cs
@@ -50,6 +50,7 @@ public sealed class RenderContext
     public required IDictionary<string, IDisposable> Subscriptions { get; init; }
     /// <summary>Surface-scoped logger; <c>null</c> if the host did not supply one.</summary>
     public OpenClaw.Shared.IOpenClawLogger? Logger { get; init; }
+    public MediaLoadBudget? MediaBudget { get; init; }
     /// <summary>
     /// Surface-scoped set of JSON Pointer paths that hold sensitive values.
     /// Populated by renderers (e.g., obscured TextField); consulted by
@@ -293,4 +294,13 @@ public sealed class RenderContext
         public bool Overlaps(IEnumerable<string> other) => false;
         public bool SetEquals(IEnumerable<string> other) { foreach (var _ in other) return false; return true; }
     }
+}
+
+public sealed class MediaLoadBudget
+{
+    internal const int MaxImageLoadsPerRender = 128;
+    private int _imageLoadsRemaining = MaxImageLoadsPerRender;
+
+    public bool TryReserveImageLoad() =>
+        System.Threading.Interlocked.Decrement(ref _imageLoadsRemaining) >= 0;
 }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/MediaResolver.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/MediaResolver.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using OpenClaw.Shared;
 using Windows.Storage.Streams;
@@ -14,7 +15,7 @@ namespace OpenClawTray.A2UI.Rendering;
 /// Single resolver for image/video/audio URLs in A2UI surfaces. Enforces the
 /// security policy from the spec:
 ///   - https://&lt;allowlist&gt; only
-///   - data: image/png|jpeg|webp up to 2 MiB
+///   - data: image/png|jpeg|webp|svg+xml up to 2 MiB
 ///   - everything else → broken-image fallback (logged once)
 /// Allowlist is mutable at runtime so a future <c>createSurface.theme</c> /
 /// manifest can extend it without restarting the process.
@@ -30,6 +31,8 @@ public sealed class MediaResolver
     private const long DataUrlMaxBytes = 2L * 1024 * 1024;
     /// <summary>Hard cap on remote image bytes. Sized to dwarf realistic UI imagery while still preventing OOM from a hostile/compromised allowlisted host.</summary>
     internal const long RemoteImageMaxBytes = 8L * 1024 * 1024;
+    /// <summary>Bound on SVG SetSourceAsync. SVG render time isn't bounded by the byte cap (a 1 MiB path expression can be pathologically expensive), so cap wall time here.</summary>
+    internal static readonly TimeSpan SvgRenderTimeout = TimeSpan.FromSeconds(8);
 
     public MediaResolver(IOpenClawLogger logger)
     {
@@ -59,11 +62,18 @@ public sealed class MediaResolver
         var comma = url.IndexOf(',');
         if (comma < 0) return false;
         var header = url.Substring(5, comma - 5).ToLowerInvariant();
-        if (!(header.StartsWith("image/png") || header.StartsWith("image/jpeg") || header.StartsWith("image/webp")))
+        if (!(header.StartsWith("image/png")
+              || header.StartsWith("image/jpeg")
+              || header.StartsWith("image/webp")
+              || header.StartsWith("image/svg+xml")))
             return false;
-        // Tight size check based on actual base64 decode length (account for padding).
+        // SVG data: URLs are commonly transmitted as percent-encoded UTF-8 (utf8 / charset=utf-8) rather than base64.
+        // The size cap still applies — measure against the worst-case decoded size of the payload portion.
+        bool isBase64 = header.Contains(";base64");
         var encoded = url.Length - comma - 1;
-        long decoded = ComputeBase64DecodedLength(url, comma + 1, encoded);
+        long decoded = isBase64
+            ? ComputeBase64DecodedLength(url, comma + 1, encoded)
+            : encoded; // percent-encoded text decodes to at most `encoded` bytes
         return decoded <= DataUrlMaxBytes;
     }
 
@@ -82,9 +92,9 @@ public sealed class MediaResolver
         return realChars / 4 * 3 - padding;
     }
 
-    public Task<BitmapImage?> LoadImageAsync(string url) => LoadImageAsync(url, CancellationToken.None);
+    public Task<ImageSource?> LoadImageAsync(string url) => LoadImageAsync(url, CancellationToken.None);
 
-    public async Task<BitmapImage?> LoadImageAsync(string url, CancellationToken cancellationToken)
+    public async Task<ImageSource?> LoadImageAsync(string url, CancellationToken cancellationToken)
     {
         if (!IsAllowed(url))
         {
@@ -93,21 +103,34 @@ public sealed class MediaResolver
         }
         try
         {
+            byte[] bytes;
+            bool mimeIsSvg;
             if (url.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase))
             {
-                var comma = url.IndexOf(',');
-                var b64 = url.Substring(comma + 1);
-                var bytes = Convert.FromBase64String(b64);
+                if (!TryDecodeDataUrl(url, out bytes, out mimeIsSvg))
+                {
+                    _logger.Warn($"[A2UI] data: image decode failed for {Truncate(url)}");
+                    return null;
+                }
                 if (bytes.LongLength > DataUrlMaxBytes)
                 {
                     _logger.Warn($"[A2UI] data: image exceeds cap ({bytes.LongLength} > {DataUrlMaxBytes})");
                     return null;
                 }
-                return await BitmapFromBytes(bytes);
             }
-            var data = await FetchBoundedAsync(url, cancellationToken).ConfigureAwait(false);
-            if (data == null) return null;
-            return await BitmapFromBytes(data);
+            else
+            {
+                var fetched = await FetchBoundedAsync(url, cancellationToken).ConfigureAwait(false);
+                if (fetched is null) return null;
+                bytes = fetched.Value.Bytes;
+                var ct = fetched.Value.ContentType;
+                mimeIsSvg = ct != null && ct.StartsWith("image/svg+xml", StringComparison.OrdinalIgnoreCase);
+            }
+
+            // Content-Type is the strong signal; signature sniff is the fallback for servers/agents that mislabel.
+            if (mimeIsSvg || LooksLikeSvg(bytes))
+                return await SvgFromBytesAsync(bytes, cancellationToken).ConfigureAwait(false);
+            return await BitmapFromBytes(bytes).ConfigureAwait(false);
         }
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
@@ -117,7 +140,30 @@ public sealed class MediaResolver
         }
     }
 
-    private async Task<byte[]?> FetchBoundedAsync(string url, CancellationToken cancellationToken)
+    private static bool TryDecodeDataUrl(string url, out byte[] bytes, out bool mimeIsSvg)
+    {
+        bytes = Array.Empty<byte>();
+        mimeIsSvg = false;
+        var comma = url.IndexOf(',');
+        if (comma < 0) return false;
+        var header = url.Substring(5, comma - 5);
+        mimeIsSvg = header.StartsWith("image/svg+xml", StringComparison.OrdinalIgnoreCase);
+        var payload = url.Substring(comma + 1);
+        if (header.Contains(";base64", StringComparison.OrdinalIgnoreCase))
+        {
+            try { bytes = Convert.FromBase64String(payload); }
+            catch (FormatException) { return false; }
+        }
+        else
+        {
+            // RFC 2397 percent-encoding: SVG data: URLs commonly use this form (smaller than base64 for text).
+            try { bytes = System.Text.Encoding.UTF8.GetBytes(Uri.UnescapeDataString(payload)); }
+            catch (UriFormatException) { return false; }
+        }
+        return true;
+    }
+
+    private async Task<(byte[] Bytes, string? ContentType)?> FetchBoundedAsync(string url, CancellationToken cancellationToken)
     {
         // ResponseHeadersRead lets us reject by Content-Length before buffering the body.
         using var resp = await s_http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
@@ -152,7 +198,7 @@ public sealed class MediaResolver
             }
             ms.Write(buffer, 0, read);
         }
-        return ms.ToArray();
+        return (ms.ToArray(), resp.Content.Headers.ContentType?.MediaType);
     }
 
     public Uri? AsUri(string url) =>
@@ -172,6 +218,129 @@ public sealed class MediaResolver
         ms.Seek(0);
         await bmp.SetSourceAsync(ms);
         return bmp;
+    }
+
+    /// <summary>
+    /// Decode SVG bytes through D2D's static SVG 1.1 subset (no scripts, no SMIL, no &lt;foreignObject&gt;,
+    /// no external fetches — that's our trust model). Two pieces of defense-in-depth on top:
+    ///   - DOCTYPE pre-strip in case D2D's XML parser would resolve external entities (XXE / billion-laughs).
+    ///   - Wall-clock timeout because a 1 MiB SVG can hold pathologically expensive geometry.
+    /// </summary>
+    private async Task<ImageSource?> SvgFromBytesAsync(byte[] bytes, CancellationToken cancellationToken)
+    {
+        bytes = StripDoctype(bytes);
+        var svg = new SvgImageSource();
+        using var ms = new InMemoryRandomAccessStream();
+        using (var w = new DataWriter(ms))
+        {
+            w.WriteBytes(bytes);
+            await w.StoreAsync();
+            await w.FlushAsync();
+            w.DetachStream();
+        }
+        ms.Seek(0);
+
+        using var renderTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        renderTimeout.CancelAfter(SvgRenderTimeout);
+        SvgImageSourceLoadStatus status;
+        try
+        {
+            status = await svg.SetSourceAsync(ms).AsTask().WaitAsync(renderTimeout.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.Warn("[A2UI] SVG decode timed out");
+            return null;
+        }
+        if (status != SvgImageSourceLoadStatus.Success)
+        {
+            _logger.Warn($"[A2UI] SVG decode failed: {status}");
+            return null;
+        }
+        return svg;
+    }
+
+    /// <summary>Cheap content sniff for SVG bytes after BOM and leading whitespace.</summary>
+    internal static bool LooksLikeSvg(byte[] bytes)
+    {
+        if (bytes == null || bytes.Length == 0) return false;
+        int i = 0;
+        if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF) i = 3;
+        while (i < bytes.Length && (bytes[i] == 0x20 || bytes[i] == 0x09 || bytes[i] == 0x0A || bytes[i] == 0x0D)) i++;
+        int max = Math.Min(bytes.Length - i, 256);
+        if (max <= 0) return false;
+        var head = System.Text.Encoding.UTF8.GetString(bytes, i, max);
+        return head.StartsWith("<?xml", StringComparison.Ordinal)
+            || head.StartsWith("<svg", StringComparison.OrdinalIgnoreCase)
+            || head.StartsWith("<!DOCTYPE", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Remove the first <c>&lt;!DOCTYPE …&gt;</c> declaration (including any internal subset
+    /// in <c>[…]</c>) from the byte stream. SVG content has no need for a DOCTYPE — browsers
+    /// ignore it — but stripping it pre-empts XXE / entity-expansion attacks regardless of
+    /// what the downstream XML parser does.
+    /// </summary>
+    internal static byte[] StripDoctype(byte[] bytes)
+    {
+        if (bytes == null || bytes.Length == 0) return bytes ?? Array.Empty<byte>();
+        int idx = IndexOfAsciiCi(bytes, 0, "<!DOCTYPE");
+        if (idx < 0) return bytes;
+        int cursor = idx + "<!DOCTYPE".Length;
+        int firstGt = IndexOfByte(bytes, cursor, (byte)'>');
+        if (firstGt < 0) return bytes;
+        int bracket = IndexOfByteInRange(bytes, cursor, firstGt, (byte)'[');
+        int end;
+        if (bracket < 0)
+        {
+            end = firstGt;
+        }
+        else
+        {
+            int closeBracket = IndexOfByte(bytes, bracket + 1, (byte)']');
+            if (closeBracket < 0) return bytes;
+            end = IndexOfByte(bytes, closeBracket + 1, (byte)'>');
+            if (end < 0) return bytes;
+        }
+        var result = new byte[bytes.Length - (end - idx + 1)];
+        System.Buffer.BlockCopy(bytes, 0, result, 0, idx);
+        System.Buffer.BlockCopy(bytes, end + 1, result, idx, bytes.Length - end - 1);
+        return result;
+    }
+
+    private static int IndexOfByte(byte[] haystack, int start, byte needle)
+    {
+        for (int i = start; i < haystack.Length; i++)
+            if (haystack[i] == needle) return i;
+        return -1;
+    }
+
+    private static int IndexOfByteInRange(byte[] haystack, int start, int endExclusive, byte needle)
+    {
+        int limit = Math.Min(endExclusive, haystack.Length);
+        for (int i = start; i < limit; i++)
+            if (haystack[i] == needle) return i;
+        return -1;
+    }
+
+    private static int IndexOfAsciiCi(byte[] haystack, int start, string asciiNeedle)
+    {
+        if (asciiNeedle.Length == 0) return start;
+        int last = haystack.Length - asciiNeedle.Length;
+        for (int i = start; i <= last; i++)
+        {
+            bool match = true;
+            for (int j = 0; j < asciiNeedle.Length; j++)
+            {
+                byte b = haystack[i + j];
+                char c = asciiNeedle[j];
+                byte upper = (b >= (byte)'a' && b <= (byte)'z') ? (byte)(b - 0x20) : b;
+                char nUpper = (c >= 'a' && c <= 'z') ? (char)(c - 0x20) : c;
+                if (upper != (byte)nUpper) { match = false; break; }
+            }
+            if (match) return i;
+        }
+        return -1;
     }
 
     private static string Truncate(string s) =>

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/MediaResolver.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/MediaResolver.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Media;
@@ -24,19 +26,107 @@ public sealed class MediaResolver
 {
     private readonly IOpenClawLogger _logger;
     private readonly HashSet<string> _hostAllowlist = new(StringComparer.OrdinalIgnoreCase);
-    private static readonly HttpClient s_http = new()
-    {
-        Timeout = TimeSpan.FromSeconds(15),
-    };
+    private readonly HttpClient _http;
     private const long DataUrlMaxBytes = 2L * 1024 * 1024;
     /// <summary>Hard cap on remote image bytes. Sized to dwarf realistic UI imagery while still preventing OOM from a hostile/compromised allowlisted host.</summary>
     internal const long RemoteImageMaxBytes = 8L * 1024 * 1024;
     /// <summary>Bound on SVG SetSourceAsync. SVG render time isn't bounded by the byte cap (a 1 MiB path expression can be pathologically expensive), so cap wall time here.</summary>
     internal static readonly TimeSpan SvgRenderTimeout = TimeSpan.FromSeconds(8);
 
-    public MediaResolver(IOpenClawLogger logger)
+    public MediaResolver(IOpenClawLogger logger) : this(logger, handler: null) { }
+
+    /// <summary>
+    /// Test seam: pass a custom <see cref="HttpMessageHandler"/> to stub the
+    /// network. Production callers use the parameterless overload.
+    /// </summary>
+    public MediaResolver(IOpenClawLogger logger, HttpMessageHandler? handler)
     {
         _logger = logger;
+        _http = handler != null
+            ? new HttpClient(handler, disposeHandler: false) { Timeout = TimeSpan.FromSeconds(15) }
+            : new HttpClient(BuildSafeHandler(logger), disposeHandler: true) { Timeout = TimeSpan.FromSeconds(15) };
+    }
+
+    /// <summary>
+    /// Builds a SocketsHttpHandler whose ConnectCallback resolves DNS once and
+    /// rejects the connection if any resolved address is private/loopback/
+    /// link-local/multicast. Defends against DNS rebinding (TOCTOU between
+    /// allowlist hostname check and the actual TCP connect: a hostile DNS
+    /// server could otherwise return an internal IP for an allowlisted name).
+    /// </summary>
+    private static SocketsHttpHandler BuildSafeHandler(IOpenClawLogger logger)
+    {
+        return new SocketsHttpHandler
+        {
+            // Disable connection pooling so a host's resolution can't be cached
+            // across requests in a way that bypasses revalidation.
+            PooledConnectionLifetime = TimeSpan.FromMinutes(2),
+            ConnectCallback = async (ctx, ct) =>
+            {
+                var addresses = await Dns.GetHostAddressesAsync(ctx.DnsEndPoint.Host, ct).ConfigureAwait(false);
+                if (addresses.Length == 0)
+                    throw new HttpRequestException($"DNS returned no addresses for '{ctx.DnsEndPoint.Host}'");
+                // Reject the entire connection if ANY resolved address is
+                // unsafe — DNS round-robin must not let a partially-internal
+                // record slip through.
+                foreach (var ip in addresses)
+                {
+                    if (!IsPublicAddress(ip))
+                    {
+                        logger.Warn($"[A2UI] Refusing to connect to '{ctx.DnsEndPoint.Host}': resolved to non-public address {ip}");
+                        throw new HttpRequestException($"Refusing to connect to non-public address {ip} for host '{ctx.DnsEndPoint.Host}'");
+                    }
+                }
+                // Connect to the resolved IP directly so the TCP target matches
+                // exactly what we validated (no second DNS lookup downstream).
+                var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+                try
+                {
+                    await socket.ConnectAsync(addresses[0], ctx.DnsEndPoint.Port, ct).ConfigureAwait(false);
+                    return new NetworkStream(socket, ownsSocket: true);
+                }
+                catch
+                {
+                    socket.Dispose();
+                    throw;
+                }
+            },
+        };
+    }
+
+    private static bool IsPublicAddress(IPAddress ip)
+    {
+        if (IPAddress.IsLoopback(ip)) return false;
+        if (ip.AddressFamily == AddressFamily.InterNetwork)
+        {
+            var b = ip.GetAddressBytes();
+            // 0.0.0.0/8 (this network), 10.0.0.0/8 (private), 100.64.0.0/10 (CGNAT),
+            // 127.0.0.0/8 (loopback), 169.254.0.0/16 (link-local),
+            // 172.16.0.0/12 (private), 192.168.0.0/16 (private), 224.0.0.0/4 (multicast),
+            // 240.0.0.0/4 (reserved/broadcast).
+            if (b[0] == 0) return false;
+            if (b[0] == 10) return false;
+            if (b[0] == 100 && (b[1] & 0xC0) == 64) return false;
+            if (b[0] == 127) return false;
+            if (b[0] == 169 && b[1] == 254) return false;
+            if (b[0] == 172 && b[1] >= 16 && b[1] <= 31) return false;
+            if (b[0] == 192 && b[1] == 168) return false;
+            if (b[0] >= 224) return false;
+            return true;
+        }
+        if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            if (ip.IsIPv6LinkLocal) return false;
+            if (ip.IsIPv6SiteLocal) return false;
+            if (ip.IsIPv6Multicast) return false;
+            // fc00::/7 (unique local).
+            var b = ip.GetAddressBytes();
+            if ((b[0] & 0xFE) == 0xFC) return false;
+            // ::1 (loopback already caught), ::ffff:0:0/96 (IPv4-mapped) treated as v4.
+            if (ip.IsIPv4MappedToIPv6) return IsPublicAddress(ip.MapToIPv4());
+            return true;
+        }
+        return false;
     }
 
     public void AllowHost(string host)
@@ -166,7 +256,7 @@ public sealed class MediaResolver
     private async Task<(byte[] Bytes, string? ContentType)?> FetchBoundedAsync(string url, CancellationToken cancellationToken)
     {
         // ResponseHeadersRead lets us reject by Content-Length before buffering the body.
-        using var resp = await s_http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+        using var resp = await _http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);
         if (!resp.IsSuccessStatusCode)
         {

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/MediaResolver.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/MediaResolver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Media.Imaging;
 using OpenClaw.Shared;
@@ -27,6 +28,8 @@ public sealed class MediaResolver
         Timeout = TimeSpan.FromSeconds(15),
     };
     private const long DataUrlMaxBytes = 2L * 1024 * 1024;
+    /// <summary>Hard cap on remote image bytes. Sized to dwarf realistic UI imagery while still preventing OOM from a hostile/compromised allowlisted host.</summary>
+    internal const long RemoteImageMaxBytes = 8L * 1024 * 1024;
 
     public MediaResolver(IOpenClawLogger logger)
     {
@@ -58,13 +61,30 @@ public sealed class MediaResolver
         var header = url.Substring(5, comma - 5).ToLowerInvariant();
         if (!(header.StartsWith("image/png") || header.StartsWith("image/jpeg") || header.StartsWith("image/webp")))
             return false;
-        // Rough size cap based on encoded length; base64 → 4/3 expansion.
+        // Tight size check based on actual base64 decode length (account for padding).
         var encoded = url.Length - comma - 1;
-        var approx = (long)(encoded * 0.75);
-        return approx <= DataUrlMaxBytes;
+        long decoded = ComputeBase64DecodedLength(url, comma + 1, encoded);
+        return decoded <= DataUrlMaxBytes;
     }
 
-    public async Task<BitmapImage?> LoadImageAsync(string url)
+    private static long ComputeBase64DecodedLength(string url, int start, int encodedLen)
+    {
+        if (encodedLen <= 0) return 0;
+        // Strip trailing whitespace and base64 padding for a precise upper bound.
+        int padding = 0;
+        int end = start + encodedLen - 1;
+        while (end >= start && (url[end] == '=' || char.IsWhiteSpace(url[end])))
+        {
+            if (url[end] == '=') padding++;
+            end--;
+        }
+        long realChars = end - start + 1 + padding;
+        return realChars / 4 * 3 - padding;
+    }
+
+    public Task<BitmapImage?> LoadImageAsync(string url) => LoadImageAsync(url, CancellationToken.None);
+
+    public async Task<BitmapImage?> LoadImageAsync(string url, CancellationToken cancellationToken)
     {
         if (!IsAllowed(url))
         {
@@ -78,16 +98,61 @@ public sealed class MediaResolver
                 var comma = url.IndexOf(',');
                 var b64 = url.Substring(comma + 1);
                 var bytes = Convert.FromBase64String(b64);
+                if (bytes.LongLength > DataUrlMaxBytes)
+                {
+                    _logger.Warn($"[A2UI] data: image exceeds cap ({bytes.LongLength} > {DataUrlMaxBytes})");
+                    return null;
+                }
                 return await BitmapFromBytes(bytes);
             }
-            var data = await s_http.GetByteArrayAsync(url);
+            var data = await FetchBoundedAsync(url, cancellationToken).ConfigureAwait(false);
+            if (data == null) return null;
             return await BitmapFromBytes(data);
         }
+        catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
             _logger.Warn($"[A2UI] Image fetch failed for {Truncate(url)}: {ex.Message}");
             return null;
         }
+    }
+
+    private async Task<byte[]?> FetchBoundedAsync(string url, CancellationToken cancellationToken)
+    {
+        // ResponseHeadersRead lets us reject by Content-Length before buffering the body.
+        using var resp = await s_http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+        if (!resp.IsSuccessStatusCode)
+        {
+            _logger.Warn($"[A2UI] Image fetch HTTP {(int)resp.StatusCode} for {Truncate(url)}");
+            return null;
+        }
+        var contentLength = resp.Content.Headers.ContentLength;
+        if (contentLength is long cl && cl > RemoteImageMaxBytes)
+        {
+            _logger.Warn($"[A2UI] Image rejected by Content-Length ({cl} > {RemoteImageMaxBytes}) for {Truncate(url)}");
+            return null;
+        }
+
+        // Stream body into a capped buffer. Servers may lie about Content-Length
+        // or use chunked encoding without it, so enforce again on the read side.
+        using var stream = await resp.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var ms = new MemoryStream(capacity: contentLength is long c ? (int)Math.Min(c, RemoteImageMaxBytes) : 64 * 1024);
+        var buffer = new byte[16 * 1024];
+        long total = 0;
+        while (true)
+        {
+            int read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
+            if (read <= 0) break;
+            total += read;
+            if (total > RemoteImageMaxBytes)
+            {
+                _logger.Warn($"[A2UI] Image stream exceeded cap ({total} > {RemoteImageMaxBytes}) for {Truncate(url)}");
+                return null;
+            }
+            ms.Write(buffer, 0, read);
+        }
+        return ms.ToArray();
     }
 
     public Uri? AsUri(string url) =>

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/MediaResolver.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/MediaResolver.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Media.Imaging;
+using OpenClaw.Shared;
+using Windows.Storage.Streams;
+
+namespace OpenClawTray.A2UI.Rendering;
+
+/// <summary>
+/// Single resolver for image/video/audio URLs in A2UI surfaces. Enforces the
+/// security policy from the spec:
+///   - https://&lt;allowlist&gt; only
+///   - data: image/png|jpeg|webp up to 2 MiB
+///   - everything else → broken-image fallback (logged once)
+/// Allowlist is mutable at runtime so a future <c>createSurface.theme</c> /
+/// manifest can extend it without restarting the process.
+/// </summary>
+public sealed class MediaResolver
+{
+    private readonly IOpenClawLogger _logger;
+    private readonly HashSet<string> _hostAllowlist = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly HttpClient s_http = new()
+    {
+        Timeout = TimeSpan.FromSeconds(15),
+    };
+    private const long DataUrlMaxBytes = 2L * 1024 * 1024;
+
+    public MediaResolver(IOpenClawLogger logger)
+    {
+        _logger = logger;
+    }
+
+    public void AllowHost(string host)
+    {
+        if (string.IsNullOrWhiteSpace(host)) return;
+        _hostAllowlist.Add(host);
+    }
+
+    public bool IsAllowed(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return false;
+        if (url.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase))
+        {
+            return IsSafeDataImage(url);
+        }
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
+        if (uri.Scheme != Uri.UriSchemeHttps) return false;
+        return _hostAllowlist.Contains(uri.Host);
+    }
+
+    private static bool IsSafeDataImage(string url)
+    {
+        var comma = url.IndexOf(',');
+        if (comma < 0) return false;
+        var header = url.Substring(5, comma - 5).ToLowerInvariant();
+        if (!(header.StartsWith("image/png") || header.StartsWith("image/jpeg") || header.StartsWith("image/webp")))
+            return false;
+        // Rough size cap based on encoded length; base64 → 4/3 expansion.
+        var encoded = url.Length - comma - 1;
+        var approx = (long)(encoded * 0.75);
+        return approx <= DataUrlMaxBytes;
+    }
+
+    public async Task<BitmapImage?> LoadImageAsync(string url)
+    {
+        if (!IsAllowed(url))
+        {
+            _logger.Warn($"[A2UI] Image blocked: {Truncate(url)}");
+            return null;
+        }
+        try
+        {
+            if (url.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase))
+            {
+                var comma = url.IndexOf(',');
+                var b64 = url.Substring(comma + 1);
+                var bytes = Convert.FromBase64String(b64);
+                return await BitmapFromBytes(bytes);
+            }
+            var data = await s_http.GetByteArrayAsync(url);
+            return await BitmapFromBytes(data);
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"[A2UI] Image fetch failed for {Truncate(url)}: {ex.Message}");
+            return null;
+        }
+    }
+
+    public Uri? AsUri(string url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var u) ? u : null;
+
+    private static async Task<BitmapImage> BitmapFromBytes(byte[] bytes)
+    {
+        var bmp = new BitmapImage();
+        using var ms = new InMemoryRandomAccessStream();
+        using (var w = new DataWriter(ms))
+        {
+            w.WriteBytes(bytes);
+            await w.StoreAsync();
+            await w.FlushAsync();
+            w.DetachStream();
+        }
+        ms.Seek(0);
+        await bmp.SetSourceAsync(ms);
+        return bmp;
+    }
+
+    private static string Truncate(string s) =>
+        s.Length <= 60 ? s : s.Substring(0, 60) + "...";
+}

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/MediaResolver.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/MediaResolver.cs
@@ -278,59 +278,35 @@ public sealed class MediaResolver : IDisposable
     public Uri? AsUri(string url) =>
         Uri.TryCreate(url, UriKind.Absolute, out var u) ? u : null;
 
-    public Task<Uri?> ResolveMediaUriAsync(string url) => ResolveMediaUriAsync(url, CancellationToken.None);
-
-    public async Task<Uri?> ResolveMediaUriAsync(string url, CancellationToken cancellationToken)
+    /// <summary>
+    /// Gate URL for Video / AudioPlayer playback. Enforces HTTPS+allowlist
+    /// (via <see cref="IsAllowed"/>) and rejects IP-literal hosts that are not
+    /// public (catches accidental allowlist entries like https://10.0.0.1/).
+    ///
+    /// NOT a DNS-rebinding pin: the OS media stack
+    /// (<c>MediaSource.CreateFromUri</c>) performs its own DNS resolution at
+    /// playback time, so any DNS lookup here would only be best-effort triage
+    /// against the lookup the platform actually uses. The allowlist is the
+    /// load-bearing defense; image fetches go through the safe
+    /// <see cref="HttpClient"/>'s <c>ConnectCallback</c> path which DOES pin.
+    /// </summary>
+    public Uri? TryResolveMediaUri(string url)
     {
         if (!IsAllowed(url))
         {
             _logger.Warn($"[A2UI] Media blocked: {Truncate(url)}");
             return null;
         }
-
         var uri = AsUri(url);
         if (uri == null) return null;
-        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-            return uri;
-
-        try
+        if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+            && IPAddress.TryParse(uri.Host, out var literal)
+            && !HttpUrlRiskEvaluator.IsPublicAddress(literal))
         {
-            if (IPAddress.TryParse(uri.Host, out var literal))
-            {
-                if (!HttpUrlRiskEvaluator.IsPublicAddress(literal))
-                {
-                    _logger.Warn($"[A2UI] Media blocked: host '{uri.Host}' is not public");
-                    return null;
-                }
-                return uri;
-            }
-
-            var addresses = await Dns.GetHostAddressesAsync(uri.Host, cancellationToken).ConfigureAwait(false);
-            if (addresses.Length == 0)
-            {
-                _logger.Warn($"[A2UI] Media blocked: DNS returned no addresses for '{uri.Host}'");
-                return null;
-            }
-
-            foreach (var ip in addresses)
-            {
-                if (!HttpUrlRiskEvaluator.IsPublicAddress(ip))
-                {
-                    _logger.Warn($"[A2UI] Media blocked: '{uri.Host}' resolved to non-public address {ip}");
-                    return null;
-                }
-            }
-            return uri;
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.Warn($"[A2UI] Media URL validation failed for {Truncate(url)}: {ex.Message}");
+            _logger.Warn($"[A2UI] Media blocked: host '{uri.Host}' is not public");
             return null;
         }
+        return uri;
     }
 
     private static async Task<BitmapImage> BitmapFromBytes(byte[] bytes)

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/MediaResolver.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/MediaResolver.cs
@@ -22,11 +22,12 @@ namespace OpenClawTray.A2UI.Rendering;
 /// Allowlist is mutable at runtime so a future <c>createSurface.theme</c> /
 /// manifest can extend it without restarting the process.
 /// </summary>
-public sealed class MediaResolver
+public sealed class MediaResolver : IDisposable
 {
     private readonly IOpenClawLogger _logger;
     private readonly HashSet<string> _hostAllowlist = new(StringComparer.OrdinalIgnoreCase);
     private readonly HttpClient _http;
+    private bool _disposed;
     private static readonly SemaphoreSlim s_svgDecodeSemaphore = new(3, 3);
     private const long DataUrlMaxBytes = 2L * 1024 * 1024;
     /// <summary>Hard cap on remote image bytes. Sized to dwarf realistic UI imagery while still preventing OOM from a hostile/compromised allowlisted host.</summary>
@@ -59,6 +60,11 @@ public sealed class MediaResolver
     {
         return new SocketsHttpHandler
         {
+            // The ConnectCallback validates IP addresses, but auto-redirect
+            // would let an allowlisted host respond with a 30x to a hostname
+            // we never validated against the allowlist. Disable redirects
+            // entirely — a broken image is preferable to an SSRF window.
+            AllowAutoRedirect = false,
             // Disable connection pooling so a host's resolution can't be cached
             // across requests in a way that bypasses revalidation.
             PooledConnectionLifetime = TimeSpan.FromMinutes(2),
@@ -93,6 +99,17 @@ public sealed class MediaResolver
                 }
             },
         };
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        // disposeHandler:true on the production path means HttpClient.Dispose
+        // also tears down the SocketsHttpHandler and its connection pool.
+        // The test seam path (handler:null overload above) uses
+        // disposeHandler:false, so the test owns the handler lifecycle.
+        try { _http.Dispose(); } catch (Exception ex) { _logger.Debug($"[A2UI] MediaResolver dispose: {ex.Message}"); }
     }
 
     public void AllowHost(string host)
@@ -468,6 +485,12 @@ public sealed class MediaResolver
         return -1;
     }
 
-    private static string Truncate(string s) =>
-        s.Length <= 60 ? s : s.Substring(0, 60) + "...";
+    // Truncation alone leaks query/fragment for any URL shorter than 60
+    // chars. Sanitize first (drop query+fragment, keep first path segment),
+    // then bound the length so the format strings stay tidy.
+    private static string Truncate(string s)
+    {
+        var sanitized = UrlLogSanitizer.Sanitize(s);
+        return sanitized.Length <= 60 ? sanitized : sanitized.Substring(0, 60) + "...";
+    }
 }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/MediaResolver.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/MediaResolver.cs
@@ -27,6 +27,7 @@ public sealed class MediaResolver
     private readonly IOpenClawLogger _logger;
     private readonly HashSet<string> _hostAllowlist = new(StringComparer.OrdinalIgnoreCase);
     private readonly HttpClient _http;
+    private static readonly SemaphoreSlim s_svgDecodeSemaphore = new(3, 3);
     private const long DataUrlMaxBytes = 2L * 1024 * 1024;
     /// <summary>Hard cap on remote image bytes. Sized to dwarf realistic UI imagery while still preventing OOM from a hostile/compromised allowlisted host.</summary>
     internal const long RemoteImageMaxBytes = 8L * 1024 * 1024;
@@ -71,7 +72,7 @@ public sealed class MediaResolver
                 // record slip through.
                 foreach (var ip in addresses)
                 {
-                    if (!IsPublicAddress(ip))
+                    if (!HttpUrlRiskEvaluator.IsPublicAddress(ip))
                     {
                         logger.Warn($"[A2UI] Refusing to connect to '{ctx.DnsEndPoint.Host}': resolved to non-public address {ip}");
                         throw new HttpRequestException($"Refusing to connect to non-public address {ip} for host '{ctx.DnsEndPoint.Host}'");
@@ -94,41 +95,6 @@ public sealed class MediaResolver
         };
     }
 
-    private static bool IsPublicAddress(IPAddress ip)
-    {
-        if (IPAddress.IsLoopback(ip)) return false;
-        if (ip.AddressFamily == AddressFamily.InterNetwork)
-        {
-            var b = ip.GetAddressBytes();
-            // 0.0.0.0/8 (this network), 10.0.0.0/8 (private), 100.64.0.0/10 (CGNAT),
-            // 127.0.0.0/8 (loopback), 169.254.0.0/16 (link-local),
-            // 172.16.0.0/12 (private), 192.168.0.0/16 (private), 224.0.0.0/4 (multicast),
-            // 240.0.0.0/4 (reserved/broadcast).
-            if (b[0] == 0) return false;
-            if (b[0] == 10) return false;
-            if (b[0] == 100 && (b[1] & 0xC0) == 64) return false;
-            if (b[0] == 127) return false;
-            if (b[0] == 169 && b[1] == 254) return false;
-            if (b[0] == 172 && b[1] >= 16 && b[1] <= 31) return false;
-            if (b[0] == 192 && b[1] == 168) return false;
-            if (b[0] >= 224) return false;
-            return true;
-        }
-        if (ip.AddressFamily == AddressFamily.InterNetworkV6)
-        {
-            if (ip.IsIPv6LinkLocal) return false;
-            if (ip.IsIPv6SiteLocal) return false;
-            if (ip.IsIPv6Multicast) return false;
-            // fc00::/7 (unique local).
-            var b = ip.GetAddressBytes();
-            if ((b[0] & 0xFE) == 0xFC) return false;
-            // ::1 (loopback already caught), ::ffff:0:0/96 (IPv4-mapped) treated as v4.
-            if (ip.IsIPv4MappedToIPv6) return IsPublicAddress(ip.MapToIPv4());
-            return true;
-        }
-        return false;
-    }
-
     public void AllowHost(string host)
     {
         if (string.IsNullOrWhiteSpace(host)) return;
@@ -144,6 +110,7 @@ public sealed class MediaResolver
         }
         if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
         if (uri.Scheme != Uri.UriSchemeHttps) return false;
+        if (!string.IsNullOrEmpty(uri.UserInfo)) return false;
         return _hostAllowlist.Contains(uri.Host);
     }
 
@@ -294,6 +261,61 @@ public sealed class MediaResolver
     public Uri? AsUri(string url) =>
         Uri.TryCreate(url, UriKind.Absolute, out var u) ? u : null;
 
+    public Task<Uri?> ResolveMediaUriAsync(string url) => ResolveMediaUriAsync(url, CancellationToken.None);
+
+    public async Task<Uri?> ResolveMediaUriAsync(string url, CancellationToken cancellationToken)
+    {
+        if (!IsAllowed(url))
+        {
+            _logger.Warn($"[A2UI] Media blocked: {Truncate(url)}");
+            return null;
+        }
+
+        var uri = AsUri(url);
+        if (uri == null) return null;
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            return uri;
+
+        try
+        {
+            if (IPAddress.TryParse(uri.Host, out var literal))
+            {
+                if (!HttpUrlRiskEvaluator.IsPublicAddress(literal))
+                {
+                    _logger.Warn($"[A2UI] Media blocked: host '{uri.Host}' is not public");
+                    return null;
+                }
+                return uri;
+            }
+
+            var addresses = await Dns.GetHostAddressesAsync(uri.Host, cancellationToken).ConfigureAwait(false);
+            if (addresses.Length == 0)
+            {
+                _logger.Warn($"[A2UI] Media blocked: DNS returned no addresses for '{uri.Host}'");
+                return null;
+            }
+
+            foreach (var ip in addresses)
+            {
+                if (!HttpUrlRiskEvaluator.IsPublicAddress(ip))
+                {
+                    _logger.Warn($"[A2UI] Media blocked: '{uri.Host}' resolved to non-public address {ip}");
+                    return null;
+                }
+            }
+            return uri;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"[A2UI] Media URL validation failed for {Truncate(url)}: {ex.Message}");
+            return null;
+        }
+    }
+
     private static async Task<BitmapImage> BitmapFromBytes(byte[] bytes)
     {
         var bmp = new BitmapImage();
@@ -318,36 +340,49 @@ public sealed class MediaResolver
     /// </summary>
     private async Task<ImageSource?> SvgFromBytesAsync(byte[] bytes, CancellationToken cancellationToken)
     {
-        bytes = StripDoctype(bytes);
-        var svg = new SvgImageSource();
-        using var ms = new InMemoryRandomAccessStream();
-        using (var w = new DataWriter(ms))
+        if (!await s_svgDecodeSemaphore.WaitAsync(SvgRenderTimeout, cancellationToken).ConfigureAwait(false))
         {
-            w.WriteBytes(bytes);
-            await w.StoreAsync();
-            await w.FlushAsync();
-            w.DetachStream();
+            _logger.Warn("[A2UI] SVG decode queue saturated");
+            return null;
         }
-        ms.Seek(0);
 
-        using var renderTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        renderTimeout.CancelAfter(SvgRenderTimeout);
-        SvgImageSourceLoadStatus status;
         try
         {
-            status = await svg.SetSourceAsync(ms).AsTask().WaitAsync(renderTimeout.Token).ConfigureAwait(false);
+            bytes = StripDoctype(bytes);
+            var svg = new SvgImageSource();
+            using var ms = new InMemoryRandomAccessStream();
+            using (var w = new DataWriter(ms))
+            {
+                w.WriteBytes(bytes);
+                await w.StoreAsync();
+                await w.FlushAsync();
+                w.DetachStream();
+            }
+            ms.Seek(0);
+
+            using var renderTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            renderTimeout.CancelAfter(SvgRenderTimeout);
+            SvgImageSourceLoadStatus status;
+            try
+            {
+                status = await svg.SetSourceAsync(ms).AsTask().WaitAsync(renderTimeout.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                _logger.Warn("[A2UI] SVG decode timed out");
+                return null;
+            }
+            if (status != SvgImageSourceLoadStatus.Success)
+            {
+                _logger.Warn($"[A2UI] SVG decode failed: {status}");
+                return null;
+            }
+            return svg;
         }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        finally
         {
-            _logger.Warn("[A2UI] SVG decode timed out");
-            return null;
+            s_svgDecodeSemaphore.Release();
         }
-        if (status != SvgImageSourceLoadStatus.Success)
-        {
-            _logger.Warn($"[A2UI] SVG decode failed: {status}");
-            return null;
-        }
-        return svg;
     }
 
     /// <summary>Cheap content sniff for SVG bytes after BOM and leading whitespace.</summary>

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/ContainerRenderers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/ContainerRenderers.cs
@@ -65,28 +65,96 @@ public sealed class ListRenderer : IComponentRenderer
             ? Orientation.Horizontal
             : Orientation.Vertical;
 
-        var stack = new StackPanel
+        // Virtualize via ItemsRepeater + ItemsRepeaterScrollHost. Building 10k
+        // FrameworkElements upfront — the previous StackPanel behavior — was
+        // fine for tiny lists but pinned the UI thread on large ones. The
+        // repeater realizes only the items in the viewport. (Spec §5 calls
+        // this out as the expected mapping for v1.)
+        var children = ctx.GetExplicitChildren(c);
+        var alignmentValue = c.Properties["alignment"]?.GetValue<string>();
+        var spacing = ctx.Theme.Spacing is { } sp ? sp : 6.0;
+
+        var layout = new StackLayout
         {
             Orientation = orientation,
-            Spacing = ctx.Theme.Spacing is { } s ? s : 6,
+            Spacing = spacing,
         };
-        ContainerHelpers.ApplyAlignment(stack, c.Properties["alignment"]?.GetValue<string>(), horizontal: orientation == Orientation.Horizontal);
 
-        foreach (var childId in ctx.GetExplicitChildren(c))
+        var repeater = new ItemsRepeater
         {
-            var built = ctx.BuildChild(childId);
-            if (built != null) stack.Children.Add(built);
-        }
+            Layout = layout,
+            ItemsSource = children,
+            ItemTemplate = new ChildIdTemplate(ctx),
+        };
 
-        // Wrap in a ScrollViewer so long lists don't blow out the surface.
-        return new ScrollViewer
+        var scrollViewer = new ScrollViewer
         {
             HorizontalScrollMode = orientation == Orientation.Horizontal ? ScrollMode.Auto : ScrollMode.Disabled,
             HorizontalScrollBarVisibility = orientation == Orientation.Horizontal ? ScrollBarVisibility.Auto : ScrollBarVisibility.Disabled,
             VerticalScrollMode = orientation == Orientation.Vertical ? ScrollMode.Auto : ScrollMode.Disabled,
             VerticalScrollBarVisibility = orientation == Orientation.Vertical ? ScrollBarVisibility.Auto : ScrollBarVisibility.Disabled,
-            Content = stack,
+            Content = repeater,
         };
+        // Cross-axis alignment lives on the scrollviewer; the repeater's layout
+        // governs main-axis flow.
+        if (alignmentValue != null)
+        {
+            if (orientation == Orientation.Horizontal)
+            {
+                scrollViewer.VerticalAlignment = alignmentValue switch
+                {
+                    "start" => VerticalAlignment.Top,
+                    "center" => VerticalAlignment.Center,
+                    "end" => VerticalAlignment.Bottom,
+                    "stretch" => VerticalAlignment.Stretch,
+                    _ => scrollViewer.VerticalAlignment,
+                };
+            }
+            else
+            {
+                scrollViewer.HorizontalAlignment = alignmentValue switch
+                {
+                    "start" => HorizontalAlignment.Left,
+                    "center" => HorizontalAlignment.Center,
+                    "end" => HorizontalAlignment.Right,
+                    "stretch" => HorizontalAlignment.Stretch,
+                    _ => scrollViewer.HorizontalAlignment,
+                };
+            }
+        }
+        return scrollViewer;
+    }
+
+    /// <summary>
+    /// Resolves each <c>children[i]</c> string-id back to its A2UI component on
+    /// realization. Caches by id so scrolling back to a previously-realized item
+    /// reuses the same instance and its bindings stay subscribed.
+    /// </summary>
+    private sealed class ChildIdTemplate : Microsoft.UI.Xaml.IElementFactory
+    {
+        private readonly RenderContext _ctx;
+        private readonly System.Collections.Generic.Dictionary<string, UIElement> _cache = new(StringComparer.Ordinal);
+        public ChildIdTemplate(RenderContext ctx) { _ctx = ctx; }
+
+        public UIElement GetElement(Microsoft.UI.Xaml.ElementFactoryGetArgs args)
+        {
+            if (args.Data is string id)
+            {
+                if (_cache.TryGetValue(id, out var existing))
+                    return existing;
+                var built = _ctx.BuildChild(id) ?? (UIElement)new ContentPresenter();
+                _cache[id] = built;
+                return built;
+            }
+            return new ContentPresenter();
+        }
+
+        public void RecycleElement(Microsoft.UI.Xaml.ElementFactoryRecycleArgs args)
+        {
+            // Keep the realized element in the cache so re-realization reuses it
+            // and its DataModel subscriptions stay live. Removing here would
+            // double-build on every scroll.
+        }
     }
 }
 
@@ -96,14 +164,19 @@ public sealed class CardRenderer : IComponentRenderer
 
     public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
     {
+        // Honor theme.Spacing as the card's padding so a tighter / looser
+        // surface theme propagates down. Fallback 16 matches Fluent default.
+        var pad = ctx.Theme.Spacing is { } sp ? sp * 2 : 16;
         var border = new Border
         {
             CornerRadius = new CornerRadius(ctx.Theme.CornerRadius is { } r ? r : 8),
-            Padding = new Thickness(16),
+            Padding = new Thickness(pad),
             BorderThickness = new Thickness(1),
         };
-        try { border.Background = (Brush)Application.Current.Resources["CardBackgroundFillColorDefaultBrush"]; } catch { }
-        try { border.BorderBrush = (Brush)Application.Current.Resources["CardStrokeColorDefaultBrush"]; } catch { }
+        if (Application.Current.Resources.TryGetValue("CardBackgroundFillColorDefaultBrush", out var bg) && bg is Brush bgBrush)
+            border.Background = bgBrush;
+        if (Application.Current.Resources.TryGetValue("CardStrokeColorDefaultBrush", out var bs) && bs is Brush bsBrush)
+            border.BorderBrush = bsBrush;
 
         var childId = ctx.GetSingleChild(c, "child");
         if (childId != null) border.Child = ctx.BuildChild(childId);
@@ -128,9 +201,10 @@ public sealed class TabsRenderer : IComponentRenderer
 
         if (c.Properties["tabItems"] is JsonArray arr)
         {
+            int tabIndex = 0;
             foreach (var node in arr)
             {
-                if (node is not JsonObject tabObj) continue;
+                if (node is not JsonObject tabObj) { tabIndex++; continue; }
                 var titleVal = A2UIValue.From(tabObj["title"]);
                 var titleText = ctx.ResolveString(titleVal) ?? "Tab";
                 var childId = tabObj["child"]?.GetValue<string>();
@@ -142,15 +216,18 @@ public sealed class TabsRenderer : IComponentRenderer
                     Content = childId != null ? ctx.BuildChild(childId) : null,
                 };
 
-                // Live-bind the title if it's path-bound.
+                // Live-bind the title if it's path-bound. Key by tab index — never
+                // Guid.NewGuid(), which leaked a subscription on every render and
+                // collided when two tabs had null childId.
                 if (titleVal?.HasPath == true)
                 {
-                    var subKey = $"tab::{childId ?? Guid.NewGuid().ToString()}::title";
+                    var subKey = $"tab::{tabIndex}::title";
                     void Update() => tab.Header = ctx.ResolveString(titleVal) ?? "Tab";
                     ctx.WatchValue(c.Id, subKey, titleVal, Update);
                 }
 
                 tabs.TabItems.Add(tab);
+                tabIndex++;
             }
         }
         return tabs;
@@ -201,9 +278,12 @@ public sealed class DividerRenderer : IComponentRenderer
             rect.HorizontalAlignment = HorizontalAlignment.Stretch;
             rect.VerticalAlignment = VerticalAlignment.Center;
         }
-        rect.Margin = new Thickness(0, 4, 0, 4);
-        try { rect.Fill = (Brush)Application.Current.Resources["DividerStrokeColorDefaultBrush"]; }
-        catch { rect.Fill = new SolidColorBrush(Microsoft.UI.Colors.Gray); }
+        var marginV = ctx.Theme.Spacing is { } sp ? sp / 2 : 4;
+        rect.Margin = new Thickness(0, marginV, 0, marginV);
+        if (Application.Current.Resources.TryGetValue("DividerStrokeColorDefaultBrush", out var divBrush) && divBrush is Brush b)
+            rect.Fill = b;
+        else
+            rect.Fill = new SolidColorBrush(Microsoft.UI.Colors.Gray);
         return rect;
     }
 }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/ContainerRenderers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/ContainerRenderers.cs
@@ -1,0 +1,268 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using System.Text.Json.Nodes;
+using OpenClawTray.A2UI.Protocol;
+
+namespace OpenClawTray.A2UI.Rendering.Renderers;
+
+public sealed class RowRenderer : IComponentRenderer
+{
+    public string ComponentName => "Row";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        var sp = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = ctx.Theme.Spacing is { } s ? s : 8,
+        };
+        ContainerHelpers.ApplyDistribution(sp, c.Properties["distribution"]?.GetValue<string>(), horizontal: true);
+        ContainerHelpers.ApplyAlignment(sp, c.Properties["alignment"]?.GetValue<string>(), horizontal: true);
+
+        foreach (var childId in ctx.GetExplicitChildren(c))
+        {
+            var built = ctx.BuildChild(childId);
+            if (built != null) sp.Children.Add(built);
+        }
+        return sp;
+    }
+}
+
+public sealed class ColumnRenderer : IComponentRenderer
+{
+    public string ComponentName => "Column";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        var sp = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = ctx.Theme.Spacing is { } s ? s : 8,
+            MinWidth = 0,
+        };
+        ContainerHelpers.ApplyDistribution(sp, c.Properties["distribution"]?.GetValue<string>(), horizontal: false);
+        ContainerHelpers.ApplyAlignment(sp, c.Properties["alignment"]?.GetValue<string>(), horizontal: false);
+
+        foreach (var childId in ctx.GetExplicitChildren(c))
+        {
+            var built = ctx.BuildChild(childId);
+            if (built != null) sp.Children.Add(built);
+        }
+        return sp;
+    }
+}
+
+public sealed class ListRenderer : IComponentRenderer
+{
+    public string ComponentName => "List";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        var direction = c.Properties["direction"]?.GetValue<string>() ?? "vertical";
+        var orientation = direction.Equals("horizontal", StringComparison.OrdinalIgnoreCase)
+            ? Orientation.Horizontal
+            : Orientation.Vertical;
+
+        var stack = new StackPanel
+        {
+            Orientation = orientation,
+            Spacing = ctx.Theme.Spacing is { } s ? s : 6,
+        };
+        ContainerHelpers.ApplyAlignment(stack, c.Properties["alignment"]?.GetValue<string>(), horizontal: orientation == Orientation.Horizontal);
+
+        foreach (var childId in ctx.GetExplicitChildren(c))
+        {
+            var built = ctx.BuildChild(childId);
+            if (built != null) stack.Children.Add(built);
+        }
+
+        // Wrap in a ScrollViewer so long lists don't blow out the surface.
+        return new ScrollViewer
+        {
+            HorizontalScrollMode = orientation == Orientation.Horizontal ? ScrollMode.Auto : ScrollMode.Disabled,
+            HorizontalScrollBarVisibility = orientation == Orientation.Horizontal ? ScrollBarVisibility.Auto : ScrollBarVisibility.Disabled,
+            VerticalScrollMode = orientation == Orientation.Vertical ? ScrollMode.Auto : ScrollMode.Disabled,
+            VerticalScrollBarVisibility = orientation == Orientation.Vertical ? ScrollBarVisibility.Auto : ScrollBarVisibility.Disabled,
+            Content = stack,
+        };
+    }
+}
+
+public sealed class CardRenderer : IComponentRenderer
+{
+    public string ComponentName => "Card";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        var border = new Border
+        {
+            CornerRadius = new CornerRadius(ctx.Theme.CornerRadius is { } r ? r : 8),
+            Padding = new Thickness(16),
+            BorderThickness = new Thickness(1),
+        };
+        try { border.Background = (Brush)Application.Current.Resources["CardBackgroundFillColorDefaultBrush"]; } catch { }
+        try { border.BorderBrush = (Brush)Application.Current.Resources["CardStrokeColorDefaultBrush"]; } catch { }
+
+        var childId = ctx.GetSingleChild(c, "child");
+        if (childId != null) border.Child = ctx.BuildChild(childId);
+        return border;
+    }
+}
+
+public sealed class TabsRenderer : IComponentRenderer
+{
+    public string ComponentName => "Tabs";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        var tabs = new TabView
+        {
+            IsAddTabButtonVisible = false,
+            CanReorderTabs = false,
+            CanDragTabs = false,
+            TabWidthMode = TabViewWidthMode.SizeToContent,
+            CloseButtonOverlayMode = TabViewCloseButtonOverlayMode.Auto,
+        };
+
+        if (c.Properties["tabItems"] is JsonArray arr)
+        {
+            foreach (var node in arr)
+            {
+                if (node is not JsonObject tabObj) continue;
+                var titleVal = A2UIValue.From(tabObj["title"]);
+                var titleText = ctx.ResolveString(titleVal) ?? "Tab";
+                var childId = tabObj["child"]?.GetValue<string>();
+
+                var tab = new TabViewItem
+                {
+                    Header = titleText,
+                    IsClosable = false,
+                    Content = childId != null ? ctx.BuildChild(childId) : null,
+                };
+
+                // Live-bind the title if it's path-bound.
+                if (titleVal?.HasPath == true)
+                {
+                    var subKey = $"tab::{childId ?? Guid.NewGuid().ToString()}::title";
+                    void Update() => tab.Header = ctx.ResolveString(titleVal) ?? "Tab";
+                    ctx.WatchValue(c.Id, subKey, titleVal, Update);
+                }
+
+                tabs.TabItems.Add(tab);
+            }
+        }
+        return tabs;
+    }
+}
+
+public sealed class ModalRenderer : IComponentRenderer
+{
+    public string ComponentName => "Modal";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        // v1: render as inline Expander showing the entry-point child as the
+        // header and the content child as the body. A real Window-level dialog
+        // is preferred long-term but requires XAML-root threading we don't yet
+        // have plumbed for arbitrary surface trees.
+        var entryId = ctx.GetSingleChild(c, "entryPointChild");
+        var contentId = ctx.GetSingleChild(c, "contentChild");
+
+        var expander = new Expander
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+        };
+        if (entryId != null) expander.Header = ctx.BuildChild(entryId);
+        if (contentId != null) expander.Content = ctx.BuildChild(contentId);
+        return expander;
+    }
+}
+
+public sealed class DividerRenderer : IComponentRenderer
+{
+    public string ComponentName => "Divider";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        var axis = c.Properties["axis"]?.GetValue<string>() ?? "horizontal";
+        var rect = new Microsoft.UI.Xaml.Shapes.Rectangle();
+        if (axis.Equals("vertical", StringComparison.OrdinalIgnoreCase))
+        {
+            rect.Width = 1;
+            rect.HorizontalAlignment = HorizontalAlignment.Center;
+            rect.VerticalAlignment = VerticalAlignment.Stretch;
+        }
+        else
+        {
+            rect.Height = 1;
+            rect.HorizontalAlignment = HorizontalAlignment.Stretch;
+            rect.VerticalAlignment = VerticalAlignment.Center;
+        }
+        rect.Margin = new Thickness(0, 4, 0, 4);
+        try { rect.Fill = (Brush)Application.Current.Resources["DividerStrokeColorDefaultBrush"]; }
+        catch { rect.Fill = new SolidColorBrush(Microsoft.UI.Colors.Gray); }
+        return rect;
+    }
+}
+
+internal static class ContainerHelpers
+{
+    public static void ApplyDistribution(StackPanel sp, string? value, bool horizontal)
+    {
+        if (value == null) return;
+        // StackPanel doesn't have a true justify-content; map to alignment of the panel itself.
+        if (horizontal)
+        {
+            sp.HorizontalAlignment = value switch
+            {
+                "start" => HorizontalAlignment.Left,
+                "center" => HorizontalAlignment.Center,
+                "end" => HorizontalAlignment.Right,
+                "spaceBetween" or "spaceAround" or "spaceEvenly" => HorizontalAlignment.Stretch,
+                _ => sp.HorizontalAlignment,
+            };
+        }
+        else
+        {
+            sp.VerticalAlignment = value switch
+            {
+                "start" => VerticalAlignment.Top,
+                "center" => VerticalAlignment.Center,
+                "end" => VerticalAlignment.Bottom,
+                "spaceBetween" or "spaceAround" or "spaceEvenly" => VerticalAlignment.Stretch,
+                _ => sp.VerticalAlignment,
+            };
+        }
+    }
+
+    public static void ApplyAlignment(StackPanel sp, string? value, bool horizontal)
+    {
+        if (value == null) return;
+        // Cross-axis alignment.
+        if (horizontal)
+        {
+            sp.VerticalAlignment = value switch
+            {
+                "start" => VerticalAlignment.Top,
+                "center" => VerticalAlignment.Center,
+                "end" => VerticalAlignment.Bottom,
+                "stretch" => VerticalAlignment.Stretch,
+                _ => sp.VerticalAlignment,
+            };
+        }
+        else
+        {
+            sp.HorizontalAlignment = value switch
+            {
+                "start" => HorizontalAlignment.Left,
+                "center" => HorizontalAlignment.Center,
+                "end" => HorizontalAlignment.Right,
+                "stretch" => HorizontalAlignment.Stretch,
+                _ => sp.HorizontalAlignment,
+            };
+        }
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/ContainerRenderers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/ContainerRenderers.cs
@@ -240,21 +240,46 @@ public sealed class ModalRenderer : IComponentRenderer
 
     public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
     {
-        // v1: render as inline Expander showing the entry-point child as the
-        // header and the content child as the body. A real Window-level dialog
-        // is preferred long-term but requires XAML-root threading we don't yet
-        // have plumbed for arbitrary surface trees.
+        // Render as a real ContentDialog launched from the entry-point child.
+        // The entry-point is shown inline; clicking it shows the dialog with
+        // the content-child as its body. Falls back to Expander when no
+        // XamlRoot can be resolved (e.g. surface not yet attached to a window).
         var entryId = ctx.GetSingleChild(c, "entryPointChild");
         var contentId = ctx.GetSingleChild(c, "contentChild");
 
-        var expander = new Expander
+        var entryElement = entryId != null ? ctx.BuildChild(entryId) : null;
+        var contentElement = contentId != null ? ctx.BuildChild(contentId) : null;
+
+        // Wrap the entry in a Button so we have a uniform click target.
+        // (A2UI entry-point may itself be a Button, but it may also be a Card/Text.)
+        var trigger = new Button
         {
+            Content = entryElement,
             HorizontalAlignment = HorizontalAlignment.Stretch,
             HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent),
+            BorderThickness = new Thickness(0),
+            Padding = new Thickness(0),
         };
-        if (entryId != null) expander.Header = ctx.BuildChild(entryId);
-        if (contentId != null) expander.Content = ctx.BuildChild(contentId);
-        return expander;
+
+        var titleVal = ctx.GetValue(c, "title");
+        var titleText = ctx.ResolveString(titleVal);
+
+        trigger.Click += async (_, _) =>
+        {
+            if (trigger.XamlRoot is null) return; // not yet in tree
+            var dialog = new ContentDialog
+            {
+                XamlRoot = trigger.XamlRoot,
+                Title = titleText ?? string.Empty,
+                Content = contentElement,
+                CloseButtonText = "Close",
+            };
+            try { await dialog.ShowAsync(); }
+            catch { /* ContentDialog throws if another dialog is open; swallow */ }
+        };
+        AutomationHelpers.Apply(trigger, c, ctx);
+        return trigger;
     }
 }
 

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/ContainerRenderers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/ContainerRenderers.cs
@@ -206,7 +206,7 @@ public sealed class TabsRenderer : IComponentRenderer
             {
                 if (node is not JsonObject tabObj) { tabIndex++; continue; }
                 var titleVal = A2UIValue.From(tabObj["title"]);
-                var titleText = ctx.ResolveString(titleVal) ?? "Tab";
+                var titleText = ctx.ResolveString(titleVal) ?? OpenClawTray.Helpers.LocalizationHelper.GetString("A2UI_TabFallback");
                 var childId = tabObj["child"]?.GetValue<string>();
 
                 var tab = new TabViewItem
@@ -222,7 +222,7 @@ public sealed class TabsRenderer : IComponentRenderer
                 if (titleVal?.HasPath == true)
                 {
                     var subKey = $"tab::{tabIndex}::title";
-                    void Update() => tab.Header = ctx.ResolveString(titleVal) ?? "Tab";
+                    void Update() => tab.Header = ctx.ResolveString(titleVal) ?? OpenClawTray.Helpers.LocalizationHelper.GetString("A2UI_TabFallback");
                     ctx.WatchValue(c.Id, subKey, titleVal, Update);
                 }
 
@@ -273,7 +273,7 @@ public sealed class ModalRenderer : IComponentRenderer
                 XamlRoot = trigger.XamlRoot,
                 Title = titleText ?? string.Empty,
                 Content = contentElement,
-                CloseButtonText = "Close",
+                CloseButtonText = OpenClawTray.Helpers.LocalizationHelper.GetString("A2UI_ModalClose"),
             };
             try { await dialog.ShowAsync(); }
             catch { /* ContentDialog throws if another dialog is open; swallow */ }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/DisplayRenderers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/DisplayRenderers.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using OpenClawTray.A2UI.Protocol;
+
+namespace OpenClawTray.A2UI.Rendering.Renderers;
+
+public sealed class TextRenderer : IComponentRenderer
+{
+    public string ComponentName => "Text";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        var tb = new TextBlock { TextWrapping = TextWrapping.Wrap };
+        ApplyUsageHint(tb, c.Properties["usageHint"]?.GetValue<string>());
+
+        var textVal = ctx.GetValue(c, "text");
+        void Update() => tb.Text = ctx.ResolveString(textVal) ?? string.Empty;
+        Update();
+        ctx.WatchValue(c.Id, "text", textVal, Update);
+        return tb;
+    }
+
+    private static void ApplyUsageHint(TextBlock tb, string? hint)
+    {
+        var resourceKey = hint switch
+        {
+            "h1" => "TitleLargeTextBlockStyle",
+            "h2" => "TitleTextBlockStyle",
+            "h3" => "SubtitleTextBlockStyle",
+            "h4" => "BodyStrongTextBlockStyle",
+            "h5" => "BodyStrongTextBlockStyle",
+            "caption" => "CaptionTextBlockStyle",
+            "body" => "BodyTextBlockStyle",
+            null => "BodyTextBlockStyle",
+            _ => "BodyTextBlockStyle",
+        };
+        try { tb.Style = (Style)Application.Current.Resources[resourceKey]; } catch { }
+        // Some style keys don't exist on every WinUI version; fall back gracefully.
+        if (tb.Style == null && hint != null)
+        {
+            try { tb.Style = (Style)Application.Current.Resources["BodyTextBlockStyle"]; } catch { }
+        }
+    }
+}
+
+public sealed class ImageRenderer : IComponentRenderer
+{
+    private readonly MediaResolver _media;
+    public ImageRenderer(MediaResolver media) { _media = media; }
+    public string ComponentName => "Image";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        var image = new Image();
+        ApplyFit(image, c.Properties["fit"]?.GetValue<string>());
+        ApplyUsageHint(image, c.Properties["usageHint"]?.GetValue<string>());
+
+        var urlVal = ctx.GetValue(c, "url");
+        void Update()
+        {
+            var url = ctx.ResolveString(urlVal);
+            if (!string.IsNullOrEmpty(url)) _ = LoadAsync(image, url);
+        }
+        Update();
+        ctx.WatchValue(c.Id, "url", urlVal, Update);
+        return image;
+    }
+
+    private async Task LoadAsync(Image target, string url)
+    {
+        var bmp = await _media.LoadImageAsync(url);
+        if (bmp != null) target.Source = bmp;
+    }
+
+    private static void ApplyFit(Image image, string? fit)
+    {
+        image.Stretch = fit switch
+        {
+            "contain" => Stretch.Uniform,
+            "cover" => Stretch.UniformToFill,
+            "fill" => Stretch.Fill,
+            "none" => Stretch.None,
+            "scale-down" => Stretch.Uniform,
+            _ => Stretch.Uniform,
+        };
+    }
+
+    private static void ApplyUsageHint(Image image, string? hint)
+    {
+        switch (hint)
+        {
+            case "icon":
+                image.Width = image.Height = 24;
+                break;
+            case "avatar":
+                image.Width = image.Height = 40;
+                // Approximate circle with corner radius via clipping is non-trivial here;
+                // leave as a square avatar for v1.
+                break;
+            case "smallFeature":
+                image.Height = 80;
+                break;
+            case "mediumFeature":
+                image.Height = 160;
+                break;
+            case "largeFeature":
+                image.Height = 240;
+                break;
+            case "header":
+                image.Stretch = Stretch.UniformToFill;
+                image.HorizontalAlignment = HorizontalAlignment.Stretch;
+                break;
+        }
+    }
+}
+
+public sealed class IconRenderer : IComponentRenderer
+{
+    public string ComponentName => "Icon";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        var fontIcon = new FontIcon
+        {
+            FontFamily = new FontFamily("Segoe Fluent Icons"),
+            FontSize = 16,
+        };
+        var nameVal = ctx.GetValue(c, "name");
+        void Update() => fontIcon.Glyph = MapName(ctx.ResolveString(nameVal));
+        Update();
+        ctx.WatchValue(c.Id, "name", nameVal, Update);
+        return fontIcon;
+    }
+
+    /// <summary>Map A2UI v0.8 icon-name enum to Segoe Fluent glyphs.</summary>
+    private static string MapName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return ""; // outlined help (?)
+        return name switch
+        {
+            "accountCircle" => "",
+            "add" => "",
+            "arrowBack" => "",
+            "arrowForward" => "",
+            "attachFile" => "",
+            "calendarToday" => "",
+            "call" => "",
+            "camera" => "",
+            "check" => "",
+            "close" => "",
+            "delete" => "",
+            "download" => "",
+            "edit" => "",
+            "event" => "",
+            "error" => "",
+            "favorite" => "",
+            "favoriteOff" => "",
+            "folder" => "",
+            "help" => "",
+            "home" => "",
+            "info" => "",
+            "locationOn" => "",
+            "lock" => "",
+            "lockOpen" => "",
+            "mail" => "",
+            "menu" => "",
+            "moreVert" => "",
+            "moreHoriz" => "",
+            "notificationsOff" => "",
+            "notifications" => "",
+            "payment" => "",
+            "person" => "",
+            "phone" => "",
+            "photo" => "",
+            "print" => "",
+            "refresh" => "",
+            "search" => "",
+            "send" => "",
+            "settings" => "",
+            "share" => "",
+            "shoppingCart" => "",
+            "star" => "",
+            "starHalf" => "",
+            "starOff" => "",
+            "upload" => "",
+            "visibility" => "",
+            "visibilityOff" => "",
+            "warning" => "",
+            _ => "",
+        };
+    }
+}
+
+public sealed class VideoRenderer : IComponentRenderer
+{
+    private readonly MediaResolver _media;
+    public VideoRenderer(MediaResolver media) { _media = media; }
+    public string ComponentName => "Video";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        var player = new MediaPlayerElement
+        {
+            AreTransportControlsEnabled = true,
+            MinHeight = 180,
+        };
+        var urlVal = ctx.GetValue(c, "url");
+        void Update()
+        {
+            var url = ctx.ResolveString(urlVal);
+            if (string.IsNullOrEmpty(url)) return;
+            if (!_media.IsAllowed(url)) return;
+            var uri = _media.AsUri(url);
+            if (uri != null) player.Source = global::Windows.Media.Core.MediaSource.CreateFromUri(uri);
+        }
+        Update();
+        ctx.WatchValue(c.Id, "url", urlVal, Update);
+        return player;
+    }
+}
+
+public sealed class AudioPlayerRenderer : IComponentRenderer
+{
+    private readonly MediaResolver _media;
+    public AudioPlayerRenderer(MediaResolver media) { _media = media; }
+    public string ComponentName => "AudioPlayer";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        var stack = new StackPanel { Spacing = 4 };
+        var description = new TextBlock();
+        var descVal = ctx.GetValue(c, "description");
+        void DescUpdate() => description.Text = ctx.ResolveString(descVal) ?? string.Empty;
+        DescUpdate();
+        ctx.WatchValue(c.Id, "description", descVal, DescUpdate);
+        try { description.Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"]; } catch { }
+
+        var player = new MediaPlayerElement
+        {
+            AreTransportControlsEnabled = true,
+            MinHeight = 50,
+        };
+        var urlVal = ctx.GetValue(c, "url");
+        void UrlUpdate()
+        {
+            var url = ctx.ResolveString(urlVal);
+            if (string.IsNullOrEmpty(url)) return;
+            if (!_media.IsAllowed(url)) return;
+            var uri = _media.AsUri(url);
+            if (uri != null) player.Source = global::Windows.Media.Core.MediaSource.CreateFromUri(uri);
+        }
+        UrlUpdate();
+        ctx.WatchValue(c.Id, "url", urlVal, UrlUpdate);
+
+        if (!string.IsNullOrEmpty(description.Text)) stack.Children.Add(description);
+        stack.Children.Add(player);
+        return stack;
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/DisplayRenderers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/DisplayRenderers.cs
@@ -157,6 +157,9 @@ public sealed class ImageRenderer : IComponentRenderer
 public sealed class IconRenderer : IComponentRenderer
 {
     public string ComponentName => "Icon";
+    // Emit at most one info log per name-with-known-fidelity-issue, per process.
+    // Cheap signal that lets us judge whether to invest in a better glyph.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, byte> s_loggedFidelity = new();
 
     public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
     {
@@ -166,7 +169,16 @@ public sealed class IconRenderer : IComponentRenderer
             FontSize = 16,
         };
         var nameVal = ctx.GetValue(c, "name");
-        void Update() => fontIcon.Glyph = MapName(ctx.ResolveString(nameVal));
+        void Update()
+        {
+            var name = ctx.ResolveString(nameVal);
+            fontIcon.Glyph = MapName(name);
+            // moreHoriz currently reuses moreVert's glyph (no canonical horizontal
+            // ellipsis in MDL2). Log once so we can tell whether real surfaces
+            // ask for it before swapping in a custom font.
+            if (name == "moreHoriz" && s_loggedFidelity.TryAdd("moreHoriz", 1))
+                ctx.Logger?.Info("[A2UI] icon 'moreHoriz' is rendered with the moreVert glyph (no canonical horizontal in Segoe Fluent Icons).");
+        }
         Update();
         ctx.WatchValue(c.Id, "name", nameVal, Update);
         // The icon name is the natural automation label when no explicit one is set.

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/DisplayRenderers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/DisplayRenderers.cs
@@ -104,11 +104,12 @@ public sealed class ImageRenderer : IComponentRenderer
 
     private async Task LoadAsync(Image target, string url, int[] generation, int token)
     {
-        var bmp = await _media.LoadImageAsync(url).ConfigureAwait(true);
+        // ImageSource is the common base of BitmapImage (raster) and SvgImageSource — Image.Source accepts either.
+        var src = await _media.LoadImageAsync(url).ConfigureAwait(true);
         // Only commit if our token is still current. Volatile read is sufficient
         // — UI thread is the only writer and we're awaited back onto it.
-        if (bmp != null && System.Threading.Volatile.Read(ref generation[0]) == token)
-            target.Source = bmp;
+        if (src != null && System.Threading.Volatile.Read(ref generation[0]) == token)
+            target.Source = src;
     }
 
     private static void ApplyFit(Image image, string? fit)

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/DisplayRenderers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/DisplayRenderers.cs
@@ -37,11 +37,13 @@ public sealed class TextRenderer : IComponentRenderer
             null => "BodyTextBlockStyle",
             _ => "BodyTextBlockStyle",
         };
-        try { tb.Style = (Style)Application.Current.Resources[resourceKey]; } catch { }
+        if (Application.Current.Resources.TryGetValue(resourceKey, out var styleObj) && styleObj is Style s)
+            tb.Style = s;
         // Some style keys don't exist on every WinUI version; fall back gracefully.
-        if (tb.Style == null && hint != null)
+        if (tb.Style == null && hint != null
+            && Application.Current.Resources.TryGetValue("BodyTextBlockStyle", out var fallback) && fallback is Style fb)
         {
-            try { tb.Style = (Style)Application.Current.Resources["BodyTextBlockStyle"]; } catch { }
+            tb.Style = fb;
         }
     }
 }
@@ -55,24 +57,58 @@ public sealed class ImageRenderer : IComponentRenderer
     public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
     {
         var image = new Image();
+        var usageHint = c.Properties["usageHint"]?.GetValue<string>();
         ApplyFit(image, c.Properties["fit"]?.GetValue<string>());
-        ApplyUsageHint(image, c.Properties["usageHint"]?.GetValue<string>());
+        ApplyUsageHint(image, usageHint);
 
+        // Single counter per image; each load takes a snapshot and only assigns
+        // the bitmap if no later load has started. Stops a slow first response
+        // from clobbering a faster second one when the URL flips quickly.
+        var generation = new int[] { 0 };
         var urlVal = ctx.GetValue(c, "url");
         void Update()
         {
             var url = ctx.ResolveString(urlVal);
-            if (!string.IsNullOrEmpty(url)) _ = LoadAsync(image, url);
+            if (string.IsNullOrEmpty(url))
+            {
+                System.Threading.Interlocked.Increment(ref generation[0]);
+                image.Source = null;
+                return;
+            }
+            int token = System.Threading.Interlocked.Increment(ref generation[0]);
+            _ = LoadAsync(image, url, generation, token);
         }
         Update();
         ctx.WatchValue(c.Id, "url", urlVal, Update);
+        // A2UI carries alt text in `description` (preferred) or `label` for images.
+        AutomationHelpers.Apply(image, c, ctx);
+
+        // Avatar usageHint: clip to a circle. Wrapping in a Border with rounded
+        // CornerRadius is the simplest WinUI3-friendly approach (PersonPicture
+        // gives us full Fluent parity but doesn't accept arbitrary BitmapImage
+        // sources without templating).
+        if (string.Equals(usageHint, "avatar", StringComparison.OrdinalIgnoreCase))
+        {
+            var diameter = image.Width > 0 ? image.Width : 40;
+            return new Border
+            {
+                Width = diameter,
+                Height = diameter,
+                CornerRadius = new CornerRadius(diameter / 2),
+                Child = image,
+                HorizontalAlignment = HorizontalAlignment.Left,
+            };
+        }
         return image;
     }
 
-    private async Task LoadAsync(Image target, string url)
+    private async Task LoadAsync(Image target, string url, int[] generation, int token)
     {
-        var bmp = await _media.LoadImageAsync(url);
-        if (bmp != null) target.Source = bmp;
+        var bmp = await _media.LoadImageAsync(url).ConfigureAwait(true);
+        // Only commit if our token is still current. Volatile read is sufficient
+        // — UI thread is the only writer and we're awaited back onto it.
+        if (bmp != null && System.Threading.Volatile.Read(ref generation[0]) == token)
+            target.Source = bmp;
     }
 
     private static void ApplyFit(Image image, string? fit)
@@ -132,6 +168,10 @@ public sealed class IconRenderer : IComponentRenderer
         void Update() => fontIcon.Glyph = MapName(ctx.ResolveString(nameVal));
         Update();
         ctx.WatchValue(c.Id, "name", nameVal, Update);
+        // The icon name is the natural automation label when no explicit one is set.
+        AutomationHelpers.Apply(fontIcon, c, ctx);
+        if (string.IsNullOrEmpty(Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(fontIcon)))
+            AutomationHelpers.SetName(fontIcon, ctx.ResolveString(nameVal));
         return fontIcon;
     }
 
@@ -223,6 +263,7 @@ public sealed class VideoRenderer : IComponentRenderer
         }
         Update();
         ctx.WatchValue(c.Id, "url", urlVal, Update);
+        AutomationHelpers.Apply(player, c, ctx);
         return player;
     }
 }
@@ -241,7 +282,8 @@ public sealed class AudioPlayerRenderer : IComponentRenderer
         void DescUpdate() => description.Text = ctx.ResolveString(descVal) ?? string.Empty;
         DescUpdate();
         ctx.WatchValue(c.Id, "description", descVal, DescUpdate);
-        try { description.Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"]; } catch { }
+        if (Application.Current.Resources.TryGetValue("CaptionTextBlockStyle", out var capStyle) && capStyle is Style cs)
+            description.Style = cs;
 
         var player = new MediaPlayerElement
         {
@@ -262,6 +304,7 @@ public sealed class AudioPlayerRenderer : IComponentRenderer
 
         if (!string.IsNullOrEmpty(description.Text)) stack.Children.Add(description);
         stack.Children.Add(player);
+        AutomationHelpers.Apply(stack, c, ctx);
         return stack;
     }
 }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/DisplayRenderers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/DisplayRenderers.cs
@@ -65,6 +65,7 @@ public sealed class ImageRenderer : IComponentRenderer
         // the bitmap if no later load has started. Stops a slow first response
         // from clobbering a faster second one when the URL flips quickly.
         var generation = new int[] { 0 };
+        System.Threading.CancellationTokenSource? loadCts = null;
         var urlVal = ctx.GetValue(c, "url");
         void Update()
         {
@@ -72,11 +73,19 @@ public sealed class ImageRenderer : IComponentRenderer
             if (string.IsNullOrEmpty(url))
             {
                 System.Threading.Interlocked.Increment(ref generation[0]);
+                loadCts?.Cancel();
                 image.Source = null;
                 return;
             }
+            if (ctx.MediaBudget?.TryReserveImageLoad() == false)
+            {
+                ctx.Logger?.Warn("[A2UI] Image load rejected: surface media budget exhausted");
+                return;
+            }
             int token = System.Threading.Interlocked.Increment(ref generation[0]);
-            _ = LoadAsync(image, url, generation, token);
+            loadCts?.Cancel();
+            loadCts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(20));
+            _ = LoadAsync(image, url, generation, token, loadCts.Token, ctx.Logger);
         }
         Update();
         ctx.WatchValue(c.Id, "url", urlVal, Update);
@@ -102,14 +111,27 @@ public sealed class ImageRenderer : IComponentRenderer
         return image;
     }
 
-    private async Task LoadAsync(Image target, string url, int[] generation, int token)
+    private async Task LoadAsync(
+        Image target,
+        string url,
+        int[] generation,
+        int token,
+        System.Threading.CancellationToken cancellationToken,
+        OpenClaw.Shared.IOpenClawLogger? logger)
     {
-        // ImageSource is the common base of BitmapImage (raster) and SvgImageSource — Image.Source accepts either.
-        var src = await _media.LoadImageAsync(url).ConfigureAwait(true);
-        // Only commit if our token is still current. Volatile read is sufficient
-        // — UI thread is the only writer and we're awaited back onto it.
-        if (src != null && System.Threading.Volatile.Read(ref generation[0]) == token)
-            target.Source = src;
+        try
+        {
+            // ImageSource is the common base of BitmapImage (raster) and SvgImageSource — Image.Source accepts either.
+            var src = await _media.LoadImageAsync(url, cancellationToken).ConfigureAwait(true);
+            // Only commit if our token is still current. Volatile read is sufficient
+            // — UI thread is the only writer and we're awaited back onto it.
+            if (src != null && System.Threading.Volatile.Read(ref generation[0]) == token)
+                target.Source = src;
+        }
+        catch (OperationCanceledException)
+        {
+            logger?.Debug("[A2UI] Image load cancelled");
+        }
     }
 
     private static void ApplyFit(Image image, string? fit)
@@ -265,19 +287,44 @@ public sealed class VideoRenderer : IComponentRenderer
             AreTransportControlsEnabled = true,
             MinHeight = 180,
         };
+        var generation = new int[] { 0 };
         var urlVal = ctx.GetValue(c, "url");
         void Update()
         {
             var url = ctx.ResolveString(urlVal);
-            if (string.IsNullOrEmpty(url)) return;
-            if (!_media.IsAllowed(url)) return;
-            var uri = _media.AsUri(url);
-            if (uri != null) player.Source = global::Windows.Media.Core.MediaSource.CreateFromUri(uri);
+            if (string.IsNullOrEmpty(url))
+            {
+                System.Threading.Interlocked.Increment(ref generation[0]);
+                player.Source = null;
+                return;
+            }
+            int token = System.Threading.Interlocked.Increment(ref generation[0]);
+            _ = LoadMediaAsync(player, url, generation, token, ctx.Logger);
         }
         Update();
         ctx.WatchValue(c.Id, "url", urlVal, Update);
         AutomationHelpers.Apply(player, c, ctx);
         return player;
+    }
+
+    private async Task LoadMediaAsync(
+        MediaPlayerElement player,
+        string url,
+        int[] generation,
+        int token,
+        OpenClaw.Shared.IOpenClawLogger? logger)
+    {
+        try
+        {
+            using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var uri = await _media.ResolveMediaUriAsync(url, cts.Token).ConfigureAwait(true);
+            if (uri != null && System.Threading.Volatile.Read(ref generation[0]) == token)
+                player.Source = global::Windows.Media.Core.MediaSource.CreateFromUri(uri);
+        }
+        catch (OperationCanceledException)
+        {
+            logger?.Warn("[A2UI] Video URL validation timed out");
+        }
     }
 }
 
@@ -303,14 +350,19 @@ public sealed class AudioPlayerRenderer : IComponentRenderer
             AreTransportControlsEnabled = true,
             MinHeight = 50,
         };
+        var generation = new int[] { 0 };
         var urlVal = ctx.GetValue(c, "url");
         void UrlUpdate()
         {
             var url = ctx.ResolveString(urlVal);
-            if (string.IsNullOrEmpty(url)) return;
-            if (!_media.IsAllowed(url)) return;
-            var uri = _media.AsUri(url);
-            if (uri != null) player.Source = global::Windows.Media.Core.MediaSource.CreateFromUri(uri);
+            if (string.IsNullOrEmpty(url))
+            {
+                System.Threading.Interlocked.Increment(ref generation[0]);
+                player.Source = null;
+                return;
+            }
+            int token = System.Threading.Interlocked.Increment(ref generation[0]);
+            _ = LoadMediaAsync(player, url, generation, token, ctx.Logger);
         }
         UrlUpdate();
         ctx.WatchValue(c.Id, "url", urlVal, UrlUpdate);
@@ -319,5 +371,25 @@ public sealed class AudioPlayerRenderer : IComponentRenderer
         stack.Children.Add(player);
         AutomationHelpers.Apply(stack, c, ctx);
         return stack;
+    }
+
+    private async Task LoadMediaAsync(
+        MediaPlayerElement player,
+        string url,
+        int[] generation,
+        int token,
+        OpenClaw.Shared.IOpenClawLogger? logger)
+    {
+        try
+        {
+            using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var uri = await _media.ResolveMediaUriAsync(url, cts.Token).ConfigureAwait(true);
+            if (uri != null && System.Threading.Volatile.Read(ref generation[0]) == token)
+                player.Source = global::Windows.Media.Core.MediaSource.CreateFromUri(uri);
+        }
+        catch (OperationCanceledException)
+        {
+            logger?.Warn("[A2UI] Audio URL validation timed out");
+        }
     }
 }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/DisplayRenderers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/DisplayRenderers.cs
@@ -135,61 +135,66 @@ public sealed class IconRenderer : IComponentRenderer
         return fontIcon;
     }
 
-    /// <summary>Map A2UI v0.8 icon-name enum to Segoe Fluent glyphs.</summary>
+    /// <summary>
+    /// Map A2UI v0.8 icon-name enum to Segoe Fluent Icons glyph codepoints.
+    /// The icon-name enum is the v0.8 Material-derived set; each name maps to
+    /// the closest-meaning Segoe MDL2 / Fluent glyph. Unknown names fall back
+    /// to the Help glyph rather than rendering an empty box.
+    /// </summary>
     private static string MapName(string? name)
     {
-        if (string.IsNullOrWhiteSpace(name)) return ""; // outlined help (?)
+        if (string.IsNullOrWhiteSpace(name)) return ""; // Help (?)
         return name switch
         {
-            "accountCircle" => "",
-            "add" => "",
-            "arrowBack" => "",
-            "arrowForward" => "",
-            "attachFile" => "",
-            "calendarToday" => "",
-            "call" => "",
-            "camera" => "",
-            "check" => "",
-            "close" => "",
-            "delete" => "",
-            "download" => "",
-            "edit" => "",
-            "event" => "",
-            "error" => "",
-            "favorite" => "",
-            "favoriteOff" => "",
-            "folder" => "",
-            "help" => "",
-            "home" => "",
-            "info" => "",
-            "locationOn" => "",
-            "lock" => "",
-            "lockOpen" => "",
-            "mail" => "",
-            "menu" => "",
-            "moreVert" => "",
-            "moreHoriz" => "",
-            "notificationsOff" => "",
-            "notifications" => "",
-            "payment" => "",
-            "person" => "",
-            "phone" => "",
-            "photo" => "",
-            "print" => "",
-            "refresh" => "",
-            "search" => "",
-            "send" => "",
-            "settings" => "",
-            "share" => "",
-            "shoppingCart" => "",
-            "star" => "",
-            "starHalf" => "",
-            "starOff" => "",
-            "upload" => "",
-            "visibility" => "",
-            "visibilityOff" => "",
-            "warning" => "",
-            _ => "",
+            "accountCircle"    => "", // Contact
+            "add"              => "", // Add
+            "arrowBack"        => "", // Back
+            "arrowForward"     => "", // Forward
+            "attachFile"       => "", // Attach
+            "calendarToday"    => "", // CalendarDay
+            "call"             => "", // Phone
+            "camera"           => "", // Camera
+            "check"            => "", // CheckMark
+            "close"            => "", // Cancel
+            "delete"           => "", // Delete
+            "download"         => "", // Download
+            "edit"             => "", // Edit
+            "event"            => "", // Calendar
+            "error"            => "", // Error
+            "favorite"         => "", // HeartFill
+            "favoriteOff"      => "", // Heart (outline)
+            "folder"           => "", // Folder
+            "help"             => "", // Help / Unknown
+            "home"             => "", // Home
+            "info"             => "", // Info
+            "locationOn"       => "", // MapPin
+            "lock"             => "", // Lock
+            "lockOpen"         => "", // Unlock
+            "mail"             => "", // Mail
+            "menu"             => "", // GlobalNavButton (hamburger)
+            "moreVert"         => "", // More (vertical dots)
+            "moreHoriz"        => "", // More — no canonical horizontal in MDL2; reuse vertical
+            "notificationsOff" => "", // RingerOff
+            "notifications"    => "", // Ringer
+            "payment"          => "", // Payment
+            "person"           => "", // Contact
+            "phone"            => "", // Phone
+            "photo"            => "", // Picture
+            "print"            => "", // Print
+            "refresh"          => "", // Refresh
+            "search"           => "", // Search
+            "send"             => "", // Send
+            "settings"         => "", // Settings (gear)
+            "share"            => "", // Share
+            "shoppingCart"     => "", // ShoppingCart
+            "star"             => "", // FavoriteStarFill
+            "starHalf"         => "", // HalfStarLeft
+            "starOff"          => "", // FavoriteStar (outline)
+            "upload"           => "", // Upload
+            "visibility"       => "", // RedEye / View
+            "visibilityOff"    => "", // Hide
+            "warning"          => "", // Warning
+            _                  => "", // Help (unknown name)
         };
     }
 }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/DisplayRenderers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/DisplayRenderers.cs
@@ -7,6 +7,23 @@ using OpenClawTray.A2UI.Protocol;
 
 namespace OpenClawTray.A2UI.Rendering.Renderers;
 
+/// <summary>
+/// Tiny IDisposable shim so renderers can stash arbitrary cleanup actions in
+/// the surface's subscription dictionary. The host disposes registered
+/// subscriptions on rebuild, which is exactly when we want to cancel async
+/// work the renderer kicked off (e.g. timer-bound CancellationTokenSources).
+/// </summary>
+internal sealed class RendererCleanup : IDisposable
+{
+    private Action? _onDispose;
+    public RendererCleanup(Action onDispose) => _onDispose = onDispose;
+    public void Dispose()
+    {
+        var action = System.Threading.Interlocked.Exchange(ref _onDispose, null);
+        try { action?.Invoke(); } catch { /* cleanup must never throw */ }
+    }
+}
+
 public sealed class TextRenderer : IComponentRenderer
 {
     public string ComponentName => "Text";
@@ -73,7 +90,13 @@ public sealed class ImageRenderer : IComponentRenderer
             if (string.IsNullOrEmpty(url))
             {
                 System.Threading.Interlocked.Increment(ref generation[0]);
-                loadCts?.Cancel();
+                var prev = loadCts;
+                loadCts = null;
+                if (prev != null)
+                {
+                    try { prev.Cancel(); } catch { }
+                    prev.Dispose();
+                }
                 image.Source = null;
                 return;
             }
@@ -83,12 +106,30 @@ public sealed class ImageRenderer : IComponentRenderer
                 return;
             }
             int token = System.Threading.Interlocked.Increment(ref generation[0]);
-            loadCts?.Cancel();
+            // Cancel + dispose the previous timer-bound CTS. CancellationTokenSource
+            // wraps a kernel timer when constructed with a TimeSpan, so leaking
+            // these on a chatty url path holds handles until GC.
+            var prevCts = loadCts;
             loadCts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(20));
+            if (prevCts != null)
+            {
+                try { prevCts.Cancel(); } catch { }
+                prevCts.Dispose();
+            }
             _ = LoadAsync(image, url, generation, token, loadCts.Token, ctx.Logger);
         }
         Update();
         ctx.WatchValue(c.Id, "url", urlVal, Update);
+        // Cancel + dispose the live CTS on surface rebuild so an in-flight load
+        // doesn't continue running after the visual tree has moved on.
+        ctx.RegisterSubscription(c.Id, "imageLoadCts", new RendererCleanup(() =>
+        {
+            var cts = loadCts;
+            loadCts = null;
+            if (cts == null) return;
+            try { cts.Cancel(); } catch { }
+            cts.Dispose();
+        }));
         // A2UI carries alt text in `description` (preferred) or `label` for images.
         AutomationHelpers.Apply(image, c, ctx);
 
@@ -203,10 +244,18 @@ public sealed class IconRenderer : IComponentRenderer
         }
         Update();
         ctx.WatchValue(c.Id, "name", nameVal, Update);
-        // The icon name is the natural automation label when no explicit one is set.
+        // Prefer the A2UI label/description fields (they are human-readable
+        // and localized by the agent). Fall back to NOT announcing the icon
+        // at all — the previous behavior would speak raw enum names like
+        // "moreHoriz" or "accountCircle" to Narrator users, which is worse
+        // than the icon being skipped. Decorative icons inside Buttons / Cards
+        // already have parent labels for assistive tech.
         AutomationHelpers.Apply(fontIcon, c, ctx);
         if (string.IsNullOrEmpty(Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(fontIcon)))
-            AutomationHelpers.SetName(fontIcon, ctx.ResolveString(nameVal));
+        {
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetAccessibilityView(
+                fontIcon, Microsoft.UI.Xaml.Automation.Peers.AccessibilityView.Raw);
+        }
         return fontIcon;
     }
 

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/DisplayRenderers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/DisplayRenderers.cs
@@ -336,44 +336,20 @@ public sealed class VideoRenderer : IComponentRenderer
             AreTransportControlsEnabled = true,
             MinHeight = 180,
         };
-        var generation = new int[] { 0 };
         var urlVal = ctx.GetValue(c, "url");
         void Update()
         {
             var url = ctx.ResolveString(urlVal);
-            if (string.IsNullOrEmpty(url))
-            {
-                System.Threading.Interlocked.Increment(ref generation[0]);
-                player.Source = null;
-                return;
-            }
-            int token = System.Threading.Interlocked.Increment(ref generation[0]);
-            _ = LoadMediaAsync(player, url, generation, token, ctx.Logger);
+            // Gate is allowlist + IP-literal-public only — DNS-rebinding pin
+            // would not hold here because MediaSource.CreateFromUri does its
+            // own resolution at playback. See MediaResolver.TryResolveMediaUri.
+            var uri = string.IsNullOrEmpty(url) ? null : _media.TryResolveMediaUri(url);
+            player.Source = uri == null ? null : global::Windows.Media.Core.MediaSource.CreateFromUri(uri);
         }
         Update();
         ctx.WatchValue(c.Id, "url", urlVal, Update);
         AutomationHelpers.Apply(player, c, ctx);
         return player;
-    }
-
-    private async Task LoadMediaAsync(
-        MediaPlayerElement player,
-        string url,
-        int[] generation,
-        int token,
-        OpenClaw.Shared.IOpenClawLogger? logger)
-    {
-        try
-        {
-            using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(10));
-            var uri = await _media.ResolveMediaUriAsync(url, cts.Token).ConfigureAwait(true);
-            if (uri != null && System.Threading.Volatile.Read(ref generation[0]) == token)
-                player.Source = global::Windows.Media.Core.MediaSource.CreateFromUri(uri);
-        }
-        catch (OperationCanceledException)
-        {
-            logger?.Warn("[A2UI] Video URL validation timed out");
-        }
     }
 }
 
@@ -399,19 +375,12 @@ public sealed class AudioPlayerRenderer : IComponentRenderer
             AreTransportControlsEnabled = true,
             MinHeight = 50,
         };
-        var generation = new int[] { 0 };
         var urlVal = ctx.GetValue(c, "url");
         void UrlUpdate()
         {
             var url = ctx.ResolveString(urlVal);
-            if (string.IsNullOrEmpty(url))
-            {
-                System.Threading.Interlocked.Increment(ref generation[0]);
-                player.Source = null;
-                return;
-            }
-            int token = System.Threading.Interlocked.Increment(ref generation[0]);
-            _ = LoadMediaAsync(player, url, generation, token, ctx.Logger);
+            var uri = string.IsNullOrEmpty(url) ? null : _media.TryResolveMediaUri(url);
+            player.Source = uri == null ? null : global::Windows.Media.Core.MediaSource.CreateFromUri(uri);
         }
         UrlUpdate();
         ctx.WatchValue(c.Id, "url", urlVal, UrlUpdate);
@@ -420,25 +389,5 @@ public sealed class AudioPlayerRenderer : IComponentRenderer
         stack.Children.Add(player);
         AutomationHelpers.Apply(stack, c, ctx);
         return stack;
-    }
-
-    private async Task LoadMediaAsync(
-        MediaPlayerElement player,
-        string url,
-        int[] generation,
-        int token,
-        OpenClaw.Shared.IOpenClawLogger? logger)
-    {
-        try
-        {
-            using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(10));
-            var uri = await _media.ResolveMediaUriAsync(url, cts.Token).ConfigureAwait(true);
-            if (uri != null && System.Threading.Volatile.Read(ref generation[0]) == token)
-                player.Source = global::Windows.Media.Core.MediaSource.CreateFromUri(uri);
-        }
-        catch (OperationCanceledException)
-        {
-            logger?.Warn("[A2UI] Audio URL validation timed out");
-        }
     }
 }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/InteractiveRenderers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/InteractiveRenderers.cs
@@ -321,9 +321,12 @@ public sealed class MultipleChoiceRenderer : IComponentRenderer
                 {
                     if (inProgrammatic) return;
                     var tag = (combo.SelectedItem as ComboBoxItem)?.Tag as string;
-                    var arr = new JsonArray();
-                    if (tag != null) arr.Add(JsonValue.Create(tag));
-                    ctx.DataModel.Write(selVal.Path!, arr);
+                    // Single-mode writes a scalar string (or null), not a one-element array.
+                    // Other components binding to the same path expect a string in single
+                    // mode; the previous JsonArray round-tripped as a stringified "[\"x\"]".
+                    // ResolveSingle still tolerates either shape on read for back-compat.
+                    JsonNode? value = tag != null ? JsonValue.Create(tag) : null;
+                    ctx.DataModel.Write(selVal.Path!, value);
                 };
             }
             AutomationHelpers.Apply(combo, c, ctx);

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/InteractiveRenderers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/InteractiveRenderers.cs
@@ -23,7 +23,8 @@ public sealed class ButtonRenderer : IComponentRenderer
         var primary = c.Properties["primary"]?.GetValue<bool>() ?? false;
         if (primary)
         {
-            try { btn.Style = (Style)Application.Current.Resources["AccentButtonStyle"]; } catch { }
+            if (Application.Current.Resources.TryGetValue("AccentButtonStyle", out var accentStyle) && accentStyle is Style s)
+                btn.Style = s;
         }
 
         var actionNode = c.Properties["action"];
@@ -37,9 +38,16 @@ public sealed class ButtonRenderer : IComponentRenderer
                 Name = actionName,
                 SurfaceId = ctx.SurfaceId,
                 SourceComponentId = c.Id,
-                Context = ctx.BuildActionContext(actionNode),
+                Context = ctx.BuildActionContext(c, actionNode),
             });
         };
+
+        // Accessibility: an icon-only button has no text Content, so Narrator
+        // would announce it as "button". Pull A2UI label/description; fall back
+        // to the action name when neither is provided.
+        AutomationHelpers.Apply(btn, c, ctx);
+        if (string.IsNullOrEmpty(Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(btn)))
+            AutomationHelpers.SetName(btn, actionName);
         return btn;
     }
 }
@@ -82,6 +90,7 @@ public sealed class CheckBoxRenderer : IComponentRenderer
                 ctx.DataModel.Write(valVal.Path!, JsonValue.Create(false));
             };
         }
+        AutomationHelpers.Apply(cb, c, ctx);
         return cb;
     }
 }
@@ -128,6 +137,14 @@ public sealed class TextFieldRenderer : IComponentRenderer
         ctx.WatchValue(c.Id, "label", labelVal, LabelUpdate);
 
         var textVal = ctx.GetValue(c, "text");
+
+        // Obscured fields are sensitive: register the bound path so dump/action-context
+        // redact it (canvas.a2ui.dump is the loudest exfil channel). The value still
+        // round-trips through the data model so a Submit button can read it via an
+        // explicit dataBinding opt-in — but every other read path drops it.
+        if (obscured && textVal?.HasPath == true)
+            ctx.MarkSecretPath(textVal.Path);
+
         bool inProgrammatic = false;
         void TextUpdate()
         {
@@ -163,6 +180,7 @@ public sealed class TextFieldRenderer : IComponentRenderer
             }
         }
 
+        AutomationHelpers.Apply(element, c, ctx);
         return element;
     }
 
@@ -234,14 +252,26 @@ public sealed class DateTimeInputRenderer : IComponentRenderer
                 var t = timePicker?.Time ?? d.TimeOfDay;
                 var combined = new DateTimeOffset(d.Year, d.Month, d.Day,
                     t.Hours, t.Minutes, t.Seconds, d.Offset);
-                var formatted = !string.IsNullOrEmpty(outputFormat)
-                    ? combined.ToString(outputFormat, CultureInfo.InvariantCulture)
-                    : combined.ToString("o");
+                string formatted;
+                try
+                {
+                    formatted = !string.IsNullOrEmpty(outputFormat)
+                        ? combined.ToString(outputFormat, CultureInfo.InvariantCulture)
+                        : combined.ToString("o");
+                }
+                catch (FormatException)
+                {
+                    // Bogus agent-supplied format. Fall back to ISO-8601 so the
+                    // surface keeps working — without this, every keystroke
+                    // throws and the tab re-renders as the unknown placeholder.
+                    formatted = combined.ToString("o");
+                }
                 ctx.DataModel.Write(valVal.Path!, JsonValue.Create(formatted));
             }
             if (datePicker != null) datePicker.DateChanged += (_, _) => Push();
             if (timePicker != null) timePicker.TimeChanged += (_, _) => Push();
         }
+        AutomationHelpers.Apply(sp, c, ctx);
         return sp;
     }
 }
@@ -296,6 +326,7 @@ public sealed class MultipleChoiceRenderer : IComponentRenderer
                     ctx.DataModel.Write(selVal.Path!, arr);
                 };
             }
+            AutomationHelpers.Apply(combo, c, ctx);
             return combo;
         }
         else
@@ -341,6 +372,7 @@ public sealed class MultipleChoiceRenderer : IComponentRenderer
                     ctx.DataModel.Write(selVal.Path!, arr);
                 };
             }
+            AutomationHelpers.Apply(list, c, ctx);
             return list;
         }
     }
@@ -428,6 +460,14 @@ public sealed class SliderRenderer : IComponentRenderer
                 ctx.DataModel.Write(valVal.Path!, JsonValue.Create(e.NewValue));
             };
         }
+
+        // Wire step / stepSize → StepFrequency. Default 1, matching WinUI.
+        var step = c.Properties["step"] is JsonValue jvs && jvs.TryGetValue<double>(out var s1) ? s1
+                 : c.Properties["stepSize"] is JsonValue jvs2 && jvs2.TryGetValue<double>(out var s2) ? s2
+                 : 1.0;
+        if (step > 0) slider.StepFrequency = step;
+
+        AutomationHelpers.Apply(slider, c, ctx);
         return slider;
     }
 }

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/InteractiveRenderers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/InteractiveRenderers.cs
@@ -1,0 +1,433 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using OpenClawTray.A2UI.Protocol;
+
+namespace OpenClawTray.A2UI.Rendering.Renderers;
+
+public sealed class ButtonRenderer : IComponentRenderer
+{
+    public string ComponentName => "Button";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        var btn = new Button { HorizontalAlignment = HorizontalAlignment.Stretch };
+
+        var childId = ctx.GetSingleChild(c, "child");
+        if (childId != null)
+            btn.Content = ctx.BuildChild(childId);
+
+        var primary = c.Properties["primary"]?.GetValue<bool>() ?? false;
+        if (primary)
+        {
+            try { btn.Style = (Style)Application.Current.Resources["AccentButtonStyle"]; } catch { }
+        }
+
+        var actionNode = c.Properties["action"];
+        var actionName = (actionNode is JsonObject ao && ao["name"] is JsonValue nv && nv.TryGetValue<string>(out var n)) ? n : null;
+
+        btn.Click += (_, _) =>
+        {
+            if (string.IsNullOrEmpty(actionName)) return;
+            ctx.Actions.Raise(new A2UIAction
+            {
+                Name = actionName,
+                SurfaceId = ctx.SurfaceId,
+                SourceComponentId = c.Id,
+                Context = ctx.BuildActionContext(actionNode),
+            });
+        };
+        return btn;
+    }
+}
+
+public sealed class CheckBoxRenderer : IComponentRenderer
+{
+    public string ComponentName => "CheckBox";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        var cb = new CheckBox();
+
+        var labelVal = ctx.GetValue(c, "label");
+        void LabelUpdate() => cb.Content = ctx.ResolveString(labelVal) ?? string.Empty;
+        LabelUpdate();
+        ctx.WatchValue(c.Id, "label", labelVal, LabelUpdate);
+
+        var valVal = ctx.GetValue(c, "value");
+        bool inProgrammatic = false;
+
+        void ValueUpdate()
+        {
+            inProgrammatic = true;
+            try { cb.IsChecked = ctx.ResolveBoolean(valVal) ?? false; }
+            finally { inProgrammatic = false; }
+        }
+        ValueUpdate();
+        ctx.WatchValue(c.Id, "value", valVal, ValueUpdate);
+
+        if (valVal?.HasPath == true)
+        {
+            cb.Checked += (_, _) =>
+            {
+                if (inProgrammatic) return;
+                ctx.DataModel.Write(valVal.Path!, JsonValue.Create(true));
+            };
+            cb.Unchecked += (_, _) =>
+            {
+                if (inProgrammatic) return;
+                ctx.DataModel.Write(valVal.Path!, JsonValue.Create(false));
+            };
+        }
+        return cb;
+    }
+}
+
+public sealed class TextFieldRenderer : IComponentRenderer
+{
+    public string ComponentName => "TextField";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        var fieldType = c.Properties["textFieldType"]?.GetValue<string>() ?? "shortText";
+        bool multiline = fieldType == "longText";
+        bool obscured = fieldType == "obscured";
+
+        FrameworkElement element;
+        TextBox? textBox = null;
+        PasswordBox? passwordBox = null;
+
+        if (obscured)
+        {
+            passwordBox = new PasswordBox();
+            element = passwordBox;
+        }
+        else
+        {
+            textBox = new TextBox
+            {
+                AcceptsReturn = multiline,
+                TextWrapping = multiline ? TextWrapping.Wrap : TextWrapping.NoWrap,
+                MinHeight = multiline ? 80 : 32,
+            };
+            ApplyInputScope(textBox, fieldType);
+            element = textBox;
+        }
+
+        var labelVal = ctx.GetValue(c, "label");
+        void LabelUpdate()
+        {
+            var label = ctx.ResolveString(labelVal);
+            if (textBox != null) textBox.Header = label;
+            if (passwordBox != null) passwordBox.Header = label;
+        }
+        LabelUpdate();
+        ctx.WatchValue(c.Id, "label", labelVal, LabelUpdate);
+
+        var textVal = ctx.GetValue(c, "text");
+        bool inProgrammatic = false;
+        void TextUpdate()
+        {
+            inProgrammatic = true;
+            try
+            {
+                var s = ctx.ResolveString(textVal) ?? string.Empty;
+                if (textBox != null) textBox.Text = s;
+                if (passwordBox != null) passwordBox.Password = s;
+            }
+            finally { inProgrammatic = false; }
+        }
+        TextUpdate();
+        ctx.WatchValue(c.Id, "text", textVal, TextUpdate);
+
+        if (textVal?.HasPath == true)
+        {
+            if (textBox != null)
+            {
+                textBox.TextChanged += (_, _) =>
+                {
+                    if (inProgrammatic) return;
+                    ctx.DataModel.Write(textVal.Path!, JsonValue.Create(textBox.Text));
+                };
+            }
+            if (passwordBox != null)
+            {
+                passwordBox.PasswordChanged += (_, _) =>
+                {
+                    if (inProgrammatic) return;
+                    ctx.DataModel.Write(textVal.Path!, JsonValue.Create(passwordBox.Password));
+                };
+            }
+        }
+
+        return element;
+    }
+
+    private static void ApplyInputScope(TextBox tb, string fieldType)
+    {
+        var name = fieldType switch
+        {
+            "number" => Microsoft.UI.Xaml.Input.InputScopeNameValue.Number,
+            "date" => Microsoft.UI.Xaml.Input.InputScopeNameValue.DateMonthNumber,
+            _ => Microsoft.UI.Xaml.Input.InputScopeNameValue.Default,
+        };
+        var scope = new Microsoft.UI.Xaml.Input.InputScope();
+        scope.Names.Add(new Microsoft.UI.Xaml.Input.InputScopeName(name));
+        tb.InputScope = scope;
+    }
+}
+
+public sealed class DateTimeInputRenderer : IComponentRenderer
+{
+    public string ComponentName => "DateTimeInput";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        var enableDate = c.Properties["enableDate"]?.GetValue<bool>() ?? true;
+        var enableTime = c.Properties["enableTime"]?.GetValue<bool>() ?? false;
+        var outputFormat = c.Properties["outputFormat"]?.GetValue<string>();
+
+        var sp = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+        CalendarDatePicker? datePicker = null;
+        TimePicker? timePicker = null;
+
+        if (enableDate)
+        {
+            datePicker = new CalendarDatePicker { PlaceholderText = "Select date" };
+            sp.Children.Add(datePicker);
+        }
+        if (enableTime)
+        {
+            timePicker = new TimePicker();
+            sp.Children.Add(timePicker);
+        }
+
+        var valVal = ctx.GetValue(c, "value");
+        bool inProgrammatic = false;
+        void ValueUpdate()
+        {
+            var s = ctx.ResolveString(valVal);
+            if (string.IsNullOrEmpty(s)) return;
+            if (DateTimeOffset.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out var dto))
+            {
+                inProgrammatic = true;
+                try
+                {
+                    if (datePicker != null) datePicker.Date = dto;
+                    if (timePicker != null) timePicker.Time = dto.TimeOfDay;
+                }
+                finally { inProgrammatic = false; }
+            }
+        }
+        ValueUpdate();
+        ctx.WatchValue(c.Id, "value", valVal, ValueUpdate);
+
+        if (valVal?.HasPath == true)
+        {
+            void Push()
+            {
+                if (inProgrammatic) return;
+                var d = datePicker?.Date ?? DateTimeOffset.Now;
+                var t = timePicker?.Time ?? d.TimeOfDay;
+                var combined = new DateTimeOffset(d.Year, d.Month, d.Day,
+                    t.Hours, t.Minutes, t.Seconds, d.Offset);
+                var formatted = !string.IsNullOrEmpty(outputFormat)
+                    ? combined.ToString(outputFormat, CultureInfo.InvariantCulture)
+                    : combined.ToString("o");
+                ctx.DataModel.Write(valVal.Path!, JsonValue.Create(formatted));
+            }
+            if (datePicker != null) datePicker.DateChanged += (_, _) => Push();
+            if (timePicker != null) timePicker.TimeChanged += (_, _) => Push();
+        }
+        return sp;
+    }
+}
+
+public sealed class MultipleChoiceRenderer : IComponentRenderer
+{
+    public string ComponentName => "MultipleChoice";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        var max = c.Properties["maxAllowedSelections"] is JsonValue jv && jv.TryGetValue<int>(out var m) ? m : int.MaxValue;
+        var single = max == 1;
+
+        var options = ParseOptions(c, ctx);
+
+        if (single)
+        {
+            var combo = new ComboBox { PlaceholderText = "Select..." };
+            foreach (var (label, value) in options)
+                combo.Items.Add(new ComboBoxItem { Content = label, Tag = value });
+
+            var selVal = ctx.GetValue(c, "selections");
+            bool inProgrammatic = false;
+            void Update()
+            {
+                inProgrammatic = true;
+                try
+                {
+                    var current = ResolveSingle(ctx, selVal);
+                    foreach (var item in combo.Items)
+                    {
+                        if (item is ComboBoxItem cbi && (cbi.Tag as string) == current)
+                        {
+                            combo.SelectedItem = cbi;
+                            break;
+                        }
+                    }
+                }
+                finally { inProgrammatic = false; }
+            }
+            Update();
+            ctx.WatchValue(c.Id, "selections", selVal, Update);
+
+            if (selVal?.HasPath == true)
+            {
+                combo.SelectionChanged += (_, _) =>
+                {
+                    if (inProgrammatic) return;
+                    var tag = (combo.SelectedItem as ComboBoxItem)?.Tag as string;
+                    var arr = new JsonArray();
+                    if (tag != null) arr.Add(JsonValue.Create(tag));
+                    ctx.DataModel.Write(selVal.Path!, arr);
+                };
+            }
+            return combo;
+        }
+        else
+        {
+            var list = new ListView { SelectionMode = ListViewSelectionMode.Multiple, MaxHeight = 240 };
+            foreach (var (label, value) in options)
+                list.Items.Add(new ListViewItem { Content = label, Tag = value });
+
+            var selVal = ctx.GetValue(c, "selections");
+            bool inProgrammatic = false;
+            void Update()
+            {
+                inProgrammatic = true;
+                try
+                {
+                    var current = new HashSet<string>(ResolveMulti(ctx, selVal), StringComparer.Ordinal);
+                    foreach (var item in list.Items)
+                    {
+                        if (item is ListViewItem lvi && lvi.Tag is string tag && current.Contains(tag))
+                        {
+                            if (!list.SelectedItems.Contains(lvi))
+                                list.SelectedItems.Add(lvi);
+                        }
+                        else if (item is ListViewItem lvi2 && list.SelectedItems.Contains(lvi2))
+                        {
+                            list.SelectedItems.Remove(lvi2);
+                        }
+                    }
+                }
+                finally { inProgrammatic = false; }
+            }
+            Update();
+            ctx.WatchValue(c.Id, "selections", selVal, Update);
+
+            if (selVal?.HasPath == true)
+            {
+                list.SelectionChanged += (_, _) =>
+                {
+                    if (inProgrammatic) return;
+                    var arr = new JsonArray();
+                    foreach (var sel in list.SelectedItems)
+                        if (sel is ListViewItem lvi && lvi.Tag is string tag) arr.Add(JsonValue.Create(tag));
+                    ctx.DataModel.Write(selVal.Path!, arr);
+                };
+            }
+            return list;
+        }
+    }
+
+    private static List<(string label, string value)> ParseOptions(A2UIComponentDef c, RenderContext ctx)
+    {
+        var result = new List<(string, string)>();
+        if (c.Properties["options"] is not JsonArray arr) return result;
+        foreach (var item in arr)
+        {
+            if (item is not JsonObject o) continue;
+            var labelVal = A2UIValue.From(o["label"]);
+            var label = ctx.ResolveString(labelVal) ?? "";
+            var value = o["value"]?.GetValue<string>() ?? label;
+            result.Add((label, value));
+        }
+        return result;
+    }
+
+    private static string? ResolveSingle(RenderContext ctx, A2UIValue? value)
+    {
+        if (value == null) return null;
+        if (value.LiteralArray is { Count: > 0 } arr) return arr[0];
+        if (value.HasPath)
+        {
+            var node = ctx.DataModel.Read(value.Path!);
+            if (node is JsonArray ja && ja.Count > 0 && ja[0] is JsonValue jv && jv.TryGetValue<string>(out var s))
+                return s;
+            if (node is JsonValue v && v.TryGetValue<string>(out var s2)) return s2;
+        }
+        return null;
+    }
+
+    private static IEnumerable<string> ResolveMulti(RenderContext ctx, A2UIValue? value)
+    {
+        if (value == null) yield break;
+        if (value.LiteralArray is { } arr)
+        {
+            foreach (var s in arr) yield return s;
+            yield break;
+        }
+        if (value.HasPath)
+        {
+            var node = ctx.DataModel.Read(value.Path!);
+            if (node is JsonArray ja)
+            {
+                foreach (var item in ja)
+                    if (item is JsonValue jv && jv.TryGetValue<string>(out var s)) yield return s;
+            }
+        }
+    }
+}
+
+public sealed class SliderRenderer : IComponentRenderer
+{
+    public string ComponentName => "Slider";
+
+    public FrameworkElement Render(A2UIComponentDef c, RenderContext ctx)
+    {
+        var slider = new Slider
+        {
+            Minimum = c.Properties["minValue"] is JsonValue jvmin && jvmin.TryGetValue<double>(out var mn) ? mn : 0,
+            Maximum = c.Properties["maxValue"] is JsonValue jvmax && jvmax.TryGetValue<double>(out var mx) ? mx : 100,
+        };
+        var valVal = ctx.GetValue(c, "value");
+        bool inProgrammatic = false;
+        void Update()
+        {
+            inProgrammatic = true;
+            try
+            {
+                var n = ctx.ResolveNumber(valVal);
+                if (n.HasValue) slider.Value = n.Value;
+            }
+            finally { inProgrammatic = false; }
+        }
+        Update();
+        ctx.WatchValue(c.Id, "value", valVal, Update);
+
+        if (valVal?.HasPath == true)
+        {
+            slider.ValueChanged += (_, e) =>
+            {
+                if (inProgrammatic) return;
+                ctx.DataModel.Write(valVal.Path!, JsonValue.Create(e.NewValue));
+            };
+        }
+        return slider;
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/InteractiveRenderers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/InteractiveRenderers.cs
@@ -214,7 +214,7 @@ public sealed class DateTimeInputRenderer : IComponentRenderer
 
         if (enableDate)
         {
-            datePicker = new CalendarDatePicker { PlaceholderText = "Select date" };
+            datePicker = new CalendarDatePicker { PlaceholderText = OpenClawTray.Helpers.LocalizationHelper.GetString("A2UI_DateTimeSelectDate") };
             sp.Children.Add(datePicker);
         }
         if (enableTime)
@@ -289,7 +289,7 @@ public sealed class MultipleChoiceRenderer : IComponentRenderer
 
         if (single)
         {
-            var combo = new ComboBox { PlaceholderText = "Select..." };
+            var combo = new ComboBox { PlaceholderText = OpenClawTray.Helpers.LocalizationHelper.GetString("A2UI_MultipleChoiceSelect") };
             foreach (var (label, value) in options)
                 combo.Items.Add(new ComboBoxItem { Content = label, Tag = value });
 

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/UnknownRenderer.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/UnknownRenderer.cs
@@ -31,9 +31,10 @@ public sealed class UnknownRenderer : IComponentRenderer
             Glyph = "", // outlined warning
             FontFamily = new FontFamily("Segoe Fluent Icons"),
         });
+        var template = OpenClawTray.Helpers.LocalizationHelper.GetString("A2UI_UnsupportedComponent");
         stack.Children.Add(new TextBlock
         {
-            Text = $"Unsupported component: {component.ComponentName}",
+            Text = string.Format(System.Globalization.CultureInfo.CurrentCulture, template, component.ComponentName),
             VerticalAlignment = VerticalAlignment.Center,
         });
         return stack;

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/UnknownRenderer.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/UnknownRenderer.cs
@@ -1,0 +1,41 @@
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using OpenClawTray.A2UI.Protocol;
+
+namespace OpenClawTray.A2UI.Rendering.Renderers;
+
+/// <summary>
+/// Placeholder for unrecognized component types. Never crashes; surfaces
+/// the offending name + a warning glyph so operators can see catalog drift.
+/// Also used for renderer-thrown exceptions (registered under "__error__").
+/// </summary>
+public sealed class UnknownRenderer : IComponentRenderer
+{
+    public string ComponentName => "<unknown>";
+
+    public FrameworkElement Render(A2UIComponentDef component, RenderContext ctx)
+    {
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Padding = new Thickness(8),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Microsoft.UI.Colors.OrangeRed),
+            CornerRadius = new CornerRadius(4),
+        };
+        stack.Children.Add(new FontIcon
+        {
+            Glyph = "", // outlined warning
+            FontFamily = new FontFamily("Segoe Fluent Icons"),
+        });
+        stack.Children.Add(new TextBlock
+        {
+            Text = $"Unsupported component: {component.ComponentName}",
+            VerticalAlignment = VerticalAlignment.Center,
+        });
+        return stack;
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/UnknownRenderer.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/UnknownRenderer.cs
@@ -11,7 +11,7 @@ namespace OpenClawTray.A2UI.Rendering.Renderers;
 /// the offending name + a warning glyph so operators can see catalog drift.
 /// Also used for renderer-thrown exceptions (registered under "__error__").
 /// </summary>
-public sealed class UnknownRenderer : IComponentRenderer
+internal sealed class UnknownRenderer : IComponentRenderer
 {
     public string ComponentName => "<unknown>";
 

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/SecretRedactor.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/SecretRedactor.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+
+namespace OpenClawTray.A2UI.Rendering;
+
+/// <summary>
+/// Runtime defense for secrets in the surface data model. Combines two
+/// signals: an explicit registry of secret paths (populated when an
+/// obscured TextField binds there) and a key-name denylist matching
+/// <c>password*</c>, <c>secret*</c>, <c>token*</c> case-insensitively.
+/// Used for canvas.a2ui.dump output, action context scoping, and log redaction.
+/// </summary>
+internal static class SecretRedactor
+{
+    /// <summary>
+    /// Path-segment substring denylist. Matches when a single JSON Pointer
+    /// segment contains any of these (case-insensitive). Use substring rather
+    /// than prefix so <c>/auth/sessionToken</c> and <c>/loginPassword</c> are
+    /// caught alongside the obvious <c>/password</c>.
+    /// </summary>
+    private static readonly string[] s_denylist =
+    {
+        "password",
+        "secret",
+        "token",
+    };
+
+    /// <summary>
+    /// True if <paramref name="path"/> is registered as a secret path or any
+    /// segment matches the denylist.
+    /// </summary>
+    public static bool IsSecret(string? path, IReadOnlySet<string> registered)
+    {
+        if (string.IsNullOrEmpty(path)) return false;
+        var normalized = Normalize(path);
+        if (registered.Contains(normalized)) return true;
+        // Any ancestor of the path counts: obscuring "/credentials" should hide "/credentials/password" too.
+        foreach (var prefix in registered)
+        {
+            if (prefix.Length == 0 || prefix == "/") continue;
+            if (normalized.StartsWith(prefix + "/", StringComparison.Ordinal)) return true;
+        }
+        return MatchesDenylist(normalized);
+    }
+
+    /// <summary>
+    /// Deep-clone <paramref name="root"/> with values at registered or
+    /// denylisted paths replaced with <c>"[REDACTED]"</c>.
+    /// </summary>
+    public static JsonNode? Redact(JsonNode? root, IReadOnlySet<string> registered)
+    {
+        if (root == null) return null;
+        return RedactNode(root.DeepClone(), "/", registered);
+    }
+
+    /// <summary>
+    /// Same as <see cref="Redact"/>, but mutates the supplied node in place.
+    /// Caller is responsible for passing a clone if they want to preserve the original.
+    /// </summary>
+    public static JsonNode? RedactInPlace(JsonNode? root, IReadOnlySet<string> registered)
+    {
+        if (root == null) return null;
+        return RedactNode(root, "/", registered);
+    }
+
+    private static JsonNode? RedactNode(JsonNode? node, string path, IReadOnlySet<string> registered)
+    {
+        if (node is JsonObject obj)
+        {
+            var keys = new List<string>(obj.Count);
+            foreach (var kv in obj) keys.Add(kv.Key);
+            foreach (var key in keys)
+            {
+                var childPath = path == "/" ? "/" + EncodeSegment(key) : path + "/" + EncodeSegment(key);
+                var current = obj[key];
+                if (IsSecret(childPath, registered) || MatchesKey(key))
+                {
+                    obj[key] = JsonValue.Create("[REDACTED]");
+                }
+                else
+                {
+                    var replaced = RedactNode(current, childPath, registered);
+                    if (!ReferenceEquals(replaced, current)) obj[key] = replaced;
+                }
+            }
+            return obj;
+        }
+        if (node is JsonArray arr)
+        {
+            for (int i = 0; i < arr.Count; i++)
+            {
+                var childPath = path == "/" ? "/" + i : path + "/" + i;
+                var current = arr[i];
+                var replaced = RedactNode(current, childPath, registered);
+                if (!ReferenceEquals(replaced, current)) arr[i] = replaced;
+            }
+            return arr;
+        }
+        return node;
+    }
+
+    private static bool MatchesDenylist(string path)
+    {
+        // Walk segments; denylist match on any segment.
+        var span = path.AsSpan();
+        if (span.Length > 0 && span[0] == '/') span = span.Slice(1);
+        while (!span.IsEmpty)
+        {
+            var slash = span.IndexOf('/');
+            var segment = slash < 0 ? span : span.Slice(0, slash);
+            if (MatchesSegment(segment)) return true;
+            if (slash < 0) break;
+            span = span.Slice(slash + 1);
+        }
+        return false;
+    }
+
+    private static bool MatchesKey(string key)
+    {
+        if (string.IsNullOrEmpty(key)) return false;
+        return MatchesSegment(key.AsSpan());
+    }
+
+    private static bool MatchesSegment(ReadOnlySpan<char> segment)
+    {
+        foreach (var bad in s_denylist)
+            if (segment.Contains(bad.AsSpan(), StringComparison.OrdinalIgnoreCase)) return true;
+        return false;
+    }
+
+    private static string Normalize(string p) =>
+        string.IsNullOrEmpty(p) ? "/" : (p[0] == '/' ? p : "/" + p);
+
+    private static string EncodeSegment(string key) =>
+        key.Replace("~", "~0").Replace("/", "~1");
+}

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/SecretRedactor.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/SecretRedactor.cs
@@ -17,13 +17,28 @@ internal static class SecretRedactor
     /// Path-segment substring denylist. Matches when a single JSON Pointer
     /// segment contains any of these (case-insensitive). Use substring rather
     /// than prefix so <c>/auth/sessionToken</c> and <c>/loginPassword</c> are
-    /// caught alongside the obvious <c>/password</c>.
+    /// caught alongside the obvious <c>/password</c>. False positives (e.g.
+    /// "private" matching "/privateBeta") are preferred to false negatives:
+    /// hiding a non-secret leaks nothing, leaking a secret is the failure mode.
     /// </summary>
     private static readonly string[] s_denylist =
     {
         "password",
         "secret",
         "token",
+        "apikey",
+        "bearer",
+        "authorization",
+        "pin",
+        "otp",
+        "mfa",
+        "credential",
+        "session",
+        "cookie",
+        "auth",
+        "refresh",
+        "private",
+        "access",
     };
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/A2UI/Telemetry/IA2UITelemetry.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Telemetry/IA2UITelemetry.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace OpenClawTray.A2UI.Telemetry;
+
+/// <summary>
+/// Per-spec §11 structured telemetry seam. Renderer code calls these from the
+/// hot paths so a downstream telemetry adapter can emit per-event records
+/// without scraping flat log lines. Default implementation is a no-op so the
+/// renderer ships gateway-less without an extra dependency.
+/// </summary>
+public interface IA2UITelemetry
+{
+    /// <summary>An A2UI JSONL push was applied. <paramref name="kind"/> is the envelope discriminator (e.g. "surfaceUpdate", "beginRendering").</summary>
+    void Push(string surfaceId, string kind, int messageCount);
+
+    /// <summary>A user-originated action was raised on a surface. Does not carry the action context (which can include PII).</summary>
+    void Action(string surfaceId, string actionName, string? sourceComponentId);
+
+    /// <summary>A componentName fell through to <c>UnknownRenderer</c> (catalog drift signal).</summary>
+    void UnknownComponent(string surfaceId, string componentName, string componentId);
+
+    /// <summary>Media URL blocked by the resolver allowlist or scheme/size policy. <paramref name="reason"/> is one of "scheme", "host", "size", "decode".</summary>
+    void MediaBlocked(string surfaceId, string url, string reason);
+}
+
+/// <summary>No-op default. Renderer code calls into this safely when no adapter is wired.</summary>
+public sealed class NullA2UITelemetry : IA2UITelemetry
+{
+    public static readonly NullA2UITelemetry Instance = new();
+    private NullA2UITelemetry() { }
+    public void Push(string surfaceId, string kind, int messageCount) { }
+    public void Action(string surfaceId, string actionName, string? sourceComponentId) { }
+    public void UnknownComponent(string surfaceId, string componentName, string componentId) { }
+    public void MediaBlocked(string surfaceId, string url, string reason) { }
+}

--- a/src/OpenClaw.Tray.WinUI/A2UI/Theming/A2UITheme.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Theming/A2UITheme.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Text.Json.Nodes;
+using Microsoft.UI;
+using Windows.UI;
+
+namespace OpenClawTray.A2UI.Theming;
+
+/// <summary>
+/// Per-surface theme overrides resolved from createSurface.theme. Optional —
+/// surfaces without theme payloads default to Fluent (XamlControlsResources).
+/// Values resolve to <see cref="ThemeResource"/> overrides applied to the
+/// SurfaceHost's resource scope, never globally.
+/// </summary>
+public sealed class A2UITheme
+{
+    public Color? Accent { get; init; }
+    public Color? Background { get; init; }
+    public Color? Foreground { get; init; }
+    public Color? CardBackground { get; init; }
+    public string? FontFamily { get; init; }
+    public double? CornerRadius { get; init; }
+    public double? Spacing { get; init; }
+
+    public static A2UITheme Empty { get; } = new();
+
+    /// <summary>
+    /// Parse <c>beginRendering.styles</c>. v0.8 standard catalog defines two
+    /// fields: <c>font</c> and <c>primaryColor</c>. Older / extended payloads
+    /// may carry richer color/typography blocks; we read both forms.
+    /// </summary>
+    public static A2UITheme Parse(JsonObject? payload)
+    {
+        if (payload == null) return Empty;
+
+        var primary = ParseFlatString(payload, "primaryColor");
+        var fontFlat = ParseFlatString(payload, "font");
+
+        return new A2UITheme
+        {
+            Accent = primary != null ? TryParseHex(primary) : ParseNestedColor(payload, "colors", "accent"),
+            Background = ParseNestedColor(payload, "colors", "background"),
+            Foreground = ParseNestedColor(payload, "colors", "foreground"),
+            CardBackground = ParseNestedColor(payload, "colors", "card"),
+            FontFamily = fontFlat ?? ParseNestedString(payload, "typography", "fontFamily"),
+            CornerRadius = ParseDouble(payload, "radius"),
+            Spacing = ParseDouble(payload, "spacing"),
+        };
+    }
+
+    private static string? ParseFlatString(JsonObject root, string key) =>
+        root[key] is JsonValue jv && jv.TryGetValue<string>(out var s) ? s : null;
+
+    private static Color? ParseNestedColor(JsonObject root, string parent, string key)
+    {
+        if (root[parent] is not JsonObject p) return null;
+        if (p[key] is not JsonValue jv) return null;
+        if (!jv.TryGetValue<string>(out var s) || string.IsNullOrWhiteSpace(s)) return null;
+        return TryParseHex(s);
+    }
+
+    private static string? ParseNestedString(JsonObject root, string parent, string key)
+    {
+        if (root[parent] is not JsonObject p) return null;
+        if (p[key] is JsonValue jv && jv.TryGetValue<string>(out var s)) return s;
+        return null;
+    }
+
+    private static double? ParseDouble(JsonObject root, string key)
+    {
+        if (root[key] is JsonValue jv && jv.TryGetValue<double>(out var d)) return d;
+        return null;
+    }
+
+    private static Color? TryParseHex(string s)
+    {
+        s = s.Trim();
+        if (s.StartsWith('#')) s = s[1..];
+        try
+        {
+            if (s.Length == 6)
+            {
+                byte r = Convert.ToByte(s.Substring(0, 2), 16);
+                byte g = Convert.ToByte(s.Substring(2, 2), 16);
+                byte b = Convert.ToByte(s.Substring(4, 2), 16);
+                return Color.FromArgb(0xFF, r, g, b);
+            }
+            if (s.Length == 8)
+            {
+                byte a = Convert.ToByte(s.Substring(0, 2), 16);
+                byte r = Convert.ToByte(s.Substring(2, 2), 16);
+                byte g = Convert.ToByte(s.Substring(4, 2), 16);
+                byte b = Convert.ToByte(s.Substring(6, 2), 16);
+                return Color.FromArgb(a, r, g, b);
+            }
+        }
+        catch { }
+        return null;
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1880,7 +1880,9 @@ public partial class App : Application
     {
         if (_settingsWindow == null || _settingsWindow.IsClosed)
         {
-            _settingsWindow = new SettingsWindow(_settings!, _nodeService);
+            // Pass a delegate so the settings window sees the current NodeService
+            // even after OnSettingsSaved disposes/recreates it (M31).
+            _settingsWindow = new SettingsWindow(_settings!, () => _nodeService);
             _settingsWindow.Closed += (s, e) => 
             {
                 _settingsWindow.SettingsSaved -= OnSettingsSaved;
@@ -1925,6 +1927,15 @@ public partial class App : Application
         else
         {
             InitializeGatewayClient();
+        }
+
+        // Refresh the open settings window's MCP status — the new node service
+        // is now wired and the window should show "Listening" / startup error
+        // for the new instance, not stale text from the disposed one (M31).
+        if (_settingsWindow != null && !_settingsWindow.IsClosed)
+        {
+            try { _settingsWindow.RefreshMcpStatus(); }
+            catch (Exception ex) { Logger.Warn($"Settings refresh error: {ex.Message}"); }
         }
 
         // Update global hotkey

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -246,9 +246,17 @@ public partial class App : Application
         // Single instance check - keep mutex alive for app lifetime.
         // When running with an isolated data dir (tests), suffix the mutex name so
         // the test instance does not collide with the user's regular tray app.
-        var mutexName = DataDirOverride is null
-            ? "OpenClawTray"
-            : $"OpenClawTray-{Math.Abs(DataDirOverride.GetHashCode()):X8}";
+        // String.GetHashCode() is randomized per process since .NET Core 2.1, so
+        // two test runs against the same data dir would otherwise pick different
+        // mutex names — and `Math.Abs(int.MinValue)` overflows. Use a stable
+        // SHA-256 prefix instead.
+        var mutexName = "OpenClawTray";
+        if (DataDirOverride is not null)
+        {
+            var hash = System.Security.Cryptography.SHA256.HashData(
+                System.Text.Encoding.UTF8.GetBytes(DataDirOverride));
+            mutexName = $"OpenClawTray-{Convert.ToHexString(hash, 0, 4)}";
+        }
         _mutex = new Mutex(true, mutexName, out bool createdNew);
         if (!createdNew)
         {

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -101,9 +101,14 @@ public partial class App : Application
 
     private string[]? _startupArgs;
     private string? _pendingProtocolUri;
-    private static readonly string DataPath = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "OpenClawTray");
+    // OPENCLAW_TRAY_DATA_DIR isolates a test instance: settings, logs, run marker,
+    // crash log, exec approvals, and the single-instance mutex name all derive from it.
+    private static readonly string? DataDirOverride =
+        Environment.GetEnvironmentVariable("OPENCLAW_TRAY_DATA_DIR") is { Length: > 0 } v ? v : null;
+    private static readonly string DataPath = DataDirOverride
+        ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "OpenClawTray");
     private static readonly string CrashLogPath = Path.Combine(DataPath, "crash.log");
     private static readonly string RunMarkerPath = Path.Combine(DataPath, "run.marker");
 
@@ -238,8 +243,13 @@ public partial class App : Application
         // Check for protocol activation (MSIX packaged apps receive deep links this way)
         string? protocolUri = GetProtocolActivationUri();
 
-        // Single instance check - keep mutex alive for app lifetime
-        _mutex = new Mutex(true, "OpenClawTray", out bool createdNew);
+        // Single instance check - keep mutex alive for app lifetime.
+        // When running with an isolated data dir (tests), suffix the mutex name so
+        // the test instance does not collide with the user's regular tray app.
+        var mutexName = DataDirOverride is null
+            ? "OpenClawTray"
+            : $"OpenClawTray-{Math.Abs(DataDirOverride.GetHashCode()):X8}";
+        _mutex = new Mutex(true, mutexName, out bool createdNew);
         if (!createdNew)
         {
             // Forward deep link args to running instance (command-line or protocol activation)
@@ -269,12 +279,16 @@ public partial class App : Application
         // Register URI scheme on first run
         DeepLinkHandler.RegisterUriScheme();
 
-        // Check for updates before launching
-        var shouldLaunch = await CheckForUpdatesAsync();
-        if (!shouldLaunch)
+        // Check for updates before launching. Skip in test instances — no UI dialogs,
+        // no network calls, no startup delay.
+        if (DataDirOverride is null)
         {
-            Exit();
-            return;
+            var shouldLaunch = await CheckForUpdatesAsync();
+            if (!shouldLaunch)
+            {
+                Exit();
+                return;
+            }
         }
 
         // Register toast activation handler

--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -47,6 +47,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="OpenClaw.Tray.UITests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260101001" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4654" />
     <PackageReference Include="WinUIEx" Version="2.9.0" />

--- a/src/OpenClaw.Tray.WinUI/Services/DiagnosticsJsonlService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/DiagnosticsJsonlService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text.Json;
+using OpenClaw.Shared;
 
 namespace OpenClawTray.Services;
 
@@ -48,7 +49,7 @@ public static class DiagnosticsJsonlService
             try
             {
                 RotateIfNeeded();
-                File.AppendAllText(s_filePath!, JsonSerializer.Serialize(record) + Environment.NewLine);
+                File.AppendAllText(s_filePath!, TokenSanitizer.Sanitize(JsonSerializer.Serialize(record)) + Environment.NewLine);
             }
             catch (IOException ex)
             {

--- a/src/OpenClaw.Tray.WinUI/Services/DiagnosticsJsonlService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/DiagnosticsJsonlService.cs
@@ -1,16 +1,28 @@
 using System;
 using System.IO;
 using System.Text.Json;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 using OpenClaw.Shared;
 
 namespace OpenClawTray.Services;
 
+/// <summary>
+/// Append-only structured event log. Same async pattern as <see cref="Logger"/>:
+/// callers enqueue, a single background task drains; under load this used to
+/// stall whichever thread was hottest because writes happened under a lock on
+/// the calling thread.
+/// </summary>
 public static class DiagnosticsJsonlService
 {
     private const long MaxBytes = 5 * 1024 * 1024;
     private const int MaxArchives = 5;
-    private static readonly object s_lock = new();
+    private const int ChannelCapacity = 4096;
+
     private static string? s_filePath;
+    private static Channel<string>? s_channel;
+    private static Task? s_writerTask;
+    private static readonly object s_initLock = new();
 
     public static string? FilePath => s_filePath;
 
@@ -20,7 +32,20 @@ public static class DiagnosticsJsonlService
         {
             var logDirectory = Path.Combine(dataPath, "Logs");
             Directory.CreateDirectory(logDirectory);
-            s_filePath = Path.Combine(logDirectory, "diagnostics.jsonl");
+            lock (s_initLock)
+            {
+                s_filePath = Path.Combine(logDirectory, "diagnostics.jsonl");
+                if (s_channel == null)
+                {
+                    s_channel = Channel.CreateBounded<string>(new BoundedChannelOptions(ChannelCapacity)
+                    {
+                        FullMode = BoundedChannelFullMode.DropOldest,
+                        SingleReader = true,
+                        SingleWriter = false,
+                    });
+                    s_writerTask = Task.Run(WriterLoopAsync);
+                }
+            }
         }
         catch (IOException ex)
         {
@@ -36,49 +61,72 @@ public static class DiagnosticsJsonlService
     {
         if (string.IsNullOrWhiteSpace(eventName) || string.IsNullOrWhiteSpace(s_filePath))
             return;
+        var channel = s_channel;
+        if (channel == null) return;
 
-        var record = new
+        try
         {
-            ts = DateTimeOffset.Now,
-            @event = eventName,
-            metadata
-        };
-
-        lock (s_lock)
+            var record = new
+            {
+                ts = DateTimeOffset.Now,
+                @event = eventName,
+                metadata
+            };
+            var line = TokenSanitizer.Sanitize(JsonSerializer.Serialize(record));
+            channel.Writer.TryWrite(line);
+        }
+        catch (NotSupportedException ex)
         {
-            try
-            {
-                RotateIfNeeded();
-                File.AppendAllText(s_filePath!, TokenSanitizer.Sanitize(JsonSerializer.Serialize(record)) + Environment.NewLine);
-            }
-            catch (IOException ex)
-            {
-                Logger.Warn($"Diagnostics JSONL write failed: {ex.Message}");
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                Logger.Warn($"Diagnostics JSONL write denied: {ex.Message}");
-            }
-            catch (NotSupportedException ex)
-            {
-                Logger.Warn($"Diagnostics JSONL record was not serializable: {ex.Message}");
-            }
+            // Serialization failure is the only thing we want to surface from
+            // the calling thread — record IS untrusted (caller-supplied).
+            Logger.Warn($"Diagnostics JSONL record was not serializable: {ex.Message}");
         }
     }
 
-    private static void RotateIfNeeded()
+    private static async Task WriterLoopAsync()
     {
-        if (string.IsNullOrWhiteSpace(s_filePath))
-            return;
+        var channel = s_channel;
+        if (channel == null) return;
+        var reader = channel.Reader;
+        while (await reader.WaitToReadAsync().ConfigureAwait(false))
+        {
+            var path = s_filePath;
+            if (path == null)
+            {
+                // Drain anyway so the channel doesn't fill up.
+                while (reader.TryRead(out _)) { }
+                continue;
+            }
 
-        var current = new FileInfo(s_filePath);
+            try
+            {
+                RotateIfNeeded(path);
+                using var fs = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read);
+                using var sw = new StreamWriter(fs);
+                int wrote = 0;
+                while (reader.TryRead(out var pending))
+                {
+                    sw.WriteLine(pending);
+                    if (++wrote >= 256) break;
+                }
+                sw.Flush();
+            }
+            catch (IOException ex) { Logger.Warn($"Diagnostics JSONL write failed: {ex.Message}"); }
+            catch (UnauthorizedAccessException ex) { Logger.Warn($"Diagnostics JSONL write denied: {ex.Message}"); }
+            catch (Exception ex) { Logger.Warn($"Diagnostics JSONL writer error: {ex.Message}"); }
+        }
+    }
+
+    private static void RotateIfNeeded(string path)
+    {
+        var current = new FileInfo(path);
         if (!current.Exists || current.Length <= MaxBytes)
             return;
 
         for (var i = MaxArchives; i >= 1; i--)
         {
-            var source = i == 1 ? s_filePath : $"{s_filePath}.{i - 1}";
-            var destination = $"{s_filePath}.{i}";
+            var source = i == 1 ? path : $"{path}.{i - 1}";
+            var destination = $"{path}.{i}";
             if (!File.Exists(source))
                 continue;
 

--- a/src/OpenClaw.Tray.WinUI/Services/Logger.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/Logger.cs
@@ -8,9 +8,16 @@ namespace OpenClawTray.Services;
 /// </summary>
 public static class Logger
 {
+    private const long RotateThresholdBytes = 5 * 1024 * 1024;
+    // Sample the file size every N writes instead of every write — File.Length on
+    // Windows requires a metadata round-trip that's heavy at high log volume, and
+    // we don't need byte-precise rotation.
+    private const int RotateCheckInterval = 64;
+
     private static readonly object _lock = new();
     private static readonly string _logDirectory;
     private static readonly string _logFilePath;
+    private static int _writesSinceRotateCheck;
 
     static Logger()
     {
@@ -20,22 +27,13 @@ public static class Logger
             : Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "OpenClawTray");
-        
+
         Directory.CreateDirectory(_logDirectory);
         _logFilePath = Path.Combine(_logDirectory, "openclaw-tray.log");
-        
-        // Rotate log if too large (> 5MB)
-        try
-        {
-            var fileInfo = new FileInfo(_logFilePath);
-            if (fileInfo.Exists && fileInfo.Length > 5 * 1024 * 1024)
-            {
-                var backupPath = Path.Combine(_logDirectory, "openclaw-tray.log.old");
-                if (File.Exists(backupPath)) File.Delete(backupPath);
-                File.Move(_logFilePath, backupPath);
-            }
-        }
-        catch { }
+
+        // Initial rotation pass picks up anything left from a previous run that
+        // exceeded the threshold. The append path also rotates periodically.
+        TryRotate();
     }
 
     public static string LogFilePath => _logFilePath;
@@ -54,6 +52,11 @@ public static class Logger
         {
             try
             {
+                if (++_writesSinceRotateCheck >= RotateCheckInterval)
+                {
+                    _writesSinceRotateCheck = 0;
+                    TryRotate();
+                }
                 File.AppendAllText(_logFilePath, line + Environment.NewLine);
             }
             catch { }
@@ -62,5 +65,20 @@ public static class Logger
 #if DEBUG
         System.Diagnostics.Debug.WriteLine(line);
 #endif
+    }
+
+    private static void TryRotate()
+    {
+        try
+        {
+            var fileInfo = new FileInfo(_logFilePath);
+            if (fileInfo.Exists && fileInfo.Length > RotateThresholdBytes)
+            {
+                var backupPath = Path.Combine(_logDirectory, "openclaw-tray.log.old");
+                if (File.Exists(backupPath)) File.Delete(backupPath);
+                File.Move(_logFilePath, backupPath);
+            }
+        }
+        catch { }
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Services/Logger.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/Logger.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using OpenClaw.Shared;
 
 namespace OpenClawTray.Services;
 
@@ -46,7 +47,7 @@ public static class Logger
     private static void Log(string level, string message)
     {
         var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
-        var line = $"[{timestamp}] [{level}] {message}";
+        var line = $"[{timestamp}] [{level}] {TokenSanitizer.Sanitize(message)}";
 
         lock (_lock)
         {

--- a/src/OpenClaw.Tray.WinUI/Services/Logger.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/Logger.cs
@@ -14,9 +14,12 @@ public static class Logger
 
     static Logger()
     {
-        _logDirectory = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "OpenClawTray");
+        // OPENCLAW_TRAY_DATA_DIR keeps test instances out of the user's log file.
+        _logDirectory = Environment.GetEnvironmentVariable("OPENCLAW_TRAY_DATA_DIR") is { Length: > 0 } overrideDir
+            ? overrideDir
+            : Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "OpenClawTray");
         
         Directory.CreateDirectory(_logDirectory);
         _logFilePath = Path.Combine(_logDirectory, "openclaw-tray.log");

--- a/src/OpenClaw.Tray.WinUI/Services/Logger.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/Logger.cs
@@ -1,24 +1,41 @@
 using System;
 using System.IO;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 using OpenClaw.Shared;
 
 namespace OpenClawTray.Services;
 
 /// <summary>
-/// Simple file logger for the tray application.
+/// File logger for the tray. Calls return immediately: writes are queued onto
+/// a bounded <see cref="Channel{T}"/> and a single background task drains
+/// them in batches. UI / dispatcher / MCP threads no longer block on disk
+/// I/O. Drop-oldest is the overflow policy — losing the oldest queued line
+/// is preferable to back-pressuring callers, since the recent context around
+/// a failure is what matters at debug time.
+///
+/// Write failures are not silent: the most recent error is exposed via
+/// <see cref="LastWriteError"/> and mirrored to <see cref="System.Diagnostics.Trace"/>
+/// so a release build can be diagnosed via DebugView/ETW.
 /// </summary>
 public static class Logger
 {
     private const long RotateThresholdBytes = 5 * 1024 * 1024;
-    // Sample the file size every N writes instead of every write — File.Length on
-    // Windows requires a metadata round-trip that's heavy at high log volume, and
-    // we don't need byte-precise rotation.
+    // Sample the file size after this many flushes — File.Length on Windows
+    // requires a metadata round-trip and we don't need byte-precise rotation.
     private const int RotateCheckInterval = 64;
+    // Cap. Drop-oldest on overflow keeps memory bounded under a logging
+    // storm while preserving the most recent lines.
+    private const int ChannelCapacity = 4096;
 
-    private static readonly object _lock = new();
     private static readonly string _logDirectory;
     private static readonly string _logFilePath;
+    private static readonly Channel<string> s_channel;
+    private static readonly Task s_writerTask;
     private static int _writesSinceRotateCheck;
+
+    /// <summary>Most recent write/rotate failure, or null if the writer is healthy.</summary>
+    public static string? LastWriteError { get; private set; }
 
     static Logger()
     {
@@ -29,12 +46,33 @@ public static class Logger
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "OpenClawTray");
 
-        Directory.CreateDirectory(_logDirectory);
+        try { Directory.CreateDirectory(_logDirectory); }
+        catch (Exception ex) { ReportWriteFailure($"create log dir: {ex.Message}"); }
         _logFilePath = Path.Combine(_logDirectory, "openclaw-tray.log");
 
         // Initial rotation pass picks up anything left from a previous run that
         // exceeded the threshold. The append path also rotates periodically.
         TryRotate();
+
+        s_channel = Channel.CreateBounded<string>(new BoundedChannelOptions(ChannelCapacity)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+        s_writerTask = Task.Run(WriterLoopAsync);
+
+        // Best-effort flush on process exit. The runtime gives us a few seconds
+        // of grace; missing the deadline is preferable to losing logs entirely.
+        AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+        {
+            try
+            {
+                s_channel.Writer.TryComplete();
+                s_writerTask.Wait(TimeSpan.FromSeconds(2));
+            }
+            catch { /* shutdown — nothing to do */ }
+        };
     }
 
     public static string LogFilePath => _logFilePath;
@@ -49,23 +87,51 @@ public static class Logger
         var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
         var line = $"[{timestamp}] [{level}] {TokenSanitizer.Sanitize(message)}";
 
-        lock (_lock)
-        {
-            try
-            {
-                if (++_writesSinceRotateCheck >= RotateCheckInterval)
-                {
-                    _writesSinceRotateCheck = 0;
-                    TryRotate();
-                }
-                File.AppendAllText(_logFilePath, line + Environment.NewLine);
-            }
-            catch { }
-        }
+        // TryWrite is non-blocking. With DropOldest semantics the call should
+        // never fail unless the writer has been completed (process shutdown).
+        s_channel.Writer.TryWrite(line);
 
 #if DEBUG
         System.Diagnostics.Debug.WriteLine(line);
 #endif
+    }
+
+    private static async Task WriterLoopAsync()
+    {
+        var reader = s_channel.Reader;
+        while (await reader.WaitToReadAsync().ConfigureAwait(false))
+        {
+            int wrote = 0;
+            try
+            {
+                // Open once per drained batch so high-volume bursts don't pay
+                // a full File.AppendAllText (open/seek/close) per line.
+                using var fs = new FileStream(_logFilePath, FileMode.Append, FileAccess.Write, FileShare.Read);
+                using var sw = new StreamWriter(fs);
+                while (reader.TryRead(out var pending))
+                {
+                    sw.WriteLine(pending);
+                    wrote++;
+                    if (wrote >= 256) break; // bound batch so rotation can kick in promptly
+                }
+                sw.Flush();
+                LastWriteError = null;
+            }
+            catch (Exception ex)
+            {
+                ReportWriteFailure(ex.Message);
+            }
+
+            if (wrote > 0)
+            {
+                _writesSinceRotateCheck += wrote;
+                if (_writesSinceRotateCheck >= RotateCheckInterval)
+                {
+                    _writesSinceRotateCheck = 0;
+                    TryRotate();
+                }
+            }
+        }
     }
 
     private static void TryRotate()
@@ -80,6 +146,18 @@ public static class Logger
                 File.Move(_logFilePath, backupPath);
             }
         }
-        catch { }
+        catch (Exception ex)
+        {
+            ReportWriteFailure($"rotate: {ex.Message}");
+        }
+    }
+
+    private static void ReportWriteFailure(string detail)
+    {
+        LastWriteError = detail;
+        try { System.Diagnostics.Trace.WriteLine($"[OpenClaw Logger] {detail}"); } catch { }
+#if DEBUG
+        try { System.Diagnostics.Debug.WriteLine($"[OpenClaw Logger] {detail}"); } catch { }
+#endif
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -584,6 +584,12 @@ public sealed class NodeService : IDisposable
     /// CSP, etc.) that mangles arbitrary external URLs. Agents that want to
     /// load a page inside an embedded surface should use <c>canvas.present</c>.
     ///
+    /// Open canvas windows are NOT closed after navigate. A2UI surfaces are
+    /// control panels / dashboards / launchers, not browser frames; clicking a
+    /// link inside one shouldn't dismiss it any more than clicking a link in
+    /// the Start Menu would. Agents that want explicit teardown should call
+    /// <c>canvas.hide</c> or emit <c>deleteSurface</c>.
+    ///
     /// CanvasCapability has already validated the URL with HttpUrlValidator;
     /// we re-validate here as defense-in-depth so the OS-level shell-execute
     /// can never see an unvetted string.
@@ -642,7 +648,7 @@ public sealed class NodeService : IDisposable
                     return;
                 }
 
-                LaunchAndCleanup(canonical!);
+                LaunchInDefaultBrowser(canonical!);
             }
             catch (Exception ex)
             {
@@ -700,13 +706,20 @@ public sealed class NodeService : IDisposable
     /// open in-app canvas surfaces (web or A2UI) on the dispatcher. Failures
     /// are logged but never thrown — callers expect a fire-and-forget shape.
     /// </summary>
-    private void LaunchAndCleanup(string canonical)
+    private void LaunchInDefaultBrowser(string canonical)
     {
         // Process.Start with UseShellExecute=true wraps ShellExecuteEx, which
         // routes the URL to the user's registered http/https handler — never
         // to a script host or file association — given the validator already
-        // restricted the scheme. Browser launch doesn't need the UI dispatcher;
-        // the canvas-window cleanup does.
+        // restricted the scheme.
+        //
+        // Note: this used to close any open canvas windows after launch. That
+        // made sense when canvas == WebView2 and navigate implied "you don't
+        // need this frame anymore." With native A2UI the canvas is a control
+        // surface (dashboard / launcher), not a browser frame — clicking a
+        // link in a dashboard shouldn't nuke the dashboard. Lifecycle is now
+        // explicit: agents that want the canvas dismissed after a navigate
+        // should follow up with canvas.hide or deleteSurface.
         try
         {
             var psi = new System.Diagnostics.ProcessStartInfo
@@ -715,18 +728,12 @@ public sealed class NodeService : IDisposable
                 UseShellExecute = true,
             };
             using var proc = System.Diagnostics.Process.Start(psi);
-            _logger.Info($"Canvas navigate → default browser: {canonical}");
+            _logger.Info($"Canvas navigate → default browser: {OpenClaw.Shared.UrlLogSanitizer.Sanitize(canonical)}");
         }
         catch (Exception ex)
         {
             _logger.Error("Canvas navigate failed", ex);
         }
-
-        _dispatcherQueue.TryEnqueue(() =>
-        {
-            try { CloseWebCanvasWindow(); } catch (Exception ex) { _logger.Warn($"Close web canvas after navigate failed: {ex.Message}"); }
-            try { CloseA2UICanvasWindow(); } catch (Exception ex) { _logger.Warn($"Close A2UI canvas after navigate failed: {ex.Message}"); }
-        });
     }
 
     private string BuildNavigationAgentIdentity()

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -73,6 +73,14 @@ public class NodeService : IDisposable
             ? p
             : McpDefaultPort;
     public static string McpServerUrl => $"http://127.0.0.1:{McpPort}/";
+    /// <summary>
+    /// Path of the MCP bearer-token file. The file is created on first MCP server
+    /// start and persists across restarts; the same string is sent on every POST
+    /// as <c>Authorization: Bearer &lt;contents&gt;</c>. Surfaced by Settings UI so
+    /// users can hand the value off to local agents/CLIs without spelunking.
+    /// </summary>
+    public static string McpTokenPath =>
+        System.IO.Path.Combine(SettingsManager.SettingsDirectoryPath, "mcp-token.txt");
     private readonly bool _enableMcpServer;
     private McpHttpServer? _mcpServer;
     private string? _mcpStartupError;
@@ -312,8 +320,7 @@ public class NodeService : IDisposable
             // reads from the same path. Loopback bind + Origin/Host checks
             // remain in front; this layer rejects untrusted local processes
             // that could otherwise reach the predictable 127.0.0.1:port endpoint.
-            var tokenPath = System.IO.Path.Combine(SettingsManager.SettingsDirectoryPath, "mcp-token.txt");
-            var authToken = OpenClaw.Shared.Mcp.McpAuthToken.LoadOrCreate(tokenPath);
+            var authToken = OpenClaw.Shared.Mcp.McpAuthToken.LoadOrCreate(McpTokenPath);
             attempt = new McpHttpServer(bridge, McpPort, _logger, authToken);
             attempt.Start();
             _mcpServer = attempt;

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -8,6 +8,8 @@ using Microsoft.UI.Dispatching;
 using OpenClaw.Shared;
 using OpenClaw.Shared.Capabilities;
 using OpenClaw.Shared.Mcp;
+using OpenClawTray.A2UI.Actions;
+using OpenClawTray.A2UI.Rendering;
 using OpenClawTray.Helpers;
 using OpenClawTray.Windows;
 using Microsoft.UI.Xaml;
@@ -25,11 +27,13 @@ public class NodeService : IDisposable
     private readonly SettingsManager? _settings;
     private WindowsNodeClient? _nodeClient;
     private CanvasWindow? _canvasWindow;
+    private A2UICanvasWindow? _a2uiCanvasWindow;
+    private MediaResolver? _mediaResolver;
+    private ActionDispatcher? _actionDispatcher;
     private ScreenCaptureService? _screenCaptureService;
     private ScreenRecordingService? _screenRecordingService;
     private CameraCaptureService? _cameraCaptureService;
     private DateTime _lastScreenCaptureNotification = DateTime.MinValue;
-    private string? _a2uiHostUrl;
     
     // Capabilities
     private SystemCapability? _systemCapability;
@@ -132,8 +136,6 @@ public class NodeService : IDisposable
         RegisterCapabilities();
 
         await _nodeClient.ConnectAsync();
-
-        _a2uiHostUrl = BuildA2UIHostUrl(_nodeClient.GatewayUrl);
     }
 
     /// <summary>
@@ -176,6 +178,12 @@ public class NodeService : IDisposable
             _dispatcherQueue.TryEnqueue(() => _canvasWindow.Close());
             _canvasWindow = null;
         }
+
+        if (_a2uiCanvasWindow != null && !_a2uiCanvasWindow.IsClosed)
+        {
+            _dispatcherQueue.TryEnqueue(() => _a2uiCanvasWindow.Close());
+            _a2uiCanvasWindow = null;
+        }
     }
     
     private void RegisterCapabilities()
@@ -206,6 +214,8 @@ public class NodeService : IDisposable
             _canvasCapability.SnapshotRequested += OnCanvasSnapshot;
             _canvasCapability.A2UIPushRequested += OnCanvasA2UIPush;
             _canvasCapability.A2UIResetRequested += OnCanvasA2UIReset;
+            _canvasCapability.A2UIDumpRequested += OnCanvasA2UIDumpAsync;
+            _canvasCapability.CapsRequested += OnCanvasCapsAsync;
             Register(_canvasCapability);
         }
 
@@ -443,19 +453,23 @@ public class NodeService : IDisposable
         {
             try
             {
+                // Web canvas is taking the foreground — close the native A2UI window so
+                // the user only sees the most-recently-targeted surface (last-write-wins).
+                CloseA2UICanvasWindow();
+
                 // Create or reuse canvas window
                 if (_canvasWindow == null || _canvasWindow.IsClosed)
                 {
                     _canvasWindow = new CanvasWindow();
                     _canvasWindow.SetTrustedGatewayOrigin(GatewayUrl, _token);
                 }
-                
+
                 // Configure window
                 _canvasWindow.Title = args.Title;
                 _canvasWindow.SetSize(args.Width, args.Height);
                 _canvasWindow.SetPosition(args.X, args.Y);
                 _canvasWindow.SetAlwaysOnTop(args.AlwaysOnTop);
-                
+
                 // Load content
                 if (!string.IsNullOrEmpty(args.Url))
                 {
@@ -465,11 +479,11 @@ public class NodeService : IDisposable
                 {
                     _canvasWindow.LoadHtml(args.Html);
                 }
-                
+
                 // Show window
                 _canvasWindow.Activate();
                 _canvasWindow.BringToFront(args.AlwaysOnTop);
-                
+
                 _logger.Info($"Canvas presented: {args.Width}x{args.Height}");
             }
             catch (Exception ex)
@@ -477,6 +491,24 @@ public class NodeService : IDisposable
                 _logger.Error("Canvas present failed", ex);
             }
         });
+    }
+
+    private void CloseWebCanvasWindow()
+    {
+        if (_canvasWindow != null && !_canvasWindow.IsClosed)
+        {
+            try { _canvasWindow.Close(); } catch { /* ignore */ }
+        }
+        _canvasWindow = null;
+    }
+
+    private void CloseA2UICanvasWindow()
+    {
+        if (_a2uiCanvasWindow != null && !_a2uiCanvasWindow.IsClosed)
+        {
+            try { _a2uiCanvasWindow.Close(); } catch { /* ignore */ }
+        }
+        _a2uiCanvasWindow = null;
     }
     
     private void OnCanvasHide(object? sender, EventArgs args)
@@ -511,7 +543,8 @@ public class NodeService : IDisposable
                 }
                 else
                 {
-                    _logger.Warn("Canvas navigate ignored: canvas not available");
+                    // Native A2UI canvas can't navigate to URLs — that's a web-canvas concept.
+                    _logger.Warn("Canvas navigate ignored: web canvas not available (native A2UI surface does not support URL navigation)");
                 }
             }
             catch (Exception ex)
@@ -520,11 +553,11 @@ public class NodeService : IDisposable
             }
         });
     }
-    
+
     private async Task<string> OnCanvasEval(string script)
     {
         var tcs = new TaskCompletionSource<string>();
-        
+
         bool enqueued = _dispatcherQueue.TryEnqueue(async () =>
         {
             try
@@ -534,9 +567,17 @@ public class NodeService : IDisposable
                     var result = await _canvasWindow.EvalAsync(script);
                     tcs.SetResult(result);
                 }
+                else if (_a2uiCanvasWindow != null && !_a2uiCanvasWindow.IsClosed)
+                {
+                    // Native A2UI surface has no JS runtime; surface a structured error
+                    // so callers can branch instead of pattern-matching free-text.
+                    tcs.SetException(new InvalidOperationException(
+                        "CANVAS_EVAL_UNAVAILABLE: native A2UI renderer has no JS runtime; use canvas.a2ui.dump for state introspection"));
+                }
                 else
                 {
-                    tcs.SetException(new InvalidOperationException("Canvas not available"));
+                    tcs.SetException(new InvalidOperationException(
+                        "CANVAS_NOT_OPEN: no canvas window is currently open"));
                 }
             }
             catch (Exception ex)
@@ -545,15 +586,15 @@ public class NodeService : IDisposable
             }
         });
         if (!enqueued)
-            tcs.TrySetException(new InvalidOperationException("Dispatcher queue unavailable"));
-        
+            tcs.TrySetException(new InvalidOperationException("CANVAS_DISPATCHER_UNAVAILABLE: dispatcher queue rejected"));
+
         return await tcs.Task;
     }
-    
+
     private async Task<string> OnCanvasSnapshot(CanvasSnapshotArgs args)
     {
         var tcs = new TaskCompletionSource<string>();
-        
+
         bool enqueued = _dispatcherQueue.TryEnqueue(async () =>
         {
             try
@@ -563,9 +604,17 @@ public class NodeService : IDisposable
                     var base64 = await _canvasWindow.CaptureSnapshotAsync(args.Format);
                     tcs.SetResult(base64);
                 }
+                else if (_a2uiCanvasWindow != null && !_a2uiCanvasWindow.IsClosed)
+                {
+                    // Render the native XAML surface to PNG/JPEG via RenderTargetBitmap
+                    // so vision pipelines and regression diffs keep working post-cutover.
+                    var base64 = await _a2uiCanvasWindow.CaptureSnapshotAsync(args.Format);
+                    tcs.SetResult(base64);
+                }
                 else
                 {
-                    tcs.SetException(new InvalidOperationException("Canvas not available"));
+                    tcs.SetException(new InvalidOperationException(
+                        "CANVAS_NOT_OPEN: no canvas window is currently open"));
                 }
             }
             catch (Exception ex)
@@ -574,9 +623,74 @@ public class NodeService : IDisposable
             }
         });
         if (!enqueued)
-            tcs.TrySetException(new InvalidOperationException("Dispatcher queue unavailable"));
-        
+            tcs.TrySetException(new InvalidOperationException("CANVAS_DISPATCHER_UNAVAILABLE: dispatcher queue rejected"));
+
         return await tcs.Task;
+    }
+
+    private Task<string> OnCanvasA2UIDumpAsync()
+    {
+        var tcs = new TaskCompletionSource<string>();
+        bool enqueued = _dispatcherQueue.TryEnqueue(() =>
+        {
+            try
+            {
+                if (_a2uiCanvasWindow == null || _a2uiCanvasWindow.IsClosed)
+                {
+                    tcs.SetResult(System.Text.Json.JsonSerializer.Serialize(new
+                    {
+                        renderer = "none",
+                        a2uiVersion = "0.8",
+                        surfaceCount = 0,
+                        surfaces = new { },
+                    }));
+                    return;
+                }
+                tcs.SetResult(_a2uiCanvasWindow.GetStateSnapshot());
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+        });
+        if (!enqueued)
+            tcs.TrySetException(new InvalidOperationException("CANVAS_DISPATCHER_UNAVAILABLE: dispatcher queue rejected"));
+        return tcs.Task;
+    }
+
+    private Task<string> OnCanvasCapsAsync()
+    {
+        var tcs = new TaskCompletionSource<string>();
+        bool enqueued = _dispatcherQueue.TryEnqueue(() =>
+        {
+            try
+            {
+                bool nativeOpen = _a2uiCanvasWindow != null && !_a2uiCanvasWindow.IsClosed;
+                bool webOpen = _canvasWindow != null && !_canvasWindow.IsClosed;
+                var caps = new
+                {
+                    renderer = nativeOpen ? "native" : (webOpen ? "web" : "none"),
+                    eval = webOpen,
+                    snapshot = webOpen || nativeOpen,
+                    navigate = webOpen,
+                    a2ui = new
+                    {
+                        version = "0.8",
+                        push = true,
+                        reset = true,
+                        introspect = nativeOpen,
+                    },
+                };
+                tcs.SetResult(System.Text.Json.JsonSerializer.Serialize(caps));
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+        });
+        if (!enqueued)
+            tcs.TrySetException(new InvalidOperationException("CANVAS_DISPATCHER_UNAVAILABLE: dispatcher queue rejected"));
+        return tcs.Task;
     }
 
     private void EnsureCanvasWindow()
@@ -589,54 +703,61 @@ public class NodeService : IDisposable
         }
     }
 
-    private static string? BuildA2UIHostUrl(string? gatewayUrl)
+    /// <summary>
+    /// Lazily build the action dispatcher + media resolver shared by the
+    /// native A2UI canvas. The dispatcher routes outbound user actions to
+    /// the gateway when connected, falling back to a logger-only sink for
+    /// MCP-only mode (a future MCP notifications channel will replace it).
+    /// </summary>
+    private ActionDispatcher GetOrCreateActionDispatcher()
     {
-        if (!GatewayUrlHelper.TryNormalizeWebSocketUrl(gatewayUrl, out var normalizedGatewayUrl))
-            return null;
-        
-        if (!Uri.TryCreate(normalizedGatewayUrl, UriKind.Absolute, out var uri))
-            return null;
-        
-        var scheme = uri.Scheme.Equals("wss", StringComparison.OrdinalIgnoreCase) ? "https" : "http";
-        var port = uri.Port;
-        var host = uri.Host;
-        return $"{scheme}://{host}:{port}/__openclaw__/a2ui/";
+        if (_actionDispatcher != null) return _actionDispatcher;
+
+        var transports = new IA2UIActionTransport[]
+        {
+            new GatewayActionTransport(() => _nodeClient, _logger),
+            new LoggingActionTransport(_logger),
+        };
+        _actionDispatcher = new ActionDispatcher(transports, _logger);
+        return _actionDispatcher;
     }
-    
+
+    private MediaResolver GetOrCreateMediaResolver()
+    {
+        if (_mediaResolver != null) return _mediaResolver;
+        _mediaResolver = new MediaResolver(_logger);
+        return _mediaResolver;
+    }
+
+    private void EnsureA2UICanvasWindow()
+    {
+        if (_a2uiCanvasWindow != null && !_a2uiCanvasWindow.IsClosed) return;
+
+        // Native A2UI is taking the foreground — close the legacy WebView2 canvas
+        // so its placeholder doesn't mask the rendered surface.
+        CloseWebCanvasWindow();
+
+        var actions = GetOrCreateActionDispatcher();
+        var media = GetOrCreateMediaResolver();
+        _a2uiCanvasWindow = new A2UICanvasWindow(actions, media, _logger);
+        _a2uiCanvasWindow.Activate();
+        _a2uiCanvasWindow.BringToFront(false);
+    }
+
     private void OnCanvasA2UIPush(object? sender, CanvasA2UIArgs args)
     {
-        _dispatcherQueue.TryEnqueue(async () =>
+        _dispatcherQueue.TryEnqueue(() =>
         {
             try
             {
-                EnsureCanvasWindow();
-                if (_canvasWindow == null)
+                EnsureA2UICanvasWindow();
+                if (_a2uiCanvasWindow == null)
                 {
-                    _logger.Error("Canvas A2UI push failed: canvas window not available");
+                    _logger.Error("Canvas A2UI push failed: native canvas window not available");
                     return;
                 }
-                
-                var hostUrl = _a2uiHostUrl ?? BuildA2UIHostUrl(GatewayUrl);
-                if (string.IsNullOrWhiteSpace(hostUrl))
-                {
-                    _logger.Error("Canvas A2UI push failed: A2UI host URL unavailable");
-                    return;
-                }
-                
-                await _canvasWindow.EnsureA2UIHostAsync(hostUrl);
-                
-                var jsonl = args.Jsonl ?? string.Empty;
-                var lines = jsonl.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
-                var sent = 0;
-                foreach (var line in lines)
-                {
-                    var trimmed = line.Trim();
-                    if (string.IsNullOrWhiteSpace(trimmed)) continue;
-                    await _canvasWindow.SendA2UIMessageAsync(trimmed);
-                    sent++;
-                }
-                
-                _logger.Info($"Canvas A2UI push: {sent} message(s)");
+                _a2uiCanvasWindow.Push(args.Jsonl ?? string.Empty);
+                _a2uiCanvasWindow.BringToFront(false);
             }
             catch (Exception ex)
             {
@@ -644,26 +765,19 @@ public class NodeService : IDisposable
             }
         });
     }
-    
+
     private void OnCanvasA2UIReset(object? sender, EventArgs args)
     {
-        _dispatcherQueue.TryEnqueue(async () =>
+        _dispatcherQueue.TryEnqueue(() =>
         {
             try
             {
-                if (_canvasWindow == null || _canvasWindow.IsClosed)
+                if (_a2uiCanvasWindow == null || _a2uiCanvasWindow.IsClosed)
                 {
-                    _logger.Warn("Canvas A2UI reset ignored: canvas not available");
+                    _logger.Debug("Canvas A2UI reset: no native canvas to reset");
                     return;
                 }
-                
-                var hostUrl = _a2uiHostUrl ?? BuildA2UIHostUrl(GatewayUrl);
-                if (!string.IsNullOrWhiteSpace(hostUrl))
-                {
-                    await _canvasWindow.EnsureA2UIHostAsync(hostUrl);
-                }
-                
-                await _canvasWindow.ResetA2UIAsync();
+                _a2uiCanvasWindow.Reset();
                 _logger.Info("Canvas A2UI reset");
             }
             catch (Exception ex)
@@ -820,6 +934,13 @@ public class NodeService : IDisposable
         {
             var window = _canvasWindow;
             _canvasWindow = null;
+            _dispatcherQueue.TryEnqueue(() => { try { window?.Close(); } catch { } });
+        }
+
+        if (_a2uiCanvasWindow != null && !_a2uiCanvasWindow.IsClosed)
+        {
+            var window = _a2uiCanvasWindow;
+            _a2uiCanvasWindow = null;
             _dispatcherQueue.TryEnqueue(() => { try { window?.Close(); } catch { } });
         }
     }

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -94,6 +94,11 @@ public sealed class NodeService : IDisposable
         int.TryParse(Environment.GetEnvironmentVariable("OPENCLAW_MCP_PORT"), out var p) && p > 0
             ? p
             : McpDefaultPort;
+    private static readonly bool SuppressExternalBrowserLaunches =
+        string.Equals(
+            Environment.GetEnvironmentVariable("OPENCLAW_SUPPRESS_EXTERNAL_BROWSER"),
+            "1",
+            StringComparison.Ordinal);
     public static string McpServerUrl => $"http://127.0.0.1:{McpPort}/";
     /// <summary>
     /// Path of the MCP bearer-token file. The file is created on first MCP server
@@ -793,6 +798,12 @@ public sealed class NodeService : IDisposable
     /// </summary>
     private void LaunchInDefaultBrowser(string canonical)
     {
+        if (SuppressExternalBrowserLaunches)
+        {
+            _logger.Info($"Canvas navigate suppressed external browser launch: {OpenClaw.Shared.UrlLogSanitizer.Sanitize(canonical)}");
+            return;
+        }
+
         // Process.Start with UseShellExecute=true wraps ShellExecuteEx, which
         // routes the URL to the user's registered http/https handler — never
         // to a script host or file association — given the validator already

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -27,6 +27,10 @@ public class NodeService : IDisposable
     private readonly SettingsManager? _settings;
     private WindowsNodeClient? _nodeClient;
     private CanvasWindow? _canvasWindow;
+    // Invariant: _a2uiCanvasWindow is only read/written from the UI dispatcher
+    // (DispatcherQueue.TryEnqueue callbacks). Today's WinUI dispatcher serializes,
+    // so no memory barrier is needed — but introducing a non-dispatcher caller
+    // would silently see stale references. Stay on-thread or marshal.
     private A2UICanvasWindow? _a2uiCanvasWindow;
     private MediaResolver? _mediaResolver;
     private ActionDispatcher? _actionDispatcher;
@@ -302,7 +306,15 @@ public class NodeService : IDisposable
                 _logger,
                 serverName: "openclaw-tray-mcp",
                 serverVersion: typeof(NodeService).Assembly.GetName().Version?.ToString() ?? "0.0.0");
-            attempt = new McpHttpServer(bridge, McpPort, _logger);
+            // Bearer-token auth. Token is created on first start and persists
+            // alongside other OpenClawTray data (so OPENCLAW_TRAY_DATA_DIR
+            // isolation in tests scopes the token too); CLI/agent registration
+            // reads from the same path. Loopback bind + Origin/Host checks
+            // remain in front; this layer rejects untrusted local processes
+            // that could otherwise reach the predictable 127.0.0.1:port endpoint.
+            var tokenPath = System.IO.Path.Combine(SettingsManager.SettingsDirectoryPath, "mcp-token.txt");
+            var authToken = OpenClaw.Shared.Mcp.McpAuthToken.LoadOrCreate(tokenPath);
+            attempt = new McpHttpServer(bridge, McpPort, _logger, authToken);
             attempt.Start();
             _mcpServer = attempt;
             _mcpStartupError = null;
@@ -556,7 +568,7 @@ public class NodeService : IDisposable
 
     private async Task<string> OnCanvasEval(string script)
     {
-        var tcs = new TaskCompletionSource<string>();
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         bool enqueued = _dispatcherQueue.TryEnqueue(async () =>
         {
@@ -565,24 +577,24 @@ public class NodeService : IDisposable
                 if (_canvasWindow != null && !_canvasWindow.IsClosed)
                 {
                     var result = await _canvasWindow.EvalAsync(script);
-                    tcs.SetResult(result);
+                    tcs.TrySetResult(result);
                 }
                 else if (_a2uiCanvasWindow != null && !_a2uiCanvasWindow.IsClosed)
                 {
                     // Native A2UI surface has no JS runtime; surface a structured error
                     // so callers can branch instead of pattern-matching free-text.
-                    tcs.SetException(new InvalidOperationException(
+                    tcs.TrySetException(new InvalidOperationException(
                         "CANVAS_EVAL_UNAVAILABLE: native A2UI renderer has no JS runtime; use canvas.a2ui.dump for state introspection"));
                 }
                 else
                 {
-                    tcs.SetException(new InvalidOperationException(
+                    tcs.TrySetException(new InvalidOperationException(
                         "CANVAS_NOT_OPEN: no canvas window is currently open"));
                 }
             }
             catch (Exception ex)
             {
-                tcs.SetException(ex);
+                tcs.TrySetException(ex);
             }
         });
         if (!enqueued)
@@ -593,7 +605,7 @@ public class NodeService : IDisposable
 
     private async Task<string> OnCanvasSnapshot(CanvasSnapshotArgs args)
     {
-        var tcs = new TaskCompletionSource<string>();
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         bool enqueued = _dispatcherQueue.TryEnqueue(async () =>
         {
@@ -602,24 +614,24 @@ public class NodeService : IDisposable
                 if (_canvasWindow != null && !_canvasWindow.IsClosed)
                 {
                     var base64 = await _canvasWindow.CaptureSnapshotAsync(args.Format);
-                    tcs.SetResult(base64);
+                    tcs.TrySetResult(base64);
                 }
                 else if (_a2uiCanvasWindow != null && !_a2uiCanvasWindow.IsClosed)
                 {
                     // Render the native XAML surface to PNG/JPEG via RenderTargetBitmap
                     // so vision pipelines and regression diffs keep working post-cutover.
                     var base64 = await _a2uiCanvasWindow.CaptureSnapshotAsync(args.Format);
-                    tcs.SetResult(base64);
+                    tcs.TrySetResult(base64);
                 }
                 else
                 {
-                    tcs.SetException(new InvalidOperationException(
+                    tcs.TrySetException(new InvalidOperationException(
                         "CANVAS_NOT_OPEN: no canvas window is currently open"));
                 }
             }
             catch (Exception ex)
             {
-                tcs.SetException(ex);
+                tcs.TrySetException(ex);
             }
         });
         if (!enqueued)
@@ -630,14 +642,14 @@ public class NodeService : IDisposable
 
     private Task<string> OnCanvasA2UIDumpAsync()
     {
-        var tcs = new TaskCompletionSource<string>();
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         bool enqueued = _dispatcherQueue.TryEnqueue(() =>
         {
             try
             {
                 if (_a2uiCanvasWindow == null || _a2uiCanvasWindow.IsClosed)
                 {
-                    tcs.SetResult(System.Text.Json.JsonSerializer.Serialize(new
+                    tcs.TrySetResult(System.Text.Json.JsonSerializer.Serialize(new
                     {
                         renderer = "none",
                         a2uiVersion = "0.8",
@@ -646,11 +658,11 @@ public class NodeService : IDisposable
                     }));
                     return;
                 }
-                tcs.SetResult(_a2uiCanvasWindow.GetStateSnapshot());
+                tcs.TrySetResult(_a2uiCanvasWindow.GetStateSnapshot());
             }
             catch (Exception ex)
             {
-                tcs.SetException(ex);
+                tcs.TrySetException(ex);
             }
         });
         if (!enqueued)
@@ -660,7 +672,7 @@ public class NodeService : IDisposable
 
     private Task<string> OnCanvasCapsAsync()
     {
-        var tcs = new TaskCompletionSource<string>();
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         bool enqueued = _dispatcherQueue.TryEnqueue(() =>
         {
             try
@@ -681,11 +693,11 @@ public class NodeService : IDisposable
                         introspect = nativeOpen,
                     },
                 };
-                tcs.SetResult(System.Text.Json.JsonSerializer.Serialize(caps));
+                tcs.TrySetResult(System.Text.Json.JsonSerializer.Serialize(caps));
             }
             catch (Exception ex)
             {
-                tcs.SetException(ex);
+                tcs.TrySetException(ex);
             }
         });
         if (!enqueued)
@@ -726,6 +738,12 @@ public class NodeService : IDisposable
     {
         if (_mediaResolver != null) return _mediaResolver;
         _mediaResolver = new MediaResolver(_logger);
+        // Settings.A2UIImageHosts is the single source of truth for HTTPS image
+        // fetching. Empty list = inline data: only, which is the safe default.
+        if (_settings?.A2UIImageHosts is { Count: > 0 } hosts)
+        {
+            foreach (var host in hosts) _mediaResolver.AllowHost(host);
+        }
         return _mediaResolver;
     }
 

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -58,7 +58,13 @@ public class NodeService : IDisposable
     // "Deferred"), McpServerUrl needs to read the live port off the running
     // server, not the constant. Settings UI is the only consumer today.
     public const int McpDefaultPort = 8765;
-    public static string McpServerUrl => $"http://127.0.0.1:{McpDefaultPort}/";
+    // OPENCLAW_MCP_PORT lets test instances bind a free port instead of fighting
+    // over the default. Falls back to McpDefaultPort when unset or unparseable.
+    private static readonly int McpPort =
+        int.TryParse(Environment.GetEnvironmentVariable("OPENCLAW_MCP_PORT"), out var p) && p > 0
+            ? p
+            : McpDefaultPort;
+    public static string McpServerUrl => $"http://127.0.0.1:{McpPort}/";
     private readonly bool _enableMcpServer;
     private McpHttpServer? _mcpServer;
     private string? _mcpStartupError;
@@ -286,7 +292,7 @@ public class NodeService : IDisposable
                 _logger,
                 serverName: "openclaw-tray-mcp",
                 serverVersion: typeof(NodeService).Assembly.GetName().Version?.ToString() ?? "0.0.0");
-            attempt = new McpHttpServer(bridge, McpDefaultPort, _logger);
+            attempt = new McpHttpServer(bridge, McpPort, _logger);
             attempt.Start();
             _mcpServer = attempt;
             _mcpStartupError = null;
@@ -296,8 +302,8 @@ public class NodeService : IDisposable
             // Categorize so Settings can show something actionable instead of
             // raw HRESULT text. HttpListener errors on Windows fall into a
             // small set of recurring causes on developer machines.
-            _mcpStartupError = DescribeMcpStartupFailure(ex, McpDefaultPort);
-            _logger.Error($"[MCP] Failed to start HTTP server on port {McpDefaultPort}: {_mcpStartupError}", ex);
+            _mcpStartupError = DescribeMcpStartupFailure(ex, McpPort);
+            _logger.Error($"[MCP] Failed to start HTTP server on port {McpPort}: {_mcpStartupError}", ex);
             // Avoid leaking the half-constructed listener / CTS.
             try { attempt?.Dispose(); } catch { /* ignore */ }
             _mcpServer = null;

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -550,27 +550,60 @@ public class NodeService : IDisposable
         });
     }
     
-    private void OnCanvasNavigate(object? sender, string url)
+    /// <summary>
+    /// Service a <c>canvas.navigate</c> request by launching the URL in the
+    /// OS default browser. Always — even if a WebView2 canvas window is open.
+    /// Rationale: "open this link" on Windows means the default browser, and
+    /// the embedded WebView2 canvas runs URL-rewriting (gateway-origin pinning,
+    /// CSP, etc.) that mangles arbitrary external URLs. Agents that want to
+    /// load a page inside an embedded surface should use <c>canvas.present</c>.
+    ///
+    /// CanvasCapability has already validated the URL with HttpUrlValidator;
+    /// we re-validate here as defense-in-depth so the OS-level shell-execute
+    /// can never see an unvetted string.
+    /// </summary>
+    private Task<string> OnCanvasNavigate(string url)
     {
+        if (!HttpUrlValidator.TryParse(url, out var canonical, out var validationError))
+        {
+            _logger.Warn($"OnCanvasNavigate rejected (validator): {validationError}");
+            return Task.FromException<string>(new InvalidOperationException($"Invalid url: {validationError}"));
+        }
+
+        // Hand off to the OS default browser, then close any open in-app canvas
+        // windows: the user's attention is moving to the browser, so leaving an
+        // embedded canvas (web or A2UI) open is just clutter — and worse, an
+        // earlier canvas.present for the same URL would otherwise leave a
+        // misrendered gateway-pinned page sitting in the WebView2 host.
+        //
+        // Process.Start with UseShellExecute=true wraps ShellExecuteEx, which
+        // routes the URL to the user's registered http/https handler — never
+        // to a script host or file association — given the validator already
+        // restricted the scheme. Browser launch doesn't need the UI dispatcher;
+        // the canvas-window cleanup does.
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = canonical!,
+                UseShellExecute = true,
+            };
+            using var proc = System.Diagnostics.Process.Start(psi);
+            _logger.Info($"Canvas navigate → default browser: {canonical}");
+        }
+        catch (Exception ex)
+        {
+            _logger.Error("Canvas navigate failed", ex);
+            return Task.FromException<string>(ex);
+        }
+
         _dispatcherQueue.TryEnqueue(() =>
         {
-            try
-            {
-                if (_canvasWindow != null && !_canvasWindow.IsClosed)
-                {
-                    _canvasWindow.Navigate(url);
-                }
-                else
-                {
-                    // Native A2UI canvas can't navigate to URLs — that's a web-canvas concept.
-                    _logger.Warn("Canvas navigate ignored: web canvas not available (native A2UI surface does not support URL navigation)");
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.Error("Canvas navigate failed", ex);
-            }
+            try { CloseWebCanvasWindow(); } catch (Exception ex) { _logger.Warn($"Close web canvas after navigate failed: {ex.Message}"); }
+            try { CloseA2UICanvasWindow(); } catch (Exception ex) { _logger.Warn($"Close A2UI canvas after navigate failed: {ex.Message}"); }
         });
+
+        return Task.FromResult("browser");
     }
 
     private async Task<string> OnCanvasEval(string script)
@@ -691,7 +724,11 @@ public class NodeService : IDisposable
                     renderer = nativeOpen ? "native" : (webOpen ? "web" : "none"),
                     eval = webOpen,
                     snapshot = webOpen || nativeOpen,
-                    navigate = webOpen,
+                    // navigate is always available: when no web canvas is open
+                    // we fall back to launching the OS default browser. The
+                    // navigate response carries an "opener" field so the agent
+                    // can tell which path was taken.
+                    navigate = true,
                     a2ui = new
                     {
                         version = "0.8",
@@ -722,6 +759,26 @@ public class NodeService : IDisposable
         }
     }
 
+    // Mutable context shared with GatewayActionTransport. SessionKey is updated
+    // from push props (when the agent supplies one); host/instance stay tied to
+    // the node client identity. Default sessionKey is "main", matching Android's
+    // resolveMainSessionKey() fallback.
+    private sealed class GatewayActionContext : IGatewayActionContext
+    {
+        private readonly Func<WindowsNodeClient?> _client;
+        private string _sessionKey = "main";
+        public GatewayActionContext(Func<WindowsNodeClient?> client) { _client = client; }
+        public string SessionKey
+        {
+            get => _sessionKey;
+            set => _sessionKey = string.IsNullOrWhiteSpace(value) ? "main" : value.Trim();
+        }
+        public string Host => _client()?.DisplayName ?? $"Windows Node ({Environment.MachineName})";
+        public string InstanceId => _client()?.FullDeviceId.ToLowerInvariant() ?? string.Empty;
+    }
+
+    private GatewayActionContext? _actionContext;
+
     /// <summary>
     /// Lazily build the action dispatcher + media resolver shared by the
     /// native A2UI canvas. The dispatcher routes outbound user actions to
@@ -732,13 +789,42 @@ public class NodeService : IDisposable
     {
         if (_actionDispatcher != null) return _actionDispatcher;
 
+        _actionContext = new GatewayActionContext(() => _nodeClient);
         var transports = new IA2UIActionTransport[]
         {
-            new GatewayActionTransport(() => _nodeClient, _logger),
+            new GatewayActionTransport(() => _nodeClient, _actionContext, _logger),
             new LoggingActionTransport(_logger),
         };
         _actionDispatcher = new ActionDispatcher(transports, _logger);
         return _actionDispatcher;
+    }
+
+    /// <summary>
+    /// Pull <c>sessionKey</c> out of the push props blob and update the action
+    /// context so subsequent button clicks route to the same session. Silently
+    /// no-ops when props is malformed or doesn't include a sessionKey — the
+    /// previous (or default "main") value stays in effect.
+    /// </summary>
+    private void UpdateSessionKeyFromPushProps(string? propsJson)
+    {
+        if (_actionContext == null) return;
+        if (string.IsNullOrWhiteSpace(propsJson)) return;
+        try
+        {
+            using var doc = JsonDocument.Parse(propsJson);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object &&
+                doc.RootElement.TryGetProperty("sessionKey", out var sk) &&
+                sk.ValueKind == JsonValueKind.String)
+            {
+                var v = sk.GetString();
+                if (!string.IsNullOrWhiteSpace(v)) _actionContext.SessionKey = v!;
+            }
+        }
+        catch
+        {
+            // Bad props JSON is a gateway/agent bug, not an action-routing bug.
+            // Keep the previous sessionKey rather than failing the push.
+        }
     }
 
     private MediaResolver GetOrCreateMediaResolver()
@@ -781,6 +867,9 @@ public class NodeService : IDisposable
                     _logger.Error("Canvas A2UI push failed: native canvas window not available");
                     return;
                 }
+                // Pick up an explicit sessionKey from props if the agent supplied one,
+                // so a Button click on this surface routes back to the same session.
+                UpdateSessionKeyFromPushProps(args.Props);
                 _a2uiCanvasWindow.Push(args.Jsonl ?? string.Empty);
                 _a2uiCanvasWindow.BringToFront(false);
             }

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -38,6 +38,7 @@ public class NodeService : IDisposable
     private ScreenRecordingService? _screenRecordingService;
     private CameraCaptureService? _cameraCaptureService;
     private DateTime _lastScreenCaptureNotification = DateTime.MinValue;
+    private readonly HashSet<string> _allowedNavigationHosts = new(StringComparer.OrdinalIgnoreCase);
     
     // Capabilities
     private SystemCapability? _systemCapability;
@@ -366,6 +367,14 @@ public class NodeService : IDisposable
         _mcpStartupError = null;
     }
 
+    public string ResetMcpToken()
+    {
+        var token = McpAuthToken.Reset(McpTokenPath);
+        _mcpServer?.UpdateAuthToken(token);
+        _logger.Info("[MCP] Bearer token rotated");
+        return token;
+    }
+
     public GatewayNodeInfo? GetLocalNodeInfo()
     {
         if (_nodeClient == null)
@@ -567,15 +576,69 @@ public class NodeService : IDisposable
         if (!HttpUrlValidator.TryParse(url, out var canonical, out var validationError))
         {
             _logger.Warn($"OnCanvasNavigate rejected (validator): {validationError}");
-            return Task.FromException<string>(new InvalidOperationException($"Invalid url: {validationError}"));
+            throw new InvalidOperationException($"Invalid url: {validationError}");
         }
 
-        // Hand off to the OS default browser, then close any open in-app canvas
-        // windows: the user's attention is moving to the browser, so leaving an
-        // embedded canvas (web or A2UI) open is just clutter — and worse, an
-        // earlier canvas.present for the same URL would otherwise leave a
-        // misrendered gateway-pinned page sitting in the WebView2 host.
-        //
+        var risk = HttpUrlRiskEvaluator.Evaluate(canonical!);
+        var requiresPrompt =
+            risk.RequiresConfirmation && !_allowedNavigationHosts.Contains(risk.HostKey);
+
+        // The agent gets the same response shape and the same response time
+        // whether or not a confirmation prompt is needed. If we awaited the
+        // prompt here, response latency would leak the user's decision time
+        // (or even the existence of a prompt). Fire the prompt+launch off as
+        // a background task and return the synthesized success immediately.
+        if (requiresPrompt)
+        {
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    var decision = await new UrlNavigationApprovalService(_logger)
+                        .RequestAsync(risk, BuildNavigationAgentIdentity())
+                        .ConfigureAwait(false);
+
+                    if (decision.Kind == UrlNavigationApprovalDecisionKind.Deny)
+                    {
+                        _logger.Warn($"Canvas navigate denied: {risk.CanonicalOrigin} ({decision.Reason ?? "user denied"}); already reported success to agent");
+                        return;
+                    }
+
+                    if (decision.Kind == UrlNavigationApprovalDecisionKind.AllowHost)
+                    {
+                        _allowedNavigationHosts.Add(risk.HostKey);
+                        _logger.Info($"Canvas navigate host allowlisted for this session: {risk.HostKey}");
+                    }
+
+                    LaunchAndCleanup(canonical!);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error("Canvas navigate (deferred) failed", ex);
+                }
+            });
+        }
+        else
+        {
+            // Low-risk path runs synchronously (still very fast — Process.Start
+            // doesn't wait for the browser to render). The constant-time
+            // contract is "high-risk paths don't reveal user choice", not
+            // "high- and low-risk are indistinguishable" — the URL and risk
+            // profile are the agent's own input, so it already knows which
+            // path applies.
+            LaunchAndCleanup(canonical!);
+        }
+
+        return Task.FromResult("browser");
+    }
+
+    /// <summary>
+    /// Hand off to the OS default browser via ShellExecuteEx, then close any
+    /// open in-app canvas surfaces (web or A2UI) on the dispatcher. Failures
+    /// are logged but never thrown — callers expect a fire-and-forget shape.
+    /// </summary>
+    private void LaunchAndCleanup(string canonical)
+    {
         // Process.Start with UseShellExecute=true wraps ShellExecuteEx, which
         // routes the URL to the user's registered http/https handler — never
         // to a script host or file association — given the validator already
@@ -585,7 +648,7 @@ public class NodeService : IDisposable
         {
             var psi = new System.Diagnostics.ProcessStartInfo
             {
-                FileName = canonical!,
+                FileName = canonical,
                 UseShellExecute = true,
             };
             using var proc = System.Diagnostics.Process.Start(psi);
@@ -594,7 +657,6 @@ public class NodeService : IDisposable
         catch (Exception ex)
         {
             _logger.Error("Canvas navigate failed", ex);
-            return Task.FromException<string>(ex);
         }
 
         _dispatcherQueue.TryEnqueue(() =>
@@ -602,8 +664,15 @@ public class NodeService : IDisposable
             try { CloseWebCanvasWindow(); } catch (Exception ex) { _logger.Warn($"Close web canvas after navigate failed: {ex.Message}"); }
             try { CloseA2UICanvasWindow(); } catch (Exception ex) { _logger.Warn($"Close A2UI canvas after navigate failed: {ex.Message}"); }
         });
+    }
 
-        return Task.FromResult("browser");
+    private string BuildNavigationAgentIdentity()
+    {
+        var device = _nodeClient?.ShortDeviceId ?? _nodeClient?.FullDeviceId ?? "local MCP";
+        var gateway = _nodeClient?.GatewayUrl;
+        return string.IsNullOrWhiteSpace(gateway)
+            ? device
+            : $"{device} via {GatewayUrlHelper.SanitizeForDisplay(gateway)}";
     }
 
     private async Task<string> OnCanvasEval(string script)
@@ -1059,4 +1128,3 @@ public class NodeService : IDisposable
         }
     }
 }
-

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -43,6 +43,23 @@ public sealed class NodeService : IDisposable
     // set; value byte is unused.
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, byte> _allowedNavigationHosts =
         new(StringComparer.OrdinalIgnoreCase);
+
+    // Navigation-prompt rate-limit / coalescing state. A token-holding agent
+    // looping canvas.navigate could otherwise stack arbitrarily many topmost
+    // MessageBoxW prompts.
+    //   _navigationPromptGate: only one prompt visible at a time across all hosts.
+    //   _pendingNavigationPrompts: in-flight prompt per HostKey — a second
+    //     request for the same host inherits the user's decision instead of
+    //     queueing a duplicate prompt.
+    //   _navigationDenyCooldown: HostKey → expiresAt. After a Deny, repeated
+    //     requests for the same host auto-deny silently for the cooldown
+    //     window so a hostile loop can't keep nagging the user.
+    private readonly SemaphoreSlim _navigationPromptGate = new(1, 1);
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, Task<UrlNavigationApprovalDecision>> _pendingNavigationPrompts =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, DateTimeOffset> _navigationDenyCooldown =
+        new(StringComparer.OrdinalIgnoreCase);
+    private static readonly TimeSpan NavigationDenyCooldownDuration = TimeSpan.FromSeconds(30);
     
     // Capabilities
     private SystemCapability? _systemCapability;
@@ -612,43 +629,15 @@ public sealed class NodeService : IDisposable
         {
             try
             {
-                // Pin DNS at approval time. A bare hostname like "example.com"
-                // would otherwise pass HttpUrlRiskEvaluator (since only IP
-                // literals are inspected) and hand-off to the browser without
-                // ever checking what IP it actually resolves to. A hostile DNS
-                // could point a public-looking name at an internal address.
+                // Best-effort triage: resolve DNS now so a hostname pointing at
+                // an internal IP raises the prompt. This is NOT a pin on the
+                // launched request — the OS browser performs its own DNS
+                // resolution when handed the URL, so the actual trust boundary
+                // is the user's browser zone/proxy config. A second resolve
+                // immediately before ShellExecute would not change that.
                 var pinnedRisk = await EnrichWithDnsRiskAsync(initialRisk).ConfigureAwait(false);
-                var requiresPrompt =
-                    pinnedRisk.RequiresConfirmation && !_allowedNavigationHosts.ContainsKey(pinnedRisk.HostKey);
-
-                if (requiresPrompt)
-                {
-                    var decision = await new UrlNavigationApprovalService(_logger)
-                        .RequestAsync(pinnedRisk, BuildNavigationAgentIdentity())
-                        .ConfigureAwait(false);
-
-                    if (decision.Kind == UrlNavigationApprovalDecisionKind.Deny)
-                    {
-                        _logger.Warn($"Canvas navigate denied: {OpenClaw.Shared.UrlLogSanitizer.Sanitize(pinnedRisk.CanonicalOrigin)} ({decision.Reason ?? "user denied"}); already reported success to agent");
-                        return;
-                    }
-
-                    // AllowHost (session-allowlist) is currently unreachable from
-                    // the Win32 prompt — Yes maps to AllowOnce only. The session
-                    // allowlist remains in NodeService as scaffolding for a future
-                    // Fluent ContentDialog prompt (worklist T2-43).
-                }
-
-                // Re-resolve immediately before launch so a TTL-1 record can't
-                // flip the resolved IP between approval and shell-execute.
-                var preLaunchRisk = await EnrichWithDnsRiskAsync(initialRisk).ConfigureAwait(false);
-                if (preLaunchRisk.RequiresConfirmation && !_allowedNavigationHosts.ContainsKey(preLaunchRisk.HostKey))
-                {
-                    _logger.Warn($"Canvas navigate aborted at launch: pre-launch DNS re-check flagged {OpenClaw.Shared.UrlLogSanitizer.Sanitize(preLaunchRisk.CanonicalOrigin)}");
-                    return;
-                }
-
-                LaunchInDefaultBrowser(canonical!);
+                if (await ShouldLaunchAfterPromptAsync(pinnedRisk).ConfigureAwait(false))
+                    LaunchInDefaultBrowser(canonical!);
             }
             catch (Exception ex)
             {
@@ -661,6 +650,102 @@ public sealed class NodeService : IDisposable
         // prompt here, response latency would leak the user's decision time
         // (or even the existence of a prompt).
         return Task.FromResult("browser");
+    }
+
+    /// <summary>
+    /// Decide whether to launch given an enriched risk profile, prompting the
+    /// user when required while bounding prompt frequency:
+    ///   - HostKey in the deny cooldown → silently refuse (recent denial).
+    ///   - HostKey already in the session allowlist → launch.
+    ///   - Concurrent request for the same HostKey → await the existing prompt
+    ///     and inherit its decision rather than stacking a duplicate prompt.
+    ///   - Otherwise: hold the global single-prompt gate, show the prompt,
+    ///     record cooldown on Deny.
+    /// </summary>
+    private async Task<bool> ShouldLaunchAfterPromptAsync(HttpUrlRiskProfile pinnedRisk)
+    {
+        if (!pinnedRisk.RequiresConfirmation || _allowedNavigationHosts.ContainsKey(pinnedRisk.HostKey))
+            return true;
+
+        if (_navigationDenyCooldown.TryGetValue(pinnedRisk.HostKey, out var expiresAt))
+        {
+            if (DateTimeOffset.UtcNow < expiresAt)
+            {
+                _logger.Warn($"Canvas navigate auto-denied (cooldown): {OpenClaw.Shared.UrlLogSanitizer.Sanitize(pinnedRisk.CanonicalOrigin)}");
+                return false;
+            }
+            // Stale entry — drop it. A racing concurrent request can re-add via
+            // the deny path below; this is just opportunistic cleanup.
+            _navigationDenyCooldown.TryRemove(pinnedRisk.HostKey, out _);
+        }
+
+        // Coalesce: if a prompt is already pending for this host, await its
+        // outcome instead of showing a second prompt for the same destination.
+        // Use a TaskCompletionSource so all waiters resolve atomically.
+        var tcs = new TaskCompletionSource<UrlNavigationApprovalDecision>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var existing = _pendingNavigationPrompts.GetOrAdd(pinnedRisk.HostKey, tcs.Task);
+        if (!ReferenceEquals(existing, tcs.Task))
+        {
+            var inherited = await existing.ConfigureAwait(false);
+            return inherited.Kind != UrlNavigationApprovalDecisionKind.Deny;
+        }
+
+        try
+        {
+            // Serialize prompt display globally — multiple HostKeys racing must
+            // not stack overlapping topmost MessageBoxes either.
+            await _navigationPromptGate.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                // Re-check cooldown / allowlist now that we hold the gate — a
+                // prior prompt's Deny may have populated the cooldown while we
+                // were queued.
+                if (_allowedNavigationHosts.ContainsKey(pinnedRisk.HostKey))
+                {
+                    var allowDecision = UrlNavigationApprovalDecision.AllowOnce();
+                    tcs.TrySetResult(allowDecision);
+                    return true;
+                }
+                if (_navigationDenyCooldown.TryGetValue(pinnedRisk.HostKey, out var nowExpires)
+                    && DateTimeOffset.UtcNow < nowExpires)
+                {
+                    var denyDecision = UrlNavigationApprovalDecision.Deny("cooldown");
+                    tcs.TrySetResult(denyDecision);
+                    _logger.Warn($"Canvas navigate auto-denied (cooldown): {OpenClaw.Shared.UrlLogSanitizer.Sanitize(pinnedRisk.CanonicalOrigin)}");
+                    return false;
+                }
+
+                var decision = await new UrlNavigationApprovalService(_logger)
+                    .RequestAsync(pinnedRisk, BuildNavigationAgentIdentity())
+                    .ConfigureAwait(false);
+                tcs.TrySetResult(decision);
+
+                if (decision.Kind == UrlNavigationApprovalDecisionKind.Deny)
+                {
+                    _navigationDenyCooldown[pinnedRisk.HostKey] = DateTimeOffset.UtcNow + NavigationDenyCooldownDuration;
+                    _logger.Warn($"Canvas navigate denied: {OpenClaw.Shared.UrlLogSanitizer.Sanitize(pinnedRisk.CanonicalOrigin)} ({decision.Reason ?? "user denied"}); already reported success to agent");
+                    return false;
+                }
+                // AllowHost (session-allowlist) is currently unreachable from
+                // the Win32 prompt — Yes maps to AllowOnce only. The session
+                // allowlist remains as scaffolding for a future Fluent
+                // ContentDialog prompt (worklist T2-43).
+                return true;
+            }
+            finally
+            {
+                _navigationPromptGate.Release();
+            }
+        }
+        catch (Exception ex)
+        {
+            tcs.TrySetException(ex);
+            throw;
+        }
+        finally
+        {
+            _pendingNavigationPrompts.TryRemove(pinnedRisk.HostKey, out _);
+        }
     }
 
     /// <summary>
@@ -1190,6 +1275,8 @@ public sealed class NodeService : IDisposable
         // handle survives node teardown/recreate.
         try { _actionDispatcher?.Dispose(); } catch { /* ignore */ }
         _actionDispatcher = null;
+
+        try { _navigationPromptGate.Dispose(); } catch { /* ignore */ }
 
         if (_canvasWindow != null && !_canvasWindow.IsClosed)
         {

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -19,7 +19,7 @@ namespace OpenClawTray.Services;
 /// <summary>
 /// Windows Node service - manages node connection and capabilities
 /// </summary>
-public class NodeService : IDisposable
+public sealed class NodeService : IDisposable
 {
     private readonly IOpenClawLogger _logger;
     private readonly DispatcherQueue _dispatcherQueue;
@@ -38,7 +38,11 @@ public class NodeService : IDisposable
     private ScreenRecordingService? _screenRecordingService;
     private CameraCaptureService? _cameraCaptureService;
     private DateTime _lastScreenCaptureNotification = DateTime.MinValue;
-    private readonly HashSet<string> _allowedNavigationHosts = new(StringComparer.OrdinalIgnoreCase);
+    // Concurrent navigates from rapid-fire agent requests can race on the
+    // bucket structure of a HashSet. Use ConcurrentDictionary as a thread-safe
+    // set; value byte is unused.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, byte> _allowedNavigationHosts =
+        new(StringComparer.OrdinalIgnoreCase);
     
     // Capabilities
     private SystemCapability? _systemCapability;
@@ -322,6 +326,13 @@ public class NodeService : IDisposable
             // remain in front; this layer rejects untrusted local processes
             // that could otherwise reach the predictable 127.0.0.1:port endpoint.
             var authToken = OpenClaw.Shared.Mcp.McpAuthToken.LoadOrCreate(McpTokenPath);
+            // ACL hygiene check: warn if the token file is owned by someone
+            // else, or if the DACL grants read to anyone outside
+            // {current user, SYSTEM, Administrators}. Warning-only — restricting
+            // ACLs is best-effort and a malicious local user can already do
+            // worse than read this file. The point is operator visibility.
+            var aclWarning = OpenClaw.Shared.Mcp.McpAuthToken.VerifyAcl(McpTokenPath);
+            if (aclWarning != null) _logger.Warn($"[MCP] {aclWarning}");
             attempt = new McpHttpServer(bridge, McpPort, _logger, authToken);
             attempt.Start();
             _mcpServer = attempt;
@@ -435,7 +446,13 @@ public class NodeService : IDisposable
     
     private void OnPairingStatusChanged(object? sender, PairingStatusEventArgs args)
     {
-        _logger.Info($"Pairing status changed: {args.Status} (device: {args.DeviceId.Substring(0, 16)}...)");
+        // Guard the slice — a malformed/missing/short device id would otherwise
+        // throw out of the event handler and suppress PairingStatusChanged,
+        // hiding the very pairing problem the listener is trying to diagnose.
+        var displayId = string.IsNullOrEmpty(args.DeviceId)
+            ? "unknown"
+            : args.DeviceId[..Math.Min(16, args.DeviceId.Length)];
+        _logger.Info($"Pairing status changed: {args.Status} (device: {displayId}...)");
         PairingStatusChanged?.Invoke(this, args);
     }
 
@@ -579,57 +596,103 @@ public class NodeService : IDisposable
             throw new InvalidOperationException($"Invalid url: {validationError}");
         }
 
-        var risk = HttpUrlRiskEvaluator.Evaluate(canonical!);
-        var requiresPrompt =
-            risk.RequiresConfirmation && !_allowedNavigationHosts.Contains(risk.HostKey);
+        var initialRisk = HttpUrlRiskEvaluator.Evaluate(canonical!);
 
-        // The agent gets the same response shape and the same response time
-        // whether or not a confirmation prompt is needed. If we awaited the
-        // prompt here, response latency would leak the user's decision time
-        // (or even the existence of a prompt). Fire the prompt+launch off as
-        // a background task and return the synthesized success immediately.
-        if (requiresPrompt)
+        // Move the entire decision off the request thread so the agent's
+        // response latency carries no signal about the user's decision (see
+        // long comment retained below). DNS resolution + prompt + launch all
+        // run from the worker.
+        _ = Task.Run(async () =>
         {
-            _ = Task.Run(async () =>
+            try
             {
-                try
+                // Pin DNS at approval time. A bare hostname like "example.com"
+                // would otherwise pass HttpUrlRiskEvaluator (since only IP
+                // literals are inspected) and hand-off to the browser without
+                // ever checking what IP it actually resolves to. A hostile DNS
+                // could point a public-looking name at an internal address.
+                var pinnedRisk = await EnrichWithDnsRiskAsync(initialRisk).ConfigureAwait(false);
+                var requiresPrompt =
+                    pinnedRisk.RequiresConfirmation && !_allowedNavigationHosts.ContainsKey(pinnedRisk.HostKey);
+
+                if (requiresPrompt)
                 {
                     var decision = await new UrlNavigationApprovalService(_logger)
-                        .RequestAsync(risk, BuildNavigationAgentIdentity())
+                        .RequestAsync(pinnedRisk, BuildNavigationAgentIdentity())
                         .ConfigureAwait(false);
 
                     if (decision.Kind == UrlNavigationApprovalDecisionKind.Deny)
                     {
-                        _logger.Warn($"Canvas navigate denied: {risk.CanonicalOrigin} ({decision.Reason ?? "user denied"}); already reported success to agent");
+                        _logger.Warn($"Canvas navigate denied: {OpenClaw.Shared.UrlLogSanitizer.Sanitize(pinnedRisk.CanonicalOrigin)} ({decision.Reason ?? "user denied"}); already reported success to agent");
                         return;
                     }
 
-                    if (decision.Kind == UrlNavigationApprovalDecisionKind.AllowHost)
-                    {
-                        _allowedNavigationHosts.Add(risk.HostKey);
-                        _logger.Info($"Canvas navigate host allowlisted for this session: {risk.HostKey}");
-                    }
-
-                    LaunchAndCleanup(canonical!);
+                    // AllowHost (session-allowlist) is currently unreachable from
+                    // the Win32 prompt — Yes maps to AllowOnce only. The session
+                    // allowlist remains in NodeService as scaffolding for a future
+                    // Fluent ContentDialog prompt (worklist T2-43).
                 }
-                catch (Exception ex)
+
+                // Re-resolve immediately before launch so a TTL-1 record can't
+                // flip the resolved IP between approval and shell-execute.
+                var preLaunchRisk = await EnrichWithDnsRiskAsync(initialRisk).ConfigureAwait(false);
+                if (preLaunchRisk.RequiresConfirmation && !_allowedNavigationHosts.ContainsKey(preLaunchRisk.HostKey))
                 {
-                    _logger.Error("Canvas navigate (deferred) failed", ex);
+                    _logger.Warn($"Canvas navigate aborted at launch: pre-launch DNS re-check flagged {OpenClaw.Shared.UrlLogSanitizer.Sanitize(preLaunchRisk.CanonicalOrigin)}");
+                    return;
                 }
-            });
-        }
-        else
-        {
-            // Low-risk path runs synchronously (still very fast — Process.Start
-            // doesn't wait for the browser to render). The constant-time
-            // contract is "high-risk paths don't reveal user choice", not
-            // "high- and low-risk are indistinguishable" — the URL and risk
-            // profile are the agent's own input, so it already knows which
-            // path applies.
-            LaunchAndCleanup(canonical!);
-        }
 
+                LaunchAndCleanup(canonical!);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Canvas navigate (deferred) failed", ex);
+            }
+        });
+
+        // The agent gets the same response shape and the same response time
+        // whether or not a confirmation prompt is needed. If we awaited the
+        // prompt here, response latency would leak the user's decision time
+        // (or even the existence of a prompt).
         return Task.FromResult("browser");
+    }
+
+    /// <summary>
+    /// If the URL's host is a DNS name, resolve it and treat any non-public
+    /// answer as a Reason. Returns the input profile unchanged for IP literals
+    /// or when DNS resolution fails (a failed DNS lookup is its own
+    /// confirmation trigger).
+    /// </summary>
+    private static async Task<HttpUrlRiskProfile> EnrichWithDnsRiskAsync(HttpUrlRiskProfile risk)
+    {
+        if (!Uri.TryCreate(risk.CanonicalUrl, UriKind.Absolute, out var uri)) return risk;
+        if (System.Net.IPAddress.TryParse(uri.Host, out _)) return risk;
+
+        try
+        {
+            using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(3));
+            var addresses = await System.Net.Dns.GetHostAddressesAsync(uri.Host, cts.Token).ConfigureAwait(false);
+            var extra = new List<string>(risk.Reasons);
+            bool anyNonPublic = false;
+            foreach (var ip in addresses)
+            {
+                if (!HttpUrlRiskEvaluator.IsPublicAddress(ip))
+                {
+                    anyNonPublic = true;
+                    extra.Add($"DNS resolved '{uri.Host}' to non-public address {ip}");
+                }
+            }
+            if (!anyNonPublic) return risk;
+            var merged = extra.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+            return risk with { RequiresConfirmation = true, Reasons = merged };
+        }
+        catch (Exception ex)
+        {
+            // Failed lookup → require prompt: better to ask than to ship the
+            // user to an unverifiable destination.
+            var extra = new List<string>(risk.Reasons) { $"DNS resolution failed for '{uri.Host}': {ex.Message}" };
+            return risk with { RequiresConfirmation = true, Reasons = extra.Distinct(StringComparer.OrdinalIgnoreCase).ToArray() };
+        }
     }
 
     /// <summary>
@@ -1112,7 +1175,15 @@ public class NodeService : IDisposable
 
         try { _cameraCaptureService?.Dispose(); } catch { /* ignore */ }
         try { _screenRecordingService?.Dispose(); } catch { /* ignore */ }
-        
+        // MediaResolver owns SocketsHttpHandler + HttpClient (disposeHandler:true);
+        // without disposal the connection pool survives node teardown/recreate.
+        try { _mediaResolver?.Dispose(); } catch { /* ignore */ }
+        _mediaResolver = null;
+        // ActionDispatcher owns a SemaphoreSlim; without disposal the kernel
+        // handle survives node teardown/recreate.
+        try { _actionDispatcher?.Dispose(); } catch { /* ignore */ }
+        _actionDispatcher = null;
+
         if (_canvasWindow != null && !_canvasWindow.IsClosed)
         {
             var window = _canvasWindow;

--- a/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
@@ -66,6 +66,13 @@ public class SettingsManager
     public bool NodeBrowserProxyEnabled { get; set; } = true;
     // Local MCP HTTP server (independent of EnableNodeMode)
     public bool EnableMcpServer { get; set; } = false;
+    /// <summary>
+    /// Hostnames the A2UI image renderer is allowed to fetch over HTTPS.
+    /// Empty by default — agents can still ship inline data: images. The
+    /// runtime never bypasses this list, so it is the single switch keeping
+    /// agent JSON from issuing arbitrary outbound HTTP from the tray process.
+    /// </summary>
+    public List<string> A2UIImageHosts { get; set; } = new();
     public bool HasSeenActivityStreamTip { get; set; } = false;
     public string SkippedUpdateTag { get; set; } = "";
 
@@ -111,6 +118,7 @@ public class SettingsManager
                     NodeLocationEnabled = loaded.NodeLocationEnabled;
                     NodeBrowserProxyEnabled = loaded.NodeBrowserProxyEnabled;
                     EnableMcpServer = loaded.EnableMcpServer;
+                    A2UIImageHosts = loaded.A2UIImageHosts ?? new List<string>();
                     // Legacy McpOnlyMode migration:
                     //   true  → node off (no gateway), MCP on
                     //   false → leave MCP off; the user has not opted in to a
@@ -173,6 +181,7 @@ public class SettingsManager
                 NodeLocationEnabled = NodeLocationEnabled,
                 NodeBrowserProxyEnabled = NodeBrowserProxyEnabled,
                 EnableMcpServer = EnableMcpServer,
+                A2UIImageHosts = A2UIImageHosts.Count == 0 ? null : new List<string>(A2UIImageHosts),
                 // McpOnlyMode is legacy — never written; remains null in serialized output.
                 HasSeenActivityStreamTip = HasSeenActivityStreamTip,
                 SkippedUpdateTag = string.IsNullOrWhiteSpace(SkippedUpdateTag) ? null : SkippedUpdateTag,

--- a/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
@@ -10,9 +10,14 @@ namespace OpenClawTray.Services;
 /// </summary>
 public class SettingsManager
 {
-    private static readonly string SettingsDirectory = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-        "OpenClawTray");
+    // OPENCLAW_TRAY_DATA_DIR overrides both this and App.DataPath so an isolated test
+    // instance can run alongside the user's real tray without clobbering settings.
+    private static readonly string SettingsDirectory =
+        Environment.GetEnvironmentVariable("OPENCLAW_TRAY_DATA_DIR") is { Length: > 0 } overrideDir
+            ? overrideDir
+            : Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "OpenClawTray");
 
     private static readonly string SettingsFilePath = Path.Combine(SettingsDirectory, "settings.json");
 

--- a/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
@@ -151,7 +151,12 @@ public class SettingsManager
         try
         {
             Directory.CreateDirectory(SettingsDirectory);
-            
+            // Lock the tray data dir to current user + SYSTEM + Administrators —
+            // it co-locates the MCP bearer token, settings.json (which embeds
+            // gateway/bootstrap credentials), and diagnostics jsonl. Other apps
+            // running as the same user could otherwise read these freely.
+            OpenClaw.Shared.Mcp.McpAuthToken.TryRestrictDataDirectoryAcl(SettingsDirectory);
+
             var data = new SettingsData
             {
                 GatewayUrl = GatewayUrl,

--- a/src/OpenClaw.Tray.WinUI/Services/UrlNavigationApprovalService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/UrlNavigationApprovalService.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenClaw.Shared;
+
+namespace OpenClawTray.Services;
+
+internal enum UrlNavigationApprovalDecisionKind
+{
+    Deny,
+    AllowOnce,
+    AllowHost,
+}
+
+internal sealed record UrlNavigationApprovalDecision(UrlNavigationApprovalDecisionKind Kind, string? Reason = null)
+{
+    public static UrlNavigationApprovalDecision Deny(string? reason = null) => new(UrlNavigationApprovalDecisionKind.Deny, reason);
+    public static UrlNavigationApprovalDecision AllowOnce() => new(UrlNavigationApprovalDecisionKind.AllowOnce);
+    public static UrlNavigationApprovalDecision AllowHost() => new(UrlNavigationApprovalDecisionKind.AllowHost);
+}
+
+/// <summary>
+/// Confirmation prompt for high-risk navigations. Backed by Win32 MessageBoxW
+/// rather than a WinUI ContentDialog: the tray's only live XAML window is the
+/// off-screen keep-alive used to anchor the WinUI runtime, so a ContentDialog
+/// rendered against its XamlRoot would never be visible. Spinning up a fresh
+/// visible Window for the prompt crashed with ExecutionEngineException when
+/// invoked from the MCP handler's nested dispatcher callback. Win32 MessageBox
+/// has no WinUI dependencies, can be called from any thread, and pumps its own
+/// modal message loop — so it's reliable from the MCP request path regardless
+/// of which (if any) tray windows are open.
+/// </summary>
+internal sealed class UrlNavigationApprovalService
+{
+    private readonly IOpenClawLogger _logger;
+
+    public UrlNavigationApprovalService(IOpenClawLogger logger)
+    {
+        _logger = logger;
+    }
+
+    public Task<UrlNavigationApprovalDecision> RequestAsync(
+        HttpUrlRiskProfile risk,
+        string agentIdentity,
+        CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            return Task.FromResult(UrlNavigationApprovalDecision.Deny("Navigation prompt was cancelled"));
+
+        var caption = "OpenClaw — Approve URL";
+        var reasonsBlock = risk.Reasons.Count == 0
+            ? "(no specific reasons captured)"
+            : string.Join(Environment.NewLine, risk.Reasons.Select(r => "• " + r));
+        var text =
+            "An agent wants to open a high-risk destination in your browser." + Environment.NewLine +
+            Environment.NewLine +
+            risk.CanonicalOrigin + Environment.NewLine +
+            Environment.NewLine +
+            $"Zone: {risk.Zone}" + Environment.NewLine +
+            $"Agent: {agentIdentity}" + Environment.NewLine +
+            $"Host: {risk.HostKey}" + Environment.NewLine +
+            Environment.NewLine +
+            "Reasons:" + Environment.NewLine + reasonsBlock + Environment.NewLine +
+            Environment.NewLine +
+            "Yes — open this URL." + Environment.NewLine +
+            "No — block it.";
+
+        // Run MessageBoxW on a worker thread so the calling MCP handler's
+        // continuation doesn't pin while the user thinks. MessageBoxW pumps its
+        // own modal loop, so it's safe to call from a non-UI thread.
+        return Task.Run(() =>
+        {
+            try
+            {
+                var flags = MB_YESNO | MB_ICONWARNING | MB_TOPMOST | MB_SETFOREGROUND | MB_DEFBUTTON2;
+                var result = MessageBoxW(IntPtr.Zero, text, caption, flags);
+                var decision = result == IDYES
+                    ? UrlNavigationApprovalDecision.AllowOnce()
+                    : UrlNavigationApprovalDecision.Deny();
+                _logger.Info($"[NavigationApproval] Prompt decision: {decision.Kind} for {risk.CanonicalOrigin}");
+                return decision;
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn($"[NavigationApproval] Prompt failed: {ex.Message}");
+                return UrlNavigationApprovalDecision.Deny($"Prompt failed: {ex.Message}");
+            }
+        }, cancellationToken);
+    }
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern int MessageBoxW(IntPtr hWnd, string text, string caption, uint type);
+
+    private const uint MB_YESNO = 0x00000004;
+    private const uint MB_ICONWARNING = 0x00000030;
+    private const uint MB_DEFBUTTON2 = 0x00000100;
+    private const uint MB_TOPMOST = 0x00040000;
+    private const uint MB_SETFOREGROUND = 0x00010000;
+    private const int IDYES = 6;
+}

--- a/src/OpenClaw.Tray.WinUI/Services/UrlNavigationApprovalService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/UrlNavigationApprovalService.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenClaw.Shared;
+using OpenClawTray.Helpers;
 
 namespace OpenClawTray.Services;
 
@@ -11,14 +13,16 @@ internal enum UrlNavigationApprovalDecisionKind
 {
     Deny,
     AllowOnce,
-    AllowHost,
+    // AllowHost was reserved for a "remember this host for the session"
+    // button, but the Win32 MessageBoxW prompt only exposes Yes/No. Removed
+    // until the prompt is reworked into a Fluent ContentDialog with a third
+    // button (worklist T2-43).
 }
 
 internal sealed record UrlNavigationApprovalDecision(UrlNavigationApprovalDecisionKind Kind, string? Reason = null)
 {
     public static UrlNavigationApprovalDecision Deny(string? reason = null) => new(UrlNavigationApprovalDecisionKind.Deny, reason);
     public static UrlNavigationApprovalDecision AllowOnce() => new(UrlNavigationApprovalDecisionKind.AllowOnce);
-    public static UrlNavigationApprovalDecision AllowHost() => new(UrlNavigationApprovalDecisionKind.AllowHost);
 }
 
 /// <summary>
@@ -49,23 +53,33 @@ internal sealed class UrlNavigationApprovalService
         if (cancellationToken.IsCancellationRequested)
             return Task.FromResult(UrlNavigationApprovalDecision.Deny("Navigation prompt was cancelled"));
 
-        var caption = "OpenClaw — Approve URL";
+        // All user-facing strings come from Resources.resw so we ship the prompt
+        // in every supported locale. Reasons themselves originate in
+        // HttpUrlRiskEvaluator and are still English; localizing that catalog is
+        // a separate item (see worklist).
+        var caption = LocalizationHelper.GetString("UrlApproval_Caption");
         var reasonsBlock = risk.Reasons.Count == 0
-            ? "(no specific reasons captured)"
+            ? LocalizationHelper.GetString("UrlApproval_NoReasons")
             : string.Join(Environment.NewLine, risk.Reasons.Select(r => "• " + r));
+        var zoneLine = string.Format(CultureInfo.CurrentCulture,
+            LocalizationHelper.GetString("UrlApproval_ZoneFormat"), risk.Zone);
+        var agentLine = string.Format(CultureInfo.CurrentCulture,
+            LocalizationHelper.GetString("UrlApproval_AgentFormat"), agentIdentity);
+        var hostLine = string.Format(CultureInfo.CurrentCulture,
+            LocalizationHelper.GetString("UrlApproval_HostFormat"), risk.HostKey);
         var text =
-            "An agent wants to open a high-risk destination in your browser." + Environment.NewLine +
+            LocalizationHelper.GetString("UrlApproval_Body") + Environment.NewLine +
             Environment.NewLine +
             risk.CanonicalOrigin + Environment.NewLine +
             Environment.NewLine +
-            $"Zone: {risk.Zone}" + Environment.NewLine +
-            $"Agent: {agentIdentity}" + Environment.NewLine +
-            $"Host: {risk.HostKey}" + Environment.NewLine +
+            zoneLine + Environment.NewLine +
+            agentLine + Environment.NewLine +
+            hostLine + Environment.NewLine +
             Environment.NewLine +
-            "Reasons:" + Environment.NewLine + reasonsBlock + Environment.NewLine +
+            LocalizationHelper.GetString("UrlApproval_ReasonsHeader") + Environment.NewLine + reasonsBlock + Environment.NewLine +
             Environment.NewLine +
-            "Yes — open this URL." + Environment.NewLine +
-            "No — block it.";
+            LocalizationHelper.GetString("UrlApproval_YesHint") + Environment.NewLine +
+            LocalizationHelper.GetString("UrlApproval_NoHint");
 
         // Run MessageBoxW on a worker thread so the calling MCP handler's
         // continuation doesn't pin while the user thinks. MessageBoxW pumps its
@@ -79,7 +93,7 @@ internal sealed class UrlNavigationApprovalService
                 var decision = result == IDYES
                     ? UrlNavigationApprovalDecision.AllowOnce()
                     : UrlNavigationApprovalDecision.Deny();
-                _logger.Info($"[NavigationApproval] Prompt decision: {decision.Kind} for {risk.CanonicalOrigin}");
+                _logger.Info($"[NavigationApproval] Prompt decision: {decision.Kind} for {UrlLogSanitizer.Sanitize(risk.CanonicalOrigin)}");
                 return decision;
             }
             catch (Exception ex)

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -633,6 +633,12 @@
   <data name="Canvas_WaitingForContent" xml:space="preserve">
     <value>Waiting for content...</value>
   </data>
+  <data name="A2UI_CanvasTitle" xml:space="preserve">
+    <value>Canvas</value>
+  </data>
+  <data name="A2UI_UnsupportedComponent" xml:space="preserve">
+    <value>Unsupported component: {0}</value>
+  </data>
 
   <!-- ==================== WebChatWindow.xaml ==================== -->
 

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -639,6 +639,18 @@
   <data name="A2UI_UnsupportedComponent" xml:space="preserve">
     <value>Unsupported component: {0}</value>
   </data>
+  <data name="A2UI_TabFallback" xml:space="preserve">
+    <value>Tab</value>
+  </data>
+  <data name="A2UI_ModalClose" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="A2UI_DateTimeSelectDate" xml:space="preserve">
+    <value>Select date</value>
+  </data>
+  <data name="A2UI_MultipleChoiceSelect" xml:space="preserve">
+    <value>Select...</value>
+  </data>
 
   <!-- ==================== WebChatWindow.xaml ==================== -->
 
@@ -975,6 +987,57 @@ On your gateway host (Mac/Linux), run:
     <value>Failed to start: </value>
   </data>
 
+  <!-- ==================== MCP token (SettingsWindow) ==================== -->
+
+  <data name="SettingsMcpTokenLabel.Text" xml:space="preserve">
+    <value>Bearer token:</value>
+  </data>
+  <data name="SettingsMcpTokenRevealButton.Content" xml:space="preserve">
+    <value>Reveal</value>
+  </data>
+  <data name="SettingsMcpTokenCopyButton.Content" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="SettingsMcpTokenResetButton.Content" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="SettingsMcpToken_RevealButton" xml:space="preserve">
+    <value>Reveal</value>
+  </data>
+  <data name="SettingsMcpToken_HideButton" xml:space="preserve">
+    <value>Hide</value>
+  </data>
+  <data name="SettingsMcpToken_NotGenerated" xml:space="preserve">
+    <value>(not generated — enable MCP server and click Save)</value>
+  </data>
+  <data name="SettingsMcpToken_StoredAtFormat" xml:space="preserve">
+    <value>Stored at {0}</value>
+  </data>
+  <data name="SettingsMcpToken_HintFormat" xml:space="preserve">
+    <value>Send as 'Authorization: Bearer &lt;token&gt;' on every request. Stored at {0}.</value>
+  </data>
+  <data name="SettingsMcpToken_ResetToastTitle" xml:space="preserve">
+    <value>MCP token reset</value>
+  </data>
+  <data name="SettingsMcpToken_ResetToastBody" xml:space="preserve">
+    <value>Old MCP bearer tokens are now invalid.</value>
+  </data>
+  <data name="SettingsMcpToken_ResetFailedFormat" xml:space="preserve">
+    <value>Failed to reset token: {0}</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_Title" xml:space="preserve">
+    <value>Reset MCP bearer token?</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_Body" xml:space="preserve">
+    <value>Existing local MCP clients (Claude Desktop, Cursor, Claude Code) will stop working until you reconfigure them with the new token.</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_PrimaryButton" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_CloseButton" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+
   <!-- ==================== DownloadProgressDialog ==================== -->
 
   <data name="WindowTitle_Downloading" xml:space="preserve">
@@ -982,6 +1045,36 @@ On your gateway host (Mac/Linux), run:
   </data>
   <data name="Download_ProgressText" xml:space="preserve">
     <value>Downloading update...</value>
+  </data>
+
+  <!-- ==================== UrlNavigationApprovalService prompt ==================== -->
+
+  <data name="UrlApproval_Caption" xml:space="preserve">
+    <value>OpenClaw — Approve URL</value>
+  </data>
+  <data name="UrlApproval_Body" xml:space="preserve">
+    <value>An agent wants to open a high-risk destination in your browser.</value>
+  </data>
+  <data name="UrlApproval_NoReasons" xml:space="preserve">
+    <value>(no specific reasons captured)</value>
+  </data>
+  <data name="UrlApproval_ZoneFormat" xml:space="preserve">
+    <value>Zone: {0}</value>
+  </data>
+  <data name="UrlApproval_AgentFormat" xml:space="preserve">
+    <value>Agent: {0}</value>
+  </data>
+  <data name="UrlApproval_HostFormat" xml:space="preserve">
+    <value>Host: {0}</value>
+  </data>
+  <data name="UrlApproval_ReasonsHeader" xml:space="preserve">
+    <value>Reasons:</value>
+  </data>
+  <data name="UrlApproval_YesHint" xml:space="preserve">
+    <value>Yes — open this URL.</value>
+  </data>
+  <data name="UrlApproval_NoHint" xml:space="preserve">
+    <value>No — block it.</value>
   </data>
 
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -633,6 +633,12 @@
   <data name="Canvas_WaitingForContent" xml:space="preserve">
     <value>En attente de contenu...</value>
   </data>
+  <data name="A2UI_CanvasTitle" xml:space="preserve">
+    <value>Canvas</value>
+  </data>
+  <data name="A2UI_UnsupportedComponent" xml:space="preserve">
+    <value>Composant non pris en charge : {0}</value>
+  </data>
 
   <!-- ==================== WebChatWindow.xaml ==================== -->
 

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -639,6 +639,18 @@
   <data name="A2UI_UnsupportedComponent" xml:space="preserve">
     <value>Composant non pris en charge : {0}</value>
   </data>
+  <data name="A2UI_TabFallback" xml:space="preserve">
+    <value>Onglet</value>
+  </data>
+  <data name="A2UI_ModalClose" xml:space="preserve">
+    <value>Fermer</value>
+  </data>
+  <data name="A2UI_DateTimeSelectDate" xml:space="preserve">
+    <value>Sélectionner une date</value>
+  </data>
+  <data name="A2UI_MultipleChoiceSelect" xml:space="preserve">
+    <value>Sélectionner...</value>
+  </data>
 
   <!-- ==================== WebChatWindow.xaml ==================== -->
 
@@ -975,6 +987,57 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Échec du démarrage : </value>
   </data>
 
+  <!-- ==================== MCP token (SettingsWindow) ==================== -->
+
+  <data name="SettingsMcpTokenLabel.Text" xml:space="preserve">
+    <value>Jeton porteur :</value>
+  </data>
+  <data name="SettingsMcpTokenRevealButton.Content" xml:space="preserve">
+    <value>Afficher</value>
+  </data>
+  <data name="SettingsMcpTokenCopyButton.Content" xml:space="preserve">
+    <value>Copier</value>
+  </data>
+  <data name="SettingsMcpTokenResetButton.Content" xml:space="preserve">
+    <value>Réinitialiser</value>
+  </data>
+  <data name="SettingsMcpToken_RevealButton" xml:space="preserve">
+    <value>Afficher</value>
+  </data>
+  <data name="SettingsMcpToken_HideButton" xml:space="preserve">
+    <value>Masquer</value>
+  </data>
+  <data name="SettingsMcpToken_NotGenerated" xml:space="preserve">
+    <value>(non généré — activez le serveur MCP et cliquez sur Enregistrer)</value>
+  </data>
+  <data name="SettingsMcpToken_StoredAtFormat" xml:space="preserve">
+    <value>Stocké à {0}</value>
+  </data>
+  <data name="SettingsMcpToken_HintFormat" xml:space="preserve">
+    <value>Envoyer comme 'Authorization: Bearer &lt;token&gt;' à chaque requête. Stocké à {0}.</value>
+  </data>
+  <data name="SettingsMcpToken_ResetToastTitle" xml:space="preserve">
+    <value>Jeton MCP réinitialisé</value>
+  </data>
+  <data name="SettingsMcpToken_ResetToastBody" xml:space="preserve">
+    <value>Les anciens jetons porteur MCP sont désormais invalides.</value>
+  </data>
+  <data name="SettingsMcpToken_ResetFailedFormat" xml:space="preserve">
+    <value>Échec de la réinitialisation du jeton : {0}</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_Title" xml:space="preserve">
+    <value>Réinitialiser le jeton porteur MCP ?</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_Body" xml:space="preserve">
+    <value>Les clients MCP locaux existants (Claude Desktop, Cursor, Claude Code) cesseront de fonctionner jusqu'à ce que vous les reconfiguriez avec le nouveau jeton.</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_PrimaryButton" xml:space="preserve">
+    <value>Réinitialiser</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_CloseButton" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+
   <!-- ==================== DownloadProgressDialog ==================== -->
 
   <data name="WindowTitle_Downloading" xml:space="preserve">
@@ -982,5 +1045,35 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   </data>
   <data name="Download_ProgressText" xml:space="preserve">
     <value>Téléchargement en cours...</value>
+  </data>
+
+  <!-- ==================== UrlNavigationApprovalService prompt ==================== -->
+
+  <data name="UrlApproval_Caption" xml:space="preserve">
+    <value>OpenClaw — Approuver l'URL</value>
+  </data>
+  <data name="UrlApproval_Body" xml:space="preserve">
+    <value>Un agent souhaite ouvrir une destination à haut risque dans votre navigateur.</value>
+  </data>
+  <data name="UrlApproval_NoReasons" xml:space="preserve">
+    <value>(aucune raison spécifique capturée)</value>
+  </data>
+  <data name="UrlApproval_ZoneFormat" xml:space="preserve">
+    <value>Zone : {0}</value>
+  </data>
+  <data name="UrlApproval_AgentFormat" xml:space="preserve">
+    <value>Agent : {0}</value>
+  </data>
+  <data name="UrlApproval_HostFormat" xml:space="preserve">
+    <value>Hôte : {0}</value>
+  </data>
+  <data name="UrlApproval_ReasonsHeader" xml:space="preserve">
+    <value>Raisons :</value>
+  </data>
+  <data name="UrlApproval_YesHint" xml:space="preserve">
+    <value>Oui — ouvrir cette URL.</value>
+  </data>
+  <data name="UrlApproval_NoHint" xml:space="preserve">
+    <value>Non — la bloquer.</value>
   </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -633,6 +633,12 @@
   <data name="Canvas_WaitingForContent" xml:space="preserve">
     <value>Wachten op inhoud...</value>
   </data>
+  <data name="A2UI_CanvasTitle" xml:space="preserve">
+    <value>Canvas</value>
+  </data>
+  <data name="A2UI_UnsupportedComponent" xml:space="preserve">
+    <value>Niet-ondersteunde component: {0}</value>
+  </data>
 
   <!-- ==================== WebChatWindow.xaml ==================== -->
 

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -639,6 +639,18 @@
   <data name="A2UI_UnsupportedComponent" xml:space="preserve">
     <value>Niet-ondersteunde component: {0}</value>
   </data>
+  <data name="A2UI_TabFallback" xml:space="preserve">
+    <value>Tabblad</value>
+  </data>
+  <data name="A2UI_ModalClose" xml:space="preserve">
+    <value>Sluiten</value>
+  </data>
+  <data name="A2UI_DateTimeSelectDate" xml:space="preserve">
+    <value>Datum kiezen</value>
+  </data>
+  <data name="A2UI_MultipleChoiceSelect" xml:space="preserve">
+    <value>Kiezen...</value>
+  </data>
 
   <!-- ==================== WebChatWindow.xaml ==================== -->
 
@@ -975,6 +987,57 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>Starten mislukt: </value>
   </data>
 
+  <!-- ==================== MCP token (SettingsWindow) ==================== -->
+
+  <data name="SettingsMcpTokenLabel.Text" xml:space="preserve">
+    <value>Bearer-token:</value>
+  </data>
+  <data name="SettingsMcpTokenRevealButton.Content" xml:space="preserve">
+    <value>Tonen</value>
+  </data>
+  <data name="SettingsMcpTokenCopyButton.Content" xml:space="preserve">
+    <value>Kopiëren</value>
+  </data>
+  <data name="SettingsMcpTokenResetButton.Content" xml:space="preserve">
+    <value>Resetten</value>
+  </data>
+  <data name="SettingsMcpToken_RevealButton" xml:space="preserve">
+    <value>Tonen</value>
+  </data>
+  <data name="SettingsMcpToken_HideButton" xml:space="preserve">
+    <value>Verbergen</value>
+  </data>
+  <data name="SettingsMcpToken_NotGenerated" xml:space="preserve">
+    <value>(niet gegenereerd — schakel de MCP-server in en klik op Opslaan)</value>
+  </data>
+  <data name="SettingsMcpToken_StoredAtFormat" xml:space="preserve">
+    <value>Opgeslagen op {0}</value>
+  </data>
+  <data name="SettingsMcpToken_HintFormat" xml:space="preserve">
+    <value>Stuur bij elke aanvraag mee als 'Authorization: Bearer &lt;token&gt;'. Opgeslagen op {0}.</value>
+  </data>
+  <data name="SettingsMcpToken_ResetToastTitle" xml:space="preserve">
+    <value>MCP-token gereset</value>
+  </data>
+  <data name="SettingsMcpToken_ResetToastBody" xml:space="preserve">
+    <value>Oude MCP-bearer-tokens zijn nu ongeldig.</value>
+  </data>
+  <data name="SettingsMcpToken_ResetFailedFormat" xml:space="preserve">
+    <value>Resetten van token mislukt: {0}</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_Title" xml:space="preserve">
+    <value>MCP-bearer-token resetten?</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_Body" xml:space="preserve">
+    <value>Bestaande lokale MCP-clients (Claude Desktop, Cursor, Claude Code) werken niet meer totdat je ze opnieuw configureert met het nieuwe token.</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_PrimaryButton" xml:space="preserve">
+    <value>Resetten</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_CloseButton" xml:space="preserve">
+    <value>Annuleren</value>
+  </data>
+
   <!-- ==================== DownloadProgressDialog ==================== -->
 
   <data name="WindowTitle_Downloading" xml:space="preserve">
@@ -982,6 +1045,36 @@ Voer op uw gateway-host (Mac/Linux) uit:
   </data>
   <data name="Download_ProgressText" xml:space="preserve">
     <value>Update downloaden...</value>
+  </data>
+
+  <!-- ==================== UrlNavigationApprovalService prompt ==================== -->
+
+  <data name="UrlApproval_Caption" xml:space="preserve">
+    <value>OpenClaw — URL goedkeuren</value>
+  </data>
+  <data name="UrlApproval_Body" xml:space="preserve">
+    <value>Een agent wil een risicovolle bestemming in je browser openen.</value>
+  </data>
+  <data name="UrlApproval_NoReasons" xml:space="preserve">
+    <value>(geen specifieke redenen vastgelegd)</value>
+  </data>
+  <data name="UrlApproval_ZoneFormat" xml:space="preserve">
+    <value>Zone: {0}</value>
+  </data>
+  <data name="UrlApproval_AgentFormat" xml:space="preserve">
+    <value>Agent: {0}</value>
+  </data>
+  <data name="UrlApproval_HostFormat" xml:space="preserve">
+    <value>Host: {0}</value>
+  </data>
+  <data name="UrlApproval_ReasonsHeader" xml:space="preserve">
+    <value>Redenen:</value>
+  </data>
+  <data name="UrlApproval_YesHint" xml:space="preserve">
+    <value>Ja — open deze URL.</value>
+  </data>
+  <data name="UrlApproval_NoHint" xml:space="preserve">
+    <value>Nee — blokkeer hem.</value>
   </data>
 
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -633,6 +633,12 @@
   <data name="Canvas_WaitingForContent" xml:space="preserve">
     <value>等待内容...</value>
   </data>
+  <data name="A2UI_CanvasTitle" xml:space="preserve">
+    <value>画布</value>
+  </data>
+  <data name="A2UI_UnsupportedComponent" xml:space="preserve">
+    <value>不支持的组件: {0}</value>
+  </data>
 
   <!-- ==================== WebChatWindow.xaml ==================== -->
 

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -636,6 +636,18 @@
   <data name="A2UI_CanvasTitle" xml:space="preserve">
     <value>画布</value>
   </data>
+  <data name="A2UI_TabFallback" xml:space="preserve">
+    <value>选项卡</value>
+  </data>
+  <data name="A2UI_ModalClose" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="A2UI_DateTimeSelectDate" xml:space="preserve">
+    <value>选择日期</value>
+  </data>
+  <data name="A2UI_MultipleChoiceSelect" xml:space="preserve">
+    <value>选择...</value>
+  </data>
   <data name="A2UI_UnsupportedComponent" xml:space="preserve">
     <value>不支持的组件: {0}</value>
   </data>
@@ -975,6 +987,57 @@
     <value>启动失败：</value>
   </data>
 
+  <!-- ==================== MCP token (SettingsWindow) ==================== -->
+
+  <data name="SettingsMcpTokenLabel.Text" xml:space="preserve">
+    <value>Bearer 令牌：</value>
+  </data>
+  <data name="SettingsMcpTokenRevealButton.Content" xml:space="preserve">
+    <value>显示</value>
+  </data>
+  <data name="SettingsMcpTokenCopyButton.Content" xml:space="preserve">
+    <value>复制</value>
+  </data>
+  <data name="SettingsMcpTokenResetButton.Content" xml:space="preserve">
+    <value>重置</value>
+  </data>
+  <data name="SettingsMcpToken_RevealButton" xml:space="preserve">
+    <value>显示</value>
+  </data>
+  <data name="SettingsMcpToken_HideButton" xml:space="preserve">
+    <value>隐藏</value>
+  </data>
+  <data name="SettingsMcpToken_NotGenerated" xml:space="preserve">
+    <value>(未生成 — 启用 MCP 服务器并单击保存)</value>
+  </data>
+  <data name="SettingsMcpToken_StoredAtFormat" xml:space="preserve">
+    <value>保存位置：{0}</value>
+  </data>
+  <data name="SettingsMcpToken_HintFormat" xml:space="preserve">
+    <value>每次请求都以 'Authorization: Bearer &lt;token&gt;' 发送。保存位置：{0}。</value>
+  </data>
+  <data name="SettingsMcpToken_ResetToastTitle" xml:space="preserve">
+    <value>MCP 令牌已重置</value>
+  </data>
+  <data name="SettingsMcpToken_ResetToastBody" xml:space="preserve">
+    <value>旧的 MCP Bearer 令牌现已失效。</value>
+  </data>
+  <data name="SettingsMcpToken_ResetFailedFormat" xml:space="preserve">
+    <value>重置令牌失败：{0}</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_Title" xml:space="preserve">
+    <value>重置 MCP Bearer 令牌？</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_Body" xml:space="preserve">
+    <value>现有的本地 MCP 客户端（Claude Desktop、Cursor、Claude Code）将停止工作，直到您使用新令牌重新配置它们。</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_PrimaryButton" xml:space="preserve">
+    <value>重置</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_CloseButton" xml:space="preserve">
+    <value>取消</value>
+  </data>
+
   <!-- ==================== DownloadProgressDialog ==================== -->
 
   <data name="WindowTitle_Downloading" xml:space="preserve">
@@ -982,6 +1045,36 @@
   </data>
   <data name="Download_ProgressText" xml:space="preserve">
     <value>正在下载更新...</value>
+  </data>
+
+  <!-- ==================== UrlNavigationApprovalService prompt ==================== -->
+
+  <data name="UrlApproval_Caption" xml:space="preserve">
+    <value>OpenClaw — 批准 URL</value>
+  </data>
+  <data name="UrlApproval_Body" xml:space="preserve">
+    <value>代理希望在您的浏览器中打开高风险目的地。</value>
+  </data>
+  <data name="UrlApproval_NoReasons" xml:space="preserve">
+    <value>(未记录具体原因)</value>
+  </data>
+  <data name="UrlApproval_ZoneFormat" xml:space="preserve">
+    <value>区域：{0}</value>
+  </data>
+  <data name="UrlApproval_AgentFormat" xml:space="preserve">
+    <value>代理：{0}</value>
+  </data>
+  <data name="UrlApproval_HostFormat" xml:space="preserve">
+    <value>主机：{0}</value>
+  </data>
+  <data name="UrlApproval_ReasonsHeader" xml:space="preserve">
+    <value>原因：</value>
+  </data>
+  <data name="UrlApproval_YesHint" xml:space="preserve">
+    <value>是 — 打开此 URL。</value>
+  </data>
+  <data name="UrlApproval_NoHint" xml:space="preserve">
+    <value>否 — 阻止该请求。</value>
   </data>
 
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -633,6 +633,12 @@
   <data name="Canvas_WaitingForContent" xml:space="preserve">
     <value>等待內容...</value>
   </data>
+  <data name="A2UI_CanvasTitle" xml:space="preserve">
+    <value>畫布</value>
+  </data>
+  <data name="A2UI_UnsupportedComponent" xml:space="preserve">
+    <value>不支援的元件: {0}</value>
+  </data>
 
   <!-- ==================== WebChatWindow.xaml ==================== -->
 

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -636,6 +636,18 @@
   <data name="A2UI_CanvasTitle" xml:space="preserve">
     <value>畫布</value>
   </data>
+  <data name="A2UI_TabFallback" xml:space="preserve">
+    <value>索引標籤</value>
+  </data>
+  <data name="A2UI_ModalClose" xml:space="preserve">
+    <value>關閉</value>
+  </data>
+  <data name="A2UI_DateTimeSelectDate" xml:space="preserve">
+    <value>選擇日期</value>
+  </data>
+  <data name="A2UI_MultipleChoiceSelect" xml:space="preserve">
+    <value>選擇...</value>
+  </data>
   <data name="A2UI_UnsupportedComponent" xml:space="preserve">
     <value>不支援的元件: {0}</value>
   </data>
@@ -975,6 +987,57 @@
     <value>啟動失敗：</value>
   </data>
 
+  <!-- ==================== MCP token (SettingsWindow) ==================== -->
+
+  <data name="SettingsMcpTokenLabel.Text" xml:space="preserve">
+    <value>Bearer 權杖：</value>
+  </data>
+  <data name="SettingsMcpTokenRevealButton.Content" xml:space="preserve">
+    <value>顯示</value>
+  </data>
+  <data name="SettingsMcpTokenCopyButton.Content" xml:space="preserve">
+    <value>複製</value>
+  </data>
+  <data name="SettingsMcpTokenResetButton.Content" xml:space="preserve">
+    <value>重設</value>
+  </data>
+  <data name="SettingsMcpToken_RevealButton" xml:space="preserve">
+    <value>顯示</value>
+  </data>
+  <data name="SettingsMcpToken_HideButton" xml:space="preserve">
+    <value>隱藏</value>
+  </data>
+  <data name="SettingsMcpToken_NotGenerated" xml:space="preserve">
+    <value>(尚未產生 — 啟用 MCP 伺服器並按儲存)</value>
+  </data>
+  <data name="SettingsMcpToken_StoredAtFormat" xml:space="preserve">
+    <value>儲存於 {0}</value>
+  </data>
+  <data name="SettingsMcpToken_HintFormat" xml:space="preserve">
+    <value>每次請求皆以 'Authorization: Bearer &lt;token&gt;' 傳送。儲存於 {0}。</value>
+  </data>
+  <data name="SettingsMcpToken_ResetToastTitle" xml:space="preserve">
+    <value>MCP 權杖已重設</value>
+  </data>
+  <data name="SettingsMcpToken_ResetToastBody" xml:space="preserve">
+    <value>舊的 MCP Bearer 權杖現已失效。</value>
+  </data>
+  <data name="SettingsMcpToken_ResetFailedFormat" xml:space="preserve">
+    <value>重設權杖失敗：{0}</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_Title" xml:space="preserve">
+    <value>重設 MCP Bearer 權杖？</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_Body" xml:space="preserve">
+    <value>現有的本機 MCP 用戶端（Claude Desktop、Cursor、Claude Code）將停止運作，直到您使用新權杖重新設定它們。</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_PrimaryButton" xml:space="preserve">
+    <value>重設</value>
+  </data>
+  <data name="SettingsMcpTokenResetDialog_CloseButton" xml:space="preserve">
+    <value>取消</value>
+  </data>
+
   <!-- ==================== DownloadProgressDialog ==================== -->
 
   <data name="WindowTitle_Downloading" xml:space="preserve">
@@ -982,6 +1045,36 @@
   </data>
   <data name="Download_ProgressText" xml:space="preserve">
     <value>正在下載更新...</value>
+  </data>
+
+  <!-- ==================== UrlNavigationApprovalService prompt ==================== -->
+
+  <data name="UrlApproval_Caption" xml:space="preserve">
+    <value>OpenClaw — 核准 URL</value>
+  </data>
+  <data name="UrlApproval_Body" xml:space="preserve">
+    <value>代理想在您的瀏覽器中開啟高風險目標。</value>
+  </data>
+  <data name="UrlApproval_NoReasons" xml:space="preserve">
+    <value>(未記錄特定原因)</value>
+  </data>
+  <data name="UrlApproval_ZoneFormat" xml:space="preserve">
+    <value>區域：{0}</value>
+  </data>
+  <data name="UrlApproval_AgentFormat" xml:space="preserve">
+    <value>代理：{0}</value>
+  </data>
+  <data name="UrlApproval_HostFormat" xml:space="preserve">
+    <value>主機：{0}</value>
+  </data>
+  <data name="UrlApproval_ReasonsHeader" xml:space="preserve">
+    <value>原因：</value>
+  </data>
+  <data name="UrlApproval_YesHint" xml:space="preserve">
+    <value>是 — 開啟此 URL。</value>
+  </data>
+  <data name="UrlApproval_NoHint" xml:space="preserve">
+    <value>否 — 封鎖此項。</value>
   </data>
 
 </root>

--- a/src/OpenClaw.Tray.WinUI/Windows/A2UICanvasWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/A2UICanvasWindow.xaml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<winex:WindowEx
+    x:Class="OpenClawTray.Windows.A2UICanvasWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:winex="using:WinUIEx"
+    Title="Canvas"
+    Width="900" Height="650"
+    MinWidth="320" MinHeight="240">
+
+    <Window.SystemBackdrop>
+        <MicaBackdrop/>
+    </Window.SystemBackdrop>
+
+    <Grid x:Name="RootGrid">
+        <!-- Empty placeholder shown when no surfaces are active. -->
+        <StackPanel x:Name="EmptyPanel"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Spacing="12"
+                    Padding="32"
+                    Visibility="Visible">
+            <FontIcon Glyph="&#xE71B;" FontSize="32" Opacity="0.55"/>
+            <TextBlock Text="Waiting for content..."
+                       Style="{StaticResource SubtitleTextBlockStyle}"
+                       Opacity="0.7"
+                       HorizontalAlignment="Center"/>
+        </StackPanel>
+
+        <!-- Single-surface mode: SingleSurfaceHost holds the surface root. -->
+        <ContentControl x:Name="SingleSurfaceHost"
+                        Visibility="Collapsed"
+                        HorizontalContentAlignment="Stretch"
+                        VerticalContentAlignment="Stretch"/>
+
+        <!-- Multi-surface mode: TabView shown when >1 surface active. -->
+        <TabView x:Name="MultiSurfaceTabs"
+                 Visibility="Collapsed"
+                 IsAddTabButtonVisible="False"
+                 CanReorderTabs="False"
+                 CanDragTabs="False"/>
+    </Grid>
+</winex:WindowEx>

--- a/src/OpenClaw.Tray.WinUI/Windows/A2UICanvasWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/A2UICanvasWindow.xaml
@@ -21,7 +21,7 @@
                     Padding="32"
                     Visibility="Visible">
             <FontIcon Glyph="&#xE71B;" FontSize="32" Opacity="0.55"/>
-            <TextBlock Text="Waiting for content..."
+            <TextBlock x:Name="WaitingForContentText"
                        Style="{StaticResource SubtitleTextBlockStyle}"
                        Opacity="0.7"
                        HorizontalAlignment="Center"/>

--- a/src/OpenClaw.Tray.WinUI/Windows/A2UICanvasWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/A2UICanvasWindow.xaml
@@ -4,7 +4,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:winex="using:WinUIEx"
-    Title="Canvas"
     Width="900" Height="650"
     MinWidth="320" MinHeight="240">
 
@@ -13,18 +12,21 @@
     </Window.SystemBackdrop>
 
     <Grid x:Name="RootGrid">
-        <!-- Empty placeholder shown when no surfaces are active. -->
+        <!-- Empty placeholder shown when no surfaces are active. The icon is
+             decorative — Narrator should announce only the text. -->
         <StackPanel x:Name="EmptyPanel"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     Spacing="12"
                     Padding="32"
                     Visibility="Visible">
-            <FontIcon Glyph="&#xE71B;" FontSize="32" Opacity="0.55"/>
+            <FontIcon Glyph="&#xE71B;" FontSize="32" Opacity="0.55"
+                      AutomationProperties.AccessibilityView="Raw"/>
             <TextBlock x:Name="WaitingForContentText"
                        Style="{StaticResource SubtitleTextBlockStyle}"
                        Opacity="0.7"
-                       HorizontalAlignment="Center"/>
+                       HorizontalAlignment="Center"
+                       AutomationProperties.LiveSetting="Polite"/>
         </StackPanel>
 
         <!-- Single-surface mode: SingleSurfaceHost holds the surface root. -->

--- a/src/OpenClaw.Tray.WinUI/Windows/A2UICanvasWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/A2UICanvasWindow.xaml.cs
@@ -152,7 +152,22 @@ public sealed partial class A2UICanvasWindow : WindowEx
             target = RootGrid;
 
         var rtb = new RenderTargetBitmap();
-        await rtb.RenderAsync(target);
+        try
+        {
+            await rtb.RenderAsync(target);
+        }
+        catch (System.Runtime.InteropServices.COMException ex)
+        {
+            // Common when the window is minimised or has not yet completed first
+            // layout. RenderTargetBitmap surfaces the underlying composition error
+            // as a COMException; surface a structured code rather than a stack
+            // trace through the snapshot pipeline.
+            throw new InvalidOperationException("CANVAS_SNAPSHOT_NOT_VISIBLE: window is not in a renderable state", ex);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new InvalidOperationException("CANVAS_SNAPSHOT_NOT_VISIBLE: target is not in a renderable state", ex);
+        }
         var pixelBuffer = await rtb.GetPixelsAsync();
         var pixels = pixelBuffer.ToArray();
 

--- a/src/OpenClaw.Tray.WinUI/Windows/A2UICanvasWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/A2UICanvasWindow.xaml.cs
@@ -80,6 +80,8 @@ public sealed partial class A2UICanvasWindow : WindowEx
             try { _router.SurfaceCreated -= OnSurfaceCreated; } catch { }
             try { _router.SurfaceDeleted -= OnSurfaceDeleted; } catch { }
             try { _router.ResetAll(); } catch { }
+            _surfaceScrollers.Clear();
+            _surfaceTabs.Clear();
         };
     }
 
@@ -105,6 +107,40 @@ public sealed partial class A2UICanvasWindow : WindowEx
     // SurfaceId → existing TabViewItem, so add/remove diffs can preserve the
     // user's selected tab and avoid re-templating unchanged surfaces (M15).
     private readonly Dictionary<string, TabViewItem> _surfaceTabs = new(StringComparer.Ordinal);
+    // SurfaceId → ScrollViewer wrapping that surface's RootElement. A2UI is
+    // designed against web semantics: surfaces don't carry their own outer
+    // scroller because the document body scrolls. WinUI containers don't, so
+    // a tall surface clips at the viewport. Cached so reconciling tab content
+    // doesn't churn ScrollViewer instances (and lose scroll position) on
+    // every UpdateLayout pass.
+    private readonly Dictionary<string, ScrollViewer> _surfaceScrollers = new(StringComparer.Ordinal);
+
+    private ScrollViewer GetOrCreateScroller(SurfaceHost s)
+    {
+        if (_surfaceScrollers.TryGetValue(s.SurfaceId, out var existing))
+        {
+            if (!ReferenceEquals(existing.Content, s.RootElement))
+                existing.Content = s.RootElement;
+            return existing;
+        }
+        // HorizontalScrollBarVisibility=Disabled forces children to lay out
+        // within the viewport width — same as the HTML body's default of
+        // wrapping rather than overflowing horizontally. Vertical=Auto keeps
+        // the bar out of sight when the content fits.
+        var sv = new ScrollViewer
+        {
+            Content = s.RootElement,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+            VerticalScrollMode = ScrollMode.Auto,
+            HorizontalScrollMode = ScrollMode.Disabled,
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            VerticalContentAlignment = VerticalAlignment.Top,
+            ZoomMode = ZoomMode.Disabled,
+        };
+        _surfaceScrollers[s.SurfaceId] = sv;
+        return sv;
+    }
 
     private void UpdateLayout()
     {
@@ -117,18 +153,28 @@ public sealed partial class A2UICanvasWindow : WindowEx
             SingleSurfaceHost.Content = null;
             MultiSurfaceTabs.TabItems.Clear();
             _surfaceTabs.Clear();
+            _surfaceScrollers.Clear();
             Title = OpenClawTray.Helpers.LocalizationHelper.GetString("A2UI_CanvasTitle");
             return;
         }
 
         EmptyPanel.Visibility = Visibility.Collapsed;
 
+        // Drop cached scrollers for surfaces that no longer exist so we don't
+        // pin their content trees in memory.
+        var live = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var s in surfaces) live.Add(s.SurfaceId);
+        var staleScrollers = new List<string>();
+        foreach (var kv in _surfaceScrollers)
+            if (!live.Contains(kv.Key)) staleScrollers.Add(kv.Key);
+        foreach (var id in staleScrollers) _surfaceScrollers.Remove(id);
+
         if (surfaces.Count == 1)
         {
             var s = surfaces[0];
             SingleSurfaceHost.Visibility = Visibility.Visible;
             MultiSurfaceTabs.Visibility = Visibility.Collapsed;
-            SingleSurfaceHost.Content = s.RootElement;
+            SingleSurfaceHost.Content = GetOrCreateScroller(s);
             MultiSurfaceTabs.TabItems.Clear();
             _surfaceTabs.Clear();
             Title = string.IsNullOrWhiteSpace(s.Title)
@@ -166,12 +212,13 @@ public sealed partial class A2UICanvasWindow : WindowEx
         {
             var s = surfaces[i];
             var header = string.IsNullOrWhiteSpace(s.Title) ? s.SurfaceId : s.Title!;
+            var scroller = GetOrCreateScroller(s);
             if (!_surfaceTabs.TryGetValue(s.SurfaceId, out var tab))
             {
                 tab = new TabViewItem
                 {
                     Header = header,
-                    Content = s.RootElement,
+                    Content = scroller,
                     IsClosable = false,
                     Tag = s.SurfaceId,
                 };
@@ -181,7 +228,7 @@ public sealed partial class A2UICanvasWindow : WindowEx
             else
             {
                 if (!Equals(tab.Header, header)) tab.Header = header;
-                if (!ReferenceEquals(tab.Content, s.RootElement)) tab.Content = s.RootElement;
+                if (!ReferenceEquals(tab.Content, scroller)) tab.Content = scroller;
                 int currentIndex = MultiSurfaceTabs.TabItems.IndexOf(tab);
                 if (currentIndex != i)
                 {

--- a/src/OpenClaw.Tray.WinUI/Windows/A2UICanvasWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/A2UICanvasWindow.xaml.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Imaging;
+using OpenClaw.Shared;
+using OpenClawTray.A2UI.Actions;
+using OpenClawTray.A2UI.DataModel;
+using OpenClawTray.A2UI.Hosting;
+using OpenClawTray.A2UI.Rendering;
+using WinUIEx;
+using Windows.Graphics.Imaging;
+using Windows.Storage.Streams;
+
+namespace OpenClawTray.Windows;
+
+/// <summary>
+/// Native A2UI canvas. Hosts an <see cref="A2UIRouter"/> that drives one or
+/// more <see cref="SurfaceHost"/> instances directly into XAML. No WebView2,
+/// no HTTP host, no JS bridge.
+/// </summary>
+public sealed partial class A2UICanvasWindow : WindowEx
+{
+    [DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [DllImport("user32.dll")]
+    private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+    private static readonly IntPtr HWND_TOPMOST = new(-1);
+    private static readonly IntPtr HWND_NOTOPMOST = new(-2);
+    private const int SW_SHOWNORMAL = 1;
+    private const uint SWP_NOMOVE = 0x0002;
+    private const uint SWP_NOSIZE = 0x0001;
+    private const uint SWP_SHOWWINDOW = 0x0040;
+
+    private readonly DispatcherQueue _dispatcher;
+    private readonly A2UIRouter _router;
+    private readonly DataModelStore _dataModel;
+
+    public bool IsClosed { get; private set; }
+
+    /// <summary>
+    /// Construct the native A2UI canvas window. <paramref name="actions"/> is
+    /// the dispatcher used for any user interactions raised by surface widgets.
+    /// </summary>
+    public A2UICanvasWindow(IActionSink actions, MediaResolver media, IOpenClawLogger logger)
+    {
+        InitializeComponent();
+        this.SetIcon("Assets\\openclaw.ico");
+        Closed += (_, _) => IsClosed = true;
+
+        _dispatcher = DispatcherQueue.GetForCurrentThread();
+        _dataModel = new DataModelStore(_dispatcher);
+        var registry = ComponentRendererRegistry.BuildDefault(media);
+        _router = new A2UIRouter(_dispatcher, _dataModel, registry, actions, logger);
+
+        _router.SurfaceCreated += OnSurfaceCreated;
+        _router.SurfaceDeleted += OnSurfaceDeleted;
+    }
+
+    /// <summary>
+    /// Push a JSONL blob through the router. Safe from any thread — the
+    /// router posts UI work to the dispatcher.
+    /// </summary>
+    public void Push(string jsonl) => _router.Push(jsonl);
+
+    /// <summary>Reset everything: surfaces, data models, visuals.</summary>
+    public void Reset() => _router.ResetAll();
+
+    private void OnSurfaceCreated(object? sender, SurfaceHost host)
+    {
+        UpdateLayout();
+    }
+
+    private void OnSurfaceDeleted(object? sender, string surfaceId)
+    {
+        UpdateLayout();
+    }
+
+    private void UpdateLayout()
+    {
+        var surfaces = new List<SurfaceHost>(_router.Surfaces.Values);
+        if (surfaces.Count == 0)
+        {
+            EmptyPanel.Visibility = Visibility.Visible;
+            SingleSurfaceHost.Visibility = Visibility.Collapsed;
+            MultiSurfaceTabs.Visibility = Visibility.Collapsed;
+            SingleSurfaceHost.Content = null;
+            MultiSurfaceTabs.TabItems.Clear();
+            Title = "Canvas";
+            return;
+        }
+
+        EmptyPanel.Visibility = Visibility.Collapsed;
+
+        if (surfaces.Count == 1)
+        {
+            var s = surfaces[0];
+            SingleSurfaceHost.Visibility = Visibility.Visible;
+            MultiSurfaceTabs.Visibility = Visibility.Collapsed;
+            SingleSurfaceHost.Content = s.RootElement;
+            MultiSurfaceTabs.TabItems.Clear();
+            Title = string.IsNullOrWhiteSpace(s.Title) ? "Canvas" : s.Title!;
+        }
+        else
+        {
+            SingleSurfaceHost.Visibility = Visibility.Collapsed;
+            MultiSurfaceTabs.Visibility = Visibility.Visible;
+            SingleSurfaceHost.Content = null;
+            MultiSurfaceTabs.TabItems.Clear();
+            foreach (var s in surfaces)
+            {
+                var tab = new TabViewItem
+                {
+                    Header = string.IsNullOrWhiteSpace(s.Title) ? s.SurfaceId : s.Title!,
+                    Content = s.RootElement,
+                    IsClosable = false,
+                };
+                MultiSurfaceTabs.TabItems.Add(tab);
+            }
+            Title = "Canvas";
+        }
+    }
+
+    /// <summary>
+    /// Render the current visible content (Empty / Single / Multi mode) into a
+    /// PNG or JPEG and return base64. Uses XAML's RenderTargetBitmap so the
+    /// snapshot reflects the actual visual tree, not a Win32 window blit.
+    /// </summary>
+    public async Task<string> CaptureSnapshotAsync(string format = "png")
+    {
+        // Pick the visible host. Falls back to the root grid if neither is shown
+        // (e.g. surfaces have been pushed but layout hasn't settled).
+        FrameworkElement? target = null;
+        if (SingleSurfaceHost.Visibility == Visibility.Visible)
+            target = SingleSurfaceHost;
+        else if (MultiSurfaceTabs.Visibility == Visibility.Visible)
+            target = MultiSurfaceTabs;
+        else if (EmptyPanel.Visibility == Visibility.Visible)
+            target = EmptyPanel;
+
+        if (target == null || target.ActualWidth <= 0 || target.ActualHeight <= 0)
+            target = RootGrid;
+
+        var rtb = new RenderTargetBitmap();
+        await rtb.RenderAsync(target);
+        var pixelBuffer = await rtb.GetPixelsAsync();
+        var pixels = pixelBuffer.ToArray();
+
+        var encoderId = format.Equals("jpeg", StringComparison.OrdinalIgnoreCase) || format.Equals("jpg", StringComparison.OrdinalIgnoreCase)
+            ? BitmapEncoder.JpegEncoderId
+            : BitmapEncoder.PngEncoderId;
+
+        using var stream = new InMemoryRandomAccessStream();
+        var encoder = await BitmapEncoder.CreateAsync(encoderId, stream);
+        var dpi = 96.0; // RenderTargetBitmap is logical-pixel sized; encode at 1:1.
+        encoder.SetPixelData(
+            BitmapPixelFormat.Bgra8,
+            BitmapAlphaMode.Premultiplied,
+            (uint)rtb.PixelWidth,
+            (uint)rtb.PixelHeight,
+            dpi,
+            dpi,
+            pixels);
+        await encoder.FlushAsync();
+
+        stream.Seek(0);
+        var bytes = new byte[stream.Size];
+        using var reader = new DataReader(stream);
+        await reader.LoadAsync((uint)stream.Size);
+        reader.ReadBytes(bytes);
+        return Convert.ToBase64String(bytes);
+    }
+
+    /// <summary>
+    /// JSON state dump: surfaces (with components + data model) keyed by id.
+    /// Returned as a string so callers can hand it back through MCP without
+    /// further serialization. Reflects the renderer's authoritative state at
+    /// call time — components that haven't been rendered yet are still listed.
+    /// </summary>
+    public string GetStateSnapshot()
+    {
+        var surfaces = new JsonObject();
+        foreach (var (id, host) in _router.Surfaces)
+        {
+            surfaces[id] = host.GetSnapshot();
+        }
+        var snapshot = new JsonObject
+        {
+            ["renderer"] = "native",
+            ["a2uiVersion"] = "0.8",
+            ["surfaceCount"] = _router.Surfaces.Count,
+            ["surfaces"] = surfaces,
+        };
+        return snapshot.ToJsonString();
+    }
+
+    public void BringToFront(bool keepTopMost = false)
+    {
+        try
+        {
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            if (hwnd == IntPtr.Zero) return;
+            ShowWindow(hwnd, SW_SHOWNORMAL);
+            SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+            SetForegroundWindow(hwnd);
+            if (!keepTopMost)
+                SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+        }
+        catch { /* best-effort */ }
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Windows/A2UICanvasWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/A2UICanvasWindow.xaml.cs
@@ -57,6 +57,7 @@ public sealed partial class A2UICanvasWindow : WindowEx
         InitializeComponent();
         this.SetIcon("Assets\\openclaw.ico");
         Closed += (_, _) => IsClosed = true;
+        WaitingForContentText.Text = OpenClawTray.Helpers.LocalizationHelper.GetString("Canvas_WaitingForContent");
 
         _dispatcher = DispatcherQueue.GetForCurrentThread();
         _dataModel = new DataModelStore(_dispatcher);
@@ -86,6 +87,10 @@ public sealed partial class A2UICanvasWindow : WindowEx
         UpdateLayout();
     }
 
+    // SurfaceId → existing TabViewItem, so add/remove diffs can preserve the
+    // user's selected tab and avoid re-templating unchanged surfaces (M15).
+    private readonly Dictionary<string, TabViewItem> _surfaceTabs = new(StringComparer.Ordinal);
+
     private void UpdateLayout()
     {
         var surfaces = new List<SurfaceHost>(_router.Surfaces.Values);
@@ -96,7 +101,8 @@ public sealed partial class A2UICanvasWindow : WindowEx
             MultiSurfaceTabs.Visibility = Visibility.Collapsed;
             SingleSurfaceHost.Content = null;
             MultiSurfaceTabs.TabItems.Clear();
-            Title = "Canvas";
+            _surfaceTabs.Clear();
+            Title = OpenClawTray.Helpers.LocalizationHelper.GetString("A2UI_CanvasTitle");
             return;
         }
 
@@ -109,26 +115,74 @@ public sealed partial class A2UICanvasWindow : WindowEx
             MultiSurfaceTabs.Visibility = Visibility.Collapsed;
             SingleSurfaceHost.Content = s.RootElement;
             MultiSurfaceTabs.TabItems.Clear();
-            Title = string.IsNullOrWhiteSpace(s.Title) ? "Canvas" : s.Title!;
+            _surfaceTabs.Clear();
+            Title = string.IsNullOrWhiteSpace(s.Title)
+                ? OpenClawTray.Helpers.LocalizationHelper.GetString("A2UI_CanvasTitle")
+                : s.Title!;
+            return;
         }
-        else
+
+        SingleSurfaceHost.Visibility = Visibility.Collapsed;
+        MultiSurfaceTabs.Visibility = Visibility.Visible;
+        SingleSurfaceHost.Content = null;
+
+        // Diff incrementally so a third surface added doesn't reset the user's
+        // selected tab. Algorithm:
+        //   1. Track the currently selected surface id (if any) so we can restore it.
+        //   2. Remove tabs whose surfaceId no longer exists.
+        //   3. For each surface: reuse the cached TabViewItem (refresh header) or create.
+        //   4. Reorder TabItems to match the surface list.
+        var selectedId = (MultiSurfaceTabs.SelectedItem as TabViewItem)?.Tag as string;
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var s in surfaces) seen.Add(s.SurfaceId);
+
+        // Pass 1: drop stale.
+        var stale = new List<string>();
+        foreach (var kv in _surfaceTabs)
+            if (!seen.Contains(kv.Key)) stale.Add(kv.Key);
+        foreach (var id in stale)
         {
-            SingleSurfaceHost.Visibility = Visibility.Collapsed;
-            MultiSurfaceTabs.Visibility = Visibility.Visible;
-            SingleSurfaceHost.Content = null;
-            MultiSurfaceTabs.TabItems.Clear();
-            foreach (var s in surfaces)
+            if (_surfaceTabs.Remove(id, out var oldTab))
+                MultiSurfaceTabs.TabItems.Remove(oldTab);
+        }
+
+        // Pass 2: ensure each surface has a tab and the visual ordering matches.
+        for (int i = 0; i < surfaces.Count; i++)
+        {
+            var s = surfaces[i];
+            var header = string.IsNullOrWhiteSpace(s.Title) ? s.SurfaceId : s.Title!;
+            if (!_surfaceTabs.TryGetValue(s.SurfaceId, out var tab))
             {
-                var tab = new TabViewItem
+                tab = new TabViewItem
                 {
-                    Header = string.IsNullOrWhiteSpace(s.Title) ? s.SurfaceId : s.Title!,
+                    Header = header,
                     Content = s.RootElement,
                     IsClosable = false,
+                    Tag = s.SurfaceId,
                 };
-                MultiSurfaceTabs.TabItems.Add(tab);
+                _surfaceTabs[s.SurfaceId] = tab;
+                MultiSurfaceTabs.TabItems.Insert(i, tab);
             }
-            Title = "Canvas";
+            else
+            {
+                if (!Equals(tab.Header, header)) tab.Header = header;
+                if (!ReferenceEquals(tab.Content, s.RootElement)) tab.Content = s.RootElement;
+                int currentIndex = MultiSurfaceTabs.TabItems.IndexOf(tab);
+                if (currentIndex != i)
+                {
+                    MultiSurfaceTabs.TabItems.RemoveAt(currentIndex);
+                    MultiSurfaceTabs.TabItems.Insert(i, tab);
+                }
+            }
         }
+
+        // Restore selection by surfaceId. WinUI auto-selects index 0 when items
+        // are inserted into an empty TabView; re-select the previously-selected
+        // surface if it still exists.
+        if (selectedId != null && _surfaceTabs.TryGetValue(selectedId, out var stillSelected))
+            MultiSurfaceTabs.SelectedItem = stillSelected;
+
+        Title = OpenClawTray.Helpers.LocalizationHelper.GetString("A2UI_CanvasTitle");
     }
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/Windows/A2UICanvasWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/A2UICanvasWindow.xaml.cs
@@ -56,7 +56,9 @@ public sealed partial class A2UICanvasWindow : WindowEx
     {
         InitializeComponent();
         this.SetIcon("Assets\\openclaw.ico");
-        Closed += (_, _) => IsClosed = true;
+        // Title is set programmatically (rather than via XAML literal) so we
+        // never flash "Canvas" in en-US before the locale's resw value loads.
+        Title = OpenClawTray.Helpers.LocalizationHelper.GetString("A2UI_CanvasTitle");
         WaitingForContentText.Text = OpenClawTray.Helpers.LocalizationHelper.GetString("Canvas_WaitingForContent");
 
         _dispatcher = DispatcherQueue.GetForCurrentThread();
@@ -66,6 +68,19 @@ public sealed partial class A2UICanvasWindow : WindowEx
 
         _router.SurfaceCreated += OnSurfaceCreated;
         _router.SurfaceDeleted += OnSurfaceDeleted;
+
+        // Explicit teardown: unsubscribe router events and reset surfaces so
+        // the router's component subscriptions don't outlive the window. The
+        // router holds back-references via event delegates; without this, a
+        // closed window stays GC-rooted by router state until the next
+        // ResetAll, which may never come if the window owned the router.
+        Closed += (_, _) =>
+        {
+            IsClosed = true;
+            try { _router.SurfaceCreated -= OnSurfaceCreated; } catch { }
+            try { _router.SurfaceDeleted -= OnSurfaceDeleted; } catch { }
+            try { _router.ResetAll(); } catch { }
+        };
     }
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml
@@ -234,6 +234,34 @@
                                    Style="{StaticResource CaptionTextBlockStyle}"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                     </Grid>
+                    <Grid Margin="0,4,0,0" ColumnSpacing="8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" x:Uid="SettingsMcpTokenLabel" Text="Bearer token:" Style="{StaticResource CaptionTextBlockStyle}"
+                                   VerticalAlignment="Center"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                        <TextBox Grid.Column="1" x:Name="McpTokenTextBox" IsReadOnly="True"
+                                 BorderThickness="0" Background="Transparent" Padding="0"
+                                 FontFamily="Consolas" FontSize="12"
+                                 VerticalAlignment="Center"
+                                 AutomationProperties.AutomationId="McpTokenTextBox"/>
+                        <Button Grid.Column="2" x:Name="McpTokenRevealButton" x:Uid="SettingsMcpTokenRevealButton"
+                                AutomationProperties.AutomationId="McpTokenRevealButton"
+                                Content="Reveal" Click="OnRevealMcpToken" Padding="8,2"/>
+                        <Button Grid.Column="3" x:Name="McpTokenCopyButton" x:Uid="SettingsMcpTokenCopyButton"
+                                AutomationProperties.AutomationId="McpTokenCopyButton"
+                                Content="Copy" Click="OnCopyMcpToken" Padding="8,2" Margin="4,0,0,0"/>
+                    </Grid>
+                    <TextBlock x:Uid="SettingsMcpTokenHint"
+                               x:Name="McpTokenHintText"
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               TextWrapping="Wrap"
+                               Margin="0,2,0,0"/>
                 </StackPanel>
                 
             </StackPanel>

--- a/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml
@@ -237,10 +237,11 @@
                     <Grid Margin="0,4,0,0" ColumnSpacing="8">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
+                             <ColumnDefinition Width="*"/>
+                             <ColumnDefinition Width="Auto"/>
+                             <ColumnDefinition Width="Auto"/>
+                             <ColumnDefinition Width="Auto"/>
+                         </Grid.ColumnDefinitions>
                         <TextBlock Grid.Column="0" x:Uid="SettingsMcpTokenLabel" Text="Bearer token:" Style="{StaticResource CaptionTextBlockStyle}"
                                    VerticalAlignment="Center"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
@@ -252,10 +253,13 @@
                         <Button Grid.Column="2" x:Name="McpTokenRevealButton" x:Uid="SettingsMcpTokenRevealButton"
                                 AutomationProperties.AutomationId="McpTokenRevealButton"
                                 Content="Reveal" Click="OnRevealMcpToken" Padding="8,2"/>
-                        <Button Grid.Column="3" x:Name="McpTokenCopyButton" x:Uid="SettingsMcpTokenCopyButton"
-                                AutomationProperties.AutomationId="McpTokenCopyButton"
-                                Content="Copy" Click="OnCopyMcpToken" Padding="8,2" Margin="4,0,0,0"/>
-                    </Grid>
+                         <Button Grid.Column="3" x:Name="McpTokenCopyButton" x:Uid="SettingsMcpTokenCopyButton"
+                                 AutomationProperties.AutomationId="McpTokenCopyButton"
+                                 Content="Copy" Click="OnCopyMcpToken" Padding="8,2" Margin="4,0,0,0"/>
+                         <Button Grid.Column="4" x:Name="McpTokenResetButton"
+                                 AutomationProperties.AutomationId="McpTokenResetButton"
+                                 Content="Reset" Click="OnResetMcpToken" Padding="8,2" Margin="4,0,0,0"/>
+                     </Grid>
                     <TextBlock x:Uid="SettingsMcpTokenHint"
                                x:Name="McpTokenHintText"
                                Style="{StaticResource CaptionTextBlockStyle}"

--- a/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml
@@ -256,7 +256,7 @@
                          <Button Grid.Column="3" x:Name="McpTokenCopyButton" x:Uid="SettingsMcpTokenCopyButton"
                                  AutomationProperties.AutomationId="McpTokenCopyButton"
                                  Content="Copy" Click="OnCopyMcpToken" Padding="8,2" Margin="4,0,0,0"/>
-                         <Button Grid.Column="4" x:Name="McpTokenResetButton"
+                         <Button Grid.Column="4" x:Name="McpTokenResetButton" x:Uid="SettingsMcpTokenResetButton"
                                  AutomationProperties.AutomationId="McpTokenResetButton"
                                  Content="Reset" Click="OnResetMcpToken" Padding="8,2" Margin="4,0,0,0"/>
                      </Grid>

--- a/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml.cs
@@ -12,7 +12,11 @@ namespace OpenClawTray.Windows;
 public sealed partial class SettingsWindow : WindowEx
 {
     private readonly SettingsManager _settings;
-    private readonly NodeService? _nodeService;
+    // Delegate (not captured instance) so the window always reads the current
+    // node service — the tray disposes & recreates NodeService in
+    // App.OnSettingsSaved, and the previous reference would otherwise go stale
+    // and show "Stopped" / "Failed to start" forever.
+    private readonly Func<NodeService?> _nodeServiceProvider;
     private string _manualGatewayUrl = "";
     public bool IsClosed { get; private set; }
 
@@ -20,9 +24,14 @@ public sealed partial class SettingsWindow : WindowEx
     public event EventHandler? CommandCenterRequested;
 
     public SettingsWindow(SettingsManager settings, NodeService? nodeService = null)
+        : this(settings, nodeService != null ? () => nodeService : (Func<NodeService?>)(() => null))
+    {
+    }
+
+    public SettingsWindow(SettingsManager settings, Func<NodeService?> nodeServiceProvider)
     {
         _settings = settings;
-        _nodeService = nodeService;
+        _nodeServiceProvider = nodeServiceProvider;
         InitializeComponent();
         
         Title = LocalizationHelper.GetString("WindowTitle_Settings");
@@ -140,12 +149,28 @@ public sealed partial class SettingsWindow : WindowEx
         }
     }
 
+    /// <summary>
+    /// Public refresh hook called by the host after it tears down and rebuilds
+    /// the NodeService (e.g. App.OnSettingsSaved). Re-reads the running/error
+    /// state from the current node service and refreshes the status text.
+    /// </summary>
+    public void RefreshMcpStatus()
+    {
+        try
+        {
+            UpdateMcpStatus();
+            UpdateMcpTokenDisplay();
+        }
+        catch { /* best-effort UI refresh */ }
+    }
+
     private void UpdateMcpStatus()
     {
         var toggleOn = McpServerToggle.IsOn;
         var savedOn = _settings.EnableMcpServer;
-        var running = _nodeService?.IsMcpRunning == true;
-        var startupError = _nodeService?.McpStartupError;
+        var nodeService = _nodeServiceProvider();
+        var running = nodeService?.IsMcpRunning == true;
+        var startupError = nodeService?.McpStartupError;
 
         if (!toggleOn)
         {

--- a/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml.cs
@@ -90,6 +90,54 @@ public sealed partial class SettingsWindow : WindowEx
         McpUrlTextBox.Text = NodeService.McpServerUrl;
         McpServerToggle.Toggled += (_, _) => UpdateMcpStatus();
         UpdateMcpStatus();
+        UpdateMcpTokenDisplay();
+    }
+
+    // Bearer-token display state. Token is masked by default — first click of Reveal
+    // shows it, second click hides again. Copy always copies the unmasked value.
+    private bool _mcpTokenRevealed;
+
+    private void UpdateMcpTokenDisplay()
+    {
+        var token = OpenClaw.Shared.Mcp.McpAuthToken.TryLoad(NodeService.McpTokenPath);
+        var path = NodeService.McpTokenPath;
+        if (token == null)
+        {
+            // File hasn't been generated yet — only happens before the first MCP server start.
+            McpTokenTextBox.Text = "(not generated — enable MCP server and click Save)";
+            McpTokenRevealButton.IsEnabled = false;
+            McpTokenCopyButton.IsEnabled = false;
+            McpTokenHintText.Text = $"Stored at {path}";
+            return;
+        }
+        McpTokenRevealButton.IsEnabled = true;
+        McpTokenCopyButton.IsEnabled = true;
+        McpTokenTextBox.Text = _mcpTokenRevealed ? token : new string('•', token.Length);
+        McpTokenRevealButton.Content = _mcpTokenRevealed ? "Hide" : "Reveal";
+        McpTokenHintText.Text =
+            $"Send as 'Authorization: Bearer <token>' on every request. Stored at {path}.";
+    }
+
+    private void OnRevealMcpToken(object sender, RoutedEventArgs e)
+    {
+        _mcpTokenRevealed = !_mcpTokenRevealed;
+        UpdateMcpTokenDisplay();
+    }
+
+    private void OnCopyMcpToken(object sender, RoutedEventArgs e)
+    {
+        var token = OpenClaw.Shared.Mcp.McpAuthToken.TryLoad(NodeService.McpTokenPath);
+        if (string.IsNullOrEmpty(token)) return;
+        try
+        {
+            var pkg = new global::Windows.ApplicationModel.DataTransfer.DataPackage();
+            pkg.SetText(token);
+            global::Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(pkg);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"[Settings] Failed to copy MCP bearer token: {ex.Message}");
+        }
     }
 
     private void UpdateMcpStatus()

--- a/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml.cs
@@ -113,20 +113,22 @@ public sealed partial class SettingsWindow : WindowEx
         if (token == null)
         {
             // File hasn't been generated yet — only happens before the first MCP server start.
-            McpTokenTextBox.Text = "(not generated — enable MCP server and click Save)";
+            McpTokenTextBox.Text = LocalizationHelper.GetString("SettingsMcpToken_NotGenerated");
             McpTokenRevealButton.IsEnabled = false;
             McpTokenCopyButton.IsEnabled = false;
             McpTokenResetButton.IsEnabled = true;
-            McpTokenHintText.Text = $"Stored at {path}";
+            McpTokenHintText.Text = string.Format(System.Globalization.CultureInfo.CurrentCulture,
+                LocalizationHelper.GetString("SettingsMcpToken_StoredAtFormat"), path);
             return;
         }
         McpTokenRevealButton.IsEnabled = true;
         McpTokenCopyButton.IsEnabled = true;
         McpTokenResetButton.IsEnabled = true;
         McpTokenTextBox.Text = _mcpTokenRevealed ? token : new string('•', token.Length);
-        McpTokenRevealButton.Content = _mcpTokenRevealed ? "Hide" : "Reveal";
-        McpTokenHintText.Text =
-            $"Send as 'Authorization: Bearer <token>' on every request. Stored at {path}.";
+        McpTokenRevealButton.Content = LocalizationHelper.GetString(
+            _mcpTokenRevealed ? "SettingsMcpToken_HideButton" : "SettingsMcpToken_RevealButton");
+        McpTokenHintText.Text = string.Format(System.Globalization.CultureInfo.CurrentCulture,
+            LocalizationHelper.GetString("SettingsMcpToken_HintFormat"), path);
     }
 
     private void OnRevealMcpToken(object sender, RoutedEventArgs e)
@@ -134,6 +136,13 @@ public sealed partial class SettingsWindow : WindowEx
         _mcpTokenRevealed = !_mcpTokenRevealed;
         UpdateMcpTokenDisplay();
     }
+
+    // Auto-clear delay for the bearer token after Copy. 30s matches the
+    // Edge/Chrome password-manager default and gives the user time to switch
+    // windows and paste once. We only wipe if the clipboard *still* contains
+    // our token — copying anything else in the interim takes precedence.
+    private static readonly TimeSpan s_mcpTokenClipboardClearDelay = TimeSpan.FromSeconds(30);
+    private System.Threading.CancellationTokenSource? _mcpTokenClipboardClearCts;
 
     private void OnCopyMcpToken(object sender, RoutedEventArgs e)
     {
@@ -144,6 +153,7 @@ public sealed partial class SettingsWindow : WindowEx
             var pkg = new global::Windows.ApplicationModel.DataTransfer.DataPackage();
             pkg.SetText(token);
             global::Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(pkg);
+            ScheduleMcpTokenClipboardClear(token);
         }
         catch (Exception ex)
         {
@@ -151,8 +161,56 @@ public sealed partial class SettingsWindow : WindowEx
         }
     }
 
-    private void OnResetMcpToken(object sender, RoutedEventArgs e)
+    private void ScheduleMcpTokenClipboardClear(string copiedToken)
     {
+        // Cancel any previous pending clear — we just refreshed the clipboard.
+        _mcpTokenClipboardClearCts?.Cancel();
+        _mcpTokenClipboardClearCts?.Dispose();
+        var cts = new System.Threading.CancellationTokenSource();
+        _mcpTokenClipboardClearCts = cts;
+        var dispatcherQueue = global::Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(s_mcpTokenClipboardClearDelay, cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { return; }
+
+            // Clipboard APIs are STA-bound — marshal back to the UI thread.
+            dispatcherQueue?.TryEnqueue(() =>
+            {
+                try
+                {
+                    var current = global::Windows.ApplicationModel.DataTransfer.Clipboard.GetContent();
+                    if (current == null) return;
+                    if (!current.Contains(global::Windows.ApplicationModel.DataTransfer.StandardDataFormats.Text)) return;
+                    string? text = null;
+                    try
+                    {
+                        text = current.GetTextAsync().AsTask().GetAwaiter().GetResult();
+                    }
+                    catch { return; }
+                    if (!string.Equals(text, copiedToken, StringComparison.Ordinal)) return; // user replaced it
+                    global::Windows.ApplicationModel.DataTransfer.Clipboard.Clear();
+                    Logger.Info("[Settings] MCP bearer token auto-cleared from clipboard");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warn($"[Settings] Clipboard auto-clear failed: {ex.Message}");
+                }
+            });
+        });
+    }
+
+    private async void OnResetMcpToken(object sender, RoutedEventArgs e)
+    {
+        // Reset rotates the bearer token immediately and invalidates every
+        // configured local MCP client. A single accidental click would force
+        // the user to reconfigure Claude Desktop / Cursor / Claude Code, so
+        // gate behind a confirmation dialog with Cancel as the default button.
+        if (!await ConfirmResetMcpTokenAsync()) return;
+
         try
         {
             var nodeService = _nodeServiceProvider();
@@ -166,16 +224,65 @@ public sealed partial class SettingsWindow : WindowEx
             Logger.Info("[Settings] MCP bearer token reset");
 
             new ToastContentBuilder()
-                .AddText("MCP token reset")
-                .AddText("Old MCP bearer tokens are now invalid.")
+                .AddText(LocalizationHelper.GetString("SettingsMcpToken_ResetToastTitle"))
+                .AddText(LocalizationHelper.GetString("SettingsMcpToken_ResetToastBody"))
                 .Show();
         }
         catch (Exception ex)
         {
             Logger.Warn($"[Settings] Failed to reset MCP bearer token: {ex.Message}");
-            McpTokenHintText.Text = $"Failed to reset token: {ex.Message}";
+            McpTokenHintText.Text = string.Format(System.Globalization.CultureInfo.CurrentCulture,
+                LocalizationHelper.GetString("SettingsMcpToken_ResetFailedFormat"), ex.Message);
         }
     }
+
+    private async Task<bool> ConfirmResetMcpTokenAsync()
+    {
+        // ContentDialog needs a XamlRoot to anchor against. Settings is a real
+        // WinUI window with content, so this should always succeed; if it
+        // doesn't (e.g. content not yet attached), fall back to confirming via
+        // a Win32 message box rather than silently performing the reset.
+        var xamlRoot = (this.Content as Microsoft.UI.Xaml.FrameworkElement)?.XamlRoot;
+        if (xamlRoot != null)
+        {
+            try
+            {
+                var dialog = new Microsoft.UI.Xaml.Controls.ContentDialog
+                {
+                    Title = LocalizationHelper.GetString("SettingsMcpTokenResetDialog_Title"),
+                    Content = LocalizationHelper.GetString("SettingsMcpTokenResetDialog_Body"),
+                    PrimaryButtonText = LocalizationHelper.GetString("SettingsMcpTokenResetDialog_PrimaryButton"),
+                    CloseButtonText = LocalizationHelper.GetString("SettingsMcpTokenResetDialog_CloseButton"),
+                    DefaultButton = Microsoft.UI.Xaml.Controls.ContentDialogButton.Close,
+                    XamlRoot = xamlRoot,
+                };
+                var result = await dialog.ShowAsync();
+                return result == Microsoft.UI.Xaml.Controls.ContentDialogResult.Primary;
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn($"[Settings] Reset confirmation dialog failed, falling back to MessageBox: {ex.Message}");
+            }
+        }
+
+        // Off-thread fallback: Win32 MessageBoxW so we never reset without confirmation.
+        return await Task.Run(() =>
+        {
+            const uint MB_OKCANCEL = 0x00000001;
+            const uint MB_ICONWARNING = 0x00000030;
+            const uint MB_DEFBUTTON2 = 0x00000100;
+            const int IDOK = 1;
+            var caption = LocalizationHelper.GetString("SettingsMcpTokenResetDialog_Title");
+            var text = LocalizationHelper.GetString("SettingsMcpTokenResetDialog_Body");
+            var rc = NativeMessageBox(IntPtr.Zero, text, caption,
+                MB_OKCANCEL | MB_ICONWARNING | MB_DEFBUTTON2);
+            return rc == IDOK;
+        });
+    }
+
+    [System.Runtime.InteropServices.DllImport("user32.dll", EntryPoint = "MessageBoxW",
+        CharSet = System.Runtime.InteropServices.CharSet.Unicode, SetLastError = true)]
+    private static extern int NativeMessageBox(IntPtr hWnd, string text, string caption, uint type);
 
     /// <summary>
     /// Public refresh hook called by the host after it tears down and rebuilds

--- a/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/SettingsWindow.xaml.cs
@@ -116,11 +116,13 @@ public sealed partial class SettingsWindow : WindowEx
             McpTokenTextBox.Text = "(not generated — enable MCP server and click Save)";
             McpTokenRevealButton.IsEnabled = false;
             McpTokenCopyButton.IsEnabled = false;
+            McpTokenResetButton.IsEnabled = true;
             McpTokenHintText.Text = $"Stored at {path}";
             return;
         }
         McpTokenRevealButton.IsEnabled = true;
         McpTokenCopyButton.IsEnabled = true;
+        McpTokenResetButton.IsEnabled = true;
         McpTokenTextBox.Text = _mcpTokenRevealed ? token : new string('•', token.Length);
         McpTokenRevealButton.Content = _mcpTokenRevealed ? "Hide" : "Reveal";
         McpTokenHintText.Text =
@@ -146,6 +148,32 @@ public sealed partial class SettingsWindow : WindowEx
         catch (Exception ex)
         {
             Logger.Warn($"[Settings] Failed to copy MCP bearer token: {ex.Message}");
+        }
+    }
+
+    private void OnResetMcpToken(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var nodeService = _nodeServiceProvider();
+            if (nodeService != null)
+                nodeService.ResetMcpToken();
+            else
+                OpenClaw.Shared.Mcp.McpAuthToken.Reset(NodeService.McpTokenPath);
+
+            _mcpTokenRevealed = false;
+            UpdateMcpTokenDisplay();
+            Logger.Info("[Settings] MCP bearer token reset");
+
+            new ToastContentBuilder()
+                .AddText("MCP token reset")
+                .AddText("Old MCP bearer tokens are now invalid.")
+                .Show();
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"[Settings] Failed to reset MCP bearer token: {ex.Message}");
+            McpTokenHintText.Text = $"Failed to reset token: {ex.Message}";
         }
     }
 

--- a/src/skills/windows-a2ui/SKILL.md
+++ b/src/skills/windows-a2ui/SKILL.md
@@ -96,7 +96,7 @@ Children are referenced by **id**, not nested in place. Build the surface as a f
 | Component | Properties |
 |---|---|
 | **Text** | `text`: A2UIValue; `usageHint`: `h1`/`h2`/`h3`/`h4`/`h5`/`body` (default) /`caption`. Maps to WinUI text styles (`TitleLargeTextBlockStyle` etc.). Wraps. |
-| **Image** | `url`: A2UIValue; `fit`: `contain`/`cover`/`fill`/`none`/`scale-down` (defaults to `contain`); `usageHint`: `icon` (24 px square), `avatar` (40 px square), `smallFeature` (h=80), `mediumFeature` (h=160), `largeFeature` (h=240), `header` (stretch). `description` or `label` is used as the automation/alt name. Subject to MediaResolver allowlist. |
+| **Image** | `url`: A2UIValue; `fit`: `contain`/`cover`/`fill`/`none`/`scale-down` (defaults to `contain`); `usageHint`: `icon` (24 px square), `avatar` (40 px square), `smallFeature` (h=80), `mediumFeature` (h=160), `largeFeature` (h=240), `header` (stretch). `description` or `label` is used as the automation/alt name. Subject to MediaResolver allowlist. SVG is supported via the same `url` slot. Accepted as `data:image/svg+xml;base64,…` (≤ 2 MiB) or as `https://allowed-host/…svg` (host must be in `Settings.A2UIImageHosts`). The renderer uses Direct2D's static SVG 1.1 subset — no scripts, no animation, no `<foreignObject>`, no external references. Self-contained SVGs only. |
 | **Icon** | `name`: A2UIValue resolving to an entry in the icon enum below. |
 | **Video** | `url`: A2UIValue. Renders as `MediaPlayerElement` with transport controls. URL must pass MediaResolver allowlist. |
 | **AudioPlayer** | `url`: A2UIValue; optional `description`: A2UIValue (caption above the player). |
@@ -196,6 +196,39 @@ Notes on the example:
 - The Button declares `dataBinding: ["/form"]` so both `/form/email` and `/form/password` are in scope. Without that, `/form/password` would be dropped from `action.context` because the `obscured` TextField marks it as secret and the implicit scope refuses to include secrets.
 - Each child is declared as a top-level component and referenced by id; do not nest component objects inline.
 - `beginRendering.root` is sent last, after all component and data-model state is in place.
+
+## Prefer generated SVG over external raster URLs
+
+The Windows node's image pipeline is **closed by default for HTTPS hosts** — `Settings.A2UIImageHosts` is empty until the operator adds entries. That means `<Image>` components pointing at arbitrary `https://cdn.example.com/icon.png` URLs will almost always render as a broken-image placeholder on a fresh install. Don't assume any specific image host is reachable.
+
+**Default to inline-generated SVG via `data:image/svg+xml;…`.** SVG is small in bytes, expressive enough for icons, charts, badges, status glyphs, sparklines, simple diagrams, and arbitrary vector illustration, and works on every Windows node without any operator configuration. The 2 MiB data-URL cap is generous — text SVG compresses well, and 2 MiB holds a substantial amount of geometry.
+
+When to use which:
+
+- **Inline SVG (`data:image/svg+xml;…`)** — first choice for anything you can author from primitives: icons not in the v0.8 icon enum, status indicators, progress bars beyond `<Slider>`, simple charts, color swatches, ASCII-style diagrams as vector, decorative dividers, signature/handwriting, geometry the agent computed.
+- **Inline data-URL raster (`data:image/png;…`, `data:image/jpeg;…`, `data:image/webp;…`)** — when the agent already has raster bytes (e.g., from a screenshot tool or a generated image). Same 2 MiB cap.
+- **Allowlisted `https://`** — only when you have specific reason to believe the host is on `Settings.A2UIImageHosts` (e.g., the user previously confirmed it, or you're writing a surface for a known operator deployment with a known image CDN). Otherwise, prefer one of the two above.
+
+Authoring guidance for SVG:
+
+- Always include `xmlns="http://www.w3.org/2000/svg"` on the root `<svg>` element.
+- Set an explicit `viewBox` (e.g. `viewBox="0 0 24 24"` for icons) and let `fit` on the `<Image>` component handle scaling. Don't bake fixed `width`/`height` into the SVG.
+- Use `<rect>`, `<circle>`, `<ellipse>`, `<line>`, `<polyline>`, `<polygon>`, `<path>`, `<g>`, `<text>` — these are well-supported by the static SVG 1.1 subset.
+- Avoid `<script>`, event-handler attributes (`onload`, etc.), `<animate>`/SMIL, `<foreignObject>`, `<image href="https://…">`, `<use href="https://…">`. They will be silently ignored — the renderer is a static subset — but emitting them is a tell that the SVG was poorly authored, and at minimum wastes data-URL budget.
+- Encoding: prefer raw `data:image/svg+xml;utf8,<svg…>` (URL-encode the `<`, `>`, `#`, and `"` characters) for small SVGs to keep them human-readable; switch to `data:image/svg+xml;base64,…` once the payload exceeds a few hundred bytes.
+- Keep payloads well below the 2 MiB cap. Aim for "small icons under 1 KB, complex illustrations under 100 KB, charts under 500 KB." If a single image needs more than that, the right answer is probably to compose multiple A2UI components rather than ship one giant SVG.
+
+Example — inline SVG icon used in place of a raster URL:
+
+```json
+{"id":"checkIcon","component":{"Image":{
+  "url":{"literalString":"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M5 12l4 4 10-10' stroke='currentColor' stroke-width='2' fill='none'/></svg>"},
+  "fit":"contain",
+  "usageHint":"icon"
+}}}
+```
+
+The single biggest UX difference between a Windows-node A2UI surface that "just works" and one that's full of broken-image placeholders is whether the agent reaches for inline SVG or external raster URLs. Reach for SVG.
 
 ## Things to avoid
 

--- a/src/skills/windows-a2ui/SKILL.md
+++ b/src/skills/windows-a2ui/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: windows-a2ui
+description: Generate A2UI v0.8 surfaces for the OpenClaw Windows tray node, which renders A2UI natively in WinUI/XAML (not a WebView). Read this when pushing canvas.a2ui.push/canvas.a2ui.pushJSONL to a Windows node — covers the 18 supported components (Row, Column, List, Card, Tabs, Modal, Divider, Text, Image, Icon, Video, AudioPlayer, Button, CheckBox, TextField, DateTimeInput, MultipleChoice, Slider), the icon-name enum, the A2UIValue tagged union, JSONL envelope shapes, and action.context security / dataBinding rules. Catalog-strict: components outside this list render as the fallback Unknown placeholder.
+---
+
+# Windows Node A2UI
+
+The Windows tray node (`OpenClaw.Tray.WinUI`) implements an A2UI v0.8 renderer in **native WinUI 3 / XAML**. Each A2UI component maps to a real `FrameworkElement` (StackPanel, Border, TabView, TextBox, Slider, etc.) — there is no WebView, no Lit, no shadow DOM. The renderer is **catalog-strict**: a `surfaceUpdate` referencing a component name not in the table below renders as a single Unknown placeholder, not as an attempted best-effort.
+
+Use this skill whenever the user asks the agent to push UI to a Windows node, or whenever you'd otherwise generate a generic A2UI payload — Windows specifics (component set, icon enum, secret-path rules) differ from the Lit reference renderer.
+
+## Wire shape
+
+A2UI is delivered to the node via the gateway RPC `canvas.a2ui.push` (or the alias `canvas.a2ui.pushJSONL`), with a single string parameter `jsonl` holding **newline-separated JSON envelopes**. Surfaces are torn down with `canvas.a2ui.reset` (no parameters).
+
+Four envelope kinds, sent in order:
+
+```jsonl
+{"surfaceUpdate":{"surfaceId":"main","components":[ /* component defs */ ]}}
+{"dataModelUpdate":{"surfaceId":"main","path":"/","contents":[ /* entries */ ]}}
+{"beginRendering":{"surfaceId":"main","root":"<root-component-id>","catalogId":"a2ui-v0.8","styles":{}}}
+{"deleteSurface":{"surfaceId":"main"}}
+```
+
+- `surfaceUpdate` declares (or replaces) the component set for a surface. There is no separate createSurface envelope in v0.8 — the surface is implied by its first surfaceUpdate.
+- `dataModelUpdate` writes typed entries into the surface's data model. `path` scopes the keys; omit (or use `"/"`) to replace the whole model.
+- `beginRendering` picks the root component for the surface and applies optional styles. Send it after the surfaceUpdate that introduces the components.
+- `deleteSurface` tears a surface down. Use `canvas.a2ui.reset` if you want every surface gone.
+
+Lines exceeding 1 MiB are dropped server-side. Malformed lines are logged and skipped — they do not abort the stream.
+
+## Component definition shape
+
+Each entry of `surfaceUpdate.components`:
+
+```json
+{
+  "id": "btnPrimary",
+  "component": { "<ComponentName>": { /* properties */ } },
+  "weight": 1.0
+}
+```
+
+- `id` is the surface-unique handle used as a child reference and as `sourceComponentId` on outbound actions.
+- `component` is a one-key wrapper whose key is the discriminator. Names are case-sensitive (the registry is loaded with `OrdinalIgnoreCase` lookup, but match the wire exactly).
+- `weight` is optional and currently ignored by the Windows renderer's StackPanel layout.
+
+## A2UIValue (the literal-or-bound tagged union)
+
+Almost every component property accepts a value of this shape:
+
+```json
+{ "literalString":  "Hello" }
+{ "literalNumber":  42 }
+{ "literalBoolean": true }
+{ "literalArray":   ["a", "b"] }
+{ "path":           "/user/name" }
+```
+
+A `path` is a JSON Pointer into the surface's data model. The renderer subscribes to the path and re-renders the affected element on `dataModelUpdate`. Two-way bindings (TextField, CheckBox, Slider, DateTimeInput, MultipleChoice) write back to the same path on user interaction.
+
+## Data model entries
+
+`dataModelUpdate.contents[]` items:
+
+```json
+{ "key": "name",     "valueString":  "Alice" }
+{ "key": "count",    "valueNumber":  3 }
+{ "key": "enabled",  "valueBoolean": true }
+{ "key": "user",     "valueMap": [
+  { "key": "first",  "valueString": "Alice" },
+  { "key": "last",   "valueString": "Smith" }
+] }
+```
+
+Exactly one of `valueString` / `valueNumber` / `valueBoolean` / `valueMap` should be set per entry. `valueMap` is a recursive adjacency list (each item is itself an entry). Arrays of strings are not first-class on the data-model side — store them as a `path` consumed by `MultipleChoice.selections` or by a literalArray default.
+
+## Components
+
+### Containers
+
+| Component | Children | Properties (Windows-renderer) |
+|---|---|---|
+| **Row** | `children: { "explicitList": ["id1","id2",...] }` | `distribution`: `start`/`center`/`end`/`spaceBetween`/`spaceAround`/`spaceEvenly` (main-axis); `alignment`: `start`/`center`/`end`/`stretch` (cross-axis). Renders as horizontal `StackPanel`; default spacing 8. |
+| **Column** | `children: { "explicitList": [...] }` | Same as Row, vertical. |
+| **List** | `children: { "explicitList": [...] }` | `direction`: `vertical` (default) or `horizontal`; `alignment`. Wrapped in a `ScrollViewer`. **Template/data-bound rows are not supported in v1** — supply explicit child ids. |
+| **Card** | `child: "<id>"` (single string, not explicitList) | None. Renders as a themed `Border` with 16 px padding and rounded corners. |
+| **Tabs** | per-tab via `tabItems` | `tabItems: [{ "title": <A2UIValue>, "child": "<id>" }, ...]`. Renders as a `TabView` with non-closable, non-reorderable tabs. |
+| **Modal** | `entryPointChild: "<id>"`, `contentChild: "<id>"` | None. **Currently rendered inline as an `Expander`**, not a real dialog. The entryPointChild becomes the header; the contentChild becomes the expanded body. |
+| **Divider** | — | `axis`: `horizontal` (default) or `vertical`. Renders as a 1 px rectangle. |
+
+Children are referenced by **id**, not nested in place. Build the surface as a flat array of components and let `beginRendering.root` pick the entry point.
+
+### Display
+
+| Component | Properties |
+|---|---|
+| **Text** | `text`: A2UIValue; `usageHint`: `h1`/`h2`/`h3`/`h4`/`h5`/`body` (default) /`caption`. Maps to WinUI text styles (`TitleLargeTextBlockStyle` etc.). Wraps. |
+| **Image** | `url`: A2UIValue; `fit`: `contain`/`cover`/`fill`/`none`/`scale-down` (defaults to `contain`); `usageHint`: `icon` (24 px square), `avatar` (40 px square), `smallFeature` (h=80), `mediumFeature` (h=160), `largeFeature` (h=240), `header` (stretch). `description` or `label` is used as the automation/alt name. Subject to MediaResolver allowlist. |
+| **Icon** | `name`: A2UIValue resolving to an entry in the icon enum below. |
+| **Video** | `url`: A2UIValue. Renders as `MediaPlayerElement` with transport controls. URL must pass MediaResolver allowlist. |
+| **AudioPlayer** | `url`: A2UIValue; optional `description`: A2UIValue (caption above the player). |
+| **Divider** | (listed under Containers) |
+
+#### Icon enum
+
+The Windows renderer recognizes only the v0.8 Material-derived icon-name enum, mapped onto Segoe Fluent Icons glyphs. Anything outside this set falls back to the Help glyph:
+
+```
+accountCircle, add, arrowBack, arrowForward, attachFile, calendarToday,
+call, camera, check, close, delete, download, edit, event, error,
+favorite, favoriteOff, folder, help, home, info, locationOn, lock,
+lockOpen, mail, menu, moreVert, moreHoriz, notificationsOff,
+notifications, payment, person, phone, photo, print, refresh, search,
+send, settings, share, shoppingCart, star, starHalf, starOff, upload,
+visibility, visibilityOff, warning
+```
+
+`moreHoriz` falls back to the same glyph as `moreVert` (no horizontal-three-dots in MDL2). Use one of these names verbatim — arbitrary glyph strings will not work.
+
+### Interactive
+
+| Component | Properties |
+|---|---|
+| **Button** | `child`: `<id>` of the label/icon content; `primary`: bool (accent style); `action`: `{ "name": "<actionName>", "context": [{ "key":"...", "value":<A2UIValue> }, ...] }`. Click raises an outbound A2UIAction (see below). Auto-applies `action.name` as the accessibility name when no label/description is set. |
+| **CheckBox** | `label`: A2UIValue; `value`: A2UIValue (boolean). When `value.path` is set, toggling the checkbox writes the new boolean back to the path. |
+| **TextField** | `label`: A2UIValue; `text`: A2UIValue; `textFieldType`: `shortText` (default), `longText` (multiline TextBox, min height 80), `obscured` (PasswordBox — see secret-path rules below), `number` (numeric InputScope), `date` (date InputScope). When `text.path` is set, edits write back. |
+| **DateTimeInput** | `value`: A2UIValue (ISO 8601 string round-trip); `enableDate`: bool (default `true`); `enableTime`: bool (default `false`); `outputFormat`: optional .NET format string applied to the writeback (defaults to ISO 8601 `o`). |
+| **MultipleChoice** | `options`: `[{ "label": <A2UIValue>, "value": "<string>" }, ...]`; `selections`: A2UIValue resolving to an array of selected `value` strings; `maxAllowedSelections`: int. **`maxAllowedSelections == 1` renders as a `ComboBox` (single-select)**; everything else renders as a multi-select `ListView`. The path is always written back as a JSON array. |
+| **Slider** | `value`: A2UIValue (number); `minValue` (default 0); `maxValue` (default 100); `step` or `stepSize` (default 1.0) — wired to `Slider.StepFrequency`. |
+
+Any property accepting an A2UIValue accepts both literals and `path` bindings interchangeably — pick `path` whenever the value should react to `dataModelUpdate`.
+
+## Outbound actions
+
+When a Button is clicked (the only action source in v1), the node sends an A2UIAction back over the gateway:
+
+```json
+{
+  "name":              "submitForm",
+  "surfaceId":         "main",
+  "sourceComponentId": "btnPrimary",
+  "context":           { "email": "alice@example.com" },
+  "timestamp":         "2026-04-27T18:12:34.000Z"
+}
+```
+
+`context` is the flattened result of the button's `action.context` array, with each entry's value resolved (literal or path read).
+
+### Action-context security (dataBinding)
+
+The renderer scopes which paths are allowed to flow into `context`:
+
+- **Explicit scope (preferred):** declare `dataBinding` on the source component as an array of paths or `{ "path": "..." }` objects. Only those paths (and their subtrees) can be read into `context`. A `dataBinding: ["/"]` opts in to everything.
+- **Implicit scope (fallback):** if no `dataBinding` is set, the scope is the union of all paths referenced by the component's *non-action* properties. Useful but easy to misjudge.
+- **Secret paths** (any path bound to a `TextField` of type `obscured`) are dropped from `context` unless `dataBinding` lists them **explicitly**. The implicit scope never picks up secrets, even if they're trivially within reach.
+
+Paths outside the allowed set are silently dropped from the action envelope. If you need a value to round-trip back to the agent, either bind a property to it on the source component, or list it in `dataBinding`.
+
+## Capability gate
+
+Three RPCs are involved, all of which must be on the gateway's `gateway.nodes.allowCommands` list (and the node must advertise them via `node.describe`):
+
+```
+canvas.a2ui.push
+canvas.a2ui.pushJSONL
+canvas.a2ui.reset
+```
+
+The Windows node advertises all three. The richer v0.9 envelopes (e.g. `canvas.a2ui.schema`, `canvas.a2ui.dump`) are **not** implemented; do not attempt them.
+
+## Worked example
+
+Sign-in form with a path-bound text field and a primary button:
+
+```jsonl
+{"surfaceUpdate":{"surfaceId":"main","components":[
+  {"id":"root","component":{"Column":{"alignment":"stretch","children":{"explicitList":["title","emailField","pwField","submit"]}}}},
+  {"id":"title","component":{"Text":{"text":{"literalString":"Sign in"},"usageHint":"h2"}}},
+  {"id":"emailField","component":{"TextField":{"label":{"literalString":"Email"},"text":{"path":"/form/email"},"textFieldType":"shortText"}}},
+  {"id":"pwField","component":{"TextField":{"label":{"literalString":"Password"},"text":{"path":"/form/password"},"textFieldType":"obscured"}}},
+  {"id":"submit","component":{"Button":{"primary":true,"child":"submitLabel","dataBinding":["/form"],"action":{"name":"signIn","context":[
+    {"key":"email","value":{"path":"/form/email"}},
+    {"key":"password","value":{"path":"/form/password"}}
+  ]}}}},
+  {"id":"submitLabel","component":{"Text":{"text":{"literalString":"Sign in"}}}}
+]}}
+{"dataModelUpdate":{"surfaceId":"main","path":"/","contents":[
+  {"key":"form","valueMap":[{"key":"email","valueString":""},{"key":"password","valueString":""}]}
+]}}
+{"beginRendering":{"surfaceId":"main","root":"root","catalogId":"a2ui-v0.8"}}
+```
+
+Notes on the example:
+
+- The Button declares `dataBinding: ["/form"]` so both `/form/email` and `/form/password` are in scope. Without that, `/form/password` would be dropped from `action.context` because the `obscured` TextField marks it as secret and the implicit scope refuses to include secrets.
+- Each child is declared as a top-level component and referenced by id; do not nest component objects inline.
+- `beginRendering.root` is sent last, after all component and data-model state is in place.
+
+## Things to avoid
+
+- **Inline children.** Always declare components flat and reference by id via `children.explicitList` (containers) or `child` (Card/Button/Modal halves) or per-tab `child` (Tabs).
+- **Template/data-bound List rows.** Not implemented — pre-expand or use repeated explicit children.
+- **Modal as a real dialog.** It currently renders as an inline Expander. Don't rely on focus-trapping or backdrop dismiss.
+- **Custom icon names.** Anything outside the icon enum becomes the Help glyph. Don't ship Material/Fluent codepoints directly.
+- **Putting secrets in implicit context.** `obscured` TextField paths only flow into `action.context` when listed in the source component's `dataBinding`. Make the opt-in explicit.
+- **v0.9 envelope kinds.** `canvas.a2ui.schema`, `canvas.a2ui.dump`, etc. are not supported on this node; they will land in `UnknownEnvelopeMessage` and be dropped.

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -14,7 +14,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <!--
+      Coverage is collected via the `dotnet-coverage` global tool, NOT coverlet.
+      OpenClaw.Tray.IntegrationTests spawns the tray exe out-of-process; coverlet's
+      in-proc instrumentation cannot capture coverage from spawned children, while
+      dotnet-coverage uses a runtime profiler that does. CI installs the tool and
+      wraps each `dotnet test` invocation with `dotnet-coverage collect`.
+    -->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/tests/OpenClaw.Shared.Tests/A2UICapabilitySecurityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/A2UICapabilitySecurityTests.cs
@@ -1,0 +1,84 @@
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using OpenClaw.Shared;
+using OpenClaw.Shared.Capabilities;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+/// <summary>
+/// Boundary-layer enforcement for the unified review's C5 (size caps) and M5
+/// (symlink-resolved temp validation). These run against the capability
+/// directly with no UI dependency.
+/// </summary>
+public class A2UICapabilitySecurityTests
+{
+    private static System.Text.Json.JsonElement Parse(string json)
+        => JsonDocument.Parse(json).RootElement.Clone();
+
+    [Fact]
+    public async Task A2UIPush_InlineJsonl_ExceedsByteCap_ReturnsError()
+    {
+        var cap = new CanvasCapability(NullLogger.Instance);
+        // Build a payload just over the 4 MiB cap. Use ASCII so byte count == char count.
+        var big = new string('a', (int)CanvasCapability.MaxA2UIJsonlBytes + 16);
+        var req = new NodeInvokeRequest
+        {
+            Id = "sec1",
+            Command = "canvas.a2ui.push",
+            Args = Parse($"{{\"jsonl\":{JsonSerializer.Serialize(big)}}}"),
+        };
+        var res = await cap.ExecuteAsync(req);
+        Assert.False(res.Ok);
+        Assert.Contains("maximum size", res.Error);
+    }
+
+    [Fact]
+    public async Task A2UIPush_InlineJsonl_ExceedsLineCap_ReturnsError()
+    {
+        var cap = new CanvasCapability(NullLogger.Instance);
+        // One short line per row, well past the line cap, well under the byte cap.
+        var sb = new System.Text.StringBuilder();
+        for (int i = 0; i < CanvasCapability.MaxA2UIJsonlLines + 16; i++)
+            sb.Append("{}\n");
+        var req = new NodeInvokeRequest
+        {
+            Id = "sec2",
+            Command = "canvas.a2ui.push",
+            Args = Parse($"{{\"jsonl\":{JsonSerializer.Serialize(sb.ToString())}}}"),
+        };
+        var res = await cap.ExecuteAsync(req);
+        Assert.False(res.Ok);
+        Assert.Contains("maximum of", res.Error);
+    }
+
+    [Fact]
+    public async Task A2UIPush_FileJsonl_OverCap_ReturnsError()
+    {
+        var cap = new CanvasCapability(NullLogger.Instance);
+        var tmpFile = Path.Combine(Path.GetTempPath(), $"a2ui-oversize-{System.Guid.NewGuid():N}.jsonl");
+        try
+        {
+            // 4 MiB + 1 — just over the cap. Use FileStream + SetLength to avoid
+            // allocating a huge string in memory just for the test.
+            using (var fs = File.Create(tmpFile))
+            {
+                fs.SetLength(CanvasCapability.MaxA2UIJsonlBytes + 1);
+            }
+            var req = new NodeInvokeRequest
+            {
+                Id = "sec3",
+                Command = "canvas.a2ui.push",
+                Args = Parse($"{{\"jsonlPath\":{JsonSerializer.Serialize(tmpFile)}}}"),
+            };
+            var res = await cap.ExecuteAsync(req);
+            Assert.False(res.Ok);
+            Assert.Contains("maximum size", res.Error);
+        }
+        finally
+        {
+            try { File.Delete(tmpFile); } catch { }
+        }
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/A2UICapabilitySecurityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/A2UICapabilitySecurityTests.cs
@@ -81,4 +81,56 @@ public class A2UICapabilitySecurityTests
             try { File.Delete(tmpFile); } catch { }
         }
     }
+
+    [Fact]
+    public async Task A2UIPush_FileJsonl_SymlinkOutsideTemp_ReturnsError()
+    {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrWhiteSpace(localAppData))
+            return;
+
+        var outsideDir = Path.Combine(localAppData, "OpenClawTests", Guid.NewGuid().ToString("N"));
+        var outsideFile = Path.Combine(outsideDir, "payload.jsonl");
+        var linkPath = Path.Combine(Path.GetTempPath(), $"a2ui-link-{Guid.NewGuid():N}.jsonl");
+
+        try
+        {
+            Directory.CreateDirectory(outsideDir);
+            await File.WriteAllTextAsync(outsideFile, "{}");
+            try
+            {
+                File.CreateSymbolicLink(linkPath, outsideFile);
+            }
+            catch (IOException)
+            {
+                return;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                return;
+            }
+
+            var cap = new CanvasCapability(NullLogger.Instance);
+            var req = new NodeInvokeRequest
+            {
+                Id = "sec4",
+                Command = "canvas.a2ui.push",
+                Args = Parse($"{{\"jsonlPath\":{JsonSerializer.Serialize(linkPath)}}}"),
+            };
+
+            var res = await cap.ExecuteAsync(req);
+
+            Assert.False(res.Ok);
+            Assert.Contains("temp", res.Error, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { File.Delete(linkPath); } catch { }
+            try { Directory.Delete(outsideDir, recursive: true); } catch { }
+        }
+    }
 }

--- a/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
@@ -960,6 +960,8 @@ public class CanvasCapabilityTests
         Assert.True(cap.CanHandle("canvas.a2ui.push"));
         Assert.True(cap.CanHandle("canvas.a2ui.pushJSONL"));
         Assert.True(cap.CanHandle("canvas.a2ui.reset"));
+        Assert.True(cap.CanHandle("canvas.a2ui.dump"));
+        Assert.True(cap.CanHandle("canvas.caps"));
         Assert.False(cap.CanHandle("canvas.unknown"));
         Assert.Equal("canvas", cap.Category);
     }
@@ -1296,11 +1298,76 @@ public class CanvasCapabilityTests
         {
             Id = "c19",
             Command = "canvas.a2ui.push",
-            Args = Parse($"{{\"jsonlPath\":\"{traversalPath.Replace("\\", "\\\\")}\"}}") 
+            Args = Parse($"{{\"jsonlPath\":\"{traversalPath.Replace("\\", "\\\\")}\"}}")
         };
         var res = await cap.ExecuteAsync(req);
         Assert.False(res.Ok);
         Assert.Contains("temp directory", res.Error);
+    }
+
+    [Fact]
+    public async Task A2UIDump_ReturnsError_WhenNoCanvasOpen()
+    {
+        var cap = new CanvasCapability(NullLogger.Instance);
+        var req = new NodeInvokeRequest { Id = "c20", Command = "canvas.a2ui.dump", Args = Parse("""{}""") };
+        var res = await cap.ExecuteAsync(req);
+        Assert.False(res.Ok);
+        Assert.Contains("CANVAS_NOT_OPEN", res.Error);
+    }
+
+    [Fact]
+    public async Task A2UIDump_CallsHandler_AndReturnsParsedPayload()
+    {
+        var cap = new CanvasCapability(NullLogger.Instance);
+        cap.A2UIDumpRequested += () => Task.FromResult("""{"surfaceId":"main","root":"r1","components":[],"dataModel":{}}""");
+
+        var req = new NodeInvokeRequest { Id = "c21", Command = "canvas.a2ui.dump", Args = Parse("""{}""") };
+        var res = await cap.ExecuteAsync(req);
+        Assert.True(res.Ok);
+        // Payload is a parsed object (JsonElement), not a quoted string — verify by re-serializing.
+        var json = JsonSerializer.Serialize(res.Payload);
+        Assert.Contains("\"surfaceId\":\"main\"", json);
+        Assert.Contains("\"root\":\"r1\"", json);
+    }
+
+    [Fact]
+    public async Task A2UIDump_ReturnsError_WhenHandlerThrows()
+    {
+        var cap = new CanvasCapability(NullLogger.Instance);
+        cap.A2UIDumpRequested += () => throw new InvalidOperationException("dispatcher gone");
+
+        var req = new NodeInvokeRequest { Id = "c22", Command = "canvas.a2ui.dump", Args = Parse("""{}""") };
+        var res = await cap.ExecuteAsync(req);
+        Assert.False(res.Ok);
+        Assert.Contains("CANVAS_DUMP_FAILED", res.Error);
+        Assert.Contains("dispatcher gone", res.Error);
+    }
+
+    [Fact]
+    public async Task Caps_ReturnsDefault_WhenNoHandler()
+    {
+        var cap = new CanvasCapability(NullLogger.Instance);
+        var req = new NodeInvokeRequest { Id = "c23", Command = "canvas.caps", Args = Parse("""{}""") };
+        var res = await cap.ExecuteAsync(req);
+        Assert.True(res.Ok);
+        var json = JsonSerializer.Serialize(res.Payload);
+        Assert.Contains("\"renderer\":\"none\"", json);
+        Assert.Contains("\"eval\":false", json);
+        Assert.Contains("\"snapshot\":false", json);
+    }
+
+    [Fact]
+    public async Task Caps_CallsHandler_AndReturnsParsedPayload()
+    {
+        var cap = new CanvasCapability(NullLogger.Instance);
+        cap.CapsRequested += () => Task.FromResult("""{"renderer":"native","eval":false,"snapshot":true,"a2ui":{"version":"0.8","introspect":true}}""");
+
+        var req = new NodeInvokeRequest { Id = "c24", Command = "canvas.caps", Args = Parse("""{}""") };
+        var res = await cap.ExecuteAsync(req);
+        Assert.True(res.Ok);
+        var json = JsonSerializer.Serialize(res.Payload);
+        Assert.Contains("\"renderer\":\"native\"", json);
+        Assert.Contains("\"introspect\":true", json);
     }
 }
 

--- a/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
@@ -1157,11 +1157,15 @@ public class CanvasCapabilityTests
     }
 
     [Fact]
-    public async Task Navigate_RaisesEvent_WhenUrlPresent()
+    public async Task Navigate_InvokesHandler_WithCanonicalUrl()
     {
         var cap = new CanvasCapability(NullLogger.Instance);
-        string? navigatedUrl = null;
-        cap.NavigateRequested += (s, url) => navigatedUrl = url;
+        string? handlerSawUrl = null;
+        cap.NavigateRequested += url =>
+        {
+            handlerSawUrl = url;
+            return Task.FromResult("browser");
+        };
 
         var req = new NodeInvokeRequest
         {
@@ -1171,7 +1175,93 @@ public class CanvasCapabilityTests
         };
         var res = await cap.ExecuteAsync(req);
         Assert.True(res.Ok);
-        Assert.Equal("https://example.com/page", navigatedUrl);
+        Assert.Equal("https://example.com/page", handlerSawUrl);
+    }
+
+    [Fact]
+    public async Task Navigate_ResponseIncludesOpenerAndCanonicalUrl()
+    {
+        var cap = new CanvasCapability(NullLogger.Instance);
+        cap.NavigateRequested += _ => Task.FromResult("browser");
+
+        var req = new NodeInvokeRequest
+        {
+            Id = "c12b",
+            Command = "canvas.navigate",
+            // Mixed-case scheme/host should be canonicalized to lowercase before
+            // the agent sees the response.
+            Args = Parse("""{"url":"HTTPS://Example.COM/Path"}""")
+        };
+        var res = await cap.ExecuteAsync(req);
+        Assert.True(res.Ok);
+
+        var json = System.Text.Json.JsonSerializer.Serialize(res.Payload);
+        Assert.Contains("\"opener\":\"browser\"", json);
+        Assert.Contains("\"navigated\":true", json);
+        // Scheme and host lowercased; path preserved.
+        Assert.Contains("\"url\":\"https://example.com/Path\"", json);
+    }
+
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("file:///C:/Windows/System32/calc.exe")]
+    [InlineData("ms-settings:network")]
+    [InlineData("/relative/path")]
+    [InlineData("https://attacker@evil.example.com/")]
+    public async Task Navigate_RejectsUnsafeUrls_WithoutInvokingHandler(string url)
+    {
+        var cap = new CanvasCapability(NullLogger.Instance);
+        bool handlerCalled = false;
+        cap.NavigateRequested += _ =>
+        {
+            handlerCalled = true;
+            return Task.FromResult("browser");
+        };
+
+        var req = new NodeInvokeRequest
+        {
+            Id = "c12c",
+            Command = "canvas.navigate",
+            Args = Parse($$"""{"url":{{System.Text.Json.JsonSerializer.Serialize(url)}}}""")
+        };
+        var res = await cap.ExecuteAsync(req);
+        Assert.False(res.Ok);
+        Assert.False(handlerCalled);
+        Assert.Contains("Invalid url", res.Error);
+    }
+
+    [Fact]
+    public async Task Navigate_NoHandler_ReturnsError()
+    {
+        var cap = new CanvasCapability(NullLogger.Instance);
+        // No NavigateRequested subscription — agent should be told honestly.
+
+        var req = new NodeInvokeRequest
+        {
+            Id = "c12d",
+            Command = "canvas.navigate",
+            Args = Parse("""{"url":"https://example.com/"}""")
+        };
+        var res = await cap.ExecuteAsync(req);
+        Assert.False(res.Ok);
+        Assert.Contains("CANVAS_NOT_AVAILABLE", res.Error);
+    }
+
+    [Fact]
+    public async Task Navigate_HandlerThrows_SurfacesAsError()
+    {
+        var cap = new CanvasCapability(NullLogger.Instance);
+        cap.NavigateRequested += _ => throw new InvalidOperationException("browser refused");
+
+        var req = new NodeInvokeRequest
+        {
+            Id = "c12e",
+            Command = "canvas.navigate",
+            Args = Parse("""{"url":"https://example.com/"}""")
+        };
+        var res = await cap.ExecuteAsync(req);
+        Assert.False(res.Ok);
+        Assert.Contains("browser refused", res.Error);
     }
 
     [Fact]

--- a/tests/OpenClaw.Shared.Tests/HttpUrlRiskEvaluatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/HttpUrlRiskEvaluatorTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using OpenClaw.Shared;
 
 namespace OpenClaw.Shared.Tests;
@@ -26,5 +27,43 @@ public class HttpUrlRiskEvaluatorTests
 
         Assert.True(risk.RequiresConfirmation);
         Assert.Contains(risk.Reasons, reason => reason.Contains(reasonFragment, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Evaluate_IdnHostnameMismatch_TriggersConfirmation()
+    {
+        // Cyrillic 'а' looks identical to Latin 'a' but Punycode-encodes to a
+        // different ASCII form. The evaluator must surface the mismatch as a
+        // Reason so the prompt fires on visually-deceptive hosts.
+        var risk = HttpUrlRiskEvaluator.Evaluate("https://аpple.com/");
+        Assert.True(risk.RequiresConfirmation);
+        Assert.Contains(risk.Reasons, r => r.Contains("punycode", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData("::")]                    // unspecified
+    [InlineData("2001:db8::1")]           // documentation
+    [InlineData("2001:0000::1")]          // Teredo
+    [InlineData("2002::1")]               // 6to4
+    [InlineData("100::1")]                // discard-only
+    [InlineData("fc00::1")]               // unique local
+    [InlineData("fe80::1")]               // link-local
+    [InlineData("ff00::1")]               // multicast
+    [InlineData("::ffff:10.0.0.1")]       // IPv4-mapped private
+    public void IsPublicAddress_NonPublicIPv6_ReturnsFalse(string ipString)
+    {
+        var ip = IPAddress.Parse(ipString);
+        Assert.False(HttpUrlRiskEvaluator.IsPublicAddress(ip),
+            $"Expected {ipString} to be classified as non-public");
+    }
+
+    [Theory]
+    [InlineData("2606:4700:4700::1111")]  // Cloudflare DNS — public IPv6
+    [InlineData("2400:cb00::1")]
+    public void IsPublicAddress_PublicIPv6_ReturnsTrue(string ipString)
+    {
+        var ip = IPAddress.Parse(ipString);
+        Assert.True(HttpUrlRiskEvaluator.IsPublicAddress(ip),
+            $"Expected {ipString} to be classified as public");
     }
 }

--- a/tests/OpenClaw.Shared.Tests/HttpUrlRiskEvaluatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/HttpUrlRiskEvaluatorTests.cs
@@ -1,0 +1,30 @@
+using OpenClaw.Shared;
+
+namespace OpenClaw.Shared.Tests;
+
+public class HttpUrlRiskEvaluatorTests
+{
+    [Fact]
+    public void Evaluate_PublicHttpsHost_DoesNotRequireConfirmation()
+    {
+        var risk = HttpUrlRiskEvaluator.Evaluate("https://example.com/path?q=1");
+
+        Assert.False(risk.RequiresConfirmation);
+        Assert.Equal("https://example.com/", risk.CanonicalOrigin);
+        Assert.Equal("example.com", risk.HostKey);
+    }
+
+    [Theory]
+    [InlineData("http://example.com/", "HTTPS")]
+    [InlineData("https://127.0.0.1:8080/", "loopback")]
+    [InlineData("https://192.168.1.1/", "private")]
+    [InlineData("https://router/", "no dot")]
+    [InlineData("https://8.8.8.8/", "IP literal")]
+    public void Evaluate_HighRiskUrls_RequireConfirmation(string url, string reasonFragment)
+    {
+        var risk = HttpUrlRiskEvaluator.Evaluate(url);
+
+        Assert.True(risk.RequiresConfirmation);
+        Assert.Contains(risk.Reasons, reason => reason.Contains(reasonFragment, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/HttpUrlValidatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/HttpUrlValidatorTests.cs
@@ -1,0 +1,82 @@
+using OpenClaw.Shared;
+
+namespace OpenClaw.Shared.Tests;
+
+public class HttpUrlValidatorTests
+{
+    [Theory]
+    [InlineData("http://example.com")]
+    [InlineData("https://example.com")]
+    [InlineData("https://example.com/path?query=1#frag")]
+    [InlineData("https://sub.example.com:8443/x")]
+    [InlineData("HTTPS://EXAMPLE.COM/")]
+    public void Accepts_HttpAndHttps(string url)
+    {
+        var ok = HttpUrlValidator.TryParse(url, out var canonical, out var error);
+        Assert.True(ok, error);
+        Assert.NotNull(canonical);
+    }
+
+    [Fact]
+    public void Canonicalizes_LowercasesSchemeAndHost()
+    {
+        HttpUrlValidator.TryParse("HTTPS://EXAMPLE.COM/Path", out var canonical, out _);
+        // Uri.AbsoluteUri lowercases scheme and host; preserves path case.
+        Assert.StartsWith("https://example.com/", canonical);
+        Assert.EndsWith("Path", canonical);
+    }
+
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("file:///C:/Windows/System32/calc.exe")]
+    [InlineData("ms-settings:network")]
+    [InlineData("data:text/html,<script>alert(1)</script>")]
+    [InlineData("ftp://example.com/")]
+    [InlineData("openclaw://settings")]
+    public void Rejects_NonHttpSchemes(string url)
+    {
+        var ok = HttpUrlValidator.TryParse(url, out _, out var error);
+        Assert.False(ok);
+        Assert.Contains("scheme", error);
+    }
+
+    [Theory]
+    [InlineData("/relative/path")]
+    [InlineData("example.com")]
+    [InlineData("not a url")]
+    public void Rejects_NonAbsolute(string url)
+    {
+        var ok = HttpUrlValidator.TryParse(url, out _, out var error);
+        Assert.False(ok);
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Rejects_NullEmptyOrWhitespace(string? url)
+    {
+        var ok = HttpUrlValidator.TryParse(url, out _, out var error);
+        Assert.False(ok);
+        Assert.Equal("url is empty", error);
+    }
+
+    [Theory]
+    [InlineData("https://attacker@evil.com/")]
+    [InlineData("https://user:pass@example.com/")]
+    public void Rejects_Userinfo(string url)
+    {
+        var ok = HttpUrlValidator.TryParse(url, out _, out var error);
+        Assert.False(ok);
+        Assert.Contains("userinfo", error);
+    }
+
+    [Fact]
+    public void Trims_LeadingAndTrailingWhitespace()
+    {
+        var ok = HttpUrlValidator.TryParse("  https://example.com/  ", out var canonical, out _);
+        Assert.True(ok);
+        Assert.Equal("https://example.com/", canonical);
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/McpAuthTokenResetTests.cs
+++ b/tests/OpenClaw.Shared.Tests/McpAuthTokenResetTests.cs
@@ -1,0 +1,32 @@
+using OpenClaw.Shared.Mcp;
+
+namespace OpenClaw.Shared.Tests;
+
+public class McpAuthTokenResetTests
+{
+    [Fact]
+    public void Reset_ReplacesExistingToken()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "openclaw-token-tests", Guid.NewGuid().ToString("N"));
+        var path = Path.Combine(dir, "mcp-token.txt");
+        try
+        {
+            var first = McpAuthToken.LoadOrCreate(path);
+            var second = McpAuthToken.Reset(path);
+
+            Assert.NotEqual(first, second);
+            Assert.Equal(second, File.ReadAllText(path).Trim());
+            Assert.Equal(43, second.Length);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Reset_RejectsMissingPath()
+    {
+        Assert.Throws<ArgumentException>(() => McpAuthToken.Reset(""));
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/McpHttpServerTests.cs
+++ b/tests/OpenClaw.Shared.Tests/McpHttpServerTests.cs
@@ -376,4 +376,62 @@ public class McpHttpServerTests
         var bridge = new McpToolBridge(() => Array.Empty<INodeCapability>());
         Assert.Throws<ArgumentNullException>(() => new McpHttpServer(bridge, 1234, null!));
     }
+
+    [Fact]
+    public async Task Auth_RequiresBearerToken_When_TokenConfigured()
+    {
+        const string token = "supersecret";
+        var port = FreePort();
+        var bridge = new McpToolBridge(() => new INodeCapability[] { new FakeCapability() });
+        using var server = new McpHttpServer(bridge, port, NullLogger.Instance, token);
+        server.Start();
+
+        using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}/") };
+        var content = new StringContent(
+            """{"jsonrpc":"2.0","id":1,"method":"tools/list"}""",
+            System.Text.Encoding.UTF8,
+            "application/json");
+
+        // No Authorization header → 401.
+        var resp = await http.PostAsync("", content);
+        Assert.Equal(System.Net.HttpStatusCode.Unauthorized, resp.StatusCode);
+
+        // Wrong token → 401.
+        http.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "wrong");
+        var content2 = new StringContent(
+            """{"jsonrpc":"2.0","id":1,"method":"tools/list"}""",
+            System.Text.Encoding.UTF8,
+            "application/json");
+        var resp2 = await http.PostAsync("", content2);
+        Assert.Equal(System.Net.HttpStatusCode.Unauthorized, resp2.StatusCode);
+
+        // Correct token → 200.
+        http.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+        var content3 = new StringContent(
+            """{"jsonrpc":"2.0","id":1,"method":"tools/list"}""",
+            System.Text.Encoding.UTF8,
+            "application/json");
+        var resp3 = await http.PostAsync("", content3);
+        Assert.Equal(System.Net.HttpStatusCode.OK, resp3.StatusCode);
+    }
+
+    [Fact]
+    public async Task Auth_NoToken_AllowsAllRequests_LegacyDevMode()
+    {
+        // Constructing without an authToken keeps the prior unauthenticated
+        // contract (relying on loopback + Origin/Host gates only). Existing
+        // setups that haven't migrated to bearer auth keep working.
+        var port = FreePort();
+        var bridge = new McpToolBridge(() => new INodeCapability[] { new FakeCapability() });
+        using var server = new McpHttpServer(bridge, port, NullLogger.Instance);
+        server.Start();
+
+        using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}/") };
+        var content = new StringContent(
+            """{"jsonrpc":"2.0","id":1,"method":"tools/list"}""",
+            System.Text.Encoding.UTF8,
+            "application/json");
+        var resp = await http.PostAsync("", content);
+        Assert.Equal(System.Net.HttpStatusCode.OK, resp.StatusCode);
+    }
 }

--- a/tests/OpenClaw.Shared.Tests/McpToolBridgeTests.cs
+++ b/tests/OpenClaw.Shared.Tests/McpToolBridgeTests.cs
@@ -76,7 +76,7 @@ public class McpToolBridgeTests
         {
             new FakeCapability("system", "system.notify"),
             new FakeCapability("canvas", "canvas.a2ui.push"),
-            new FakeCapability("screen", "screen.capture"),
+            new FakeCapability("screen", "screen.snapshot"),
             new FakeCapability("camera", "camera.snap"),
             new FakeCapability("custom", "custom.unknown"),
         };
@@ -93,7 +93,7 @@ public class McpToolBridgeTests
         // Curated descriptions should be specific, not the generic "{category} capability: {cmd}" stub.
         Assert.Contains("toast notification", byName["system.notify"]);
         Assert.Contains("A2UI v0.8", byName["canvas.a2ui.push"]);
-        Assert.Contains("screenshot", byName["screen.capture"]);
+        Assert.Contains("screenshot", byName["screen.snapshot"]);
         Assert.Contains("camera", byName["camera.snap"], System.StringComparison.OrdinalIgnoreCase);
 
         // Unknown commands keep the generic fallback so newly-added capabilities still render.

--- a/tests/OpenClaw.Shared.Tests/McpToolBridgeTests.cs
+++ b/tests/OpenClaw.Shared.Tests/McpToolBridgeTests.cs
@@ -70,6 +70,37 @@ public class McpToolBridgeTests
     }
 
     [Fact]
+    public async Task ToolsList_KnownCommands_GetCuratedDescriptions()
+    {
+        var caps = new List<INodeCapability>
+        {
+            new FakeCapability("system", "system.notify"),
+            new FakeCapability("canvas", "canvas.a2ui.push"),
+            new FakeCapability("screen", "screen.capture"),
+            new FakeCapability("camera", "camera.snap"),
+            new FakeCapability("custom", "custom.unknown"),
+        };
+        var bridge = CreateBridge(caps);
+        var resp = await bridge.HandleRequestAsync(@"{""jsonrpc"":""2.0"",""id"":1,""method"":""tools/list""}");
+
+        using var doc = JsonDocument.Parse(resp!);
+        var byName = new Dictionary<string, string>();
+        foreach (var t in doc.RootElement.GetProperty("result").GetProperty("tools").EnumerateArray())
+        {
+            byName[t.GetProperty("name").GetString()!] = t.GetProperty("description").GetString()!;
+        }
+
+        // Curated descriptions should be specific, not the generic "{category} capability: {cmd}" stub.
+        Assert.Contains("toast notification", byName["system.notify"]);
+        Assert.Contains("A2UI v0.8", byName["canvas.a2ui.push"]);
+        Assert.Contains("screenshot", byName["screen.capture"]);
+        Assert.Contains("camera", byName["camera.snap"], System.StringComparison.OrdinalIgnoreCase);
+
+        // Unknown commands keep the generic fallback so newly-added capabilities still render.
+        Assert.Equal("custom capability: custom.unknown", byName["custom.unknown"]);
+    }
+
+    [Fact]
     public async Task ToolsList_PicksUpNewCapabilityRegisteredAfterStart()
     {
         var caps = new List<INodeCapability>

--- a/tests/OpenClaw.Shared.Tests/TokenSanitizerTests.cs
+++ b/tests/OpenClaw.Shared.Tests/TokenSanitizerTests.cs
@@ -1,0 +1,34 @@
+using OpenClaw.Shared;
+
+namespace OpenClaw.Shared.Tests;
+
+public class TokenSanitizerTests
+{
+    [Fact]
+    public void Sanitize_RedactsAuthorizationBearerHeader()
+    {
+        var sanitized = TokenSanitizer.Sanitize("Authorization: Bearer abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNO12");
+
+        Assert.DoesNotContain("abcdefghijklmnopqrstuvwxyz", sanitized);
+        Assert.Contains("Authorization: Bearer [REDACTED]", sanitized);
+    }
+
+    [Fact]
+    public void Sanitize_RedactsJsonTokenFields()
+    {
+        var sanitized = TokenSanitizer.Sanitize("""{"authToken":"super-secret-value","other":"visible"}""");
+
+        Assert.Contains(""""authToken":"[REDACTED]"""", sanitized);
+        Assert.Contains(""""other":"visible"""", sanitized);
+    }
+
+    [Fact]
+    public void Sanitize_RedactsBareMcpTokenShape()
+    {
+        var token = new string('A', 43);
+        var sanitized = TokenSanitizer.Sanitize($"token is {token}");
+
+        Assert.DoesNotContain(token, sanitized);
+        Assert.Contains("[REDACTED_TOKEN]", sanitized);
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/UrlLogSanitizerTests.cs
+++ b/tests/OpenClaw.Shared.Tests/UrlLogSanitizerTests.cs
@@ -1,0 +1,50 @@
+using OpenClaw.Shared;
+
+namespace OpenClaw.Shared.Tests;
+
+/// <summary>
+/// The sanitizer is meant to make it safe to put agent-supplied URLs in
+/// disk-backed log files. The threat is that query strings carry tokens, and
+/// log retention is "forever" on a developer machine. These tests assert that
+/// the common credential-bearing query parameters never appear in the output.
+/// </summary>
+public sealed class UrlLogSanitizerTests
+{
+    [Theory]
+    [InlineData("https://login.example.com/oauth/callback?code=abc123&state=xyz",
+                "https://login.example.com/oauth/…")]
+    [InlineData("https://example.com/reset?token=secret-recovery-link",
+                "https://example.com/reset")]
+    [InlineData("https://api.example.com/v1/users?email=user@example.com",
+                "https://api.example.com/v1/…")]
+    [InlineData("https://share.example.com/file?sig=AAA&Expires=1",
+                "https://share.example.com/file")]
+    [InlineData("https://example.com/", "https://example.com/")]
+    [InlineData("https://example.com:8443/path?q=1#frag",
+                "https://example.com:8443/path")]
+    public void Sanitize_DropsQueryAndFragment(string input, string expected)
+    {
+        Assert.Equal(expected, UrlLogSanitizer.Sanitize(input));
+    }
+
+    [Theory]
+    [InlineData("token=secret")]
+    [InlineData("code=abc")]
+    [InlineData("email=user@example.com")]
+    [InlineData("sig=signature-bytes")]
+    [InlineData("password=hunter2")]
+    public void Sanitize_NeverEchoesCredentialFragments(string credentialQuery)
+    {
+        var sanitized = UrlLogSanitizer.Sanitize($"https://example.com/path?{credentialQuery}");
+        Assert.DoesNotContain(credentialQuery, sanitized, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(null, "<empty>")]
+    [InlineData("", "<empty>")]
+    [InlineData("not a url", "<unparseable URL>")]
+    public void Sanitize_HandlesEdgeCases(string? input, string expected)
+    {
+        Assert.Equal(expected, UrlLogSanitizer.Sanitize(input));
+    }
+}

--- a/tests/OpenClaw.Tray.IntegrationTests/A2UICanvasIntegrationTests.cs
+++ b/tests/OpenClaw.Tray.IntegrationTests/A2UICanvasIntegrationTests.cs
@@ -1,0 +1,291 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OpenClaw.Tray.IntegrationTests;
+
+/// <summary>
+/// End-to-end "agent presents a rich UI to the user" smoke test against a live
+/// tray. Builds a v0.8 A2UI surface that exercises one component per catalog
+/// category (containers, display, interactive), pushes it through MCP, asks the
+/// running tray to introspect itself via canvas.a2ui.dump, mutates the data
+/// model and re-introspects, then captures a real PNG of the rendered window.
+///
+/// Where the per-component UITests in OpenClaw.Tray.UITests verify each
+/// renderer in isolation against a synthetic harness, this test proves the same
+/// pipeline survives the full hop: MCP HTTP → bridge event → UI dispatcher →
+/// A2UICanvasWindow.Push → A2UIRouter → SurfaceHost → live XAML tree, all
+/// inside the shipped tray exe.
+/// </summary>
+public sealed class A2UICanvasIntegrationTests : IClassFixture<TrayAppFixture>
+{
+    private const string SurfaceId = "integration-rich";
+
+    private readonly TrayAppFixture _fixture;
+
+    public A2UICanvasIntegrationTests(TrayAppFixture fixture) => _fixture = fixture;
+
+    [IntegrationFact]
+    public async Task RichSurface_PushDumpAndSnapshot_RoundTripsThroughNativeRenderer()
+    {
+        // Other tests in the class fixture push their own minimal surfaces.
+        // Reset first so we can assert exact surface counts deterministically.
+        await _fixture.Client.CallToolExpectSuccessAsync("canvas.a2ui.reset");
+
+        var (jsonl, componentIds) = BuildRichJsonl();
+
+        // 1. Push the rich payload. Bridge returns success after enqueuing the
+        //    UI work; the dispatcher applies parser → router → SurfaceHost in
+        //    order before any subsequent dispatcher-bound call (dump, caps,
+        //    snapshot) gets to run.
+        using (var pushResp = await _fixture.Client.CallToolExpectSuccessAsync("canvas.a2ui.push", new { jsonl }))
+        {
+            Assert.True(pushResp.RootElement.GetProperty("pushed").GetBoolean());
+        }
+
+        // 2. canvas.caps should now report the native renderer with introspection on.
+        using (var capsResp = await _fixture.Client.CallToolExpectSuccessAsync("canvas.caps"))
+        {
+            var caps = capsResp.RootElement;
+            Assert.Equal("native", caps.GetProperty("renderer").GetString());
+            Assert.True(caps.GetProperty("snapshot").GetBoolean());
+            var a2ui = caps.GetProperty("a2ui");
+            Assert.Equal("0.8", a2ui.GetProperty("version").GetString());
+            Assert.True(a2ui.GetProperty("introspect").GetBoolean());
+            Assert.True(a2ui.GetProperty("push").GetBoolean());
+            Assert.True(a2ui.GetProperty("reset").GetBoolean());
+        }
+
+        // 3. canvas.a2ui.dump exposes the surface graph the renderer is driving.
+        using (var dumpResp = await _fixture.Client.CallToolExpectSuccessAsync("canvas.a2ui.dump"))
+        {
+            var dump = dumpResp.RootElement;
+            Assert.Equal("native", dump.GetProperty("renderer").GetString());
+            Assert.Equal("0.8", dump.GetProperty("a2uiVersion").GetString());
+            Assert.Equal(1, dump.GetProperty("surfaceCount").GetInt32());
+
+            var surface = dump.GetProperty("surfaces").GetProperty(SurfaceId);
+            Assert.Equal("rootCard", surface.GetProperty("root").GetString());
+
+            var presentIds = surface.GetProperty("components").EnumerateArray()
+                .Select(c => c.GetProperty("id").GetString()!)
+                .ToHashSet();
+            foreach (var id in componentIds)
+            {
+                Assert.True(presentIds.Contains(id), $"Expected component '{id}' in dump, got: {string.Join(",", presentIds)}");
+            }
+
+            // Every declared component should expose its componentName + properties payload.
+            var rootCard = surface.GetProperty("components").EnumerateArray()
+                .First(c => c.GetProperty("id").GetString() == "rootCard");
+            Assert.Equal("Card", rootCard.GetProperty("componentName").GetString());
+            Assert.Equal("mainCol", rootCard.GetProperty("properties").GetProperty("child").GetString());
+
+            // Initial data model seed propagated through to the per-surface store.
+            var dm = surface.GetProperty("dataModel");
+            Assert.Equal("Hello, integration tests", dm.GetProperty("headline").GetString());
+            Assert.False(dm.GetProperty("agreed").GetBoolean());
+            Assert.Equal(20.0, dm.GetProperty("volume").GetDouble(), 3);
+        }
+
+        // 4. Mutate the data model — agent UIs do this constantly. A pure
+        //    dataModelUpdate (no surfaceUpdate) must flow through bound
+        //    properties without rebuilding the visual tree.
+        var dataUpdate = new JsonObject
+        {
+            ["dataModelUpdate"] = new JsonObject
+            {
+                ["surfaceId"] = SurfaceId,
+                ["contents"] = new JsonArray
+                {
+                    new JsonObject { ["key"] = "headline", ["valueString"] = "Sensor 4 back online" },
+                    new JsonObject { ["key"] = "agreed",   ["valueBoolean"] = true },
+                    new JsonObject { ["key"] = "volume",   ["valueNumber"] = 75.0 },
+                },
+            },
+        }.ToJsonString();
+        await _fixture.Client.CallToolExpectSuccessAsync("canvas.a2ui.push", new { jsonl = dataUpdate });
+
+        using (var dumpAfter = await _fixture.Client.CallToolExpectSuccessAsync("canvas.a2ui.dump"))
+        {
+            var dm = dumpAfter.RootElement.GetProperty("surfaces").GetProperty(SurfaceId).GetProperty("dataModel");
+            Assert.Equal("Sensor 4 back online", dm.GetProperty("headline").GetString());
+            Assert.True(dm.GetProperty("agreed").GetBoolean());
+            Assert.Equal(75.0, dm.GetProperty("volume").GetDouble(), 3);
+        }
+
+        // 5. Snapshot the rendered window. Window activation + first layout pass
+        //    are racy under integration conditions (locked desktop, hidden
+        //    session), so we accept either a valid PNG or a well-formed tool
+        //    error. When the PNG arrives, validate the header — that's proof
+        //    the native A2UI tree got far enough to rasterize.
+        var (snapErr, snapText) = await _fixture.Client.CallToolAcceptingFailureAsync("canvas.snapshot", new
+        {
+            format = "png",
+            maxWidth = 800,
+        });
+        if (!snapErr)
+        {
+            using var snapDoc = JsonDocument.Parse(snapText);
+            var b64 = snapDoc.RootElement.GetProperty("base64").GetString();
+            Assert.False(string.IsNullOrWhiteSpace(b64));
+            var bytes = Convert.FromBase64String(b64!);
+            // PNG signature: 89 50 4E 47 0D 0A 1A 0A
+            Assert.True(bytes.Length > 8, $"Snapshot bytes too small: {bytes.Length}");
+            Assert.Equal(0x89, bytes[0]);
+            Assert.Equal((byte)'P', bytes[1]);
+            Assert.Equal((byte)'N', bytes[2]);
+            Assert.Equal((byte)'G', bytes[3]);
+            Assert.Equal(0x0D, bytes[4]);
+            Assert.Equal(0x0A, bytes[5]);
+            Assert.Equal(0x1A, bytes[6]);
+            Assert.Equal(0x0A, bytes[7]);
+        }
+
+        // 6. Reset clears everything; dump should report no surfaces.
+        await _fixture.Client.CallToolExpectSuccessAsync("canvas.a2ui.reset");
+        using (var dumpAfterReset = await _fixture.Client.CallToolExpectSuccessAsync("canvas.a2ui.dump"))
+        {
+            Assert.Equal(0, dumpAfterReset.RootElement.GetProperty("surfaceCount").GetInt32());
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Build a v0.8 surface that exercises one component per catalog category,
+    /// plus an initial dataModelUpdate so bound widgets paint with sane values
+    /// on the first frame. Returns the JSONL string and the list of component
+    /// ids the caller can assert against the dump.
+    /// </summary>
+    private static (string Jsonl, string[] ComponentIds) BuildRichJsonl()
+    {
+        var componentIds = new[]
+        {
+            "rootCard", "mainCol",
+            "title", "subtitle",
+            "buttonRow", "btnSave", "btnCancel", "lblSave", "lblCancel",
+            "agreeBox",
+            "volumeSlider",
+            "divider",
+            "helpTabs", "tabOverview", "tabDetails",
+            "footerIcon",
+        };
+
+        var components = new JsonArray
+        {
+            // Containers
+            Component("rootCard", "Card", new JsonObject { ["child"] = "mainCol" }),
+            Component("mainCol", "Column", new JsonObject
+            {
+                ["children"] = Children(
+                    "title", "subtitle", "buttonRow",
+                    "agreeBox", "volumeSlider",
+                    "divider", "helpTabs", "footerIcon"),
+            }),
+            Component("buttonRow", "Row", new JsonObject { ["children"] = Children("btnSave", "btnCancel") }),
+            Component("helpTabs", "Tabs", new JsonObject
+            {
+                ["tabItems"] = new JsonArray
+                {
+                    new JsonObject { ["title"] = Lit("Overview"), ["child"] = "tabOverview" },
+                    new JsonObject { ["title"] = Lit("Details"),  ["child"] = "tabDetails" },
+                },
+            }),
+
+            // Display
+            Component("title", "Text", new JsonObject
+            {
+                ["text"] = Lit("OpenClaw Daily Briefing"),
+                ["usageHint"] = "h1",
+            }),
+            Component("subtitle",    "Text",    new JsonObject { ["text"] = Path("/headline") }),
+            Component("tabOverview", "Text",    new JsonObject { ["text"] = Lit("Two new alerts since yesterday.") }),
+            Component("tabDetails",  "Text",    new JsonObject { ["text"] = Lit("Sensor 4 dropped offline at 03:14.") }),
+            Component("lblSave",     "Text",    new JsonObject { ["text"] = Lit("Save") }),
+            Component("lblCancel",   "Text",    new JsonObject { ["text"] = Lit("Cancel") }),
+            Component("divider",     "Divider", new JsonObject { ["axis"] = "horizontal" }),
+            Component("footerIcon",  "Icon",    new JsonObject { ["name"] = Lit("settings") }),
+
+            // Interactive
+            Component("btnSave",   "Button", new JsonObject { ["child"] = "lblSave",   ["action"] = new JsonObject { ["name"] = "save"   } }),
+            Component("btnCancel", "Button", new JsonObject { ["child"] = "lblCancel", ["action"] = new JsonObject { ["name"] = "cancel" } }),
+            Component("agreeBox", "CheckBox", new JsonObject
+            {
+                ["label"] = Lit("I have read the briefing"),
+                ["value"] = Path("/agreed"),
+            }),
+            Component("volumeSlider", "Slider", new JsonObject
+            {
+                ["minValue"] = 0.0,
+                ["maxValue"] = 100.0,
+                ["value"] = Path("/volume"),
+            }),
+        };
+
+        var styles = new JsonObject
+        {
+            ["primaryColor"] = "#FF6F61",
+            ["radius"] = 8.0,
+            ["spacing"] = 12.0,
+        };
+
+        var surfaceUpdate = new JsonObject
+        {
+            ["surfaceUpdate"] = new JsonObject
+            {
+                ["surfaceId"] = SurfaceId,
+                ["components"] = components,
+            },
+        }.ToJsonString();
+
+        var beginRendering = new JsonObject
+        {
+            ["beginRendering"] = new JsonObject
+            {
+                ["surfaceId"] = SurfaceId,
+                ["root"] = "rootCard",
+                ["styles"] = styles,
+            },
+        }.ToJsonString();
+
+        var seedDataModel = new JsonObject
+        {
+            ["dataModelUpdate"] = new JsonObject
+            {
+                ["surfaceId"] = SurfaceId,
+                ["contents"] = new JsonArray
+                {
+                    new JsonObject { ["key"] = "headline", ["valueString"]  = "Hello, integration tests" },
+                    new JsonObject { ["key"] = "agreed",   ["valueBoolean"] = false },
+                    new JsonObject { ["key"] = "volume",   ["valueNumber"]  = 20.0 },
+                },
+            },
+        }.ToJsonString();
+
+        var jsonl = surfaceUpdate + "\n" + beginRendering + "\n" + seedDataModel;
+        return (jsonl, componentIds);
+    }
+
+    private static JsonObject Component(string id, string componentName, JsonObject? props = null) =>
+        new()
+        {
+            ["id"] = id,
+            ["component"] = new JsonObject { [componentName] = props ?? new JsonObject() },
+        };
+
+    private static JsonObject Lit(string s) => new() { ["literalString"] = s };
+    private static JsonObject Path(string p) => new() { ["path"] = p };
+
+    private static JsonObject Children(params string[] ids)
+    {
+        var arr = new JsonArray();
+        foreach (var id in ids) arr.Add(JsonValue.Create(id));
+        return new JsonObject { ["explicitList"] = arr };
+    }
+}

--- a/tests/OpenClaw.Tray.IntegrationTests/IntegrationFactAttribute.cs
+++ b/tests/OpenClaw.Tray.IntegrationTests/IntegrationFactAttribute.cs
@@ -1,0 +1,28 @@
+using System;
+using Xunit;
+
+namespace OpenClaw.Tray.IntegrationTests;
+
+/// <summary>
+/// Black-box integration tests that spawn the tray app as a subprocess. Skipped
+/// unless OPENCLAW_RUN_INTEGRATION=1 because they need a real Windows desktop
+/// session (the WinUI3 app cannot run headless) and they pop UI windows / tray
+/// icons during execution.
+/// </summary>
+public sealed class IntegrationFactAttribute : FactAttribute
+{
+    private const string EnvVar = "OPENCLAW_RUN_INTEGRATION";
+
+    public IntegrationFactAttribute()
+    {
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(EnvVar)))
+        {
+            Skip = $"Integration tests disabled. Set {EnvVar}=1 to enable.";
+            return;
+        }
+        if (!OperatingSystem.IsWindows())
+        {
+            Skip = "Tray integration tests require Windows.";
+        }
+    }
+}

--- a/tests/OpenClaw.Tray.IntegrationTests/McpClient.cs
+++ b/tests/OpenClaw.Tray.IntegrationTests/McpClient.cs
@@ -18,10 +18,17 @@ public sealed class McpClient : IDisposable
     private readonly string _endpoint;
     private int _id;
 
-    public McpClient(string endpoint)
+    public McpClient(string endpoint) : this(endpoint, authToken: null) { }
+
+    public McpClient(string endpoint, string? authToken)
     {
         _endpoint = endpoint;
         _http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        if (!string.IsNullOrEmpty(authToken))
+        {
+            _http.DefaultRequestHeaders.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", authToken);
+        }
     }
 
     public Task<JsonDocument> InitializeAsync()

--- a/tests/OpenClaw.Tray.IntegrationTests/McpClient.cs
+++ b/tests/OpenClaw.Tray.IntegrationTests/McpClient.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace OpenClaw.Tray.IntegrationTests;
+
+/// <summary>
+/// Tiny JSON-RPC over HTTP client for the MCP endpoint. Exposes the two methods
+/// these tests need (tools/list, tools/call) plus a generic Send for anything
+/// else. Each call is a fresh POST — the MCP HTTP transport is request/response,
+/// not session-based.
+/// </summary>
+public sealed class McpClient : IDisposable
+{
+    private readonly HttpClient _http;
+    private readonly string _endpoint;
+    private int _id;
+
+    public McpClient(string endpoint)
+    {
+        _endpoint = endpoint;
+        _http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+    }
+
+    public Task<JsonDocument> InitializeAsync()
+        => SendAsync("initialize", parameters: null);
+
+    public Task<JsonDocument> ListToolsAsync()
+        => SendAsync("tools/list", parameters: null);
+
+    /// <summary>
+    /// Call a tool. Returns the parsed JSON-RPC response. Caller checks
+    /// result.isError and result.content[0].text per MCP spec.
+    /// </summary>
+    public Task<JsonDocument> CallToolAsync(string name, object? arguments = null)
+    {
+        var parameters = arguments is null
+            ? (object)new { name }
+            : new { name, arguments };
+        return SendAsync("tools/call", parameters);
+    }
+
+    public async Task<JsonDocument> SendAsync(string method, object? parameters)
+    {
+        var id = System.Threading.Interlocked.Increment(ref _id);
+        var requestObj = parameters is null
+            ? (object)new { jsonrpc = "2.0", id, method }
+            : new { jsonrpc = "2.0", id, method, @params = parameters };
+        var requestJson = JsonSerializer.Serialize(requestObj);
+
+        using var content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+        using var resp = await _http.PostAsync(_endpoint, content).ConfigureAwait(false);
+        var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+        if (!resp.IsSuccessStatusCode)
+        {
+            throw new HttpRequestException(
+                $"MCP HTTP {(int)resp.StatusCode}: {body}");
+        }
+
+        return JsonDocument.Parse(body);
+    }
+
+    /// <summary>
+    /// Convenience: call a tool, assert the JSON-RPC envelope is well-formed,
+    /// and return result.content[0].text parsed as JSON. Throws if the tool
+    /// returned isError=true.
+    /// </summary>
+    public async Task<JsonDocument> CallToolExpectSuccessAsync(string name, object? arguments = null)
+    {
+        using var doc = await CallToolAsync(name, arguments).ConfigureAwait(false);
+        var result = doc.RootElement.GetProperty("result");
+        var isError = result.GetProperty("isError").GetBoolean();
+        var text = result.GetProperty("content")[0].GetProperty("text").GetString();
+        if (isError)
+        {
+            throw new InvalidOperationException($"Tool {name} returned isError=true: {text}");
+        }
+        return JsonDocument.Parse(text!);
+    }
+
+    /// <summary>
+    /// Call a tool and return a tuple of (isError, payloadText). Use when the
+    /// test should accept either success or a tool error (e.g. hardware-gated
+    /// commands like canvas.eval without an active canvas window).
+    /// </summary>
+    public async Task<(bool IsError, string Text)> CallToolAcceptingFailureAsync(string name, object? arguments = null)
+    {
+        using var doc = await CallToolAsync(name, arguments).ConfigureAwait(false);
+        var result = doc.RootElement.GetProperty("result");
+        var isError = result.GetProperty("isError").GetBoolean();
+        var text = result.GetProperty("content")[0].GetProperty("text").GetString() ?? "";
+        return (isError, text);
+    }
+
+    public void Dispose() => _http.Dispose();
+}

--- a/tests/OpenClaw.Tray.IntegrationTests/McpHttpServerIntegrationTests.cs
+++ b/tests/OpenClaw.Tray.IntegrationTests/McpHttpServerIntegrationTests.cs
@@ -56,7 +56,8 @@ public class McpHttpServerIntegrationTests : IClassFixture<TrayAppFixture>
         };
         foreach (var cmd in expected)
         {
-            Assert.True(names.Contains(cmd), $"tools/list missing command: {cmd}");
+            Assert.True(names.Contains(cmd),
+                $"tools/list missing command: {cmd}. Got: {string.Join(", ", names)}");
         }
 
         // Curated descriptions kicked in (not the generic stub).

--- a/tests/OpenClaw.Tray.IntegrationTests/McpHttpServerIntegrationTests.cs
+++ b/tests/OpenClaw.Tray.IntegrationTests/McpHttpServerIntegrationTests.cs
@@ -250,8 +250,8 @@ public class McpHttpServerIntegrationTests : IClassFixture<TrayAppFixture>
     public async Task CanvasNavigate_ReturnsNavigated()
     {
         // HttpUrlValidator only accepts http/https. We don't need the page to
-        // resolve — the tool returns success as soon as the navigate event is
-        // raised on the canvas window.
+        // resolve or launch — the fixture suppresses external browser launches,
+        // and the tool returns success as soon as the navigate event is raised.
         using var payload = await _fixture.Client.CallToolExpectSuccessAsync("canvas.navigate", new
         {
             url = "https://example.com/",

--- a/tests/OpenClaw.Tray.IntegrationTests/McpHttpServerIntegrationTests.cs
+++ b/tests/OpenClaw.Tray.IntegrationTests/McpHttpServerIntegrationTests.cs
@@ -51,8 +51,8 @@ public class McpHttpServerIntegrationTests : IClassFixture<TrayAppFixture>
             "system.execApprovals.get", "system.execApprovals.set",
             "canvas.present", "canvas.hide", "canvas.navigate", "canvas.eval",
             "canvas.snapshot", "canvas.a2ui.push", "canvas.a2ui.reset",
-            "screen.capture", "screen.list",
-            "camera.list", "camera.snap",
+            "screen.snapshot", "screen.record",
+            "camera.list", "camera.snap", "camera.clip",
         };
         foreach (var cmd in expected)
         {
@@ -156,25 +156,17 @@ public class McpHttpServerIntegrationTests : IClassFixture<TrayAppFixture>
     }
 
     // ---- screen.* ----
+    // Canonical OpenClaw protocol: screen.snapshot + screen.record only.
+    // No screen.list / screen.capture (those were stale drift from the prior
+    // bridge description set).
 
     [IntegrationFact]
-    public async Task ScreenList_ReturnsAtLeastOneDisplay()
-    {
-        using var payload = await _fixture.Client.CallToolExpectSuccessAsync("screen.list");
-        var screens = payload.RootElement.GetProperty("screens");
-        Assert.True(screens.GetArrayLength() >= 1, "Expected at least one display");
-        var first = screens[0];
-        Assert.True(first.TryGetProperty("index", out _));
-        Assert.True(first.TryGetProperty("bounds", out _));
-    }
-
-    [IntegrationFact]
-    public async Task ScreenCapture_ReturnsImageOrWellFormedError()
+    public async Task ScreenSnapshot_ReturnsImageOrWellFormedError()
     {
         // On a real desktop session this returns a base64 image; on a locked
         // session or some VMs it can fail. Either way we want a well-formed
         // response — no transport errors.
-        var (isError, text) = await _fixture.Client.CallToolAcceptingFailureAsync("screen.capture", new
+        var (isError, text) = await _fixture.Client.CallToolAcceptingFailureAsync("screen.snapshot", new
         {
             format = "png",
             maxWidth = 320,

--- a/tests/OpenClaw.Tray.IntegrationTests/McpHttpServerIntegrationTests.cs
+++ b/tests/OpenClaw.Tray.IntegrationTests/McpHttpServerIntegrationTests.cs
@@ -84,9 +84,12 @@ public class McpHttpServerIntegrationTests : IClassFixture<TrayAppFixture>
     {
         // Set up an explicit allow rule so this test does not depend on the
         // default policy (which other tests in the class may have replaced —
-        // xUnit does not guarantee execution order).
+        // xUnit does not guarantee execution order). execApprovals.set
+        // requires the current policy hash as baseHash to prevent stale writes.
+        var baseHash = await GetExecApprovalsHashAsync();
         await _fixture.Client.CallToolExpectSuccessAsync("system.execApprovals.set", new
         {
+            baseHash,
             defaultAction = "deny",
             rules = new object[]
             {
@@ -102,6 +105,13 @@ public class McpHttpServerIntegrationTests : IClassFixture<TrayAppFixture>
         var stdout = payload.RootElement.GetProperty("stdout").GetString() ?? "";
         Assert.Contains("hello-from-mcp", stdout);
         Assert.Equal(0, payload.RootElement.GetProperty("exitCode").GetInt32());
+    }
+
+    private async Task<string> GetExecApprovalsHashAsync()
+    {
+        using var doc = await _fixture.Client.CallToolExpectSuccessAsync("system.execApprovals.get");
+        return doc.RootElement.GetProperty("hash").GetString()
+            ?? throw new InvalidOperationException("system.execApprovals.get did not return a hash");
     }
 
     [IntegrationFact]
@@ -137,11 +147,15 @@ public class McpHttpServerIntegrationTests : IClassFixture<TrayAppFixture>
     {
         using var beforeDoc = await _fixture.Client.CallToolExpectSuccessAsync("system.execApprovals.get");
         Assert.True(beforeDoc.RootElement.GetProperty("enabled").GetBoolean());
+        var baseHash = beforeDoc.RootElement.GetProperty("hash").GetString()!;
 
-        // Set a single deterministic rule and verify it round-trips.
+        // Set a single deterministic rule and verify it round-trips. The
+        // server requires baseHash to match the current policy hash so it
+        // can refuse stale writes.
         var marker = "integration-marker-" + System.Guid.NewGuid().ToString("N").Substring(0, 8);
         using var setDoc = await _fixture.Client.CallToolExpectSuccessAsync("system.execApprovals.set", new
         {
+            baseHash,
             defaultAction = "deny",
             rules = new object[]
             {
@@ -235,9 +249,12 @@ public class McpHttpServerIntegrationTests : IClassFixture<TrayAppFixture>
     [IntegrationFact]
     public async Task CanvasNavigate_ReturnsNavigated()
     {
+        // HttpUrlValidator only accepts http/https. We don't need the page to
+        // resolve — the tool returns success as soon as the navigate event is
+        // raised on the canvas window.
         using var payload = await _fixture.Client.CallToolExpectSuccessAsync("canvas.navigate", new
         {
-            url = "about:blank",
+            url = "https://example.com/",
         });
         Assert.True(payload.RootElement.GetProperty("navigated").GetBoolean());
     }

--- a/tests/OpenClaw.Tray.IntegrationTests/McpHttpServerIntegrationTests.cs
+++ b/tests/OpenClaw.Tray.IntegrationTests/McpHttpServerIntegrationTests.cs
@@ -1,0 +1,307 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OpenClaw.Tray.IntegrationTests;
+
+/// <summary>
+/// Black-box HTTP integration tests against a spawned tray instance. Each test
+/// drives one (or two related) MCP commands. Tests that depend on hardware or
+/// UI state (canvas eval/snapshot, camera snap) accept either a successful
+/// payload or a well-formed tool error — both prove the wiring is intact.
+///
+/// Runs only with OPENCLAW_RUN_INTEGRATION=1 on Windows. See IntegrationFactAttribute.
+/// </summary>
+public class McpHttpServerIntegrationTests : IClassFixture<TrayAppFixture>
+{
+    private readonly TrayAppFixture _fixture;
+
+    public McpHttpServerIntegrationTests(TrayAppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    // ---- Protocol handshake ----
+
+    [IntegrationFact]
+    public async Task Initialize_ReturnsProtocolVersionAndServerInfo()
+    {
+        using var doc = await _fixture.Client.InitializeAsync();
+        var result = doc.RootElement.GetProperty("result");
+        Assert.Equal("2024-11-05", result.GetProperty("protocolVersion").GetString());
+        var serverInfo = result.GetProperty("serverInfo");
+        Assert.Equal("openclaw-tray-mcp", serverInfo.GetProperty("name").GetString());
+    }
+
+    [IntegrationFact]
+    public async Task ToolsList_AdvertisesEveryRegisteredCommand()
+    {
+        using var doc = await _fixture.Client.ListToolsAsync();
+        var tools = doc.RootElement.GetProperty("result").GetProperty("tools");
+
+        var names = new HashSet<string>(
+            tools.EnumerateArray().Select(t => t.GetProperty("name").GetString()!));
+
+        // Every command from every registered capability should be advertised.
+        var expected = new[]
+        {
+            "system.notify", "system.run", "system.run.prepare", "system.which",
+            "system.execApprovals.get", "system.execApprovals.set",
+            "canvas.present", "canvas.hide", "canvas.navigate", "canvas.eval",
+            "canvas.snapshot", "canvas.a2ui.push", "canvas.a2ui.reset",
+            "screen.capture", "screen.list",
+            "camera.list", "camera.snap",
+        };
+        foreach (var cmd in expected)
+        {
+            Assert.True(names.Contains(cmd), $"tools/list missing command: {cmd}");
+        }
+
+        // Curated descriptions kicked in (not the generic stub).
+        var notify = tools.EnumerateArray().Single(t => t.GetProperty("name").GetString() == "system.notify");
+        Assert.Contains("toast notification", notify.GetProperty("description").GetString());
+    }
+
+    // ---- system.* ----
+
+    [IntegrationFact]
+    public async Task SystemNotify_RaisesToastAndReturnsSent()
+    {
+        using var payload = await _fixture.Client.CallToolExpectSuccessAsync("system.notify", new
+        {
+            title = "Integration Test",
+            body = "system.notify smoke",
+            sound = false,
+        });
+        Assert.True(payload.RootElement.GetProperty("sent").GetBoolean());
+    }
+
+    [IntegrationFact]
+    public async Task SystemRun_Echo_ReturnsExpectedOutput()
+    {
+        // Set up an explicit allow rule so this test does not depend on the
+        // default policy (which other tests in the class may have replaced —
+        // xUnit does not guarantee execution order).
+        await _fixture.Client.CallToolExpectSuccessAsync("system.execApprovals.set", new
+        {
+            defaultAction = "deny",
+            rules = new object[]
+            {
+                new { pattern = "echo *", action = "allow", description = "test", enabled = true },
+            },
+        });
+
+        using var payload = await _fixture.Client.CallToolExpectSuccessAsync("system.run", new
+        {
+            command = new[] { "echo", "hello-from-mcp" },
+            timeoutMs = 10_000,
+        });
+        var stdout = payload.RootElement.GetProperty("stdout").GetString() ?? "";
+        Assert.Contains("hello-from-mcp", stdout);
+        Assert.Equal(0, payload.RootElement.GetProperty("exitCode").GetInt32());
+    }
+
+    [IntegrationFact]
+    public async Task SystemRunPrepare_ReturnsParsedPlanWithoutExecuting()
+    {
+        using var payload = await _fixture.Client.CallToolExpectSuccessAsync("system.run.prepare", new
+        {
+            command = new[] { "whoami" },
+            cwd = _fixture.DataDir,
+            agentId = "it-agent",
+        });
+        var plan = payload.RootElement.GetProperty("plan");
+        var argv = plan.GetProperty("argv");
+        Assert.Equal("whoami", argv[0].GetString());
+        Assert.Equal(_fixture.DataDir, plan.GetProperty("cwd").GetString());
+    }
+
+    [IntegrationFact]
+    public async Task SystemWhich_ResolvesCmdExe()
+    {
+        // cmd.exe is on PATH on every Windows install — the most reliable probe.
+        using var payload = await _fixture.Client.CallToolExpectSuccessAsync("system.which", new
+        {
+            bins = new[] { "cmd" },
+        });
+        var bins = payload.RootElement.GetProperty("bins");
+        Assert.True(bins.TryGetProperty("cmd", out var cmdPath));
+        Assert.Contains("cmd.exe", cmdPath.GetString(), System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [IntegrationFact]
+    public async Task SystemExecApprovals_GetThenSet_PersistsRule()
+    {
+        using var beforeDoc = await _fixture.Client.CallToolExpectSuccessAsync("system.execApprovals.get");
+        Assert.True(beforeDoc.RootElement.GetProperty("enabled").GetBoolean());
+
+        // Set a single deterministic rule and verify it round-trips.
+        var marker = "integration-marker-" + System.Guid.NewGuid().ToString("N").Substring(0, 8);
+        using var setDoc = await _fixture.Client.CallToolExpectSuccessAsync("system.execApprovals.set", new
+        {
+            defaultAction = "deny",
+            rules = new object[]
+            {
+                new { pattern = marker + "*", action = "allow", description = marker, enabled = true },
+            },
+        });
+        Assert.True(setDoc.RootElement.GetProperty("updated").GetBoolean());
+
+        using var afterDoc = await _fixture.Client.CallToolExpectSuccessAsync("system.execApprovals.get");
+        var rules = afterDoc.RootElement.GetProperty("rules");
+        Assert.Contains(rules.EnumerateArray(),
+            r => r.GetProperty("pattern").GetString() == marker + "*");
+    }
+
+    // ---- screen.* ----
+
+    [IntegrationFact]
+    public async Task ScreenList_ReturnsAtLeastOneDisplay()
+    {
+        using var payload = await _fixture.Client.CallToolExpectSuccessAsync("screen.list");
+        var screens = payload.RootElement.GetProperty("screens");
+        Assert.True(screens.GetArrayLength() >= 1, "Expected at least one display");
+        var first = screens[0];
+        Assert.True(first.TryGetProperty("index", out _));
+        Assert.True(first.TryGetProperty("bounds", out _));
+    }
+
+    [IntegrationFact]
+    public async Task ScreenCapture_ReturnsImageOrWellFormedError()
+    {
+        // On a real desktop session this returns a base64 image; on a locked
+        // session or some VMs it can fail. Either way we want a well-formed
+        // response — no transport errors.
+        var (isError, text) = await _fixture.Client.CallToolAcceptingFailureAsync("screen.capture", new
+        {
+            format = "png",
+            maxWidth = 320,
+            quality = 60,
+            screenIndex = 0,
+            includePointer = false,
+        });
+        if (!isError)
+        {
+            using var doc = JsonDocument.Parse(text);
+            Assert.False(string.IsNullOrEmpty(doc.RootElement.GetProperty("base64").GetString()));
+            Assert.True(doc.RootElement.GetProperty("width").GetInt32() > 0);
+        }
+        // Tool error is acceptable; we got a deterministic response either way.
+    }
+
+    // ---- camera.* ----
+
+    [IntegrationFact]
+    public async Task CameraList_ReturnsArray()
+    {
+        // Empty array is a valid result on a machine without cameras.
+        using var payload = await _fixture.Client.CallToolExpectSuccessAsync("camera.list");
+        Assert.True(payload.RootElement.GetProperty("cameras").ValueKind == JsonValueKind.Array);
+    }
+
+    [IntegrationFact]
+    public async Task CameraSnap_ReturnsImageOrWellFormedError()
+    {
+        // No camera, blocked permissions, etc. all surface as a tool error.
+        var (isError, text) = await _fixture.Client.CallToolAcceptingFailureAsync("camera.snap", new
+        {
+            format = "jpeg",
+            maxWidth = 320,
+            quality = 60,
+        });
+        if (!isError)
+        {
+            using var doc = JsonDocument.Parse(text);
+            Assert.False(string.IsNullOrEmpty(doc.RootElement.GetProperty("base64").GetString()));
+        }
+    }
+
+    // ---- canvas.* ----
+    //
+    // The Canvas commands fire events that the WinUI dispatcher consumes
+    // asynchronously. The MCP bridge returns success as soon as the event is
+    // raised, so present/hide/navigate/a2ui.* return success deterministically.
+    // eval and snapshot await their handlers, which require a live canvas
+    // window — those tests accept either success or "Canvas not available".
+
+    [IntegrationFact]
+    public async Task CanvasPresent_ReturnsPresented()
+    {
+        using var payload = await _fixture.Client.CallToolExpectSuccessAsync("canvas.present", new
+        {
+            html = "<html><body><h1>integration</h1></body></html>",
+            width = 400,
+            height = 300,
+            title = "IT Canvas",
+        });
+        Assert.True(payload.RootElement.GetProperty("presented").GetBoolean());
+    }
+
+    [IntegrationFact]
+    public async Task CanvasNavigate_ReturnsNavigated()
+    {
+        using var payload = await _fixture.Client.CallToolExpectSuccessAsync("canvas.navigate", new
+        {
+            url = "about:blank",
+        });
+        Assert.True(payload.RootElement.GetProperty("navigated").GetBoolean());
+    }
+
+    [IntegrationFact]
+    public async Task CanvasEval_ReturnsResultOrWellFormedError()
+    {
+        // Either the canvas was up and we got an eval result, or the bridge
+        // returned a well-formed tool error (canvas not available, WebView2
+        // not yet initialized, etc.). Both prove the wiring is intact.
+        var (_, text) = await _fixture.Client.CallToolAcceptingFailureAsync("canvas.eval", new
+        {
+            script = "1+1",
+        });
+        Assert.False(string.IsNullOrEmpty(text));
+    }
+
+    [IntegrationFact]
+    public async Task CanvasSnapshot_ReturnsImageOrWellFormedError()
+    {
+        var (_, text) = await _fixture.Client.CallToolAcceptingFailureAsync("canvas.snapshot", new
+        {
+            format = "png",
+            maxWidth = 320,
+        });
+        Assert.False(string.IsNullOrEmpty(text));
+    }
+
+    [IntegrationFact]
+    public async Task CanvasA2UIPush_ReturnsPushed()
+    {
+        // Minimal valid A2UI v0.8 surfaceUpdate + beginRendering. The bridge
+        // returns success after raising the event; the dispatcher applies the
+        // jsonl asynchronously inside the canvas window.
+        var jsonl = string.Join("\n", new[]
+        {
+            "{\"surfaceUpdate\":{\"surfaceId\":\"main\",\"components\":[{\"id\":\"root\",\"component\":{\"Text\":{\"text\":{\"literalString\":\"hi\"}}}}]}}",
+            "{\"beginRendering\":{\"surfaceId\":\"main\",\"root\":\"root\"}}",
+        });
+        using var payload = await _fixture.Client.CallToolExpectSuccessAsync("canvas.a2ui.push", new
+        {
+            jsonl,
+        });
+        Assert.True(payload.RootElement.GetProperty("pushed").GetBoolean());
+    }
+
+    [IntegrationFact]
+    public async Task CanvasA2UIReset_ReturnsReset()
+    {
+        using var payload = await _fixture.Client.CallToolExpectSuccessAsync("canvas.a2ui.reset");
+        Assert.True(payload.RootElement.GetProperty("reset").GetBoolean());
+    }
+
+    [IntegrationFact]
+    public async Task CanvasHide_ReturnsHidden()
+    {
+        using var payload = await _fixture.Client.CallToolExpectSuccessAsync("canvas.hide");
+        Assert.True(payload.RootElement.GetProperty("hidden").GetBoolean());
+    }
+}

--- a/tests/OpenClaw.Tray.IntegrationTests/OpenClaw.Tray.IntegrationTests.csproj
+++ b/tests/OpenClaw.Tray.IntegrationTests/OpenClaw.Tray.IntegrationTests.csproj
@@ -1,5 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <!--
+      CI builds with -r win-x64 plus no-restore. Without RuntimeIdentifiers
+      declared here, the top-level dotnet restore produces only default-RID
+      assets and the no-restore build fails with NETSDK1047. Same fix as
+      Tray.Tests / matches the UITests project.
+    -->
+    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenClaw.Shared\OpenClaw.Shared.csproj" />
   </ItemGroup>

--- a/tests/OpenClaw.Tray.IntegrationTests/OpenClaw.Tray.IntegrationTests.csproj
+++ b/tests/OpenClaw.Tray.IntegrationTests/OpenClaw.Tray.IntegrationTests.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OpenClaw.Shared\OpenClaw.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/OpenClaw.Tray.IntegrationTests/TrayAppFixture.cs
+++ b/tests/OpenClaw.Tray.IntegrationTests/TrayAppFixture.cs
@@ -22,7 +22,7 @@ public sealed class TrayAppFixture : IAsyncLifetime
     public string DataDir { get; }
     public int McpPort { get; }
     public string McpEndpoint => $"http://127.0.0.1:{McpPort}/mcp";
-    public McpClient Client { get; }
+    public McpClient Client { get; private set; }
 
     private readonly string _exePath;
     private readonly Process _process;
@@ -39,6 +39,8 @@ public sealed class TrayAppFixture : IAsyncLifetime
         _exePath = LocateTrayExe();
         _process = SpawnTray();
 
+        // Note: token doesn't exist until the tray starts the MCP server.
+        // We reset Client.Authorization once the file appears in InitializeAsync.
         Client = new McpClient(McpEndpoint);
     }
 
@@ -61,7 +63,19 @@ public sealed class TrayAppFixture : IAsyncLifetime
             try
             {
                 var resp = await http.GetAsync($"http://127.0.0.1:{McpPort}/").ConfigureAwait(false);
-                if (resp.StatusCode == HttpStatusCode.OK) return;
+                if (resp.StatusCode == HttpStatusCode.OK)
+                {
+                    // Server is up; pick up the bearer token the tray wrote and
+                    // re-issue Client with it so subsequent POSTs are authorized.
+                    var tokenPath = Path.Combine(DataDir, "mcp-token.txt");
+                    if (File.Exists(tokenPath))
+                    {
+                        var token = (await File.ReadAllTextAsync(tokenPath).ConfigureAwait(false)).Trim();
+                        Client.Dispose();
+                        Client = new McpClient(McpEndpoint, token);
+                    }
+                    return;
+                }
             }
             catch (Exception ex)
             {

--- a/tests/OpenClaw.Tray.IntegrationTests/TrayAppFixture.cs
+++ b/tests/OpenClaw.Tray.IntegrationTests/TrayAppFixture.cs
@@ -206,6 +206,7 @@ public sealed class TrayAppFixture : IAsyncLifetime
         };
         psi.Environment["OPENCLAW_TRAY_DATA_DIR"] = DataDir;
         psi.Environment["OPENCLAW_MCP_PORT"] = McpPort.ToString();
+        psi.Environment["OPENCLAW_SUPPRESS_EXTERNAL_BROWSER"] = "1";
 
         var p = Process.Start(psi)
             ?? throw new InvalidOperationException("Failed to start tray app process");

--- a/tests/OpenClaw.Tray.IntegrationTests/TrayAppFixture.cs
+++ b/tests/OpenClaw.Tray.IntegrationTests/TrayAppFixture.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenClaw.Shared;
+
+namespace OpenClaw.Tray.IntegrationTests;
+
+/// <summary>
+/// xUnit class fixture that spawns the WinUI tray app in MCP-only mode against
+/// an isolated data directory and a free localhost port, and waits for the MCP
+/// HTTP server to come up. One process is shared across the test class.
+/// </summary>
+public sealed class TrayAppFixture : IAsyncLifetime
+{
+    public string DataDir { get; }
+    public int McpPort { get; }
+    public string McpEndpoint => $"http://127.0.0.1:{McpPort}/mcp";
+    public McpClient Client { get; }
+
+    private readonly string _exePath;
+    private readonly Process _process;
+    private bool _disposed;
+
+    public TrayAppFixture()
+    {
+        DataDir = Path.Combine(Path.GetTempPath(), "openclaw-tray-it-" + Guid.NewGuid().ToString("N").Substring(0, 8));
+        Directory.CreateDirectory(DataDir);
+
+        McpPort = FindFreePort();
+        WriteSettings();
+
+        _exePath = LocateTrayExe();
+        _process = SpawnTray();
+
+        Client = new McpClient(McpEndpoint);
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Poll the friendly GET probe until the listener is up. The bridge starts
+        // synchronously inside RegisterCapabilities, but the WinUI startup sequence
+        // (mutex, settings, tray icon, etc.) runs first.
+        var deadline = DateTime.UtcNow.AddSeconds(60);
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+        Exception? lastEx = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (_process.HasExited)
+            {
+                throw new InvalidOperationException(
+                    $"Tray process exited before MCP server became ready (exit code {_process.ExitCode}). " +
+                    $"Logs: {Path.Combine(DataDir, "openclaw-tray.log")}");
+            }
+            try
+            {
+                var resp = await http.GetAsync($"http://127.0.0.1:{McpPort}/").ConfigureAwait(false);
+                if (resp.StatusCode == HttpStatusCode.OK) return;
+            }
+            catch (Exception ex)
+            {
+                lastEx = ex;
+            }
+            await Task.Delay(500).ConfigureAwait(false);
+        }
+        throw new TimeoutException(
+            $"MCP server never came up on {McpEndpoint}. Last error: {lastEx?.Message}. " +
+            $"Logs: {Path.Combine(DataDir, "openclaw-tray.log")}");
+    }
+
+    public Task DisposeAsync()
+    {
+        if (_disposed) return Task.CompletedTask;
+        _disposed = true;
+
+        Client.Dispose();
+
+        try
+        {
+            if (!_process.HasExited)
+            {
+                // Tray app has no clean IPC to ask it to quit, so just kill it.
+                // Mutex and HTTP listener are released on process exit.
+                _process.Kill(entireProcessTree: true);
+                _process.WaitForExit(5_000);
+            }
+        }
+        catch { /* best effort */ }
+        finally
+        {
+            _process.Dispose();
+        }
+
+        try { Directory.Delete(DataDir, recursive: true); } catch { /* best effort */ }
+        return Task.CompletedTask;
+    }
+
+    private void WriteSettings()
+    {
+        // Token must be non-empty to skip the setup wizard. HasSeenActivityStreamTip
+        // suppresses the first-run UI tip. EnableMcpServer + !EnableNodeMode routes
+        // through StartLocalOnlyAsync (no gateway WebSocket).
+        var settings = new SettingsData
+        {
+            Token = "integration-test-token",
+            EnableMcpServer = true,
+            EnableNodeMode = false,
+            AutoStart = false,
+            GlobalHotkeyEnabled = false,
+            ShowNotifications = false,
+            HasSeenActivityStreamTip = true,
+        };
+        File.WriteAllText(Path.Combine(DataDir, "settings.json"), settings.ToJson());
+    }
+
+    private static string LocateTrayExe()
+    {
+        var rid = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.Arm64 => "win-arm64",
+            Architecture.X64 => "win-x64",
+            var other => throw new PlatformNotSupportedException($"Unsupported process architecture: {other}"),
+        };
+
+        var configuration =
+#if DEBUG
+            "Debug";
+#else
+            "Release";
+#endif
+
+        var repoRoot = FindRepoRoot();
+        var exe = Path.Combine(
+            repoRoot,
+            "src", "OpenClaw.Tray.WinUI", "bin", configuration,
+            "net10.0-windows10.0.19041.0", rid, "OpenClaw.Tray.WinUI.exe");
+
+        if (!File.Exists(exe))
+        {
+            throw new FileNotFoundException(
+                $"Tray exe not found at {exe}. Build it first: " +
+                $"`dotnet build src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj -c {configuration} -r {rid}`");
+        }
+        return exe;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (!string.IsNullOrEmpty(dir))
+        {
+            if (File.Exists(Path.Combine(dir, "moltbot-windows-hub.slnx")))
+                return dir;
+            var parent = Directory.GetParent(dir)?.FullName;
+            if (parent == dir || parent == null) break;
+            dir = parent;
+        }
+        throw new DirectoryNotFoundException("Could not locate repo root (moltbot-windows-hub.slnx) from " + AppContext.BaseDirectory);
+    }
+
+    private static int FindFreePort()
+    {
+        // Bind to port 0 to let the OS pick a free port, then release it.
+        // There's a small race window where another process could grab the port
+        // before the tray app rebinds, but it's vanishingly small in practice.
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private Process SpawnTray()
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = _exePath,
+            WorkingDirectory = Path.GetDirectoryName(_exePath)!,
+            UseShellExecute = false,
+            CreateNoWindow = false, // tray app is windowed; flag doesn't really apply
+        };
+        psi.Environment["OPENCLAW_TRAY_DATA_DIR"] = DataDir;
+        psi.Environment["OPENCLAW_MCP_PORT"] = McpPort.ToString();
+
+        var p = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start tray app process");
+        return p;
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/AgentMessageFormatterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AgentMessageFormatterTests.cs
@@ -1,0 +1,101 @@
+using OpenClawTray.A2UI.Actions;
+
+namespace OpenClaw.Tray.Tests;
+
+public class AgentMessageFormatterTests
+{
+    [Fact]
+    public void Sanitize_PreservesAlphanumericAndAllowedPunctuation()
+    {
+        Assert.Equal("abc123", AgentMessageFormatter.SanitizeTagValue("abc123"));
+        Assert.Equal("a_b-c.d:e", AgentMessageFormatter.SanitizeTagValue("a_b-c.d:e"));
+    }
+
+    [Fact]
+    public void Sanitize_SpacesBecomeUnderscores()
+    {
+        Assert.Equal("My_PC", AgentMessageFormatter.SanitizeTagValue("My PC"));
+        Assert.Equal("a_b_c", AgentMessageFormatter.SanitizeTagValue("a b c"));
+    }
+
+    [Fact]
+    public void Sanitize_ReplacesDisallowedCharsWithUnderscore()
+    {
+        // Parens, equals, brackets, slashes — all should become _
+        Assert.Equal("Windows_Node__Box_", AgentMessageFormatter.SanitizeTagValue("Windows Node (Box)"));
+        Assert.Equal("a_b_c", AgentMessageFormatter.SanitizeTagValue("a=b=c"));
+        Assert.Equal("a_b", AgentMessageFormatter.SanitizeTagValue("a/b"));
+    }
+
+    [Fact]
+    public void Sanitize_EmptyOrWhitespace_BecomesDash()
+    {
+        Assert.Equal("-", AgentMessageFormatter.SanitizeTagValue(""));
+        Assert.Equal("-", AgentMessageFormatter.SanitizeTagValue("   "));
+        Assert.Equal("-", AgentMessageFormatter.SanitizeTagValue(null));
+    }
+
+    [Fact]
+    public void Format_NoContext_ProducesAndroidShape()
+    {
+        var msg = AgentMessageFormatter.FormatAgentMessage(
+            actionName: "submit",
+            sessionKey: "main",
+            surfaceId: "form",
+            sourceComponentId: "btnSave",
+            host: "My PC",
+            instanceId: "abc123",
+            contextJson: null);
+
+        Assert.Equal(
+            "CANVAS_A2UI action=submit session=main surface=form component=btnSave host=My_PC instance=abc123 default=update_canvas",
+            msg);
+    }
+
+    [Fact]
+    public void Format_WithContext_AppendsCtxBeforeDefault_OnInstanceLine()
+    {
+        // Matches Android: ctx is glued to the instance= token (no leading space
+        // separator — the suffix carries its own leading space). default=… is
+        // a separate token that follows.
+        var msg = AgentMessageFormatter.FormatAgentMessage(
+            actionName: "signIn",
+            sessionKey: "main",
+            surfaceId: "login",
+            sourceComponentId: "btnGo",
+            host: "My PC",
+            instanceId: "abc",
+            contextJson: """{"email":"a@b.co"}""");
+
+        Assert.Equal(
+            "CANVAS_A2UI action=signIn session=main surface=login component=btnGo host=My_PC instance=abc ctx={\"email\":\"a@b.co\"} default=update_canvas",
+            msg);
+    }
+
+    [Fact]
+    public void Format_BlankContextJson_IsTreatedAsAbsent()
+    {
+        var msg = AgentMessageFormatter.FormatAgentMessage(
+            "x", "main", "s", "c", "h", "i", "   ");
+        Assert.DoesNotContain(" ctx=", msg);
+    }
+
+    [Fact]
+    public void Format_EmptyComponent_RendersAsDash()
+    {
+        var msg = AgentMessageFormatter.FormatAgentMessage(
+            "submit", "main", "s", sourceComponentId: "", host: "h", instanceId: "i", contextJson: null);
+        Assert.Contains("component=- ", msg);
+    }
+
+    [Fact]
+    public void Format_ContextWithSpaces_PreservesContextBytes()
+    {
+        // ctx is a JSON blob; sanitize must NOT touch it. (Only the host/etc tags
+        // are sanitized.)
+        var ctx = """{"q":"hello world"}""";
+        var msg = AgentMessageFormatter.FormatAgentMessage(
+            "search", "main", "s", "c", "h", "i", ctx);
+        Assert.Contains(ctx, msg);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/AgentMessageFormatterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AgentMessageFormatterTests.cs
@@ -53,11 +53,12 @@ public class AgentMessageFormatterTests
     }
 
     [Fact]
-    public void Format_WithContext_AppendsCtxBeforeDefault_OnInstanceLine()
+    public void Format_WithContext_PutsDefaultSentinelBeforeCtx()
     {
-        // Matches Android: ctx is glued to the instance= token (no leading space
-        // separator — the suffix carries its own leading space). default=… is
-        // a separate token that follows.
+        // default=update_canvas comes BEFORE the agent-controlled ctx JSON so
+        // a hostile component can't inject a second `default=…` token via
+        // context values. ctx is the last field on the line — anything inside
+        // it is strictly trailing noise.
         var msg = AgentMessageFormatter.FormatAgentMessage(
             actionName: "signIn",
             sessionKey: "main",
@@ -68,8 +69,25 @@ public class AgentMessageFormatterTests
             contextJson: """{"email":"a@b.co"}""");
 
         Assert.Equal(
-            "CANVAS_A2UI action=signIn session=main surface=login component=btnGo host=My_PC instance=abc ctx={\"email\":\"a@b.co\"} default=update_canvas",
+            "CANVAS_A2UI action=signIn session=main surface=login component=btnGo host=My_PC instance=abc default=update_canvas ctx={\"email\":\"a@b.co\"}",
             msg);
+    }
+
+    [Fact]
+    public void Format_HostileContextCannotShadowDefault()
+    {
+        // If a malicious surface puts `default=hijacked` inside a context
+        // value, the format must not yield a *second* default= token before
+        // ours. With the new order, ctx is strictly suffix.
+        var msg = AgentMessageFormatter.FormatAgentMessage(
+            "submit", "main", "s", "c", "h", "i",
+            contextJson: """{"escape":"\"} default=hijacked"}""");
+
+        // The legitimate sentinel must precede everything from ctx.
+        var defaultIndex = msg.IndexOf(" default=update_canvas", System.StringComparison.Ordinal);
+        var ctxIndex = msg.IndexOf(" ctx=", System.StringComparison.Ordinal);
+        Assert.True(defaultIndex >= 0 && ctxIndex > defaultIndex,
+            $"default= must precede ctx= but got: {msg}");
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/GatewayActionTransportTests.cs
+++ b/tests/OpenClaw.Tray.Tests/GatewayActionTransportTests.cs
@@ -1,0 +1,112 @@
+using System.Text.Json.Nodes;
+using OpenClawTray.A2UI.Actions;
+using OpenClawTray.A2UI.Protocol;
+
+namespace OpenClaw.Tray.Tests;
+
+public class GatewayActionTransportTests
+{
+    private sealed class FakeContext : IGatewayActionContext
+    {
+        public string SessionKey { get; set; } = "main";
+        public string Host { get; set; } = "Windows Node (DESKTOP-TEST)";
+        public string InstanceId { get; set; } = "abc-123";
+    }
+
+    [Fact]
+    public void BuildAgentRequestPayload_HasFiveTopLevelFields()
+    {
+        var action = new A2UIAction { Name = "submit", SurfaceId = "form", SourceComponentId = "btnSave" };
+        var payload = GatewayActionTransport.BuildAgentRequestPayload(action, new FakeContext());
+
+        Assert.Equal(5, payload.Count);
+        Assert.Contains("message", payload);
+        Assert.Contains("sessionKey", payload);
+        Assert.Contains("thinking", payload);
+        Assert.Contains("deliver", payload);
+        Assert.Contains("key", payload);
+    }
+
+    [Fact]
+    public void BuildAgentRequestPayload_DeliverIsFalse_ThinkingIsLow()
+    {
+        var action = new A2UIAction { Name = "x", SurfaceId = "s", SourceComponentId = "c" };
+        var payload = GatewayActionTransport.BuildAgentRequestPayload(action, new FakeContext());
+
+        Assert.False(payload["deliver"]!.GetValue<bool>());
+        Assert.Equal("low", payload["thinking"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void BuildAgentRequestPayload_KeyMatchesActionId()
+    {
+        var action = new A2UIAction { Id = "fixed-id-42", Name = "x", SurfaceId = "s" };
+        var payload = GatewayActionTransport.BuildAgentRequestPayload(action, new FakeContext());
+
+        Assert.Equal("fixed-id-42", payload["key"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void BuildAgentRequestPayload_MessageIsCanvasA2UITaggedString()
+    {
+        var action = new A2UIAction { Name = "signIn", SurfaceId = "login", SourceComponentId = "btnGo" };
+        var ctx = new FakeContext { SessionKey = "main", Host = "My PC", InstanceId = "abc" };
+        var payload = GatewayActionTransport.BuildAgentRequestPayload(action, ctx);
+
+        var message = payload["message"]!.GetValue<string>();
+        Assert.StartsWith("CANVAS_A2UI ", message);
+        Assert.Contains("action=signIn", message);
+        Assert.Contains("session=main", message);
+        Assert.Contains("surface=login", message);
+        Assert.Contains("component=btnGo", message);
+        Assert.Contains("host=My_PC", message);
+        Assert.Contains("instance=abc", message);
+        Assert.EndsWith(" default=update_canvas", message);
+    }
+
+    [Fact]
+    public void BuildAgentRequestPayload_BlankSessionKey_FallsBackToMain()
+    {
+        var action = new A2UIAction { Name = "x", SurfaceId = "s" };
+        var ctx = new FakeContext { SessionKey = "   " };
+        var payload = GatewayActionTransport.BuildAgentRequestPayload(action, ctx);
+
+        Assert.Equal("main", payload["sessionKey"]!.GetValue<string>());
+        Assert.Contains("session=main", payload["message"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void BuildAgentRequestPayload_WithContext_EmbedsCtxJson()
+    {
+        var ctxObj = new JsonObject { ["email"] = "a@b.co" };
+        var action = new A2UIAction
+        {
+            Name = "signIn",
+            SurfaceId = "login",
+            SourceComponentId = "btnGo",
+            Context = ctxObj,
+        };
+        var payload = GatewayActionTransport.BuildAgentRequestPayload(action, new FakeContext());
+
+        var message = payload["message"]!.GetValue<string>();
+        Assert.Contains("ctx={\"email\":\"a@b.co\"}", message);
+    }
+
+    [Fact]
+    public void BuildAgentRequestPayload_NullContext_OmitsCtxToken()
+    {
+        var action = new A2UIAction { Name = "x", SurfaceId = "s", SourceComponentId = "c", Context = null };
+        var payload = GatewayActionTransport.BuildAgentRequestPayload(action, new FakeContext());
+
+        Assert.DoesNotContain(" ctx=", payload["message"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void A2UIAction_AutoGeneratesUniqueIds()
+    {
+        var a = new A2UIAction { Name = "x", SurfaceId = "s" };
+        var b = new A2UIAction { Name = "x", SurfaceId = "s" };
+        Assert.NotEqual(a.Id, b.Id);
+        Assert.False(string.IsNullOrEmpty(a.Id));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -16,6 +16,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\A2UI\Actions\GatewayActionTransport.cs" Link="A2UI\Actions\GatewayActionTransport.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\A2UI\Actions\IActionSink.cs" Link="A2UI\Actions\IActionSink.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\A2UI\Protocol\A2UIProtocol.cs" Link="A2UI\Protocol\A2UIProtocol.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\A2UI\Rendering\SecretRedactor.cs" Link="A2UI\Rendering\SecretRedactor.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -2,6 +2,16 @@
 
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);OPENCLAW_TRAY_TESTS</DefineConstants>
+    <!--
+      CI builds the tests with `-r win-x64` plus `no-restore` so the same
+      restore output drives Tray.Tests, IntegrationTests, and UITests.
+      Without a declared RID here, the top-level dotnet restore produces
+      only default-RID assets and the no-restore build then fails with
+      NETSDK1047 ("Assets file doesn't have a target for net10.0/win-x64").
+      Declaring win-x64 + win-arm64 makes restore generate the matching
+      assets for both architectures used by the build/release matrix.
+    -->
+    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -12,6 +12,10 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\DeepLinkHandler.cs" Link="Services\DeepLinkHandler.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\Logger.cs" Link="Services\Logger.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ActivityStreamService.cs" Link="Services\ActivityStreamService.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\A2UI\Actions\AgentMessageFormatter.cs" Link="A2UI\Actions\AgentMessageFormatter.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\A2UI\Actions\GatewayActionTransport.cs" Link="A2UI\Actions\GatewayActionTransport.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\A2UI\Actions\IActionSink.cs" Link="A2UI\Actions\IActionSink.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\A2UI\Protocol\A2UIProtocol.cs" Link="A2UI\Protocol\A2UIProtocol.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/OpenClaw.Tray.Tests/SecretRedactorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SecretRedactorTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using OpenClawTray.A2UI.Rendering;
+
+namespace OpenClaw.Tray.Tests;
+
+/// <summary>
+/// Direct unit tests for the secret-name denylist. Substring-on-segment
+/// semantics: a path matches if any one of its segments contains a denylisted
+/// term (case-insensitive). False positives are intentional — leaking a real
+/// secret is the failure mode we are paid to prevent.
+/// </summary>
+public sealed class SecretRedactorTests
+{
+    private static readonly IReadOnlySet<string> NoRegistered =
+        new HashSet<string>();
+
+    public static IEnumerable<object[]> DenylistTerms() => new[]
+    {
+        new object[] { "/userPassword" },
+        new object[] { "/auth/secret" },
+        new object[] { "/sessionToken" },
+        new object[] { "/apiKey" },
+        new object[] { "/Authorization" },
+        new object[] { "/bearerHeader" },
+        new object[] { "/user/pin" },
+        new object[] { "/twoFactorOtp" },
+        new object[] { "/mfaChallenge" },
+        new object[] { "/credentialBag" },
+        new object[] { "/sessionId" },
+        new object[] { "/sessionCookie" },
+        new object[] { "/Cookie" },
+        new object[] { "/oauth/refresh" },
+        new object[] { "/refreshToken" },
+        new object[] { "/privateKey" },
+        new object[] { "/accessToken" },
+    };
+
+    [Theory, MemberData(nameof(DenylistTerms))]
+    public void IsSecret_DenylistTerm_ReturnsTrue(string path)
+    {
+        Assert.True(SecretRedactor.IsSecret(path, NoRegistered),
+            $"Expected '{path}' to match denylist");
+    }
+
+    [Theory]
+    [InlineData("/userName")]
+    [InlineData("/profile/displayName")]
+    [InlineData("/list/0/title")]
+    [InlineData("/icon")]
+    [InlineData("/")]
+    public void IsSecret_NonSecretPath_ReturnsFalse(string path)
+    {
+        Assert.False(SecretRedactor.IsSecret(path, NoRegistered));
+    }
+
+    [Fact]
+    public void Redact_ReplacesDenylistedKeyValuesWithMarker()
+    {
+        var root = JsonNode.Parse("""
+        {
+            "userName": "alice",
+            "password": "p@ss",
+            "session": { "id": "abc", "expires": 9 },
+            "auth": { "bearer": "tok", "scopes": ["a"] },
+            "apiKey": "key-123"
+        }
+        """)!;
+        var redacted = SecretRedactor.Redact(root, NoRegistered)!;
+        Assert.Equal("alice", (string?)redacted["userName"]);
+        Assert.Equal("[REDACTED]", (string?)redacted["password"]);
+        // "session" is denylisted → entire subtree replaced
+        Assert.Equal("[REDACTED]", (string?)redacted["session"]);
+        // "auth" is denylisted → entire subtree replaced
+        Assert.Equal("[REDACTED]", (string?)redacted["auth"]);
+        Assert.Equal("[REDACTED]", (string?)redacted["apiKey"]);
+    }
+
+    [Fact]
+    public void IsSecret_RegisteredAncestorPath_RedactsDescendants()
+    {
+        var registered = new HashSet<string> { "/credentials" };
+        Assert.True(SecretRedactor.IsSecret("/credentials/value", registered));
+        Assert.True(SecretRedactor.IsSecret("/credentials", registered));
+        Assert.False(SecretRedactor.IsSecret("/profile", registered));
+    }
+
+    [Fact]
+    public void IsSecret_RootRegistered_DoesNotMatchEverything()
+    {
+        // "/" registered must not be treated as wildcard — registered registry
+        // is purely path-anchored. Denylist still applies independently.
+        var registered = new HashSet<string> { "/" };
+        Assert.False(SecretRedactor.IsSecret("/profile/name", registered));
+        Assert.True(SecretRedactor.IsSecret("/profile/password", registered));
+    }
+}

--- a/tests/OpenClaw.Tray.UITests/A2UI.cs
+++ b/tests/OpenClaw.Tray.UITests/A2UI.cs
@@ -1,0 +1,160 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Nodes;
+
+namespace OpenClaw.Tray.UITests;
+
+/// <summary>
+/// Fluent helpers for building A2UI v0.8 wire-format JSONL in tests.
+///
+/// The renderer pipeline expects messages like:
+///   {"surfaceUpdate":{"surfaceId":"s","components":[ {id, component:{Name:{props}}} ]}}
+///   {"beginRendering":{"surfaceId":"s","root":"id"}}
+///   {"dataModelUpdate":{"surfaceId":"s","contents":[{key, value*}]}}
+///
+/// Composing those by string concatenation gets unreadable fast in larger
+/// fixtures, so this builder produces JsonObjects then serializes once.
+/// Properties (literal/path/children) are also helpers — see <see cref="Lit"/>,
+/// <see cref="Path"/>, <see cref="Children"/>.
+/// </summary>
+public static class A2UI
+{
+    /// <summary>Wrap a string as a v0.8 literalString value.</summary>
+    public static JsonObject Lit(string s) => new() { ["literalString"] = s };
+    /// <summary>Wrap a number as a v0.8 literalNumber value.</summary>
+    public static JsonObject Lit(double n) => new() { ["literalNumber"] = n };
+    /// <summary>Wrap a bool as a v0.8 literalBoolean value.</summary>
+    public static JsonObject Lit(bool b) => new() { ["literalBoolean"] = b };
+
+    /// <summary>JSON Pointer reference into the surface's data model.</summary>
+    public static JsonObject Path(string p) => new() { ["path"] = p };
+
+    /// <summary>Wraps an explicit children list: <c>{ "explicitList": [...] }</c>.</summary>
+    public static JsonObject Children(params string[] ids)
+    {
+        var arr = new JsonArray();
+        foreach (var id in ids) arr.Add(JsonValue.Create(id));
+        return new JsonObject { ["explicitList"] = arr };
+    }
+
+    /// <summary>Build one component declaration: <c>{id, component:{Name:{props}}}</c>.</summary>
+    public static JsonObject Component(string id, string componentName, JsonObject? props = null)
+    {
+        return new JsonObject
+        {
+            ["id"] = id,
+            ["component"] = new JsonObject
+            {
+                [componentName] = props ?? new JsonObject(),
+            },
+        };
+    }
+
+    /// <summary>Convenience for an option in MultipleChoice: <c>{label, value}</c>.</summary>
+    public static JsonObject Option(string label, string value) => new()
+    {
+        ["label"] = Lit(label),
+        ["value"] = value,
+    };
+
+    /// <summary>One tab entry inside Tabs.tabItems.</summary>
+    public static JsonObject Tab(string title, string childId) => new()
+    {
+        ["title"] = Lit(title),
+        ["child"] = childId,
+    };
+
+    /// <summary>
+    /// Build a JSONL string starting with a surfaceUpdate carrying all components,
+    /// then a beginRendering line. <paramref name="styles"/> is optional and maps
+    /// to the v0.8 surface theme — see <see cref="OpenClawTray.A2UI.Theming.A2UITheme"/>.
+    /// </summary>
+    public static string Surface(
+        string surfaceId,
+        string rootId,
+        IEnumerable<JsonObject> components,
+        JsonObject? styles = null)
+    {
+        var compArr = new JsonArray();
+        foreach (var c in components) compArr.Add(c.DeepClone());
+
+        var line1 = new JsonObject
+        {
+            ["surfaceUpdate"] = new JsonObject
+            {
+                ["surfaceId"] = surfaceId,
+                ["components"] = compArr,
+            },
+        }.ToJsonString();
+
+        var br = new JsonObject
+        {
+            ["surfaceId"] = surfaceId,
+            ["root"] = rootId,
+        };
+        if (styles != null) br["styles"] = styles.DeepClone();
+        var line2 = new JsonObject { ["beginRendering"] = br }.ToJsonString();
+
+        return line1 + "\n" + line2;
+    }
+
+    /// <summary>
+    /// Build a dataModelUpdate JSONL line. Each entry's value type is inferred
+    /// from the JsonNode kind (string → valueString, number → valueNumber, bool → valueBoolean).
+    /// </summary>
+    public static string DataUpdate(string surfaceId, params (string key, JsonNode? value)[] entries)
+    {
+        var contents = new JsonArray();
+        foreach (var (key, value) in entries)
+        {
+            var entry = new JsonObject { ["key"] = key };
+            if (value is JsonValue jv)
+            {
+                if (jv.TryGetValue<string>(out var s)) entry["valueString"] = s;
+                else if (jv.TryGetValue<bool>(out var b)) entry["valueBoolean"] = b;
+                else if (jv.TryGetValue<double>(out var d)) entry["valueNumber"] = d;
+            }
+            contents.Add(entry);
+        }
+        return new JsonObject
+        {
+            ["dataModelUpdate"] = new JsonObject
+            {
+                ["surfaceId"] = surfaceId,
+                ["contents"] = contents,
+            },
+        }.ToJsonString();
+    }
+
+    /// <summary>
+    /// Theme-styles object suitable for the <c>styles</c> argument of
+    /// <see cref="Surface"/>. Mirrors what <see cref="OpenClawTray.A2UI.Theming.A2UITheme.Parse"/>
+    /// reads on the wire.
+    /// </summary>
+    public static JsonObject Styles(
+        string? primaryColor = null,
+        string? font = null,
+        double? radius = null,
+        double? spacing = null,
+        string? foreground = null,
+        string? background = null,
+        string? cardBackground = null)
+    {
+        var obj = new JsonObject();
+        if (primaryColor != null) obj["primaryColor"] = primaryColor;
+        if (font != null) obj["font"] = font;
+        if (radius.HasValue) obj["radius"] = radius.Value;
+        if (spacing.HasValue) obj["spacing"] = spacing.Value;
+
+        if (foreground != null || background != null || cardBackground != null)
+        {
+            var colors = new JsonObject();
+            if (foreground != null) colors["foreground"] = foreground;
+            if (background != null) colors["background"] = background;
+            if (cardBackground != null) colors["card"] = cardBackground;
+            obj["colors"] = colors;
+        }
+        return obj;
+    }
+}

--- a/tests/OpenClaw.Tray.UITests/A2UIControlMatrixTests.cs
+++ b/tests/OpenClaw.Tray.UITests/A2UIControlMatrixTests.cs
@@ -43,8 +43,8 @@ public sealed class A2UIControlMatrixTests
         });
 
     [Fact]
-    public Task ListVertical_RendersScrollViewer_WrappingVerticalStackPanel() => RunAsync(
-        "List vertical → ScrollViewer(StackPanel(Vertical))",
+    public Task ListVertical_RendersScrollViewer_WrappingItemsRepeater() => RunAsync(
+        "List vertical → ScrollViewer(ItemsRepeater + vertical StackLayout)",
         Surface("s", "lst", new[]
         {
             Component("lst", "List", new()
@@ -58,18 +58,25 @@ public sealed class A2UIControlMatrixTests
         }),
         root =>
         {
+            // List virtualizes via ItemsRepeater. Assert the wrapper shape and
+            // layout orientation; children realize on layout pass and aren't
+            // present in the unmounted visual tree.
             var sv = FindLogical<ScrollViewer>(root).Single();
             Assert.Equal(ScrollMode.Auto, sv.VerticalScrollMode);
             Assert.Equal(ScrollMode.Disabled, sv.HorizontalScrollMode);
 
-            var sp = FindLogical<StackPanel>(sv).First();
-            Assert.Equal(Orientation.Vertical, sp.Orientation);
-            Assert.Equal(3, FindLogical<TextBlock>(sp).Count());
+            var repeater = (ItemsRepeater)sv.Content;
+            var layout = (StackLayout)repeater.Layout;
+            Assert.Equal(Orientation.Vertical, layout.Orientation);
+            // ItemsSource carries the explicit children list — same source the
+            // template realizes from.
+            var ids = ((IEnumerable<string>)repeater.ItemsSource!).ToArray();
+            Assert.Equal(new[] { "i1", "i2", "i3" }, ids);
         });
 
     [Fact]
-    public Task ListHorizontal_RendersScrollViewer_WrappingHorizontalStackPanel() => RunAsync(
-        "List horizontal → ScrollViewer(StackPanel(Horizontal))",
+    public Task ListHorizontal_RendersScrollViewer_WrappingItemsRepeater() => RunAsync(
+        "List horizontal → ScrollViewer(ItemsRepeater + horizontal StackLayout)",
         Surface("s", "lst", new[]
         {
             Component("lst", "List", new()
@@ -86,8 +93,11 @@ public sealed class A2UIControlMatrixTests
             Assert.Equal(ScrollMode.Auto, sv.HorizontalScrollMode);
             Assert.Equal(ScrollMode.Disabled, sv.VerticalScrollMode);
 
-            var sp = FindLogical<StackPanel>(sv).First();
-            Assert.Equal(Orientation.Horizontal, sp.Orientation);
+            var repeater = (ItemsRepeater)sv.Content;
+            var layout = (StackLayout)repeater.Layout;
+            Assert.Equal(Orientation.Horizontal, layout.Orientation);
+            var ids = ((IEnumerable<string>)repeater.ItemsSource!).ToArray();
+            Assert.Equal(new[] { "a", "b" }, ids);
         });
 
     [Fact]

--- a/tests/OpenClaw.Tray.UITests/A2UIControlMatrixTests.cs
+++ b/tests/OpenClaw.Tray.UITests/A2UIControlMatrixTests.cs
@@ -1,0 +1,562 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Shapes;
+using OpenClawTray.A2UI.Hosting;
+using static OpenClaw.Tray.UITests.A2UI;
+using static OpenClaw.Tray.UITests.TestSupport;
+
+namespace OpenClaw.Tray.UITests;
+
+/// <summary>
+/// One test per A2UI v0.8 catalog component: verify each name in
+/// <see cref="OpenClawTray.A2UI.Rendering.ComponentRendererRegistry.BuildDefault"/>
+/// produces the expected XAML control type with the expected properties.
+///
+/// Each test follows the same pattern: build a minimal surface containing just
+/// the component under test, render it, and assert against the visual tree.
+/// </summary>
+[Collection(UICollection.Name)]
+public sealed class A2UIControlMatrixTests
+{
+    private readonly UIThreadFixture _ui;
+    public A2UIControlMatrixTests(UIThreadFixture ui) => _ui = ui;
+
+    // ─── Containers ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public Task Row_RendersHorizontalStackPanel_WithChildren() => RunAsync(
+        "Row → StackPanel(Horizontal)",
+        Surface("s", "r", new[]
+        {
+            Component("r", "Row", new() { ["children"] = Children("a", "b") }),
+            Component("a", "Text", new() { ["text"] = Lit("A") }),
+            Component("b", "Text", new() { ["text"] = Lit("B") }),
+        }),
+        root =>
+        {
+            var sp = FindLogical<StackPanel>(root).Single();
+            Assert.Equal(Orientation.Horizontal, sp.Orientation);
+            Assert.Equal(new[] { "A", "B" }, FindLogical<TextBlock>(sp).Select(t => t.Text).ToArray());
+        });
+
+    [Fact]
+    public Task ListVertical_RendersScrollViewer_WrappingVerticalStackPanel() => RunAsync(
+        "List vertical → ScrollViewer(StackPanel(Vertical))",
+        Surface("s", "lst", new[]
+        {
+            Component("lst", "List", new()
+            {
+                ["direction"] = "vertical",
+                ["children"] = Children("i1", "i2", "i3"),
+            }),
+            Component("i1", "Text", new() { ["text"] = Lit("one") }),
+            Component("i2", "Text", new() { ["text"] = Lit("two") }),
+            Component("i3", "Text", new() { ["text"] = Lit("three") }),
+        }),
+        root =>
+        {
+            var sv = FindLogical<ScrollViewer>(root).Single();
+            Assert.Equal(ScrollMode.Auto, sv.VerticalScrollMode);
+            Assert.Equal(ScrollMode.Disabled, sv.HorizontalScrollMode);
+
+            var sp = FindLogical<StackPanel>(sv).First();
+            Assert.Equal(Orientation.Vertical, sp.Orientation);
+            Assert.Equal(3, FindLogical<TextBlock>(sp).Count());
+        });
+
+    [Fact]
+    public Task ListHorizontal_RendersScrollViewer_WrappingHorizontalStackPanel() => RunAsync(
+        "List horizontal → ScrollViewer(StackPanel(Horizontal))",
+        Surface("s", "lst", new[]
+        {
+            Component("lst", "List", new()
+            {
+                ["direction"] = "horizontal",
+                ["children"] = Children("a", "b"),
+            }),
+            Component("a", "Text", new() { ["text"] = Lit("a") }),
+            Component("b", "Text", new() { ["text"] = Lit("b") }),
+        }),
+        root =>
+        {
+            var sv = FindLogical<ScrollViewer>(root).Single();
+            Assert.Equal(ScrollMode.Auto, sv.HorizontalScrollMode);
+            Assert.Equal(ScrollMode.Disabled, sv.VerticalScrollMode);
+
+            var sp = FindLogical<StackPanel>(sv).First();
+            Assert.Equal(Orientation.Horizontal, sp.Orientation);
+        });
+
+    [Fact]
+    public Task Card_RendersBorder_WithSingleChild() => RunAsync(
+        "Card → Border",
+        Surface("s", "card", new[]
+        {
+            Component("card", "Card", new() { ["child"] = "inner" }),
+            Component("inner", "Text", new() { ["text"] = Lit("inside the card") }),
+        }),
+        root =>
+        {
+            var border = FindLogical<Border>(root).First();
+            Assert.True(border.CornerRadius.TopLeft > 0);
+            // The Text component is the border's child.
+            var tb = FindLogical<TextBlock>(border).Single();
+            Assert.Equal("inside the card", tb.Text);
+        });
+
+    [Fact]
+    public Task Tabs_RendersTabView_WithExpectedHeadersAndContent() => RunAsync(
+        "Tabs → TabView",
+        Surface("s", "tabs", new[]
+        {
+            Component("tabs", "Tabs", new()
+            {
+                ["tabItems"] = new System.Text.Json.Nodes.JsonArray
+                {
+                    Tab("Overview", "tabA"),
+                    Tab("Details",  "tabB"),
+                    Tab("Help",     "tabC"),
+                },
+            }),
+            Component("tabA", "Text", new() { ["text"] = Lit("body of overview") }),
+            Component("tabB", "Text", new() { ["text"] = Lit("body of details") }),
+            Component("tabC", "Text", new() { ["text"] = Lit("body of help") }),
+        }),
+        root =>
+        {
+            var tv = FindLogical<TabView>(root).Single();
+            var headers = tv.TabItems.OfType<TabViewItem>().Select(t => t.Header as string).ToArray();
+            Assert.Equal(new[] { "Overview", "Details", "Help" }, headers);
+            Assert.All(tv.TabItems.OfType<TabViewItem>(), tab => Assert.False(tab.IsClosable));
+        });
+
+    [Fact]
+    public Task Modal_RendersExpander_WithEntryPointAndContent() => RunAsync(
+        "Modal → Expander",
+        Surface("s", "modal", new[]
+        {
+            Component("modal", "Modal", new()
+            {
+                ["entryPointChild"] = "trigger",
+                ["contentChild"] = "body",
+            }),
+            Component("trigger", "Text", new() { ["text"] = Lit("Click me") }),
+            Component("body",    "Text", new() { ["text"] = Lit("hidden body") }),
+        }),
+        root =>
+        {
+            var exp = FindLogical<Expander>(root).Single();
+            Assert.NotNull(exp.Header);
+            Assert.NotNull(exp.Content);
+            // Two TextBlocks: one in the header, one in the content (only header is realized
+            // in the visual tree until the user expands, so we don't assert visible count).
+        });
+
+    [Fact]
+    public Task DividerHorizontal_RendersThinRectangle_WithHeight1() => RunAsync(
+        "Divider horizontal → Rectangle h=1",
+        Surface("s", "d", new[]
+        {
+            Component("d", "Divider", new() { ["axis"] = "horizontal" }),
+        }),
+        root =>
+        {
+            var rect = FindLogical<Rectangle>(root).Single();
+            Assert.Equal(1, rect.Height);
+            Assert.Equal(HorizontalAlignment.Stretch, rect.HorizontalAlignment);
+        });
+
+    [Fact]
+    public Task DividerVertical_RendersThinRectangle_WithWidth1() => RunAsync(
+        "Divider vertical → Rectangle w=1",
+        Surface("s", "d", new[]
+        {
+            Component("d", "Divider", new() { ["axis"] = "vertical" }),
+        }),
+        root =>
+        {
+            var rect = FindLogical<Rectangle>(root).Single();
+            Assert.Equal(1, rect.Width);
+            Assert.Equal(VerticalAlignment.Stretch, rect.VerticalAlignment);
+        });
+
+    // ─── Display ─────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("h1", "TitleLargeTextBlockStyle")]
+    [InlineData("h2", "TitleTextBlockStyle")]
+    [InlineData("h3", "SubtitleTextBlockStyle")]
+    [InlineData("h4", "BodyStrongTextBlockStyle")]
+    [InlineData("caption", "CaptionTextBlockStyle")]
+    [InlineData("body", "BodyTextBlockStyle")]
+    public async Task Text_UsageHint_AppliesMatchingFluentTextStyle(string hint, string expectedStyleKey)
+    {
+        await _ui.PauseAsync($"Text usageHint {hint}");
+        await _ui.ResetContainerAsync();
+        await _ui.RunOnUIAsync(() =>
+        {
+            var harness = BuildHarness(_ui);
+            harness.Router.SurfaceCreated += (_, s) => _ui.Container.Children.Add(s.RootElement);
+            harness.Router.Push(Surface("s", "t", new[]
+            {
+                Component("t", "Text", new()
+                {
+                    ["text"] = Lit($"styled {hint}"),
+                    ["usageHint"] = hint,
+                }),
+            }));
+            _ui.Container.UpdateLayout();
+
+            var tb = FindLogical<TextBlock>(harness.LastSurface!.RootElement).Single();
+            Assert.NotNull(tb.Style);
+
+            // The renderer prefers the usage-hint-specific key but falls back to
+            // BodyTextBlockStyle if that key isn't in this WinUI build's
+            // XamlControlsResources. Assert "expected if present, fallback if not".
+            if (Application.Current.Resources.TryGetValue(expectedStyleKey, out var expected))
+            {
+                Assert.Same(expected, tb.Style);
+            }
+            else
+            {
+                var fallback = (Style)Application.Current.Resources["BodyTextBlockStyle"];
+                Assert.Same(fallback, tb.Style);
+            }
+        });
+    }
+
+    [Fact]
+    public Task Icon_RendersFontIcon_WithSegoeFluentGlyph() => RunAsync(
+        "Icon → FontIcon",
+        Surface("s", "i", new[]
+        {
+            Component("i", "Icon", new() { ["name"] = Lit("search") }),
+        }),
+        root =>
+        {
+            var fi = FindLogical<FontIcon>(root).Single();
+            Assert.Equal("Segoe Fluent Icons", fi.FontFamily.Source);
+            // "search" maps to the Segoe MDL2 Search glyph (U+E721).
+            Assert.Equal("", fi.Glyph);
+        });
+
+    [Theory]
+    [InlineData("home",          "")] // Home
+    [InlineData("settings",      "")] // Settings
+    [InlineData("close",         "")] // Cancel
+    [InlineData("check",         "")] // CheckMark
+    [InlineData("warning",       "")] // Warning
+    [InlineData("delete",        "")] // Delete
+    [InlineData("notifications", "")] // Ringer
+    [InlineData("noSuchIcon",    "")] // unknown name → Help fallback
+    public Task Icon_NameMapsToExpectedGlyph(string name, string expectedGlyph) => RunAsync(
+        $"Icon \"{name}\"",
+        Surface("s", "i", new[]
+        {
+            Component("i", "Icon", new() { ["name"] = Lit(name) }),
+        }),
+        root =>
+        {
+            var fi = FindLogical<FontIcon>(root).Single();
+            Assert.Equal(expectedGlyph, fi.Glyph);
+        });
+
+    [Fact]
+    public Task Icon_EmptyName_FallsBackToHelpGlyph() => RunAsync(
+        "Icon empty name",
+        Surface("s", "i", new[]
+        {
+            Component("i", "Icon", new() { ["name"] = Lit("") }),
+        }),
+        root =>
+        {
+            var fi = FindLogical<FontIcon>(root).Single();
+            Assert.Equal("", fi.Glyph); // Help
+        });
+
+    // ─── Interactive ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public Task CheckBox_LiteralValueTrue_RendersChecked() => RunAsync(
+        "CheckBox literal true",
+        Surface("s", "cb", new[]
+        {
+            Component("cb", "CheckBox", new()
+            {
+                ["label"] = Lit("Agree"),
+                ["value"] = Lit(true),
+            }),
+        }),
+        root =>
+        {
+            var cb = FindLogical<CheckBox>(root).Single();
+            Assert.Equal("Agree", cb.Content as string);
+            Assert.True(cb.IsChecked);
+        });
+
+    [Fact]
+    public async Task CheckBox_PathBound_DataModelWritesPropagateBothWays()
+    {
+        await _ui.PauseAsync("CheckBox ↔ data model");
+        await _ui.ResetContainerAsync();
+        var harness = await _ui.RunOnUIAsync(() =>
+        {
+            var h = BuildHarness(_ui);
+            h.Router.Push(Surface("s", "cb", new[]
+            {
+                Component("cb", "CheckBox", new()
+                {
+                    ["label"] = Lit("Subscribe"),
+                    ["value"] = Path("/subscribed"),
+                }),
+            }));
+            return Task.FromResult(h);
+        });
+
+        await _ui.RunOnUIAsync(() =>
+        {
+            var cb = FindLogical<CheckBox>(harness.LastSurface!.RootElement).Single();
+            Assert.False(cb.IsChecked); // no data yet → unchecked
+
+            // Data → UI: set the path, expect IsChecked=true.
+            harness.Router.Push(DataUpdate("s", ("subscribed", System.Text.Json.Nodes.JsonValue.Create(true))));
+            Assert.True(cb.IsChecked);
+
+            // UI → Data: programmatically uncheck, expect data model to flip back.
+            cb.IsChecked = false;
+            var node = harness.DataModel.Read("s", "/subscribed") as System.Text.Json.Nodes.JsonValue;
+            Assert.NotNull(node);
+            Assert.True(node!.TryGetValue<bool>(out var b) && b == false);
+        });
+        await _ui.PauseAsync();
+    }
+
+    [Fact]
+    public Task TextField_ShortText_RendersSingleLineTextBox() => RunAsync(
+        "TextField shortText → TextBox",
+        Surface("s", "tf", new[]
+        {
+            Component("tf", "TextField", new()
+            {
+                ["textFieldType"] = "shortText",
+                ["label"] = Lit("Name"),
+                ["text"] = Lit("Ada"),
+            }),
+        }),
+        root =>
+        {
+            var tb = FindLogical<TextBox>(root).Single();
+            Assert.Equal("Name", tb.Header as string);
+            Assert.Equal("Ada", tb.Text);
+            Assert.False(tb.AcceptsReturn);
+            Assert.Equal(TextWrapping.NoWrap, tb.TextWrapping);
+        });
+
+    [Fact]
+    public Task TextField_LongText_RendersMultilineTextBox() => RunAsync(
+        "TextField longText → multiline TextBox",
+        Surface("s", "tf", new[]
+        {
+            Component("tf", "TextField", new()
+            {
+                ["textFieldType"] = "longText",
+                ["label"] = Lit("Notes"),
+            }),
+        }),
+        root =>
+        {
+            var tb = FindLogical<TextBox>(root).Single();
+            Assert.True(tb.AcceptsReturn);
+            Assert.Equal(TextWrapping.Wrap, tb.TextWrapping);
+            Assert.True(tb.MinHeight >= 80);
+        });
+
+    [Fact]
+    public Task TextField_Obscured_RendersPasswordBox() => RunAsync(
+        "TextField obscured → PasswordBox",
+        Surface("s", "tf", new[]
+        {
+            Component("tf", "TextField", new()
+            {
+                ["textFieldType"] = "obscured",
+                ["label"] = Lit("PIN"),
+                ["text"] = Lit("1234"),
+            }),
+        }),
+        root =>
+        {
+            var pb = FindLogical<PasswordBox>(root).Single();
+            Assert.Equal("PIN", pb.Header as string);
+            Assert.Equal("1234", pb.Password);
+            // No TextBox should be present when obscured.
+            Assert.Empty(FindLogical<TextBox>(root));
+        });
+
+    [Fact]
+    public Task DateTimeInput_DateAndTime_RendersBothPickers() => RunAsync(
+        "DateTimeInput date+time",
+        Surface("s", "dt", new[]
+        {
+            Component("dt", "DateTimeInput", new()
+            {
+                ["enableDate"] = true,
+                ["enableTime"] = true,
+            }),
+        }),
+        root =>
+        {
+            Assert.Single(FindLogical<CalendarDatePicker>(root));
+            Assert.Single(FindLogical<TimePicker>(root));
+        });
+
+    [Fact]
+    public Task DateTimeInput_DateOnly_RendersOnlyCalendarPicker() => RunAsync(
+        "DateTimeInput date-only",
+        Surface("s", "dt", new[]
+        {
+            Component("dt", "DateTimeInput", new()
+            {
+                ["enableDate"] = true,
+                ["enableTime"] = false,
+            }),
+        }),
+        root =>
+        {
+            Assert.Single(FindLogical<CalendarDatePicker>(root));
+            Assert.Empty(FindLogical<TimePicker>(root));
+        });
+
+    [Fact]
+    public Task MultipleChoice_Single_RendersComboBox_WithOptions() => RunAsync(
+        "MultipleChoice (max=1) → ComboBox",
+        Surface("s", "mc", new[]
+        {
+            Component("mc", "MultipleChoice", new()
+            {
+                ["maxAllowedSelections"] = 1,
+                ["options"] = new System.Text.Json.Nodes.JsonArray
+                {
+                    Option("Light", "light"),
+                    Option("Dark", "dark"),
+                    Option("Auto", "auto"),
+                },
+            }),
+        }),
+        root =>
+        {
+            var combo = FindLogical<ComboBox>(root).Single();
+            var labels = combo.Items.OfType<ComboBoxItem>().Select(i => i.Content as string).ToArray();
+            Assert.Equal(new[] { "Light", "Dark", "Auto" }, labels);
+        });
+
+    [Fact]
+    public Task MultipleChoice_Multi_RendersListView_WithMultipleSelectionMode() => RunAsync(
+        "MultipleChoice (max=3) → ListView",
+        Surface("s", "mc", new[]
+        {
+            Component("mc", "MultipleChoice", new()
+            {
+                ["maxAllowedSelections"] = 3,
+                ["options"] = new System.Text.Json.Nodes.JsonArray
+                {
+                    Option("Red",   "r"),
+                    Option("Green", "g"),
+                    Option("Blue",  "b"),
+                    Option("Alpha", "a"),
+                },
+            }),
+        }),
+        root =>
+        {
+            var lv = FindLogical<ListView>(root).Single();
+            Assert.Equal(ListViewSelectionMode.Multiple, lv.SelectionMode);
+            Assert.Equal(4, lv.Items.Count);
+        });
+
+    [Fact]
+    public Task Slider_LiteralValue_AppliesRangeAndValue() => RunAsync(
+        "Slider literal value",
+        Surface("s", "sl", new[]
+        {
+            Component("sl", "Slider", new()
+            {
+                ["minValue"] = 0.0,
+                ["maxValue"] = 200.0,
+                ["value"] = Lit(42.0),
+            }),
+        }),
+        root =>
+        {
+            var slider = FindLogical<Slider>(root).Single();
+            Assert.Equal(0, slider.Minimum);
+            Assert.Equal(200, slider.Maximum);
+            Assert.Equal(42, slider.Value);
+        });
+
+    [Fact]
+    public async Task Slider_PathBound_UserChangeWritesToDataModel()
+    {
+        await _ui.PauseAsync("Slider ↔ data model");
+        await _ui.ResetContainerAsync();
+        var harness = await _ui.RunOnUIAsync(() =>
+        {
+            var h = BuildHarness(_ui);
+            h.Router.Push(Surface("s", "sl", new[]
+            {
+                Component("sl", "Slider", new()
+                {
+                    ["minValue"] = 0.0,
+                    ["maxValue"] = 100.0,
+                    ["value"] = Path("/volume"),
+                }),
+            }));
+            h.Router.Push(DataUpdate("s", ("volume", System.Text.Json.Nodes.JsonValue.Create(25.0))));
+            return Task.FromResult(h);
+        });
+
+        await _ui.RunOnUIAsync(() =>
+        {
+            var slider = FindLogical<Slider>(harness.LastSurface!.RootElement).Single();
+            Assert.Equal(25, slider.Value);
+
+            // Simulate the user dragging the slider — the renderer wires ValueChanged
+            // back to DataModel.Write.
+            slider.Value = 73;
+            var node = harness.DataModel.Read("s", "/volume") as System.Text.Json.Nodes.JsonValue;
+            Assert.NotNull(node);
+            Assert.True(node!.TryGetValue<double>(out var d) && d == 73);
+        });
+        await _ui.PauseAsync();
+    }
+
+    // ─── helper ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// One-shot run for matrix tests: pause label, render the JSONL, run the
+    /// caller-supplied assertion against the SurfaceHost's logical tree.
+    ///
+    /// We deliberately do NOT mount the surface in the fixture's Window
+    /// container: templated controls (TextBox, PasswordBox, ListView) hit PRI
+    /// "file not found" lookups during template apply in unpackaged WinUI3
+    /// test processes. Walking the renderer-produced logical tree
+    /// (Panel.Children, Border.Child, ContentControl.Content, etc.) is
+    /// sufficient to verify each catalog component's output, and avoids the
+    /// hosting limitation entirely.
+    /// </summary>
+    private async Task RunAsync(string pauseLabel, string jsonl, System.Action<FrameworkElement> assertOnRoot)
+    {
+        await _ui.PauseAsync(pauseLabel);
+        await _ui.ResetContainerAsync();
+        await _ui.RunOnUIAsync(() =>
+        {
+            var harness = BuildHarness(_ui);
+            harness.Router.Push(jsonl);
+            Assert.NotNull(harness.LastSurface);
+            assertOnRoot(harness.LastSurface!.RootElement);
+        });
+        await _ui.PauseAsync();
+    }
+}

--- a/tests/OpenClaw.Tray.UITests/A2UIControlMatrixTests.cs
+++ b/tests/OpenClaw.Tray.UITests/A2UIControlMatrixTests.cs
@@ -144,8 +144,8 @@ public sealed class A2UIControlMatrixTests
         });
 
     [Fact]
-    public Task Modal_RendersExpander_WithEntryPointAndContent() => RunAsync(
-        "Modal → Expander",
+    public Task Modal_RendersTriggerButton_ContentDeferredUntilClick() => RunAsync(
+        "Modal → Button trigger (ContentDialog on click)",
         Surface("s", "modal", new[]
         {
             Component("modal", "Modal", new()
@@ -158,11 +158,15 @@ public sealed class A2UIControlMatrixTests
         }),
         root =>
         {
-            var exp = FindLogical<Expander>(root).Single();
-            Assert.NotNull(exp.Header);
-            Assert.NotNull(exp.Content);
-            // Two TextBlocks: one in the header, one in the content (only header is realized
-            // in the visual tree until the user expands, so we don't assert visible count).
+            // Modal now renders as a Button whose Content is the entry-point
+            // child; clicking it opens a ContentDialog hosting the content
+            // child. The body Text isn't in the visual tree until the dialog
+            // is opened, so we assert the trigger label is realized but the
+            // body label is not.
+            var btn = FindLogical<Button>(root).Single();
+            var labels = FindLogical<TextBlock>(root).Select(t => t.Text).ToArray();
+            Assert.Contains("Click me", labels);
+            Assert.DoesNotContain("hidden body", labels);
         });
 
     [Fact]

--- a/tests/OpenClaw.Tray.UITests/A2UIDashboardScaleTest.cs
+++ b/tests/OpenClaw.Tray.UITests/A2UIDashboardScaleTest.cs
@@ -1,0 +1,328 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Shapes;
+using static OpenClaw.Tray.UITests.A2UI;
+using static OpenClaw.Tray.UITests.TestSupport;
+
+namespace OpenClaw.Tray.UITests;
+
+/// <summary>
+/// One realistic, ~60-component dashboard surface that exercises every
+/// catalog component, four levels of nesting, theming, and a live
+/// dataModelUpdate after the initial render. The point of this test is
+/// breadth, not depth: if it passes, the renderer pipeline produces *something
+/// reasonable* for every supported wire input shape.
+/// </summary>
+[Collection(UICollection.Name)]
+public sealed class A2UIDashboardScaleTest
+{
+    private readonly UIThreadFixture _ui;
+    public A2UIDashboardScaleTest(UIThreadFixture ui) => _ui = ui;
+
+    [Fact]
+    public async Task Dashboard_AllControlTypes_RendersExpectedTreeWithoutUnknownPlaceholders()
+    {
+        var jsonl = BuildDashboardJsonl();
+
+        await _ui.PauseAsync("Dashboard at scale (~60 components)");
+        await _ui.ResetContainerAsync();
+        var harness = await _ui.RunOnUIAsync(() =>
+        {
+            var h = BuildHarness(_ui);
+            h.Router.Push(jsonl);
+            Assert.NotNull(h.LastSurface);
+            return Task.FromResult(h);
+        });
+
+        // Tree walking + assertions all happen on the UI thread (WinUI types
+        // are thread-affine; cross-thread access throws COMException).
+        await _ui.RunOnUIAsync(() =>
+        {
+            var root = harness.LastSurface!.RootElement;
+
+            var grid = root as Grid;
+            Assert.NotNull(grid);
+            Assert.True(grid!.Children.Count > 0, "surface root Grid is empty — BeginRendering didn't produce a tree");
+
+            // ── Structure: many Columns, multiple Rows ─
+            var allStackPanels = FindLogical<StackPanel>(root).ToList();
+            var allRows    = allStackPanels.Where(s => s.Orientation == Orientation.Horizontal).ToList();
+            var allColumns = allStackPanels.Where(s => s.Orientation == Orientation.Vertical).ToList();
+            Assert.True(allColumns.Count >= 5, $"expected ≥5 columns, got {allColumns.Count}");
+            Assert.True(allRows.Count    >= 3, $"expected ≥3 rows, got {allRows.Count}");
+
+            // ── Tabs: one TabView, three tab items with the right headers ─
+            var tabView = FindLogical<TabView>(root).Single();
+            var headers = tabView.TabItems.OfType<TabViewItem>().Select(t => t.Header as string).ToArray();
+            Assert.Equal(new[] { "Overview", "Settings", "Help" }, headers);
+
+            // ── Each catalog component appears at least once ─
+            Assert.NotEmpty(FindLogical<FontIcon>(root));                  // Icon
+            Assert.NotEmpty(FindLogical<TextBlock>(root));                 // Text
+            Assert.NotEmpty(FindLogical<Border>(root));                    // Card
+            Assert.NotEmpty(FindLogical<ScrollViewer>(root));              // List
+            Assert.NotEmpty(FindLogical<Expander>(root));                  // Modal
+            Assert.NotEmpty(FindLogical<Rectangle>(root));                 // Divider
+            Assert.NotEmpty(FindLogical<Button>(root));                    // Button
+            Assert.NotEmpty(FindLogical<CheckBox>(root));                  // CheckBox
+            Assert.NotEmpty(FindLogical<TextBox>(root));                   // TextField shortText / longText
+            Assert.NotEmpty(FindLogical<PasswordBox>(root));               // TextField obscured
+            Assert.NotEmpty(FindLogical<CalendarDatePicker>(root));        // DateTimeInput (date)
+            Assert.NotEmpty(FindLogical<TimePicker>(root));                // DateTimeInput (time)
+            Assert.NotEmpty(FindLogical<ComboBox>(root));                  // MultipleChoice (max=1)
+            Assert.NotEmpty(FindLogical<ListView>(root));                  // MultipleChoice (max>1)
+            Assert.NotEmpty(FindLogical<Slider>(root));                    // Slider
+            Assert.NotEmpty(FindLogical<MediaPlayerElement>(root));        // Video / AudioPlayer
+
+            // ── Specific counts on the items we know we declared ─
+            var sliders = FindLogical<Slider>(root).ToList();
+            Assert.Equal(3, sliders.Count); // 2 in Overview card + 1 in Settings (Volume)
+
+            var buttons = FindLogical<Button>(root).ToList();
+            // Header refresh + 3 in Help row + 1 inside Modal entry-point = 5
+            Assert.Equal(5, buttons.Count);
+
+            var textBoxes = FindLogical<TextBox>(root).ToList();
+            Assert.Equal(2, textBoxes.Count); // shortText "Display name" + longText "Bio"
+            Assert.Single(FindLogical<PasswordBox>(root));
+
+            // ── No UnknownRenderer placeholders ─
+            var unsupported = FindLogical<TextBlock>(root)
+                .Where(t => t.Text.StartsWith("Unsupported component:")).ToList();
+            Assert.Empty(unsupported);
+
+            // ── Theme reached the renderers ─
+            // The top-level Column (root.Children[0]) is built by ColumnRenderer
+            // and reads its Spacing from theme.Spacing. Some inner StackPanels
+            // (AudioPlayer's, etc.) intentionally use their own hard-coded
+            // spacing — we don't assert those.
+            var rootColumn = (StackPanel)grid.Children[0];
+            Assert.Equal(Orientation.Vertical, rootColumn.Orientation);
+            Assert.Equal(12, rootColumn.Spacing);
+
+            // Radius=10 → Card border has CornerRadius=10. Card sets Padding=16
+            // (Border + Padding > 0 distinguishes it from ContentPresenter borders
+            // inside templated controls).
+            var cardBorder = FindLogical<Border>(root)
+                .First(b => b.CornerRadius.TopLeft > 0 && b.Padding.Left > 0);
+            Assert.Equal(10, cardBorder.CornerRadius.TopLeft);
+
+            // Accent registered as a surface-scoped resource.
+            Assert.True(root.Resources.ContainsKey("A2UIAccentBrush"));
+        });
+
+        // ── Live update propagates: change /name and /volume after first render ─
+        await _ui.PauseAsync("data update → bound text + slider refresh");
+        await _ui.RunOnUIAsync(() =>
+        {
+            var root = harness.LastSurface!.RootElement;
+
+            harness.Router.Push(DataUpdate("dash",
+                ("name",   JsonValue.Create("Grace Hopper")),
+                ("volume", JsonValue.Create(88.0))));
+
+            var nameField = FindLogical<TextBox>(root).Single(t => t.Header as string == "Display name");
+            Assert.Equal("Grace Hopper", nameField.Text);
+
+            // Settings/Volume is the last Slider declared in source order. We use
+            // the last one rather than re-finding by some identifier because the
+            // wire format doesn't expose component IDs on the resulting controls.
+            var volSlider = FindLogical<Slider>(root).Last();
+            Assert.Equal(88, volSlider.Value);
+        });
+        await _ui.PauseAsync();
+    }
+
+    /// <summary>
+    /// The dashboard fixture itself. Returned as a JSONL string ready to push
+    /// to <see cref="OpenClawTray.A2UI.Hosting.A2UIRouter.Push"/>.
+    /// </summary>
+    private static string BuildDashboardJsonl()
+    {
+        var components = new List<JsonObject>();
+
+        // ── Top-level layout ──────────────────────────────────────────────
+        components.Add(Component("root", "Column", new()
+        {
+            ["children"] = Children("hdr", "tabs", "ftr"),
+        }));
+
+        // ── Header row ────────────────────────────────────────────────────
+        components.Add(Component("hdr", "Row", new()
+        {
+            ["children"] = Children("hdrIcon", "hdrTitle", "hdrDiv", "hdrBtn"),
+            ["alignment"] = "center",
+        }));
+        components.Add(Component("hdrIcon", "Icon", new() { ["name"] = Lit("home") }));
+        components.Add(Component("hdrTitle", "Text", new()
+        {
+            ["text"] = Lit("OpenClaw Dashboard"),
+            ["usageHint"] = "h1",
+        }));
+        components.Add(Component("hdrDiv", "Divider", new() { ["axis"] = "vertical" }));
+        components.Add(Component("hdrBtn", "Button", new()
+        {
+            ["primary"] = true,
+            ["child"] = "hdrBtnLbl",
+            ["action"] = new JsonObject { ["name"] = "refresh" },
+        }));
+        components.Add(Component("hdrBtnLbl", "Text", new() { ["text"] = Lit("Refresh") }));
+
+        // ── Tabs ──────────────────────────────────────────────────────────
+        components.Add(Component("tabs", "Tabs", new()
+        {
+            ["tabItems"] = new JsonArray
+            {
+                Tab("Overview", "ovRoot"),
+                Tab("Settings", "stRoot"),
+                Tab("Help",     "hpRoot"),
+            },
+        }));
+
+        // ── Tab 1: Overview ─────────────────────────────────────────
+        components.Add(Component("ovRoot", "Column", new()
+        {
+            ["children"] = Children("ovCard", "ovDiv", "ovList", "ovMedia"),
+        }));
+        components.Add(Component("ovCard", "Card", new() { ["child"] = "ovCardCol" }));
+        components.Add(Component("ovCardCol", "Column", new()
+        {
+            ["children"] = Children("ovH2", "ovCap", "ovSlide1", "ovSlide2"),
+        }));
+        components.Add(Component("ovH2",  "Text", new() { ["text"] = Lit("System Status"), ["usageHint"] = "h2" }));
+        components.Add(Component("ovCap", "Text", new() { ["text"] = Lit("Last updated: just now"), ["usageHint"] = "caption" }));
+        components.Add(Component("ovSlide1", "Slider", new() { ["minValue"] = 0.0, ["maxValue"] = 100.0, ["value"] = Lit(42.0) }));
+        components.Add(Component("ovSlide2", "Slider", new() { ["minValue"] = 0.0, ["maxValue"] = 100.0, ["value"] = Lit(75.0) }));
+
+        components.Add(Component("ovDiv", "Divider", new() { ["axis"] = "horizontal" }));
+
+        components.Add(Component("ovList", "List", new()
+        {
+            ["direction"] = "vertical",
+            ["children"] = Children("svcA", "svcB", "svcC", "svcD", "svcE"),
+        }));
+        components.Add(Component("svcA", "Text", new() { ["text"] = Lit("service-a: running") }));
+        components.Add(Component("svcB", "Text", new() { ["text"] = Lit("service-b: running") }));
+        components.Add(Component("svcC", "Text", new() { ["text"] = Lit("service-c: running") }));
+        components.Add(Component("svcD", "Text", new() { ["text"] = Lit("service-d: stopped") }));
+        components.Add(Component("svcE", "Text", new() { ["text"] = Lit("service-e: running") }));
+
+        components.Add(Component("ovMedia", "Row", new() { ["children"] = Children("ovImg", "ovAudio") }));
+        components.Add(Component("ovImg",   "Image", new() { ["url"] = Lit("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=") }));
+        components.Add(Component("ovAudio", "AudioPlayer", new()
+        {
+            ["url"]         = Lit("https://example.com/clip.mp3"),
+            ["description"] = Lit("Notification chime"),
+        }));
+
+        // ── Tab 2: Settings ─────────────────────────────────────────
+        components.Add(Component("stRoot", "Column", new()
+        {
+            ["children"] = Children("stTitle", "stName", "stBio", "stToken", "stNotify", "stTheme", "stTags", "stSched", "stVol"),
+        }));
+        components.Add(Component("stTitle", "Text", new() { ["text"] = Lit("User Preferences"), ["usageHint"] = "h3" }));
+        components.Add(Component("stName",  "TextField", new()
+        {
+            ["textFieldType"] = "shortText",
+            ["label"] = Lit("Display name"),
+            ["text"] = Path("/name"),
+        }));
+        components.Add(Component("stBio", "TextField", new()
+        {
+            ["textFieldType"] = "longText",
+            ["label"] = Lit("Bio"),
+            ["text"] = Path("/bio"),
+        }));
+        components.Add(Component("stToken", "TextField", new()
+        {
+            ["textFieldType"] = "obscured",
+            ["label"] = Lit("API token"),
+            ["text"] = Path("/token"),
+        }));
+        components.Add(Component("stNotify", "CheckBox", new()
+        {
+            ["label"] = Lit("Enable notifications"),
+            ["value"] = Path("/notify"),
+        }));
+        components.Add(Component("stTheme", "MultipleChoice", new()
+        {
+            ["maxAllowedSelections"] = 1,
+            ["selections"] = Path("/theme"),
+            ["options"] = new JsonArray
+            {
+                Option("Light", "light"),
+                Option("Dark",  "dark"),
+                Option("Auto",  "auto"),
+            },
+        }));
+        components.Add(Component("stTags", "MultipleChoice", new()
+        {
+            ["maxAllowedSelections"] = 3,
+            ["selections"] = Path("/tags"),
+            ["options"] = new JsonArray
+            {
+                Option("alpha", "a"),
+                Option("beta",  "b"),
+                Option("gamma", "g"),
+                Option("delta", "d"),
+            },
+        }));
+        components.Add(Component("stSched", "DateTimeInput", new()
+        {
+            ["enableDate"] = true,
+            ["enableTime"] = true,
+            ["value"] = Path("/scheduled"),
+        }));
+        components.Add(Component("stVol", "Slider", new()
+        {
+            ["minValue"] = 0.0,
+            ["maxValue"] = 100.0,
+            ["value"] = Path("/volume"),
+        }));
+
+        // ── Tab 3: Help ─────────────────────────────────────────────
+        components.Add(Component("hpRoot", "Column", new()
+        {
+            ["children"] = Children("hpH2", "hpBody", "hpModal", "hpRow"),
+        }));
+        components.Add(Component("hpH2",   "Text", new() { ["text"] = Lit("Need help?"), ["usageHint"] = "h2" }));
+        components.Add(Component("hpBody", "Text", new() { ["text"] = Lit("Check the documentation or contact support."), ["usageHint"] = "body" }));
+        components.Add(Component("hpModal", "Modal", new()
+        {
+            ["entryPointChild"] = "hpModalEntry",
+            ["contentChild"]    = "hpModalContent",
+        }));
+        components.Add(Component("hpModalEntry",   "Button", new()
+        {
+            ["child"]  = "hpModalEntryLbl",
+            ["action"] = new JsonObject { ["name"] = "showDetails" },
+        }));
+        components.Add(Component("hpModalEntryLbl", "Text", new() { ["text"] = Lit("Show details") }));
+        components.Add(Component("hpModalContent", "Text", new() { ["text"] = Lit("Detailed help text would go here.") }));
+
+        components.Add(Component("hpRow", "Row", new() { ["children"] = Children("hpDocs", "hpContact", "hpAbout") }));
+        components.Add(Component("hpDocs",    "Button", new() { ["child"] = "hpDocsLbl",    ["primary"] = true, ["action"] = new JsonObject { ["name"] = "openDocs" } }));
+        components.Add(Component("hpContact", "Button", new() { ["child"] = "hpContactLbl",                      ["action"] = new JsonObject { ["name"] = "contact" } }));
+        components.Add(Component("hpAbout",   "Button", new() { ["child"] = "hpAboutLbl",                        ["action"] = new JsonObject { ["name"] = "about" } }));
+        components.Add(Component("hpDocsLbl",    "Text", new() { ["text"] = Lit("Open Docs") }));
+        components.Add(Component("hpContactLbl", "Text", new() { ["text"] = Lit("Contact") }));
+        components.Add(Component("hpAboutLbl",   "Text", new() { ["text"] = Lit("About") }));
+
+        // ── Footer row ────────────────────────────────────────────────────
+        components.Add(Component("ftr", "Row", new() { ["children"] = Children("ftrVer", "ftrDiv", "ftrConn") }));
+        components.Add(Component("ftrVer",  "Text", new() { ["text"] = Lit("v0.4.4"),   ["usageHint"] = "caption" }));
+        components.Add(Component("ftrDiv",  "Divider", new() { ["axis"] = "vertical" }));
+        components.Add(Component("ftrConn", "Text", new() { ["text"] = Lit("Connected"), ["usageHint"] = "caption" }));
+
+        return Surface(
+            "dash",
+            "root",
+            components,
+            styles: Styles(spacing: 12, radius: 10, primaryColor: "#0078D4"));
+    }
+}

--- a/tests/OpenClaw.Tray.UITests/A2UIDashboardScaleTest.cs
+++ b/tests/OpenClaw.Tray.UITests/A2UIDashboardScaleTest.cs
@@ -66,7 +66,9 @@ public sealed class A2UIDashboardScaleTest
             Assert.NotEmpty(FindLogical<TextBlock>(root));                 // Text
             Assert.NotEmpty(FindLogical<Border>(root));                    // Card
             Assert.NotEmpty(FindLogical<ScrollViewer>(root));              // List
-            Assert.NotEmpty(FindLogical<Expander>(root));                  // Modal
+            // Modal renders as a trigger Button hosting the entry-point child;
+            // clicking it shows a ContentDialog. We don't assert a Modal-specific
+            // type here — its presence is reflected in the Button count below.
             Assert.NotEmpty(FindLogical<Rectangle>(root));                 // Divider
             Assert.NotEmpty(FindLogical<Button>(root));                    // Button
             Assert.NotEmpty(FindLogical<CheckBox>(root));                  // CheckBox
@@ -84,8 +86,11 @@ public sealed class A2UIDashboardScaleTest
             Assert.Equal(3, sliders.Count); // 2 in Overview card + 1 in Settings (Volume)
 
             var buttons = FindLogical<Button>(root).ToList();
-            // Header refresh + 3 in Help row + 1 inside Modal entry-point = 5
-            Assert.Equal(5, buttons.Count);
+            // Header refresh (1) + 3 in Help row (3) + Modal trigger Button (1)
+            // wrapping its entry-point Button (1) = 6. The Modal now wraps its
+            // entry-point in a uniform click target, so the entry Button shows
+            // up nested inside the trigger.
+            Assert.Equal(6, buttons.Count);
 
             var textBoxes = FindLogical<TextBox>(root).ToList();
             Assert.Equal(2, textBoxes.Count); // shortText "Display name" + longText "Bio"

--- a/tests/OpenClaw.Tray.UITests/A2UIRenderingTests.cs
+++ b/tests/OpenClaw.Tray.UITests/A2UIRenderingTests.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using OpenClawTray.A2UI.Hosting;
+
+namespace OpenClaw.Tray.UITests;
+
+/// <summary>
+/// End-to-end render tests that drive the production
+/// <see cref="A2UIRouter"/> + <see cref="SurfaceHost"/> pipeline against a real
+/// WinUI3 visual tree. Each test:
+///   1. Builds a fresh router on the UI thread.
+///   2. Pushes canonical JSONL fixtures (matches the v0.8 wire format the agent emits).
+///   3. Mounts the resulting <see cref="SurfaceHost.RootElement"/> in the
+///      fixture's hidden Window so the tree gets a XamlRoot.
+///   4. Walks the visual tree with <see cref="VisualTreeHelper"/> to assert.
+/// </summary>
+[Collection(UICollection.Name)]
+public sealed class A2UIRenderingTests
+{
+    private readonly UIThreadFixture _ui;
+    public A2UIRenderingTests(UIThreadFixture ui) => _ui = ui;
+
+    [Fact]
+    public async Task TextComponent_RendersTextBlock_WithLiteralText()
+    {
+        const string jsonl =
+            """{"surfaceUpdate":{"surfaceId":"s1","components":[{"id":"r","component":{"Text":{"text":{"literalString":"hello world"}}}}]}}""" + "\n" +
+            """{"beginRendering":{"surfaceId":"s1","root":"r"}}""";
+
+        await _ui.PauseAsync("Text → TextBlock");
+        await RenderAndAssertAsync(jsonl, root =>
+        {
+            var blocks = FindDescendants<TextBlock>(root).ToList();
+            Assert.Single(blocks);
+            Assert.Equal("hello world", blocks[0].Text);
+        });
+        await _ui.PauseAsync();
+    }
+
+    [Fact]
+    public async Task ColumnContainer_RendersStackPanel_WithThreeChildren()
+    {
+        const string jsonl =
+            """{"surfaceUpdate":{"surfaceId":"s","components":[""" +
+                """{"id":"col","component":{"Column":{"children":{"explicitList":["a","b","c"]}}}},""" +
+                """{"id":"a","component":{"Text":{"text":{"literalString":"first"}}}},""" +
+                """{"id":"b","component":{"Text":{"text":{"literalString":"second"}}}},""" +
+                """{"id":"c","component":{"Text":{"text":{"literalString":"third"}}}}""" +
+            """]}}""" + "\n" +
+            """{"beginRendering":{"surfaceId":"s","root":"col"}}""";
+
+        await _ui.PauseAsync("Column container w/ 3 children");
+        await RenderAndAssertAsync(jsonl, root =>
+        {
+            var stacks = FindDescendants<StackPanel>(root).ToList();
+            Assert.Single(stacks);
+            Assert.Equal(Orientation.Vertical, stacks[0].Orientation);
+
+            var blocks = FindDescendants<TextBlock>(root).Select(b => b.Text).ToList();
+            Assert.Equal(new[] { "first", "second", "third" }, blocks);
+        });
+        await _ui.PauseAsync();
+    }
+
+    [Fact]
+    public async Task DataModelUpdate_AfterBeginRendering_UpdatesBoundTextReactively()
+    {
+        const string jsonl =
+            """{"surfaceUpdate":{"surfaceId":"s","components":[{"id":"r","component":{"Text":{"text":{"path":"/greeting"}}}}]}}""" + "\n" +
+            """{"beginRendering":{"surfaceId":"s","root":"r"}}""";
+
+        await _ui.PauseAsync("DataModelUpdate → reactive text");
+        await _ui.ResetContainerAsync();
+        var harness = await _ui.RunOnUIAsync(() =>
+        {
+            var h = BuildHarness();
+            h.Router.Push(jsonl);
+            Assert.NotNull(h.LastSurface);
+            _ui.Container.Children.Add(h.LastSurface!.RootElement);
+            _ui.Container.UpdateLayout();
+
+            var tb = FindDescendants<TextBlock>(h.LastSurface.RootElement).Single();
+            Assert.Equal(string.Empty, tb.Text); // bound path empty until data arrives
+            return Task.FromResult(h);
+        });
+
+        await _ui.PauseAsync("write /greeting = 'howdy'");
+        await _ui.RunOnUIAsync(() =>
+        {
+            harness.Router.Push("""{"dataModelUpdate":{"surfaceId":"s","contents":[{"key":"greeting","valueString":"howdy"}]}}""");
+            _ui.Container.UpdateLayout();
+            var tb = FindDescendants<TextBlock>(harness.LastSurface!.RootElement).Single();
+            Assert.Equal("howdy", tb.Text);
+        });
+
+        await _ui.PauseAsync("write /greeting = 'hi again'");
+        await _ui.RunOnUIAsync(() =>
+        {
+            harness.Router.Push("""{"dataModelUpdate":{"surfaceId":"s","contents":[{"key":"greeting","valueString":"hi again"}]}}""");
+            _ui.Container.UpdateLayout();
+            var tb = FindDescendants<TextBlock>(harness.LastSurface!.RootElement).Single();
+            Assert.Equal("hi again", tb.Text);
+        });
+        await _ui.PauseAsync();
+    }
+
+    [Fact]
+    public async Task ButtonClick_RaisesActionThroughSink_WithSurfaceAndComponentIds()
+    {
+        const string jsonl =
+            """{"surfaceUpdate":{"surfaceId":"sBtn","components":[""" +
+                """{"id":"btn","component":{"Button":{"child":"lbl","action":{"name":"submit"}}}},""" +
+                """{"id":"lbl","component":{"Text":{"text":{"literalString":"Go"}}}}""" +
+            """]}}""" + "\n" +
+            """{"beginRendering":{"surfaceId":"sBtn","root":"btn"}}""";
+
+        await _ui.PauseAsync("Button click → action raised");
+        await _ui.ResetContainerAsync();
+        var harness = await _ui.RunOnUIAsync(() =>
+        {
+            var h = BuildHarness();
+            h.Router.Push(jsonl);
+            Assert.NotNull(h.LastSurface);
+            _ui.Container.Children.Add(h.LastSurface!.RootElement);
+            _ui.Container.UpdateLayout();
+            return Task.FromResult(h);
+        });
+
+        await _ui.PauseAsync("(button visible)");
+        await _ui.RunOnUIAsync(() =>
+        {
+            var btn = FindDescendants<Button>(harness.LastSurface!.RootElement).Single();
+            var labelText = FindDescendants<TextBlock>(btn).Single().Text;
+            Assert.Equal("Go", labelText);
+
+            // Synthesize a click via the public IInvokeProvider automation pattern —
+            // the documented WinUI test path. (OnClick is sealed in many controls.)
+            var peer = Microsoft.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer.CreatePeerForElement(btn);
+            var invoke = peer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface.Invoke)
+                as Microsoft.UI.Xaml.Automation.Provider.IInvokeProvider;
+            Assert.NotNull(invoke);
+            invoke!.Invoke();
+        });
+
+        await _ui.PauseAsync("(action arrived at sink)");
+        Assert.Single(harness.Actions.Raised);
+        Assert.Equal("submit", harness.Actions.Raised[0].Name);
+        Assert.Equal("sBtn", harness.Actions.Raised[0].SurfaceId);
+        Assert.Equal("btn", harness.Actions.Raised[0].SourceComponentId);
+        await _ui.PauseAsync();
+    }
+
+    [Fact]
+    public async Task UnknownComponent_RendersUnknownPlaceholder_NotNull()
+    {
+        // Component name "Frobnicate" has no renderer → UnknownRenderer kicks in.
+        const string jsonl =
+            """{"surfaceUpdate":{"surfaceId":"sU","components":[{"id":"r","component":{"Frobnicate":{"foo":"bar"}}}]}}""" + "\n" +
+            """{"beginRendering":{"surfaceId":"sU","root":"r"}}""";
+
+        await _ui.PauseAsync("Unknown component → fallback");
+        await RenderAndAssertAsync(jsonl, root =>
+        {
+            // The unknown renderer produces *something* visible — a non-null FrameworkElement.
+            // We don't assert the exact placeholder shape; that's a renderer-internal detail.
+            // The important contract: the surface tree didn't collapse to empty.
+            var allDescendants = FindDescendants<FrameworkElement>(root).ToList();
+            Assert.NotEmpty(allDescendants);
+        });
+        await _ui.PauseAsync();
+    }
+
+    [Fact]
+    public async Task DeleteSurface_RemovesSurfaceFromRouter()
+    {
+        const string jsonl =
+            """{"surfaceUpdate":{"surfaceId":"toDelete","components":[{"id":"r","component":{"Text":{"text":{"literalString":"x"}}}}]}}""" + "\n" +
+            """{"beginRendering":{"surfaceId":"toDelete","root":"r"}}""";
+
+        await _ui.PauseAsync("DeleteSurface → router cleanup");
+        await _ui.ResetContainerAsync();
+        var harness = await _ui.RunOnUIAsync(() =>
+        {
+            var h = BuildHarness();
+            h.Router.Push(jsonl);
+            _ui.Container.Children.Add(h.LastSurface!.RootElement);
+            _ui.Container.UpdateLayout();
+            Assert.True(h.Router.Surfaces.ContainsKey("toDelete"));
+            return Task.FromResult(h);
+        });
+
+        await _ui.PauseAsync("(surface present, about to delete)");
+        await _ui.RunOnUIAsync(() =>
+        {
+            harness.Router.Push("""{"deleteSurface":{"surfaceId":"toDelete"}}""");
+            Assert.False(harness.Router.Surfaces.ContainsKey("toDelete"));
+        });
+        await _ui.PauseAsync();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private async Task RenderAndAssertAsync(string jsonl, Action<FrameworkElement> assertOnRoot)
+    {
+        await _ui.ResetContainerAsync();
+        await _ui.RunOnUIAsync(() =>
+        {
+            var harness = TestSupport.BuildHarness(_ui);
+            // Mount the empty surface root before the tree is built so templated
+            // controls have a XamlRoot during template application (avoids PRI
+            // resource lookup failures in unpackaged WinUI3 tests).
+            harness.Router.SurfaceCreated += (_, s) => _ui.Container.Children.Add(s.RootElement);
+            harness.Router.Push(jsonl);
+            Assert.NotNull(harness.LastSurface);
+            _ui.Container.UpdateLayout();
+            assertOnRoot(harness.LastSurface!.RootElement);
+        });
+    }
+
+    private TestHarness BuildHarness() => TestSupport.BuildHarness(_ui);
+
+    private static IEnumerable<T> FindDescendants<T>(DependencyObject root) where T : DependencyObject
+        => TestSupport.FindDescendants<T>(root);
+}

--- a/tests/OpenClaw.Tray.UITests/A2UISvgTests.cs
+++ b/tests/OpenClaw.Tray.UITests/A2UISvgTests.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Imaging;
+using OpenClaw.Shared;
+using OpenClawTray.A2UI.Rendering;
+
+namespace OpenClaw.Tray.UITests;
+
+/// <summary>
+/// SVG decode tests for <see cref="MediaResolver"/>. These exercise the security
+/// envelope from the SVG addition spec: the same allowlist/cap policy as PNG, plus
+/// defense-in-depth against XXE / billion-laughs / pathological geometry.
+///
+/// All tests use <c>data:image/svg+xml</c> URLs so no HTTP traffic is involved at
+/// the resolver layer — the asserts about "no external request" are structurally
+/// guaranteed (D2D's static SVG 1.1 subset has no network stack either).
+/// </summary>
+[Collection(UICollection.Name)]
+public sealed class A2UISvgTests
+{
+    private readonly UIThreadFixture _ui;
+    public A2UISvgTests(UIThreadFixture ui) => _ui = ui;
+
+    private const string MinSvg =
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>" +
+        "<rect width='24' height='24' fill='red'/></svg>";
+
+    private static MediaResolver NewResolver() => new(NullLogger.Instance);
+
+    private static string DataSvgUtf8(string svgXml) =>
+        "data:image/svg+xml;utf8," + Uri.EscapeDataString(svgXml);
+
+    private static string DataSvgBase64(string svgXml) =>
+        "data:image/svg+xml;base64," + Convert.ToBase64String(Encoding.UTF8.GetBytes(svgXml));
+
+    [Fact]
+    public async Task DataSvg_Utf8_RoundTrips_ToSvgImageSource()
+    {
+        await _ui.RunOnUIAsync(async () =>
+        {
+            var media = NewResolver();
+            var src = await media.LoadImageAsync(DataSvgUtf8(MinSvg));
+            Assert.NotNull(src);
+            Assert.IsType<SvgImageSource>(src);
+        });
+    }
+
+    [Fact]
+    public async Task DataSvg_Base64_RoundTrips_ToSvgImageSource()
+    {
+        await _ui.RunOnUIAsync(async () =>
+        {
+            var media = NewResolver();
+            var src = await media.LoadImageAsync(DataSvgBase64(MinSvg));
+            Assert.NotNull(src);
+            Assert.IsType<SvgImageSource>(src);
+        });
+    }
+
+    [Fact]
+    public async Task DataPng_StillReturnsBitmapImage()
+    {
+        // 1x1 transparent PNG.
+        const string pngB64 =
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+        var url = "data:image/png;base64," + pngB64;
+        await _ui.RunOnUIAsync(async () =>
+        {
+            var media = NewResolver();
+            var src = await media.LoadImageAsync(url);
+            Assert.NotNull(src);
+            Assert.IsType<BitmapImage>(src);
+        });
+    }
+
+    [Fact]
+    public void RemoteSvg_HostNotAllowlisted_RejectedByIsAllowed()
+    {
+        var media = NewResolver(); // empty allowlist
+        Assert.False(media.IsAllowed("https://not-on-allowlist.example/foo.svg"));
+    }
+
+    [Fact]
+    public void RemoteSvg_HostOnAllowlist_PassesIsAllowed()
+    {
+        var media = NewResolver();
+        media.AllowHost("cdn.example.com");
+        Assert.True(media.IsAllowed("https://cdn.example.com/foo.svg"));
+    }
+
+    [Fact]
+    public void DataSvg_OverCap_RejectedByIsAllowed()
+    {
+        var media = NewResolver();
+        // Just over 2 MiB worth of payload chars; non-base64 cap = encoded-length upper bound.
+        var giant = new string('A', 2 * 1024 * 1024 + 1);
+        var url = "data:image/svg+xml;utf8," + giant;
+        Assert.False(media.IsAllowed(url));
+    }
+
+    [Fact]
+    public async Task ScriptAndEventHandlers_DecodeSuccessfully_AreInert()
+    {
+        // D2D has no script engine; <script> and on* attributes are dropped silently.
+        // The regression guard is: decode succeeds and the test process doesn't crash.
+        var svg =
+            "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'>" +
+            "<script>throw new Error('script ran')</script>" +
+            "<rect width='10' height='10' onclick='throw new Error(1)' fill='blue'/>" +
+            "</svg>";
+        await _ui.RunOnUIAsync(async () =>
+        {
+            var media = NewResolver();
+            var src = await media.LoadImageAsync(DataSvgUtf8(svg));
+            Assert.NotNull(src);
+            Assert.IsType<SvgImageSource>(src);
+        });
+    }
+
+    [Fact]
+    public async Task ForeignObject_Inert_NoExternalFetch()
+    {
+        var svg =
+            "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'>" +
+            "<foreignObject width='10' height='10'>" +
+            "<body xmlns='http://www.w3.org/1999/xhtml'><iframe src='https://attacker.example/leak'/></body>" +
+            "</foreignObject></svg>";
+        await _ui.RunOnUIAsync(async () =>
+        {
+            var media = NewResolver();
+            // Data URL → MediaResolver makes zero HTTP calls; D2D has no network stack either.
+            var src = await media.LoadImageAsync(DataSvgUtf8(svg));
+            // foreignObject is dropped by the static subset — decode shouldn't fail outright,
+            // but we don't depend on a particular pass/fail outcome here. The load-bearing
+            // assertion is "no exception, no HTTP", which is structurally true.
+            _ = src;
+        });
+    }
+
+    [Fact]
+    public async Task ExternalReferences_Inert_NoNetworkIo()
+    {
+        var svg =
+            "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'>" +
+            "<image href='https://attacker.example/leak.png' width='10' height='10'/>" +
+            "<use href='https://attacker.example/x.svg#g'/>" +
+            "</svg>";
+        await _ui.RunOnUIAsync(async () =>
+        {
+            var media = NewResolver();
+            var src = await media.LoadImageAsync(DataSvgUtf8(svg));
+            // External href targets are dropped by D2D's static subset; we just verify no crash / hang.
+            _ = src;
+        });
+    }
+
+    [Fact]
+    public async Task Xxe_DoctypeStrippedPrePass_NoFileRead()
+    {
+        // The DOCTYPE-with-internal-subset is what would let an XML parser try to resolve
+        // file:/// entities. MediaResolver strips the entire <!DOCTYPE …> declaration before
+        // handing bytes to D2D, so even if D2D's parser were XXE-permissive (it isn't, that
+        // we know of), the entity declarations are gone.
+        var svg =
+            "<?xml version=\"1.0\"?>" +
+            "<!DOCTYPE svg [<!ENTITY xxe SYSTEM \"file:///c:/windows/win.ini\">]>" +
+            "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'><text x='0' y='10'>&xxe;</text></svg>";
+        await _ui.RunOnUIAsync(async () =>
+        {
+            var media = NewResolver();
+            // Decode either succeeds with empty text (entity unresolved post-strip) or returns
+            // null (status != Success). Either is acceptable; the load-bearing fact is that no
+            // file read occurs — guaranteed by the strip happening before the parser sees bytes.
+            var src = await media.LoadImageAsync(DataSvgUtf8(svg));
+            _ = src;
+        });
+    }
+
+    [Fact]
+    public async Task BillionLaughs_DoctypeStripped_ReturnsPromptly()
+    {
+        var svg =
+            "<?xml version=\"1.0\"?>" +
+            "<!DOCTYPE svg [" +
+            "<!ENTITY lol \"lol\">" +
+            "<!ENTITY lol2 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">" +
+            "<!ENTITY lol3 \"&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;\">" +
+            "<!ENTITY lol4 \"&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;\">" +
+            "]>" +
+            "<svg xmlns='http://www.w3.org/2000/svg'><text>&lol4;</text></svg>";
+        await _ui.RunOnUIAsync(async () =>
+        {
+            var media = NewResolver();
+            var sw = Stopwatch.StartNew();
+            var src = await media.LoadImageAsync(DataSvgUtf8(svg));
+            sw.Stop();
+            // DOCTYPE strip removes all <!ENTITY> declarations before parsing begins, so
+            // the entity-expansion blowup never happens. The wall-clock cap (SvgRenderTimeout)
+            // is the backstop. Either way, decode must complete well under timeout.
+            Assert.True(
+                sw.Elapsed < MediaResolver.SvgRenderTimeout + TimeSpan.FromSeconds(2),
+                $"billion-laughs decode took {sw.Elapsed} (>{MediaResolver.SvgRenderTimeout})");
+            _ = src;
+        });
+    }
+
+    [Fact]
+    public async Task PathologicalGeometry_BoundedByRenderTimeout()
+    {
+        // Build an SVG with a very long path expression. Stay under the 2 MiB data-URL cap
+        // by base64-encoding to avoid percent-escape bloat.
+        var sb = new StringBuilder("<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><path d='M0,0 ");
+        var rng = new Random(0);
+        for (int i = 0; i < 30_000; i++)
+        {
+            sb.Append('C')
+              .Append(rng.Next(100)).Append(',').Append(rng.Next(100)).Append(' ')
+              .Append(rng.Next(100)).Append(',').Append(rng.Next(100)).Append(' ')
+              .Append(rng.Next(100)).Append(',').Append(rng.Next(100)).Append(' ');
+        }
+        sb.Append("'/></svg>");
+        var url = DataSvgBase64(sb.ToString());
+
+        await _ui.RunOnUIAsync(async () =>
+        {
+            var media = NewResolver();
+            var sw = Stopwatch.StartNew();
+            var src = await media.LoadImageAsync(url);
+            sw.Stop();
+            // Decode (or timeout) must complete within the configured wall-clock bound.
+            Assert.True(
+                sw.Elapsed < MediaResolver.SvgRenderTimeout + TimeSpan.FromSeconds(2),
+                $"pathological-geometry decode took {sw.Elapsed} (>{MediaResolver.SvgRenderTimeout})");
+            _ = src;
+        });
+    }
+}

--- a/tests/OpenClaw.Tray.UITests/A2UIThemeTests.cs
+++ b/tests/OpenClaw.Tray.UITests/A2UIThemeTests.cs
@@ -1,0 +1,147 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using static OpenClaw.Tray.UITests.A2UI;
+using static OpenClaw.Tray.UITests.TestSupport;
+
+namespace OpenClaw.Tray.UITests;
+
+/// <summary>
+/// Tests for <c>beginRendering.styles</c> theme application. Three concerns:
+///   1. <c>spacing</c> reaches the container renderers (Row/Column/List Spacing).
+///   2. <c>radius</c> reaches the Card renderer (Border CornerRadius).
+///   3. Color/font overrides land in the surface root's local resource scope as
+///      <c>A2UIAccentBrush</c> / <c>A2UIForegroundBrush</c> / <c>A2UIFontFamily</c>
+///      so renderers (or downstream styles) can pick them up via DynamicResource.
+/// </summary>
+[Collection(UICollection.Name)]
+public sealed class A2UIThemeTests
+{
+    private readonly UIThreadFixture _ui;
+    public A2UIThemeTests(UIThreadFixture ui) => _ui = ui;
+
+    [Fact]
+    public async Task Theme_SpacingOverride_AppliesToColumnStackPanel()
+    {
+        await _ui.PauseAsync("theme spacing → StackPanel.Spacing");
+        await _ui.ResetContainerAsync();
+        await _ui.RunOnUIAsync(() =>
+        {
+            var harness = BuildHarness(_ui);
+            harness.Router.Push(Surface(
+                "s", "col",
+                new[]
+                {
+                    Component("col", "Column", new() { ["children"] = Children("a", "b") }),
+                    Component("a", "Text", new() { ["text"] = Lit("first") }),
+                    Component("b", "Text", new() { ["text"] = Lit("second") }),
+                },
+                styles: Styles(spacing: 32)));
+
+
+            var sp = FindLogical<StackPanel>(harness.LastSurface!.RootElement).Single();
+            Assert.Equal(32, sp.Spacing);
+        });
+        await _ui.PauseAsync();
+    }
+
+    [Fact]
+    public async Task Theme_RadiusOverride_AppliesToCardBorderCornerRadius()
+    {
+        await _ui.PauseAsync("theme radius → Border.CornerRadius");
+        await _ui.ResetContainerAsync();
+        await _ui.RunOnUIAsync(() =>
+        {
+            var harness = BuildHarness(_ui);
+            harness.Router.Push(Surface(
+                "s", "card",
+                new[]
+                {
+                    Component("card", "Card", new() { ["child"] = "tx" }),
+                    Component("tx", "Text", new() { ["text"] = Lit("rounded") }),
+                },
+                styles: Styles(radius: 24)));
+
+
+            var border = FindLogical<Border>(harness.LastSurface!.RootElement).First();
+            Assert.Equal(24, border.CornerRadius.TopLeft);
+            Assert.Equal(24, border.CornerRadius.TopRight);
+            Assert.Equal(24, border.CornerRadius.BottomLeft);
+            Assert.Equal(24, border.CornerRadius.BottomRight);
+        });
+        await _ui.PauseAsync();
+    }
+
+    [Fact]
+    public async Task Theme_AccentColor_RegistersInSurfaceRootResources()
+    {
+        await _ui.PauseAsync("theme primaryColor → resource scope");
+        await _ui.ResetContainerAsync();
+        await _ui.RunOnUIAsync(() =>
+        {
+            var harness = BuildHarness(_ui);
+            harness.Router.Push(Surface(
+                "s", "t",
+                new[]
+                {
+                    Component("t", "Text", new() { ["text"] = Lit("themed") }),
+                },
+                styles: Styles(primaryColor: "#FF8800")));
+
+
+            var root = harness.LastSurface!.RootElement;
+            Assert.True(root.Resources.ContainsKey("A2UIAccentBrush"));
+            var brush = root.Resources["A2UIAccentBrush"] as SolidColorBrush;
+            Assert.NotNull(brush);
+            Assert.Equal(0xFF, brush!.Color.R);
+            Assert.Equal(0x88, brush.Color.G);
+            Assert.Equal(0x00, brush.Color.B);
+        });
+        await _ui.PauseAsync();
+    }
+
+    [Fact]
+    public async Task Theme_FontFamily_RegistersInSurfaceRootResources()
+    {
+        await _ui.PauseAsync("theme font → resource scope");
+        await _ui.ResetContainerAsync();
+        await _ui.RunOnUIAsync(() =>
+        {
+            var harness = BuildHarness(_ui);
+            harness.Router.Push(Surface(
+                "s", "t",
+                new[]
+                {
+                    Component("t", "Text", new() { ["text"] = Lit("typeset") }),
+                },
+                styles: Styles(font: "Cascadia Code")));
+
+
+            var root = harness.LastSurface!.RootElement;
+            Assert.True(root.Resources.ContainsKey("A2UIFontFamily"));
+            var ff = root.Resources["A2UIFontFamily"] as FontFamily;
+            Assert.NotNull(ff);
+            Assert.Equal("Cascadia Code", ff!.Source);
+        });
+        await _ui.PauseAsync();
+    }
+
+    [Fact]
+    public async Task Theme_NoStyles_LeavesSurfaceResourcesUntouched()
+    {
+        await _ui.ResetContainerAsync();
+        await _ui.RunOnUIAsync(() =>
+        {
+            var harness = BuildHarness(_ui);
+            harness.Router.Push(Surface(
+                "s", "t",
+                new[] { Component("t", "Text", new() { ["text"] = Lit("plain") }) }));
+
+
+            var root = harness.LastSurface!.RootElement;
+            Assert.False(root.Resources.ContainsKey("A2UIAccentBrush"));
+            Assert.False(root.Resources.ContainsKey("A2UIFontFamily"));
+        });
+    }
+}

--- a/tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj
+++ b/tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    A2UI rendering tests that drive the real WinUI3 / WindowsAppSDK runtime.
+    A class-fixture spins a dedicated STA dispatcher thread and starts a single
+    hidden Application + Window once per test process; tests marshal onto the
+    UI thread to construct surfaces and walk the resulting visual tree.
+
+    Runs only on Windows. Slower than pure-data tests (~seconds to bootstrap,
+    tens of ms per assertion) but exercises the actual XAML produced by the
+    A2UI renderers.
+  -->
+
+  <PropertyGroup>
+    <!-- Override the net10.0 default from tests/Directory.Build.props -->
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+
+    <!-- Deliberately NOT setting <UseWinUI>true</UseWinUI>: that flag turns the
+         project into a WinUI app (forces WinExe output, swaps the test SDK's
+         entry point for the XAML-generated one) and breaks the testhost wiring
+         that copies Microsoft.TestPlatform.* DLLs. We don't author any XAML
+         here — we just reference WinUI3 types programmatically — so we keep the
+         standard test-SDK pipeline and pull WinUI in via the package reference
+         + ProjectReference to OpenClaw.Tray.WinUI. -->
+
+    <Platforms>x64;ARM64</Platforms>
+    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
+    <RootNamespace>OpenClaw.Tray.UITests</RootNamespace>
+
+    <!-- System.Drawing.Common 4.7.0 advisory comes in transitively via the
+         Tray.WinUI ProjectReference. The main project warns; we don't want it
+         to escalate to an error here just because tests/Directory.Build.props
+         sets TreatWarningsAsErrors=true. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1904</WarningsNotAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260101001" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4654" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OpenClaw.Tray.WinUI\OpenClaw.Tray.WinUI.csproj" />
+    <ProjectReference Include="..\..\src\OpenClaw.Shared\OpenClaw.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj
+++ b/tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj
@@ -27,6 +27,23 @@
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <RootNamespace>OpenClaw.Tray.UITests</RootNamespace>
 
+    <!-- Self-contained WinAppSDK deployment so the test host doesn't depend on a
+         system-registered Microsoft.WindowsAppRuntime.1.8 framework MSIX. The
+         GitHub windows-latest runner doesn't preinstall it, and we don't want
+         developers cloning the repo to need a separate runtime install either.
+         Pairs with the matching settings on OpenClaw.Tray.WinUI.csproj.
+
+         Bootstrap auto-init is suppressed here because the WindowsAppSDK NuGet
+         injects the same auto-initializer source into every Exe/WinExe project,
+         and the referenced OpenClaw.Tray.WinUI assembly already carries one
+         compiled in — re-injecting it produces CS0436 type conflicts. The
+         parent assembly's [ModuleInitializer] still fires when its types are
+         first touched, which is enough to load the locally-deployed runtime. -->
+    <WindowsPackageType>None</WindowsPackageType>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <WindowsAppSDKBootstrapInitialize>false</WindowsAppSDKBootstrapInitialize>
+    <WindowsAppSDKUndockedRegFreeWinRTInitialize>false</WindowsAppSDKUndockedRegFreeWinRTInitialize>
+
     <!-- System.Drawing.Common 4.7.0 advisory comes in transitively via the
          Tray.WinUI ProjectReference. The main project warns; we don't want it
          to escalate to an error here just because tests/Directory.Build.props

--- a/tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj
+++ b/tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj
@@ -27,23 +27,6 @@
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <RootNamespace>OpenClaw.Tray.UITests</RootNamespace>
 
-    <!-- Self-contained WinAppSDK deployment so the test host doesn't depend on a
-         system-registered Microsoft.WindowsAppRuntime.1.8 framework MSIX. The
-         GitHub windows-latest runner doesn't preinstall it, and we don't want
-         developers cloning the repo to need a separate runtime install either.
-         Pairs with the matching settings on OpenClaw.Tray.WinUI.csproj.
-
-         Bootstrap auto-init is suppressed here because the WindowsAppSDK NuGet
-         injects the same auto-initializer source into every Exe/WinExe project,
-         and the referenced OpenClaw.Tray.WinUI assembly already carries one
-         compiled in — re-injecting it produces CS0436 type conflicts. The
-         parent assembly's [ModuleInitializer] still fires when its types are
-         first touched, which is enough to load the locally-deployed runtime. -->
-    <WindowsPackageType>None</WindowsPackageType>
-    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
-    <WindowsAppSDKBootstrapInitialize>false</WindowsAppSDKBootstrapInitialize>
-    <WindowsAppSDKUndockedRegFreeWinRTInitialize>false</WindowsAppSDKUndockedRegFreeWinRTInitialize>
-
     <!-- System.Drawing.Common 4.7.0 advisory comes in transitively via the
          Tray.WinUI ProjectReference. The main project warns; we don't want it
          to escalate to an error here just because tests/Directory.Build.props

--- a/tests/OpenClaw.Tray.UITests/SmokeTests.cs
+++ b/tests/OpenClaw.Tray.UITests/SmokeTests.cs
@@ -1,0 +1,52 @@
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace OpenClaw.Tray.UITests;
+
+[Collection(UICollection.Name)]
+public sealed class SmokeTests
+{
+    private readonly UIThreadFixture _ui;
+    public SmokeTests(UIThreadFixture ui) => _ui = ui;
+
+    [Fact]
+    public async Task Fixture_BootsApplicationAndWindow()
+    {
+        await _ui.RunOnUIAsync(() =>
+        {
+            Assert.NotNull(Application.Current);
+            Assert.NotNull(_ui.TestWindow);
+            Assert.NotNull(_ui.Container);
+        });
+    }
+
+    [Fact]
+    public async Task Container_AcceptsTextBlockAndLaysOut()
+    {
+        await _ui.ResetContainerAsync();
+        await _ui.RunOnUIAsync(() =>
+        {
+            var tb = new TextBlock { Text = "hello" };
+            _ui.Container.Children.Add(tb);
+
+            // Force a layout pass so we can measure that the element is live.
+            _ui.Container.UpdateLayout();
+            Assert.Equal("hello", tb.Text);
+            Assert.NotNull(tb.XamlRoot); // attached to a real XamlRoot
+        });
+    }
+
+    [Fact]
+    public async Task ApplicationResources_HasBodyTextBlockStyle()
+    {
+        // Sanity: the renderers look up XamlControlsResources keys; if this
+        // fails, A2UI tests will silently render unstyled text.
+        await _ui.RunOnUIAsync(() =>
+        {
+            var res = Application.Current.Resources["BodyTextBlockStyle"];
+            Assert.IsAssignableFrom<Style>(res);
+        });
+    }
+
+}

--- a/tests/OpenClaw.Tray.UITests/TestApp.cs
+++ b/tests/OpenClaw.Tray.UITests/TestApp.cs
@@ -1,0 +1,63 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Markup;
+
+namespace OpenClaw.Tray.UITests;
+
+/// <summary>
+/// Minimal Application used by the test process.
+///
+/// Why no resource merge in the ctor: in WinAppSDK 1.8, accessing
+/// <see cref="Application.Resources"/> during ctor throws COMException — the
+/// underlying COM object isn't fully wired until after construction returns.
+/// Resources are set up by <see cref="MergeStandardResources"/>, called from the
+/// fixture once the dispatcher confirms the app is alive.
+///
+/// Renderers that look up theme keys (e.g. <c>BodyTextBlockStyle</c>) wrap each
+/// lookup in try/catch and tolerate missing keys, so tests still get a live
+/// visual tree even before the merge happens — assertions on text content,
+/// hierarchy, and click handlers don't depend on theme styles.
+/// </summary>
+internal sealed class TestApp : Application
+{
+    /// <summary>
+    /// Merge XamlControlsResources + the production App.xaml's custom keys
+    /// (LobsterAccentBrush, AccentButtonStyle) so renderers that look them up
+    /// resolve a real value. Call this ON THE UI THREAD after Application.Current
+    /// is set.
+    /// </summary>
+    public void MergeStandardResources()
+    {
+        try
+        {
+            Resources.MergedDictionaries.Add(new Microsoft.UI.Xaml.Controls.XamlControlsResources());
+        }
+        catch
+        {
+            // If XamlControlsResources can't load (rare; missing assembly), keep
+            // going — the renderers degrade gracefully without theme styles.
+        }
+
+        TryAddResource("LobsterAccentBrush",
+            "<SolidColorBrush xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' Color='#E74C3C' />");
+
+        TryAddResource("AccentButtonStyle",
+            "<Style xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' " +
+            "TargetType='Button'>" +
+            "<Setter Property='Foreground' Value='White' />" +
+            "<Setter Property='CornerRadius' Value='4' />" +
+            "</Style>");
+    }
+
+    private void TryAddResource(string key, string xaml)
+    {
+        try
+        {
+            Resources[key] = XamlReader.Load(xaml);
+        }
+        catch
+        {
+            // best-effort; missing key just means renderers fall back.
+        }
+    }
+}

--- a/tests/OpenClaw.Tray.UITests/TestSupport.cs
+++ b/tests/OpenClaw.Tray.UITests/TestSupport.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using OpenClaw.Shared;
+using OpenClawTray.A2UI.Actions;
+using OpenClawTray.A2UI.DataModel;
+using OpenClawTray.A2UI.Hosting;
+using OpenClawTray.A2UI.Protocol;
+using OpenClawTray.A2UI.Rendering;
+
+namespace OpenClaw.Tray.UITests;
+
+/// <summary>
+/// Shared helpers for A2UI rendering tests. A test typically:
+///   1. Builds a <see cref="TestHarness"/> on the UI thread.
+///   2. Pushes a JSONL fixture (built with <see cref="A2UI"/>).
+///   3. Mounts <see cref="TestHarness.LastSurface"/>'s root in the fixture
+///      container so it gets a XamlRoot.
+///   4. Walks the visual tree with <see cref="FindDescendants{T}"/>.
+/// </summary>
+public static class TestSupport
+{
+    /// <summary>Build a fresh router/registry/datamodel/sink stack for one test.</summary>
+    public static TestHarness BuildHarness(UIThreadFixture ui)
+    {
+        var logger = NullLogger.Instance;
+        var media = new MediaResolver(logger);
+        var registry = ComponentRendererRegistry.BuildDefault(media);
+        var dataModel = new DataModelStore(ui.Dispatcher);
+        var actions = new RecordingActionSink();
+        var router = new A2UIRouter(ui.Dispatcher, dataModel, registry, actions, logger);
+        var harness = new TestHarness(router, dataModel, actions);
+        router.SurfaceCreated += (_, s) => harness.LastSurface = s;
+        return harness;
+    }
+
+    /// <summary>
+    /// Yields every <typeparamref name="T"/> in the visual subtree rooted at
+    /// <paramref name="root"/>. Requires the tree to be attached to a XamlRoot
+    /// (templated controls otherwise fail to apply their template, breaking the walk).
+    /// </summary>
+    public static IEnumerable<T> FindDescendants<T>(DependencyObject root) where T : DependencyObject
+    {
+        var count = VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < count; i++)
+        {
+            var child = VisualTreeHelper.GetChild(root, i);
+            if (child is T t) yield return t;
+            foreach (var grand in FindDescendants<T>(child)) yield return grand;
+        }
+    }
+
+    /// <summary>
+    /// Yields every <typeparamref name="T"/> reachable through the logical /
+    /// content properties that A2UI renderers populate (Panel.Children,
+    /// Border.Child, ContentControl.Content, ScrollViewer.Content,
+    /// TabView.TabItems, Expander.Header/Content). Doesn't require the tree
+    /// to be mounted, so it works for templated controls (TextBox, PasswordBox,
+    /// ListView, ComboBox) whose template apply requires PRI resources that
+    /// unpackaged test processes can't always resolve.
+    /// </summary>
+    public static IEnumerable<T> FindLogical<T>(DependencyObject root) where T : DependencyObject
+    {
+        if (root is T self) yield return self;
+
+        switch (root)
+        {
+            case Panel panel:
+                foreach (var child in panel.Children)
+                    foreach (var d in FindLogical<T>(child)) yield return d;
+                break;
+            case Border border when border.Child is FrameworkElement bc:
+                foreach (var d in FindLogical<T>(bc)) yield return d;
+                break;
+            case ScrollViewer sv when sv.Content is FrameworkElement sc:
+                foreach (var d in FindLogical<T>(sc)) yield return d;
+                break;
+            case TabView tv:
+                foreach (var ti in tv.TabItems.OfType<TabViewItem>())
+                {
+                    if (ti is T tiT) yield return tiT;
+                    if (ti.Content is FrameworkElement tc)
+                        foreach (var d in FindLogical<T>(tc)) yield return d;
+                }
+                break;
+            case Expander exp:
+                if (exp.Header is FrameworkElement eh)
+                    foreach (var d in FindLogical<T>(eh)) yield return d;
+                if (exp.Content is FrameworkElement ec)
+                    foreach (var d in FindLogical<T>(ec)) yield return d;
+                break;
+            case ContentControl cc when cc.Content is FrameworkElement cf:
+                foreach (var d in FindLogical<T>(cf)) yield return d;
+                break;
+        }
+    }
+}
+
+/// <summary>One-shot per-test holder: router + the sink that records actions.</summary>
+public sealed class TestHarness
+{
+    public A2UIRouter Router { get; }
+    public DataModelStore DataModel { get; }
+    public RecordingActionSink Actions { get; }
+    public SurfaceHost? LastSurface { get; set; }
+
+    public TestHarness(A2UIRouter router, DataModelStore dataModel, RecordingActionSink actions)
+    {
+        Router = router;
+        DataModel = dataModel;
+        Actions = actions;
+    }
+}
+
+/// <summary>Action sink that captures everything the surface emits, in order.</summary>
+public sealed class RecordingActionSink : IActionSink
+{
+    public List<A2UIAction> Raised { get; } = new();
+    public void Raise(A2UIAction action) => Raised.Add(action);
+}

--- a/tests/OpenClaw.Tray.UITests/UIThreadFixture.cs
+++ b/tests/OpenClaw.Tray.UITests/UIThreadFixture.cs
@@ -31,12 +31,14 @@ namespace OpenClaw.Tray.UITests;
 /// </summary>
 public sealed class UIThreadFixture : IDisposable
 {
-    // Match OpenClaw.Tray.WinUI.csproj's Microsoft.WindowsAppSDK package version (1.8).
-    // The test project ships a self-contained WinAppSDK runtime (see
-    // OpenClaw.Tray.UITests.csproj — WindowsAppSDKSelfContained=true), so this call
-    // resolves to the locally-deployed Microsoft.WindowsAppRuntime.dll rather than a
-    // system-registered framework MSIX. That keeps CI and dev machines free of an
-    // out-of-band runtime install.
+    // Match OpenClaw.Tray.WinUI.csproj's Microsoft.WindowsAppSDK package version
+    // (1.8). The bootstrapper resolves a system-installed
+    // Microsoft.WindowsAppRuntime.1.8 framework MSIX (stable channel = empty version
+    // tag). On dev machines and on CI the runtime is installed out-of-band — see
+    // .github/workflows/ci.yml ("Install WindowsAppRuntime") and the README setup
+    // notes. Self-contained deployment was tried but doesn't survive the xunit
+    // testhost: the testhost.exe lives in the .NET SDK directory, so the SDK's
+    // P/Invoke-based auto-initializer can't probe the test bin folder.
     private const uint WinAppSdkMajorMinor = 0x00010008;
     private const string WinAppSdkVersionTag = "";
 
@@ -135,9 +137,7 @@ public sealed class UIThreadFixture : IDisposable
     {
         try
         {
-            // Initialize WinAppSDK runtime. With self-contained deployment the local
-            // Microsoft.WindowsAppRuntime.Bootstrap.dll resolves to the locally-shipped
-            // runtime files instead of looking up a system framework MSIX.
+            // Initialize WinAppSDK runtime (unpackaged process).
             if (Interlocked.Exchange(ref s_bootstrapInitialized, 1) == 0)
             {
                 Bootstrap.Initialize(WinAppSdkMajorMinor, WinAppSdkVersionTag);

--- a/tests/OpenClaw.Tray.UITests/UIThreadFixture.cs
+++ b/tests/OpenClaw.Tray.UITests/UIThreadFixture.cs
@@ -31,9 +31,12 @@ namespace OpenClaw.Tray.UITests;
 /// </summary>
 public sealed class UIThreadFixture : IDisposable
 {
-    // Match OpenClaw.Tray.WinUI.csproj's Microsoft.WindowsAppSDK package version
-    // (1.8). The bootstrapper resolves a system-installed Microsoft.WindowsAppRuntime.1.8
-    // package; on this machine those are stable-channel, so the version tag is empty.
+    // Match OpenClaw.Tray.WinUI.csproj's Microsoft.WindowsAppSDK package version (1.8).
+    // The test project ships a self-contained WinAppSDK runtime (see
+    // OpenClaw.Tray.UITests.csproj — WindowsAppSDKSelfContained=true), so this call
+    // resolves to the locally-deployed Microsoft.WindowsAppRuntime.dll rather than a
+    // system-registered framework MSIX. That keeps CI and dev machines free of an
+    // out-of-band runtime install.
     private const uint WinAppSdkMajorMinor = 0x00010008;
     private const string WinAppSdkVersionTag = "";
 
@@ -132,7 +135,9 @@ public sealed class UIThreadFixture : IDisposable
     {
         try
         {
-            // Initialize WinAppSDK runtime (unpackaged process).
+            // Initialize WinAppSDK runtime. With self-contained deployment the local
+            // Microsoft.WindowsAppRuntime.Bootstrap.dll resolves to the locally-shipped
+            // runtime files instead of looking up a system framework MSIX.
             if (Interlocked.Exchange(ref s_bootstrapInitialized, 1) == 0)
             {
                 Bootstrap.Initialize(WinAppSdkMajorMinor, WinAppSdkVersionTag);

--- a/tests/OpenClaw.Tray.UITests/UIThreadFixture.cs
+++ b/tests/OpenClaw.Tray.UITests/UIThreadFixture.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.Windows.ApplicationModel.DynamicDependency;
+
+namespace OpenClaw.Tray.UITests;
+
+/// <summary>
+/// Bootstraps a single WinUI3 <see cref="Application"/> + hidden <see cref="Window"/>
+/// on a dedicated STA thread for the lifetime of the test process. Tests marshal
+/// onto that thread via <see cref="RunOnUIAsync"/>.
+///
+/// Why this shape:
+///   - WinUI3 Application is a process singleton; only one Application.Start may
+///     run per process. So the fixture is a collection fixture (single instance
+///     across all UI tests).
+///   - Application.Start blocks the calling thread (it pumps the message loop),
+///     so we spin a dedicated thread and call Application.Start there.
+///   - Renderers like <see cref="OpenClawTray.A2UI.Rendering.Renderers.TextRenderer"/>
+///     call Application.Current.Resources["BodyTextBlockStyle"], so a real
+///     Application instance must exist.
+///   - A hidden Window provides a XamlRoot for elements that need one (theme
+///     resource resolution, focus state, etc.). We host the surface under
+///     <see cref="Container"/>, a Grid that is the Window's Content.
+///
+/// Tests must NOT touch WinUI types from xUnit's worker thread directly — always
+/// marshal via <see cref="RunOnUIAsync{T}"/> or <see cref="RunOnUIAsync"/>.
+/// </summary>
+public sealed class UIThreadFixture : IDisposable
+{
+    // Match OpenClaw.Tray.WinUI.csproj's Microsoft.WindowsAppSDK package version
+    // (1.8). The bootstrapper resolves a system-installed Microsoft.WindowsAppRuntime.1.8
+    // package; on this machine those are stable-channel, so the version tag is empty.
+    private const uint WinAppSdkMajorMinor = 0x00010008;
+    private const string WinAppSdkVersionTag = "";
+
+    private static int s_bootstrapInitialized; // 0 = no, 1 = yes
+
+    private readonly Thread _uiThread;
+    private readonly ManualResetEventSlim _ready = new(false);
+    private Exception? _startupError;
+
+    /// <summary>
+    /// True when env var SLOW_UI_TESTS=1. Window stays visible, tests insert
+    /// deliberate pauses via <see cref="PauseAsync"/> so a human can watch.
+    /// </summary>
+    public bool IsSlow { get; }
+
+    /// <summary>Default pause length when running in slow mode.</summary>
+    public int SlowStepMs { get; }
+
+    /// <summary>Dispatcher attached to the UI thread. Use to enqueue work.</summary>
+    public DispatcherQueue Dispatcher { get; private set; } = null!;
+
+    /// <summary>The hidden top-level Window owned by the fixture.</summary>
+    public Window TestWindow { get; private set; } = null!;
+
+    /// <summary>
+    /// Top-level Grid that tests can drop content into. Cleared between tests
+    /// by the test code (call <see cref="ResetContainerAsync"/>).
+    /// </summary>
+    public Grid Container { get; private set; } = null!;
+
+    public UIThreadFixture()
+    {
+        IsSlow = string.Equals(
+            Environment.GetEnvironmentVariable("SLOW_UI_TESTS"), "1", StringComparison.Ordinal);
+        SlowStepMs = int.TryParse(
+            Environment.GetEnvironmentVariable("SLOW_UI_STEP_MS"), out var ms) && ms > 0 ? ms : 800;
+
+        _uiThread = new Thread(UIThreadProc)
+        {
+            IsBackground = true,
+            Name = "UIThreadFixture",
+        };
+        _uiThread.SetApartmentState(ApartmentState.STA);
+        _uiThread.Start();
+
+        // Wait up to 30s for Application.Start + Window setup to signal ready.
+        if (!_ready.Wait(TimeSpan.FromSeconds(30)))
+            throw new InvalidOperationException("UIThreadFixture failed to initialize within 30s");
+        if (_startupError != null)
+            throw new InvalidOperationException("UIThreadFixture initialization failed", _startupError);
+    }
+
+    /// <summary>Run an async lambda on the UI thread, awaiting its completion.</summary>
+    public Task<T> RunOnUIAsync<T>(Func<Task<T>> work)
+    {
+        var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!Dispatcher.TryEnqueue(async () =>
+        {
+            try { tcs.SetResult(await work().ConfigureAwait(true)); }
+            catch (Exception ex) { tcs.SetException(ex); }
+        }))
+        {
+            tcs.SetException(new InvalidOperationException("Dispatcher rejected enqueue (shutting down?)"));
+        }
+        return tcs.Task;
+    }
+
+    /// <summary>Run a sync lambda on the UI thread, awaiting its completion.</summary>
+    public Task RunOnUIAsync(Action work) => RunOnUIAsync(() => { work(); return Task.FromResult(0); });
+
+    /// <summary>Run an async void lambda on the UI thread, awaiting its completion.</summary>
+    public Task RunOnUIAsync(Func<Task> work) => RunOnUIAsync(async () => { await work().ConfigureAwait(true); return 0; });
+
+    /// <summary>Clear the container so each test starts from an empty surface.</summary>
+    public Task ResetContainerAsync() => RunOnUIAsync(() => Container.Children.Clear());
+
+    /// <summary>
+    /// In slow mode, sleep for <see cref="SlowStepMs"/> (or the override) and
+    /// optionally update the window title with a step label so the watcher can
+    /// follow what's being demonstrated. No-op when slow mode is off.
+    /// </summary>
+    public Task PauseAsync(string? label = null, int? ms = null)
+    {
+        if (!IsSlow) return Task.CompletedTask;
+        if (label != null && Dispatcher != null)
+        {
+            Dispatcher.TryEnqueue(() =>
+            {
+                try { TestWindow.Title = $"A2UI render test — {label}"; } catch { }
+            });
+        }
+        return Task.Delay(ms ?? SlowStepMs);
+    }
+
+    private void UIThreadProc()
+    {
+        try
+        {
+            // Initialize WinAppSDK runtime (unpackaged process).
+            if (Interlocked.Exchange(ref s_bootstrapInitialized, 1) == 0)
+            {
+                Bootstrap.Initialize(WinAppSdkMajorMinor, WinAppSdkVersionTag);
+            }
+
+            // Application.Start blocks the calling thread until Application.Current.Exit().
+            // The lambda runs once, on this same thread, with a live dispatcher.
+            Application.Start(p =>
+            {
+                try
+                {
+                    var app = new TestApp(); // ctor stashes itself as Application.Current
+                    // Application.Resources can only be touched once the COM object
+                    // is fully wired; safe by the time we reach here (post-ctor).
+                    app.MergeStandardResources();
+
+                    Dispatcher = DispatcherQueue.GetForCurrentThread();
+
+                    Container = new Grid { Padding = new Microsoft.UI.Xaml.Thickness(24) };
+                    TestWindow = new Window
+                    {
+                        Title = "OpenClaw.Tray.UITests",
+                        Content = Container,
+                    };
+
+                    if (IsSlow)
+                    {
+                        // Resize to something a human can watch comfortably.
+                        try
+                        {
+                            TestWindow.AppWindow.Resize(new Windows.Graphics.SizeInt32(900, 640));
+                        }
+                        catch { /* best-effort sizing */ }
+                    }
+
+                    TestWindow.Activate();
+
+                    if (!IsSlow)
+                    {
+                        // Default: hide the window so CI runs are silent.
+                        TryHide(TestWindow);
+                    }
+
+                    _ready.Set();
+                }
+                catch (Exception ex)
+                {
+                    _startupError = ex;
+                    _ready.Set();
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            _startupError = ex;
+            _ready.Set();
+        }
+    }
+
+    private static void TryHide(Window w)
+    {
+        try
+        {
+            // WindowsAppSDK 1.5+ supports AppWindow.Hide via WinUIEx, but to keep
+            // deps minimal we just move the window off-screen. It's still a real
+            // Window — XamlRoot is attached, the visual tree lays out — but the
+            // user never sees it during tests.
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(w);
+            // SW_HIDE = 0
+            ShowWindow(hwnd, 0);
+        }
+        catch
+        {
+            // best-effort; tests still work even if the window briefly flashes.
+        }
+    }
+
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)]
+    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    public void Dispose()
+    {
+        try
+        {
+            // Ask the UI thread to exit. Application.Current.Exit() unwinds
+            // Application.Start; the thread then completes naturally.
+            if (Dispatcher != null)
+            {
+                Dispatcher.TryEnqueue(() =>
+                {
+                    try { TestWindow?.Close(); } catch { }
+                    try { Application.Current?.Exit(); } catch { }
+                });
+            }
+            // Don't block the test process forever if the UI thread misbehaves.
+            _uiThread.Join(TimeSpan.FromSeconds(5));
+        }
+        catch
+        {
+            // Disposal is best-effort.
+        }
+    }
+}
+
+/// <summary>
+/// All UI tests share one Application/Window — declare them in this collection
+/// so xUnit serializes them and reuses the fixture.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class UICollection : ICollectionFixture<UIThreadFixture>
+{
+    public const string Name = "UI";
+}


### PR DESCRIPTION
## Summary

Brings the Windows tray to feature parity with the Android client on A2UI v0.8 and works through a security review of the resulting attack surface.

- **Native WinUI A2UI renderer.** Replaces the Lit/WebView2 path with a XAML-native renderer hosting all 18 v0.8 components (Row, Column, List, Card, Tabs, Modal, Divider, Text, Image, Icon, Video, AudioPlayer, Button, CheckBox, TextField, DateTimeInput, MultipleChoice, Slider). Catalog-strict registry, JSONL envelope routing, A2UIValue tagged-union resolution, surface-scoped data model with subscriptions, action.context dataBinding scoping, secret-path redaction. SVG support added on top of D2D, with DOCTYPE strip + decode budgeting.
- **Local MCP server.** Bearer-token auth, loopback-only bind, Origin/Host/Content-Type CSRF gate, per-request deadline + handler concurrency cap with drain-on-Dispose. Black-box integration tests cover every advertised tool. Tray Settings surfaces the endpoint, masked token, and a reset button.
- **canvas.navigate routes to the OS default browser** (no longer requires an embedded WebView2 surface). High-risk URLs (loopback / private IP / link-local / no-dot intranet / non-HTTPS / IP literal / Windows Internet Security Manager Local-Machine or Intranet zone) require user confirmation via a Win32 MessageBox prompt; the agent always receives the same success response immediately and the prompt+launch run fire-and-forget so the user's decision and decision time aren't exposed via timing.
- **Media safety.** Image / Video / AudioPlayer route through MediaResolver with HTTPS-only allowlist, DNS resolution + non-public-IP rejection (defends against DNS rebinding), data: URL size cap, Content-Length and stream-side byte caps for image fetches, and per-image cancellation tokens.
- **jsonlPath TOCTOU.** canvas.a2ui.push jsonlPath rejects unresolved reparse points, opens the file once with FileStream, re-validates the resolved path with GetFinalPathNameByHandle, and enforces the size cap on the open stream.
- **Token sanitization.** TokenSanitizer redacts Authorization: Bearer, JSON token/secret/bearer fields, and bare 43-char base64url tokens from log + jsonl diagnostics + malformed-line logs.

All Win32/COM APIs in the URL security path (`MessageBoxW`, `IInternetSecurityManager::MapUrlToZone` via documented CLSID/IID) are public and shipped in the current Windows SDK.

## Test plan

- [x] `OpenClaw.Shared.Tests` — 1039 passed
- [x] `OpenClaw.Tray.Tests` — 219 passed
- [x] `OpenClaw.Tray.IntegrationTests` (`OPENCLAW_RUN_INTEGRATION=1`, real tray spawned per fixture) — 18 passed
- [x] `OpenClaw.Tray.UITests` — 62 passed
- [x] Manual: `canvas.navigate http://www.example.com` from MCP client — confirmation prompt appears, "Yes" launches default browser, "No" silently blocks, agent gets identical success in both cases
- [x] Manual: rich A2UI surface push round-trips through native renderer with `canvas.a2ui.dump` returning the redacted state snapshot
- [x] Manual: MCP token reset from Settings — old token invalidated, new token hot-swapped without restarting the listener

🤖 Generated with [Claude Code](https://claude.com/claude-code)