### PR TITLE
fix: ID-based parallel tool call tracking with truthful Interrupted state

### DIFF
--- a/src/OpenClaw.Chat/ChatModels.cs
+++ b/src/OpenClaw.Chat/ChatModels.cs
@@ -30,7 +30,8 @@ public enum ChatToolCallStatus
 {
     InProgress,
     Success,
-    Error
+    Error,
+    Interrupted
 }
 
 public enum ChatTone
@@ -87,13 +88,15 @@ public record ChatTimelineState(
     string? ActiveToolCallId,
     string? CurrentIntent,
     System.Collections.Immutable.ImmutableHashSet<string> LocalNonces,
+    System.Collections.Immutable.ImmutableDictionary<string, string> ActiveToolCalls,
     bool HistoryLoaded = false,
     ChatPermissionRequest? PendingPermission = null)
 {
     public static ChatTimelineState Initial() => new(
         System.Collections.Immutable.ImmutableList<ChatTimelineItem>.Empty,
         false, 1, null, null, null, null,
-        System.Collections.Immutable.ImmutableHashSet<string>.Empty);
+        System.Collections.Immutable.ImmutableHashSet<string>.Empty,
+        System.Collections.Immutable.ImmutableDictionary<string, string>.Empty);
 }
 
 public record ChatHistoryPage(ChatEvent[] Events, int NextSince, int PrevBefore, bool HasMore);
@@ -107,9 +110,9 @@ public record ChatMessageEvent(string Text, string? ReasoningText = null, bool R
 public record ChatMessageDeltaEvent(string Text) : ChatEvent;
 public record ChatTurnEndEvent() : ChatEvent;
 public record ChatIntentEvent(string Intent) : ChatEvent;
-public record ChatToolStartEvent(string Text, string ToolName, JsonObject? ToolArgs = null) : ChatEvent;
-public record ChatToolOutputEvent(string Text) : ChatEvent;
-public record ChatToolErrorEvent(string Text) : ChatEvent;
+public record ChatToolStartEvent(string Text, string ToolName, JsonObject? ToolArgs = null, string? ToolCallId = null) : ChatEvent;
+public record ChatToolOutputEvent(string Text, string? ToolCallId = null) : ChatEvent;
+public record ChatToolErrorEvent(string Text, string? ToolCallId = null) : ChatEvent;
 public record ChatContextChangedEvent(string? Cwd, string? GitBranch) : ChatEvent;
 public record ChatStatusEvent(string Text, ChatTone Tone) : ChatEvent;
 public record ChatErrorEvent(string Text) : ChatEvent;

--- a/src/OpenClaw.Chat/ChatTimelineReducer.cs
+++ b/src/OpenClaw.Chat/ChatTimelineReducer.cs
@@ -107,10 +107,13 @@ public static class ChatTimelineReducer
             var idx = entries.FindIndex(en => en.Id == tid);
             if (idx >= 0)
             {
+                var existingOutput = entries[idx].ToolOutput;
                 entries = entries.SetItem(idx, entries[idx] with
                 {
                     ToolResult = ChatToolCallStatus.Success,
-                    ToolOutput = e.Text
+                    ToolOutput = string.IsNullOrEmpty(e.Text) && existingOutput is not null
+                        ? existingOutput
+                        : e.Text
                 });
             }
         }

--- a/src/OpenClaw.Chat/ChatTimelineReducer.cs
+++ b/src/OpenClaw.Chat/ChatTimelineReducer.cs
@@ -14,12 +14,12 @@ public static class ChatTimelineReducer
             ChatReasoningDeltaEvent e => UpsertReasoning(BeginTurn(state), e.Text, replace: false),
             ChatMessageDeltaEvent e => UpsertAssistant(BeginTurn(state), e.Text, replace: false, streaming: true),
             ChatMessageEvent e => UpsertAssistant(BeginTurn(state), e.Text, replace: true, streaming: false, e.ReconcilePrevious),
