### PR TITLE
Add easy setup diagnostics logging

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -436,6 +436,12 @@ File-based logging with automatic rotation:
 - Rotation: When log exceeds 5MB, old log → `openclaw-tray.log.old`
 - Thread-safe: Uses lock for concurrent writes
 
+**Easy-button setup diagnostics:**
+- Human summary: `%LOCALAPPDATA%\OpenClawTray\Logs\Setup\easy-setup-latest.txt`
+- Machine-readable latest trace: `%LOCALAPPDATA%\OpenClawTray\Logs\Setup\easy-setup-latest.jsonl`
+- Per-run traces: `%LOCALAPPDATA%\OpenClawTray\Logs\Setup\setup-*.jsonl`
+- Contents are redacted and cover setup phases, WSL commands, pairing, gateway checks, repair, and remove lifecycle steps.
+
 **Log Levels:**
 - `INFO` - Normal operation (connections, events)
 - `WARN` - Recoverable issues (reconnects, timeouts)

--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ openclaw-windows-node/
 Settings are stored in:
 - Settings: `%APPDATA%\OpenClawTray\settings.json`
 - Logs: `%LOCALAPPDATA%\OpenClawTray\openclaw-tray.log`
+- Easy-button setup summary: `%LOCALAPPDATA%\OpenClawTray\Logs\Setup\easy-setup-latest.txt`
+- Easy-button setup JSONL: `%LOCALAPPDATA%\OpenClawTray\Logs\Setup\easy-setup-latest.jsonl`
 
 Default gateway: `ws://localhost:18789`
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -139,6 +139,7 @@ Download and install WebView2 from [Microsoft](https://developer.microsoft.com/m
 - Make sure the OpenClaw gateway process is running.
 - Check Windows Firewall — if your gateway runs on a different machine, allow inbound traffic on port 18789.
 - See the log at `%LOCALAPPDATA%\OpenClawTray\openclaw-tray.log` for connection errors.
+- For easy-button setup, repair, or remove failures, start with `%LOCALAPPDATA%\OpenClawTray\Logs\Setup\easy-setup-latest.txt`; Copilot CLI/debugging tools can use `%LOCALAPPDATA%\OpenClawTray\Logs\Setup\easy-setup-latest.jsonl`.
 
 ### "Not yet paired" message on reconnect
 
@@ -155,6 +156,7 @@ See [issue #81](https://github.com/openclaw/openclaw-windows-node/issues/81) for
 - Make sure you paste the **entire** setup code — it's a single base64url-encoded string.
 - Check for accidental leading/trailing whitespace.
 - The code must be from a compatible gateway version. Try entering the gateway URL and token manually instead.
+- If the easy-button setup flow generated the code, check `%LOCALAPPDATA%\OpenClawTray\Logs\Setup\easy-setup-latest.txt` for the failing phase and next action.
 
 ### Connection test fails
 
@@ -162,6 +164,7 @@ See [issue #81](https://github.com/openclaw/openclaw-windows-node/issues/81) for
 - Check that your token is valid and hasn't expired.
 - If the gateway is on another machine, ensure Windows Firewall allows traffic on the gateway port.
 - See the log at `%LOCALAPPDATA%\OpenClawTray\openclaw-tray.log` for detailed error messages.
+- Easy-button setup diagnostics keep per-run JSONL traces at `%LOCALAPPDATA%\OpenClawTray\Logs\Setup\setup-*.jsonl` and update `easy-setup-latest.txt`/`.jsonl` after each run.
 
 ### Wizard shows "offline"
 

--- a/src/OpenClaw.Tray.WinUI/Onboarding/V2/OnboardingV2Bridge.cs
+++ b/src/OpenClaw.Tray.WinUI/Onboarding/V2/OnboardingV2Bridge.cs
@@ -341,7 +341,7 @@ public sealed class OnboardingV2Bridge : IDisposable
             DispatchToUi(() =>
             {
                 MarkAllStagesIdle();
-                _state.LocalSetupErrorMessage = $"Could not start setup engine: {ex.Message}";
+                _state.LocalSetupErrorMessage = AppendSetupDiagnosticsHint($"Could not start setup engine: {ex.Message}");
                 _state.LocalSetupCanRetry = true;
             });
             return;
@@ -388,7 +388,7 @@ public sealed class OnboardingV2Bridge : IDisposable
             Logger.Error($"[V2Bridge] RunLocalOnlyAsync threw synchronously: {ex.Message}");
             DispatchToUi(() =>
             {
-                _state.LocalSetupErrorMessage = ex.Message;
+                _state.LocalSetupErrorMessage = AppendSetupDiagnosticsHint(ex.Message);
                 _state.LocalSetupCanRetry = true;
             });
         }
@@ -402,7 +402,7 @@ public sealed class OnboardingV2Bridge : IDisposable
         var errorMessage = (status == LocalGatewaySetupStatus.FailedRetryable
                          || status == LocalGatewaySetupStatus.FailedTerminal
                          || status == LocalGatewaySetupStatus.Blocked)
-            ? st.UserMessage
+            ? AppendSetupDiagnosticsHint(st.UserMessage)
             : null;
 
         // Hanselman review: only FailedRetryable should expose Try-again.
@@ -747,9 +747,17 @@ public sealed class OnboardingV2Bridge : IDisposable
             var rows = AllRowsIdle();
             rows[V2Stage.RemovingExistingGateway] = V2RowState.Failed;
             _state.LocalSetupRows = rows;
-            _state.LocalSetupErrorMessage = message;
+            _state.LocalSetupErrorMessage = AppendSetupDiagnosticsHint(message);
             _state.LocalSetupCanRetry = true;
         });
+    }
+
+    private static string AppendSetupDiagnosticsHint(string? message)
+    {
+        var baseMessage = string.IsNullOrWhiteSpace(message)
+            ? "Local setup failed."
+            : message;
+        return baseMessage + Environment.NewLine + "Setup diagnostics: " + LocalGatewaySetupDiagnosticsService.LatestSummaryPathForCurrentUser();
     }
 
     private void ApplyFreshLocalReplacementRow(Dictionary<V2Stage, V2RowState> rows)

--- a/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetup.cs
@@ -138,6 +138,7 @@ public sealed class LocalGatewaySetupState
 {
     public int SchemaVersion { get; set; } = 1;
     public string RunId { get; set; } = Guid.NewGuid().ToString("N");
+    public string InstallId { get; set; } = Guid.NewGuid().ToString("N");
     public LocalGatewaySetupPhase Phase { get; set; } = LocalGatewaySetupPhase.NotStarted;
     public LocalGatewaySetupStatus Status { get; set; } = LocalGatewaySetupStatus.Pending;
     public string DistroName { get; set; } = "OpenClawGateway";
@@ -266,12 +267,18 @@ public interface IWslCommandRunner
 public sealed class WslExeCommandRunner : IWslCommandRunner
 {
     private readonly IOpenClawLogger _logger;
+    private readonly ILocalGatewaySetupDiagnosticsSink _diagnostics;
     private readonly TimeSpan _defaultTimeout;
     private readonly TimeSpan _streamDrainTimeout;
 
-    public WslExeCommandRunner(IOpenClawLogger? logger = null, TimeSpan? defaultTimeout = null, TimeSpan? streamDrainTimeout = null)
+    public WslExeCommandRunner(
+        IOpenClawLogger? logger = null,
+        TimeSpan? defaultTimeout = null,
+        TimeSpan? streamDrainTimeout = null,
+        ILocalGatewaySetupDiagnosticsSink? diagnostics = null)
     {
         _logger = logger ?? NullLogger.Instance;
+        _diagnostics = diagnostics ?? NullLocalGatewaySetupDiagnosticsSink.Instance;
         _defaultTimeout = defaultTimeout ?? TimeSpan.FromSeconds(30);
         _streamDrainTimeout = streamDrainTimeout ?? TimeSpan.FromSeconds(5);
     }
@@ -377,7 +384,9 @@ public sealed class WslExeCommandRunner : IWslCommandRunner
 
         ApplyEnvironment(psi, environment);
 
-        _logger.Info($"[WSL] {fileName} {string.Join(" ", arguments.Select(RedactArgument))}");
+        _logger.Info($"[WSL] {fileName} {string.Join(" ", RedactArguments(arguments))}");
+        var commandId = _diagnostics.CommandStarted(fileName, arguments, _defaultTimeout);
+        var sw = Stopwatch.StartNew();
 
         using var process = new Process { StartInfo = psi };
         try
@@ -386,7 +395,10 @@ public sealed class WslExeCommandRunner : IWslCommandRunner
         }
         catch (Exception ex)
         {
-            return new WslCommandResult(-1, string.Empty, $"Failed to start wsl.exe: {ex.Message}");
+            var result = new WslCommandResult(-1, string.Empty, $"Failed to start wsl.exe: {ex.Message}");
+            sw.Stop();
+            _diagnostics.CommandCompleted(commandId, fileName, arguments, sw.Elapsed, result, timedOut: false);
+            return result;
         }
 
         var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
@@ -424,6 +436,14 @@ public sealed class WslExeCommandRunner : IWslCommandRunner
             {
                 _logger.Warn($"[WSL] Failed to kill cancelled process: {ex.Message}");
             }
+            sw.Stop();
+            _diagnostics.CommandCompleted(
+                commandId,
+                fileName,
+                arguments,
+                sw.Elapsed,
+                new WslCommandResult(-1, string.Empty, "wsl.exe cancelled"),
+                timedOut: false);
             throw;
         }
 
