### PR TITLE
Improve async loading states for list pages

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml
@@ -39,7 +39,26 @@
                      Title="Single-agent mode"
                      Message="All messages route to the default agent. Add bindings for multi-agent routing."/>
 
-            <ListView x:Name="BindingsList" SelectionMode="None">
+            <InfoBar x:Name="ConnectionInfoBar"
+                     IsOpen="False" IsClosable="False"
+                     Severity="Warning"
+                     Title="Gateway disconnected"
+                     Message="Connect to a gateway to load bindings.">
+                <InfoBar.ActionButton>
+                    <Button Content="Open Connection" Click="OnOpenConnectionClick"/>
+                </InfoBar.ActionButton>
+            </InfoBar>
+
+            <StackPanel x:Name="LoadingState" Orientation="Horizontal" Spacing="12"
+                        HorizontalAlignment="Center" Padding="0,24,0,16"
+                        Visibility="Collapsed">
+                <ProgressRing IsActive="True" Width="20" Height="20"/>
+                <TextBlock Text="Loading bindings..."
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           VerticalAlignment="Center"/>
+            </StackPanel>
+
+            <ListView x:Name="BindingsList" SelectionMode="None" Visibility="Collapsed">
                 <ListView.ItemTemplate>
                     <DataTemplate>
                         <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"

--- a/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using OpenClawTray.Services;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text.Json;
@@ -11,6 +12,7 @@ public sealed partial class BindingsPage : Page
 {
     private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private AppState? _appState;
+    private readonly AsyncListLoadingState _bindingsLoading = new();
 
     public BindingsPage()
     {
@@ -23,15 +25,38 @@ public sealed partial class BindingsPage : Page
 
     public void Initialize()
     {
+        if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
         _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
         // Use cached config if available
         if (_appState?.Config.HasValue == true)
+        {
             ParseBindings(_appState.Config.Value);
+            _bindingsLoading.BeginRefresh();
+            UpdateLoadingVisuals();
+        }
+        else
+        {
+            _bindingsLoading.BeginInitialRefresh();
+            UpdateLoadingVisuals();
+        }
         // Request fresh config
-        if (CurrentApp.GatewayClient != null)
-            _ = CurrentApp.GatewayClient.RequestConfigAsync();
+        var client = CurrentApp.GatewayClient;
+        if (client != null)
+        {
+            ConnectionInfoBar.IsOpen = false;
+            _ = client.RequestConfigAsync();
+        }
+        else
+        {
+            _bindingsLoading.Fail();
+            ShowDisconnected();
+            UpdateLoadingVisuals();
+        }
     }
+
+    private void OnOpenConnectionClick(object sender, RoutedEventArgs e)
+        => ((IAppCommands)CurrentApp).Navigate("connection");
 
     private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
     {
@@ -79,26 +104,67 @@ public sealed partial class BindingsPage : Page
                 }
             }
         }
-        catch { }
+        catch (Exception ex)
+        {
+            _bindingsLoading.Fail();
+            ShowLoadFailure(ex);
+            UpdateLoadingVisuals();
+            return;
+        }
 
         if (bindings.Count == 0)
         {
-            SingleAgentInfoBar.IsOpen = true;
             BindingsList.ItemsSource = null;
         }
         else
         {
-            SingleAgentInfoBar.IsOpen = false;
             BindingsList.ItemsSource = bindings;
         }
+
+        _bindingsLoading.Complete(bindings.Count);
+        UpdateLoadingVisuals();
     }
 
     private void RefreshButton_Click(object sender, RoutedEventArgs e)
     {
-        if (CurrentApp.GatewayClient != null)
+        var client = CurrentApp.GatewayClient;
+        if (client != null)
         {
-            _ = CurrentApp.GatewayClient.RequestConfigAsync();
+            ConnectionInfoBar.IsOpen = false;
+            _bindingsLoading.BeginRefresh();
+            UpdateLoadingVisuals();
+            _ = client.RequestConfigAsync();
         }
+        else
+        {
+            _bindingsLoading.Fail();
+            ShowDisconnected();
+            UpdateLoadingVisuals();
+        }
+    }
+
+    private void UpdateLoadingVisuals()
+    {
+        LoadingState.Visibility = _bindingsLoading.ShouldShowLoading ? Visibility.Visible : Visibility.Collapsed;
+        BindingsList.Visibility = _bindingsLoading.ShouldShowContent ? Visibility.Visible : Visibility.Collapsed;
+        SingleAgentInfoBar.IsOpen = _bindingsLoading.ShouldShowEmpty;
+        RefreshButton.IsEnabled = CurrentApp.GatewayClient != null && _bindingsLoading.CanEdit;
+    }
+
+    private void ShowDisconnected()
+    {
+        ConnectionInfoBar.Title = "Gateway disconnected";
+        ConnectionInfoBar.Message = "Connect to a gateway to load bindings.";
+        ConnectionInfoBar.Severity = InfoBarSeverity.Warning;
+        ConnectionInfoBar.IsOpen = true;
+    }
+
+    private void ShowLoadFailure(Exception ex)
+    {
+        ConnectionInfoBar.Title = "Could not load bindings";
+        ConnectionInfoBar.Message = ex.Message;
+        ConnectionInfoBar.Severity = InfoBarSeverity.Error;
+        ConnectionInfoBar.IsOpen = true;
     }
 
     private class BindingViewModel

--- a/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml
@@ -18,19 +18,26 @@
         <StackPanel Grid.Row="0" Spacing="8" Margin="0,0,0,12">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Text="⏱️ Cron Jobs" Style="{StaticResource TitleTextBlockStyle}" Grid.Column="0"/>
