### PR TITLE
feat: gateway registry (multi-gateway support)

### DIFF
--- a/src/OpenClaw.Shared/ConnectionDiagnostics.cs
+++ b/src/OpenClaw.Shared/ConnectionDiagnostics.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// A single diagnostic event from the connection state machine.
+/// </summary>
+public sealed record ConnectionEvent(
+    DateTime Timestamp,
+    string Direction,     // "→ GW", "← GW", "→ WSL", "INTERNAL"
+    string EventType,     // "CONNECT", "CHALLENGE", "AUTH", "HELLO_OK", "ERROR",
+                          // "PAIRED", "RECONNECT", "DISCONNECT", "AUTO_APPROVE",
+                          // "SIGNATURE_REJECTED", "PAIRING_REQUIRED", "STATE_CHANGE"
+    string Summary,
+    string? Detail = null,
+    string? TokenType = null,   // "shared", "bootstrap", "device", null
+    string[]? Scopes = null);
+
+/// <summary>
+/// Thread-safe ring buffer of connection diagnostic events.
+/// UI subscribes to <see cref="EventRecorded"/> for real-time updates.
+/// </summary>
+public sealed class ConnectionDiagnostics
+{
+    private readonly object _lock = new();
+    private readonly LinkedList<ConnectionEvent> _events = new();
+    private readonly int _maxEvents;
+
+    public event EventHandler<ConnectionEvent>? EventRecorded;
+
+    public ConnectionDiagnostics(int maxEvents = 500)
+    {
+        _maxEvents = maxEvents;
+    }
+
+    public void Record(string direction, string eventType, string summary,
+        string? detail = null, string? tokenType = null, string[]? scopes = null)
+    {
+        var evt = new ConnectionEvent(
+            DateTime.Now, direction, eventType, summary, detail, tokenType, scopes);
+
+        lock (_lock)
+        {
+            _events.AddFirst(evt);
+            while (_events.Count > _maxEvents)
+                _events.RemoveLast();
+        }
+
+        EventRecorded?.Invoke(this, evt);
+    }
+
+    /// <summary>Returns a snapshot of events (newest first).</summary>
+    public IReadOnlyList<ConnectionEvent> GetSnapshot()
+    {
+        lock (_lock)
+        {
+            return new List<ConnectionEvent>(_events);
+        }
+    }
+
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _events.Clear();
+        }
+    }
+
+    public int Count
+    {
+        get { lock (_lock) { return _events.Count; } }
+    }
+
+    // ── Convenience methods ──
+
+    public void RecordConnect(string url, string? tokenType)
+        => Record("→ GW", "CONNECT", $"Connecting to {url}", tokenType: tokenType);
+
+    public void RecordChallenge(string nonce)
+        => Record("← GW", "CHALLENGE", $"Challenge received", detail: $"nonce={nonce}");
+
+    public void RecordAuthSent(string tokenType, string[]? requestedScopes, string signatureMode, string? deviceId)
+        => Record("→ GW", "AUTH", $"Auth sent ({tokenType}, sig={signatureMode})",
+            detail: $"deviceId={deviceId}\nscopes=[{string.Join(", ", requestedScopes ?? Array.Empty<string>())}]",
+            tokenType: tokenType, scopes: requestedScopes);
+
+    public void RecordHelloOk(string[]? grantedScopes, string? deviceToken)
+        => Record("← GW", "HELLO_OK", "Connected",
+            detail: deviceToken != null ? $"deviceToken={deviceToken[..Math.Min(10, deviceToken.Length)]}..." : null,
+            scopes: grantedScopes);
+
+    public void RecordSignatureRejected(string mode, string fallback)
+        => Record("← GW", "SIGNATURE_REJECTED", $"Signature rejected ({mode} → {fallback})");
+
+    public void RecordPairingRequired(string? requestId, string? reason)
+        => Record("← GW", "PAIRING_REQUIRED", $"Pairing required: {reason ?? "unknown"}",
+            detail: requestId != null ? $"requestId={requestId}" : null);
+
+    public void RecordAuthFailed(string message)
+        => Record("← GW", "ERROR", $"Auth failed: {message}");
+
+    public void RecordDisconnect(string? reason)
+        => Record("INTERNAL", "DISCONNECT", reason ?? "Disconnected");
+
+    public void RecordStateChange(string role, string fromState, string toState)
+        => Record("INTERNAL", "STATE_CHANGE", $"{role}: {fromState} → {toState}");
+
+    public void RecordAutoApprove(string requestId)
+        => Record("→ WSL", "AUTO_APPROVE", $"Auto-approving device", detail: $"requestId={requestId}");
+
+    public void RecordNodeConnect(string url, string? tokenType)
+        => Record("→ GW", "NODE_CONNECT", $"Node connecting to {url}", tokenType: tokenType);
+
+    public void RecordNodePaired(string? deviceId)
+        => Record("← GW", "NODE_PAIRED", $"Node paired", detail: deviceId != null ? $"deviceId={deviceId[..Math.Min(16, deviceId.Length)]}..." : null);
+
+    public void RecordCredentialResolved(string source, string? tokenType, bool isBootstrap)
+        => Record("INTERNAL", "CREDENTIAL_RESOLVED", $"Using {source} (bootstrap={isBootstrap})", tokenType: tokenType);
+}

--- a/src/OpenClaw.Shared/DeviceIdentity.cs
+++ b/src/OpenClaw.Shared/DeviceIdentity.cs
@@ -81,6 +81,32 @@ public class DeviceIdentity
 
     public static bool HasStoredDeviceTokenForRole(string dataPath, string role, IOpenClawLogger? logger = null) =>
         !string.IsNullOrWhiteSpace(TryReadStoredDeviceTokenForRole(dataPath, role, logger));
+
+    /// <summary>
+    /// Clears the stored device token from the identity file without regenerating the keypair.
+    /// Used when applying a setup code to a new gateway — the old device token is invalid.
+    /// </summary>
+    public static void TryClearStoredDeviceToken(string dataPath, IOpenClawLogger? logger = null)
+    {
+        var keyPath = Path.Combine(dataPath, "device-key-ed25519.json");
+        if (!File.Exists(keyPath)) return;
+
+        try
+        {
+            var json = File.ReadAllText(keyPath);
+            var data = JsonSerializer.Deserialize<DeviceKeyData>(json);
+            if (data != null && !string.IsNullOrEmpty(data.DeviceToken))
+            {
+                data.DeviceToken = null;
+                File.WriteAllText(keyPath, JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true }));
+                logger?.Info("Cleared stored device token for fresh pairing");
+            }
+        }
+        catch (Exception ex)
+        {
+            logger?.Warn($"Failed to clear stored device token: {ex.Message}");
+        }
+    }
     
     public DeviceIdentity(string dataPath, IOpenClawLogger? logger = null)
     {

--- a/src/OpenClaw.Shared/DeviceIdentity.cs
+++ b/src/OpenClaw.Shared/DeviceIdentity.cs
@@ -83,6 +83,24 @@ public class DeviceIdentity
         !string.IsNullOrWhiteSpace(TryReadStoredDeviceTokenForRole(dataPath, role, logger));
 
     /// <summary>
+    /// Reads the device ID from the identity file without loading the full keypair.
+    /// </summary>
+    public static string? TryReadDeviceId(string dataPath)
+    {
+        var keyPath = Path.Combine(dataPath, "device-key-ed25519.json");
+        if (!File.Exists(keyPath)) return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(keyPath));
+            if (doc.RootElement.TryGetProperty("DeviceId", out var prop) &&
+                prop.ValueKind == JsonValueKind.String)
+                return prop.GetString();
+        }
+        catch { }
+        return null;
+    }
+
+    /// <summary>
     /// Clears the stored device token from the identity file without regenerating the keypair.
     /// Used when applying a setup code to a new gateway — the old device token is invalid.
     /// </summary>

--- a/src/OpenClaw.Shared/DeviceIdentity.cs
+++ b/src/OpenClaw.Shared/DeviceIdentity.cs
@@ -95,11 +95,12 @@ public class DeviceIdentity
         {
             var json = File.ReadAllText(keyPath);
             var data = JsonSerializer.Deserialize<DeviceKeyData>(json);
-            if (data != null && !string.IsNullOrEmpty(data.DeviceToken))
+            if (data != null && (!string.IsNullOrEmpty(data.DeviceToken) || !string.IsNullOrEmpty(data.OperatorDeviceToken)))
             {
                 data.DeviceToken = null;
+                data.OperatorDeviceToken = null;
                 File.WriteAllText(keyPath, JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true }));
-                logger?.Info("Cleared stored device token for fresh pairing");
+                logger?.Info("Cleared stored device tokens for fresh pairing");
             }
         }
         catch (Exception ex)
@@ -482,7 +483,50 @@ public class DeviceIdentity
         public string[]? DeviceTokenScopes { get; set; }
         public string? NodeDeviceToken { get; set; }
         public string[]? NodeDeviceTokenScopes { get; set; }
+        public string? OperatorDeviceToken { get; set; }
         public string? Algorithm { get; set; }
         public long CreatedAt { get; set; }
+    }
+
+    /// <summary>
+    /// Reads the stored operator device token from the identity file.
+    /// </summary>
+    public static string? TryReadStoredOperatorDeviceToken(string dataPath, IOpenClawLogger? logger = null)
+    {
+        var keyPath = Path.Combine(dataPath, "device-key-ed25519.json");
+        if (!File.Exists(keyPath)) return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(keyPath));
+            if (doc.RootElement.TryGetProperty("OperatorDeviceToken", out var prop) &&
+                prop.ValueKind == JsonValueKind.String)
+            {
+                var value = prop.GetString();
+                return string.IsNullOrWhiteSpace(value) ? null : value;
+            }
+        }
+        catch (Exception ex) { logger?.Warn($"Failed to read operator device token: {ex.Message}"); }
+        return null;
+    }
+
+    /// <summary>
+    /// Stores the operator device token in the identity file.
+    /// </summary>
+    public static void StoreOperatorDeviceToken(string dataPath, string token, IOpenClawLogger? logger = null)
+    {
+        var keyPath = Path.Combine(dataPath, "device-key-ed25519.json");
+        if (!File.Exists(keyPath)) return;
+        try
+        {
+            var json = File.ReadAllText(keyPath);
+            var data = JsonSerializer.Deserialize<DeviceKeyData>(json);
+            if (data != null)
+            {
+                data.OperatorDeviceToken = token;
+                File.WriteAllText(keyPath, JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true }));
+                logger?.Info("Operator device token stored in identity file");
+            }
+        }
+        catch (Exception ex) { logger?.Error($"Failed to store operator device token: {ex.Message}"); }
     }
 }

--- a/src/OpenClaw.Shared/DeviceIdentity.cs
+++ b/src/OpenClaw.Shared/DeviceIdentity.cs
@@ -111,19 +111,16 @@ public class DeviceIdentity
 
         try
         {
-            var json = File.ReadAllText(keyPath);
-            var data = JsonSerializer.Deserialize<DeviceKeyData>(json);
-            if (data != null && (!string.IsNullOrEmpty(data.DeviceToken) || !string.IsNullOrEmpty(data.OperatorDeviceToken)))
-            {
-                data.DeviceToken = null;
-                data.OperatorDeviceToken = null;
-                File.WriteAllText(keyPath, JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true }));
-                logger?.Info("Cleared stored device tokens for fresh pairing");
-            }
+            // Delete the entire identity file so a fresh Ed25519 keypair is generated
+            // on the next connection. Clearing just tokens is insufficient because
+            // the keypair itself is gateway-specific — a different gateway won't
+            // recognize signatures from a keypair that was paired elsewhere.
+            File.Delete(keyPath);
+            logger?.Info("Deleted stored device identity for fresh pairing");
         }
         catch (Exception ex)
         {
-            logger?.Warn($"Failed to clear stored device token: {ex.Message}");
+            logger?.Warn($"Failed to delete stored device identity: {ex.Message}");
         }
     }
     

--- a/src/OpenClaw.Shared/GatewayConnectionService.cs
+++ b/src/OpenClaw.Shared/GatewayConnectionService.cs
@@ -1,0 +1,450 @@
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Factory for creating gateway operator clients. Enables testing without real WebSockets.
+/// </summary>
+public interface IGatewayClientFactory
+{
+    OpenClawGatewayClient Create(string gatewayUrl, string token, IOpenClawLogger logger, bool tokenIsBootstrapToken = false, string? identityPath = null);
+}
+
+/// <summary>
+/// Default factory that creates real <see cref="OpenClawGatewayClient"/> instances.
+/// </summary>
+public sealed class DefaultGatewayClientFactory : IGatewayClientFactory
+{
+    public OpenClawGatewayClient Create(string gatewayUrl, string token, IOpenClawLogger logger, bool tokenIsBootstrapToken = false, string? identityPath = null)
+        => new(gatewayUrl, token, logger, tokenIsBootstrapToken, identityPath: identityPath);
+}
+
+/// <summary>
+/// Adapter for node service connection. Implemented in the WinUI layer
+/// since NodeService depends on WinUI types (DispatcherQueue, FrameworkElement).
+/// </summary>
+public interface INodeConnector
+{
+    bool IsEnabled { get; }
+    Task ConnectAsync(string gatewayUrl, string? nodeToken, string? bootstrapToken, CancellationToken ct = default);
+    Task DisconnectAsync(CancellationToken ct = default);
+}
+
+/// <summary>
+/// Unified gateway connection service. Single owner of the operator client lifecycle,
+/// credential resolution, and connection state machine.
+///
+/// All 3 flows (WSL setup, manual onboarding, connection page) call the same API.
+/// Token storage goes through GatewayRegistry exclusively.
+/// </summary>
+public sealed class GatewayConnectionService : IDisposable
+{
+    private readonly GatewayRegistry _registry;
+    private readonly IGatewayClientFactory _clientFactory;
+    private readonly IOpenClawLogger _logger;
+    private readonly SemaphoreSlim _transitionLock = new(1, 1);
+
+    private OpenClawGatewayClient? _operatorClient;
+    private int _generation; // Stale-event guard
+    private CancellationTokenSource? _connectCts;
+
+    // Role states
+    private GatewayRoleState _operatorState = GatewayRoleState.Idle;
+    private GatewayRoleState _nodeState = GatewayRoleState.Disabled;
+    private string? _lastError;
+    private string? _pairingRequestId;
+    private GatewayRole? _pairingRole;
+
+    /// <summary>Current connection snapshot for UI consumption.</summary>
+    public GatewayConnectionSnapshot Snapshot => BuildSnapshot();
+
+    /// <summary>The active operator client, if connected. Do NOT manage its lifetime externally.</summary>
+    public OpenClawGatewayClient? OperatorClient => _operatorClient;
+
+    /// <summary>Fired on every state transition. Args: (oldState, newState, snapshot).</summary>
+    public event Action<GatewayConnectionState, GatewayConnectionState, GatewayConnectionSnapshot>? StateChanged;
+
+    /// <summary>
+    /// Re-fired from the operator client for consumers that need raw gateway events
+    /// without subscribing to a mutable client reference.
+    /// </summary>
+    public event EventHandler<ConnectionStatus>? OperatorStatusChanged;
+    public event EventHandler<SessionInfo[]>? SessionsUpdated;
+    public event EventHandler<GatewayNodeInfo[]>? NodesUpdated;
+    public event EventHandler<GatewaySelfInfo>? GatewaySelfUpdated;
+    public event EventHandler<ChannelHealth[]>? ChannelHealthUpdated;
+    public event EventHandler<OpenClawNotification>? NotificationReceived;
+    public event EventHandler<AgentActivity>? ActivityChanged;
+
+    public GatewayConnectionService(
+        GatewayRegistry registry,
+        IGatewayClientFactory? clientFactory = null,
+        IOpenClawLogger? logger = null)
+    {
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        _clientFactory = clientFactory ?? new DefaultGatewayClientFactory();
+        _logger = logger ?? NullLogger.Instance;
+    }
+
+    // ── Configure ──
+
+    /// <summary>
+    /// Configure the active gateway from a decoded setup code.
+    /// Caller decodes the raw setup code (SetupCodeDecoder is in the Tray layer).
+    /// Clears stored device tokens for fresh pairing.
+    /// </summary>
+    public bool ApplySetupCode(string url, string? bootstrapToken, string? dataPath = null)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return false;
+
+        var id = GatewayRecord.GenerateId(url);
+        _registry.Remove(id);
+        _registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = id,
+            Url = url,
+            BootstrapToken = bootstrapToken,
+        });
+
+        // Clear stale identity in the per-gateway directory so a fresh keypair
+        // is generated for this gateway (it may have been reinstalled).
+        var gwIdentityPath = Path.Combine(GatewayRecord.BaseIdentityDir, "gateways", id);
+        DeviceIdentity.TryClearStoredDeviceToken(gwIdentityPath);
+
+        SetRoleState(GatewayRole.Operator, GatewayRoleState.Idle);
+        return true;
+    }
+
+    /// <summary>
+    /// Set credentials directly (e.g., shared gateway token from WSL setup, or manual token entry).
+    /// </summary>
+    public void SetCredential(string url, string token, GatewayCredentialKind kind)
+    {
+        if (string.IsNullOrWhiteSpace(url) || string.IsNullOrWhiteSpace(token)) return;
+
+        var id = GatewayRecord.GenerateId(url);
+        var existing = _registry.GetAll().FirstOrDefault(g => g.Id == id);
+        var record = existing?.Clone() ?? new GatewayRecord { Id = id, Url = url };
+
+        switch (kind)
+        {
+            case GatewayCredentialKind.SharedGatewayToken:
+                record.SharedGatewayToken = token;
+                break;
+            case GatewayCredentialKind.BootstrapToken:
+                record.BootstrapToken = token;
+                break;
+            case GatewayCredentialKind.OperatorDeviceToken:
+                record.OperatorDeviceToken = token;
+                record.BootstrapToken = null;
+                break;
+            case GatewayCredentialKind.NodeDeviceToken:
+                record.NodeDeviceToken = token;
+                break;
+        }
+
+        _registry.AddOrUpdate(record);
+    }
+
+    // ── Connect ──
+
+    /// <summary>
+    /// Connect the operator client using credentials from the active gateway record.
+    /// </summary>
+    public async Task ConnectOperatorAsync(CancellationToken ct = default)
+    {
+        await _transitionLock.WaitAsync(ct);
+        try
+        {
+            var activeGw = _registry.GetActive();
+            if (activeGw == null)
+            {
+                _logger.Warn("[ConnectionService] No active gateway — cannot connect");
+                return;
+            }
+
+            // Resolve credential: SharedGatewayToken → BootstrapToken → stored device token
+            string? effectiveToken = null;
+            var isBootstrap = false;
+
+            if (!string.IsNullOrWhiteSpace(activeGw.SharedGatewayToken))
+            {
+                effectiveToken = activeGw.SharedGatewayToken;
+            }
+            else if (!string.IsNullOrWhiteSpace(activeGw.BootstrapToken))
+            {
+                effectiveToken = activeGw.BootstrapToken;
+                isBootstrap = true;
+            }
+
+            // Fall through to stored device token in per-gateway identity file
+            if (string.IsNullOrWhiteSpace(effectiveToken))
+            {
+                var storedToken = DeviceIdentity.TryReadStoredDeviceToken(activeGw.IdentityPath);
+                if (!string.IsNullOrWhiteSpace(storedToken))
+                    effectiveToken = storedToken;
+            }
+
+            if (string.IsNullOrWhiteSpace(effectiveToken))
+            {
+                _logger.Info("[ConnectionService] No credential available — skipping connect");
+                return;
+            }
+
+            var gatewayUrl = activeGw.Url;
+            if (string.IsNullOrWhiteSpace(gatewayUrl)) return;
+
+            // Cancel previous connect attempt
+            _connectCts?.Cancel();
+            _connectCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+            // Dispose old client
+            UnsubscribeAndDispose();
+
+            // Bump generation to ignore stale events
+            var gen = Interlocked.Increment(ref _generation);
+
+            SetRoleState(GatewayRole.Operator, GatewayRoleState.Connecting);
+
+            _operatorClient = _clientFactory.Create(gatewayUrl, effectiveToken, _logger, isBootstrap, identityPath: activeGw.IdentityPath);
+            SubscribeClientEvents(_operatorClient, gen);
+
+            _logger.Info($"[ConnectionService] Connecting operator to {GatewayUrlHelper.SanitizeForDisplay(gatewayUrl)} (bootstrap={isBootstrap})");
+            await _operatorClient.ConnectAsync();
+        }
+        finally
+        {
+            _transitionLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Connect the node service via the injected adapter.
+    /// </summary>
+    public async Task ConnectNodeAsync(INodeConnector node, CancellationToken ct = default)
+    {
+        if (!node.IsEnabled)
+        {
+            SetRoleState(GatewayRole.Node, GatewayRoleState.Disabled);
+            return;
+        }
+
+        var activeGw = _registry.GetActive();
+        if (activeGw == null) return;
+
+        var nodeToken = activeGw.NodeDeviceToken ?? activeGw.OperatorDeviceToken ?? "";
+        SetRoleState(GatewayRole.Node, GatewayRoleState.Connecting);
+        await node.ConnectAsync(activeGw.Url, nodeToken, activeGw.BootstrapToken, ct);
+    }
+
+    // ── Pairing ──
+
+    /// <summary>
+    /// Approve a pending pairing. Pass an approver callback for automated flows (WSL), null for manual.
+    /// The callback receives the optional requestId and should perform the approval.
+    /// </summary>
+    public async Task ApproveAsync(GatewayRole role, string? requestId, Func<string?, CancellationToken, Task>? approver, CancellationToken ct = default)
+    {
+        if (approver == null)
+        {
+            _logger.Info($"[ConnectionService] Manual approval required for {role} (requestId={requestId})");
+            return; // User must approve via CLI
+        }
+
+        _logger.Info($"[ConnectionService] Auto-approving {role} (requestId={requestId})");
+        await approver(requestId, ct);
+    }
+
+    // ── Token persistence (called by event handlers) ──
+
+    /// <summary>
+    /// Store an operator device token received from the gateway (hello-ok handoff or pairing event).
+    /// </summary>
+    public void StoreOperatorDeviceToken(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token)) return;
+        var gw = _registry.GetActive();
+        if (gw == null) return;
+
+        gw.OperatorDeviceToken = token;
+        gw.BootstrapToken = null;
+        _registry.AddOrUpdate(gw);
+        _logger.Info("[ConnectionService] Stored operator device token");
+    }
+
+    /// <summary>
+    /// Store a node device token.
+    /// </summary>
+    public void StoreNodeDeviceToken(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token)) return;
+        var gw = _registry.GetActive();
+        if (gw == null) return;
+
+        gw.NodeDeviceToken = token;
+        _registry.AddOrUpdate(gw);
+        _logger.Info("[ConnectionService] Stored node device token");
+    }
+
+    // ── Lifecycle ──
+
+    public async Task DisconnectAsync()
+    {
+        await _transitionLock.WaitAsync();
+        try
+        {
+            _connectCts?.Cancel();
+            UnsubscribeAndDispose();
+            SetRoleState(GatewayRole.Operator, GatewayRoleState.Idle);
+            SetRoleState(GatewayRole.Node, GatewayRoleState.Disabled);
+        }
+        finally
+        {
+            _transitionLock.Release();
+        }
+    }
+
+    public async Task ReconnectAsync(CancellationToken ct = default)
+    {
+        await DisconnectAsync();
+        await ConnectOperatorAsync(ct);
+    }
+
+    public void Dispose()
+    {
+        _connectCts?.Cancel();
+        UnsubscribeAndDispose();
+        _transitionLock.Dispose();
+    }
+
+    // ── Chat credential resolution ──
+
+    /// <summary>
+    /// Resolve the best token for web dashboard (chat) auth.
+    /// Precedence: SharedGatewayToken → OperatorDeviceToken.
+    /// </summary>
+    public (string url, string token, string source)? ResolveChatCredentials()
+    {
+        var gw = _registry.GetActive();
+        if (gw == null || string.IsNullOrWhiteSpace(gw.Url)) return null;
+
+        if (!string.IsNullOrWhiteSpace(gw.SharedGatewayToken))
+            return (gw.Url, gw.SharedGatewayToken, "shared");
+        if (!string.IsNullOrWhiteSpace(gw.OperatorDeviceToken))
+            return (gw.Url, gw.OperatorDeviceToken, "operator");
+        return null;
+    }
+
+    // ── Internal ──
+
+    private void SetRoleState(GatewayRole role, GatewayRoleState newState)
+    {
+        var oldOverall = BuildSnapshot().Overall;
+
+        if (role == GatewayRole.Operator) _operatorState = newState;
+        else _nodeState = newState;
+
+        var snapshot = BuildSnapshot();
+        // Fire on every role state change so UI always reflects current state
+        StateChanged?.Invoke(oldOverall, snapshot.Overall, snapshot);
+    }
+
+    private GatewayConnectionSnapshot BuildSnapshot()
+    {
+        var gw = _registry.GetActive();
+        var hasCredential = gw != null &&
+            (!string.IsNullOrWhiteSpace(gw.OperatorDeviceToken) ||
+             !string.IsNullOrWhiteSpace(gw.BootstrapToken) ||
+             !string.IsNullOrWhiteSpace(gw.SharedGatewayToken));
+
+        return new GatewayConnectionSnapshot
+        {
+            Overall = GatewayConnectionSnapshot.DeriveOverall(_operatorState, _nodeState, hasCredential),
+            Operator = _operatorState,
+            Node = _nodeState,
+            GatewayUrl = gw?.Url,
+            LastError = _lastError,
+            PairingRequestId = _pairingRequestId,
+            PairingRole = _pairingRole,
+        };
+    }
+
+    private void SubscribeClientEvents(OpenClawGatewayClient client, int gen)
+    {
+        client.StatusChanged += (s, status) =>
+        {
+            if (_generation != gen) return; // Stale client
+            HandleOperatorStatus(status, client);
+        };
+
+        client.AuthenticationFailed += (s, msg) =>
+        {
+            if (_generation != gen) return;
+            _lastError = msg;
+            if (client.IsPairingRequired)
+            {
+                _pairingRequestId = client.PairingRequiredRequestId;
+                _pairingRole = GatewayRole.Operator;
+                SetRoleState(GatewayRole.Operator, GatewayRoleState.PairingRequired);
+            }
+            else
+            {
+                SetRoleState(GatewayRole.Operator, GatewayRoleState.Error);
+            }
+        };
+
+        // Re-fire events through stable surface
+        client.SessionsUpdated += (s, e) => { if (_generation == gen) SessionsUpdated?.Invoke(s, e); };
+        client.NodesUpdated += (s, e) => { if (_generation == gen) NodesUpdated?.Invoke(s, e); };
+        client.GatewaySelfUpdated += (s, e) => { if (_generation == gen) GatewaySelfUpdated?.Invoke(s, e); };
+        client.ChannelHealthUpdated += (s, e) => { if (_generation == gen) ChannelHealthUpdated?.Invoke(s, e); };
+        client.NotificationReceived += (s, e) => { if (_generation == gen) NotificationReceived?.Invoke(s, e); };
+        client.ActivityChanged += (s, e) => { if (_generation == gen) ActivityChanged?.Invoke(s, e); };
+    }
+
+    private void HandleOperatorStatus(ConnectionStatus status, OpenClawGatewayClient client)
+    {
+        OperatorStatusChanged?.Invoke(client, status);
+
+        switch (status)
+        {
+            case ConnectionStatus.Connected:
+                _lastError = null;
+
+                // Persist operator device token from bootstrap handoff
+                var opToken = client.OperatorDeviceToken;
+                if (!string.IsNullOrWhiteSpace(opToken))
+                    StoreOperatorDeviceToken(opToken);
+
+                SetRoleState(GatewayRole.Operator, GatewayRoleState.Connected);
+                break;
+
+            case ConnectionStatus.Connecting:
+                SetRoleState(GatewayRole.Operator, GatewayRoleState.Connecting);
+                break;
+
+            case ConnectionStatus.Error:
+                if (client.IsPairingRequired)
+                {
+                    _pairingRequestId = client.PairingRequiredRequestId;
+                    _pairingRole = GatewayRole.Operator;
+                    SetRoleState(GatewayRole.Operator, GatewayRoleState.PairingRequired);
+                }
+                else
+                {
+                    SetRoleState(GatewayRole.Operator, GatewayRoleState.Error);
+                }
+                break;
+
+            case ConnectionStatus.Disconnected:
+                SetRoleState(GatewayRole.Operator, GatewayRoleState.Idle);
+                break;
+        }
+    }
+
+    private void UnsubscribeAndDispose()
+    {
+        // Bump generation so any lingering event handlers are ignored
+        Interlocked.Increment(ref _generation);
+        _operatorClient?.Dispose();
+        _operatorClient = null;
+    }
+}

--- a/src/OpenClaw.Shared/GatewayConnectionState.cs
+++ b/src/OpenClaw.Shared/GatewayConnectionState.cs
@@ -1,0 +1,100 @@
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Connection state for a single role (operator or node).
+/// </summary>
+public enum GatewayRoleState
+{
+    /// <summary>Not configured or disabled.</summary>
+    Idle,
+    /// <summary>WebSocket handshake in progress.</summary>
+    Connecting,
+    /// <summary>Authenticated and receiving data.</summary>
+    Connected,
+    /// <summary>Gateway requires device approval before connecting.</summary>
+    PairingRequired,
+    /// <summary>Connection failed.</summary>
+    Error,
+    /// <summary>Role is not enabled (node mode off).</summary>
+    Disabled,
+}
+
+/// <summary>
+/// Overall connection state derived from operator + node role states.
+/// </summary>
+public enum GatewayConnectionState
+{
+    /// <summary>No gateway configured.</summary>
+    Idle,
+    /// <summary>Gateway URL + credential stored, not connected.</summary>
+    Configured,
+    /// <summary>At least one role is connecting.</summary>
+    Connecting,
+    /// <summary>All enabled roles are connected.</summary>
+    Ready,
+    /// <summary>At least one role requires pairing approval.</summary>
+    PairingRequired,
+    /// <summary>At least one role has an error.</summary>
+    Error,
+}
+
+/// <summary>
+/// Which role a pairing/connection event applies to.
+/// </summary>
+public enum GatewayRole
+{
+    Operator,
+    Node,
+}
+
+/// <summary>
+/// What kind of credential is being stored.
+/// </summary>
+public enum GatewayCredentialKind
+{
+    /// <summary>Gateway's shared secret (gateway.auth.token). Used for web dashboard auth.</summary>
+    SharedGatewayToken,
+    /// <summary>Single-use token from setup code for pairing.</summary>
+    BootstrapToken,
+    /// <summary>Per-device credential for operator WebSocket auth.</summary>
+    OperatorDeviceToken,
+    /// <summary>Per-device credential for node WebSocket auth.</summary>
+    NodeDeviceToken,
+}
+
+/// <summary>
+/// Snapshot of the current connection state for UI consumption.
+/// </summary>
+public sealed record GatewayConnectionSnapshot
+{
+    public GatewayConnectionState Overall { get; init; }
+    public GatewayRoleState Operator { get; init; }
+    public GatewayRoleState Node { get; init; }
+    public string? GatewayUrl { get; init; }
+    public string? LastError { get; init; }
+    public string? PairingRequestId { get; init; }
+    public GatewayRole? PairingRole { get; init; }
+
+    public static GatewayConnectionState DeriveOverall(
+        GatewayRoleState operatorState,
+        GatewayRoleState nodeState,
+        bool hasCredential)
+    {
+        if (operatorState == GatewayRoleState.Error || nodeState == GatewayRoleState.Error)
+            return GatewayConnectionState.Error;
+        if (operatorState == GatewayRoleState.PairingRequired || nodeState == GatewayRoleState.PairingRequired)
+            return GatewayConnectionState.PairingRequired;
+        if (operatorState == GatewayRoleState.Connecting || nodeState == GatewayRoleState.Connecting)
+            return GatewayConnectionState.Connecting;
+
+        var opReady = operatorState == GatewayRoleState.Connected;
+        var nodeReady = nodeState is GatewayRoleState.Connected or GatewayRoleState.Disabled;
+        if (opReady && nodeReady)
+            return GatewayConnectionState.Ready;
+
+        if (hasCredential)
+            return GatewayConnectionState.Configured;
+
+        return GatewayConnectionState.Idle;
+    }
+}