@@ -437,10 +457,13 @@ public sealed class WslExeCommandRunner : IWslCommandRunner
         var stdout = await DrainAsync(stdoutTask, _streamDrainTimeout, _logger, isStderr: false);
         var stderr = await DrainAsync(stderrTask, _streamDrainTimeout, _logger, isStderr: true);
 
-        if (timedOut)
-            return new WslCommandResult(-1, stdout, "wsl.exe timed out");
+        var finalResult = timedOut
+            ? new WslCommandResult(-1, stdout, "wsl.exe timed out")
+            : new WslCommandResult(process.ExitCode, stdout, stderr);
 
-        return new WslCommandResult(process.ExitCode, stdout, stderr);
+        sw.Stop();
+        _diagnostics.CommandCompleted(commandId, fileName, arguments, sw.Elapsed, finalResult, timedOut);
+        return finalResult;
     }
 
     internal static async Task<string> DrainAsync(Task<string> readTask, TimeSpan drainTimeout, IOpenClawLogger logger, bool isStderr)
@@ -509,12 +532,8 @@ public sealed class WslExeCommandRunner : IWslCommandRunner
         environment["WSLENV"] = string.IsNullOrWhiteSpace(existing) ? entry : existing + ":" + entry;
     }
 
-    private static string RedactArgument(string argument) =>
-        SecretRedactor.Redact(argument.Contains("token", StringComparison.OrdinalIgnoreCase)
-            || argument.Contains("private", StringComparison.OrdinalIgnoreCase)
-            || argument.Contains("setupCode", StringComparison.OrdinalIgnoreCase)
-                ? "<redacted>"
-                : argument);
+    private static IEnumerable<string> RedactArguments(IReadOnlyList<string> arguments) =>
+        SetupDiagnosticsRedactor.RedactArguments(arguments);
 }
 
 public sealed record LocalGatewayPreflightResult(
@@ -3367,6 +3386,7 @@ public sealed class LocalGatewaySetupEngine
     private readonly IOperatorPairingService _operatorPairing;
     private readonly IWindowsTrayNodeProvisioner _windowsTrayNode;
     private readonly IOpenClawLogger _logger;
+    private readonly ILocalGatewaySetupDiagnosticsSink _diagnostics;
 
     public event Action<LocalGatewaySetupState>? StateChanged;
 
@@ -3414,7 +3434,8 @@ public sealed class LocalGatewaySetupEngine
         IGatewayConfigurationPreparer? gatewayConfigurationPreparer = null,
         IGatewayServiceManager? gatewayServiceManager = null,
         ILocalGatewayEndpointResolver? endpointResolver = null,
-        ISharedGatewayTokenProvisioner? sharedGatewayTokenProvisioner = null)
+        ISharedGatewayTokenProvisioner? sharedGatewayTokenProvisioner = null,
+        ILocalGatewaySetupDiagnosticsSink? diagnosticsSink = null)
     {
         _options = options;
         _stateStore = stateStore;
@@ -3432,13 +3453,19 @@ public sealed class LocalGatewaySetupEngine
         _operatorPairing = operatorPairing;
         _windowsTrayNode = windowsTrayNode;
         _logger = logger ?? NullLogger.Instance;
+        _diagnostics = diagnosticsSink ?? NullLocalGatewaySetupDiagnosticsSink.Instance;
     }
 
     public async Task<LocalGatewaySetupState> RunLocalOnlyAsync(CancellationToken cancellationToken = default)
     {
+        var runStopwatch = Stopwatch.StartNew();
         var state = await _stateStore.LoadAsync(cancellationToken) ?? LocalGatewaySetupState.Create(_options);
+        state.RunId = Guid.NewGuid().ToString("N");
+        if (string.IsNullOrWhiteSpace(state.InstallId))
+            state.InstallId = Guid.NewGuid().ToString("N");
         state.DistroName = _options.DistroName;
         state.GatewayUrl = LocalGatewayEndpointResolver.BuildLoopbackGatewayUrl(_options);
+        _diagnostics.RunStarted(state, _options);
         var distroExists = await HasDistroAsync(cancellationToken);
         var allowExistingDistroForRun = ShouldAllowExistingDistroForRun(state, distroExists, _options.AllowExistingDistro);
         var preflightOptions = _options with { AllowExistingDistro = allowExistingDistroForRun };
@@ -3509,6 +3536,8 @@ public sealed class LocalGatewaySetupEngine
         await RunPhaseAsync(state, LocalGatewaySetupPhase.InstallOpenClawCli, "Installing OpenClaw inside WSL", async () =>
         {
             var result = await _openClawLinuxInstaller.InstallAsync(_options, cancellationToken);
+            foreach (var installerEvent in result.Events ?? Array.Empty<OpenClawLinuxInstallerEvent>())
+                _diagnostics.InstallerEvent(LocalGatewaySetupPhase.InstallOpenClawCli, installerEvent);
             if (!result.Success)
             {
                 if (!string.IsNullOrWhiteSpace(result.Detail))
@@ -3609,6 +3638,9 @@ public sealed class LocalGatewaySetupEngine
             await SaveAndPublishAsync(state, cancellationToken);
         }
 
+        runStopwatch.Stop();
+        _diagnostics.RunCompleted(state, runStopwatch.Elapsed);
+        await _diagnostics.FlushAsync(TimeSpan.FromSeconds(2), cancellationToken);
         return state;
     }
 
@@ -3672,7 +3704,9 @@ public sealed class LocalGatewaySetupEngine
         if (state.Status is not LocalGatewaySetupStatus.Pending and not LocalGatewaySetupStatus.Running)
             return;
 
+        var phaseStopwatch = Stopwatch.StartNew();
         state.StartPhase(phase, message);
+        _diagnostics.PhaseStarted(state, phase, message);
         await SaveAndPublishAsync(state, cancellationToken);
         bool completed;
         try
@@ -3686,6 +3720,9 @@ public sealed class LocalGatewaySetupEngine
             // Persist cancelled state so restarts don't resume from stale Running phase
             try { await _stateStore.SaveAsync(state, CancellationToken.None); } catch { }
             StateChanged?.Invoke(state);
+            phaseStopwatch.Stop();
+            _diagnostics.PhaseCompleted(state, phase, message, phaseStopwatch.Elapsed);
+            await _diagnostics.FlushAsync(TimeSpan.FromSeconds(2), CancellationToken.None);
             throw;
         }
         catch (Exception ex)
@@ -3693,18 +3730,27 @@ public sealed class LocalGatewaySetupEngine
             _logger.Error($"Local gateway setup phase {phase} failed.", ex);
             var retryable = ex is not (UnauthorizedAccessException or NotSupportedException or InvalidOperationException or ArgumentException);
             state.Block($"{phase.ToString().ToLowerInvariant()}_failed", ex.Message, retryable: retryable, detail: SecretRedactor.Redact(ex.ToString()));
+            phaseStopwatch.Stop();
+            _diagnostics.PhaseCompleted(state, phase, message, phaseStopwatch.Elapsed);
             await SaveAndPublishAsync(state, cancellationToken);
+            await _diagnostics.FlushAsync(TimeSpan.FromSeconds(2), cancellationToken);
             return;
         }
 
         if (completed && state.Status == LocalGatewaySetupStatus.Running)
         {
             state.CompletePhase(phase, message);
+            phaseStopwatch.Stop();
+            _diagnostics.PhaseCompleted(state, phase, message, phaseStopwatch.Elapsed);
             await SaveAndPublishAsync(state, cancellationToken);
         }
         else if (!completed)
         {
+            phaseStopwatch.Stop();
+            _diagnostics.PhaseCompleted(state, phase, message, phaseStopwatch.Elapsed);
             await SaveAndPublishAsync(state, cancellationToken);
+            if (state.Status is LocalGatewaySetupStatus.FailedRetryable or LocalGatewaySetupStatus.FailedTerminal or LocalGatewaySetupStatus.Blocked)
+                await _diagnostics.FlushAsync(TimeSpan.FromSeconds(2), cancellationToken);
         }
     }
 
@@ -3764,71 +3810,106 @@ public sealed class LocalGatewayLifecycleManager : ILocalGatewayLifecycleManager
     private readonly ILocalGatewayHealthProbe _healthProbe;
     private readonly ILocalGatewaySetupSettings? _settings;
     private readonly IOpenClawLogger? _logger;
+    private readonly ILocalGatewaySetupDiagnosticsSink _diagnostics;
 
-    public LocalGatewayLifecycleManager(LocalGatewaySetupOptions options, IWslCommandRunner wsl, ILocalGatewayHealthProbe healthProbe, ILocalGatewaySetupSettings? settings = null, IOpenClawLogger? logger = null)
+    public LocalGatewayLifecycleManager(
+        LocalGatewaySetupOptions options,
+        IWslCommandRunner wsl,
+        ILocalGatewayHealthProbe healthProbe,
+        ILocalGatewaySetupSettings? settings = null,
+        IOpenClawLogger? logger = null,
+        ILocalGatewaySetupDiagnosticsSink? diagnosticsSink = null)
     {
         _options = options;
         _wsl = wsl;
         _healthProbe = healthProbe;
         _settings = settings;
         _logger = logger;
+        _diagnostics = diagnosticsSink ?? NullLocalGatewaySetupDiagnosticsSink.Instance;
     }
 
     public async Task<LocalGatewayLifecycleResult> RepairAsync(CancellationToken cancellationToken = default)
     {
+        var lifecycleStopwatch = Stopwatch.StartNew();
+        _diagnostics.LifecycleStarted("repair");
         var steps = new List<string>();
         var distros = await _wsl.ListDistrosAsync(cancellationToken);
         if (!distros.Any(d => d.Name.Equals(_options.DistroName, StringComparison.OrdinalIgnoreCase) && d.Version == 2))
-            return Fail("distro_missing", $"The OpenClaw WSL distro '{_options.DistroName}' was not found.", steps);
+        {
+            _diagnostics.LifecycleStep("repair", "distro_present", success: false, "distro_missing", $"The OpenClaw WSL distro '{_options.DistroName}' was not found.");
+            return await CompleteLifecycleAsync("repair", Fail("distro_missing", $"The OpenClaw WSL distro '{_options.DistroName}' was not found.", steps), lifecycleStopwatch, cancellationToken);
+        }
 
         // Tear down any stale keepalive before terminating; we'll spawn a fresh one
         // after the gateway becomes healthy. Without this, the old keepalive lingers
         // pointing at a now-restarted VM but is no longer tracked by our marker.
         WslDistroKeepAlive.Stop(_options.DistroName, _logger);
         steps.Add("keepalive_stopped");
+        _diagnostics.LifecycleStep("repair", "keepalive_stopped", success: true);
 
         await _wsl.TerminateDistroAsync(_options.DistroName, cancellationToken);
         steps.Add("distro_terminated");
+        _diagnostics.LifecycleStep("repair", "distro_terminated", success: true);
 
         var daemonReload = await RunInDistroAsRootAsync(["systemctl", "daemon-reload"], cancellationToken);
         steps.Add("daemon_reloaded");
         if (!daemonReload.Success)
-            return Fail("daemon_reload_failed", "Failed to reload OpenClaw Gateway systemd units.", steps);
+        {
+            _diagnostics.LifecycleStep("repair", "daemon_reloaded", success: false, "daemon_reload_failed", "Failed to reload OpenClaw Gateway systemd units.");
+            return await CompleteLifecycleAsync("repair", Fail("daemon_reload_failed", "Failed to reload OpenClaw Gateway systemd units.", steps), lifecycleStopwatch, cancellationToken);
+        }
+        _diagnostics.LifecycleStep("repair", "daemon_reloaded", success: true);
 
         var gateway = await RestartGatewayServiceAsync(steps, cancellationToken);
         if (!gateway.Success)
-            return gateway;
+            return await CompleteLifecycleAsync("repair", gateway, lifecycleStopwatch, cancellationToken);
 
         var health = await _healthProbe.WaitForHealthyAsync(LocalGatewayEndpointResolver.BuildLoopbackGatewayUrl(_options), cancellationToken);
         steps.Add("gateway_health_checked");
         if (!health.Success)
-            return Fail("gateway_unhealthy", health.Error ?? WslLogsHelp("Gateway did not become healthy after repair."), steps);
+        {
+            _diagnostics.LifecycleStep("repair", "gateway_health_checked", success: false, "gateway_unhealthy", health.Error ?? WslLogsHelp("Gateway did not become healthy after repair."));
+            return await CompleteLifecycleAsync("repair", Fail("gateway_unhealthy", health.Error ?? WslLogsHelp("Gateway did not become healthy after repair."), steps), lifecycleStopwatch, cancellationToken);
+        }
+        _diagnostics.LifecycleStep("repair", "gateway_health_checked", success: true);
 
         // Re-arm the keepalive so the VM stays up after repair completes, even if the
         // tray that triggered repair exits before the next OnLaunched hook runs.
         WslDistroKeepAlive.EnsureStarted(_options.DistroName, _logger);
         steps.Add("keepalive_started");
+        _diagnostics.LifecycleStep("repair", "keepalive_started", success: true);
 
-        return new LocalGatewayLifecycleResult(true, Steps: steps);
+        return await CompleteLifecycleAsync("repair", new LocalGatewayLifecycleResult(true, Steps: steps), lifecycleStopwatch, cancellationToken);
     }
 
     public async Task<LocalGatewayLifecycleResult> RemoveAsync(LocalGatewayRemoveRequest request, CancellationToken cancellationToken = default)
     {
+        var lifecycleStopwatch = Stopwatch.StartNew();
+        _diagnostics.LifecycleStarted("remove");
         var steps = new List<string>();
         if (!request.ConfirmRemove)
-            return Fail("confirmation_required", "Removing the local OpenClaw Gateway requires explicit confirmation.", steps);
+        {
+            _diagnostics.LifecycleStep("remove", "confirmation_required", success: false, "confirmation_required", "Removing the local OpenClaw Gateway requires explicit confirmation.");
+            return await CompleteLifecycleAsync("remove", Fail("confirmation_required", "Removing the local OpenClaw Gateway requires explicit confirmation.", steps), lifecycleStopwatch, cancellationToken);
+        }
 
         // Stop the keepalive before terminating so the marker file does not survive
         // distro removal and confuse a future install with the same name.
         WslDistroKeepAlive.Stop(_options.DistroName, _logger);
         steps.Add("keepalive_stopped");
+        _diagnostics.LifecycleStep("remove", "keepalive_stopped", success: true);
 
         await _wsl.TerminateDistroAsync(_options.DistroName, cancellationToken);
         steps.Add("distro_terminated");
+        _diagnostics.LifecycleStep("remove", "distro_terminated", success: true);
         var unregister = await _wsl.UnregisterDistroAsync(_options.DistroName, cancellationToken);
         steps.Add("distro_unregistered");
         if (!unregister.Success)
-            return Fail("distro_unregister_failed", $"Failed to unregister WSL distro '{_options.DistroName}'.", steps);
+        {
+            _diagnostics.LifecycleStep("remove", "distro_unregistered", success: false, "distro_unregister_failed", $"Failed to unregister WSL distro '{_options.DistroName}'.");
+            return await CompleteLifecycleAsync("remove", Fail("distro_unregister_failed", $"Failed to unregister WSL distro '{_options.DistroName}'.", steps), lifecycleStopwatch, cancellationToken);
+        }
+        _diagnostics.LifecycleStep("remove", "distro_unregistered", success: true);
 
         if (request.ClearLocalCredentials && _settings is not null)
         {
@@ -3838,12 +3919,13 @@ public sealed class LocalGatewayLifecycleManager : ILocalGatewayLifecycleManager
             _settings.UseSshTunnel = false;
             _settings.Save();
             steps.Add("local_credentials_cleared");
+            _diagnostics.LifecycleStep("remove", "local_credentials_cleared", success: true);
         }
 
         if (request.PreserveRelayRegistration)
             steps.Add("relay_registration_preserved");
 
-        return new LocalGatewayLifecycleResult(true, Steps: steps);
+        return await CompleteLifecycleAsync("remove", new LocalGatewayLifecycleResult(true, Steps: steps), lifecycleStopwatch, cancellationToken);
     }
 
     private async Task<LocalGatewayLifecycleResult> RestartGatewayServiceAsync(List<string> steps, CancellationToken cancellationToken)
@@ -3852,17 +3934,29 @@ public sealed class LocalGatewayLifecycleManager : ILocalGatewayLifecycleManager
         var enable = await RunInDistroAsRootAsync(["systemctl", "enable", "--now", $"{serviceName}.service"], cancellationToken);
         steps.Add($"{serviceName}_enabled");
         if (!enable.Success)
+        {
+            _diagnostics.LifecycleStep("repair", $"{serviceName}_enabled", success: false, "service_enable_failed", $"Failed to enable {serviceName}.service.");
             return Fail("service_enable_failed", $"Failed to enable {serviceName}.service.", steps);
+        }
+        _diagnostics.LifecycleStep("repair", $"{serviceName}_enabled", success: true);
 
         var restart = await RunInDistroAsRootAsync(["systemctl", "restart", $"{serviceName}.service"], cancellationToken);
         steps.Add($"{serviceName}_restarted");
         if (!restart.Success)
+        {
+            _diagnostics.LifecycleStep("repair", $"{serviceName}_restarted", success: false, "service_restart_failed", $"Failed to restart {serviceName}.service.");
             return Fail("service_restart_failed", $"Failed to restart {serviceName}.service.", steps);
+        }
+        _diagnostics.LifecycleStep("repair", $"{serviceName}_restarted", success: true);
 
         var active = await RunInDistroAsRootAsync(["systemctl", "is-active", "--quiet", $"{serviceName}.service"], cancellationToken);
         steps.Add($"{serviceName}_active_checked");
         if (!active.Success)
+        {
+            _diagnostics.LifecycleStep("repair", $"{serviceName}_active_checked", success: false, "service_inactive", $"{serviceName}.service is not active after repair.");
             return Fail("service_inactive", $"{serviceName}.service is not active after repair.", steps);
+        }
+        _diagnostics.LifecycleStep("repair", $"{serviceName}_active_checked", success: true);
 
         return new LocalGatewayLifecycleResult(true, Steps: steps);
     }
@@ -3872,6 +3966,18 @@ public sealed class LocalGatewayLifecycleManager : ILocalGatewayLifecycleManager
         var args = new List<string> { "-d", _options.DistroName, "-u", "root", "--" };
         args.AddRange(command);
         return _wsl.RunAsync(args, cancellationToken);
+    }
+
+    private async Task<LocalGatewayLifecycleResult> CompleteLifecycleAsync(
+        string operation,
+        LocalGatewayLifecycleResult result,
+        Stopwatch stopwatch,
+        CancellationToken cancellationToken)
+    {
+        stopwatch.Stop();
+        _diagnostics.LifecycleCompleted(operation, result, stopwatch.Elapsed);
+        await _diagnostics.FlushAsync(TimeSpan.FromSeconds(2), cancellationToken);
+        return result;
     }
 
     private static string WslLogsHelp(string message) => message + " Follow aka.ms/wsllogs for WSL diagnostic collection instructions.";
@@ -3950,7 +4056,8 @@ public static class LocalGatewaySetupEngineFactory
             catch { /* best-effort — engine will overwrite on first save */ }
         }
 
-        var wsl = new WslExeCommandRunner(logger, TimeSpan.FromMinutes(30));
+        var diagnostics = new LocalGatewaySetupDiagnosticsService();
+        var wsl = new WslExeCommandRunner(logger, TimeSpan.FromMinutes(30), diagnostics: diagnostics);
         var settingsAdapter = new SettingsManagerLocalGatewaySetupSettings(settings, gatewayRegistry);
         var bootstrapTokenProvider = new WslGatewayCliBootstrapTokenProvider(wsl, options.OpenClawInstallPrefix + "/bin/openclaw");
         var sharedGatewayTokenProvider = new WslGatewayCliSharedGatewayTokenProvider(wsl);
@@ -3968,7 +4075,8 @@ public static class LocalGatewaySetupEngineFactory
             new SettingsWindowsTrayNodeProvisioner(settingsAdapter, windowsNodeConnector, pendingDeviceApprover),
             logger,
             gatewayConfigurationPreparer: gatewayConfigurationPreparer,
-            sharedGatewayTokenProvisioner: new SettingsSharedGatewayTokenProvisioner(settingsAdapter, sharedGatewayTokenProvider, gatewayConfigurationPreparer));
+            sharedGatewayTokenProvisioner: new SettingsSharedGatewayTokenProvisioner(settingsAdapter, sharedGatewayTokenProvider, gatewayConfigurationPreparer),
+            diagnosticsSink: diagnostics);
     }
 
     private static string ResolveDistroName(LocalGatewaySetupRuntimeConfiguration runtime, string? explicitDistroName)

--- a/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetupDiagnostics.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/LocalGatewaySetup/LocalGatewaySetupDiagnostics.cs
@@ -1,0 +1,751 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Security.Principal;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenClaw.Shared;
+using OpenClawTray.Onboarding.Services;
+using OpenClawTray.Services;
+
+namespace OpenClawTray.Services.LocalGatewaySetup;
+
+/// <summary>
+/// Schema v1 for easy-button setup diagnostics.
+///
+/// Required top-level JSONL fields:
+/// schema_version, timestamp_utc, run_id, install_id, level, event.
+///
+/// Optional top-level JSONL fields:
+/// phase, visible_stage, status, message, failure_code, retryable,
+/// duration_ms, details.
+/// </summary>
+public interface ILocalGatewaySetupDiagnosticsSink
+{
+    string? RunTracePath { get; }
+    string? LatestTracePath { get; }
+    string? LatestSummaryPath { get; }
+
+    void RunStarted(LocalGatewaySetupState state, LocalGatewaySetupOptions options);
+    void RunCompleted(LocalGatewaySetupState state, TimeSpan duration);
+    void PhaseStarted(LocalGatewaySetupState state, LocalGatewaySetupPhase phase, string message);
+    void PhaseCompleted(LocalGatewaySetupState state, LocalGatewaySetupPhase phase, string message, TimeSpan duration);
+    string CommandStarted(string fileName, IReadOnlyList<string> arguments, TimeSpan timeout);
+    void CommandCompleted(string commandId, string fileName, IReadOnlyList<string> arguments, TimeSpan duration, WslCommandResult result, bool timedOut);
+    void InstallerEvent(LocalGatewaySetupPhase phase, OpenClawLinuxInstallerEvent installerEvent);
+    void LifecycleStarted(string operation);
+    void LifecycleStep(string operation, string step, bool success, string? errorCode = null, string? errorMessage = null);
+    void LifecycleCompleted(string operation, LocalGatewayLifecycleResult result, TimeSpan duration);
+    Task FlushAsync(TimeSpan timeout, CancellationToken cancellationToken = default);
+}
+
+public sealed class NullLocalGatewaySetupDiagnosticsSink : ILocalGatewaySetupDiagnosticsSink
+{
+    public static readonly NullLocalGatewaySetupDiagnosticsSink Instance = new();
+
+    public string? RunTracePath => null;
+    public string? LatestTracePath => null;
+    public string? LatestSummaryPath => null;
+
+    public void RunStarted(LocalGatewaySetupState state, LocalGatewaySetupOptions options) { }
+    public void RunCompleted(LocalGatewaySetupState state, TimeSpan duration) { }
+    public void PhaseStarted(LocalGatewaySetupState state, LocalGatewaySetupPhase phase, string message) { }
+    public void PhaseCompleted(LocalGatewaySetupState state, LocalGatewaySetupPhase phase, string message, TimeSpan duration) { }
+    public string CommandStarted(string fileName, IReadOnlyList<string> arguments, TimeSpan timeout) => string.Empty;
+    public void CommandCompleted(string commandId, string fileName, IReadOnlyList<string> arguments, TimeSpan duration, WslCommandResult result, bool timedOut) { }
+    public void InstallerEvent(LocalGatewaySetupPhase phase, OpenClawLinuxInstallerEvent installerEvent) { }
+    public void LifecycleStarted(string operation) { }
+    public void LifecycleStep(string operation, string step, bool success, string? errorCode = null, string? errorMessage = null) { }
+    public void LifecycleCompleted(string operation, LocalGatewayLifecycleResult result, TimeSpan duration) { }
+    public Task FlushAsync(TimeSpan timeout, CancellationToken cancellationToken = default) => Task.CompletedTask;
+}
+
+public sealed class LocalGatewaySetupDiagnosticsService : ILocalGatewaySetupDiagnosticsSink
+{
+    public const int SchemaVersion = 1;
+    private const int MaxCommandOutputChars = 4096;
+    private const int MaxStoredRecords = 512;
+
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        WriteIndented = false
+    };
+
+    private readonly object _lock = new();
+    private readonly string _setupLogDirectory;
+    private readonly List<SetupDiagnosticRecord> _records = new();
+    private string? _runId;
+    private string? _installId;
+    private bool _initialized;
+
+    public LocalGatewaySetupDiagnosticsService(string? localDataPath = null)
+    {
+        _setupLogDirectory = Path.Combine(localDataPath ?? ResolveLocalDataPath(), "Logs", "Setup");
+        LatestTracePath = Path.Combine(_setupLogDirectory, "easy-setup-latest.jsonl");
+        LatestSummaryPath = Path.Combine(_setupLogDirectory, "easy-setup-latest.txt");
+    }
+
+    public string? RunTracePath { get; private set; }
+    public string? LatestTracePath { get; }
+    public string? LatestSummaryPath { get; }
+
+    public static string ResolveLocalDataPath()
+    {
+        if (Environment.GetEnvironmentVariable("OPENCLAW_TRAY_DATA_DIR") is { Length: > 0 } dataOverride)
+            return dataOverride;
+
+        if (Environment.GetEnvironmentVariable("OPENCLAW_TRAY_LOCALAPPDATA_DIR") is { Length: > 0 } localDataOverride)
+            return Path.Combine(localDataOverride, "OpenClawTray");
+
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "OpenClawTray");
+    }
+
+    public static string LatestSummaryPathForCurrentUser() =>
+        Path.Combine(ResolveLocalDataPath(), "Logs", "Setup", "easy-setup-latest.txt");
+
+    public static string SetupStatePathForCurrentUser() =>
+        Path.Combine(ResolveLocalDataPath(), "setup-state.json");
+
+    public void RunStarted(LocalGatewaySetupState state, LocalGatewaySetupOptions options)
+    {
+        EnsureRunInitialized(state);
+        Write(new SetupDiagnosticRecord(
+            Event: "run_started",
+            Level: "info",
+            RunId: state.RunId,
+            InstallId: state.InstallId,
+            Status: state.Status.ToString(),
+            Message: "Local easy-button setup started.",
+            Details: new Dictionary<string, object?>
+            {
+                ["distro_name"] = options.DistroName,
+                ["gateway_url"] = SetupDiagnosticsRedactor.SanitizeText(LocalGatewayEndpointResolver.BuildLoopbackGatewayUrl(options)),
+                ["gateway_port"] = options.GatewayPort,
+                ["openclaw_install_version"] = options.OpenClawInstallVersion,
+                ["allow_existing_distro"] = options.AllowExistingDistro,
+                ["enable_windows_tray_node"] = options.EnableWindowsTrayNodeByDefault,
+                ["os_version"] = Environment.OSVersion.VersionString,
+                ["process_architecture"] = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture.ToString(),
+                ["os_architecture"] = System.Runtime.InteropServices.RuntimeInformation.OSArchitecture.ToString(),
+                ["dotnet_runtime"] = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription,
+                ["is_64_bit_os"] = Environment.Is64BitOperatingSystem,
+                ["is_elevated"] = IsElevated(),
+                ["setup_state_path"] = SetupStatePathForCurrentUser(),
+                ["tray_log_path"] = Logger.LogFilePath
+            }));
+    }
+
+    public void RunCompleted(LocalGatewaySetupState state, TimeSpan duration)
+    {
+        EnsureRunInitialized(state);
+        var failed = state.Status is LocalGatewaySetupStatus.FailedRetryable
+            or LocalGatewaySetupStatus.FailedTerminal
+            or LocalGatewaySetupStatus.Blocked;
+        Write(new SetupDiagnosticRecord(
+            Event: failed ? "run_failed" : "run_completed",
+            Level: failed ? "error" : "info",
+            RunId: state.RunId,
+            InstallId: state.InstallId,
+            Phase: state.Phase.ToString(),
+            VisibleStage: GetVisibleStage(state.Phase),
+            Status: state.Status.ToString(),
+            Message: state.UserMessage,
+            FailureCode: state.FailureCode,
+            Retryable: state.Status == LocalGatewaySetupStatus.FailedRetryable,
+            DurationMs: duration.TotalMilliseconds,
+            Details: BuildStateDetails(state)));
+        WriteSummary(state, duration);
+    }
+
+    public void PhaseStarted(LocalGatewaySetupState state, LocalGatewaySetupPhase phase, string message)
+    {
+        EnsureRunInitialized(state);
+        Write(new SetupDiagnosticRecord(
+            Event: "phase_started",
+            Level: "info",
+            RunId: state.RunId,
+            InstallId: state.InstallId,
+            Phase: phase.ToString(),
+            VisibleStage: GetVisibleStage(phase),
+            Status: state.Status.ToString(),
+            Message: message));
+    }
+
+    public void PhaseCompleted(LocalGatewaySetupState state, LocalGatewaySetupPhase phase, string message, TimeSpan duration)
+    {
+        EnsureRunInitialized(state);
+        var failed = state.Status is LocalGatewaySetupStatus.FailedRetryable
+            or LocalGatewaySetupStatus.FailedTerminal
+            or LocalGatewaySetupStatus.Blocked
+            or LocalGatewaySetupStatus.Cancelled;
+        Write(new SetupDiagnosticRecord(
+            Event: failed ? "phase_failed" : "phase_succeeded",
+            Level: failed ? "error" : "info",
+            RunId: state.RunId,
+            InstallId: state.InstallId,
+            Phase: phase.ToString(),
+            VisibleStage: GetVisibleStage(phase),
+            Status: state.Status.ToString(),
+            Message: failed ? state.UserMessage : message,
+            FailureCode: state.FailureCode,
+            Retryable: state.Status == LocalGatewaySetupStatus.FailedRetryable,
+            DurationMs: duration.TotalMilliseconds,
+            Details: failed ? BuildStateDetails(state) : null));
+
+        if (failed)
+            WriteSummary(state, duration);
+    }
+
+    public string CommandStarted(string fileName, IReadOnlyList<string> arguments, TimeSpan timeout)
+    {
+        var commandId = Guid.NewGuid().ToString("N")[..12];
+        Write(new SetupDiagnosticRecord(
+            Event: "command_started",
+            Level: "debug",
+            RunId: _runId,
+            InstallId: _installId,
+            Message: fileName,
+            Details: new Dictionary<string, object?>
+            {
+                ["command_id"] = commandId,
+                ["file_name"] = fileName,
+                ["arguments"] = SetupDiagnosticsRedactor.RedactArguments(arguments),
+                ["timeout_ms"] = timeout.TotalMilliseconds
+            }));
+        return commandId;
+    }
+
+    public void CommandCompleted(string commandId, string fileName, IReadOnlyList<string> arguments, TimeSpan duration, WslCommandResult result, bool timedOut)
+    {
+        var stdout = SetupDiagnosticsRedactor.SanitizeCommandOutput(result.StandardOutput, MaxCommandOutputChars, out var stdoutTruncated);
+        var stderr = SetupDiagnosticsRedactor.SanitizeCommandOutput(result.StandardError, MaxCommandOutputChars, out var stderrTruncated);
+        Write(new SetupDiagnosticRecord(
+            Event: result.Success && !timedOut ? "command_succeeded" : "command_failed",
+            Level: result.Success && !timedOut ? "debug" : "warn",
+            RunId: _runId,
+            InstallId: _installId,
+            Message: fileName,
+            DurationMs: duration.TotalMilliseconds,
+            Details: new Dictionary<string, object?>
+            {
+                ["command_id"] = commandId,
+                ["file_name"] = fileName,
+                ["arguments"] = SetupDiagnosticsRedactor.RedactArguments(arguments),
+                ["exit_code"] = result.ExitCode,
+                ["timed_out"] = timedOut,
+                ["stdout"] = stdout,
+                ["stdout_truncated"] = stdoutTruncated,
+                ["stderr"] = stderr,
+                ["stderr_truncated"] = stderrTruncated
+            }));
+    }
+
+    public void InstallerEvent(LocalGatewaySetupPhase phase, OpenClawLinuxInstallerEvent installerEvent)
+    {
+        Write(new SetupDiagnosticRecord(
+            Event: "installer_event",
+            Level: "info",
+            RunId: _runId,
+            InstallId: _installId,
+            Phase: phase.ToString(),
+            VisibleStage: GetVisibleStage(phase),
+            Message: SetupDiagnosticsRedactor.SanitizeText(installerEvent.Message ?? installerEvent.RawLine),
+            Details: new Dictionary<string, object?>
+            {
+                ["installer_event"] = SetupDiagnosticsRedactor.SanitizeText(installerEvent.Event),
+                ["installer_phase"] = SetupDiagnosticsRedactor.SanitizeText(installerEvent.Phase),
+                ["raw_line"] = SetupDiagnosticsRedactor.SanitizeText(installerEvent.RawLine)
+            }));
+    }
+
+    public void LifecycleStarted(string operation)
+    {
+        EnsureLifecycleInitialized(operation);
+        Write(new SetupDiagnosticRecord(
+            Event: "lifecycle_started",
+            Level: "info",
+            RunId: _runId,
+            InstallId: _installId,
+            Message: operation));
+    }
+
+    public void LifecycleStep(string operation, string step, bool success, string? errorCode = null, string? errorMessage = null)
+    {
+        Write(new SetupDiagnosticRecord(
+            Event: success ? "lifecycle_step_succeeded" : "lifecycle_step_failed",
+            Level: success ? "info" : "error",
+            RunId: _runId,
+            InstallId: _installId,
+            Message: step,
+            FailureCode: errorCode,
+            Details: new Dictionary<string, object?>
+            {
+                ["operation"] = operation,
+                ["step"] = step,
+                ["error_message"] = SetupDiagnosticsRedactor.SanitizeText(errorMessage)
+            }));
+    }
+
+    public void LifecycleCompleted(string operation, LocalGatewayLifecycleResult result, TimeSpan duration)
+    {
+        Write(new SetupDiagnosticRecord(
+            Event: result.Success ? "lifecycle_completed" : "lifecycle_failed",
+            Level: result.Success ? "info" : "error",
+            RunId: _runId,
+            InstallId: _installId,
+            Message: operation,
+            FailureCode: result.ErrorCode,
+            Retryable: !result.Success,
+            DurationMs: duration.TotalMilliseconds,
+            Details: new Dictionary<string, object?>
+            {
+                ["operation"] = operation,
+                ["error_message"] = SetupDiagnosticsRedactor.SanitizeText(result.ErrorMessage),
+                ["steps"] = result.Steps ?? Array.Empty<string>()
+            }));
+        WriteLifecycleSummary(operation, result, duration);
+    }
+
+    public Task FlushAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
+    }
+
+    private void EnsureRunInitialized(LocalGatewaySetupState state)
+    {
+        lock (_lock)
+        {
+            if (_initialized
+                && string.Equals(_runId, state.RunId, StringComparison.Ordinal)
+                && string.Equals(_installId, state.InstallId, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            Directory.CreateDirectory(_setupLogDirectory);
+            _runId = state.RunId;
+            _installId = state.InstallId;
+            var timestamp = DateTimeOffset.UtcNow.ToString("yyyyMMdd-HHmmss");
+            var shortRunId = string.IsNullOrWhiteSpace(state.RunId)
+                ? Guid.NewGuid().ToString("N")[..12]
+                : state.RunId[..Math.Min(12, state.RunId.Length)];
+            RunTracePath = Path.Combine(_setupLogDirectory, $"setup-{timestamp}-{shortRunId}.jsonl");
+            SafeDelete(LatestTracePath);
+            SafeDelete(LatestSummaryPath);
+            _records.Clear();
+            _initialized = true;
+        }
+    }
+
+    private void EnsureLifecycleInitialized(string operation)
+    {
+        lock (_lock)
+        {
+            Directory.CreateDirectory(_setupLogDirectory);
+            _runId = Guid.NewGuid().ToString("N");
+            _installId = null;
+            var timestamp = DateTimeOffset.UtcNow.ToString("yyyyMMdd-HHmmss");
+            var operationSlug = string.IsNullOrWhiteSpace(operation)
+                ? "lifecycle"
+                : string.Concat(operation.Where(char.IsLetterOrDigit)).ToLowerInvariant();
+            if (string.IsNullOrWhiteSpace(operationSlug))
+                operationSlug = "lifecycle";
+            RunTracePath = Path.Combine(_setupLogDirectory, $"setup-{timestamp}-{operationSlug}-{_runId[..12]}.jsonl");
+            SafeDelete(LatestTracePath);
+            SafeDelete(LatestSummaryPath);
+            _records.Clear();
+            _initialized = true;
+        }
+    }
+
+    private void Write(SetupDiagnosticRecord record)
+    {
+        lock (_lock)
+        {
+            if (RunTracePath is null || LatestTracePath is null)
+                return;
+
+            var sanitized = record.Sanitized();
+            _records.Add(sanitized);
+            if (_records.Count > MaxStoredRecords)
+                _records.RemoveAt(0);
+
+            var line = SetupDiagnosticsRedactor.SanitizeText(JsonSerializer.Serialize(sanitized, s_jsonOptions)) ?? "{}";
+            File.AppendAllText(RunTracePath, line + Environment.NewLine, Encoding.UTF8);
+            File.AppendAllText(LatestTracePath, line + Environment.NewLine, Encoding.UTF8);
+        }
+    }
+
+    private void WriteSummary(LocalGatewaySetupState state, TimeSpan duration)
+    {
+        lock (_lock)
+        {
+            if (LatestSummaryPath is null)
+                return;
+
+            Directory.CreateDirectory(_setupLogDirectory);
+            File.WriteAllText(LatestSummaryPath, BuildSummary(state, duration), Encoding.UTF8);
+        }
+    }
+
+    private void WriteLifecycleSummary(string operation, LocalGatewayLifecycleResult result, TimeSpan duration)
+    {
+        lock (_lock)
+        {
+            if (LatestSummaryPath is null)
+                return;
+
+            Directory.CreateDirectory(_setupLogDirectory);
+            File.WriteAllText(LatestSummaryPath, BuildLifecycleSummary(operation, result, duration), Encoding.UTF8);
+        }
+    }
+
+    private string BuildSummary(LocalGatewaySetupState state, TimeSpan duration)
+    {
+        var failed = state.Status is LocalGatewaySetupStatus.FailedRetryable
+            or LocalGatewaySetupStatus.FailedTerminal
+            or LocalGatewaySetupStatus.Blocked;
+        var sb = new StringBuilder();
+        sb.AppendLine("OpenClaw easy setup diagnostics");
+        sb.AppendLine($"Outcome: {(failed ? "FAILED" : state.Status.ToString().ToUpperInvariant())}");
+        if (failed)
+        {
+            sb.AppendLine($"Failed phase: {LastRunningPhase(state)}");
+            if (!string.IsNullOrWhiteSpace(state.FailureCode))
+                sb.AppendLine($"Failure code: {SetupDiagnosticsRedactor.SanitizeText(state.FailureCode)}");
+            if (!string.IsNullOrWhiteSpace(state.UserMessage))
+                sb.AppendLine($"Message: {SetupDiagnosticsRedactor.SanitizeText(state.UserMessage)}");
+            sb.AppendLine($"Retryable: {state.Status == LocalGatewaySetupStatus.FailedRetryable}");
+        }
+        sb.AppendLine($"Run ID: {state.RunId}");
+        sb.AppendLine($"Install ID: {state.InstallId}");
+        sb.AppendLine($"Updated UTC: {DateTimeOffset.UtcNow:O}");
+        sb.AppendLine($"Duration: {duration.TotalSeconds:F1}s");
+        sb.AppendLine($"Summary: {LatestSummaryPath}");
+        sb.AppendLine($"JSONL trace: {LatestTracePath}");
+        sb.AppendLine($"Per-run JSONL trace: {RunTracePath}");
+        sb.AppendLine($"Tray log: {Logger.LogFilePath}");
+        sb.AppendLine($"Setup state: {SetupStatePathForCurrentUser()}");
+        sb.AppendLine();
+        sb.AppendLine("Phase timeline:");
+        foreach (var record in _records.Where(r => r.Event is "phase_succeeded" or "phase_failed"))
+        {
+            var mark = record.Event == "phase_succeeded" ? "OK" : "FAILED";
+            var phase = record.Phase ?? "(unknown)";
+            var visible = string.IsNullOrWhiteSpace(record.VisibleStage) ? "" : $" [{record.VisibleStage}]";
+            var ms = record.DurationMs is null ? "" : $" {record.DurationMs.Value:F0}ms";
+            sb.AppendLine($"- {mark} {phase}{visible}{ms} - {SetupDiagnosticsRedactor.SanitizeText(record.Message)}");
+        }
+        if (failed)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Next actions:");
+            foreach (var action in BuildNextActions(state))
+                sb.AppendLine($"- {action}");
+        }
+        return sb.ToString();
+    }
+
+    private string BuildLifecycleSummary(string operation, LocalGatewayLifecycleResult result, TimeSpan duration)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("OpenClaw easy setup diagnostics");
+        sb.AppendLine($"Outcome: {(result.Success ? "COMPLETE" : "FAILED")}");
+        sb.AppendLine($"Gateway lifecycle operation: {SetupDiagnosticsRedactor.SanitizeText(operation)}");
+        if (!result.Success)
+        {
+            if (!string.IsNullOrWhiteSpace(result.ErrorCode))
+                sb.AppendLine($"Failure code: {SetupDiagnosticsRedactor.SanitizeText(result.ErrorCode)}");
+            if (!string.IsNullOrWhiteSpace(result.ErrorMessage))
+                sb.AppendLine($"Message: {SetupDiagnosticsRedactor.SanitizeText(result.ErrorMessage)}");
+        }
+        sb.AppendLine($"Run ID: {_runId}");
+        sb.AppendLine($"Updated UTC: {DateTimeOffset.UtcNow:O}");
+        sb.AppendLine($"Duration: {duration.TotalSeconds:F1}s");
+        sb.AppendLine($"Summary: {LatestSummaryPath}");
+        sb.AppendLine($"JSONL trace: {LatestTracePath}");
+        sb.AppendLine($"Per-run JSONL trace: {RunTracePath}");
+        sb.AppendLine($"Tray log: {Logger.LogFilePath}");
+        sb.AppendLine();
+        sb.AppendLine("Lifecycle timeline:");
+        foreach (var record in _records.Where(r => r.Event is "lifecycle_step_succeeded" or "lifecycle_step_failed"))
+        {
+            var mark = record.Event == "lifecycle_step_succeeded" ? "OK" : "FAILED";
+            sb.AppendLine($"- {mark} {SetupDiagnosticsRedactor.SanitizeText(record.Message)}");
+        }
+        if (!result.Success)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Next actions:");
+            sb.AppendLine($"- Open setup JSONL trace: {LatestTracePath}");
+            sb.AppendLine($"- Open tray log: {Logger.LogFilePath}");
+            if (string.Join(" ", result.ErrorCode, result.ErrorMessage).Contains("wsl", StringComparison.OrdinalIgnoreCase)
+                || string.Join(" ", result.ErrorCode, result.ErrorMessage).Contains("gateway", StringComparison.OrdinalIgnoreCase))
+            {
+                sb.AppendLine("- If WSL diagnostics are needed, follow aka.ms/wsllogs.");
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static Dictionary<string, object?> BuildStateDetails(LocalGatewaySetupState state)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["issues"] = state.Issues.Select(issue => new Dictionary<string, object?>
+            {
+                ["code"] = SetupDiagnosticsRedactor.SanitizeText(issue.Code),
+                ["message"] = SetupDiagnosticsRedactor.SanitizeText(issue.Message),
+                ["severity"] = issue.Severity.ToString(),
+                ["detail"] = SetupDiagnosticsRedactor.SanitizeText(issue.Detail)
+            }).ToArray(),
+            ["next_actions"] = BuildNextActions(state)
+        };
+    }
+
+    private static string[] BuildNextActions(LocalGatewaySetupState state)
+    {
+        var actions = new List<string>
+        {
+            $"Open setup summary: {LatestSummaryPathForCurrentUser()}",
+            $"Open setup JSONL trace: {Path.Combine(ResolveLocalDataPath(), "Logs", "Setup", "easy-setup-latest.jsonl")}",
+            $"Open tray log: {Logger.LogFilePath}"
+        };
+
+        var text = string.Join(" ", new[] { state.FailureCode, state.UserMessage }.Where(s => !string.IsNullOrWhiteSpace(s)));
+        if (text.Contains("wsl", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("gateway", StringComparison.OrdinalIgnoreCase)
+            || state.Issues.Any(issue => issue.Message.Contains("aka.ms/wsllogs", StringComparison.OrdinalIgnoreCase)))
+        {
+            actions.Add("If WSL diagnostics are needed, follow aka.ms/wsllogs.");
+        }
+
+        return actions.ToArray();
+    }
+
+    private static string? GetVisibleStage(LocalGatewaySetupPhase phase)
+    {
+        var index = LocalSetupProgressStageMap.IndexOfStageForPhase(phase);
+        return index >= 0 ? LocalSetupProgressStageMap.VisibleStages[index].LabelKey : null;
+    }
+
+    private static LocalGatewaySetupPhase LastRunningPhase(LocalGatewaySetupState state)
+    {
+        for (var i = state.History.Count - 1; i >= 0; i--)
+        {
+            var phase = state.History[i].Phase;
+            if (phase is not LocalGatewaySetupPhase.Failed
+                and not LocalGatewaySetupPhase.Cancelled
+                and not LocalGatewaySetupPhase.NotStarted)
+            {
+                return phase;
+            }
+        }
+
+        return state.Phase;
+    }
+
+    private static bool IsElevated()
+    {
+        if (!OperatingSystem.IsWindows())
+            return false;
+
+        try
+        {
+            using var identity = WindowsIdentity.GetCurrent();
+            var principal = new WindowsPrincipal(identity);
+            return principal.IsInRole(WindowsBuiltInRole.Administrator);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static void SafeDelete(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return;
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+}
+
+internal sealed record SetupDiagnosticRecord(
+    [property: JsonPropertyName("event")] string Event,
+    [property: JsonPropertyName("level")] string Level,
+    [property: JsonPropertyName("run_id")] string? RunId,
+    [property: JsonPropertyName("install_id")] string? InstallId,
+    [property: JsonPropertyName("timestamp_utc")] DateTimeOffset? TimestampUtc = null,
+    [property: JsonPropertyName("phase")] string? Phase = null,
+    [property: JsonPropertyName("visible_stage")] string? VisibleStage = null,
+    [property: JsonPropertyName("status")] string? Status = null,
+    [property: JsonPropertyName("message")] string? Message = null,
+    [property: JsonPropertyName("failure_code")] string? FailureCode = null,
+    [property: JsonPropertyName("retryable")] bool? Retryable = null,
+    [property: JsonPropertyName("duration_ms")] double? DurationMs = null,
+    [property: JsonPropertyName("details")] IReadOnlyDictionary<string, object?>? Details = null)
+{
+    [JsonPropertyName("schema_version")]
+    public int SchemaVersion => LocalGatewaySetupDiagnosticsService.SchemaVersion;
+
+    public SetupDiagnosticRecord Sanitized() => this with
+    {
+        TimestampUtc = TimestampUtc ?? DateTimeOffset.UtcNow,
+        RunId = SetupDiagnosticsRedactor.SanitizeText(RunId),
+        InstallId = SetupDiagnosticsRedactor.SanitizeText(InstallId),
+        Phase = SetupDiagnosticsRedactor.SanitizeText(Phase),
+        VisibleStage = SetupDiagnosticsRedactor.SanitizeText(VisibleStage),
+        Status = SetupDiagnosticsRedactor.SanitizeText(Status),
+        Message = SetupDiagnosticsRedactor.SanitizeText(Message),
+        FailureCode = SetupDiagnosticsRedactor.SanitizeText(FailureCode),
+        Details = SetupDiagnosticsRedactor.SanitizeDictionary(Details)
+    };
+}
+
+internal static partial class SetupDiagnosticsRedactor
+{
+    private static readonly string[] SecretValueFlags =
+    [
+        "--token",
+        "--bootstrap-token",
+        "--operator-token",
+        "--device-token",
+        "--setup-code",
+        "--password",
+        "--pass",
+        "--key",
+        "--private-key",
+        "--auth"
+    ];
+
+    [GeneratedRegex(@"(?i)(https?|wss?)://([^/\s:@]+):([^@\s/]+)@")]
+    private static partial Regex UrlCredentialRegex();
+
+    [GeneratedRegex(@"-----BEGIN [A-Z ]*(?:PRIVATE|PUBLIC) KEY-----.*?-----END [A-Z ]*(?:PRIVATE|PUBLIC) KEY-----", RegexOptions.Singleline)]
+    private static partial Regex PrivateKeyRegex();
+
+    [GeneratedRegex(@"eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+")]
+    private static partial Regex JwtRegex();
+
+    [GeneratedRegex(@"(?i)(OPENCLAW_[A-Z0-9_]*(?:TOKEN|SECRET|KEY)|(?:setup[_-]?code|bootstrap[_-]?token|device[_-]?token|gateway[_-]?token|auth[_-]?token|private[_-]?key|password|secret))([^\r\n\S]*[:=][^\r\n\S]*)([^\s,;""'}]+)")]
+    private static partial Regex KeyValueSecretRegex();
+
+    public static string? SanitizeText(string? value)
+    {
+        if (value is null)
+            return null;
+
+        var sanitized = value.Replace("\0", string.Empty, StringComparison.Ordinal);
+        sanitized = PrivateKeyRegex().Replace(sanitized, "<redacted-private-key>");
+        sanitized = JwtRegex().Replace(sanitized, "<redacted-jwt>");
+        sanitized = UrlCredentialRegex().Replace(sanitized, "$1://<redacted>@");
+        sanitized = KeyValueSecretRegex().Replace(sanitized, "$1$2<redacted>");
+        sanitized = TokenSanitizer.Sanitize(SecretRedactor.Redact(sanitized));
+        return sanitized;
+    }
+
+    public static IReadOnlyList<string> RedactArguments(IReadOnlyList<string> arguments)
+    {
+        var redacted = new List<string>(arguments.Count);
+        var redactNext = false;
+        foreach (var argument in arguments)
+        {
+            if (redactNext)
+            {
+                redacted.Add("<redacted>");
+                redactNext = false;
+                continue;
+            }
+
+            var equalsIndex = argument.IndexOf('=');
+            var flagName = equalsIndex > 0 ? argument[..equalsIndex] : argument;
+            if (IsSecretFlag(flagName))
+            {
+                if (equalsIndex > 0)
+                    redacted.Add(argument[..(equalsIndex + 1)] + "<redacted>");
+                else
+                {
+                    redacted.Add(argument);
+                    redactNext = true;
+                }
+                continue;
+            }
+
+            redacted.Add(SanitizeText(argument) ?? string.Empty);
+        }
+
+        return redacted;
+    }
+
+    public static string? SanitizeCommandOutput(string? value, int maxChars, out bool truncated)
+    {
+        truncated = false;
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        var retained = value;
+        if (retained.Length > maxChars)
+        {
+            retained = retained[^maxChars..];
+            truncated = true;
+        }
+
+        return SanitizeText(retained.Trim());
+    }
+
+    public static IReadOnlyDictionary<string, object?>? SanitizeDictionary(IReadOnlyDictionary<string, object?>? details)
+    {
+        if (details is null)
+            return null;
+
+        var sanitized = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var pair in details)
+            sanitized[pair.Key] = SanitizeValue(pair.Value);
+        return sanitized;
+    }
+
+    private static object? SanitizeValue(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            string s => SanitizeText(s),
+            IReadOnlyDictionary<string, object?> d => SanitizeDictionary(d),
+            IEnumerable<string> strings => strings.Select(SanitizeText).ToArray(),
+            IEnumerable<object?> values => values.Select(SanitizeValue).ToArray(),
+            _ => value
+        };
+    }
+
+    private static bool IsSecretFlag(string flagName)
+    {
+        foreach (var flag in SecretValueFlags)
+        {
+            if (flagName.Equals(flag, StringComparison.OrdinalIgnoreCase)
+                || flagName.Contains("token", StringComparison.OrdinalIgnoreCase)
+                || flagName.Contains("secret", StringComparison.OrdinalIgnoreCase)
+                || flagName.Contains("password", StringComparison.OrdinalIgnoreCase)
+                || flagName.Contains("private", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/LocalGatewaySetupDiagnosticsTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalGatewaySetupDiagnosticsTests.cs
@@ -1,0 +1,154 @@
+using OpenClawTray.Services.LocalGatewaySetup;
+
+namespace OpenClaw.Tray.Tests;
+
+public class LocalGatewaySetupDiagnosticsTests
+{
+    [Fact]
+    public void Diagnostics_WritesFailureJsonlAndHumanSummary()
+    {
+        using var temp = new LocalGatewaySetupTests.TempDirectory();
+        var service = new LocalGatewaySetupDiagnosticsService(temp.Path);
+        var options = new LocalGatewaySetupOptions();
+        var state = LocalGatewaySetupState.Create(options);
+        state.RunId = "run123";
+        state.InstallId = "install456";
+
+        service.RunStarted(state, options);
+        state.StartPhase(LocalGatewaySetupPhase.Preflight, "Checking your PC");
+        service.PhaseStarted(state, LocalGatewaySetupPhase.Preflight, "Checking your PC");
+        state.Block(
+            "wsl_unavailable",
+            "WSL is unavailable. bootstrapToken: secret-token",
+            retryable: true,
+            detail: "gateway-token=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+        service.PhaseCompleted(state, LocalGatewaySetupPhase.Preflight, "Checking your PC", TimeSpan.FromMilliseconds(42));
+        service.RunCompleted(state, TimeSpan.FromMilliseconds(50));
+
+        var jsonl = File.ReadAllText(service.LatestTracePath!);
+        var summary = File.ReadAllText(service.LatestSummaryPath!);
+
+        Assert.Contains("\"schema_version\":1", jsonl);
+        Assert.Contains("\"event\":\"phase_failed\"", jsonl);
+        Assert.Contains("\"failure_code\":\"wsl_unavailable\"", jsonl);
+        Assert.DoesNotContain("secret-token", jsonl);
+        Assert.DoesNotContain("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", jsonl);
+        Assert.Contains("Outcome: FAILED", summary);
+        Assert.Contains("Failed phase: Preflight", summary);
+        Assert.Contains("Failure code: wsl_unavailable", summary);
+        Assert.Contains("easy-setup-latest.jsonl", summary);
+    }
+
+    [Fact]
+    public void Diagnostics_RedactsCommandArgumentsAndOutputOnDisk()
+    {
+        using var temp = new LocalGatewaySetupTests.TempDirectory();
+        var service = new LocalGatewaySetupDiagnosticsService(temp.Path);
+        var options = new LocalGatewaySetupOptions();
+        var state = LocalGatewaySetupState.Create(options);
+        state.RunId = "run-redact";
+        state.InstallId = "install-redact";
+        service.RunStarted(state, options);
+
+        var secretHex = "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd";
+        var commandId = service.CommandStarted(
+            "openclaw",
+            ["gateway", "status", "--token", "super-secret-token", "--password=super-secret-password"],
+            TimeSpan.FromSeconds(5));
+        service.CommandCompleted(
+            commandId,
+            "openclaw",
+            ["gateway", "status", "--token", "super-secret-token", "--password=super-secret-password"],
+            TimeSpan.FromMilliseconds(10),
+            new WslCommandResult(
+                1,
+                $"bootstrapToken: secret-token\nraw token {secretHex}",
+                "-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----"),
+            timedOut: false);
+
+        var jsonl = File.ReadAllText(service.LatestTracePath!);
+
+        Assert.DoesNotContain("super-secret-token", jsonl);
+        Assert.DoesNotContain("super-secret-password", jsonl);
+        Assert.DoesNotContain("secret-token", jsonl);
+        Assert.DoesNotContain(secretHex, jsonl);
+        Assert.DoesNotContain("BEGIN PRIVATE KEY", jsonl);
+        Assert.Contains("<redacted>", jsonl);
+    }
+
+    [Fact]
+    public async Task Engine_WritesRunAndPhaseDiagnostics_ForSuccessfulSetup()
+    {
+        using var temp = new LocalGatewaySetupTests.TempDirectory();
+        var statePath = Path.Combine(temp.Path, "setup-state.json");
+        var wsl = new LocalGatewaySetupTests.FakeWslCommandRunner();
+        var provisioning = new FakeProvisioner();
+        var diagnostics = new LocalGatewaySetupDiagnosticsService(temp.Path);
+        var engine = new LocalGatewaySetupEngine(
+            new LocalGatewaySetupOptions { InstanceInstallLocation = Path.Combine(temp.Path, "OpenClawGateway") },
+            new LocalGatewaySetupStateStore(statePath),
+            new LocalGatewayPreflightProbe(wsl, new LocalGatewaySetupTests.FixedPortProbe(available: true)),
+            wsl,
+            new LocalGatewaySetupTests.SuccessfulHealthProbe(),
+            provisioning,
+            provisioning,
+            provisioning,
+            wslInstanceInstaller: new WslStoreInstanceInstaller(wsl, createDirectory: _ => { }),
+            wslInstanceConfigurator: new LocalGatewaySetupTests.FakeWslInstanceConfigurator(),
+            openClawLinuxInstaller: new LocalGatewaySetupTests.FakeOpenClawLinuxInstaller(),
+            gatewayConfigurationPreparer: new LocalGatewaySetupTests.FakeGatewayConfigurationPreparer(),
+            gatewayServiceManager: new LocalGatewaySetupTests.FakeGatewayServiceManager(),
+            diagnosticsSink: diagnostics);
+
+        var state = await engine.RunLocalOnlyAsync();
+
+        Assert.Equal(LocalGatewaySetupStatus.Complete, state.Status);
+        var jsonl = File.ReadAllText(diagnostics.LatestTracePath!);
+        Assert.Contains("\"event\":\"run_started\"", jsonl);
+        Assert.Contains("\"event\":\"phase_started\"", jsonl);
+        Assert.Contains("\"event\":\"phase_succeeded\"", jsonl);
+        Assert.Contains("\"event\":\"run_completed\"", jsonl);
+        Assert.Contains("\"phase\":\"CreateWslInstance\"", jsonl);
+        Assert.Contains("Outcome: COMPLETE", File.ReadAllText(diagnostics.LatestSummaryPath!));
+    }
+
+    [Fact]
+    public async Task LifecycleManager_WritesGatewayLifecycleFailureDiagnostics()
+    {
+        using var temp = new LocalGatewaySetupTests.TempDirectory();
+        var diagnostics = new LocalGatewaySetupDiagnosticsService(temp.Path);
+        var manager = new LocalGatewayLifecycleManager(
+            new LocalGatewaySetupOptions(),
+            new LocalGatewaySetupTests.FakeWslCommandRunner(),
+            new LocalGatewaySetupTests.SuccessfulHealthProbe(),
+            diagnosticsSink: diagnostics);
+
+        var result = await manager.RemoveAsync(new LocalGatewayRemoveRequest(ConfirmRemove: false, ClearLocalCredentials: false));
+
+        Assert.False(result.Success);
+        var jsonl = File.ReadAllText(diagnostics.LatestTracePath!);
+        var summary = File.ReadAllText(diagnostics.LatestSummaryPath!);
+        Assert.Contains("\"event\":\"lifecycle_started\"", jsonl);
+        Assert.Contains("\"event\":\"lifecycle_step_failed\"", jsonl);
+        Assert.Contains("\"event\":\"lifecycle_failed\"", jsonl);
+        Assert.Contains("\"failure_code\":\"confirmation_required\"", jsonl);
+        Assert.Contains("Gateway lifecycle operation: remove", summary);
+        Assert.Contains("Failure code: confirmation_required", summary);
+    }
+
+    private sealed class FakeProvisioner :
+        IBootstrapTokenProvisioner, IOperatorPairingService, IWindowsTrayNodeProvisioner
+    {
+        public Task<ProvisioningResult> MintAsync(LocalGatewaySetupState state, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ProvisioningResult(true));
+
+        Task<ProvisioningResult> IOperatorPairingService.PairAsync(LocalGatewaySetupState state, CancellationToken cancellationToken) =>
+            Task.FromResult(new ProvisioningResult(true));
+
+        Task<ProvisioningResult> IWindowsTrayNodeProvisioner.CheckReadinessAsync(LocalGatewaySetupState state, CancellationToken cancellationToken) =>
+            Task.FromResult(new ProvisioningResult(true));
+
+        Task<ProvisioningResult> IWindowsTrayNodeProvisioner.PairAsync(LocalGatewaySetupState state, CancellationToken cancellationToken) =>
+            Task.FromResult(new ProvisioningResult(true));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Onboarding\Services\LocalSetupProgressStageMap.cs" Link="Imported\LocalSetupProgressStageMap.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\GatewayChatUrlBuilder.cs" Link="Imported\GatewayChatUrlBuilder.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Onboarding\Services\LocalGatewayApprover.cs" Link="Imported\LocalGatewayApprover.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\LocalGatewaySetup\LocalGatewaySetupDiagnostics.cs" Link="Imported\LocalGatewaySetupDiagnostics.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\LocalGatewaySetup\LocalGatewaySetup.cs" Link="Imported\LocalGatewaySetup.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\LocalGatewaySetup\LocalGatewayUninstall.cs" Link="Imported\LocalGatewayUninstall.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Onboarding\Services\GatewayHealthCheck.cs" Link="Imported\GatewayHealthCheck.cs" />


### PR DESCRIPTION
## Summary
- Adds a setup-specific diagnostics sink for the easy-button local gateway install, pairing, gateway health, repair, and remove lifecycle.
- Writes a human-readable latest summary plus machine-readable JSONL traces under `%LOCALAPPDATA%\OpenClawTray\Logs\Setup\`.
- Redacts setup codes, tokens, key material, URL credentials, secret argv values, and command output before writing diagnostics to disk.
- Surfaces the setup summary path in V2 onboarding failures and documents the new troubleshooting files.

## Debug artifacts for affected users
- Human summary: `%LOCALAPPDATA%\OpenClawTray\Logs\Setup\easy-setup-latest.txt`
- Latest JSONL trace: `%LOCALAPPDATA%\OpenClawTray\Logs\Setup\easy-setup-latest.jsonl`
- Per-run JSONL traces: `%LOCALAPPDATA%\OpenClawTray\Logs\Setup\setup-*.jsonl`
- Existing tray log remains: `%LOCALAPPDATA%\OpenClawTray\openclaw-tray.log`

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — 1803 passed, 28 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — 1153 passed

Draft PR so someone hitting setup/pairing/gateway failures can install/test this branch and share the redacted diagnostics artifacts for debugging.