### PR TITLE
Clean up credential source fallbacks

### DIFF
--- a/src/OpenClaw.Connection/InteractiveGatewayCredentialResolver.cs
+++ b/src/OpenClaw.Connection/InteractiveGatewayCredentialResolver.cs
@@ -12,79 +12,45 @@ public static class InteractiveGatewayCredentialResolver
 {
     public static bool TryResolve(
         GatewayRegistry? registry,
-        string settingsDirectory,
         IDeviceIdentityReader identityReader,
-        string? effectiveGatewayUrl,
-        string? legacyToken,
-        string? legacyBootstrapToken,
         out InteractiveGatewayCredential? credential)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(settingsDirectory);
         ArgumentNullException.ThrowIfNull(identityReader);
 
         var active = registry?.GetActive();
-        if (active != null && !string.IsNullOrWhiteSpace(active.Url))
-        {
-            // For HTTP surfaces (chat), prefer SharedGatewayToken over DeviceToken.
-            // DeviceToken is for WebSocket auth (auth.deviceToken); SharedGatewayToken
-            // is for HTTP ?token= auth which the chat/dashboard endpoints expect.
-            if (!string.IsNullOrWhiteSpace(active.SharedGatewayToken))
-            {
-                credential = new InteractiveGatewayCredential(
-                    active.Url,
-                    active.SharedGatewayToken!,
-                    false,
-                    CredentialResolver.SourceSharedGatewayToken);
-                return true;
-            }
-
-            // Fall back to standard credential resolution (DeviceToken → Bootstrap)
-            var resolver = new CredentialResolver(identityReader);
-            var resolved = resolver.ResolveOperator(active, registry!.GetIdentityDirectory(active.Id));
-            if (resolved != null)
-            {
-                credential = new InteractiveGatewayCredential(
-                    active.Url,
-                    resolved.Token,
-                    resolved.IsBootstrapToken,
-                    resolved.Source);
-                return true;
-            }
-
-            if (!string.Equals(active.Url, effectiveGatewayUrl, StringComparison.OrdinalIgnoreCase))
-            {
-                credential = null;
-                return false;
-            }
-        }
-
-        var gatewayUrl = effectiveGatewayUrl;
-        if (string.IsNullOrWhiteSpace(gatewayUrl))
+        if (active == null || string.IsNullOrWhiteSpace(active.Url))
         {
             credential = null;
             return false;
         }
 
-        var legacyRecord = new GatewayRecord
+        // For HTTP surfaces (chat), prefer SharedGatewayToken over DeviceToken.
+        // DeviceToken is for WebSocket auth (auth.deviceToken); SharedGatewayToken
+        // is for HTTP ?token= auth which the chat/dashboard endpoints expect.
+        if (!string.IsNullOrWhiteSpace(active.SharedGatewayToken))
         {
-            Id = "legacy-settings",
-            Url = gatewayUrl,
-            SharedGatewayToken = legacyToken,
-            BootstrapToken = legacyBootstrapToken
-        };
-        var resolver2 = new CredentialResolver(identityReader);
-        var legacyCredential = resolver2.ResolveOperator(legacyRecord, settingsDirectory);
-        if (legacyCredential == null)
+            credential = new InteractiveGatewayCredential(
+                active.Url,
+                active.SharedGatewayToken!,
+                false,
+                CredentialResolver.SourceSharedGatewayToken);
+            return true;
+        }
+
+        // Fall back to standard credential resolution (DeviceToken → Bootstrap)
+        var resolver = new CredentialResolver(identityReader);
+        var resolved = resolver.ResolveOperator(active, registry!.GetIdentityDirectory(active.Id));
+        if (resolved == null)
         {
             credential = null;
             return false;
         }
 
         credential = new InteractiveGatewayCredential(
-            gatewayUrl,
-            legacyCredential.Token,
-            legacyCredential.IsBootstrapToken,
-            legacyCredential.Source);
+            active.Url,
+            resolved.Token,
+            resolved.IsBootstrapToken,
+            resolved.Source);
         return true;
     }
 }

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1587,6 +1587,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         if (!string.IsNullOrWhiteSpace(effectiveUrl) &&
             string.Equals(record.Url, effectiveUrl, StringComparison.OrdinalIgnoreCase))
         {
+            Logger.Warn("[GatewayRegistry] Resolved operator credential from legacy root identity path; migration copy may have failed.");
             return resolver.ResolveOperator(record, SettingsManager.SettingsDirectoryPath);
         }
 
