### PR TITLE
Add Run system tools permission toggle

### DIFF
--- a/src/OpenClaw.Connection/ConnectionSettingsSnapshot.cs
+++ b/src/OpenClaw.Connection/ConnectionSettingsSnapshot.cs
@@ -20,4 +20,5 @@ public sealed record ConnectionSettingsSnapshot(
     bool NodeBrowserProxyEnabled,
     bool NodeSttEnabled,
     bool NodeTtsEnabled,
+    bool NodeSystemRunEnabled,
     string? FullSettingsJson);

--- a/src/OpenClaw.Connection/SettingsChangeImpact.cs
+++ b/src/OpenClaw.Connection/SettingsChangeImpact.cs
@@ -54,7 +54,8 @@ public static class SettingsChangeClassifier
             prev.NodeLocationEnabled != next.NodeLocationEnabled ||
             prev.NodeBrowserProxyEnabled != next.NodeBrowserProxyEnabled ||
             prev.NodeSttEnabled != next.NodeSttEnabled ||
-            prev.NodeTtsEnabled != next.NodeTtsEnabled)
+            prev.NodeTtsEnabled != next.NodeTtsEnabled ||
+            prev.NodeSystemRunEnabled != next.NodeSystemRunEnabled)
             return SettingsChangeImpact.CapabilityReload;
 
         // Check if anything else changed (UI-only changes)

--- a/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
@@ -17,11 +17,19 @@ public class SystemCapability : NodeCapabilityBase
     private const int DefaultRunTimeoutMs = 30_000;
     private const int MaxRunTimeoutMs = 600_000; // 10 minutes
 
-    private static readonly string[] _commands = new[]
+    private static readonly string[] _commandsWithRun = new[]
     {
         "system.notify",
         "system.run",
         "system.run.prepare",
+        "system.which",
+        "system.execApprovals.get",
+        "system.execApprovals.set"
+    };
+
+    private static readonly string[] _commandsWithoutRun = new[]
+    {
+        "system.notify",
         "system.which",
         "system.execApprovals.get",
         "system.execApprovals.set"
@@ -47,8 +55,11 @@ public class SystemCapability : NodeCapabilityBase
         "net "
     ];
     
-    public override IReadOnlyList<string> Commands => _commands;
-    
+    private readonly bool _includeRunCommands;
+
+    public override IReadOnlyList<string> Commands =>
+        _includeRunCommands ? _commandsWithRun : _commandsWithoutRun;
+
     // Event to let UI handle the actual notification display
     public event EventHandler<SystemNotifyArgs>? NotifyRequested;
     
@@ -62,8 +73,18 @@ public class SystemCapability : NodeCapabilityBase
     // V2 exec approval handler (null = legacy path; inert until explicitly set)
     private IExecApprovalV2Handler? _v2Handler;
     
-    public SystemCapability(IOpenClawLogger logger) : base(logger)
+    /// <param name="logger">Capability logger.</param>
+    /// <param name="includeRunCommands">
+    /// When false, <c>system.run</c> and <c>system.run.prepare</c> are dropped
+    /// from <see cref="Commands"/> and <see cref="ExecuteAsync"/> rejects them
+    /// with a clear error before any V2/legacy dispatch. The rest of the
+    /// <c>system</c> category (notify/which/execApprovals.get/set) is
+    /// unaffected. Wired from the tray "Run system tools" permission toggle
+    /// via <c>NodeCapabilityGating.ShouldRegisterSystemRun</c>.
+    /// </param>
+    public SystemCapability(IOpenClawLogger logger, bool includeRunCommands = true) : base(logger)
     {
+        _includeRunCommands = includeRunCommands;
     }
     
     /// <summary>
