### PR TITLE
Add async loading states for large lists

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml
@@ -39,7 +39,16 @@
                      Title="Single-agent mode"
                      Message="All messages route to the default agent. Add bindings for multi-agent routing."/>
 
-            <ListView x:Name="BindingsList" SelectionMode="None">
+            <StackPanel x:Name="LoadingState" Orientation="Horizontal" Spacing="12"
+                        HorizontalAlignment="Center" Padding="0,24,0,16"
+                        Visibility="Collapsed">
+                <ProgressRing IsActive="True" Width="20" Height="20"/>
+                <TextBlock Text="Loading bindings…"
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           VerticalAlignment="Center"/>
+            </StackPanel>
+
+            <ListView x:Name="BindingsList" SelectionMode="None" Visibility="Collapsed">
                 <ListView.ItemTemplate>
                     <DataTemplate>
                         <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"

--- a/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml.cs
@@ -11,6 +11,7 @@ public sealed partial class BindingsPage : Page
 {
     private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private AppState? _appState;
+    private readonly AsyncListLoadingState _bindingsLoading = new();
 
     public BindingsPage()
     {
@@ -23,14 +24,31 @@ public sealed partial class BindingsPage : Page
 
     public void Initialize()
     {
+        if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
         _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
         // Use cached config if available
         if (_appState?.Config.HasValue == true)
+        {
             ParseBindings(_appState.Config.Value);
+        }
+        else
+        {
+            _bindingsLoading.BeginInitialRefresh();
+            ApplyBindingsLoadingState();
+        }
         // Request fresh config
         if (CurrentApp.GatewayClient != null)
+        {
+            _bindingsLoading.BeginRefresh();
+            ApplyBindingsLoadingState();
             _ = CurrentApp.GatewayClient.RequestConfigAsync();
+        }
+        else
+        {
+            _bindingsLoading.Fail();
+            ApplyBindingsLoadingState();
+        }
     }
 
     private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
@@ -91,14 +109,27 @@ public sealed partial class BindingsPage : Page
             SingleAgentInfoBar.IsOpen = false;
             BindingsList.ItemsSource = bindings;
         }
+        _bindingsLoading.Complete(bindings.Count);
+        ApplyBindingsLoadingState();
     }
 
     private void RefreshButton_Click(object sender, RoutedEventArgs e)
     {
         if (CurrentApp.GatewayClient != null)
         {
+            _bindingsLoading.BeginRefresh();
+            ApplyBindingsLoadingState();
             _ = CurrentApp.GatewayClient.RequestConfigAsync();
         }
+    }
+
+    private void ApplyBindingsLoadingState()
+    {
+        LoadingState.Visibility = _bindingsLoading.ShouldShowLoading ? Visibility.Visible : Visibility.Collapsed;
+        BindingsList.Visibility = _bindingsLoading.ShouldShowContent ? Visibility.Visible : Visibility.Collapsed;
+        SingleAgentInfoBar.IsOpen = _bindingsLoading.ShouldShowEmpty;
+        BindingsList.IsEnabled = _bindingsLoading.CanEdit;
+        RefreshButton.IsEnabled = _bindingsLoading.CanEdit;
     }
 
     private class BindingViewModel

--- a/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml
@@ -266,7 +266,7 @@
         <!-- Loading state -->
         <StackPanel x:Name="LoadingState" Grid.Row="4"
                     VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8"
-                    Visibility="Collapsed">
+                    Visibility="Visible">
             <ProgressRing IsActive="True" Width="24" Height="24" HorizontalAlignment="Center"/>
             <TextBlock Text="Loading cron jobs…"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -278,7 +278,8 @@
 
         <!-- Empty state -->
         <StackPanel x:Name="EmptyState" Grid.Row="4"
-                    VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8">
+                    VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8"
+                    Visibility="Collapsed">
             <TextBlock Text="⏱️" FontSize="48" HorizontalAlignment="Center"/>
             <TextBlock Text="No cron jobs configured"
                        Style="{StaticResource SubtitleTextBlockStyle}"

--- a/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml
@@ -263,6 +263,16 @@
         <!-- Notification for completed one-shot jobs -->
         <InfoBar x:Name="JobCompletedInfoBar" Grid.Row="3" IsOpen="False" Severity="Success" IsClosable="True" Margin="0,0,0,8"/>
 
+        <!-- Loading state -->
+        <StackPanel x:Name="LoadingState" Grid.Row="4"
+                    VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8"
+                    Visibility="Collapsed">
+            <ProgressRing IsActive="True" Width="24" Height="24" HorizontalAlignment="Center"/>
+            <TextBlock Text="Loading cron jobs…"
+                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                       HorizontalAlignment="Center"/>
+        </StackPanel>
+
         <!-- Jobs list (manually managed for inline editing) -->
         <StackPanel x:Name="JobsListPanel" Grid.Row="4" Spacing="4" Visibility="Collapsed"/>
 

--- a/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
@@ -528,6 +528,7 @@ public sealed partial class CronPage : Page
 
     private void ParseCronList(JsonElement payload, bool keepRefreshing = false)
     {
+        var hadLoadedJobs = _jobsLoading.HasLoaded;
         var jobs = new List<CronJobViewModel>();
 
         foreach (var item in payload.EnumerateArray())
@@ -760,8 +761,15 @@ public sealed partial class CronPage : Page
             }
 
             _jobs = jobs;
-            _jobsLoading.Complete(jobs.Count);
-            if (keepRefreshing)
+            if (keepRefreshing && !hadLoadedJobs && jobs.Count == 0)
+            {
+                _jobsLoading.BeginInitialRefresh();
+            }
+            else
+            {
+                _jobsLoading.Complete(jobs.Count);
+            }
+            if (keepRefreshing && _jobsLoading.HasLoaded)
                 _jobsLoading.BeginRefresh();
 
             // Restore expanded state from persisted set

--- a/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
@@ -26,6 +26,7 @@ public sealed partial class CronPage : Page
     private HashSet<string> _removedJobIds = new(); // jobs user explicitly removed (suppress auto-delete notification)
     private HashSet<string> _expandedJobIds = new(); // persisted expanded state
     private CancellationTokenSource? _infoDismissCts = null; // auto-dismiss timer for InfoBar
+    private readonly AsyncListLoadingState _jobsLoading = new();
 
     public CronPage()
     {
@@ -38,12 +39,28 @@ public sealed partial class CronPage : Page
 
     public void Initialize()
     {
+        if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
         _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
         if (CurrentApp.GatewayClient != null)
         {
+            if (_appState.CronList.HasValue)
+            {
+                UpdateFromGateway(_appState.CronList.Value, keepRefreshing: true);
+            }
+            else
+            {
+                _jobsLoading.BeginInitialRefresh();
+                ApplyJobsLoadingState();
+            }
+
             _ = CurrentApp.GatewayClient.RequestCronListAsync();
             _ = CurrentApp.GatewayClient.RequestCronStatusAsync();
+        }
+        else
+        {
+            _jobsLoading.Fail();
+            ApplyJobsLoadingState();
         }
     }
 
@@ -65,12 +82,15 @@ public sealed partial class CronPage : Page
 
     private void OnRunNowClick(object sender, RoutedEventArgs e)
     {
+        if (!_jobsLoading.CanEdit) return;
         var btn = sender as Button;
         var jobId = btn?.Tag as string;
         if (string.IsNullOrEmpty(jobId) || CurrentApp.GatewayClient == null) return;
         var vm = _jobs.Find(j => j.Id == jobId);
         if (vm != null && !vm.IsEnabled) return;
         _runningJobIds.Add(jobId);
+        _jobsLoading.BeginRefresh();
+        ApplyJobsLoadingState();
         btn!.Content = "Running...";
         btn.IsEnabled = false;
 
@@ -104,21 +124,27 @@ public sealed partial class CronPage : Page
 
     private void OnRemoveClick(object sender, RoutedEventArgs e)
     {
+        if (!_jobsLoading.CanEdit) return;
         var jobId = (sender as Button)?.Tag as string;
         if (string.IsNullOrEmpty(jobId) || CurrentApp.GatewayClient == null) return;
         _removedJobIds.Add(jobId);
+        _jobsLoading.BeginRefresh();
+        ApplyJobsLoadingState();
         // Gateway client's HandleKnownResponse refreshes the list automatically on cron.remove
         _ = CurrentApp.GatewayClient.RemoveCronJobAsync(jobId);
     }
 
     private void OnToggleEnabledClick(object sender, RoutedEventArgs e)
     {
+        if (!_jobsLoading.CanEdit) return;
         var jobId = (sender as Button)?.Tag as string;
         if (string.IsNullOrEmpty(jobId) || CurrentApp.GatewayClient == null) return;
 
         var vm = _jobs.Find(j => j.Id == jobId);
         if (vm != null)
         {
+            _jobsLoading.BeginRefresh();
+            ApplyJobsLoadingState();
             _ = CurrentApp.GatewayClient.UpdateCronJobAsync(jobId, new { enabled = !vm.IsEnabled });
         }
     }
@@ -128,6 +154,7 @@ public sealed partial class CronPage : Page
 
     private void OnNewJobClick(object sender, RoutedEventArgs e)
     {
+        if (!_jobsLoading.CanEdit) return;
         _editingJobId = null;
         RestoreFormFromInline(); // ensure form is back in its home position
         ResetForm();
@@ -138,6 +165,7 @@ public sealed partial class CronPage : Page
 
     private void OnEditJobClick(object sender, RoutedEventArgs e)
     {
+        if (!_jobsLoading.CanEdit) return;
         var jobId = (sender as Button)?.Tag as string;
         if (string.IsNullOrEmpty(jobId)) return;
         var vm = _jobs.Find(j => j.Id == jobId);
@@ -206,6 +234,7 @@ public sealed partial class CronPage : Page
 
     private void OnFormSaveClick(object sender, RoutedEventArgs e)
     {
+        if (!_jobsLoading.CanEdit) return;
         // Validate
         var name = FormName.Text?.Trim();
         if (string.IsNullOrEmpty(name))
@@ -305,6 +334,8 @@ public sealed partial class CronPage : Page
             if (kind == "at")
                 patch["deleteAfterRun"] = FormDeleteAfterRun.IsChecked == true;
 
+            _jobsLoading.BeginRefresh();
+            ApplyJobsLoadingState();
             _ = CurrentApp.GatewayClient.UpdateCronJobAsync(_editingJobId, patch);
         }
         else
@@ -327,6 +358,8 @@ public sealed partial class CronPage : Page
             if (kind == "at")
                 job["deleteAfterRun"] = FormDeleteAfterRun.IsChecked == true;
 
+            _jobsLoading.BeginRefresh();
+            ApplyJobsLoadingState();
             _ = CurrentApp.GatewayClient.AddCronJobAsync(job);
         }
 
@@ -471,19 +504,19 @@ public sealed partial class CronPage : Page
         }
     }
 
-    public void UpdateFromGateway(JsonElement data)
+    public void UpdateFromGateway(JsonElement data, bool keepRefreshing = false)
     {
         // The gateway client passes the payload directly (not wrapped)
         if (data.ValueKind == JsonValueKind.Array)
         {
-            ParseCronList(data);
+            ParseCronList(data, keepRefreshing);
         }
         else if (data.ValueKind == JsonValueKind.Object)
         {
             // cron.list returns { jobs: [...], total, offset, limit, hasMore, ... }
             if (data.TryGetProperty("jobs", out var jobsEl) && jobsEl.ValueKind == JsonValueKind.Array)
             {
-                ParseCronList(jobsEl);
+                ParseCronList(jobsEl, keepRefreshing);
             }
             // cron.status returns { enabled, storePath, jobs (count), nextWakeAtMs }
             else if (data.TryGetProperty("nextWakeAtMs", out _) || data.TryGetProperty("storePath", out _))
@@ -493,7 +526,7 @@ public sealed partial class CronPage : Page
         }
     }
 
-    private void ParseCronList(JsonElement payload)
+    private void ParseCronList(JsonElement payload, bool keepRefreshing = false)
     {
         var jobs = new List<CronJobViewModel>();
 
@@ -727,6 +760,9 @@ public sealed partial class CronPage : Page
             }
 
             _jobs = jobs;
+            _jobsLoading.Complete(jobs.Count);
+            if (keepRefreshing)
+                _jobsLoading.BeginRefresh();
 
             // Restore expanded state from persisted set
             foreach (var vm in _jobs)
@@ -749,6 +785,7 @@ public sealed partial class CronPage : Page
                 JobsListPanel.Visibility = Visibility.Collapsed;
                 EmptyState.Visibility = Visibility.Visible;
             }
+            ApplyJobsLoadingState();
         });
     }
 
@@ -1242,6 +1279,7 @@ public sealed partial class CronPage : Page
 
     private void OnHistoryClick(object sender, RoutedEventArgs e)
     {
+        if (!_jobsLoading.CanEdit) return;
         var jobId = (sender as Button)?.Tag as string;
         if (string.IsNullOrEmpty(jobId) || CurrentApp.GatewayClient == null) return;
         var vm = _jobs.Find(j => j.Id == jobId);
@@ -1608,6 +1646,30 @@ public sealed partial class CronPage : Page
         if (span.TotalMinutes < 60) return $"{(int)span.TotalMinutes}m";
         if (span.TotalHours < 24) return span.Minutes > 0 ? $"{(int)span.TotalHours}h {span.Minutes}m" : $"{(int)span.TotalHours}h";
         return $"{(int)span.TotalDays}d {span.Hours}h";
+    }
+
+    private void ApplyJobsLoadingState()
+    {
+        LoadingState.Visibility = _jobsLoading.ShouldShowLoading ? Visibility.Visible : Visibility.Collapsed;
+        JobsListPanel.Visibility = _jobsLoading.ShouldShowContent ? Visibility.Visible : Visibility.Collapsed;
+        EmptyState.Visibility = _jobsLoading.ShouldShowEmpty ? Visibility.Visible : Visibility.Collapsed;
+        NewJobButton.IsEnabled = _jobsLoading.CanEdit && CurrentApp.GatewayClient != null;
+        SetDescendantControlsEnabled(JobsListPanel, _jobsLoading.CanEdit);
+        SetDescendantControlsEnabled(JobFormPanel, _jobsLoading.CanEdit);
+        JobsListPanel.Opacity = _jobsLoading.CanEdit ? 1.0 : 0.7;
+        JobFormPanel.Opacity = _jobsLoading.CanEdit ? 1.0 : 0.7;
+    }
+
+    private static void SetDescendantControlsEnabled(DependencyObject parent, bool isEnabled)
+    {
+        var count = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChildrenCount(parent);
+        for (var i = 0; i < count; i++)
+        {
+            var child = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChild(parent, i);
+            if (child is Control control)
+                control.IsEnabled = isEnabled;
+            SetDescendantControlsEnabled(child, isEnabled);
+        }
     }
 
     private class CronJobViewModel

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
@@ -49,6 +49,16 @@
             <SelectorBarItem x:Name="AllTab" Text="All" IsSelected="True"/>
         </SelectorBar>
 
+        <!-- Loading state -->
+        <StackPanel x:Name="LoadingState" Grid.Row="4" Spacing="8"
+                    HorizontalAlignment="Center" VerticalAlignment="Center"
+                    Visibility="Collapsed">
+            <ProgressRing IsActive="True" Width="24" Height="24" HorizontalAlignment="Center"/>
+            <TextBlock Text="Loading sessions…"
+                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                       HorizontalAlignment="Center"/>
+        </StackPanel>
+
         <!-- Empty state -->
         <StackPanel x:Name="EmptyState" Grid.Row="4" Spacing="8"
                     HorizontalAlignment="Center" VerticalAlignment="Center"

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -19,6 +19,7 @@ public sealed partial class SessionsPage : Page
     private SessionInfo[]? _allSessions;
     private string _activeChannel = "all";
     private Microsoft.UI.Dispatching.DispatcherQueueTimer? _refreshTimer;
+    private readonly AsyncListLoadingState _sessionsLoading = new();
 
     public SessionsPage()
     {
@@ -47,14 +48,30 @@ public sealed partial class SessionsPage : Page
 
         if (CurrentApp.GatewayClient == null)
         {
+            _sessionsLoading.Fail();
+            ApplySessionsLoadingState();
             EmptyState.Visibility = Visibility.Collapsed;
             SessionListView.ItemsSource = null;
             return;
         }
 
-        if (_appState?.Sessions != null)
-            UpdateSessions(_appState.Sessions);
+        if (_allSessions != null)
+        {
+            _sessionsLoading.Complete(_allSessions.Length);
+            ApplyFilter();
+        }
+        else if (_appState?.Sessions is { Length: > 0 } cachedSessions)
+        {
+            UpdateSessions(cachedSessions);
+        }
+        else
+        {
+            _sessionsLoading.BeginInitialRefresh();
+            ApplySessionsLoadingState();
+        }
 
+        _sessionsLoading.BeginRefresh();
+        ApplyFilter();
         _ = CurrentApp.GatewayClient.RequestSessionsAsync();
         _ = CurrentApp.GatewayClient.RequestModelsListAsync();
     }
@@ -65,6 +82,7 @@ public sealed partial class SessionsPage : Page
     public void UpdateSessions(SessionInfo[] sessions)
     {
         _allSessions = sessions;
+        _sessionsLoading.Complete(sessions.Length);
         RebuildChannelTabs();
         ApplyFilter();
     }
@@ -95,11 +113,9 @@ public sealed partial class SessionsPage : Page
         if (_allSessions == null || _allSessions.Length == 0)
         {
             SessionListView.ItemsSource = null;
-            EmptyState.Visibility = Visibility.Visible;
+            ApplySessionsLoadingState(0);
             return;
         }
-
-        EmptyState.Visibility = Visibility.Collapsed;
 
         IEnumerable<SessionInfo> filtered = _allSessions;
 
@@ -117,12 +133,13 @@ public sealed partial class SessionsPage : Page
         if (viewModels.Count == 0)
         {
             SessionListView.ItemsSource = null;
-            EmptyState.Visibility = Visibility.Visible;
         }
         else
         {
             SessionListView.ItemsSource = viewModels;
         }
+
+        ApplySessionsLoadingState(viewModels.Count);
     }
 
     private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
@@ -178,6 +195,7 @@ public sealed partial class SessionsPage : Page
 
     private async void OnResetSession(object sender, RoutedEventArgs e)
     {
+        if (!_sessionsLoading.CanEdit) return;
         if (sender is Button btn && btn.Tag is string key)
         {
             var client = CurrentApp.GatewayClient;
@@ -189,6 +207,7 @@ public sealed partial class SessionsPage : Page
 
     private async void OnDeleteSession(object sender, RoutedEventArgs e)
     {
+        if (!_sessionsLoading.CanEdit) return;
         if (sender is Button btn && btn.Tag is string key)
         {
             var client = CurrentApp.GatewayClient;
@@ -200,6 +219,7 @@ public sealed partial class SessionsPage : Page
 
     private async void OnCompactSession(object sender, RoutedEventArgs e)
     {
+        if (!_sessionsLoading.CanEdit) return;
         if (sender is Button btn && btn.Tag is string key)
         {
             var client = CurrentApp.GatewayClient;
@@ -214,6 +234,8 @@ public sealed partial class SessionsPage : Page
         var client = CurrentApp.GatewayClient;
         if (client != null)
         {
+            _sessionsLoading.BeginRefresh();
+            ApplyFilter();
             _ = client.RequestSessionsAsync();
             _ = client.RequestModelsListAsync();
         }
@@ -239,6 +261,17 @@ public sealed partial class SessionsPage : Page
         if (n >= 1_000_000) return $"{n / 1_000_000.0:0.#}M";
         if (n >= 1_000) return $"{n / 1_000.0:0.#}K";
         return n.ToString();
+    }
+
+    private void ApplySessionsLoadingState(int? visibleItemCount = null)
+    {
+        var visibleCount = visibleItemCount ?? _sessionsLoading.ItemCount;
+        LoadingState.Visibility = _sessionsLoading.ShouldShowLoading ? Visibility.Visible : Visibility.Collapsed;
+        SessionListView.Visibility = _sessionsLoading.HasLoaded && visibleCount > 0 ? Visibility.Visible : Visibility.Collapsed;
+        EmptyState.Visibility = _sessionsLoading.HasLoaded && visibleCount == 0 ? Visibility.Visible : Visibility.Collapsed;
+        ChannelSelector.IsEnabled = _sessionsLoading.CanEdit;
+        RefreshButton.IsEnabled = _sessionsLoading.CanEdit;
+        SessionListView.IsEnabled = _sessionsLoading.CanEdit;
     }
 }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml
@@ -122,7 +122,20 @@
                         </SelectorBar>
                     </Grid>
                     <Border Height="1" Background="{ThemeResource CardStrokeColorDefaultBrush}"/>
-                    <ListView x:Name="DailyListView" SelectionMode="None">
+                    <StackPanel x:Name="DailyLoadingPanel" Orientation="Horizontal" Spacing="12"
+                                HorizontalAlignment="Center" Padding="0,24,0,16"
+                                Visibility="Collapsed">
+                        <ProgressRing IsActive="True" Width="20" Height="20"/>
+                        <TextBlock Text="Loading daily costs…"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   VerticalAlignment="Center"/>
+                    </StackPanel>
+                    <TextBlock x:Name="DailyEmptyText"
+                               Text="No daily cost data"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               HorizontalAlignment="Center" Padding="0,24,0,16"
+                               Visibility="Collapsed"/>
+                    <ListView x:Name="DailyListView" SelectionMode="None" Visibility="Collapsed">
                         <ListView.ItemTemplate>
                             <DataTemplate>
                                 <Grid Padding="4,6">

--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
@@ -16,6 +16,8 @@ public sealed partial class UsagePage : Page
     private AppState? _appState;
     // Default matches the XAML-selected Period7DaysItem (IsSelected="True").
     private int _currentPeriodDays = 7;
+    private readonly AsyncListLoadingState _dailyCostLoading = new();
+    private readonly AsyncListLoadingState _providerLoading = new();
 
     public UsagePage()
     {
@@ -28,6 +30,7 @@ public sealed partial class UsagePage : Page
 
     public void Initialize()
     {
+        if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
         _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
         if (CurrentApp.GatewayClient != null)
@@ -41,7 +44,21 @@ public sealed partial class UsagePage : Page
             {
                 UpdateUsageCost(_appState.UsageCost);
             }
+            else
+            {
+                _dailyCostLoading.BeginInitialRefresh();
+                ApplyDailyCostLoadingState();
+            }
             if (_appState?.UsageStatus != null) UpdateUsageStatus(_appState.UsageStatus);
+            else
+            {
+                _providerLoading.BeginInitialRefresh();
+                ApplyProviderLoadingState();
+            }
+            _dailyCostLoading.BeginRefresh();
+            _providerLoading.BeginRefresh();
+            ApplyDailyCostLoadingState();
+            ApplyProviderLoadingState();
             _ = CurrentApp.GatewayClient.RequestUsageAsync();
             _ = CurrentApp.GatewayClient.RequestUsageCostAsync(_currentPeriodDays);
             _ = CurrentApp.GatewayClient.RequestUsageStatusAsync();
@@ -49,7 +66,10 @@ public sealed partial class UsagePage : Page
         else
         {
             // Not connected — nothing to load, hide the loading skeleton.
-            ProviderLoadingPanel.Visibility = Visibility.Collapsed;
+            _dailyCostLoading.Fail();
+            _providerLoading.Fail();
+            ApplyDailyCostLoadingState();
+            ApplyProviderLoadingState();
         }
     }
 
@@ -61,7 +81,8 @@ public sealed partial class UsagePage : Page
                 if (_appState?.Usage != null) UpdateUsage(_appState.Usage);
                 break;
             case nameof(AppState.UsageCost):
-                if (_appState?.UsageCost != null) UpdateUsageCost(_appState.UsageCost);
+                if (_appState?.UsageCost != null && _appState.UsageCost.Days == _currentPeriodDays)
+                    UpdateUsageCost(_appState.UsageCost);
                 break;
             case nameof(AppState.UsageStatus):
                 if (_appState?.UsageStatus != null) UpdateUsageStatus(_appState.UsageStatus);
@@ -88,6 +109,8 @@ public sealed partial class UsagePage : Page
             Date = d.Date,
             Cost = $"${d.TotalCost:F2}",
         }).ToList();
+        _dailyCostLoading.Complete(cost.Daily.Count);
+        ApplyDailyCostLoadingState();
     }
 
     public void UpdateUsageStatus(GatewayUsageStatusInfo status)
@@ -101,10 +124,8 @@ public sealed partial class UsagePage : Page
             Status = p.Error ?? "",
         }).ToList();
 
-        bool hasProviders = status.Providers.Count > 0;
-        ProviderLoadingPanel.Visibility = Visibility.Collapsed;
-        ProviderListView.Visibility = hasProviders ? Visibility.Visible : Visibility.Collapsed;
-        ProviderEmptyText.Visibility = hasProviders ? Visibility.Collapsed : Visibility.Visible;
+        _providerLoading.Complete(status.Providers.Count);
+        ApplyProviderLoadingState();
     }
 
     private void OnPeriodSelectionChanged(SelectorBar sender, SelectorBarSelectionChangedEventArgs args)
@@ -120,6 +141,8 @@ public sealed partial class UsagePage : Page
 
         if (CurrentApp.GatewayClient != null)
         {
+            _dailyCostLoading.BeginInitialRefresh();
+            ApplyDailyCostLoadingState();
             _ = CurrentApp.GatewayClient.RequestUsageCostAsync(days);
         }
     }
@@ -129,6 +152,23 @@ public sealed partial class UsagePage : Page
         if (n >= 1_000_000) return (n / 1_000_000.0).ToString("F1", CultureInfo.InvariantCulture) + "M";
         if (n >= 1_000) return (n / 1_000.0).ToString("F1", CultureInfo.InvariantCulture) + "K";
         return n.ToString();
+    }
+
+    private void ApplyDailyCostLoadingState()
+    {
+        DailyLoadingPanel.Visibility = _dailyCostLoading.ShouldShowLoading ? Visibility.Visible : Visibility.Collapsed;
+        DailyListView.Visibility = _dailyCostLoading.ShouldShowContent ? Visibility.Visible : Visibility.Collapsed;
+        DailyEmptyText.Visibility = _dailyCostLoading.ShouldShowEmpty ? Visibility.Visible : Visibility.Collapsed;
+        DailyListView.IsEnabled = _dailyCostLoading.CanEdit;
+        PeriodSelector.IsEnabled = _dailyCostLoading.CanEdit;
+    }
+
+    private void ApplyProviderLoadingState()
+    {
+        ProviderLoadingPanel.Visibility = _providerLoading.ShouldShowLoading ? Visibility.Visible : Visibility.Collapsed;
+        ProviderListView.Visibility = _providerLoading.ShouldShowContent ? Visibility.Visible : Visibility.Collapsed;
+        ProviderEmptyText.Visibility = _providerLoading.ShouldShowEmpty ? Visibility.Visible : Visibility.Collapsed;
+        ProviderListView.IsEnabled = _providerLoading.CanEdit;
     }
 
     private class ProviderRow

--- a/src/OpenClaw.Tray.WinUI/Services/AsyncListLoadingState.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AsyncListLoadingState.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace OpenClawTray.Services;
+
+internal sealed class AsyncListLoadingState
+{
+    public bool HasLoaded { get; private set; }
+    public bool IsRefreshing { get; private set; }
+    public int ItemCount { get; private set; }
+
+    public bool HasItems => HasLoaded && ItemCount > 0;
+    public bool CanEdit => !IsRefreshing;
+    public bool ShouldShowLoading => IsRefreshing && !HasLoaded;
+    public bool ShouldShowContent => HasItems;
+    public bool ShouldShowEmpty => HasLoaded && ItemCount == 0;
+
+    public void BeginRefresh()
+    {
+        IsRefreshing = true;
+    }
+
+    public void BeginInitialRefresh()
+    {
+        HasLoaded = false;
+        ItemCount = 0;
+        IsRefreshing = true;
+    }
+
+    public void Complete(int itemCount)
+    {
+        ItemCount = Math.Max(0, itemCount);
+        HasLoaded = true;
+        IsRefreshing = false;
+    }
+
+    public void Fail()
+    {
+        IsRefreshing = false;
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/AsyncListLoadingPageWiringTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AsyncListLoadingPageWiringTests.cs
@@ -31,6 +31,19 @@ public sealed class AsyncListLoadingPageWiringTests
         Assert.Contains(".CanEdit", source);
     }
 
+    [Fact]
+    public void CronPage_DefaultsToLoadingUntilFirstListResponse()
+    {
+        var xaml = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", "CronPage.xaml");
+        var source = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", "CronPage.xaml.cs");
+
+        Assert.Contains("x:Name=\"LoadingState\" Grid.Row=\"4\"", xaml);
+        Assert.Contains("Visibility=\"Visible\"", xaml);
+        Assert.Contains("x:Name=\"EmptyState\" Grid.Row=\"4\"", xaml);
+        Assert.Contains("Visibility=\"Collapsed\"", xaml);
+        Assert.Contains("keepRefreshing && !hadLoadedJobs && jobs.Count == 0", source);
+    }
+
     private static string ReadSource(params string[] relativePathParts)
     {
         var root = Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT") ?? Directory.GetCurrentDirectory();

--- a/tests/OpenClaw.Tray.Tests/AsyncListLoadingPageWiringTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AsyncListLoadingPageWiringTests.cs
@@ -46,7 +46,29 @@ public sealed class AsyncListLoadingPageWiringTests
 
     private static string ReadSource(params string[] relativePathParts)
     {
-        var root = Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT") ?? Directory.GetCurrentDirectory();
+        var root = GetRepositoryRoot();
         return File.ReadAllText(Path.Combine(new[] { root }.Concat(relativePathParts).ToArray()));
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        var env = Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT");
+        if (!string.IsNullOrWhiteSpace(env) && Directory.Exists(env))
+            return env;
+
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "openclaw-windows-node.slnx")) &&
+                Directory.Exists(Path.Combine(directory.FullName, "src")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException(
+            "Could not find repository root. Set OPENCLAW_REPO_ROOT to the repo path.");
     }
 }

