### PR TITLE
Fix node capability binding diagnostics

### DIFF
--- a/src/OpenClaw.Connection/NodeConnector.cs
+++ b/src/OpenClaw.Connection/NodeConnector.cs
@@ -79,6 +79,7 @@ public sealed class NodeConnector : INodeConnector
         catch (Exception ex)
         {
             _logger.Warn($"[NodeConnector] ClientCreated handler threw: {ex.Message}");
+            _diagnostics?.Record("node", "ClientCreated handler failed; node may connect without capabilities", ex.Message);
         }
 
         _client.StatusChanged += (s, e) => StatusChanged?.Invoke(this, e);

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -132,7 +132,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         var settings = _settings ?? new SettingsManager();
         // NodeService is still required for capability registration on the manager's
         // WindowsNodeClient (via App.xaml.cs ClientCreated → AttachClient bridge).
-        var nodeService = EnsureNodeServiceForLocalGatewaySetup(settings);
+        var nodeService = EnsureNodeService(settings);
         // Suppress manager auto-start of node during setup so the engine retains
         // strict phase ordering (operator paired → WSL CLI device-approve → node
         // pairing). EnsureNodeConnectedAsync (called by ConnectionManagerWindowsNodeConnector
@@ -711,6 +711,22 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         {
             try
             {
+                // A node client was just created (manager auto-start OR setup engine
+                // EnsureNodeConnectedAsync). We MUST have a NodeService to register
+                // capabilities on this client before the outbound "connect" goes out —
+                // see NodeConnector.cs:66. Build it lazily here so we never depend on
+                // OnLaunched ordering or the _suppressNodeDuringSetup gate having
+                // landed in the right state. EnsureNodeService is
+                // idempotent — it returns the existing instance if already built.
+                // Without this, _nodeService?.AttachClient below is a silent no-op and
+                // the gateway sees the node with caps=0/cmds=0 (regression introduced
+                // 2026-05-12 in 62533e2 when capability registration moved to this
+                // lazy bridge pattern).
+                if (_settings != null)
+                {
+                    EnsureNodeService(_settings);
+                }
+
                 diagnostics.Record("node", $"ClientCreated fired, _nodeService null={_nodeService is null}");
                 _nodeService?.AttachClient(args.Client, args.BearerToken);
                 var client = args.Client;
@@ -762,7 +778,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         // The method is idempotent — safe to call here AND later if first-run setup runs.
         if (ShouldInitializeNodeService() && _settings != null)
         {
-            EnsureNodeServiceForLocalGatewaySetup(_settings);
+            EnsureNodeService(_settings);
         }
 
         // Initialize connections — always create operator client for UI data,
@@ -1678,7 +1694,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             return false;
         }
 
-        var nodeService = EnsureNodeServiceForLocalGatewaySetup(_settings);
+        var nodeService = EnsureNodeService(_settings);
         if (nodeService == null)
         {
             Logger.Warn("MCP-only mode requested but node service could not be initialized");
@@ -1779,7 +1795,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         });
     }
 
-    private NodeService? EnsureNodeServiceForLocalGatewaySetup(SettingsManager settings)
+    private NodeService? EnsureNodeService(SettingsManager settings)
     {
         if (_nodeService != null)
             return _nodeService;

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -722,19 +722,34 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 // the gateway sees the node with caps=0/cmds=0 (regression introduced
                 // 2026-05-12 in 62533e2 when capability registration moved to this
                 // lazy bridge pattern).
-                if (_settings != null)
+                if (_settings == null)
+                {
+                    Logger.Warn("[App] NodeConnector.ClientCreated fired before settings were initialized; node may connect without capabilities");
+                    diagnostics.Record("node", "WARNING: settings unavailable; cannot initialize NodeService for capability binding");
+                }
+                else
                 {
                     EnsureNodeService(_settings);
                 }
 
                 diagnostics.Record("node", $"ClientCreated fired, _nodeService null={_nodeService is null}");
-                _nodeService?.AttachClient(args.Client, args.BearerToken);
+                if (_nodeService == null)
+                {
+                    Logger.Warn("[App] NodeService unavailable during ClientCreated; node may connect with caps=0/cmds=0");
+                    diagnostics.Record("node", "WARNING: NodeService unavailable; cannot bind node capabilities");
+                    return;
+                }
+
+                _nodeService.AttachClient(args.Client, args.BearerToken);
                 var client = args.Client;
                 diagnostics.Record("node", $"After AttachClient: caps={client.Capabilities.Count}, cmds={client.RegisteredCommandCount}");
                 if (client.RegisteredCommandCount > 0)
                     diagnostics.Record("node", $"Commands sample: {string.Join(", ", client.RegisteredCommandsSample)}...");
                 else
+                {
+                    Logger.Warn("[App] Node capability binding produced 0 commands before connect");
                     diagnostics.Record("node", "WARNING: 0 commands registered on node client before connect");
+                }
             }
             catch (Exception ex)
             {

--- a/tests/OpenClaw.Connection.Tests/NodeConnectorTests.cs
+++ b/tests/OpenClaw.Connection.Tests/NodeConnectorTests.cs
@@ -62,6 +62,20 @@ public class NodeConnectorTests
     }
 
     [Fact]
+    public async Task ConnectAsync_WhenClientCreatedHandlerThrows_RecordsDiagnostic()
+    {
+        var diagnostics = new ConnectionDiagnostics();
+        using var connector = new NodeConnector(new StubLogger(), diagnostics);
+        connector.ClientCreated += (_, _) => throw new InvalidOperationException("boom");
+
+        await connector.ConnectAsync("ws://127.0.0.1:9", new GatewayCredential("tok", false, "test"), "id-path");
+
+        var evt = Assert.Single(diagnostics.GetAll(), e => e.Category == "node");
+        Assert.Equal("ClientCreated handler failed; node may connect without capabilities", evt.Message);
+        Assert.Equal("boom", evt.Detail);
+    }
+
+    [Fact]
     public async Task DisconnectAsync_WhenNotConnected_CompletesWithoutError()
     {
         using var connector = new NodeConnector(new StubLogger());


### PR DESCRIPTION
## Summary
- Lazily creates NodeService during node ClientCreated so capabilities can bind before connect
- Logs and records diagnostics when settings, NodeService, or command registration are unavailable instead of silently no-oping
- Keeps the tray from crashing if capability binding fails

## Validation
- .\\build.ps1
- dotnet test .\\tests\\OpenClaw.Shared.Tests\\OpenClaw.Shared.Tests.csproj --no-restore (1782 passed, 28 skipped)
- dotnet test .\\tests\\OpenClaw.Tray.Tests\\OpenClaw.Tray.Tests.csproj --no-restore (1112 passed)