### PR TITLE
polish(tray): tighten 'System tools' strings + add missing tray toggle

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
@@ -37,6 +37,7 @@ public static class FluentIconCatalog
     public const string Voice = "\uE767";          // Volume (speaker, for TTS)
     public const string Speech = "\uF12E";         // Dictate (speech-to-text)
     public const string System = "\uE839";         // PC1 — "this PC as a node" (per CDR-0001 — was TVMonitor \uE7F4)
+    public const string Terminal = "\uE756";       // CommandPrompt — system.run shell-command capability
     public const string Operator = "\uE77B";       // ContactInfo — operator role (a human controlling agents)
 
     // ── Actions ────────────────────────────────────────────────────

--- a/src/OpenClaw.Tray.WinUI/Services/TrayMenuStateBuilder.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/TrayMenuStateBuilder.cs
@@ -1290,6 +1290,9 @@ internal sealed class TrayMenuStateBuilder
         AddPermToggle(items, "Windows node", FluentIconCatalog.System,
             "Run OpenClaw as a local node on this PC",
             () => settings.EnableNodeMode, v => settings.EnableNodeMode = v);
+        AddPermToggle(items, "System tools", FluentIconCatalog.Terminal,
+            "Let agents run shell commands and scripts on this PC",
+            () => settings.NodeSystemRunEnabled, v => settings.NodeSystemRunEnabled = v);
         AddPermToggle(items, "Browser control", FluentIconCatalog.Browser,
             "Let agents drive web browsers via proxy",
             () => settings.NodeBrowserProxyEnabled, v => settings.NodeBrowserProxyEnabled = v);

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2992,10 +2992,10 @@ On your gateway host (Mac/Linux), run:
     <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
-    <value>Run system tools</value>
+    <value>System tools</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
-    <value>Lets agents run shell commands on this PC via system.run. Individual commands are still gated by your exec approval policy; turn this off to drop the capability from the node entirely.</value>
+    <value>Lets agents run shell commands and scripts on this PC. Turn this off to block all command execution.</value>
   </data>
   <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
     <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2943,10 +2943,10 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
-    <value>Run system tools</value>
+    <value>System tools</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
-    <value>Lets agents run shell commands on this PC via system.run. Individual commands are still gated by your exec approval policy; turn this off to drop the capability from the node entirely.</value>
+    <value>Lets agents run shell commands and scripts on this PC. Turn this off to block all command execution.</value>
   </data>
   <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
     <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2944,10 +2944,10 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
-    <value>Run system tools</value>
+    <value>System tools</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
-    <value>Lets agents run shell commands on this PC via system.run. Individual commands are still gated by your exec approval policy; turn this off to drop the capability from the node entirely.</value>
+    <value>Lets agents run shell commands and scripts on this PC. Turn this off to block all command execution.</value>
   </data>
   <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
     <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2943,10 +2943,10 @@
     <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
-    <value>Run system tools</value>
+    <value>System tools</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
-    <value>Lets agents run shell commands on this PC via system.run. Individual commands are still gated by your exec approval policy; turn this off to drop the capability from the node entirely.</value>
+    <value>Lets agents run shell commands and scripts on this PC. Turn this off to block all command execution.</value>
   </data>
   <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
     <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2943,10 +2943,10 @@
     <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
-    <value>Run system tools</value>
+    <value>System tools</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
-    <value>Lets agents run shell commands on this PC via system.run. Individual commands are still gated by your exec approval policy; turn this off to drop the capability from the node entirely.</value>
+    <value>Lets agents run shell commands and scripts on this PC. Turn this off to block all command execution.</value>
   </data>
   <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
     <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>

--- a/tests/OpenClaw.Tray.Tests/FluentIconCatalogTests.cs
+++ b/tests/OpenClaw.Tray.Tests/FluentIconCatalogTests.cs
@@ -18,7 +18,7 @@ public sealed class FluentIconCatalogTests
     {
         "StatusOk", "StatusWarn", "StatusErr",
         "Sessions", "Approvals", "Devices", "Hostname", "Permissions",
-        "Browser", "Camera", "Canvas", "Screen", "Location", "Voice", "Speech", "System", "Operator",
+        "Browser", "Camera", "Canvas", "Screen", "Location", "Voice", "Speech", "System", "Terminal", "Operator",
         "Dashboard", "OpenInBrowser", "Chat", "CanvasAct", "VoiceAct", "Settings", "QuickSend",
         "Setup", "About", "Exit",
         "Add", "Back", "Sync", "Lock", "Plug", "MoreOverflow",


### PR DESCRIPTION
Two follow-ups on top of `6711591 Add Run system tools permission toggle` (already on master):

### 1. Polish the toggle strings (`7bfff2e`)
The upstream commit shipped a verbose, jargon-heavy description that broke the existing Permissions page convention. This PR brings it back in line with the rest of the toggles (Browser/Camera/Canvas/Screen/...).

| Field | Before | After |
|---|---|---|
| Label | "Run system tools" | "System tools" |
| Description | "Lets agents run shell commands on this PC via system.run. Individual commands are still gated by your exec approval policy; turn this off to drop the capability from the node entirely." (33 words, mentions `system.run` and "exec approval policy" jargon) | "Lets agents run shell commands and scripts on this PC. Turn this off to block all command execution." (17 words) |

Applied across `en-us` / `fr-fr` / `nl-nl` / `zh-cn` / `zh-tw` (matching the existing pattern where non-English files carry English placeholders).

### 2. Add the missing tray right-click toggle (`f6741ed`)
The tray menu has toggles for every other capability (Windows node, Browser control, Camera, Canvas, Screen, Location, TTS, STT) but the upstream commit forgot to add one for System tools. Users had to open Settings → Permissions to flip it.

Adds:
- `FluentIconCatalog.Terminal` (`\uE756` CommandPrompt) — distinct from the existing `System` glyph which represents "this PC as a node"
- `AddPermToggle` for `NodeSystemRunEnabled` in `TrayMenuStateBuilder`, placed right after "Windows node" to match the Permissions page ordering
- `FluentIconCatalogTests` entry for the new constant

### Validation
- `./build.ps1` — PASS
- `OpenClaw.Shared.Tests` — 1811 passed / 28 skipped
- `OpenClaw.Tray.Tests` — 1150 passed