### PR TITLE
refactor: remove AppDispatcherQueue and move AppLogger to its own file

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -4145,16 +4145,5 @@ public partial class App : Application
             }
         }
     }
-
-    private Microsoft.UI.Dispatching.DispatcherQueue? AppDispatcherQueue =>
-        Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
 }
 
-internal class AppLogger : IOpenClawLogger
-{
-    public void Info(string message) => Logger.Info(message);
-    public void Debug(string message) => Logger.Debug(message);
-    public void Warn(string message) => Logger.Warn(message);
-    public void Error(string message, Exception? ex = null) => 
-        Logger.Error(ex != null ? $"{message}: {ex.Message}" : message);
-}

--- a/src/OpenClaw.Tray.WinUI/AppLogger.cs
+++ b/src/OpenClaw.Tray.WinUI/AppLogger.cs
@@ -1,0 +1,13 @@
+using OpenClaw.Shared;
+using OpenClawTray.Services;
+
+namespace OpenClawTray;
+
+internal sealed class AppLogger : IOpenClawLogger
+{
+    public void Info(string message) => Logger.Info(message);
+    public void Debug(string message) => Logger.Debug(message);
+    public void Warn(string message) => Logger.Warn(message);
+    public void Error(string message, Exception? ex = null) =>
+        Logger.Error(ex != null ? $"{message}: {ex.Message}" : message);
+}


### PR DESCRIPTION
## Summary
Two small cleanups in App.xaml.cs, both with zero behavior change.

`AppDispatcherQueue` was a private property wrapping `DispatcherQueue.GetForCurrentThread()`
with no callers anywhere in the codebase. `AppLogger` was an internal class nested at the
bottom of App.xaml.cs; it now lives in its own file in the same namespace, which is the
natural place for it.

## What changed
- Removed `AppDispatcherQueue` (private property, zero callers confirmed via grep)
- Moved `AppLogger` to `src/OpenClaw.Tray.WinUI/AppLogger.cs` (same namespace, added `sealed`)

## Testing
- `dotnet build src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj -r win-x64 --nologo` — green
- `dotnet test tests/OpenClaw.Tray.Tests --nologo` — green

## Notes
`AppLogger` has 21 call sites across four files; all resolve without changes because
`internal` is assembly-scoped and the namespace is unchanged.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>