### PR TITLE
Fix zero-state chat trap + auto-approve own-node sub-pairing

### DIFF
--- a/src/OpenClaw.Chat/ChatModels.cs
+++ b/src/OpenClaw.Chat/ChatModels.cs
@@ -123,7 +123,30 @@ public record ChatDataSnapshot(
     IReadOnlyDictionary<string, ChatTimelineState> Timelines,
     string? DefaultThreadId,
     string? ConnectionStatus,
-    string[] AvailableModels);
+    string[] AvailableModels,
+    ChatComposeTarget ComposeTarget);
+
+/// <summary>
+/// Describes where the UI may send the next chat message. Distinct from
+/// <see cref="ChatDataSnapshot.Threads"/> because, in protocols like the
+/// OpenClaw gateway, there is always a canonical "main" target whose session
+/// row may not have been materialized yet (zero sessions on fresh install).
+/// The UI uses this to decide whether the composer should be enabled even
+/// when <see cref="ChatDataSnapshot.Threads"/> is empty.
+/// </summary>
+/// <param name="SessionKey">
+/// The provider-resolved canonical session key for the default send target,
+/// or <c>null</c> when not yet known (e.g. handshake incomplete).
+/// </param>
+/// <param name="IsReady">
+/// True when the provider is connected, has resolved a canonical send target,
+/// and accepts <see cref="IChatDataProvider.SendMessageAsync"/> calls keyed by
+/// <see cref="SessionKey"/>.
+/// </param>
+public sealed record ChatComposeTarget(string? SessionKey, bool IsReady)
+{
+    public static ChatComposeTarget NotReady { get; } = new(null, false);
+}
 
 public sealed class ChatDataChangedEventArgs(ChatDataSnapshot snapshot) : EventArgs
 {
@@ -157,7 +180,10 @@ public interface IChatDataProvider : IAsyncDisposable
     event EventHandler<ChatProviderNotificationEventArgs>? NotificationRequested;
 
     Task<ChatDataSnapshot> LoadAsync(CancellationToken cancellationToken = default);
-    Task<ChatThread> CreateThreadAsync(string? initialMessage = null, CancellationToken cancellationToken = default);
+    // Note: there is intentionally no CreateThreadAsync. The gateway protocol
+    // has no "create new session" RPC; the canonical send target is exposed via
+    // ChatDataSnapshot.ComposeTarget and the first SendMessageAsync against it
+    // implicitly materializes the session on the server.
     Task SendMessageAsync(string threadId, string message, CancellationToken cancellationToken = default);
     Task SendMessageAsync(string threadId, string message, CancellationToken cancellationToken, IReadOnlyList<OpenClaw.Shared.ChatAttachment>? attachments) =>
         SendMessageAsync(threadId, message, cancellationToken);

--- a/src/OpenClaw.Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/GatewayConnectionManager.cs
@@ -871,6 +871,8 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
                 return;
             }
 
+            var approvalGeneration = Interlocked.Read(ref _generation);
+            bool attemptedApprove = false;
             bool approved = false;
             try
             {
@@ -885,6 +887,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
                         _diagnostics.Record("node", $"Auto-approving node pairing (requestId={e.RequestId})");
                         try
                         {
+                            attemptedApprove = true;
                             approved = await operatorClient.NodePairApproveAsync(e.RequestId);
                             if (!approved)
                                 _diagnostics.Record("node", "Node auto-approval failed");
@@ -899,12 +902,12 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             }
             finally
             {
-                // Always record the requestId so we don't spin-loop attempting
-                // an approve that the gateway has refused (transient or
-                // policy). A second deliberate retry should come from a new
-                // user-initiated action, not from auto-replaying every
-                // re-broadcast of the same pending entry.
-                _lastAutoApprovedRequestId = e.RequestId;
+                // Only dedupe after an actual approve attempt. If the operator
+                // client was disconnected or lacked scope, the operator-side
+                // NodePairListUpdated path must still be able to approve this
+                // same requestId once the operator is ready.
+                if (attemptedApprove && Interlocked.Read(ref _generation) == approvalGeneration)
+                    _lastAutoApprovedRequestId = e.RequestId;
                 Interlocked.Exchange(ref _autoApproveInFlight, null);
             }
 
@@ -914,7 +917,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             {
                 _diagnostics.Record("node", "Node pairing auto-approved — reconnecting node");
                 await Task.Delay(1000); // brief delay for gateway to process
-                if (Interlocked.Read(ref _generation) == _generation) // re-check before side effect
+                if (Interlocked.Read(ref _generation) == approvalGeneration)
                     await StartNodeConnectionAsync();
             }
         }

--- a/src/OpenClaw.Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/GatewayConnectionManager.cs
@@ -857,17 +857,21 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             _transitionSemaphore.Release();
         }
 
-        // Auto-approve node pairing if operator has admin/pairing scope
+        // Auto-approve node pairing if operator has admin/pairing scope.
+        // _autoApproveInFlight is a CAS guard scoped to JUST the approve RPC —
+        // we release it before the reconnect delay so unrelated approvals
+        // (different requestIds) aren't starved while we wait for the gateway
+        // and node-reconnect handshake to settle (which can take 5–30s on
+        // first connect via WSL cold-start).
         if (e.Status == PairingStatus.Pending && !string.IsNullOrWhiteSpace(e.RequestId)
             && e.RequestId != _lastAutoApprovedRequestId)
         {
-            // Atomic guard: only one approval in-flight at a time.
-            // If another approval is already running, skip this one entirely.
             if (Interlocked.CompareExchange(ref _autoApproveInFlight, e.RequestId, null) != null)
             {
                 return;
             }
 
+            bool approved = false;
             try
             {
                 var operatorClient = _activeLifecycle?.DataClient;
@@ -881,18 +885,9 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
                         _diagnostics.Record("node", $"Auto-approving node pairing (requestId={e.RequestId})");
                         try
                         {
-                            var approved = await operatorClient.NodePairApproveAsync(e.RequestId);
-                            if (approved)
-                            {
-                                _lastAutoApprovedRequestId = e.RequestId;
-                                _diagnostics.Record("node", "Node pairing auto-approved — reconnecting node");
-                                await Task.Delay(1000); // brief delay for gateway to process
-                                await StartNodeConnectionAsync();
-                            }
-                            else
-                            {
+                            approved = await operatorClient.NodePairApproveAsync(e.RequestId);
+                            if (!approved)
                                 _diagnostics.Record("node", "Node auto-approval failed");
-                            }
                         }
                         catch (Exception ex)
                         {
@@ -904,7 +899,23 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             }
             finally
             {
+                // Always record the requestId so we don't spin-loop attempting
+                // an approve that the gateway has refused (transient or
+                // policy). A second deliberate retry should come from a new
+                // user-initiated action, not from auto-replaying every
+                // re-broadcast of the same pending entry.
+                _lastAutoApprovedRequestId = e.RequestId;
                 Interlocked.Exchange(ref _autoApproveInFlight, null);
+            }
+
+            // Post-approve reconnect happens OUTSIDE the CAS guard so it
+            // doesn't block unrelated approvals.
+            if (approved)
+            {
+                _diagnostics.Record("node", "Node pairing auto-approved — reconnecting node");
+                await Task.Delay(1000); // brief delay for gateway to process
+                if (Interlocked.Read(ref _generation) == _generation) // re-check before side effect
+                    await StartNodeConnectionAsync();
             }
         }
     }
@@ -930,6 +941,11 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         if (operatorClient?.IsConnectedToGateway != true) return;
         if (!OperatorScopeHelper.CanApproveDevices(operatorClient.GrantedOperatorScopes)) return;
 
+        // Track whether ANY approve succeeded so we know to schedule one
+        // reconnect at the end (rather than reconnecting per-entry, which
+        // would race with itself).
+        string? lastApprovedRequestId = null;
+
         foreach (var req in info.Pending)
         {
             if (Interlocked.Read(ref _generation) != gen) return;
@@ -937,40 +953,63 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             if (req.RequestId == _lastAutoApprovedRequestId) continue;
             if (!string.Equals(req.NodeId, ownNodeId, StringComparison.OrdinalIgnoreCase)) continue;
 
-            // Same atomic guard as the node-side flow to avoid concurrent
-            // approvals of the same requestId from racing event paths.
+            // CAS guard scoped to JUST the approve RPC. Release before the
+            // post-approve reconnect so unrelated approvals are not starved
+            // (e.g. another own-node pending with a different requestId in
+            // the same or next snapshot).
             if (Interlocked.CompareExchange(ref _autoApproveInFlight, req.RequestId, null) != null)
                 continue;
 
+            bool approved = false;
             try
             {
                 _diagnostics.Record("node", $"Operator-side auto-approving own node pairing (requestId={req.RequestId})");
-                var approved = await operatorClient.NodePairApproveAsync(req.RequestId);
-                if (approved)
+                try
                 {
-                    _lastAutoApprovedRequestId = req.RequestId;
-                    _diagnostics.Record("node", "Operator-side node pair approved — reconnecting node so caps propagate");
-                    await Task.Delay(1000);
-                    if (Interlocked.Read(ref _generation) == gen)
-                        await StartNodeConnectionAsync();
+                    approved = await operatorClient.NodePairApproveAsync(req.RequestId);
+                    if (!approved)
+                        _diagnostics.Record("node", "Operator-side node pair approval rejected by gateway");
                 }
-                else
+                catch (Exception ex)
                 {
-                    _diagnostics.Record("node", "Operator-side node pair approval rejected by gateway");
+                    _logger.Warn($"[ConnMgr] Operator-side node auto-approve failed: {ex.Message}");
+                    _diagnostics.Record("node", $"Operator-side auto-approve error: {ex.Message}");
                 }
-            }
-            catch (Exception ex)
-            {
-                _logger.Warn($"[ConnMgr] Operator-side node auto-approve failed: {ex.Message}");
-                _diagnostics.Record("node", $"Operator-side auto-approve error: {ex.Message}");
             }
             finally
             {
+                // Always record the requestId — both on success (prevent
+                // re-approving the same id after the gateway re-broadcasts)
+                // and on failure (prevent a spin loop on a rejected id).
+                // Re-check generation: if a reconnect happened during the
+                // await above, DisposeActiveClient already cleared
+                // _lastAutoApprovedRequestId for the new generation; we must
+                // not overwrite that null with a stale id from the old gen.
+                if (Interlocked.Read(ref _generation) == gen)
+                    _lastAutoApprovedRequestId = req.RequestId;
                 Interlocked.Exchange(ref _autoApproveInFlight, null);
             }
-            // Only attempt one approval per snapshot — gateway will push a
-            // fresh NodePairListUpdated after our approve lands.
-            break;
+
+            if (approved)
+            {
+                lastApprovedRequestId = req.RequestId;
+                // Continue scanning so a second own-pending in the same
+                // snapshot (e.g. stale requestId from prior session) also
+                // gets attempted — broken only by an explicit failure to
+                // approve, which we still try the next entry for.
+            }
+            // On failure/rejection, fall through to next own-pending entry
+            // rather than break — the gateway may not re-broadcast if the
+            // approve frame round-tripped and was rejected mid-flight.
+        }
+
+        // Single reconnect after the snapshot is fully processed.
+        if (lastApprovedRequestId is not null)
+        {
+            _diagnostics.Record("node", $"Operator-side approved {lastApprovedRequestId} — reconnecting node so caps propagate");
+            await Task.Delay(1000);
+            if (Interlocked.Read(ref _generation) == gen)
+                await StartNodeConnectionAsync();
         }
     }
 

