### PR TITLE
Dedupe chat surface selection

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/ChatSurfaceResolver.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/ChatSurfaceResolver.cs
@@ -1,0 +1,48 @@
+using OpenClawTray.Helpers;
+
+namespace OpenClawTray.Chat;
+
+public enum ChatSurfaceTarget
+{
+    HubChat,
+    TrayChat,
+}
+
+public readonly record struct ChatSurfaceDecision(
+    bool UseLegacyWebChat,
+    string? ChatUrl,
+    bool ChatUrlChanged);
+
+public static class ChatSurfaceResolver
+{
+    public static ChatSurfaceDecision Resolve(
+        ChatSurfaceTarget target,
+        bool useLegacyWebChatSetting,
+        string? currentChatUrl,
+        string? resolvedChatUrl)
+    {
+        var useLegacy = DebugChatSurfaceOverrides.ResolveUseLegacy(
+            GetOverride(target),
+            useLegacyWebChatSetting);
+
+        var urlChanged = !string.Equals(resolvedChatUrl, currentChatUrl, StringComparison.Ordinal);
+        return new ChatSurfaceDecision(useLegacy, resolvedChatUrl, urlChanged);
+    }
+
+    public static string? BuildChatUrl(string? gatewayUrl, string? token)
+    {
+        gatewayUrl ??= string.Empty;
+        token ??= string.Empty;
+
+        return GatewayChatUrlBuilder.TryBuildChatUrl(gatewayUrl, token, out var url, out _)
+            ? url
+            : null;
+    }
+
+    private static ChatSurfaceOverride GetOverride(ChatSurfaceTarget target) => target switch
+    {
+        ChatSurfaceTarget.HubChat => DebugChatSurfaceOverrides.HubChat,
+        ChatSurfaceTarget.TrayChat => DebugChatSurfaceOverrides.TrayChat,
+        _ => ChatSurfaceOverride.NoOverride,
+    };
+}

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -162,19 +162,16 @@ public sealed partial class ChatPage : Page
     {
         if (CurrentApp.Settings is null) return;
 
-        // HIGH 3: re-resolve the chat URL from the current settings on every
-        // surface application — _chatUrl was previously computed once in
-        // Initialize() and never refreshed, so SettingsSaved (e.g. token /
-        // gateway URL change) would leave the WebView pointing at a stale URL.
-        var freshUrl = TryComputeChatUrl(CurrentApp.Settings);
-        var urlChanged = !string.Equals(freshUrl, _chatUrl, StringComparison.Ordinal);
-        _chatUrl = freshUrl;
+        var decision = ChatSurfaceResolver.Resolve(
+            ChatSurfaceTarget.HubChat,
+            CurrentApp.Settings.UseLegacyWebChat,
+            _chatUrl,
+            TryComputeChatUrl(CurrentApp.Settings));
 
-        var useLegacy = OpenClawTray.Chat.DebugChatSurfaceOverrides.ResolveUseLegacy(
-            OpenClawTray.Chat.DebugChatSurfaceOverrides.HubChat,
-            CurrentApp.Settings.UseLegacyWebChat);
-        if (useLegacy)
-            ShowWebViewSurface(forceNavigate: urlChanged);
+        _chatUrl = decision.ChatUrl;
+
+        if (decision.UseLegacyWebChat)
+            ShowWebViewSurface(forceNavigate: decision.ChatUrlChanged);
         else
             ShowFunctionalSurface();
     }
@@ -189,9 +186,8 @@ public sealed partial class ChatPage : Page
             settings.LegacyToken,
             settings.LegacyBootstrapToken,
             out var credential) &&
-            credential is { IsBootstrapToken: false } &&
-            GatewayChatUrlBuilder.TryBuildChatUrl(credential.GatewayUrl, credential.Token, out var url, out _)
-            ? url
+            credential is { IsBootstrapToken: false }
+            ? ChatSurfaceResolver.BuildChatUrl(credential.GatewayUrl, credential.Token)
             : null;
     }
 

