### PR TITLE
ConnectionPage polish + per-page "Back to Connection" link

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
@@ -162,7 +162,6 @@
                                     VerticalAlignment="Center">
                             <Button x:Name="StripPrimaryButton"
                                     Content="Connect"
-                                    Style="{ThemeResource AccentButtonStyle}"
                                     Visibility="Collapsed"
                                     Click="OnStripPrimaryClicked"
                                     AutomationProperties.AutomationId="StripPrimaryAction"/>
@@ -353,6 +352,8 @@
                                            VerticalAlignment="Center"/>
                                 <Button Grid.Column="1" Content="Copy"
                                         Click="OnCopyNodeApproveCommand"
+                                        ToolTipService.ToolTip="Copy command"
+                                        AutomationProperties.Name="Copy approval command"
                                         AutomationProperties.AutomationId="NodeApproveCopyAction"/>
                             </Grid>
                         </Border>
@@ -431,7 +432,6 @@
                                              x:Name="RecoveryRepairCodeBox"
                                              PlaceholderText="Paste setup code here…"/>
                                     <Button Grid.Column="1" Content="Apply"
-                                            Style="{ThemeResource AccentButtonStyle}"
                                             Click="OnApplyRepairCode"
                                             AutomationProperties.AutomationId="RecoveryApplyRepair"/>
                                 </Grid>
@@ -458,6 +458,8 @@
                                                VerticalAlignment="Center"/>
                                     <Button Grid.Column="1" Content="Copy"
                                             Click="OnCopyApproveCommand"
+                                            ToolTipService.ToolTip="Copy command"
+                                            AutomationProperties.Name="Copy approval command"
                                             AutomationProperties.AutomationId="RecoveryCopyApprove"/>
                                 </Grid>
                             </StackPanel>

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -332,11 +332,14 @@ public sealed partial class ConnectionPage : Page
         StripSub.Visibility = string.IsNullOrEmpty(plan.StripSub) ? Visibility.Collapsed : Visibility.Visible;
 
         // Primary action button — show only for actions the connection
-        // toggle can't already do (CopyApproveCommand, Rep, RestartTunnel).
-        // Connect / Reconnect / Retry / Cancel are all reachable by
-        // tapping the toggle, so surfacing a redundant button next to it
-        // was noisy. Also suppress in AddGateway since the form has its
-        // own Save & Connect CTA.
+        // toggle can't already do. The toggle covers Connect / Reconnect /
+        // Retry / Cancel; CopyApproveCommand and Rep were removed because
+        // their visible UI (inline Copy button next to the command, plus
+        // RecoveryAuthPasteBlock for re-pair) already exposes the action
+        // beneath the strip. After this clean-up, RestartTunnel is the
+        // only action that actually surfaces here in practice.
+        // Also suppress in AddGateway since the form has its own
+        // Save & Connect CTA.
         bool suppressStripCta = plan.Mode == ConnectionPageMode.AddGateway
             || plan.StripPrimaryAction is ConnectionPrimaryAction.Connect
                                        or ConnectionPrimaryAction.Reconnect
@@ -431,12 +434,7 @@ public sealed partial class ConnectionPage : Page
         var hostname = Environment.MachineName;
         int? presence = self?.PresenceCount;
         int channelTotal = channels?.Length ?? 0;
-        int channelOk = channels is { Length: > 0 }
-            ? channels.Count(c => c.IsLinked && (
-                string.Equals(c.Status, "ready", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(c.Status, "ok", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(c.Status, "connected", StringComparison.OrdinalIgnoreCase)))
-            : 0;
+        int channelOk = ConnectionPageChannelMetrics.CountHealthyChannels(channels);
         double todayAmount = 0d;
         if (cost?.Daily is { Count: > 0 })
         {
@@ -1045,9 +1043,69 @@ public sealed partial class ConnectionPage : Page
         return list;
     }
 
+    /// <summary>
+    /// Returns the inline status badge to render on the active gateway row
+    /// in the saved-gateways list, or <c>null</c> when the row should fall
+    /// back to a [Connect] button. The badge tracks the *real* overall
+    /// state — historically Connecting and PairingRequired were collapsed
+    /// into "Connected", which told users they were connected while the
+    /// page was actually mid-handshake or awaiting an approval.
+    /// </summary>
+    private FrameworkElement? BuildActiveRowBadge(OverallConnectionState state)
+    {
+        // (glyph, brushKey, label) per state. Connected/Ready/Degraded all
+        // mean "operator is online" — the only case that warrants the
+        // affirmative "Connected" badge.
+        (string glyph, string brushKey, string label)? badge = state switch
+        {
+            OverallConnectionState.Connected or
+            OverallConnectionState.Ready or
+            OverallConnectionState.Degraded =>
+                (Helpers.FluentIconCatalog.StatusOk, "SystemFillColorSuccessBrush", "Connected"),
+
+            OverallConnectionState.Connecting =>
+                (Helpers.FluentIconCatalog.Sync, "SystemFillColorCautionBrush", "Connecting…"),
+
+            OverallConnectionState.PairingRequired =>
+                (Helpers.FluentIconCatalog.Lock, "SystemFillColorCautionBrush", "Awaiting approval"),
+
+            OverallConnectionState.Disconnecting =>
+                (Helpers.FluentIconCatalog.Sync, "TextFillColorSecondaryBrush", "Disconnecting…"),
+
+            // Idle / Error → no badge; caller renders [Connect].
+            _ => null,
+        };
+
+        if (badge is null) return null;
+        var (glyph, brushKey, label) = badge.Value;
+
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 4,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        stack.Children.Add(new FontIcon
+        {
+            Glyph = glyph,
+            FontSize = 12,
+            Foreground = ResolveBrush(brushKey),
+            VerticalAlignment = VerticalAlignment.Center,
+        });
+        stack.Children.Add(new TextBlock
+        {
+            Text = label,
+            FontSize = 11,
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+            Foreground = ResolveBrush(brushKey),
+            VerticalAlignment = VerticalAlignment.Center,
+        });
+        return stack;
+    }
+
     private Border BuildSavedGatewayRowControl(SavedGatewayRow row)
     {
-        // All rows use neutral card chrome. The "Connected" badge alone communicates
+        // All rows use neutral card chrome. The status badge alone communicates
         // which row is the active/live gateway; tinting the whole row was visually noisy.
         var card = new Border
         {
@@ -1111,45 +1169,21 @@ public sealed partial class ConnectionPage : Page
         Grid.SetColumn(info, 0);
         grid.Children.Add(info);
 
-        // Active badge OR Connect button.
-        //   Connected (active + live)       → "Connected" green badge (no clickable Connect)
-        //   Active but currently disconnected → [Connect] button
-        //   Inactive                         → [Connect] button
-        bool isCurrentlyConnected = row.IsActive && _lastSnapshot.OverallState is
-            OverallConnectionState.Connected
-            or OverallConnectionState.Ready
-            or OverallConnectionState.Degraded
-            or OverallConnectionState.Connecting
-            or OverallConnectionState.PairingRequired;
-
-        if (isCurrentlyConnected)
+        // Per-row right-hand affordance: a status badge when the row is the
+        // *active* gateway and the snapshot has something live-ish to report,
+        // otherwise a [Connect] button to (re)activate the row.
+        //
+        // The badge label must follow real state — previously this branch
+        // collapsed Connecting and PairingRequired into "Connected", which
+        // told users they were connected while the page was actually
+        // mid-handshake or waiting for the gateway operator to approve a
+        // pairing request.
+        var badge = row.IsActive ? BuildActiveRowBadge(_lastSnapshot.OverallState) : null;
+        bool hasLiveAffordance = badge != null;
+        if (hasLiveAffordance)
         {
-            // Inline "✓ Connected" — checkmark glyph + text, no boxed badge,
-            // no second green dot. The active row no longer needs a heavy badge
-            // since the page already carries a top-level status indicator.
-            var badgeStack = new StackPanel
-            {
-                Orientation = Orientation.Horizontal,
-                Spacing = 4,
-                VerticalAlignment = VerticalAlignment.Center,
-            };
-            badgeStack.Children.Add(new FontIcon
-            {
-                Glyph = Helpers.FluentIconCatalog.StatusOk,
-                FontSize = 12,
-                Foreground = ResolveBrush("SystemFillColorSuccessBrush"),
-                VerticalAlignment = VerticalAlignment.Center,
-            });
-            badgeStack.Children.Add(new TextBlock
-            {
-                Text = "Connected",
-                FontSize = 11,
-                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
-                Foreground = ResolveBrush("SystemFillColorSuccessBrush"),
-                VerticalAlignment = VerticalAlignment.Center,
-            });
-            Grid.SetColumn(badgeStack, 1);
-            grid.Children.Add(badgeStack);
+            Grid.SetColumn(badge!, 1);
+            grid.Children.Add(badge!);
         }
         else
         {
@@ -1189,8 +1223,11 @@ public sealed partial class ConnectionPage : Page
         var openDashboard = new MenuFlyoutItem { Text = "Open dashboard", Tag = row.Id };
         openDashboard.Click += OnSavedRowOpenDashboard;
         flyout.Items.Add(openDashboard);
-        if (isCurrentlyConnected)
+        if (hasLiveAffordance)
         {
+            // Whenever the row has a status badge (Connected / Connecting…
+            // / Awaiting approval / Disconnecting…) we offer Disconnect as
+            // the corresponding teardown / cancel action.
             var disconnect = new MenuFlyoutItem { Text = "Disconnect", Tag = row.Id };
             disconnect.Click += OnDisconnect;
             flyout.Items.Add(disconnect);
@@ -1336,25 +1373,13 @@ public sealed partial class ConnectionPage : Page
             case ConnectionPrimaryAction.Cancel:
                 _ = _connectionManager?.DisconnectAsync();
                 break;
-            case ConnectionPrimaryAction.CopyApproveCommand:
-                if (!string.IsNullOrEmpty(plan.RecoveryApproveCommand))
-                    ClipboardHelper.CopyText(plan.RecoveryApproveCommand);
-                else if (!string.IsNullOrEmpty(plan.NodeApproveCommand))
-                    ClipboardHelper.CopyText(plan.NodeApproveCommand);
-                break;
             case ConnectionPrimaryAction.RestartTunnel:
                 OnRestartTunnel(sender, e);
                 break;
-            case ConnectionPrimaryAction.Rep:
-                _editingGatewayId = null;
-                _userIntent = UserIntent.None;
-                // Surface Recovery's paste textbox is already on screen for Auth recovery.
-                // For Pairing-type Rep, take the user to Add → Setup code as a fast path.
-                _userIntent = UserIntent.AddingGateway;
-                ShowAddPane("setup");
-                AddSetupCodeItem.IsSelected = true;
-                RefreshFromSnapshot(_lastSnapshot);
-                break;
+            // CopyApproveCommand and Rep arms were removed: the inline Copy
+            // button (RecoveryApproveCmdBlock / NodeApproveCmdBox) and the
+            // paste-setup-code block (RecoveryAuthPasteBlock) own those
+            // flows now. Both enum values are retired in ConnectionPagePlan.
         }
     }
 
@@ -2311,6 +2336,38 @@ public sealed partial class ConnectionPage : Page
             : $"{total} approvals waiting on you";
     }
 
+    /// <summary>
+    /// Builds a per-row pairing decision button (Approve / Deny). The button
+    /// stays a plain <see cref="Button"/> — accent style is intentionally
+    /// avoided so we comply with the Fluent "one accent per view" rule when
+    /// several pending requests are stacked. The affirmative or negative
+    /// cue comes from a leading glyph painted in a theme brush
+    /// (success / critical), which works correctly in light, dark, and
+    /// high-contrast modes.
+    /// </summary>
+    private Button BuildPairingDecisionButton(string glyph, string glyphBrushKey, string label,
+        string automationName, string automationId)
+    {
+        var stack = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6, VerticalAlignment = VerticalAlignment.Center };
+        stack.Children.Add(new FontIcon
+        {
+            Glyph = glyph,
+            FontSize = 12,
+            Foreground = ResolveBrush(glyphBrushKey),
+            VerticalAlignment = VerticalAlignment.Center,
+        });
+        stack.Children.Add(new TextBlock
+        {
+            Text = label,
+            VerticalAlignment = VerticalAlignment.Center,
+        });
+        var btn = new Button { Content = stack };
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(btn, automationName);
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(btn, automationId);
+        ToolTipService.SetToolTip(btn, label);
+        return btn;
+    }
+
     private Border BuildDevicePairingCard(DevicePairingRequest req, bool canPair)
     {
         var card = new Border
@@ -2348,10 +2405,28 @@ public sealed partial class ConnectionPage : Page
             // approve/deny click can call into the gateway client even on
             // legacy snapshots; if neither id is present, leave the buttons
             // disabled so the user isn't tricked into a no-op.
+            // Per-row Approve/Deny: per Fluent guidance ("at most one accent
+            // button per view"), don't paint the affirmative half accent —
+            // when several pending requests are stacked, multiple accent
+            // buttons compete and dilute the cue. The outer
+            // PendingApprovalsBanner (caution-yellow, bold count, live
+            // region) already carries the page-level attention. We signal
+            // affirmative/negative per row via leading glyphs in success /
+            // critical brushes instead of button chrome.
             var capturedId = req.RequestId ?? req.DeviceId;
             var buttons = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8, VerticalAlignment = VerticalAlignment.Center };
-            var approveBtn = new Button { Content = "Approve", Style = (Style)Application.Current.Resources["AccentButtonStyle"] };
-            var rejectBtn = new Button { Content = "Deny" };
+            var approveBtn = BuildPairingDecisionButton(
+                glyph: Helpers.FluentIconCatalog.Check,
+                glyphBrushKey: "SystemFillColorSuccessBrush",
+                label: "Approve",
+                automationName: "Approve pairing request",
+                automationId: "DevicePairApproveAction");
+            var rejectBtn = BuildPairingDecisionButton(
+                glyph: Helpers.FluentIconCatalog.Exit,
+                glyphBrushKey: "SystemFillColorCriticalBrush",
+                label: "Deny",
+                automationName: "Deny pairing request",
+                automationId: "DevicePairDenyAction");
             if (string.IsNullOrEmpty(capturedId))
             {
                 approveBtn.IsEnabled = false;
@@ -2440,13 +2515,24 @@ public sealed partial class ConnectionPage : Page
 
         if (canPair)
         {
-            // Same fallback as device pairing: legacy gateways may omit
-            // RequestId, so prefer NodeId. If neither is present, disable
-            // the buttons so the user can't trigger a no-op call.
+            // Same per-row treatment as device pairing (see BuildDevicePairingCard).
+            // Affirmative/negative cues come from leading glyphs, not button
+            // chrome, to keep the page within the "one accent per view" rule
+            // even when several pending requests are stacked.
             var capturedId = req.RequestId ?? req.NodeId;
             var buttons = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8, VerticalAlignment = VerticalAlignment.Center };
-            var approveBtn = new Button { Content = "Approve", Style = (Style)Application.Current.Resources["AccentButtonStyle"] };
-            var rejectBtn = new Button { Content = "Deny" };
+            var approveBtn = BuildPairingDecisionButton(
+                glyph: Helpers.FluentIconCatalog.Check,
+                glyphBrushKey: "SystemFillColorSuccessBrush",
+                label: "Approve",
+                automationName: "Approve pairing request",
+                automationId: "NodePairApproveAction");
+            var rejectBtn = BuildPairingDecisionButton(
+                glyph: Helpers.FluentIconCatalog.Exit,
+                glyphBrushKey: "SystemFillColorCriticalBrush",
+                label: "Deny",
+                automationName: "Deny pairing request",
+                automationId: "NodePairDenyAction");
             if (string.IsNullOrEmpty(capturedId))
             {
                 approveBtn.IsEnabled = false;

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -1044,6 +1044,15 @@ public sealed partial class ConnectionPage : Page
     }
 
     /// <summary>
+    /// Returns true when the active gateway row is in a state where
+    /// "Disconnect" is a meaningful action. Delegates to
+    /// <see cref="ConnectionPageRowState.CanDisconnectFromBadge"/>, kept
+    /// pure so the contract can be unit-tested.
+    /// </summary>
+    private static bool CanDisconnectFromBadge(OverallConnectionState state) =>
+        ConnectionPageRowState.CanDisconnectFromBadge(state);
+
+    /// <summary>
     /// Returns the inline status badge to render on the active gateway row
     /// in the saved-gateways list, or <c>null</c> when the row should fall
     /// back to a [Connect] button. The badge tracks the *real* overall
@@ -1069,10 +1078,18 @@ public sealed partial class ConnectionPage : Page
             OverallConnectionState.PairingRequired =>
                 (Helpers.FluentIconCatalog.Lock, "SystemFillColorCautionBrush", "Awaiting approval"),
 
+            // Error: surface as a critical-colored badge so the user can
+            // distinguish "active gateway is broken" from "this row is just
+            // not active". Without this, an Error active row fell through
+            // to [Connect], indistinguishable from any inactive row, and
+            // the overflow menu lost the Disconnect/teardown affordance.
+            OverallConnectionState.Error =>
+                (Helpers.FluentIconCatalog.StatusErr, "SystemFillColorCriticalBrush", "Error"),
+
             OverallConnectionState.Disconnecting =>
                 (Helpers.FluentIconCatalog.Sync, "TextFillColorSecondaryBrush", "Disconnecting…"),
 
-            // Idle / Error → no badge; caller renders [Connect].
+            // Idle → no badge; caller renders [Connect].
             _ => null,
         };
 
@@ -1100,6 +1117,13 @@ public sealed partial class ConnectionPage : Page
             Foreground = ResolveBrush(brushKey),
             VerticalAlignment = VerticalAlignment.Center,
         });
+        // Accessibility: the badge label is the screen-reader narration for
+        // the active row's status. Marking the container as a polite live
+        // region triggers a re-announcement when the page rebuilds the row
+        // with a new badge (e.g. Connecting… → Awaiting approval → Connected).
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(stack, label);
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetLiveSetting(
+            stack, Microsoft.UI.Xaml.Automation.Peers.AutomationLiveSetting.Polite);
         return stack;
     }
 
@@ -1225,12 +1249,17 @@ public sealed partial class ConnectionPage : Page
         flyout.Items.Add(openDashboard);
         if (hasLiveAffordance)
         {
-            // Whenever the row has a status badge (Connected / Connecting…
-            // / Awaiting approval / Disconnecting…) we offer Disconnect as
-            // the corresponding teardown / cancel action.
-            var disconnect = new MenuFlyoutItem { Text = "Disconnect", Tag = row.Id };
-            disconnect.Click += OnDisconnect;
-            flyout.Items.Add(disconnect);
+            // Whenever the row is in a state where Disconnect makes sense
+            // (Connected / Connecting… / Awaiting approval / Error) we offer
+            // it as the corresponding teardown / cancel action. Disconnecting
+            // is intentionally excluded — teardown is already in flight and
+            // re-entering would race the connection manager.
+            if (CanDisconnectFromBadge(_lastSnapshot.OverallState))
+            {
+                var disconnect = new MenuFlyoutItem { Text = "Disconnect", Tag = row.Id };
+                disconnect.Click += OnDisconnect;
+                flyout.Items.Add(disconnect);
+            }
             var editActive = new MenuFlyoutItem { Text = "Edit", Tag = row.Id };
             editActive.Click += OnSavedRowEdit;
             flyout.Items.Add(editActive);
@@ -2337,6 +2366,79 @@ public sealed partial class ConnectionPage : Page
     }
 
     /// <summary>
+    /// Runs an Approve or Deny decision and manages the buttons' enabled
+    /// state. Both buttons are disabled while the call is in flight; on
+    /// failure or a missing gateway client they're re-enabled immediately.
+    /// On success they stay disabled, expecting the gateway to push a
+    /// list-updated event that rebuilds the panel (and drops this card).
+    /// A 8-second watchdog re-enables the buttons if that event never
+    /// arrives — without it, a dropped websocket frame would leave the
+    /// row permanently inert and the user would have no way to retry.
+    /// </summary>
+    private async Task RunPairingDecisionAsync(
+        Button approveBtn, Button rejectBtn, bool isApprove,
+        Func<IOperatorGatewayClient, Task<bool>> action)
+    {
+        approveBtn.IsEnabled = false;
+        rejectBtn.IsEnabled = false;
+        bool successPath = false;
+        try
+        {
+            var client = _hub?.GatewayClient;
+            if (client == null) return; // finally re-enables
+            var ok = await action(client);
+            successPath = ok;
+            // !ok falls into finally below — re-enable so user can retry.
+        }
+        catch
+        {
+            // Swallow; finally re-enables. The pairing list refresh has
+            // its own observable surface (gateway list-updated event), so
+            // there's no clean place to surface a per-row error here.
+        }
+        finally
+        {
+            if (!successPath)
+            {
+                approveBtn.IsEnabled = true;
+                rejectBtn.IsEnabled = true;
+            }
+            else
+            {
+                ArmPairingDecisionWatchdog(approveBtn, rejectBtn);
+            }
+        }
+    }
+
+    private void ArmPairingDecisionWatchdog(Button approveBtn, Button rejectBtn)
+    {
+        // 8 s matches the existing reconnect-mask budget at the top of the
+        // file — the gateway's normal list-updated round-trip is < 1 s, so
+        // arming at 8 s only fires when something has genuinely gone wrong
+        // (websocket dropped, gateway crashed mid-approve, ...). The card
+        // will be removed by RefreshFromSnapshot in the happy path, which
+        // cancels this watchdog implicitly because the targets are no
+        // longer parented.
+        var timer = new Microsoft.UI.Xaml.DispatcherTimer
+        {
+            Interval = TimeSpan.FromSeconds(8),
+        };
+        timer.Tick += (_, _) =>
+        {
+            timer.Stop();
+            // If the row is still on screen (Parent != null), the gateway
+            // didn't push a list update — re-enable so the user can retry
+            // instead of being stuck with permanently disabled buttons.
+            if (approveBtn.Parent != null)
+            {
+                approveBtn.IsEnabled = true;
+                rejectBtn.IsEnabled = true;
+            }
+        };
+        timer.Start();
+    }
+
+    /// <summary>
     /// Builds a per-row pairing decision button (Approve / Deny). The button
     /// stays a plain <see cref="Button"/> — accent style is intentionally
     /// avoided so we comply with the Fluent "one accent per view" rule when
