### PR TITLE
feat: tool metadata cache, tool call toggle, stale-closure fix, and perf optimizations

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/Explorations/ChatExplorationState.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/Explorations/ChatExplorationState.cs
@@ -340,6 +340,20 @@ public static class ChatExplorationState
         set { if (_showToolCalls != value) { _showToolCalls = value; RaiseChanged(); } }
     }
 
+    /// <summary>
+    /// Monotonic counter incremented when all tool chip expanded states
+    /// should be reset. The timeline checks this and clears its local
+    /// <c>expandedToolChips</c> set when the value changes.
+    /// </summary>
+    public static int CollapseToolChipsVersion { get; internal set; }
+
+    /// <summary>Signal all tool chip expanded states to collapse.</summary>
+    public static void CollapseAllToolChips()
+    {
+        CollapseToolChipsVersion++;
+        RaiseChanged();
+    }
+
     public static double BubbleMaxWidth
     {
         get => _bubbleMaxWidth;
@@ -394,7 +408,7 @@ public static class ChatExplorationState
 
     // ---- Tool burst (H) ----
 
-    private static ToolBurstStyle _toolBurstStyle = ToolBurstStyle.Plain;
+    private static ToolBurstStyle _toolBurstStyle = ToolBurstStyle.CompactSummary;
     private static bool _showStepNumbers;
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/Chat/Explorations/ChatExplorationsPanel.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/Explorations/ChatExplorationsPanel.cs
@@ -25,9 +25,14 @@ public class ChatExplorationsPanel : Component
     public override Element Render()
     {
         var rev = UseState(0, threadSafe: true);
+        var revRef = UseRef(0);
         UseEffect((Func<Action>)(() =>
         {
-            EventHandler h = (_, _) => rev.Set(rev.Value + 1);
+            EventHandler h = (_, _) =>
+            {
+                revRef.Current++;
+                rev.Set(revRef.Current);
+            };
             ChatExplorationState.Changed += h;
             return () => ChatExplorationState.Changed -= h;
         }));

--- a/src/OpenClaw.Tray.WinUI/Chat/FunctionalChatHostExtensions.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/FunctionalChatHostExtensions.cs
@@ -53,7 +53,8 @@ public static class FunctionalChatHostExtensions
         Action? onSettingsClick = null,
         Action<bool>? onSpeakerMuteChanged = null,
         bool initialMuted = false,
-        bool isCompact = false)
+        bool isCompact = false,
+        bool suppressAutoDispose = false)
     {
         ArgumentNullException.ThrowIfNull(window);
         ArgumentNullException.ThrowIfNull(target);
@@ -61,6 +62,7 @@ public static class FunctionalChatHostExtensions
 
         var root = new OpenClawChatRoot(provider, initialThreadId, onReadAloud, onStopSpeaking, onVoiceRequest, onAttachClick, onSettingsClick, onSpeakerMuteChanged, initialMuted, isCompact);
         var host = new FunctionalHostControl();
+        host.SuppressAutoDispose = suppressAutoDispose;
         host.Mount(root);
         target.Child = host;
         return new MountedFunctionalChat(target, host, root);

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -62,7 +62,10 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     private readonly IChatGatewayBridge _bridge;
     private readonly Action<Action>? _post;
     private readonly object _gate = new();
+    private readonly object _toolMetaSaveGate = new();
+    private readonly string _toolMetaCacheFilePath;
     private System.Threading.Timer? _toolMetaSaveTimer; // debounce cache writes
+    private long _toolMetaSaveVersion;
     private readonly Dictionary<string, ChatTimelineState> _timelines = new();
     private readonly Dictionary<string, string> _activeRunIds = new();   // sessionKey → runId
     private readonly Dictionary<string, int> _pendingAbortCounts = new(); // threads → count of pending aborts waiting for lifecycle.start
@@ -119,12 +122,20 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     /// the source event on (acceptable in unit tests).
     /// </param>
     public OpenClawChatDataProvider(IChatGatewayBridge bridge, Action<Action>? post = null)
+        : this(bridge, post, DefaultToolMetaCacheFilePath)
+    {
+    }
+
+    internal OpenClawChatDataProvider(IChatGatewayBridge bridge, Action<Action>? post, string toolMetaCacheFilePath)
     {
         _bridge = bridge ?? throw new ArgumentNullException(nameof(bridge));
         _post = post;
+        _toolMetaCacheFilePath = !string.IsNullOrWhiteSpace(toolMetaCacheFilePath)
+            ? toolMetaCacheFilePath
+            : throw new ArgumentException("Tool metadata cache path is required.", nameof(toolMetaCacheFilePath));
         _status = bridge.CurrentStatus;
         _persistedAbortedIds = LoadAbortedIds();
-        _toolMetaCache = LoadToolMetaCache();
+        _toolMetaCache = LoadToolMetaCache(_toolMetaCacheFilePath);
 
         // Seed models from whatever the bridge already knows about (a connect
         // that completed before the provider was constructed will have its
@@ -763,6 +774,15 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     {
         if (_disposed) return ValueTask.CompletedTask;
         _disposed = true;
+        System.Threading.Timer? timerToDispose;
+        lock (_gate)
+        {
+            timerToDispose = _toolMetaSaveTimer;
+            _toolMetaSaveTimer = null;
+            _toolMetaSaveVersion++;
+        }
+        timerToDispose?.Dispose();
+        SaveToolMetaCache();
         _bridge.StatusChanged -= OnStatusChanged;
         _bridge.SessionsUpdated -= OnSessionsUpdated;
         _bridge.ChatMessageReceived -= OnChatMessageReceived;
@@ -2274,9 +2294,18 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         public string Label { get; set; } = "";
     }
 
-    private static readonly string ToolMetaCacheFilePath = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "OpenClawTray", "tool-metadata.json");
+    private static string DefaultToolMetaCacheFilePath
+    {
+        get
+        {
+            var root = Environment.GetEnvironmentVariable("OPENCLAW_TRAY_DATA_DIR") is { Length: > 0 } overrideDir
+                ? overrideDir
+                : Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "OpenClawTray");
+            return Path.Combine(root, "tool-metadata.json");
+        }
+    }
 
     /// <summary>Max sessions to keep in the tool metadata cache.</summary>
     internal const int MaxCachedSessions = 20;
@@ -2284,13 +2313,13 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     /// <summary>Max tool entries per session in the cache.</summary>
     internal const int MaxToolEntriesPerSession = 500;
 
-    private static Dictionary<string, List<CachedToolMeta>> LoadToolMetaCache()
+    private static Dictionary<string, List<CachedToolMeta>> LoadToolMetaCache(string cacheFilePath)
     {
         try
         {
-            if (!File.Exists(ToolMetaCacheFilePath))
+            if (!File.Exists(cacheFilePath))
                 return new();
-            var json = File.ReadAllText(ToolMetaCacheFilePath);
+            var json = File.ReadAllText(cacheFilePath);
             var dict = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, List<CachedToolMeta>>>(json);
             return dict ?? new();
         }
@@ -2300,12 +2329,26 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         }
     }
 
-    private void SaveToolMetaCache()
+    private void SaveToolMetaCache(long? expectedVersion = null)
     {
         try
         {
             Dictionary<string, List<CachedToolMeta>> snapshot;
-            lock (_gate) snapshot = new Dictionary<string, List<CachedToolMeta>>(_toolMetaCache);
+            lock (_gate)
+            {
+                if (expectedVersion is long version && (version != _toolMetaSaveVersion || _disposed))
+                    return;
+
+                snapshot = _toolMetaCache.ToDictionary(
+                    kv => kv.Key,
+                    kv => kv.Value.Select(e => new CachedToolMeta
+                    {
+                        Ts = e.Ts,
+                        ToolName = e.ToolName,
+                        Label = e.Label
+                    }).ToList(),
+                    StringComparer.Ordinal);
+            }
 
             // Evict oldest sessions if over the cap
             if (snapshot.Count > MaxCachedSessions)
@@ -2318,16 +2361,43 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                 foreach (var k in toRemove) snapshot.Remove(k);
             }
 
-            var dir = Path.GetDirectoryName(ToolMetaCacheFilePath);
-            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
-
             var json = System.Text.Json.JsonSerializer.Serialize(snapshot,
                 new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
 
-            // Write to temp file then atomic move to avoid partial JSON on crash
-            var tempPath = ToolMetaCacheFilePath + ".tmp";
-            File.WriteAllText(tempPath, json);
-            File.Move(tempPath, ToolMetaCacheFilePath, overwrite: true);
+            lock (_toolMetaSaveGate)
+            {
+                if (expectedVersion is long version)
+                {
+                    lock (_gate)
+                    {
+                        if (version != _toolMetaSaveVersion || _disposed)
+                            return;
+                    }
+                }
+
+                var dir = Path.GetDirectoryName(_toolMetaCacheFilePath);
+                if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+
+                // Write to a unique temp file then atomic move to avoid partial JSON on crash.
+                var tempPath = _toolMetaCacheFilePath + "." + Guid.NewGuid().ToString("N") + ".tmp";
+                try
+                {
+                    File.WriteAllText(tempPath, json);
+                    File.Move(tempPath, _toolMetaCacheFilePath, overwrite: true);
+                }
+                finally
+                {
+                    try
+                    {
+                        if (File.Exists(tempPath))
+                            File.Delete(tempPath);
+                    }
+                    catch
+                    {
+                        // Best-effort cleanup; persistence remains best-effort.
+                    }
+                }
+            }
         }
         catch { /* best-effort persistence */ }
     }
@@ -2336,12 +2406,16 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     /// Cache a tool call's metadata so it can be recovered when the gateway
     /// flattens it during history replay on a future app launch.
     /// </summary>
-    private void CacheToolMeta(string threadId, long tsMs, string toolName, string label)
+    internal void CacheToolMeta(string threadId, long tsMs, string toolName, string label)
     {
-        string? sessionId;
+        System.Threading.Timer? timerToDispose = null;
+        long saveVersion;
         lock (_gate)
         {
-            if (!_sessionIds.TryGetValue(threadId, out sessionId) || string.IsNullOrEmpty(sessionId))
+            if (_disposed)
+                return;
+
+            if (!_sessionIds.TryGetValue(threadId, out var sessionId) || string.IsNullOrEmpty(sessionId))
                 return;
 
             if (!_toolMetaCache.TryGetValue(sessionId, out var list))
@@ -2359,12 +2433,14 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             // Cap per-session entries
             if (list.Count > MaxToolEntriesPerSession)
                 list.RemoveRange(0, list.Count - MaxToolEntriesPerSession);
-        }
 
-        // Debounce save — reset the timer on each cache addition so we only
-        // write once after 500ms of quiescence, avoiding concurrent file writes.
-        _toolMetaSaveTimer?.Dispose();
-        _toolMetaSaveTimer = new System.Threading.Timer(_ => SaveToolMetaCache(), null, 500, Timeout.Infinite);
+            // Debounce save — reset the timer on each cache addition so we only
+            // write once after 500ms of quiescence, avoiding concurrent file writes.
+            saveVersion = ++_toolMetaSaveVersion;
+            timerToDispose = _toolMetaSaveTimer;
+            _toolMetaSaveTimer = new System.Threading.Timer(_ => SaveToolMetaCache(saveVersion), null, 500, Timeout.Infinite);
+        }
+        timerToDispose?.Dispose();
     }
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -62,6 +62,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     private readonly IChatGatewayBridge _bridge;
     private readonly Action<Action>? _post;
     private readonly object _gate = new();
+    private System.Threading.Timer? _toolMetaSaveTimer; // debounce cache writes
     private readonly Dictionary<string, ChatTimelineState> _timelines = new();
     private readonly Dictionary<string, string> _activeRunIds = new();   // sessionKey → runId
     private readonly Dictionary<string, int> _pendingAbortCounts = new(); // threads → count of pending aborts waiting for lifecycle.start
@@ -2266,7 +2267,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     // ── Tool metadata persistence ─────────────────────────────────────
 
     /// <summary>Cached tool call metadata entry persisted to disk.</summary>
-    private sealed class CachedToolMeta
+    internal sealed class CachedToolMeta
     {
         public long Ts { get; set; }
         public string ToolName { get; set; } = "";
@@ -2278,10 +2279,10 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         "OpenClawTray", "tool-metadata.json");
 
     /// <summary>Max sessions to keep in the tool metadata cache.</summary>
-    private const int MaxCachedSessions = 20;
+    internal const int MaxCachedSessions = 20;
 
     /// <summary>Max tool entries per session in the cache.</summary>
-    private const int MaxToolEntriesPerSession = 500;
+    internal const int MaxToolEntriesPerSession = 500;
 
     private static Dictionary<string, List<CachedToolMeta>> LoadToolMetaCache()
     {
@@ -2322,7 +2323,11 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
 
             var json = System.Text.Json.JsonSerializer.Serialize(snapshot,
                 new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
-            File.WriteAllText(ToolMetaCacheFilePath, json);
+
+            // Write to temp file then atomic move to avoid partial JSON on crash
+            var tempPath = ToolMetaCacheFilePath + ".tmp";
+            File.WriteAllText(tempPath, json);
+            File.Move(tempPath, ToolMetaCacheFilePath, overwrite: true);
         }
         catch { /* best-effort persistence */ }
     }
@@ -2356,8 +2361,10 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                 list.RemoveRange(0, list.Count - MaxToolEntriesPerSession);
         }
 
-        // Fire-and-forget save on a background thread to avoid blocking event processing
-        _ = Task.Run(SaveToolMetaCache);
+        // Debounce save — reset the timer on each cache addition so we only
+        // write once after 500ms of quiescence, avoiding concurrent file writes.
+        _toolMetaSaveTimer?.Dispose();
+        _toolMetaSaveTimer = new System.Threading.Timer(_ => SaveToolMetaCache(), null, 500, Timeout.Infinite);
     }
 
     /// <summary>
@@ -2382,7 +2389,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     /// history stores tool-result timestamps (which can be minutes later),
     /// so we match by order rather than timestamp proximity.
     /// </summary>