-                <TextBlock x:Name="JobCountText" Text="(0)" VerticalAlignment="Center" Grid.Column="1" Margin="8,0,0,0"
-                           Style="{StaticResource CaptionTextBlockStyle}"
-                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                <Button x:Name="NewJobButton" Grid.Column="3" Click="OnNewJobClick" Padding="8,4">
-                    <StackPanel Orientation="Horizontal" Spacing="4">
-                        <FontIcon Glyph="&#xE710;" FontSize="14"/>
-                        <TextBlock Text="New Job" FontSize="13"/>
+                     <ColumnDefinition Width="Auto"/>
+                     <ColumnDefinition Width="Auto"/>
+                     <ColumnDefinition Width="*"/>
+                     <ColumnDefinition Width="Auto"/>
+                     <ColumnDefinition Width="Auto"/>
+                 </Grid.ColumnDefinitions>
+                 <TextBlock Text="⏱️ Cron Jobs" Style="{StaticResource TitleTextBlockStyle}" Grid.Column="0"/>
+                 <TextBlock x:Name="JobCountText" Text="(0)" VerticalAlignment="Center" Grid.Column="1" Margin="8,0,0,0"
+                            Style="{StaticResource CaptionTextBlockStyle}"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                 <Button x:Name="RefreshButton" Grid.Column="3" Click="OnRefreshClick" Padding="8,4" Margin="0,0,8,0">
+                     <StackPanel Orientation="Horizontal" Spacing="4">
+                         <FontIcon Glyph="&#xE72C;" FontSize="14"/>
+                         <TextBlock Text="Refresh" FontSize="13"/>
+                     </StackPanel>
+                 </Button>
+                 <Button x:Name="NewJobButton" Grid.Column="4" Click="OnNewJobClick" Padding="8,4">
+                     <StackPanel Orientation="Horizontal" Spacing="4">
+                         <FontIcon Glyph="&#xE710;" FontSize="14"/>
+                         <TextBlock Text="New Job" FontSize="13"/>
                     </StackPanel>
                 </Button>
             </Grid>
@@ -60,8 +67,18 @@
             </Border>
         </StackPanel>
 
-        <!-- Store path (hidden, just for data) -->
-        <TextBlock x:Name="StorePathText" Visibility="Collapsed"/>
+         <!-- Store path (hidden, just for data) -->
+         <TextBlock x:Name="StorePathText" Visibility="Collapsed"/>
+
+         <InfoBar x:Name="ConnectionInfoBar" Grid.Row="1"
+                  IsOpen="False" IsClosable="False" Severity="Warning"
+                  Title="Gateway disconnected"
+                  Message="Connect to a gateway to load cron jobs."
+                  Margin="0,0,0,12">
+             <InfoBar.ActionButton>
+                 <Button Content="Open Connection" Click="OnOpenConnectionClick"/>
+             </InfoBar.ActionButton>
+         </InfoBar>
 
         <!-- Job creation/edit form -->
         <Border x:Name="JobFormPanel" Grid.Row="2" Visibility="Collapsed"
@@ -263,12 +280,22 @@
         <!-- Notification for completed one-shot jobs -->
         <InfoBar x:Name="JobCompletedInfoBar" Grid.Row="3" IsOpen="False" Severity="Success" IsClosable="True" Margin="0,0,0,8"/>
 
-        <!-- Jobs list (manually managed for inline editing) -->
-        <StackPanel x:Name="JobsListPanel" Grid.Row="4" Spacing="4" Visibility="Collapsed"/>
+         <!-- Jobs list (manually managed for inline editing) -->
+         <StackPanel x:Name="JobsListPanel" Grid.Row="4" Spacing="4" Visibility="Collapsed"/>
 
-        <!-- Empty state -->
-        <StackPanel x:Name="EmptyState" Grid.Row="4"
-                    VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8">
+         <StackPanel x:Name="LoadingState" Grid.Row="4" Orientation="Horizontal" Spacing="12"
+                     HorizontalAlignment="Center" VerticalAlignment="Center"
+                     Visibility="Visible">
+             <ProgressRing IsActive="True" Width="22" Height="22"/>
+             <TextBlock Text="Loading cron jobs..."
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        VerticalAlignment="Center"/>
+         </StackPanel>
+
+         <!-- Empty state -->
+         <StackPanel x:Name="EmptyState" Grid.Row="4"
+                     VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8"
+                     Visibility="Collapsed">
             <TextBlock Text="⏱️" FontSize="48" HorizontalAlignment="Center"/>
             <TextBlock Text="No cron jobs configured"
                        Style="{StaticResource SubtitleTextBlockStyle}"

--- a/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
@@ -26,6 +26,7 @@ public sealed partial class CronPage : Page
     private HashSet<string> _removedJobIds = new(); // jobs user explicitly removed (suppress auto-delete notification)
     private HashSet<string> _expandedJobIds = new(); // persisted expanded state
     private CancellationTokenSource? _infoDismissCts = null; // auto-dismiss timer for InfoBar
