### PR TITLE
Fix WebSocket lifecycle responsiveness

### DIFF
--- a/src/OpenClaw.Connection/GatewayClientFactory.cs
+++ b/src/OpenClaw.Connection/GatewayClientFactory.cs
@@ -46,7 +46,7 @@ internal sealed class GatewayClientLifecycleAdapter : IGatewayClientLifecycle
     public event EventHandler<ConnectionStatus>? StatusChanged;
     public event EventHandler<string>? AuthenticationFailed;
 
-    public Task ConnectAsync(CancellationToken ct) => _client.ConnectAsync();
+    public Task ConnectAsync(CancellationToken ct) => _client.ConnectAsync(ct);
 
     public void Dispose() => _client.Dispose();
 }

--- a/src/OpenClaw.Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/GatewayConnectionManager.cs
@@ -254,7 +254,10 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
                 catch (OperationCanceledException) { }
                 catch (Exception ex)
                 {
-                    _logger.Error($"[ConnMgr] Connect failed: {ex.Message}");
+                    if (Interlocked.Read(ref _generation) == gen)
+                    {
+                        _logger.Error($"[ConnMgr] Connect failed: {ex.Message}");
+                    }
                 }
             }, ct);
     }
@@ -276,6 +279,11 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
     /// <summary>Core disconnect logic. Caller must hold <see cref="_transitionSemaphore"/>.</summary>
     private void DisconnectCore()
     {
+        Interlocked.Increment(ref _generation);
+        var oldCts = Interlocked.Exchange(ref _operationCts, null);
+        oldCts?.Cancel();
+        oldCts?.Dispose();
+
         var prev = _stateMachine.Current.OverallState;
         DisposeActiveClient();
         _stateMachine.TryTransition(ConnectionTrigger.DisconnectRequested);
@@ -533,7 +541,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         // Start node connection outside the semaphore to avoid deadlocks
         if (_nodeConnector != null && ShouldStartNodeConnection())
         {
-            await StartNodeConnectionAsync();
+            await StartNodeConnectionAsync(gen);
         }
     }
 
