### PR TITLE
fix(onboarding): restore pairing setup flow

### DIFF
--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -711,12 +711,11 @@ public class WindowsNodeClient : WebSocketClientBase
                         _isPendingApproval = true;
                         _isPaired = false;
                         _pairingBlocked = true;
-                        _logger.Info("Not yet paired - check 'openclaw devices list' for pending approval");
-                        _logger.Info($"To approve, run: openclaw devices approve {_deviceIdentity.DeviceId}");
+                        _logger.Info("Not yet paired - check 'openclaw devices list' for the pending requestId, then approve it");
                         EmitPairingStatusOnTransition(new PairingStatusEventArgs(
                             PairingStatus.Pending, 
                             _deviceIdentity.DeviceId,
-                            $"Run: openclaw devices approve {ShortDeviceId}..."));
+                            "Run: openclaw devices list"));
                     }
                 }
                 else
@@ -771,6 +770,10 @@ public class WindowsNodeClient : WebSocketClientBase
             }
             if (errorProp.TryGetProperty("details", out var detailsProp))
             {
+                if (TryGetString(detailsProp, "code", out var detailCode) && errorCode == "none")
+                {
+                    errorCode = detailCode!;
+                }
                 if (TryGetString(detailsProp, "reason", out var reason))
                 {
                     pairingReason = reason;
@@ -780,11 +783,24 @@ public class WindowsNodeClient : WebSocketClientBase
                     pairingRequestId = requestId;
                 }
             }
+            if (errorProp.TryGetProperty("data", out var dataProp) &&
+                dataProp.TryGetProperty("details", out var dataDetailsProp))
+            {
+                if (errorCode == "none" && TryGetString(dataDetailsProp, "code", out var dataDetailCode))
+                {
+                    errorCode = dataDetailCode!;
+                }
+                if (string.IsNullOrWhiteSpace(pairingRequestId) && TryGetString(dataDetailsProp, "requestId", out var dataRequestId))
+                {
+                    pairingRequestId = dataRequestId;
+                }
+            }
         }
 
         _logger.Info($"[HANDSHAKE] Connect error: message=\"{error}\", code={errorCode}");
 
