### PR TITLE
docs: refresh repository documentation audit

### DIFF
--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -1,4 +1,12 @@
-# Code Review - OpenClaw Windows Hub
+# Historical Code Review - OpenClaw Windows Hub
+
+> Current audit status (2026-05-21): this review is retained as a point-in-time
+> snapshot from early 2026. Several findings have since been addressed or moved
+> into dedicated architecture docs, including the connection state machine,
+> credential storage, and expanded test coverage. Use
+> [`TEST_COVERAGE.md`](./TEST_COVERAGE.md) and
+> [`CONNECTION_ARCHITECTURE.md`](./CONNECTION_ARCHITECTURE.md) for current
+> status before acting on the historical recommendations below.
 
 ## Overview
 This document provides a comprehensive code review of the OpenClaw Windows Hub repository, focusing on correctness, security, and best practices.
@@ -62,6 +70,10 @@ else if (sessions.ValueKind == JsonValueKind.Object) { /* ... */ }
 #### 2. Reconnection Loop Edge Cases (Medium Priority)
 
 **Location**: `OpenClawGatewayClient.ReconnectWithBackoffAsync()` (lines 164-185)
+
+**Current status**: Superseded by the dedicated connection architecture in
+`OpenClaw.Connection`, including `ConnectionStateMachine` and
+`GatewayConnectionManager`.
 
 **Issue**: Multiple paths can trigger reconnection simultaneously:
 - Manual reconnect in `CheckHealthAsync()` (line 92)
@@ -207,10 +219,14 @@ public async Task SendChatMessageAsync(string message)
 
 ### ⚠️ Security Recommendations
 
-1. **Token Storage** (Medium Priority)
-   - Currently stores auth token in `settings.json` as plain text
-   - **Recommendation**: Use Windows Data Protection API (DPAPI) to encrypt tokens
-   - Example: `ProtectedData.Protect()` from `System.Security.Cryptography`
+1. **Credential Storage** (Medium Priority)
+   - Historical finding: older settings stored gateway credentials directly in
+     `settings.json`.
+   - Current status: gateway credential ownership moved to the gateway registry
+     and device identity files; SettingsManager uses Windows DPAPI for stored
+     API keys where applicable.
+   - **Recommendation**: keep new credential paths documented and covered by
+     migration/security tests.
 
 2. **WebSocket Message Validation** (Low-Medium Priority)
    - No explicit size limits on incoming messages
@@ -224,10 +240,11 @@ public async Task SendChatMessageAsync(string message)
 
 ## Testing Coverage
 
-### ✅ Tests Added (571 tests)
+### Tests Added
 
-1. **OpenClaw.Shared.Tests** (478 tests) - Models, gateway client, exec approvals, capabilities, URL helpers, notification categorization, shell quoting
-2. **OpenClaw.Tray.Tests** (93 tests) - Menu display, menu positioning, settings round-trip, deep link parsing
+The original review was written when the suite was much smaller. The current
+test project inventory and latest required-suite runtime counts live in
+[`TEST_COVERAGE.md`](./TEST_COVERAGE.md).
 
 ### 📋 Recommended Additional Tests
 
@@ -322,14 +339,16 @@ if (Key.Contains('/') || Key.Contains('\\'))
 ## Recommendations Summary
 
 ### High Priority
-1. ✅ Add unit tests - **COMPLETED (88 tests)**
-2. Consider encrypting auth token in settings.json (use DPAPI)
-3. Add integration tests for WebSocket communication
+1. Add unit tests - **completed and expanded; see `TEST_COVERAGE.md`**
+2. Review remaining credential-at-rest gaps against the current gateway
+   registry/device identity model
+3. Add integration tests for WebSocket communication where live-gateway coverage
+   is still required
 
 ### Medium Priority
 4. Improve error handling consistency
 5. Add schema versioning to protocol
-6. Implement connection state machine
+6. Connection state machine - **completed in `OpenClaw.Connection`**
 7. Add message size limits
 
 ### Low Priority
@@ -342,17 +361,18 @@ if (Key.Contains('/') || Key.Contains('\\'))
 
 The OpenClaw Windows Hub codebase demonstrates good software engineering practices with proper async/await usage, event-driven architecture, and resource management. The main areas for improvement are:
 
