### PR TITLE
Harden deep-link IPC handling

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -22,6 +22,7 @@ using System.IO;
 using System.IO.Pipes;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,8 +33,6 @@ namespace OpenClawTray;
 
 public partial class App : Application, OpenClawTray.Services.IAppCommands
 {
-    private const string PipeName = "OpenClawTray-DeepLink";
-    
     internal static readonly UpdatumManager AppUpdater = new("shanselman", "openclaw-windows-hub")
     {
         FetchOnlyLatestRelease = true,
@@ -266,6 +265,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         ?? Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "OpenClawTray");
+    private static readonly string DeepLinkPipeName =
+        DeepLinkSecurityPolicy.BuildCurrentUserScopedPipeName(DataPath);
     // Operator/node identity store (DeviceIdentity). Lives at %APPDATA%\OpenClawTray
     // by convention so it follows the user across machines via roaming profile.
     // OPENCLAW_TRAY_APPDATA_DIR isolates a test/E2E identity store the same way
@@ -796,7 +797,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 ? _startupArgs[1] : null);
         if (startupDeepLink != null)
         {
-            HandleDeepLink(startupDeepLink);
+            await HandleDeepLinkAsync(startupDeepLink);
         }
 
         Logger.Info("Application started (WinUI 3)");
@@ -1247,6 +1248,28 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         };
         var result = await dialog.ShowAsync();
         return result == ContentDialogResult.Primary;
+    }
+
+    private async Task<bool> ConfirmDeepLinkActionAsync(DeepLinkResult result)
+    {
+        var root = _keepAliveWindow?.Content as FrameworkElement;
+        if (root?.XamlRoot == null)
+        {
+            Logger.Warn($"Cannot confirm deep link action without XAML root: {DeepLinkSecurityPolicy.RedactForLog($"openclaw://{result.Path}")}");
+            return false;
+        }
+
+        var dialog = new ContentDialog
+        {
+            Title = "Confirm OpenClaw action",
+            Content = $"A deep link wants to {DeepLinkSecurityPolicy.GetActionDisplayName(result)}.",
+            PrimaryButtonText = "Allow",
+            CloseButtonText = "Cancel",
+            DefaultButton = ContentDialogButton.Close,
+            XamlRoot = root.XamlRoot
+        };
+        var dialogResult = await dialog.ShowAsync();
+        return dialogResult == ContentDialogResult.Primary;
     }
 
     private void AddRecentActivity(
@@ -3278,20 +3301,40 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             {
                 try
                 {
-                    using var pipe = new NamedPipeServerStream(PipeName, PipeDirection.In);
+                    using var pipe = new NamedPipeServerStream(
+                        DeepLinkPipeName,
+                        PipeDirection.In,
+                        maxNumberOfServerInstances: 1,
+                        PipeTransmissionMode.Byte,
+                        PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly,
+                        inBufferSize: DeepLinkSecurityPolicy.MaxIpcMessageBytes,
+                        outBufferSize: 0);
                     await pipe.WaitForConnectionAsync(token);
-                    using var reader = new System.IO.StreamReader(pipe);
-                    var uri = await reader.ReadLineAsync(token);
+                    var uri = await ReadDeepLinkIpcPayloadAsync(pipe, token);
                     if (!string.IsNullOrEmpty(uri))
                     {
-                        Logger.Info($"Received deep link via IPC: {uri}");
-                        OnUiThread(() => HandleDeepLink(uri));
+                        Logger.Info($"Received deep link via IPC: {DeepLinkSecurityPolicy.RedactForLog(uri)}");
+                        OnUiThread(() => _ = HandleDeepLinkAsync(uri));
                     }
                 }
                 catch (OperationCanceledException)
                 {
                     Logger.Info("Deep link server stopping (canceled)");
                     break; // Normal shutdown
+                }
+                catch (InvalidDataException ex)
+                {
+                    if (!token.IsCancellationRequested)
+                    {
+                        Logger.Warn($"Rejected deep link IPC payload: {ex.Message}");
+                    }
+                }
+                catch (TimeoutException ex)
+                {
+                    if (!token.IsCancellationRequested)
+                    {
+                        Logger.Warn($"Rejected deep link IPC payload: {ex.Message}");
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -3303,6 +3346,77 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 }
             }
         }, token);
+    }
+
+    private static async Task<string?> ReadDeepLinkIpcPayloadAsync(Stream stream, CancellationToken appToken)
+    {
+        using var readCts = CancellationTokenSource.CreateLinkedTokenSource(appToken);
+        readCts.CancelAfter(DeepLinkSecurityPolicy.IpcReadTimeout);
+
+        var scratch = new byte[1024];
+        var payload = new byte[DeepLinkSecurityPolicy.MaxIpcMessageBytes + 1];
+        var totalBytes = 0;
+
+        try
+        {
+            while (true)
+            {
+                var remaining = payload.Length - totalBytes;
+                if (remaining <= 0)
+                    throw new InvalidDataException("payload exceeds maximum size");
+
+                var read = await stream.ReadAsync(
+                    scratch.AsMemory(0, Math.Min(scratch.Length, remaining)),
+                    readCts.Token);
+                if (read == 0)
+                    break;
+
+                scratch.AsSpan(0, read).CopyTo(payload.AsSpan(totalBytes));
+                totalBytes += read;
+                if (totalBytes > DeepLinkSecurityPolicy.MaxIpcMessageBytes)
+                    throw new InvalidDataException("payload exceeds maximum size");
+            }
+        }
+        catch (OperationCanceledException) when (!appToken.IsCancellationRequested)
+        {
+            throw new TimeoutException("timed out while reading payload");
+        }
+
+        if (totalBytes == 0)
+            return null;
+
+        try
+        {
+            return new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true)
+                .GetString(payload, 0, totalBytes)
+                .TrimEnd('\r', '\n');
+        }
+        catch (DecoderFallbackException ex)
+        {
+            throw new InvalidDataException("payload is not valid UTF-8", ex);
+        }
+    }
+
+    private async Task HandleDeepLinkAsync(string uri)
+    {
+        var result = DeepLinkParser.ParseDeepLink(uri);
+        if (result == null)
+        {
+            Logger.Warn($"Rejected invalid deep link: {DeepLinkSecurityPolicy.RedactForLog(uri)}");
+            return;
+        }
+
+        if (DeepLinkSecurityPolicy.RequiresConfirmation(result))
+        {
+            var confirmed = await ConfirmDeepLinkActionAsync(result);
+            if (!confirmed)
+            {
+                Logger.Warn($"Rejected unconfirmed deep link action: {DeepLinkSecurityPolicy.RedactForLog(uri)}");
+                return;
+            }
+        }
+
+        HandleDeepLink(uri);
     }
 
     private void HandleDeepLink(string uri)
@@ -3363,11 +3477,29 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     {
         try
         {
-            using var pipe = new NamedPipeClientStream(".", PipeName, PipeDirection.Out);
+            if (!DeepLinkSecurityPolicy.IsIpcPayloadWithinLimit(uri))
+            {
+                Logger.Warn($"Rejected oversized deep link before IPC forwarding: {DeepLinkSecurityPolicy.RedactForLog(uri)}");
+                return;
+            }
+
+            if (DeepLinkParser.ParseDeepLink(uri) == null)
+            {
+                Logger.Warn($"Rejected invalid deep link before IPC forwarding: {DeepLinkSecurityPolicy.RedactForLog(uri)}");
+                return;
+            }
+
+            var payload = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true)
+                .GetBytes(uri);
+            using var pipe = new NamedPipeClientStream(
+                ".",
+                DeepLinkPipeName,
+                PipeDirection.Out,
+                PipeOptions.CurrentUserOnly);
             pipe.Connect(1000);
-            using var writer = new System.IO.StreamWriter(pipe);
-            writer.WriteLine(uri);
-            writer.Flush();
+            pipe.Write(payload, 0, payload.Length);
+            pipe.Flush();
+            pipe.WaitForPipeDrain();
         }
         catch (Exception ex)
         {

--- a/src/OpenClaw.Tray.WinUI/Services/DeepLinkHandler.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/DeepLinkHandler.cs
@@ -59,7 +59,7 @@ public static class DeepLinkHandler
 
         var path = result.Path?.TrimEnd('/') ?? string.Empty;
 
-        Logger.Info($"Handling deep link: {path}");
+        Logger.Info($"Handling deep link: {DeepLinkSecurityPolicy.RedactForLog(uri)}");
 
         switch (path.ToLowerInvariant())
         {
@@ -239,7 +239,7 @@ public static class DeepLinkHandler
                         try
                         {
                             await actions.SendMessage(agentMessage);
-                            Logger.Info($"Sent message via deep link: {agentMessage}");
+                            Logger.Info("Sent message via deep link");
                         }
                         catch (Exception ex)
                         {

--- a/src/OpenClaw.Tray.WinUI/Services/DeepLinkSecurityPolicy.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/DeepLinkSecurityPolicy.cs
@@ -1,0 +1,119 @@
+using OpenClaw.Shared;
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Security.Principal;
+using System.Text;
+
+namespace OpenClawTray.Services;
+
+internal static class DeepLinkSecurityPolicy
+{
+    public const int MaxIpcMessageBytes = 8192;
+    public static readonly TimeSpan IpcReadTimeout = TimeSpan.FromSeconds(2);
+
+    private const string PipeNamePrefix = "OpenClawTray-DeepLink";
+
+    private static readonly HashSet<string> StateChangingPaths = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "send",
+        "agent",
+        "voice",
+        "voice-start",
+        "voice-stop",
+        "ssh-restart",
+        "restart-ssh",
+        "restart-ssh-tunnel"
+    };
+
+    public static string BuildCurrentUserScopedPipeName(string dataPath)
+        => BuildPipeName(dataPath, GetCurrentUserScope(), GetCurrentSessionId());
+
+    internal static string BuildPipeName(string dataPath, string userScope, int sessionId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dataPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(userScope);
+
+        var scope = $"{userScope}|{sessionId}|{Path.GetFullPath(dataPath)}";
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(scope));
+        return $"{PipeNamePrefix}-{Convert.ToHexString(hash, 0, 8)}";
+    }
+
+    public static bool IsIpcPayloadWithinLimit(string? uri)
+        => !string.IsNullOrEmpty(uri) && Encoding.UTF8.GetByteCount(uri) <= MaxIpcMessageBytes;
+
+    public static bool IsStateChangingPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return false;
+
+        var normalized = path.Trim().Trim('/').ToLowerInvariant();
+        if (StateChangingPaths.Contains(normalized))
+            return true;
+
+        var slashIndex = normalized.IndexOf('/');
+        return slashIndex > 0 && StateChangingPaths.Contains(normalized[..slashIndex]);
+    }
+
+    public static bool RequiresConfirmation(DeepLinkResult? result)
+        => result != null && IsStateChangingPath(result.Path);
+
+    public static string RedactForLog(string? uri)
+    {
+        if (string.IsNullOrWhiteSpace(uri))
+            return "<empty-deep-link>";
+
+        var result = DeepLinkParser.ParseDeepLink(uri);
+        if (result == null)
+            return "<invalid-deep-link>";
+
+        var redactedPath = RedactPathForLog(result.Path);
+        return string.IsNullOrEmpty(result.Query)
+            ? $"openclaw://{redactedPath}"
+            : $"openclaw://{redactedPath}?<redacted>";
+    }
+
+    internal static string GetActionDisplayName(DeepLinkResult result)
+    {
+        var path = result.Path.Trim().Trim('/').ToLowerInvariant();
+        return path switch
+        {
+            "send" => "open the quick-send window with a prefilled message",
+            "agent" => "send a message to the agent",
+            "voice" or "voice-start" => "start voice input",
+            "voice-stop" => "stop voice input",
+            "ssh-restart" or "restart-ssh" or "restart-ssh-tunnel" => "restart the SSH tunnel",
+            _ => "run this OpenClaw action"
+        };
+    }
+
+    internal static string RedactPathForLog(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return "";
+
+        var normalized = path.Trim().Trim('/');
+        if (normalized.Length == 0)
+            return "";
+
+        var slashIndex = normalized.IndexOf('/');
+        var firstSegment = slashIndex >= 0 ? normalized[..slashIndex] : normalized;
+
+        return slashIndex >= 0 ? $"{firstSegment}/..." : firstSegment;
+    }
+
+    private static string GetCurrentUserScope()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var sid = WindowsIdentity.GetCurrent().User?.Value;
+            if (!string.IsNullOrWhiteSpace(sid))
+                return sid;
+        }
+
+        return $"{Environment.MachineName}\\{Environment.UserName}";
+    }
+
+    private static int GetCurrentSessionId()
+        => OperatingSystem.IsWindows() ? Process.GetCurrentProcess().SessionId : 0;
+}

