### PR TITLE
fix(v2-wizard): pre-seed gateway.reload.mode=hot to keep wizard.next alive across config writes

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Onboarding/GatewayWizard/GatewayWizardPage.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/GatewayWizard/GatewayWizardPage.cs
@@ -93,6 +93,44 @@ public sealed class GatewayWizardPage : Component<GatewayWizardState>
 
                 setWizardState("complete");
                 SaveState("complete");
+
+                // Re-arm gateway.reload.mode=hybrid (the gateway default) now that
+                // the wizard's burst of config writes is done. The pre-seed in
+                // OpenClawCliGatewayConfigurationPreparer.PrepareAsync set this to
+                // "hot" so the wizard's mid-flow config writes wouldn't fire a
+                // service restart that cancels the in-flight wizard.next (see that
+                // file's comment for the full root-cause analysis). Leaving "hot"
+                // permanent would silently suppress restart-required config changes
+                // later (e.g., port/bind/auth changes from the tray Settings page
+                // would update openclaw.json but the running gateway would keep its
+                // old settings). Resetting to "hybrid" restores normal behavior.
+                //
+                // This write itself does not trigger a reload: gateway.reload is a
+                // { prefix: "gateway.reload", kind: "none" } rule in
+                // src/gateway/config-reload-plan.ts:50. Best-effort fire-and-forget;
+                // failures only log because we don't want to block the wizard
+                // complete transition on a config write blip.
+                try
+                {
+                    var resetClient = ((App)Microsoft.UI.Xaml.Application.Current).GatewayClient ?? Props.GatewayClient;
+                    if (resetClient is not null)
+                    {
+                        _ = resetClient.SetConfigAsync("gateway.reload.mode", "hybrid")
+                            .ContinueWith(t =>
+                            {
+                                if (t.IsFaulted)
+                                    Logger.Warn($"[GatewayWizard] Failed to reset gateway.reload.mode to hybrid: {t.Exception?.GetBaseException().Message}");
+                                else if (t.Result)
+                                    Logger.Info("[GatewayWizard] Reset gateway.reload.mode to hybrid after wizard completion");
+                                else
+                                    Logger.Warn("[GatewayWizard] Reset gateway.reload.mode returned false (config.set declined)");
+                            }, TaskScheduler.Default);
+                    }
+                }
+                catch (Exception resetEx)
+                {
+                    Logger.Warn($"[GatewayWizard] Could not schedule gateway.reload.mode reset: {resetEx.Message}");
+                }
                 return;
             }
 
@@ -331,6 +369,10 @@ public sealed class GatewayWizardPage : Component<GatewayWizardState>
                     ApplyStep(response);
                 }
             }
+            catch (OperationCanceledException ex)
+            {
+                await TryRecoverFromServiceRestartAsync(app, stepId, ex);
+            }
             catch (Exception ex)
             {
                 // SECURITY: Log full exception, show a sanitized version of the gateway
@@ -392,6 +434,17 @@ public sealed class GatewayWizardPage : Component<GatewayWizardState>
                 var response = await client.SendWizardRequestAsync("wizard.next", parameters);
                 ApplyStep(response);
             }
+            catch (OperationCanceledException ex)
+            {
+                // Sibling-defect recovery: SkipStep hits the same WS close 1012
+                // restart race as SubmitStep when the user clicks the Skip button
+                // (vs picking __skip__ + Continue). Route through the same recovery
+                // helper so a transient disconnect or service-restart mid-skip
+                // doesn't leave the wizard surface stuck. See SubmitStep's catch
+                // for the underlying root-cause analysis.
+                var app2 = (App)Microsoft.UI.Xaml.Application.Current;
+                await TryRecoverFromServiceRestartAsync(app2, stepId, ex);
+            }
             catch (Exception ex)
             {
                 Logger.Error($"[GatewayWizard] Skip step failed: {ex}");
@@ -406,6 +459,112 @@ public sealed class GatewayWizardPage : Component<GatewayWizardState>
             {
                 await Task.Delay(400); // Brief delay so button disable is visible
                 setSubmitting(false);
+            }
+        }
+
+        // Recovery helper shared by SubmitStep and SkipStep.
+        //
+        // Empirical bug (logs at 2026-05-16 14:47:44, channels-skip path on a
+        // fresh openclaw.json): the gateway commits the wizard's collected
+        // config to disk between stages (writeWizardConfigFile at
+        // src/wizard/setup.ts:750). On a fresh install that snapshot adds new
+        // gateway.bind / gateway.tailscale.* / gateway.controlUi.* /
+        // auth.profiles.* paths, all of which match the catch-all
+        // { prefix: "gateway", kind: "restart" } rule in
+        // src/gateway/config-reload-plan.ts:126. The chokidar config-reload
+        // watcher in src/gateway/config-reload.ts queues a service restart
+        // (WS close 1012, "gateway restarting", restartExpectedMs: 1500 — see
+        // src/cli/gateway-cli/run-loop.ts:558).
+        // OpenClawGatewayClient.ClearPendingRequests then raises
+        // OperationCanceledException from the pending wizard TCS.
+        //
+        // The primary fix for this is the gateway.reload.mode=hot pre-seed in
+        // OpenClawCliGatewayConfigurationPreparer.PrepareAsync; this helper is
+        // the defense-in-depth path that still runs if any other event drops
+        // the wizard.next mid-flight (gateway crash, manual systemctl restart,
+        // intermittent WSL network blip, etc.). Mirrors the macOS tray pattern
+        // in apps/macos/Sources/OpenClaw/OnboardingWizard.swift:171-186
+        // (restartIfSessionLost): wait for reconnect, clear stale session,
+        // re-issue wizard.start. If the gateway-side session is still alive
+        // (transient WS disconnect, no full restart), fall back to wizard.status
+        // — mirrors StartWizard at the top of this file (lines 238-253).
+        async Task TryRecoverFromServiceRestartAsync(App app, string failingStepId, OperationCanceledException originalEx)
+        {
+            Logger.Info($"[GatewayWizard] wizard.next cancelled by service-restart-like event ({originalEx.Message}); waiting for reconnect to restart wizard…");
+            setErrorMsg("");
+            setWizardState("loading");
+            SaveState("loading");
+
+            IOperatorGatewayClient? client = null;
+            var reconnected = false;
+            for (int wait = 0; wait < 20; wait++)
+            {
+                client = app.GatewayClient ?? Props.GatewayClient;
+                if (client?.IsConnectedToGateway == true) { reconnected = true; break; }
+                await Task.Delay(1000);
+            }
+
+            if (!reconnected || client == null)
+            {
+                Logger.Warn("[GatewayWizard] Gateway did not reconnect within 20s after service restart");
+                var msg = LocalizationHelper.GetString("Onboarding_Wizard_ErrorGatewayDisconnectedDetail");
+                if (string.IsNullOrEmpty(msg) || msg == "Onboarding_Wizard_ErrorGatewayDisconnectedDetail")
+                    msg = "Gateway is restarting. Try again in a moment.";
+                setErrorMsg(msg);
+                setWizardState("error");
+                SaveState("error", msg);
+                return;
+            }
+
+            // Clear the stale session before restarting so wizard.start does not
+            // get rejected with "wizard already running" if the server preserved
+            // the in-memory session across our WS close (transient blip).
+            Props.WizardSessionId = null;
+            Props.WizardStepPayload = null;
+
+            try
+            {
+                Logger.Info("[GatewayWizard] Reconnected; calling wizard.start to recover from service restart");
+                var restartResponse = await client.SendWizardRequestAsync("wizard.start");
+                ApplyStep(restartResponse);
+            }
+            catch (InvalidOperationException sessionStillRunning) when (sessionStillRunning.Message.Contains("already running", StringComparison.OrdinalIgnoreCase))
+            {
+                // Transient disconnect, NOT a full service restart: the gateway-side
+                // wizard session is still alive. wizard.status returns {status,error?}
+                // only — no step payload — but ApplyStep falls through to
+                // setWizardState("active") preserving whatever stale step the UI was
+                // showing. Mirrors StartWizard's pattern at lines 238-253.
+                Logger.Info("[GatewayWizard] Wizard session still running after reconnect, fetching current status…");
+                try
+                {
+                    var statusResponse = await client.SendWizardRequestAsync("wizard.status");
+                    ApplyStep(statusResponse);
+                }
+                catch
+                {
+                    Logger.Warn("[GatewayWizard] Could not resume existing wizard session after reconnect, marking offline");
+                    setWizardState("offline");
+                    SaveState("offline");
+                }
+            }
+            catch (InvalidOperationException unknownOrMissing) when (
+                unknownOrMissing.Message.Contains("unknown method", StringComparison.OrdinalIgnoreCase) ||
+                unknownOrMissing.Message.Contains("not found", StringComparison.OrdinalIgnoreCase))
+            {
+                Logger.Warn($"[GatewayWizard] wizard.start after reconnect hit unknown-method/not-found: {unknownOrMissing.Message}");
+                setWizardState("offline");
+                SaveState("offline");
+            }
+            catch (Exception restartEx)
+            {
+                Logger.Error($"[GatewayWizard] wizard.start after service restart failed: {restartEx}");
+                var fallback = LocalizationHelper.GetString("Onboarding_Wizard_StepError");
+                if (fallback == "Onboarding_Wizard_StepError") fallback = WizardErrorFormatter.GenericFallbackMessage;
+                var msg = WizardErrorFormatter.FormatStepError(restartEx, failingStepId, fallback);
+                setErrorMsg(msg);
+                setWizardState("error");
+                SaveState("error", msg);
             }
         }
 

