### PR TITLE
Bump Windows tray clients to advertise protocol v4 (unblocks fresh-install pairing)

### DIFF
--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -907,7 +907,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
             @params = new
             {
                 minProtocol = 3,
-                maxProtocol = 3,
+                maxProtocol = 4,
                 client = new
                 {
                     id = OperatorClientId,  // Native client ID

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -589,7 +589,7 @@ public class WindowsNodeClient : WebSocketClientBase
             @params = new
             {
                 minProtocol = 3,
-                maxProtocol = 3,
+                maxProtocol = 4,
                 client = new
                 {
                     id = ClientId,  // Must match what we sign in payload


### PR DESCRIPTION
# Bump Windows tray clients to protocol v4

## What

Bumps `maxProtocol` from `3` to `4` in the operator and node clients' `connect` handshake. Two-line change in two files.

## Why (currently blocking)

Both Windows clients hard-code `minProtocol=3, maxProtocol=3` in their connect handshake. The OpenClaw gateway service installed by `LocalGatewaySetupEngine` uses `OpenClawInstallVersion = "latest"`, which now requires protocol v4 — it returns:

```json
{"error":{"code":"INVALID_REQUEST","message":"protocol mismatch","details":{"expectedProtocol":4,"minimumProbeProtocol":4}}}
```

…and refuses any client that doesn't advertise v4 in its connect range. Result: every fresh local-WSL setup hangs on the operator pairing phase and times out with `operator_pairing_timeout` after the engine retries the handshake repeatedly.

Reproduced today on a fully-wiped slate — `setup-state.json` lands at `Phase=Failed, Status=FailedRetryable, FailureCode=operator_pairing_timeout` after `[HANDSHAKE] Connect error from gateway: message="protocol mismatch"`.

## How

`maxProtocol` → `4`, `minProtocol` stays at `3` so we still negotiate down for older gateways that haven't been updated. Standard backward-compatible negotiation window — gateway picks whatever it supports inside `[3, 4]`.

The signed connect payload (`BuildConnectPayloadV3` / `SignConnectPayloadV3`) is unchanged — verified that v3 signatures remain valid against v4 gateways. WebSocket probe against the running v4 gateway with `maxProtocol=4` accepts the connection and emits `connect.challenge` identically to the v3 probe; only the subsequent auth handshake requires v4 in the client's range.

```diff
 src/OpenClaw.Shared/OpenClawGatewayClient.cs
-                minProtocol = 3,
-                maxProtocol = 3,
+                minProtocol = 3,
+                maxProtocol = 4,

 src/OpenClaw.Shared/WindowsNodeClient.cs
-                minProtocol = 3,
-                maxProtocol = 3,
+                minProtocol = 3,
+                maxProtocol = 4,
```

## Validation

- `./build.ps1` ✅ all four projects
- `OpenClaw.Shared.Tests` ✅ 1548 passed / 28 skipped / 0 failed
- `OpenClaw.Tray.Tests` ✅ 1178 passed / 0 failed
- Live probe against running gateway: `connect.challenge` returned for both `maxProtocol=3` and `maxProtocol=4` requests

## Out of scope

- If protocol v4 introduces new fields the client *can* take advantage of (richer device descriptors, extended scopes, etc.), that's a follow-up. This PR is the minimum to unblock pairing.
- Bumping `minProtocol` to drop v3 entirely should wait until the v4 gateway is the broad default.

## Co-author

Co-authored with Copilot.
