### PR TITLE
fix(onboarding): setup code bootstrap flow, connection error handling, and token priority

### DIFF
--- a/src/OpenClaw.Shared/WebSocketClientBase.cs
+++ b/src/OpenClaw.Shared/WebSocketClientBase.cs
@@ -118,11 +118,7 @@ public abstract class WebSocketClientBase : IDisposable
             _webSocket = new ClientWebSocket();
             _webSocket.Options.KeepAliveInterval = TimeSpan.FromSeconds(30);
 
-            // Set Origin header (convert ws/wss to http/https)
             var uri = new Uri(_gatewayUrl);
-            var originScheme = uri.Scheme == "wss" ? "https" : "http";
-            var origin = $"{originScheme}://{uri.Host}:{uri.Port}";
-            _webSocket.Options.SetRequestHeader("Origin", origin);
 
             if (!string.IsNullOrEmpty(_credentials))
             {

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -781,7 +781,8 @@ public class WindowsNodeClient : WebSocketClientBase
 
         _logger.Info($"[HANDSHAKE] Connect error: message=\"{error}\", code={errorCode}");
 
-        if (string.Equals(errorCode, "NOT_PAIRED", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(errorCode, "NOT_PAIRED", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(errorCode, "PAIRING_REQUIRED", StringComparison.OrdinalIgnoreCase))
         {
             if (_isPendingApproval)
             {

--- a/src/OpenClaw.Tray.WinUI/Onboarding/Pages/ConnectionPage.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/Pages/ConnectionPage.cs
@@ -83,6 +83,7 @@ public sealed class ConnectionPage : Component<OnboardingState>
             GetDetectedLocalUrl);
         var (url, setUrl) = UseState(initialUrl);
         var (token, setToken) = UseState("");
+        var (gotBootstrapToken, setGotBootstrapToken) = UseState(false);
         var (nodeMode, setNodeMode) = UseState(Props.Settings.EnableNodeMode);
         var (setupCode, setSetupCode) = UseState("");
 
@@ -161,7 +162,7 @@ public sealed class ConnectionPage : Component<OnboardingState>
             if (result.Token != null)
             {
                 setToken(result.Token);
-                // Bootstrap token stored in GatewayRegistry via ApplySetupCodeAsync
+                setGotBootstrapToken(true);
             }
             setStatusMsg($"✅ {LocalizationHelper.GetString("Onboarding_Connection_StatusDecoded")}");
         }
@@ -176,6 +177,7 @@ public sealed class ConnectionPage : Component<OnboardingState>
 
         void OnTokenChanged(string v)
         {
+            setGotBootstrapToken(false);
             setToken(v);
             Props.ConnectionTested = false;
             setStatusMsg("");
@@ -293,11 +295,14 @@ public sealed class ConnectionPage : Component<OnboardingState>
                     var sshConfig = useSshTunnel
                         ? new OpenClawTray.Services.Connection.SshTunnelConfig(sshUser, sshHost, sshRemotePort, sshLocalPort)
                         : null;
+                    var isBootstrap = !string.IsNullOrWhiteSpace(setupCode)
+                        && SetupCodeDecoder.Decode(setupCode) is { Success: true };
                     var record = new OpenClawTray.Services.Connection.GatewayRecord
                     {
                         Id = recordId,
                         Url = normalizedUrl,
-                        SharedGatewayToken = !string.IsNullOrWhiteSpace(token) ? token : null,
+                        BootstrapToken = isBootstrap && !string.IsNullOrWhiteSpace(token) ? token : null,
+                        SharedGatewayToken = !isBootstrap && !string.IsNullOrWhiteSpace(token) ? token : null,
                         SshTunnel = sshConfig,
                     };
                     registry.AddOrUpdate(record);
@@ -314,6 +319,8 @@ public sealed class ConnectionPage : Component<OnboardingState>
                 bool connected = false;
                 bool pairingRequired = false;
                 bool authFailed = false;
+                int consecutiveErrors = 0;
+                const int maxTransientErrors = 3;
 
                 for (int attempt = 0; attempt < 30; attempt++)
                 {
@@ -328,7 +335,15 @@ public sealed class ConnectionPage : Component<OnboardingState>
                     if (snapshot.OverallState == OpenClawTray.Services.Connection.OverallConnectionState.PairingRequired)
                     { pairingRequired = true; break; }
                     if (snapshot.OverallState == OpenClawTray.Services.Connection.OverallConnectionState.Error)
-                    { authFailed = true; break; }
+                    {
+                        consecutiveErrors++;
+                        if (consecutiveErrors >= maxTransientErrors)
+                        { authFailed = true; break; }
+                    }
+                    else
+                    {
+                        consecutiveErrors = 0;
+                    }
                 }
 
                 if (connected)

--- a/src/OpenClaw.Tray.WinUI/Services/Connection/CredentialResolver.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/Connection/CredentialResolver.cs
@@ -37,13 +37,13 @@ public sealed class CredentialResolver : ICredentialResolver
         if (!string.IsNullOrWhiteSpace(storedToken))
             return new GatewayCredential(storedToken!, false, SourceDeviceToken);
 
-        // 2. Shared gateway token — works for any device, full scopes
-        if (!string.IsNullOrWhiteSpace(record.SharedGatewayToken))
-            return new GatewayCredential(record.SharedGatewayToken!, false, SourceSharedGatewayToken);
-
-        // 3. Bootstrap token — one-time setup, limited scopes
+        // 2. Bootstrap token
         if (!string.IsNullOrWhiteSpace(record.BootstrapToken))
             return new GatewayCredential(record.BootstrapToken!, true, SourceBootstrapToken);
+
+        // 3. Shared gateway token
+        if (!string.IsNullOrWhiteSpace(record.SharedGatewayToken))
+            return new GatewayCredential(record.SharedGatewayToken!, false, SourceSharedGatewayToken);
 
         return null;
     }
@@ -57,13 +57,13 @@ public sealed class CredentialResolver : ICredentialResolver
         if (!string.IsNullOrWhiteSpace(storedToken))
             return new GatewayCredential(storedToken!, false, SourceNodeDeviceToken);
 
-        // 2. Shared gateway token
-        if (!string.IsNullOrWhiteSpace(record.SharedGatewayToken))
-            return new GatewayCredential(record.SharedGatewayToken!, false, SourceSharedGatewayToken);
-
-        // 3. Bootstrap token
+        // 2. Bootstrap token
         if (!string.IsNullOrWhiteSpace(record.BootstrapToken))
             return new GatewayCredential(record.BootstrapToken!, true, SourceBootstrapToken);
+
+        // 3. Shared gateway token
+        if (!string.IsNullOrWhiteSpace(record.SharedGatewayToken))
+            return new GatewayCredential(record.SharedGatewayToken!, false, SourceSharedGatewayToken);
 
         return null;
     }

--- a/src/OpenClaw.Tray.WinUI/Services/StartupSetupState.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/StartupSetupState.cs
@@ -19,11 +19,10 @@ internal static class StartupSetupState
 
     public static bool RequiresSetup(SettingsManager settings, string dataPath)
     {
-        if (settings.EnableNodeMode && HasStoredNodeDeviceToken(dataPath))
-        {
+        var hasOperatorToken = DeviceIdentity.HasStoredDeviceToken(dataPath);
+        var hasNodeToken = HasStoredNodeDeviceToken(dataPath);
+        if (hasOperatorToken || hasNodeToken)
             return false;
-        }
-
-        return !settings.EnableMcpServer;
+        return true;
     }
 }


### PR DESCRIPTION
The onboarding wizard fails to complete when using a setup code from the
gateway. This PR fixes the bootstrap token flow end-to-end.

Changes:
- Remove Origin header from native WebSocket client (gateway misclassifies
  it as Control-UI)
- Handle PAIRING_REQUIRED error code alongside NOT_PAIRED
- Prioritize BootstrapToken over SharedGatewayToken in credential resolution
- Store setup code tokens as BootstrapToken, debounce transient Error
  state in polling loop (v3→v2 signature fallback briefly sets Error)
- Check operator AND node token in RequiresSetup (previous logic skipped
  the wizard for fresh installs when EnableMcpServer was enabled)

Generated with OpenClaw (model: DeepSeek v4 Flash).