-            ChatTurnEndEvent => state with { TurnActive = false, ActiveAssistantId = null, ActiveReasoningId = null, PendingPermission = null },
+            ChatTurnEndEvent => ApplyTurnEnd(state),
             ChatIntentEvent e => state with { CurrentIntent = e.Intent },
             ChatToolStartEvent e => ApplyToolStart(state, e),
             ChatToolOutputEvent e => ApplyToolOutput(state, e),
             ChatToolErrorEvent e => ApplyToolError(state, e),
-            ChatErrorEvent e => PushEntry(EndTurn(state), ChatTimelineItemKind.Status, e.Text, ChatTone.Error),
+            ChatErrorEvent e => PushEntry(ApplyTurnEnd(state), ChatTimelineItemKind.Status, e.Text, ChatTone.Error),
             ChatStatusEvent e => PushEntry(state, ChatTimelineItemKind.Status, e.Text, e.Tone),
             ChatRestoredEvent e => PushEntry(state, ChatTimelineItemKind.Status, e.Text, ChatTone.Info),
             ChatContextChangedEvent => state,
@@ -80,21 +80,29 @@ public static class ChatTimelineReducer
     static ChatTimelineState ApplyToolStart(ChatTimelineState state, ChatToolStartEvent e)
     {
         var id = $"e{state.NextId}";
+        var activeToolCalls = state.ActiveToolCalls;
+
+        // Register by ToolCallId if available (parallel-safe correlation).
+        if (e.ToolCallId is { } tcId)
+            activeToolCalls = activeToolCalls.SetItem(tcId, id);
+
         return state with
         {
             Entries = state.Entries.Add(new(id, ChatTimelineItemKind.ToolCall, e.Text,
                 ToolName: e.ToolName, ToolResult: ChatToolCallStatus.InProgress,
                 IntentSummary: e.Text, ToolArgs: e.ToolArgs)),
             NextId = state.NextId + 1,
-            ActiveToolCallId = id,
+            // Only update legacy positional slot for events without a correlation ID.
+            ActiveToolCallId = e.ToolCallId is null ? id : state.ActiveToolCallId,
+            ActiveToolCalls = activeToolCalls,
             TurnActive = true
         };
     }
 
     static ChatTimelineState ApplyToolOutput(ChatTimelineState state, ChatToolOutputEvent e)
     {
-        var entries = state.Entries;
-        if (state.ActiveToolCallId is { } tid)
+        var (entries, entryId) = ResolveToolEntry(state, e.ToolCallId);
+        if (entryId is { } tid)
         {
             var idx = entries.FindIndex(en => en.Id == tid);
             if (idx >= 0)
@@ -106,13 +114,20 @@ public static class ChatTimelineReducer
                 });
             }
         }
-        return state with { Entries = entries, ActiveToolCallId = null, PendingPermission = null };
+        return state with
+        {
+            Entries = entries,
+            // Don't remove from ActiveToolCalls here: multiple output events can arrive
+            // for the same tool (command_output + item end). Mapping is cleared at turn end.
+            ActiveToolCallId = (entryId == state.ActiveToolCallId) ? null : state.ActiveToolCallId,
+            PendingPermission = null
+        };
     }
 
     static ChatTimelineState ApplyToolError(ChatTimelineState state, ChatToolErrorEvent e)
     {
-        var entries = state.Entries;
-        if (state.ActiveToolCallId is { } tid)
+        var (entries, entryId) = ResolveToolEntry(state, e.ToolCallId);
+        if (entryId is { } tid)
         {
             var idx = entries.FindIndex(en => en.Id == tid);
             if (idx >= 0)
@@ -124,7 +139,32 @@ public static class ChatTimelineReducer
                 });
             }
         }
