### PR TITLE
fix: native chat UX improvements — focus, flickering, bubbles, notifications

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3187,6 +3187,8 @@ public partial class App : Application
         {
             if (_hubWindow != null && !_hubWindow.IsClosed)
                 return false;
+            if (_chatWindow is { IsClosed: false, Visible: true })
+                return false;
             if (_onboardingWindow != null)
                 return false; // Onboarding window has chat overlay
         }

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
@@ -83,12 +83,25 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
             .Set(t =>
             {
                 t.TextWrapping = TextWrapping.Wrap;
-                t.IsTextSelectionEnabled = true;
                 ApplySafeMarkdownInlines(t, text);
             });
 
+    // Cache parsed markdown text per TextBlock to avoid re-clearing and
+    // rebuilding Inlines on every re-render when message content is stable.
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<TextBlock, string>
+        s_markdownCache = new();
+
     private static void ApplySafeMarkdownInlines(TextBlock textBlock, string? text)
     {
+        // Skip re-parsing only when text is unchanged AND inlines are still
+        // present. ConfigureTextBlock sets control.Text="" which clears
+        // Inlines, so we must re-apply even if the source text matches.
+        if (textBlock.Inlines.Count > 0
+            && s_markdownCache.TryGetValue(textBlock, out var cached)
+            && cached == text)
+            return;
+        s_markdownCache.AddOrUpdate(textBlock, text ?? "");
+
         textBlock.Inlines.Clear();
 
         foreach (var segment in ChatMarkdownSanitizer.SanitizeAndSplitStrongEmphasis(text))
@@ -192,7 +205,6 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
         // Live values from ChatExplorationState (groups C/D/F).
         var bubbleRadius     = ChatVisualResolver.BubbleCornerRadius();
         var bubblePadding    = ChatVisualResolver.BubbleInnerPadding();
-        var bubbleMaxWidth   = ChatVisualResolver.BubbleMaxWidth();
         var bubbleSideMargin = ChatVisualResolver.BubbleSideMargin();
         var showAsstBubbles  = ChatVisualResolver.ShowAssistantBubbles();
         var showToolCalls    = ChatVisualResolver.ShowToolCalls();
@@ -700,7 +712,6 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                     .Set(t =>
                     {
                         t.TextWrapping = TextWrapping.Wrap;
-                        t.IsTextSelectionEnabled = true;
                         t.FontSize = 14;
                         t.Foreground = userBubbleFg;
                     })
@@ -708,7 +719,6 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
              .Set(b =>
              {
                  b.CornerRadius = bubbleRadius;
-                b.MaxWidth = bubbleMaxWidth;
                  b.Padding = bubblePadding;
                  b.VerticalAlignment = VerticalAlignment.Center;
              });
@@ -723,10 +733,12 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                    ? AvatarBox("🧑", userAvatarBg, userBubbleBdr, userAvatarFg).VAlign(VerticalAlignment.Center)
                    : Border(Empty()).Size(36, 36));
 
-            var bubbleRow = (FlexRow(
-                bubble,
-                rightSlot
-            ) with { ColumnGap = bubbleSideMargin }).HAlign(HorizontalAlignment.Right);
+            var bubbleRow = Grid(
+                [GridSize.Star(), GridSize.Auto],
+                [GridSize.Auto],
+                bubble.HAlign(HorizontalAlignment.Right).Grid(row: 0, column: 0),
+                rightSlot.Grid(row: 0, column: 1).Margin(bubbleSideMargin, 0, 0, 0)
+            ).HAlign(HorizontalAlignment.Stretch);
 
             Element footer = Empty();
             if (endsBurst && showTimestamps)
@@ -776,14 +788,15 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
              .Set(b =>
              {
                  b.CornerRadius = bubbleRadius;
-                 b.MaxWidth = bubbleMaxWidth;
                  b.Padding = bubblePadding;
              });
 
-            var bubbleRow = (FlexRow(
-                leftSlot,
-                card
-            ) with { ColumnGap = bubbleSideMargin }).HAlign(HorizontalAlignment.Left);
+            var bubbleRow = Grid(
+                [GridSize.Auto, GridSize.Star()],
+                [GridSize.Auto],
+                leftSlot.Grid(row: 0, column: 0).Margin(0, 0, bubbleSideMargin, 0),
+                card.HAlign(HorizontalAlignment.Left).Grid(row: 0, column: 1)
+            ).HAlign(HorizontalAlignment.Stretch);
 
             Element footer = Empty();
             if (endsBurst && showTimestamps)
@@ -1341,7 +1354,7 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                 ).Background(toolCardBgBrush)
                  .WithBorder(toolCardBorderBrush, 1)
                  .CornerRadius(8)