@@ -653,7 +661,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         StateChanged += Handler;
         try
         {
-            var startAttempted = await StartNodeConnectionAsync();
+            var startAttempted = await StartNodeConnectionAsync(Interlocked.Read(ref _generation));
 
             if (!startAttempted)
             {
@@ -706,11 +714,18 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         return _isNodeEnabled?.Invoke() ?? false;
     }
 
-    private async Task<bool> StartNodeConnectionAsync()
-    {
-        if (_nodeConnector == null || _activeGatewayRecordId == null || _activeIdentityPath == null) return false;
+    private bool IsGenerationStale(long? generation)
+        => generation.HasValue && Interlocked.Read(ref _generation) != generation.Value;
 
-        var record = _registry.GetById(_activeGatewayRecordId);
+    private async Task<bool> StartNodeConnectionAsync(long? generation = null)
+    {
+        if (IsGenerationStale(generation)) return false;
+
+        var activeGatewayRecordId = _activeGatewayRecordId;
+        var activeIdentityPath = _activeIdentityPath;
+        if (_nodeConnector == null || activeGatewayRecordId == null || activeIdentityPath == null) return false;
+
+        var record = _registry.GetById(activeGatewayRecordId);
         if (record == null)
         {
             _logger.Warn("[ConnMgr] Cannot start node — gateway record not found");
@@ -718,7 +733,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         }
 
         // Use root identity path — clients always read/write from root, not per-gateway
-        var nodeCredential = _credentialResolver.ResolveNode(record, _activeIdentityPath!);
+        var nodeCredential = _credentialResolver.ResolveNode(record, activeIdentityPath);
         if (nodeCredential == null)
         {
             _logger.Warn("[ConnMgr] No node credential available — skipping node connection");
@@ -731,6 +746,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         await _transitionSemaphore.WaitAsync();
         try
         {
+            if (IsGenerationStale(generation)) return false;
             _stateMachine.SetNodeEnabled(true);
         }
         finally
@@ -747,7 +763,9 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
 
         try
         {
-            await _nodeConnector.ConnectAsync(nodeConnectUrl, nodeCredential, _activeIdentityPath,
+            if (IsGenerationStale(generation)) return false;
+
+            await _nodeConnector.ConnectAsync(nodeConnectUrl, nodeCredential, activeIdentityPath,
                 useV2Signature: _gatewayNeedsV2Signature);
         }
         catch (Exception ex)
@@ -809,6 +827,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
 
     private async void OnNodePairingStatusChanged(object? sender, PairingStatusEventArgs e)
     {
+        var handlerGeneration = Interlocked.Read(ref _generation);
         _diagnostics.Record("node", $"Node pairing: {e.Status}");
 
         await _transitionSemaphore.WaitAsync();
@@ -871,7 +890,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
                                 _lastAutoApprovedRequestId = e.RequestId;
                                 _diagnostics.Record("node", "Node pairing auto-approved — reconnecting node");
                                 await Task.Delay(1000); // brief delay for gateway to process
-                                await StartNodeConnectionAsync();
+                                await StartNodeConnectionAsync(handlerGeneration);
                             }
                             else
                             {

--- a/src/OpenClaw.Shared/WebSocketClientBase.cs
+++ b/src/OpenClaw.Shared/WebSocketClientBase.cs
@@ -21,6 +21,8 @@ public abstract class WebSocketClientBase : IDisposable
     private bool _disposed;
     private int _reconnectAttempts;
     private int _reconnectLoopActive;
+    private long _connectionGeneration;
+    private readonly SemaphoreSlim _sendSemaphore = new(1, 1);
     private static readonly int[] BackoffMs = { 1000, 2000, 4000, 8000, 15000, 30000, 60000 };
 
     protected readonly string _token;
@@ -102,7 +104,7 @@ public abstract class WebSocketClientBase : IDisposable
         _cts = new CancellationTokenSource();
     }
 
-    public async Task ConnectAsync()
+    public async Task ConnectAsync(CancellationToken cancellationToken = default)
     {
         if (_disposed)
         {
@@ -110,29 +112,41 @@ public abstract class WebSocketClientBase : IDisposable
             return;
         }
 
+        var connectGeneration = Interlocked.Increment(ref _connectionGeneration);
+        ClientWebSocket? ws = null;
+
         try
         {
             RaiseStatusChanged(ConnectionStatus.Connecting);
             _logger.Info($"Connecting to {ClientRole}: {GatewayUrlForDisplay}");
 
-            _webSocket = new ClientWebSocket();
-            _webSocket.Options.KeepAliveInterval = TimeSpan.FromSeconds(30);
+            ws = new ClientWebSocket();
+            ws.Options.KeepAliveInterval = TimeSpan.FromSeconds(30);
+            _webSocket = ws;
 
             // Set Origin header (convert ws/wss to http/https)
             var uri = new Uri(_gatewayUrl);
             var originScheme = uri.Scheme == "wss" ? "https" : "http";
             var origin = $"{originScheme}://{uri.Host}:{uri.Port}";
-            _webSocket.Options.SetRequestHeader("Origin", origin);
+            ws.Options.SetRequestHeader("Origin", origin);
 
             if (!string.IsNullOrEmpty(_credentials))
             {
                 var credentialsToEncode = GatewayUrlHelper.DecodeCredentials(_credentials);
-                _webSocket.Options.SetRequestHeader(
+                ws.Options.SetRequestHeader(
                     "Authorization",
                     $"Basic {Convert.ToBase64String(Encoding.UTF8.GetBytes(credentialsToEncode))}");
             }
 
-            await _webSocket.ConnectAsync(uri, _cts.Token);
+            using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, cancellationToken);
+            var connectToken = connectCts.Token;
+
+            await ws.ConnectAsync(uri, connectToken);
+            if (!IsCurrentConnection(ws, connectGeneration) || connectToken.IsCancellationRequested)
+            {
+                DisposeStaleSocket(ws);
+                return;
+            }
 
             // Don't reset _reconnectAttempts here — TCP connect succeeding doesn't mean
             // auth will succeed. Reset only after the full application-level handshake
@@ -140,19 +154,39 @@ public abstract class WebSocketClientBase : IDisposable
             _logger.Info($"{ClientRole} connected, waiting for challenge...");
 
             await OnConnectedAsync();
+            if (!IsCurrentConnection(ws, connectGeneration) || connectToken.IsCancellationRequested)
+            {
+                DisposeStaleSocket(ws);
+                return;
+            }
 
-            _ = Task.Run(() => ListenForMessagesAsync(), _cts.Token);
+            _ = Task.Run(() => ListenForMessagesAsync(ws, _cts.Token, connectGeneration), _cts.Token);
         }
         catch (OperationCanceledException)
         {
             _logger.Debug($"{ClientRole} connect canceled (likely shutdown)");
+            if (ws != null && ReferenceEquals(_webSocket, ws))
+            {
+                _webSocket = null;
+                try { ws.Dispose(); } catch { /* ignore dispose errors */ }
+            }
         }
         catch (ObjectDisposedException)
         {
             _logger.Debug($"{ClientRole} connect aborted after dispose");
+            if (ws != null && ReferenceEquals(_webSocket, ws))
+            {
+                _webSocket = null;
+                try { ws.Dispose(); } catch { /* ignore dispose errors */ }
+            }
         }
         catch (Exception ex)
         {
+            if (ws != null && ReferenceEquals(_webSocket, ws))
+            {
+                _webSocket = null;
+                try { ws.Dispose(); } catch { /* ignore dispose errors */ }
+            }
             _logger.Error($"{ClientRole} connection failed", ex);
             RaiseStatusChanged(ConnectionStatus.Error);
 
@@ -163,7 +197,22 @@ public abstract class WebSocketClientBase : IDisposable
         }
     }
 
-    private async Task ListenForMessagesAsync()
+    private bool IsCurrentConnection(ClientWebSocket ws, long generation)
+        => !_disposed
+            && Interlocked.Read(ref _connectionGeneration) == generation
+            && ReferenceEquals(_webSocket, ws);
+
+    private void DisposeStaleSocket(ClientWebSocket ws)
+    {
+        if (ReferenceEquals(_webSocket, ws))
+        {
+            _webSocket = null;
+        }
+
+        try { ws.Dispose(); } catch { /* ignore dispose errors */ }
+    }
+
+    private async Task ListenForMessagesAsync(ClientWebSocket ws, CancellationToken cancellationToken, long connectionGeneration)
     {
         // Rent a pooled buffer — consistent with the SendRawAsync hot path; avoids a large
         // (16–64 KB) heap allocation per connection that would otherwise land on the LOH.
@@ -172,10 +221,10 @@ public abstract class WebSocketClientBase : IDisposable
 
         try
         {
-            while (_webSocket?.State == WebSocketState.Open && !_cts.Token.IsCancellationRequested)
+            while (ws.State == WebSocketState.Open && !cancellationToken.IsCancellationRequested)
             {
-                var result = await _webSocket.ReceiveAsync(
-                    new ArraySegment<byte>(buffer, 0, ReceiveBufferSize), _cts.Token);
+                var result = await ws.ReceiveAsync(
+                    new ArraySegment<byte>(buffer, 0, ReceiveBufferSize), cancellationToken);
 
                 if (result.MessageType == WebSocketMessageType.Text)
                 {
@@ -197,11 +246,14 @@ public abstract class WebSocketClientBase : IDisposable
                 }
                 else if (result.MessageType == WebSocketMessageType.Close)
                 {
-                    var closeStatus = _webSocket.CloseStatus?.ToString() ?? "unknown";
-                    var closeDesc = _webSocket.CloseStatusDescription ?? "no description";
+                    var closeStatus = ws.CloseStatus?.ToString() ?? "unknown";
+                    var closeDesc = ws.CloseStatusDescription ?? "no description";
                     _logger.Info($"Server closed connection: {closeStatus} - {closeDesc}");
-                    OnDisconnected();
-                    RaiseStatusChanged(ConnectionStatus.Disconnected);
+                    if (IsCurrentConnection(ws, connectionGeneration))
+                    {
+                        OnDisconnected();
+                        RaiseStatusChanged(ConnectionStatus.Disconnected);
+                    }
                     break;
                 }
             }
@@ -209,16 +261,22 @@ public abstract class WebSocketClientBase : IDisposable
         catch (WebSocketException ex) when (ex.WebSocketErrorCode == WebSocketError.ConnectionClosedPrematurely)
         {
             _logger.Warn("Connection closed prematurely");
-            OnDisconnected();
-            RaiseStatusChanged(ConnectionStatus.Disconnected);
+            if (IsCurrentConnection(ws, connectionGeneration))
+            {
+                OnDisconnected();
+                RaiseStatusChanged(ConnectionStatus.Disconnected);
+            }
         }
         catch (OperationCanceledException) { }
         catch (ObjectDisposedException) { /* CTS or WebSocket disposed during shutdown */ }
         catch (Exception ex)
         {
             _logger.Error($"{ClientRole} listen error", ex);
-            OnError(ex);
-            RaiseStatusChanged(ConnectionStatus.Error);
+            if (IsCurrentConnection(ws, connectionGeneration))
+            {
+                OnError(ex);
+                RaiseStatusChanged(ConnectionStatus.Error);
+            }
         }
         finally
         {
@@ -226,11 +284,11 @@ public abstract class WebSocketClientBase : IDisposable
         }
 
         // Auto-reconnect if not intentionally disposed
-        if (!_disposed)
+        if (!_disposed && IsCurrentConnection(ws, connectionGeneration))
         {
             try
             {
-                if (!_cts.Token.IsCancellationRequested && ShouldAutoReconnect())
+                if (!cancellationToken.IsCancellationRequested && ShouldAutoReconnect())
                 {
                     await ReconnectWithBackoffAsync();
                 }
@@ -295,20 +353,19 @@ public abstract class WebSocketClientBase : IDisposable
     /// <summary>Send a text message over the WebSocket. Thread-safe.</summary>
     protected async Task SendRawAsync(string message)
     {
-        // Capture local reference to avoid TOCTOU race with reconnect/dispose
-        var ws = _webSocket;
-        if (ws?.State != WebSocketState.Open) return;
+        await _sendSemaphore.WaitAsync(_cts.Token);
 
         try
         {
+            if (!CanSendRaw) return;
+
             // Rent a pooled buffer to avoid per-send heap allocations on the hot send path.
             var byteCount = Encoding.UTF8.GetByteCount(message);
             var buffer = ArrayPool<byte>.Shared.Rent(byteCount);
             try
             {
                 var written = Encoding.UTF8.GetBytes(message, buffer);
-                await ws.SendAsync(buffer.AsMemory(0, written),
-                    WebSocketMessageType.Text, true, _cts.Token);
+                await SendWebSocketTextAsync(buffer.AsMemory(0, written), _cts.Token);
             }
             finally
             {
@@ -323,6 +380,25 @@ public abstract class WebSocketClientBase : IDisposable
         {
             _logger.Warn($"WebSocket send failed (state changed): {ex.Message}");
         }
+        finally
+        {
+            _sendSemaphore.Release();
+        }
+    }
+
+    /// <summary>Test seam for send gating; production sends only when the current socket is open.</summary>
+    protected virtual bool CanSendRaw => _webSocket?.State == WebSocketState.Open;
+
+    /// <summary>Test seam for the raw WebSocket send performed under the send gate.</summary>
+    protected virtual ValueTask SendWebSocketTextAsync(ReadOnlyMemory<byte> payload, CancellationToken cancellationToken)
+    {
+        var ws = _webSocket;
+        if (ws?.State != WebSocketState.Open)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        return ws.SendAsync(payload, WebSocketMessageType.Text, true, cancellationToken);
     }
 
     /// <summary>Gracefully close the WebSocket connection.</summary>
@@ -346,6 +422,7 @@ public abstract class WebSocketClientBase : IDisposable
 
         OnDisposing();
 
+        Interlocked.Increment(ref _connectionGeneration);
         try { _cts.Cancel(); } catch { }
 
         var ws = _webSocket;

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -5,6 +5,8 @@ using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 
 namespace OpenClaw.Shared;
@@ -36,6 +38,9 @@ public class WindowsNodeClient : WebSocketClientBase
     private volatile bool _rateLimited;
     private bool _useV2Signature; // true after v3 signature rejected by gateway
     public bool UseV2Signature { get => _useV2Signature; set => _useV2Signature = value; }
+    private const int InvokeDispatchQueueCapacity = 32;
+    private readonly Channel<NodeInvokeDispatchItem> _invokeDispatchQueue;
+    private readonly Task _invokeDispatchTask;
     // Bug 3: source-side idempotency for PairingStatusChanged. HandleHelloOk runs on every
     // WS reconnect and re-fires PairingStatus.Paired even when nothing changed, causing a
     // toast storm in the tray UI. Track the last emitted status and only fire on transitions.
@@ -98,6 +103,17 @@ public class WindowsNodeClient : WebSocketClientBase
 
     protected override int ReceiveBufferSize => 65536;
     protected override string ClientRole => "node";
+
+    private enum NodeInvokeResponseKind
+    {
+        RequestResponse,
+        EventResult
+    }
+
+    private sealed record NodeInvokeDispatchItem(
+        NodeInvokeRequest Request,
+        INodeCapability Capability,
+        NodeInvokeResponseKind ResponseKind);
     
     public WindowsNodeClient(string gatewayUrl, string token, string dataPath, IOpenClawLogger? logger = null, string? bootstrapToken = null)
         : base(gatewayUrl, ResolveRequiredCredential(token, bootstrapToken, dataPath, logger), logger)
@@ -117,6 +133,15 @@ public class WindowsNodeClient : WebSocketClientBase
             Platform = "windows",
             DisplayName = $"Windows Node ({Environment.MachineName})"
         };
+
+        _invokeDispatchQueue = Channel.CreateBounded<NodeInvokeDispatchItem>(
+            new BoundedChannelOptions(InvokeDispatchQueueCapacity)
+            {
+                FullMode = BoundedChannelFullMode.Wait,
+                SingleReader = true,
+                SingleWriter = false
+            });
+        _invokeDispatchTask = Task.Run(() => InvokeDispatchLoopAsync(CancellationToken));
     }
 
     private static string NormalizeOptionalCredential(string? credential)
@@ -476,26 +501,13 @@ public class WindowsNodeClient : WebSocketClientBase
             return;
         }
         
-        var stopwatch = Stopwatch.StartNew();
-        try
+        if (!TryEnqueueNodeInvoke(
+            new NodeInvokeDispatchItem(request, capability, NodeInvokeResponseKind.EventResult),
+            requestId,
+            command))
         {
-            // Raise event for UI notification
-            InvokeReceived?.Invoke(this, request);
-            
-            // Execute the command
-            var response = await capability.ExecuteAsync(request);
-            response.Id = requestId;
-             
-            await SendNodeInvokeResultAsync(requestId, response.Ok, response.Payload, response.Error);
-            stopwatch.Stop();
-            RaiseInvokeCompleted(requestId, command, response.Ok, response.Error, stopwatch.Elapsed);
-        }
-        catch (Exception ex)
-        {
-            _logger.Error($"[NODE] Command execution failed: {command}", ex);
-            await SendNodeInvokeResultAsync(requestId, false, null, "Command execution failed");
-            stopwatch.Stop();
-            RaiseInvokeCompleted(requestId, command, false, "Command execution failed", stopwatch.Elapsed);
+            await SendNodeInvokeResultAsync(requestId, false, null, "Node is busy; try again shortly");
+            RaiseInvokeCompleted(requestId, command, false, "Node is busy; try again shortly", TimeSpan.Zero);
         }
     }
     
@@ -1000,27 +1012,106 @@ public class WindowsNodeClient : WebSocketClientBase
             return;
         }
         
-        var stopwatch = Stopwatch.StartNew();
+        if (!TryEnqueueNodeInvoke(
+            new NodeInvokeDispatchItem(request, capability, NodeInvokeResponseKind.RequestResponse),
+            requestId,
+            command))
+        {
+            await SendErrorResponseAsync(requestId, "Node is busy; try again shortly");
+            RaiseInvokeCompleted(requestId, command, false, "Node is busy; try again shortly", TimeSpan.Zero);
+        }
+    }
+
+    private bool TryEnqueueNodeInvoke(NodeInvokeDispatchItem item, string requestId, string command)
+    {
+        if (IsDisposed || CancellationToken.IsCancellationRequested)
+        {
+            _logger.Warn($"[NODE] Dropping node.invoke {requestId} for {command}: node is shutting down");
+            return false;
+        }
+
+        if (_invokeDispatchQueue.Writer.TryWrite(item))
+        {
+            return true;
+        }
+
+        _logger.Warn($"[NODE] Invoke dispatcher busy; rejecting {requestId} for {command}");
+        return false;
+    }
+
+    private async Task InvokeDispatchLoopAsync(CancellationToken cancellationToken)
+    {
         try
         {
-            // Raise event for UI notification
-            InvokeReceived?.Invoke(this, request);
-            
-            // Execute the command
-            var response = await capability.ExecuteAsync(request);
-            response.Id = requestId;
-             
-            await SendInvokeResponseAsync(response);
-            stopwatch.Stop();
-            RaiseInvokeCompleted(requestId, command, response.Ok, response.Error, stopwatch.Elapsed);
+            while (await _invokeDispatchQueue.Reader.WaitToReadAsync(cancellationToken))
+            {
+                while (_invokeDispatchQueue.Reader.TryRead(out var item))
+                {
+                    try
+                    {
+                        await ExecuteNodeInvokeAsync(item);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Error($"[NODE] Invoke dispatcher item failed: {item.Request.Command}", ex);
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
         }
         catch (Exception ex)
         {
-            _logger.Error($"Command execution failed: {command}", ex);
-            await SendErrorResponseAsync(requestId, "Command execution failed");
-            stopwatch.Stop();
-            RaiseInvokeCompleted(requestId, command, false, "Command execution failed", stopwatch.Elapsed);
+            _logger.Error("[NODE] Invoke dispatcher stopped unexpectedly", ex);
         }
+    }
+
+    private async Task ExecuteNodeInvokeAsync(NodeInvokeDispatchItem item)
+    {
+        var request = item.Request;
+        var command = request.Command;
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            InvokeReceived?.Invoke(this, request);
+
+            var response = await item.Capability.ExecuteAsync(request);
+            response.Id = request.Id;
+
+            await SendDispatchResponseAsync(item, response);
+            stopwatch.Stop();
+            RaiseInvokeCompleted(request.Id, command, response.Ok, response.Error, stopwatch.Elapsed);
+        }
+        catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"[NODE] Command execution failed: {command}", ex);
+            await SendDispatchErrorAsync(item, "Command execution failed");
+            stopwatch.Stop();
+            RaiseInvokeCompleted(request.Id, command, false, "Command execution failed", stopwatch.Elapsed);
+        }
+    }
+
+    private Task SendDispatchResponseAsync(NodeInvokeDispatchItem item, NodeInvokeResponse response)
+    {
+        return item.ResponseKind == NodeInvokeResponseKind.EventResult
+            ? SendNodeInvokeResultAsync(item.Request.Id, response.Ok, response.Payload, response.Error)
+            : SendInvokeResponseAsync(response);
+    }
+
+    private Task SendDispatchErrorAsync(NodeInvokeDispatchItem item, string error)
+    {
+        return item.ResponseKind == NodeInvokeResponseKind.EventResult
+            ? SendNodeInvokeResultAsync(item.Request.Id, false, null, error)
+            : SendErrorResponseAsync(item.Request.Id, error);
     }
 
     private void RaiseInvokeCompleted(string requestId, string command, bool ok, string? error, TimeSpan duration)
@@ -1156,5 +1247,10 @@ public class WindowsNodeClient : WebSocketClientBase
             _isPendingApproval = false;
             _isPaired = false;
         }
+    }
+
+    protected override void OnDisposing()
+    {
+        _invokeDispatchQueue.Writer.TryComplete();
     }
 }

--- a/tests/OpenClaw.Shared.Tests/WebSocketClientBaseTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WebSocketClientBaseTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -19,9 +20,18 @@ public class TestWebSocketClient : WebSocketClientBase
     public Exception? LastError { get; private set; }
     public int OnDisposingCallCount { get; private set; }
     public bool AutoReconnectEnabled { get; set; } = true;
+    private readonly TaskCompletionSource _firstSendEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _releaseSends = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _activeSends;
+    private int _maxConcurrentSends;
+    private int _sendCallCount;
 
     protected override int ReceiveBufferSize => 8192;
     protected override string ClientRole => "test";
+    public bool SimulateOpenSocket { get; set; }
+    public int MaxConcurrentSends => Volatile.Read(ref _maxConcurrentSends);
+    public int SendCallCount => Volatile.Read(ref _sendCallCount);
+    public Task FirstSendEntered => _firstSendEntered.Task;
 
     public TestWebSocketClient(string gatewayUrl, string token, IOpenClawLogger? logger = null)
         : base(gatewayUrl, token, logger) { }
@@ -56,9 +66,42 @@ public class TestWebSocketClient : WebSocketClientBase
 
     protected override bool ShouldAutoReconnect() => AutoReconnectEnabled;
 
+    protected override bool CanSendRaw => SimulateOpenSocket;
+
+    protected override async ValueTask SendWebSocketTextAsync(ReadOnlyMemory<byte> payload, CancellationToken cancellationToken)
+    {
+        Interlocked.Increment(ref _sendCallCount);
+        var active = Interlocked.Increment(ref _activeSends);
+        UpdateMaxConcurrentSends(active);
+        _firstSendEntered.TrySetResult();
+
+        try
+        {
+            await _releaseSends.Task.WaitAsync(cancellationToken);
+        }
+        finally
+        {
+            Interlocked.Decrement(ref _activeSends);
+        }
+    }
+
+    private void UpdateMaxConcurrentSends(int active)
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref _maxConcurrentSends);
+            if (active <= current) return;
+            if (Interlocked.CompareExchange(ref _maxConcurrentSends, active, current) == current) return;
+        }
+    }
+
+    public void ReleaseSends() => _releaseSends.TrySetResult();
+
     // Expose protected members for testing
     public void TestRaiseStatusChanged(ConnectionStatus status)
         => RaiseStatusChanged(status);