--- a/tests/OpenClaw.Tray.Tests/DeepLinkSecurityPolicyTests.cs
+++ b/tests/OpenClaw.Tray.Tests/DeepLinkSecurityPolicyTests.cs
@@ -1,0 +1,88 @@
+using OpenClaw.Shared;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public class DeepLinkSecurityPolicyTests
+{
+    [Theory]
+    [InlineData("send")]
+    [InlineData("send/anything")]
+    [InlineData("agent")]
+    [InlineData("voice")]
+    [InlineData("voice-start")]
+    [InlineData("voice-stop")]
+    [InlineData("ssh-restart")]
+    [InlineData("restart-ssh")]
+    [InlineData("restart-ssh-tunnel")]
+    public void IsStateChangingPath_RejectsUnsafeActions(string path)
+    {
+        Assert.True(DeepLinkSecurityPolicy.IsStateChangingPath(path));
+    }
+
+    [Theory]
+    [InlineData("settings")]
+    [InlineData("dashboard")]
+    [InlineData("dashboard/sessions")]
+    [InlineData("config")]
+    [InlineData("support-context")]
+    public void IsStateChangingPath_AllowsBenignActions(string path)
+    {
+        Assert.False(DeepLinkSecurityPolicy.IsStateChangingPath(path));
+    }
+
+    [Theory]
+    [InlineData("openclaw://agent?message=hello%20world&token=secret", "openclaw://agent?<redacted>")]
+    [InlineData("openclaw://send/private-message?message=secret", "openclaw://send/...?<redacted>")]
+    [InlineData("openclaw://dashboard/sessions?filter=abc", "openclaw://dashboard/...?<redacted>")]
+    [InlineData("openclaw://settings", "openclaw://settings")]
+    public void RedactForLog_RemovesQueryAndPathPayloads(string uri, string expected)
+    {
+        Assert.Equal(expected, DeepLinkSecurityPolicy.RedactForLog(uri));
+    }
+
+    [Fact]
+    public void RedactForLog_DoesNotEchoInvalidInput()
+    {
+        Assert.Equal("<invalid-deep-link>", DeepLinkSecurityPolicy.RedactForLog("https://example.com/?token=secret"));
+    }
+
+    [Fact]
+    public void RequiresConfirmation_OnlyForStateChangingActions()
+    {
+        Assert.True(DeepLinkSecurityPolicy.RequiresConfirmation(
+            DeepLinkParser.ParseDeepLink("openclaw://agent?message=ping")));
+        Assert.False(DeepLinkSecurityPolicy.RequiresConfirmation(
+            DeepLinkParser.ParseDeepLink("openclaw://dashboard/sessions")));
+    }
+
+    [Fact]
+    public void BuildPipeName_IsDeterministicAndScoped()
+    {
+        var first = DeepLinkSecurityPolicy.BuildPipeName(@"C:\Users\alice\AppData\Local\OpenClawTray", "S-1-5-21-alice", 2);
+        var second = DeepLinkSecurityPolicy.BuildPipeName(@"C:\Users\alice\AppData\Local\OpenClawTray", "S-1-5-21-alice", 2);
+        var differentUser = DeepLinkSecurityPolicy.BuildPipeName(@"C:\Users\alice\AppData\Local\OpenClawTray", "S-1-5-21-bob", 2);
+        var differentSession = DeepLinkSecurityPolicy.BuildPipeName(@"C:\Users\alice\AppData\Local\OpenClawTray", "S-1-5-21-alice", 3);
+        var differentDataDir = DeepLinkSecurityPolicy.BuildPipeName(@"D:\isolated\OpenClawTray", "S-1-5-21-alice", 2);
+
+        Assert.Equal(first, second);
+        Assert.NotEqual(first, differentUser);
+        Assert.NotEqual(first, differentSession);
+        Assert.NotEqual(first, differentDataDir);
+        Assert.StartsWith("OpenClawTray-DeepLink-", first);
+        Assert.DoesNotContain("S-1-5-21-alice", first);
+        Assert.DoesNotContain("Users", first);
+    }
+
+    [Fact]
+    public void IsIpcPayloadWithinLimit_EnforcesUtf8ByteLimit()
+    {
+        var maxPayload = new string('a', DeepLinkSecurityPolicy.MaxIpcMessageBytes);
+        var oversizedPayload = new string('a', DeepLinkSecurityPolicy.MaxIpcMessageBytes + 1);
+
+        Assert.True(DeepLinkSecurityPolicy.IsIpcPayloadWithinLimit(maxPayload));
+        Assert.False(DeepLinkSecurityPolicy.IsIpcPayloadWithinLimit(oversizedPayload));
+        Assert.False(DeepLinkSecurityPolicy.IsIpcPayloadWithinLimit(""));
+        Assert.False(DeepLinkSecurityPolicy.IsIpcPayloadWithinLimit(null));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -35,6 +35,7 @@
 
   <ItemGroup>
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\DeepLinkHandler.cs" Link="Services\DeepLinkHandler.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\DeepLinkSecurityPolicy.cs" Link="Services\DeepLinkSecurityPolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\AppState.cs" Link="Services\AppState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\Logger.cs" Link="Services\Logger.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SettingsManager.cs" Link="Services\SettingsManager.cs" />


### PR DESCRIPTION
## Summary
- Replaces the fixed deep-link IPC pipe with a current-user/session/data-dir scoped pipe name and `PipeOptions.CurrentUserOnly` on the pipe connection.
- Adds bounded UTF-8 IPC payload reads with timeout handling and oversize/invalid payload rejection.
- Redacts deep-link URI query/path payloads from logs and removes message text from agent deep-link logging.
- Requires explicit user confirmation before state-changing deep-link actions (`send`, `agent`, `voice`, `voice-stop`, SSH restart aliases) execute while preserving benign navigation/config/help links.
- Adds unit coverage for unsafe action policy, log redaction, pipe-name scoping, and IPC payload bounds.

## Security/privacy impact
This addresses the high-consensus finding that a predictable pipe plus unbounded forwarded payloads could allow local cross-user/session IPC abuse or leak sensitive URI contents such as messages, tokens, and query strings in logs. The pipe is now scoped to the active user/session/data directory, payloads are bounded, logs are redacted, and state-changing links require user approval.

## User impact
Benign deep links continue to navigate/open diagnostic surfaces without prompts. Deep links that can change state now show an Allow/Cancel confirmation before running.

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — 1795 total, 0 failed, 1767 passed, 28 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — 1066 total, 0 failed, 1066 passed