### PR TITLE
Avoid reserializing gateway event logs

### DIFF
--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -1369,7 +1369,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
                     HandleResponse(root);
                     break;
                 case "event":
-                    HandleEvent(root);
+                    HandleEvent(root, json.Length);
                     break;
             }
         }
@@ -2214,7 +2214,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
         return sb.ToString().TrimEnd();
     }
 
-    private void HandleEvent(JsonElement root)
+    private void HandleEvent(JsonElement root, int rawMessageLength)
     {
         if (!root.TryGetProperty("event", out var eventProp)) return;
         var eventType = eventProp.GetString();
@@ -2225,7 +2225,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
                 HandleConnectChallenge(root);
                 break;
             case "agent":
-                HandleAgentEvent(root);
+                HandleAgentEvent(root, rawMessageLength);
                 break;
             case "health":
                 if (root.TryGetProperty("payload", out var hp) &&
@@ -2236,7 +2236,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
                 }
                 break;
             case "chat":
-                HandleChatEvent(root);
+                HandleChatEvent(root, rawMessageLength);
                 break;
             case "session":
                 HandleSessionEvent(root);
@@ -2303,7 +2303,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
         }
     }
 
-    private void HandleAgentEvent(JsonElement root)
+    private void HandleAgentEvent(JsonElement root, int rawMessageLength)
     {
         if (!root.TryGetProperty("payload", out var payload)) return;
 
@@ -2311,9 +2311,8 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
         // tool args/outputs, and URLs. Log shape only (type + length).
         try
         {
-            var rawLen = root.GetRawText().Length;
             var streamHint = payload.TryGetProperty("stream", out var sh) ? sh.GetString() ?? "" : "";
-            _logger.Debug($"Agent event received: stream={streamHint} len={rawLen}");
+            _logger.Debug($"Agent event received: stream={streamHint} len={rawMessageLength}");
         }
         catch { }
 
@@ -2456,13 +2455,12 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
         }
     }
 
-    private void HandleChatEvent(JsonElement root)
+    private void HandleChatEvent(JsonElement root, int rawMessageLength)
     {
         // HIGH 4: never log chat content. Log shape only — the raw payload
         // can include user prompts, assistant text, tool output, and even
         // bearer tokens routed through the gateway in some flows.
-        var rawText = root.GetRawText();
-        _logger.Debug($"Chat event received: len={rawText.Length}");
+        _logger.Debug($"Chat event received: len={rawMessageLength}");
         
         if (!root.TryGetProperty("payload", out var payload)) return;
         EmitRawChatEvent(payload);

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -570,6 +570,32 @@ public class OpenClawGatewayClientTests
     }
 
     [Fact]
+    public void ProcessRawMessage_ChatEventLogsRawLengthWithoutPayloadContent()
+    {
+        var logger = new TestLogger();
+        var helper = new GatewayClientTestHelper(logger);
+        var rawMessage = "{\"type\":\"event\",\"event\":\"chat\",\"payload\":{\"sessionKey\":\"main\",\"text\":\"super-secret chat payload\",\"role\":\"user\"}}";
+
+        helper.ProcessRawMessage(rawMessage);
+
+        Assert.Contains(logger.Logs, log => log == $"DEBUG: Chat event received: len={rawMessage.Length}");
+        Assert.DoesNotContain(logger.Logs, log => log.Contains("super-secret", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void ProcessRawMessage_AgentEventLogsRawLengthWithoutPayloadContent()
+    {
+        var logger = new TestLogger();
+        var helper = new GatewayClientTestHelper(logger);
+        var rawMessage = "{\"type\":\"event\",\"event\":\"agent\",\"payload\":{\"sessionKey\":\"main\",\"stream\":\"tool\",\"data\":{\"phase\":\"call\",\"name\":\"shell\",\"args\":{\"command\":\"super-secret command\"}}}}";
+
+        helper.ProcessRawMessage(rawMessage);
+
+        Assert.Contains(logger.Logs, log => log == $"DEBUG: Agent event received: stream=tool len={rawMessage.Length}");
+        Assert.DoesNotContain(logger.Logs, log => log.Contains("super-secret", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void ClassifyNotification_DetectsHealthAlerts()
     {
         var helper = new GatewayClientTestHelper();


### PR DESCRIPTION
## Summary
- Avoid reserializing high-volume gateway chat/agent event JSON just to compute debug log lengths.
- Pass the original WebSocket message length through event dispatch and keep logs shape-only.
- Add regression coverage for chat and agent event logging without payload content leakage.

## 10 performance improvements identified
| Rank | Candidate | Impact | Effort |
| --- | --- | --- | --- |
| 1 | Avoid `JsonElement.GetRawText()` reserialization in chat/agent event logging | High on high-volume gateway streams | Low |
| 2 | Reuse static `JsonSerializerOptions` instead of inline `new JsonSerializerOptions` | Medium allocation reduction | Low |
| 3 | Reduce `GatewayRegistry` snapshot/list copies around mutations | Medium GC reduction | Low-Medium |
| 4 | Cache or write-through settings/identity file reads on startup paths | Medium-High startup I/O reduction | Medium |
| 5 | Reduce `CommandCenterStateBuilder` intermediate `ToList()` materialization | Medium UI rebuild/GC reduction | Low |
| 6 | Cache repeated `GetRawText()` results during config/gateway parsing | Medium parsing reduction | Low |
| 7 | Tighten `ActivityStreamService.GetItems()` snapshot/enumeration under lock | Medium lock contention reduction | Low-Medium |
| 8 | Avoid list-to-array double allocation in camera enumeration | Low-Medium allocation reduction | Low |
| 9 | Pool/reuse WebSocket multi-frame `StringBuilder` instances | Low-Medium allocation reduction | Low |
| 10 | Guard `DeviceStatusProvider` CPU sampling against overlapping timer callbacks | Low-Medium background CPU reduction | Low |

## Why this one
The selected change has the best impact-to-effort ratio: chat and agent events are frequent, payloads can be large, and the previous logging path reserialized the full `JsonElement` only to get `.Length`. Using the original inbound JSON length preserves the diagnostic signal without allocating a duplicate payload string.

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`