### PR TITLE
Visual refinement + bugs fix

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1252,6 +1252,8 @@ public partial class App : Application
         // ToggleAction delegates; recreate the lookup each rebuild.
         _permToggleActions.Clear();
 
+        ApplyTrayMenuPreviewDataIfRequested();
+
         var isConnected = _currentStatus == ConnectionStatus.Connected;
         var statusText = LocalizationHelper.GetConnectionStatusText(_currentStatus);
 
@@ -1318,8 +1320,8 @@ public partial class App : Application
         ToolTipService.SetToolTip(brandBtn, isConnected ? "Disconnect from gateway" : "Connect to gateway");
         brandBtn.Click += (s, ev) =>
         {
-            OnTrayMenuItemClicked(this, isConnected ? "disconnect" : "reconnect");
             _trayMenuWindow?.HideCascade();
+            OnTrayMenuItemClicked(this, isConnected ? "disconnect" : "reconnect");
         };
         Grid.SetColumn(brandBtn, 2);
         brandGrid.Children.Add(brandBtn);
@@ -1539,6 +1541,92 @@ public partial class App : Application
     }
 
     /// <summary>
+    /// Opt-in design preview: when the <c>OPENCLAW_TRAY_PREVIEW_DATA</c>
+    /// environment variable is set to <c>1</c>, populate the session/usage
+    /// caches with synthetic values so the Sessions and Usage flyouts render
+    /// meaningful progress bars and provider data without a live gateway.
+    /// Real data takes precedence — preview values are only written when the
+    /// corresponding cache is empty/null, so attaching to a real gateway
+    /// after launch immediately replaces the preview.
+    /// </summary>
+    private void ApplyTrayMenuPreviewDataIfRequested()
+    {
+        var flag = Environment.GetEnvironmentVariable("OPENCLAW_TRAY_PREVIEW_DATA");
+        if (string.IsNullOrEmpty(flag) || flag == "0") return;
+
+        {
+            var now = DateTime.UtcNow;
+            _lastSessions = new[]
+            {
+                new SessionInfo
+                {
+                    Key = "preview:main", IsMain = true, Status = "active",
+                    Model = "claude-opus-4.7", DisplayName = "Main · preview",
+                    InputTokens = 124_000, OutputTokens = 36_000,
+                    ContextTokens = 200_000,
+                    UpdatedAt = now.AddMinutes(-2), LastSeen = now,
+                },
+                new SessionInfo
+                {
+                    Key = "preview:dashboard", IsMain = false, Status = "idle",
+                    Model = "gpt-5.4", DisplayName = "agent:main:dashboard",
+                    InputTokens = 58_000, OutputTokens = 12_000,
+                    ContextTokens = 128_000,
+                    UpdatedAt = now.AddHours(-1), LastSeen = now,
+                },
+                new SessionInfo
+                {
+                    Key = "preview:scratch", IsMain = false, Status = "idle",
+                    Model = "claude-haiku-4.5", DisplayName = "agent:main:scratch",
+                    InputTokens = 6_400, OutputTokens = 1_200,
+                    ContextTokens = 64_000,
+                    UpdatedAt = now.AddHours(-4), LastSeen = now,
+                },
+            };
+        }
+
+        _lastUsage = new GatewayUsageInfo
+        {
+            InputTokens = 188_400,
+            OutputTokens = 49_200,
+            TotalTokens = 237_600,
+            CostUsd = 4.82,
+            RequestCount = 142,
+            Model = "claude-opus-4.7",
+        };
+
+        _lastUsageStatus = new GatewayUsageStatusInfo
+        {
+            UpdatedAt = DateTime.UtcNow,
+            Providers = new()
+            {
+                new GatewayUsageProviderInfo
+                {
+                    Provider = "anthropic", DisplayName = "Anthropic",
+                    Plan = "Pro",
+                    Windows = new()
+                    {
+                        new() { Label = "5h window", UsedPercent = 64 },
+                        new() { Label = "Weekly",    UsedPercent = 28 },
+                        new() { Label = "Monthly",   UsedPercent = 0 },
+                    },
+                },
+                new GatewayUsageProviderInfo
+                {
+                    Provider = "openai", DisplayName = "OpenAI",
+                    Plan = "Tier 4",
+                    Windows = new()
+                    {
+                        new() { Label = "RPM",    UsedPercent = 41 },
+                        new() { Label = "TPM",    UsedPercent = 73 },
+                        new() { Label = "Daily",  UsedPercent = 96 },
+                    },
+                },
+            },
+        };
+    }
+
+    /// <summary>
     /// Flyout items for the local-node Permissions row: one check-toggle per
     /// capability flag in <see cref="SettingsData"/>. Toggling saves the
     /// setting and reconnects so the gateway picks up the new capability set.
