### PR TITLE
fix: setup flow, connection page, and chat token bugs

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -559,16 +559,26 @@ public sealed partial class ConnectionPage : Page
 
         DirectConnectResultText.Text = "Connecting…";
 
-        // Remember previous active gateway so we can revert on failure
+        // Snapshot previous state for rollback
         var previousActiveId = _gatewayRegistry.ActiveGatewayId;
+        var previousSettings = _hub?.Settings;
+        var prevGatewayUrl = previousSettings?.GatewayUrl;
+        var prevUseSsh = previousSettings?.UseSshTunnel ?? false;
+        var prevSshUser = previousSettings?.SshTunnelUser;
+        var prevSshHost = previousSettings?.SshTunnelHost;
+        var prevSshRemotePort = previousSettings?.SshTunnelRemotePort ?? 0;
+        var prevSshLocalPort = previousSettings?.SshTunnelLocalPort ?? 0;
+
+        var existing = _gatewayRegistry.FindByUrl(url);
+        var isNewRecord = existing == null;
+        var existingRecordSnapshot = existing;
+        var recordId = existing?.Id ?? Guid.NewGuid().ToString();
 
         try
         {
             await _connectionManager.DisconnectAsync();
 
             // Create/update gateway record with shared token + SSH config
-            var existing = _gatewayRegistry.FindByUrl(url);
-            var recordId = existing?.Id ?? Guid.NewGuid().ToString();
             var record = new GatewayRecord
             {
                 Id = recordId,
@@ -609,19 +619,18 @@ public sealed partial class ConnectionPage : Page
             }
 
             // Save settings (SSH config + gateway URL for legacy compat)
-            var settings = _hub?.Settings;
-            if (settings != null)
+            if (previousSettings != null)
             {
-                settings.GatewayUrl = url;
-                settings.UseSshTunnel = useSsh;
+                previousSettings.GatewayUrl = url;
+                previousSettings.UseSshTunnel = useSsh;
                 if (useSsh && sshConfig != null)
                 {
-                    settings.SshTunnelUser = sshConfig.User;
-                    settings.SshTunnelHost = sshConfig.Host;
-                    settings.SshTunnelRemotePort = sshConfig.RemotePort;
-                    settings.SshTunnelLocalPort = sshConfig.LocalPort;
+                    previousSettings.SshTunnelUser = sshConfig.User;
+                    previousSettings.SshTunnelHost = sshConfig.Host;
+                    previousSettings.SshTunnelRemotePort = sshConfig.RemotePort;
+                    previousSettings.SshTunnelLocalPort = sshConfig.LocalPort;
                 }
-                settings.Save();
+                previousSettings.Save();
             }
 
             // Start SSH tunnel if configured
@@ -633,18 +642,82 @@ public sealed partial class ConnectionPage : Page
             }
 
             await _connectionManager.ConnectAsync(recordId);
-            DirectConnectResultText.Text = $"✓ Connected to {GatewayUrlHelper.SanitizeForDisplay(url)}";
+
+            // Poll connection manager state — ConnectAsync fires connect asynchronously,
+            // so we need to wait for a definitive result before reporting success/failure.
+            bool connected = false;
+            bool failed = false;
+            for (int attempt = 0; attempt < 15; attempt++)
+            {
+                await Task.Delay(1000);
+                var snapshot = _connectionManager.CurrentSnapshot;
+                if (snapshot.OverallState is Services.Connection.OverallConnectionState.Connected
+                    or Services.Connection.OverallConnectionState.Ready)
+                {
+                    connected = true;
+                    break;
+                }
+                if (snapshot.OverallState is Services.Connection.OverallConnectionState.Error)
+                {
+                    failed = true;
+                    break;
+                }
+                if (snapshot.OverallState is Services.Connection.OverallConnectionState.PairingRequired)
+                {
+                    DirectConnectResultText.Text = $"⏳ Pairing required — approve on gateway";
+                    return; // don't rollback, pairing is in progress
+                }
+            }
+
+            if (connected)
+            {
+                DirectConnectResultText.Text = $"✓ Connected to {GatewayUrlHelper.SanitizeForDisplay(url)}";
+                return;
+            }
+
+            // Connection failed or timed out — rollback
+            var reason = failed ? "Connection failed" : "Connection timed out";
+            DirectConnectResultText.Text = $"✗ {reason}";
+            RollbackDirectConnect(previousActiveId, isNewRecord, recordId, existingRecordSnapshot,
+                previousSettings, prevGatewayUrl, prevUseSsh, prevSshUser, prevSshHost, prevSshRemotePort, prevSshLocalPort);
         }
         catch (Exception ex)
         {
             DirectConnectResultText.Text = $"✗ {ex.Message}";
+            RollbackDirectConnect(previousActiveId, isNewRecord, recordId, existingRecordSnapshot,
+                previousSettings, prevGatewayUrl, prevUseSsh, prevSshUser, prevSshHost, prevSshRemotePort, prevSshLocalPort);
+        }
+    }
 
