### PR TITLE
Add Test Voice Input button to Voice & Audio settings

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3032,6 +3032,7 @@ public partial class App : Application
             _hubWindow.QuickSendAction = () => ShowQuickSend();
             _hubWindow.OpenSetupAction = () => _ = ShowOnboardingAsync();
             _hubWindow.OpenConnectionStatusAction = ShowConnectionStatusWindow;
+            _hubWindow.OpenVoiceAction = () => ShowVoiceOverlay();
             _hubWindow.ConnectionManager = _connectionManager;
             _hubWindow.GatewayRegistry = _gatewayRegistry;
             _hubWindow.ConnectAction = () =>

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
@@ -59,6 +59,14 @@
 
                     <ProgressBar x:Name="DownloadProgress" Visibility="Collapsed"
                                  Minimum="0" Maximum="100"/>
+
+                    <Button x:Name="TestVoiceButton" Click="OnTestVoiceClick"
+                            Visibility="Collapsed">
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <FontIcon Glyph="&#xE720;" FontSize="14"/>
+                            <TextBlock x:Uid="VoiceSettingsPage_TestVoiceButtonText" x:Name="TestVoiceButtonText" Text="Test Voice Input"/>
+                        </StackPanel>
+                    </Button>
                 </StackPanel>
             </Border>
 

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
@@ -116,11 +116,13 @@ public sealed partial class VoiceSettingsPage : Page
         {
             ModelStatusText.Text = L("VoiceSettingsPage_StatusModelReady");
             DownloadButtonText.Text = L("VoiceSettingsPage_ButtonReDownload");
+            TestVoiceButton.Visibility = Visibility.Visible;
         }
         else
         {
             ModelStatusText.Text = L("VoiceSettingsPage_StatusDownloadRequired");
             DownloadButtonText.Text = L("VoiceSettingsPage_ButtonDownloadModel");
+            TestVoiceButton.Visibility = Visibility.Collapsed;
         }
     }
 
@@ -262,6 +264,11 @@ public sealed partial class VoiceSettingsPage : Page
     }
 
     // ── TTS Voice Selection ──
+
+    private void OnTestVoiceClick(object sender, RoutedEventArgs e)
+    {
+        _hub?.OpenVoiceAction?.Invoke();
+    }
 
     private void LoadTtsSettings(SettingsManager settings)
     {

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using OpenClaw.Shared;
 using OpenClaw.Shared.Capabilities;
 using OpenClawTray.Helpers;
@@ -276,30 +277,106 @@ public sealed partial class VoiceSettingsPage : Page
             try { await _voiceService.StopAsync(); } catch { }
         }
 
-        // Use the existing voice service — it's already initialized with the
-        // correct model and settings.
         var voiceService = _voiceService ?? new VoiceService(new AppLogger(), _hub.Settings);
+        var ownsVoiceService = voiceService != _voiceService;
 
-        var transcriptText = new TextBlock
+        // ── Transcript area (matches Companion Voice overlay style) ──
+        var emptyStateIcon = new FontIcon
         {
-            Text = "Press Start, then speak. Your words will appear here.",
-            TextWrapping = TextWrapping.Wrap,
-            Margin = new Thickness(0, 8, 0, 0)
+            Glyph = "\uE720",
+            FontSize = 32,
+            Opacity = 0.3,
+            HorizontalAlignment = HorizontalAlignment.Center
+        };
+        var emptyStateText = new TextBlock
+        {
+            Text = "Press Start and begin speaking",
+            FontSize = 13,
+            Opacity = 0.4,
+            HorizontalAlignment = HorizontalAlignment.Center
+        };
+        var emptyState = new StackPanel
+        {
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            Spacing = 8,
+            Margin = new Thickness(0, 40, 0, 40),
+        };
+        emptyState.Children.Add(emptyStateIcon);
+        emptyState.Children.Add(emptyStateText);
+
+        var transcriptPanel = new StackPanel { Spacing = 8 };
+        transcriptPanel.Children.Add(emptyState);
+
+        var transcriptScroll = new ScrollViewer
+        {
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            Padding = new Thickness(12),
+            MaxHeight = 220,
+            Content = transcriptPanel
         };
 
+        var transcriptBorder = new Border
+        {
+            Background = (Brush)Application.Current.Resources["CardBackgroundFillColorSecondaryBrush"],
+            CornerRadius = new CornerRadius(8),
+            Child = transcriptScroll
+        };
+
+        // ── Audio level bar ──
+        var levelBarBg = new Border
+        {
+            Background = (Brush)Application.Current.Resources["ControlStrongFillColorDefaultBrush"],
+            CornerRadius = new CornerRadius(2),
+            Opacity = 0.3
+        };
+        var levelBarFill = new Border
+        {
+            Background = new SolidColorBrush((global::Windows.UI.Color)Application.Current.Resources["SystemAccentColor"]),
+            CornerRadius = new CornerRadius(2),
+            HorizontalAlignment = HorizontalAlignment.Left,
+            Width = 0
+        };
+        var levelBarGrid = new Grid
+        {
+            Height = 4,
+            Margin = new Thickness(0, 0, 0, 8)
+        };
+        levelBarGrid.Children.Add(levelBarBg);
+        levelBarGrid.Children.Add(levelBarFill);
+
+        // ── Status text ──
         var statusText = new TextBlock
         {
-            Text = "",
-            TextWrapping = TextWrapping.Wrap,
-            FontSize = 11,
-            Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Gray)
+            Text = "Press Start to begin",
+            FontSize = 12,
+            Opacity = 0.5,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Margin = new Thickness(0, 0, 0, 10)
         };
 
-        var startButton = new Button { Content = "Start Listening" };
-        var panel = new StackPanel { Spacing = 8 };
-        panel.Children.Add(startButton);
+        // ── Start/Stop button (accent style, matches overlay) ──
+        var btnIcon = new FontIcon { Glyph = "\uE768", FontSize = 14 };
+        var btnLabel = new TextBlock { Text = "Start Listening", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold };
+        var btnContent = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+        btnContent.Children.Add(btnIcon);
+        btnContent.Children.Add(btnLabel);
+
+        var startButton = new Button
+        {
+            Content = btnContent,
+            Style = (Style)Application.Current.Resources["AccentButtonStyle"],
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            Height = 40
+        };
+
+        // ── Layout ──
+        var panel = new StackPanel { Spacing = 0, Width = 340 };
+        panel.Children.Add(transcriptBorder);
+        panel.Children.Add(new Border { Height = 12 });
+        panel.Children.Add(levelBarGrid);
         panel.Children.Add(statusText);
-        panel.Children.Add(transcriptText);
+        panel.Children.Add(startButton);
 
         var dialog = new ContentDialog
         {
@@ -310,16 +387,67 @@ public sealed partial class VoiceSettingsPage : Page
         };
 
         var listening = false;
+        TextBlock? lastBubbleText = null;
+
+        void AddBubble(string text)
+        {
+            // Hide empty state on first transcription
+            if (emptyState.Visibility == Visibility.Visible)
+                emptyState.Visibility = Visibility.Collapsed;
+
+            // Consolidate rapid segments into the same bubble
+            if (lastBubbleText != null)
+            {
+                lastBubbleText.Text += " " + text;
+            }
+            else
+            {
+                var bubble = new Border
+                {
+                    Background = new SolidColorBrush(Microsoft.UI.Colors.DodgerBlue),
+                    CornerRadius = new CornerRadius(12, 12, 4, 12),
+                    Padding = new Thickness(12, 10, 12, 10),
+                    HorizontalAlignment = HorizontalAlignment.Right,
+                    Margin = new Thickness(24, 4, 0, 4)
+                };
+
+                var grid = new Grid { ColumnSpacing = 8 };
+                grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+                grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+                var icon = new FontIcon
+                {
+                    Glyph = "\uE77B",
+                    FontSize = 12,
+                    VerticalAlignment = VerticalAlignment.Top,
+                    Margin = new Thickness(0, 3, 0, 0),
+                    Foreground = new SolidColorBrush(Microsoft.UI.Colors.White)
+                };
+                Grid.SetColumn(icon, 0);
+                grid.Children.Add(icon);
+
+                lastBubbleText = new TextBlock
+                {
+                    Text = text,
+                    TextWrapping = TextWrapping.Wrap,
+                    FontSize = 13,
+                    IsTextSelectionEnabled = true,
+                    Foreground = new SolidColorBrush(Microsoft.UI.Colors.White)
+                };
+                Grid.SetColumn(lastBubbleText, 1);
+                grid.Children.Add(lastBubbleText);
+
+                bubble.Child = grid;
+                transcriptPanel.Children.Add(bubble);
+            }
+
+            transcriptScroll.UpdateLayout();
+            transcriptScroll.ChangeView(null, transcriptScroll.ScrollableHeight, null);
+        }
 
         void OnTranscription(string text)
         {
-            DispatcherQueue.TryEnqueue(() =>
-            {
-                if (transcriptText.Text == "Listening..." || transcriptText.Text.StartsWith("Press Start"))
-                    transcriptText.Text = text;
-                else
-                    transcriptText.Text += " " + text;
-            });
+            DispatcherQueue.TryEnqueue(() => AddBubble(text));
         }
 
         void OnDiagnostic(string msg)
@@ -327,35 +455,73 @@ public sealed partial class VoiceSettingsPage : Page
             DispatcherQueue.TryEnqueue(() => statusText.Text = msg);
         }
 