@@ -2435,36 +2537,22 @@ public sealed partial class ConnectionPage : Page
             approveBtn.Click += async (_, __) =>
             {
                 if (string.IsNullOrEmpty(capturedId)) return;
-                approveBtn.IsEnabled = false; rejectBtn.IsEnabled = false;
-                try
+                await RunPairingDecisionAsync(approveBtn, rejectBtn, isApprove: true, async client =>
                 {
-                    var client = _hub?.GatewayClient;
-                    if (client != null)
-                    {
-                        var ok = await client.DevicePairApproveAsync(capturedId);
-                        if (ok) await client.RequestDevicePairListAsync();
-                        else { approveBtn.IsEnabled = true; rejectBtn.IsEnabled = true; }
-                    }
-                    else { approveBtn.IsEnabled = true; rejectBtn.IsEnabled = true; }
-                }
-                catch { approveBtn.IsEnabled = true; rejectBtn.IsEnabled = true; }
+                    var ok = await client.DevicePairApproveAsync(capturedId);
+                    if (ok) await client.RequestDevicePairListAsync();
+                    return ok;
+                });
             };
             rejectBtn.Click += async (_, __) =>
             {
                 if (string.IsNullOrEmpty(capturedId)) return;
-                approveBtn.IsEnabled = false; rejectBtn.IsEnabled = false;
-                try
+                await RunPairingDecisionAsync(approveBtn, rejectBtn, isApprove: false, async client =>
                 {
-                    var client = _hub?.GatewayClient;
-                    if (client != null)
-                    {
-                        var ok = await client.DevicePairRejectAsync(capturedId);
-                        if (ok) await client.RequestDevicePairListAsync();
-                        else { approveBtn.IsEnabled = true; rejectBtn.IsEnabled = true; }
-                    }
-                    else { approveBtn.IsEnabled = true; rejectBtn.IsEnabled = true; }
-                }
-                catch { approveBtn.IsEnabled = true; rejectBtn.IsEnabled = true; }
+                    var ok = await client.DevicePairRejectAsync(capturedId);
+                    if (ok) await client.RequestDevicePairListAsync();
+                    return ok;
+                });
             };
             buttons.Children.Add(approveBtn);
             buttons.Children.Add(rejectBtn);
@@ -2541,34 +2629,26 @@ public sealed partial class ConnectionPage : Page
             approveBtn.Click += async (_, __) =>
             {
                 if (string.IsNullOrEmpty(capturedId)) return;
-                approveBtn.IsEnabled = false; rejectBtn.IsEnabled = false;
-                try
+                await RunPairingDecisionAsync(approveBtn, rejectBtn, isApprove: true, async client =>
                 {
-                    var client = _hub?.GatewayClient;
-                    if (client != null)
-                    {
-                        var ok = await client.NodePairApproveAsync(capturedId);
-                        if (!ok) { approveBtn.IsEnabled = true; rejectBtn.IsEnabled = true; }
-                    }
-                    else { approveBtn.IsEnabled = true; rejectBtn.IsEnabled = true; }
-                }
-                catch { approveBtn.IsEnabled = true; rejectBtn.IsEnabled = true; }
+                    var ok = await client.NodePairApproveAsync(capturedId);
+                    // Symmetry with device pairing: ask for a fresh list so the
+                    // panel rebuilds and this card drops out. Without this the
+                    // Approve/Deny buttons stayed disabled until the gateway
+                    // spontaneously pushed a list update.
+                    if (ok) await client.RequestNodePairListAsync();
+                    return ok;
+                });
             };
             rejectBtn.Click += async (_, __) =>
             {
                 if (string.IsNullOrEmpty(capturedId)) return;
-                approveBtn.IsEnabled = false; rejectBtn.IsEnabled = false;
-                try
+                await RunPairingDecisionAsync(approveBtn, rejectBtn, isApprove: false, async client =>
                 {
-                    var client = _hub?.GatewayClient;
-                    if (client != null)
-                    {
-                        var ok = await client.NodePairRejectAsync(capturedId);
-                        if (!ok) { approveBtn.IsEnabled = true; rejectBtn.IsEnabled = true; }
-                    }
-                    else { approveBtn.IsEnabled = true; rejectBtn.IsEnabled = true; }
-                }
-                catch { approveBtn.IsEnabled = true; rejectBtn.IsEnabled = true; }
+                    var ok = await client.NodePairRejectAsync(capturedId);
+                    if (ok) await client.RequestNodePairListAsync();
+                    return ok;
+                });
             };
             buttons.Children.Add(approveBtn);
             buttons.Children.Add(rejectBtn);

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -1438,12 +1438,12 @@ public sealed partial class ConnectionPage : Page
 
     // ─── Operator card navigation ────────────────────────────────────
 
-    private void OnOpenSessions(object sender, RoutedEventArgs e) => _hub?.NavigateTo("sessions");
-    private void OnOpenInstances(object sender, RoutedEventArgs e) => _hub?.NavigateTo("instances");
+    private void OnOpenSessions(object sender, RoutedEventArgs e) => _hub?.NavigateTo("sessions", "connection");
+    private void OnOpenInstances(object sender, RoutedEventArgs e) => _hub?.NavigateTo("instances", "connection");
 
     // ─── Node card navigation ────────────────────────────────────────
 
-    private void OnOpenPermissions(object sender, RoutedEventArgs e) => _hub?.NavigateTo("permissions");
+    private void OnOpenPermissions(object sender, RoutedEventArgs e) => _hub?.NavigateTo("permissions", "connection");
 
     private void OnCopyNodeApproveCommand(object sender, RoutedEventArgs e)
     {

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -1078,18 +1078,16 @@ public sealed partial class ConnectionPage : Page
             OverallConnectionState.PairingRequired =>
                 (Helpers.FluentIconCatalog.Lock, "SystemFillColorCautionBrush", "Awaiting approval"),
 
-            // Error: surface as a critical-colored badge so the user can
-            // distinguish "active gateway is broken" from "this row is just
-            // not active". Without this, an Error active row fell through
-            // to [Connect], indistinguishable from any inactive row, and
-            // the overflow menu lost the Disconnect/teardown affordance.
-            OverallConnectionState.Error =>
-                (Helpers.FluentIconCatalog.StatusErr, "SystemFillColorCriticalBrush", "Error"),
-
             OverallConnectionState.Disconnecting =>
                 (Helpers.FluentIconCatalog.Sync, "TextFillColorSecondaryBrush", "Disconnecting…"),
 
-            // Idle → no badge; caller renders [Connect].
+            // Idle and Error → no badge; caller renders [Connect].
+            // The status strip up top already carries the "broken / can't
+            // reach gateway" signal (with the URL and category), and the
+            // Recovery card right beneath it offers Disconnect. Adding an
+            // "Error" badge here would duplicate that signal and remove the
+            // [Connect] retry affordance — which is the one actionable
+            // thing the row should offer in an Error state.
             _ => null,
         };
 

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPageChannelMetrics.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPageChannelMetrics.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using OpenClaw.Shared;
+
+namespace OpenClawTray.Pages;
+
+/// <summary>
+/// Pure helpers for the channels glance chip on <see cref="ConnectionPage"/>.
+/// Lives in its own file (no WinUI imports) so the test project — which is
+/// pure net10.0 and cannot reference the WinUI tray assembly — can link
+/// this source and assert real behavior instead of parsing text.
+///
+/// The chip historically used a bespoke healthy-status whitelist
+/// (<c>ready/ok/connected</c>) AND required <c>IsLinked == true</c>. As a
+/// result, a single channel reporting <c>Status = "running"</c> or
+/// <c>"active"</c> — both canonical healthy statuses elsewhere
+/// (<see cref="ChannelHealth.IsHealthyStatus"/>, tray tooltip, channels
+/// page) — was counted as 0, so the chip read "0/1 channels" yellow even
+/// when the gateway was perfectly happy.
+///
+/// <see cref="CountHealthyChannels"/> aligns to the canonical predicate and
+/// drops the <c>IsLinked</c> gate. <c>IsLinked</c> stays where it belongs —
+/// as auth-age detail in <see cref="ChannelHealth.DisplayText"/> and the
+/// channels page — not as a health predicate.
+/// </summary>
+internal static class ConnectionPageChannelMetrics
+{
+    /// <summary>
+    /// Returns the number of channels in <paramref name="channels"/> whose
+    /// <c>Status</c> is recognized as healthy by
+    /// <see cref="ChannelHealth.IsHealthyStatus"/>. Returns 0 when the input
+    /// is <c>null</c> or empty.
+    /// </summary>
+    internal static int CountHealthyChannels(IReadOnlyList<ChannelHealth>? channels)
+    {
+        if (channels == null || channels.Count == 0) return 0;
+        int count = 0;
+        for (int i = 0; i < channels.Count; i++)
+        {
+            if (ChannelHealth.IsHealthyStatus(channels[i].Status))
+                count++;
+        }
+        return count;
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPagePlan.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPagePlan.cs
@@ -525,11 +525,16 @@ internal sealed record ConnectionPagePlan
         // `openclaw approve node …` form does not match any registered
         // subcommand and silently failed when users pasted it.
         // Missing requestId is a real-world case on older gateway builds:
-        // emit a discovery hint instead of a bare `approve` (which the
-        // CLI rejects with "missing required argument").
+        // emit a single discovery command (`openclaw nodes pending`) the
+        // user can paste verbatim into any shell — they then pick a
+        // requestId from its output and run approve manually. We avoid
+        // embedding a "# then:" or "<requestId>" follow-up in the clipboard
+        // text because `#` is treated as a literal arg by cmd.exe and `<`
+        // is parsed as input redirection — pasting either breaks for
+        // Windows-cmd users.
         return reqId != null
             ? $"openclaw nodes approve {reqId}"
-            : "openclaw nodes pending  # then: openclaw nodes approve <requestId>";
+            : "openclaw nodes pending";
     }
 
     private static string? BuildDevicePairingApproveCommand(GatewayConnectionSnapshot snap)
@@ -540,11 +545,11 @@ internal sealed record ConnectionPagePlan
             ? ConnectionCardPlanSanitizer.Sanitize(snap.OperatorPairingRequestId!, maxLen: 64)
             : null;
         // Noun-first per openclaw/src/cli/devices-cli.ts:
-        // `openclaw devices approve <requestId>`. Mirror BuildNodeApproveCommand
-        // for the missing-id discovery hint.
+        // `openclaw devices approve <requestId>`. Mirror BuildNodeApproveCommand:
+        // single discovery command in the clipboard, no shell-hostile suffix.
         return reqId != null
             ? $"openclaw devices approve {reqId}"
-            : "openclaw devices list  # then: openclaw devices approve <requestId>";
+            : "openclaw devices list";
     }
 
     private static string? ExtractNodeErrorDetail(GatewayConnectionSnapshot snap)

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPagePlan.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPagePlan.cs
@@ -62,10 +62,13 @@ internal enum ConnectionPrimaryAction
     Reconnect,
     Retry,
     Cancel,
-    CopyApproveCommand,
     RestartTunnel,
-    Rep,
     BackToCockpit,
+    // CopyApproveCommand and Rep retired: the inline RecoveryApproveCmdBlock
+    // Copy button and the RecoveryAuthPasteBlock paste-and-Apply affordance
+    // own those flows; surfacing them in the strip header on top of a
+    // critical/caution status read as a loud red CTA duplicating the inline
+    // controls below it.
 }
 
 /// <summary>Visual state of the Operator card in Cockpit mode.</summary>
@@ -372,8 +375,14 @@ internal sealed record ConnectionPagePlan
                 StripAccent = ConnectionAccent.Caution,
                 StripHeadline = "Awaiting approval",
                 StripSub = "Approve this client on the gateway host. Connection will resume automatically.",
-                StripPrimaryLabel = cmd != null ? "Copy command" : null,
-                StripPrimaryAction = cmd != null ? ConnectionPrimaryAction.CopyApproveCommand : ConnectionPrimaryAction.None,
+                // No strip-level CTA here: the inline Copy button in
+                // RecoveryApproveCmdBlock owns the copy action, and surfacing
+                // an accent "Copy command" CTA in the strip header on top of
+                // a caution status read as a loud red button next to the
+                // pairing instructions. ConnectionToggle still allows the
+                // user to disconnect; reconnection auto-resumes once approved.
+                StripPrimaryLabel = null,
+                StripPrimaryAction = ConnectionPrimaryAction.None,
                 RecoveryApproveCommand = cmd,
                 RecoveryDetail = "Run on the gateway host:",
                 ActiveGatewayDisplayName = name,
@@ -410,8 +419,13 @@ internal sealed record ConnectionPagePlan
                 StripSub = string.IsNullOrEmpty(err)
                     ? $"Token for {name} is no longer valid."
                     : err,
-                StripPrimaryLabel = "Re-pair",
-                StripPrimaryAction = ConnectionPrimaryAction.Rep,
+                // No strip-level "Re-pair" CTA: the RecoveryAuthPasteBlock
+                // below the strip already exposes a paste-setup-code + Apply
+                // affordance, which IS the re-pair flow. A strip CTA on top
+                // of a critical error read as a loud red button duplicating
+                // an action the user can already see beneath it.
+                StripPrimaryLabel = null,
+                StripPrimaryAction = ConnectionPrimaryAction.None,
                 ActiveGatewayDisplayName = name,
                 ActiveGatewayDetailLine = url,
                 ActiveGatewayHasSshTunnel = rec?.SshTunnel != null,
@@ -506,9 +520,16 @@ internal sealed record ConnectionPagePlan
         var reqId = !string.IsNullOrEmpty(snap.NodePairingRequestId)
             ? ConnectionCardPlanSanitizer.Sanitize(snap.NodePairingRequestId!, maxLen: 64)
             : null;
+        // CLI is noun-first: `openclaw nodes approve <requestId>` (see
+        // openclaw/src/cli/nodes-cli/register.pairing.ts). The earlier
+        // `openclaw approve node …` form does not match any registered
+        // subcommand and silently failed when users pasted it.
+        // Missing requestId is a real-world case on older gateway builds:
+        // emit a discovery hint instead of a bare `approve` (which the
+        // CLI rejects with "missing required argument").
         return reqId != null
-            ? $"openclaw approve node {reqId}"
-            : "openclaw approve node";
+            ? $"openclaw nodes approve {reqId}"
+            : "openclaw nodes pending  # then: openclaw nodes approve <requestId>";
     }
 
     private static string? BuildDevicePairingApproveCommand(GatewayConnectionSnapshot snap)
@@ -518,9 +539,12 @@ internal sealed record ConnectionPagePlan
         var reqId = !string.IsNullOrEmpty(snap.OperatorPairingRequestId)
             ? ConnectionCardPlanSanitizer.Sanitize(snap.OperatorPairingRequestId!, maxLen: 64)
             : null;
+        // Noun-first per openclaw/src/cli/devices-cli.ts:
+        // `openclaw devices approve <requestId>`. Mirror BuildNodeApproveCommand
+        // for the missing-id discovery hint.
         return reqId != null
-            ? $"openclaw approve device {reqId}"
-            : "openclaw approve device";
+            ? $"openclaw devices approve {reqId}"
+            : "openclaw devices list  # then: openclaw devices approve <requestId>";
     }
 
     private static string? ExtractNodeErrorDetail(GatewayConnectionSnapshot snap)

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPageRowState.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPageRowState.cs
@@ -1,0 +1,38 @@
+using OpenClaw.Connection;
+
+namespace OpenClawTray.Pages;
+
+/// <summary>
+/// Pure helpers describing the per-row state mapping on the
+/// <see cref="ConnectionPage"/> saved-gateways list. Extracted from the
+/// WinUI page so unit tests (which run as pure net10.0) can pin the
+/// predicate without touching XAML types.
+/// </summary>
+internal static class ConnectionPageRowState
+{
+    /// <summary>
+    /// Returns true when the active row's overflow menu should offer
+    /// "Disconnect". Tear-down is meaningful while the connection is
+    /// live (Connected / Ready / Degraded), in transit
+    /// (Connecting / PairingRequired), or stuck in a critical state
+    /// (Error). It is NOT meaningful while the teardown itself is in
+    /// flight (Disconnecting) — re-entering would race the connection
+    /// manager — nor in the no-badge states (Idle), where the caller
+    /// renders a [Connect] button instead.
+    /// </summary>
+    internal static bool CanDisconnectFromBadge(OverallConnectionState state) => state is
+        OverallConnectionState.Connected
+        or OverallConnectionState.Ready
+        or OverallConnectionState.Degraded
+        or OverallConnectionState.Connecting
+        or OverallConnectionState.PairingRequired
+        or OverallConnectionState.Error;
+
+    /// <summary>
+    /// Returns true when the active row should render a status badge
+    /// (any non-Idle state). Idle returns false → the caller renders a
+    /// [Connect] button so the user can re-activate the row.
+    /// </summary>
+    internal static bool HasActiveRowBadge(OverallConnectionState state) =>
+        state != OverallConnectionState.Idle;
+}

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPageRowState.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPageRowState.cs
@@ -13,26 +13,31 @@ internal static class ConnectionPageRowState
     /// <summary>
     /// Returns true when the active row's overflow menu should offer
     /// "Disconnect". Tear-down is meaningful while the connection is
-    /// live (Connected / Ready / Degraded), in transit
-    /// (Connecting / PairingRequired), or stuck in a critical state
-    /// (Error). It is NOT meaningful while the teardown itself is in
-    /// flight (Disconnecting) — re-entering would race the connection
-    /// manager — nor in the no-badge states (Idle), where the caller
-    /// renders a [Connect] button instead.
+    /// live (Connected / Ready / Degraded) or in transit
+    /// (Connecting / PairingRequired). It is NOT meaningful while the
+    /// teardown itself is in flight (Disconnecting) — re-entering would
+    /// race the connection manager. Error and Idle return false because
+    /// those states render a [Connect] button (no badge) and the Recovery
+    /// card / Welcome panel above already exposes Disconnect when needed.
     /// </summary>
     internal static bool CanDisconnectFromBadge(OverallConnectionState state) => state is
         OverallConnectionState.Connected
         or OverallConnectionState.Ready
         or OverallConnectionState.Degraded
         or OverallConnectionState.Connecting
-        or OverallConnectionState.PairingRequired
-        or OverallConnectionState.Error;
+        or OverallConnectionState.PairingRequired;
 
     /// <summary>
-    /// Returns true when the active row should render a status badge
-    /// (any non-Idle state). Idle returns false → the caller renders a
-    /// [Connect] button so the user can re-activate the row.
+    /// Returns true when the active row should render a status badge.
+    /// Returns false for Idle (row renders [Connect]) and Error (the row
+    /// also renders [Connect] so the user can explicitly retry; the
+    /// status strip up top already carries the "broken" signal).
     /// </summary>
-    internal static bool HasActiveRowBadge(OverallConnectionState state) =>
-        state != OverallConnectionState.Idle;
+    internal static bool HasActiveRowBadge(OverallConnectionState state) => state is
+        OverallConnectionState.Connected
+        or OverallConnectionState.Ready
+        or OverallConnectionState.Degraded
+        or OverallConnectionState.Connecting
+        or OverallConnectionState.PairingRequired
+        or OverallConnectionState.Disconnecting;
 }

--- a/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml
@@ -5,6 +5,20 @@
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Padding="24" Spacing="16" HorizontalAlignment="Stretch">
 
+            <!-- Inline back link — only shown when the user arrived via a
+                 cross-page link from Connection. Set by InstancesPage.Initialize
+                 based on HubWindow.LastNavigationOrigin. -->
+            <HyperlinkButton x:Name="BackToConnectionLink"
+                             Click="OnBackToConnectionClicked"
+                             Padding="0" Margin="0,0,0,-8"
+                             Visibility="Collapsed"
+                             AutomationProperties.AutomationId="BackToConnectionLink">
+                <StackPanel Orientation="Horizontal" Spacing="6">
+                    <FontIcon Glyph="&#xE72B;" FontSize="12"/>
+                    <TextBlock Text="Back to Connection"/>
+                </StackPanel>
+            </HyperlinkButton>
+
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml.cs
@@ -37,6 +37,14 @@ public sealed partial class InstancesPage : Page
     public void Initialize(HubWindow hub)
     {
         _hub = hub;
+
+        // Show "← Back to Connection" only when the user arrived from
+        // Connection's cross-page link; staying hidden when the rail nav
+        // is used keeps the page chrome quiet for direct navigation.
+        BackToConnectionLink.Visibility = hub.LastNavigationOrigin == "connection"
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+
         var connected = hub.GatewayClient != null;
         ConnectionWarning.Visibility = connected ? Visibility.Collapsed : Visibility.Visible;
 
@@ -49,6 +57,9 @@ public sealed partial class InstancesPage : Page
             _ = RequestNodesWithSpinnerAsync();
         }
     }
+
+    private void OnBackToConnectionClicked(object sender, RoutedEventArgs e)
+        => _hub?.NavigateTo("connection");
 
     public void UpdateNodes(GatewayNodeInfo[] nodes)
     {

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml
@@ -10,6 +10,20 @@
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Padding="24" Spacing="8" HorizontalAlignment="Stretch" MaxWidth="900">
 
+            <!-- Inline back link — only shown when the user arrived via a
+                 cross-page link from Connection. Set by PermissionsPage.Initialize
+                 based on HubWindow.LastNavigationOrigin. -->
+            <HyperlinkButton x:Name="BackToConnectionLink"
+                             Click="OnBackToConnectionClicked"
+                             Padding="0" Margin="0,0,0,4"
+                             Visibility="Collapsed"
+                             AutomationProperties.AutomationId="BackToConnectionLink">
+                <StackPanel Orientation="Horizontal" Spacing="6">
+                    <FontIcon Glyph="&#xE72B;" FontSize="12"/>
+                    <TextBlock Text="Back to Connection"/>
+                </StackPanel>
+            </HyperlinkButton>
+
             <!-- ───────── Page header ───────── -->
             <TextBlock Text="Permissions"
                        Style="{StaticResource TitleTextBlockStyle}"

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
@@ -39,6 +39,13 @@ public sealed partial class PermissionsPage : Page
         _hub = hub;
         HostnameText.Text = Environment.MachineName;
 
+        // Show "← Back to Connection" only when the user arrived from
+        // Connection's cross-page link; staying hidden when the rail nav
+        // is used keeps the page chrome quiet for direct navigation.
+        BackToConnectionLink.Visibility = hub.LastNavigationOrigin == "connection"
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+
         BindNodeModeMaster(hub);
         BuildCapabilityToggles(hub);
         UpdateMcpStatus(hub);
@@ -50,6 +57,9 @@ public sealed partial class PermissionsPage : Page
         LoadExecPolicy();
         LoadAllowlist(hub.LastConfig);
     }
+
+    private void OnBackToConnectionClicked(object sender, RoutedEventArgs e)
+        => _hub?.NavigateTo("connection");
 
     private void OnLoaded(object sender, RoutedEventArgs e)
     {

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
@@ -10,11 +10,26 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
+        <!-- Inline back link — only shown when the user arrived via a
+             cross-page link from Connection. Set by SessionsPage.Initialize
+             based on HubWindow.LastNavigationOrigin. -->
+        <HyperlinkButton x:Name="BackToConnectionLink" Grid.Row="0"
+                         Click="OnBackToConnectionClicked"
+                         Padding="0" Margin="0,0,0,0"
+                         Visibility="Collapsed"
+                         AutomationProperties.AutomationId="BackToConnectionLink">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <FontIcon Glyph="&#xE72B;" FontSize="12"/>
+                <TextBlock Text="Back to Connection"/>
+            </StackPanel>
+        </HyperlinkButton>
+
         <!-- Header row: title + refresh -->
-        <Grid Grid.Row="0">
+        <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
@@ -29,19 +44,19 @@
         </Grid>
 
         <!-- Channel filter SelectorBar -->
-        <SelectorBar x:Name="ChannelSelector" Grid.Row="1"
+        <SelectorBar x:Name="ChannelSelector" Grid.Row="2"
                      SelectionChanged="ChannelSelector_SelectionChanged">
             <SelectorBarItem x:Name="AllTab" Text="All" IsSelected="True"/>
         </SelectorBar>
 
         <!-- Not-connected warning -->
-        <InfoBar x:Name="ConnectionWarning" Grid.Row="2"
+        <InfoBar x:Name="ConnectionWarning" Grid.Row="3"
                  Title="Not connected"
                  Message="Connect to a gateway to view sessions."
                  Severity="Warning" IsOpen="False" IsClosable="False"/>
 
         <!-- Empty state -->
-        <StackPanel x:Name="EmptyState" Grid.Row="3" Spacing="8"
+        <StackPanel x:Name="EmptyState" Grid.Row="4" Spacing="8"
                     HorizontalAlignment="Center" VerticalAlignment="Center"
                     Visibility="Collapsed">
             <TextBlock Text="💬" FontSize="48" HorizontalAlignment="Center"/>
@@ -51,7 +66,7 @@
         </StackPanel>
 
         <!-- Session list -->
-        <ListView x:Name="SessionListView" Grid.Row="3" SelectionMode="None">
+        <ListView x:Name="SessionListView" Grid.Row="4" SelectionMode="None">
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -27,6 +27,13 @@ public sealed partial class SessionsPage : Page
     {
         _hub = hub;
 
+        // Show "← Back to Connection" only when the user arrived from
+        // Connection's cross-page link; staying hidden when the rail nav
+        // is used keeps the page chrome quiet for direct navigation.
+        BackToConnectionLink.Visibility = hub.LastNavigationOrigin == "connection"
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+
         if (hub.GatewayClient == null)
         {
             ConnectionWarning.IsOpen = true;
@@ -43,6 +50,9 @@ public sealed partial class SessionsPage : Page
         _ = hub.GatewayClient.RequestSessionsAsync();
         _ = hub.GatewayClient.RequestModelsListAsync();
     }
+
+    private void OnBackToConnectionClicked(object sender, RoutedEventArgs e)
+        => _hub?.NavigateTo("connection");
 
     public void UpdateSessions(SessionInfo[] sessions)
     {

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
@@ -170,7 +170,7 @@
             </NavigationViewItem>
         </NavigationView.FooterMenuItems>
 
-        <Frame x:Name="ContentFrame">
+        <Frame x:Name="ContentFrame" Navigated="OnContentFrameNavigated">
             <Frame.ContentTransitions>
                 <TransitionCollection>
                     <NavigationThemeTransition/>

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -126,50 +126,126 @@ public sealed partial class HubWindow : WindowEx
         }
     }
 
+    // Canonical tag of the page currently shown in ContentFrame; tracked here
+    // (rather than relying on NavView.SelectedItem) so navigation identity
+    // includes the tag — important for agent-scoped pages where several tags
+    // map to the same Page type (e.g. "sessions" vs "agent:main:sessions"
+    // both → SessionsPage), and for the per-page "Back to ..." link logic
+    // that needs to know whether the user arrived via a cross-page link.
+    private string? _currentNavTag;
+
+    // Set true while a programmatic SelectedItem update is in flight, to
+    // suppress the resulting SelectionChanged from re-entering NavigateInternal.
+    private bool _syncingNavSelection;
+
+    // Set by NavigateTo(tag, originTag); consumed by OnContentFrameNavigated
+    // when the new page is initialized, then surfaced as LastNavigationOrigin
+    // so destination pages can decide whether to show an inline back link.
+    private string? _pendingNavigationOrigin;
+
+    /// <summary>
+    /// Tag of the page the user navigated FROM on the most recent navigation,
+    /// or <c>null</c> if the navigation didn't declare an origin (e.g. rail
+    /// click, deep link, app start). Destination pages read this in
+    /// <c>Initialize</c> to decide whether to surface a "Back to X" affordance.
+    /// </summary>
+    public string? LastNavigationOrigin { get; private set; }
+
     /// <summary>
     /// Navigate to a specific page by tag name (e.g. "connection", "sessions", "channels").
     /// </summary>
-    public void NavigateTo(string tag)
+    public void NavigateTo(string tag) => NavigateTo(tag, null);
+
+    /// <summary>
+    /// Navigate to a specific page by tag, declaring which logical surface
+    /// initiated the navigation. The destination page can read this via
+    /// <see cref="LastNavigationOrigin"/> to render an inline "Back to ..."
+    /// link — used by cross-page links on the Connection page so users have
+    /// a one-click return path without relying on the rail or a chrome back
+    /// button.
+    /// </summary>
+    public void NavigateTo(string tag, string? originTag)
+    {
+        _pendingNavigationOrigin = originTag;
+        NavigateInternal(NormalizeNavTag(tag));
+    }
+
+    private string NormalizeNavTag(string tag)
     {
         // Map legacy tags — Home page was retired in favor of the Lobby/Cockpit
         // layout on Connection. Any caller still using "home" or "general"
         // (deep links, persisted nav state, command palette) lands here.
-        if (tag == "home" || tag == "general") tag = "connection";
-        if (tag == "about") tag = "info";
-        if (tag == "nodes") tag = "instances";
+        if (tag == "home" || tag == "general") return "connection";
+        if (tag == "about") return "info";
+        if (tag == "nodes") return "instances";
         // Map legacy agent-scoped workspace/cron tags
-        if (tag == "cron") tag = $"agent:{_currentAgentId}:cron";
-        if (tag == "workspace") tag = $"agent:{_currentAgentId}:workspace";
-
-        // Search all nav items including nested
-        if (FindAndSelectNavItem(NavView.MenuItems, tag)) return;
-        if (FindAndSelectNavItem(NavView.FooterMenuItems, tag)) return;
-
-        // Fallback: navigate directly
-        if (tag.StartsWith("agent:")) { _currentAgentId = ParseAgentIdFromTag(tag); _cachedCommands = null; }
-        var pageType = TagToPageType(tag);
-        if (pageType != null)
-        {
-            ContentFrame.Navigate(pageType);
-            InitializeCurrentPage();
-        }
+        if (tag == "cron") return $"agent:{_currentAgentId}:cron";
+        if (tag == "workspace") return $"agent:{_currentAgentId}:workspace";
+        return tag;
     }
 
-    private bool FindAndSelectNavItem(IList<object> items, string tag)
+    private void NavigateInternal(string tag)
     {
-        foreach (var item in items)
+        var pageType = TagToPageType(tag);
+        if (pageType == null)
         {
-            if (item is NavigationViewItem navItem)
+            // Unknown tag: nothing to navigate, but we still need to discard
+            // any pending origin so it doesn't leak into the next real
+            // navigation (where it would surface a wrong "Back to ..." link).
+            _pendingNavigationOrigin = null;
+            return;
+        }
+
+        // Identity dedupe: navigation identity = (PageType, normalized tag).
+        // Page-type-only dedupe would collapse distinct logical destinations
+        // that share a Page (e.g. agent switching on WorkspacePage), and
+        // would also push duplicate back-stack entries when the user
+        // re-invokes the current page.
+        if (ContentFrame.SourcePageType == pageType && _currentNavTag == tag)
+        {
+            // Same as above: Frame.Navigate is skipped, so
+            // OnContentFrameNavigated won't run to consume the origin.
+            // Clear it here to avoid stale-origin leakage on the next nav.
+            _pendingNavigationOrigin = null;
+            return;
+        }
+
+        // Best-effort rail highlight. Suppress the selection-changed callback
+        // so this programmatic update doesn't re-enter NavigateInternal.
+        var item = FindNavItemForTag(NavView.MenuItems, tag)
+                ?? FindNavItemForTag(NavView.FooterMenuItems, tag);
+        if (item != null && !ReferenceEquals(NavView.SelectedItem, item))
+        {
+            _syncingNavSelection = true;
+            try { NavView.SelectedItem = item; }
+            finally { _syncingNavSelection = false; }
+        }
+
+        // Pass the tag as the navigation parameter so OnContentFrameNavigated
+        // can recover the canonical destination on Back/Forward.
+        ContentFrame.Navigate(pageType, tag);
+    }
+
+    private static NavigationViewItem? FindNavItemForTag(IList<object> items, string tag)
+    {
+        foreach (var raw in items)
+        {
+            if (raw is NavigationViewItem item)
             {
-                if (navItem.Tag as string == tag) { NavView.SelectedItem = navItem; return true; }
-                if (navItem.MenuItems.Count > 0 && FindAndSelectNavItem(navItem.MenuItems, tag))
+                if ((item.Tag as string) == tag) return item;
+                if (item.MenuItems.Count > 0)
                 {
-                    navItem.IsExpanded = true;
-                    return true;
+                    var nested = FindNavItemForTag(item.MenuItems, tag);
+                    if (nested != null)
+                    {
+                        // Expand parent so the user can see the selected child.
+                        item.IsExpanded = true;
+                        return nested;
+                    }
                 }
             }
         }
-        return false;
+        return null;
     }
 
     public void UpdateStatus(ConnectionStatus status)
@@ -639,18 +715,44 @@ public sealed partial class HubWindow : WindowEx
 
     private void NavView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
     {
-        if (args.SelectedItem is NavigationViewItem item)
+        // Skip when the selection was set programmatically by
+        // OnContentFrameNavigated reflecting a Back/Forward — the page
+        // is already showing and re-running NavigateInternal would push
+        // a duplicate back-stack entry.
+        if (_syncingNavSelection) return;
+
+        if (args.SelectedItem is NavigationViewItem item && item.Tag is string tag)
         {
-            var tag = item.Tag as string;
-            if (tag?.StartsWith("agent:") == true)
-            { _currentAgentId = ParseAgentIdFromTag(tag); _cachedCommands = null; }
-            var pageType = TagToPageType(tag);
-            if (pageType != null)
+            NavigateInternal(NormalizeNavTag(tag));
+        }
+    }
+
+    /// <summary>
+    /// Authoritative post-navigation hook. Runs for every successful
+    /// Frame.Navigate, so it's the single place that rebuilds
+    /// <see cref="_currentNavTag"/> / <see cref="_currentAgentId"/> /
+    /// <see cref="LastNavigationOrigin"/> and re-runs
+    /// <see cref="InitializeCurrentPage"/> for the page that's now visible.
+    /// </summary>
+    private void OnContentFrameNavigated(object sender, Microsoft.UI.Xaml.Navigation.NavigationEventArgs e)
+    {
+        var tag = e.Parameter as string;
+        _currentNavTag = tag;
+        LastNavigationOrigin = _pendingNavigationOrigin;
+        _pendingNavigationOrigin = null;
+
+        // Keep _currentAgentId aligned with the page that's now visible.
+        if (tag != null && tag.StartsWith("agent:"))
+        {
+            var newAgent = ParseAgentIdFromTag(tag);
+            if (newAgent != _currentAgentId)
             {
-                ContentFrame.Navigate(pageType);
-                InitializeCurrentPage();
+                _currentAgentId = newAgent;
+                _cachedCommands = null;
             }
         }
+
+        InitializeCurrentPage();
     }
 
     /// <summary>
@@ -719,9 +821,13 @@ public sealed partial class HubWindow : WindowEx
             case AgentEventsPage agentEvents:
                 agentEvents.ClearCentralCache = ClearAgentEvents;
                 agentEvents.PopulateAgentFilter(this);
-                // When navigated via top-level nav (tag "agentevents"), show all agents
-                var agentEventsTag = (NavView?.SelectedItem as NavigationViewItem)?.Tag as string;
-                var eventsAgentFilter = agentEventsTag?.StartsWith("agent:") == true ? _currentAgentId : null;
+                // When navigated via top-level nav (tag "agentevents") show all
+                // agents; when reached via an agent-scoped tag (e.g.
+                // "agent:main:agentevents") scope to that agent. Reading
+                // _currentNavTag (set by OnContentFrameNavigated) is more
+                // reliable than peeking NavView.SelectedItem, which may briefly
+                // disagree during Back/Forward.
+                var eventsAgentFilter = _currentNavTag?.StartsWith("agent:") == true ? _currentAgentId : null;
                 agentEvents.SetAgentFilter(eventsAgentFilter);
                 if (agentEvents.EventCount == 0 && LastAgentEvents != null)
                 {

--- a/tests/OpenClaw.Tray.Tests/ConnectionPageApproveCommandTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ConnectionPageApproveCommandTests.cs
@@ -32,6 +32,8 @@ public sealed class ConnectionPageApproveCommandTests
         if (!string.IsNullOrWhiteSpace(env) && Directory.Exists(env))
             return env;
 
+        // Walk up from the test binary location until we hit the solution
+        // file. Works for `dotnet test` and IDE runs out of the box.
         var directory = new DirectoryInfo(AppContext.BaseDirectory);
         while (directory != null)
         {
@@ -44,20 +46,56 @@ public sealed class ConnectionPageApproveCommandTests
             directory = directory.Parent;
         }
 
+        // CI artifact-copy fallback: this test file is colocated with other
+        // tests under tests/OpenClaw.Tray.Tests; AppContext.BaseDirectory in
+        // those layouts points at a copied bin folder that does not include
+        // the solution file. As a last resort, inspect the source-file path
+        // baked into this assembly's debug info via [CallerFilePath] — we
+        // captured it at compile time below — and walk up from there.
+        var callerFile = ThisFile.Path;
+        if (!string.IsNullOrEmpty(callerFile) && File.Exists(callerFile))
+        {
+            var probe = new DirectoryInfo(Path.GetDirectoryName(callerFile)!);
+            while (probe != null)
+            {
+                if (File.Exists(Path.Combine(probe.FullName, "openclaw-windows-node.slnx")) &&
+                    Directory.Exists(Path.Combine(probe.FullName, "src")))
+                {
+                    return probe.FullName;
+                }
+                probe = probe.Parent;
+            }
+        }
+
         throw new InvalidOperationException(
             "Could not find repository root. Set OPENCLAW_REPO_ROOT to the repo path.");
+    }
+
+    // Captures this test file's source path at compile time so the test can
+    // locate the repo even when run from a copied artifact layout where
+    // AppContext.BaseDirectory has no ancestor containing the .slnx.
+    private static class ThisFile
+    {
+        public static readonly string Path = Capture();
+        private static string Capture([System.Runtime.CompilerServices.CallerFilePath] string filePath = "")
+            => filePath;
     }
 
     [Fact]
     public void NodeApproveCommand_UsesNounFirstSubcommand()
     {
         var src = ReadPlanSource();
-        // The active emission must be the noun-first form. Asserting the
-        // exact interpolated literal pins both the command path and the
-        // placement of the request id.
-        Assert.Contains("$\"openclaw nodes approve {reqId}\"", src);
-        // And the legacy broken form must not return as an *emitted* string —
-        // we check for the interpolated/quoted variants, not the bare phrase,
+        // Pin the noun-first command prefix rather than the full
+        // interpolated literal — this stays correct if someone renames
+        // the local variable from `reqId` to `requestId`, switches to
+        // `string.Format`, or extracts the literal to a constant.
+        AssertContainsCli(
+            src,
+            "openclaw nodes approve ",
+            "BuildNodeApproveCommand must emit noun-first `openclaw nodes approve <id>`; the verb-first form (`openclaw approve node`) silently failed when pasted.");
+
+        // The legacy broken form must not return as an *emitted* string —
+        // check the interpolated/quoted variants, not the bare phrase,
         // because the explanatory comment also names the legacy command.
         Assert.DoesNotContain("$\"openclaw approve node {reqId}\"", src);
         Assert.DoesNotContain("\"openclaw approve node\"", src);
@@ -67,25 +105,91 @@ public sealed class ConnectionPageApproveCommandTests
     public void DevicesApproveCommand_UsesNounFirstSubcommand()
     {
         var src = ReadPlanSource();
-        Assert.Contains("$\"openclaw devices approve {reqId}\"", src);
+        AssertContainsCli(
+            src,
+            "openclaw devices approve ",
+            "BuildDevicePairingApproveCommand must emit noun-first `openclaw devices approve <id>`; the verb-first form (`openclaw approve device`) silently failed when pasted.");
+
         Assert.DoesNotContain("$\"openclaw approve device {reqId}\"", src);
         Assert.DoesNotContain("\"openclaw approve device\"", src);
     }
 
     [Fact]
-    public void MissingRequestId_EmitsDiscoveryHint_NotBareApprove()
+    public void MissingRequestId_EmitsShellSafeDiscoveryCommand_NotBareApprove()
     {
         // CLI's approve subcommands require a <requestId> positional. A bare
         // `openclaw nodes approve` / `openclaw devices approve` exits
         // non-zero with "missing required argument", so the user-facing
         // fallback must lead with a discovery command instead.
         var src = ReadPlanSource();
-        Assert.Contains("openclaw nodes pending", src);
-        Assert.Contains("openclaw devices list", src);
+        AssertContainsCli(src, "openclaw nodes pending",
+            "Missing-requestId fallback for node pairing must emit `openclaw nodes pending` (a shell-safe discovery command).");
+        AssertContainsCli(src, "openclaw devices list",
+            "Missing-requestId fallback for device pairing must emit `openclaw devices list` (a shell-safe discovery command).");
+
         // Defense in depth: assert there's no bare end-of-string approve
         // literal (which would be the broken legacy fallback).
         Assert.DoesNotContain("\"openclaw nodes approve\"", src);
         Assert.DoesNotContain("\"openclaw devices approve\"", src);
+
+        // And the clipboard text must not contain shell-hostile syntax
+        // for the fallback path. `#` is parsed as a literal arg by
+        // cmd.exe; `<requestId>` is parsed as input redirection. Either
+        // would break the paste-and-run flow for Windows-cmd users.
+        // We only check inside the two emission helpers, not the whole
+        // file, because comments explaining the rationale legitimately
+        // mention these characters.
+        var nodeBody = ExtractMethodBody(src, "BuildNodeApproveCommand");
+        var devBody = ExtractMethodBody(src, "BuildDevicePairingApproveCommand");
+        AssertNoShellHostileChars(nodeBody, nameof(nodeBody));
+        AssertNoShellHostileChars(devBody, nameof(devBody));
+    }
+
+    private static void AssertContainsCli(string source, string expected, string message)
+    {
+        if (!source.Contains(expected, System.StringComparison.Ordinal))
+            Assert.Fail($"Expected source to contain `{expected}`. {message}");
+    }
+
+    private static void AssertNoShellHostileChars(string methodBody, string methodLabel)
+    {
+        // Scan only string literals inside the method body — comments
+        // legitimately reference `#` and `<` while explaining the rationale.
+        foreach (System.Text.RegularExpressions.Match m in System.Text.RegularExpressions.Regex.Matches(
+            methodBody, "\\$?\"[^\"\\n]*\""))
+        {
+            var literal = m.Value;
+            // Allow `<` and `#` only when not embedded inside an interpolation
+            // hole (which we strip first so `{reqId}` etc. don't trigger).
+            var stripped = System.Text.RegularExpressions.Regex.Replace(literal, "\\{[^}]*\\}", "");
+            if (stripped.Contains('#') || stripped.Contains('<') || stripped.Contains('>'))
+                Assert.Fail(
+                    $"String literal in {methodLabel} contains shell-hostile char(s): `{literal}`. " +
+                    "cmd.exe parses `#` as a literal arg and `<`/`>` as I/O redirection — pasting the " +
+                    "copied text into cmd will fail. Use a single command without comment/redirect chars.");
+        }
+    }
+
+    private static string ExtractMethodBody(string source, string methodName)
+    {
+        // Coarse extractor: from the method signature to the matching closing
+        // brace at the same indentation. Sufficient for short pure helpers
+        // like BuildNodeApproveCommand / BuildDevicePairingApproveCommand.
+        var sigIndex = source.IndexOf(methodName + "(", System.StringComparison.Ordinal);
+        if (sigIndex < 0) return string.Empty;
+        var bodyStart = source.IndexOf('{', sigIndex);
+        if (bodyStart < 0) return string.Empty;
+        int depth = 0;
+        for (int i = bodyStart; i < source.Length; i++)
+        {
+            if (source[i] == '{') depth++;
+            else if (source[i] == '}')
+            {
+                depth--;
+                if (depth == 0) return source.Substring(bodyStart, i - bodyStart + 1);
+            }
+        }
+        return source.Substring(bodyStart);
     }
 }
 

--- a/tests/OpenClaw.Tray.Tests/ConnectionPageApproveCommandTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ConnectionPageApproveCommandTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+
+namespace OpenClaw.Tray.Tests;
+
+/// <summary>
+/// Pins the CLI approve commands emitted by <c>ConnectionPagePlan</c>. The
+/// OpenClaw CLI registers approve as a noun-first subcommand
+/// (<c>openclaw nodes approve &lt;requestId&gt;</c> and
+/// <c>openclaw devices approve &lt;requestId&gt;</c>). The previous verb-first
+/// strings (<c>openclaw approve node …</c>) silently failed when users
+/// pasted them on the gateway host, so this test guards against regressing
+/// back to that broken form.
+///
+/// Source-parsed for the same reason as <c>FluentIconCatalogTests</c>:
+/// <c>OpenClaw.Tray.Tests</c> is a pure net10.0 project that does not
+/// reference the WinUI tray assembly.
+/// </summary>
+public sealed class ConnectionPageApproveCommandTests
+{
+    private static string ReadPlanSource()
+    {
+        var path = Path.Combine(
+            GetRepositoryRoot(),
+            "src", "OpenClaw.Tray.WinUI", "Pages", "ConnectionPagePlan.cs");
+        return File.ReadAllText(path);
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        var env = Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT");
+        if (!string.IsNullOrWhiteSpace(env) && Directory.Exists(env))
+            return env;
+
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "openclaw-windows-node.slnx")) &&
+                Directory.Exists(Path.Combine(directory.FullName, "src")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException(
+            "Could not find repository root. Set OPENCLAW_REPO_ROOT to the repo path.");
+    }
+
+    [Fact]
+    public void NodeApproveCommand_UsesNounFirstSubcommand()
+    {
+        var src = ReadPlanSource();
+        // The active emission must be the noun-first form. Asserting the
+        // exact interpolated literal pins both the command path and the
+        // placement of the request id.
+        Assert.Contains("$\"openclaw nodes approve {reqId}\"", src);
+        // And the legacy broken form must not return as an *emitted* string —
+        // we check for the interpolated/quoted variants, not the bare phrase,
+        // because the explanatory comment also names the legacy command.
+        Assert.DoesNotContain("$\"openclaw approve node {reqId}\"", src);
+        Assert.DoesNotContain("\"openclaw approve node\"", src);
+    }
+
+    [Fact]
+    public void DevicesApproveCommand_UsesNounFirstSubcommand()
+    {
+        var src = ReadPlanSource();
+        Assert.Contains("$\"openclaw devices approve {reqId}\"", src);
+        Assert.DoesNotContain("$\"openclaw approve device {reqId}\"", src);
+        Assert.DoesNotContain("\"openclaw approve device\"", src);
+    }
+
+    [Fact]
+    public void MissingRequestId_EmitsDiscoveryHint_NotBareApprove()
+    {
+        // CLI's approve subcommands require a <requestId> positional. A bare
+        // `openclaw nodes approve` / `openclaw devices approve` exits
+        // non-zero with "missing required argument", so the user-facing
+        // fallback must lead with a discovery command instead.
+        var src = ReadPlanSource();
+        Assert.Contains("openclaw nodes pending", src);
+        Assert.Contains("openclaw devices list", src);
+        // Defense in depth: assert there's no bare end-of-string approve
+        // literal (which would be the broken legacy fallback).
+        Assert.DoesNotContain("\"openclaw nodes approve\"", src);
+        Assert.DoesNotContain("\"openclaw devices approve\"", src);
+    }
+}
+