-        if (string.Equals(errorCode, "NOT_PAIRED", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(errorCode, "NOT_PAIRED", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(errorCode, "PAIRING_REQUIRED", StringComparison.OrdinalIgnoreCase))
         {
             if (_isPendingApproval)
             {
@@ -797,10 +813,12 @@ public class WindowsNodeClient : WebSocketClientBase
             _pairingApprovedAwaitingReconnect = false;
 
             var detail = !string.IsNullOrWhiteSpace(pairingRequestId)
-                ? $"Device {ShortDeviceId} requires approval (request {pairingRequestId})"
-                : $"Run: openclaw devices approve {ShortDeviceId}...";
+                ? $"Run: openclaw devices approve {pairingRequestId}"
+                : "Run: openclaw devices list";
             _logger.Info($"[NODE] Pairing required for this device; reason={pairingReason ?? "unknown"}, requestId={pairingRequestId ?? "none"}");
-            _logger.Info($"To approve, run: openclaw devices approve {_deviceIdentity.DeviceId}");
+            _logger.Info(!string.IsNullOrWhiteSpace(pairingRequestId)
+                ? $"To approve, run: openclaw devices approve {pairingRequestId}"
+                : "To approve, run: openclaw devices list and approve the pending requestId");
             EmitPairingStatusOnTransition(new PairingStatusEventArgs(
                 PairingStatus.Pending,
                 _deviceIdentity.DeviceId,

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -172,6 +172,7 @@ public partial class App : Application
     private GatewaySelfInfo? _lastGatewaySelf;
     private PairingListInfo? _lastNodePairList;
     private DevicePairingListInfo? _lastDevicePairList;
+    private string? _lastNodePairingRequestId;
     private ModelsListInfo? _lastModelsList;
     private PresenceEntry[]? _lastPresence;
     private readonly List<AgentEventInfo> _agentEventsCache = new();
@@ -2574,6 +2575,7 @@ public partial class App : Application
         {
             if (args.Status == OpenClaw.Shared.PairingStatus.Pending)
             {
+                _lastNodePairingRequestId = args.RequestId;
                 // Bug #2 (manual test 2026-05-05): suppress the "copy pairing command"
                 // toast while the local-setup engine is mid-Phase-14 node-role PairAsync.
                 // The loopback gateway parks the role-upgrade as Pending for ~100ms before
@@ -2587,10 +2589,11 @@ public partial class App : Application
                     Logger.Info($"Suppressing pairing-pending toast: autopair Phase 14 in progress for {args.DeviceId}");
                     return;
                 }
-                ShowPairingPendingNotification(args.DeviceId);
+                ShowPairingPendingNotification(args.DeviceId, PairingApprovalCommand.Build(args.RequestId));
             }
             else if (args.Status == OpenClaw.Shared.PairingStatus.Paired)
             {
+                _lastNodePairingRequestId = null;
                 // Bug 3: idempotency guard — only show "Node paired" toast/activity once
                 // per device per session. WS reconnects re-fire Paired; suppress duplicates.
                 var deviceKey = args.DeviceId ?? string.Empty;
@@ -2610,6 +2613,7 @@ public partial class App : Application
             }
             else if (args.Status == OpenClaw.Shared.PairingStatus.Rejected)
             {
+                _lastNodePairingRequestId = null;
                 AddRecentActivity("Node pairing rejected", category: "node", dashboardPath: "nodes", nodeId: args.DeviceId, details: args.Message ?? LocalizationHelper.GetString("Toast_PairingRejectedDetail"));
                 ShowToast(new ToastContentBuilder()
                     .AddText(LocalizationHelper.GetString("Toast_PairingRejected"))
@@ -2634,6 +2638,7 @@ public partial class App : Application
             _hubWindow.NodeIsConnected = _nodeService.IsConnected;
             _hubWindow.NodeIsPaired = _nodeService.IsPaired;
             _hubWindow.NodeIsPendingApproval = _nodeService.IsPendingApproval;
+            _hubWindow.NodePairingRequestId = _lastNodePairingRequestId;
             _hubWindow.NodeShortDeviceId = _nodeService.ShortDeviceId;
             _hubWindow.NodeFullDeviceId = _nodeService.FullDeviceId;
             _hubWindow.VoiceServiceInstance = _nodeService.VoiceService;
@@ -2643,15 +2648,16 @@ public partial class App : Application
             _hubWindow.NodeIsConnected = false;
             _hubWindow.NodeIsPaired = false;
             _hubWindow.NodeIsPendingApproval = false;
+            _hubWindow.NodePairingRequestId = null;
         }
     }
 
-    public static string BuildPairingApprovalCommand(string deviceId) =>
-        $"openclaw devices approve {deviceId}";
+    public static string BuildPairingApprovalCommand(string? requestId) =>
+        PairingApprovalCommand.Build(requestId);
 
     public void ShowPairingPendingNotification(string deviceId, string? approvalCommand = null)
     {
-        var command = approvalCommand ?? BuildPairingApprovalCommand(deviceId);
+        var command = approvalCommand ?? BuildPairingApprovalCommand(null);
         var shortDeviceId = deviceId.Length > 16 ? deviceId[..16] : deviceId;
 
         AddRecentActivity("Node pairing pending", category: "node", dashboardPath: "nodes", nodeId: deviceId);

--- a/src/OpenClaw.Tray.WinUI/Onboarding/Pages/ConnectionPage.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/Pages/ConnectionPage.cs
@@ -83,6 +83,7 @@ public sealed class ConnectionPage : Component<OnboardingState>
             GetDetectedLocalUrl);
         var (url, setUrl) = UseState(initialUrl);
         var (token, setToken) = UseState("");
+        var (gotBootstrapToken, setGotBootstrapToken) = UseState(false);
         var (nodeMode, setNodeMode) = UseState(Props.Settings.EnableNodeMode);
         var (setupCode, setSetupCode) = UseState("");
 
@@ -100,8 +101,8 @@ public sealed class ConnectionPage : Component<OnboardingState>
         var (statusMsg, setStatusMsg) = UseState(Props.Mode == ConnectionMode.Local ? detectedMsg : LocalizationHelper.GetString("Onboarding_Connection_Ready"));
         var (testing, setTesting) = UseState(false);
         var (pairingDeviceId, setPairingDeviceId) = UseState(visualPairingDeviceId);
-        var (pairingCommand, setPairingCommand) = UseState(string.IsNullOrEmpty(visualPairingDeviceId) ? "" : App.BuildPairingApprovalCommand(visualPairingDeviceId));
-        var (copied, setCopied) = UseState(!string.IsNullOrEmpty(visualPairingDeviceId));
+        var (pairingCommand, setPairingCommand) = UseState(string.IsNullOrEmpty(visualPairingDeviceId) ? "" : App.BuildPairingApprovalCommand(null));
+        var (copied, setCopied) = UseState(false);
         var (copyFailed, setCopyFailed) = UseState(false);
 
         var urlReadOnly = ConnectionPageModeSelector.IsGatewayUrlReadOnly(mode); // Ssh mode pins the local-forward URL
@@ -136,7 +137,12 @@ public sealed class ConnectionPage : Component<OnboardingState>
 
         void OnSetupCodeChanged(string code)
         {
-            if (string.IsNullOrWhiteSpace(code)) return;
+            if (string.IsNullOrWhiteSpace(code))
+            {
+                setSetupCode("");
+                setGotBootstrapToken(false);
+                return;
+            }
 
             var result = SetupCodeDecoder.Decode(code);
 
@@ -161,7 +167,7 @@ public sealed class ConnectionPage : Component<OnboardingState>
             if (result.Token != null)
             {
                 setToken(result.Token);
-                // Bootstrap token stored in GatewayRegistry via ApplySetupCodeAsync
+                setGotBootstrapToken(true);
             }
             setStatusMsg($"✅ {LocalizationHelper.GetString("Onboarding_Connection_StatusDecoded")}");
         }
@@ -176,6 +182,7 @@ public sealed class ConnectionPage : Component<OnboardingState>
 
         void OnTokenChanged(string v)
         {
+            setGotBootstrapToken(false);
             setToken(v);
             Props.ConnectionTested = false;
             setStatusMsg("");
@@ -293,11 +300,15 @@ public sealed class ConnectionPage : Component<OnboardingState>
                     var sshConfig = useSshTunnel
                         ? new OpenClawTray.Services.Connection.SshTunnelConfig(sshUser, sshHost, sshRemotePort, sshLocalPort)
                         : null;
+                    var isBootstrap = gotBootstrapToken
+                        && !string.IsNullOrWhiteSpace(setupCode)
+                        && SetupCodeDecoder.Decode(setupCode) is { Success: true };
                     var record = new OpenClawTray.Services.Connection.GatewayRecord
                     {
                         Id = recordId,
                         Url = normalizedUrl,
-                        SharedGatewayToken = !string.IsNullOrWhiteSpace(token) ? token : null,
+                        BootstrapToken = isBootstrap && !string.IsNullOrWhiteSpace(token) ? token : null,
+                        SharedGatewayToken = !isBootstrap && !string.IsNullOrWhiteSpace(token) ? token : null,
                         SshTunnel = sshConfig,
                     };
                     registry.AddOrUpdate(record);
@@ -314,7 +325,10 @@ public sealed class ConnectionPage : Component<OnboardingState>
                 bool connected = false;
                 bool pairingRequired = false;
                 bool authFailed = false;
+                int consecutiveErrors = 0;
+                const int maxTransientErrors = 3;
 
+                OpenClawTray.Services.Connection.GatewayConnectionSnapshot? lastSnapshot = null;
                 for (int attempt = 0; attempt < 30; attempt++)
                 {
                     await Task.Delay(1000);
@@ -322,13 +336,22 @@ public sealed class ConnectionPage : Component<OnboardingState>
 
                     var snapshot = app.ConnectionManager?.CurrentSnapshot;
                     if (snapshot == null) continue;
+                    lastSnapshot = snapshot;
                     if (snapshot.OverallState is OpenClawTray.Services.Connection.OverallConnectionState.Connected
                         or OpenClawTray.Services.Connection.OverallConnectionState.Ready)
                     { connected = true; break; }
                     if (snapshot.OverallState == OpenClawTray.Services.Connection.OverallConnectionState.PairingRequired)
                     { pairingRequired = true; break; }
                     if (snapshot.OverallState == OpenClawTray.Services.Connection.OverallConnectionState.Error)
-                    { authFailed = true; break; }
+                    {
+                        consecutiveErrors++;
+                        if (consecutiveErrors >= maxTransientErrors)
+                        { authFailed = true; break; }
+                    }
+                    else
+                    {
+                        consecutiveErrors = 0;
+                    }
                 }
 
                 if (connected)
@@ -347,11 +370,12 @@ public sealed class ConnectionPage : Component<OnboardingState>
 
                     setStatusMsg($"⏳ {LocalizationHelper.GetString("Onboarding_Connection_StatusPairing")}");
                     setPairingDeviceId(deviceId);
-                    var cmd = App.BuildPairingApprovalCommand(deviceId);
+                    var requestId = lastSnapshot?.OperatorPairingRequestId ?? lastSnapshot?.NodePairingRequestId;
+                    var cmd = App.BuildPairingApprovalCommand(requestId);
                     setPairingCommand(cmd);
-                    var commandCopied = TryCopyPairingCommand(cmd);
+                    var commandCopied = !string.IsNullOrWhiteSpace(requestId) && TryCopyPairingCommand(cmd);
                     setCopied(commandCopied);
-                    setCopyFailed(!commandCopied);
+                    setCopyFailed(!commandCopied && !string.IsNullOrWhiteSpace(requestId));
                     app.ShowPairingPendingNotification(deviceId, cmd);
                 }
                 else if (authFailed)

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -205,47 +205,17 @@ public sealed partial class ConnectionPage : Page
 
     private void UpdatePairingGuidance(GatewayConnectionSnapshot snapshot)
     {
-        // Get device ID from snapshot or from the identity file
-        var deviceId = snapshot.OperatorDeviceId ?? snapshot.NodeDeviceId;
-        if (string.IsNullOrEmpty(deviceId))
-        {
-            // Try reading from identity file
-            try
-            {
-                var activeGw = _gatewayRegistry?.GetActive();
-                if (activeGw != null && _gatewayRegistry != null)
-                {
-                    var idDir = _gatewayRegistry.GetIdentityDirectory(activeGw.Id);
-                    var keyPath = System.IO.Path.Combine(idDir, "device-key-ed25519.json");
-                    if (System.IO.File.Exists(keyPath))
-                    {
-                        var json = System.Text.Json.JsonDocument.Parse(System.IO.File.ReadAllText(keyPath));
-                        if (json.RootElement.TryGetProperty("DeviceId", out var did))
-                            deviceId = did.GetString();
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"[ConnectionPage] Failed to read device ID from identity file: {ex.Message}");
-            }
-        }
-
         if (snapshot.OperatorState == RoleConnectionState.PairingRequired)
         {
             PairingGuidanceCard.Visibility = Visibility.Visible;
             PairingGuidanceText.Text = "🔐 Operator: Awaiting approval from gateway";
-            PairingApproveCommandText.Text = !string.IsNullOrEmpty(deviceId)
-                ? $"openclaw devices approve {deviceId}"
-                : "openclaw devices approve <deviceId>";
+            PairingApproveCommandText.Text = PairingApprovalCommand.Build(snapshot.OperatorPairingRequestId);
         }
         else if (snapshot.NodeState == RoleConnectionState.PairingRequired)
         {
             PairingGuidanceCard.Visibility = Visibility.Visible;
             PairingGuidanceText.Text = "🔐 Node: Awaiting approval from gateway";
-            PairingApproveCommandText.Text = !string.IsNullOrEmpty(deviceId)
-                ? $"openclaw devices approve {deviceId}"
-                : "openclaw devices approve <deviceId>";
+            PairingApproveCommandText.Text = PairingApprovalCommand.Build(snapshot.NodePairingRequestId);
         }
         else
         {
@@ -444,8 +414,7 @@ public sealed partial class ConnectionPage : Page
             {
                 PairingStatusText.Text = "Pairing: ⏳ Pending approval";
                 ApprovalHelpPanel.Visibility = Visibility.Visible;
-                var deviceRef = fullId ?? shortId ?? "";
-                ApprovalCommandText.Text = $"openclaw devices approve {deviceRef}";
+                ApprovalCommandText.Text = PairingApprovalCommand.Build(_hub.NodePairingRequestId);
             }
             else
             {

--- a/src/OpenClaw.Tray.WinUI/Services/Connection/ConnectionStateMachine.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/Connection/ConnectionStateMachine.cs
@@ -286,7 +286,10 @@ internal sealed class ConnectionStateMachine
                 RoleConnectionState.PairingRejected => OpenClaw.Shared.PairingStatus.Rejected,
                 RoleConnectionState.Connected => OpenClaw.Shared.PairingStatus.Paired,
                 _ => OpenClaw.Shared.PairingStatus.Unknown
-            }
+            },
+            // Clear requestId when no longer in PairingRequired to prevent stale reads
+            NodePairingRequestId = _nodeState == RoleConnectionState.PairingRequired
+                ? Current.NodePairingRequestId : null
         };
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Services/Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/Connection/GatewayConnectionManager.cs
@@ -694,7 +694,8 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
                 _stateMachine.Current = _stateMachine.Current with
                 {
                     NodePairingStatus = _nodeConnector.PairingStatus,
-                    NodeDeviceId = _nodeConnector.NodeDeviceId
+                    NodeDeviceId = _nodeConnector.NodeDeviceId,
+                    NodePairingRequestId = e.Status == PairingStatus.Pending ? e.RequestId : null
                 };
             }
 

--- a/src/OpenClaw.Tray.WinUI/Services/Connection/GatewayConnectionSnapshot.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/Connection/GatewayConnectionSnapshot.cs
@@ -25,6 +25,11 @@ public sealed record GatewayConnectionSnapshot
     public string? NodeError { get; init; }
     public OpenClaw.Shared.PairingStatus NodePairingStatus { get; init; }
     public string? NodeDeviceId { get; init; }
+    /// <summary>
+    /// The requestId returned by the gateway when node pairing is required.
+    /// Used by setup flows to approve the specific pairing request via CLI.
+    /// </summary>
+    public string? NodePairingRequestId { get; init; }
 
     // ─── Gateway ───
     public string? GatewayId { get; init; }

--- a/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCommand.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCommand.cs
@@ -1,0 +1,9 @@
+namespace OpenClawTray.Services;
+
+internal static class PairingApprovalCommand
+{
+    public static string Build(string? requestId) =>
+        string.IsNullOrWhiteSpace(requestId)
+            ? "openclaw devices list"
+            : $"openclaw devices approve {requestId.Trim()}";
+}

--- a/src/OpenClaw.Tray.WinUI/Services/StartupSetupState.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/StartupSetupState.cs
@@ -19,11 +19,16 @@ internal static class StartupSetupState
 
     public static bool RequiresSetup(SettingsManager settings, string dataPath)
     {
-        if (settings.EnableNodeMode && HasStoredNodeDeviceToken(dataPath))
+        if (settings.EnableNodeMode)
+        {
+            return !HasStoredNodeDeviceToken(dataPath);
+        }
+
+        if (settings.EnableMcpServer)
         {
             return false;
         }
 
-        return !settings.EnableMcpServer;
+        return !DeviceIdentity.HasStoredDeviceToken(dataPath);
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -55,6 +55,7 @@ public sealed partial class HubWindow : WindowEx
     public bool NodeIsConnected { get; set; }
     public bool NodeIsPaired { get; set; }
     public bool NodeIsPendingApproval { get; set; }
+    public string? NodePairingRequestId { get; set; }
     public string? LastAuthError { get; set; }
     public string? NodeShortDeviceId { get; set; }
     public VoiceService? VoiceServiceInstance { get; set; }

--- a/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
@@ -335,8 +335,110 @@ public class WindowsNodeClientTests
 
             Assert.Single(pairingEvents);
             Assert.Equal(PairingStatus.Pending, pairingEvents[0].Status);
+            Assert.Equal("req-123", pairingEvents[0].RequestId);
             Assert.Contains("req-123", pairingEvents[0].Message);
             Assert.DoesNotContain(ConnectionStatus.Error, statusChanges);
+            Assert.True(client.IsPendingApproval);
+            Assert.False(client.IsPaired);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public void HandleResponse_PairingRequiredInDetailsCode_EmitsPendingPairingRequest()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+
+            var pairingEvents = new List<PairingStatusEventArgs>();
+            var statusChanges = new List<ConnectionStatus>();
+            client.PairingStatusChanged += (_, e) => pairingEvents.Add(e);
+            client.StatusChanged += (_, s) => statusChanges.Add(s);
+
+            var json = """
+                {
+                    "type": "res",
+                    "ok": false,
+                    "error": {
+                        "message": "Device approval required",
+                        "details": {
+                            "code": "PAIRING_REQUIRED",
+                            "reason": "first-connect",
+                            "requestId": "req-456"
+                        }
+                    }
+                }
+                """;
+            var root = JsonDocument.Parse(json).RootElement;
+
+            var handleResponseMethod = typeof(WindowsNodeClient).GetMethod(
+                "HandleResponse",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            handleResponseMethod!.Invoke(client, [root]);
+
+            Assert.Single(pairingEvents);
+            Assert.Equal(PairingStatus.Pending, pairingEvents[0].Status);
+            Assert.Equal("req-456", pairingEvents[0].RequestId);
+            Assert.Contains("req-456", pairingEvents[0].Message);
+            Assert.DoesNotContain(ConnectionStatus.Error, statusChanges);
+            Assert.True(client.IsPendingApproval);
+            Assert.False(client.IsPaired);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+
+    [Fact]
+    public void HandleResponse_PairingRequiredInDataDetails_EmitsPendingPairingRequestId()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+
+            var pairingEvents = new List<PairingStatusEventArgs>();
+            client.PairingStatusChanged += (_, e) => pairingEvents.Add(e);
+
+            var json = """
+                {
+                    "type": "res",
+                    "ok": false,
+                    "error": {
+                        "message": "Device approval required",
+                        "data": {
+                            "details": {
+                                "code": "PAIRING_REQUIRED",
+                                "requestId": "req-789"
+                            }
+                        }
+                    }
+                }
+                """;
+            var root = JsonDocument.Parse(json).RootElement;
+
+            var handleResponseMethod = typeof(WindowsNodeClient).GetMethod(
+                "HandleResponse",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            handleResponseMethod!.Invoke(client, [root]);
+
+            Assert.Single(pairingEvents);
+            Assert.Equal(PairingStatus.Pending, pairingEvents[0].Status);
+            Assert.Equal("req-789", pairingEvents[0].RequestId);
+            Assert.Contains("req-789", pairingEvents[0].Message);
             Assert.True(client.IsPendingApproval);
             Assert.False(client.IsPaired);
         }

--- a/tests/OpenClaw.Tray.Tests/Connection/PairingFlowTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Connection/PairingFlowTests.cs
@@ -46,10 +46,11 @@ public class PairingFlowTests : IDisposable
 
         // Node: Connecting → PairingRequired
         var snapshot = await FireAndWait(manager, () =>
-            _nodeConnector.FirePairingStatusChanged(PairingStatus.Pending));
+            _nodeConnector.FirePairingStatusChanged(PairingStatus.Pending, "node-request-123"));
 
         Assert.Equal(RoleConnectionState.PairingRequired, snapshot.NodeState);
         Assert.Equal(PairingStatus.Pending, snapshot.NodePairingStatus);
+        Assert.Equal("node-request-123", snapshot.NodePairingRequestId);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -39,6 +39,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\OnboardingChatBootstrapper.cs" Link="Services\OnboardingChatBootstrapper.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\GatewayCredentialResolver.cs" Link="Services\GatewayCredentialResolver.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\StartupSetupState.cs" Link="Services\StartupSetupState.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\PairingApprovalCommand.cs" Link="Services\PairingApprovalCommand.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ActivityStreamService.cs" Link="Services\ActivityStreamService.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeInvokeActivityFormatter.cs" Link="Services\NodeInvokeActivityFormatter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeCapabilityGating.cs" Link="Services\NodeCapabilityGating.cs" />

--- a/tests/OpenClaw.Tray.Tests/PairingApprovalCommandTests.cs
+++ b/tests/OpenClaw.Tray.Tests/PairingApprovalCommandTests.cs
@@ -1,0 +1,21 @@
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class PairingApprovalCommandTests
+{
+    [Fact]
+    public void Build_UsesRequestId()
+    {
+        var command = PairingApprovalCommand.Build("bd8ad7b1-4a57-48cc-93a4-36c8626c87e9");
+
+        Assert.Equal("openclaw devices approve bd8ad7b1-4a57-48cc-93a4-36c8626c87e9", command);
+    }
+
+    [Fact]
+    public void Build_WithoutRequestId_FallsBackToList()
+    {
+        Assert.Equal("openclaw devices list", PairingApprovalCommand.Build(null));
+        Assert.Equal("openclaw devices list", PairingApprovalCommand.Build("   "));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/StartupSetupStateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/StartupSetupStateTests.cs
@@ -28,6 +28,16 @@ public class StartupSetupStateTests
     }
 
     [Fact]
+    public void RequiresSetup_ReturnsFalse_WhenOperatorTokenExistsForOperatorMode()
+    {
+        using var temp = TempSettings.Create();
+        StoreDeviceToken(temp.Path);
+        var settings = new SettingsManager(temp.Path);
+
+        Assert.False(StartupSetupState.RequiresSetup(settings, temp.Path));
+    }
+
+    [Fact]
     public void RequiresSetup_ReturnsFalse_WhenMcpOnlyModeIsEnabled()
     {
         using var temp = TempSettings.Create();


### PR DESCRIPTION
## Summary

This restores the Windows Tray onboarding/pairing setup flow by fixing credential precedence, setup-code bootstrap handling, setup-state detection, and pairing approval guidance.

The approval command shown/copied by the UI now uses the gateway pairing `requestId` instead of the node/device id. When no request id is available, the UI falls back to `openclaw devices list` instead of generating an invalid approve command.

## Changes

- keep stored device/shared tokens ahead of bootstrap setup-code tokens
- treat setup-code credentials as bootstrap credentials only
- require the correct stored token for operator/node startup setup checks
- propagate pairing request ids through connection state/snapshots
- show/copy `openclaw devices approve <requestId>` for pending pairing
- add tests for startup setup state, pairing request id parsing, pairing flow state, and approval command generation

## Validation

Tested on two Windows machines

- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`
- Manual pairing flow:
  - setup code accepted
  - operator pairing request approved with request id
  - node role-upgrade pairing request approved with request id
  - Windows node reached paired/connected state
 
## Notes

This change was prepared with assistance from Codex and manually tested before submission.
