### PR TITLE
Introduce single AppState model + service extractions

### DIFF
--- a/docs/DATA_FLOW_ARCHITECTURE.md
+++ b/docs/DATA_FLOW_ARCHITECTURE.md
@@ -1,0 +1,196 @@
+# Data Flow Architecture
+
+This document describes how gateway data flows from the WebSocket connection to the UI — the observable application model, event handling, and page update patterns.
+
+## Overview
+
+The tray app uses a single observable model (`AppState`) as the source of truth for all gateway-cached state. A dedicated event handler service (`GatewayService`) owns all 27 WebSocket event subscriptions and dispatches updates to `AppState` on the UI thread. Pages subscribe to `AppState.PropertyChanged` for live updates.
+
+```mermaid
+flowchart TD
+    GW["Gateway WebSocket"] -->|27 events| GS["GatewayService"]
+    GS -->|EnqueueModelUpdate| AS["AppState (INPC)"]
+    AS -->|PropertyChanged| P1["ConnectionPage"]
+    AS -->|PropertyChanged| P2["SessionsPage"]
+    AS -->|PropertyChanged| P3["UsagePage"]
+    AS -->|PropertyChanged| P4["...14 pages total"]
+    AS -->|PropertyChanged| HW["HubWindow\n(title bar, nav sidebar)"]
+    AS -->|PropertyChanged| APP["App.xaml.cs\n(tray icon, tray menu)"]
+    GS -->|4 re-raised events| APP
+    APP -->|reads| AS
+
+    style AS fill:#2d6a4f,color:#fff
+    style GS fill:#1b4332,color:#fff
+```
+
+## Key components
+
+### AppState (`Services/AppState.cs`)
+
+Single source of truth for all gateway-cached data. Implements `INotifyPropertyChanged`.
+
+```
+src/OpenClaw.Tray.WinUI/Services/AppState.cs
+```
+
+**Properties** (24+): `Status`, `CurrentActivity`, `Sessions`, `Channels`, `Nodes`, `Usage`, `UsageCost`, `UsageStatus`, `GatewaySelf`, `NodePairList`, `DevicePairList`, `ModelsList`, `Presence`, `AgentsList`, `Config`, `ConfigSchema`, `SkillsData`, `CronList`, `CronStatus`, `CronRuns`, `AgentFilesList`, `AgentFileContent`, `AuthFailureMessage`, `UpdateInfo`, `LastCheckTime`
+
+**Threading model**: All property writes must happen on the UI thread (enforced by `Debug.Assert` in `SetField`). This guarantees `PropertyChanged` fires on the UI thread, so pages can update UI directly without `DispatcherQueue.TryEnqueue`.
+
+**Lifetime**: Created once in `App.OnLaunched`, lives for the app's lifetime. Accessible globally via `((App)Application.Current).AppState`. Connections come and go; pages always have a single stable view of the data.
+
+**Key methods**:
+- `ClearCachedData()` — resets all gateway data fields on disconnect (does NOT reset `Status` — that's managed by `OnManagerStateChanged`)
+- `AddAgentEvent(evt)` — ring buffer, newest-first, capped at 400
+- `GetAgentIds()` — computed from `AgentsList` JSON
+- `SetSessionPreview/GetSessionPreview/PruneSessionPreviews` — thread-safe via lock
+
+### GatewayService (`Services/GatewayService.cs`)
+
+Owns all 27 operator gateway client event subscriptions. Moved from App.xaml.cs to separate concerns.
+
+```
+src/OpenClaw.Tray.WinUI/Services/GatewayService.cs
+```
+
+**Event categories**:
+
+| Category | Count | Pattern | Examples |
+|----------|-------|---------|----------|
+| A: Simple data | 15 | `EnqueueModelUpdate(() => _state.X = value)` | Usage, Config, Models, Presence |
+| B: Complex data | 8 | Update AppState + side effects (logging, dedup, throttling) | Channels, Sessions, Nodes, Activity |
+| C: Re-raised | 4 | Update AppState + re-raise event for App | StatusChanged, AuthFailed, SessionCommand, Notification |
+
+**Stale-event safety**: Uses a generation counter (`_clientGeneration`) that increments on every `AttachClient` call. The `EnqueueModelUpdate` helper captures the generation and re-checks inside the dispatcher callback, preventing stale events from an old client from mutating state after a client swap.
+
+```csharp
+private void EnqueueModelUpdate(Action update)
+{
+    var gen = _clientGeneration;
+    _dispatcher.TryEnqueue(() =>
+    {
+        if (gen == _clientGeneration) update();
+    });
+}
+```
+
+**Client lifecycle**: `AttachClient(newClient, oldClient)` unsubscribes from old, increments generation, clears service-level caches (channel signature, session activities, display state), subscribes to new.
+
+### App.xaml.cs — orchestration layer
+
+App creates `AppState` and `GatewayService` in `OnLaunched` and wires them together:
+
+```mermaid
+sequenceDiagram
+    participant CM as ConnectionManager
+    participant App as App.xaml.cs
+    participant GS as GatewayService
+    participant AS as AppState
+    participant HW as HubWindow
+    participant Page as Active Page
+
+    CM->>App: OperatorClientChanged
+    App->>GS: AttachClient(new, old)
+    Note over GS: Unsubscribe old, subscribe new
+
+    CM->>App: StateChanged (connect/disconnect)
+    App->>AS: Status = mapped (on UI thread)
+
+    Note over GS: Gateway event arrives (BG thread)
+    GS->>AS: EnqueueModelUpdate (UI thread)
+    AS->>Page: PropertyChanged
+    AS->>HW: PropertyChanged (title bar)
+    AS->>App: PropertyChanged (tray icon/menu)
+```
+
+**What stays in App**:
+- `OnManagerStateChanged` — maps `GatewayConnectionSnapshot` to `ConnectionStatus`, writes `AppState.Status`
+- Node service handlers — `OnNodeStatusChanged`, `OnPairingStatusChanged`, etc.
+- Toast/notification display (via `ToastService`)
+- Window management — `ShowHub`, `ShowChatWindow`, `ShowVoiceOverlay`
+- Tray icon/menu updates (subscribes to `AppState.PropertyChanged`)
+- `IAppCommands` implementation
+
+**What moved out**:
+- 27 gateway event handlers → `GatewayService`
+- 20+ `_last*` cached fields → `AppState` properties
+- Toast dedup state → `ToastService`
+- Diagnostic clipboard methods → `DiagnosticsClipboardService`
+
+### Pages — direct observation
+
+Pages access `AppState` globally and subscribe to `PropertyChanged` for live updates. They no longer depend on `HubWindow` for data.
+
+```
+// Every page that observes gateway data:
+private static App CurrentApp => (App)Application.Current;
+private AppState? _appState;
+
+public void Initialize()
+{
+    _appState = CurrentApp.AppState;
+    _appState.PropertyChanged += OnAppStateChanged;
+}
+
+private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
+{
+    switch (e.PropertyName)
+    {
+        case nameof(AppState.Sessions):
+            // UI update — already on UI thread
+            break;
+    }
+}
+```
+
+**Page observation map**:
+
+| Page | Observes |
+|------|----------|
+| ConnectionPage | Status, NodePairList, DevicePairList, Channels, UsageCost, Sessions, GatewaySelf |
+| SessionsPage | Sessions, ModelsList |
+| ChannelsPage | Channels |
+| UsagePage | Usage, UsageCost, UsageStatus |
+| InstancesPage | Nodes, Presence |
+| ConfigPage | Config, ConfigSchema |
+| BindingsPage | Config |
+| CronPage | CronList, CronStatus, CronRuns |
+| SkillsPage | SkillsData |
+| WorkspacePage | AgentFilesList, AgentFileContent |
+| AgentEventsPage | AgentEventAdded (separate event) |
+| AboutPage | GatewaySelf |
+
+Pages that don't observe AppState: ActivityPage, ChatPage, SettingsPage, SandboxPage, VoiceSettingsPage.
+
+### HubWindow — minimal role
+
+HubWindow's role is now limited to:
+- **Title bar** — subscribes to `AppState.Status` and `AppState.GatewaySelf` for status/version display
+- **Navigation sidebar** — subscribes to `AppState.AgentsList` to rebuild agent nav items
+- **Page lifecycle** — `InitializeCurrentPage()` calls `page.Initialize()` when the user navigates
+
+HubWindow no longer caches gateway data or forwards updates to pages.
+
+## Service file map
+
+```
+src/OpenClaw.Tray.WinUI/Services/
+├── AppState.cs                    — Observable model (INPC, 24+ properties)
+├── GatewayService.cs              — 27 event subscriptions, UI dispatch
+├── IAppCommands.cs                — Page → App command interface
+├── ToastService.cs                — Toast display, dedup, sound config
+├── DiagnosticsClipboardService.cs — Copy* diagnostic clipboard methods
+├── AppStateSnapshot.cs            — Frozen snapshot for CommandCenter
+├── TrayStateSnapshot.cs           — Frozen snapshot for tray tooltip
+├── TrayMenuSnapshot.cs            — Frozen snapshot for tray menu builder
+├── TrayMenuStateBuilder.cs        — Builds tray popup menu UI
+└── TrayTooltipBuilder.cs          — Builds tray tooltip string
+```
+
+## Threading rules
+
+1. **AppState writes**: UI thread only. `SetField` asserts `DispatcherQueue.HasThreadAccess`.
+2. **GatewayService handlers**: Run on WebSocket background threads. Use `EnqueueModelUpdate` to dispatch to UI thread before writing to AppState.
+3. **PropertyChanged handlers**: Fire on UI thread (guaranteed by rule 1). Pages can update UI directly — no `TryEnqueue` needed.
+4. **Session previews**: Thread-safe via `lock` (read from any thread, write from any thread).
+5. **Tray menu refresh**: Debounced via `DispatcherQueuePriority.Low` to coalesce rapid AppState changes.

--- a/src/OpenClaw.Shared/Capabilities/CanvasCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/CanvasCapability.cs
@@ -247,7 +247,11 @@ public class CanvasCapability : NodeCapabilityBase
         catch (Exception ex)
         {
             Logger.Error("canvas.eval handler failed", ex);
-            return Error("Eval failed");
+            // Surface structured CANVAS_* errors for diagnostics; keep generic
+            // message for other exceptions to avoid leaking internal details.
+            var msg = ex.Message.StartsWith("CANVAS_", StringComparison.Ordinal)
+                ? ex.Message : "Eval failed";
+            return Error(msg);
         }
     }
     
@@ -279,7 +283,9 @@ public class CanvasCapability : NodeCapabilityBase
         catch (Exception ex)
         {
             Logger.Error("canvas.snapshot handler failed", ex);
-            return Error("Snapshot failed");
+            var msg = ex.Message.StartsWith("CANVAS_", StringComparison.Ordinal)
+                ? ex.Message : "Snapshot failed";
+            return Error(msg);
         }
     }
     

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -213,13 +213,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private ChatWindow? _chatWindow;
     private ConnectionStatusWindow? _connectionStatusWindow;
 
-    // Bug 3: per-device idempotencyfor "Node paired" toast. WindowsNodeClient.HandleHelloOk
-    // re-fires PairingStatusChanged(Paired) on every WS reconnect; we only want one toast
-    // per device per session. (Source-side suppression also exists in WindowsNodeClient as
-    // defense-in-depth.)
-    private readonly HashSet<string> _shownPairedToasts = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, DateTime> _recentToastKeys = new(StringComparer.OrdinalIgnoreCase);
-    private static readonly TimeSpan ToastDedupeWindow = TimeSpan.FromSeconds(30);
+    private DiagnosticsClipboardService? _diagnosticsClipboard;
+    private ToastService? _toastService;
     
     // Node service (optional, enabled in settings)
     private NodeService? _nodeService;
@@ -614,6 +609,9 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         _gatewayService.SessionCommandCompleted += OnGatewaySessionCommandCompleted;
         _gatewayService.NotificationReceived += OnGatewayNotificationReceived;
         _appState.PropertyChanged += OnAppStateChanged;
+
+        _diagnosticsClipboard = new DiagnosticsClipboardService(BuildCommandCenterState);
+        _toastService = new ToastService(() => _settings);
 
         DiagnosticsJsonlService.Write("app.start", new
         {
@@ -1028,15 +1026,15 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             case "configfolder": OpenConfigFolder(); break;
             case "diagnosticsfolder": OpenDiagnosticsFolder(); break;
             case "connectionstatus": ShowConnectionStatusWindow(); break;
-            case "supportcontext": CopySupportContext(); break;
-            case "debugbundle": CopyDebugBundle(); break;
-            case "browsersetup": CopyBrowserSetupGuidance(); break;
-            case "portdiagnostics": CopyPortDiagnostics(); break;
-            case "capabilitydiagnostics": CopyCapabilityDiagnostics(); break;
-            case "nodeinventory": CopyNodeInventory(); break;
-            case "channelsummary": CopyChannelSummary(); break;
-            case "activitysummary": CopyActivitySummary(); break;
-            case "extensibilitysummary": CopyExtensibilitySummary(); break;
+            case "supportcontext": _diagnosticsClipboard!.CopySupportContext(); break;
+            case "debugbundle": _diagnosticsClipboard!.CopyDebugBundle(); break;
+            case "browsersetup": _diagnosticsClipboard!.CopyBrowserSetupGuidance(); break;
+            case "portdiagnostics": _diagnosticsClipboard!.CopyPortDiagnostics(); break;
+            case "capabilitydiagnostics": _diagnosticsClipboard!.CopyCapabilityDiagnostics(); break;
+            case "nodeinventory": _diagnosticsClipboard!.CopyNodeInventory(); break;
+            case "channelsummary": _diagnosticsClipboard!.CopyChannelSummary(); break;
+            case "activitysummary": _diagnosticsClipboard!.CopyActivitySummary(); break;
+            case "extensibilitysummary": _diagnosticsClipboard!.CopyExtensibilitySummary(); break;
             case "restartsshtunnel": RestartSshTunnel(); break;
             case "copydeviceid": CopyDeviceIdToClipboard(); break;
             case "copynodesummary": CopyNodeSummaryToClipboard(); break;
@@ -1090,7 +1088,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             CopyTextToClipboard(_nodeService.FullDeviceId);
             
             // Show toast confirming copy
-            ShowToast(new ToastContentBuilder()
+            _toastService!.ShowToast(new ToastContentBuilder()
                 .AddText(LocalizationHelper.GetString("Toast_DeviceIdCopied"))
                 .AddText(string.Format(LocalizationHelper.GetString("Toast_DeviceIdCopiedDetail"), _nodeService.ShortDeviceId)));
         }
@@ -1116,7 +1114,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
             CopyTextToClipboard(summary);
 
-            ShowToast(new ToastContentBuilder()
+            _toastService!.ShowToast(new ToastContentBuilder()
                 .AddText(LocalizationHelper.GetString("Toast_NodeSummaryCopied"))
                 .AddText(string.Format(LocalizationHelper.GetString("Toast_NodeSummaryCopiedDetail"), _appState!.Nodes.Length)));
         }
@@ -1173,7 +1171,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
             if (!sent)
             {
-                ShowToast(new ToastContentBuilder()
+                _toastService!.ShowToast(new ToastContentBuilder()
                     .AddText(LocalizationHelper.GetString("Toast_SessionActionFailed"))
                     .AddText(LocalizationHelper.GetString("Toast_SessionActionFailedDetail")));
                 return;
@@ -1189,7 +1187,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             Logger.Warn($"Session action error ({action}): {ex.Message}");
             try
             {
-                ShowToast(new ToastContentBuilder()
+                _toastService!.ShowToast(new ToastContentBuilder()
                     .AddText(LocalizationHelper.GetString("Toast_SessionActionFailed"))
                     .AddText(ex.Message));
             }
@@ -1916,7 +1914,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         if (status == ConnectionStatus.Connected && nodeService?.IsPaired == true)
         {
             var deviceId = nodeService.FullDeviceId;
-            if (HasRecentToast("node-paired", deviceId))
+            if (_toastService!.HasRecentToast("node-paired", deviceId))
             {
                 Logger.Info($"[ToastDeduper] Suppressed node-connected toast after node-paired deviceId={deviceId}");
                 return;
@@ -1924,7 +1922,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
             try
             {
-                ShowToast(new ToastContentBuilder()
+                _toastService!.ShowToast(new ToastContentBuilder()
                     .AddText(LocalizationHelper.GetString("Toast_NodeModeActive"))
                     .AddText(LocalizationHelper.GetString("Toast_NodeModeActiveDetail")),
                     "node-connected",
@@ -1986,10 +1984,11 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 // Bug 3: idempotency guard — only show "Node paired" toast/activity once
                 // per device per session. WS reconnects re-fire Paired; suppress duplicates.
                 var deviceKey = args.DeviceId ?? string.Empty;
-                if (_shownPairedToasts.Add(deviceKey))
+                if (!_toastService!.HasShownPairedToast(deviceKey))
                 {
+                    _toastService!.MarkPairedToastShown(deviceKey);
                     AddRecentActivity("Node paired", category: "node", dashboardPath: "nodes", nodeId: args.DeviceId);
-                    ShowToast(new ToastContentBuilder()
+                    _toastService!.ShowToast(new ToastContentBuilder()
                         .AddText(LocalizationHelper.GetString("Toast_NodePaired"))
                         .AddText(LocalizationHelper.GetString("Toast_NodePairedDetail")),
                         "node-paired",
@@ -2003,7 +2002,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             else if (args.Status == OpenClaw.Shared.PairingStatus.Rejected)
             {
                 AddRecentActivity("Node pairing rejected", category: "node", dashboardPath: "nodes", nodeId: args.DeviceId, details: args.Message ?? LocalizationHelper.GetString("Toast_PairingRejectedDetail"));
-                ShowToast(new ToastContentBuilder()
+                _toastService!.ShowToast(new ToastContentBuilder()
                     .AddText(LocalizationHelper.GetString("Toast_PairingRejected"))
                     .AddText(LocalizationHelper.GetString("Toast_PairingRejectedDetail")),
                     "node-pairing-rejected",
@@ -2047,7 +2046,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         var shortDeviceId = deviceId.Length > 16 ? deviceId[..16] : deviceId;
 
         AddRecentActivity("Node pairing pending", category: "node", dashboardPath: "nodes", nodeId: deviceId);
-        ShowToast(new ToastContentBuilder()
+        _toastService!.ShowToast(new ToastContentBuilder()
             .AddText(LocalizationHelper.GetString("Toast_PairingPending"))
             .AddText(string.Format(LocalizationHelper.GetString("Toast_PairingPendingDetail"), shortDeviceId))
             .AddButton(new ToastButton()
@@ -2065,7 +2064,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         // Agent requested a notification via node.invoke system.notify
         try
         {
-            ShowToast(new ToastContentBuilder()
+            _toastService!.ShowToast(new ToastContentBuilder()
                 .AddText(args.Title)
                 .AddText(args.Body));
         }
@@ -2077,7 +2076,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
     private void OnNodeToastRequested(object? sender, Microsoft.Toolkit.Uwp.Notifications.ToastContentBuilder builder)
         => OnUiThread(() =>
-            NonFatalAction.Run(() => ShowToast(builder), msg => Logger.Warn($"Failed to show node toast: {msg}")));
+            NonFatalAction.Run(() => _toastService!.ShowToast(builder), msg => Logger.Warn($"Failed to show node toast: {msg}")));
 
     private void OnNodeInvokeCompleted(object? sender, NodeInvokeCompletedEventArgs args)
     {
@@ -2181,7 +2180,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                     dashboardPath: !string.IsNullOrWhiteSpace(result.Key) ? $"sessions/{result.Key}" : "sessions",
                     sessionKey: result.Key);
 
-                ShowToast(new ToastContentBuilder()
+                _toastService!.ShowToast(new ToastContentBuilder()
                     .AddText(title)
                     .AddText(message));
             }
@@ -2254,7 +2253,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                            .AddArgument("action", "open_chat"));
             }
 
-            ShowToast(builder);
+            _toastService!.ShowToast(builder);
         }
         catch (Exception ex)
         {
@@ -2462,7 +2461,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 OnUiThread(UpdateStatusDetailWindow);
                 if (userInitiated)
                 {
-                    ShowToast(new ToastContentBuilder()
+                    _toastService!.ShowToast(new ToastContentBuilder()
                         .AddText(LocalizationHelper.GetString("Toast_HealthCheck"))
                         .AddText("Node Mode is connected; gateway health is streaming."));
                 }
@@ -2471,7 +2470,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
             if (userInitiated)
             {
-                ShowToast(new ToastContentBuilder()
+                _toastService!.ShowToast(new ToastContentBuilder()
                     .AddText(LocalizationHelper.GetString("Toast_HealthCheck"))
                     .AddText(LocalizationHelper.GetString("Toast_HealthCheckNotConnected")));
             }
@@ -2484,7 +2483,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             await client.CheckHealthAsync();
             if (userInitiated)
             {
-                ShowToast(new ToastContentBuilder()
+                _toastService!.ShowToast(new ToastContentBuilder()
                     .AddText(LocalizationHelper.GetString("Toast_HealthCheck"))
                     .AddText(LocalizationHelper.GetString("Toast_HealthCheckSent")));
             }
@@ -2494,7 +2493,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             Logger.Warn($"Health check failed: {ex.Message}");
             if (userInitiated)
             {
-                ShowToast(new ToastContentBuilder()
+                _toastService!.ShowToast(new ToastContentBuilder()
                     .AddText(LocalizationHelper.GetString("Toast_HealthCheckFailed"))
                     .AddText(ex.Message));
             }
@@ -2858,7 +2857,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     {
         if (_settings?.UseSshTunnel != true)
         {
-            ShowToast(new ToastContentBuilder()
+            _toastService!.ShowToast(new ToastContentBuilder()
                 .AddText("SSH tunnel")
                 .AddText("Managed SSH tunnel mode is not enabled."));
             return;
@@ -2880,7 +2879,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             if (!EnsureSshTunnelConfigured())
             {
                 UpdateStatusDetailWindow();
-                ShowToast(new ToastContentBuilder()
+                _toastService!.ShowToast(new ToastContentBuilder()
                     .AddText("SSH tunnel restart failed")
                     .AddText(_sshTunnelService?.LastError ?? "Check SSH tunnel settings and logs."));
                 return;
@@ -2889,7 +2888,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             _ = _connectionManager?.ReconnectAsync();
 
             UpdateStatusDetailWindow();
-            ShowToast(new ToastContentBuilder()
+            _toastService!.ShowToast(new ToastContentBuilder()
                 .AddText("SSH tunnel")
                 .AddText("Restarted; reconnecting to gateway."));
         }
@@ -2897,7 +2896,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         {
             Logger.Error($"SSH tunnel restart request failed: {ex.Message}");
             DiagnosticsJsonlService.Write("tunnel.restart_request_failed", new { ex.Message });
-            ShowToast(new ToastContentBuilder()
+            _toastService!.ShowToast(new ToastContentBuilder()
                 .AddText("SSH tunnel restart failed")
                 .AddText(ex.Message));
         }
@@ -3034,7 +3033,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
         try
         {
-            ShowToast(new ToastContentBuilder()
+            _toastService!.ShowToast(new ToastContentBuilder()
                 .AddText(LocalizationHelper.GetString("Toast_ActivityStreamTip"))
                 .AddText(LocalizationHelper.GetString("Toast_ActivityStreamTipDetail"))
                 .AddButton(new ToastButton()
@@ -3048,65 +3047,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     }
 
     #endregion
-
-    private void ShowToast(ToastContentBuilder builder, string? toastTag = null, string? deviceId = null)
-    {
-        if (!ShouldShowToast(toastTag, deviceId))
-            return;
-
-        var sound = _settings?.NotificationSound;
-        if (string.Equals(sound, "None", StringComparison.OrdinalIgnoreCase))
-        {
-            builder.AddAudio(new ToastAudio { Silent = true });
-        }
-        else if (string.Equals(sound, "Subtle", StringComparison.OrdinalIgnoreCase))
-        {
-            builder.AddAudio(new Uri("ms-winsoundevent:Notification.IM"), silent: false);
-        }
-        builder.Show();
-    }
-
-    private bool ShouldShowToast(string? toastTag, string? deviceId)
-    {
-        if (string.IsNullOrWhiteSpace(toastTag))
-            return true;
-
-        var normalizedDeviceId = NormalizeToastDeviceId(deviceId);
-        var dedupeKey = BuildToastKey(toastTag, normalizedDeviceId);
-        var now = DateTime.UtcNow;
-
-        foreach (var staleKey in _recentToastKeys
-            .Where(pair => now - pair.Value >= ToastDedupeWindow)
-            .Select(pair => pair.Key)
-            .ToArray())
-        {
-            _recentToastKeys.Remove(staleKey);
-        }
-
-        if (_recentToastKeys.TryGetValue(dedupeKey, out var lastShown) &&
-            now - lastShown < ToastDedupeWindow)
-        {
-            Logger.Info($"[ToastDeduper] Suppressed duplicate toast tag={toastTag} deviceId={normalizedDeviceId}");
-            return false;
-        }
-
-        _recentToastKeys[dedupeKey] = now;
-        Logger.Info($"[ToastDeduper] Showing toast tag={toastTag} deviceId={normalizedDeviceId}");
-        return true;
-    }
-
-    private bool HasRecentToast(string toastTag, string? deviceId)
-    {
-        var normalizedDeviceId = NormalizeToastDeviceId(deviceId);
-        return _recentToastKeys.TryGetValue(BuildToastKey(toastTag, normalizedDeviceId), out var lastShown) &&
-            DateTime.UtcNow - lastShown < ToastDedupeWindow;
-    }
-
-    private static string NormalizeToastDeviceId(string? deviceId) =>
-        string.IsNullOrWhiteSpace(deviceId) ? "global" : deviceId.Trim();
-
-    private static string BuildToastKey(string toastTag, string normalizedDeviceId) =>
-        $"{toastTag.Trim()}:{normalizedDeviceId}";
 
     private bool TryResolveChatCredentials(
         out string gatewayUrl,
@@ -3289,46 +3229,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             Logger.Warn($"Failed to open {label} folder {folderPath}: {ex.Message}");
         }
     }
-
-    private void CopyDiagnostic(string label, Func<GatewayCommandCenterState, string> format)
-    {
-        try
-        {
-            CopyTextToClipboard(format(BuildCommandCenterState()));
-            Logger.Info($"Copied {label} from deep link");
-        }
-        catch (Exception ex)
-        {
-            Logger.Warn($"Failed to copy {label} from deep link: {ex.Message}");
-        }
-    }
-
-    private void CopySupportContext() =>
-        CopyDiagnostic("support context", CommandCenterTextHelper.BuildSupportContext);
-
-    private void CopyDebugBundle() =>
-        CopyDiagnostic("debug bundle", CommandCenterTextHelper.BuildDebugBundle);
-
-    private void CopyBrowserSetupGuidance() =>
-        CopyDiagnostic("browser setup guidance", CommandCenterTextHelper.BuildBrowserSetupGuidance);
-
-    private void CopyPortDiagnostics() =>
-        CopyDiagnostic("port diagnostics", s => CommandCenterTextHelper.BuildPortDiagnosticsSummary(s.PortDiagnostics));
-
-    private void CopyCapabilityDiagnostics() =>
-        CopyDiagnostic("capability diagnostics", CommandCenterTextHelper.BuildCapabilityDiagnosticsSummary);
-
-    private void CopyNodeInventory() =>
-        CopyDiagnostic("node inventory", s => CommandCenterTextHelper.BuildNodeInventorySummary(s.Nodes));
-
-    private void CopyChannelSummary() =>
-        CopyDiagnostic("channel summary", s => CommandCenterTextHelper.BuildChannelSummaryText(s.Channels));
-
-    private void CopyActivitySummary() =>
-        CopyDiagnostic("activity summary", s => CommandCenterTextHelper.BuildActivitySummary(s.RecentActivity));
-
-    private void CopyExtensibilitySummary() =>
-        CopyDiagnostic("extensibility summary", s => CommandCenterTextHelper.BuildExtensibilitySummary(s.Channels));
 
     private void OnGlobalHotkeyPressed(object? sender, EventArgs e)
     {
@@ -3557,15 +3457,15 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             OpenConfigFolder = OpenConfigFolder,
             OpenDiagnosticsFolder = OpenDiagnosticsFolder,
             OpenConnectionStatus = ShowConnectionStatusWindow,
-            CopySupportContext = CopySupportContext,
-            CopyDebugBundle = CopyDebugBundle,
-            CopyBrowserSetupGuidance = CopyBrowserSetupGuidance,
-            CopyPortDiagnostics = CopyPortDiagnostics,
-            CopyCapabilityDiagnostics = CopyCapabilityDiagnostics,
-            CopyNodeInventory = CopyNodeInventory,
-            CopyChannelSummary = CopyChannelSummary,
-            CopyActivitySummary = CopyActivitySummary,
-            CopyExtensibilitySummary = CopyExtensibilitySummary,
+            CopySupportContext = _diagnosticsClipboard!.CopySupportContext,
+            CopyDebugBundle = _diagnosticsClipboard!.CopyDebugBundle,
+            CopyBrowserSetupGuidance = _diagnosticsClipboard!.CopyBrowserSetupGuidance,
+            CopyPortDiagnostics = _diagnosticsClipboard!.CopyPortDiagnostics,
+            CopyCapabilityDiagnostics = _diagnosticsClipboard!.CopyCapabilityDiagnostics,
+            CopyNodeInventory = _diagnosticsClipboard!.CopyNodeInventory,
+            CopyChannelSummary = _diagnosticsClipboard!.CopyChannelSummary,
+            CopyActivitySummary = _diagnosticsClipboard!.CopyActivitySummary,
+            CopyExtensibilitySummary = _diagnosticsClipboard!.CopyExtensibilitySummary,
             RestartSshTunnel = RestartSshTunnel,
             OpenChat = ShowWebChat,
             OpenCommandCenter = ShowStatusDetail,
@@ -3646,7 +3546,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                         break;
                     case "copy_pairing_command" when arguments.TryGetValue("command", out var command):
                         CopyTextToClipboard(command);
-                        ShowToast(new ToastContentBuilder()
+                        _toastService!.ShowToast(new ToastContentBuilder()
                             .AddText(LocalizationHelper.GetString("Toast_PairingCommandCopied"))
                             .AddText(command));
                         break;

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -609,6 +609,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         _gatewayService.SessionCommandCompleted += OnGatewaySessionCommandCompleted;
         _gatewayService.NotificationReceived += OnGatewayNotificationReceived;
         _appState.PropertyChanged += OnAppStateChanged;
+        _appState.AgentEventAdded += evt => _hubWindow?.UpdateAgentEvent(evt);
 
         _diagnosticsClipboard = new DiagnosticsClipboardService(BuildCommandCenterState);
         _toastService = new ToastService(() => _settings);
@@ -2595,7 +2596,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             {
                 _ = _connectionManager?.ReconnectAsync();
             };
-            _hubWindow.ClearAppAgentEventsCache = () => _appState!.ClearAgentEvents();
+            _hubWindow.ClearAppAgentEventsCache = null; // AppModel.ClearAgentEvents() already called by HubWindow
             if (_nodeService != null)
             {
                 _hubWindow.NodeIsConnected = _nodeService.IsConnected;

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Toolkit.Uwp.Notifications;
+using Microsoft.Toolkit.Uwp.Notifications;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
@@ -30,7 +30,7 @@ using WinUIEx;
 
 namespace OpenClawTray;
 
-public partial class App : Application
+public partial class App : Application, OpenClawTray.Services.IAppCommands
 {
     private const string PipeName = "OpenClawTray-DeepLink";
     
@@ -177,6 +177,8 @@ public partial class App : Application
     private GlobalHotkeyService? _globalHotkey;
     private Mutex? _mutex;
     private Microsoft.UI.Dispatching.DispatcherQueue? _dispatcherQueue;
+    private AppState? _appState;
+    private GatewayService? _gatewayService;
     private CancellationTokenSource? _deepLinkCts;
     private bool _isExiting;
     
@@ -188,27 +190,6 @@ public partial class App : Application
     private ConnectionStatus _currentStatus = ConnectionStatus.Disconnected;
     private WeakReference<ToggleSwitch>? _connectionToggleRef;
     private bool _suspendConnectionToggleEvent;
-    private AgentActivity? _currentActivity;
-    private ChannelHealth[] _lastChannels = Array.Empty<ChannelHealth>();
-    private SessionInfo[] _lastSessions = Array.Empty<SessionInfo>();
-    private GatewayNodeInfo[] _lastNodes = Array.Empty<GatewayNodeInfo>();
-    private readonly Dictionary<string, SessionPreviewInfo> _sessionPreviews = new();
-    private readonly object _sessionPreviewsLock = new();
-    private DateTime _lastPreviewRequestUtc = DateTime.MinValue;
-    private GatewayUsageInfo? _lastUsage;
-    private GatewayUsageStatusInfo? _lastUsageStatus;
-    private GatewayCostUsageInfo? _lastUsageCost;
-    private GatewaySelfInfo? _lastGatewaySelf;
-    private PairingListInfo? _lastNodePairList;
-    private DevicePairingListInfo? _lastDevicePairList;
-    private ModelsListInfo? _lastModelsList;
-    private PresenceEntry[]? _lastPresence;
-    private readonly List<AgentEventInfo> _agentEventsCache = new();
-    private const int MaxAppAgentEvents = 400;
-    private UpdateCommandCenterInfo _lastUpdateInfo = BuildInitialUpdateInfo();
-    private DateTime _lastCheckTime = DateTime.Now;
-    private DateTime _lastUsageActivityLogUtc = DateTime.MinValue;
-    private string? _lastChannelStatusSignature;
 
     // FrozenDictionary for O(1) case-insensitive notification type → setting lookup — no per-call allocation.
     private static readonly System.Collections.Frozen.FrozenDictionary<string, Func<SettingsManager, bool>> s_notifTypeMap =
@@ -225,21 +206,14 @@ public partial class App : Application
             ["error"]     = s => s.NotifyUrgent,  // errors follow urgent setting
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
-    // Session-aware activity tracking
-    private readonly Dictionary<string, AgentActivity> _sessionActivities = new();
-    private string? _displayedSessionKey;
-    private DateTime _lastSessionSwitch = DateTime.MinValue;
-    private static readonly TimeSpan SessionSwitchDebounce = TimeSpan.FromSeconds(3);
-
     // Windows (created on demand)
     private HubWindow? _hubWindow;
     private TrayMenuWindow? _trayMenuWindow;
     private QuickSendDialog? _quickSendDialog;
     private ChatWindow? _chatWindow;
     private ConnectionStatusWindow? _connectionStatusWindow;
-    private string? _authFailureMessage;
 
-    // Bug 3: per-device idempotency for "Node paired" toast. WindowsNodeClient.HandleHelloOk
+    // Bug 3: per-device idempotencyfor "Node paired" toast. WindowsNodeClient.HandleHelloOk
     // re-fires PairingStatusChanged(Paired) on every WS reconnect; we only want one toast
     // per device per session. (Source-side suppression also exists in WindowsNodeClient as
     // defense-in-depth.)
@@ -630,6 +604,17 @@ public partial class App : Application
                 ? null
                 : OpenClawTray.Chat.FunctionalChatHostExtensions.AsPost(_dispatcherQueue));
         DiagnosticsJsonlService.Configure(DataPath);
+
+        // Central observable model + gateway event handler.
+        _appState = new AppState(_dispatcherQueue);
+        _appState.UpdateInfo = BuildInitialUpdateInfo();
+        _gatewayService = new GatewayService(_appState, _dispatcherQueue!);
+        _gatewayService.ConnectionStatusChanged += OnGatewayConnectionStatusChanged;
+        _gatewayService.AuthenticationFailed += OnGatewayAuthenticationFailed;
+        _gatewayService.SessionCommandCompleted += OnGatewaySessionCommandCompleted;
+        _gatewayService.NotificationReceived += OnGatewayNotificationReceived;
+        _appState.PropertyChanged += OnAppStateChanged;
+
         DiagnosticsJsonlService.Write("app.start", new
         {
             nodeMode = _settings.EnableNodeMode,
@@ -1117,11 +1102,11 @@ public partial class App : Application
 
     private void CopyNodeSummaryToClipboard()
     {
-        if (_lastNodes.Length == 0) return;
+        if (_appState!.Nodes.Length == 0) return;
 
         try
         {
-            var lines = _lastNodes.Select(node =>
+            var lines = _appState!.Nodes.Select(node =>
             {
                 var state = node.IsOnline ? "online" : "offline";
                 var name = string.IsNullOrWhiteSpace(node.DisplayName) ? node.ShortId : node.DisplayName;
@@ -1133,7 +1118,7 @@ public partial class App : Application
 
             ShowToast(new ToastContentBuilder()
                 .AddText(LocalizationHelper.GetString("Toast_NodeSummaryCopied"))
-                .AddText(string.Format(LocalizationHelper.GetString("Toast_NodeSummaryCopiedDetail"), _lastNodes.Length)));
+                .AddText(string.Format(LocalizationHelper.GetString("Toast_NodeSummaryCopiedDetail"), _appState!.Nodes.Length)));
         }
         catch (Exception ex)
         {
@@ -1258,15 +1243,7 @@ public partial class App : Application
 
     private void LocalDisconnectCleanup()
     {
-        _lastSessions = Array.Empty<SessionInfo>();
-        _lastNodes = Array.Empty<GatewayNodeInfo>();
-        _lastPresence = Array.Empty<PresenceEntry>();
-        _lastChannels = Array.Empty<ChannelHealth>();
-        _lastNodePairList = null;
-        _lastDevicePairList = null;
-        _lastModelsList = null;
-        _lastGatewaySelf = null;
-        _agentEventsCache.Clear();
+        _appState?.ClearCachedData();
         UpdateTrayIcon();
         _hubWindow?.UpdateStatus(ConnectionStatus.Disconnected);
         RefreshTrayMenuIfOpen();
@@ -1310,21 +1287,21 @@ public partial class App : Application
         return new TrayMenuSnapshot
         {
             CurrentStatus = _currentStatus,
-            AuthFailureMessage = _authFailureMessage,
+            AuthFailureMessage = _appState?.AuthFailureMessage,
             GatewayUrl = _settings?.GetEffectiveGatewayUrl(),
-            GatewaySelf = _lastGatewaySelf,
-            Presence = _lastPresence,
+            GatewaySelf = _appState?.GatewaySelf,
+            Presence = _appState?.Presence,
             EnableNodeMode = _settings?.EnableNodeMode == true && _nodeService != null,
             NodeIsPaired = _nodeService?.IsPaired ?? false,
             NodeIsPendingApproval = _nodeService?.IsPendingApproval ?? false,
             NodeIsConnected = _nodeService?.IsConnected ?? false,
-            NodePairList = _lastNodePairList,
-            DevicePairList = _lastDevicePairList,
-            Nodes = _lastNodes,
-            Sessions = _lastSessions,
-            Usage = _lastUsage,
-            UsageStatus = _lastUsageStatus,
-            UsageCost = _lastUsageCost,
+            NodePairList = _appState?.NodePairList,
+            DevicePairList = _appState?.DevicePairList,
+            Nodes = _appState?.Nodes ?? Array.Empty<GatewayNodeInfo>(),
+            Sessions = _appState?.Sessions ?? Array.Empty<SessionInfo>(),
+            Usage = _appState?.Usage,
+            UsageStatus = _appState?.UsageStatus,
+            UsageCost = _appState?.UsageCost,
             Settings = _settings,
             SetupMenuLabel = setupMenuLabel,
         };
@@ -1347,74 +1324,77 @@ public partial class App : Application
 
         {
             var now = DateTime.UtcNow;
-            _lastSessions = new[]
+            if (_appState != null)
             {
-                new SessionInfo
+                _appState.Sessions = new[]
                 {
-                    Key = "preview:main", IsMain = true, Status = "active",
-                    Model = "claude-opus-4.7", DisplayName = "Main · preview",
-                    InputTokens = 124_000, OutputTokens = 36_000,
-                    ContextTokens = 200_000,
-                    UpdatedAt = now.AddMinutes(-2), LastSeen = now,
-                },
-                new SessionInfo
+                    new SessionInfo
+                    {
+                        Key = "preview:main", IsMain = true, Status = "active",
+                        Model = "claude-opus-4.7", DisplayName = "Main · preview",
+                        InputTokens = 124_000, OutputTokens = 36_000,
+                        ContextTokens = 200_000,
+                        UpdatedAt = now.AddMinutes(-2), LastSeen = now,
+                    },
+                    new SessionInfo
+                    {
+                        Key = "preview:dashboard", IsMain = false, Status = "idle",
+                        Model = "gpt-5.4", DisplayName = "agent:main:dashboard",
+                        InputTokens = 58_000, OutputTokens = 12_000,
+                        ContextTokens = 128_000,
+                        UpdatedAt = now.AddHours(-1), LastSeen = now,
+                    },
+                    new SessionInfo
+                    {
+                        Key = "preview:scratch", IsMain = false, Status = "idle",
+                        Model = "claude-haiku-4.5", DisplayName = "agent:main:scratch",
+                        InputTokens = 6_400, OutputTokens = 1_200,
+                        ContextTokens = 64_000,
+                        UpdatedAt = now.AddHours(-4), LastSeen = now,
+                    },
+                };
+
+                _appState.Usage = new GatewayUsageInfo
                 {
-                    Key = "preview:dashboard", IsMain = false, Status = "idle",
-                    Model = "gpt-5.4", DisplayName = "agent:main:dashboard",
-                    InputTokens = 58_000, OutputTokens = 12_000,
-                    ContextTokens = 128_000,
-                    UpdatedAt = now.AddHours(-1), LastSeen = now,
-                },
-                new SessionInfo
+                    InputTokens = 188_400,
+                    OutputTokens = 49_200,
+                    TotalTokens = 237_600,
+                    CostUsd = 4.82,
+                    RequestCount = 142,
+                    Model = "claude-opus-4.7",
+                };
+
+                _appState.UsageStatus = new GatewayUsageStatusInfo
                 {
-                    Key = "preview:scratch", IsMain = false, Status = "idle",
-                    Model = "claude-haiku-4.5", DisplayName = "agent:main:scratch",
-                    InputTokens = 6_400, OutputTokens = 1_200,
-                    ContextTokens = 64_000,
-                    UpdatedAt = now.AddHours(-4), LastSeen = now,
-                },
-            };
+                    UpdatedAt = DateTime.UtcNow,
+                    Providers = new()
+                    {
+                        new GatewayUsageProviderInfo
+                        {
+                            Provider = "anthropic", DisplayName = "Anthropic",
+                            Plan = "Pro",
+                            Windows = new()
+                            {
+                                new() { Label = "5h window", UsedPercent = 64 },
+                                new() { Label = "Weekly",    UsedPercent = 28 },
+                                new() { Label = "Monthly",   UsedPercent = 0 },
+                            },
+                        },
+                        new GatewayUsageProviderInfo
+                        {
+                            Provider = "openai", DisplayName = "OpenAI",
+                            Plan = "Tier 4",
+                            Windows = new()
+                            {
+                                new() { Label = "RPM",    UsedPercent = 41 },
+                                new() { Label = "TPM",    UsedPercent = 73 },
+                                new() { Label = "Daily",  UsedPercent = 96 },
+                            },
+                        },
+                    },
+                };
+            }
         }
-
-        _lastUsage = new GatewayUsageInfo
-        {
-            InputTokens = 188_400,
-            OutputTokens = 49_200,
-            TotalTokens = 237_600,
-            CostUsd = 4.82,
-            RequestCount = 142,
-            Model = "claude-opus-4.7",
-        };
-
-        _lastUsageStatus = new GatewayUsageStatusInfo
-        {
-            UpdatedAt = DateTime.UtcNow,
-            Providers = new()
-            {
-                new GatewayUsageProviderInfo
-                {
-                    Provider = "anthropic", DisplayName = "Anthropic",
-                    Plan = "Pro",
-                    Windows = new()
-                    {
-                        new() { Label = "5h window", UsedPercent = 64 },
-                        new() { Label = "Weekly",    UsedPercent = 28 },
-                        new() { Label = "Monthly",   UsedPercent = 0 },
-                    },
-                },
-                new GatewayUsageProviderInfo
-                {
-                    Provider = "openai", DisplayName = "OpenAI",
-                    Plan = "Tier 4",
-                    Windows = new()
-                    {
-                        new() { Label = "RPM",    UsedPercent = 41 },
-                        new() { Label = "TPM",    UsedPercent = 73 },
-                        new() { Label = "Daily",  UsedPercent = 96 },
-                    },
-                },
-            },
-        };
     }
 
 
@@ -1636,70 +1616,14 @@ public partial class App : Application
     /// </summary>
     private void OnOperatorClientChanged(object? sender, OperatorClientChangedEventArgs e)
     {
-        // Unsubscribe from old client
-        if (e.OldClient is { } old)
-        {
-            old.StatusChanged -= OnConnectionStatusChanged;
-            old.AuthenticationFailed -= OnAuthenticationFailed;
-            old.ActivityChanged -= OnActivityChanged;
-            old.NotificationReceived -= OnNotificationReceived;
-            old.ChannelHealthUpdated -= OnChannelHealthUpdated;
-            old.SessionsUpdated -= OnSessionsUpdated;
-            old.UsageUpdated -= OnUsageUpdated;
-            old.UsageStatusUpdated -= OnUsageStatusUpdated;
-            old.UsageCostUpdated -= OnUsageCostUpdated;
-            old.NodesUpdated -= OnNodesUpdated;
-            old.SessionPreviewUpdated -= OnSessionPreviewUpdated;
-            old.SessionCommandCompleted -= OnSessionCommandCompleted;
-            old.GatewaySelfUpdated -= OnGatewaySelfUpdated;
-            old.CronListUpdated -= OnCronListUpdated;
-            old.CronStatusUpdated -= OnCronStatusUpdated;
-            old.CronRunsUpdated -= OnCronRunsUpdated;
-            old.ConfigUpdated -= OnConfigUpdated;
-            old.ConfigSchemaUpdated -= OnConfigSchemaUpdated;
-            old.SkillsStatusUpdated -= OnSkillsStatusUpdated;
-            old.AgentEventReceived -= OnAgentEventReceived;
-            old.NodePairListUpdated -= OnNodePairListUpdated;
-            old.DevicePairListUpdated -= OnDevicePairListUpdated;
-            old.ModelsListUpdated -= OnModelsListUpdated;
-            old.PresenceUpdated -= OnPresenceUpdated;
-            old.AgentsListUpdated -= OnAgentsListUpdated;
-            old.AgentFilesListUpdated -= OnAgentFilesListUpdated;
-            old.AgentFileContentUpdated -= OnAgentFileContentUpdated;
-        }
+        // Delegate all 27 event subscriptions to GatewayService
+        _gatewayService?.AttachClient(e.NewClient, e.OldClient);
 
-        // Subscribe to new client
+        // Configure new client
         if (e.NewClient is { } client)
         {
             client.SetUserRules(_settings?.UserRules?.Count > 0 ? _settings.UserRules : null);
             client.SetPreferStructuredCategories(_settings?.PreferStructuredCategories ?? true);
-            client.StatusChanged += OnConnectionStatusChanged;
-            client.AuthenticationFailed += OnAuthenticationFailed;
-            client.ActivityChanged += OnActivityChanged;
-            client.NotificationReceived += OnNotificationReceived;
-            client.ChannelHealthUpdated += OnChannelHealthUpdated;
-            client.SessionsUpdated += OnSessionsUpdated;
-            client.UsageUpdated += OnUsageUpdated;
-            client.UsageStatusUpdated += OnUsageStatusUpdated;
-            client.UsageCostUpdated += OnUsageCostUpdated;
-            client.NodesUpdated += OnNodesUpdated;
-            client.SessionPreviewUpdated += OnSessionPreviewUpdated;
-            client.SessionCommandCompleted += OnSessionCommandCompleted;
-            client.GatewaySelfUpdated += OnGatewaySelfUpdated;
-            client.CronListUpdated += OnCronListUpdated;
-            client.CronStatusUpdated += OnCronStatusUpdated;
-            client.CronRunsUpdated += OnCronRunsUpdated;
-            client.ConfigUpdated += OnConfigUpdated;
-            client.ConfigSchemaUpdated += OnConfigSchemaUpdated;
-            client.SkillsStatusUpdated += OnSkillsStatusUpdated;
-            client.AgentEventReceived += OnAgentEventReceived;
-            client.NodePairListUpdated += OnNodePairListUpdated;
-            client.DevicePairListUpdated += OnDevicePairListUpdated;
-            client.ModelsListUpdated += OnModelsListUpdated;
-            client.PresenceUpdated += OnPresenceUpdated;
-            client.AgentsListUpdated += OnAgentsListUpdated;
-            client.AgentFilesListUpdated += OnAgentFilesListUpdated;
-            client.AgentFileContentUpdated += OnAgentFileContentUpdated;
 
             var concreteClient = client as OpenClawGatewayClient;
             if (concreteClient == null)
@@ -1713,7 +1637,8 @@ public partial class App : Application
 
         RaiseChatProviderChanged();
 
-        _lastGatewaySelf = null;
+        if (_appState != null)
+            _appState.GatewaySelf = null;
 
         // Update UI references
         OnUiThread(() =>
@@ -1734,6 +1659,7 @@ public partial class App : Application
     /// <summary>
     /// Handles the connection manager's StateChanged event.
     /// Maps the snapshot to the existing tray icon / UI status system.
+    /// Only authoritative writer of <see cref="AppState.Status"/>.
     /// </summary>
     private void OnManagerStateChanged(object? sender, GatewayConnectionSnapshot snap)
     {
@@ -1755,6 +1681,7 @@ public partial class App : Application
         _currentStatus = mapped;
         OnUiThread(() =>
         {
+            if (_appState != null) _appState.Status = mapped;
             _hubWindow?.UpdateStatus(mapped);
             UpdateTrayIcon();
             SyncConnectionToggle(mapped);
@@ -1787,9 +1714,9 @@ public partial class App : Application
             _nodeService.NotificationRequested += OnNodeNotificationRequested;
             _nodeService.ToastRequested += OnNodeToastRequested;
             _nodeService.PairingStatusChanged += OnPairingStatusChanged;
-            _nodeService.ChannelHealthUpdated += OnChannelHealthUpdated;
+            _nodeService.ChannelHealthUpdated += _gatewayService!.OnChannelHealthUpdated;
             _nodeService.InvokeCompleted += OnNodeInvokeCompleted;
-            _nodeService.GatewaySelfUpdated += OnGatewaySelfUpdated;
+            _nodeService.GatewaySelfUpdated += _gatewayService!.OnGatewaySelfUpdated;
             return _nodeService;
         }
         catch (Exception ex)
@@ -1823,14 +1750,14 @@ public partial class App : Application
             nodeConnected = _nodeService?.IsConnected ?? false,
             nodePaired = _nodeService?.IsPaired ?? false,
             nodePendingApproval = _nodeService?.IsPendingApproval ?? false,
-            gatewayVersion = _lastGatewaySelf?.ServerVersion,
-            sessionCount = _lastSessions?.Length ?? 0,
-            nodeCount = _lastNodes?.Length ?? 0,
+            gatewayVersion = _appState!.GatewaySelf?.ServerVersion,
+            sessionCount = _appState!.Sessions?.Length ?? 0,
+            nodeCount = _appState!.Nodes?.Length ?? 0,
         };
 
         app.SessionsHandler = async (agentId) =>
         {
-            var sessions = _lastSessions ?? Array.Empty<SessionInfo>();
+            var sessions = _appState!.Sessions ?? Array.Empty<SessionInfo>();
             if (!string.IsNullOrEmpty(agentId))
                 sessions = sessions.Where(s => s.Key != null &&
                     s.Key.StartsWith($"agent:{agentId}:", StringComparison.OrdinalIgnoreCase)).ToArray();
@@ -1839,8 +1766,8 @@ public partial class App : Application
 
         app.AgentsHandler = async () =>
         {
-            if (_lastAgentsList.HasValue &&
-                _lastAgentsList.Value.TryGetProperty("agents", out var agentsArr) &&
+            if (_appState!.AgentsList.HasValue &&
+                _appState!.AgentsList.Value.TryGetProperty("agents", out var agentsArr) &&
                 agentsArr.ValueKind == System.Text.Json.JsonValueKind.Array)
             {
                 return System.Text.Json.JsonSerializer.Deserialize<object>(agentsArr.GetRawText());
@@ -1850,7 +1777,7 @@ public partial class App : Application
 
         app.NodesHandler = () =>
         {
-            return _lastNodes?.Select(n => new { n.DisplayName, n.NodeId, n.IsOnline, n.Platform, n.CapabilityCount }).ToArray()
+            return _appState!.Nodes?.Select(n => new { n.DisplayName, n.NodeId, n.IsOnline, n.Platform, n.CapabilityCount }).ToArray()
                 ?? Array.Empty<object>();
         };
 
@@ -1915,8 +1842,8 @@ public partial class App : Application
             var items = new List<object>
             {
                 new { type = "status", status = _currentStatus.ToString() },
-                new { type = "sessions", count = _lastSessions?.Length ?? 0 },
-                new { type = "nodes", count = _lastNodes?.Length ?? 0 },
+                new { type = "sessions", count = _appState!.Sessions?.Length ?? 0 },
+                new { type = "nodes", count = _appState!.Nodes?.Length ?? 0 },
             };
             return items;
         };
@@ -2188,32 +2115,15 @@ public partial class App : Application
         return "metadata";
     }
 
-    private void OnConnectionStatusChanged(object? sender, ConnectionStatus status)
+    // ── Re-raised event handlers from GatewayService ──────────────────
+
+    private void OnGatewayConnectionStatusChanged(object? sender, ConnectionStatus status)
     {
-        // Status field is maintained by OnManagerStateChanged — no write needed here.
-        DiagnosticsJsonlService.Write("connection.status", new
-        {
-            status = status.ToString(),
-            nodeMode = _settings?.EnableNodeMode == true
-        });
         _hubWindow?.UpdateStatus(status);
         if (status == ConnectionStatus.Connected)
         {
-            _authFailureMessage = null;
             if (_hubWindow != null && !_hubWindow.IsClosed)
                 _hubWindow.LastAuthError = null;
-        }
-
-        // Clear stale data when disconnected so tray menu doesn't show old sessions/nodes
-        if (status == ConnectionStatus.Disconnected || status == ConnectionStatus.Error)
-        {
-            _lastSessions = Array.Empty<SessionInfo>();
-            _lastChannels = Array.Empty<ChannelHealth>();
-            _lastNodes = Array.Empty<GatewayNodeInfo>();
-            _lastNodePairList = null;
-            _lastDevicePairList = null;
-            _lastModelsList = null;
-            _lastGatewaySelf = null;
         }
 
         UpdateTrayIcon();
@@ -2226,10 +2136,224 @@ public partial class App : Application
                 RefreshTrayMenuIfOpen();
             }
         });
-        
+
         if (status == ConnectionStatus.Connected)
         {
             _ = RunHealthCheckAsync();
+        }
+    }
+
+    private void OnGatewayAuthenticationFailed(object? sender, string message)
+    {
+        UpdateTrayIcon();
+
+        // Forward to hub/connection page
+        if (_hubWindow != null && !_hubWindow.IsClosed)
+        {
+            _hubWindow.LastAuthError = message;
+            _hubWindow.UpdateStatus(_currentStatus);
+        }
+    }
+
+    private void OnGatewaySessionCommandCompleted(object? sender, SessionCommandResult result)
+    {
+        OnUiThread(() =>
+        {
+            try
+            {
+                var title = result.Ok ? "✅ Session updated" : "❌ Session action failed";
+                var key = string.IsNullOrWhiteSpace(result.Key) ? "session" : result.Key!;
+                var message = result.Ok
+                    ? result.Method switch
+                    {
+                        "sessions.patch" => $"Updated settings for {key}",
+                        "sessions.reset" => $"Reset {key}",
+                        "sessions.compact" => result.Kept.HasValue
+                            ? $"Compacted {key} ({result.Kept.Value} lines kept)"
+                            : $"Compacted {key}",
+                        "sessions.delete" => $"Deleted {key}",
+                        _ => $"Completed action for {key}"
+                    }
+                    : result.Error ?? "Request failed";
+                AddRecentActivity(
+                    $"{title.Replace("✅ ", "").Replace("❌ ", "")}: {message}",
+                    category: "session",
+                    dashboardPath: !string.IsNullOrWhiteSpace(result.Key) ? $"sessions/{result.Key}" : "sessions",
+                    sessionKey: result.Key);
+
+                ShowToast(new ToastContentBuilder()
+                    .AddText(title)
+                    .AddText(message));
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn($"Failed to show session action toast: {ex.Message}");
+            }
+        });
+
+        if (result.Ok)
+        {
+            _ = _connectionManager?.OperatorClient?.RequestSessionsAsync();
+        }
+    }
+
+    private void OnGatewayNotificationReceived(object? sender, OpenClawNotification notification)
+    {
+        // Voice overlay: show agent chat responses, and (independently) speak them
+        // if the user enabled "Read responses aloud".
+        if (notification.IsChat && !string.IsNullOrEmpty(notification.Message))
+        {
+            if (_voiceOverlayWindow != null)
+            {
+                OnUiThread(() =>
+                {
+                    try
+                    {
+                        _voiceOverlayWindow?.AddAgentResponse(notification.Message);
+                    }
+                    catch { }
+                });
+            }
+
+            // TTS: read response aloud whenever the toggle is on (any chat surface).
+            if (_settings?.VoiceTtsEnabled == true)
+            {
+                _ = (_chatCoordinator?.SpeakResponseAsync(notification.Message) ?? Task.CompletedTask);
+            }
+        }
+
+        if (_settings?.ShowNotifications != true) return;
+        if (!ShouldShowNotification(notification)) return;
+
+        // Store in history
+        NotificationHistoryService.AddNotification(new Services.GatewayNotification
+        {
+            Title = notification.Title,
+            Message = notification.Message,
+            Category = notification.Type
+        });
+
+        // Show toast
+        try
+        {
+            var builder = new ToastContentBuilder()
+                .AddText(notification.Title ?? "OpenClaw")
+                .AddText(notification.Message);
+
+            var logoPath = GetNotificationIcon(notification.Type);
+            if (!string.IsNullOrEmpty(logoPath) && System.IO.File.Exists(logoPath))
+            {
+                builder.AddAppLogoOverride(new Uri(logoPath), ToastGenericAppLogoCrop.Circle);
+            }
+
+            if (notification.IsChat)
+            {
+                builder.AddArgument("action", "open_chat")
+                       .AddButton(new ToastButton()
+                           .SetContent("Open Chat")
+                           .AddArgument("action", "open_chat"));
+            }
+
+            ShowToast(builder);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Failed to show toast: {ex.Message}");
+        }
+    }
+
+    // ── AppState → HubWindow bridge (temporary until pages observe directly) ──
+
+    private void OnAppStateChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (_hubWindow == null || _hubWindow.IsClosed || _appState == null) return;
+
+        switch (e.PropertyName)
+        {
+            case nameof(AppState.Status):
+                _hubWindow.UpdateStatus(_appState.Status);
+                break;
+            case nameof(AppState.GatewaySelf):
+                _hubWindow.UpdateGatewaySelf(_appState.GatewaySelf!);
+                UpdateStatusDetailWindow();
+                break;
+            case nameof(AppState.Sessions):
+                _hubWindow.UpdateSessions(_appState.Sessions);
+                UpdateStatusDetailWindow();
+                break;
+            case nameof(AppState.Channels):
+                _hubWindow.UpdateChannelHealth(_appState.Channels);
+                _hubWindow.UpdateStatus(_appState.Status);
+                break;
+            case nameof(AppState.Usage):
+                _hubWindow.UpdateUsage(_appState.Usage!);
+                break;
+            case nameof(AppState.UsageStatus):
+                _hubWindow.UpdateUsageStatus(_appState.UsageStatus!);
+                break;
+            case nameof(AppState.UsageCost):
+                _hubWindow.UpdateUsageCost(_appState.UsageCost!);
+                UpdateStatusDetailWindow();
+                break;
+            case nameof(AppState.Nodes):
+                _hubWindow.UpdateNodes(_appState.Nodes);
+                UpdateStatusDetailWindow();
+                break;
+            case nameof(AppState.NodePairList):
+                if (_appState.NodePairList != null)
+                    _hubWindow.UpdateNodePairList(_appState.NodePairList);
+                break;
+            case nameof(AppState.DevicePairList):
+                if (_appState.DevicePairList != null)
+                    _hubWindow.UpdateDevicePairList(_appState.DevicePairList);
+                break;
+            case nameof(AppState.ModelsList):
+                if (_appState.ModelsList != null)
+                    _hubWindow.UpdateModelsList(_appState.ModelsList);
+                break;
+            case nameof(AppState.Presence):
+                if (_appState.Presence != null)
+                    _hubWindow.UpdatePresence(_appState.Presence);
+                break;
+            case nameof(AppState.AgentsList):
+                if (_appState.AgentsList.HasValue)
+                    _hubWindow.UpdateAgentsList(_appState.AgentsList.Value);
+                break;
+            case nameof(AppState.Config):
+                if (_appState.Config.HasValue)
+                    _hubWindow.UpdateConfig(_appState.Config.Value);
+                break;
+            case nameof(AppState.ConfigSchema):
+                if (_appState.ConfigSchema.HasValue)
+                    _hubWindow.UpdateConfigSchema(_appState.ConfigSchema.Value);
+                break;
+            case nameof(AppState.SkillsData):
+                if (_appState.SkillsData.HasValue)
+                    _hubWindow.UpdateSkillsStatus(_appState.SkillsData.Value);
+                break;
+            case nameof(AppState.CronList):
+                if (_appState.CronList.HasValue)
+                    _hubWindow.UpdateCronList(_appState.CronList.Value);
+                break;
+            case nameof(AppState.CronStatus):
+                if (_appState.CronStatus.HasValue)
+                    _hubWindow.UpdateCronStatus(_appState.CronStatus.Value);
+                break;
+            case nameof(AppState.CronRuns):
+                if (_appState.CronRuns.HasValue)
+                    _hubWindow.UpdateCronRuns(_appState.CronRuns.Value);
+                break;
+            case nameof(AppState.AgentFilesList):
+                if (_appState.AgentFilesList.HasValue)
+                    _hubWindow.UpdateAgentFilesList(_appState.AgentFilesList.Value);
+                break;
+            case nameof(AppState.AgentFileContent):
+                if (_appState.AgentFileContent.HasValue)
+                    _hubWindow.UpdateAgentFileContent(_appState.AgentFileContent.Value);
+                break;
+            case nameof(AppState.CurrentActivity):
+                UpdateTrayIcon();
+                break;
         }
     }
 
@@ -2289,416 +2413,6 @@ public partial class App : Application
         }
     }
 
-    private void OnAuthenticationFailed(object? sender, string message)
-    {
-        _authFailureMessage = message;
-        Logger.Error($"Authentication failed: {message}");
-        DiagnosticsJsonlService.Write("connection.auth_failed", new
-        {
-            message,
-            nodeMode = _settings?.EnableNodeMode == true
-        });
-        AddRecentActivity($"Auth failed: {message}", category: "error");
-        UpdateTrayIcon();
-
-        // Forward to hub/connection page
-        if (_hubWindow != null && !_hubWindow.IsClosed)
-        {
-            _hubWindow.LastAuthError = message;
-            _hubWindow.UpdateStatus(_currentStatus);
-        }
-    }
-
-    private void OnActivityChanged(object? sender, AgentActivity? activity)
-    {
-        if (activity == null)
-        {
-            // Activity ended
-            if (_displayedSessionKey != null && _sessionActivities.ContainsKey(_displayedSessionKey))
-            {
-                _sessionActivities.Remove(_displayedSessionKey);
-            }
-            _currentActivity = null;
-        }
-        else
-        {
-            var sessionKey = activity.SessionKey ?? "default";
-            _sessionActivities[sessionKey] = activity;
-            AddRecentActivity(
-                $"{sessionKey}: {activity.Label}",
-                category: "session",
-                dashboardPath: $"sessions/{sessionKey}",
-                details: activity.Kind.ToString(),
-                sessionKey: sessionKey);
-
-            // Debounce session switching
-            var now = DateTime.Now;
-            if (_displayedSessionKey != sessionKey && 
-                (now - _lastSessionSwitch) > SessionSwitchDebounce)
-            {
-                _displayedSessionKey = sessionKey;
-                _lastSessionSwitch = now;
-            }
-
-            if (_displayedSessionKey == sessionKey)
-            {
-                _currentActivity = activity;
-            }
-        }
-        
-        UpdateTrayIcon();
-    }
-
-    private void OnChannelHealthUpdated(object? sender, ChannelHealth[] channels)
-    {
-        _lastChannels = channels;
-        _lastCheckTime = DateTime.Now;
-        var signature = string.Join("|", channels
-            .OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase)
-            .Select(c => $"{c.Name}:{c.Status}:{c.Error}"));
-        if (!string.Equals(signature, _lastChannelStatusSignature, StringComparison.Ordinal))
-        {
-            _lastChannelStatusSignature = signature;
-            var summary = channels.Length == 0
-                ? "No channels reported"
-                : string.Join(", ", channels.Select(c => $"{c.Name}={c.Status}"));
-            DiagnosticsJsonlService.Write("gateway.health.channels", new
-            {
-                channelCount = channels.Length,
-                healthyCount = channels.Count(c => ChannelHealth.IsHealthyStatus(c.Status)),
-                errorCount = channels.Count(c => !string.IsNullOrWhiteSpace(c.Error))
-            });
-            AddRecentActivity("Channel health updated", category: "channel", dashboardPath: "channels", details: summary);
-        }
-
-        OnUiThread(() =>
-        {
-            _hubWindow?.UpdateChannelHealth(channels);
-            _hubWindow?.UpdateStatus(_currentStatus);
-        });
-    }
-
-    private void OnSessionsUpdated(object? sender, SessionInfo[] sessions)
-    {
-        _lastSessions = sessions;
-        OnUiThread(UpdateStatusDetailWindow);
-
-        OnUiThread(() =>
-        {
-            _hubWindow?.UpdateSessions(sessions);
-        });
-
-        var activeKeys = new HashSet<string>(sessions.Select(s => s.Key), StringComparer.Ordinal);
-        lock (_sessionPreviewsLock)
-        {
-            var stale = _sessionPreviews.Keys.Where(key => !activeKeys.Contains(key)).ToArray();
-            foreach (var key in stale)
-                _sessionPreviews.Remove(key);
-        }
-
-        if (_connectionManager?.OperatorClient != null &&
-            sessions.Length > 0 &&
-            DateTime.UtcNow - _lastPreviewRequestUtc > TimeSpan.FromSeconds(5))
-        {
-            _lastPreviewRequestUtc = DateTime.UtcNow;
-            var keys = sessions.Take(5).Select(s => s.Key).ToArray();
-            _ = _connectionManager.OperatorClient.RequestSessionPreviewAsync(keys, limit: 3, maxChars: 140);
-        }
-    }
-
-    private void OnUsageUpdated(object? sender, GatewayUsageInfo usage)
-    {
-        _lastUsage = usage;
-        OnUiThread(() =>
-        {
-            _hubWindow?.UpdateUsage(usage);
-        });
-    }
-
-    private void OnUsageStatusUpdated(object? sender, GatewayUsageStatusInfo usageStatus)
-    {
-        _lastUsageStatus = usageStatus;
-        OnUiThread(() =>
-        {
-            _hubWindow?.UpdateUsageStatus(usageStatus);
-        });
-    }
-
-    private void OnUsageCostUpdated(object? sender, GatewayCostUsageInfo usageCost)
-    {
-        _lastUsageCost = usageCost;
-        OnUiThread(UpdateStatusDetailWindow);
-
-        OnUiThread(() =>
-        {
-            _hubWindow?.UpdateUsageCost(usageCost);
-        });
-
-        if (DateTime.UtcNow - _lastUsageActivityLogUtc > TimeSpan.FromMinutes(1))
-        {
-            _lastUsageActivityLogUtc = DateTime.UtcNow;
-            AddRecentActivity(
-                $"{usageCost.Days}d usage ${usageCost.Totals.TotalCost:F2}",
-                category: "usage",
-                dashboardPath: "usage",
-                details: $"{usageCost.Totals.TotalTokens:N0} tokens");
-        }
-    }
-
-    private void OnGatewaySelfUpdated(object? sender, GatewaySelfInfo gatewaySelf)
-    {
-        _lastGatewaySelf = _lastGatewaySelf?.Merge(gatewaySelf) ?? gatewaySelf;
-        DiagnosticsJsonlService.Write("gateway.self", new
-        {
-            version = _lastGatewaySelf.ServerVersion,
-            protocol = _lastGatewaySelf.Protocol,
-            uptimeMs = _lastGatewaySelf.UptimeMs,
-            authMode = _lastGatewaySelf.AuthMode,
-            stateVersionPresence = _lastGatewaySelf.StateVersionPresence,
-            stateVersionHealth = _lastGatewaySelf.StateVersionHealth,
-            presenceCount = _lastGatewaySelf.PresenceCount
-        });
-        OnUiThread(() =>
-        {
-            UpdateStatusDetailWindow();
-            _hubWindow?.UpdateGatewaySelf(_lastGatewaySelf);
-        });
-    }
-
-    private void OnNodesUpdated(object? sender, GatewayNodeInfo[] nodes)
-    {
-        var previousCount = _lastNodes.Length;
-        var previousOnline = _lastNodes.Count(n => n.IsOnline);
-        var online = nodes.Count(n => n.IsOnline);
-        _lastNodes = nodes;
-        OnUiThread(UpdateStatusDetailWindow);
-
-        OnUiThread(() =>
-        {
-            _hubWindow?.UpdateNodes(nodes);
-        });
-
-        if (nodes.Length != previousCount || online != previousOnline)
-        {
-            AddRecentActivity(
-                $"Nodes {online}/{nodes.Length} online",
-                category: "node",
-                dashboardPath: "nodes");
-        }
-    }
-
-    private void OnSessionPreviewUpdated(object? sender, SessionsPreviewPayloadInfo payload)
-    {
-        lock (_sessionPreviewsLock)
-        {
-            foreach (var preview in payload.Previews)
-            {
-                _sessionPreviews[preview.Key] = preview;
-            }
-        }
-        OnUiThread(UpdateStatusDetailWindow);
-    }
-
-    private void OnSessionCommandCompleted(object? sender, SessionCommandResult result)
-    {
-        OnUiThread(() =>
-        {
-            try
-            {
-                var title = result.Ok ? "✅ Session updated" : "❌ Session action failed";
-                var key = string.IsNullOrWhiteSpace(result.Key) ? "session" : result.Key!;
-                var message = result.Ok
-                    ? result.Method switch
-                    {
-                        "sessions.patch" => $"Updated settings for {key}",
-                        "sessions.reset" => $"Reset {key}",
-                        "sessions.compact" => result.Kept.HasValue
-                            ? $"Compacted {key} ({result.Kept.Value} lines kept)"
-                            : $"Compacted {key}",
-                        "sessions.delete" => $"Deleted {key}",
-                        _ => $"Completed action for {key}"
-                    }
-                    : result.Error ?? "Request failed";
-                AddRecentActivity(
-                    $"{title.Replace("✅ ", "").Replace("❌ ", "")}: {message}",
-                    category: "session",
-                    dashboardPath: !string.IsNullOrWhiteSpace(result.Key) ? $"sessions/{result.Key}" : "sessions",
-                    sessionKey: result.Key);
-
-                ShowToast(new ToastContentBuilder()
-                    .AddText(title)
-                    .AddText(message));
-            }
-            catch (Exception ex)
-            {
-                Logger.Warn($"Failed to show session action toast: {ex.Message}");
-            }
-        });
-
-        if (result.Ok)
-        {
-            _ = _connectionManager?.OperatorClient?.RequestSessionsAsync();
-        }
-    }
-
-    private void OnCronListUpdated(object? sender, System.Text.Json.JsonElement data)
-    {
-        OnUiThread(() => _hubWindow?.UpdateCronList(data));
-    }
-
-    private void OnCronStatusUpdated(object? sender, System.Text.Json.JsonElement data)
-    {
-        OnUiThread(() => _hubWindow?.UpdateCronStatus(data));
-    }
-
-    private void OnCronRunsUpdated(object? sender, System.Text.Json.JsonElement data)
-    {
-        OnUiThread(() => _hubWindow?.UpdateCronRuns(data));
-    }
-
-    private void OnSkillsStatusUpdated(object? sender, System.Text.Json.JsonElement data)
-    {
-        OnUiThread(() => _hubWindow?.UpdateSkillsStatus(data));
-    }
-
-    private void OnConfigUpdated(object? sender, System.Text.Json.JsonElement data)
-    {
-        OnUiThread(() => _hubWindow?.UpdateConfig(data));
-    }
-
-    private void OnConfigSchemaUpdated(object? sender, System.Text.Json.JsonElement data)
-    {
-        OnUiThread(() => _hubWindow?.UpdateConfigSchema(data));
-    }
-
-    private System.Text.Json.JsonElement? _lastAgentsList;
-
-    private void OnAgentsListUpdated(object? sender, System.Text.Json.JsonElement data)
-    {
-        _lastAgentsList = data.Clone();
-        OnUiThread(() => _hubWindow?.UpdateAgentsList(data));
-    }
-
-    private void OnAgentFilesListUpdated(object? sender, System.Text.Json.JsonElement data)
-    {
-        OnUiThread(() => _hubWindow?.UpdateAgentFilesList(data));
-    }
-
-    private void OnAgentFileContentUpdated(object? sender, System.Text.Json.JsonElement data)
-    {
-        OnUiThread(() => _hubWindow?.UpdateAgentFileContent(data));
-    }
-
-    private void OnAgentEventReceived(object? sender, AgentEventInfo evt)
-    {
-        OnUiThread(() =>
-        {
-            _agentEventsCache.Insert(0, evt);
-            if (_agentEventsCache.Count > MaxAppAgentEvents)
-                _agentEventsCache.RemoveRange(MaxAppAgentEvents, _agentEventsCache.Count - MaxAppAgentEvents);
-            _hubWindow?.UpdateAgentEvent(evt);
-        });
-    }
-
-    private void OnNodePairListUpdated(object? sender, PairingListInfo data)
-    {
-        _lastNodePairList = data;
-        OnUiThread(() => _hubWindow?.UpdateNodePairList(data));
-    }
-
-    private void OnDevicePairListUpdated(object? sender, DevicePairingListInfo data)
-    {
-        _lastDevicePairList = data;
-        OnUiThread(() => _hubWindow?.UpdateDevicePairList(data));
-    }
-
-    private void OnModelsListUpdated(object? sender, ModelsListInfo data)
-    {
-        _lastModelsList = data;
-        OnUiThread(() => _hubWindow?.UpdateModelsList(data));
-    }
-
-    private void OnPresenceUpdated(object? sender, PresenceEntry[] data)
-    {
-        _lastPresence = data;
-        OnUiThread(() => _hubWindow?.UpdatePresence(data));
-    }
-
-    private void OnNotificationReceived(object? sender, OpenClawNotification notification)
-    {
-        AddRecentActivity(
-            $"{notification.Type ?? "info"}: {notification.Title ?? "notification"}",
-            category: "notification",
-            details: notification.Message);
-
-        // Voice overlay: show agent chat responses, and (independently) speak them
-        // if the user enabled "Read responses aloud". TTS used to be gated on
-        // an active voice overlay session — we want the toggle to honor every
-        // chat reply now that voice and text chat will eventually share one UI.
-        if (notification.IsChat && !string.IsNullOrEmpty(notification.Message))
-        {
-            if (_voiceOverlayWindow != null)
-            {
-                OnUiThread(() =>
-                {
-                    try
-                    {
-                        _voiceOverlayWindow?.AddAgentResponse(notification.Message);
-                    }
-                    catch { }
-                });
-            }
-
-            // TTS: read response aloud whenever the toggle is on (any chat surface).
-            if (_settings?.VoiceTtsEnabled == true)
-            {
-                _ = (_chatCoordinator?.SpeakResponseAsync(notification.Message) ?? Task.CompletedTask);
-            }
-        }
-
-        if (_settings?.ShowNotifications != true) return;
-        if (!ShouldShowNotification(notification)) return;
-
-        // Store in history
-        NotificationHistoryService.AddNotification(new Services.GatewayNotification
-        {
-            Title = notification.Title,
-            Message = notification.Message,
-            Category = notification.Type
-        });
-
-        // Show toast
-        try
-        {
-            var builder = new ToastContentBuilder()
-                .AddText(notification.Title ?? "OpenClaw")
-                .AddText(notification.Message);
-
-            // Add category-specific inline image (emoji rendered as text is fine, 
-            // but we can add app logo override for better visibility)
-            var logoPath = GetNotificationIcon(notification.Type);
-            if (!string.IsNullOrEmpty(logoPath) && System.IO.File.Exists(logoPath))
-            {
-                builder.AddAppLogoOverride(new Uri(logoPath), ToastGenericAppLogoCrop.Circle);
-            }
-
-            // Add "Open Chat" button for chat notifications
-            if (notification.IsChat)
-            {
-                builder.AddArgument("action", "open_chat")
-                       .AddButton(new ToastButton()
-                           .SetContent("Open Chat")
-                           .AddArgument("action", "open_chat"));
-            }
-
-            ShowToast(builder);
-        }
-        catch (Exception ex)
-        {
-            Logger.Warn($"Failed to show toast: {ex.Message}");
-        }
-    }
-
     private static string? GetNotificationIcon(string? type)
     {
         // For now, use the app icon for all notifications
@@ -2744,7 +2458,7 @@ public partial class App : Application
         {
             if (_settings?.EnableNodeMode == true && _nodeService?.IsConnected == true)
             {
-                _lastCheckTime = DateTime.Now;
+                _appState!.LastCheckTime = DateTime.Now;
                 OnUiThread(UpdateStatusDetailWindow);
                 if (userInitiated)
                 {
@@ -2766,7 +2480,7 @@ public partial class App : Application
 
         try
         {
-            _lastCheckTime = DateTime.Now;
+            _appState!.LastCheckTime = DateTime.Now;
             await client.CheckHealthAsync();
             if (userInitiated)
             {
@@ -2837,12 +2551,12 @@ public partial class App : Application
     private TrayStateSnapshot CaptureTraySnapshot() => new TrayStateSnapshot
     {
         Status = _currentStatus,
-        CurrentActivity = _currentActivity,
-        Channels = _lastChannels,
-        Nodes = _lastNodes,
+        CurrentActivity = _appState!.CurrentActivity,
+        Channels = _appState!.Channels,
+        Nodes = _appState!.Nodes,
         LocalNodeFallback = _nodeService?.GetLocalNodeInfo(),
-        AuthFailureMessage = _authFailureMessage,
-        LastCheckTime = _lastCheckTime,
+        AuthFailureMessage = _appState!.AuthFailureMessage,
+        LastCheckTime = _appState!.LastCheckTime,
         Settings = _settings
     };
 
@@ -2856,6 +2570,7 @@ public partial class App : Application
         {
             _hubWindow = new HubWindow();
             _hubWindow.Settings = _settings;
+            _hubWindow.AppModel = _appState;
             _hubWindow.GatewayClient = _connectionManager?.OperatorClient;
             _hubWindow.CurrentStatus = _currentStatus;
             _hubWindow.OpenDashboardAction = OpenDashboard;
@@ -2881,7 +2596,7 @@ public partial class App : Application
             {
                 _ = _connectionManager?.ReconnectAsync();
             };
-            _hubWindow.ClearAppAgentEventsCache = () => _agentEventsCache.Clear();
+            _hubWindow.ClearAppAgentEventsCache = () => _appState!.ClearAgentEvents();
             if (_nodeService != null)
             {
                 _hubWindow.NodeIsConnected = _nodeService.IsConnected;
@@ -2954,15 +2669,15 @@ public partial class App : Application
     {
         if (_hubWindow == null) return;
         // Seed all cached data types so pages see data immediately
-        if (_lastSessions.Length > 0) _hubWindow.UpdateSessions(_lastSessions);
-        if (_lastNodes.Length > 0) _hubWindow.UpdateNodes(_lastNodes);
-        if (_lastNodePairList != null) _hubWindow.UpdateNodePairList(_lastNodePairList);
-        if (_lastDevicePairList != null) _hubWindow.UpdateDevicePairList(_lastDevicePairList);
-        if (_lastModelsList != null) _hubWindow.UpdateModelsList(_lastModelsList);
-        if (_lastPresence != null) _hubWindow.UpdatePresence(_lastPresence);
-        if (_lastGatewaySelf != null) _hubWindow.UpdateGatewaySelf(_lastGatewaySelf);
-        if (_lastAgentsList.HasValue) _hubWindow.UpdateAgentsList(_lastAgentsList.Value);
-        if (_agentEventsCache.Count > 0) _hubWindow.SeedAgentEvents(_agentEventsCache);
+        if (_appState!.Sessions.Length > 0) _hubWindow.UpdateSessions(_appState!.Sessions);
+        if (_appState!.Nodes.Length > 0) _hubWindow.UpdateNodes(_appState!.Nodes);
+        if (_appState!.NodePairList != null) _hubWindow.UpdateNodePairList(_appState!.NodePairList);
+        if (_appState!.DevicePairList != null) _hubWindow.UpdateDevicePairList(_appState!.DevicePairList);
+        if (_appState!.ModelsList != null) _hubWindow.UpdateModelsList(_appState!.ModelsList);
+        if (_appState!.Presence != null) _hubWindow.UpdatePresence(_appState!.Presence);
+        if (_appState!.GatewaySelf != null) _hubWindow.UpdateGatewaySelf(_appState!.GatewaySelf);
+        if (_appState!.AgentsList.HasValue) _hubWindow.UpdateAgentsList(_appState!.AgentsList.Value);
+        if (_appState!.AgentEvents.Count > 0) _hubWindow.SeedAgentEvents();
     }
 
     private void ShowSettings()
@@ -2987,7 +2702,7 @@ public partial class App : Application
             case SettingsChangeImpact.FullReconnectRequired:
             case SettingsChangeImpact.OperatorReconnectRequired:
                 // Full reconnect: tear down everything and rebuild
-                _lastGatewaySelf = null;
+                _appState!.GatewaySelf = null;
                 if (_settings?.UseSshTunnel != true)
                 {
                     _sshTunnelService?.Stop();
@@ -3212,16 +2927,16 @@ public partial class App : Application
     private AppStateSnapshot CaptureSnapshot() => new AppStateSnapshot
     {
         Status = _currentStatus,
-        LastCheckTime = _lastCheckTime,
-        Channels = _lastChannels,
-        Sessions = _lastSessions,
-        Nodes = _lastNodes,
-        Usage = _lastUsage,
-        UsageStatus = _lastUsageStatus,
-        UsageCost = _lastUsageCost,
-        GatewaySelf = _lastGatewaySelf,
-        AuthFailureMessage = _authFailureMessage,
-        LastUpdateInfo = _lastUpdateInfo,
+        LastCheckTime = _appState!.LastCheckTime,
+        Channels = _appState!.Channels,
+        Sessions = _appState!.Sessions,
+        Nodes = _appState!.Nodes,
+        Usage = _appState!.Usage,
+        UsageStatus = _appState!.UsageStatus,
+        UsageCost = _appState!.UsageCost,
+        GatewaySelf = _appState!.GatewaySelf,
+        AuthFailureMessage = _appState!.AuthFailureMessage,
+        LastUpdateInfo = _appState!.UpdateInfo,
         Settings = _settings,
         NodeService = _nodeService,
         SshTunnelSnapshot = _sshTunnelService?.CreateSnapshot(),
@@ -3469,12 +3184,31 @@ public partial class App : Application
         }
     }
 
+    // ── IAppCommands implementation ─────────────────────────────────────
+
+    void IAppCommands.OpenDashboard(string? path) => OpenDashboard(path);
+    void IAppCommands.Navigate(string pageTag) => ShowHub(pageTag);
+    void IAppCommands.Reconnect() => _ = _connectionManager?.ReconnectAsync();
+    void IAppCommands.Disconnect()
+    {
+        _ = _connectionManager?.DisconnectAsync();
+        UpdateTrayIcon();
+        _hubWindow?.UpdateStatus(ConnectionStatus.Disconnected);
+    }
+    void IAppCommands.ShowVoiceOverlay() => ShowVoiceOverlay();
+    void IAppCommands.ShowChat() => ShowChatWindow();
+    void IAppCommands.ShowQuickSend() => ShowQuickSend();
+    void IAppCommands.CheckForUpdates() => _ = CheckForUpdatesUserInitiatedAsync();
+    void IAppCommands.ShowOnboarding() => _ = ShowOnboardingAsync();
+    void IAppCommands.ShowConnectionStatus() => ShowConnectionStatusWindow();
+    void IAppCommands.NotifySettingsSaved() => OnSettingsSaved(this, EventArgs.Empty);
+
     private async void ToggleChannel(string channelName)
     {
         var client = _connectionManager?.OperatorClient;
         if (client == null) return;
 
-        var channel = _lastChannels.FirstOrDefault(c => c.Name == channelName);
+        var channel = _appState!.Channels.FirstOrDefault(c => c.Name == channelName);
         if (channel == null) return;
 
         try
@@ -3637,7 +3371,7 @@ public partial class App : Application
         {
 #if DEBUG
             Logger.Info("Skipping update check in debug build");
-            _lastUpdateInfo = new UpdateCommandCenterInfo
+            _appState!.UpdateInfo = new UpdateCommandCenterInfo
             {
                 Status = "Skipped",
                 CurrentVersion = typeof(App).Assembly.GetName().Version?.ToString() ?? "unknown",
@@ -3647,7 +3381,7 @@ public partial class App : Application
             return true;
 #else
             Logger.Info("Checking for updates...");
-            _lastUpdateInfo = new UpdateCommandCenterInfo
+            _appState!.UpdateInfo = new UpdateCommandCenterInfo
             {
                 Status = "Checking",
                 CurrentVersion = typeof(App).Assembly.GetName().Version?.ToString() ?? "unknown",
@@ -3658,7 +3392,7 @@ public partial class App : Application
             if (!updateFound)
             {
                 Logger.Info("No updates available");
-                _lastUpdateInfo = new UpdateCommandCenterInfo
+                _appState!.UpdateInfo = new UpdateCommandCenterInfo
                 {
                     Status = "Current",
                     CurrentVersion = typeof(App).Assembly.GetName().Version?.ToString() ?? "unknown",
@@ -3671,7 +3405,7 @@ public partial class App : Application
             var release = AppUpdater.LatestRelease!;
             var changelog = AppUpdater.GetChangelog(true) ?? "No release notes available.";
             Logger.Info($"Update available: {release.TagName}");
-            _lastUpdateInfo = new UpdateCommandCenterInfo
+            _appState!.UpdateInfo = new UpdateCommandCenterInfo
             {
                 Status = "Available",
                 CurrentVersion = typeof(App).Assembly.GetName().Version?.ToString() ?? "unknown",
@@ -3684,7 +3418,7 @@ public partial class App : Application
                 string.Equals(_settings.SkippedUpdateTag, release.TagName, StringComparison.OrdinalIgnoreCase))
             {
                 Logger.Info($"Skipping update prompt for remembered version {release.TagName}");
-                _lastUpdateInfo.Detail = "skipped by user";
+                _appState!.UpdateInfo.Detail = "skipped by user";
                 return true;
             }
 
@@ -3693,7 +3427,7 @@ public partial class App : Application
 
             if (result == UpdateDialogResult.Download)
             {
-                _lastUpdateInfo.Detail = "download requested";
+                _appState!.UpdateInfo.Detail = "download requested";
                 if (_settings != null)
                 {
                     _settings.SkippedUpdateTag = string.Empty;
@@ -3707,7 +3441,7 @@ public partial class App : Application
             {
                 _settings.SkippedUpdateTag = release.TagName ?? string.Empty;
                 _settings.Save();
-                _lastUpdateInfo.Detail = "skipped by user";
+                _appState!.UpdateInfo.Detail = "skipped by user";
             }
 
             return true; // RemindLater or Skip - continue
@@ -3716,7 +3450,7 @@ public partial class App : Application
         catch (Exception ex)
         {
             Logger.Warn($"Update check failed: {ex.Message}");
-            _lastUpdateInfo = new UpdateCommandCenterInfo
+            _appState!.UpdateInfo = new UpdateCommandCenterInfo
             {
                 Status = "Failed",
                 CurrentVersion = typeof(App).Assembly.GetName().Version?.ToString() ?? "unknown",

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -63,6 +63,13 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     public GatewayConnectionManager? ConnectionManager => _connectionManager;
     internal SettingsManager Settings => _settings ?? throw new InvalidOperationException("Settings are not initialized.");
 
+    /// <summary>The active hub window, exposed so pages can obtain an HWND for file pickers.</summary>
+    internal Microsoft.UI.Xaml.Window? ActiveHubWindow => _hubWindow;
+    /// <summary>The current voice service instance (node or standalone).</summary>
+    internal VoiceService? VoiceService => _nodeService?.VoiceService ?? _standaloneVoiceService;
+    /// <summary>The full device ID of the local node service (if running).</summary>
+    internal string? NodeFullDeviceId => _nodeService?.FullDeviceId;
+
     public OpenClawTray.Chat.OpenClawChatDataProvider? ChatProvider => _chatCoordinator?.Provider;
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1249,8 +1249,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private void LocalDisconnectCleanup()
     {
         _appState?.ClearCachedData();
+        if (_appState != null) _appState.Status = ConnectionStatus.Disconnected;
         UpdateTrayIcon();
-        _hubWindow?.UpdateStatus(ConnectionStatus.Disconnected);
         RefreshTrayMenuIfOpen();
     }
 
@@ -1647,11 +1647,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         {
             if (_appState != null)
                 _appState.GatewaySelf = null;
-            if (_hubWindow != null && !_hubWindow.IsClosed)
-            {
-                _hubWindow.GatewayClient = _connectionManager?.OperatorClient;
-                _hubWindow.CurrentStatus = _appState!.Status;
-            }
         });
     }
 
@@ -1684,7 +1679,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         OnUiThread(() =>
         {
             if (_appState != null) _appState.Status = mapped;
-            _hubWindow?.UpdateStatus(mapped);
             UpdateTrayIcon();
             SyncConnectionToggle(mapped);
             if (mapped is ConnectionStatus.Connected or ConnectionStatus.Disconnected or ConnectionStatus.Error)
@@ -1905,13 +1899,9 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         if (_settings?.EnableNodeMode == true)
         {
             // Status field is maintained by OnManagerStateChanged — no write needed here.
-            _hubWindow?.UpdateStatus(status);
             UpdateTrayIcon();
             OnUiThread(UpdateStatusDetailWindow);
         }
-
-        // Keep hub node state in sync for ConnectionPage
-        SyncHubNodeState();
         
         // Don't show "connected" toast if waiting for pairing - we'll show pairing status instead
         var nodeService = _nodeService;
@@ -2014,32 +2004,12 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             }
         }
         catch { /* ignore */ }
-
-        SyncHubNodeState();
     }
 
     /// <summary>
     /// Pushes current node service state to hub window so ConnectionPage reflects live pairing/identity.
+    /// Now a no-op — pages read App properties directly via CurrentApp.
     /// </summary>
-    private void SyncHubNodeState()
-    {
-        if (_hubWindow == null || _hubWindow.IsClosed) return;
-        if (_nodeService != null)
-        {
-            _hubWindow.NodeIsConnected = _nodeService.IsConnected;
-            _hubWindow.NodeIsPaired = _nodeService.IsPaired;
-            _hubWindow.NodeIsPendingApproval = _nodeService.IsPendingApproval;
-            _hubWindow.NodeShortDeviceId = _nodeService.ShortDeviceId;
-            _hubWindow.NodeFullDeviceId = _nodeService.FullDeviceId;
-            _hubWindow.VoiceServiceInstance = _nodeService.VoiceService;
-        }
-        else
-        {
-            _hubWindow.NodeIsConnected = false;
-            _hubWindow.NodeIsPaired = false;
-            _hubWindow.NodeIsPendingApproval = false;
-        }
-    }
 
     public static string BuildPairingApprovalCommand(string deviceId) =>
         $"openclaw devices approve {deviceId}";
@@ -2122,11 +2092,9 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
     private void OnGatewayConnectionStatusChanged(object? sender, ConnectionStatus status)
     {
-        _hubWindow?.UpdateStatus(status);
-        if (status == ConnectionStatus.Connected)
+        if (status == ConnectionStatus.Connected && _appState != null)
         {
-            if (_hubWindow != null && !_hubWindow.IsClosed)
-                _hubWindow.LastAuthError = null;
+            _appState.AuthFailureMessage = null;
         }
 
         UpdateTrayIcon();
@@ -2150,11 +2118,10 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     {
         UpdateTrayIcon();
 
-        // Forward to hub/connection page
-        if (_hubWindow != null && !_hubWindow.IsClosed)
+        // Store auth failure in AppState — HubWindow observes it via PropertyChanged
+        if (_appState != null)
         {
-            _hubWindow.LastAuthError = message;
-            _hubWindow.UpdateStatus(_appState!.Status);
+            _appState.AuthFailureMessage = message;
         }
     }
 
@@ -2265,7 +2232,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         }
     }
 
-    // ── AppState → App-level side effects (title bar, tray, status detail) ──
+    // ── AppState → tray-level side effects (tray icon, tray menu, status detail) ──
 
     private void OnAppStateChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
@@ -2273,13 +2240,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
         switch (e.PropertyName)
         {
-            case nameof(AppState.Status):
-                if (_hubWindow != null && !_hubWindow.IsClosed)
-                    _hubWindow.UpdateStatus(_appState.Status);
-                break;
             case nameof(AppState.GatewaySelf):
-                if (_hubWindow != null && !_hubWindow.IsClosed && _appState.GatewaySelf != null)
-                    _hubWindow.UpdateGatewaySelf(_appState.GatewaySelf);
                 UpdateStatusDetailWindow();
                 RefreshTrayMenuIfOpen();
                 break;
@@ -2288,8 +2249,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 RefreshTrayMenuIfOpen();
                 break;
             case nameof(AppState.Channels):
-                if (_hubWindow != null && !_hubWindow.IsClosed)
-                    _hubWindow.UpdateStatus(_appState.Status);
                 RefreshTrayMenuIfOpen();
                 break;
             case nameof(AppState.UsageCost):
@@ -2299,10 +2258,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             case nameof(AppState.Nodes):
                 UpdateStatusDetailWindow();
                 RefreshTrayMenuIfOpen();
-                break;
-            case nameof(AppState.AgentsList):
-                if (_hubWindow != null && !_hubWindow.IsClosed && _appState.AgentsList.HasValue)
-                    _hubWindow.UpdateAgentsList(_appState.AgentsList.Value);
                 break;
             case nameof(AppState.CurrentActivity):
                 UpdateTrayIcon();
@@ -2549,42 +2504,9 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         if (_hubWindow == null || _hubWindow.IsClosed)
         {
             _hubWindow = new HubWindow();
-            _hubWindow.Settings = _settings;
             _hubWindow.AppModel = _appState;
-            _hubWindow.GatewayClient = _connectionManager?.OperatorClient;
-            _hubWindow.CurrentStatus = _appState!.Status;
-            _hubWindow.OpenDashboardAction = OpenDashboard;
-            _hubWindow.CheckForUpdatesAction = () => _ = CheckForUpdatesUserInitiatedAsync();
+            _hubWindow.ApplyNavPaneState(_settings!);
             _hubWindow.QuickSendAction = () => ShowQuickSend();
-            _hubWindow.OpenSetupAction = () => _ = ShowOnboardingAsync();
-            _hubWindow.OpenConnectionStatusAction = ShowConnectionStatusWindow;
-            _hubWindow.OpenVoiceAction = () => ShowVoiceOverlay();
-            _hubWindow.ConnectionManager = _connectionManager;
-            _hubWindow.GatewayRegistry = _gatewayRegistry;
-            _hubWindow.ConnectAction = () =>
-            {
-                _ = _connectionManager?.ReconnectAsync();
-            };
-            _hubWindow.DisconnectAction = () =>
-            {
-                _ = _connectionManager?.DisconnectAsync();
-                // Status is updated by OnManagerStateChanged when disconnect completes.
-                UpdateTrayIcon();
-                _hubWindow?.UpdateStatus(ConnectionStatus.Disconnected);
-            };
-            _hubWindow.ReconnectAction = () =>
-            {
-                _ = _connectionManager?.ReconnectAsync();
-            };
-            if (_nodeService != null)
-            {
-                _hubWindow.NodeIsConnected = _nodeService.IsConnected;
-                _hubWindow.NodeIsPaired = _nodeService.IsPaired;
-                _hubWindow.NodeIsPendingApproval = _nodeService.IsPendingApproval;
-                _hubWindow.NodeShortDeviceId = _nodeService.ShortDeviceId;
-                _hubWindow.NodeFullDeviceId = _nodeService.FullDeviceId;
-            }
-            _hubWindow.VoiceServiceInstance = _nodeService?.VoiceService ?? _standaloneVoiceService;
             _hubWindow.SettingsSaved += OnSettingsSaved;
             _hubWindow.Closed += (s, e) =>
             {
@@ -2592,28 +2514,11 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 _hubWindow = null;
             };
 
-            // Seed ALL cached data BEFORE first navigation so pages see data in Initialize()
-            SeedHubCachedData();
+            _hubWindow.BindToAppState();
 
-            // Navigate to default page now that properties and data are set
+            // Navigate to default page now that AppModel is set
             _hubWindow.NavigateToDefault();
         }
-        // Always update live state
-        _hubWindow.Settings = _settings;
-        _hubWindow.GatewayClient = _connectionManager?.OperatorClient;
-        _hubWindow.CurrentStatus = _appState!.Status;
-        _hubWindow.VoiceServiceInstance = _nodeService?.VoiceService ?? _standaloneVoiceService;
-        if (_nodeService != null)
-        {
-            _hubWindow.NodeIsConnected = _nodeService.IsConnected;
-            _hubWindow.NodeIsPaired = _nodeService.IsPaired;
-            _hubWindow.NodeIsPendingApproval = _nodeService.IsPendingApproval;
-            _hubWindow.NodeShortDeviceId = _nodeService.ShortDeviceId;
-            _hubWindow.NodeFullDeviceId = _nodeService.FullDeviceId;
-        }
-
-        // Seed cached data into hub (also on re-show)
-        SeedHubCachedData();
 
         if (navigateTo != null)
         {
@@ -2644,14 +2549,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         }
     }
 
-    private void SeedHubCachedData()
-    {
-        if (_hubWindow == null) return;
-        // Seed only what HubWindow itself needs (nav sidebar + title bar)
-        if (_appState!.GatewaySelf != null) _hubWindow.UpdateGatewaySelf(_appState!.GatewaySelf);
-        if (_appState!.AgentsList.HasValue) _hubWindow.UpdateAgentsList(_appState!.AgentsList.Value);
-    }
-
     private void ShowSettings()
     {
         ShowHub("settings");
@@ -2680,7 +2577,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                     _sshTunnelService?.Stop();
                 }
                 // Status is updated by OnManagerStateChanged when reconnect starts.
-                _hubWindow?.UpdateStatus(ConnectionStatus.Disconnected);
+                if (_appState != null) _appState.Status = ConnectionStatus.Disconnected;
                 UpdateTrayIcon();
 
                 // Reset chat window — it has a stale URL/token
@@ -2723,14 +2620,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         }
 
         AutoStartManager.SetAutoStart(_settings.AutoStart);
-
-        // Keep hub window in sync
-        if (_hubWindow != null && !_hubWindow.IsClosed)
-        {
-            _hubWindow.Settings = _settings;
-            _hubWindow.GatewayClient = _connectionManager?.OperatorClient;
-            _hubWindow.CurrentStatus = _appState!.Status;
-        }
 
         // Notify ad-hoc listeners (e.g. ChatWindow may be alive but not
         // owned by the hub) that settings have changed.
@@ -2890,7 +2779,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
     private void UpdateStatusDetailWindow()
     {
-        _hubWindow?.UpdateStatus(_appState!.Status);
+        // No-op — hub window observes AppState.PropertyChanged directly.
+        // Tray status detail window reads from AppState too.
     }
 
     private GatewayCommandCenterState BuildCommandCenterState() =>
@@ -2977,13 +2867,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 TryStartLocalMcpOnlyNode();
             }
 
-            // Keep hub window in sync with new client
-            if (_hubWindow != null && !_hubWindow.IsClosed)
-            {
-                _hubWindow.Settings = _settings;
-                _hubWindow.GatewayClient = _connectionManager?.OperatorClient;
-                _hubWindow.CurrentStatus = _appState!.Status;
-            }
+            // Keep hub window in sync with new client — no shadow state to push,
+            // hub observes AppState directly.
         };
         _onboardingWindow.Closed += (s, e) =>
         {
@@ -3106,7 +2991,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     {
         _ = _connectionManager?.DisconnectAsync();
         UpdateTrayIcon();
-        _hubWindow?.UpdateStatus(ConnectionStatus.Disconnected);
     }
     void IAppCommands.ShowVoiceOverlay() => ShowVoiceOverlay();
     void IAppCommands.ShowChat() => ShowChatWindow();
@@ -3668,7 +3552,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             {
                 Logger.Warn("SSH tunnel is enabled but settings are incomplete");
                 _appState!.Status = ConnectionStatus.Error;
-                _hubWindow?.UpdateStatus(_appState!.Status);
                 UpdateTrayIcon();
                 return false;
             }
@@ -3697,7 +3580,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             {
                 Logger.Error($"Failed to start SSH tunnel: {ex.Message}");
                 _appState!.Status = ConnectionStatus.Error;
-                _hubWindow?.UpdateStatus(_appState!.Status);
                 UpdateTrayIcon();
                 return false;
             }

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1642,12 +1642,11 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
         RaiseChatProviderChanged();
 
-        if (_appState != null)
-            _appState.GatewaySelf = null;
-
         // Update UI references
         OnUiThread(() =>
         {
+            if (_appState != null)
+                _appState.GatewaySelf = null;
             if (_hubWindow != null && !_hubWindow.IsClosed)
             {
                 _hubWindow.GatewayClient = _connectionManager?.OperatorClient;
@@ -2279,8 +2278,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                     _hubWindow.UpdateStatus(_appState.Status);
                 break;
             case nameof(AppState.GatewaySelf):
-                if (_hubWindow != null && !_hubWindow.IsClosed)
-                    _hubWindow.UpdateGatewaySelf(_appState.GatewaySelf!);
+                if (_hubWindow != null && !_hubWindow.IsClosed && _appState.GatewaySelf != null)
+                    _hubWindow.UpdateGatewaySelf(_appState.GatewaySelf);
                 UpdateStatusDetailWindow();
                 break;
             case nameof(AppState.Sessions):

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -122,10 +122,10 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     public LocalGatewaySetupEngine CreateLocalGatewaySetupEngine(
         bool replaceExistingConfigurationConfirmed = false)
     {
-        if (_connectionManager == null || _gatewayRegistry == null)
+        if (_connectionManager == null || _gatewayRegistry == null || _gatewayService == null)
         {
             throw new InvalidOperationException(
-                "GatewayConnectionManager / GatewayRegistry must be initialized before " +
+                "GatewayConnectionManager / GatewayRegistry / GatewayService must be initialized before " +
                 "CreateLocalGatewaySetupEngine. App.OnLaunched initializes them before " +
                 "ShowOnboardingAsync — if you reach here, the init order has regressed.");
         }
@@ -1263,7 +1263,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private void LocalDisconnectCleanup()
     {
         _appState?.ClearCachedData();
-        if (_appState != null) _appState.Status = ConnectionStatus.Disconnected;
         UpdateTrayIcon();
         // Dismiss the tray menu on disconnect — it will capture fresh data on next open
         _trayMenuWindow?.HideCascade();
@@ -1643,6 +1642,15 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     /// </summary>
     private void OnOperatorClientChanged(object? sender, OperatorClientChangedEventArgs e)
     {
+        if (_dispatcherQueue is { HasThreadAccess: false } dispatcher)
+        {
+            if (!dispatcher.TryEnqueue(() => OnOperatorClientChanged(sender, e)))
+            {
+                Logger.Warn("[ConnMgr] Failed to dispatch operator client swap to UI thread");
+            }
+            return;
+        }
+
         // Delegate all 27 event subscriptions to GatewayService
         _gatewayService?.AttachClient(e.NewClient, e.OldClient);
 
@@ -1665,11 +1673,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         RaiseChatProviderChanged();
 
         // Update UI references
-        OnUiThread(() =>
-        {
-            if (_appState != null)
-                _appState.GatewaySelf = null;
-        });
+        if (_appState != null)
+            _appState.GatewaySelf = null;
     }
 
     private void RaiseChatProviderChanged()
@@ -1680,7 +1685,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     /// <summary>
     /// Handles the connection manager's StateChanged event.
     /// Maps the snapshot to the existing tray icon / UI status system.
-    /// Only authoritative writer of <see cref="AppState.Status"/>.
+    /// Authoritative writer of gateway lifecycle status. Local prerequisite
+    /// failures can still mark the app Error before the manager can connect.
     /// </summary>
     private void OnManagerStateChanged(object? sender, GatewayConnectionSnapshot snap)
     {
@@ -1719,6 +1725,12 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         if (_dispatcherQueue == null)
             return null;
 
+        if (_gatewayService == null)
+        {
+            Logger.Error("GatewayService must be initialized before NodeService event wiring");
+            return null;
+        }
+
         try
         {
             _nodeService = new NodeService(
@@ -1733,9 +1745,9 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             _nodeService.NotificationRequested += OnNodeNotificationRequested;
             _nodeService.ToastRequested += OnNodeToastRequested;
             _nodeService.PairingStatusChanged += OnPairingStatusChanged;
-            _nodeService.ChannelHealthUpdated += _gatewayService!.OnChannelHealthUpdated;
+            _nodeService.ChannelHealthUpdated += _gatewayService.OnChannelHealthUpdated;
             _nodeService.InvokeCompleted += OnNodeInvokeCompleted;
-            _nodeService.GatewaySelfUpdated += _gatewayService!.OnGatewaySelfUpdated;
+            _nodeService.GatewaySelfUpdated += _gatewayService.OnGatewaySelfUpdated;
             return _nodeService;
         }
         catch (Exception ex)
@@ -2528,7 +2540,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                     _sshTunnelService?.Stop();
                 }
                 // Status is updated by OnManagerStateChanged when reconnect starts.
-                if (_appState != null) _appState.Status = ConnectionStatus.Disconnected;
                 UpdateTrayIcon();
 
                 // Reset chat window — it has a stale URL/token

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -2281,19 +2281,24 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 if (_hubWindow != null && !_hubWindow.IsClosed && _appState.GatewaySelf != null)
                     _hubWindow.UpdateGatewaySelf(_appState.GatewaySelf);
                 UpdateStatusDetailWindow();
+                RefreshTrayMenuIfOpen();
                 break;
             case nameof(AppState.Sessions):
                 UpdateStatusDetailWindow();
+                RefreshTrayMenuIfOpen();
                 break;
             case nameof(AppState.Channels):
                 if (_hubWindow != null && !_hubWindow.IsClosed)
                     _hubWindow.UpdateStatus(_appState.Status);
+                RefreshTrayMenuIfOpen();
                 break;
             case nameof(AppState.UsageCost):
                 UpdateStatusDetailWindow();
+                RefreshTrayMenuIfOpen();
                 break;
             case nameof(AppState.Nodes):
                 UpdateStatusDetailWindow();
+                RefreshTrayMenuIfOpen();
                 break;
             case nameof(AppState.AgentsList):
                 if (_hubWindow != null && !_hubWindow.IsClosed && _appState.AgentsList.HasValue)
@@ -2302,10 +2307,37 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             case nameof(AppState.CurrentActivity):
                 UpdateTrayIcon();
                 break;
+            case nameof(AppState.Usage):
+            case nameof(AppState.UsageStatus):
+            case nameof(AppState.Presence):
+            case nameof(AppState.NodePairList):
+            case nameof(AppState.DevicePairList):
+                RefreshTrayMenuIfOpen();
+                break;
         }
     }
 
+    private bool _trayMenuRefreshPending;
+
     private void RefreshTrayMenuIfOpen()
+    {
+        if (_trayMenuWindow == null || !_trayMenuWindow.IsShown)
+            return;
+
+        // Debounce: multiple AppState properties change in rapid succession
+        // (sessions, nodes, usage, channels all arrive on connect).
+        // Coalesce into a single rebuild on the next dispatcher tick.
+        if (_trayMenuRefreshPending)
+            return;
+        _trayMenuRefreshPending = true;
+        _dispatcherQueue?.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
+        {
+            _trayMenuRefreshPending = false;
+            RefreshTrayMenuNow();
+        });
+    }
+
+    private void RefreshTrayMenuNow()
     {
         try
         {

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -178,6 +178,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private Mutex? _mutex;
     private Microsoft.UI.Dispatching.DispatcherQueue? _dispatcherQueue;
     private AppState? _appState;
+    internal AppState? AppState => _appState;
     private GatewayService? _gatewayService;
     private CancellationTokenSource? _deepLinkCts;
     private bool _isExiting;
@@ -187,7 +188,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     /// Reads are safe from any thread; derives from the connection manager's state machine.
     /// SSH tunnel errors in EnsureSshTunnelConfigured also write this temporarily (Phase 3 moves tunnel to manager).
     /// </summary>
-    private ConnectionStatus _currentStatus = ConnectionStatus.Disconnected;
     private WeakReference<ToggleSwitch>? _connectionToggleRef;
     private bool _suspendConnectionToggleEvent;
 
@@ -609,7 +609,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         _gatewayService.SessionCommandCompleted += OnGatewaySessionCommandCompleted;
         _gatewayService.NotificationReceived += OnGatewayNotificationReceived;
         _appState.PropertyChanged += OnAppStateChanged;
-        _appState.AgentEventAdded += evt => _hubWindow?.UpdateAgentEvent(evt);
 
         _diagnosticsClipboard = new DiagnosticsClipboardService(BuildCommandCenterState);
         _toastService = new ToastService(() => _settings);
@@ -925,7 +924,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             _voiceOverlayWindow.TextSubmitted += text =>
             {
                 var client = _connectionManager?.OperatorClient;
-                if (client != null && _currentStatus == ConnectionStatus.Connected)
+                if (client != null && _appState!.Status == ConnectionStatus.Connected)
                 {
                     _ = client.SendChatMessageAsync(text);
                 }
@@ -1009,7 +1008,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             case "companion":
                 // If disconnected, open Connection page (status, gateways, add flow)
                 // If connected, open Hub at default page
-                if (_currentStatus != ConnectionStatus.Connected)
+                if (_appState!.Status != ConnectionStatus.Connected)
                     ShowHub("connection");
                 else
                     ShowHub();
@@ -1285,7 +1284,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
         return new TrayMenuSnapshot
         {
-            CurrentStatus = _currentStatus,
+            CurrentStatus = _appState!.Status,
             AuthFailureMessage = _appState?.AuthFailureMessage,
             GatewayUrl = _settings?.GetEffectiveGatewayUrl(),
             GatewaySelf = _appState?.GatewaySelf,
@@ -1645,7 +1644,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             if (_hubWindow != null && !_hubWindow.IsClosed)
             {
                 _hubWindow.GatewayClient = _connectionManager?.OperatorClient;
-                _hubWindow.CurrentStatus = _currentStatus;
+                _hubWindow.CurrentStatus = _appState!.Status;
             }
         });
     }
@@ -1676,8 +1675,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             OverallConnectionState.Disconnecting => ConnectionStatus.Disconnected,
             _ => ConnectionStatus.Disconnected
         };
-
-        _currentStatus = mapped;
         OnUiThread(() =>
         {
             if (_appState != null) _appState.Status = mapped;
@@ -1745,7 +1742,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
         app.StatusHandler = () => new
         {
-            connectionStatus = _currentStatus.ToString(),
+            connectionStatus = _appState!.Status.ToString(),
             nodeConnected = _nodeService?.IsConnected ?? false,
             nodePaired = _nodeService?.IsPaired ?? false,
             nodePendingApproval = _nodeService?.IsPendingApproval ?? false,
@@ -1782,9 +1779,9 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
         app.ConfigGetHandler = async (path) =>
         {
-            if (_hubWindow?.LastConfig == null) return new { error = "Config not loaded" };
+            if (_appState?.Config == null) return new { error = "Config not loaded" };
             // Config is already redacted by the gateway's redactConfigSnapshot
-            var raw = _hubWindow.LastConfig.Value;
+            var raw = _appState.Config.Value;
             var config = raw.TryGetProperty("parsed", out var parsed) ? parsed
                 : (raw.TryGetProperty("config", out var cfg) ? cfg : raw);
             if (!string.IsNullOrEmpty(path))
@@ -1840,7 +1837,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         {
             var items = new List<object>
             {
-                new { type = "status", status = _currentStatus.ToString() },
+                new { type = "status", status = _appState!.Status.ToString() },
                 new { type = "sessions", count = _appState!.Sessions?.Length ?? 0 },
                 new { type = "nodes", count = _appState!.Nodes?.Length ?? 0 },
             };
@@ -2151,7 +2148,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         if (_hubWindow != null && !_hubWindow.IsClosed)
         {
             _hubWindow.LastAuthError = message;
-            _hubWindow.UpdateStatus(_currentStatus);
+            _hubWindow.UpdateStatus(_appState!.Status);
         }
     }
 
@@ -2262,94 +2259,39 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         }
     }
 
-    // ── AppState → HubWindow bridge (temporary until pages observe directly) ──
+    // ── AppState → App-level side effects (title bar, tray, status detail) ──
 
     private void OnAppStateChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (_hubWindow == null || _hubWindow.IsClosed || _appState == null) return;
+        if (_appState == null) return;
 
         switch (e.PropertyName)
         {
             case nameof(AppState.Status):
-                _hubWindow.UpdateStatus(_appState.Status);
+                if (_hubWindow != null && !_hubWindow.IsClosed)
+                    _hubWindow.UpdateStatus(_appState.Status);
                 break;
             case nameof(AppState.GatewaySelf):
-                _hubWindow.UpdateGatewaySelf(_appState.GatewaySelf!);
+                if (_hubWindow != null && !_hubWindow.IsClosed)
+                    _hubWindow.UpdateGatewaySelf(_appState.GatewaySelf!);
                 UpdateStatusDetailWindow();
                 break;
             case nameof(AppState.Sessions):
-                _hubWindow.UpdateSessions(_appState.Sessions);
                 UpdateStatusDetailWindow();
                 break;
             case nameof(AppState.Channels):
-                _hubWindow.UpdateChannelHealth(_appState.Channels);
-                _hubWindow.UpdateStatus(_appState.Status);
-                break;
-            case nameof(AppState.Usage):
-                _hubWindow.UpdateUsage(_appState.Usage!);
-                break;
-            case nameof(AppState.UsageStatus):
-                _hubWindow.UpdateUsageStatus(_appState.UsageStatus!);
+                if (_hubWindow != null && !_hubWindow.IsClosed)
+                    _hubWindow.UpdateStatus(_appState.Status);
                 break;
             case nameof(AppState.UsageCost):
-                _hubWindow.UpdateUsageCost(_appState.UsageCost!);
                 UpdateStatusDetailWindow();
                 break;
             case nameof(AppState.Nodes):
-                _hubWindow.UpdateNodes(_appState.Nodes);
                 UpdateStatusDetailWindow();
                 break;
-            case nameof(AppState.NodePairList):
-                if (_appState.NodePairList != null)
-                    _hubWindow.UpdateNodePairList(_appState.NodePairList);
-                break;
-            case nameof(AppState.DevicePairList):
-                if (_appState.DevicePairList != null)
-                    _hubWindow.UpdateDevicePairList(_appState.DevicePairList);
-                break;
-            case nameof(AppState.ModelsList):
-                if (_appState.ModelsList != null)
-                    _hubWindow.UpdateModelsList(_appState.ModelsList);
-                break;
-            case nameof(AppState.Presence):
-                if (_appState.Presence != null)
-                    _hubWindow.UpdatePresence(_appState.Presence);
-                break;
             case nameof(AppState.AgentsList):
-                if (_appState.AgentsList.HasValue)
+                if (_hubWindow != null && !_hubWindow.IsClosed && _appState.AgentsList.HasValue)
                     _hubWindow.UpdateAgentsList(_appState.AgentsList.Value);
-                break;
-            case nameof(AppState.Config):
-                if (_appState.Config.HasValue)
-                    _hubWindow.UpdateConfig(_appState.Config.Value);
-                break;
-            case nameof(AppState.ConfigSchema):
-                if (_appState.ConfigSchema.HasValue)
-                    _hubWindow.UpdateConfigSchema(_appState.ConfigSchema.Value);
-                break;
-            case nameof(AppState.SkillsData):
-                if (_appState.SkillsData.HasValue)
-                    _hubWindow.UpdateSkillsStatus(_appState.SkillsData.Value);
-                break;
-            case nameof(AppState.CronList):
-                if (_appState.CronList.HasValue)
-                    _hubWindow.UpdateCronList(_appState.CronList.Value);
-                break;
-            case nameof(AppState.CronStatus):
-                if (_appState.CronStatus.HasValue)
-                    _hubWindow.UpdateCronStatus(_appState.CronStatus.Value);
-                break;
-            case nameof(AppState.CronRuns):
-                if (_appState.CronRuns.HasValue)
-                    _hubWindow.UpdateCronRuns(_appState.CronRuns.Value);
-                break;
-            case nameof(AppState.AgentFilesList):
-                if (_appState.AgentFilesList.HasValue)
-                    _hubWindow.UpdateAgentFilesList(_appState.AgentFilesList.Value);
-                break;
-            case nameof(AppState.AgentFileContent):
-                if (_appState.AgentFileContent.HasValue)
-                    _hubWindow.UpdateAgentFileContent(_appState.AgentFileContent.Value);
                 break;
             case nameof(AppState.CurrentActivity):
                 UpdateTrayIcon();
@@ -2550,7 +2492,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
     private TrayStateSnapshot CaptureTraySnapshot() => new TrayStateSnapshot
     {
-        Status = _currentStatus,
+        Status = _appState!.Status,
         CurrentActivity = _appState!.CurrentActivity,
         Channels = _appState!.Channels,
         Nodes = _appState!.Nodes,
@@ -2572,7 +2514,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             _hubWindow.Settings = _settings;
             _hubWindow.AppModel = _appState;
             _hubWindow.GatewayClient = _connectionManager?.OperatorClient;
-            _hubWindow.CurrentStatus = _currentStatus;
+            _hubWindow.CurrentStatus = _appState!.Status;
             _hubWindow.OpenDashboardAction = OpenDashboard;
             _hubWindow.CheckForUpdatesAction = () => _ = CheckForUpdatesUserInitiatedAsync();
             _hubWindow.QuickSendAction = () => ShowQuickSend();
@@ -2596,7 +2538,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             {
                 _ = _connectionManager?.ReconnectAsync();
             };
-            _hubWindow.ClearAppAgentEventsCache = null; // AppModel.ClearAgentEvents() already called by HubWindow
             if (_nodeService != null)
             {
                 _hubWindow.NodeIsConnected = _nodeService.IsConnected;
@@ -2622,7 +2563,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         // Always update live state
         _hubWindow.Settings = _settings;
         _hubWindow.GatewayClient = _connectionManager?.OperatorClient;
-        _hubWindow.CurrentStatus = _currentStatus;
+        _hubWindow.CurrentStatus = _appState!.Status;
         _hubWindow.VoiceServiceInstance = _nodeService?.VoiceService ?? _standaloneVoiceService;
         if (_nodeService != null)
         {
@@ -2668,16 +2609,9 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private void SeedHubCachedData()
     {
         if (_hubWindow == null) return;
-        // Seed all cached data types so pages see data immediately
-        if (_appState!.Sessions.Length > 0) _hubWindow.UpdateSessions(_appState!.Sessions);
-        if (_appState!.Nodes.Length > 0) _hubWindow.UpdateNodes(_appState!.Nodes);
-        if (_appState!.NodePairList != null) _hubWindow.UpdateNodePairList(_appState!.NodePairList);
-        if (_appState!.DevicePairList != null) _hubWindow.UpdateDevicePairList(_appState!.DevicePairList);
-        if (_appState!.ModelsList != null) _hubWindow.UpdateModelsList(_appState!.ModelsList);
-        if (_appState!.Presence != null) _hubWindow.UpdatePresence(_appState!.Presence);
+        // Seed only what HubWindow itself needs (nav sidebar + title bar)
         if (_appState!.GatewaySelf != null) _hubWindow.UpdateGatewaySelf(_appState!.GatewaySelf);
         if (_appState!.AgentsList.HasValue) _hubWindow.UpdateAgentsList(_appState!.AgentsList.Value);
-        if (_appState!.AgentEvents.Count > 0) _hubWindow.SeedAgentEvents();
     }
 
     private void ShowSettings()
@@ -2757,7 +2691,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         {
             _hubWindow.Settings = _settings;
             _hubWindow.GatewayClient = _connectionManager?.OperatorClient;
-            _hubWindow.CurrentStatus = _currentStatus;
+            _hubWindow.CurrentStatus = _appState!.Status;
         }
 
         // Notify ad-hoc listeners (e.g. ChatWindow may be alive but not
@@ -2918,7 +2852,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
     private void UpdateStatusDetailWindow()
     {
-        _hubWindow?.UpdateStatus(_currentStatus);
+        _hubWindow?.UpdateStatus(_appState!.Status);
     }
 
     private GatewayCommandCenterState BuildCommandCenterState() =>
@@ -2926,7 +2860,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
     private AppStateSnapshot CaptureSnapshot() => new AppStateSnapshot
     {
-        Status = _currentStatus,
+        Status = _appState!.Status,
         LastCheckTime = _appState!.LastCheckTime,
         Channels = _appState!.Channels,
         Sessions = _appState!.Sessions,
@@ -3010,7 +2944,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             {
                 _hubWindow.Settings = _settings;
                 _hubWindow.GatewayClient = _connectionManager?.OperatorClient;
-                _hubWindow.CurrentStatus = _currentStatus;
+                _hubWindow.CurrentStatus = _appState!.Status;
             }
         };
         _onboardingWindow.Closed += (s, e) =>
@@ -3695,8 +3629,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 _settings.SshTunnelLocalPort is < 1 or > 65535)
             {
                 Logger.Warn("SSH tunnel is enabled but settings are incomplete");
-                _currentStatus = ConnectionStatus.Error;
-                _hubWindow?.UpdateStatus(_currentStatus);
+                _appState!.Status = ConnectionStatus.Error;
+                _hubWindow?.UpdateStatus(_appState!.Status);
                 UpdateTrayIcon();
                 return false;
             }
@@ -3724,8 +3658,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             catch (Exception ex)
             {
                 Logger.Error($"Failed to start SSH tunnel: {ex.Message}");
-                _currentStatus = ConnectionStatus.Error;
-                _hubWindow?.UpdateStatus(_currentStatus);
+                _appState!.Status = ConnectionStatus.Error;
+                _hubWindow?.UpdateStatus(_appState!.Status);
                 UpdateTrayIcon();
                 return false;
             }

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1251,7 +1251,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         _appState?.ClearCachedData();
         if (_appState != null) _appState.Status = ConnectionStatus.Disconnected;
         UpdateTrayIcon();
-        RefreshTrayMenuIfOpen();
+        // Dismiss the tray menu on disconnect — it will capture fresh data on next open
+        _trayMenuWindow?.HideCascade();
     }
 
     private void BuildTrayMenuPopup(TrayMenuWindow menu)
@@ -1683,7 +1684,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             SyncConnectionToggle(mapped);
             if (mapped is ConnectionStatus.Connected or ConnectionStatus.Disconnected or ConnectionStatus.Error)
             {
-                RefreshTrayMenuIfOpen();
+                // Dismiss the tray menu on state change — it will capture fresh data on next open
+                _trayMenuWindow?.HideCascade();
             }
         });
     }
@@ -2104,7 +2106,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             SyncConnectionToggle(status);
             if (status is ConnectionStatus.Connected or ConnectionStatus.Disconnected or ConnectionStatus.Error)
             {
-                RefreshTrayMenuIfOpen();
+                // Dismiss the tray menu on state change — it will capture fresh data on next open
+                _trayMenuWindow?.HideCascade();
             }
         });
 
@@ -2232,7 +2235,10 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         }
     }
 
-    // ── AppState → tray-level side effects (tray icon, tray menu, status detail) ──
+    // ── AppState → tray-level side effects (tray icon, status detail) ──
+    // The tray menu is NOT refreshed live while open — data is frozen at
+    // open time via TrayMenuSnapshot to avoid WinUI layout races that cause
+    // blank subflyouts. The menu captures a fresh snapshot on every open.
 
     private void OnAppStateChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
@@ -2241,78 +2247,17 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         switch (e.PropertyName)
         {
             case nameof(AppState.GatewaySelf):
-                UpdateStatusDetailWindow();
-                RefreshTrayMenuIfOpen();
-                break;
             case nameof(AppState.Sessions):
-                UpdateStatusDetailWindow();
-                RefreshTrayMenuIfOpen();
-                break;
-            case nameof(AppState.Channels):
-                RefreshTrayMenuIfOpen();
-                break;
             case nameof(AppState.UsageCost):
-                UpdateStatusDetailWindow();
-                RefreshTrayMenuIfOpen();
-                break;
             case nameof(AppState.Nodes):
                 UpdateStatusDetailWindow();
-                RefreshTrayMenuIfOpen();
                 break;
             case nameof(AppState.CurrentActivity):
                 UpdateTrayIcon();
                 break;
-            case nameof(AppState.Usage):
-            case nameof(AppState.UsageStatus):
-            case nameof(AppState.Presence):
-            case nameof(AppState.NodePairList):
-            case nameof(AppState.DevicePairList):
-                RefreshTrayMenuIfOpen();
-                break;
         }
     }
 
-    private bool _trayMenuRefreshPending;
-
-    private void RefreshTrayMenuIfOpen()
-    {
-        if (_trayMenuWindow == null || !_trayMenuWindow.IsShown)
-            return;
-
-        // Debounce: multiple AppState properties change in rapid succession
-        // (sessions, nodes, usage, channels all arrive on connect).
-        // Coalesce into a single rebuild on the next dispatcher tick.
-        if (_trayMenuRefreshPending)
-            return;
-        _trayMenuRefreshPending = true;
-        _dispatcherQueue?.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
-        {
-            _trayMenuRefreshPending = false;
-            RefreshTrayMenuNow();
-        });
-    }
-
-    private void RefreshTrayMenuNow()
-    {
-        try
-        {
-            if (_trayMenuWindow == null || !_trayMenuWindow.IsShown)
-                return;
-
-            var openCascadeTag = _trayMenuWindow.ActiveFlyoutTag;
-            _trayMenuWindow.ClearItems();
-            BuildTrayMenuPopup(_trayMenuWindow);
-            _trayMenuWindow.SizeToContentKeepBottom();
-            if (!string.IsNullOrEmpty(openCascadeTag))
-            {
-                _trayMenuWindow.TryRestoreCascade(openCascadeTag);
-            }
-        }
-        catch (Exception ex)
-        {
-            LogCrash("RefreshTrayMenuIfOpen", ex);
-        }
-    }
 
     private void SyncConnectionToggle(ConnectionStatus status)
     {

--- a/src/OpenClaw.Tray.WinUI/Helpers/InstanceManagementControls.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/InstanceManagementControls.cs
@@ -4,7 +4,6 @@ using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using OpenClaw.Shared;
-using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -21,7 +20,7 @@ namespace OpenClawTray.Helpers;
 /// <remarks>
 /// Builders return null when their backing data is empty so callers can
 /// <c>AppendIfNotNull</c> them. The destructive actions (Rename, Forget) need
-/// a <see cref="HubWindow"/> for gateway client access and a
+/// an <see cref="IOperatorGatewayClient"/> for gateway client access and a
 /// <see cref="FrameworkElement"/> whose <see cref="UIElement.XamlRoot"/> anchors
 /// the <see cref="ContentDialog"/>.
 /// </remarks>
@@ -35,7 +34,7 @@ public static class InstanceManagementControls
     /// </summary>
     public static FrameworkElement BuildManagementBody(
         GatewayNodeInfo node,
-        HubWindow hub,
+        IOperatorGatewayClient? gatewayClient,
         FrameworkElement xamlRootSource)
     {
         var stack = new StackPanel { Spacing = 10 };
@@ -51,7 +50,7 @@ public static class InstanceManagementControls
         AppendIfNotNull(stack, BuildCommandsSection(node));
         AppendIfNotNull(stack, BuildPathEnvSection(node));
 
-        stack.Children.Add(BuildActionFooter(node, hub, xamlRootSource));
+        stack.Children.Add(BuildActionFooter(node, gatewayClient, xamlRootSource));
 
         return stack;
     }
@@ -294,10 +293,10 @@ public static class InstanceManagementControls
 
     public static StackPanel BuildActionFooter(
         GatewayNodeInfo node,
-        HubWindow hub,
+        IOperatorGatewayClient? gatewayClient,
         FrameworkElement xamlRootSource)
     {
-        var clientAvailable = hub.GatewayClient != null;
+        var clientAvailable = gatewayClient != null;
 
         var footer = new StackPanel
         {
@@ -328,7 +327,7 @@ public static class InstanceManagementControls
         };
         renameBtn.Click += async (_, _) =>
         {
-            try { await OnRenameClickedAsync(node, hub, xamlRootSource); }
+            try { await OnRenameClickedAsync(node, gatewayClient, xamlRootSource); }
             catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Rename click failed: {ex}"); }
         };
         actions.Children.Add(renameBtn);
@@ -345,7 +344,7 @@ public static class InstanceManagementControls
         };
         forgetBtn.Click += async (_, _) =>
         {
-            try { await OnForgetClickedAsync(node, hub, xamlRootSource); }
+            try { await OnForgetClickedAsync(node, gatewayClient, xamlRootSource); }
             catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Forget click failed: {ex}"); }
         };
         actions.Children.Add(forgetBtn);
@@ -360,10 +359,10 @@ public static class InstanceManagementControls
 
     private static async Task OnRenameClickedAsync(
         GatewayNodeInfo node,
-        HubWindow hub,
+        IOperatorGatewayClient? gatewayClient,
         FrameworkElement xamlRootSource)
     {
-        if (hub.GatewayClient is not { } client) return;
+        if (gatewayClient is not { } client) return;
         if (_dialogOpen) return;
         _dialogOpen = true;
         try
@@ -463,10 +462,10 @@ public static class InstanceManagementControls
 
     private static async Task OnForgetClickedAsync(
         GatewayNodeInfo node,
-        HubWindow hub,
+        IOperatorGatewayClient? gatewayClient,
         FrameworkElement xamlRootSource)
     {
-        if (hub.GatewayClient is not { } client) return;
+        if (gatewayClient is not { } client) return;
         if (_dialogOpen) return;
         _dialogOpen = true;
         try

--- a/src/OpenClaw.Tray.WinUI/Pages/AboutPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/AboutPage.xaml.cs
@@ -1,8 +1,10 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using OpenClawTray.Helpers;
+using OpenClawTray.Services;
 using OpenClawTray.Windows;
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 
 namespace OpenClawTray.Pages;
@@ -10,16 +12,33 @@ namespace OpenClawTray.Pages;
 public sealed partial class AboutPage : Page
 {
     private HubWindow? _hub;
+    private AppState? _appState;
 
     public AboutPage()
     {
         InitializeComponent();
+        Unloaded += (_, _) =>
+        {
+            if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+        };
     }
 
     public void Initialize(HubWindow hub)
     {
         _hub = hub;
+        _appState = ((App)Application.Current).AppState;
+        _appState.PropertyChanged += OnAppStateChanged;
         TryLoadGatewayInfo();
+    }
+
+    private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(AppState.GatewaySelf):
+                RefreshGatewayInfo();
+                break;
+        }
     }
 
     public void RefreshGatewayInfo() => TryLoadGatewayInfo();

--- a/src/OpenClaw.Tray.WinUI/Pages/AboutPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/AboutPage.xaml.cs
@@ -2,7 +2,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
-using OpenClawTray.Windows;
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -11,7 +10,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class AboutPage : Page
 {
-    private HubWindow? _hub;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private AppState? _appState;
 
     public AboutPage()
@@ -23,10 +22,9 @@ public sealed partial class AboutPage : Page
         };
     }
 
-    public void Initialize(HubWindow hub)
+    public void Initialize()
     {
-        _hub = hub;
-        _appState = ((App)Application.Current).AppState;
+        _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
         TryLoadGatewayInfo();
     }
@@ -45,8 +43,8 @@ public sealed partial class AboutPage : Page
 
     private void TryLoadGatewayInfo()
     {
-        var self = _hub?.LastGatewaySelf;
-        if (_hub?.CurrentStatus == OpenClaw.Shared.ConnectionStatus.Connected && self != null)
+        var self = CurrentApp.AppState?.GatewaySelf;
+        if (CurrentApp.AppState?.Status == OpenClaw.Shared.ConnectionStatus.Connected && self != null)
         {
             GatewayVersionText.Text = self.VersionText;
             GatewayModelText.Text = self.Protocol.HasValue ? $"protocol v{self.Protocol}" : "unknown";
@@ -99,8 +97,8 @@ public sealed partial class AboutPage : Page
             var context = $"OpenClaw Hub v0.1.0\n"
                 + $"OS: {Environment.OSVersion}\n"
                 + $"Runtime: {System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}\n"
-                + $"Connection: {_hub?.CurrentStatus}\n"
-                + $"Gateway: {_hub?.Settings?.GetEffectiveGatewayUrl() ?? "n/a"}\n";
+                + $"Connection: {CurrentApp.AppState?.Status}\n"
+                + $"Gateway: {CurrentApp.Settings?.GetEffectiveGatewayUrl() ?? "n/a"}\n";
 
             ClipboardHelper.CopyText(context);
         }
@@ -112,7 +110,7 @@ public sealed partial class AboutPage : Page
 
     private void OnCheckUpdatesClick(object sender, RoutedEventArgs e)
     {
-        _hub?.CheckForUpdatesAction?.Invoke();
+        ((IAppCommands)CurrentApp).CheckForUpdates();
     }
 
     private void OnDocumentationClick(object sender, RoutedEventArgs e)
@@ -141,6 +139,6 @@ public sealed partial class AboutPage : Page
 
     private void OnDashboardClick(object sender, RoutedEventArgs e)
     {
-        _hub?.OpenDashboardAction?.Invoke(null);
+        ((IAppCommands)CurrentApp).OpenDashboard(null);
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Pages/ActivityPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ActivityPage.xaml.cs
@@ -2,7 +2,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using OpenClawTray.Services;
-using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,7 +10,6 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class ActivityPage : Page
 {
-    private HubWindow? _hub;
     private string _currentFilter = "all";
     private bool _initialized;
 
@@ -27,9 +25,8 @@ public sealed partial class ActivityPage : Page
         _initialized = false;
     }
 
-    public void Initialize(HubWindow hub)
+    public void Initialize()
     {
-        _hub = hub;
         if (!_initialized)
         {
             ActivityStreamService.Updated += OnActivityUpdated;

--- a/src/OpenClaw.Tray.WinUI/Pages/AgentEventsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/AgentEventsPage.xaml.cs
@@ -60,7 +60,11 @@ public sealed partial class AgentEventsPage : Page
         _initialized = true;
         Unloaded += (_, _) =>
         {
-            if (_appState != null) _appState.AgentEventAdded -= OnAgentEventAdded;
+            if (_appState != null)
+            {
+                _appState.AgentEventAdded -= OnAgentEventAdded;
+                _appState.PropertyChanged -= OnAppStateChanged;
+            }
         };
     }
 
@@ -68,7 +72,17 @@ public sealed partial class AgentEventsPage : Page
     {
         _appState = ((App)Application.Current).AppState;
         _appState.AgentEventAdded += OnAgentEventAdded;
+        _appState.PropertyChanged += OnAppStateChanged;
         PopulateAgentFilter(hub);
+    }
+
+    private void OnAppStateChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(AppState.AgentEvents) && _appState?.AgentEvents.Count == 0)
+        {
+            _allEvents.Clear();
+            ApplyFilter();
+        }
     }
 
     private void OnAgentEventAdded(AgentEventInfo evt)

--- a/src/OpenClaw.Tray.WinUI/Pages/AgentEventsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/AgentEventsPage.xaml.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using OpenClaw.Shared;
+using OpenClawTray.Services;
 using OpenClawTray.Windows;
 
 namespace OpenClawTray.Pages;
@@ -16,6 +17,7 @@ public sealed partial class AgentEventsPage : Page
     private string _activeFilter = "all";
     private string? _agentIdFilter;
     private bool _filterDirty;
+    private AppState? _appState;
 
     /// <summary>Set by HubWindow so Clear can also clear the central cache.</summary>
     public Action? ClearCentralCache { get; set; }
@@ -56,6 +58,22 @@ public sealed partial class AgentEventsPage : Page
     {
         InitializeComponent();
         _initialized = true;
+        Unloaded += (_, _) =>
+        {
+            if (_appState != null) _appState.AgentEventAdded -= OnAgentEventAdded;
+        };
+    }
+
+    public void Initialize(HubWindow hub)
+    {
+        _appState = ((App)Application.Current).AppState;
+        _appState.AgentEventAdded += OnAgentEventAdded;
+        PopulateAgentFilter(hub);
+    }
+
+    private void OnAgentEventAdded(AgentEventInfo evt)
+    {
+        AddEvent(evt);
     }
 
     public void AddEvent(AgentEventInfo evt)

--- a/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml.cs
@@ -1,7 +1,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using OpenClawTray.Services;
-using OpenClawTray.Windows;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text.Json;
@@ -10,7 +9,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class BindingsPage : Page
 {
-    private HubWindow? _hub;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private AppState? _appState;
 
     public BindingsPage()
@@ -22,17 +21,16 @@ public sealed partial class BindingsPage : Page
         };
     }
 
-    public void Initialize(HubWindow hub)
+    public void Initialize()
     {
-        _hub = hub;
-        _appState = ((App)Application.Current).AppState;
+        _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
         // Use cached config if available
         if (_appState?.Config.HasValue == true)
             ParseBindings(_appState.Config.Value);
         // Request fresh config
-        if (hub.GatewayClient != null)
-            _ = hub.GatewayClient.RequestConfigAsync();
+        if (CurrentApp.GatewayClient != null)
+            _ = CurrentApp.GatewayClient.RequestConfigAsync();
     }
 
     private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
@@ -97,9 +95,9 @@ public sealed partial class BindingsPage : Page
 
     private void RefreshButton_Click(object sender, RoutedEventArgs e)
     {
-        if (_hub?.GatewayClient != null)
+        if (CurrentApp.GatewayClient != null)
         {
-            _ = _hub.GatewayClient.RequestConfigAsync();
+            _ = CurrentApp.GatewayClient.RequestConfigAsync();
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml.cs
@@ -1,7 +1,9 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using OpenClawTray.Services;
 using OpenClawTray.Windows;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text.Json;
 
 namespace OpenClawTray.Pages;
@@ -9,21 +11,38 @@ namespace OpenClawTray.Pages;
 public sealed partial class BindingsPage : Page
 {
     private HubWindow? _hub;
+    private AppState? _appState;
 
     public BindingsPage()
     {
         InitializeComponent();
+        Unloaded += (_, _) =>
+        {
+            if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+        };
     }
 
     public void Initialize(HubWindow hub)
     {
         _hub = hub;
+        _appState = ((App)Application.Current).AppState;
+        _appState.PropertyChanged += OnAppStateChanged;
         // Use cached config if available
-        if (hub.LastConfig.HasValue)
-            ParseBindings(hub.LastConfig.Value);
+        if (_appState?.Config.HasValue == true)
+            ParseBindings(_appState.Config.Value);
         // Request fresh config
         if (hub.GatewayClient != null)
             _ = hub.GatewayClient.RequestConfigAsync();
+    }
+
+    private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(AppState.Config):
+                if (_appState!.Config.HasValue) UpdateConfig(_appState.Config.Value);
+                break;
+        }
     }
 
     public void UpdateConfig(JsonElement config)

--- a/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml
@@ -9,10 +9,6 @@
 
             <TextBlock x:Uid="ChannelsPage_TextBlock_10" Text="📡 Channels" Style="{StaticResource TitleTextBlockStyle}"/>
 
-            <InfoBar x:Uid="ConnectionWarning" x:Name="ConnectionWarning" Title="Not Connected"
-                     Message="Connect to gateway to see live data"
-                     Severity="Warning" IsOpen="True" IsClosable="False" Visibility="Collapsed"/>
-
             <!-- Channel Cards -->
             <StackPanel x:Name="ChannelsList" Spacing="8"/>
 

--- a/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
@@ -5,7 +5,6 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
 using OpenClaw.Shared;
 using OpenClawTray.Services;
-using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -14,7 +13,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class ChannelsPage : Page
 {
-    private HubWindow? _hub;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private AppState? _appState;
 
     public ChannelsPage()
@@ -26,13 +25,12 @@ public sealed partial class ChannelsPage : Page
         };
     }
 
-    public void Initialize(HubWindow hub)
+    public void Initialize()
     {
-        _hub = hub;
-        _appState = ((App)Application.Current).AppState;
+        _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
-        ConnectionWarning.Visibility = hub.GatewayClient != null ? Visibility.Collapsed : Visibility.Visible;
-        if (hub.GatewayClient != null)
+        ConnectionWarning.Visibility = CurrentApp.GatewayClient != null ? Visibility.Collapsed : Visibility.Visible;
+        if (CurrentApp.GatewayClient != null)
         {
             // Apply cached data immediately
             if (_appState?.Channels != null)
@@ -167,7 +165,7 @@ public sealed partial class ChannelsPage : Page
     {
         if (sender is Button btn && btn.Tag is string name)
         {
-            var client = _hub?.GatewayClient;
+            var client = CurrentApp.GatewayClient;
             if (client == null) { ConnectionWarning.Visibility = Visibility.Visible; return; }
             btn.IsEnabled = false;
             try
@@ -184,7 +182,7 @@ public sealed partial class ChannelsPage : Page
     {
         if (sender is Button btn && btn.Tag is string name)
         {
-            var client = _hub?.GatewayClient;
+            var client = CurrentApp.GatewayClient;
             if (client == null) { ConnectionWarning.Visibility = Visibility.Visible; return; }
             btn.IsEnabled = false;
             try

--- a/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
@@ -52,32 +52,29 @@ public sealed partial class ChannelsPage : Page
 
     public void UpdateChannels(ChannelHealth[] channels)
     {
-        DispatcherQueue?.TryEnqueue(() =>
+        if (channels.Length == 0)
         {
-            if (channels.Length == 0)
-            {
-                ChannelsList.Children.Clear();
-                EmptyState.Visibility = Visibility.Visible;
-                return;
-            }
+            ChannelsList.Children.Clear();
+            EmptyState.Visibility = Visibility.Visible;
+            return;
+        }
 
-            EmptyState.Visibility = Visibility.Collapsed;
-            var vms = new List<ChannelViewModel>();
-            foreach (var ch in channels)
+        EmptyState.Visibility = Visibility.Collapsed;
+        var vms = new List<ChannelViewModel>();
+        foreach (var ch in channels)
+        {
+            var isHealthy = ChannelHealth.IsHealthyStatus(ch.Status);
+            var isIntermediate = ChannelHealth.IsIntermediateStatus(ch.Status);
+            vms.Add(new ChannelViewModel
             {
-                var isHealthy = ChannelHealth.IsHealthyStatus(ch.Status);
-                var isIntermediate = ChannelHealth.IsIntermediateStatus(ch.Status);
-                vms.Add(new ChannelViewModel
-                {
-                    Name = ch.Name,
-                    Status = ch.Error != null ? $"Error: {ch.Error}" : ch.Status,
-                    StatusColor = isHealthy ? "Green" : (isIntermediate ? "Yellow" : "Red"),
-                    IsRunning = isHealthy,
-                    ProbeInfo = ch.AuthAge != null ? $"Auth age: {ch.AuthAge}" : null,
-                });
-            }
-            RenderChannels(vms);
-        });
+                Name = ch.Name,
+                Status = ch.Error != null ? $"Error: {ch.Error}" : ch.Status,
+                StatusColor = isHealthy ? "Green" : (isIntermediate ? "Yellow" : "Red"),
+                IsRunning = isHealthy,
+                ProbeInfo = ch.AuthAge != null ? $"Auth age: {ch.AuthAge}" : null,
+            });
+        }
+        RenderChannels(vms);
     }
 
     private void RenderChannels(List<ChannelViewModel> channels)

--- a/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
@@ -4,32 +4,51 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
 using OpenClaw.Shared;
+using OpenClawTray.Services;
 using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace OpenClawTray.Pages;
 
 public sealed partial class ChannelsPage : Page
 {
     private HubWindow? _hub;
+    private AppState? _appState;
 
     public ChannelsPage()
     {
         InitializeComponent();
+        Unloaded += (_, _) =>
+        {
+            if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+        };
     }
 
     public void Initialize(HubWindow hub)
     {
         _hub = hub;
+        _appState = ((App)Application.Current).AppState;
+        _appState.PropertyChanged += OnAppStateChanged;
         ConnectionWarning.Visibility = hub.GatewayClient != null ? Visibility.Collapsed : Visibility.Visible;
         if (hub.GatewayClient != null)
         {
             // Apply cached data immediately
-            if (hub.LastChannels != null)
-                UpdateChannels(hub.LastChannels);
+            if (_appState?.Channels != null)
+                UpdateChannels(_appState.Channels);
             else
                 ChannelsList.Children.Clear();
+        }
+    }
+
+    private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(AppState.Channels):
+                UpdateChannels(_appState!.Channels);
+                break;
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
@@ -29,7 +29,6 @@ public sealed partial class ChannelsPage : Page
     {
         _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
-        ConnectionWarning.Visibility = CurrentApp.GatewayClient != null ? Visibility.Collapsed : Visibility.Visible;
         if (CurrentApp.GatewayClient != null)
         {
             // Apply cached data immediately
@@ -163,7 +162,7 @@ public sealed partial class ChannelsPage : Page
         if (sender is Button btn && btn.Tag is string name)
         {
             var client = CurrentApp.GatewayClient;
-            if (client == null) { ConnectionWarning.Visibility = Visibility.Visible; return; }
+            if (client == null) return;
             btn.IsEnabled = false;
             try
             {
@@ -180,7 +179,7 @@ public sealed partial class ChannelsPage : Page
         if (sender is Button btn && btn.Tag is string name)
         {
             var client = CurrentApp.GatewayClient;
-            if (client == null) { ConnectionWarning.Visibility = Visibility.Visible; return; }
+            if (client == null) return;
             btn.IsEnabled = false;
             try
             {

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -7,7 +7,6 @@ using OpenClawTray.Chat;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using OpenClaw.Connection;
-using OpenClawTray.Windows;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -21,7 +20,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class ChatPage : Page
 {
-    private HubWindow? _hub;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private IDisposable? _functionalHost;
     private IChatDataProvider? _mountedProvider;
     private string? _chatUrl;
@@ -57,8 +56,7 @@ public sealed partial class ChatPage : Page
                 WebView.CoreWebView2.NavigationStarting -= _navStartingHandler;
         }
 
-        if (_hub is not null)
-            _hub.SettingsSaved -= OnSettingsSaved;
+        CurrentApp.SettingsChanged -= OnSettingsSaved;
 
         if (App.Current is App app)
             app.ChatProviderChanged -= OnAppChatProviderChanged;
@@ -69,15 +67,13 @@ public sealed partial class ChatPage : Page
         OpenClawTray.Chat.DebugChatSurfaceOverrides.Changed -= OnDebugOverrideChanged;
     }
 
-    public void Initialize(HubWindow hub)
+    public void Initialize()
     {
-        _hub = hub;
-
         // Compute a "open in browser" URL once so the toolbar button works
         // even when the gateway isn't fully reachable yet.
-        if (hub.Settings is not null)
+        if (CurrentApp.Settings is not null)
         {
-            var url = TryComputeChatUrl(hub.Settings);
+            var url = TryComputeChatUrl(CurrentApp.Settings);
             if (!string.IsNullOrEmpty(url))
             {
                 _chatUrl = url;
@@ -86,8 +82,8 @@ public sealed partial class ChatPage : Page
 
         // Re-mount on settings change so toggling "Use standard Gateway Chat
         // interface" swaps the surface live.
-        hub.SettingsSaved -= OnSettingsSaved;
-        hub.SettingsSaved += OnSettingsSaved;
+        CurrentApp.SettingsChanged -= OnSettingsSaved;
+        CurrentApp.SettingsChanged += OnSettingsSaved;
 
         if (App.Current is App app)
         {
@@ -120,19 +116,19 @@ public sealed partial class ChatPage : Page
 
     private void ApplyChatSurface()
     {
-        if (_hub?.Settings is null) return;
+        if (CurrentApp.Settings is null) return;
 
         // HIGH 3: re-resolve the chat URL from the current settings on every
         // surface application — _chatUrl was previously computed once in
         // Initialize() and never refreshed, so SettingsSaved (e.g. token /
         // gateway URL change) would leave the WebView pointing at a stale URL.
-        var freshUrl = TryComputeChatUrl(_hub.Settings);
+        var freshUrl = TryComputeChatUrl(CurrentApp.Settings);
         var urlChanged = !string.Equals(freshUrl, _chatUrl, StringComparison.Ordinal);
         _chatUrl = freshUrl;
 
         var useLegacy = OpenClawTray.Chat.DebugChatSurfaceOverrides.ResolveUseLegacy(
             OpenClawTray.Chat.DebugChatSurfaceOverrides.HubChat,
-            _hub.Settings.UseLegacyWebChat);
+            CurrentApp.Settings.UseLegacyWebChat);
         if (useLegacy)
             ShowWebViewSurface(forceNavigate: urlChanged);
         else
@@ -191,7 +187,7 @@ public sealed partial class ChatPage : Page
 
         PlaceholderPanel.Visibility = Visibility.Collapsed;
         ChatHost.Visibility = Visibility.Visible;
-        _functionalHost = ((Window)_hub!).MountFunctionalChat(
+        _functionalHost = CurrentApp.ActiveHubWindow!.MountFunctionalChat(
             ChatHost,
             provider,
             onReadAloud: readAloud);
@@ -228,8 +224,8 @@ public sealed partial class ChatPage : Page
             return;
         }
 
-        if (_hub?.Settings is null) return;
-        _ = InitializeWebViewAsync(_hub.Settings);
+        if (CurrentApp.Settings is null) return;
+        _ = InitializeWebViewAsync(CurrentApp.Settings);
     }
 
     private bool NavigateWebViewToCurrentChatUrl()
@@ -280,7 +276,7 @@ public sealed partial class ChatPage : Page
         try
         {
             if (!InteractiveGatewayCredentialResolver.TryResolve(
-                _hub?.GatewayRegistry,
+                CurrentApp.Registry,
                 SettingsManager.SettingsDirectoryPath,
                 DeviceIdentityFileReader.Instance,
                 settings.GetEffectiveGatewayUrl(),
@@ -363,7 +359,7 @@ public sealed partial class ChatPage : Page
             };
             WebView.CoreWebView2.NavigationStarting += _navStartingHandler;
 
-            _connectionManager = _hub?.ConnectionManager;
+            _connectionManager = CurrentApp.ConnectionManager;
             _navigationCts?.Cancel();
             _navigationCts = new CancellationTokenSource();
             _ = NavigateWhenChatReadyAsync(_connectionManager, credential.GatewayUrl, _navigationCts.Token);
@@ -568,6 +564,6 @@ public sealed partial class ChatPage : Page
         RetryChatButton.Visibility = Visibility.Collapsed;
         LoadingRing.IsActive = true;
         LoadingRing.Visibility = Visibility.Visible;
-        _ = NavigateWhenChatReadyAsync(_connectionManager, _hub?.GatewayRegistry?.GetById(_hub.GatewayRegistry.ActiveGatewayId ?? "")?.Url ?? "gateway", _navigationCts.Token);
+        _ = NavigateWhenChatReadyAsync(_connectionManager, CurrentApp.Registry?.GetById(CurrentApp.Registry.ActiveGatewayId ?? "")?.Url ?? "gateway", _navigationCts.Token);
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
@@ -52,48 +52,45 @@ public sealed partial class ConfigPage : Page
     public void UpdateConfig(JsonElement config)
     {
         var configSnapshot = config.Clone();
-        DispatcherQueue?.TryEnqueue(() =>
+        try
         {
-            try
+            OpenClawTray.Services.Logger.Info("[ConfigPage] UpdateConfig received");
+            _lastConfig = configSnapshot;
+
+            // Get baseHash from the config.get response
+            // The gateway returns a 'hash' field which is SHA256 of the raw file content
+            if (configSnapshot.TryGetProperty("baseHash", out var bh) && bh.ValueKind == JsonValueKind.String)
             {
-                OpenClawTray.Services.Logger.Info("[ConfigPage] UpdateConfig received");
-                _lastConfig = configSnapshot;
-
-                // Get baseHash from the config.get response
-                // The gateway returns a 'hash' field which is SHA256 of the raw file content
-                if (configSnapshot.TryGetProperty("baseHash", out var bh) && bh.ValueKind == JsonValueKind.String)
-                {
-                    _baseHash = bh.GetString();
-                }
-                else if (configSnapshot.TryGetProperty("hash", out var hashEl) && hashEl.ValueKind == JsonValueKind.String)
-                {
-                    _baseHash = hashEl.GetString();
-                }
-                else if (configSnapshot.TryGetProperty("raw", out var rawEl) && rawEl.ValueKind == JsonValueKind.String)
-                {
-                    // Fallback: compute from raw content
-                    var rawContent = rawEl.GetString();
-                    if (rawContent != null)
-                    {
-                        var bytes = System.Text.Encoding.UTF8.GetBytes(rawContent);
-                        var hash = System.Security.Cryptography.SHA256.HashData(bytes);
-                        _baseHash = Convert.ToHexStringLower(hash);
-                    }
-                }
-
-                // Show file path in subtitle if available
-                if (configSnapshot.TryGetProperty("path", out var pathEl))
-                    ConfigSubtitle.Text = $"Editing {pathEl.GetString()} via schema-driven form";
-
-                RenderTree();
-                UpdateRawJson();
+                _baseHash = bh.GetString();
             }
-            catch (Exception ex)
+            else if (configSnapshot.TryGetProperty("hash", out var hashEl) && hashEl.ValueKind == JsonValueKind.String)
             {
-                OpenClawTray.Services.Logger.Error($"[ConfigPage] Failed to render config: {ex}");
-                ShowConfigRenderError();
+                _baseHash = hashEl.GetString();
             }
-        });
+            else if (configSnapshot.TryGetProperty("raw", out var rawEl) && rawEl.ValueKind == JsonValueKind.String)
+            {
+                // Fallback: compute from raw content
+                var rawContent = rawEl.GetString();
+                if (rawContent != null)
+                {
+                    var bytes = System.Text.Encoding.UTF8.GetBytes(rawContent);
+                    var hash = System.Security.Cryptography.SHA256.HashData(bytes);
+                    _baseHash = Convert.ToHexStringLower(hash);
+                }
+            }
+
+            // Show file path in subtitle if available
+            if (configSnapshot.TryGetProperty("path", out var pathEl))
+                ConfigSubtitle.Text = $"Editing {pathEl.GetString()} via schema-driven form";
+
+            RenderTree();
+            UpdateRawJson();
+        }
+        catch (Exception ex)
+        {
+            OpenClawTray.Services.Logger.Error($"[ConfigPage] Failed to render config: {ex}");
+            ShowConfigRenderError();
+        }
     }
 
     private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
@@ -112,21 +109,18 @@ public sealed partial class ConfigPage : Page
     public void UpdateConfigSchema(JsonElement schema)
     {
         var schemaSnapshot = schema.Clone();
-        DispatcherQueue?.TryEnqueue(() =>
+        try
         {
-            try
-            {
-                _lastSchema = schemaSnapshot;
-                // Re-render tree if config is already loaded
-                if (_lastConfig.HasValue)
-                    RenderTree();
-            }
-            catch (Exception ex)
-            {
-                OpenClawTray.Services.Logger.Error($"[ConfigPage] Failed to render config schema: {ex}");
-                ShowConfigRenderError();
-            }
-        });
+            _lastSchema = schemaSnapshot;
+            // Re-render tree if config is already loaded
+            if (_lastConfig.HasValue)
+                RenderTree();
+        }
+        catch (Exception ex)
+        {
+            OpenClawTray.Services.Logger.Error($"[ConfigPage] Failed to render config schema: {ex}");
+            ShowConfigRenderError();
+        }
     }
 
     private void RenderTree()

--- a/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
@@ -4,7 +4,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using OpenClawTray.Services;
-using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -18,7 +17,7 @@ public sealed partial class ConfigPage : Page
 {
     private static readonly JsonElement s_emptyObject = JsonDocument.Parse("{}").RootElement.Clone();
 
-    private HubWindow? _hub;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private AppState? _appState;
     private JsonElement? _lastConfig;
     private JsonElement? _lastSchema;
@@ -38,16 +37,15 @@ public sealed partial class ConfigPage : Page
         };
     }
 
-    public void Initialize(HubWindow hub)
+    public void Initialize()
     {
-        _hub = hub;
-        _appState = ((App)Application.Current).AppState;
+        _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
         OpenClawTray.Services.Logger.Info("[ConfigPage] Initialize");
-        if (hub.GatewayClient != null)
+        if (CurrentApp.GatewayClient != null)
         {
-            _ = hub.GatewayClient.RequestConfigSchemaAsync();
-            _ = hub.GatewayClient.RequestConfigAsync();
+            _ = CurrentApp.GatewayClient.RequestConfigSchemaAsync();
+            _ = CurrentApp.GatewayClient.RequestConfigAsync();
         }
     }
 
@@ -234,7 +232,7 @@ public sealed partial class ConfigPage : Page
 
     private void OnOpenDashboard(object sender, RoutedEventArgs e)
     {
-        _hub?.OpenDashboardAction?.Invoke("config");
+        ((IAppCommands)CurrentApp).OpenDashboard("config");
     }
 
     private static void ExpandAll(IList<TreeViewNode> nodes)
@@ -267,7 +265,7 @@ public sealed partial class ConfigPage : Page
             return;
         }
 
-        if (_hub?.GatewayClient == null || !_lastConfig.HasValue)
+        if (CurrentApp.GatewayClient == null || !_lastConfig.HasValue)
         {
             SaveStatus.Text = "Not connected";
             return;
@@ -295,13 +293,13 @@ public sealed partial class ConfigPage : Page
         SaveStatus.Text = "Saving...";
         try
         {
-            var ok = await _hub.GatewayClient.PatchConfigAsync(updatedElement, _baseHash);
+            var ok = await CurrentApp.GatewayClient.PatchConfigAsync(updatedElement, _baseHash);
             SaveStatus.Text = ok ? "✓ Saved" : "✗ Save failed — changes preserved";
 
             if (ok)
             {
                 _pendingChanges.Clear();
-                _ = _hub.GatewayClient.RequestConfigAsync();
+                _ = CurrentApp.GatewayClient.RequestConfigAsync();
             }
         }
         catch (Exception) { SaveStatus.Text = "✗ Save failed — changes preserved"; }
@@ -356,11 +354,11 @@ public sealed partial class ConfigPage : Page
 
     private void OnRefresh(object sender, RoutedEventArgs e)
     {
-        if (_hub?.GatewayClient != null)
+        if (CurrentApp.GatewayClient != null)
         {
             SaveStatus.Text = "";
-            _ = _hub.GatewayClient.RequestConfigSchemaAsync();
-            _ = _hub.GatewayClient.RequestConfigAsync();
+            _ = CurrentApp.GatewayClient.RequestConfigSchemaAsync();
+            _ = CurrentApp.GatewayClient.RequestConfigAsync();
         }
     }
 
@@ -743,20 +741,20 @@ public sealed partial class ConfigPage : Page
 
     private void OnValueEdited(string configPath, object newValue)
     {
-        if (_hub?.GatewayClient == null) return;
+        if (CurrentApp.GatewayClient == null) return;
 
         _ = Task.Run(async () =>
         {
             try
             {
-                var success = await _hub.GatewayClient.SetConfigAsync(configPath, newValue);
+                var success = await CurrentApp.GatewayClient.SetConfigAsync(configPath, newValue);
                 DispatcherQueue?.TryEnqueue(() =>
                 {
                     SaveStatus.Text = success
                         ? $"✅ Sent {configPath}"
                         : $"❌ Failed to save {configPath}";
-                    if (success && _hub?.GatewayClient != null)
-                        _ = _hub.GatewayClient.RequestConfigAsync();
+                    if (success && CurrentApp.GatewayClient != null)
+                        _ = CurrentApp.GatewayClient.RequestConfigAsync();
                 });
             }
             catch (Exception ex)

--- a/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
@@ -3,9 +3,11 @@ using Microsoft.UI.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using OpenClawTray.Services;
 using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -17,6 +19,7 @@ public sealed partial class ConfigPage : Page
     private static readonly JsonElement s_emptyObject = JsonDocument.Parse("{}").RootElement.Clone();
 
     private HubWindow? _hub;
+    private AppState? _appState;
     private JsonElement? _lastConfig;
     private JsonElement? _lastSchema;
     private string? _baseHash;
@@ -29,11 +32,17 @@ public sealed partial class ConfigPage : Page
     public ConfigPage()
     {
         InitializeComponent();
+        Unloaded += (_, _) =>
+        {
+            if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+        };
     }
 
     public void Initialize(HubWindow hub)
     {
         _hub = hub;
+        _appState = ((App)Application.Current).AppState;
+        _appState.PropertyChanged += OnAppStateChanged;
         OpenClawTray.Services.Logger.Info("[ConfigPage] Initialize");
         if (hub.GatewayClient != null)
         {
@@ -87,6 +96,19 @@ public sealed partial class ConfigPage : Page
                 ShowConfigRenderError();
             }
         });
+    }
+
+    private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(AppState.Config):
+                if (_appState!.Config.HasValue) UpdateConfig(_appState.Config.Value);
+                break;
+            case nameof(AppState.ConfigSchema):
+                if (_appState!.ConfigSchema.HasValue) UpdateConfigSchema(_appState.ConfigSchema.Value);
+                break;
+        }
     }
 
     public void UpdateConfigSchema(JsonElement schema)

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
@@ -357,6 +357,13 @@
                             </Grid>
                         </Border>
 
+                        <!-- Connect button when awaiting node pairing approval -->
+                        <Button x:Name="NodeReconnectButton" Visibility="Collapsed"
+                                Content="Connect" Click="OnReconnectFromRecovery"
+                                Style="{StaticResource AccentButtonStyle}"
+                                Margin="0,4,0,0"
+                                AutomationProperties.AutomationId="NodeReconnect"/>
+
                         <!-- Capability chips removed in favor of NodeCapabilityText
                              above. Element kept for back-compat with code-behind
                              that may still reference it (currently inert). -->
@@ -466,6 +473,9 @@
                         <!-- Escape hatch: just disconnect; the always-visible
                              gateways list below offers switching by one click. -->
                         <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
+                            <Button Content="Connect" Click="OnReconnectFromRecovery"
+                                    Style="{StaticResource AccentButtonStyle}"
+                                    AutomationProperties.AutomationId="RecoveryConnect"/>
                             <Button Content="Disconnect" Click="OnDisconnect"
                                     AutomationProperties.AutomationId="RecoveryDisconnect"/>
                         </StackPanel>
@@ -767,6 +777,7 @@
                         <TextBox x:Name="DirectUrlBox"
                                  Header="Gateway URL"
                                  PlaceholderText="ws://host.local:18790"
+                                 TextChanged="OnDirectInputChanged"
                                  AutomationProperties.AutomationId="AddDirectUrl"/>
                         <PasswordBox x:Name="DirectTokenBox"
                                      Header="Shared token"
@@ -887,7 +898,7 @@
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                TextWrapping="Wrap"/>
 
-                    <!-- Save / Cancel row -->
+                    <!-- Test / Save / Cancel row -->
                     <Grid ColumnSpacing="8">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
@@ -903,6 +914,11 @@
                                 Content="Cancel"
                                 Click="OnAddBack"/>
                     </Grid>
+                    <TextBlock x:Name="AddTestResultText"
+                               Visibility="Collapsed"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,0"
+                               Style="{StaticResource CaptionTextBlockStyle}"/>
                 </StackPanel>
             </Border>
 

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -728,15 +728,17 @@ public sealed partial class ConnectionPage : Page
         if (settings != null) NodeModeToggle.IsOn = settings.EnableNodeMode;
         _suppressNodeModeToggle = false;
 
-        // Approve command box (only when pairing required)
+        // Approve command box + connect button (only when pairing required)
         if (plan.NodeCard == NodeCardState.OnNodePairingRequired && plan.NodeApproveCommand != null)
         {
             NodeApproveCmdBox.Visibility = Visibility.Visible;
             NodeApproveCmdText.Text = plan.NodeApproveCommand;
+            NodeReconnectButton.Visibility = Visibility.Visible;
         }
         else
         {
             NodeApproveCmdBox.Visibility = Visibility.Collapsed;
+            NodeReconnectButton.Visibility = Visibility.Collapsed;
         }
 
         // Capability chips — skip the rebuild if the rendered output would
@@ -781,7 +783,7 @@ public sealed partial class ConnectionPage : Page
             RecoveryCategory.Pairing => new[]
             {
                 "Approve this client on the gateway host using the command below.",
-                "Once approved, this client will connect automatically.",
+                "Once approved, click Connect to resume.",
             },
             RecoveryCategory.Tunnel => new[]
             {
@@ -1580,6 +1582,90 @@ public sealed partial class ConnectionPage : Page
 
     // ─── Add gateway: Save ────────────────────────────────────────────
 
+    // ─── Auto-test connectivity (debounced) ────────────────────────────
+
+    private System.Threading.CancellationTokenSource? _connectivityTestCts;
+
+    private void OnDirectInputChanged(object sender, RoutedEventArgs e)
+    {
+        ScheduleConnectivityTest(DirectUrlBox.Text?.Trim());
+    }
+
+    private void ScheduleConnectivityTest(string? rawUrl)
+    {
+        _connectivityTestCts?.Cancel();
+        if (string.IsNullOrWhiteSpace(rawUrl))
+        {
+            AddTestResultText.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
+            return;
+        }
+        _connectivityTestCts = new System.Threading.CancellationTokenSource();
+        var token = _connectivityTestCts.Token;
+        // Debounce 600ms so we don't hit the network on every keystroke
+        _ = RunConnectivityTestAsync(rawUrl, token, delay: 600);
+    }
+
+    private async Task RunConnectivityTestAsync(string rawUrl, System.Threading.CancellationToken ct, int delay = 0)
+    {
+        if (delay > 0)
+        {
+            await Task.Delay(delay, ct);
+            if (ct.IsCancellationRequested) return;
+        }
+
+        AddTestResultText.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
+        AddTestResultText.Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"];
+        AddTestResultText.Text = "Testing connection…";
+
+        try
+        {
+            var url = GatewayUrlHelper.NormalizeForWebSocket(rawUrl);
+            var httpUrl = url.Replace("ws://", "http://").Replace("wss://", "https://").TrimEnd('/');
+
+            using var httpClient = new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+            System.Net.Http.HttpResponseMessage? response = null;
+            try { response = await httpClient.GetAsync(httpUrl, ct); }
+            catch (OperationCanceledException) { throw; }
+            catch { }
+
+            if (ct.IsCancellationRequested) return;
+
+            if (response == null || !response.IsSuccessStatusCode)
+            {
+                try { response = await httpClient.GetAsync($"{httpUrl}/health", ct); }
+                catch (OperationCanceledException) { throw; }
+                catch { }
+            }
+
+            if (ct.IsCancellationRequested) return;
+
+            if (response != null && response.IsSuccessStatusCode)
+            {
+                AddTestResultText.Text = $"✓ Gateway reachable";
+                AddTestResultText.Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["SystemFillColorSuccessBrush"];
+            }
+            else if (response != null)
+            {
+                AddTestResultText.Text = $"⚠ Gateway responded with {(int)response.StatusCode}";
+                AddTestResultText.Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["SystemFillColorCautionBrush"];
+            }
+            else
+            {
+                AddTestResultText.Text = $"✗ Cannot reach gateway";
+                AddTestResultText.Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["SystemFillColorCriticalBrush"];
+            }
+        }
+        catch (OperationCanceledException) { /* debounce or page nav */ }
+        catch (Exception ex)
+        {
+            if (!ct.IsCancellationRequested)
+            {
+                AddTestResultText.Text = $"✗ {ex.Message}";
+                AddTestResultText.Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["SystemFillColorCriticalBrush"];
+            }
+        }
+    }
+
     private async void OnAddSave(object sender, RoutedEventArgs e)
     {
         var tag = ActiveAddPaneTag();
@@ -1978,6 +2064,9 @@ public sealed partial class ConnectionPage : Page
                 : decoded.Token!.Substring(0, Math.Min(8, decoded.Token.Length)) + "…";
             AddSetupCodePreviewToken.Text = $"Token: {tokenHint}";
             AddSetupCodePreviewPanel.Visibility = Visibility.Visible;
+            // Auto-test connectivity with the decoded URL
+            if (!string.IsNullOrEmpty(decoded.Url))
+                ScheduleConnectivityTest(decoded.Url);
         }
         else
         {
@@ -2146,6 +2235,11 @@ public sealed partial class ConnectionPage : Page
     private void OnDisconnect(object sender, RoutedEventArgs e)
     {
         ((IAppCommands)CurrentApp).Disconnect();
+    }
+
+    private void OnReconnectFromRecovery(object sender, RoutedEventArgs e)
+    {
+        ((IAppCommands)CurrentApp).Reconnect();
     }
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -6,7 +6,6 @@ using OpenClaw.Shared;
 using OpenClawTray.Helpers;
 using OpenClawTray.Onboarding.Services;
 using OpenClawTray.Services;
-using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -32,7 +31,7 @@ namespace OpenClawTray.Pages;
 public sealed partial class ConnectionPage : Page
 {
     // ─── DI / services ───
-    private HubWindow? _hub;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private AppState? _appState;
     private IGatewayConnectionManager? _connectionManager;
     private GatewayRegistry? _gatewayRegistry;
@@ -88,14 +87,13 @@ public sealed partial class ConnectionPage : Page
 
     // ─── Initialization ───────────────────────────────────────────────
 
-    public void Initialize(HubWindow hub)
+    public void Initialize()
     {
-        _hub = hub;
         _appState = ((App)Application.Current).AppState;
         _appState.PropertyChanged += OnAppStateChanged;
-        _connectionManager = hub.ConnectionManager;
-        _gatewayRegistry = hub.GatewayRegistry;
-        var settings = hub.Settings;
+        _connectionManager = CurrentApp.ConnectionManager;
+        _gatewayRegistry = CurrentApp.Registry;
+        var settings = CurrentApp.Settings;
         if (settings == null) return;
 
         // Local-WSL install entry points. The hub only exposes
@@ -106,7 +104,7 @@ public sealed partial class ConnectionPage : Page
         //     Welcome screen for first-run users.
         //   • AddLocalWslItem — third method tab inside the Add Gateway
         //     form, alongside Direct and Setup code.
-        var localSetupAvailable = hub.OpenSetupAction is not null;
+        var localSetupAvailable = true;
         var localSetupVisibility = localSetupAvailable
             ? Visibility.Visible
             : Visibility.Collapsed;
@@ -179,7 +177,7 @@ public sealed partial class ConnectionPage : Page
 
     private void RefreshFromSnapshot(GatewayConnectionSnapshot snapshot)
     {
-        if (_hub == null) return;
+        
 
         // Reconnect-mask: see field comment. While the mask window is open,
         // pretend the gateway/operator state is still at its last-stable
@@ -232,8 +230,8 @@ public sealed partial class ConnectionPage : Page
 
         var savedCount = _gatewayRegistry?.GetAll().Count ?? 0;
         var activeRecord = _gatewayRegistry?.GetActive();
-        var self = _hub.LastGatewaySelf;
-        var settings = _hub.Settings;
+        var self = CurrentApp.AppState?.GatewaySelf;
+        var settings = CurrentApp.Settings;
 
         var plan = ConnectionPagePlan.Build(
             effective, activeRecord, self, settings, savedCount, _userIntent);
@@ -247,7 +245,7 @@ public sealed partial class ConnectionPage : Page
         LoadSavedGateways();
 
         // Bridge auth error (lives outside the plan as a transient modifier)
-        var authError = _hub.LastAuthError;
+        var authError = CurrentApp.AppState?.AuthFailureMessage;
         if (!string.IsNullOrEmpty(authError))
         {
             AuthErrorBar.Message = GetAuthErrorGuidance(authError!);
@@ -636,7 +634,7 @@ public sealed partial class ConnectionPage : Page
         }
         NodeCardBorder.Visibility = Visibility.Visible;
 
-        var settings = _hub?.Settings;
+        var settings = CurrentApp.Settings;
         var enabledCaps = settings != null ? CountEnabledCapabilities(settings) : 0;
 
         // Body text + chips (defined below) cover every Node state. The
@@ -979,7 +977,7 @@ public sealed partial class ConnectionPage : Page
         // response (server-reported, the source of truth for what we're
         // actually using). For inactive saved gateways we fall back to whatever
         // credential is stored on the record.
-        var activeAuthMode = _hub?.LastGatewaySelf?.AuthMode;
+        var activeAuthMode = CurrentApp.AppState?.GatewaySelf?.AuthMode;
 
         if (_gatewayRegistry != null)
         {
@@ -1336,7 +1334,7 @@ public sealed partial class ConnectionPage : Page
             case ConnectionPrimaryAction.Connect:
             case ConnectionPrimaryAction.Reconnect:
             case ConnectionPrimaryAction.Retry:
-                _hub?.ReconnectAction?.Invoke();
+                ((IAppCommands)CurrentApp).Reconnect();
                 break;
             case ConnectionPrimaryAction.Cancel:
                 _ = _connectionManager?.DisconnectAsync();
@@ -1386,17 +1384,17 @@ public sealed partial class ConnectionPage : Page
     /// </summary>
     private void OnInstallLocalWslGateway(object sender, RoutedEventArgs e)
     {
-        _hub?.OpenSetupAction?.Invoke();
+        ((IAppCommands)CurrentApp).ShowOnboarding();
     }
 
     // ─── Operator card navigation ────────────────────────────────────
 
-    private void OnOpenSessions(object sender, RoutedEventArgs e) => _hub?.NavigateTo("sessions");
-    private void OnOpenInstances(object sender, RoutedEventArgs e) => _hub?.NavigateTo("instances");
+    private void OnOpenSessions(object sender, RoutedEventArgs e) => ((IAppCommands)CurrentApp).Navigate("sessions");
+    private void OnOpenInstances(object sender, RoutedEventArgs e) => ((IAppCommands)CurrentApp).Navigate("instances");
 
     // ─── Node card navigation ────────────────────────────────────────
 
-    private void OnOpenPermissions(object sender, RoutedEventArgs e) => _hub?.NavigateTo("permissions");
+    private void OnOpenPermissions(object sender, RoutedEventArgs e) => ((IAppCommands)CurrentApp).Navigate("permissions");
 
     private void OnCopyNodeApproveCommand(object sender, RoutedEventArgs e)
     {
@@ -1650,7 +1648,7 @@ public sealed partial class ConnectionPage : Page
 
         // Snapshot previous state for rollback (mirrors legacy logic exactly)
         var previousActiveId = _gatewayRegistry.ActiveGatewayId;
-        var previousSettings = _hub?.Settings;
+        var previousSettings = CurrentApp.Settings;
         var prevGatewayUrl = previousSettings?.GatewayUrl;
         var prevUseSsh = previousSettings?.UseSshTunnel ?? false;
         var prevSshUser = previousSettings?.SshTunnelUser;
@@ -1943,13 +1941,13 @@ public sealed partial class ConnectionPage : Page
                     AddResultText.Text = $"✗ {decoded.Error}";
                     return;
                 }
-                var settings = _hub?.Settings;
+                var settings = CurrentApp.Settings;
                 if (settings == null) return;
                 if (!string.IsNullOrEmpty(decoded.Url))
                     settings.GatewayUrl = decoded.Url;
                 settings.Save();
                 AddResultText.Text = $"✓ Applied — gateway: {SanitizeUrl(decoded.Url ?? settings.GatewayUrl ?? "")}";
-                _hub?.RaiseSettingsSaved();
+                ((IAppCommands)CurrentApp).NotifySettingsSaved();
             }
         }
         finally
@@ -2147,7 +2145,7 @@ public sealed partial class ConnectionPage : Page
 
     private void OnDisconnect(object sender, RoutedEventArgs e)
     {
-        _hub?.DisconnectAction?.Invoke();
+        ((IAppCommands)CurrentApp).Disconnect();
     }
 
     /// <summary>
@@ -2161,19 +2159,19 @@ public sealed partial class ConnectionPage : Page
         if (ConnectionToggle.IsOn)
         {
             // User asked to reconnect.
-            _hub?.ReconnectAction?.Invoke();
+            ((IAppCommands)CurrentApp).Reconnect();
         }
         else
         {
             // User asked to disconnect.
-            _hub?.DisconnectAction?.Invoke();
+            ((IAppCommands)CurrentApp).Disconnect();
         }
     }
 
     private void OnNodeModeToggled(object sender, RoutedEventArgs e)
     {
         if (_suppressNodeModeToggle) return;
-        var settings = _hub?.Settings;
+        var settings = CurrentApp.Settings;
         if (settings == null) return;
         settings.EnableNodeMode = NodeModeToggle.IsOn;
         settings.Save();
@@ -2181,7 +2179,7 @@ public sealed partial class ConnectionPage : Page
         // the role change registers; mask the brief transient window so the
         // gateway/operator visuals don't flicker through "Disconnected".
         BeginReconnectMask();
-        _hub?.RaiseSettingsSaved();
+        ((IAppCommands)CurrentApp).NotifySettingsSaved();
         RefreshFromSnapshot(_lastSnapshot);
     }
 
@@ -2257,7 +2255,7 @@ public sealed partial class ConnectionPage : Page
 
         if (hasDevicePending)
         {
-            var scopes = _hub?.GatewayClient?.GrantedOperatorScopes ?? (IReadOnlyList<string>)Array.Empty<string>();
+            var scopes = CurrentApp.GatewayClient?.GrantedOperatorScopes ?? (IReadOnlyList<string>)Array.Empty<string>();
             var canPair = OperatorScopeHelper.CanApproveDevices(scopes);
             // Build the set of fallback ids that collide across multiple
             // pending requests. When a legacy gateway omits RequestId we
@@ -2285,7 +2283,7 @@ public sealed partial class ConnectionPage : Page
 
         if (hasNodePending)
         {
-            var scopes = _hub?.GatewayClient?.GrantedOperatorScopes ?? (IReadOnlyList<string>)Array.Empty<string>();
+            var scopes = CurrentApp.GatewayClient?.GrantedOperatorScopes ?? (IReadOnlyList<string>)Array.Empty<string>();
             var canPair = OperatorScopeHelper.CanApproveDevices(scopes);
             // Same ambiguity guard as UpdateDevicePairingRequests above:
             // if a legacy gateway sends multiple node-pair requests with
@@ -2390,7 +2388,7 @@ public sealed partial class ConnectionPage : Page
                 approveBtn.IsEnabled = false; rejectBtn.IsEnabled = false;
                 try
                 {
-                    var client = _hub?.GatewayClient;
+                    var client = CurrentApp.GatewayClient;
                     if (client != null)
                     {
                         var ok = await client.DevicePairApproveAsync(capturedId);
@@ -2407,7 +2405,7 @@ public sealed partial class ConnectionPage : Page
                 approveBtn.IsEnabled = false; rejectBtn.IsEnabled = false;
                 try
                 {
-                    var client = _hub?.GatewayClient;
+                    var client = CurrentApp.GatewayClient;
                     if (client != null)
                     {
                         var ok = await client.DevicePairRejectAsync(capturedId);
@@ -2485,7 +2483,7 @@ public sealed partial class ConnectionPage : Page
                 approveBtn.IsEnabled = false; rejectBtn.IsEnabled = false;
                 try
                 {
-                    var client = _hub?.GatewayClient;
+                    var client = CurrentApp.GatewayClient;
                     if (client != null)
                     {
                         var ok = await client.NodePairApproveAsync(capturedId);
@@ -2501,7 +2499,7 @@ public sealed partial class ConnectionPage : Page
                 approveBtn.IsEnabled = false; rejectBtn.IsEnabled = false;
                 try
                 {
-                    var client = _hub?.GatewayClient;
+                    var client = CurrentApp.GatewayClient;
                     if (client != null)
                     {
                         var ok = await client.NodePairRejectAsync(capturedId);

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -165,14 +165,6 @@ public sealed partial class ConnectionPage : Page
         });
     }
 
-    /// <summary>Legacy bridge from HubWindow's ConnectionStatus-based pumps.</summary>
-    public void UpdateStatus(ConnectionStatus status)
-    {
-        var snapshot = _connectionManager?.CurrentSnapshot ?? GatewayConnectionSnapshot.Idle;
-        _lastSnapshot = snapshot;
-        RefreshFromSnapshot(snapshot);
-    }
-
     // ─── Plan apply ───────────────────────────────────────────────────
 
     private void RefreshFromSnapshot(GatewayConnectionSnapshot snapshot)
@@ -2323,7 +2315,9 @@ public sealed partial class ConnectionPage : Page
         switch (e.PropertyName)
         {
             case nameof(AppState.Status):
-                UpdateStatus(_appState!.Status);
+                var snapshot = _connectionManager?.CurrentSnapshot ?? GatewayConnectionSnapshot.Idle;
+                _lastSnapshot = snapshot;
+                RefreshFromSnapshot(snapshot);
                 break;
             case nameof(AppState.NodePairList):
                 if (_appState!.NodePairList != null) UpdatePairingRequests(_appState.NodePairList);

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -2338,6 +2338,7 @@ public sealed partial class ConnectionPage : Page
         catch (Exception ex)
         {
             Services.Logger.Warn($"[ConnectionPage] OnAppStateChanged({e.PropertyName}) failed: {ex.Message}");
+            throw;
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -2312,25 +2312,32 @@ public sealed partial class ConnectionPage : Page
 
     private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
     {
-        switch (e.PropertyName)
+        try
         {
-            case nameof(AppState.Status):
-                var snapshot = _connectionManager?.CurrentSnapshot ?? GatewayConnectionSnapshot.Idle;
-                _lastSnapshot = snapshot;
-                RefreshFromSnapshot(snapshot);
-                break;
-            case nameof(AppState.NodePairList):
-                if (_appState!.NodePairList != null) UpdatePairingRequests(_appState.NodePairList);
-                break;
-            case nameof(AppState.DevicePairList):
-                if (_appState!.DevicePairList != null) UpdateDevicePairingRequests(_appState.DevicePairList);
-                break;
-            case nameof(AppState.Channels):
-            case nameof(AppState.UsageCost):
-            case nameof(AppState.Sessions):
-            case nameof(AppState.GatewaySelf):
-                OnGlanceDataChanged();
-                break;
+            switch (e.PropertyName)
+            {
+                case nameof(AppState.Status):
+                    var snapshot = _connectionManager?.CurrentSnapshot ?? GatewayConnectionSnapshot.Idle;
+                    _lastSnapshot = snapshot;
+                    RefreshFromSnapshot(snapshot);
+                    break;
+                case nameof(AppState.NodePairList):
+                    if (_appState?.NodePairList != null) UpdatePairingRequests(_appState.NodePairList);
+                    break;
+                case nameof(AppState.DevicePairList):
+                    if (_appState?.DevicePairList != null) UpdateDevicePairingRequests(_appState.DevicePairList);
+                    break;
+                case nameof(AppState.Channels):
+                case nameof(AppState.UsageCost):
+                case nameof(AppState.Sessions):
+                case nameof(AppState.GatewaySelf):
+                    OnGlanceDataChanged();
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            Services.Logger.Warn($"[ConnectionPage] OnAppStateChanged({e.PropertyName}) failed: {ex.Message}");
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -9,6 +9,7 @@ using OpenClawTray.Services;
 using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -32,6 +33,7 @@ public sealed partial class ConnectionPage : Page
 {
     // ─── DI / services ───
     private HubWindow? _hub;
+    private AppState? _appState;
     private IGatewayConnectionManager? _connectionManager;
     private GatewayRegistry? _gatewayRegistry;
     private GatewayDiscoveryService? _discoveryService;
@@ -89,6 +91,8 @@ public sealed partial class ConnectionPage : Page
     public void Initialize(HubWindow hub)
     {
         _hub = hub;
+        _appState = ((App)Application.Current).AppState;
+        _appState.PropertyChanged += OnAppStateChanged;
         _connectionManager = hub.ConnectionManager;
         _gatewayRegistry = hub.GatewayRegistry;
         var settings = hub.Settings;
@@ -142,6 +146,7 @@ public sealed partial class ConnectionPage : Page
             _reconnectMaskTimer.Tick -= OnReconnectMaskTimeout;
             _reconnectMaskTimer = null;
         }
+        if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
     }
 
     private void OnManagerStateChanged(object? sender, GatewayConnectionSnapshot snapshot)
@@ -419,9 +424,9 @@ public sealed partial class ConnectionPage : Page
             return;
         }
 
-        var self = _hub?.LastGatewaySelf;
-        var channels = _hub?.LastChannels;
-        var cost = _hub?.LastUsageCost;
+        var self = _appState?.GatewaySelf;
+        var channels = _appState?.Channels;
+        var cost = _appState?.UsageCost;
         var activeRec = _gatewayRegistry?.GetActive();
 
         // Compute the fingerprint from the same inputs the chips render so
@@ -584,7 +589,7 @@ public sealed partial class ConnectionPage : Page
 
         // Status sub-row (mirrors PermissionsPage NodeStatusDot pattern):
         // colored dot + descriptive label that reflects the live state.
-        var sessions = _hub?.LastSessions;
+        var sessions = _appState?.Sessions;
         int activeSessions = sessions?.Count(s =>
             string.Equals(s.Status, "active", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(s.Status, "running", StringComparison.OrdinalIgnoreCase)) ?? 0;
@@ -2219,6 +2224,28 @@ public sealed partial class ConnectionPage : Page
         _maskHasObservedTransient = false;
         if (_connectionManager != null)
             RefreshFromSnapshot(_connectionManager.CurrentSnapshot);
+    }
+
+    private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(AppState.Status):
+                UpdateStatus(_appState!.Status);
+                break;
+            case nameof(AppState.NodePairList):
+                if (_appState!.NodePairList != null) UpdatePairingRequests(_appState.NodePairList);
+                break;
+            case nameof(AppState.DevicePairList):
+                if (_appState!.DevicePairList != null) UpdateDevicePairingRequests(_appState.DevicePairList);
+                break;
+            case nameof(AppState.Channels):
+            case nameof(AppState.UsageCost):
+            case nameof(AppState.Sessions):
+            case nameof(AppState.GatewaySelf):
+                OnGlanceDataChanged();
+                break;
+        }
     }
 
     // ─── Pending pairing — populate the banner with existing semantics ─

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPagePlan.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPagePlan.cs
@@ -371,7 +371,7 @@ internal sealed record ConnectionPagePlan
                 StripGlyph = OpenClawTray.Helpers.FluentIconCatalog.Lock,
                 StripAccent = ConnectionAccent.Caution,
                 StripHeadline = "Awaiting approval",
-                StripSub = "Approve this client on the gateway host. Connection will resume automatically.",
+                StripSub = "Approve this client on the gateway host. Click Connect once approved.",
                 StripPrimaryLabel = cmd != null ? "Copy command" : null,
                 StripPrimaryAction = cmd != null ? ConnectionPrimaryAction.CopyApproveCommand : ConnectionPrimaryAction.None,
                 RecoveryApproveCommand = cmd,
@@ -507,8 +507,8 @@ internal sealed record ConnectionPagePlan
             ? ConnectionCardPlanSanitizer.Sanitize(snap.NodePairingRequestId!, maxLen: 64)
             : null;
         return reqId != null
-            ? $"openclaw approve node {reqId}"
-            : "openclaw approve node";
+            ? $"openclaw nodes approve {reqId}"
+            : "openclaw nodes approve";
     }
 
     private static string? BuildDevicePairingApproveCommand(GatewayConnectionSnapshot snap)
@@ -519,8 +519,8 @@ internal sealed record ConnectionPagePlan
             ? ConnectionCardPlanSanitizer.Sanitize(snap.OperatorPairingRequestId!, maxLen: 64)
             : null;
         return reqId != null
-            ? $"openclaw approve device {reqId}"
-            : "openclaw approve device";
+            ? $"openclaw devices approve {reqId}"
+            : "openclaw devices approve";
     }
 
     private static string? ExtractNodeErrorDetail(GatewayConnectionSnapshot snap)

--- a/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
@@ -3,9 +3,11 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using OpenClaw.Shared;
+using OpenClawTray.Services;
 using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -17,6 +19,7 @@ namespace OpenClawTray.Pages;
 public sealed partial class CronPage : Page
 {
     private HubWindow? _hub;
+    private AppState? _appState;
     private List<CronJobViewModel> _jobs = new();
     private Border? _editingCard = null; // card hidden during inline edit
     private string? _historyJobId = null; // job whose history is currently displayed
@@ -28,15 +31,37 @@ public sealed partial class CronPage : Page
     public CronPage()
     {
         InitializeComponent();
+        Unloaded += (_, _) =>
+        {
+            if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+        };
     }
 
     public void Initialize(HubWindow hub)
     {
         _hub = hub;
+        _appState = ((App)Application.Current).AppState;
+        _appState.PropertyChanged += OnAppStateChanged;
         if (hub.GatewayClient != null)
         {
             _ = hub.GatewayClient.RequestCronListAsync();
             _ = hub.GatewayClient.RequestCronStatusAsync();
+        }
+    }
+
+    private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(AppState.CronList):
+                if (_appState!.CronList.HasValue) UpdateFromGateway(_appState.CronList.Value);
+                break;
+            case nameof(AppState.CronStatus):
+                if (_appState!.CronStatus.HasValue) UpdateFromGateway(_appState.CronStatus.Value);
+                break;
+            case nameof(AppState.CronRuns):
+                if (_appState!.CronRuns.HasValue) UpdateCronRuns(_appState.CronRuns.Value);
+                break;
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
@@ -4,7 +4,6 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using OpenClaw.Shared;
 using OpenClawTray.Services;
-using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -18,7 +17,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class CronPage : Page
 {
-    private HubWindow? _hub;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private AppState? _appState;
     private List<CronJobViewModel> _jobs = new();
     private Border? _editingCard = null; // card hidden during inline edit
@@ -37,15 +36,14 @@ public sealed partial class CronPage : Page
         };
     }
 
-    public void Initialize(HubWindow hub)
+    public void Initialize()
     {
-        _hub = hub;
-        _appState = ((App)Application.Current).AppState;
+        _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
-        if (hub.GatewayClient != null)
+        if (CurrentApp.GatewayClient != null)
         {
-            _ = hub.GatewayClient.RequestCronListAsync();
-            _ = hub.GatewayClient.RequestCronStatusAsync();
+            _ = CurrentApp.GatewayClient.RequestCronListAsync();
+            _ = CurrentApp.GatewayClient.RequestCronStatusAsync();
         }
     }
 
@@ -69,14 +67,14 @@ public sealed partial class CronPage : Page
     {
         var btn = sender as Button;
         var jobId = btn?.Tag as string;
-        if (string.IsNullOrEmpty(jobId) || _hub?.GatewayClient == null) return;
+        if (string.IsNullOrEmpty(jobId) || CurrentApp.GatewayClient == null) return;
         var vm = _jobs.Find(j => j.Id == jobId);
         if (vm != null && !vm.IsEnabled) return;
         _runningJobIds.Add(jobId);
         btn!.Content = "Running...";
         btn.IsEnabled = false;
 
-        _hub.GatewayClient.RunCronJobAsync(jobId).ContinueWith(t =>
+        CurrentApp.GatewayClient.RunCronJobAsync(jobId).ContinueWith(t =>
         {
             if (t.IsFaulted || (t.IsCompletedSuccessfully && !t.Result))
             {
@@ -84,13 +82,13 @@ public sealed partial class CronPage : Page
                 DispatcherQueue?.TryEnqueue(() =>
                 {
                     _runningJobIds.Remove(jobId);
-                    _ = _hub?.GatewayClient?.RequestCronListAsync();
+                    _ = CurrentApp.GatewayClient?.RequestCronListAsync();
                 });
             }
         });
 
         // Safety timeout: clear running state after 90s if gateway never reports completion
-        var capturedHub = _hub;
+        // Safety timeout uses CurrentApp directly
         Task.Delay(TimeSpan.FromSeconds(90)).ContinueWith(_ =>
         {
             if (_runningJobIds.Contains(jobId))
@@ -98,7 +96,7 @@ public sealed partial class CronPage : Page
                 DispatcherQueue?.TryEnqueue(() =>
                 {
                     _runningJobIds.Remove(jobId);
-                    _ = capturedHub?.GatewayClient?.RequestCronListAsync();
+                    _ = CurrentApp.GatewayClient?.RequestCronListAsync();
                 });
             }
         });
@@ -107,21 +105,21 @@ public sealed partial class CronPage : Page
     private void OnRemoveClick(object sender, RoutedEventArgs e)
     {
         var jobId = (sender as Button)?.Tag as string;
-        if (string.IsNullOrEmpty(jobId) || _hub?.GatewayClient == null) return;
+        if (string.IsNullOrEmpty(jobId) || CurrentApp.GatewayClient == null) return;
         _removedJobIds.Add(jobId);
         // Gateway client's HandleKnownResponse refreshes the list automatically on cron.remove
-        _ = _hub.GatewayClient.RemoveCronJobAsync(jobId);
+        _ = CurrentApp.GatewayClient.RemoveCronJobAsync(jobId);
     }
 
     private void OnToggleEnabledClick(object sender, RoutedEventArgs e)
     {
         var jobId = (sender as Button)?.Tag as string;
-        if (string.IsNullOrEmpty(jobId) || _hub?.GatewayClient == null) return;
+        if (string.IsNullOrEmpty(jobId) || CurrentApp.GatewayClient == null) return;
 
         var vm = _jobs.Find(j => j.Id == jobId);
         if (vm != null)
         {
-            _ = _hub.GatewayClient.UpdateCronJobAsync(jobId, new { enabled = !vm.IsEnabled });
+            _ = CurrentApp.GatewayClient.UpdateCronJobAsync(jobId, new { enabled = !vm.IsEnabled });
         }
     }
 
@@ -223,7 +221,7 @@ public sealed partial class CronPage : Page
             return;
         }
 
-        if (_hub?.GatewayClient == null)
+        if (CurrentApp.GatewayClient == null)
         {
             ShowFormError("Not connected to gateway.");
             return;
@@ -307,7 +305,7 @@ public sealed partial class CronPage : Page
             if (kind == "at")
                 patch["deleteAfterRun"] = FormDeleteAfterRun.IsChecked == true;
 
-            _ = _hub.GatewayClient.UpdateCronJobAsync(_editingJobId, patch);
+            _ = CurrentApp.GatewayClient.UpdateCronJobAsync(_editingJobId, patch);
         }
         else
         {
@@ -329,7 +327,7 @@ public sealed partial class CronPage : Page
             if (kind == "at")
                 job["deleteAfterRun"] = FormDeleteAfterRun.IsChecked == true;
 
-            _ = _hub.GatewayClient.AddCronJobAsync(job);
+            _ = CurrentApp.GatewayClient.AddCronJobAsync(job);
         }
 
         RestoreFormFromInline();
@@ -1245,7 +1243,7 @@ public sealed partial class CronPage : Page
     private void OnHistoryClick(object sender, RoutedEventArgs e)
     {
         var jobId = (sender as Button)?.Tag as string;
-        if (string.IsNullOrEmpty(jobId) || _hub?.GatewayClient == null) return;
+        if (string.IsNullOrEmpty(jobId) || CurrentApp.GatewayClient == null) return;
         var vm = _jobs.Find(j => j.Id == jobId);
         if (vm != null && !vm.IsEnabled) return;
         if (_historyJobId == jobId)
@@ -1275,7 +1273,7 @@ public sealed partial class CronPage : Page
             histPanel.Visibility = Visibility.Visible;
         }
 
-        _ = _hub.GatewayClient.RequestCronRunsAsync(jobId, limit: 20, offset: 0);
+        _ = CurrentApp.GatewayClient.RequestCronRunsAsync(jobId, limit: 20, offset: 0);
     }
 
     private void HideHistoryPanel(string jobId)
@@ -1395,12 +1393,12 @@ public sealed partial class CronPage : Page
             loadMoreBtn.Click += (s, args) =>
             {
                 var jid = (s as Button)?.Tag as string;
-                if (!string.IsNullOrEmpty(jid) && _hub?.GatewayClient != null)
+                if (!string.IsNullOrEmpty(jid) && CurrentApp.GatewayClient != null)
                 {
                     loadMoreBtn.IsEnabled = false;
                     loadMoreBtn.Content = "Loading...";
                     // For simplicity, reload with higher limit
-                    _ = _hub.GatewayClient.RequestCronRunsAsync(jid, limit: nextOffset + 20, offset: 0);
+                    _ = CurrentApp.GatewayClient.RequestCronRunsAsync(jid, limit: nextOffset + 20, offset: 0);
                 }
             };
             histPanel.Children.Add(loadMoreBtn);

--- a/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
@@ -2,6 +2,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using OpenClaw.Shared;
 using OpenClawTray.Helpers;
+using OpenClawTray.Services;
 using OpenClawTray.Windows;
 using System;
 using System.Diagnostics;
@@ -13,7 +14,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class DebugPage : Page
 {
-    private HubWindow? _hub;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
 
     private static readonly string LocalAppData = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "OpenClawTray");
@@ -24,9 +25,8 @@ public sealed partial class DebugPage : Page
 
     public DebugPage() { InitializeComponent(); }
 
-    public void Initialize(HubWindow hub)
+    public void Initialize()
     {
-        _hub = hub;
         LoadLog();
         LoadConnectionStatus();
         LoadDeviceIdentity();
@@ -122,9 +122,9 @@ public sealed partial class DebugPage : Page
 
     private void LoadConnectionStatus()
     {
-        if (_hub == null) return;
+        var status = CurrentApp.AppState?.Status ?? ConnectionStatus.Disconnected;
 
-        var statusText = _hub.CurrentStatus switch
+        var statusText = status switch
         {
             ConnectionStatus.Connected => "🟢 Connected",
             ConnectionStatus.Connecting => "🟡 Connecting",
@@ -134,8 +134,8 @@ public sealed partial class DebugPage : Page
         };
         OperatorStatusText.Text = statusText;
 
-        GatewayUrlText.Text = _hub.Settings?.GetEffectiveGatewayUrl() ?? "—";
-        NodeModeText.Text = _hub.Settings?.EnableNodeMode == true ? "Enabled" : "Disabled";
+        GatewayUrlText.Text = CurrentApp.Settings?.GetEffectiveGatewayUrl() ?? "—";
+        NodeModeText.Text = CurrentApp.Settings?.EnableNodeMode == true ? "Enabled" : "Disabled";
     }
 
     // ── Device Identity ──────────────────────────────────────────────
@@ -218,7 +218,7 @@ public sealed partial class DebugPage : Page
 
     private void OnOpenConnectionStatus(object sender, RoutedEventArgs e)
     {
-        _hub?.OpenConnectionStatusAction?.Invoke();
+        ((IAppCommands)CurrentApp).ShowConnectionStatus();
     }
 
     private void OnCopySupportContext(object sender, RoutedEventArgs e)
@@ -248,7 +248,7 @@ public sealed partial class DebugPage : Page
 
     private void OnRelaunchOnboarding(object sender, RoutedEventArgs e)
     {
-        _hub?.OpenSetupAction?.Invoke();
+        ((IAppCommands)CurrentApp).ShowOnboarding();
     }
 
     private ChatExplorationsWindow? _explorationsWindow;

--- a/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml
@@ -40,15 +40,6 @@
                 </Button>
             </Grid>
 
-            <InfoBar x:Uid="InstancesPage_ConnectionWarning"
-                     x:Name="ConnectionWarning"
-                     Title="Not connected"
-                     Message="Connect to a gateway to see live instance data."
-                     Severity="Warning"
-                     IsOpen="True"
-                     IsClosable="False"
-                     Visibility="Collapsed"/>
-
             <StackPanel x:Name="EmptyState"
                         Spacing="8"
                         HorizontalAlignment="Center"

--- a/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml.cs
@@ -6,7 +6,6 @@ using Microsoft.UI.Xaml.Media;
 using OpenClaw.Shared;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
-using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -26,7 +25,7 @@ namespace OpenClawTray.Pages;
 /// </summary>
 public sealed partial class InstancesPage : Page
 {
-    private HubWindow? _hub;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private AppState? _appState;
     private GatewayNodeInfo[]? _lastNodes;
     private PresenceEntry[]? _lastPresence;
@@ -41,12 +40,11 @@ public sealed partial class InstancesPage : Page
     }
 
     /// <summary>Called by HubWindow when this page becomes the navigation target.</summary>
-    public void Initialize(HubWindow hub)
+    public void Initialize()
     {
-        _hub = hub;
-        _appState = ((App)Application.Current).AppState;
+        _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
-        var connected = hub.GatewayClient != null;
+        var connected = CurrentApp.GatewayClient != null;
         ConnectionWarning.Visibility = connected ? Visibility.Collapsed : Visibility.Visible;
 
         _lastNodes = _appState?.Nodes;
@@ -102,9 +100,9 @@ public sealed partial class InstancesPage : Page
 
     private async System.Threading.Tasks.Task RequestNodesWithSpinnerAsync()
     {
-        if (_hub?.GatewayClient is not { } client)
+        if (CurrentApp.GatewayClient is not { } client)
         {
-            // Still re-render in case _hub.GatewayClient state changed.
+            // Still re-render in case gateway client state changed.
             Rerender();
             return;
         }
@@ -137,7 +135,7 @@ public sealed partial class InstancesPage : Page
 
     private void Rerender()
     {
-        var connected = _hub?.GatewayClient != null;
+        var connected = CurrentApp.GatewayClient != null;
         ConnectionWarning.Visibility = connected ? Visibility.Collapsed : Visibility.Visible;
 
         // Single timestamp shared by merge classification AND age formatting so
@@ -150,7 +148,7 @@ public sealed partial class InstancesPage : Page
             _lastPresence,
             new InstanceMergeOptions
             {
-                LocalNodeId = _hub?.NodeFullDeviceId,
+                LocalNodeId = CurrentApp.NodeFullDeviceId,
                 LocalHost = Environment.MachineName,
                 OnUnmatchedNode = msg => Debug.WriteLine($"[InstancesPage] {msg}"),
                 NowUtc = () => nowUtc,
@@ -240,9 +238,9 @@ public sealed partial class InstancesPage : Page
         var updateLine = BuildUpdateLine(row, nowUtc);
         if (updateLine is not null) body.Children.Add(updateLine);
 
-        if (row.IsManaged && row.Node is not null && _hub is not null)
+        if (row.IsManaged && row.Node is not null)
         {
-            var managementBody = InstanceManagementControls.BuildManagementBody(row.Node, _hub, this);
+            var managementBody = InstanceManagementControls.BuildManagementBody(row.Node, CurrentApp.GatewayClient, this);
             if (managementBody is FrameworkElement fe)
             {
                 fe.Margin = new Thickness(0, 10, 0, 0);

--- a/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml.cs
@@ -5,9 +5,11 @@ using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
 using OpenClaw.Shared;
 using OpenClawTray.Helpers;
+using OpenClawTray.Services;
 using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 
@@ -25,28 +27,48 @@ namespace OpenClawTray.Pages;
 public sealed partial class InstancesPage : Page
 {
     private HubWindow? _hub;
+    private AppState? _appState;
     private GatewayNodeInfo[]? _lastNodes;
     private PresenceEntry[]? _lastPresence;
 
     public InstancesPage()
     {
         InitializeComponent();
+        Unloaded += (_, _) =>
+        {
+            if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+        };
     }
 
     /// <summary>Called by HubWindow when this page becomes the navigation target.</summary>
     public void Initialize(HubWindow hub)
     {
         _hub = hub;
+        _appState = ((App)Application.Current).AppState;
+        _appState.PropertyChanged += OnAppStateChanged;
         var connected = hub.GatewayClient != null;
         ConnectionWarning.Visibility = connected ? Visibility.Collapsed : Visibility.Visible;
 
-        _lastNodes = hub.LastNodes;
-        _lastPresence = hub.LastPresence;
+        _lastNodes = _appState?.Nodes;
+        _lastPresence = _appState?.Presence;
         Rerender();
 
         if (connected)
         {
             _ = RequestNodesWithSpinnerAsync();
+        }
+    }
+
+    private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(AppState.Nodes):
+                UpdateNodes(_appState!.Nodes);
+                break;
+            case nameof(AppState.Presence):
+                if (_appState!.Presence != null) UpdatePresence(_appState.Presence);
+                break;
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml.cs
@@ -42,12 +42,10 @@ public sealed partial class InstancesPage : Page
     {
         _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
-        var connected = CurrentApp.GatewayClient != null;
-        ConnectionWarning.Visibility = connected ? Visibility.Collapsed : Visibility.Visible;
 
         Rerender();
 
-        if (connected)
+        if (CurrentApp.GatewayClient != null)
         {
             _ = RequestNodesWithSpinnerAsync();
         }
@@ -61,7 +59,7 @@ public sealed partial class InstancesPage : Page
                 UpdateNodes(_appState!.Nodes);
                 break;
             case nameof(AppState.Presence):
-                if (_appState!.Presence != null) UpdatePresence(_appState.Presence);
+                UpdatePresence(_appState!.Presence ?? Array.Empty<PresenceEntry>());
                 break;
         }
     }
@@ -120,8 +118,7 @@ public sealed partial class InstancesPage : Page
 
     private void Rerender()
     {
-        var connected = CurrentApp.GatewayClient != null;
-        ConnectionWarning.Visibility = connected ? Visibility.Collapsed : Visibility.Visible;
+        InstancesList.Children.Clear();
 
         // Single timestamp shared by merge classification AND age formatting so
         // a row's status word (e.g. "Active") never disagrees with the relative

--- a/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml.cs
@@ -27,8 +27,6 @@ public sealed partial class InstancesPage : Page
 {
     private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private AppState? _appState;
-    private GatewayNodeInfo[]? _lastNodes;
-    private PresenceEntry[]? _lastPresence;
 
     public InstancesPage()
     {
@@ -47,8 +45,6 @@ public sealed partial class InstancesPage : Page
         var connected = CurrentApp.GatewayClient != null;
         ConnectionWarning.Visibility = connected ? Visibility.Collapsed : Visibility.Visible;
 
-        _lastNodes = _appState?.Nodes;
-        _lastPresence = _appState?.Presence;
         Rerender();
 
         if (connected)
@@ -72,26 +68,15 @@ public sealed partial class InstancesPage : Page
 
     public void UpdateNodes(GatewayNodeInfo[] nodes)
     {
-        DispatcherQueue?.TryEnqueue(() =>
-        {
-            _lastNodes = nodes;
-            // A node push satisfies an in-flight refresh request.
-            SetRefreshing(false);
-            Rerender();
-        });
+        // A node push satisfies an in-flight refresh request.
+        SetRefreshing(false);
+        Rerender();
     }
 
     public void UpdatePresence(PresenceEntry[] entries)
     {
-        DispatcherQueue?.TryEnqueue(() =>
-        {
-            _lastPresence = entries;
-            Rerender();
-        });
+        Rerender();
     }
-
-    // Legacy alias kept for HubWindow's older fan-out signature.
-    public void UpdatePresenceData(PresenceEntry[] entries) => UpdatePresence(entries);
 
     private void OnRefreshClicked(object sender, RoutedEventArgs e)
     {
@@ -144,8 +129,8 @@ public sealed partial class InstancesPage : Page
         var nowUtc = DateTime.UtcNow;
 
         var merged = InstanceMerger.Merge(
-            _lastNodes,
-            _lastPresence,
+            _appState?.Nodes,
+            _appState?.Presence,
             new InstanceMergeOptions
             {
                 LocalNodeId = CurrentApp.NodeFullDeviceId,

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
@@ -5,7 +5,6 @@ using OpenClaw.Shared;
 using OpenClaw.Shared.Capabilities;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
-using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -17,7 +16,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class PermissionsPage : Page
 {
-    private HubWindow? _hub;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private bool _suppressMcpToggle;
     private bool _suppressTtsProviderChange;
     private readonly List<ToggleSwitch> _featureToggles = new();
@@ -34,77 +33,76 @@ public sealed partial class PermissionsPage : Page
         Unloaded += OnUnloaded;
     }
 
-    public void Initialize(HubWindow hub)
+    public void Initialize()
     {
-        _hub = hub;
         HostnameText.Text = Environment.MachineName;
 
-        BindNodeModeMaster(hub);
-        BuildCapabilityToggles(hub);
-        UpdateMcpStatus(hub);
-        UpdateSttCard(hub);
-        UpdateTtsCard(hub);
-        UpdateNodeStatus(hub);
-        ApplyFeaturesEnabledState(hub);
+        BindNodeModeMaster();
+        BuildCapabilityToggles();
+        UpdateMcpStatus();
+        UpdateSttCard();
+        UpdateTtsCard();
+        UpdateNodeStatus();
+        ApplyFeaturesEnabledState();
 
         LoadExecPolicy();
-        LoadAllowlist(hub.AppModel?.Config);
+        LoadAllowlist(CurrentApp.AppState?.Config);
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
-        if (_hub?.Settings != null)
-            _hub.Settings.Saved += OnSettingsSaved;
+        if (CurrentApp.Settings != null)
+            CurrentApp.Settings.Saved += OnSettingsSaved;
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
-        if (_hub?.Settings != null)
-            _hub.Settings.Saved -= OnSettingsSaved;
+        if (CurrentApp.Settings != null)
+            CurrentApp.Settings.Saved -= OnSettingsSaved;
     }
 
     private bool _suppressNodeModeToggle;
 
-    private void BindNodeModeMaster(HubWindow hub)
+    private void BindNodeModeMaster()
     {
-        if (hub.Settings == null) return;
+        if (CurrentApp.Settings == null) return;
         _suppressNodeModeToggle = true;
-        NodeModeToggle.IsOn = hub.Settings.EnableNodeMode;
+        NodeModeToggle.IsOn = CurrentApp.Settings.EnableNodeMode;
         _suppressNodeModeToggle = false;
     }
 
     private void OnNodeModeToggled(object sender, RoutedEventArgs e)
     {
-        if (_suppressNodeModeToggle || _hub?.Settings == null) return;
-        _hub.Settings.EnableNodeMode = NodeModeToggle.IsOn;
-        _hub.Settings.Save();
-        _hub.RaiseSettingsSaved();
-        ApplyFeaturesEnabledState(_hub);
-        UpdateNodeStatus(_hub);
-        UpdateSttCard(_hub);
-        UpdateTtsCard(_hub);
+        if (_suppressNodeModeToggle || CurrentApp.Settings == null) return;
+        CurrentApp.Settings.EnableNodeMode = NodeModeToggle.IsOn;
+        CurrentApp.Settings.Save();
+        ((IAppCommands)CurrentApp).NotifySettingsSaved();
+        ApplyFeaturesEnabledState();
+        UpdateNodeStatus();
+        UpdateSttCard();
+        UpdateTtsCard();
     }
 
     private void OnSettingsSaved(object? sender, EventArgs e)
     {
-        if (_hub == null) return;
+        
         DispatcherQueue?.TryEnqueue(() =>
         {
             if (!IsLoaded) return;
-            BindNodeModeMaster(_hub);
-            ApplyFeaturesEnabledState(_hub);
-            UpdateNodeStatus(_hub);
-            ReloadFeatureToggleStates(_hub);
-            UpdateMcpStatus(_hub);
-            UpdateSttCard(_hub);
-            UpdateTtsCard(_hub);
+            BindNodeModeMaster();
+            ApplyFeaturesEnabledState();
+            UpdateNodeStatus();
+            ReloadFeatureToggleStates();
+            UpdateMcpStatus();
+            UpdateSttCard();
+            UpdateTtsCard();
         });
     }
 
-    private void ReloadFeatureToggleStates(HubWindow hub)
+    private void ReloadFeatureToggleStates()
     {
-        if (hub.Settings == null || _featureToggles.Count == 0) return;
-        var s = hub.Settings;
+        if (CurrentApp.Settings == null || _featureToggles.Count == 0) return;
+        var s = CurrentApp.Settings;
         // Order matches BuildCapabilityToggles: browser, camera, canvas, screen, location, tts, stt.
         bool[] expected =
         {
@@ -123,9 +121,9 @@ public sealed partial class PermissionsPage : Page
     /// no effect until Node Mode is back on. ItemsRepeater isn't a Control (no IsEnabled),
     /// so we apply per-toggle plus an Opacity on the repeater.
     /// </summary>
-    private void ApplyFeaturesEnabledState(HubWindow hub)
+    private void ApplyFeaturesEnabledState()
     {
-        var nodeEnabled = hub.Settings?.EnableNodeMode ?? false;
+        var nodeEnabled = CurrentApp.Settings?.EnableNodeMode ?? false;
         CapabilityRepeater.Opacity = nodeEnabled ? 1.0 : 0.4;
         foreach (var toggle in _featureToggles)
             toggle.IsEnabled = nodeEnabled;
@@ -134,10 +132,10 @@ public sealed partial class PermissionsPage : Page
             : "PermissionsPage_FeaturesDescription_Disabled");
     }
 
-    private void BuildCapabilityToggles(HubWindow hub)
+    private void BuildCapabilityToggles()
     {
-        if (hub.Settings == null) return;
-        var settings = hub.Settings;
+        if (CurrentApp.Settings == null) return;
+        var settings = CurrentApp.Settings;
 
         // OnToggleSideEffect runs after the new value is persisted.
         var capabilities = new (string Icon, string Label, string Description, bool Value, Action<bool> Setter, Action<bool>? OnToggleSideEffect)[]
@@ -170,7 +168,7 @@ public sealed partial class PermissionsPage : Page
                 LocalizationHelper.GetString("PermissionsPage_Cap_Stt_Label"),
                 LocalizationHelper.GetString("PermissionsPage_Cap_Stt_Description"),
                 settings.NodeSttEnabled, v => settings.NodeSttEnabled = v,
-                v => { if (v) EnsureWhisperModelDownloadedAsync(hub); }),
+                v => { if (v) EnsureWhisperModelDownloadedAsync(); }),
         };
 
         var items = new List<UIElement>();
@@ -190,11 +188,11 @@ public sealed partial class PermissionsPage : Page
             {
                 setter(toggle.IsOn);
                 settings.Save();
-                hub.RaiseSettingsSaved();
+                ((IAppCommands)CurrentApp).NotifySettingsSaved();
                 capturedSideEffect?.Invoke(toggle.IsOn);
-                UpdateSttCard(hub);
-                UpdateTtsCard(hub);
-                UpdateNodeStatus(hub);
+                UpdateSttCard();
+                UpdateTtsCard();
+                UpdateNodeStatus();
             };
             _featureToggles.Add(toggle);
             items.Add(BuildCapabilityRow(icon, label, description, toggle));
@@ -211,7 +209,7 @@ public sealed partial class PermissionsPage : Page
     /// page-locally so <see cref="UpdateSttEngineHint"/> can surface "downloading" /
     /// failure copy that's accurate regardless of which code path started the download.
     /// </summary>
-    private async void EnsureWhisperModelDownloadedAsync(HubWindow hub)
+    private async void EnsureWhisperModelDownloadedAsync()
     {
         // async void: ANY uncaught throw bypasses WinUI's UnhandledException handling
         // and tears down the process. Keep every statement inside the try so we can't
@@ -219,22 +217,22 @@ public sealed partial class PermissionsPage : Page
         var logger = new AppLogger();
         try
         {
-            var modelName = hub.Settings?.SttModelName ?? "base";
+            var modelName = CurrentApp.Settings?.SttModelName ?? "base";
             var modelManager = new OpenClaw.Shared.Audio.WhisperModelManager(
                 SettingsManager.SettingsDirectoryPath, logger);
 
             if (modelManager.IsModelDownloaded(modelName) || _isDownloadingWhisperModel) return;
             // Also defer to a VoiceService-initiated download that may be in flight —
             // concurrent writes to the same model file would otherwise be possible.
-            if (hub.VoiceServiceInstance?.IsWhisperDownloadingModel == true)
+            if (CurrentApp.VoiceService?.IsWhisperDownloadingModel == true)
             {
-                if (IsLoaded) UpdateSttCard(hub);
+                if (IsLoaded) UpdateSttCard();
                 return;
             }
 
             _isDownloadingWhisperModel = true;
             _whisperDownloadError = null;
-            if (IsLoaded) UpdateSttCard(hub);
+            if (IsLoaded) UpdateSttCard();
 
             try
             {
@@ -248,7 +246,7 @@ public sealed partial class PermissionsPage : Page
             finally
             {
                 _isDownloadingWhisperModel = false;
-                if (IsLoaded) UpdateSttCard(hub);
+                if (IsLoaded) UpdateSttCard();
             }
         }
         catch (Exception ex)
@@ -307,22 +305,22 @@ public sealed partial class PermissionsPage : Page
 
     // ── Speech-to-Text card ──────────────────────────────────────────
 
-    private void UpdateSttCard(HubWindow hub)
+    private void UpdateSttCard()
     {
-        var enabled = hub.Settings?.NodeSttEnabled == true;
+        var enabled = CurrentApp.Settings?.NodeSttEnabled == true;
         SttCard.Visibility = enabled ? Visibility.Visible : Visibility.Collapsed;
-        if (!enabled || hub.Settings == null) return;
-        UpdateSttEngineHint(hub);
+        if (!enabled || CurrentApp.Settings == null) return;
+        UpdateSttEngineHint();
     }
 
-    private void UpdateSttEngineHint(HubWindow hub)
+    private void UpdateSttEngineHint()
     {
-        var modelName = hub.Settings?.SttModelName ?? "base";
+        var modelName = CurrentApp.Settings?.SttModelName ?? "base";
         var modelManager = new OpenClaw.Shared.Audio.WhisperModelManager(
             SettingsManager.SettingsDirectoryPath, new AppLogger());
         var modelDownloaded = modelManager.IsModelDownloaded(modelName);
         var modelDownloading = _isDownloadingWhisperModel
-            || (hub.VoiceServiceInstance?.IsWhisperDownloadingModel ?? false);
+            || (CurrentApp.VoiceService?.IsWhisperDownloadingModel ?? false);
 
         if (modelDownloaded)
         {
@@ -345,18 +343,18 @@ public sealed partial class PermissionsPage : Page
 
     private void OnSttMoreSettingsClick(object sender, RoutedEventArgs e)
     {
-        _hub?.NavigateTo("voice");
+        ((IAppCommands)CurrentApp).Navigate("voice");
     }
 
     // ── Text-to-Speech card ──────────────────────────────────────────
 
-    private void UpdateTtsCard(HubWindow hub)
+    private void UpdateTtsCard()
     {
-        var enabled = hub.Settings?.NodeTtsEnabled == true;
+        var enabled = CurrentApp.Settings?.NodeTtsEnabled == true;
         TtsCard.Visibility = enabled ? Visibility.Visible : Visibility.Collapsed;
-        if (!enabled || hub.Settings == null) return;
+        if (!enabled || CurrentApp.Settings == null) return;
 
-        var settings = hub.Settings;
+        var settings = CurrentApp.Settings;
 
         _suppressTtsProviderChange = true;
         TtsProviderComboBox.SelectedIndex = settings.TtsProvider switch
@@ -402,17 +400,17 @@ public sealed partial class PermissionsPage : Page
     private void OnTtsProviderSelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (_suppressTtsProviderChange) return;
-        if (_hub?.Settings == null) return;
+        if (CurrentApp.Settings == null) return;
 
         var newProvider = (TtsProviderComboBox.SelectedItem is ComboBoxItem item && item.Tag is string tag)
             ? tag
             : TtsCapability.WindowsProvider;
 
-        if (!string.Equals(_hub.Settings.TtsProvider, newProvider, StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(CurrentApp.Settings.TtsProvider, newProvider, StringComparison.OrdinalIgnoreCase))
         {
-            _hub.Settings.TtsProvider = newProvider;
-            _hub.Settings.Save();
-            _hub.RaiseSettingsSaved();
+            CurrentApp.Settings.TtsProvider = newProvider;
+            CurrentApp.Settings.Save();
+            ((IAppCommands)CurrentApp).NotifySettingsSaved();
             TtsStatusText.Text = LocalizationHelper.Format(
                 "PermissionsPage_TtsStatus_DefaultProviderFormat", newProvider);
         }
@@ -422,8 +420,8 @@ public sealed partial class PermissionsPage : Page
 
     private void OnTtsElevenLabsCommitted(object sender, RoutedEventArgs e)
     {
-        if (_hub?.Settings == null) return;
-        var settings = _hub.Settings;
+        if (CurrentApp.Settings == null) return;
+        var settings = CurrentApp.Settings;
 
         var changed = false;
 
@@ -455,7 +453,7 @@ public sealed partial class PermissionsPage : Page
         if (changed)
         {
             settings.Save();
-            _hub.RaiseSettingsSaved();
+            ((IAppCommands)CurrentApp).NotifySettingsSaved();
             TtsElevenLabsApiKeyBox.Password =
                 string.IsNullOrEmpty(settings.TtsElevenLabsApiKey) ? "" : SavedApiKeySentinel;
             TtsStatusText.Text = LocalizationHelper.GetString("PermissionsPage_TtsStatus_ElevenLabsSaved");
@@ -464,10 +462,10 @@ public sealed partial class PermissionsPage : Page
 
     // ── Node status ──────────────────────────────────────────────────
 
-    private void UpdateNodeStatus(HubWindow hub)
+    private void UpdateNodeStatus()
     {
-        var nodeEnabled = hub.Settings?.EnableNodeMode ?? false;
-        var isConnected = hub.CurrentStatus == ConnectionStatus.Connected;
+        var nodeEnabled = CurrentApp.Settings?.EnableNodeMode ?? false;
+        var isConnected = (CurrentApp.AppState?.Status ?? ConnectionStatus.Disconnected) == ConnectionStatus.Connected;
 
         if (!nodeEnabled)
         {
@@ -481,13 +479,13 @@ public sealed partial class PermissionsPage : Page
             NodeStatusText.Text = LocalizationHelper.GetString("PermissionsPage_NodeStatus_Active");
 
             var caps = new List<string>();
-            if (hub.Settings?.NodeBrowserProxyEnabled == true) caps.Add("browser");
-            if (hub.Settings?.NodeCameraEnabled == true) caps.Add("camera");
-            if (hub.Settings?.NodeCanvasEnabled == true) caps.Add("canvas");
-            if (hub.Settings?.NodeScreenEnabled == true) caps.Add("screen");
-            if (hub.Settings?.NodeLocationEnabled == true) caps.Add("location");
-            if (hub.Settings?.NodeTtsEnabled == true) caps.Add("tts");
-            if (hub.Settings?.NodeSttEnabled == true) caps.Add("stt");
+            if (CurrentApp.Settings?.NodeBrowserProxyEnabled == true) caps.Add("browser");
+            if (CurrentApp.Settings?.NodeCameraEnabled == true) caps.Add("camera");
+            if (CurrentApp.Settings?.NodeCanvasEnabled == true) caps.Add("canvas");
+            if (CurrentApp.Settings?.NodeScreenEnabled == true) caps.Add("screen");
+            if (CurrentApp.Settings?.NodeLocationEnabled == true) caps.Add("location");
+            if (CurrentApp.Settings?.NodeTtsEnabled == true) caps.Add("tts");
+            if (CurrentApp.Settings?.NodeSttEnabled == true) caps.Add("stt");
             NodeDetailsText.Text = caps.Count > 0
                 ? LocalizationHelper.Format(
                     "PermissionsPage_NodeStatus_ActiveDetailsFormat",
@@ -504,9 +502,9 @@ public sealed partial class PermissionsPage : Page
 
     // ── MCP server ───────────────────────────────────────────────────
 
-    private void UpdateMcpStatus(HubWindow hub)
+    private void UpdateMcpStatus()
     {
-        var settings = hub.Settings;
+        var settings = CurrentApp.Settings;
         if (settings == null) return;
 
         _suppressMcpToggle = true;
@@ -528,11 +526,11 @@ public sealed partial class PermissionsPage : Page
     private void OnMcpToggled(object sender, RoutedEventArgs e)
     {
         if (_suppressMcpToggle) return;
-        if (_hub?.Settings == null) return;
-        _hub.Settings.EnableMcpServer = McpToggle.IsOn;
-        _hub.Settings.Save();
-        _hub.RaiseSettingsSaved();
-        UpdateMcpStatus(_hub);
+        if (CurrentApp.Settings == null) return;
+        CurrentApp.Settings.EnableMcpServer = McpToggle.IsOn;
+        CurrentApp.Settings.Save();
+        ((IAppCommands)CurrentApp).NotifySettingsSaved();
+        UpdateMcpStatus();
     }
 
     private void OnCopyMcpToken(object sender, RoutedEventArgs e)

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
@@ -48,7 +48,7 @@ public sealed partial class PermissionsPage : Page
         ApplyFeaturesEnabledState(hub);
 
         LoadExecPolicy();
-        LoadAllowlist(hub.LastConfig);
+        LoadAllowlist(hub.AppModel?.Config);
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)

--- a/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
@@ -2,7 +2,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using OpenClaw.Shared;
 using OpenClawTray.Services;
-using OpenClawTray.Windows;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -13,7 +12,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class SandboxPage : Page
 {
-    private HubWindow? _hub;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private bool _suppress;
     private bool _dialogOpen;
     private OpenClaw.Shared.Mxc.MxcAvailability? _cachedAvailability;
@@ -86,9 +85,8 @@ public sealed partial class SandboxPage : Page
         CustomFoldersList.ItemsSource = CustomFolders;
     }
 
-    public void Initialize(HubWindow hub)
+    public void Initialize()
     {
-        _hub = hub;
         LoadState();
         ProbeStatus();
         UpdateControlsEnabledState();
@@ -98,7 +96,7 @@ public sealed partial class SandboxPage : Page
 
     private void LoadState()
     {
-        if (_hub?.Settings is not { } settings) return;
+        if (CurrentApp.Settings is not { } settings) return;
 
         _suppress = true;
         try
@@ -300,7 +298,7 @@ public sealed partial class SandboxPage : Page
 
     private void ApplyPreset(SandboxPreset preset)
     {
-        if (_hub?.Settings is not { } s) return;
+        if (CurrentApp.Settings is not { } s) return;
 
         _suppress = true;
         try
@@ -347,7 +345,7 @@ public sealed partial class SandboxPage : Page
 
     private void UpdatePresetHighlight()
     {
-        var s = _hub?.Settings;
+        var s = CurrentApp.Settings;
         var active = s is null ? null : DetectActivePreset(s);
         SetPresetCardActive(PresetLockedButton, active?.Tag == s_lockedDown.Tag);
         SetPresetCardActive(PresetBalancedButton, active?.Tag == s_balanced.Tag);
@@ -451,7 +449,7 @@ public sealed partial class SandboxPage : Page
     private void Save()
     {
         if (_suppress) return;
-        _hub?.Settings?.Save();
+        CurrentApp.Settings?.Save();
         UpdatePresetHighlight();
     }
 
@@ -466,7 +464,7 @@ public sealed partial class SandboxPage : Page
     private async void OnSandboxEnabledToggled(object sender, RoutedEventArgs e)
     {
         if (_suppress) return;
-        if (_hub?.Settings is not { } s) return;
+        if (CurrentApp.Settings is not { } s) return;
 
         var newValue = SandboxEnabledToggle.IsOn;
         var oldValue = s.SystemRunSandboxEnabled;
@@ -530,7 +528,7 @@ public sealed partial class SandboxPage : Page
     private void OnNetInternetToggled(object sender, RoutedEventArgs e)
     {
         if (_suppress) return;
-        if (_hub?.Settings is not { } s) return;
+        if (CurrentApp.Settings is not { } s) return;
         s.SystemRunAllowOutbound = NetInternetToggle.IsOn;
         Save();
     }
@@ -538,7 +536,7 @@ public sealed partial class SandboxPage : Page
     private void OnDocsAccessChanged(object sender, SelectionChangedEventArgs e)
     {
         if (_suppress) return;
-        if (_hub?.Settings is not { } s) return;
+        if (CurrentApp.Settings is not { } s) return;
         s.SandboxDocumentsAccess = ReadAccessTag(DocsAccessCombo);
         Save();
     }
@@ -546,7 +544,7 @@ public sealed partial class SandboxPage : Page
     private void OnDownloadsAccessChanged(object sender, SelectionChangedEventArgs e)
     {
         if (_suppress) return;
-        if (_hub?.Settings is not { } s) return;
+        if (CurrentApp.Settings is not { } s) return;
         s.SandboxDownloadsAccess = ReadAccessTag(DownloadsAccessCombo);
         Save();
     }
@@ -554,7 +552,7 @@ public sealed partial class SandboxPage : Page
     private void OnDesktopAccessChanged(object sender, SelectionChangedEventArgs e)
     {
         if (_suppress) return;
-        if (_hub?.Settings is not { } s) return;
+        if (CurrentApp.Settings is not { } s) return;
         s.SandboxDesktopAccess = ReadAccessTag(DesktopAccessCombo);
         Save();
     }
@@ -564,7 +562,8 @@ public sealed partial class SandboxPage : Page
 
     private async System.Threading.Tasks.Task PickCustomFolderAsync(SandboxFolderAccess access)
     {
-        if (_hub is null) return;
+        var window = CurrentApp.ActiveHubWindow;
+        if (window is null) return;
 
         var picker = new FolderPicker
         {
@@ -572,7 +571,7 @@ public sealed partial class SandboxPage : Page
         };
         picker.FileTypeFilter.Add("*");
 
-        var hwnd = WindowNative.GetWindowHandle(_hub);
+        var hwnd = WindowNative.GetWindowHandle(window);
         InitializeWithWindow.Initialize(picker, hwnd);
 
         var folder = await picker.PickSingleFolderAsync();
@@ -588,7 +587,7 @@ public sealed partial class SandboxPage : Page
         CustomFolders.Add(row);
         RefreshCustomFoldersUi();
 
-        if (_hub.Settings is { } s)
+        if (CurrentApp.Settings is { } s)
         {
             s.SandboxCustomFolders.Add(new SandboxCustomFolder { Path = folder.Path, Access = access });
             Save();
@@ -610,7 +609,7 @@ public sealed partial class SandboxPage : Page
             return;
         }
 
-        if (_hub?.Settings is not { } s) return;
+        if (CurrentApp.Settings is not { } s) return;
 
         var newIndex = combo.SelectedIndex;
         var newAccess = newIndex switch
@@ -653,7 +652,7 @@ public sealed partial class SandboxPage : Page
         if (row != null) CustomFolders.Remove(row);
         RefreshCustomFoldersUi();
 
-        if (_hub?.Settings is { } s)
+        if (CurrentApp.Settings is { } s)
         {
             s.SandboxCustomFolders.RemoveAll(f => string.Equals(f.Path, path, StringComparison.OrdinalIgnoreCase));
             Save();
@@ -664,7 +663,7 @@ public sealed partial class SandboxPage : Page
     {
         if (_suppress) return;
         if (sender is not RadioButton rb || rb.Tag is not string tag) return;
-        if (_hub?.Settings is not { } s) return;
+        if (CurrentApp.Settings is not { } s) return;
         s.SandboxClipboard = tag switch
         {
             "Read" => SandboxClipboardMode.Read,
@@ -680,7 +679,7 @@ public sealed partial class SandboxPage : Page
         if (_suppress) return;
         var secs = (int)Math.Round(e.NewValue);
         TimeoutLabel.Text = $"Max time per command: {secs} sec";
-        if (_hub?.Settings is not { } s) return;
+        if (CurrentApp.Settings is not { } s) return;
         s.SandboxTimeoutMs = secs * 1000;
         Save();
     }
@@ -688,7 +687,7 @@ public sealed partial class SandboxPage : Page
     private void OnMaxOutputChanged(object sender, SelectionChangedEventArgs e)
     {
         if (_suppress) return;
-        if (_hub?.Settings is not { } s) return;
+        if (CurrentApp.Settings is not { } s) return;
         var tag = (string?)((ComboBoxItem?)MaxOutputCombo.SelectedItem)?.Tag;
         if (tag != null && long.TryParse(tag, out var bytes))
         {

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
@@ -34,12 +34,6 @@
             <SelectorBarItem x:Name="AllTab" Text="All" IsSelected="True"/>
         </SelectorBar>
 
-        <!-- Not-connected warning -->
-        <InfoBar x:Name="ConnectionWarning" Grid.Row="2"
-                 Title="Not connected"
-                 Message="Connect to a gateway to view sessions."
-                 Severity="Warning" IsOpen="False" IsClosable="False"/>
-
         <!-- Empty state -->
         <StackPanel x:Name="EmptyState" Grid.Row="3" Spacing="8"
                     HorizontalAlignment="Center" VerticalAlignment="Center"

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -3,9 +3,11 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using OpenClaw.Shared;
+using OpenClawTray.Services;
 using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 
 namespace OpenClawTray.Pages;
@@ -13,6 +15,7 @@ namespace OpenClawTray.Pages;
 public sealed partial class SessionsPage : Page
 {
     private HubWindow? _hub;
+    private AppState? _appState;
     private SessionInfo[]? _allSessions;
     private string _activeChannel = "all";
     private Microsoft.UI.Dispatching.DispatcherQueueTimer? _refreshTimer;
@@ -20,12 +23,18 @@ public sealed partial class SessionsPage : Page
     public SessionsPage()
     {
         InitializeComponent();
-        Unloaded += (_, _) => { _refreshTimer?.Stop(); _refreshTimer = null; };
+        Unloaded += (_, _) =>
+        {
+            _refreshTimer?.Stop(); _refreshTimer = null;
+            if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+        };
     }
 
     public void Initialize(HubWindow hub)
     {
         _hub = hub;
+        _appState = ((App)Application.Current).AppState;
+        _appState.PropertyChanged += OnAppStateChanged;
 
         if (hub.GatewayClient == null)
         {
@@ -37,8 +46,8 @@ public sealed partial class SessionsPage : Page
 
         ConnectionWarning.IsOpen = false;
 
-        if (hub.LastSessions != null)
-            UpdateSessions(hub.LastSessions);
+        if (_appState?.Sessions != null)
+            UpdateSessions(_appState.Sessions);
 
         _ = hub.GatewayClient.RequestSessionsAsync();
         _ = hub.GatewayClient.RequestModelsListAsync();
@@ -112,6 +121,19 @@ public sealed partial class SessionsPage : Page
         else
         {
             SessionListView.ItemsSource = viewModels;
+        }
+    }
+
+    private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(AppState.Sessions):
+                UpdateSessions(_appState!.Sessions);
+                break;
+            case nameof(AppState.ModelsList):
+                if (_appState!.ModelsList != null) UpdateModelsList(_appState.ModelsList);
+                break;
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -31,6 +31,8 @@ public sealed partial class SessionsPage : Page
 
     public void Initialize()
     {
+        // Guard against duplicate subscriptions (NavigationCacheMode reuses page)
+        if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
         _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
 

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -38,13 +38,10 @@ public sealed partial class SessionsPage : Page
 
         if (CurrentApp.GatewayClient == null)
         {
-            ConnectionWarning.IsOpen = true;
             EmptyState.Visibility = Visibility.Collapsed;
             SessionListView.ItemsSource = null;
             return;
         }
-
-        ConnectionWarning.IsOpen = false;
 
         if (_appState?.Sessions != null)
             UpdateSessions(_appState.Sessions);

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -4,7 +4,6 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using OpenClaw.Shared;
 using OpenClawTray.Services;
-using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -14,7 +13,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class SessionsPage : Page
 {
-    private HubWindow? _hub;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private AppState? _appState;
     private SessionInfo[]? _allSessions;
     private string _activeChannel = "all";
@@ -30,13 +29,12 @@ public sealed partial class SessionsPage : Page
         };
     }
 
-    public void Initialize(HubWindow hub)
+    public void Initialize()
     {
-        _hub = hub;
-        _appState = ((App)Application.Current).AppState;
+        _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
 
-        if (hub.GatewayClient == null)
+        if (CurrentApp.GatewayClient == null)
         {
             ConnectionWarning.IsOpen = true;
             EmptyState.Visibility = Visibility.Collapsed;
@@ -49,8 +47,8 @@ public sealed partial class SessionsPage : Page
         if (_appState?.Sessions != null)
             UpdateSessions(_appState.Sessions);
 
-        _ = hub.GatewayClient.RequestSessionsAsync();
-        _ = hub.GatewayClient.RequestModelsListAsync();
+        _ = CurrentApp.GatewayClient.RequestSessionsAsync();
+        _ = CurrentApp.GatewayClient.RequestModelsListAsync();
     }
 
     public void UpdateSessions(SessionInfo[] sessions)
@@ -173,7 +171,7 @@ public sealed partial class SessionsPage : Page
 
     private void ChannelSelector_SelectionChanged(SelectorBar sender, SelectorBarSelectionChangedEventArgs args)
     {
-        if (_hub == null) return;
+        
         var selected = sender.SelectedItem;
         _activeChannel = selected == AllTab ? "all" : (selected?.Text ?? "all");
         ApplyFilter();
@@ -183,7 +181,7 @@ public sealed partial class SessionsPage : Page
     {
         if (sender is Button btn && btn.Tag is string key)
         {
-            var client = _hub?.GatewayClient;
+            var client = CurrentApp.GatewayClient;
             if (client == null) return;
             try { await client.ResetSessionAsync(key); }
             catch { }
@@ -194,7 +192,7 @@ public sealed partial class SessionsPage : Page
     {
         if (sender is Button btn && btn.Tag is string key)
         {
-            var client = _hub?.GatewayClient;
+            var client = CurrentApp.GatewayClient;
             if (client == null) return;
             try { await client.DeleteSessionAsync(key); }
             catch { }
@@ -205,7 +203,7 @@ public sealed partial class SessionsPage : Page
     {
         if (sender is Button btn && btn.Tag is string key)
         {
-            var client = _hub?.GatewayClient;
+            var client = CurrentApp.GatewayClient;
             if (client == null) return;
             try { await client.CompactSessionAsync(key); }
             catch { }
@@ -214,7 +212,7 @@ public sealed partial class SessionsPage : Page
 
     private void OnRefresh(object sender, RoutedEventArgs e)
     {
-        var client = _hub?.GatewayClient;
+        var client = CurrentApp.GatewayClient;
         if (client != null)
         {
             _ = client.RequestSessionsAsync();

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -56,16 +56,8 @@ public sealed partial class SessionsPage : Page
     public void UpdateSessions(SessionInfo[] sessions)
     {
         _allSessions = sessions;
-        DispatcherQueue?.TryEnqueue(() =>
-        {
-            RebuildChannelTabs();
-            ApplyFilter();
-        });
-    }
-
-    public void UpdateModelsList(ModelsListInfo data)
-    {
-        // Models data received — re-render in case we want it later
+        RebuildChannelTabs();
+        ApplyFilter();
     }
 
     private void RebuildChannelTabs()
@@ -130,9 +122,6 @@ public sealed partial class SessionsPage : Page
         {
             case nameof(AppState.Sessions):
                 UpdateSessions(_appState!.Sessions);
-                break;
-            case nameof(AppState.ModelsList):
-                if (_appState!.ModelsList != null) UpdateModelsList(_appState.ModelsList);
                 break;
         }
     }

--- a/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml.cs
@@ -5,7 +5,6 @@ using OpenClaw.Shared;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using OpenClawTray.Services.LocalGatewaySetup;
-using OpenClawTray.Windows;
 using System;
 using System.IO;
 using System.Threading;
@@ -14,7 +13,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class SettingsPage : Page
 {
-    private HubWindow? _hub;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private bool _initialized;
     private bool _saving;
     private bool _loading;
@@ -35,36 +34,36 @@ public sealed partial class SettingsPage : Page
         Unloaded += OnUnloaded;
     }
 
-    public void Initialize(HubWindow hub)
+    public void Initialize()
     {
-        _hub = hub;
-        if (!_initialized && hub.Settings != null)
+        var settings = CurrentApp.Settings;
+        if (!_initialized && settings != null)
         {
             _loading = true;
-            LoadSettings(hub.Settings);
+            LoadSettings(settings);
             _loading = false;
             WireAutoSaveHandlers();
             _initialized = true;
         }
-        else if (_initialized && hub.Settings != null)
+        else if (_initialized && settings != null)
         {
             _loading = true;
-            ScreenRecordingToggle.IsOn = hub.Settings.ScreenRecordingConsentGiven;
-            CameraRecordingToggle.IsOn = hub.Settings.CameraRecordingConsentGiven;
+            ScreenRecordingToggle.IsOn = settings.ScreenRecordingConsentGiven;
+            CameraRecordingToggle.IsOn = settings.CameraRecordingConsentGiven;
             _loading = false;
         }
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
-        if (_hub?.Settings != null)
-            _hub.Settings.Saved += OnExternalSettingsChanged;
+        if (CurrentApp.Settings != null)
+            CurrentApp.Settings.Saved += OnExternalSettingsChanged;
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
-        if (_hub?.Settings != null)
-            _hub.Settings.Saved -= OnExternalSettingsChanged;
+        if (CurrentApp.Settings != null)
+            CurrentApp.Settings.Saved -= OnExternalSettingsChanged;
     }
 
     // ── Auto-save wiring ──
@@ -81,14 +80,14 @@ public sealed partial class SettingsPage : Page
                 Persist(s => s.NotificationSound = item.Tag?.ToString() ?? "Default");
         };
 
-        WireCheckBox(NotifyHealthCb, v => _hub!.Settings!.NotifyHealth = v);
-        WireCheckBox(NotifyUrgentCb, v => _hub!.Settings!.NotifyUrgent = v);
-        WireCheckBox(NotifyReminderCb, v => _hub!.Settings!.NotifyReminder = v);
-        WireCheckBox(NotifyEmailCb, v => _hub!.Settings!.NotifyEmail = v);
-        WireCheckBox(NotifyCalendarCb, v => _hub!.Settings!.NotifyCalendar = v);
-        WireCheckBox(NotifyBuildCb, v => _hub!.Settings!.NotifyBuild = v);
-        WireCheckBox(NotifyStockCb, v => _hub!.Settings!.NotifyStock = v);
-        WireCheckBox(NotifyInfoCb, v => _hub!.Settings!.NotifyInfo = v);
+        WireCheckBox(NotifyHealthCb, v => CurrentApp.Settings!.NotifyHealth = v);
+        WireCheckBox(NotifyUrgentCb, v => CurrentApp.Settings!.NotifyUrgent = v);
+        WireCheckBox(NotifyReminderCb, v => CurrentApp.Settings!.NotifyReminder = v);
+        WireCheckBox(NotifyEmailCb, v => CurrentApp.Settings!.NotifyEmail = v);
+        WireCheckBox(NotifyCalendarCb, v => CurrentApp.Settings!.NotifyCalendar = v);
+        WireCheckBox(NotifyBuildCb, v => CurrentApp.Settings!.NotifyBuild = v);
+        WireCheckBox(NotifyStockCb, v => CurrentApp.Settings!.NotifyStock = v);
+        WireCheckBox(NotifyInfoCb, v => CurrentApp.Settings!.NotifyInfo = v);
 
         ScreenRecordingToggle.Toggled += (_, _) => Persist(s => s.ScreenRecordingConsentGiven = ScreenRecordingToggle.IsOn);
         CameraRecordingToggle.Toggled += (_, _) => Persist(s => s.CameraRecordingConsentGiven = CameraRecordingToggle.IsOn);
@@ -103,13 +102,13 @@ public sealed partial class SettingsPage : Page
 
     private void Persist(Action<SettingsManager> mutate)
     {
-        if (_loading || _hub?.Settings == null) return;
+        if (_loading || CurrentApp.Settings == null) return;
         _saving = true;
         try
         {
-            mutate(_hub.Settings);
-            _hub.Settings.Save();
-            _hub.RaiseSettingsSaved();
+            mutate(CurrentApp.Settings);
+            CurrentApp.Settings.Save();
+            ((IAppCommands)CurrentApp).NotifySettingsSaved();
             ShowSavedIndicator();
         }
         finally
@@ -120,14 +119,14 @@ public sealed partial class SettingsPage : Page
 
     private void PersistAutoStart()
     {
-        if (_loading || _hub?.Settings == null) return;
+        if (_loading || CurrentApp.Settings == null) return;
         _saving = true;
         try
         {
-            _hub.Settings.AutoStart = AutoStartToggle.IsOn;
-            _hub.Settings.Save();
-            AutoStartManager.SetAutoStart(_hub.Settings.AutoStart);
-            _hub.RaiseSettingsSaved();
+            CurrentApp.Settings.AutoStart = AutoStartToggle.IsOn;
+            CurrentApp.Settings.Save();
+            AutoStartManager.SetAutoStart(CurrentApp.Settings.AutoStart);
+            ((IAppCommands)CurrentApp).NotifySettingsSaved();
             ShowSavedIndicator();
         }
         finally
@@ -152,13 +151,13 @@ public sealed partial class SettingsPage : Page
 
     private void OnExternalSettingsChanged(object? sender, EventArgs e)
     {
-        if (_hub?.Settings == null || _saving) return;
+        if (CurrentApp.Settings == null || _saving) return;
         DispatcherQueue.TryEnqueue(() =>
         {
             _loading = true;
             try
             {
-                LoadSettings(_hub.Settings);
+                LoadSettings(CurrentApp.Settings);
             }
             finally
             {
@@ -297,10 +296,10 @@ public sealed partial class SettingsPage : Page
         _uninstallCts = new CancellationTokenSource();
         try
         {
-            if (_hub?.Settings == null)
+            if (CurrentApp.Settings == null)
                 throw new InvalidOperationException("Settings not available.");
 
-            var engine = LocalGatewayUninstall.Build(_hub.Settings, registry: _hub.GatewayRegistry);
+            var engine = LocalGatewayUninstall.Build(CurrentApp.Settings, registry: CurrentApp.Registry);
             var uninstallResult = await engine.RunAsync(
                 new LocalGatewayUninstallOptions
                 {

--- a/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml.cs
@@ -3,7 +3,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using OpenClawTray.Services;
-using OpenClawTray.Windows;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -14,7 +13,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class SkillsPage : Page
 {
-    private HubWindow? _hub;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private AppState? _appState;
     private List<SkillData> _allSkills = new();
 
@@ -42,15 +41,14 @@ public sealed partial class SkillsPage : Page
         };
     }
 
-    public void Initialize(HubWindow hub)
+    public void Initialize()
     {
-        _hub = hub;
-        _appState = ((App)Application.Current).AppState;
+        _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
-        PopulateAgentFilter(hub);
-        if (hub.GatewayClient != null)
+        PopulateAgentFilter();
+        if (CurrentApp.GatewayClient != null)
         {
-            _ = hub.GatewayClient.RequestSkillsStatusAsync(GetSelectedAgentId());
+            _ = CurrentApp.GatewayClient.RequestSkillsStatusAsync(GetSelectedAgentId());
         }
     }
 
@@ -64,12 +62,12 @@ public sealed partial class SkillsPage : Page
         }
     }
 
-    private void PopulateAgentFilter(HubWindow hub)
+    private void PopulateAgentFilter()
     {
         AgentFilterCombo.SelectionChanged -= OnAgentFilterChanged;
         AgentFilterCombo.Items.Clear();
         AgentFilterCombo.Items.Add(new ComboBoxItem { Content = "All Agents", Tag = "" });
-        foreach (var id in hub.GetAgentIds())
+        foreach (var id in CurrentApp.AppState?.GetAgentIds() ?? new List<string> { "main" })
             AgentFilterCombo.Items.Add(new ComboBoxItem { Content = id, Tag = id });
         AgentFilterCombo.SelectedIndex = 0;
         AgentFilterCombo.SelectionChanged += OnAgentFilterChanged;
@@ -87,7 +85,7 @@ public sealed partial class SkillsPage : Page
 
     private void OnAgentFilterChanged(object sender, SelectionChangedEventArgs e)
     {
-        var client = _hub?.GatewayClient;
+        var client = CurrentApp.GatewayClient;
         if (client != null)
             _ = client.RequestSkillsStatusAsync(GetSelectedAgentId());
     }
@@ -95,14 +93,14 @@ public sealed partial class SkillsPage : Page
     private async void OnToggleSkillClick(object sender, RoutedEventArgs e)
     {
         if (sender is not Button btn || btn.Tag is not string skillKey) return;
-        if (_hub?.GatewayClient == null) return;
+        if (CurrentApp.GatewayClient == null) return;
 
         var skill = _allSkills.FirstOrDefault(s => s.SkillKey == skillKey);
         if (skill == null) return;
 
         bool newState = !skill.IsEnabled;
         btn.IsEnabled = false;
-        var success = await _hub.GatewayClient.SetSkillEnabledAsync(skillKey, newState);
+        var success = await CurrentApp.GatewayClient.SetSkillEnabledAsync(skillKey, newState);
         btn.IsEnabled = true;
 
         if (success)

--- a/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml.cs
@@ -2,8 +2,10 @@ using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using OpenClawTray.Services;
 using OpenClawTray.Windows;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text.Json;
 using Windows.UI;
@@ -13,6 +15,7 @@ namespace OpenClawTray.Pages;
 public sealed partial class SkillsPage : Page
 {
     private HubWindow? _hub;
+    private AppState? _appState;
     private List<SkillData> _allSkills = new();
 
     public string? CurrentAgentId => GetSelectedAgentId();
@@ -20,6 +23,10 @@ public sealed partial class SkillsPage : Page
     public SkillsPage()
     {
         InitializeComponent();
+        Unloaded += (_, _) =>
+        {
+            if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+        };
         EnabledHeaderBtn.Click += (s, e) =>
         {
             _enabledExpanded = !_enabledExpanded;
@@ -38,10 +45,22 @@ public sealed partial class SkillsPage : Page
     public void Initialize(HubWindow hub)
     {
         _hub = hub;
+        _appState = ((App)Application.Current).AppState;
+        _appState.PropertyChanged += OnAppStateChanged;
         PopulateAgentFilter(hub);
         if (hub.GatewayClient != null)
         {
             _ = hub.GatewayClient.RequestSkillsStatusAsync(GetSelectedAgentId());
+        }
+    }
+
+    private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(AppState.SkillsData):
+                if (_appState!.SkillsData.HasValue) UpdateFromGateway(_appState.SkillsData.Value);
+                break;
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml.cs
@@ -177,11 +177,8 @@ public sealed partial class SkillsPage : Page
         // Sort alphabetically
         skills.Sort((a, b) => string.Compare(a.Name, b.Name, System.StringComparison.OrdinalIgnoreCase));
 
-        DispatcherQueue?.TryEnqueue(() =>
-        {
-            _allSkills = skills;
-            RebuildCards();
-        });
+        _allSkills = skills;
+        RebuildCards();
     }
 
     private bool _enabledExpanded = true;

--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml
@@ -9,10 +9,6 @@
 
             <TextBlock x:Uid="UsagePage_TextBlock_10" Text="📊 Usage &amp; Cost" Style="{StaticResource TitleTextBlockStyle}"/>
 
-            <InfoBar x:Uid="ConnectionWarning" x:Name="ConnectionWarning" Title="Not Connected"
-                     Message="Connect to gateway to see live data"
-                     Severity="Warning" IsOpen="True" IsClosable="False" Visibility="Collapsed"/>
-
             <!-- Big number: Total Cost -->
             <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"

--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
@@ -2,7 +2,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using OpenClaw.Shared;
 using OpenClawTray.Services;
-using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -13,7 +12,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class UsagePage : Page
 {
-    private HubWindow? _hub;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private AppState? _appState;
     // Default matches the XAML-selected Period7DaysItem (IsSelected="True").
     private int _currentPeriodDays = 7;
@@ -27,13 +26,12 @@ public sealed partial class UsagePage : Page
         };
     }
 
-    public void Initialize(HubWindow hub)
+    public void Initialize()
     {
-        _hub = hub;
-        _appState = ((App)Application.Current).AppState;
+        _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
-        ConnectionWarning.Visibility = hub.GatewayClient != null ? Visibility.Collapsed : Visibility.Visible;
-        if (hub.GatewayClient != null)
+        ConnectionWarning.Visibility = CurrentApp.GatewayClient != null ? Visibility.Collapsed : Visibility.Visible;
+        if (CurrentApp.GatewayClient != null)
         {
             // Apply cached data immediately, then request fresh.
             if (_appState?.Usage != null) UpdateUsage(_appState.Usage);
@@ -45,9 +43,9 @@ public sealed partial class UsagePage : Page
                 UpdateUsageCost(_appState.UsageCost);
             }
             if (_appState?.UsageStatus != null) UpdateUsageStatus(_appState.UsageStatus);
-            _ = hub.GatewayClient.RequestUsageAsync();
-            _ = hub.GatewayClient.RequestUsageCostAsync(_currentPeriodDays);
-            _ = hub.GatewayClient.RequestUsageStatusAsync();
+            _ = CurrentApp.GatewayClient.RequestUsageAsync();
+            _ = CurrentApp.GatewayClient.RequestUsageCostAsync(_currentPeriodDays);
+            _ = CurrentApp.GatewayClient.RequestUsageStatusAsync();
         }
         else
         {
@@ -130,9 +128,9 @@ public sealed partial class UsagePage : Page
         if (days == _currentPeriodDays) return;
         _currentPeriodDays = days;
 
-        if (_hub?.GatewayClient != null)
+        if (CurrentApp.GatewayClient != null)
         {
-            _ = _hub.GatewayClient.RequestUsageCostAsync(days);
+            _ = CurrentApp.GatewayClient.RequestUsageCostAsync(days);
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
@@ -1,9 +1,11 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using OpenClaw.Shared;
+using OpenClawTray.Services;
 using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 
@@ -12,30 +14,37 @@ namespace OpenClawTray.Pages;
 public sealed partial class UsagePage : Page
 {
     private HubWindow? _hub;
+    private AppState? _appState;
     // Default matches the XAML-selected Period7DaysItem (IsSelected="True").
     private int _currentPeriodDays = 7;
 
     public UsagePage()
     {
         InitializeComponent();
+        Unloaded += (_, _) =>
+        {
+            if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+        };
     }
 
     public void Initialize(HubWindow hub)
     {
         _hub = hub;
+        _appState = ((App)Application.Current).AppState;
+        _appState.PropertyChanged += OnAppStateChanged;
         ConnectionWarning.Visibility = hub.GatewayClient != null ? Visibility.Collapsed : Visibility.Visible;
         if (hub.GatewayClient != null)
         {
             // Apply cached data immediately, then request fresh.
-            if (hub.LastUsage != null) UpdateUsage(hub.LastUsage);
+            if (_appState?.Usage != null) UpdateUsage(_appState.Usage);
             // Only apply cached cost data when its period matches the current
             // selection — otherwise the daily list briefly shows e.g. 30-day
             // data while the selector reads "7 Days".
-            if (hub.LastUsageCost != null && hub.LastUsageCost.Days == _currentPeriodDays)
+            if (_appState?.UsageCost != null && _appState.UsageCost.Days == _currentPeriodDays)
             {
-                UpdateUsageCost(hub.LastUsageCost);
+                UpdateUsageCost(_appState.UsageCost);
             }
-            if (hub.LastUsageStatus != null) UpdateUsageStatus(hub.LastUsageStatus);
+            if (_appState?.UsageStatus != null) UpdateUsageStatus(_appState.UsageStatus);
             _ = hub.GatewayClient.RequestUsageAsync();
             _ = hub.GatewayClient.RequestUsageCostAsync(_currentPeriodDays);
             _ = hub.GatewayClient.RequestUsageStatusAsync();
@@ -44,6 +53,22 @@ public sealed partial class UsagePage : Page
         {
             // Not connected — nothing to load, hide the loading skeleton.
             ProviderLoadingPanel.Visibility = Visibility.Collapsed;
+        }
+    }
+
+    private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(AppState.Usage):
+                if (_appState!.Usage != null) UpdateUsage(_appState.Usage);
+                break;
+            case nameof(AppState.UsageCost):
+                if (_appState!.UsageCost != null) UpdateUsageCost(_appState.UsageCost);
+                break;
+            case nameof(AppState.UsageStatus):
+                if (_appState!.UsageStatus != null) UpdateUsageStatus(_appState.UsageStatus);
+                break;
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
@@ -30,7 +30,6 @@ public sealed partial class UsagePage : Page
     {
         _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
-        ConnectionWarning.Visibility = CurrentApp.GatewayClient != null ? Visibility.Collapsed : Visibility.Visible;
         if (CurrentApp.GatewayClient != null)
         {
             // Apply cached data immediately, then request fresh.
@@ -59,13 +58,13 @@ public sealed partial class UsagePage : Page
         switch (e.PropertyName)
         {
             case nameof(AppState.Usage):
-                if (_appState!.Usage != null) UpdateUsage(_appState.Usage);
+                if (_appState?.Usage != null) UpdateUsage(_appState.Usage);
                 break;
             case nameof(AppState.UsageCost):
-                if (_appState!.UsageCost != null) UpdateUsageCost(_appState.UsageCost);
+                if (_appState?.UsageCost != null) UpdateUsageCost(_appState.UsageCost);
                 break;
             case nameof(AppState.UsageStatus):
-                if (_appState!.UsageStatus != null) UpdateUsageStatus(_appState.UsageStatus);
+                if (_appState?.UsageStatus != null) UpdateUsageStatus(_appState.UsageStatus);
                 break;
         }
     }

--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
@@ -72,49 +72,40 @@ public sealed partial class UsagePage : Page
 
     public void UpdateUsage(GatewayUsageInfo usage)
     {
-        DispatcherQueue?.TryEnqueue(() =>
-        {
-            RequestCountText.Text = usage.RequestCount.ToString();
-            // Note: TotalCostText and TokenCountText are owned by UpdateUsageCost
-            // (period-scoped), not UpdateUsage (all-time). Writing them from both
-            // sources caused a race where the last response to arrive won — see
-            // Hanselman review #1 (HIGH).
-        });
+        RequestCountText.Text = usage.RequestCount.ToString();
+        // Note: TotalCostText and TokenCountText are owned by UpdateUsageCost
+        // (period-scoped), not UpdateUsage (all-time). Writing them from both
+        // sources caused a race where the last response to arrive won — see
+        // Hanselman review #1 (HIGH).
     }
 
     public void UpdateUsageCost(GatewayCostUsageInfo cost)
     {
-        DispatcherQueue?.TryEnqueue(() =>
-        {
-            TotalCostText.Text = $"${cost.Totals.TotalCost:F2}";
-            TokenCountText.Text = FormatLargeNumber(cost.Totals.TotalTokens);
+        TotalCostText.Text = $"${cost.Totals.TotalCost:F2}";
+        TokenCountText.Text = FormatLargeNumber(cost.Totals.TotalTokens);
 
-            DailyListView.ItemsSource = cost.Daily.Select(d => new DailyRow
-            {
-                Date = d.Date,
-                Cost = $"${d.TotalCost:F2}",
-            }).ToList();
-        });
+        DailyListView.ItemsSource = cost.Daily.Select(d => new DailyRow
+        {
+            Date = d.Date,
+            Cost = $"${d.TotalCost:F2}",
+        }).ToList();
     }
 
     public void UpdateUsageStatus(GatewayUsageStatusInfo status)
     {
-        DispatcherQueue?.TryEnqueue(() =>
+        ProviderCountText.Text = status.Providers.Count.ToString();
+        ProviderListView.ItemsSource = status.Providers.Select(p => new ProviderRow
         {
-            ProviderCountText.Text = status.Providers.Count.ToString();
-            ProviderListView.ItemsSource = status.Providers.Select(p => new ProviderRow
-            {
-                Name = p.DisplayName,
-                Plan = p.Plan ?? "",
-                Usage = p.Windows.Count > 0 ? $"{p.Windows[0].UsedPercent:F0}% used" : "",
-                Status = p.Error ?? "",
-            }).ToList();
+            Name = p.DisplayName,
+            Plan = p.Plan ?? "",
+            Usage = p.Windows.Count > 0 ? $"{p.Windows[0].UsedPercent:F0}% used" : "",
+            Status = p.Error ?? "",
+        }).ToList();
 
-            bool hasProviders = status.Providers.Count > 0;
-            ProviderLoadingPanel.Visibility = Visibility.Collapsed;
-            ProviderListView.Visibility = hasProviders ? Visibility.Visible : Visibility.Collapsed;
-            ProviderEmptyText.Visibility = hasProviders ? Visibility.Collapsed : Visibility.Visible;
-        });
+        bool hasProviders = status.Providers.Count > 0;
+        ProviderLoadingPanel.Visibility = Visibility.Collapsed;
+        ProviderListView.Visibility = hasProviders ? Visibility.Visible : Visibility.Collapsed;
+        ProviderEmptyText.Visibility = hasProviders ? Visibility.Collapsed : Visibility.Visible;
     }
 
     private void OnPeriodSelectionChanged(SelectorBar sender, SelectorBarSelectionChangedEventArgs args)

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
@@ -5,7 +5,6 @@ using OpenClaw.Shared;
 using OpenClaw.Shared.Capabilities;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
-using OpenClawTray.Windows;
 using System;
 using System.Globalization;
 using System.Linq;
@@ -15,7 +14,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class VoiceSettingsPage : Page
 {
-    private HubWindow? _hub;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private VoiceService? _voiceService;
     private bool _isVoiceTestDialogOpen;
     private bool _suppressEvents;
@@ -42,21 +41,20 @@ public sealed partial class VoiceSettingsPage : Page
         };
     }
 
-    public void Initialize(HubWindow hub, VoiceService? voiceService)
+    public void Initialize(VoiceService? voiceService)
     {
-        _hub = hub;
         _voiceService = voiceService;
         LoadSettings();
     }
 
     private void LoadSettings()
     {
-        if (_hub?.Settings == null) return;
+        if (CurrentApp.Settings == null) return;
         _suppressEvents = true;
 
         try
         {
-            var settings = _hub.Settings;
+            var settings = CurrentApp.Settings;
 
             SttEnabledToggle.IsOn = settings.NodeSttEnabled;
 
@@ -103,7 +101,7 @@ public sealed partial class VoiceSettingsPage : Page
         // Determine the selected model. Prefer settings; fall back to the
         // ModelCombo selection if settings haven't been wired yet so the
         // status reflects what's on disk even before Initialize completes.
-        var modelName = _hub?.Settings?.SttModelName
+        var modelName = CurrentApp.Settings?.SttModelName
             ?? (ModelCombo?.SelectedItem as ComboBoxItem)?.Tag?.ToString()
             ?? "base";
 
@@ -136,59 +134,59 @@ public sealed partial class VoiceSettingsPage : Page
 
     private void OnSttToggled(object sender, RoutedEventArgs e)
     {
-        if (_suppressEvents || _hub?.Settings == null) return;
-        _hub.Settings.NodeSttEnabled = SttEnabledToggle.IsOn;
-        _hub.Settings.Save();
+        if (_suppressEvents || CurrentApp.Settings == null) return;
+        CurrentApp.Settings.NodeSttEnabled = SttEnabledToggle.IsOn;
+        CurrentApp.Settings.Save();
         UpdateCardVisibility();
     }
 
     private void OnModelChanged(object sender, SelectionChangedEventArgs e)
     {
-        if (_suppressEvents || _hub?.Settings == null) return;
+        if (_suppressEvents || CurrentApp.Settings == null) return;
 
         if (ModelCombo.SelectedItem is ComboBoxItem item && item.Tag is string modelName)
         {
-            _hub.Settings.SttModelName = modelName;
-            _hub.Settings.Save();
+            CurrentApp.Settings.SttModelName = modelName;
+            CurrentApp.Settings.Save();
             UpdateModelStatus();
         }
     }
 
     private void OnLanguageChanged(object sender, SelectionChangedEventArgs e)
     {
-        if (_suppressEvents || _hub?.Settings == null) return;
+        if (_suppressEvents || CurrentApp.Settings == null) return;
 
         if (LanguageCombo.SelectedItem is ComboBoxItem item && item.Tag is string lang)
         {
-            _hub.Settings.SttLanguage = lang;
-            _hub.Settings.Save();
+            CurrentApp.Settings.SttLanguage = lang;
+            CurrentApp.Settings.Save();
         }
     }
 
     private void OnSilenceChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
     {
-        if (_suppressEvents || _hub?.Settings == null) return;
-        _hub.Settings.SttSilenceTimeout = (float)SilenceSlider.Value;
-        _hub.Settings.Save();
+        if (_suppressEvents || CurrentApp.Settings == null) return;
+        CurrentApp.Settings.SttSilenceTimeout = (float)SilenceSlider.Value;
+        CurrentApp.Settings.Save();
     }
 
     private void OnTtsResponseToggled(object sender, RoutedEventArgs e)
     {
-        if (_suppressEvents || _hub?.Settings == null) return;
-        _hub.Settings.VoiceTtsEnabled = TtsResponseToggle.IsOn;
-        _hub.Settings.Save();
+        if (_suppressEvents || CurrentApp.Settings == null) return;
+        CurrentApp.Settings.VoiceTtsEnabled = TtsResponseToggle.IsOn;
+        CurrentApp.Settings.Save();
     }
 
     private void OnAudioFeedbackToggled(object sender, RoutedEventArgs e)
     {
-        if (_suppressEvents || _hub?.Settings == null) return;
-        _hub.Settings.VoiceAudioFeedback = AudioFeedbackToggle.IsOn;
-        _hub.Settings.Save();
+        if (_suppressEvents || CurrentApp.Settings == null) return;
+        CurrentApp.Settings.VoiceAudioFeedback = AudioFeedbackToggle.IsOn;
+        CurrentApp.Settings.Save();
     }
 
     private async void OnDownloadClick(object sender, RoutedEventArgs e)
     {
-        if (_hub?.Settings == null) return;
+        if (CurrentApp.Settings == null) return;
 
         // Cancel any in-progress Whisper download (only). Piper downloads are
         // independent and keep running.
@@ -237,9 +235,9 @@ public sealed partial class VoiceSettingsPage : Page
             // button label flips to "Re-download" (UpdateModelStatus). The
             // download manager short-circuits if the file exists, so we
             // delete first to force a fresh fetch + SHA-256 re-verify.
-            manager.DeleteModel(_hub.Settings.SttModelName);
+            manager.DeleteModel(CurrentApp.Settings.SttModelName);
             await manager.DownloadModelAsync(
-                _hub.Settings.SttModelName,
+                CurrentApp.Settings.SttModelName,
                 progress,
                 _whisperDownloadCts.Token);
 
@@ -272,7 +270,7 @@ public sealed partial class VoiceSettingsPage : Page
 
     private async void OnTestVoiceClick(object sender, RoutedEventArgs e)
     {
-        if (_hub?.Settings == null || _isVoiceTestDialogOpen) return;
+        if (CurrentApp.Settings == null || _isVoiceTestDialogOpen) return;
 
         _isVoiceTestDialogOpen = true;
         TestVoiceButton.IsEnabled = false;
@@ -281,7 +279,7 @@ public sealed partial class VoiceSettingsPage : Page
         {
             // Use a dedicated test service so settings verification never stops,
             // submits through, or otherwise mutates the live voice overlay session.
-            await using var voiceService = new VoiceService(new AppLogger(), _hub.Settings);
+            await using var voiceService = new VoiceService(new AppLogger(), CurrentApp.Settings);
 
             // ── Transcript area (matches Companion Voice overlay style) ──
             var emptyStateIcon = new FontIcon
@@ -639,11 +637,11 @@ public sealed partial class VoiceSettingsPage : Page
 
     private void OnPiperVoiceChanged(object sender, SelectionChangedEventArgs e)
     {
-        if (_suppressEvents || _hub?.Settings == null) return;
+        if (_suppressEvents || CurrentApp.Settings == null) return;
         if (PiperVoiceCombo.SelectedItem is ComboBoxItem item && item.Tag is string voiceId)
         {
-            _hub.Settings.TtsPiperVoiceId = voiceId;
-            _hub.Settings.Save();
+            CurrentApp.Settings.TtsPiperVoiceId = voiceId;
+            CurrentApp.Settings.Save();
         }
         UpdatePiperVoiceState();
     }
@@ -655,7 +653,7 @@ public sealed partial class VoiceSettingsPage : Page
     /// </summary>
     private void UpdatePiperVoiceState()
     {
-        if (_hub?.Settings == null) return;
+        if (CurrentApp.Settings == null) return;
         if (PiperVoiceCombo.SelectedItem is not ComboBoxItem item || item.Tag is not string voiceId)
             return;
 
@@ -684,7 +682,7 @@ public sealed partial class VoiceSettingsPage : Page
 
     private async void OnPiperDownloadClick(object sender, RoutedEventArgs e)
     {
-        if (_hub?.Settings == null) return;
+        if (CurrentApp.Settings == null) return;
         if (PiperVoiceCombo.SelectedItem is not ComboBoxItem item || item.Tag is not string voiceId) return;
 
         // Cancel any prior Piper download (only). Whisper downloads are
@@ -752,7 +750,7 @@ public sealed partial class VoiceSettingsPage : Page
 
     private void OnPiperDeleteClick(object sender, RoutedEventArgs e)
     {
-        if (_hub?.Settings == null) return;
+        if (CurrentApp.Settings == null) return;
         if (PiperVoiceCombo.SelectedItem is not ComboBoxItem item || item.Tag is not string voiceId) return;
 
         try
@@ -771,7 +769,7 @@ public sealed partial class VoiceSettingsPage : Page
 
     private async void OnPiperPreviewClick(object sender, RoutedEventArgs e)
     {
-        if (_hub?.Settings == null) return;
+        if (CurrentApp.Settings == null) return;
         if (PiperVoiceCombo.SelectedItem is not ComboBoxItem item || item.Tag is not string voiceId) return;
 
         PiperPreviewButton.IsEnabled = false;
@@ -780,7 +778,7 @@ public sealed partial class VoiceSettingsPage : Page
 
         try
         {
-            using var tts = new TextToSpeechService(new AppLogger(), _hub.Settings);
+            using var tts = new TextToSpeechService(new AppLogger(), CurrentApp.Settings);
             await tts.SpeakAsync(new OpenClaw.Shared.Capabilities.TtsSpeakArgs
             {
                 Text = L("VoiceSettingsPage_CompanionPreviewText"),
@@ -849,43 +847,43 @@ public sealed partial class VoiceSettingsPage : Page
 
     private void OnTtsProviderChanged(object sender, SelectionChangedEventArgs e)
     {
-        if (_suppressEvents || _hub?.Settings == null) return;
+        if (_suppressEvents || CurrentApp.Settings == null) return;
 
         if (TtsProviderCombo.SelectedItem is ComboBoxItem item && item.Tag is string provider)
         {
-            _hub.Settings.TtsProvider = provider;
-            _hub.Settings.Save();
+            CurrentApp.Settings.TtsProvider = provider;
+            CurrentApp.Settings.Save();
         }
         UpdateTtsProviderVisibility();
     }
 
     private void OnWindowsVoiceChanged(object sender, SelectionChangedEventArgs e)
     {
-        if (_suppressEvents || _hub?.Settings == null) return;
+        if (_suppressEvents || CurrentApp.Settings == null) return;
 
         if (WindowsVoiceCombo.SelectedItem is ComboBoxItem item && item.Tag is string voiceId)
         {
-            _hub.Settings.TtsWindowsVoiceId = voiceId;
-            _hub.Settings.Save();
+            CurrentApp.Settings.TtsWindowsVoiceId = voiceId;
+            CurrentApp.Settings.Save();
         }
     }
 
     private async void OnPreviewVoiceClick(object sender, RoutedEventArgs e)
     {
-        if (_hub?.Settings == null) return;
+        if (CurrentApp.Settings == null) return;
 
         PreviewVoiceButton.IsEnabled = false;
         PreviewVoiceButton.Content = L("VoiceSettingsPage_PreviewButtonPlaying");
 
         try
         {
-            var tts = new TextToSpeechService(new AppLogger(), _hub.Settings);
+            var tts = new TextToSpeechService(new AppLogger(), CurrentApp.Settings);
             try
             {
                 await tts.SpeakAsync(new OpenClaw.Shared.Capabilities.TtsSpeakArgs
                 {
                     Text = L("VoiceSettingsPage_CompanionPreviewText"),
-                    Provider = _hub.Settings.TtsProvider,
+                    Provider = CurrentApp.Settings.TtsProvider,
                     VoiceId = WindowsVoiceCombo.SelectedItem is ComboBoxItem item ? item.Tag?.ToString() : null,
                     Interrupt = true
                 });
@@ -911,22 +909,22 @@ public sealed partial class VoiceSettingsPage : Page
 
     private void OnElevenLabsKeyChanged(object sender, RoutedEventArgs e)
     {
-        if (_suppressEvents || _hub?.Settings == null) return;
-        _hub.Settings.TtsElevenLabsApiKey = ElevenLabsApiKeyBox.Password;
-        _hub.Settings.Save();
+        if (_suppressEvents || CurrentApp.Settings == null) return;
+        CurrentApp.Settings.TtsElevenLabsApiKey = ElevenLabsApiKeyBox.Password;
+        CurrentApp.Settings.Save();
     }
 
     private void OnElevenLabsVoiceIdChanged(object sender, TextChangedEventArgs e)
     {
-        if (_suppressEvents || _hub?.Settings == null) return;
-        _hub.Settings.TtsElevenLabsVoiceId = ElevenLabsVoiceIdBox.Text;
-        _hub.Settings.Save();
+        if (_suppressEvents || CurrentApp.Settings == null) return;
+        CurrentApp.Settings.TtsElevenLabsVoiceId = ElevenLabsVoiceIdBox.Text;
+        CurrentApp.Settings.Save();
     }
 
     private void OnElevenLabsModelChanged(object sender, TextChangedEventArgs e)
     {
-        if (_suppressEvents || _hub?.Settings == null) return;
-        _hub.Settings.TtsElevenLabsModel = ElevenLabsModelBox.Text;
-        _hub.Settings.Save();
+        if (_suppressEvents || CurrentApp.Settings == null) return;
+        CurrentApp.Settings.TtsElevenLabsModel = ElevenLabsModelBox.Text;
+        CurrentApp.Settings.Save();
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml.cs
@@ -2,7 +2,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using OpenClaw.Shared;
 using OpenClawTray.Services;
-using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -12,12 +11,13 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class WorkspacePage : Page
 {
-    private HubWindow? _hub;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private AppState? _appState;
     private readonly Dictionary<string, TabViewItem> _fileTabs = new(StringComparer.OrdinalIgnoreCase);
     private bool _tabsPopulated;
 
-    private string AgentId => _hub?.CurrentAgentId ?? "main";
+    /// <summary>Set by HubWindow before <see cref="Initialize"/> to specify the active agent scope.</summary>
+    public string AgentId { get; set; } = "main";
     public string CurrentAgentId => AgentId;
 
     public WorkspacePage()
@@ -29,23 +29,23 @@ public sealed partial class WorkspacePage : Page
         };
     }
 
-    public void Initialize(HubWindow hub)
+    public void Initialize()
     {
-        _hub = hub;
-        _appState = ((App)Application.Current).AppState;
+        _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
         // Only request fresh data when no matching cache exists.
         var hasMatchingCache = _appState?.AgentFilesList.HasValue == true &&
             string.Equals(_appState?.AgentFilesListAgentId, AgentId, StringComparison.OrdinalIgnoreCase);
-        if (hub.GatewayClient != null && hub.CurrentStatus == ConnectionStatus.Connected && !hasMatchingCache)
+        var status = CurrentApp.AppState?.Status ?? OpenClaw.Shared.ConnectionStatus.Disconnected;
+        if (CurrentApp.GatewayClient != null && status == OpenClaw.Shared.ConnectionStatus.Connected && !hasMatchingCache)
         {
             FallbackInfoBar.IsOpen = false;
             LoadingRing.IsActive = true;
             LoadingPanel.Visibility = Visibility.Visible;
             ClearTabs();
-            _ = hub.GatewayClient.RequestAgentFilesListAsync(AgentId);
+            _ = CurrentApp.GatewayClient.RequestAgentFilesListAsync(AgentId);
         }
-        else if (hub.GatewayClient == null || hub.CurrentStatus != ConnectionStatus.Connected)
+        else if (CurrentApp.GatewayClient == null || status != OpenClaw.Shared.ConnectionStatus.Connected)
         {
             FallbackInfoBar.IsOpen = true;
             FallbackInfoBar.Message = "Connect to gateway to view workspace files.";
@@ -105,8 +105,8 @@ public sealed partial class WorkspacePage : Page
             FileTabs.SelectedIndex = 0;
             _tabsPopulated = true;
             // Explicitly fetch first tab content (SelectionChanged may not fire for programmatic index set)
-            if (FileTabs.SelectedItem is TabViewItem firstTab && firstTab.Tag is string firstName && _hub?.GatewayClient != null)
-                _ = _hub.GatewayClient.RequestAgentFileGetAsync(AgentId, firstName);
+            if (FileTabs.SelectedItem is TabViewItem firstTab && firstTab.Tag is string firstName && CurrentApp.GatewayClient != null)
+                _ = CurrentApp.GatewayClient.RequestAgentFileGetAsync(AgentId, firstName);
         }
     }
 
@@ -191,21 +191,21 @@ public sealed partial class WorkspacePage : Page
     {
         // Lazy load on tab select if content is still placeholder
         if (FileTabs.SelectedItem is TabViewItem tab && tab.Tag is string fileName &&
-            tab.Content is StackPanel && _hub?.GatewayClient != null)
+            tab.Content is StackPanel && CurrentApp.GatewayClient != null)
         {
-            _ = _hub.GatewayClient.RequestAgentFileGetAsync(AgentId, fileName);
+            _ = CurrentApp.GatewayClient.RequestAgentFileGetAsync(AgentId, fileName);
         }
     }
 
     private void RefreshButton_Click(object sender, RoutedEventArgs e)
     {
-        if (_hub?.GatewayClient != null)
+        if (CurrentApp.GatewayClient != null)
         {
             LoadingRing.IsActive = true;
             LoadingPanel.Visibility = Visibility.Visible;
             FallbackInfoBar.IsOpen = false;
             ClearTabs();
-            _ = _hub.GatewayClient.RequestAgentFilesListAsync(AgentId);
+            _ = CurrentApp.GatewayClient.RequestAgentFilesListAsync(AgentId);
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml.cs
@@ -1,9 +1,11 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using OpenClaw.Shared;
+using OpenClawTray.Services;
 using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text.Json;
 
 namespace OpenClawTray.Pages;
@@ -11,6 +13,7 @@ namespace OpenClawTray.Pages;
 public sealed partial class WorkspacePage : Page
 {
     private HubWindow? _hub;
+    private AppState? _appState;
     private readonly Dictionary<string, TabViewItem> _fileTabs = new(StringComparer.OrdinalIgnoreCase);
     private bool _tabsPopulated;
 
@@ -20,28 +23,45 @@ public sealed partial class WorkspacePage : Page
     public WorkspacePage()
     {
         InitializeComponent();
+        Unloaded += (_, _) =>
+        {
+            if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+        };
     }
 
     public void Initialize(HubWindow hub)
     {
         _hub = hub;
-        // If HubWindow has cached file list data for this agent, it will replay after Initialize.
+        _appState = ((App)Application.Current).AppState;
+        _appState.PropertyChanged += OnAppStateChanged;
         // Only request fresh data when no matching cache exists.
-        var hasMatchingCache = hub.LastAgentFilesList.HasValue &&
-            string.Equals(hub.LastAgentFilesListAgentId, AgentId, StringComparison.OrdinalIgnoreCase);
+        var hasMatchingCache = _appState?.AgentFilesList.HasValue == true &&
+            string.Equals(_appState?.AgentFilesListAgentId, AgentId, StringComparison.OrdinalIgnoreCase);
         if (hub.GatewayClient != null && hub.CurrentStatus == ConnectionStatus.Connected && !hasMatchingCache)
         {
             FallbackInfoBar.IsOpen = false;
             LoadingRing.IsActive = true;
             LoadingPanel.Visibility = Visibility.Visible;
             ClearTabs();
-            hub.RecordAgentFilesListRequest(AgentId);
             _ = hub.GatewayClient.RequestAgentFilesListAsync(AgentId);
         }
         else if (hub.GatewayClient == null || hub.CurrentStatus != ConnectionStatus.Connected)
         {
             FallbackInfoBar.IsOpen = true;
             FallbackInfoBar.Message = "Connect to gateway to view workspace files.";
+        }
+    }
+
+    private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(AppState.AgentFilesList):
+                if (_appState!.AgentFilesList.HasValue) UpdateAgentFilesList(_appState.AgentFilesList.Value);
+                break;
+            case nameof(AppState.AgentFileContent):
+                if (_appState!.AgentFileContent.HasValue) UpdateAgentFileContent(_appState.AgentFileContent.Value);
+                break;
         }
     }
 
@@ -185,7 +205,6 @@ public sealed partial class WorkspacePage : Page
             LoadingPanel.Visibility = Visibility.Visible;
             FallbackInfoBar.IsOpen = false;
             ClearTabs();
-            _hub.RecordAgentFilesListRequest(AgentId);
             _ = _hub.GatewayClient.RequestAgentFilesListAsync(AgentId);
         }
     }

--- a/src/OpenClaw.Tray.WinUI/Services/AppState.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AppState.cs
@@ -225,8 +225,9 @@ internal sealed class AppState : INotifyPropertyChanged
     public void ClearCachedData()
     {
         // Status is NOT reset — it is managed by OnManagerStateChanged.
+        // AuthFailureMessage is NOT reset — it's set by OnAuthenticationFailed
+        // and cleared explicitly on Connected (not on disconnect/error).
         CurrentActivity = null;
-        AuthFailureMessage = null;
         Channels = Array.Empty<ChannelHealth>();
         Sessions = Array.Empty<SessionInfo>();
         Nodes = Array.Empty<GatewayNodeInfo>();

--- a/src/OpenClaw.Tray.WinUI/Services/AppState.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AppState.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -32,8 +31,10 @@ internal sealed class AppState : INotifyPropertyChanged
     private bool SetField<T>(ref T field, T value, [CallerMemberName] string? name = null)
     {
 #if !OPENCLAW_TRAY_TESTS
-        Debug.Assert(_dispatcher == null || _dispatcher.HasThreadAccess,
-            $"AppState.{name} must be written on UI thread");
+        if (_dispatcher != null && !_dispatcher.HasThreadAccess)
+        {
+            throw new InvalidOperationException($"AppState.{name} must be written on UI thread");
+        }
 #endif
         if (EqualityComparer<T>.Default.Equals(field, value)) return false;
         field = value;
@@ -151,8 +152,10 @@ internal sealed class AppState : INotifyPropertyChanged
     public void AddAgentEvent(AgentEventInfo evt)
     {
 #if !OPENCLAW_TRAY_TESTS
-        Debug.Assert(_dispatcher == null || _dispatcher.HasThreadAccess,
-            "AppState.AddAgentEvent must be called on UI thread");
+        if (_dispatcher != null && !_dispatcher.HasThreadAccess)
+        {
+            throw new InvalidOperationException("AppState.AddAgentEvent must be called on UI thread");
+        }
 #endif
         _agentEvents.Insert(0, evt);
         if (_agentEvents.Count > MaxAgentEvents)

--- a/src/OpenClaw.Tray.WinUI/Services/AppState.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AppState.cs
@@ -1,0 +1,246 @@
+using Microsoft.UI.Dispatching;
+using OpenClaw.Connection;
+using OpenClaw.Shared;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+
+namespace OpenClawTray.Services;
+
+/// <summary>
+/// Single source of truth for all gateway-cached state. All property writes
+/// must happen on the UI thread (enforced by <see cref="SetField{T}"/>).
+/// Pages and HubWindow observe changes via <see cref="INotifyPropertyChanged"/>.
+/// </summary>
+internal sealed class AppState : INotifyPropertyChanged
+{
+    private readonly DispatcherQueue? _dispatcher;
+
+    public AppState(DispatcherQueue? dispatcher = null) => _dispatcher = dispatcher;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private bool SetField<T>(ref T field, T value, [CallerMemberName] string? name = null)
+    {
+        Debug.Assert(_dispatcher == null || _dispatcher.HasThreadAccess,
+            $"AppState.{name} must be written on UI thread");
+        if (EqualityComparer<T>.Default.Equals(field, value)) return false;
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        return true;
+    }
+
+    // ── Connection ──────────────────────────────────────────────────────
+
+    private ConnectionStatus _status = ConnectionStatus.Disconnected;
+    public ConnectionStatus Status { get => _status; set => SetField(ref _status, value); }
+
+    private AgentActivity? _currentActivity;
+    public AgentActivity? CurrentActivity { get => _currentActivity; set => SetField(ref _currentActivity, value); }
+
+    private string? _authFailureMessage;
+    public string? AuthFailureMessage { get => _authFailureMessage; set => SetField(ref _authFailureMessage, value); }
+
+    // ── Channels / Sessions / Nodes ─────────────────────────────────────
+
+    private ChannelHealth[] _channels = Array.Empty<ChannelHealth>();
+    public ChannelHealth[] Channels { get => _channels; set => SetField(ref _channels, value); }
+
+    private SessionInfo[] _sessions = Array.Empty<SessionInfo>();
+    public SessionInfo[] Sessions { get => _sessions; set => SetField(ref _sessions, value); }
+
+    private GatewayNodeInfo[] _nodes = Array.Empty<GatewayNodeInfo>();
+    public GatewayNodeInfo[] Nodes { get => _nodes; set => SetField(ref _nodes, value); }
+
+    // ── Usage ───────────────────────────────────────────────────────────
+
+    private GatewayUsageInfo? _usage;
+    public GatewayUsageInfo? Usage { get => _usage; set => SetField(ref _usage, value); }
+
+    private GatewayUsageStatusInfo? _usageStatus;
+    public GatewayUsageStatusInfo? UsageStatus { get => _usageStatus; set => SetField(ref _usageStatus, value); }
+
+    private GatewayCostUsageInfo? _usageCost;
+    public GatewayCostUsageInfo? UsageCost { get => _usageCost; set => SetField(ref _usageCost, value); }
+
+    // ── Gateway identity ────────────────────────────────────────────────
+
+    private GatewaySelfInfo? _gatewaySelf;
+    public GatewaySelfInfo? GatewaySelf { get => _gatewaySelf; set => SetField(ref _gatewaySelf, value); }
+
+    // ── Pairing ─────────────────────────────────────────────────────────
+
+    private PairingListInfo? _nodePairList;
+    public PairingListInfo? NodePairList { get => _nodePairList; set => SetField(ref _nodePairList, value); }
+
+    private DevicePairingListInfo? _devicePairList;
+    public DevicePairingListInfo? DevicePairList { get => _devicePairList; set => SetField(ref _devicePairList, value); }
+
+    // ── Models ──────────────────────────────────────────────────────────
+
+    private ModelsListInfo? _modelsList;
+    public ModelsListInfo? ModelsList { get => _modelsList; set => SetField(ref _modelsList, value); }
+
+    // ── Presence ────────────────────────────────────────────────────────
+
+    private PresenceEntry[]? _presence;
+    public PresenceEntry[]? Presence { get => _presence; set => SetField(ref _presence, value); }
+
+    // ── JSON-typed data ─────────────────────────────────────────────────
+
+    private JsonElement? _agentsList;
+    public JsonElement? AgentsList { get => _agentsList; set => SetField(ref _agentsList, value); }
+
+    private JsonElement? _config;
+    public JsonElement? Config { get => _config; set => SetField(ref _config, value); }
+
+    private JsonElement? _configSchema;
+    public JsonElement? ConfigSchema { get => _configSchema; set => SetField(ref _configSchema, value); }
+
+    private JsonElement? _skillsData;
+    public JsonElement? SkillsData { get => _skillsData; set => SetField(ref _skillsData, value); }
+
+    private string? _skillsAgentId;
+    public string? SkillsAgentId { get => _skillsAgentId; set => SetField(ref _skillsAgentId, value); }
+
+    private JsonElement? _agentFilesList;
+    public JsonElement? AgentFilesList { get => _agentFilesList; set => SetField(ref _agentFilesList, value); }
+
+    private string? _agentFilesListAgentId;
+    public string? AgentFilesListAgentId { get => _agentFilesListAgentId; set => SetField(ref _agentFilesListAgentId, value); }
+
+    private JsonElement? _cronList;
+    public JsonElement? CronList { get => _cronList; set => SetField(ref _cronList, value); }
+
+    private JsonElement? _cronStatus;
+    public JsonElement? CronStatus { get => _cronStatus; set => SetField(ref _cronStatus, value); }
+
+    private JsonElement? _cronRuns;
+    public JsonElement? CronRuns { get => _cronRuns; set => SetField(ref _cronRuns, value); }
+
+    private JsonElement? _agentFileContent;
+    public JsonElement? AgentFileContent { get => _agentFileContent; set => SetField(ref _agentFileContent, value); }
+
+    // ── Update info ─────────────────────────────────────────────────────
+
+    private UpdateCommandCenterInfo _updateInfo = new();
+    public UpdateCommandCenterInfo UpdateInfo { get => _updateInfo; set => SetField(ref _updateInfo, value); }
+
+    private DateTime _lastCheckTime = DateTime.Now;
+    public DateTime LastCheckTime { get => _lastCheckTime; set => SetField(ref _lastCheckTime, value); }
+
+    // ── Agent events (ring buffer, newest-first) ────────────────────────
+
+    private readonly List<AgentEventInfo> _agentEvents = new();
+    public IReadOnlyList<AgentEventInfo> AgentEvents => _agentEvents;
+
+    /// <summary>Fires on UI thread when a new event is added.</summary>
+    public event Action<AgentEventInfo>? AgentEventAdded;
+
+    public void AddAgentEvent(AgentEventInfo evt)
+    {
+        Debug.Assert(_dispatcher == null || _dispatcher.HasThreadAccess,
+            "AppState.AddAgentEvent must be called on UI thread");
+        _agentEvents.Insert(0, evt);
+        if (_agentEvents.Count > MaxAgentEvents)
+            _agentEvents.RemoveRange(MaxAgentEvents, _agentEvents.Count - MaxAgentEvents);
+        AgentEventAdded?.Invoke(evt);
+    }
+
+    public void ClearAgentEvents()
+    {
+        _agentEvents.Clear();
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AgentEvents)));
+    }
+
+    private const int MaxAgentEvents = 400;
+
+    // ── Session previews (thread-safe, not observable) ───────────────────
+
+    private readonly Dictionary<string, SessionPreviewInfo> _sessionPreviews = new();
+    private readonly object _sessionPreviewsLock = new();
+
+    public SessionPreviewInfo? GetSessionPreview(string key)
+    {
+        lock (_sessionPreviewsLock)
+            return _sessionPreviews.TryGetValue(key, out var p) ? p : null;
+    }
+
+    public void SetSessionPreview(string key, SessionPreviewInfo preview)
+    {
+        lock (_sessionPreviewsLock)
+            _sessionPreviews[key] = preview;
+    }
+
+    public void PruneSessionPreviews(HashSet<string> validKeys)
+    {
+        lock (_sessionPreviewsLock)
+        {
+            var stale = _sessionPreviews.Keys.Where(key => !validKeys.Contains(key)).ToArray();
+            foreach (var key in stale)
+                _sessionPreviews.Remove(key);
+        }
+    }
+
+    // ── Computed helpers ────────────────────────────────────────────────
+
+    /// <summary>Extract agent IDs from cached <see cref="AgentsList"/> JSON.</summary>
+    public List<string> GetAgentIds()
+    {
+        var ids = new List<string>();
+        if (_agentsList.HasValue &&
+            _agentsList.Value.TryGetProperty("agents", out var agentsEl) &&
+            agentsEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var agent in agentsEl.EnumerateArray())
+            {
+                var id = agent.TryGetProperty("id", out var idEl) ? idEl.GetString() ?? "" : "";
+                if (!string.IsNullOrEmpty(id)) ids.Add(id);
+            }
+        }
+        if (ids.Count == 0) ids.Add("main");
+        return ids;
+    }
+
+    // ── Lifecycle ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Resets ALL gateway data fields to defaults. Called on disconnect and client swap.
+    /// Does NOT reset <see cref="Status"/> — that is managed by OnManagerStateChanged.
+    /// Fires <see cref="PropertyChanged"/> for every property so observers refresh.
+    /// </summary>
+    public void ClearCachedData()
+    {
+        // Status is NOT reset — it is managed by OnManagerStateChanged.
+        CurrentActivity = null;
+        AuthFailureMessage = null;
+        Channels = Array.Empty<ChannelHealth>();
+        Sessions = Array.Empty<SessionInfo>();
+        Nodes = Array.Empty<GatewayNodeInfo>();
+        Usage = null;
+        UsageStatus = null;
+        UsageCost = null;
+        GatewaySelf = null;
+        NodePairList = null;
+        DevicePairList = null;
+        ModelsList = null;
+        Presence = null;
+        AgentsList = null;
+        Config = null;
+        ConfigSchema = null;
+        SkillsData = null;
+        SkillsAgentId = null;
+        AgentFilesList = null;
+        AgentFilesListAgentId = null;
+        AgentFileContent = null;
+        CronList = null;
+        CronStatus = null;
+        CronRuns = null;
+        ClearAgentEvents();
+        lock (_sessionPreviewsLock) _sessionPreviews.Clear();
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/AppState.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AppState.cs
@@ -1,6 +1,3 @@
-using Microsoft.UI.Dispatching;
-using OpenClaw.Connection;
-using OpenClaw.Shared;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -8,6 +5,11 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using OpenClaw.Connection;
+using OpenClaw.Shared;
+#if !OPENCLAW_TRAY_TESTS
+using Microsoft.UI.Dispatching;
+#endif
 
 namespace OpenClawTray.Services;
 
@@ -18,16 +20,21 @@ namespace OpenClawTray.Services;
 /// </summary>
 internal sealed class AppState : INotifyPropertyChanged
 {
+#if !OPENCLAW_TRAY_TESTS
     private readonly DispatcherQueue? _dispatcher;
-
     public AppState(DispatcherQueue? dispatcher = null) => _dispatcher = dispatcher;
+#else
+    public AppState() { }
+#endif
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
     private bool SetField<T>(ref T field, T value, [CallerMemberName] string? name = null)
     {
+#if !OPENCLAW_TRAY_TESTS
         Debug.Assert(_dispatcher == null || _dispatcher.HasThreadAccess,
             $"AppState.{name} must be written on UI thread");
+#endif
         if (EqualityComparer<T>.Default.Equals(field, value)) return false;
         field = value;
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
@@ -143,8 +150,10 @@ internal sealed class AppState : INotifyPropertyChanged
 
     public void AddAgentEvent(AgentEventInfo evt)
     {
+#if !OPENCLAW_TRAY_TESTS
         Debug.Assert(_dispatcher == null || _dispatcher.HasThreadAccess,
             "AppState.AddAgentEvent must be called on UI thread");
+#endif
         _agentEvents.Insert(0, evt);
         if (_agentEvents.Count > MaxAgentEvents)
             _agentEvents.RemoveRange(MaxAgentEvents, _agentEvents.Count - MaxAgentEvents);

--- a/src/OpenClaw.Tray.WinUI/Services/DiagnosticsClipboardService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/DiagnosticsClipboardService.cs
@@ -1,0 +1,59 @@
+using OpenClaw.Shared;
+using OpenClawTray.Helpers;
+using System;
+
+namespace OpenClawTray.Services;
+
+/// <summary>
+/// Groups diagnostic clipboard operations that were spread across App.xaml.cs.
+/// Each method copies a formatted diagnostic to the clipboard.
+/// </summary>
+internal sealed class DiagnosticsClipboardService
+{
+    private readonly Func<GatewayCommandCenterState> _captureState;
+
+    public DiagnosticsClipboardService(Func<GatewayCommandCenterState> captureState)
+    {
+        _captureState = captureState;
+    }
+
+    public void CopyDiagnostic(string label, Func<GatewayCommandCenterState, string> format)
+    {
+        try
+        {
+            App.CopyTextToClipboard(format(_captureState()));
+            Logger.Info($"Copied {label} from deep link");
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Failed to copy {label} from deep link: {ex.Message}");
+        }
+    }
+
+    public void CopySupportContext() =>
+        CopyDiagnostic("support context", CommandCenterTextHelper.BuildSupportContext);
+
+    public void CopyDebugBundle() =>
+        CopyDiagnostic("debug bundle", CommandCenterTextHelper.BuildDebugBundle);
+
+    public void CopyBrowserSetupGuidance() =>
+        CopyDiagnostic("browser setup guidance", CommandCenterTextHelper.BuildBrowserSetupGuidance);
+
+    public void CopyPortDiagnostics() =>
+        CopyDiagnostic("port diagnostics", s => CommandCenterTextHelper.BuildPortDiagnosticsSummary(s.PortDiagnostics));
+
+    public void CopyCapabilityDiagnostics() =>
+        CopyDiagnostic("capability diagnostics", CommandCenterTextHelper.BuildCapabilityDiagnosticsSummary);
+
+    public void CopyNodeInventory() =>
+        CopyDiagnostic("node inventory", s => CommandCenterTextHelper.BuildNodeInventorySummary(s.Nodes));
+
+    public void CopyChannelSummary() =>
+        CopyDiagnostic("channel summary", s => CommandCenterTextHelper.BuildChannelSummaryText(s.Channels));
+
+    public void CopyActivitySummary() =>
+        CopyDiagnostic("activity summary", s => CommandCenterTextHelper.BuildActivitySummary(s.RecentActivity));
+
+    public void CopyExtensibilitySummary() =>
+        CopyDiagnostic("extensibility summary", s => CommandCenterTextHelper.BuildExtensibilitySummary(s.Channels));
+}

--- a/src/OpenClaw.Tray.WinUI/Services/GatewayService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/GatewayService.cs
@@ -294,7 +294,6 @@ internal sealed class GatewayService
         if (sender != _currentClient) return;
 
         var activeKeys = new HashSet<string>(sessions.Select(s => s.Key), StringComparer.Ordinal);
-        _state.PruneSessionPreviews(activeKeys);
 
         // Throttled preview request
         if (_currentClient != null &&
@@ -306,7 +305,11 @@ internal sealed class GatewayService
             _ = _currentClient.RequestSessionPreviewAsync(keys, limit: 3, maxChars: 140);
         }
 
-        EnqueueModelUpdate(() => _state.Sessions = sessions);
+        EnqueueModelUpdate(() =>
+        {
+            _state.Sessions = sessions;
+            _state.PruneSessionPreviews(activeKeys);
+        });
     }
 
     private void OnUsageCostUpdated(object? sender, GatewayCostUsageInfo usageCost)

--- a/src/OpenClaw.Tray.WinUI/Services/GatewayService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/GatewayService.cs
@@ -49,6 +49,15 @@ internal sealed class GatewayService
     /// </summary>
     public void AttachClient(IOperatorGatewayClient? newClient, IOperatorGatewayClient? oldClient)
     {
+        if (!_dispatcher.HasThreadAccess)
+        {
+            if (!_dispatcher.TryEnqueue(() => AttachClient(newClient, oldClient)))
+            {
+                Logger.Warn("[GatewayService] Failed to dispatch operator client swap to UI thread");
+            }
+            return;
+        }
+
         if (oldClient != null)
             UnsubscribeAll(oldClient);
 
@@ -258,6 +267,7 @@ internal sealed class GatewayService
     internal void OnChannelHealthUpdated(object? sender, ChannelHealth[] channels)
     {
         if (sender != _currentClient && sender is IOperatorGatewayClient) return;
+        if (sender is not IOperatorGatewayClient && _state.Status != ConnectionStatus.Connected) return;
 
         var signature = string.Join("|", channels
             .OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase)
@@ -333,6 +343,7 @@ internal sealed class GatewayService
     internal void OnGatewaySelfUpdated(object? sender, GatewaySelfInfo gatewaySelf)
     {
         if (sender != _currentClient && sender is IOperatorGatewayClient) return;
+        if (sender is not IOperatorGatewayClient && _state.Status != ConnectionStatus.Connected) return;
 
         EnqueueModelUpdate(() =>
         {

--- a/src/OpenClaw.Tray.WinUI/Services/GatewayService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/GatewayService.cs
@@ -1,0 +1,485 @@
+using Microsoft.UI.Dispatching;
+using OpenClaw.Shared;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+
+namespace OpenClawTray.Services;
+
+/// <summary>
+/// Owns all 27 operator gateway client event subscriptions.
+/// Handlers dispatch model updates to the UI thread via <see cref="EnqueueModelUpdate"/>,
+/// writing to <see cref="AppState"/> which fires <see cref="System.ComponentModel.INotifyPropertyChanged.PropertyChanged"/>.
+/// Four events are re-raised for App-level UI side effects (toasts, tray icon, health checks).
+/// </summary>
+internal sealed class GatewayService
+{
+    private readonly AppState _state;
+    private readonly DispatcherQueue _dispatcher;
+
+    // Re-raised events — App subscribes for UI side effects that don't belong in this service.
+    public event EventHandler<ConnectionStatus>? ConnectionStatusChanged;
+    public event EventHandler<string>? AuthenticationFailed;
+    public event EventHandler<SessionCommandResult>? SessionCommandCompleted;
+    public event EventHandler<OpenClawNotification>? NotificationReceived;
+
+    // Throttle / dedup state (moved from App)
+    private DateTime _lastPreviewRequestUtc = DateTime.MinValue;
+    private DateTime _lastUsageActivityLogUtc = DateTime.MinValue;
+    private string? _lastChannelStatusSignature;
+    private readonly Dictionary<string, AgentActivity> _sessionActivities = new();
+    private string? _displayedSessionKey;
+    private DateTime _lastSessionSwitch = DateTime.MinValue;
+    private static readonly TimeSpan SessionSwitchDebounce = TimeSpan.FromSeconds(3);
+
+    // Client tracking for stale-event safety
+    private IOperatorGatewayClient? _currentClient;
+    private int _clientGeneration;
+
+    public GatewayService(AppState state, DispatcherQueue dispatcher)
+    {
+        _state = state;
+        _dispatcher = dispatcher;
+    }
+
+    /// <summary>
+    /// Swap client subscriptions. Unsubscribes from <paramref name="oldClient"/>,
+    /// subscribes to <paramref name="newClient"/>. Either may be null (MCP-only / first connect).
+    /// </summary>
+    public void AttachClient(IOperatorGatewayClient? newClient, IOperatorGatewayClient? oldClient)
+    {
+        if (oldClient != null)
+            UnsubscribeAll(oldClient);
+
+        _clientGeneration++;
+        _currentClient = newClient;
+
+        // Clear service-level caches on actual client swap
+        if (!ReferenceEquals(oldClient, newClient))
+        {
+            _lastChannelStatusSignature = null;
+            _sessionActivities.Clear();
+            _displayedSessionKey = null;
+            _lastSessionSwitch = DateTime.MinValue;
+        }
+
+        if (newClient != null)
+            SubscribeAll(newClient);
+    }
+
+    // ── Dispatcher helper ───────────────────────────────────────────────
+
+    /// <summary>
+    /// Dispatch a model update to the UI thread. Guards against stale events
+    /// from a previous client by capturing and re-checking the client generation.
+    /// </summary>
+    private void EnqueueModelUpdate(Action update)
+    {
+        var gen = _clientGeneration;
+        if (_dispatcher.HasThreadAccess)
+        {
+            if (gen == _clientGeneration) update();
+        }
+        else
+        {
+            _dispatcher.TryEnqueue(() =>
+            {
+                if (gen == _clientGeneration) update();
+            });
+        }
+    }
+
+    // ── Subscribe / Unsubscribe ─────────────────────────────────────────
+
+    private void SubscribeAll(IOperatorGatewayClient client)
+    {
+        client.StatusChanged += OnConnectionStatusChanged;
+        client.AuthenticationFailed += OnAuthenticationFailed;
+        client.ActivityChanged += OnActivityChanged;
+        client.NotificationReceived += OnNotificationReceived;
+        client.ChannelHealthUpdated += OnChannelHealthUpdated;
+        client.SessionsUpdated += OnSessionsUpdated;
+        client.UsageUpdated += OnUsageUpdated;
+        client.UsageStatusUpdated += OnUsageStatusUpdated;
+        client.UsageCostUpdated += OnUsageCostUpdated;
+        client.NodesUpdated += OnNodesUpdated;
+        client.SessionPreviewUpdated += OnSessionPreviewUpdated;
+        client.SessionCommandCompleted += OnSessionCommandCompleted;
+        client.GatewaySelfUpdated += OnGatewaySelfUpdated;
+        client.CronListUpdated += OnCronListUpdated;
+        client.CronStatusUpdated += OnCronStatusUpdated;
+        client.CronRunsUpdated += OnCronRunsUpdated;
+        client.ConfigUpdated += OnConfigUpdated;
+        client.ConfigSchemaUpdated += OnConfigSchemaUpdated;
+        client.SkillsStatusUpdated += OnSkillsStatusUpdated;
+        client.AgentEventReceived += OnAgentEventReceived;
+        client.NodePairListUpdated += OnNodePairListUpdated;
+        client.DevicePairListUpdated += OnDevicePairListUpdated;
+        client.ModelsListUpdated += OnModelsListUpdated;
+        client.PresenceUpdated += OnPresenceUpdated;
+        client.AgentsListUpdated += OnAgentsListUpdated;
+        client.AgentFilesListUpdated += OnAgentFilesListUpdated;
+        client.AgentFileContentUpdated += OnAgentFileContentUpdated;
+    }
+
+    private void UnsubscribeAll(IOperatorGatewayClient client)
+    {
+        client.StatusChanged -= OnConnectionStatusChanged;
+        client.AuthenticationFailed -= OnAuthenticationFailed;
+        client.ActivityChanged -= OnActivityChanged;
+        client.NotificationReceived -= OnNotificationReceived;
+        client.ChannelHealthUpdated -= OnChannelHealthUpdated;
+        client.SessionsUpdated -= OnSessionsUpdated;
+        client.UsageUpdated -= OnUsageUpdated;
+        client.UsageStatusUpdated -= OnUsageStatusUpdated;
+        client.UsageCostUpdated -= OnUsageCostUpdated;
+        client.NodesUpdated -= OnNodesUpdated;
+        client.SessionPreviewUpdated -= OnSessionPreviewUpdated;
+        client.SessionCommandCompleted -= OnSessionCommandCompleted;
+        client.GatewaySelfUpdated -= OnGatewaySelfUpdated;
+        client.CronListUpdated -= OnCronListUpdated;
+        client.CronStatusUpdated -= OnCronStatusUpdated;
+        client.CronRunsUpdated -= OnCronRunsUpdated;
+        client.ConfigUpdated -= OnConfigUpdated;
+        client.ConfigSchemaUpdated -= OnConfigSchemaUpdated;
+        client.SkillsStatusUpdated -= OnSkillsStatusUpdated;
+        client.AgentEventReceived -= OnAgentEventReceived;
+        client.NodePairListUpdated -= OnNodePairListUpdated;
+        client.DevicePairListUpdated -= OnDevicePairListUpdated;
+        client.ModelsListUpdated -= OnModelsListUpdated;
+        client.PresenceUpdated -= OnPresenceUpdated;
+        client.AgentsListUpdated -= OnAgentsListUpdated;
+        client.AgentFilesListUpdated -= OnAgentFilesListUpdated;
+        client.AgentFileContentUpdated -= OnAgentFileContentUpdated;
+    }
+
+    // ── Category C: Re-raised events (update AppState + re-raise for App) ──
+
+    private void OnConnectionStatusChanged(object? sender, ConnectionStatus status)
+    {
+        if (sender != _currentClient) return;
+
+        DiagnosticsJsonlService.Write("connection.status", new
+        {
+            status = status.ToString()
+        });
+
+        EnqueueModelUpdate(() =>
+        {
+            if (status == ConnectionStatus.Connected)
+            {
+                _state.AuthFailureMessage = null;
+            }
+
+            if (status == ConnectionStatus.Disconnected || status == ConnectionStatus.Error)
+            {
+                _state.ClearCachedData();
+            }
+
+            ConnectionStatusChanged?.Invoke(this, status);
+        });
+    }
+
+    private void OnAuthenticationFailed(object? sender, string message)
+    {
+        if (sender != _currentClient) return;
+
+        Logger.Error($"Authentication failed: {message}");
+        DiagnosticsJsonlService.Write("connection.auth_failed", new { message });
+        ActivityStreamService.Add(
+            category: "error",
+            title: $"Auth failed: {message}");
+
+        EnqueueModelUpdate(() =>
+        {
+            _state.AuthFailureMessage = message;
+            AuthenticationFailed?.Invoke(this, message);
+        });
+    }
+
+    private void OnSessionCommandCompleted(object? sender, SessionCommandResult result)
+    {
+        if (sender != _currentClient) return;
+        EnqueueModelUpdate(() => SessionCommandCompleted?.Invoke(this, result));
+    }
+
+    private void OnNotificationReceived(object? sender, OpenClawNotification notification)
+    {
+        if (sender != _currentClient) return;
+
+        ActivityStreamService.Add(
+            category: "notification",
+            title: $"{notification.Type ?? "info"}: {notification.Title ?? "notification"}",
+            details: notification.Message);
+
+        EnqueueModelUpdate(() => NotificationReceived?.Invoke(this, notification));
+    }
+
+    // ── Category B: Complex data (state + side effects) ─────────────────
+
+    private void OnActivityChanged(object? sender, AgentActivity? activity)
+    {
+        if (sender != _currentClient) return;
+
+        EnqueueModelUpdate(() =>
+        {
+            if (activity == null)
+            {
+                if (_displayedSessionKey != null && _sessionActivities.ContainsKey(_displayedSessionKey))
+                    _sessionActivities.Remove(_displayedSessionKey);
+                _state.CurrentActivity = null;
+            }
+            else
+            {
+                var sessionKey = activity.SessionKey ?? "default";
+                _sessionActivities[sessionKey] = activity;
+                ActivityStreamService.Add(
+                    category: "session",
+                    title: $"{sessionKey}: {activity.Label}",
+                    dashboardPath: $"sessions/{sessionKey}",
+                    details: activity.Kind.ToString(),
+                    sessionKey: sessionKey);
+
+                var now = DateTime.Now;
+                if (_displayedSessionKey != sessionKey &&
+                    (now - _lastSessionSwitch) > SessionSwitchDebounce)
+                {
+                    _displayedSessionKey = sessionKey;
+                    _lastSessionSwitch = now;
+                }
+
+                if (_displayedSessionKey == sessionKey)
+                    _state.CurrentActivity = activity;
+            }
+        });
+    }
+
+    internal void OnChannelHealthUpdated(object? sender, ChannelHealth[] channels)
+    {
+        if (sender != _currentClient && sender is IOperatorGatewayClient) return;
+
+        var signature = string.Join("|", channels
+            .OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(c => $"{c.Name}:{c.Status}:{c.Error}"));
+
+        if (!string.Equals(signature, _lastChannelStatusSignature, StringComparison.Ordinal))
+        {
+            _lastChannelStatusSignature = signature;
+            var summary = channels.Length == 0
+                ? "No channels reported"
+                : string.Join(", ", channels.Select(c => $"{c.Name}={c.Status}"));
+            DiagnosticsJsonlService.Write("gateway.health.channels", new
+            {
+                channelCount = channels.Length,
+                healthyCount = channels.Count(c => ChannelHealth.IsHealthyStatus(c.Status)),
+                errorCount = channels.Count(c => !string.IsNullOrWhiteSpace(c.Error))
+            });
+            ActivityStreamService.Add(
+                category: "channel",
+                title: "Channel health updated",
+                dashboardPath: "channels",
+                details: summary);
+        }
+
+        EnqueueModelUpdate(() =>
+        {
+            _state.LastCheckTime = DateTime.Now;
+            _state.Channels = channels;
+        });
+    }
+
+    private void OnSessionsUpdated(object? sender, SessionInfo[] sessions)
+    {
+        if (sender != _currentClient) return;
+
+        var activeKeys = new HashSet<string>(sessions.Select(s => s.Key), StringComparer.Ordinal);
+        _state.PruneSessionPreviews(activeKeys);
+
+        // Throttled preview request
+        if (_currentClient != null &&
+            sessions.Length > 0 &&
+            DateTime.UtcNow - _lastPreviewRequestUtc > TimeSpan.FromSeconds(5))
+        {
+            _lastPreviewRequestUtc = DateTime.UtcNow;
+            var keys = sessions.Take(5).Select(s => s.Key).ToArray();
+            _ = _currentClient.RequestSessionPreviewAsync(keys, limit: 3, maxChars: 140);
+        }
+
+        EnqueueModelUpdate(() => _state.Sessions = sessions);
+    }
+
+    private void OnUsageCostUpdated(object? sender, GatewayCostUsageInfo usageCost)
+    {
+        if (sender != _currentClient) return;
+
+        if (DateTime.UtcNow - _lastUsageActivityLogUtc > TimeSpan.FromMinutes(1))
+        {
+            _lastUsageActivityLogUtc = DateTime.UtcNow;
+            ActivityStreamService.Add(
+                category: "usage",
+                title: $"{usageCost.Days}d usage ${usageCost.Totals.TotalCost:F2}",
+                dashboardPath: "usage",
+                details: $"{usageCost.Totals.TotalTokens:N0} tokens");
+        }
+
+        EnqueueModelUpdate(() => _state.UsageCost = usageCost);
+    }
+
+    internal void OnGatewaySelfUpdated(object? sender, GatewaySelfInfo gatewaySelf)
+    {
+        if (sender != _currentClient && sender is IOperatorGatewayClient) return;
+
+        EnqueueModelUpdate(() =>
+        {
+            _state.GatewaySelf = _state.GatewaySelf?.Merge(gatewaySelf) ?? gatewaySelf;
+            DiagnosticsJsonlService.Write("gateway.self", new
+            {
+                version = _state.GatewaySelf.ServerVersion,
+                protocol = _state.GatewaySelf.Protocol,
+                uptimeMs = _state.GatewaySelf.UptimeMs,
+                authMode = _state.GatewaySelf.AuthMode,
+                stateVersionPresence = _state.GatewaySelf.StateVersionPresence,
+                stateVersionHealth = _state.GatewaySelf.StateVersionHealth,
+                presenceCount = _state.GatewaySelf.PresenceCount
+            });
+        });
+    }
+
+    private void OnNodesUpdated(object? sender, GatewayNodeInfo[] nodes)
+    {
+        if (sender != _currentClient) return;
+
+        EnqueueModelUpdate(() =>
+        {
+            var previousCount = _state.Nodes.Length;
+            var previousOnline = _state.Nodes.Count(n => n.IsOnline);
+            var online = nodes.Count(n => n.IsOnline);
+
+            _state.Nodes = nodes;
+
+            if (nodes.Length != previousCount || online != previousOnline)
+            {
+                ActivityStreamService.Add(
+                    category: "node",
+                    title: $"Nodes {online}/{nodes.Length} online",
+                    dashboardPath: "nodes");
+            }
+        });
+    }
+
+    private void OnSessionPreviewUpdated(object? sender, SessionsPreviewPayloadInfo payload)
+    {
+        if (sender != _currentClient) return;
+
+        foreach (var preview in payload.Previews)
+            _state.SetSessionPreview(preview.Key, preview);
+    }
+
+    private void OnAgentEventReceived(object? sender, AgentEventInfo evt)
+    {
+        if (sender != _currentClient) return;
+        EnqueueModelUpdate(() => _state.AddAgentEvent(evt));
+    }
+
+    // ── Category A: Simple data (just update AppState) ──────────────────
+
+    private void OnUsageUpdated(object? sender, GatewayUsageInfo usage)
+    {
+        if (sender != _currentClient) return;
+        EnqueueModelUpdate(() => _state.Usage = usage);
+    }
+
+    private void OnUsageStatusUpdated(object? sender, GatewayUsageStatusInfo usageStatus)
+    {
+        if (sender != _currentClient) return;
+        EnqueueModelUpdate(() => _state.UsageStatus = usageStatus);
+    }
+
+    private void OnCronListUpdated(object? sender, JsonElement data)
+    {
+        if (sender != _currentClient) return;
+        var cloned = data.Clone();
+        EnqueueModelUpdate(() => _state.CronList = cloned);
+    }
+
+    private void OnCronStatusUpdated(object? sender, JsonElement data)
+    {
+        if (sender != _currentClient) return;
+        var cloned = data.Clone();
+        EnqueueModelUpdate(() => _state.CronStatus = cloned);
+    }
+
+    private void OnCronRunsUpdated(object? sender, JsonElement data)
+    {
+        if (sender != _currentClient) return;
+        var cloned = data.Clone();
+        EnqueueModelUpdate(() => _state.CronRuns = cloned);
+    }
+
+    private void OnSkillsStatusUpdated(object? sender, JsonElement data)
+    {
+        if (sender != _currentClient) return;
+        var cloned = data.Clone();
+        EnqueueModelUpdate(() => _state.SkillsData = cloned);
+    }
+
+    private void OnConfigUpdated(object? sender, JsonElement data)
+    {
+        if (sender != _currentClient) return;
+        var cloned = data.Clone();
+        EnqueueModelUpdate(() => _state.Config = cloned);
+    }
+
+    private void OnConfigSchemaUpdated(object? sender, JsonElement data)
+    {
+        if (sender != _currentClient) return;
+        var cloned = data.Clone();
+        EnqueueModelUpdate(() => _state.ConfigSchema = cloned);
+    }
+
+    private void OnAgentsListUpdated(object? sender, JsonElement data)
+    {
+        if (sender != _currentClient) return;
+        var cloned = data.Clone();
+        EnqueueModelUpdate(() => _state.AgentsList = cloned);
+    }
+
+    private void OnAgentFilesListUpdated(object? sender, JsonElement data)
+    {
+        if (sender != _currentClient) return;
+        var cloned = data.Clone();
+        EnqueueModelUpdate(() => _state.AgentFilesList = cloned);
+    }
+
+    private void OnAgentFileContentUpdated(object? sender, JsonElement data)
+    {
+        if (sender != _currentClient) return;
+        var cloned = data.Clone();
+        EnqueueModelUpdate(() => _state.AgentFileContent = cloned);
+    }
+
+    private void OnNodePairListUpdated(object? sender, PairingListInfo data)
+    {
+        if (sender != _currentClient) return;
+        EnqueueModelUpdate(() => _state.NodePairList = data);
+    }
+
+    private void OnDevicePairListUpdated(object? sender, DevicePairingListInfo data)
+    {
+        if (sender != _currentClient) return;
+        EnqueueModelUpdate(() => _state.DevicePairList = data);
+    }
+
+    private void OnModelsListUpdated(object? sender, ModelsListInfo data)
+    {
+        if (sender != _currentClient) return;
+        EnqueueModelUpdate(() => _state.ModelsList = data);
+    }
+
+    private void OnPresenceUpdated(object? sender, PresenceEntry[] data)
+    {
+        if (sender != _currentClient) return;
+        EnqueueModelUpdate(() => _state.Presence = data);
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/GatewayService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/GatewayService.cs
@@ -295,14 +295,15 @@ internal sealed class GatewayService
 
         var activeKeys = new HashSet<string>(sessions.Select(s => s.Key), StringComparer.Ordinal);
 
-        // Throttled preview request
-        if (_currentClient != null &&
+        // Throttled preview request (capture client ref for safety)
+        var client = _currentClient;
+        if (client != null &&
             sessions.Length > 0 &&
             DateTime.UtcNow - _lastPreviewRequestUtc > TimeSpan.FromSeconds(5))
         {
             _lastPreviewRequestUtc = DateTime.UtcNow;
             var keys = sessions.Take(5).Select(s => s.Key).ToArray();
-            _ = _currentClient.RequestSessionPreviewAsync(keys, limit: 3, maxChars: 140);
+            _ = client.RequestSessionPreviewAsync(keys, limit: 3, maxChars: 140);
         }
 
         EnqueueModelUpdate(() =>

--- a/src/OpenClaw.Tray.WinUI/Services/IAppCommands.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/IAppCommands.cs
@@ -1,0 +1,21 @@
+namespace OpenClawTray.Services;
+
+/// <summary>
+/// Typed interface for page → app commands. Decouples pages from HubWindow
+/// so they don't need a reference to the full window for navigation and actions.
+/// Implemented by <see cref="App"/>.
+/// </summary>
+internal interface IAppCommands
+{
+    void OpenDashboard(string? path = null);
+    void Navigate(string pageTag);
+    void Reconnect();
+    void Disconnect();
+    void ShowVoiceOverlay();
+    void ShowChat();
+    void ShowQuickSend();
+    void CheckForUpdates();
+    void ShowOnboarding();
+    void ShowConnectionStatus();
+    void NotifySettingsSaved();
+}

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -1096,7 +1096,7 @@ public sealed class NodeService : IDisposable
         if (!enqueued)
             tcs.TrySetException(new InvalidOperationException("CANVAS_DISPATCHER_UNAVAILABLE: dispatcher queue rejected"));
 
-        return await tcs.Task;
+        return await WaitWithTimeout(tcs.Task, "canvas.eval");
     }
 
     private async Task<string> OnCanvasSnapshot(CanvasSnapshotArgs args)
@@ -1133,7 +1133,7 @@ public sealed class NodeService : IDisposable
         if (!enqueued)
             tcs.TrySetException(new InvalidOperationException("CANVAS_DISPATCHER_UNAVAILABLE: dispatcher queue rejected"));
 
-        return await tcs.Task;
+        return await WaitWithTimeout(tcs.Task, "canvas.snapshot");
     }
 
     private Task<string> OnCanvasA2UIDumpAsync()
@@ -1203,6 +1203,21 @@ public sealed class NodeService : IDisposable
         if (!enqueued)
             tcs.TrySetException(new InvalidOperationException("CANVAS_DISPATCHER_UNAVAILABLE: dispatcher queue rejected"));
         return tcs.Task;
+    }
+
+    /// <summary>
+    /// Awaits a dispatcher-bridged TCS with a timeout so that canvas commands
+    /// return a tool error instead of hanging indefinitely when the UI thread
+    /// dispatcher is not pumping (e.g. headless CI).
+    /// </summary>
+    private static async Task<string> WaitWithTimeout(Task<string> task, string command, int timeoutSeconds = 15)
+    {
+        if (await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(timeoutSeconds))) != task)
+        {
+            throw new TimeoutException(
+                $"CANVAS_TIMEOUT: {command} did not complete within {timeoutSeconds}s — the UI dispatcher may not be pumping");
+        }
+        return await task; // propagate the result or exception
     }
 
     private void EnsureCanvasWindow()

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -1065,9 +1065,11 @@ public sealed class NodeService : IDisposable
     private async Task<string> OnCanvasEval(string script)
     {
         var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cts = new CancellationTokenSource();
 
         bool enqueued = _dispatcherQueue.TryEnqueue(async () =>
         {
+            if (cts.IsCancellationRequested) return;
             try
             {
                 if (_canvasWindow != null && !_canvasWindow.IsClosed)
@@ -1096,15 +1098,17 @@ public sealed class NodeService : IDisposable
         if (!enqueued)
             tcs.TrySetException(new InvalidOperationException("CANVAS_DISPATCHER_UNAVAILABLE: dispatcher queue rejected"));
 
-        return await WaitWithTimeout(tcs.Task, "canvas.eval");
+        return await WaitWithTimeout(tcs.Task, cts, "canvas.eval");
     }
 
     private async Task<string> OnCanvasSnapshot(CanvasSnapshotArgs args)
     {
         var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cts = new CancellationTokenSource();
 
         bool enqueued = _dispatcherQueue.TryEnqueue(async () =>
         {
+            if (cts.IsCancellationRequested) return;
             try
             {
                 if (_canvasWindow != null && !_canvasWindow.IsClosed)
@@ -1133,7 +1137,7 @@ public sealed class NodeService : IDisposable
         if (!enqueued)
             tcs.TrySetException(new InvalidOperationException("CANVAS_DISPATCHER_UNAVAILABLE: dispatcher queue rejected"));
 
-        return await WaitWithTimeout(tcs.Task, "canvas.snapshot");
+        return await WaitWithTimeout(tcs.Task, cts, "canvas.snapshot");
     }
 
     private Task<string> OnCanvasA2UIDumpAsync()
@@ -1208,12 +1212,14 @@ public sealed class NodeService : IDisposable
     /// <summary>
     /// Awaits a dispatcher-bridged TCS with a timeout so that canvas commands
     /// return a tool error instead of hanging indefinitely when the UI thread
-    /// dispatcher is not pumping (e.g. headless CI).
+    /// dispatcher is not pumping (e.g. headless CI). Cancels the CTS on timeout
+    /// so the enqueued callback skips execution.
     /// </summary>
-    private static async Task<string> WaitWithTimeout(Task<string> task, string command, int timeoutSeconds = 15)
+    private static async Task<string> WaitWithTimeout(Task<string> task, CancellationTokenSource cts, string command, int timeoutSeconds = 15)
     {
         if (await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(timeoutSeconds))) != task)
         {
+            cts.Cancel();
             throw new TimeoutException(
                 $"CANVAS_TIMEOUT: {command} did not complete within {timeoutSeconds}s — the UI dispatcher may not be pumping");
         }

--- a/src/OpenClaw.Tray.WinUI/Services/ToastService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ToastService.cs
@@ -14,6 +14,7 @@ internal sealed class ToastService
     private readonly Func<SettingsManager?> _getSettings;
     private readonly Dictionary<string, DateTime> _recentToastKeys = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<string> _shownPairedToasts = new(StringComparer.Ordinal);
+    private readonly object _gate = new();
     private static readonly TimeSpan ToastDedupeWindow = TimeSpan.FromSeconds(30);
 
     public ToastService(Func<SettingsManager?> getSettings)
@@ -43,19 +44,32 @@ internal sealed class ToastService
     public bool HasRecentToast(string toastTag, string? deviceId)
     {
         var normalizedDeviceId = NormalizeToastDeviceId(deviceId);
-        return _recentToastKeys.TryGetValue(BuildToastKey(toastTag, normalizedDeviceId), out var lastShown) &&
-            DateTime.UtcNow - lastShown < ToastDedupeWindow;
+        lock (_gate)
+        {
+            return _recentToastKeys.TryGetValue(BuildToastKey(toastTag, normalizedDeviceId), out var lastShown) &&
+                DateTime.UtcNow - lastShown < ToastDedupeWindow;
+        }
     }
 
     /// <summary>
     /// Per-device idempotency for "Node paired" toast. Prevents duplicate
     /// toasts when PairingStatusChanged(Paired) re-fires on WS reconnect.
     /// </summary>
-    public bool HasShownPairedToast(string deviceId) =>
-        _shownPairedToasts.Contains(deviceId);
+    public bool HasShownPairedToast(string deviceId)
+    {
+        lock (_gate)
+        {
+            return _shownPairedToasts.Contains(deviceId);
+        }
+    }
 
-    public void MarkPairedToastShown(string deviceId) =>
-        _shownPairedToasts.Add(deviceId);
+    public void MarkPairedToastShown(string deviceId)
+    {
+        lock (_gate)
+        {
+            _shownPairedToasts.Add(deviceId);
+        }
+    }
 
     private bool ShouldShowToast(string? toastTag, string? deviceId)
     {
@@ -66,22 +80,26 @@ internal sealed class ToastService
         var dedupeKey = BuildToastKey(toastTag, normalizedDeviceId);
         var now = DateTime.UtcNow;
 
-        foreach (var staleKey in _recentToastKeys
-            .Where(pair => now - pair.Value >= ToastDedupeWindow)
-            .Select(pair => pair.Key)
-            .ToArray())
+        lock (_gate)
         {
-            _recentToastKeys.Remove(staleKey);
+            foreach (var staleKey in _recentToastKeys
+                .Where(pair => now - pair.Value >= ToastDedupeWindow)
+                .Select(pair => pair.Key)
+                .ToArray())
+            {
+                _recentToastKeys.Remove(staleKey);
+            }
+
+            if (_recentToastKeys.TryGetValue(dedupeKey, out var lastShown) &&
+                now - lastShown < ToastDedupeWindow)
+            {
+                Logger.Info($"[ToastDeduper] Suppressed duplicate toast tag={toastTag} deviceId={normalizedDeviceId}");
+                return false;
+            }
+
+            _recentToastKeys[dedupeKey] = now;
         }
 
-        if (_recentToastKeys.TryGetValue(dedupeKey, out var lastShown) &&
-            now - lastShown < ToastDedupeWindow)
-        {
-            Logger.Info($"[ToastDeduper] Suppressed duplicate toast tag={toastTag} deviceId={normalizedDeviceId}");
-            return false;
-        }
-
-        _recentToastKeys[dedupeKey] = now;
         Logger.Info($"[ToastDeduper] Showing toast tag={toastTag} deviceId={normalizedDeviceId}");
         return true;
     }

--- a/src/OpenClaw.Tray.WinUI/Services/ToastService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ToastService.cs
@@ -1,0 +1,94 @@
+using Microsoft.Toolkit.Uwp.Notifications;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenClawTray.Services;
+
+/// <summary>
+/// Toast notification display with dedup and sound configuration.
+/// Extracted from App.xaml.cs to group toast-related state and logic.
+/// </summary>
+internal sealed class ToastService
+{
+    private readonly Func<SettingsManager?> _getSettings;
+    private readonly Dictionary<string, DateTime> _recentToastKeys = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _shownPairedToasts = new(StringComparer.Ordinal);
+    private static readonly TimeSpan ToastDedupeWindow = TimeSpan.FromSeconds(30);
+
+    public ToastService(Func<SettingsManager?> getSettings)
+    {
+        _getSettings = getSettings;
+    }
+
+    /// <summary>Shows a toast with optional dedup by tag + device ID.</summary>
+    public void ShowToast(ToastContentBuilder builder, string? toastTag = null, string? deviceId = null)
+    {
+        if (!ShouldShowToast(toastTag, deviceId))
+            return;
+
+        var sound = _getSettings()?.NotificationSound;
+        if (string.Equals(sound, "None", StringComparison.OrdinalIgnoreCase))
+        {
+            builder.AddAudio(new ToastAudio { Silent = true });
+        }
+        else if (string.Equals(sound, "Subtle", StringComparison.OrdinalIgnoreCase))
+        {
+            builder.AddAudio(new Uri("ms-winsoundevent:Notification.IM"), silent: false);
+        }
+        builder.Show();
+    }
+
+    /// <summary>Check whether a toast with this tag was recently shown (within dedup window).</summary>
+    public bool HasRecentToast(string toastTag, string? deviceId)
+    {
+        var normalizedDeviceId = NormalizeToastDeviceId(deviceId);
+        return _recentToastKeys.TryGetValue(BuildToastKey(toastTag, normalizedDeviceId), out var lastShown) &&
+            DateTime.UtcNow - lastShown < ToastDedupeWindow;
+    }
+
+    /// <summary>
+    /// Per-device idempotency for "Node paired" toast. Prevents duplicate
+    /// toasts when PairingStatusChanged(Paired) re-fires on WS reconnect.
+    /// </summary>
+    public bool HasShownPairedToast(string deviceId) =>
+        _shownPairedToasts.Contains(deviceId);
+
+    public void MarkPairedToastShown(string deviceId) =>
+        _shownPairedToasts.Add(deviceId);
+
+    private bool ShouldShowToast(string? toastTag, string? deviceId)
+    {
+        if (string.IsNullOrWhiteSpace(toastTag))
+            return true;
+
+        var normalizedDeviceId = NormalizeToastDeviceId(deviceId);
+        var dedupeKey = BuildToastKey(toastTag, normalizedDeviceId);
+        var now = DateTime.UtcNow;
+
+        foreach (var staleKey in _recentToastKeys
+            .Where(pair => now - pair.Value >= ToastDedupeWindow)
+            .Select(pair => pair.Key)
+            .ToArray())
+        {
+            _recentToastKeys.Remove(staleKey);
+        }
+
+        if (_recentToastKeys.TryGetValue(dedupeKey, out var lastShown) &&
+            now - lastShown < ToastDedupeWindow)
+        {
+            Logger.Info($"[ToastDeduper] Suppressed duplicate toast tag={toastTag} deviceId={normalizedDeviceId}");
+            return false;
+        }
+
+        _recentToastKeys[dedupeKey] = now;
+        Logger.Info($"[ToastDeduper] Showing toast tag={toastTag} deviceId={normalizedDeviceId}");
+        return true;
+    }
+
+    private static string NormalizeToastDeviceId(string? deviceId) =>
+        string.IsNullOrWhiteSpace(deviceId) ? "global" : deviceId.Trim();
+
+    private static string BuildToastKey(string toastTag, string normalizedDeviceId) =>
+        $"{toastTag.Trim()}:{normalizedDeviceId}";
+}

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
@@ -91,29 +91,29 @@
             SelectionChanged="NavView_SelectionChanged">
 
         <NavigationView.MenuItems>
-            <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_82" Tag="chat" Content="Chat">
+            <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_82" x:Name="NavChat" Tag="chat" Content="Chat">
                 <NavigationViewItem.Icon><FontIcon Glyph="&#xE8BD;"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItemSeparator/>
 
-            <NavigationViewItemHeader x:Uid="HubWindow_NavigationViewItemHeader_87" Content="Gateway"/>
+            <NavigationViewItemHeader x:Uid="HubWindow_NavigationViewItemHeader_87" x:Name="NavGatewayHeader" Content="Gateway"/>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_88" Tag="connection" Content="Connection">
                 <NavigationViewItem.Icon><FontIcon Glyph="&#xE839;"/></NavigationViewItem.Icon>
             </NavigationViewItem>
-            <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_91" Tag="sessions" Content="Sessions">
+            <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_91" x:Name="NavSessions" Tag="sessions" Content="Sessions">
                 <NavigationViewItem.Icon><FontIcon Glyph="&#xE8F2;"/></NavigationViewItem.Icon>
             </NavigationViewItem>
-            <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_97" Tag="skills" Content="Skills">
+            <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_97" x:Name="NavSkills" Tag="skills" Content="Skills">
                 <NavigationViewItem.Icon><FontIcon Glyph="&#xE945;"/></NavigationViewItem.Icon>
             </NavigationViewItem>
-            <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_109" Tag="channels" Content="Channels">
+            <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_109" x:Name="NavChannels" Tag="channels" Content="Channels">
                 <NavigationViewItem.Icon><FontIcon Glyph="&#xEC05;"/></NavigationViewItem.Icon>
             </NavigationViewItem>
-            <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_112" Tag="instances" Content="Instances">
+            <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_112" x:Name="NavInstances" Tag="instances" Content="Instances">
                 <NavigationViewItem.Icon><FontIcon Glyph="&#xE977;"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <!-- Advanced — consolidates gateway-oriented pages -->
-            <NavigationViewItem Content="Advanced" SelectsOnInvoked="False">
+            <NavigationViewItem x:Name="NavAdvanced" Content="Advanced" SelectsOnInvoked="False">
                 <NavigationViewItem.Icon><FontIcon Glyph="&#xE950;"/></NavigationViewItem.Icon>
                 <NavigationViewItem.MenuItems>
                     <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_94" Tag="agentevents" Content="Agent Events">
@@ -141,7 +141,7 @@
                     </NavigationViewItem>
                 </NavigationViewItem.MenuItems>
             </NavigationViewItem>
-            <NavigationViewItemSeparator/>
+            <NavigationViewItemSeparator x:Name="NavGatewaySeparator"/>
 
             <NavigationViewItemHeader x:Uid="HubWindow_NavigationViewItemHeader_129" Content="This Computer"/>
             <NavigationViewItem Tag="voice" Content="Voice &amp; Audio">

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -61,14 +61,17 @@ public sealed partial class HubWindow : WindowEx
 
     private void OnAppModelChanged(object? sender, PropertyChangedEventArgs e)
     {
-        switch (e.PropertyName)
+        if (IsClosed || AppModel == null) return;
+        try
         {
-            case nameof(AppState.Status):
-                DispatcherQueue?.TryEnqueue(() =>
-                {
-                    if (IsClosed) return;
-                    _cachedCommands = null;
-                    UpdateTitleBarStatus(AppModel!.Status);
+            switch (e.PropertyName)
+            {
+                case nameof(AppState.Status):
+                    DispatcherQueue?.TryEnqueue(() =>
+                    {
+                        if (IsClosed) return;
+                        _cachedCommands = null;
+                        UpdateTitleBarStatus(AppModel!.Status);
                 });
                 break;
             case nameof(AppState.GatewaySelf):
@@ -88,6 +91,11 @@ public sealed partial class HubWindow : WindowEx
                         RebuildAgentNavItems(AppModel.AgentsList.Value);
                 });
                 break;
+        }
+        }
+        catch (Exception ex)
+        {
+            Services.Logger.Warn($"[HubWindow] OnAppModelChanged({e.PropertyName}) failed: {ex.Message}");
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -7,6 +7,7 @@ using OpenClawTray.Pages;
 using OpenClawTray.Services;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using WinUIEx;
 
@@ -16,50 +17,11 @@ public sealed partial class HubWindow : WindowEx
 {
     public bool IsClosed { get; private set; }
 
-    // Shared state accessible by pages
-    private SettingsManager? _settings;
-    public SettingsManager? Settings
-    {
-        get => _settings;
-        set
-        {
-            _settings = value;
-            // Apply persisted nav-pane state. NavView starts with its XAML
-            // default of IsPaneOpen=true; honor the user's last preference
-            // here so they don't re-toggle on every Hub open.
-            if (value != null && NavView != null)
-            {
-                NavView.IsPaneOpen = value.HubNavPaneOpen;
-            }
-        }
-    }
-    public IOperatorGatewayClient? GatewayClient { get; set; }
-    public ConnectionStatus CurrentStatus { get; set; }
+    private static App CurrentApp => (App)Application.Current;
+
     internal AppState? AppModel { get; set; }
     private string _currentAgentId = "main";
     public string CurrentAgentId => _currentAgentId;
-
-    // Legacy compatibility alias
-    public string SelectedAgentId => _currentAgentId;
-    public Action<string?>? OpenDashboardAction { get; set; }
-    public Action? CheckForUpdatesAction { get; set; }
-    public Action? ConnectAction { get; set; }
-    public Action? DisconnectAction { get; set; }
-    public Action? ReconnectAction { get; set; }
-    public Action? OpenSetupAction { get; set; }
-    public Action? OpenConnectionStatusAction { get; set; }
-    public Action? OpenVoiceAction { get; set; }
-    public OpenClaw.Connection.IGatewayConnectionManager? ConnectionManager { get; set; }
-    public OpenClaw.Connection.GatewayRegistry? GatewayRegistry { get; set; }
-
-    // Node service state (set by App.xaml.cs in ShowHub)
-    public bool NodeIsConnected { get; set; }
-    public bool NodeIsPaired { get; set; }
-    public bool NodeIsPendingApproval { get; set; }
-    public string? LastAuthError { get; set; }
-    public string? NodeShortDeviceId { get; set; }
-    public VoiceService? VoiceServiceInstance { get; set; }
-    public string? NodeFullDeviceId { get; set; }
 
     // Event for settings saved (App.xaml.cs subscribes)
     public event EventHandler? SettingsSaved;
@@ -71,16 +33,73 @@ public sealed partial class HubWindow : WindowEx
         InitializeComponent();
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);
-        Closed += (s, e) => IsClosed = true;
+        Closed += (s, e) =>
+        {
+            IsClosed = true;
+            if (AppModel != null)
+                AppModel.PropertyChanged -= OnAppModelChanged;
+        };
 
         this.SetWindowSize(900, 650);
         this.CenterOnScreen();
         this.SetIcon(IconHelper.GetStatusIconPath(ConnectionStatus.Connected));
 
         RootGrid.SizeChanged += OnRootGridSizeChanged;
+    }
 
-        // Don't select a nav item here — Settings/GatewayClient aren't set yet.
-        // ShowHub() in App.xaml.cs calls NavigateToDefault() after setting properties.
+    /// <summary>
+    /// Subscribe to AppState property changes for title bar and nav updates.
+    /// Called from App.ShowHub() after setting AppModel.
+    /// </summary>
+    internal void BindToAppState()
+    {
+        if (AppModel != null)
+        {
+            AppModel.PropertyChanged += OnAppModelChanged;
+        }
+    }
+
+    private void OnAppModelChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(AppState.Status):
+                DispatcherQueue?.TryEnqueue(() =>
+                {
+                    if (IsClosed) return;
+                    _cachedCommands = null;
+                    UpdateTitleBarStatus(AppModel!.Status);
+                });
+                break;
+            case nameof(AppState.GatewaySelf):
+                DispatcherQueue?.TryEnqueue(() =>
+                {
+                    if (IsClosed) return;
+                    UpdateTitleBarStatus(AppModel!.Status);
+                    if (ContentFrame?.Content is AboutPage about)
+                        about.RefreshGatewayInfo();
+                });
+                break;
+            case nameof(AppState.AgentsList):
+                DispatcherQueue?.TryEnqueue(() =>
+                {
+                    if (IsClosed) return;
+                    if (AppModel!.AgentsList.HasValue)
+                        RebuildAgentNavItems(AppModel.AgentsList.Value);
+                });
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Apply persisted nav-pane state. Called from App.ShowHub() after creating the window.
+    /// </summary>
+    internal void ApplyNavPaneState(SettingsManager settings)
+    {
+        if (NavView != null)
+        {
+            NavView.IsPaneOpen = settings.HubNavPaneOpen;
+        }
     }
 
     private void OnRootGridSizeChanged(object sender, SizeChangedEventArgs e)
@@ -99,14 +118,12 @@ public sealed partial class HubWindow : WindowEx
     }
 
     /// <summary>
-    /// Navigate to the default page. Call after setting Settings/GatewayClient.
+    /// Navigate to the default page. Call after setting AppModel.
     /// </summary>
     public void NavigateToDefault()
     {
         if (ContentFrame.Content == null)
         {
-            // Connection is the landing page (Home was removed; legacy
-            // "home"/"general" tags alias to "connection" in NavigateTo).
             NavigateTo("connection");
         }
     }
@@ -157,25 +174,6 @@ public sealed partial class HubWindow : WindowEx
         return false;
     }
 
-    public void UpdateStatus(ConnectionStatus status)
-    {
-        try
-        {
-            DispatcherQueue?.TryEnqueue(() =>
-            {
-                if (IsClosed) return;
-                CurrentStatus = status;
-                _cachedCommands = null;
-                UpdateTitleBarStatus(status);
-                if (ContentFrame?.Content is ConnectionPage connectionPage)
-                {
-                    connectionPage.UpdateStatus(status);
-                }
-            });
-        }
-        catch { }
-    }
-
     private void UpdateTitleBarStatus(ConnectionStatus status)
     {
         var (color, text) = status switch
@@ -195,7 +193,7 @@ public sealed partial class HubWindow : WindowEx
             TitleStatusText.Text = text;
 
         // Update role indicator dots
-        var snapshot = ConnectionManager?.CurrentSnapshot;
+        var snapshot = CurrentApp.ConnectionManager?.CurrentSnapshot;
         if (snapshot != null)
         {
             TitleOpDot.Fill = RoleDotBrush(snapshot.OperatorState);
@@ -225,35 +223,6 @@ public sealed partial class HubWindow : WindowEx
     };
 
     public GatewaySelfInfo? LastGatewaySelf => AppModel?.GatewaySelf;
-
-    public void UpdateGatewaySelf(GatewaySelfInfo self)
-    {
-        try
-        {
-            DispatcherQueue?.TryEnqueue(() =>
-            {
-                if (IsClosed) return;
-                UpdateTitleBarStatus(CurrentStatus);
-                if (ContentFrame?.Content is AboutPage about)
-                    about.RefreshGatewayInfo();
-            });
-        }
-        catch { }
-    }
-
-    public void UpdateAgentsList(System.Text.Json.JsonElement data)
-    {
-        try
-        {
-            DispatcherQueue?.TryEnqueue(() =>
-            {
-                if (IsClosed) return;
-                // Rebuild nav sidebar agent items
-                RebuildAgentNavItems(data);
-            });
-        }
-        catch { }
-    }
 
     private void RebuildAgentNavItems(System.Text.Json.JsonElement data)
     {
@@ -307,14 +276,15 @@ public sealed partial class HubWindow : WindowEx
     /// </summary>
     private void OnNavPaneStateChanged(NavigationView sender, object args)
     {
-        if (_settings == null) return;
+        var settings = CurrentApp.Settings;
+        if (settings == null) return;
         // PaneOpening fires BEFORE IsPaneOpen flips, PaneClosing fires
         // BEFORE it flips the other way. Use the event identity to know
         // the new state rather than reading IsPaneOpen.
         var newState = args is NavigationViewPaneClosingEventArgs ? false : true;
-        if (_settings.HubNavPaneOpen == newState) return;
-        _settings.HubNavPaneOpen = newState;
-        try { _settings.Save(); } catch { /* swallow — don't block UI */ }
+        if (settings.HubNavPaneOpen == newState) return;
+        settings.HubNavPaneOpen = newState;
+        try { settings.Save(); } catch { /* swallow — don't block UI */ }
     }
 
     private void InitializeCurrentPage()
@@ -338,7 +308,7 @@ public sealed partial class HubWindow : WindowEx
             case InstancesPage instances: instances.Initialize(); break;
             case PermissionsPage permissions: permissions.Initialize(); break;
             case SandboxPage sandbox: sandbox.Initialize(); break;
-            case VoiceSettingsPage voice: voice.Initialize(VoiceServiceInstance); break;
+            case VoiceSettingsPage voice: voice.Initialize(CurrentApp.VoiceService); break;
             case ActivityPage activity: activity.Initialize(); break;
             case AgentEventsPage agentEvents:
                 agentEvents.Initialize(this);
@@ -521,42 +491,43 @@ public sealed partial class HubWindow : WindowEx
 
             // Actions
             new() { Icon = "💬", Title = "Open Chat Window", Subtitle = "Open standalone chat", Tag = "chat" },
-            new() { Icon = "🌐", Title = "Open Dashboard", Subtitle = "Open web dashboard", Execute = () => OpenDashboardAction?.Invoke(null) },
+            new() { Icon = "🌐", Title = "Open Dashboard", Subtitle = "Open web dashboard", Execute = () => ((IAppCommands)Application.Current).OpenDashboard(null) },
             new() { Icon = "📤", Title = "Quick Send", Subtitle = "Send a quick message", Execute = () => QuickSendAction?.Invoke() },
         };
 
         // Toggle commands
-        if (Settings != null)
+        var settings = CurrentApp.Settings;
+        if (settings != null)
         {
             commands.Add(new CommandItem
             {
                 Icon = "🔌", Title = "Toggle Node Mode",
-                Subtitle = Settings.EnableNodeMode ? "Currently ON" : "Currently OFF",
-                Execute = () => { Settings.EnableNodeMode = !Settings.EnableNodeMode; Settings.Save(); RaiseSettingsSaved(); }
+                Subtitle = settings.EnableNodeMode ? "Currently ON" : "Currently OFF",
+                Execute = () => { settings.EnableNodeMode = !settings.EnableNodeMode; settings.Save(); RaiseSettingsSaved(); }
             });
             commands.Add(new CommandItem
             {
                 Icon = "📷", Title = "Toggle Camera",
-                Subtitle = Settings.NodeCameraEnabled ? "Currently ON" : "Currently OFF",
-                Execute = () => { Settings.NodeCameraEnabled = !Settings.NodeCameraEnabled; Settings.Save(); RaiseSettingsSaved(); }
+                Subtitle = settings.NodeCameraEnabled ? "Currently ON" : "Currently OFF",
+                Execute = () => { settings.NodeCameraEnabled = !settings.NodeCameraEnabled; settings.Save(); RaiseSettingsSaved(); }
             });
             commands.Add(new CommandItem
             {
                 Icon = "🎨", Title = "Toggle Canvas",
-                Subtitle = Settings.NodeCanvasEnabled ? "Currently ON" : "Currently OFF",
-                Execute = () => { Settings.NodeCanvasEnabled = !Settings.NodeCanvasEnabled; Settings.Save(); RaiseSettingsSaved(); }
+                Subtitle = settings.NodeCanvasEnabled ? "Currently ON" : "Currently OFF",
+                Execute = () => { settings.NodeCanvasEnabled = !settings.NodeCanvasEnabled; settings.Save(); RaiseSettingsSaved(); }
             });
             commands.Add(new CommandItem
             {
                 Icon = "🖥️", Title = "Toggle Screen Capture",
-                Subtitle = Settings.NodeScreenEnabled ? "Currently ON" : "Currently OFF",
-                Execute = () => { Settings.NodeScreenEnabled = !Settings.NodeScreenEnabled; Settings.Save(); RaiseSettingsSaved(); }
+                Subtitle = settings.NodeScreenEnabled ? "Currently ON" : "Currently OFF",
+                Execute = () => { settings.NodeScreenEnabled = !settings.NodeScreenEnabled; settings.Save(); RaiseSettingsSaved(); }
             });
             commands.Add(new CommandItem
             {
                 Icon = "🌐", Title = "Toggle Browser Control",
-                Subtitle = Settings.NodeBrowserProxyEnabled ? "Currently ON" : "Currently OFF",
-                Execute = () => { Settings.NodeBrowserProxyEnabled = !Settings.NodeBrowserProxyEnabled; Settings.Save(); RaiseSettingsSaved(); }
+                Subtitle = settings.NodeBrowserProxyEnabled ? "Currently ON" : "Currently OFF",
+                Execute = () => { settings.NodeBrowserProxyEnabled = !settings.NodeBrowserProxyEnabled; settings.Save(); RaiseSettingsSaved(); }
             });
         }
 
@@ -571,7 +542,7 @@ public sealed partial class HubWindow : WindowEx
                 {
                     Icon = "🧠", Title = $"Go to session: {key}",
                     Subtitle = "Open in dashboard",
-                    Execute = () => OpenDashboardAction?.Invoke($"sessions/{key}")
+                    Execute = () => ((IAppCommands)Application.Current).OpenDashboard($"sessions/{key}")
                 });
             }
         }

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -182,8 +182,6 @@ public sealed partial class HubWindow : WindowEx
                 if (IsClosed) return;
                 CurrentStatus = status;
                 _cachedCommands = null;
-                if (status == ConnectionStatus.Disconnected && AppModel != null)
-                    AppModel.GatewaySelf = null;
                 UpdateTitleBarStatus(status);
                 if (ContentFrame?.Content is ConnectionPage connectionPage)
                 {

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -56,6 +56,7 @@ public sealed partial class HubWindow : WindowEx
         if (AppModel != null)
         {
             AppModel.PropertyChanged += OnAppModelChanged;
+            UpdateGatewayNavVisibility(AppModel.Status == ConnectionStatus.Connected);
         }
     }
 
@@ -71,7 +72,9 @@ public sealed partial class HubWindow : WindowEx
                     {
                         if (IsClosed) return;
                         _cachedCommands = null;
-                        UpdateTitleBarStatus(AppModel!.Status);
+                        var status = AppModel!.Status;
+                        UpdateTitleBarStatus(status);
+                        UpdateGatewayNavVisibility(status == ConnectionStatus.Connected);
                 });
                 break;
             case nameof(AppState.GatewaySelf):
@@ -229,6 +232,37 @@ public sealed partial class HubWindow : WindowEx
             new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Red),
         _ => new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Gray),
     };
+
+    private void UpdateGatewayNavVisibility(bool connected)
+    {
+        var vis = connected ? Visibility.Visible : Visibility.Collapsed;
+        NavChat.Visibility = vis;
+        NavSessions.Visibility = vis;
+        NavSkills.Visibility = vis;
+        NavChannels.Visibility = vis;
+        NavInstances.Visibility = vis;
+        NavAdvanced.Visibility = vis;
+        NavGatewaySeparator.Visibility = vis;
+        // Keep NavGatewayHeader visible always (Connection is under it)
+
+        // If currently viewing a hidden page, navigate to Connection
+        if (!connected)
+        {
+            var currentTag = (NavView?.SelectedItem as NavigationViewItem)?.Tag as string;
+            var gatewayTags = new HashSet<string> { "chat", "sessions", "skills", "channels", "instances", "agentevents", "bindings", "config", "usage", "cron", "workspace" };
+            if (currentTag != null && (gatewayTags.Contains(currentTag) || currentTag.StartsWith("agent:")))
+            {
+                foreach (NavigationViewItem item in NavView.MenuItems.OfType<NavigationViewItem>())
+                {
+                    if (item.Tag as string == "connection")
+                    {
+                        NavView.SelectedItem = item;
+                        break;
+                    }
+                }
+            }
+        }
+    }
 
     public GatewaySelfInfo? LastGatewaySelf => AppModel?.GatewaySelf;
 

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -35,6 +35,7 @@ public sealed partial class HubWindow : WindowEx
     }
     public IOperatorGatewayClient? GatewayClient { get; set; }
     public ConnectionStatus CurrentStatus { get; set; }
+    internal AppState? AppModel { get; set; }
     private string _currentAgentId = "main";
     public string CurrentAgentId => _currentAgentId;
 
@@ -60,20 +61,20 @@ public sealed partial class HubWindow : WindowEx
     public VoiceService? VoiceServiceInstance { get; set; }
     public string? NodeFullDeviceId { get; set; }
 
-    // Cached gateway data — pages read these on navigation
-    public SessionInfo[]? LastSessions { get; private set; }
-    public ChannelHealth[]? LastChannels { get; private set; }
-    public GatewayUsageInfo? LastUsage { get; private set; }
-    public GatewayCostUsageInfo? LastUsageCost { get; private set; }
-    public GatewayUsageStatusInfo? LastUsageStatus { get; private set; }
-    public GatewayNodeInfo[]? LastNodes { get; private set; }
+    // Gateway data — read-through from AppModel (single source of truth)
+    public SessionInfo[]? LastSessions => AppModel?.Sessions;
+    public ChannelHealth[]? LastChannels => AppModel?.Channels;
+    public GatewayUsageInfo? LastUsage => AppModel?.Usage;
+    public GatewayCostUsageInfo? LastUsageCost => AppModel?.UsageCost;
+    public GatewayUsageStatusInfo? LastUsageStatus => AppModel?.UsageStatus;
+    public GatewayNodeInfo[]? LastNodes => AppModel?.Nodes;
 
-    public System.Text.Json.JsonElement? LastConfig { get; private set; }
-    public System.Text.Json.JsonElement? LastConfigSchema { get; private set; }
-    public System.Text.Json.JsonElement? LastSkillsData { get; private set; }
-    public string? LastSkillsAgentId { get; private set; }
-    public System.Text.Json.JsonElement? LastAgentFilesList { get; private set; }
-    public string? LastAgentFilesListAgentId { get; private set; }
+    public System.Text.Json.JsonElement? LastConfig => AppModel?.Config;
+    public System.Text.Json.JsonElement? LastConfigSchema => AppModel?.ConfigSchema;
+    public System.Text.Json.JsonElement? LastSkillsData => AppModel?.SkillsData;
+    public string? LastSkillsAgentId => AppModel?.SkillsAgentId;
+    public System.Text.Json.JsonElement? LastAgentFilesList => AppModel?.AgentFilesList;
+    public string? LastAgentFilesListAgentId => AppModel?.AgentFilesListAgentId;
     private string? _pendingAgentFilesListAgentId;
 
     // Event for settings saved (App.xaml.cs subscribes)
@@ -181,8 +182,8 @@ public sealed partial class HubWindow : WindowEx
                 if (IsClosed) return;
                 CurrentStatus = status;
                 _cachedCommands = null;
-                if (status == ConnectionStatus.Disconnected)
-                    _lastGatewaySelf = null;
+                if (status == ConnectionStatus.Disconnected && AppModel != null)
+                    AppModel.GatewaySelf = null;
                 UpdateTitleBarStatus(status);
                 if (ContentFrame?.Content is ConnectionPage connectionPage)
                 {
@@ -206,7 +207,7 @@ public sealed partial class HubWindow : WindowEx
         TitleStatusDot.Fill = new Microsoft.UI.Xaml.Media.SolidColorBrush(color);
 
         // Build status text with version when connected
-        if (status == ConnectionStatus.Connected && _lastGatewaySelf is { ServerVersion: { Length: > 0 } ver })
+        if (status == ConnectionStatus.Connected && LastGatewaySelf is { ServerVersion: { Length: > 0 } ver })
             TitleStatusText.Text = $"v{ver}";
         else
             TitleStatusText.Text = text;
@@ -241,12 +242,10 @@ public sealed partial class HubWindow : WindowEx
         _ => new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Gray),
     };
 
-    private GatewaySelfInfo? _lastGatewaySelf;
-    public GatewaySelfInfo? LastGatewaySelf => _lastGatewaySelf;
+    public GatewaySelfInfo? LastGatewaySelf => AppModel?.GatewaySelf;
 
     public void UpdateGatewaySelf(GatewaySelfInfo self)
     {
-        _lastGatewaySelf = self;
         try
         {
             DispatcherQueue?.TryEnqueue(() =>
@@ -262,7 +261,6 @@ public sealed partial class HubWindow : WindowEx
 
     public void UpdateSessions(SessionInfo[] sessions)
     {
-        LastSessions = sessions;
         if (IsClosed) return;
         DispatcherQueue?.TryEnqueue(() =>
         {
@@ -273,7 +271,6 @@ public sealed partial class HubWindow : WindowEx
 
     public void UpdateChannelHealth(ChannelHealth[] channels)
     {
-        LastChannels = channels;
         if (IsClosed) return;
         DispatcherQueue?.TryEnqueue(() =>
         {
@@ -284,7 +281,6 @@ public sealed partial class HubWindow : WindowEx
 
     public void UpdateUsage(GatewayUsageInfo usage)
     {
-        LastUsage = usage;
         if (IsClosed) return;
         DispatcherQueue?.TryEnqueue(() =>
         {
@@ -294,7 +290,6 @@ public sealed partial class HubWindow : WindowEx
 
     public void UpdateUsageCost(GatewayCostUsageInfo cost)
     {
-        LastUsageCost = cost;
         if (IsClosed) return;
         DispatcherQueue?.TryEnqueue(() =>
         {
@@ -305,7 +300,6 @@ public sealed partial class HubWindow : WindowEx
 
     public void UpdateUsageStatus(GatewayUsageStatusInfo status)
     {
-        LastUsageStatus = status;
         if (IsClosed) return;
         DispatcherQueue?.TryEnqueue(() =>
         {
@@ -315,7 +309,6 @@ public sealed partial class HubWindow : WindowEx
 
     public void UpdateNodes(GatewayNodeInfo[] nodes)
     {
-        LastNodes = nodes;
         if (IsClosed) return;
         DispatcherQueue?.TryEnqueue(() =>
         {
@@ -323,13 +316,10 @@ public sealed partial class HubWindow : WindowEx
         });
     }
 
-    // Cached cron data for when CronPage isn't active
-    private System.Text.Json.JsonElement? _lastCronList;
-    private System.Text.Json.JsonElement? _lastCronStatus;
+    // Cron data — read-through from AppModel (no private cache needed)
 
     public void UpdateCronList(System.Text.Json.JsonElement data)
     {
-        _lastCronList = data.Clone();
         try
         {
             DispatcherQueue?.TryEnqueue(() =>
@@ -343,7 +333,6 @@ public sealed partial class HubWindow : WindowEx
 
     public void UpdateCronStatus(System.Text.Json.JsonElement data)
     {
-        _lastCronStatus = data.Clone();
         try
         {
             DispatcherQueue?.TryEnqueue(() =>
@@ -370,14 +359,13 @@ public sealed partial class HubWindow : WindowEx
 
     public void SeedCronData(CronPage page)
     {
-        if (_lastCronList.HasValue) page.UpdateFromGateway(_lastCronList.Value);
-        if (_lastCronStatus.HasValue) page.UpdateFromGateway(_lastCronStatus.Value);
+        if (AppModel?.CronList.HasValue == true) page.UpdateFromGateway(AppModel.CronList.Value);
+        if (AppModel?.CronStatus.HasValue == true) page.UpdateFromGateway(AppModel.CronStatus.Value);
     }
 
     public void UpdateConfig(System.Text.Json.JsonElement config)
     {
         var snapshot = config.Clone();
-        LastConfig = snapshot;
         if (IsClosed) return;
         DispatcherQueue?.TryEnqueue(() =>
         {
@@ -389,7 +377,6 @@ public sealed partial class HubWindow : WindowEx
     public void UpdateConfigSchema(System.Text.Json.JsonElement schema)
     {
         var snapshot = schema.Clone();
-        LastConfigSchema = snapshot;
         if (IsClosed) return;
         try
         {
@@ -407,13 +394,11 @@ public sealed partial class HubWindow : WindowEx
         try
         {
             var snapshot = data.Clone();
-            LastSkillsData = snapshot;
             DispatcherQueue?.TryEnqueue(() =>
             {
                 if (IsClosed) return;
                 if (ContentFrame?.Content is SkillsPage sp)
                 {
-                    LastSkillsAgentId = sp.CurrentAgentId;
                     sp.UpdateFromGateway(snapshot);
                 }
             });
@@ -423,7 +408,6 @@ public sealed partial class HubWindow : WindowEx
 
     public void UpdateAgentsList(System.Text.Json.JsonElement data)
     {
-        LastAgentsData = data;
         try
         {
             DispatcherQueue?.TryEnqueue(() =>
@@ -461,22 +445,7 @@ public sealed partial class HubWindow : WindowEx
     }
 
     /// <summary>Extract agent IDs from cached agents data.</summary>
-    public List<string> GetAgentIds()
-    {
-        var ids = new List<string>();
-        if (LastAgentsData.HasValue &&
-            LastAgentsData.Value.TryGetProperty("agents", out var agentsEl) &&
-            agentsEl.ValueKind == System.Text.Json.JsonValueKind.Array)
-        {
-            foreach (var agent in agentsEl.EnumerateArray())
-            {
-                var id = agent.TryGetProperty("id", out var idEl) ? idEl.GetString() ?? "" : "";
-                if (!string.IsNullOrEmpty(id)) ids.Add(id);
-            }
-        }
-        if (ids.Count == 0) ids.Add("main");
-        return ids;
-    }
+    public List<string> GetAgentIds() => AppModel?.GetAgentIds() ?? new List<string> { "main" };
 
     public void RecordAgentFilesListRequest(string agentId)
     {
@@ -490,8 +459,6 @@ public sealed partial class HubWindow : WindowEx
             var snapshot = data.Clone();
             var responseAgentId = _pendingAgentFilesListAgentId ?? _currentAgentId;
             _pendingAgentFilesListAgentId = null;
-            LastAgentFilesListAgentId = responseAgentId;
-            LastAgentFilesList = snapshot;
             DispatcherQueue?.TryEnqueue(() =>
             {
                 if (IsClosed) return;
@@ -519,11 +486,7 @@ public sealed partial class HubWindow : WindowEx
         catch { }
     }
 
-    // Agent events ring buffer (max 400, cached centrally)
-    // All mutations happen on the UI thread via DispatcherQueue
-    private const int MaxAgentEvents = 400;
-    private readonly System.Collections.Generic.List<AgentEventInfo> _agentEvents = new();
-    public System.Collections.Generic.IReadOnlyList<AgentEventInfo> LastAgentEvents => _agentEvents;
+    public System.Collections.Generic.IReadOnlyList<AgentEventInfo> LastAgentEvents => AppModel?.AgentEvents ?? (System.Collections.Generic.IReadOnlyList<AgentEventInfo>)Array.Empty<AgentEventInfo>();
 
     /// <summary>Called by App to also clear its own agent event cache when Clear is invoked.</summary>
     public Action? ClearAppAgentEventsCache { get; set; }
@@ -532,25 +495,21 @@ public sealed partial class HubWindow : WindowEx
     {
         DispatcherQueue?.TryEnqueue(() =>
         {
-            _agentEvents.Clear();
+            AppModel?.ClearAgentEvents();
             ClearAppAgentEventsCache?.Invoke();
         });
     }
 
-    /// <summary>Seed the hub's agent event cache from App-level cache (deduplicates by RunId+Seq).</summary>
-    public void SeedAgentEvents(IReadOnlyList<AgentEventInfo> appCache)
+    /// <summary>Seed the currently visible AgentEventsPage from AppModel.</summary>
+    public void SeedAgentEvents()
     {
         DispatcherQueue?.TryEnqueue(() =>
         {
-            var existingKeys = new System.Collections.Generic.HashSet<(string, int)>(
-                _agentEvents.Select(e => (e.RunId, e.Seq)));
-            foreach (var evt in appCache)
+            if (ContentFrame?.Content is AgentEventsPage page)
             {
-                if (!existingKeys.Contains((evt.RunId, evt.Seq)))
-                {
-                    _agentEvents.Add(evt);
-                    if (_agentEvents.Count >= MaxAgentEvents) break;
-                }
+                var events = AppModel?.AgentEvents ?? (System.Collections.Generic.IReadOnlyList<AgentEventInfo>)Array.Empty<AgentEventInfo>();
+                foreach (var evt in events)
+                    page.AddEvent(evt);
             }
         });
     }
@@ -562,23 +521,19 @@ public sealed partial class HubWindow : WindowEx
             DispatcherQueue?.TryEnqueue(() =>
             {
                 if (IsClosed) return;
-                _agentEvents.Insert(0, evt);
-                if (_agentEvents.Count > MaxAgentEvents)
-                    _agentEvents.RemoveRange(MaxAgentEvents, _agentEvents.Count - MaxAgentEvents);
                 if (ContentFrame?.Content is AgentEventsPage agentEvents) agentEvents.AddEvent(evt);
             });
         }
         catch { }
     }
 
-    // Pairing data
-    public PairingListInfo? LastNodePairList { get; private set; }
-    public DevicePairingListInfo? LastDevicePairList { get; private set; }
-    public ModelsListInfo? LastModelsList { get; private set; }
+    // Pairing data — read-through from AppModel
+    public PairingListInfo? LastNodePairList => AppModel?.NodePairList;
+    public DevicePairingListInfo? LastDevicePairList => AppModel?.DevicePairList;
+    public ModelsListInfo? LastModelsList => AppModel?.ModelsList;
 
     public void UpdateNodePairList(PairingListInfo data)
     {
-        LastNodePairList = data;
         try
         {
             DispatcherQueue?.TryEnqueue(() =>
@@ -594,7 +549,6 @@ public sealed partial class HubWindow : WindowEx
 
     public void UpdateDevicePairList(DevicePairingListInfo data)
     {
-        LastDevicePairList = data;
         try
         {
             DispatcherQueue?.TryEnqueue(() =>
@@ -608,7 +562,6 @@ public sealed partial class HubWindow : WindowEx
 
     public void UpdateModelsList(ModelsListInfo data)
     {
-        LastModelsList = data;
         try
         {
             DispatcherQueue?.TryEnqueue(() =>
@@ -620,12 +573,11 @@ public sealed partial class HubWindow : WindowEx
         catch { }
     }
 
-    public PresenceEntry[]? LastPresence { get; private set; }
-    public System.Text.Json.JsonElement? LastAgentsData { get; private set; }
+    public PresenceEntry[]? LastPresence => AppModel?.Presence;
+    public System.Text.Json.JsonElement? LastAgentsData => AppModel?.AgentsList;
 
     public void UpdatePresence(PresenceEntry[] data)
     {
-        LastPresence = data;
         try
         {
             DispatcherQueue?.TryEnqueue(() =>

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -74,7 +74,12 @@ public sealed partial class HubWindow : WindowEx
                         _cachedCommands = null;
                         var status = AppModel!.Status;
                         UpdateTitleBarStatus(status);
-                        UpdateGatewayNavVisibility(status == ConnectionStatus.Connected);
+                        // Defer nav visibility to avoid stowed exceptions during NavigationView layout
+                        DispatcherQueue?.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
+                        {
+                            if (IsClosed) return;
+                            UpdateGatewayNavVisibility(AppModel!.Status == ConnectionStatus.Connected);
+                        });
                 });
                 break;
             case nameof(AppState.GatewaySelf):
@@ -99,6 +104,7 @@ public sealed partial class HubWindow : WindowEx
         catch (Exception ex)
         {
             Services.Logger.Warn($"[HubWindow] OnAppModelChanged({e.PropertyName}) failed: {ex.Message}");
+            throw;
         }
     }
 
@@ -235,32 +241,38 @@ public sealed partial class HubWindow : WindowEx
 
     private void UpdateGatewayNavVisibility(bool connected)
     {
-        var vis = connected ? Visibility.Visible : Visibility.Collapsed;
-        NavChat.Visibility = vis;
-        NavSessions.Visibility = vis;
-        NavSkills.Visibility = vis;
-        NavChannels.Visibility = vis;
-        NavInstances.Visibility = vis;
-        NavAdvanced.Visibility = vis;
-        NavGatewaySeparator.Visibility = vis;
-        // Keep NavGatewayHeader visible always (Connection is under it)
-
-        // If currently viewing a hidden page, navigate to Connection
-        if (!connected)
+        try
         {
-            var currentTag = (NavView?.SelectedItem as NavigationViewItem)?.Tag as string;
-            var gatewayTags = new HashSet<string> { "chat", "sessions", "skills", "channels", "instances", "agentevents", "bindings", "config", "usage", "cron", "workspace" };
-            if (currentTag != null && (gatewayTags.Contains(currentTag) || currentTag.StartsWith("agent:")))
+            var vis = connected ? Visibility.Visible : Visibility.Collapsed;
+            NavChat.Visibility = vis;
+            NavSessions.Visibility = vis;
+            NavSkills.Visibility = vis;
+            NavChannels.Visibility = vis;
+            NavInstances.Visibility = vis;
+            NavAdvanced.Visibility = vis;
+            NavGatewaySeparator.Visibility = vis;
+
+            if (!connected)
             {
-                foreach (NavigationViewItem item in NavView.MenuItems.OfType<NavigationViewItem>())
+                var currentTag = (NavView?.SelectedItem as NavigationViewItem)?.Tag as string;
+                var gatewayTags = new HashSet<string> { "chat", "sessions", "skills", "channels", "instances", "agentevents", "bindings", "config", "usage", "cron", "workspace" };
+                if (currentTag != null && (gatewayTags.Contains(currentTag) || currentTag.StartsWith("agent:")))
                 {
-                    if (item.Tag as string == "connection")
+                    foreach (NavigationViewItem item in NavView.MenuItems.OfType<NavigationViewItem>())
                     {
-                        NavView.SelectedItem = item;
-                        break;
+                        if (item.Tag as string == "connection")
+                        {
+                            NavView.SelectedItem = item;
+                            break;
+                        }
                     }
                 }
             }
+        }
+        catch (Exception ex)
+        {
+            Services.Logger.Warn($"[HubWindow] UpdateGatewayNavVisibility failed: {ex.Message}");
+            throw;
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -321,25 +321,25 @@ public sealed partial class HubWindow : WindowEx
     {
         switch (ContentFrame.Content)
         {
-            case ChatPage chat: chat.Initialize(this); break;
-            case SessionsPage sessions: sessions.Initialize(this); break;
-            case ConnectionPage connection: connection.Initialize(this); break;
-            case ChannelsPage channels: channels.Initialize(this); break;
-            case UsagePage usage: usage.Initialize(this); break;
-            case CronPage cron: cron.Initialize(this); break;
-            case SkillsPage skills: skills.Initialize(this); break;
+            case ChatPage chat: chat.Initialize(); break;
+            case SessionsPage sessions: sessions.Initialize(); break;
+            case ConnectionPage connection: connection.Initialize(); break;
+            case ChannelsPage channels: channels.Initialize(); break;
+            case UsagePage usage: usage.Initialize(); break;
+            case CronPage cron: cron.Initialize(); break;
+            case SkillsPage skills: skills.Initialize(); break;
             case ConfigPage config:
-                try { config.Initialize(this); }
+                try { config.Initialize(); }
                 catch (Exception ex)
                 {
                     OpenClawTray.Services.Logger.Error($"[HubWindow] ConfigPage seed failed: {ex}");
                 }
                 break;
-            case InstancesPage instances: instances.Initialize(this); break;
-            case PermissionsPage permissions: permissions.Initialize(this); break;
-            case SandboxPage sandbox: sandbox.Initialize(this); break;
-            case VoiceSettingsPage voice: voice.Initialize(this, VoiceServiceInstance); break;
-            case ActivityPage activity: activity.Initialize(this); break;
+            case InstancesPage instances: instances.Initialize(); break;
+            case PermissionsPage permissions: permissions.Initialize(); break;
+            case SandboxPage sandbox: sandbox.Initialize(); break;
+            case VoiceSettingsPage voice: voice.Initialize(VoiceServiceInstance); break;
+            case ActivityPage activity: activity.Initialize(); break;
             case AgentEventsPage agentEvents:
                 agentEvents.ClearCentralCache = () => AppModel?.ClearAgentEvents();
                 agentEvents.PopulateAgentFilter(this);
@@ -347,11 +347,14 @@ public sealed partial class HubWindow : WindowEx
                 var eventsAgentFilter = agentEventsTag?.StartsWith("agent:") == true ? _currentAgentId : null;
                 agentEvents.SetAgentFilter(eventsAgentFilter);
                 break;
-            case WorkspacePage workspace: workspace.Initialize(this); break;
-            case BindingsPage bindings: bindings.Initialize(this); break;
-            case SettingsPage settings: settings.Initialize(this); break;
-            case DebugPage debug: debug.Initialize(this); break;
-            case AboutPage about: about.Initialize(this); break;
+            case WorkspacePage workspace:
+                workspace.AgentId = _currentAgentId;
+                workspace.Initialize();
+                break;
+            case BindingsPage bindings: bindings.Initialize(); break;
+            case SettingsPage settings: settings.Initialize(); break;
+            case DebugPage debug: debug.Initialize(); break;
+            case AboutPage about: about.Initialize(); break;
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -341,11 +341,18 @@ public sealed partial class HubWindow : WindowEx
             case VoiceSettingsPage voice: voice.Initialize(VoiceServiceInstance); break;
             case ActivityPage activity: activity.Initialize(); break;
             case AgentEventsPage agentEvents:
+                agentEvents.Initialize(this);
                 agentEvents.ClearCentralCache = () => AppModel?.ClearAgentEvents();
                 agentEvents.PopulateAgentFilter(this);
                 var agentEventsTag = (NavView?.SelectedItem as NavigationViewItem)?.Tag as string;
                 var eventsAgentFilter = agentEventsTag?.StartsWith("agent:") == true ? _currentAgentId : null;
                 agentEvents.SetAgentFilter(eventsAgentFilter);
+                // Seed existing events from AppState
+                if (agentEvents.EventCount == 0 && AppModel?.AgentEvents is { Count: > 0 } events)
+                {
+                    for (int i = events.Count - 1; i >= 0; i--)
+                        agentEvents.AddEvent(events[i]);
+                }
                 break;
             case WorkspacePage workspace:
                 workspace.AgentId = _currentAgentId;

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -61,22 +61,6 @@ public sealed partial class HubWindow : WindowEx
     public VoiceService? VoiceServiceInstance { get; set; }
     public string? NodeFullDeviceId { get; set; }
 
-    // Gateway data — read-through from AppModel (single source of truth)
-    public SessionInfo[]? LastSessions => AppModel?.Sessions;
-    public ChannelHealth[]? LastChannels => AppModel?.Channels;
-    public GatewayUsageInfo? LastUsage => AppModel?.Usage;
-    public GatewayCostUsageInfo? LastUsageCost => AppModel?.UsageCost;
-    public GatewayUsageStatusInfo? LastUsageStatus => AppModel?.UsageStatus;
-    public GatewayNodeInfo[]? LastNodes => AppModel?.Nodes;
-
-    public System.Text.Json.JsonElement? LastConfig => AppModel?.Config;
-    public System.Text.Json.JsonElement? LastConfigSchema => AppModel?.ConfigSchema;
-    public System.Text.Json.JsonElement? LastSkillsData => AppModel?.SkillsData;
-    public string? LastSkillsAgentId => AppModel?.SkillsAgentId;
-    public System.Text.Json.JsonElement? LastAgentFilesList => AppModel?.AgentFilesList;
-    public string? LastAgentFilesListAgentId => AppModel?.AgentFilesListAgentId;
-    private string? _pendingAgentFilesListAgentId;
-
     // Event for settings saved (App.xaml.cs subscribes)
     public event EventHandler? SettingsSaved;
 
@@ -257,153 +241,6 @@ public sealed partial class HubWindow : WindowEx
         catch { }
     }
 
-    public void UpdateSessions(SessionInfo[] sessions)
-    {
-        if (IsClosed) return;
-        DispatcherQueue?.TryEnqueue(() =>
-        {
-            if (ContentFrame?.Content is SessionsPage sp) sp.UpdateSessions(sessions);
-            else if (ContentFrame?.Content is ConnectionPage cp) cp.OnGlanceDataChanged();
-        });
-    }
-
-    public void UpdateChannelHealth(ChannelHealth[] channels)
-    {
-        if (IsClosed) return;
-        DispatcherQueue?.TryEnqueue(() =>
-        {
-            if (ContentFrame?.Content is ChannelsPage cp) cp.UpdateChannels(channels);
-            else if (ContentFrame?.Content is ConnectionPage connection) connection.OnGlanceDataChanged();
-        });
-    }
-
-    public void UpdateUsage(GatewayUsageInfo usage)
-    {
-        if (IsClosed) return;
-        DispatcherQueue?.TryEnqueue(() =>
-        {
-            if (ContentFrame?.Content is UsagePage up) up.UpdateUsage(usage);
-        });
-    }
-
-    public void UpdateUsageCost(GatewayCostUsageInfo cost)
-    {
-        if (IsClosed) return;
-        DispatcherQueue?.TryEnqueue(() =>
-        {
-            if (ContentFrame?.Content is UsagePage up) up.UpdateUsageCost(cost);
-            else if (ContentFrame?.Content is ConnectionPage cp) cp.OnGlanceDataChanged();
-        });
-    }
-
-    public void UpdateUsageStatus(GatewayUsageStatusInfo status)
-    {
-        if (IsClosed) return;
-        DispatcherQueue?.TryEnqueue(() =>
-        {
-            if (ContentFrame?.Content is UsagePage up) up.UpdateUsageStatus(status);
-        });
-    }
-
-    public void UpdateNodes(GatewayNodeInfo[] nodes)
-    {
-        if (IsClosed) return;
-        DispatcherQueue?.TryEnqueue(() =>
-        {
-            if (ContentFrame?.Content is InstancesPage ip) ip.UpdateNodes(nodes);
-        });
-    }
-
-    // Cron data — read-through from AppModel (no private cache needed)
-
-    public void UpdateCronList(System.Text.Json.JsonElement data)
-    {
-        try
-        {
-            DispatcherQueue?.TryEnqueue(() =>
-            {
-                if (IsClosed) return;
-                if (ContentFrame?.Content is CronPage cp) cp.UpdateFromGateway(data);
-            });
-        }
-        catch { }
-    }
-
-    public void UpdateCronStatus(System.Text.Json.JsonElement data)
-    {
-        try
-        {
-            DispatcherQueue?.TryEnqueue(() =>
-            {
-                if (IsClosed) return;
-                if (ContentFrame?.Content is CronPage cp) cp.UpdateFromGateway(data);
-            });
-        }
-        catch { }
-    }
-
-    public void UpdateCronRuns(System.Text.Json.JsonElement data)
-    {
-        try
-        {
-            DispatcherQueue?.TryEnqueue(() =>
-            {
-                if (IsClosed) return;
-                if (ContentFrame?.Content is CronPage cp) cp.UpdateCronRuns(data);
-            });
-        }
-        catch { }
-    }
-
-    public void SeedCronData(CronPage page)
-    {
-        if (AppModel?.CronList.HasValue == true) page.UpdateFromGateway(AppModel.CronList.Value);
-        if (AppModel?.CronStatus.HasValue == true) page.UpdateFromGateway(AppModel.CronStatus.Value);
-    }
-
-    public void UpdateConfig(System.Text.Json.JsonElement config)
-    {
-        var snapshot = config.Clone();
-        if (IsClosed) return;
-        DispatcherQueue?.TryEnqueue(() =>
-        {
-            if (ContentFrame?.Content is ConfigPage cp) cp.UpdateConfig(snapshot);
-            else if (ContentFrame?.Content is BindingsPage bp) bp.UpdateConfig(snapshot);
-        });
-    }
-
-    public void UpdateConfigSchema(System.Text.Json.JsonElement schema)
-    {
-        var snapshot = schema.Clone();
-        if (IsClosed) return;
-        try
-        {
-            DispatcherQueue?.TryEnqueue(() =>
-            {
-                if (IsClosed) return;
-                if (ContentFrame?.Content is ConfigPage cp) cp.UpdateConfigSchema(snapshot);
-            });
-        }
-        catch { }
-    }
-
-    public void UpdateSkillsStatus(System.Text.Json.JsonElement data)
-    {
-        try
-        {
-            var snapshot = data.Clone();
-            DispatcherQueue?.TryEnqueue(() =>
-            {
-                if (IsClosed) return;
-                if (ContentFrame?.Content is SkillsPage sp)
-                {
-                    sp.UpdateFromGateway(snapshot);
-                }
-            });
-        }
-        catch { }
-    }
-
     public void UpdateAgentsList(System.Text.Json.JsonElement data)
     {
         try
@@ -445,147 +282,7 @@ public sealed partial class HubWindow : WindowEx
     /// <summary>Extract agent IDs from cached agents data.</summary>
     public List<string> GetAgentIds() => AppModel?.GetAgentIds() ?? new List<string> { "main" };
 
-    public void RecordAgentFilesListRequest(string agentId)
-    {
-        _pendingAgentFilesListAgentId = string.IsNullOrWhiteSpace(agentId) ? "main" : agentId;
-    }
-
-    public void UpdateAgentFilesList(System.Text.Json.JsonElement data)
-    {
-        try
-        {
-            var snapshot = data.Clone();
-            var responseAgentId = _pendingAgentFilesListAgentId ?? _currentAgentId;
-            _pendingAgentFilesListAgentId = null;
-            DispatcherQueue?.TryEnqueue(() =>
-            {
-                if (IsClosed) return;
-                if (ContentFrame?.Content is WorkspacePage wp &&
-                    string.Equals(wp.CurrentAgentId, responseAgentId, StringComparison.OrdinalIgnoreCase))
-                {
-                    wp.UpdateAgentFilesList(snapshot);
-                }
-            });
-        }
-        catch { }
-    }
-
-    public void UpdateAgentFileContent(System.Text.Json.JsonElement data)
-    {
-        try
-        {
-            var snapshot = data.Clone();
-            DispatcherQueue?.TryEnqueue(() =>
-            {
-                if (IsClosed) return;
-                if (ContentFrame?.Content is WorkspacePage wp) wp.UpdateAgentFileContent(snapshot);
-            });
-        }
-        catch { }
-    }
-
-    public System.Collections.Generic.IReadOnlyList<AgentEventInfo> LastAgentEvents => AppModel?.AgentEvents ?? (System.Collections.Generic.IReadOnlyList<AgentEventInfo>)Array.Empty<AgentEventInfo>();
-
-    /// <summary>Called by App to also clear its own agent event cache when Clear is invoked.</summary>
-    public Action? ClearAppAgentEventsCache { get; set; }
-
-    public void ClearAgentEvents()
-    {
-        DispatcherQueue?.TryEnqueue(() =>
-        {
-            AppModel?.ClearAgentEvents();
-            ClearAppAgentEventsCache?.Invoke();
-        });
-    }
-
-    /// <summary>Seed the currently visible AgentEventsPage from AppModel.</summary>
-    public void SeedAgentEvents()
-    {
-        DispatcherQueue?.TryEnqueue(() =>
-        {
-            if (ContentFrame?.Content is AgentEventsPage page)
-            {
-                var events = AppModel?.AgentEvents ?? (System.Collections.Generic.IReadOnlyList<AgentEventInfo>)Array.Empty<AgentEventInfo>();
-                foreach (var evt in events)
-                    page.AddEvent(evt);
-            }
-        });
-    }
-
-    public void UpdateAgentEvent(AgentEventInfo evt)
-    {
-        try
-        {
-            DispatcherQueue?.TryEnqueue(() =>
-            {
-                if (IsClosed) return;
-                if (ContentFrame?.Content is AgentEventsPage agentEvents) agentEvents.AddEvent(evt);
-            });
-        }
-        catch { }
-    }
-
-    // Pairing data — read-through from AppModel
-    public PairingListInfo? LastNodePairList => AppModel?.NodePairList;
-    public DevicePairingListInfo? LastDevicePairList => AppModel?.DevicePairList;
-    public ModelsListInfo? LastModelsList => AppModel?.ModelsList;
-
-    public void UpdateNodePairList(PairingListInfo data)
-    {
-        try
-        {
-            DispatcherQueue?.TryEnqueue(() =>
-            {
-                if (IsClosed) return;
-                // Operator/node pairing approval moved from NodesPage to ConnectionPage
-                // (single home for all pairing approvals).
-                if (ContentFrame?.Content is ConnectionPage cp) cp.UpdatePairingRequests(data);
-            });
-        }
-        catch { }
-    }
-
-    public void UpdateDevicePairList(DevicePairingListInfo data)
-    {
-        try
-        {
-            DispatcherQueue?.TryEnqueue(() =>
-            {
-                if (IsClosed) return;
-                if (ContentFrame?.Content is ConnectionPage cp) cp.UpdateDevicePairingRequests(data);
-            });
-        }
-        catch { }
-    }
-
-    public void UpdateModelsList(ModelsListInfo data)
-    {
-        try
-        {
-            DispatcherQueue?.TryEnqueue(() =>
-            {
-                if (IsClosed) return;
-                if (ContentFrame?.Content is SessionsPage sp) sp.UpdateModelsList(data);
-            });
-        }
-        catch { }
-    }
-
-    public PresenceEntry[]? LastPresence => AppModel?.Presence;
     public System.Text.Json.JsonElement? LastAgentsData => AppModel?.AgentsList;
-
-    public void UpdatePresence(PresenceEntry[] data)
-    {
-        try
-        {
-            DispatcherQueue?.TryEnqueue(() =>
-            {
-                if (IsClosed) return;
-                if (ContentFrame?.Content is InstancesPage ip) ip.UpdatePresence(data);
-            });
-        }
-        catch { }
-    }
 
     private void NavView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
     {
@@ -625,72 +322,33 @@ public sealed partial class HubWindow : WindowEx
         switch (ContentFrame.Content)
         {
             case ChatPage chat: chat.Initialize(this); break;
-            case SessionsPage sessions:
-                sessions.Initialize(this);
-                if (LastModelsList != null) sessions.UpdateModelsList(LastModelsList);
-                break;
-            case ConnectionPage connection:
-                connection.Initialize(this);
-                if (LastNodePairList != null) connection.UpdatePairingRequests(LastNodePairList);
-                if (LastDevicePairList != null) connection.UpdateDevicePairingRequests(LastDevicePairList);
-                break;
+            case SessionsPage sessions: sessions.Initialize(this); break;
+            case ConnectionPage connection: connection.Initialize(this); break;
             case ChannelsPage channels: channels.Initialize(this); break;
             case UsagePage usage: usage.Initialize(this); break;
-            case CronPage cron: cron.Initialize(this); SeedCronData(cron); break;
-            case SkillsPage skills:
-                skills.Initialize(this);
-                if (LastSkillsData.HasValue && LastSkillsAgentId == skills.CurrentAgentId)
-                    skills.UpdateFromGateway(LastSkillsData.Value);
-                break;
+            case CronPage cron: cron.Initialize(this); break;
+            case SkillsPage skills: skills.Initialize(this); break;
             case ConfigPage config:
-                try
-                {
-                    config.Initialize(this);
-                    if (LastConfigSchema.HasValue) config.UpdateConfigSchema(LastConfigSchema.Value);
-                    if (LastConfig.HasValue) config.UpdateConfig(LastConfig.Value);
-                }
+                try { config.Initialize(this); }
                 catch (Exception ex)
                 {
                     OpenClawTray.Services.Logger.Error($"[HubWindow] ConfigPage seed failed: {ex}");
                 }
                 break;
-            case InstancesPage instances:
-                // Initialize already seeds _lastNodes/_lastPresence from
-                // hub.LastNodes/hub.LastPresence and triggers a single
-                // Rerender. Calling UpdateNodes/UpdatePresence here would
-                // cause two additional dispatcher-queued rebuilds on every
-                // page entry — visible flicker on lists with many cards.
-                instances.Initialize(this);
-                break;
+            case InstancesPage instances: instances.Initialize(this); break;
             case PermissionsPage permissions: permissions.Initialize(this); break;
             case SandboxPage sandbox: sandbox.Initialize(this); break;
             case VoiceSettingsPage voice: voice.Initialize(this, VoiceServiceInstance); break;
             case ActivityPage activity: activity.Initialize(this); break;
             case AgentEventsPage agentEvents:
-                agentEvents.ClearCentralCache = ClearAgentEvents;
+                agentEvents.ClearCentralCache = () => AppModel?.ClearAgentEvents();
                 agentEvents.PopulateAgentFilter(this);
-                // When navigated via top-level nav (tag "agentevents"), show all agents
                 var agentEventsTag = (NavView?.SelectedItem as NavigationViewItem)?.Tag as string;
                 var eventsAgentFilter = agentEventsTag?.StartsWith("agent:") == true ? _currentAgentId : null;
                 agentEvents.SetAgentFilter(eventsAgentFilter);
-                if (agentEvents.EventCount == 0 && LastAgentEvents != null)
-                {
-                    for (int i = LastAgentEvents.Count - 1; i >= 0; i--)
-                        agentEvents.AddEvent(LastAgentEvents[i]);
-                }
                 break;
-            case WorkspacePage workspace:
-                workspace.Initialize(this);
-                if (LastAgentFilesList.HasValue &&
-                    string.Equals(LastAgentFilesListAgentId, workspace.CurrentAgentId, StringComparison.OrdinalIgnoreCase))
-                {
-                    workspace.UpdateAgentFilesList(LastAgentFilesList.Value);
-                }
-                break;
-            case BindingsPage bindings:
-                bindings.Initialize(this);
-                if (LastConfig.HasValue) bindings.UpdateConfig(LastConfig.Value);
-                break;
+            case WorkspacePage workspace: workspace.Initialize(this); break;
+            case BindingsPage bindings: bindings.Initialize(this); break;
             case SettingsPage settings: settings.Initialize(this); break;
             case DebugPage debug: debug.Initialize(this); break;
             case AboutPage about: about.Initialize(this); break;
@@ -893,9 +551,10 @@ public sealed partial class HubWindow : WindowEx
         }
 
         // Dynamic session commands
-        if (LastSessions != null)
+        var sessions = AppModel?.Sessions;
+        if (sessions != null)
         {
-            foreach (var session in LastSessions)
+            foreach (var session in sessions)
             {
                 var key = session.Key;
                 commands.Add(new CommandItem

--- a/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
@@ -120,7 +120,6 @@ public sealed partial class TrayMenuWindow : WindowEx
     private string? _activeFlyoutKey;
     private string? _activeFlyoutTag;
     private readonly Dictionary<string, (Button button, IReadOnlyList<TrayMenuFlyoutItem> items)> _flyoutsByTag = new(StringComparer.Ordinal);
-    public string? ActiveFlyoutTag => _activeFlyoutTag;
     private bool _isShown;
     /// <summary>True while the menu window is visible. App can use this to
     /// trigger an in-place rebuild when backing state changes mid-display.</summary>
@@ -202,7 +201,7 @@ public sealed partial class TrayMenuWindow : WindowEx
 
                 var foreground = GetForegroundWindow();
                 var thisHwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-                var flyoutHwnd = _activeFlyoutWindow != null
+                var flyoutHwnd = _activeFlyoutWindow != null && _activeFlyoutWindow._isShown
                     ? WinRT.Interop.WindowNative.GetWindowHandle(_activeFlyoutWindow)
                     : IntPtr.Zero;
                 var ownerHwnd = _ownerMenu != null
@@ -916,51 +915,6 @@ public sealed partial class TrayMenuWindow : WindowEx
         _isShown = false;
     }
 
-    /// <summary>
-    /// Re-measures content and resizes the window while keeping the bottom edge anchored.
-    /// </summary>
-    public void SizeToContentKeepBottom()
-    {
-        var oldPos = AppWindow.Position;
-        var oldSize = AppWindow.Size;
-        var oldBottom = oldPos.Y + oldSize.Height;
-
-        SizeToContent();
-
-        var newSize = AppWindow.Size;
-        var newY = oldBottom - newSize.Height;
-        if (TryGetCurrentMonitorWorkArea(out var workArea))
-        {
-            const int margin = 8;
-            newY = Math.Max(workArea.Top + margin, newY);
-            newY = Math.Min(workArea.Bottom - newSize.Height - margin, newY);
-        }
-
-        AppWindow.Move(new global::Windows.Graphics.PointInt32(oldPos.X, newY));
-        _lastMoveAndResizeRect = new global::Windows.Graphics.RectInt32(oldPos.X, newY, newSize.Width, newSize.Height);
-    }
-
-    private bool TryGetCurrentMonitorWorkArea(out RECT workArea)
-    {
-        var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-        var hMonitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-        if (hMonitor == IntPtr.Zero)
-        {
-            workArea = default;
-            return false;
-        }
-
-        var info = new MONITORINFO { cbSize = Marshal.SizeOf<MONITORINFO>() };
-        if (!GetMonitorInfo(hMonitor, ref info))
-        {
-            workArea = default;
-            return false;
-        }
-
-        workArea = info.rcWork;
-        return true;
-    }
-
     public void SizeToContent() => SizeToContent(MenuWidthViewUnits);
 
     /// <summary>
@@ -1150,6 +1104,15 @@ public sealed partial class TrayMenuWindow : WindowEx
 
         if (!ReferenceEquals(_activeFlyoutOwner, ownerButton) || !string.Equals(_activeFlyoutKey, flyoutKey, StringComparison.Ordinal))
         {
+            // Hide the submenu while repopulating so the user never sees
+            // an empty or stale panel. ShowAdjacentTo will re-show it once
+            // the new content has been measured and sized.
+            if (flyoutWindow._isShown)
+            {
+                flyoutWindow.Hide();
+                flyoutWindow._isShown = false;
+            }
+
             flyoutWindow.ClearItems();
             foreach (var item in items)
             {
@@ -1196,22 +1159,12 @@ public sealed partial class TrayMenuWindow : WindowEx
     private void HideActiveFlyout()
     {
         _activeFlyoutWindow?.HideCascade();
-        _activeFlyoutWindow = null;
+        // Keep _activeFlyoutWindow alive for reuse — creating a new WinUI
+        // window on every hover is expensive and causes content measurement
+        // failures before XamlRoot is initialized.
         _activeFlyoutOwner = null;
         _activeFlyoutKey = null;
         _activeFlyoutTag = null;
-    }
-
-    public bool TryRestoreCascade(string? tag)
-    {
-        if (string.IsNullOrEmpty(tag))
-            return false;
-
-        if (!_flyoutsByTag.TryGetValue(tag, out var entry))
-            return false;
-
-        ShowCascadingFlyout(entry.button, entry.items);
-        return true;
     }
 
     private static string CreateFlyoutKey(IEnumerable<TrayMenuFlyoutItem> items)
@@ -1301,7 +1254,7 @@ public sealed partial class TrayMenuWindow : WindowEx
                 break;
             case VirtualKey.Left:
             case VirtualKey.Escape:
-                if (_activeFlyoutWindow != null)
+                if (_activeFlyoutWindow != null && _activeFlyoutWindow._isShown)
                 {
                     HideActiveFlyout();
                 }
@@ -1325,7 +1278,7 @@ public sealed partial class TrayMenuWindow : WindowEx
             timer.Stop();
             var foreground = GetForegroundWindow();
             var thisHwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            var flyoutHwnd = _activeFlyoutWindow == null
+            var flyoutHwnd = _activeFlyoutWindow == null || !_activeFlyoutWindow._isShown
                 ? IntPtr.Zero
                 : WinRT.Interop.WindowNative.GetWindowHandle(_activeFlyoutWindow);
 

--- a/tests/OpenClaw.Tray.Tests/AppStateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppStateTests.cs
@@ -103,7 +103,8 @@ public class AppStateTests
         Assert.Null(state.Usage);
         Assert.Null(state.GatewaySelf);
         Assert.Null(state.NodePairList);
-        Assert.Null(state.AuthFailureMessage);
+        // AuthFailureMessage is NOT cleared by ClearCachedData (preserved for UI display)
+        Assert.Equal("test error", state.AuthFailureMessage);
         Assert.Null(state.CurrentActivity);
         Assert.Null(state.Config);
         Assert.Null(state.AgentsList);
@@ -112,7 +113,8 @@ public class AppStateTests
         Assert.Contains(nameof(AppState.Sessions), fired);
         Assert.Contains(nameof(AppState.Channels), fired);
         Assert.Contains(nameof(AppState.GatewaySelf), fired);
-        Assert.Contains(nameof(AppState.AuthFailureMessage), fired);
+        // AuthFailureMessage is NOT cleared by ClearCachedData
+        Assert.DoesNotContain(nameof(AppState.AuthFailureMessage), fired);
     }
 
     // ── AddAgentEvent ring buffer ───────────────────────────────────────

--- a/tests/OpenClaw.Tray.Tests/AppStateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppStateTests.cs
@@ -1,0 +1,255 @@
+using OpenClaw.Connection;
+using OpenClaw.Shared;
+using OpenClawTray.Services;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json;
+using Xunit;
+
+namespace OpenClaw.Tray.Tests;
+
+public class AppStateTests
+{
+    private AppState CreateState() => new();
+
+    // ── PropertyChanged ─────────────────────────────────────────────────
+
+    [Fact]
+    public void SetField_FiresPropertyChanged_ExactlyOnce()
+    {
+        var state = CreateState();
+        var fired = new List<string>();
+        state.PropertyChanged += (_, e) => fired.Add(e.PropertyName!);
+
+        state.Status = ConnectionStatus.Connected;
+
+        Assert.Single(fired);
+        Assert.Equal(nameof(AppState.Status), fired[0]);
+    }
+
+    [Fact]
+    public void SetField_SameValue_DoesNotFire()
+    {
+        var state = CreateState();
+        state.Status = ConnectionStatus.Disconnected; // default
+        var fired = new List<string>();
+        state.PropertyChanged += (_, e) => fired.Add(e.PropertyName!);
+
+        state.Status = ConnectionStatus.Disconnected; // same value
+
+        Assert.Empty(fired);
+    }
+
+    [Fact]
+    public void SetField_NewArrayReference_AlwaysFires()
+    {
+        var state = CreateState();
+        var arr1 = new SessionInfo[] { new() { Key = "a" } };
+        state.Sessions = arr1;
+
+        var fired = new List<string>();
+        state.PropertyChanged += (_, e) => fired.Add(e.PropertyName!);
+
+        var arr2 = new SessionInfo[] { new() { Key = "a" } };
+        state.Sessions = arr2; // different reference, same content
+
+        Assert.Single(fired);
+        Assert.Equal(nameof(AppState.Sessions), fired[0]);
+    }
+
+    [Fact]
+    public void SetField_NullableProperty_FiresOnChange()
+    {
+        var state = CreateState();
+        var fired = new List<string>();
+        state.PropertyChanged += (_, e) => fired.Add(e.PropertyName!);
+
+        state.GatewaySelf = new GatewaySelfInfo { ServerVersion = "1.0" };
+        state.GatewaySelf = null;
+
+        Assert.Equal(2, fired.Count);
+        Assert.All(fired, name => Assert.Equal(nameof(AppState.GatewaySelf), name));
+    }
+
+    // ── ClearCachedData ────────────────────────────────────────────────
+
+    [Fact]
+    public void ClearCachedData_ResetsAllFieldsAndFiresPropertyChanged()
+    {
+        var state = CreateState();
+        state.Status = ConnectionStatus.Connected;
+        state.Sessions = new[] { new SessionInfo { Key = "test" } };
+        state.Channels = new[] { new ChannelHealth { Name = "ch1" } };
+        state.Nodes = new[] { new GatewayNodeInfo { NodeId = "n1" } };
+        state.Usage = new GatewayUsageInfo { TotalTokens = 100 };
+        state.GatewaySelf = new GatewaySelfInfo { ServerVersion = "1.0" };
+        state.NodePairList = new PairingListInfo();
+        state.AuthFailureMessage = "test error";
+
+        var fired = new List<string>();
+        state.PropertyChanged += (_, e) => fired.Add(e.PropertyName!);
+
+        state.ClearCachedData();
+
+        // Status should NOT be reset by ClearCachedData
+        Assert.Equal(ConnectionStatus.Connected, state.Status);
+        Assert.DoesNotContain(nameof(AppState.Status), fired);
+
+        // Everything else should be cleared
+        Assert.Empty(state.Sessions);
+        Assert.Empty(state.Channels);
+        Assert.Empty(state.Nodes);
+        Assert.Null(state.Usage);
+        Assert.Null(state.GatewaySelf);
+        Assert.Null(state.NodePairList);
+        Assert.Null(state.AuthFailureMessage);
+        Assert.Null(state.CurrentActivity);
+        Assert.Null(state.Config);
+        Assert.Null(state.AgentsList);
+
+        // Should have fired PropertyChanged for each cleared property
+        Assert.Contains(nameof(AppState.Sessions), fired);
+        Assert.Contains(nameof(AppState.Channels), fired);
+        Assert.Contains(nameof(AppState.GatewaySelf), fired);
+        Assert.Contains(nameof(AppState.AuthFailureMessage), fired);
+    }
+
+    // ── AddAgentEvent ring buffer ───────────────────────────────────────
+
+    [Fact]
+    public void AddAgentEvent_NewestFirst()
+    {
+        var state = CreateState();
+        var evt1 = new AgentEventInfo { RunId = "r1", Seq = 1 };
+        var evt2 = new AgentEventInfo { RunId = "r2", Seq = 2 };
+
+        state.AddAgentEvent(evt1);
+        state.AddAgentEvent(evt2);
+
+        Assert.Equal(2, state.AgentEvents.Count);
+        Assert.Equal("r2", state.AgentEvents[0].RunId); // newest first
+        Assert.Equal("r1", state.AgentEvents[1].RunId);
+    }
+
+    [Fact]
+    public void AddAgentEvent_CapsAt400()
+    {
+        var state = CreateState();
+        for (int i = 0; i < 450; i++)
+            state.AddAgentEvent(new AgentEventInfo { RunId = $"r{i}", Seq = i });
+
+        Assert.Equal(400, state.AgentEvents.Count);
+        Assert.Equal("r449", state.AgentEvents[0].RunId); // newest
+    }
+
+    [Fact]
+    public void AddAgentEvent_FiresAgentEventAdded()
+    {
+        var state = CreateState();
+        AgentEventInfo? received = null;
+        state.AgentEventAdded += evt => received = evt;
+
+        var expected = new AgentEventInfo { RunId = "test", Seq = 1 };
+        state.AddAgentEvent(expected);
+
+        Assert.NotNull(received);
+        Assert.Equal("test", received.RunId);
+    }
+
+    [Fact]
+    public void ClearAgentEvents_ClearsAndFiresPropertyChanged()
+    {
+        var state = CreateState();
+        state.AddAgentEvent(new AgentEventInfo { RunId = "r1", Seq = 1 });
+        Assert.Single(state.AgentEvents);
+
+        var fired = new List<string>();
+        state.PropertyChanged += (_, e) => fired.Add(e.PropertyName!);
+
+        state.ClearAgentEvents();
+
+        Assert.Empty(state.AgentEvents);
+        Assert.Contains(nameof(AppState.AgentEvents), fired);
+    }
+
+    // ── Session previews ────────────────────────────────────────────────
+
+    [Fact]
+    public void SessionPreview_SetAndGet()
+    {
+        var state = CreateState();
+        var preview = new SessionPreviewInfo { Key = "s1" };
+
+        state.SetSessionPreview("s1", preview);
+
+        Assert.Equal("s1", state.GetSessionPreview("s1")?.Key);
+        Assert.Null(state.GetSessionPreview("nonexistent"));
+    }
+
+    [Fact]
+    public void PruneSessionPreviews_RemovesStale()
+    {
+        var state = CreateState();
+        state.SetSessionPreview("keep", new SessionPreviewInfo { Key = "keep" });
+        state.SetSessionPreview("remove", new SessionPreviewInfo { Key = "remove" });
+
+        state.PruneSessionPreviews(new HashSet<string> { "keep" });
+
+        Assert.NotNull(state.GetSessionPreview("keep"));
+        Assert.Null(state.GetSessionPreview("remove"));
+    }
+
+    // ── GetAgentIds ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetAgentIds_DefaultsToMain()
+    {
+        var state = CreateState();
+        var ids = state.GetAgentIds();
+        Assert.Single(ids);
+        Assert.Equal("main", ids[0]);
+    }
+
+    [Fact]
+    public void GetAgentIds_ParsesFromAgentsList()
+    {
+        var state = CreateState();
+        var json = JsonDocument.Parse("""{"agents":[{"id":"alpha"},{"id":"beta"}]}""");
+        state.AgentsList = json.RootElement.Clone();
+
+        var ids = state.GetAgentIds();
+        Assert.Equal(2, ids.Count);
+        Assert.Contains("alpha", ids);
+        Assert.Contains("beta", ids);
+    }
+
+    // ── Multiple properties ─────────────────────────────────────────────
+
+    [Fact]
+    public void AllProperties_FirePropertyChanged()
+    {
+        var state = CreateState();
+        var fired = new List<string>();
+        state.PropertyChanged += (_, e) => fired.Add(e.PropertyName!);
+
+        state.Status = ConnectionStatus.Connected;
+        state.CurrentActivity = new AgentActivity();
+        state.AuthFailureMessage = "fail";
+        state.Channels = new[] { new ChannelHealth() };
+        state.Sessions = new[] { new SessionInfo() };
+        state.Nodes = new[] { new GatewayNodeInfo() };
+        state.Usage = new GatewayUsageInfo();
+        state.UsageStatus = new GatewayUsageStatusInfo();
+        state.UsageCost = new GatewayCostUsageInfo();
+        state.GatewaySelf = new GatewaySelfInfo();
+        state.NodePairList = new PairingListInfo();
+        state.DevicePairList = new DevicePairingListInfo();
+        state.ModelsList = new ModelsListInfo();
+        state.Presence = new PresenceEntry[] { };
+        state.UpdateInfo = new UpdateCommandCenterInfo();
+
+        Assert.Equal(15, fired.Count);
+        Assert.All(fired, name => Assert.False(string.IsNullOrEmpty(name)));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -35,6 +35,7 @@
 
   <ItemGroup>
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\DeepLinkHandler.cs" Link="Services\DeepLinkHandler.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\AppState.cs" Link="Services\AppState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\Logger.cs" Link="Services\Logger.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SettingsManager.cs" Link="Services\SettingsManager.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\OnboardingChatBootstrapper.cs" Link="Services\OnboardingChatBootstrapper.cs" />


### PR DESCRIPTION
## Summary

Introduces a single observable application model (AppState) that replaces scattered _last* fields in App.xaml.cs and duplicate Last* properties in HubWindow.xaml.cs.

### Architecture changes
- **AppState** (INPC observable, 24+ properties) - single source of truth
- **GatewayService** - owns 27 WebSocket event subscriptions
- **IAppCommands** - typed interface for page to app commands
- **ToastService** - toast display with dedup
- **DiagnosticsClipboardService** - 10 Copy diagnostic methods

### Results
- App.xaml.cs: 3736 to ~3370 lines (-10%)
- HubWindow.xaml.cs: 894 to ~540 lines (-40%)
- 6 new service files
- Duplicate state eliminated
- Pages access App.Current directly instead of HubWindow

### Bug fixes
- Fixed disconnect clearing (was only 7 of 20+ fields)
- Fixed approval CLI commands
- Fixed blank tray flyouts
- Added Connect button in awaiting-approval cards
- Auto-test gateway connectivity on URL input

### Validation
- Build, 1620 shared tests, 967 tray tests all pass
- Cross-model adversarial review (Opus + Codex) - 5 findings fixed