+
+    public Task TestSendRawAsync(string message) => SendRawAsync(message);
 
     public bool TestIsDisposed => IsDisposed;
     public string TestGatewayUrlForDisplay => GatewayUrlForDisplay;
@@ -197,6 +240,45 @@ public class WebSocketClientBaseTests
         Assert.Equal(2, statuses.Count);
         Assert.All(statuses, s => Assert.Equal(ConnectionStatus.Error, s));
         client.Dispose();
+    }
+
+    [Fact]
+    public async Task SendRawAsync_SerializesConcurrentSends()
+    {
+        var client = new TestWebSocketClient("ws://localhost:18789", "token", _logger)
+        {
+            SimulateOpenSocket = true
+        };
+
+        var first = client.TestSendRawAsync("one");
+        await client.FirstSendEntered.WaitAsync(TimeSpan.FromSeconds(1));
+
+        var second = client.TestSendRawAsync("two");
+        await Task.Delay(100);
+
+        Assert.Equal(1, client.SendCallCount);
+        Assert.Equal(1, client.MaxConcurrentSends);
+
+        client.ReleaseSends();
+        await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(2, client.SendCallCount);
+        Assert.Equal(1, client.MaxConcurrentSends);
+        client.Dispose();
+    }
+
+    [Fact]
+    public async Task SendRawAsync_HonorsClientCancellation()
+    {
+        var client = new TestWebSocketClient("ws://localhost:18789", "token", _logger)
+        {
+            SimulateOpenSocket = true
+        };
+
+        client.Dispose();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => client.TestSendRawAsync("message"));
     }
 
     [Fact]