@@ -2925,11 +2926,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
         if (!InteractiveGatewayCredentialResolver.TryResolve(
             _gatewayRegistry,
-            SettingsManager.SettingsDirectoryPath,
             DeviceIdentityFileReader.Instance,
-            _settings.GetEffectiveGatewayUrl(),
-            _settings.LegacyToken,
-            _settings.LegacyBootstrapToken,
             out var credential) ||
             credential == null)
         {

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -139,11 +139,7 @@ public sealed partial class ChatPage : Page
     {
         return InteractiveGatewayCredentialResolver.TryResolve(
             (App.Current as App)?.Registry,
-            SettingsManager.SettingsDirectoryPath,
             DeviceIdentityFileReader.Instance,
-            settings.GetEffectiveGatewayUrl(),
-            settings.LegacyToken,
-            settings.LegacyBootstrapToken,
             out var credential) &&
             credential is { IsBootstrapToken: false } &&
             GatewayChatUrlBuilder.TryBuildChatUrl(credential.GatewayUrl, credential.Token, out var url, out _)
@@ -277,11 +273,7 @@ public sealed partial class ChatPage : Page
         {
             if (!InteractiveGatewayCredentialResolver.TryResolve(
                 CurrentApp.Registry,
-                SettingsManager.SettingsDirectoryPath,
                 DeviceIdentityFileReader.Instance,
-                settings.GetEffectiveGatewayUrl(),
-                settings.LegacyToken,
-                settings.LegacyBootstrapToken,
                 out var credential) ||
                 credential == null)
             {

--- a/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
@@ -1634,6 +1634,10 @@ public sealed class SettingsManagerLocalGatewaySetupSettings : ILocalGatewaySetu
 {
     private readonly SettingsManager _settings;
     private readonly OpenClaw.Connection.GatewayRegistry? _registry;
+    private string _token = "";
+    private string _bootstrapToken = "";
+    private bool _tokenAssigned;
+    private bool _bootstrapTokenAssigned;
 
     public SettingsManagerLocalGatewaySetupSettings(SettingsManager settings, OpenClaw.Connection.GatewayRegistry? registry = null)
     {
@@ -1642,8 +1646,24 @@ public sealed class SettingsManagerLocalGatewaySetupSettings : ILocalGatewaySetu
     }
 
     public string GatewayUrl { get => _settings.GatewayUrl; set => _settings.GatewayUrl = value; }
-    public string Token { get; set; } = "";
-    public string BootstrapToken { get; set; } = "";
+    public string Token
+    {
+        get => _token;
+        set
+        {
+            _token = value ?? string.Empty;
+            _tokenAssigned = true;
+        }
+    }
+    public string BootstrapToken
+    {
+        get => _bootstrapToken;
+        set
+        {
+            _bootstrapToken = value ?? string.Empty;
+            _bootstrapTokenAssigned = true;
+        }
+    }
     public bool UseSshTunnel { get => _settings.UseSshTunnel; set => _settings.UseSshTunnel = value; }
     public bool EnableNodeMode { get => _settings.EnableNodeMode; set => _settings.EnableNodeMode = value; }
 
@@ -1656,13 +1676,16 @@ public sealed class SettingsManagerLocalGatewaySetupSettings : ILocalGatewaySetu
         {
             var existing = _registry.FindByUrl(GatewayUrl);
             var recordId = existing?.Id ?? System.Guid.NewGuid().ToString();
-            var record = new OpenClaw.Connection.GatewayRecord
+            var record = (existing ?? new OpenClaw.Connection.GatewayRecord { Id = recordId }) with
             {
-                Id = recordId,
                 Url = GatewayUrl,
-                SharedGatewayToken = !string.IsNullOrWhiteSpace(Token) ? Token : existing?.SharedGatewayToken,
-                BootstrapToken = !string.IsNullOrWhiteSpace(BootstrapToken) ? BootstrapToken : existing?.BootstrapToken,
-                IsLocal = true,
+                SharedGatewayToken = _tokenAssigned
+                    ? (string.IsNullOrWhiteSpace(_token) ? null : _token)
+                    : existing?.SharedGatewayToken,
+                BootstrapToken = _bootstrapTokenAssigned
+                    ? (string.IsNullOrWhiteSpace(_bootstrapToken) ? null : _bootstrapToken)
+                    : existing?.BootstrapToken,
+                IsLocal = true
             };
             _registry.AddOrUpdate(record);
             _registry.SetActive(recordId);
@@ -1976,6 +1999,8 @@ public sealed class SettingsOperatorPairingService : IOperatorPairingService
 
     private ResolvedOperatorCredential? ResolveCredential()
     {
+        // Setup-only pending credentials: normal post-setup callers must use
+        // CredentialResolver so stored device tokens are never downgraded.
         if (!string.IsNullOrWhiteSpace(_settings.Token))
             return new ResolvedOperatorCredential(_settings.Token, false);
 

--- a/tests/OpenClaw.Connection.Tests/InteractiveGatewayCredentialResolverTests.cs
+++ b/tests/OpenClaw.Connection.Tests/InteractiveGatewayCredentialResolverTests.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using OpenClaw.Shared;
 using OpenClaw.Connection;
 
@@ -36,11 +35,7 @@ public class InteractiveGatewayCredentialResolverTests : IDisposable
 
         var resolved = InteractiveGatewayCredentialResolver.TryResolve(
             _registry,
-            _tempDir,
             _identityReader,
-            "ws://legacy:18789",
-            null,
-            null,
             out var credential);
 
         Assert.True(resolved);
@@ -65,11 +60,7 @@ public class InteractiveGatewayCredentialResolverTests : IDisposable
 
         var resolved = InteractiveGatewayCredentialResolver.TryResolve(
             _registry,
-            _tempDir,
             _identityReader,
-            "ws://active:18789",
-            null,
-            null,
             out var credential);
 
         Assert.True(resolved);
@@ -94,11 +85,7 @@ public class InteractiveGatewayCredentialResolverTests : IDisposable
 
         var resolved = InteractiveGatewayCredentialResolver.TryResolve(
             _registry,
-            _tempDir,
             _identityReader,
-            "ws://active:18789",
-            null,
-            null,
             out var credential);
 
         Assert.True(resolved);
@@ -109,23 +96,40 @@ public class InteractiveGatewayCredentialResolverTests : IDisposable
     }
 
     [Fact]
-    public void TryResolve_FallsBackToLegacySettingsWhenNoRegistryIsActive()
+    public void TryResolve_ReturnsFalse_WhenNoRegistryIsActive()
     {
         var resolved = InteractiveGatewayCredentialResolver.TryResolve(
             _registry,
-            _tempDir,
             _identityReader,
-            "ws://legacy:18789",
-            "legacy-token",
-            null,
+            out var credential);
+
+        Assert.False(resolved);
+        Assert.Null(credential);
+    }
+
+    [Fact]
+    public void TryResolve_UsesActiveGatewayDeviceToken_WhenSharedTokenMissing()
+    {
+        var record = new GatewayRecord
+        {
+            Id = "gw-1",
+            Url = "ws://active:18789"
+        };
+        _registry.AddOrUpdate(record);
+        _registry.SetActive(record.Id);
+        _identityReader.OperatorToken = "paired-token";
+
+        var resolved = InteractiveGatewayCredentialResolver.TryResolve(
+            _registry,
+            _identityReader,
             out var credential);
 
         Assert.True(resolved);
         Assert.NotNull(credential);
-        Assert.Equal("ws://legacy:18789", credential!.GatewayUrl);
-        Assert.Equal("legacy-token", credential.Token);
+        Assert.Equal("ws://active:18789", credential!.GatewayUrl);
+        Assert.Equal("paired-token", credential.Token);
         Assert.False(credential.IsBootstrapToken);
-        Assert.Equal(CredentialResolver.SourceSharedGatewayToken, credential.Source);
+        Assert.Equal(CredentialResolver.SourceDeviceToken, credential.Source);
     }
 
     private sealed class MockDeviceIdentityReader : IDeviceIdentityReader

--- a/tests/OpenClaw.Tray.Tests/LocalGatewaySetupTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalGatewaySetupTests.cs
@@ -546,6 +546,98 @@ public class LocalGatewaySetupTests
     }
 
     [Fact]
+    public void SettingsManagerLocalGatewaySetupSettings_PersistsCredentialsToRegistryOnly()
+    {
+        using var temp = new TempDirectory();
+        var settings = new OpenClawTray.Services.SettingsManager(temp.Path);
+        var registry = new OpenClaw.Connection.GatewayRegistry(temp.Path);
+        var adapter = new SettingsManagerLocalGatewaySetupSettings(settings, registry)
+        {
+            GatewayUrl = "ws://localhost:18789",
+            Token = "shared-token",
+            BootstrapToken = "bootstrap-token"
+        };
+
+        adapter.Save();
+
+        var record = registry.GetActive();
+        Assert.NotNull(record);
+        Assert.Equal("shared-token", record!.SharedGatewayToken);
+        Assert.Equal("bootstrap-token", record.BootstrapToken);
+
+        using var savedSettings = System.Text.Json.JsonDocument.Parse(File.ReadAllText(Path.Combine(temp.Path, "settings.json")));
+        Assert.False(savedSettings.RootElement.TryGetProperty("Token", out _));
+        Assert.False(savedSettings.RootElement.TryGetProperty("BootstrapToken", out _));
+    }
+
+    [Fact]
+    public void SettingsManagerLocalGatewaySetupSettings_PreservesRecordFieldsAndUnassignedCredentials()
+    {
+        using var temp = new TempDirectory();
+        var settings = new OpenClawTray.Services.SettingsManager(temp.Path);
+        var registry = new OpenClaw.Connection.GatewayRegistry(temp.Path);
+        var lastConnected = DateTime.UtcNow;
+        var existing = new OpenClaw.Connection.GatewayRecord
+        {
+            Id = "gw-1",
+            Url = "ws://localhost:18789",
+            FriendlyName = "Local",
+            SharedGatewayToken = "existing-shared",
+            BootstrapToken = "existing-bootstrap",
+            LastConnected = lastConnected,
+            SshTunnel = new OpenClaw.Connection.SshTunnelConfig("user", "host", 18789, 18790)
+        };
+        registry.AddOrUpdate(existing);
+        registry.SetActive(existing.Id);
+
+        var adapter = new SettingsManagerLocalGatewaySetupSettings(settings, registry)
+        {
+            GatewayUrl = existing.Url,
+            UseSshTunnel = false
+        };
+        adapter.Save();
+
+        var record = registry.GetActive();
+        Assert.NotNull(record);
+        Assert.Equal("Local", record!.FriendlyName);
+        Assert.Equal("existing-shared", record.SharedGatewayToken);
+        Assert.Equal("existing-bootstrap", record.BootstrapToken);
+        Assert.Equal(lastConnected, record.LastConnected);
+        Assert.Equal(existing.SshTunnel, record.SshTunnel);
+        Assert.True(record.IsLocal);
+    }
+
+    [Fact]
+    public void SettingsManagerLocalGatewaySetupSettings_ClearsExplicitlyClearedRegistryCredentials()
+    {
+        using var temp = new TempDirectory();
+        var settings = new OpenClawTray.Services.SettingsManager(temp.Path);
+        var registry = new OpenClaw.Connection.GatewayRegistry(temp.Path);
+        var existing = new OpenClaw.Connection.GatewayRecord
+        {
+            Id = "gw-1",
+            Url = "ws://localhost:18789",
+            SharedGatewayToken = "existing-shared",
+            BootstrapToken = "existing-bootstrap",
+        };
+        registry.AddOrUpdate(existing);
+        registry.SetActive(existing.Id);
+
+        var adapter = new SettingsManagerLocalGatewaySetupSettings(settings, registry)
+        {
+            GatewayUrl = existing.Url,
+            Token = "",
+            BootstrapToken = ""
+        };
+        adapter.Save();
+
+        var record = registry.GetActive();
+        Assert.NotNull(record);
+        Assert.Null(record!.SharedGatewayToken);
+        Assert.Null(record.BootstrapToken);
+    }
+
+    [Fact]
     public async Task SettingsSharedGatewayTokenProvisioner_DoesNotPersistTokenWhenGatewayConfigFails()
     {
         var settings = new FakeSetupSettings();


### PR DESCRIPTION
## Summary
- Remove the legacy settings Token/BootstrapToken fallback from interactive chat/dashboard credential resolution; these flows now resolve from the active GatewayRegistry record plus per-gateway identity only.
- Keep one-time legacy migration intact and retain the legacy root identity startup backstop with a warning for failed/old migrations.
- Tighten local gateway setup credential persistence so setup credentials merge through GatewayRegistry, preserve existing record metadata, and explicit clears remove registry tokens instead of preserving stale values.
- Add regression coverage for active-registry credential resolution and local setup registry-only credential persistence/clear behavior.

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Connection.Tests/OpenClaw.Connection.Tests.csproj --no-restore`