--- a/tests/OpenClaw.Tray.Tests/ConnectionPageChannelMetricsTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ConnectionPageChannelMetricsTests.cs
@@ -1,0 +1,96 @@
+using OpenClaw.Shared;
+using OpenClawTray.Pages;
+
+namespace OpenClaw.Tray.Tests;
+
+/// <summary>
+/// Behavior tests for the Connection page channel-count chip. Guards the
+/// regression where one running channel rendered as "0/1" yellow because
+/// the chip required <c>IsLinked == true</c> AND a narrower healthy-status
+/// whitelist than the canonical <see cref="ChannelHealth.IsHealthyStatus"/>.
+/// </summary>
+public sealed class ConnectionPageChannelMetricsTests
+{
+    [Fact]
+    public void Null_ReturnsZero()
+    {
+        Assert.Equal(0, ConnectionPageChannelMetrics.CountHealthyChannels(null));
+    }
+
+    [Fact]
+    public void Empty_ReturnsZero()
+    {
+        Assert.Equal(0, ConnectionPageChannelMetrics.CountHealthyChannels(System.Array.Empty<ChannelHealth>()));
+    }
+
+    [Theory]
+    [InlineData("ok")]
+    [InlineData("connected")]
+    [InlineData("running")]
+    [InlineData("active")]
+    [InlineData("ready")]
+    public void HealthyStatuses_AreCounted_RegardlessOfIsLinked(string status)
+    {
+        // The chip used to require IsLinked=true. Several channel types are
+        // functional without an OAuth-style "linked" flag, so excluding them
+        // produced "0/1 channels" yellow on a perfectly happy gateway.
+        var channels = new[]
+        {
+            new ChannelHealth { Name = "ch", Status = status, IsLinked = false },
+        };
+
+        Assert.Equal(1, ConnectionPageChannelMetrics.CountHealthyChannels(channels));
+    }
+
+    [Theory]
+    [InlineData("error")]
+    [InlineData("disconnected")]
+    [InlineData("stale")]
+    [InlineData("stopped")]
+    [InlineData("configured")]
+    [InlineData("not configured")]
+    [InlineData("connecting")]
+    [InlineData("reconnecting")]
+    [InlineData("pending")]
+    [InlineData("idle")]
+    [InlineData("paused")]
+    public void NonHealthyStatuses_AreNotCounted(string status)
+    {
+        var channels = new[]
+        {
+            new ChannelHealth { Name = "ch", Status = status, IsLinked = true },
+        };
+
+        Assert.Equal(0, ConnectionPageChannelMetrics.CountHealthyChannels(channels));
+    }
+
+    [Fact]
+    public void MixedSet_CountsOnlyHealthy()
+    {
+        // Real-world snapshot the chip used to mishandle: one running
+        // channel (linked=false) + one stopped + one error → expect 1.
+        var channels = new[]
+        {
+            new ChannelHealth { Name = "telegram", Status = "running", IsLinked = false },
+            new ChannelHealth { Name = "discord",  Status = "stopped", IsLinked = true },
+            new ChannelHealth { Name = "slack",    Status = "error",   IsLinked = true,  Error = "auth expired" },
+        };
+
+        Assert.Equal(1, ConnectionPageChannelMetrics.CountHealthyChannels(channels));
+    }
+
+    [Fact]
+    public void StatusComparison_IsCaseInsensitive()
+    {
+        // Matches ChannelHealth.IsHealthyStatus semantics: status strings come
+        // from gateway JSON and casing varies in the wild.
+        var channels = new[]
+        {
+            new ChannelHealth { Name = "a", Status = "READY",   IsLinked = false },
+            new ChannelHealth { Name = "b", Status = "Running", IsLinked = false },
+            new ChannelHealth { Name = "c", Status = "OK",      IsLinked = true  },
+        };
+
+        Assert.Equal(3, ConnectionPageChannelMetrics.CountHealthyChannels(channels));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/ConnectionPageRowStateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ConnectionPageRowStateTests.cs
@@ -18,7 +18,6 @@ public sealed class ConnectionPageRowStateTests
     [InlineData(OverallConnectionState.Degraded)]
     [InlineData(OverallConnectionState.Connecting)]
     [InlineData(OverallConnectionState.PairingRequired)]
-    [InlineData(OverallConnectionState.Error)]
     public void CanDisconnectFromBadge_TrueForLiveAndPendingStates(OverallConnectionState state)
     {
         Assert.True(ConnectionPageRowState.CanDisconnectFromBadge(state),
@@ -43,6 +42,17 @@ public sealed class ConnectionPageRowStateTests
             "Idle rows render [Connect]; Disconnect is meaningless.");
     }
 
+    [Fact]
+    public void CanDisconnectFromBadge_FalseInErrorState()
+    {
+        // In Error the row renders [Connect] so the user can retry. The
+        // status strip up top already shouts "Can't reach gateway" and
+        // the Recovery card right beneath it offers Disconnect — adding
+        // it to the row overflow too would duplicate the action.
+        Assert.False(ConnectionPageRowState.CanDisconnectFromBadge(OverallConnectionState.Error),
+            "Error rows render [Connect]; Disconnect lives on the Recovery card above.");
+    }
+
     [Theory]
     [InlineData(OverallConnectionState.Connected)]
     [InlineData(OverallConnectionState.Ready)]
@@ -50,12 +60,8 @@ public sealed class ConnectionPageRowStateTests
     [InlineData(OverallConnectionState.Connecting)]
     [InlineData(OverallConnectionState.PairingRequired)]
     [InlineData(OverallConnectionState.Disconnecting)]
-    [InlineData(OverallConnectionState.Error)]
-    public void HasActiveRowBadge_TrueForNonIdleStates(OverallConnectionState state)
+    public void HasActiveRowBadge_TrueForLiveAndTransientStates(OverallConnectionState state)
     {
-        // The Error case is the regression added in this commit pass: an
-        // active row in Error used to render [Connect] indistinguishably
-        // from an inactive row, hiding the failure.
         Assert.True(ConnectionPageRowState.HasActiveRowBadge(state),
             $"{state} should render a status badge so the user can see the live state.");
     }
@@ -64,6 +70,17 @@ public sealed class ConnectionPageRowStateTests
     public void HasActiveRowBadge_FalseWhenIdle()
     {
         Assert.False(ConnectionPageRowState.HasActiveRowBadge(OverallConnectionState.Idle),
-            "Idle is the only state without a badge — the row falls back to [Connect].");
+            "Idle has no live connection — the row falls back to [Connect].");
+    }
+
+    [Fact]
+    public void HasActiveRowBadge_FalseInErrorState()
+    {
+        // Error explicitly falls back to [Connect] so the user has an
+        // actionable retry per gateway. The strip + Recovery card up top
+        // already carry the failure signal; the row should be the action
+        // surface, not a redundant status surface.
+        Assert.False(ConnectionPageRowState.HasActiveRowBadge(OverallConnectionState.Error),
+            "Error rows render [Connect] so the user can explicitly retry.");
     }
 }

--- a/tests/OpenClaw.Tray.Tests/ConnectionPageRowStateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ConnectionPageRowStateTests.cs
@@ -1,0 +1,69 @@
+using OpenClaw.Connection;
+using OpenClawTray.Pages;
+
+namespace OpenClaw.Tray.Tests;
+
+/// <summary>
+/// Behavior tests for the saved-gateway row state predicates. These guard
+/// the regression where the overflow menu offered Disconnect during
+/// Disconnecting (re-entering teardown), and the related cleanup that
+/// gave the active row a proper Error badge instead of dropping back to
+/// [Connect] indistinguishably from inactive rows.
+/// </summary>
+public sealed class ConnectionPageRowStateTests
+{
+    [Theory]
+    [InlineData(OverallConnectionState.Connected)]
+    [InlineData(OverallConnectionState.Ready)]
+    [InlineData(OverallConnectionState.Degraded)]
+    [InlineData(OverallConnectionState.Connecting)]
+    [InlineData(OverallConnectionState.PairingRequired)]
+    [InlineData(OverallConnectionState.Error)]
+    public void CanDisconnectFromBadge_TrueForLiveAndPendingStates(OverallConnectionState state)
+    {
+        Assert.True(ConnectionPageRowState.CanDisconnectFromBadge(state),
+            $"{state} should expose Disconnect (state has a live/pending connection to tear down).");
+    }
+
+    [Fact]
+    public void CanDisconnectFromBadge_FalseWhileDisconnecting()
+    {
+        // Disconnecting is the exact state that USED to receive Disconnect
+        // and race the connection manager — this is the regression guard.
+        Assert.False(ConnectionPageRowState.CanDisconnectFromBadge(OverallConnectionState.Disconnecting),
+            "Disconnecting must NOT offer Disconnect — teardown is already in flight.");
+    }
+
+    [Fact]
+    public void CanDisconnectFromBadge_FalseWhenIdle()
+    {
+        // Idle rows render [Connect], not a badge — there's nothing to
+        // disconnect from.
+        Assert.False(ConnectionPageRowState.CanDisconnectFromBadge(OverallConnectionState.Idle),
+            "Idle rows render [Connect]; Disconnect is meaningless.");
+    }
+
+    [Theory]
+    [InlineData(OverallConnectionState.Connected)]
+    [InlineData(OverallConnectionState.Ready)]
+    [InlineData(OverallConnectionState.Degraded)]
+    [InlineData(OverallConnectionState.Connecting)]
+    [InlineData(OverallConnectionState.PairingRequired)]
+    [InlineData(OverallConnectionState.Disconnecting)]
+    [InlineData(OverallConnectionState.Error)]
+    public void HasActiveRowBadge_TrueForNonIdleStates(OverallConnectionState state)
+    {
+        // The Error case is the regression added in this commit pass: an
+        // active row in Error used to render [Connect] indistinguishably
+        // from an inactive row, hiding the failure.
+        Assert.True(ConnectionPageRowState.HasActiveRowBadge(state),
+            $"{state} should render a status badge so the user can see the live state.");
+    }
+
+    [Fact]
+    public void HasActiveRowBadge_FalseWhenIdle()
+    {
+        Assert.False(ConnectionPageRowState.HasActiveRowBadge(OverallConnectionState.Idle),
+            "Idle is the only state without a badge — the row falls back to [Connect].");
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/FluentIconCatalogTests.cs
+++ b/tests/OpenClaw.Tray.Tests/FluentIconCatalogTests.cs
@@ -256,14 +256,18 @@ public sealed class TrayMenuPopupCompositionTests
     {
         var src = ReadHubWindowXaml();
 
-        var aliasIndex = src.IndexOf("if (tag == \"nodes\") tag = \"instances\";", StringComparison.Ordinal);
-        var selectIndex = src.IndexOf("FindAndSelectNavItem(NavView.MenuItems, tag)", StringComparison.Ordinal);
+        // Legacy "nodes" deep links must still land on the Instances rail
+        // item. The normalization rule lives in NormalizeNavTag, which
+        // NavigateTo applies before handing the tag to NavigateInternal
+        // (which is what actually highlights the rail item via
+        // FindNavItemForTag and calls Frame.Navigate).
+        var aliasIndex = src.IndexOf("if (tag == \"nodes\") return \"instances\";", StringComparison.Ordinal);
+        var funnelIndex = src.IndexOf("NavigateInternal(NormalizeNavTag(tag))", StringComparison.Ordinal);
+        var selectIndex = src.IndexOf("FindNavItemForTag(NavView.MenuItems, tag)", StringComparison.Ordinal);
 
-        Assert.True(aliasIndex >= 0, "NavigateTo must keep legacy nodes deep links working.");
-        Assert.True(selectIndex >= 0, "NavigateTo must select a nav item before falling back to direct navigation.");
-        Assert.True(
-            aliasIndex < selectIndex,
-            "Legacy nodes tag must be normalized before nav item selection so the Instances item is highlighted.");
+        Assert.True(aliasIndex >= 0, "NormalizeNavTag must keep legacy 'nodes' deep links pointing at 'instances'.");
+        Assert.True(funnelIndex >= 0, "NavigateTo must normalize the tag before routing through NavigateInternal.");
+        Assert.True(selectIndex >= 0, "NavigateInternal must select a nav item by tag before falling back to direct navigation.");
     }
 
     private static string GetRepositoryRoot()

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Onboarding\Services\WizardFlowController.cs" Link="Imported\WizardFlowController.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Dialogs\QuickSendCoordinator.cs" Link="Imported\QuickSendCoordinator.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Pages\ConnectionPageChannelMetrics.cs" Link="Imported\ConnectionPageChannelMetrics.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Pages\ConnectionPageRowState.cs" Link="Imported\ConnectionPageRowState.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Onboarding\Services\WizardStepSelection.cs" Link="Imported\WizardStepSelection.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Onboarding\Services\WizardFlowController.cs" Link="Imported\WizardFlowController.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Dialogs\QuickSendCoordinator.cs" Link="Imported\QuickSendCoordinator.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Pages\ConnectionPageChannelMetrics.cs" Link="Imported\ConnectionPageChannelMetrics.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Polish pass over the rebuilt `ConnectionPage` (#418) — four user-visible bugs + Fluent guideline cleanup.

## Bugs fixed

- **Pairing approve command didn't work.** Code emitted verb-first `openclaw approve node <id>` which the CLI silently rejects. Now noun-first: `openclaw nodes approve <id>` / `openclaw devices approve <id>`. Missing-id fallback emits a single shell-safe discovery command.
- **Channels chip showed `0/1` yellow** when a single channel was healthy. Chip required `IsLinked` AND a narrower healthy whitelist than `ChannelHealth.IsHealthyStatus`; `running` / `active` weren't counted. Now uses the canonical predicate, drops the `IsLinked` gate.
- **Active gateway row said "Connected"** while the strip up top said "Connecting…" / "Awaiting approval". New `BuildActiveRowBadge` maps each `OverallConnectionState` to the correct (glyph, brush, label). `Error` deliberately falls back to `[Connect]` so the user can explicitly retry with the URL visible — the strip + Recovery card already carry the failure status.
- **Loud red strip CTAs** ("Copy command", "Re-pair") duplicated the inline `RecoveryApproveCmdBlock` Copy button and the `RecoveryAuthPasteBlock` paste-and-Apply affordance. Both removed; `StripPrimaryButton` drops `AccentButtonStyle` so the surviving `RestartTunnel` / `Retry` cases stop reading red.

## Fluent guideline cleanup

- Per-row `Approve`/`Deny` in the pending-pair lists no longer use `AccentButtonStyle` (violated "one accent per view" when multiple requests stacked). Plain `Button` + leading `Check` / `Exit` glyphs in success / critical brushes via new `BuildPairingDecisionButton` helper. The outer `PendingApprovalsBanner` (caution-yellow + bold count + `LiveSetting=Polite`) already carries page-level attention.
- `RecoveryAuthPasteBlock` `Apply` drops `AccentButtonStyle` for parity with `AddSaveButton` `Save & connect`.
- Active-row badge sets `AutomationProperties.Name` + `LiveSetting=Polite` so screen readers re-announce on state transitions.

## Robustness

- `Disconnecting` no longer offers `Disconnect` in the overflow (was re-entering teardown).
- Node-pair `Approve`/`Deny` now call `RequestNodePairListAsync` on success (symmetric with device-pair). Both flows go through a shared `RunPairingDecisionAsync` with an 8s `DispatcherTimer` watchdog so a dropped websocket frame can't leave the buttons permanently disabled.
- Inline Copy buttons gain `ToolTipService.ToolTip` + `AutomationProperties.Name`.

## Tests

New: `ConnectionPageChannelMetricsTests`, `ConnectionPageApproveCommandTests` (with a shell-safety scan that fails on `#` / `<` / `>` in emission method bodies), `ConnectionPageRowStateTests`. **+26 new tests**, all behavior-level where possible (pure helpers extracted to `ConnectionPageChannelMetrics.cs` and `ConnectionPageRowState.cs` so the net10.0 test project can link them).

## Validation

- `./build.ps1` — all projects green.
- `dotnet test OpenClaw.Shared.Tests` — **1620 passed**, 28 skipped (unchanged baseline).
- `dotnet test OpenClaw.Tray.Tests` — **992 passed** (was 966; +26 new).

## Review

Cross-referenced with the Hanselman dual-model review (Claude Opus 4.6 + GPT-5.2-codex). All 5 HIGH-consensus findings addressed; one LOW-consensus design-call (Error row badge vs `[Connect]` retry button) was deliberately reverted after user UX feedback — the strip + Recovery card already carry the failure status, and `[Connect]` is more actionable.

---

## Follow-up: "Back to Connection" inline link (9c9f705)

Connection's cross-page links (**Open Sessions** / **Open Instances** / **Open Permissions**) were one-way trips. Adds a small **"← Back to Connection"** `HyperlinkButton` at the top of each destination page, **only visible when the user actually arrived via one of those links** — staying hidden when the user navigates via the rail keeps the chrome quiet for direct navigation. Chosen over a chrome `NavigationView.IsBackButtonVisible` back arrow (which felt visually noisy and redundant with the rail) per the [WinUI backwards-navigation guidance](https://learn.microsoft.com/en-us/windows/apps/design/controls/navigationview#backwards-navigation) trade-offs.

**Plumbing.** New `HubWindow.NavigateTo(string tag, string? originTag)` overload stashes the origin in `_pendingNavigationOrigin`, consumed once by a new `Frame.Navigated` handler and surfaced as `HubWindow.LastNavigationOrigin` for the destination's `Initialize()`. The navigation funnel is also refactored: `NavigateTo` → `NormalizeNavTag` → `NavigateInternal` → `Frame.Navigate(pageType, tag)`, so navigation identity is `(PageType, normalized tag)` rather than just `PageType` — necessary because agent-scoped pages (e.g. `agent:main:sessions`) and top-level (`sessions`) tags both map to `SessionsPage`. `OnContentFrameNavigated` becomes the single post-nav dispatcher (updates `_currentNavTag` / `_currentAgentId` / `LastNavigationOrigin` and re-runs `InitializeCurrentPage()` exactly once).

**Hanselman dual-model review (Opus + Codex).** Both models flagged a HIGH-severity origin leak: `_pendingNavigationOrigin` wasn't cleared on `NavigateInternal` early-return paths (dedupe or unknown tag), so a later unrelated navigation could inherit a stale origin and surface a wrong back link. Fixed by clearing the field in both early-return branches.

**Validation.** `./build.ps1` ✅ · `Shared.Tests` 1620 passed / 28 skipped · `Tray.Tests` 1001 passed.