--- a/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenClaw.Shared;
 using OpenClaw.Shared.Capabilities;
@@ -1221,6 +1222,70 @@ public class WindowsNodeClientTests
         }
     }
 
+    private sealed class BlockingCapability : INodeCapability
+    {
+        private readonly TaskCompletionSource<NodeInvokeResponse> _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int StartedCount;
+        public bool IsCompleted => _completion.Task.IsCompleted;
+        public string Category => "blocking";
+        public IReadOnlyList<string> Commands { get; } = ["blocking.wait"];
+        public bool CanHandle(string command) => command == "blocking.wait";
+
+        public Task<NodeInvokeResponse> ExecuteAsync(NodeInvokeRequest request)
+        {
+            Interlocked.Increment(ref StartedCount);
+            return _completion.Task;
+        }
+
+        public void Complete() =>
+            _completion.TrySetResult(new NodeInvokeResponse { Ok = true, Payload = new { done = true } });
+    }
+
+    [Fact]
+    public async Task CommandDispatch_ReturnsBeforeCapabilityCompletes()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+            var cap = new BlockingCapability();
+            client.RegisterCapability(cap);
+
+            var json = """
+                {
+                  "type": "req",
+                  "id": "req-blocking",
+                  "method": "node.invoke",
+                  "params": {
+                    "command": "blocking.wait",
+                    "args": {}
+                  }
+                }
+                """;
+
+            var processTask = InvokeProcessMessageAsync(client, json);
+            var completed = await Task.WhenAny(processTask, Task.Delay(250));
+
+            Assert.Same(processTask, completed);
+            Assert.False(cap.IsCompleted);
+
+            await WaitForConditionAsync(
+                () => Volatile.Read(ref cap.StartedCount) == 1,
+                TimeSpan.FromSeconds(1));
+
+            cap.Complete();
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
     [Fact]
     public async Task CommandDispatch_RoutesToRegisteredCapability()
     {
@@ -1248,6 +1313,7 @@ public class WindowsNodeClientTests
                 """;
 
             await InvokeProcessMessageAsync(client, json);
+            await WaitForConditionAsync(() => cap.ExecuteCount == 1, TimeSpan.FromSeconds(1));
 
             Assert.Equal(1, cap.ExecuteCount);
             Assert.Equal("mock.ping", cap.LastCommand);
@@ -1325,6 +1391,7 @@ public class WindowsNodeClientTests
                 """;
 
             await InvokeProcessMessageAsync(client, json);
+            await WaitForConditionAsync(() => first.ExecuteCount == 1, TimeSpan.FromSeconds(1));
 
             Assert.Equal(1, first.ExecuteCount);
             Assert.Equal(0, second.ExecuteCount);
@@ -1363,6 +1430,7 @@ public class WindowsNodeClientTests
                 """;
 
             await InvokeProcessMessageAsync(client, json);
+            await WaitForConditionAsync(() => cap.ExecuteCount == 1, TimeSpan.FromSeconds(1));
 
             Assert.Equal(1, cap.ExecuteCount);
             Assert.Equal("mock.ping", cap.LastCommand);
@@ -1382,5 +1450,17 @@ public class WindowsNodeClientTests
         Assert.NotNull(processMethod);
         var task = (Task)processMethod!.Invoke(client, [json])!;
         await task;
+    }
+
+    private static async Task WaitForConditionAsync(Func<bool> predicate, TimeSpan timeout)
+    {
+        var start = DateTime.UtcNow;
+        while (!predicate())
+        {
+            if (DateTime.UtcNow - start > timeout)
+                throw new TimeoutException("Condition was not met before the timeout.");
+
+            await Task.Delay(25);
+        }
     }
 }

--- a/tests/OpenClaw.Tray.Tests/GatewayConnectionManagerConnectTests.cs
+++ b/tests/OpenClaw.Tray.Tests/GatewayConnectionManagerConnectTests.cs
@@ -44,6 +44,26 @@ public sealed class GatewayConnectionManagerConnectTests : IDisposable
         Assert.Equal(OverallConnectionState.Connecting, _manager.CurrentSnapshot.OverallState);
     }
 
+    [Fact]
+    public async Task DisconnectAsync_CancelsInFlightLifecycleConnect()
+    {
+        _registry.AddOrUpdate(new GatewayRecord { Id = "gw-1", Url = "ws://localhost:18789", IsLocal = true });
+        _registry.SetActive("gw-1");
+        _resolver.OperatorCredential = new GatewayCredential("operator-token", IsBootstrapToken: false, Source: "test");
+
+        await _manager.ConnectAsync("gw-1");
+        var lifecycle = _factory.CreatedClients.Single();
+        var token = await lifecycle.ConnectStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.False(token.IsCancellationRequested);
+
+        await _manager.DisconnectAsync();
+
+        await WaitForConditionAsync(
+            () => token.IsCancellationRequested,
+            TimeSpan.FromSeconds(1));
+    }
+
     private sealed class FakeCredentialResolver : ICredentialResolver
     {
         public GatewayCredential? OperatorCredential { get; set; }
@@ -69,14 +89,32 @@ public sealed class GatewayConnectionManagerConnectTests : IDisposable
     {
         public OpenClawGatewayClient DataClient { get; } = new(gatewayUrl, "mock-token", NullLogger.Instance);
         public bool IsDisposed { get; private set; }
+        public TaskCompletionSource<CancellationToken> ConnectStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
 
 #pragma warning disable CS0067 // Events required by interface but not fired in this regression test.
         public event EventHandler<ConnectionStatus>? StatusChanged;
         public event EventHandler<string>? AuthenticationFailed;
 #pragma warning restore CS0067
 
-        public Task ConnectAsync(CancellationToken ct) => Task.CompletedTask;
+        public Task ConnectAsync(CancellationToken ct)
+        {
+            ConnectStarted.TrySetResult(ct);
+            return Task.Delay(Timeout.InfiniteTimeSpan, ct);
+        }
 
         public void Dispose() => IsDisposed = true;
+    }
+
+    private static async Task WaitForConditionAsync(Func<bool> predicate, TimeSpan timeout)
+    {
+        var start = DateTime.UtcNow;
+        while (!predicate())
+        {
+            if (DateTime.UtcNow - start > timeout)
+                throw new TimeoutException("Condition was not met before the timeout.");
+
+            await Task.Delay(25);
+        }
     }
 }


### PR DESCRIPTION
﻿## Summary
- Serialize outbound WebSocket sends to prevent concurrent `ClientWebSocket.SendAsync` collisions.
- Thread connection cancellation from `GatewayConnectionManager` through `GatewayClientFactory` into `WebSocketClientBase`, with captured-socket listen loops and generation guards for stale lifecycle work.
- Move node invoke capability execution off the WebSocket receive loop using bounded observed dispatch while preserving existing response protocols.

## Felt-performance/correctness risk addressed
This prevents receive loops from being blocked by long-running node capabilities, prevents fire-and-forget request sends from colliding, and avoids stale connect/reconnect work updating gateway or node state after cancellation/disconnect.

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`
- Additional targeted: `dotnet test ./tests/OpenClaw.Connection.Tests/OpenClaw.Connection.Tests.csproj`