--- a/src/OpenClaw.Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/GatewayConnectionManager.cs
@@ -239,6 +239,22 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
                 _gatewayNeedsV2Signature = true;
             };
 
+            // Operator-side auto-approve: the node-side WindowsNodeClient
+            // only sees its own pairing state. But when the gateway broadcasts
+            // a node.pair.requested event, the OPERATOR client gets a fresh
+            // NodePairListUpdated push. If our own node deviceId shows up in
+            // that pending list and we have approval scopes, approve it
+            // immediately — otherwise the user is stuck looking at a connected
+            // node with empty capabilities until they manually approve.
+            // This complements (not replaces) the node-side flow on line ~810
+            // which still handles the case where the node knows it's pending
+            // before any operator event lands.
+            lifecycle.DataClient.NodePairListUpdated += (s, info) =>
+            {
+                if (Interlocked.Read(ref _generation) != gen) return;
+                _ = TryOperatorAutoApproveOwnNodePairAsync(info, gen);
+            };
+
             // If we already know this gateway needs v2, tell the client upfront
             if (_gatewayNeedsV2Signature)
                 lifecycle.DataClient.UseV2Signature = true;
@@ -890,6 +906,71 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             {
                 Interlocked.Exchange(ref _autoApproveInFlight, null);
             }
+        }
+    }
+
+    /// <summary>
+    /// Operator-side auto-approve. When the gateway pushes
+    /// <see cref="OpenClawGatewayClient.NodePairListUpdated"/> and there is a
+    /// pending entry for our OWN node's deviceId, approve it. The node-side
+    /// auto-approve at <see cref="OnNodePairingStatusChanged"/> handles the
+    /// case where the node already knows it is pending; this method handles
+    /// the case where the node is device-paired (its WindowsNodeClient sees
+    /// itself as Paired) but its node-sub-pairing hasn't been approved yet —
+    /// the only signal for that case is the operator-side broadcast.
+    /// </summary>
+    private async Task TryOperatorAutoApproveOwnNodePairAsync(PairingListInfo? info, long gen)
+    {
+        if (info?.Pending == null || info.Pending.Count == 0) return;
+
+        var ownNodeId = _nodeConnector?.NodeDeviceId;
+        if (string.IsNullOrWhiteSpace(ownNodeId)) return;
+
+        var operatorClient = _activeLifecycle?.DataClient;
+        if (operatorClient?.IsConnectedToGateway != true) return;
+        if (!OperatorScopeHelper.CanApproveDevices(operatorClient.GrantedOperatorScopes)) return;
+
+        foreach (var req in info.Pending)
+        {
+            if (Interlocked.Read(ref _generation) != gen) return;
+            if (string.IsNullOrWhiteSpace(req.RequestId)) continue;
+            if (req.RequestId == _lastAutoApprovedRequestId) continue;
+            if (!string.Equals(req.NodeId, ownNodeId, StringComparison.OrdinalIgnoreCase)) continue;
+
+            // Same atomic guard as the node-side flow to avoid concurrent
+            // approvals of the same requestId from racing event paths.
+            if (Interlocked.CompareExchange(ref _autoApproveInFlight, req.RequestId, null) != null)
+                continue;
+
+            try
+            {
+                _diagnostics.Record("node", $"Operator-side auto-approving own node pairing (requestId={req.RequestId})");
+                var approved = await operatorClient.NodePairApproveAsync(req.RequestId);
+                if (approved)
+                {
+                    _lastAutoApprovedRequestId = req.RequestId;
+                    _diagnostics.Record("node", "Operator-side node pair approved — reconnecting node so caps propagate");
+                    await Task.Delay(1000);
+                    if (Interlocked.Read(ref _generation) == gen)
+                        await StartNodeConnectionAsync();
+                }
+                else
+                {
+                    _diagnostics.Record("node", "Operator-side node pair approval rejected by gateway");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn($"[ConnMgr] Operator-side node auto-approve failed: {ex.Message}");
+                _diagnostics.Record("node", $"Operator-side auto-approve error: {ex.Message}");
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _autoApproveInFlight, null);
+            }
+            // Only attempt one approval per snapshot — gateway will push a
+            // fresh NodePairListUpdated after our approve lands.
+            break;
         }
     }
 

--- a/src/OpenClaw.Shared/IOperatorGatewayClient.cs
+++ b/src/OpenClaw.Shared/IOperatorGatewayClient.cs
@@ -41,6 +41,10 @@ public interface IOperatorGatewayClient
     string? OperatorDeviceId { get; }
     IReadOnlyList<string> GrantedOperatorScopes { get; }
     bool IsConnectedToGateway { get; }
+    /// <summary>Canonical main session key resolved from hello-ok; <c>null</c> until handshake.</summary>
+    string? MainSessionKey { get; }
+    /// <summary>True once the hello-ok handshake has been processed.</summary>
+    bool HasHandshakeSnapshot { get; }
 
     // ─── Connection events (from WebSocketClientBase) ───
     event EventHandler<ConnectionStatus>? StatusChanged;

--- a/src/OpenClaw.Shared/OpenClaw.Shared.csproj
+++ b/src/OpenClaw.Shared/OpenClaw.Shared.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="OpenClaw.Shared.Tests" />
+    <InternalsVisibleTo Include="OpenClaw.Connection.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -44,7 +44,31 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
     private readonly object _sessionsLock = new();
     private readonly DeviceIdentity _deviceIdentity;
     private readonly string _currentGatewayUrl;
-    private string _mainSessionKey = "main";
+    private string? _mainSessionKey;
+    private bool _hasHandshakeSnapshot;
+
+    /// <summary>
+    /// The gateway's canonical main session key as published in the hello-ok
+    /// snapshot (preferring the canonical <c>sessionDefaults.mainSessionKey</c>
+    /// over the legacy alias <c>mainKey</c>). <c>null</c> until handshake
+    /// completes or after a disconnect. Callers should pass this exact value
+    /// (or <c>null</c>) to <see cref="SendChatMessageForRunAsync"/>; never
+    /// substitute a literal like <c>"main"</c>, which can drift from the
+    /// canonical key the gateway echoes back in chat events.
+    /// </summary>
+    /// <remarks>
+    /// Read via <see cref="Volatile.Read{T}(ref T)"/> because the field is
+    /// written from the gateway WebSocket thread and read from the UI thread
+    /// (through <see cref="OpenClawChatDataProvider"/>).
+    /// </remarks>
+    public string? MainSessionKey => Volatile.Read(ref _mainSessionKey);
+
+    /// <summary>
+    /// True once the hello-ok handshake has been processed (i.e. session
+    /// defaults are known). Reset to false on disconnect. Surfaces to the UI
+    /// as <see cref="OpenClaw.Chat.ChatComposeTarget.IsReady"/>.
+    /// </summary>
+    public bool HasHandshakeSnapshot => Volatile.Read(ref _hasHandshakeSnapshot);
     private string? _operatorDeviceId;
     private string[] _grantedOperatorScopes = Array.Empty<string>();
     private string _connectAuthToken;
@@ -141,6 +165,13 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
     protected override void OnDisconnected()
     {
         ClearPendingRequests();
+        // Invalidate the handshake snapshot — the next hello-ok must
+        // re-establish the canonical session key, scopes, etc. Without this,
+        // a reconnect-after-server-restart could leave the tray sending to a
+        // stale canonical key that the new server doesn't recognize, and
+        // HasHandshakeSnapshot would lie about the offline state to callers.
+        Volatile.Write(ref _mainSessionKey, null);
+        Volatile.Write(ref _hasHandshakeSnapshot, false);
     }
 
     protected override void OnDisposing()
@@ -273,9 +304,8 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
         if (string.IsNullOrWhiteSpace(message) && !hasAttachments)
             throw new ArgumentException("Message or attachment is required", nameof(message));
 