+        void OnSpeaking(bool isSpeaking)
+        {
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                if (isSpeaking)
+                {
+                    statusText.Text = "\U0001f3a4 Listening...";
+                    // New speech utterance → new bubble
+                    lastBubbleText = null;
+                }
+                else
+                {
+                    statusText.Text = "Speak now";
+                }
+            });
+        }
+
+        void OnAudioLevel(float level)
+        {
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                var maxWidth = levelBarGrid.ActualWidth > 0 ? levelBarGrid.ActualWidth : 340;
+                levelBarFill.Width = Math.Max(0, level * maxWidth);
+            });
+        }
+
         startButton.Click += async (_, _) =>
         {
             if (!listening)
             {
                 listening = true;
-                startButton.Content = "Stop Listening";
-                transcriptText.Text = "Listening...";
+                btnIcon.Glyph = "\uE71A";
+                btnLabel.Text = "Stop Listening";
                 voiceService.TranscriptionReceived += OnTranscription;
                 voiceService.DiagnosticMessage += OnDiagnostic;
+                voiceService.SpeakingChanged += OnSpeaking;
+                voiceService.AudioLevelChanged += OnAudioLevel;
                 try
                 {
                     await voiceService.StartVoiceChatAsync();
-                    statusText.Text = "Voice chat started — speak now";
+                    statusText.Text = "Speak now";
                 }
                 catch (Exception ex)
                 {
                     statusText.Text = $"Error: {ex.Message}";
                     listening = false;
-                    startButton.Content = "Start Listening";
+                    btnIcon.Glyph = "\uE768";
+                    btnLabel.Text = "Start Listening";
+                    voiceService.TranscriptionReceived -= OnTranscription;
+                    voiceService.DiagnosticMessage -= OnDiagnostic;
+                    voiceService.SpeakingChanged -= OnSpeaking;
+                    voiceService.AudioLevelChanged -= OnAudioLevel;
                 }
             }
             else
             {
                 listening = false;
-                startButton.Content = "Start Listening";
+                btnIcon.Glyph = "\uE768";
+                btnLabel.Text = "Start Listening";
+                statusText.Text = "Processing...";
+                levelBarFill.Width = 0;
+                await voiceService.StopAsync();
                 voiceService.TranscriptionReceived -= OnTranscription;
                 voiceService.DiagnosticMessage -= OnDiagnostic;
-                await voiceService.StopAsync();
-                statusText.Text = "Stopped";
+                voiceService.SpeakingChanged -= OnSpeaking;
+                voiceService.AudioLevelChanged -= OnAudioLevel;
+                statusText.Text = "Done — check your transcript above";
             }
         };
 
