### PR TITLE
Debounce Hub gateway nav hiding

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Services/GatewayNavVisibilityDebouncePolicy.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/GatewayNavVisibilityDebouncePolicy.cs
@@ -1,0 +1,29 @@
+using OpenClaw.Shared;
+using System;
+
+namespace OpenClawTray.Services;
+
+internal enum GatewayNavVisibilityDecision
+{
+    ShowNow,
+    HideNow,
+    ScheduleHide
+}
+
+internal static class GatewayNavVisibilityDebouncePolicy
+{
+    public static readonly TimeSpan DisconnectHideDelay = TimeSpan.FromSeconds(2);
+
+    public static GatewayNavVisibilityDecision GetDecision(ConnectionStatus status, bool debounceDisconnected)
+    {
+        if (status == ConnectionStatus.Connected)
+            return GatewayNavVisibilityDecision.ShowNow;
+
+        return debounceDisconnected
+            ? GatewayNavVisibilityDecision.ScheduleHide
+            : GatewayNavVisibilityDecision.HideNow;
+    }
+
+    public static bool ShouldHideAfterDelay(ConnectionStatus status) =>
+        status != ConnectionStatus.Connected;
+}

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -46,6 +46,7 @@ public sealed partial class HubWindow : WindowEx
     /// <summary>When true, ChatPage should auto-start voice recording on next navigation. Consumed (reset to false) by ChatPage.</summary>
     public bool PendingAutoStartVoice { get; set; }
     public string? NodeFullDeviceId { get; set; }
+    private Microsoft.UI.Dispatching.DispatcherQueueTimer? _gatewayNavHideTimer;
 
     // Cached gateway data — pages read these on navigation
     public SessionInfo[]? LastSessions { get; private set; }
@@ -78,6 +79,7 @@ public sealed partial class HubWindow : WindowEx
         Closed += (s, e) =>
         {
             IsClosed = true;
+            _gatewayNavHideTimer?.Stop();
             if (AppModel != null)
                 AppModel.PropertyChanged -= OnAppModelChanged;
         };
@@ -99,7 +101,7 @@ public sealed partial class HubWindow : WindowEx
         {
             AppModel.PropertyChanged += OnAppModelChanged;
             UpdateTitleBarStatus(AppModel.Status);
-            UpdateGatewayNavVisibility(AppModel.Status == ConnectionStatus.Connected);
+            ScheduleGatewayNavVisibilityForStatus(AppModel.Status, debounceDisconnected: false);
         }
     }
 
@@ -121,7 +123,7 @@ public sealed partial class HubWindow : WindowEx
                         DispatcherQueue?.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
                         {
                             if (IsClosed) return;
-                            UpdateGatewayNavVisibility(AppModel!.Status == ConnectionStatus.Connected);
+                            ScheduleGatewayNavVisibilityForStatus(AppModel!.Status, debounceDisconnected: true);
                         });
                 });
                 break;
@@ -367,6 +369,50 @@ public sealed partial class HubWindow : WindowEx
             new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Red),
         _ => new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Gray),
     };