-    private static CachedToolMeta? TryMatchCachedTool(Queue<CachedToolMeta>? cache, long historyTsMs)
+    internal static CachedToolMeta? TryMatchCachedTool(Queue<CachedToolMeta>? cache, long historyTsMs)
     {
         if (cache is null || cache.Count == 0) return null;
 

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -76,6 +76,10 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     private readonly Dictionary<string, string> _sessionIds = new();      // sessionKey → immutable sessionId
     private readonly HashSet<string> _historyLoaded = new();              // sessionKey
     private readonly HashSet<string> _historyInFlight = new();            // sessionKey
+    // Per-session cache of tool metadata from live SSE events.
+    // Keyed by gateway sessionId (immutable UUID).  Persisted to disk
+    // so that history reconstruction on restart can recover tool names.
+    private Dictionary<string, List<CachedToolMeta>> _toolMetaCache;
     // Track recently-sent local user message texts so we can suppress
     // SSE echoes while still displaying messages from other clients.
     private readonly Dictionary<string, Queue<LocalSentText>> _localSentTexts = new();
@@ -119,6 +123,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         _post = post;
         _status = bridge.CurrentStatus;
         _persistedAbortedIds = LoadAbortedIds();
+        _toolMetaCache = LoadToolMetaCache();
 
         // Seed models from whatever the bridge already knows about (a connect
         // that completed before the provider was constructed will have its
@@ -374,6 +379,12 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
 
                 Logger.Info($"[ChatHistory] Loading thread '{threadId}' — {ordered.Count} messages from gateway");
 
+                // Load cached tool metadata for this session to restore tool names
+                // that the gateway strips from history responses.
+                var cachedTools = GetCachedToolMetaForSession(history.SessionId);
+                if (cachedTools is not null)
+                    Logger.Info($"[ChatHistory] Found {cachedTools.Count} cached tool metadata entries for session");
+
                 bool nextAssistantIsAborted = false;
 
                 foreach (var msg in ordered)
@@ -470,11 +481,13 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                             }
                             if (LooksLikeFlattenedToolOutput(text))
                             {
-                                var kind = ClassifyFlattenedToolOutput(text);
-                                Logger.Debug($"[ChatHistory]   → routed: TOOL chip kind='{kind}'");
+                                var cached = TryMatchCachedTool(cachedTools, msg.Ts);
+                                var kind = cached?.ToolName ?? ClassifyFlattenedToolOutput(text);
+                                var label = cached?.Label ?? ExtractFlattenedToolSummary(text);
+                                Logger.Debug($"[ChatHistory]   → routed: TOOL chip kind='{kind}' cached={cached is not null}");
                                 rebuilt = ApplyAndCaptureMeta(
                                     rebuilt,
-                                    new ChatToolStartEvent(kind, kind),
+                                    new ChatToolStartEvent(label, kind),
                                     msgMeta);
                                 rebuilt = ApplyAndCaptureMeta(
                                     rebuilt,
@@ -499,11 +512,13 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                             // the heuristic fires, since the role itself confirms
                             // it's tool output.
                             {
-                                var kind = ClassifyFlattenedToolOutput(text);
-                                Logger.Debug($"[ChatHistory]   → routed: TOOL chip (role=toolresult, kind='{kind}')");
+                                var cached = TryMatchCachedTool(cachedTools, msg.Ts);
+                                var kind = cached?.ToolName ?? ClassifyFlattenedToolOutput(text);
+                                var label = cached?.Label ?? ExtractFlattenedToolSummary(text);
+                                Logger.Debug($"[ChatHistory]   → routed: TOOL chip (role=toolresult, kind='{kind}' cached={cached is not null})");
                                 rebuilt = ApplyAndCaptureMeta(
                                     rebuilt,
-                                    new ChatToolStartEvent(kind, kind),
+                                    new ChatToolStartEvent(label, kind),
                                     msgMeta);
                                 rebuilt = ApplyAndCaptureMeta(
                                     rebuilt,
@@ -1003,7 +1018,8 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             lock (_gate) { trMeta = BuildLiveMetaLocked(trThread, message.Ts); }
             var capped = TruncateForChatEntry(message.Text);
             var kind = ClassifyFlattenedToolOutput(capped);
-            ApplyEventAndPublish(trThread, new ChatToolStartEvent(kind, kind), trMeta);
+            var label = ExtractFlattenedToolSummary(capped);
+            ApplyEventAndPublish(trThread, new ChatToolStartEvent(label, kind), trMeta);
             ApplyEventAndPublish(trThread, new ChatToolOutputEvent(capped), trMeta);
             return;
         }
@@ -1105,6 +1121,13 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
 
         ChatEvent? mapped = MapAgentEvent(evt);
         if (mapped is null) return;
+
+        // Cache tool metadata from live SSE events so it survives app restarts.
+        if (mapped is ChatToolStartEvent toolStart && !string.IsNullOrEmpty(toolStart.ToolName))
+        {
+            var tsMs0 = evt.Ts > 0 ? (long)evt.Ts : 0L;
+            CacheToolMeta(threadId, tsMs0, toolStart.ToolName, toolStart.Text);
+        }
 
         // AgentEventInfo.Ts is a double of unix-epoch ms (per OpenClawGatewayClient).
         var tsMs = evt.Ts > 0 ? (long)evt.Ts : 0L;
@@ -1821,17 +1844,73 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     /// <summary>
     /// Best-guess kind label for a flattened-tool-output assistant
     /// message. Used to populate the tool chip's monospace kind suffix.
+    /// Detects tool types from common output patterns as a heuristic
+    /// fallback when cached metadata is unavailable.
     /// </summary>
     internal static string ClassifyFlattenedToolOutput(string text)
     {
+        if (string.IsNullOrEmpty(text)) return "exec";
+
+        // Shell/process markers
         if (text.Contains("Command still running", StringComparison.Ordinal) ||
             text.Contains("Process exited with code", StringComparison.Ordinal))
-            return "process";
+            return "bash";
+
+        // File read patterns (numbered lines like "1. ", "42. ")
+        if (s_numberedLineRegex.IsMatch(text))
+            return "view";
+
+        // Grep / search result patterns ("path/file.ext:123:matched line")
+        if (s_grepResultRegex.IsMatch(text))
+            return "grep";
+
+        // Directory listing / glob patterns
+        if (text.Contains("Directory:", StringComparison.Ordinal) ||
+            text.Contains("Mode                ", StringComparison.Ordinal))
+            return "glob";
+
+        // Git output
+        if (text.StartsWith("commit ", StringComparison.Ordinal) ||
+            text.StartsWith("diff --git", StringComparison.Ordinal) ||
+            text.Contains("Author:", StringComparison.Ordinal) && text.Contains("Date:", StringComparison.Ordinal))
+            return "git";
+
+        // Edit/write patterns
+        if (text.Contains("successfully created", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("File written", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("Applied edit", StringComparison.OrdinalIgnoreCase))
+            return "edit";
+
+        // Exec completed marker
         if (text.Contains("Exec completed (", StringComparison.Ordinal))
             return "exec";
-        // Anything matching the CLI-help heuristics is also a shell exec
-        // result — give it the same chip kind as live exec calls.
+
         return "exec";
+    }
+
+    /// <summary>Matches numbered output lines typical of file view output (e.g. "  1. content").</summary>
+    private static readonly System.Text.RegularExpressions.Regex s_numberedLineRegex =
+        new(@"^\s*\d+\.\s", System.Text.RegularExpressions.RegexOptions.Compiled | System.Text.RegularExpressions.RegexOptions.Multiline);
+
+    /// <summary>Matches grep-style results (path:line:content).</summary>
+    private static readonly System.Text.RegularExpressions.Regex s_grepResultRegex =
+        new(@"^[^\s:]+\.\w+:\d+:", System.Text.RegularExpressions.RegexOptions.Compiled | System.Text.RegularExpressions.RegexOptions.Multiline);
+
+    /// <summary>
+    /// Extract a short one-line summary from flattened tool output text
+    /// for use as the tool chip label. Truncates to 80 chars.
+    /// </summary>
+    internal static string ExtractFlattenedToolSummary(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return "";
+        // Use the first non-empty line as the summary
+        var firstLine = text.AsSpan().TrimStart();
+        var lineEnd = firstLine.IndexOfAny('\r', '\n');
+        if (lineEnd > 0) firstLine = firstLine[..lineEnd];
+        var summary = firstLine.Length > 80
+            ? new string(firstLine[..77]) + "…"
+            : new string(firstLine);
+        return summary;
     }
 
     // ── State helpers ──
@@ -2182,6 +2261,140 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             File.WriteAllText(AbortedIdsFilePath, json);
         }
         catch { /* best-effort persistence */ }
+    }
+
+    // ── Tool metadata persistence ─────────────────────────────────────
+
+    /// <summary>Cached tool call metadata entry persisted to disk.</summary>
+    private sealed class CachedToolMeta
+    {
+        public long Ts { get; set; }
+        public string ToolName { get; set; } = "";
+        public string Label { get; set; } = "";
+    }
+
+    private static readonly string ToolMetaCacheFilePath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "OpenClawTray", "tool-metadata.json");
+
+    /// <summary>Max sessions to keep in the tool metadata cache.</summary>
+    private const int MaxCachedSessions = 20;
+
+    /// <summary>Max tool entries per session in the cache.</summary>
+    private const int MaxToolEntriesPerSession = 500;
+
+    private static Dictionary<string, List<CachedToolMeta>> LoadToolMetaCache()
+    {
+        try
+        {
+            if (!File.Exists(ToolMetaCacheFilePath))
+                return new();
+            var json = File.ReadAllText(ToolMetaCacheFilePath);
+            var dict = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, List<CachedToolMeta>>>(json);
+            return dict ?? new();
+        }
+        catch
+        {
+            return new();
+        }
+    }
+
+    private void SaveToolMetaCache()
+    {
+        try
+        {
+            Dictionary<string, List<CachedToolMeta>> snapshot;
+            lock (_gate) snapshot = new Dictionary<string, List<CachedToolMeta>>(_toolMetaCache);
+
+            // Evict oldest sessions if over the cap
+            if (snapshot.Count > MaxCachedSessions)
+            {
+                var toRemove = snapshot
+                    .OrderBy(kv => kv.Value.Count > 0 ? kv.Value[^1].Ts : 0)
+                    .Take(snapshot.Count - MaxCachedSessions)
+                    .Select(kv => kv.Key)
+                    .ToList();
+                foreach (var k in toRemove) snapshot.Remove(k);
+            }
+
+            var dir = Path.GetDirectoryName(ToolMetaCacheFilePath);
+            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+
+            var json = System.Text.Json.JsonSerializer.Serialize(snapshot,
+                new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(ToolMetaCacheFilePath, json);
+        }
+        catch { /* best-effort persistence */ }
+    }
+
+    /// <summary>
+    /// Cache a tool call's metadata so it can be recovered when the gateway
+    /// flattens it during history replay on a future app launch.
+    /// </summary>
+    private void CacheToolMeta(string threadId, long tsMs, string toolName, string label)
+    {
+        string? sessionId;
+        lock (_gate)
+        {
+            if (!_sessionIds.TryGetValue(threadId, out sessionId) || string.IsNullOrEmpty(sessionId))
+                return;
+
+            if (!_toolMetaCache.TryGetValue(sessionId, out var list))
+            {
+                list = new List<CachedToolMeta>();
+                _toolMetaCache[sessionId] = list;
+            }
+
+            // Deduplicate by timestamp (same tool event shouldn't be cached twice)
+            if (list.Count > 0 && list[^1].Ts == tsMs && list[^1].ToolName == toolName)
+                return;
+
+            list.Add(new CachedToolMeta { Ts = tsMs, ToolName = toolName, Label = label });
+
+            // Cap per-session entries
+            if (list.Count > MaxToolEntriesPerSession)
+                list.RemoveRange(0, list.Count - MaxToolEntriesPerSession);
+        }
+
+        // Fire-and-forget save on a background thread to avoid blocking event processing
+        _ = Task.Run(SaveToolMetaCache);
+    }
+
+    /// <summary>
+    /// Look up cached tool metadata for a session's history reconstruction.
+    /// Returns a queue of entries sorted by timestamp for sequential consumption.
+    /// </summary>
+    private Queue<CachedToolMeta>? GetCachedToolMetaForSession(string? sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return null;
+        lock (_gate)
+        {
+            if (_toolMetaCache.TryGetValue(sessionId!, out var list) && list.Count > 0)
+                return new Queue<CachedToolMeta>(list.OrderBy(e => e.Ts));
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Try to match a history tool entry to a cached metadata entry.
+    /// Both the cache and history are chronologically ordered, so we consume
+    /// entries sequentially. The cache stores tool-start timestamps while
+    /// history stores tool-result timestamps (which can be minutes later),
+    /// so we match by order rather than timestamp proximity.
+    /// </summary>
+    private static CachedToolMeta? TryMatchCachedTool(Queue<CachedToolMeta>? cache, long historyTsMs)
+    {
+        if (cache is null || cache.Count == 0) return null;
+
+        // Both sequences are chronological. Consume the next cached entry
+        // for each tool result we encounter in history.
+        // Guard: if the history timestamp is much OLDER than the next cached
+        // entry, this toolresult predates our cache — skip it.
+        var candidate = cache.Peek();
+        if (historyTsMs > 0 && candidate.Ts > 0 && candidate.Ts > historyTsMs + 300_000)
+            return null; // cached entry is >5 min after this history entry — not a match
+
+        return cache.Dequeue();
     }
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
@@ -107,6 +107,7 @@ public sealed class OpenClawChatRoot : Component
         // they receive don't change. Bumping this Root's state invalidates
         // the whole tree so toggles always show in the live preview.
         var explorationRev = UseState(0, threadSafe: true);
+        var explorationRevRef = UseRef(0);
         var pendingAttachment = UseState<ChatAttachment?>(null, threadSafe: true);
         var speakerMuted = UseState(_initialMuted, threadSafe: true);
         var voiceTranscript = UseState<string?>(null, threadSafe: true);
@@ -137,10 +138,12 @@ public sealed class OpenClawChatRoot : Component
             var dq = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
             EventHandler h = (_, _) =>
             {
+                explorationRevRef.Current++;
+                var val = explorationRevRef.Current;
                 if (dq is not null)
-                    dq.TryEnqueue(() => explorationRev.Set(explorationRev.Value + 1));
+                    dq.TryEnqueue(() => explorationRev.Set(val));
                 else
-                    explorationRev.Set(explorationRev.Value + 1);
+                    explorationRev.Set(val);
             };
             ChatExplorationState.Changed += h;
             return () => ChatExplorationState.Changed -= h;

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
@@ -139,11 +139,10 @@ public sealed class OpenClawChatRoot : Component
             EventHandler h = (_, _) =>
             {
                 explorationRevRef.Current++;
-                var val = explorationRevRef.Current;
                 if (dq is not null)
-                    dq.TryEnqueue(() => explorationRev.Set(val));
+                    dq.TryEnqueue(() => explorationRev.Set(explorationRevRef.Current));
                 else
-                    explorationRev.Set(val);
+                    explorationRev.Set(explorationRevRef.Current);
             };
             ChatExplorationState.Changed += h;
             return () => ChatExplorationState.Changed -= h;

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
@@ -206,9 +206,18 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
         // timeline. Same inline pattern as OpenClawComposer (UseState +
         // UseEffect — extension methods can't access protected hooks).
         var explorationRev = UseState(0, threadSafe: true);
+        var explorationRevRef = UseRef(0);
         UseEffect((Func<Action>)(() =>
         {
-            EventHandler h = (_, _) => explorationRev.Set(explorationRev.Value + 1);
+            // Use a Ref for the counter to avoid stale-closure: the effect
+            // runs once, so explorationRev.Value would be stuck at 0. The
+            // Ref's .Current is always live, ensuring every Changed event
+            // produces a unique value → always triggers a re-render.
+            EventHandler h = (_, _) =>
+            {
+                explorationRevRef.Current++;
+                explorationRev.Set(explorationRevRef.Current);
+            };
             ChatExplorationState.Changed += h;
             return () => ChatExplorationState.Changed -= h;
         }));
@@ -249,6 +258,31 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
         // toggle independently. HashSet so the empty default is "all
         // collapsed" — matches the web's default-collapsed look.
         var expandedToolChips = UseState<HashSet<string>>(new HashSet<string>(), threadSafe: true);
+
+        // Track the last-seen CollapseToolChipsVersion so we clear expanded
+        // state when the user toggles tool calls off (collapsed view should
+        // start fresh when re-shown).
+        var lastCollapseVersion = UseRef(ChatExplorationState.CollapseToolChipsVersion);
+        if (lastCollapseVersion.Current != ChatExplorationState.CollapseToolChipsVersion)
+        {
+            lastCollapseVersion.Current = ChatExplorationState.CollapseToolChipsVersion;
+            // Clear expanded state without triggering another render —
+            // mutate in-place since we're already inside a render pass.
+            // The state will be observed as empty on the next render.
+            if (expandedToolChips.Value is { Count: > 0 } chips)
+                chips.Clear();
+        }
+
+        // When showToolCalls changes, pre-clear the native StackPanel so the
+        // reconciler (SyncChildren) only does inserts into an empty panel
+        // instead of expensive per-element RemoveAt calls that cascade
+        // Unloaded events through deep visual subtrees.
+        var prevShowToolCallsRef = UseRef(showToolCalls);
+        if (prevShowToolCallsRef.Current != showToolCalls)
+        {
+            prevShowToolCallsRef.Current = showToolCalls;
+            contentRef.Current?.Children.Clear();
+        }
 
         // Hover state — set of entry ids currently under the pointer. Used to
         // reveal the trash / speak action icons beside user / assistant
@@ -1667,7 +1701,7 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
         static bool IsAgentSide(ChatTimelineItemKind k) =>
             k == ChatTimelineItemKind.Assistant || k == ChatTimelineItemKind.ToolCall;
 
-        var renderedEntries = new Element[Props.Entries.Count];
+        var renderedEntries = new Element?[Props.Entries.Count];
         for (int i = 0; i < Props.Entries.Count; i++)
         {
             var entry = Props.Entries[i];
@@ -1682,16 +1716,11 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
             // block instead of N separate chips with repeated footers.
             if (entry.Kind == ChatTimelineItemKind.ToolCall)
             {
-                if (!showToolCalls)
-                {
-                    renderedEntries[i] = Empty().WithKey(entry.Id);
-                    continue;
-                }
                 if (!startsBurst)
                 {
                     // Non-start tool entries collapsed into the burst rendered
-                    // at startsBurst; render Empty here to avoid duplication.
-                    renderedEntries[i] = Empty().WithKey(entry.Id);
+                    // at startsBurst; render null here to avoid duplication.
+                    renderedEntries[i] = null;
                     continue;
                 }
                 var burst = new System.Collections.Generic.List<ChatTimelineItem> { entry };
@@ -1700,6 +1729,11 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                 {
                     burst.Add(Props.Entries[j]);
                     j++;
+                }
+                if (!showToolCalls)
+                {
+                    renderedEntries[i] = null;
+                    continue;
                 }
                 renderedEntries[i] = RenderToolBurst(burst, showAvatar).WithKey(entry.Id);
                 continue;

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
@@ -266,11 +266,8 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
         if (lastCollapseVersion.Current != ChatExplorationState.CollapseToolChipsVersion)
         {
             lastCollapseVersion.Current = ChatExplorationState.CollapseToolChipsVersion;
-            // Clear expanded state without triggering another render —
-            // mutate in-place since we're already inside a render pass.
-            // The state will be observed as empty on the next render.
-            if (expandedToolChips.Value is { Count: > 0 } chips)
-                chips.Clear();
+            if (expandedToolChips.Value.Count > 0)
+                expandedToolChips.Set(new HashSet<string>());
         }
 
         // When showToolCalls changes, pre-clear the native StackPanel so the

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
@@ -86,9 +86,14 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         // be called from an extension method). Same pattern in
         // OpenClawChatTimeline + OpenClawChatRoot.
         var explorationRev = UseState(0, threadSafe: true);
+        var explorationRevRef = UseRef(0);
         UseEffect((Func<Action>)(() =>
         {
-            EventHandler h = (_, _) => explorationRev.Set(explorationRev.Value + 1);
+            EventHandler h = (_, _) =>
+            {
+                explorationRevRef.Current++;
+                explorationRev.Set(explorationRevRef.Current);
+            };
             ChatExplorationState.Changed += h;
             return () => ChatExplorationState.Changed -= h;
         }));
@@ -468,7 +473,8 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
                 .Set("ButtonBorderBrush", new SolidColorBrush(Colors.Transparent))
                 .Set("ButtonBorderBrushPointerOver", new SolidColorBrush(Colors.Transparent))
                 .Set("ButtonBorderBrushPressed", new SolidColorBrush(Colors.Transparent)))
-            .AutomationName(tip);
+            .AutomationName(tip)
+            .SetToolTip(tip);
 
         // 5 icons (Send/Stop/Attach/Voice/More) honor ChatExplorationState
         // Show + Glyph overrides set from the explorations panel.
@@ -517,6 +523,22 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
                 Props.IsSpeakerMuted ? "Unmute" : "Mute",
                 () => Props.OnSpeakerToggle())
             : Empty();
+        // Toggle tool-call visibility. Same wrench icon in both states;
+        // reduced opacity when tool calls are hidden to indicate "off"
+        // without looking disabled. Tooltip clarifies the action.
+        var showTools = ChatExplorationState.ShowToolCalls;
+        var toolToggleBtn = IconButton(
+            "\uE90F",  // Wrench
+            showTools ? "Hide tool calls" : "Show tool calls",
+            () =>
+            {
+                var next = !ChatExplorationState.ShowToolCalls;
+                if (!next)
+                    ChatExplorationState.CollapseToolChipsVersion++;
+                ChatExplorationState.ShowToolCalls = next;
+            })
+            .Set(b => b.Opacity = showTools ? 1.0 : 0.55);
+
         var settingsBtn = Props.OnSettingsClick is not null
             ? IconButton("\uE713", "Settings", () => Props.OnSettingsClick())
             : Empty();
@@ -739,7 +761,7 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
             // Wrapping in FlexRow caused the Button to stretch to the Star column width.
             var bottomRow = Grid([GridSize.Auto, GridSize.Star()], [GridSize.Auto],
                 combinedPill.HAlign(HorizontalAlignment.Left).Grid(row: 0, column: 0),
-                (FlexRow(attachBtn, voiceCancelBtn, voiceBtn, speakerBtn, settingsBtn, actionBtn, stopBtn) with { ColumnGap = 4 })                    .HAlign(HorizontalAlignment.Right).Grid(row: 0, column: 1)
+                (FlexRow(attachBtn, voiceCancelBtn, voiceBtn, speakerBtn, toolToggleBtn, settingsBtn, actionBtn, stopBtn) with { ColumnGap = 4 })                    .HAlign(HorizontalAlignment.Right).Grid(row: 0, column: 1)
             );
 
             return VStack(0,
@@ -757,7 +779,7 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         }
 
         var actionsRow = Grid([GridSize.Star(), GridSize.Auto], [GridSize.Auto],
-            (FlexRow(attachBtn, voiceCancelBtn, voiceBtn, speakerBtn, settingsBtn, actionBtn, stopBtn)
+            (FlexRow(attachBtn, voiceCancelBtn, voiceBtn, speakerBtn, toolToggleBtn, settingsBtn, actionBtn, stopBtn)
                 with { ColumnGap = 4 })
             .HAlign(HorizontalAlignment.Right)
             .Grid(row: 0, column: 1)

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml
@@ -2,7 +2,8 @@
 <Page
     x:Class="OpenClawTray.Pages.ChatPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    NavigationCacheMode="Enabled">
 
     <Grid>
         <Grid.RowDefinitions>

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -251,7 +251,8 @@ public sealed partial class ChatPage : Page
             onAttachClick: OnAttachClicked,
             onSettingsClick: () => _hub?.NavigateTo("voice"),
             onSpeakerMuteChanged: muted => (App.Current as App)?.SetChatSpeakerMuted(muted),
-            initialMuted: CurrentApp.Settings?.VoiceTtsEnabled == false);
+            initialMuted: CurrentApp.Settings?.VoiceTtsEnabled == false,
+            suppressAutoDispose: true);
         _mountedProvider = provider;
 
         // If the V hotkey (or another caller) requested auto-start voice,

--- a/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
+++ b/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
@@ -802,6 +802,14 @@ public sealed class FunctionalHostControl : ContentControl, IDisposable
     private int _renderPending;
     private bool _disposed;
 
+    /// <summary>
+    /// When true, the control will not auto-dispose on <c>Unloaded</c>.
+    /// Set this when the host lives inside a page with
+    /// <c>NavigationCacheMode="Enabled"</c> so the component tree
+    /// survives page navigation.
+    /// </summary>
+    public bool SuppressAutoDispose { get; set; }
+
     public FunctionalHostControl()
     {
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
@@ -810,7 +818,7 @@ public sealed class FunctionalHostControl : ContentControl, IDisposable
         VerticalContentAlignment = VerticalAlignment.Stretch;
         Background = ThemeResources.ResolveBrush("SolidBackgroundFillColorBaseBrush");
         IsTabStop = false;
-        Unloaded += (_, _) => Dispose();
+        Unloaded += (_, _) => { if (!SuppressAutoDispose) Dispose(); };
     }
 
     public void Mount(Component component)
@@ -1425,6 +1433,7 @@ internal sealed class UiRenderer(Action requestRender)
         return new GridLength(double.Parse(value, CultureInfo.InvariantCulture), GridUnitType.Pixel);
     }
 
+
     private void SyncChildren(Panel panel, IReadOnlyList<Element?> elements, string path, List<Action> effects)
     {
         var renderedChildren = elements
@@ -1447,6 +1456,21 @@ internal sealed class UiRenderer(Action requestRender)
         var desiredChildren = renderedChildren.Select(child => child.Control).ToArray();
         if (ChildrenMatch(panel, desiredChildren))
             return;
+
+        // Fast path: when panel is empty (e.g. pre-cleared), just add children
+        // directly. Avoids EnsureChildAt → RemoveFromParent which scans ALL
+        // cached controls — O(controls × children) with no benefit when
+        // children have no parent.
+        if (panel.Children.Count == 0)
+        {
+            foreach (var child in desiredChildren)
+            {
+                if (child is FrameworkElement { Parent: { } })
+                    RemoveFromParent(child);
+                panel.Children.Add(child);
+            }
+            return;
+        }
 
         var desiredSet = new HashSet<UIElement>(desiredChildren);
         for (var i = panel.Children.Count - 1; i >= 0; i--)

--- a/tests/OpenClaw.Tray.Tests/FlattenedToolOutputDetectionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/FlattenedToolOutputDetectionTests.cs
@@ -224,10 +224,14 @@ public class FlattenedToolOutputDetectionTests
     }
 
     [Theory]
-    [InlineData("Command still running (session foo, pid 1)", "process")]
-    [InlineData("Process exited with code 0", "process")]
+    [InlineData("Command still running (session foo, pid 1)", "bash")]
+    [InlineData("Process exited with code 0", "bash")]
     [InlineData("Exec completed (oceanic, code 0)", "exec")]
     [InlineData("OpenClaw 2026.4.23 — Usage: openclaw help", "exec")]
+    [InlineData("  1. using System;\n  2. using System.IO;\n  3. namespace Foo;", "view")]
+    [InlineData("src/Main.cs:42:    var x = 1;", "grep")]
+    [InlineData("commit abc123\nAuthor: User\nDate: Mon Jan 1", "git")]
+    [InlineData("diff --git a/foo.cs b/foo.cs", "git")]
     public void ClassifiesKindCorrectly(string text, string expected)
     {
         Assert.Equal(expected, OpenClawChatDataProvider.ClassifyFlattenedToolOutput(text));
@@ -240,10 +244,9 @@ public class FlattenedToolOutputDetectionTests
     public void ToolresultRoleAlwaysClassified(string text)
     {
         // ``toolresult`` role sidesteps the heuristic — but the kind label
-        // must still come out as either "exec" or "process" so the chip
-        // header reads sensibly. Default fallthrough is "exec".
+        // must still produce a recognized tool type so the chip header reads
+        // sensibly. Default fallthrough is "exec".
         var kind = OpenClawChatDataProvider.ClassifyFlattenedToolOutput(text);
-        Assert.True(kind == "exec" || kind == "process",
-            $"Unexpected kind '{kind}' for: {text}");
+        Assert.False(string.IsNullOrEmpty(kind), $"Empty kind for: {text}");
     }
 }

--- a/tests/OpenClaw.Tray.Tests/FlattenedToolOutputDetectionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/FlattenedToolOutputDetectionTests.cs
@@ -249,4 +249,29 @@ public class FlattenedToolOutputDetectionTests
         var kind = OpenClawChatDataProvider.ClassifyFlattenedToolOutput(text);
         Assert.False(string.IsNullOrEmpty(kind), $"Empty kind for: {text}");
     }
+
+    // ── Additional classifier edge cases ──
+
+    [Theory]
+    [InlineData("Cloning into 'repo'...\nremote: Enumerating objects: 100", "exec")]
+    [InlineData("On branch main\nYour branch is up to date with 'origin/main'.", "exec")]
+    [InlineData("fatal: not a git repository", "exec")]
+    [InlineData("src/foo.cs\nsrc/bar.cs\nsrc/baz.cs", "exec")]
+    [InlineData("  1. first line\n  2. second line\n  3. third line", "view")]
+    [InlineData("--- a/src/main.cs\n+++ b/src/main.cs\n@@ -1,3 +1,4 @@", "exec")]
+    public void ClassifiesAdditionalKindsCorrectly(string text, string expected)
+    {
+        Assert.Equal(expected, OpenClawChatDataProvider.ClassifyFlattenedToolOutput(text));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("x")]
+    public void ClassifyFlattenedToolOutput_EmptyOrTiny_ReturnsExecDefault(string text)
+    {
+        // Even empty/tiny text should return a non-empty kind (default "exec")
+        var kind = OpenClawChatDataProvider.ClassifyFlattenedToolOutput(text);
+        Assert.False(string.IsNullOrEmpty(kind));
+    }
 }

--- a/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
@@ -1,0 +1,139 @@
+using OpenClawTray.Chat;
+using Xunit;
+
+namespace OpenClaw.Tray.Tests;
+
+/// <summary>
+/// Tests for the tool metadata cache matching logic used to recover tool
+/// names/labels after gateway history flattening.
+/// </summary>
+public class ToolMetaCacheTests
+{
+    private static OpenClawChatDataProvider.CachedToolMeta Meta(long ts, string tool, string label) =>
+        new() { Ts = ts, ToolName = tool, Label = label };
+
+    // ── TryMatchCachedTool ──
+
+    [Fact]
+    public void TryMatch_NullCache_ReturnsNull()
+    {
+        Assert.Null(OpenClawChatDataProvider.TryMatchCachedTool(null, 1000));
+    }
+
+    [Fact]
+    public void TryMatch_EmptyCache_ReturnsNull()
+    {
+        var cache = new Queue<OpenClawChatDataProvider.CachedToolMeta>();
+        Assert.Null(OpenClawChatDataProvider.TryMatchCachedTool(cache, 1000));
+    }
+
+    [Fact]
+    public void TryMatch_SingleEntry_DequeuesAndReturns()
+    {
+        var cache = new Queue<OpenClawChatDataProvider.CachedToolMeta>();
+        cache.Enqueue(Meta(100, "bash", "ls -la"));
+
+        var result = OpenClawChatDataProvider.TryMatchCachedTool(cache, 200);
+
+        Assert.NotNull(result);
+        Assert.Equal("bash", result!.ToolName);
+        Assert.Equal("ls -la", result.Label);
+        Assert.Empty(cache); // consumed
+    }
+
+    [Fact]
+    public void TryMatch_SequentialOrder_MatchesByPosition()
+    {
+        var cache = new Queue<OpenClawChatDataProvider.CachedToolMeta>();
+        cache.Enqueue(Meta(100, "bash", "first"));
+        cache.Enqueue(Meta(200, "grep", "second"));
+        cache.Enqueue(Meta(300, "view", "third"));
+
+        // Each call should dequeue the next entry regardless of timestamp
+        var r1 = OpenClawChatDataProvider.TryMatchCachedTool(cache, 500);
+        var r2 = OpenClawChatDataProvider.TryMatchCachedTool(cache, 600);
+        var r3 = OpenClawChatDataProvider.TryMatchCachedTool(cache, 700);
+
+        Assert.Equal("bash", r1!.ToolName);
+        Assert.Equal("grep", r2!.ToolName);
+        Assert.Equal("view", r3!.ToolName);
+        Assert.Empty(cache);
+    }
+
+    [Fact]
+    public void TryMatch_MoreHistoryThanCache_ReturnsNullWhenExhausted()
+    {
+        var cache = new Queue<OpenClawChatDataProvider.CachedToolMeta>();
+        cache.Enqueue(Meta(100, "bash", "only entry"));
+
+        var r1 = OpenClawChatDataProvider.TryMatchCachedTool(cache, 200);
+        var r2 = OpenClawChatDataProvider.TryMatchCachedTool(cache, 300);
+
+        Assert.NotNull(r1);
+        Assert.Null(r2); // exhausted
+    }
+
+    [Fact]
+    public void TryMatch_CachedEntryFarAfterHistory_SkipsMatch()
+    {
+        // Cache entry is >5 minutes (300_000ms) after the history entry —
+        // means this history tool result predates the cache.
+        var cache = new Queue<OpenClawChatDataProvider.CachedToolMeta>();
+        cache.Enqueue(Meta(500_000, "bash", "future entry"));
+
+        var result = OpenClawChatDataProvider.TryMatchCachedTool(cache, 100_000);
+
+        Assert.Null(result);
+        Assert.Single(cache); // NOT consumed — entry stays for later
+    }
+
+    [Fact]
+    public void TryMatch_CachedEntrySlightlyAfterHistory_StillMatches()
+    {
+        // Cache entry is <5 min after history — normal SSE delay, should match.
+        var cache = new Queue<OpenClawChatDataProvider.CachedToolMeta>();
+        cache.Enqueue(Meta(200_000, "bash", "recent entry"));
+
+        var result = OpenClawChatDataProvider.TryMatchCachedTool(cache, 100_000);
+
+        Assert.NotNull(result);
+        Assert.Equal("bash", result!.ToolName);
+    }
+
+    [Fact]
+    public void TryMatch_ZeroTimestamps_AlwaysMatch()
+    {
+        // When timestamps are 0, the guard is skipped — always dequeue.
+        var cache = new Queue<OpenClawChatDataProvider.CachedToolMeta>();
+        cache.Enqueue(Meta(0, "bash", "no timestamp"));
+
+        var result = OpenClawChatDataProvider.TryMatchCachedTool(cache, 0);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void TryMatch_RepeatedToolNames_PreservesOrder()
+    {
+        // Multiple entries with the same tool name should be matched in order.
+        var cache = new Queue<OpenClawChatDataProvider.CachedToolMeta>();
+        cache.Enqueue(Meta(100, "bash", "first bash"));
+        cache.Enqueue(Meta(200, "bash", "second bash"));
+        cache.Enqueue(Meta(300, "bash", "third bash"));
+
+        var r1 = OpenClawChatDataProvider.TryMatchCachedTool(cache, 500);
+        var r2 = OpenClawChatDataProvider.TryMatchCachedTool(cache, 600);
+
+        Assert.Equal("first bash", r1!.Label);
+        Assert.Equal("second bash", r2!.Label);
+    }
+
+    // ── Constants ──
+
+    [Fact]
+    public void SessionLimits_AreReasonable()
+    {
+        Assert.Equal(20, OpenClawChatDataProvider.MaxCachedSessions);
+        Assert.Equal(500, OpenClawChatDataProvider.MaxToolEntriesPerSession);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
@@ -1,4 +1,7 @@
+using OpenClaw.Chat;
+using OpenClaw.Shared;
 using OpenClawTray.Chat;
+using System.Text.Json;
 using Xunit;
 
 namespace OpenClaw.Tray.Tests;
@@ -135,5 +138,86 @@ public class ToolMetaCacheTests
     {
         Assert.Equal(20, OpenClawChatDataProvider.MaxCachedSessions);
         Assert.Equal(500, OpenClawChatDataProvider.MaxToolEntriesPerSession);
+    }
+
+    [Fact]
+    public async Task CacheToolMeta_ConcurrentAdds_FlushesCompleteValidJson()
+    {
+        using var tempDir = new TempDirectory();
+        var cachePath = Path.Combine(tempDir.DirectoryPath, "tool-metadata.json");
+        var bridge = new FakeBridge
+        {
+            History = new ChatHistoryInfo
+            {
+                SessionKey = "main",
+                SessionId = "session-1"
+            }
+        };
+        var provider = new OpenClawChatDataProvider(bridge, post: null, toolMetaCacheFilePath: cachePath);
+        await provider.LoadHistoryAsync("main");
+
+        Parallel.For(0, 100, i =>
+            provider.CacheToolMeta("main", 1_000 + i, "bash", $"echo {i}"));
+
+        await provider.DisposeAsync();
+
+        var json = File.ReadAllText(cachePath);
+        var cache = JsonSerializer.Deserialize<Dictionary<string, List<OpenClawChatDataProvider.CachedToolMeta>>>(json);
+
+        Assert.NotNull(cache);
+        Assert.True(cache!.TryGetValue("session-1", out var entries));
+        Assert.Equal(100, entries!.Count);
+        Assert.Empty(Directory.EnumerateFiles(tempDir.DirectoryPath, "*.tmp"));
+    }
+
+    private sealed class FakeBridge : IChatGatewayBridge
+    {
+        public bool IsConnected { get; set; }
+        public ConnectionStatus CurrentStatus { get; set; }
+        public string? MainSessionKey { get; set; }
+        public bool HasHandshakeSnapshot { get; set; }
+        public ChatHistoryInfo History { get; set; } = new() { SessionKey = "main" };
+
+        public SessionInfo[] GetSessionList() => Array.Empty<SessionInfo>();
+        public ModelsListInfo? GetCurrentModelsList() => null;
+        public Task SendChatMessageAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null) => Task.CompletedTask;
+        public Task PatchSessionModelAsync(string sessionKey, string model) => Task.CompletedTask;
+        public Task PatchSessionThinkingLevelAsync(string sessionKey, string thinkingLevel) => Task.CompletedTask;
+        public Task<ChatHistoryInfo> RequestChatHistoryAsync(string? sessionKey) => Task.FromResult(History);
+        public Task SendChatAbortAsync(string runId, string? sessionKey = null) => Task.CompletedTask;
+        public event EventHandler<ConnectionStatus>? StatusChanged;
+        public event EventHandler<SessionInfo[]>? SessionsUpdated;
+        public event EventHandler<ChatMessageInfo>? ChatMessageReceived;
+        public event EventHandler<AgentEventInfo>? AgentEventReceived;
+        public event EventHandler<ModelsListInfo>? ModelsListUpdated;
+        public void RaiseStatus(ConnectionStatus status) => StatusChanged?.Invoke(this, status);
+        public void RaiseSessions(SessionInfo[] sessions) => SessionsUpdated?.Invoke(this, sessions);
+        public void RaiseChat(ChatMessageInfo message) => ChatMessageReceived?.Invoke(this, message);
+        public void RaiseAgent(AgentEventInfo evt) => AgentEventReceived?.Invoke(this, evt);
+        public void RaiseModels(ModelsListInfo models) => ModelsListUpdated?.Invoke(this, models);
+        public void Dispose() { }
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public string DirectoryPath { get; } = Path.Combine(Path.GetTempPath(), "openclaw-tool-meta-" + Guid.NewGuid().ToString("N"));
+
+        public TempDirectory()
+        {
+            Directory.CreateDirectory(DirectoryPath);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(DirectoryPath))
+                    Directory.Delete(DirectoryPath, recursive: true);
+            }
+            catch
+            {
+                // Test cleanup is best-effort.
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Improves the chat experience with tool call caching, a toggle UI, and critical bug fixes.

### Tool Metadata Cache
- Persists tool call metadata (name, label, timestamp) to disk so flattened tool outputs from gateway history replay can be recovered with proper tool names/icons
- Sequential order matching between cache and history entries
- Session limits (20 sessions, 500 entries per session)
- Debounced saves (500ms quiescence timer) to prevent concurrent file writes
- Atomic file writes (write .tmp then File.Move) to prevent partial JSON on crash

### Tool Call Toggle
- Wrench icon in the toolbar to show/hide tool calls in chat
- 0.55 opacity when hidden, full opacity when shown
- Tooltips on all toolbar buttons for accessibility
- Collapses all expanded tool chips when hiding

### Stale-Closure Fix (Critical)
- Fixed a bug where UseState closures in ChatExplorationState.Changed handlers captured the initial value (0), causing Set(1) to be a no-op after the first toggle
- Affected all 4 components: Timeline, Composer, ChatRoot, ExplorationsPanel
- Fixed with UseRef-based counter pattern

### Performance Optimizations
- Pre-clear native StackPanel before render so SyncChildren only does inserts
- SyncChildren fast path for empty panels (skip RemoveFromParent scans)
- ChatRoot reads explorationRevRef.Current inside dispatcher lambda

### Tests
- 19 new tests (1161 total): ToolMetaCacheTests (sequential matching, exhaustion, guards), classifier edge cases
- All existing tests pass

### Other
- ChatPage NavigationCacheMode=Enabled, suppressAutoDispose on FunctionalHostControl
- Improved ClassifyFlattenedToolOutput heuristics (bash, view, grep, git, edit, glob detection)