### PR TITLE
Refactor WinUI clipboard text copies

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -23,7 +23,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Updatum;
-using Windows.ApplicationModel.DataTransfer;
 using WinUIEx;
 
 namespace OpenClawTray;
@@ -1052,9 +1051,7 @@ public partial class App : Application
         
         try
         {
-            var dataPackage = new global::Windows.ApplicationModel.DataTransfer.DataPackage();
-            dataPackage.SetText(_nodeService.FullDeviceId);
-            global::Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(dataPackage);
+            CopyTextToClipboard(_nodeService.FullDeviceId);
             
             // Show toast confirming copy
             ShowToast(new ToastContentBuilder()
@@ -1081,9 +1078,7 @@ public partial class App : Application
             });
             var summary = string.Join(Environment.NewLine, lines);
 
-            var dataPackage = new global::Windows.ApplicationModel.DataTransfer.DataPackage();
-            dataPackage.SetText(summary);
-            global::Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(dataPackage);
+            CopyTextToClipboard(summary);
 
             ShowToast(new ToastContentBuilder()
                 .AddText(LocalizationHelper.GetString("Toast_NodeSummaryCopied"))
@@ -4394,9 +4389,7 @@ public partial class App : Application
 
     public static void CopyTextToClipboard(string text)
     {
-        var dataPackage = new global::Windows.ApplicationModel.DataTransfer.DataPackage();
-        dataPackage.SetText(text);
-        global::Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(dataPackage);
+        ClipboardHelper.CopyText(text);
     }
 
     #endregion

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
@@ -11,7 +11,6 @@ using Microsoft.UI.Xaml.Media;
 using OpenClawTray.FunctionalUI;
 using OpenClawTray.FunctionalUI.Core;
 using OpenClawTray.Chat.Explorations;
-using Windows.ApplicationModel.DataTransfer;
 using Windows.UI;
 using static OpenClawTray.FunctionalUI.Factories;
 using static OpenClawTray.FunctionalUI.Core.Theme;
@@ -588,10 +587,7 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
             if (string.IsNullOrEmpty(text)) return;
             try
             {
-                var data = new DataPackage();
-                data.SetText(text);
-                Clipboard.SetContent(data);
-                Clipboard.Flush();
+                ClipboardHelper.CopyText(text, flush: true);
             }
             catch { /* clipboard contention — silently ignore */ }
         }

--- a/src/OpenClaw.Tray.WinUI/Dialogs/QuickSendDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/QuickSendDialog.cs
@@ -343,9 +343,7 @@ public sealed class QuickSendDialog : WindowEx
 
     private static void CopyTextToClipboard(string text)
     {
-        var data = new global::Windows.ApplicationModel.DataTransfer.DataPackage();
-        data.SetText(text);
-        global::Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(data);
+        ClipboardHelper.CopyText(text);
     }
 
     private void QueueFocusMessageInput()

--- a/src/OpenClaw.Tray.WinUI/Helpers/ClipboardHelper.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/ClipboardHelper.cs
@@ -1,0 +1,16 @@
+using Windows.ApplicationModel.DataTransfer;
+
+namespace OpenClawTray.Helpers;
+
+internal static class ClipboardHelper
+{
+    public static void CopyText(string text, bool flush = false)
+    {
+        var dataPackage = new DataPackage();
+        dataPackage.SetText(text);
+        Clipboard.SetContent(dataPackage);
+
+        if (flush)
+            Clipboard.Flush();
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Onboarding/Pages/WizardPage.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/Pages/WizardPage.cs
@@ -588,9 +588,7 @@ public sealed class WizardPage : Component<OnboardingState>
                         {
                             try
                             {
-                                var dp = new global::Windows.ApplicationModel.DataTransfer.DataPackage();
-                                dp.SetText(code);
-                                global::Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(dp);
+                                ClipboardHelper.CopyText(code);
                             }
                             catch { }
                         }).VAlign(VerticalAlignment.Center)

--- a/src/OpenClaw.Tray.WinUI/Pages/AboutPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/AboutPage.xaml.cs
@@ -1,9 +1,9 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using OpenClawTray.Helpers;
 using OpenClawTray.Windows;
 using System;
 using System.Diagnostics;
-using WinDataTransfer = global::Windows.ApplicationModel.DataTransfer;
 
 namespace OpenClawTray.Pages;
 
@@ -83,9 +83,7 @@ public sealed partial class AboutPage : Page
                 + $"Connection: {_hub?.CurrentStatus}\n"
                 + $"Gateway: {_hub?.Settings?.GetEffectiveGatewayUrl() ?? "n/a"}\n";
 
-            var dataPackage = new WinDataTransfer.DataPackage();
-            dataPackage.SetText(context);
-            WinDataTransfer.Clipboard.SetContent(dataPackage);
+            ClipboardHelper.CopyText(context);
         }
         catch (Exception ex)
         {

--- a/src/OpenClaw.Tray.WinUI/Pages/CapabilitiesPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/CapabilitiesPage.xaml.cs
@@ -3,11 +3,11 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using OpenClaw.Shared;
 using OpenClaw.Shared.Capabilities;
+using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
-using Windows.ApplicationModel.DataTransfer;
 using Windows.System;
 
 namespace OpenClawTray.Pages;
@@ -310,9 +310,7 @@ public sealed partial class CapabilitiesPage : Page
             if (System.IO.File.Exists(tokenPath))
             {
                 var token = System.IO.File.ReadAllText(tokenPath).Trim();
-                var dp = new DataPackage();
-                dp.SetText(token);
-                Clipboard.SetContent(dp);
+                ClipboardHelper.CopyText(token);
                 McpStatusText.Text = "Token copied to clipboard";
             }
             else
@@ -328,9 +326,7 @@ public sealed partial class CapabilitiesPage : Page
 
     private void OnCopyMcpUrl(object sender, RoutedEventArgs e)
     {
-        var dp = new DataPackage();
-        dp.SetText(NodeService.McpServerUrl);
-        Clipboard.SetContent(dp);
+        ClipboardHelper.CopyText(NodeService.McpServerUrl);
         McpStatusText.Text = "URL copied to clipboard";
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using OpenClaw.Shared;
+using OpenClawTray.Helpers;
 using OpenClawTray.Onboarding.Services;
 using OpenClawTray.Services;
 using OpenClawTray.Services.Connection;
@@ -8,7 +9,6 @@ using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Windows.ApplicationModel.DataTransfer;
 
 namespace OpenClawTray.Pages;
 
@@ -255,9 +255,7 @@ public sealed partial class ConnectionPage : Page
 
     private void OnCopyApproveCommand(object sender, RoutedEventArgs e)
     {
-        var dp = new DataPackage();
-        dp.SetText(PairingApproveCommandText.Text);
-        Clipboard.SetContent(dp);
+        ClipboardHelper.CopyText(PairingApproveCommandText.Text);
     }
 
     private void OnReconnectAfterApproval(object sender, RoutedEventArgs e)
@@ -920,8 +918,6 @@ public sealed partial class ConnectionPage : Page
 
     private static void CopyToClipboard(string text)
     {
-        var dp = new DataPackage();
-        dp.SetText(text);
-        Clipboard.SetContent(dp);
+        ClipboardHelper.CopyText(text);
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
@@ -1,13 +1,13 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using OpenClaw.Shared;
+using OpenClawTray.Helpers;
 using OpenClawTray.Windows;
 using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
-using WinDataTransfer = global::Windows.ApplicationModel.DataTransfer;
 
 namespace OpenClawTray.Pages;
 
@@ -115,9 +115,7 @@ public sealed partial class DebugPage : Page
 
     private void OnCopyLog(object sender, RoutedEventArgs e)
     {
-        var dp = new WinDataTransfer.DataPackage();
-        dp.SetText(LogText.Text ?? "");
-        WinDataTransfer.Clipboard.SetContent(dp);
+        ClipboardHelper.CopyText(LogText.Text ?? "");
     }
 
     // ── Connection Status ────────────────────────────────────────────
@@ -183,9 +181,7 @@ public sealed partial class DebugPage : Page
     private void OnCopyDeviceId(object sender, RoutedEventArgs e)
     {
         var fullId = DeviceIdText.Tag as string ?? DeviceIdText.Text;
-        var dp = new WinDataTransfer.DataPackage();
-        dp.SetText(fullId);
-        WinDataTransfer.Clipboard.SetContent(dp);
+        ClipboardHelper.CopyText(fullId);
     }
 
     // ── Debug Actions ────────────────────────────────────────────────
@@ -238,9 +234,7 @@ public sealed partial class DebugPage : Page
             $"Time: {DateTime.UtcNow:u}"
         };
 
-        var dp = new WinDataTransfer.DataPackage();
-        dp.SetText(string.Join("\n", lines));
-        WinDataTransfer.Clipboard.SetContent(dp);
+        ClipboardHelper.CopyText(string.Join("\n", lines));
 
         if (sender is Button btn)
         {

--- a/src/OpenClaw.Tray.WinUI/Pages/NodesPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/NodesPage.xaml.cs
@@ -10,7 +10,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using WinDataTransfer = global::Windows.ApplicationModel.DataTransfer;
 using WinColor = global::Windows.UI.Color;
 
 namespace OpenClawTray.Pages;
@@ -741,9 +740,7 @@ public sealed partial class NodesPage : Page
     {
         if (sender is Button btn && btn.Tag is string deviceId)
         {
-            var dataPackage = new WinDataTransfer.DataPackage();
-            dataPackage.SetText(deviceId);
-            WinDataTransfer.Clipboard.SetContent(dataPackage);
+            ClipboardHelper.CopyText(deviceId);
             btn.Content = "✓";
             var timer = DispatcherQueue.CreateTimer();
             timer.Interval = TimeSpan.FromSeconds(2);

--- a/src/OpenClaw.Tray.WinUI/Windows/ConnectionStatusWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/ConnectionStatusWindow.xaml.cs
@@ -6,13 +6,13 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Media;
 using OpenClaw.Shared;
+using OpenClawTray.Helpers;
 using OpenClawTray.Onboarding.Services;
 using OpenClawTray.Services.Connection;
 using System;
 using System.IO;
 using System.Text;
 using WinUIEx;
-using WinDataTransfer = global::Windows.ApplicationModel.DataTransfer;
 
 namespace OpenClawTray.Windows;
 
@@ -529,9 +529,7 @@ public sealed partial class ConnectionStatusWindow : WindowEx
 
     private void OnCopyTimeline(object sender, RoutedEventArgs e)
     {
-        var dp = new WinDataTransfer.DataPackage();
-        dp.SetText(_plainBuffer.ToString());
-        WinDataTransfer.Clipboard.SetContent(dp);
+        ClipboardHelper.CopyText(_plainBuffer.ToString());
     }
 
     private void OnClearTimeline(object sender, RoutedEventArgs e)

--- a/src/OpenClaw.Tray.WinUI/Windows/SetupWizardWindow.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/SetupWizardWindow.cs
@@ -919,9 +919,7 @@ public sealed class SetupWizardWindow : WindowEx
             var fullId = _copyDeviceIdButton.Tag?.ToString();
             if (string.IsNullOrEmpty(fullId)) return;
 
-            var dataPackage = new global::Windows.ApplicationModel.DataTransfer.DataPackage();
-            dataPackage.SetText(fullId);
-            global::Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(dataPackage);
+            ClipboardHelper.CopyText(fullId);
             _copyDeviceIdButton.Content = LocalizationHelper.GetString("Setup_DeviceIdCopied");
             Logger.Info("[Setup] Device ID copied to clipboard");
 


### PR DESCRIPTION
## Summary

- add a shared `ClipboardHelper.CopyText` for WinUI text clipboard writes
- replace repeated `DataPackage`/`Clipboard.SetContent` snippets across App, pages, windows, dialogs, onboarding, and chat
- preserve the existing chat timeline `Clipboard.Flush()` behavior via an optional helper flag

## Testing

- uild.ps1`
- `dotnet test .ests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test .ests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`