### PR TITLE
fix(usage): make 7/30 day toggle work + redesign with Fluent SelectorBar

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml
@@ -59,60 +59,90 @@
                 </Border>
             </StackPanel>
 
-            <!-- Time period buttons -->
-            <StackPanel Orientation="Horizontal" Spacing="8">
-                <Button x:Uid="Period7DaysButton" x:Name="Period7DaysButton" Content="7 Days" Click="OnPeriod7Days"
-                        Style="{ThemeResource AccentButtonStyle}"/>
-                <Button x:Uid="Period30DaysButton" x:Name="Period30DaysButton" Content="30 Days" Click="OnPeriod30Days"/>
-            </StackPanel>
+            <!-- Provider Breakdown card — real-time provider status (independent of the time range below). -->
+            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1" CornerRadius="8" Padding="16" Margin="0,8,0,0">
+                <StackPanel Spacing="12">
+                    <TextBlock x:Uid="UsagePage_TextBlock_70" Text="Provider Breakdown"
+                               Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                    <Border Height="1" Background="{ThemeResource CardStrokeColorDefaultBrush}"/>
+                    <StackPanel x:Name="ProviderLoadingPanel" Orientation="Horizontal" Spacing="12"
+                                HorizontalAlignment="Center" Padding="0,24,0,16">
+                        <ProgressRing IsActive="True" Width="20" Height="20"/>
+                        <TextBlock x:Uid="UsagePage_ProviderLoading" Text="Loading providers…"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   VerticalAlignment="Center"/>
+                    </StackPanel>
+                    <TextBlock x:Uid="UsagePage_NoProviders" x:Name="ProviderEmptyText"
+                               Text="No providers configured"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               HorizontalAlignment="Center" Padding="0,24,0,16"
+                               Visibility="Collapsed"/>
+                    <ListView x:Name="ProviderListView" SelectionMode="None" Visibility="Collapsed">
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <Grid Padding="4,8">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                    <TextBlock Grid.Column="1" Text="{Binding Plan}" Margin="16,0"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                               VerticalAlignment="Center"/>
+                                    <TextBlock Grid.Column="2" Text="{Binding Usage}" Margin="16,0"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                               VerticalAlignment="Center"/>
+                                    <TextBlock Grid.Column="3" Text="{Binding Status}" FontWeight="SemiBold"
+                                               VerticalAlignment="Center"/>
+                                </Grid>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                </StackPanel>
+            </Border>
 
-            <!-- Provider Breakdown -->
-            <TextBlock x:Uid="UsagePage_TextBlock_70" Text="Provider Breakdown" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,8,0,0"/>
-            <ListView x:Name="ProviderListView" SelectionMode="None">
-                <ListView.ItemTemplate>
-                    <DataTemplate>
-                        <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                                BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,0,0,4">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
-                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                                <TextBlock Grid.Column="1" Text="{Binding Requests}" Margin="16,0"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                           VerticalAlignment="Center"/>
-                                <TextBlock Grid.Column="2" Text="{Binding Tokens}" Margin="16,0"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                           VerticalAlignment="Center"/>
-                                <TextBlock Grid.Column="3" Text="{Binding Cost}" FontWeight="SemiBold"
-                                           VerticalAlignment="Center"/>
-                            </Grid>
-                        </Border>
-                    </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView>
-
-            <!-- Daily Cost -->
-            <TextBlock x:Uid="UsagePage_TextBlock_100" Text="Daily Cost" Style="{StaticResource BodyStrongTextBlockStyle}" Margin="0,8,0,0"/>
-            <ListView x:Name="DailyListView" SelectionMode="None">
-                <ListView.ItemTemplate>
-                    <DataTemplate>
-                        <Grid Padding="4,6">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Text="{Binding Date}"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                            <TextBlock Grid.Column="1" Text="{Binding Cost}" FontWeight="SemiBold"/>
-                        </Grid>
-                    </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView>
+            <!-- Daily Cost card — header + time-range selector grouped together so
+                 the filter is visually scoped to the data inside the same card. -->
+            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1" CornerRadius="8" Padding="16" Margin="0,8,0,0">
+                <StackPanel Spacing="12">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Uid="UsagePage_TextBlock_100" Text="Daily Cost"
+                                   Style="{StaticResource BodyStrongTextBlockStyle}"
+                                   VerticalAlignment="Center"/>
+                        <SelectorBar Grid.Column="1" x:Name="PeriodSelector"
+                                     SelectionChanged="OnPeriodSelectionChanged">
+                            <SelectorBarItem x:Uid="Period7DaysItem"  x:Name="Period7DaysItem"  Text="7 Days" IsSelected="True"/>
+                            <SelectorBarItem x:Uid="Period30DaysItem" x:Name="Period30DaysItem" Text="30 Days"/>
+                        </SelectorBar>
+                    </Grid>
+                    <Border Height="1" Background="{ThemeResource CardStrokeColorDefaultBrush}"/>
+                    <ListView x:Name="DailyListView" SelectionMode="None">
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <Grid Padding="4,6">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Text="{Binding Date}"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                    <TextBlock Grid.Column="1" Text="{Binding Cost}" FontWeight="SemiBold"/>
+                                </Grid>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                </StackPanel>
+            </Border>
 
         </StackPanel>
     </ScrollViewer>

--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
@@ -12,6 +12,8 @@ namespace OpenClawTray.Pages;
 public sealed partial class UsagePage : Page
 {
     private HubWindow? _hub;
+    // Default matches the XAML-selected Period7DaysItem (IsSelected="True").
+    private int _currentPeriodDays = 7;
 
     public UsagePage()
     {
@@ -24,13 +26,24 @@ public sealed partial class UsagePage : Page
         ConnectionWarning.Visibility = hub.GatewayClient != null ? Visibility.Collapsed : Visibility.Visible;
         if (hub.GatewayClient != null)
         {
-            // Apply cached data immediately, then request fresh
+            // Apply cached data immediately, then request fresh.
             if (hub.LastUsage != null) UpdateUsage(hub.LastUsage);
-            if (hub.LastUsageCost != null) UpdateUsageCost(hub.LastUsageCost);
+            // Only apply cached cost data when its period matches the current
+            // selection — otherwise the daily list briefly shows e.g. 30-day
+            // data while the selector reads "7 Days".
+            if (hub.LastUsageCost != null && hub.LastUsageCost.Days == _currentPeriodDays)
+            {
+                UpdateUsageCost(hub.LastUsageCost);
+            }
             if (hub.LastUsageStatus != null) UpdateUsageStatus(hub.LastUsageStatus);
             _ = hub.GatewayClient.RequestUsageAsync();
-            _ = hub.GatewayClient.RequestUsageCostAsync(30);
+            _ = hub.GatewayClient.RequestUsageCostAsync(_currentPeriodDays);
             _ = hub.GatewayClient.RequestUsageStatusAsync();
+        }
+        else
+        {
+            // Not connected — nothing to load, hide the loading skeleton.
+            ProviderLoadingPanel.Visibility = Visibility.Collapsed;
         }
     }
 
@@ -39,8 +52,10 @@ public sealed partial class UsagePage : Page
         DispatcherQueue?.TryEnqueue(() =>
         {
             RequestCountText.Text = usage.RequestCount.ToString();
-            TokenCountText.Text = FormatLargeNumber(usage.TotalTokens);
-            TotalCostText.Text = $"${usage.CostUsd:F2}";
+            // Note: TotalCostText and TokenCountText are owned by UpdateUsageCost
+            // (period-scoped), not UpdateUsage (all-time). Writing them from both
+            // sources caused a race where the last response to arrive won — see
+            // Hanselman review #1 (HIGH).
         });
     }
 
@@ -67,23 +82,33 @@ public sealed partial class UsagePage : Page
             ProviderListView.ItemsSource = status.Providers.Select(p => new ProviderRow
             {
                 Name = p.DisplayName,
-                Requests = p.Plan ?? "",
-                Tokens = p.Windows.Count > 0 ? $"{p.Windows[0].UsedPercent:F0}% used" : "",
-                Cost = p.Error ?? "",
+                Plan = p.Plan ?? "",
+                Usage = p.Windows.Count > 0 ? $"{p.Windows[0].UsedPercent:F0}% used" : "",
+                Status = p.Error ?? "",
             }).ToList();
+
+            bool hasProviders = status.Providers.Count > 0;
+            ProviderLoadingPanel.Visibility = Visibility.Collapsed;
+            ProviderListView.Visibility = hasProviders ? Visibility.Visible : Visibility.Collapsed;
+            ProviderEmptyText.Visibility = hasProviders ? Visibility.Collapsed : Visibility.Visible;
         });
     }
 
-    private void OnPeriod7Days(object sender, RoutedEventArgs e)
+    private void OnPeriodSelectionChanged(SelectorBar sender, SelectorBarSelectionChangedEventArgs args)
     {
-        Period7DaysButton.Style = (Style)Application.Current.Resources["AccentButtonStyle"];
-        Period30DaysButton.Style = (Style)Application.Current.Resources["DefaultButtonStyle"];
+        var days = ReferenceEquals(sender.SelectedItem, Period30DaysItem) ? 30 : 7;
+        SelectPeriod(days);
     }
 