--- a/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
@@ -1146,6 +1146,30 @@ public sealed class OpenClawCliGatewayConfigurationPreparer : IGatewayConfigurat
             openClaw + " config set gateway.port " + options.GatewayPort.ToString(CultureInfo.InvariantCulture) + " --strict-json",
             openClaw + " config set gateway.auth.mode token",
             "xargs -r " + openClaw + " config set gateway.auth.token </var/lib/openclaw/gateway-token",
+            // Suppress restart-required reloads triggered by config writes the V2 setup
+            // wizard makes mid-flow. With the default "hybrid" mode, the gateway-side
+            // wizard at src/wizard/setup.ts:750 commits the wizard's collected snapshot
+            // (gateway.bind / gateway.tailscale.* / gateway.controlUi.* /
+            // auth.profiles.*) — those paths fall under the catch-all restart rule
+            // in src/gateway/config-reload-plan.ts (line 126: { prefix: "gateway",
+            // kind: "restart" }) and would fire a service restart (WS close 1012,
+            // restartExpectedMs: 1500). That cancels the in-flight wizard.next mid-
+            // step and forces the operator to re-walk the entire wizard with no
+            // memory of the previous answers.
+            //
+            // Setting reload.mode=hot makes the watcher LOG-and-IGNORE restart-required
+            // changes (src/gateway/config-reload.ts:274-281: "config reload requires
+            // gateway restart; hot mode ignoring") while still allowing legitimate
+            // hot reloads (channels/hooks/plugins). The gateway already has the right
+            // bind/auth/port from this PrepareGatewayConfig phase, so suppressing the
+            // mid-wizard restart loses nothing: the wizard's writes for those paths
+            // are no-ops in terms of running gateway state.
+            //
+            // gateway.reload itself is { prefix: "gateway.reload", kind: "none" } in
+            // the reload-plan rules, so this write does not itself trigger a reload.
+            // The watcher is not yet active when this script runs (StartGateway phase
+            // hasn't started), so even the earlier writes above don't notify.
+            openClaw + " config set gateway.reload.mode hot",
             openClaw + " config validate"
         });
 


### PR DESCRIPTION
## Bug

On a fresh V2 onboarding run (fresh WSL + first-ever `openclaw.json`), the gateway wizard hangs after the user picks **"none — I'll add channels later"** at the channels-select step. The `wizard.next` request is cancelled with `OperationCanceledException("Gateway connection lost while waiting for wizard response")` and the operator is stuck. No prior fix in the last two weeks unblocked this path.

Two weeks of windows-side hardening had treated this as a wizard-state / parse / reconnect defect. It is none of those.

## Root cause

After the operator submits any answer that lets `setupChannels` return (`__skip__` is the fastest path; real-channel paths land in the same place after their sub-prompts), the gateway-side wizard at `src/wizard/setup.ts:750` calls `writeWizardConfigFile` to persist the collected snapshot to disk. On the first run that snapshot adds new paths under `gateway.bind` / `gateway.tailscale.*` / `gateway.controlUi.*` / `auth.profiles.*` — all of which match the catch-all `{ prefix: "gateway", kind: "restart" }` rule at `src/gateway/config-reload-plan.ts:126`. The chokidar config watcher (`src/gateway/config-reload.ts`) queues a service restart — WS close `1012`, `"gateway restarting"`, `restartExpectedMs: 1500` (`src/cli/gateway-cli/run-loop.ts:558`). The in-flight `wizard.next` response never makes it back; `OpenClawGatewayClient.ClearPendingRequests` raises the cancellation from the pending TCS.

