### PR TITLE
fix(node): route capture/record toasts through App.ShowToast

### DIFF
--- a/src/OpenClaw.Shared/NonFatalAction.cs
+++ b/src/OpenClaw.Shared/NonFatalAction.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace OpenClaw.Shared;
+
+public static class NonFatalAction
+{
+    public static void Run(Action action, Action<string> onError)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception ex)
+        {
+            onError(ex.Message);
+        }
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -2680,16 +2680,7 @@ public partial class App : Application
     }
 
     private void OnNodeToastRequested(object? sender, Microsoft.Toolkit.Uwp.Notifications.ToastContentBuilder builder)
-    {
-        try
-        {
-            ShowToast(builder);
-        }
-        catch (Exception ex)
-        {
-            Logger.Warn($"Failed to show node toast: {ex.Message}");
-        }
-    }
+        => NonFatalAction.Run(() => ShowToast(builder), msg => Logger.Warn($"Failed to show node toast: {msg}"));
 
     private void OnNodeInvokeCompleted(object? sender, NodeInvokeCompletedEventArgs args)
     {

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -2680,7 +2680,16 @@ public partial class App : Application
     }
 
     private void OnNodeToastRequested(object? sender, Microsoft.Toolkit.Uwp.Notifications.ToastContentBuilder builder)
-        => ShowToast(builder);
+    {
+        try
+        {
+            ShowToast(builder);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Failed to show node toast: {ex.Message}");
+        }
+    }
 
     private void OnNodeInvokeCompleted(object? sender, NodeInvokeCompletedEventArgs args)
     {

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -2680,7 +2680,8 @@ public partial class App : Application
     }
 
     private void OnNodeToastRequested(object? sender, Microsoft.Toolkit.Uwp.Notifications.ToastContentBuilder builder)
-        => NonFatalAction.Run(() => ShowToast(builder), msg => Logger.Warn($"Failed to show node toast: {msg}"));
+        => _dispatcherQueue?.TryEnqueue(() =>
+            NonFatalAction.Run(() => ShowToast(builder), msg => Logger.Warn($"Failed to show node toast: {msg}")));
 
     private void OnNodeInvokeCompleted(object? sender, NodeInvokeCompletedEventArgs args)
     {

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -2316,6 +2316,7 @@ public partial class App : Application
                 identityDataPath: IdentityDataPath);
             _nodeService.StatusChanged += OnNodeStatusChanged;
             _nodeService.NotificationRequested += OnNodeNotificationRequested;
+            _nodeService.ToastRequested += OnNodeToastRequested;
             _nodeService.PairingStatusChanged += OnPairingStatusChanged;
             _nodeService.ChannelHealthUpdated += OnChannelHealthUpdated;
             _nodeService.InvokeCompleted += OnNodeInvokeCompleted;
@@ -2677,6 +2678,9 @@ public partial class App : Application
             Logger.Warn($"Failed to show node notification: {ex.Message}");
         }
     }
+
+    private void OnNodeToastRequested(object? sender, Microsoft.Toolkit.Uwp.Notifications.ToastContentBuilder builder)
+        => ShowToast(builder);
 
     private void OnNodeInvokeCompleted(object? sender, NodeInvokeCompletedEventArgs args)
     {

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -149,6 +149,7 @@ public sealed class NodeService : IDisposable
     public event EventHandler<NodeInvokeCompletedEventArgs>? InvokeCompleted;
     public event EventHandler<GatewaySelfInfo>? GatewaySelfUpdated;
     public event EventHandler<RecordingStateEventArgs>? RecordingStateChanged;
+    public event EventHandler<ToastContentBuilder>? ToastRequested;
     
     public bool IsScreenRecording { get; private set; }
     public bool IsCameraRecording { get; private set; }
@@ -1367,7 +1368,9 @@ public sealed class NodeService : IDisposable
         if ((now - _lastScreenCaptureNotification).TotalSeconds > 10)
         {
             _lastScreenCaptureNotification = now;
-            ShowToast("Toast_ScreenCaptured", "Toast_ScreenCapturedDetail");
+            ToastRequested?.Invoke(this, new ToastContentBuilder()
+                .AddText(LocalizationHelper.GetString("Toast_ScreenCaptured"))
+                .AddText(LocalizationHelper.GetString("Toast_ScreenCapturedDetail")));
         }
         
         return await _screenCaptureService.CaptureAsync(args);
@@ -1386,14 +1389,20 @@ public sealed class NodeService : IDisposable
         SetRecordingState(RecordingType.Screen, true, args.DurationMs);
         try
         {
-            ShowToast("Toast_ScreenRecordingStarted", "Toast_ScreenRecordingStartedDetail");
+            ToastRequested?.Invoke(this, new ToastContentBuilder()
+                .AddText(LocalizationHelper.GetString("Toast_ScreenRecordingStarted"))
+                .AddText(LocalizationHelper.GetString("Toast_ScreenRecordingStartedDetail")));
             var result = await _screenRecordingService.RecordAsync(args);
-            ShowToast("Toast_ScreenRecordingComplete", "Toast_ScreenRecordingCompleteDetail");
+            ToastRequested?.Invoke(this, new ToastContentBuilder()
+                .AddText(LocalizationHelper.GetString("Toast_ScreenRecordingComplete"))
+                .AddText(LocalizationHelper.GetString("Toast_ScreenRecordingCompleteDetail")));
             return result;
         }
         catch (Exception ex) when (ex is not InvalidOperationException)
         {
-            ShowToast("Toast_ScreenRecordingFailed", "Toast_ScreenRecordingFailedDetail");
+            ToastRequested?.Invoke(this, new ToastContentBuilder()
+                .AddText(LocalizationHelper.GetString("Toast_ScreenRecordingFailed"))
+                .AddText(LocalizationHelper.GetString("Toast_ScreenRecordingFailedDetail")));
             throw;
         }
         finally
@@ -1429,21 +1438,15 @@ public sealed class NodeService : IDisposable
         }
         catch (UnauthorizedAccessException ex)
         {
-            try
-            {
-                new ToastContentBuilder()
-                    .AddText(LocalizationHelper.GetString("Toast_CameraBlocked"))
-                    .AddText(LocalizationHelper.GetString("Toast_CameraBlockedDetail"))
-                    .Show();
-            }
-            catch { }
-            
+            ToastRequested?.Invoke(this, new ToastContentBuilder()
+                .AddText(LocalizationHelper.GetString("Toast_CameraBlocked"))
+                .AddText(LocalizationHelper.GetString("Toast_CameraBlockedDetail")));
             throw new InvalidOperationException(
                 "Camera access blocked. Enable camera access for desktop apps in Windows Privacy settings.",
                 ex);
         }
     }
-    
+
     private async Task<CameraClipResult> OnCameraClip(CameraClipArgs args)
     {
         if (_cameraCaptureService == null)
@@ -1457,22 +1460,20 @@ public sealed class NodeService : IDisposable
         SetRecordingState(RecordingType.Camera, true, args.DurationMs);
         try
         {
-            ShowToast("Toast_CameraRecordingStarted", "Toast_CameraRecordingStartedDetail");
+            ToastRequested?.Invoke(this, new ToastContentBuilder()
+                .AddText(LocalizationHelper.GetString("Toast_CameraRecordingStarted"))
+                .AddText(LocalizationHelper.GetString("Toast_CameraRecordingStartedDetail")));
             var result = await _cameraCaptureService.ClipAsync(args);
-            ShowToast("Toast_CameraRecordingComplete", "Toast_CameraRecordingCompleteDetail");
+            ToastRequested?.Invoke(this, new ToastContentBuilder()
+                .AddText(LocalizationHelper.GetString("Toast_CameraRecordingComplete"))
+                .AddText(LocalizationHelper.GetString("Toast_CameraRecordingCompleteDetail")));
             return result;
         }
         catch (UnauthorizedAccessException ex)
         {
-            try
-            {
-                new ToastContentBuilder()
-                    .AddText(LocalizationHelper.GetString("Toast_CameraBlocked"))
-                    .AddText(LocalizationHelper.GetString("Toast_CameraBlockedDetail"))
-                    .Show();
-            }
-            catch { }
-            
+            ToastRequested?.Invoke(this, new ToastContentBuilder()
+                .AddText(LocalizationHelper.GetString("Toast_CameraBlocked"))
+                .AddText(LocalizationHelper.GetString("Toast_CameraBlockedDetail")));
             throw new InvalidOperationException(
                 "Camera access blocked. Enable camera access for desktop apps in Windows Privacy settings.",
                 ex);
@@ -1781,18 +1782,6 @@ public sealed class NodeService : IDisposable
         }
 
         await tcs.Task;
-    }
-
-    private static void ShowToast(string titleKey, string detailKey)
-    {
-        try
-        {
-            new ToastContentBuilder()
-                .AddText(LocalizationHelper.GetString(titleKey))
-                .AddText(LocalizationHelper.GetString(detailKey))
-                .Show();
-        }
-        catch { /* ignore notification errors */ }
     }
 
     #endregion

--- a/tests/OpenClaw.Shared.Tests/NonFatalActionTests.cs
+++ b/tests/OpenClaw.Shared.Tests/NonFatalActionTests.cs
@@ -1,0 +1,32 @@
+using System;
+using Xunit;
+using OpenClaw.Shared;
+
+namespace OpenClaw.Shared.Tests;
+
+public class NonFatalActionTests
+{
+    [Fact]
+    public void Run_ThrowingAction_DoesNotPropagate()
+    {
+        var warned = false;
+        NonFatalAction.Run(() => throw new InvalidOperationException("boom"), _ => warned = true);
+        Assert.True(warned);
+    }
+
+    [Fact]
+    public void Run_ThrowingAction_PassesExceptionMessageToOnError()
+    {
+        string? received = null;
+        NonFatalAction.Run(() => throw new InvalidOperationException("boom"), msg => received = msg);
+        Assert.Equal("boom", received);
+    }
+
+    [Fact]
+    public void Run_SuccessfulAction_DoesNotCallOnError()
+    {
+        var errorCalled = false;
+        NonFatalAction.Run(() => { }, _ => errorCalled = true);
+        Assert.False(errorCalled);
+    }
+}


### PR DESCRIPTION
## Summary

`NodeService` had its own `ShowToast` helper that called `ToastContentBuilder.Show()` directly. This bypassed the sound preference (`None` / `Subtle` / `Default`) and the 30-second deduplication window both implemented in `App.ShowToast`.

All screen-capture, screen-record, and camera toasts were affected — including toasts that fire on attacker-controllable triggers (`screen.snapshot` throttled once per 10 s).

## Changes

- Remove `NodeService.ShowToast`
- Add `NodeService.ToastRequested` event (`EventHandler<ToastContentBuilder>`)
- Replace all direct toast calls in capture/record handlers with `ToastRequested?.Invoke`
- Subscribe in `App` and delegate to `App.ShowToast`, so sound preferences and dedup are honoured

Fixes #342.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>