### PR TITLE
fix(onboarding): use dark text on yellow warning cards

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Onboarding/Pages/ReadyPage.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/Pages/ReadyPage.cs
@@ -69,12 +69,14 @@ public sealed class ReadyPage : Component<OnboardingState>
                 VStack(8,
                     TextBlock("🔌 Node Mode Active")
                         .FontSize(14)
-                        .FontWeight(new global::Windows.UI.Text.FontWeight(600)),
+                        .FontWeight(new global::Windows.UI.Text.FontWeight(600))
+                        .Foreground("#3D2A0F"),
                     TextBlock("This PC will operate as a remote compute node. " +
                         "The gateway can invoke screen capture, camera, and system " +
                         "commands on this machine.")
                         .FontSize(12)
-                        .Opacity(0.8)
+                        .Foreground("#3D2A0F")
+                        .Opacity(0.85)
                         .TextWrapping()
                 ).Padding(12)
             )

--- a/src/OpenClaw.Tray.WinUI/Onboarding/Pages/WelcomePage.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/Pages/WelcomePage.cs
@@ -34,7 +34,10 @@ public sealed class WelcomePage : Component
                 .TextWrapping()
                 .Margin(0, 4, 0, 0),
 
-            // Combined security notice + trust card
+            // Combined security notice + trust card.
+            // Use explicit dark text on the yellow background so it remains
+            // readable in dark mode (where the inherited theme foreground is white
+            // and would otherwise render white-on-yellow).
             Border(
                 VStack(8,
                     HStack(6,
@@ -42,14 +45,17 @@ public sealed class WelcomePage : Component
                         TextBlock(LocalizationHelper.GetString("Onboarding_Welcome_SecurityTitle"))
                             .FontSize(13)
                             .FontWeight(new global::Windows.UI.Text.FontWeight(600))
+                            .Foreground("#3D2A0F")
                     ),
                     TextBlock(LocalizationHelper.GetString("Onboarding_Welcome_SecurityBody"))
                         .FontSize(12)
                         .Opacity(0.85)
+                        .Foreground("#3D2A0F")
                         .TextWrapping(),
                     TextBlock(LocalizationHelper.GetString("Onboarding_Welcome_TrustTitle"))
                         .FontSize(13)
                         .FontWeight(new global::Windows.UI.Text.FontWeight(600))
+                        .Foreground("#3D2A0F")
                         .Margin(0, 4, 0, 0),
                     BulletItem("Onboarding_Welcome_Trust_Commands", "Run commands on your computer"),
                     BulletItem("Onboarding_Welcome_Trust_Files", "Read and write files"),
@@ -71,8 +77,8 @@ public sealed class WelcomePage : Component
         var text = LocalizationHelper.GetString(key);
         if (text == key) text = fallback;
         return HStack(6,
-            TextBlock("•").FontSize(12).Opacity(0.6),
-            TextBlock(text).FontSize(12).Opacity(0.7)
+            TextBlock("•").FontSize(12).Foreground("#3D2A0F").Opacity(0.6),
+            TextBlock(text).FontSize(12).Foreground("#3D2A0F").Opacity(0.8)
         );
     }
 }

--- a/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
+++ b/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
@@ -30,6 +30,7 @@ public sealed class ElementModifiers
     public HorizontalAlignment? HorizontalAlignment { get; set; }
     public VerticalAlignment? VerticalAlignment { get; set; }
     public Brush? Background { get; set; }
+    public Brush? Foreground { get; set; }
     public CornerRadius? CornerRadius { get; set; }
     public double? FontSize { get; set; }
     public FontWeight? FontWeight { get; set; }
@@ -356,6 +357,10 @@ public static class ElementExtensions
         element.Apply(e => e.Modifiers.Background = new SolidColorBrush(ParseColor(hex)));
     public static T Background<T>(this T element, Color color) where T : Element =>
         element.Apply(e => e.Modifiers.Background = new SolidColorBrush(color));
+    public static T Foreground<T>(this T element, string hex) where T : Element =>
+        element.Apply(e => e.Modifiers.Foreground = new SolidColorBrush(ParseColor(hex)));
+    public static T Foreground<T>(this T element, Color color) where T : Element =>
+        element.Apply(e => e.Modifiers.Foreground = new SolidColorBrush(color));
     public static T CornerRadius<T>(this T element, double value) where T : Element =>
         element.Apply(e => e.Modifiers.CornerRadius = new CornerRadius(value));
     public static T FontSize<T>(this T element, double value) where T : Element =>
