### PR TITLE
polish(tray/chat): replace reconnecting spinner with skeleton timeline + composer

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/Explorations/ChatExplorationState.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/Explorations/ChatExplorationState.cs
@@ -85,6 +85,14 @@ public enum ChatPreviewState
     Thinking,
     /// <summary>Composer shows the tool-permission banner with Allow/Deny.</summary>
     PendingPermission,
+    /// <summary>
+    /// Force the pre-connect "Reconnecting to your last conversation…"
+    /// banner that <see cref="OpenClaw.Tray.WinUI.Chat.OpenClawChatRoot"/>
+    /// renders when <c>effectiveThread</c> is null because the gateway
+    /// handshake hasn't completed yet. Lets designers see the banner
+    /// without having to actually disconnect.
+    /// </summary>
+    Reconnecting,
 }
 
 public enum ChatComposerLayout

--- a/src/OpenClaw.Tray.WinUI/Chat/Explorations/ChatExplorationsPanel.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/Explorations/ChatExplorationsPanel.cs
@@ -215,7 +215,8 @@ public class ChatExplorationsPanel : Component
                 ChatPreviewState.Loading,
                 ChatPreviewState.Empty,
                 ChatPreviewState.Thinking,
-                ChatPreviewState.PendingPermission)
+                ChatPreviewState.PendingPermission,
+                ChatPreviewState.Reconnecting)
         );
 
         // ── H. Tool burst (multi-step task framing) ──────────────────

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -114,6 +114,14 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     // <see cref="ChatTimelineItem"/> record.
     private readonly Dictionary<string, Dictionary<string, ChatEntryMetadata>> _entryMeta = new();
     private SessionInfo[] _sessions = Array.Empty<SessionInfo>();
+    // True once the gateway has delivered a sessions list (even an empty
+    // one) for the current connection. Used to gate the synthetic
+    // compose-only thread so the UI doesn't briefly render the welcome
+    // zero-state in the window between hello-ok (HasHandshakeSnapshot)
+    // and the first sessions.list — at that point the gateway may still
+    // be about to deliver real sessions for a returning user. Reset to
+    // false on disconnect alongside `_status`.
+    private bool _sessionsListReceived;
     private string[] _availableModels = Array.Empty<string>();
     private ConnectionStatus _status;
     private bool _disposed;
@@ -852,6 +860,13 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                                    && _status == ConnectionStatus.Connected;
             _status = status;
 
+            // Reset the sessions-list-received gate whenever we leave the
+            // Connected state. Any cached sessions belong to the previous
+            // connection; the UI must treat the composer as not-yet-ready
+            // until the next sessions.list arrives.
+            if (status != ConnectionStatus.Connected)
+                _sessionsListReceived = false;
+
             // On (re)connect, reload any thread that either previously loaded
             // successfully or has a timeline but never completed loading.
             // The second case covers initial connect: the UI may have created
@@ -920,6 +935,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         lock (_gate)
         {
             _sessions = sessions ?? Array.Empty<SessionInfo>();
+            _sessionsListReceived = true;
             EnsureTimelinesForSessionsLocked();
             snapshot = BuildSnapshotLocked();
 
@@ -2101,7 +2117,12 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     {
         if (!_timelines.TryGetValue(threadId, out var current))
         {
-            current = ChatTimelineState.Initial() with { HistoryLoaded = true };
+            // HistoryLoaded stays false until LoadHistoryAsync rebuilds
+            // the timeline from the gateway. The UI relies on this flag
+            // to distinguish "session exists, history still fetching"
+            // (show reconnecting view) from "session truly empty"
+            // (show welcome zero-state).
+            current = ChatTimelineState.Initial();
             _timelines[threadId] = current;
         }
         return current;
@@ -2113,7 +2134,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         {
             if (string.IsNullOrEmpty(s.Key)) continue;
             if (!_timelines.ContainsKey(s.Key))
-                _timelines[s.Key] = ChatTimelineState.Initial() with { HistoryLoaded = true };
+                _timelines[s.Key] = ChatTimelineState.Initial();
         }
     }
 
@@ -2131,7 +2152,12 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         var composeKey = _bridge.MainSessionKey;
         var composeReady = _bridge.HasHandshakeSnapshot
             && !string.IsNullOrWhiteSpace(composeKey)
-            && _status == ConnectionStatus.Connected;
+            && _status == ConnectionStatus.Connected
+            // Wait until sessions.list has been delivered for this
+            // connection — otherwise the UI may synthesize a compose-only
+            // thread (and render the welcome zero-state) in the brief
+            // window before a returning user's real sessions arrive.
+            && _sessionsListReceived;
 
         // If the compose target hasn't materialized as a real session yet but
         // already has an optimistic timeline (because the user sent a message

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
@@ -364,20 +364,138 @@ public sealed class OpenClawChatRoot : Component
                     ToolName: "shell",
                     Detail: "Run `git status` in the current repo.");
                 break;
+
+            case ChatPreviewState.Reconnecting:
+                // Force the skeleton-timeline body that the real chat
+                // surface renders when effectiveThread is null or history
+                // hasn't loaded. Use the same body override path so the
+                // rest of the layout (composer suppressed) matches
+                // production.
+                bodyOverride = RenderSkeletonTimeline();
+                suppressComposer = true;
+                break;
         }
 
-        // Production zero-state: triggered both when no thread is selected
-        // *and* when a thread is selected but has no messages yet. These were
-        // previously two distinct screens (PlaceholderEmptyState vs an empty
-        // OpenClawChatTimeline) but render identically now — the user only
-        // cares "this conversation is empty, what do I do?", not whether a
-        // thread record exists in the backend.
+        // Production zero-state: triggered when a thread is selected
+        // but has no messages yet (true "empty conversation"). We only
+        // surface the welcome zero-state once we're confident the
+        // conversation is genuinely empty — i.e. either the thread is
+        // the synthetic compose-only thread (fresh install, no real
+        // session yet) or `chat.history` has actually completed
+        // (timeline.HistoryLoaded). For a real session whose history is
+        // still being fetched, fall back to the reconnecting view so
+        // the welcome screen doesn't flicker on top of an as-yet
+        // unloaded timeline. See OpenClawChatDataProvider.HistoryLoaded
+        // — set to true only inside LoadHistoryAsync's rebuild.
         var isEmptyConversation = entries.Count == 0
             && !showThinking
             && pendingPermissionOverride is null;
+        var isComposeOnlyThread = composeOnlyThread is not null
+            && ReferenceEquals(effectiveThread, composeOnlyThread);
+        var gatewayConnected = string.Equals(connState, "connected", StringComparison.Ordinal);
+        // Raw eligibility: would we *otherwise* render the welcome zero-state
+        // right now? We still need this signal to drive the settling effect
+        // below, but the actual decision to render welcome is gated on
+        // `welcomeSettledState` so a brief, race-driven eligibility window
+        // (e.g. an empty sessions.list briefly arriving before the populated
+        // one for a returning user) never flashes the suggestion buttons.
+        //
+        // Two distinct paths qualify for welcome:
+        //   1. Fresh install — the synthetic compose-only thread is selected
+        //      AND the snapshot truly has no real threads yet. If real
+        //      threads exist but the compose-only thread is *briefly*
+        //      selected during a session-switch race, we explicitly do NOT
+        //      qualify — that's the case that previously flashed welcome
+        //      on returning users.
+        //   2. Returning user with an empty real session — a real thread is
+        //      selected and its history has fully loaded (HistoryLoaded=true)
+        //      but contains zero messages.
+        var hasRealThreads = snapshot.Threads.Length > 0;
+        var welcomeEligibleRaw = isEmptyConversation
+            && gatewayConnected
+            && (
+                (isComposeOnlyThread && !hasRealThreads)
+                || (!isComposeOnlyThread && timeline.HistoryLoaded)
+            );
 
-        Element body = bodyOverride ?? (effectiveThread is null || isEmptyConversation
-            ? RenderZeroState(suggestion =>
+        // Settling debounce: only promote to "authoritative" once the
+        // welcome-eligible signal has been stable for ~800ms. This protects
+        // against transient mid-handshake windows where threads briefly
+        // appear empty, ComposeTarget becomes ready, and the synthetic
+        // compose-only thread otherwise tricks the renderer into showing the
+        // suggestion buttons before the real session list lands. Fresh-
+        // install users still see the welcome screen — just ~800ms after
+        // connect — which is still well within perceived "loading" time.
+        // 800ms (up from 300ms) absorbs gateway sequences where an empty
+        // sessions.list precedes the populated one by several hundred ms.
+        var welcomeSettledState = UseState<bool>(false);
+        UseEffect((Func<Action>)(() =>
+        {
+            if (!welcomeEligibleRaw)
+            {
+                if (welcomeSettledState.Value) welcomeSettledState.Set(false);
+                return () => { };
+            }
+            // Schedule the promote-to-settled call once the eligibility
+            // window has been stable for the debounce interval. The hook
+            // dependency key includes every input that influences the
+            // welcome decision, so any change cancels the pending callback
+            // via the returned cleanup before re-arming on the next pass.
+            var dq = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+            var cancelled = false;
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await Task.Delay(800);
+                    if (cancelled) return;
+                    dq?.TryEnqueue(() => { if (!cancelled) welcomeSettledState.Set(true); });
+                }
+                catch { }
+            });
+            return () => { cancelled = true; };
+        }),
+            welcomeEligibleRaw,
+            effectiveThread?.Id ?? string.Empty,
+            isComposeOnlyThread,
+            timeline.HistoryLoaded,
+            hasRealThreads);
+
+        var emptyConversationIsAuthoritative = welcomeEligibleRaw && welcomeSettledState.Value;
+
+        Element body;
+        var bodyIsSkeleton = false;
+        if (bodyOverride is not null)
+        {
+            body = bodyOverride;
+            // Exploration preview drives bodyOverride for ChatPreviewState.Reconnecting
+            // by passing RenderSkeletonTimeline() in; piggy-back on the suppressed
+            // composer flag so the preview also shows the skeleton composer.
+            if (previewState == ChatPreviewState.Reconnecting) bodyIsSkeleton = true;
+        }
+        else if (effectiveThread is null)
+        {
+            // Pre-connect window: no real session and no compose target
+            // ready yet. Skip the welcome zero-state so returning users
+            // don't get the prompt suggestion screen while the node is
+            // still connecting. Show skeleton placeholders instead of a
+            // spinner so the surface visually resembles the chat that
+            // will land in a moment.
+            body = RenderSkeletonTimeline();
+            bodyIsSkeleton = true;
+        }
+        else if (isEmptyConversation && !emptyConversationIsAuthoritative)
+        {
+            // Real session selected but its history hasn't finished
+            // loading yet. Render skeleton message bubbles so the user
+            // sees the chat's structural shape forming up; the real
+            // entries replace the skeleton once chat.history lands.
+            body = RenderSkeletonTimeline();
+            bodyIsSkeleton = true;
+        }
+        else if (isEmptyConversation)
+        {
+            body = RenderZeroState(suggestion =>
                 {
                     if (firstSendInFlight.Value) return; // debounce double-click
                     if (effectiveThread is { } t)
@@ -385,8 +503,11 @@ public sealed class OpenClawChatRoot : Component
                         firstSendInFlight.Set(true);
                         OnSend(t.Id, suggestion, null);
                     }
-                }, suggestionsDisabled: firstSendInFlight.Value)
-            : Component<OpenClawChatTimeline, OpenClawChatTimelineProps>(new(
+                }, suggestionsDisabled: firstSendInFlight.Value);
+        }
+        else
+        {
+            body = Component<OpenClawChatTimeline, OpenClawChatTimelineProps>(new(
                 SessionId: effectiveThread.Id,
                 Entries: entries,
                 HasMoreHistory: false,
@@ -400,7 +521,8 @@ public sealed class OpenClawChatRoot : Component
                     ? (text => _onReadAloud(text))
                     : null,
                 OnStopSpeaking: _onStopSpeaking,
-                ScrollToBottomToken: scrollToBottomToken.Value)));
+                ScrollToBottomToken: scrollToBottomToken.Value));
+        }
 
         // Distinct list of channel labels (= thread titles) — feeds the
         // composer's first ComboBox so the user can switch chats from the
@@ -459,7 +581,7 @@ public sealed class OpenClawChatRoot : Component
                 RegisterVoiceStarter: starter => TriggerVoiceRecording = starter,
                 OnAttachmentPasted: att => pendingAttachment.Set(att),
                 IsCompact: _isCompact))
-            : Empty();
+            : (bodyIsSkeleton ? RenderSkeletonComposer() : Empty());
 
         var divider = Empty();
 
@@ -482,6 +604,159 @@ public sealed class OpenClawChatRoot : Component
             Model = snapshot.AvailableModels is { Length: > 0 } m ? m[0] : null,
             CreatedAt = DateTimeOffset.Now.AddMinutes(-1),
             UpdatedAt = DateTimeOffset.Now,
+        };
+    }
+
+    /// <summary>
+    /// Skeleton timeline shown in place of the welcome zero-state and the
+    /// snapshot-null loading screen while the gateway/node handshake is in
+    /// flight or <c>chat.history</c> is still being fetched. Renders a
+    /// short stack of muted, message-shaped placeholder bubbles that
+    /// alternate left/right alignment so the surface visually resembles
+    /// the timeline that will replace it once entries arrive. A returning
+    /// user therefore sees a clearly intentional "messages are loading"
+    /// affordance instead of either the first-launch prompt suggestions or
+    /// a centered spinner that has no relationship to the chat structure.
+    /// Uses a fixed 8px bubble corner radius so the skeleton matches the
+    /// composer placeholder regardless of the user's <see cref="ChatVisualResolver"/>
+    /// preset (the real bubbles intentionally rebase from their exploration
+    /// preset; this is loading chrome, not the live timeline).
+    /// </summary>
+    private static Element RenderSkeletonTimeline()
+    {
+        // Two-tier palette: a softer "bubble" fill and a marginally stronger
+        // "text line" stripe so each bubble reads as a real message with
+        // text inside. Both lean subtle — the line alpha is ~20%, the bubble
+        // ~22%, so the placeholders read on light/dark/acrylic without
+        // competing with the real timeline's visual weight.
+        var bubbleBrush = (Microsoft.UI.Xaml.Media.Brush)new Microsoft.UI.Xaml.Media.SolidColorBrush(
+            global::Windows.UI.Color.FromArgb(0x38, 0x80, 0x80, 0x80));
+        var lineBrush = (Microsoft.UI.Xaml.Media.Brush)new Microsoft.UI.Xaml.Media.SolidColorBrush(
+            global::Windows.UI.Color.FromArgb(0x35, 0x80, 0x80, 0x80));
+
+        Element Line(double width) =>
+            Border()
+                .Background(lineBrush)
+                .Set(b =>
+                {
+                    b.CornerRadius = new CornerRadius(4);
+                    b.Width = width;
+                    b.Height = 8;
+                    b.HorizontalAlignment = HorizontalAlignment.Left;
+                });
+
+        // Bubble with N subtle text-line stripes inside. lineWidths drives
+        // both line count and width variation so each bubble reads like a
+        // different message length. phaseMs staggers the shimmer pulse so
+        // the bubbles breathe one after another instead of in unison.
+        Element Bubble(double[] lineWidths, HorizontalAlignment align, double phaseMs)
+        {
+            var lines = new Element?[lineWidths.Length];
+            for (int i = 0; i < lineWidths.Length; i++) lines[i] = Line(lineWidths[i]);
+            return Border(
+                VStack(8, lines)
+            ).Background(bubbleBrush)
+             .Set(b =>
+             {
+                 b.CornerRadius = new CornerRadius(8);
+                 b.Padding = new Thickness(16, 12, 16, 12);
+                 b.HorizontalAlignment = align;
+                 b.Margin = new Thickness(16, 8, 16, 8);
+             })
+             .OnMount(MakeShimmer(phaseMs));
+        }
+
+        return Border(
+            VStack(0,
+                Bubble(new[] { 240.0, 180.0 }, HorizontalAlignment.Left, 0),
+                Bubble(new[] { 140.0 }, HorizontalAlignment.Right, 140),
+                Bubble(new[] { 280.0, 240.0, 160.0 }, HorizontalAlignment.Left, 280),
+                Bubble(new[] { 120.0 }, HorizontalAlignment.Right, 420),
+                Bubble(new[] { 200.0 }, HorizontalAlignment.Left, 560)
+            )
+        ).Set(b => b.Padding = new Thickness(0, 16, 0, 16));
+    }
+
+    /// <summary>
+    /// Skeleton composer shown at the bottom of the chat surface while the
+    /// real composer is still gated. Renders a rounded input-field placeholder
+    /// and a circular send-button placeholder, both pulsing in sync with the
+    /// skeleton bubbles above. Keeps the overall chat surface visually intact
+    /// so the layout doesn't shift when the real composer lands.
+    /// </summary>
+    private static Element RenderSkeletonComposer()
+    {
+        var bubbleBrush = (Microsoft.UI.Xaml.Media.Brush)new Microsoft.UI.Xaml.Media.SolidColorBrush(
+            global::Windows.UI.Color.FromArgb(0x30, 0x80, 0x80, 0x80));
+
+        var inputField = Border()
+            .Background(bubbleBrush)
+            .Set(b =>
+            {
+                b.CornerRadius = new CornerRadius(8);
+                b.Height = 56;
+                b.Margin = new Thickness(0, 0, 8, 0);
+                b.HorizontalAlignment = HorizontalAlignment.Stretch;
+            })
+            .OnMount(MakeShimmer(0));
+
+        var sendButton = Border()
+            .Background(bubbleBrush)
+            .Set(b =>
+            {
+                b.CornerRadius = new CornerRadius(20);
+                b.Width = 40;
+                b.Height = 40;
+                b.VerticalAlignment = VerticalAlignment.Center;
+            })
+            .OnMount(MakeShimmer(160));
+
+        return Border(
+            Grid(new[] { GridSize.Star(), GridSize.Auto }, new[] { GridSize.Auto },
+                inputField.Grid(row: 0, column: 0),
+                sendButton.Grid(row: 0, column: 1)
+            )
+        ).Set(b => b.Padding = new Thickness(16, 8, 16, 16));
+    }
+
+    /// <summary>
+    /// Builds an OnMount action that attaches a Storyboard-driven opacity
+    /// pulse to the target element. <paramref name="beginOffsetMs"/> staggers
+    /// the pulse phase so multiple bubbles wave in sequence rather than
+    /// blinking in unison. The animation auto-reverses and repeats forever;
+    /// the storyboard is dropped from scope once started but kept alive by
+    /// the visual tree via its target ref.
+    /// </summary>
+    private static Action<FrameworkElement> MakeShimmer(double beginOffsetMs)
+    {
+        return fe =>
+        {
+            try
+            {
+                var anim = new Microsoft.UI.Xaml.Media.Animation.DoubleAnimation
+                {
+                    From = 1.0,
+                    To = 0.45,
+                    Duration = new Duration(TimeSpan.FromMilliseconds(900)),
+                    AutoReverse = true,
+                    RepeatBehavior = Microsoft.UI.Xaml.Media.Animation.RepeatBehavior.Forever,
+                    EasingFunction = new Microsoft.UI.Xaml.Media.Animation.SineEase
+                    {
+                        EasingMode = Microsoft.UI.Xaml.Media.Animation.EasingMode.EaseInOut,
+                    },
+                    BeginTime = TimeSpan.FromMilliseconds(beginOffsetMs),
+                };
+                Microsoft.UI.Xaml.Media.Animation.Storyboard.SetTarget(anim, fe);
+                Microsoft.UI.Xaml.Media.Animation.Storyboard.SetTargetProperty(anim, "Opacity");
+                var sb = new Microsoft.UI.Xaml.Media.Animation.Storyboard();
+                sb.Children.Add(anim);
+                sb.Begin();
+            }
+            catch
+            {
+                // Animations are non-essential — never let a storyboard error
+                // disrupt the skeleton surface render.
+            }
         };
     }
 

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -453,6 +453,11 @@ public class OpenClawChatDataProviderTests
         bridge.HasHandshakeSnapshot = true;
         bridge.MainSessionKey = "agent:main:main";
         bridge.RaiseStatus(ConnectionStatus.Connected);
