### PR TITLE
feat(wizard): three QoL polish fixes to gateway wizard

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Onboarding/GatewayWizard/GatewayWizardPage.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/GatewayWizard/GatewayWizardPage.cs
@@ -610,14 +610,22 @@ public sealed class GatewayWizardPage : Component<GatewayWizardState>
             // Top heading is driven by the wizard's current step title (or
             // local lifecycle title for loading/error/complete/offline). The
             // hosting V2 page suppresses its own heading when this wizard
-            // is embedded so we don't show two titles.
+            // is embedded so we don't show two titles. Capped at 2 lines
+            // with ellipsis so a long server-supplied step title can't push
+            // the device-code block or "Open in browser" button off-screen.
             TextBlock(string.IsNullOrEmpty(displayTitle)
                     ? LocalizationHelper.GetString("Onboarding_Wizard_Title")
                     : displayTitle)
                 .FontSize(28)
                 .SemiBold()
                 .HAlign(HorizontalAlignment.Center)
-                .TextWrapping(),
+                .TextWrapping()
+                .Set(t =>
+                {
+                    t.MaxLines = 2;
+                    t.TextTrimming = Microsoft.UI.Xaml.TextTrimming.CharacterEllipsis;
+                    t.TextAlignment = Microsoft.UI.Xaml.TextAlignment.Center;
+                }),
 
             Border(
                 ScrollView(

--- a/src/OpenClaw.Tray.WinUI/Onboarding/GatewayWizard/GatewayWizardPage.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/GatewayWizard/GatewayWizardPage.cs
@@ -555,6 +555,9 @@ public sealed class GatewayWizardPage : Component<GatewayWizardState>
             if (urlMatch.Success)
             {
                 var detectedUrl = urlMatch.Value;
+                // Width-matches the card above (both stretch within the
+                // outer VStack's MaxWidth(460)). The browser is never opened
+                // automatically — the user must click this button.
                 urlButton = Button($"🌐 Open in browser: {detectedUrl}", () =>
                 {
                     try
@@ -563,10 +566,7 @@ public sealed class GatewayWizardPage : Component<GatewayWizardState>
                         _ = global::Windows.System.Launcher.LaunchUriAsync(btnUri);
                     }
                     catch { }
-                }).HAlign(HorizontalAlignment.Left);
-
-                // Auto-open the browser on first render of this step
-                // (UseEffect runs once per step since stepId changes)
+                }).HAlign(HorizontalAlignment.Stretch);
             }
 
             // Device code detection — look for "Code: XXXX-XXXX" or similar.
@@ -600,37 +600,28 @@ public sealed class GatewayWizardPage : Component<GatewayWizardState>
             }
         }
 
