### PR TITLE
Tray menu (right-click): Fluent style tray-menu redesign

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -972,6 +972,16 @@ public partial class App : Application
         {
             case "status": ShowStatusDetail(); break;
             case "reconnect": _ = _connectionManager?.ReconnectAsync(); break;
+            case "disconnect":
+                _ = _connectionManager?.DisconnectAsync();
+                _lastSessions = Array.Empty<SessionInfo>();
+                _lastNodePairList = null;
+                _lastDevicePairList = null;
+                _lastModelsList = null;
+                _agentEventsCache.Clear();
+                UpdateTrayIcon();
+                _hubWindow?.UpdateStatus(ConnectionStatus.Disconnected);
+                break;
             case "dashboard": OpenDashboard(); break;
             case "canvas": ShowCanvasWindow(); break;
             case "openchat": ShowChatWindow(); break;
@@ -1251,6 +1261,7 @@ public partial class App : Application
         var criticalBrush = (Microsoft.UI.Xaml.Media.Brush)resources["SystemFillColorCriticalBrush"];
         var secondaryText = (Microsoft.UI.Xaml.Media.Brush)resources["TextFillColorSecondaryBrush"];
         var captionStyle = (Style)resources["CaptionTextBlockStyle"];
+        var controlSecondaryFill = (Microsoft.UI.Xaml.Media.Brush)resources["ControlFillColorSecondaryBrush"];
 
         // ── Brand Header (non-interactive) — VarB: horizontal block,
         //     emoji 28 + "OpenClaw" SemiBold 18, padding 14,10,14,8.
@@ -1281,22 +1292,27 @@ public partial class App : Application
         });
 
         // ── Gateway Section ──
-        var gwGrid = new Grid
+        // (device-card format)
+        var gwOuter = new StackPanel
         {
-            Padding = new Thickness(14, 4, 14, 8),
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            ColumnDefinitions =
-            {
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
-                new ColumnDefinition { Width = GridLength.Auto }
-            }
+            Padding = new Thickness(12, 8, 12, 8),
+            Spacing = 2,
+            HorizontalAlignment = HorizontalAlignment.Stretch
         };
 
-        var gwInfo = new StackPanel { Spacing = 2, VerticalAlignment = VerticalAlignment.Center };
+        // ── Line 1: dot + "Gateway" + Local chip ──
+        var gwLine1 = new Grid { ColumnSpacing = 6 };
+        gwLine1.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        gwLine1.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        gwLine1.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
-        // Gateway status line
-        var gwStatusRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6 };
-        gwStatusRow.Children.Add(new Microsoft.UI.Xaml.Shapes.Ellipse
+        var gwNameRow = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        gwNameRow.Children.Add(new Microsoft.UI.Xaml.Shapes.Ellipse
         {
             Width = 8, Height = 8,
             VerticalAlignment = VerticalAlignment.Center,
@@ -1304,122 +1320,103 @@ public partial class App : Application
                 : _currentStatus == ConnectionStatus.Connecting ? cautionBrush
                 : neutralBrush
         });
-        gwStatusRow.Children.Add(new TextBlock
+        gwNameRow.Children.Add(new TextBlock
         {
-            Text = $"Gateway · {statusText}",
-            Style = captionStyle,
-            FontSize = 12,
-            VerticalAlignment = VerticalAlignment.Center
+            Text = "Gateway",
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+            FontSize = 13,
+            VerticalAlignment = VerticalAlignment.Center,
+            IsTextSelectionEnabled = false
         });
-        gwInfo.Children.Add(gwStatusRow);
+        Grid.SetColumn(gwNameRow, 0);
+        gwLine1.Children.Add(gwNameRow);
 
-        // Gateway details
+        // Right-side chip: "Local" when connected to localhost, else version chip when available
+        string? chipText = null;
+        var gwUrl = _settings?.GetEffectiveGatewayUrl();
+        Uri? gwUri = null;
+        if (!string.IsNullOrEmpty(gwUrl)) Uri.TryCreate(gwUrl, UriKind.Absolute, out gwUri);
         if (isConnected)
         {
-            var detailParts = new List<string>();
-            if (_lastGatewaySelf != null && !string.IsNullOrEmpty(_lastGatewaySelf.ServerVersion))
-                detailParts.Add($"v{_lastGatewaySelf.ServerVersion}");
-            var url = _settings?.GetEffectiveGatewayUrl();
-            if (!string.IsNullOrEmpty(url) && Uri.TryCreate(url, UriKind.Absolute, out var uri))
-                detailParts.Add($"{uri.Host}:{uri.Port}");
-            if (_lastPresence != null && _lastPresence.Length > 0)
-                detailParts.Add($"{_lastPresence.Length} client{(_lastPresence.Length != 1 ? "s" : "")}");
-            if (detailParts.Count > 0)
-            {
-                gwInfo.Children.Add(new TextBlock
-                {
-                    Text = string.Join(" · ", detailParts),
-                    Style = captionStyle,
-                    Foreground = secondaryText,
-                    FontSize = 11
-                });
-            }
+            if (gwUri != null && (gwUri.Host == "localhost" || gwUri.Host == "127.0.0.1" || gwUri.Host == "::1"))
+                chipText = "Local";
+            else if (_lastGatewaySelf != null && !string.IsNullOrEmpty(_lastGatewaySelf.ServerVersion))
+                chipText = $"v{_lastGatewaySelf.ServerVersion}";
         }
+        if (chipText != null)
+        {
+            var chip = new Border
+            {
+                CornerRadius = new CornerRadius(4),
+                Padding = new Thickness(6, 1, 6, 1),
+                Background = controlSecondaryFill,
+                VerticalAlignment = VerticalAlignment.Center,
+                Child = new TextBlock
+                {
+                    Text = chipText,
+                    FontSize = 10,
+                    Foreground = secondaryText,
+                    IsTextSelectionEnabled = false
+                }
+            };
+            Grid.SetColumn(chip, 2);
+            gwLine1.Children.Add(chip);
+        }
+        gwOuter.Children.Add(gwLine1);
 
-        // Node pairing status
+        // ── Line 2: secondary details ──
+        var gwLine2Parts = new List<string>();
+        if (gwUri != null) gwLine2Parts.Add($"{gwUri.Host}:{gwUri.Port}");
+        gwLine2Parts.Add(statusText.ToLowerInvariant());
+        if (isConnected && _lastPresence != null && _lastPresence.Length > 0)
+            gwLine2Parts.Add($"{_lastPresence.Length} client{(_lastPresence.Length != 1 ? "s" : "")}");
         if (_settings?.EnableNodeMode == true && _nodeService != null)
         {
-            var nodeText = _nodeService.IsPaired ? "Node paired"
-                : _nodeService.IsPendingApproval ? "⏳ Node pairing pending"
-                : _nodeService.IsConnected ? "Node connected"
-                : null;
-            if (nodeText != null)
-            {
-                gwInfo.Children.Add(new TextBlock
-                {
-                    Text = nodeText,
-                    Style = captionStyle,
-                    Foreground = secondaryText,
-                    FontSize = 11
-                });
-            }
+            if (_nodeService.IsPaired) gwLine2Parts.Add("node paired");
+            else if (_nodeService.IsPendingApproval) gwLine2Parts.Add("node pairing pending");
+            else if (_nodeService.IsConnected) gwLine2Parts.Add("node connected");
         }
+        gwOuter.Children.Add(new TextBlock
+        {
+            Text = string.Join(" · ", gwLine2Parts),
+            Style = captionStyle,
+            Foreground = secondaryText,
+            FontSize = 11,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            IsTextSelectionEnabled = false
+        });
 
-        // Auth failure
+        // Auth failure inline (line 3, critical brush) ── preserved from prior layout
         if (!string.IsNullOrEmpty(_authFailureMessage))
         {
-            gwInfo.Children.Add(new TextBlock
+            gwOuter.Children.Add(new TextBlock
             {
-                Text = $"⚠️ {_authFailureMessage}",
+                Text = _authFailureMessage,
                 Style = captionStyle,
                 Foreground = criticalBrush,
                 FontSize = 11,
                 TextWrapping = TextWrapping.Wrap,
-                MaxWidth = 240
+                MaxWidth = 240,
+                IsTextSelectionEnabled = false
             });
         }
 
-        Grid.SetColumn(gwInfo, 0);
-        gwGrid.Children.Add(gwInfo);
+        // Hover flyout: Disconnect/Reconnect action verbs + open settings.
+        // Button label uses the ACTION verb ("Disconnect") not the current
+        // state, per UX convention.
+        var gwFlyoutItems = new List<TrayMenuFlyoutItem>
+        {
+            new() { Text = "Gateway", IsHeader = true },
+        };
+        if (isConnected)
+            gwFlyoutItems.Add(new() { Text = "Disconnect", Action = "disconnect" });
+        else
+            gwFlyoutItems.Add(new() { Text = "Connect", Action = "reconnect" });
+        gwFlyoutItems.Add(new() { Text = "Open connection settings", Action = "connection" });
 
-        // Gateway connect/disconnect button
-        var connectBtn = new ToggleButton
-        {
-            IsChecked = isConnected,
-            Content = isConnected ? "Connected" : "Disconnected",
-            VerticalAlignment = VerticalAlignment.Center,
-            HorizontalAlignment = HorizontalAlignment.Right,
-            Padding = new Thickness(10, 4, 10, 4),
-            MinHeight = 0,
-            MinWidth = 0,
-            FontSize = 11
-        };
-        AutomationProperties.SetName(connectBtn, isConnected ? "Disconnect from gateway" : "Connect to gateway");
-        ToolTipService.SetToolTip(connectBtn, isConnected ? "Click to disconnect from gateway" : "Click to connect to gateway");
-        connectBtn.Click += (s, ev) =>
-        {
-            var on = connectBtn.IsChecked == true;
-            connectBtn.Content = on ? "Connected" : "Disconnected";
-            ToolTipService.SetToolTip(connectBtn, on ? "Click to disconnect from gateway" : "Click to connect to gateway");
-            if (on)
-            {
-                _ = _connectionManager?.ReconnectAsync();
-            }
-            else
-            {
-                _ = _connectionManager?.DisconnectAsync();
-                // Status is updated by OnManagerStateChanged when disconnect completes.
-                _lastSessions = Array.Empty<SessionInfo>();
-                _lastNodePairList = null;
-                _lastDevicePairList = null;
-                _lastModelsList = null;
-                _agentEventsCache.Clear();
-                UpdateTrayIcon();
-                _hubWindow?.UpdateStatus(ConnectionStatus.Disconnected);
-            }
-            // Dismiss menu after toggle — header will rebuild with correct state on next open
-            _trayMenuWindow?.HideCascade();
-        };
-        Grid.SetColumn(connectBtn, 1);
-        gwGrid.Children.Add(connectBtn);
-
-        // Make gateway info area clickable → opens Connection page
-        gwInfo.Tapped += (s, ev) =>
-        {
-            ShowHub("connection");
-        };
-        AutomationProperties.SetName(gwInfo, $"Gateway {statusText}. Activate to open connection settings.");
-        menu.AddCustomElement(gwGrid);
+        AutomationProperties.SetName(gwOuter,
+            $"Gateway {statusText}. Activate to open connection settings.");
+        menu.AddFlyoutCustomItem(gwOuter, gwFlyoutItems, action: "connection");
 
         // ── Connected Devices (moved above Sessions) ──
         var connectedNodes = _lastNodes.Where(n => n.IsOnline).ToArray();

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1531,7 +1531,7 @@ public partial class App : Application
             "Companion Settings...",
             FluentIconCatalog.Build(FluentIconCatalog.Settings),
             "companion",
-            "Win+;");
+            "Ctrl+Alt+;");
         menu.AddMenuItem("About", FluentIconCatalog.Build(FluentIconCatalog.About), "about");
         menu.AddMenuItem("Close", FluentIconCatalog.Build(FluentIconCatalog.Exit), "exit");
     }

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -730,6 +730,7 @@ public partial class App : Application
             _globalHotkey = new GlobalHotkeyService();
             _globalHotkey.HotkeyPressed += OnGlobalHotkeyPressed;
             _globalHotkey.VoiceHotkeyPressed += OnVoiceHotkeyPressed;
+            _globalHotkey.SettingsHotkeyPressed += OnSettingsHotkeyPressed;
             _globalHotkey.Register();
         }
 
@@ -1401,22 +1402,61 @@ public partial class App : Application
             });
         }
 
-        // Hover flyout: Disconnect/Reconnect action verbs + open settings.
-        // Button label uses the ACTION verb ("Disconnect") not the current
-        // state, per UX convention.
-        var gwFlyoutItems = new List<TrayMenuFlyoutItem>
+        // Wrap the 2-line content in a Grid with a visible Disconnect/Connect
+        // button on the right side. The info area is clickable to open
+        // connection settings; the button is its own click target.
+        var gwHost = new Grid
         {
-            new() { Text = "Gateway", IsHeader = true },
+            Padding = new Thickness(14, 6, 14, 8),
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            ColumnSpacing = 8
         };
-        if (isConnected)
-            gwFlyoutItems.Add(new() { Text = "Disconnect", Action = "disconnect" });
-        else
-            gwFlyoutItems.Add(new() { Text = "Connect", Action = "reconnect" });
-        gwFlyoutItems.Add(new() { Text = "Open connection settings", Action = "connection" });
+        gwHost.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        gwHost.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        // Move gwOuter padding to the host Grid since gwOuter is now nested.
+        gwOuter.Padding = new Thickness(0);
+        gwOuter.Tapped += (s, ev) => ShowHub("connection");
+        Grid.SetColumn(gwOuter, 0);
+        gwHost.Children.Add(gwOuter);
+
+        var gwBtn = new Button
+        {
+            Content = isConnected ? "Disconnect" : "Connect",
+            VerticalAlignment = VerticalAlignment.Center,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Padding = new Thickness(12, 4, 12, 4),
+            MinHeight = 0,
+            MinWidth = 0,
+            FontSize = 11
+        };
+        AutomationProperties.SetName(gwBtn, isConnected ? "Disconnect from gateway" : "Connect to gateway");
+        ToolTipService.SetToolTip(gwBtn, isConnected ? "Disconnect from gateway" : "Connect to gateway");
+        gwBtn.Click += (s, ev) =>
+        {
+            if (isConnected)
+            {
+                _ = _connectionManager?.DisconnectAsync();
+                _lastSessions = Array.Empty<SessionInfo>();
+                _lastNodePairList = null;
+                _lastDevicePairList = null;
+                _lastModelsList = null;
+                _agentEventsCache.Clear();
+                UpdateTrayIcon();
+                _hubWindow?.UpdateStatus(ConnectionStatus.Disconnected);
+            }
+            else
+            {
+                _ = _connectionManager?.ReconnectAsync();
+            }
+            _trayMenuWindow?.HideCascade();
+        };
+        Grid.SetColumn(gwBtn, 1);
+        gwHost.Children.Add(gwBtn);
 
         AutomationProperties.SetName(gwOuter,
             $"Gateway {statusText}. Activate to open connection settings.");
-        menu.AddFlyoutCustomItem(gwOuter, gwFlyoutItems, action: "connection");
+        menu.AddCustomElement(gwHost);
 
         // ── Connected Devices (moved above Sessions) ──
         var connectedNodes = _lastNodes.Where(n => n.IsOnline).ToArray();
@@ -1428,30 +1468,11 @@ public partial class App : Application
             var deviceSummaryRight = $"{connectedNodes.Length} online · {totalCaps} caps";
             menu.AddCustomElement(BuildSectionHeader("Devices", deviceSummaryRight));
 
-            var currentHost = Environment.MachineName;
-
             foreach (var node in connectedNodes.Take(5))
             {
                 var card = BuildDeviceCard(node, successBrush, neutralBrush, secondaryText);
                 var flyoutItems = BuildDeviceFlyoutItems(node);
                 menu.AddFlyoutCustomItem(card, flyoutItems, action: "nodes");
-
-                // If this node is the local machine, surface a Permissions
-                // submenu directly beneath it. The 3-column inline toggle
-                // grid that used to live here was too dense and shipped with
-                // emoji icons; the flyout collapses to a single row and
-                // routes through FluentIconCatalog.
-                bool isLocal = node.DisplayName?.Contains(currentHost, StringComparison.OrdinalIgnoreCase) == true
-                    || node.NodeId?.Contains(currentHost, StringComparison.OrdinalIgnoreCase) == true;
-                if (isLocal && _settings != null)
-                {
-                    var permIcon = FluentIconCatalog.Build(FluentIconCatalog.Permissions);
-                    menu.AddFlyoutMenuItem(
-                        "Permissions",
-                        permIcon,
-                        BuildPermissionsFlyoutItems(_settings),
-                        indent: true);
-                }
             }
         }
 
@@ -1468,24 +1489,25 @@ public partial class App : Application
 
             foreach (var session in _lastSessions.Take(4))
             {
-                var card = BuildSessionCard(session, successBrush, cautionBrush, neutralBrush, criticalBrush, secondaryText);
-                var flyoutItems = BuildSessionFlyoutItems(session);
+                var card = BuildSessionCardCompact(session, successBrush, cautionBrush, neutralBrush, secondaryText);
+                var flyoutItems = BuildSessionFlyoutItems(session, secondaryText);
                 menu.AddFlyoutCustomItem(card, flyoutItems, action: "sessions");
-            }
-
-            if (_lastSessions.Length > 4)
-            {
-                var extra = _lastSessions.Length - 4;
-                menu.AddMenuItem(
-                    $"More ({extra} more)",
-                    FluentIconCatalog.Build(FluentIconCatalog.Sessions),
-                    "sessions",
-                    indent: true);
             }
         }
 
-        // ── Pairing approval pending (closest analogue to the spec's
-        // "exec approvals" row in current code) ──
+        // ── Usage ──
+        if (_lastSessions.Length > 0)
+        {
+            menu.AddSeparator();
+            var totalTokensAll2 = _lastSessions.Sum(s => s.InputTokens + s.OutputTokens);
+            menu.AddCustomElement(BuildSectionHeader("Usage", $"{FormatTokenCount(totalTokensAll2)} tokens"));
+            menu.AddMenuItem(
+                "View detailed usage",
+                FluentIconCatalog.Build(FluentIconCatalog.About),
+                "usage");
+        }
+
+        // ── Pairing approval pending ──
         var nodePendingCount = _lastNodePairList?.Pending.Count ?? 0;
         var devicePendingCount = _lastDevicePairList?.Pending.Count ?? 0;
         if (nodePendingCount + devicePendingCount > 0)
@@ -1499,24 +1521,25 @@ public partial class App : Application
 
         // ── Actions ──
         menu.AddSeparator();
+        if (_settings != null)
+        {
+            menu.AddFlyoutMenuItem(
+                "Permissions",
+                FluentIconCatalog.Build(FluentIconCatalog.Permissions),
+                BuildPermissionsFlyoutItems(_settings));
+        }
         menu.AddMenuItem("Dashboard", FluentIconCatalog.Build(FluentIconCatalog.Dashboard), "dashboard");
         menu.AddMenuItem("Chat", FluentIconCatalog.Build(FluentIconCatalog.Chat), "openchat");
         menu.AddMenuItem("Canvas", FluentIconCatalog.Build(FluentIconCatalog.CanvasAct), "canvas");
         menu.AddMenuItem("Voice", FluentIconCatalog.Build(FluentIconCatalog.VoiceAct), "voice");
-        menu.AddMenuItem("Companion Settings...", FluentIconCatalog.Build(FluentIconCatalog.Settings), "companion");
-        menu.AddMenuItem(LocalizationHelper.GetString("Menu_QuickSend"), FluentIconCatalog.Build(FluentIconCatalog.QuickSend), "quicksend");
-
-        // Setup Guide / Reconfigure entry (PR #274 must-fix #6) — label flips
-        // based on whether prior config exists.
-        var setupMenuLabel = _settings != null
-            && new OpenClawTray.Onboarding.Services.OnboardingExistingConfigGuard(_settings, IdentityDataPath)
-                .HasExistingConfiguration()
-            ? LocalizationHelper.GetString("Menu_Reconfigure")
-            : LocalizationHelper.GetString("Menu_SetupGuide");
-        menu.AddMenuItem(setupMenuLabel, FluentIconCatalog.Build(FluentIconCatalog.Setup), "setup");
 
         // ── Footer ──
         menu.AddSeparator();
+        menu.AddMenuItemWithHint(
+            "Companion Settings...",
+            FluentIconCatalog.Build(FluentIconCatalog.Settings),
+            "companion",
+            "Win+;");
         menu.AddMenuItem("About", FluentIconCatalog.Build(FluentIconCatalog.About), "about");
         menu.AddMenuItem(LocalizationHelper.GetString("Menu_Exit"), FluentIconCatalog.Build(FluentIconCatalog.Exit), "exit");
     }
@@ -1547,30 +1570,29 @@ public partial class App : Application
             () => settings.NodeLocationEnabled, v => settings.NodeLocationEnabled = v);
         AddPermToggle(items, "Allow voice (TTS)", FluentIconCatalog.Voice,
             () => settings.NodeTtsEnabled, v => settings.NodeTtsEnabled = v);