@@ -98,6 +119,16 @@ public class SystemCapability : NodeCapabilityBase
     
     public override async Task<NodeInvokeResponse> ExecuteAsync(NodeInvokeRequest request)
     {
+        // "Run system tools" kill switch — applied before V2/legacy dispatch
+        // so stale gateway allowlists and cached MCP clients still see the
+        // capability as disabled when the user turned it off.
+        if (!_includeRunCommands &&
+            (request.Command == "system.run" || request.Command == "system.run.prepare"))
+        {
+            Logger.Info($"[system.run] rejected: 'Run system tools' is disabled (command={request.Command})");
+            return Error("system.run is disabled by user setting (Permissions → Run system tools).");
+        }
+
         return request.Command switch
         {
             "system.notify" => await HandleNotifyAsync(request),

--- a/src/OpenClaw.Shared/SettingsData.cs
+++ b/src/OpenClaw.Shared/SettingsData.cs
@@ -40,6 +40,16 @@ public class SettingsData
     public bool CameraRecordingConsentGiven { get; set; } = false;
     public bool NodeLocationEnabled { get; set; } = true;
     public bool NodeBrowserProxyEnabled { get; set; } = true;
+    /// <summary>
+    /// Master switch for the <c>system.run</c> + <c>system.run.prepare</c>
+    /// commands. When <c>false</c>, those commands are dropped from the
+    /// capability's declared command list (so they don't appear in the
+    /// connect handshake or in MCP <c>tools/list</c>) and invocations are
+    /// rejected defensively. Per-command exec approvals still apply when
+    /// enabled. Default <c>true</c> for backward compatibility — exec has
+    /// been part of the Windows node since day one.
+    /// </summary>
+    public bool NodeSystemRunEnabled { get; set; } = true;
     public bool NodeSttEnabled { get; set; } = false;
     /// <summary>STT language: "auto" for Whisper auto-detect, or a BCP-47 tag like "en-US".</summary>
     public string SttLanguage { get; set; } = "auto";

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
@@ -114,9 +114,10 @@ public sealed partial class PermissionsPage : Page
     {
         if (CurrentApp.Settings == null || _featureToggles.Count == 0) return;
         var s = CurrentApp.Settings;
-        // Order matches BuildCapabilityToggles: browser, camera, canvas, screen, location, tts, stt.
+        // Order matches BuildCapabilityToggles: system-run, browser, camera, canvas, screen, location, tts, stt.
         bool[] expected =
         {
+            s.NodeSystemRunEnabled,
             s.NodeBrowserProxyEnabled, s.NodeCameraEnabled, s.NodeCanvasEnabled,
             s.NodeScreenEnabled, s.NodeLocationEnabled, s.NodeTtsEnabled, s.NodeSttEnabled,
         };
@@ -151,6 +152,10 @@ public sealed partial class PermissionsPage : Page
         // OnToggleSideEffect runs after the new value is persisted.
         var capabilities = new (string Icon, string Label, string Description, bool Value, Action<bool> Setter, Action<bool>? OnToggleSideEffect)[]
         {
+            ("⚡",
+                LocalizationHelper.GetString("PermissionsPage_Cap_SystemRun_Label"),
+                LocalizationHelper.GetString("PermissionsPage_Cap_SystemRun_Description"),
+                settings.NodeSystemRunEnabled, v => settings.NodeSystemRunEnabled = v, null),
             ("🌐",
                 LocalizationHelper.GetString("PermissionsPage_Cap_Browser_Label"),
                 LocalizationHelper.GetString("PermissionsPage_Cap_Browser_Description"),

--- a/src/OpenClaw.Tray.WinUI/Services/NodeCapabilityGating.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeCapabilityGating.cs
@@ -13,6 +13,11 @@ namespace OpenClawTray.Services;
 /// Defaults: capabilities default ON (a missing or null settings object
 /// counts as enabled) except <c>tts.speak</c> and <c>stt.transcribe</c>,
 /// which are privacy-sensitive and require an explicit opt-in.
+///
+/// <see cref="ShouldRegisterSystemRun"/> gates the <c>system.run</c> /
+/// <c>system.run.prepare</c> commands inside <c>SystemCapability</c>, not
+/// the whole <c>system</c> category — <c>system.notify</c>, <c>system.which</c>,
+/// and the exec-approval read/write commands stay registered regardless.
 /// </summary>
 internal static class NodeCapabilityGating
 {
@@ -23,4 +28,5 @@ internal static class NodeCapabilityGating
     public static bool ShouldRegisterBrowserProxy(SettingsManager? s) => s?.NodeBrowserProxyEnabled != false;
     public static bool ShouldRegisterTts(SettingsManager? s)          => s?.NodeTtsEnabled          == true;
     public static bool ShouldRegisterStt(SettingsManager? s)          => s?.NodeSttEnabled          == true;
+    public static bool ShouldRegisterSystemRun(SettingsManager? s)    => s?.NodeSystemRunEnabled    != false;
 }

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -276,8 +276,13 @@ public sealed class NodeService : IDisposable
         _appCapability = new AppCapability(_logger);
         Register(_appCapability);
 
-        // System capability (notifications + command execution)
-        _systemCapability = new SystemCapability(_logger);
+        // System capability (notifications + command execution). The
+        // "Run system tools" toggle gates the run/run.prepare commands
+        // inside the capability — the rest (notify/which/execApprovals)
+        // stay registered regardless.
+        _systemCapability = new SystemCapability(
+            _logger,
+            includeRunCommands: NodeCapabilityGating.ShouldRegisterSystemRun(_settings));
         _systemCapability.NotifyRequested += OnSystemNotify;
         _systemCapability.SetCommandRunner(BuildSystemRunRunner());
         _systemCapability.SetApprovalPolicy(new ExecApprovalPolicy(_dataPath, _logger));
@@ -457,32 +462,17 @@ public sealed class NodeService : IDisposable
 
         _logger.Info($"[NodeService] AttachClient: capabilitiesBuilt={capabilitiesBuilt}, _capabilities.Count={_capabilities.Count}");
 
-        // First connect after app startup may not have built capability objects yet.
-        // RegisterCapabilities() populates _capabilities and registers them on _nodeClient.
-        if (!capabilitiesBuilt)
-        {
-            _logger.Info("[NodeService] AttachClient: capabilities not yet built, calling RegisterCapabilities()");
-            RegisterCapabilities();
-        }
-        else
-        {
-            // Reconnect path: capabilities already exist, just re-bind to the new client.
-            lock (_capabilitiesLock)
-            {
-                foreach (var capability in _capabilities)
-                {
-                    try
-                    {
-                        client.RegisterCapability(capability);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.Warn($"[NodeService] AttachClient: failed to register {capability.Category}: {ex.Message}");
-                    }
-                }
-            }
-            _logger.Info($"[NodeService] AttachClient: re-registered {_capabilities.Count} capabilities on new client");
-        }
+        // Always rebuild from current settings. The previous reconnect path
+        // re-registered the cached _capabilities instances, but _capabilities
+        // is only cleared in DisconnectAsync — which is never invoked on the
+        // reconnect path used by App.OnSettingsSaved (CapabilityReload calls
+        // ReconnectAsync, not DisconnectAsync). That left toggles like
+        // NodeCanvasEnabled / NodeSystemRunEnabled silently requiring a full
+        // app restart to take effect. RegisterCapabilities() clears the list,
+        // rebuilds with current settings, and registers on the new _nodeClient
+        // — correct for first-attach AND reconnect.
+        _logger.Info("[NodeService] AttachClient: rebuilding capabilities from current settings");
+        RegisterCapabilities();
 
         // Log final registration state for diagnostics
         _logger.Info($"[NodeService] AttachClient DONE: client.Registration.Capabilities={client.RegisteredCapabilityCount}, client.Registration.Commands={client.RegisteredCommandCount}");
@@ -705,6 +695,8 @@ public sealed class NodeService : IDisposable
             disabled.AddRange(CommandCenterCommandGroups.SafeCompanionCommands.Where(command => command.StartsWith("location.", StringComparison.OrdinalIgnoreCase)));
         if (_settings?.NodeBrowserProxyEnabled == false)
             disabled.Add("browser.proxy");
+        if (_settings?.NodeSystemRunEnabled == false)
+            disabled.AddRange(new[] { "system.run", "system.run.prepare" });
         if (_settings?.NodeSttEnabled != true)
             disabled.Add(SttCapability.TranscribeCommand);
         if (_settings?.NodeTtsEnabled != true)

--- a/src/OpenClaw.Tray.WinUI/Services/SettingsDataExtensions.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SettingsDataExtensions.cs
@@ -21,5 +21,6 @@ public static class SettingsDataExtensions
         settings.NodeBrowserProxyEnabled,
         settings.NodeSttEnabled,
         settings.NodeTtsEnabled,
+        settings.NodeSystemRunEnabled,
         settings.ToJson());
 }

--- a/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
@@ -86,6 +86,13 @@ public class SettingsManager
     public bool CameraRecordingConsentGiven { get; set; } = false;
     public bool NodeLocationEnabled { get; set; } = true;
     public bool NodeBrowserProxyEnabled { get; set; } = true;
+    /// <summary>
+    /// Master switch for the <c>system.run</c> / <c>system.run.prepare</c>
+    /// commands. Per-command exec approvals still apply when this is on;
+    /// flipping it off removes those commands from the declared capability
+    /// entirely. Default <c>true</c> (backward compatible).
+    /// </summary>
+    public bool NodeSystemRunEnabled { get; set; } = true;
     public bool NodeSttEnabled { get; set; } = false;
     /// <summary>STT language: "auto" for Whisper auto-detect, or a BCP-47 tag like "en-US".</summary>
     public string SttLanguage { get; set; } = "auto";
@@ -199,6 +206,7 @@ public class SettingsManager
                     CameraRecordingConsentGiven = loaded.CameraRecordingConsentGiven;
                     NodeLocationEnabled = loaded.NodeLocationEnabled;
                     NodeBrowserProxyEnabled = loaded.NodeBrowserProxyEnabled;
+                    NodeSystemRunEnabled = loaded.NodeSystemRunEnabled;
                     NodeSttEnabled = loaded.NodeSttEnabled;
                     SttLanguage = string.IsNullOrWhiteSpace(loaded.SttLanguage) ? SttLanguage : loaded.SttLanguage;
                     SttModelName = string.IsNullOrWhiteSpace(loaded.SttModelName) ? SttModelName : loaded.SttModelName;
@@ -320,6 +328,7 @@ public class SettingsManager
         CameraRecordingConsentGiven = CameraRecordingConsentGiven,
         NodeLocationEnabled = NodeLocationEnabled,
         NodeBrowserProxyEnabled = NodeBrowserProxyEnabled,
+        NodeSystemRunEnabled = NodeSystemRunEnabled,
         NodeSttEnabled = NodeSttEnabled,
         SttLanguage = SttLanguage,
         SttModelName = SttModelName,

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2992,10 +2992,10 @@ On your gateway host (Mac/Linux), run:
     <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
-    <value>Run system tools</value>
+    <value>System tools</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
-    <value>Lets agents run shell commands on this PC via system.run. Individual commands are still gated by your exec approval policy; turn this off to drop the capability from the node entirely.</value>
+    <value>Lets agents run shell commands and scripts on this PC. Turn this off to block all command execution.</value>
   </data>
   <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
     <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2991,6 +2991,12 @@ On your gateway host (Mac/Linux), run:
   <data name="PermissionsPage_Cap_Stt_Description" xml:space="preserve">
     <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
   </data>
+  <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
+    <value>Run system tools</value>
+  </data>
+  <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
+    <value>Lets agents run shell commands on this PC via system.run. Individual commands are still gated by your exec approval policy; turn this off to drop the capability from the node entirely.</value>
+  </data>
   <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
     <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2942,6 +2942,12 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="PermissionsPage_Cap_Stt_Description" xml:space="preserve">
     <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
   </data>
+  <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
+    <value>Run system tools</value>
+  </data>
+  <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
+    <value>Lets agents run shell commands on this PC via system.run. Individual commands are still gated by your exec approval policy; turn this off to drop the capability from the node entirely.</value>
+  </data>
   <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
     <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2943,10 +2943,10 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
-    <value>Run system tools</value>
+    <value>System tools</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
-    <value>Lets agents run shell commands on this PC via system.run. Individual commands are still gated by your exec approval policy; turn this off to drop the capability from the node entirely.</value>
+    <value>Lets agents run shell commands and scripts on this PC. Turn this off to block all command execution.</value>
   </data>
   <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
     <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2944,10 +2944,10 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
-    <value>Run system tools</value>
+    <value>System tools</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
-    <value>Lets agents run shell commands on this PC via system.run. Individual commands are still gated by your exec approval policy; turn this off to drop the capability from the node entirely.</value>
+    <value>Lets agents run shell commands and scripts on this PC. Turn this off to block all command execution.</value>
   </data>
   <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
     <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2943,6 +2943,12 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="PermissionsPage_Cap_Stt_Description" xml:space="preserve">
     <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
   </data>
+  <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
+    <value>Run system tools</value>
+  </data>
+  <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
+    <value>Lets agents run shell commands on this PC via system.run. Individual commands are still gated by your exec approval policy; turn this off to drop the capability from the node entirely.</value>
+  </data>
   <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
     <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2942,6 +2942,12 @@
   <data name="PermissionsPage_Cap_Stt_Description" xml:space="preserve">
     <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
   </data>
+  <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
+    <value>Run system tools</value>
+  </data>
+  <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
+    <value>Lets agents run shell commands on this PC via system.run. Individual commands are still gated by your exec approval policy; turn this off to drop the capability from the node entirely.</value>
+  </data>
   <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
     <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2943,10 +2943,10 @@
     <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
-    <value>Run system tools</value>
+    <value>System tools</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
-    <value>Lets agents run shell commands on this PC via system.run. Individual commands are still gated by your exec approval policy; turn this off to drop the capability from the node entirely.</value>
+    <value>Lets agents run shell commands and scripts on this PC. Turn this off to block all command execution.</value>
   </data>
   <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
     <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2942,6 +2942,12 @@
   <data name="PermissionsPage_Cap_Stt_Description" xml:space="preserve">
     <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
   </data>
+  <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
+    <value>Run system tools</value>
+  </data>
+  <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
+    <value>Lets agents run shell commands on this PC via system.run. Individual commands are still gated by your exec approval policy; turn this off to drop the capability from the node entirely.</value>
+  </data>
   <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
     <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2943,10 +2943,10 @@
     <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
-    <value>Run system tools</value>
+    <value>System tools</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
-    <value>Lets agents run shell commands on this PC via system.run. Individual commands are still gated by your exec approval policy; turn this off to drop the capability from the node entirely.</value>
+    <value>Lets agents run shell commands and scripts on this PC. Turn this off to block all command execution.</value>
   </data>
   <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
     <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>

--- a/tests/OpenClaw.Connection.Tests/SettingsChangeImpactTests.cs
+++ b/tests/OpenClaw.Connection.Tests/SettingsChangeImpactTests.cs
@@ -20,6 +20,7 @@ public class SettingsChangeImpactTests
         bool nodeBrowserProxyEnabled = false,
         bool nodeSttEnabled = false,
         bool nodeTtsEnabled = false,
+        bool nodeSystemRunEnabled = true,
         string? fullSettingsJson = null) => new(
         gatewayUrl,
         useSshTunnel,
@@ -36,6 +37,7 @@ public class SettingsChangeImpactTests
         nodeBrowserProxyEnabled,
         nodeSttEnabled,
         nodeTtsEnabled,
+        nodeSystemRunEnabled,
         fullSettingsJson);
 
     [Fact]
@@ -92,6 +94,18 @@ public class SettingsChangeImpactTests
     {
         var prev = MakeSnapshot(gatewayUrl: "wss://test", nodeCanvasEnabled: true);
         var next = MakeSnapshot(gatewayUrl: "wss://test", nodeCanvasEnabled: false);
+        Assert.Equal(SettingsChangeImpact.CapabilityReload,
+            SettingsChangeClassifier.Classify(prev, next));
+    }
+
+    [Fact]
+    public void SystemRunCapabilityChanged_ReturnsCapabilityReload()
+    {
+        // Flipping the "Run system tools" toggle must trigger a capability
+        // reload — without it the App.OnSettingsSaved branch falls through to
+        // UiOnly and the connect-handshake commands list stays stale.
+        var prev = MakeSnapshot(gatewayUrl: "wss://test", nodeSystemRunEnabled: true);
+        var next = MakeSnapshot(gatewayUrl: "wss://test", nodeSystemRunEnabled: false);
         Assert.Equal(SettingsChangeImpact.CapabilityReload,
             SettingsChangeClassifier.Classify(prev, next));
     }

--- a/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
@@ -756,6 +756,83 @@ public class SystemCapabilityTests
             });
         }
     }
+
+    [Fact]
+    public void Commands_IncludeRunByDefault()
+    {
+        // Backward-compatibility: the no-arg path used by every existing test
+        // and call-site must keep advertising system.run + system.run.prepare.
+        var cap = new SystemCapability(NullLogger.Instance);
+        Assert.Contains("system.run", cap.Commands);
+        Assert.Contains("system.run.prepare", cap.Commands);
+        Assert.Contains("system.notify", cap.Commands);
+        Assert.Contains("system.which", cap.Commands);
+        Assert.Contains("system.execApprovals.get", cap.Commands);
+        Assert.Contains("system.execApprovals.set", cap.Commands);
+    }
+
+    [Fact]
+    public void Commands_OmitRunWhenIncludeRunCommandsFalse()
+    {
+        // "Run system tools" toggle off: the run commands disappear from the
+        // declared command list (the handshake's connect message + MCP
+        // tools/list) while the rest of the system category stays.
+        var cap = new SystemCapability(NullLogger.Instance, includeRunCommands: false);
+        Assert.DoesNotContain("system.run", cap.Commands);
+        Assert.DoesNotContain("system.run.prepare", cap.Commands);
+        Assert.Contains("system.notify", cap.Commands);
+        Assert.Contains("system.which", cap.Commands);
+        Assert.Contains("system.execApprovals.get", cap.Commands);
+        Assert.Contains("system.execApprovals.set", cap.Commands);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SystemRun_ReturnsDisabledErrorWhenIncludeRunCommandsFalse()
+    {
+        // Even if a stale gateway allowlist still routes system.run to us
+        // (commands are snapshotted at pairing-approval time), the capability
+        // must refuse before any V2/legacy dispatch runs.
+        var cap = new SystemCapability(NullLogger.Instance, includeRunCommands: false);
+        var resp = await cap.ExecuteAsync(new NodeInvokeRequest
+        {
+            Id = "rn1",
+            Command = "system.run",
+            Args = Parse("""{"cmd":"echo hello"}""")
+        });
+        Assert.False(resp.Ok);
+        Assert.Contains("Run system tools", resp.Error ?? "", StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SystemRunPrepare_ReturnsDisabledErrorWhenIncludeRunCommandsFalse()
+    {
+        var cap = new SystemCapability(NullLogger.Instance, includeRunCommands: false);
+        var resp = await cap.ExecuteAsync(new NodeInvokeRequest
+        {
+            Id = "rp1",
+            Command = "system.run.prepare",
+            Args = Parse("""{"cmd":"echo hello"}""")
+        });
+        Assert.False(resp.Ok);
+        Assert.Contains("Run system tools", resp.Error ?? "", StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_OtherSystemCommands_StillWorkWhenIncludeRunCommandsFalse()
+    {
+        // system.notify must keep working — the toggle only gates the run
+        // commands. Notifications and the exec-approval reader/writer stay
+        // available so the user can still inspect their policy from the
+        // operator console.
+        var cap = new SystemCapability(NullLogger.Instance, includeRunCommands: false);
+        var resp = await cap.ExecuteAsync(new NodeInvokeRequest
+        {
+            Id = "n1",
+            Command = "system.notify",
+            Args = Parse("""{"title":"Hello","body":"World","sound":false}""")
+        });
+        Assert.True(resp.Ok);
+    }
 }
 
 public class BrowserProxyCapabilityTests

--- a/tests/OpenClaw.Shared.Tests/McpToolBridgeTests.cs
+++ b/tests/OpenClaw.Shared.Tests/McpToolBridgeTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenClaw.Shared;
+using OpenClaw.Shared.Capabilities;
 using OpenClaw.Shared.Mcp;
 using Xunit;
 
@@ -462,6 +463,58 @@ public class McpToolBridgeTests
         Assert.DoesNotContain("stt.transcribe", toolNames);
         Assert.DoesNotContain("stt.listen", toolNames);
         Assert.DoesNotContain("stt.status", toolNames);
+    }
+
+    [Fact]
+    public async Task ToolsList_SystemRun_Present_WhenSystemCapabilityIncludesRunCommands()
+    {
+        // Default SystemCapability (includeRunCommands: true) — the
+        // "Run system tools" toggle is on. tools/list advertises both
+        // system.run and system.run.prepare.
+        var caps = new List<INodeCapability>
+        {
+            new SystemCapability(OpenClaw.Shared.NullLogger.Instance),
+        };
+        var bridge = CreateBridge(caps);
+        var resp = await bridge.HandleRequestAsync(@"{""jsonrpc"":""2.0"",""id"":1,""method"":""tools/list""}");
+
+        using var doc = JsonDocument.Parse(resp!);
+        var toolNames = new HashSet<string>();
+        foreach (var t in doc.RootElement.GetProperty("result").GetProperty("tools").EnumerateArray())
+            toolNames.Add(t.GetProperty("name").GetString()!);
+
+        Assert.Contains("system.run", toolNames);
+        Assert.Contains("system.run.prepare", toolNames);
+        // The rest of the system category is always present.
+        Assert.Contains("system.notify", toolNames);
+        Assert.Contains("system.which", toolNames);
+    }
+
+    [Fact]
+    public async Task ToolsList_SystemRun_Absent_WhenSystemCapabilityExcludesRunCommands()
+    {
+        // "Run system tools" toggle off: NodeService constructs
+        // SystemCapability(includeRunCommands: false). The MCP tools/list
+        // must drop the two run commands but keep the rest of the system
+        // category (notify/which/execApprovals).
+        var caps = new List<INodeCapability>
+        {
+            new SystemCapability(OpenClaw.Shared.NullLogger.Instance, includeRunCommands: false),
+        };
+        var bridge = CreateBridge(caps);
+        var resp = await bridge.HandleRequestAsync(@"{""jsonrpc"":""2.0"",""id"":1,""method"":""tools/list""}");
+
+        using var doc = JsonDocument.Parse(resp!);
+        var toolNames = new HashSet<string>();
+        foreach (var t in doc.RootElement.GetProperty("result").GetProperty("tools").EnumerateArray())
+            toolNames.Add(t.GetProperty("name").GetString()!);
+
+        Assert.DoesNotContain("system.run", toolNames);
+        Assert.DoesNotContain("system.run.prepare", toolNames);
+        Assert.Contains("system.notify", toolNames);
+        Assert.Contains("system.which", toolNames);
+        Assert.Contains("system.execApprovals.get", toolNames);
+        Assert.Contains("system.execApprovals.set", toolNames);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
@@ -77,6 +77,8 @@ public class LocalizationValidationTests
         "PermissionsPage_Cap_Tts_Description",
         "PermissionsPage_Cap_Stt_Label",
         "PermissionsPage_Cap_Stt_Description",
+        "PermissionsPage_Cap_SystemRun_Label",
+        "PermissionsPage_Cap_SystemRun_Description",
         "PermissionsPage_SttHint_Ready",
         "PermissionsPage_SttHint_Downloading",
         "PermissionsPage_SttHint_FailedFormat",

--- a/tests/OpenClaw.Tray.Tests/NodeCapabilityGatingTests.cs
+++ b/tests/OpenClaw.Tray.Tests/NodeCapabilityGatingTests.cs
@@ -43,6 +43,7 @@ public sealed class NodeCapabilityGatingTests : IDisposable
         Assert.True(NodeCapabilityGating.ShouldRegisterCamera(null));
         Assert.True(NodeCapabilityGating.ShouldRegisterLocation(null));
         Assert.True(NodeCapabilityGating.ShouldRegisterBrowserProxy(null));
+        Assert.True(NodeCapabilityGating.ShouldRegisterSystemRun(null));
     }
 
     [Fact]
@@ -72,6 +73,18 @@ public sealed class NodeCapabilityGatingTests : IDisposable
         Assert.True(NodeCapabilityGating.ShouldRegisterCamera(s));
         Assert.True(NodeCapabilityGating.ShouldRegisterLocation(s));
         Assert.True(NodeCapabilityGating.ShouldRegisterBrowserProxy(s));
+        Assert.True(NodeCapabilityGating.ShouldRegisterSystemRun(s));
+    }
+
+    [Fact]
+    public void SystemRun_OnlyDisabledWhenExplicitlySetToFalse()
+    {
+        var s = NewSettings();
+        Assert.True(NodeCapabilityGating.ShouldRegisterSystemRun(s));
+        s.NodeSystemRunEnabled = false;
+        Assert.False(NodeCapabilityGating.ShouldRegisterSystemRun(s));
+        s.NodeSystemRunEnabled = true;
+        Assert.True(NodeCapabilityGating.ShouldRegisterSystemRun(s));
     }
 
     [Fact]
@@ -122,11 +135,13 @@ public sealed class NodeCapabilityGatingTests : IDisposable
         s.NodeCameraEnabled = false;
         s.NodeLocationEnabled = false;
         s.NodeBrowserProxyEnabled = false;
+        s.NodeSystemRunEnabled = false;
 
         Assert.False(NodeCapabilityGating.ShouldRegisterCanvas(s));
         Assert.False(NodeCapabilityGating.ShouldRegisterScreen(s));
         Assert.False(NodeCapabilityGating.ShouldRegisterCamera(s));
         Assert.False(NodeCapabilityGating.ShouldRegisterLocation(s));
         Assert.False(NodeCapabilityGating.ShouldRegisterBrowserProxy(s));
+        Assert.False(NodeCapabilityGating.ShouldRegisterSystemRun(s));
     }
 }


### PR DESCRIPTION
Adds a Permissions page toggle (default **on**) to gate the `system.run` and `system.run.prepare` commands.

When **off**:
- Both commands are dropped from the connect handshake and from MCP `tools/list`.
- A defensive kill-switch in `SystemCapability.ExecuteAsync` rejects them even if a stale gateway allowlist still routes them here.
- The rest of the `system` category (`system.notify`, `system.which`, `system.execApprovals.get/set`) stays registered.

### Behavioral fix bundled with the toggle
`NodeService.AttachClient` now always rebuilds capabilities from current settings instead of re-registering cached instances on reconnect. The reconnect path used by `App.OnSettingsSaved` calls `ReconnectAsync` (not `DisconnectAsync`), which never cleared the cached list, so toggle changes were silently swallowed until next app restart.

### Scope
Toggle only. Capability-display unifier, gateway divergence diagnostics, and instance-merger work from the original `feat/system-run-toggle` branch are deferred to follow-up PRs.

### Validation
- `./build.ps1` — PASS
- `OpenClaw.Shared.Tests` — 1810 passed / 28 skipped
- `OpenClaw.Tray.Tests` — 1150 passed