-            // Revert active gateway on failure so the app doesn't point at a broken config
-            if (previousActiveId != null)
-            {
-                _gatewayRegistry.SetActive(previousActiveId);
-                _gatewayRegistry.Save();
-            }
+    private void RollbackDirectConnect(
+        string? previousActiveId, bool isNewRecord, string recordId,
+        GatewayRecord? existingRecordSnapshot, SettingsManager? settings,
+        string? prevGatewayUrl, bool prevUseSsh, string? prevSshUser,
+        string? prevSshHost, int prevSshRemotePort, int prevSshLocalPort)
+    {
+        if (_gatewayRegistry == null) return;
+
+        // Restore or remove the gateway record
+        if (isNewRecord)
+            _gatewayRegistry.Remove(recordId);
+        else if (existingRecordSnapshot != null)
+            _gatewayRegistry.AddOrUpdate(existingRecordSnapshot);
+
+        // Restore active gateway
+        if (previousActiveId != null)
+            _gatewayRegistry.SetActive(previousActiveId);
+        _gatewayRegistry.Save();
+
+        // Restore legacy settings
+        if (settings != null)
+        {
+            settings.GatewayUrl = prevGatewayUrl;
+            settings.UseSshTunnel = prevUseSsh;
+            settings.SshTunnelUser = prevSshUser;
+            settings.SshTunnelHost = prevSshHost;
+            settings.SshTunnelRemotePort = prevSshRemotePort;
+            settings.SshTunnelLocalPort = prevSshLocalPort;
+            settings.Save();
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -36,6 +36,8 @@ public sealed partial class ConnectionPage : Page
         if (_connectionManager != null)
             _connectionManager.StateChanged += OnManagerStateChanged;
 
+        Unloaded += OnPageUnloaded;
+
         // Populate manual connection fields
         GatewayUrlTextBox.Text = settings.GatewayUrl ?? "";
         SshToggle.IsOn = settings.UseSshTunnel;
@@ -57,6 +59,12 @@ public sealed partial class ConnectionPage : Page
     private static readonly Microsoft.UI.Xaml.Media.SolidColorBrush s_dimBrush = new(Microsoft.UI.ColorHelper.FromArgb(40, 255, 255, 255));
 
     private GatewayConnectionSnapshot? _lastSnapshot;
+
+    private void OnPageUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (_connectionManager != null)
+            _connectionManager.StateChanged -= OnManagerStateChanged;
+    }
 
     private void OnManagerStateChanged(object? sender, GatewayConnectionSnapshot snapshot)
     {
@@ -217,7 +225,10 @@ public sealed partial class ConnectionPage : Page
                     }
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[ConnectionPage] Failed to read device ID from identity file: {ex.Message}");
+            }
         }
 
         if (snapshot.OperatorState == RoleConnectionState.PairingRequired)
@@ -520,25 +531,40 @@ public sealed partial class ConnectionPage : Page
         }
 
         url = GatewayUrlHelper.NormalizeForWebSocket(url);
