### PR TITLE
fix(wizard): restore static 'Configuring Gateway' heading; step title back in card

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Onboarding/GatewayWizard/GatewayWizardPage.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/GatewayWizard/GatewayWizardPage.cs
@@ -775,7 +775,14 @@ public sealed class GatewayWizardPage : Component<GatewayWizardState>
             TextBlock(LocalizationHelper.GetString("Onboarding_Wizard_Title"))
                 .FontSize(28)
                 .SemiBold()
-                .HAlign(HorizontalAlignment.Center),
+                .HAlign(HorizontalAlignment.Center)
+                .TextWrapping()
+                .Set(t =>
+                {
+                    t.MaxLines = 2;
+                    t.TextTrimming = Microsoft.UI.Xaml.TextTrimming.CharacterEllipsis;
+                    t.TextAlignment = Microsoft.UI.Xaml.TextAlignment.Center;
+                }),
 
             Border(
                 ScrollView(

--- a/src/OpenClaw.Tray.WinUI/Onboarding/GatewayWizard/GatewayWizardPage.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/GatewayWizard/GatewayWizardPage.cs
@@ -766,29 +766,36 @@ public sealed class GatewayWizardPage : Component<GatewayWizardState>
         // detected URL — including OAuth/device-code URLs.
 
         return VStack(8,
-            // Top heading is driven by the wizard's current step title (or
-            // local lifecycle title for loading/error/complete/offline). The
-            // hosting V2 page suppresses its own heading when this wizard
-            // is embedded so we don't show two titles. Capped at 2 lines
-            // with ellipsis so a long server-supplied step title can't push
-            // the device-code block or "Open in browser" button off-screen.
-            TextBlock(string.IsNullOrEmpty(displayTitle)
-                    ? LocalizationHelper.GetString("Onboarding_Wizard_Title")
-                    : displayTitle)
+            // Top heading is the static "Configuring Gateway" label. The
+            // hosting V2 page suppresses its own duplicate heading when
+            // this wizard is embedded, so we render exactly one here. The
+            // per-step title (or local lifecycle title for
+            // loading/error/complete/offline) is rendered inside the card
+            // below as the sub-heading.
+            TextBlock(LocalizationHelper.GetString("Onboarding_Wizard_Title"))
                 .FontSize(28)
                 .SemiBold()
-                .HAlign(HorizontalAlignment.Center)
-                .TextWrapping()
-                .Set(t =>
-                {
-                    t.MaxLines = 2;
-                    t.TextTrimming = Microsoft.UI.Xaml.TextTrimming.CharacterEllipsis;
-                    t.TextAlignment = Microsoft.UI.Xaml.TextAlignment.Center;
-                }),
+                .HAlign(HorizontalAlignment.Center),
 
             Border(
                 ScrollView(
                     VStack(10,
+                        TextBlock(displayTitle)
+                            .FontSize(15)
+                            .FontWeight(new global::Windows.UI.Text.FontWeight(700))
+                            .TextWrapping()
+                            .Set(t =>
+                            {
+                                // Server-supplied stepTitle in the "active" state has
+                                // untrusted length. Cap at 3 lines with ellipsis so a
+                                // verbose title can't push displayMessage and inputArea
+                                // below the card's MaxHeight(350) fold, and so a long
+                                // unbroken token (URL, slug) trims instead of clipping
+                                // horizontally inside the ScrollView (which has
+                                // HorizontalScrollMode=Disabled).
+                                t.MaxLines = 3;
+                                t.TextTrimming = Microsoft.UI.Xaml.TextTrimming.CharacterEllipsis;
+                            }),
                         TextBlock(displayMessage)
                             .FontSize(13)
                             .TextWrapping(),


### PR DESCRIPTION
## Summary

Reverts the heading layout in the embedded Gateway Wizard. The earlier QoL pass (ed9be7e + 656d46f) over-corrected: it removed both static "Configuring Gateway" labels (the V2 host page's and the wizard's) and promoted the per-step title to the top, leaving the page without its recognizable identity.

This PR restores the wizard's static top heading to "Configuring Gateway" (`Onboarding_Wizard_Title`) and moves the per-step / lifecycle title back into the gateway config card as a bold sub-heading above the message. The V2 host page's own duplicate heading remains suppressed when the wizard is embedded — so we end up with exactly one "Configuring Gateway" label, not two and not zero.

## Changes

`src/OpenClaw.Tray.WinUI/Onboarding/GatewayWizard/GatewayWizardPage.cs`

- Top heading: static `Onboarding_Wizard_Title` (was: dynamic `displayTitle` with fallback)
- Card: re-added bold `displayTitle` TextBlock above the message
- Top heading no longer needs `MaxLines=2` + `CharacterEllipsis` (fixed short string)
- Card sub-heading inherits the same defensive `MaxLines=3` + `CharacterEllipsis` cap that 656d46f added, since the untrusted server-supplied `stepTitle` now lives there in the `active` state (defends against long titles pushing content past `MaxHeight(350)` and long unbroken tokens clipping horizontally inside the `HorizontalScrollMode=Disabled` ScrollView)

## Review

Ran a Hanselman dual-model review (Opus + Codex). HIGH-consensus finding: the in-card title needed the same long-server-title protection that the previous top heading had — addressed before merge. Other findings (top heading locale wrapping; phantom line on empty `displayTitle`; reduced visibility of lifecycle status in card sub-heading) were either pre-existing conditions or by-design per the requested layout.

## Validation

- ✅ `./build.ps1` — all 4 projects build clean
- ✅ `OpenClaw.Shared.Tests` — 1776 passed, 28 skipped
- ✅ `OpenClaw.Tray.Tests` — 1089 passed

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
