### PR TITLE
fix: use node.pair.approve for node command auto-approval

### DIFF
--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -196,7 +196,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
 
     public string? OperatorDeviceId => _operatorDeviceId;
     public IReadOnlyList<string> GrantedOperatorScopes => _grantedOperatorScopes;
-    public bool IsConnectedToGateway => IsConnected;
+    public virtual bool IsConnectedToGateway => IsConnected;
 
     public OpenClawGatewayClient(string gatewayUrl, string token, IOpenClawLogger? logger = null, bool tokenIsBootstrapToken = false, bool bootstrapPairAsNode = false, string? identityPath = null)
         : base(gatewayUrl, token, logger)
@@ -686,7 +686,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
         await SendTrackedRequestAsync("node.pair.list");
     }
 
-    public Task<bool> NodePairApproveAsync(string requestId)
+    public virtual Task<bool> NodePairApproveAsync(string requestId)
     {
         return TrySendTrackedRequestAsync("node.pair.approve", new { requestId });
     }
@@ -797,7 +797,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
         await SendTrackedRequestAsync("device.pair.list");
     }
 
-    public Task<bool> DevicePairApproveAsync(string requestId)
+    public virtual Task<bool> DevicePairApproveAsync(string requestId)
     {
         return TrySendTrackedRequestAsync("device.pair.approve", new { requestId });
     }

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -84,6 +84,18 @@ public class WindowsNodeClient : WebSocketClientBase
     /// <summary>Human-readable display name surfaced to the gateway and other nodes.</summary>
     public string DisplayName => _registration.DisplayName;
 
+    /// <summary>Exposes the registration for internal diagnostics only.</summary>
+    internal NodeRegistration Registration => _registration;
+
+    /// <summary>Number of registered capabilities (read-only diagnostic accessor).</summary>
+    public int RegisteredCapabilityCount => _registration.Capabilities.Count;
+
+    /// <summary>Number of registered commands (read-only diagnostic accessor).</summary>
+    public int RegisteredCommandCount => _registration.Commands.Count;
+
+    /// <summary>First few registered command names for diagnostic logging.</summary>
+    public IEnumerable<string> RegisteredCommandsSample => _registration.Commands.Take(5);
+
     protected override int ReceiveBufferSize => 65536;
     protected override string ClientRole => "node";
     
@@ -545,6 +557,8 @@ public class WindowsNodeClient : WebSocketClientBase
 
         _logger.Info($"[HANDSHAKE] → Sending connect:");
         _logger.Info($"[HANDSHAKE]   role=node, clientId={ClientId}, mode=node");
+        _logger.Info($"[HANDSHAKE]   caps={_registration.Capabilities.Count}: [{string.Join(", ", _registration.Capabilities)}]");
+        _logger.Info($"[HANDSHAKE]   commands={_registration.Commands.Count}: [{string.Join(", ", _registration.Commands)}]");
         _logger.Info($"[HANDSHAKE]   isBootstrap={usingBootstrap}, hasNodeDeviceToken={isPaired}");
         _logger.Info($"[HANDSHAKE]   deviceId={_deviceIdentity.DeviceId[..Math.Min(16, _deviceIdentity.DeviceId.Length)]}...");
         _logger.Info($"[HANDSHAKE]   nonce={nonce?[..Math.Min(15, nonce?.Length ?? 0)]}...");

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -673,11 +673,19 @@ public partial class App : Application
         {
             try
             {
+                diagnostics.Record("node", $"ClientCreated fired, _nodeService null={_nodeService is null}");
                 _nodeService?.AttachClient(args.Client, args.BearerToken);
+                var client = args.Client;
+                diagnostics.Record("node", $"After AttachClient: caps={client.Capabilities.Count}, cmds={client.RegisteredCommandCount}");
+                if (client.RegisteredCommandCount > 0)
+                    diagnostics.Record("node", $"Commands sample: {string.Join(", ", client.RegisteredCommandsSample)}...");
+                else
+                    diagnostics.Record("node", "WARNING: 0 commands registered on node client before connect");
             }
             catch (Exception ex)
             {
                 Logger.Warn($"[App] NodeConnector.ClientCreated handler failed: {ex.Message}");
+                diagnostics.Record("node", $"ClientCreated handler THREW: {ex.Message}");
             }
         };
         // Wrap the SSH tunnel service so the connection manager can start/stop the tunnel

