### PR TITLE
refactor(tray): extract TrayTooltipBuilder from App.xaml.cs

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3294,45 +3294,20 @@ public partial class App : Application
         _trayIcon.Tooltip = tooltip;
     }
 
-    private string BuildTrayTooltip()
+    private string BuildTrayTooltip() =>
+        new TrayTooltipBuilder(CaptureTraySnapshot()).Build();
+
+    private TrayStateSnapshot CaptureTraySnapshot() => new TrayStateSnapshot
     {
-        var topology = GatewayTopologyClassifier.Classify(
-            _settings?.GatewayUrl,
-            _settings?.UseSshTunnel == true,
-            _settings?.SshTunnelHost,
-            _settings?.SshTunnelLocalPort ?? 0,
-            _settings?.SshTunnelRemotePort ?? 0);
-        var channelReady = _lastChannels.Count(c => ChannelHealth.IsHealthyStatus(c.Status));
-        var nodeOnline = _lastNodes.Count(n => n.IsOnline);
-        var nodeTotal = _lastNodes.Length;
-        if (nodeTotal == 0 && _nodeService?.GetLocalNodeInfo() is { } localNode)
-        {
-            nodeTotal = 1;
-            nodeOnline = localNode.IsOnline ? 1 : 0;
-        }
-
-        var warningCount = 0;
-        if (_currentStatus != ConnectionStatus.Connected)
-            warningCount++;
-        if (_authFailureMessage != null)
-            warningCount++;
-        if (_lastChannels.Length == 0 && _currentStatus == ConnectionStatus.Connected)
-            warningCount++;
-
-        var tooltip = $"OpenClaw Tray - {_currentStatus}; " +
-            $"{topology.DisplayName}; " +
-            $"Channels {channelReady}/{_lastChannels.Length}; " +
-            $"Nodes {nodeOnline}/{nodeTotal}; " +
-            $"Warnings {warningCount}; " +
-            $"Last {_lastCheckTime:HH:mm:ss}";
-
-        if (_currentActivity != null && !string.IsNullOrEmpty(_currentActivity.DisplayText))
-        {
-            tooltip = $"OpenClaw Tray - {_currentActivity.DisplayText}; {_currentStatus}";
-        }
-
-        return TrayTooltipFormatter.FitShellTooltip(tooltip);
-    }
+        Status = _currentStatus,
+        CurrentActivity = _currentActivity,
+        Channels = _lastChannels,
+        Nodes = _lastNodes,
+        LocalNodeFallback = _nodeService?.GetLocalNodeInfo(),
+        AuthFailureMessage = _authFailureMessage,
+        LastCheckTime = _lastCheckTime,
+        Settings = _settings
+    };
 
     #endregion
 