+    private readonly AsyncListLoadingState _cronLoading = new();
 
     public CronPage()
     {
@@ -38,13 +39,47 @@ public sealed partial class CronPage : Page
 
     public void Initialize()
     {
+        if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
         _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
-        if (CurrentApp.GatewayClient != null)
+        var client = CurrentApp.GatewayClient;
+        if (client != null)
         {
-            _ = CurrentApp.GatewayClient.RequestCronListAsync();
-            _ = CurrentApp.GatewayClient.RequestCronStatusAsync();
+            ConnectionInfoBar.IsOpen = false;
+            _cronLoading.BeginInitialRefresh();
+            UpdateCronLoadingVisuals();
+            _ = client.RequestCronListAsync();
+            _ = client.RequestCronStatusAsync();
         }
+        else
+        {
+            _cronLoading.Fail();
+            ShowDisconnected();
+            UpdateCronLoadingVisuals();
+        }
+    }
+
+    private void OnOpenConnectionClick(object sender, RoutedEventArgs e)
+        => ((IAppCommands)CurrentApp).Navigate("connection");
+
+    private void OnRefreshClick(object sender, RoutedEventArgs e)
+    {
+        var client = CurrentApp.GatewayClient;
+        if (client == null)
+        {
+            _cronLoading.Fail();
+            ShowDisconnected();
+            UpdateCronLoadingVisuals();
+            return;
+        }
+
+        ConnectionInfoBar.IsOpen = false;
+        _cronLoading.BeginRefresh();
+        if (_editingJobId == null)
+            RebuildJobCards();
+        UpdateCronLoadingVisuals();
+        _ = client.RequestCronListAsync();
+        _ = client.RequestCronStatusAsync();
     }
 
     private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
@@ -67,7 +102,9 @@ public sealed partial class CronPage : Page
     {
         var btn = sender as Button;
         var jobId = btn?.Tag as string;
-        if (string.IsNullOrEmpty(jobId) || CurrentApp.GatewayClient == null) return;
+        if (string.IsNullOrEmpty(jobId)) return;
+        if (!_cronLoading.CanEdit) return;
+        if (CurrentApp.GatewayClient == null) { ShowDisconnected(); return; }
         var vm = _jobs.Find(j => j.Id == jobId);
         if (vm != null && !vm.IsEnabled) return;
         _runningJobIds.Add(jobId);
@@ -105,7 +142,9 @@ public sealed partial class CronPage : Page
     private void OnRemoveClick(object sender, RoutedEventArgs e)
     {
         var jobId = (sender as Button)?.Tag as string;
-        if (string.IsNullOrEmpty(jobId) || CurrentApp.GatewayClient == null) return;
+        if (string.IsNullOrEmpty(jobId)) return;
+        if (!_cronLoading.CanEdit) return;
+        if (CurrentApp.GatewayClient == null) { ShowDisconnected(); return; }
         _removedJobIds.Add(jobId);
         // Gateway client's HandleKnownResponse refreshes the list automatically on cron.remove
         _ = CurrentApp.GatewayClient.RemoveCronJobAsync(jobId);
@@ -114,7 +153,9 @@ public sealed partial class CronPage : Page
     private void OnToggleEnabledClick(object sender, RoutedEventArgs e)
     {
         var jobId = (sender as Button)?.Tag as string;
-        if (string.IsNullOrEmpty(jobId) || CurrentApp.GatewayClient == null) return;
+        if (string.IsNullOrEmpty(jobId)) return;
+        if (!_cronLoading.CanEdit) return;
+        if (CurrentApp.GatewayClient == null) { ShowDisconnected(); return; }
 
         var vm = _jobs.Find(j => j.Id == jobId);
         if (vm != null)
@@ -128,6 +169,8 @@ public sealed partial class CronPage : Page
 
     private void OnNewJobClick(object sender, RoutedEventArgs e)
     {
+        if (!_cronLoading.CanEdit) return;
+        if (CurrentApp.GatewayClient == null) { ShowDisconnected(); return; }
         _editingJobId = null;
         RestoreFormFromInline(); // ensure form is back in its home position
         ResetForm();
@@ -140,6 +183,8 @@ public sealed partial class CronPage : Page
     {
         var jobId = (sender as Button)?.Tag as string;
         if (string.IsNullOrEmpty(jobId)) return;
+        if (!_cronLoading.CanEdit) return;
+        if (CurrentApp.GatewayClient == null) { ShowDisconnected(); return; }
         var vm = _jobs.Find(j => j.Id == jobId);
         if (vm == null || !vm.IsEnabled) return;
 
@@ -206,6 +251,12 @@ public sealed partial class CronPage : Page
 
     private void OnFormSaveClick(object sender, RoutedEventArgs e)
     {
+        if (!_cronLoading.CanEdit)
+        {
+            ShowFormError("Wait for the latest cron jobs to finish loading before saving changes.");
+            return;
+        }
+
         // Validate
         var name = FormName.Text?.Trim();
         if (string.IsNullOrEmpty(name))
@@ -738,17 +789,17 @@ public sealed partial class CronPage : Page
             if (jobs.Count > 0)
             {
                 // Don't rebuild cards if we're currently editing inline (would lose the form)
-                if (_editingJobId == null)
+            _cronLoading.Complete(jobs.Count);
+
+            if (_editingJobId == null)
                     RebuildJobCards();
-                JobsListPanel.Visibility = Visibility.Visible;
-                EmptyState.Visibility = Visibility.Collapsed;
             }
             else
             {
                 JobsListPanel.Children.Clear();
-                JobsListPanel.Visibility = Visibility.Collapsed;
-                EmptyState.Visibility = Visibility.Visible;
             }
+
+            UpdateCronLoadingVisuals();
         });
     }
 
@@ -778,6 +829,25 @@ public sealed partial class CronPage : Page
             StorePathText.Text = storePath;
             NextWakeText.Text = $"· Next wake: {nextWake}";
         });
+    }
+
+    private void UpdateCronLoadingVisuals()
+    {
+        LoadingState.Visibility = _cronLoading.ShouldShowLoading ? Visibility.Visible : Visibility.Collapsed;
+        JobsListPanel.Visibility = _cronLoading.ShouldShowContent ? Visibility.Visible : Visibility.Collapsed;
+        EmptyState.Visibility = _cronLoading.ShouldShowEmpty ? Visibility.Visible : Visibility.Collapsed;
+        var canUseGateway = CurrentApp.GatewayClient != null && _cronLoading.CanEdit;
+        NewJobButton.IsEnabled = canUseGateway;
+        RefreshButton.IsEnabled = canUseGateway;
+        FormSaveButton.IsEnabled = _cronLoading.CanEdit;
+    }
+
+    private void ShowDisconnected()
+    {
+        ConnectionInfoBar.Title = "Gateway disconnected";
+        ConnectionInfoBar.Message = "Connect to a gateway to load cron jobs.";
+        ConnectionInfoBar.Severity = InfoBarSeverity.Warning;
+        ConnectionInfoBar.IsOpen = true;
     }
 
     private static string FormatCronSchedule(JsonElement sched, string tz)
@@ -1227,9 +1297,9 @@ public sealed partial class CronPage : Page
         return chip;
     }
 