+
+        // Validate SSH config upfront before mutating any state
+        var useSsh = SshToggle.IsOn;
+        SshTunnelConfig? sshConfig = null;
+        if (useSsh)
+        {
+            var sshUser = SshUserBox.Text.Trim();
+            var sshHost = SshHostBox.Text.Trim();
+            if (string.IsNullOrWhiteSpace(sshUser) || string.IsNullOrWhiteSpace(sshHost))
+            {
+                DirectConnectResultText.Text = "SSH user and host are required";
+                return;
+            }
+            if (!int.TryParse(SshRemotePortBox.Text, out var remotePort) || remotePort is < 1 or > 65535)
+            {
+                DirectConnectResultText.Text = "SSH remote port must be 1–65535";
+                return;
+            }
+            if (!int.TryParse(SshLocalPortBox.Text, out var localPort) || localPort is < 1 or > 65535)
+            {
+                DirectConnectResultText.Text = "SSH local port must be 1–65535";
+                return;
+            }
+            sshConfig = new SshTunnelConfig(sshUser, sshHost, remotePort, localPort);
+        }
+
         DirectConnectResultText.Text = "Connecting…";
+
+        // Remember previous active gateway so we can revert on failure
+        var previousActiveId = _gatewayRegistry.ActiveGatewayId;
 
         try
         {
             await _connectionManager.DisconnectAsync();
-
-            // Parse SSH config
-            var useSsh = SshToggle.IsOn;
-            SshTunnelConfig? sshConfig = null;
-            if (useSsh)
-            {
-                var sshUser = SshUserBox.Text.Trim();
-                var sshHost = SshHostBox.Text.Trim();
-                int.TryParse(SshRemotePortBox.Text, out var remotePort);
-                int.TryParse(SshLocalPortBox.Text, out var localPort);
-                if (remotePort <= 0) remotePort = 18789;
-                if (localPort <= 0) localPort = 18789;
-                sshConfig = new SshTunnelConfig(sshUser, sshHost, remotePort, localPort);
-            }
 
             // Create/update gateway record with shared token + SSH config
             var existing = _gatewayRegistry.FindByUrl(url);
@@ -576,7 +602,10 @@ public sealed partial class ConnectionPage : Page
                     writer.Flush();
                     System.IO.File.WriteAllBytes(keyPath, ms.ToArray());
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"[ConnectionPage] Failed to clear device tokens: {ex.Message}");
+                }
             }
 
             // Save settings (SSH config + gateway URL for legacy compat)
@@ -609,6 +638,13 @@ public sealed partial class ConnectionPage : Page
         catch (Exception ex)
         {
             DirectConnectResultText.Text = $"✗ {ex.Message}";
+
+            // Revert active gateway on failure so the app doesn't point at a broken config
+            if (previousActiveId != null)
+            {
+                _gatewayRegistry.SetActive(previousActiveId);
+                _gatewayRegistry.Save();
+            }
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Services/Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/Connection/GatewayConnectionManager.cs
@@ -297,10 +297,16 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         try
         {
             DisconnectCore();
-            // Stop tunnel when switching gateways — the new one may not need it
+            // Stop tunnel when switching gateways — the new one may not need it.
+            // Use a bounded timeout to avoid blocking all connection transitions.
             if (_tunnelManager?.IsActive == true)
             {
-                try { await _tunnelManager.StopAsync(); }
+                try
+                {
+                    var tunnelStop = _tunnelManager.StopAsync();
+                    if (await Task.WhenAny(tunnelStop, Task.Delay(TimeSpan.FromSeconds(5))) != tunnelStop)
+                        _logger.Warn("[ConnMgr] Tunnel stop timed out during gateway switch");
+                }
                 catch (Exception ex) { _logger.Warn($"[ConnMgr] Tunnel stop error on gateway switch: {ex.Message}"); }
             }
             _gatewayNeedsV2Signature = false; // new gateway might support v3
@@ -790,17 +796,27 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             _nodeConnector.StatusChanged -= OnNodeStatusChanged;
             _nodeConnector.PairingStatusChanged -= OnNodePairingStatusChanged;
         }
-        _stateMachine.TryTransition(ConnectionTrigger.Disposed);
-        DisposeActiveClient();
-        // Stop tunnel on app shutdown — run on threadpool with timeout to avoid stalling exit
-        if (_tunnelManager?.IsActive == true)
+        // Acquire semaphore briefly to ensure no in-flight reconnect/switch is mid-transition.
+        // Use a short timeout — if something is stuck, proceed with disposal anyway.
+        try { _transitionSemaphore.Wait(TimeSpan.FromSeconds(2)); } catch { }
+        try
         {
-            try { Task.Run(() => _tunnelManager.StopAsync()).Wait(TimeSpan.FromSeconds(3)); }
-            catch { /* shutting down — best effort */ }
+            _stateMachine.TryTransition(ConnectionTrigger.Disposed);
+            DisposeActiveClient();
+            // Stop tunnel on app shutdown — run on threadpool with timeout to avoid stalling exit
+            if (_tunnelManager?.IsActive == true)
+            {
+                try { Task.Run(() => _tunnelManager.StopAsync()).Wait(TimeSpan.FromSeconds(3)); }
+                catch { /* shutting down — best effort */ }
+            }
+            _operationCts?.Cancel();
+            _operationCts?.Dispose();
         }
-        _operationCts?.Cancel();
-        _operationCts?.Dispose();
-        _transitionSemaphore.Dispose();
+        finally
+        {
+            try { _transitionSemaphore.Release(); } catch { }
+            _transitionSemaphore.Dispose();
+        }
     }
 }
 

--- a/src/OpenClaw.Tray.WinUI/Services/Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/Connection/GatewayConnectionManager.cs
@@ -81,6 +81,17 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         await _transitionSemaphore.WaitAsync();
         try
         {
+            await ConnectCoreAsync(gatewayId);
+        }
+        finally
+        {
+            _transitionSemaphore.Release();
+        }
+    }
+
+    /// <summary>Core connect logic. Caller must hold <see cref="_transitionSemaphore"/>.</summary>
+    private async Task ConnectCoreAsync(string? gatewayId = null)
+    {
             var id = gatewayId ?? _registry.ActiveGatewayId;
             if (id == null)
             {
@@ -238,11 +249,6 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
                     _logger.Error($"[ConnMgr] Connect failed: {ex.Message}");
                 }
             }, ct);
-        }
-        finally
-        {
-            _transitionSemaphore.Release();
-        }
     }
 
     public async Task DisconnectAsync()
@@ -251,11 +257,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         await _transitionSemaphore.WaitAsync();
         try
         {
-            var prev = _stateMachine.Current.OverallState;
-            DisposeActiveClient();
-            _stateMachine.TryTransition(ConnectionTrigger.DisconnectRequested);
-            _diagnostics.RecordStateChange(prev, _stateMachine.Current.OverallState);
-            EmitStateChanged(prev);
+            DisconnectCore();
         }
         finally
         {
@@ -263,24 +265,52 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         }
     }
 
+    /// <summary>Core disconnect logic. Caller must hold <see cref="_transitionSemaphore"/>.</summary>
+    private void DisconnectCore()
+    {
+        var prev = _stateMachine.Current.OverallState;
+        DisposeActiveClient();
+        _stateMachine.TryTransition(ConnectionTrigger.DisconnectRequested);
+        _diagnostics.RecordStateChange(prev, _stateMachine.Current.OverallState);
+        EmitStateChanged(prev);
+    }
+
     public async Task ReconnectAsync()
     {
-        await DisconnectAsync();
-        await ConnectAsync();
+        ThrowIfDisposed();
+        await _transitionSemaphore.WaitAsync();
+        try
+        {
+            DisconnectCore();
+            await ConnectCoreAsync();
+        }
+        finally
+        {
+            _transitionSemaphore.Release();
+        }
     }
 
     public async Task SwitchGatewayAsync(string gatewayId)
     {
-        await DisconnectAsync();
-        // Stop tunnel when switching gateways — the new one may not need it
-        if (_tunnelManager?.IsActive == true)
+        ThrowIfDisposed();
+        await _transitionSemaphore.WaitAsync();
+        try
         {
-            try { await _tunnelManager.StopAsync(); }
-            catch (Exception ex) { _logger.Warn($"[ConnMgr] Tunnel stop error on gateway switch: {ex.Message}"); }
+            DisconnectCore();
+            // Stop tunnel when switching gateways — the new one may not need it
+            if (_tunnelManager?.IsActive == true)
+            {
+                try { await _tunnelManager.StopAsync(); }
+                catch (Exception ex) { _logger.Warn($"[ConnMgr] Tunnel stop error on gateway switch: {ex.Message}"); }
+            }
+            _gatewayNeedsV2Signature = false; // new gateway might support v3
+            _registry.SetActive(gatewayId);
+            await ConnectCoreAsync(gatewayId);
         }
-        _gatewayNeedsV2Signature = false; // new gateway might support v3
-        _registry.SetActive(gatewayId);
-        await ConnectAsync(gatewayId);
+        finally
+        {
+            _transitionSemaphore.Release();
+        }
     }
 
     public async Task<SetupCodeResult> ApplySetupCodeAsync(string setupCode)
@@ -723,10 +753,10 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
 
     private void DisposeActiveClient()
     {
-        // Disconnect node first
+        // Disconnect node first — run on threadpool to avoid sync context deadlocks
         if (_nodeConnector != null)
         {
-            try { _nodeConnector.DisconnectAsync().Wait(TimeSpan.FromSeconds(2)); }
+            try { Task.Run(() => _nodeConnector.DisconnectAsync()).Wait(TimeSpan.FromSeconds(2)); }
             catch (Exception ex) { _logger.Warn($"[ConnMgr] Node disconnect error: {ex.Message}"); }
         }
 
@@ -762,10 +792,10 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         }
         _stateMachine.TryTransition(ConnectionTrigger.Disposed);
         DisposeActiveClient();
-        // Stop tunnel on app shutdown
+        // Stop tunnel on app shutdown — run on threadpool with timeout to avoid stalling exit
         if (_tunnelManager?.IsActive == true)
         {
-            try { _tunnelManager.StopAsync().GetAwaiter().GetResult(); }
+            try { Task.Run(() => _tunnelManager.StopAsync()).Wait(TimeSpan.FromSeconds(3)); }
             catch { /* shutting down — best effort */ }
         }
         _operationCts?.Cancel();

--- a/src/OpenClaw.Tray.WinUI/Services/Connection/InteractiveGatewayCredentialResolver.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/Connection/InteractiveGatewayCredentialResolver.cs
@@ -5,6 +5,9 @@ namespace OpenClawTray.Services.Connection;
 
 /// <summary>
 /// Resolves operator credentials for user-facing surfaces such as chat.
+/// Unlike the connection credential resolver which prefers DeviceToken (WebSocket auth),
+/// this resolver prefers SharedGatewayToken because HTTP surfaces (chat URL ?token=)
+/// authenticate via the shared token, not the per-device WebSocket token.
 /// </summary>
 public static class InteractiveGatewayCredentialResolver
 {
@@ -19,10 +22,24 @@ public static class InteractiveGatewayCredentialResolver
         ArgumentException.ThrowIfNullOrWhiteSpace(settingsDirectory);
         ArgumentNullException.ThrowIfNull(identityReader);
 
-        var resolver = new CredentialResolver(identityReader);
         var active = registry?.GetActive();
         if (active != null && !string.IsNullOrWhiteSpace(active.Url))
         {
+            // For HTTP surfaces (chat), prefer SharedGatewayToken over DeviceToken.
+            // DeviceToken is for WebSocket auth (auth.deviceToken); SharedGatewayToken
+            // is for HTTP ?token= auth which the chat/dashboard endpoints expect.
+            if (!string.IsNullOrWhiteSpace(active.SharedGatewayToken))
+            {
+                credential = new InteractiveGatewayCredential(
+                    active.Url,
+                    active.SharedGatewayToken!,
+                    false,
+                    "record.SharedGatewayToken");
+                return true;
+            }
+
+            // Fall back to standard credential resolution (DeviceToken → Bootstrap)
+            var resolver = new CredentialResolver(identityReader);
             var resolved = resolver.ResolveOperator(active, registry!.GetIdentityDirectory(active.Id));
             if (resolved != null)
             {
@@ -55,7 +72,8 @@ public static class InteractiveGatewayCredentialResolver
             SharedGatewayToken = settings.LegacyToken,
             BootstrapToken = settings.LegacyBootstrapToken
         };
-        var legacyCredential = resolver.ResolveOperator(legacyRecord, settingsDirectory);
+        var resolver2 = new CredentialResolver(identityReader);
+        var legacyCredential = resolver2.ResolveOperator(legacyRecord, settingsDirectory);
         if (legacyCredential == null)
         {
             credential = null;

--- a/src/OpenClaw.Tray.WinUI/Services/Connection/InteractiveGatewayCredentialResolver.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/Connection/InteractiveGatewayCredentialResolver.cs
@@ -34,7 +34,7 @@ public static class InteractiveGatewayCredentialResolver
                     active.Url,
                     active.SharedGatewayToken!,
                     false,
-                    "record.SharedGatewayToken");
+                    CredentialResolver.SourceSharedGatewayToken);
                 return true;
             }
 