-    private void OnPeriod30Days(object sender, RoutedEventArgs e)
+    private void SelectPeriod(int days)
     {
-        Period30DaysButton.Style = (Style)Application.Current.Resources["AccentButtonStyle"];
-        Period7DaysButton.Style = (Style)Application.Current.Resources["DefaultButtonStyle"];
+        if (days == _currentPeriodDays) return;
+        _currentPeriodDays = days;
+
+        if (_hub?.GatewayClient != null)
+        {
+            _ = _hub.GatewayClient.RequestUsageCostAsync(days);
+        }
     }
 
     private static string FormatLargeNumber(long n)
@@ -96,9 +121,9 @@ public sealed partial class UsagePage : Page
     private class ProviderRow
     {
         public string Name { get; set; } = "";
-        public string Requests { get; set; } = "";
-        public string Tokens { get; set; } = "";
-        public string Cost { get; set; } = "";
+        public string Plan { get; set; } = "";
+        public string Usage { get; set; } = "";
+        public string Status { get; set; } = "";
     }
 
     private class DailyRow

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2111,11 +2111,17 @@ On your gateway host (Mac/Linux), run:
   <data name="UsagePage_TextBlock_55.Text" xml:space="preserve">
     <value>Providers</value>
   </data>
-  <data name="Period7DaysButton.Content" xml:space="preserve">
+  <data name="Period7DaysItem.Text" xml:space="preserve">
     <value>7 Days</value>
   </data>
-  <data name="Period30DaysButton.Content" xml:space="preserve">
+  <data name="Period30DaysItem.Text" xml:space="preserve">
     <value>30 Days</value>
+  </data>
+  <data name="UsagePage_ProviderLoading.Text" xml:space="preserve">
+    <value>Loading providers…</value>
+  </data>
+  <data name="UsagePage_NoProviders.Text" xml:space="preserve">
+    <value>No providers configured</value>
   </data>
   <data name="UsagePage_TextBlock_70.Text" xml:space="preserve">
     <value>Provider Breakdown</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2112,11 +2112,17 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="UsagePage_TextBlock_55.Text" xml:space="preserve">
     <value>Fournisseurs</value>
   </data>
-  <data name="Period7DaysButton.Content" xml:space="preserve">
+  <data name="Period7DaysItem.Text" xml:space="preserve">
     <value>7 jours</value>
   </data>
-  <data name="Period30DaysButton.Content" xml:space="preserve">
+  <data name="Period30DaysItem.Text" xml:space="preserve">
     <value>30 jours</value>
+  </data>
+  <data name="UsagePage_ProviderLoading.Text" xml:space="preserve">
+    <value>Chargement des fournisseurs…</value>
+  </data>
+  <data name="UsagePage_NoProviders.Text" xml:space="preserve">
+    <value>Aucun fournisseur configuré</value>
   </data>
   <data name="UsagePage_TextBlock_70.Text" xml:space="preserve">
     <value>Répartition par fournisseur</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2113,11 +2113,17 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="UsagePage_TextBlock_55.Text" xml:space="preserve">
     <value>Aanbieders</value>
   </data>
-  <data name="Period7DaysButton.Content" xml:space="preserve">
+  <data name="Period7DaysItem.Text" xml:space="preserve">
     <value>7 dagen</value>
   </data>
-  <data name="Period30DaysButton.Content" xml:space="preserve">
+  <data name="Period30DaysItem.Text" xml:space="preserve">
     <value>30 dagen</value>
+  </data>
+  <data name="UsagePage_ProviderLoading.Text" xml:space="preserve">
+    <value>Aanbieders laden…</value>
+  </data>
+  <data name="UsagePage_NoProviders.Text" xml:space="preserve">
+    <value>Geen aanbieders geconfigureerd</value>
   </data>
   <data name="UsagePage_TextBlock_70.Text" xml:space="preserve">
     <value>Uitsplitsing per provider</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2112,11 +2112,17 @@
   <data name="UsagePage_TextBlock_55.Text" xml:space="preserve">
     <value>提供程序</value>
   </data>
-  <data name="Period7DaysButton.Content" xml:space="preserve">
+  <data name="Period7DaysItem.Text" xml:space="preserve">
     <value>7 天</value>
   </data>
-  <data name="Period30DaysButton.Content" xml:space="preserve">
+  <data name="Period30DaysItem.Text" xml:space="preserve">
     <value>30 天</value>
+  </data>
+  <data name="UsagePage_ProviderLoading.Text" xml:space="preserve">
+    <value>正在加载提供程序…</value>
+  </data>
+  <data name="UsagePage_NoProviders.Text" xml:space="preserve">
+    <value>未配置任何提供程序</value>
   </data>
   <data name="UsagePage_TextBlock_70.Text" xml:space="preserve">
     <value>提供程序明细</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2112,11 +2112,17 @@
   <data name="UsagePage_TextBlock_55.Text" xml:space="preserve">
     <value>提供者</value>
   </data>