@@ -364,9 +530,18 @@ public sealed partial class VoiceSettingsPage : Page
         // Clean up when dialog closes
         if (listening)
         {
+            listening = false;
+            levelBarFill.Width = 0;
+            await voiceService.StopAsync();
             voiceService.TranscriptionReceived -= OnTranscription;
             voiceService.DiagnosticMessage -= OnDiagnostic;
-            await voiceService.StopAsync();
+            voiceService.SpeakingChanged -= OnSpeaking;
+            voiceService.AudioLevelChanged -= OnAudioLevel;
+        }
+
+        if (ownsVoiceService)
+        {
+            await voiceService.DisposeAsync();
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
@@ -243,6 +243,7 @@ public sealed partial class VoiceSettingsPage : Page
 
             ModelStatusText.Text = L("VoiceSettingsPage_StatusModelReady");
             DownloadButtonText.Text = L("VoiceSettingsPage_ButtonReDownload");
+            TestVoiceButton.Visibility = Visibility.Visible;
         }
         catch (OperationCanceledException)
         {
@@ -265,9 +266,108 @@ public sealed partial class VoiceSettingsPage : Page
 
     // ── TTS Voice Selection ──
 
-    private void OnTestVoiceClick(object sender, RoutedEventArgs e)
+    private async void OnTestVoiceClick(object sender, RoutedEventArgs e)
     {
-        _hub?.OpenVoiceAction?.Invoke();
+        if (_hub?.Settings == null) return;
+
+        // Stop any existing voice session first so we can grab the mic
+        if (_voiceService != null)
+        {
+            try { await _voiceService.StopAsync(); } catch { }
+        }
+
+        // Use the existing voice service — it's already initialized with the
+        // correct model and settings.
+        var voiceService = _voiceService ?? new VoiceService(new AppLogger(), _hub.Settings);
+
+        var transcriptText = new TextBlock
+        {
+            Text = "Press Start, then speak. Your words will appear here.",
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(0, 8, 0, 0)
+        };
+
+        var statusText = new TextBlock
+        {
+            Text = "",
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = 11,
+            Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Gray)
+        };
+
+        var startButton = new Button { Content = "Start Listening" };
+        var panel = new StackPanel { Spacing = 8 };
+        panel.Children.Add(startButton);
+        panel.Children.Add(statusText);
+        panel.Children.Add(transcriptText);
+
+        var dialog = new ContentDialog
+        {
+            Title = "Test Voice Input",
+            Content = panel,
+            CloseButtonText = "Done",
+            XamlRoot = this.XamlRoot
+        };
+
+        var listening = false;
+
+        void OnTranscription(string text)
+        {
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                if (transcriptText.Text == "Listening..." || transcriptText.Text.StartsWith("Press Start"))
+                    transcriptText.Text = text;
+                else
+                    transcriptText.Text += " " + text;
+            });
+        }
+
+        void OnDiagnostic(string msg)
+        {
+            DispatcherQueue.TryEnqueue(() => statusText.Text = msg);
+        }
+
+        startButton.Click += async (_, _) =>
+        {
+            if (!listening)
+            {
+                listening = true;
+                startButton.Content = "Stop Listening";
+                transcriptText.Text = "Listening...";
+                voiceService.TranscriptionReceived += OnTranscription;
+                voiceService.DiagnosticMessage += OnDiagnostic;
+                try
+                {
+                    await voiceService.StartVoiceChatAsync();
+                    statusText.Text = "Voice chat started — speak now";
+                }
+                catch (Exception ex)
+                {
+                    statusText.Text = $"Error: {ex.Message}";
+                    listening = false;
+                    startButton.Content = "Start Listening";
+                }
+            }
+            else
+            {
+                listening = false;
+                startButton.Content = "Start Listening";
+                voiceService.TranscriptionReceived -= OnTranscription;
+                voiceService.DiagnosticMessage -= OnDiagnostic;
+                await voiceService.StopAsync();
+                statusText.Text = "Stopped";
+            }
+        };
+
+        await dialog.ShowAsync();
+
+        // Clean up when dialog closes
+        if (listening)
+        {
+            voiceService.TranscriptionReceived -= OnTranscription;
+            voiceService.DiagnosticMessage -= OnDiagnostic;
+            await voiceService.StopAsync();
+        }
     }
 
     private void LoadTtsSettings(SettingsManager settings)

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
@@ -17,6 +17,7 @@ public sealed partial class VoiceSettingsPage : Page
 {
     private HubWindow? _hub;
     private VoiceService? _voiceService;
+    private bool _isVoiceTestDialogOpen;
     private bool _suppressEvents;
     // Per-asset CTS so a Piper download doesn't cancel an in-flight Whisper
     // download (and vice versa). Each download type owns its own token.
@@ -249,6 +250,7 @@ public sealed partial class VoiceSettingsPage : Page
         catch (OperationCanceledException)
         {
             ModelStatusText.Text = L("VoiceSettingsPage_StatusDownloadCanceled");
+            TestVoiceButton.Visibility = Visibility.Collapsed;
         }
         catch (Exception ex)
         {
@@ -257,6 +259,7 @@ public sealed partial class VoiceSettingsPage : Page
             // detail; show a generic message.
             Logger.Error($"Whisper model download failed: {ex}");
             ModelStatusText.Text = L("VoiceSettingsPage_StatusError");
+            TestVoiceButton.Visibility = Visibility.Collapsed;
         }
         finally
         {
@@ -269,279 +272,317 @@ public sealed partial class VoiceSettingsPage : Page
 
     private async void OnTestVoiceClick(object sender, RoutedEventArgs e)
     {
-        if (_hub?.Settings == null) return;
+        if (_hub?.Settings == null || _isVoiceTestDialogOpen) return;
 
-        // Stop any existing voice session first so we can grab the mic
-        if (_voiceService != null)
+        _isVoiceTestDialogOpen = true;
+        TestVoiceButton.IsEnabled = false;
+
+        try
         {
-            try { await _voiceService.StopAsync(); } catch { }
-        }
+            // Use a dedicated test service so settings verification never stops,
+            // submits through, or otherwise mutates the live voice overlay session.
+            await using var voiceService = new VoiceService(new AppLogger(), _hub.Settings);
 
-        var voiceService = _voiceService ?? new VoiceService(new AppLogger(), _hub.Settings);
-        var ownsVoiceService = voiceService != _voiceService;
-
-        // ── Transcript area (matches Companion Voice overlay style) ──
-        var emptyStateIcon = new FontIcon
-        {
-            Glyph = "\uE720",
-            FontSize = 32,
-            Opacity = 0.3,
-            HorizontalAlignment = HorizontalAlignment.Center
-        };
-        var emptyStateText = new TextBlock
-        {
-            Text = "Press Start and begin speaking",
-            FontSize = 13,
-            Opacity = 0.4,
-            HorizontalAlignment = HorizontalAlignment.Center
-        };
-        var emptyState = new StackPanel
-        {
-            HorizontalAlignment = HorizontalAlignment.Center,
-            VerticalAlignment = VerticalAlignment.Center,
-            Spacing = 8,
-            Margin = new Thickness(0, 40, 0, 40),
-        };
-        emptyState.Children.Add(emptyStateIcon);
-        emptyState.Children.Add(emptyStateText);
-
-        var transcriptPanel = new StackPanel { Spacing = 8 };
-        transcriptPanel.Children.Add(emptyState);
-
-        var transcriptScroll = new ScrollViewer
-        {
-            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-            Padding = new Thickness(12),
-            MaxHeight = 220,
-            Content = transcriptPanel
-        };
-
-        var transcriptBorder = new Border
-        {
-            Background = (Brush)Application.Current.Resources["CardBackgroundFillColorSecondaryBrush"],
-            CornerRadius = new CornerRadius(8),
-            Child = transcriptScroll
-        };
-
-        // ── Audio level bar ──
-        var levelBarBg = new Border
-        {
-            Background = (Brush)Application.Current.Resources["ControlStrongFillColorDefaultBrush"],
-            CornerRadius = new CornerRadius(2),
-            Opacity = 0.3
-        };
-        var levelBarFill = new Border
-        {
-            Background = new SolidColorBrush((global::Windows.UI.Color)Application.Current.Resources["SystemAccentColor"]),
-            CornerRadius = new CornerRadius(2),
-            HorizontalAlignment = HorizontalAlignment.Left,
-            Width = 0
-        };
-        var levelBarGrid = new Grid
-        {
-            Height = 4,
-            Margin = new Thickness(0, 0, 0, 8)
-        };
-        levelBarGrid.Children.Add(levelBarBg);
-        levelBarGrid.Children.Add(levelBarFill);
-
-        // ── Status text ──
-        var statusText = new TextBlock
-        {
-            Text = "Press Start to begin",
-            FontSize = 12,
-            Opacity = 0.5,
-            HorizontalAlignment = HorizontalAlignment.Center,
-            Margin = new Thickness(0, 0, 0, 10)
-        };
-
-        // ── Start/Stop button (accent style, matches overlay) ──
-        var btnIcon = new FontIcon { Glyph = "\uE768", FontSize = 14 };
-        var btnLabel = new TextBlock { Text = "Start Listening", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold };
-        var btnContent = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
-        btnContent.Children.Add(btnIcon);
-        btnContent.Children.Add(btnLabel);
-
-        var startButton = new Button
-        {
-            Content = btnContent,
-            Style = (Style)Application.Current.Resources["AccentButtonStyle"],
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            Height = 40
-        };
-
-        // ── Layout ──
-        var panel = new StackPanel { Spacing = 0, Width = 340 };
-        panel.Children.Add(transcriptBorder);
-        panel.Children.Add(new Border { Height = 12 });
-        panel.Children.Add(levelBarGrid);
-        panel.Children.Add(statusText);
-        panel.Children.Add(startButton);
-
-        var dialog = new ContentDialog
-        {
-            Title = "Test Voice Input",
-            Content = panel,
-            CloseButtonText = "Done",
-            XamlRoot = this.XamlRoot
-        };
-
-        var listening = false;
-        TextBlock? lastBubbleText = null;
-
-        void AddBubble(string text)
-        {
-            // Hide empty state on first transcription
-            if (emptyState.Visibility == Visibility.Visible)
-                emptyState.Visibility = Visibility.Collapsed;
-
-            // Consolidate rapid segments into the same bubble
-            if (lastBubbleText != null)
+            // ── Transcript area (matches Companion Voice overlay style) ──
+            var emptyStateIcon = new FontIcon
             {
-                lastBubbleText.Text += " " + text;
-            }
-            else
+                Glyph = "\uE720",
+                FontSize = 32,
+                Opacity = 0.3,
+                HorizontalAlignment = HorizontalAlignment.Center
+            };
+            var emptyStateText = new TextBlock
             {
-                var bubble = new Border
-                {
-                    Background = new SolidColorBrush(Microsoft.UI.Colors.DodgerBlue),
-                    CornerRadius = new CornerRadius(12, 12, 4, 12),
-                    Padding = new Thickness(12, 10, 12, 10),
-                    HorizontalAlignment = HorizontalAlignment.Right,
-                    Margin = new Thickness(24, 4, 0, 4)
-                };
-
-                var grid = new Grid { ColumnSpacing = 8 };
-                grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-                grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-
-                var icon = new FontIcon
-                {
-                    Glyph = "\uE77B",
-                    FontSize = 12,
-                    VerticalAlignment = VerticalAlignment.Top,
-                    Margin = new Thickness(0, 3, 0, 0),
-                    Foreground = new SolidColorBrush(Microsoft.UI.Colors.White)
-                };
-                Grid.SetColumn(icon, 0);
-                grid.Children.Add(icon);
-
-                lastBubbleText = new TextBlock
-                {
-                    Text = text,
-                    TextWrapping = TextWrapping.Wrap,
-                    FontSize = 13,
-                    IsTextSelectionEnabled = true,
-                    Foreground = new SolidColorBrush(Microsoft.UI.Colors.White)
-                };
-                Grid.SetColumn(lastBubbleText, 1);
-                grid.Children.Add(lastBubbleText);
-
-                bubble.Child = grid;
-                transcriptPanel.Children.Add(bubble);
-            }
-
-            transcriptScroll.UpdateLayout();
-            transcriptScroll.ChangeView(null, transcriptScroll.ScrollableHeight, null);
-        }
-
-        void OnTranscription(string text)
-        {
-            DispatcherQueue.TryEnqueue(() => AddBubble(text));
-        }
-
-        void OnDiagnostic(string msg)
-        {
-            DispatcherQueue.TryEnqueue(() => statusText.Text = msg);
-        }
-
-        void OnSpeaking(bool isSpeaking)
-        {
-            DispatcherQueue.TryEnqueue(() =>
+                Text = "Press Start and begin speaking",
+                FontSize = 13,
+                Opacity = 0.4,
+                HorizontalAlignment = HorizontalAlignment.Center
+            };
+            var emptyState = new StackPanel
             {
-                if (isSpeaking)
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                Spacing = 8,
+                Margin = new Thickness(0, 40, 0, 40),
+            };
+            emptyState.Children.Add(emptyStateIcon);
+            emptyState.Children.Add(emptyStateText);
+
+            var transcriptPanel = new StackPanel { Spacing = 8 };
+            transcriptPanel.Children.Add(emptyState);
+
+            var transcriptScroll = new ScrollViewer
+            {
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                Padding = new Thickness(12),
+                MaxHeight = 220,
+                Content = transcriptPanel
+            };
+
+            var transcriptBorder = new Border
+            {
+                Background = (Brush)Application.Current.Resources["CardBackgroundFillColorSecondaryBrush"],
+                CornerRadius = new CornerRadius(8),
+                Child = transcriptScroll
+            };
+
+            // ── Audio level bar ──
+            var levelBarBg = new Border
+            {
+                Background = (Brush)Application.Current.Resources["ControlStrongFillColorDefaultBrush"],
+                CornerRadius = new CornerRadius(2),
+                Opacity = 0.3
+            };
+            var levelBarFill = new Border
+            {
+                Background = new SolidColorBrush((global::Windows.UI.Color)Application.Current.Resources["SystemAccentColor"]),
+                CornerRadius = new CornerRadius(2),
+                HorizontalAlignment = HorizontalAlignment.Left,
+                Width = 0
+            };
+            var levelBarGrid = new Grid
+            {
+                Height = 4,
+                Margin = new Thickness(0, 0, 0, 8)
+            };
+            levelBarGrid.Children.Add(levelBarBg);
+            levelBarGrid.Children.Add(levelBarFill);
+
+            // ── Status text ──
+            var statusText = new TextBlock
+            {
+                Text = "Press Start to begin",
+                FontSize = 12,
+                Opacity = 0.5,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                Margin = new Thickness(0, 0, 0, 10)
+            };
+
+            // ── Start/Stop button (accent style, matches overlay) ──
+            var btnIcon = new FontIcon { Glyph = "\uE768", FontSize = 14 };
+            var btnLabel = new TextBlock { Text = "Start Listening", FontWeight = Microsoft.UI.Text.FontWeights.SemiBold };
+            var btnContent = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+            btnContent.Children.Add(btnIcon);
+            btnContent.Children.Add(btnLabel);
+
+            var startButton = new Button
+            {
+                Content = btnContent,
+                Style = (Style)Application.Current.Resources["AccentButtonStyle"],
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Height = 40
+            };
+
+            // ── Layout ──
+            var panel = new StackPanel { Spacing = 0, Width = 340 };
+            panel.Children.Add(transcriptBorder);
+            panel.Children.Add(new Border { Height = 12 });
+            panel.Children.Add(levelBarGrid);
+            panel.Children.Add(statusText);
+            panel.Children.Add(startButton);
+
+            var dialog = new ContentDialog
+            {
+                Title = "Test Voice Input",
+                Content = panel,
+                CloseButtonText = "Done",
+                XamlRoot = this.XamlRoot
+            };
+
+            var listening = false;
+            var voiceOperationInProgress = false;
+            var handlersAttached = false;
+            TextBlock? lastBubbleText = null;
+
+            void AddBubble(string text)
+            {
+                // Hide empty state on first transcription
+                if (emptyState.Visibility == Visibility.Visible)
+                    emptyState.Visibility = Visibility.Collapsed;
+
+                // Consolidate rapid segments into the same bubble
+                if (lastBubbleText != null)
                 {
-                    statusText.Text = "\U0001f3a4 Listening...";
-                    // New speech utterance → new bubble
-                    lastBubbleText = null;
+                    lastBubbleText.Text += " " + text;
                 }
                 else
                 {
-                    statusText.Text = "Speak now";
+                    var bubble = new Border
+                    {
+                        Background = new SolidColorBrush(Microsoft.UI.Colors.DodgerBlue),
+                        CornerRadius = new CornerRadius(12, 12, 4, 12),
+                        Padding = new Thickness(12, 10, 12, 10),
+                        HorizontalAlignment = HorizontalAlignment.Right,
+                        Margin = new Thickness(24, 4, 0, 4)
+                    };
+
+                    var grid = new Grid { ColumnSpacing = 8 };
+                    grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+                    grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+                    var icon = new FontIcon
+                    {
+                        Glyph = "\uE77B",
+                        FontSize = 12,
+                        VerticalAlignment = VerticalAlignment.Top,
+                        Margin = new Thickness(0, 3, 0, 0),
+                        Foreground = new SolidColorBrush(Microsoft.UI.Colors.White)
+                    };
+                    Grid.SetColumn(icon, 0);
+                    grid.Children.Add(icon);
+
+                    lastBubbleText = new TextBlock
+                    {
+                        Text = text,
+                        TextWrapping = TextWrapping.Wrap,
+                        FontSize = 13,
+                        IsTextSelectionEnabled = true,
+                        Foreground = new SolidColorBrush(Microsoft.UI.Colors.White)
+                    };
+                    Grid.SetColumn(lastBubbleText, 1);
+                    grid.Children.Add(lastBubbleText);
+
+                    bubble.Child = grid;
+                    transcriptPanel.Children.Add(bubble);
                 }
-            });
-        }
 
-        void OnAudioLevel(float level)
-        {
-            DispatcherQueue.TryEnqueue(() =>
-            {
-                var maxWidth = levelBarGrid.ActualWidth > 0 ? levelBarGrid.ActualWidth : 340;
-                levelBarFill.Width = Math.Max(0, level * maxWidth);
-            });
-        }
+                transcriptScroll.UpdateLayout();
+                transcriptScroll.ChangeView(null, transcriptScroll.ScrollableHeight, null);
+            }
 
