### PR TITLE
test(msix): publish update feed endpoint

### DIFF
--- a/.github/workflows/msix-update-feed-pages.yml
+++ b/.github/workflows/msix-update-feed-pages.yml
@@ -1,0 +1,42 @@
+name: Publish MSIX update feed
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - docs/msix-feed/**
+      - .github/workflows/msix-update-feed-pages.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Prepare MSIX update feed
+        run: |
+          mkdir -p _site
+          cp docs/msix-feed/openclaw-x64.appinstaller _site/openclaw-x64.appinstaller
+          touch _site/.nojekyll
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: _site
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/msix-feed/openclaw-x64.appinstaller
+++ b/docs/msix-feed/openclaw-x64.appinstaller
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AppInstaller
+  xmlns="http://schemas.microsoft.com/appx/appinstaller/2018"
+  Version="0.4.8.0"
+  Uri="https://openclaw.github.io/openclaw-windows-node/openclaw-x64.appinstaller">
+  <MainPackage
+    Name="OpenClaw.Companion"
+    Publisher="CN=Scott Hanselman, O=Scott Hanselman, L=Forest Grove, S=Oregon, C=US"
+    Version="0.4.8.0"
+    ProcessorArchitecture="x64"
+    Uri="https://github.com/indierawk2k2/openclaw-windows-node/releases/download/msix-e2e-blue-lobster-update-test-2026-05-20-1325/OpenClawCompanion-0.4.8-win-x64.msix" />
+  <UpdateSettings>
+    <AutomaticBackgroundTask />
+  </UpdateSettings>
+</AppInstaller>


### PR DESCRIPTION
## Summary
- Adds a minimal GitHub Pages deployment for the MSIX x64 update feed.
- Publishes `docs/msix-feed/openclaw-x64.appinstaller` as `/openclaw-x64.appinstaller`, matching the URL embedded in the current signed test MSIX: `https://openclaw.github.io/openclaw-windows-node/openclaw-x64.appinstaller`.
- Points the feed at the signed `0.4.8.0` blue-lobster test MSIX so we can validate App Installer update discovery before the full MSIX hardening PR lands.

## Notes for maintainers
This is intentionally a narrow test-enablement PR. It does not include the full MSIX hardening changes. The feed currently references the signed test package hosted on `indierawk2k2/openclaw-windows-node` because that is the package already built for validation.

If the first Pages deploy reports that Pages is not enabled, enable GitHub Pages for this repository with **GitHub Actions** as the source, then rerun the `Publish MSIX update feed` workflow.

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — 1803 passed, 28 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — 1149 passed