@@ -1551,26 +1639,34 @@ public partial class App : Application
         };
 
         AddPermToggle(items, "Windows node", FluentIconCatalog.System,
+            "Run OpenClaw as a local node on this PC",
             () => settings.EnableNodeMode, v => settings.EnableNodeMode = v);
         AddPermToggle(items, "Browser control", FluentIconCatalog.Browser,
+            "Let agents drive web browsers via proxy",
             () => settings.NodeBrowserProxyEnabled, v => settings.NodeBrowserProxyEnabled = v);
         AddPermToggle(items, "Camera", FluentIconCatalog.Camera,
+            "Allow webcam capture during sessions",
             () => settings.NodeCameraEnabled, v => settings.NodeCameraEnabled = v);
         AddPermToggle(items, "Canvas", FluentIconCatalog.Canvas,
+            "Render generated HTML canvases in chat",
             () => settings.NodeCanvasEnabled, v => settings.NodeCanvasEnabled = v);
         AddPermToggle(items, "Screen capture", FluentIconCatalog.Screen,
+            "Share what's on your screen with the agent",
             () => settings.NodeScreenEnabled, v => settings.NodeScreenEnabled = v);
         AddPermToggle(items, "Location", FluentIconCatalog.Location,
+            "Share this device's location",
             () => settings.NodeLocationEnabled, v => settings.NodeLocationEnabled = v);
         AddPermToggle(items, "Voice (TTS)", FluentIconCatalog.Voice,
+            "Read responses out loud",
             () => settings.NodeTtsEnabled, v => settings.NodeTtsEnabled = v);
         AddPermToggle(items, "Speech-to-text (STT)", FluentIconCatalog.Speech,
+            "Dictate input by speaking",
             () => settings.NodeSttEnabled, v => settings.NodeSttEnabled = v);
 
         return items;
     }
 
-    private void AddPermToggle(List<TrayMenuFlyoutItem> items, string label, string iconGlyph, Func<bool> get, Action<bool> set)
+    private void AddPermToggle(List<TrayMenuFlyoutItem> items, string label, string iconGlyph, string description, Func<bool> get, Action<bool> set)
     {
         var on = get();
         var actionId = $"perm-toggle|{label}";
@@ -1578,6 +1674,7 @@ public partial class App : Application
         {
             Text = label,
             Icon = iconGlyph,
+            Description = description,
             Action = actionId,
             IsToggle = true,
             IsOn = on,
@@ -1587,11 +1684,6 @@ public partial class App : Application
             set(!get());
             _settings?.Save();
             _ = _connectionManager?.ReconnectAsync();
-            if (_trayMenuWindow != null && _trayMenuWindow.IsShown)
-            {
-                _trayMenuWindow.ClearItems();
-                BuildTrayMenuPopup(_trayMenuWindow);
-            }
         };
     }
 