--- a/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
@@ -24,7 +24,7 @@ public sealed partial class ChatWindow : WindowEx
 {
     private string _gatewayUrl;
     private string _token;
-    private string _chatUrl;
+    private string? _chatUrl;
     private MountedFunctionalChat? _functionalHost;
     private IChatDataProvider? _mountedProvider;
     private bool _webViewInitialized;
@@ -69,7 +69,7 @@ public sealed partial class ChatWindow : WindowEx
     {
         _gatewayUrl = gatewayUrl;
         _token = token;
-        _chatUrl = BuildChatUrl(gatewayUrl, token);
+        _chatUrl = ChatSurfaceResolver.BuildChatUrl(gatewayUrl, token);
         InitializeComponent();
 
         this.SetWindowSize(DefaultChatWidth, DefaultChatHeight);
@@ -201,10 +201,15 @@ public sealed partial class ChatWindow : WindowEx
     private void ApplyChatSurface()
     {
         var setting = (App.Current as App)?.Settings?.UseLegacyWebChat ?? false;
-        var useLegacy = OpenClawTray.Chat.DebugChatSurfaceOverrides.ResolveUseLegacy(
-            OpenClawTray.Chat.DebugChatSurfaceOverrides.TrayChat,
-            setting);
-        if (useLegacy)
+        var decision = ChatSurfaceResolver.Resolve(
+            ChatSurfaceTarget.TrayChat,
+            setting,
+            _chatUrl,
+            ChatSurfaceResolver.BuildChatUrl(_gatewayUrl, _token));
+
+        _chatUrl = decision.ChatUrl;
+
+        if (decision.UseLegacyWebChat)
             ShowWebViewSurface();
         else
             ShowFunctionalSurface();
@@ -295,7 +300,7 @@ public sealed partial class ChatWindow : WindowEx
 
         _gatewayUrl = gatewayUrl;
         _token = token;
-        _chatUrl = BuildChatUrl(_gatewayUrl, _token);
+        _chatUrl = ChatSurfaceResolver.BuildChatUrl(_gatewayUrl, _token);
 
         // HIGH 4: never log the full chat URL — its query string contains the
         // auth token. Strip the query before logging.
@@ -552,13 +557,6 @@ public sealed partial class ChatWindow : WindowEx
             await dialog.ShowAsync();
         }
         catch { /* dialog display failed, already logged */ }
-    }
-
-    private static string BuildChatUrl(string gatewayUrl, string token)
-    {
-        return GatewayChatUrlBuilder.TryBuildChatUrl(gatewayUrl, token, out var url, out _)
-            ? url
-            : string.Empty;
     }
 
     private bool _backdropAppliedOnce;

--- a/tests/OpenClaw.Tray.Tests/ChatSurfaceResolverTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatSurfaceResolverTests.cs
@@ -1,0 +1,93 @@
+using OpenClawTray.Chat;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class ChatSurfaceResolverTests : IDisposable
+{
+    private readonly ChatSurfaceOverride _originalHubOverride;
+    private readonly ChatSurfaceOverride _originalTrayOverride;
+
+    public ChatSurfaceResolverTests()
+    {
+        _originalHubOverride = DebugChatSurfaceOverrides.HubChat;
+        _originalTrayOverride = DebugChatSurfaceOverrides.TrayChat;
+        DebugChatSurfaceOverrides.HubChat = ChatSurfaceOverride.NoOverride;
+        DebugChatSurfaceOverrides.TrayChat = ChatSurfaceOverride.NoOverride;
+    }
+
+    public void Dispose()
+    {
+        DebugChatSurfaceOverrides.HubChat = _originalHubOverride;
+        DebugChatSurfaceOverrides.TrayChat = _originalTrayOverride;
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Resolve_NoOverride_UsesUserLegacySetting(bool useLegacySetting)
+    {
+        var decision = ChatSurfaceResolver.Resolve(
+            ChatSurfaceTarget.HubChat,
+            useLegacySetting,
+            currentChatUrl: "https://old.example.test?token=old",
+            resolvedChatUrl: "https://new.example.test?token=new");
+
+        Assert.Equal(useLegacySetting, decision.UseLegacyWebChat);
+    }
+
+    [Fact]
+    public void Resolve_ForceLegacyOverride_WinsOverUserSetting()
+    {
+        DebugChatSurfaceOverrides.TrayChat = ChatSurfaceOverride.ForceLegacy;
+
+        var decision = ChatSurfaceResolver.Resolve(
+            ChatSurfaceTarget.TrayChat,
+            useLegacyWebChatSetting: false,
+            currentChatUrl: null,
+            resolvedChatUrl: "https://gateway.example.test?token=tok");
+
+        Assert.True(decision.UseLegacyWebChat);
+    }
+
+    [Fact]
+    public void Resolve_ForceNativeOverride_WinsOverUserSetting()
+    {
+        DebugChatSurfaceOverrides.HubChat = ChatSurfaceOverride.ForceNative;
+
+        var decision = ChatSurfaceResolver.Resolve(
+            ChatSurfaceTarget.HubChat,
+            useLegacyWebChatSetting: true,
+            currentChatUrl: null,
+            resolvedChatUrl: "https://gateway.example.test?token=tok");
+
+        Assert.False(decision.UseLegacyWebChat);
+    }
+
+    [Fact]
+    public void Resolve_ReportsUrlChangedWithOrdinalComparison()
+    {
+        var same = ChatSurfaceResolver.Resolve(
+            ChatSurfaceTarget.HubChat,
+            useLegacyWebChatSetting: true,
+            currentChatUrl: "https://gateway.example.test?token=tok",
+            resolvedChatUrl: "https://gateway.example.test?token=tok");
+
+        var changed = ChatSurfaceResolver.Resolve(
+            ChatSurfaceTarget.HubChat,
+            useLegacyWebChatSetting: true,
+            currentChatUrl: "https://gateway.example.test?token=tok",
+            resolvedChatUrl: "https://gateway.example.test?token=TOK");
+
+        Assert.False(same.ChatUrlChanged);
+        Assert.True(changed.ChatUrlChanged);
+        Assert.Equal("https://gateway.example.test?token=TOK", changed.ChatUrl);
+    }
+
+    [Fact]
+    public void BuildChatUrl_ReturnsNullForInvalidGatewayUrl()
+    {
+        var url = ChatSurfaceResolver.BuildChatUrl("not-a-url", "tok");
+
+        Assert.Null(url);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -28,6 +28,8 @@
 
   <ItemGroup>
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\IChatGatewayBridge.cs" Link="Chat\IChatGatewayBridge.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatSurfaceResolver.cs" Link="Chat\ChatSurfaceResolver.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\DebugChatSurfaceOverrides.cs" Link="Chat\DebugChatSurfaceOverrides.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatEntryMetadata.cs" Link="Chat\ChatEntryMetadata.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\ChatMarkdownSanitizer.cs" Link="Chat\ChatMarkdownSanitizer.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Chat\OpenClawChatDataProvider.cs" Link="Chat\OpenClawChatDataProvider.cs" />


### PR DESCRIPTION
## Summary
- Extract shared chat-surface decision logic into `ChatSurfaceResolver`
- Reuse it from both Hub Chat and Tray Chat while keeping UI mounting local
- Add tests for legacy/native overrides, URL-change detection, and invalid gateway URLs

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — 1803 passed / 28 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — 1128 passed