### PR TITLE
refactor(app): extract OnUiThread helper, replace dispatcher enqueue boilerplate

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -513,6 +513,8 @@ public partial class App : Application
         catch { }
     }
 
+    private void OnUiThread(Microsoft.UI.Dispatching.DispatcherQueueHandler action) => _dispatcherQueue?.TryEnqueue(action);
+
     /// <summary>
     /// Check if the app was launched via protocol activation (MSIX deep link).
     /// In WinUI 3, protocol activation is retrieved via AppInstance, not OnActivated.
@@ -922,7 +924,7 @@ public partial class App : Application
             // Wire Settings button → open the Hub on the Voice & Audio page.
             _voiceOverlayWindow.SettingsRequested += () =>
             {
-                _dispatcherQueue?.TryEnqueue(() => ShowHub("voice"));
+                OnUiThread(() => ShowHub("voice"));
             };
         }
 
@@ -2946,7 +2948,7 @@ public partial class App : Application
         _lastGatewaySelf = null;
 
         // Update UI references
-        _dispatcherQueue?.TryEnqueue(() =>
+        OnUiThread(() =>
         {
             if (_hubWindow != null && !_hubWindow.IsClosed)
             {
@@ -2983,7 +2985,7 @@ public partial class App : Application
         };
 
         _currentStatus = mapped;
-        _dispatcherQueue?.TryEnqueue(() =>
+        OnUiThread(() =>
         {
             _hubWindow?.UpdateStatus(mapped);
             UpdateTrayIcon();
@@ -3203,7 +3205,7 @@ public partial class App : Application
             // Status field is maintained by OnManagerStateChanged — no write needed here.
             _hubWindow?.UpdateStatus(status);
             UpdateTrayIcon();
-            _dispatcherQueue?.TryEnqueue(UpdateStatusDetailWindow);
+            OnUiThread(UpdateStatusDetailWindow);
         }
 
         // Keep hub node state in sync for ConnectionPage
@@ -3374,7 +3376,7 @@ public partial class App : Application
     }
 
     private void OnNodeToastRequested(object? sender, Microsoft.Toolkit.Uwp.Notifications.ToastContentBuilder builder)
-        => _dispatcherQueue?.TryEnqueue(() =>
+        => OnUiThread(() =>
             NonFatalAction.Run(() => ShowToast(builder), msg => Logger.Warn($"Failed to show node toast: {msg}")));
 
     private void OnNodeInvokeCompleted(object? sender, NodeInvokeCompletedEventArgs args)
@@ -3392,7 +3394,7 @@ public partial class App : Application
             details: details,
             nodeId: args.NodeId);
 
-        _dispatcherQueue?.TryEnqueue(UpdateStatusDetailWindow);
+        OnUiThread(UpdateStatusDetailWindow);
     }
 
     private static string GetNodeInvokePrivacyClass(string command)
@@ -3442,7 +3444,7 @@ public partial class App : Application
         }
 
         UpdateTrayIcon();
-        _dispatcherQueue?.TryEnqueue(UpdateStatusDetailWindow);
+        OnUiThread(UpdateStatusDetailWindow);
         
         if (status == ConnectionStatus.Connected)
         {
@@ -3532,7 +3534,7 @@ public partial class App : Application
             AddRecentActivity("Channel health updated", category: "channel", dashboardPath: "channels", details: summary);
         }
 
-        _dispatcherQueue?.TryEnqueue(() =>
+        OnUiThread(() =>
         {
             _hubWindow?.UpdateChannelHealth(channels);
             _hubWindow?.UpdateStatus(_currentStatus);
@@ -3542,9 +3544,9 @@ public partial class App : Application
     private void OnSessionsUpdated(object? sender, SessionInfo[] sessions)
     {
         _lastSessions = sessions;
-        _dispatcherQueue?.TryEnqueue(UpdateStatusDetailWindow);
+        OnUiThread(UpdateStatusDetailWindow);
 
-        _dispatcherQueue?.TryEnqueue(() =>
+        OnUiThread(() =>
         {
             _hubWindow?.UpdateSessions(sessions);
         });
@@ -3570,7 +3572,7 @@ public partial class App : Application
     private void OnUsageUpdated(object? sender, GatewayUsageInfo usage)
     {
         _lastUsage = usage;
-        _dispatcherQueue?.TryEnqueue(() =>
+        OnUiThread(() =>
         {
             _hubWindow?.UpdateUsage(usage);
         });
@@ -3579,7 +3581,7 @@ public partial class App : Application
     private void OnUsageStatusUpdated(object? sender, GatewayUsageStatusInfo usageStatus)
     {
         _lastUsageStatus = usageStatus;
-        _dispatcherQueue?.TryEnqueue(() =>
+        OnUiThread(() =>
         {
             _hubWindow?.UpdateUsageStatus(usageStatus);
         });
@@ -3588,9 +3590,9 @@ public partial class App : Application
     private void OnUsageCostUpdated(object? sender, GatewayCostUsageInfo usageCost)
     {
         _lastUsageCost = usageCost;
-        _dispatcherQueue?.TryEnqueue(UpdateStatusDetailWindow);
+        OnUiThread(UpdateStatusDetailWindow);
 
-        _dispatcherQueue?.TryEnqueue(() =>
+        OnUiThread(() =>
         {
             _hubWindow?.UpdateUsageCost(usageCost);
         });
@@ -3619,7 +3621,7 @@ public partial class App : Application
             stateVersionHealth = _lastGatewaySelf.StateVersionHealth,
             presenceCount = _lastGatewaySelf.PresenceCount
         });
-        _dispatcherQueue?.TryEnqueue(() =>
+        OnUiThread(() =>
         {
             UpdateStatusDetailWindow();
             _hubWindow?.UpdateGatewaySelf(_lastGatewaySelf);
@@ -3632,9 +3634,9 @@ public partial class App : Application
         var previousOnline = _lastNodes.Count(n => n.IsOnline);
         var online = nodes.Count(n => n.IsOnline);
         _lastNodes = nodes;
-        _dispatcherQueue?.TryEnqueue(UpdateStatusDetailWindow);
+        OnUiThread(UpdateStatusDetailWindow);
 
-        _dispatcherQueue?.TryEnqueue(() =>
+        OnUiThread(() =>
         {
             _hubWindow?.UpdateNodes(nodes);
         });
@@ -3657,14 +3659,12 @@ public partial class App : Application
                 _sessionPreviews[preview.Key] = preview;
             }
         }
-        _dispatcherQueue?.TryEnqueue(UpdateStatusDetailWindow);
+        OnUiThread(UpdateStatusDetailWindow);
     }
 
     private void OnSessionCommandCompleted(object? sender, SessionCommandResult result)
     {
-        if (_dispatcherQueue == null) return;
-
-        _dispatcherQueue.TryEnqueue(() =>
+        OnUiThread(() =>
         {
             try
             {
@@ -3706,32 +3706,32 @@ public partial class App : Application
 
     private void OnCronListUpdated(object? sender, System.Text.Json.JsonElement data)
     {
-        _dispatcherQueue?.TryEnqueue(() => _hubWindow?.UpdateCronList(data));
+        OnUiThread(() => _hubWindow?.UpdateCronList(data));
     }
 
     private void OnCronStatusUpdated(object? sender, System.Text.Json.JsonElement data)
     {
-        _dispatcherQueue?.TryEnqueue(() => _hubWindow?.UpdateCronStatus(data));
+        OnUiThread(() => _hubWindow?.UpdateCronStatus(data));
     }
 
     private void OnCronRunsUpdated(object? sender, System.Text.Json.JsonElement data)
     {
-        _dispatcherQueue?.TryEnqueue(() => _hubWindow?.UpdateCronRuns(data));
+        OnUiThread(() => _hubWindow?.UpdateCronRuns(data));
     }
 
     private void OnSkillsStatusUpdated(object? sender, System.Text.Json.JsonElement data)
     {
-        _dispatcherQueue?.TryEnqueue(() => _hubWindow?.UpdateSkillsStatus(data));
+        OnUiThread(() => _hubWindow?.UpdateSkillsStatus(data));
     }
 
     private void OnConfigUpdated(object? sender, System.Text.Json.JsonElement data)
     {
-        _dispatcherQueue?.TryEnqueue(() => _hubWindow?.UpdateConfig(data));
+        OnUiThread(() => _hubWindow?.UpdateConfig(data));
     }
 
     private void OnConfigSchemaUpdated(object? sender, System.Text.Json.JsonElement data)
     {
-        _dispatcherQueue?.TryEnqueue(() => _hubWindow?.UpdateConfigSchema(data));
+        OnUiThread(() => _hubWindow?.UpdateConfigSchema(data));
     }
 
     private System.Text.Json.JsonElement? _lastAgentsList;
@@ -3739,22 +3739,22 @@ public partial class App : Application
     private void OnAgentsListUpdated(object? sender, System.Text.Json.JsonElement data)
     {
         _lastAgentsList = data.Clone();
-        _dispatcherQueue?.TryEnqueue(() => _hubWindow?.UpdateAgentsList(data));
+        OnUiThread(() => _hubWindow?.UpdateAgentsList(data));
     }
 
     private void OnAgentFilesListUpdated(object? sender, System.Text.Json.JsonElement data)
     {
-        _dispatcherQueue?.TryEnqueue(() => _hubWindow?.UpdateAgentFilesList(data));
+        OnUiThread(() => _hubWindow?.UpdateAgentFilesList(data));
     }
 
     private void OnAgentFileContentUpdated(object? sender, System.Text.Json.JsonElement data)
     {
-        _dispatcherQueue?.TryEnqueue(() => _hubWindow?.UpdateAgentFileContent(data));
+        OnUiThread(() => _hubWindow?.UpdateAgentFileContent(data));
     }
 
     private void OnAgentEventReceived(object? sender, AgentEventInfo evt)
     {
-        _dispatcherQueue?.TryEnqueue(() =>
+        OnUiThread(() =>
         {
             _agentEventsCache.Insert(0, evt);
             if (_agentEventsCache.Count > MaxAppAgentEvents)
@@ -3766,25 +3766,25 @@ public partial class App : Application
     private void OnNodePairListUpdated(object? sender, PairingListInfo data)
     {
         _lastNodePairList = data;
-        _dispatcherQueue?.TryEnqueue(() => _hubWindow?.UpdateNodePairList(data));
+        OnUiThread(() => _hubWindow?.UpdateNodePairList(data));
     }
 
     private void OnDevicePairListUpdated(object? sender, DevicePairingListInfo data)
     {
         _lastDevicePairList = data;
-        _dispatcherQueue?.TryEnqueue(() => _hubWindow?.UpdateDevicePairList(data));
+        OnUiThread(() => _hubWindow?.UpdateDevicePairList(data));
     }
 
     private void OnModelsListUpdated(object? sender, ModelsListInfo data)
     {
         _lastModelsList = data;
-        _dispatcherQueue?.TryEnqueue(() => _hubWindow?.UpdateModelsList(data));
+        OnUiThread(() => _hubWindow?.UpdateModelsList(data));
     }
 
     private void OnPresenceUpdated(object? sender, PresenceEntry[] data)
     {
         _lastPresence = data;
-        _dispatcherQueue?.TryEnqueue(() => _hubWindow?.UpdatePresence(data));
+        OnUiThread(() => _hubWindow?.UpdatePresence(data));
     }
 
     private void OnNotificationReceived(object? sender, OpenClawNotification notification)
@@ -3802,7 +3802,7 @@ public partial class App : Application
         {
             if (_voiceOverlayWindow != null)
             {
-                _dispatcherQueue?.TryEnqueue(() =>
+                OnUiThread(() =>
                 {
                     try
                     {
@@ -3908,7 +3908,7 @@ public partial class App : Application
             if (_settings?.EnableNodeMode == true && _nodeService?.IsConnected == true)
             {
                 _lastCheckTime = DateTime.Now;
-                _dispatcherQueue?.TryEnqueue(UpdateStatusDetailWindow);
+                OnUiThread(UpdateStatusDetailWindow);
                 if (userInitiated)
                 {
                     ShowToast(new ToastContentBuilder()
@@ -4759,14 +4759,12 @@ public partial class App : Application
 
     private void OnVoiceHotkeyPressed(object? sender, EventArgs e)
     {
-        if (_dispatcherQueue == null) return;
-        _dispatcherQueue.TryEnqueue(() => ShowVoiceOverlay());
+        OnUiThread(() => ShowVoiceOverlay());
     }
 
     private void OnSettingsHotkeyPressed(object? sender, EventArgs e)
     {
-        if (_dispatcherQueue == null) return;
-        _dispatcherQueue.TryEnqueue(() => ShowHub("companion"));
+        OnUiThread(() => ShowHub("companion"));
     }
 
     #endregion
@@ -4938,7 +4936,7 @@ public partial class App : Application
                     if (!string.IsNullOrEmpty(uri))
                     {
                         Logger.Info($"Received deep link via IPC: {uri}");
-                        _dispatcherQueue?.TryEnqueue(() => HandleDeepLink(uri));
+                        OnUiThread(() => HandleDeepLink(uri));
                     }
                 }
                 catch (OperationCanceledException)
@@ -5038,7 +5036,7 @@ public partial class App : Application
         
         if (arguments.TryGetValue("action", out var action))
         {
-            _dispatcherQueue?.TryEnqueue(() =>
+            OnUiThread(() =>
             {
                 switch (action)
                 {


### PR DESCRIPTION
## Summary

`App.xaml.cs` repeated `_dispatcherQueue?.TryEnqueue(...)` across every gateway event handler. This adds a one-line private helper `OnUiThread` that centralises the null-safe UI thread dispatch, and replaces the 33 straightforward call sites.

No behaviour change. The delegate passes directly to `TryEnqueue` without an intermediate wrapper.

## What changed

- Added `private void OnUiThread(DispatcherQueueHandler action)` after the run marker helpers
- Replaced 33 `_dispatcherQueue?.TryEnqueue(...)` calls with `OnUiThread(...)`
- Four call sites left unchanged: the `Priority.Low` path in `ShowChatWindow` (has an else fallback), the two bool-capture patterns used for enqueue failure logging (`OnGlobalHotkeyPressed` and the `NavigateHandler` TCS), and the constructor injection of `_dispatcherQueue` into `NodeService`

## Testing

- `dotnet build src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj -r win-x64 --nologo`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>