+        AddPermToggle(items, "Allow speech-to-text (STT)", FluentIconCatalog.Voice,
+            () => settings.NodeSttEnabled, v => settings.NodeSttEnabled = v);
 
         return items;
     }
 
     private void AddPermToggle(List<TrayMenuFlyoutItem> items, string label, string iconGlyph, Func<bool> get, Action<bool> set)
     {
-        // Encode current state in the visible glyph: a check prefix when on,
-        // the capability glyph alone when off. The action id round-trips
-        // through OnTrayMenuItemClicked which calls back into the toggler.
         var on = get();
-        var prefix = on ? FluentIconCatalog.Check : iconGlyph;
         var actionId = $"perm-toggle|{label}";
         items.Add(new TrayMenuFlyoutItem
         {
-            Text = (on ? "✓  " : "    ") + label,
-            Icon = prefix,
+            Text = label,
+            Icon = iconGlyph,
             Action = actionId,
+            IsToggle = true,
+            IsOn = on,
         });
         _permToggleActions[actionId] = () =>
         {
             set(!get());
             _settings?.Save();
             _ = _connectionManager?.ReconnectAsync();
-            // Repaint the menu so the check mark reflects new state.
             if (_trayMenuWindow != null && _trayMenuWindow.IsShown)
             {
                 _trayMenuWindow.ClearItems();
@@ -1639,41 +1661,30 @@ public partial class App : Application
         return $"{(int)age.TotalDays}d ago";
     }
 
-    private static UIElement BuildSessionCard(
+    private static UIElement BuildSessionCardCompact(
         SessionInfo session,
         Microsoft.UI.Xaml.Media.Brush successBrush,
         Microsoft.UI.Xaml.Media.Brush cautionBrush,
         Microsoft.UI.Xaml.Media.Brush neutralBrush,
-        Microsoft.UI.Xaml.Media.Brush criticalBrush,
         Microsoft.UI.Xaml.Media.Brush secondaryText)
     {
-        // VarB: verbose two-row session card with progress bar.
-        //   Row 0: ● {name}                              {N}m ago
-        //   Row 1: {model}
-        //          [████████░░░░░░]  {used} / {context}
-        var usedTokens = session.InputTokens + session.OutputTokens;
-        var contextTokens = session.ContextTokens > 0 ? session.ContextTokens : 200_000;
-        var pct = usedTokens > 0 ? (int)(Math.Min(1.0, (double)usedTokens / contextTokens) * 100) : 0;
+        // VarB compact: one line — ● {name}    {N}m ago
+        // Details (model + ProgressBar) live in the hover flyout.
         var isActive = string.Equals(session.Status, "active", StringComparison.OrdinalIgnoreCase);
         var isIdle = string.Equals(session.Status, "idle", StringComparison.OrdinalIgnoreCase);
 
         var resources = Application.Current.Resources;
-        var tertiaryText = (Microsoft.UI.Xaml.Media.Brush)resources["TextFillColorTertiaryBrush"];
         var captionStyle = (Style)resources["CaptionTextBlockStyle"];
 
-        var grid = new Grid
+        var row = new Grid
         {
-            Padding = new Thickness(12, 8, 12, 8),
+            Padding = new Thickness(12, 6, 12, 6),
             HorizontalAlignment = HorizontalAlignment.Stretch,
-            RowSpacing = 4,
             ColumnSpacing = 8
         };
-        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
-        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
-        // Row 0 Col 0: status dot + display name
         var nameRow = new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -1684,9 +1695,7 @@ public partial class App : Application
         {
             Width = 8, Height = 8,
             VerticalAlignment = VerticalAlignment.Center,
-            Fill = isActive ? successBrush
-                : isIdle ? cautionBrush
-                : neutralBrush
+            Fill = isActive ? successBrush : isIdle ? cautionBrush : neutralBrush
         });
         nameRow.Children.Add(new TextBlock
         {
@@ -1697,62 +1706,72 @@ public partial class App : Application
             VerticalAlignment = VerticalAlignment.Center,
             IsTextSelectionEnabled = false
         });
-        Grid.SetRow(nameRow, 0);
         Grid.SetColumn(nameRow, 0);
-        grid.Children.Add(nameRow);
+        row.Children.Add(nameRow);
 
-        // Row 0 Col 1: relative time (only if UpdatedAt is set)
         if (session.UpdatedAt.HasValue)
         {
-            grid.Children.Add(new TextBlock
+            var time = new TextBlock
             {
                 Text = FormatRelative(session.UpdatedAt.Value),
                 Style = captionStyle,
                 FontSize = 11,
                 Foreground = secondaryText,
-                HorizontalAlignment = HorizontalAlignment.Right,
                 VerticalAlignment = VerticalAlignment.Center,
                 IsTextSelectionEnabled = false,
-            });
-            var timeBlock = (TextBlock)grid.Children[^1];
-            Grid.SetRow(timeBlock, 0);
-            Grid.SetColumn(timeBlock, 1);
+            };
+            Grid.SetColumn(time, 1);
+            row.Children.Add(time);
         }
 
-        // Row 1 spans both columns: model line + progress row
-        var detailStack = new StackPanel { Spacing = 4 };
+        return row;
+    }
 
+    private static List<TrayMenuFlyoutItem> BuildSessionFlyoutItems(SessionInfo session, Microsoft.UI.Xaml.Media.Brush secondaryText)
+    {
+        var usedTokens = session.InputTokens + session.OutputTokens;
+        var contextTokens = session.ContextTokens > 0 ? session.ContextTokens : 200_000;
+        var pct = usedTokens > 0 ? (int)(Math.Min(1.0, (double)usedTokens / contextTokens) * 100) : 0;
+
+        var items = new List<TrayMenuFlyoutItem>
+        {
+            new() { Text = session.DisplayName ?? session.Key, IsHeader = true },
+        };
+
+        // Custom row: model name + ProgressBar + ratio
+        var resources = Application.Current.Resources;
+        var captionStyle = (Style)resources["CaptionTextBlockStyle"];
+
+        var detailStack = new StackPanel
+        {
+            Padding = new Thickness(12, 6, 12, 8),
+            Spacing = 4
+        };
         var modelText = !string.IsNullOrEmpty(session.Model) ? session.Model! : "unknown model";
         detailStack.Children.Add(new TextBlock
         {
             Text = modelText,
             Style = captionStyle,
             FontSize = 12,
-            Foreground = string.IsNullOrEmpty(session.Model) ? tertiaryText : secondaryText,
+            Foreground = secondaryText,
             TextTrimming = TextTrimming.CharacterEllipsis,
             IsTextSelectionEnabled = false
         });
-
         var progressRow = new Grid { ColumnSpacing = 8 };
         progressRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
         progressRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-
         var bar = new ProgressBar
         {
-            Minimum = 0,
-            Maximum = 100,
-            Value = pct,
-            Height = 4,
+            Minimum = 0, Maximum = 100, Value = pct, Height = 4,
             VerticalAlignment = VerticalAlignment.Center,
             HorizontalAlignment = HorizontalAlignment.Stretch,
             CornerRadius = new CornerRadius(2)
         };
         Grid.SetColumn(bar, 0);
         progressRow.Children.Add(bar);
-
-        var tokenLabel = new TextBlock
+        var tokLbl = new TextBlock
         {
-            Text = $"{FormatTokenCount(usedTokens)} / {FormatTokenCount(contextTokens)}",
+            Text = $"{FormatTokenCount(usedTokens)} / {FormatTokenCount(contextTokens)} ({pct}%)",
             Style = captionStyle,
             FontSize = 11,
             Foreground = secondaryText,
@@ -1760,80 +1779,33 @@ public partial class App : Application
             HorizontalAlignment = HorizontalAlignment.Right,
             IsTextSelectionEnabled = false
         };
-        Grid.SetColumn(tokenLabel, 1);
-        progressRow.Children.Add(tokenLabel);
-
+        Grid.SetColumn(tokLbl, 1);
+        progressRow.Children.Add(tokLbl);
         detailStack.Children.Add(progressRow);
+        items.Add(new() { CustomContent = detailStack });
 
-        Grid.SetRow(detailStack, 1);
-        Grid.SetColumn(detailStack, 0);
-        Grid.SetColumnSpan(detailStack, 2);
-        grid.Children.Add(detailStack);
-
-        return grid;
-    }
-
-    private static List<TrayMenuFlyoutItem> BuildSessionFlyoutItems(SessionInfo session)
-    {
-        var usedTokens = session.InputTokens + session.OutputTokens;
-        var contextTokens = session.ContextTokens > 0 ? session.ContextTokens : 200_000;
-        var pct = usedTokens > 0 ? (int)(Math.Min(1.0, (double)usedTokens / contextTokens) * 100) : 0;
-        var statusIcon = string.Equals(session.Status, "active", StringComparison.OrdinalIgnoreCase) ? "🟢"
-            : string.Equals(session.Status, "done", StringComparison.OrdinalIgnoreCase) ? "✅" : "⚪";
-
-        var items = new List<TrayMenuFlyoutItem>
-        {
-            new() { Text = session.DisplayName ?? session.Key, IsHeader = true },
-        };
-
-        // Model · Provider
-        var modelParts = new List<string>();
-        if (!string.IsNullOrEmpty(session.Model)) modelParts.Add(session.Model);
-        if (!string.IsNullOrEmpty(session.Provider)) modelParts.Add(session.Provider);
-        if (modelParts.Count > 0) items.Add(new() { Text = string.Join(" · ", modelParts) });
-
-        // Channel
+        // Channel / status
         if (!string.IsNullOrEmpty(session.Channel))
-            items.Add(new() { Text = $"📡 {session.Channel}" });
+            items.Add(new() { Text = $"Channel: {session.Channel}" });
+        items.Add(new() { Text = $"{session.Status} · {session.AgeText}" });
 
-        // Status · age
-        items.Add(new() { Text = $"{statusIcon} {session.Status} · {session.AgeText}" });
-
-        // Token usage
+        // Token detail breakdown
         items.Add(new() { Text = "Token Usage", IsHeader = true });
         if (usedTokens > 0)
         {
             items.Add(new() { Text = $"Input     {FormatTokenCount(session.InputTokens)}" });
             items.Add(new() { Text = $"Output    {FormatTokenCount(session.OutputTokens)}" });
-            items.Add(new() { Text = $"Total     {FormatTokenCount(usedTokens)} / {FormatTokenCount(contextTokens)} ({pct}%)" });
         }
         else
         {
             items.Add(new() { Text = "No token usage yet" });
         }
 
-        // Context window
-        if (session.ContextTokens > 0)
-            items.Add(new() { Text = $"Context   {FormatTokenCount(session.ContextTokens)} window" });
-
-        // Thinking / Verbose
-        if (!string.IsNullOrEmpty(session.ThinkingLevel) || !string.IsNullOrEmpty(session.VerboseLevel))
-        {
-            items.Add(new() { Text = "Settings", IsHeader = true });
-            if (!string.IsNullOrEmpty(session.ThinkingLevel))
-                items.Add(new() { Text = $"🧠 Thinking: {session.ThinkingLevel}" });
-            if (!string.IsNullOrEmpty(session.VerboseLevel))
-                items.Add(new() { Text = $"📝 Verbose: {session.VerboseLevel}" });
-        }
-
-        // Subject / Room
-        if (!string.IsNullOrEmpty(session.Subject))
-            items.Add(new() { Text = $"Subject: {session.Subject}" });
-        if (!string.IsNullOrEmpty(session.Room))
-            items.Add(new() { Text = $"Room: {session.Room}" });
-
         return items;
     }
+
+    private static List<TrayMenuFlyoutItem> BuildSessionFlyoutItems(SessionInfo session)
+        => BuildSessionFlyoutItems(session, (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]);
 
     private static UIElement BuildDeviceCard(
         GatewayNodeInfo node,
@@ -3583,6 +3555,8 @@ public partial class App : Application
             _globalHotkey ??= new GlobalHotkeyService();
             _globalHotkey.HotkeyPressed -= OnGlobalHotkeyPressed;
             _globalHotkey.HotkeyPressed += OnGlobalHotkeyPressed;
+            _globalHotkey.SettingsHotkeyPressed -= OnSettingsHotkeyPressed;
+            _globalHotkey.SettingsHotkeyPressed += OnSettingsHotkeyPressed;
             _globalHotkey.Register();
         }
         else
@@ -4159,6 +4133,12 @@ public partial class App : Application
     {
         if (_dispatcherQueue == null) return;
         _dispatcherQueue.TryEnqueue(() => ShowVoiceOverlay());
+    }
+
+    private void OnSettingsHotkeyPressed(object? sender, EventArgs e)
+    {
+        if (_dispatcherQueue == null) return;
+        _dispatcherQueue.TryEnqueue(() => ShowHub("companion"));
     }
 
     #endregion

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -2,6 +2,7 @@ using Microsoft.Toolkit.Uwp.Notifications;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using OpenClaw.Shared;
 using OpenClawTray.Dialogs;
@@ -1282,12 +1283,12 @@ public partial class App : Application
             VerticalAlignment = VerticalAlignment.Center,
             Children =
             {
-                new TextBlock
+                new Microsoft.UI.Xaml.Controls.Image
                 {
-                    Text = FluentIconCatalog.Brand,
-                    FontSize = 28,
-                    VerticalAlignment = VerticalAlignment.Center,
-                    IsTextSelectionEnabled = false
+                    Source = new BitmapImage(new Uri("ms-appx:///Assets/Square44x44Logo.targetsize-48_altform-unplated.png")),
+                    Width = 28,
+                    Height = 28,
+                    VerticalAlignment = VerticalAlignment.Center
                 },
                 new TextBlock
                 {
@@ -1462,11 +1463,16 @@ public partial class App : Application
 
         // Tap the gateway block to open connection settings (button has its own click handler)
         gwOuter.Padding = new Thickness(14, 6, 14, 8);
-        gwOuter.Tapped += (s, ev) => ShowHub("connection");
 
         AutomationProperties.SetName(gwOuter,
             $"Gateway {statusText}. Activate to open connection settings.");
-        menu.AddCustomElement(gwOuter);
+
+        // Gateway hover flyout — richer connection details
+        var gwFlyoutItems = BuildGatewayFlyoutItems(
+            isConnected, statusText, gwUri, _lastPresence, _lastGatewaySelf,
+            _lastNodePairList, _lastDevicePairList, _authFailureMessage,
+            captionStyle, secondaryText, successBrush, neutralBrush, criticalBrush);
+        menu.AddFlyoutCustomItem(gwOuter, gwFlyoutItems, action: "connection");
 
         // ── Connected Devices (moved above Sessions) ──
         // Devices flow directly after the Gateway block without a divider
@@ -1498,9 +1504,8 @@ public partial class App : Application
             menu.AddFlyoutCustomItem(sessionsRow, sessionsFlyout, action: "sessions");
         }
 
-        // ── Usage ──
+        // ── Usage (no divider — flows directly under Sessions) ──
         {
-            menu.AddSeparator();
             var usageRow = BuildUsageRow(secondaryText);
             var usageFlyout = BuildUsageFlyoutItems(secondaryText);
             menu.AddFlyoutCustomItem(usageRow, usageFlyout, action: "usage");
@@ -1528,7 +1533,7 @@ public partial class App : Application
             "companion",
             "Win+;");
         menu.AddMenuItem("About", FluentIconCatalog.Build(FluentIconCatalog.About), "about");
-        menu.AddMenuItem(LocalizationHelper.GetString("Menu_Exit"), FluentIconCatalog.Build(FluentIconCatalog.Exit), "exit");
+        menu.AddMenuItem("Close", FluentIconCatalog.Build(FluentIconCatalog.Exit), "exit");
     }
 
     /// <summary>
@@ -1746,6 +1751,177 @@ public partial class App : Application
         grid.Children.Add(summary);
 
         return grid;
+    }
+
+    private static List<TrayMenuFlyoutItem> BuildGatewayFlyoutItems(
+        bool isConnected,
+        string statusText,
+        Uri? gwUri,
+        PresenceEntry[]? presence,
+        GatewaySelfInfo? self,
+        PairingListInfo? nodePair,
+        DevicePairingListInfo? devicePair,
+        string? authFailure,
+        Style captionStyle,
+        Microsoft.UI.Xaml.Media.Brush secondaryText,
+        Microsoft.UI.Xaml.Media.Brush successBrush,
+        Microsoft.UI.Xaml.Media.Brush neutralBrush,
+        Microsoft.UI.Xaml.Media.Brush criticalBrush)
+    {
+        var items = new List<TrayMenuFlyoutItem>
+        {
+            new() { Text = "Gateway", IsHeader = true }
+        };
+
+        // Status card: ● Online/Offline · localhost:7070
+        var statusCard = new StackPanel
+        {
+            Padding = new Thickness(12, 2, 12, 6),
+            Spacing = 2,
+            MinWidth = 280
+        };
+        var statusLine = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        statusLine.Children.Add(new Microsoft.UI.Xaml.Shapes.Ellipse
+        {
+            Width = 8, Height = 8,
+            VerticalAlignment = VerticalAlignment.Center,
+            Fill = isConnected ? successBrush : neutralBrush
+        });
+        var statusParts = new List<string> { statusText };
+        if (gwUri != null) statusParts.Add($"{gwUri.Host}:{gwUri.Port}");
+        statusLine.Children.Add(new TextBlock
+        {
+            Text = string.Join(" · ", statusParts),
+            FontSize = 12,
+            VerticalAlignment = VerticalAlignment.Center,
+            IsTextSelectionEnabled = false
+        });
+        statusCard.Children.Add(statusLine);
+
+        if (gwUri != null)
+        {
+            statusCard.Children.Add(new TextBlock
+            {
+                Text = gwUri.ToString(),
+                Style = captionStyle,
+                FontSize = 11,
+                Foreground = secondaryText,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                IsTextSelectionEnabled = false
+            });
+        }
+        items.Add(new() { CustomContent = statusCard });
+
+        if (!string.IsNullOrEmpty(authFailure))
+        {
+            var authRow = new StackPanel { Padding = new Thickness(12, 2, 12, 4) };
+            authRow.Children.Add(new TextBlock
+            {
+                Text = authFailure,
+                Style = captionStyle, FontSize = 11,
+                Foreground = criticalBrush,
+                TextWrapping = TextWrapping.Wrap,
+                MaxWidth = 260,
+                IsTextSelectionEnabled = false
+            });
+            items.Add(new() { CustomContent = authRow });
+        }
+
+        // Server details
+        if (self != null && self.HasAnyDetails)
+        {
+            items.Add(new() { Text = "Server", IsHeader = true });
+            if (!string.IsNullOrEmpty(self.ServerVersion))
+                items.Add(BuildKvRow("Version", $"v{self.ServerVersion}", secondaryText, captionStyle));
+            if (!string.IsNullOrEmpty(self.AuthMode))
+                items.Add(BuildKvRow("Auth", self.AuthMode!, secondaryText, captionStyle));
+            if (self.Protocol.HasValue)
+                items.Add(BuildKvRow("Protocol", $"v{self.Protocol}", secondaryText, captionStyle));
+            if (self.UptimeMs.HasValue)
+                items.Add(BuildKvRow("Uptime", FormatUptime(self.UptimeMs.Value), secondaryText, captionStyle));
+            if (!string.IsNullOrEmpty(self.ConnectionId))
+                items.Add(BuildKvRow("Conn ID", self.ConnectionId!, secondaryText, captionStyle));
+        }
+
+        // Presence
+        if (isConnected && presence != null && presence.Length > 0)
+        {
+            items.Add(new() { Text = $"Clients ({presence.Length})", IsHeader = true });
+            foreach (var p in presence.Take(6))
+            {
+                var name = !string.IsNullOrEmpty(p.Host) ? p.Host! : (p.Platform ?? "client");
+                var detailParts = new List<string>();
+                if (!string.IsNullOrEmpty(p.Platform)) detailParts.Add(p.Platform!);
+                if (!string.IsNullOrEmpty(p.Version)) detailParts.Add($"v{p.Version}");
+                if (!string.IsNullOrEmpty(p.Mode)) detailParts.Add(p.Mode!);
+                items.Add(BuildKvRow(name!, string.Join(" · ", detailParts), secondaryText, captionStyle));
+            }
+        }
+
+        // Pending pairings (if any) — quick summary line
+        var nodePending = nodePair?.Pending.Count ?? 0;
+        var devicePending = devicePair?.Pending.Count ?? 0;
+        if (nodePending + devicePending > 0)
+        {
+            items.Add(new() { Text = "Pending approval", IsHeader = true });
+            if (nodePending > 0)
+                items.Add(BuildKvRow("Nodes", nodePending.ToString(), secondaryText, captionStyle));
+            if (devicePending > 0)
+                items.Add(BuildKvRow("Devices", devicePending.ToString(), secondaryText, captionStyle));
+        }
+
+        return items;
+    }
+
+    private static TrayMenuFlyoutItem BuildKvRow(string key, string value, Microsoft.UI.Xaml.Media.Brush secondaryText, Style captionStyle)
+    {
+        var grid = new Grid
+        {
+            Padding = new Thickness(12, 2, 12, 2),
+            ColumnSpacing = 12,
+            MinWidth = 260
+        };
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+        var k = new TextBlock
+        {
+            Text = key,
+            FontSize = 12,
+            VerticalAlignment = VerticalAlignment.Center,
+            Foreground = secondaryText,
+            IsTextSelectionEnabled = false
+        };
+        Grid.SetColumn(k, 0);
+        grid.Children.Add(k);
+
+        var v = new TextBlock
+        {
+            Text = value,
+            FontSize = 12,
+            VerticalAlignment = VerticalAlignment.Center,
+            TextAlignment = TextAlignment.Right,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            IsTextSelectionEnabled = false
+        };
+        Grid.SetColumn(v, 1);
+        grid.Children.Add(v);
+
+        return new TrayMenuFlyoutItem { CustomContent = grid };
+    }
+
+    private static string FormatUptime(long ms)
+    {
+        var ts = TimeSpan.FromMilliseconds(ms);
+        if (ts.TotalDays >= 1) return $"{(int)ts.TotalDays}d {ts.Hours}h";
+        if (ts.TotalHours >= 1) return $"{(int)ts.TotalHours}h {ts.Minutes}m";
+        if (ts.TotalMinutes >= 1) return $"{(int)ts.TotalMinutes}m";
+        return $"{(int)ts.TotalSeconds}s";
     }
 
     private List<TrayMenuFlyoutItem> BuildSessionsListFlyoutItems(

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1605,6 +1605,61 @@ public partial class App : Application
         return n.ToString();
     }
 
+    /// <summary>
+    /// Mini progress bar built from Borders inside a Grid (two Star columns:
+    /// pct and 100-pct). Avoids the default WinUI ProgressBar template which
+    /// renders 0-height inside dynamic-width flyout layouts.
+    /// </summary>
+    private static FrameworkElement BuildMiniBar(double percent)
+    {
+        var p = Math.Min(100.0, Math.Max(0.0, percent));
+        var resources = Application.Current.Resources;
+        var accent = (Microsoft.UI.Xaml.Media.Brush)resources["AccentFillColorDefaultBrush"];
+        var track = (Microsoft.UI.Xaml.Media.Brush)resources["ControlStrongFillColorDefaultBrush"];
+
+        var grid = new Grid
+        {
+            Height = 6,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Center,
+            MinWidth = 80
+        };
+        // 1e-6 guard so an empty (0%) bar still renders the track column at
+        // full width; a 0/0 star pair would collapse.
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(Math.Max(0.0001, p), GridUnitType.Star) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(Math.Max(0.0001, 100.0 - p), GridUnitType.Star) });
+
+        var filled = new Microsoft.UI.Xaml.Controls.Border
+        {
+            Background = accent,
+            CornerRadius = new CornerRadius(3, 0, 0, 3),
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch
+        };
+        if (p <= 0)
+        {
+            filled.Opacity = 0; // hide accent stub at exactly 0% but keep slot
+        }
+        Grid.SetColumn(filled, 0);
+        grid.Children.Add(filled);
+
+        var rest = new Microsoft.UI.Xaml.Controls.Border
+        {
+            Background = track,
+            CornerRadius = p >= 100 ? new CornerRadius(0, 3, 3, 0) : new CornerRadius(0, 3, 3, 0),
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch
+        };
+        if (p <= 0)
+        {
+            rest.CornerRadius = new CornerRadius(3);
+        }
+        Grid.SetColumn(rest, 1);
+        grid.Children.Add(rest);
+
+        return grid;
+    }
+
     // ── Rich card builder helpers for tray menu ──
 
     private static readonly FrozenDictionary<string, string> CapabilityIcons = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -1669,15 +1724,8 @@ public partial class App : Application
             HorizontalAlignment = HorizontalAlignment.Stretch,
             ColumnSpacing = 8
         };
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(24) });
         grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
         grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-
-        var icon = FluentIconCatalog.Build(FluentIconCatalog.Sessions);
-        icon.HorizontalAlignment = HorizontalAlignment.Center;
-        icon.VerticalAlignment = VerticalAlignment.Center;
-        Grid.SetColumn(icon, 0);
-        grid.Children.Add(icon);
 
         var title = new TextBlock
         {
@@ -1687,7 +1735,7 @@ public partial class App : Application
             VerticalAlignment = VerticalAlignment.Center,
             IsTextSelectionEnabled = false
         };
-        Grid.SetColumn(title, 1);
+        Grid.SetColumn(title, 0);
         grid.Children.Add(title);
 
         var summary = new TextBlock
@@ -1699,7 +1747,7 @@ public partial class App : Application
             VerticalAlignment = VerticalAlignment.Center,
             IsTextSelectionEnabled = false
         };
-        Grid.SetColumn(summary, 2);
+        Grid.SetColumn(summary, 1);
         grid.Children.Add(summary);
 
         return grid;