--- a/src/OpenClaw.Tray.WinUI/Services/TrayStateSnapshot.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/TrayStateSnapshot.cs
@@ -1,0 +1,16 @@
+using OpenClaw.Shared;
+using System;
+
+namespace OpenClawTray.Services;
+
+internal sealed record TrayStateSnapshot
+{
+    public ConnectionStatus Status             { get; init; }
+    public AgentActivity? CurrentActivity      { get; init; }
+    public ChannelHealth[] Channels            { get; init; } = [];
+    public GatewayNodeInfo[] Nodes             { get; init; } = [];
+    public GatewayNodeInfo? LocalNodeFallback  { get; init; }
+    public string? AuthFailureMessage          { get; init; }
+    public DateTime LastCheckTime              { get; init; }
+    public SettingsManager? Settings           { get; init; }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/TrayTooltipBuilder.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/TrayTooltipBuilder.cs
@@ -1,0 +1,53 @@
+using OpenClaw.Shared;
+using OpenClawTray.Helpers;
+using System.Linq;
+
+namespace OpenClawTray.Services;
+
+internal sealed class TrayTooltipBuilder
+{
+    private readonly TrayStateSnapshot _snapshot;
+
+    internal TrayTooltipBuilder(TrayStateSnapshot snapshot)
+    {
+        _snapshot = snapshot;
+    }
+
+    internal string Build()
+    {
+        var topology = GatewayTopologyClassifier.Classify(
+            _snapshot.Settings?.GatewayUrl,
+            _snapshot.Settings?.UseSshTunnel == true,
+            _snapshot.Settings?.SshTunnelHost,
+            _snapshot.Settings?.SshTunnelLocalPort ?? 0,
+            _snapshot.Settings?.SshTunnelRemotePort ?? 0);
+
+        var channelReady = _snapshot.Channels.Count(c => ChannelHealth.IsHealthyStatus(c.Status));
+        var nodeOnline = _snapshot.Nodes.Count(n => n.IsOnline);
+        var nodeTotal = _snapshot.Nodes.Length;
+        if (nodeTotal == 0 && _snapshot.LocalNodeFallback is { } localNode)
+        {
+            nodeTotal = 1;
+            nodeOnline = localNode.IsOnline ? 1 : 0;
+        }
+
+        var warningCount = 0;
+        if (_snapshot.Status != ConnectionStatus.Connected) warningCount++;
+        if (_snapshot.AuthFailureMessage != null) warningCount++;
+        if (_snapshot.Channels.Length == 0 && _snapshot.Status == ConnectionStatus.Connected) warningCount++;
+
+        var tooltip = $"OpenClaw Tray - {_snapshot.Status}; " +
+            $"{topology.DisplayName}; " +
+            $"Channels {channelReady}/{_snapshot.Channels.Length}; " +
+            $"Nodes {nodeOnline}/{nodeTotal}; " +
+            $"Warnings {warningCount}; " +
+            $"Last {_snapshot.LastCheckTime:HH:mm:ss}";
+
+        if (_snapshot.CurrentActivity != null && !string.IsNullOrEmpty(_snapshot.CurrentActivity.DisplayText))
+        {
+            tooltip = $"OpenClaw Tray - {_snapshot.CurrentActivity.DisplayText}; {_snapshot.Status}";
+        }
+
+        return TrayTooltipFormatter.FitShellTooltip(tooltip);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -43,6 +43,8 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeInvokeActivityFormatter.cs" Link="Services\NodeInvokeActivityFormatter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeCapabilityGating.cs" Link="Services\NodeCapabilityGating.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\TrayTooltipFormatter.cs" Link="Helpers\TrayTooltipFormatter.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\TrayStateSnapshot.cs" Link="Services\TrayStateSnapshot.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\TrayTooltipBuilder.cs" Link="Services\TrayTooltipBuilder.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\TextToSpeech\ElevenLabsTextToSpeechClient.cs" Link="Services\TextToSpeech\ElevenLabsTextToSpeechClient.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\GatewayDiscoveryService.cs" Link="Services\GatewayDiscoveryService.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\A2UI\Actions\AgentMessageFormatter.cs" Link="A2UI\Actions\AgentMessageFormatter.cs" />

--- a/tests/OpenClaw.Tray.Tests/Services/TrayTooltipBuilderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Services/TrayTooltipBuilderTests.cs
@@ -1,0 +1,264 @@
+using OpenClaw.Shared;
+using OpenClawTray.Helpers;
+using OpenClawTray.Services;
+using System;
+using System.IO;
+using Xunit;
+
+namespace OpenClaw.Tray.Tests.Services;
+
+public sealed class TrayTooltipBuilderTests : IDisposable
+{
+    private static readonly DateTime FixedTime = new(2024, 1, 15, 10, 30, 45);
+
+    private readonly string _tempDir;
+
+    public TrayTooltipBuilderTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "OpenClawTray.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* ignore */ }
+    }
+
+    private static TrayStateSnapshot BaseConnected(
+        ChannelHealth[]? channels = null,
+        GatewayNodeInfo[]? nodes = null,
+        string? authFailure = null,
+        AgentActivity? activity = null) => new TrayStateSnapshot
+    {
+        Status = ConnectionStatus.Connected,
+        Channels = channels ?? [],
+        Nodes = nodes ?? [],
+        AuthFailureMessage = authFailure,
+        CurrentActivity = activity,
+        LastCheckTime = FixedTime
+    };
+
+    [Fact]
+    public void Build_ConnectedWithChannelsAndNodes_ContainsExpectedSegments()
+    {
+        var snapshot = BaseConnected(
+            channels: [new ChannelHealth { Status = "ok" }, new ChannelHealth { Status = "stopped" }],
+            nodes: [new GatewayNodeInfo { IsOnline = true }]);
+
+        var result = new TrayTooltipBuilder(snapshot).Build();
+
+        Assert.Contains("OpenClaw Tray - Connected", result);
+        Assert.Contains("Channels 1/2", result);
+        Assert.Contains("Nodes 1/1", result);
+        Assert.Contains("Warnings 0", result);
+        Assert.Contains("Last 10:30:45", result);
+    }
+
+    [Fact]
+    public void Build_ActivityWithDisplayText_OverridesStandardFormat()
+    {
+        var activity = new AgentActivity { Kind = ActivityKind.Exec, Label = "running tests", IsMain = true };
+        var snapshot = BaseConnected(activity: activity);
+
+        var result = new TrayTooltipBuilder(snapshot).Build();
+
+        Assert.Contains("💻 running tests", result);
+        Assert.Contains("Connected", result);
+        Assert.DoesNotContain("Channels", result);
+    }
+
+    [Fact]
+    public void Build_ActivityIdle_DoesNotOverrideStandardFormat()
+    {
+        var activity = new AgentActivity { Kind = ActivityKind.Idle };
+        var snapshot = BaseConnected(
+            channels: [new ChannelHealth { Status = "ok" }],
+            activity: activity);
+
+        var result = new TrayTooltipBuilder(snapshot).Build();
+
+        Assert.Contains("Channels", result);
+    }
+
+    [Fact]
+    public void Build_StatusNotConnected_CountsOneWarning()
+    {
+        var snapshot = new TrayStateSnapshot
+        {
+            Status = ConnectionStatus.Disconnected,
+            Channels = [new ChannelHealth { Status = "ok" }],
+            Nodes = [],
+            LastCheckTime = FixedTime
+        };
+
+        var result = new TrayTooltipBuilder(snapshot).Build();
+
+        Assert.Contains("Warnings 1", result);
+    }
+
+    [Fact]
+    public void Build_AuthFailureMessage_CountsOneWarning()
+    {
+        var snapshot = BaseConnected(
+            channels: [new ChannelHealth { Status = "ok" }],
+            authFailure: "token expired");
+
+        var result = new TrayTooltipBuilder(snapshot).Build();
+
+        Assert.Contains("Warnings 1", result);
+    }
+
+    [Fact]
+    public void Build_ConnectedWithNoChannels_CountsOneWarning()
+    {
+        var snapshot = BaseConnected(channels: []);
+
+        var result = new TrayTooltipBuilder(snapshot).Build();
+
+        Assert.Contains("Warnings 1", result);
+    }
+
+    [Fact]
+    public void Build_MultipleWarningConditions_SumsCorrectly()
+    {
+        // Disconnected (+1) + auth failure (+1); no-channels warning only fires when Connected
+        var snapshot = new TrayStateSnapshot
+        {
+            Status = ConnectionStatus.Disconnected,
+            AuthFailureMessage = "expired",
+            Channels = [],
+            Nodes = [],
+            LastCheckTime = FixedTime
+        };
+
+        var result = new TrayTooltipBuilder(snapshot).Build();
+
+        Assert.Contains("Warnings 2", result);
+    }
+
+    [Fact]
+    public void Build_NoNodesNoFallback_ShowsZeroNodes()
+    {
+        var snapshot = BaseConnected(
+            channels: [new ChannelHealth { Status = "ok" }],
+            nodes: []);
+
+        var result = new TrayTooltipBuilder(snapshot).Build();
+
+        Assert.Contains("Nodes 0/0", result);
+    }
+
+    [Fact]
+    public void Build_NoGatewayNodesButLocalFallback_UsesLocalNode()
+    {
+        var snapshot = new TrayStateSnapshot
+        {
+            Status = ConnectionStatus.Connected,
+            Channels = [new ChannelHealth { Status = "ok" }],
+            Nodes = [],
+            LocalNodeFallback = new GatewayNodeInfo { IsOnline = true },
+            LastCheckTime = FixedTime
+        };
+
+        var result = new TrayTooltipBuilder(snapshot).Build();
+
+        Assert.Contains("Nodes 1/1", result);
+    }
+
+    [Fact]
+    public void Build_LocalFallbackOffline_CountsAsOffline()
+    {
+        var snapshot = new TrayStateSnapshot
+        {
+            Status = ConnectionStatus.Connected,
+            Channels = [new ChannelHealth { Status = "ok" }],
+            Nodes = [],
+            LocalNodeFallback = new GatewayNodeInfo { IsOnline = false },
+            LastCheckTime = FixedTime
+        };
+
+        var result = new TrayTooltipBuilder(snapshot).Build();
+
+        Assert.Contains("Nodes 0/1", result);
+    }
+
+    [Fact]
+    public void Build_MultipleNodes_CountsOnlineCorrectly()
+    {
+        var snapshot = BaseConnected(nodes:
+        [
+            new GatewayNodeInfo { IsOnline = true },
+            new GatewayNodeInfo { IsOnline = false },
+            new GatewayNodeInfo { IsOnline = true }
+        ]);
+
+        var result = new TrayTooltipBuilder(snapshot).Build();
+
+        Assert.Contains("Nodes 2/3", result);
+    }
+
+    [Fact]
+    public void Build_ChannelCounting_OnlyHealthyStatusesCountAsReady()
+    {
+        var snapshot = BaseConnected(channels:
+        [
+            new ChannelHealth { Status = "ok" },
+            new ChannelHealth { Status = "running" },
+            new ChannelHealth { Status = "stopped" },
+            new ChannelHealth { Status = "error" }
+        ]);
+
+        var result = new TrayTooltipBuilder(snapshot).Build();
+
+        Assert.Contains("Channels 2/4", result);
+    }
+
+    [Fact]
+    public void Build_LongTooltip_IsTruncatedToShellLimit()
+    {
+        var activity = new AgentActivity
+        {
+            Kind = ActivityKind.Exec,
+            Label = new string('x', 200),
+            IsMain = true
+        };
+        var snapshot = BaseConnected(activity: activity);
+
+        var result = new TrayTooltipBuilder(snapshot).Build();
+
+        Assert.True(result.Length <= TrayTooltipFormatter.MaxShellTooltipLength);
+        Assert.EndsWith("...", result);
+    }
+
+    [Fact]
+    public void Build_NullSettings_ShowsUnknownGatewayTopology()
+    {
+        var snapshot = BaseConnected();
+
+        var result = new TrayTooltipBuilder(snapshot).Build();
+
+        Assert.Contains("Unknown gateway", result);
+    }
+
+    [Fact]
+    public void Build_SshTunnelSettings_ReflectsMacOverSshTopology()
+    {
+        var settings = new SettingsManager(_tempDir)
+        {
+            UseSshTunnel = true,
+            SshTunnelHost = "myhost.com"
+        };
+        var snapshot = new TrayStateSnapshot
+        {
+            Status = ConnectionStatus.Connected,
+            Settings = settings,
+            Channels = [],
+            Nodes = [],
+            LastCheckTime = FixedTime
+        };
+
+        var result = new TrayTooltipBuilder(snapshot).Build();
+
+        Assert.Contains("Mac over SSH", result);
+    }
+}


### PR DESCRIPTION
## Summary

`BuildTrayTooltip` in `App.xaml.cs` read eight fields directly to
assemble the tray icon tooltip string. This moves that logic into a
dedicated `TrayTooltipBuilder`, following the snapshot pattern
established by `CommandCenterStateBuilder` in PR #297.

## What changed

- Add `TrayStateSnapshot` — an 8-field record (status, activity,
  channels, nodes, local node fallback, auth failure message, last check
  time, settings) following the same structure as `AppStateSnapshot`.
  `NodeService` is not held in the snapshot; `GetLocalNodeInfo()` is
  called once at capture time and the result stored as `LocalNodeFallback`
- Add `TrayTooltipBuilder` — receives a snapshot, contains the tooltip
  assembly logic, delegates to `TrayTooltipFormatter.FitShellTooltip`
  for the 127-char Windows shell limit
- Replace `BuildTrayTooltip` body in `App.xaml.cs` with a two-line
  delegation; add `CaptureTraySnapshot` alongside it
- Add 15 unit tests covering: standard format, activity override, idle
  activity (no override), warning count conditions, node counting,
  local node fallback, channel counting, truncation, and topology display

## Testing

- `dotnet build src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj -r win-x64 --nologo`
- `dotnet test tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --nologo` — 15 new tests, all passing
- Manual: hover over tray icon — tooltip shows status, topology, channel
  count, node count, warning count, and last check time as before; with
  active agent activity the activity text overrides the status line as expected

## Notes

No observable behaviour change. The snapshot captures the same fields
that `BuildTrayTooltip` was reading directly, in the same call context
(UI thread).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>