### PR TITLE
Initialize hub title bar status on bind

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -57,6 +57,7 @@ public sealed partial class HubWindow : WindowEx
         if (AppModel != null)
         {
             AppModel.PropertyChanged += OnAppModelChanged;
+            UpdateTitleBarStatus(AppModel.Status);
             UpdateGatewayNavVisibility(AppModel.Status == ConnectionStatus.Connected);
         }
     }


### PR DESCRIPTION
## Summary
- Initialize the HubWindow title bar status when binding to AppState so tray-launched windows reflect the current connection immediately.
- Keeps subsequent updates on the existing AppState PropertyChanged path.

## Hanselman review
| Issue | Opus | Codex | Consensus | Fix confidence |
|---|---:|---:|---|---:|
| No correctness issues found in scoped change | — | — | HIGH | 99% |

## Validation
- ./build.ps1
- dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore
- dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore