### PR TITLE
refactor: remove dead recording handler and extract two static helpers from App.xaml.cs

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -279,7 +279,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
         "OpenClawTray");
     private static readonly string CrashLogPath = Path.Combine(DataPath, "crash.log");
-    private static readonly string RunMarkerPath = Path.Combine(DataPath, "run.marker");
+    private static readonly AppRunMarker s_runMarker = new(Path.Combine(DataPath, "run.marker"));
 
     public App()
     {
@@ -297,8 +297,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
         InitializeComponent();
         
-        CheckPreviousRun();
-        MarkRunStarted();
+        s_runMarker.Check();
+        s_runMarker.MarkStarted();
         
         // Hook up crash handlers
         this.UnhandledException += OnUnhandledException;
@@ -326,7 +326,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     
     private void OnProcessExit(object? sender, EventArgs e)
     {
-        MarkRunEnded();
+        s_runMarker.MarkEnded();
         try
         {
             Logger.Info($"Process exiting (ExitCode={Environment.ExitCode})");
@@ -511,42 +511,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         return value;
     }
     
-    private static void CheckPreviousRun()
-    {
-        try
-        {
-            if (File.Exists(RunMarkerPath))
-            {
-                var startedAt = File.ReadAllText(RunMarkerPath);
-                Logger.Error($"Previous session did not exit cleanly (started {startedAt})");
-                File.Delete(RunMarkerPath);
-            }
-        }
-        catch { }
-    }
-    
-    private static void MarkRunStarted()
-    {
-        try
-        {
-            var dir = Path.GetDirectoryName(RunMarkerPath);
-            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
-                Directory.CreateDirectory(dir);
-            File.WriteAllText(RunMarkerPath, DateTime.Now.ToString("O"));
-        }
-        catch { }
-    }
-    
-    private static void MarkRunEnded()
-    {
-        try
-        {
-            if (File.Exists(RunMarkerPath))
-                File.Delete(RunMarkerPath);
-        }
-        catch { }
-    }
-
     private void OnUiThread(Microsoft.UI.Dispatching.DispatcherQueueHandler action) => _dispatcherQueue?.TryEnqueue(action);
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -2129,30 +2129,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             catch { /* ignore */ }
         }
     }
-    
-    private void OnRecordingStateChanged(object? sender, RecordingStateEventArgs args)
-    {
-        var source = args.Type == RecordingType.Screen ? "Screen" : "Camera";
-        if (args.IsActive)
-        {
-            var title = args.Type == RecordingType.Screen
-                ? LocalizationHelper.GetString("Activity_ScreenRecordingStarted")
-                : LocalizationHelper.GetString("Activity_CameraRecordingStarted");
-            var duration = args.DurationMs > 0 ? $" ({args.DurationMs / 1000.0:0.#}s)" : "";
-            AddRecentActivity($"{title}{duration}", category: "node",
-                icon: "🔴",
-                details: string.Format(LocalizationHelper.GetString("Activity_RecordingRequestedByAgent"), source));
-        }
-        else
-        {
-            var title = args.Type == RecordingType.Screen
-                ? LocalizationHelper.GetString("Activity_ScreenRecordingComplete")
-                : LocalizationHelper.GetString("Activity_CameraRecordingComplete");
-            AddRecentActivity(title, category: "node",
-                icon: "✅",
-                details: string.Format(LocalizationHelper.GetString("Activity_RecordingSentToAgent"), source));
-        }
-    }
 
     private void OnPairingStatusChanged(object? sender, OpenClaw.Shared.PairingStatusEventArgs args)
     {

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -22,7 +22,6 @@ using System.Drawing;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -361,156 +360,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         catch { /* Ignore logging failures */ }
     }
 