@@ -1816,16 +1864,7 @@ public partial class App : Application
         Grid.SetColumn(model, 0);
         line2.Children.Add(model);
 
-        var bar = new ProgressBar
-        {
-            Minimum = 0, Maximum = 100, Value = pct,
-            Height = 6,
-            IsIndeterminate = false,
-            VerticalAlignment = VerticalAlignment.Center,
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            CornerRadius = new CornerRadius(3),
-            MinWidth = 80
-        };
+        var bar = BuildMiniBar(pct);
         Grid.SetColumn(bar, 1);
         line2.Children.Add(bar);
 
@@ -1856,15 +1895,8 @@ public partial class App : Application
             HorizontalAlignment = HorizontalAlignment.Stretch,
             ColumnSpacing = 8
         };
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(24) });
         grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
         grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-
-        var icon = FluentIconCatalog.Build(FluentIconCatalog.Dashboard);
-        icon.HorizontalAlignment = HorizontalAlignment.Center;
-        icon.VerticalAlignment = VerticalAlignment.Center;
-        Grid.SetColumn(icon, 0);
-        grid.Children.Add(icon);
 
         var title = new TextBlock
         {
@@ -1874,19 +1906,27 @@ public partial class App : Application
             VerticalAlignment = VerticalAlignment.Center,
             IsTextSelectionEnabled = false
         };
-        Grid.SetColumn(title, 1);
+        Grid.SetColumn(title, 0);
         grid.Children.Add(title);
 
-        // Right-side summary: $X.XX · Y tokens (from gateway _lastUsage, fallback to session aggregation)
+        // Right-side summary: $X.XX · Y tokens (always include both when any data present)
         var totalTokens = _lastUsage?.TotalTokens
             ?? _lastSessions.Sum(s => s.InputTokens + s.OutputTokens);
         var cost = _lastUsage?.CostUsd
             ?? _lastUsageCost?.Totals.TotalCost
             ?? 0.0;
-        var summaryParts = new List<string>();
-        if (cost > 0) summaryParts.Add($"${cost.ToString("F2", CultureInfo.InvariantCulture)}");
-        if (totalTokens > 0) summaryParts.Add($"{FormatTokenCount(totalTokens)} tokens");
-        var summaryText = summaryParts.Count > 0 ? string.Join(" · ", summaryParts) : "no data";
+        string summaryText;
+        if (cost <= 0 && totalTokens <= 0)
+        {
+            summaryText = "no data";
+        }
+        else
+        {
+            // Always show both, formatted as "$X.XX · Y tokens" even when one is 0.
+            var costStr = "$" + cost.ToString("F2", CultureInfo.InvariantCulture);
+            var tokStr = $"{FormatTokenCount(totalTokens)} tokens";
+            summaryText = $"{costStr} · {tokStr}";
+        }
 
         var summary = new TextBlock
         {
@@ -1896,7 +1936,7 @@ public partial class App : Application
             VerticalAlignment = VerticalAlignment.Center,
             IsTextSelectionEnabled = false
         };
-        Grid.SetColumn(summary, 2);
+        Grid.SetColumn(summary, 1);
         grid.Children.Add(summary);
 
         return grid;
@@ -2018,17 +2058,7 @@ public partial class App : Application
                     Grid.SetColumn(label, 0);
                     winRow.Children.Add(label);
 
-                    var bar = new ProgressBar
-                    {
-                        Minimum = 0, Maximum = 100,
-                        Value = Math.Min(100.0, Math.Max(0.0, win.UsedPercent)),
-                        Height = 6,
-                        IsIndeterminate = false,
-                        VerticalAlignment = VerticalAlignment.Center,
-                        HorizontalAlignment = HorizontalAlignment.Stretch,
-                        CornerRadius = new CornerRadius(3),
-                        MinWidth = 80
-                    };
+                    var bar = BuildMiniBar(Math.Min(100.0, Math.Max(0.0, win.UsedPercent)));
                     Grid.SetColumn(bar, 1);
                     winRow.Children.Add(bar);
 

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1252,17 +1252,30 @@ public partial class App : Application
         var secondaryText = (Microsoft.UI.Xaml.Media.Brush)resources["TextFillColorSecondaryBrush"];
         var captionStyle = (Style)resources["CaptionTextBlockStyle"];
 
-        // ── Brand Header (non-interactive) ──
+        // ── Brand Header (non-interactive) — VarB: horizontal block,
+        //     emoji 28 + "OpenClaw" SemiBold 18, padding 14,10,14,8.
         menu.AddCustomElement(new StackPanel
         {
-            Padding = new Thickness(14, 10, 14, 6),
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Padding = new Thickness(14, 10, 14, 8),
+            VerticalAlignment = VerticalAlignment.Center,
             Children =
             {
                 new TextBlock
                 {
-                    Text = $"{FluentIconCatalog.Brand} OpenClaw",
+                    Text = FluentIconCatalog.Brand,
+                    FontSize = 28,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    IsTextSelectionEnabled = false
+                },
+                new TextBlock
+                {
+                    Text = "OpenClaw",
                     FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
-                    FontSize = 14
+                    FontSize = 18,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    IsTextSelectionEnabled = false
                 }
             }
         });
@@ -1456,11 +1469,21 @@ public partial class App : Application
             var sessionSummaryRight = $"{activeCount} active · {FormatTokenCount(totalTokensAll)} tokens";
             menu.AddCustomElement(BuildSectionHeader("Sessions", sessionSummaryRight));
 
-            foreach (var session in _lastSessions.Take(5))
+            foreach (var session in _lastSessions.Take(4))
             {
                 var card = BuildSessionCard(session, successBrush, cautionBrush, neutralBrush, criticalBrush, secondaryText);
                 var flyoutItems = BuildSessionFlyoutItems(session);
                 menu.AddFlyoutCustomItem(card, flyoutItems, action: "sessions");
+            }
+
+            if (_lastSessions.Length > 4)
+            {
+                var extra = _lastSessions.Length - 4;
+                menu.AddMenuItem(
+                    $"More ({extra} more)",
+                    FluentIconCatalog.Build(FluentIconCatalog.Sessions),
+                    "sessions",
+                    indent: true);
             }
         }
 
@@ -1610,6 +1633,15 @@ public partial class App : Application
         return grid;
     }
 
+    private static string FormatRelative(DateTime utc)
+    {
+        var age = DateTime.UtcNow - utc;
+        if (age.TotalSeconds < 60) return "just now";
+        if (age.TotalMinutes < 60) return $"{(int)age.TotalMinutes}m ago";
+        if (age.TotalHours < 24) return $"{(int)age.TotalHours}h ago";
+        return $"{(int)age.TotalDays}d ago";
+    }
+
     private static UIElement BuildSessionCard(
         SessionInfo session,
         Microsoft.UI.Xaml.Media.Brush successBrush,
@@ -1618,139 +1650,128 @@ public partial class App : Application
         Microsoft.UI.Xaml.Media.Brush criticalBrush,
         Microsoft.UI.Xaml.Media.Brush secondaryText)
     {
+        // VarB: verbose two-row session card with progress bar.
+        //   Row 0: ● {name}                              {N}m ago
+        //   Row 1: {model}
+        //          [████████░░░░░░]  {used} / {context}
         var usedTokens = session.InputTokens + session.OutputTokens;
         var contextTokens = session.ContextTokens > 0 ? session.ContextTokens : 200_000;
         var pct = usedTokens > 0 ? (int)(Math.Min(1.0, (double)usedTokens / contextTokens) * 100) : 0;
         var isActive = string.Equals(session.Status, "active", StringComparison.OrdinalIgnoreCase);
         var isIdle = string.Equals(session.Status, "idle", StringComparison.OrdinalIgnoreCase);
 
+        var resources = Application.Current.Resources;
+        var tertiaryText = (Microsoft.UI.Xaml.Media.Brush)resources["TextFillColorTertiaryBrush"];
+        var captionStyle = (Style)resources["CaptionTextBlockStyle"];
+
         var grid = new Grid
         {
-            Padding = new Thickness(12, 6, 12, 6),
+            Padding = new Thickness(12, 8, 12, 8),
             HorizontalAlignment = HorizontalAlignment.Stretch,
-            RowSpacing = 2,
-            ColumnSpacing = 6
+            RowSpacing = 4,
+            ColumnSpacing = 8
         };
         grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
         grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
-        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto }); // status dot
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) }); // name
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto }); // model badge
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto }); // chevron
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
-        // Row 0: status dot
-        var dot = new Microsoft.UI.Xaml.Shapes.Ellipse
+        // Row 0 Col 0: status dot + display name
+        var nameRow = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        nameRow.Children.Add(new Microsoft.UI.Xaml.Shapes.Ellipse
         {
             Width = 8, Height = 8,
             VerticalAlignment = VerticalAlignment.Center,
             Fill = isActive ? successBrush
                 : isIdle ? cautionBrush
                 : neutralBrush
-        };
-        Grid.SetRow(dot, 0);
-        Grid.SetColumn(dot, 0);
-        grid.Children.Add(dot);
-
-        // Row 0: session name
-        var nameBlock = new TextBlock
+        });
+        nameRow.Children.Add(new TextBlock
         {
             Text = session.DisplayName ?? session.Key,
             FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
-            FontSize = 12,
+            FontSize = 13,
             TextTrimming = TextTrimming.CharacterEllipsis,
             VerticalAlignment = VerticalAlignment.Center,
             IsTextSelectionEnabled = false
-        };
-        Grid.SetRow(nameBlock, 0);
-        Grid.SetColumn(nameBlock, 1);
-        grid.Children.Add(nameBlock);
+        });
+        Grid.SetRow(nameRow, 0);
+        Grid.SetColumn(nameRow, 0);
+        grid.Children.Add(nameRow);
 
-        // Row 0: model badge
-        if (!string.IsNullOrEmpty(session.Model))
+        // Row 0 Col 1: relative time (only if UpdatedAt is set)
+        if (session.UpdatedAt.HasValue)
         {
-            var modelBadge = BuildBadge(session.Model);
-            Grid.SetRow(modelBadge, 0);
-            Grid.SetColumn(modelBadge, 2);
-            grid.Children.Add(modelBadge);
-        }
-
-        // Row 0: chevron
-        var chevron = new TextBlock
-        {
-            Text = "›",
-            FontSize = 14,
-            Opacity = 0.5,
-            VerticalAlignment = VerticalAlignment.Center,
-            IsTextSelectionEnabled = false
-        };
-        Grid.SetRow(chevron, 0);
-        Grid.SetColumn(chevron, 3);
-        grid.Children.Add(chevron);
-
-        // Row 1: token info + channel badge + status
-        var row1 = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Spacing = 6,
-            VerticalAlignment = VerticalAlignment.Center
-        };
-        var tokenText = usedTokens > 0
-            ? $"{FormatTokenCount(usedTokens)}/{FormatTokenCount(contextTokens)} ({pct}%)"
-            : "";
-        if (!string.IsNullOrEmpty(tokenText))
-        {
-            row1.Children.Add(new TextBlock
+            grid.Children.Add(new TextBlock
             {
-                Text = tokenText,
+                Text = FormatRelative(session.UpdatedAt.Value),
+                Style = captionStyle,
                 FontSize = 11,
                 Foreground = secondaryText,
+                HorizontalAlignment = HorizontalAlignment.Right,
                 VerticalAlignment = VerticalAlignment.Center,
-                IsTextSelectionEnabled = false
+                IsTextSelectionEnabled = false,
             });
+            var timeBlock = (TextBlock)grid.Children[^1];
+            Grid.SetRow(timeBlock, 0);
+            Grid.SetColumn(timeBlock, 1);
         }
-        if (!string.IsNullOrEmpty(session.Channel))
+
+        // Row 1 spans both columns: model line + progress row
+        var detailStack = new StackPanel { Spacing = 4 };
+
+        var modelText = !string.IsNullOrEmpty(session.Model) ? session.Model! : "unknown model";
+        detailStack.Children.Add(new TextBlock
         {
-            var channelAbbrev = session.Channel!.Length <= 2
-                ? session.Channel.ToUpperInvariant()
-                : session.Channel[..2].ToUpperInvariant();
-            row1.Children.Add(BuildBadge(channelAbbrev));
-        }
-        var statusText = string.IsNullOrEmpty(session.Status) ? "Unknown"
-            : char.ToUpperInvariant(session.Status[0]) + session.Status[1..];
-        row1.Children.Add(new TextBlock
+            Text = modelText,
+            Style = captionStyle,
+            FontSize = 12,
+            Foreground = string.IsNullOrEmpty(session.Model) ? tertiaryText : secondaryText,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            IsTextSelectionEnabled = false
+        });
+
+        var progressRow = new Grid { ColumnSpacing = 8 };
+        progressRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        progressRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var bar = new ProgressBar
         {
-            Text = statusText,
+            Minimum = 0,
+            Maximum = 100,
+            Value = pct,
+            Height = 4,
+            VerticalAlignment = VerticalAlignment.Center,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            CornerRadius = new CornerRadius(2)
+        };
+        Grid.SetColumn(bar, 0);
+        progressRow.Children.Add(bar);
+
+        var tokenLabel = new TextBlock
+        {
+            Text = $"{FormatTokenCount(usedTokens)} / {FormatTokenCount(contextTokens)}",
+            Style = captionStyle,
             FontSize = 11,
             Foreground = secondaryText,
             VerticalAlignment = VerticalAlignment.Center,
+            HorizontalAlignment = HorizontalAlignment.Right,
             IsTextSelectionEnabled = false
-        });
-        Grid.SetRow(row1, 1);
-        Grid.SetColumn(row1, 1);
-        Grid.SetColumnSpan(row1, 3);
-        grid.Children.Add(row1);
+        };
+        Grid.SetColumn(tokenLabel, 1);
+        progressRow.Children.Add(tokenLabel);
 
-        // Row 2: thin progress bar
-        if (usedTokens > 0)
-        {
-            var bar = new ProgressBar
-            {
-                Minimum = 0,
-                Maximum = 100,
-                Value = pct,
-                Height = 3,
-                HorizontalAlignment = HorizontalAlignment.Stretch,
-                CornerRadius = new CornerRadius(1.5),
-                Foreground = pct > 80 ? criticalBrush
-                    : pct > 50 ? cautionBrush
-                    : successBrush
-            };
-            Grid.SetRow(bar, 2);
-            Grid.SetColumn(bar, 0);
-            Grid.SetColumnSpan(bar, 4);
-            grid.Children.Add(bar);
-        }
+        detailStack.Children.Add(progressRow);
+
+        Grid.SetRow(detailStack, 1);
+        Grid.SetColumn(detailStack, 0);
+        Grid.SetColumnSpan(detailStack, 2);
+        grid.Children.Add(detailStack);
 
         return grid;
     }
@@ -1823,57 +1844,84 @@ public partial class App : Application
         Microsoft.UI.Xaml.Media.Brush neutralBrush,
         Microsoft.UI.Xaml.Media.Brush secondaryText)
     {
+        // VarB: verbose two-line device card.
+        //   Line 1: ● {DisplayName}                [os-pill]  ›
+        //   Line 2: Online · {Role} · Windows {OsVersion} · app {Version}
         var nodeName = !string.IsNullOrWhiteSpace(node.DisplayName) ? node.DisplayName : node.ShortId;
 
-        var grid = new Grid
-        {
-            Padding = new Thickness(12, 6, 12, 6),
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            RowSpacing = 2,
-            ColumnSpacing = 6
-        };
-        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
-        grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto }); // dot
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) }); // name
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto }); // platform badge
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto }); // chevron
+        var resources = Application.Current.Resources;
+        var captionStyle = (Style)resources["CaptionTextBlockStyle"];
+        var controlSecondaryFill = (Microsoft.UI.Xaml.Media.Brush)resources["ControlFillColorSecondaryBrush"];
 
-        // Row 0: status dot
-        var dot = new Microsoft.UI.Xaml.Shapes.Ellipse
+        // Build line-2 tokens: drop empties, render only if at least one survives.
+        var line2Tokens = new List<string>
+        {
+            node.IsOnline ? "Online" : "Offline"
+        };
+        if (!string.IsNullOrWhiteSpace(node.Mode)) line2Tokens.Add(node.Mode!);
+        // No dedicated OsVersion field on GatewayNodeInfo; surface platform/family
+        // when available as the OS hint. Falls under the "drop unknown tokens" rule.
+        if (!string.IsNullOrWhiteSpace(node.DeviceFamily)) line2Tokens.Add(node.DeviceFamily!);
+        if (!string.IsNullOrWhiteSpace(node.Version)) line2Tokens.Add($"app {node.Version}");
+
+        var outer = new StackPanel
+        {
+            Padding = new Thickness(12, 8, 12, 8),
+            Spacing = 2,
+            HorizontalAlignment = HorizontalAlignment.Stretch
+        };
+
+        // ── Line 1 ──
+        var line1 = new Grid { ColumnSpacing = 6 };
+        line1.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });            // dot + name stack
+        line1.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) }); // spacer
+        line1.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });            // os chip
+        line1.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });            // chevron
+
+        var nameRow = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        nameRow.Children.Add(new Microsoft.UI.Xaml.Shapes.Ellipse
         {
             Width = 8, Height = 8,
             VerticalAlignment = VerticalAlignment.Center,
             Fill = node.IsOnline ? successBrush : neutralBrush
-        };
-        Grid.SetRow(dot, 0);
-        Grid.SetColumn(dot, 0);
-        grid.Children.Add(dot);
-
-        // Row 0: device name
-        var nameBlock = new TextBlock
+        });
+        nameRow.Children.Add(new TextBlock
         {
             Text = nodeName,
             FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
-            FontSize = 12,
+            FontSize = 13,
             TextTrimming = TextTrimming.CharacterEllipsis,
             VerticalAlignment = VerticalAlignment.Center,
             IsTextSelectionEnabled = false
-        };
-        Grid.SetRow(nameBlock, 0);
-        Grid.SetColumn(nameBlock, 1);
-        grid.Children.Add(nameBlock);
+        });
+        Grid.SetColumn(nameRow, 0);
+        line1.Children.Add(nameRow);
 
-        // Row 0: platform badge
-        if (!string.IsNullOrEmpty(node.Platform))
+        if (!string.IsNullOrWhiteSpace(node.Platform))
         {
-            var badge = BuildBadge(node.Platform);
-            Grid.SetRow(badge, 0);
-            Grid.SetColumn(badge, 2);
-            grid.Children.Add(badge);
+            var osChip = new Border
+            {
+                CornerRadius = new CornerRadius(4),
+                Padding = new Thickness(6, 1, 6, 1),
+                Background = controlSecondaryFill,
+                VerticalAlignment = VerticalAlignment.Center,
+                Child = new TextBlock
+                {
+                    Text = node.Platform!.ToLowerInvariant(),
+                    FontSize = 10,
+                    Foreground = secondaryText,
+                    IsTextSelectionEnabled = false
+                }
+            };
+            Grid.SetColumn(osChip, 2);
+            line1.Children.Add(osChip);
         }
 
-        // Row 0: chevron
         var chevron = new TextBlock
         {
             Text = "›",
@@ -1882,48 +1930,27 @@ public partial class App : Application
             VerticalAlignment = VerticalAlignment.Center,
             IsTextSelectionEnabled = false
         };
-        Grid.SetRow(chevron, 0);
         Grid.SetColumn(chevron, 3);
-        grid.Children.Add(chevron);
+        line1.Children.Add(chevron);
+        outer.Children.Add(line1);
 
-        // Row 1: capability icons + count + online/offline
-        var row1 = new StackPanel
+        // ── Line 2 (verbose details) ──
+        // Always render when at least one non-name token exists; otherwise the
+        // card collapses to single-line (just line 1).
+        if (line2Tokens.Count > 0)
         {
-            Orientation = Orientation.Horizontal,
-            Spacing = 4,
-            VerticalAlignment = VerticalAlignment.Center
-        };
-
-        // Capability emoji icons
-        var capIcons = new System.Text.StringBuilder();
-        if (node.Capabilities.Count > 0)
-        {
-            foreach (var cap in node.Capabilities)
+            outer.Children.Add(new TextBlock
             {
-                if (CapabilityIcons.TryGetValue(cap, out var icon))
-                    capIcons.Append(icon);
-            }
+                Text = string.Join(" · ", line2Tokens),
+                Style = captionStyle,
+                FontSize = 11,
+                Foreground = secondaryText,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                IsTextSelectionEnabled = false
+            });
         }
-        var capText = capIcons.Length > 0
-            ? $"{capIcons} {node.CapabilityCount} caps"
-            : node.CapabilityCount > 0 ? $"{node.CapabilityCount} caps" : "";
-        var statusLabel = node.IsOnline ? "online" : "offline";
-        var row1Text = !string.IsNullOrEmpty(capText) ? $"{capText}  ·  {statusLabel}" : statusLabel;
 
-        row1.Children.Add(new TextBlock
-        {
-            Text = row1Text,
-            FontSize = 11,
-            Foreground = secondaryText,
-            VerticalAlignment = VerticalAlignment.Center,
-            IsTextSelectionEnabled = false
-        });
-        Grid.SetRow(row1, 1);
-        Grid.SetColumn(row1, 1);
-        Grid.SetColumnSpan(row1, 3);
-        grid.Children.Add(row1);
-
-        return grid;
+        return outer;
     }
 
     private static List<TrayMenuFlyoutItem> BuildDeviceFlyoutItems(GatewayNodeInfo node)

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1518,7 +1518,8 @@ public partial class App : Application
             menu.AddFlyoutMenuItem(
                 "Permissions",
                 FluentIconCatalog.Build(FluentIconCatalog.Permissions),
-                BuildPermissionsFlyoutItems(_settings));
+                BuildPermissionsFlyoutItems(_settings),
+                action: "permissions");
         }
         menu.AddMenuItem("Dashboard", FluentIconCatalog.Build(FluentIconCatalog.Dashboard), "dashboard");
         menu.AddMenuItem("Chat", FluentIconCatalog.Build(FluentIconCatalog.Chat), "openchat");
@@ -1548,21 +1549,21 @@ public partial class App : Application
             new() { Text = "Permissions", IsHeader = true },
         };
 
-        AddPermToggle(items, "Enable Windows node", FluentIconCatalog.System,
+        AddPermToggle(items, "Windows node", FluentIconCatalog.System,
             () => settings.EnableNodeMode, v => settings.EnableNodeMode = v);
-        AddPermToggle(items, "Allow browser control", FluentIconCatalog.Browser,
+        AddPermToggle(items, "Browser control", FluentIconCatalog.Browser,
             () => settings.NodeBrowserProxyEnabled, v => settings.NodeBrowserProxyEnabled = v);
-        AddPermToggle(items, "Allow camera", FluentIconCatalog.Camera,
+        AddPermToggle(items, "Camera", FluentIconCatalog.Camera,
             () => settings.NodeCameraEnabled, v => settings.NodeCameraEnabled = v);
-        AddPermToggle(items, "Allow canvas", FluentIconCatalog.Canvas,
+        AddPermToggle(items, "Canvas", FluentIconCatalog.Canvas,
             () => settings.NodeCanvasEnabled, v => settings.NodeCanvasEnabled = v);
-        AddPermToggle(items, "Allow screen capture", FluentIconCatalog.Screen,
+        AddPermToggle(items, "Screen capture", FluentIconCatalog.Screen,
             () => settings.NodeScreenEnabled, v => settings.NodeScreenEnabled = v);
-        AddPermToggle(items, "Allow location", FluentIconCatalog.Location,
+        AddPermToggle(items, "Location", FluentIconCatalog.Location,
             () => settings.NodeLocationEnabled, v => settings.NodeLocationEnabled = v);
-        AddPermToggle(items, "Allow voice (TTS)", FluentIconCatalog.Voice,
+        AddPermToggle(items, "Voice (TTS)", FluentIconCatalog.Voice,
             () => settings.NodeTtsEnabled, v => settings.NodeTtsEnabled = v);
-        AddPermToggle(items, "Allow speech-to-text (STT)", FluentIconCatalog.Voice,
+        AddPermToggle(items, "Speech-to-text (STT)", FluentIconCatalog.Speech,
             () => settings.NodeSttEnabled, v => settings.NodeSttEnabled = v);
 
         return items;
@@ -1667,7 +1668,7 @@ public partial class App : Application
         ["browser"] = FluentIconCatalog.Browser,
         ["clipboard"] = "\uE77F",     // PasteAsText
         ["tts"] = FluentIconCatalog.Voice,
-        ["stt"] = FluentIconCatalog.Voice,
+        ["stt"] = FluentIconCatalog.Speech,
         ["location"] = FluentIconCatalog.Location,
         ["canvas"] = FluentIconCatalog.Canvas,
         ["system"] = FluentIconCatalog.System,

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1265,13 +1265,20 @@ public partial class App : Application
         var captionStyle = (Style)resources["CaptionTextBlockStyle"];
         var controlSecondaryFill = (Microsoft.UI.Xaml.Media.Brush)resources["ControlFillColorSecondaryBrush"];
 
-        // ── Brand Header (non-interactive) — VarB: horizontal block,
-        //     emoji 28 + "OpenClaw" SemiBold 18, padding 14,10,14,8.
-        menu.AddCustomElement(new StackPanel
+        // ── Brand Header with Disconnect/Connect on the right ──
+        var brandGrid = new Grid
+        {
+            Padding = new Thickness(14, 10, 14, 8),
+            ColumnSpacing = 8
+        };
+        brandGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        brandGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        brandGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var brandRow = new StackPanel
         {
             Orientation = Orientation.Horizontal,
             Spacing = 8,
-            Padding = new Thickness(14, 10, 14, 8),
             VerticalAlignment = VerticalAlignment.Center,
             Children =
             {
@@ -1291,7 +1298,56 @@ public partial class App : Application
                     IsTextSelectionEnabled = false
                 }
             }
-        });
+        };
+        Grid.SetColumn(brandRow, 0);
+        brandGrid.Children.Add(brandRow);
+
+        var brandBtn = new Button
+        {
+            Content = isConnected ? "Disconnect" : "Connect",
+            VerticalAlignment = VerticalAlignment.Center,
+            Padding = new Thickness(12, 4, 12, 4),
+            MinHeight = 0,
+            MinWidth = 0,
+            FontSize = 12
+        };
+        AutomationProperties.SetName(brandBtn, isConnected ? "Disconnect from gateway" : "Connect to gateway");
+        ToolTipService.SetToolTip(brandBtn, isConnected ? "Disconnect from gateway" : "Connect to gateway");
+        brandBtn.Click += (s, ev) =>
+        {
+            if (isConnected)
+            {
+                _ = _connectionManager?.DisconnectAsync();
+                _lastSessions = Array.Empty<SessionInfo>();
+                _lastNodePairList = null;
+                _lastDevicePairList = null;
+                _lastModelsList = null;
+                _agentEventsCache.Clear();
+                UpdateTrayIcon();
+                _hubWindow?.UpdateStatus(ConnectionStatus.Disconnected);
+            }
+            else
+            {
+                _ = _connectionManager?.ReconnectAsync();
+            }
+            _trayMenuWindow?.HideCascade();
+        };
+        Grid.SetColumn(brandBtn, 2);
+        brandGrid.Children.Add(brandBtn);
+
+        menu.AddCustomElement(brandGrid);
+
+        // ── Pairing approval pending (high-priority action above Gateway) ──
+        var nodePendingCount = _lastNodePairList?.Pending.Count ?? 0;
+        var devicePendingCount = _lastDevicePairList?.Pending.Count ?? 0;
+        if (nodePendingCount + devicePendingCount > 0)
+        {
+            var total = nodePendingCount + devicePendingCount;
+            menu.AddMenuItem(
+                $"Pairing approval pending ({total})",
+                FluentIconCatalog.Build(FluentIconCatalog.Approvals),
+                "hub");
+        }
 
         // ── Gateway Section ──
         // (device-card format)
@@ -1333,15 +1389,7 @@ public partial class App : Application
         Grid.SetColumn(gwNameRow, 0);
         gwLine1.Children.Add(gwNameRow);
 
-        // Right-side: optional chip + Disconnect/Connect button on the header line
-        var gwRight = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Spacing = 6,
-            VerticalAlignment = VerticalAlignment.Center,
-            HorizontalAlignment = HorizontalAlignment.Right
-        };
-
+        // Right-side: optional chip on the header line (Disconnect lives in brand header)
         string? chipText = null;
         var gwUrl = _settings?.GetEffectiveGatewayUrl();
         Uri? gwUri = null;
@@ -1355,12 +1403,13 @@ public partial class App : Application
         }
         if (chipText != null)
         {
-            gwRight.Children.Add(new Border
+            var chip = new Border
             {
                 CornerRadius = new CornerRadius(4),
                 Padding = new Thickness(6, 1, 6, 1),
                 Background = controlSecondaryFill,
                 VerticalAlignment = VerticalAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Right,
                 Child = new TextBlock
                 {
                     Text = chipText,
@@ -1368,43 +1417,10 @@ public partial class App : Application
                     Foreground = secondaryText,
                     IsTextSelectionEnabled = false
                 }
-            });
+            };
+            Grid.SetColumn(chip, 2);
+            gwLine1.Children.Add(chip);
         }
-
-        var gwBtn = new Button
-        {
-            Content = isConnected ? "Disconnect" : "Connect",
-            VerticalAlignment = VerticalAlignment.Center,
-            Padding = new Thickness(10, 2, 10, 2),
-            MinHeight = 0,
-            MinWidth = 0,
-            FontSize = 11
-        };
-        AutomationProperties.SetName(gwBtn, isConnected ? "Disconnect from gateway" : "Connect to gateway");
-        ToolTipService.SetToolTip(gwBtn, isConnected ? "Disconnect from gateway" : "Connect to gateway");
-        gwBtn.Click += (s, ev) =>
-        {
-            if (isConnected)
-            {
-                _ = _connectionManager?.DisconnectAsync();
-                _lastSessions = Array.Empty<SessionInfo>();
-                _lastNodePairList = null;
-                _lastDevicePairList = null;
-                _lastModelsList = null;
-                _agentEventsCache.Clear();
-                UpdateTrayIcon();
-                _hubWindow?.UpdateStatus(ConnectionStatus.Disconnected);
-            }
-            else
-            {
-                _ = _connectionManager?.ReconnectAsync();
-            }
-            _trayMenuWindow?.HideCascade();
-        };
-        gwRight.Children.Add(gwBtn);
-
-        Grid.SetColumn(gwRight, 2);
-        gwLine1.Children.Add(gwRight);
         gwOuter.Children.Add(gwLine1);
 
         // ── Line 2: secondary details ──
@@ -1453,15 +1469,11 @@ public partial class App : Application
         menu.AddCustomElement(gwOuter);
 
         // ── Connected Devices (moved above Sessions) ──
+        // Devices flow directly after the Gateway block without a divider
+        // or section header — they share the gateway visual format.
         var connectedNodes = _lastNodes.Where(n => n.IsOnline).ToArray();
         if (connectedNodes.Length > 0)
         {
-            menu.AddSeparator();
-
-            var totalCaps = connectedNodes.Sum(n => n.CapabilityCount);
-            var deviceSummaryRight = $"{connectedNodes.Length} online · {totalCaps} caps";
-            menu.AddCustomElement(BuildSectionHeader("Devices", deviceSummaryRight));
-
             foreach (var node in connectedNodes.Take(5))
             {
                 var card = BuildDeviceCard(node, successBrush, neutralBrush, secondaryText);
@@ -1492,18 +1504,6 @@ public partial class App : Application
             var usageRow = BuildUsageRow(secondaryText);
             var usageFlyout = BuildUsageFlyoutItems(secondaryText);
             menu.AddFlyoutCustomItem(usageRow, usageFlyout, action: "usage");
-        }
-
-        // ── Pairing approval pending ──
-        var nodePendingCount = _lastNodePairList?.Pending.Count ?? 0;
-        var devicePendingCount = _lastDevicePairList?.Pending.Count ?? 0;
-        if (nodePendingCount + devicePendingCount > 0)
-        {
-            var total = nodePendingCount + devicePendingCount;
-            menu.AddMenuItem(
-                $"Pairing approval pending ({total})",
-                FluentIconCatalog.Build(FluentIconCatalog.Approvals),
-                "hub");
         }
 
         // ── Actions ──
@@ -1771,7 +1771,6 @@ public partial class App : Application
             items.Add(new() { CustomContent = card });
         }
 
-        items.Add(new() { Text = "Open Sessions →", Action = "sessions" });
         return items;
     }
 
@@ -2119,7 +2118,6 @@ public partial class App : Application
             }
         }
 
-        items.Add(new() { Text = "Open detailed usage →", Action = "usage" });
         return items;
     }
 

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -985,6 +985,8 @@ public partial class App : Application
                 UpdateTrayIcon();
                 _hubWindow?.UpdateStatus(ConnectionStatus.Disconnected);
                 break;
+            case "connection": ShowHub("connection"); break;
+            case "permissions": ShowHub("permissions"); break;
             case "dashboard": OpenDashboard(); break;
             case "canvas": ShowCanvasWindow(); break;
             case "openchat": ShowChatWindow(); break;
@@ -1316,21 +1318,7 @@ public partial class App : Application
         ToolTipService.SetToolTip(brandBtn, isConnected ? "Disconnect from gateway" : "Connect to gateway");
         brandBtn.Click += (s, ev) =>
         {
-            if (isConnected)
-            {
-                _ = _connectionManager?.DisconnectAsync();
-                _lastSessions = Array.Empty<SessionInfo>();
-                _lastNodePairList = null;
-                _lastDevicePairList = null;
-                _lastModelsList = null;
-                _agentEventsCache.Clear();
-                UpdateTrayIcon();
-                _hubWindow?.UpdateStatus(ConnectionStatus.Disconnected);
-            }
-            else
-            {
-                _ = _connectionManager?.ReconnectAsync();
-            }
+            OnTrayMenuItemClicked(this, isConnected ? "disconnect" : "reconnect");
             _trayMenuWindow?.HideCascade();
         };
         Grid.SetColumn(brandBtn, 2);
@@ -1525,6 +1513,19 @@ public partial class App : Application
         menu.AddMenuItem("Chat", FluentIconCatalog.Build(FluentIconCatalog.Chat), "openchat");
         menu.AddMenuItem("Canvas", FluentIconCatalog.Build(FluentIconCatalog.CanvasAct), "canvas");
         menu.AddMenuItem("Voice", FluentIconCatalog.Build(FluentIconCatalog.VoiceAct), "voice");
+        menu.AddMenuItem(
+            LocalizationHelper.GetString("Menu_QuickSend"),
+            FluentIconCatalog.Build(FluentIconCatalog.QuickSend),
+            "quicksend");
+
+        // Setup Guide / Reconfigure entry — label flips based on whether prior
+        // configuration exists; routes to the existing "setup" action handler.
+        var setupMenuLabel = _settings != null
+            && new OpenClawTray.Onboarding.Services.OnboardingExistingConfigGuard(_settings, IdentityDataPath)
+                .HasExistingConfiguration()
+            ? LocalizationHelper.GetString("Menu_Reconfigure")
+            : LocalizationHelper.GetString("Menu_SetupGuide");
+        menu.AddMenuItem(setupMenuLabel, FluentIconCatalog.Build(FluentIconCatalog.Setup), "setup");
 
         // ── Footer ──
         menu.AddSeparator();

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.Toolkit.Uwp.Notifications;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using OpenClaw.Shared;
@@ -1011,8 +1012,14 @@ public partial class App : Application
             case "copydeviceid": CopyDeviceIdToClipboard(); break;
             case "copynodesummary": CopyNodeSummaryToClipboard(); break;
             case "exit": ExitApplication(); break;
+            case "about": ShowHub("about"); break;
             default:
-                if (action.StartsWith("session-reset|", StringComparison.Ordinal))
+                if (action.StartsWith("perm-toggle|", StringComparison.Ordinal)
+                    && _permToggleActions.TryGetValue(action, out var permAction))
+                {
+                    permAction();
+                }
+                else if (action.StartsWith("session-reset|", StringComparison.Ordinal))
                     _ = ExecuteSessionActionAsync("reset", action["session-reset|".Length..]);
                 else if (action.StartsWith("session-compact|", StringComparison.Ordinal))
                     _ = ExecuteSessionActionAsync("compact", action["session-compact|".Length..]);
@@ -1210,8 +1217,40 @@ public partial class App : Application
 
     private void BuildTrayMenuPopup(TrayMenuWindow menu)
     {
+        // Render the whole menu inside a single update batch so layout
+        // measures only once instead of once-per-row. Pair with EndUpdate
+        // in finally so an exception mid-build doesn't wedge layout.
+        menu.BeginUpdate();
+        try
+        {
+            BuildTrayMenuPopupCore(menu);
+        }
+        finally
+        {
+            menu.EndUpdate();
+        }
+    }
+
+    private void BuildTrayMenuPopupCore(TrayMenuWindow menu)
+    {
+        // Stale closures from the previous build hold references to old
+        // ToggleAction delegates; recreate the lookup each rebuild.
+        _permToggleActions.Clear();
+
         var isConnected = _currentStatus == ConnectionStatus.Connected;
         var statusText = LocalizationHelper.GetConnectionStatusText(_currentStatus);
+
+        // Cache theme brushes once per build so cells don't each do a
+        // resource lookup. The previous implementation looked up
+        // SystemFill/Text brushes per row, which contributed to the
+        // visible right-click hitch.
+        var resources = Application.Current.Resources;
+        var successBrush = (Microsoft.UI.Xaml.Media.Brush)resources["SystemFillColorSuccessBrush"];
+        var cautionBrush = (Microsoft.UI.Xaml.Media.Brush)resources["SystemFillColorCautionBrush"];
+        var neutralBrush = (Microsoft.UI.Xaml.Media.Brush)resources["SystemFillColorNeutralBrush"];
+        var criticalBrush = (Microsoft.UI.Xaml.Media.Brush)resources["SystemFillColorCriticalBrush"];
+        var secondaryText = (Microsoft.UI.Xaml.Media.Brush)resources["TextFillColorSecondaryBrush"];
+        var captionStyle = (Style)resources["CaptionTextBlockStyle"];
 
         // ── Brand Header (non-interactive) ──
         menu.AddCustomElement(new StackPanel
@@ -1221,7 +1260,7 @@ public partial class App : Application
             {
                 new TextBlock
                 {
-                    Text = "🦞 OpenClaw",
+                    Text = $"{FluentIconCatalog.Brand} OpenClaw",
                     FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
                     FontSize = 14
                 }
@@ -1248,15 +1287,14 @@ public partial class App : Application
         {
             Width = 8, Height = 8,
             VerticalAlignment = VerticalAlignment.Center,
-            Fill = new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                isConnected ? Microsoft.UI.Colors.LimeGreen
-                : _currentStatus == ConnectionStatus.Connecting ? Microsoft.UI.Colors.Orange
-                : Microsoft.UI.Colors.Gray)
+            Fill = isConnected ? successBrush
+                : _currentStatus == ConnectionStatus.Connecting ? cautionBrush
+                : neutralBrush
         });
         gwStatusRow.Children.Add(new TextBlock
         {
             Text = $"Gateway · {statusText}",
-            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            Style = captionStyle,
             FontSize = 12,
             VerticalAlignment = VerticalAlignment.Center
         });
@@ -1278,8 +1316,8 @@ public partial class App : Application
                 gwInfo.Children.Add(new TextBlock
                 {
                     Text = string.Join(" · ", detailParts),
-                    Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
-                    Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+                    Style = captionStyle,
+                    Foreground = secondaryText,
                     FontSize = 11
                 });
             }
@@ -1297,8 +1335,8 @@ public partial class App : Application
                 gwInfo.Children.Add(new TextBlock
                 {
                     Text = nodeText,
-                    Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
-                    Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+                    Style = captionStyle,
+                    Foreground = secondaryText,
                     FontSize = 11
                 });
             }
@@ -1310,8 +1348,8 @@ public partial class App : Application
             gwInfo.Children.Add(new TextBlock
             {
                 Text = $"⚠️ {_authFailureMessage}",
-                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
-                Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.OrangeRed),
+                Style = captionStyle,
+                Foreground = criticalBrush,
                 FontSize = 11,
                 TextWrapping = TextWrapping.Wrap,
                 MaxWidth = 240
@@ -1333,6 +1371,7 @@ public partial class App : Application
             MinWidth = 0,
             FontSize = 11
         };
+        AutomationProperties.SetName(connectBtn, isConnected ? "Disconnect from gateway" : "Connect to gateway");
         ToolTipService.SetToolTip(connectBtn, isConnected ? "Click to disconnect from gateway" : "Click to connect to gateway");
         connectBtn.Click += (s, ev) =>
         {
@@ -1366,42 +1405,10 @@ public partial class App : Application
         {
             ShowHub("connection");
         };
+        AutomationProperties.SetName(gwInfo, $"Gateway {statusText}. Activate to open connection settings.");
         menu.AddCustomElement(gwGrid);
 
-        // ── Sessions ──
-        if (_lastSessions.Length > 0)
-        {
-            menu.AddSeparator();
-
-            // Section header: "Sessions  3 active · 45K tokens"
-            var sessionCount = _lastSessions.Length;
-            var activeCount = _lastSessions.Count(s => string.Equals(s.Status, "active", StringComparison.OrdinalIgnoreCase));
-            var totalTokensAll = _lastSessions.Sum(s => s.InputTokens + s.OutputTokens);
-            var sessionSummaryRight = $"{activeCount} active · {FormatTokenCount(totalTokensAll)} tokens";
-            menu.AddCustomElement(BuildSectionHeader("Sessions", sessionSummaryRight));
-
-            // Individual session cards
-            foreach (var session in _lastSessions.Take(5))
-            {
-                var card = BuildSessionCard(session);
-                var flyoutItems = BuildSessionFlyoutItems(session);
-                menu.AddFlyoutCustomItem(card, flyoutItems, action: "sessions");
-            }
-        }
-
-        // ── Pairing Pending ──
-        var nodePendingCount = _lastNodePairList?.Pending.Count ?? 0;
-        var devicePendingCount = _lastDevicePairList?.Pending.Count ?? 0;
-        if (nodePendingCount + devicePendingCount > 0)
-        {
-            var total = nodePendingCount + devicePendingCount;
-            menu.AddMenuItem($"⚠️ Pairing approval pending ({total})", "🔗", "hub");
-        }
-
-        // ── Connected Devices with inline permission toggles ──
-        // Only show currently-connected nodes; offline/stale paired nodes
-        // remain visible on the full Nodes page where they can be renamed
-        // or forgotten.
+        // ── Connected Devices (moved above Sessions) ──
         var connectedNodes = _lastNodes.Where(n => n.IsOnline).ToArray();
         if (connectedNodes.Length > 0)
         {
@@ -1415,109 +1422,145 @@ public partial class App : Application
 
             foreach (var node in connectedNodes.Take(5))
             {
-                var card = BuildDeviceCard(node);
+                var card = BuildDeviceCard(node, successBrush, neutralBrush, secondaryText);
                 var flyoutItems = BuildDeviceFlyoutItems(node);
                 menu.AddFlyoutCustomItem(card, flyoutItems, action: "nodes");
 
-                // If this node is the local machine, show capability toggles underneath
+                // If this node is the local machine, surface a Permissions
+                // submenu directly beneath it. The 3-column inline toggle
+                // grid that used to live here was too dense and shipped with
+                // emoji icons; the flyout collapses to a single row and
+                // routes through FluentIconCatalog.
                 bool isLocal = node.DisplayName?.Contains(currentHost, StringComparison.OrdinalIgnoreCase) == true
                     || node.NodeId?.Contains(currentHost, StringComparison.OrdinalIgnoreCase) == true;
                 if (isLocal && _settings != null)
                 {
-                    // Build compact toggle button grid (3 columns)
-                    var capToggles = new Dictionary<string, (Func<bool> Get, Action<bool> Set)>(StringComparer.OrdinalIgnoreCase)
-                    {
-                        ["browser"] = (() => _settings.NodeBrowserProxyEnabled, v => _settings.NodeBrowserProxyEnabled = v),
-                        ["camera"] = (() => _settings.NodeCameraEnabled, v => _settings.NodeCameraEnabled = v),
-                        ["canvas"] = (() => _settings.NodeCanvasEnabled, v => _settings.NodeCanvasEnabled = v),
-                        ["screen"] = (() => _settings.NodeScreenEnabled, v => _settings.NodeScreenEnabled = v),
-                        ["location"] = (() => _settings.NodeLocationEnabled, v => _settings.NodeLocationEnabled = v),
-                        ["tts"] = (() => _settings.NodeTtsEnabled, v => _settings.NodeTtsEnabled = v),
-                        ["system"] = (() => _settings.EnableNodeMode, v => _settings.EnableNodeMode = v),
-                    };
-
-                    // Show ALL possible capability toggles (not just gateway-reported ones)
-                    // so disabled capabilities like TTS appear as "off" buttons
-                    var allCaps = capToggles.Keys.ToList();
-
-                    if (allCaps.Count > 0)
-                    {
-                        var columns = 3;
-                        var grid = new Grid
-                        {
-                            Margin = new Thickness(28, 4, 14, 4),
-                            ColumnSpacing = 4,
-                            RowSpacing = 4,
-                            HorizontalAlignment = HorizontalAlignment.Stretch
-                        };
-                        for (int c = 0; c < columns; c++)
-                            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-                        var rowCount = (allCaps.Count + columns - 1) / columns;
-                        for (int r = 0; r < rowCount; r++)
-                            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
-
-                        for (int i = 0; i < allCaps.Count; i++)
-                        {
-                            var cap = allCaps[i];
-                            var capToggle = capToggles[cap];
-                            var icon = CapabilityIcons.TryGetValue(cap, out var emoji) ? emoji : "▪";
-                            var label = char.ToUpper(cap[0]) + cap[1..];
-                            var isOn = capToggle.Get();
-
-                            var btn = new ToggleButton
-                            {
-                                IsChecked = isOn,
-                                HorizontalAlignment = HorizontalAlignment.Stretch,
-                                HorizontalContentAlignment = HorizontalAlignment.Center,
-                                Padding = new Thickness(6, 5, 6, 5),
-                                MinHeight = 0,
-                                MinWidth = 0,
-                                Content = new TextBlock
-                                {
-                                    Text = $"{icon} {label}",
-                                    FontSize = 11,
-                                    TextTrimming = TextTrimming.CharacterEllipsis
-                                }
-                            };
-                            var capRef = capToggle; // capture for lambda
-                            btn.Click += (s, ev) =>
-                            {
-                                var on = ((ToggleButton)s!).IsChecked == true;
-                                capRef.Set(on); _settings.Save(); _ = _connectionManager?.ReconnectAsync();
-                            };
-                            Grid.SetRow(btn, i / columns);
-                            Grid.SetColumn(btn, i % columns);
-                            grid.Children.Add(btn);
-                        }
-                        menu.AddCustomElement(grid);
-                    }
+                    var permIcon = FluentIconCatalog.Build(FluentIconCatalog.Permissions);
+                    menu.AddFlyoutMenuItem(
+                        "Permissions",
+                        permIcon,
+                        BuildPermissionsFlyoutItems(_settings),
+                        indent: true);
                 }
             }
         }
 
+        // ── Sessions (now below Devices) ──
+        if (_lastSessions.Length > 0)
+        {
+            menu.AddSeparator();
+
+            var sessionCount = _lastSessions.Length;
+            var activeCount = _lastSessions.Count(s => string.Equals(s.Status, "active", StringComparison.OrdinalIgnoreCase));
+            var totalTokensAll = _lastSessions.Sum(s => s.InputTokens + s.OutputTokens);
+            var sessionSummaryRight = $"{activeCount} active · {FormatTokenCount(totalTokensAll)} tokens";
+            menu.AddCustomElement(BuildSectionHeader("Sessions", sessionSummaryRight));
+
+            foreach (var session in _lastSessions.Take(5))
+            {
+                var card = BuildSessionCard(session, successBrush, cautionBrush, neutralBrush, criticalBrush, secondaryText);
+                var flyoutItems = BuildSessionFlyoutItems(session);
+                menu.AddFlyoutCustomItem(card, flyoutItems, action: "sessions");
+            }
+        }
+
+        // ── Pairing approval pending (closest analogue to the spec's
+        // "exec approvals" row in current code) ──
+        var nodePendingCount = _lastNodePairList?.Pending.Count ?? 0;
+        var devicePendingCount = _lastDevicePairList?.Pending.Count ?? 0;
+        if (nodePendingCount + devicePendingCount > 0)
+        {
+            var total = nodePendingCount + devicePendingCount;
+            menu.AddMenuItem(
+                $"Pairing approval pending ({total})",
+                FluentIconCatalog.Build(FluentIconCatalog.Approvals),
+                "hub");
+        }
+
         // ── Actions ──
         menu.AddSeparator();
-        menu.AddMenuItem("Dashboard", "🌐", "dashboard");
-        menu.AddMenuItem("Chat", "💬", "openchat");
-        menu.AddMenuItem("Canvas", "🎨", "canvas");
-        menu.AddMenuItem("Voice", "🎙️", "voice");
-        menu.AddMenuItem("Companion Settings...", "🦞", "companion");
-        menu.AddMenuItem(LocalizationHelper.GetString("Menu_QuickSend"), "📤", "quicksend");
+        menu.AddMenuItem("Dashboard", FluentIconCatalog.Build(FluentIconCatalog.Dashboard), "dashboard");
+        menu.AddMenuItem("Chat", FluentIconCatalog.Build(FluentIconCatalog.Chat), "openchat");
+        menu.AddMenuItem("Canvas", FluentIconCatalog.Build(FluentIconCatalog.CanvasAct), "canvas");
+        menu.AddMenuItem("Voice", FluentIconCatalog.Build(FluentIconCatalog.VoiceAct), "voice");
+        menu.AddMenuItem("Companion Settings...", FluentIconCatalog.Build(FluentIconCatalog.Settings), "companion");
+        menu.AddMenuItem(LocalizationHelper.GetString("Menu_QuickSend"), FluentIconCatalog.Build(FluentIconCatalog.QuickSend), "quicksend");
 
         // Setup Guide / Reconfigure entry (PR #274 must-fix #6) — label flips
-        // based on whether prior config exists. Click dispatches "setup" which
-        // invokes the existing ShowOnboardingAsync handler (case in OnTrayMenuAction).
+        // based on whether prior config exists.
         var setupMenuLabel = _settings != null
             && new OpenClawTray.Onboarding.Services.OnboardingExistingConfigGuard(_settings, IdentityDataPath)
                 .HasExistingConfiguration()
             ? LocalizationHelper.GetString("Menu_Reconfigure")
             : LocalizationHelper.GetString("Menu_SetupGuide");
-        menu.AddMenuItem(setupMenuLabel, "🧭", "setup");
+        menu.AddMenuItem(setupMenuLabel, FluentIconCatalog.Build(FluentIconCatalog.Setup), "setup");
 
-        // ── Exit ──
+        // ── Footer ──
         menu.AddSeparator();
-        menu.AddMenuItem(LocalizationHelper.GetString("Menu_Exit"), "❌", "exit");
+        menu.AddMenuItem("About", FluentIconCatalog.Build(FluentIconCatalog.About), "about");
+        menu.AddMenuItem(LocalizationHelper.GetString("Menu_Exit"), FluentIconCatalog.Build(FluentIconCatalog.Exit), "exit");
     }
+
+    /// <summary>
+    /// Flyout items for the local-node Permissions row: one check-toggle per
+    /// capability flag in <see cref="SettingsData"/>. Toggling saves the
+    /// setting and reconnects so the gateway picks up the new capability set.
+    /// </summary>
+    private List<TrayMenuFlyoutItem> BuildPermissionsFlyoutItems(SettingsManager settings)
+    {
+        var items = new List<TrayMenuFlyoutItem>
+        {
+            new() { Text = "Permissions", IsHeader = true },
+        };
+
+        AddPermToggle(items, "Enable Windows node", FluentIconCatalog.System,
+            () => settings.EnableNodeMode, v => settings.EnableNodeMode = v);
+        AddPermToggle(items, "Allow browser control", FluentIconCatalog.Browser,
+            () => settings.NodeBrowserProxyEnabled, v => settings.NodeBrowserProxyEnabled = v);
+        AddPermToggle(items, "Allow camera", FluentIconCatalog.Camera,
+            () => settings.NodeCameraEnabled, v => settings.NodeCameraEnabled = v);
+        AddPermToggle(items, "Allow canvas", FluentIconCatalog.Canvas,
+            () => settings.NodeCanvasEnabled, v => settings.NodeCanvasEnabled = v);
+        AddPermToggle(items, "Allow screen capture", FluentIconCatalog.Screen,
+            () => settings.NodeScreenEnabled, v => settings.NodeScreenEnabled = v);
+        AddPermToggle(items, "Allow location", FluentIconCatalog.Location,
+            () => settings.NodeLocationEnabled, v => settings.NodeLocationEnabled = v);
+        AddPermToggle(items, "Allow voice (TTS)", FluentIconCatalog.Voice,
+            () => settings.NodeTtsEnabled, v => settings.NodeTtsEnabled = v);
+
+        return items;
+    }
+
+    private void AddPermToggle(List<TrayMenuFlyoutItem> items, string label, string iconGlyph, Func<bool> get, Action<bool> set)
+    {
+        // Encode current state in the visible glyph: a check prefix when on,
+        // the capability glyph alone when off. The action id round-trips
+        // through OnTrayMenuItemClicked which calls back into the toggler.
+        var on = get();
+        var prefix = on ? FluentIconCatalog.Check : iconGlyph;
+        var actionId = $"perm-toggle|{label}";
+        items.Add(new TrayMenuFlyoutItem
+        {
+            Text = (on ? "✓  " : "    ") + label,
+            Icon = prefix,
+            Action = actionId,
+        });
+        _permToggleActions[actionId] = () =>
+        {
+            set(!get());
+            _settings?.Save();
+            _ = _connectionManager?.ReconnectAsync();
+            // Repaint the menu so the check mark reflects new state.
+            if (_trayMenuWindow != null && _trayMenuWindow.IsShown)
+            {
+                _trayMenuWindow.ClearItems();
+                BuildTrayMenuPopup(_trayMenuWindow);
+            }
+        };
+    }
+
+    private readonly Dictionary<string, Action> _permToggleActions = new(StringComparer.Ordinal);
+
 
     private static string FormatTokenCount(long n)
     {
@@ -1567,7 +1610,13 @@ public partial class App : Application
         return grid;
     }
 
-    private static UIElement BuildSessionCard(SessionInfo session)
+    private static UIElement BuildSessionCard(
+        SessionInfo session,
+        Microsoft.UI.Xaml.Media.Brush successBrush,
+        Microsoft.UI.Xaml.Media.Brush cautionBrush,
+        Microsoft.UI.Xaml.Media.Brush neutralBrush,
+        Microsoft.UI.Xaml.Media.Brush criticalBrush,
+        Microsoft.UI.Xaml.Media.Brush secondaryText)
     {
         var usedTokens = session.InputTokens + session.OutputTokens;
         var contextTokens = session.ContextTokens > 0 ? session.ContextTokens : 200_000;
@@ -1595,10 +1644,9 @@ public partial class App : Application
         {
             Width = 8, Height = 8,
             VerticalAlignment = VerticalAlignment.Center,
-            Fill = new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                isActive ? Microsoft.UI.Colors.LimeGreen
-                : isIdle ? Microsoft.UI.Colors.Orange
-                : Microsoft.UI.Colors.Gray)
+            Fill = isActive ? successBrush
+                : isIdle ? cautionBrush
+                : neutralBrush
         };
         Grid.SetRow(dot, 0);
         Grid.SetColumn(dot, 0);
@@ -1656,7 +1704,7 @@ public partial class App : Application
             {
                 Text = tokenText,
                 FontSize = 11,
-                Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+                Foreground = secondaryText,
                 VerticalAlignment = VerticalAlignment.Center,
                 IsTextSelectionEnabled = false
             });
@@ -1674,7 +1722,7 @@ public partial class App : Application
         {
             Text = statusText,
             FontSize = 11,
-            Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+            Foreground = secondaryText,
             VerticalAlignment = VerticalAlignment.Center,
             IsTextSelectionEnabled = false
         });
@@ -1694,10 +1742,9 @@ public partial class App : Application
                 Height = 3,
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 CornerRadius = new CornerRadius(1.5),
-                Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                    pct > 80 ? Microsoft.UI.Colors.Red
-                    : pct > 50 ? Microsoft.UI.Colors.Orange
-                    : Microsoft.UI.Colors.LimeGreen)
+                Foreground = pct > 80 ? criticalBrush
+                    : pct > 50 ? cautionBrush
+                    : successBrush
             };
             Grid.SetRow(bar, 2);
             Grid.SetColumn(bar, 0);
@@ -1770,7 +1817,11 @@ public partial class App : Application
         return items;
     }
 
-    private static UIElement BuildDeviceCard(GatewayNodeInfo node)
+    private static UIElement BuildDeviceCard(
+        GatewayNodeInfo node,
+        Microsoft.UI.Xaml.Media.Brush successBrush,
+        Microsoft.UI.Xaml.Media.Brush neutralBrush,
+        Microsoft.UI.Xaml.Media.Brush secondaryText)
     {
         var nodeName = !string.IsNullOrWhiteSpace(node.DisplayName) ? node.DisplayName : node.ShortId;
 
@@ -1793,8 +1844,7 @@ public partial class App : Application
         {
             Width = 8, Height = 8,
             VerticalAlignment = VerticalAlignment.Center,
-            Fill = new Microsoft.UI.Xaml.Media.SolidColorBrush(
-                node.IsOnline ? Microsoft.UI.Colors.LimeGreen : Microsoft.UI.Colors.Gray)
+            Fill = node.IsOnline ? successBrush : neutralBrush
         };
         Grid.SetRow(dot, 0);
         Grid.SetColumn(dot, 0);
@@ -1864,7 +1914,7 @@ public partial class App : Application
         {
             Text = row1Text,
             FontSize = 11,
-            Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+            Foreground = secondaryText,
             VerticalAlignment = VerticalAlignment.Center,
             IsTextSelectionEnabled = false
         });

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -14,6 +14,7 @@ using OpenClawTray.Services.LocalGatewaySetup;
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
@@ -1485,26 +1486,19 @@ public partial class App : Application
             var activeCount = _lastSessions.Count(s => string.Equals(s.Status, "active", StringComparison.OrdinalIgnoreCase));
             var totalTokensAll = _lastSessions.Sum(s => s.InputTokens + s.OutputTokens);
             var sessionSummaryRight = $"{activeCount} active · {FormatTokenCount(totalTokensAll)} tokens";
-            menu.AddCustomElement(BuildSectionHeader("Sessions", sessionSummaryRight));
 
-            foreach (var session in _lastSessions.Take(4))
-            {
-                var card = BuildSessionCardCompact(session, successBrush, cautionBrush, neutralBrush, secondaryText);
-                var flyoutItems = BuildSessionFlyoutItems(session, secondaryText);
-                menu.AddFlyoutCustomItem(card, flyoutItems, action: "sessions");
-            }
+            // Single collapsed entry whose hover flyout reveals the session list.
+            var sessionsRow = BuildSessionsListRow(sessionCount, activeCount, totalTokensAll, secondaryText);
+            var sessionsFlyout = BuildSessionsListFlyoutItems(secondaryText, successBrush, cautionBrush, neutralBrush);
+            menu.AddFlyoutCustomItem(sessionsRow, sessionsFlyout, action: "sessions");
         }
 
         // ── Usage ──
-        if (_lastSessions.Length > 0)
         {
             menu.AddSeparator();
-            var totalTokensAll2 = _lastSessions.Sum(s => s.InputTokens + s.OutputTokens);
-            menu.AddCustomElement(BuildSectionHeader("Usage", $"{FormatTokenCount(totalTokensAll2)} tokens"));
-            menu.AddMenuItem(
-                "View detailed usage",
-                FluentIconCatalog.Build(FluentIconCatalog.About),
-                "usage");
+            var usageRow = BuildUsageRow(secondaryText);
+            var usageFlyout = BuildUsageFlyoutItems(secondaryText);
+            menu.AddFlyoutCustomItem(usageRow, usageFlyout, action: "usage");
         }
 
         // ── Pairing approval pending ──
@@ -1661,36 +1655,116 @@ public partial class App : Application
         return $"{(int)age.TotalDays}d ago";
     }
 
-    private static UIElement BuildSessionCardCompact(
-        SessionInfo session,
+    // ── Sessions: collapsed entry + flyout list ─────────────────────────
+
+    private UIElement BuildSessionsListRow(int total, int active, long totalTokens, Microsoft.UI.Xaml.Media.Brush secondaryText)
+    {
+        // Card row: [icon] Sessions    (N active · X tokens)
+        var resources = Application.Current.Resources;
+        var captionStyle = (Style)resources["CaptionTextBlockStyle"];
+
+        var grid = new Grid
+        {
+            Padding = new Thickness(12, 8, 12, 8),
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            ColumnSpacing = 8
+        };
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(24) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var icon = FluentIconCatalog.Build(FluentIconCatalog.Sessions);
+        icon.HorizontalAlignment = HorizontalAlignment.Center;
+        icon.VerticalAlignment = VerticalAlignment.Center;
+        Grid.SetColumn(icon, 0);
+        grid.Children.Add(icon);
+
+        var title = new TextBlock
+        {
+            Text = "Sessions",
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+            FontSize = 13,
+            VerticalAlignment = VerticalAlignment.Center,
+            IsTextSelectionEnabled = false
+        };
+        Grid.SetColumn(title, 1);
+        grid.Children.Add(title);
+
+        var summary = new TextBlock
+        {
+            Text = $"{active} active · {FormatTokenCount(totalTokens)} tokens",
+            Style = captionStyle,
+            FontSize = 11,
+            Foreground = secondaryText,
+            VerticalAlignment = VerticalAlignment.Center,
+            IsTextSelectionEnabled = false
+        };
+        Grid.SetColumn(summary, 2);
+        grid.Children.Add(summary);
+
+        return grid;
+    }
+
+    private List<TrayMenuFlyoutItem> BuildSessionsListFlyoutItems(
+        Microsoft.UI.Xaml.Media.Brush secondaryText,
         Microsoft.UI.Xaml.Media.Brush successBrush,
         Microsoft.UI.Xaml.Media.Brush cautionBrush,
-        Microsoft.UI.Xaml.Media.Brush neutralBrush,
-        Microsoft.UI.Xaml.Media.Brush secondaryText)
+        Microsoft.UI.Xaml.Media.Brush neutralBrush)
     {
-        // VarB compact: one line — ● {name}    {N}m ago
-        // Details (model + ProgressBar) live in the hover flyout.
+        var items = new List<TrayMenuFlyoutItem>
+        {
+            new() { Text = $"Sessions ({_lastSessions.Length})", IsHeader = true }
+        };
+
+        if (_lastSessions.Length == 0)
+        {
+            items.Add(new() { Text = "No active sessions" });
+            return items;
+        }
+
+        foreach (var session in _lastSessions.Take(8))
+        {
+            var card = BuildSessionListCard(session, secondaryText, successBrush, cautionBrush, neutralBrush);
+            items.Add(new() { CustomContent = card });
+        }
+
+        items.Add(new() { Text = "Open Sessions →", Action = "sessions" });
+        return items;
+    }
+
+    private static UIElement BuildSessionListCard(
+        SessionInfo session,
+        Microsoft.UI.Xaml.Media.Brush secondaryText,
+        Microsoft.UI.Xaml.Media.Brush successBrush,
+        Microsoft.UI.Xaml.Media.Brush cautionBrush,
+        Microsoft.UI.Xaml.Media.Brush neutralBrush)
+    {
+        // 2-row card:
+        //   Row 0: ● {name}                              {age}
+        //   Row 1: {model}              [████░░░░] {used}/{ctx} ({pct}%)
         var isActive = string.Equals(session.Status, "active", StringComparison.OrdinalIgnoreCase);
         var isIdle = string.Equals(session.Status, "idle", StringComparison.OrdinalIgnoreCase);
+        var usedTokens = session.InputTokens + session.OutputTokens;
+        var contextTokens = session.ContextTokens > 0 ? session.ContextTokens : 200_000;
+        var pct = usedTokens > 0 ? Math.Min(100.0, (double)usedTokens / contextTokens * 100.0) : 0.0;
 
         var resources = Application.Current.Resources;
         var captionStyle = (Style)resources["CaptionTextBlockStyle"];
 
-        var row = new Grid
+        var outer = new StackPanel
         {
-            Padding = new Thickness(12, 6, 12, 6),
+            Padding = new Thickness(12, 6, 12, 8),
+            Spacing = 4,
             HorizontalAlignment = HorizontalAlignment.Stretch,
-            ColumnSpacing = 8
+            MinWidth = 260
         };
-        row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-        row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
-        var nameRow = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-            Spacing = 6,
-            VerticalAlignment = VerticalAlignment.Center
-        };
+        // Row 0: dot + name + age
+        var line1 = new Grid { ColumnSpacing = 6 };
+        line1.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        line1.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var nameRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6, VerticalAlignment = VerticalAlignment.Center };
         nameRow.Children.Add(new Microsoft.UI.Xaml.Shapes.Ellipse
         {
             Width = 8, Height = 8,
@@ -1707,105 +1781,322 @@ public partial class App : Application
             IsTextSelectionEnabled = false
         });
         Grid.SetColumn(nameRow, 0);
-        row.Children.Add(nameRow);
+        line1.Children.Add(nameRow);
 
         if (session.UpdatedAt.HasValue)
         {
-            var time = new TextBlock
+            var age = new TextBlock
             {
                 Text = FormatRelative(session.UpdatedAt.Value),
-                Style = captionStyle,
-                FontSize = 11,
-                Foreground = secondaryText,
+                Style = captionStyle, FontSize = 11, Foreground = secondaryText,
                 VerticalAlignment = VerticalAlignment.Center,
-                IsTextSelectionEnabled = false,
+                IsTextSelectionEnabled = false
             };
-            Grid.SetColumn(time, 1);
-            row.Children.Add(time);
+            Grid.SetColumn(age, 1);
+            line1.Children.Add(age);
         }
+        outer.Children.Add(line1);
 
-        return row;
+        // Row 1: model + progress + ratio
+        var line2 = new Grid { ColumnSpacing = 8 };
+        line2.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        line2.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        line2.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var modelText = !string.IsNullOrEmpty(session.Model) ? session.Model! : "unknown";
+        var model = new TextBlock
+        {
+            Text = modelText,
+            Style = captionStyle, FontSize = 11, Foreground = secondaryText,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            VerticalAlignment = VerticalAlignment.Center,
+            MaxWidth = 100,
+            IsTextSelectionEnabled = false
+        };
+        Grid.SetColumn(model, 0);
+        line2.Children.Add(model);
+
+        var bar = new ProgressBar
+        {
+            Minimum = 0, Maximum = 100, Value = pct,
+            Height = 6,
+            IsIndeterminate = false,
+            VerticalAlignment = VerticalAlignment.Center,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            CornerRadius = new CornerRadius(3),
+            MinWidth = 80
+        };
+        Grid.SetColumn(bar, 1);
+        line2.Children.Add(bar);
+
+        var ratio = new TextBlock
+        {
+            Text = $"{FormatTokenCount(usedTokens)}/{FormatTokenCount(contextTokens)} ({(int)pct}%)",
+            Style = captionStyle, FontSize = 11, Foreground = secondaryText,
+            VerticalAlignment = VerticalAlignment.Center,
+            IsTextSelectionEnabled = false
+        };
+        Grid.SetColumn(ratio, 2);
+        line2.Children.Add(ratio);
+
+        outer.Children.Add(line2);
+        return outer;
     }
 
-    private static List<TrayMenuFlyoutItem> BuildSessionFlyoutItems(SessionInfo session, Microsoft.UI.Xaml.Media.Brush secondaryText)
+    // ── Usage: collapsed entry + flyout body ────────────────────────────
+
+    private UIElement BuildUsageRow(Microsoft.UI.Xaml.Media.Brush secondaryText)
     {
-        var usedTokens = session.InputTokens + session.OutputTokens;
-        var contextTokens = session.ContextTokens > 0 ? session.ContextTokens : 200_000;
-        var pct = usedTokens > 0 ? (int)(Math.Min(1.0, (double)usedTokens / contextTokens) * 100) : 0;
-
-        var items = new List<TrayMenuFlyoutItem>
-        {
-            new() { Text = session.DisplayName ?? session.Key, IsHeader = true },
-        };
-
-        // Custom row: model name + ProgressBar + ratio
         var resources = Application.Current.Resources;
         var captionStyle = (Style)resources["CaptionTextBlockStyle"];
 
-        var detailStack = new StackPanel
+        var grid = new Grid
         {
-            Padding = new Thickness(12, 6, 12, 8),
-            Spacing = 4
-        };
-        var modelText = !string.IsNullOrEmpty(session.Model) ? session.Model! : "unknown model";
-        detailStack.Children.Add(new TextBlock
-        {
-            Text = modelText,
-            Style = captionStyle,
-            FontSize = 12,
-            Foreground = secondaryText,
-            TextTrimming = TextTrimming.CharacterEllipsis,
-            IsTextSelectionEnabled = false
-        });
-        var progressRow = new Grid { ColumnSpacing = 8 };
-        progressRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-        progressRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-        var bar = new ProgressBar
-        {
-            Minimum = 0, Maximum = 100, Value = pct, Height = 4,
-            VerticalAlignment = VerticalAlignment.Center,
+            Padding = new Thickness(12, 8, 12, 8),
             HorizontalAlignment = HorizontalAlignment.Stretch,
-            CornerRadius = new CornerRadius(2)
+            ColumnSpacing = 8
         };
-        Grid.SetColumn(bar, 0);
-        progressRow.Children.Add(bar);
-        var tokLbl = new TextBlock
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(24) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var icon = FluentIconCatalog.Build(FluentIconCatalog.Dashboard);
+        icon.HorizontalAlignment = HorizontalAlignment.Center;
+        icon.VerticalAlignment = VerticalAlignment.Center;
+        Grid.SetColumn(icon, 0);
+        grid.Children.Add(icon);
+
+        var title = new TextBlock
         {
-            Text = $"{FormatTokenCount(usedTokens)} / {FormatTokenCount(contextTokens)} ({pct}%)",
-            Style = captionStyle,
-            FontSize = 11,
-            Foreground = secondaryText,
+            Text = "Usage",
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+            FontSize = 13,
             VerticalAlignment = VerticalAlignment.Center,
-            HorizontalAlignment = HorizontalAlignment.Right,
             IsTextSelectionEnabled = false
         };
-        Grid.SetColumn(tokLbl, 1);
-        progressRow.Children.Add(tokLbl);
-        detailStack.Children.Add(progressRow);
-        items.Add(new() { CustomContent = detailStack });
+        Grid.SetColumn(title, 1);
+        grid.Children.Add(title);
 
-        // Channel / status
-        if (!string.IsNullOrEmpty(session.Channel))
-            items.Add(new() { Text = $"Channel: {session.Channel}" });
-        items.Add(new() { Text = $"{session.Status} · {session.AgeText}" });
+        // Right-side summary: $X.XX · Y tokens (from gateway _lastUsage, fallback to session aggregation)
+        var totalTokens = _lastUsage?.TotalTokens
+            ?? _lastSessions.Sum(s => s.InputTokens + s.OutputTokens);
+        var cost = _lastUsage?.CostUsd
+            ?? _lastUsageCost?.Totals.TotalCost
+            ?? 0.0;
+        var summaryParts = new List<string>();
+        if (cost > 0) summaryParts.Add($"${cost.ToString("F2", CultureInfo.InvariantCulture)}");
+        if (totalTokens > 0) summaryParts.Add($"{FormatTokenCount(totalTokens)} tokens");
+        var summaryText = summaryParts.Count > 0 ? string.Join(" · ", summaryParts) : "no data";
 
-        // Token detail breakdown
-        items.Add(new() { Text = "Token Usage", IsHeader = true });
-        if (usedTokens > 0)
+        var summary = new TextBlock
         {
-            items.Add(new() { Text = $"Input     {FormatTokenCount(session.InputTokens)}" });
-            items.Add(new() { Text = $"Output    {FormatTokenCount(session.OutputTokens)}" });
+            Text = summaryText,
+            Style = captionStyle, FontSize = 11,
+            Foreground = secondaryText,
+            VerticalAlignment = VerticalAlignment.Center,
+            IsTextSelectionEnabled = false
+        };
+        Grid.SetColumn(summary, 2);
+        grid.Children.Add(summary);
+
+        return grid;
+    }
+
+    private List<TrayMenuFlyoutItem> BuildUsageFlyoutItems(Microsoft.UI.Xaml.Media.Brush secondaryText)
+    {
+        var resources = Application.Current.Resources;
+        var captionStyle = (Style)resources["CaptionTextBlockStyle"];
+        var subhead = (Style)resources["BodyStrongTextBlockStyle"];
+
+        var items = new List<TrayMenuFlyoutItem>
+        {
+            new() { Text = "Usage", IsHeader = true }
+        };
+
+        var totalTokens = _lastUsage?.TotalTokens
+            ?? _lastSessions.Sum(s => s.InputTokens + s.OutputTokens);
+        var inputTokens = _lastUsage?.InputTokens
+            ?? _lastSessions.Sum(s => s.InputTokens);
+        var outputTokens = _lastUsage?.OutputTokens
+            ?? _lastSessions.Sum(s => s.OutputTokens);
+        var cost = _lastUsage?.CostUsd
+            ?? _lastUsageCost?.Totals.TotalCost
+            ?? 0.0;
+        var requests = _lastUsage?.RequestCount ?? 0;
+
+        // Totals card
+        if (totalTokens > 0 || cost > 0)
+        {
+            var totalsCard = new StackPanel
+            {
+                Padding = new Thickness(12, 6, 12, 8),
+                Spacing = 2,
+                MinWidth = 260
+            };
+            if (cost > 0)
+            {
+                totalsCard.Children.Add(new TextBlock
+                {
+                    Text = "$" + cost.ToString("F2", CultureInfo.InvariantCulture),
+                    FontSize = 20,
+                    FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+                    IsTextSelectionEnabled = false
+                });
+            }
+            var detail = new List<string>();
+            if (totalTokens > 0) detail.Add($"{FormatTokenCount(totalTokens)} tokens");
+            if (inputTokens > 0 || outputTokens > 0)
+                detail.Add($"in {FormatTokenCount(inputTokens)} · out {FormatTokenCount(outputTokens)}");
+            if (requests > 0) detail.Add($"{requests} requests");
+            if (detail.Count > 0)
+            {
+                totalsCard.Children.Add(new TextBlock
+                {
+                    Text = string.Join(" · ", detail),
+                    Style = captionStyle, FontSize = 11,
+                    Foreground = secondaryText,
+                    IsTextSelectionEnabled = false
+                });
+            }
+            items.Add(new() { CustomContent = totalsCard });
         }
         else
         {
-            items.Add(new() { Text = "No token usage yet" });
+            items.Add(new() { Text = "No usage data yet" });
         }
 
+        // Providers section
+        var providers = _lastUsageStatus?.Providers;
+        if (providers != null && providers.Count > 0)
+        {
+            items.Add(new() { Text = "Providers", IsHeader = true });
+            foreach (var prov in providers)
+            {
+                var provCard = new StackPanel
+                {
+                    Padding = new Thickness(12, 4, 12, 6),
+                    Spacing = 3,
+                    MinWidth = 260
+                };
+                var header = !string.IsNullOrEmpty(prov.DisplayName) ? prov.DisplayName : prov.Provider;
+                if (!string.IsNullOrEmpty(prov.Plan)) header += $" · {prov.Plan}";
+                provCard.Children.Add(new TextBlock
+                {
+                    Text = header,
+                    FontSize = 12,
+                    FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+                    IsTextSelectionEnabled = false
+                });
+
+                if (!string.IsNullOrEmpty(prov.Error))
+                {
+                    provCard.Children.Add(new TextBlock
+                    {
+                        Text = prov.Error!,
+                        Style = captionStyle, FontSize = 11,
+                        Foreground = (Microsoft.UI.Xaml.Media.Brush)resources["SystemFillColorCriticalBrush"],
+                        TextWrapping = TextWrapping.Wrap,
+                        IsTextSelectionEnabled = false
+                    });
+                }
+
+                foreach (var win in prov.Windows)
+                {
+                    var winRow = new Grid { ColumnSpacing = 8 };
+                    winRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(70) });
+                    winRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                    winRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+                    var label = new TextBlock
+                    {
+                        Text = win.Label,
+                        Style = captionStyle, FontSize = 11,
+                        Foreground = secondaryText,
+                        VerticalAlignment = VerticalAlignment.Center,
+                        IsTextSelectionEnabled = false
+                    };
+                    Grid.SetColumn(label, 0);
+                    winRow.Children.Add(label);
+
+                    var bar = new ProgressBar
+                    {
+                        Minimum = 0, Maximum = 100,
+                        Value = Math.Min(100.0, Math.Max(0.0, win.UsedPercent)),
+                        Height = 6,
+                        IsIndeterminate = false,
+                        VerticalAlignment = VerticalAlignment.Center,
+                        HorizontalAlignment = HorizontalAlignment.Stretch,
+                        CornerRadius = new CornerRadius(3),
+                        MinWidth = 80
+                    };
+                    Grid.SetColumn(bar, 1);
+                    winRow.Children.Add(bar);
+
+                    var pctLbl = new TextBlock
+                    {
+                        Text = $"{(int)win.UsedPercent}%",
+                        Style = captionStyle, FontSize = 11,
+                        Foreground = secondaryText,
+                        VerticalAlignment = VerticalAlignment.Center,
+                        IsTextSelectionEnabled = false
+                    };
+                    Grid.SetColumn(pctLbl, 2);
+                    winRow.Children.Add(pctLbl);
+
+                    provCard.Children.Add(winRow);
+                }
+
+                items.Add(new() { CustomContent = provCard });
+            }
+        }
+
+        // By Model section — aggregate from sessions
+        var byModel = _lastSessions
+            .Where(s => !string.IsNullOrEmpty(s.Model))
+            .GroupBy(s => s.Model!, StringComparer.OrdinalIgnoreCase)
+            .Select(g => new { Model = g.Key, Tokens = g.Sum(s => s.InputTokens + s.OutputTokens) })
+            .Where(x => x.Tokens > 0)
+            .OrderByDescending(x => x.Tokens)
+            .Take(3)
+            .ToList();
+        if (byModel.Count > 0)
+        {
+            items.Add(new() { Text = "By Model", IsHeader = true });
+            foreach (var m in byModel)
+            {
+                var row = new Grid
+                {
+                    Padding = new Thickness(12, 2, 12, 2),
+                    ColumnSpacing = 8,
+                    MinWidth = 260
+                };
+                row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+                var name = new TextBlock
+                {
+                    Text = m.Model,
+                    Style = captionStyle, FontSize = 11,
+                    TextTrimming = TextTrimming.CharacterEllipsis,
+                    IsTextSelectionEnabled = false
+                };
+                Grid.SetColumn(name, 0);
+                row.Children.Add(name);
+                var amt = new TextBlock
+                {
+                    Text = $"{FormatTokenCount(m.Tokens)} tokens",
+                    Style = captionStyle, FontSize = 11,
+                    Foreground = secondaryText,
+                    IsTextSelectionEnabled = false
+                };
+                Grid.SetColumn(amt, 1);
+                row.Children.Add(amt);
+                items.Add(new() { CustomContent = row });
+            }
+        }
+
+        items.Add(new() { Text = "Open detailed usage →", Action = "usage" });
         return items;
     }
-
-    private static List<TrayMenuFlyoutItem> BuildSessionFlyoutItems(SessionInfo session)
-        => BuildSessionFlyoutItems(session, (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]);
 
     private static UIElement BuildDeviceCard(
         GatewayNodeInfo node,

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1333,7 +1333,15 @@ public partial class App : Application
         Grid.SetColumn(gwNameRow, 0);
         gwLine1.Children.Add(gwNameRow);
 
-        // Right-side chip: "Local" when connected to localhost, else version chip when available
+        // Right-side: optional chip + Disconnect/Connect button on the header line
+        var gwRight = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+            VerticalAlignment = VerticalAlignment.Center,
+            HorizontalAlignment = HorizontalAlignment.Right
+        };
+
         string? chipText = null;
         var gwUrl = _settings?.GetEffectiveGatewayUrl();
         Uri? gwUri = null;
@@ -1347,7 +1355,7 @@ public partial class App : Application
         }
         if (chipText != null)
         {
-            var chip = new Border
+            gwRight.Children.Add(new Border
             {
                 CornerRadius = new CornerRadius(4),
                 Padding = new Thickness(6, 1, 6, 1),
@@ -1360,10 +1368,43 @@ public partial class App : Application
                     Foreground = secondaryText,
                     IsTextSelectionEnabled = false
                 }
-            };
-            Grid.SetColumn(chip, 2);
-            gwLine1.Children.Add(chip);
+            });
         }
+
+        var gwBtn = new Button
+        {
+            Content = isConnected ? "Disconnect" : "Connect",
+            VerticalAlignment = VerticalAlignment.Center,
+            Padding = new Thickness(10, 2, 10, 2),
+            MinHeight = 0,
+            MinWidth = 0,
+            FontSize = 11
+        };
+        AutomationProperties.SetName(gwBtn, isConnected ? "Disconnect from gateway" : "Connect to gateway");
+        ToolTipService.SetToolTip(gwBtn, isConnected ? "Disconnect from gateway" : "Connect to gateway");
+        gwBtn.Click += (s, ev) =>
+        {
+            if (isConnected)
+            {
+                _ = _connectionManager?.DisconnectAsync();
+                _lastSessions = Array.Empty<SessionInfo>();
+                _lastNodePairList = null;
+                _lastDevicePairList = null;
+                _lastModelsList = null;
+                _agentEventsCache.Clear();
+                UpdateTrayIcon();
+                _hubWindow?.UpdateStatus(ConnectionStatus.Disconnected);
+            }
+            else
+            {
+                _ = _connectionManager?.ReconnectAsync();
+            }
+            _trayMenuWindow?.HideCascade();
+        };
+        gwRight.Children.Add(gwBtn);
+
+        Grid.SetColumn(gwRight, 2);
+        gwLine1.Children.Add(gwRight);
         gwOuter.Children.Add(gwLine1);
 
         // ── Line 2: secondary details ──
@@ -1403,61 +1444,13 @@ public partial class App : Application
             });
         }
 
-        // Wrap the 2-line content in a Grid with a visible Disconnect/Connect
-        // button on the right side. The info area is clickable to open
-        // connection settings; the button is its own click target.
-        var gwHost = new Grid
-        {
-            Padding = new Thickness(14, 6, 14, 8),
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            ColumnSpacing = 8
-        };
-        gwHost.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-        gwHost.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-
-        // Move gwOuter padding to the host Grid since gwOuter is now nested.
-        gwOuter.Padding = new Thickness(0);
+        // Tap the gateway block to open connection settings (button has its own click handler)
+        gwOuter.Padding = new Thickness(14, 6, 14, 8);
         gwOuter.Tapped += (s, ev) => ShowHub("connection");
-        Grid.SetColumn(gwOuter, 0);
-        gwHost.Children.Add(gwOuter);
-
-        var gwBtn = new Button
-        {
-            Content = isConnected ? "Disconnect" : "Connect",
-            VerticalAlignment = VerticalAlignment.Center,
-            HorizontalAlignment = HorizontalAlignment.Right,
-            Padding = new Thickness(12, 4, 12, 4),
-            MinHeight = 0,
-            MinWidth = 0,
-            FontSize = 11
-        };
-        AutomationProperties.SetName(gwBtn, isConnected ? "Disconnect from gateway" : "Connect to gateway");
-        ToolTipService.SetToolTip(gwBtn, isConnected ? "Disconnect from gateway" : "Connect to gateway");
-        gwBtn.Click += (s, ev) =>
-        {
-            if (isConnected)
-            {
-                _ = _connectionManager?.DisconnectAsync();
-                _lastSessions = Array.Empty<SessionInfo>();
-                _lastNodePairList = null;
-                _lastDevicePairList = null;
-                _lastModelsList = null;
-                _agentEventsCache.Clear();
-                UpdateTrayIcon();
-                _hubWindow?.UpdateStatus(ConnectionStatus.Disconnected);
-            }
-            else
-            {
-                _ = _connectionManager?.ReconnectAsync();
-            }
-            _trayMenuWindow?.HideCascade();
-        };
-        Grid.SetColumn(gwBtn, 1);
-        gwHost.Children.Add(gwBtn);
 
         AutomationProperties.SetName(gwOuter,
             $"Gateway {statusText}. Activate to open connection settings.");
-        menu.AddCustomElement(gwHost);
+        menu.AddCustomElement(gwOuter);
 
         // ── Connected Devices (moved above Sessions) ──
         var connectedNodes = _lastNodes.Where(n => n.IsOnline).ToArray();
@@ -1664,15 +1657,17 @@ public partial class App : Application
 
     private static readonly FrozenDictionary<string, string> CapabilityIcons = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
-        ["screen"] = "🖥",
-        ["camera"] = "📷",
-        ["browser"] = "🌐",
-        ["clipboard"] = "📋",
-        ["tts"] = "🔊",
-        ["location"] = "📍",
-        ["canvas"] = "🎨",
-        ["system"] = "⚙",
-        ["device"] = "📱",
+        ["screen"] = FluentIconCatalog.Screen,
+        ["camera"] = FluentIconCatalog.Camera,
+        ["browser"] = FluentIconCatalog.Browser,
+        ["clipboard"] = "\uE77F",     // PasteAsText
+        ["tts"] = FluentIconCatalog.Voice,
+        ["stt"] = FluentIconCatalog.Voice,
+        ["location"] = FluentIconCatalog.Location,
+        ["canvas"] = FluentIconCatalog.Canvas,
+        ["system"] = FluentIconCatalog.System,
+        ["device"] = FluentIconCatalog.Devices,
+        ["app"] = "\uECAA",           // AppIconDefault
     }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     private static Grid BuildSectionHeader(string title, string summary)
@@ -2251,15 +2246,44 @@ public partial class App : Application
             new() { Text = nodeName, IsHeader = true },
         };
 
-        // Status + platform + mode on one line
-        var statusIcon = node.IsOnline ? "🟢" : "⚪";
-        var statusText = node.IsOnline ? "Online" : "Offline";
-        var infoParts = new List<string> { $"{statusIcon} {statusText}" };
-        if (!string.IsNullOrEmpty(node.Platform)) infoParts.Add(node.Platform);
-        if (!string.IsNullOrEmpty(node.Mode)) infoParts.Add(node.Mode);
-        items.Add(new() { Text = string.Join(" · ", infoParts) });
+        // Status card: ● Online · windows · node
+        //              Last seen 4m ago
+        var resources = Application.Current.Resources;
+        var captionStyle = (Style)resources["CaptionTextBlockStyle"];
+        var secondaryText = (Microsoft.UI.Xaml.Media.Brush)resources["TextFillColorSecondaryBrush"];
+        var successBrush = (Microsoft.UI.Xaml.Media.Brush)resources["SystemFillColorSuccessBrush"];
+        var neutralBrush = (Microsoft.UI.Xaml.Media.Brush)resources["SystemFillColorNeutralBrush"];
 
-        // Last seen
+        var statusCard = new StackPanel
+        {
+            Padding = new Thickness(12, 2, 12, 6),
+            Spacing = 2,
+            MinWidth = 260
+        };
+        var statusLine = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        statusLine.Children.Add(new Microsoft.UI.Xaml.Shapes.Ellipse
+        {
+            Width = 8, Height = 8,
+            VerticalAlignment = VerticalAlignment.Center,
+            Fill = node.IsOnline ? successBrush : neutralBrush
+        });
+        var statusParts = new List<string> { node.IsOnline ? "Online" : "Offline" };
+        if (!string.IsNullOrEmpty(node.Platform)) statusParts.Add(node.Platform);
+        if (!string.IsNullOrEmpty(node.Mode)) statusParts.Add(node.Mode);
+        statusLine.Children.Add(new TextBlock
+        {
+            Text = string.Join(" · ", statusParts),
+            FontSize = 12,
+            VerticalAlignment = VerticalAlignment.Center,
+            IsTextSelectionEnabled = false
+        });
+        statusCard.Children.Add(statusLine);
+
         if (node.LastSeen.HasValue)
         {
             var age = DateTime.UtcNow - node.LastSeen.Value;
@@ -2267,10 +2291,17 @@ public partial class App : Application
                 : age.TotalHours < 1 ? $"{(int)age.TotalMinutes}m ago"
                 : age.TotalDays < 1 ? $"{(int)age.TotalHours}h ago"
                 : $"{(int)age.TotalDays}d ago";
-            items.Add(new() { Text = $"Last seen {seenText}" });
+            statusCard.Children.Add(new TextBlock
+            {
+                Text = $"Last seen {seenText}",
+                Style = captionStyle, FontSize = 11,
+                Foreground = secondaryText,
+                IsTextSelectionEnabled = false
+            });
         }
+        items.Add(new() { CustomContent = statusCard });
 
-        // Capabilities + Commands merged — capability as header, commands as details
+        // Capabilities + Commands
         if (node.Capabilities.Count > 0 || node.Commands.Count > 0)
         {
             items.Add(new() { Text = $"Capabilities ({node.CapabilityCount}) · Commands ({node.CommandCount})", IsHeader = true });
@@ -2279,33 +2310,67 @@ public partial class App : Application
                 .GroupBy(c => c.Contains('.') ? c[..c.IndexOf('.')] : c, StringComparer.OrdinalIgnoreCase)
                 .ToDictionary(g => g.Key, g => g.Select(c => c.Contains('.') ? c[(c.IndexOf('.') + 1)..] : c).ToList(), StringComparer.OrdinalIgnoreCase);
 
-            // Show each capability with its commands on separate lines
             var shownGroups = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var cap in node.Capabilities)
             {
-                var icon = CapabilityIcons.TryGetValue(cap, out var emoji) ? emoji : "▪";
-                if (cmdGroups.TryGetValue(cap, out var cmds) && cmds.Count > 0)
-                {
-                    items.Add(new() { Text = $"{icon} {cap}" });
-                    items.Add(new() { Text = $"    {string.Join(", ", cmds)}" });
-                    shownGroups.Add(cap);
-                }
-                else
-                {
-                    items.Add(new() { Text = $"{icon} {cap}" });
-                    shownGroups.Add(cap);
-                }
+                cmdGroups.TryGetValue(cap, out var cmds);
+                items.Add(new() { CustomContent = BuildCapabilityRow(cap, cmds, secondaryText, captionStyle) });
+                shownGroups.Add(cap);
             }
 
-            // Show any command groups not covered by a capability
+            // Command groups without a matching capability entry
             foreach (var group in cmdGroups.Where(g => !shownGroups.Contains(g.Key)).OrderBy(g => g.Key))
             {
-                items.Add(new() { Text = $"▸ {group.Key}" });
-                items.Add(new() { Text = $"    {string.Join(", ", group.Value)}" });
+                items.Add(new() { CustomContent = BuildCapabilityRow(group.Key, group.Value, secondaryText, captionStyle) });
             }
         }
 
         return items;
+    }
+
+    private static UIElement BuildCapabilityRow(string cap, List<string>? commands, Microsoft.UI.Xaml.Media.Brush secondaryText, Style captionStyle)
+    {
+        var grid = new Grid
+        {
+            Padding = new Thickness(12, 4, 12, 4),
+            ColumnSpacing = 10,
+            MinWidth = 260
+        };
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(24) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+        var glyph = CapabilityIcons.TryGetValue(cap, out var pua) ? pua : "\uE7C3"; // Page (fallback)
+        var icon = FluentIconCatalog.Build(glyph);
+        icon.HorizontalAlignment = HorizontalAlignment.Center;
+        icon.VerticalAlignment = VerticalAlignment.Top;
+        icon.Margin = new Thickness(0, 2, 0, 0);
+        Grid.SetColumn(icon, 0);
+        grid.Children.Add(icon);
+
+        var stack = new StackPanel { Spacing = 1, VerticalAlignment = VerticalAlignment.Center };
+        stack.Children.Add(new TextBlock
+        {
+            Text = cap,
+            FontSize = 13,
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+            IsTextSelectionEnabled = false
+        });
+        if (commands != null && commands.Count > 0)
+        {
+            stack.Children.Add(new TextBlock
+            {
+                Text = string.Join(", ", commands),
+                Style = captionStyle, FontSize = 11,
+                Foreground = secondaryText,
+                TextWrapping = TextWrapping.Wrap,
+                MaxWidth = 240,
+                IsTextSelectionEnabled = false
+            });
+        }
+        Grid.SetColumn(stack, 1);
+        grid.Children.Add(stack);
+
+        return grid;
     }
 
     private static Border BuildBadge(string text)

--- a/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
@@ -45,7 +45,7 @@ public static class FluentIconCatalog
     public const string QuickSend = "\uE724";      // Send (Mail variant) — closest universal Send glyph
     public const string Setup = "\uE825";          // MapPin (compass glyph U+E1D3 isn't reliably in Segoe Fluent; MapPin is safer)
     public const string About = "\uE946";          // Info
