### PR TITLE
fix(onboarding): skip wizard for paired operators and make "Keep my setup" actually dismiss

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Onboarding/OnboardingWindow.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/OnboardingWindow.cs
@@ -595,6 +595,11 @@ public sealed class OnboardingWindow : WindowEx
         }
         catch (Exception ex)
         {
+            // If Close() fails the window is still alive. Reset the guard so a
+            // subsequent X-button or normal Finish path is NOT permanently
+            // suppressed (otherwise TryCompleteOnboarding becomes unreachable
+            // for the lifetime of this window).
+            _dismissedWithoutCompletion = false;
             Logger.Warn($"[OnboardingWindow] Close after dismiss threw: {ex.Message}");
         }
     }

--- a/src/OpenClaw.Tray.WinUI/Onboarding/OnboardingWindow.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/OnboardingWindow.cs
@@ -86,17 +86,21 @@ public sealed class OnboardingWindow : WindowEx
         _state = new OnboardingState(settings);
         _state.Finished += OnOnboardingFinished;
         _state.RouteChanged += OnRouteChanged;
+        _state.Dismissed += OnOnboardingDismissed;
 
-        // Construct the existing-config guard and apply returning-user defaults.
-        // When existing config is detected, default SetupPath to Advanced so the
-        // user lands on the SetupWarning page with Next enabled (→ Connection page)
-        // rather than the local setup path. The warn-and-confirm gate on
-        // SetupWarningPage protects the "Set up locally" button.
+        // Construct the existing-config guard for returning users. The
+        // <see cref="SetupWarningPage"/> uses this to render the warn-and-confirm
+        // ("Replace my setup" / "Keep my setup") section when prior credentials,
+        // a non-default gateway URL, or a completed setup-state file is present.
+        //
+        // We intentionally do NOT preselect SetupPath here. Leaving it null keeps
+        // the global nav-bar Next button disabled on SetupWarning so the user MUST
+        // pick one of the three explicit choices ("Replace my setup", "Keep my
+        // setup", or "Advanced setup") — eliminating the accidental Next-into-setup
+        // path Scott Hanselman hit when clicking "Keep my setup".
         if (identityDataPath != null)
         {
             _state.ExistingConfigGuard = new OnboardingExistingConfigGuard(settings, identityDataPath);
-            if (_state.ExistingConfigGuard.HasExistingConfiguration())
-                _state.SetupPath = SetupPath.Advanced;
         }
 
         // Optional override for visual tests / engineering: jump straight to a route.
@@ -572,17 +576,48 @@ public sealed class OnboardingWindow : WindowEx
         _ = ShowIncompleteSetupDialogAsync();
     }
 