@@ -899,12 +904,14 @@ internal sealed class UiRenderer(Action requestRender)
                 if (m.FontFamily is { } textFamily) tb.FontFamily = textFamily;
                 if (m.TextWrapping is { } wrapping) tb.TextWrapping = wrapping;
                 if (m.Padding is { } textPadding) tb.Padding = textPadding;
+                if (m.Foreground is { } textFg) tb.Foreground = textFg;
                 break;
             case Control c:
                 if (m.Padding is { } controlPadding) c.Padding = controlPadding;
                 if (m.FontSize is { } controlSize) c.FontSize = controlSize;
                 if (m.FontWeight is { } controlWeight) c.FontWeight = controlWeight;
                 if (m.FontFamily is { } controlFamily) c.FontFamily = controlFamily;
+                if (m.Foreground is { } controlFg) c.Foreground = controlFg;
                 break;
             case Border b:
                 if (m.Padding is { } borderPadding) b.Padding = borderPadding;

--- a/tests/OpenClaw.Tray.UITests/OnboardingWarningCardTests.cs
+++ b/tests/OpenClaw.Tray.UITests/OnboardingWarningCardTests.cs
@@ -1,0 +1,214 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using OpenClawTray.FunctionalUI;
+using OpenClawTray.FunctionalUI.Hosting;
+using OpenClawTray.Onboarding.Pages;
+using OpenClawTray.Onboarding.Services;
+using OpenClawTray.Services;
+using static OpenClawTray.FunctionalUI.Factories;
+using static OpenClawTray.FunctionalUI.ElementExtensions;
+
+namespace OpenClaw.Tray.UITests;
+
+/// <summary>
+/// Regression coverage for PR #257 (PR 241 follow-up).
+///
+/// PR 241 introduced two yellow warning cards on the Welcome and Ready pages.
+/// They use a hard-coded yellow background but inherited the system theme
+/// foreground, which renders as white in dark mode → unreadable. The fix sets
+/// an explicit dark-brown <c>#3D2A0F</c> foreground on every TextBlock inside
+/// those cards.
+///
+/// These tests exercise:
+///   1. The new <c>Foreground</c> modifier on FunctionalUI propagates to the
+///      rendered <see cref="TextBlock"/>.
+///   2. The Welcome page security-notice card has explicit dark text on every
+///      non-emoji TextBlock.
+///   3. The Ready page node-mode card has explicit dark text on every non-emoji
+///      TextBlock when node mode is enabled.
+///
+/// We assert at the visual-tree level rather than via a screenshot baseline:
+/// the bug is "this brush is missing", which a brush comparison expresses
+/// precisely without the maintenance cost of pixel diffs.
+/// </summary>
+[Collection(UICollection.Name)]
+public sealed class OnboardingWarningCardTests
+{
+    private const uint ExpectedDarkText = 0xFF3D2A0FU; // ARGB
+    private const uint WelcomeYellow   = 0xFFFFF4E0U;
+    private const uint ReadyYellow     = 0xFFFFF3E0U;
+
+    private readonly UIThreadFixture _ui;
+    public OnboardingWarningCardTests(UIThreadFixture ui) => _ui = ui;
+
+    [Fact]
+    public async Task ForegroundModifier_AppliesExplicitBrushToTextBlock()
+    {
+        await _ui.ResetContainerAsync();
+
+        var host = await _ui.RunOnUIAsync(() => Task.FromResult(MountFunctional(
+            _ => TextBlock("hello").Foreground("#3D2A0F"))));
+
+        // FunctionalHostControl renders via DispatcherQueue.TryEnqueue, so the
+        // first call returns before Render() runs. A second RunOnUIAsync is
+        // serialized after that queued render, so by the time it executes the
+        // visual tree is built.
+        await _ui.RunOnUIAsync(() =>
+        {
+            _ui.Container.UpdateLayout();
+            var tb = FindLogicalDescendants<TextBlock>(host)
+                .Single(t => t.Text == "hello");
+            AssertSolidColor(tb.Foreground, ExpectedDarkText, "TextBlock.Foreground");
+        });
+    }
+
+    [Fact]
+    public async Task WelcomePage_WarningCard_HasExplicitDarkForegroundOnAllText()
+    {
+        await _ui.ResetContainerAsync();
+
+        var host = await _ui.RunOnUIAsync(() => Task.FromResult(MountComponent(new WelcomePage())));
+
+        await _ui.RunOnUIAsync(() =>
+        {
+            _ui.Container.UpdateLayout();
+            var yellowBorder = FindLogicalDescendants<Border>(host)
+                .Single(b => IsSolidColor(b.Background, WelcomeYellow));
+            AssertNonEmojiTextHasForeground(yellowBorder, ExpectedDarkText);
+        });
+    }
+
+    [Fact]
+    public async Task ReadyPage_NodeModeCard_HasExplicitDarkForegroundOnAllText()
+    {
+        // Isolate SettingsManager from the real %APPDATA%\OpenClawTray
+        // (per AGENTS.md: never use `new SettingsManager()` against real settings).
+        var tempDir = Path.Combine(Path.GetTempPath(), "openclaw-uitests-" + Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            await _ui.ResetContainerAsync();
+
+            var settings = new SettingsManager(tempDir);
+            settings.EnableNodeMode = true; // forces ModeInfoCard() into the yellow node-mode branch
+            using var state = new OnboardingState(settings)
+            {
+                Mode = ConnectionMode.Local,
+            };
+
+            var host = await _ui.RunOnUIAsync(() => Task.FromResult(MountFunctional(
+                _ => Component<ReadyPage, OnboardingState>(state))));
+
+            await _ui.RunOnUIAsync(() =>
+            {
+                _ui.Container.UpdateLayout();
+                var yellowBorder = FindLogicalDescendants<Border>(host)
+                    .Single(b => IsSolidColor(b.Background, ReadyYellow));
+                AssertNonEmojiTextHasForeground(yellowBorder, ExpectedDarkText);
+            });
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    /// <summary>Construct + mount a FunctionalHostControl on the UI thread.</summary>
+    private FunctionalHostControl MountFunctional(System.Func<OpenClawTray.FunctionalUI.Core.RenderContext, OpenClawTray.FunctionalUI.Core.Element> render)
+    {
+        var host = new FunctionalHostControl();
+        _ui.Container.Children.Add(host);
+        host.Mount(render);
+        return host;
+    }
+
+    /// <summary>Construct + mount a Component on a FunctionalHostControl on the UI thread.</summary>
+    private FunctionalHostControl MountComponent(OpenClawTray.FunctionalUI.Core.Component component)
+    {
+        var host = new FunctionalHostControl();
+        _ui.Container.Children.Add(host);
+        host.Mount(component);
+        return host;
+    }
+
+    // ---------- helpers ----------
+
+    /// <summary>
+    /// Walks the FunctionalUI logical tree (StackPanel/Border children, no XamlRoot
+    /// required) collecting every descendant of the requested type.
+    /// </summary>
+    private static System.Collections.Generic.IEnumerable<T> FindLogicalDescendants<T>(
+        Microsoft.UI.Xaml.DependencyObject root)
+        where T : Microsoft.UI.Xaml.DependencyObject
+    {
+        if (root is T self) yield return self;
+
+        switch (root)
+        {
+            case Panel panel:
+                foreach (var c in panel.Children)
+                    foreach (var d in FindLogicalDescendants<T>(c)) yield return d;
+                break;
+            case Border border when border.Child is Microsoft.UI.Xaml.FrameworkElement bc:
+                foreach (var d in FindLogicalDescendants<T>(bc)) yield return d;
+                break;
+            case ContentControl cc when cc.Content is Microsoft.UI.Xaml.FrameworkElement cf:
+                foreach (var d in FindLogicalDescendants<T>(cf)) yield return d;
+                break;
+        }
+    }
+
+    private static bool IsSolidColor(Brush? brush, uint argb) =>
+        brush is SolidColorBrush scb && ColorToArgb(scb.Color) == argb;
+
+    private static uint ColorToArgb(Windows.UI.Color c) =>
+        ((uint)c.A << 24) | ((uint)c.R << 16) | ((uint)c.G << 8) | c.B;
+
+    private static void AssertSolidColor(Brush? brush, uint argb, string what)
+    {
+        Assert.NotNull(brush);
+        var scb = Assert.IsType<SolidColorBrush>(brush);
+        Assert.Equal(argb, ColorToArgb(scb.Color));
+        _ = what;
+    }
+
+    /// <summary>
+    /// Asserts that every <see cref="TextBlock"/> under <paramref name="card"/>
+    /// whose text is a non-emoji string has the expected explicit foreground.
+    /// Emoji TextBlocks are skipped because color emoji glyphs render from their
+    /// own palette and ignore the foreground brush — explicitly coloring them
+    /// would have no visible effect.
+    /// </summary>
+    private static void AssertNonEmojiTextHasForeground(Border card, uint expectedArgb)
+    {
+        var nonEmojiTexts = FindLogicalDescendants<TextBlock>(card)
+            .Where(tb => !string.IsNullOrEmpty(tb.Text) && !IsEmojiOnly(tb.Text))
+            .ToList();
+
+        Assert.NotEmpty(nonEmojiTexts);
+        foreach (var tb in nonEmojiTexts)
+        {
+            AssertSolidColor(tb.Foreground, expectedArgb, $"text \"{tb.Text}\"");
+        }
+    }
+
+    /// <summary>
+    /// Returns true if every code point in <paramref name="s"/> is outside the
+    /// Basic Latin / Latin-1 range and either a Symbol or above U+1F000 (emoji
+    /// plane). Used to skip warning-icon TextBlocks like "⚠️" and "🔌•".
+    /// </summary>
+    private static bool IsEmojiOnly(string s)
+    {
+        foreach (var rune in s.EnumerateRunes())
+        {
+            // Bullet character "•" (U+2022) is treated as text, not emoji.
+            if (rune.Value == 0x2022) return false;
+            // Latin / digit / whitespace → not emoji.
+            if (rune.Value < 0x2300 && !char.IsSymbol((char)rune.Value)) return false;
+        }
+        return s.Length > 0;
+    }
+}


### PR DESCRIPTION
PR 241 follow-up.

The Welcome page security-notice card and the Ready page node-mode card use a yellow background but inherit the system theme foreground, which renders as white in dark mode — making the text unreadable.

## Changes

- Add a `Foreground` modifier to `OpenClawTray.FunctionalUI` (brush prop + extension overloads, applied to `TextBlock` and `Control` in `ApplyModifiers`).
- `WelcomePage`: explicit `#3D2A0F` text on the security-notice card (title, body, ""Your agent can:"" subheading, bullets).
- `ReadyPage`: same treatment for the ""🔌 Node Mode Active"" yellow card.

## Tests (commit 3975474)

New `tests/OpenClaw.Tray.UITests/OnboardingWarningCardTests.cs` (3 tests, all passing):

1. `ForegroundModifier_AppliesExplicitBrushToTextBlock` — exercises the new Foreground modifier end-to-end through `FunctionalHostControl` and asserts the produced `TextBlock.Foreground` is a `SolidColorBrush(#3D2A0F)`.
2. `WelcomePage_WarningCard_HasExplicitDarkForegroundOnAllText` — renders the Welcome page, locates the yellow card by background brush, and asserts every non-emoji TextBlock inside has the explicit dark text color.
3. `ReadyPage_NodeModeCard_HasExplicitDarkForegroundOnAllText` — same shape for the Ready page node-mode card with `EnableNodeMode = true`. `SettingsManager` is constructed with a temp directory per AGENTS.md isolation rule.

Tree-level brush assertions are used in preference to pixel screenshot baselines: the bug is a missing brush, so brush comparison expresses the regression precisely without screenshot maintenance overhead.

## Validation

- `./build.ps1` — all projects built successfully.
- Visual screenshot verified — dark brown text legible on the yellow card.
- `OpenClaw.Tray.Tests` — 406/406 passed.
- `OpenClaw.Shared.Tests` — 1100/1100 passed.
- `OpenClaw.Tray.UITests` — 65/65 passed (3 new + 62 existing).

## Out of scope

- The second PR-241 follow-up (auto-pop on already-paired devices) was already addressed by Scott in 5be08f4 + a794d5f on master.
- Other onboarding cards using `#FFFFFF` / `#E8F4FD` backgrounds likely have the same dark-mode unreadability problem. Filed as #258 to keep this PR scoped to the originally reported yellow-warning bug.