-        startButton.Click += async (_, _) =>
-        {
-            if (!listening)
+            void OnTranscription(string text)
             {
-                listening = true;
-                btnIcon.Glyph = "\uE71A";
-                btnLabel.Text = "Stop Listening";
+                DispatcherQueue.TryEnqueue(() => AddBubble(text));
+            }
+
+            void OnDiagnostic(string msg)
+            {
+                DispatcherQueue.TryEnqueue(() => statusText.Text = msg);
+            }
+
+            void OnSpeaking(bool isSpeaking)
+            {
+                DispatcherQueue.TryEnqueue(() =>
+                {
+                    if (isSpeaking)
+                    {
+                        statusText.Text = "\U0001f3a4 Listening...";
+                        // New speech utterance → new bubble
+                        lastBubbleText = null;
+                    }
+                    else
+                    {
+                        statusText.Text = "Speak now";
+                    }
+                });
+            }
+
+            void OnAudioLevel(float level)
+            {
+                DispatcherQueue.TryEnqueue(() =>
+                {
+                    var maxWidth = levelBarGrid.ActualWidth > 0 ? levelBarGrid.ActualWidth : 340;
+                    levelBarFill.Width = Math.Max(0, level * maxWidth);
+                });
+            }
+
+            void AttachVoiceHandlers()
+            {
+                if (handlersAttached) return;
                 voiceService.TranscriptionReceived += OnTranscription;
                 voiceService.DiagnosticMessage += OnDiagnostic;
                 voiceService.SpeakingChanged += OnSpeaking;
                 voiceService.AudioLevelChanged += OnAudioLevel;
-                try
-                {
-                    await voiceService.StartVoiceChatAsync();
-                    statusText.Text = "Speak now";
-                }
-                catch (Exception ex)
-                {
-                    statusText.Text = $"Error: {ex.Message}";
-                    listening = false;
-                    btnIcon.Glyph = "\uE768";
-                    btnLabel.Text = "Start Listening";
-                    voiceService.TranscriptionReceived -= OnTranscription;
-                    voiceService.DiagnosticMessage -= OnDiagnostic;
-                    voiceService.SpeakingChanged -= OnSpeaking;
-                    voiceService.AudioLevelChanged -= OnAudioLevel;
-                }
+                handlersAttached = true;
             }
-            else
+
+            void DetachVoiceHandlers()
             {
-                listening = false;
-                btnIcon.Glyph = "\uE768";
-                btnLabel.Text = "Start Listening";
-                statusText.Text = "Processing...";
-                levelBarFill.Width = 0;
-                await voiceService.StopAsync();
+                if (!handlersAttached) return;
                 voiceService.TranscriptionReceived -= OnTranscription;
                 voiceService.DiagnosticMessage -= OnDiagnostic;
                 voiceService.SpeakingChanged -= OnSpeaking;
                 voiceService.AudioLevelChanged -= OnAudioLevel;
-                statusText.Text = "Done — check your transcript above";
+                handlersAttached = false;
             }
-        };
 