+    /// <summary>
+    /// Set when the user explicitly dismisses the wizard via
+    /// <see cref="OnboardingState.Dismiss"/> (e.g., "Keep my setup" on the
+    /// SetupWarning page). <see cref="OnClosed"/> consults this to skip the
+    /// completion pipeline so existing settings and gateway connection are
+    /// preserved untouched.
+    /// </summary>
+    private bool _dismissedWithoutCompletion;
+
+    private void OnOnboardingDismissed(object? sender, EventArgs e)
+    {
+        Logger.Info("[OnboardingWindow] Dismissed by user (keep-existing-setup) — closing without completing");
+        _dismissedWithoutCompletion = true;
+        try
+        {
+            Close();
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"[OnboardingWindow] Close after dismiss threw: {ex.Message}");
+        }
+    }
+
     private void OnClosed(object sender, WindowEventArgs args)
     {
         // X button path: also runs TryCompleteOnboarding (idempotent via _completionDispatched)
         // so a user who clicks the title-bar X on the Ready page still gets the chat-window
         // launch when a model has been configured, matching the Finish-button behavior.
-        _ = TryCompleteOnboarding();
+        //
+        // Skipped entirely when the user explicitly dismissed via "Keep my setup" — that
+        // path must NOT mark onboarding complete, must NOT fire OnboardingCompleted, and
+        // must NOT touch settings/AutoStart so the prior gateway connection is preserved.
+        if (!_dismissedWithoutCompletion)
+        {
+            _ = TryCompleteOnboarding();
+        }
 
         if (_stateDisposed) return;
         _stateDisposed = true;
         _state.Finished -= OnOnboardingFinished;
         _state.RouteChanged -= OnRouteChanged;
+        _state.Dismissed -= OnOnboardingDismissed;
         if (Completed)
         {
             _state.GatewayClient = null;

--- a/src/OpenClaw.Tray.WinUI/Onboarding/Pages/SetupWarningPage.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/Pages/SetupWarningPage.cs
@@ -68,7 +68,12 @@ public sealed class SetupWarningPage : Component<OnboardingState>
 
         void CancelReplace()
         {
+            // "Keep my setup" — the user has existing configuration and wants to
+            // keep it. Dismiss the wizard entirely rather than just hiding the
+            // warning section (which previously left the user one nav-bar Next
+            // click away from entering setup anyway — Scott Hanselman repro).
             setConfirmingReplace(false);
+            Props.Dismiss();
         }
 
         void ChooseAdvanced()

--- a/src/OpenClaw.Tray.WinUI/Onboarding/Pages/SetupWarningPage.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/Pages/SetupWarningPage.cs
@@ -72,7 +72,9 @@ public sealed class SetupWarningPage : Component<OnboardingState>
             // keep it. Dismiss the wizard entirely rather than just hiding the
             // warning section (which previously left the user one nav-bar Next
             // click away from entering setup anyway — Scott Hanselman repro).
-            setConfirmingReplace(false);
+            // We deliberately do NOT call setConfirmingReplace(false) here: the
+            // window is about to close, and the redundant state change would
+            // briefly re-render the "Set up locally" button before teardown.
             Props.Dismiss();
         }
 

--- a/src/OpenClaw.Tray.WinUI/Onboarding/Services/OnboardingExistingConfigGuard.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/Services/OnboardingExistingConfigGuard.cs
@@ -56,10 +56,51 @@ public sealed class OnboardingExistingConfigGuard
             HasBootstrapToken: false,
             HasNonDefaultGatewayUrl: !string.IsNullOrWhiteSpace(_settings.GatewayUrl)
                 && !string.Equals(_settings.GatewayUrl, DefaultGatewayUrl, StringComparison.OrdinalIgnoreCase),
-            HasOperatorDeviceToken: DeviceIdentity.HasStoredDeviceToken(_identityDataPath),
+            HasOperatorDeviceToken: HasAnyOperatorDeviceToken(_identityDataPath),
             HasNodeDeviceToken: DeviceIdentity.HasStoredDeviceTokenForRole(_identityDataPath, "node"),
             HasCompletedOrRunningSetupState: ReadSetupStateIsActive(_setupStatePath),
             HasWslDistro: false);