-    private static Button MakeActionButton(string glyph, string text, string jobId, RoutedEventHandler handler)
+    private Button MakeActionButton(string glyph, string text, string jobId, RoutedEventHandler handler)
     {
-        var btn = new Button { Tag = jobId, FontSize = 12, Padding = new Thickness(8, 4, 8, 4) };
+        var btn = new Button { Tag = jobId, FontSize = 12, Padding = new Thickness(8, 4, 8, 4), IsEnabled = _cronLoading.CanEdit };
         var sp = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 4 };
         sp.Children.Add(new FontIcon { Glyph = glyph, FontSize = 12 });
         sp.Children.Add(new TextBlock { Text = text });
@@ -1243,7 +1313,9 @@ public sealed partial class CronPage : Page
     private void OnHistoryClick(object sender, RoutedEventArgs e)
     {
         var jobId = (sender as Button)?.Tag as string;
-        if (string.IsNullOrEmpty(jobId) || CurrentApp.GatewayClient == null) return;
+        if (string.IsNullOrEmpty(jobId)) return;
+        if (!_cronLoading.CanEdit) return;
+        if (CurrentApp.GatewayClient == null) { ShowDisconnected(); return; }
         var vm = _jobs.Find(j => j.Id == jobId);
         if (vm != null && !vm.IsEnabled) return;
         if (_historyJobId == jobId)

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
@@ -45,9 +45,27 @@
 
         <!-- Channel filter SelectorBar -->
         <SelectorBar x:Name="ChannelSelector" Grid.Row="2"
-                     SelectionChanged="ChannelSelector_SelectionChanged">
+                      SelectionChanged="ChannelSelector_SelectionChanged">
             <SelectorBarItem x:Name="AllTab" Text="All" IsSelected="True"/>
         </SelectorBar>
+
+        <InfoBar x:Name="ConnectionInfoBar" Grid.Row="3"
+                 IsOpen="False" IsClosable="False" Severity="Warning"
+                 Title="Gateway disconnected"
+                 Message="Connect to a gateway to load sessions.">
+            <InfoBar.ActionButton>
+                <Button Content="Open Connection" Click="OnOpenConnectionClick"/>
+            </InfoBar.ActionButton>
+        </InfoBar>
+
+        <StackPanel x:Name="LoadingState" Grid.Row="4" Orientation="Horizontal" Spacing="12"
+                    HorizontalAlignment="Center" VerticalAlignment="Center"
+                    Visibility="Collapsed">
+            <ProgressRing IsActive="True" Width="22" Height="22"/>
+            <TextBlock Text="Loading sessions..."
+                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                       VerticalAlignment="Center"/>
+        </StackPanel>
 
         <!-- Empty state -->
         <StackPanel x:Name="EmptyState" Grid.Row="4" Spacing="8"
@@ -116,12 +134,15 @@
 
                             <!-- Row 4: Action buttons -->
                             <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8" Margin="16,4,0,0">
-                                <Button Content="Reset" Tag="{Binding Key}" Click="OnResetSession"
-                                        Style="{StaticResource DefaultButtonStyle}" Padding="8,4"/>
-                                <Button Content="Compact" Tag="{Binding Key}" Click="OnCompactSession"
-                                        Style="{StaticResource DefaultButtonStyle}" Padding="8,4"/>
-                                <Button Content="Delete" Tag="{Binding Key}" Click="OnDeleteSession"
-                                        Foreground="IndianRed" Padding="8,4"/>
+                                 <Button Content="Reset" Tag="{Binding Key}" Click="OnResetSession"
+                                         IsEnabled="{Binding CanEdit}"
+                                         Style="{StaticResource DefaultButtonStyle}" Padding="8,4"/>
+                                 <Button Content="Compact" Tag="{Binding Key}" Click="OnCompactSession"
+                                         IsEnabled="{Binding CanEdit}"
+                                         Style="{StaticResource DefaultButtonStyle}" Padding="8,4"/>
+                                 <Button Content="Delete" Tag="{Binding Key}" Click="OnDeleteSession"
+                                         IsEnabled="{Binding CanEdit}"
+                                         Foreground="IndianRed" Padding="8,4"/>
                             </StackPanel>
                         </Grid>
                     </Border>

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -19,6 +19,7 @@ public sealed partial class SessionsPage : Page
     private SessionInfo[]? _allSessions;
     private string _activeChannel = "all";
     private Microsoft.UI.Dispatching.DispatcherQueueTimer? _refreshTimer;
+    private readonly AsyncListLoadingState _sessionLoading = new();
 
     public SessionsPage()
     {
@@ -45,26 +46,44 @@ public sealed partial class SessionsPage : Page
             ? Visibility.Visible
             : Visibility.Collapsed;
 
-        if (CurrentApp.GatewayClient == null)
+        var client = CurrentApp.GatewayClient;
+        if (client == null)
         {
-            EmptyState.Visibility = Visibility.Collapsed;
-            SessionListView.ItemsSource = null;
+            _sessionLoading.Fail();
+            ShowDisconnected();
+            ApplyFilter();
             return;
         }
 
-        if (_appState?.Sessions != null)
-            UpdateSessions(_appState.Sessions);
+        ConnectionInfoBar.IsOpen = false;
 
-        _ = CurrentApp.GatewayClient.RequestSessionsAsync();
-        _ = CurrentApp.GatewayClient.RequestModelsListAsync();
+        if (_appState?.Sessions is { Length: > 0 } sessions)
+        {
+            _sessionLoading.Complete(sessions.Length);
+            UpdateSessions(sessions);
+            _sessionLoading.BeginRefresh();
+            ApplyFilter();
+        }
+        else
+        {
+            _sessionLoading.BeginInitialRefresh();
+            ApplyFilter();
+        }
+
+        _ = client.RequestSessionsAsync();
+        _ = client.RequestModelsListAsync();
     }
 
     private void OnBackToConnectionClicked(object sender, RoutedEventArgs e)
         => ((IAppCommands)CurrentApp).Navigate("connection");
 
+    private void OnOpenConnectionClick(object sender, RoutedEventArgs e)
+        => ((IAppCommands)CurrentApp).Navigate("connection");
+
     public void UpdateSessions(SessionInfo[] sessions)
     {
         _allSessions = sessions;
+        _sessionLoading.Complete(sessions.Length);
         RebuildChannelTabs();
         ApplyFilter();
     }
@@ -92,16 +111,18 @@ public sealed partial class SessionsPage : Page
 
     private void ApplyFilter()
     {
-        if (_allSessions == null || _allSessions.Length == 0)
+        if (!_sessionLoading.HasLoaded)
         {
             SessionListView.ItemsSource = null;
-            EmptyState.Visibility = Visibility.Visible;
+            SessionListView.Visibility = Visibility.Collapsed;
+            EmptyState.Visibility = Visibility.Collapsed;
+            LoadingState.Visibility = _sessionLoading.ShouldShowLoading ? Visibility.Visible : Visibility.Collapsed;
+            RefreshButton.IsEnabled = CurrentApp.GatewayClient != null && _sessionLoading.CanEdit;
+            ChannelSelector.IsEnabled = false;
             return;
         }
 
-        EmptyState.Visibility = Visibility.Collapsed;
-
-        IEnumerable<SessionInfo> filtered = _allSessions;
+        IEnumerable<SessionInfo> filtered = _allSessions ?? Array.Empty<SessionInfo>();
 
         if (_activeChannel != "all")
         {
@@ -117,12 +138,19 @@ public sealed partial class SessionsPage : Page
         if (viewModels.Count == 0)
         {
             SessionListView.ItemsSource = null;
-            EmptyState.Visibility = Visibility.Visible;
+            SessionListView.Visibility = Visibility.Collapsed;
+            EmptyState.Visibility = _sessionLoading.ShouldShowEmpty || _sessionLoading.HasLoaded ? Visibility.Visible : Visibility.Collapsed;
         }
         else
         {
             SessionListView.ItemsSource = viewModels;
+            SessionListView.Visibility = Visibility.Visible;
+            EmptyState.Visibility = Visibility.Collapsed;
         }
+
+        LoadingState.Visibility = _sessionLoading.ShouldShowLoading ? Visibility.Visible : Visibility.Collapsed;
+        RefreshButton.IsEnabled = CurrentApp.GatewayClient != null && _sessionLoading.CanEdit;
+        ChannelSelector.IsEnabled = _sessionLoading.HasLoaded && _sessionLoading.CanEdit;
     }
 
     private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
@@ -166,6 +194,7 @@ public sealed partial class SessionsPage : Page
             TokensText = tokensText,
             ContextPercent = contextPercent,
             HasTokenData = hasTokens || contextPercent > 0,
+            CanEdit = _sessionLoading.CanEdit,
         };
     }
 
@@ -181,9 +210,9 @@ public sealed partial class SessionsPage : Page
         if (sender is Button btn && btn.Tag is string key)
         {
             var client = CurrentApp.GatewayClient;
-            if (client == null) return;
+            if (client == null) { ShowDisconnected(); return; }
             try { await client.ResetSessionAsync(key); }
-            catch { }
+            catch (Exception ex) { ShowActionFailure("Reset failed", ex); }
         }
     }
 
@@ -192,9 +221,9 @@ public sealed partial class SessionsPage : Page
         if (sender is Button btn && btn.Tag is string key)
         {
             var client = CurrentApp.GatewayClient;
-            if (client == null) return;
+            if (client == null) { ShowDisconnected(); return; }
             try { await client.DeleteSessionAsync(key); }
-            catch { }
+            catch (Exception ex) { ShowActionFailure("Delete failed", ex); }
         }
     }
 
@@ -203,20 +232,28 @@ public sealed partial class SessionsPage : Page
         if (sender is Button btn && btn.Tag is string key)
         {
             var client = CurrentApp.GatewayClient;
-            if (client == null) return;
+            if (client == null) { ShowDisconnected(); return; }
             try { await client.CompactSessionAsync(key); }
-            catch { }
+            catch (Exception ex) { ShowActionFailure("Compact failed", ex); }
         }
     }
 
     private void OnRefresh(object sender, RoutedEventArgs e)
     {
         var client = CurrentApp.GatewayClient;
-        if (client != null)
+        if (client == null)
         {
-            _ = client.RequestSessionsAsync();
-            _ = client.RequestModelsListAsync();
+            _sessionLoading.Fail();
+            ShowDisconnected();
+            ApplyFilter();
+            return;
         }
+
+        ConnectionInfoBar.IsOpen = false;
+        _sessionLoading.BeginRefresh();
+        ApplyFilter();
+        _ = client.RequestSessionsAsync();
+        _ = client.RequestModelsListAsync();
 
         if (RefreshButton.Content is StackPanel)
         {
@@ -240,6 +277,23 @@ public sealed partial class SessionsPage : Page
         if (n >= 1_000) return $"{n / 1_000.0:0.#}K";
         return n.ToString();
     }
+
+    private void ShowDisconnected()
+    {
+        ConnectionInfoBar.Title = "Gateway disconnected";
+        ConnectionInfoBar.Message = "Connect to a gateway to load sessions.";
+        ConnectionInfoBar.Severity = InfoBarSeverity.Warning;
+        ConnectionInfoBar.IsOpen = true;
+        RefreshButton.IsEnabled = false;
+    }
+
+    private void ShowActionFailure(string title, Exception ex)
+    {
+        ConnectionInfoBar.Title = title;
+        ConnectionInfoBar.Message = ex.Message;
+        ConnectionInfoBar.Severity = InfoBarSeverity.Error;
+        ConnectionInfoBar.IsOpen = true;
+    }
 }
 
 public class SessionViewModel