-        await dialog.ShowAsync();
+            dialog.Closing += (_, args) =>
+            {
+                if (!voiceOperationInProgress) return;
+                args.Cancel = true;
+                statusText.Text = "Please wait for voice input to finish...";
+            };
 
-        // Clean up when dialog closes
-        if (listening)
-        {
-            listening = false;
-            levelBarFill.Width = 0;
-            await voiceService.StopAsync();
-            voiceService.TranscriptionReceived -= OnTranscription;
-            voiceService.DiagnosticMessage -= OnDiagnostic;
-            voiceService.SpeakingChanged -= OnSpeaking;
-            voiceService.AudioLevelChanged -= OnAudioLevel;
+            startButton.Click += async (_, _) =>
+            {
+                if (voiceOperationInProgress) return;
+                voiceOperationInProgress = true;
+                startButton.IsEnabled = false;
+
+                if (!listening)
+                {
+                    try
+                    {
+                        listening = true;
+                        btnIcon.Glyph = "\uE71A";
+                        btnLabel.Text = "Stop Listening";
+                        AttachVoiceHandlers();
+                        await voiceService.StartVoiceChatAsync();
+                        statusText.Text = "Speak now";
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error($"Voice input test failed: {ex}");
+                        statusText.Text = "Could not start voice input";
+                        listening = false;
+                        btnIcon.Glyph = "\uE768";
+                        btnLabel.Text = "Start Listening";
+                        DetachVoiceHandlers();
+                    }
+                }
+                else
+                {
+                    try
+                    {
+                        statusText.Text = "Processing...";
+                        levelBarFill.Width = 0;
+                        await voiceService.StopAsync();
+                        statusText.Text = "Done — check your transcript above";
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error($"Voice input test stop failed: {ex}");
+                        statusText.Text = "Could not stop voice input cleanly";
+                    }
+                    finally
+                    {
+                        listening = false;
+                        btnIcon.Glyph = "\uE768";
+                        btnLabel.Text = "Start Listening";
+                        DetachVoiceHandlers();
+                    }
+                }
+
+                voiceOperationInProgress = false;
+                startButton.IsEnabled = true;
+            };
+
+            await dialog.ShowAsync();
+
+            // Clean up when dialog closes
+            if (listening)
+            {
+                listening = false;
+                levelBarFill.Width = 0;
+                await voiceService.StopAsync();
+                DetachVoiceHandlers();
+            }
+
         }
