### PR TITLE
Fix startup setup check for per-gateway node tokens

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Onboarding/Services/OnboardingExistingConfigGuard.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/Services/OnboardingExistingConfigGuard.cs
@@ -57,7 +57,7 @@ public sealed class OnboardingExistingConfigGuard
             HasNonDefaultGatewayUrl: !string.IsNullOrWhiteSpace(_settings.GatewayUrl)
                 && !string.Equals(_settings.GatewayUrl, DefaultGatewayUrl, StringComparison.OrdinalIgnoreCase),
             HasOperatorDeviceToken: HasAnyOperatorDeviceToken(_identityDataPath),
-            HasNodeDeviceToken: DeviceIdentity.HasStoredDeviceTokenForRole(_identityDataPath, "node"),
+            HasNodeDeviceToken: HasAnyDeviceTokenForRole(_identityDataPath, "node"),
             HasCompletedOrRunningSetupState: ReadSetupStateIsActive(_setupStatePath),
             HasWslDistro: false);
     }
@@ -71,9 +71,16 @@ public sealed class OnboardingExistingConfigGuard
     /// <c>StartupSetupState</c> so the startup auto-launch decision and the
     /// in-wizard "existing configuration" warning agree.
     /// </summary>
-    public static bool HasAnyOperatorDeviceToken(string dataPath)
+    public static bool HasAnyOperatorDeviceToken(string dataPath) =>
+        HasAnyDeviceTokenForRole(dataPath, "operator");
+
+    /// <summary>
+    /// Scans both the legacy root identity and per-gateway identity directories
+    /// for a device token for the specified role.
+    /// </summary>
+    public static bool HasAnyDeviceTokenForRole(string dataPath, string role)
     {
-        if (DeviceIdentity.HasStoredDeviceToken(dataPath, NullLogger.Instance))
+        if (DeviceIdentity.HasStoredDeviceTokenForRole(dataPath, role, NullLogger.Instance))
         {
             return true;
         }
@@ -88,7 +95,7 @@ public sealed class OnboardingExistingConfigGuard
         {
             foreach (var dir in Directory.EnumerateDirectories(gatewaysDir))
             {
-                if (DeviceIdentity.HasStoredDeviceToken(dir, NullLogger.Instance))
+                if (DeviceIdentity.HasStoredDeviceTokenForRole(dir, role, NullLogger.Instance))
                 {
                     return true;
                 }

--- a/src/OpenClaw.Tray.WinUI/Services/StartupSetupState.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/StartupSetupState.cs
@@ -6,7 +6,7 @@ namespace OpenClawTray.Services;
 internal static class StartupSetupState
 {
     public static bool HasStoredNodeDeviceToken(string dataPath) =>
-        DeviceIdentity.HasStoredDeviceTokenForRole(dataPath, "node", NullLogger.Instance);
+        OnboardingExistingConfigGuard.HasAnyDeviceTokenForRole(dataPath, "node");
 
     /// <summary>
     /// True if the user has an operator device token (root or any per-gateway dir)

--- a/tests/OpenClaw.Tray.Tests/OnboardingExistingConfigGuardTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OnboardingExistingConfigGuardTests.cs
@@ -69,6 +69,24 @@ public class OnboardingExistingConfigGuardTests
     }
 
     [Fact]
+    public void HasExistingConfiguration_ReturnsTrue_WhenNodeTokenStoredOnlyInPerGatewayDir()
+    {
+        using var temp = new TempDir();
+        var perGatewayDir = Path.Combine(temp.Path, "gateways", "gw-node");
+        Directory.CreateDirectory(perGatewayDir);
+        var identity = new DeviceIdentity(perGatewayDir);
+        identity.Initialize();
+        identity.StoreDeviceTokenForRole("node", "per-gateway-node-token");
+        var settings = new SettingsManager(temp.Path);
+        var guard = new OnboardingExistingConfigGuard(settings, temp.Path, temp.StatePath);
+
+        var summary = guard.GetSummary();
+        Assert.True(summary.HasNodeDeviceToken);
+        Assert.True(summary.HasAny);
+        Assert.True(guard.HasExistingConfiguration());
+    }
+
+    [Fact]
     public void HasExistingConfiguration_ReturnsTrue_WhenGatewayUrlIsNonDefault()
     {
         using var temp = new TempDir();

--- a/tests/OpenClaw.Tray.Tests/StartupSetupStateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/StartupSetupStateTests.cs
@@ -17,6 +17,19 @@ public class StartupSetupStateTests
     }
 
     [Fact]
+    public void RequiresSetup_ReturnsFalse_WhenNodeTokenStoredOnlyInPerGatewayDir()
+    {
+        using var temp = TempSettings.Create();
+        var perGatewayDir = Path.Combine(temp.Path, "gateways", "gw-node");
+        Directory.CreateDirectory(perGatewayDir);
+        StoreNodeDeviceToken(perGatewayDir);
+        var settings = new SettingsManager(temp.Path) { EnableNodeMode = true };
+
+        Assert.False(StartupSetupState.RequiresSetup(settings, temp.Path));
+        Assert.True(StartupSetupState.CanStartNodeGateway(settings, temp.Path));
+    }
+
+    [Fact]
     public void RequiresSetup_ReturnsTrue_WhenOnlyOperatorTokenExistsForNodeMode()
     {
         using var temp = TempSettings.Create();


### PR DESCRIPTION
## Summary
- fixes node-mode startup setup detection when the node device token is stored only under `gateways/<gateway-id>/device-key-ed25519.json`
- reuses the per-gateway identity scan for both operator and node token roles
- adds regression coverage for the startup gate and existing-config guard

## Repro evidence
After #340, clicking **Keep my setup** closed the onboarding window, but a full exit + relaunch still reopened setup for a local node-mode profile with:
- `EnableNodeMode=true`
- root identity missing `NodeDeviceToken`
- per-gateway identity containing `NodeDeviceToken`

Sanitized log evidence from the broken run:
```text
[OnboardingState] Dismiss invoked (user chose to keep existing setup)
[OnboardingWindow] Dismissed by user (keep-existing-setup) — closing without completing
...
[OnboardingWindow] OnWizardComplete skipping chat launch; route=SetupWarning, setupStillRequired=True
```

After this fix and x64 rebuild, relaunch no longer opens onboarding; the post-launch log only shows normal gateway/node connection:
```text
Connecting to last successful gateway during startup: ws://localhost:18789 (identity.DeviceToken)
Connecting to node: ws://localhost:18789
[HANDSHAKE]   isBootstrap=False, hasNodeDeviceToken=True
Node registered successfully! ID: c340a12b10f1dacb
```

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — 1548 passed, 28 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — 1180 passed