@@ -252,5 +306,6 @@ public class SessionViewModel
     public string TokensText { get; set; } = "";
     public double ContextPercent { get; set; }
     public bool HasTokenData { get; set; }
+    public bool CanEdit { get; set; } = true;
     public Visibility TokenRowVisibility => HasTokenData ? Visibility.Visible : Visibility.Collapsed;
 }

--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml
@@ -9,6 +9,15 @@
 
             <TextBlock x:Uid="UsagePage_TextBlock_10" Text="📊 Usage &amp; Cost" Style="{StaticResource TitleTextBlockStyle}"/>
 
+            <InfoBar x:Name="ConnectionInfoBar"
+                     IsOpen="False" IsClosable="False" Severity="Warning"
+                     Title="Gateway disconnected"
+                     Message="Connect to a gateway to load usage data.">
+                <InfoBar.ActionButton>
+                    <Button Content="Open Connection" Click="OnOpenConnectionClick"/>
+                </InfoBar.ActionButton>
+            </InfoBar>
+
             <!-- Big number: Total Cost -->
             <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
@@ -121,8 +130,20 @@
                             <SelectorBarItem x:Uid="Period30DaysItem" x:Name="Period30DaysItem" Text="30 Days"/>
                         </SelectorBar>
                     </Grid>
-                    <Border Height="1" Background="{ThemeResource CardStrokeColorDefaultBrush}"/>
-                    <ListView x:Name="DailyListView" SelectionMode="None">
+                     <Border Height="1" Background="{ThemeResource CardStrokeColorDefaultBrush}"/>
+                    <StackPanel x:Name="DailyLoadingPanel" Orientation="Horizontal" Spacing="12"
+                                HorizontalAlignment="Center" Padding="0,24,0,16">
+                        <ProgressRing IsActive="True" Width="20" Height="20"/>
+                        <TextBlock Text="Loading daily costs..."
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   VerticalAlignment="Center"/>
+                    </StackPanel>
+                    <TextBlock x:Name="DailyEmptyText"
+                               Text="No daily usage for this period"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               HorizontalAlignment="Center" Padding="0,24,0,16"
+                               Visibility="Collapsed"/>
+                     <ListView x:Name="DailyListView" SelectionMode="None">
                         <ListView.ItemTemplate>
                             <DataTemplate>
                                 <Grid Padding="4,6">

--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
@@ -16,6 +16,9 @@ public sealed partial class UsagePage : Page
     private AppState? _appState;
     // Default matches the XAML-selected Period7DaysItem (IsSelected="True").
     private int _currentPeriodDays = 7;
+    private readonly AsyncListLoadingState _providerLoading = new();
+    private readonly AsyncListLoadingState _dailyCostLoading = new();
+    private DateTime _lastAppliedUsageCostUpdatedAtUtc = DateTime.MinValue;
 
     public UsagePage()
     {
@@ -28,10 +31,13 @@ public sealed partial class UsagePage : Page
 
     public void Initialize()
     {
+        if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
         _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
-        if (CurrentApp.GatewayClient != null)
+        var client = CurrentApp.GatewayClient;
+        if (client != null)
         {
+            ConnectionInfoBar.IsOpen = false;
             // Apply cached data immediately, then request fresh.
             if (_appState?.Usage != null) UpdateUsage(_appState.Usage);
             // Only apply cached cost data when its period matches the current
@@ -40,18 +46,32 @@ public sealed partial class UsagePage : Page
             if (_appState?.UsageCost != null && _appState.UsageCost.Days == _currentPeriodDays)
             {
                 UpdateUsageCost(_appState.UsageCost);
+                _dailyCostLoading.BeginRefresh();
+            }
+            else
+            {
+                _dailyCostLoading.BeginInitialRefresh();
             }
             if (_appState?.UsageStatus != null) UpdateUsageStatus(_appState.UsageStatus);
-            _ = CurrentApp.GatewayClient.RequestUsageAsync();
-            _ = CurrentApp.GatewayClient.RequestUsageCostAsync(_currentPeriodDays);
-            _ = CurrentApp.GatewayClient.RequestUsageStatusAsync();
+            else _providerLoading.BeginInitialRefresh();
+            UpdateDailyCostLoadingVisuals();
+            UpdateProviderLoadingVisuals();
+            _ = client.RequestUsageAsync();
+            _ = client.RequestUsageCostAsync(_currentPeriodDays);
+            _ = client.RequestUsageStatusAsync();
         }
         else
         {
-            // Not connected — nothing to load, hide the loading skeleton.
-            ProviderLoadingPanel.Visibility = Visibility.Collapsed;
+            _providerLoading.Fail();
+            _dailyCostLoading.Fail();
+            ShowDisconnected();
+            UpdateProviderLoadingVisuals();
+            UpdateDailyCostLoadingVisuals();
         }
     }
+
+    private void OnOpenConnectionClick(object sender, RoutedEventArgs e)
+        => ((IAppCommands)CurrentApp).Navigate("connection");
 
     private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
     {
@@ -80,6 +100,13 @@ public sealed partial class UsagePage : Page
 
     public void UpdateUsageCost(GatewayCostUsageInfo cost)
     {
+        if (cost.Days != _currentPeriodDays)
+            return;
+
+        if (cost.UpdatedAt < _lastAppliedUsageCostUpdatedAtUtc)
+            return;
+
+        _lastAppliedUsageCostUpdatedAtUtc = cost.UpdatedAt;
         TotalCostText.Text = $"${cost.Totals.TotalCost:F2}";
         TokenCountText.Text = FormatLargeNumber(cost.Totals.TotalTokens);
 
@@ -88,6 +115,8 @@ public sealed partial class UsagePage : Page
             Date = d.Date,
             Cost = $"${d.TotalCost:F2}",
         }).ToList();
+        _dailyCostLoading.Complete(cost.Daily.Count);
+        UpdateDailyCostLoadingVisuals();
     }
 
     public void UpdateUsageStatus(GatewayUsageStatusInfo status)