-    public const string Exit = "\uE7E8";           // PowerButton
+    public const string Exit = "\uE711";           // Cancel (X) — used for "Close" menu item
 
     // ── Affordances ────────────────────────────────────────────────
     public const string ChevronR = "\uE76C";       // ChevronRight

--- a/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
@@ -33,7 +33,8 @@ public static class FluentIconCatalog
     public const string Canvas = "\uE70F";         // Edit
     public const string Screen = "\uE7F4";         // TVMonitor
     public const string Location = "\uE707";       // MapPin (Globe2 alt)
-    public const string Voice = "\uE720";          // Microphone
+    public const string Voice = "\uE767";          // Volume (speaker, for TTS)
+    public const string Speech = "\uF12E";         // Dictate (speech-to-text)
     public const string System = "\uE713";         // Settings (Enable node toggle)
 
     // ── Actions ────────────────────────────────────────────────────

--- a/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
@@ -1,0 +1,85 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace OpenClawTray.Helpers;
+
+/// <summary>
+/// Central catalog of Segoe Fluent Icons (PUA) glyphs used by the tray UI.
+/// Each entry is a single-character string in the Private Use Area
+/// (U+E000-U+F8FF) so call sites avoid magic literals and tests can verify
+/// the catalog is well-formed.
+///
+/// Codepoints are taken from the published Segoe Fluent Icons list. Where
+/// a semantic match was ambiguous the closest available glyph is used and
+/// noted in a comment.
+/// </summary>
+public static class FluentIconCatalog
+{
+    // ── Status / state ─────────────────────────────────────────────
+    public const string StatusOk = "\uE73E";       // CheckMark
+    public const string StatusWarn = "\uE7BA";     // Warning
+    public const string StatusErr = "\uEA39";      // ErrorBadge
+
+    // ── Sections / categories ──────────────────────────────────────
+    public const string Sessions = "\uE8BD";       // Message
+    public const string Approvals = "\uE7BA";      // Warning (re-use)
+    public const string Devices = "\uE772";        // Devices
+    public const string Permissions = "\uE72E";    // Permissions
+
+    // ── Capabilities (per-permission glyphs) ───────────────────────
+    public const string Browser = "\uE774";        // Globe
+    public const string Camera = "\uE722";         // Camera
+    public const string Canvas = "\uE70F";         // Edit
+    public const string Screen = "\uE7F4";         // TVMonitor
+    public const string Location = "\uE707";       // MapPin (Globe2 alt)
+    public const string Voice = "\uE720";          // Microphone
+    public const string System = "\uE713";         // Settings (Enable node toggle)
+
+    // ── Actions ────────────────────────────────────────────────────
+    public const string Dashboard = "\uE774";      // Globe
+    public const string Chat = "\uE8BD";           // Message
+    public const string CanvasAct = "\uE70F";      // Edit
+    public const string VoiceAct = "\uE720";       // Microphone
+    public const string Settings = "\uE713";       // Settings
+    public const string QuickSend = "\uE724";      // Send (Mail variant) — closest universal Send glyph
+    public const string Setup = "\uE825";          // MapPin (compass glyph U+E1D3 isn't reliably in Segoe Fluent; MapPin is safer)
+    public const string About = "\uE946";          // Info
+    public const string Exit = "\uE7E8";           // PowerButton
+
+    // ── Affordances ────────────────────────────────────────────────
+    public const string ChevronR = "\uE76C";       // ChevronRight
+    public const string Check = "\uE73E";          // CheckMark
+
+    // ── Brand placeholder (lobster emoji currently retained) ───────
+    public const string Brand = "🦞";
+
+    /// <summary>
+    /// Builds a <see cref="FontIcon"/> for the given PUA glyph using the
+    /// system-resolved <c>SymbolThemeFontFamily</c> so the icon honors
+    /// the user's selected icon font (Segoe Fluent Icons on Win11, Segoe
+    /// MDL2 Assets fallback on Win10).
+    /// </summary>
+    public static FontIcon Build(string glyph, double size = 16)
+    {
+        return new FontIcon
+        {
+            Glyph = glyph,
+            FontFamily = (FontFamily)Application.Current.Resources["SymbolThemeFontFamily"],
+            FontSize = size,
+        };
+    }
+
+    /// <summary>
+    /// True when <paramref name="value"/> is a single character in the
+    /// Unicode Private Use Area (U+E000-U+F8FF) — i.e. a Segoe Fluent
+    /// Icons glyph rather than an emoji.
+    /// </summary>
+    public static bool IsPuaGlyph(string? value)
+    {
+        if (string.IsNullOrEmpty(value) || value.Length != 1)
+            return false;
+        var c = value[0];
+        return c >= '\uE000' && c <= '\uF8FF';
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/GlobalHotkeyService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/GlobalHotkeyService.cs
@@ -261,7 +261,7 @@ public class GlobalHotkeyService : IDisposable
 
             // Settings hotkey: Win+; — opens Companion Settings.
             if (RegisterHotKey(hWnd, HOTKEY_ID_SETTINGS,
-                MOD_WIN | MOD_NOREPEAT,
+                MOD_CONTROL | MOD_ALT | MOD_NOREPEAT,
                 VK_OEM_1))
             {
                 Logger.Info("Settings hotkey registered: Win+;");

--- a/src/OpenClaw.Tray.WinUI/Services/GlobalHotkeyService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/GlobalHotkeyService.cs
@@ -13,11 +13,14 @@ public class GlobalHotkeyService : IDisposable
 {
     private const int HOTKEY_ID = 9001;
     private const int HOTKEY_ID_VOICE = 9002;
+    private const int HOTKEY_ID_SETTINGS = 9003;
     private const uint MOD_CONTROL = 0x0002;
     private const uint MOD_ALT = 0x0001;
     private const uint MOD_SHIFT = 0x0004;
+    private const uint MOD_WIN = 0x0008;
     private const uint VK_C = 0x43;
     private const uint VK_V = 0x56;
+    private const uint VK_OEM_1 = 0xBA; // ';:' on US keyboards
     private const int WM_HOTKEY = 0x0312;
 
     [DllImport("user32.dll", SetLastError = true)]
@@ -117,6 +120,7 @@ public class GlobalHotkeyService : IDisposable
 
     public event EventHandler? HotkeyPressed;
     public event EventHandler? VoiceHotkeyPressed;
+    public event EventHandler? SettingsHotkeyPressed;
 
     public GlobalHotkeyService()
     {
@@ -255,6 +259,18 @@ public class GlobalHotkeyService : IDisposable
                 Logger.Warn("Failed to register voice hotkey Ctrl+Alt+Shift+V");
             }
 
+            // Settings hotkey: Win+; — opens Companion Settings.
+            if (RegisterHotKey(hWnd, HOTKEY_ID_SETTINGS,
+                MOD_WIN | MOD_NOREPEAT,
+                VK_OEM_1))
+            {
+                Logger.Info("Settings hotkey registered: Win+;");
+            }
+            else
+            {
+                Logger.Warn("Failed to register settings hotkey Win+;");
+            }
+
             _opCompleted.Set();
             return IntPtr.Zero;
         }
@@ -267,6 +283,7 @@ public class GlobalHotkeyService : IDisposable
                 {
                     UnregisterHotKey(hWnd, HOTKEY_ID);
                     UnregisterHotKey(hWnd, HOTKEY_ID_VOICE);
+                    UnregisterHotKey(hWnd, HOTKEY_ID_SETTINGS);
                     _registered = false;
                     Logger.Info("Global hotkeys unregistered");
                 }
@@ -291,6 +308,11 @@ public class GlobalHotkeyService : IDisposable
         {
             Logger.Info("Voice hotkey pressed: Ctrl+Alt+Shift+V");
             VoiceHotkeyPressed?.Invoke(this, EventArgs.Empty);
+        }
+        else if (msg == WM_HOTKEY && wParam.ToInt32() == HOTKEY_ID_SETTINGS)
+        {
+            Logger.Info("Settings hotkey pressed: Win+;");
+            SettingsHotkeyPressed?.Invoke(this, EventArgs.Empty);
         }
         return DefWindowProc(hWnd, msg, wParam, lParam);
     }

--- a/src/OpenClaw.Tray.WinUI/Services/GlobalHotkeyService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/GlobalHotkeyService.cs
@@ -259,16 +259,17 @@ public class GlobalHotkeyService : IDisposable
                 Logger.Warn("Failed to register voice hotkey Ctrl+Alt+Shift+V");
             }
 
-            // Settings hotkey: Win+; — opens Companion Settings.
+            // Settings hotkey: Ctrl+Alt+; — opens Companion Settings.
+            // (Win+; is reserved by Windows for the emoji panel.)
             if (RegisterHotKey(hWnd, HOTKEY_ID_SETTINGS,
                 MOD_CONTROL | MOD_ALT | MOD_NOREPEAT,
                 VK_OEM_1))
             {
-                Logger.Info("Settings hotkey registered: Win+;");
+                Logger.Info("Settings hotkey registered: Ctrl+Alt+;");
             }
             else
             {
-                Logger.Warn("Failed to register settings hotkey Win+;");
+                Logger.Warn("Failed to register settings hotkey Ctrl+Alt+;");
             }
 
             _opCompleted.Set();
@@ -311,7 +312,7 @@ public class GlobalHotkeyService : IDisposable
         }
         else if (msg == WM_HOTKEY && wParam.ToInt32() == HOTKEY_ID_SETTINGS)
         {
-            Logger.Info("Settings hotkey pressed: Win+;");
+            Logger.Info("Settings hotkey pressed: Ctrl+Alt+;");
             SettingsHotkeyPressed?.Invoke(this, EventArgs.Empty);
         }
         return DefWindowProc(hWnd, msg, wParam, lParam);

--- a/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
@@ -575,11 +575,14 @@ public sealed partial class TrayMenuWindow : WindowEx
         {
             HorizontalAlignment = HorizontalAlignment.Stretch
         };
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(24) });
+        var leftPad = indent ? 28 : 12;
+        // Column 0 holds the left padding + a 24-px icon slot. The previous
+        // version had column 0 = 24 px while the icon Border also took a
+        // leftPad margin → glyphs were clipped at the column boundary.
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(leftPad + 24) });
         grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
         grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
-        var leftPad = indent ? 28 : 12;
         var iconSlot = new Border
         {
             Width = 24,

--- a/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
@@ -554,6 +554,25 @@ public sealed partial class TrayMenuWindow : WindowEx
         Grid.SetColumn(labelStack, 1);
         grid.Children.Add(labelStack);
 
+        var trailing = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        var stateLabel = new TextBlock
+        {
+            Text = isOn ? "On" : "Off",
+            FontSize = 12,
+            VerticalAlignment = VerticalAlignment.Center,
+            Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+            IsTextSelectionEnabled = false,
+            MinWidth = 22,
+            TextAlignment = TextAlignment.Right
+        };
+        AutomationProperties.SetAccessibilityView(stateLabel, AccessibilityView.Raw);
+        trailing.Children.Add(stateLabel);
+
         var toggle = new ToggleSwitch
         {
             IsOn = isOn,
@@ -565,11 +584,14 @@ public sealed partial class TrayMenuWindow : WindowEx
         AutomationProperties.SetName(toggle, title);
         toggle.Toggled += (s, e) =>
         {
+            stateLabel.Text = toggle.IsOn ? "On" : "Off";
             if (!string.IsNullOrEmpty(action))
                 MenuItemClicked?.Invoke(this, action);
         };
-        Grid.SetColumn(toggle, 2);
-        grid.Children.Add(toggle);
+        trailing.Children.Add(toggle);
+
+        Grid.SetColumn(trailing, 2);
+        grid.Children.Add(trailing);
 
         grid.PointerEntered += (s, e) => HideActiveFlyout();
         MenuPanel.Children.Add(grid);

--- a/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
@@ -500,6 +500,181 @@ public sealed partial class TrayMenuWindow : WindowEx
     }
 
     /// <summary>
+    /// Adds a row with [icon] [title (+ optional description)] [WinUI ToggleSwitch].
+    /// Toggling the switch fires MenuItemClicked with the supplied action id.
+    /// Used by the Permissions flyout to mirror the in-app PermissionsPage.
+    /// </summary>
+    public void AddToggleItem(string title, string? icon, string? description, bool isOn, string action)
+    {
+        var grid = new Grid
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            Padding = new Thickness(12, 6, 12, 6),
+            ColumnSpacing = 8
+        };
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(28) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var iconElement = ResolveIcon(icon);
+        if (iconElement != null)
+        {
+            AutomationProperties.SetAccessibilityView(iconElement, AccessibilityView.Raw);
+            if (iconElement is FrameworkElement ife)
+            {
+                ife.HorizontalAlignment = HorizontalAlignment.Center;
+                ife.VerticalAlignment = VerticalAlignment.Center;
+            }
+            Grid.SetColumn(iconElement, 0);
+            grid.Children.Add(iconElement);
+        }
+
+        var labelStack = new StackPanel { VerticalAlignment = VerticalAlignment.Center, Spacing = 1 };
+        labelStack.Children.Add(new TextBlock
+        {
+            Text = title,
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+            FontSize = 13,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            IsTextSelectionEnabled = false
+        });
+        if (!string.IsNullOrEmpty(description))
+        {
+            labelStack.Children.Add(new TextBlock
+            {
+                Text = description!,
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+                FontSize = 11,
+                TextWrapping = TextWrapping.Wrap,
+                IsTextSelectionEnabled = false,
+                MaxWidth = 280
+            });
+        }
+        Grid.SetColumn(labelStack, 1);
+        grid.Children.Add(labelStack);
+
+        var toggle = new ToggleSwitch
+        {
+            IsOn = isOn,
+            OnContent = null,
+            OffContent = null,
+            MinWidth = 0,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        AutomationProperties.SetName(toggle, title);
+        toggle.Toggled += (s, e) =>
+        {
+            if (!string.IsNullOrEmpty(action))
+                MenuItemClicked?.Invoke(this, action);
+        };
+        Grid.SetColumn(toggle, 2);
+        grid.Children.Add(toggle);
+
+        grid.PointerEntered += (s, e) => HideActiveFlyout();
+        MenuPanel.Children.Add(grid);
+        _itemCount++;
+    }
+
+    /// <summary>
+    /// Adds a standard menu item with a right-aligned secondary text hint
+    /// (used for keyboard-shortcut display like "Win+;").
+    /// </summary>
+    public void AddMenuItemWithHint(string text, IconElement? icon, string action, string hint, bool indent = false)
+    {
+        var hintBlock = new TextBlock
+        {
+            Text = hint,
+            FontSize = 11,
+            Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+            VerticalAlignment = VerticalAlignment.Center,
+            IsTextSelectionEnabled = false
+        };
+        AutomationProperties.SetAccessibilityView(hintBlock, AccessibilityView.Raw);
+        AddMenuItemWithTrailingElement(text, icon, action, hintBlock, indent);
+    }
+
+    private void AddMenuItemWithTrailingElement(string text, IconElement? icon, string action, FrameworkElement trailing, bool indent)
+    {
+        var row = BuildItemRowWithTrailing(text, icon, trailing, indent, out var label);
+        var button = new Button
+        {
+            Content = row,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            Padding = new Thickness(0, 8, 0, 8),
+            Background = s_transparentBrush,
+            BorderThickness = new Thickness(0),
+            Tag = action,
+            CornerRadius = new CornerRadius(4)
+        };
+        AutomationProperties.SetAutomationId(button, BuildMenuItemAutomationId(action, text));
+        AutomationProperties.SetName(button, text);
+        button.Click += (s, e) =>
+        {
+            MenuItemClicked?.Invoke(this, action);
+            HideCascade();
+        };
+        button.PointerEntered += (s, e) =>
+        {
+            HideActiveFlyout();
+            button.Background = SubtleHoverBrush;
+        };
+        button.PointerExited += (s, e) =>
+        {
+            button.Background = s_transparentBrush;
+        };
+        MenuPanel.Children.Add(button);
+        _itemCount++;
+    }
+
+    private static Grid BuildItemRowWithTrailing(string text, IconElement? icon, FrameworkElement? trailing, bool indent, out TextBlock label)
+    {
+        var grid = new Grid { HorizontalAlignment = HorizontalAlignment.Stretch };
+        var leftPad = indent ? 28 : 12;
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(leftPad + 24) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        var iconSlot = new Border
+        {
+            Width = 24,
+            Margin = new Thickness(leftPad, 0, 0, 0),
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        if (icon != null)
+        {
+            AutomationProperties.SetAccessibilityView(icon, AccessibilityView.Raw);
+            if (icon is FrameworkElement fe)
+            {
+                fe.HorizontalAlignment = HorizontalAlignment.Center;
+                fe.VerticalAlignment = VerticalAlignment.Center;
+            }
+            iconSlot.Child = icon;
+        }
+        Grid.SetColumn(iconSlot, 0);
+        grid.Children.Add(iconSlot);
+        label = new TextBlock
+        {
+            Text = text,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            IsTextSelectionEnabled = false,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(8, 0, 8, 0)
+        };
+        Grid.SetColumn(label, 1);
+        grid.Children.Add(label);
+        if (trailing != null)
+        {
+            trailing.Margin = new Thickness(0, 0, 12, 0);
+            trailing.VerticalAlignment = VerticalAlignment.Center;
+            Grid.SetColumn(trailing, 2);
+            grid.Children.Add(trailing);
+        }
+        return grid;
+    }
+
+    /// <summary>
     /// Adds a custom UIElement as a flyout-enabled menu item with hover/click behavior.
     /// Same behavior as AddFlyoutMenuItem but accepts any UIElement instead of text.
     /// </summary>
@@ -873,6 +1048,14 @@ public sealed partial class TrayMenuWindow : WindowEx
                 {
                     flyoutWindow.AddHeader(item.Text);
                 }
+                else if (item.CustomContent != null)
+                {
+                    flyoutWindow.AddCustomElement(item.CustomContent);
+                }
+                else if (item.IsToggle)
+                {
+                    flyoutWindow.AddToggleItem(item.Text, item.Icon, item.Description, item.IsOn, item.Action);
+                }
                 else if (string.IsNullOrEmpty(item.Action))
                 {
                     // Non-interactive detail line — compact padding
@@ -1045,4 +1228,16 @@ public sealed class TrayMenuFlyoutItem
     public string? Icon { get; set; }
     public string Action { get; set; } = "";
     public bool IsHeader { get; set; }
+
+    // Renders the row with a WinUI ToggleSwitch on the right. When toggled
+    // the flyout fires MenuItemClicked with Action.
+    public bool IsToggle { get; set; }
+    public bool IsOn { get; set; }
+
+    // Optional secondary description text shown below the title (for ToggleSwitch rows).
+    public string? Description { get; set; }
+
+    // Free-form content: when set, the renderer drops the row in via
+    // AddCustomElement and ignores Text/Icon/Action.
+    public UIElement? CustomContent { get; set; }
 }

--- a/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
@@ -1,13 +1,16 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using OpenClaw.Shared;
 using OpenClawTray.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Windows.System;
 using WinUIEx;
 
 namespace OpenClawTray.Windows;
@@ -112,9 +115,31 @@ public sealed partial class TrayMenuWindow : WindowEx
     private Button? _activeFlyoutOwner;
     private string? _activeFlyoutKey;
     private bool _isShown;
+    /// <summary>True while the menu window is visible. App can use this to
+    /// trigger an in-place rebuild when backing state changes mid-display.</summary>
+    public bool IsShown => _isShown;
     private global::Windows.Graphics.RectInt32? _lastMoveAndResizeRect;
     private uint _lastMeasureDpi;
     private double _lastMeasureRasterizationScale;
+    private int _updateDepth;
+
+    // Cached theme brushes resolved lazily on first use, then reused for the
+    // lifetime of the window. The previous implementation looked up every
+    // brush via Application.Current.Resources for every row in the menu,
+    // which showed up as a visible hitch on right-click. The cache also
+    // collapses Microsoft.UI.Colors.Transparent allocations.
+    private Brush? _subtleHoverBrush;
+    private Brush? _dividerBrush;
+    private Brush? _secondaryTextBrush;
+    private static readonly Brush s_transparentBrush =
+        new SolidColorBrush(Microsoft.UI.Colors.Transparent);
+
+    private Brush SubtleHoverBrush =>
+        _subtleHoverBrush ??= (Brush)Application.Current.Resources["SubtleFillColorSecondaryBrush"];
+    private Brush DividerBrush =>
+        _dividerBrush ??= (Brush)Application.Current.Resources["DividerStrokeColorDefaultBrush"];
+    private Brush SecondaryTextBrush =>
+        _secondaryTextBrush ??= (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"];
 
     public TrayMenuWindow() : this(ownerMenu: null)
     {
@@ -141,6 +166,15 @@ public sealed partial class TrayMenuWindow : WindowEx
         
         // Hide when focus lost
         Activated += OnActivated;
+
+        // Keyboard navigation across menu items. We intentionally do NOT
+        // attach per-Button KeyboardAccelerator instances — those crash
+        // inside this WindowEx popup because their scope falls outside
+        // the XamlRoot (see commit 08bce3a on the abandoned settings
+        // branch). A single KeyDown handler on MenuPanel sidesteps the
+        // accelerator scope entirely.
+        MenuPanel.KeyDown += OnMenuPanelKeyDown;
+        MenuPanel.IsTabStop = false;
     }
 
     private void OnActivated(object sender, WindowActivatedEventArgs args)
@@ -281,47 +315,52 @@ public sealed partial class TrayMenuWindow : WindowEx
 
     public void AddMenuItem(string text, string? icon, string action, bool isEnabled = true, bool indent = false)
     {
-        var content = new TextBlock
-        {
-            Text = string.IsNullOrEmpty(icon) ? text : $"{icon}  {text}",
-            TextTrimming = TextTrimming.CharacterEllipsis,
-            IsTextSelectionEnabled = false
-        };
+        var iconElement = ResolveIcon(icon);
+        AddMenuItem(text, iconElement, action, isEnabled, indent);
+    }
 
-        var leftPadding = indent ? 28 : 12;
+    /// <summary>
+    /// Overload that takes a prebuilt <see cref="IconElement"/> (preferred for
+    /// PUA Segoe Fluent glyphs). Lays the row out as a 3-column grid:
+    /// [24-px icon] [stretching label] [auto chevron/accelerator hint].
+    /// </summary>
+    public void AddMenuItem(string text, IconElement? icon, string action, bool isEnabled = true, bool indent = false, IconElement? trailing = null)
+    {
+        var row = BuildItemRow(text, icon, trailing, indent, out var label);
+
         var button = new Button
         {
-            Content = content,
+            Content = row,
             HorizontalAlignment = HorizontalAlignment.Stretch,
-            HorizontalContentAlignment = HorizontalAlignment.Left,
-            Padding = new Thickness(leftPadding, 8, 12, 8),
-            Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent),
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            Padding = new Thickness(0, 8, 0, 8),
+            Background = s_transparentBrush,
             BorderThickness = new Thickness(0),
             IsEnabled = isEnabled,
             Tag = action,
             CornerRadius = new CornerRadius(4)
         };
         AutomationProperties.SetAutomationId(button, BuildMenuItemAutomationId(action, text));
+        AutomationProperties.SetName(button, text);
 
         if (!isEnabled)
-            content.Opacity = 0.5;
+            label.Opacity = 0.5;
 
         button.Click += (s, e) =>
         {
             MenuItemClicked?.Invoke(this, action);
-            HideCascade(); // Hide instead of close - window is reused
+            HideCascade();
         };
 
-        // Hover effect
         button.PointerEntered += (s, e) =>
         {
             HideActiveFlyout();
             if (button.IsEnabled)
-                button.Background = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["SubtleFillColorSecondaryBrush"];
+                button.Background = SubtleHoverBrush;
         };
         button.PointerExited += (s, e) =>
         {
-            button.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent);
+            button.Background = s_transparentBrush;
         };
 
         MenuPanel.Children.Add(button);
@@ -342,35 +381,40 @@ public sealed partial class TrayMenuWindow : WindowEx
 
     public void AddFlyoutMenuItem(string text, string? icon, IEnumerable<TrayMenuFlyoutItem> items, bool indent = false, string? action = null)
     {
-        var content = new TextBlock
-        {
-            Text = string.IsNullOrEmpty(icon) ? $"{text}  ›" : $"{icon}  {text}  ›",
-            TextTrimming = TextTrimming.CharacterEllipsis,
-            IsTextSelectionEnabled = false
-        };
+        AddFlyoutMenuItem(text, ResolveIcon(icon), items, indent, action);
+    }
 
+    public void AddFlyoutMenuItem(string text, IconElement? icon, IEnumerable<TrayMenuFlyoutItem> items, bool indent = false, string? action = null)
+    {
         var flyoutItems = items.ToArray();
 
-        var leftPadding = indent ? 28 : 12;
+        var chevron = FluentIconCatalog.Build(FluentIconCatalog.ChevronR, 12);
+        chevron.Opacity = 0.6;
+        AutomationProperties.SetAccessibilityView(chevron, AccessibilityView.Raw);
+
+        var row = BuildItemRow(text, icon, chevron, indent, out _);
+
         var button = new Button
         {
-            Content = content,
+            Content = row,
             HorizontalAlignment = HorizontalAlignment.Stretch,
-            HorizontalContentAlignment = HorizontalAlignment.Left,
-            Padding = new Thickness(leftPadding, 8, 12, 8),
-            Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent),
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            Padding = new Thickness(0, 8, 0, 8),
+            Background = s_transparentBrush,
             BorderThickness = new Thickness(0),
             CornerRadius = new CornerRadius(4)
         };
+        AutomationProperties.SetName(button, text + " submenu");
+        AutomationProperties.SetAutomationId(button, BuildMenuItemAutomationId(action ?? text, text));
 
         button.PointerEntered += (s, e) =>
         {
-            button.Background = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["SubtleFillColorSecondaryBrush"];
+            button.Background = SubtleHoverBrush;
             ShowCascadingFlyout(button, flyoutItems);
         };
         button.PointerExited += (s, e) =>
         {
-            button.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent);
+            button.Background = s_transparentBrush;
         };
         button.Click += (s, e) =>
         {
@@ -395,8 +439,9 @@ public sealed partial class TrayMenuWindow : WindowEx
         {
             Height = 1,
             Margin = new Thickness(8, 6, 8, 6),
-            Background = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["DividerStrokeColorDefaultBrush"]
+            Background = DividerBrush
         };
+        AutomationProperties.SetAccessibilityView(sep, AccessibilityView.Raw);
         sep.PointerEntered += (s, e) => HideActiveFlyout();
         MenuPanel.Children.Add(sep);
         _separatorCount++;
@@ -425,6 +470,8 @@ public sealed partial class TrayMenuWindow : WindowEx
             VerticalAlignment = VerticalAlignment.Center
         });
 