-        var effectiveSessionKey = string.IsNullOrWhiteSpace(sessionKey)
-            ? _mainSessionKey
-            : sessionKey.Trim();
+        var effectiveSessionKey = ResolveEffectiveSessionKey(
+            sessionKey, Volatile.Read(ref _mainSessionKey), "chat.send");
 
         var requestId = Guid.NewGuid().ToString();
         var completion = new TaskCompletionSource<ChatSendResult>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -333,9 +363,8 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
     /// </summary>
     public async Task<ChatHistoryInfo> RequestChatHistoryAsync(string? sessionKey = null, int timeoutMs = 15000)
     {
-        var effectiveSessionKey = string.IsNullOrWhiteSpace(sessionKey)
-            ? _mainSessionKey
-            : sessionKey.Trim();
+        var effectiveSessionKey = ResolveEffectiveSessionKey(
+            sessionKey, Volatile.Read(ref _mainSessionKey), "chat.history");
 
         var payload = await SendWizardRequestAsync(
             "chat.history",
@@ -354,9 +383,8 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
     {
         if (string.IsNullOrWhiteSpace(runId))
             throw new ArgumentException("runId is required", nameof(runId));
-        var effectiveSessionKey = string.IsNullOrWhiteSpace(sessionKey)
-            ? _mainSessionKey
-            : sessionKey.Trim();
+        var effectiveSessionKey = ResolveEffectiveSessionKey(
+            sessionKey, Volatile.Read(ref _mainSessionKey), "chat.abort");
         await SendWizardRequestAsync("chat.abort", new { runId, sessionKey = effectiveSessionKey }, timeoutMs);
     }
 
@@ -1498,8 +1526,13 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
             ResetReconnectAttempts();
             _operatorDeviceId = TryGetHandshakeDeviceId(payload);
             _grantedOperatorScopes = TryGetHandshakeScopes(payload);
-            _mainSessionKey = TryGetHandshakeMainSessionKey(payload) ?? "main";
-            _logger.Info($"[HANDSHAKE] deviceId={_operatorDeviceId}, scopes=[{string.Join(", ", _grantedOperatorScopes)}], mainSession={_mainSessionKey}");
+            // Write the key first, then publish the readiness flag. Pair with
+            // Volatile.Read on the public getters so a reader observing
+            // HasHandshakeSnapshot==true is guaranteed to see the populated
+            // MainSessionKey (release/acquire ordering).
+            Volatile.Write(ref _mainSessionKey, TryGetHandshakeMainSessionKey(payload));
+            Volatile.Write(ref _hasHandshakeSnapshot, true);
+            _logger.Info($"[HANDSHAKE] deviceId={_operatorDeviceId}, scopes=[{string.Join(", ", _grantedOperatorScopes)}], mainSession={_mainSessionKey ?? "(unset)"}");
             PublishGatewaySelf(GatewaySelfInfo.FromHelloOk(payload));
             if (_bootstrapPairAsNode)
             {
@@ -1537,7 +1570,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
             {
                 _logger.Info($"Granted operator scopes: {string.Join(", ", _grantedOperatorScopes)}");
             }
-            _logger.Info($"Main session key: {_mainSessionKey}");
+            _logger.Info($"Main session key: {_mainSessionKey ?? "(unset)"}");
 
             // Extract presence from snapshot
             TryParsePresence(payload);
@@ -2055,6 +2088,31 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
         return buffer[..count];
     }
 
+    /// <summary>
+    /// Resolves the effective <c>sessionKey</c> for a chat-related RPC,
+    /// preferring a non-empty caller-supplied value over the handshake
+    /// <paramref name="resolvedMainSessionKey"/>. Throws
+    /// <see cref="InvalidOperationException"/> if neither is usable —
+    /// callers MUST NOT fall back to a literal like <c>"main"</c>, which
+    /// can drift from the canonical key the gateway echoes back.
+    /// </summary>
+    /// <remarks>
+    /// Extracted as an internal static so unit tests can exercise the
+    /// pre-handshake throw without needing a live WebSocket — see
+    /// <c>OpenClawGatewayClientSessionKeyTests</c>.
+    /// </remarks>
+    internal static string ResolveEffectiveSessionKey(
+        string? callerSessionKey, string? resolvedMainSessionKey, string operationName)
+    {
+        var effective = string.IsNullOrWhiteSpace(callerSessionKey)
+            ? resolvedMainSessionKey
+            : callerSessionKey.Trim();
+        if (string.IsNullOrWhiteSpace(effective))
+            throw new InvalidOperationException(
+                $"{operationName} requires a sessionKey, but the gateway handshake has not resolved one yet.");
+        return effective;
+    }
+
     private static string? TryGetHandshakeMainSessionKey(JsonElement payload)
     {
         if (!payload.TryGetProperty("snapshot", out var snapshot) || snapshot.ValueKind != JsonValueKind.Object)
@@ -2067,13 +2125,29 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
             return null;
         }
 
-        if (!sessionDefaults.TryGetProperty("mainKey", out var mainKey) || mainKey.ValueKind != JsonValueKind.String)
+        // Prefer the canonical "mainSessionKey" (e.g. "agent:main:main") over
+        // the legacy alias "mainKey" (e.g. "main"). The gateway accepts both
+        // for chat.send routing, but the chat/session events it emits back
+        // are keyed by the canonical form. Using the alias here would cause
+        // the tray's local timeline (keyed by the alias) to diverge from the
+        // gateway's echo (keyed by canonical), stranding optimistic state.
+        if (sessionDefaults.TryGetProperty("mainSessionKey", out var canonical) &&
+            canonical.ValueKind == JsonValueKind.String)
         {
-            return null;
+            var canonicalValue = canonical.GetString();
+            if (!string.IsNullOrWhiteSpace(canonicalValue))
+                return canonicalValue;
         }
 
-        var value = mainKey.GetString();
-        return string.IsNullOrWhiteSpace(value) ? null : value;
+        if (sessionDefaults.TryGetProperty("mainKey", out var mainKey) &&
+            mainKey.ValueKind == JsonValueKind.String)
+        {
+            var value = mainKey.GetString();
+            if (!string.IsNullOrWhiteSpace(value))
+                return value;
+        }
+
+        return null;
     }
 
     private static string? TryGetHandshakeDeviceToken(JsonElement payload)
@@ -2365,11 +2439,17 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
         }
         catch { }
 
-        // sessionKey is inside payload, not root
-        var sessionKey = "unknown";
+        // sessionKey is inside payload, not root. We deliberately do NOT
+        // substitute a fallback like "unknown" or "main" — empty must
+        // propagate so the provider can drop the event and surface the
+        // protocol gap, rather than silently routing into a synthetic bucket.
+        var sessionKey = "";
         if (payload.TryGetProperty("sessionKey", out var sk))
-            sessionKey = sk.GetString() ?? "unknown";
-        var isMain = sessionKey == "main" || sessionKey.Contains(":main:");
+            sessionKey = sk.GetString() ?? "";
+        if (string.IsNullOrEmpty(sessionKey))
+            _logger.Warn("[GatewayClient] Agent event missing sessionKey; will be dropped downstream.");
+        var isMain = !string.IsNullOrEmpty(sessionKey)
+            && (sessionKey == "main" || sessionKey.Contains(":main:"));
 
         // Emit raw agent event (cloned for thread safety)
         try
@@ -2515,10 +2595,15 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
         if (!root.TryGetProperty("payload", out var payload)) return;
         EmitRawChatEvent(payload);
 
-        // Extract sessionKey for the timeline-driving event.
-        var sessionKey = "main";
+        // Extract sessionKey for the timeline-driving event. As with agent
+        // events, do NOT substitute a fallback like "main" — empty must
+        // propagate so the provider's empty-key drop policy can surface the
+        // protocol gap instead of silently routing into a synthetic bucket.
+        var sessionKey = "";
         if (payload.TryGetProperty("sessionKey", out var skProp))
-            sessionKey = skProp.GetString() ?? "main";
+            sessionKey = skProp.GetString() ?? "";
+        if (string.IsNullOrEmpty(sessionKey))
+            _logger.Warn("[GatewayClient] Chat event missing sessionKey; will be dropped downstream.");
 
         // Best-effort usage extraction — gateway emits this only on terminal
         // (state="final") events in practice; we still read it defensively

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -207,6 +207,14 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
     public event EventHandler<JsonElement>? AgentsListUpdated;
     public event EventHandler<JsonElement>? AgentFilesListUpdated;
     public event EventHandler<JsonElement>? AgentFileContentUpdated;
+
+    // ─── Test-only event raisers ───
+    // Exposed via [InternalsVisibleTo("OpenClaw.Connection.Tests")] so unit
+    // tests can drive event-handler code paths without a live WebSocket.
+    // Avoids the previous reflection-on-private-backing-field approach which
+    // silently breaks the moment the events grow explicit add/remove blocks.
+    internal void RaiseNodePairListUpdatedForTests(PairingListInfo info)
+        => NodePairListUpdated?.Invoke(this, info);
     /// <summary>
     /// Raised when the gateway broadcasts a "chat" event (assistant or user
     /// message echo). Use this to drive a chat-UI timeline; the existing

--- a/src/OpenClaw.Tray.WinUI/Chat/Explorations/FakeChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/Explorations/FakeChatDataProvider.cs
@@ -87,7 +87,8 @@ public sealed class FakeChatDataProvider : IChatDataProvider
             Timelines: timelines,
             DefaultThreadId: ThreadId,
             ConnectionStatus: "connected",
-            AvailableModels: Models);
+            AvailableModels: Models,
+            ComposeTarget: new ChatComposeTarget(ThreadId, true));
     }
 
     private void RaiseChanged() =>
@@ -95,9 +96,6 @@ public sealed class FakeChatDataProvider : IChatDataProvider
 
     public Task<ChatDataSnapshot> LoadAsync(CancellationToken cancellationToken = default)
         => Task.FromResult(BuildSnapshot());
-
-    public Task<ChatThread> CreateThreadAsync(string? initialMessage = null, CancellationToken cancellationToken = default)
-        => Task.FromResult(new ChatThread { Id = ThreadId, Title = "Exploration preview" });
 
     public Task SendMessageAsync(string threadId, string message, CancellationToken cancellationToken = default)
     {

--- a/src/OpenClaw.Tray.WinUI/Chat/IChatGatewayBridge.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/IChatGatewayBridge.cs
@@ -11,6 +11,10 @@ public interface IChatGatewayBridge : IDisposable
 {
     bool IsConnected { get; }
     ConnectionStatus CurrentStatus { get; }
+    /// <summary>Canonical main session key resolved by the gateway handshake; <c>null</c> until ready.</summary>
+    string? MainSessionKey { get; }
+    /// <summary>True once the gateway handshake has resolved session defaults.</summary>
+    bool HasHandshakeSnapshot { get; }
     SessionInfo[] GetSessionList();
     ModelsListInfo? GetCurrentModelsList();
 
@@ -75,6 +79,8 @@ public sealed class GatewayClientChatBridge : IChatGatewayBridge
 
     public bool IsConnected => _client.IsConnectedToGateway;
     public ConnectionStatus CurrentStatus => _currentStatus;
+    public string? MainSessionKey => _client.MainSessionKey;
+    public bool HasHandshakeSnapshot => _client.HasHandshakeSnapshot;
     public SessionInfo[] GetSessionList() => _client.GetSessionList();
     public ModelsListInfo? GetCurrentModelsList() => _currentModels;
 

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -134,28 +134,6 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         }
     }
 
-    public Task<ChatThread> CreateThreadAsync(string? initialMessage = null, CancellationToken cancellationToken = default)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        // The gateway has no "create new chat session" RPC today; the operator
-        // is always wired to the gateway's main session. Return that thread
-        // and (optionally) send the initial message into it.
-        ChatThread thread;
-        lock (_gate)
-        {
-            EnsureTimelinesForSessionsLocked();
-            thread = ResolveMainOrFirstThreadLocked()
-                     ?? new ChatThread { Id = "main", Title = "Main session", Status = ChatThreadStatus.Running };
-        }
-
-        if (!string.IsNullOrWhiteSpace(initialMessage))
-        {
-            return SendMessageAsync(thread.Id, initialMessage!, cancellationToken)
-                .ContinueWith(_ => thread, cancellationToken, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
-        }
-        return Task.FromResult(thread);
-    }
-
     // Explicit interface implementation (no attachments).
     Task IChatDataProvider.SendMessageAsync(string threadId, string message, CancellationToken cancellationToken)
         => SendMessageAsync(threadId, message, cancellationToken, attachments: null);
@@ -854,9 +832,21 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     {
         if (message is null) return;
 
+        // The gateway must include a canonical sessionKey on every chat event.
+        // If it doesn't, that's a protocol bug — drop the event rather than
+        // routing it to a literal "main" bucket that can't possibly match the
+        // optimistic timeline keyed by the canonical key. Surfacing the drop
+        // here makes future protocol gaps visible instead of silently merging
+        // into a synthetic key.
+        if (string.IsNullOrEmpty(message.SessionKey))
+        {
+            Logger.Warn($"[ChatProvider] Dropping chat message with empty sessionKey (role={message.Role})");
+            return;
+        }
+
         // Suppress chat messages for threads that were aborted by the user.
         // Chat messages don't carry a runId, so we use thread-level suppression.
-        var msgThreadId = string.IsNullOrEmpty(message.SessionKey) ? "main" : message.SessionKey;
+        var msgThreadId = message.SessionKey;
         lock (_gate)
         {
             if (_abortedThreads.Contains(msgThreadId))
@@ -880,7 +870,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             if (LooksLikeSystemControlNote(message.Text))
             {
                 if (string.IsNullOrEmpty(message.Text)) return;
-                var sysThread = string.IsNullOrEmpty(message.SessionKey) ? "main" : message.SessionKey;
+                var sysThread = message.SessionKey;
                 ChatEntryMetadata? sysMeta;
                 lock (_gate) { sysMeta = BuildLiveMetaLocked(sysThread, message.Ts); }
                 ApplyEventAndPublish(sysThread,
@@ -896,7 +886,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         if (roleLower == "toolresult" || roleLower == "tool_result")
         {
             if (string.IsNullOrEmpty(message.Text)) return;
-            var trThread = string.IsNullOrEmpty(message.SessionKey) ? "main" : message.SessionKey;
+            var trThread = message.SessionKey;
             ChatEntryMetadata? trMeta;
             lock (_gate) { trMeta = BuildLiveMetaLocked(trThread, message.Ts); }
             var capped = TruncateForChatEntry(message.Text);
@@ -911,7 +901,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         if (string.IsNullOrEmpty(message.Text))
             return;
 
-        var threadId = string.IsNullOrEmpty(message.SessionKey) ? "main" : message.SessionKey;
+        var threadId = message.SessionKey;
         ChatEntryMetadata? meta;
         lock (_gate)
         {
@@ -953,7 +943,15 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     private void OnAgentEventReceived(object? sender, AgentEventInfo evt)
     {
         if (evt is null) return;
-        var threadId = string.IsNullOrEmpty(evt.SessionKey) ? "main" : evt.SessionKey;
+        // As with chat events, every agent event must carry a canonical
+        // sessionKey. Drop the event rather than routing to "main" if missing —
+        // see the rationale in OnChatMessageReceived.
+        if (string.IsNullOrEmpty(evt.SessionKey))
+        {
+            Logger.Warn($"[ChatProvider] Dropping agent event with empty sessionKey (stream={evt.Stream})");
+            return;
+        }
+        var threadId = evt.SessionKey;
 
         // Always update run tracking first (state maintenance must not be skipped).
         UpdateActiveRunId(evt, threadId);
@@ -1762,23 +1760,51 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         }
     }
 
-    private ChatThread? ResolveMainOrFirstThreadLocked()
-    {
-        if (_sessions.Length == 0) return null;
-        var main = Array.Find(_sessions, s => s.IsMain);
-        return ToThread(main ?? _sessions[0]);
-    }
-
     private ChatDataSnapshot BuildSnapshotLocked()
     {
-        var threads = new ChatThread[_sessions.Length];
+        // Build threads from the gateway's authoritative session list.
+        // No synthesis based on local timeline keys — the UI's compose target
+        // is exposed separately via ChatComposeTarget so the renderer can show
+        // a usable composer even before the first session materializes server-
+        // side (e.g. fresh install with zero sessions).
+        var threadList = new List<ChatThread>(_sessions.Length + 1);
         for (int i = 0; i < _sessions.Length; i++)
-            threads[i] = ToThread(_sessions[i]);
+            threadList.Add(ToThread(_sessions[i]));
+
+        var composeKey = _bridge.MainSessionKey;
+        var composeReady = _bridge.HasHandshakeSnapshot
+            && !string.IsNullOrWhiteSpace(composeKey)
+            && _status == ConnectionStatus.Connected;
+
+        // If the compose target hasn't materialized as a real session yet but
+        // already has an optimistic timeline (because the user sent a message
+        // before the gateway echoed back sessions.list), surface a synthetic
+        // thread record so the UI can render the optimistic bubble without
+        // falling back into the "no thread selected" zero state. The synthetic
+        // thread's Id is the canonical compose key, so when SessionsUpdated
+        // eventually arrives with the same key it replaces the synthetic in
+        // place — no migration, no re-keying.
+        if (composeReady
+            && composeKey is { } ck
+            && _timelines.TryGetValue(ck, out var pendingTl)
+            && pendingTl.Entries.Count > 0
+            && !_sessions.Any(s => string.Equals(s.Key, ck, StringComparison.Ordinal)))
+        {
+            threadList.Add(new ChatThread
+            {
+                Id = ck,
+                Title = "Main session",
+                Status = ChatThreadStatus.Running,
+                Activity = ChatActivity.Idle,
+            });
+        }
+
+        var threads = threadList.ToArray();
 
         // Snapshot a defensive copy of the timeline dict.
         var timelinesCopy = new Dictionary<string, ChatTimelineState>(_timelines);
 
-        var defaultThreadId = ResolveDefaultThreadIdLocked(threads);
+        var defaultThreadId = ResolveDefaultThreadIdLocked();
 
         var connectionLabel = _status switch
         {
@@ -1789,32 +1815,47 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             _ => _status.ToString()
         };
 
+        var composeTarget = composeReady
+            ? new ChatComposeTarget(composeKey, true)
+            : ChatComposeTarget.NotReady;
+
         return new ChatDataSnapshot(
             Threads: threads,
             Timelines: timelinesCopy,
             DefaultThreadId: defaultThreadId,
             ConnectionStatus: connectionLabel,
-            AvailableModels: _availableModels);
+            AvailableModels: _availableModels,
+            ComposeTarget: composeTarget);
     }
 
-    private static string? ResolveDefaultThreadIdLocked(ChatThread[] threads)
+    private string? ResolveDefaultThreadIdLocked()
     {
-        if (threads.Length == 0) return null;
-        for (int i = 0; i < threads.Length; i++)
+        // Prefer the gateway's canonical main session (IsMain on SessionInfo)
+        // so we never have to guess from a literal like "main". Only fall back
+        // to the compose target (pre-materialization) or the first available
+        // session when no main is present.
+        for (int i = 0; i < _sessions.Length; i++)
         {
-            // ChatThread doesn't carry the IsMain flag explicitly, so detect it
-            // by a heuristic: the upstream Title we set for main sessions.
-            if (string.Equals(threads[i].Id, "main", StringComparison.OrdinalIgnoreCase))
-                return threads[i].Id;
+            var s = _sessions[i];
+            if (s.IsMain && !string.IsNullOrEmpty(s.Key))
+                return s.Key;
         }
-        return threads[0].Id;
+        if (_bridge.HasHandshakeSnapshot
+            && _bridge.MainSessionKey is { } mk
+            && !string.IsNullOrWhiteSpace(mk))
+            return mk;
+        if (_sessions.Length > 0 && !string.IsNullOrEmpty(_sessions[0].Key))
+            return _sessions[0].Key;
+        return null;
     }
 
     private static ChatThread ToThread(SessionInfo s)
     {
         return new ChatThread
         {
-            Id = string.IsNullOrEmpty(s.Key) ? "main" : s.Key,
+            // SessionInfo.Key is the canonical gateway session key; we trust
+            // it as-is rather than substituting a literal like "main".
+            Id = s.Key ?? string.Empty,
             Title = !string.IsNullOrWhiteSpace(s.DisplayName)
                 ? s.DisplayName!
                 : (s.IsMain ? "Main session" : s.ShortKey),

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
@@ -104,6 +104,11 @@ public sealed class OpenClawChatRoot : Component
         var speakerMuted = UseState(_initialMuted, threadSafe: true);
         var voiceTranscript = UseState<string?>(null, threadSafe: true);
         var voiceAudioLevel = UseState(0f, threadSafe: true);
+        // Guards a duplicate suggestion-button click before the snapshot
+        // reflects the optimistic local user entry (which then ordinarily
+        // hides the zero-state buttons via the isEmptyConversation check).
+        // Cleared automatically when the next snapshot arrives.
+        var firstSendInFlight = UseState(false, threadSafe: true);
 
         // Wire the OnFileAttached callback so the host window/page can set the
         // pending attachment after the file picker completes.
@@ -147,6 +152,19 @@ public sealed class OpenClawChatRoot : Component
             EventHandler<ChatDataChangedEventArgs> onChanged = (_, e) =>
             {
                 setSnapshot(e.Snapshot);
+                // The debounce must clear only when the new snapshot is evidence
+                // that the send round-trip has progressed for the compose key —
+                // either the optimistic user entry landed (Timelines has it) or
+                // an error event ended the turn. Clearing on every snapshot
+                // (presence, models, status, channel health …) would re-enable
+                // the suggestion buttons before the optimistic entry rendered
+                // and let a double-click duplicate-send.
+                if (e.Snapshot.ComposeTarget.SessionKey is { } ck &&
+                    e.Snapshot.Timelines.TryGetValue(ck, out var ctl) &&
+                    ctl.Entries.Any(x => x.Kind == ChatTimelineItemKind.User))
+                {
+                    firstSendInFlight.Set(false);
+                }
                 if (selectedIdRef.Current is null && e.Snapshot.DefaultThreadId is { } d)
                 {
                     setSelected(d);
@@ -199,14 +217,46 @@ public sealed class OpenClawChatRoot : Component
             ? Array.Find(snapshot.Threads, t => t.Id == id)
             : null;
 
-        // Lazy-load history the first time a thread is selected.
+        // If no real session is selected yet but the provider exposes a ready
+        // compose target (gateway connected + handshake snapshot resolved),
+        // synthesize a transient compose-only ChatThread so the composer is
+        // visible from the welcome screen. The synthetic thread's Id is the
+        // canonical compose key — so when the gateway materializes the session
+        // and SessionsUpdated arrives, Threads contains a real entry with the
+        // same Id and `selectedThread` resolves to it on the next render
+        // without any re-keying or migration.
+        ChatThread? composeOnlyThread = null;
+        if (selectedThread is null
+            && snapshot.ComposeTarget.IsReady
+            && snapshot.ComposeTarget.SessionKey is { } composeKey)
+        {
+            composeOnlyThread = new ChatThread
+            {
+                Id = composeKey,
+                Title = "Main session",
+                Status = ChatThreadStatus.Running,
+                Activity = ChatActivity.Idle,
+            };
+        }
+
+        // For everything below, `effectiveThread` is the thread the UI should
+        // render against. `selectedThread` stays null when nothing materialized
+        // exists yet so the zero-state still shows; `composeOnlyThread` exists
+        // so the composer can be wired up.
+        var effectiveThread = selectedThread ?? composeOnlyThread;
+
+        // Lazy-load history the first time a real (materialized) thread is
+        // selected. Don't fire for the compose-only synthetic thread — it
+        // doesn't exist server-side yet, so chat.history would 404.
         if (selectedThread is not null && _provider is OpenClawChatDataProvider native)
         {
             var threadId = selectedThread.Id;
             RunFireAndForget(ct => native.LoadHistoryAsync(threadId, force: false, ct));
         }
 
-        var timeline = selectedThread is not null && snapshot.Timelines.TryGetValue(selectedThread.Id, out var tl)
+        // Pull the timeline from the effective thread (so optimistic entries
+        // from a pre-materialization first send are visible immediately).
+        var timeline = effectiveThread is not null && snapshot.Timelines.TryGetValue(effectiveThread.Id, out var tl)
             ? tl
             : ChatTimelineState.Initial();
 
@@ -227,7 +277,7 @@ public sealed class OpenClawChatRoot : Component
         // Per-entry metadata for the OpenClaw timeline footer (sender · time · model).
         // Keep the same dictionary instance across composer-only renders so the
         // timeline can skip re-rendering while the user types.
-        var entryMeta = selectedThread is null ? null : entryMetaSnapshot;
+        var entryMeta = effectiveThread is null ? null : entryMetaSnapshot;
 
         // The gateway's default agent identity is "Field" (matches the web UI footer),
         // but for the WinUI tray we surface a generic "Assistant" label so the
@@ -313,21 +363,25 @@ public sealed class OpenClawChatRoot : Component
             && !showThinking
             && pendingPermissionOverride is null;
 
-        Element body = bodyOverride ?? (selectedThread is null || isEmptyConversation
+        Element body = bodyOverride ?? (effectiveThread is null || isEmptyConversation
             ? RenderZeroState(suggestion =>
                 {
-                    if (selectedThread is { } t)
+                    if (firstSendInFlight.Value) return; // debounce double-click
+                    if (effectiveThread is { } t)
+                    {
+                        firstSendInFlight.Set(true);
                         OnSend(t.Id, suggestion, null);
-                })
+                    }
+                }, suggestionsDisabled: firstSendInFlight.Value)
             : Component<OpenClawChatTimeline, OpenClawChatTimelineProps>(new(
-                SessionId: selectedThread.Id,
+                SessionId: effectiveThread.Id,
                 Entries: entries,
                 HasMoreHistory: false,
                 OnLoadMoreHistory: null,
                 EntryMetadata: entryMeta,
                 UserSenderLabel: "OpenClaw Windows Tray",
                 AssistantSenderLabel: assistantSenderLabel,
-                DefaultModel: selectedThread.Model,
+                DefaultModel: effectiveThread.Model,
                 ShowThinkingIndicator: showThinking,
                 OnReadAloud: _onReadAloud is not null
                     ? (text => _onReadAloud(text))
@@ -344,23 +398,23 @@ public sealed class OpenClawChatRoot : Component
             .Distinct(StringComparer.Ordinal)
             .ToArray();
 
-        Element composer = (selectedThread is not null && !suppressComposer)
+        Element composer = (effectiveThread is not null && !suppressComposer)
             ? Component<OpenClawComposer, OpenClawComposerProps>(new(
                 ConnectionState: connState,
                 TurnActive: turnActiveOverride,
                 PendingPermission: pendingPermissionOverride,
-                ChannelLabel: selectedThread.Title ?? "main",
+                ChannelLabel: effectiveThread.Title ?? "Main session",
                 AvailableChannels: channelTitles,
                 AvailableModels: snapshot.AvailableModels,
-                CurrentModel: selectedThread.Model,
-                CurrentThinkingLevel: selectedThread.ThinkingLevel,
+                CurrentModel: effectiveThread.Model,
+                CurrentThinkingLevel: effectiveThread.ThinkingLevel,
                 OnSend: (msg, att) =>
                 {
                     pendingAttachment.Set(null);
-                    OnSend(selectedThread.Id, msg, att);
+                    OnSend(effectiveThread.Id, msg, att);
                 },
-                OnStop: () => OnStop(selectedThread.Id),
-                OnPermissionResponse: (rid, allow) => OnPermission(selectedThread.Id, rid, allow),
+                OnStop: () => OnStop(effectiveThread.Id),
+                OnPermissionResponse: (rid, allow) => OnPermission(effectiveThread.Id, rid, allow),
                 OnChannelChanged: title =>
                 {
                     var match = Array.Find(snapshot.Threads, t => t.Title == title);
@@ -370,9 +424,9 @@ public sealed class OpenClawChatRoot : Component
                         selectedIdRef.Current = match.Id;
                     }
                 },
-                OnModelChanged: model => RunFireAndForget(ct => _provider.SetModelAsync(selectedThread.Id, model, ct)),
-                OnThinkingLevelChanged: level => RunFireAndForget(ct => _provider.SetThinkingLevelAsync(selectedThread.Id, level, ct)),
-                OnPermissionsChanged: allowAll => RunFireAndForget(ct => _provider.SetPermissionModeAsync(selectedThread.Id, allowAll, ct)),
+                OnModelChanged: model => RunFireAndForget(ct => _provider.SetModelAsync(effectiveThread.Id, model, ct)),
+                OnThinkingLevelChanged: level => RunFireAndForget(ct => _provider.SetThinkingLevelAsync(effectiveThread.Id, level, ct)),
+                OnPermissionsChanged: allowAll => RunFireAndForget(ct => _provider.SetPermissionModeAsync(effectiveThread.Id, allowAll, ct)),
                 OnVoiceRequest: _onVoiceRequest,
                 OnAttachClick: _onAttachClick,
                 PendingAttachment: pendingAttachment.Value,
@@ -422,16 +476,16 @@ public sealed class OpenClawChatRoot : Component
     /// is responsible for routing the suggestion text into a send (typically
     /// via the active thread's OnSend handler).
     /// </summary>
-    private static Element RenderZeroState(Action<string> onSuggestionPicked)
+    private static Element RenderZeroState(Action<string> onSuggestionPicked, bool suggestionsDisabled = false)
     {
         var welcomeTitle = LocalizedOrDefault("Chat_ZeroState_WelcomeTitle", "Welcome to OpenClaw");
         var welcomeSubtitle = LocalizedOrDefault("Chat_ZeroState_WelcomeSubtitle", "How can I help you today?");
 
         var suggestions = new[]
         {
-            "Summarize the last commit on this branch",
-            "Explain what this repo does",
-            "Show me how to add a new chat exploration option",
+            "Say hi 👋",
+            "What can you do?",
+            "Give me a quick tour of OpenClaw",
         };
 
         Element SuggestionButton(string text) =>
@@ -442,6 +496,7 @@ public sealed class OpenClawChatRoot : Component
                     b.HorizontalContentAlignment = HorizontalAlignment.Left;
                     b.Padding = new Thickness(12, 10, 12, 10);
                     b.CornerRadius = new CornerRadius(8);
+                    b.IsEnabled = !suggestionsDisabled;
                 });
 
         return Border(

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -137,8 +137,10 @@ public sealed partial class ConnectionPage : Page
         {
             _ = Task.Run(async () =>
             {
-                try { await client.RequestNodePairListAsync(); } catch { /* surface via diag */ }
-                try { await client.RequestDevicePairListAsync(); } catch { /* surface via diag */ }
+                try { await client.RequestNodePairListAsync(); }
+                catch (Exception ex) { Services.Logger.Warn($"[ConnectionPage] Eager node-pair refresh failed: {ex.Message}"); }
+                try { await client.RequestDevicePairListAsync(); }
+                catch (Exception ex) { Services.Logger.Warn($"[ConnectionPage] Eager device-pair refresh failed: {ex.Message}"); }
             });
         }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -128,6 +128,27 @@ public sealed partial class ConnectionPage : Page
         // active row as "disconnected" for one frame before the snapshot pass
         // flips it to "Connected".
         RefreshFromSnapshot(_connectionManager?.CurrentSnapshot ?? GatewayConnectionSnapshot.Idle);
+
+        // Eagerly refresh pending-pairing lists so the banner reflects truth
+        // the moment the user navigates here (rather than waiting for the
+        // gateway to push the next node.pair.requested broadcast). Both calls
+        // are tracked + idempotent on the gateway side.
+        if (CurrentApp.GatewayClient is { IsConnectedToGateway: true } client)
+        {
+            _ = Task.Run(async () =>
+            {
+                try { await client.RequestNodePairListAsync(); } catch { /* surface via diag */ }
+                try { await client.RequestDevicePairListAsync(); } catch { /* surface via diag */ }
+            });
+        }
+
+        // Push any already-resolved pending lists into the page immediately
+        // — the AppState may have been populated on a prior visit and the
+        // PropertyChanged subscriber only fires on future changes.
+        if (_appState?.NodePairList is { } existingNode)
+            UpdatePairingRequests(existingNode);
+        if (_appState?.DevicePairList is { } existingDevice)
+            UpdateDevicePairingRequests(existingDevice);
     }
 
     private void OnPageUnloaded(object sender, RoutedEventArgs e)

--- a/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml
@@ -70,6 +70,45 @@
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
             </StackPanel>
 
+            <!--
+                Pending-pair banner. Surfaces the same warning that
+                ConnectionPage shows so the user is never stuck staring at a
+                "connected node with empty capabilities" without an obvious
+                affordance. The actual approve/reject UI lives on the
+                Connection page; clicking the button navigates there. The
+                banner stays collapsed unless there's at least one pending
+                node or device pair.
+            -->
+            <Border x:Name="PendingPairBanner"
+                    Visibility="Collapsed"
+                    Background="{ThemeResource SystemFillColorCautionBackgroundBrush}"
+                    BorderBrush="{ThemeResource SystemFillColorCautionBrush}"
+                    BorderThickness="1"
+                    CornerRadius="6"
+                    Padding="12,10">
+                <StackPanel Orientation="Horizontal" Spacing="10">
+                    <FontIcon Glyph="&#xE7BA;" FontSize="18"
+                              Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                              VerticalAlignment="Center"/>
+                    <StackPanel Spacing="2" VerticalAlignment="Center">
+                        <TextBlock x:Name="PendingPairBannerText"
+                                   Text="Pairing approval required"
+                                   Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                        <TextBlock x:Name="PendingPairBannerSubtext"
+                                   Text="A node has connected but its capabilities won't activate until you approve the pairing request."
+                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   TextWrapping="Wrap"
+                                   MaxWidth="520"/>
+                    </StackPanel>
+                    <Button x:Name="PendingPairBannerAction"
+                            Content="Review on Connection page"
+                            Click="OnPendingPairBannerClicked"
+                            VerticalAlignment="Center"
+                            HorizontalAlignment="Right"/>
+                </StackPanel>
+            </Border>
+
             <StackPanel x:Name="InstancesList" Spacing="8"/>
 
         </StackPanel>

--- a/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml.cs
@@ -63,8 +63,10 @@ public sealed partial class InstancesPage : Page
             // navigation (without waiting for the gateway's next broadcast).
             _ = Task.Run(async () =>
             {
-                try { await CurrentApp.GatewayClient.RequestNodePairListAsync(); } catch { }
-                try { await CurrentApp.GatewayClient.RequestDevicePairListAsync(); } catch { }
+                try { await CurrentApp.GatewayClient.RequestNodePairListAsync(); }
+                catch (Exception ex) { Services.Logger.Warn($"[InstancesPage] Eager node-pair refresh failed: {ex.Message}"); }
+                try { await CurrentApp.GatewayClient.RequestDevicePairListAsync(); }
+                catch (Exception ex) { Services.Logger.Warn($"[InstancesPage] Eager device-pair refresh failed: {ex.Message}"); }
             });
         }
     }

--- a/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml.cs
@@ -54,10 +54,18 @@ public sealed partial class InstancesPage : Page
         _appState.PropertyChanged += OnAppStateChanged;
 
         Rerender();
+        UpdatePendingPairBanner();
 
         if (CurrentApp.GatewayClient != null)
         {
             _ = RequestNodesWithSpinnerAsync();
+            // Also poll the pair lists so the banner is correct on first
+            // navigation (without waiting for the gateway's next broadcast).
+            _ = Task.Run(async () =>
+            {
+                try { await CurrentApp.GatewayClient.RequestNodePairListAsync(); } catch { }
+                try { await CurrentApp.GatewayClient.RequestDevicePairListAsync(); } catch { }
+            });
         }
     }
 
@@ -74,8 +82,49 @@ public sealed partial class InstancesPage : Page
             case nameof(AppState.Presence):
                 UpdatePresence(_appState!.Presence ?? Array.Empty<PresenceEntry>());
                 break;
+            case nameof(AppState.NodePairList):
+            case nameof(AppState.DevicePairList):
+                UpdatePendingPairBanner();
+                break;
         }
     }
+
+    /// <summary>
+    /// Show a banner at the top of the Instances list when there's at least
+    /// one pending node-pair or device-pair request. The actual approve/reject
+    /// UI lives on the Connection page (where the legacy "Pending approvals"
+    /// banner already handles per-row decisions) — this banner just makes it
+    /// impossible to miss while looking at a node that appears connected but
+    /// has empty capabilities.
+    /// </summary>
+    private void UpdatePendingPairBanner()
+    {
+        if (PendingPairBanner is null) return;
+        var nodePending = _appState?.NodePairList?.Pending?.Count ?? 0;
+        var devicePending = _appState?.DevicePairList?.Pending?.Count ?? 0;
+        var total = nodePending + devicePending;
+        if (total == 0)
+        {
+            PendingPairBanner.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        PendingPairBanner.Visibility = Visibility.Visible;
+        PendingPairBannerText.Text = total == 1
+            ? "1 pairing approval waiting"
+            : $"{total} pairing approvals waiting";
+
+        var nodeOwnId = CurrentApp.NodeFullDeviceId;
+        var ownIsPending = !string.IsNullOrWhiteSpace(nodeOwnId)
+            && (_appState?.NodePairList?.Pending?.Any(p =>
+                string.Equals(p.NodeId, nodeOwnId, StringComparison.OrdinalIgnoreCase)) ?? false);
+        PendingPairBannerSubtext.Text = ownIsPending
+            ? "This node is connected but its capabilities and commands won't activate until the pairing is approved."
+            : "A node or device is waiting for approval before it can join.";
+    }
+
+    private void OnPendingPairBannerClicked(object sender, RoutedEventArgs e)
+        => ((IAppCommands)CurrentApp).Navigate("connection");
 
     public void UpdateNodes(GatewayNodeInfo[] nodes)
     {

--- a/tests/OpenClaw.Connection.Tests/NodePairAutoApproveTests.cs
+++ b/tests/OpenClaw.Connection.Tests/NodePairAutoApproveTests.cs
@@ -217,6 +217,34 @@ public class NodePairAutoApproveTests : IDisposable
     }
 
     [Fact]
+    public async Task OperatorSideAutoApprove_NodeSideSkippedWithoutScope_CanStillApproveSameRequestId()
+    {
+        using var manager = CreateConnectedManager();
+
+        var lifecycle = _factory.CreatedClients[0];
+        lifecycle.TrackingClient.SetGrantedScopes(["operator.read"]); // no admin/pairing yet
+        lifecycle.TrackingClient.SetIsConnected(true);
+        _nodeConnector.NodeDeviceId = "own-id";
+
+        await FireAndWait(manager, () =>
+            _nodeConnector.FireStatusChanged(ConnectionStatus.Connecting));
+
+        _nodeConnector.FirePairingStatusChanged(PairingStatus.Pending, requestId: "req-same-later-scope");
+        await Task.Delay(200);
+        Assert.Empty(lifecycle.TrackingClient.ApprovalMethodsCalled);
+
+        lifecycle.TrackingClient.SetGrantedScopes(["operator.admin"]);
+        var approvalDone = lifecycle.TrackingClient.WaitForApprovalCallAsync();
+        lifecycle.TrackingClient.FireNodePairListUpdated(new PairingListInfo
+        {
+            Pending = [new PairingRequest { RequestId = "req-same-later-scope", NodeId = "own-id" }]
+        });
+        await approvalDone;
+
+        Assert.Contains("node.pair.approve", lifecycle.TrackingClient.ApprovalMethodsCalled);
+    }
+
+    [Fact]
     public async Task OperatorSideAutoApprove_SameRequestId_DoesNotApproveTwice()
     {
         using var manager = CreateConnectedManager();

--- a/tests/OpenClaw.Connection.Tests/NodePairAutoApproveTests.cs
+++ b/tests/OpenClaw.Connection.Tests/NodePairAutoApproveTests.cs
@@ -131,6 +131,122 @@ public class NodePairAutoApproveTests : IDisposable
             .Count(m => m == "node.pair.approve"));
     }
 
+    [Fact]
+    public async Task OperatorSideAutoApprove_ApprovesPendingForOwnNodeId()
+    {
+        // Operator-side regression test for the scenario where:
+        //   1. The Windows node device is already paired (so the node-side
+        //      WindowsNodeClient sees PairingStatus.Paired and never fires
+        //      Pending — the existing OnNodePairingStatusChanged path can't
+        //      kick in).
+        //   2. The gateway nevertheless broadcasts node.pair.requested
+        //      because the node-sub-pairing record is empty (gateway's
+        //      /home/openclaw/.openclaw/nodes/paired.json = "{}").
+        //   3. The operator client receives the resulting
+        //      NodePairListUpdated push containing OUR own nodeId.
+        // Manager must auto-approve via the operator path, otherwise the
+        // node sits as "connected with 0 capabilities" indefinitely.
+        using var manager = CreateConnectedManager();
+
+        var lifecycle = _factory.CreatedClients[0];
+        lifecycle.TrackingClient.SetGrantedScopes(["operator.admin"]);
+        lifecycle.TrackingClient.SetIsConnected(true);
+
+        const string ownNodeId = "f52d5187f33563a00947012c8de63f489cd0127bf008017e77090e218918a9f6";
+        _nodeConnector.NodeDeviceId = ownNodeId;
+
+        var approvalDone = lifecycle.TrackingClient.WaitForApprovalCallAsync();
+        lifecycle.TrackingClient.FireNodePairListUpdated(new PairingListInfo
+        {
+            Pending =
+            [
+                new PairingRequest { RequestId = "op-side-req-1", NodeId = ownNodeId }
+            ]
+        });
+        await approvalDone;
+
+        Assert.Contains("node.pair.approve", lifecycle.TrackingClient.ApprovalMethodsCalled);
+    }
+
+    [Fact]
+    public async Task OperatorSideAutoApprove_IgnoresPendingForOtherNodeId()
+    {
+        // Defensive: when the gateway has multiple pending node-pair
+        // requests (e.g. another tray on the same gateway), the operator
+        // path must only approve OUR own deviceId — never silently
+        // approve a peer.
+        using var manager = CreateConnectedManager();
+
+        var lifecycle = _factory.CreatedClients[0];
+        lifecycle.TrackingClient.SetGrantedScopes(["operator.admin"]);
+        lifecycle.TrackingClient.SetIsConnected(true);
+        _nodeConnector.NodeDeviceId = "f52d5187...own";
+
+        lifecycle.TrackingClient.FireNodePairListUpdated(new PairingListInfo
+        {
+            Pending =
+            [
+                new PairingRequest { RequestId = "req-someone-else", NodeId = "different-node-id" }
+            ]
+        });
+        await Task.Delay(200);
+
+        Assert.Empty(lifecycle.TrackingClient.ApprovalMethodsCalled);
+    }
+
+    [Fact]
+    public async Task OperatorSideAutoApprove_WithoutScope_DoesNotApprove()
+    {
+        using var manager = CreateConnectedManager();
+
+        var lifecycle = _factory.CreatedClients[0];
+        lifecycle.TrackingClient.SetGrantedScopes(["operator.read"]); // no admin/pairing
+        lifecycle.TrackingClient.SetIsConnected(true);
+        _nodeConnector.NodeDeviceId = "own-id";
+
+        lifecycle.TrackingClient.FireNodePairListUpdated(new PairingListInfo
+        {
+            Pending =
+            [
+                new PairingRequest { RequestId = "req-no-scope", NodeId = "own-id" }
+            ]
+        });
+        await Task.Delay(200);
+
+        Assert.Empty(lifecycle.TrackingClient.ApprovalMethodsCalled);
+    }
+
+    [Fact]
+    public async Task OperatorSideAutoApprove_SameRequestId_DoesNotApproveTwice()
+    {
+        using var manager = CreateConnectedManager();
+
+        var lifecycle = _factory.CreatedClients[0];
+        lifecycle.TrackingClient.SetGrantedScopes(["operator.admin"]);
+        lifecycle.TrackingClient.SetIsConnected(true);
+        _nodeConnector.NodeDeviceId = "own-id";
+
+        var firstDone = lifecycle.TrackingClient.WaitForApprovalCallAsync();
+        lifecycle.TrackingClient.FireNodePairListUpdated(new PairingListInfo
+        {
+            Pending = [new PairingRequest { RequestId = "dedupe-1", NodeId = "own-id" }]
+        });
+        await firstDone;
+        // Wait for the post-approve sequence to complete before firing the
+        // second event; _lastAutoApprovedRequestId must be set first.
+        await Task.Delay(1100);
+
+        // Re-broadcast (same id) — must be skipped via _lastAutoApprovedRequestId.
+        lifecycle.TrackingClient.FireNodePairListUpdated(new PairingListInfo
+        {
+            Pending = [new PairingRequest { RequestId = "dedupe-1", NodeId = "own-id" }]
+        });
+        await Task.Delay(200);
+
+        Assert.Equal(1, lifecycle.TrackingClient.ApprovalMethodsCalled
+            .Count(m => m == "node.pair.approve"));
+    }
+
     // ─── Helpers ───
 
     private GatewayConnectionManager CreateConnectedManager()
@@ -276,6 +392,22 @@ public class NodePairAutoApproveTests : IDisposable
             _approvalMethodsCalled.Add("device.pair.approve");
             _approvalSignal?.TrySetResult();
             return Task.FromResult(true);
+        }
+
+        /// <summary>
+        /// Raises NodePairListUpdated on this client so tests can drive the
+        /// operator-side auto-approve path without a live WebSocket.
+        /// </summary>
+        public void FireNodePairListUpdated(PairingListInfo info)
+        {
+            var ev = typeof(OpenClawGatewayClient).GetEvent("NodePairListUpdated");
+            Assert.NotNull(ev);
+            var field = typeof(OpenClawGatewayClient).GetField(
+                "NodePairListUpdated",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            var handler = (EventHandler<PairingListInfo>?)field!.GetValue(this);
+            handler?.Invoke(this, info);
         }
     }
 

--- a/tests/OpenClaw.Connection.Tests/NodePairAutoApproveTests.cs
+++ b/tests/OpenClaw.Connection.Tests/NodePairAutoApproveTests.cs
@@ -396,19 +396,14 @@ public class NodePairAutoApproveTests : IDisposable
 
         /// <summary>
         /// Raises NodePairListUpdated on this client so tests can drive the
-        /// operator-side auto-approve path without a live WebSocket.
+        /// operator-side auto-approve path without a live WebSocket. Uses the
+        /// internal test-only raiser exposed via
+        /// [InternalsVisibleTo("OpenClaw.Connection.Tests")] — earlier this
+        /// reached the private event backing field by reflection, which
+        /// silently broke the moment the event got refactored.
         /// </summary>
         public void FireNodePairListUpdated(PairingListInfo info)
-        {
-            var ev = typeof(OpenClawGatewayClient).GetEvent("NodePairListUpdated");
-            Assert.NotNull(ev);
-            var field = typeof(OpenClawGatewayClient).GetField(
-                "NodePairListUpdated",
-                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-            Assert.NotNull(field);
-            var handler = (EventHandler<PairingListInfo>?)field!.GetValue(this);
-            handler?.Invoke(this, info);
-        }
+            => RaiseNodePairListUpdatedForTests(info);
     }
 
     private sealed class ScriptedNodeConnector : INodeConnector

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientSessionKeyTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientSessionKeyTests.cs
@@ -1,0 +1,74 @@
+using OpenClaw.Shared;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+/// <summary>
+/// Exercises the protocol-layer guard that prevents a chat RPC from going out
+/// with no resolved canonical sessionKey. This is the central invariant for
+/// the zero-state bug fix: the gateway client must NOT silently substitute a
+/// literal like "main" when the handshake hasn't resolved the canonical key
+/// yet — that's exactly how the optimistic local timeline diverged from the
+/// gateway's echo (keyed by e.g. "agent:main:main") before the fix.
+/// </summary>
+public class OpenClawGatewayClientSessionKeyTests
+{
+    [Fact]
+    public void ResolveEffectiveSessionKey_BothEmpty_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            OpenClawGatewayClient.ResolveEffectiveSessionKey(null, null, "chat.send"));
+        Assert.Contains("handshake has not resolved", ex.Message);
+        Assert.Contains("chat.send", ex.Message);
+    }
+
+    [Fact]
+    public void ResolveEffectiveSessionKey_CallerEmpty_HandshakeEmpty_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            OpenClawGatewayClient.ResolveEffectiveSessionKey("", "", "chat.history"));
+        Assert.Throws<InvalidOperationException>(() =>
+            OpenClawGatewayClient.ResolveEffectiveSessionKey("   ", "   ", "chat.abort"));
+    }
+
+    [Fact]
+    public void ResolveEffectiveSessionKey_HandshakeResolved_ReturnsCanonical()
+    {
+        var result = OpenClawGatewayClient.ResolveEffectiveSessionKey(
+            callerSessionKey: null,
+            resolvedMainSessionKey: "agent:main:main",
+            operationName: "chat.send");
+        Assert.Equal("agent:main:main", result);
+    }
+
+    [Fact]
+    public void ResolveEffectiveSessionKey_CallerOverridesHandshake()
+    {
+        var result = OpenClawGatewayClient.ResolveEffectiveSessionKey(
+            callerSessionKey: "other-session",
+            resolvedMainSessionKey: "agent:main:main",
+            operationName: "chat.send");
+        Assert.Equal("other-session", result);
+    }
+
+    [Fact]
+    public void ResolveEffectiveSessionKey_TrimsWhitespace()
+    {
+        var result = OpenClawGatewayClient.ResolveEffectiveSessionKey(
+            callerSessionKey: "  agent:main:main  ",
+            resolvedMainSessionKey: null,
+            operationName: "chat.send");
+        Assert.Equal("agent:main:main", result);
+    }
+
+    [Fact]
+    public void ResolveEffectiveSessionKey_DoesNotSubstituteLiteralMainAlias()
+    {
+        // Regression guard: if a future refactor re-introduces a "main"
+        // fallback inside ResolveEffectiveSessionKey, this test will catch
+        // it. The whole point of the zero-state fix is that the client
+        // MUST refuse rather than guess.
+        Assert.Throws<InvalidOperationException>(() =>
+            OpenClawGatewayClient.ResolveEffectiveSessionKey(null, null, "chat.send"));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OnboardingChatBootstrapperTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OnboardingChatBootstrapperTests.cs
@@ -91,6 +91,8 @@ public sealed class OnboardingChatBootstrapperTests : IDisposable
         public bool IsConnectedToGateway { get; init; } = true;
         public string? OperatorDeviceId => "operator";
         public IReadOnlyList<string> GrantedOperatorScopes => Array.Empty<string>();
+        public string? MainSessionKey { get; init; } = "main";
+        public bool HasHandshakeSnapshot { get; init; } = true;
 
         public event EventHandler<OpenClawNotification>? NotificationReceived;
         public event EventHandler<AgentActivity>? ActivityChanged;

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -11,6 +11,8 @@ public class OpenClawChatDataProviderTests
     {
         public bool IsConnected { get; set; }
         public ConnectionStatus CurrentStatus { get; set; }
+        public string? MainSessionKey { get; set; }
+        public bool HasHandshakeSnapshot { get; set; }
         public List<string> SentMessages { get; } = new();
         public List<string?> SentSessionKeys { get; } = new();
         public List<string?> SentSessionIds { get; } = new();
@@ -396,23 +398,31 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
-    public async Task CreateThreadAsync_WithInitialMessage_SendsAndReturnsMain()
+    public async Task LoadAsync_FreshInstall_NoSessions_ExposesNotReadyComposeTarget()
     {
-        var (bridge, provider, _, _) = CreateProvider(new[] { MainSession() });
-        await provider.LoadAsync();
-
-        var thread = await provider.CreateThreadAsync("first message");
-
-        Assert.Equal("main", thread.Id);
-        Assert.Equal("first message", bridge.SentMessages[0]);
+        // Replaces the pre-refactor CreateThreadAsync tests: there is no
+        // create-thread RPC on the gateway, so the provider must never
+        // synthesize a thread out of thin air. Instead, the snapshot exposes
+        // a ChatComposeTarget that tells the UI whether/where to send.
+        var (_, provider, _, _) = CreateProvider();
+        var snap = await provider.LoadAsync();
+        Assert.Empty(snap.Threads);
+        Assert.False(snap.ComposeTarget.IsReady);
+        Assert.Null(snap.ComposeTarget.SessionKey);
     }
 
     [Fact]
-    public async Task CreateThreadAsync_WithoutSession_ReturnsSyntheticMain()
+    public async Task LoadAsync_HandshakeKnown_ZeroSessions_ExposesReadyComposeTarget()
     {
-        var (_, provider, _, _) = CreateProvider();
-        var thread = await provider.CreateThreadAsync(null);
-        Assert.Equal("main", thread.Id);
+        var (bridge, provider, _, _) = CreateProvider();
+        bridge.HasHandshakeSnapshot = true;
+        bridge.MainSessionKey = "agent:main:main";
+        bridge.RaiseStatus(ConnectionStatus.Connected);
+        var snap = await provider.LoadAsync();
+        Assert.Empty(snap.Threads);
+        Assert.True(snap.ComposeTarget.IsReady);
+        Assert.Equal("agent:main:main", snap.ComposeTarget.SessionKey);
+        Assert.Equal("agent:main:main", snap.DefaultThreadId);
     }
 
     // ── Parity additions: streaming, lifecycle, reasoning, history, abort ──
@@ -1690,5 +1700,183 @@ public class OpenClawChatDataProviderTests
         var timeline = snapshots[^1].Timelines["main"];
         var userEntry = timeline.Entries.Last(e => e.Kind == ChatTimelineItemKind.User);
         Assert.Contains("test.txt", userEntry.Text);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    //  Compose-target fix: covers the "fresh install, zero sessions" path
+    //  that previously stranded optimistic state under a synthetic "main"
+    //  key while the gateway echoed events back under "agent:main:main".
+    //  See OpenClawChatDataProvider.BuildSnapshotLocked for the design.
+    // ─────────────────────────────────────────────────────────────────────
+
+    private static (FakeBridge bridge, OpenClawChatDataProvider provider, List<ChatDataSnapshot> snapshots)
+        CreateConnectedProvider(string canonicalMainKey = "agent:main:main")
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider();
+        bridge.HasHandshakeSnapshot = true;
+        bridge.MainSessionKey = canonicalMainKey;
+        bridge.RaiseStatus(ConnectionStatus.Connected);
+        return (bridge, provider, snapshots);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_FreshInstall_OptimisticEntryKeyedByCanonicalSessionKey()
+    {
+        // Regression for the zero-state bug: the user clicks a suggestion on
+        // a fresh install (zero sessions). The optimistic entry must land in
+        // a timeline keyed by the gateway's canonical session key — NOT a
+        // literal "main". Otherwise the gateway's chat events (which come
+        // back keyed by the canonical key) build a SECOND timeline and the
+        // optimistic state is orphaned.
+        var (bridge, provider, snapshots) = CreateConnectedProvider("agent:main:main");
+        await provider.LoadAsync();
+
+        await provider.SendMessageAsync("agent:main:main", "hi");
+
+        Assert.Contains(bridge.SentMessages, m => m == "hi");
+        Assert.Equal("agent:main:main", bridge.SentSessionKeys[0]);
+        var latest = snapshots[^1];
+        Assert.True(latest.Timelines.ContainsKey("agent:main:main"));
+        Assert.False(latest.Timelines.ContainsKey("main"),
+            "The provider must never key timelines by the literal 'main' alias.");
+        Assert.Single(latest.Timelines["agent:main:main"].Entries, e => e.Kind == ChatTimelineItemKind.User);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_FreshInstall_SnapshotExposesComposeOnlyTimeline()
+    {
+        // Before the first SessionsUpdated arrives, the gateway-side session
+        // doesn't exist yet, so Threads is empty. But the optimistic user
+        // bubble must still be reachable to the UI: it's stored under the
+        // compose-target key. The UI then synthesizes a compose-only thread
+        // (matching the canonical key) so the timeline can render.
+        var (_, provider, snapshots) = CreateConnectedProvider("agent:main:main");
+        await provider.LoadAsync();
+
+        await provider.SendMessageAsync("agent:main:main", "hi");
+
+        var latest = snapshots[^1];
+        // BuildSnapshotLocked surfaces a synthetic ChatThread when the
+        // compose key has optimistic entries but isn't materialized yet.
+        Assert.Single(latest.Threads);
+        Assert.Equal("agent:main:main", latest.Threads[0].Id);
+        Assert.Equal("agent:main:main", latest.ComposeTarget.SessionKey);
+    }
+
+    [Fact]
+    public async Task SessionsUpdated_AfterFirstSend_PreservesOptimisticTimeline()
+    {
+        // The critical assertion: when the gateway materializes the session
+        // and emits SessionsUpdated with the canonical key, the optimistic
+        // entry that was written under that exact key SURVIVES (no second
+        // empty timeline gets created on top of it).
+        var (bridge, provider, snapshots) = CreateConnectedProvider("agent:main:main");
+        await provider.LoadAsync();
+        await provider.SendMessageAsync("agent:main:main", "hi");
+
+        bridge.RaiseSessions(new[]
+        {
+            new SessionInfo { Key = "agent:main:main", IsMain = true, DisplayName = "Main session", Status = "active" }
+        });
+
+        var latest = snapshots[^1];
+        Assert.Single(latest.Threads);
+        Assert.Equal("agent:main:main", latest.Threads[0].Id);
+        var timeline = latest.Timelines["agent:main:main"];
+        Assert.Single(timeline.Entries, e => e.Kind == ChatTimelineItemKind.User);
+        Assert.Equal("hi", timeline.Entries.First(e => e.Kind == ChatTimelineItemKind.User).Text);
+    }
+
+    [Fact]
+    public async Task ChatEvent_WithEmptySessionKey_IsDropped()
+    {
+        // The "main" literal fallback in event handlers was the second half
+        // of the bug: it would silently route mis-routed events to a synthetic
+        // bucket. The fix is to drop the event and log — surfacing protocol
+        // bugs instead of papering over them.
+        var (bridge, provider, snapshots) = CreateConnectedProvider("agent:main:main");
+        await provider.LoadAsync();
+        await provider.SendMessageAsync("agent:main:main", "hi");
+        var snapshotCountBefore = snapshots.Count;
+
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "",
+            Role = "assistant",
+            Text = "echo with no session key — should be dropped"
+        });
+
+        Assert.Equal(snapshotCountBefore, snapshots.Count);
+        // And specifically: no synthetic "main" timeline was created.
+        Assert.False(snapshots[^1].Timelines.ContainsKey("main"));
+    }
+
+    [Fact]
+    public async Task ChatEvent_WithCanonicalSessionKey_AppendsToExistingTimeline()
+    {
+        // Happy path: gateway echoes assistant text back under the same
+        // canonical key the optimistic entry used. They land in one timeline.
+        var (bridge, provider, snapshots) = CreateConnectedProvider("agent:main:main");
+        await provider.LoadAsync();
+        await provider.SendMessageAsync("agent:main:main", "hi");
+
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "agent:main:main",
+            Role = "assistant",
+            Text = "hello back",
+            State = "final"
+        });
+
+        var latest = snapshots[^1];
+        var timeline = latest.Timelines["agent:main:main"];
+        Assert.Contains(timeline.Entries, e => e.Kind == ChatTimelineItemKind.User && e.Text == "hi");
+        Assert.Contains(timeline.Entries, e => e.Kind == ChatTimelineItemKind.Assistant && e.Text == "hello back");
+        Assert.False(latest.Timelines.ContainsKey("main"));
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_PreHandshake_GatewayClientRefusesViaProvider()
+    {
+        // Provider-level proof that the upstream guard fires: SendMessageAsync
+        // bubbles the InvalidOperationException raised by the gateway client's
+        // ResolveEffectiveSessionKey when no canonical sessionKey is known.
+        // (The pure-function unit test for the helper itself lives in
+        //  OpenClawGatewayClientSessionKeyTests in OpenClaw.Shared.Tests.)
+        var (bridge, provider, _, _) = CreateProvider();
+        bridge.IsConnected = true;
+        bridge.SendBehavior = (_, key, _) =>
+        {
+            if (string.IsNullOrWhiteSpace(key))
+                throw new InvalidOperationException(
+                    "chat.send requires a sessionKey, but the gateway handshake has not resolved one yet.");
+            return Task.CompletedTask;
+        };
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await provider.SendMessageAsync("", "hi"));
+    }
+
+    [Fact]
+    public async Task ResolveDefaultThreadId_PrefersIsMain_NotLiteralStringMatch()
+    {
+        // The pre-refactor ResolveDefaultThreadIdLocked heuristic compared
+        // thread.Id to the literal "main", which would silently lose the
+        // default when the canonical key was "agent:main:main".
+        var (bridge, provider, snapshots) = CreateConnectedProvider("agent:main:main");
+        bridge.RaiseSessions(new[]
+        {
+            new SessionInfo { Key = "agent:main:other", IsMain = false, DisplayName = "Other" },
+            new SessionInfo { Key = "agent:main:main",  IsMain = true,  DisplayName = "Main" }
+        });
+        var snap = await provider.LoadAsync();
+        Assert.Equal("agent:main:main", snap.DefaultThreadId);
+    }
+
+    private sealed class TestLogger : OpenClaw.Shared.IOpenClawLogger
+    {
+        public void Debug(string message) { }
+        public void Info(string message) { }
+        public void Warn(string message) { }
+        public void Error(string message, Exception? ex = null) { }
     }
 }


### PR DESCRIPTION
## Summary

Two related setup-flow bugs hit while debugging a fresh install against a WSL gateway. Both fixed here, plus tests.

## Bug 1 — Zero-state chat trap (commit fd9e2a9)

On a fresh install with zero gateway sessions, the user landed on a welcome screen with three suggestion buttons that did nothing and a hidden composer.

**Root cause** (validated by 3-model fresh root-cause analysis): OpenClawChatDataProvider maintained a C# replica of gateway session state keyed by `threadId` that conflated UI selection token with server-assigned `sessionKey`. `CreateThreadAsync` synthesized a thread with `Id = "main"` (literal), but the gateway's hello-ok publishes BOTH `sessionDefaults.mainKey = "main"` (legacy alias) and `sessionDefaults.mainSessionKey = "agent:main:main"` (canonical), and the parser was reading the alias. Optimistic local entries landed under `"main"` while gateway echoes used `"agent:main:main"` → two timelines, message orphaned, UI stuck.

**Fix**:
- Deleted `IChatDataProvider.CreateThreadAsync` (a fiction — the gateway has no `session.create` RPC).
- Added `ChatComposeTarget {SessionKey, IsReady}` to `ChatDataSnapshot` as a first-class "where to send" concept.
- `TryGetHandshakeMainSessionKey` now prefers the canonical key.
- `OpenClawGatewayClient._mainSessionKey` → `string?` (no `"main"` default), reset on disconnect, `Volatile.Read/Write`-protected.
- Extracted `ResolveEffectiveSessionKey` — throws `InvalidOperationException` instead of silently substituting a literal.
- `HandleChatEvent` / `HandleAgentEvent` no longer substitute `"main"`/`"unknown"` for missing `sessionKey`; provider drops events with empty keys.
- `OpenClawChatRoot`: deleted `StartFirstChat` and safety-net fallback (now structurally impossible); `effectiveThread = selectedThread ?? composeOnlyThread`; composer visible whenever `ComposeTarget.IsReady`; `firstSendInFlight` debounce only clears when the snapshot's compose-target timeline has the optimistic entry.
- Friendlier zero-state suggestions ("Say hi 👋", "What can you do?", "Give me a quick tour of OpenClaw").

Followed by an adversarial dual-model code review which surfaced 5 HIGH-consensus issues, all addressed.

## Bug 2 — Node pairing pending forever (commit fa421a3)

On the same install, after the device was paired, the gateway showed the Windows node as Connected but with `caps: []` and `commands: []`. Agent capabilities silently inert.

**Root cause**: the gateway maintains two separate tables — `devices/paired.json` (device-level identity) and `nodes/paired.json` (node-sub-pairing with caps/commands). The device-pair flow had auto-approved the device, but the node-sub-pairing was sitting in `nodes/pending.json` indefinitely. The existing `OnNodePairingStatusChanged` auto-approve only triggers from the node-side `WindowsNodeClient.PairingStatusChanged` event, which fires `Pending` only when the node-side connection itself is pending. With the device already paired, the node-side client saw `Paired` and never raised `Pending` — the only signal for the missing node-sub-pairing was the operator-side `NodePairListUpdated` broadcast, which wasn't wired to auto-approve.

**Fix**:
- New `TryOperatorAutoApproveOwnNodePairAsync` in `GatewayConnectionManager`. Subscribes to `NodePairListUpdated` on every new operator client. When a pending entry's `NodeId` matches our own `_nodeConnector.NodeDeviceId` and we have `operator.admin`/`operator.pairing` scope, calls `NodePairApproveAsync`. Reuses `_autoApproveInFlight` CAS guard and `_lastAutoApprovedRequestId` dedup.
- `InstancesPage`: caution-yellow banner at top when any pair is pending, with contextual subtext when our own node is the one waiting. Button navigates to `ConnectionPage` where the existing per-row approve/reject UI lives.
- `ConnectionPage.Initialize()`: eagerly calls `RequestNodePairListAsync` + `RequestDevicePairListAsync`, and pushes already-loaded `AppState` pending lists into the banner immediately.

Tests: 4 new cases in `NodePairAutoApproveTests` covering own-node approve, other-node ignored, missing scope, and dedup-on-rebroadcast.

## Validation

- `./build.ps1` ✅
- `OpenClaw.Shared.Tests`: 1782 passed / 28 skipped ✅
- `OpenClaw.Tray.Tests`: 1096 passed ✅
- `OpenClaw.Connection.Tests`: 228 passed ✅
- Live end-to-end against a WSL gateway: zero-state chat now sends correctly with the canonical key; gateway's `node.list` went from `caps: []` to all 8 caps populated after launch.

## Files changed

- `src/OpenClaw.Chat/ChatModels.cs` — delete `CreateThreadAsync`, add `ChatComposeTarget`
- `src/OpenClaw.Shared/OpenClawGatewayClient.cs` — canonical key parse, nullable + Volatile main session key, `ResolveEffectiveSessionKey` helper, drop `"main"`/`"unknown"` fallbacks
- `src/OpenClaw.Shared/IOperatorGatewayClient.cs` — expose `MainSessionKey` + `HasHandshakeSnapshot`
- `src/OpenClaw.Connection/GatewayConnectionManager.cs` — operator-side auto-approve path
- `src/OpenClaw.Tray.WinUI/Chat/{IChatGatewayBridge, OpenClawChatDataProvider, OpenClawChatRoot}.cs` — provider refactor, UI compose-target wiring
- `src/OpenClaw.Tray.WinUI/Pages/{ConnectionPage, InstancesPage}.{xaml, xaml.cs}` — pending-pair surfacing
- `tests/OpenClaw.Shared.Tests/OpenClawGatewayClientSessionKeyTests.cs` — new
- `tests/OpenClaw.Connection.Tests/NodePairAutoApproveTests.cs` — +4 cases for operator-side path
- `tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs` — replaced 2 obsolete tests with 7 new ones for compose-target behavior

🦞