-1. **Testing**: Now addressed with 88 unit tests covering core functionality
+1. **Testing**: Now addressed by the expanded xUnit suite documented in `TEST_COVERAGE.md`
 2. **Error Handling**: Could be more consistent
-3. **Security**: Token encryption would enhance security
+3. **Security**: Continue reviewing credential-at-rest coverage as storage paths evolve
 4. **Robustness**: JSON parsing could be more resilient
 
-All critical functionality has been validated through the new unit test suite. The code is production-ready with the caveat that the identified medium-priority issues should be addressed for long-term maintainability.
+Critical functionality has broad automated coverage, but this historical review
+should not be treated as the live source of truth for current issue status.
 
 ---
 
-**Review Date**: 2026-01-29 (updated 2026-03-18)
+**Review Date**: 2026-01-29 (historical review; documentation audit 2026-05-21)
 **Reviewer**: GitHub Copilot Coding Agent
-**Test Coverage**: 571 tests, all passing
+**Test Coverage**: See [`TEST_COVERAGE.md`](./TEST_COVERAGE.md) for current counts
 **Overall Grade**: B+ (Good, with room for improvement)
 

--- a/docs/CONNECTION_ARCHITECTURE.md
+++ b/docs/CONNECTION_ARCHITECTURE.md
@@ -212,7 +212,7 @@ The connect handshake uses Ed25519 signatures with v3→v2 fallback:
 
 ## Tests
 
-Connection tests live in `tests/OpenClaw.Connection.Tests/` (215 tests):
+Connection tests live in `tests/OpenClaw.Connection.Tests/`:
 
 - `ConnectionStateMachineTests` — FSM transitions, derived overall state
 - `CredentialResolverTests` — credential precedence for operator and node

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -190,4 +190,4 @@ OpenClaw Tray checks for updates automatically and shows a notification when a n
 
 Go to **Settings → Apps → Installed apps**, find **OpenClaw Tray**, and click **Uninstall**. Alternatively, use **Add or Remove Programs** in the Control Panel.
 
