### PR TITLE
chore(deps): align CommandPalette Windows SDK BuildTools

### DIFF
--- a/src/OpenClaw.CommandPalette/Directory.Packages.props
+++ b/src/OpenClaw.CommandPalette/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.183" />
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4188" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools.MSIX" Version="1.7.20250829.1" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.250907003" />
     <PackageVersion Include="Shmuelie.WinRTServer" Version="2.1.1" />


### PR DESCRIPTION
## Summary
- Align CommandPalette's `Microsoft.Windows.SDK.BuildTools` package version with the tray and FunctionalUI projects
- Keeps the PowerToys Command Palette extension build on the same SDK tooling baseline as the rest of the Windows targets

Fixes #311.

## Validation
- `dotnet restore .\src\OpenClaw.CommandPalette`
- `dotnet build .\src\OpenClaw.CommandPalette -c Debug -p:Platform=x64 --no-restore` (existing missing publish profile warning only)
- `dotnet build .\src\OpenClaw.CommandPalette -c Debug -p:Platform=arm64 --no-restore` (existing missing publish profile warning only)
- `.\build.ps1`
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` (1767 passed, 28 skipped)
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` (1043 passed)

## Notes
CommandPalette still has docs, tests, solution/CI wiring, and live deep-link commands, so this keeps the existing extension healthy without broadening scope into a product re-evaluation.