--- a/tests/OpenClaw.Tray.Tests/AsyncListLoadingPageWiringTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AsyncListLoadingPageWiringTests.cs
@@ -1,0 +1,39 @@
+using System.IO;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class AsyncListLoadingPageWiringTests
+{
+    [Theory]
+    [InlineData("SessionsPage.xaml", "Loading sessions")]
+    [InlineData("CronPage.xaml", "Loading cron jobs")]
+    [InlineData("UsagePage.xaml", "Loading daily costs")]
+    [InlineData("BindingsPage.xaml", "Loading bindings")]
+    public void BigListPages_HaveFirstLoadPlaceholders(string fileName, string loadingText)
+    {
+        var source = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", fileName);
+
+        Assert.Contains("<ProgressRing", source);
+        Assert.Contains(loadingText, source);
+    }
+
+    [Theory]
+    [InlineData("SessionsPage.xaml.cs")]
+    [InlineData("CronPage.xaml.cs")]
+    [InlineData("UsagePage.xaml.cs")]
+    [InlineData("BindingsPage.xaml.cs")]
+    public void BigListPages_DisableListInteractionsDuringRefresh(string fileName)
+    {
+        var source = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", fileName);
+
+        Assert.Contains("AsyncListLoadingState", source);
+        Assert.Contains(".BeginRefresh()", source);
+        Assert.Contains(".CanEdit", source);
+    }
+
+    private static string ReadSource(params string[] relativePathParts)
+    {
+        var root = Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT") ?? Directory.GetCurrentDirectory();
+        return File.ReadAllText(Path.Combine(new[] { root }.Concat(relativePathParts).ToArray()));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/AsyncListLoadingStateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AsyncListLoadingStateTests.cs
@@ -1,0 +1,72 @@
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class AsyncListLoadingStateTests
+{
+    [Fact]
+    public void FirstRefresh_ShowsLoadingAndDisablesEdits()
+    {
+        var state = new AsyncListLoadingState();
+
+        state.BeginInitialRefresh();
+
+        Assert.True(state.IsRefreshing);
+        Assert.False(state.CanEdit);
+        Assert.True(state.ShouldShowLoading);
+        Assert.False(state.ShouldShowContent);
+        Assert.False(state.ShouldShowEmpty);
+    }
+
+    [Fact]
+    public void RefreshAfterLoadedItems_KeepsContentVisibleButDisablesEdits()
+    {
+        var state = new AsyncListLoadingState();
+        state.Complete(3);
+
+        state.BeginRefresh();
+
+        Assert.False(state.ShouldShowLoading);
+        Assert.True(state.ShouldShowContent);
+        Assert.False(state.CanEdit);
+    }
+
+    [Fact]
+    public void RefreshAfterLoadedEmpty_KeepsEmptyVisibleButDisablesEdits()
+    {
+        var state = new AsyncListLoadingState();
+        state.Complete(0);
+
+        state.BeginRefresh();
+
+        Assert.False(state.ShouldShowLoading);
+        Assert.True(state.ShouldShowEmpty);
+        Assert.False(state.CanEdit);
+    }
+
+    [Fact]
+    public void BeginInitialRefresh_ClearsStaleContentForNewQueryScope()
+    {
+        var state = new AsyncListLoadingState();
+        state.Complete(3);
+
+        state.BeginInitialRefresh();
+
+        Assert.False(state.HasLoaded);
+        Assert.Equal(0, state.ItemCount);
+        Assert.True(state.ShouldShowLoading);
+    }
+
+    [Fact]
+    public void Complete_NormalizesNegativeCounts()
+    {
+        var state = new AsyncListLoadingState();
+
+        state.Complete(-1);
+
+        Assert.True(state.HasLoaded);
+        Assert.Equal(0, state.ItemCount);
+        Assert.True(state.CanEdit);
+        Assert.True(state.ShouldShowEmpty);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\StartupSetupState.cs" Link="Services\StartupSetupState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SetupExistingGatewayClassifier.cs" Link="Services\SetupExistingGatewayClassifier.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ActivityStreamService.cs" Link="Services\ActivityStreamService.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\AsyncListLoadingState.cs" Link="Services\AsyncListLoadingState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeInvokeActivityFormatter.cs" Link="Services\NodeInvokeActivityFormatter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeCapabilityGating.cs" Link="Services\NodeCapabilityGating.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\TrayTooltipFormatter.cs" Link="Helpers\TrayTooltipFormatter.cs" />


### PR DESCRIPTION
## Summary
- add a reusable `AsyncListLoadingState` for first-load, stale-while-refresh, and loaded-empty list states
- show explicit loading placeholders on Sessions, Cron, Usage, and Bindings instead of flashing empty states while gateway data is slow
- keep stale list data visible during refresh but disable editing/actions until fresh data arrives
- guard Usage cost updates so stale responses from an older period cannot overwrite the selected period

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`