### PR TITLE
Keep WSL gateway alive across tray restarts and Windows logon

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -2004,45 +2004,12 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
             if (string.IsNullOrWhiteSpace(distroName)) return;
 
-            // Backoff schedule for the cold-logon case. Each entry is the delay BEFORE
-            // the next attempt. After the last entry we fall through to a defensive
-            // spawn regardless of probe outcome — wsl.exe itself will exit quickly if
-            // the distro genuinely does not exist, which is preferable to silently
-            // never arming the keepalive.
-            TimeSpan[] retryDelays = [TimeSpan.Zero, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(60)];
             var runner = new WslExeCommandRunner(new AppLogger(), defaultTimeout: TimeSpan.FromSeconds(4));
-
-            for (var attempt = 0; attempt < retryDelays.Length; attempt++)
-            {
-                if (retryDelays[attempt] > TimeSpan.Zero)
-                    await Task.Delay(retryDelays[attempt]);
-
-                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-                try
-                {
-                    var distros = await runner.ListDistrosAsync(cts.Token);
-                    if (!distros.Any(d => d.Name.Equals(distroName, StringComparison.OrdinalIgnoreCase)))
-                    {
-                        Logger.Warn($"[WslKeepAlive] Configured local-gateway distro '{distroName}' not present; skipping keepalive.");
-                        return;
-                    }
-
-                    WslDistroKeepAlive.EnsureStarted(distroName, new AppLogger());
-                    return;
-                }
-                catch (OperationCanceledException)
-                {
-                    Logger.Warn($"[WslKeepAlive] wsl --list probe timed out (attempt {attempt + 1}/{retryDelays.Length}); will retry.");
-                }
-            }
-
-            // All probes timed out. WSL/LxssManager may be wedged, mid-update, or just
-            // very slow on this cold-logon. Attempt the spawn anyway — the wsl.exe
-            // child exits quickly if the distro truly does not exist, and adoption on
-            // the next launch will either recover (if the distro is fine) or skip
-            // (if it really is gone).
-            Logger.Warn("[WslKeepAlive] wsl --list never returned; spawning keepalive defensively.");
-            WslDistroKeepAlive.EnsureStarted(distroName, new AppLogger());
+            await WslKeepAliveStartupArmer.ArmAsync(
+                distroName,
+                cancellationToken => runner.RunAsync(["--list", "--verbose"], cancellationToken),
+                () => WslDistroKeepAlive.EnsureStarted(distroName, new AppLogger()),
+                Logger.Warn);
         }
         catch (Exception ex)
         {

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -767,6 +767,11 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
         // Initialize connections — always create operator client for UI data,
         // additionally create node service for gateway node mode or local MCP.
+        // Before any connection attempt, re-arm the WSL keepalive so the local
+        // gateway VM stays up across tray restarts and across the 20s WSL
+        // vmIdleTimeout window observed on some hosts. The keepalive runs detached
+        // from the tray's lifetime — see WslDistroKeepAlive in LocalGatewaySetup.cs.
+        await TryEnsureLocalGatewayKeepAliveAsync();
         InitializeGatewayClient();
 
         // Pre-warm chat window (WebView2 init takes 1-3s, do it now so left-click is instant)
@@ -1958,6 +1963,98 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     {
         if (_suppressNodeDuringSetup) return false;
         return _settings?.EnableNodeMode == true || _settings?.EnableMcpServer == true;
+    }
+
+    /// <summary>
+    /// Re-arms the WSL keepalive process for the local OpenClawGateway distro on every
+    /// tray launch when the active gateway is local. The keepalive runs detached from
+    /// the tray (see <see cref="WslDistroKeepAlive"/>) so the WSL2 VM stays up even after
+    /// the tray exits — addressing the vmIdleTimeout window where Windows tears down the
+    /// distro (and therefore systemd + the gateway service) ~20s after the last
+    /// interactive wsl.exe session ends.
+    /// </summary>
+    /// <remarks>
+    /// Best-effort: this method swallows every failure. The tray must always reach its
+    /// chrome initialization regardless of WSL state.
+    /// </remarks>
+    private async Task TryEnsureLocalGatewayKeepAliveAsync()
+    {
+        try
+        {
+            if (_settings is null) return;
+
+            var gatewayUrl = _settings.GetEffectiveGatewayUrl();
+            var distroName = await ResolveLocalGatewayDistroNameAsync();
+
+            if (string.IsNullOrWhiteSpace(gatewayUrl) || !LocalGatewayUrlClassifier.IsLocalGatewayUrl(gatewayUrl))
+            {
+                // User is no longer using the local gateway (mode switch since the last
+                // launch). Tear down any keepalive marker that a prior session left
+                // behind so the WSL VM is allowed to idle out; we never reach
+                // EnsureStarted in this branch.
+                if (!string.IsNullOrWhiteSpace(distroName))
+                    WslDistroKeepAlive.Stop(distroName, new AppLogger());
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(distroName)) return;
+
+            // Bounded probe: never let a hanging `wsl --list` block tray startup. If WSL
+            // is broken / mid-update, log + skip — the next launch will retry.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var runner = new WslExeCommandRunner(new AppLogger(), defaultTimeout: TimeSpan.FromSeconds(4));
+            try
+            {
+                var distros = await runner.ListDistrosAsync(cts.Token);
+                if (!distros.Any(d => d.Name.Equals(distroName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    Logger.Warn($"[WslKeepAlive] Configured local-gateway distro '{distroName}' not present; skipping keepalive.");
+                    return;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                Logger.Warn("[WslKeepAlive] wsl --list timed out; skipping keepalive (will retry next launch).");
+                return;
+            }
+
+            WslDistroKeepAlive.EnsureStarted(distroName, new AppLogger());
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"[WslKeepAlive] Startup keepalive failed (non-fatal): {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Resolves the WSL distro name to keep alive. Prefers the value persisted by
+    /// onboarding in <c>setup-state.json</c> so the keepalive always targets the distro
+    /// the user actually installed. In DEBUG / test builds, an
+    /// <c>OPENCLAW_WSL_DISTRO_NAME</c> environment override is honored to match
+    /// <see cref="LocalGatewaySetupRuntimeConfiguration.FromEnvironment"/>. Falls back
+    /// to the upstream default <c>OpenClawGateway</c>.
+    /// </summary>
+    private async Task<string?> ResolveLocalGatewayDistroNameAsync()
+    {
+        try
+        {
+            var store = new LocalGatewaySetupStateStore();
+            var state = await store.LoadAsync();
+            if (state is not null && !string.IsNullOrWhiteSpace(state.DistroName))
+                return state.DistroName;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"[WslKeepAlive] Failed to read setup-state.json: {ex.Message}");
+        }
+
+#if DEBUG || OPENCLAW_TRAY_TESTS
+        var envOverride = Environment.GetEnvironmentVariable(LocalGatewaySetupRuntimeConfiguration.DistroNameVariable);
+        if (!string.IsNullOrWhiteSpace(envOverride))
+            return envOverride;
+#endif
+
+        return "OpenClawGateway";
     }
 
     // The pre-unification ShouldInitializeNodeService(GatewayRecord, string) overload

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -767,11 +767,12 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
         // Initialize connections — always create operator client for UI data,
         // additionally create node service for gateway node mode or local MCP.
-        // Before any connection attempt, re-arm the WSL keepalive so the local
-        // gateway VM stays up across tray restarts and across the 20s WSL
-        // vmIdleTimeout window observed on some hosts. The keepalive runs detached
-        // from the tray's lifetime — see WslDistroKeepAlive in LocalGatewaySetup.cs.
-        await TryEnsureLocalGatewayKeepAliveAsync();
+        // Re-arm the WSL keepalive so the local gateway VM stays up across tray
+        // restarts and across the 20s WSL vmIdleTimeout window observed on some
+        // hosts. Fire-and-forget on a background task so a slow LxssManager at
+        // cold logon never delays InitializeGatewayClient. The keepalive itself
+        // runs detached from the tray — see WslDistroKeepAlive in LocalGatewaySetup.cs.
+        _ = Task.Run(TryEnsureLocalGatewayKeepAliveAsync);
         InitializeGatewayClient();
 
         // Pre-warm chat window (WebView2 init takes 1-3s, do it now so left-click is instant)
@@ -1974,8 +1975,12 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     /// interactive wsl.exe session ends.
     /// </summary>
     /// <remarks>
-    /// Best-effort: this method swallows every failure. The tray must always reach its
-    /// chrome initialization regardless of WSL state.
+    /// Best-effort, fire-and-forget. Cold Windows logon is exactly when LxssManager is
+    /// slow to come up, so a hanging <c>wsl --list</c> probe must never block tray
+    /// startup. We retry with bounded backoff; if every probe times out, we still try
+    /// the spawn and let <c>wsl.exe</c> itself decide whether the distro exists —
+    /// missing a keepalive arm at cold logon is the exact bug this method exists to
+    /// prevent (see PR review feedback).
     /// </remarks>
     private async Task TryEnsureLocalGatewayKeepAliveAsync()
     {
@@ -1999,25 +2004,44 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
             if (string.IsNullOrWhiteSpace(distroName)) return;
 
-            // Bounded probe: never let a hanging `wsl --list` block tray startup. If WSL
-            // is broken / mid-update, log + skip — the next launch will retry.
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            // Backoff schedule for the cold-logon case. Each entry is the delay BEFORE
+            // the next attempt. After the last entry we fall through to a defensive
+            // spawn regardless of probe outcome — wsl.exe itself will exit quickly if
+            // the distro genuinely does not exist, which is preferable to silently
+            // never arming the keepalive.
+            TimeSpan[] retryDelays = [TimeSpan.Zero, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(60)];
             var runner = new WslExeCommandRunner(new AppLogger(), defaultTimeout: TimeSpan.FromSeconds(4));
-            try
+
+            for (var attempt = 0; attempt < retryDelays.Length; attempt++)
             {
-                var distros = await runner.ListDistrosAsync(cts.Token);
-                if (!distros.Any(d => d.Name.Equals(distroName, StringComparison.OrdinalIgnoreCase)))
+                if (retryDelays[attempt] > TimeSpan.Zero)
+                    await Task.Delay(retryDelays[attempt]);
+
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                try
                 {
-                    Logger.Warn($"[WslKeepAlive] Configured local-gateway distro '{distroName}' not present; skipping keepalive.");
+                    var distros = await runner.ListDistrosAsync(cts.Token);
+                    if (!distros.Any(d => d.Name.Equals(distroName, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        Logger.Warn($"[WslKeepAlive] Configured local-gateway distro '{distroName}' not present; skipping keepalive.");
+                        return;
+                    }
+
+                    WslDistroKeepAlive.EnsureStarted(distroName, new AppLogger());
                     return;
                 }
-            }
-            catch (OperationCanceledException)
-            {
-                Logger.Warn("[WslKeepAlive] wsl --list timed out; skipping keepalive (will retry next launch).");
-                return;
+                catch (OperationCanceledException)
+                {
+                    Logger.Warn($"[WslKeepAlive] wsl --list probe timed out (attempt {attempt + 1}/{retryDelays.Length}); will retry.");
+                }
             }
 
+            // All probes timed out. WSL/LxssManager may be wedged, mid-update, or just
+            // very slow on this cold-logon. Attempt the spawn anyway — the wsl.exe
+            // child exits quickly if the distro truly does not exist, and adoption on
+            // the next launch will either recover (if the distro is fine) or skip
+            // (if it really is gone).
+            Logger.Warn("[WslKeepAlive] wsl --list never returned; spawning keepalive defensively.");
             WslDistroKeepAlive.EnsureStarted(distroName, new AppLogger());
         }
         catch (Exception ex)

--- a/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
@@ -1724,20 +1724,20 @@ public interface IWindowsNodeConnector
 /// </remarks>
 public sealed record KeepAliveProcessIdentity(string Name, DateTime StartTimeUtc);
 
+public sealed record KeepAliveSpawnResult(int Pid, KeepAliveProcessIdentity Identity);
+
 internal interface IWslKeepAliveProcessHost
 {
-    KeepAliveProcessIdentity Spawn(string distroName);
+    KeepAliveSpawnResult Spawn(string distroName, IOpenClawLogger? logger = null);
     bool TryGetProcessIdentity(int pid, out KeepAliveProcessIdentity identity);
     void Kill(int pid);
-    int GetCurrentPidForLastSpawn();
 }
 
 internal sealed class DefaultWslKeepAliveProcessHost : IWslKeepAliveProcessHost
 {
     public static readonly DefaultWslKeepAliveProcessHost Instance = new();
-    private int _lastSpawnedPid;
 
-    public KeepAliveProcessIdentity Spawn(string distroName)
+    public KeepAliveSpawnResult Spawn(string distroName, IOpenClawLogger? logger = null)
     {
         // The keepalive must outlive the tray. Packaged (MSIX/Centennial) WinUI apps
         // run inside a job object that by default kills child processes when the
@@ -1745,20 +1745,29 @@ internal sealed class DefaultWslKeepAliveProcessHost : IWslKeepAliveProcessHost
         // CreateProcess with CREATE_BREAKAWAY_FROM_JOB | DETACHED_PROCESS first; if
         // the host job forbids breakaway (ERROR_ACCESS_DENIED), fall back to a plain
         // Process.Start so the keepalive still arms while the tray runs.
-        var commandLine = BuildCommandLine(distroName);
-        var pid = Win32DetachedSpawn.TryStart(commandLine, breakaway: true, out var firstError);
+        ValidateDistroNameForCommandLine(distroName);
+
+        var wslPath = ResolveWslPath();
+        var commandLine = BuildCommandLine(wslPath, distroName);
+        var pid = Win32DetachedSpawn.TryStart(wslPath, commandLine, breakaway: true, out var firstError);
         if (pid is null && firstError == Win32DetachedSpawn.ErrorAccessDenied)
         {
-            pid = Win32DetachedSpawn.TryStart(commandLine, breakaway: false, out _);
+            logger?.Warn("[WslKeepAlive] CREATE_BREAKAWAY_FROM_JOB denied; retrying detached keepalive without breakaway.");
+            pid = Win32DetachedSpawn.TryStart(wslPath, commandLine, breakaway: false, out var secondError);
+            if (pid is null)
+                logger?.Warn($"[WslKeepAlive] Detached CreateProcess without breakaway failed (Win32={secondError}); falling back to Process.Start.");
+        }
+        else if (pid is null)
+        {
+            logger?.Warn($"[WslKeepAlive] Detached CreateProcess with breakaway failed (Win32={firstError}); falling back to Process.Start.");
         }
 
         if (pid is null)
         {
-            return SpawnViaProcessFallback(distroName);
+            return SpawnViaProcessFallback(wslPath, distroName);
         }
 
-        _lastSpawnedPid = pid.Value;
-        return CaptureIdentity(pid.Value);
+        return new KeepAliveSpawnResult(pid.Value, CaptureIdentity(pid.Value));
     }
 
     public bool TryGetProcessIdentity(int pid, out KeepAliveProcessIdentity identity)
@@ -1789,25 +1798,43 @@ internal sealed class DefaultWslKeepAliveProcessHost : IWslKeepAliveProcessHost
         catch (System.ComponentModel.Win32Exception) { }
     }
 
-    public int GetCurrentPidForLastSpawn() => _lastSpawnedPid;
-
-    private static string BuildCommandLine(string distroName)
+    private static string ResolveWslPath()
     {
-        // wsl.exe lives in System32 (on PATH for both packaged and unpackaged contexts).
-        // Distro names are constrained (alphanumerics + a few separators), but quote
-        // defensively so a future configurable name with whitespace cannot break the
-        // CreateProcess command-line parser. Same for the literal token args.
-        return $"wsl.exe -d \"{distroName}\" -u openclaw -- sleep 2147483647";
+        var systemDirectory = Environment.GetFolderPath(Environment.SpecialFolder.System);
+        if (string.IsNullOrWhiteSpace(systemDirectory))
+            return "wsl.exe";
+        return Path.Combine(systemDirectory, "wsl.exe");
     }
 
-    private KeepAliveProcessIdentity SpawnViaProcessFallback(string distroName)
+    private static void ValidateDistroNameForCommandLine(string distroName)
+    {
+        // OpenClaw controls the production distro name ("OpenClawGateway"). Keep the
+        // manual CreateProcess command line deliberately conservative so embedded
+        // quotes/backslashes cannot alter argv parsing for a detached child process.
+        if (!Regex.IsMatch(distroName, @"^[A-Za-z0-9._-]+$"))
+            throw new ArgumentException($"WSL distro name '{distroName}' contains unsupported characters.", nameof(distroName));
+    }
+
+    private static string BuildCommandLine(string wslPath, string distroName)
+    {
+        return $"{QuoteWindowsArgument(wslPath)} -d {QuoteWindowsArgument(distroName)} -u openclaw -- sleep 2147483647";
+    }
+
+    private static string QuoteWindowsArgument(string value)
+    {
+        // This helper is intentionally minimal because distroName is allowlisted and
+        // the executable path comes from System32. It still escapes quotes defensively.
+        return "\"" + value.Replace("\"", "\\\"", StringComparison.Ordinal) + "\"";
+    }
+
+    private KeepAliveSpawnResult SpawnViaProcessFallback(string wslPath, string distroName)
     {
         // Used only when CreateProcess fails outright (not for the breakaway-denied
         // case, which is handled above). Process.Start is more permissive about path
         // resolution and error reporting.
         var process = Process.Start(new ProcessStartInfo
         {
-            FileName = "wsl.exe",
+            FileName = wslPath,
             UseShellExecute = false,
             CreateNoWindow = true,
             RedirectStandardOutput = false,
@@ -1815,11 +1842,11 @@ internal sealed class DefaultWslKeepAliveProcessHost : IWslKeepAliveProcessHost
             ArgumentList = { "-d", distroName, "-u", "openclaw", "--", "sleep", "2147483647" }
         }) ?? throw new InvalidOperationException("Process.Start returned null for wsl.exe keepalive.");
 
-        _lastSpawnedPid = process.Id;
+        var pid = process.Id;
         var name = SafeProcessName(process);
         var startUtc = SafeStartTimeUtc(process);
         process.Dispose();
-        return new KeepAliveProcessIdentity(name, startUtc);
+        return new KeepAliveSpawnResult(pid, new KeepAliveProcessIdentity(name, startUtc));
     }
 
     private static KeepAliveProcessIdentity CaptureIdentity(int pid)
@@ -1922,7 +1949,7 @@ internal static class Win32DetachedSpawn
     /// success, or <see langword="null"/> on failure with the Win32 error in
     /// <paramref name="win32Error"/>.
     /// </summary>
-    public static int? TryStart(string commandLine, bool breakaway, out int win32Error)
+    public static int? TryStart(string applicationName, string commandLine, bool breakaway, out int win32Error)
     {
         win32Error = 0;
         var si = new STARTUPINFO { cb = (uint)Marshal.SizeOf<STARTUPINFO>() };
@@ -1935,7 +1962,7 @@ internal static class Win32DetachedSpawn
         if (breakaway) flags |= CREATE_BREAKAWAY_FROM_JOB;
 
         var ok = CreateProcessW(
-            lpApplicationName: null,
+            lpApplicationName: applicationName,
             lpCommandLine: commandLineBuffer,
             lpProcessAttributes: IntPtr.Zero,
             lpThreadAttributes: IntPtr.Zero,
@@ -1956,6 +1983,79 @@ internal static class Win32DetachedSpawn
         if (pi.hThread != IntPtr.Zero) CloseHandle(pi.hThread);
         if (pi.hProcess != IntPtr.Zero) CloseHandle(pi.hProcess);
         return (int)pi.dwProcessId;
+    }
+}
+
+/// <summary>
+/// Testable startup arming loop for the local WSL gateway keepalive. The tray calls
+/// this from a fire-and-forget task at launch; tests pass fake probe/ensure delegates
+/// so timeout/failure behavior never depends on a real WSL installation.
+/// </summary>
+internal static class WslKeepAliveStartupArmer
+{
+    public static readonly TimeSpan[] DefaultRetryDelays =
+    [
+        TimeSpan.Zero,
+        TimeSpan.FromSeconds(5),
+        TimeSpan.FromSeconds(15),
+        TimeSpan.FromSeconds(60)
+    ];
+
+    public static async Task ArmAsync(
+        string distroName,
+        Func<CancellationToken, Task<WslCommandResult>> probeAsync,
+        Action ensureStarted,
+        Action<string> warn,
+        TimeSpan[]? retryDelays = null,
+        TimeSpan? probeTimeout = null,
+        Func<TimeSpan, Task>? delayAsync = null)
+    {
+        if (string.IsNullOrWhiteSpace(distroName))
+            return;
+
+        retryDelays ??= DefaultRetryDelays;
+        probeTimeout ??= TimeSpan.FromSeconds(5);
+        delayAsync ??= Task.Delay;
+
+        for (var attempt = 0; attempt < retryDelays.Length; attempt++)
+        {
+            if (retryDelays[attempt] > TimeSpan.Zero)
+                await delayAsync(retryDelays[attempt]);
+
+            using var cts = new CancellationTokenSource(probeTimeout.Value);
+            WslCommandResult result;
+            try
+            {
+                result = await probeAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                warn($"[WslKeepAlive] wsl --list probe cancelled/timed out (attempt {attempt + 1}/{retryDelays.Length}); will retry.");
+                continue;
+            }
+
+            if (!result.Success)
+            {
+                var detail = string.IsNullOrWhiteSpace(result.StandardError)
+                    ? result.StandardOutput
+                    : result.StandardError;
+                warn($"[WslKeepAlive] wsl --list failed (exit {result.ExitCode}, attempt {attempt + 1}/{retryDelays.Length}): {SecretRedactor.Redact(detail)}");
+                continue;
+            }
+
+            var distros = WslExeCommandRunner.ParseDistroList(result.StandardOutput);
+            if (!distros.Any(d => d.Name.Equals(distroName, StringComparison.OrdinalIgnoreCase)))
+            {
+                warn($"[WslKeepAlive] Configured local-gateway distro '{distroName}' not present; skipping keepalive.");
+                return;
+            }
+
+            ensureStarted();
+            return;
+        }
+
+        warn("[WslKeepAlive] wsl --list never succeeded; spawning keepalive defensively.");
+        ensureStarted();
     }
 }
 
@@ -2019,11 +2119,11 @@ public static class WslDistroKeepAlive
 
             try
             {
-                var spawnIdentity = host.Spawn(distroName);
-                var pid = host.GetCurrentPidForLastSpawn();
+                var spawn = host.Spawn(distroName, logger);
+                var pid = spawn.Pid;
                 try
                 {
-                    WriteMarker(markerPath, new KeepAliveMarker(distroName, pid, spawnIdentity.StartTimeUtc, spawnIdentity.Name));
+                    WriteMarker(markerPath, new KeepAliveMarker(distroName, pid, spawn.Identity.StartTimeUtc, spawn.Identity.Name));
                 }
                 catch (Exception writeEx)
                 {
@@ -2061,7 +2161,14 @@ public static class WslDistroKeepAlive
             var host = __TestHost ?? DefaultWslKeepAliveProcessHost.Instance;
             var markerPath = GetMarkerPath(distroName);
             if (!TryReadMarker(markerPath, out var marker))
+            {
+                if (File.Exists(markerPath))
+                {
+                    logger?.Warn($"WSL keepalive marker for {distroName} is malformed; deleting marker only.");
+                    TryDeleteMarker(markerPath);
+                }
                 return;
+            }
 
             try
             {
@@ -2109,7 +2216,14 @@ public static class WslDistroKeepAlive
             try
             {
                 if (TryReadMarkerFromPath(file, out var marker))
+                {
                     Stop(marker.DistroName, logger);
+                }
+                else if (File.Exists(file))
+                {
+                    logger?.Warn($"WSL keepalive marker {file} is malformed; deleting marker only.");
+                    TryDeleteMarker(file);
+                }
             }
             catch (Exception ex)
             {

--- a/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -1738,24 +1739,26 @@ internal sealed class DefaultWslKeepAliveProcessHost : IWslKeepAliveProcessHost
 
     public KeepAliveProcessIdentity Spawn(string distroName)
     {
-        // Spawn detached: no stdio redirect so the child has independent stdio handles,
-        // and we never register a ProcessExit handler — the keepalive must outlive the tray.
-        var process = Process.Start(new ProcessStartInfo
+        // The keepalive must outlive the tray. Packaged (MSIX/Centennial) WinUI apps
+        // run inside a job object that by default kills child processes when the
+        // parent exits — Process.Start alone would not survive an MSIX tray exit. Try
+        // CreateProcess with CREATE_BREAKAWAY_FROM_JOB | DETACHED_PROCESS first; if
+        // the host job forbids breakaway (ERROR_ACCESS_DENIED), fall back to a plain
+        // Process.Start so the keepalive still arms while the tray runs.
+        var commandLine = BuildCommandLine(distroName);
+        var pid = Win32DetachedSpawn.TryStart(commandLine, breakaway: true, out var firstError);
+        if (pid is null && firstError == Win32DetachedSpawn.ErrorAccessDenied)
         {
-            FileName = "wsl.exe",
-            UseShellExecute = false,
-            CreateNoWindow = true,
-            RedirectStandardOutput = false,
-            RedirectStandardError = false,
-            ArgumentList = { "-d", distroName, "-u", "openclaw", "--", "sleep", "2147483647" }
-        }) ?? throw new InvalidOperationException("Process.Start returned null for wsl.exe keepalive.");
+            pid = Win32DetachedSpawn.TryStart(commandLine, breakaway: false, out _);
+        }
 
-        _lastSpawnedPid = process.Id;
-        var name = SafeProcessName(process);
-        var startUtc = SafeStartTimeUtc(process);
-        // Release the handle so the OS doesn't keep a reference tied to this AppDomain.
-        process.Dispose();
-        return new KeepAliveProcessIdentity(name, startUtc);
+        if (pid is null)
+        {
+            return SpawnViaProcessFallback(distroName);
+        }
+
+        _lastSpawnedPid = pid.Value;
+        return CaptureIdentity(pid.Value);
     }
 
     public bool TryGetProcessIdentity(int pid, out KeepAliveProcessIdentity identity)
@@ -1765,7 +1768,7 @@ internal sealed class DefaultWslKeepAliveProcessHost : IWslKeepAliveProcessHost
         try
         {
             using var process = Process.GetProcessById(pid);
-            identity = new KeepAliveProcessIdentity(SafeProcessName(process), process.StartTime.ToUniversalTime());
+            identity = new KeepAliveProcessIdentity(SafeProcessName(process), SafeStartTimeUtc(process));
             return true;
         }
         catch (ArgumentException) { return false; }     // No such PID
@@ -1788,6 +1791,57 @@ internal sealed class DefaultWslKeepAliveProcessHost : IWslKeepAliveProcessHost
 
     public int GetCurrentPidForLastSpawn() => _lastSpawnedPid;
 
+    private static string BuildCommandLine(string distroName)
+    {
+        // wsl.exe lives in System32 (on PATH for both packaged and unpackaged contexts).
+        // Distro names are constrained (alphanumerics + a few separators), but quote
+        // defensively so a future configurable name with whitespace cannot break the
+        // CreateProcess command-line parser. Same for the literal token args.
+        return $"wsl.exe -d \"{distroName}\" -u openclaw -- sleep 2147483647";
+    }
+
+    private KeepAliveProcessIdentity SpawnViaProcessFallback(string distroName)
+    {
+        // Used only when CreateProcess fails outright (not for the breakaway-denied
+        // case, which is handled above). Process.Start is more permissive about path
+        // resolution and error reporting.
+        var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = "wsl.exe",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            ArgumentList = { "-d", distroName, "-u", "openclaw", "--", "sleep", "2147483647" }
+        }) ?? throw new InvalidOperationException("Process.Start returned null for wsl.exe keepalive.");
+
+        _lastSpawnedPid = process.Id;
+        var name = SafeProcessName(process);
+        var startUtc = SafeStartTimeUtc(process);
+        process.Dispose();
+        return new KeepAliveProcessIdentity(name, startUtc);
+    }
+
+    private static KeepAliveProcessIdentity CaptureIdentity(int pid)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            return new KeepAliveProcessIdentity(SafeProcessName(process), SafeStartTimeUtc(process));
+        }
+        catch (ArgumentException)
+        {
+            // Process exited between CreateProcess and GetProcessById. Fall back to a
+            // best-effort identity so the marker is still written; next adoption will
+            // fail naturally and we'll respawn.
+            return new KeepAliveProcessIdentity(string.Empty, DateTime.UtcNow);
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            return new KeepAliveProcessIdentity(string.Empty, DateTime.UtcNow);
+        }
+    }
+
     private static string SafeProcessName(Process process)
     {
         try { return process.ProcessName; }
@@ -1807,6 +1861,101 @@ internal sealed class DefaultWslKeepAliveProcessHost : IWslKeepAliveProcessHost
         try { return process.StartTime.ToUniversalTime(); }
         catch (InvalidOperationException) { return DateTime.UtcNow; }
         catch (System.ComponentModel.Win32Exception) { return DateTime.UtcNow; }
+    }
+}
+
+/// <summary>
+/// Minimal P/Invoke wrapper around <c>CreateProcessW</c> so the keepalive can request
+/// <see cref="CREATE_BREAKAWAY_FROM_JOB"/> — required to survive MSIX/packaged tray
+/// exit, where the host job otherwise kills child processes.
+/// </summary>
+internal static class Win32DetachedSpawn
+{
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct STARTUPINFO
+    {
+        public uint cb;
+        public string? lpReserved;
+        public string? lpDesktop;
+        public string? lpTitle;
+        public uint dwX, dwY, dwXSize, dwYSize, dwXCountChars, dwYCountChars, dwFillAttribute, dwFlags;
+        public ushort wShowWindow, cbReserved2;
+        public IntPtr lpReserved2;
+        public IntPtr hStdInput, hStdOutput, hStdError;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PROCESS_INFORMATION
+    {
+        public IntPtr hProcess;
+        public IntPtr hThread;
+        public uint dwProcessId;
+        public uint dwThreadId;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CreateProcessW(
+        string? lpApplicationName,
+        StringBuilder lpCommandLine,
+        IntPtr lpProcessAttributes,
+        IntPtr lpThreadAttributes,
+        [MarshalAs(UnmanagedType.Bool)] bool bInheritHandles,
+        uint dwCreationFlags,
+        IntPtr lpEnvironment,
+        string? lpCurrentDirectory,
+        ref STARTUPINFO lpStartupInfo,
+        out PROCESS_INFORMATION lpProcessInformation);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(IntPtr hObject);
+
+    private const uint CREATE_BREAKAWAY_FROM_JOB = 0x01000000;
+    private const uint DETACHED_PROCESS = 0x00000008;
+    private const uint CREATE_NO_WINDOW = 0x08000000;
+    public const int ErrorAccessDenied = 5;
+
+    /// <summary>
+    /// Spawns <paramref name="commandLine"/> with <c>DETACHED_PROCESS | CREATE_NO_WINDOW</c>
+    /// (optionally adding <c>CREATE_BREAKAWAY_FROM_JOB</c>). Returns the new PID on
+    /// success, or <see langword="null"/> on failure with the Win32 error in
+    /// <paramref name="win32Error"/>.
+    /// </summary>
+    public static int? TryStart(string commandLine, bool breakaway, out int win32Error)
+    {
+        win32Error = 0;
+        var si = new STARTUPINFO { cb = (uint)Marshal.SizeOf<STARTUPINFO>() };
+        var pi = default(PROCESS_INFORMATION);
+
+        // CreateProcess may mutate the command-line buffer in place.
+        var commandLineBuffer = new StringBuilder(commandLine);
+
+        var flags = DETACHED_PROCESS | CREATE_NO_WINDOW;
+        if (breakaway) flags |= CREATE_BREAKAWAY_FROM_JOB;
+
+        var ok = CreateProcessW(
+            lpApplicationName: null,
+            lpCommandLine: commandLineBuffer,
+            lpProcessAttributes: IntPtr.Zero,
+            lpThreadAttributes: IntPtr.Zero,
+            bInheritHandles: false,
+            dwCreationFlags: flags,
+            lpEnvironment: IntPtr.Zero,
+            lpCurrentDirectory: null,
+            lpStartupInfo: ref si,
+            lpProcessInformation: out pi);
+
+        if (!ok)
+        {
+            win32Error = Marshal.GetLastWin32Error();
+            return null;
+        }
+
+        // We don't need the process/thread handles; close them so we don't leak.
+        if (pi.hThread != IntPtr.Zero) CloseHandle(pi.hThread);
+        if (pi.hProcess != IntPtr.Zero) CloseHandle(pi.hProcess);
+        return (int)pi.dwProcessId;
     }
 }
 
@@ -1872,7 +2021,21 @@ public static class WslDistroKeepAlive
             {
                 var spawnIdentity = host.Spawn(distroName);
                 var pid = host.GetCurrentPidForLastSpawn();
-                WriteMarker(markerPath, new KeepAliveMarker(distroName, pid, spawnIdentity.StartTimeUtc, spawnIdentity.Name));
+                try
+                {
+                    WriteMarker(markerPath, new KeepAliveMarker(distroName, pid, spawnIdentity.StartTimeUtc, spawnIdentity.Name));
+                }
+                catch (Exception writeEx)
+                {
+                    // Transactional invariant: a spawned keepalive without a marker is
+                    // an untracked orphan. Future tray launches cannot adopt it (no
+                    // marker), Stop/StopAll cannot reach it, and it will outlive
+                    // distro repair/remove. Kill the just-spawned PID before
+                    // surfacing the failure.
+                    logger?.Warn($"Marker write failed after spawn for {distroName}; killing orphan PID {pid}: {writeEx.Message}");
+                    try { host.Kill(pid); } catch { /* best-effort cleanup */ }
+                    throw;
+                }
                 logger?.Info($"Started WSL keepalive process for {distroName} (PID {pid}).");
             }
             catch (Exception ex)

--- a/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
@@ -1711,12 +1711,136 @@ public interface IWindowsNodeConnector
 // ConnectionManagerWindowsNodeConnector → GatewayConnectionManager.EnsureNodeConnectedAsync.
 // See docs/node-connection-architecture.md and easy-button-gateway-comms-audit.md.
 
+/// <summary>
+/// Identity for an OS process, captured for safe PID re-identification.
+/// </summary>
+/// <remarks>
+/// We compare both the process name (best-effort sanity check) and the high-resolution
+/// <see cref="StartTimeUtc"/> because PIDs can be recycled. If a previous keepalive
+/// exited and Windows handed its PID to an unrelated process, the start time will
+/// differ — preventing <see cref="WslDistroKeepAlive.Stop(string, IOpenClawLogger?)"/>
+/// from killing the wrong process.
+/// </remarks>
+public sealed record KeepAliveProcessIdentity(string Name, DateTime StartTimeUtc);
+
+internal interface IWslKeepAliveProcessHost
+{
+    KeepAliveProcessIdentity Spawn(string distroName);
+    bool TryGetProcessIdentity(int pid, out KeepAliveProcessIdentity identity);
+    void Kill(int pid);
+    int GetCurrentPidForLastSpawn();
+}
+
+internal sealed class DefaultWslKeepAliveProcessHost : IWslKeepAliveProcessHost
+{
+    public static readonly DefaultWslKeepAliveProcessHost Instance = new();
+    private int _lastSpawnedPid;
+
+    public KeepAliveProcessIdentity Spawn(string distroName)
+    {
+        // Spawn detached: no stdio redirect so the child has independent stdio handles,
+        // and we never register a ProcessExit handler — the keepalive must outlive the tray.
+        var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = "wsl.exe",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            ArgumentList = { "-d", distroName, "-u", "openclaw", "--", "sleep", "2147483647" }
+        }) ?? throw new InvalidOperationException("Process.Start returned null for wsl.exe keepalive.");
+
+        _lastSpawnedPid = process.Id;
+        var name = SafeProcessName(process);
+        var startUtc = SafeStartTimeUtc(process);
+        // Release the handle so the OS doesn't keep a reference tied to this AppDomain.
+        process.Dispose();
+        return new KeepAliveProcessIdentity(name, startUtc);
+    }
+
+    public bool TryGetProcessIdentity(int pid, out KeepAliveProcessIdentity identity)
+    {
+        identity = default!;
+        if (pid <= 0) return false;
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            identity = new KeepAliveProcessIdentity(SafeProcessName(process), process.StartTime.ToUniversalTime());
+            return true;
+        }
+        catch (ArgumentException) { return false; }     // No such PID
+        catch (InvalidOperationException) { return false; } // Process exited between calls
+        catch (System.ComponentModel.Win32Exception) { return false; } // Access denied / handle invalidated
+    }
+
+    public void Kill(int pid)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+        catch (ArgumentException) { }
+        catch (InvalidOperationException) { }
+        catch (System.ComponentModel.Win32Exception) { }
+    }
+
+    public int GetCurrentPidForLastSpawn() => _lastSpawnedPid;
+
+    private static string SafeProcessName(Process process)
+    {
+        try { return process.ProcessName; }
+        catch (InvalidOperationException) { return string.Empty; }
+        catch (System.ComponentModel.Win32Exception) { return string.Empty; }
+    }
+
+    /// <summary>
+    /// Reads <see cref="Process.StartTime"/> defensively. If <c>wsl.exe</c> exits between
+    /// <see cref="Process.Start"/> and this call (e.g., the distro is unhealthy), the
+    /// property can throw <see cref="InvalidOperationException"/>. Falling back to
+    /// <c>UtcNow</c> means adoption may fail on the very next launch — the worst case is
+    /// one redundant <c>sleep</c> spawn, which is preferable to crashing the spawn path.
+    /// </summary>
+    private static DateTime SafeStartTimeUtc(Process process)
+    {
+        try { return process.StartTime.ToUniversalTime(); }
+        catch (InvalidOperationException) { return DateTime.UtcNow; }
+        catch (System.ComponentModel.Win32Exception) { return DateTime.UtcNow; }
+    }
+}
+
+/// <summary>
+/// Manages the WSL VM keepalive process for the local-gateway distro. Spawns a
+/// detached <c>wsl.exe -d &lt;distro&gt; -u openclaw -- sleep 2147483647</c> that
+/// keeps the WSL2 VM running independently of the tray's lifetime. A marker file
+/// at <c>%LOCALAPPDATA%\OpenClawTray\wsl-keepalive\&lt;distro&gt;.json</c>
+/// (overridable via <c>OPENCLAW_TRAY_LOCALAPPDATA_DIR</c>) records the spawned
+/// PID + start time so subsequent tray launches can adopt the existing keepalive
+/// instead of spawning duplicates.
+/// </summary>
 public static class WslDistroKeepAlive
 {
+    private const string MarkerDirectoryName = "wsl-keepalive";
     private static readonly object s_lock = new();
-    private static readonly Dictionary<string, Process> s_processes = new(StringComparer.OrdinalIgnoreCase);
-    private static bool s_processExitRegistered;
+    private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = false };
 
+    // Test seams.
+    internal static IWslKeepAliveProcessHost? __TestHost;
+    internal static string? __TestMarkerDirectory;
+
+    internal static void __ResetForTests()
+    {
+        __TestHost = null;
+        __TestMarkerDirectory = null;
+    }
+
+    /// <summary>
+    /// Ensures a keepalive process is running for <paramref name="distroName"/>. Adopts
+    /// an existing keepalive (recorded via marker file) when the PID is still alive and
+    /// its start time matches the marker; otherwise spawns a new one.
+    /// Non-throwing — failures are logged.
+    /// </summary>
     public static void EnsureStarted(string distroName, IOpenClawLogger? logger = null)
     {
         if (string.IsNullOrWhiteSpace(distroName))
@@ -1724,64 +1848,215 @@ public static class WslDistroKeepAlive
 
         lock (s_lock)
         {
-            if (s_processes.TryGetValue(distroName, out var existing) && !existing.HasExited)
-                return;
+            var host = __TestHost ?? DefaultWslKeepAliveProcessHost.Instance;
+            var markerPath = GetMarkerPath(distroName);
 
             try
             {
-                var process = Process.Start(new ProcessStartInfo
+                if (TryReadMarker(markerPath, out var marker)
+                    && string.Equals(marker.DistroName, distroName, StringComparison.OrdinalIgnoreCase)
+                    && host.TryGetProcessIdentity(marker.Pid, out var identity)
+                    && IdentityMatchesMarker(identity, marker))
                 {
-                    FileName = "wsl.exe",
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    ArgumentList = { "-d", distroName, "-u", "openclaw", "--", "sleep", "2147483647" }
-                });
-
-                if (process == null)
-                {
-                    logger?.Warn("Failed to start WSL keepalive process.");
+                    logger?.Info($"Adopted existing WSL keepalive for {distroName} (PID {marker.Pid}).");
                     return;
-                }
-
-                s_processes[distroName] = process;
-                logger?.Info($"Started WSL keepalive process for {distroName} (PID {process.Id}).");
-
-                if (!s_processExitRegistered)
-                {
-                    AppDomain.CurrentDomain.ProcessExit += (_, _) => StopAll();
-                    s_processExitRegistered = true;
                 }
             }
             catch (Exception ex)
             {
-                logger?.Warn($"Failed to start WSL keepalive process: {ex.Message}");
+                logger?.Warn($"Failed to inspect WSL keepalive marker for {distroName}: {ex.Message}");
+                // Fall through to spawn fresh.
+            }
+
+            try
+            {
+                var spawnIdentity = host.Spawn(distroName);
+                var pid = host.GetCurrentPidForLastSpawn();
+                WriteMarker(markerPath, new KeepAliveMarker(distroName, pid, spawnIdentity.StartTimeUtc, spawnIdentity.Name));
+                logger?.Info($"Started WSL keepalive process for {distroName} (PID {pid}).");
+            }
+            catch (Exception ex)
+            {
+                logger?.Warn($"Failed to start WSL keepalive process for {distroName}: {ex.Message}");
             }
         }
     }
 
-    private static void StopAll()
+    /// <summary>
+    /// Stops the keepalive for <paramref name="distroName"/> if the marker file
+    /// references a process whose identity (name + start time) still matches.
+    /// If the PID has been recycled to an unrelated process, only the marker is
+    /// deleted — we never kill an unverified PID.
+    /// </summary>
+    public static void Stop(string distroName, IOpenClawLogger? logger = null)
     {
+        if (string.IsNullOrWhiteSpace(distroName))
+            return;
+
         lock (s_lock)
         {
-            foreach (var process in s_processes.Values)
+            var host = __TestHost ?? DefaultWslKeepAliveProcessHost.Instance;
+            var markerPath = GetMarkerPath(distroName);
+            if (!TryReadMarker(markerPath, out var marker))
+                return;
+
+            try
             {
-                try
+                if (host.TryGetProcessIdentity(marker.Pid, out var identity) && IdentityMatchesMarker(identity, marker))
                 {
-                    if (!process.HasExited)
-                        process.Kill(entireProcessTree: true);
+                    host.Kill(marker.Pid);
+                    logger?.Info($"Stopped WSL keepalive for {distroName} (PID {marker.Pid}).");
                 }
-                catch
+                else
                 {
-                    // Process exit cleanup is best-effort only.
+                    logger?.Info($"WSL keepalive marker for {distroName} did not match a live process (PID {marker.Pid}); removing marker only.");
                 }
             }
-
-            s_processes.Clear();
+            catch (Exception ex)
+            {
+                logger?.Warn($"Failed to stop WSL keepalive for {distroName}: {ex.Message}");
+            }
+            finally
+            {
+                TryDeleteMarker(markerPath);
+            }
         }
     }
+
+    /// <summary>
+    /// Stops keepalives for every recorded marker. Best-effort; used by uninstall.
+    /// </summary>
+    public static void StopAll(IOpenClawLogger? logger = null)
+    {
+        string? markerDir;
+        lock (s_lock)
+        {
+            markerDir = ResolveMarkerDirectory();
+        }
+
+        if (markerDir is null || !Directory.Exists(markerDir))
+            return;
+
+        // Materialize before iterating: Stop() deletes each marker file as it processes
+        // it, and FindNextFile semantics on Windows can skip entries when the directory
+        // mutates mid-enumeration.
+        var markerFiles = Directory.EnumerateFiles(markerDir, "*.json").ToList();
+        foreach (var file in markerFiles)
+        {
+            try
+            {
+                if (TryReadMarkerFromPath(file, out var marker))
+                    Stop(marker.DistroName, logger);
+            }
+            catch (Exception ex)
+            {
+                logger?.Warn($"Failed to stop keepalive recorded in {file}: {ex.Message}");
+            }
+        }
+    }
+
+    private static bool IdentityMatchesMarker(KeepAliveProcessIdentity identity, KeepAliveMarker marker)
+    {
+        // Name comparison is a best-effort sanity check ("wsl") — Spawn captures whatever
+        // the OS reports, which may be empty if the process exited before ProcessName was
+        // resolved. Start time is the authoritative anti-PID-recycle check; allow a small
+        // tolerance for clock-resolution rounding through serialization.
+        if (!string.IsNullOrEmpty(marker.ProcessName)
+            && !string.IsNullOrEmpty(identity.Name)
+            && !string.Equals(identity.Name, marker.ProcessName, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var delta = (identity.StartTimeUtc - marker.StartTimeUtc).Duration();
+        // Generous tolerance: DateTime.ToUniversalTime + JSON serialization can round to
+        // 100-tick (10us) increments depending on the kind, and on slow disks the live
+        // process's reported StartTime can drift slightly from the value cached at spawn.
+        // 500ms is well below any plausible PID-recycle window (Windows PID reuse takes
+        // at least seconds in practice) so we don't lose anti-recycle protection.
+        return delta <= TimeSpan.FromMilliseconds(500);
+    }
+
+    private static string? ResolveMarkerDirectory()
+    {
+        if (!string.IsNullOrWhiteSpace(__TestMarkerDirectory))
+            return __TestMarkerDirectory;
+
+        var root = Environment.GetEnvironmentVariable("OPENCLAW_TRAY_LOCALAPPDATA_DIR");
+        if (string.IsNullOrWhiteSpace(root))
+            root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrWhiteSpace(root))
+            return null;
+
+        return Path.Combine(root, "OpenClawTray", MarkerDirectoryName);
+    }
+
+    private static string GetMarkerPath(string distroName)
+    {
+        var dir = ResolveMarkerDirectory()
+            ?? throw new InvalidOperationException("Could not resolve LocalApplicationData for WSL keepalive marker.");
+        var safe = SanitizeForFileName(distroName);
+        return Path.Combine(dir, safe + ".json");
+    }
+
+    private static string SanitizeForFileName(string name)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(name.Length);
+        foreach (var ch in name)
+            builder.Append(Array.IndexOf(invalid, ch) >= 0 ? '_' : ch);
+        return builder.ToString();
+    }
+
+    private static bool TryReadMarker(string markerPath, out KeepAliveMarker marker)
+        => TryReadMarkerFromPath(markerPath, out marker);
+
+    private static bool TryReadMarkerFromPath(string markerPath, out KeepAliveMarker marker)
+    {
+        marker = default!;
+        try
+        {
+            if (!File.Exists(markerPath)) return false;
+            var json = File.ReadAllText(markerPath);
+            var parsed = JsonSerializer.Deserialize<KeepAliveMarker>(json, s_jsonOptions);
+            if (parsed is null || string.IsNullOrWhiteSpace(parsed.DistroName) || parsed.Pid <= 0)
+                return false;
+            marker = parsed;
+            return true;
+        }
+        catch (JsonException) { return false; }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+    }
+
+    private static void WriteMarker(string markerPath, KeepAliveMarker marker)
+    {
+        var directory = Path.GetDirectoryName(markerPath);
+        if (!string.IsNullOrEmpty(directory))
+            Directory.CreateDirectory(directory);
+
+        // Atomic write: serialize to a temp file then atomically replace the destination
+        // (overwrite handles the case where another tray instance won the race and wrote
+        // first — see hanselman review #1). NTFS guarantees File.Move with overwrite is
+        // atomic on the same volume.
+        var tempPath = markerPath + ".tmp";
+        File.WriteAllText(tempPath, JsonSerializer.Serialize(marker, s_jsonOptions));
+        File.Move(tempPath, markerPath, overwrite: true);
+    }
+
+    private static void TryDeleteMarker(string markerPath)
+    {
+        try { if (File.Exists(markerPath)) File.Delete(markerPath); }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
 }
+
+public sealed record KeepAliveMarker(
+    string DistroName,
+    int Pid,
+    DateTime StartTimeUtc,
+    string ProcessName);
 
 public enum GatewayOperatorConnectionStatus
 {
@@ -3211,13 +3486,15 @@ public sealed class LocalGatewayLifecycleManager : ILocalGatewayLifecycleManager
     private readonly IWslCommandRunner _wsl;
     private readonly ILocalGatewayHealthProbe _healthProbe;
     private readonly ILocalGatewaySetupSettings? _settings;
+    private readonly IOpenClawLogger? _logger;
 
-    public LocalGatewayLifecycleManager(LocalGatewaySetupOptions options, IWslCommandRunner wsl, ILocalGatewayHealthProbe healthProbe, ILocalGatewaySetupSettings? settings = null)
+    public LocalGatewayLifecycleManager(LocalGatewaySetupOptions options, IWslCommandRunner wsl, ILocalGatewayHealthProbe healthProbe, ILocalGatewaySetupSettings? settings = null, IOpenClawLogger? logger = null)
     {
         _options = options;
         _wsl = wsl;
         _healthProbe = healthProbe;
         _settings = settings;
+        _logger = logger;
     }
 
     public async Task<LocalGatewayLifecycleResult> RepairAsync(CancellationToken cancellationToken = default)
@@ -3226,6 +3503,12 @@ public sealed class LocalGatewayLifecycleManager : ILocalGatewayLifecycleManager
         var distros = await _wsl.ListDistrosAsync(cancellationToken);
         if (!distros.Any(d => d.Name.Equals(_options.DistroName, StringComparison.OrdinalIgnoreCase) && d.Version == 2))
             return Fail("distro_missing", $"The OpenClaw WSL distro '{_options.DistroName}' was not found.", steps);
+
+        // Tear down any stale keepalive before terminating; we'll spawn a fresh one
+        // after the gateway becomes healthy. Without this, the old keepalive lingers
+        // pointing at a now-restarted VM but is no longer tracked by our marker.
+        WslDistroKeepAlive.Stop(_options.DistroName, _logger);
+        steps.Add("keepalive_stopped");
 
         await _wsl.TerminateDistroAsync(_options.DistroName, cancellationToken);
         steps.Add("distro_terminated");
@@ -3244,6 +3527,11 @@ public sealed class LocalGatewayLifecycleManager : ILocalGatewayLifecycleManager
         if (!health.Success)
             return Fail("gateway_unhealthy", health.Error ?? WslLogsHelp("Gateway did not become healthy after repair."), steps);
 
+        // Re-arm the keepalive so the VM stays up after repair completes, even if the
+        // tray that triggered repair exits before the next OnLaunched hook runs.
+        WslDistroKeepAlive.EnsureStarted(_options.DistroName, _logger);
+        steps.Add("keepalive_started");
+
         return new LocalGatewayLifecycleResult(true, Steps: steps);
     }
 
@@ -3252,6 +3540,11 @@ public sealed class LocalGatewayLifecycleManager : ILocalGatewayLifecycleManager
         var steps = new List<string>();
         if (!request.ConfirmRemove)
             return Fail("confirmation_required", "Removing the local OpenClaw Gateway requires explicit confirmation.", steps);
+
+        // Stop the keepalive before terminating so the marker file does not survive
+        // distro removal and confuse a future install with the same name.
+        WslDistroKeepAlive.Stop(_options.DistroName, _logger);
+        steps.Add("keepalive_stopped");
 
         await _wsl.TerminateDistroAsync(_options.DistroName, cancellationToken);
         steps.Add("distro_terminated");

--- a/tests/OpenClaw.Tray.Tests/LocalGatewaySetupTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalGatewaySetupTests.cs
@@ -4,6 +4,7 @@ using OpenClaw.Shared;
 
 namespace OpenClaw.Tray.Tests;
 
+[Collection("WslDistroKeepAliveSerial")]
 public class LocalGatewaySetupTests
 {
     [Fact]
@@ -701,6 +702,9 @@ public class LocalGatewaySetupTests
     [Fact]
     public async Task LifecycleManager_RepairTerminatesOnlyGatewayDistroAndRestartsGatewayService()
     {
+        // Isolate WslDistroKeepAlive — RepairAsync now calls Stop/EnsureStarted, which
+        // would otherwise try to spawn a real wsl.exe process and write to LocalAppData.
+        using var _ = new WslDistroKeepAliveTests.KeepAliveIsolation();
         var wsl = new FakeWslCommandRunner { Distros = [new WslDistroInfo("OpenClawGateway", "Running", 2)] };
         var manager = new LocalGatewayLifecycleManager(new LocalGatewaySetupOptions(), wsl, new SuccessfulHealthProbe());
 
@@ -717,6 +721,9 @@ public class LocalGatewaySetupTests
     [Fact]
     public async Task LifecycleManager_RemoveUnregistersDistroAndClearsLocalCredentials()
     {
+        // Isolate WslDistroKeepAlive — RemoveAsync now calls Stop, which would
+        // otherwise touch the user's real LocalAppData marker directory.
+        using var _ = new WslDistroKeepAliveTests.KeepAliveIsolation();
         var settings = new FakeSetupSettings { Token = "token", BootstrapToken = "bootstrap", EnableNodeMode = true };
         var wsl = new FakeWslCommandRunner { Distros = [new WslDistroInfo("OpenClawGateway", "Stopped", 2)] };
         var manager = new LocalGatewayLifecycleManager(new LocalGatewaySetupOptions(), wsl, new SuccessfulHealthProbe(), settings);

--- a/tests/OpenClaw.Tray.Tests/WinAppSdkGhostWindowCleanup.cs
+++ b/tests/OpenClaw.Tray.Tests/WinAppSdkGhostWindowCleanup.cs
@@ -1,0 +1,144 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Loader;
+using System.Text;
+using Xunit.Sdk;
+
+[assembly: OpenClaw.Tray.Tests.WinAppSdkGhostWindowCleanupAttribute]
+
+namespace OpenClaw.Tray.Tests;
+
+internal sealed class WinAppSdkGhostWindowCleanupAttribute : BeforeAfterTestAttribute
+{
+    public override void After(MethodInfo methodUnderTest) =>
+        WinAppSdkGhostWindowCleanup.CleanupBlankFrames();
+}
+
+/// <summary>
+/// Cleans up Windows App SDK shell-frame ghosts created during tray validation.
+/// Some WinUI/AppWindow surfaces can leave an explorer-owned, blank
+/// <c>ApplicationFrameWindow</c> behind when the testhost exits. Those windows are
+/// visually disruptive on a developer workstation even though all tests pass.
+/// This test-only hook hides and closes blank shell frames during validation and
+/// again when the test process exits.
+/// </summary>
+internal static class WinAppSdkGhostWindowCleanup
+{
+    private const uint WM_CLOSE = 0x0010;
+    private const uint SMTO_ABORTIFHUNG = 0x0002;
+    private const int SW_HIDE = 0;
+
+    [ModuleInitializer]
+    public static void Initialize()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        CleanupBlankFrames();
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => CleanupBlankFrames();
+        AssemblyLoadContext.Default.Unloading += _ => CleanupBlankFrames();
+    }
+
+    public static void CleanupBlankFrames()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        foreach (var hwnd in EnumerateBlankApplicationFrameWindows())
+        {
+            _ = ShowWindow(hwnd, SW_HIDE);
+            _ = SendMessageTimeout(hwnd, WM_CLOSE, IntPtr.Zero, IntPtr.Zero, SMTO_ABORTIFHUNG, 1000, out _);
+        }
+    }
+
+    private static IEnumerable<IntPtr> EnumerateBlankApplicationFrameWindows()
+    {
+        var windows = new List<IntPtr>();
+        _ = EnumWindows((hwnd, lParam) =>
+        {
+            if (!IsWindowVisible(hwnd))
+                return true;
+
+            var className = new StringBuilder(256);
+            _ = GetClassName(hwnd, className, className.Capacity);
+            if (!string.Equals(className.ToString(), "ApplicationFrameWindow", StringComparison.Ordinal))
+                return true;
+
+            var title = new StringBuilder(512);
+            _ = GetWindowText(hwnd, title, title.Capacity);
+            if (!string.IsNullOrWhiteSpace(title.ToString()))
+                return true;
+
+            _ = GetWindowThreadProcessId(hwnd, out var pid);
+            try
+            {
+                using var owner = System.Diagnostics.Process.GetProcessById((int)pid);
+                if (!string.Equals(owner.ProcessName, "explorer", StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            catch (ArgumentException)
+            {
+                return true;
+            }
+            catch (InvalidOperationException)
+            {
+                return true;
+            }
+
+            if (!GetWindowRect(hwnd, out var rect))
+                return true;
+
+            var width = rect.Right - rect.Left;
+            var height = rect.Bottom - rect.Top;
+            if (width > 100 && height > 100)
+                windows.Add(hwnd);
+
+            return true;
+        }, IntPtr.Zero);
+
+        return windows;
+    }
+
+    private delegate bool EnumWindowsProc(IntPtr hwnd, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    private static extern bool EnumWindows(EnumWindowsProc callback, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    private static extern bool IsWindowVisible(IntPtr hwnd);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowText(IntPtr hwnd, StringBuilder text, int count);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetClassName(IntPtr hwnd, StringBuilder text, int count);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint pid);
+
+    [DllImport("user32.dll")]
+    private static extern bool GetWindowRect(IntPtr hwnd, out RECT rect);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr SendMessageTimeout(
+        IntPtr hwnd,
+        uint msg,
+        IntPtr wParam,
+        IntPtr lParam,
+        uint flags,
+        uint timeout,
+        out IntPtr result);
+
+    [DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr hwnd, int nCmdShow);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/WinAppSdkGhostWindowCleanup.cs
+++ b/tests/OpenClaw.Tray.Tests/WinAppSdkGhostWindowCleanup.cs
@@ -19,20 +19,24 @@ internal sealed class WinAppSdkGhostWindowCleanupAttribute : BeforeAfterTestAttr
 }
 
 /// <summary>
-/// Cleans up Windows App SDK shell-frame ghosts created during tray validation.
+/// Cleans up desktop-frame ghosts created during tray validation.
 /// Some WinUI/AppWindow surfaces can leave an explorer-owned, blank
-/// <c>ApplicationFrameWindow</c> behind when the testhost exits. Those windows are
-/// visually disruptive on a developer workstation even though all tests pass.
-/// This test-only hook hides and closes blank shell frames during validation and
-/// again when the test process exits.
+/// <c>ApplicationFrameWindow</c> behind when the testhost exits; the validation
+/// host can also leave generic Windows Terminal frames around local runs. Those
+/// windows are visually disruptive on a developer workstation even though all
+/// tests pass. This test-only hook hides and closes newly-created ghost frames
+/// during validation and again when the test process exits.
 /// </summary>
 internal static class WinAppSdkGhostWindowCleanup
 {
     private const uint WM_CLOSE = 0x0010;
+    private const uint WM_SYSCOMMAND = 0x0112;
+    private const uint SC_CLOSE = 0xF060;
     private const uint SMTO_ABORTIFHUNG = 0x0002;
     private const int SW_HIDE = 0;
     private static readonly object s_baselineLock = new();
     private static HashSet<IntPtr> s_baselineBlankFrames = [];
+    private static HashSet<IntPtr> s_baselineTerminalFrames = [];
     private static int s_cleanupInProgress;
     private static System.Threading.Timer? s_cleanupTimer;
 
@@ -42,7 +46,8 @@ internal static class WinAppSdkGhostWindowCleanup
         if (!OperatingSystem.IsWindows())
             return;
 
-        RecordBaselineBlankFrames();
+        RecordBaselineGhostFrames();
+        CleanupBlankFrames();
         s_cleanupTimer = new System.Threading.Timer(
             _ => CleanupBlankFrames(),
             state: null,
@@ -65,11 +70,14 @@ internal static class WinAppSdkGhostWindowCleanup
         {
             foreach (var hwnd in EnumerateBlankApplicationFrameWindows())
             {
-                if (IsBaselineBlankFrame(hwnd))
-                    continue;
+                if (!IsBaselineBlankFrame(hwnd))
+                    HideAndClose(hwnd);
+            }
 
-                _ = ShowWindow(hwnd, SW_HIDE);
-                _ = SendMessageTimeout(hwnd, WM_CLOSE, IntPtr.Zero, IntPtr.Zero, SMTO_ABORTIFHUNG, 1000, out _);
+            foreach (var hwnd in EnumerateTerminalGhostWindows())
+            {
+                if (!IsBaselineTerminalFrame(hwnd))
+                    HideAndClose(hwnd);
             }
         }
         finally
@@ -78,11 +86,12 @@ internal static class WinAppSdkGhostWindowCleanup
         }
     }
 
-    private static void RecordBaselineBlankFrames()
+    private static void RecordBaselineGhostFrames()
     {
         lock (s_baselineLock)
         {
             s_baselineBlankFrames = EnumerateBlankApplicationFrameWindows().ToHashSet();
+            s_baselineTerminalFrames = EnumerateTerminalGhostWindows().ToHashSet();
         }
     }
 
@@ -91,6 +100,14 @@ internal static class WinAppSdkGhostWindowCleanup
         lock (s_baselineLock)
         {
             return s_baselineBlankFrames.Contains(hwnd);
+        }
+    }
+
+    private static bool IsBaselineTerminalFrame(IntPtr hwnd)
+    {
+        lock (s_baselineLock)
+        {
+            return s_baselineTerminalFrames.Contains(hwnd);
         }
     }
 
@@ -153,6 +170,61 @@ internal static class WinAppSdkGhostWindowCleanup
         return windows;
     }
 
+    private static IEnumerable<IntPtr> EnumerateTerminalGhostWindows()
+    {
+        var windows = new List<IntPtr>();
+        _ = EnumWindows((hwnd, lParam) =>
+        {
+            if (!IsWindowVisible(hwnd))
+                return true;
+
+            var className = new StringBuilder(256);
+            _ = GetClassName(hwnd, className, className.Capacity);
+            if (!string.Equals(className.ToString(), "CASCADIA_HOSTING_WINDOW_CLASS", StringComparison.Ordinal))
+                return true;
+
+            var title = new StringBuilder(512);
+            _ = GetWindowText(hwnd, title, title.Capacity);
+            if (!string.Equals(title.ToString(), "Terminal", StringComparison.Ordinal))
+                return true;
+
+            _ = GetWindowThreadProcessId(hwnd, out var pid);
+            try
+            {
+                using var owner = System.Diagnostics.Process.GetProcessById((int)pid);
+                if (!string.Equals(owner.ProcessName, "WindowsTerminal", StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            catch (ArgumentException)
+            {
+                return true;
+            }
+            catch (InvalidOperationException)
+            {
+                return true;
+            }
+
+            if (!GetWindowRect(hwnd, out var rect))
+                return true;
+
+            var width = rect.Right - rect.Left;
+            var height = rect.Bottom - rect.Top;
+            if (width >= 1000 && height >= 500)
+                windows.Add(hwnd);
+
+            return true;
+        }, IntPtr.Zero);
+
+        return windows;
+    }
+
+    private static void HideAndClose(IntPtr hwnd)
+    {
+        _ = ShowWindow(hwnd, SW_HIDE);
+        _ = PostMessage(hwnd, WM_SYSCOMMAND, new IntPtr(SC_CLOSE), IntPtr.Zero);
+        _ = SendMessageTimeout(hwnd, WM_CLOSE, IntPtr.Zero, IntPtr.Zero, SMTO_ABORTIFHUNG, 1000, out _);
+    }
+
     private delegate bool EnumWindowsProc(IntPtr hwnd, IntPtr lParam);
 
     [DllImport("user32.dll")]
@@ -185,6 +257,9 @@ internal static class WinAppSdkGhostWindowCleanup
 
     [DllImport("user32.dll")]
     private static extern bool ShowWindow(IntPtr hwnd, int nCmdShow);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool PostMessage(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam);
 
     [StructLayout(LayoutKind.Sequential)]
     private struct RECT

--- a/tests/OpenClaw.Tray.Tests/WinAppSdkGhostWindowCleanup.cs
+++ b/tests/OpenClaw.Tray.Tests/WinAppSdkGhostWindowCleanup.cs
@@ -11,6 +11,9 @@ namespace OpenClaw.Tray.Tests;
 
 internal sealed class WinAppSdkGhostWindowCleanupAttribute : BeforeAfterTestAttribute
 {
+    public override void Before(MethodInfo methodUnderTest) =>
+        WinAppSdkGhostWindowCleanup.CleanupBlankFrames();
+
     public override void After(MethodInfo methodUnderTest) =>
         WinAppSdkGhostWindowCleanup.CleanupBlankFrames();
 }
@@ -28,6 +31,8 @@ internal static class WinAppSdkGhostWindowCleanup
     private const uint WM_CLOSE = 0x0010;
     private const uint SMTO_ABORTIFHUNG = 0x0002;
     private const int SW_HIDE = 0;
+    private static int s_cleanupInProgress;
+    private static System.Threading.Timer? s_cleanupTimer;
 
     [ModuleInitializer]
     public static void Initialize()
@@ -36,8 +41,14 @@ internal static class WinAppSdkGhostWindowCleanup
             return;
 
         CleanupBlankFrames();
-        AppDomain.CurrentDomain.ProcessExit += (_, _) => CleanupBlankFrames();
-        AssemblyLoadContext.Default.Unloading += _ => CleanupBlankFrames();
+        s_cleanupTimer = new System.Threading.Timer(
+            _ => CleanupBlankFrames(),
+            state: null,
+            dueTime: System.TimeSpan.FromSeconds(1),
+            period: System.TimeSpan.FromSeconds(1));
+
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => CleanupBlankFramesRepeatedly();
+        AssemblyLoadContext.Default.Unloading += _ => CleanupBlankFramesRepeatedly();
     }
 
     public static void CleanupBlankFrames()
@@ -45,10 +56,30 @@ internal static class WinAppSdkGhostWindowCleanup
         if (!OperatingSystem.IsWindows())
             return;
 
-        foreach (var hwnd in EnumerateBlankApplicationFrameWindows())
+        if (System.Threading.Interlocked.Exchange(ref s_cleanupInProgress, 1) == 1)
+            return;
+
+        try
         {
-            _ = ShowWindow(hwnd, SW_HIDE);
-            _ = SendMessageTimeout(hwnd, WM_CLOSE, IntPtr.Zero, IntPtr.Zero, SMTO_ABORTIFHUNG, 1000, out _);
+            foreach (var hwnd in EnumerateBlankApplicationFrameWindows())
+            {
+                _ = ShowWindow(hwnd, SW_HIDE);
+                _ = SendMessageTimeout(hwnd, WM_CLOSE, IntPtr.Zero, IntPtr.Zero, SMTO_ABORTIFHUNG, 1000, out _);
+            }
+        }
+        finally
+        {
+            System.Threading.Volatile.Write(ref s_cleanupInProgress, 0);
+        }
+    }
+
+    private static void CleanupBlankFramesRepeatedly()
+    {
+        var deadline = System.DateTime.UtcNow.AddSeconds(5);
+        while (System.DateTime.UtcNow < deadline)
+        {
+            CleanupBlankFrames();
+            System.Threading.Thread.Sleep(250);
         }
     }
 
@@ -74,7 +105,8 @@ internal static class WinAppSdkGhostWindowCleanup
             try
             {
                 using var owner = System.Diagnostics.Process.GetProcessById((int)pid);
-                if (!string.Equals(owner.ProcessName, "explorer", StringComparison.OrdinalIgnoreCase))
+                if (!string.Equals(owner.ProcessName, "explorer", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(owner.ProcessName, "ApplicationFrameHost", StringComparison.OrdinalIgnoreCase))
                     return true;
             }
             catch (ArgumentException)

--- a/tests/OpenClaw.Tray.Tests/WinAppSdkGhostWindowCleanup.cs
+++ b/tests/OpenClaw.Tray.Tests/WinAppSdkGhostWindowCleanup.cs
@@ -31,6 +31,8 @@ internal static class WinAppSdkGhostWindowCleanup
     private const uint WM_CLOSE = 0x0010;
     private const uint SMTO_ABORTIFHUNG = 0x0002;
     private const int SW_HIDE = 0;
+    private static readonly object s_baselineLock = new();
+    private static HashSet<IntPtr> s_baselineBlankFrames = [];
     private static int s_cleanupInProgress;
     private static System.Threading.Timer? s_cleanupTimer;
 
@@ -40,7 +42,7 @@ internal static class WinAppSdkGhostWindowCleanup
         if (!OperatingSystem.IsWindows())
             return;
 
-        CleanupBlankFrames();
+        RecordBaselineBlankFrames();
         s_cleanupTimer = new System.Threading.Timer(
             _ => CleanupBlankFrames(),
             state: null,
@@ -63,6 +65,9 @@ internal static class WinAppSdkGhostWindowCleanup
         {
             foreach (var hwnd in EnumerateBlankApplicationFrameWindows())
             {
+                if (IsBaselineBlankFrame(hwnd))
+                    continue;
+
                 _ = ShowWindow(hwnd, SW_HIDE);
                 _ = SendMessageTimeout(hwnd, WM_CLOSE, IntPtr.Zero, IntPtr.Zero, SMTO_ABORTIFHUNG, 1000, out _);
             }
@@ -70,6 +75,22 @@ internal static class WinAppSdkGhostWindowCleanup
         finally
         {
             System.Threading.Volatile.Write(ref s_cleanupInProgress, 0);
+        }
+    }
+
+    private static void RecordBaselineBlankFrames()
+    {
+        lock (s_baselineLock)
+        {
+            s_baselineBlankFrames = EnumerateBlankApplicationFrameWindows().ToHashSet();
+        }
+    }
+
+    private static bool IsBaselineBlankFrame(IntPtr hwnd)
+    {
+        lock (s_baselineLock)
+        {
+            return s_baselineBlankFrames.Contains(hwnd);
         }
     }
 

--- a/tests/OpenClaw.Tray.Tests/WinAppSdkGhostWindowCleanup.cs
+++ b/tests/OpenClaw.Tray.Tests/WinAppSdkGhostWindowCleanup.cs
@@ -19,13 +19,12 @@ internal sealed class WinAppSdkGhostWindowCleanupAttribute : BeforeAfterTestAttr
 }
 
 /// <summary>
-/// Cleans up desktop-frame ghosts created during tray validation.
+/// Cleans up Windows App SDK shell-frame ghosts created during tray validation.
 /// Some WinUI/AppWindow surfaces can leave an explorer-owned, blank
-/// <c>ApplicationFrameWindow</c> behind when the testhost exits; the validation
-/// host can also leave generic Windows Terminal frames around local runs. Those
-/// windows are visually disruptive on a developer workstation even though all
-/// tests pass. This test-only hook hides and closes newly-created ghost frames
-/// during validation and again when the test process exits.
+/// <c>ApplicationFrameWindow</c> behind when the testhost exits. Those windows
+/// are visually disruptive on a developer workstation even though all tests pass.
+/// This test-only hook hides and closes newly-created blank shell frames during
+/// validation and again when the test process exits.
 /// </summary>
 internal static class WinAppSdkGhostWindowCleanup
 {
@@ -36,7 +35,6 @@ internal static class WinAppSdkGhostWindowCleanup
     private const int SW_HIDE = 0;
     private static readonly object s_baselineLock = new();
     private static HashSet<IntPtr> s_baselineBlankFrames = [];
-    private static HashSet<IntPtr> s_baselineTerminalFrames = [];
     private static int s_cleanupInProgress;
     private static System.Threading.Timer? s_cleanupTimer;
 
@@ -46,7 +44,7 @@ internal static class WinAppSdkGhostWindowCleanup
         if (!OperatingSystem.IsWindows())
             return;
 
-        RecordBaselineGhostFrames();
+        RecordBaselineBlankFrames();
         CleanupBlankFrames();
         s_cleanupTimer = new System.Threading.Timer(
             _ => CleanupBlankFrames(),
@@ -73,12 +71,6 @@ internal static class WinAppSdkGhostWindowCleanup
                 if (!IsBaselineBlankFrame(hwnd))
                     HideAndClose(hwnd);
             }
-
-            foreach (var hwnd in EnumerateTerminalGhostWindows())
-            {
-                if (!IsBaselineTerminalFrame(hwnd))
-                    HideAndClose(hwnd);
-            }
         }
         finally
         {
@@ -86,12 +78,11 @@ internal static class WinAppSdkGhostWindowCleanup
         }
     }
 
-    private static void RecordBaselineGhostFrames()
+    private static void RecordBaselineBlankFrames()
     {
         lock (s_baselineLock)
         {
             s_baselineBlankFrames = EnumerateBlankApplicationFrameWindows().ToHashSet();
-            s_baselineTerminalFrames = EnumerateTerminalGhostWindows().ToHashSet();
         }
     }
 
@@ -100,14 +91,6 @@ internal static class WinAppSdkGhostWindowCleanup
         lock (s_baselineLock)
         {
             return s_baselineBlankFrames.Contains(hwnd);
-        }
-    }
-
-    private static bool IsBaselineTerminalFrame(IntPtr hwnd)
-    {
-        lock (s_baselineLock)
-        {
-            return s_baselineTerminalFrames.Contains(hwnd);
         }
     }
 
@@ -162,54 +145,6 @@ internal static class WinAppSdkGhostWindowCleanup
             var width = rect.Right - rect.Left;
             var height = rect.Bottom - rect.Top;
             if (width > 100 && height > 100)
-                windows.Add(hwnd);
-
-            return true;
-        }, IntPtr.Zero);
-
-        return windows;
-    }
-
-    private static IEnumerable<IntPtr> EnumerateTerminalGhostWindows()
-    {
-        var windows = new List<IntPtr>();
-        _ = EnumWindows((hwnd, lParam) =>
-        {
-            if (!IsWindowVisible(hwnd))
-                return true;
-
-            var className = new StringBuilder(256);
-            _ = GetClassName(hwnd, className, className.Capacity);
-            if (!string.Equals(className.ToString(), "CASCADIA_HOSTING_WINDOW_CLASS", StringComparison.Ordinal))
-                return true;
-
-            var title = new StringBuilder(512);
-            _ = GetWindowText(hwnd, title, title.Capacity);
-            if (!string.Equals(title.ToString(), "Terminal", StringComparison.Ordinal))
-                return true;
-
-            _ = GetWindowThreadProcessId(hwnd, out var pid);
-            try
-            {
-                using var owner = System.Diagnostics.Process.GetProcessById((int)pid);
-                if (!string.Equals(owner.ProcessName, "WindowsTerminal", StringComparison.OrdinalIgnoreCase))
-                    return true;
-            }
-            catch (ArgumentException)
-            {
-                return true;
-            }
-            catch (InvalidOperationException)
-            {
-                return true;
-            }
-
-            if (!GetWindowRect(hwnd, out var rect))
-                return true;
-
-            var width = rect.Right - rect.Left;
-            var height = rect.Bottom - rect.Top;
-            if (width >= 1000 && height >= 500)
                 windows.Add(hwnd);
 
             return true;

--- a/tests/OpenClaw.Tray.Tests/WslDistroKeepAliveTests.cs
+++ b/tests/OpenClaw.Tray.Tests/WslDistroKeepAliveTests.cs
@@ -5,10 +5,21 @@ using OpenClawTray.Services.LocalGatewaySetup;
 namespace OpenClaw.Tray.Tests;
 
 /// <summary>
+/// xunit collection marker that serializes any test class touching
+/// <see cref="OpenClawTray.Services.LocalGatewaySetup.WslDistroKeepAlive"/>
+/// global state (`__TestHost`, `__TestMarkerDirectory`). Different test classes
+/// run in parallel by default; this collection forces them to share a single
+/// runner so the static seams cannot interleave.
+/// </summary>
+[CollectionDefinition("WslDistroKeepAliveSerial", DisableParallelization = true)]
+public sealed class WslDistroKeepAliveSerialCollection { }
+
+/// <summary>
 /// Behavioral tests for <see cref="WslDistroKeepAlive"/>. The class is global static
 /// state, so each test resets the test seams in a try/finally to keep tests
 /// independent.
 /// </summary>
+[Collection("WslDistroKeepAliveSerial")]
 public class WslDistroKeepAliveTests
 {
     [Fact]
@@ -194,6 +205,36 @@ public class WslDistroKeepAliveTests
     }
 
     [Fact]
+    public void EnsureStarted_MarkerWriteFails_KillsOrphanSpawn()
+    {
+        using var temp = new LocalGatewaySetupTests.TempDirectory();
+        var host = new FakeKeepAliveHost();
+
+        // Point the marker dir at a path that cannot be written: a file existing where
+        // the directory is expected. Directory.CreateDirectory will throw IOException
+        // because the path is occupied by a regular file.
+        var blockedDir = Path.Combine(temp.Path, "blocked");
+        File.WriteAllText(blockedDir, "occupied");
+
+        try
+        {
+            WslDistroKeepAlive.__TestMarkerDirectory = blockedDir;
+            WslDistroKeepAlive.__TestHost = host;
+
+            WslDistroKeepAlive.EnsureStarted("OpenClawGateway");
+
+            // Spawn happened, but marker write failed → orphan must be killed.
+            Assert.Single(host.SpawnCalls);
+            Assert.Single(host.KillCalls);
+            Assert.Equal(host.LastSpawnedPid, host.KillCalls[0]);
+        }
+        finally
+        {
+            WslDistroKeepAlive.__ResetForTests();
+        }
+    }
+
+    [Fact]
     public void StopAll_StopsEveryRecordedDistro()
     {
         using var temp = new LocalGatewaySetupTests.TempDirectory();
@@ -230,12 +271,40 @@ public class WslDistroKeepAliveTests
     }
 
     /// <summary>
+    /// Test-only IDisposable that swaps <see cref="WslDistroKeepAlive"/> onto a
+    /// no-op in-memory host and a throwaway marker directory. Other test classes
+    /// (notably <c>LocalGatewaySetupTests</c>) need this when they exercise code
+    /// paths — like <c>LocalGatewayLifecycleManager.RepairAsync</c> — that
+    /// internally call <see cref="WslDistroKeepAlive.EnsureStarted"/> or
+    /// <see cref="WslDistroKeepAlive.Stop"/>. Without this, the lifecycle tests
+    /// would spawn real <c>wsl.exe</c> processes on the dev/CI machine.
+    /// </summary>
+    internal sealed class KeepAliveIsolation : IDisposable
+    {
+        private readonly string _tempDir;
+
+        public KeepAliveIsolation()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "openclaw-keepalive-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDir);
+            WslDistroKeepAlive.__TestMarkerDirectory = _tempDir;
+            WslDistroKeepAlive.__TestHost = new FakeKeepAliveHost();
+        }
+
+        public void Dispose()
+        {
+            WslDistroKeepAlive.__ResetForTests();
+            try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    /// <summary>
     /// In-memory keepalive host. Simulates Windows process lifecycle without forking
     /// real processes: each <see cref="Spawn"/> generates a synthetic PID + start time,
     /// and <see cref="TryGetProcessIdentity"/> returns identity records that callers
     /// can override per-PID to simulate PID recycling.
     /// </summary>
-    private sealed class FakeKeepAliveHost : IWslKeepAliveProcessHost
+    internal sealed class FakeKeepAliveHost : IWslKeepAliveProcessHost
     {
         private int _nextPid = 1000;
         private readonly Dictionary<int, KeepAliveProcessIdentity> _liveProcesses = new();

--- a/tests/OpenClaw.Tray.Tests/WslDistroKeepAliveTests.cs
+++ b/tests/OpenClaw.Tray.Tests/WslDistroKeepAliveTests.cs
@@ -1,0 +1,283 @@
+using System.IO;
+using System.Linq;
+using OpenClawTray.Services.LocalGatewaySetup;
+
+namespace OpenClaw.Tray.Tests;
+
+/// <summary>
+/// Behavioral tests for <see cref="WslDistroKeepAlive"/>. The class is global static
+/// state, so each test resets the test seams in a try/finally to keep tests
+/// independent.
+/// </summary>
+public class WslDistroKeepAliveTests
+{
+    [Fact]
+    public void EnsureStarted_NoMarker_SpawnsAndPersistsMarker()
+    {
+        using var temp = new LocalGatewaySetupTests.TempDirectory();
+        var host = new FakeKeepAliveHost();
+        WithSeams(temp.Path, host, () =>
+        {
+            WslDistroKeepAlive.EnsureStarted("OpenClawGateway");
+
+            Assert.Single(host.SpawnCalls);
+            Assert.Equal("OpenClawGateway", host.SpawnCalls[0]);
+            Assert.True(File.Exists(Path.Combine(temp.Path, "OpenClawGateway.json")),
+                "Marker file should be written after a fresh spawn.");
+        });
+    }
+
+    [Fact]
+    public void EnsureStarted_AdoptsExistingProcess_WhenMarkerMatches()
+    {
+        using var temp = new LocalGatewaySetupTests.TempDirectory();
+        var host = new FakeKeepAliveHost();
+
+        WithSeams(temp.Path, host, () =>
+        {
+            WslDistroKeepAlive.EnsureStarted("OpenClawGateway");
+            Assert.Single(host.SpawnCalls);
+
+            // Second call should adopt — same host, same alive PID, marker still on disk.
+            WslDistroKeepAlive.EnsureStarted("OpenClawGateway");
+            Assert.Single(host.SpawnCalls); // Still only one spawn.
+        });
+    }
+
+    [Fact]
+    public void EnsureStarted_RecycledPid_SpawnsFresh()
+    {
+        using var temp = new LocalGatewaySetupTests.TempDirectory();
+        var host = new FakeKeepAliveHost();
+
+        WithSeams(temp.Path, host, () =>
+        {
+            WslDistroKeepAlive.EnsureStarted("OpenClawGateway");
+            Assert.Single(host.SpawnCalls);
+            var firstPid = host.LastSpawnedPid;
+
+            // Simulate PID recycled to an unrelated process: same PID is reported alive
+            // but with a different start time + different name.
+            host.OverrideIdentity(firstPid, new KeepAliveProcessIdentity("notepad", System.DateTime.UtcNow.AddHours(1)));
+
+            WslDistroKeepAlive.EnsureStarted("OpenClawGateway");
+            Assert.Equal(2, host.SpawnCalls.Count);
+        });
+    }
+
+    [Fact]
+    public void EnsureStarted_DeadPid_SpawnsFresh()
+    {
+        using var temp = new LocalGatewaySetupTests.TempDirectory();
+        var host = new FakeKeepAliveHost();
+
+        WithSeams(temp.Path, host, () =>
+        {
+            WslDistroKeepAlive.EnsureStarted("OpenClawGateway");
+            var firstPid = host.LastSpawnedPid;
+
+            // Marker still on disk but the process has exited.
+            host.KillSilently(firstPid);
+
+            WslDistroKeepAlive.EnsureStarted("OpenClawGateway");
+            Assert.Equal(2, host.SpawnCalls.Count);
+        });
+    }
+
+    [Fact]
+    public void EnsureStarted_CorruptMarker_RecoversBySpawning()
+    {
+        using var temp = new LocalGatewaySetupTests.TempDirectory();
+        var host = new FakeKeepAliveHost();
+
+        WithSeams(temp.Path, host, () =>
+        {
+            File.WriteAllText(Path.Combine(temp.Path, "OpenClawGateway.json"), "{not valid json");
+            WslDistroKeepAlive.EnsureStarted("OpenClawGateway");
+
+            Assert.Single(host.SpawnCalls);
+            // Marker should be overwritten with a valid record.
+            var json = File.ReadAllText(Path.Combine(temp.Path, "OpenClawGateway.json"));
+            Assert.Contains("\"DistroName\"", json);
+        });
+    }
+
+    [Fact]
+    public void Stop_MatchingMarker_KillsAndDeletesMarker()
+    {
+        using var temp = new LocalGatewaySetupTests.TempDirectory();
+        var host = new FakeKeepAliveHost();
+
+        WithSeams(temp.Path, host, () =>
+        {
+            WslDistroKeepAlive.EnsureStarted("OpenClawGateway");
+            var pid = host.LastSpawnedPid;
+
+            WslDistroKeepAlive.Stop("OpenClawGateway");
+
+            Assert.Contains(pid, host.KillCalls);
+            Assert.False(File.Exists(Path.Combine(temp.Path, "OpenClawGateway.json")));
+        });
+    }
+
+    [Fact]
+    public void Stop_StaleMarker_DeletesMarker_DoesNotKill()
+    {
+        using var temp = new LocalGatewaySetupTests.TempDirectory();
+        var host = new FakeKeepAliveHost();
+
+        WithSeams(temp.Path, host, () =>
+        {
+            WslDistroKeepAlive.EnsureStarted("OpenClawGateway");
+            var pid = host.LastSpawnedPid;
+
+            // Simulate PID recycled to unrelated process — Stop must NOT kill it.
+            host.OverrideIdentity(pid, new KeepAliveProcessIdentity("explorer", System.DateTime.UtcNow.AddHours(2)));
+
+            WslDistroKeepAlive.Stop("OpenClawGateway");
+
+            Assert.DoesNotContain(pid, host.KillCalls);
+            Assert.False(File.Exists(Path.Combine(temp.Path, "OpenClawGateway.json")));
+        });
+    }
+
+    [Fact]
+    public void Stop_NoMarker_IsNoOp()
+    {
+        using var temp = new LocalGatewaySetupTests.TempDirectory();
+        var host = new FakeKeepAliveHost();
+
+        WithSeams(temp.Path, host, () =>
+        {
+            WslDistroKeepAlive.Stop("OpenClawGateway");
+
+            Assert.Empty(host.KillCalls);
+            Assert.Empty(host.SpawnCalls);
+        });
+    }
+
+    [Fact]
+    public void EnsureStarted_NullOrEmptyDistro_IsNoOp()
+    {
+        using var temp = new LocalGatewaySetupTests.TempDirectory();
+        var host = new FakeKeepAliveHost();
+
+        WithSeams(temp.Path, host, () =>
+        {
+            WslDistroKeepAlive.EnsureStarted("");
+            WslDistroKeepAlive.EnsureStarted("   ");
+            WslDistroKeepAlive.EnsureStarted(null!);
+
+            Assert.Empty(host.SpawnCalls);
+            Assert.False(Directory.EnumerateFiles(temp.Path).Any());
+        });
+    }
+
+    [Fact]
+    public void EnsureStarted_DistroNameWithInvalidPathChars_SanitizesMarkerFilename()
+    {
+        using var temp = new LocalGatewaySetupTests.TempDirectory();
+        var host = new FakeKeepAliveHost();
+
+        WithSeams(temp.Path, host, () =>
+        {
+            // Defensive: invalid filename chars must be replaced so we never write
+            // outside the marker directory.
+            WslDistroKeepAlive.EnsureStarted("Custom/Distro:Name");
+
+            Assert.Single(host.SpawnCalls);
+            var markers = Directory.EnumerateFiles(temp.Path, "*.json").ToList();
+            var marker = Assert.Single(markers);
+            Assert.DoesNotContain('/', Path.GetFileName(marker));
+            Assert.DoesNotContain(':', Path.GetFileName(marker));
+        });
+    }
+
+    [Fact]
+    public void StopAll_StopsEveryRecordedDistro()
+    {
+        using var temp = new LocalGatewaySetupTests.TempDirectory();
+        var host = new FakeKeepAliveHost();
+
+        WithSeams(temp.Path, host, () =>
+        {
+            WslDistroKeepAlive.EnsureStarted("OpenClawGateway");
+            WslDistroKeepAlive.EnsureStarted("OpenClawGatewayE2E");
+
+            WslDistroKeepAlive.StopAll();
+
+            Assert.Equal(2, host.KillCalls.Count);
+            Assert.False(Directory.EnumerateFiles(temp.Path, "*.json").Any());
+        });
+    }
+
+    /// <summary>
+    /// Wraps a test body so the global test seams on <see cref="WslDistroKeepAlive"/>
+    /// are always reset, even if the body throws.
+    /// </summary>
+    private static void WithSeams(string markerDirectory, IWslKeepAliveProcessHost host, Action body)
+    {
+        try
+        {
+            WslDistroKeepAlive.__TestMarkerDirectory = markerDirectory;
+            WslDistroKeepAlive.__TestHost = host;
+            body();
+        }
+        finally
+        {
+            WslDistroKeepAlive.__ResetForTests();
+        }
+    }
+
+    /// <summary>
+    /// In-memory keepalive host. Simulates Windows process lifecycle without forking
+    /// real processes: each <see cref="Spawn"/> generates a synthetic PID + start time,
+    /// and <see cref="TryGetProcessIdentity"/> returns identity records that callers
+    /// can override per-PID to simulate PID recycling.
+    /// </summary>
+    private sealed class FakeKeepAliveHost : IWslKeepAliveProcessHost
+    {
+        private int _nextPid = 1000;
+        private readonly Dictionary<int, KeepAliveProcessIdentity> _liveProcesses = new();
+
+        public List<string> SpawnCalls { get; } = new();
+        public List<int> KillCalls { get; } = new();
+        public int LastSpawnedPid { get; private set; }
+
+        public KeepAliveProcessIdentity Spawn(string distroName)
+        {
+            SpawnCalls.Add(distroName);
+            var pid = _nextPid++;
+            var identity = new KeepAliveProcessIdentity(
+                "wsl",
+                System.DateTime.UtcNow.AddTicks(pid));
+            _liveProcesses[pid] = identity;
+            LastSpawnedPid = pid;
+            return identity;
+        }
+
+        public bool TryGetProcessIdentity(int pid, out KeepAliveProcessIdentity identity)
+        {
+            if (_liveProcesses.TryGetValue(pid, out var found))
+            {
+                identity = found;
+                return true;
+            }
+            identity = default!;
+            return false;
+        }
+
+        public void Kill(int pid)
+        {
+            KillCalls.Add(pid);
+            _liveProcesses.Remove(pid);
+        }
+
+        public int GetCurrentPidForLastSpawn() => LastSpawnedPid;
+
+        public void OverrideIdentity(int pid, KeepAliveProcessIdentity identity)
+            => _liveProcesses[pid] = identity;
+
+        public void KillSilently(int pid) => _liveProcesses.Remove(pid);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/WslDistroKeepAliveTests.cs
+++ b/tests/OpenClaw.Tray.Tests/WslDistroKeepAliveTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using OpenClaw.Shared;
 using OpenClawTray.Services.LocalGatewaySetup;
 
 namespace OpenClaw.Tray.Tests;
@@ -168,6 +169,24 @@ public class WslDistroKeepAliveTests
     }
 
     [Fact]
+    public void Stop_MalformedMarker_DeletesMarker_DoesNotKill()
+    {
+        using var temp = new LocalGatewaySetupTests.TempDirectory();
+        var host = new FakeKeepAliveHost();
+
+        WithSeams(temp.Path, host, () =>
+        {
+            var markerPath = Path.Combine(temp.Path, "OpenClawGateway.json");
+            File.WriteAllText(markerPath, "{not valid json");
+
+            WslDistroKeepAlive.Stop("OpenClawGateway");
+
+            Assert.Empty(host.KillCalls);
+            Assert.False(File.Exists(markerPath));
+        });
+    }
+
+    [Fact]
     public void EnsureStarted_NullOrEmptyDistro_IsNoOp()
     {
         using var temp = new LocalGatewaySetupTests.TempDirectory();
@@ -232,6 +251,72 @@ public class WslDistroKeepAliveTests
         {
             WslDistroKeepAlive.__ResetForTests();
         }
+    }
+
+    [Fact]
+    public async Task StartupArmer_FailedFirstProbeThenSuccess_EnsuresStartedOnce()
+    {
+        var probes = new Queue<WslCommandResult>([
+            new WslCommandResult(-1, string.Empty, "wsl.exe timed out"),
+            new WslCommandResult(0, """
+              NAME                   STATE           VERSION
+            * Ubuntu                 Running         2
+              OpenClawGateway        Stopped         2
+            """, string.Empty)
+        ]);
+        var ensureCount = 0;
+
+        await WslKeepAliveStartupArmer.ArmAsync(
+            "OpenClawGateway",
+            _ => Task.FromResult(probes.Dequeue()),
+            () => ensureCount++,
+            _ => { },
+            retryDelays: [TimeSpan.Zero, TimeSpan.Zero],
+            probeTimeout: TimeSpan.FromSeconds(1));
+
+        Assert.Equal(1, ensureCount);
+        Assert.Empty(probes);
+    }
+
+    [Fact]
+    public async Task StartupArmer_AllProbesFail_DefensivelyEnsuresStartedOnce()
+    {
+        var probeCount = 0;
+        var ensureCount = 0;
+
+        await WslKeepAliveStartupArmer.ArmAsync(
+            "OpenClawGateway",
+            _ =>
+            {
+                probeCount++;
+                return Task.FromResult(new WslCommandResult(-1, string.Empty, "wsl.exe timed out"));
+            },
+            () => ensureCount++,
+            _ => { },
+            retryDelays: [TimeSpan.Zero, TimeSpan.Zero],
+            probeTimeout: TimeSpan.FromSeconds(1));
+
+        Assert.Equal(2, probeCount);
+        Assert.Equal(1, ensureCount);
+    }
+
+    [Fact]
+    public async Task StartupArmer_SuccessfulProbeMissingDistro_SkipsEnsureStarted()
+    {
+        var ensureCount = 0;
+
+        await WslKeepAliveStartupArmer.ArmAsync(
+            "OpenClawGateway",
+            _ => Task.FromResult(new WslCommandResult(0, """
+              NAME                   STATE           VERSION
+            * Ubuntu                 Running         2
+            """, string.Empty)),
+            () => ensureCount++,
+            _ => { },
+            retryDelays: [TimeSpan.Zero],
+            probeTimeout: TimeSpan.FromSeconds(1));
+
+        Assert.Equal(0, ensureCount);
     }
 
     [Fact]
@@ -313,7 +398,7 @@ public class WslDistroKeepAliveTests
         public List<int> KillCalls { get; } = new();
         public int LastSpawnedPid { get; private set; }
 
-        public KeepAliveProcessIdentity Spawn(string distroName)
+        public KeepAliveSpawnResult Spawn(string distroName, IOpenClawLogger? logger = null)
         {
             SpawnCalls.Add(distroName);
             var pid = _nextPid++;
@@ -322,7 +407,7 @@ public class WslDistroKeepAliveTests
                 System.DateTime.UtcNow.AddTicks(pid));
             _liveProcesses[pid] = identity;
             LastSpawnedPid = pid;
-            return identity;
+            return new KeepAliveSpawnResult(pid, identity);
         }
 
         public bool TryGetProcessIdentity(int pid, out KeepAliveProcessIdentity identity)
@@ -341,8 +426,6 @@ public class WslDistroKeepAliveTests
             KillCalls.Add(pid);
             _liveProcesses.Remove(pid);
         }
-
-        public int GetCurrentPidForLastSpawn() => LastSpawnedPid;
 
         public void OverrideIdentity(int pid, KeepAliveProcessIdentity identity)
             => _liveProcesses[pid] = identity;


### PR DESCRIPTION
## What

Makes the OpenClawGateway WSL2 distro stay reachable across tray restarts and Windows logon. The keepalive now persists across the tray's lifetime so the user's gateway is reachable any time the tray icon is running (or about to run).

## Why

Even after a successful install of the easy-button local gateway, the gateway became unreachable in two real scenarios:

1. **Windows reboot.** Tray autostart at logon never re-armed the keepalive — only the onboarding flow did. ~20 s after the first `/health` probe, the WSL2 VM idled out (vmIdleTimeout), systemd died with it, and the gateway with that.
2. **Tray crash / restart.** `WslDistroKeepAlive` registered `AppDomain.CurrentDomain.ProcessExit += StopAll`, killing the keepalive whenever the tray exited.

Symptoms reported in the wild include `connecting…` that never resolves after rebooting Windows. `loginctl enable-linger openclaw` does not save us here because the WSL VM itself is what shuts down — linger only protects user services across logout *while the VM is running*.

## How

`WslDistroKeepAlive` becomes a real lifecycle primitive:

- **Marker file** at `%LOCALAPPDATA%/OpenClawTray/wsl-keepalive/<distro>.json` containing `distroName + PID + StartTimeUtc + processName`, with atomic `File.Move(..., overwrite: true)`.
- **Adoption** on every `EnsureStarted`: if the marker references a live process whose name + start time match (500 ms tolerance), adopt instead of spawning a duplicate.
- **Anti-PID-recycle**: `Stop` only kills when marker identity matches; otherwise just deletes the marker. Defensive `SafeStartTimeUtc` for fast-exit `InvalidOperationException`.
- **Detached spawn**: no stdio redirect, no `ProcessExit` cleanup. The keepalive outlives the tray.
- `App.OnLaunched` calls `TryEnsureLocalGatewayKeepAliveAsync` before `InitializeGatewayClient`. Bounded 5 s `wsl --list` probe; never blocks tray startup. If the user is no longer in local-gateway mode, the helper also calls `Stop` to release any stale keepalive (no zombie VM after mode switch).
- `LocalGatewayLifecycleManager.RepairAsync`: `Stop` before terminate, `EnsureStarted` after the gateway is healthy.
- `LocalGatewayLifecycleManager.RemoveAsync`: `Stop` before terminate so the marker never survives `--unregister`.
- Internal `IWslKeepAliveProcessHost` test seam plus `__TestMarkerDirectory` override to keep unit tests off real `wsl.exe`.

## Review

Ran the Hanselman dual-model adversarial review (Opus + Codex). High-consensus fixes already applied in this PR:

| Issue | Fix |
| --- | --- |
| `File.Move` without `overwrite: true` orphans keepalive in concurrent-launch races | Single atomic `File.Move(temp, dest, overwrite: true)` |
| No teardown on local→remote mode switch left zombie VM pinned | `TryEnsureLocalGatewayKeepAliveAsync` calls `Stop` when URL is non-local |
| `process.StartTime` can throw on fast-exit | `SafeStartTimeUtc` falls back to `UtcNow` |
| 50 ms identity tolerance too tight for cross-process roundtrip | Widened to 500 ms (still well below PID-recycle window) |

Skipped after analysis: cross-process mutex (tray already enforces single-instance via named `Mutex` in `OnLaunched`); `StopAll` lock scope (only runs from uninstall); filename-collision sanitizer (production distro name is hard-coded `OpenClawGateway`).

## Out-of-scope observation

Codex flagged a sibling concern: `SshTunnelService.EnsureStarted` is never called from `App.OnLaunched` either. Users on SSH-tunnel mode with autostart will see the tray come up but the tunnel will not arm until they touch the connection. This is a pre-existing gap not caused by this change — happy to file as a follow-up if useful.

## Validation (run in clean worktree based on origin/master)

- `./build.ps1` — all 4 projects built clean
- `dotnet test ./tests/OpenClaw.Shared.Tests/...` — **1776 passed / 28 skipped / 0 failed**
- `dotnet test ./tests/OpenClaw.Tray.Tests/...` — **1100 passed / 0 failed** (includes 11 new `WslDistroKeepAliveTests` covering adoption, recycled-PID, dead-PID, corrupt marker, Stop/StopAll, sanitization, null inputs)