--- a/src/OpenClaw.Shared/GatewayRecord.cs
+++ b/src/OpenClaw.Shared/GatewayRecord.cs
@@ -17,6 +17,10 @@ public class GatewayRecord
     /// Transient bootstrap token for pairing. Cleared after pairing completes.
     /// </summary>
     public string? BootstrapToken { get; set; }
+    /// <summary>
+    /// The gateway's shared secret token (gateway.auth.token). Used for web dashboard auth.
+    /// </summary>
+    public string? SharedGatewayToken { get; set; }
 
     /// <summary>
     /// Generates a stable, human-readable ID from a gateway URL.
@@ -49,6 +53,7 @@ public class GatewayRecord
         OperatorDeviceToken = OperatorDeviceToken,
         NodeDeviceToken = NodeDeviceToken,
         BootstrapToken = BootstrapToken,
+        SharedGatewayToken = SharedGatewayToken,
     };
 }
 

--- a/src/OpenClaw.Shared/GatewayRecord.cs
+++ b/src/OpenClaw.Shared/GatewayRecord.cs
@@ -23,6 +23,23 @@ public class GatewayRecord
     public string? SharedGatewayToken { get; set; }
 
     /// <summary>
+    /// Base directory for per-gateway identity files. Defaults to %APPDATA%/OpenClawTray.
+    /// </summary>
+    [JsonIgnore]
+    public static string BaseIdentityDir { get; set; } = Path.Combine(
+        Environment.GetEnvironmentVariable("OPENCLAW_TRAY_APPDATA_DIR")
+            ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "OpenClawTray");
+
+    /// <summary>
+    /// Per-gateway directory for device identity (keypair + tokens).
+    /// Each gateway gets its own Ed25519 keypair so switching gateways
+    /// doesn't cause stale signature/token errors.
+    /// </summary>
+    [JsonIgnore]
+    public string IdentityPath => Path.Combine(BaseIdentityDir, "gateways", Id);
+
+    /// <summary>
     /// Generates a stable, human-readable ID from a gateway URL.
     /// Examples: ws://localhost:18789 → "localhost-18789",
     ///           wss://gw.example.com → "gw-example-com-443"

--- a/src/OpenClaw.Shared/GatewayRecord.cs
+++ b/src/OpenClaw.Shared/GatewayRecord.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Minimal record for a paired gateway. Only auth-critical fields are persisted;
+/// display metadata (name, version, uptime) comes from the gateway at connect time.
+/// </summary>
+public class GatewayRecord
+{
+    public string Id { get; set; } = "";
+    public string Url { get; set; } = "";
+    public string? OperatorDeviceToken { get; set; }
+    public string? NodeDeviceToken { get; set; }
+    /// <summary>
+    /// Transient bootstrap token for pairing. Cleared after pairing completes.
+    /// </summary>
+    public string? BootstrapToken { get; set; }
+
+    /// <summary>
+    /// Generates a stable, human-readable ID from a gateway URL.
+    /// Examples: ws://localhost:18789 → "localhost-18789",
+    ///           wss://gw.example.com → "gw-example-com-443"
+    /// </summary>
+    public static string GenerateId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return "unknown";
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            var host = uri.Host.Replace('.', '-').ToLowerInvariant();
+            var port = uri.Port > 0
+                ? uri.Port
+                : (uri.Scheme is "wss" or "https" ? 443 : 80);
+            return $"{host}-{port}";
+        }
+
+        // Fallback: sanitize raw string
+        return new string(url.Where(c => char.IsLetterOrDigit(c) || c == '-').ToArray())
+            .ToLowerInvariant();
+    }
+
+    internal GatewayRecord Clone() => new()
+    {
+        Id = Id,
+        Url = Url,
+        OperatorDeviceToken = OperatorDeviceToken,
+        NodeDeviceToken = NodeDeviceToken,
+        BootstrapToken = BootstrapToken,
+    };
+}
+
+/// <summary>
+/// Top-level JSON envelope for gateways.json.
+/// </summary>
+public class GatewayRegistryData
+{
+    public string? ActiveGatewayId { get; set; }
+    public List<GatewayRecord> Gateways { get; set; } = new();
+
+    private static readonly JsonSerializerOptions s_options = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public string ToJson() => JsonSerializer.Serialize(this, s_options);
+
+    public static GatewayRegistryData? FromJson(string? json)
+    {
+        if (string.IsNullOrEmpty(json))
+            return null;
+        try
+        {
+            return JsonSerializer.Deserialize<GatewayRegistryData>(json, s_options);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/OpenClaw.Shared/GatewayRegistry.cs
+++ b/src/OpenClaw.Shared/GatewayRegistry.cs
@@ -184,11 +184,13 @@ public class GatewayRegistry
         {
             Directory.CreateDirectory(_directory);
 
-            var tempPath = _filePath + ".tmp";
+            var tempPath = $"{_filePath}.{Guid.NewGuid():N}.tmp";
             var json = _data.ToJson();
             File.WriteAllText(tempPath, json);
             McpAuthToken.TryRestrictSensitiveFileAcl(tempPath);
             File.Move(tempPath, _filePath, overwrite: true);
+            // Re-apply ACL after move — Windows may inherit target's existing DACL
+            McpAuthToken.TryRestrictSensitiveFileAcl(_filePath);
         }
         catch (Exception)
         {

--- a/src/OpenClaw.Shared/GatewayRegistry.cs
+++ b/src/OpenClaw.Shared/GatewayRegistry.cs
@@ -82,6 +82,8 @@ public class GatewayRegistry
                     existing.OperatorDeviceToken = record.OperatorDeviceToken;
                 if (record.NodeDeviceToken != null)
                     existing.NodeDeviceToken = record.NodeDeviceToken;
+                if (record.SharedGatewayToken != null)
+                    existing.SharedGatewayToken = record.SharedGatewayToken;
                 // BootstrapToken: always overwrite (null = cleared after pairing)
                 existing.BootstrapToken = record.BootstrapToken;
             }

--- a/src/OpenClaw.Shared/GatewayRegistry.cs
+++ b/src/OpenClaw.Shared/GatewayRegistry.cs
@@ -1,0 +1,198 @@
+using System.Text.Json;
+using OpenClaw.Shared.Mcp;
+
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Manages a registry of paired gateways persisted to gateways.json.
+/// Thread-safe — all public methods are serialized via an internal lock.
+/// </summary>
+public class GatewayRegistry
+{
+    private const string FileName = "gateways.json";
+
+    private readonly string _filePath;
+    private readonly string _directory;
+    private readonly object _lock = new();
+    private GatewayRegistryData _data = new();
+
+    /// <summary>
+    /// Runtime-only connection status of the active gateway (not persisted).
+    /// </summary>
+    public ConnectionStatus ActiveConnectionStatus { get; set; }
+
+    /// <summary>
+    /// Runtime-only reference to the connected gateway client (not persisted).
+    /// </summary>
+    public OpenClawGatewayClient? ActiveClient { get; set; }
+
+    public GatewayRegistry(string dataPath)
+    {
+        if (string.IsNullOrWhiteSpace(dataPath))
+            throw new ArgumentException("Data path cannot be empty.", nameof(dataPath));
+
+        _directory = dataPath;
+        _filePath = Path.Combine(dataPath, FileName);
+        Load();
+    }
+
+    /// <summary>
+    /// Returns a clone of the active gateway record, or null if none is active.
+    /// </summary>
+    public GatewayRecord? GetActive()
+    {
+        lock (_lock)
+        {
+            var active = FindActive();
+            return active?.Clone();
+        }
+    }
+
+    /// <summary>
+    /// Sets the active gateway by ID. Returns false if the ID is not found.
+    /// </summary>
+    public bool SetActive(string id)
+    {
+        lock (_lock)
+        {
+            var gw = _data.Gateways.FirstOrDefault(g => g.Id == id);
+            if (gw == null) return false;
+            _data.ActiveGatewayId = id;
+            Save();
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Adds or updates a gateway record (matched by ID).
+    /// </summary>
+    public void AddOrUpdate(GatewayRecord record, bool setActive = true)
+    {
+        if (record == null) throw new ArgumentNullException(nameof(record));
+        if (string.IsNullOrWhiteSpace(record.Id))
+            throw new ArgumentException("Gateway record must have an Id.", nameof(record));
+
+        lock (_lock)
+        {
+            var existing = _data.Gateways.FirstOrDefault(g => g.Id == record.Id);
+            if (existing != null)
+            {
+                existing.Url = record.Url;
+                if (record.OperatorDeviceToken != null)
+                    existing.OperatorDeviceToken = record.OperatorDeviceToken;
+                if (record.NodeDeviceToken != null)
+                    existing.NodeDeviceToken = record.NodeDeviceToken;
+                // BootstrapToken: always overwrite (null = cleared after pairing)
+                existing.BootstrapToken = record.BootstrapToken;
+            }
+            else
+            {
+                _data.Gateways.Add(record.Clone());
+            }
+
+            if (setActive)
+                _data.ActiveGatewayId = record.Id;
+
+            Save();
+        }
+    }
+
+    /// <summary>
+    /// Removes a gateway by ID. Clears activeGatewayId if it was the active one.
+    /// Returns true if a record was removed.
+    /// </summary>
+    public bool Remove(string id)
+    {
+        lock (_lock)
+        {
+            var removed = _data.Gateways.RemoveAll(g => g.Id == id) > 0;
+            if (removed && _data.ActiveGatewayId == id)
+                _data.ActiveGatewayId = null;
+            if (removed)
+                Save();
+            return removed;
+        }
+    }
+
+    /// <summary>
+    /// Returns a snapshot of all gateway records.
+    /// </summary>
+    public IReadOnlyList<GatewayRecord> GetAll()
+    {
+        lock (_lock)
+        {
+            return _data.Gateways.Select(g => g.Clone()).ToList();
+        }
+    }
+
+    /// <summary>
+    /// One-time migration: creates a gateway record from existing settings if the
+    /// registry is empty. Returns true if migration occurred.
+    /// </summary>
+    public bool TryMigrateFromSettings(string? url, string? operatorToken, string? nodeDeviceToken)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return false;
+
+        lock (_lock)
+        {
+            if (_data.Gateways.Count > 0)
+                return false;
+
+            var record = new GatewayRecord
+            {
+                Id = GatewayRecord.GenerateId(url),
+                Url = url,
+                OperatorDeviceToken = string.IsNullOrWhiteSpace(operatorToken) ? null : operatorToken,
+                NodeDeviceToken = string.IsNullOrWhiteSpace(nodeDeviceToken) ? null : nodeDeviceToken,
+            };
+
+            _data.Gateways.Add(record);
+            _data.ActiveGatewayId = record.Id;
+            Save();
+            return true;
+        }
+    }
+
+    // ── Internal ──
+
+    private GatewayRecord? FindActive() =>
+        _data.Gateways.FirstOrDefault(g => g.Id == _data.ActiveGatewayId);
+
+    private void Load()
+    {
+        try
+        {
+            if (File.Exists(_filePath))
+            {
+                var json = File.ReadAllText(_filePath);
+                _data = GatewayRegistryData.FromJson(json) ?? new GatewayRegistryData();
+            }
+        }
+        catch (Exception)
+        {
+            _data = new GatewayRegistryData();
+        }
+    }
+
+    /// <summary>
+    /// Atomic save: write to temp file, then rename to avoid corruption.
+    /// </summary>
+    private void Save()
+    {
+        try
+        {
+            Directory.CreateDirectory(_directory);
+
+            var tempPath = _filePath + ".tmp";
+            var json = _data.ToJson();
+            File.WriteAllText(tempPath, json);
+            McpAuthToken.TryRestrictSensitiveFileAcl(tempPath);
+            File.Move(tempPath, _filePath, overwrite: true);
+        }
+        catch (Exception)
+        {
+            // Best-effort persistence — don't crash the app
+        }
+    }
+}

--- a/src/OpenClaw.Shared/GatewayRegistry.cs
+++ b/src/OpenClaw.Shared/GatewayRegistry.cs
@@ -95,6 +95,7 @@ public class GatewayRegistry
             if (setActive)
                 _data.ActiveGatewayId = record.Id;
 
+            EnsureIdentityDirectory(record.Id);
             Save();
         }
     }
@@ -160,6 +161,41 @@ public class GatewayRegistry
 
     private GatewayRecord? FindActive() =>
         _data.Gateways.FirstOrDefault(g => g.Id == _data.ActiveGatewayId);
+
+    private static void EnsureIdentityDirectory(string gatewayId)
+    {
+        if (string.IsNullOrWhiteSpace(gatewayId)) return;
+        var dir = Path.Combine(GatewayRecord.BaseIdentityDir, "gateways", gatewayId);
+        try { Directory.CreateDirectory(dir); } catch { }
+    }
+
+    /// <summary>
+    /// One-time migration: moves the legacy root device-key-ed25519.json into the
+    /// active gateway's per-gateway identity directory. Idempotent.
+    /// </summary>
+    public void MigrateLegacyIdentityFile()
+    {
+        lock (_lock)
+        {
+            var active = FindActive();
+            if (active == null) return;
+
+            var legacyPath = Path.Combine(GatewayRecord.BaseIdentityDir, "device-key-ed25519.json");
+            if (!File.Exists(legacyPath)) return;
+
+            var targetDir = active.IdentityPath;
+            var targetPath = Path.Combine(targetDir, "device-key-ed25519.json");
+            if (File.Exists(targetPath)) return;
+
+            try
+            {
+                Directory.CreateDirectory(targetDir);
+                File.Copy(legacyPath, targetPath);
+                File.Delete(legacyPath);
+            }
+            catch { }
+        }
+    }
 
     private void Load()
     {

--- a/src/OpenClaw.Shared/Models.cs
+++ b/src/OpenClaw.Shared/Models.cs
@@ -22,17 +22,38 @@ public enum PairingStatus
     Rejected    // Pairing was rejected
 }
 
+/// <summary>
+/// Internal state machine for node pairing. Replaces the former set of
+/// boolean flags (_isPendingApproval, _isPaired, _pairingBlocked,
+/// _pairingApprovedAwaitingReconnect) with a single source of truth.
+/// </summary>
+public enum NodePairingState
+{
+    Unknown,              // Initial or post-disconnect (not yet determined)
+    AwaitingApproval,     // Waiting for pairing approval; blocks auto-reconnect
+    ApprovedReconnecting, // Approval received; reconnecting to get device token
+    Paired,               // Fully paired (device token stored or gateway confirmed)
+    Rejected              // Pairing was rejected by the gateway
+}
+
 public class PairingStatusEventArgs : EventArgs
 {
     public PairingStatus Status { get; }
     public string DeviceId { get; }
     public string? Message { get; }
+    /// <summary>
+    /// Operator device token issued by the gateway during bootstrap pairing.
+    /// Present when the node's hello-ok includes auth.deviceTokens with role=operator.
+    /// The app should store this for the operator client to use.
+    /// </summary>
+    public string? OperatorDeviceToken { get; }
     
-    public PairingStatusEventArgs(PairingStatus status, string deviceId, string? message = null)
+    public PairingStatusEventArgs(PairingStatus status, string deviceId, string? message = null, string? operatorDeviceToken = null)
     {
         Status = status;
         DeviceId = deviceId;
         Message = message;
+        OperatorDeviceToken = operatorDeviceToken;
     }
 }
 

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -28,6 +28,17 @@ public class OpenClawGatewayClient : WebSocketClientBase
         "operator.approvals",
         "operator.pairing"
     ];
+
+    // Scopes compatible with bootstrap-issued operator device tokens.
+    // Bootstrap tokens cannot carry admin or pairing scopes.
+    private static readonly string[] s_operatorBootstrapDeviceTokenScopes =
+    [
+        "operator.approvals",
+        "operator.read",
+        "operator.write"
+    ];
+
+    // Scopes for fresh non-local or bootstrap devices (no admin/pairing).
     private static readonly string[] s_operatorBootstrapScopes =
     [
         "operator.approvals",
@@ -61,6 +72,7 @@ public class OpenClawGatewayClient : WebSocketClientBase
     private string[] _grantedOperatorScopes = Array.Empty<string>();
     private string _connectAuthToken;
     private SignatureTokenMode _signatureTokenMode = SignatureTokenMode.V3AuthToken;
+    private bool _hasOperatorDeviceToken; // True when _connectAuthToken is a device token (not shared secret)
     private long? _challengeTimestampMs;
     private string? _currentChallengeNonce;
     private bool _usageStatusUnsupported;
@@ -194,12 +206,12 @@ public class OpenClawGatewayClient : WebSocketClientBase
         _tokenIsBootstrapToken = tokenIsBootstrapToken;
         _bootstrapPairAsNode = bootstrapPairAsNode;
         _currentGatewayUrl = gatewayUrl;
-        var dataPath = Path.Combine(
+        var identityPath = Path.Combine(
             Environment.GetEnvironmentVariable("OPENCLAW_TRAY_APPDATA_DIR")
                 ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
             "OpenClawTray");
 
-        _deviceIdentity = new DeviceIdentity(dataPath, _logger);
+        _deviceIdentity = new DeviceIdentity(identityPath, _logger);
         _deviceIdentity.Initialize();
         _connectAuthToken = _deviceIdentity.DeviceToken ?? (_tokenIsBootstrapToken ? string.Empty : _token);
     }
@@ -1022,7 +1034,8 @@ public class OpenClawGatewayClient : WebSocketClientBase
                     : TryGetHandshakeDeviceTokenScopesCore(payload, preferredRole: null);
                 _deviceIdentity.StoreDeviceTokenWithScopes(newDeviceToken, deviceTokenScopes);
                 _connectAuthToken = newDeviceToken;
-                _logger.Info("Operator device token stored for reconnect");
+                _hasOperatorDeviceToken = true;
+                _logger.Info("Operator device token received for reconnect");
             }
 
             _logger.Info("Handshake complete (hello-ok)");
@@ -1393,6 +1406,7 @@ public class OpenClawGatewayClient : WebSocketClientBase
     private static bool IsTerminalAuthError(string errorMessage)
     {
         return errorMessage.Contains("token mismatch", StringComparison.OrdinalIgnoreCase) ||
+               errorMessage.Contains("bootstrap token invalid", StringComparison.OrdinalIgnoreCase) ||
                errorMessage.Contains("origin not allowed", StringComparison.OrdinalIgnoreCase) ||
                errorMessage.Contains("too many failed", StringComparison.OrdinalIgnoreCase);
     }

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -73,6 +73,11 @@ public class OpenClawGatewayClient : WebSocketClientBase
     private string _connectAuthToken;
     private SignatureTokenMode _signatureTokenMode = SignatureTokenMode.V3AuthToken;
     private bool _hasOperatorDeviceToken; // True when _connectAuthToken is a device token (not shared secret)
+
+    /// <summary>
+    /// The operator's device token, if one was issued during bootstrap handoff.
+    /// </summary>
+    public string? OperatorDeviceToken => _hasOperatorDeviceToken ? _connectAuthToken : null;
     private long? _challengeTimestampMs;
     private string? _currentChallengeNonce;
     private bool _usageStatusUnsupported;

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -72,7 +72,12 @@ public class OpenClawGatewayClient : WebSocketClientBase
     private string[] _grantedOperatorScopes = Array.Empty<string>();
     private string _connectAuthToken;
     private SignatureTokenMode _signatureTokenMode = SignatureTokenMode.V3AuthToken;
-    private bool _hasOperatorDeviceToken; // True when _connectAuthToken is a device token (not shared secret)
+    private bool _hasOperatorDeviceToken;
+
+    /// <summary>
+    /// Optional diagnostics collector. Set before connecting to capture events.
+    /// </summary>
+    public ConnectionDiagnostics? Diagnostics { get; set; }
 
     /// <summary>
     /// The operator's device token, if one was issued during bootstrap handoff.
@@ -205,18 +210,18 @@ public class OpenClawGatewayClient : WebSocketClientBase
     public IReadOnlyList<string> GrantedOperatorScopes => _grantedOperatorScopes;
     public bool IsConnectedToGateway => IsConnected;
 
-    public OpenClawGatewayClient(string gatewayUrl, string token, IOpenClawLogger? logger = null, bool tokenIsBootstrapToken = false, bool bootstrapPairAsNode = false)
+    public OpenClawGatewayClient(string gatewayUrl, string token, IOpenClawLogger? logger = null, bool tokenIsBootstrapToken = false, bool bootstrapPairAsNode = false, string? identityPath = null)
         : base(gatewayUrl, token, logger)
     {
         _tokenIsBootstrapToken = tokenIsBootstrapToken;
         _bootstrapPairAsNode = bootstrapPairAsNode;
         _currentGatewayUrl = gatewayUrl;
-        var identityPath = Path.Combine(
+        var effectiveIdentityPath = identityPath ?? Path.Combine(
             Environment.GetEnvironmentVariable("OPENCLAW_TRAY_APPDATA_DIR")
                 ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
             "OpenClawTray");
 
-        _deviceIdentity = new DeviceIdentity(identityPath, _logger);
+        _deviceIdentity = new DeviceIdentity(effectiveIdentityPath, _logger);
         _deviceIdentity.Initialize();
         _connectAuthToken = _deviceIdentity.DeviceToken ?? (_tokenIsBootstrapToken ? string.Empty : _token);
     }
@@ -699,6 +704,9 @@ public class OpenClawGatewayClient : WebSocketClientBase
 
         try
         {
+            Diagnostics?.RecordAuthSent(
+                _tokenIsBootstrapToken ? "bootstrap" : (!string.IsNullOrEmpty(_deviceIdentity.DeviceToken) ? "device" : "shared"),
+                requestedScopes, _signatureTokenMode.ToString(), _deviceIdentity.DeviceId);
             await SendRawAsync(JsonSerializer.Serialize(msg));
         }
         catch
@@ -1044,6 +1052,7 @@ public class OpenClawGatewayClient : WebSocketClientBase
             }
 
             _logger.Info("Handshake complete (hello-ok)");
+            Diagnostics?.RecordHelloOk(_grantedOperatorScopes, newDeviceToken);
             if (!string.IsNullOrWhiteSpace(_operatorDeviceId))
             {
                 _logger.Info($"Operator device ID: {_operatorDeviceId}");
@@ -1211,11 +1220,13 @@ public class OpenClawGatewayClient : WebSocketClientBase
             if (_signatureTokenMode != previousMode)
             {
                 _logger.Warn($"Gateway rejected device signature with mode {previousMode}; retrying with mode {_signatureTokenMode}");
+                Diagnostics?.RecordSignatureRejected(previousMode.ToString(), _signatureTokenMode.ToString());
                 _ = SendConnectMessageAsync(_currentChallengeNonce);
                 return;
             }
 
             _logger.Warn("Gateway rejected device signature in all supported payload modes");
+            Diagnostics?.RecordAuthFailed("device signature rejected in all modes");
             _authFailed = true;
             RaiseAuthenticationFailed("device signature rejected in all modes — the gateway may require a different auth protocol version");
             RaiseStatusChanged(ConnectionStatus.Error);
@@ -1229,6 +1240,7 @@ public class OpenClawGatewayClient : WebSocketClientBase
             _pairingRequiredAwaitingApproval = true;
             _pairingRequiredRequestId = pairingDetails.RequestId;
             _logger.Warn("Pairing approval required for this device; auto-reconnect paused until manual reconnect or app restart");
+            Diagnostics?.RecordPairingRequired(pairingDetails.RequestId, message);
             RaiseStatusChanged(ConnectionStatus.Error);
             return;
         }
@@ -1237,6 +1249,7 @@ public class OpenClawGatewayClient : WebSocketClientBase
         if (method == "connect" && IsTerminalAuthError(message))
         {
             _authFailed = true;
+            Diagnostics?.RecordAuthFailed(message);
             RaiseAuthenticationFailed(message);
             RaiseStatusChanged(ConnectionStatus.Error);
             return;
@@ -1755,6 +1768,7 @@ public class OpenClawGatewayClient : WebSocketClientBase
         _currentChallengeNonce = nonce;
         
         _logger.Info($"Received challenge, nonce: {nonce}");
+        Diagnostics?.RecordChallenge(nonce);
         _ = SendConnectMessageAsync(nonce);
     }
 

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -633,16 +633,16 @@ public class WindowsNodeClient : WebSocketClientBase
             // PairingStatusChanged when the gateway includes auth.deviceToken in hello-ok.
             bool gotNewToken = false;
             string? operatorDeviceToken = null;
+            string? nodeDeviceToken = null;
             if (payload.TryGetProperty("auth", out var authPayload))
             {
                 // Extract node device token
                 if (authPayload.TryGetProperty("deviceToken", out var deviceTokenProp))
                 {
-                    var deviceToken = deviceTokenProp.GetString();
-                    if (!string.IsNullOrEmpty(deviceToken))
+                    nodeDeviceToken = deviceTokenProp.GetString();
+                    if (!string.IsNullOrEmpty(nodeDeviceToken))
                     {
                         gotNewToken = true;
-                        _deviceIdentity.StoreDeviceToken(deviceToken);
                     }
                 }
 
@@ -670,7 +670,7 @@ public class WindowsNodeClient : WebSocketClientBase
                     var wasWaiting = _pairingState is NodePairingState.AwaitingApproval or NodePairingState.ApprovedReconnecting;
                     _pairingState = NodePairingState.Paired;
                     _logger.Info("Received device token - we are now paired!");
-                    _deviceIdentity.StoreDeviceTokenForRole("node", deviceToken, TryGetAuthScopes(authPayload));
+                    _deviceIdentity.StoreDeviceTokenForRole("node", nodeDeviceToken!, TryGetAuthScopes(authPayload));
                     EmitPairingStatusOnTransition(new PairingStatusEventArgs(
                         PairingStatus.Paired,
                         _deviceIdentity.DeviceId,

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -26,13 +26,7 @@ public class WindowsNodeClient : WebSocketClientBase
     private bool _isConnected;
     private string? _nodeId;
     private string? _pendingNonce;  // Store nonce from challenge for signing
-    private bool _isPendingApproval;  // True when connected but awaiting pairing approval
-    private bool _isPaired;
-    // Bridges the gap between an approval event and the next hello-ok when the gateway omits auth.deviceToken.
-    private bool _pairingApprovedAwaitingReconnect;
-    // Persists across disconnect/error so ShouldAutoReconnect can block reconnect
-    // even after OnDisconnected clears _isPendingApproval.
-    private volatile bool _pairingBlocked;
+    private NodePairingState _pairingState = NodePairingState.Unknown;
     private volatile bool _rateLimited;
     // Bug 3: source-side idempotency for PairingStatusChanged. HandleHelloOk runs on every
     // WS reconnect and re-fires PairingStatus.Paired even when nothing changed, causing a
@@ -62,10 +56,11 @@ public class WindowsNodeClient : WebSocketClientBase
     public IReadOnlyList<INodeCapability> Capabilities => _capabilities;
     
     /// <summary>True if connected but waiting for pairing approval on gateway</summary>
-    public bool IsPendingApproval => _isPendingApproval;
+    public bool IsPendingApproval => _pairingState == NodePairingState.AwaitingApproval;
     
     /// <summary>True if device is paired via a stored token or an explicit gateway approval event.</summary>
-    public bool IsPaired => _isPaired || !string.IsNullOrEmpty(_deviceIdentity.NodeDeviceToken);
+    public bool IsPaired => _pairingState is NodePairingState.Paired or NodePairingState.ApprovedReconnecting
+        || !string.IsNullOrEmpty(_deviceIdentity.NodeDeviceToken);
     
     /// <summary>Device ID for display/approval (first 16 chars of full ID)</summary>
     public string ShortDeviceId => _deviceIdentity.DeviceId.Length > 16 
@@ -297,15 +292,12 @@ public class WindowsNodeClient : WebSocketClientBase
             return;
         }
 
-        if (!PayloadTargetsCurrentDevice(payload) || _isPendingApproval)
+        if (!PayloadTargetsCurrentDevice(payload) || _pairingState == NodePairingState.AwaitingApproval)
         {
             return;
         }
 
-        _isPendingApproval = true;
-        _isPaired = false;
-        _pairingBlocked = true;
-        _pairingApprovedAwaitingReconnect = false;
+        _pairingState = NodePairingState.AwaitingApproval;
 
         _logger.Info($"[NODE] Pairing requested for this device via {eventType}");
         _logger.Info($"To approve, run: openclaw devices approve {_deviceIdentity.DeviceId}");
@@ -336,10 +328,7 @@ public class WindowsNodeClient : WebSocketClientBase
 
         if (string.Equals(decision, "approved", StringComparison.OrdinalIgnoreCase))
         {
-            _isPendingApproval = false;
-            _isPaired = true;
-            _pairingBlocked = false; // Allow reconnect after approval
-            _pairingApprovedAwaitingReconnect = true;
+            _pairingState = NodePairingState.ApprovedReconnecting;
 
             EmitPairingStatusOnTransition(new PairingStatusEventArgs(
                 PairingStatus.Paired,
@@ -353,9 +342,7 @@ public class WindowsNodeClient : WebSocketClientBase
 
         if (string.Equals(decision, "rejected", StringComparison.OrdinalIgnoreCase))
         {
-            _isPendingApproval = false;
-            _isPaired = false;
-            _pairingApprovedAwaitingReconnect = false;
+            _pairingState = NodePairingState.Rejected;
 
             EmitPairingStatusOnTransition(new PairingStatusEventArgs(
                 PairingStatus.Rejected,
@@ -630,7 +617,7 @@ public class WindowsNodeClient : WebSocketClientBase
         if (payload.TryGetProperty("type", out var t) && t.GetString() == "hello-ok")
         {
             PublishGatewaySelf(GatewaySelfInfo.FromHelloOk(payload));
-            var reconnectingAfterApproval = _pairingApprovedAwaitingReconnect;
+            var wasReconnectingAfterApproval = _pairingState == NodePairingState.ApprovedReconnecting;
             _isConnected = true;
             _rateLimited = false; // Clear transient rate-limit on successful connect
             ResetReconnectAttempts();
@@ -645,23 +632,50 @@ public class WindowsNodeClient : WebSocketClientBase
             // Use gotNewToken to guard the fallback check below and avoid a double-fire of
             // PairingStatusChanged when the gateway includes auth.deviceToken in hello-ok.
             bool gotNewToken = false;
-            if (payload.TryGetProperty("auth", out var authPayload) &&
-                authPayload.TryGetProperty("deviceToken", out var deviceTokenProp))
+            string? operatorDeviceToken = null;
+            if (payload.TryGetProperty("auth", out var authPayload))
             {
-                var deviceToken = deviceTokenProp.GetString();
-                if (!string.IsNullOrEmpty(deviceToken))
+                // Extract node device token
+                if (authPayload.TryGetProperty("deviceToken", out var deviceTokenProp))
                 {
-                    gotNewToken = true;
-                    var wasWaiting = _isPendingApproval || reconnectingAfterApproval;
-                    _isPendingApproval = false;
-                    _isPaired = true;
-                    _pairingApprovedAwaitingReconnect = false;
+                    var deviceToken = deviceTokenProp.GetString();
+                    if (!string.IsNullOrEmpty(deviceToken))
+                    {
+                        gotNewToken = true;
+                        _deviceIdentity.StoreDeviceToken(deviceToken);
+                    }
+                }
+
+                // Extract operator device token from deviceTokens array (bootstrap handoff)
+                if (authPayload.TryGetProperty("deviceTokens", out var deviceTokensArray) &&
+                    deviceTokensArray.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var entry in deviceTokensArray.EnumerateArray())
+                    {
+                        if (entry.TryGetProperty("role", out var roleProp) &&
+                            string.Equals(roleProp.GetString(), "operator", StringComparison.OrdinalIgnoreCase) &&
+                            entry.TryGetProperty("deviceToken", out var opTokenProp))
+                        {
+                            operatorDeviceToken = opTokenProp.GetString();
+                            if (!string.IsNullOrEmpty(operatorDeviceToken))
+                            {
+                                _logger.Info($"Received operator device token from bootstrap handoff (len={operatorDeviceToken.Length}, prefix={operatorDeviceToken[..Math.Min(8, operatorDeviceToken.Length)]})");
+                            }
+                        }
+                    }
+                }
+
+                if (gotNewToken)
+                {
+                    var wasWaiting = _pairingState is NodePairingState.AwaitingApproval or NodePairingState.ApprovedReconnecting;
+                    _pairingState = NodePairingState.Paired;
                     _logger.Info("Received device token - we are now paired!");
                     _deviceIdentity.StoreDeviceTokenForRole("node", deviceToken, TryGetAuthScopes(authPayload));
                     EmitPairingStatusOnTransition(new PairingStatusEventArgs(
                         PairingStatus.Paired,
                         _deviceIdentity.DeviceId,
-                        wasWaiting ? "Pairing approved!" : null));
+                        wasWaiting ? "Pairing approved!" : null,
+                        operatorDeviceToken));
                 }
             }
             
@@ -673,18 +687,14 @@ public class WindowsNodeClient : WebSocketClientBase
             {
                     if (string.IsNullOrEmpty(_deviceIdentity.NodeDeviceToken))
                 {
-                    if (reconnectingAfterApproval)
+                    if (wasReconnectingAfterApproval)
                     {
-                        _isPendingApproval = false;
-                        _isPaired = true;
-                        _pairingApprovedAwaitingReconnect = false;
+                        _pairingState = NodePairingState.Paired;
                         _logger.Info("Gateway accepted the node after pairing approval without returning a device token.");
                     }
                     else
                     {
-                        _isPendingApproval = true;
-                        _isPaired = false;
-                        _pairingBlocked = true;
+                        _pairingState = NodePairingState.AwaitingApproval;
                         _logger.Info("Not yet paired - check 'openclaw devices list' for pending approval");
                         _logger.Info($"To approve, run: openclaw devices approve {_deviceIdentity.DeviceId}");
                         EmitPairingStatusOnTransition(new PairingStatusEventArgs(
@@ -695,9 +705,7 @@ public class WindowsNodeClient : WebSocketClientBase
                 }
                 else
                 {
-                    _isPendingApproval = false;
-                    _isPaired = true;
-                    _pairingApprovedAwaitingReconnect = false;
+                    _pairingState = NodePairingState.Paired;
                     _logger.Info("Already paired with stored device token");
                     EmitPairingStatusOnTransition(new PairingStatusEventArgs(
                         PairingStatus.Paired, 
@@ -757,15 +765,12 @@ public class WindowsNodeClient : WebSocketClientBase
 
         if (string.Equals(errorCode, "NOT_PAIRED", StringComparison.OrdinalIgnoreCase))
         {
-            if (_isPendingApproval)
+            if (_pairingState == NodePairingState.AwaitingApproval)
             {
                 return;
             }
 
-            _isPendingApproval = true;
-            _isPaired = false;
-            _pairingBlocked = true;
-            _pairingApprovedAwaitingReconnect = false;
+            _pairingState = NodePairingState.AwaitingApproval;
 
             var detail = !string.IsNullOrWhiteSpace(pairingRequestId)
                 ? $"Device {ShortDeviceId} requires approval (request {pairingRequestId})"
@@ -1071,8 +1076,7 @@ public class WindowsNodeClient : WebSocketClientBase
     {
         // Don't reconnect while awaiting pairing approval — each reconnect
         // generates a new pairing request on the gateway, causing a storm.
-        // _pairingBlocked survives OnDisconnected (which clears _isPendingApproval).
-        if (_pairingBlocked)
+        if (_pairingState == NodePairingState.AwaitingApproval)
             return false;
 
         if (_rateLimited)
@@ -1084,14 +1088,20 @@ public class WindowsNodeClient : WebSocketClientBase
     protected override void OnDisconnected()
     {
         _isConnected = false;
-        _isPendingApproval = false;
-        _isPaired = false;
+        // Preserve AwaitingApproval and ApprovedReconnecting across disconnects
+        // so reconnect is still blocked/allowed correctly.
+        if (_pairingState is not NodePairingState.AwaitingApproval and not NodePairingState.ApprovedReconnecting)
+        {
+            _pairingState = NodePairingState.Unknown;
+        }
     }
 
     protected override void OnError(Exception ex)
     {
         _isConnected = false;
-        _isPendingApproval = false;
-        _isPaired = false;
+        if (_pairingState is not NodePairingState.AwaitingApproval and not NodePairingState.ApprovedReconnecting)
+        {
+            _pairingState = NodePairingState.Unknown;
+        }
     }
 }

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -26,7 +26,7 @@ public class WindowsNodeClient : WebSocketClientBase
     private bool _isConnected;
     private string? _nodeId;
     private string? _pendingNonce;  // Store nonce from challenge for signing
-    private NodePairingState _pairingState = NodePairingState.Unknown;
+    private volatile NodePairingState _pairingState = NodePairingState.Unknown;
     private volatile bool _rateLimited;
     // Bug 3: source-side idempotency for PairingStatusChanged. HandleHelloOk runs on every
     // WS reconnect and re-fires PairingStatus.Paired even when nothing changed, causing a

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1044,8 +1044,8 @@ public partial class App : Application
         };
         menu.AddCustomElement(gwGrid);
 
-        // ── Sessions ──
-        if (_lastSessions.Length > 0)
+        // ── Sessions (only when connected) ──
+        if (_currentStatus == ConnectionStatus.Connected && _lastSessions.Length > 0)
         {
             menu.AddSeparator();
 
@@ -1074,8 +1074,8 @@ public partial class App : Application
             menu.AddMenuItem($"⚠️ Pairing approval pending ({total})", "🔗", "hub");
         }
 
-        // ── Connected Devices with inline permission toggles ──
-        if (_lastNodes.Length > 0)
+        // ── Connected Devices (only when connected) ──
+        if (_currentStatus == ConnectionStatus.Connected && _lastNodes.Length > 0)
         {
             menu.AddSeparator();
 
@@ -1999,6 +1999,26 @@ public partial class App : Application
             _hubWindow?.UpdateStatus(_currentStatus);
             UpdateTrayIcon();
             _dispatcherQueue?.TryEnqueue(UpdateStatusDetailWindow);
+
+            // Clear stale gateway data when disconnected
+            if (status == ConnectionStatus.Disconnected || status == ConnectionStatus.Error)
+            {
+                _lastSessions = Array.Empty<SessionInfo>();
+                _lastChannels = Array.Empty<ChannelHealth>();
+                _lastNodes = Array.Empty<GatewayNodeInfo>();
+                _lastNodePairList = null;
+                _lastDevicePairList = null;
+                _lastModelsList = null;
+                _lastGatewaySelf = null;
+            }
+        }
+
+        // Clear stale auth errors when node connects successfully
+        if (status == ConnectionStatus.Connected)
+        {
+            _authFailureMessage = null;
+            if (_hubWindow != null && !_hubWindow.IsClosed)
+                _hubWindow.LastAuthError = null;
         }
 
         // Keep hub node state in sync for ConnectionPage
@@ -2094,30 +2114,47 @@ public partial class App : Application
                 }
 
                 // If the gateway issued a role-specific operator device token during
-                // bootstrap pairing, store it in Settings.Token for the operator client
-                // AND for chat/dashboard HTTP auth (gateway accepts device tokens for both).
+                // bootstrap pairing, store it in Settings.Token AND the identity file.
                 if (!string.IsNullOrWhiteSpace(args.OperatorDeviceToken) && _settings != null)
                 {
                     Logger.Info("Storing operator device token from bootstrap handoff");
                     _settings.Token = args.OperatorDeviceToken;
-                    _settings.BootstrapToken = ""; // Bootstrap consumed — clear it
-                    _settings.Save();
+                    DeviceIdentity.StoreOperatorDeviceToken(DataPath, args.OperatorDeviceToken, new AppLogger());
+                }
 
-                    // Reset chat window so it picks up the new token
+                // Always clear consumed bootstrap token after node pairs
+                if (_settings != null && !string.IsNullOrWhiteSpace(_settings.BootstrapToken))
+                {
+                    _settings.BootstrapToken = "";
+                }
+
+                // If no operator token from gateway, try the stored one from a previous session
+                if (string.IsNullOrWhiteSpace(_settings?.Token))
+                {
+                    var storedOpToken = DeviceIdentity.TryReadStoredOperatorDeviceToken(DataPath);
+                    if (!string.IsNullOrWhiteSpace(storedOpToken) && _settings != null)
+                    {
+                        Logger.Info("Using stored operator device token from previous session");
+                        _settings.Token = storedOpToken;
+                    }
+                }
+
+                _settings?.Save();
+
+                // Reinitialize operator client — dispatch to UI thread
+                _dispatcherQueue?.TryEnqueue(() =>
+                {
                     if (_chatWindow != null)
                     {
                         _chatWindow.ForceClose();
                         _chatWindow = null;
                     }
-                }
-
-                // Reinitialize operator client so it picks up the operator device token.
-                if (_gatewayClient == null || !_gatewayClient.IsConnectedToGateway)
-                {
-                    Logger.Info("Node paired — reinitializing operator client with operator device token");
-                    _dispatcherQueue?.TryEnqueue(() => InitializeGatewayClient());
-                }
-                }
+                    if (_gatewayClient == null || !_gatewayClient.IsConnectedToGateway)
+                    {
+                        Logger.Info("Node paired — reinitializing operator client");
+                        InitializeGatewayClient();
+                    }
+                });
             }
             else if (args.Status == OpenClaw.Shared.PairingStatus.Rejected)
             {
@@ -2139,6 +2176,9 @@ public partial class App : Application
     /// </summary>
     private void SyncHubNodeState()
     {
+        // Update tray icon/tooltip to reflect pairing state
+        UpdateTrayIcon();
+
         if (_hubWindow == null || _hubWindow.IsClosed) return;
         if (_nodeService != null)
         {
@@ -2155,6 +2195,10 @@ public partial class App : Application
             _hubWindow.NodeIsPaired = false;
             _hubWindow.NodeIsPendingApproval = false;
         }
+
+        // Refresh the hub's status display so ConnectionPage, HomePage,
+        // and the title bar all reflect the current pairing state.
+        _hubWindow.UpdateStatus(_currentStatus);
     }
 
     public static string BuildPairingApprovalCommand(string deviceId) =>
@@ -2817,8 +2861,18 @@ public partial class App : Application
             $"OpenClaw Tray — {_currentStatus}",
             $"Topology: {topology.DisplayName}",
             $"Channels: {channelReady}/{_lastChannels.Length} ready · Nodes: {nodeOnline}/{nodeTotal} online",
-            $"Warnings: {warningCount} · Last check: {_lastCheckTime:HH:mm:ss}"
         };
+
+        if (_nodeService != null)
+        {
+            var pairingText = _nodeService.IsPaired ? "Paired"
+                : _nodeService.IsPendingApproval ? "Pending approval"
+                : _nodeService.IsConnected ? "Connected (not paired)"
+                : "Disconnected";
+            tooltip.Add($"Node: {pairingText}");
+        }
+
+        tooltip.Add($"Warnings: {warningCount} · Last check: {_lastCheckTime:HH:mm:ss}");
 
         if (_currentActivity != null && !string.IsNullOrEmpty(_currentActivity.DisplayText))
         {

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -94,6 +94,7 @@ public partial class App : Application
     public void ReinitializeGatewayClient(bool useBootstrapHandoffAuth = false) =>
         InitializeGatewayClient(useBootstrapHandoffAuth);
     private SettingsManager? _settings;
+    private GatewayRegistry? _gatewayRegistry;
     private SshTunnelService? _sshTunnelService;
     private GlobalHotkeyService? _globalHotkey;
     private Mutex? _mutex;
@@ -101,7 +102,20 @@ public partial class App : Application
     private CancellationTokenSource? _deepLinkCts;
     private bool _isExiting;
     
-    private ConnectionStatus _currentStatus = ConnectionStatus.Disconnected;
+    private ConnectionStatus _currentStatusBacking = ConnectionStatus.Disconnected;
+    private ConnectionStatus _currentStatus
+    {
+        get => _currentStatusBacking;
+        set
+        {
+            _currentStatusBacking = value;
+            if (_gatewayRegistry != null)
+            {
+                _gatewayRegistry.ActiveConnectionStatus = value;
+                _gatewayRegistry.ActiveClient = _gatewayClient;
+            }
+        }
+    }
     private AgentActivity? _currentActivity;
     private ChannelHealth[] _lastChannels = Array.Empty<ChannelHealth>();
     private SessionInfo[] _lastSessions = Array.Empty<SessionInfo>();
@@ -364,6 +378,19 @@ public partial class App : Application
 
         // Initialize settings before update check so skip selections can be remembered.
         _settings = new SettingsManager();
+
+        // Initialize gateway registry (migrates from settings on first run)
+        _gatewayRegistry = new GatewayRegistry(DataPath);
+        if (_gatewayRegistry.GetAll().Count == 0)
+        {
+            var storedOpToken = DeviceIdentity.TryReadStoredOperatorDeviceToken(DataPath);
+            var storedNodeToken = DeviceIdentity.TryReadStoredDeviceToken(DataPath);
+            _gatewayRegistry.TryMigrateFromSettings(
+                _settings.GatewayUrl,
+                storedOpToken ?? (string.IsNullOrWhiteSpace(_settings.Token) ? null : _settings.Token),
+                storedNodeToken);
+        }
+
         DiagnosticsJsonlService.Configure(DataPath);
         DiagnosticsJsonlService.Write("app.start", new
         {
@@ -938,7 +965,7 @@ public partial class App : Application
             var detailParts = new List<string>();
             if (_lastGatewaySelf != null && !string.IsNullOrEmpty(_lastGatewaySelf.ServerVersion))
                 detailParts.Add($"v{_lastGatewaySelf.ServerVersion}");
-            var url = _settings?.GetEffectiveGatewayUrl();
+            var url = GetActiveGatewayUrl();
             if (!string.IsNullOrEmpty(url) && Uri.TryCreate(url, UriKind.Absolute, out var uri))
                 detailParts.Add($"{uri.Host}:{uri.Port}");
             if (_lastPresence != null && _lastPresence.Length > 0)
@@ -1639,8 +1666,7 @@ public partial class App : Application
         if (_settings == null) return;
         if (!EnsureSshTunnelConfigured()) return;
 
-        // Guard against empty gateway URL (e.g., fresh install before onboarding)
-        var gatewayUrl = _settings.GetEffectiveGatewayUrl();
+        var gatewayUrl = GetActiveGatewayUrl();
         if (string.IsNullOrWhiteSpace(gatewayUrl))
         {
             Logger.Info("Gateway URL not configured — skipping client initialization");
@@ -1763,8 +1789,6 @@ public partial class App : Application
             return;
         }
 
-        // Surface gateway-disabled fallback so the user isn't surprised when
-        // they enabled both but only MCP comes up.
         if (enableNode && !canRunGateway && enableMcp)
         {
             Logger.Warn("Node mode enabled but gateway auth is missing — running MCP-only.");
@@ -1788,10 +1812,12 @@ public partial class App : Application
             _nodeService.GatewaySelfUpdated += OnGatewaySelfUpdated;
             _nodeService.RecordingStateChanged += OnRecordingStateChanged;
 
-            if (canRunGateway)
+            if (canRunGateway && !string.IsNullOrWhiteSpace(gatewayUrl))
             {
+                // Use node device token if available, fall back to operator token
+                var nodeToken = activeGw?.NodeDeviceToken ?? activeGw?.OperatorDeviceToken ?? "";
                 Logger.Info($"Initializing Windows Node service (gateway{(enableMcp ? " + MCP" : "")})...");
-                _ = _nodeService.ConnectAsync(_settings.GetEffectiveGatewayUrl(), _settings.Token, _settings.BootstrapToken);
+                _ = _nodeService.ConnectAsync(gatewayUrl, nodeToken, activeGw?.BootstrapToken);
             }
             else
             {
@@ -1987,6 +2013,26 @@ public partial class App : Application
         return _settings?.EnableNodeMode == true || _settings?.EnableMcpServer == true;
     }
 
+    /// <summary>
+    /// Gets the effective gateway URL from the registry.
+    /// Applies SSH tunnel override if enabled.
+    /// </summary>
+    private string? GetActiveGatewayUrl()
+    {
+        var gw = _gatewayRegistry?.GetActive();
+        var baseUrl = gw?.Url;
+        if (string.IsNullOrWhiteSpace(baseUrl)) return null;
+        if (_settings?.UseSshTunnel == true)
+            return $"ws://127.0.0.1:{_settings.SshTunnelLocalPort}";
+        return baseUrl;
+    }
+
+    /// <summary>
+    /// Gets the operator token from the registry.
+    /// </summary>
+    private string? GetActiveOperatorToken() =>
+        _gatewayRegistry?.GetActive()?.OperatorDeviceToken;
+
     private void OnNodeStatusChanged(object? sender, ConnectionStatus status)
     {
         Logger.Info($"Node status: {status}");
@@ -2113,33 +2159,30 @@ public partial class App : Application
                     Logger.Info($"Suppressing duplicate Paired toast for device {deviceKey}");
                 }
 
-                // If the gateway issued a role-specific operator device token during
-                // bootstrap pairing, store it in Settings.Token AND the identity file.
-                if (!string.IsNullOrWhiteSpace(args.OperatorDeviceToken) && _settings != null)
+                // Store tokens in the gateway registry — this is the only place
+                // gateway records are created, ensuring only successfully paired
+                // gateways appear in the registry.
+                if (_gatewayRegistry != null)
                 {
-                    Logger.Info("Storing operator device token from bootstrap handoff");
-                    _settings.Token = args.OperatorDeviceToken;
-                    DeviceIdentity.StoreOperatorDeviceToken(DataPath, args.OperatorDeviceToken, new AppLogger());
-                }
+                    var activeGw = _gatewayRegistry.GetActive();
 
-                // Always clear consumed bootstrap token after node pairs
-                if (_settings != null && !string.IsNullOrWhiteSpace(_settings.BootstrapToken))
-                {
-                    _settings.BootstrapToken = "";
-                }
-
-                // If no operator token from gateway, try the stored one from a previous session
-                if (string.IsNullOrWhiteSpace(_settings?.Token))
-                {
-                    var storedOpToken = DeviceIdentity.TryReadStoredOperatorDeviceToken(DataPath);
-                    if (!string.IsNullOrWhiteSpace(storedOpToken) && _settings != null)
+                    if (activeGw != null)
                     {
-                        Logger.Info("Using stored operator device token from previous session");
-                        _settings.Token = storedOpToken;
+                        if (!string.IsNullOrWhiteSpace(args.OperatorDeviceToken))
+                        {
+                            Logger.Info("Storing operator device token from bootstrap handoff");
+                            activeGw.OperatorDeviceToken = args.OperatorDeviceToken;
+                            // Only clear bootstrap token once we have a proper operator token
+                            activeGw.BootstrapToken = null;
+                        }
+
+                        var nodeToken = DeviceIdentity.TryReadStoredDeviceToken(DataPath);
+                        if (!string.IsNullOrWhiteSpace(nodeToken))
+                            activeGw.NodeDeviceToken = nodeToken;
+
+                        _gatewayRegistry.AddOrUpdate(activeGw);
                     }
                 }
-
-                _settings?.Save();
 
                 // Reinitialize operator client — dispatch to UI thread
                 _dispatcherQueue?.TryEnqueue(() =>
@@ -2288,6 +2331,23 @@ public partial class App : Application
             _authFailureMessage = null;
             if (_hubWindow != null && !_hubWindow.IsClosed)
                 _hubWindow.LastAuthError = null;
+
+            // Persist operator device token from bootstrap handoff to the registry
+            if (_gatewayRegistry != null && _gatewayClient != null)
+            {
+                var activeGw = _gatewayRegistry.GetActive();
+                if (activeGw != null && string.IsNullOrWhiteSpace(activeGw.OperatorDeviceToken))
+                {
+                    var opToken = _gatewayClient.OperatorDeviceToken;
+                    if (!string.IsNullOrWhiteSpace(opToken))
+                    {
+                        Logger.Info("Persisting operator device token from handoff to registry");
+                        activeGw.OperatorDeviceToken = opToken;
+                        activeGw.BootstrapToken = null;
+                        _gatewayRegistry.AddOrUpdate(activeGw);
+                    }
+                }
+            }
         }
 
         // Clear stale data when disconnected so tray menu doesn't show old sessions/nodes
@@ -2892,8 +2952,7 @@ public partial class App : Application
         {
             _hubWindow = new HubWindow();
             _hubWindow.Settings = _settings;
-            _hubWindow.GatewayClient = _gatewayClient;
-            _hubWindow.CurrentStatus = _currentStatus;
+            _hubWindow.GatewayRegistry = _gatewayRegistry;
             _hubWindow.OpenDashboardAction = OpenDashboard;
             _hubWindow.CheckForUpdatesAction = () => _ = CheckForUpdatesUserInitiatedAsync();
             _hubWindow.QuickSendAction = () => ShowQuickSend();
@@ -2942,10 +3001,8 @@ public partial class App : Application
             // Navigate to default page now that properties and data are set
             _hubWindow.NavigateToDefault();
         }
-        // Always update live state
         _hubWindow.Settings = _settings;
-        _hubWindow.GatewayClient = _gatewayClient;
-        _hubWindow.CurrentStatus = _currentStatus;
+        _hubWindow.GatewayRegistry = _gatewayRegistry;
         _hubWindow.VoiceServiceInstance = _nodeService?.VoiceService ?? _standaloneVoiceService;
         if (_nodeService != null)
         {
@@ -3031,6 +3088,9 @@ public partial class App : Application
 
         // Reset status so the tray doesn't show a stale "Connected" from the previous mode
         _currentStatus = ConnectionStatus.Disconnected;
+        _lastSessions = Array.Empty<SessionInfo>();
+        _lastNodes = Array.Empty<GatewayNodeInfo>();
+        _lastChannels = Array.Empty<ChannelHealth>();
         _hubWindow?.UpdateStatus(_currentStatus);
         UpdateTrayIcon();
 
@@ -3073,8 +3133,7 @@ public partial class App : Application
         if (_hubWindow != null && !_hubWindow.IsClosed)
         {
             _hubWindow.Settings = _settings;
-            _hubWindow.GatewayClient = _gatewayClient;
-            _hubWindow.CurrentStatus = _currentStatus;
+            _hubWindow.GatewayRegistry = _gatewayRegistry;
         }
     }
 
@@ -3104,12 +3163,9 @@ public partial class App : Application
         if (_hubWindow != null && !_hubWindow.IsClosed)
         {
             _hubWindow.Settings = _settings;
-            _hubWindow.GatewayClient = _gatewayClient;
-            _hubWindow.CurrentStatus = _currentStatus;
+            _hubWindow.GatewayRegistry = _gatewayRegistry;
         }
-    }
-
-    /// <summary>
+    }    /// <summary>
     /// Reconnects only the node service (preserves gateway client + chat window).
     /// Use for capability toggle changes that don't require a full reconnect.
     /// </summary>
@@ -3725,12 +3781,10 @@ public partial class App : Application
             if (ShouldInitializeNodeService())
                 InitializeNodeService();
 
-            // Keep hub window in sync with new client
             if (_hubWindow != null && !_hubWindow.IsClosed)
             {
                 _hubWindow.Settings = _settings;
-                _hubWindow.GatewayClient = _gatewayClient;
-                _hubWindow.CurrentStatus = _currentStatus;
+                _hubWindow.GatewayRegistry = _gatewayRegistry;
             }
         };
         _onboardingWindow.Closed += (s, e) => _onboardingWindow = null;
@@ -3857,7 +3911,8 @@ public partial class App : Application
         if (_settings == null) return;
         if (!EnsureSshTunnelConfigured()) return;
         
-        var baseUrl = _settings.GetEffectiveGatewayUrl()
+        var gwUrl = GetActiveGatewayUrl() ?? "";
+        var baseUrl = gwUrl
             .Replace("ws://", "http://")
             .Replace("wss://", "https://")
             .TrimEnd('/');
@@ -3866,10 +3921,11 @@ public partial class App : Application
             ? baseUrl
             : $"{baseUrl}/{path.TrimStart('/')}";
 
-        if (!string.IsNullOrEmpty(_settings.Token))
+        var token = GetActiveOperatorToken();
+        if (!string.IsNullOrEmpty(token))
         {
             var separator = url.Contains('?') ? "&" : "?";
-            url = $"{url}{separator}token={Uri.EscapeDataString(_settings.Token)}";
+            url = $"{url}{separator}token={Uri.EscapeDataString(token)}";
         }
 
         try

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -96,6 +96,9 @@ public partial class App : Application
         InitializeGatewayClient(useBootstrapHandoffAuth);
     private SettingsManager? _settings;
     private GatewayRegistry? _gatewayRegistry;
+    private GatewayConnectionService? _connectionService;
+    private ConnectionDiagnostics? _diagnostics;
+    private ConnectionStatusWindow? _connectionStatusWindow;
     private SshTunnelService? _sshTunnelService;
     private GlobalHotkeyService? _globalHotkey;
     private Mutex? _mutex;
@@ -391,6 +394,11 @@ public partial class App : Application
                 storedOpToken ?? (string.IsNullOrWhiteSpace(_settings.Token) ? null : _settings.Token),
                 storedNodeToken);
         }
+        _gatewayRegistry.MigrateLegacyIdentityFile();
+
+        // Initialize connection service + diagnostics
+        _diagnostics = new ConnectionDiagnostics();
+        _connectionService = new GatewayConnectionService(_gatewayRegistry, logger: new AppLogger());
 
         DiagnosticsJsonlService.Configure(DataPath);
         DiagnosticsJsonlService.Write("app.start", new
@@ -1678,20 +1686,31 @@ public partial class App : Application
         var activeGw = _gatewayRegistry?.GetActive();
         string? effectiveToken = null;
         var tokenIsBootstrap = false;
+        var identityPath = activeGw?.IdentityPath;
 
-        if (!string.IsNullOrWhiteSpace(activeGw?.OperatorDeviceToken))
+        // Match upstream: SharedGatewayToken → BootstrapToken → stored device token.
+        if (!string.IsNullOrWhiteSpace(activeGw?.SharedGatewayToken))
         {
-            effectiveToken = activeGw.OperatorDeviceToken;
+            effectiveToken = activeGw.SharedGatewayToken;
+            _diagnostics?.RecordCredentialResolved("registry:SharedGatewayToken", "shared", false);
         }
         else if (!string.IsNullOrWhiteSpace(activeGw?.BootstrapToken))
         {
             effectiveToken = activeGw.BootstrapToken;
             tokenIsBootstrap = true;
+            _diagnostics?.RecordCredentialResolved("registry:BootstrapToken", "bootstrap", true);
         }
         else if (!string.IsNullOrWhiteSpace(_settings.Token))
         {
-            // Fallback: settings for legacy/manual token entry
             effectiveToken = _settings.Token;
+        }
+
+        // Fall through to stored device token in per-gateway identity file
+        if (string.IsNullOrWhiteSpace(effectiveToken) && identityPath != null)
+        {
+            var storedToken = DeviceIdentity.TryReadStoredDeviceToken(identityPath);
+            if (!string.IsNullOrWhiteSpace(storedToken))
+                effectiveToken = storedToken;
         }
 
         if (string.IsNullOrWhiteSpace(effectiveToken))
@@ -1712,7 +1731,9 @@ public partial class App : Application
             gatewayUrl,
             effectiveToken,
             new AppLogger(),
-            tokenIsBootstrapToken);
+            tokenIsBootstrapToken,
+            identityPath: identityPath);
+        _gatewayClient.Diagnostics = _diagnostics;
         _gatewayClient.SetUserRules(_settings.UserRules.Count > 0 ? _settings.UserRules : null);
         _gatewayClient.SetPreferStructuredCategories(_settings.PreferStructuredCategories);
         _gatewayClient.StatusChanged += OnConnectionStatusChanged;
@@ -1786,8 +1807,9 @@ public partial class App : Application
         var enableMcp = _settings.EnableMcpServer;
         if (!enableNode && !enableMcp) return;
 
-        // Gateway connection requires auth (operator token, bootstrap token, or stored device token); MCP doesn't.
-        var canRunGateway = StartupSetupState.CanStartNodeGateway(_settings, IdentityDataPath);
+        var activeGwForNode = _gatewayRegistry?.GetActive();
+        var nodeIdentityPath = activeGwForNode?.IdentityPath ?? IdentityDataPath;
+        var canRunGateway = StartupSetupState.CanStartNodeGateway(_settings, nodeIdentityPath);
 
         if (enableNode && !canRunGateway && !enableMcp)
         {
@@ -1809,7 +1831,7 @@ public partial class App : Application
                 () => _keepAliveWindow?.Content as FrameworkElement,
                 _settings,
                 enableMcpServer: enableMcp,
-                identityDataPath: IdentityDataPath);
+                identityDataPath: nodeIdentityPath);
             _nodeService.StatusChanged += OnNodeStatusChanged;
             _nodeService.NotificationRequested += OnNodeNotificationRequested;
             _nodeService.PairingStatusChanged += OnPairingStatusChanged;
@@ -2177,7 +2199,7 @@ public partial class App : Application
                             activeGw.BootstrapToken = null;
                         }
 
-                        var nodeToken = DeviceIdentity.TryReadStoredDeviceToken(DataPath);
+                        var nodeToken = DeviceIdentity.TryReadStoredDeviceToken(activeGw.IdentityPath);
                         if (!string.IsNullOrWhiteSpace(nodeToken))
                             activeGw.NodeDeviceToken = nodeToken;
 
@@ -2189,27 +2211,21 @@ public partial class App : Application
                 if (_settings != null)
                 {
                     if (!string.IsNullOrWhiteSpace(args.OperatorDeviceToken))
-                    {
                         _settings.Token = args.OperatorDeviceToken;
-                        DeviceIdentity.StoreOperatorDeviceToken(DataPath, args.OperatorDeviceToken, new AppLogger());
-                    }
                     if (!string.IsNullOrWhiteSpace(_settings.BootstrapToken))
                         _settings.BootstrapToken = "";
                     _settings.Save();
                 }
 
-                // Reinitialize operator client — dispatch to UI thread
+                // Close stale chat window so the next open picks up new credentials.
+                // No operator reconnect needed — HandleHelloOk already stored the
+                // device token in memory and in the per-gateway identity file.
                 _dispatcherQueue?.TryEnqueue(() =>
                 {
                     if (_chatWindow != null)
                     {
                         _chatWindow.ForceClose();
                         _chatWindow = null;
-                    }
-                    if (_gatewayClient == null || !_gatewayClient.IsConnectedToGateway)
-                    {
-                        Logger.Info("Node paired — reinitializing operator client");
-                        InitializeGatewayClient();
                     }
                 });
             }
@@ -2379,6 +2395,16 @@ public partial class App : Application
         UpdateTrayIcon();
         _dispatcherQueue?.TryEnqueue(UpdateStatusDetailWindow);
         
+        // Update connection status window
+        _dispatcherQueue?.TryEnqueue(() =>
+        {
+            if (status != ConnectionStatus.Connected)
+            {
+                ShowConnectionStatusWindow();
+            }
+            _connectionStatusWindow?.UpdateOperatorStatus(status);
+        });
+
         if (status == ConnectionStatus.Connected)
         {
             _ = RunHealthCheckAsync();
@@ -2967,6 +2993,7 @@ public partial class App : Application
             _hubWindow = new HubWindow();
             _hubWindow.Settings = _settings;
             _hubWindow.GatewayRegistry = _gatewayRegistry;
+            _hubWindow.ConnectionService = _connectionService;
             _hubWindow.OpenDashboardAction = OpenDashboard;
             _hubWindow.CheckForUpdatesAction = () => _ = CheckForUpdatesUserInitiatedAsync();
             _hubWindow.QuickSendAction = () => ShowQuickSend();
@@ -3017,6 +3044,7 @@ public partial class App : Application
         }
         _hubWindow.Settings = _settings;
         _hubWindow.GatewayRegistry = _gatewayRegistry;
+            _hubWindow.ConnectionService = _connectionService;
         _hubWindow.VoiceServiceInstance = _nodeService?.VoiceService ?? _standaloneVoiceService;
         if (_nodeService != null)
         {
@@ -3148,6 +3176,7 @@ public partial class App : Application
         {
             _hubWindow.Settings = _settings;
             _hubWindow.GatewayRegistry = _gatewayRegistry;
+            _hubWindow.ConnectionService = _connectionService;
         }
     }
 
@@ -3181,6 +3210,7 @@ public partial class App : Application
         {
             _hubWindow.Settings = _settings;
             _hubWindow.GatewayRegistry = _gatewayRegistry;
+            _hubWindow.ConnectionService = _connectionService;
         }
     }    /// <summary>
     /// Reconnects only the node service (preserves gateway client + chat window).
@@ -3252,6 +3282,20 @@ public partial class App : Application
     private void ShowStatusDetail()
     {
         ShowHub("general");
+    }
+
+    private void ShowConnectionStatusWindow()
+    {
+        if (_diagnostics == null) return;
+
+        if (_connectionStatusWindow == null || _connectionStatusWindow.IsClosed)
+        {
+            _connectionStatusWindow = new ConnectionStatusWindow(_diagnostics, _gatewayRegistry, _connectionService);
+            _connectionStatusWindow.Closed += (_, _) => _connectionStatusWindow = null;
+        }
+
+        _connectionStatusWindow.RefreshAll();
+        _connectionStatusWindow.Activate();
     }
 
     private void RestartSshTunnel()
@@ -3802,6 +3846,7 @@ public partial class App : Application
             {
                 _hubWindow.Settings = _settings;
                 _hubWindow.GatewayRegistry = _gatewayRegistry;
+            _hubWindow.ConnectionService = _connectionService;
             }
         };
         _onboardingWindow.Closed += (s, e) => _onboardingWindow = null;

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3924,13 +3924,6 @@ public partial class App : Application
             ? baseUrl
             : $"{baseUrl}/{path.TrimStart('/')}";
 
-        var token = GetActiveOperatorToken();
-        if (!string.IsNullOrEmpty(token))
-        {
-            var separator = url.Contains('?') ? "&" : "?";
-            url = $"{url}{separator}token={Uri.EscapeDataString(token)}";
-        }
-
         try
         {
             Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3153,6 +3153,9 @@ public partial class App : Application
         try { oldNodeService?.Dispose(); } catch (Exception ex) { Logger.Warn($"Node dispose error: {ex.Message}"); }
 
         _currentStatus = ConnectionStatus.Disconnected;
+        _lastSessions = Array.Empty<SessionInfo>();
+        _lastNodes = Array.Empty<GatewayNodeInfo>();
+        _lastChannels = Array.Empty<ChannelHealth>();
         _hubWindow?.UpdateStatus(_currentStatus);
         UpdateTrayIcon();
 

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -71,7 +71,8 @@ public partial class App : Application
             settings,
             new AppLogger(),
             nodeService,
-            replaceExistingConfigurationConfirmed: replaceExistingConfigurationConfirmed);
+            replaceExistingConfigurationConfirmed: replaceExistingConfigurationConfirmed,
+            gatewayRegistry: _gatewayRegistry);
         // Bug #2: cache so OnPairingStatusChanged can read engine.IsAutoPairingWindowsNode
         // and suppress the "copy pairing command" toast during the Phase 14 blip.
         _localSetupEngine = engine;
@@ -1673,29 +1674,34 @@ public partial class App : Application
             return;
         }
 
-        // Bug #4 (Wizard hung at "Authenticating"): broaden credential resolution
-        // beyond settings.Token so a paired operator whose only credential is
-        // BootstrapToken or a stored DeviceIdentity DeviceToken still gets a
-        // client. Mirrors the prototype's resolver shape (openclaw-windows-node
-        // App.xaml.cs:1244-1298). Logic lives in GatewayCredentialResolver so
-        // Tray tests can cover all branches without booting WinUI.
-        var identityPath = Path.Combine(SettingsManager.SettingsDirectoryPath, "device-key-ed25519.json");
-        var credential = OpenClawTray.Services.GatewayCredentialResolver.Resolve(
-            _settings.Token,
-            _settings.BootstrapToken,
-            identityPath,
-            msg => Logger.Warn(msg));
-        if (credential == null)
+        // Resolve credential from registry (single source of truth)
+        var activeGw = _gatewayRegistry?.GetActive();
+        string? effectiveToken = null;
+        var tokenIsBootstrap = false;
+
+        if (!string.IsNullOrWhiteSpace(activeGw?.OperatorDeviceToken))
+        {
+            effectiveToken = activeGw.OperatorDeviceToken;
+        }
+        else if (!string.IsNullOrWhiteSpace(activeGw?.BootstrapToken))
+        {
+            effectiveToken = activeGw.BootstrapToken;
+            tokenIsBootstrap = true;
+        }
+        else if (!string.IsNullOrWhiteSpace(_settings.Token))
+        {
+            // Fallback: settings for legacy/manual token entry
+            effectiveToken = _settings.Token;
+        }
+
+        if (string.IsNullOrWhiteSpace(effectiveToken))
         {
             Logger.Info("Gateway token not configured — skipping operator client initialization");
             return;
         }
 
-        // Caller's useBootstrapHandoffAuth hint is preserved as an OR so existing
-        // call sites that put a bootstrap value into settings.Token + pass true
-        // continue to send auth.bootstrapToken (OpenClawGatewayClient.cs:556-565).
-        var tokenIsBootstrapToken = credential.IsBootstrapToken || useBootstrapHandoffAuth;
-        Logger.Info($"Gateway credential resolved from {credential.Source} (bootstrap={tokenIsBootstrapToken})");
+        var tokenIsBootstrapToken = tokenIsBootstrap || useBootstrapHandoffAuth;
+        Logger.Info($"Gateway credential resolved (bootstrap={tokenIsBootstrapToken})");
 
         // Unsubscribe from old client if exists
         UnsubscribeGatewayEvents();
@@ -1704,7 +1710,7 @@ public partial class App : Application
 
         _gatewayClient = new OpenClawGatewayClient(
             gatewayUrl,
-            credential.Token,
+            effectiveToken,
             new AppLogger(),
             tokenIsBootstrapToken);
         _gatewayClient.SetUserRules(_settings.UserRules.Count > 0 ? _settings.UserRules : null);
@@ -2157,9 +2163,7 @@ public partial class App : Application
                     Logger.Info($"Suppressing duplicate Paired toast for device {deviceKey}");
                 }
 