-        return state with { Entries = entries, ActiveToolCallId = null, PendingPermission = null };
+        return state with
+        {
+            Entries = entries,
+            ActiveToolCallId = (entryId == state.ActiveToolCallId) ? null : state.ActiveToolCallId,
+            ActiveToolCalls = e.ToolCallId is { } k ? state.ActiveToolCalls.Remove(k) : state.ActiveToolCalls,
+            PendingPermission = null
+        };
+    }
+
+    /// <summary>
+    /// Resolve which timeline entry a tool output/error belongs to.
+    /// Prefers ID-based lookup (parallel-safe); falls back to ActiveToolCallId only for legacy events (no ID).
+    /// </summary>
+    static (System.Collections.Immutable.ImmutableList<ChatTimelineItem> Entries, string? EntryId) ResolveToolEntry(
+        ChatTimelineState state, string? toolCallId)
+    {
+        if (toolCallId is { } tcId)
+        {
+            // ID provided: strict lookup only. If mapping already consumed, no-op (don't misroute).
+            return state.ActiveToolCalls.TryGetValue(tcId, out var entryId)
+                ? (state.Entries, entryId)
+                : (state.Entries, null);
+        }
+
+        // No ID: legacy positional fallback.
+        return (state.Entries, state.ActiveToolCallId);
     }
 
     static ChatTimelineState UpsertAssistant(ChatTimelineState state, string text, bool replace, bool streaming, bool reconcilePrevious = false)
@@ -206,14 +246,42 @@ public static class ChatTimelineReducer
         };
     }
 
-    static ChatTimelineState EndTurn(ChatTimelineState state) => state with
+    static ChatTimelineState ApplyTurnEnd(ChatTimelineState state)
     {
-        TurnActive = false,
-        ActiveAssistantId = null,
-        ActiveReasoningId = null,
-        ActiveToolCallId = null,
-        PendingPermission = null
-    };
+        var entries = state.Entries;
+
+        // Collect all entry IDs that are still tracked as active.
+        var activeEntryIds = new System.Collections.Generic.HashSet<string>();
+        if (state.ActiveToolCallId is { } fallbackId)
+            activeEntryIds.Add(fallbackId);
+        foreach (var kvp in state.ActiveToolCalls)
+            activeEntryIds.Add(kvp.Value);
+
+        // Mark all remaining in-progress tools as Interrupted (reality: they never completed).
+        foreach (var entryId in activeEntryIds)
+        {
+            var idx = entries.FindIndex(en => en.Id == entryId);
+            if (idx >= 0 && entries[idx].ToolResult == ChatToolCallStatus.InProgress)
+            {
+                entries = entries.SetItem(idx, entries[idx] with
+                {
+                    ToolResult = ChatToolCallStatus.Interrupted
+                });
+            }
+        }
+
+        return state with
+        {
+            Entries = entries,
+            TurnActive = false,
+            ActiveAssistantId = null,
+            ActiveReasoningId = null,
+            ActiveToolCallId = null,
+            ActiveToolCalls = System.Collections.Immutable.ImmutableDictionary<string, string>.Empty,
+            PendingPermission = null
+        };
+    }
+
 
     static ChatTimelineState BeginTurn(ChatTimelineState state) =>
         state.TurnActive ? state : state with { TurnActive = true };

--- a/src/OpenClaw.Tray.WinUI/Chat/Explorations/FakeChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/Explorations/FakeChatDataProvider.cs
@@ -65,6 +65,7 @@ public sealed class FakeChatDataProvider : IChatDataProvider
             ActiveToolCallId: null,
             CurrentIntent: null,
             LocalNonces: ImmutableHashSet<string>.Empty,
+            ActiveToolCalls: ImmutableDictionary<string, string>.Empty,
             HistoryLoaded: true,
             PendingPermission: null);
     }

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -1219,15 +1219,15 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         var phase = evt.Data.TryGetProperty("phase", out var phaseProp) ? phaseProp.GetString() ?? "" : "";
         var title = evt.Data.TryGetProperty("title", out var titleProp) ? titleProp.GetString() ?? "" : "";
         var toolName = ExtractToolKindFromTitle(title);
+        var itemId = evt.Data.TryGetProperty("itemId", out var idProp) ? idProp.GetString() : null;
 
         return phase.ToLowerInvariant() switch
         {
-            "start" => new ChatToolStartEvent(title, toolName),
+            "start" => new ChatToolStartEvent(title, toolName, ToolCallId: itemId),
             // ``end`` flips the active tool's status to Success even when no
             // command_output arrived (e.g. ``read``, ``glob`` — non-shell).
-            // Use the title as a no-op output so the reducer marks Success.
-            "end" => new ChatToolOutputEvent(string.Empty),
-            "error" => new ChatToolErrorEvent(title),
+            "end" => new ChatToolOutputEvent(string.Empty, ToolCallId: itemId),
+            "error" => new ChatToolErrorEvent(title, ToolCallId: itemId),
             _ => null
         };
     }
@@ -1252,7 +1252,8 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         if (string.IsNullOrEmpty(output))
             return null;
 
-        return new ChatToolOutputEvent(output);
+        var itemId = evt.Data.TryGetProperty("itemId", out var idProp) ? idProp.GetString() : null;
+        return new ChatToolOutputEvent(output, ToolCallId: itemId);
     }
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
@@ -936,7 +936,7 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
             {
                 // Same palette as the previous chip — keeps continuity with
                 // Kenny's Cat04 tool cards. Running orange / Done green /
-                // Error critical.
+                // Error critical / Interrupted grey.
                 switch (entry.ToolResult)
                 {
                     case ChatToolCallStatus.Success:
@@ -945,6 +945,9 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                     case ChatToolCallStatus.Error:
                         var err = themeBrush("SystemFillColorCriticalBrush");
                         return (LocalizationHelper.GetString("Chat_Status_Error"), err, err);
+                    case ChatToolCallStatus.Interrupted:
+                        var grey = themeBrush("TextFillColorTertiaryBrush");
+                        return (LocalizationHelper.GetString("Chat_Status_Interrupted"), grey, grey);
                     default:
                         var run = new SolidColorBrush(Color.FromArgb(0xFF, 0xDC, 0x78, 0x1E));
                         return (LocalizationHelper.GetString("Chat_Status_Running"), run, themeBrush("TextFillColorTertiaryBrush"));
@@ -1148,12 +1151,15 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
             var stepCount = entries.Count;
 
             // Aggregate burst status: Error if any errored, Running if any
-            // not-yet-finished, otherwise Done. Drives the task header pill.
+            // not-yet-finished, Interrupted if any interrupted (but not running),
+            // otherwise Done. Drives the task header pill.
             ChatToolCallStatus aggregateStatus = ChatToolCallStatus.Success;
             foreach (var e in entries)
             {
                 if (e.ToolResult == ChatToolCallStatus.Error) { aggregateStatus = ChatToolCallStatus.Error; break; }
-                if (e.ToolResult != ChatToolCallStatus.Success) aggregateStatus = ChatToolCallStatus.InProgress;
+                if (e.ToolResult == ChatToolCallStatus.InProgress) { aggregateStatus = ChatToolCallStatus.InProgress; }
+                else if (e.ToolResult == ChatToolCallStatus.Interrupted && aggregateStatus == ChatToolCallStatus.Success)
+                    aggregateStatus = ChatToolCallStatus.Interrupted;
             }
             var (taskStatusText, taskStatusBg, _) = ResolveStatus(new ChatTimelineItem(
                 Id: "agg", Kind: ChatTimelineItemKind.ToolCall, Text: null,
@@ -1313,6 +1319,11 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                         case ChatToolCallStatus.Error:
                             return Caption("\uE711")
                                 .Foreground(themeBrush("SystemFillColorCriticalBrush"))
+                                .Set(t => { t.FontFamily = new FontFamily("Segoe Fluent Icons, Segoe MDL2 Assets"); t.FontSize = size; })
+                                .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center);
+                        case ChatToolCallStatus.Interrupted:
+                            return Caption("\uE738")
+                                .Foreground(themeBrush("TextFillColorTertiaryBrush"))
                                 .Set(t => { t.FontFamily = new FontFamily("Segoe Fluent Icons, Segoe MDL2 Assets"); t.FontSize = size; })
                                 .HAlign(HorizontalAlignment.Center).VAlign(VerticalAlignment.Center);
                         default:

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2826,6 +2826,9 @@ On your gateway host (Mac/Linux), run:
   <data name="Chat_Status_Error" xml:space="preserve">
     <value>Error</value>
   </data>
+  <data name="Chat_Status_Interrupted" xml:space="preserve">
+    <value>Interrupted</value>
+  </data>
   <data name="Chat_Timeline_LoadEarlier" xml:space="preserve">
     <value>Load earlier messages</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2777,6 +2777,9 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="Chat_Status_Error" xml:space="preserve">
     <value>Erreur</value>
   </data>
+  <data name="Chat_Status_Interrupted" xml:space="preserve">
+    <value>Interrompu</value>
+  </data>
   <data name="Chat_Timeline_LoadEarlier" xml:space="preserve">
     <value>Charger les messages précédents</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2778,6 +2778,9 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="Chat_Status_Error" xml:space="preserve">
     <value>Fout</value>
   </data>
+  <data name="Chat_Status_Interrupted" xml:space="preserve">
+    <value>Onderbroken</value>
+  </data>
   <data name="Chat_Timeline_LoadEarlier" xml:space="preserve">
     <value>Eerdere berichten laden</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2777,6 +2777,9 @@
   <data name="Chat_Status_Error" xml:space="preserve">
     <value>错误</value>
   </data>
+  <data name="Chat_Status_Interrupted" xml:space="preserve">
+    <value>已中断</value>
+  </data>
   <data name="Chat_Timeline_LoadEarlier" xml:space="preserve">
     <value>加载更早的消息</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2777,6 +2777,9 @@
   <data name="Chat_Status_Error" xml:space="preserve">
     <value>錯誤</value>
   </data>
+  <data name="Chat_Status_Interrupted" xml:space="preserve">
+    <value>已中斷</value>
+  </data>
   <data name="Chat_Timeline_LoadEarlier" xml:space="preserve">
     <value>載入較早的訊息</value>
   </data>

--- a/tests/OpenClaw.Tray.Tests/ChatTimelineReducerTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelineReducerTests.cs
@@ -154,6 +154,19 @@ public class ChatTimelineReducerTests
     }
 
     [Fact]
+    public void ToolOutput_WithToolCallId_PreservesOutputWhenEndEventIsEmpty()
+    {
+        var state = ChatTimelineState.Initial();
+        state = ChatTimelineReducer.Apply(state, new ChatToolStartEvent("exec command", "exec", ToolCallId: "tc1"));
+        state = ChatTimelineReducer.Apply(state, new ChatToolOutputEvent("command output", ToolCallId: "tc1"));
+
+        var updated = ChatTimelineReducer.Apply(state, new ChatToolOutputEvent(string.Empty, ToolCallId: "tc1"));
+
+        Assert.Equal(ChatToolCallStatus.Success, updated.Entries[0].ToolResult);
+        Assert.Equal("command output", updated.Entries[0].ToolOutput);
+    }
+
+    [Fact]
     public void ToolError_WithToolCallId_MatchesCorrectTool()
     {
         var state = ChatTimelineState.Initial();

--- a/tests/OpenClaw.Tray.Tests/ChatTimelineReducerTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelineReducerTests.cs
@@ -80,4 +80,121 @@ public class ChatTimelineReducerTests
         Assert.Equal(256, state.LocalNonces.Count);
         Assert.Contains("nonce-299", state.LocalNonces);
     }
+
+    [Fact]
+    public void TurnEnd_ClearsActiveToolCallId()
+    {
+        var state = ChatTimelineReducer.Apply(
+            ChatTimelineState.Initial(),
+            new ChatToolStartEvent("powershell", "powershell"));
+
+        Assert.NotNull(state.ActiveToolCallId);
+
+        var updated = ChatTimelineReducer.Apply(state, new ChatTurnEndEvent());
+
+        Assert.Null(updated.ActiveToolCallId);
+    }
+
+    [Fact]
+    public void TurnEnd_MarksInProgressToolAsInterrupted()
+    {
+        var state = ChatTimelineReducer.Apply(
+            ChatTimelineState.Initial(),
+            new ChatToolStartEvent("powershell", "powershell"));
+
+        var updated = ChatTimelineReducer.Apply(state, new ChatTurnEndEvent());
+
+        Assert.Single(updated.Entries);
+        Assert.Equal(ChatToolCallStatus.Interrupted, updated.Entries[0].ToolResult);
+    }
+
+    [Fact]
+    public void TurnEnd_WithNoActiveTool_IsNoOpForToolState()
+    {
+        var state = ChatTimelineReducer.Apply(
+            ChatTimelineState.Initial(),
+            new ChatThinkingEvent(string.Empty));
+
+        var updated = ChatTimelineReducer.Apply(state, new ChatTurnEndEvent());
+
+        Assert.False(updated.TurnActive);
+        Assert.Null(updated.ActiveToolCallId);
+    }
+
+    [Fact]
+    public void TurnEnd_MarksMultipleParallelToolsAsInterrupted()
+    {
+        var state = ChatTimelineState.Initial();
+        state = ChatTimelineReducer.Apply(state, new ChatToolStartEvent("read", "read", ToolCallId: "tc1"));
+        state = ChatTimelineReducer.Apply(state, new ChatToolStartEvent("grep", "grep", ToolCallId: "tc2"));
+
+        var updated = ChatTimelineReducer.Apply(state, new ChatTurnEndEvent());
+
+        Assert.Equal(2, updated.Entries.Count);
+        Assert.Equal(ChatToolCallStatus.Interrupted, updated.Entries[0].ToolResult);
+        Assert.Equal(ChatToolCallStatus.Interrupted, updated.Entries[1].ToolResult);
+        Assert.Null(updated.ActiveToolCallId);
+        Assert.Empty(updated.ActiveToolCalls);
+    }
+
+    [Fact]
+    public void ToolOutput_WithToolCallId_MatchesCorrectTool()
+    {
+        var state = ChatTimelineState.Initial();
+        state = ChatTimelineReducer.Apply(state, new ChatToolStartEvent("read foo", "read", ToolCallId: "tc1"));
+        state = ChatTimelineReducer.Apply(state, new ChatToolStartEvent("grep bar", "grep", ToolCallId: "tc2"));
+
+        // Output for tc1 arrives (even though tc2 started later)
+        var updated = ChatTimelineReducer.Apply(state, new ChatToolOutputEvent("file contents", ToolCallId: "tc1"));
+
+        Assert.Equal(ChatToolCallStatus.Success, updated.Entries[0].ToolResult);
+        Assert.Equal("file contents", updated.Entries[0].ToolOutput);
+        // tc2 still in progress
+        Assert.Equal(ChatToolCallStatus.InProgress, updated.Entries[1].ToolResult);
+    }
+
+    [Fact]
+    public void ToolError_WithToolCallId_MatchesCorrectTool()
+    {
+        var state = ChatTimelineState.Initial();
+        state = ChatTimelineReducer.Apply(state, new ChatToolStartEvent("read foo", "read", ToolCallId: "tc1"));
+        state = ChatTimelineReducer.Apply(state, new ChatToolStartEvent("grep bar", "grep", ToolCallId: "tc2"));
+
+        var updated = ChatTimelineReducer.Apply(state, new ChatToolErrorEvent("not found", ToolCallId: "tc2"));
+
+        // tc1 still in progress
+        Assert.Equal(ChatToolCallStatus.InProgress, updated.Entries[0].ToolResult);
+        // tc2 errored
+        Assert.Equal(ChatToolCallStatus.Error, updated.Entries[1].ToolResult);
+        Assert.Equal("not found", updated.Entries[1].ToolOutput);
+    }
+
+    [Fact]
+    public void ToolOutput_WithoutToolCallId_FallsBackToLastStarted()
+    {
+        // Legacy events without ToolCallId use positional fallback
+        var state = ChatTimelineReducer.Apply(
+            ChatTimelineState.Initial(),
+            new ChatToolStartEvent("powershell", "powershell"));
+
+        var updated = ChatTimelineReducer.Apply(state, new ChatToolOutputEvent("output text"));
+
+        Assert.Equal(ChatToolCallStatus.Success, updated.Entries[0].ToolResult);
+        Assert.Null(updated.ActiveToolCallId);
+    }
+
+    [Fact]
+    public void Error_MarksActiveToolAsInterrupted()
+    {
+        var state = ChatTimelineReducer.Apply(
+            ChatTimelineState.Initial(),
+            new ChatToolStartEvent("powershell", "powershell"));
+
+        var updated = ChatTimelineReducer.Apply(state, new ChatErrorEvent("Something broke"));
+
+        // Tool should be marked Interrupted (not Success — it never completed)
+        Assert.Equal(ChatToolCallStatus.Interrupted, updated.Entries[0].ToolResult);
+        Assert.Null(updated.ActiveToolCallId);
+        Assert.False(updated.TurnActive);
+    }
 }

--- a/tests/OpenClaw.Tray.Tests/LocalGatewayUninstallTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalGatewayUninstallTests.cs
@@ -16,6 +16,7 @@ namespace OpenClaw.Tray.Tests;
 /// All tests use isolated temp directories via OPENCLAW_TRAY_DATA_DIR /
 /// OPENCLAW_TRAY_LOCALAPPDATA_DIR to avoid touching the real user profile.
 /// </summary>
+[Collection(OpenClawTrayDataDirEnvironmentCollection.Name)]
 public sealed class LocalGatewayUninstallTests
 {
     // -----------------------------------------------------------------------

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -894,6 +894,25 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
+    public async Task AgentEvent_ItemEndAfterCommandOutput_PreservesOutput()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        await provider.LoadAsync();
+
+        bridge.RaiseAgent(MakeAgentEvent("item",
+            """{"phase":"start","kind":"tool","title":"exec run command echo hi","itemId":"tool-1"}"""));
+        bridge.RaiseAgent(MakeAgentEvent("command_output",
+            """{"phase":"end","itemId":"tool-1","output":"hi\n"}"""));
+        bridge.RaiseAgent(MakeAgentEvent("item",
+            """{"phase":"end","kind":"tool","title":"exec run command echo hi","itemId":"tool-1"}"""));
+
+        var timeline = snapshots[^1].Timelines["main"];
+        var entry = Assert.Single(timeline.Entries);
+        Assert.Equal(ChatToolCallStatus.Success, entry.ToolResult);
+        Assert.Equal("hi\n", entry.ToolOutput);
+    }
+
+    [Fact]
     public async Task AgentEvent_ToolError_ExtractsErrorText()
     {
         var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });

--- a/tests/OpenClaw.Tray.Tests/SettingsManagerIsolationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SettingsManagerIsolationTests.cs
@@ -3,6 +3,13 @@ using System.Text.Json;
 
 namespace OpenClaw.Tray.Tests;
 
+[CollectionDefinition(OpenClawTrayDataDirEnvironmentCollection.Name, DisableParallelization = true)]
+public sealed class OpenClawTrayDataDirEnvironmentCollection
+{
+    public const string Name = "OpenClawTrayDataDirEnvironment";
+}
+
+[Collection(OpenClawTrayDataDirEnvironmentCollection.Name)]
 public sealed class SettingsManagerIsolationTests
 {
     [Fact]


### PR DESCRIPTION
## Problem

Tool calls in the chat window get stuck in 'running' state due to:
1. Single \ActiveToolCallId\ slot can't track parallel tool calls
2. Turn end/error events don't finalize in-progress tools
3. Legacy fallback misroutes outputs to wrong tools when IDs are involved

## Solution

- **ID-based parallel tracking**: \ActiveToolCalls\ (ImmutableDictionary) maps \	oolCallId → entryId\ for parallel-safe correlation
- **Truthful Interrupted state**: Tools that never completed show as 'Interrupted' (grey dash) instead of fake 'Success'
- **Strict ID resolution**: If a \	oolCallId\ is provided but mapping is gone, returns null (no-op) — never misroutes to the wrong tool
- **Robust event ordering**: Output mapping preserved until turn end to handle \command_output\ + \item end\ arriving in any order
- **Legacy fallback preserved**: \ActiveToolCallId\ only set for events without correlation IDs (sequential legacy path)

## UI

- Interrupted tools render with grey dash glyph in \TextFillColorTertiaryBrush\
- Aggregate status priority: Error > InProgress > Interrupted > Success
- Localized to all 5 supported locales

## Testing

- 9 new regression tests covering parallel tools, ID correlation, interrupted state, legacy fallback
- All 2902 tests pass