+        AutomationProperties.SetName(panel, text);
+        AutomationProperties.SetHeadingLevel(panel, AutomationHeadingLevel.Level1);
         MenuPanel.Children.Add(panel);
         _headerCount += 2; // Counts as larger
     }
@@ -438,6 +485,8 @@ public sealed partial class TrayMenuWindow : WindowEx
             Padding = new Thickness(12, 10, 12, 4),
             Opacity = 0.7
         };
+        AutomationProperties.SetHeadingLevel(tb, AutomationHeadingLevel.Level2);
+        AutomationProperties.SetName(tb, text);
         tb.PointerEntered += (s, e) => HideActiveFlyout();
         MenuPanel.Children.Add(tb);
         _headerCount++;
@@ -458,25 +507,45 @@ public sealed partial class TrayMenuWindow : WindowEx
     {
         var flyoutItems = items.ToArray();
 
+        // Wrap content in a 3-col grid so chevron is right-aligned and the
+        // tappable area extends across the full row.
+        var grid = new Grid
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch
+        };
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        Grid.SetColumn((FrameworkElement)content, 0);
+        grid.Children.Add(content);
+
+        var chevron = FluentIconCatalog.Build(FluentIconCatalog.ChevronR, 12);
+        chevron.Opacity = 0.6;
+        chevron.Margin = new Thickness(0, 0, 12, 0);
+        chevron.VerticalAlignment = VerticalAlignment.Center;
+        AutomationProperties.SetAccessibilityView(chevron, AccessibilityView.Raw);
+        Grid.SetColumn(chevron, 1);
+        grid.Children.Add(chevron);
+
         var button = new Button
         {
-            Content = content,
+            Content = grid,
             HorizontalAlignment = HorizontalAlignment.Stretch,
             HorizontalContentAlignment = HorizontalAlignment.Stretch,
             Padding = new Thickness(0),
-            Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent),
+            Background = s_transparentBrush,
             BorderThickness = new Thickness(0),
             CornerRadius = new CornerRadius(6)
         };
 
         button.PointerEntered += (s, e) =>
         {
-            button.Background = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["SubtleFillColorSecondaryBrush"];
+            button.Background = SubtleHoverBrush;
             ShowCascadingFlyout(button, flyoutItems);
         };
         button.PointerExited += (s, e) =>
         {
-            button.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent);
+            button.Background = s_transparentBrush;
         };
         button.Click += (s, e) =>
         {
@@ -494,6 +563,107 @@ public sealed partial class TrayMenuWindow : WindowEx
 
         MenuPanel.Children.Add(button);
         _itemCount++;
+    }
+
+    /// <summary>
+    /// Builds the standard 3-column row layout used by AddMenuItem and
+    /// AddFlyoutMenuItem: [24-px icon] [label] [trailing].
+    /// </summary>
+    private static Grid BuildItemRow(string text, IconElement? icon, IconElement? trailing, bool indent, out TextBlock label)
+    {
+        var grid = new Grid
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch
+        };
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(24) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var leftPad = indent ? 28 : 12;
+        var iconSlot = new Border
+        {
+            Width = 24,
+            Margin = new Thickness(leftPad, 0, 0, 0),
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        if (icon != null)
+        {
+            AutomationProperties.SetAccessibilityView(icon, AccessibilityView.Raw);
+            if (icon is FrameworkElement fe)
+            {
+                fe.HorizontalAlignment = HorizontalAlignment.Center;
+                fe.VerticalAlignment = VerticalAlignment.Center;
+            }
+            iconSlot.Child = icon;
+        }
+        Grid.SetColumn(iconSlot, 0);
+        grid.Children.Add(iconSlot);
+
+        label = new TextBlock
+        {
+            Text = text,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            IsTextSelectionEnabled = false,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(8, 0, 8, 0)
+        };
+        Grid.SetColumn(label, 1);
+        grid.Children.Add(label);
+
+        if (trailing != null)
+        {
+            if (trailing is FrameworkElement tfe)
+            {
+                tfe.Margin = new Thickness(0, 0, 12, 0);
+                tfe.VerticalAlignment = VerticalAlignment.Center;
+            }
+            Grid.SetColumn(trailing, 2);
+            grid.Children.Add(trailing);
+        }
+
+        return grid;
+    }
+
+    /// <summary>
+    /// Resolves a legacy string icon argument: a single PUA character maps to
+    /// a FontIcon via <see cref="FluentIconCatalog"/>; anything else (emoji,
+    /// multi-char) renders as a plain TextBlock so existing call sites keep
+    /// working while the rest of the UI migrates.
+    /// </summary>
+    private static IconElement? ResolveIcon(string? icon)
+    {
+        if (string.IsNullOrEmpty(icon))
+            return null;
+        if (FluentIconCatalog.IsPuaGlyph(icon))
+            return FluentIconCatalog.Build(icon!);
+        // Wrap emoji in a PathIcon-shaped surrogate via FontIcon so the row
+        // layout is consistent. FontIcon happily renders non-PUA characters
+        // using the default font family fallback.
+        return new FontIcon
+        {
+            Glyph = icon!,
+            FontSize = 14
+        };
+    }
+
+    /// <summary>
+    /// Suppresses layout passes while a batch of Add* calls runs. Pair every
+    /// call with <see cref="EndUpdate"/>. Nested begin/end pairs are honored.
+    /// </summary>
+    public void BeginUpdate()
+    {
+        _updateDepth++;
+    }
+
+    public void EndUpdate()
+    {
+        if (_updateDepth > 0)
+            _updateDepth--;
+        if (_updateDepth == 0)
+        {
+            MenuPanel.InvalidateMeasure();
+        }
     }
 
     /// <summary>
@@ -784,6 +954,54 @@ public sealed partial class TrayMenuWindow : WindowEx
             dpi = 96;
 
         return Math.Max(1, (int)Math.Ceiling(viewUnits * dpi / 96.0));
+    }
+
+    private void OnMenuPanelKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        var buttons = MenuPanel.Children
+            .OfType<Button>()
+            .Where(b => b.IsEnabled && b.Visibility == Visibility.Visible)
+            .ToList();
+        if (buttons.Count == 0)
+            return;
+
+        var focused = FocusManager.GetFocusedElement(MenuPanel.XamlRoot) as Button;
+        var idx = focused == null ? -1 : buttons.IndexOf(focused);
+
+        switch (e.Key)
+        {
+            case VirtualKey.Down:
+                buttons[(idx + 1 + buttons.Count) % buttons.Count].Focus(FocusState.Keyboard);
+                e.Handled = true;
+                break;
+            case VirtualKey.Up:
+                buttons[(idx - 1 + buttons.Count) % buttons.Count].Focus(FocusState.Keyboard);
+                e.Handled = true;
+                break;
+            case VirtualKey.Right:
+                if (focused != null && ReferenceEquals(focused, _activeFlyoutOwner) && _activeFlyoutWindow != null)
+                {
+                    // Already open — push focus into the child flyout.
+                    var firstChild = _activeFlyoutWindow.MenuPanel.Children
+                        .OfType<Button>().FirstOrDefault();
+                    firstChild?.Focus(FocusState.Keyboard);
+                    e.Handled = true;
+                }
+                break;
+            case VirtualKey.Left:
+            case VirtualKey.Escape:
+                if (_activeFlyoutWindow != null)
+                {
+                    HideActiveFlyout();
+                }
+                else
+                {
+                    HideCascade();
+                    _ownerMenu?.HideCascade();
+                }
+                e.Handled = true;
+                break;
+        }
     }
 
     private void HideCascadeIfFocusLeavesMenu()

--- a/tests/OpenClaw.Tray.Tests/FluentIconCatalogTests.cs
+++ b/tests/OpenClaw.Tray.Tests/FluentIconCatalogTests.cs
@@ -201,6 +201,39 @@ public sealed class TrayMenuPopupCompositionTests
         Assert.DoesNotContain("Build compact toggle button grid (3 columns)", src);
     }
 
+    /// <summary>
+    /// Regression guard: every static action emitted by the tray menu's
+    /// top-level entries (Gateway header, Permissions, Setup, QuickSend, etc.)
+    /// must have an explicit case in <c>OnTrayMenuItemClicked</c>. The default
+    /// fall-through to <c>ShowHub(action)</c> is convenient but easy to break
+    /// silently — these specific actions are user-visible entry points and
+    /// should be wired explicitly.
+    /// </summary>
+    [Fact]
+    public void BuildTrayMenuPopup_TopLevelActions_AllHaveExplicitHandlers()
+    {
+        var src = ReadAppXaml();
+        string[] requiredActions =
+        {
+            "connection",   // gateway card
+            "disconnect",   // brand-header button (when connected)
+            "reconnect",    // brand-header button (when disconnected)
+            "permissions",  // permissions row
+            "setup",        // setup/reconfigure row
+            "quicksend",    // quicksend row
+            "companion",    // footer
+            "about",        // footer
+            "exit",         // footer
+        };
+
+        foreach (var action in requiredActions)
+        {
+            Assert.True(
+                src.Contains($"case \"{action}\":", StringComparison.Ordinal),
+                $"OnTrayMenuItemClicked must explicitly handle case \"{action}\"");
+        }
+    }
+
     private static string GetRepositoryRoot()
     {
         var env = Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT");

--- a/tests/OpenClaw.Tray.Tests/FluentIconCatalogTests.cs
+++ b/tests/OpenClaw.Tray.Tests/FluentIconCatalogTests.cs
@@ -1,0 +1,225 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace OpenClaw.Tray.Tests;
+
+/// <summary>
+/// Pins the <c>FluentIconCatalog</c> contract: every advertised glyph is a
+/// single Unicode Private Use Area character (or the documented Brand
+/// emoji), and the helper builder uses the SymbolThemeFontFamily resource.
+///
+/// We parse the source rather than reflect on the assembly because
+/// <c>OpenClaw.Tray.Tests</c> is a pure net10.0 project that doesn't
+/// reference the WinUI tray assembly directly.
+/// </summary>
+public sealed class FluentIconCatalogTests
+{
+    private static readonly string[] ExpectedConstants =
+    {
+        "StatusOk", "StatusWarn", "StatusErr",
+        "Sessions", "Approvals", "Devices", "Permissions",
+        "Browser", "Camera", "Canvas", "Screen", "Location", "Voice", "System",
+        "Dashboard", "Chat", "CanvasAct", "VoiceAct", "Settings", "QuickSend",
+        "Setup", "About", "Exit",
+        "ChevronR", "Check",
+        "Brand",
+    };
+
+    private static string ReadCatalogSource()
+    {
+        var path = Path.Combine(
+            GetRepositoryRoot(),
+            "src", "OpenClaw.Tray.WinUI", "Helpers", "FluentIconCatalog.cs");
+        return File.ReadAllText(path);
+    }
+
+    private static IDictionary<string, string> ParseConstants(string source)
+    {
+        // Matches:   public const string Name = "\uXXXX";   or
+        //            public const string Name = "🦞";
+        var rx = new Regex(
+            @"public\s+const\s+string\s+(?<name>\w+)\s*=\s*""(?<value>(?:\\u[0-9A-Fa-f]{4}|[^""\\]|\\.)*)"";",
+            RegexOptions.Compiled);
+
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (Match m in rx.Matches(source))
+        {
+            map[m.Groups["name"].Value] = Regex.Unescape(m.Groups["value"].Value);
+        }
+        return map;
+    }
+
+    [Fact]
+    public void Catalog_ExposesEveryAdvertisedConstant()
+    {
+        var src = ReadCatalogSource();
+        var map = ParseConstants(src);
+        foreach (var name in ExpectedConstants)
+        {
+            Assert.True(map.ContainsKey(name), $"FluentIconCatalog.{name} is missing");
+            Assert.False(string.IsNullOrEmpty(map[name]), $"FluentIconCatalog.{name} is empty");
+        }
+    }
+
+    [Fact]
+    public void PuaConstants_AreSingleCharacterInPrivateUseArea()
+    {
+        var src = ReadCatalogSource();
+        var map = ParseConstants(src);
+        foreach (var name in ExpectedConstants)
+        {
+            if (name == "Brand")
+                continue; // Brand is an emoji surrogate pair by design.
+
+            Assert.True(map.TryGetValue(name, out var value),
+                $"FluentIconCatalog.{name} not found in source");
+            Assert.True(value!.Length == 1,
+                $"FluentIconCatalog.{name} should be a single character; got {value.Length}");
+            var c = value[0];
+            Assert.True(c >= '\uE000' && c <= '\uF8FF',
+                $"FluentIconCatalog.{name} codepoint U+{(int)c:X4} is outside PUA");
+        }
+    }
+
+    [Fact]
+    public void Catalog_DefinesBuildHelper()
+    {
+        var src = ReadCatalogSource();
+        Assert.Contains("public static FontIcon Build", src);
+        Assert.Contains("SymbolThemeFontFamily", src);
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        var env = Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT");
+        if (!string.IsNullOrWhiteSpace(env) && Directory.Exists(env))
+            return env;
+
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "openclaw-windows-node.slnx")) &&
+                Directory.Exists(Path.Combine(directory.FullName, "src")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException(
+            "Could not find repository root. Set OPENCLAW_REPO_ROOT to the repo path.");
+    }
+}
+
+/// <summary>
+/// Guard against regressions in <c>BuildTrayMenuPopup</c>: section order,
+/// theme-brush usage, presence of a Permissions submenu for the local
+/// device, and routing of the new "about" action.
+/// </summary>
+public sealed class TrayMenuPopupCompositionTests
+{
+    private static string ReadAppXaml()
+    {
+        var path = Path.Combine(
+            GetRepositoryRoot(),
+            "src", "OpenClaw.Tray.WinUI", "App.xaml.cs");
+        return File.ReadAllText(path);
+    }
+
+    [Fact]
+    public void BuildTrayMenuPopup_NoHardcodedColors()
+    {
+        var src = ReadAppXaml();
+        // Anything in the tray menu must route through theme brushes; the
+        // refactor explicitly forbids Microsoft.UI.Colors.* sneaking back
+        // into the menu builders.
+        Assert.DoesNotContain("Microsoft.UI.Colors.LimeGreen", src);
+        Assert.DoesNotContain("Microsoft.UI.Colors.Orange", src);
+        Assert.DoesNotContain("Microsoft.UI.Colors.OrangeRed", src);
+        Assert.DoesNotContain("Microsoft.UI.Colors.Gray", src);
+        Assert.DoesNotContain("Microsoft.UI.Colors.Red", src);
+    }
+
+    [Fact]
+    public void BuildTrayMenuPopup_UsesThemeBrushes()
+    {
+        var src = ReadAppXaml();
+        Assert.Contains("SystemFillColorSuccessBrush", src);
+        Assert.Contains("SystemFillColorCautionBrush", src);
+        Assert.Contains("SystemFillColorNeutralBrush", src);
+        Assert.Contains("SystemFillColorCriticalBrush", src);
+    }
+
+    [Fact]
+    public void BuildTrayMenuPopup_SectionOrder_GatewayThenDevicesThenSessions()
+    {
+        var src = ReadAppXaml();
+        var gateway = src.IndexOf("// ── Gateway Section ──", StringComparison.Ordinal);
+        var devices = src.IndexOf("// ── Connected Devices (moved above Sessions) ──", StringComparison.Ordinal);
+        var sessions = src.IndexOf("// ── Sessions (now below Devices) ──", StringComparison.Ordinal);
+        var actions = src.IndexOf("// ── Actions ──", StringComparison.Ordinal);
+        var footer = src.IndexOf("// ── Footer ──", StringComparison.Ordinal);
+
+        Assert.True(gateway > 0, "Gateway section marker missing");
+        Assert.True(devices > gateway, "Devices must follow Gateway");
+        Assert.True(sessions > devices, "Sessions must follow Devices");
+        Assert.True(actions > sessions, "Actions must follow Sessions");
+        Assert.True(footer > actions, "Footer must follow Actions");
+    }
+
+    [Fact]
+    public void BuildTrayMenuPopup_EmitsPermissionsSubmenuForLocalDevice()
+    {
+        var src = ReadAppXaml();
+        Assert.Contains("BuildPermissionsFlyoutItems", src);
+        Assert.Contains("FluentIconCatalog.Permissions", src);
+    }
+
+    [Fact]
+    public void BuildTrayMenuPopup_RoutesAboutAction()
+    {
+        var src = ReadAppXaml();
+        Assert.Contains("\"About\", FluentIconCatalog.Build(FluentIconCatalog.About), \"about\"", src);
+        Assert.Contains("case \"about\":", src);
+    }
+
+    [Fact]
+    public void BuildTrayMenuPopup_BatchesUpdates()
+    {
+        var src = ReadAppXaml();
+        Assert.Contains("menu.BeginUpdate();", src);
+        Assert.Contains("menu.EndUpdate();", src);
+    }
+
+    [Fact]
+    public void BuildTrayMenuPopup_DoesNotEmitInlinePermissionGrid()
+    {
+        var src = ReadAppXaml();
+        // The old 3-column ToggleButton grid was the source of the
+        // permission-row regression; ensure it's gone.
+        Assert.DoesNotContain("Build compact toggle button grid (3 columns)", src);
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        var env = Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT");
+        if (!string.IsNullOrWhiteSpace(env) && Directory.Exists(env))
+            return env;
+
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "openclaw-windows-node.slnx")) &&
+                Directory.Exists(Path.Combine(directory.FullName, "src")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException(
+            "Could not find repository root. Set OPENCLAW_REPO_ROOT to the repo path.");
+    }
+}


### PR DESCRIPTION
## Summary
 
<img width="478" height="480" alt="image" src="https://github.com/user-attachments/assets/3c49eaf5-ffaf-4c2b-a968-70fa548442a7" />
 VarB variant of the WinUI 3 tray-menu redesign — an informative, Fluent-styled
 tray context menu (right click) for OpenClaw built fresh on top of `upstream/master` to 
avoid the perf regressions in the prior round.
 
 ## Key changes
 - **Brand header**: app icon (`Square44x44Logo`) replaces emoji glyph; 
Disconnect/Connect button moved here so the Gateway block stays clean.
 - **Gateway**: now a chevron-flyout row using the same card format as devices.
 Hover reveals a rich detail flyout (server version, auth mode, protocol, 
uptime, conn id, clients, pending approvals). Click still opens Connection 
settings.
 - **Devices**: flow directly under Gateway with no divider/section header. 
Device flyout uses Fluent FontIcon glyphs (`FluentIconCatalog`) and renders 
each capability as a card with bold title + caption commands list. Ellipse + 
theme brush replaces emoji status dot.
 - **Permissions**: top-level Action with hover flyout. WinUI `ToggleSwitch` 
rows with `Off`/`On` text label that updates live, matching the Windows 
Settings Accessibility page pattern.
 - **Sessions / Usage**: collapsed L1 rows with rich hover flyouts (mini 
progress bars, totals, providers, by-model).
 - **Pairing approval pending**: high-priority row placed above Gateway block.
 - **Companion Settings** moved to footer with `Ctrl+Alt+;` hotkey (Win+; 
conflicted with Windows emoji panel).
 - **Menu cleanup**: `Exit` → `Close` with Cancel (X) icon; removed Quick Send,
 Setup/Reconfigure, More(N).
 
 <img width="418" height="426" alt="image" src="https://github.com/user-attachments/assets/ac744c34-d542-44c3-909d-e8cc620edbe3" />
<img width="439" height="480" alt="image" src="https://github.com/user-attachments/assets/fcba0d78-f43c-42f1-8bfb-ced9481682c2" />
 
 ## Validation
 - `./build.ps1` — all projects build cleanly.
 - `OpenClaw.Shared.Tests`: **1548 passed**, 28 skipped.
 - `OpenClaw.Tray.Tests`: **1188 passed**.
 
 ## Scope
 Touches only the tray menu (`App.xaml.cs`, `TrayMenuWindow.xaml.cs`, 
`GlobalHotkeyService.cs`, `FluentIconCatalog.cs`, `FluentIconCatalogTests.cs`).
 No functional behavior changed.
 
 Diff: ~1900 insertions / ~517 deletions across 5 files.