-                // Store tokens in the gateway registry — this is the only place
-                // gateway records are created, ensuring only successfully paired
-                // gateways appear in the registry.
+                // Store tokens in the gateway registry
                 if (_gatewayRegistry != null)
                 {
                     var activeGw = _gatewayRegistry.GetActive();
@@ -2170,7 +2174,6 @@ public partial class App : Application
                         {
                             Logger.Info("Storing operator device token from bootstrap handoff");
                             activeGw.OperatorDeviceToken = args.OperatorDeviceToken;
-                            // Only clear bootstrap token once we have a proper operator token
                             activeGw.BootstrapToken = null;
                         }
 
@@ -2180,6 +2183,19 @@ public partial class App : Application
 
                         _gatewayRegistry.AddOrUpdate(activeGw);
                     }
+                }
+
+                // Sync to settings for setup engine and other consumers
+                if (_settings != null)
+                {
+                    if (!string.IsNullOrWhiteSpace(args.OperatorDeviceToken))
+                    {
+                        _settings.Token = args.OperatorDeviceToken;
+                        DeviceIdentity.StoreOperatorDeviceToken(DataPath, args.OperatorDeviceToken, new AppLogger());
+                    }
+                    if (!string.IsNullOrWhiteSpace(_settings.BootstrapToken))
+                        _settings.BootstrapToken = "";
+                    _settings.Save();
                 }
 
                 // Reinitialize operator client — dispatch to UI thread
@@ -3884,25 +3900,37 @@ public partial class App : Application
         token = string.Empty;
         credentialSource = "none";
 
-        if (_settings == null)
-            return false;
-
-        gatewayUrl = _settings.GetEffectiveGatewayUrl();
+        // Registry is the single source of truth
+        var activeGw = _gatewayRegistry?.GetActive();
+        gatewayUrl = GetActiveGatewayUrl() ?? "";
         if (string.IsNullOrWhiteSpace(gatewayUrl))
             return false;
 
-        var identityPath = Path.Combine(SettingsManager.SettingsDirectoryPath, "device-key-ed25519.json");
-        var credential = OpenClawTray.Services.GatewayCredentialResolver.Resolve(
-            _settings.Token,
-            _settings.BootstrapToken,
-            identityPath,
-            msg => Logger.Warn(msg));
-        if (credential == null)
-            return false;
+        // Prefer shared gateway token (for web dashboard auth),
+        // fall back to operator device token, then settings
+        if (!string.IsNullOrWhiteSpace(activeGw?.SharedGatewayToken))
+        {
+            token = activeGw.SharedGatewayToken;
+            credentialSource = "registry:shared";
+            return true;
+        }
 
-        token = credential.Token;
-        credentialSource = credential.Source;
-        return true;
+        if (!string.IsNullOrWhiteSpace(activeGw?.OperatorDeviceToken))
+        {
+            token = activeGw.OperatorDeviceToken;
+            credentialSource = "registry:operator";
+            return true;
+        }
+
+        // Last resort: settings (for legacy/manual token entry)
+        if (!string.IsNullOrWhiteSpace(_settings?.Token))
+        {
+            token = _settings.Token;
+            credentialSource = "settings";
+            return true;
+        }
+
+        return false;
     }
 
     #region Actions

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -2092,6 +2092,32 @@ public partial class App : Application
                 {
                     Logger.Info($"Suppressing duplicate Paired toast for device {deviceKey}");
                 }
+
+                // If the gateway issued a role-specific operator device token during
+                // bootstrap pairing, store it in Settings.Token for the operator client
+                // AND for chat/dashboard HTTP auth (gateway accepts device tokens for both).
+                if (!string.IsNullOrWhiteSpace(args.OperatorDeviceToken) && _settings != null)
+                {
+                    Logger.Info("Storing operator device token from bootstrap handoff");
+                    _settings.Token = args.OperatorDeviceToken;
+                    _settings.BootstrapToken = ""; // Bootstrap consumed — clear it
+                    _settings.Save();
+
+                    // Reset chat window so it picks up the new token
+                    if (_chatWindow != null)
+                    {
+                        _chatWindow.ForceClose();
+                        _chatWindow = null;
+                    }
+                }
+
+                // Reinitialize operator client so it picks up the operator device token.
+                if (_gatewayClient == null || !_gatewayClient.IsConnectedToGateway)
+                {
+                    Logger.Info("Node paired — reinitializing operator client with operator device token");
+                    _dispatcherQueue?.TryEnqueue(() => InitializeGatewayClient());
+                }
+                }
             }
             else if (args.Status == OpenClaw.Shared.PairingStatus.Rejected)
             {

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1812,12 +1812,10 @@ public partial class App : Application
             _nodeService.GatewaySelfUpdated += OnGatewaySelfUpdated;
             _nodeService.RecordingStateChanged += OnRecordingStateChanged;
 
-            if (canRunGateway && !string.IsNullOrWhiteSpace(gatewayUrl))
+            if (canRunGateway)
             {
-                // Use node device token if available, fall back to operator token
-                var nodeToken = activeGw?.NodeDeviceToken ?? activeGw?.OperatorDeviceToken ?? "";
                 Logger.Info($"Initializing Windows Node service (gateway{(enableMcp ? " + MCP" : "")})...");
-                _ = _nodeService.ConnectAsync(gatewayUrl, nodeToken, activeGw?.BootstrapToken);
+                _ = _nodeService.ConnectAsync(_settings.GetEffectiveGatewayUrl(), _settings.Token, _settings.BootstrapToken);
             }
             else
             {

--- a/src/OpenClaw.Tray.WinUI/Onboarding/Pages/ConnectionPage.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/Pages/ConnectionPage.cs
@@ -162,8 +162,9 @@ public sealed class ConnectionPage : Component<OnboardingState>
             {
                 setToken(result.Token);
                 // Bootstrap token goes to BootstrapToken only — it's single-use for pairing.
-                // Don't save as Settings.Token (causes reconnect storms on restart).
+                // Clear Settings.Token to prevent dual-token confusion.
                 Props.Settings.BootstrapToken = result.Token;
+                Props.Settings.Token = "";
             }
             setStatusMsg($"✅ {LocalizationHelper.GetString("Onboarding_Connection_StatusDecoded")}");
         }

--- a/src/OpenClaw.Tray.WinUI/Onboarding/Pages/WizardPage.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/Pages/WizardPage.cs
@@ -461,7 +461,13 @@ public sealed class WizardPage : Component<OnboardingState>
                         var selIdx = values.IndexOf(stepInput);
                         var labelsArr = labels.ToArray();
                         var valuesArr = values.ToArray();
-                        inputArea = RadioButtons(labelsArr, selIdx >= 0 ? selIdx : 0,
+                        // Default to first option if none selected
+                        if (selIdx < 0)
+                        {
+                            selIdx = 0;
+                            setStepInput(valuesArr[0]);
+                        }
+                        inputArea = RadioButtons(labelsArr, selIdx,
                             idx =>
                             {
                                 if (idx >= 0 && idx < valuesArr.Length)

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -55,7 +55,9 @@ public sealed partial class ChatPage : Page
                 return;
             }
 
-            if (!TryBuildChatUrl(gatewayUrl, settings.Token, out var chatUrl, out var errorMessage))
+            // Use SharedGatewayToken from registry (web dashboard auth), fall back to settings.Token
+            var chatToken = _hub?.GatewayRegistry?.GetActive()?.SharedGatewayToken ?? settings.Token;
+            if (!TryBuildChatUrl(gatewayUrl, chatToken, out var chatUrl, out var errorMessage))
             {
                 PlaceholderPanel.Visibility = Visibility.Collapsed;
                 ErrorPanel.Visibility = Visibility.Visible;

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
@@ -22,10 +22,11 @@
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1" CornerRadius="8" Padding="16">
                 <StackPanel Spacing="8">
-                    <!-- Row 1: Status + Reconnect -->
+                    <!-- Row 1: Status + Buttons -->
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8">
@@ -34,7 +35,9 @@
                                        Style="{StaticResource SubtitleTextBlockStyle}"/>
                         </StackPanel>
                         <Button x:Uid="ReconnectButton" x:Name="ReconnectButton" Grid.Column="1" Content="Reconnect"
-                                VerticalAlignment="Center" Click="OnReconnect" IsEnabled="False"/>
+                                VerticalAlignment="Center" Click="OnReconnect" IsEnabled="False" Margin="0,0,8,0"/>
+                        <Button x:Name="DisconnectButton" Grid.Column="2" Content="Disconnect"
+                                VerticalAlignment="Center" Click="OnDisconnect" Visibility="Collapsed"/>
                     </Grid>
                     <!-- Row 2: Gateway details -->
                     <TextBlock x:Name="GatewayDetailText"
@@ -55,72 +58,15 @@
                                    Style="{StaticResource CaptionTextBlockStyle}"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                     </StackPanel>
-                    <!-- Row 5: Connect/Disconnect toggle -->
-                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                        <ToggleSwitch x:Uid="ConnectToggle" x:Name="ConnectToggle" Header="Connection"
-                                      Toggled="OnConnectToggled"/>
-                    </StackPanel>
-                </StackPanel>
-            </Border>
-
-            <!-- ═══ Section 2: Gateway Discovery ═══ -->
-            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                    BorderThickness="1" CornerRadius="8" Padding="16">
-                <StackPanel Spacing="12">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock x:Uid="ConnectionPage_TextBlock_76" Grid.Column="0" Text="📡 Available Gateways"
-                                   Style="{StaticResource BodyStrongTextBlockStyle}" VerticalAlignment="Center"/>
-                        <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
-                            <ProgressRing x:Name="ScanProgressRing" IsActive="False" Width="16" Height="16"
-                                          VerticalAlignment="Center" Visibility="Collapsed"/>
-                            <Button x:Name="ScanButton" Click="OnScanForGateways" VerticalAlignment="Center">
-                                <StackPanel Orientation="Horizontal" Spacing="6">
-                                    <FontIcon Glyph="&#xE11A;" FontSize="14"/>
-                                    <TextBlock x:Uid="ConnectionPage_TextBlock_84" Text="Scan"/>
-                                </StackPanel>
-                            </Button>
-                        </StackPanel>
-                    </Grid>
-                    <StackPanel x:Name="GatewayListPanel" Spacing="4" Visibility="Collapsed"/>
-                    <!-- Inline token prompt (shown when connecting to a gateway that needs auth) -->
-                    <Border x:Name="TokenPromptPanel" Visibility="Collapsed"
-                            Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
-                            CornerRadius="6" Padding="12" Margin="0,4,0,0">
-                        <StackPanel Spacing="8">
-                            <TextBlock x:Uid="TokenPromptText" x:Name="TokenPromptText" Text="This gateway requires a token to connect."
-                                       Style="{StaticResource CaptionTextBlockStyle}" TextWrapping="Wrap"/>
-                            <Grid ColumnSpacing="8">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
-                                <TextBox x:Uid="TokenPromptBox" x:Name="TokenPromptBox" Grid.Column="0"
-                                             PlaceholderText="Gateway token" Header="Token"/>
-                                <Button x:Uid="ConnectionPage_Button_105" Grid.Column="1" Content="Cancel"
-                                        VerticalAlignment="Bottom" Click="OnCancelTokenPrompt"/>
-                                <Button x:Uid="TokenPromptConnectBtn" x:Name="TokenPromptConnectBtn" Grid.Column="2" Content="Connect"
-                                        Style="{ThemeResource AccentButtonStyle}"
-                                        VerticalAlignment="Bottom" Click="OnConnectWithToken"/>
-                            </Grid>
-                            <TextBlock x:Uid="ConnectionPage_TextBlock_111" Text="Run 'openclaw qr' on the gateway host for a setup code, or find the token in the gateway's config."
-                                       Style="{StaticResource CaptionTextBlockStyle}"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                       FontSize="11" TextWrapping="Wrap"/>
-                        </StackPanel>
-                    </Border>
-                    <TextBlock x:Uid="GatewayEmptyText" x:Name="GatewayEmptyText" Text="No gateways found. Click Scan to search."
+                    <!-- Row 5: Connection attempts (shown when connecting) -->
+                    <TextBlock x:Name="ConnectionAttemptsText"
                                Style="{StaticResource CaptionTextBlockStyle}"
-                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               Visibility="Collapsed"/>
                 </StackPanel>
             </Border>
 
-            <!-- ═══ Section 3: Setup Code ═══ -->
+            <!-- ═══ Section 2: Setup Code (primary CTA) ═══ -->
             <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1" CornerRadius="8" Padding="16">
@@ -135,19 +81,71 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <TextBox x:Uid="SetupCodeTextBox" x:Name="SetupCodeTextBox" Grid.Column="0"
-                                 PlaceholderText="Paste setup code here…"/>
+                                 PlaceholderText="Paste setup code here…" TextChanged="OnSetupCodeTextChanged"/>
                         <Button x:Uid="ApplySetupCodeButton" x:Name="ApplySetupCodeButton" Grid.Column="1" Content="Apply"
                                 Style="{ThemeResource AccentButtonStyle}"
                                 Click="OnApplySetupCode" VerticalAlignment="Bottom"/>
                     </Grid>
+                    <!-- Decoded preview (shown after pasting) -->
+                    <StackPanel x:Name="SetupCodePreviewPanel" Spacing="4" Visibility="Collapsed">
+                        <TextBlock x:Name="SetupCodePreviewUrl"
+                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                        <TextBlock x:Name="SetupCodePreviewToken"
+                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                    </StackPanel>
                     <TextBlock x:Name="SetupCodeResultText"
                                Style="{StaticResource CaptionTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                 </StackPanel>
             </Border>
 
-            <!-- ═══ Section 4: Advanced Connection Settings ═══ -->
-            <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" IsExpanded="True">
+            <!-- ═══ Section 3: Device Identity (always visible when paired) ═══ -->
+            <Border x:Name="DeviceIdentityCard" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1" CornerRadius="8" Padding="16">
+                <StackPanel Spacing="8">
+                    <TextBlock x:Uid="ConnectionPage_TextBlock_200" Text="🪪 This Device" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                    <Grid ColumnSpacing="8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Uid="ConnectionPage_TextBlock_207" Grid.Column="0" Text="Device ID:" VerticalAlignment="Center"
+                                   Style="{StaticResource CaptionTextBlockStyle}"/>
+                        <TextBlock x:Name="DeviceIdText" Grid.Column="1" VerticalAlignment="Center"
+                                   Style="{StaticResource BodyTextBlockStyle}" IsTextSelectionEnabled="True"/>
+                        <Button x:Uid="CopyDeviceIdButton" x:Name="CopyDeviceIdButton" Grid.Column="2" Content="Copy"
+                                Click="OnCopyDeviceId" VerticalAlignment="Center"/>
+                    </Grid>
+                    <TextBlock x:Name="PairingStatusText"
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                    <!-- Pending approval help -->
+                    <StackPanel x:Name="ApprovalHelpPanel" Spacing="4" Visibility="Collapsed">
+                        <TextBlock x:Uid="ConnectionPage_TextBlock_219" Text="Run this command on the gateway host to approve:"
+                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                        <Grid ColumnSpacing="8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock x:Name="ApprovalCommandText" Grid.Column="0"
+                                       IsTextSelectionEnabled="True"
+                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                       FontFamily="Consolas" TextWrapping="Wrap"/>
+                            <Button x:Uid="CopyApprovalButton" x:Name="CopyApprovalButton" Grid.Column="1" Content="Copy"
+                                    Click="OnCopyApprovalCommand" VerticalAlignment="Top"/>
+                        </Grid>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- ═══ Section 4: Advanced Connection Settings (collapsed) ═══ -->
+            <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" IsExpanded="False">
                 <Expander.Header>
                     <TextBlock x:Uid="ConnectionPage_TextBlock_152" Text="Advanced Connection Settings" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                 </Expander.Header>
@@ -191,49 +189,6 @@
                     </StackPanel>
                 </StackPanel>
             </Expander>
-
-            <!-- ═══ Section 5: Device Identity ═══ -->
-            <Border x:Name="DeviceIdentityCard" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                    BorderThickness="1" CornerRadius="8" Padding="16" Visibility="Collapsed">
-                <StackPanel Spacing="8">
-                    <TextBlock x:Uid="ConnectionPage_TextBlock_200" Text="🪪 This Device" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                    <Grid ColumnSpacing="8">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock x:Uid="ConnectionPage_TextBlock_207" Grid.Column="0" Text="Device ID:" VerticalAlignment="Center"
-                                   Style="{StaticResource CaptionTextBlockStyle}"/>
-                        <TextBlock x:Name="DeviceIdText" Grid.Column="1" VerticalAlignment="Center"
-                                   Style="{StaticResource BodyTextBlockStyle}" IsTextSelectionEnabled="True"/>
-                        <Button x:Uid="CopyDeviceIdButton" x:Name="CopyDeviceIdButton" Grid.Column="2" Content="Copy"
-                                Click="OnCopyDeviceId" VerticalAlignment="Center"/>
-                    </Grid>
-                    <TextBlock x:Name="PairingStatusText"
-                               Style="{StaticResource CaptionTextBlockStyle}"
-                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                    <!-- Pending approval help -->
-                    <StackPanel x:Name="ApprovalHelpPanel" Spacing="4" Visibility="Collapsed">
-                        <TextBlock x:Uid="ConnectionPage_TextBlock_219" Text="Run this command on the gateway host to approve:"
-                                   Style="{StaticResource CaptionTextBlockStyle}"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <Grid ColumnSpacing="8">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBlock x:Name="ApprovalCommandText" Grid.Column="0"
-                                       IsTextSelectionEnabled="True"
-                                       Style="{StaticResource CaptionTextBlockStyle}"
-                                       FontFamily="Consolas" TextWrapping="Wrap"/>
-                            <Button x:Uid="CopyApprovalButton" x:Name="CopyApprovalButton" Grid.Column="1" Content="Copy"
-                                    Click="OnCopyApprovalCommand" VerticalAlignment="Top"/>
-                        </Grid>
-                    </StackPanel>
-                </StackPanel>
-            </Border>
 
             <!-- ═══ Section 6: Connection Log ═══ -->
             <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
@@ -101,6 +101,20 @@
                 </StackPanel>
             </Border>
 
+            <!-- ═══ Section 2.5: Recent Gateways ═══ -->
+            <Border x:Name="RecentGatewaysCard" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1" CornerRadius="8" Padding="16"
+                    Visibility="Collapsed">
+                <StackPanel Spacing="8">
+                    <TextBlock Text="📡 Recent Gateways" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                    <TextBlock Text="Switch between previously paired gateways."
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                    <StackPanel x:Name="GatewayListPanel" Spacing="6"/>
+                </StackPanel>
+            </Border>
+
             <!-- ═══ Section 3: Device Identity (always visible when paired) ═══ -->
             <Border x:Name="DeviceIdentityCard" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -16,6 +16,7 @@ public sealed partial class ConnectionPage : Page
 {
     private HubWindow? _hub;
     private int _connectionAttempts;
+    private GatewayConnectionService? _svc;
 
     public ConnectionPage()
     {
@@ -25,8 +26,15 @@ public sealed partial class ConnectionPage : Page
     public void Initialize(HubWindow hub)
     {
         _hub = hub;
+        _svc = hub.ConnectionService;
         var settings = hub.Settings;
         if (settings == null) return;
+
+        // Subscribe to live state changes from the connection service
+        if (_svc != null)
+        {
+            _svc.StateChanged += OnServiceStateChanged;
+        }
 
         // Populate manual connection fields
         GatewayUrlTextBox.Text = settings.GatewayUrl ?? "";
@@ -42,6 +50,24 @@ public sealed partial class ConnectionPage : Page
         UpdateDeviceIdentity();
         LoadConnectionLog();
         LoadGatewayList();
+    }
+
+    private void OnServiceStateChanged(GatewayConnectionState oldState, GatewayConnectionState newState, GatewayConnectionSnapshot snapshot)
+    {
+        DispatcherQueue?.TryEnqueue(() =>
+        {
+            // Map service state to ConnectionStatus for the existing UpdateStatus method
+            var status = snapshot.Operator switch
+            {
+                GatewayRoleState.Connected => ConnectionStatus.Connected,
+                GatewayRoleState.Connecting => ConnectionStatus.Connecting,
+                GatewayRoleState.PairingRequired => ConnectionStatus.Error,
+                GatewayRoleState.Error => ConnectionStatus.Error,
+                _ => ConnectionStatus.Disconnected
+            };
+            UpdateStatus(status);
+            LoadGatewayList();
+        });
     }
 
     public void UpdateStatus(ConnectionStatus status)
@@ -363,7 +389,7 @@ public sealed partial class ConnectionPage : Page
 
         registry.SetActive(gwId);
 
-        // Update settings URL from the new active gateway (for the Advanced UI)
+        // Update settings URL from the new active gateway
         var active = registry.GetActive();
         if (active != null && _hub?.Settings != null)
         {
@@ -373,7 +399,13 @@ public sealed partial class ConnectionPage : Page
         }
 
         LoadGatewayList();
+
+        // Connect via service + legacy reconnect
         _hub?.ReconnectAction?.Invoke();
+        if (_svc != null)
+        {
+            _ = _svc.ConnectOperatorAsync();
+        }
     }
 
     private void OnRemoveGateway(object sender, RoutedEventArgs e)
@@ -397,6 +429,10 @@ public sealed partial class ConnectionPage : Page
     {
         _connectionAttempts = 0;
         _hub?.ReconnectAction?.Invoke();
+        if (_svc != null)
+        {
+            _ = _svc.ConnectOperatorAsync();
+        }
     }
 
     private void OnSshToggled(object sender, RoutedEventArgs e)
@@ -473,26 +509,57 @@ public sealed partial class ConnectionPage : Page
 
     private void OnApplySetupCode(object sender, RoutedEventArgs e)
     {
+        var svc = _hub?.ConnectionService;
         var settings = _hub?.Settings;
         if (settings == null) return;
 
-        // Compute the shared identity data path (same as App.DataPath)
-        var dataPath = Environment.GetEnvironmentVariable("OPENCLAW_TRAY_DATA_DIR") is { Length: > 0 } v
-            ? v
-            : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "OpenClawTray");
-
-        var result = SetupCodeApplicator.Apply(SetupCodeTextBox.Text, settings, dataPath, _hub?.GatewayRegistry);
-        if (!result.Success)
+        var rawCode = SetupCodeTextBox.Text?.Trim();
+        if (string.IsNullOrWhiteSpace(rawCode))
         {
-            SetupCodeResultText.Text = $"✗ {result.Error}";
+            SetupCodeResultText.Text = "✗ Please paste a setup code.";
             return;
         }
 
-        SetupCodeResultText.Text = $"✓ Applied — gateway: {result.DisplayUrl}";
-        GatewayUrlTextBox.Text = settings.GatewayUrl ?? "";
-        TokenTextBox.Text = ""; // Token was cleared by the applicator
+        var decoded = OpenClawTray.Onboarding.Services.SetupCodeDecoder.Decode(rawCode);
+        if (!decoded.Success)
+        {
+            SetupCodeResultText.Text = $"✗ {decoded.Error}";
+            return;
+        }
 
+        var gatewayUrl = decoded.Url ?? settings.GatewayUrl ?? "";
+
+        if (svc != null && !string.IsNullOrWhiteSpace(gatewayUrl))
+        {
+            // Use the connection service — handles registry + per-gateway identity
+            svc.ApplySetupCode(gatewayUrl, decoded.Token);
+        }
+        else
+        {
+            // Fallback: direct registry write (service not available)
+            SetupCodeApplicator.Apply(rawCode, settings, registry: _hub?.GatewayRegistry);
+        }
+
+        // Sync to settings for setup engine and other consumers
+        if (!string.IsNullOrEmpty(decoded.Url))
+            settings.GatewayUrl = decoded.Url;
+        if (!string.IsNullOrEmpty(decoded.Token))
+            settings.BootstrapToken = decoded.Token;
+        settings.Token = "";
+        settings.Save();
+
+        var displayUrl = GatewayUrlHelper.SanitizeForDisplay(gatewayUrl);
+        SetupCodeResultText.Text = $"✓ Applied — gateway: {displayUrl}";
+        GatewayUrlTextBox.Text = settings.GatewayUrl ?? "";
+        TokenTextBox.Text = "";
+
+        // Trigger connection via service (drives the state machine)
+        // Also raise settings saved so App.xaml.cs reconnects (until service fully replaces it)
         _hub?.RaiseSettingsSaved();
+        if (svc != null)
+        {
+            _ = svc.ConnectOperatorAsync();
+        }
     }
 
     private void OnCopyDeviceId(object sender, RoutedEventArgs e)

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -5,6 +5,7 @@ using OpenClawTray.Onboarding.Services;
 using OpenClawTray.Services;
 using OpenClawTray.Windows;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Windows.ApplicationModel.DataTransfer;
@@ -40,11 +41,23 @@ public sealed partial class ConnectionPage : Page
         UpdateStatus(hub.CurrentStatus);
         UpdateDeviceIdentity();
         LoadConnectionLog();
+        LoadGatewayList();
     }
 
     public void UpdateStatus(ConnectionStatus status)
     {
-        var (color, text) = status switch
+        var registry = _hub?.GatewayRegistry;
+        var activeGw = registry?.GetActive();
+        var hasOperatorToken = !string.IsNullOrWhiteSpace(activeGw?.OperatorDeviceToken);
+        var hasNodeToken = !string.IsNullOrWhiteSpace(activeGw?.NodeDeviceToken);
+        var hasBothTokens = hasOperatorToken && hasNodeToken;
+
+        // Only show "Connected" when operator has a working token
+        var effectiveStatus = status;
+        if (status == ConnectionStatus.Connected && !hasOperatorToken)
+            effectiveStatus = ConnectionStatus.Connecting; // still bootstrapping
+
+        var (color, text) = effectiveStatus switch
         {
             ConnectionStatus.Connected => (Microsoft.UI.Colors.LimeGreen, "Connected"),
             ConnectionStatus.Connecting => (Microsoft.UI.Colors.Orange, "Connecting…"),
@@ -55,14 +68,12 @@ public sealed partial class ConnectionPage : Page
         StatusDot.Fill = new Microsoft.UI.Xaml.Media.SolidColorBrush(color);
         StatusText.Text = text;
 
-        // Button visibility: Reconnect when disconnected/error, Disconnect when connected
-        var isConnected = status == ConnectionStatus.Connected;
-        ReconnectButton.IsEnabled = status != ConnectionStatus.Connecting;
+        var isConnected = effectiveStatus == ConnectionStatus.Connected;
+        ReconnectButton.IsEnabled = effectiveStatus != ConnectionStatus.Connecting;
         ReconnectButton.Visibility = isConnected ? Visibility.Collapsed : Visibility.Visible;
         DisconnectButton.Visibility = isConnected ? Visibility.Visible : Visibility.Collapsed;
 
-        // Connection attempts counter
-        if (status == ConnectionStatus.Connecting)
+        if (effectiveStatus == ConnectionStatus.Connecting)
         {
             _connectionAttempts++;
             ConnectionAttemptsText.Text = $"Connection attempt {_connectionAttempts}…";
@@ -70,14 +81,14 @@ public sealed partial class ConnectionPage : Page
         }
         else
         {
-            if (status == ConnectionStatus.Connected)
+            if (effectiveStatus == ConnectionStatus.Connected)
                 _connectionAttempts = 0;
             ConnectionAttemptsText.Visibility = Visibility.Collapsed;
         }
 
         // Gateway details
         var self = _hub?.LastGatewaySelf;
-        var effectiveUrl = _hub?.Settings?.GetEffectiveGatewayUrl() ?? "";
+        var effectiveUrl = activeGw?.Url ?? "";
 
         if (self != null && status == ConnectionStatus.Connected)
         {
@@ -94,7 +105,18 @@ public sealed partial class ConnectionPage : Page
         }
         else
         {
-            GatewayDetailText.Text = "";
+            // Show registry state even when not connected
+            var detailParts = new List<string>();
+            if (activeGw != null)
+            {
+                if (!string.IsNullOrWhiteSpace(activeGw.OperatorDeviceToken))
+                    detailParts.Add("Operator: paired");
+                else if (!string.IsNullOrWhiteSpace(activeGw.BootstrapToken))
+                    detailParts.Add("Operator: pairing…");
+                if (!string.IsNullOrWhiteSpace(activeGw.NodeDeviceToken))
+                    detailParts.Add("Node: paired");
+            }
+            GatewayDetailText.Text = detailParts.Count > 0 ? string.Join(" · ", detailParts) : "";
             GatewayUrlDetail.Text = !string.IsNullOrEmpty(effectiveUrl)
                 ? SanitizeUrl(effectiveUrl) : "";
         }
@@ -127,6 +149,7 @@ public sealed partial class ConnectionPage : Page
 
         UpdateDeviceIdentity();
         LoadConnectionLog();
+        LoadGatewayList();
 
         // Show auth error if present
         var authError = _hub?.LastAuthError;
@@ -236,6 +259,133 @@ public sealed partial class ConnectionPage : Page
         return url;
     }
 
+    // ─── Gateway List ───
+
+    private void LoadGatewayList()
+    {
+        GatewayListPanel.Children.Clear();
+        var registry = _hub?.GatewayRegistry;
+        if (registry == null)
+        {
+            RecentGatewaysCard.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        var gateways = registry.GetAll();
+        if (gateways.Count == 0)
+        {
+            RecentGatewaysCard.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        RecentGatewaysCard.Visibility = Visibility.Visible;
+        var active = registry.GetActive();
+
+        foreach (var gw in gateways)
+        {
+            var isActive = gw.Id == active?.Id;
+            var row = new Grid { ColumnSpacing = 8, Padding = new Thickness(0, 2, 0, 2) };
+            row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) });
+            row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) });
+            row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) });
+
+            // Active indicator
+            var indicator = new TextBlock
+            {
+                Text = isActive ? "✓" : "",
+                VerticalAlignment = VerticalAlignment.Center,
+                Width = 16,
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            };
+            Grid.SetColumn(indicator, 0);
+            row.Children.Add(indicator);
+
+            // URL + token status
+            var hasOp = !string.IsNullOrWhiteSpace(gw.OperatorDeviceToken);
+            var hasNode = !string.IsNullOrWhiteSpace(gw.NodeDeviceToken);
+            var hasBoot = !string.IsNullOrWhiteSpace(gw.BootstrapToken);
+            var statusParts = new List<string>();
+            if (hasOp && hasNode) statusParts.Add("paired");
+            else if (hasBoot) statusParts.Add("pairing…");
+            else if (hasNode) statusParts.Add("node only");
+            var statusSuffix = statusParts.Count > 0 ? $"  ({string.Join(", ", statusParts)})" : "";
+
+            var infoPanel = new StackPanel { VerticalAlignment = VerticalAlignment.Center };
+            infoPanel.Children.Add(new TextBlock
+            {
+                Text = GatewayUrlHelper.SanitizeForDisplay(gw.Url),
+                Style = (Style)Application.Current.Resources["BodyTextBlockStyle"],
+                TextTrimming = TextTrimming.CharacterEllipsis,
+            });
+            infoPanel.Children.Add(new TextBlock
+            {
+                Text = $"{gw.Id}{statusSuffix}",
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+            });
+            Grid.SetColumn(infoPanel, 1);
+            row.Children.Add(infoPanel);
+
+            // Connect button
+            var connectBtn = new Button
+            {
+                Content = isActive ? "Active" : "Connect",
+                IsEnabled = !isActive,
+                VerticalAlignment = VerticalAlignment.Center,
+                Tag = gw.Id,
+            };
+            connectBtn.Click += OnConnectGateway;
+            Grid.SetColumn(connectBtn, 2);
+            row.Children.Add(connectBtn);
+
+            // Remove button
+            var removeBtn = new Button
+            {
+                Content = "✕",
+                VerticalAlignment = VerticalAlignment.Center,
+                Tag = gw.Id,
+                Padding = new Thickness(6, 4, 6, 4),
+            };
+            removeBtn.Click += OnRemoveGateway;
+            Grid.SetColumn(removeBtn, 3);
+            row.Children.Add(removeBtn);
+
+            GatewayListPanel.Children.Add(row);
+        }
+    }
+
+    private void OnConnectGateway(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button btn || btn.Tag is not string gwId) return;
+        var registry = _hub?.GatewayRegistry;
+        if (registry == null) return;
+
+        registry.SetActive(gwId);
+
+        // Update settings URL from the new active gateway (for the Advanced UI)
+        var active = registry.GetActive();
+        if (active != null && _hub?.Settings != null)
+        {
+            _hub.Settings.GatewayUrl = active.Url;
+            _hub.Settings.Token = active.OperatorDeviceToken ?? "";
+            _hub.Settings.Save();
+        }
+
+        LoadGatewayList();
+        _hub?.ReconnectAction?.Invoke();
+    }
+
+    private void OnRemoveGateway(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button btn || btn.Tag is not string gwId) return;
+        var registry = _hub?.GatewayRegistry;
+        if (registry == null) return;
+
+        registry.Remove(gwId);
+        LoadGatewayList();
+    }
+
     // ─── Event Handlers ───
 
     private void OnDisconnect(object sender, RoutedEventArgs e)
@@ -331,7 +481,7 @@ public sealed partial class ConnectionPage : Page
             ? v
             : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "OpenClawTray");
 
-        var result = SetupCodeApplicator.Apply(SetupCodeTextBox.Text, settings, dataPath);
+        var result = SetupCodeApplicator.Apply(SetupCodeTextBox.Text, settings, dataPath, _hub?.GatewayRegistry);
         if (!result.Success)
         {
             SetupCodeResultText.Text = $"✗ {result.Error}";

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -6,6 +6,7 @@ using OpenClawTray.Services;
 using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Windows.ApplicationModel.DataTransfer;
 
@@ -514,36 +515,24 @@ public sealed partial class ConnectionPage : Page
 
     private void OnApplySetupCode(object sender, RoutedEventArgs e)
     {
-        var code = SetupCodeTextBox.Text?.Trim();
-        if (string.IsNullOrEmpty(code))
-        {
-            SetupCodeResultText.Text = "Please paste a setup code.";
-            return;
-        }
+        var settings = _hub?.Settings;
+        if (settings == null) return;
 
-        var result = SetupCodeDecoder.Decode(code);
+        // Compute the shared identity data path (same as App.DataPath)
+        var dataPath = Environment.GetEnvironmentVariable("OPENCLAW_TRAY_DATA_DIR") is { Length: > 0 } v
+            ? v
+            : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "OpenClawTray");
+
+        var result = SetupCodeApplicator.Apply(SetupCodeTextBox.Text, settings, dataPath);
         if (!result.Success)
         {
             SetupCodeResultText.Text = $"✗ {result.Error}";
             return;
         }
 
-        var settings = _hub?.Settings;
-        if (settings == null) return;
-
-        if (!string.IsNullOrEmpty(result.Url))
-            settings.GatewayUrl = result.Url;
-        if (!string.IsNullOrEmpty(result.Token))
-        {
-            // Bootstrap token goes to BootstrapToken only — it's single-use for pairing.
-            // Don't save it as Settings.Token, which would cause reconnect storms on restart.
-            settings.BootstrapToken = result.Token;
-        }
-
-        settings.Save();
-
-        SetupCodeResultText.Text = $"✓ Applied — gateway: {SanitizeUrl(result.Url ?? settings.GatewayUrl ?? "")}";
+        SetupCodeResultText.Text = $"✓ Applied — gateway: {result.DisplayUrl}";
         GatewayUrlTextBox.Text = settings.GatewayUrl ?? "";
+        TokenTextBox.Text = ""; // Token was cleared by the applicator
 
         _hub?.RaiseSettingsSaved();
     }

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -5,7 +5,6 @@ using OpenClawTray.Onboarding.Services;
 using OpenClawTray.Services;
 using OpenClawTray.Windows;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Windows.ApplicationModel.DataTransfer;
@@ -15,20 +14,11 @@ namespace OpenClawTray.Pages;
 public sealed partial class ConnectionPage : Page
 {
     private HubWindow? _hub;
-    private GatewayDiscoveryService? _discoveryService;
-    private List<DiscoveredGateway> _discoveredGateways = new();
-    private bool _suppressToggle;
-    private string? _pendingGatewayUrl; // URL waiting for token input
-    private string? _pendingGatewayId;
+    private int _connectionAttempts;
 
     public ConnectionPage()
     {
         InitializeComponent();
-        Unloaded += (_, _) =>
-        {
-            _discoveryService?.Dispose();
-            _discoveryService = null;
-        };
     }
 
     public void Initialize(HubWindow hub)
@@ -47,47 +37,9 @@ public sealed partial class ConnectionPage : Page
         SshRemotePortBox.Text = settings.SshTunnelRemotePort.ToString();
         SshLocalPortBox.Text = settings.SshTunnelLocalPort.ToString();
 
-        // Set connect toggle without triggering event
-        _suppressToggle = true;
-        ConnectToggle.IsOn = hub.CurrentStatus == ConnectionStatus.Connected ||
-                             hub.CurrentStatus == ConnectionStatus.Connecting;
-        _suppressToggle = false;
-
         UpdateStatus(hub.CurrentStatus);
         UpdateDeviceIdentity();
         LoadConnectionLog();
-
-        // Auto-scan for gateways when disconnected or when no URL configured
-        if (hub.CurrentStatus != ConnectionStatus.Connected ||
-            string.IsNullOrWhiteSpace(settings.GatewayUrl))
-        {
-            _ = AutoScanAsync();
-        }
-    }
-
-    private async System.Threading.Tasks.Task AutoScanAsync()
-    {
-        try
-        {
-            _discoveryService?.Dispose();
-            _discoveryService = new GatewayDiscoveryService();
-            ScanProgressRing.IsActive = true;
-            ScanProgressRing.Visibility = Visibility.Visible;
-            GatewayEmptyText.Text = "Scanning for gateways…";
-
-            await _discoveryService.StartDiscoveryAsync();
-            _discoveredGateways = _discoveryService.Gateways.ToList();
-            PopulateGatewayList();
-        }
-        catch
-        {
-            // Silently fail on auto-scan — user can manually scan
-        }
-        finally
-        {
-            ScanProgressRing.IsActive = false;
-            ScanProgressRing.Visibility = Visibility.Collapsed;
-        }
     }
 
     public void UpdateStatus(ConnectionStatus status)
@@ -103,15 +55,25 @@ public sealed partial class ConnectionPage : Page
         StatusDot.Fill = new Microsoft.UI.Xaml.Media.SolidColorBrush(color);
         StatusText.Text = text;
 
-        // Reconnect button enabled when connected or error
-        ReconnectButton.IsEnabled = status == ConnectionStatus.Connected ||
-                                    status == ConnectionStatus.Error;
+        // Button visibility: Reconnect when disconnected/error, Disconnect when connected
+        var isConnected = status == ConnectionStatus.Connected;
+        ReconnectButton.IsEnabled = status != ConnectionStatus.Connecting;
+        ReconnectButton.Visibility = isConnected ? Visibility.Collapsed : Visibility.Visible;
+        DisconnectButton.Visibility = isConnected ? Visibility.Visible : Visibility.Collapsed;
 
-        // Update connect toggle without firing event
-        _suppressToggle = true;
-        ConnectToggle.IsOn = status == ConnectionStatus.Connected ||
-                             status == ConnectionStatus.Connecting;
-        _suppressToggle = false;
+        // Connection attempts counter
+        if (status == ConnectionStatus.Connecting)
+        {
+            _connectionAttempts++;
+            ConnectionAttemptsText.Text = $"Connection attempt {_connectionAttempts}…";
+            ConnectionAttemptsText.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            if (status == ConnectionStatus.Connected)
+                _connectionAttempts = 0;
+            ConnectionAttemptsText.Visibility = Visibility.Collapsed;
+        }
 
         // Gateway details
         var self = _hub?.LastGatewaySelf;
@@ -206,7 +168,9 @@ public sealed partial class ConnectionPage : Page
 
             if (_hub.NodeIsPaired)
             {
-                PairingStatusText.Text = "Pairing: ✓ Paired";
+                var gwUrl = _hub.Settings?.GetEffectiveGatewayUrl();
+                var gwDisplay = !string.IsNullOrEmpty(gwUrl) ? $" to {GatewayUrlHelper.SanitizeForDisplay(gwUrl)}" : "";
+                PairingStatusText.Text = $"Pairing: ✓ Paired{gwDisplay}";
                 ApprovalHelpPanel.Visibility = Visibility.Collapsed;
             }
             else if (_hub.NodeIsPendingApproval)
@@ -231,12 +195,11 @@ public sealed partial class ConnectionPage : Page
     private void LoadConnectionLog()
     {
         ConnectionLogPanel.Children.Clear();
-        // Pull from node + error categories which contain connection-related events
-        var nodeItems = ActivityStreamService.GetItems(10, "node");
-        var errorItems = ActivityStreamService.GetItems(5, "error");
+        var nodeItems = ActivityStreamService.GetItems(15, "node");
+        var errorItems = ActivityStreamService.GetItems(10, "error");
         var items = nodeItems.Concat(errorItems)
             .OrderByDescending(i => i.Timestamp)
-            .Take(10)
+            .Take(15)
             .ToList();
 
         if (items.Count == 0)
@@ -248,11 +211,15 @@ public sealed partial class ConnectionPage : Page
         ConnectionLogEmpty.Visibility = Visibility.Collapsed;
         foreach (var item in items)
         {
+            var text = $"{item.Timestamp:HH:mm:ss}  {item.Title}";
+            if (!string.IsNullOrEmpty(item.Details))
+                text += $" — {item.Details}";
             var tb = new TextBlock
             {
-                Text = $"{item.Timestamp:HH:mm:ss}  {item.Title}",
+                Text = text,
                 Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
-                Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]
+                Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+                TextWrapping = TextWrapping.Wrap
             };
             ConnectionLogPanel.Children.Add(tb);
         }
@@ -271,18 +238,14 @@ public sealed partial class ConnectionPage : Page
 
     // ─── Event Handlers ───
 
-    private void OnConnectToggled(object sender, RoutedEventArgs e)
+    private void OnDisconnect(object sender, RoutedEventArgs e)
     {
-        if (_suppressToggle || _hub == null) return;
-
-        if (ConnectToggle.IsOn)
-            _hub.ConnectAction?.Invoke();
-        else
-            _hub.DisconnectAction?.Invoke();
+        _hub?.DisconnectAction?.Invoke();
     }
 
     private void OnReconnect(object sender, RoutedEventArgs e)
     {
+        _connectionAttempts = 0;
         _hub?.ReconnectAction?.Invoke();
     }
 
@@ -334,183 +297,28 @@ public sealed partial class ConnectionPage : Page
         _hub?.RaiseSettingsSaved();
     }
 
-    private async void OnScanForGateways(object sender, RoutedEventArgs e)
+    private void OnSetupCodeTextChanged(object sender, TextChangedEventArgs e)
     {
-        ScanButton.IsEnabled = false;
-        ScanProgressRing.IsActive = true;
-        ScanProgressRing.Visibility = Visibility.Visible;
-        GatewayEmptyText.Visibility = Visibility.Collapsed;
-
-        try
+        var code = SetupCodeTextBox.Text?.Trim();
+        if (string.IsNullOrEmpty(code) || code.Length < 10)
         {
-            _discoveryService?.Dispose();
-            _discoveryService = new GatewayDiscoveryService();
-            await _discoveryService.StartDiscoveryAsync();
-            _discoveredGateways = _discoveryService.Gateways.ToList();
-            PopulateGatewayList();
-        }
-        catch (Exception ex)
-        {
-            GatewayEmptyText.Text = $"Discovery failed: {ex.Message}";
-            GatewayEmptyText.Visibility = Visibility.Visible;
-        }
-        finally
-        {
-            ScanButton.IsEnabled = true;
-            ScanProgressRing.IsActive = false;
-            ScanProgressRing.Visibility = Visibility.Collapsed;
-        }
-    }
-
-    private void PopulateGatewayList()
-    {
-        var currentUrl = _hub?.Settings?.GetEffectiveGatewayUrl();
-        // Build display list: discovered gateways + synthesized current gateway if not found
-        var displayList = new List<DiscoveredGateway>(_discoveredGateways);
-
-        // Compare by host:port to avoid ws:// vs http:// mismatches
-        string? currentHostPort = null;
-        Uri? currentUri = null;
-        if (!string.IsNullOrEmpty(currentUrl) && Uri.TryCreate(currentUrl, UriKind.Absolute, out var parsedUri))
-        {
-            currentUri = parsedUri;
-            currentHostPort = $"{parsedUri.Host}:{parsedUri.Port}";
+            SetupCodePreviewPanel.Visibility = Visibility.Collapsed;
+            SetupCodeResultText.Text = "";
+            return;
         }
 
-        if (_hub?.CurrentStatus == ConnectionStatus.Connected &&
-            currentHostPort != null &&
-            !displayList.Any(g => $"{g.Host}:{g.Port}".Equals(currentHostPort, StringComparison.OrdinalIgnoreCase)))
+        var decoded = SetupCodeDecoder.Decode(code);
+        if (decoded.Success)
         {
-            displayList.Insert(0, new DiscoveredGateway
-            {
-                Id = $"current-{currentHostPort}",
-                DisplayName = _hub.LastGatewaySelf?.ServerVersion != null
-                    ? $"Current Gateway (v{_hub.LastGatewaySelf.ServerVersion})"
-                    : "Current Gateway",
-                Host = currentUri!.Host,
-                Port = currentUri!.Port,
-                TlsEnabled = currentUri!.Scheme is "wss" or "https"
-            });
-        }
-
-        if (displayList.Count > 0)
-        {
-            GatewayListPanel.Children.Clear();
-            foreach (var gw in displayList)
-            {
-                var row = new Grid { Padding = new Thickness(4, 8, 4, 8), ColumnSpacing = 8 };
-                row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-                row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-                row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-
-                var info = new StackPanel { VerticalAlignment = VerticalAlignment.Center };
-                var nameTb = new TextBlock
-                {
-                    Text = gw.DisplayName,
-                    Style = (Style)Application.Current.Resources["BodyStrongTextBlockStyle"]
-                };
-                var addrTb = new TextBlock
-                {
-                    Text = $"{gw.Host}:{gw.Port}",
-                    Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
-                    Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]
-                };
-                info.Children.Add(nameTb);
-                info.Children.Add(addrTb);
-                Grid.SetColumn(info, 0);
-                row.Children.Add(info);
-
-                if (gw.TlsEnabled)
-                {
-                    var tls = new TextBlock { Text = "🔒", VerticalAlignment = VerticalAlignment.Center };
-                    Grid.SetColumn(tls, 1);
-                    row.Children.Add(tls);
-                }
-
-                // Match current gateway by host:port
-                var gwHostPort = $"{gw.Host}:{gw.Port}";
-                var isCurrentGw = currentHostPort != null &&
-                    gwHostPort.Equals(currentHostPort, StringComparison.OrdinalIgnoreCase);
-                var connectBtn = new Button
-                {
-                    Content = isCurrentGw ? "✓" : "→",
-                    VerticalAlignment = VerticalAlignment.Center,
-                    IsEnabled = !isCurrentGw,
-                    Tag = gw.Id
-                };
-                connectBtn.Click += OnConnectToGateway;
-                Grid.SetColumn(connectBtn, 2);
-                row.Children.Add(connectBtn);
-
-                GatewayListPanel.Children.Add(row);
-            }
-            GatewayListPanel.Visibility = Visibility.Visible;
-            GatewayEmptyText.Visibility = Visibility.Collapsed;
+            SetupCodePreviewUrl.Text = $"Gateway: {decoded.Url ?? "(not specified)"}";
+            SetupCodePreviewToken.Text = $"Bootstrap token: {decoded.Token?[..Math.Min(8, decoded.Token?.Length ?? 0)]}…";
+            SetupCodePreviewPanel.Visibility = Visibility.Visible;
+            SetupCodeResultText.Text = "";
         }
         else
         {
-            GatewayListPanel.Visibility = Visibility.Collapsed;
-            GatewayEmptyText.Text = "No gateways found. Click Scan to search.";
-            GatewayEmptyText.Visibility = Visibility.Visible;
+            SetupCodePreviewPanel.Visibility = Visibility.Collapsed;
         }
-    }
-
-    private void OnConnectToGateway(object sender, RoutedEventArgs e)
-    {
-        if (sender is not Button btn || btn.Tag is not string gatewayId) return;
-        var gw = _discoveredGateways.FirstOrDefault(g => g.Id == gatewayId);
-        if (gw == null || _hub?.Settings == null) return;
-
-        // When switching to a different gateway, always prompt for token
-        // (different gateways may have different tokens)
-        var currentUrl = _hub.Settings.GetEffectiveGatewayUrl() ?? "";
-        var isSameGateway = !string.IsNullOrEmpty(currentUrl) &&
-            Uri.TryCreate(currentUrl, UriKind.Absolute, out var curUri) &&
-            $"{curUri.Host}:{curUri.Port}".Equals($"{gw.Host}:{gw.Port}", StringComparison.OrdinalIgnoreCase);
-
-        if (isSameGateway)
-            return; // already connected to this one
-
-        _pendingGatewayUrl = gw.ConnectionUrl;
-        _pendingGatewayId = gw.Id;
-        TokenPromptText.Text = $"Connect to gateway at {gw.Host}:{gw.Port}";
-        TokenPromptBox.Text = _hub.Settings.Token ?? "";
-        TokenPromptPanel.Visibility = Visibility.Visible;
-        TokenPromptBox.Focus(Microsoft.UI.Xaml.FocusState.Programmatic);
-    }
-
-    private void OnConnectWithToken(object sender, RoutedEventArgs e)
-    {
-        var token = TokenPromptBox.Text?.Trim();
-        if (string.IsNullOrEmpty(token) || _hub?.Settings == null || string.IsNullOrEmpty(_pendingGatewayUrl))
-            return;
-
-        _hub.Settings.GatewayUrl = _pendingGatewayUrl;
-        _hub.Settings.Token = token;
-        if (!string.IsNullOrEmpty(_pendingGatewayId))
-            _hub.Settings.PreferredGatewayId = _pendingGatewayId;
-        _hub.Settings.Save();
-        _hub?.RaiseSettingsSaved();
-
-        // Clear auth error from previous attempt
-        if (_hub != null) _hub.LastAuthError = null;
-        AuthErrorBar.IsOpen = false;
-
-        GatewayUrlTextBox.Text = _pendingGatewayUrl;
-        TokenTextBox.Text = token;
-        TokenPromptPanel.Visibility = Visibility.Collapsed;
-        _pendingGatewayUrl = null;
-        _pendingGatewayId = null;
-
-        // Refresh discovery list to show ✓ on newly connected gateway
-        PopulateGatewayList();
-    }
-
-    private void OnCancelTokenPrompt(object sender, RoutedEventArgs e)
-    {
-        TokenPromptPanel.Visibility = Visibility.Collapsed;
-        _pendingGatewayUrl = null;
-        _pendingGatewayId = null;
     }
 
     private void OnApplySetupCode(object sender, RoutedEventArgs e)