@@ -1614,50 +1706,50 @@ public partial class App : Application
     {
         var p = Math.Min(100.0, Math.Max(0.0, percent));
         var resources = Application.Current.Resources;
-        var accent = (Microsoft.UI.Xaml.Media.Brush)resources["AccentFillColorDefaultBrush"];
-        var track = (Microsoft.UI.Xaml.Media.Brush)resources["ControlStrongFillColorDefaultBrush"];
+        // Two-tier color: green by default, red only once usage nearly maxed
+        // (≥ 95%). No amber middle band — keeps the signal binary and clear.
+        string accentKey = p >= 95 ? "SystemFillColorCriticalBrush"
+                                   : "SystemFillColorSuccessBrush";
+        var accent = (Microsoft.UI.Xaml.Media.Brush)resources[accentKey];
+        var track = (Microsoft.UI.Xaml.Media.Brush)resources["ControlAltFillColorTertiaryBrush"];
+        // Subtle hairline stroke — macOS-style — gives the bar a defined edge
+        // even when the fill is at 0% or matches the surrounding chrome.
+        var stroke = (Microsoft.UI.Xaml.Media.Brush)resources["ControlStrokeColorDefaultBrush"];
 
-        var grid = new Grid
+        // Outer wrapper carries the rounded corners + track color and clips
+        // the inner accent fill. This guarantees both ends render a clean
+        // pill cap regardless of percent or flyout width.
+        var frame = new Microsoft.UI.Xaml.Controls.Border
         {
             Height = 6,
+            CornerRadius = new CornerRadius(3),
+            Background = track,
+            BorderBrush = stroke,
+            BorderThickness = new Thickness(1),
             HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Center,
-            MinWidth = 80
+            Margin = new Thickness(0, 2, 0, 2),
+            MinWidth = 60,
         };
-        // 1e-6 guard so an empty (0%) bar still renders the track column at
-        // full width; a 0/0 star pair would collapse.
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(Math.Max(0.0001, p), GridUnitType.Star) });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(Math.Max(0.0001, 100.0 - p), GridUnitType.Star) });
+
+        var fillGrid = new Grid();
+        // 1e-6 guard so a 0% bar still renders the empty slot; a 0/0 star pair
+        // would collapse and break the wrapper height.
+        fillGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(Math.Max(0.0001, p), GridUnitType.Star) });
+        fillGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(Math.Max(0.0001, 100.0 - p), GridUnitType.Star) });
 
         var filled = new Microsoft.UI.Xaml.Controls.Border
         {
             Background = accent,
-            CornerRadius = new CornerRadius(3, 0, 0, 3),
             HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Opacity = p <= 0 ? 0 : 1,
         };
-        if (p <= 0)
-        {
-            filled.Opacity = 0; // hide accent stub at exactly 0% but keep slot
-        }
         Grid.SetColumn(filled, 0);
-        grid.Children.Add(filled);
+        fillGrid.Children.Add(filled);
 
-        var rest = new Microsoft.UI.Xaml.Controls.Border
-        {
-            Background = track,
-            CornerRadius = p >= 100 ? new CornerRadius(0, 3, 3, 0) : new CornerRadius(0, 3, 3, 0),
-            HorizontalAlignment = HorizontalAlignment.Stretch,
-            VerticalAlignment = VerticalAlignment.Stretch
-        };
-        if (p <= 0)
-        {
-            rest.CornerRadius = new CornerRadius(3);
-        }
-        Grid.SetColumn(rest, 1);
-        grid.Children.Add(rest);
-
-        return grid;
+        frame.Child = fillGrid;
+        return frame;
     }
 
     // ── Rich card builder helpers for tray menu ──
@@ -1945,7 +2037,7 @@ public partial class App : Application
 
         foreach (var session in _lastSessions.Take(8))
         {
-            var card = BuildSessionListCard(session, secondaryText, successBrush, cautionBrush, neutralBrush);
+            var card = BuildSessionListCard(session, secondaryText);
             items.Add(new() { CustomContent = card });
         }
 
@@ -1954,16 +2046,11 @@ public partial class App : Application
 
     private static UIElement BuildSessionListCard(
         SessionInfo session,
-        Microsoft.UI.Xaml.Media.Brush secondaryText,
-        Microsoft.UI.Xaml.Media.Brush successBrush,
-        Microsoft.UI.Xaml.Media.Brush cautionBrush,
-        Microsoft.UI.Xaml.Media.Brush neutralBrush)
+        Microsoft.UI.Xaml.Media.Brush secondaryText)
     {
         // 2-row card:
-        //   Row 0: ● {name}                              {age}
+        //   Row 0: {name}                                    {age}
         //   Row 1: {model}              [████░░░░] {used}/{ctx} ({pct}%)
-        var isActive = string.Equals(session.Status, "active", StringComparison.OrdinalIgnoreCase);
-        var isIdle = string.Equals(session.Status, "idle", StringComparison.OrdinalIgnoreCase);
         var usedTokens = session.InputTokens + session.OutputTokens;
         var contextTokens = session.ContextTokens > 0 ? session.ContextTokens : 200_000;
         var pct = usedTokens > 0 ? Math.Min(100.0, (double)usedTokens / contextTokens * 100.0) : 0.0;
@@ -1979,18 +2066,12 @@ public partial class App : Application
             MinWidth = 260
         };
 
-        // Row 0: dot + name + age
+        // Row 0: name + age
         var line1 = new Grid { ColumnSpacing = 6 };
         line1.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
         line1.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
         var nameRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6, VerticalAlignment = VerticalAlignment.Center };