-                 .Set(b => { b.MaxWidth = bubbleMaxWidth; b.HorizontalAlignment = HorizontalAlignment.Left; });
+                 .Set(b => { b.HorizontalAlignment = HorizontalAlignment.Left; });
 
                 // Wrap with the assistant avatar slot so the burst visually
                 // anchors to the agent that produced it (and lines up with the
@@ -1354,10 +1367,12 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                         ? AssistantAvatar().VAlign(VerticalAlignment.Top)
                         : Border(Empty()).Size(36, 36));
 
-                var burstRow = (FlexRow(
-                    leftSlot,
-                    listCard
-                ) with { ColumnGap = bubbleSideMargin }).HAlign(HorizontalAlignment.Left);
+                var burstRow = Grid(
+                    [GridSize.Auto, GridSize.Star()],
+                    [GridSize.Auto],
+                    leftSlot.Grid(row: 0, column: 0).Margin(0, 0, bubbleSideMargin, 0),
+                    listCard.HAlign(HorizontalAlignment.Left).Grid(row: 0, column: 1)
+                ).HAlign(HorizontalAlignment.Stretch);
 
                 // When avatar is present, drop the left margin to 0 so the
                 // avatar fills the indent slot. Otherwise keep the original 36.
@@ -1403,7 +1418,6 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                                 {
                                     t.FontSize = 12;
                                     t.TextWrapping = TextWrapping.Wrap;
-                                    t.IsTextSelectionEnabled = true;
                                     t.FontFamily = new FontFamily("Cascadia Code, Cascadia Mono, Consolas");
                                 })
                                 .Foreground(TertiaryText)

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
@@ -61,7 +61,12 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
 
     public override Element Render()
     {
-        var inputState = UseState("", threadSafe: true);
+        // UseRef for input text — avoids full-tree re-render on every keypress.
+        // A separate hasTextState tracks the empty↔non-empty transition so the
+        // send button accent styling updates correctly (at most 2 re-renders
+        // per compose cycle instead of one per keypress).
+        var inputRef = UseRef("");
+        var hasTextState = UseState(false);
 
         // Subscribe to ChatExplorationState so toggles re-render the composer.
         // Inline because UseState/UseEffect are protected on Component (can't
@@ -81,12 +86,18 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         var sendButtonSize       = ChatVisualResolver.SendButtonSize();
         var composerLayout       = ChatExplorationState.ComposerLayout;
 
+        // Version bump triggers a re-render on send so the cleared ref value
+        // is pushed to the TextBox control.
+        var sendVersion = UseState(0);
+
         var sendAction = () =>
         {
-            var msg = inputState.Value?.Trim();
+            var msg = inputRef.Current?.Trim();
             if (string.IsNullOrEmpty(msg)) return;
             Props.OnSend(msg);
-            inputState.Set("");
+            inputRef.Current = "";
+            hasTextState.Set(false);
+            sendVersion.Set(sendVersion.Value + 1);
         };
         var sendActionRef = UseRef<Action>(sendAction);
         sendActionRef.Current = sendAction;
@@ -157,7 +168,11 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         };
 
         // ── Row 2: multi-line composer textbox ─────────────────────────
