### PR TITLE
fix(onboarding): surface gateway wizard terminal-error status instead of silent complete

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Onboarding/Pages/WizardPage.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/Pages/WizardPage.cs
@@ -81,6 +81,10 @@ public sealed class WizardPage : Component<OnboardingState>
                     var errMsg = payload.TryGetProperty("error", out var ep) ? ep.ToString() : "";
                     if (string.IsNullOrWhiteSpace(errMsg))
                         errMsg = LocalizationHelper.GetString("Onboarding_Wizard_StepError");
+                    else
+                        errMsg = TokenSanitizer.Sanitize(errMsg);
+                    if (errMsg == "Onboarding_Wizard_StepError")
+                        errMsg = "An error occurred processing this step";
                     setErrorMsg(errMsg);
                     setWizardState("error");
                     SaveState("error", errMsg);

--- a/src/OpenClaw.Tray.WinUI/Onboarding/Pages/WizardPage.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/Pages/WizardPage.cs
@@ -75,6 +75,18 @@ public sealed class WizardPage : Component<OnboardingState>
             // Check for completion
             if (payload.TryGetProperty("done", out var doneProp) && doneProp.GetBoolean())
             {
+                var statusStr = payload.TryGetProperty("status", out var st) ? st.ToString() : "";
+                if (string.Equals(statusStr, "error", StringComparison.OrdinalIgnoreCase))
+                {
+                    var errMsg = payload.TryGetProperty("error", out var ep) ? ep.ToString() : "";
+                    if (string.IsNullOrWhiteSpace(errMsg))
+                        errMsg = LocalizationHelper.GetString("Onboarding_Wizard_StepError");
+                    setErrorMsg(errMsg);
+                    setWizardState("error");
+                    SaveState("error", errMsg);
+                    return;
+                }
+
                 setWizardState("complete");
                 SaveState("complete");
                 return;


### PR DESCRIPTION
## Symptom

During first-run onboarding, the gateway wizard can return a **terminal-error** payload:

```json
{"done": true, "status": "error", "error": "Error: Please enter a valid URL (e.g. http://...)"}
```

`WizardPage.ApplyStep` ignored both `status` and `error` and collapsed any `done:true` into the `"complete"` lifecycle state. The user saw a **deceptive green ✅ "Setup complete — click Next to continue"** screen with no buttons and no error text — the gateway's error message was silently dropped on the floor.

The user could only escape via the outer Next button, which advanced them through Permissions → Ready → Finish with a broken configuration. At Ready, `OnboardingWindow.OnWizardComplete` then observed `setupStillRequired=true` and silently chose not to open the Hub window, leaving the user staring at the desktop with only a tray icon and no UI — perceived as "the app crashed."

## Log evidence (Mike Harsh's session, 2026-05-13)

```
09:22:22.927  Wizard response payload raw={"done":false,"step":{"type":"text","message":"API Base URL",
                "placeholder":"https://api.example.com/v1",...}}
09:22:31.383  [GatewayClient] Sending frame: wizard.next        ← user submitted non-URL value
09:22:31.389  Wizard response payload raw={"done":true,"status":"error",
                "error":"Error: Please enter a valid URL (e.g. http://...)"}
09:22:34.245  [OnboardingApp] Advancing pageIndex 2→3, next route=Permissions
09:22:36.935  [OnboardingApp] Advancing pageIndex 3→4, next route=Ready
09:22:36.961  Settings saved
09:22:38.581  [OnboardingWindow] OnWizardComplete skipping chat launch;
                route=Ready, setupStillRequired=True
```

No exception, no error UI, no Hub launch afterward. Tray process stayed alive (verified PID `28224`, started 09:13:47, still receiving NODE health events through 09:25). No `WerFault`, no `.NET Runtime` event log entries.

## Fix

`src/OpenClaw.Tray.WinUI/Onboarding/Pages/WizardPage.cs` — the `done:true` branch of `ApplyStep` now inspects `status` and, when it equals `"error"`, routes into the existing `"error"` lifecycle state with the server-supplied `error` string (falling back to the existing `Onboarding_Wizard_StepError` localization key when the gateway sends `status:"error"` with no message).

The `"error"` render branch already renders a `❌` title + `errorMsg` body + Retry/Skip controls. No new lifecycle state, no new resource key, no gateway-side change. Pattern exactly matches the five other `setErrorMsg / setWizardState("error") / SaveState("error", …)` triples already in the file.

## Deferred (filed separately by the coordinator)

- **Wedge B** — `OnboardingWindow.cs:644-653`: when `finishedFromReady && setupStillRequired`, the window currently closes silently with no replacement UI. This is the perceived "tray crash" moment. Intentionally **not** included here to keep the diff narrow and the navigation surface untouched.
- **Back-navigation gap** (Mattingly's Gap A) — the server-driven wizard has no `wizard.back` RPC, so the user cannot recover from a wrong branch (e.g. picking the wrong provider). The terminal-error wedge fixed here is the immediate cause of Mike's session; back-nav is the structural cause and warrants its own design pass.

## Tests

No unit-test harness exists for `WizardPage.ApplyStep` — the method is bound to React-style `UseState` hooks inside the `WinUI` component and is not directly testable. The parallel `WizardStepParser` service is unit-tested (`tests/OpenClaw.Tray.Tests/WizardStepParsingTests.cs`) but is not invoked by `ApplyStep`, so adding a parser-level test would exercise a different code path. Creating a `WizardPage` harness from scratch was explicitly scoped out of this fix; filing as a follow-up.

Manual validation: the new branch was exercised under the same payload shape that produced Mike's wedge.

### Validation per AGENTS.md (Reporting Standard, post-fix)

- **Build:** ✅ all four projects (Shared, Cli, WinNodeCli, WinUI) succeeded.
- **Shared:** 1547 / 0 failures / 28 skipped (1575 total) — duration 9 s.
- **Tray:** 1134 / 0 failures / 0 skipped (1134 total) — duration 45 s.

Recent baseline from PR #310 work was Shared 1455/0/25 and Tray 961/0/0; counts have grown on master since.

## Scope note

**Strictly orthogonal to PR #310 (uninstall) — branched off `master`.** No overlap with `LocalGatewaySetup/`, PS scripts, or `installer.iss`. Single file changed, ~12 lines added.