-
-        if (ownsVoiceService)
+        finally
         {
-            await voiceService.DisposeAsync();
+            TestVoiceButton.IsEnabled = true;
+            _isVoiceTestDialogOpen = false;
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2747,4 +2747,7 @@ On your gateway host (Mac/Linux), run:
   <data name="VoiceSettingsPage_PreviewVoiceButtonContent" xml:space="preserve">
     <value>▶ Preview Voice</value>
   </data>
+  <data name="VoiceSettingsPage_TestVoiceButtonText.Text" xml:space="preserve">
+    <value>Test Voice Input</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2748,4 +2748,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="VoiceSettingsPage_PreviewVoiceButtonContent" xml:space="preserve">
     <value>▶ Aperçu de la voix</value>
   </data>
+  <data name="VoiceSettingsPage_TestVoiceButtonText.Text" xml:space="preserve">
+    <value>Tester la saisie vocale</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2749,4 +2749,7 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="VoiceSettingsPage_PreviewVoiceButtonContent" xml:space="preserve">
     <value>▶ Voorbeeld van stem</value>
   </data>
+  <data name="VoiceSettingsPage_TestVoiceButtonText.Text" xml:space="preserve">
+    <value>Spraakinvoer testen</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2748,4 +2748,7 @@
   <data name="VoiceSettingsPage_PreviewVoiceButtonContent" xml:space="preserve">
     <value>▶ 预览语音</value>
   </data>
+  <data name="VoiceSettingsPage_TestVoiceButtonText.Text" xml:space="preserve">
+    <value>测试语音输入</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2748,4 +2748,7 @@
   <data name="VoiceSettingsPage_PreviewVoiceButtonContent" xml:space="preserve">
     <value>▶ 預覽語音</value>
   </data>
+  <data name="VoiceSettingsPage_TestVoiceButtonText.Text" xml:space="preserve">
+    <value>測試語音輸入</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -47,6 +47,7 @@ public sealed partial class HubWindow : WindowEx
     public Action? ReconnectAction { get; set; }
     public Action? OpenSetupAction { get; set; }
     public Action? OpenConnectionStatusAction { get; set; }
+    public Action? OpenVoiceAction { get; set; }
     public OpenClawTray.Services.Connection.IGatewayConnectionManager? ConnectionManager { get; set; }
     public OpenClawTray.Services.Connection.GatewayRegistry? GatewayRegistry { get; set; }
 

--- a/src/OpenClaw.Tray.WinUI/Windows/VoiceOverlayWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/VoiceOverlayWindow.xaml.cs
@@ -22,6 +22,7 @@ public sealed partial class VoiceOverlayWindow : WindowEx
     private readonly VoiceService _voiceService;
     private readonly IOpenClawLogger _logger;
     private readonly DispatcherQueue _dispatcherQueue;
+    private readonly bool _testOnly;
     private bool _isMuted;
 
     /// <summary>Fired when the user submits transcribed text to the agent.</summary>
@@ -31,16 +32,25 @@ public sealed partial class VoiceOverlayWindow : WindowEx
     /// navigate to the Voice & Audio page (e.g. via <c>ShowHub("voice")</c>).</summary>
     public event Action? SettingsRequested;
 
-    public VoiceOverlayWindow(VoiceService voiceService, IOpenClawLogger logger)
+    /// <param name="testOnly">When true, transcription is displayed but never
+    /// submitted to the agent — used for mic/model verification from Settings.</param>
+    public VoiceOverlayWindow(VoiceService voiceService, IOpenClawLogger logger, bool testOnly = false)
     {
         InitializeComponent();
         _voiceService = voiceService;
         _logger = logger;
+        _testOnly = testOnly;
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
 
         // Modern custom title bar
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);
+
+        if (_testOnly)
+        {
+            Title = "Test Voice Input";
+            IsAlwaysOnTop = false;
+        }
 
         _voiceService.TranscriptionReceived += OnTranscriptionReceived;
         _voiceService.UtteranceCompleted += OnUtteranceCompleted;
@@ -91,6 +101,7 @@ public sealed partial class VoiceOverlayWindow : WindowEx
         // Fire once per silence-bounded utterance. The visual bubble already
         // shows the streamed text; here we just hand the complete sentence
         // to the gateway exactly once.
+        if (_testOnly) return; // Test mode: transcribe only, don't submit
         _dispatcherQueue.TryEnqueue(() =>
         {
             if (!string.IsNullOrWhiteSpace(utterance.Text))


### PR DESCRIPTION
## Summary

Redesigns the **Test Voice Input** dialog in Voice & Audio settings to match the visual style of the Companion Voice overlay window.

### Changes

**UI redesign:**
- Mic icon + hint text empty state (replaces plain text placeholder)
- DodgerBlue chat bubbles with person icon for transcribed speech
- Live audio level bar (accent-colored fill on gray track)
- Accent-styled Start/Stop button with play/stop icons
- Centered status text showing mic state

**Bug fixes:**
- **Transcription not appearing** — event handlers were unsubscribed *before* \StopAsync()\ flushed the speech buffer; moved unsubscription to after flush completes
- **Event handler leak** — if \StartVoiceChatAsync()\ threw, handlers remained subscribed on the shared VoiceService; now cleaned up in catch block
- **Resource leak** — locally-created VoiceService instances are now disposed when the dialog closes

**Behavior:**
- Continuous listening mode — each pause creates a new bubble, mic stays active until manual stop
- Audio level and speaking state provide real-time visual feedback
- No messages sent to the agent (test-only mode)

### Testing
- 1443 unit tests passing (OpenClaw.Shared.Tests)
- Manual testing: mic capture, VAD detection, Whisper transcription, bubble rendering, start/stop lifecycle