--- a/src/OpenClaw.Tray.WinUI/Pages/HomePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/HomePage.xaml.cs
@@ -14,7 +14,6 @@ public sealed partial class HomePage : Page
 {
     private HubWindow? _hub;
     private bool _buttonsWired;
-    private ConnectionStatus _lastStatus = ConnectionStatus.Disconnected;
     private SessionInfo[]? _lastSessions;
 
     public HomePage()
@@ -53,7 +52,6 @@ public sealed partial class HomePage : Page
 
     public void UpdateConnectionStatus(ConnectionStatus status, string? gatewayUrl)
     {
-        _lastStatus = status;
         DispatcherQueue?.TryEnqueue(() =>
         {
             if (!string.IsNullOrEmpty(gatewayUrl))
@@ -131,10 +129,11 @@ public sealed partial class HomePage : Page
     public void UpdateSessions(SessionInfo[] sessions)
     {
         _lastSessions = sessions;
+        var status = _hub?.CurrentStatus ?? ConnectionStatus.Disconnected;
         DispatcherQueue?.TryEnqueue(() =>
         {
-            UpdateCompanionRing(_lastStatus);
-            UpdateStatusText(_lastStatus);
+            UpdateCompanionRing(status);
+            UpdateStatusText(status);
         });
     }
 

--- a/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
@@ -1516,16 +1516,18 @@ public sealed class OpenClawGatewayOperatorConnector : IGatewayOperatorConnector
 {
     private readonly IOpenClawLogger _logger;
     private readonly TimeSpan _timeout;
+    private readonly string? _identityPath;
 
-    public OpenClawGatewayOperatorConnector(IOpenClawLogger? logger = null, TimeSpan? timeout = null)
+    public OpenClawGatewayOperatorConnector(IOpenClawLogger? logger = null, TimeSpan? timeout = null, string? identityPath = null)
     {
         _logger = logger ?? NullLogger.Instance;
         _timeout = timeout ?? TimeSpan.FromSeconds(35);
+        _identityPath = identityPath;
     }
 
     public async Task<GatewayOperatorConnectionResult> ConnectAsync(string gatewayUrl, string token, bool tokenIsBootstrapToken = false, CancellationToken cancellationToken = default)
     {
-        using var client = new OpenClawGatewayClient(gatewayUrl, token, _logger, tokenIsBootstrapToken, bootstrapPairAsNode: false);
+        using var client = new OpenClawGatewayClient(gatewayUrl, token, _logger, tokenIsBootstrapToken, bootstrapPairAsNode: false, identityPath: _identityPath);
         var completion = new TaskCompletionSource<GatewayOperatorConnectionResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         client.StatusChanged += (_, status) =>
@@ -1565,7 +1567,7 @@ public sealed class OpenClawGatewayOperatorConnector : IGatewayOperatorConnector
 
     public async Task<GatewayOperatorConnectionResult> ConnectWithStoredDeviceTokenAsync(string gatewayUrl, CancellationToken cancellationToken = default)
     {
-        var dataPath = Path.Combine(
+        var dataPath = _identityPath ?? Path.Combine(
             Environment.GetEnvironmentVariable("OPENCLAW_TRAY_APPDATA_DIR")
                 ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
             "OpenClawTray");
@@ -1712,6 +1714,13 @@ public sealed class SettingsOperatorPairingService : IOperatorPairingService
         _settings.GatewayUrl = state.GatewayUrl;
         _settings.UseSshTunnel = false;
         _settings.Save();
+
+        // Clear any stale per-gateway identity so a fresh keypair is generated.
+        // After a nuke+reinstall the gateway is new but the per-gateway dir may
+        // contain a keypair from a previous gateway instance at the same URL.
+        var gwId = GatewayRecord.GenerateId(state.GatewayUrl);
+        var gwIdentityPath = Path.Combine(GatewayRecord.BaseIdentityDir, "gateways", gwId);
+        DeviceIdentity.TryClearStoredDeviceToken(gwIdentityPath);
 
         if (_connector == null)
             return new ProvisioningResult(true);
@@ -3020,7 +3029,10 @@ public static class LocalGatewaySetupEngineFactory
 
         var wsl = new WslExeCommandRunner(logger, TimeSpan.FromMinutes(30));
         var settingsAdapter = new SettingsManagerLocalGatewaySetupSettings(settings, gatewayRegistry);
-        var operatorConnector = new OpenClawGatewayOperatorConnector(logger);
+        var gwId = GatewayRecord.GenerateId(options.GatewayUrl);
+        var gwIdentityPath = Path.Combine(GatewayRecord.BaseIdentityDir, "gateways", gwId);
+        try { Directory.CreateDirectory(gwIdentityPath); } catch { }
+        var operatorConnector = new OpenClawGatewayOperatorConnector(logger, identityPath: gwIdentityPath);
         var bootstrapTokenProvider = new WslGatewayCliBootstrapTokenProvider(wsl, options.OpenClawInstallPrefix + "/bin/openclaw");
         var sharedGatewayTokenProvider = new WslGatewayCliSharedGatewayTokenProvider(wsl);
         var gatewayConfigurationPreparer = new OpenClawCliGatewayConfigurationPreparer(wsl);

--- a/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
@@ -359,8 +359,6 @@ public sealed class WslExeCommandRunner : IWslCommandRunner
             RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true,
-            StandardOutputEncoding = Encoding.UTF8,
-            StandardErrorEncoding = Encoding.UTF8
         };
 
         foreach (var argument in arguments)
@@ -374,6 +372,7 @@ public sealed class WslExeCommandRunner : IWslCommandRunner
         try
         {
             process.Start();
+            _logger.Info($"[WSL] Process started (PID {process.Id})");
         }
         catch (Exception ex)
         {
@@ -383,16 +382,19 @@ public sealed class WslExeCommandRunner : IWslCommandRunner
         var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
         var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
 
+        _logger.Info($"[WSL] Waiting for exit (timeout={_defaultTimeout.TotalSeconds}s)");
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeoutCts.CancelAfter(_defaultTimeout);
         bool timedOut = false;
         try
         {
             await process.WaitForExitAsync(timeoutCts.Token);
+            _logger.Info($"[WSL] Process exited (code={process.ExitCode})");
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
             timedOut = true;
+            _logger.Warn("[WSL] Process timed out — killing");
             try
             {
                 process.Kill(entireProcessTree: true);
@@ -410,8 +412,11 @@ public sealed class WslExeCommandRunner : IWslCommandRunner
         // during PR #274 smoke testing where the gateway distro held the pipes open for
         // hours. WaitForExitAsync only governs process exit, not stream drain, so we
         // need an explicit drain bound here.
+        _logger.Info("[WSL] Draining stdout...");
         var stdout = await DrainAsync(stdoutTask, _streamDrainTimeout, _logger, isStderr: false);
+        _logger.Info("[WSL] Draining stderr...");
         var stderr = await DrainAsync(stderrTask, _streamDrainTimeout, _logger, isStderr: true);
+        _logger.Info($"[WSL] Done (timedOut={timedOut}, stdout={stdout.Length}c, stderr={stderr.Length}c)");
 
         if (timedOut)
             return new WslCommandResult(-1, stdout, "wsl.exe timed out");

--- a/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
@@ -1315,15 +1315,69 @@ public interface ILocalGatewaySetupSettings
 public sealed class SettingsManagerLocalGatewaySetupSettings : ILocalGatewaySetupSettings
 {
     private readonly SettingsManager _settings;
+    private readonly GatewayRegistry? _registry;
 
-    public SettingsManagerLocalGatewaySetupSettings(SettingsManager settings)
+    public SettingsManagerLocalGatewaySetupSettings(SettingsManager settings, GatewayRegistry? registry = null)
     {
         _settings = settings;
+        _registry = registry;
     }
 
-    public string GatewayUrl { get => _settings.GatewayUrl; set => _settings.GatewayUrl = value; }
-    public string Token { get => _settings.Token; set => _settings.Token = value; }
-    public string BootstrapToken { get => _settings.BootstrapToken; set => _settings.BootstrapToken = value; }
+    public string GatewayUrl
+    {
+        get => _registry?.GetActive()?.Url ?? _settings.GatewayUrl;
+        set
+        {
+            _settings.GatewayUrl = value;
+            if (_registry != null && !string.IsNullOrWhiteSpace(value))
+            {
+                var gw = _registry.GetActive();
+                if (gw != null)
+                {
+                    gw.Url = value;
+                    _registry.AddOrUpdate(gw);
+                }
+                else
+                {
+                    // Create record if none exists (e.g., first setup)
+                    var id = GatewayRecord.GenerateId(value);
+                    _registry.AddOrUpdate(new GatewayRecord { Id = id, Url = value });
+                }
+            }
+        }
+    }
+
+    public string Token
+    {
+        get => _registry?.GetActive()?.OperatorDeviceToken ?? _settings.Token;
+        set
+        {
+            _settings.Token = value;
+            var gw = _registry?.GetActive();
+            if (gw != null && !string.IsNullOrWhiteSpace(value))
+            {
+                // If no operator token yet, this is the shared gateway token
+                // (provisioned before pairing). Store it as both.
+                if (string.IsNullOrWhiteSpace(gw.SharedGatewayToken))
+                    gw.SharedGatewayToken = value;
+                gw.OperatorDeviceToken = value;
+                gw.BootstrapToken = null;
+                _registry!.AddOrUpdate(gw);
+            }
+        }
+    }
+
+    public string BootstrapToken
+    {
+        get => _registry?.GetActive()?.BootstrapToken ?? _settings.BootstrapToken;
+        set
+        {
+            _settings.BootstrapToken = value;
+            var gw = _registry?.GetActive();
+            if (gw != null) { gw.BootstrapToken = value; _registry!.AddOrUpdate(gw); }
+        }
+    }
+
     public bool UseSshTunnel { get => _settings.UseSshTunnel; set => _settings.UseSshTunnel = value; }
     public bool EnableNodeMode { get => _settings.EnableNodeMode; set => _settings.EnableNodeMode = value; }
     public void Save() => _settings.Save();
@@ -1632,8 +1686,8 @@ public sealed class SettingsOperatorPairingService : IOperatorPairingService
     private readonly IGatewayOperatorConnector? _connector;
     private readonly IPendingDeviceApprover? _pendingApprover;
 
-    public SettingsOperatorPairingService(SettingsManager settings, IGatewayOperatorConnector? connector = null, IPendingDeviceApprover? pendingApprover = null)
-        : this(new SettingsManagerLocalGatewaySetupSettings(settings), connector, pendingApprover)
+    public SettingsOperatorPairingService(SettingsManager settings, IGatewayOperatorConnector? connector = null, IPendingDeviceApprover? pendingApprover = null, GatewayRegistry? registry = null)
+        : this(new SettingsManagerLocalGatewaySetupSettings(settings, registry), connector, pendingApprover)
     {
     }
 
@@ -2325,8 +2379,8 @@ public sealed class SettingsWindowsTrayNodeProvisioner : IWindowsTrayNodeProvisi
     private readonly IWindowsNodeConnector? _connector;
     private readonly IPendingDeviceApprover? _pendingApprover;
 
-    public SettingsWindowsTrayNodeProvisioner(SettingsManager settings, IWindowsNodeConnector? connector = null, IPendingDeviceApprover? pendingApprover = null)
-        : this(new SettingsManagerLocalGatewaySetupSettings(settings), connector, pendingApprover)
+    public SettingsWindowsTrayNodeProvisioner(SettingsManager settings, IWindowsNodeConnector? connector = null, IPendingDeviceApprover? pendingApprover = null, GatewayRegistry? registry = null)
+        : this(new SettingsManagerLocalGatewaySetupSettings(settings, registry), connector, pendingApprover)
     {
     }
 
@@ -2921,7 +2975,8 @@ public static class LocalGatewaySetupEngineFactory
         bool allowExistingDistro = false,
         bool replaceExistingConfigurationConfirmed = false,
         string? identityDataPath = null,
-        string? setupStatePath = null)
+        string? setupStatePath = null,
+        GatewayRegistry? gatewayRegistry = null)
     {
         // Defense-in-depth fail-closed: refuse to construct the engine if any of the
         // 6 sync existing-config predicates fire and the caller has not passed explicit
@@ -2964,7 +3019,7 @@ public static class LocalGatewaySetupEngineFactory
         };
 
         var wsl = new WslExeCommandRunner(logger, TimeSpan.FromMinutes(30));
-        var settingsAdapter = new SettingsManagerLocalGatewaySetupSettings(settings);
+        var settingsAdapter = new SettingsManagerLocalGatewaySetupSettings(settings, gatewayRegistry);
         var operatorConnector = new OpenClawGatewayOperatorConnector(logger);
         var bootstrapTokenProvider = new WslGatewayCliBootstrapTokenProvider(wsl, options.OpenClawInstallPrefix + "/bin/openclaw");
         var sharedGatewayTokenProvider = new WslGatewayCliSharedGatewayTokenProvider(wsl);

--- a/src/OpenClaw.Tray.WinUI/Services/SetupCodeApplicator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SetupCodeApplicator.cs
@@ -44,9 +44,8 @@ public static class SetupCodeApplicator
         settings.Token = "";
         settings.Save();
 
-        // Clear stored device token — setup code targets a potentially different gateway
-        if (!string.IsNullOrEmpty(dataPath))
-            DeviceIdentity.TryClearStoredDeviceToken(dataPath);
+        // No need to clear device tokens — per-gateway identity directories
+        // ensure each gateway gets its own Ed25519 keypair and tokens.
 
         var displayUrl = GatewayUrlHelper.SanitizeForDisplay(gatewayUrl);
         return new ApplyResult(true, DisplayUrl: displayUrl);

--- a/src/OpenClaw.Tray.WinUI/Services/SetupCodeApplicator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SetupCodeApplicator.cs
@@ -23,6 +23,7 @@ public static class SetupCodeApplicator
 
         var gatewayUrl = result.Url ?? settings.GatewayUrl ?? "";
 
+        // Registry: single source of truth
         if (registry != null && !string.IsNullOrWhiteSpace(gatewayUrl))
         {
             var id = GatewayRecord.GenerateId(gatewayUrl);
@@ -34,6 +35,14 @@ public static class SetupCodeApplicator
                 BootstrapToken = result.Token,
             });
         }
+
+        // Settings: keep in sync for setup engine and other consumers
+        if (!string.IsNullOrEmpty(result.Url))
+            settings.GatewayUrl = result.Url;
+        if (!string.IsNullOrEmpty(result.Token))
+            settings.BootstrapToken = result.Token;
+        settings.Token = "";
+        settings.Save();
 
         // Clear stored device token — setup code targets a potentially different gateway
         if (!string.IsNullOrEmpty(dataPath))

--- a/src/OpenClaw.Tray.WinUI/Services/SetupCodeApplicator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SetupCodeApplicator.cs
@@ -4,23 +4,15 @@ using OpenClawTray.Onboarding.Services;
 namespace OpenClawTray.Services;
 
 /// <summary>
-/// Applies a decoded setup code to settings. Shared by Settings page and
-/// Onboarding wizard to guarantee consistent behavior:
-/// — GatewayUrl is updated from the decoded URL
-/// — BootstrapToken is set (single-use, for pairing only)
-/// — Token is cleared to prevent dual-token confusion
-/// — Stored device token is cleared (setup code = new pairing to a potentially different gateway)
+/// Applies a decoded setup code to the gateway registry (the single source
+/// of truth for gateway URL, tokens, and bootstrap state).
 /// </summary>
 public static class SetupCodeApplicator
 {
     public record ApplyResult(bool Success, string? DisplayUrl = null, string? Error = null);
 
-    /// <summary>
-    /// Decodes the raw setup code and applies the result to settings.
-    /// Clears Settings.Token and stored device tokens to avoid stale
-    /// credentials from a previous gateway pairing.
-    /// </summary>
-    public static ApplyResult Apply(string? rawCode, SettingsManager settings, string? dataPath = null)
+    public static ApplyResult Apply(string? rawCode, SettingsManager settings,
+        string? dataPath = null, GatewayRegistry? registry = null)
     {
         if (string.IsNullOrWhiteSpace(rawCode))
             return new ApplyResult(false, Error: "Please paste a setup code.");
@@ -29,32 +21,25 @@ public static class SetupCodeApplicator
         if (!result.Success)
             return new ApplyResult(false, Error: result.Error);
 
-        if (!string.IsNullOrEmpty(result.Url))
-            settings.GatewayUrl = result.Url;
+        var gatewayUrl = result.Url ?? settings.GatewayUrl ?? "";
 
-        if (!string.IsNullOrEmpty(result.Token))
+        if (registry != null && !string.IsNullOrWhiteSpace(gatewayUrl))
         {
-            // Bootstrap token goes to BootstrapToken only — it's single-use for
-            // device pairing and must NOT be saved as Settings.Token.
-            settings.BootstrapToken = result.Token;
+            var id = GatewayRecord.GenerateId(gatewayUrl);
+            registry.Remove(id);
+            registry.AddOrUpdate(new GatewayRecord
+            {
+                Id = id,
+                Url = gatewayUrl,
+                BootstrapToken = result.Token,
+            });
         }
 
-        // Clear the manual token to prevent the dual-save race where
-        // a stale Token value is persisted alongside BootstrapToken.
-        settings.Token = "";
-
-        // Clear any stored device token from a previous pairing — the setup code
-        // may target a different gateway that doesn't recognize the old token.
+        // Clear stored device token — setup code targets a potentially different gateway
         if (!string.IsNullOrEmpty(dataPath))
-        {
             DeviceIdentity.TryClearStoredDeviceToken(dataPath);
-        }
 
-        settings.Save();
-
-        var displayUrl = GatewayUrlHelper.SanitizeForDisplay(
-            result.Url ?? settings.GatewayUrl ?? "");
-
+        var displayUrl = GatewayUrlHelper.SanitizeForDisplay(gatewayUrl);
         return new ApplyResult(true, DisplayUrl: displayUrl);
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Services/SetupCodeApplicator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SetupCodeApplicator.cs
@@ -1,0 +1,60 @@
+using OpenClaw.Shared;
+using OpenClawTray.Onboarding.Services;
+
+namespace OpenClawTray.Services;
+
+/// <summary>
+/// Applies a decoded setup code to settings. Shared by Settings page and
+/// Onboarding wizard to guarantee consistent behavior:
+/// — GatewayUrl is updated from the decoded URL
+/// — BootstrapToken is set (single-use, for pairing only)
+/// — Token is cleared to prevent dual-token confusion
+/// — Stored device token is cleared (setup code = new pairing to a potentially different gateway)
+/// </summary>
+public static class SetupCodeApplicator
+{
+    public record ApplyResult(bool Success, string? DisplayUrl = null, string? Error = null);
+
+    /// <summary>
+    /// Decodes the raw setup code and applies the result to settings.
+    /// Clears Settings.Token and stored device tokens to avoid stale
+    /// credentials from a previous gateway pairing.
+    /// </summary>
+    public static ApplyResult Apply(string? rawCode, SettingsManager settings, string? dataPath = null)
+    {
+        if (string.IsNullOrWhiteSpace(rawCode))
+            return new ApplyResult(false, Error: "Please paste a setup code.");
+
+        var result = SetupCodeDecoder.Decode(rawCode.Trim());
+        if (!result.Success)
+            return new ApplyResult(false, Error: result.Error);
+
+        if (!string.IsNullOrEmpty(result.Url))
+            settings.GatewayUrl = result.Url;
+
+        if (!string.IsNullOrEmpty(result.Token))
+        {
+            // Bootstrap token goes to BootstrapToken only — it's single-use for
+            // device pairing and must NOT be saved as Settings.Token.
+            settings.BootstrapToken = result.Token;
+        }
+
+        // Clear the manual token to prevent the dual-save race where
+        // a stale Token value is persisted alongside BootstrapToken.
+        settings.Token = "";
+
+        // Clear any stored device token from a previous pairing — the setup code
+        // may target a different gateway that doesn't recognize the old token.
+        if (!string.IsNullOrEmpty(dataPath))
+        {
+            DeviceIdentity.TryClearStoredDeviceToken(dataPath);
+        }
+
+        settings.Save();
+
+        var displayUrl = GatewayUrlHelper.SanitizeForDisplay(
+            result.Url ?? settings.GatewayUrl ?? "");
+
+        return new ApplyResult(true, DisplayUrl: displayUrl);
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
@@ -22,6 +22,7 @@ public sealed partial class ChatWindow : WindowEx
     private string _chatUrl = "";
     private bool _webViewInitialized;
     public bool IsClosed { get; private set; }
+    public string Token => _token;
 
     [DllImport("user32.dll")] private static extern int GetWindowLong(IntPtr hWnd, int nIndex);
     [DllImport("user32.dll")] private static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
@@ -52,7 +53,7 @@ public sealed partial class ChatWindow : WindowEx
         public int dwFlags;
     }
 
-    public ChatWindow(string gatewayUrl, string token)
+    public ChatWindow(string gatewayUrl, string token, string? deviceId = null)
     {
         _gatewayUrl = gatewayUrl;
         _token = token;

--- a/src/OpenClaw.Tray.WinUI/Windows/ConnectionStatusWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/ConnectionStatusWindow.xaml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<winex:WindowEx x:Uid="ConnectionStatusWindow"
+    x:Class="OpenClawTray.Windows.ConnectionStatusWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:winex="using:WinUIEx"
+    Title="Connection Status"
+    Width="1100" Height="700"
+    MinWidth="800" MinHeight="500">
+
+    <Window.SystemBackdrop>
+        <MicaBackdrop/>
+    </Window.SystemBackdrop>
+
+    <Grid Padding="12" ColumnSpacing="12">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="320"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <!-- LEFT COLUMN: State Machine + Gateways + Credentials (fixed width) -->
+        <ScrollViewer Grid.Column="0" VerticalScrollBarVisibility="Auto">
+        <StackPanel>
+
+            <!-- State Machine Visual -->
+            <TextBlock Text="STATE MACHINE" FontWeight="Bold" FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="0,0,0,4" CharacterSpacing="100"/>
+            <Grid Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="6" Padding="10" Margin="0,0,0,8">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <!-- Operator flow -->
+                <StackPanel Grid.Row="0" Margin="0,0,0,6">
+                    <StackPanel Orientation="Horizontal" Spacing="4" Margin="0,0,0,3">
+                        <TextBlock Text="OPERATOR" FontSize="9" FontWeight="Bold" Foreground="{ThemeResource TextFillColorSecondaryBrush}" CharacterSpacing="80" VerticalAlignment="Center" Width="65"/>
+                        <Border x:Name="OpDisconnected" CornerRadius="3" Padding="6,2"><TextBlock Text="Off" FontSize="10"/></Border>
+                        <TextBlock Text="→" VerticalAlignment="Center" FontSize="9" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                        <Border x:Name="OpConnecting" CornerRadius="3" Padding="6,2"><TextBlock Text="Connecting" FontSize="10"/></Border>
+                        <TextBlock Text="→" VerticalAlignment="Center" FontSize="9" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                        <Border x:Name="OpConnected" CornerRadius="3" Padding="6,2"><TextBlock Text="Connected" FontSize="10"/></Border>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="4" Margin="69,0,0,0">
+                        <Border x:Name="OpPairing" CornerRadius="3" Padding="6,2"><TextBlock Text="Pairing" FontSize="10"/></Border>
+                        <Border x:Name="OpError" CornerRadius="3" Padding="6,2"><TextBlock Text="Error" FontSize="10"/></Border>
+                    </StackPanel>
+                    <TextBlock x:Name="OpDetailText" FontSize="9" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="69,2,0,0" TextWrapping="Wrap"/>
+                </StackPanel>
+
+                <!-- Node flow -->
+                <StackPanel Grid.Row="1">
+                    <StackPanel Orientation="Horizontal" Spacing="4" Margin="0,0,0,3">
+                        <TextBlock Text="NODE" FontSize="9" FontWeight="Bold" Foreground="{ThemeResource TextFillColorSecondaryBrush}" CharacterSpacing="80" VerticalAlignment="Center" Width="65"/>
+                        <Border x:Name="NodeDisconnected" CornerRadius="3" Padding="6,2"><TextBlock Text="Off" FontSize="10"/></Border>
+                        <TextBlock Text="→" VerticalAlignment="Center" FontSize="9" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                        <Border x:Name="NodeConnecting" CornerRadius="3" Padding="6,2"><TextBlock Text="Connecting" FontSize="10"/></Border>
+                        <TextBlock Text="→" VerticalAlignment="Center" FontSize="9" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                        <Border x:Name="NodeConnected" CornerRadius="3" Padding="6,2"><TextBlock Text="Connected" FontSize="10"/></Border>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="4" Margin="69,0,0,0">
+                        <Border x:Name="NodePairing" CornerRadius="3" Padding="6,2"><TextBlock Text="Pairing" FontSize="10"/></Border>
+                        <Border x:Name="NodeError" CornerRadius="3" Padding="6,2"><TextBlock Text="Error" FontSize="10"/></Border>
+                    </StackPanel>
+                    <TextBlock x:Name="NodeDetailText" FontSize="9" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="69,2,0,0" TextWrapping="Wrap"/>
+                </StackPanel>
+            </Grid>
+
+            <!-- Gateways -->
+            <TextBlock Text="GATEWAYS" FontWeight="Bold" FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="0,0,0,4" CharacterSpacing="100"/>
+            <StackPanel x:Name="GatewayListPanel" Spacing="3" Margin="0,0,0,8"/>
+
+            <!-- Credentials -->
+            <TextBlock Text="CREDENTIALS" FontWeight="Bold" FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="0,0,0,4" CharacterSpacing="100"/>
+            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="6" Padding="10">
+                <TextBlock x:Name="CredentialsText" FontFamily="Consolas" FontSize="10.5" TextWrapping="Wrap" IsTextSelectionEnabled="True"/>
+            </Border>
+        </StackPanel>
+        </ScrollViewer>
+
+        <!-- RIGHT COLUMN: Event Timeline (takes all remaining space) -->
+        <Grid Grid.Column="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <Grid Grid.Row="0" Margin="0,0,0,4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Column="0" Text="EVENT TIMELINE" FontWeight="Bold" FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" VerticalAlignment="Center" CharacterSpacing="100"/>
+                <Button Grid.Column="1" Content="Copy" Click="OnCopyTimeline" Margin="0,0,4,0" Padding="6,2" FontSize="11"/>
+                <Button Grid.Column="2" Content="Clear" Click="OnClearTimeline" Padding="6,2" FontSize="11"/>
+            </Grid>
+            <ScrollViewer Grid.Row="1" x:Name="TimelineScroll"
+                          Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="6" Padding="10"
+                          VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+                <RichTextBlock x:Name="TimelineRichText" FontFamily="Consolas" FontSize="11" IsTextSelectionEnabled="True" TextWrapping="NoWrap"/>
+            </ScrollViewer>
+        </Grid>
+    </Grid>
+</winex:WindowEx>

--- a/src/OpenClaw.Tray.WinUI/Windows/ConnectionStatusWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/ConnectionStatusWindow.xaml.cs
@@ -1,0 +1,361 @@
+using Microsoft.UI;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Text;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
+using Microsoft.UI.Xaml.Media;
+using OpenClaw.Shared;
+using System;
+using System.IO;
+using System.Text;
+using WinUIEx;
+using WinDataTransfer = global::Windows.ApplicationModel.DataTransfer;
+
+namespace OpenClawTray.Windows;
+
+public sealed partial class ConnectionStatusWindow : WindowEx
+{
+    private readonly ConnectionDiagnostics _diagnostics;
+    private readonly GatewayRegistry? _registry;
+    private readonly GatewayConnectionService? _service;
+    private readonly DispatcherQueue _dispatcherQueue;
+    private readonly StringBuilder _plainBuffer = new();
+    private DateTime _lastOpStatusTime = DateTime.Now;
+
+    private static readonly SolidColorBrush GreenBrush = new(ColorHelper.FromArgb(255, 76, 175, 80));
+    private static readonly SolidColorBrush AmberBrush = new(ColorHelper.FromArgb(255, 255, 193, 7));
+    private static readonly SolidColorBrush RedBrush = new(ColorHelper.FromArgb(255, 211, 47, 47));
+    private static readonly SolidColorBrush DimBrush = new(ColorHelper.FromArgb(40, 255, 255, 255));
+    private static readonly SolidColorBrush ErrorTextBrush = new(ColorHelper.FromArgb(255, 239, 83, 80));
+    private static readonly SolidColorBrush AuthTextBrush = new(ColorHelper.FromArgb(255, 255, 213, 79));
+    private static readonly SolidColorBrush OkTextBrush = new(ColorHelper.FromArgb(255, 129, 199, 132));
+    private static readonly SolidColorBrush DimTextBrush = new(ColorHelper.FromArgb(180, 180, 180, 180));
+
+    public bool IsClosed { get; private set; }
+
+    public ConnectionStatusWindow(ConnectionDiagnostics diagnostics, GatewayRegistry? registry, GatewayConnectionService? service = null)
+    {
+        InitializeComponent();
+        _diagnostics = diagnostics;
+        _registry = registry;
+        _service = service;
+        _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+
+        // Load existing events
+        var existing = _diagnostics.GetSnapshot();
+        for (int i = existing.Count - 1; i >= 0; i--)
+            AppendTimelineRich(existing[i]);
+
+        _diagnostics.EventRecorded += OnEventRecorded;
+
+        // Subscribe to service state changes for live state machine updates
+        if (_service != null)
+            _service.StateChanged += OnServiceStateChanged;
+
+        Closed += (_, _) =>
+        {
+            IsClosed = true;
+            _diagnostics.EventRecorded -= OnEventRecorded;
+            if (_service != null)
+                _service.StateChanged -= OnServiceStateChanged;
+        };
+
+        RefreshAll();
+    }
+
+    private void OnServiceStateChanged(GatewayConnectionState oldState, GatewayConnectionState newState, GatewayConnectionSnapshot snapshot)
+    {
+        _dispatcherQueue.TryEnqueue(() =>
+        {
+            _lastOpStatusTime = DateTime.Now;
+            RefreshStateMachineFromSnapshot(snapshot);
+            RefreshGateways();
+            RefreshCredentials();
+        });
+    }
+
+    private void OnEventRecorded(object? sender, ConnectionEvent evt)
+    {
+        _dispatcherQueue.TryEnqueue(() =>
+        {
+            PrependTimelineRich(evt);
+            // Auto-refresh state on state-changing events
+            if (evt.EventType is "HELLO_OK" or "ERROR" or "PAIRING_REQUIRED" or "DISCONNECT" or "STATE_CHANGE")
+                RefreshAll();
+        });
+    }
+
+    public void UpdateOperatorStatus(ConnectionStatus status)
+    {
+        _lastOpStatusTime = DateTime.Now;
+        // If service is wired, let OnServiceStateChanged handle it
+        if (_service != null) return;
+        _dispatcherQueue.TryEnqueue(RefreshStateMachine);
+    }
+
+    public void RefreshAll()
+    {
+        if (_service != null)
+            RefreshStateMachineFromSnapshot(_service.Snapshot);
+        else
+            RefreshStateMachine();
+        RefreshGateways();
+        RefreshCredentials();
+    }
+
+    private void RefreshStateMachineFromSnapshot(GatewayConnectionSnapshot snapshot)
+    {
+        HighlightState(OpDisconnected, snapshot.Operator == GatewayRoleState.Idle, DimBrush);
+        HighlightState(OpConnecting, snapshot.Operator == GatewayRoleState.Connecting, AmberBrush);
+        HighlightState(OpConnected, snapshot.Operator == GatewayRoleState.Connected, GreenBrush);
+        HighlightState(OpError, snapshot.Operator == GatewayRoleState.Error, RedBrush);
+        HighlightState(OpPairing, snapshot.Operator == GatewayRoleState.PairingRequired, AmberBrush);
+
+        var elapsed = DateTime.Now - _lastOpStatusTime;
+        var elapsedStr = elapsed.TotalSeconds < 60 ? $"{elapsed.TotalSeconds:F0}s" : $"{elapsed.TotalMinutes:F0}m";
+        OpDetailText.Text = snapshot.Operator switch
+        {
+            GatewayRoleState.Connected => $"✓ {elapsedStr}",
+            GatewayRoleState.Error => $"✗ {elapsedStr} — {snapshot.LastError ?? "unknown error"}",
+            GatewayRoleState.PairingRequired => $"⏳ Approval needed (requestId={snapshot.PairingRequestId?[..Math.Min(8, snapshot.PairingRequestId.Length)]}…)",
+            _ => elapsedStr
+        };
+
+        HighlightState(NodeDisconnected, snapshot.Node is GatewayRoleState.Idle or GatewayRoleState.Disabled, DimBrush);
+        HighlightState(NodeConnecting, snapshot.Node == GatewayRoleState.Connecting, AmberBrush);
+        HighlightState(NodeConnected, snapshot.Node == GatewayRoleState.Connected, GreenBrush);
+        HighlightState(NodeError, snapshot.Node == GatewayRoleState.Error, RedBrush);
+        HighlightState(NodePairing, snapshot.Node == GatewayRoleState.PairingRequired, AmberBrush);
+        NodeDetailText.Text = snapshot.Node == GatewayRoleState.Disabled ? "disabled" : "";
+    }
+
+    private void RefreshStateMachine()
+    {
+        var status = _registry?.ActiveConnectionStatus ?? ConnectionStatus.Disconnected;
+
+        HighlightState(OpDisconnected, status == ConnectionStatus.Disconnected, DimBrush);
+        HighlightState(OpConnecting, status == ConnectionStatus.Connecting, AmberBrush);
+        HighlightState(OpConnected, status == ConnectionStatus.Connected, GreenBrush);
+        HighlightState(OpError, status == ConnectionStatus.Error, RedBrush);
+        HighlightState(OpPairing, false, DimBrush);
+
+        var elapsed = DateTime.Now - _lastOpStatusTime;
+        var elapsedStr = elapsed.TotalSeconds < 60 ? $"{elapsed.TotalSeconds:F0}s" : $"{elapsed.TotalMinutes:F0}m";
+        OpDetailText.Text = status == ConnectionStatus.Connected
+            ? $"✓ {elapsedStr}"
+            : status == ConnectionStatus.Error ? $"✗ {elapsedStr}" : elapsedStr;
+
+        HighlightState(NodeDisconnected, true, DimBrush);
+        HighlightState(NodeConnecting, false, AmberBrush);
+        HighlightState(NodeConnected, false, GreenBrush);
+        HighlightState(NodeError, false, RedBrush);
+        HighlightState(NodePairing, false, DimBrush);
+        NodeDetailText.Text = "";
+    }
+
+    private static void HighlightState(Border border, bool active, SolidColorBrush activeBrush)
+    {
+        border.Background = active ? activeBrush : DimBrush;
+        border.Opacity = active ? 1.0 : 0.35;
+    }
+
+    private void RefreshGateways()
+    {
+        GatewayListPanel.Children.Clear();
+        var gateways = _registry?.GetAll();
+        var activeId = _registry?.GetActive()?.Id;
+
+        if (gateways == null || gateways.Count == 0)
+        {
+            GatewayListPanel.Children.Add(new TextBlock { Text = "No gateways", FontSize = 11, Foreground = DimTextBrush });
+            return;
+        }
+
+        foreach (var gw in gateways)
+        {
+            var isActive = gw.Id == activeId;
+            var hasIdentity = File.Exists(Path.Combine(gw.IdentityPath, "device-key-ed25519.json"));
+
+            var tokens = "";
+            if (!string.IsNullOrWhiteSpace(gw.SharedGatewayToken)) tokens += "S";
+            if (!string.IsNullOrWhiteSpace(gw.BootstrapToken)) tokens += "B";
+            if (!string.IsNullOrWhiteSpace(gw.OperatorDeviceToken)) tokens += "O";
+            if (!string.IsNullOrWhiteSpace(gw.NodeDeviceToken)) tokens += "N";
+
+            var opState = _service?.Snapshot.Operator ?? GatewayRoleState.Idle;
+            var statusIcon = isActive
+                ? (opState == GatewayRoleState.Connected ? "🟢" : opState == GatewayRoleState.Error ? "🔴" : opState == GatewayRoleState.Connecting ? "🟡" : "⚪")
+                : "○";
+
+            var border = new Border
+            {
+                Background = Application.Current.Resources["CardBackgroundFillColorDefaultBrush"] as Brush,
+                CornerRadius = new CornerRadius(5),
+                Padding = new Thickness(8, 5, 8, 5),
+                BorderThickness = isActive ? new Thickness(1.5) : new Thickness(0),
+                BorderBrush = isActive ? GreenBrush : null,
+            };
+
+            var sp = new StackPanel();
+            sp.Children.Add(new TextBlock
+            {
+                Text = $"{statusIcon} {gw.Url}",
+                FontSize = 11.5,
+                FontWeight = isActive ? FontWeights.Bold : FontWeights.Normal
+            });
+            sp.Children.Add(new TextBlock
+            {
+                Text = $"  {gw.Id}  {(hasIdentity ? "🔑" : "—")}  [{tokens}]",
+                FontSize = 9.5,
+                Foreground = DimTextBrush
+            });
+
+            border.Child = sp;
+            GatewayListPanel.Children.Add(border);
+        }
+    }
+
+    private void RefreshCredentials()
+    {
+        var activeGw = _registry?.GetActive();
+        var sb = new StringBuilder();
+
+        sb.AppendLine("REGISTRY");
+        sb.AppendLine($"  SharedGateway  {Redact(activeGw?.SharedGatewayToken)}");
+        sb.AppendLine($"  Bootstrap      {Redact(activeGw?.BootstrapToken)}");
+        sb.AppendLine($"  OpDevToken     {Redact(activeGw?.OperatorDeviceToken)}");
+        sb.AppendLine($"  NodeDevToken   {Redact(activeGw?.NodeDeviceToken)}");
+
+        if (activeGw != null)
+        {
+            var keyPath = Path.Combine(activeGw.IdentityPath, "device-key-ed25519.json");
+            sb.AppendLine();
+            sb.AppendLine($"IDENTITY ({(File.Exists(keyPath) ? "✅" : "❌")})");
+            if (File.Exists(keyPath))
+            {
+                try
+                {
+                    var json = System.Text.Json.JsonDocument.Parse(File.ReadAllText(keyPath));
+                    var root = json.RootElement;
+                    sb.AppendLine($"  DeviceId       {TryGet(root, "DeviceId", 16)}");
+                    sb.AppendLine($"  DeviceToken    {TryGet(root, "DeviceToken")}");
+                    sb.AppendLine($"  Scopes         {TryGetArray(root, "DeviceTokenScopes")}");
+                    sb.AppendLine($"  NodeToken      {TryGet(root, "NodeDeviceToken")}");
+                }
+                catch { sb.AppendLine("  (parse error)"); }
+            }
+        }
+
+        sb.AppendLine();
+        sb.Append("RESOLVES → ");
+        if (!string.IsNullOrWhiteSpace(activeGw?.SharedGatewayToken))
+            sb.Append("SharedGateway (admin)");
+        else if (!string.IsNullOrWhiteSpace(activeGw?.BootstrapToken))
+            sb.Append("Bootstrap (limited)");
+        else
+            sb.Append("StoredDevice / settings");
+
+        CredentialsText.Text = sb.ToString();
+    }
+
+    // ── Timeline with colors ──
+
+    private void PrependTimelineRich(ConnectionEvent evt)
+    {
+        var para = CreateTimelineParagraph(evt);
+        TimelineRichText.Blocks.Insert(0, para);
+        while (TimelineRichText.Blocks.Count > 500)
+            TimelineRichText.Blocks.RemoveAt(TimelineRichText.Blocks.Count - 1);
+
+        _plainBuffer.Insert(0, FormatPlain(evt));
+    }
+
+    private void AppendTimelineRich(ConnectionEvent evt)
+    {
+        TimelineRichText.Blocks.Add(CreateTimelineParagraph(evt));
+        _plainBuffer.AppendLine(FormatPlain(evt).TrimEnd());
+    }
+
+    private static Paragraph CreateTimelineParagraph(ConnectionEvent evt)
+    {
+        var para = new Paragraph { Margin = new Thickness(0, 0, 0, 2) };
+
+        // Timestamp
+        para.Inlines.Add(new Run { Text = evt.Timestamp.ToString("HH:mm:ss.fff") + " ", Foreground = DimTextBrush });
+
+        // Direction
+        para.Inlines.Add(new Run { Text = evt.Direction.PadRight(6) + " ", Foreground = DimTextBrush });
+
+        // Event type + summary (color-coded)
+        var brush = evt.EventType switch
+        {
+            "ERROR" or "AUTH_FAILED" => ErrorTextBrush,
+            "SIGNATURE_REJECTED" or "PAIRING_REQUIRED" => AmberBrush,
+            "AUTH" or "CREDENTIAL_RESOLVED" => AuthTextBrush,
+            "HELLO_OK" or "NODE_PAIRED" => OkTextBrush,
+            _ => (SolidColorBrush?)null
+        };
+
+        var summary = $"[{evt.EventType}] {evt.Summary}";
+        para.Inlines.Add(brush != null
+            ? new Run { Text = summary, Foreground = brush }
+            : new Run { Text = summary });
+
+        // Detail on next line
+        if (!string.IsNullOrEmpty(evt.Detail))
+        {
+            para.Inlines.Add(new Run { Text = "\n    " + evt.Detail.Replace("\n", "\n    "), Foreground = DimTextBrush, FontSize = 10 });
+        }
+
+        return para;
+    }
+
+    private static string FormatPlain(ConnectionEvent evt)
+    {
+        var detail = evt.Detail != null ? $"\n    {evt.Detail.Replace("\n", "\n    ")}" : "";
+        return $"{evt.Timestamp:HH:mm:ss.fff} {evt.Direction,-6} [{evt.EventType}] {evt.Summary}{detail}\n";
+    }
+
+    private void OnCopyTimeline(object sender, RoutedEventArgs e)
+    {
+        var dp = new WinDataTransfer.DataPackage();
+        dp.SetText(_plainBuffer.ToString());
+        WinDataTransfer.Clipboard.SetContent(dp);
+    }
+
+    private void OnClearTimeline(object sender, RoutedEventArgs e)
+    {
+        _plainBuffer.Clear();
+        TimelineRichText.Blocks.Clear();
+        _diagnostics.Clear();
+    }
+
+    private static string Redact(string? v) =>
+        string.IsNullOrWhiteSpace(v) ? "null" : $"{v[..Math.Min(10, v.Length)]}… ({v.Length}c)";
+
+    private static string TryGet(System.Text.Json.JsonElement root, string prop, int maxLen = 10)
+    {
+        if (root.TryGetProperty(prop, out var val) && val.ValueKind == System.Text.Json.JsonValueKind.String)
+        {
+            var s = val.GetString() ?? "";
+            return s.Length > maxLen ? $"{s[..maxLen]}…" : s;
+        }
+        return "null";
+    }
+
+    private static string TryGetArray(System.Text.Json.JsonElement root, string prop)
+    {
+        if (root.TryGetProperty(prop, out var val) && val.ValueKind == System.Text.Json.JsonValueKind.Array)
+        {
+            var items = new System.Collections.Generic.List<string>();
+            foreach (var item in val.EnumerateArray())
+            {
+                var s = item.GetString() ?? "";
+                items.Add(s.Replace("operator.", ""));
+            }
+            return items.Count > 0 ? string.Join(", ", items) : "(empty)";
+        }
+        return "null";
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -35,6 +35,7 @@ public sealed partial class HubWindow : WindowEx
     }
     public OpenClawGatewayClient? GatewayClient => GatewayRegistry?.ActiveClient;
     public GatewayRegistry? GatewayRegistry { get; set; }
+    public GatewayConnectionService? ConnectionService { get; set; }
     public ConnectionStatus CurrentStatus => GatewayRegistry?.ActiveConnectionStatus ?? ConnectionStatus.Disconnected;
     private string _currentAgentId = "main";
     public string CurrentAgentId => _currentAgentId;

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -101,13 +101,22 @@ public sealed partial class HubWindow : WindowEx
 
     /// <summary>
     /// Navigate to the default page. Call after setting Settings/GatewayClient.
+    /// When disconnected, lands on Connection page instead of Home.
     /// </summary>
     public void NavigateToDefault()
     {
         if (ContentFrame.Content == null)
         {
-            // Navigate to Home (first item)
-            NavView.SelectedItem = NavView.MenuItems[0];
+            UpdateNavItemsForConnectionState(CurrentStatus);
+            if (CurrentStatus == ConnectionStatus.Disconnected &&
+                (GatewayClient == null || !GatewayClient.IsConnectedToGateway))
+            {
+                NavigateTo("connection");
+            }
+            else
+            {
+                NavView.SelectedItem = NavView.MenuItems[0];
+            }
         }
     }
 
@@ -163,6 +172,7 @@ public sealed partial class HubWindow : WindowEx
                 if (status == ConnectionStatus.Disconnected)
                     _lastGatewaySelf = null;
                 UpdateTitleBarStatus(status);
+                UpdateNavItemsForConnectionState(status);
                 if (ContentFrame?.Content is HomePage homePage)
                 {
                     homePage.UpdateConnectionStatus(status, Settings?.GetEffectiveGatewayUrl());
@@ -171,9 +181,67 @@ public sealed partial class HubWindow : WindowEx
                 {
                     connectionPage.UpdateStatus(status);
                 }
+                // When disconnected and on a gateway-dependent page, redirect to Connection
+                if (status == ConnectionStatus.Disconnected && IsGatewayDependentPage(ContentFrame?.Content))
+                {
+                    NavigateTo("connection");
+                }
             });
         }
         catch { }
+    }
+
+    private static bool IsGatewayDependentPage(object? page) => page is
+        ChatPage or SessionsPage or ConversationsPage or AgentEventsPage or
+        ChannelsPage or NodesPage or InstancesPage or ConfigPage or
+        UsagePage or BindingsPage or SkillsPage or CronPage or WorkspacePage;
+
+    private static readonly string[] s_gatewayDependentTags =
+    [
+        "chat", "sessions", "conversations", "agentevents", "skills",
+        "channels", "nodes", "bindings", "config", "usage", "cron"
+    ];
+
+    private void UpdateNavItemsForConnectionState(ConnectionStatus status)
+    {
+        var visible = status == ConnectionStatus.Connected;
+        SetNavItemsVisibility(NavView.MenuItems, visible);
+    }
+
+    private static void SetNavItemsVisibility(IList<object> items, bool connected)
+    {
+        foreach (var item in items)
+        {
+            if (item is NavigationViewItem navItem)
+            {
+                var tag = navItem.Tag as string;
+                if (tag != null && s_gatewayDependentTags.Contains(tag))
+                {
+                    navItem.Visibility = connected ? Visibility.Visible : Visibility.Collapsed;
+                }
+                if (tag != null && tag.StartsWith("agent:"))
+                {
+                    navItem.Visibility = connected ? Visibility.Visible : Visibility.Collapsed;
+                }
+                if (navItem.MenuItems.Count > 0)
+                {
+                    SetNavItemsVisibility(navItem.MenuItems, connected);
+                    var hasGatewayChildren = navItem.MenuItems.OfType<NavigationViewItem>()
+                        .Any(c => (c.Tag as string)?.StartsWith("agent:") == true ||
+                                  s_gatewayDependentTags.Contains(c.Tag as string ?? ""));
+                    if (hasGatewayChildren)
+                    {
+                        var allHidden = navItem.MenuItems.OfType<NavigationViewItem>()
+                            .All(c => c.Visibility == Visibility.Collapsed);
+                        navItem.Visibility = allHidden ? Visibility.Collapsed : Visibility.Visible;
+                    }
+                }
+            }
+            if (item is NavigationViewItemHeader header && header.Content?.ToString() == "Gateway")
+            {
+                header.Visibility = connected ? Visibility.Visible : Visibility.Collapsed;
+            }
+        }
     }
 
     private void UpdateTitleBarStatus(ConnectionStatus status)
@@ -197,6 +265,11 @@ public sealed partial class HubWindow : WindowEx
                 TitleStatusText.Text = $"Connected · v{self.ServerVersion}";
             if (self?.PresenceCount is > 0)
                 TitleStatusText.Text += $" · {self.PresenceCount} clients";
+
+            if (NodeIsPaired)
+                TitleStatusText.Text += " · Node paired";
+            else if (NodeIsPendingApproval)
+                TitleStatusText.Text += " · Node pending approval";
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -33,8 +33,9 @@ public sealed partial class HubWindow : WindowEx
             }
         }
     }
-    public OpenClawGatewayClient? GatewayClient { get; set; }
-    public ConnectionStatus CurrentStatus { get; set; }
+    public OpenClawGatewayClient? GatewayClient => GatewayRegistry?.ActiveClient;
+    public GatewayRegistry? GatewayRegistry { get; set; }
+    public ConnectionStatus CurrentStatus => GatewayRegistry?.ActiveConnectionStatus ?? ConnectionStatus.Disconnected;
     private string _currentAgentId = "main";
     public string CurrentAgentId => _currentAgentId;
 
@@ -167,7 +168,6 @@ public sealed partial class HubWindow : WindowEx
             DispatcherQueue?.TryEnqueue(() =>
             {
                 if (IsClosed) return;
-                CurrentStatus = status;
                 _cachedCommands = null;
                 if (status == ConnectionStatus.Disconnected)
                     _lastGatewaySelf = null;
@@ -175,7 +175,8 @@ public sealed partial class HubWindow : WindowEx
                 UpdateNavItemsForConnectionState(status);
                 if (ContentFrame?.Content is HomePage homePage)
                 {
-                    homePage.UpdateConnectionStatus(status, Settings?.GetEffectiveGatewayUrl());
+                    var gwUrl = GatewayRegistry?.GetActive()?.Url;
+                    homePage.UpdateConnectionStatus(status, gwUrl);
                 }
                 if (ContentFrame?.Content is ConnectionPage connectionPage)
                 {

--- a/tests/OpenClaw.Shared.Tests/GatewayConnectionServiceTests.cs
+++ b/tests/OpenClaw.Shared.Tests/GatewayConnectionServiceTests.cs
@@ -1,0 +1,339 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+/// <summary>
+/// Test factory that tracks created clients.
+/// </summary>
+internal sealed class TrackingClientFactory : IGatewayClientFactory
+{
+    public List<(string url, string token, bool isBootstrap, string? identityPath)> Created { get; } = new();
+
+    public OpenClawGatewayClient Create(string gatewayUrl, string token, IOpenClawLogger logger, bool tokenIsBootstrapToken = false, string? identityPath = null)
+    {
+        Created.Add((gatewayUrl, token, tokenIsBootstrapToken, identityPath));
+        return new OpenClawGatewayClient(gatewayUrl, token, logger, tokenIsBootstrapToken, identityPath: identityPath);
+    }
+}
+
+public class GatewayConnectionServiceTests
+{
+    private static string CreateTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "openclaw-svc-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static (GatewayConnectionService svc, GatewayRegistry reg, TrackingClientFactory factory) CreateService()
+    {
+        var dir = CreateTempDir();
+        var reg = new GatewayRegistry(dir);
+        var factory = new TrackingClientFactory();
+        var svc = new GatewayConnectionService(reg, factory);
+        return (svc, reg, factory);
+    }
+
+    // ── State: Initial ──
+
+    [Fact]
+    public void Initial_State_Is_Idle()
+    {
+        var (svc, _, _) = CreateService();
+        var snap = svc.Snapshot;
+        Assert.Equal(GatewayConnectionState.Idle, snap.Overall);
+        Assert.Equal(GatewayRoleState.Idle, snap.Operator);
+        Assert.Equal(GatewayRoleState.Disabled, snap.Node);
+        Assert.Null(svc.OperatorClient);
+    }
+
+    // ── ApplySetupCode ──
+
+    [Fact]
+    public void ApplySetupCode_Creates_Gateway_Record()
+    {
+        var (svc, reg, _) = CreateService();
+        var result = svc.ApplySetupCode("ws://localhost:18789", "bootstrap-tok-123");
+
+        Assert.True(result);
+        var gw = reg.GetActive();
+        Assert.NotNull(gw);
+        Assert.Equal("ws://localhost:18789", gw.Url);
+        Assert.Equal("bootstrap-tok-123", gw.BootstrapToken);
+        Assert.Null(gw.OperatorDeviceToken);
+    }
+
+    [Fact]
+    public void ApplySetupCode_Clears_Previous_Record()
+    {
+        var (svc, reg, _) = CreateService();
+        reg.AddOrUpdate(new GatewayRecord
+        {
+            Id = "localhost-18789",
+            Url = "ws://localhost:18789",
+            OperatorDeviceToken = "old-op-token",
+            NodeDeviceToken = "old-node-token",
+        });
+
+        svc.ApplySetupCode("ws://localhost:18789", "fresh-bootstrap");
+
+        var gw = reg.GetActive();
+        Assert.NotNull(gw);
+        Assert.Equal("fresh-bootstrap", gw.BootstrapToken);
+        Assert.Null(gw.OperatorDeviceToken);
+        Assert.Null(gw.NodeDeviceToken);
+    }
+
+    [Fact]
+    public void ApplySetupCode_EmptyUrl_ReturnsFalse()
+    {
+        var (svc, _, _) = CreateService();
+        Assert.False(svc.ApplySetupCode("", "tok"));
+        Assert.False(svc.ApplySetupCode(null!, "tok"));
+    }
+
+    // ── SetCredential ──
+
+    [Fact]
+    public void SetCredential_SharedGatewayToken()
+    {
+        var (svc, reg, _) = CreateService();
+        svc.SetCredential("ws://gw:1234", "shared-secret", GatewayCredentialKind.SharedGatewayToken);
+
+        var gw = reg.GetActive();
+        Assert.NotNull(gw);
+        Assert.Equal("shared-secret", gw.SharedGatewayToken);
+    }
+
+    [Fact]
+    public void SetCredential_BootstrapToken()
+    {
+        var (svc, reg, _) = CreateService();
+        svc.SetCredential("ws://gw:1234", "bt-123", GatewayCredentialKind.BootstrapToken);
+
+        var gw = reg.GetActive();
+        Assert.Equal("bt-123", gw!.BootstrapToken);
+    }
+
+    [Fact]
+    public void SetCredential_OperatorDeviceToken_ClearsBootstrap()
+    {
+        var (svc, reg, _) = CreateService();
+        svc.SetCredential("ws://gw:1234", "bt-123", GatewayCredentialKind.BootstrapToken);
+        svc.SetCredential("ws://gw:1234", "op-device-tok", GatewayCredentialKind.OperatorDeviceToken);
+
+        var gw = reg.GetActive();
+        Assert.Equal("op-device-tok", gw!.OperatorDeviceToken);
+        Assert.Null(gw.BootstrapToken); // Cleared after device token received
+    }
+
+    [Fact]
+    public void SetCredential_PreservesExistingFields()
+    {
+        var (svc, reg, _) = CreateService();
+        svc.SetCredential("ws://gw:1234", "shared", GatewayCredentialKind.SharedGatewayToken);
+        svc.SetCredential("ws://gw:1234", "op-tok", GatewayCredentialKind.OperatorDeviceToken);
+
+        var gw = reg.GetActive();
+        Assert.Equal("shared", gw!.SharedGatewayToken);
+        Assert.Equal("op-tok", gw.OperatorDeviceToken);
+    }
+
+    // ── ConnectOperatorAsync ──
+
+    [Fact]
+    public async Task ConnectOperator_WithBootstrapToken_CreatesClient()
+    {
+        var (svc, reg, factory) = CreateService();
+        svc.ApplySetupCode("ws://localhost:18789", "bootstrap-tok");
+
+        await svc.ConnectOperatorAsync();
+
+        Assert.Single(factory.Created);
+        Assert.Equal("ws://localhost:18789", factory.Created[0].url);
+        Assert.Equal("bootstrap-tok", factory.Created[0].token);
+        Assert.True(factory.Created[0].isBootstrap);
+        Assert.NotNull(svc.OperatorClient);
+    }
+
+    [Fact]
+    public async Task ConnectOperator_WithOperatorToken_PrefersOverBootstrap()
+    {
+        var (svc, reg, factory) = CreateService();
+        reg.AddOrUpdate(new GatewayRecord
+        {
+            Id = "gw-1234",
+            Url = "ws://gw:1234",
+            OperatorDeviceToken = "device-tok",
+            BootstrapToken = "should-not-use",
+        });
+
+        await svc.ConnectOperatorAsync();
+
+        Assert.Single(factory.Created);
+        Assert.Equal("device-tok", factory.Created[0].token);
+        Assert.False(factory.Created[0].isBootstrap);
+    }
+
+    [Fact]
+    public async Task ConnectOperator_NoCredential_DoesNothing()
+    {
+        var (svc, reg, factory) = CreateService();
+        reg.AddOrUpdate(new GatewayRecord { Id = "gw", Url = "ws://gw:1234" });
+
+        await svc.ConnectOperatorAsync();
+
+        Assert.Empty(factory.Created);
+        Assert.Null(svc.OperatorClient);
+    }
+
+    [Fact]
+    public async Task ConnectOperator_NoActiveGateway_DoesNothing()
+    {
+        var (svc, _, factory) = CreateService();
+
+        await svc.ConnectOperatorAsync();
+
+        Assert.Empty(factory.Created);
+    }
+
+    // ── State transitions ──
+
+    [Fact]
+    public async Task ConnectOperator_SetsState_Connecting()
+    {
+        var (svc, _, _) = CreateService();
+        svc.ApplySetupCode("ws://gw:1234", "tok");
+
+        var states = new List<GatewayConnectionState>();
+        svc.StateChanged += (old, @new, snap) => states.Add(@new);
+
+        await svc.ConnectOperatorAsync();
+
+        Assert.Contains(GatewayConnectionState.Connecting, states);
+    }
+
+    // ── Token storage ──
+
+    [Fact]
+    public void StoreOperatorDeviceToken_UpdatesRegistry()
+    {
+        var (svc, reg, _) = CreateService();
+        svc.ApplySetupCode("ws://gw:1234", "bootstrap");
+
+        svc.StoreOperatorDeviceToken("new-device-tok");
+
+        var gw = reg.GetActive();
+        Assert.Equal("new-device-tok", gw!.OperatorDeviceToken);
+        Assert.Null(gw.BootstrapToken); // Cleared
+    }
+
+    [Fact]
+    public void StoreNodeDeviceToken_UpdatesRegistry()
+    {
+        var (svc, reg, _) = CreateService();
+        svc.ApplySetupCode("ws://gw:1234", "bootstrap");
+
+        svc.StoreNodeDeviceToken("node-tok");
+
+        var gw = reg.GetActive();
+        Assert.Equal("node-tok", gw!.NodeDeviceToken);
+    }
+
+    // ── Chat credentials ──
+
+    [Fact]
+    public void ResolveChatCredentials_PrefersSharedToken()
+    {
+        var (svc, reg, _) = CreateService();
+        reg.AddOrUpdate(new GatewayRecord
+        {
+            Id = "gw",
+            Url = "ws://gw:1234",
+            SharedGatewayToken = "shared-secret",
+            OperatorDeviceToken = "device-tok",
+        });
+
+        var cred = svc.ResolveChatCredentials();
+        Assert.NotNull(cred);
+        Assert.Equal("shared-secret", cred.Value.token);
+        Assert.Equal("shared", cred.Value.source);
+    }
+
+    [Fact]
+    public void ResolveChatCredentials_FallsBackToOperatorToken()
+    {
+        var (svc, reg, _) = CreateService();
+        reg.AddOrUpdate(new GatewayRecord
+        {
+            Id = "gw",
+            Url = "ws://gw:1234",
+            OperatorDeviceToken = "device-tok",
+        });
+
+        var cred = svc.ResolveChatCredentials();
+        Assert.NotNull(cred);
+        Assert.Equal("device-tok", cred.Value.token);
+        Assert.Equal("operator", cred.Value.source);
+    }
+
+    [Fact]
+    public void ResolveChatCredentials_NoTokens_ReturnsNull()
+    {
+        var (svc, reg, _) = CreateService();
+        reg.AddOrUpdate(new GatewayRecord { Id = "gw", Url = "ws://gw:1234" });
+
+        Assert.Null(svc.ResolveChatCredentials());
+    }
+
+    // ── Disconnect ──
+
+    [Fact]
+    public async Task Disconnect_ResetsState()
+    {
+        var (svc, _, _) = CreateService();
+        svc.ApplySetupCode("ws://gw:1234", "tok");
+        await svc.ConnectOperatorAsync();
+
+        await svc.DisconnectAsync();
+
+        Assert.Null(svc.OperatorClient);
+        Assert.Equal(GatewayRoleState.Idle, svc.Snapshot.Operator);
+    }
+
+    // ── Reconnect disposes old client ──
+
+    [Fact]
+    public async Task Reconnect_CreatesNewClient()
+    {
+        var (svc, _, factory) = CreateService();
+        svc.ApplySetupCode("ws://gw:1234", "tok");
+
+        await svc.ConnectOperatorAsync();
+        await svc.ReconnectAsync();
+
+        Assert.Equal(2, factory.Created.Count); // Old + new
+    }
+
+    // ── DeriveOverall ──
+
+    [Theory]
+    [InlineData(GatewayRoleState.Connected, GatewayRoleState.Connected, true, GatewayConnectionState.Ready)]
+    [InlineData(GatewayRoleState.Connected, GatewayRoleState.Disabled, true, GatewayConnectionState.Ready)]
+    [InlineData(GatewayRoleState.Connecting, GatewayRoleState.Disabled, true, GatewayConnectionState.Connecting)]
+    [InlineData(GatewayRoleState.Error, GatewayRoleState.Disabled, true, GatewayConnectionState.Error)]
+    [InlineData(GatewayRoleState.PairingRequired, GatewayRoleState.Disabled, true, GatewayConnectionState.PairingRequired)]
+    [InlineData(GatewayRoleState.Idle, GatewayRoleState.Disabled, true, GatewayConnectionState.Configured)]
+    [InlineData(GatewayRoleState.Idle, GatewayRoleState.Disabled, false, GatewayConnectionState.Idle)]
+    [InlineData(GatewayRoleState.Connected, GatewayRoleState.Connecting, true, GatewayConnectionState.Connecting)]
+    [InlineData(GatewayRoleState.Connected, GatewayRoleState.PairingRequired, true, GatewayConnectionState.PairingRequired)]
+    public void DeriveOverall_CorrectState(GatewayRoleState op, GatewayRoleState node, bool hasCred, GatewayConnectionState expected)
+    {
+        Assert.Equal(expected, GatewayConnectionSnapshot.DeriveOverall(op, node, hasCred));
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/GatewayRegistryTests.cs
+++ b/tests/OpenClaw.Shared.Tests/GatewayRegistryTests.cs
@@ -1,0 +1,439 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+public class GatewayRegistryTests
+{
+    private static string CreateTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "openclaw-gwreg-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static void Cleanup(string dir)
+    {
+        try { Directory.Delete(dir, true); } catch { }
+    }
+
+    // ── ID Generation ──
+
+    [Theory]
+    [InlineData("ws://localhost:18789", "localhost-18789")]
+    [InlineData("wss://gw.example.com", "gw-example-com-443")]
+    [InlineData("ws://192.168.1.100:18789", "192-168-1-100-18789")]
+    [InlineData("wss://my-gateway.tailnet.ts.net:443", "my-gateway-tailnet-ts-net-443")]
+    [InlineData("ws://HOST:9999", "host-9999")]
+    public void GenerateId_ProducesExpectedSlug(string url, string expected)
+    {
+        Assert.Equal(expected, GatewayRecord.GenerateId(url));
+    }
+
+    [Fact]
+    public void GenerateId_EmptyUrl_ReturnsUnknown()
+    {
+        Assert.Equal("unknown", GatewayRecord.GenerateId(""));
+        Assert.Equal("unknown", GatewayRecord.GenerateId(null!));
+    }
+
+    [Fact]
+    public void GenerateId_InvalidUrl_ReturnsSanitizedFallback()
+    {
+        var id = GatewayRecord.GenerateId("not-a-url");
+        Assert.False(string.IsNullOrEmpty(id));
+        Assert.DoesNotContain("://", id);
+    }
+
+    // ── CRUD Operations ──
+
+    [Fact]
+    public void AddOrUpdate_AddsNewRecord()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry = new GatewayRegistry(dir);
+            var record = new GatewayRecord { Id = "gw1", Url = "ws://localhost:18789" };
+            registry.AddOrUpdate(record);
+
+            var all = registry.GetAll();
+            Assert.Single(all);
+            Assert.Equal("gw1", all[0].Id);
+            Assert.Equal("ws://localhost:18789", all[0].Url);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public void AddOrUpdate_UpdatesExistingRecord()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry = new GatewayRegistry(dir);
+            registry.AddOrUpdate(new GatewayRecord { Id = "gw1", Url = "ws://old:1234" });
+            registry.AddOrUpdate(new GatewayRecord { Id = "gw1", Url = "ws://new:5678", OperatorDeviceToken = "tok" });
+
+            var all = registry.GetAll();
+            Assert.Single(all);
+            Assert.Equal("ws://new:5678", all[0].Url);
+            Assert.Equal("tok", all[0].OperatorDeviceToken);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public void AddOrUpdate_PreservesExistingTokensOnUpdate()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry = new GatewayRegistry(dir);
+            registry.AddOrUpdate(new GatewayRecord
+            {
+                Id = "gw1", Url = "ws://host:1234",
+                OperatorDeviceToken = "op-tok", NodeDeviceToken = "node-tok"
+            });
+
+            // Update with null tokens — should not overwrite existing
+            registry.AddOrUpdate(new GatewayRecord { Id = "gw1", Url = "ws://host:1234" });
+
+            var gw = registry.GetActive();
+            Assert.NotNull(gw);
+            Assert.Equal("op-tok", gw.OperatorDeviceToken);
+            Assert.Equal("node-tok", gw.NodeDeviceToken);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public void AddOrUpdate_SetActiveFalse_DoesNotChangeActive()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry = new GatewayRegistry(dir);
+            registry.AddOrUpdate(new GatewayRecord { Id = "gw1", Url = "ws://a:1" });
+            registry.AddOrUpdate(new GatewayRecord { Id = "gw2", Url = "ws://b:2" }, setActive: false);
+
+            var active = registry.GetActive();
+            Assert.NotNull(active);
+            Assert.Equal("gw1", active.Id);
+            Assert.Equal(2, registry.GetAll().Count);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public void Remove_RemovesRecord()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry = new GatewayRegistry(dir);
+            registry.AddOrUpdate(new GatewayRecord { Id = "gw1", Url = "ws://a:1" });
+            registry.AddOrUpdate(new GatewayRecord { Id = "gw2", Url = "ws://b:2" });
+
+            Assert.True(registry.Remove("gw1"));
+            Assert.Single(registry.GetAll());
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public void Remove_ClearsActiveIfRemoved()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry = new GatewayRegistry(dir);
+            registry.AddOrUpdate(new GatewayRecord { Id = "gw1", Url = "ws://a:1" });
+
+            registry.Remove("gw1");
+            Assert.Null(registry.GetActive());
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public void Remove_NonExistent_ReturnsFalse()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry = new GatewayRegistry(dir);
+            Assert.False(registry.Remove("nope"));
+        }
+        finally { Cleanup(dir); }
+    }
+
+    // ── Active Gateway ──
+
+    [Fact]
+    public void SetActive_ValidId_SetsActive()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry = new GatewayRegistry(dir);
+            registry.AddOrUpdate(new GatewayRecord { Id = "gw1", Url = "ws://a:1" });
+            registry.AddOrUpdate(new GatewayRecord { Id = "gw2", Url = "ws://b:2" });
+
+            Assert.True(registry.SetActive("gw1"));
+            Assert.Equal("gw1", registry.GetActive()!.Id);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public void SetActive_InvalidId_ReturnsFalse()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry = new GatewayRegistry(dir);
+            registry.AddOrUpdate(new GatewayRecord { Id = "gw1", Url = "ws://a:1" });
+
+            Assert.False(registry.SetActive("nope"));
+            Assert.Equal("gw1", registry.GetActive()!.Id);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public void GetActive_EmptyRegistry_ReturnsNull()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry = new GatewayRegistry(dir);
+            Assert.Null(registry.GetActive());
+        }
+        finally { Cleanup(dir); }
+    }
+
+    // ── JSON Persistence ──
+
+    [Fact]
+    public void Persistence_SurvivesReload()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry1 = new GatewayRegistry(dir);
+            registry1.AddOrUpdate(new GatewayRecord
+            {
+                Id = "gw1", Url = "ws://host:1234",
+                OperatorDeviceToken = "op", NodeDeviceToken = "node"
+            });
+
+            // Load a new instance from the same directory
+            var registry2 = new GatewayRegistry(dir);
+            var gw = registry2.GetActive();
+            Assert.NotNull(gw);
+            Assert.Equal("gw1", gw.Id);
+            Assert.Equal("ws://host:1234", gw.Url);
+            Assert.Equal("op", gw.OperatorDeviceToken);
+            Assert.Equal("node", gw.NodeDeviceToken);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public void Persistence_MultipleGateways_RoundTrip()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry1 = new GatewayRegistry(dir);
+            registry1.AddOrUpdate(new GatewayRecord { Id = "gw1", Url = "ws://a:1" }, setActive: false);
+            registry1.AddOrUpdate(new GatewayRecord { Id = "gw2", Url = "ws://b:2" });
+
+            var registry2 = new GatewayRegistry(dir);
+            Assert.Equal(2, registry2.GetAll().Count);
+            Assert.Equal("gw2", registry2.GetActive()!.Id);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    // ── Edge Cases ──
+
+    [Fact]
+    public void Load_MissingFile_StartsEmpty()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry = new GatewayRegistry(dir);
+            Assert.Empty(registry.GetAll());
+            Assert.Null(registry.GetActive());
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public void Load_CorruptJson_StartsEmpty()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "gateways.json"), "{{not json}}");
+            var registry = new GatewayRegistry(dir);
+            Assert.Empty(registry.GetAll());
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public void Load_EmptyFile_StartsEmpty()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "gateways.json"), "");
+            var registry = new GatewayRegistry(dir);
+            Assert.Empty(registry.GetAll());
+        }
+        finally { Cleanup(dir); }
+    }
+
+    // ── Migration ──
+
+    [Fact]
+    public void TryMigrateFromSettings_EmptyRegistry_CreatesSingleRecord()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry = new GatewayRegistry(dir);
+            var migrated = registry.TryMigrateFromSettings("ws://localhost:18789", "op-token", "node-token");
+
+            Assert.True(migrated);
+            var gw = registry.GetActive();
+            Assert.NotNull(gw);
+            Assert.Equal("localhost-18789", gw.Id);
+            Assert.Equal("ws://localhost:18789", gw.Url);
+            Assert.Equal("op-token", gw.OperatorDeviceToken);
+            Assert.Equal("node-token", gw.NodeDeviceToken);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public void TryMigrateFromSettings_NonEmptyRegistry_DoesNothing()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry = new GatewayRegistry(dir);
+            registry.AddOrUpdate(new GatewayRecord { Id = "existing", Url = "ws://x:1" });
+
+            var migrated = registry.TryMigrateFromSettings("ws://localhost:18789", "tok", null);
+            Assert.False(migrated);
+            Assert.Single(registry.GetAll());
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public void TryMigrateFromSettings_EmptyUrl_ReturnsFalse()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry = new GatewayRegistry(dir);
+            Assert.False(registry.TryMigrateFromSettings("", "tok", null));
+            Assert.False(registry.TryMigrateFromSettings(null, "tok", null));
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public void TryMigrateFromSettings_NullTokens_StoresNullTokens()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry = new GatewayRegistry(dir);
+            registry.TryMigrateFromSettings("ws://host:1234", null, null);
+
+            var gw = registry.GetActive();
+            Assert.NotNull(gw);
+            Assert.Null(gw.OperatorDeviceToken);
+            Assert.Null(gw.NodeDeviceToken);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    // ── Immutability of returned records ──
+
+    [Fact]
+    public void GetActive_ReturnedRecordDoesNotMutateInternal()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry = new GatewayRegistry(dir);
+            registry.AddOrUpdate(new GatewayRecord { Id = "gw1", Url = "ws://a:1", OperatorDeviceToken = "original" });
+
+            var returned = registry.GetActive()!;
+            returned.OperatorDeviceToken = "mutated";
+
+            Assert.Equal("original", registry.GetActive()!.OperatorDeviceToken);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    [Fact]
+    public void GetAll_ReturnedListDoesNotMutateInternal()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var registry = new GatewayRegistry(dir);
+            registry.AddOrUpdate(new GatewayRecord { Id = "gw1", Url = "ws://a:1" });
+
+            var all = registry.GetAll();
+            all[0].Url = "mutated";
+
+            Assert.Equal("ws://a:1", registry.GetAll()[0].Url);
+        }
+        finally { Cleanup(dir); }
+    }
+
+    // ── GatewayRegistryData JSON ──
+
+    [Fact]
+    public void GatewayRegistryData_JsonRoundTrip()
+    {
+        var data = new GatewayRegistryData
+        {
+            ActiveGatewayId = "gw1",
+            Gateways = new()
+            {
+                new GatewayRecord { Id = "gw1", Url = "ws://a:1", OperatorDeviceToken = "op" },
+                new GatewayRecord { Id = "gw2", Url = "ws://b:2" },
+            }
+        };
+
+        var json = data.ToJson();
+        var parsed = GatewayRegistryData.FromJson(json);
+
+        Assert.NotNull(parsed);
+        Assert.Equal("gw1", parsed.ActiveGatewayId);
+        Assert.Equal(2, parsed.Gateways.Count);
+        Assert.Equal("op", parsed.Gateways[0].OperatorDeviceToken);
+        Assert.Null(parsed.Gateways[1].OperatorDeviceToken);
+    }
+
+    [Fact]
+    public void GatewayRegistryData_FromJson_InvalidJson_ReturnsNull()
+    {
+        Assert.Null(GatewayRegistryData.FromJson("not json"));
+        Assert.Null(GatewayRegistryData.FromJson(""));
+        Assert.Null(GatewayRegistryData.FromJson(null));
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -1843,12 +1843,13 @@ public class OpenClawGatewayClientTests
     // --- HandleRequestError: device signature invalid ---
 
     [Fact]
-    public void HandleRequestError_DeviceSignatureInvalid_CyclesSignatureMode()
+    public void HandleRequestError_DeviceSignatureInvalid_IsTerminalWhenAlreadyV2()
     {
-        var helper = new GatewayClientTestHelper();
-        // Starting mode is V3AuthToken; first rejection should move it to V3EmptyToken
-        Assert.Equal("V3AuthToken", helper.GetSignatureTokenMode());
+        var logger = new TestLogger();
+        var helper = new GatewayClientTestHelper(logger);
+        var authEvents = helper.CaptureAuthenticationFailedEvents();
 
+        // Default is V2 — first rejection is terminal (no further fallback)
         helper.TrackPendingRequest("req-sig-1", "connect");
         helper.ProcessRawMessage("""
         {
@@ -1859,7 +1860,9 @@ public class OpenClawGatewayClientTests
         }
         """);
 
-        Assert.Equal("V3EmptyToken", helper.GetSignatureTokenMode());
+        Assert.True(helper.GetAuthFailedFlag());
+        Assert.Single(authEvents);
+        Assert.Contains("device signature", authEvents[0], StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -2096,29 +2099,4 @@ public class OpenClawGatewayClientTests
         Assert.False(helper.GetAuthFailedFlag());
     }
 
-    [Fact]
-    public void HandleRequestError_AllDeviceSignatureModesExhausted_SetsAuthFailed()
-    {
-        var logger = new TestLogger();
-        var helper = new GatewayClientTestHelper(logger);
-        var authEvents = helper.CaptureAuthenticationFailedEvents();
-
-        // Cycle through all 4 signature modes by sending 4 successive rejections
-        for (int i = 1; i <= 4; i++)
-        {
-            helper.TrackPendingRequest($"req-sig-exhaust-{i}", "connect");
-            helper.ProcessRawMessage($$"""
-            {
-                "type": "res",
-                "id": "req-sig-exhaust-{{i}}",
-                "ok": false,
-                "error": "device signature invalid"
-            }
-            """);
-        }
-
-        Assert.True(helper.GetAuthFailedFlag());
-        Assert.Single(authEvents);
-        Assert.Contains("device signature", authEvents[0], StringComparison.OrdinalIgnoreCase);
-    }
 }

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -1843,18 +1843,34 @@ public class OpenClawGatewayClientTests
     // --- HandleRequestError: device signature invalid ---
 
     [Fact]
-    public void HandleRequestError_DeviceSignatureInvalid_IsTerminalWhenAlreadyV2()
+    public void HandleRequestError_DeviceSignatureInvalid_IsTerminalWhenAllModesExhausted()
     {
         var logger = new TestLogger();
         var helper = new GatewayClientTestHelper(logger);
         var authEvents = helper.CaptureAuthenticationFailedEvents();
 
-        // Default is V2 — first rejection is terminal (no further fallback)
-        helper.TrackPendingRequest("req-sig-1", "connect");
+        // Default is V3AuthToken — 4 modes must be exhausted before terminal
+        // V3AuthToken → V3EmptyToken → V2AuthToken → V2EmptyToken → terminal
+        for (int i = 1; i <= 3; i++)
+        {
+            helper.TrackPendingRequest($"req-sig-{i}", "connect");
+            helper.ProcessRawMessage($$"""
+            {
+                "type": "res",
+                "id": "req-sig-{{i}}",
+                "ok": false,
+                "error": "device signature invalid"
+            }
+            """);
+            Assert.False(helper.GetAuthFailedFlag(), $"Should not be terminal after rejection {i}");
+        }
+
+        // 4th rejection (V2EmptyToken → V2EmptyToken, no change) is terminal
+        helper.TrackPendingRequest("req-sig-4", "connect");
         helper.ProcessRawMessage("""
         {
             "type": "res",
-            "id": "req-sig-1",
+            "id": "req-sig-4",
             "ok": false,
             "error": "device signature invalid"
         }

--- a/tests/OpenClaw.Shared.Tests/SharedIdentityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/SharedIdentityTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.IO;
+using OpenClaw.Shared;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+public class SharedIdentityTests
+{
+    [Fact]
+    public void TwoClients_SamePath_ShareDeviceId()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-shared-id-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            // Simulate operator and node sharing the same identity path
+            var identity1 = new DeviceIdentity(dataPath);
+            identity1.Initialize();
+
+            var identity2 = new DeviceIdentity(dataPath);
+            identity2.Initialize();
+
+            Assert.Equal(identity1.DeviceId, identity2.DeviceId);
+            Assert.Equal(identity1.PublicKeyBase64Url, identity2.PublicKeyBase64Url);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public void StoredDeviceToken_IsVisibleToNewInstance()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-shared-id-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            // First instance (node) stores a device token after pairing
+            var nodeIdentity = new DeviceIdentity(dataPath);
+            nodeIdentity.Initialize();
+            nodeIdentity.StoreDeviceToken("paired-device-token-123");
+
+            // Second instance (operator) loads the same identity and should see the token
+            var operatorIdentity = new DeviceIdentity(dataPath);
+            operatorIdentity.Initialize();
+
+            Assert.Equal("paired-device-token-123", operatorIdentity.DeviceToken);
+            Assert.Equal(nodeIdentity.DeviceId, operatorIdentity.DeviceId);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public void GatewayClient_PicksUpStoredDeviceToken()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-shared-id-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            // Simulate node pairing: create identity and store device token
+            var nodeIdentity = new DeviceIdentity(dataPath);
+            nodeIdentity.Initialize();
+            nodeIdentity.StoreDeviceToken("node-paired-token");
+
+            // Operator client created AFTER node paired — should pick up the token
+            using var operatorClient = new OpenClawGatewayClient(
+                "ws://localhost:18789",
+                "manual-token",
+                dataPath: dataPath);
+
+            // The operator's effective auth should prefer the stored device token
+            Assert.Equal(nodeIdentity.DeviceId, operatorClient.OperatorDeviceId is null
+                ? nodeIdentity.DeviceId  // DeviceId comes from identity
+                : operatorClient.OperatorDeviceId);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/SharedIdentityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/SharedIdentityTests.cs
@@ -64,29 +64,37 @@ public class SharedIdentityTests
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-shared-id-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataPath);
+        var previousAppData = Environment.GetEnvironmentVariable("OPENCLAW_TRAY_APPDATA_DIR");
 
         try
         {
+            // Point the gateway client at our test data path
+            Environment.SetEnvironmentVariable("OPENCLAW_TRAY_APPDATA_DIR", dataPath);
+
             // Simulate node pairing: create identity and store device token
-            var nodeIdentity = new DeviceIdentity(dataPath);
+            Directory.CreateDirectory(Path.Combine(dataPath, "OpenClawTray"));
+            var nodeIdentity = new DeviceIdentity(Path.Combine(dataPath, "OpenClawTray"));
             nodeIdentity.Initialize();
             nodeIdentity.StoreDeviceToken("node-paired-token");
 
             // Operator client created AFTER node paired — should pick up the token
-            using var operatorClient = new OpenClawGatewayClient(
+            using (var operatorClient = new OpenClawGatewayClient(
                 "ws://localhost:18789",
-                "manual-token",
-                dataPath: dataPath);
-
-            // The operator's effective auth should prefer the stored device token
-            Assert.Equal(nodeIdentity.DeviceId, operatorClient.OperatorDeviceId is null
-                ? nodeIdentity.DeviceId  // DeviceId comes from identity
-                : operatorClient.OperatorDeviceId);
+                "manual-token"))
+            {
+                // The operator's effective auth should prefer the stored device token
+                Assert.Equal("node-paired-token", operatorClient.ConnectAuthToken);
+            }
         }
         finally
         {
-            if (Directory.Exists(dataPath))
-                Directory.Delete(dataPath, true);
+            Environment.SetEnvironmentVariable("OPENCLAW_TRAY_APPDATA_DIR", previousAppData);
+            try
+            {
+                if (Directory.Exists(dataPath))
+                    Directory.Delete(dataPath, true);
+            }
+            catch (IOException) { /* file lock from NSec Key — non-critical in test cleanup */ }
         }
     }
 }

--- a/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
@@ -56,12 +56,12 @@ public class WindowsNodeClientTests
         {
             using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
 
-            // Put client into pending-approval state (simulates first-connect, no stored token)
-            var isPendingField = typeof(WindowsNodeClient).GetField(
-                "_isPendingApproval",
+            // Put client into awaiting-approval state (simulates first-connect, no stored token)
+            var pairingStateField = typeof(WindowsNodeClient).GetField(
+                "_pairingState",
                 BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.NotNull(isPendingField);
-            isPendingField!.SetValue(client, true);
+            Assert.NotNull(pairingStateField);
+            pairingStateField!.SetValue(client, NodePairingState.AwaitingApproval);
 
             var pairingEvents = new List<PairingStatusEventArgs>();
             client.PairingStatusChanged += (_, e) => pairingEvents.Add(e);
@@ -357,10 +357,10 @@ public class WindowsNodeClientTests
         {
             using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
 
-            var isPendingField = typeof(WindowsNodeClient).GetField(
-                "_isPendingApproval",
+            var pairingStateField = typeof(WindowsNodeClient).GetField(
+                "_pairingState",
                 BindingFlags.NonPublic | BindingFlags.Instance);
-            isPendingField!.SetValue(client, true);
+            pairingStateField!.SetValue(client, NodePairingState.AwaitingApproval);
 
             var pairingEvents = new List<PairingStatusEventArgs>();
             client.PairingStatusChanged += (_, e) => pairingEvents.Add(e);
@@ -657,7 +657,7 @@ public class WindowsNodeClientTests
     [Theory]
     [InlineData("OnDisconnected")]
     [InlineData("OnError")]
-    public async Task EventOnlyPairedState_IsClearedByConnectionResetHooks(string hookName)
+    public async Task ApprovedReconnectingState_SurvivesConnectionReset(string hookName)
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataPath);
@@ -666,6 +666,7 @@ public class WindowsNodeClientTests
         {
             using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
 
+            // Simulate pairing approval (sets state to ApprovedReconnecting)
             await InvokeHandleEventAsync(client, $$"""
                 {
                     "type": "event",
@@ -693,8 +694,10 @@ public class WindowsNodeClientTests
                 method!.Invoke(client, null);
             }
 
+            // ApprovedReconnecting survives disconnects — the device IS paired,
+            // it's just reconnecting to get the device token from the gateway.
             Assert.False(client.IsPendingApproval);
-            Assert.False(client.IsPaired);
+            Assert.True(client.IsPaired);
         }
         finally
         {

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -26,6 +26,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SettingsManager.cs" Link="Services\SettingsManager.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\BootstrapMessageInjector.cs" Link="Services\BootstrapMessageInjector.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\GatewayCredentialResolver.cs" Link="Services\GatewayCredentialResolver.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SetupCodeApplicator.cs" Link="Services\SetupCodeApplicator.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\StartupSetupState.cs" Link="Services\StartupSetupState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ActivityStreamService.cs" Link="Services\ActivityStreamService.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeInvokeActivityFormatter.cs" Link="Services\NodeInvokeActivityFormatter.cs" />

--- a/tests/OpenClaw.Tray.Tests/SetupCodeApplicatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SetupCodeApplicatorTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using OpenClaw.Shared;
+using OpenClawTray.Services;
+using Xunit;
+
+namespace OpenClaw.Tray.Tests;
+
+public class SetupCodeApplicatorTests
+{
+    private SettingsManager CreateTempSettings()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"openclaw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        return new SettingsManager(dir);
+    }
+
+    [Fact]
+    public void Apply_ValidSetupCode_SetsBootstrapTokenAndClearsToken()
+    {
+        var settings = CreateTempSettings();
+        settings.Token = "old-manual-token";
+        settings.Save();
+
+        // Build a valid setup code: base64url of { "url": "ws://localhost:18789", "bootstrapToken": "bt-123" }
+        var json = """{"url":"ws://localhost:18789","bootstrapToken":"bt-123"}""";
+        var code = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(json))
+            .Replace('+', '-').Replace('/', '_').TrimEnd('=');
+
+        var result = SetupCodeApplicator.Apply(code, settings);
+
+        Assert.True(result.Success);
+        Assert.Equal("ws://localhost:18789", settings.GatewayUrl);
+        Assert.Equal("bt-123", settings.BootstrapToken);
+        Assert.Equal("", settings.Token); // Must be cleared
+    }
+
+    [Fact]
+    public void Apply_EmptyCode_ReturnsFalse()
+    {
+        var settings = CreateTempSettings();
+        var result = SetupCodeApplicator.Apply("", settings);
+
+        Assert.False(result.Success);
+        Assert.NotNull(result.Error);
+    }
+
+    [Fact]
+    public void Apply_InvalidBase64_ReturnsFalse()
+    {
+        var settings = CreateTempSettings();
+        var result = SetupCodeApplicator.Apply("!!!not-base64!!!", settings);
+
+        Assert.False(result.Success);
+    }
+
+    [Fact]
+    public void Apply_DoesNotLeaveTokenPopulated()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"openclaw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        var settings = new SettingsManager(dir);
+        settings.Token = "should-be-cleared";
+        settings.BootstrapToken = "";
+        settings.Save();
+
+        var json = """{"url":"ws://10.0.0.1:18789","bootstrapToken":"fresh-token"}""";
+        var code = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(json))
+            .Replace('+', '-').Replace('/', '_').TrimEnd('=');
+
+        SetupCodeApplicator.Apply(code, settings);
+
+        // Reload settings from disk to verify persistence
+        var reloaded = new SettingsManager(dir);
+        Assert.Equal("", reloaded.Token);
+        Assert.Equal("fresh-token", reloaded.BootstrapToken);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/SetupCodeApplicatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SetupCodeApplicatorTests.cs
@@ -8,31 +8,34 @@ namespace OpenClaw.Tray.Tests;
 
 public class SetupCodeApplicatorTests
 {
-    private SettingsManager CreateTempSettings()
+    private static string CreateTempDir()
     {
         var dir = Path.Combine(Path.GetTempPath(), $"openclaw-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(dir);
-        return new SettingsManager(dir);
+        return dir;
     }
 
-    [Fact]
-    public void Apply_ValidSetupCode_SetsBootstrapTokenAndClearsToken()
-    {
-        var settings = CreateTempSettings();
-        settings.Token = "old-manual-token";
-        settings.Save();
+    private static SettingsManager CreateTempSettings() => new SettingsManager(CreateTempDir());
 
-        // Build a valid setup code: base64url of { "url": "ws://localhost:18789", "bootstrapToken": "bt-123" }
-        var json = """{"url":"ws://localhost:18789","bootstrapToken":"bt-123"}""";
-        var code = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(json))
+    private static string EncodeSetupCode(string json) =>
+        Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(json))
             .Replace('+', '-').Replace('/', '_').TrimEnd('=');
 
-        var result = SetupCodeApplicator.Apply(code, settings);
+    [Fact]
+    public void Apply_ValidSetupCode_ReturnsSuccess()
+    {
+        var dir = CreateTempDir();
+        var settings = new SettingsManager(dir);
+        var registry = new GatewayRegistry(dir);
+
+        var code = EncodeSetupCode("""{"url":"ws://localhost:18789","bootstrapToken":"bt-123"}""");
+        var result = SetupCodeApplicator.Apply(code, settings, dir, registry);
 
         Assert.True(result.Success);
-        Assert.Equal("ws://localhost:18789", settings.GatewayUrl);
-        Assert.Equal("bt-123", settings.BootstrapToken);
-        Assert.Equal("", settings.Token); // Must be cleared
+        var gw = registry.GetActive();
+        Assert.NotNull(gw);
+        Assert.Equal("ws://localhost:18789", gw.Url);
+        Assert.Equal("bt-123", gw.BootstrapToken);
     }
 
     [Fact]
@@ -55,24 +58,72 @@ public class SetupCodeApplicatorTests
     }
 
     [Fact]
-    public void Apply_DoesNotLeaveTokenPopulated()
+    public void Apply_BootstrapTokenStoredInRegistry()
     {
-        var dir = Path.Combine(Path.GetTempPath(), $"openclaw-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(dir);
+        var dir = CreateTempDir();
         var settings = new SettingsManager(dir);
-        settings.Token = "should-be-cleared";
-        settings.BootstrapToken = "";
-        settings.Save();
+        var registry = new GatewayRegistry(dir);
 
-        var json = """{"url":"ws://10.0.0.1:18789","bootstrapToken":"fresh-token"}""";
-        var code = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(json))
-            .Replace('+', '-').Replace('/', '_').TrimEnd('=');
+        var code = EncodeSetupCode("""{"url":"ws://10.0.0.1:18789","bootstrapToken":"fresh-token"}""");
+        SetupCodeApplicator.Apply(code, settings, dir, registry);
 
-        SetupCodeApplicator.Apply(code, settings);
+        var gw = registry.GetActive();
+        Assert.NotNull(gw);
+        Assert.Equal("fresh-token", gw.BootstrapToken);
+    }
 
-        // Reload settings from disk to verify persistence
-        var reloaded = new SettingsManager(dir);
-        Assert.Equal("", reloaded.Token);
-        Assert.Equal("fresh-token", reloaded.BootstrapToken);
+    // ── Gateway Registry Integration ──
+
+    [Fact]
+    public void Apply_WithRegistry_CreatesRecordWithBootstrapToken()
+    {
+        var dir = CreateTempDir();
+        var settings = new SettingsManager(dir);
+        var registry = new GatewayRegistry(dir);
+
+        var code = EncodeSetupCode("""{"url":"ws://gw1:18789","bootstrapToken":"bt-1"}""");
+        var result = SetupCodeApplicator.Apply(code, settings, dir, registry);
+
+        Assert.True(result.Success);
+        var active = registry.GetActive();
+        Assert.NotNull(active);
+        Assert.Equal("gw1-18789", active.Id);
+        Assert.Equal("ws://gw1:18789", active.Url);
+        Assert.Equal("bt-1", active.BootstrapToken);
+        Assert.Null(active.OperatorDeviceToken);
+    }
+
+    [Fact]
+    public void Apply_WithRegistry_ClearsOldTokensOnReApply()
+    {
+        var dir = CreateTempDir();
+        var settings = new SettingsManager(dir);
+        var registry = new GatewayRegistry(dir);
+
+        registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "gw1-18789", Url = "ws://gw1:18789",
+            OperatorDeviceToken = "old-op", NodeDeviceToken = "old-node",
+        });
+
+        var code = EncodeSetupCode("""{"url":"ws://gw1:18789","bootstrapToken":"bt-fresh"}""");
+        SetupCodeApplicator.Apply(code, settings, dir, registry);
+
+        var active = registry.GetActive();
+        Assert.NotNull(active);
+        Assert.Equal("bt-fresh", active.BootstrapToken);
+        Assert.Null(active.OperatorDeviceToken);
+        Assert.Null(active.NodeDeviceToken);
+    }
+
+    [Fact]
+    public void Apply_WithoutRegistry_StillWorks()
+    {
+        var settings = CreateTempSettings();
+        var code = EncodeSetupCode("""{"url":"ws://host:1234","bootstrapToken":"tok"}""");
+
+        var result = SetupCodeApplicator.Apply(code, settings);
+
+        Assert.True(result.Success);
     }
 }