--- a/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
@@ -222,8 +222,18 @@ public sealed class LocalGatewaySetupStateStore : ILocalGatewaySetupStateStore
         if (!File.Exists(_statePath))
             return null;
 
-        await using var stream = File.OpenRead(_statePath);
-        return await JsonSerializer.DeserializeAsync<LocalGatewaySetupState>(stream, s_jsonOptions, cancellationToken);
+        try
+        {
+            await using var stream = File.OpenRead(_statePath);
+            return await JsonSerializer.DeserializeAsync<LocalGatewaySetupState>(stream, s_jsonOptions, cancellationToken);
+        }
+        catch (JsonException)
+        {
+            // Corrupt or incompatible state file — treat as fresh start
+            System.Diagnostics.Debug.WriteLine($"[SetupState] Corrupt setup-state.json at {_statePath}, deleting and starting fresh");
+            try { File.Delete(_statePath); } catch { }
+            return null;
+        }
     }
 
     public async Task SaveAsync(LocalGatewaySetupState state, CancellationToken cancellationToken = default)
@@ -2775,12 +2785,18 @@ public sealed class LocalGatewaySetupEngine
         }
         catch (OperationCanceledException)
         {
+            state.Status = LocalGatewaySetupStatus.Cancelled;
+            state.UserMessage = "Setup was cancelled.";
+            // Persist cancelled state so restarts don't resume from stale Running phase
+            try { await _stateStore.SaveAsync(state, CancellationToken.None); } catch { }
+            StateChanged?.Invoke(state);
             throw;
         }
         catch (Exception ex)
         {
             _logger.Error($"Local gateway setup phase {phase} failed.", ex);
-            state.Block($"{phase.ToString().ToLowerInvariant()}_failed", ex.Message, retryable: true, detail: SecretRedactor.Redact(ex.ToString()));
+            var retryable = ex is not (UnauthorizedAccessException or NotSupportedException or InvalidOperationException or ArgumentException);
+            state.Block($"{phase.ToString().ToLowerInvariant()}_failed", ex.Message, retryable: retryable, detail: SecretRedactor.Redact(ex.ToString()));
             await SaveAndPublishAsync(state, cancellationToken);
             return;
         }

--- a/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
+++ b/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
@@ -3,7 +3,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
-using System.Runtime.CompilerServices;
 using Windows.UI;
 using Windows.UI.Text;
 using OpenClawTray.Services;
@@ -681,12 +680,21 @@ internal sealed class UiRenderer(Action requestRender)
     {
         control.SelectionChanged -= RadioButtonsSelectionChanged;
         control.Tag = element;
-        var sameRef = ReferenceEquals(control.ItemsSource, element.Items);
-        var itemsHash = RuntimeHelpers.GetHashCode(element.Items);
-        var idxBefore = control.SelectedIndex;
-        Logger.Debug($"[WizardDiag] ConfigureRadioButtons before: itemsHash={itemsHash} sameRef={sameRef} reqIdx={element.SelectedIndex} idxBefore={idxBefore}");
-        control.ItemsSource = element.Items;
-        var idxAfterSet = control.SelectedIndex;
+
+        // Only reassign ItemsSource when the items have actually changed (content comparison).
+        // Setting ItemsSource to a new array reference with the same content causes the
+        // WinUI RadioButtons control to rebuild its children and reset the visual selection,
+        // which makes SelectedIndex assignments unreliable and causes selection to not stick.
+        var currentItems = control.ItemsSource as string[];
+        var needsItemUpdate = currentItems == null
+            || currentItems.Length != element.Items.Length
+            || !currentItems.AsSpan().SequenceEqual(element.Items);
+
+        if (needsItemUpdate)
+        {
+            control.ItemsSource = element.Items;
+        }
+
         if (element.SelectedIndex >= 0 && element.SelectedIndex < element.Items.Length)
         {
             control.SelectedIndex = element.SelectedIndex;
@@ -697,7 +705,6 @@ internal sealed class UiRenderer(Action requestRender)
             control.SelectedIndex = -1;
             control.SelectedItem = null;
         }
-        Logger.Debug($"[WizardDiag] ConfigureRadioButtons after: itemsHash={itemsHash} idxAfterSet={idxAfterSet} idxFinal={control.SelectedIndex}");
         control.SelectionChanged += RadioButtonsSelectionChanged;
         ApplyModifiers(control, element);
         ApplySetters(control, element);

--- a/tests/OpenClaw.Tray.Tests/Connection/InteractiveGatewayCredentialResolverTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Connection/InteractiveGatewayCredentialResolverTests.cs
@@ -79,7 +79,7 @@ public class InteractiveGatewayCredentialResolverTests : IDisposable
     }
 
     [Fact]
-    public void TryResolve_PrefersPerGatewayDeviceToken()
+    public void TryResolve_PrefersSharedGatewayTokenOverDeviceTokenForHttpSurfaces()
     {
         var settings = new SettingsManager(_tempDir) { GatewayUrl = "ws://active:18789" };
         var record = new GatewayRecord
@@ -103,7 +103,7 @@ public class InteractiveGatewayCredentialResolverTests : IDisposable
         Assert.NotNull(credential);
         Assert.Equal("shared-token", credential!.Token);
         Assert.False(credential.IsBootstrapToken);
-        Assert.Equal("record.SharedGatewayToken", credential.Source);
+        Assert.Equal(CredentialResolver.SourceSharedGatewayToken, credential.Source);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/Connection/InteractiveGatewayCredentialResolverTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Connection/InteractiveGatewayCredentialResolverTests.cs
@@ -101,10 +101,9 @@ public class InteractiveGatewayCredentialResolverTests : IDisposable
 
         Assert.True(resolved);
         Assert.NotNull(credential);
-        Assert.Equal("paired-token", credential!.Token);
+        Assert.Equal("shared-token", credential!.Token);
         Assert.False(credential.IsBootstrapToken);
-        Assert.Equal(CredentialResolver.SourceDeviceToken, credential.Source);
-        Assert.Equal(_registry.GetIdentityDirectory(record.Id), _identityReader.LastOperatorPath);
+        Assert.Equal("record.SharedGatewayToken", credential.Source);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes 12 bugs across setup flow, connection page, connection manager, and chat token resolution.

### Wizard RadioButtons (user-reported)
- **RadioButtons selection not sticking** — \ConfigureRadioButtons\ always reassigned \ItemsSource\ on every re-render (even when items were identical), causing WinUI to reset the visual selection. Now skips \ItemsSource\ when items are content-equal.

### ConnectionPage — Direct Connect
- **SSH validation** — empty user/host and invalid ports now rejected upfront before any state mutation
- **Registry revert on failure** — if connect fails, active gateway reverts to previous instead of leaving a broken config active
- **Silent catches logged** — identity file read/write errors now logged via \Debug.WriteLine\
- **StateChanged leak** — page now unsubscribes from \StateChanged\ on \Unloaded\

### GatewayConnectionManager
- **ReconnectAsync race condition** — extracted \ConnectCoreAsync\/\DisconnectCore\ so \ReconnectAsync\ and \SwitchGatewayAsync\ hold the semaphore atomically across disconnect+connect
- **Deadlock risk** — \DisposeActiveClient\ now uses \Task.Run\ to avoid sync context deadlocks
- **Dispose timeout** — tunnel stop in \Dispose()\ uses \Task.Run().Wait(3s)\ instead of unbounded \GetResult()\

### Setup Flow
- **Cancelled state persisted** — cancellation now saves \Cancelled\ status before rethrowing, preventing stale \Running\ phase on restart
- **Permanent failures classified** — \UnauthorizedAccessException\, \InvalidOperationException\, etc. marked non-retryable
- **Corrupt state file** — \LoadAsync\ catches \JsonException\, deletes corrupt file, starts fresh

### Chat Token
- **Wrong token for HTTP auth** — \InteractiveGatewayCredentialResolver\ now prefers \SharedGatewayToken\ for chat/dashboard HTTP surfaces instead of \DeviceToken\ (which is for WebSocket auth)

## Testing
- All 2353 tests pass (1443 shared + 910 tray)
- Manual testing: direct connect, chat, wizard radio buttons