-Your settings file at `%APPDATA%\OpenClawTray\settings.json` and device key at `%LOCALAPPDATA%\OpenClawTray\device-key-ed25519.json` are not removed automatically — delete them manually if you want a clean uninstall.
+Your settings file at `%APPDATA%\OpenClawTray\settings.json` and device identity files under `%APPDATA%\OpenClawTray\` (including per-gateway keys at `%APPDATA%\OpenClawTray\gateways\<gateway-id>\device-key-ed25519.json`) are not removed automatically — delete them manually if you want a clean uninstall.

--- a/docs/TEST_COVERAGE.md
+++ b/docs/TEST_COVERAGE.md
@@ -1,135 +1,94 @@
 # Test Coverage Summary
 
-**2349 tests total** (1464 shared + 885 tray) — required suites passing ✅
+**Last audited**: 2026-05-21<br>
+**Framework**: xUnit / .NET 10.0<br>
+**Required validation status**: passing (`.\build.ps1`, Shared tests, Tray tests)
 
-| Metric | Value |
-|--------|-------|
-| Total Tests | 2349 |
-| Result | 2327 passed, 22 skipped |
-| Failing | 0 |
-| Framework | xUnit / .NET 10.0 |
+## Required validation suites
 
-## Test Projects
+These are the suites every agent must run after code changes, as documented in
+`AGENTS.md`.
 
-### OpenClaw.Shared.Tests — 1464 tests
+| Suite | Latest runtime result |
+|---|---:|
+| `OpenClaw.Shared.Tests` | 1,897 total: 1,869 passed, 28 skipped |
+| `OpenClaw.Tray.Tests` | 1,191 total: 1,191 passed, 0 skipped |
 
-#### ModelsTests
-- **AgentActivityTests** (~15) — glyph mapping for all ActivityKind values, display text formatting
-- **ChannelHealthTests** (~25) — status display for ON/OFF/ERR/LINKED/READY states, case-insensitive matching
-- **SessionInfoTests** (~25) — display text, main/sub session prefixes, ShortKey extraction, context summaries
-- **SessionInfoContextSummaryTests** (~8) — token window formatting, millions/thousands display
-- **SessionInfoRichDisplayTextTests** (~8) — rich display labels, display name fallback
-- **SessionInfoAgeTextTests** (~6) — relative time formatting (minutes, hours ago)
-- **GatewayUsageInfoTests** (~12) — token counts (999, 15.0K, 2.5M), cost display, empty state
-- **GatewayNodeInfoTests** (~10) — display name, node info formatting
+Runtime totals come from `dotnet test` on 2026-05-21. They are higher than
+method counts because some `[Theory]` tests expand into multiple cases.
 
-#### OpenClawGatewayClientTests (~50)
-- Notification classification (health, urgent, calendar, build, email alerts)
-- Tool-to-activity mapping (exec, read, write, edit, search, browser, message)
-- Path shortening and label truncation
-- `ResetUnsupportedMethodFlags` — clearing unsupported flag state
+## Test project inventory
 
-#### ExecApprovalPolicyTests (~20)
-- Policy rule evaluation, persistence, pattern matching
+| Project | Primary scope | Test methods |
+|---|---|---:|
+| `OpenClaw.Connection.Tests` | Gateway registry, credential resolution, connection manager/state machine, setup codes, pairing, diagnostics | 189 |
+| `OpenClaw.Shared.Tests` | Shared models, gateway client, capabilities, MCP, exec approval, A2UI security, URL handling, notification categorization | 1,356 |
+| `OpenClaw.Tray.Tests` | Tray state/UI helpers, settings isolation, onboarding, connection page behavior, localization, local gateway setup/uninstall | 798 |
+| `OpenClaw.Tray.UITests` | Native WinUI/A2UI control and rendering coverage | 50 |
+| `OpenClaw.WinNode.Cli.Tests` | Windows node CLI argument parsing, command behavior, JSON output, uninstall flow | 79 |
+| `OpenClawTray.FunctionalUI.Tests` | Functional UI smoke coverage | 8 |
+| `OpenClawTray.OnboardingV2.Tests` | Onboarding V2 page flow and state coverage | 9 |
+| `OpenClaw.Tray.IntegrationTests` | Integration-test project scaffold; no `[Fact]`/`[Theory]` methods currently | 0 |
 
-#### CapabilityTests (~30)
-- **SystemCapabilityTests** — system command handling
-- **CanvasCapabilityTests** — canvas command handling
-- **ScreenCapabilityTests** — screen command handling
-- **CameraCapabilityTests** — camera command handling
+The method inventory is a source scan of `[Fact]` and `[Theory]` attributes. Use
+`dotnet test` for authoritative runtime totals.
 
-#### NodeCapabilitiesTests (~15)
-- Base class parsing, `ExecuteAsync` return values, payload handling
+## Coverage highlights
 
-#### DeviceIdentityTests (~15)
-- Payload format validation, pairing status events
+### OpenClaw.Shared.Tests
 
-#### NotificationCategorizerTests (~30)
-- Keyword matching, channel-to-type mapping (health, calendar, stock, build, email, urgent)
-- Priority rules, default categorization
+- **Model and display formatting** — activity glyphs, session labels, gateway usage/node display, channel status, and rich text helpers.
+- **Gateway and WebSocket behavior** — gateway client parsing, session keys, WebSocket base handling, URL normalization, local gateway classification, and token sanitization.
+- **Capabilities and MCP** — app/canvas/screen/camera/system capabilities, MCP auth token reset, MCP HTTP server, MCP tool bridge, MXC availability, MXC policy building, and command runners.
+- **Exec approval** — legacy policy coverage plus V2 evaluator, input validation, normalization, prompt adapter, routing, coordinator, store, environment sanitizing, and shell-wrapper parsing.
+- **A2UI and web bridge** — A2UI capability security, asset hash pinning, web bridge message handling, and channel payload/status tests.
+- **Security and localization-adjacent helpers** — HTTP URL validation/risk evaluation, device identity, identity migration, notification categorization, speech language normalization, and non-fatal action handling.
 
-#### GatewayUrlHelperTests (~25)
-- URL normalization (http→ws, https→wss)
-- Embedded credential stripping
-- Port preservation, path handling
+### OpenClaw.Tray.Tests
 
-#### SystemRunTests (~20)
-- Command execution, timeout handling, environment variables
+- **Tray UI and state** — app state, menu display/position/sizing, tray tooltip formatting, activity streams, async list loading, diagnostics contracts, markup regressions, and chat timeline/markdown handling.
+- **Connection and pairing** — connection manager node connector tests, connection page approval/channel metrics/row state, operator and Windows tray node pairing approval, gateway action transport, and quick-send coordination.
+- **Settings and startup** — settings round-trip/isolation, consent and settings save, auto-start defaults, startup setup state, existing config guard policy, and local setup progress stage mapping.
+- **Onboarding and local gateway setup** — onboarding completion/chat bootstrapper/existing config guard, wizard flow/selection/error/step parsing, setup code decoding, local gateway setup diagnostics, uninstall, WSL keep-alive, and auto-pair flags.
+- **Localization and resources** — localization key parity, capability page localization, fluent icon catalog coverage, and installer assertion tests.
 
-#### ShellQuotingTests (~20)
-- Shell metachar detection (`&`, `|`, `;`, `$`, `` ` ``, `*`, `?`, `<`, `>`, etc.)
-- Quoting for safe shell invocation
+### Additional projects
 
-#### WindowsNodeClientTests (~10)
-- URL handling, endpoint construction
+- **OpenClaw.Connection.Tests** keeps connection architecture tests separate from tray UI concerns.
+- **OpenClaw.Tray.UITests** covers A2UI/native WinUI rendering behavior that is awkward to validate through pure unit tests.
+- **OpenClaw.WinNode.Cli.Tests** covers the standalone Windows node CLI contract.
+- **OpenClawTray.OnboardingV2.Tests** and **OpenClawTray.FunctionalUI.Tests** cover newer UI surfaces outside the main tray test project.
 
-#### NodeInvokeResponseTests (~5)
-- Default values, property setting
-
-#### ReadmeValidationTests (~5)
-- Documentation sync checks
-
----
-
-### OpenClaw.Tray.Tests — 885 tests
-
-#### Core Tray Tests
-
-- **MenuDisplayHelperTests** (~40) — `GetStatusIcon` emoji mapping for Connected/Disconnected/Connecting/Error states, `GetChannelStatusIcon` status icons for running/idle/pending/error/disconnected + case-insensitive variants, `GetNextToggleValue` ON↔OFF toggling, unknown/empty status fallback
-- **MenuPositionerTests** (~15) — Screen edge clamping (top-left, bottom-right), taskbar-at-right scenario, menu positioning relative to cursor
-- **SettingsRoundTripTests** (~15) — Serialization/deserialization round trips, default values on missing keys, backward compatibility with older settings formats
-- **DeepLinkParserTests** (~23) — `ParseDeepLink` protocol validation, null/empty handling, subpath parsing, trailing slash stripping, query parameter extraction, URL-encoded message handling
-
-#### Onboarding Tests
-
-- **GatewayWizardStateTests** — Gateway wizard state persistence defaults and disposal
-- **GatewayChatHelperTests** (11) — URL scheme conversion, token encoding, localhost checks, session keys
-- **LocalGatewayApproverTests** (13) — IsLocalGateway for localhost/remote/edge cases
-- **SetupCodeDecoderTests** (14) — Base64url decode, size limits, JSON validation, URL/token extraction
-- **GatewayHealthCheckTests** (6) — Health URI building, scheme conversion, port preservation
-- **SecurityValidationTests** (16) — Locale whitelist, port range, path traversal, URI scheme validation
-- **WizardStepParsingTests** (12) — JSON step parsing, options, completion, sensitive fields
-- **GatewayDiscoveryServiceTests** — mDNS host selection and connection URL regression coverage
-- **LocalizationValidationTests** — locale key parity, onboarding key presence, duplicate detection, and all-or-none translation consistency
-
-#### Connection Architecture Tests
-
-- **GatewayRegistryTests / GatewayRegistryMigrationTests** — active gateway persistence, URL lookup, migration from legacy settings, per-gateway identity copy.
-- **CredentialResolverTests / InteractiveGatewayCredentialResolverTests** — device-token-first precedence, shared token fallback, bootstrap pairing state, legacy fallback for user-facing chat.
-- **GatewayConnectionManagerTests / ConnectionStateMachineTests** — operator/node lifecycle, transitions, diagnostics, reconnect/disconnect behavior.
-- **PairingFlowTests / SetupCodeFlowTests / StaleEventGuardTests** — bootstrap setup codes, pairing state transitions, and stale event suppression.
-- **RetryPolicyTests / ConnectionDiagnosticsTests / NodeConnectorTests / SettingsChangeImpactTests** — retry classification, diagnostics, node connector behavior, and settings change impact.
-
----
-
-## Running Tests
+## Running tests
 
 ```powershell
-# All tests
-dotnet test
-
-# Single project
+# Required validation after code changes
+$env:OPENCLAW_REPO_ROOT = (Get-Location).Path
+.\build.ps1
 dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore
 dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore
 
+# All tests in the solution
+dotnet test
+
+# Single project
+dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj
+
 # Specific test class
 dotnet test --filter "FullyQualifiedName~MenuDisplayHelperTests"
-
-# Onboarding tests only
-dotnet test --filter "FullyQualifiedName~Onboarding"
 
 # Verbose output
 dotnet test --logger "console;verbosity=detailed"
 ```
 
-## Not Covered (Requires Integration Tests)
+In a fresh worktree, run the project once without `--no-restore` or build it
+first so `dotnet test --no-restore` cannot no-op before `bin\` exists.
 
-- Windows shell tray hover/click behavior
-- Full WinUI onboarding wizard flow, including WebView2 navigation
-- Real gateway/node pairing against a live gateway
+## Not fully covered by automated tests
 
----
-
-**Last Updated**: 2026-05-10
-**Framework**: xUnit / .NET 10.0
-**Status**: ✅ required suites passing (`.\build.ps1`, Shared tests, Tray tests)
+- Real shell tray hover/click behavior against Explorer.
+- Full live gateway/node pairing against a remote gateway.
+- Long-running soak behavior for reconnects, high-frequency activity updates,
+  and memory usage over multi-day sessions.
+- Manual visual acceptance for complex WinUI surfaces where screenshot
+  comparison would be brittle.

--- a/docs/a2ui/README.md
+++ b/docs/a2ui/README.md
@@ -4,10 +4,10 @@ This folder is the entry point for everything A2UI in this repo. It captures
 the v0.8 specification, the standard catalog, and a side-by-side grading of
 two implementations:
 
-- **Lit reference** in `C:\Users\andersonch\Code\openclaw` (web components,
-  rendered in a browser via the OpenClaw canvas host).
-- **Native WinUI** in this repo (`src/OpenClaw.Tray.WinUI/A2UI/`,
-  branch `feat/a2ui-native-winui`).
+- **Lit reference** from the upstream OpenClaw A2UI renderer
+  (`vendor/a2ui/renderers/lit/src/0.8`, web components rendered in a
+  browser via the OpenClaw canvas host).
+- **Native WinUI** in this repo (`src/OpenClaw.Tray.WinUI/A2UI/`).
 
 The native WinUI design doc that predates this overview lives at
 [`../A2UI_NATIVE_WINUI.md`](../A2UI_NATIVE_WINUI.md); this folder

--- a/docs/a2ui/grading.md
+++ b/docs/a2ui/grading.md
@@ -3,12 +3,12 @@
 This grades two implementations against the v0.8 spec
 (<https://a2ui.org/specification/v0.8-a2ui/>):
 
-- **Lit reference** at `C:\Users\andersonch\Code\openclaw\vendor\a2ui\renderers\lit\src\0.8`
+- **Lit reference** at `vendor\a2ui\renderers\lit\src\0.8` in the
+  upstream OpenClaw checkout
 - **Native WinUI** in this repo at `src/OpenClaw.Tray.WinUI/A2UI/`
 
 The Lit code looks like the canonical browser renderer the OpenClaw
-canvas host ships; the WinUI code is this repo's branch
-`feat/a2ui-native-winui`.
+canvas host ships; the WinUI code is the native renderer in this repo.
 
 Citations use repo-local paths. Lit paths are anchored at the OpenClaw
 checkout: `openclaw\vendor\a2ui\renderers\lit\src\0.8\`. WinUI paths are

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/ContainerRenderers.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/Renderers/ContainerRenderers.cs
@@ -242,8 +242,7 @@ public sealed class ModalRenderer : IComponentRenderer
     {
         // Render as a real ContentDialog launched from the entry-point child.
         // The entry-point is shown inline; clicking it shows the dialog with
-        // the content-child as its body. Falls back to Expander when no
-        // XamlRoot can be resolved (e.g. surface not yet attached to a window).
+        // the content-child as its body once the trigger is attached to XAML.
         var entryId = ctx.GetSingleChild(c, "entryPointChild");
         var contentId = ctx.GetSingleChild(c, "contentChild");
 

--- a/src/OpenClaw.Tray.WinUI/THIRD_PARTY_NOTICES.md
+++ b/src/OpenClaw.Tray.WinUI/THIRD_PARTY_NOTICES.md
@@ -2,7 +2,7 @@
 
 The colorful sidebar SVG files in `Assets/SidebarIcons/` are derived from the
 **Fluent UI System Icons** project by Microsoft, color variant
-(890 icons, also known as `fluent-color` in the Iconify ecosystem).
+(20 selected icons from the full `fluent-color` set in the Iconify ecosystem).
 
 The app/tray/window lobster icon (`Assets/openclaw.ico`, plus the
 `Square*` / `StoreLogo` / `LockScreenLogo` PNG family) is derived from the

--- a/src/skills/windows-a2ui/SKILL.md
+++ b/src/skills/windows-a2ui/SKILL.md
@@ -86,7 +86,7 @@ Exactly one of `valueString` / `valueNumber` / `valueBoolean` / `valueMap` shoul
 | **List** | `children: { "explicitList": [...] }` | `direction`: `vertical` (default) or `horizontal`; `alignment`. Wrapped in a `ScrollViewer`. **Template/data-bound rows are not supported in v1** — supply explicit child ids. |
 | **Card** | `child: "<id>"` (single string, not explicitList) | None. Renders as a themed `Border` with 16 px padding and rounded corners. |
 | **Tabs** | per-tab via `tabItems` | `tabItems: [{ "title": <A2UIValue>, "child": "<id>" }, ...]`. Renders as a `TabView` with non-closable, non-reorderable tabs. |
-| **Modal** | `entryPointChild: "<id>"`, `contentChild: "<id>"` | None. **Currently rendered inline as an `Expander`**, not a real dialog. The entryPointChild becomes the header; the contentChild becomes the expanded body. |
+| **Modal** | `entryPointChild: "<id>"`, `contentChild: "<id>"` | `title`: optional `A2UIValue<string>`. Renders as a native `ContentDialog` triggered by the entryPointChild; the contentChild becomes the dialog body. |
 | **Divider** | — | `axis`: `horizontal` (default) or `vertical`. Renders as a 1 px rectangle. |
 
 Children are referenced by **id**, not nested in place. Build the surface as a flat array of components and let `beginRendering.root` pick the entry point.
@@ -234,7 +234,7 @@ The single biggest UX difference between a Windows-node A2UI surface that "just 
 
 - **Inline children.** Always declare components flat and reference by id via `children.explicitList` (containers) or `child` (Card/Button/Modal halves) or per-tab `child` (Tabs).
 - **Template/data-bound List rows.** Not implemented — pre-expand or use repeated explicit children.
-- **Modal as a real dialog.** It currently renders as an inline Expander. Don't rely on focus-trapping or backdrop dismiss.
+- **Inline modal bodies.** Modal renders as a native `ContentDialog`, so don't design content that only works when expanded inline in the surface layout.
 - **Custom icon names.** Anything outside the icon enum becomes the Help glyph. Don't ship Material/Fluent codepoints directly.
 - **Putting secrets in implicit context.** `obscured` TextField paths only flow into `action.context` when listed in the source component's `dataBinding`. Make the opt-in explicit.
 - **v0.9 envelope kinds.** `canvas.a2ui.schema`, `canvas.a2ui.dump`, etc. are not supported on this node; they will land in `UnknownEnvelopeMessage` and be dropped.


### PR DESCRIPTION
## Summary
- Refresh stale documentation found during a full docs audit across core setup, connection, A2UI, testing, review, and attribution docs.
- Update test coverage to reflect the current required validation suites and test project inventory.
- Correct A2UI Modal documentation to match native ContentDialog rendering, update device identity paths, remove a stale connection test count, and fix sidebar icon attribution.

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` (1,897 total; 1,869 passed; 28 skipped)
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` (1,191 total; 1,191 passed)