### PR TITLE
Fix incomplete onboarding Finish recovery

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Onboarding/OnboardingWindow.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/OnboardingWindow.cs
@@ -45,10 +45,11 @@ public sealed class OnboardingWindow : WindowEx
     private bool _chatWebViewInitialized;
     private readonly OnboardingState _state;
     private bool _stateDisposed;
-    // Single-fire guard so the X button (Closed) and the Finish button (state.Complete →
-    // OnOnboardingFinished → Close → Closed) don't both dispatch completion. Both paths
-    // route through OnWizardComplete which no-ops after the first call.
+    // Single-fire guard so the X button (Closed) and the Finish button (state.Complete ->
+    // OnOnboardingFinished -> Close -> Closed) don't both dispatch completion. Both paths
+    // route through TryCompleteOnboarding which no-ops after the first call.
     private bool _completionDispatched;
+    private bool _incompleteSetupDialogOpen;
 
     public OnboardingWindow(SettingsManager settings, string? identityDataPath = null)
     {
@@ -562,16 +563,21 @@ public sealed class OnboardingWindow : WindowEx
 
     private void OnOnboardingFinished(object? sender, EventArgs e)
     {
-        OnWizardComplete();
-        Close();
+        if (TryCompleteOnboarding())
+        {
+            Close();
+            return;
+        }
+
+        _ = ShowIncompleteSetupDialogAsync();
     }
 
     private void OnClosed(object sender, WindowEventArgs args)
     {
-        // X button path: also runs OnWizardComplete (idempotent via _completionDispatched)
+        // X button path: also runs TryCompleteOnboarding (idempotent via _completionDispatched)
         // so a user who clicks the title-bar X on the Ready page still gets the chat-window
         // launch when a model has been configured, matching the Finish-button behavior.
-        OnWizardComplete();
+        _ = TryCompleteOnboarding();
 
         if (_stateDisposed) return;
         _stateDisposed = true;
@@ -595,12 +601,19 @@ public sealed class OnboardingWindow : WindowEx
     /// gateway wizard can stop on a later channel step even after credentials/model
     /// setup succeeded, but Finish on Ready still runs this handler.
     /// </summary>
-    private void OnWizardComplete()
+    private bool TryCompleteOnboarding()
     {
-        if (_completionDispatched) return;
-        _completionDispatched = true;
-
+        if (_completionDispatched) return true;
         var finishedFromReady = _state.CurrentRoute == OnboardingRoute.Ready;
+        var dataPath = _identityDataPath ?? SettingsManager.SettingsDirectoryPath;
+        var setupStillRequired = StartupSetupState.RequiresSetup(_settings, dataPath);
+        if (OnboardingCompletionPolicy.Decide(_state.CurrentRoute, setupStillRequired) == OnboardingCompletionOutcome.BlockIncompleteReady)
+        {
+            Logger.Warn("[OnboardingWindow] Finish blocked because setup is still required; keeping onboarding open");
+            return false;
+        }
+
+        _completionDispatched = true;
 
         _settings.Save();
         Completed = true;
@@ -620,16 +633,53 @@ public sealed class OnboardingWindow : WindowEx
 
         OnboardingCompleted?.Invoke(this, EventArgs.Empty);
 
-        var dataPath = _identityDataPath ?? SettingsManager.SettingsDirectoryPath;
-        var setupStillRequired = StartupSetupState.RequiresSetup(_settings, dataPath);
         if (finishedFromReady && !setupStillRequired)
         {
-            Logger.Info("[OnboardingWindow] OnWizardComplete launching HubWindow on chat tab");
+            Logger.Info("[OnboardingWindow] TryCompleteOnboarding launching HubWindow on chat tab");
             ShowHubChatAfterWizardClose();
         }
         else
         {
-            Logger.Info($"[OnboardingWindow] OnWizardComplete skipping chat launch; route={_state.CurrentRoute}, setupStillRequired={setupStillRequired}");
+            Logger.Info($"[OnboardingWindow] TryCompleteOnboarding skipping chat launch; route={_state.CurrentRoute}, setupStillRequired={setupStillRequired}");
+        }
+
+        return true;
+    }
+
+    private async Task ShowIncompleteSetupDialogAsync()
+    {
+        if (_incompleteSetupDialogOpen) return;
+        _incompleteSetupDialogOpen = true;
+        try
+        {
+            if (_rootGrid.XamlRoot is null)
+            {
+                Logger.Warn("[OnboardingWindow] Cannot show incomplete setup dialog; XamlRoot is unavailable");
+                return;
+            }
+
+            var dialog = new ContentDialog
+            {
+                Title = LocalizationHelper.GetString("Onboarding_IncompleteSetup_Title"),
+                Content = new TextBlock
+                {
+                    Text = LocalizationHelper.GetString("Onboarding_IncompleteSetup_Body"),
+                    TextWrapping = TextWrapping.Wrap
+                },
+                CloseButtonText = LocalizationHelper.GetString("Onboarding_IncompleteSetup_Close"),
+                DefaultButton = ContentDialogButton.Close,
+                XamlRoot = _rootGrid.XamlRoot
+            };
+
+            await dialog.ShowAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"[OnboardingWindow] Failed to show incomplete setup dialog: {ex.Message}");
+        }
+        finally
+        {
+            _incompleteSetupDialogOpen = false;
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Onboarding/Services/OnboardingCompletionPolicy.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/Services/OnboardingCompletionPolicy.cs
@@ -1,0 +1,15 @@
+namespace OpenClawTray.Onboarding.Services;
+
+public enum OnboardingCompletionOutcome
+{
+    Complete,
+    BlockIncompleteReady
+}
+
+public static class OnboardingCompletionPolicy
+{
+    public static OnboardingCompletionOutcome Decide(OnboardingRoute currentRoute, bool setupStillRequired) =>
+        currentRoute == OnboardingRoute.Ready && setupStillRequired
+            ? OnboardingCompletionOutcome.BlockIncompleteReady
+            : OnboardingCompletionOutcome.Complete;
+}

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -1135,6 +1135,15 @@ On your gateway host (Mac/Linux), run:
   <data name="Onboarding_Finish" xml:space="preserve">
     <value>Finish</value>
   </data>
+  <data name="Onboarding_IncompleteSetup_Title" xml:space="preserve">
+    <value>Setup isn't complete</value>
+  </data>
+  <data name="Onboarding_IncompleteSetup_Body" xml:space="preserve">
+    <value>OpenClaw still needs setup before it can open the Hub. Use Back to return to the wizard or connection steps, fix the missing setup, and then try Finish again.</value>
+  </data>
+  <data name="Onboarding_IncompleteSetup_Close" xml:space="preserve">
+    <value>OK</value>
+  </data>
   <data name="Onboarding_Connection_Title" xml:space="preserve">
     <value>Choose your Gateway</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -1086,6 +1086,15 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="Onboarding_Finish" xml:space="preserve">
     <value>Terminer</value>
   </data>
+  <data name="Onboarding_IncompleteSetup_Title" xml:space="preserve">
+    <value>La configuration n’est pas terminée</value>
+  </data>
+  <data name="Onboarding_IncompleteSetup_Body" xml:space="preserve">
+    <value>OpenClaw a encore besoin d’être configuré avant de pouvoir ouvrir le Hub. Utilisez Retour pour revenir à l’assistant ou aux étapes de connexion, corrigez la configuration manquante, puis réessayez Terminer.</value>
+  </data>
+  <data name="Onboarding_IncompleteSetup_Close" xml:space="preserve">
+    <value>D'accord</value>
+  </data>
   <data name="Onboarding_Welcome_Title" xml:space="preserve">
     <value>Bienvenue dans OpenClaw</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -1087,6 +1087,15 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="Onboarding_Finish" xml:space="preserve">
     <value>Voltooien</value>
   </data>
+  <data name="Onboarding_IncompleteSetup_Title" xml:space="preserve">
+    <value>Setup is nog niet voltooid</value>
+  </data>
+  <data name="Onboarding_IncompleteSetup_Body" xml:space="preserve">
+    <value>OpenClaw heeft nog setup nodig voordat de Hub kan worden geopend. Gebruik Terug om naar de wizard of verbindingsstappen te gaan, los de ontbrekende setup op en probeer daarna Voltooien opnieuw.</value>
+  </data>
+  <data name="Onboarding_IncompleteSetup_Close" xml:space="preserve">
+    <value>Oké</value>
+  </data>
   <data name="Onboarding_Welcome_Title" xml:space="preserve">
     <value>Welkom bij OpenClaw</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -1086,6 +1086,15 @@
   <data name="Onboarding_Finish" xml:space="preserve">
     <value>完成</value>
   </data>
+  <data name="Onboarding_IncompleteSetup_Title" xml:space="preserve">
+    <value>设置尚未完成</value>
+  </data>
+  <data name="Onboarding_IncompleteSetup_Body" xml:space="preserve">
+    <value>OpenClaw 仍需要完成设置，才能打开 Hub。请使用“返回”回到向导或连接步骤，修复缺失的设置，然后再次尝试“完成”。</value>
+  </data>
+  <data name="Onboarding_IncompleteSetup_Close" xml:space="preserve">
+    <value>确定</value>
+  </data>
   <data name="Onboarding_Welcome_Title" xml:space="preserve">
     <value>欢迎使用 OpenClaw</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -1086,6 +1086,15 @@
   <data name="Onboarding_Finish" xml:space="preserve">
     <value>完成</value>
   </data>
+  <data name="Onboarding_IncompleteSetup_Title" xml:space="preserve">
+    <value>設定尚未完成</value>
+  </data>
+  <data name="Onboarding_IncompleteSetup_Body" xml:space="preserve">
+    <value>OpenClaw 仍需要完成設定，才能開啟 Hub。請使用「返回」回到精靈或連線步驟，修正缺少的設定，然後再次嘗試「完成」。</value>
+  </data>
+  <data name="Onboarding_IncompleteSetup_Close" xml:space="preserve">
+    <value>確定</value>
+  </data>
   <data name="Onboarding_Welcome_Title" xml:space="preserve">
     <value>歡迎使用 OpenClaw</value>
   </data>

--- a/tests/OpenClaw.Tray.Tests/OnboardingCompletionPolicyTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OnboardingCompletionPolicyTests.cs
@@ -1,0 +1,30 @@
+using OpenClawTray.Onboarding.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public class OnboardingCompletionPolicyTests
+{
+    [Fact]
+    public void Decide_ReadyWithSetupStillRequired_BlocksCompletion()
+    {
+        var outcome = OnboardingCompletionPolicy.Decide(OnboardingRoute.Ready, setupStillRequired: true);
+
+        Assert.Equal(OnboardingCompletionOutcome.BlockIncompleteReady, outcome);
+    }
+
+    [Fact]
+    public void Decide_ReadyWithSetupComplete_AllowsCompletion()
+    {
+        var outcome = OnboardingCompletionPolicy.Decide(OnboardingRoute.Ready, setupStillRequired: false);
+
+        Assert.Equal(OnboardingCompletionOutcome.Complete, outcome);
+    }
+
+    [Fact]
+    public void Decide_NonReadyRoute_PreservesExistingCompletionBehavior()
+    {
+        var outcome = OnboardingCompletionPolicy.Decide(OnboardingRoute.Wizard, setupStillRequired: true);
+
+        Assert.Equal(OnboardingCompletionOutcome.Complete, outcome);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\A2UI\Protocol\A2UIProtocol.cs" Link="A2UI\Protocol\A2UIProtocol.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\A2UI\Rendering\SecretRedactor.cs" Link="A2UI\Rendering\SecretRedactor.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Onboarding\Services\OnboardingState.cs" Link="Imported\OnboardingState.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Onboarding\Services\OnboardingCompletionPolicy.cs" Link="Imported\OnboardingCompletionPolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Onboarding\Services\OnboardingExistingConfigGuard.cs" Link="Imported\OnboardingExistingConfigGuard.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Onboarding\Services\LocalSetupProgressPolicy.cs" Link="Imported\LocalSetupProgressPolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Onboarding\Services\LocalSetupProgressStageMap.cs" Link="Imported\LocalSetupProgressStageMap.cs" />


### PR DESCRIPTION
Fixes #330.\n\n## Summary\n- block Ready-page Finish when setup is still required\n- keep onboarding open and show a localized recovery dialog\n- add a pure completion policy with tests\n\n## Validation\n- .\\build.ps1\n- dotnet test .\\tests\\OpenClaw.Shared.Tests\\OpenClaw.Shared.Tests.csproj --no-restore\n- dotnet test .\\tests\\OpenClaw.Tray.Tests\\OpenClaw.Tray.Tests.csproj --no-restore