-        var textbox = TextField(inputState.Value, v => inputState.Set(v))
+        var textbox = TextField(inputRef.Current, v =>
+            {
+                inputRef.Current = v;
+                hasTextState.Set(!string.IsNullOrWhiteSpace(v));
+            })
             .Set(tb =>
             {
                 tb.PlaceholderText = placeholder;
@@ -248,7 +263,7 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
             // Default state (empty input): no accent fill — subtle/transparent
             // so the composer reads as neutral. Once the user types, switch to
             // the user-bubble accent so Send becomes the primary action.
-            var hasText = !string.IsNullOrWhiteSpace(inputState.Value);
+            var hasText = hasTextState.Value;
             var glyphBrush = hasText
                 ? (Brush)new SolidColorBrush(Colors.White)
                 : (Brush)Microsoft.UI.Xaml.Application.Current.Resources["TextFillColorSecondaryBrush"];

--- a/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
@@ -76,8 +76,8 @@ public class SettingsManager
     /// Default false (native).
     /// </summary>
     public bool UseLegacyWebChat { get; set; } = false;
-    
-    // Node mode (gateway WebSocket connection — separate from MCP)
+
+    // Node mode(gateway WebSocket connection — separate from MCP)
     public bool EnableNodeMode { get; set; } = false;
     public bool NodeCanvasEnabled { get; set; } = true;
     public bool NodeScreenEnabled { get; set; } = true;

--- a/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
@@ -34,7 +34,9 @@ public sealed partial class ChatWindow : WindowEx
     [DllImport("user32.dll")] private static extern bool GetMonitorInfo(IntPtr hMonitor, ref MONITORINFO mi);
     [DllImport("user32.dll")] private static extern bool SetForegroundWindow(IntPtr hWnd);
     [DllImport("user32.dll")] private static extern uint GetDpiForWindow(IntPtr hWnd);
+    [DllImport("user32.dll")] private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
     [DllImport("dwmapi.dll")] private static extern int DwmSetWindowAttribute(IntPtr hwnd, uint attr, ref int val, int size);
+    [DllImport("dwmapi.dll")] private static extern int DwmExtendFrameIntoClientArea(IntPtr hwnd, ref MARGINS margins);
 
     private const int GWL_EXSTYLE = -20;
     private const int GWL_STYLE = -16;
@@ -44,6 +46,9 @@ public sealed partial class ChatWindow : WindowEx
     private const uint MONITOR_DEFAULTTONEAREST = 2;
     private const uint DWMWA_WINDOW_CORNER_PREFERENCE = 33;
     private const int DWMWCP_ROUND = 2;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MARGINS { public int Left, Right, Top, Bottom; }
 
     [StructLayout(LayoutKind.Sequential)] private struct POINT { public int X, Y; }
     [StructLayout(LayoutKind.Sequential)] private struct RECT2 { public int Left, Top, Right, Bottom; }
@@ -63,10 +68,10 @@ public sealed partial class ChatWindow : WindowEx
         _chatUrl = BuildChatUrl(gatewayUrl, token);
         InitializeComponent();
 
-        this.SetWindowSize(480, 640);
+        this.SetWindowSize(DefaultChatWidth, DefaultChatHeight);
         this.SetIcon("Assets\\openclaw.ico");
 
-        // Set as tool window (hidden from taskbar) + remove system caption
+        // Set as tool window (hidden from taskbar) + remove system caption.
         var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
         var exStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
         SetWindowLong(hwnd, GWL_EXSTYLE, exStyle | WS_EX_TOOLWINDOW);
@@ -98,6 +103,11 @@ public sealed partial class ChatWindow : WindowEx
                 this.Hide();
             };
             contentRoot.KeyboardAccelerators.Add(escAccel);
+            // Suppress the default "Esc" tooltip that WinUI shows for
+            // keyboard accelerators — it lingers as a floating orphan
+            // when the user scrolls the chat timeline.
+            contentRoot.KeyboardAcceleratorPlacementMode =
+                Microsoft.UI.Xaml.Input.KeyboardAcceleratorPlacementMode.Hidden;
         }
 
         // Subscribe to global SettingsChanged so the surface swaps when the
@@ -121,6 +131,9 @@ public sealed partial class ChatWindow : WindowEx
         ApplySystemBackdrop();
         ApplyPreviewTheme();
     }
+
+    private const int DefaultChatWidth = 480;
+    private const int DefaultChatHeight = 640;
 
     private void OnAppSettingsChanged(object? sender, EventArgs e) => ApplyChatSurface();
 
@@ -513,15 +526,17 @@ public sealed partial class ChatWindow : WindowEx
         uint dpi = GetDpiForWindow(hwnd);
         double scale = dpi / 96.0;
 
-        int panelWPx = (int)(480 * scale);
-        int panelHPx = (int)(640 * scale);
+        int panelWPx = (int)(DefaultChatWidth * scale);
+        int panelHPx = (int)(DefaultChatHeight * scale);
 
         int margin = 8;
         int x = work.Right - panelWPx - margin;
         int y = work.Bottom - panelHPx - margin;
 
-        this.Move(x, y);
-        this.SetWindowSize(480, 640);
+        // Position and size atomically while still hidden to avoid flicker.
+        const uint SWP_NOZORDER = 0x0004;
+        const uint SWP_NOACTIVATE = 0x0010;
+        SetWindowPos(hwnd, IntPtr.Zero, x, y, panelWPx, panelHPx, SWP_NOZORDER | SWP_NOACTIVATE);
 
         // Provider may have arrived after construction — re-apply surface so
         // a native-mode window swaps placeholder → live tree on first show.

--- a/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
+++ b/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
@@ -1005,7 +1005,14 @@ internal sealed class UiRenderer(Action requestRender)
 
     private TextBlock ConfigureTextBlock(TextBlock control, TextBlockElement element)
     {
-        control.Text = element.Text;
+        // Skip Text assignment when element text is empty and the control
+        // has Inlines (populated by a setter, e.g. SafeMarkdownText).
+        // Setting Text on a TextBlock with Inlines clears them.
+        if (!(string.IsNullOrEmpty(element.Text) && control.Inlines.Count > 0))
+        {
+            if (control.Text != element.Text)
+                control.Text = element.Text;
+        }
         ApplyModifiers(control, element);
         ApplySetters(control, element);
         return control;
@@ -1202,8 +1209,9 @@ internal sealed class UiRenderer(Action requestRender)
     {
         var child = element.Child is null ? null : RenderElement(element.Child, path + ".child", effects);
         if (child is not null)
-            RemoveFromParent(child);
-        control.Child = child;
+            SetChild(control, child);
+        else
+            control.Child = null;
         ApplyModifiers(control, element);
         ApplySetters(control, element);
         return control;
@@ -1236,12 +1244,8 @@ internal sealed class UiRenderer(Action requestRender)
     private Border ConfigureGrid(Border wrapper, GridElement element, string path, List<Action> effects)
     {
         var grid = GetOrCreate<WinGrid>(path + ".grid");
-        grid.ColumnDefinitions.Clear();
-        foreach (var col in element.Columns)
-            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = ParseGridLength(col) });
-        grid.RowDefinitions.Clear();
-        foreach (var row in element.Rows)
-            grid.RowDefinitions.Add(new RowDefinition { Height = ParseGridLength(row) });
+        SyncGridDefinitions(grid.ColumnDefinitions, element.Columns, s => new ColumnDefinition { Width = ParseGridLength(s) }, cd => cd.Width);
+        SyncGridDefinitions(grid.RowDefinitions, element.Rows, s => new RowDefinition { Height = ParseGridLength(s) }, rd => rd.Height);
         SyncChildren(grid, element.Children, path, effects);
         SetChild(wrapper, grid);
         ApplyModifiers(wrapper, element);
@@ -1249,12 +1253,53 @@ internal sealed class UiRenderer(Action requestRender)
         return wrapper;
     }
 
+    /// <summary>
+    /// Updates grid column/row definitions only when they actually differ,
+    /// avoiding unnecessary layout invalidation that causes cursor/background
+    /// flickering on re-render.
+    /// </summary>
+    private static void SyncGridDefinitions<TDef>(
+        IList<TDef> existing,
+        IReadOnlyList<string> desired,
+        Func<string, TDef> create,
+        Func<TDef, GridLength> getLength)
+    {
+        if (existing.Count == desired.Count)
+        {
+            var match = true;
+            for (var i = 0; i < desired.Count; i++)
+            {
+                var want = ParseGridLength(desired[i]);
+                var have = getLength(existing[i]);
+                if (want.GridUnitType != have.GridUnitType || Math.Abs(want.Value - have.Value) > double.Epsilon)
+                {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) return;
+        }
+
+        existing.Clear();
+        foreach (var d in desired)
+            existing.Add(create(d));
+    }
+
     private ScrollViewer ConfigureScrollView(ScrollViewer control, ScrollViewElement element, string path, List<Action> effects)
     {
         var child = element.Child is null ? null : RenderElement(element.Child, path + ".content", effects);
         if (child is not null)
-            RemoveFromParent(child);
-        control.Content = child;
+        {
+            if (!ReferenceEquals(control.Content, child))
+            {
+                RemoveFromParent(child);
+                control.Content = child;
+            }
+        }
+        else
+        {
+            control.Content = null;
+        }
         control.VerticalScrollBarVisibility = ScrollBarVisibility.Auto;
         control.HorizontalScrollMode = element.Modifiers.HorizontalScrollMode ?? ScrollMode.Auto;
         ApplyModifiers(control, element);
@@ -1266,9 +1311,18 @@ internal sealed class UiRenderer(Action requestRender)
     {
         var child = element.Child is null ? null : RenderElement(element.Child, path + ".content", effects);
         if (child is not null)
-            RemoveFromParent(child);
+        {
+            if (!ReferenceEquals(control.Content, child))
+            {
+                RemoveFromParent(child);
+                control.Content = child;
+            }
+        }
+        else
+        {
+            control.Content = null;
+        }
         control.Header = element.Header;
-        control.Content = child;
         control.IsExpanded = element.IsExpanded;
         ApplyModifiers(control, element);
         ApplySetters(control, element);


### PR DESCRIPTION
## Summary

Fixes several UX issues in the native FunctionalUI chat surface:

### Composer focus loss
- Use \UseRef\ for input text instead of \UseState\ to prevent full-tree re-render on every keypress
- \UseState<bool>\ tracks empty↔non-empty for send button accent styling (2 re-renders per compose cycle, not per-keypress)

### Flickering during streaming
- \ConfigureBorder\: skip child detach/reattach when child reference is unchanged
- \ConfigureScrollView\/\ConfigureExpander\: same \ReferenceEquals\ guard
- \ConfigureGrid\: skip column/row definition rebuild when definitions match

### Bubble clipping/overflow
- Switch bubble rows from \FlexRow\ (StackPanel) to \Grid\ with Auto+Star columns so bubbles constrain to available window width
- Remove fixed 560px \MaxWidth\ cap — bubbles now fill available space responsively

### Notifications
- Suppress chat toast notifications when tray \ChatWindow\ is already visible

### Chat window chrome
- Suppress orphaned Esc keyboard accelerator tooltip on scroll
- Use atomic \SetWindowPos\ for flicker-free show/hide positioning