--- a/src/OpenClaw.Tray.WinUI/Services/Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/Connection/GatewayConnectionManager.cs
@@ -31,6 +31,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
     private bool _disposed;
     private bool _gatewayNeedsV2Signature; // remembered across reconnects
     private string? _lastAutoApprovedRequestId; // prevent auto-approve loops
+    private string? _autoApproveInFlight; // atomic guard against concurrent approval of same requestId
 
     public event EventHandler<GatewayConnectionSnapshot>? StateChanged;
     public event EventHandler<ConnectionDiagnosticEvent>? DiagnosticEvent;
@@ -709,39 +710,52 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         if (e.Status == PairingStatus.Pending && !string.IsNullOrWhiteSpace(e.RequestId)
             && e.RequestId != _lastAutoApprovedRequestId)
         {
-            var operatorClient = _activeLifecycle?.DataClient;
-            if (operatorClient?.IsConnectedToGateway == true)
+            // Atomic guard: only one approval in-flight at a time.
+            // If another approval is already running, skip this one entirely.
+            if (Interlocked.CompareExchange(ref _autoApproveInFlight, e.RequestId, null) != null)
             {
-                var scopes = operatorClient.GrantedOperatorScopes;
-                var canApprove = scopes.Any(s =>
-                    s.Equals("operator.admin", StringComparison.OrdinalIgnoreCase) ||
-                    s.Equals("operator.pairing", StringComparison.OrdinalIgnoreCase));
+                return;
+            }
 
-                if (canApprove)
+            try
+            {
+                var operatorClient = _activeLifecycle?.DataClient;
+                if (operatorClient?.IsConnectedToGateway == true)
                 {
-                    _diagnostics.Record("node", $"Auto-approving node pairing (requestId={e.RequestId})");
-                    try
+                    var scopes = operatorClient.GrantedOperatorScopes;
+                    var canApprove = scopes.Any(s =>
+                        s.Equals("operator.admin", StringComparison.OrdinalIgnoreCase) ||
+                        s.Equals("operator.pairing", StringComparison.OrdinalIgnoreCase));
+
+                    if (canApprove)
                     {
-                        var approved = await operatorClient.DevicePairApproveAsync(e.RequestId);
-                        if (approved)
+                        _diagnostics.Record("node", $"Auto-approving node pairing (requestId={e.RequestId})");
+                        try
                         {
-                            // Only set guard after confirmed success to allow retry on transient failure
-                            _lastAutoApprovedRequestId = e.RequestId;
-                            _diagnostics.Record("node", "Node pairing auto-approved — reconnecting node");
-                            await Task.Delay(1000); // brief delay for gateway to process
-                            await StartNodeConnectionAsync();
+                            var approved = await operatorClient.NodePairApproveAsync(e.RequestId);
+                            if (approved)
+                            {
+                                _lastAutoApprovedRequestId = e.RequestId;
+                                _diagnostics.Record("node", "Node pairing auto-approved — reconnecting node");
+                                await Task.Delay(1000); // brief delay for gateway to process
+                                await StartNodeConnectionAsync();
+                            }
+                            else
+                            {
+                                _diagnostics.Record("node", "Node auto-approval failed");
+                            }
                         }
-                        else
+                        catch (Exception ex)
                         {
-                            _diagnostics.Record("node", "Node auto-approval failed");
+                            _logger.Warn($"[ConnMgr] Node auto-approve failed: {ex.Message}");
+                            _diagnostics.Record("node", $"Auto-approve error: {ex.Message}");
                         }
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.Warn($"[ConnMgr] Node auto-approve failed: {ex.Message}");
-                        _diagnostics.Record("node", $"Auto-approve error: {ex.Message}");
                     }
                 }
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _autoApproveInFlight, null);
             }
         }
     }
@@ -805,6 +819,8 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         var old = _activeLifecycle;
         _activeLifecycle = null;
         _activeGatewayRecordId = null;