The macOS tray hits the same race conceptually but operators on macOS treat re-walking the wizard as acceptable (`OnboardingWizard.swift:171-186` `restartIfSessionLost`). V2 has no such pattern. Earlier adjacent fixes (PR #413 commit `c6ccf5d`, `OnboardingWindow.cs:520-522`) were partial workarounds for adjacent symptoms of the same restart race.

## Fix — primary

`OpenClawCliGatewayConfigurationPreparer.PrepareAsync` (`LocalGatewaySetup.cs`) extends the bootstrap script that `PrepareGatewayConfig` runs inside the WSL distro to also commit `gateway.reload.mode = hot`. The watcher then takes the `"hot"` branch at `config-reload.ts:274-281` (`"config reload requires gateway restart; hot mode ignoring"`) and silently ignores restart-required changes during the wizard, while still applying legitimate hot reloads (channels, hooks, plugins, cron, heartbeat, MCP runtimes).

The pre-seed runs during `LocalGatewaySetupPhase.PrepareGatewayConfig` — BEFORE `InstallGatewayService` / `StartGateway` — so chokidar isn't yet watching the file and none of the bootstrap writes trigger reload events themselves. `gateway.reload` is itself a `{ prefix: "gateway.reload", kind: "none" }` rule (`config-reload-plan.ts:50`).

After the wizard reaches `done: true`, `GatewayWizardPage.ApplyStep` resets `gateway.reload.mode` to the default `"hybrid"` via `SetConfigAsync` (best-effort, logged-only on failure). Without this reset, leaving `hot` permanent would silently break the tray Settings page's port/auth/bind edits (running gateway keeps old settings, file shows new) — flagged HIGH by both Hanselman reviewers.

## Fix — defense in depth

`GatewayWizardPage.SubmitStep` adds a focused `OperationCanceledException` catch that mirrors the macOS `restartIfSessionLost` pattern: wait up to 20s for the gateway client to come back, clear the stale `WizardSessionId` and `WizardStepPayload`, then call `wizard.start` to recover.

The recovery is extracted to a private async helper `TryRecoverFromServiceRestartAsync` and invoked from BOTH `SubmitStep` AND `SkipStep` (sibling-defect fix — the Skip button hits the same WS close 1012 race as Continue). The recovery's `wizard.start` call also falls back to `wizard.status` on the `"wizard already running"` `InvalidOperationException`, mirroring `StartWizard:238-253` — covers the transient WS disconnect path where the gateway-side session is still alive after our client reconnects.

With the primary fix in place this recovery path shouldn't fire on the channels-skip flow, but it preserves graceful recovery if some other event (gateway crash, manual `systemctl restart`, network blip) drops the connection mid-wizard.

## Hanselman review

Ran dual-model adversarial review (Claude Opus 4.6 + GPT-5.2 Codex) per the `hanselman-code-review` skill. Consensus table:

| Finding | Opus | Codex | Consensus | Action |
|---|---|---|---|---|
| `reload.mode=hot` is permanent → silently breaks future port/auth/bind edits | MEDIUM | HIGH | **HIGH** | Reset to `hybrid` on wizard `done` |
| `SkipStep` has identical race, no recovery | HIGH | — | LOW (symmetric-defect catch) | Extract helper, share with `SubmitStep` |
| Recovery missing `wizard.status` fallback on "already running" | — | MEDIUM | LOW (symmetric-defect catch) | Mirror `StartWizard:238-253` |
| OCE catch lacks token/message filter (theoretical, no CT in scope today) | MEDIUM | LOW | LOW | Deferred — note in commit message for when a CT is added |

All three actionable findings folded into the single commit on this PR.

## Scope / non-goals

- **No gateway repo changes** — Windows-side-only fix.
- No change to V1 `WizardPage.cs` / `WizardStepParser.cs` (V1 is phased out by PR #381 / #413).
- Does not address the latent gateway `Boolean("false") === true` confirm-coercion defect in `WizardSessionPrompter.confirm` (`src/wizard/session.ts:152`); out of scope.
- Does not change V2 nav UX or the embedded `GatewayWelcomePage` shape.

## Validation

- `./build.ps1` — ✅ all 4 projects
- `dotnet test ./tests/OpenClaw.Tray.Tests/...  --no-restore` — ✅ 1086 passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/... --no-restore` — ✅ 1767 passed / 28 skipped (`IntegrationFact` per AGENTS.md memory)
- Manual repro via `dev-reset-rebuild-launch.ps1 -WipeWslDistro`: walked V2 flow through GatewayWelcome → provider/model → channels-select → "none — I'll add channels later" → wizard advanced naturally to setupSearch / setupSkills / setupInternalHooks / finalize — **no 1012, no restart, no re-walk, operator's previous answers preserved.**
- Pre-fix repro produced a 1012 immediately after the channels-skip `wizard.next`; post-fix repro shows the watcher logging the ignored restart and the response arriving normally.

cc @shanselman for review.