+    }
+
+    /// <summary>
+    /// Scans both the legacy root identity and per-gateway identity directories
+    /// for an operator device token. Modern pairings (post-GatewayRegistry)
+    /// write tokens to <c>&lt;dataPath&gt;/gateways/&lt;gatewayId&gt;/device-key-ed25519.json</c>
+    /// via <c>DeviceIdentityStore</c>; the legacy root file is kept by migration
+    /// but is NOT created by fresh pairings. Single source of truth shared with
+    /// <c>StartupSetupState</c> so the startup auto-launch decision and the
+    /// in-wizard "existing configuration" warning agree.
+    /// </summary>
+    public static bool HasAnyOperatorDeviceToken(string dataPath)
+    {
+        if (DeviceIdentity.HasStoredDeviceToken(dataPath, NullLogger.Instance))
+        {
+            return true;
+        }
+
+        var gatewaysDir = Path.Combine(dataPath, "gateways");
+        if (!Directory.Exists(gatewaysDir))
+        {
+            return false;
+        }
+
+        try
+        {
+            foreach (var dir in Directory.EnumerateDirectories(gatewaysDir))
+            {
+                if (DeviceIdentity.HasStoredDeviceToken(dir, NullLogger.Instance))
+                {
+                    return true;
+                }
+            }
+        }
+        catch (Exception)
+        {
+            // Best-effort scan — IO/permission failure should not silently allow
+            // the wizard to be skipped, so fall through to "no usable token".
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/Onboarding/Services/OnboardingExistingConfigGuard.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/Services/OnboardingExistingConfigGuard.cs
@@ -13,7 +13,13 @@ namespace OpenClawTray.Onboarding.Services;
 /// </summary>
 public sealed class OnboardingExistingConfigGuard
 {
-    private const string DefaultGatewayUrl = "ws://localhost:18789";
+    /// <summary>
+    /// Default loopback gateway URL. Single source of truth — also referenced by
+    /// <c>StartupSetupState.HasNonDefaultGatewayUrl</c>. If you change this, the
+    /// invariant test <c>StartupSetupStateTests.DefaultGatewayUrl_MatchesGuardConstant</c>
+    /// will catch drift.
+    /// </summary>
+    public const string DefaultGatewayUrl = "ws://localhost:18789";
     private readonly SettingsManager _settings;
     private readonly string _identityDataPath;
     private readonly string _setupStatePath;

--- a/src/OpenClaw.Tray.WinUI/Onboarding/Services/OnboardingState.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/Services/OnboardingState.cs
@@ -24,13 +24,19 @@ public sealed class OnboardingState : IDisposable
 
     /// <summary>
     /// Raises <see cref="Dismissed"/>. Called by pages that offer a "keep my existing
-    /// setup and exit the wizard" option.
+    /// setup and exit the wizard" option. Idempotent — subsequent calls are no-ops
+    /// so a double-click or repeated handler invocation cannot fire the lifecycle
+    /// signal twice.
     /// </summary>
     public void Dismiss()
     {
+        if (_dismissed) return;
+        _dismissed = true;
         OpenClawTray.Services.Logger.Info("[OnboardingState] Dismiss invoked (user chose to keep existing setup)");
         Dismissed?.Invoke(this, EventArgs.Empty);
     }
+
+    private bool _dismissed;
 
     /// <summary>
     /// The currently displayed route. Updated by OnboardingApp on navigation.

--- a/src/OpenClaw.Tray.WinUI/Onboarding/Services/OnboardingState.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/Services/OnboardingState.cs
@@ -14,6 +14,25 @@ public sealed class OnboardingState : IDisposable
     public event EventHandler? PageChanged;
 
     /// <summary>
+    /// Raised when the user explicitly dismisses the wizard without completing it
+    /// (e.g., clicks "Keep my setup" on the SetupWarning page when existing config
+    /// is present). <see cref="OnboardingWindow"/> handles this by closing the
+    /// window without firing <see cref="Finished"/> or running the "complete
+    /// onboarding" pipeline — existing settings and gateway connection are preserved.
+    /// </summary>
+    public event EventHandler? Dismissed;
+
+    /// <summary>
+    /// Raises <see cref="Dismissed"/>. Called by pages that offer a "keep my existing
+    /// setup and exit the wizard" option.
+    /// </summary>
+    public void Dismiss()
+    {
+        OpenClawTray.Services.Logger.Info("[OnboardingState] Dismiss invoked (user chose to keep existing setup)");
+        Dismissed?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
     /// The currently displayed route. Updated by OnboardingApp on navigation.
     /// </summary>
     public OnboardingRoute CurrentRoute { get; set; } = OnboardingRoute.SetupWarning;

--- a/src/OpenClaw.Tray.WinUI/Services/StartupSetupState.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/StartupSetupState.cs
@@ -4,8 +4,29 @@ namespace OpenClawTray.Services;
 
 internal static class StartupSetupState
 {
+    /// <summary>
+    /// Default loopback gateway URL. Matches <c>OnboardingExistingConfigGuard.DefaultGatewayUrl</c>;
+    /// kept in sync intentionally so both startup and onboarding decisions use the same signal
+    /// for "user has a real (non-default) gateway target configured".
+    /// </summary>
+    private const string DefaultGatewayUrl = "ws://localhost:18789";
+
     public static bool HasStoredNodeDeviceToken(string dataPath) =>
         DeviceIdentity.HasStoredDeviceTokenForRole(dataPath, "node", NullLogger.Instance);
+
+    /// <summary>
+    /// True if the user has previously paired this device as an operator
+    /// (root device token present) AND has a non-default gateway URL configured.
+    /// Both signals together indicate a working operator config — guards against
+    /// orphan tokens or default-URL-only configs that wouldn't actually connect.
+    /// </summary>
+    public static bool HasUsableOperatorConfiguration(SettingsManager settings, string dataPath) =>
+        DeviceIdentity.HasStoredDeviceToken(dataPath, NullLogger.Instance)
+        && HasNonDefaultGatewayUrl(settings);
+
+    private static bool HasNonDefaultGatewayUrl(SettingsManager settings) =>
+        !string.IsNullOrWhiteSpace(settings.GatewayUrl)
+        && !string.Equals(settings.GatewayUrl, DefaultGatewayUrl, StringComparison.OrdinalIgnoreCase);
 
     public static bool CanStartNodeGateway(SettingsManager settings, string dataPath)
     {
@@ -19,11 +40,27 @@ internal static class StartupSetupState
 
     public static bool RequiresSetup(SettingsManager settings, string dataPath)
     {
-        if (settings.EnableNodeMode && HasStoredNodeDeviceToken(dataPath))
+        // Node mode: needs a paired node device token to operate.
+        if (settings.EnableNodeMode)
+        {
+            return !HasStoredNodeDeviceToken(dataPath);
+        }
+
+        // MCP-only mode doesn't require an authenticated gateway.
+        if (settings.EnableMcpServer)
         {
             return false;
         }
 
-        return !settings.EnableMcpServer;
+        // Operator mode: returning users with a stored operator device token AND
+        // a non-default gateway URL already have a working configuration — don't
+        // auto-launch the wizard (Scott Hanselman repro: remote-gateway operator
+        // saw the wizard pop on every launch).
+        if (HasUsableOperatorConfiguration(settings, dataPath))
+        {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Services/StartupSetupState.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/StartupSetupState.cs
@@ -13,48 +13,13 @@ internal static class StartupSetupState
     /// AND a configured gateway target (non-default <c>GatewayUrl</c> or an SSH tunnel
     /// host). Both signals together indicate a working operator config — guards
     /// against orphan tokens and against tokens-without-target stale state.
+    /// Token detection delegates to
+    /// <see cref="OnboardingExistingConfigGuard.HasAnyOperatorDeviceToken"/> so the
+    /// startup decision and the in-wizard guard agree on what counts as paired.
     /// </summary>
     public static bool HasUsableOperatorConfiguration(SettingsManager settings, string dataPath) =>
-        HasAnyOperatorDeviceToken(dataPath) && HasAnyConfiguredGatewayTarget(settings);
-
-    /// <summary>
-    /// Scans the legacy root identity AND per-gateway identity directories for an
-    /// operator device token. Modern pairings (post-GatewayRegistry) write tokens
-    /// to <c>&lt;dataPath&gt;/gateways/&lt;gatewayId&gt;/device-key-ed25519.json</c>
-    /// via <c>DeviceIdentityStore</c>; the legacy root file is kept by migration
-    /// but is NOT created by fresh pairings.
-    /// </summary>
-    internal static bool HasAnyOperatorDeviceToken(string dataPath)
-    {
-        if (DeviceIdentity.HasStoredDeviceToken(dataPath, NullLogger.Instance))
-        {
-            return true;
-        }
-
-        var gatewaysDir = Path.Combine(dataPath, "gateways");
-        if (!Directory.Exists(gatewaysDir))
-        {
-            return false;
-        }
-
-        try
-        {
-            foreach (var dir in Directory.EnumerateDirectories(gatewaysDir))
-            {
-                if (DeviceIdentity.HasStoredDeviceToken(dir, NullLogger.Instance))
-                {
-                    return true;
-                }
-            }
-        }
-        catch (Exception)
-        {
-            // Best-effort scan — IO/permission failure should not silently allow
-            // the wizard to be skipped, so fall through to "no usable token".
-        }
-
-        return false;
-    }
+        OnboardingExistingConfigGuard.HasAnyOperatorDeviceToken(dataPath)
+        && HasAnyConfiguredGatewayTarget(settings);
 
     /// <summary>
     /// True when the user has configured an actual gateway target — either a

--- a/src/OpenClaw.Tray.WinUI/Services/StartupSetupState.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/StartupSetupState.cs
@@ -1,32 +1,82 @@
 using OpenClaw.Shared;
+using OpenClawTray.Onboarding.Services;
 
 namespace OpenClawTray.Services;
 
 internal static class StartupSetupState
 {
-    /// <summary>
-    /// Default loopback gateway URL. Matches <c>OnboardingExistingConfigGuard.DefaultGatewayUrl</c>;
-    /// kept in sync intentionally so both startup and onboarding decisions use the same signal
-    /// for "user has a real (non-default) gateway target configured".
-    /// </summary>
-    private const string DefaultGatewayUrl = "ws://localhost:18789";
-
     public static bool HasStoredNodeDeviceToken(string dataPath) =>
         DeviceIdentity.HasStoredDeviceTokenForRole(dataPath, "node", NullLogger.Instance);
 
     /// <summary>
-    /// True if the user has previously paired this device as an operator
-    /// (root device token present) AND has a non-default gateway URL configured.
-    /// Both signals together indicate a working operator config — guards against
-    /// orphan tokens or default-URL-only configs that wouldn't actually connect.
+    /// True if the user has an operator device token (root or any per-gateway dir)
+    /// AND a configured gateway target (non-default <c>GatewayUrl</c> or an SSH tunnel
+    /// host). Both signals together indicate a working operator config — guards
+    /// against orphan tokens and against tokens-without-target stale state.
     /// </summary>
     public static bool HasUsableOperatorConfiguration(SettingsManager settings, string dataPath) =>
-        DeviceIdentity.HasStoredDeviceToken(dataPath, NullLogger.Instance)
-        && HasNonDefaultGatewayUrl(settings);
+        HasAnyOperatorDeviceToken(dataPath) && HasAnyConfiguredGatewayTarget(settings);
+
+    /// <summary>
+    /// Scans the legacy root identity AND per-gateway identity directories for an
+    /// operator device token. Modern pairings (post-GatewayRegistry) write tokens
+    /// to <c>&lt;dataPath&gt;/gateways/&lt;gatewayId&gt;/device-key-ed25519.json</c>
+    /// via <c>DeviceIdentityStore</c>; the legacy root file is kept by migration
+    /// but is NOT created by fresh pairings.
+    /// </summary>
+    internal static bool HasAnyOperatorDeviceToken(string dataPath)
+    {
+        if (DeviceIdentity.HasStoredDeviceToken(dataPath, NullLogger.Instance))
+        {
+            return true;
+        }
+
+        var gatewaysDir = Path.Combine(dataPath, "gateways");
+        if (!Directory.Exists(gatewaysDir))
+        {
+            return false;
+        }
+
+        try
+        {
+            foreach (var dir in Directory.EnumerateDirectories(gatewaysDir))
+            {
+                if (DeviceIdentity.HasStoredDeviceToken(dir, NullLogger.Instance))
+                {
+                    return true;
+                }
+            }
+        }
+        catch (Exception)
+        {
+            // Best-effort scan — IO/permission failure should not silently allow
+            // the wizard to be skipped, so fall through to "no usable token".
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// True when the user has configured an actual gateway target — either a
+    /// non-default <c>GatewayUrl</c> or an SSH tunnel host (which routes via
+    /// <c>ws://127.0.0.1:LocalPort</c> and would otherwise look "default").
+    /// </summary>
+    internal static bool HasAnyConfiguredGatewayTarget(SettingsManager settings)
+    {
+        if (settings.UseSshTunnel && !string.IsNullOrWhiteSpace(settings.SshTunnelHost))
+        {
+            return true;
+        }
+
+        return HasNonDefaultGatewayUrl(settings);
+    }
 
     private static bool HasNonDefaultGatewayUrl(SettingsManager settings) =>
         !string.IsNullOrWhiteSpace(settings.GatewayUrl)
-        && !string.Equals(settings.GatewayUrl, DefaultGatewayUrl, StringComparison.OrdinalIgnoreCase);
+        && !string.Equals(
+            settings.GatewayUrl,
+            OnboardingExistingConfigGuard.DefaultGatewayUrl,
+            StringComparison.OrdinalIgnoreCase);
 
     public static bool CanStartNodeGateway(SettingsManager settings, string dataPath)
     {
@@ -40,22 +90,25 @@ internal static class StartupSetupState
 
     public static bool RequiresSetup(SettingsManager settings, string dataPath)
     {
-        // Node mode: needs a paired node device token to operate.
-        if (settings.EnableNodeMode)
-        {
-            return !HasStoredNodeDeviceToken(dataPath);
-        }
-
-        // MCP-only mode doesn't require an authenticated gateway.
+        // MCP-only mode doesn't require an authenticated gateway. Checked first
+        // so that an MCP-server user with EnableNodeMode accidentally left on
+        // (but no node token) still bypasses the wizard — preserves the
+        // original "MCP wins" precedence.
         if (settings.EnableMcpServer)
         {
             return false;
         }
 
-        // Operator mode: returning users with a stored operator device token AND
-        // a non-default gateway URL already have a working configuration — don't
-        // auto-launch the wizard (Scott Hanselman repro: remote-gateway operator
-        // saw the wizard pop on every launch).
+        // Node mode: needs a paired node device token to operate as a node.
+        if (settings.EnableNodeMode)
+        {
+            return !HasStoredNodeDeviceToken(dataPath);
+        }
+
+        // Operator mode: returning users with any operator device token AND a
+        // configured gateway target already have a working configuration —
+        // don't auto-launch the wizard (Scott Hanselman repro: remote-gateway
+        // operator saw the wizard pop on every launch).
         if (HasUsableOperatorConfiguration(settings, dataPath))
         {
             return false;

--- a/tests/OpenClaw.Tray.Tests/OnboardingExistingConfigGuardTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OnboardingExistingConfigGuardTests.cs
@@ -31,6 +31,31 @@ public class OnboardingExistingConfigGuardTests
     }
 
     [Fact]
+    public void HasExistingConfiguration_ReturnsTrue_WhenOperatorTokenStoredOnlyInPerGatewayDir()
+    {
+        // Modern pairings (post-GatewayRegistry) store the operator device token
+        // at <dataPath>/gateways/<gatewayId>/device-key-ed25519.json via
+        // DeviceIdentityStore. The legacy root file is NOT written for fresh
+        // pairings, so the guard MUST scan per-gateway directories — otherwise
+        // a returning user opening Setup/Reconfigure would not see the
+        // "Replace my setup / Keep my setup" warning and could overwrite a
+        // working config (Hanselman PR #340 review feedback).
+        using var temp = new TempDir();
+        var perGatewayDir = Path.Combine(temp.Path, "gateways", "gw-abc");
+        Directory.CreateDirectory(perGatewayDir);
+        var identity = new DeviceIdentity(perGatewayDir);
+        identity.Initialize();
+        identity.StoreDeviceToken("per-gateway-operator-token");
+        var settings = new SettingsManager(temp.Path);
+        var guard = new OnboardingExistingConfigGuard(settings, temp.Path, temp.StatePath);
+
+        var summary = guard.GetSummary();
+        Assert.True(summary.HasOperatorDeviceToken);
+        Assert.True(summary.HasAny);
+        Assert.True(guard.HasExistingConfiguration());
+    }
+
+    [Fact]
     public void HasExistingConfiguration_ReturnsTrue_WhenNodeDeviceTokenExists()
     {
         using var temp = new TempDir();

--- a/tests/OpenClaw.Tray.Tests/OnboardingStateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OnboardingStateTests.cs
@@ -339,6 +339,22 @@ public class OnboardingStateTests
     }
 
     [Fact]
+    public void Dismiss_IsIdempotent_FiresDismissedAtMostOnce()
+    {
+        // Hardening: lifecycle signal must not fire twice if a page accidentally
+        // calls Dismiss again (e.g., double-click or repeated handler invocation).
+        var state = CreateState();
+        var count = 0;
+        state.Dismissed += (_, _) => count++;
+
+        state.Dismiss();
+        state.Dismiss();
+        state.Dismiss();
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
     public void Dismiss_DoesNotFireFinishedEvent()
     {
         // "Keep my setup" must NOT route through the completion pipeline —

--- a/tests/OpenClaw.Tray.Tests/OnboardingStateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OnboardingStateTests.cs
@@ -324,6 +324,45 @@ public class OnboardingStateTests
 
     #endregion
 
+    #region Dismiss
+
+    [Fact]
+    public void Dismiss_FiresDismissedEvent()
+    {
+        var state = CreateState();
+        var fired = false;
+        state.Dismissed += (_, _) => fired = true;
+
+        state.Dismiss();
+
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public void Dismiss_DoesNotFireFinishedEvent()
+    {
+        // "Keep my setup" must NOT route through the completion pipeline —
+        // OnboardingWindow relies on Finished being unraised so it skips
+        // TryCompleteOnboarding and leaves prior settings/connection untouched.
+        var state = CreateState();
+        var finished = false;
+        state.Finished += (_, _) => finished = true;
+
+        state.Dismiss();
+
+        Assert.False(finished);
+    }
+
+    [Fact]
+    public void Dismiss_DoesNotThrow_WithoutHandler()
+    {
+        var state = CreateState();
+        var ex = Record.Exception(() => state.Dismiss());
+        Assert.Null(ex);
+    }
+
+    #endregion
+
     #region NotifyRouteChanged
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/StartupSetupStateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/StartupSetupStateTests.cs
@@ -91,6 +91,79 @@ public class StartupSetupStateTests
         Assert.False(StartupSetupState.HasUsableOperatorConfiguration(settings, temp.Path));
     }
 
+    [Fact]
+    public void RequiresSetup_ReturnsFalse_WhenSshTunnelConfiguredWithStoredToken()
+    {
+        // SSH topology routes via ws://127.0.0.1:LocalPort so the user keeps
+        // GatewayUrl at default. Detection must treat (UseSshTunnel + host) as
+        // a configured target so SSH operators are not re-prompted at launch.
+        using var temp = TempSettings.Create();
+        StoreDeviceToken(temp.Path);
+        var settings = new SettingsManager(temp.Path)
+        {
+            UseSshTunnel = true,
+            SshTunnelHost = "ssh.example.com",
+            SshTunnelUser = "ops",
+        };
+
+        Assert.False(StartupSetupState.RequiresSetup(settings, temp.Path));
+    }
+
+    [Fact]
+    public void RequiresSetup_ReturnsTrue_WhenSshTunnelEnabledButNoHostConfigured()
+    {
+        using var temp = TempSettings.Create();
+        StoreDeviceToken(temp.Path);
+        var settings = new SettingsManager(temp.Path) { UseSshTunnel = true };
+
+        Assert.True(StartupSetupState.RequiresSetup(settings, temp.Path));
+    }
+
+    [Fact]
+    public void RequiresSetup_ReturnsFalse_WhenOperatorTokenStoredOnlyInPerGatewayDir()
+    {
+        // Modern pairings (post-GatewayRegistry) store device tokens in
+        // <dataPath>/gateways/<gatewayId>/device-key-ed25519.json via
+        // DeviceIdentityStore. The legacy root file is NOT created for fresh
+        // pairings, so RequiresSetup must scan the per-gateway directories.
+        using var temp = TempSettings.Create();
+        var perGatewayDir = Path.Combine(temp.Path, "gateways", "gw-abc");
+        Directory.CreateDirectory(perGatewayDir);
+        StoreDeviceToken(perGatewayDir);
+        var settings = new SettingsManager(temp.Path) { GatewayUrl = "wss://remote.example.com:443" };
+
+        Assert.False(StartupSetupState.RequiresSetup(settings, temp.Path));
+    }
+
+    [Fact]
+    public void RequiresSetup_ReturnsFalse_WhenMcpEnabledEvenWithNodeModeAndNoNodeToken()
+    {
+        // Regression guard: the original code returned !EnableMcpServer as the
+        // fallback so MCP-only mode bypassed onboarding even when EnableNodeMode
+        // was accidentally true with no node token. The new ordering must
+        // preserve "MCP wins" precedence.
+        using var temp = TempSettings.Create();
+        var settings = new SettingsManager(temp.Path)
+        {
+            EnableNodeMode = true,
+            EnableMcpServer = true,
+        };
+
+        Assert.False(StartupSetupState.RequiresSetup(settings, temp.Path));
+    }
+
+    [Fact]
+    public void DefaultGatewayUrl_MatchesGuardConstant()
+    {
+        // OnboardingExistingConfigGuard.DefaultGatewayUrl is the single source
+        // of truth referenced by StartupSetupState.HasNonDefaultGatewayUrl.
+        // This test exists so a future change to the constant (or a refactor
+        // that re-introduces a duplicate) is caught immediately.
+        Assert.Equal(
+            "ws://localhost:18789",
+            OpenClawTray.Onboarding.Services.OnboardingExistingConfigGuard.DefaultGatewayUrl);
+    }
+
     private static void StoreDeviceToken(string dataPath)
     {
         var identity = new DeviceIdentity(dataPath);

--- a/tests/OpenClaw.Tray.Tests/StartupSetupStateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/StartupSetupStateTests.cs
@@ -46,6 +46,51 @@ public class StartupSetupStateTests
         Assert.False(StartupSetupState.CanStartNodeGateway(settings, temp.Path));
     }
 
+    [Fact]
+    public void RequiresSetup_ReturnsFalse_WhenOperatorPairedWithRemoteGateway()
+    {
+        // Scott Hanselman repro: operator mode with a non-default (remote) gateway URL
+        // and a stored operator device token — wizard must NOT auto-launch on next start.
+        using var temp = TempSettings.Create();
+        StoreDeviceToken(temp.Path);
+        var settings = new SettingsManager(temp.Path) { GatewayUrl = "wss://remote.example.com:443" };
+
+        Assert.False(StartupSetupState.RequiresSetup(settings, temp.Path));
+    }
+
+    [Fact]
+    public void RequiresSetup_ReturnsTrue_WhenOperatorTokenExistsButGatewayUrlIsDefault()
+    {
+        // Stale-token guard: a stored operator token alone is not enough. Without a
+        // configured non-default gateway URL the app has no target to connect to,
+        // so first-run setup should still be offered.
+        using var temp = TempSettings.Create();
+        StoreDeviceToken(temp.Path);
+        var settings = new SettingsManager(temp.Path) { GatewayUrl = "ws://localhost:18789" };
+
+        Assert.True(StartupSetupState.RequiresSetup(settings, temp.Path));
+    }
+
+    [Fact]
+    public void RequiresSetup_ReturnsTrue_WhenNonDefaultGatewayUrlButNoOperatorToken()
+    {
+        // Inverse guard: a non-default URL alone (no pairing yet) still needs setup.
+        using var temp = TempSettings.Create();
+        var settings = new SettingsManager(temp.Path) { GatewayUrl = "wss://remote.example.com:443" };
+
+        Assert.True(StartupSetupState.RequiresSetup(settings, temp.Path));
+    }
+
+    [Fact]
+    public void HasUsableOperatorConfiguration_ReturnsFalse_WhenGatewayUrlIsNullOrWhitespace()
+    {
+        using var temp = TempSettings.Create();
+        StoreDeviceToken(temp.Path);
+        var settings = new SettingsManager(temp.Path) { GatewayUrl = "   " };
+
+        Assert.False(StartupSetupState.HasUsableOperatorConfiguration(settings, temp.Path));
+    }
+
     private static void StoreDeviceToken(string dataPath)
     {
         var identity = new DeviceIdentity(dataPath);


### PR DESCRIPTION
Reported by @shanselman against latest master:

1. **Tray app pops the onboarding wizard at launch** even though there is already a working configuration with a connection to a remote gateway.
2. **"Keep my setup" doesn't keep the setup** — clicking it on the warn-and-confirm UI doesn't dismiss the wizard; the user can still advance into setup via the global Next button.

## Root cause

1. `StartupSetupState.RequiresSetup` only short-circuited for node mode (`EnableNodeMode + node device token`) or MCP-only mode. An operator with a non-default gateway URL + stored device token still got the wizard popped at `OnLaunched`.
2. `SetupWarningPage.CancelReplace` only toggled in-page state. Worse, `OnboardingWindow` defaulted `SetupPath = SetupPath.Advanced` whenever existing config was detected, so the global nav-bar Next button stayed enabled and the user was one click from advancing into `ConnectionPage`.

## Fix (commit b3b5b2f)

- New operator-mode short-circuit in `StartupSetupState.RequiresSetup`: returning users with both an operator device token and a configured gateway target skip the wizard.
- New `OnboardingState.Dismiss()` / `Dismissed` event. `OnboardingWindow` listens, sets a `_dismissedWithoutCompletion` guard, and `Close()`s — `OnClosed` skips `TryCompleteOnboarding` when guarded so `OnboardingCompleted` does NOT fire and existing settings/gateway connection are preserved.
- `SetupWarningPage.CancelReplace` calls `Props.Dismiss()`.
- Belt-and-suspenders: dropped the auto-default of `SetupPath = SetupPath.Advanced` in `OnboardingWindow`. With `SetupPath` left null, the global Next button is disabled on SetupWarning, so the user MUST pick **Replace my setup**, **Keep my setup**, or **Advanced setup** explicitly.

## Adversarial review fixes (commit 8338c5d)

Ran a Hanselman-style dual-model review (Claude Opus + GPT Codex) before sending. The two models surfaced complementary issues; all six actionable findings are folded in:

| Finding | Source | Resolution |
|---|---|---|
| Per-gateway tokens missed (`gateways/<id>/device-key-ed25519.json`) | Codex HIGH | Scan added in `HasAnyOperatorDeviceToken` |
| SSH-tunnel users falsely re-prompted (loopback URL) | Codex HIGH | `UseSshTunnel + SshTunnelHost` counted as a configured target |
| MCP precedence regression (`NodeMode=true + MCP=true + no node token`) | Codex MEDIUM | MCP check moved before NodeMode |
| `Close()` exception left `_dismissedWithoutCompletion=true` permanently | Opus MEDIUM | Flag reset in catch block |
| `DefaultGatewayUrl` duplicated across two files | Opus HIGH | Promoted to `OnboardingExistingConfigGuard.DefaultGatewayUrl` (public const) + invariant test |
| `CancelReplace` UI flash from dead `setConfirmingReplace(false)` | Opus MEDIUM | Removed |

## Tests added

- `StartupSetupStateTests`: operator paired with remote returns false; operator+default URL still requires setup; non-default URL alone still requires setup; null/whitespace URL; SSH tunnel + token; SSH enabled but no host; per-gateway-only token; MCP+NodeMode+no node token bypass; `DefaultGatewayUrl_MatchesGuardConstant` invariant.
- `OnboardingStateTests`: `Dismiss` fires `Dismissed`; does NOT fire `Finished`; safe with no handler.

## Validation

- `./build.ps1` ✅
- `OpenClaw.Shared.Tests`: 1548 passed, 28 skipped
- `OpenClaw.Tray.Tests`: 1180 passed (+5 new)

cc @shanselman — please give it a look when you can.