+        _lastAutoApprovedRequestId = null;
+        Interlocked.Exchange(ref _autoApproveInFlight, null);
         if (old != null)
         {
             OperatorClientChanged?.Invoke(this, new OperatorClientChangedEventArgs

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -420,6 +420,8 @@ public sealed class NodeService : IDisposable
             capabilitiesBuilt = _capabilities.Count > 0;
         }
 
+        _logger.Info($"[NodeService] AttachClient: capabilitiesBuilt={capabilitiesBuilt}, _capabilities.Count={_capabilities.Count}");
+
         // First connect after app startup may not have built capability objects yet.
         // RegisterCapabilities() populates _capabilities and registers them on _nodeClient.
         if (!capabilitiesBuilt)
@@ -446,6 +448,9 @@ public sealed class NodeService : IDisposable
             }
             _logger.Info($"[NodeService] AttachClient: re-registered {_capabilities.Count} capabilities on new client");
         }
+
+        // Log final registration state for diagnostics
+        _logger.Info($"[NodeService] AttachClient DONE: client.Registration.Capabilities={client.RegisteredCapabilityCount}, client.Registration.Commands={client.RegisteredCommandCount}");
     }
 
     /// <summary>

--- a/tests/OpenClaw.Tray.Tests/Connection/NodePairAutoApproveTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Connection/NodePairAutoApproveTests.cs
@@ -1,0 +1,319 @@
+using OpenClaw.Shared;
+using OpenClawTray.Services.Connection;
+
+namespace OpenClaw.Tray.Tests.Connection;
+
+/// <summary>
+/// Regression tests for the node command-upgrade auto-approval path in
+/// <see cref="GatewayConnectionManager"/>.
+///
+/// Bug: when a node's PairingStatusChanged fires with Pending + RequestId,
+/// the manager must call <c>NodePairApproveAsync</c> (node.pair.approve).
+/// A previous version incorrectly called <c>DevicePairApproveAsync</c>
+/// (device.pair.approve), which targets a completely separate pairing
+/// system and silently fails, leaving the node with 0 effective commands.
+/// </summary>
+public class NodePairAutoApproveTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly GatewayRegistry _registry;
+    private readonly MockCredentialResolver _resolver;
+    private readonly TrackingClientFactory _factory;
+    private readonly ScriptedNodeConnector _nodeConnector;
+
+    public NodePairAutoApproveTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "openclaw-autoapprove-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        _registry = new GatewayRegistry(_tempDir);
+        _resolver = new MockCredentialResolver();
+        _factory = new TrackingClientFactory();
+        _nodeConnector = new ScriptedNodeConnector();
+    }
+
+    public void Dispose()
+    {
+        _nodeConnector.Dispose();
+        try { Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    [Fact]
+    public async Task AutoApprove_CallsNodePairApprove_NotDevicePairApprove()
+    {
+        using var manager = CreateConnectedManager();
+
+        var lifecycle = _factory.CreatedClients[0];
+        lifecycle.TrackingClient.SetGrantedScopes(["operator.admin"]);
+        lifecycle.TrackingClient.SetIsConnected(true);
+
+        await FireAndWait(manager, () =>
+            _nodeConnector.FireStatusChanged(ConnectionStatus.Connecting));
+
+        // Set up signal before firing the event
+        var approvalDone = lifecycle.TrackingClient.WaitForApprovalCallAsync();
+        _nodeConnector.FirePairingStatusChanged(PairingStatus.Pending, requestId: "req-node-cmd-upgrade-42");
+        await approvalDone;
+
+        var client = lifecycle.TrackingClient;
+        Assert.Contains("node.pair.approve", client.ApprovalMethodsCalled);
+        Assert.DoesNotContain("device.pair.approve", client.ApprovalMethodsCalled);
+    }
+
+    [Fact]
+    public async Task AutoApprove_WithoutRequestId_DoesNotAttemptApproval()
+    {
+        using var manager = CreateConnectedManager();
+
+        var lifecycle = _factory.CreatedClients[0];
+        lifecycle.TrackingClient.SetGrantedScopes(["operator.admin"]);
+        lifecycle.TrackingClient.SetIsConnected(true);
+
+        await FireAndWait(manager, () =>
+            _nodeConnector.FireStatusChanged(ConnectionStatus.Connecting));
+
+        // Pending WITHOUT a requestId — auto-approval should not trigger.
+        // Brief delay is acceptable here: we're asserting nothing happened.
+        _nodeConnector.FirePairingStatusChanged(PairingStatus.Pending, requestId: null);
+        await Task.Delay(200);
+
+        Assert.Empty(lifecycle.TrackingClient.ApprovalMethodsCalled);
+    }
+
+    [Fact]
+    public async Task AutoApprove_WithoutAdminScope_DoesNotAttemptApproval()
+    {
+        using var manager = CreateConnectedManager();
+
+        var lifecycle = _factory.CreatedClients[0];
+        lifecycle.TrackingClient.SetGrantedScopes(["operator.read"]);
+        lifecycle.TrackingClient.SetIsConnected(true);
+
+        await FireAndWait(manager, () =>
+            _nodeConnector.FireStatusChanged(ConnectionStatus.Connecting));
+
+        // Insufficient scope — auto-approval should not trigger.
+        _nodeConnector.FirePairingStatusChanged(PairingStatus.Pending, requestId: "req-123");
+        await Task.Delay(200);
+
+        Assert.Empty(lifecycle.TrackingClient.ApprovalMethodsCalled);
+    }
+
+    [Fact]
+    public async Task AutoApprove_SameRequestId_DoesNotApproveTwice()
+    {
+        using var manager = CreateConnectedManager();
+
+        var lifecycle = _factory.CreatedClients[0];
+        lifecycle.TrackingClient.SetGrantedScopes(["operator.admin"]);
+        lifecycle.TrackingClient.SetIsConnected(true);
+
+        await FireAndWait(manager, () =>
+            _nodeConnector.FireStatusChanged(ConnectionStatus.Connecting));
+
+        // Block the approve call so it stays in-flight
+        lifecycle.TrackingClient.BlockApproveUntilReleased();
+
+        // Set up signal to know when first approve is entered
+        var firstEntered = lifecycle.TrackingClient.WaitForApprovalCallAsync();
+        _nodeConnector.FirePairingStatusChanged(PairingStatus.Pending, requestId: "req-same");
+        await firstEntered; // First call has entered NodePairApproveAsync but is blocked
+
+        // Fire second event while first is still in-flight — CAS guard should reject
+        _nodeConnector.FirePairingStatusChanged(PairingStatus.Pending, requestId: "req-same");
+        await Task.Delay(200); // brief wait for the second handler to run and be rejected
+
+        // Release the blocked first approval
+        lifecycle.TrackingClient.ReleaseApproveGate();
+        await Task.Delay(200); // let it complete
+
+        // Only one approval call should have been made
+        Assert.Equal(1, lifecycle.TrackingClient.ApprovalMethodsCalled
+            .Count(m => m == "node.pair.approve"));
+    }
+
+    // ─── Helpers ───
+
+    private GatewayConnectionManager CreateConnectedManager()
+    {
+        _registry.AddOrUpdate(new GatewayRecord { Id = "gw1", Url = "wss://test" });
+        _registry.SetActive("gw1");
+        Directory.CreateDirectory(_registry.GetIdentityDirectory("gw1"));
+
+        _resolver.OperatorCredential = new GatewayCredential("op-tok", false, "test");
+        _resolver.NodeCredential = new GatewayCredential("node-tok", false, "test");
+
+        var manager = new GatewayConnectionManager(
+            _resolver, _factory, _registry, NullLogger.Instance,
+            nodeConnector: _nodeConnector,
+            isNodeEnabled: () => true);
+
+        manager.ConnectAsync("gw1").GetAwaiter().GetResult();
+        return manager;
+    }
+
+    private static async Task<GatewayConnectionSnapshot> FireAndWait(
+        GatewayConnectionManager manager, Action action, int timeoutMs = 5000)
+    {
+        var tcs = new TaskCompletionSource<GatewayConnectionSnapshot>();
+        void Handler(object? _, GatewayConnectionSnapshot s)
+        {
+            manager.StateChanged -= Handler;
+            tcs.TrySetResult(s);
+        }
+        manager.StateChanged += Handler;
+        action();
+        return await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(timeoutMs));
+    }
+
+    // ─── Mocks ───
+
+    private sealed class MockCredentialResolver : ICredentialResolver
+    {
+        public GatewayCredential? OperatorCredential { get; set; }
+        public GatewayCredential? NodeCredential { get; set; }
+        public GatewayCredential? ResolveOperator(GatewayRecord record, string identityPath) => OperatorCredential;
+        public GatewayCredential? ResolveNode(GatewayRecord record, string identityPath) => NodeCredential;
+    }
+
+    private sealed class TrackingClientFactory : IGatewayClientFactory
+    {
+        public List<TrackingLifecycle> CreatedClients { get; } = [];
+
+        public IGatewayClientLifecycle Create(string gatewayUrl, GatewayCredential credential, string identityPath, IOpenClawLogger logger)
+        {
+            var mock = new TrackingLifecycle(gatewayUrl);
+            CreatedClients.Add(mock);
+            return mock;
+        }
+    }
+
+    internal sealed class TrackingLifecycle : IGatewayClientLifecycle
+    {
+        public TrackingGatewayClient TrackingClient { get; }
+        public OpenClawGatewayClient DataClient => TrackingClient;
+#pragma warning disable CS0067 // Events required by interface but not fired in tests
+        public event EventHandler<ConnectionStatus>? StatusChanged;
+        public event EventHandler<string>? AuthenticationFailed;
+#pragma warning restore CS0067
+        public Task ConnectAsync(CancellationToken ct) => Task.CompletedTask;
+        public void Dispose() { }
+
+        public TrackingLifecycle(string url)
+        {
+            TrackingClient = new TrackingGatewayClient(url);
+        }
+    }
+
+    /// <summary>
+    /// Extends OpenClawGatewayClient so it can be returned as DataClient.
+    /// Overrides the virtual approve methods to track which approval API
+    /// the manager actually calls.
+    /// </summary>
+    internal sealed class TrackingGatewayClient : OpenClawGatewayClient
+    {
+        private readonly List<string> _approvalMethodsCalled = [];
+        private bool _simulatedConnected;
+        private TaskCompletionSource? _approvalSignal;
+        private TaskCompletionSource? _approveGate; // blocks NodePairApproveAsync until released
+
+        public IReadOnlyList<string> ApprovalMethodsCalled => _approvalMethodsCalled;
+
+        public TrackingGatewayClient(string url)
+            : base(url, "mock-token", NullLogger.Instance) { }
+
+        public void SetGrantedScopes(string[] scopes)
+        {
+            var field = typeof(OpenClawGatewayClient).GetField(
+                "_grantedOperatorScopes",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(field); // Fail loudly if the field is renamed
+            field!.SetValue(this, scopes);
+        }
+
+        public void SetIsConnected(bool connected)
+        {
+            _simulatedConnected = connected;
+        }
+
+        /// <summary>
+        /// Returns a task that completes when the next approval method is called.
+        /// Use instead of Task.Delay for deterministic test synchronization.
+        /// </summary>
+        public Task WaitForApprovalCallAsync(int timeoutMs = 5000)
+        {
+            _approvalSignal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            return _approvalSignal.Task.WaitAsync(TimeSpan.FromMilliseconds(timeoutMs));
+        }
+
+        /// <summary>
+        /// Makes NodePairApproveAsync block until <see cref="ReleaseApproveGate"/> is called.
+        /// Used to keep an approval in-flight so concurrent calls can be tested.
+        /// </summary>
+        public void BlockApproveUntilReleased()
+        {
+            _approveGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        /// <summary>Releases a blocked NodePairApproveAsync call.</summary>
+        public void ReleaseApproveGate()
+        {
+            _approveGate?.TrySetResult();
+        }
+
+        public override bool IsConnectedToGateway => _simulatedConnected;
+
+        public override async Task<bool> NodePairApproveAsync(string requestId)
+        {
+            _approvalMethodsCalled.Add("node.pair.approve");
+            _approvalSignal?.TrySetResult();
+            if (_approveGate != null)
+                await _approveGate.Task;
+            return true;
+        }
+
+        public override Task<bool> DevicePairApproveAsync(string requestId)
+        {
+            _approvalMethodsCalled.Add("device.pair.approve");
+            _approvalSignal?.TrySetResult();
+            return Task.FromResult(true);
+        }
+    }
+
+    private sealed class ScriptedNodeConnector : INodeConnector
+    {
+        public bool IsConnected { get; private set; }
+        public PairingStatus PairingStatus { get; set; } = PairingStatus.Unknown;
+        public string? NodeDeviceId { get; set; }
+        public NodeConnectionMode Mode { get; set; } = NodeConnectionMode.Disabled;
+
+        public event EventHandler<ConnectionStatus>? StatusChanged;
+        public event EventHandler<PairingStatusEventArgs>? PairingStatusChanged;
+#pragma warning disable CS0067
+        public event EventHandler<NodeClientCreatedEventArgs>? ClientCreated;
+#pragma warning restore CS0067
+
+        public Task ConnectAsync(string gatewayUrl, GatewayCredential credential,
+            string identityPath, bool useV2Signature = false)
+        {
+            Mode = NodeConnectionMode.Gateway;
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync() => Task.CompletedTask;
+
+        public void FireStatusChanged(ConnectionStatus status)
+        {
+            IsConnected = status == ConnectionStatus.Connected;
+            StatusChanged?.Invoke(this, status);
+        }
+
+        public void FirePairingStatusChanged(PairingStatus status, string? requestId = null)
+        {
+            PairingStatus = status;
+            PairingStatusChanged?.Invoke(this, new PairingStatusEventArgs(
+                status, NodeDeviceId ?? "test-node", requestId: requestId));
+        }
+
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
## Problem

The auto-approval handler in `GatewayConnectionManager.OnNodePairingStatusChanged` was calling `DevicePairApproveAsync` (`device.pair.approve`) for node command upgrade pairing requests. Device pairing and node command pairing are **separate systems** with separate request stores on the gateway, so the gateway returned `unknown requestId` and the auto-approval silently failed — leaving the node with **0 effective commands**.

## Root Cause

Line 725 of `GatewayConnectionManager.cs` called the wrong approval method:
- **Before:** `operatorClient.DevicePairApproveAsync(e.RequestId)`
- **After:** `operatorClient.NodePairApproveAsync(e.RequestId)`

## Changes

### Bug Fix
- `DevicePairApproveAsync` → `NodePairApproveAsync` in the auto-approval path

### Race Condition Fix
- Added `_autoApproveInFlight` with `Interlocked.CompareExchange` — atomic guard ensures only one approval runs at a time
- Single `try/finally` with `Interlocked.Exchange` for cleanup

### Gateway Switch Cleanup
- Clear `_lastAutoApprovedRequestId` and `_autoApproveInFlight` in `DisposeActiveClient` so gateway switches start clean

### Testability
- Made `NodePairApproveAsync`, `DevicePairApproveAsync`, `IsConnectedToGateway` virtual on `OpenClawGatewayClient`

### Diagnostics
- Log caps/commands counts in the node handshake connect message
- Log `AttachClient` capability registration state
- Log `ClientCreated` event handler state in the diagnostics timeline
- Expose `RegisteredCapabilityCount`, `RegisteredCommandCount`, `RegisteredCommandsSample` (read-only) on `WindowsNodeClient`; `Registration` made internal

### Tests (4 new)
- `AutoApprove_CallsNodePairApprove_NotDevicePairApprove` — core regression test
- `AutoApprove_WithoutRequestId_DoesNotAttemptApproval`
- `AutoApprove_WithoutAdminScope_DoesNotAttemptApproval`
- `AutoApprove_SameRequestId_DoesNotApproveTwice` — exercises CAS guard with blocked in-flight approval

## Validation
- `./build.ps1` ✅
- `dotnet test OpenClaw.Shared.Tests` — 1,548 passed ✅
- `dotnet test OpenClaw.Tray.Tests` — 1,182 passed ✅
- Live tested: node now reports 18 commands on gateway (`openclaw nodes describe`)
