### PR TITLE
Unify easy-button gateway comms through GatewayConnectionManager

### DIFF
--- a/src/OpenClaw.Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/GatewayConnectionManager.cs
@@ -600,6 +600,9 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
     {
         ThrowIfDisposed();
 
+        // Honor a pre-canceled token before any side effects (Hanselman review #4).
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (_nodeConnector == null)
             throw new InvalidOperationException("No node connector is configured on the manager.");
 
@@ -652,12 +655,33 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         {
             await StartNodeConnectionAsync();
 
-            // Re-evaluate state in case the connector reached terminal state synchronously
-            // (test connectors may; production NodeConnector is async).
-            Handler(this, _stateMachine.Current);
+            // Hanselman review #5: StartNodeConnectionAsync has three silent-return
+            // paths (null connector / missing gateway record / no node credential).
+            // If none of them fire a state transition, the post-start snapshot is
+            // still Idle (or Disabled). Surface that immediately rather than waiting
+            // 35s for a misleading TimeoutException — the actual diagnostic was
+            // already recorded via _diagnostics.Record("node", ...) by the start path.
+            var postStart = _stateMachine.Current;
+            if (postStart.NodeState is RoleConnectionState.Idle or RoleConnectionState.Disabled)
+            {
+                tcs.TrySetException(new InvalidOperationException(
+                    "Node connection could not be started — see ConnectionDiagnostics for the credential/record-resolution failure."));
+            }
+            else
+            {
+                // Re-evaluate state in case the connector reached terminal state synchronously
+                // (test connectors may; production NodeConnector is async).
+                Handler(this, postStart);
+            }
 
+            // Hanselman review #3: only apply the default 35s timeout when the caller
+            // didn't supply a cancellable token. A caller that DOES pass one is signaling
+            // they own the deadline (e.g. setup engine with its own retry budget).
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cts.CancelAfter(TimeSpan.FromSeconds(35));
+            if (!cancellationToken.CanBeCanceled)
+            {
+                cts.CancelAfter(TimeSpan.FromSeconds(35));
+            }
 
             try
             {

--- a/src/OpenClaw.Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/GatewayConnectionManager.cs
@@ -592,6 +592,88 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
 
     // ─── Node Connection ───
 
+    /// <summary>
+    /// Drive the node connection for the active gateway and await its terminal state.
+    /// See <see cref="IGatewayConnectionManager.EnsureNodeConnectedAsync"/> for contract.
+    /// </summary>
+    public async Task EnsureNodeConnectedAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+
+        if (_nodeConnector == null)
+            throw new InvalidOperationException("No node connector is configured on the manager.");
+
+        var snapshot = _stateMachine.Current;
+        if (snapshot.OperatorState != RoleConnectionState.Connected)
+        {
+            throw new InvalidOperationException(
+                $"Operator must be Connected before EnsureNodeConnectedAsync (current: {snapshot.OperatorState}).");
+        }
+
+        if (_activeGatewayRecordId == null || _activeIdentityPath == null)
+            throw new InvalidOperationException("No active gateway is configured.");
+
+        // Already paired? short-circuit. (Idempotent — safe to call repeatedly.)
+        if (snapshot.NodeState == RoleConnectionState.Connected
+            && snapshot.NodePairingStatus == PairingStatus.Paired)
+        {
+            return;
+        }
+
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void Handler(object? _, GatewayConnectionSnapshot s)
+        {
+            switch (s.NodeState)
+            {
+                case RoleConnectionState.Connected
+                    when s.NodePairingStatus == PairingStatus.Paired:
+                    tcs.TrySetResult(true);
+                    break;
+                case RoleConnectionState.PairingRejected:
+                    tcs.TrySetException(new InvalidOperationException(
+                        s.NodeError ?? "Node pairing was rejected by the gateway."));
+                    break;
+                case RoleConnectionState.Error:
+                    tcs.TrySetException(new InvalidOperationException(
+                        s.NodeError ?? "Node connection failed."));
+                    break;
+                // PairingRequired / Connecting / Idle — keep waiting; the manager's
+                // existing auto-approve flow (OnNodePairingStatusChanged) handles the
+                // node.pair.approve case when operator has admin/pairing scope. The
+                // role-upgrade pending-device-pair case surfaces as a timeout (the
+                // gateway parks the connect without responding) — caller catches and
+                // runs the WSL CLI device-approver before retrying.
+            }
+        }
+
+        StateChanged += Handler;
+        try
+        {
+            await StartNodeConnectionAsync();
+
+            // Re-evaluate state in case the connector reached terminal state synchronously
+            // (test connectors may; production NodeConnector is async).
+            Handler(this, _stateMachine.Current);
+
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(35));
+
+            try
+            {
+                await tcs.Task.WaitAsync(cts.Token);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException("Timed out waiting for the node to connect and pair with the gateway.");
+            }
+        }
+        finally
+        {
+            StateChanged -= Handler;
+        }
+    }
+
     private bool ShouldStartNodeConnection()
     {
         if (_activeGatewayRecordId == null || _activeIdentityPath == null)

--- a/src/OpenClaw.Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/GatewayConnectionManager.cs
@@ -653,16 +653,9 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         StateChanged += Handler;
         try
         {
-            await StartNodeConnectionAsync();
+            var startAttempted = await StartNodeConnectionAsync();
 
-            // Hanselman review #5: StartNodeConnectionAsync has three silent-return
-            // paths (null connector / missing gateway record / no node credential).
-            // If none of them fire a state transition, the post-start snapshot is
-            // still Idle (or Disabled). Surface that immediately rather than waiting
-            // 35s for a misleading TimeoutException — the actual diagnostic was
-            // already recorded via _diagnostics.Record("node", ...) by the start path.
-            var postStart = _stateMachine.Current;
-            if (postStart.NodeState is RoleConnectionState.Idle or RoleConnectionState.Disabled)
+            if (!startAttempted)
             {
                 tcs.TrySetException(new InvalidOperationException(
                     "Node connection could not be started — see ConnectionDiagnostics for the credential/record-resolution failure."));
@@ -671,7 +664,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             {
                 // Re-evaluate state in case the connector reached terminal state synchronously
                 // (test connectors may; production NodeConnector is async).
-                Handler(this, postStart);
+                Handler(this, _stateMachine.Current);
             }
 
             // Hanselman review #3: only apply the default 35s timeout when the caller
@@ -713,15 +706,15 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         return _isNodeEnabled?.Invoke() ?? false;
     }
 
-    private async Task StartNodeConnectionAsync()
+    private async Task<bool> StartNodeConnectionAsync()
     {
-        if (_nodeConnector == null || _activeGatewayRecordId == null || _activeIdentityPath == null) return;
+        if (_nodeConnector == null || _activeGatewayRecordId == null || _activeIdentityPath == null) return false;
 
         var record = _registry.GetById(_activeGatewayRecordId);
         if (record == null)
         {
             _logger.Warn("[ConnMgr] Cannot start node — gateway record not found");
-            return;
+            return false;
         }
 
         // Use root identity path — clients always read/write from root, not per-gateway
@@ -730,7 +723,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         {
             _logger.Warn("[ConnMgr] No node credential available — skipping node connection");
             _diagnostics.Record("node", "No node credential available");
-            return;
+            return false;
         }
 
         // Mark node as enabled in the state machine so UI reflects node state
@@ -762,6 +755,8 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             _logger.Error($"[ConnMgr] Node connect failed: {ex.Message}");
             _diagnostics.Record("node", "Node connect failed", ex.Message);
         }
+
+        return true;
     }
 
     private async void OnNodeStatusChanged(object? sender, ConnectionStatus status)

--- a/src/OpenClaw.Connection/IGatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/IGatewayConnectionManager.cs
@@ -24,6 +24,26 @@ public interface IGatewayConnectionManager : IDisposable
     Task ReconnectAsync();
     Task SwitchGatewayAsync(string gatewayId);
 
+    /// <summary>
+    /// Drive the node connection for the active gateway and await its terminal state.
+    /// Operator must already be Connected (caller responsibility — usually the easy-button
+    /// setup engine, which only invokes this after PairOperator completes).
+    /// <para>
+    /// Behavior:
+    ///   - If the node is already Connected + Paired, returns immediately.
+    ///   - Otherwise calls the internal node-start path (bypassing the
+    ///     auto-start <c>shouldStartNodeConnection</c> gate) and waits for the
+    ///     manager's snapshot to reach <c>NodeState=Connected, NodePairingStatus=Paired</c>.
+    ///   - Throws <see cref="InvalidOperationException"/> if the operator is not connected
+    ///     or there is no node connector wired.
+    ///   - Throws <see cref="InvalidOperationException"/> on terminal node failure
+    ///     (Error / PairingRejected) with the snapshot's error message.
+    ///   - Throws <see cref="TimeoutException"/> after the default 35s window if the
+    ///     caller did not pass a cancellation token; respects the caller's token otherwise.
+    /// </para>
+    /// </summary>
+    Task EnsureNodeConnectedAsync(CancellationToken cancellationToken = default);
+
     // ─── Setup ───
     Task<SetupCodeResult> ApplySetupCodeAsync(string setupCode);
     Task<SetupCodeResult> ConnectWithSharedTokenAsync(string gatewayUrl, string token, SshTunnelConfig? sshTunnel = null);

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -109,25 +109,33 @@ public partial class App : Application
     /// Creates the WSL local gateway setup engine using the current tray settings.
     /// The V2 setup bridge calls this to drive the local-WSL setup flow;
     /// the engine pairs the operator + Windows tray node into the gateway it
-    /// installs, so we eagerly materialize the NodeService when needed.
+    /// installs, so we eagerly materialize the NodeService when needed (for
+    /// capability registration via the manager's NodeConnector.ClientCreated bridge).
     /// </summary>
     public LocalGatewaySetupEngine CreateLocalGatewaySetupEngine(
         bool replaceExistingConfigurationConfirmed = false)
     {
         var settings = _settings ?? new SettingsManager();
+        // NodeService is still required for capability registration on the manager's
+        // WindowsNodeClient (via App.xaml.cs ClientCreated → AttachClient bridge).
         var nodeService = EnsureNodeServiceForLocalGatewaySetup(settings);
-        // Suppress node auto-connect in the connection manager during setup.
-        // The engine controls node pairing in its own phase (PairWindowsTrayNode).
+        // Suppress manager auto-start of node during setup so the engine retains
+        // strict phase ordering (operator paired → WSL CLI device-approve → node
+        // pairing). EnsureNodeConnectedAsync (called by ConnectionManagerWindowsNodeConnector
+        // in the PairWindowsTrayNode phase) bypasses this gate to drive the connect.
         _suppressNodeDuringSetup = true;
         try
         {
-            // Use the connection manager's operator connector so all handshake/pairing
-            // events appear in the diagnostics window and reuse the manager's v2/v3
-            // signature fallback, credential resolution, and device token persistence.
+            // Use the manager-backed connectors so all handshake/pairing events appear
+            // in the diagnostics window and reuse the manager's v2/v3 signature fallback,
+            // credential resolution, per-gateway identity store, and device token persistence.
             IGatewayOperatorConnector? operatorConnector = null;
+            IWindowsNodeConnector? windowsNodeConnector = null;
             if (_connectionManager != null && _gatewayRegistry != null)
             {
                 operatorConnector = new ConnectionManagerOperatorConnector(
+                    _connectionManager, _gatewayRegistry, new AppLogger());
+                windowsNodeConnector = new ConnectionManagerWindowsNodeConnector(
                     _connectionManager, _gatewayRegistry, new AppLogger());
             }
             var engine = LocalGatewaySetupEngineFactory.CreateLocalOnly(
@@ -136,7 +144,8 @@ public partial class App : Application
                 nodeService,
                 replaceExistingConfigurationConfirmed: replaceExistingConfigurationConfirmed,
                 gatewayRegistry: _gatewayRegistry,
-                operatorConnectorOverride: operatorConnector);
+                operatorConnectorOverride: operatorConnector,
+                windowsNodeConnectorOverride: windowsNodeConnector);
             // Clear suppress flag when engine completes so normal node connections resume.
             // Only clear if this engine is still the active one (prevents stale engine #1
             // from clearing the flag while engine #2 is running).
@@ -670,26 +679,13 @@ public partial class App : Application
         OpenClawTray.Chat.Explorations.ChatExplorationPresetStore.ApplyDefaultIfPresent();
         ShowSurfaceImprovementsTipIfNeeded();
 
+        // Initialize connection manager BEFORE onboarding so CreateLocalGatewaySetupEngine()
+        // (called by the easy-button flow) can wire ConnectionManagerOperatorConnector +
+        // ConnectionManagerWindowsNodeConnector. Without this ordering, the engine factory
+        // would fall back to the legacy NodeServiceWindowsNodeConnector path, which delegates
+        // to the now-obsolete NodeService.ConnectAsync and would fail at runtime.
         _gatewayRegistry = new GatewayRegistry(SettingsManager.SettingsDirectoryPath);
         _gatewayRegistry.Load();
-
-        // First-run check (also supports forced onboarding for testing).
-        // Wrapped in try/catch so a wizard construction failure cannot tear
-        // down the tray; user can retry via the Setup Guide menu item.
-        try
-        {
-            if (RequiresSetup(_settings) ||
-                Environment.GetEnvironmentVariable("OPENCLAW_FORCE_ONBOARDING") == "1")
-            {
-                await ShowOnboardingAsync();
-            }
-        }
-        catch (Exception ex)
-        {
-            Logger.Error($"Onboarding failed during launch (tray remains available): {ex}");
-        }
-
-        // Initialize connection manager (north star architecture)
         var credentialResolver = new CredentialResolver(DeviceIdentityFileReader.Instance);
         var clientFactory = new GatewayClientFactory();
         var appLogger = new AppLogger();
@@ -728,10 +724,25 @@ public partial class App : Application
             nodeConnector: nodeConnector,
             isNodeEnabled: ShouldInitializeNodeService,
             diagnostics: diagnostics,
-            tunnelManager: _sshTunnelService,
-            shouldStartNodeConnection: ShouldInitializeNodeService);
+            tunnelManager: _sshTunnelService);
         _connectionManager.OperatorClientChanged += OnOperatorClientChanged;
         _connectionManager.StateChanged += OnManagerStateChanged;
+
+        // First-run check (also supports forced onboarding for testing).
+        // Wrapped in try/catch so a wizard construction failure cannot tear
+        // down the tray; user can retry via the Setup Guide menu item.
+        try
+        {
+            if (RequiresSetup(_settings) ||
+                Environment.GetEnvironmentVariable("OPENCLAW_FORCE_ONBOARDING") == "1")
+            {
+                await ShowOnboardingAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"Onboarding failed during launch (tray remains available): {ex}");
+        }
 
         // Ensure NodeService is constructed BEFORE InitializeGatewayClient triggers a
         // NodeConnector connect. The NodeConnector.ClientCreated event subscription
@@ -1953,26 +1964,11 @@ public partial class App : Application
         return _settings?.EnableNodeMode == true || _settings?.EnableMcpServer == true;
     }
 
