### PR TITLE
test: ignore generated XAML in localization validation

### DIFF
--- a/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
@@ -273,6 +273,7 @@ public class LocalizationValidationTests
         var missing = new List<string>();
 
         foreach (var xamlPath in Directory.EnumerateFiles(winUiRoot, "*.xaml", SearchOption.AllDirectories)
+                     .Where(IsSourceXaml)
                      .OrderBy(p => p, StringComparer.OrdinalIgnoreCase))
         {
             var relativePath = Path.GetRelativePath(GetRepositoryRoot(), xamlPath);
@@ -308,6 +309,14 @@ public class LocalizationValidationTests
         Assert.True(missing.Count == 0,
             "Every localizable XAML attribute on an x:Uid element must have an en-us Resources.resw key. Missing: " +
             string.Join("; ", missing.Take(50)));
+    }
+
+    private static bool IsSourceXaml(string path)
+    {
+        var relative = Path.GetRelativePath(GetRepositoryRoot(), path);
+        var segments = relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return !segments.Contains("bin", StringComparer.OrdinalIgnoreCase) &&
+               !segments.Contains("obj", StringComparer.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Restrict localization XAML validation to source XAML by excluding generated bin/obj paths
- Prevent build-generated XAML from causing false missing-resource failures after local builds

## Validation
- dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --filter LocalizationValidationTests.XamlControlsWithXUid_HaveMatchingEnUsResources
- .\build.ps1
- dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore
- dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore