### PR TITLE
feat: add ExecApprovalsCoordinator and ICanPresentEvaluator

### DIFF
--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2Result.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2Result.cs
@@ -11,7 +11,9 @@ public enum ExecApprovalV2Code
     AllowlistMiss,
     UserDenied,
     ValidationFailed,
-    ResolutionFailed
+    ResolutionFailed,
+    InternalError,  // invariant violations and unexpected internal bugs detected at runtime
+    Allow,          // coordinator approved; caller may execute the command
 }
 
 /// <summary>
@@ -49,6 +51,14 @@ public sealed class ExecApprovalV2Result
 
     public static ExecApprovalV2Result ResolutionFailed(string reason)
         => new(ExecApprovalV2Code.ResolutionFailed, reason);
+
+    public static ExecApprovalV2Result InternalError(string reason)
+        => new(ExecApprovalV2Code.InternalError, reason);
+
+    public static ExecApprovalV2Result Allow()
+        => new(ExecApprovalV2Code.Allow, "approved");
+
+    public bool IsAllow => Code == ExecApprovalV2Code.Allow;
 
     public override string ToString() => $"{Code}: {Reason}";
 }

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenClaw.Shared;
+
+namespace OpenClaw.Shared.ExecApprovals;
+
+// Full coordinator pipeline: validate → normalize → buildContext → evaluate(pass1) →
+// prompt/fallback → [persistAllowlistEntry stub] → evaluate(pass2) → final decision.
+// Rail 10: no WinUI types. Rail 17: SemaphoreSlim serializes the prompt+pass2 block.
+// Rail 19: not wired in production src in PR7 — verified by test 15.
+// Must be registered as singleton when wired (PR8+): the SemaphoreSlim is per-instance.
+public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
+{
+    private readonly ExecApprovalsStore _store;
+    private readonly ICanPresentEvaluator _canPresent;
+    private readonly IExecApprovalV2PromptHandler _prompt;
+    private readonly IOpenClawLogger _logger;
+
+    // Serializes the prompt call + second-pass block (rail 17).
+    // Does NOT protect validate/normalize/buildContext — those are stateless.
+    private readonly SemaphoreSlim _promptLock = new(1, 1);
+
+    public ExecApprovalsCoordinator(
+        ExecApprovalsStore store,
+        ICanPresentEvaluator canPresentEvaluator,
+        IExecApprovalV2PromptHandler promptHandler,
+        IOpenClawLogger logger)
+    {
+        _store = store;
+        _canPresent = canPresentEvaluator;
+        _prompt = promptHandler;
+        _logger = logger;
+    }
+
+    public async Task<ExecApprovalV2Result> HandleAsync(NodeInvokeRequest request, string correlationId)
+    {
+        if (string.IsNullOrEmpty(correlationId))
+            correlationId = Guid.NewGuid().ToString("N");
+
+        // Step 1: validate
+        var validation = ExecApprovalV2InputValidator.Validate(request);
+        if (!validation.IsValid)
+            return LogAndReturn(validation.Error!, correlationId,
+                promptAttempted: false, fallbackUsed: false);
+
+        // Step 2: normalize (unwrap shell wrappers, resolve executables, build canonical identity)
+        var norm = ExecApprovalV2Normalizer.Normalize(validation.Request!);
+        if (!norm.IsResolved)
+            return LogAndReturn(norm.Error!, correlationId,
+                promptAttempted: false, fallbackUsed: false);
+        var identity = norm.Identity!;
+
+        // Step 3: buildContext
+        var resolved = _store.ResolveReadOnly(identity.AgentId);
+
+        // Env injection guard — preserves SystemCapability.HandleRunAsync:343-351 behavior.
+        // identity.Env is IReadOnlyDictionary; copy to Dictionary for Sanitize.
+        var envInput = identity.Env is null
+            ? null
+            : new Dictionary<string, string>(identity.Env, StringComparer.OrdinalIgnoreCase);
+        var envResult = ExecEnvSanitizer.Sanitize(envInput);
+
+        if (envResult.Blocked.Length > 0)
+        {
+            var blockedNames = (string[])envResult.Blocked.Clone();
+            Array.Sort(blockedNames, StringComparer.OrdinalIgnoreCase);
+            _logger.Warn($"[EXEC-APPROVALS] [{correlationId}] env-blocked: [{string.Join(", ", blockedNames)}]");
+            return LogAndReturn(ExecApprovalV2Result.ValidationFailed("env-blocked"),
+                correlationId, promptAttempted: false, fallbackUsed: false);
+        }
+
+        var sanitizedEnv = envResult.Allowed as IReadOnlyDictionary<string, string>;
+        IReadOnlyList<ExecAllowlistEntry> matches = resolved.Defaults.Security == ExecSecurity.Allowlist
+            ? ExecAllowlistMatcher.MatchAll(resolved.Allowlist, identity.AllowlistResolutions)
+            : [];
+
+        var context = new ExecApprovalEvaluation(
+            identity.Command,
+            identity.DisplayCommand,
+            identity.AgentId,
+            resolved.Defaults.Security,
+            resolved.Defaults.Ask,
+            sanitizedEnv,
+            identity.AllowlistResolutions,
+            identity.AllowAlwaysPatterns,
+            matches);
+
+        // Step 4: first pass (approvalDecision always null in PR7 — CVE #8682, ADR-0002 Phase 2)
+        var pass1 = ExecApprovalEvaluator.Evaluate(context, null);
+        if (pass1 is ExecHostPolicyDecision.DenyOutcome denyPass1)
+            return LogAndReturn(denyPass1.Error, correlationId,
+                promptAttempted: false, fallbackUsed: false, canonical: context.DisplayCommand);
+        if (pass1 is ExecHostPolicyDecision.AllowOutcome)
+        {
+            // Pre-approved path (security=Full, ask=Off or allowlist satisfied): skip prompt
+            _logger.Info($"[EXEC-APPROVALS] [{correlationId}] path=new " +
+                $"canonical=\"{SanitizeForLog(context.DisplayCommand)}\" decision=allow " +
+                $"reason=approved fallbackUsed=false promptAttempted=false");
+            return ExecApprovalV2Result.Allow();
+        }
+        // RequiresPromptOutcome → continue to prompt/fallback block
+
+        // Steps 5-7: prompt/fallback + second pass (critical section)
+        bool promptAttempted = false;
+        bool fallbackUsed = false;
+
+        await _promptLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            ExecApprovalDecision followupDecision;
+
+            if (_canPresent.CanPresent(identity.SessionKey))
+            {
+                promptAttempted = true;
+                ExecApprovalPromptOutcome promptResult;
+                try
+                {
+                    promptResult = await _prompt.PromptAsync(
+                        BuildPromptRequest(context, identity, correlationId),
+                        cancellationToken: default).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Presenter failure → fail-closed, no fallback delegation
+                    return LogAndReturn(ExecApprovalV2Result.UserDenied("prompt-failed"),
+                        correlationId, promptAttempted: true, fallbackUsed: false,
+                        canonical: context.DisplayCommand);
+                }
+
+                // Allow (plain) from a prompt handler is an invariant violation —
+                // only AllowOnce and AllowAlways are semantically valid from UI.
+                if (promptResult == ExecApprovalPromptOutcome.Allow)
+                {
+                    _logger.Error($"[EXEC-APPROVALS] [{correlationId}] invariant: " +
+                        "prompt returned Allow — treating as invariant violation deny");
+                    return LogAndReturn(ExecApprovalV2Result.InternalError("prompt-returned-allow"),
+                        correlationId, promptAttempted: true, fallbackUsed: false,
+                        canonical: context.DisplayCommand);
+                }
+
+                // Exhaustive mapping without _ so the compiler warns if ExecApprovalPromptOutcome
+                // gains a new value. Allow is unreachable here — handled by the check above.
+                followupDecision = promptResult switch
+                {
+                    ExecApprovalPromptOutcome.Deny => ExecApprovalDecision.Deny,
+                    ExecApprovalPromptOutcome.AllowOnce => ExecApprovalDecision.AllowOnce,
+                    ExecApprovalPromptOutcome.AllowAlways => ExecApprovalDecision.AllowAlways,
+                    ExecApprovalPromptOutcome.Allow => throw new UnreachableException("prompt-returned-allow handled above"),
+                };
+            }
+            else
+            {
+                fallbackUsed = true;
+                followupDecision = FallbackDecision(context, resolved.Defaults.AskFallback);
+            }
+
+            // Step 6: AddAllowlistEntry stub (PR9 implements for AllowAlways + security==Allowlist)
+
+            // Step 7: second pass — must never return RequiresPrompt
+            var pass2 = ExecApprovalEvaluator.Evaluate(context, followupDecision);
+            if (pass2 is ExecHostPolicyDecision.DenyOutcome denyPass2)
+                return LogAndReturn(denyPass2.Error, correlationId, promptAttempted, fallbackUsed,
+                    canonical: context.DisplayCommand);
+            if (pass2 is ExecHostPolicyDecision.RequiresPromptOutcome)
+            {
+                _logger.Error($"[EXEC-APPROVALS] [{correlationId}] invariant: " +
+                    "second pass returned RequiresPrompt");
+                return LogAndReturn(ExecApprovalV2Result.InternalError("second-pass-requires-prompt"),
+                    correlationId, promptAttempted, fallbackUsed, canonical: context.DisplayCommand);
+            }
+            // AllowOutcome → fall through to steps 8-10
+        }
+        finally
+        {
+            _promptLock.Release();
+        }
+
+        // Step 8: RecordAllowlistUse stub (PR9)
+
+        // Step 9: final allow log
+        _logger.Info($"[EXEC-APPROVALS] [{correlationId}] path=new " +
+            $"canonical=\"{SanitizeForLog(context.DisplayCommand)}\" decision=allow " +
+            $"reason=approved fallbackUsed={fallbackUsed} promptAttempted={promptAttempted}");
+
+        // Step 10: return Allow
+        return ExecApprovalV2Result.Allow();
+    }
+
+    // Fail-safe defaults when no UI is available (Saltzer/Schroeder fail-safe defaults, OWASP ASVS 4.1.4).
+    // ask=Always → Deny: human approval is a precondition; without UI the only safe outcome is deny.
+    private static ExecApprovalDecision FallbackDecision(
+        ExecApprovalEvaluation context,
+        ExecAsk askFallback)
+    {
+        return askFallback switch
+        {
+            ExecAsk.Off => ExecApprovalDecision.AllowOnce,
+            ExecAsk.OnMiss => context.AllowlistSatisfied
+                ? ExecApprovalDecision.AllowOnce
+                : ExecApprovalDecision.Deny,
+            ExecAsk.Always => ExecApprovalDecision.Deny,
+            ExecAsk.Deny => ExecApprovalDecision.Deny,
+            _ => ExecApprovalDecision.Deny,  // defensive
+        };
+    }
+
+    private static ExecApprovalV2PromptRequest BuildPromptRequest(
+        ExecApprovalEvaluation context,
+        CanonicalCommandIdentity identity,
+        string correlationId)
+        => new()
+        {
+            DisplayCommand = context.DisplayCommand,  // NOT sanitized — presenter's responsibility (rail 11)
+            Cwd = identity.Cwd,
+            Security = context.Security,
+            Ask = context.Ask,
+            AgentId = context.AgentId ?? "main",
+            ResolvedPath = context.Resolution?.ResolvedPath,
+            SessionKey = identity.SessionKey,
+            CorrelationId = correlationId,
+            // Host omitted in PR7 (no gateway wiring yet)
+        };
+
+    // Anti log-injection: replaces control characters in DisplayCommand before writing to logs.
+    // Truncates to 200 chars — sufficient for triage, bounded for disk-bound logs.
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return "";
+        Span<char> buffer = stackalloc char[Math.Min(value.Length, 200)];
+        var count = 0;
+        foreach (var ch in value)
+        {
+            if (count == buffer.Length) break;
+            buffer[count++] = char.IsControl(ch) ? ' ' : ch;
+        }
+        var sanitized = new string(buffer[..count]);
+        return value.Length > count ? sanitized + "..." : sanitized;
+    }
+
+    private ExecApprovalV2Result LogAndReturn(
+        ExecApprovalV2Result result,
+        string correlationId,
+        bool promptAttempted,
+        bool fallbackUsed,
+        string? canonical = null)
+    {
+        var safeCanonical = SanitizeForLog(canonical);
+        var msg = $"[EXEC-APPROVALS] [{correlationId}] path=new " +
+            $"canonical=\"{safeCanonical}\" decision=deny reason={result.Reason} " +
+            $"fallbackUsed={fallbackUsed} promptAttempted={promptAttempted}";
+        if (result.Code == ExecApprovalV2Code.InternalError)
+            _logger.Error(msg);
+        else
+            _logger.Warn(msg);
+        return result;
+    }
+}

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
@@ -40,6 +40,8 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
         if (string.IsNullOrEmpty(correlationId))
             correlationId = Guid.NewGuid().ToString("N");
 
+        try
+        {
         // Step 1: validate
         var validation = ExecApprovalV2InputValidator.Validate(request);
         if (!validation.IsValid)
@@ -187,6 +189,18 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
 
         // Step 10: return Allow
         return ExecApprovalV2Result.Allow();
+        }
+        catch (Exception ex)
+        {
+            // Outer safety net: any unhandled exception in buildContext, CanPresent, FallbackDecision,
+            // or an out-of-range prompt outcome produces a typed deny instead of escaping HandleAsync.
+            // Rail 1: failures in the new path must never be silent or untyped.
+            var msg = $"[EXEC-APPROVALS] [{correlationId}] path=new " +
+                $"canonical=\"\" decision=deny reason=unexpected-exception " +
+                $"fallbackUsed=false promptAttempted=false";
+            _logger.Error(msg, ex);
+            return ExecApprovalV2Result.InternalError("unexpected-exception");
+        }
     }
 
     // Fail-safe defaults when no UI is available (Saltzer/Schroeder fail-safe defaults, OWASP ASVS 4.1.4).

--- a/src/OpenClaw.Shared/ExecApprovals/ICanPresentEvaluator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ICanPresentEvaluator.cs
@@ -1,0 +1,30 @@
+namespace OpenClaw.Shared.ExecApprovals;
+
+// Determines whether the coordinator can present a UI prompt for this request.
+// Doc 08 F1 lists four inputs to canPresent: requestSessionKey, activeSessionKey,
+// lastInputSeconds, desktopInteractive. Only requestSessionKey is passed by the
+// coordinator — the other three are encapsulated inside the implementation:
+//   activeSessionKey: provided by whatever tracks the active tray session.
+//   lastInputSeconds: read via Win32 GetLastInputInfo (OQ-F1).
+//   desktopInteractive: read via OpenInputDesktop / WTSQuerySessionInformation (OQ-F1).
+// Keeping these out of the interface keeps the coordinator UI-free (rail 10) and
+// testable without Win32. Must never throw — fail to false (no UI available).
+public interface ICanPresentEvaluator
+{
+    bool CanPresent(string? requestSessionKey);
+}
+
+// Default for PR7: UI not wired yet. Everything routes to FallbackDecision.
+public sealed class AlwaysCannotPresentEvaluator : ICanPresentEvaluator
+{
+    public static readonly AlwaysCannotPresentEvaluator Instance = new();
+    public bool CanPresent(string? requestSessionKey) => false;
+}
+
+// Test double: always reports UI available. Used in coordinator tests to
+// exercise the prompt path with the null prompt handler.
+public sealed class AlwaysCanPresentEvaluator : ICanPresentEvaluator
+{
+    public static readonly AlwaysCanPresentEvaluator Instance = new();
+    public bool CanPresent(string? requestSessionKey) => true;
+}

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
@@ -1,0 +1,480 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using OpenClaw.Shared;
+using OpenClaw.Shared.ExecApprovals;
+
+namespace OpenClaw.Shared.Tests;
+
+/// <summary>
+/// Tests for PR7: ExecApprovalsCoordinator full pipeline.
+/// Covers rail 8 (observability), rail 10 (UI-free), rail 17 (concurrency),
+/// rail 19 (production wiring inert), env injection guard, and log injection prevention.
+/// </summary>
+public class ExecApprovalsCoordinatorTests : IDisposable
+{
+    private readonly string _dir;
+
+    public ExecApprovalsCoordinatorTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"oca-coord-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static JsonElement Parse(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+
+    // ["cmd","/c","echo","hello"] reliably resolves cmd.exe on Windows via WellKnownPaths.
+    // Shell wrapper form: singular resolution succeeds; allowlistResolutions=[] (echo is a builtin).
+    private static NodeInvokeRequest Req(string argsJson)
+        => new() { Id = "r1", Command = "system.run", Args = Parse(argsJson) };
+
+    private static NodeInvokeRequest DefaultReq()
+        => Req("""{"command":["cmd","/c","echo","hello"]}""");
+
+    private void WriteStoreFile(string json)
+        => File.WriteAllText(Path.Combine(_dir, "exec-approvals.json"), json);
+
+    private ExecApprovalsCoordinator MakeCoordinator(
+        ICanPresentEvaluator? canPresent = null,
+        IExecApprovalV2PromptHandler? prompt = null,
+        IOpenClawLogger? logger = null)
+    {
+        var log = logger ?? NullLogger.Instance;
+        return new(
+            new ExecApprovalsStore(_dir, log),
+            canPresent ?? AlwaysCannotPresentEvaluator.Instance,
+            prompt ?? ExecApprovalV2NullPromptHandler.Instance,
+            log);
+    }
+
+    // ── 1. No file → SecurityDeny (default-deny on first activation) ──────────
+
+    [Fact]
+    public async Task NoFile_ReturnsSecurityDeny()
+    {
+        var result = await MakeCoordinator().HandleAsync(DefaultReq(), "c1");
+        Assert.Equal(ExecApprovalV2Code.SecurityDeny, result.Code);
+    }
+
+    // ── 2. security=full → Allow ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task SecurityFull_AskOff_ReturnsAllow()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"off"}}""");
+        var result = await MakeCoordinator().HandleAsync(DefaultReq(), "c2");
+        Assert.True(result.IsAllow);
+    }
+
+    // ── 3. security=deny → SecurityDeny ──────────────────────────────────────
+
+    [Fact]
+    public async Task SecurityDeny_ReturnsSecurityDeny()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"deny"}}""");
+        var result = await MakeCoordinator().HandleAsync(DefaultReq(), "c3");
+        Assert.Equal(ExecApprovalV2Code.SecurityDeny, result.Code);
+    }
+
+    // ── 4. ask=always, canPresent=false, askFallback=deny → UserDenied ────────
+
+    [Fact]
+    public async Task AskAlways_CannotPresent_FallbackDeny_ReturnsUserDenied()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always","askFallback":"deny"}}""");
+        var result = await MakeCoordinator().HandleAsync(DefaultReq(), "c4");
+        // FallbackDecision(ExecAsk.Deny) → ExecApprovalDecision.Deny → pass2 step2 → UserDenied
+        Assert.Equal(ExecApprovalV2Code.UserDenied, result.Code);
+        Assert.Equal("user-denied", result.Reason);
+    }
+
+    // ── 5. ask=always, canPresent=false, askFallback=off → Allow ─────────────
+
+    [Fact]
+    public async Task AskAlways_CannotPresent_FallbackOff_ReturnsAllow()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always","askFallback":"off"}}""");
+        var log = new CapturingLogger();
+        var result = await MakeCoordinator(logger: log).HandleAsync(DefaultReq(), "c5");
+        Assert.True(result.IsAllow);
+        Assert.NotNull(log.LastInfo);
+        Assert.Contains("fallbackUsed=True", log.LastInfo, StringComparison.Ordinal);
+    }
+
+    // ── 6. canPresent=true, NullPromptHandler → UserDenied ───────────────────
+
+    [Fact]
+    public async Task CanPresent_NullPrompt_ReturnsUserDenied()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always"}}""");
+        var result = await MakeCoordinator(
+            canPresent: AlwaysCanPresentEvaluator.Instance,
+            prompt: ExecApprovalV2NullPromptHandler.Instance).HandleAsync(DefaultReq(), "c6");
+        Assert.Equal(ExecApprovalV2Code.UserDenied, result.Code);
+    }
+
+    // ── 7. canPresent=true, AllowOnce → Allow ────────────────────────────────
+
+    [Fact]
+    public async Task CanPresent_AllowOnce_ReturnsAllow()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always"}}""");
+        var log = new CapturingLogger();
+        var result = await MakeCoordinator(
+            canPresent: AlwaysCanPresentEvaluator.Instance,
+            prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.AllowOnce),
+            logger: log).HandleAsync(DefaultReq(), "c7");
+        Assert.True(result.IsAllow);
+        Assert.Contains("promptAttempted=True", log.LastInfo!, StringComparison.Ordinal);
+        Assert.DoesNotContain("fallbackUsed=True", log.LastInfo!, StringComparison.Ordinal);
+    }
+
+    // ── 8. canPresent=true, AllowAlways → Allow ───────────────────────────────
+
+    [Fact]
+    public async Task CanPresent_AllowAlways_ReturnsAllow()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always"}}""");
+        var result = await MakeCoordinator(
+            canPresent: AlwaysCanPresentEvaluator.Instance,
+            prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.AllowAlways))
+            .HandleAsync(DefaultReq(), "c8");
+        Assert.True(result.IsAllow);
+    }
+
+    // ── 9. Invariant: prompt returns Allow → InternalError ────────────────────
+
+    [Fact]
+    public async Task PromptReturnsAllowPlain_ReturnsInternalError()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always"}}""");
+        var result = await MakeCoordinator(
+            canPresent: AlwaysCanPresentEvaluator.Instance,
+            prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.Allow))
+            .HandleAsync(DefaultReq(), "c9");
+        Assert.Equal(ExecApprovalV2Code.InternalError, result.Code);
+        Assert.Equal("prompt-returned-allow", result.Reason);
+    }
+
+    // ── 10. Prompt throws → UserDenied, no fallback ───────────────────────────
+
+    [Fact]
+    public async Task PromptThrows_ReturnsUserDenied_FallbackNotUsed()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always"}}""");
+        var log = new CapturingLogger();
+        var result = await MakeCoordinator(
+            canPresent: AlwaysCanPresentEvaluator.Instance,
+            prompt: new ThrowingPromptHandler(),
+            logger: log).HandleAsync(DefaultReq(), "c10");
+        Assert.Equal(ExecApprovalV2Code.UserDenied, result.Code);
+        Assert.Equal("prompt-failed", result.Reason);
+        // Must not delegate to fallback after presenter failure
+        Assert.Contains("fallbackUsed=False", log.LastWarn!, StringComparison.Ordinal);
+    }
+
+    // ── 11. Input invalid → ValidationFailed ─────────────────────────────────
+
+    [Fact]
+    public async Task InvalidInput_ReturnsValidationFailed()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full"}}""");
+        var result = await MakeCoordinator().HandleAsync(
+            Req("""{}"""), "c11");
+        Assert.Equal(ExecApprovalV2Code.ValidationFailed, result.Code);
+    }
+
+    // ── 12. security=allowlist, allowlist empty, ask=off → AllowlistMiss ──────
+
+    [Fact]
+    public async Task SecurityAllowlist_EmptyList_ReturnsAllowlistMiss()
+    {
+        // ["cmd","/c","echo","hello"] → shell wrapper → allowlistResolutions=[] → AllowlistSatisfied=false
+        WriteStoreFile("""{"version":1,"defaults":{"security":"allowlist","ask":"off"}}""");
+        var result = await MakeCoordinator().HandleAsync(DefaultReq(), "c12");
+        Assert.Equal(ExecApprovalV2Code.AllowlistMiss, result.Code);
+    }
+
+    // ── 13. FallbackDecision(ask=Always) → Deny, not AllowOnce ───────────────
+
+    [Fact]
+    public async Task FallbackDecision_AskFallbackAlways_ReturnsDeny()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always","askFallback":"always"}}""");
+        var result = await MakeCoordinator().HandleAsync(DefaultReq(), "c13");
+        // ExecAsk.Always → ExecApprovalDecision.Deny → pass2 → UserDenied (fail-safe)
+        Assert.False(result.IsAllow);
+        Assert.NotEqual(ExecApprovalV2Code.Allow, result.Code);
+    }
+
+    // ── 14. Rail 8 — 7 log fields present ────────────────────────────────────
+
+    [Fact]
+    public async Task Rail8_AllSevenLogFieldsPresent()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"deny"}}""");
+        var log = new CapturingLogger();
+        await MakeCoordinator(logger: log).HandleAsync(DefaultReq(), "corr-14");
+
+        // security=deny → LogAndReturn → Warn; check all 7 rail-8 fields
+        Assert.NotNull(log.LastWarn);
+        var msg = log.LastWarn!;
+        Assert.Contains("corr-14", msg, StringComparison.Ordinal);
+        Assert.Contains("path=new", msg, StringComparison.Ordinal);
+        Assert.Contains("canonical=", msg, StringComparison.Ordinal);
+        Assert.Contains("decision=deny", msg, StringComparison.Ordinal);
+        Assert.Contains("reason=", msg, StringComparison.Ordinal);
+        Assert.Contains("fallbackUsed=", msg, StringComparison.Ordinal);
+        Assert.Contains("promptAttempted=", msg, StringComparison.Ordinal);
+    }
+
+    // ── 15. Coordinator not wired in production src ───────────────────────────
+
+    [Fact]
+    public void ProductionWiring_CoordinatorNotReferencedInSrc()
+    {
+        var repoRoot = FindRepoRoot();
+        Assert.NotNull(repoRoot);
+        var srcDir = Path.Combine(repoRoot, "src");
+        var violations = Directory
+            .GetFiles(srcDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.EndsWith("ExecApprovalsCoordinator.cs", StringComparison.OrdinalIgnoreCase))
+            .Where(f => File.ReadAllText(f).Contains("ExecApprovalsCoordinator", StringComparison.Ordinal))
+            .ToList();
+        Assert.Empty(violations);
+    }
+
+    // ── 16. Rail 10 — coordinator in OpenClaw.Shared, not Tray ───────────────
+
+    [Fact]
+    public void Rail10_CoordinatorAssemblyIsOpenClawShared()
+    {
+        var asm = typeof(ExecApprovalsCoordinator).Assembly.GetName().Name;
+        Assert.Equal("OpenClaw.Shared", asm);
+    }
+
+    // ── 17. Concurrency — 5 simultaneous requests don't corrupt state ─────────
+
+    [Fact]
+    public async Task Concurrency_FiveConcurrentRequests_AllReturnValidResults()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"off"}}""");
+        var coordinator = MakeCoordinator();
+        var tasks = Enumerable.Range(0, 5)
+            .Select(i => coordinator.HandleAsync(DefaultReq(), $"conc-{i}"))
+            .ToList();
+        var results = await Task.WhenAll(tasks);
+        Assert.All(results, r => Assert.NotNull(r));
+        Assert.All(results, r => Assert.True(r.IsAllow));
+    }
+
+    // ── 18. Env injection → ValidationFailed("env-blocked") ──────────────────
+
+    [Fact]
+    public async Task EnvInjection_BlockedEnvVar_ReturnsValidationFailed()
+    {
+        // security=full,ask=off rules out other denies; env PATH is always blocked
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"off"}}""");
+        var log = new CapturingLogger();
+        var result = await MakeCoordinator(logger: log)
+            .HandleAsync(Req("""{"command":["cmd","/c","echo","hello"],"env":{"PATH":"C:\\evil"}}"""), "c18");
+
+        Assert.Equal(ExecApprovalV2Code.ValidationFailed, result.Code);
+        Assert.Equal("env-blocked", result.Reason);
+        // Separate Warn with blocked names (emitted before LogAndReturn)
+        Assert.Contains(log.Warns, w =>
+            w.Contains("env-blocked", StringComparison.Ordinal) &&
+            w.Contains("PATH", StringComparison.Ordinal));
+    }
+
+    // ── 19. Log injection — DisplayCommand control chars replaced in log ───────
+
+    [Fact]
+    public async Task LogInjection_ControlCharsInCommand_SanitizedInLog()
+    {
+        // \r\n in JSON string → actual CR+LF in the parsed command argument
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"off"}}""");
+        var log = new CapturingLogger();
+        await MakeCoordinator(logger: log)
+            .HandleAsync(Req("""{"command":["cmd","/c","x\r\n[EXEC-APPROVALS] [fake] FAKE"]}"""), "c19");
+
+        // Should allow (security=full, ask=off)
+        Assert.NotNull(log.LastInfo);
+        // CR+LF must not appear literally in the log line
+        Assert.DoesNotContain("\r\n", log.LastInfo!, StringComparison.Ordinal);
+    }
+
+    // ── 20. Lock released after prompt throws — second call must not deadlock ────
+
+    [Fact]
+    public async Task PromptThrows_LockReleasedForSubsequentCall()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always"}}""");
+        var coordinator = MakeCoordinator(
+            canPresent: AlwaysCanPresentEvaluator.Instance,
+            prompt: new ThrowingPromptHandler());
+
+        var first = await coordinator.HandleAsync(DefaultReq(), "lock-1");
+        Assert.Equal(ExecApprovalV2Code.UserDenied, first.Code);
+
+        // Second call must complete — if lock was not released this would deadlock
+        var second = await coordinator.HandleAsync(DefaultReq(), "lock-2");
+        Assert.Equal(ExecApprovalV2Code.UserDenied, second.Code);
+    }
+
+    // ── 21a. Concurrency with actual lock contention ───────────────────────────
+
+    [Fact]
+    public async Task Concurrency_PromptPathWithLockContention_AllReturnValidResults()
+    {
+        // ask=always + canPresent=true → all requests enter the locked block
+        // NullPromptHandler returns Deny → all should be UserDenied (no deadlock, no corruption)
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always"}}""");
+        var coordinator = MakeCoordinator(canPresent: AlwaysCanPresentEvaluator.Instance);
+        var tasks = Enumerable.Range(0, 5)
+            .Select(i => coordinator.HandleAsync(DefaultReq(), $"cont-{i}"))
+            .ToList();
+        var results = await Task.WhenAll(tasks);
+        Assert.All(results, r => Assert.NotNull(r));
+        // NullPromptHandler returns Deny → UserDenied for all
+        Assert.All(results, r => Assert.Equal(ExecApprovalV2Code.UserDenied, r.Code));
+    }
+
+    // ── 22a. ExecApprovalV2Result — new codes constructible (InternalError, Allow) ──
+
+    [Fact]
+    public void V2Result_InternalError_CodeAndReason()
+    {
+        var r = ExecApprovalV2Result.InternalError("invariant-violation");
+        Assert.Equal(ExecApprovalV2Code.InternalError, r.Code);
+        Assert.Equal("invariant-violation", r.Reason);
+        Assert.False(r.IsAllow);
+    }
+
+    [Fact]
+    public void V2Result_Allow_IsAllowTrueAndReasonApproved()
+    {
+        var r = ExecApprovalV2Result.Allow();
+        Assert.Equal(ExecApprovalV2Code.Allow, r.Code);
+        Assert.Equal("approved", r.Reason);
+        Assert.True(r.IsAllow);
+    }
+
+    [Fact]
+    public void V2Result_IsAllow_FalseForAllDenyCodes()
+    {
+        Assert.False(ExecApprovalV2Result.SecurityDeny("x").IsAllow);
+        Assert.False(ExecApprovalV2Result.UserDenied("x").IsAllow);
+        Assert.False(ExecApprovalV2Result.ValidationFailed("x").IsAllow);
+        Assert.False(ExecApprovalV2Result.InternalError("x").IsAllow);
+    }
+
+    // ── 21. ICanPresentEvaluator stubs ────────────────────────────────────────
+
+    [Fact]
+    public void AlwaysCannotPresent_AlwaysReturnsFalse()
+    {
+        Assert.False(AlwaysCannotPresentEvaluator.Instance.CanPresent(null));
+        Assert.False(AlwaysCannotPresentEvaluator.Instance.CanPresent("session-key"));
+    }
+
+    [Fact]
+    public void AlwaysCanPresent_AlwaysReturnsTrue()
+    {
+        Assert.True(AlwaysCanPresentEvaluator.Instance.CanPresent(null));
+        Assert.True(AlwaysCanPresentEvaluator.Instance.CanPresent("session-key"));
+    }
+
+    // ── 22. Empty correlationId → auto-generated 32-char hex ─────────────────
+
+    [Fact]
+    public async Task EmptyCorrelationId_AutoGeneratedInLog()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"deny"}}""");
+        var log = new CapturingLogger();
+        await MakeCoordinator(logger: log).HandleAsync(DefaultReq(), "");
+
+        Assert.NotNull(log.LastWarn);
+        // log format: "[EXEC-APPROVALS] [<correlationId>] path=new ..."
+        // auto-generated correlationId: Guid.NewGuid().ToString("N") → 32 hex chars
+        var msg = log.LastWarn!;
+        var second = msg.IndexOf('[', msg.IndexOf(']') + 1) + 1;
+        var end = msg.IndexOf(']', second);
+        Assert.True(end > second);
+        var id = msg[second..end];
+        Assert.Equal(32, id.Length);
+        Assert.True(id.All(c => char.IsAsciiHexDigit(c)), $"Expected 32 hex chars, got: {id}");
+    }
+
+    // ── 23. FallbackDecision(OnMiss, AllowlistSatisfied=false) → Deny ─────────
+
+    [Fact]
+    public async Task FallbackDecision_AskFallbackOnMiss_NotSatisfied_ReturnsDeny()
+    {
+        // security=full, ask=always → RequiresPrompt in pass1
+        // canPresent=false → FallbackDecision(context, ExecAsk.OnMiss)
+        // AllowlistSatisfied=false (security=Full, not Allowlist) → Deny
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always","askFallback":"on-miss"}}""");
+        var result = await MakeCoordinator().HandleAsync(DefaultReq(), "c23");
+        Assert.False(result.IsAllow);
+    }
+
+    // ── Test doubles ──────────────────────────────────────────────────────────
+
+    private sealed class FixedDecisionPromptHandler : IExecApprovalV2PromptHandler
+    {
+        private readonly ExecApprovalPromptOutcome _outcome;
+        public FixedDecisionPromptHandler(ExecApprovalPromptOutcome o) => _outcome = o;
+        public Task<ExecApprovalPromptOutcome> PromptAsync(
+            ExecApprovalV2PromptRequest _,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(_outcome);
+    }
+
+    private sealed class ThrowingPromptHandler : IExecApprovalV2PromptHandler
+    {
+        public Task<ExecApprovalPromptOutcome> PromptAsync(
+            ExecApprovalV2PromptRequest _,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("simulated presenter crash");
+    }
+
+    private sealed class CapturingLogger : IOpenClawLogger
+    {
+        public List<string> Infos { get; } = [];
+        public List<string> Warns { get; } = [];
+        public List<string> Errors { get; } = [];
+        public string? LastInfo => Infos.Count > 0 ? Infos[^1] : null;
+        public string? LastWarn => Warns.Count > 0 ? Warns[^1] : null;
+        public string? LastError => Errors.Count > 0 ? Errors[^1] : null;
+        public void Info(string m) => Infos.Add(m);
+        public void Debug(string m) { }
+        public void Warn(string m) => Warns.Add(m);
+        public void Error(string m, Exception? _ = null) => Errors.Add(m);
+    }
+
+    private static string? FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "openclaw-windows-node.slnx")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        return null;
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
@@ -432,6 +432,22 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         Assert.False(result.IsAllow);
     }
 
+    // ── 24. Outer safety net — CanPresent throws → InternalError, not exception ───
+
+    [Fact]
+    public async Task CanPresent_Throws_ReturnsInternalError_NotException()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always"}}""");
+        var log = new CapturingLogger();
+        var result = await MakeCoordinator(
+            canPresent: new ThrowingCanPresentEvaluator(),
+            logger: log).HandleAsync(DefaultReq(), "outer-1");
+
+        Assert.Equal(ExecApprovalV2Code.InternalError, result.Code);
+        Assert.Equal("unexpected-exception", result.Reason);
+        Assert.Contains(log.Errors, e => e.Contains("unexpected-exception"));
+    }
+
     // ── Test doubles ──────────────────────────────────────────────────────────
 
     private sealed class FixedDecisionPromptHandler : IExecApprovalV2PromptHandler
@@ -442,6 +458,12 @@ public class ExecApprovalsCoordinatorTests : IDisposable
             ExecApprovalV2PromptRequest _,
             CancellationToken cancellationToken = default)
             => Task.FromResult(_outcome);
+    }
+
+    private sealed class ThrowingCanPresentEvaluator : ICanPresentEvaluator
+    {
+        public bool CanPresent(string? requestSessionKey)
+            => throw new InvalidOperationException("simulated canPresent crash");
     }
 
     private sealed class ThrowingPromptHandler : IExecApprovalV2PromptHandler


### PR DESCRIPTION
## Summary
Adds `ExecApprovalsCoordinator`, which implements the full exec approval
pipeline for the Windows port. The previous `IExecApprovalV2Handler`
implementation was a null stub. This wires the existing building
blocks — validator, normalizer, store, evaluator, and prompt handler —
into the correct two-pass flow: validate, build evaluation context,
first pass, prompt or fallback, second pass, final decision.

## What changed
- `ExecApprovalsCoordinator`: coordinator implementing `IExecApprovalV2Handler`
- `ICanPresentEvaluator`: interface for the UI availability check, with two stubs for testing
- `ExecApprovalV2Result`: `InternalError` and `Allow` codes with `IsAllow` property

## Testing
- `dotnet test tests/OpenClaw.Shared.Tests --filter "ExecApproval"` — 430 passed
- 28 new tests covering all decision branches, env injection guard,
  log injection prevention, lock release, and concurrent requests

## Notes
Allowlist entry persistence and use recording are stubs — they belong
to the next step. The coordinator is not wired into production in this
change; a test enforces that invariant.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>