@@ -102,9 +131,8 @@ public sealed partial class UsagePage : Page
         }).ToList();
 
         bool hasProviders = status.Providers.Count > 0;
-        ProviderLoadingPanel.Visibility = Visibility.Collapsed;
-        ProviderListView.Visibility = hasProviders ? Visibility.Visible : Visibility.Collapsed;
-        ProviderEmptyText.Visibility = hasProviders ? Visibility.Collapsed : Visibility.Visible;
+        _providerLoading.Complete(status.Providers.Count);
+        UpdateProviderLoadingVisuals();
     }
 
     private void OnPeriodSelectionChanged(SelectorBar sender, SelectorBarSelectionChangedEventArgs args)
@@ -117,11 +145,46 @@ public sealed partial class UsagePage : Page
     {
         if (days == _currentPeriodDays) return;
         _currentPeriodDays = days;
+        _lastAppliedUsageCostUpdatedAtUtc = DateTime.MinValue;
+        DailyListView.ItemsSource = null;
+        TotalCostText.Text = "—";
+        TokenCountText.Text = "—";
+        _dailyCostLoading.BeginInitialRefresh();
+        UpdateDailyCostLoadingVisuals();
 
         if (CurrentApp.GatewayClient != null)
         {
             _ = CurrentApp.GatewayClient.RequestUsageCostAsync(days);
         }
+        else
+        {
+            _dailyCostLoading.Fail();
+            ShowDisconnected();
+            UpdateDailyCostLoadingVisuals();
+        }
+    }
+
+    private void UpdateDailyCostLoadingVisuals()
+    {
+        DailyLoadingPanel.Visibility = _dailyCostLoading.ShouldShowLoading ? Visibility.Visible : Visibility.Collapsed;
+        DailyListView.Visibility = _dailyCostLoading.ShouldShowContent ? Visibility.Visible : Visibility.Collapsed;
+        DailyEmptyText.Visibility = _dailyCostLoading.ShouldShowEmpty ? Visibility.Visible : Visibility.Collapsed;
+        PeriodSelector.IsEnabled = _dailyCostLoading.CanEdit;
+    }
+
+    private void UpdateProviderLoadingVisuals()
+    {
+        ProviderLoadingPanel.Visibility = _providerLoading.ShouldShowLoading ? Visibility.Visible : Visibility.Collapsed;
+        ProviderListView.Visibility = _providerLoading.ShouldShowContent ? Visibility.Visible : Visibility.Collapsed;
+        ProviderEmptyText.Visibility = _providerLoading.ShouldShowEmpty ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private void ShowDisconnected()
+    {
+        ConnectionInfoBar.Title = "Gateway disconnected";
+        ConnectionInfoBar.Message = "Connect to a gateway to load usage data.";
+        ConnectionInfoBar.Severity = InfoBarSeverity.Warning;
+        ConnectionInfoBar.IsOpen = true;
     }
 
     private static string FormatLargeNumber(long n)

--- a/src/OpenClaw.Tray.WinUI/Services/AsyncListLoadingState.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AsyncListLoadingState.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace OpenClawTray.Services;
+
+internal sealed class AsyncListLoadingState
+{
+    public bool HasLoaded { get; private set; }
+    public bool IsRefreshing { get; private set; }
+    public int ItemCount { get; private set; }
+
+    public bool HasItems => HasLoaded && ItemCount > 0;
+    public bool CanEdit => !IsRefreshing;
+    public bool ShouldShowLoading => IsRefreshing && !HasLoaded;
+    public bool ShouldShowContent => HasItems;
+    public bool ShouldShowEmpty => HasLoaded && ItemCount == 0;
+
+    public void BeginRefresh()
+    {
+        IsRefreshing = true;
+    }
+
+    public void BeginInitialRefresh()
+    {
+        HasLoaded = false;
+        ItemCount = 0;
+        IsRefreshing = true;
+    }
+
+    public void Complete(int itemCount)
+    {
+        ItemCount = Math.Max(0, itemCount);
+        HasLoaded = true;
+        IsRefreshing = false;
+    }
+
+    public void Fail()
+    {
+        IsRefreshing = false;
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/AsyncListLoadingPageWiringTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AsyncListLoadingPageWiringTests.cs
@@ -1,0 +1,98 @@
+using System.IO;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class AsyncListLoadingPageWiringTests
+{
+    [Theory]
+    [InlineData("SessionsPage.xaml", "Loading sessions")]
+    [InlineData("CronPage.xaml", "Loading cron jobs")]
+    [InlineData("UsagePage.xaml", "Loading daily costs")]
+    [InlineData("BindingsPage.xaml", "Loading bindings")]
+    public void BigListPages_HaveFirstLoadPlaceholders(string fileName, string loadingText)
+    {
+        var source = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", fileName);
+
+        Assert.Contains("<ProgressRing", source);
+        Assert.Contains(loadingText, source);
+    }
+
+    [Theory]
+    [InlineData("SessionsPage.xaml.cs")]
+    [InlineData("CronPage.xaml.cs")]
+    [InlineData("UsagePage.xaml.cs")]
+    [InlineData("BindingsPage.xaml.cs")]
+    public void BigListPages_DisableListInteractionsDuringRefresh(string fileName)
+    {
+        var source = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", fileName);
+
+        Assert.Contains("AsyncListLoadingState", source);
+        Assert.Contains(".BeginRefresh()", source);
+        Assert.Contains(".CanEdit", source);
+    }
+
+    [Theory]
+    [InlineData("SessionsPage.xaml.cs")]
+    [InlineData("CronPage.xaml.cs")]
+    [InlineData("UsagePage.xaml.cs")]
+    [InlineData("BindingsPage.xaml.cs")]
+    public void BigListPages_SurfaceDisconnectedState(string fileName)
+    {
+        var source = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", fileName);
+
+        Assert.Contains("ShowDisconnected", source);
+        Assert.Contains("Navigate(\"connection\")", source);
+        Assert.Contains(".Fail()", source);
+    }
+
+    [Fact]
+    public void UsagePage_GuardsStalePeriodResponses()
+    {
+        var source = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", "UsagePage.xaml.cs");
+
+        Assert.Contains("cost.Days != _currentPeriodDays", source);
+        Assert.Contains("cost.UpdatedAt < _lastAppliedUsageCostUpdatedAtUtc", source);
+        Assert.Contains("_dailyCostLoading.BeginInitialRefresh()", source);
+    }
+
+    [Fact]
+    public void CronPage_DefaultsToLoadingUntilFirstListResponse()
+    {
+        var xaml = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", "CronPage.xaml");
+        var source = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", "CronPage.xaml.cs");
+
+        Assert.Contains("x:Name=\"LoadingState\" Grid.Row=\"4\"", xaml);
+        Assert.Contains("Visibility=\"Visible\"", xaml);
+        Assert.Contains("x:Name=\"EmptyState\" Grid.Row=\"4\"", xaml);
+        Assert.Contains("Visibility=\"Collapsed\"", xaml);
+        Assert.Contains("_cronLoading.Complete(jobs.Count)", source);
+    }
+
+    private static string ReadSource(params string[] relativePathParts)
+    {
+        var root = GetRepositoryRoot();
+        return File.ReadAllText(Path.Combine(new[] { root }.Concat(relativePathParts).ToArray()));
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        var env = Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT");
+        if (!string.IsNullOrWhiteSpace(env) && Directory.Exists(env))
+            return env;
+
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "openclaw-windows-node.slnx")) &&
+                Directory.Exists(Path.Combine(directory.FullName, "src")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException(
+            "Could not find repository root. Set OPENCLAW_REPO_ROOT to the repo path.");
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/AsyncListLoadingStateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AsyncListLoadingStateTests.cs
@@ -1,0 +1,86 @@
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class AsyncListLoadingStateTests
+{
+    [Fact]
+    public void FirstRefresh_ShowsLoadingAndDisablesEdits()
+    {
+        var state = new AsyncListLoadingState();
+
+        state.BeginInitialRefresh();
+
+        Assert.True(state.IsRefreshing);
+        Assert.False(state.CanEdit);
+        Assert.True(state.ShouldShowLoading);
+        Assert.False(state.ShouldShowContent);
+        Assert.False(state.ShouldShowEmpty);
+    }
+
+    [Fact]
+    public void RefreshAfterLoadedItems_KeepsContentVisibleButDisablesEdits()
+    {
+        var state = new AsyncListLoadingState();
+        state.Complete(3);
+
+        state.BeginRefresh();
+
+        Assert.False(state.ShouldShowLoading);
+        Assert.True(state.ShouldShowContent);
+        Assert.False(state.CanEdit);
+    }
+
+    [Fact]
+    public void RefreshAfterLoadedEmpty_KeepsEmptyVisibleButDisablesEdits()
+    {
+        var state = new AsyncListLoadingState();
+        state.Complete(0);
+
+        state.BeginRefresh();
+
+        Assert.False(state.ShouldShowLoading);
+        Assert.True(state.ShouldShowEmpty);
+        Assert.False(state.CanEdit);
+    }
+
+    [Fact]
+    public void BeginInitialRefresh_ClearsStaleContentForNewQueryScope()
+    {
+        var state = new AsyncListLoadingState();
+        state.Complete(3);
+
+        state.BeginInitialRefresh();
+
+        Assert.False(state.HasLoaded);
+        Assert.Equal(0, state.ItemCount);
+        Assert.True(state.ShouldShowLoading);
+    }
+
+    [Fact]
+    public void Fail_StopsRefreshingWithoutChangingLoadedContent()
+    {
+        var state = new AsyncListLoadingState();
+        state.Complete(3);
+
+        state.BeginRefresh();
+        state.Fail();
+
+        Assert.False(state.IsRefreshing);
+        Assert.True(state.HasItems);
+        Assert.True(state.CanEdit);
+    }
+
+    [Fact]
+    public void Complete_NormalizesNegativeCounts()
+    {
+        var state = new AsyncListLoadingState();
+
+        state.Complete(-1);
+
+        Assert.True(state.HasLoaded);
+        Assert.Equal(0, state.ItemCount);
+        Assert.True(state.CanEdit);
+        Assert.True(state.ShouldShowEmpty);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\StartupSetupState.cs" Link="Services\StartupSetupState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SetupExistingGatewayClassifier.cs" Link="Services\SetupExistingGatewayClassifier.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ActivityStreamService.cs" Link="Services\ActivityStreamService.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\AsyncListLoadingState.cs" Link="Services\AsyncListLoadingState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeInvokeActivityFormatter.cs" Link="Services\NodeInvokeActivityFormatter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeCapabilityGating.cs" Link="Services\NodeCapabilityGating.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\TrayTooltipFormatter.cs" Link="Helpers\TrayTooltipFormatter.cs" />


### PR DESCRIPTION
## Summary
- add a small shared `AsyncListLoadingState` for first-load, stale-while-refresh, loaded-empty, and refresh-failed list states
- wire Sessions, Cron, Usage, and Bindings to show explicit loading placeholders instead of flashing empty states on slow gateway responses
- keep safe stale content visible during refresh while disabling unsafe edits/actions, and route disconnected states to Connection settings instead of silently no-oping
- guard Usage daily-cost updates against stale period responses and older same-period payloads

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj` (seeded fresh worktree test build)
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj` (seeded fresh worktree test build)
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`