-        // Auto-open browser for auth URLs when a new step arrives
-        UseEffect(() =>
-        {
-            if (!string.IsNullOrEmpty(displayMessage))
-            {
-                var urlMatch = UrlInMessagePattern.Match(displayMessage);
-                if (urlMatch.Success)
-                {
-                    try
-                    {
-                        if (Uri.TryCreate(urlMatch.Value, UriKind.Absolute, out var autoUri) && (autoUri.Scheme == "https" || autoUri.Scheme == "http"))
-                        _ = global::Windows.System.Launcher.LaunchUriAsync(autoUri);
-                    }
-                    catch { }
-                }
-            }
-        }, stepId); // Re-runs when stepId changes (new step)
+        // Browser launch is intentionally NOT automatic. Some wizard steps
+        // (e.g. the security/info page or pairing instructions) send a URL
+        // that is purely informational; auto-opening was disruptive. The
+        // user can click the "Open in browser" button below to launch any
+        // detected URL — including OAuth/device-code URLs.
 
         return VStack(8,
-            TextBlock(LocalizationHelper.GetString("Onboarding_Wizard_Title"))
-                .FontSize(22)
-                .FontWeight(new global::Windows.UI.Text.FontWeight(700))
-                .HAlign(HorizontalAlignment.Center),
+            // Top heading is driven by the wizard's current step title (or
+            // local lifecycle title for loading/error/complete/offline). The
+            // hosting V2 page suppresses its own heading when this wizard
+            // is embedded so we don't show two titles.
+            TextBlock(string.IsNullOrEmpty(displayTitle)
+                    ? LocalizationHelper.GetString("Onboarding_Wizard_Title")
+                    : displayTitle)
+                .FontSize(28)
+                .SemiBold()
+                .HAlign(HorizontalAlignment.Center)
+                .TextWrapping(),
 
             Border(
                 ScrollView(
                     VStack(10,
-                        TextBlock(displayTitle)
-                            .FontSize(15)
-                            .FontWeight(new global::Windows.UI.Text.FontWeight(700))
-                            .TextWrapping(),
                         TextBlock(displayMessage)
                             .FontSize(13)
                             .TextWrapping(),
@@ -640,6 +631,7 @@ public sealed class GatewayWizardPage : Component<GatewayWizardState>
             )
             .CornerRadius(8)
             .BackgroundResource("CardBackgroundFillColorDefaultBrush")
+            .HAlign(HorizontalAlignment.Stretch)
             .MaxHeight(350),
 
             // Device code display (large, copyable — for auth flows)

--- a/src/OpenClawTray.OnboardingV2/Pages/GatewayWelcomePage.cs
+++ b/src/OpenClawTray.OnboardingV2/Pages/GatewayWelcomePage.cs
@@ -23,31 +23,31 @@ public sealed class GatewayWelcomePage : Component<OnboardingV2State>
 {
     public override Element Render()
     {
-        var theme = Props.EffectiveTheme;
-
-        // Title is intentionally minimal — the wizard's own header provides
-        // step context. Margin pushes it down so it doesn't crowd the V2
-        // title bar.
-        var heading = TextBlock(V2Strings.Get("V2_Gateway_Title"))
-            .FontSize(28)
-            .SemiBold()
-            .HAlign(HorizontalAlignment.Center)
-            .Set(t => t.Foreground = V2Theme.TextStrong(theme));
-
         var children = new List<Element?>
         {
             new BorderElement(null).Height(24),
-            heading,
-            new BorderElement(null).Height(20),
         };
 
         // Embed the gateway wizard (provider/model RPC picker). The host
-        // populates GatewayWizardChildFactory at mount time. In the
-        // standalone preview (no host) this is null and the page renders
-        // the heading only.
+        // populates GatewayWizardChildFactory at mount time. When it is
+        // present the wizard renders its own dynamic step-driven heading;
+        // we deliberately do NOT add the static "Configuring gateway"
+        // heading here to avoid showing two titles for the same UI.
+        // In the standalone preview (no host) we render only the heading.
         if (Props.GatewayWizardChildFactory is { } childFactory)
         {
             children.Add(childFactory().Margin(0, 0, 0, 0));
+        }
+        else
+        {
+            var theme = Props.EffectiveTheme;
+            var heading = TextBlock(V2Strings.Get("V2_Gateway_Title"))
+                .FontSize(28)
+                .SemiBold()
+                .HAlign(HorizontalAlignment.Center)
+                .Set(t => t.Foreground = V2Theme.TextStrong(theme));
+            children.Add(heading);
+            children.Add(new BorderElement(null).Height(20));
         }
 
         return VStack(0, children.ToArray())


### PR DESCRIPTION
Three small quality-of-life polish fixes for the gateway wizard.

### 1. Don't auto-launch URLs in the browser
Informational steps (e.g. the security/info page or pairing instructions) sent a URL that was opened in the browser as soon as the step was rendered, which was disruptive. Removed the per-step `UseEffect` that called `LaunchUriAsync`. The user can still launch any detected URL — including OAuth/device-code URLs — by clicking the **🌐 Open in browser** button.

### 2. Stop showing two titles
The V2 page rendered a static "Configuring gateway" heading, and the wizard immediately rendered "Configuring Gateway" again below it (followed by yet another gateway-supplied step title inside the card). Now the V2 page omits its static heading when the wizard is embedded, and the wizard renders a single dynamic heading driven by the current step title (with sensible fallbacks for `loading` / `error` / `complete` / `offline`). The redundant step-title `TextBlock` inside the card is removed. Standalone-preview behaviour (no child factory) still shows the V2 heading.

### 3. Width-align the "Open in browser" button with the card
The button was left-aligned and auto-sized, so its right edge did not match the card above it. Switched the button to `HorizontalAlignment.Stretch` and stretched the card too — both share the outer `VStack`'s `MaxWidth(460)`, so their edges now line up.

### Validation
- `.\build.ps1` ✅
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` ✅ 1620 passed / 28 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` ✅ 953 passed