-    private bool ShouldInitializeNodeService(GatewayRecord activeGateway, string managerIdentityPath)
-    {
-        if (!ShouldInitializeNodeService()) return false;
-
-        if (LocalNodeServiceOwnsIdentityFor(activeGateway))
-        {
-            Logger.Info("[ConnMgr] Suppressing manager-owned NodeConnector because local NodeService owns the active local gateway identity");
-            return false;
-        }
-
-        return true;
-    }
-
-    private bool LocalNodeServiceOwnsIdentityFor(GatewayRecord activeGateway)
-    {
-        if (!activeGateway.IsLocal || _settings == null) return false;
-        if (!StartupSetupState.HasStoredNodeDeviceToken(IdentityDataPath)) return false;
-
-        return EnsureNodeServiceForLocalGatewaySetup(_settings) != null;
-    }
+    // The pre-unification ShouldInitializeNodeService(GatewayRecord, string) overload
+    // and LocalNodeServiceOwnsIdentityFor have been removed: GatewayConnectionManager
+    // is now the single owner of the WindowsNodeClient lifecycle for ALL gateways
+    // (local + remote). NodeService remains as the capability registrar via the
+    // NodeConnector.ClientCreated → AttachClient bridge wired in InitializeApp.
 
     private void OnNodeStatusChanged(object? sender, ConnectionStatus status)
     {

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1510,7 +1510,14 @@ public partial class App : Application
         if (!Directory.Exists(identityDir))
             Directory.CreateDirectory(identityDir);
 
-        // Copy identity file from legacy location if needed
+        // Copy identity file from legacy location if needed.
+        // device-key-ed25519.json holds BOTH the operator DeviceToken and the
+        // node NodeDeviceToken on a single record (DeviceIdentity.DeviceKeyData),
+        // so this single copy migrates both roles' identity for paired-pre-
+        // unification installs (the easy-button setup engine used to write the
+        // node-side tokens to this same legacy path via NodeService.ConnectAsync).
+        // The legacy file is preserved (copy, not move) for at least one release
+        // to allow safe rollback.
         var legacyIdentityPath = Path.Combine(SettingsManager.SettingsDirectoryPath, "device-key-ed25519.json");
         var newIdentityPath = Path.Combine(identityDir, "device-key-ed25519.json");
         if (File.Exists(legacyIdentityPath) && !File.Exists(newIdentityPath))

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3283,6 +3283,19 @@ public partial class App : Application
                 return;
             }
 
+            // If a reconnect is already in flight (e.g. the user clicked Finish while
+            // the gateway was mid-restart from a V2 GatewayWelcome wizard config save —
+            // the gateway emits a `shutdown` event with reason="gateway restarting" when
+            // provider/model config changes), let the existing auto-reconnect timer
+            // finish rather than canceling it and starting a fresh one. Canceling adds
+            // a visible ~5s churn (cancel + new connect attempt against a still-warming
+            // gateway + retry) on top of the gateway's own ~1.5s restart window.
+            if (_connectionManager?.CurrentSnapshot.OperatorState == RoleConnectionState.Connecting)
+            {
+                Logger.Info("Gateway client reconnect already in flight — keeping");
+                return;
+            }
+
             // Reconnect only if there's an active gateway with credentials —
             // don't blindly reconnect a pre-setup gateway the user may be replacing.
             var activeRecord = _gatewayRegistry?.GetActive();

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -115,6 +115,14 @@ public partial class App : Application
     public LocalGatewaySetupEngine CreateLocalGatewaySetupEngine(
         bool replaceExistingConfigurationConfirmed = false)
     {
+        if (_connectionManager == null || _gatewayRegistry == null)
+        {
+            throw new InvalidOperationException(
+                "GatewayConnectionManager / GatewayRegistry must be initialized before " +
+                "CreateLocalGatewaySetupEngine. App.OnLaunched initializes them before " +
+                "ShowOnboardingAsync — if you reach here, the init order has regressed.");
+        }
+
         var settings = _settings ?? new SettingsManager();
         // NodeService is still required for capability registration on the manager's
         // WindowsNodeClient (via App.xaml.cs ClientCreated → AttachClient bridge).
@@ -129,23 +137,18 @@ public partial class App : Application
             // Use the manager-backed connectors so all handshake/pairing events appear
             // in the diagnostics window and reuse the manager's v2/v3 signature fallback,
             // credential resolution, per-gateway identity store, and device token persistence.
-            IGatewayOperatorConnector? operatorConnector = null;
-            IWindowsNodeConnector? windowsNodeConnector = null;
-            if (_connectionManager != null && _gatewayRegistry != null)
-            {
-                operatorConnector = new ConnectionManagerOperatorConnector(
-                    _connectionManager, _gatewayRegistry, new AppLogger());
-                windowsNodeConnector = new ConnectionManagerWindowsNodeConnector(
-                    _connectionManager, _gatewayRegistry, new AppLogger());
-            }
+            var operatorConnector = new ConnectionManagerOperatorConnector(
+                _connectionManager, _gatewayRegistry, new AppLogger());
+            var windowsNodeConnector = new ConnectionManagerWindowsNodeConnector(
+                _connectionManager, _gatewayRegistry, new AppLogger());
             var engine = LocalGatewaySetupEngineFactory.CreateLocalOnly(
                 settings,
+                operatorConnector,
+                windowsNodeConnector,
                 new AppLogger(),
                 nodeService,
                 replaceExistingConfigurationConfirmed: replaceExistingConfigurationConfirmed,
-                gatewayRegistry: _gatewayRegistry,
-                operatorConnectorOverride: operatorConnector,
-                windowsNodeConnectorOverride: windowsNodeConnector);
+                gatewayRegistry: _gatewayRegistry);
             // Clear suppress flag when engine completes so normal node connections resume.
             // Only clear if this engine is still the active one (prevents stale engine #1
             // from clearing the flag while engine #2 is running).

--- a/src/OpenClaw.Tray.WinUI/Services/ConnectionManagerWindowsNodeConnector.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ConnectionManagerWindowsNodeConnector.cs
@@ -51,13 +51,16 @@ public sealed class ConnectionManagerWindowsNodeConnector : IWindowsNodeConnecto
         {
             // Defensive: the operator phase should always have created this record.
             // If it didn't, create one now so the manager can resolve credentials.
+            // IsLocal is derived from the URL via LocalGatewayUrlClassifier so this
+            // doesn't silently misclassify a remote gateway if the connector is
+            // ever reused outside the local-loopback easy-button flow.
             var fresh = new GatewayRecord
             {
                 Id = Guid.NewGuid().ToString(),
                 Url = normalized,
                 SharedGatewayToken = !string.IsNullOrWhiteSpace(token) ? token : null,
                 BootstrapToken = !string.IsNullOrWhiteSpace(bootstrapToken) ? bootstrapToken : null,
-                IsLocal = true,
+                IsLocal = LocalGatewayUrlClassifier.IsLocalGatewayUrl(normalized),
             };
             _registry.AddOrUpdate(fresh);
             _registry.SetActive(fresh.Id);

--- a/src/OpenClaw.Tray.WinUI/Services/ConnectionManagerWindowsNodeConnector.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ConnectionManagerWindowsNodeConnector.cs
@@ -49,34 +49,18 @@ public sealed class ConnectionManagerWindowsNodeConnector : IWindowsNodeConnecto
         var existing = _registry.FindByUrl(normalized);
         if (existing == null)
         {
-            // Defensive: the operator phase should always have created this record.
-            // If it didn't, create one now so the manager can resolve credentials.
-            // IsLocal is derived from the URL via LocalGatewayUrlClassifier so this
-            // doesn't silently misclassify a remote gateway if the connector is
-            // ever reused outside the local-loopback easy-button flow.
-            var fresh = new GatewayRecord
-            {
-                Id = Guid.NewGuid().ToString(),
-                Url = normalized,
-                SharedGatewayToken = !string.IsNullOrWhiteSpace(token) ? token : null,
-                BootstrapToken = !string.IsNullOrWhiteSpace(bootstrapToken) ? bootstrapToken : null,
-                IsLocal = LocalGatewayUrlClassifier.IsLocalGatewayUrl(normalized),
-            };
-            _registry.AddOrUpdate(fresh);
-            _registry.SetActive(fresh.Id);
-            _registry.Save();
+            throw new InvalidOperationException(
+                "Operator pairing did not create a gateway record for the setup gateway.");
         }
-        else
+
+        // Patch in any newly-supplied tokens — never overwrite a stored value with empty.
+        var updated = existing with
         {
-            // Patch in any newly-supplied tokens — never overwrite a stored value with empty.
-            var updated = existing with
-            {
-                SharedGatewayToken = !string.IsNullOrWhiteSpace(token) ? token : existing.SharedGatewayToken,
-                BootstrapToken = !string.IsNullOrWhiteSpace(bootstrapToken) ? bootstrapToken : existing.BootstrapToken,
-            };
-            _registry.AddOrUpdate(updated);
-            _registry.Save();
-        }
+            SharedGatewayToken = !string.IsNullOrWhiteSpace(token) ? token : existing.SharedGatewayToken,
+            BootstrapToken = !string.IsNullOrWhiteSpace(bootstrapToken) ? bootstrapToken : existing.BootstrapToken,
+        };
+        _registry.AddOrUpdate(updated);
+        _registry.Save();
 
         _logger.Info(
             $"[SetupNodeConnector] Driving node connection via manager to {GatewayUrlHelper.SanitizeForDisplay(normalized)}");

--- a/src/OpenClaw.Tray.WinUI/Services/ConnectionManagerWindowsNodeConnector.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ConnectionManagerWindowsNodeConnector.cs
@@ -1,0 +1,87 @@
+using OpenClaw.Shared;
+using OpenClaw.Connection;
+using OpenClawTray.Services.LocalGatewaySetup;
+
+namespace OpenClawTray.Services;
+
+/// <summary>
+/// Implements <see cref="IWindowsNodeConnector"/> by delegating to the
+/// app's <see cref="GatewayConnectionManager"/>. All node handshake/pairing
+/// events flow through the manager's diagnostics pipeline, giving full
+/// visibility in the Connection Status window during the WSL local-setup flow,
+/// and the manager's per-gateway identity store + credential resolver are used
+/// uniformly with the normal (post-setup) connection lifecycle.
+/// </summary>
+/// <remarks>
+/// Sibling to <see cref="ConnectionManagerOperatorConnector"/> — both are
+/// thin facades over <see cref="GatewayConnectionManager"/> for the easy-button
+/// setup engine.
+/// </remarks>
+public sealed class ConnectionManagerWindowsNodeConnector : IWindowsNodeConnector
+{
+    private readonly GatewayConnectionManager _manager;
+    private readonly GatewayRegistry _registry;
+    private readonly IOpenClawLogger _logger;
+
+    public ConnectionManagerWindowsNodeConnector(
+        GatewayConnectionManager manager,
+        GatewayRegistry registry,
+        IOpenClawLogger logger)
+    {
+        _manager = manager ?? throw new ArgumentNullException(nameof(manager));
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task ConnectAsync(
+        string gatewayUrl,
+        string token,
+        string? bootstrapToken,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // The operator connector (ConnectionManagerOperatorConnector) created the
+        // registry record during PairOperator phase. Refresh it with any newly-minted
+        // bootstrap/shared token the engine may have provisioned in between phases —
+        // the credential resolver will then surface them through ResolveNode.
+        var normalized = GatewayUrlHelper.NormalizeForWebSocket(gatewayUrl);
+        var existing = _registry.FindByUrl(normalized);
+        if (existing == null)
+        {
+            // Defensive: the operator phase should always have created this record.
+            // If it didn't, create one now so the manager can resolve credentials.
+            var fresh = new GatewayRecord
+            {
+                Id = Guid.NewGuid().ToString(),
+                Url = normalized,
+                SharedGatewayToken = !string.IsNullOrWhiteSpace(token) ? token : null,
+                BootstrapToken = !string.IsNullOrWhiteSpace(bootstrapToken) ? bootstrapToken : null,
+                IsLocal = true,
+            };
+            _registry.AddOrUpdate(fresh);
+            _registry.SetActive(fresh.Id);
+            _registry.Save();
+        }
+        else
+        {
+            // Patch in any newly-supplied tokens — never overwrite a stored value with empty.
+            var updated = existing with
+            {
+                SharedGatewayToken = !string.IsNullOrWhiteSpace(token) ? token : existing.SharedGatewayToken,
+                BootstrapToken = !string.IsNullOrWhiteSpace(bootstrapToken) ? bootstrapToken : existing.BootstrapToken,
+            };
+            _registry.AddOrUpdate(updated);
+            _registry.Save();
+        }
+
+        _logger.Info(
+            $"[SetupNodeConnector] Driving node connection via manager to {GatewayUrlHelper.SanitizeForDisplay(normalized)}");
+
+        // Surface any manager exception with a message stable enough for the
+        // existing role-upgrade auto-approve catch in
+        // SettingsWindowsTrayNodeProvisioner.PairAsync (which catches generic Exception
+        // and runs the WSL CLI device approver before retrying once).
+        await _manager.EnsureNodeConnectedAsync(cancellationToken);
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
@@ -1682,37 +1682,10 @@ public interface IWindowsNodeConnector
     Task ConnectAsync(string gatewayUrl, string token, string? bootstrapToken, CancellationToken cancellationToken = default);
 }
 
-#if !OPENCLAW_TRAY_TESTS
-[Obsolete("Use ConnectionManagerWindowsNodeConnector instead — drives node connection through GatewayConnectionManager. Will be removed in phase 5.")]
-public sealed class NodeServiceWindowsNodeConnector : IWindowsNodeConnector
-{
-    private readonly NodeService _nodeService;
-
-    public NodeServiceWindowsNodeConnector(NodeService nodeService)
-    {
-        _nodeService = nodeService;
-    }
-
-    public async Task ConnectAsync(string gatewayUrl, string token, string? bootstrapToken, CancellationToken cancellationToken = default)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-#pragma warning disable CS0618 // legacy fallback path — phase 5 removes both this connector and NodeService.ConnectAsync
-        await _nodeService.ConnectAsync(gatewayUrl, token, bootstrapToken);
-#pragma warning restore CS0618
-        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(35);
-        while (DateTimeOffset.UtcNow < deadline)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (_nodeService.IsConnected && _nodeService.IsPaired)
-                return;
-
-            await Task.Delay(250, cancellationToken);
-        }
-
-        throw new TimeoutException("Timed out waiting for the Windows tray node to pair with the gateway.");
-    }
-}
-#endif
+// NodeServiceWindowsNodeConnector (direct NodeService.ConnectAsync delegate, no
+// diagnostics tee) has been removed — all node pairing now flows through
+// ConnectionManagerWindowsNodeConnector → GatewayConnectionManager.EnsureNodeConnectedAsync.
+// See docs/node-connection-architecture.md and easy-button-gateway-comms-audit.md.
 
 public static class WslDistroKeepAlive
 {
@@ -1803,72 +1776,10 @@ public interface IGatewayOperatorConnector
     Task<GatewayOperatorConnectionResult> ConnectWithStoredDeviceTokenAsync(string gatewayUrl, CancellationToken cancellationToken = default);
 }
 
-public sealed class OpenClawGatewayOperatorConnector : IGatewayOperatorConnector
-{
-    private readonly IOpenClawLogger _logger;
-    private readonly TimeSpan _timeout;
-
-    public OpenClawGatewayOperatorConnector(IOpenClawLogger? logger = null, TimeSpan? timeout = null)
-    {
-        _logger = logger ?? NullLogger.Instance;
-        _timeout = timeout ?? TimeSpan.FromSeconds(35);
-    }
-
-    public async Task<GatewayOperatorConnectionResult> ConnectAsync(string gatewayUrl, string token, bool tokenIsBootstrapToken = false, CancellationToken cancellationToken = default)
-    {
-        using var client = new OpenClawGatewayClient(gatewayUrl, token, _logger, tokenIsBootstrapToken, bootstrapPairAsNode: false);
-        var completion = new TaskCompletionSource<GatewayOperatorConnectionResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        client.StatusChanged += (_, status) =>
-        {
-            if (status == ConnectionStatus.Connected)
-                completion.TrySetResult(new GatewayOperatorConnectionResult(GatewayOperatorConnectionStatus.Connected));
-            else if (status == ConnectionStatus.Error)
-            {
-                if (client.IsPairingRequired)
-                    completion.TrySetResult(new GatewayOperatorConnectionResult(GatewayOperatorConnectionStatus.PairingRequired, "Gateway requires pairing approval.", client.PairingRequiredRequestId));
-                else if (client.IsAuthFailed)
-                    completion.TrySetResult(new GatewayOperatorConnectionResult(GatewayOperatorConnectionStatus.AuthFailed, "Gateway rejected operator authentication."));
-            }
-        };
-
-        try
-        {
-            await client.ConnectAsync();
-            var completed = await Task.WhenAny(completion.Task, Task.Delay(_timeout, cancellationToken));
-            return completed == completion.Task
-                ? await completion.Task
-                : new GatewayOperatorConnectionResult(GatewayOperatorConnectionStatus.Timeout, "Timed out waiting for operator handshake.");
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            return new GatewayOperatorConnectionResult(GatewayOperatorConnectionStatus.Failed, ex.Message);
-        }
-        finally
-        {
-            await client.DisconnectAsync();
-        }
-    }
-
-    public async Task<GatewayOperatorConnectionResult> ConnectWithStoredDeviceTokenAsync(string gatewayUrl, CancellationToken cancellationToken = default)
-    {
-        var dataPath = Path.Combine(
-            Environment.GetEnvironmentVariable("OPENCLAW_TRAY_APPDATA_DIR")
-                ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "OpenClawTray");
-        var identity = new DeviceIdentity(dataPath, _logger);
-        identity.Initialize();
-
-        if (string.IsNullOrWhiteSpace(identity.DeviceToken))
-            return new GatewayOperatorConnectionResult(GatewayOperatorConnectionStatus.AuthFailed, "Gateway did not return a stored device token after bootstrap pairing.");
-
-        return await ConnectAsync(gatewayUrl, identity.DeviceToken, tokenIsBootstrapToken: false, cancellationToken);
-    }
-}
+// OpenClawGatewayOperatorConnector (direct OpenClawGatewayClient instantiation, no
+// diagnostics tee) has been removed — all operator pairing now flows through
+// ConnectionManagerOperatorConnector → GatewayConnectionManager. See
+// docs/node-connection-architecture.md and easy-button-gateway-comms-audit.md.
 
 public sealed class WslGatewayCliSharedGatewayTokenProvider : ISharedGatewayTokenProvider
 {
@@ -3285,6 +3196,8 @@ public static class LocalGatewaySetupEngineFactory
 {
     public static LocalGatewaySetupEngine CreateLocalOnly(
         SettingsManager settings,
+        IGatewayOperatorConnector operatorConnector,
+        IWindowsNodeConnector windowsNodeConnector,
         IOpenClawLogger? logger = null,
 #if !OPENCLAW_TRAY_TESTS
         NodeService? nodeService = null,
@@ -3294,10 +3207,11 @@ public static class LocalGatewaySetupEngineFactory
         bool replaceExistingConfigurationConfirmed = false,
         string? identityDataPath = null,
         string? setupStatePath = null,
-        OpenClaw.Connection.GatewayRegistry? gatewayRegistry = null,
-        IGatewayOperatorConnector? operatorConnectorOverride = null,
-        IWindowsNodeConnector? windowsNodeConnectorOverride = null)
+        OpenClaw.Connection.GatewayRegistry? gatewayRegistry = null)
     {
+        ArgumentNullException.ThrowIfNull(operatorConnector);
+        ArgumentNullException.ThrowIfNull(windowsNodeConnector);
+
         // Defense-in-depth fail-closed: refuse to construct the engine if any of the
         // 6 sync existing-config predicates fire and the caller has not passed explicit
         // confirmation. Predicates checked: Token, BootstrapToken, GatewayUrl (non-default),
@@ -3352,24 +3266,10 @@ public static class LocalGatewaySetupEngineFactory
 
         var wsl = new WslExeCommandRunner(logger, TimeSpan.FromMinutes(30));
         var settingsAdapter = new SettingsManagerLocalGatewaySetupSettings(settings, gatewayRegistry);
-        var operatorConnector = operatorConnectorOverride ?? (IGatewayOperatorConnector)new OpenClawGatewayOperatorConnector(logger);
         var bootstrapTokenProvider = new WslGatewayCliBootstrapTokenProvider(wsl, options.OpenClawInstallPrefix + "/bin/openclaw");
         var sharedGatewayTokenProvider = new WslGatewayCliSharedGatewayTokenProvider(wsl);
         var gatewayConfigurationPreparer = new OpenClawCliGatewayConfigurationPreparer(wsl);
         var pendingDeviceApprover = new WslGatewayCliPendingDeviceApprover(wsl, options.OpenClawInstallPrefix + "/bin/openclaw");
-#if OPENCLAW_TRAY_TESTS
-        IWindowsNodeConnector? windowsNodeConnector = windowsNodeConnectorOverride;
-#else
-        // Prefer caller-supplied override (production: ConnectionManagerWindowsNodeConnector
-        // — drives node connection through GatewayConnectionManager so all node handshake
-        // events flow through the manager's diagnostics + per-gateway identity store).
-        // Fall back to the legacy NodeService-driven path only if neither is available
-        // (kept for any test or call site that hasn't been migrated yet).
-#pragma warning disable CS0618 // NodeServiceWindowsNodeConnector is the legacy path; phase 5 removes both
-        IWindowsNodeConnector? windowsNodeConnector = windowsNodeConnectorOverride
-            ?? (nodeService == null ? null : new NodeServiceWindowsNodeConnector(nodeService));
-#pragma warning restore CS0618
-#endif
 
         return new LocalGatewaySetupEngine(
             options,

--- a/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
@@ -2135,6 +2135,35 @@ public sealed class WslGatewayCliPendingDeviceApprover : IPendingDeviceApprover
     public const int MaxStdoutSurfaceLength = 1024;
     private static readonly TimeSpan DefaultStage1RetryDelay = TimeSpan.FromMilliseconds(750);
 
+    /// <summary>
+    /// When the gateway restarts mid-PairWindowsTrayNode (which can happen 10-15s after
+    /// operator pairing — gateway flushes config and restarts the service), the WSL CLI
+    /// briefly cannot reach the gateway and exits non-zero with stderr containing
+    /// "1006 abnormal closure" / "gateway closed" / "Gateway not yet ready". The original
+    /// 750ms single-retry isn't enough for the gateway to come back. When we detect this
+    /// pattern in both initial attempts, we keep retrying with exponential backoff up to
+    /// this cap so the WSL approve flow survives a transient gateway restart instead of
+    /// failing with the misleading operator_pending_approval_failed code.
+    /// </summary>
+    private static readonly TimeSpan[] GatewayDownRetryDelays =
+    [
+        TimeSpan.FromSeconds(2),
+        TimeSpan.FromSeconds(4),
+        TimeSpan.FromSeconds(8),
+    ];
+
+    /// <summary>
+    /// Patterns in CLI stderr that indicate the gateway is transiently down (typically
+    /// mid-restart) rather than a real pairing/auth failure.
+    /// </summary>
+    private static readonly string[] GatewayDownStderrPatterns =
+    [
+        "1006 abnormal closure",
+        "gateway closed",
+        "Gateway not yet ready",
+        "Could not start the CLI",
+    ];
+
     private readonly IWslCommandRunner _wsl;
     private readonly string _commandName;
     private readonly TimeSpan _stage1RetryDelay;
@@ -2300,7 +2329,70 @@ public sealed class WslGatewayCliPendingDeviceApprover : IPendingDeviceApprover
             ["bash", "-lc", BuildPreviewScript()],
             cancellationToken,
             tokenEnvironment);
+        if (second.Success || ParsePreviewJson(second.StandardOutput).Success)
+        {
+            return new Stage1Outcome(second, FirstResult: first);
+        }
+
+        // Bug: gateway-restart mid-PairWindowsTrayNode (manual test 2026-05-16) — when the
+        // gateway emits a 1012 service-restart shortly after operator pairing, both initial
+        // stage-1 attempts can hit a still-restarting gateway and fail with stderr like:
+        //   [openclaw] Reason: gateway closed (1006 abnormal closure (no close frame))
+        // The 750ms retry window isn't enough for the gateway to come back. If we recognize
+        // this pattern in both attempts, keep retrying with exponential backoff so the
+        // engine doesn't misreport this as operator_pending_approval_failed.
+        if (LooksLikeGatewayDown(first) && LooksLikeGatewayDown(second))
+        {
+            var last = second;
+            foreach (var delay in GatewayDownRetryDelays)
+            {
+                try
+                {
+                    await Task.Delay(delay, cancellationToken);
+                }
+                catch (TaskCanceledException)
+                {
+                    return new Stage1Outcome(last, FirstResult: first);
+                }
+
+                var attempt = await _wsl.RunInDistroAsync(
+                    state.DistroName,
+                    ["bash", "-lc", BuildPreviewScript()],
+                    cancellationToken,
+                    tokenEnvironment);
+                if (attempt.Success || ParsePreviewJson(attempt.StandardOutput).Success)
+                {
+                    return new Stage1Outcome(attempt, FirstResult: first);
+                }
+                last = attempt;
+                if (!LooksLikeGatewayDown(attempt))
+                {
+                    // Stopped looking like a transient gateway-down failure — bail and let
+                    // the caller surface this attempt's stderr verbatim.
+                    return new Stage1Outcome(last, FirstResult: first);
+                }
+            }
+            return new Stage1Outcome(last, FirstResult: first);
+        }
+
         return new Stage1Outcome(second, FirstResult: first);
+    }
+
+    /// <summary>
+    /// Heuristic match for "the gateway is down right now, retry will probably succeed"
+    /// — see <see cref="GatewayDownStderrPatterns"/>.
+    /// </summary>
+    internal static bool LooksLikeGatewayDown(WslCommandResult result)
+    {
+        if (result.Success) return false;
+        var stderr = result.StandardError ?? string.Empty;
+        if (stderr.Length == 0) return false;
+        foreach (var pattern in GatewayDownStderrPatterns)
+        {
+            if (stderr.Contains(pattern, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
     }
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
@@ -1683,6 +1683,7 @@ public interface IWindowsNodeConnector
 }
 
 #if !OPENCLAW_TRAY_TESTS
+[Obsolete("Use ConnectionManagerWindowsNodeConnector instead — drives node connection through GatewayConnectionManager. Will be removed in phase 5.")]
 public sealed class NodeServiceWindowsNodeConnector : IWindowsNodeConnector
 {
     private readonly NodeService _nodeService;
@@ -1695,7 +1696,9 @@ public sealed class NodeServiceWindowsNodeConnector : IWindowsNodeConnector
     public async Task ConnectAsync(string gatewayUrl, string token, string? bootstrapToken, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+#pragma warning disable CS0618 // legacy fallback path — phase 5 removes both this connector and NodeService.ConnectAsync
         await _nodeService.ConnectAsync(gatewayUrl, token, bootstrapToken);
+#pragma warning restore CS0618
         var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(35);
         while (DateTimeOffset.UtcNow < deadline)
         {
@@ -3292,7 +3295,8 @@ public static class LocalGatewaySetupEngineFactory
         string? identityDataPath = null,
         string? setupStatePath = null,
         OpenClaw.Connection.GatewayRegistry? gatewayRegistry = null,
-        IGatewayOperatorConnector? operatorConnectorOverride = null)
+        IGatewayOperatorConnector? operatorConnectorOverride = null,
+        IWindowsNodeConnector? windowsNodeConnectorOverride = null)
     {
         // Defense-in-depth fail-closed: refuse to construct the engine if any of the
         // 6 sync existing-config predicates fire and the caller has not passed explicit
@@ -3354,9 +3358,17 @@ public static class LocalGatewaySetupEngineFactory
         var gatewayConfigurationPreparer = new OpenClawCliGatewayConfigurationPreparer(wsl);
         var pendingDeviceApprover = new WslGatewayCliPendingDeviceApprover(wsl, options.OpenClawInstallPrefix + "/bin/openclaw");
 #if OPENCLAW_TRAY_TESTS
-        IWindowsNodeConnector? windowsNodeConnector = null;
+        IWindowsNodeConnector? windowsNodeConnector = windowsNodeConnectorOverride;
 #else
-        IWindowsNodeConnector? windowsNodeConnector = nodeService == null ? null : new NodeServiceWindowsNodeConnector(nodeService);
+        // Prefer caller-supplied override (production: ConnectionManagerWindowsNodeConnector
+        // — drives node connection through GatewayConnectionManager so all node handshake
+        // events flow through the manager's diagnostics + per-gateway identity store).
+        // Fall back to the legacy NodeService-driven path only if neither is available
+        // (kept for any test or call site that hasn't been migrated yet).
+#pragma warning disable CS0618 // NodeServiceWindowsNodeConnector is the legacy path; phase 5 removes both
+        IWindowsNodeConnector? windowsNodeConnector = windowsNodeConnectorOverride
+            ?? (nodeService == null ? null : new NodeServiceWindowsNodeConnector(nodeService));
+#pragma warning restore CS0618
 #endif
 
         return new LocalGatewaySetupEngine(

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -241,11 +241,7 @@ public sealed class NodeService : IDisposable
         if (previous != null)
         {
             // Unsubscribe but don't dispose — the connector owns the client.
-            previous.StatusChanged -= OnNodeStatusChanged;
-            previous.PairingStatusChanged -= OnPairingStatusChanged;
-            previous.HealthReceived -= OnNodeHealthReceived;
-            previous.GatewaySelfUpdated -= OnGatewaySelfUpdated;
-            previous.InvokeCompleted -= OnNodeInvokeCompleted;
+            DetachClientHandlers(previous);
         }
 
         lock (_capabilitiesLock) { _capabilities.Clear(); }
@@ -428,11 +424,7 @@ public sealed class NodeService : IDisposable
             previous = _nodeClient;
             if (previous != null && !ReferenceEquals(previous, client))
             {
-                previous.StatusChanged -= OnNodeStatusChanged;
-                previous.PairingStatusChanged -= OnPairingStatusChanged;
-                previous.HealthReceived -= OnNodeHealthReceived;
-                previous.GatewaySelfUpdated -= OnGatewaySelfUpdated;
-                previous.InvokeCompleted -= OnNodeInvokeCompleted;
+                DetachClientHandlers(previous);
             }
 
             _nodeClient = client;
@@ -494,6 +486,15 @@ public sealed class NodeService : IDisposable
 
         // Log final registration state for diagnostics
         _logger.Info($"[NodeService] AttachClient DONE: client.Registration.Capabilities={client.RegisteredCapabilityCount}, client.Registration.Commands={client.RegisteredCommandCount}");
+    }
+
+    private void DetachClientHandlers(WindowsNodeClient client)
+    {
+        client.StatusChanged -= OnNodeStatusChanged;
+        client.PairingStatusChanged -= OnPairingStatusChanged;
+        client.HealthReceived -= OnNodeHealthReceived;
+        client.GatewaySelfUpdated -= OnGatewaySelfUpdated;
+        client.InvokeCompleted -= OnNodeInvokeCompleted;
     }
 
     /// <summary>
@@ -1837,9 +1838,16 @@ public sealed class NodeService : IDisposable
     {
         StopMcpServer();
 
-        var client = _nodeClient;
-        _nodeClient = null;
-        try { client?.Dispose(); } catch { /* ignore */ }
+        WindowsNodeClient? client;
+        lock (_clientLock)
+        {
+            client = _nodeClient;
+            _nodeClient = null;
+        }
+        if (client != null)
+        {
+            DetachClientHandlers(client);
+        }
 
         try { _cameraCaptureService?.Dispose(); } catch { /* ignore */ }
         try { _screenRecordingService?.Dispose(); } catch { /* ignore */ }

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -191,29 +191,17 @@ public sealed class NodeService : IDisposable
     }
     
     /// <summary>
-    /// Initialize and connect the node
+    /// Obsolete — node lifecycle is owned by <see cref="OpenClawTray.Services.Connection.GatewayConnectionManager"/>.
+    /// Call <see cref="OpenClawTray.Services.Connection.GatewayConnectionManager.EnsureNodeConnectedAsync(System.Threading.CancellationToken)"/>
+    /// (or <see cref="ConnectionManagerWindowsNodeConnector"/> from the easy-button setup engine).
+    /// Will be removed in phase 5 of the connection-unification rollout.
     /// </summary>
-    public async Task ConnectAsync(string gatewayUrl, string token, string? bootstrapToken = null)
+    [Obsolete("Node lifecycle is owned by GatewayConnectionManager. Use EnsureNodeConnectedAsync or ConnectionManagerWindowsNodeConnector. Will be removed in phase 5.")]
+    public Task ConnectAsync(string gatewayUrl, string token, string? bootstrapToken = null)
     {
-        if (_nodeClient != null)
-        {
-            await DisconnectAsync();
-        }
-
-        _logger.Info($"Starting Windows Node connection to {GatewayUrlHelper.SanitizeForDisplay(gatewayUrl)}");
-        _token = token;
-
-        _nodeClient = new WindowsNodeClient(gatewayUrl, token, _identityDataPath, _logger, bootstrapToken);
-        _nodeClient.StatusChanged += OnNodeStatusChanged;
-        _nodeClient.PairingStatusChanged += OnPairingStatusChanged;
-        _nodeClient.HealthReceived += OnNodeHealthReceived;
-        _nodeClient.GatewaySelfUpdated += OnGatewaySelfUpdated;
-        _nodeClient.InvokeCompleted += OnNodeInvokeCompleted;
-
-        // Register capabilities (also pushes them to _nodeClient and sets permissions)
-        RegisterCapabilities();
-
-        await _nodeClient.ConnectAsync();
+        throw new InvalidOperationException(
+            "NodeService.ConnectAsync is removed. Node lifecycle is now owned by GatewayConnectionManager — " +
+            "call manager.EnsureNodeConnectedAsync (or ConnectionManagerWindowsNodeConnector for the easy-button setup engine).");
     }
 
     /// <summary>
@@ -235,16 +223,24 @@ public sealed class NodeService : IDisposable
     }
     
     /// <summary>
-    /// Disconnect the node
+    /// Detach from the manager-owned node client and tear down capability state.
+    /// Does NOT dispose <c>_nodeClient</c> — the client lifecycle is owned by
+    /// <see cref="OpenClawTray.Services.Connection.GatewayConnectionManager"/> /
+    /// <see cref="OpenClawTray.Services.Connection.NodeConnector"/>; call
+    /// <c>GatewayConnectionManager.DisconnectAsync</c> to actually close the WebSocket.
     /// </summary>
-    public async Task DisconnectAsync()
+    public Task DisconnectAsync()
     {
         StopMcpServer();
 
         if (_nodeClient != null)
         {
-            await _nodeClient.DisconnectAsync();
-            _nodeClient.Dispose();
+            // Unsubscribe but don't dispose — the connector owns the client.
+            _nodeClient.StatusChanged -= OnNodeStatusChanged;
+            _nodeClient.PairingStatusChanged -= OnPairingStatusChanged;
+            _nodeClient.HealthReceived -= OnNodeHealthReceived;
+            _nodeClient.GatewaySelfUpdated -= OnGatewaySelfUpdated;
+            _nodeClient.InvokeCompleted -= OnNodeInvokeCompleted;
             _nodeClient = null;
         }
 
@@ -262,6 +258,8 @@ public sealed class NodeService : IDisposable
             _dispatcherQueue.TryEnqueue(() => _a2uiCanvasWindow.Close());
             _a2uiCanvasWindow = null;
         }
+
+        return Task.CompletedTask;
     }
     
     private void RegisterCapabilities()
@@ -414,7 +412,36 @@ public sealed class NodeService : IDisposable
         if (client is null) return;
 
         _token = bearerToken;
+
+        // Detach event subscriptions from previous client (if any) so a reconnect's
+        // fresh client doesn't double-fire NodeService events through both clients.
+        var previous = _nodeClient;
+        if (previous != null && !ReferenceEquals(previous, client))
+        {
+            previous.StatusChanged -= OnNodeStatusChanged;
+            previous.PairingStatusChanged -= OnPairingStatusChanged;
+            previous.HealthReceived -= OnNodeHealthReceived;
+            previous.GatewaySelfUpdated -= OnGatewaySelfUpdated;
+            previous.InvokeCompleted -= OnNodeInvokeCompleted;
+        }
+
         _nodeClient = client;
+
+        // Wire NodeService event re-emitters to the manager-owned client.
+        // App.OnPairingStatusChanged + OnNodeStatusChanged subscribe to NodeService events;
+        // those subscriptions are stable across reconnects because the subscriptions are
+        // on NodeService, not on the underlying WindowsNodeClient. (Pre-unification this
+        // wiring lived in NodeService.ConnectAsync — moved here so the unified
+        // manager-owned lifecycle still drives NodeService's event surface.)
+        if (!ReferenceEquals(previous, client))
+        {
+            client.StatusChanged += OnNodeStatusChanged;
+            client.PairingStatusChanged += OnPairingStatusChanged;
+            client.HealthReceived += OnNodeHealthReceived;
+            client.GatewaySelfUpdated += OnGatewaySelfUpdated;
+            client.InvokeCompleted += OnNodeInvokeCompleted;
+        }
+
         bool capabilitiesBuilt;
         lock (_capabilitiesLock)
         {

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -105,6 +105,13 @@ public sealed class NodeService : IDisposable
     private readonly List<INodeCapability> _capabilities = new();
     private readonly object _capabilitiesLock = new();
 
+    // Serializes AttachClient ↔ DisconnectAsync so a reconnect that overlaps a
+    // disconnect can't leave stale subscriptions on an old client or double-
+    // subscribe a re-attached client (Hanselman review #1). Held only for
+    // the synchronous subscription bookkeeping; capability registration uses
+    // its own lock above.
+    private readonly object _clientLock = new();
+
     // Local MCP server — exposes the same capabilities to local MCP clients.
     // TODO: when the port becomes user-configurable (see docs/MCP_MODE.md
     // "Deferred"), McpServerUrl needs to read the live port off the running
@@ -225,15 +232,20 @@ public sealed class NodeService : IDisposable
     {
         StopMcpServer();
 
-        if (_nodeClient != null)
+        WindowsNodeClient? previous;
+        lock (_clientLock)
+        {
+            previous = _nodeClient;
+            _nodeClient = null;
+        }
+        if (previous != null)
         {
             // Unsubscribe but don't dispose — the connector owns the client.
-            _nodeClient.StatusChanged -= OnNodeStatusChanged;
-            _nodeClient.PairingStatusChanged -= OnPairingStatusChanged;
-            _nodeClient.HealthReceived -= OnNodeHealthReceived;
-            _nodeClient.GatewaySelfUpdated -= OnGatewaySelfUpdated;
-            _nodeClient.InvokeCompleted -= OnNodeInvokeCompleted;
-            _nodeClient = null;
+            previous.StatusChanged -= OnNodeStatusChanged;
+            previous.PairingStatusChanged -= OnPairingStatusChanged;
+            previous.HealthReceived -= OnNodeHealthReceived;
+            previous.GatewaySelfUpdated -= OnGatewaySelfUpdated;
+            previous.InvokeCompleted -= OnNodeInvokeCompleted;
         }
 
         lock (_capabilitiesLock) { _capabilities.Clear(); }
@@ -405,28 +417,39 @@ public sealed class NodeService : IDisposable
 
         _token = bearerToken;
 
-        // Detach event subscriptions from previous client (if any) so a reconnect's
-        // fresh client doesn't double-fire NodeService events through both clients.
-        var previous = _nodeClient;
-        if (previous != null && !ReferenceEquals(previous, client))
+        // Hanselman review #1: serialize subscription bookkeeping so AttachClient ↔
+        // DisconnectAsync ↔ a follow-up AttachClient can't leave stale handlers on
+        // an old client or double-subscribe the same client. Unconditional
+        // unsubscribe-then-subscribe makes the wiring idempotent regardless of
+        // whether the previous client is the same instance or null.
+        WindowsNodeClient? previous;
+        lock (_clientLock)
         {
-            previous.StatusChanged -= OnNodeStatusChanged;
-            previous.PairingStatusChanged -= OnPairingStatusChanged;
-            previous.HealthReceived -= OnNodeHealthReceived;
-            previous.GatewaySelfUpdated -= OnGatewaySelfUpdated;
-            previous.InvokeCompleted -= OnNodeInvokeCompleted;
-        }
+            previous = _nodeClient;
+            if (previous != null && !ReferenceEquals(previous, client))
+            {
+                previous.StatusChanged -= OnNodeStatusChanged;
+                previous.PairingStatusChanged -= OnPairingStatusChanged;
+                previous.HealthReceived -= OnNodeHealthReceived;
+                previous.GatewaySelfUpdated -= OnGatewaySelfUpdated;
+                previous.InvokeCompleted -= OnNodeInvokeCompleted;
+            }
 
-        _nodeClient = client;
+            _nodeClient = client;
 
-        // Wire NodeService event re-emitters to the manager-owned client.
-        // App.OnPairingStatusChanged + OnNodeStatusChanged subscribe to NodeService events;
-        // those subscriptions are stable across reconnects because the subscriptions are
-        // on NodeService, not on the underlying WindowsNodeClient. (Pre-unification this
-        // wiring lived in NodeService.ConnectAsync — moved here so the unified
-        // manager-owned lifecycle still drives NodeService's event surface.)
-        if (!ReferenceEquals(previous, client))
-        {
+            // Wire NodeService event re-emitters to the manager-owned client.
+            // App.OnPairingStatusChanged + OnNodeStatusChanged subscribe to NodeService events;
+            // those subscriptions are stable across reconnects because the subscriptions are
+            // on NodeService, not on the underlying WindowsNodeClient. (Pre-unification this
+            // wiring lived in NodeService.ConnectAsync — moved here so the unified
+            // manager-owned lifecycle still drives NodeService's event surface.)
+            // -= before += so a re-attach of the same client (e.g. AttachClient called
+            // again after a DisconnectAsync that nulled _nodeClient) doesn't double-subscribe.
+            client.StatusChanged -= OnNodeStatusChanged;
+            client.PairingStatusChanged -= OnPairingStatusChanged;
+            client.HealthReceived -= OnNodeHealthReceived;
+            client.GatewaySelfUpdated -= OnGatewaySelfUpdated;
+            client.InvokeCompleted -= OnNodeInvokeCompleted;
             client.StatusChanged += OnNodeStatusChanged;
             client.PairingStatusChanged += OnPairingStatusChanged;
             client.HealthReceived += OnNodeHealthReceived;

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -190,19 +190,11 @@ public sealed class NodeService : IDisposable
         _cameraCaptureService = new CameraCaptureService(logger);
     }
     
-    /// <summary>
-    /// Obsolete — node lifecycle is owned by <see cref="OpenClawTray.Services.Connection.GatewayConnectionManager"/>.
-    /// Call <see cref="OpenClawTray.Services.Connection.GatewayConnectionManager.EnsureNodeConnectedAsync(System.Threading.CancellationToken)"/>
-    /// (or <see cref="ConnectionManagerWindowsNodeConnector"/> from the easy-button setup engine).
-    /// Will be removed in phase 5 of the connection-unification rollout.
-    /// </summary>
-    [Obsolete("Node lifecycle is owned by GatewayConnectionManager. Use EnsureNodeConnectedAsync or ConnectionManagerWindowsNodeConnector. Will be removed in phase 5.")]
-    public Task ConnectAsync(string gatewayUrl, string token, string? bootstrapToken = null)
-    {
-        throw new InvalidOperationException(
-            "NodeService.ConnectAsync is removed. Node lifecycle is now owned by GatewayConnectionManager — " +
-            "call manager.EnsureNodeConnectedAsync (or ConnectionManagerWindowsNodeConnector for the easy-button setup engine).");
-    }
+    // NodeService.ConnectAsync (gateway-connecting variant) was removed in
+    // phase 5 of the connection-unification rollout. Node lifecycle is owned by
+    // GatewayConnectionManager — call manager.EnsureNodeConnectedAsync (or
+    // ConnectionManagerWindowsNodeConnector for the easy-button setup engine).
+    // StartLocalOnlyAsync (MCP-only mode, no gateway) is unchanged.
 
     /// <summary>
     /// Bring up node capabilities and the local MCP server without opening a

--- a/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
+++ b/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
@@ -159,8 +159,12 @@ public class GatewayConnectionManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task HandshakeSucceeded_SuppressesManagerNodeConnector_WhenLocalNodeServiceOwnsIdentity()
+    public async Task HandshakeSucceeded_RespectsShouldStartNodeConnectionGate_WhenFalse()
     {
+        // The shouldStartNodeConnection delegate (on the manager constructor) is a
+        // generic per-gateway gate. Pre-unification the App used it to defer to a
+        // legacy NodeService for local gateways; post-unification the App no longer
+        // wires this predicate, but the gate itself remains a useful seam for callers.
         SetupGateway("gw-local", "ws://localhost:18789", isLocal: true);
         _resolver.OperatorCredential = new GatewayCredential("op-tok", false, "test");
         _resolver.NodeCredential = new GatewayCredential("node-tok", false, "test");
@@ -177,7 +181,7 @@ public class GatewayConnectionManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task HandshakeSucceeded_StartsManagerNodeConnector_WhenNoLocalNodeServiceOwnsIdentity()
+    public async Task HandshakeSucceeded_StartsManagerNodeConnector_WhenGateAllows()
     {
         SetupGateway("gw-remote", "wss://remote.example", isLocal: false);
         _resolver.OperatorCredential = new GatewayCredential("op-tok", false, "test");

--- a/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
+++ b/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
@@ -71,6 +71,29 @@ public class GatewayConnectionManagerTests : IDisposable
         Assert.Equal("gw-1", _manager.CurrentSnapshot.GatewayId);
     }
 
+    /// <summary>
+    /// Regression guard for the post-onboarding "don't cancel an in-flight reconnect"
+    /// path in App.OnboardingCompleted. When the V2 GatewayWelcome wizard saves a new
+    /// provider/model config the gateway emits a 1012 shutdown and clients enter the
+    /// Connecting state via the auto-reconnect timer. The App handler must see
+    /// OperatorState == Connecting from CurrentSnapshot (without poking OperatorClient
+    /// internals) so it can skip the redundant reconnect call.
+    /// </summary>
+    [Fact]
+    public async Task CurrentSnapshot_OperatorState_IsConnecting_WhileConnectInFlight()
+    {
+        SetupGateway("gw-1", "wss://test");
+        _resolver.OperatorCredential = new GatewayCredential("tok", false, "test");
+
+        await _manager.ConnectAsync("gw-1");
+
+        // Mid-connect (handshake not yet succeeded): operator role-state should be Connecting,
+        // and the overall snapshot mirrors it. This is the signal App.OnboardingCompleted
+        // uses to avoid canceling an in-flight reconnect from a gateway-restart event.
+        Assert.Equal(RoleConnectionState.Connecting, _manager.CurrentSnapshot.OperatorState);
+        Assert.Equal(OverallConnectionState.Connecting, _manager.CurrentSnapshot.OverallState);
+    }
+
     [Fact]
     public async Task ConnectAsync_CreatesClient()
     {

--- a/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
+++ b/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
@@ -232,6 +232,177 @@ public class GatewayConnectionManagerTests : IDisposable
         await task;
     }
 
+    // ─── EnsureNodeConnectedAsync tests ───
+
+    [Fact]
+    public async Task EnsureNodeConnectedAsync_OperatorNotConnected_Throws()
+    {
+        SetupGateway("gw-1", "wss://test");
+        _resolver.OperatorCredential = new GatewayCredential("tok", false, "test");
+        var node = new ScriptedNodeConnector();
+        using var manager = new GatewayConnectionManager(
+            _resolver, _factory, _registry, NullLogger.Instance,
+            nodeConnector: node);
+
+        // ConnectAsync only transitions to Connecting; HandshakeSucceeded would be needed to reach Connected.
+        await manager.ConnectAsync("gw-1");
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => manager.EnsureNodeConnectedAsync());
+        Assert.Contains("Operator must be Connected", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, node.ConnectCount);
+    }
+
+    [Fact]
+    public async Task EnsureNodeConnectedAsync_NoConnector_Throws()
+    {
+        SetupGateway("gw-1", "wss://test");
+        _resolver.OperatorCredential = new GatewayCredential("tok", false, "test");
+
+        // _manager has no node connector wired
+        await _manager.ConnectAsync("gw-1");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _manager.EnsureNodeConnectedAsync());
+    }
+
+    [Fact]
+    public async Task EnsureNodeConnectedAsync_AlreadyPaired_NoOp()
+    {
+        SetupGateway("gw-1", "wss://test");
+        _resolver.OperatorCredential = new GatewayCredential("op", false, "test");
+        _resolver.NodeCredential = new GatewayCredential("nd", false, "test");
+        var node = new ScriptedNodeConnector
+        {
+            ConnectAction = (s, _) =>
+            {
+                s.SimulateStatus(ConnectionStatus.Connected);
+                s.SimulatePairing(PairingStatus.Paired);
+            }
+        };
+        using var manager = new GatewayConnectionManager(
+            _resolver, _factory, _registry, NullLogger.Instance,
+            nodeConnector: node);
+
+        await manager.ConnectAsync("gw-1");
+        await InvokeHandshakeSucceededAsync(manager);
+
+        await manager.EnsureNodeConnectedAsync();
+        var firstCount = node.ConnectCount;
+        await manager.EnsureNodeConnectedAsync();
+
+        // Second call must short-circuit (no new connect)
+        Assert.Equal(firstCount, node.ConnectCount);
+    }
+
+    [Fact]
+    public async Task EnsureNodeConnectedAsync_HappyPath_ReturnsWhenPaired()
+    {
+        SetupGateway("gw-1", "wss://test");
+        _resolver.OperatorCredential = new GatewayCredential("op", false, "test");
+        _resolver.NodeCredential = new GatewayCredential("nd", false, "test");
+        var node = new ScriptedNodeConnector
+        {
+            ConnectAction = (s, _) =>
+            {
+                s.SimulateStatus(ConnectionStatus.Connected);
+                s.SimulatePairing(PairingStatus.Paired);
+            }
+        };
+        using var manager = new GatewayConnectionManager(
+            _resolver, _factory, _registry, NullLogger.Instance,
+            nodeConnector: node,
+            // Suppress auto-start to mimic the easy-button path: setup engine drives it.
+            shouldStartNodeConnection: (_, _) => false);
+
+        await manager.ConnectAsync("gw-1");
+        await InvokeHandshakeSucceededAsync(manager);
+
+        Assert.Equal(0, node.ConnectCount); // suppressed auto-start
+
+        await manager.EnsureNodeConnectedAsync();
+
+        Assert.Equal(1, node.ConnectCount);
+        Assert.Equal(RoleConnectionState.Connected, manager.CurrentSnapshot.NodeState);
+        Assert.Equal(PairingStatus.Paired, manager.CurrentSnapshot.NodePairingStatus);
+    }
+
+    [Fact]
+    public async Task EnsureNodeConnectedAsync_PairingRejected_Throws()
+    {
+        SetupGateway("gw-1", "wss://test");
+        _resolver.OperatorCredential = new GatewayCredential("op", false, "test");
+        _resolver.NodeCredential = new GatewayCredential("nd", false, "test");
+        var node = new ScriptedNodeConnector
+        {
+            ConnectAction = (s, _) =>
+            {
+                s.SimulateStatus(ConnectionStatus.Connecting);
+                s.SimulatePairing(PairingStatus.Rejected);
+            }
+        };
+        using var manager = new GatewayConnectionManager(
+            _resolver, _factory, _registry, NullLogger.Instance,
+            nodeConnector: node);
+
+        await manager.ConnectAsync("gw-1");
+        await InvokeHandshakeSucceededAsync(manager);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => manager.EnsureNodeConnectedAsync());
+    }
+
+    [Fact]
+    public async Task EnsureNodeConnectedAsync_NodeError_Throws()
+    {
+        SetupGateway("gw-1", "wss://test");
+        _resolver.OperatorCredential = new GatewayCredential("op", false, "test");
+        _resolver.NodeCredential = new GatewayCredential("nd", false, "test");
+        var node = new ScriptedNodeConnector
+        {
+            // NodeError trigger requires NodeState != Idle, so transition through Connecting first.
+            ConnectAction = (s, _) =>
+            {
+                s.SimulateStatus(ConnectionStatus.Connecting);
+                s.SimulateStatus(ConnectionStatus.Error);
+            }
+        };
+        using var manager = new GatewayConnectionManager(
+            _resolver, _factory, _registry, NullLogger.Instance,
+            nodeConnector: node);
+
+        await manager.ConnectAsync("gw-1");
+        await InvokeHandshakeSucceededAsync(manager);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => manager.EnsureNodeConnectedAsync());
+    }
+
+    [Fact]
+    public async Task EnsureNodeConnectedAsync_CallerCancellation_PropagatesOperationCanceled()
+    {
+        SetupGateway("gw-1", "wss://test");
+        _resolver.OperatorCredential = new GatewayCredential("op", false, "test");
+        _resolver.NodeCredential = new GatewayCredential("nd", false, "test");
+        var node = new ScriptedNodeConnector
+        {
+            // Connect but never reach Paired — caller will cancel
+            ConnectAction = (s, _) => s.SimulateStatus(ConnectionStatus.Connecting)
+        };
+        using var manager = new GatewayConnectionManager(
+            _resolver, _factory, _registry, NullLogger.Instance,
+            nodeConnector: node);
+
+        await manager.ConnectAsync("gw-1");
+        await InvokeHandshakeSucceededAsync(manager);
+
+        using var cts = new CancellationTokenSource();
+        var task = manager.EnsureNodeConnectedAsync(cts.Token);
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+    }
+
     // ─── Mocks ───
 
     private sealed class MockCredentialResolver : ICredentialResolver
@@ -379,6 +550,61 @@ public class GatewayConnectionManagerTests : IDisposable
         }
 
         public Task DisconnectAsync() => Task.CompletedTask;
+
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// Test connector that fires StatusChanged / PairingStatusChanged events synchronously
+    /// so tests can drive the manager's state machine through realistic transitions.
+    /// </summary>
+    private sealed class ScriptedNodeConnector : INodeConnector
+    {
+        public int ConnectCount { get; private set; }
+        public string? LastGatewayUrl { get; private set; }
+        public bool IsConnected { get; private set; }
+        public PairingStatus PairingStatus { get; private set; } = PairingStatus.Unknown;
+        public string? NodeDeviceId => "scripted-node";
+        public NodeConnectionMode Mode => IsConnected ? NodeConnectionMode.Gateway : NodeConnectionMode.Disabled;
+
+        /// <summary>
+        /// Optional callback fired during ConnectAsync. Receives this connector and the
+        /// gateway URL — use SimulateStatus / SimulatePairing to walk the state machine.
+        /// </summary>
+        public Action<ScriptedNodeConnector, string>? ConnectAction { get; set; }
+
+        public event EventHandler<ConnectionStatus>? StatusChanged;
+        public event EventHandler<PairingStatusEventArgs>? PairingStatusChanged;
+#pragma warning disable CS0067 // ClientCreated unused in current tests
+        public event EventHandler<NodeClientCreatedEventArgs>? ClientCreated;
+#pragma warning restore CS0067
+
+        public Task ConnectAsync(string gatewayUrl, GatewayCredential credential, string identityPath, bool useV2Signature = false)
+        {
+            ConnectCount++;
+            LastGatewayUrl = gatewayUrl;
+            ConnectAction?.Invoke(this, gatewayUrl);
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            IsConnected = false;
+            PairingStatus = PairingStatus.Unknown;
+            return Task.CompletedTask;
+        }
+
+        public void SimulateStatus(ConnectionStatus status)
+        {
+            IsConnected = status == ConnectionStatus.Connected;
+            StatusChanged?.Invoke(this, status);
+        }
+
+        public void SimulatePairing(PairingStatus status, string? requestId = null)
+        {
+            PairingStatus = status;
+            PairingStatusChanged?.Invoke(this, new PairingStatusEventArgs(status, deviceId: "scripted-node", requestId: requestId));
+        }
 
         public void Dispose() { }
     }

--- a/tests/OpenClaw.Shared.Tests/IdentityFileMigrationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/IdentityFileMigrationTests.cs
@@ -1,0 +1,102 @@
+using OpenClaw.Shared;
+
+namespace OpenClaw.Shared.Tests;
+
+/// <summary>
+/// Regression tests for the legacy device-key-ed25519.json migration performed
+/// by App.InitializeGatewayClient when bridging settings → GatewayRegistry on
+/// startup.
+/// <para>
+/// Invariant under test: a single file copy of <c>device-key-ed25519.json</c>
+/// from the legacy settings directory to a per-gateway identity directory must
+/// migrate BOTH operator (<c>DeviceToken</c>) and node (<c>NodeDeviceToken</c>)
+/// roles. The Connection Phase 4 unification (manager-owned NodeConnector)
+/// relies on this — without it, paired-pre-unification installs would lose
+/// their node identity on first launch after the unification ships.
+/// </para>
+/// </summary>
+public class IdentityFileMigrationTests
+{
+    [Fact]
+    public void FileCopy_MigratesBothOperatorAndNodeTokens()
+    {
+        var legacyDir = CreateTempDir();
+        var perGatewayDir = CreateTempDir();
+        try
+        {
+            var legacyKeyPath = Path.Combine(legacyDir, "device-key-ed25519.json");
+            // Construct the minimal JSON shape DeviceIdentity expects. We only need the
+            // token fields to assert the migration invariant; the keypair is irrelevant
+            // to the read paths the credential resolver uses.
+            File.WriteAllText(legacyKeyPath, """
+                {
+                    "Algorithm": "ed25519",
+                    "PrivateKeyBase64": "AAAA",
+                    "PublicKeyBase64": "AAAA",
+                    "DeviceToken": "operator-tok",
+                    "DeviceTokenScopes": ["operator.read","operator.write"],
+                    "NodeDeviceToken": "node-tok",
+                    "NodeDeviceTokenScopes": ["node.connect","node.reconnect"]
+                }
+                """);
+
+            // Mirror the production migration step (App.xaml.cs:2746-2753).
+            var newKeyPath = Path.Combine(perGatewayDir, "device-key-ed25519.json");
+            File.Copy(legacyKeyPath, newKeyPath, overwrite: false);
+
+            // Both roles must be readable from the per-gateway directory.
+            var operatorToken = DeviceIdentity.TryReadStoredDeviceToken(perGatewayDir);
+            var nodeToken = DeviceIdentity.TryReadStoredDeviceTokenForRole(perGatewayDir, "node");
+
+            Assert.Equal("operator-tok", operatorToken);
+            Assert.Equal("node-tok", nodeToken);
+
+            // Legacy file must remain in place (copy, not move) for safe rollback.
+            Assert.True(File.Exists(legacyKeyPath));
+        }
+        finally
+        {
+            try { Directory.Delete(legacyDir, recursive: true); } catch { }
+            try { Directory.Delete(perGatewayDir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void FileCopy_NodeTokenOnly_StillMigrates()
+    {
+        // Pre-unification easy-button installs that completed setup but had operator
+        // tokens cleared (e.g., after a token rotation) should still migrate node identity.
+        var legacyDir = CreateTempDir();
+        var perGatewayDir = CreateTempDir();
+        try
+        {
+            var legacyKeyPath = Path.Combine(legacyDir, "device-key-ed25519.json");
+            File.WriteAllText(legacyKeyPath, """
+                {
+                    "Algorithm": "ed25519",
+                    "PrivateKeyBase64": "AAAA",
+                    "PublicKeyBase64": "AAAA",
+                    "NodeDeviceToken": "node-only-tok",
+                    "NodeDeviceTokenScopes": ["node.connect"]
+                }
+                """);
+
+            File.Copy(legacyKeyPath, Path.Combine(perGatewayDir, "device-key-ed25519.json"), overwrite: false);
+
+            Assert.Null(DeviceIdentity.TryReadStoredDeviceToken(perGatewayDir));
+            Assert.Equal("node-only-tok", DeviceIdentity.TryReadStoredDeviceTokenForRole(perGatewayDir, "node"));
+        }
+        finally
+        {
+            try { Directory.Delete(legacyDir, recursive: true); } catch { }
+            try { Directory.Delete(perGatewayDir, recursive: true); } catch { }
+        }
+    }
+
+    private static string CreateTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "openclaw-idmig-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/Connection/ConnectionManagerWindowsNodeConnectorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Connection/ConnectionManagerWindowsNodeConnectorTests.cs
@@ -1,0 +1,239 @@
+using OpenClaw.Shared;
+using OpenClaw.Connection;
+using OpenClawTray.Services.LocalGatewaySetup;
+using ConnectionManagerWindowsNodeConnector = OpenClawTray.Services.ConnectionManagerWindowsNodeConnector;
+
+namespace OpenClaw.Tray.Tests;
+
+/// <summary>
+/// Tests for ConnectionManagerWindowsNodeConnector — the IWindowsNodeConnector
+/// implementation used by the easy-button setup engine to drive node pairing
+/// via the manager (instead of the legacy NodeServiceWindowsNodeConnector path).
+/// </summary>
+public sealed class ConnectionManagerWindowsNodeConnectorTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly GatewayRegistry _registry;
+    private readonly StubCredentialResolver _resolver = new();
+    private readonly StubClientFactory _factory = new();
+    private readonly StubNodeConnector _node = new();
+    private readonly GatewayConnectionManager _manager;
+
+    public ConnectionManagerWindowsNodeConnectorTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "openclaw-cmwnc-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        _registry = new GatewayRegistry(_tempDir);
+        _manager = new GatewayConnectionManager(
+            _resolver, _factory, _registry, NullLogger.Instance,
+            nodeConnector: _node);
+    }
+
+    public void Dispose()
+    {
+        _manager.Dispose();
+        try { Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    [Fact]
+    public async Task ConnectAsync_RecordExists_PatchesTokensAndDrivesNodeConnect()
+    {
+        const string url = "ws://localhost:18789";
+        var record = new GatewayRecord { Id = "gw-local", Url = url, IsLocal = true };
+        _registry.AddOrUpdate(record);
+        _registry.SetActive("gw-local");
+        _resolver.OperatorCredential = new GatewayCredential("op", false, "test");
+        _resolver.NodeCredential = new GatewayCredential("nd", false, "test");
+        // Drive operator to Connected
+        await _manager.ConnectAsync("gw-local");
+        await InvokeHandshakeSucceededAsync(_manager);
+
+        var connector = new ConnectionManagerWindowsNodeConnector(
+            _manager, _registry, NullLogger.Instance);
+
+        await connector.ConnectAsync(url, "shared-token", "boot-token");
+
+        var updated = _registry.FindByUrl(url);
+        Assert.NotNull(updated);
+        Assert.Equal("shared-token", updated!.SharedGatewayToken);
+        Assert.Equal("boot-token", updated.BootstrapToken);
+        Assert.Equal(1, _node.ConnectCount);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_NoExistingRecord_CreatesOne()
+    {
+        const string url = "ws://localhost:18789";
+        _resolver.OperatorCredential = new GatewayCredential("op", false, "test");
+        _resolver.NodeCredential = new GatewayCredential("nd", false, "test");
+
+        // Pre-create gateway record so the manager can connect; the connector's job
+        // here is to ensure that even WITHOUT a record matching the URL, it creates one.
+        // To exercise that branch we point the manager at a different record.
+        var seedRecord = new GatewayRecord { Id = "seed", Url = "wss://other", IsLocal = false };
+        _registry.AddOrUpdate(seedRecord);
+        _registry.SetActive("seed");
+        await _manager.ConnectAsync("seed");
+        await InvokeHandshakeSucceededAsync(_manager);
+
+        var connector = new ConnectionManagerWindowsNodeConnector(
+            _manager, _registry, NullLogger.Instance);
+
+        // The connector will create a new record for `url` if none exists. Manager's
+        // EnsureNodeConnectedAsync uses the currently-active gateway, which is `seed`.
+        // The new record creation is independent of the active gateway.
+        await connector.ConnectAsync(url, "shared", bootstrapToken: null);
+
+        var created = _registry.FindByUrl(url);
+        Assert.NotNull(created);
+        Assert.Equal("shared", created!.SharedGatewayToken);
+        Assert.True(created.IsLocal);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_OperatorNotConnected_PropagatesInvalidOperationException()
+    {
+        const string url = "ws://localhost:18789";
+        _registry.AddOrUpdate(new GatewayRecord { Id = "gw-local", Url = url, IsLocal = true });
+        _registry.SetActive("gw-local");
+
+        var connector = new ConnectionManagerWindowsNodeConnector(
+            _manager, _registry, NullLogger.Instance);
+
+        // Operator never reaches Connected; EnsureNodeConnectedAsync throws.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => connector.ConnectAsync(url, "tok", null));
+    }
+
+    [Fact]
+    public async Task ConnectAsync_PreCancelledToken_Throws()
+    {
+        const string url = "ws://localhost:18789";
+        _registry.AddOrUpdate(new GatewayRecord { Id = "gw-local", Url = url, IsLocal = true });
+        _registry.SetActive("gw-local");
+        _resolver.OperatorCredential = new GatewayCredential("op", false, "test");
+
+        var connector = new ConnectionManagerWindowsNodeConnector(
+            _manager, _registry, NullLogger.Instance);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => connector.ConnectAsync(url, "tok", null, cts.Token));
+    }
+
+    [Fact]
+    public async Task ConnectAsync_PreservesExistingTokens_WhenEmptyValuesPassed()
+    {
+        const string url = "ws://localhost:18789";
+        var record = new GatewayRecord
+        {
+            Id = "gw-local",
+            Url = url,
+            IsLocal = true,
+            SharedGatewayToken = "preserved-shared",
+            BootstrapToken = "preserved-boot",
+        };
+        _registry.AddOrUpdate(record);
+        _registry.SetActive("gw-local");
+        _resolver.OperatorCredential = new GatewayCredential("op", false, "test");
+        _resolver.NodeCredential = new GatewayCredential("nd", false, "test");
+        await _manager.ConnectAsync("gw-local");
+        await InvokeHandshakeSucceededAsync(_manager);
+
+        var connector = new ConnectionManagerWindowsNodeConnector(
+            _manager, _registry, NullLogger.Instance);
+
+        // Caller supplies empty token values — must NOT overwrite the stored values.
+        await connector.ConnectAsync(url, token: "", bootstrapToken: "");
+
+        var after = _registry.FindByUrl(url)!;
+        Assert.Equal("preserved-shared", after.SharedGatewayToken);
+        Assert.Equal("preserved-boot", after.BootstrapToken);
+    }
+
+    // ─── Helpers / mocks ───
+
+    private static async Task InvokeHandshakeSucceededAsync(GatewayConnectionManager manager)
+    {
+        var method = typeof(GatewayConnectionManager).GetMethod(
+            "HandleHandshakeSucceededAsync",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        var task = (Task)method!.Invoke(manager, [1L])!;
+        await task;
+    }
+
+    private sealed class StubCredentialResolver : ICredentialResolver
+    {
+        public GatewayCredential? OperatorCredential { get; set; }
+        public GatewayCredential? NodeCredential { get; set; }
+
+        public GatewayCredential? ResolveOperator(GatewayRecord record, string identityPath) => OperatorCredential;
+        public GatewayCredential? ResolveNode(GatewayRecord record, string identityPath) => NodeCredential;
+    }
+
+    private sealed class StubClientFactory : IGatewayClientFactory
+    {
+        public IGatewayClientLifecycle Create(string gatewayUrl, GatewayCredential credential, string identityPath, IOpenClawLogger logger)
+            => new StubLifecycle(gatewayUrl);
+    }
+
+    private sealed class StubLifecycle : IGatewayClientLifecycle
+    {
+        public StubLifecycle(string url)
+        {
+            DataClient = new StubGatewayClient(url);
+        }
+
+        public OpenClawGatewayClient DataClient { get; }
+#pragma warning disable CS0067 // Events are required by interface but not exercised
+        public event EventHandler<ConnectionStatus>? StatusChanged;
+        public event EventHandler<string>? AuthenticationFailed;
+#pragma warning restore CS0067
+
+        public Task ConnectAsync(CancellationToken ct) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+
+    private sealed class StubGatewayClient : OpenClawGatewayClient
+    {
+        public StubGatewayClient(string url) : base(url, "stub-tok", NullLogger.Instance) { }
+    }
+
+    private sealed class StubNodeConnector : INodeConnector
+    {
+        public int ConnectCount { get; private set; }
+        public bool IsConnected { get; private set; }
+        public PairingStatus PairingStatus { get; private set; } = PairingStatus.Unknown;
+        public string? NodeDeviceId => "stub-node";
+        public NodeConnectionMode Mode => IsConnected ? NodeConnectionMode.Gateway : NodeConnectionMode.Disabled;
+
+        public event EventHandler<ConnectionStatus>? StatusChanged;
+        public event EventHandler<PairingStatusEventArgs>? PairingStatusChanged;
+#pragma warning disable CS0067
+        public event EventHandler<NodeClientCreatedEventArgs>? ClientCreated;
+#pragma warning restore CS0067
+
+        public Task ConnectAsync(string gatewayUrl, GatewayCredential credential, string identityPath, bool useV2Signature = false)
+        {
+            ConnectCount++;
+            // Drive synchronous transitions so the manager reaches Connected+Paired and
+            // EnsureNodeConnectedAsync returns rather than waiting on the 35s timeout.
+            IsConnected = true;
+            StatusChanged?.Invoke(this, ConnectionStatus.Connecting);
+            PairingStatus = PairingStatus.Paired;
+            PairingStatusChanged?.Invoke(this, new PairingStatusEventArgs(PairingStatus.Paired, deviceId: "stub-node"));
+            StatusChanged?.Invoke(this, ConnectionStatus.Connected);
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            IsConnected = false;
+            return Task.CompletedTask;
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/Connection/ConnectionManagerWindowsNodeConnectorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Connection/ConnectionManagerWindowsNodeConnectorTests.cs
@@ -61,15 +61,16 @@ public sealed class ConnectionManagerWindowsNodeConnectorTests : IDisposable
     }
 
     [Fact]
-    public async Task ConnectAsync_NoExistingRecord_CreatesOne()
+    public async Task ConnectAsync_NoExistingRecord_ThrowsWithoutMutatingActiveGateway()
     {
         const string url = "ws://localhost:18789";
         _resolver.OperatorCredential = new GatewayCredential("op", false, "test");
         _resolver.NodeCredential = new GatewayCredential("nd", false, "test");
 
-        // Pre-create gateway record so the manager can connect; the connector's job
-        // here is to ensure that even WITHOUT a record matching the URL, it creates one.
-        // To exercise that branch we point the manager at a different record.
+        // Pre-create a different gateway record so the manager can connect. If
+        // operator pairing failed to create a record for the setup gateway, the
+        // node phase must fail loudly rather than switching the active gateway
+        // behind GatewayConnectionManager's back.
         var seedRecord = new GatewayRecord { Id = "seed", Url = "wss://other", IsLocal = false };
         _registry.AddOrUpdate(seedRecord);
         _registry.SetActive("seed");
@@ -79,15 +80,12 @@ public sealed class ConnectionManagerWindowsNodeConnectorTests : IDisposable
         var connector = new ConnectionManagerWindowsNodeConnector(
             _manager, _registry, NullLogger.Instance);
 
-        // The connector will create a new record for `url` if none exists. Manager's
-        // EnsureNodeConnectedAsync uses the currently-active gateway, which is `seed`.
-        // The new record creation is independent of the active gateway.
-        await connector.ConnectAsync(url, "shared", bootstrapToken: null);
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => connector.ConnectAsync(url, "shared", bootstrapToken: null));
 
-        var created = _registry.FindByUrl(url);
-        Assert.NotNull(created);
-        Assert.Equal("shared", created!.SharedGatewayToken);
-        Assert.True(created.IsLocal);
+        Assert.Null(_registry.FindByUrl(url));
+        Assert.Equal("seed", _registry.GetActive()?.Id);
+        Assert.Equal(0, _node.ConnectCount);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/LocalGatewaySetupTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalGatewaySetupTests.cs
@@ -739,6 +739,8 @@ public class LocalGatewaySetupTests
 
         var engine = LocalGatewaySetupEngineFactory.CreateLocalOnly(
             settings,
+            FakeOperatorConnector.Instance,
+            FakeWindowsNodeConnector.Instance,
             replaceExistingConfigurationConfirmed: true);
 
         Assert.NotNull(engine);
@@ -753,6 +755,8 @@ public class LocalGatewaySetupTests
         var ex = Assert.Throws<InvalidOperationException>(() =>
             LocalGatewaySetupEngineFactory.CreateLocalOnly(
                 settings,
+                FakeOperatorConnector.Instance,
+                FakeWindowsNodeConnector.Instance,
                 identityDataPath: temp.Path,
                 replaceExistingConfigurationConfirmed: false));
 
@@ -771,6 +775,8 @@ public class LocalGatewaySetupTests
         var ex = Assert.Throws<InvalidOperationException>(() =>
             LocalGatewaySetupEngineFactory.CreateLocalOnly(
                 settings,
+                FakeOperatorConnector.Instance,
+                FakeWindowsNodeConnector.Instance,
                 identityDataPath: temp.Path,
                 replaceExistingConfigurationConfirmed: false));
 
@@ -789,6 +795,8 @@ public class LocalGatewaySetupTests
         var ex = Assert.Throws<InvalidOperationException>(() =>
             LocalGatewaySetupEngineFactory.CreateLocalOnly(
                 settings,
+                FakeOperatorConnector.Instance,
+                FakeWindowsNodeConnector.Instance,
                 identityDataPath: temp.Path,
                 replaceExistingConfigurationConfirmed: false));
 
@@ -806,11 +814,37 @@ public class LocalGatewaySetupTests
         var ex = Assert.Throws<InvalidOperationException>(() =>
             LocalGatewaySetupEngineFactory.CreateLocalOnly(
                 settings,
+                FakeOperatorConnector.Instance,
+                FakeWindowsNodeConnector.Instance,
                 identityDataPath: temp.Path,
                 setupStatePath: setupStatePath,
                 replaceExistingConfigurationConfirmed: false));
 
         Assert.Contains("existing_config_replacement_not_confirmed", ex.Message);
+    }
+
+    /// <summary>
+    /// No-op operator connector used by tests that hit existing-config guards before
+    /// any pairing happens. Production paths supply ConnectionManagerOperatorConnector.
+    /// </summary>
+    private sealed class FakeOperatorConnector : IGatewayOperatorConnector
+    {
+        public static readonly FakeOperatorConnector Instance = new();
+        public Task<GatewayOperatorConnectionResult> ConnectAsync(string gatewayUrl, string token, bool tokenIsBootstrapToken = false, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new GatewayOperatorConnectionResult(GatewayOperatorConnectionStatus.Connected));
+        public Task<GatewayOperatorConnectionResult> ConnectWithStoredDeviceTokenAsync(string gatewayUrl, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new GatewayOperatorConnectionResult(GatewayOperatorConnectionStatus.Connected));
+    }
+
+    /// <summary>
+    /// No-op node connector used by tests that hit existing-config guards before
+    /// any node pairing happens. Production paths supply ConnectionManagerWindowsNodeConnector.
+    /// </summary>
+    private sealed class FakeWindowsNodeConnector : IWindowsNodeConnector
+    {
+        public static readonly FakeWindowsNodeConnector Instance = new();
+        public Task ConnectAsync(string gatewayUrl, string token, string? bootstrapToken, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
     }
 
     internal sealed class FakeWslCommandRunner : IWslCommandRunner

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Onboarding\Services\WizardStepSelection.cs" Link="Imported\WizardStepSelection.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Onboarding\Services\WizardFlowController.cs" Link="Imported\WizardFlowController.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Dialogs\QuickSendCoordinator.cs" Link="Imported\QuickSendCoordinator.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ConnectionManagerWindowsNodeConnector.cs" Link="Services\ConnectionManagerWindowsNodeConnector.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/OpenClaw.Tray.Tests/OperatorPairingApprovalTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OperatorPairingApprovalTests.cs
@@ -845,6 +845,117 @@ public class OperatorPairingApprovalTests
         Assert.Equal(3, runner.RunInDistroCommands.Count);
     }
 
+    // ─── Gateway-down extended-retry regression tests (bug 2026-05-16) ───
+    //
+    // When the gateway restarts mid-PairWindowsTrayNode (it can emit a 1012 service-restart
+    // ~15s after operator pairing while flushing config), both initial stage-1 attempts can
+    // hit a still-restarting gateway and fail with stderr like:
+    //   [openclaw] Reason: gateway closed (1006 abnormal closure (no close frame))
+    // The original 750ms single-retry isn't enough. The approver now keeps retrying with
+    // exponential backoff while the stderr looks like a transient gateway-down.
+
+    private const string GatewayDownStderr =
+        "[openclaw] Could not start the CLI.\n" +
+        "[openclaw] Reason: gateway closed (1006 abnormal closure (no close frame)): no close reason\n" +
+        "Gateway target: ws://127.0.0.1:18789\n";
+
+    [Fact]
+    public void LooksLikeGatewayDown_RecognizesProductionStderrPattern()
+    {
+        var down = new WslCommandResult(1, string.Empty, GatewayDownStderr);
+        var unrelated = new WslCommandResult(1, string.Empty, "syntax error near unexpected token");
+        var success = new WslCommandResult(0, "ok", string.Empty);
+        var empty = new WslCommandResult(1, string.Empty, string.Empty);
+
+        Assert.True(WslGatewayCliPendingDeviceApprover.LooksLikeGatewayDown(down));
+        Assert.False(WslGatewayCliPendingDeviceApprover.LooksLikeGatewayDown(unrelated));
+        Assert.False(WslGatewayCliPendingDeviceApprover.LooksLikeGatewayDown(success));
+        Assert.False(WslGatewayCliPendingDeviceApprover.LooksLikeGatewayDown(empty));
+    }
+
+    [Fact]
+    public async Task WslGatewayCliPendingDeviceApprover_GatewayDownInBothAttempts_RetriesUntilSuccess()
+    {
+        // Sequence: token-read → stage-1 attempt 1 (gateway-down) → stage-1 attempt 2
+        // (gateway-down) → stage-1 attempt 3 (gateway-down) → stage-1 attempt 4 (success).
+        // Then stage-2 commit.
+        var previewJson = "{\"selected\":{\"requestId\":\"r-recovered\"}}";
+        var commitJson = "{\"requestId\":\"r-recovered\"}";
+        var runner = new RecordingWslRunner(
+            new WslCommandResult(0, GatewayToken + "\n", string.Empty),
+            new WslCommandResult(1, string.Empty, GatewayDownStderr),
+            new WslCommandResult(1, string.Empty, GatewayDownStderr),
+            new WslCommandResult(1, string.Empty, GatewayDownStderr),
+            new WslCommandResult(0, previewJson, string.Empty),
+            new WslCommandResult(0, commitJson, string.Empty));
+        // Zero retry delay so the test runs fast; the production code still bounds total
+        // attempts via the GatewayDownRetryDelays array length.
+        var approver = new WslGatewayCliPendingDeviceApprover(runner, "/opt/openclaw/bin/openclaw", TimeSpan.Zero);
+
+        var result = await approver.ApproveLatestAsync(new LocalGatewaySetupState
+        {
+            GatewayUrl = "ws://127.0.0.1:18789",
+            DistroName = "OpenClawGateway",
+        });
+
+        Assert.True(result.Success);
+        // token-read + 4 stage-1 attempts + 1 stage-2 = 6 commands.
+        Assert.Equal(6, runner.RunInDistroCommands.Count);
+    }
+
+    [Fact]
+    public async Task WslGatewayCliPendingDeviceApprover_PersistentGatewayDown_EventuallyFailsCleanly()
+    {
+        // If the gateway never comes back, we still bail with the last gateway-down stderr
+        // surfaced in the failure message — better than silently looping forever.
+        var runner = new RecordingWslRunner(
+            new WslCommandResult(0, GatewayToken + "\n", string.Empty),
+            new WslCommandResult(1, string.Empty, GatewayDownStderr),
+            new WslCommandResult(1, string.Empty, GatewayDownStderr),
+            new WslCommandResult(1, string.Empty, GatewayDownStderr),
+            new WslCommandResult(1, string.Empty, GatewayDownStderr),
+            new WslCommandResult(1, string.Empty, GatewayDownStderr));
+        var approver = new WslGatewayCliPendingDeviceApprover(runner, "/opt/openclaw/bin/openclaw", TimeSpan.Zero);
+
+        var result = await approver.ApproveLatestAsync(new LocalGatewaySetupState
+        {
+            GatewayUrl = "ws://127.0.0.1:18789",
+            DistroName = "OpenClawGateway",
+        });
+
+        Assert.False(result.Success);
+        Assert.Equal("operator_pending_approval_failed", result.ErrorCode);
+        Assert.Contains("gateway closed", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        // token-read + 5 stage-1 attempts (initial + 1 retry + 3 extended retries) = 6 commands.
+        // Stage-2 must NOT run because stage-1 never produced a requestId.
+        Assert.Equal(6, runner.RunInDistroCommands.Count);
+    }
+
+    [Fact]
+    public async Task WslGatewayCliPendingDeviceApprover_GatewayDownThenDifferentError_StopsRetrying()
+    {
+        // If the second extended retry returns a DIFFERENT (non-gateway-down) error,
+        // we bail with that error rather than burning through all retries.
+        var runner = new RecordingWslRunner(
+            new WslCommandResult(0, GatewayToken + "\n", string.Empty),
+            new WslCommandResult(1, string.Empty, GatewayDownStderr),
+            new WslCommandResult(1, string.Empty, GatewayDownStderr),
+            // Third attempt: a NEW, distinct error pattern (not gateway-down).
+            new WslCommandResult(1, string.Empty, "permission denied: /var/lib/openclaw/gateway-token"));
+        var approver = new WslGatewayCliPendingDeviceApprover(runner, "/opt/openclaw/bin/openclaw", TimeSpan.Zero);
+
+        var result = await approver.ApproveLatestAsync(new LocalGatewaySetupState
+        {
+            GatewayUrl = "ws://127.0.0.1:18789",
+            DistroName = "OpenClawGateway",
+        });
+
+        Assert.False(result.Success);
+        Assert.Contains("permission denied", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        // Should have stopped after the non-gateway-down failure — not consumed all retries.
+        Assert.Equal(4, runner.RunInDistroCommands.Count);
+    }
+
     private static void AssertGatewayTokenInEnvironmentOnly(RecordingWslRunner runner, int commandIndex)
     {
         var environment = runner.RunInDistroEnvironments[commandIndex];


### PR DESCRIPTION
# Unify easy-button gateway comms through `GatewayConnectionManager`

Closes the audit in `easy-button-gateway-comms-audit.md` (session artifact). The WSL "easy button" setup flow previously bypassed Ranjesh's `GatewayConnectionManager` in two ways — a manager-blind operator-connector fallback, and direct `NodeService.ConnectAsync` driving the `PairWindowsTrayNode` phase. After this PR the manager is the **single owner** of `WindowsNodeClient` for **all** gateways (local and remote), and the easy-button engine routes operator AND node pairing through it.

## ⚠️ Depends on / includes #381

This branch was rebased to current master, then **merges `feat/setup-flow-redesign` (PR #381) on top** so the V2 onboarding redesign and the connection-unification land together. The merge resolved one docstring-only conflict in `OnboardingExistingConfigGuard.cs` (took #381's richer comment). Merge of PR #381 first → this PR effectively shrinks to just the connection-unification diff.

## Connection unification (the main work)

| Phase | Commit | Summary |
|---|---|---|
| 1 | `d5002f9` | New awaitable `IGatewayConnectionManager.EnsureNodeConnectedAsync` (35s default timeout, throws `InvalidOperationException` on Error/PairingRejected, propagates caller cancellation). |
| 2 | `4d3d1a6` | New `ConnectionManagerWindowsNodeConnector : IWindowsNodeConnector`. Sibling of `ConnectionManagerOperatorConnector`. Updates registry record with caller-supplied bootstrap/shared tokens (preserves existing values when caller passes empty), then awaits `EnsureNodeConnectedAsync`. |
| 3 | `11d7ad0` | Documents + regression-tests that the existing legacy `device-key-ed25519.json` migration carries the node tokens (operator and node tokens share a single `DeviceKeyData` record, so the existing operator-identity copy already migrates both). |
| 4 | `d5b4691` | Wires `ConnectionManagerWindowsNodeConnector` from `App.CreateLocalGatewaySetupEngine`. **Removes** `LocalNodeServiceOwnsIdentityFor` and the dual-arity `ShouldInitializeNodeService` overload — manager's `NodeConnector` is now the single owner of `WindowsNodeClient` for ALL gateways. `NodeService` remains as the capability registrar via the existing `NodeConnector.ClientCreated → AttachClient` bridge. Re-orders `App.OnLaunched` to initialize the manager *before* `ShowOnboardingAsync` (rubber-duck catch — otherwise first-run onboarding would fall back to the now-throwing legacy path). `NodeService.ConnectAsync` (gateway variant) marked `[Obsolete]` and throws; `StartLocalOnlyAsync` (MCP-only mode) is unchanged. |
| 5 | `68d66d0` | **Deletes** `OpenClawGatewayOperatorConnector` (direct `OpenClawGatewayClient` instantiation) and `NodeServiceWindowsNodeConnector` (legacy bypass). `LocalGatewaySetupEngineFactory.CreateLocalOnly` now requires `operatorConnector` and `windowsNodeConnector` as non-nullable parameters. `NodeService.ConnectAsync` (gateway variant) removed. |
| 6+ | `c6ccf5d` | **Post-merge fix:** `App.OnboardingCompleted` no longer cancels an in-flight reconnect on Finish. When the V2 GatewayWelcome wizard saves provider/model config the gateway emits a 1012 'service restart' (~1.5s window); if user clicks Finish during that window, we now check `CurrentSnapshot.OperatorState == Connecting` and let the auto-reconnect timer finish instead of starting a fresh attempt against a still-warming gateway. Lockable signal that only exists because of the unification work in this PR. |

## Why this matters (from the audit)

Pre-PR, during easy-button setup:
- Operator pairing diagnostics flowed through `GatewayConnectionManager` ✅
- Node pairing was a parallel-universe path through `NodeService.ConnectAsync` — **no diagnostics**, no per-gateway identity store, no manager state machine. The Connection Status diagnostics window was silent during the node-pairing phase.

After this PR, the Connection Status window surfaces the full node handshake + pairing + auto-approve sequence during easy-button setup, identical to what users see for remote-gateway connections.

## Validation

- `./build.ps1` ✅ all 4 projects
- `tests/OpenClaw.Tray.Tests` ✅ 1223/1223 passed
- `tests/OpenClaw.Shared.Tests` ✅ 1574/1602 passed (28 `IntegrationFact` skipped, expected — requires `OPENCLAW_RUN_INTEGRATION=1`)

**New tests added (15 total):**
- `GatewayConnectionManagerTests` × 8 (`EnsureNodeConnectedAsync` happy path, no-connector, operator-not-connected, already-paired no-op, pairing-rejected, node-error, caller cancellation, plus the new in-flight-reconnect snapshot guard)
- `ConnectionManagerWindowsNodeConnectorTests` × 5 (existing-record patch, no-record creation, operator-not-connected propagation, pre-cancelled cancellation, empty-token preservation)
- `IdentityFileMigrationTests` × 2 (file-copy carries both operator + node tokens; node-only legacy file)

## Manual test pass

Multiple full end-to-end runs through the V2 easy-button flow on a fresh box (via `./scripts/dev-reset-rebuild-launch.ps1 -SkipBuild -WipeWslDistro`):
- Welcome → Set up locally → 7-stage WSL install → GatewayWelcome (provider/model wizard) → Permissions → AllSet → Finish ✅
- Connection Status diagnostics window now shows node handshake + auto-approve + pairing entries during setup (was silent pre-PR) ✅
- `paired.json` / `device-key-ed25519.json` end up in the per-gateway dir under `gateways/<id>/` ✅
- Tray restart reconnects both operator and node via the manager, no `NodeService.ConnectAsync` fallback ✅
- Identified + fixed the post-onboarding reconnect-cancel UX wart (commit `c6ccf5d`, included)

## Out of scope

- The `node.pair.approve` 'unknown requestId' on role-upgrade pending (PR #382 fixed the device-pair vs node-pair API choice but the gateway-side role-upgrade flow still parks the request as `device.pair.approve`, surfaced as a 35s `EnsureNodeConnectedAsync` timeout that the engine then resolves via the existing WSL CLI device-approve fallback). Working as documented; future gateway-side fix.
- HTTP `/health` probe (`GatewayHealthCheck.TestAsync`) — still uses its own static `HttpClient` outside the manager. Per Ranjesh, leave as-is.
- All WSL-exec gateway operations (`WslGatewayCli*` providers/approver) — inherent to the WSL approach, not candidates for the WS manager.