--- a/tests/OpenClaw.Tray.Tests/SetupCodePairingIntegrationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SetupCodePairingIntegrationTests.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenClaw.Shared;
+using OpenClawTray.Onboarding.Services;
+using OpenClawTray.Services;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OpenClaw.Tray.Tests;
+
+/// <summary>
+/// End-to-end integration test for the setup-code pairing flow.
+/// Requires a running gateway on ws://localhost:18789 (WSL) and the openclaw CLI.
+/// Skipped in CI — run manually with OPENCLAW_RUN_INTEGRATION=1.
+/// </summary>
+public class SetupCodePairingIntegrationTests
+{
+    private readonly ITestOutputHelper _output;
+    private const string GatewayUrl = "ws://localhost:18789";
+
+    public SetupCodePairingIntegrationTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private bool ShouldRun()
+    {
+        return Environment.GetEnvironmentVariable("OPENCLAW_RUN_INTEGRATION") == "1";
+    }
+
+    private string RunWsl(string command)
+    {
+        var psi = new ProcessStartInfo("wsl")
+        {
+            Arguments = $"bash -c '{command}'",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        using var proc = Process.Start(psi)!;
+        var stdout = proc.StandardOutput.ReadToEnd();
+        proc.WaitForExit(15000);
+        return stdout.Trim();
+    }
+
+    private (string url, string bootstrapToken)? GenerateFreshSetupCode()
+    {
+        _output.WriteLine("[TEST] Generating fresh setup code via WSL...");
+        var raw = RunWsl("openclaw qr --url ws://localhost:18789 2>&1 | grep 'Setup code:'");
+        var code = raw.Replace("Setup code:", "").Trim();
+        if (string.IsNullOrEmpty(code))
+        {
+            _output.WriteLine("[TEST] ERROR: Could not generate setup code");
+            return null;
+        }
+
+        var decoded = SetupCodeDecoder.Decode(code);
+        if (!decoded.Success)
+        {
+            _output.WriteLine($"[TEST] ERROR: Setup code decode failed: {decoded.Error}");
+            return null;
+        }
+        _output.WriteLine($"[TEST] Setup code: url={decoded.Url}, token={decoded.Token?[..8]}...");
+        return (decoded.Url!, decoded.Token!);
+    }
+
+    private void ClearGatewayPairings()
+    {
+        _output.WriteLine("[TEST] Clearing gateway pairings...");
+        RunWsl("echo '{}' > ~/.openclaw/devices/paired.json");
+        RunWsl("echo '[]' > ~/.openclaw/nodes/paired.json");
+        RunWsl("echo '[]' > ~/.openclaw/nodes/pending.json");
+    }
+
+    [Fact]
+    public async Task SetupCodePairing_NodePairsAndOperatorConnects()
+    {
+        if (!ShouldRun())
+        {
+            _output.WriteLine("Skipped (set OPENCLAW_RUN_INTEGRATION=1 to run)");
+            return;
+        }
+
+        // --- Step 1: Clean state ---
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-integration-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+        var settingsDir = Path.Combine(Path.GetTempPath(), $"openclaw-settings-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(settingsDir);
+
+        try
+        {
+            ClearGatewayPairings();
+
+            // --- Step 2: Generate fresh setup code ---
+            var setup = GenerateFreshSetupCode();
+            Assert.NotNull(setup);
+            var (url, bootstrapToken) = setup.Value;
+
+            // --- Step 3: Apply setup code (same as SetupCodeApplicator.Apply) ---
+            var settings = new SettingsManager(settingsDir);
+            settings.GatewayUrl = url;
+            settings.BootstrapToken = bootstrapToken;
+            settings.Token = "";
+            settings.EnableNodeMode = true;
+            settings.Save();
+            _output.WriteLine($"[TEST] Settings: url={settings.GatewayUrl}, bootstrapToken={settings.BootstrapToken[..8]}..., token='{settings.Token}'");
+
+            // Also clear any stored device token (same as SetupCodeApplicator does)
+            DeviceIdentity.TryClearStoredDeviceToken(dataPath);
+
+            // --- Step 4: Connect node (same as InitializeNodeService → ConnectAsync) ---
+            var logger = new TestOutputLogger(_output);
+            var nodeClient = new WindowsNodeClient(
+                settings.GatewayUrl,
+                settings.Token,  // empty
+                dataPath,
+                logger,
+                settings.BootstrapToken);
+
+            var nodePairedTcs = new TaskCompletionSource<PairingStatusEventArgs>();
+            nodeClient.PairingStatusChanged += (_, args) =>
+            {
+                _output.WriteLine($"[TEST] Node PairingStatusChanged: {args.Status}, operatorToken={args.OperatorDeviceToken?[..Math.Min(8, args.OperatorDeviceToken?.Length ?? 0)] ?? "null"}");
+                if (args.Status == PairingStatus.Paired)
+                    nodePairedTcs.TrySetResult(args);
+            };
+            nodeClient.StatusChanged += (_, status) =>
+                _output.WriteLine($"[TEST] Node StatusChanged: {status}");
+
+            _output.WriteLine("[TEST] Connecting node...");
+            _ = nodeClient.ConnectAsync();
+
+            // Wait for node to pair (max 15s)
+            var pairedCt = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            pairedCt.Token.Register(() => nodePairedTcs.TrySetException(new TimeoutException("Node did not pair within 15s")));
+
+            PairingStatusEventArgs pairingResult;
+            try
+            {
+                pairingResult = await nodePairedTcs.Task;
+            }
+            catch (TimeoutException)
+            {
+                _output.WriteLine("[TEST] TIMEOUT: Node did not pair");
+                Assert.Fail("Node did not pair within 15 seconds");
+                return;
+            }
+
+            _output.WriteLine($"[TEST] Node paired! DeviceId={pairingResult.DeviceId[..16]}");
+            Assert.Equal(PairingStatus.Paired, pairingResult.Status);
+
+            // --- Step 5: Extract operator device token (same as OnPairingStatusChanged) ---
+            var operatorDeviceToken = pairingResult.OperatorDeviceToken;
+            _output.WriteLine($"[TEST] Operator device token: {(operatorDeviceToken != null ? operatorDeviceToken[..8] + "..." : "NULL")}");
+            Assert.NotNull(operatorDeviceToken);
+
+            // Store in settings (same as App.OnPairingStatusChanged)
+            settings.Token = operatorDeviceToken!;
+            settings.BootstrapToken = "";
+            settings.Save();
+            _output.WriteLine($"[TEST] Settings updated: token={settings.Token[..8]}..., bootstrap cleared");
+
+            // --- Step 6: Connect operator (same as InitializeGatewayClient reinit) ---
+            var isDeviceToken = DeviceIdentity.HasStoredDeviceToken(dataPath);
+            _output.WriteLine($"[TEST] Creating operator client: effectiveToken={settings.Token[..8]}..., isDeviceToken={isDeviceToken}");
+
+            var operatorClient = new OpenClawGatewayClient(
+                settings.GatewayUrl,
+                settings.Token,
+                logger,
+                useBootstrapHandoffAuth: false,
+                dataPath: dataPath,
+                isDeviceToken: isDeviceToken);
+
+            var operatorConnectedTcs = new TaskCompletionSource<bool>();
+            var operatorErrors = new List<string>();
+            operatorClient.StatusChanged += (_, status) =>
+            {
+                _output.WriteLine($"[TEST] Operator StatusChanged: {status}");
+                if (status == ConnectionStatus.Connected)
+                    operatorConnectedTcs.TrySetResult(true);
+                else if (status == ConnectionStatus.Error)
+                    operatorConnectedTcs.TrySetResult(false);
+            };
+            operatorClient.AuthenticationFailed += (_, msg) =>
+            {
+                _output.WriteLine($"[TEST] Operator AuthFailed: {msg}");
+                operatorErrors.Add(msg);
+            };
+
+            _output.WriteLine("[TEST] Connecting operator...");
+            _ = operatorClient.ConnectAsync();
+
+            // Wait for operator (max 15s)
+            var opCt = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            opCt.Token.Register(() => operatorConnectedTcs.TrySetResult(false));
+
+            var operatorConnected = await operatorConnectedTcs.Task;
+            _output.WriteLine($"[TEST] Operator result: connected={operatorConnected}, errors={string.Join("; ", operatorErrors)}");
+
+            Assert.True(operatorConnected, $"Operator failed to connect. Errors: {string.Join("; ", operatorErrors)}");
+            Assert.True(operatorClient.IsConnectedToGateway);
+
+            // --- Step 7: Verify both connected ---
+            _output.WriteLine("[TEST] ✅ SUCCESS: Both node and operator connected!");
+            Assert.True(nodeClient.IsConnected);
+            Assert.True(nodeClient.IsPaired);
+            Assert.True(operatorClient.IsConnectedToGateway);
+
+            // Cleanup
+            await nodeClient.DisconnectAsync();
+            await operatorClient.DisconnectAsync();
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+            if (Directory.Exists(settingsDir))
+                Directory.Delete(settingsDir, true);
+        }
+    }
+
+    private class TestOutputLogger : IOpenClawLogger
+    {
+        private readonly ITestOutputHelper _output;
+        public TestOutputLogger(ITestOutputHelper output) => _output = output;
+        public void Info(string message) => _output.WriteLine($"[INFO] {message}");
+        public void Debug(string message) { } // suppress verbose
+        public void Warn(string message) => _output.WriteLine($"[WARN] {message}");
+        public void Error(string message, Exception? ex = null) => _output.WriteLine($"[ERROR] {message}");
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/SetupCodePairingIntegrationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SetupCodePairingIntegrationTests.cs
@@ -175,10 +175,7 @@ public class SetupCodePairingIntegrationTests
             var operatorClient = new OpenClawGatewayClient(
                 settings.GatewayUrl,
                 settings.Token,
-                logger,
-                useBootstrapHandoffAuth: false,
-                dataPath: dataPath,
-                isDeviceToken: isDeviceToken);
+                logger);
 
             var operatorConnectedTcs = new TaskCompletionSource<bool>();
             var operatorErrors = new List<string>();


### PR DESCRIPTION
## Gateway Registry — Multi-Gateway Support

Single source of truth for gateway URL, tokens, bootstrap state, connection status, and active client reference.

### What it does
- **Gateway Registry** (\gateways.json\): stores per-gateway credentials so switching gateways doesn't require re-pairing
- **Recent Gateways UI**: Connection page card with one-click switching
- **Chat auth fix**: \SharedGatewayToken\ stored separately so web dashboard works after pairing
- **WSL onboarding fix**: encoding mismatch causing \wsl.exe --list\ hang
- **Radio button defaults**: auto-select first option in wizard

### Security
- GUID-randomized temp file, ACL re-applied after File.Move
- Tokens removed from URLs
- 30 unit tests for registry operations
