### PR TITLE
fix(exec-shell): add zsh/dash/ash/ksh/fish to V1 POSIX shell recognizer

### DIFF
--- a/src/OpenClaw.Shared/ExecShellWrapperParser.cs
+++ b/src/OpenClaw.Shared/ExecShellWrapperParser.cs
@@ -113,7 +113,12 @@ internal static class ExecShellWrapperParser
         if (executable.Equals("bash", StringComparison.OrdinalIgnoreCase) ||
             executable.Equals("bash.exe", StringComparison.OrdinalIgnoreCase) ||
             executable.Equals("sh", StringComparison.OrdinalIgnoreCase) ||
-            executable.Equals("sh.exe", StringComparison.OrdinalIgnoreCase))
+            executable.Equals("sh.exe", StringComparison.OrdinalIgnoreCase) ||
+            executable.Equals("zsh", StringComparison.OrdinalIgnoreCase) ||
+            executable.Equals("dash", StringComparison.OrdinalIgnoreCase) ||
+            executable.Equals("ash", StringComparison.OrdinalIgnoreCase) ||
+            executable.Equals("ksh", StringComparison.OrdinalIgnoreCase) ||
+            executable.Equals("fish", StringComparison.OrdinalIgnoreCase))
         {
             for (var i = 1; i < tokens.Length; i++)
             {

--- a/src/OpenClaw.Shared/ExecShellWrapperParser.cs
+++ b/src/OpenClaw.Shared/ExecShellWrapperParser.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using OpenClaw.Shared.ExecApprovals;
 
 namespace OpenClaw.Shared;
 
@@ -78,12 +79,11 @@ internal static class ExecShellWrapperParser
         if (tokens.Length < 2)
             return default;
 
-        var executable = Path.GetFileName(tokens[0]);
+        var executable = ExecCommandToken.NormalizedBasename(tokens[0]);
         if (string.IsNullOrWhiteSpace(executable))
             return default;
 
-        if (executable.Equals("cmd", StringComparison.OrdinalIgnoreCase) ||
-            executable.Equals("cmd.exe", StringComparison.OrdinalIgnoreCase))
+        if (executable == "cmd")
         {
             for (var i = 1; i < tokens.Length; i++)
             {
@@ -98,27 +98,13 @@ internal static class ExecShellWrapperParser
             }
         }
 
-        if (executable.Equals("powershell", StringComparison.OrdinalIgnoreCase) ||
-            executable.Equals("powershell.exe", StringComparison.OrdinalIgnoreCase))
-        {
+        if (executable == "powershell")
             return ParsePowerShellPayload(tokens, "powershell");
-        }
 
-        if (executable.Equals("pwsh", StringComparison.OrdinalIgnoreCase) ||
-            executable.Equals("pwsh.exe", StringComparison.OrdinalIgnoreCase))
-        {
+        if (executable == "pwsh")
             return ParsePowerShellPayload(tokens, "pwsh");
-        }
 
-        if (executable.Equals("bash", StringComparison.OrdinalIgnoreCase) ||
-            executable.Equals("bash.exe", StringComparison.OrdinalIgnoreCase) ||
-            executable.Equals("sh", StringComparison.OrdinalIgnoreCase) ||
-            executable.Equals("sh.exe", StringComparison.OrdinalIgnoreCase) ||
-            executable.Equals("zsh", StringComparison.OrdinalIgnoreCase) ||
-            executable.Equals("dash", StringComparison.OrdinalIgnoreCase) ||
-            executable.Equals("ash", StringComparison.OrdinalIgnoreCase) ||
-            executable.Equals("ksh", StringComparison.OrdinalIgnoreCase) ||
-            executable.Equals("fish", StringComparison.OrdinalIgnoreCase))
+        if (executable is "bash" or "sh" or "zsh" or "dash" or "ash" or "ksh" or "fish")
         {
             for (var i = 1; i < tokens.Length; i++)
             {

--- a/tests/OpenClaw.Shared.Tests/ExecShellWrapperParserTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecShellWrapperParserTests.cs
@@ -267,6 +267,11 @@ public class ExecShellWrapperParserTests
     [InlineData("bash.exe -c echo hello")]
     [InlineData("sh -c echo hello")]
     [InlineData("sh.exe -c echo hello")]
+    [InlineData("zsh -c echo hello")]
+    [InlineData("dash -c echo hello")]
+    [InlineData("ash -c echo hello")]
+    [InlineData("ksh -c echo hello")]
+    [InlineData("fish -c echo hello")]
     public void Expand_Bash_C_ExtractsPayload(string command)
     {
         var result = Expand(command);

--- a/tests/OpenClaw.Shared.Tests/ExecShellWrapperParserTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecShellWrapperParserTests.cs
@@ -268,10 +268,15 @@ public class ExecShellWrapperParserTests
     [InlineData("sh -c echo hello")]
     [InlineData("sh.exe -c echo hello")]
     [InlineData("zsh -c echo hello")]
+    [InlineData("zsh.exe -c echo hello")]
     [InlineData("dash -c echo hello")]
+    [InlineData("dash.exe -c echo hello")]
     [InlineData("ash -c echo hello")]
+    [InlineData("ash.exe -c echo hello")]
     [InlineData("ksh -c echo hello")]
+    [InlineData("ksh.exe -c echo hello")]
     [InlineData("fish -c echo hello")]
+    [InlineData("fish.exe -c echo hello")]
     public void Expand_Bash_C_ExtractsPayload(string command)
     {
         var result = Expand(command);


### PR DESCRIPTION
## Summary

`ExecShellWrapperParser` (V1, the live exec-approval gate) only recognised `bash` and `sh` as POSIX shell wrappers. V2 (`ExecShellWrapperNormalizer`) already included `zsh`, `dash`, `ash`, `ksh`, and `fish`, but V1 never received the update.

As a result, a policy with `Allow: bash *` would not match a `zsh -c "..."` invocation — the command reached the policy evaluator unwrapped, so neither Allow nor Deny rules for known shells applied reliably.

## Changes

- `ExecShellWrapperParser.cs`: add `zsh`, `dash`, `ash`, `ksh`, `fish` to the POSIX shell branch
- `ExecShellWrapperParserTests.cs`: extend the existing `Expand_Bash_C_ExtractsPayload` theory with the five new shells

Fixes #366.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>