+
+    private void ScheduleGatewayNavVisibilityForStatus(ConnectionStatus status, bool debounceDisconnected)
+    {
+        switch (GatewayNavVisibilityDebouncePolicy.GetDecision(status, debounceDisconnected))
+        {
+            case GatewayNavVisibilityDecision.ShowNow:
+                _gatewayNavHideTimer?.Stop();
+                UpdateGatewayNavVisibility(connected: true);
+                break;
+            case GatewayNavVisibilityDecision.HideNow:
+                _gatewayNavHideTimer?.Stop();
+                UpdateGatewayNavVisibility(connected: false);
+                break;
+            case GatewayNavVisibilityDecision.ScheduleHide:
+                ScheduleGatewayNavHide();
+                break;
+        }
+    }
+
+    private void ScheduleGatewayNavHide()
+    {
+        if (DispatcherQueue is null)
+        {
+            UpdateGatewayNavVisibility(connected: false);
+            return;
+        }
+
+        _gatewayNavHideTimer ??= DispatcherQueue.CreateTimer();
+        _gatewayNavHideTimer.Interval = GatewayNavVisibilityDebouncePolicy.DisconnectHideDelay;
+        _gatewayNavHideTimer.Tick -= OnGatewayNavHideTimerTick;
+        _gatewayNavHideTimer.Tick += OnGatewayNavHideTimerTick;
+        _gatewayNavHideTimer.Stop();
+        _gatewayNavHideTimer.Start();
+    }
+
+    private void OnGatewayNavHideTimerTick(Microsoft.UI.Dispatching.DispatcherQueueTimer sender, object args)
+    {
+        sender.Stop();
+        if (IsClosed || AppModel is null)
+            return;
+
+        if (GatewayNavVisibilityDebouncePolicy.ShouldHideAfterDelay(AppModel.Status))
+            UpdateGatewayNavVisibility(connected: false);
+    }
 
     private void UpdateGatewayNavVisibility(bool connected)
     {

--- a/tests/OpenClaw.Tray.Tests/GatewayNavVisibilityDebouncePolicyTests.cs
+++ b/tests/OpenClaw.Tray.Tests/GatewayNavVisibilityDebouncePolicyTests.cs
@@ -1,0 +1,52 @@
+using OpenClaw.Shared;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public class GatewayNavVisibilityDebouncePolicyTests
+{
+    [Fact]
+    public void Connected_ShowsImmediately()
+    {
+        Assert.Equal(
+            GatewayNavVisibilityDecision.ShowNow,
+            GatewayNavVisibilityDebouncePolicy.GetDecision(ConnectionStatus.Connected, debounceDisconnected: true));
+    }
+
+    [Theory]
+    [InlineData(ConnectionStatus.Disconnected)]
+    [InlineData(ConnectionStatus.Connecting)]
+    [InlineData(ConnectionStatus.Error)]
+    public void NonConnected_WithDebounce_SchedulesHide(ConnectionStatus status)
+    {
+        Assert.Equal(
+            GatewayNavVisibilityDecision.ScheduleHide,
+            GatewayNavVisibilityDebouncePolicy.GetDecision(status, debounceDisconnected: true));
+    }
+
+    [Theory]
+    [InlineData(ConnectionStatus.Disconnected)]
+    [InlineData(ConnectionStatus.Connecting)]
+    [InlineData(ConnectionStatus.Error)]
+    public void NonConnected_WithoutDebounce_HidesImmediately(ConnectionStatus status)
+    {
+        Assert.Equal(
+            GatewayNavVisibilityDecision.HideNow,
+            GatewayNavVisibilityDebouncePolicy.GetDecision(status, debounceDisconnected: false));
+    }
+
+    [Fact]
+    public void ReconnectedBeforeDelay_DoesNotHide()
+    {
+        Assert.False(GatewayNavVisibilityDebouncePolicy.ShouldHideAfterDelay(ConnectionStatus.Connected));
+    }
+
+    [Theory]
+    [InlineData(ConnectionStatus.Disconnected)]
+    [InlineData(ConnectionStatus.Connecting)]
+    [InlineData(ConnectionStatus.Error)]
+    public void StillDisconnectedAfterDelay_Hides(ConnectionStatus status)
+    {
+        Assert.True(GatewayNavVisibilityDebouncePolicy.ShouldHideAfterDelay(status));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -46,6 +46,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SetupExistingGatewayClassifier.cs" Link="Services\SetupExistingGatewayClassifier.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ActivityStreamService.cs" Link="Services\ActivityStreamService.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\AsyncListLoadingState.cs" Link="Services\AsyncListLoadingState.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\GatewayNavVisibilityDebouncePolicy.cs" Link="Services\GatewayNavVisibilityDebouncePolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeInvokeActivityFormatter.cs" Link="Services\NodeInvokeActivityFormatter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeCapabilityGating.cs" Link="Services\NodeCapabilityGating.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\TrayTooltipFormatter.cs" Link="Helpers\TrayTooltipFormatter.cs" />


### PR DESCRIPTION
## Summary
- debounce hiding gateway-gated Hub navigation during short non-connected status blips
- keep startup/offline behavior unchanged by hiding immediately on initial disconnected bind
- add focused policy tests for the debounce decisions

Fixes #463

## Validation
- .\build.ps1
- dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore
- dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore