### PR TITLE
Fix tray disconnected behavior

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -840,7 +840,13 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
     private void OnTrayIconSelected(TrayIcon sender, TrayIconEventArgs e)
     {
-        ShowChatWindow();
+        if (_connectionManager?.CurrentSnapshot.OperatorState == RoleConnectionState.Connected)
+        {
+            ShowChatWindow();
+            return;
+        }
+
+        ShowHub("connection");
     }
 
     internal void ShowChatWindow()

--- a/src/OpenClaw.Tray.WinUI/Services/TrayMenuStateBuilder.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/TrayMenuStateBuilder.cs
@@ -288,7 +288,8 @@ internal sealed class TrayMenuStateBuilder
             menu.AddFlyoutCustomItem(sessionsRow, sessionsFlyout, action: "sessions");
         }
 
-        // ── Usage (no divider — flows directly under Sessions) ──
+        // ── Usage (connected only; stale disconnected usage is misleading) ──
+        if (isConnected)
         {
             var usageRow = BuildUsageRow(secondaryText);
             var usageFlyout = BuildUsageFlyoutItems(secondaryText);


### PR DESCRIPTION
## Summary
- Hide usage from the tray menu while disconnected
- Route tray icon left-click to the Connection page unless the operator is connected

## Validation
- ./build.ps1
- dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore
- dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore