### PR TITLE
fix(exec-approvals): reject Allow rules with absolute file paths

### DIFF
--- a/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
@@ -647,11 +647,20 @@ public class SystemCapability : NodeCapabilityBase
             // A remote .set call should never be able to whitelist a specific binary
             // by path — that would be a two-step EoP (compromise MCP token → whitelist
             // attacker binary → invoke it). Legitimate rules name commands, not paths.
-            // Covers: drive-rooted paths (C:\, D:/), UNC paths (\\server\), and the
-            // Windows long-path namespace prefix (\\?\).
-            if (normalized.Length >= 3 &&
-                ((char.IsLetter(normalized[0]) && normalized[1] == ':' && (normalized[2] == '\\' || normalized[2] == '/')) ||
-                 normalized.StartsWith(@"\\", StringComparison.Ordinal)))
+            // Strip one layer of matching surrounding quotes first so quoted forms
+            // ("C:\evil.exe", 'C:\evil.exe') are caught alongside bare paths.
+            // Covers: drive-rooted paths (C:\, C:/), UNC/long-path (\\, //), and
+            // forward-slash UNC namespace forms (//server/share, //?/C:/evil.exe).
+            var unquoted = normalized;
+            if (normalized.Length >= 2 &&
+                ((normalized[0] == '"' && normalized[^1] == '"') ||
+                 (normalized[0] == '\'' && normalized[^1] == '\'')))
+                unquoted = normalized[1..^1];
+
+            if (unquoted.Length >= 3 &&
+                ((char.IsLetter(unquoted[0]) && unquoted[1] == ':' && (unquoted[2] == '\\' || unquoted[2] == '/')) ||
+                 unquoted.StartsWith(@"\\", StringComparison.Ordinal) ||
+                 unquoted.StartsWith("//", StringComparison.Ordinal)))
                 return $"Absolute path allow rule is not permitted: {pattern}";
 
             foreach (var dangerous in DangerousAllowPatternFragments)

--- a/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
@@ -643,6 +643,17 @@ public class SystemCapability : NodeCapabilityBase
             if (normalized is "powershell *" or "pwsh *" or "cmd *" or "cmd.exe *")
                 return $"Broad allow rule is not permitted: {pattern}";
 
+            // Reject Allow rules whose pattern looks like an absolute file path.
+            // A remote .set call should never be able to whitelist a specific binary
+            // by path — that would be a two-step EoP (compromise MCP token → whitelist
+            // attacker binary → invoke it). Legitimate rules name commands, not paths.
+            // Covers: drive-rooted paths (C:\, D:/), UNC paths (\\server\), and the
+            // Windows long-path namespace prefix (\\?\).
+            if (normalized.Length >= 3 &&
+                ((char.IsLetter(normalized[0]) && normalized[1] == ':' && (normalized[2] == '\\' || normalized[2] == '/')) ||
+                 normalized.StartsWith(@"\\", StringComparison.Ordinal)))
+                return $"Absolute path allow rule is not permitted: {pattern}";
+
             foreach (var dangerous in DangerousAllowPatternFragments)
             {
                 if (normalized.Contains(dangerous, StringComparison.Ordinal))

--- a/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
@@ -591,6 +591,41 @@ public class SystemCapabilityTests
         }
     }
 
+    [Theory]
+    [InlineData(@"C:\Users\Public\evil.exe")]
+    [InlineData(@"C:\Windows\System32\cmd.exe")]
+    [InlineData(@"D:/tools/run.exe")]
+    [InlineData(@"\\server\share\tool.exe")]
+    [InlineData(@"\\?\C:\evil.exe")]
+    public async Task ExecApprovalsSet_RejectsAbsolutePathAllowRules(string pattern)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var cap = new SystemCapability(NullLogger.Instance);
+            var policy = new ExecApprovalPolicy(tempDir, NullLogger.Instance);
+            cap.SetApprovalPolicy(policy);
+
+            var escapedPattern = pattern.Replace(@"\", @"\\");
+            var req = new NodeInvokeRequest
+            {
+                Id = "ea-path-allow",
+                Command = "system.execApprovals.set",
+                Args = Parse($$"""{"baseHash":"{{policy.GetPolicyHash()}}","rules":[{"pattern":"{{escapedPattern}}","action":"allow","enabled":true}],"defaultAction":"deny"}""")
+            };
+
+            var res = await cap.ExecuteAsync(req);
+
+            Assert.False(res.Ok);
+            Assert.Contains("allow rule", res.Error, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
     [Fact]
     public async Task Run_BlockedEnvVar_ReturnsError()
     {

--- a/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
@@ -597,6 +597,12 @@ public class SystemCapabilityTests
     [InlineData(@"D:/tools/run.exe")]
     [InlineData(@"\\server\share\tool.exe")]
     [InlineData(@"\\?\C:\evil.exe")]
+    [InlineData(@"""C:\Users\Public\evil.exe""")]
+    [InlineData(@"'C:\Users\Public\evil.exe'")]
+    [InlineData(@"""\\server\share\tool.exe""")]
+    [InlineData(@"""\\?\C:\evil.exe""")]
+    [InlineData(@"//server/share/tool.exe")]
+    [InlineData(@"//?/C:/evil.exe")]
     public async Task ExecApprovalsSet_RejectsAbsolutePathAllowRules(string pattern)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
@@ -607,12 +613,12 @@ public class SystemCapabilityTests
             var policy = new ExecApprovalPolicy(tempDir, NullLogger.Instance);
             cap.SetApprovalPolicy(policy);
 
-            var escapedPattern = pattern.Replace(@"\", @"\\");
+            var jsonPattern = System.Text.Json.JsonSerializer.Serialize(pattern)[1..^1];
             var req = new NodeInvokeRequest
             {
                 Id = "ea-path-allow",
                 Command = "system.execApprovals.set",
-                Args = Parse($$"""{"baseHash":"{{policy.GetPolicyHash()}}","rules":[{"pattern":"{{escapedPattern}}","action":"allow","enabled":true}],"defaultAction":"deny"}""")
+                Args = Parse($$"""{"baseHash":"{{policy.GetPolicyHash()}}","rules":[{"pattern":"{{jsonPattern}}","action":"allow","enabled":true}],"defaultAction":"deny"}""")
             };
 
             var res = await cap.ExecuteAsync(req);


### PR DESCRIPTION
## Summary

`ValidateExecApprovalRules` accepted `Allow` rules whose pattern was an absolute file path (e.g. `C:\Users\Public\evil.exe`, `\?\C:\evil.exe`). A local process that obtained the MCP bearer token could use `system.execApprovals.set` to whitelist an attacker-controlled binary, then invoke it via `system.run` — a two-step local EoP.

The existing validator already blocked all-wildcard and dangerous-fragment patterns. This closes the gap on specific-path Allow rules.

## Changes

- `SystemCapability.cs`: add check in `ValidateExecApprovalRules` — rejects `Allow` patterns that start with a drive root (`X:\`, `X:/`) or a UNC/long-path prefix (`\`)
- `CapabilityTests.cs`: add `ExecApprovalsSet_RejectsAbsolutePathAllowRules` theory covering drive-rooted, forward-slash, UNC, and long-path namespace patterns

Fixes #347.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>