-  <data name="Period7DaysButton.Content" xml:space="preserve">
+  <data name="Period7DaysItem.Text" xml:space="preserve">
     <value>7 天</value>
   </data>
-  <data name="Period30DaysButton.Content" xml:space="preserve">
+  <data name="Period30DaysItem.Text" xml:space="preserve">
     <value>30 天</value>
+  </data>
+  <data name="UsagePage_ProviderLoading.Text" xml:space="preserve">
+    <value>正在載入提供者…</value>
+  </data>
+  <data name="UsagePage_NoProviders.Text" xml:space="preserve">
+    <value>未設定任何提供者</value>
   </data>
   <data name="UsagePage_TextBlock_70.Text" xml:space="preserve">
     <value>提供者明細</value>


### PR DESCRIPTION
## Problem

The 7 Days / 30 Days toggle on the Usage page only swapped button styles — it never re-fetched usage data. The page was effectively stuck on whatever period was loaded at startup. `Initialize()` also hardcoded `RequestUsageCostAsync(30)` while XAML highlighted the 7 Days button, so the UI label and the data on screen disagreed on first load.

## What changed

### Functional fix (the bug)
- Wire the period selection to `RequestUsageCostAsync(days)`, with an early-return guard so re-clicking the active period doesn't fire a duplicate request.
- `Initialize()` now requests the same period the UI is highlighting.

### UI redesign (Fluent guidance)
- Replace the two `Button` controls with a [`SelectorBar`](https://learn.microsoft.com/en-us/windows/apps/design/controls/selector-bar) — the official Fluent control for *"switch between a small number of views/filters"*. The selection underline is preserved through hover/focus/press, which `AccentButtonStyle` was losing on `PointerOver`.
- Move Provider Breakdown above the SelectorBar so it's visually clear the selector only scopes the Daily Cost data below it (provider status is real-time, not period-based).
- Wrap both Provider Breakdown and Daily Cost in full-width Fluent data cards so the page reads as three consistent cards (Total Cost / Providers / Daily Cost) instead of a mix of cards and floating headers.
- Co-locate the SelectorBar with the Daily Cost label inside the same card header row, so the filter is unambiguously scoped to the data in that card.
- Add a `ProgressRing` + *"Loading providers…"* skeleton inside the Provider Breakdown card so the first-load gateway round-trip feels intentional.
- Add a *"No providers configured"* empty-state for the Provider Breakdown card so a zero-provider response doesn't render as a blank section.

### Correctness fixes (Hanselman dual-model review)
- `UpdateUsage` no longer writes `TotalCostText` / `TokenCountText`. Those fields are now owned exclusively by `UpdateUsageCost` (the period-scoped data the toggle controls). Previously both methods raced on every load — whichever response arrived last clobbered the hero numbers with the wrong period (or all-time).
- `Initialize` only applies cached `LastUsageCost` when its `Days` field matches the current selection. Avoids briefly rendering 30-day data while the SelectorBar reads "7 Days" when the user returns to the page.

### Code clarity
- Rename misleading `ProviderRow` properties: `Requests` → `Plan`, `Tokens` → `Usage`, `Cost` → `Status`. The bindings now describe what they actually show (plan tier, current rate-limit window usage, error/status text).

### Localization
- Rename resw keys `Period7DaysButton.Content` / `Period30DaysButton.Content` → `Period7DaysItem.Text` / `Period30DaysItem.Text` across all 5 languages (en-us, fr-fr, zh-cn, zh-tw, nl-nl) to match `SelectorBarItem.Text`.
- Add `UsagePage_ProviderLoading.Text` and `UsagePage_NoProviders.Text` in all 5 languages.

## Before / after

| Before | After |
|---|---|
| 7 Days / 30 Days = AccentButton + DefaultButton; click only restyles | SelectorBar with underline indicator; click refetches `usage.cost {days}` |
| Selector floats above an unrelated "Daily Cost" header | Selector lives inside the Daily Cost card header |
| Provider Breakdown is a single bordered row below the selector — looks period-scoped | Provider Breakdown is a full-width card *above* the selector with loading + empty states |
| Hero `Total Cost` / `Tokens` race between two async sources | `UpdateUsageCost` is the sole owner of period-scoped totals |

## Validation

- `./build.ps1` succeeds for all 4 projects (Shared, Cli, WinNodeCli, WinUI).
- `OpenClaw.Shared.Tests`: **1455 passed**, 0 failed, 25 skipped.
- `OpenClaw.Tray.Tests`: **959 passed**, 0 failed.
- Manual smoke: launched tray, opened Usage page, toggled 7 ↔ 30 days, observed Daily Cost list refresh, observed selection underline persist through hover.