-    // -----------------------------------------------------------------------
-    // CLI uninstall path
-    // Invoked when --uninstall is present in argv. Runs headlessly without
-    // creating the tray UI. Attaches to the parent console so stdout/stderr
-    // are visible when invoked from PowerShell or cmd.
-    // -----------------------------------------------------------------------
-
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool AttachConsole(int dwProcessId);
-
-    private const int AttachParentProcess = -1;
-
-    private static async Task RunCliUninstallAsync(string[] args)
-    {
-        // Attach to parent console so output is visible when invoked from
-        // PowerShell or cmd.  Fails silently if no parent console exists.
-        AttachConsole(AttachParentProcess);
-
-        bool dryRun            = args.Contains("--dry-run",            StringComparer.OrdinalIgnoreCase);
-        bool confirmDestructive = args.Contains("--confirm-destructive", StringComparer.OrdinalIgnoreCase);
-
-        // Locate --json-output <path> argument
-        string? jsonOutputPath = null;
-        for (int i = 0; i < args.Length - 1; i++)
-        {
-            if (string.Equals(args[i], "--json-output", StringComparison.OrdinalIgnoreCase))
-            {
-                jsonOutputPath = args[i + 1];
-                break;
-            }
-        }
-
-        if (!confirmDestructive && !dryRun)
-        {
-            Console.Error.WriteLine(
-                "ERROR: --uninstall requires --confirm-destructive (or --dry-run).");
-            Environment.Exit(2);
-            return;
-        }
-
-        var settings = new SettingsManager();
-        var engine   = LocalGatewayUninstall.Build(settings, logger: new AppLogger());
-
-        LocalGatewayUninstallResult result;
-        try
-        {
-            result = await engine.RunAsync(new LocalGatewayUninstallOptions
-            {
-                DryRun             = dryRun,
-                ConfirmDestructive = confirmDestructive
-            });
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine($"ERROR: Uninstall engine threw: {ex.Message}");
-            Environment.Exit(1);
-            return;
-        }
-
-        // Human-readable summary (tokens already redacted inside engine steps)
-        Console.WriteLine("OpenClaw Local Gateway Uninstall");
-        Console.WriteLine($"DryRun:   {dryRun}");
-        Console.WriteLine($"Success:  {result.Success}");
-        Console.WriteLine($"Steps:    {result.Steps.Count} ({result.SkippedSteps.Count} skipped)");
-        Console.WriteLine($"Errors:   {result.Errors.Count}");
-        foreach (var e in result.Errors)
-            Console.Error.WriteLine($"  ERROR: {CliRedact(e)}");
-        Console.WriteLine("Postconditions:");
-        Console.WriteLine($"  WslDistroAbsent:    {result.Postconditions.WslDistroAbsent}");
-        Console.WriteLine($"  AutostartCleared:   {result.Postconditions.AutostartCleared}");
-        Console.WriteLine($"  SetupStateAbsent:   {result.Postconditions.SetupStateAbsent}");
-        Console.WriteLine($"  DeviceTokenCleared: {result.Postconditions.DeviceTokenCleared}");
-        Console.WriteLine($"  McpTokenPreserved:  {result.Postconditions.McpTokenPreserved}");
-        Console.WriteLine($"  KeepalivesAbsent:   {result.Postconditions.KeepalivesAbsent}");
-        Console.WriteLine($"  VhdDirAbsent:       {result.Postconditions.VhdDirAbsent}");
-        Console.WriteLine($"  LocalGatewayRecordsAbsent:      {result.Postconditions.LocalGatewayRecordsAbsent}");
-        Console.WriteLine($"  LocalGatewayIdentityDirsAbsent: {result.Postconditions.LocalGatewayIdentityDirsAbsent}");
-
-        // JSON output — redaction applied to step details and error strings
-        if (jsonOutputPath != null)
-        {
-            try
-            {
-                var dir = Path.GetDirectoryName(jsonOutputPath);
-                if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
-                    Directory.CreateDirectory(dir);
-
-                var payload = new
-                {
-                    success = result.Success,
-                    dry_run = dryRun,
-                    steps   = result.Steps.Select(s => new
-                    {
-                        name   = s.Name,
-                        status = s.Status.ToString(),
-                        detail = CliRedact(s.Detail)
-                    }),
-                    errors       = result.Errors.Select(CliRedact),
-                    skipped_steps = result.SkippedSteps,
-                    postconditions = new
-                    {
-                        wsl_distro_absent     = result.Postconditions.WslDistroAbsent,
-                        autostart_cleared     = result.Postconditions.AutostartCleared,
-                        setup_state_absent    = result.Postconditions.SetupStateAbsent,
-                        device_token_cleared  = result.Postconditions.DeviceTokenCleared,
-                        mcp_token_preserved   = result.Postconditions.McpTokenPreserved,
-                        keepalives_absent     = result.Postconditions.KeepalivesAbsent,
-                        vhd_dir_absent        = result.Postconditions.VhdDirAbsent,
-                        local_gateway_records_absent = result.Postconditions.LocalGatewayRecordsAbsent,
-                        local_gateway_identity_dirs_absent = result.Postconditions.LocalGatewayIdentityDirsAbsent
-                    }
-                };
-
-                File.WriteAllText(jsonOutputPath, JsonSerializer.Serialize(
-                    payload, new JsonSerializerOptions { WriteIndented = true }));
-
-                Console.WriteLine($"JSON result: {jsonOutputPath}");
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(
-                    $"WARNING: Failed to write JSON output to '{jsonOutputPath}': {ex.Message}");
-            }
-        }
-
-        Environment.Exit(result.Success ? 0 : 1);
-    }
-
-    /// <summary>
-    /// Redacts token/key material from a string before writing it to CLI
-    /// stdout or a JSON output file.  Mirrors the PowerShell Invoke-Redact
-    /// pattern in validate-wsl-gateway-uninstall.ps1.
-    /// </summary>
-    private static string? CliRedact(string? value)
-    {
-        if (string.IsNullOrEmpty(value)) return value;
-        // Redact JSON field values for known secret fields.
-        value = System.Text.RegularExpressions.Regex.Replace(
-            value,
-            @"(""(?i:deviceToken|device_token|token|bootstrapToken|bootstrap_token|PrivateKeyBase64|PublicKeyBase64)""\s*:\s*"")[^""]+("")",
-            "$1<redacted>$2");
-        // Redact bare key=value / key: value patterns.
-        value = System.Text.RegularExpressions.Regex.Replace(
-            value,
-            @"(?i)((?:device|bootstrap|gateway|auth|mcp)[_-]?token\s*[:=]\s*)[^\s,""'}{]+",
-            "$1<redacted>");
-        return value;
-    }
-    
     private void OnUiThread(Microsoft.UI.Dispatching.DispatcherQueueHandler action) => _dispatcherQueue?.TryEnqueue(action);
 
     /// <summary>
@@ -546,7 +395,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         // -----------------------------------------------------------------------
         if (_startupArgs.Contains("--uninstall", StringComparer.OrdinalIgnoreCase))
         {
-            await RunCliUninstallAsync(_startupArgs);
+            await CliUninstallHandler.RunAsync(_startupArgs);
             return; // Environment.Exit called inside; defensive return
         }
 

--- a/src/OpenClaw.Tray.WinUI/CliUninstallHandler.cs
+++ b/src/OpenClaw.Tray.WinUI/CliUninstallHandler.cs
@@ -1,0 +1,146 @@
+using OpenClawTray.Services;
+using OpenClawTray.Services.LocalGatewaySetup;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace OpenClawTray;
+
+/// <summary>
+/// Headless CLI handler for the --uninstall flag. Attaches to the parent console
+/// and drives the local gateway uninstall engine without creating any tray UI.
+/// </summary>
+internal static class CliUninstallHandler
+{
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool AttachConsole(int dwProcessId);
+
+    private const int AttachParentProcess = -1;
+
+    public static async Task RunAsync(string[] args)
+    {
+        AttachConsole(AttachParentProcess);
+
+        bool dryRun             = args.Contains("--dry-run",             StringComparer.OrdinalIgnoreCase);
+        bool confirmDestructive = args.Contains("--confirm-destructive", StringComparer.OrdinalIgnoreCase);
+
+        string? jsonOutputPath = null;
+        for (int i = 0; i < args.Length - 1; i++)
+        {
+            if (string.Equals(args[i], "--json-output", StringComparison.OrdinalIgnoreCase))
+            {
+                jsonOutputPath = args[i + 1];
+                break;
+            }
+        }
+
+        if (!confirmDestructive && !dryRun)
+        {
+            Console.Error.WriteLine("ERROR: --uninstall requires --confirm-destructive (or --dry-run).");
+            Environment.Exit(2);
+            return;
+        }
+
+        var settings = new SettingsManager();
+        var engine   = LocalGatewayUninstall.Build(settings, logger: new AppLogger());
+
+        LocalGatewayUninstallResult result;
+        try
+        {
+            result = await engine.RunAsync(new LocalGatewayUninstallOptions
+            {
+                DryRun             = dryRun,
+                ConfirmDestructive = confirmDestructive
+            });
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"ERROR: Uninstall engine threw: {ex.Message}");
+            Environment.Exit(1);
+            return;
+        }
+
+        Console.WriteLine("OpenClaw Local Gateway Uninstall");
+        Console.WriteLine($"DryRun:   {dryRun}");
+        Console.WriteLine($"Success:  {result.Success}");
+        Console.WriteLine($"Steps:    {result.Steps.Count} ({result.SkippedSteps.Count} skipped)");
+        Console.WriteLine($"Errors:   {result.Errors.Count}");
+        foreach (var e in result.Errors)
+            Console.Error.WriteLine($"  ERROR: {Redact(e)}");
+        Console.WriteLine("Postconditions:");
+        Console.WriteLine($"  WslDistroAbsent:    {result.Postconditions.WslDistroAbsent}");
+        Console.WriteLine($"  AutostartCleared:   {result.Postconditions.AutostartCleared}");
+        Console.WriteLine($"  SetupStateAbsent:   {result.Postconditions.SetupStateAbsent}");
+        Console.WriteLine($"  DeviceTokenCleared: {result.Postconditions.DeviceTokenCleared}");
+        Console.WriteLine($"  McpTokenPreserved:  {result.Postconditions.McpTokenPreserved}");
+        Console.WriteLine($"  KeepalivesAbsent:   {result.Postconditions.KeepalivesAbsent}");
+        Console.WriteLine($"  VhdDirAbsent:       {result.Postconditions.VhdDirAbsent}");
+        Console.WriteLine($"  LocalGatewayRecordsAbsent:      {result.Postconditions.LocalGatewayRecordsAbsent}");
+        Console.WriteLine($"  LocalGatewayIdentityDirsAbsent: {result.Postconditions.LocalGatewayIdentityDirsAbsent}");
+
+        if (jsonOutputPath != null)
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(jsonOutputPath);
+                if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+
+                var payload = new
+                {
+                    success      = result.Success,
+                    dry_run      = dryRun,
+                    steps        = result.Steps.Select(s => new
+                    {
+                        name   = s.Name,
+                        status = s.Status.ToString(),
+                        detail = Redact(s.Detail)
+                    }),
+                    errors        = result.Errors.Select(Redact),
+                    skipped_steps = result.SkippedSteps,
+                    postconditions = new
+                    {
+                        wsl_distro_absent                  = result.Postconditions.WslDistroAbsent,
+                        autostart_cleared                  = result.Postconditions.AutostartCleared,
+                        setup_state_absent                 = result.Postconditions.SetupStateAbsent,
+                        device_token_cleared               = result.Postconditions.DeviceTokenCleared,
+                        mcp_token_preserved                = result.Postconditions.McpTokenPreserved,
+                        keepalives_absent                  = result.Postconditions.KeepalivesAbsent,
+                        vhd_dir_absent                     = result.Postconditions.VhdDirAbsent,
+                        local_gateway_records_absent       = result.Postconditions.LocalGatewayRecordsAbsent,
+                        local_gateway_identity_dirs_absent = result.Postconditions.LocalGatewayIdentityDirsAbsent
+                    }
+                };
+
+                File.WriteAllText(jsonOutputPath,
+                    JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+
+                Console.WriteLine($"JSON result: {jsonOutputPath}");
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"WARNING: Failed to write JSON output to '{jsonOutputPath}': {ex.Message}");
+            }
+        }
+
+        Environment.Exit(result.Success ? 0 : 1);
+    }
+
+    /// <summary>
+    /// Redacts token/key material from a string before writing it to CLI stdout or a JSON output file.
+    /// Mirrors the PowerShell Invoke-Redact pattern in validate-wsl-gateway-uninstall.ps1.
+    /// </summary>
+    internal static string? Redact(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return value;
+        value = System.Text.RegularExpressions.Regex.Replace(
+            value,
+            @"(""(?i:deviceToken|device_token|token|bootstrapToken|bootstrap_token|PrivateKeyBase64|PublicKeyBase64)""\s*:\s*"")[^""]+("")",
+            "$1<redacted>$2");
+        value = System.Text.RegularExpressions.Regex.Replace(
+            value,
+            @"(?i)((?:device|bootstrap|gateway|auth|mcp)[_-]?token\s*[:=]\s*)[^\s,""'}{]+",
+            "$1<redacted>");
+        return value;
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/AppRunMarker.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AppRunMarker.cs
@@ -1,0 +1,47 @@
+namespace OpenClawTray.Services;
+
+/// <summary>
+/// Writes and clears a run marker file so the next launch can detect an unclean exit.
+/// </summary>
+internal sealed class AppRunMarker
+{
+    private readonly string _path;
+
+    public AppRunMarker(string path) => _path = path;
+
+    public void Check()
+    {
+        try
+        {
+            if (File.Exists(_path))
+            {
+                var startedAt = File.ReadAllText(_path);
+                Logger.Error($"Previous session did not exit cleanly (started {startedAt})");
+                File.Delete(_path);
+            }
+        }
+        catch { }
+    }
+
+    public void MarkStarted()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_path);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+            File.WriteAllText(_path, DateTime.Now.ToString("O"));
+        }
+        catch { }
+    }
+
+    public void MarkEnded()
+    {
+        try
+        {
+            if (File.Exists(_path))
+                File.Delete(_path);
+        }
+        catch { }
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -816,25 +816,6 @@ Use one of these options:
   <data name="CameraRecordingToggle.Header" xml:space="preserve">
     <value>Allow camera recording</value>
   </data>
-  <!-- ==================== Activity Stream: Recording ==================== -->
-  <data name="Activity_ScreenRecordingStarted" xml:space="preserve">
-    <value>Screen recording started</value>
-  </data>
-  <data name="Activity_ScreenRecordingComplete" xml:space="preserve">
-    <value>Screen recording complete</value>
-  </data>
-  <data name="Activity_CameraRecordingStarted" xml:space="preserve">
-    <value>Camera recording started</value>
-  </data>
-  <data name="Activity_CameraRecordingComplete" xml:space="preserve">
-    <value>Camera recording complete</value>
-  </data>
-  <data name="Activity_RecordingRequestedByAgent" xml:space="preserve">
-    <value>{0} recording requested by agent</value>
-  </data>
-  <data name="Activity_RecordingSentToAgent" xml:space="preserve">
-    <value>{0} recording sent to agent</value>
-  </data>
   <!-- ==================== Toast: Activity Stream Tip ==================== -->
   <data name="Toast_ActivityStreamTip" xml:space="preserve">
     <value>⚡ New: Activity Stream</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -772,25 +772,6 @@ Utilisez l'une de ces options :
   <data name="CameraRecordingToggle.Header" xml:space="preserve">
     <value>Autoriser l'enregistrement caméra</value>
   </data>
-  <!-- ==================== Activity Stream: Recording ==================== -->
-  <data name="Activity_ScreenRecordingStarted" xml:space="preserve">
-    <value>Enregistrement d'écran démarré</value>
-  </data>
-  <data name="Activity_ScreenRecordingComplete" xml:space="preserve">
-    <value>Enregistrement d'écran terminé</value>
-  </data>
-  <data name="Activity_CameraRecordingStarted" xml:space="preserve">
-    <value>Enregistrement caméra démarré</value>
-  </data>
-  <data name="Activity_CameraRecordingComplete" xml:space="preserve">
-    <value>Enregistrement caméra terminé</value>
-  </data>
-  <data name="Activity_RecordingRequestedByAgent" xml:space="preserve">
-    <value>Enregistrement {0} demandé par l'agent</value>
-  </data>
-  <data name="Activity_RecordingSentToAgent" xml:space="preserve">
-    <value>Enregistrement {0} envoyé à l'agent</value>
-  </data>
   <!-- ==================== Toast: Activity Stream Tip ==================== -->
   <data name="Toast_ActivityStreamTip" xml:space="preserve">
     <value>⚡ Nouveau: Fil d'activité</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -773,25 +773,6 @@ Gebruik een van deze opties:
   <data name="CameraRecordingToggle.Header" xml:space="preserve">
     <value>Camera-opname toestaan</value>
   </data>
-  <!-- ==================== Activity Stream: Recording ==================== -->
-  <data name="Activity_ScreenRecordingStarted" xml:space="preserve">
-    <value>Schermopname gestart</value>
-  </data>
-  <data name="Activity_ScreenRecordingComplete" xml:space="preserve">
-    <value>Schermopname voltooid</value>
-  </data>
-  <data name="Activity_CameraRecordingStarted" xml:space="preserve">
-    <value>Camera-opname gestart</value>
-  </data>
-  <data name="Activity_CameraRecordingComplete" xml:space="preserve">
-    <value>Camera-opname voltooid</value>
-  </data>
-  <data name="Activity_RecordingRequestedByAgent" xml:space="preserve">
-    <value>{0}-opname aangevraagd door agent</value>
-  </data>
-  <data name="Activity_RecordingSentToAgent" xml:space="preserve">
-    <value>{0}-opname verzonden naar agent</value>
-  </data>
   <!-- ==================== Toast: Activity Stream Tip ==================== -->
   <data name="Toast_ActivityStreamTip" xml:space="preserve">
     <value>⚡ Nieuw: Activiteitenstroom</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -772,25 +772,6 @@
   <data name="CameraRecordingToggle.Header" xml:space="preserve">
     <value>允许摄像头录制</value>
   </data>
-  <!-- ==================== Activity Stream: Recording ==================== -->
-  <data name="Activity_ScreenRecordingStarted" xml:space="preserve">
-    <value>屏幕录制已开始</value>
-  </data>
-  <data name="Activity_ScreenRecordingComplete" xml:space="preserve">
-    <value>屏幕录制已完成</value>
-  </data>
-  <data name="Activity_CameraRecordingStarted" xml:space="preserve">
-    <value>摄像头录制已开始</value>
-  </data>
-  <data name="Activity_CameraRecordingComplete" xml:space="preserve">
-    <value>摄像头录制已完成</value>
-  </data>
-  <data name="Activity_RecordingRequestedByAgent" xml:space="preserve">
-    <value>{0}录制由代理请求</value>
-  </data>
-  <data name="Activity_RecordingSentToAgent" xml:space="preserve">
-    <value>{0}录制已发送给代理</value>
-  </data>
   <!-- ==================== Toast: Activity Stream Tip ==================== -->
   <data name="Toast_ActivityStreamTip" xml:space="preserve">
     <value>⚡ 新功能: 活动流</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -772,25 +772,6 @@
   <data name="CameraRecordingToggle.Header" xml:space="preserve">
     <value>允許攝影機錄製</value>
   </data>
-  <!-- ==================== Activity Stream: Recording ==================== -->
-  <data name="Activity_ScreenRecordingStarted" xml:space="preserve">
-    <value>螢幕錄製已開始</value>
-  </data>
-  <data name="Activity_ScreenRecordingComplete" xml:space="preserve">
-    <value>螢幕錄製已完成</value>
-  </data>
-  <data name="Activity_CameraRecordingStarted" xml:space="preserve">
-    <value>攝影機錄製已開始</value>
-  </data>
-  <data name="Activity_CameraRecordingComplete" xml:space="preserve">
-    <value>攝影機錄製已完成</value>
-  </data>
-  <data name="Activity_RecordingRequestedByAgent" xml:space="preserve">
-    <value>{0}錄製由代理請求</value>
-  </data>
-  <data name="Activity_RecordingSentToAgent" xml:space="preserve">
-    <value>{0}錄製已傳送給代理</value>
-  </data>
   <!-- ==================== Toast: Activity Stream Tip ==================== -->
   <data name="Toast_ActivityStreamTip" xml:space="preserve">
     <value>⚡ 新功能: 串流活動</value>


### PR DESCRIPTION
## Summary

Three small cleanups in App.xaml.cs with no behavior change.

`OnRecordingStateChanged` was subscribed to a `NodeService` event that no longer fires — removed the handler and its six localization keys from all five locale files.

`AppRunMarker` (run-marker file logic) and `CliUninstallHandler` (headless `--uninstall` CLI entry point) were inline static helpers inside App.xaml.cs; both are now standalone files in the expected namespaces with no interface or dependency changes.

## What changed

- `OnRecordingStateChanged` and its six localization keys removed from all locales (en-us, fr-fr, nl-nl, zh-cn, zh-tw)
- `AppRunMarker` extracted to `Services/AppRunMarker.cs`
- `CliUninstallHandler` extracted to `CliUninstallHandler.cs`

## Testing

```
dotnet build src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj -r win-x64
dotnet test
```

All 1212 tests pass, including `LocalizationValidationTests`.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>