+        // Real gateways always send sessions.list after handshake (even an
+        // empty list). The provider waits for that signal before flipping
+        // ComposeTarget.IsReady on — otherwise the UI would briefly render
+        // the welcome zero-state for returning users mid-handshake.
+        bridge.RaiseSessions(Array.Empty<SessionInfo>());
         var snap = await provider.LoadAsync();
         Assert.Empty(snap.Threads);
         Assert.True(snap.ComposeTarget.IsReady);
@@ -495,6 +500,44 @@ public class OpenClawChatDataProviderTests
         Assert.NotEmpty(snapshots);
         Assert.Equal("Incompatible gateway", snapshots[^1].ConnectionStatus);
         Assert.False(snapshots[^1].ComposeTarget.IsReady);
+    }
+
+    [Fact]
+    public async Task LoadAsync_HandshakeKnownButSessionsNotYetReceived_ComposeTargetNotReady()
+    {
+        // Regression: in the brief window between hello-ok (HasHandshakeSnapshot
+        // becomes true) and the first sessions.list, the provider used to expose
+        // a ready ComposeTarget. The chat root would then synthesize a
+        // compose-only thread and render the welcome zero-state — even for a
+        // returning user whose real sessions were about to be delivered. The
+        // sessions-list-received gate keeps ComposeTarget.IsReady=false until
+        // the gateway has confirmed the session list for this connection.
+        var (bridge, provider, _, _) = CreateProvider();
+        bridge.HasHandshakeSnapshot = true;
+        bridge.MainSessionKey = "agent:main:main";
+        bridge.RaiseStatus(ConnectionStatus.Connected);
+        // No RaiseSessions yet — simulate the mid-handshake window.
+        var snap = await provider.LoadAsync();
+        Assert.Empty(snap.Threads);
+        Assert.False(snap.ComposeTarget.IsReady);
+    }
+
+    [Fact]
+    public async Task StatusDisconnected_AfterSessionsReceived_ComposeTargetResetsToNotReady()
+    {
+        // The sessions-list-received gate must reset on disconnect — otherwise
+        // a reconnect would keep ComposeTarget ready against a stale session
+        // list from the previous connection.
+        var (bridge, provider, _, _) = CreateProvider();
+        bridge.HasHandshakeSnapshot = true;
+        bridge.MainSessionKey = "agent:main:main";
+        bridge.RaiseStatus(ConnectionStatus.Connected);
+        bridge.RaiseSessions(Array.Empty<SessionInfo>());
+        Assert.True((await provider.LoadAsync()).ComposeTarget.IsReady);
+
+        bridge.RaiseStatus(ConnectionStatus.Disconnected);
+        var snap = await provider.LoadAsync();
+        Assert.False(snap.ComposeTarget.IsReady);
     }
 
     // ── Parity additions: streaming, lifecycle, reasoning, history, abort ──
@@ -1935,6 +1978,12 @@ public class OpenClawChatDataProviderTests
         bridge.HasHandshakeSnapshot = true;
         bridge.MainSessionKey = canonicalMainKey;
         bridge.RaiseStatus(ConnectionStatus.Connected);
+        // Mirror real gateway behavior: after handshake the gateway always
+        // emits sessions.list (even an empty one). The provider needs that
+        // signal to flip ComposeTarget.IsReady on, so that the UI doesn't
+        // briefly render the welcome zero-state for returning users whose
+        // real sessions are about to be delivered.
+        bridge.RaiseSessions(Array.Empty<SessionInfo>());
         return (bridge, provider, snapshots);
     }
 


### PR DESCRIPTION
## Summary
Replaces the centered "Reconnecting…" spinner with a message-shaped
skeleton (timeline + composer) so returning users see a placeholder
that visually maps to the chat surface that will replace it. Also
eliminates the brief zero-state flash that happened between thread
selection and the first `chat.history` response.

## What changed
- **Skeleton timeline** (`OpenClawChatRoot.RenderSkeletonTimeline`)
  - 5 alternating bubbles (L/R) with subtle text-line stripes inside
  - Bubble radius 8 (matches composer); line radius 4 (pill)
  - Staggered shimmer (Storyboard opacity 1.0 → 0.45, 900ms, AutoReverse, SineEase)
  - 4px-grid layout: padding (16, 12), margin (16, 8), VStack 8
- **Skeleton composer** (`RenderSkeletonComposer`)
  - 56-tall rounded input placeholder + 40×40 circular send placeholder
  - Synced shimmer (160ms phase offset)
- **Welcome flicker fix** (`OpenClawChatRoot`)
  - 800ms debounce on `welcomeSettledState`
  - Two-path eligibility gate combining `isComposeOnlyThread` /
    `hasRealThreads` / `timeline.HistoryLoaded` so the zero-state
    no longer appears momentarily while history is in flight
- **Sessions-list gate** (`OpenClawChatDataProvider`)
  - `_sessionsListReceived` ensures `composeReady` doesn't fire before
    we know whether real threads exist (regression test added)

## Validation
- `./build.ps1` ✅
- Tray tests 1176 / 1176 ✅
- Shared tests 1813 / 1813 ✅
- Manual: no flicker; skeleton breathes; bubble radius matches composer

## Deferred (follow-ups)
- HC-aware ThemeResource brushes for the skeleton fills
- Skip shimmer animation when `AccessibilitySettings.HighContrast`
- `AutomationProperties.Name="Loading conversation"` + LiveSetting=Polite