-        nameRow.Children.Add(new Microsoft.UI.Xaml.Shapes.Ellipse
-        {
-            Width = 8, Height = 8,
-            VerticalAlignment = VerticalAlignment.Center,
-            Fill = isActive ? successBrush : isIdle ? cautionBrush : neutralBrush
-        });
         nameRow.Children.Add(new TextBlock
         {
             Text = session.DisplayName ?? session.Key,
@@ -2017,9 +2098,8 @@ public partial class App : Application
         }
         outer.Children.Add(line1);
 
-        // Row 1: model + progress + ratio
+        // Row 1: model + ratio (text only — bar gets its own row below for clarity)
         var line2 = new Grid { ColumnSpacing = 8 };
-        line2.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
         line2.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
         line2.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
@@ -2030,15 +2110,10 @@ public partial class App : Application
             Style = captionStyle, FontSize = 11, Foreground = secondaryText,
             TextTrimming = TextTrimming.CharacterEllipsis,
             VerticalAlignment = VerticalAlignment.Center,
-            MaxWidth = 100,
             IsTextSelectionEnabled = false
         };
         Grid.SetColumn(model, 0);
         line2.Children.Add(model);
-
-        var bar = BuildMiniBar(pct);
-        Grid.SetColumn(bar, 1);
-        line2.Children.Add(bar);
 
         var ratio = new TextBlock
         {
@@ -2047,10 +2122,17 @@ public partial class App : Application
             VerticalAlignment = VerticalAlignment.Center,
             IsTextSelectionEnabled = false
         };
-        Grid.SetColumn(ratio, 2);
+        Grid.SetColumn(ratio, 1);
         line2.Children.Add(ratio);
 
         outer.Children.Add(line2);
+
+        // Row 2: dedicated full-width progress bar so it never gets squeezed
+        // between model name and ratio text.
+        var bar = BuildMiniBar(pct);
+        bar.HorizontalAlignment = HorizontalAlignment.Stretch;
+        outer.Children.Add(bar);
+
         return outer;
     }
 
@@ -2214,10 +2296,12 @@ public partial class App : Application
 
                 foreach (var win in prov.Windows)
                 {
-                    var winRow = new Grid { ColumnSpacing = 8 };
-                    winRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(70) });
-                    winRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-                    winRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+                    // Window block: label + % on one row, full-width bar below.
+                    var winBlock = new StackPanel { Spacing = 2 };
+
+                    var winHeader = new Grid { ColumnSpacing = 8 };
+                    winHeader.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                    winHeader.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
 
                     var label = new TextBlock
                     {
@@ -2228,11 +2312,7 @@ public partial class App : Application
                         IsTextSelectionEnabled = false
                     };
                     Grid.SetColumn(label, 0);
-                    winRow.Children.Add(label);
-
-                    var bar = BuildMiniBar(Math.Min(100.0, Math.Max(0.0, win.UsedPercent)));
-                    Grid.SetColumn(bar, 1);
-                    winRow.Children.Add(bar);
+                    winHeader.Children.Add(label);
 
                     var pctLbl = new TextBlock
                     {
@@ -2242,10 +2322,16 @@ public partial class App : Application
                         VerticalAlignment = VerticalAlignment.Center,
                         IsTextSelectionEnabled = false
                     };
-                    Grid.SetColumn(pctLbl, 2);
-                    winRow.Children.Add(pctLbl);
+                    Grid.SetColumn(pctLbl, 1);
+                    winHeader.Children.Add(pctLbl);
 
-                    provCard.Children.Add(winRow);
+                    winBlock.Children.Add(winHeader);
+
+                    var bar = BuildMiniBar(Math.Min(100.0, Math.Max(0.0, win.UsedPercent)));
+                    bar.HorizontalAlignment = HorizontalAlignment.Stretch;
+                    winBlock.Children.Add(bar);
+
+                    provCard.Children.Add(winBlock);
                 }
 
                 items.Add(new() { CustomContent = provCard });
@@ -2337,7 +2423,6 @@ public partial class App : Application
         line1.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });            // dot + name stack
         line1.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) }); // spacer
         line1.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });            // os chip
-        line1.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });            // chevron
 
         var nameRow = new StackPanel
         {
@@ -2383,16 +2468,9 @@ public partial class App : Application
             line1.Children.Add(osChip);
         }
 
-        var chevron = new TextBlock
-        {
-            Text = "›",
-            FontSize = 14,
-            Opacity = 0.5,
-            VerticalAlignment = VerticalAlignment.Center,
-            IsTextSelectionEnabled = false
-        };
-        Grid.SetColumn(chevron, 3);
-        line1.Children.Add(chevron);
+        // Inner chevron removed — AddFlyoutCustomItem already appends the
+        // official Fluent chevron, so drawing another here looked like a
+        // duplicate ":›" glyph in narrow flyouts.
         outer.Children.Add(line1);
 
         // ── Line 2 (verbose details) ──

--- a/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
@@ -25,7 +25,7 @@ public static class FluentIconCatalog
     public const string Sessions = "\uE8BD";       // Message
     public const string Approvals = "\uE7BA";      // Warning (re-use)
     public const string Devices = "\uE772";        // Devices
-    public const string Permissions = "\uE72E";    // Permissions
+    public const string Permissions = "\uEA18";    // Shield
 
     // ── Capabilities (per-permission glyphs) ───────────────────────
     public const string Browser = "\uE774";        // Globe

--- a/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
@@ -31,11 +31,11 @@ public static class FluentIconCatalog
     public const string Browser = "\uE774";        // Globe
     public const string Camera = "\uE722";         // Camera
     public const string Canvas = "\uE70F";         // Edit
-    public const string Screen = "\uE7F4";         // TVMonitor
+    public const string Screen = "\uEB91";         // ScreenTime (screen capture/recording)
     public const string Location = "\uE707";       // MapPin (Globe2 alt)
     public const string Voice = "\uE767";          // Volume (speaker, for TTS)
     public const string Speech = "\uF12E";         // Dictate (speech-to-text)
-    public const string System = "\uE713";         // Settings (Enable node toggle)
+    public const string System = "\uE7F4";         // TVMonitor (Windows node = this desktop)
 
     // ── Actions ────────────────────────────────────────────────────
     public const string Dashboard = "\uE774";      // Globe

--- a/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml
@@ -19,7 +19,7 @@
             <ScrollViewer VerticalScrollBarVisibility="Auto"
                           VerticalScrollMode="Auto"
                           HorizontalScrollBarVisibility="Disabled">
-                <StackPanel x:Name="MenuPanel" AutomationProperties.AutomationId="TrayMenuPanel" Padding="6,8">
+                <StackPanel x:Name="MenuPanel" AutomationProperties.AutomationId="TrayMenuPanel" Padding="6,8,6,4">
                     <!-- Menu items will be added programmatically -->
                 </StackPanel>
             </ScrollViewer>

--- a/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
@@ -509,8 +509,8 @@ public sealed partial class TrayMenuWindow : WindowEx
         var grid = new Grid
         {
             HorizontalAlignment = HorizontalAlignment.Stretch,
-            Padding = new Thickness(12, 6, 12, 6),
-            ColumnSpacing = 8
+            Padding = new Thickness(16, 10, 16, 10),
+            ColumnSpacing = 14
         };
         grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(28) });
         grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
@@ -520,6 +520,10 @@ public sealed partial class TrayMenuWindow : WindowEx
         if (iconElement != null)
         {
             AutomationProperties.SetAccessibilityView(iconElement, AccessibilityView.Raw);
+            if (iconElement is FontIcon fi)
+            {
+                fi.FontSize = 18;
+            }
             if (iconElement is FrameworkElement ife)
             {
                 ife.HorizontalAlignment = HorizontalAlignment.Center;
@@ -529,12 +533,12 @@ public sealed partial class TrayMenuWindow : WindowEx
             grid.Children.Add(iconElement);
         }
 
-        var labelStack = new StackPanel { VerticalAlignment = VerticalAlignment.Center, Spacing = 1 };
+        var labelStack = new StackPanel { VerticalAlignment = VerticalAlignment.Center, Spacing = 2 };
         labelStack.Children.Add(new TextBlock
         {
             Text = title,
-            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
-            FontSize = 13,
+            FontSize = 14,
+            FontWeight = Microsoft.UI.Text.FontWeights.Normal,
             TextTrimming = TextTrimming.CharacterEllipsis,
             IsTextSelectionEnabled = false
         });
@@ -543,12 +547,11 @@ public sealed partial class TrayMenuWindow : WindowEx
             labelStack.Children.Add(new TextBlock
             {
                 Text = description!,
-                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
                 Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
-                FontSize = 11,
+                FontSize = 12,
                 TextWrapping = TextWrapping.Wrap,
                 IsTextSelectionEnabled = false,
-                MaxWidth = 280
+                MaxWidth = 260
             });
         }
         Grid.SetColumn(labelStack, 1);
@@ -557,13 +560,13 @@ public sealed partial class TrayMenuWindow : WindowEx
         var trailing = new StackPanel
         {
             Orientation = Orientation.Horizontal,
-            Spacing = 8,
+            Spacing = 10,
             VerticalAlignment = VerticalAlignment.Center
         };
         var stateLabel = new TextBlock
         {
             Text = isOn ? "On" : "Off",
-            FontSize = 12,
+            FontSize = 13,
             VerticalAlignment = VerticalAlignment.Center,
             Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
             IsTextSelectionEnabled = false,
@@ -908,7 +911,7 @@ public sealed partial class TrayMenuWindow : WindowEx
         var desiredHeight = MenuPanel.DesiredSize.Height;
         
         // Add border chrome (1px border top+bottom = 2px, plus small rounding buffer)
-        var contentHeight = (int)Math.Ceiling(desiredHeight) + 4;
+        var contentHeight = (int)Math.Ceiling(desiredHeight) + 2;
         _menuHeight = Math.Max(contentHeight, 100);
 
         if (workAreaHeightPx > 0)
@@ -1055,7 +1058,13 @@ public sealed partial class TrayMenuWindow : WindowEx
             flyoutWindow.MenuItemClicked += (_, action) =>
             {
                 MenuItemClicked?.Invoke(this, action);
-                HideCascade();
+                // Toggle actions inside a sub-flyout should not close the
+                // cascade — the user often wants to flip several toggles
+                // before dismissing the panel.
+                if (!action.StartsWith("perm-toggle|", StringComparison.Ordinal))
+                {
+                    HideCascade();
+                }
             };
 
             _activeFlyoutWindow = flyoutWindow;


### PR DESCRIPTION
**Visual refinements to bar**
- BuildMiniBar: simplified 2-tier usage colors (green < 95%, red >= 95%) with a hairline ControlStrokeColorDefault stroke; track uses ControlAltFillColorTertiary for better contrast against the bar fill.
<img width="400" height="355" alt="image" src="https://github.com/user-attachments/assets/5913595e-0b2c-4c28-a49f-aa6ea23e6002" />
<img width="410" height="335" alt="image" src="https://github.com/user-attachments/assets/87893899-1858-4c7b-a652-ebc127ef4a83" />


**Visual Bugs**
- BuildSessionListCard: removed the leading status dot — it duplicated and visually collided with the bar color now that the bar conveys the same liveness signal.
- BuildDeviceCard: removed the inner chevron glyph that stacked on top of the outer flyout chevron drawn by AddFlyoutCustomItem (the result read as a confusing ':>' next to the device name).

**Permission Toggle**
- FluentIconCatalog.Permissions: switched key glyph (E72E) to shield (EA18) so the Permissions row matches the companion app in Settings.
- AddToggleItem: re-styled the permissions sub-flyout toggle rows to match Windows 11 Settings spacing — 16x10 padding, 14px Normal-weight title, 12px secondary description, larger icon, 'On/Off' state label next to the switch.
- AddPermToggle: each capability now carries a short description string (e.g. 'Allow webcam capture during sessions') rendered under the title.

**Interaction Bugs**
- Cascade UX: toggling a permission in the sub-flyout no longer collapses the cascade (HideCascade is skipped for perm-toggle|* actions), so users can flip several capabilities in a row. The Connect/Disconnect brand button intentionally still closes the cascade — flipping a gateway connection state needs a moment of focus shift and the user can immediately reopen the tray to confirm the new state.
- ApplyTrayMenuPreviewDataIfRequested: opt-in design-QA data injection gated on OPENCLAW_TRAY_PREVIEW_DATA=1, overriding any live gateway cache so the menu is reviewable without a real connection.
- TrayMenuWindow.xaml: tightened MenuPanel bottom padding (6,8 ->
  6,8,6,4) and shaved 2px from the SizeToContent buffer to remove odd whitespace beneath the Close row.

Validation: ./build.ps1 green; Shared tests 1548/1576 passed (28 skipped); Tray tests 1189/1189 passed.