### PR TITLE
fix: MCP server runtime toggle & AppCapability MCP-only separation

### DIFF
--- a/src/OpenClaw.Connection/SettingsChangeImpact.cs
+++ b/src/OpenClaw.Connection/SettingsChangeImpact.cs
@@ -43,9 +43,15 @@ public static class SettingsChangeClassifier
             return SettingsChangeImpact.OperatorReconnectRequired;
 
         // EnableNodeMode toggled → node reconnect
-        if (prev.EnableNodeMode != next.EnableNodeMode ||
-            prev.EnableMcpServer != next.EnableMcpServer)
+        if (prev.EnableNodeMode != next.EnableNodeMode)
             return SettingsChangeImpact.NodeReconnectRequired;
+
+        // EnableMcpServer toggled → no gateway reconnect needed; the MCP
+        // server is purely local and managed by NodeService.SetMcpEnabled
+        // in the settings-change handler. Classify as UiOnly so the
+        // reconnect path is not triggered.
+        if (prev.EnableMcpServer != next.EnableMcpServer)
+            return SettingsChangeImpact.UiOnly;
 
         // Node capability toggles → capability reload
         if (prev.NodeCanvasEnabled != next.NodeCanvasEnabled ||

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using OpenClaw.Shared;
+using OpenClaw.Shared.Capabilities;
 using OpenClawTray.Dialogs;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
@@ -251,6 +252,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     
     // Node service (optional, enabled in settings)
     private NodeService? _nodeService;
+    // MCP-only app capability — local testing/control, not exposed to gateway
+    private AppCapability? _appCapability;
     
     // Keep-alive window to anchor WinUI runtime (prevents GC/threading issues)
     private Window? _keepAliveWindow;
@@ -741,6 +744,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 }
 
                 _nodeService.AttachClient(args.Client, args.BearerToken);
+                WireAppCapabilityHandlers();
                 var client = args.Client;
                 diagnostics.Record("node", $"After AttachClient: caps={client.Capabilities.Count}, cmds={client.RegisteredCommandCount}");
                 if (client.RegisteredCommandCount > 0)
@@ -1719,6 +1723,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         try
         {
             nodeService.StartLocalOnlyAsync().GetAwaiter().GetResult();
+            WireAppCapabilityHandlers();
             Logger.Info("Started MCP-only node service without gateway connection");
             return true;
         }
@@ -1853,8 +1858,12 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
     private void WireAppCapabilityHandlers()
     {
-        var app = _nodeService?.AppCapability;
-        if (app == null) return;
+        if (_nodeService == null) return;
+        if (_appCapability != null) return; // already wired
+
+        _appCapability = new AppCapability(new AppLogger());
+        _nodeService.RegisterMcpOnlyCapability(_appCapability);
+        var app = _appCapability;
 
         app.NavigateHandler = async (page) =>
         {
@@ -2797,6 +2806,18 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             case SettingsChangeImpact.NoOp:
                 // No connection changes needed
                 break;
+        }
+
+        // MCP server lifecycle — handled separately from gateway reconnects
+        // because MCP-only mode doesn't involve a gateway at all. SetMcpEnabled
+        // checks actual runtime state (_mcpServer != null), so it's safe to
+        // call unconditionally. Only create NodeService when MCP is being
+        // enabled or the service already exists.
+        if (_settings != null && (_nodeService != null || _settings.EnableMcpServer))
+        {
+            var nodeService = EnsureNodeService(_settings);
+            nodeService?.SetMcpEnabled(_settings.EnableMcpServer);
+            WireAppCapabilityHandlers();
         }
 
         // Non-connection settings always applied regardless of impact

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -83,7 +83,6 @@ public sealed class NodeService : IDisposable
     private TtsCapability? _ttsCapability;
     private TextToSpeechService? _textToSpeechService;
     private VoiceService? _voiceService;
-    private AppCapability? _appCapability;
     private readonly string _dataPath;
     // Identity store location for the role-aware DeviceIdentity. Defaults to
     // _dataPath when no separate path is supplied (preserves existing test
@@ -104,6 +103,11 @@ public sealed class NodeService : IDisposable
     // bridge snapshot can't race a re-register.
     private readonly List<INodeCapability> _capabilities = new();
     private readonly object _capabilitiesLock = new();
+
+    // MCP-only capabilities — visible to local MCP clients but NOT registered
+    // on the gateway WebSocket. Used for app-level testing/control tools that
+    // should not be callable by remote agents.
+    private readonly List<INodeCapability> _mcpOnlyCapabilities = new();
 
     // Serializes AttachClient ↔ DisconnectAsync so a reconnect that overlaps a
     // disconnect can't leave stale subscriptions on an old client or double-
@@ -137,11 +141,10 @@ public sealed class NodeService : IDisposable
     /// </summary>
     public static string McpTokenPath =>
         System.IO.Path.Combine(SettingsManager.SettingsDirectoryPath, "mcp-token.txt");
-    private readonly bool _enableMcpServer;
+    private volatile bool _enableMcpServer;
     private McpHttpServer? _mcpServer;
     private string? _mcpStartupError;
     public bool IsMcpRunning => _mcpServer != null;
-    public AppCapability? AppCapability => _appCapability;
     public VoiceService? VoiceService => _voiceService;
     public TextToSpeechService? TextToSpeech => _textToSpeechService;
     public string McpEndpoint => McpServerUrl;
@@ -272,10 +275,6 @@ public sealed class NodeService : IDisposable
         {
         _capabilities.Clear();
 
-        // App operations capability (always registered, not gated by a toggle)
-        _appCapability = new AppCapability(_logger);
-        Register(_appCapability);
-
         // System capability (notifications + command execution)
         _systemCapability = new SystemCapability(_logger);
         _systemCapability.NotifyRequested += OnSystemNotify;
@@ -391,6 +390,18 @@ public sealed class NodeService : IDisposable
     {
         _capabilities.Add(capability);
         _nodeClient?.RegisterCapability(capability);
+    }
+
+    /// <summary>
+    /// Register a capability that is only visible to local MCP clients, not
+    /// the gateway. Used for app-level testing/control tools.
+    /// </summary>
+    public void RegisterMcpOnlyCapability(INodeCapability capability)
+    {
+        lock (_capabilitiesLock)
+        {
+            _mcpOnlyCapabilities.Add(capability);
+        }
     }
 
     /// <summary>
@@ -591,11 +602,23 @@ public sealed class NodeService : IDisposable
         {
             // Bridge reads the live _capabilities list every tools/list, so any
             // future Register(...) call is exposed via MCP automatically.
+            // MCP-only capabilities (e.g. AppCapability) are merged in so
+            // they appear in tools/list but never touch the gateway client.
             // The snapshot takes the same lock RegisterCapabilities holds,
             // so a tools/list arriving mid-rebuild observes either the old
             // or the new set — never a partially-cleared list.
             var bridge = new McpToolBridge(
-                () => { lock (_capabilitiesLock) return _capabilities.ToArray(); },
+                () => {
+                    lock (_capabilitiesLock)
+                    {
+                        if (_mcpOnlyCapabilities.Count == 0)
+                            return _capabilities.ToArray();
+                        var merged = new List<INodeCapability>(_capabilities.Count + _mcpOnlyCapabilities.Count);
+                        merged.AddRange(_capabilities);
+                        merged.AddRange(_mcpOnlyCapabilities);
+                        return merged.ToArray();
+                    }
+                },
                 _logger,
                 serverName: "openclaw-tray-mcp",
                 serverVersion: typeof(NodeService).Assembly.GetName().Version?.ToString() ?? "0.0.0");
@@ -664,6 +687,42 @@ public sealed class NodeService : IDisposable
         _mcpServer?.UpdateAuthToken(token);
         _logger.Info("[MCP] Bearer token rotated");
         return token;
+    }
+
+    /// <summary>
+    /// Update the MCP server state at runtime (e.g. when the user toggles
+    /// EnableMcpServer in the Settings UI). Starts or stops the HTTP server
+    /// and ensures capabilities are registered for MCP-only mode.
+    /// </summary>
+    public void SetMcpEnabled(bool enabled)
+    {
+        _enableMcpServer = enabled;
+
+        if (enabled)
+        {
+            if (_mcpServer != null) return; // already running
+
+            _logger.Info("[MCP] SetMcpEnabled(true) — starting MCP server");
+
+            bool needsCapabilities;
+            lock (_capabilitiesLock) { needsCapabilities = _capabilities.Count == 0; }
+            if (needsCapabilities)
+            {
+                RegisterCapabilities();
+            }
+            else
+            {
+                StartMcpServer();
+            }
+        }
+        else
+        {
+            _logger.Info("[MCP] SetMcpEnabled(false) — stopping MCP server");
+            // Always call StopMcpServer to clear stale startup errors even
+            // if the server isn't running. StopMcpServer is lock-protected
+            // and handles _mcpServer == null safely.
+            StopMcpServer();
+        }
     }
 
     public GatewayNodeInfo? GetLocalNodeInfo()

--- a/tests/OpenClaw.Connection.Tests/SettingsChangeImpactTests.cs
+++ b/tests/OpenClaw.Connection.Tests/SettingsChangeImpactTests.cs
@@ -104,4 +104,31 @@ public class SettingsChangeImpactTests
         Assert.Equal(SettingsChangeImpact.UiOnly,
             SettingsChangeClassifier.Classify(prev, next));
     }
+
+    [Fact]
+    public void McpServerToggled_ReturnsUiOnly()
+    {
+        var prev = MakeSnapshot(gatewayUrl: "wss://test", enableMcpServer: false);
+        var next = MakeSnapshot(gatewayUrl: "wss://test", enableMcpServer: true);
+        Assert.Equal(SettingsChangeImpact.UiOnly,
+            SettingsChangeClassifier.Classify(prev, next));
+    }
+
+    [Fact]
+    public void McpServerToggledOff_ReturnsUiOnly()
+    {
+        var prev = MakeSnapshot(gatewayUrl: "wss://test", enableMcpServer: true);
+        var next = MakeSnapshot(gatewayUrl: "wss://test", enableMcpServer: false);
+        Assert.Equal(SettingsChangeImpact.UiOnly,
+            SettingsChangeClassifier.Classify(prev, next));
+    }
+
+    [Fact]
+    public void McpAndNodeModeToggled_ReturnsNodeReconnect()
+    {
+        var prev = MakeSnapshot(gatewayUrl: "wss://test", enableNodeMode: false, enableMcpServer: false);
+        var next = MakeSnapshot(gatewayUrl: "wss://test", enableNodeMode: true, enableMcpServer: true);
+        Assert.Equal(SettingsChangeImpact.NodeReconnectRequired,
+            SettingsChangeClassifier.Classify(prev, next));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the broken Local MCP Server toggle in Settings — enabling/disabling MCP at runtime now correctly starts/stops the HTTP server. Also separates \AppCapability\ (app.* tools) from the gateway so they're MCP-only.

## Changes

### 1. Runtime MCP toggle (\NodeService.SetMcpEnabled\)
- \_enableMcpServer\ was \eadonly\ — toggling MCP in the UI never started/stopped the server
- Added \SetMcpEnabled(bool)\ that starts/stops the MCP HTTP server at runtime
- Called from \OnSettingsSaved\ after every settings save

### 2. Classifier fix (\SettingsChangeImpact\)
- Separated \EnableMcpServer\ from \EnableNodeMode\ — MCP toggle now returns \UiOnly\ instead of \NodeReconnectRequired\, avoiding unnecessary gateway disconnects

### 3. AppCapability → MCP-only
- Moved \AppCapability\ creation from \NodeService.RegisterCapabilities()\ to \App.xaml.cs\
- Registered via new \RegisterMcpOnlyCapability()\ — app.* tools appear in MCP \	ools/list\ but are NOT exposed to the gateway
- Added \_mcpOnlyCapabilities\ list merged into the bridge lambda
- Wired \WireAppCapabilityHandlers()\ after all capability registration paths (was defined but never called — pre-existing bug)

## Testing

- Build ✅ (all 4 projects)
- Shared tests: 1803 passed, 28 skipped ✅
- Tray tests: 1149 passed ✅
- Connection tests: 228 passed (3 new) ✅
- End-to-end: 37/39 MCP tools verified via curl (tts.speak = provider init, browser.proxy = needs gateway auth)
