### PR TITLE
Localize hard-coded XAML strings across 17 WinUI files (#491)

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml
@@ -40,13 +40,13 @@
                      Title="Single-agent mode"
                      Message="All messages route to the default agent. Add bindings for multi-agent routing."/>
 
-            <InfoBar x:Name="ConnectionInfoBar"
+            <InfoBar x:Uid="BindingsPage_GatewayDisconnected" x:Name="ConnectionInfoBar"
                      IsOpen="False" IsClosable="False"
                      Severity="Warning"
                      Title="Gateway disconnected"
                      Message="Connect to a gateway to load bindings.">
                 <InfoBar.ActionButton>
-                    <Button Content="Open Connection" Click="OnOpenConnectionClick"/>
+                    <Button x:Uid="BindingsPage_OpenConnection" Content="Open Connection" Click="OnOpenConnectionClick"/>
                 </InfoBar.ActionButton>
             </InfoBar>
 
@@ -54,7 +54,7 @@
                         HorizontalAlignment="Center" Padding="0,24,0,16"
                         Visibility="Collapsed">
                 <ProgressRing IsActive="True" Width="20" Height="20"/>
-                <TextBlock Text="Loading bindings..."
+                <TextBlock x:Uid="BindingsPage_LoadingBindings" Text="Loading bindings..."
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                            VerticalAlignment="Center"/>
             </StackPanel>

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
@@ -81,7 +81,7 @@
                             <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Approvals, Mode=OneTime}" FontSize="14"
                                       Foreground="{ThemeResource SystemFillColorCautionBrush}"
                                       AutomationProperties.AccessibilityView="Raw"/>
-                            <TextBlock x:Name="PendingApprovalsHeaderText"
+                            <TextBlock x:Uid="ConnectionPage_ApprovalsWaitingOnYou" x:Name="PendingApprovalsHeaderText"
                                        Text="Approvals waiting on you"
                                        Style="{StaticResource BodyStrongTextBlockStyle}"
                                        VerticalAlignment="Center"
@@ -138,7 +138,7 @@
 
                         <!-- Headline + sub + glance chips -->
                         <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
-                            <TextBlock x:Name="StripHeadline" Text="Not connected"
+                            <TextBlock x:Uid="ConnectionPage_NotConnected" x:Name="StripHeadline" Text="Not connected"
                                        Style="{StaticResource SubtitleTextBlockStyle}"
                                        AutomationProperties.HeadingLevel="Level1"
                                        AutomationProperties.LiveSetting="Polite"
@@ -160,7 +160,7 @@
                         <!-- Right-side action cluster -->
                         <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="4"
                                     VerticalAlignment="Center">
-                            <Button x:Name="StripPrimaryButton"
+                            <Button x:Uid="ConnectionPage_Connect" x:Name="StripPrimaryButton"
                                     Content="Connect"
                                     Visibility="Collapsed"
                                     Click="OnStripPrimaryClicked"
@@ -206,10 +206,10 @@
                                       VerticalAlignment="Center" HorizontalAlignment="Center"
                                       AutomationProperties.AccessibilityView="Raw"/>
                             <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
-                                <TextBlock Text="Operator"
+                                <TextBlock x:Uid="ConnectionPage_Operator" Text="Operator"
                                            Style="{StaticResource BodyStrongTextBlockStyle}"
                                            AutomationProperties.HeadingLevel="Level2"/>
-                                <TextBlock Text="Send commands and view sessions on this gateway from this PC."
+                                <TextBlock x:Uid="ConnectionPage_SendCommandsAndView" Text="Send commands and view sessions on this gateway from this PC."
                                            Style="{StaticResource CaptionTextBlockStyle}"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                            TextWrapping="Wrap"/>
@@ -228,19 +228,19 @@
                                       Foreground="{ThemeResource SystemFillColorNeutralBrush}"
                                       VerticalAlignment="Center" HorizontalAlignment="Center"
                                       AutomationProperties.AccessibilityView="Raw"/>
-                            <TextBlock Grid.Column="1" x:Name="OperatorStatusText"
+                            <TextBlock x:Uid="ConnectionPage_Inactive" Grid.Column="1" x:Name="OperatorStatusText"
                                        Text="Inactive"
                                        Style="{StaticResource BodyTextBlockStyle}"
                                        VerticalAlignment="Center"/>
                         </Grid>
 
                         <StackPanel Orientation="Horizontal" Spacing="12">
-                            <HyperlinkButton x:Name="OperatorSessionsLink"
+                            <HyperlinkButton x:Uid="ConnectionPage_SeeSessions" x:Name="OperatorSessionsLink"
                                              Content="See sessions ›"
                                              Padding="0" FontSize="13"
                                              Click="OnOpenSessions"
                                              AutomationProperties.Name="See sessions"/>
-                            <HyperlinkButton x:Name="OperatorInstancesLink"
+                            <HyperlinkButton x:Uid="ConnectionPage_SeeInstances" x:Name="OperatorInstancesLink"
                                              Content="See instances ›"
                                              Padding="0" FontSize="13"
                                              Click="OnOpenInstances"
@@ -282,10 +282,10 @@
                                       VerticalAlignment="Center" HorizontalAlignment="Center"
                                       AutomationProperties.AccessibilityView="Raw"/>
                             <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
-                                <TextBlock Text="Node mode"
+                                <TextBlock x:Uid="ConnectionPage_NodeMode" Text="Node mode"
                                            Style="{StaticResource BodyStrongTextBlockStyle}"
                                            AutomationProperties.HeadingLevel="Level2"/>
-                                <TextBlock Text="When on, this PC registers as a node and offers the capabilities below to agents over the gateway."
+                                <TextBlock x:Uid="ConnectionPage_WhenOnThisPC" Text="When on, this PC registers as a node and offers the capabilities below to agents over the gateway."
                                            Style="{StaticResource CaptionTextBlockStyle}"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                            TextWrapping="Wrap"/>
@@ -316,7 +316,7 @@
                                       VerticalAlignment="Center" HorizontalAlignment="Center"
                                       AutomationProperties.AccessibilityView="Raw"/>
                             <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
-                                <TextBlock x:Name="NodeStatusText"
+                                <TextBlock x:Uid="ConnectionPage_NodeModeDisabled" x:Name="NodeStatusText"
                                            Text="Node mode disabled"
                                            Style="{StaticResource BodyTextBlockStyle}"/>
                                 <!-- Canonical capability list per design naming.md:
@@ -350,7 +350,7 @@
                                            IsTextSelectionEnabled="True"
                                            TextWrapping="Wrap"
                                            VerticalAlignment="Center"/>
-                                <Button Grid.Column="1" Content="Copy"
+                                <Button x:Uid="ConnectionPage_Copy" Grid.Column="1" Content="Copy"
                                         Click="OnCopyNodeApproveCommand"
                                         ToolTipService.ToolTip="Copy command"
                                         AutomationProperties.Name="Copy approval command"
@@ -359,7 +359,7 @@
                         </Border>
 
                         <!-- Connect button when awaiting node pairing approval -->
-                        <Button x:Name="NodeReconnectButton" Visibility="Collapsed"
+                        <Button x:Uid="ConnectionPage_Connect2" x:Name="NodeReconnectButton" Visibility="Collapsed"
                                 Content="Connect" Click="OnReconnectFromRecovery"
                                 Style="{StaticResource AccentButtonStyle}"
                                 Margin="0,4,0,0"
@@ -376,7 +376,7 @@
 
                         <!-- Deep link to per-capability config -->
                         <StackPanel x:Name="NodeDeepLinks" Orientation="Horizontal" Spacing="12">
-                            <HyperlinkButton x:Name="NodePermissionsLink"
+                            <HyperlinkButton x:Uid="ConnectionPage_ManagePermissions" x:Name="NodePermissionsLink"
                                              Content="Manage permissions ›"
                                              Padding="0" FontSize="13"
                                              Click="OnOpenPermissions"
@@ -397,7 +397,7 @@
                         BorderThickness="1" CornerRadius="8" Padding="16"
                         AutomationProperties.AutomationId="RecoveryCard">
                     <StackPanel Spacing="10">
-                        <TextBlock x:Name="RecoveryHelpHeaderText"
+                        <TextBlock x:Uid="ConnectionPage_HelpUsFixThis" x:Name="RecoveryHelpHeaderText"
                                    Text="Help us fix this connection:"
                                    Style="{StaticResource BodyStrongTextBlockStyle}"/>
 
@@ -409,14 +409,14 @@
                                 Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
                                 CornerRadius="4" Padding="10">
                             <StackPanel Spacing="6">
-                                <TextBlock x:Name="RecoveryTunnelDetailText"
+                                <TextBlock x:Uid="ConnectionPage_SSHTunnelIsDown" x:Name="RecoveryTunnelDetailText"
                                            Text="SSH tunnel is down."
                                            Style="{StaticResource CaptionTextBlockStyle}"
                                            TextWrapping="Wrap"/>
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <Button Content="Restart tunnel" Click="OnRestartTunnel"
+                                    <Button x:Uid="ConnectionPage_RestartTunnel" Content="Restart tunnel" Click="OnRestartTunnel"
                                             AutomationProperties.AutomationId="RecoveryRestartTunnel"/>
-                                    <Button Content="Edit tunnel settings" Click="OnEditTunnelSettings"
+                                    <Button x:Uid="ConnectionPage_EditTunnelSettings" Content="Edit tunnel settings" Click="OnEditTunnelSettings"
                                             AutomationProperties.AutomationId="RecoveryEditTunnel"/>
                                 </StackPanel>
                             </StackPanel>
@@ -427,7 +427,7 @@
                                 Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
                                 CornerRadius="4" Padding="10">
                             <StackPanel Spacing="6">
-                                <TextBlock Text="Paste a new setup code from the gateway host."
+                                <TextBlock x:Uid="ConnectionPage_PasteANewSetup" Text="Paste a new setup code from the gateway host."
                                            Style="{StaticResource CaptionTextBlockStyle}"
                                            TextWrapping="Wrap"/>
                                 <Grid ColumnSpacing="8">
@@ -435,10 +435,10 @@
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="Auto"/>
                                     </Grid.ColumnDefinitions>
-                                    <TextBox Grid.Column="0"
+                                    <TextBox x:Uid="ConnectionPage_PasteSetupCodeHere" Grid.Column="0"
                                              x:Name="RecoveryRepairCodeBox"
                                              PlaceholderText="Paste setup code here…"/>
-                                    <Button Grid.Column="1" Content="Apply"
+                                    <Button x:Uid="ConnectionPage_Apply" Grid.Column="1" Content="Apply"
                                             Click="OnApplyRepairCode"
                                             AutomationProperties.AutomationId="RecoveryApplyRepair"/>
                                 </Grid>
@@ -450,7 +450,7 @@
                                 Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
                                 CornerRadius="4" Padding="10">
                             <StackPanel Spacing="6">
-                                <TextBlock Text="Run on the gateway host:"
+                                <TextBlock x:Uid="ConnectionPage_RunOnTheGateway" Text="Run on the gateway host:"
                                            Style="{StaticResource CaptionTextBlockStyle}"/>
                                 <Grid ColumnSpacing="8">
                                     <Grid.ColumnDefinitions>
@@ -463,7 +463,7 @@
                                                IsTextSelectionEnabled="True"
                                                TextWrapping="Wrap"
                                                VerticalAlignment="Center"/>
-                                    <Button Grid.Column="1" Content="Copy"
+                                    <Button x:Uid="ConnectionPage_Copy2" Grid.Column="1" Content="Copy"
                                             Click="OnCopyApproveCommand"
                                             ToolTipService.ToolTip="Copy command"
                                             AutomationProperties.Name="Copy approval command"
@@ -475,10 +475,10 @@
                         <!-- Escape hatch: just disconnect; the always-visible
                              gateways list below offers switching by one click. -->
                         <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
-                            <Button Content="Connect" Click="OnReconnectFromRecovery"
+                            <Button x:Uid="ConnectionPage_Connect3" Content="Connect" Click="OnReconnectFromRecovery"
                                     Style="{StaticResource AccentButtonStyle}"
                                     AutomationProperties.AutomationId="RecoveryConnect"/>
-                            <Button Content="Disconnect" Click="OnDisconnect"
+                            <Button x:Uid="ConnectionPage_Disconnect" Content="Disconnect" Click="OnDisconnect"
                                     AutomationProperties.AutomationId="RecoveryDisconnect"/>
                         </StackPanel>
                     </StackPanel>
@@ -490,7 +490,7 @@
                           HorizontalContentAlignment="Stretch"
                           IsExpanded="False">
                     <Expander.Header>
-                        <TextBlock x:Name="RecoverySavedHeaderText"
+                        <TextBlock x:Uid="ConnectionPage_SavedGateways" x:Name="RecoverySavedHeaderText"
                                    Text="Saved gateways"
                                    FontSize="13" FontWeight="SemiBold"
                                    VerticalAlignment="Center"/>
@@ -526,7 +526,7 @@
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" Text="Gateways"
+                        <TextBlock x:Uid="ConnectionPage_Gateways" Grid.Column="0" Text="Gateways"
                                    Style="{StaticResource BodyStrongTextBlockStyle}"
                                    AutomationProperties.HeadingLevel="Level2"
                                    VerticalAlignment="Center"/>
@@ -539,7 +539,7 @@
                             <StackPanel Orientation="Horizontal" Spacing="6">
                                 <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.System, Mode=OneTime}" FontSize="12"
                                           AutomationProperties.AccessibilityView="Raw"/>
-                                <TextBlock x:Name="GatewaysScanButtonText" Text="Scan" FontSize="13"/>
+                                <TextBlock x:Uid="ConnectionPage_Scan" x:Name="GatewaysScanButtonText" Text="Scan" FontSize="13"/>
                             </StackPanel>
                         </Button>
                         <Button Grid.Column="2"
@@ -550,12 +550,12 @@
                             <StackPanel Orientation="Horizontal" Spacing="6">
                                 <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Add, Mode=OneTime}" FontSize="12"
                                           AutomationProperties.AccessibilityView="Raw"/>
-                                <TextBlock Text="Add gateway" FontSize="13"/>
+                                <TextBlock x:Uid="ConnectionPage_AddGateway" Text="Add gateway" FontSize="13"/>
                             </StackPanel>
                         </Button>
                     </Grid>
 
-                    <TextBlock x:Name="SavedGatewaysEmptyText"
+                    <TextBlock x:Uid="ConnectionPage_NoSavedGatewaysYet" x:Name="SavedGatewaysEmptyText"
                                Text="No saved gateways yet."
                                Style="{StaticResource CaptionTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -575,7 +575,7 @@
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0"
+                            <TextBlock x:Uid="ConnectionPage_DiscoveredOnYourNetwork" Grid.Column="0"
                                        x:Name="GatewaysDiscoveredHeader"
                                        Text="Discovered on your network"
                                        Style="{StaticResource CaptionTextBlockStyle}"
@@ -606,7 +606,7 @@
                     Visibility="Collapsed"
                     AutomationProperties.AutomationId="WelcomeAddTilesCard">
                 <StackPanel Spacing="12">
-                    <TextBlock Text="Add a gateway"
+                    <TextBlock x:Uid="ConnectionPage_AddAGateway" Text="Add a gateway"
                                Style="{StaticResource BodyStrongTextBlockStyle}"
                                AutomationProperties.HeadingLevel="Level2"/>
 
@@ -618,7 +618,7 @@
                          the WinUI-canonical "featured callout" surface —
                          soft blue tint + info icon are theme-aware and
                          match tokens.md guidance (no custom brushes). -->
-                    <InfoBar x:Name="WelcomeLocalWslSetupCard"
+                    <InfoBar x:Uid="ConnectionPage_GetStartedInstallA" x:Name="WelcomeLocalWslSetupCard"
                              Severity="Informational"
                              IsOpen="True"
                              IsClosable="False"
@@ -626,13 +626,13 @@
                              Title="Get started — install a local gateway"
                              Message="The fastest way to start: sets up a WSL-hosted gateway on this PC and makes it the active connection.">
                         <InfoBar.ActionButton>
-                            <Button Content="Install"
+                            <Button x:Uid="ConnectionPage_Install" Content="Install"
                                     Click="OnInstallLocalWslGateway"
                                     AutomationProperties.AutomationId="WelcomeInstallLocalGateway"/>
                         </InfoBar.ActionButton>
                     </InfoBar>
 
-                    <TextBlock x:Name="WelcomeOrDivider"
+                    <TextBlock x:Uid="ConnectionPage_OrConnectToAn" x:Name="WelcomeOrDivider"
                                Text="Or connect to an existing one:"
                                Style="{StaticResource CaptionTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
@@ -656,10 +656,10 @@
                                 <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Plug, Mode=OneTime}" FontSize="24"
                                           HorizontalAlignment="Center"
                                           AutomationProperties.AccessibilityView="Raw"/>
-                                <TextBlock Text="Direct"
+                                <TextBlock x:Uid="ConnectionPage_Direct" Text="Direct"
                                            Style="{StaticResource BodyStrongTextBlockStyle}"
                                            HorizontalAlignment="Center"/>
-                                <TextBlock Text="URL + token"
+                                <TextBlock x:Uid="ConnectionPage_URLToken" Text="URL + token"
                                            Style="{StaticResource CaptionTextBlockStyle}"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                            HorizontalAlignment="Center"/>
@@ -679,10 +679,10 @@
                                 <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Lock, Mode=OneTime}" FontSize="24"
                                           HorizontalAlignment="Center"
                                           AutomationProperties.AccessibilityView="Raw"/>
-                                <TextBlock Text="Setup code"
+                                <TextBlock x:Uid="ConnectionPage_SetupCode" Text="Setup code"
                                            Style="{StaticResource BodyStrongTextBlockStyle}"
                                            HorizontalAlignment="Center"/>
-                                <TextBlock Text="Paste QR payload"
+                                <TextBlock x:Uid="ConnectionPage_PasteQRPayload" Text="Paste QR payload"
                                            Style="{StaticResource CaptionTextBlockStyle}"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                            HorizontalAlignment="Center"/>
@@ -690,7 +690,7 @@
                         </Button>
                     </Grid>
 
-                    <TextBlock Text="Each method supports an optional SSH tunnel."
+                    <TextBlock x:Uid="ConnectionPage_EachMethodSupportsAn" Text="Each method supports an optional SSH tunnel."
                                Style="{StaticResource CaptionTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
 
@@ -702,7 +702,7 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0"
+                        <TextBlock x:Uid="ConnectionPage_OrLookForOne" Grid.Column="0"
                                    Text="Or look for one on your network."
                                    Style="{StaticResource CaptionTextBlockStyle}"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -715,12 +715,12 @@
                             <StackPanel Orientation="Horizontal" Spacing="6">
                                 <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.System, Mode=OneTime}" FontSize="12"
                                           AutomationProperties.AccessibilityView="Raw"/>
-                                <TextBlock x:Name="WelcomeScanButtonText" Text="Scan" FontSize="13"/>
+                                <TextBlock x:Uid="ConnectionPage_Scan2" x:Name="WelcomeScanButtonText" Text="Scan" FontSize="13"/>
                             </StackPanel>
                         </Button>
                     </Grid>
                     <StackPanel x:Name="WelcomeDiscoveredSection" Spacing="6" Visibility="Collapsed">
-                        <TextBlock Text="Discovered on your network"
+                        <TextBlock x:Uid="ConnectionPage_DiscoveredOnYourNetwork2" Text="Discovered on your network"
                                    Style="{StaticResource CaptionTextBlockStyle}"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                         <StackPanel x:Name="WelcomeDiscoveredList" Spacing="6"/>
@@ -750,25 +750,25 @@
                         <StackPanel Orientation="Horizontal" Spacing="4">
                             <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Back, Mode=OneTime}" FontSize="10" VerticalAlignment="Center"
                                       AutomationProperties.AccessibilityView="Raw"/>
-                            <TextBlock Text="Back" VerticalAlignment="Center"/>
+                            <TextBlock x:Uid="ConnectionPage_Back" Text="Back" VerticalAlignment="Center"/>
                         </StackPanel>
                     </HyperlinkButton>
 
-                    <TextBlock Text="Add a gateway"
+                    <TextBlock x:Uid="ConnectionPage_AddAGateway2" Text="Add a gateway"
                                Style="{StaticResource SubtitleTextBlockStyle}"
                                AutomationProperties.HeadingLevel="Level1"/>
 
                     <controls:SelectorBar x:Name="AddMethodSelectorBar"
                                           SelectionChanged="OnAddMethodChanged"
                                           AutomationProperties.AutomationId="AddMethodSelector">
-                        <controls:SelectorBarItem x:Name="AddDirectItem"
+                        <controls:SelectorBarItem x:Uid="ConnectionPage_Direct2" x:Name="AddDirectItem"
                                                   Text="Direct"
                                                   IsSelected="True"
                                                   Tag="direct"/>
-                        <controls:SelectorBarItem x:Name="AddSetupCodeItem"
+                        <controls:SelectorBarItem x:Uid="ConnectionPage_SetupCode2" x:Name="AddSetupCodeItem"
                                                   Text="Setup code"
                                                   Tag="setup"/>
-                        <controls:SelectorBarItem x:Name="AddLocalWslItem"
+                        <controls:SelectorBarItem x:Uid="ConnectionPage_LocalWSL" x:Name="AddLocalWslItem"
                                                   Text="Local WSL"
                                                   Tag="local"
                                                   Visibility="Collapsed"/>
@@ -776,17 +776,17 @@
 
                     <!-- Direct pane (default selected) -->
                     <StackPanel x:Name="AddDirectPane" Spacing="8">
-                        <TextBox x:Name="DirectUrlBox"
+                        <TextBox x:Uid="ConnectionPage_GatewayURL" x:Name="DirectUrlBox"
                                  Header="Gateway URL"
                                  PlaceholderText="ws://host.local:18790"
                                  TextChanged="OnDirectInputChanged"
                                  LostFocus="OnDirectUrlLostFocus"
                                  AutomationProperties.AutomationId="AddDirectUrl"/>
-                        <TextBox x:Name="DirectTokenBox"
+                        <TextBox x:Uid="ConnectionPage_SharedToken" x:Name="DirectTokenBox"
                                  Header="Shared token"
                                  PlaceholderText="Paste shared gateway token"
                                  AutomationProperties.AutomationId="AddDirectToken"/>
-                        <TextBox x:Name="DirectNameBox"
+                        <TextBox x:Uid="ConnectionPage_NameOptional" x:Name="DirectNameBox"
                                  Header="Name (optional)"
                                  PlaceholderText="My gateway"
                                  AutomationProperties.AutomationId="AddDirectName"/>
@@ -794,7 +794,7 @@
 
                     <!-- Setup code pane -->
                     <StackPanel x:Name="AddSetupCodePane" Spacing="8" Visibility="Collapsed">
-                        <TextBlock Text="Paste a setup code from the gateway's QR or `openclaw qr` output."
+                        <TextBlock x:Uid="ConnectionPage_PasteASetupCode" Text="Paste a setup code from the gateway's QR or `openclaw qr` output."
                                    Style="{StaticResource CaptionTextBlockStyle}"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    TextWrapping="Wrap"/>
@@ -803,12 +803,12 @@
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <TextBox Grid.Column="0"
+                            <TextBox x:Uid="ConnectionPage_PasteSetupCodeHere2" Grid.Column="0"
                                      x:Name="AddSetupCodeBox"
                                      PlaceholderText="Paste setup code here…"
                                      TextChanged="OnSetupCodeTextChanged"
                                      AutomationProperties.AutomationId="AddSetupCodeInput"/>
-                            <Button Grid.Column="1" Content="Decode"
+                            <Button x:Uid="ConnectionPage_Decode" Grid.Column="1" Content="Decode"
                                     Click="OnAddSetupCodeDecode"
                                     AutomationProperties.AutomationId="AddSetupCodeDecode"/>
                         </Grid>
@@ -837,15 +837,15 @@
                          needed: the install wizard creates the gateway,
                          pairs this PC into it, and saves the record. -->
                     <StackPanel x:Name="AddLocalWslPane" Spacing="12" Visibility="Collapsed">
-                        <TextBlock Text="Install a new WSL gateway on this PC and make it the active connection. The setup wizard will install WSL if needed, provision the gateway, and pair this device automatically."
+                        <TextBlock x:Uid="ConnectionPage_InstallANewWSL" Text="Install a new WSL gateway on this PC and make it the active connection. The setup wizard will install WSL if needed, provision the gateway, and pair this device automatically."
                                    Style="{StaticResource BodyTextBlockStyle}"
                                    TextWrapping="Wrap"/>
-                        <Button x:Name="AddLocalWslInstallButton"
+                        <Button x:Uid="ConnectionPage_InstallLocalGateway" x:Name="AddLocalWslInstallButton"
                                 Content="Install local gateway"
                                 HorizontalAlignment="Left"
                                 Click="OnInstallLocalWslGateway"
                                 AutomationProperties.AutomationId="AddInstallLocalGateway"/>
-                        <TextBlock x:Name="AddLocalWslUnavailableText"
+                        <TextBlock x:Uid="ConnectionPage_LocalWSLSetupIsn" x:Name="AddLocalWslUnavailableText"
                                    Text="Local-WSL setup isn't available on this machine — the install wizard couldn't be initialized."
                                    Style="{StaticResource CaptionTextBlockStyle}"
                                    Foreground="{ThemeResource SystemFillColorCautionBrush}"
@@ -859,7 +859,7 @@
                               HorizontalContentAlignment="Stretch"
                               IsExpanded="False">
                         <Expander.Header>
-                            <TextBlock Text="Use SSH tunnel (optional)"
+                            <TextBlock x:Uid="ConnectionPage_UseSSHTunnelOptional" Text="Use SSH tunnel (optional)"
                                        FontSize="13" FontWeight="SemiBold"
                                        VerticalAlignment="Center"/>
                         </Expander.Header>
@@ -869,11 +869,11 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="*"/>
                                 </Grid.ColumnDefinitions>
-                                <TextBox Grid.Column="0"
+                                <TextBox x:Uid="ConnectionPage_SSHUser" Grid.Column="0"
                                          x:Name="AddSshUserBox"
                                          Header="SSH user"
                                          PlaceholderText="user"/>
-                                <TextBox Grid.Column="1"
+                                <TextBox x:Uid="ConnectionPage_SSHHost" Grid.Column="1"
                                          x:Name="AddSshHostBox"
                                          Header="SSH host"
                                          PlaceholderText="machine-name"/>
@@ -883,11 +883,11 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="*"/>
                                 </Grid.ColumnDefinitions>
-                                <TextBox Grid.Column="0"
+                                <TextBox x:Uid="ConnectionPage_RemotePort" Grid.Column="0"
                                          x:Name="AddSshRemotePortBox"
                                          Header="Remote port"
                                          PlaceholderText="18789"/>
-                                <TextBox Grid.Column="1"
+                                <TextBox x:Uid="ConnectionPage_LocalPort" Grid.Column="1"
                                          x:Name="AddSshLocalPortBox"
                                          Header="Local port"
                                          PlaceholderText="18789"/>
@@ -908,12 +908,12 @@
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
-                        <Button Grid.Column="1"
+                        <Button x:Uid="ConnectionPage_SaveAmpConnect" Grid.Column="1"
                                 x:Name="AddSaveButton"
                                 Content="Save &amp; connect"
                                 Click="OnAddSave"
                                 AutomationProperties.AutomationId="AddSave"/>
-                        <Button Grid.Column="2"
+                        <Button x:Uid="ConnectionPage_Cancel" Grid.Column="2"
                                 Content="Cancel"
                                 Click="OnAddBack"/>
                     </Grid>

--- a/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml
@@ -25,20 +25,20 @@
                      <ColumnDefinition Width="Auto"/>
                      <ColumnDefinition Width="Auto"/>
                  </Grid.ColumnDefinitions>
-                 <TextBlock Text="⏱️ Cron Jobs" Style="{StaticResource TitleTextBlockStyle}" Grid.Column="0"/>
+                 <TextBlock x:Uid="CronPage_CronJobs" Text="⏱️ Cron Jobs" Style="{StaticResource TitleTextBlockStyle}" Grid.Column="0"/>
                  <TextBlock x:Name="JobCountText" Text="(0)" VerticalAlignment="Center" Grid.Column="1" Margin="8,0,0,0"
                             Style="{StaticResource CaptionTextBlockStyle}"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                  <Button x:Name="RefreshButton" Grid.Column="3" Click="OnRefreshClick" Padding="8,4" Margin="0,0,8,0">
                      <StackPanel Orientation="Horizontal" Spacing="4">
                          <FontIcon Glyph="&#xE72C;" FontSize="14"/>
-                         <TextBlock Text="Refresh" FontSize="13"/>
+                         <TextBlock x:Uid="CronPage_Refresh" Text="Refresh" FontSize="13"/>
                      </StackPanel>
                  </Button>
                  <Button x:Name="NewJobButton" Grid.Column="4" Click="OnNewJobClick" Padding="8,4">
                      <StackPanel Orientation="Horizontal" Spacing="4">
                          <FontIcon Glyph="&#xE710;" FontSize="14"/>
-                         <TextBlock Text="New Job" FontSize="13"/>
+                         <TextBlock x:Uid="CronPage_NewJob" Text="New Job" FontSize="13"/>
                     </StackPanel>
                 </Button>
             </Grid>
@@ -61,13 +61,13 @@
          <!-- Store path (hidden, just for data) -->
          <TextBlock x:Name="StorePathText" Visibility="Collapsed"/>
 
-         <InfoBar x:Name="ConnectionInfoBar" Grid.Row="1"
+         <InfoBar x:Uid="CronPage_GatewayDisconnected" x:Name="ConnectionInfoBar" Grid.Row="1"
                   IsOpen="False" IsClosable="False" Severity="Warning"
                   Title="Gateway disconnected"
                   Message="Connect to a gateway to load cron jobs."
                   Margin="0,0,0,12">
              <InfoBar.ActionButton>
-                 <Button Content="Open Connection" Click="OnOpenConnectionClick"/>
+                 <Button x:Uid="CronPage_OpenConnection" Content="Open Connection" Click="OnOpenConnectionClick"/>
              </InfoBar.ActionButton>
          </InfoBar>
 
@@ -76,7 +76,7 @@
                 Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                 CornerRadius="8" Padding="20" Margin="0,0,0,12">
             <StackPanel Spacing="16">
-                <TextBlock x:Name="FormTitle" Text="New Cron Job" Style="{StaticResource SubtitleTextBlockStyle}"/>
+                <TextBlock x:Uid="CronPage_NewCronJob" x:Name="FormTitle" Text="New Cron Job" Style="{StaticResource SubtitleTextBlockStyle}"/>
 
                 <!-- Row 1: Name + Schedule type -->
                 <Grid ColumnSpacing="12">
@@ -85,25 +85,25 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
                     <StackPanel Spacing="4" Grid.Column="0">
-                        <TextBlock Text="NAME" FontSize="11" FontWeight="SemiBold"
+                        <TextBlock x:Uid="CronPage_NAME" Text="NAME" FontSize="11" FontWeight="SemiBold"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <TextBox x:Name="FormName" PlaceholderText="Morning brief" FontSize="13"/>
+                        <TextBox x:Uid="CronPage_MorningBrief" x:Name="FormName" PlaceholderText="Morning brief" FontSize="13"/>
                     </StackPanel>
                     <StackPanel Spacing="4" Grid.Column="1">
-                        <TextBlock Text="SCHEDULE" FontSize="11" FontWeight="SemiBold"
+                        <TextBlock x:Uid="CronPage_SCHEDULE" Text="SCHEDULE" FontSize="11" FontWeight="SemiBold"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                         <ComboBox x:Name="FormScheduleKind" SelectedIndex="0" HorizontalAlignment="Stretch" FontSize="13"
                                   SelectionChanged="OnScheduleKindChanged">
-                            <ComboBoxItem Content="Every" Tag="every"/>
-                            <ComboBoxItem Content="At" Tag="at"/>
-                            <ComboBoxItem Content="Cron" Tag="cron"/>
+                            <ComboBoxItem x:Uid="CronPage_Every" Content="Every" Tag="every"/>
+                            <ComboBoxItem x:Uid="CronPage_At" Content="At" Tag="at"/>
+                            <ComboBoxItem x:Uid="CronPage_Cron" Content="Cron" Tag="cron"/>
                         </ComboBox>
                     </StackPanel>
                 </Grid>
 
                 <!-- Schedule presets (cron only) -->
                 <StackPanel x:Name="CronFields" Spacing="8">
-                    <TextBlock Text="QUICK PRESETS" FontSize="11" FontWeight="SemiBold"
+                    <TextBlock x:Uid="CronPage_QUICKPRESETS" Text="QUICK PRESETS" FontSize="11" FontWeight="SemiBold"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                     <ItemsControl x:Name="PresetGrid">
                         <ItemsControl.ItemsPanel>
@@ -111,15 +111,15 @@
                                 <StackPanel Orientation="Horizontal" Spacing="6"/>
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
-                        <Button Content="⏰ Hourly" Tag="0 * * * *" Click="OnPresetClick"
+                        <Button x:Uid="CronPage_Hourly" Content="⏰ Hourly" Tag="0 * * * *" Click="OnPresetClick"
                                 FontSize="11" Padding="10,6" CornerRadius="6"/>
-                        <Button Content="🌅 Daily 9am" Tag="0 9 * * *" Click="OnPresetClick"
+                        <Button x:Uid="CronPage_Daily9am" Content="🌅 Daily 9am" Tag="0 9 * * *" Click="OnPresetClick"
                                 FontSize="11" Padding="10,6" CornerRadius="6"/>
-                        <Button Content="🌆 Daily 6pm" Tag="0 18 * * *" Click="OnPresetClick"
+                        <Button x:Uid="CronPage_Daily6pm" Content="🌆 Daily 6pm" Tag="0 18 * * *" Click="OnPresetClick"
                                 FontSize="11" Padding="10,6" CornerRadius="6"/>
-                        <Button Content="💼 Weekdays" Tag="0 9 * * 1-5" Click="OnPresetClick"
+                        <Button x:Uid="CronPage_Weekdays" Content="💼 Weekdays" Tag="0 9 * * 1-5" Click="OnPresetClick"
                                 FontSize="11" Padding="10,6" CornerRadius="6"/>
-                        <Button Content="📅 Weekly" Tag="0 9 * * 1" Click="OnPresetClick"
+                        <Button x:Uid="CronPage_Weekly" Content="📅 Weekly" Tag="0 9 * * 1" Click="OnPresetClick"
                                 FontSize="11" Padding="10,6" CornerRadius="6"/>
                     </ItemsControl>
 
@@ -130,24 +130,24 @@
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
                         <StackPanel Spacing="4" Grid.Column="0">
-                            <TextBlock Text="EXPRESSION" FontSize="11" FontWeight="SemiBold"
+                            <TextBlock x:Uid="CronPage_EXPRESSION" Text="EXPRESSION" FontSize="11" FontWeight="SemiBold"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                             <TextBox x:Name="FormCronExpr" PlaceholderText="0 9 * * *"
                                      FontSize="13" FontFamily="Consolas"/>
                         </StackPanel>
                         <StackPanel Spacing="4" Grid.Column="1">
-                            <TextBlock Text="TIMEZONE" FontSize="11" FontWeight="SemiBold"
+                            <TextBlock x:Uid="CronPage_TIMEZONE" Text="TIMEZONE" FontSize="11" FontWeight="SemiBold"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                            <ComboBox x:Name="FormTimezone" HorizontalAlignment="Stretch" FontSize="13"
+                            <ComboBox x:Uid="CronPage_Optional" x:Name="FormTimezone" HorizontalAlignment="Stretch" FontSize="13"
                                       PlaceholderText="Optional">
-                                <ComboBoxItem Content="America/New_York" Tag="America/New_York"/>
-                                <ComboBoxItem Content="America/Chicago" Tag="America/Chicago"/>
-                                <ComboBoxItem Content="America/Denver" Tag="America/Denver"/>
-                                <ComboBoxItem Content="America/Los_Angeles" Tag="America/Los_Angeles"/>
-                                <ComboBoxItem Content="Europe/London" Tag="Europe/London"/>
-                                <ComboBoxItem Content="Europe/Berlin" Tag="Europe/Berlin"/>
-                                <ComboBoxItem Content="Asia/Tokyo" Tag="Asia/Tokyo"/>
-                                <ComboBoxItem Content="UTC" Tag="UTC"/>
+                                <ComboBoxItem x:Uid="CronPage_AmericaNewYork" Content="America/New_York" Tag="America/New_York"/>
+                                <ComboBoxItem x:Uid="CronPage_AmericaChicago" Content="America/Chicago" Tag="America/Chicago"/>
+                                <ComboBoxItem x:Uid="CronPage_AmericaDenver" Content="America/Denver" Tag="America/Denver"/>
+                                <ComboBoxItem x:Uid="CronPage_AmericaLosAngeles" Content="America/Los_Angeles" Tag="America/Los_Angeles"/>
+                                <ComboBoxItem x:Uid="CronPage_EuropeLondon" Content="Europe/London" Tag="Europe/London"/>
+                                <ComboBoxItem x:Uid="CronPage_EuropeBerlin" Content="Europe/Berlin" Tag="Europe/Berlin"/>
+                                <ComboBoxItem x:Uid="CronPage_AsiaTokyo" Content="Asia/Tokyo" Tag="Asia/Tokyo"/>
+                                <ComboBoxItem x:Uid="CronPage_UTC" Content="UTC" Tag="UTC"/>
                             </ComboBox>
                         </StackPanel>
                     </Grid>
@@ -161,18 +161,18 @@
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
                         <StackPanel Spacing="4" Grid.Column="0">
-                            <TextBlock Text="EVERY" FontSize="11" FontWeight="SemiBold"
+                            <TextBlock x:Uid="CronPage_EVERY" Text="EVERY" FontSize="11" FontWeight="SemiBold"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                             <TextBox x:Name="FormEveryValue" Text="30" FontSize="13"
                                      InputScope="Number"/>
                         </StackPanel>
                         <StackPanel Spacing="4" Grid.Column="1">
-                            <TextBlock Text="UNIT" FontSize="11" FontWeight="SemiBold"
+                            <TextBlock x:Uid="CronPage_UNIT" Text="UNIT" FontSize="11" FontWeight="SemiBold"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                             <ComboBox x:Name="FormEveryUnit" SelectedIndex="0" HorizontalAlignment="Stretch" FontSize="13">
-                                <ComboBoxItem Content="Minutes" Tag="60000"/>
-                                <ComboBoxItem Content="Hours" Tag="3600000"/>
-                                <ComboBoxItem Content="Days" Tag="86400000"/>
+                                <ComboBoxItem x:Uid="CronPage_Minutes" Content="Minutes" Tag="60000"/>
+                                <ComboBoxItem x:Uid="CronPage_Hours" Content="Hours" Tag="3600000"/>
+                                <ComboBoxItem x:Uid="CronPage_Days" Content="Days" Tag="86400000"/>
                             </ComboBox>
                         </StackPanel>
                     </Grid>
@@ -180,23 +180,23 @@
 
                 <!-- At fields -->
                 <StackPanel x:Name="AtFields" Spacing="4" Visibility="Collapsed">
-                    <TextBlock Text="RUN AT" FontSize="11" FontWeight="SemiBold"
+                    <TextBlock x:Uid="CronPage_RUNAT" Text="RUN AT" FontSize="11" FontWeight="SemiBold"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                     <StackPanel Orientation="Horizontal" Spacing="12">
-                        <CalendarDatePicker x:Name="FormAtDate" PlaceholderText="Date"
+                        <CalendarDatePicker x:Uid="CronPage_Date" x:Name="FormAtDate" PlaceholderText="Date"
                                             DateFormat="{}{month.abbreviated} {day.integer}, {year.full}"/>
-                        <TextBox x:Name="FormAtTime" PlaceholderText="3:30 PM" Width="120"
+                        <TextBox x:Uid="CronPage_330PM" x:Name="FormAtTime" PlaceholderText="3:30 PM" Width="120"
                                  InputScope="TimeHour"/>
                     </StackPanel>
-                    <CheckBox x:Name="FormDeleteAfterRun" Content="Delete job after it runs" IsChecked="True"
+                    <CheckBox x:Uid="CronPage_DeleteJobAfterIt" x:Name="FormDeleteAfterRun" Content="Delete job after it runs" IsChecked="True"
                               FontSize="12" Margin="0,4,0,0"/>
                 </StackPanel>
 
                 <!-- Prompt -->
                 <StackPanel Spacing="4">
-                    <TextBlock Text="PROMPT / PAYLOAD" FontSize="11" FontWeight="SemiBold"
+                    <TextBlock x:Uid="CronPage_PROMPTPAYLOAD" Text="PROMPT / PAYLOAD" FontSize="11" FontWeight="SemiBold"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                    <TextBox x:Name="FormMessage" PlaceholderText="What should the agent do?"
+                    <TextBox x:Uid="CronPage_WhatShouldTheAgent" x:Name="FormMessage" PlaceholderText="What should the agent do?"
                              AcceptsReturn="True" TextWrapping="Wrap" MinHeight="72" MaxHeight="140" FontSize="13"/>
                 </StackPanel>
 
@@ -207,25 +207,25 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
                     <StackPanel Spacing="4" Grid.Column="0">
-                        <TextBlock Text="DELIVERY" FontSize="11" FontWeight="SemiBold"
+                        <TextBlock x:Uid="CronPage_DELIVERY" Text="DELIVERY" FontSize="11" FontWeight="SemiBold"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                         <ComboBox x:Name="FormDeliveryMode" SelectedIndex="0" HorizontalAlignment="Stretch" FontSize="13"
                                   SelectionChanged="OnDeliveryModeChanged">
-                            <ComboBoxItem Content="Silent (none)" Tag="none"/>
-                            <ComboBoxItem Content="Notify me (announce)" Tag="announce"/>
+                            <ComboBoxItem x:Uid="CronPage_SilentNone" Content="Silent (none)" Tag="none"/>
+                            <ComboBoxItem x:Uid="CronPage_NotifyMeAnnounce" Content="Notify me (announce)" Tag="announce"/>
                         </ComboBox>
                     </StackPanel>
                     <StackPanel x:Name="DeliveryChannelPanel" Spacing="4" Grid.Column="1" Visibility="Collapsed">
-                        <TextBlock Text="CHANNEL" FontSize="11" FontWeight="SemiBold"
+                        <TextBlock x:Uid="CronPage_CHANNEL" Text="CHANNEL" FontSize="11" FontWeight="SemiBold"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <TextBox x:Name="FormDeliveryChannel" PlaceholderText="e.g. webchat" FontSize="13"/>
+                        <TextBox x:Uid="CronPage_EGWebchat" x:Name="FormDeliveryChannel" PlaceholderText="e.g. webchat" FontSize="13"/>
                     </StackPanel>
                 </Grid>
 
                 <!-- Advanced options -->
                 <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
                     <Expander.Header>
-                        <TextBlock Text="Advanced options" FontSize="12"
+                        <TextBlock x:Uid="CronPage_AdvancedOptions" Text="Advanced options" FontSize="12"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                     </Expander.Header>
                     <StackPanel Spacing="12" Margin="0,4,0,0">
@@ -236,19 +236,19 @@
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
                             <StackPanel Spacing="4" Grid.Column="0">
-                                <TextBlock Text="SESSION BEHAVIOR" FontSize="11" FontWeight="SemiBold"
+                                <TextBlock x:Uid="CronPage_SESSIONBEHAVIOR" Text="SESSION BEHAVIOR" FontSize="11" FontWeight="SemiBold"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                                 <ComboBox x:Name="FormSessionTarget" SelectedIndex="0" HorizontalAlignment="Stretch" FontSize="13">
-                                    <ComboBoxItem Content="New session each run" Tag="isolated"/>
-                                    <ComboBoxItem Content="Resume main session" Tag="main"/>
+                                    <ComboBoxItem x:Uid="CronPage_NewSessionEachRun" Content="New session each run" Tag="isolated"/>
+                                    <ComboBoxItem x:Uid="CronPage_ResumeMainSession" Content="Resume main session" Tag="main"/>
                                 </ComboBox>
                             </StackPanel>
                             <StackPanel Spacing="4" Grid.Column="1">
-                                <TextBlock Text="WAKE MODE" FontSize="11" FontWeight="SemiBold"
+                                <TextBlock x:Uid="CronPage_WAKEMODE" Text="WAKE MODE" FontSize="11" FontWeight="SemiBold"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                                 <ComboBox x:Name="FormWakeMode" SelectedIndex="0" HorizontalAlignment="Stretch" FontSize="13">
-                                    <ComboBoxItem Content="Now (immediate)" Tag="now"/>
-                                    <ComboBoxItem Content="Queue (wait for idle)" Tag="queue"/>
+                                    <ComboBoxItem x:Uid="CronPage_NowImmediate" Content="Now (immediate)" Tag="now"/>
+                                    <ComboBoxItem x:Uid="CronPage_QueueWaitForIdle" Content="Queue (wait for idle)" Tag="queue"/>
                                 </ComboBox>
                             </StackPanel>
                         </Grid>
@@ -261,8 +261,8 @@
 
                 <!-- Buttons -->
                 <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right" Margin="0,4,0,0">
-                    <Button x:Name="FormCancelButton" Content="Cancel" Click="OnFormCancelClick" Padding="16,8"/>
-                    <Button x:Name="FormSaveButton" Content="Create Job" Click="OnFormSaveClick"
+                    <Button x:Uid="CronPage_Cancel" x:Name="FormCancelButton" Content="Cancel" Click="OnFormCancelClick" Padding="16,8"/>
+                    <Button x:Uid="CronPage_CreateJob" x:Name="FormSaveButton" Content="Create Job" Click="OnFormSaveClick"
                             Style="{StaticResource AccentButtonStyle}" Padding="16,8" FontWeight="SemiBold"/>
                 </StackPanel>
             </StackPanel>
@@ -278,7 +278,7 @@
                      HorizontalAlignment="Center" VerticalAlignment="Center"
                      Visibility="Visible">
              <ProgressRing IsActive="True" Width="22" Height="22"/>
-             <TextBlock Text="Loading cron jobs..."
+             <TextBlock x:Uid="CronPage_LoadingCronJobs" Text="Loading cron jobs..."
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         VerticalAlignment="Center"/>
          </StackPanel>
@@ -288,10 +288,10 @@
                      VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8"
                      Visibility="Collapsed">
             <TextBlock Text="⏱️" FontSize="48" HorizontalAlignment="Center"/>
-            <TextBlock Text="No cron jobs configured"
+            <TextBlock x:Uid="CronPage_NoCronJobsConfigured" Text="No cron jobs configured"
                        Style="{StaticResource SubtitleTextBlockStyle}"
                        HorizontalAlignment="Center"/>
-            <TextBlock Text="Cron jobs will appear here when configured via the gateway."
+            <TextBlock x:Uid="CronPage_CronJobsWillAppear" Text="Cron jobs will appear here when configured via the gateway."
                        Style="{StaticResource CaptionTextBlockStyle}"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                        HorizontalAlignment="Center" TextWrapping="Wrap" MaxWidth="320"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml
@@ -81,7 +81,7 @@
                          System → Storage). Padding=0 strips button chrome
                          so they read as inline links flush with the
                          message text. -->
-                    <controls:InfoBar x:Name="StatusInfoBar"
+                    <controls:InfoBar x:Uid="DebugPage_Status" x:Name="StatusInfoBar"
                                       IsOpen="True"
                                       IsClosable="False"
                                       Severity="Informational"
@@ -190,7 +190,7 @@
                          InfoBar with IsOpen=False does not consume any
                          vertical layout space, so this is a no-op when
                          idle. -->
-                    <controls:InfoBar x:Name="CopyFeedbackInfoBar"
+                    <controls:InfoBar x:Uid="DebugPage_Copied" x:Name="CopyFeedbackInfoBar"
                                       IsOpen="False"
                                       IsClosable="False"
                                       Severity="Success"
@@ -298,9 +298,9 @@
                                           MinWidth="220"
                                           AutomationProperties.AutomationId="DebugPageHubChatOverride"
                                           SelectionChanged="OnHubChatOverrideChanged">
-                                    <ComboBoxItem Content="No override" Tag="NoOverride"/>
-                                    <ComboBoxItem Content="Force Gateway Chat UI" Tag="ForceLegacy"/>
-                                    <ComboBoxItem Content="Force Companion Chat UI" Tag="ForceNative"/>
+                                    <ComboBoxItem x:Uid="DebugPage_NoOverride" Content="No override" Tag="NoOverride"/>
+                                    <ComboBoxItem x:Uid="DebugPage_ForceGatewayChatUI" Content="Force Gateway Chat UI" Tag="ForceLegacy"/>
+                                    <ComboBoxItem x:Uid="DebugPage_ForceCompanionChatUI" Content="Force Companion Chat UI" Tag="ForceNative"/>
                                 </ComboBox>
                             </toolkit:SettingsCard>
                             <toolkit:SettingsCard x:Uid="DiagnosticsPage_Card_TrayChat"
@@ -309,9 +309,9 @@
                                           MinWidth="220"
                                           AutomationProperties.AutomationId="DebugPageTrayChatOverride"
                                           SelectionChanged="OnTrayChatOverrideChanged">
-                                    <ComboBoxItem Content="No override" Tag="NoOverride"/>
-                                    <ComboBoxItem Content="Force Gateway Chat UI" Tag="ForceLegacy"/>
-                                    <ComboBoxItem Content="Force Companion Chat UI" Tag="ForceNative"/>
+                                    <ComboBoxItem x:Uid="DebugPage_NoOverride2" Content="No override" Tag="NoOverride"/>
+                                    <ComboBoxItem x:Uid="DebugPage_ForceGatewayChatUI2" Content="Force Gateway Chat UI" Tag="ForceLegacy"/>
+                                    <ComboBoxItem x:Uid="DebugPage_ForceCompanionChatUI2" Content="Force Companion Chat UI" Tag="ForceNative"/>
                                 </ComboBox>
                             </toolkit:SettingsCard>
                         </toolkit:SettingsExpander.Items>
@@ -416,7 +416,7 @@
                             <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Refresh, Mode=OneTime}"
                                       FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                       FontSize="12"/>
-                            <TextBlock Text="Refresh"/>
+                            <TextBlock x:Uid="DebugPage_Refresh" Text="Refresh"/>
                         </StackPanel>
                     </Button>
                     <Button x:Name="DetailCopyButton"
@@ -426,7 +426,7 @@
                             <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Copy, Mode=OneTime}"
                                       FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                       FontSize="12"/>
-                            <TextBlock Text="Copy"/>
+                            <TextBlock x:Uid="DebugPage_Copy" Text="Copy"/>
                         </StackPanel>
                     </Button>
                     <Button x:Name="DetailOpenFileButton"
@@ -437,7 +437,7 @@
                             <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.OpenInBrowser, Mode=OneTime}"
                                       FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                       FontSize="12"/>
-                            <TextBlock Text="Open file"/>
+                            <TextBlock x:Uid="DebugPage_OpenFile" Text="Open file"/>
                         </StackPanel>
                     </Button>
                 </StackPanel>

--- a/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml
@@ -92,17 +92,17 @@
                               Foreground="{ThemeResource SystemFillColorCautionBrush}"
                               VerticalAlignment="Center"/>
                     <StackPanel Spacing="2" VerticalAlignment="Center">
-                        <TextBlock x:Name="PendingPairBannerText"
+                        <TextBlock x:Uid="InstancesPage_PairingApprovalRequired" x:Name="PendingPairBannerText"
                                    Text="Pairing approval required"
                                    Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                        <TextBlock x:Name="PendingPairBannerSubtext"
+                        <TextBlock x:Uid="InstancesPage_ANodeHasConnected" x:Name="PendingPairBannerSubtext"
                                    Text="A node has connected but its capabilities won't activate until you approve the pairing request."
                                    Style="{StaticResource CaptionTextBlockStyle}"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    TextWrapping="Wrap"
                                    MaxWidth="520"/>
                     </StackPanel>
-                    <Button x:Name="PendingPairBannerAction"
+                    <Button x:Uid="InstancesPage_ReviewOnConnectionPage" x:Name="PendingPairBannerAction"
                             Content="Review on Connection page"
                             Click="OnPendingPairBannerClicked"
                             VerticalAlignment="Center"

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml
@@ -20,12 +20,12 @@
                              AutomationProperties.AutomationId="BackToConnectionLink">
                 <StackPanel Orientation="Horizontal" Spacing="6">
                     <FontIcon Glyph="&#xE72B;" FontSize="12"/>
-                    <TextBlock Text="Back to Connection"/>
+                    <TextBlock x:Uid="PermissionsPage_BackToConnection" Text="Back to Connection"/>
                 </StackPanel>
             </HyperlinkButton>
 
             <!-- ───────── Page header ───────── -->
-            <TextBlock Text="Permissions"
+            <TextBlock x:Uid="PermissionsPage_Permissions" Text="Permissions"
                        Style="{StaticResource TitleTextBlockStyle}"
                        Margin="0,0,0,2"/>
             <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,0,0,2">
@@ -59,9 +59,9 @@
                         <FontIcon Grid.Column="0" Glyph="&#xE839;" FontSize="22"
                                   VerticalAlignment="Center" HorizontalAlignment="Center"/>
                         <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
-                            <TextBlock Text="Node mode"
+                            <TextBlock x:Uid="PermissionsPage_NodeMode" Text="Node mode"
                                        Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                            <TextBlock Text="When on, this PC registers as a node and offers the capabilities below to agents over the gateway."
+                            <TextBlock x:Uid="PermissionsPage_WhenOnThisPC" Text="When on, this PC registers as a node and offers the capabilities below to agents over the gateway."
                                        Style="{StaticResource CaptionTextBlockStyle}"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                        TextWrapping="Wrap"/>
@@ -97,9 +97,9 @@
             </Border>
 
             <!-- ═════════ Capability features ═════════ -->
-            <TextBlock x:Name="FeaturesSectionHeader" Text="Capabilities" Style="{StaticResource BodyStrongTextBlockStyle}"
+            <TextBlock x:Uid="PermissionsPage_Capabilities" x:Name="FeaturesSectionHeader" Text="Capabilities" Style="{StaticResource BodyStrongTextBlockStyle}"
                        Margin="{StaticResource PermSectionHeaderMargin}"/>
-            <TextBlock x:Name="FeaturesSectionDescription"
+            <TextBlock x:Uid="PermissionsPage_ToggleIndividualFeaturesThat" x:Name="FeaturesSectionDescription"
                        Text="Toggle individual features that agents may request from this PC."
                        Style="{StaticResource CaptionTextBlockStyle}"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -171,7 +171,7 @@
             </Border>
 
             <!-- ═════════ Integrations ═════════ -->
-            <TextBlock Text="Integrations" Style="{StaticResource BodyStrongTextBlockStyle}"
+            <TextBlock x:Uid="PermissionsPage_Integrations" Text="Integrations" Style="{StaticResource BodyStrongTextBlockStyle}"
                        Margin="{StaticResource PermSectionHeaderMargin}"/>
 
             <Border x:Name="McpCard" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
@@ -241,8 +241,8 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="2">
-                        <TextBlock Text="Default action" Style="{StaticResource BodyTextBlockStyle}"/>
-                        <TextBlock Text="What happens when a command doesn't match any rule below."
+                        <TextBlock x:Uid="PermissionsPage_DefaultAction" Text="Default action" Style="{StaticResource BodyTextBlockStyle}"/>
+                        <TextBlock x:Uid="PermissionsPage_WhatHappensWhenA" Text="What happens when a command doesn't match any rule below."
                                    Style="{StaticResource CaptionTextBlockStyle}"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    TextWrapping="Wrap"/>
@@ -271,12 +271,12 @@
                         </Grid.ColumnDefinitions>
                         <StackPanel Grid.Column="0" Spacing="2">
                             <TextBlock x:Uid="PermissionsPage_TextBlock_28" Text="Rules" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                            <TextBlock Text="Patterns are matched left-to-right against the full command line. Use * as a wildcard. Changes save automatically."
+                            <TextBlock x:Uid="PermissionsPage_PatternsAreMatchedLeft" Text="Patterns are matched left-to-right against the full command line. Use * as a wildcard. Changes save automatically."
                                        Style="{StaticResource CaptionTextBlockStyle}"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                        TextWrapping="Wrap"/>
                         </StackPanel>
-                        <TextBlock Grid.Column="1" x:Name="ExecPolicySavedHint"
+                        <TextBlock x:Uid="PermissionsPage_Saved" Grid.Column="1" x:Name="ExecPolicySavedHint"
                                    Text="Saved"
                                    VerticalAlignment="Center"
                                    Style="{StaticResource CaptionTextBlockStyle}"
@@ -287,7 +287,7 @@
                                 Background="{ThemeResource ControlAltFillColorSecondaryBrush}"
                                 CornerRadius="10" Padding="10,2"
                                 VerticalAlignment="Center">
-                            <TextBlock x:Name="RulesCountBadge" Text="0 rules"
+                            <TextBlock x:Uid="PermissionsPage_0Rules" x:Name="RulesCountBadge" Text="0 rules"
                                        Style="{StaticResource CaptionTextBlockStyle}"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                         </Border>
@@ -296,7 +296,7 @@
                     <Border Height="1" Background="{ThemeResource CardStrokeColorDefaultBrush}"/>
 
                     <!-- Empty state — visible when there are no rules -->
-                    <TextBlock x:Name="RulesEmptyState"
+                    <TextBlock x:Uid="PermissionsPage_NoRulesYetAdd" x:Name="RulesEmptyState"
                                Text="No rules yet. Add a pattern below to allow or deny specific commands."
                                Style="{StaticResource CaptionTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorTertiaryBrush}"
@@ -398,7 +398,7 @@
             </Border>
 
             <!-- ═════════ Windows-level privacy ═════════ -->
-            <TextBlock Text="Windows privacy" Style="{StaticResource BodyStrongTextBlockStyle}"
+            <TextBlock x:Uid="PermissionsPage_WindowsPrivacy" Text="Windows privacy" Style="{StaticResource BodyStrongTextBlockStyle}"
                        Margin="{StaticResource PermSectionHeaderMargin}"/>
 
             <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
@@ -410,8 +410,8 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="2">
-                        <TextBlock Text="Camera, microphone &amp; screen access" Style="{StaticResource BodyTextBlockStyle}"/>
-                        <TextBlock Text="System-level privacy permissions are managed by Windows. Open Windows Privacy Settings to grant or revoke OpenClaw access."
+                        <TextBlock x:Uid="PermissionsPage_CameraMicrophoneAmpScreen" Text="Camera, microphone &amp; screen access" Style="{StaticResource BodyTextBlockStyle}"/>
+                        <TextBlock x:Uid="PermissionsPage_SystemLevelPrivacyPermissions" Text="System-level privacy permissions are managed by Windows. Open Windows Privacy Settings to grant or revoke OpenClaw access."
                                    Style="{StaticResource CaptionTextBlockStyle}"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    TextWrapping="Wrap"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml
@@ -25,11 +25,11 @@
                            VerticalAlignment="Center" />
 
                 <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
-                    <TextBlock x:Name="SandboxStatusTitle"
+                    <TextBlock x:Uid="SandboxPage_NodeSandboxIsOn" x:Name="SandboxStatusTitle"
                                Text="Node sandbox is on"
                                Style="{StaticResource TitleTextBlockStyle}"
                                TextWrapping="Wrap" />
-                    <TextBlock x:Name="SandboxStatusSubtext"
+                    <TextBlock x:Uid="SandboxPage_ProgramsTheAgentRuns" x:Name="SandboxStatusSubtext"
                                Text="Programs the agent runs on this PC are contained."
                                TextWrapping="Wrap"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
@@ -68,9 +68,9 @@
                                   Glyph="&#xE946;"
                                   VerticalAlignment="Center" />
                         <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
-                            <TextBlock Text="What gets contained"
+                            <TextBlock x:Uid="SandboxPage_WhatGetsContained" Text="What gets contained"
                                        Style="{StaticResource BodyStrongTextBlockStyle}" />
-                            <TextBlock Text="See which commands this page covers — and which need different controls."
+                            <TextBlock x:Uid="SandboxPage_SeeWhichCommandsThis" Text="See which commands this page covers — and which need different controls."
                                        Style="{StaticResource CaptionTextBlockStyle}"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                        TextWrapping="Wrap" />
@@ -91,9 +91,9 @@
                                   VerticalAlignment="Top"
                                   Margin="0,2,0,0" />
                         <TextBlock Grid.Column="1" TextWrapping="Wrap">
-                            <Run Text="Commands the agent runs through the Windows node (" />
-                            <Run Text="system.run" FontFamily="Consolas" />
-                            <Run Text=") are contained by the settings below." />
+                            <Run x:Uid="SandboxPage_CommandsTheAgentRuns" Text="Commands the agent runs through the Windows node (" />
+                            <Run x:Uid="SandboxPage_SystemRun" Text="system.run" FontFamily="Consolas" />
+                            <Run x:Uid="SandboxPage_AreContainedByThe" Text=") are contained by the settings below." />
                         </TextBlock>
                     </Grid>
 
@@ -108,7 +108,7 @@
                                   Foreground="{ThemeResource SystemFillColorCautionBrush}"
                                   VerticalAlignment="Top"
                                   Margin="0,2,0,0" />
-                        <TextBlock Grid.Column="1"
+                        <TextBlock x:Uid="SandboxPage_CommandsTheAgentRuns2" Grid.Column="1"
                                    Text="Commands the agent runs directly on the gateway aren't. If the gateway is on WSL on this PC they can reach your Windows files, clipboard, and network — use the gateway's exec approvals."
                                    TextWrapping="Wrap" />
                     </Grid>
@@ -116,7 +116,7 @@
             </Expander>
 
             <!-- Prominent error + fix action when MXC sandboxing is unavailable -->
-            <InfoBar x:Name="UnavailableActionBar"
+            <InfoBar x:Uid="SandboxPage_SandboxUnavailable" x:Name="UnavailableActionBar"
                      IsOpen="False"
                      IsClosable="False"
                      Severity="Error"
@@ -126,7 +126,7 @@
                         <TextBlock x:Name="UnavailableActionMessage" TextWrapping="Wrap" />
                         <StackPanel Orientation="Horizontal" Spacing="8">
                             <Button x:Name="UnavailablePrimaryButton" Click="OnUnavailableActionClick" Style="{ThemeResource AccentButtonStyle}" />
-                            <HyperlinkButton Content="Learn more about MXC sandboxing"
+                            <HyperlinkButton x:Uid="SandboxPage_LearnMoreAboutMXC" Content="Learn more about MXC sandboxing"
                                              NavigateUri="https://github.com/microsoft/mxc" />
                         </StackPanel>
                     </StackPanel>
@@ -142,9 +142,9 @@
                     CornerRadius="8"
                     Padding="20">
                 <StackPanel Spacing="6">
-                    <TextBlock Text="Security level"
+                    <TextBlock x:Uid="SandboxPage_SecurityLevel" Text="Security level"
                                Style="{StaticResource SubtitleTextBlockStyle}" />
-                    <TextBlock Text="One click to set every control below. Custom folders stay as you set them."
+                    <TextBlock x:Uid="SandboxPage_OneClickToSet" Text="One click to set every control below. Custom folders stay as you set them."
                                TextWrapping="Wrap"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                     <Grid ColumnSpacing="12" Margin="0,8,0,0">
@@ -165,10 +165,10 @@
                                 CornerRadius="8"
                                 Click="OnPresetLockedClick">
                             <StackPanel Spacing="8">
-                                <TextBlock Text="🔒 Locked Down"
+                                <TextBlock x:Uid="SandboxPage_LockedDown" Text="🔒 Locked Down"
                                            FontSize="18"
                                            FontWeight="SemiBold" />
-                                <TextBlock Text="No internet, no clipboard, no standard user folders."
+                                <TextBlock x:Uid="SandboxPage_NoInternetNoClipboard" Text="No internet, no clipboard, no standard user folders."
                                            TextWrapping="Wrap"
                                            FontSize="13"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
@@ -186,10 +186,10 @@
                                 CornerRadius="8"
                                 Click="OnPresetBalancedClick">
                             <StackPanel Spacing="8">
-                                <TextBlock Text="🛡 Recommended"
+                                <TextBlock x:Uid="SandboxPage_Recommended" Text="🛡 Recommended"
                                            FontSize="18"
                                            FontWeight="SemiBold" />
-                                <TextBlock Text="Internet on. Read-only on Documents, Downloads, Desktop. Clipboard read."
+                                <TextBlock x:Uid="SandboxPage_InternetOnReadOnly" Text="Internet on. Read-only on Documents, Downloads, Desktop. Clipboard read."
                                            TextWrapping="Wrap"
                                            FontSize="13"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
@@ -207,10 +207,10 @@
                                 CornerRadius="8"
                                 Click="OnPresetPermissiveClick">
                             <StackPanel Spacing="8">
-                                <TextBlock Text="⚠ Unprotected"
+                                <TextBlock x:Uid="SandboxPage_Unprotected" Text="⚠ Unprotected"
                                            FontSize="18"
                                            FontWeight="SemiBold" />
-                                <TextBlock Text="Internet on. Read+write on Documents, Downloads, Desktop. Clipboard read+write."
+                                <TextBlock x:Uid="SandboxPage_InternetOnReadWrite" Text="Internet on. Read+write on Documents, Downloads, Desktop. Clipboard read+write."
                                            TextWrapping="Wrap"
                                            FontSize="13"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
@@ -219,7 +219,7 @@
                     </Grid>
 
                     <!-- Inline warning shown when a preset is applied but custom folder grants remain -->
-                    <InfoBar x:Name="PresetCustomFoldersWarning"
+                    <InfoBar x:Uid="SandboxPage_CustomFolderGrantsStill" x:Name="PresetCustomFoldersWarning"
                              IsOpen="False"
                              IsClosable="True"
                              Severity="Warning"
@@ -234,10 +234,10 @@
                 <!-- Files (highest privacy risk — appears first) -->
                 <Expander IsExpanded="True" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
                     <Expander.Header>
-                        <TextBlock Text="📁 Files" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                        <TextBlock x:Uid="SandboxPage_Files" Text="📁 Files" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                     </Expander.Header>
                     <StackPanel Spacing="12" Padding="4">
-                        <TextBlock Text="By default the agent only has a temporary workspace folder it can read and write. Grant access to user folders below. SSH keys, browser profiles, and OpenClaw's own settings are always blocked."
+                        <TextBlock x:Uid="SandboxPage_ByDefaultTheAgent" Text="By default the agent only has a temporary workspace folder it can read and write. Grant access to user folders below. SSH keys, browser profiles, and OpenClaw's own settings are always blocked."
                                    TextWrapping="Wrap"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
 
@@ -252,38 +252,38 @@
                                 <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
 
-                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Documents" VerticalAlignment="Center"/>
+                            <TextBlock x:Uid="SandboxPage_Documents" Grid.Row="0" Grid.Column="0" Text="Documents" VerticalAlignment="Center"/>
                             <ComboBox x:Name="DocsAccessCombo" Grid.Row="0" Grid.Column="1"
                                       HorizontalAlignment="Stretch"
                                       SelectionChanged="OnDocsAccessChanged">
-                                <ComboBoxItem Content="Blocked" Tag="None" />
-                                <ComboBoxItem Content="Read only" Tag="ReadOnly" />
-                                <ComboBoxItem Content="Read &amp; write" Tag="ReadWrite" />
+                                <ComboBoxItem x:Uid="SandboxPage_Blocked" Content="Blocked" Tag="None" />
+                                <ComboBoxItem x:Uid="SandboxPage_ReadOnly" Content="Read only" Tag="ReadOnly" />
+                                <ComboBoxItem x:Uid="SandboxPage_ReadAmpWrite" Content="Read &amp; write" Tag="ReadWrite" />
                             </ComboBox>
 
-                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Downloads" VerticalAlignment="Center"/>
+                            <TextBlock x:Uid="SandboxPage_Downloads" Grid.Row="1" Grid.Column="0" Text="Downloads" VerticalAlignment="Center"/>
                             <ComboBox x:Name="DownloadsAccessCombo" Grid.Row="1" Grid.Column="1"
                                       HorizontalAlignment="Stretch"
                                       SelectionChanged="OnDownloadsAccessChanged">
-                                <ComboBoxItem Content="Blocked" Tag="None" />
-                                <ComboBoxItem Content="Read only" Tag="ReadOnly" />
-                                <ComboBoxItem Content="Read &amp; write" Tag="ReadWrite" />
+                                <ComboBoxItem x:Uid="SandboxPage_Blocked2" Content="Blocked" Tag="None" />
+                                <ComboBoxItem x:Uid="SandboxPage_ReadOnly2" Content="Read only" Tag="ReadOnly" />
+                                <ComboBoxItem x:Uid="SandboxPage_ReadAmpWrite2" Content="Read &amp; write" Tag="ReadWrite" />
                             </ComboBox>
 
-                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Desktop" VerticalAlignment="Center"/>
+                            <TextBlock x:Uid="SandboxPage_Desktop" Grid.Row="2" Grid.Column="0" Text="Desktop" VerticalAlignment="Center"/>
                             <ComboBox x:Name="DesktopAccessCombo" Grid.Row="2" Grid.Column="1"
                                       HorizontalAlignment="Stretch"
                                       SelectionChanged="OnDesktopAccessChanged">
-                                <ComboBoxItem Content="Blocked" Tag="None" />
-                                <ComboBoxItem Content="Read only" Tag="ReadOnly" />
-                                <ComboBoxItem Content="Read &amp; write" Tag="ReadWrite" />
+                                <ComboBoxItem x:Uid="SandboxPage_Blocked3" Content="Blocked" Tag="None" />
+                                <ComboBoxItem x:Uid="SandboxPage_ReadOnly3" Content="Read only" Tag="ReadOnly" />
+                                <ComboBoxItem x:Uid="SandboxPage_ReadAmpWrite3" Content="Read &amp; write" Tag="ReadWrite" />
                             </ComboBox>
                         </Grid>
 
                         <!-- Implicit-grant disclosure: PATH directories are added as
                              readonly so dev tools (git, node, python, ...) are
                              reachable from inside the sandbox. -->
-                        <TextBlock TextWrapping="Wrap"
+                        <TextBlock x:Uid="SandboxPage_ToolDirectoriesOnYour" TextWrapping="Wrap"
                                    FontSize="11"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    Text="Tool directories on your PATH are also granted read-only inside the sandbox, so command-line tools like git, node, python, and dotnet are usable. Drive roots are never granted." />
@@ -294,8 +294,8 @@
                                 CornerRadius="6"
                                 Padding="8">
                             <StackPanel Spacing="8">
-                                <TextBlock Text="Custom folders" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                <TextBlock Text="Custom grants are added on top of the rules above. Adding a folder inside Documents/Downloads/Desktop with broader access will override the row-level setting for that path."
+                                <TextBlock x:Uid="SandboxPage_CustomFolders" Text="Custom folders" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                <TextBlock x:Uid="SandboxPage_CustomGrantsAreAdded" Text="Custom grants are added on top of the rules above. Adding a folder inside Documents/Downloads/Desktop with broader access will override the row-level setting for that path."
                                            TextWrapping="Wrap"
                                            FontSize="11"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
@@ -321,9 +321,9 @@
                                                           SelectedIndex="{Binding AccessIndex, Mode=TwoWay}"
                                                           SelectionChanged="OnCustomFolderAccessChanged"
                                                           Tag="{Binding Path}">
-                                                    <ComboBoxItem Content="Blocked" />
-                                                    <ComboBoxItem Content="Read only" />
-                                                    <ComboBoxItem Content="Read &amp; write" />
+                                                    <ComboBoxItem x:Uid="SandboxPage_Blocked4" Content="Blocked" />
+                                                    <ComboBoxItem x:Uid="SandboxPage_ReadOnly4" Content="Read only" />
+                                                    <ComboBoxItem x:Uid="SandboxPage_ReadAmpWrite4" Content="Read &amp; write" />
                                                 </ComboBox>
                                                 <Button Grid.Column="2" Content="✕" Tag="{Binding Path}"
                                                         Click="OnRemoveCustomFolder"
@@ -332,12 +332,12 @@
                                         </DataTemplate>
                                     </ListView.ItemTemplate>
                                 </ListView>
-                                <TextBlock x:Name="CustomFoldersEmpty"
+                                <TextBlock x:Uid="SandboxPage_NoCustomFoldersAdded" x:Name="CustomFoldersEmpty"
                                            Text="No custom folders added."
                                            FontSize="12"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <Button Content="Add folder" Click="OnAddCustomFolder" />
+                                    <Button x:Uid="SandboxPage_AddFolder" Content="Add folder" Click="OnAddCustomFolder" />
                                 </StackPanel>
                             </StackPanel>
                         </Border>
@@ -347,35 +347,35 @@
                 <!-- Clipboard -->
                 <Expander IsExpanded="True" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
                     <Expander.Header>
-                        <TextBlock Text="📋 Clipboard" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                        <TextBlock x:Uid="SandboxPage_Clipboard" Text="📋 Clipboard" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                     </Expander.Header>
                     <StackPanel Spacing="8" Padding="4">
-                        <TextBlock Text="Clipboard often contains passwords, tokens, and private text. Read access may leak this to the agent (and over the internet, if enabled)."
+                        <TextBlock x:Uid="SandboxPage_ClipboardOftenContainsPasswords" Text="Clipboard often contains passwords, tokens, and private text. Read access may leak this to the agent (and over the internet, if enabled)."
                                    TextWrapping="Wrap"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                        <RadioButton x:Name="ClipboardNoneRadio" Content="None (default)" GroupName="Clipboard" Checked="OnClipboardChanged" Tag="None" />
-                        <RadioButton x:Name="ClipboardReadRadio" Content="Read — agent can see what you copied" GroupName="Clipboard" Checked="OnClipboardChanged" Tag="Read" />
-                        <RadioButton x:Name="ClipboardWriteRadio" Content="Write — agent can replace your clipboard (cannot read it)" GroupName="Clipboard" Checked="OnClipboardChanged" Tag="Write" />
-                        <RadioButton x:Name="ClipboardBothRadio" Content="Read &amp; write" GroupName="Clipboard" Checked="OnClipboardChanged" Tag="Both" />
+                        <RadioButton x:Uid="SandboxPage_NoneDefault" x:Name="ClipboardNoneRadio" Content="None (default)" GroupName="Clipboard" Checked="OnClipboardChanged" Tag="None" />
+                        <RadioButton x:Uid="SandboxPage_ReadAgentCanSee" x:Name="ClipboardReadRadio" Content="Read — agent can see what you copied" GroupName="Clipboard" Checked="OnClipboardChanged" Tag="Read" />
+                        <RadioButton x:Uid="SandboxPage_WriteAgentCanReplace" x:Name="ClipboardWriteRadio" Content="Write — agent can replace your clipboard (cannot read it)" GroupName="Clipboard" Checked="OnClipboardChanged" Tag="Write" />
+                        <RadioButton x:Uid="SandboxPage_ReadAmpWrite5" x:Name="ClipboardBothRadio" Content="Read &amp; write" GroupName="Clipboard" Checked="OnClipboardChanged" Tag="Both" />
                     </StackPanel>
                 </Expander>
 
                 <!-- Network -->
                 <Expander IsExpanded="True" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
                     <Expander.Header>
-                        <TextBlock Text="📡 Network" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                        <TextBlock x:Uid="SandboxPage_Network" Text="📡 Network" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                     </Expander.Header>
                     <StackPanel Spacing="12" Padding="4">
-                        <ToggleSwitch x:Name="NetInternetToggle"
+                        <ToggleSwitch x:Uid="SandboxPage_AllowInternet" x:Name="NetInternetToggle"
                                       Header="Allow internet"
                                       OffContent="Off — agent cannot reach the internet"
                                       OnContent="On — agent can connect to public internet endpoints"
                                       Toggled="OnNetInternetToggled" />
-                        <TextBlock Text="If file or clipboard read access is enabled, the agent may send that data over the internet."
+                        <TextBlock x:Uid="SandboxPage_IfFileOrClipboard" Text="If file or clipboard read access is enabled, the agent may send that data over the internet."
                                    TextWrapping="Wrap"
                                    FontSize="11"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                        <TextBlock Text="Local network devices and shares are not included yet."
+                        <TextBlock x:Uid="SandboxPage_LocalNetworkDevicesAnd" Text="Local network devices and shares are not included yet."
                                    TextWrapping="Wrap"
                                    FontSize="11"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
@@ -385,24 +385,24 @@
                 <!-- Limits -->
                 <Expander IsExpanded="False" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
                     <Expander.Header>
-                        <TextBlock Text="⏱ Limits" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                        <TextBlock x:Uid="SandboxPage_Limits" Text="⏱ Limits" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                     </Expander.Header>
                     <StackPanel Spacing="12" Padding="4">
                         <StackPanel Spacing="4">
-                            <TextBlock x:Name="TimeoutLabel" Text="Command timeout: 30 sec"/>
+                            <TextBlock x:Uid="SandboxPage_CommandTimeout30Sec" x:Name="TimeoutLabel" Text="Command timeout: 30 sec"/>
                             <Slider x:Name="TimeoutSlider" Minimum="5" Maximum="300" StepFrequency="5"
                                     Value="30" SmallChange="5" LargeChange="15"
                                     ValueChanged="OnTimeoutChanged" />
                         </StackPanel>
                         <StackPanel Spacing="4">
-                            <TextBlock Text="Maximum captured output (truncates beyond this; does not limit disk, memory, or CPU):" TextWrapping="Wrap"/>
+                            <TextBlock x:Uid="SandboxPage_MaximumCapturedOutputTruncates" Text="Maximum captured output (truncates beyond this; does not limit disk, memory, or CPU):" TextWrapping="Wrap"/>
                             <ComboBox x:Name="MaxOutputCombo"
                                       HorizontalAlignment="Stretch"
                                       SelectionChanged="OnMaxOutputChanged">
-                                <ComboBoxItem Content="1 MiB" Tag="1048576" />
-                                <ComboBoxItem Content="4 MiB (default)" Tag="4194304" />
-                                <ComboBoxItem Content="16 MiB" Tag="16777216" />
-                                <ComboBoxItem Content="64 MiB" Tag="67108864" />
+                                <ComboBoxItem x:Uid="SandboxPage_1MiB" Content="1 MiB" Tag="1048576" />
+                                <ComboBoxItem x:Uid="SandboxPage_4MiBDefault" Content="4 MiB (default)" Tag="4194304" />
+                                <ComboBoxItem x:Uid="SandboxPage_16MiB" Content="16 MiB" Tag="16777216" />
+                                <ComboBoxItem x:Uid="SandboxPage_64MiB" Content="64 MiB" Tag="67108864" />
                             </ComboBox>
                         </StackPanel>
                     </StackPanel>

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
@@ -24,7 +24,7 @@
                          AutomationProperties.AutomationId="BackToConnectionLink">
             <StackPanel Orientation="Horizontal" Spacing="6">
                 <FontIcon Glyph="&#xE72B;" FontSize="12"/>
-                <TextBlock Text="Back to Connection"/>
+                <TextBlock x:Uid="SessionsPage_BackToConnection" Text="Back to Connection"/>
             </StackPanel>
         </HyperlinkButton>
 
@@ -34,11 +34,11 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <TextBlock Text="Sessions" Style="{StaticResource TitleTextBlockStyle}"/>
+            <TextBlock x:Uid="SessionsPage_Sessions" Text="Sessions" Style="{StaticResource TitleTextBlockStyle}"/>
             <Button x:Name="RefreshButton" Grid.Column="1" Click="OnRefresh">
                 <StackPanel Orientation="Horizontal" Spacing="6">
                     <FontIcon Glyph="&#xE72C;" FontSize="14"/>
-                    <TextBlock Text="Refresh"/>
+                    <TextBlock x:Uid="SessionsPage_Refresh" Text="Refresh"/>
                 </StackPanel>
             </Button>
         </Grid>
@@ -46,15 +46,15 @@
         <!-- Channel filter SelectorBar -->
         <SelectorBar x:Name="ChannelSelector" Grid.Row="2"
                       SelectionChanged="ChannelSelector_SelectionChanged">
-            <SelectorBarItem x:Name="AllTab" Text="All" IsSelected="True"/>
+            <SelectorBarItem x:Uid="SessionsPage_All" x:Name="AllTab" Text="All" IsSelected="True"/>
         </SelectorBar>
 
-        <InfoBar x:Name="ConnectionInfoBar" Grid.Row="3"
+        <InfoBar x:Uid="SessionsPage_GatewayDisconnected" x:Name="ConnectionInfoBar" Grid.Row="3"
                  IsOpen="False" IsClosable="False" Severity="Warning"
                  Title="Gateway disconnected"
                  Message="Connect to a gateway to load sessions.">
             <InfoBar.ActionButton>
-                <Button Content="Open Connection" Click="OnOpenConnectionClick"/>
+                <Button x:Uid="SessionsPage_OpenConnection" Content="Open Connection" Click="OnOpenConnectionClick"/>
             </InfoBar.ActionButton>
         </InfoBar>
 
@@ -62,7 +62,7 @@
                     HorizontalAlignment="Center" VerticalAlignment="Center"
                     Visibility="Collapsed">
             <ProgressRing IsActive="True" Width="22" Height="22"/>
-            <TextBlock Text="Loading sessions..."
+            <TextBlock x:Uid="SessionsPage_LoadingSessions" Text="Loading sessions..."
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                        VerticalAlignment="Center"/>
         </StackPanel>
@@ -72,7 +72,7 @@
                     HorizontalAlignment="Center" VerticalAlignment="Center"
                     Visibility="Collapsed">
             <TextBlock Text="💬" FontSize="48" HorizontalAlignment="Center"/>
-            <TextBlock Text="No active sessions"
+            <TextBlock x:Uid="SessionsPage_NoActiveSessions" Text="No active sessions"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                        HorizontalAlignment="Center"/>
         </StackPanel>
@@ -134,13 +134,13 @@
 
                             <!-- Row 4: Action buttons -->
                             <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8" Margin="16,4,0,0">
-                                 <Button Content="Reset" Tag="{Binding Key}" Click="OnResetSession"
+                                 <Button x:Uid="SessionsPage_Reset" Content="Reset" Tag="{Binding Key}" Click="OnResetSession"
                                          IsEnabled="{Binding CanEdit}"
                                          Style="{StaticResource DefaultButtonStyle}" Padding="8,4"/>
-                                 <Button Content="Compact" Tag="{Binding Key}" Click="OnCompactSession"
+                                 <Button x:Uid="SessionsPage_Compact" Content="Compact" Tag="{Binding Key}" Click="OnCompactSession"
                                          IsEnabled="{Binding CanEdit}"
                                          Style="{StaticResource DefaultButtonStyle}" Padding="8,4"/>
-                                 <Button Content="Delete" Tag="{Binding Key}" Click="OnDeleteSession"
+                                 <Button x:Uid="SessionsPage_Delete" Content="Delete" Tag="{Binding Key}" Click="OnDeleteSession"
                                          IsEnabled="{Binding CanEdit}"
                                          Foreground="IndianRed" Padding="8,4"/>
                             </StackPanel>

--- a/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml
@@ -19,12 +19,12 @@
             <StackPanel Spacing="8" HorizontalAlignment="Stretch" MaxWidth="900">
 
                 <!-- Page header -->
-                <TextBlock Text="Settings"
+                <TextBlock x:Uid="SettingsPage_Settings" Text="Settings"
                            Style="{StaticResource TitleTextBlockStyle}"
                            Margin="0,0,0,8"/>
 
                 <!-- ═════════ General ═════════ -->
-                <TextBlock Text="General" Style="{StaticResource BodyStrongTextBlockStyle}"
+                <TextBlock x:Uid="SettingsPage_General" Text="General" Style="{StaticResource BodyStrongTextBlockStyle}"
                            Margin="{StaticResource SectionHeaderMargin}"/>
 
                 <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
@@ -94,7 +94,7 @@
                 </Border>
 
                 <!-- ═════════ Notifications ═════════ -->
-                <TextBlock Text="Notifications" Style="{StaticResource BodyStrongTextBlockStyle}"
+                <TextBlock x:Uid="SettingsPage_Notifications" Text="Notifications" Style="{StaticResource BodyStrongTextBlockStyle}"
                            Margin="{StaticResource SectionHeaderMargin}"/>
 
                 <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
@@ -194,7 +194,7 @@
                 </Border>
 
                 <!-- ═════════ Privacy ═════════ -->
-                <TextBlock Text="Privacy" Style="{StaticResource BodyStrongTextBlockStyle}"
+                <TextBlock x:Uid="SettingsPage_Privacy" Text="Privacy" Style="{StaticResource BodyStrongTextBlockStyle}"
                            Margin="{StaticResource SectionHeaderMargin}"/>
                 <TextBlock x:Uid="SettingsPrivacyDescription"
                            Text="Pre-approve capabilities so agents can use them without a prompt every time. You'll still see a countdown before recording starts."
@@ -247,7 +247,7 @@
                 </Border>
 
                 <!-- ═════════ Local Gateway (conditional) ═════════ -->
-                <TextBlock x:Name="LocalGatewaySectionHeader" Text="Local Gateway"
+                <TextBlock x:Uid="SettingsPage_LocalGateway" x:Name="LocalGatewaySectionHeader" Text="Local Gateway"
                            Style="{StaticResource BodyStrongTextBlockStyle}"
                            Margin="{StaticResource SectionHeaderMargin}"
                            Visibility="Collapsed"/>
@@ -260,19 +260,19 @@
                         Visibility="Collapsed"
                         AutomationProperties.AutomationId="LocalGatewayExpander">
                     <StackPanel Spacing="12">
-                        <InfoBar x:Name="MsixWarningBar"
+                        <InfoBar x:Uid="SettingsPage_MSIXInstallationDetected" x:Name="MsixWarningBar"
                                  Severity="Warning"
                                  IsOpen="False"
                                  IsClosable="False"
                                  Title="MSIX installation detected"
                                  Message="Removing OpenClaw from Windows Settings &#x2192; Apps will NOT clean up the Local Gateway (WSL distro, disk image). Use Remove Local Gateway below FIRST, then uninstall OpenClaw."/>
 
-                        <TextBlock x:Name="GatewayBodyText"
+                        <TextBlock x:Uid="SettingsPage_RemovesTheWSLDistro" x:Name="GatewayBodyText"
                                    Text="Removes the WSL distro (OpenClawGateway), its disk image, autostart entry, and clears gateway credentials. Your MCP token is preserved. Onboarding will reset."
                                    Style="{StaticResource BodyTextBlockStyle}"
                                    TextWrapping="Wrap"/>
 
-                        <Button x:Name="RemoveGatewayButton"
+                        <Button x:Uid="SettingsPage_RemoveLocalGateway" x:Name="RemoveGatewayButton"
                                 HorizontalAlignment="Right"
                                 Content="Remove Local Gateway"
                                 Click="OnRemoveGateway"
@@ -288,7 +288,7 @@
         </ScrollViewer>
 
         <!-- Saved indicator (transient, auto-hides) -->
-        <InfoBar x:Name="SavedInfoBar" Grid.Row="1"
+        <InfoBar x:Uid="SettingsPage_Saved" x:Name="SavedInfoBar" Grid.Row="1"
                  IsOpen="False" IsClosable="False"
                  Severity="Success"
                  Title="Saved"

--- a/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml
@@ -13,13 +13,13 @@
         <!-- Header -->
         <StackPanel Grid.Row="0" Spacing="8" Margin="0,0,0,12">
             <StackPanel Orientation="Horizontal" Spacing="8">
-                <TextBlock Text="🧩 Skills" Style="{StaticResource TitleTextBlockStyle}"/>
+                <TextBlock x:Uid="SkillsPage_Skills" Text="🧩 Skills" Style="{StaticResource TitleTextBlockStyle}"/>
                 <TextBlock x:Name="CountText" Text="" VerticalAlignment="Center"
                            Style="{StaticResource CaptionTextBlockStyle}"
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
             </StackPanel>
             <ComboBox x:Uid="AgentFilterCombo" x:Name="AgentFilterCombo" Header="Agent" MinWidth="200">
-                <ComboBoxItem Content="All Agents" Tag="" IsSelected="True"/>
+                <ComboBoxItem x:Uid="SkillsPage_AllAgents" Content="All Agents" Tag="" IsSelected="True"/>
             </ComboBox>
         </StackPanel>
 
@@ -37,7 +37,7 @@
                     BorderThickness="0" CornerRadius="4">
                 <StackPanel Orientation="Horizontal" Spacing="6">
                     <FontIcon x:Name="EnabledChevron" Glyph="&#xE70E;" FontSize="10" VerticalAlignment="Center"/>
-                    <TextBlock x:Name="EnabledHeaderText" Text="Enabled" FontWeight="SemiBold" FontSize="13"
+                    <TextBlock x:Uid="SkillsPage_Enabled" x:Name="EnabledHeaderText" Text="Enabled" FontWeight="SemiBold" FontSize="13"
                                VerticalAlignment="Center"/>
                 </StackPanel>
             </Button>
@@ -54,7 +54,7 @@
                             BorderThickness="0" CornerRadius="4" Visibility="Collapsed">
                         <StackPanel Orientation="Horizontal" Spacing="6">
                             <FontIcon x:Name="DisabledChevron" Glyph="&#xE70E;" FontSize="10" VerticalAlignment="Center"/>
-                            <TextBlock x:Name="DisabledHeaderText" Text="Disabled" FontWeight="SemiBold" FontSize="13"
+                            <TextBlock x:Uid="SkillsPage_Disabled" x:Name="DisabledHeaderText" Text="Disabled" FontWeight="SemiBold" FontSize="13"
                                        VerticalAlignment="Center"/>
                         </StackPanel>
                     </Button>
@@ -68,7 +68,7 @@
                     HorizontalAlignment="Center" VerticalAlignment="Center"
                     Visibility="Collapsed">
             <ProgressRing IsActive="True" Width="22" Height="22"/>
-            <TextBlock Text="Loading skills..."
+            <TextBlock x:Uid="SkillsPage_LoadingSkills" Text="Loading skills..."
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                        VerticalAlignment="Center"/>
         </StackPanel>
@@ -77,10 +77,10 @@
         <StackPanel x:Name="EmptyState" Grid.Row="1" Visibility="Collapsed"
                     VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8">
             <TextBlock Text="🧩" FontSize="48" HorizontalAlignment="Center"/>
-            <TextBlock Text="No skills installed"
+            <TextBlock x:Uid="SkillsPage_NoSkillsInstalled" Text="No skills installed"
                        Style="{StaticResource SubtitleTextBlockStyle}"
                        HorizontalAlignment="Center"/>
-            <TextBlock Text="Skills extend your agent's capabilities. Install skills via the CLI or ClawHub."
+            <TextBlock x:Uid="SkillsPage_SkillsExtendYourAgent" Text="Skills extend your agent's capabilities. Install skills via the CLI or ClawHub."
                        Style="{StaticResource CaptionTextBlockStyle}"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                        HorizontalAlignment="Center" TextWrapping="Wrap" MaxWidth="320"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml
@@ -10,12 +10,12 @@
 
             <TextBlock x:Uid="UsagePage_TextBlock_10" Text="📊 Usage &amp; Cost" Style="{StaticResource TitleTextBlockStyle}"/>
 
-            <InfoBar x:Name="ConnectionInfoBar"
+            <InfoBar x:Uid="UsagePage_GatewayDisconnected" x:Name="ConnectionInfoBar"
                      IsOpen="False" IsClosable="False" Severity="Warning"
                      Title="Gateway disconnected"
                      Message="Connect to a gateway to load usage data.">
                 <InfoBar.ActionButton>
-                    <Button Content="Open Connection" Click="OnOpenConnectionClick"/>
+                    <Button x:Uid="UsagePage_OpenConnection" Content="Open Connection" Click="OnOpenConnectionClick"/>
                 </InfoBar.ActionButton>
             </InfoBar>
 
@@ -135,11 +135,11 @@
                     <StackPanel x:Name="DailyLoadingPanel" Orientation="Horizontal" Spacing="12"
                                 HorizontalAlignment="Center" Padding="0,24,0,16">
                         <ProgressRing IsActive="True" Width="20" Height="20"/>
-                        <TextBlock Text="Loading daily costs..."
+                        <TextBlock x:Uid="UsagePage_LoadingDailyCosts" Text="Loading daily costs..."
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    VerticalAlignment="Center"/>
                     </StackPanel>
-                    <TextBlock x:Name="DailyEmptyText"
+                    <TextBlock x:Uid="UsagePage_NoDailyUsageFor" x:Name="DailyEmptyText"
                                Text="No daily usage for this period"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                HorizontalAlignment="Center" Padding="0,24,0,16"

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
@@ -65,7 +65,7 @@
                             Visibility="Collapsed">
                         <StackPanel Orientation="Horizontal" Spacing="6">
                             <FontIcon x:Name="TestVoiceBtnIcon" Glyph="&#xE720;" FontSize="14"/>
-                            <TextBlock x:Name="TestVoiceButtonText" Text="Test Voice Input"/>
+                            <TextBlock x:Uid="VoiceSettingsPage_TestVoiceInput" x:Name="TestVoiceButtonText" Text="Test Voice Input"/>
                         </StackPanel>
                     </Button>
 
@@ -95,7 +95,7 @@
                                         Style="{StaticResource AccentButtonStyle}" Padding="12,8">
                                     <StackPanel Orientation="Horizontal" Spacing="6">
                                         <FontIcon x:Name="InlineTestBtnIcon" Glyph="&#xE720;" FontSize="14"/>
-                                        <TextBlock x:Name="InlineTestBtnLabel" Text="Record" FontSize="13"/>
+                                        <TextBlock x:Uid="VoiceSettingsPage_Record" x:Name="InlineTestBtnLabel" Text="Record" FontSize="13"/>
                                     </StackPanel>
                                 </Button>
                                 <Button x:Name="InlineTestCloseBtn" Click="OnInlineTestCloseClick"

--- a/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml
@@ -42,7 +42,7 @@
                         HorizontalAlignment="Center" Spacing="8" Margin="0,24,0,0">
                 <ProgressRing x:Name="LoadingRing" IsActive="False" Width="24" Height="24"
                               HorizontalAlignment="Center"/>
-                <TextBlock Text="Loading workspace files…"
+                <TextBlock x:Uid="WorkspacePage_LoadingWorkspaceFiles" Text="Loading workspace files…"
                            Style="{StaticResource CaptionTextBlockStyle}"
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                            HorizontalAlignment="Center"/>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -3555,4 +3555,919 @@ On your gateway host (Mac/Linux), run:
   <data name="ConnectionStatusWindow.Title" xml:space="preserve">
     <value>Connection Status</value>
   </data>
+  <data name="BindingsPage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>Gateway disconnected</value>
+  </data>
+  <data name="BindingsPage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>Connect to a gateway to load bindings.</value>
+  </data>
+  <data name="BindingsPage_OpenConnection.Content" xml:space="preserve">
+    <value>Open Connection</value>
+  </data>
+  <data name="BindingsPage_LoadingBindings.Text" xml:space="preserve">
+    <value>Loading bindings...</value>
+  </data>
+  <data name="ConnectionPage_ApprovalsWaitingOnYou.Text" xml:space="preserve">
+    <value>Approvals waiting on you</value>
+  </data>
+  <data name="ConnectionPage_NotConnected.Text" xml:space="preserve">
+    <value>Not connected</value>
+  </data>
+  <data name="ConnectionPage_Connect.Content" xml:space="preserve">
+    <value>Connect</value>
+  </data>
+  <data name="ConnectionPage_Operator.Text" xml:space="preserve">
+    <value>Operator</value>
+  </data>
+  <data name="ConnectionPage_SendCommandsAndView.Text" xml:space="preserve">
+    <value>Send commands and view sessions on this gateway from this PC.</value>
+  </data>
+  <data name="ConnectionPage_Inactive.Text" xml:space="preserve">
+    <value>Inactive</value>
+  </data>
+  <data name="ConnectionPage_SeeSessions.Content" xml:space="preserve">
+    <value>See sessions ›</value>
+  </data>
+  <data name="ConnectionPage_SeeInstances.Content" xml:space="preserve">
+    <value>See instances ›</value>
+  </data>
+  <data name="ConnectionPage_NodeMode.Text" xml:space="preserve">
+    <value>Node mode</value>
+  </data>
+  <data name="ConnectionPage_WhenOnThisPC.Text" xml:space="preserve">
+    <value>When on, this PC registers as a node and offers the capabilities below to agents over the gateway.</value>
+  </data>
+  <data name="ConnectionPage_NodeModeDisabled.Text" xml:space="preserve">
+    <value>Node mode disabled</value>
+  </data>
+  <data name="ConnectionPage_Copy.Content" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="ConnectionPage_Connect2.Content" xml:space="preserve">
+    <value>Connect</value>
+  </data>
+  <data name="ConnectionPage_ManagePermissions.Content" xml:space="preserve">
+    <value>Manage permissions ›</value>
+  </data>
+  <data name="ConnectionPage_HelpUsFixThis.Text" xml:space="preserve">
+    <value>Help us fix this connection:</value>
+  </data>
+  <data name="ConnectionPage_SSHTunnelIsDown.Text" xml:space="preserve">
+    <value>SSH tunnel is down.</value>
+  </data>
+  <data name="ConnectionPage_RestartTunnel.Content" xml:space="preserve">
+    <value>Restart tunnel</value>
+  </data>
+  <data name="ConnectionPage_EditTunnelSettings.Content" xml:space="preserve">
+    <value>Edit tunnel settings</value>
+  </data>
+  <data name="ConnectionPage_PasteANewSetup.Text" xml:space="preserve">
+    <value>Paste a new setup code from the gateway host.</value>
+  </data>
+  <data name="ConnectionPage_PasteSetupCodeHere.PlaceholderText" xml:space="preserve">
+    <value>Paste setup code here…</value>
+  </data>
+  <data name="ConnectionPage_Apply.Content" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="ConnectionPage_RunOnTheGateway.Text" xml:space="preserve">
+    <value>Run on the gateway host:</value>
+  </data>
+  <data name="ConnectionPage_Copy2.Content" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="ConnectionPage_Connect3.Content" xml:space="preserve">
+    <value>Connect</value>
+  </data>
+  <data name="ConnectionPage_Disconnect.Content" xml:space="preserve">
+    <value>Disconnect</value>
+  </data>
+  <data name="ConnectionPage_SavedGateways.Text" xml:space="preserve">
+    <value>Saved gateways</value>
+  </data>
+  <data name="ConnectionPage_Gateways.Text" xml:space="preserve">
+    <value>Gateways</value>
+  </data>
+  <data name="ConnectionPage_Scan.Text" xml:space="preserve">
+    <value>Scan</value>
+  </data>
+  <data name="ConnectionPage_AddGateway.Text" xml:space="preserve">
+    <value>Add gateway</value>
+  </data>
+  <data name="ConnectionPage_NoSavedGatewaysYet.Text" xml:space="preserve">
+    <value>No saved gateways yet.</value>
+  </data>
+  <data name="ConnectionPage_DiscoveredOnYourNetwork.Text" xml:space="preserve">
+    <value>Discovered on your network</value>
+  </data>
+  <data name="ConnectionPage_AddAGateway.Text" xml:space="preserve">
+    <value>Add a gateway</value>
+  </data>
+  <data name="ConnectionPage_GetStartedInstallA.Title" xml:space="preserve">
+    <value>Get started — install a local gateway</value>
+  </data>
+  <data name="ConnectionPage_GetStartedInstallA.Message" xml:space="preserve">
+    <value>The fastest way to start: sets up a WSL-hosted gateway on this PC and makes it the active connection.</value>
+  </data>
+  <data name="ConnectionPage_Install.Content" xml:space="preserve">
+    <value>Install</value>
+  </data>
+  <data name="ConnectionPage_OrConnectToAn.Text" xml:space="preserve">
+    <value>Or connect to an existing one:</value>
+  </data>
+  <data name="ConnectionPage_Direct.Text" xml:space="preserve">
+    <value>Direct</value>
+  </data>
+  <data name="ConnectionPage_URLToken.Text" xml:space="preserve">
+    <value>URL + token</value>
+  </data>
+  <data name="ConnectionPage_SetupCode.Text" xml:space="preserve">
+    <value>Setup code</value>
+  </data>
+  <data name="ConnectionPage_PasteQRPayload.Text" xml:space="preserve">
+    <value>Paste QR payload</value>
+  </data>
+  <data name="ConnectionPage_EachMethodSupportsAn.Text" xml:space="preserve">
+    <value>Each method supports an optional SSH tunnel.</value>
+  </data>
+  <data name="ConnectionPage_OrLookForOne.Text" xml:space="preserve">
+    <value>Or look for one on your network.</value>
+  </data>
+  <data name="ConnectionPage_Scan2.Text" xml:space="preserve">
+    <value>Scan</value>
+  </data>
+  <data name="ConnectionPage_DiscoveredOnYourNetwork2.Text" xml:space="preserve">
+    <value>Discovered on your network</value>
+  </data>
+  <data name="ConnectionPage_Back.Text" xml:space="preserve">
+    <value>Back</value>
+  </data>
+  <data name="ConnectionPage_AddAGateway2.Text" xml:space="preserve">
+    <value>Add a gateway</value>
+  </data>
+  <data name="ConnectionPage_Direct2.Text" xml:space="preserve">
+    <value>Direct</value>
+  </data>
+  <data name="ConnectionPage_SetupCode2.Text" xml:space="preserve">
+    <value>Setup code</value>
+  </data>
+  <data name="ConnectionPage_LocalWSL.Text" xml:space="preserve">
+    <value>Local WSL</value>
+  </data>
+  <data name="ConnectionPage_GatewayURL.Header" xml:space="preserve">
+    <value>Gateway URL</value>
+  </data>
+  <data name="ConnectionPage_GatewayURL.PlaceholderText" xml:space="preserve">
+    <value>ws://host.local:18790</value>
+  </data>
+  <data name="ConnectionPage_SharedToken.Header" xml:space="preserve">
+    <value>Shared token</value>
+  </data>
+  <data name="ConnectionPage_SharedToken.PlaceholderText" xml:space="preserve">
+    <value>Paste shared gateway token</value>
+  </data>
+  <data name="ConnectionPage_NameOptional.Header" xml:space="preserve">
+    <value>Name (optional)</value>
+  </data>
+  <data name="ConnectionPage_NameOptional.PlaceholderText" xml:space="preserve">
+    <value>My gateway</value>
+  </data>
+  <data name="ConnectionPage_PasteASetupCode.Text" xml:space="preserve">
+    <value>Paste a setup code from the gateway's QR or `openclaw qr` output.</value>
+  </data>
+  <data name="ConnectionPage_PasteSetupCodeHere2.PlaceholderText" xml:space="preserve">
+    <value>Paste setup code here…</value>
+  </data>
+  <data name="ConnectionPage_Decode.Content" xml:space="preserve">
+    <value>Decode</value>
+  </data>
+  <data name="ConnectionPage_InstallANewWSL.Text" xml:space="preserve">
+    <value>Install a new WSL gateway on this PC and make it the active connection. The setup wizard will install WSL if needed, provision the gateway, and pair this device automatically.</value>
+  </data>
+  <data name="ConnectionPage_InstallLocalGateway.Content" xml:space="preserve">
+    <value>Install local gateway</value>
+  </data>
+  <data name="ConnectionPage_LocalWSLSetupIsn.Text" xml:space="preserve">
+    <value>Local-WSL setup isn't available on this machine — the install wizard couldn't be initialized.</value>
+  </data>
+  <data name="ConnectionPage_UseSSHTunnelOptional.Text" xml:space="preserve">
+    <value>Use SSH tunnel (optional)</value>
+  </data>
+  <data name="ConnectionPage_SSHUser.Header" xml:space="preserve">
+    <value>SSH user</value>
+  </data>
+  <data name="ConnectionPage_SSHUser.PlaceholderText" xml:space="preserve">
+    <value>user</value>
+  </data>
+  <data name="ConnectionPage_SSHHost.Header" xml:space="preserve">
+    <value>SSH host</value>
+  </data>
+  <data name="ConnectionPage_SSHHost.PlaceholderText" xml:space="preserve">
+    <value>machine-name</value>
+  </data>
+  <data name="ConnectionPage_RemotePort.Header" xml:space="preserve">
+    <value>Remote port</value>
+  </data>
+  <data name="ConnectionPage_LocalPort.Header" xml:space="preserve">
+    <value>Local port</value>
+  </data>
+  <data name="ConnectionPage_SaveAmpConnect.Content" xml:space="preserve">
+    <value>Save &amp; connect</value>
+  </data>
+  <data name="ConnectionPage_Cancel.Content" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="CronPage_CronJobs.Text" xml:space="preserve">
+    <value>⏱️ Cron Jobs</value>
+  </data>
+  <data name="CronPage_Refresh.Text" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="CronPage_NewJob.Text" xml:space="preserve">
+    <value>New Job</value>
+  </data>
+  <data name="CronPage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>Gateway disconnected</value>
+  </data>
+  <data name="CronPage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>Connect to a gateway to load cron jobs.</value>
+  </data>
+  <data name="CronPage_OpenConnection.Content" xml:space="preserve">
+    <value>Open Connection</value>
+  </data>
+  <data name="CronPage_NewCronJob.Text" xml:space="preserve">
+    <value>New Cron Job</value>
+  </data>
+  <data name="CronPage_NAME.Text" xml:space="preserve">
+    <value>NAME</value>
+  </data>
+  <data name="CronPage_MorningBrief.PlaceholderText" xml:space="preserve">
+    <value>Morning brief</value>
+  </data>
+  <data name="CronPage_SCHEDULE.Text" xml:space="preserve">
+    <value>SCHEDULE</value>
+  </data>
+  <data name="CronPage_Every.Content" xml:space="preserve">
+    <value>Every</value>
+  </data>
+  <data name="CronPage_At.Content" xml:space="preserve">
+    <value>At</value>
+  </data>
+  <data name="CronPage_Cron.Content" xml:space="preserve">
+    <value>Cron</value>
+  </data>
+  <data name="CronPage_QUICKPRESETS.Text" xml:space="preserve">
+    <value>QUICK PRESETS</value>
+  </data>
+  <data name="CronPage_Hourly.Content" xml:space="preserve">
+    <value>⏰ Hourly</value>
+  </data>
+  <data name="CronPage_Daily9am.Content" xml:space="preserve">
+    <value>🌅 Daily 9am</value>
+  </data>
+  <data name="CronPage_Daily6pm.Content" xml:space="preserve">
+    <value>🌆 Daily 6pm</value>
+  </data>
+  <data name="CronPage_Weekdays.Content" xml:space="preserve">
+    <value>💼 Weekdays</value>
+  </data>
+  <data name="CronPage_Weekly.Content" xml:space="preserve">
+    <value>📅 Weekly</value>
+  </data>
+  <data name="CronPage_EXPRESSION.Text" xml:space="preserve">
+    <value>EXPRESSION</value>
+  </data>
+  <data name="CronPage_TIMEZONE.Text" xml:space="preserve">
+    <value>TIMEZONE</value>
+  </data>
+  <data name="CronPage_Optional.PlaceholderText" xml:space="preserve">
+    <value>Optional</value>
+  </data>
+  <data name="CronPage_AmericaNewYork.Content" xml:space="preserve">
+    <value>America/New_York</value>
+  </data>
+  <data name="CronPage_AmericaChicago.Content" xml:space="preserve">
+    <value>America/Chicago</value>
+  </data>
+  <data name="CronPage_AmericaDenver.Content" xml:space="preserve">
+    <value>America/Denver</value>
+  </data>
+  <data name="CronPage_AmericaLosAngeles.Content" xml:space="preserve">
+    <value>America/Los_Angeles</value>
+  </data>
+  <data name="CronPage_EuropeLondon.Content" xml:space="preserve">
+    <value>Europe/London</value>
+  </data>
+  <data name="CronPage_EuropeBerlin.Content" xml:space="preserve">
+    <value>Europe/Berlin</value>
+  </data>
+  <data name="CronPage_AsiaTokyo.Content" xml:space="preserve">
+    <value>Asia/Tokyo</value>
+  </data>
+  <data name="CronPage_UTC.Content" xml:space="preserve">
+    <value>UTC</value>
+  </data>
+  <data name="CronPage_EVERY.Text" xml:space="preserve">
+    <value>EVERY</value>
+  </data>
+  <data name="CronPage_UNIT.Text" xml:space="preserve">
+    <value>UNIT</value>
+  </data>
+  <data name="CronPage_Minutes.Content" xml:space="preserve">
+    <value>Minutes</value>
+  </data>
+  <data name="CronPage_Hours.Content" xml:space="preserve">
+    <value>Hours</value>
+  </data>
+  <data name="CronPage_Days.Content" xml:space="preserve">
+    <value>Days</value>
+  </data>
+  <data name="CronPage_RUNAT.Text" xml:space="preserve">
+    <value>RUN AT</value>
+  </data>
+  <data name="CronPage_Date.PlaceholderText" xml:space="preserve">
+    <value>Date</value>
+  </data>
+  <data name="CronPage_330PM.PlaceholderText" xml:space="preserve">
+    <value>3:30 PM</value>
+  </data>
+  <data name="CronPage_DeleteJobAfterIt.Content" xml:space="preserve">
+    <value>Delete job after it runs</value>
+  </data>
+  <data name="CronPage_PROMPTPAYLOAD.Text" xml:space="preserve">
+    <value>PROMPT / PAYLOAD</value>
+  </data>
+  <data name="CronPage_WhatShouldTheAgent.PlaceholderText" xml:space="preserve">
+    <value>What should the agent do?</value>
+  </data>
+  <data name="CronPage_DELIVERY.Text" xml:space="preserve">
+    <value>DELIVERY</value>
+  </data>
+  <data name="CronPage_SilentNone.Content" xml:space="preserve">
+    <value>Silent (none)</value>
+  </data>
+  <data name="CronPage_NotifyMeAnnounce.Content" xml:space="preserve">
+    <value>Notify me (announce)</value>
+  </data>
+  <data name="CronPage_CHANNEL.Text" xml:space="preserve">
+    <value>CHANNEL</value>
+  </data>
+  <data name="CronPage_EGWebchat.PlaceholderText" xml:space="preserve">
+    <value>e.g. webchat</value>
+  </data>
+  <data name="CronPage_AdvancedOptions.Text" xml:space="preserve">
+    <value>Advanced options</value>
+  </data>
+  <data name="CronPage_SESSIONBEHAVIOR.Text" xml:space="preserve">
+    <value>SESSION BEHAVIOR</value>
+  </data>
+  <data name="CronPage_NewSessionEachRun.Content" xml:space="preserve">
+    <value>New session each run</value>
+  </data>
+  <data name="CronPage_ResumeMainSession.Content" xml:space="preserve">
+    <value>Resume main session</value>
+  </data>
+  <data name="CronPage_WAKEMODE.Text" xml:space="preserve">
+    <value>WAKE MODE</value>
+  </data>
+  <data name="CronPage_NowImmediate.Content" xml:space="preserve">
+    <value>Now (immediate)</value>
+  </data>
+  <data name="CronPage_QueueWaitForIdle.Content" xml:space="preserve">
+    <value>Queue (wait for idle)</value>
+  </data>
+  <data name="CronPage_Cancel.Content" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="CronPage_CreateJob.Content" xml:space="preserve">
+    <value>Create Job</value>
+  </data>
+  <data name="CronPage_LoadingCronJobs.Text" xml:space="preserve">
+    <value>Loading cron jobs...</value>
+  </data>
+  <data name="CronPage_NoCronJobsConfigured.Text" xml:space="preserve">
+    <value>No cron jobs configured</value>
+  </data>
+  <data name="CronPage_CronJobsWillAppear.Text" xml:space="preserve">
+    <value>Cron jobs will appear here when configured via the gateway.</value>
+  </data>
+  <data name="DebugPage_Status.Title" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="DebugPage_Copied.Title" xml:space="preserve">
+    <value>Copied</value>
+  </data>
+  <data name="DebugPage_NoOverride.Content" xml:space="preserve">
+    <value>No override</value>
+  </data>
+  <data name="DebugPage_ForceGatewayChatUI.Content" xml:space="preserve">
+    <value>Force Gateway Chat UI</value>
+  </data>
+  <data name="DebugPage_ForceCompanionChatUI.Content" xml:space="preserve">
+    <value>Force Companion Chat UI</value>
+  </data>
+  <data name="DebugPage_NoOverride2.Content" xml:space="preserve">
+    <value>No override</value>
+  </data>
+  <data name="DebugPage_ForceGatewayChatUI2.Content" xml:space="preserve">
+    <value>Force Gateway Chat UI</value>
+  </data>
+  <data name="DebugPage_ForceCompanionChatUI2.Content" xml:space="preserve">
+    <value>Force Companion Chat UI</value>
+  </data>
+  <data name="DebugPage_Refresh.Text" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="DebugPage_Copy.Text" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="DebugPage_OpenFile.Text" xml:space="preserve">
+    <value>Open file</value>
+  </data>
+  <data name="InstancesPage_PairingApprovalRequired.Text" xml:space="preserve">
+    <value>Pairing approval required</value>
+  </data>
+  <data name="InstancesPage_ANodeHasConnected.Text" xml:space="preserve">
+    <value>A node has connected but its capabilities won't activate until you approve the pairing request.</value>
+  </data>
+  <data name="InstancesPage_ReviewOnConnectionPage.Content" xml:space="preserve">
+    <value>Review on Connection page</value>
+  </data>
+  <data name="PermissionsPage_BackToConnection.Text" xml:space="preserve">
+    <value>Back to Connection</value>
+  </data>
+  <data name="PermissionsPage_Permissions.Text" xml:space="preserve">
+    <value>Permissions</value>
+  </data>
+  <data name="PermissionsPage_NodeMode.Text" xml:space="preserve">
+    <value>Node mode</value>
+  </data>
+  <data name="PermissionsPage_WhenOnThisPC.Text" xml:space="preserve">
+    <value>When on, this PC registers as a node and offers the capabilities below to agents over the gateway.</value>
+  </data>
+  <data name="PermissionsPage_Capabilities.Text" xml:space="preserve">
+    <value>Capabilities</value>
+  </data>
+  <data name="PermissionsPage_ToggleIndividualFeaturesThat.Text" xml:space="preserve">
+    <value>Toggle individual features that agents may request from this PC.</value>
+  </data>
+  <data name="PermissionsPage_Integrations.Text" xml:space="preserve">
+    <value>Integrations</value>
+  </data>
+  <data name="PermissionsPage_DefaultAction.Text" xml:space="preserve">
+    <value>Default action</value>
+  </data>
+  <data name="PermissionsPage_WhatHappensWhenA.Text" xml:space="preserve">
+    <value>What happens when a command doesn't match any rule below.</value>
+  </data>
+  <data name="PermissionsPage_PatternsAreMatchedLeft.Text" xml:space="preserve">
+    <value>Patterns are matched left-to-right against the full command line. Use * as a wildcard. Changes save automatically.</value>
+  </data>
+  <data name="PermissionsPage_Saved.Text" xml:space="preserve">
+    <value>Saved</value>
+  </data>
+  <data name="PermissionsPage_0Rules.Text" xml:space="preserve">
+    <value>0 rules</value>
+  </data>
+  <data name="PermissionsPage_NoRulesYetAdd.Text" xml:space="preserve">
+    <value>No rules yet. Add a pattern below to allow or deny specific commands.</value>
+  </data>
+  <data name="PermissionsPage_WindowsPrivacy.Text" xml:space="preserve">
+    <value>Windows privacy</value>
+  </data>
+  <data name="PermissionsPage_CameraMicrophoneAmpScreen.Text" xml:space="preserve">
+    <value>Camera, microphone &amp; screen access</value>
+  </data>
+  <data name="PermissionsPage_SystemLevelPrivacyPermissions.Text" xml:space="preserve">
+    <value>System-level privacy permissions are managed by Windows. Open Windows Privacy Settings to grant or revoke OpenClaw access.</value>
+  </data>
+  <data name="SandboxPage_NodeSandboxIsOn.Text" xml:space="preserve">
+    <value>Node sandbox is on</value>
+  </data>
+  <data name="SandboxPage_ProgramsTheAgentRuns.Text" xml:space="preserve">
+    <value>Programs the agent runs on this PC are contained.</value>
+  </data>
+  <data name="SandboxPage_WhatGetsContained.Text" xml:space="preserve">
+    <value>What gets contained</value>
+  </data>
+  <data name="SandboxPage_SeeWhichCommandsThis.Text" xml:space="preserve">
+    <value>See which commands this page covers — and which need different controls.</value>
+  </data>
+  <data name="SandboxPage_CommandsTheAgentRuns.Text" xml:space="preserve">
+    <value>Commands the agent runs through the Windows node (</value>
+  </data>
+  <data name="SandboxPage_SystemRun.Text" xml:space="preserve">
+    <value>system.run</value>
+  </data>
+  <data name="SandboxPage_AreContainedByThe.Text" xml:space="preserve">
+    <value>) are contained by the settings below.</value>
+  </data>
+  <data name="SandboxPage_CommandsTheAgentRuns2.Text" xml:space="preserve">
+    <value>Commands the agent runs directly on the gateway aren't. If the gateway is on WSL on this PC they can reach your Windows files, clipboard, and network — use the gateway's exec approvals.</value>
+  </data>
+  <data name="SandboxPage_SandboxUnavailable.Title" xml:space="preserve">
+    <value>Sandbox unavailable</value>
+  </data>
+  <data name="SandboxPage_LearnMoreAboutMXC.Content" xml:space="preserve">
+    <value>Learn more about MXC sandboxing</value>
+  </data>
+  <data name="SandboxPage_SecurityLevel.Text" xml:space="preserve">
+    <value>Security level</value>
+  </data>
+  <data name="SandboxPage_OneClickToSet.Text" xml:space="preserve">
+    <value>One click to set every control below. Custom folders stay as you set them.</value>
+  </data>
+  <data name="SandboxPage_LockedDown.Text" xml:space="preserve">
+    <value>🔒 Locked Down</value>
+  </data>
+  <data name="SandboxPage_NoInternetNoClipboard.Text" xml:space="preserve">
+    <value>No internet, no clipboard, no standard user folders.</value>
+  </data>
+  <data name="SandboxPage_Recommended.Text" xml:space="preserve">
+    <value>🛡 Recommended</value>
+  </data>
+  <data name="SandboxPage_InternetOnReadOnly.Text" xml:space="preserve">
+    <value>Internet on. Read-only on Documents, Downloads, Desktop. Clipboard read.</value>
+  </data>
+  <data name="SandboxPage_Unprotected.Text" xml:space="preserve">
+    <value>⚠ Unprotected</value>
+  </data>
+  <data name="SandboxPage_InternetOnReadWrite.Text" xml:space="preserve">
+    <value>Internet on. Read+write on Documents, Downloads, Desktop. Clipboard read+write.</value>
+  </data>
+  <data name="SandboxPage_CustomFolderGrantsStill.Title" xml:space="preserve">
+    <value>Custom folder grants still active</value>
+  </data>
+  <data name="SandboxPage_Files.Text" xml:space="preserve">
+    <value>📁 Files</value>
+  </data>
+  <data name="SandboxPage_ByDefaultTheAgent.Text" xml:space="preserve">
+    <value>By default the agent only has a temporary workspace folder it can read and write. Grant access to user folders below. SSH keys, browser profiles, and OpenClaw's own settings are always blocked.</value>
+  </data>
+  <data name="SandboxPage_Documents.Text" xml:space="preserve">
+    <value>Documents</value>
+  </data>
+  <data name="SandboxPage_Blocked.Content" xml:space="preserve">
+    <value>Blocked</value>
+  </data>
+  <data name="SandboxPage_ReadOnly.Content" xml:space="preserve">
+    <value>Read only</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite.Content" xml:space="preserve">
+    <value>Read &amp; write</value>
+  </data>
+  <data name="SandboxPage_Downloads.Text" xml:space="preserve">
+    <value>Downloads</value>
+  </data>
+  <data name="SandboxPage_Blocked2.Content" xml:space="preserve">
+    <value>Blocked</value>
+  </data>
+  <data name="SandboxPage_ReadOnly2.Content" xml:space="preserve">
+    <value>Read only</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite2.Content" xml:space="preserve">
+    <value>Read &amp; write</value>
+  </data>
+  <data name="SandboxPage_Desktop.Text" xml:space="preserve">
+    <value>Desktop</value>
+  </data>
+  <data name="SandboxPage_Blocked3.Content" xml:space="preserve">
+    <value>Blocked</value>
+  </data>
+  <data name="SandboxPage_ReadOnly3.Content" xml:space="preserve">
+    <value>Read only</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite3.Content" xml:space="preserve">
+    <value>Read &amp; write</value>
+  </data>
+  <data name="SandboxPage_ToolDirectoriesOnYour.Text" xml:space="preserve">
+    <value>Tool directories on your PATH are also granted read-only inside the sandbox, so command-line tools like git, node, python, and dotnet are usable. Drive roots are never granted.</value>
+  </data>
+  <data name="SandboxPage_CustomFolders.Text" xml:space="preserve">
+    <value>Custom folders</value>
+  </data>
+  <data name="SandboxPage_CustomGrantsAreAdded.Text" xml:space="preserve">
+    <value>Custom grants are added on top of the rules above. Adding a folder inside Documents/Downloads/Desktop with broader access will override the row-level setting for that path.</value>
+  </data>
+  <data name="SandboxPage_Blocked4.Content" xml:space="preserve">
+    <value>Blocked</value>
+  </data>
+  <data name="SandboxPage_ReadOnly4.Content" xml:space="preserve">
+    <value>Read only</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite4.Content" xml:space="preserve">
+    <value>Read &amp; write</value>
+  </data>
+  <data name="SandboxPage_NoCustomFoldersAdded.Text" xml:space="preserve">
+    <value>No custom folders added.</value>
+  </data>
+  <data name="SandboxPage_AddFolder.Content" xml:space="preserve">
+    <value>Add folder</value>
+  </data>
+  <data name="SandboxPage_Clipboard.Text" xml:space="preserve">
+    <value>📋 Clipboard</value>
+  </data>
+  <data name="SandboxPage_ClipboardOftenContainsPasswords.Text" xml:space="preserve">
+    <value>Clipboard often contains passwords, tokens, and private text. Read access may leak this to the agent (and over the internet, if enabled).</value>
+  </data>
+  <data name="SandboxPage_NoneDefault.Content" xml:space="preserve">
+    <value>None (default)</value>
+  </data>
+  <data name="SandboxPage_ReadAgentCanSee.Content" xml:space="preserve">
+    <value>Read — agent can see what you copied</value>
+  </data>
+  <data name="SandboxPage_WriteAgentCanReplace.Content" xml:space="preserve">
+    <value>Write — agent can replace your clipboard (cannot read it)</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite5.Content" xml:space="preserve">
+    <value>Read &amp; write</value>
+  </data>
+  <data name="SandboxPage_Network.Text" xml:space="preserve">
+    <value>📡 Network</value>
+  </data>
+  <data name="SandboxPage_AllowInternet.Header" xml:space="preserve">
+    <value>Allow internet</value>
+  </data>
+  <data name="SandboxPage_IfFileOrClipboard.Text" xml:space="preserve">
+    <value>If file or clipboard read access is enabled, the agent may send that data over the internet.</value>
+  </data>
+  <data name="SandboxPage_LocalNetworkDevicesAnd.Text" xml:space="preserve">
+    <value>Local network devices and shares are not included yet.</value>
+  </data>
+  <data name="SandboxPage_Limits.Text" xml:space="preserve">
+    <value>⏱ Limits</value>
+  </data>
+  <data name="SandboxPage_CommandTimeout30Sec.Text" xml:space="preserve">
+    <value>Command timeout: 30 sec</value>
+  </data>
+  <data name="SandboxPage_MaximumCapturedOutputTruncates.Text" xml:space="preserve">
+    <value>Maximum captured output (truncates beyond this; does not limit disk, memory, or CPU):</value>
+  </data>
+  <data name="SandboxPage_1MiB.Content" xml:space="preserve">
+    <value>1 MiB</value>
+  </data>
+  <data name="SandboxPage_4MiBDefault.Content" xml:space="preserve">
+    <value>4 MiB (default)</value>
+  </data>
+  <data name="SandboxPage_16MiB.Content" xml:space="preserve">
+    <value>16 MiB</value>
+  </data>
+  <data name="SandboxPage_64MiB.Content" xml:space="preserve">
+    <value>64 MiB</value>
+  </data>
+  <data name="SessionsPage_BackToConnection.Text" xml:space="preserve">
+    <value>Back to Connection</value>
+  </data>
+  <data name="SessionsPage_Sessions.Text" xml:space="preserve">
+    <value>Sessions</value>
+  </data>
+  <data name="SessionsPage_Refresh.Text" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="SessionsPage_All.Text" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="SessionsPage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>Gateway disconnected</value>
+  </data>
+  <data name="SessionsPage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>Connect to a gateway to load sessions.</value>
+  </data>
+  <data name="SessionsPage_OpenConnection.Content" xml:space="preserve">
+    <value>Open Connection</value>
+  </data>
+  <data name="SessionsPage_LoadingSessions.Text" xml:space="preserve">
+    <value>Loading sessions...</value>
+  </data>
+  <data name="SessionsPage_NoActiveSessions.Text" xml:space="preserve">
+    <value>No active sessions</value>
+  </data>
+  <data name="SessionsPage_Reset.Content" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="SessionsPage_Compact.Content" xml:space="preserve">
+    <value>Compact</value>
+  </data>
+  <data name="SessionsPage_Delete.Content" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="SettingsPage_Settings.Text" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="SettingsPage_General.Text" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="SettingsPage_Notifications.Text" xml:space="preserve">
+    <value>Notifications</value>
+  </data>
+  <data name="SettingsPage_Privacy.Text" xml:space="preserve">
+    <value>Privacy</value>
+  </data>
+  <data name="SettingsPage_LocalGateway.Text" xml:space="preserve">
+    <value>Local Gateway</value>
+  </data>
+  <data name="SettingsPage_MSIXInstallationDetected.Title" xml:space="preserve">
+    <value>MSIX installation detected</value>
+  </data>
+  <data name="SettingsPage_MSIXInstallationDetected.Message" xml:space="preserve">
+    <value>Removing OpenClaw from Windows Settings &amp;#x2192; Apps will NOT clean up the Local Gateway (WSL distro, disk image). Use Remove Local Gateway below FIRST, then uninstall OpenClaw.</value>
+  </data>
+  <data name="SettingsPage_RemovesTheWSLDistro.Text" xml:space="preserve">
+    <value>Removes the WSL distro (OpenClawGateway), its disk image, autostart entry, and clears gateway credentials. Your MCP token is preserved. Onboarding will reset.</value>
+  </data>
+  <data name="SettingsPage_RemoveLocalGateway.Content" xml:space="preserve">
+    <value>Remove Local Gateway</value>
+  </data>
+  <data name="SettingsPage_Saved.Title" xml:space="preserve">
+    <value>Saved</value>
+  </data>
+  <data name="SkillsPage_Skills.Text" xml:space="preserve">
+    <value>🧩 Skills</value>
+  </data>
+  <data name="SkillsPage_AllAgents.Content" xml:space="preserve">
+    <value>All Agents</value>
+  </data>
+  <data name="SkillsPage_Enabled.Text" xml:space="preserve">
+    <value>Enabled</value>
+  </data>
+  <data name="SkillsPage_Disabled.Text" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="SkillsPage_LoadingSkills.Text" xml:space="preserve">
+    <value>Loading skills...</value>
+  </data>
+  <data name="SkillsPage_NoSkillsInstalled.Text" xml:space="preserve">
+    <value>No skills installed</value>
+  </data>
+  <data name="SkillsPage_SkillsExtendYourAgent.Text" xml:space="preserve">
+    <value>Skills extend your agent's capabilities. Install skills via the CLI or ClawHub.</value>
+  </data>
+  <data name="UsagePage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>Gateway disconnected</value>
+  </data>
+  <data name="UsagePage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>Connect to a gateway to load usage data.</value>
+  </data>
+  <data name="UsagePage_OpenConnection.Content" xml:space="preserve">
+    <value>Open Connection</value>
+  </data>
+  <data name="UsagePage_LoadingDailyCosts.Text" xml:space="preserve">
+    <value>Loading daily costs...</value>
+  </data>
+  <data name="UsagePage_NoDailyUsageFor.Text" xml:space="preserve">
+    <value>No daily usage for this period</value>
+  </data>
+  <data name="VoiceSettingsPage_TestVoiceInput.Text" xml:space="preserve">
+    <value>Test Voice Input</value>
+  </data>
+  <data name="VoiceSettingsPage_Record.Text" xml:space="preserve">
+    <value>Record</value>
+  </data>
+  <data name="WorkspacePage_LoadingWorkspaceFiles.Text" xml:space="preserve">
+    <value>Loading workspace files…</value>
+  </data>
+  <data name="ChatWindow_WebChatUnavailable.Text" xml:space="preserve">
+    <value>Web Chat Unavailable</value>
+  </data>
+  <data name="ChatWindow_Retry.Content" xml:space="preserve">
+    <value>Retry</value>
+  </data>
+  <data name="ConnectionStatusWindow_ConnectionStatus.Text" xml:space="preserve">
+    <value>Connection Status</value>
+  </data>
+  <data name="ConnectionStatusWindow_STATEMACHINE.Text" xml:space="preserve">
+    <value>STATE MACHINE</value>
+  </data>
+  <data name="ConnectionStatusWindow_OPERATOR.Text" xml:space="preserve">
+    <value>OPERATOR</value>
+  </data>
+  <data name="ConnectionStatusWindow_Off.Text" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connecting.Text" xml:space="preserve">
+    <value>Connecting</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connected.Text" xml:space="preserve">
+    <value>Connected</value>
+  </data>
+  <data name="ConnectionStatusWindow_Pairing.Text" xml:space="preserve">
+    <value>Pairing</value>
+  </data>
+  <data name="ConnectionStatusWindow_Error.Text" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="ConnectionStatusWindow_NODE.Text" xml:space="preserve">
+    <value>NODE</value>
+  </data>
+  <data name="ConnectionStatusWindow_Off2.Text" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connecting2.Text" xml:space="preserve">
+    <value>Connecting</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connected2.Text" xml:space="preserve">
+    <value>Connected</value>
+  </data>
+  <data name="ConnectionStatusWindow_Pairing2.Text" xml:space="preserve">
+    <value>Pairing</value>
+  </data>
+  <data name="ConnectionStatusWindow_Error2.Text" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="ConnectionStatusWindow_GATEWAYS.Text" xml:space="preserve">
+    <value>GATEWAYS</value>
+  </data>
+  <data name="ConnectionStatusWindow_CREDENTIALS.Text" xml:space="preserve">
+    <value>CREDENTIALS</value>
+  </data>
+  <data name="ConnectionStatusWindow_SETUPCODE.Text" xml:space="preserve">
+    <value>SETUP CODE</value>
+  </data>
+  <data name="ConnectionStatusWindow_PasteASetupCode.Text" xml:space="preserve">
+    <value>Paste a setup code to connect end-to-end.</value>
+  </data>
+  <data name="ConnectionStatusWindow_PasteSetupCode.PlaceholderText" xml:space="preserve">
+    <value>Paste setup code…</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connect.Content" xml:space="preserve">
+    <value>Connect</value>
+  </data>
+  <data name="ConnectionStatusWindow_Disconnect.Content" xml:space="preserve">
+    <value>Disconnect</value>
+  </data>
+  <data name="ConnectionStatusWindow_DIRECTCONNECT.Text" xml:space="preserve">
+    <value>DIRECT CONNECT</value>
+  </data>
+  <data name="ConnectionStatusWindow_ConnectWithAGateway.Text" xml:space="preserve">
+    <value>Connect with a gateway URL and shared token (admin scope).</value>
+  </data>
+  <data name="ConnectionStatusWindow_WsLocalhost18790.PlaceholderText" xml:space="preserve">
+    <value>ws://localhost:18790</value>
+  </data>
+  <data name="ConnectionStatusWindow_WsLocalhost18790.Text" xml:space="preserve">
+    <value>ws://localhost:18790</value>
+  </data>
+  <data name="ConnectionStatusWindow_WsLocalhost18790.Header" xml:space="preserve">
+    <value>Gateway URL</value>
+  </data>
+  <data name="ConnectionStatusWindow_SharedGatewayToken.PlaceholderText" xml:space="preserve">
+    <value>Shared gateway token</value>
+  </data>
+  <data name="ConnectionStatusWindow_SharedGatewayToken.Header" xml:space="preserve">
+    <value>Token</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connect2.Content" xml:space="preserve">
+    <value>Connect</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHTunnel.Header" xml:space="preserve">
+    <value>SSH Tunnel</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHUser.Header" xml:space="preserve">
+    <value>SSH User</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHUser.PlaceholderText" xml:space="preserve">
+    <value>user</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHHost.Header" xml:space="preserve">
+    <value>SSH Host</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHHost.PlaceholderText" xml:space="preserve">
+    <value>192.168.x.x</value>
+  </data>
+  <data name="ConnectionStatusWindow_RemotePort.Header" xml:space="preserve">
+    <value>Remote Port</value>
+  </data>
+  <data name="ConnectionStatusWindow_LocalPort.Header" xml:space="preserve">
+    <value>Local Port</value>
+  </data>
+  <data name="ConnectionStatusWindow_EVENTTIMELINE.Text" xml:space="preserve">
+    <value>EVENT TIMELINE</value>
+  </data>
+  <data name="ConnectionStatusWindow_Copy.Content" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="ConnectionStatusWindow_Clear.Content" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="DiagnosticsBundleDialog_DiagnosticsBundle.Title" xml:space="preserve">
+    <value>Diagnostics bundle</value>
+  </data>
+  <data name="DiagnosticsBundleDialog_ReviewBeforeSharing.Title" xml:space="preserve">
+    <value>Review before sharing</value>
+  </data>
+  <data name="DiagnosticsBundleDialog_ReviewBeforeSharing.Message" xml:space="preserve">
+    <value>Sensitive tokens, command arguments, payloads, and recordings are excluded by the bundle builder.</value>
+  </data>
+  <data name="HubWindow_Disconnected.Text" xml:space="preserve">
+    <value>Disconnected</value>
+  </data>
+  <data name="HubWindow_Op.Text" xml:space="preserve">
+    <value>Op</value>
+  </data>
+  <data name="HubWindow_Node.Text" xml:space="preserve">
+    <value>Node</value>
+  </data>
+  <data name="HubWindow_Advanced.Content" xml:space="preserve">
+    <value>Advanced</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -3507,4 +3507,919 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="ConnectionStatusWindow.Title" xml:space="preserve">
     <value>Connection Status</value>
   </data>
+  <data name="BindingsPage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>Passerelle déconnectée</value>
+  </data>
+  <data name="BindingsPage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>Connectez-vous à une passerelle pour charger les liaisons.</value>
+  </data>
+  <data name="BindingsPage_OpenConnection.Content" xml:space="preserve">
+    <value>Ouvrir la connexion</value>
+  </data>
+  <data name="BindingsPage_LoadingBindings.Text" xml:space="preserve">
+    <value>Chargement des liaisons…</value>
+  </data>
+  <data name="ConnectionPage_ApprovalsWaitingOnYou.Text" xml:space="preserve">
+    <value>Approbations en attente</value>
+  </data>
+  <data name="ConnectionPage_NotConnected.Text" xml:space="preserve">
+    <value>Non connecté</value>
+  </data>
+  <data name="ConnectionPage_Connect.Content" xml:space="preserve">
+    <value>Connecter</value>
+  </data>
+  <data name="ConnectionPage_Operator.Text" xml:space="preserve">
+    <value>Opérateur</value>
+  </data>
+  <data name="ConnectionPage_SendCommandsAndView.Text" xml:space="preserve">
+    <value>Envoyez des commandes et consultez les sessions de cette passerelle depuis ce PC.</value>
+  </data>
+  <data name="ConnectionPage_Inactive.Text" xml:space="preserve">
+    <value>Inactif</value>
+  </data>
+  <data name="ConnectionPage_SeeSessions.Content" xml:space="preserve">
+    <value>Voir les sessions ›</value>
+  </data>
+  <data name="ConnectionPage_SeeInstances.Content" xml:space="preserve">
+    <value>Voir les instances ›</value>
+  </data>
+  <data name="ConnectionPage_NodeMode.Text" xml:space="preserve">
+    <value>Mode nœud</value>
+  </data>
+  <data name="ConnectionPage_WhenOnThisPC.Text" xml:space="preserve">
+    <value>Lorsqu'il est activé, ce PC s'enregistre comme nœud et offre les capacités ci-dessous aux agents via la passerelle.</value>
+  </data>
+  <data name="ConnectionPage_NodeModeDisabled.Text" xml:space="preserve">
+    <value>Mode nœud désactivé</value>
+  </data>
+  <data name="ConnectionPage_Copy.Content" xml:space="preserve">
+    <value>Copier</value>
+  </data>
+  <data name="ConnectionPage_Connect2.Content" xml:space="preserve">
+    <value>Connecter</value>
+  </data>
+  <data name="ConnectionPage_ManagePermissions.Content" xml:space="preserve">
+    <value>Gérer les autorisations ›</value>
+  </data>
+  <data name="ConnectionPage_HelpUsFixThis.Text" xml:space="preserve">
+    <value>Aidez-nous à réparer cette connexion :</value>
+  </data>
+  <data name="ConnectionPage_SSHTunnelIsDown.Text" xml:space="preserve">
+    <value>Le tunnel SSH est arrêté.</value>
+  </data>
+  <data name="ConnectionPage_RestartTunnel.Content" xml:space="preserve">
+    <value>Redémarrer le tunnel</value>
+  </data>
+  <data name="ConnectionPage_EditTunnelSettings.Content" xml:space="preserve">
+    <value>Modifier les paramètres du tunnel</value>
+  </data>
+  <data name="ConnectionPage_PasteANewSetup.Text" xml:space="preserve">
+    <value>Collez un nouveau code de configuration de l'hôte de la passerelle.</value>
+  </data>
+  <data name="ConnectionPage_PasteSetupCodeHere.PlaceholderText" xml:space="preserve">
+    <value>Collez le code de configuration ici…</value>
+  </data>
+  <data name="ConnectionPage_Apply.Content" xml:space="preserve">
+    <value>Appliquer</value>
+  </data>
+  <data name="ConnectionPage_RunOnTheGateway.Text" xml:space="preserve">
+    <value>Exécuter sur l'hôte de la passerelle :</value>
+  </data>
+  <data name="ConnectionPage_Copy2.Content" xml:space="preserve">
+    <value>Copier</value>
+  </data>
+  <data name="ConnectionPage_Connect3.Content" xml:space="preserve">
+    <value>Connecter</value>
+  </data>
+  <data name="ConnectionPage_Disconnect.Content" xml:space="preserve">
+    <value>Déconnecter</value>
+  </data>
+  <data name="ConnectionPage_SavedGateways.Text" xml:space="preserve">
+    <value>Passerelles enregistrées</value>
+  </data>
+  <data name="ConnectionPage_Gateways.Text" xml:space="preserve">
+    <value>Passerelles</value>
+  </data>
+  <data name="ConnectionPage_Scan.Text" xml:space="preserve">
+    <value>Analyser</value>
+  </data>
+  <data name="ConnectionPage_AddGateway.Text" xml:space="preserve">
+    <value>Ajouter une passerelle</value>
+  </data>
+  <data name="ConnectionPage_NoSavedGatewaysYet.Text" xml:space="preserve">
+    <value>Aucune passerelle enregistrée pour l'instant.</value>
+  </data>
+  <data name="ConnectionPage_DiscoveredOnYourNetwork.Text" xml:space="preserve">
+    <value>Découvert sur votre réseau</value>
+  </data>
+  <data name="ConnectionPage_AddAGateway.Text" xml:space="preserve">
+    <value>Ajouter une passerelle</value>
+  </data>
+  <data name="ConnectionPage_GetStartedInstallA.Title" xml:space="preserve">
+    <value>Pour commencer — installer une passerelle locale</value>
+  </data>
+  <data name="ConnectionPage_GetStartedInstallA.Message" xml:space="preserve">
+    <value>La méthode la plus rapide : configure une passerelle hébergée sur WSL sur ce PC et en fait la connexion active.</value>
+  </data>
+  <data name="ConnectionPage_Install.Content" xml:space="preserve">
+    <value>Installer</value>
+  </data>
+  <data name="ConnectionPage_OrConnectToAn.Text" xml:space="preserve">
+    <value>Ou connectez-vous à une existante :</value>
+  </data>
+  <data name="ConnectionPage_Direct.Text" xml:space="preserve">
+    <value>Connexion directe</value>
+  </data>
+  <data name="ConnectionPage_URLToken.Text" xml:space="preserve">
+    <value>URL + jeton</value>
+  </data>
+  <data name="ConnectionPage_SetupCode.Text" xml:space="preserve">
+    <value>Code de configuration</value>
+  </data>
+  <data name="ConnectionPage_PasteQRPayload.Text" xml:space="preserve">
+    <value>Coller la charge utile QR</value>
+  </data>
+  <data name="ConnectionPage_EachMethodSupportsAn.Text" xml:space="preserve">
+    <value>Chaque méthode prend en charge un tunnel SSH facultatif.</value>
+  </data>
+  <data name="ConnectionPage_OrLookForOne.Text" xml:space="preserve">
+    <value>Ou cherchez-en une sur votre réseau.</value>
+  </data>
+  <data name="ConnectionPage_Scan2.Text" xml:space="preserve">
+    <value>Analyser</value>
+  </data>
+  <data name="ConnectionPage_DiscoveredOnYourNetwork2.Text" xml:space="preserve">
+    <value>Découvert sur votre réseau</value>
+  </data>
+  <data name="ConnectionPage_Back.Text" xml:space="preserve">
+    <value>Retour</value>
+  </data>
+  <data name="ConnectionPage_AddAGateway2.Text" xml:space="preserve">
+    <value>Ajouter une passerelle</value>
+  </data>
+  <data name="ConnectionPage_Direct2.Text" xml:space="preserve">
+    <value>Connexion directe</value>
+  </data>
+  <data name="ConnectionPage_SetupCode2.Text" xml:space="preserve">
+    <value>Code de configuration</value>
+  </data>
+  <data name="ConnectionPage_LocalWSL.Text" xml:space="preserve">
+    <value>WSL local</value>
+  </data>
+  <data name="ConnectionPage_GatewayURL.Header" xml:space="preserve">
+    <value>URL de la passerelle</value>
+  </data>
+  <data name="ConnectionPage_GatewayURL.PlaceholderText" xml:space="preserve">
+    <value>ws://host.local:18790</value>
+  </data>
+  <data name="ConnectionPage_SharedToken.Header" xml:space="preserve">
+    <value>Jeton partagé</value>
+  </data>
+  <data name="ConnectionPage_SharedToken.PlaceholderText" xml:space="preserve">
+    <value>Coller le jeton partagé de la passerelle</value>
+  </data>
+  <data name="ConnectionPage_NameOptional.Header" xml:space="preserve">
+    <value>Nom (facultatif)</value>
+  </data>
+  <data name="ConnectionPage_NameOptional.PlaceholderText" xml:space="preserve">
+    <value>Ma passerelle</value>
+  </data>
+  <data name="ConnectionPage_PasteASetupCode.Text" xml:space="preserve">
+    <value>Collez un code de configuration depuis le QR de la passerelle ou la sortie d'`openclaw qr`.</value>
+  </data>
+  <data name="ConnectionPage_PasteSetupCodeHere2.PlaceholderText" xml:space="preserve">
+    <value>Collez le code de configuration ici…</value>
+  </data>
+  <data name="ConnectionPage_Decode.Content" xml:space="preserve">
+    <value>Décoder</value>
+  </data>
+  <data name="ConnectionPage_InstallANewWSL.Text" xml:space="preserve">
+    <value>Installez une nouvelle passerelle WSL sur ce PC et faites-en la connexion active. L'assistant d'installation installera WSL si nécessaire, configurera la passerelle et appairera cet appareil automatiquement.</value>
+  </data>
+  <data name="ConnectionPage_InstallLocalGateway.Content" xml:space="preserve">
+    <value>Installer la passerelle locale</value>
+  </data>
+  <data name="ConnectionPage_LocalWSLSetupIsn.Text" xml:space="preserve">
+    <value>La configuration WSL locale n'est pas disponible sur cette machine — l'assistant d'installation n'a pas pu être initialisé.</value>
+  </data>
+  <data name="ConnectionPage_UseSSHTunnelOptional.Text" xml:space="preserve">
+    <value>Utiliser un tunnel SSH (facultatif)</value>
+  </data>
+  <data name="ConnectionPage_SSHUser.Header" xml:space="preserve">
+    <value>Utilisateur SSH</value>
+  </data>
+  <data name="ConnectionPage_SSHUser.PlaceholderText" xml:space="preserve">
+    <value>user</value>
+  </data>
+  <data name="ConnectionPage_SSHHost.Header" xml:space="preserve">
+    <value>Hôte SSH</value>
+  </data>
+  <data name="ConnectionPage_SSHHost.PlaceholderText" xml:space="preserve">
+    <value>machine-name</value>
+  </data>
+  <data name="ConnectionPage_RemotePort.Header" xml:space="preserve">
+    <value>Port distant</value>
+  </data>
+  <data name="ConnectionPage_LocalPort.Header" xml:space="preserve">
+    <value>Port local</value>
+  </data>
+  <data name="ConnectionPage_SaveAmpConnect.Content" xml:space="preserve">
+    <value>Enregistrer &amp;amp; connecter</value>
+  </data>
+  <data name="ConnectionPage_Cancel.Content" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="CronPage_CronJobs.Text" xml:space="preserve">
+    <value>⏱️ Tâches Cron</value>
+  </data>
+  <data name="CronPage_Refresh.Text" xml:space="preserve">
+    <value>Actualiser</value>
+  </data>
+  <data name="CronPage_NewJob.Text" xml:space="preserve">
+    <value>Nouvelle tâche</value>
+  </data>
+  <data name="CronPage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>Passerelle déconnectée</value>
+  </data>
+  <data name="CronPage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>Connectez-vous à une passerelle pour charger les tâches cron.</value>
+  </data>
+  <data name="CronPage_OpenConnection.Content" xml:space="preserve">
+    <value>Ouvrir la connexion</value>
+  </data>
+  <data name="CronPage_NewCronJob.Text" xml:space="preserve">
+    <value>Nouvelle tâche Cron</value>
+  </data>
+  <data name="CronPage_NAME.Text" xml:space="preserve">
+    <value>NOM</value>
+  </data>
+  <data name="CronPage_MorningBrief.PlaceholderText" xml:space="preserve">
+    <value>Briefing du matin</value>
+  </data>
+  <data name="CronPage_SCHEDULE.Text" xml:space="preserve">
+    <value>PLANIFICATION</value>
+  </data>
+  <data name="CronPage_Every.Content" xml:space="preserve">
+    <value>Toutes les</value>
+  </data>
+  <data name="CronPage_At.Content" xml:space="preserve">
+    <value>À</value>
+  </data>
+  <data name="CronPage_Cron.Content" xml:space="preserve">
+    <value>Cron</value>
+  </data>
+  <data name="CronPage_QUICKPRESETS.Text" xml:space="preserve">
+    <value>PRÉRÉGLAGES RAPIDES</value>
+  </data>
+  <data name="CronPage_Hourly.Content" xml:space="preserve">
+    <value>⏰ Toutes les heures</value>
+  </data>
+  <data name="CronPage_Daily9am.Content" xml:space="preserve">
+    <value>🌅 Tous les jours à 9 h</value>
+  </data>
+  <data name="CronPage_Daily6pm.Content" xml:space="preserve">
+    <value>🌆 Tous les jours à 18 h</value>
+  </data>
+  <data name="CronPage_Weekdays.Content" xml:space="preserve">
+    <value>💼 Jours ouvrables</value>
+  </data>
+  <data name="CronPage_Weekly.Content" xml:space="preserve">
+    <value>📅 Hebdomadaire</value>
+  </data>
+  <data name="CronPage_EXPRESSION.Text" xml:space="preserve">
+    <value>EXPR. CRON</value>
+  </data>
+  <data name="CronPage_TIMEZONE.Text" xml:space="preserve">
+    <value>FUSEAU HORAIRE</value>
+  </data>
+  <data name="CronPage_Optional.PlaceholderText" xml:space="preserve">
+    <value>Facultatif</value>
+  </data>
+  <data name="CronPage_AmericaNewYork.Content" xml:space="preserve">
+    <value>America/New_York</value>
+  </data>
+  <data name="CronPage_AmericaChicago.Content" xml:space="preserve">
+    <value>America/Chicago</value>
+  </data>
+  <data name="CronPage_AmericaDenver.Content" xml:space="preserve">
+    <value>America/Denver</value>
+  </data>
+  <data name="CronPage_AmericaLosAngeles.Content" xml:space="preserve">
+    <value>America/Los_Angeles</value>
+  </data>
+  <data name="CronPage_EuropeLondon.Content" xml:space="preserve">
+    <value>Europe/London</value>
+  </data>
+  <data name="CronPage_EuropeBerlin.Content" xml:space="preserve">
+    <value>Europe/Berlin</value>
+  </data>
+  <data name="CronPage_AsiaTokyo.Content" xml:space="preserve">
+    <value>Asia/Tokyo</value>
+  </data>
+  <data name="CronPage_UTC.Content" xml:space="preserve">
+    <value>UTC</value>
+  </data>
+  <data name="CronPage_EVERY.Text" xml:space="preserve">
+    <value>TOUTES LES</value>
+  </data>
+  <data name="CronPage_UNIT.Text" xml:space="preserve">
+    <value>UNITÉ</value>
+  </data>
+  <data name="CronPage_Minutes.Content" xml:space="preserve">
+    <value>Min</value>
+  </data>
+  <data name="CronPage_Hours.Content" xml:space="preserve">
+    <value>Heures</value>
+  </data>
+  <data name="CronPage_Days.Content" xml:space="preserve">
+    <value>Jours</value>
+  </data>
+  <data name="CronPage_RUNAT.Text" xml:space="preserve">
+    <value>EXÉCUTER À</value>
+  </data>
+  <data name="CronPage_Date.PlaceholderText" xml:space="preserve">
+    <value>Choisir une date</value>
+  </data>
+  <data name="CronPage_330PM.PlaceholderText" xml:space="preserve">
+    <value>15:30</value>
+  </data>
+  <data name="CronPage_DeleteJobAfterIt.Content" xml:space="preserve">
+    <value>Supprimer la tâche après son exécution</value>
+  </data>
+  <data name="CronPage_PROMPTPAYLOAD.Text" xml:space="preserve">
+    <value>INVITE / CHARGE UTILE</value>
+  </data>
+  <data name="CronPage_WhatShouldTheAgent.PlaceholderText" xml:space="preserve">
+    <value>Que doit faire l'agent ?</value>
+  </data>
+  <data name="CronPage_DELIVERY.Text" xml:space="preserve">
+    <value>LIVRAISON</value>
+  </data>
+  <data name="CronPage_SilentNone.Content" xml:space="preserve">
+    <value>Silencieux (aucun)</value>
+  </data>
+  <data name="CronPage_NotifyMeAnnounce.Content" xml:space="preserve">
+    <value>M'avertir (annoncer)</value>
+  </data>
+  <data name="CronPage_CHANNEL.Text" xml:space="preserve">
+    <value>CANAL</value>
+  </data>
+  <data name="CronPage_EGWebchat.PlaceholderText" xml:space="preserve">
+    <value>ex. webchat</value>
+  </data>
+  <data name="CronPage_AdvancedOptions.Text" xml:space="preserve">
+    <value>Options avancées</value>
+  </data>
+  <data name="CronPage_SESSIONBEHAVIOR.Text" xml:space="preserve">
+    <value>COMPORTEMENT DE SESSION</value>
+  </data>
+  <data name="CronPage_NewSessionEachRun.Content" xml:space="preserve">
+    <value>Nouvelle session à chaque exécution</value>
+  </data>
+  <data name="CronPage_ResumeMainSession.Content" xml:space="preserve">
+    <value>Reprendre la session principale</value>
+  </data>
+  <data name="CronPage_WAKEMODE.Text" xml:space="preserve">
+    <value>MODE DE RÉVEIL</value>
+  </data>
+  <data name="CronPage_NowImmediate.Content" xml:space="preserve">
+    <value>Maintenant (immédiat)</value>
+  </data>
+  <data name="CronPage_QueueWaitForIdle.Content" xml:space="preserve">
+    <value>File d'attente (attendre l'inactivité)</value>
+  </data>
+  <data name="CronPage_Cancel.Content" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="CronPage_CreateJob.Content" xml:space="preserve">
+    <value>Créer la tâche</value>
+  </data>
+  <data name="CronPage_LoadingCronJobs.Text" xml:space="preserve">
+    <value>Chargement des tâches cron…</value>
+  </data>
+  <data name="CronPage_NoCronJobsConfigured.Text" xml:space="preserve">
+    <value>Aucune tâche cron configurée</value>
+  </data>
+  <data name="CronPage_CronJobsWillAppear.Text" xml:space="preserve">
+    <value>Les tâches cron apparaîtront ici lorsqu'elles seront configurées via la passerelle.</value>
+  </data>
+  <data name="DebugPage_Status.Title" xml:space="preserve">
+    <value>État</value>
+  </data>
+  <data name="DebugPage_Copied.Title" xml:space="preserve">
+    <value>Copié</value>
+  </data>
+  <data name="DebugPage_NoOverride.Content" xml:space="preserve">
+    <value>Aucun remplacement</value>
+  </data>
+  <data name="DebugPage_ForceGatewayChatUI.Content" xml:space="preserve">
+    <value>Forcer l'interface de chat de la passerelle</value>
+  </data>
+  <data name="DebugPage_ForceCompanionChatUI.Content" xml:space="preserve">
+    <value>Forcer l'interface de chat du compagnon</value>
+  </data>
+  <data name="DebugPage_NoOverride2.Content" xml:space="preserve">
+    <value>Aucun remplacement</value>
+  </data>
+  <data name="DebugPage_ForceGatewayChatUI2.Content" xml:space="preserve">
+    <value>Forcer l'interface de chat de la passerelle</value>
+  </data>
+  <data name="DebugPage_ForceCompanionChatUI2.Content" xml:space="preserve">
+    <value>Forcer l'interface de chat du compagnon</value>
+  </data>
+  <data name="DebugPage_Refresh.Text" xml:space="preserve">
+    <value>Actualiser</value>
+  </data>
+  <data name="DebugPage_Copy.Text" xml:space="preserve">
+    <value>Copier</value>
+  </data>
+  <data name="DebugPage_OpenFile.Text" xml:space="preserve">
+    <value>Ouvrir le fichier</value>
+  </data>
+  <data name="InstancesPage_PairingApprovalRequired.Text" xml:space="preserve">
+    <value>Approbation d'appairage requise</value>
+  </data>
+  <data name="InstancesPage_ANodeHasConnected.Text" xml:space="preserve">
+    <value>Un nœud s'est connecté mais ses capacités ne s'activeront pas tant que vous n'aurez pas approuvé la demande d'appairage.</value>
+  </data>
+  <data name="InstancesPage_ReviewOnConnectionPage.Content" xml:space="preserve">
+    <value>Examiner sur la page Connexion</value>
+  </data>
+  <data name="PermissionsPage_BackToConnection.Text" xml:space="preserve">
+    <value>Retour à la connexion</value>
+  </data>
+  <data name="PermissionsPage_Permissions.Text" xml:space="preserve">
+    <value>Autorisations</value>
+  </data>
+  <data name="PermissionsPage_NodeMode.Text" xml:space="preserve">
+    <value>Mode nœud</value>
+  </data>
+  <data name="PermissionsPage_WhenOnThisPC.Text" xml:space="preserve">
+    <value>Lorsqu'il est activé, ce PC s'enregistre comme nœud et offre les capacités ci-dessous aux agents via la passerelle.</value>
+  </data>
+  <data name="PermissionsPage_Capabilities.Text" xml:space="preserve">
+    <value>Capacités</value>
+  </data>
+  <data name="PermissionsPage_ToggleIndividualFeaturesThat.Text" xml:space="preserve">
+    <value>Activez ou désactivez les fonctionnalités individuelles que les agents peuvent demander à ce PC.</value>
+  </data>
+  <data name="PermissionsPage_Integrations.Text" xml:space="preserve">
+    <value>Intégrations</value>
+  </data>
+  <data name="PermissionsPage_DefaultAction.Text" xml:space="preserve">
+    <value>Action par défaut</value>
+  </data>
+  <data name="PermissionsPage_WhatHappensWhenA.Text" xml:space="preserve">
+    <value>Ce qui se passe lorsqu'une commande ne correspond à aucune règle ci-dessous.</value>
+  </data>
+  <data name="PermissionsPage_PatternsAreMatchedLeft.Text" xml:space="preserve">
+    <value>Les motifs sont comparés de gauche à droite à la ligne de commande complète. Utilisez * comme caractère générique. Les modifications sont enregistrées automatiquement.</value>
+  </data>
+  <data name="PermissionsPage_Saved.Text" xml:space="preserve">
+    <value>Enregistré</value>
+  </data>
+  <data name="PermissionsPage_0Rules.Text" xml:space="preserve">
+    <value>0 règle</value>
+  </data>
+  <data name="PermissionsPage_NoRulesYetAdd.Text" xml:space="preserve">
+    <value>Aucune règle pour l'instant. Ajoutez un motif ci-dessous pour autoriser ou refuser des commandes spécifiques.</value>
+  </data>
+  <data name="PermissionsPage_WindowsPrivacy.Text" xml:space="preserve">
+    <value>Confidentialité Windows</value>
+  </data>
+  <data name="PermissionsPage_CameraMicrophoneAmpScreen.Text" xml:space="preserve">
+    <value>Accès caméra, microphone &amp;amp; écran</value>
+  </data>
+  <data name="PermissionsPage_SystemLevelPrivacyPermissions.Text" xml:space="preserve">
+    <value>Les autorisations de confidentialité au niveau système sont gérées par Windows. Ouvrez les Paramètres de confidentialité Windows pour accorder ou révoquer l'accès à OpenClaw.</value>
+  </data>
+  <data name="SandboxPage_NodeSandboxIsOn.Text" xml:space="preserve">
+    <value>Le bac à sable du nœud est activé</value>
+  </data>
+  <data name="SandboxPage_ProgramsTheAgentRuns.Text" xml:space="preserve">
+    <value>Les programmes que l'agent exécute sur ce PC sont confinés.</value>
+  </data>
+  <data name="SandboxPage_WhatGetsContained.Text" xml:space="preserve">
+    <value>Ce qui est confiné</value>
+  </data>
+  <data name="SandboxPage_SeeWhichCommandsThis.Text" xml:space="preserve">
+    <value>Découvrez quelles commandes cette page couvre — et lesquelles nécessitent d'autres contrôles.</value>
+  </data>
+  <data name="SandboxPage_CommandsTheAgentRuns.Text" xml:space="preserve">
+    <value>Les commandes que l'agent exécute via le nœud Windows (</value>
+  </data>
+  <data name="SandboxPage_SystemRun.Text" xml:space="preserve">
+    <value>system.run</value>
+  </data>
+  <data name="SandboxPage_AreContainedByThe.Text" xml:space="preserve">
+    <value>) sont confinées par les paramètres ci-dessous.</value>
+  </data>
+  <data name="SandboxPage_CommandsTheAgentRuns2.Text" xml:space="preserve">
+    <value>Les commandes que l'agent exécute directement sur la passerelle ne le sont pas. Si la passerelle est sur WSL sur ce PC, elles peuvent accéder à vos fichiers Windows, votre presse-papiers et votre réseau — utilisez les approbations d'exécution de la passerelle.</value>
+  </data>
+  <data name="SandboxPage_SandboxUnavailable.Title" xml:space="preserve">
+    <value>Bac à sable indisponible</value>
+  </data>
+  <data name="SandboxPage_LearnMoreAboutMXC.Content" xml:space="preserve">
+    <value>En savoir plus sur le bac à sable MXC</value>
+  </data>
+  <data name="SandboxPage_SecurityLevel.Text" xml:space="preserve">
+    <value>Niveau de sécurité</value>
+  </data>
+  <data name="SandboxPage_OneClickToSet.Text" xml:space="preserve">
+    <value>Un clic pour définir tous les contrôles ci-dessous. Les dossiers personnalisés restent tels que vous les avez définis.</value>
+  </data>
+  <data name="SandboxPage_LockedDown.Text" xml:space="preserve">
+    <value>🔒 Verrouillé</value>
+  </data>
+  <data name="SandboxPage_NoInternetNoClipboard.Text" xml:space="preserve">
+    <value>Pas d'Internet, pas de presse-papiers, pas de dossiers utilisateur standard.</value>
+  </data>
+  <data name="SandboxPage_Recommended.Text" xml:space="preserve">
+    <value>🛡 Recommandé</value>
+  </data>
+  <data name="SandboxPage_InternetOnReadOnly.Text" xml:space="preserve">
+    <value>Internet activé. Lecture seule sur Documents, Téléchargements, Bureau. Lecture du presse-papiers.</value>
+  </data>
+  <data name="SandboxPage_Unprotected.Text" xml:space="preserve">
+    <value>⚠ Non protégé</value>
+  </data>
+  <data name="SandboxPage_InternetOnReadWrite.Text" xml:space="preserve">
+    <value>Internet activé. Lecture + écriture sur Documents, Téléchargements, Bureau. Lecture + écriture du presse-papiers.</value>
+  </data>
+  <data name="SandboxPage_CustomFolderGrantsStill.Title" xml:space="preserve">
+    <value>Les attributions de dossier personnalisé sont toujours actives</value>
+  </data>
+  <data name="SandboxPage_Files.Text" xml:space="preserve">
+    <value>📁 Fichiers</value>
+  </data>
+  <data name="SandboxPage_ByDefaultTheAgent.Text" xml:space="preserve">
+    <value>Par défaut, l'agent ne dispose que d'un dossier de travail temporaire qu'il peut lire et écrire. Accordez l'accès aux dossiers utilisateur ci-dessous. Les clés SSH, les profils de navigateur et les paramètres d'OpenClaw lui-même sont toujours bloqués.</value>
+  </data>
+  <data name="SandboxPage_Documents.Text" xml:space="preserve">
+    <value>Mes documents</value>
+  </data>
+  <data name="SandboxPage_Blocked.Content" xml:space="preserve">
+    <value>Bloqué</value>
+  </data>
+  <data name="SandboxPage_ReadOnly.Content" xml:space="preserve">
+    <value>Lecture seule</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite.Content" xml:space="preserve">
+    <value>Lecture &amp;amp; écriture</value>
+  </data>
+  <data name="SandboxPage_Downloads.Text" xml:space="preserve">
+    <value>Téléchargements</value>
+  </data>
+  <data name="SandboxPage_Blocked2.Content" xml:space="preserve">
+    <value>Bloqué</value>
+  </data>
+  <data name="SandboxPage_ReadOnly2.Content" xml:space="preserve">
+    <value>Lecture seule</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite2.Content" xml:space="preserve">
+    <value>Lecture &amp;amp; écriture</value>
+  </data>
+  <data name="SandboxPage_Desktop.Text" xml:space="preserve">
+    <value>Bureau</value>
+  </data>
+  <data name="SandboxPage_Blocked3.Content" xml:space="preserve">
+    <value>Bloqué</value>
+  </data>
+  <data name="SandboxPage_ReadOnly3.Content" xml:space="preserve">
+    <value>Lecture seule</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite3.Content" xml:space="preserve">
+    <value>Lecture &amp;amp; écriture</value>
+  </data>
+  <data name="SandboxPage_ToolDirectoriesOnYour.Text" xml:space="preserve">
+    <value>Les répertoires d'outils de votre PATH bénéficient également d'un accès en lecture seule dans le bac à sable, afin que les outils en ligne de commande comme git, node, python et dotnet soient utilisables. Les racines de lecteur ne sont jamais accordées.</value>
+  </data>
+  <data name="SandboxPage_CustomFolders.Text" xml:space="preserve">
+    <value>Dossiers personnalisés</value>
+  </data>
+  <data name="SandboxPage_CustomGrantsAreAdded.Text" xml:space="preserve">
+    <value>Les autorisations personnalisées sont ajoutées en plus des règles ci-dessus. L'ajout d'un dossier dans Documents/Téléchargements/Bureau avec un accès plus large remplacera le paramètre au niveau de la ligne pour ce chemin.</value>
+  </data>
+  <data name="SandboxPage_Blocked4.Content" xml:space="preserve">
+    <value>Bloqué</value>
+  </data>
+  <data name="SandboxPage_ReadOnly4.Content" xml:space="preserve">
+    <value>Lecture seule</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite4.Content" xml:space="preserve">
+    <value>Lecture &amp;amp; écriture</value>
+  </data>
+  <data name="SandboxPage_NoCustomFoldersAdded.Text" xml:space="preserve">
+    <value>Aucun dossier personnalisé ajouté.</value>
+  </data>
+  <data name="SandboxPage_AddFolder.Content" xml:space="preserve">
+    <value>Ajouter un dossier</value>
+  </data>
+  <data name="SandboxPage_Clipboard.Text" xml:space="preserve">
+    <value>📋 Presse-papiers</value>
+  </data>
+  <data name="SandboxPage_ClipboardOftenContainsPasswords.Text" xml:space="preserve">
+    <value>Le presse-papiers contient souvent des mots de passe, des jetons et du texte privé. L'accès en lecture peut divulguer ces données à l'agent (et sur Internet, s'il est activé).</value>
+  </data>
+  <data name="SandboxPage_NoneDefault.Content" xml:space="preserve">
+    <value>Aucun (par défaut)</value>
+  </data>
+  <data name="SandboxPage_ReadAgentCanSee.Content" xml:space="preserve">
+    <value>Lecture — l'agent peut voir ce que vous avez copié</value>
+  </data>
+  <data name="SandboxPage_WriteAgentCanReplace.Content" xml:space="preserve">
+    <value>Écriture — l'agent peut remplacer votre presse-papiers (sans pouvoir le lire)</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite5.Content" xml:space="preserve">
+    <value>Lecture &amp;amp; écriture</value>
+  </data>
+  <data name="SandboxPage_Network.Text" xml:space="preserve">
+    <value>📡 Réseau</value>
+  </data>
+  <data name="SandboxPage_AllowInternet.Header" xml:space="preserve">
+    <value>Autoriser Internet</value>
+  </data>
+  <data name="SandboxPage_IfFileOrClipboard.Text" xml:space="preserve">
+    <value>Si l'accès en lecture aux fichiers ou au presse-papiers est activé, l'agent peut envoyer ces données sur Internet.</value>
+  </data>
+  <data name="SandboxPage_LocalNetworkDevicesAnd.Text" xml:space="preserve">
+    <value>Les périphériques et partages réseau locaux ne sont pas encore inclus.</value>
+  </data>
+  <data name="SandboxPage_Limits.Text" xml:space="preserve">
+    <value>⏱ Limites</value>
+  </data>
+  <data name="SandboxPage_CommandTimeout30Sec.Text" xml:space="preserve">
+    <value>Délai d'expiration de commande : 30 s</value>
+  </data>
+  <data name="SandboxPage_MaximumCapturedOutputTruncates.Text" xml:space="preserve">
+    <value>Sortie capturée maximale (tronquée au-delà ; ne limite pas le disque, la mémoire ou le processeur) :</value>
+  </data>
+  <data name="SandboxPage_1MiB.Content" xml:space="preserve">
+    <value>1 MiB</value>
+  </data>
+  <data name="SandboxPage_4MiBDefault.Content" xml:space="preserve">
+    <value>4 Mio (par défaut)</value>
+  </data>
+  <data name="SandboxPage_16MiB.Content" xml:space="preserve">
+    <value>16 MiB</value>
+  </data>
+  <data name="SandboxPage_64MiB.Content" xml:space="preserve">
+    <value>64 MiB</value>
+  </data>
+  <data name="SessionsPage_BackToConnection.Text" xml:space="preserve">
+    <value>Retour à la connexion</value>
+  </data>
+  <data name="SessionsPage_Sessions.Text" xml:space="preserve">
+    <value>Mes sessions</value>
+  </data>
+  <data name="SessionsPage_Refresh.Text" xml:space="preserve">
+    <value>Actualiser</value>
+  </data>
+  <data name="SessionsPage_All.Text" xml:space="preserve">
+    <value>Tous</value>
+  </data>
+  <data name="SessionsPage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>Passerelle déconnectée</value>
+  </data>
+  <data name="SessionsPage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>Connectez-vous à une passerelle pour charger les sessions.</value>
+  </data>
+  <data name="SessionsPage_OpenConnection.Content" xml:space="preserve">
+    <value>Ouvrir la connexion</value>
+  </data>
+  <data name="SessionsPage_LoadingSessions.Text" xml:space="preserve">
+    <value>Chargement des sessions…</value>
+  </data>
+  <data name="SessionsPage_NoActiveSessions.Text" xml:space="preserve">
+    <value>Aucune session active</value>
+  </data>
+  <data name="SessionsPage_Reset.Content" xml:space="preserve">
+    <value>Réinitialiser</value>
+  </data>
+  <data name="SessionsPage_Compact.Content" xml:space="preserve">
+    <value>Compacter</value>
+  </data>
+  <data name="SessionsPage_Delete.Content" xml:space="preserve">
+    <value>Supprimer</value>
+  </data>
+  <data name="SettingsPage_Settings.Text" xml:space="preserve">
+    <value>Paramètres</value>
+  </data>
+  <data name="SettingsPage_General.Text" xml:space="preserve">
+    <value>Général</value>
+  </data>
+  <data name="SettingsPage_Notifications.Text" xml:space="preserve">
+    <value>Mes notifications</value>
+  </data>
+  <data name="SettingsPage_Privacy.Text" xml:space="preserve">
+    <value>Confidentialité</value>
+  </data>
+  <data name="SettingsPage_LocalGateway.Text" xml:space="preserve">
+    <value>Passerelle locale</value>
+  </data>
+  <data name="SettingsPage_MSIXInstallationDetected.Title" xml:space="preserve">
+    <value>Installation MSIX détectée</value>
+  </data>
+  <data name="SettingsPage_MSIXInstallationDetected.Message" xml:space="preserve">
+    <value>La suppression d'OpenClaw via Paramètres Windows &amp;amp;#x2192; Applications ne nettoiera PAS la passerelle locale (distribution WSL, image disque). Utilisez d'abord Supprimer la passerelle locale ci-dessous, puis désinstallez OpenClaw.</value>
+  </data>
+  <data name="SettingsPage_RemovesTheWSLDistro.Text" xml:space="preserve">
+    <value>Supprime la distribution WSL (OpenClawGateway), son image disque, l'entrée de démarrage automatique et efface les identifiants de la passerelle. Votre jeton MCP est conservé. L'intégration sera réinitialisée.</value>
+  </data>
+  <data name="SettingsPage_RemoveLocalGateway.Content" xml:space="preserve">
+    <value>Supprimer la passerelle locale</value>
+  </data>
+  <data name="SettingsPage_Saved.Title" xml:space="preserve">
+    <value>Enregistré</value>
+  </data>
+  <data name="SkillsPage_Skills.Text" xml:space="preserve">
+    <value>🧩 Compétences</value>
+  </data>
+  <data name="SkillsPage_AllAgents.Content" xml:space="preserve">
+    <value>Tous les agents</value>
+  </data>
+  <data name="SkillsPage_Enabled.Text" xml:space="preserve">
+    <value>Activé</value>
+  </data>
+  <data name="SkillsPage_Disabled.Text" xml:space="preserve">
+    <value>Désactivé</value>
+  </data>
+  <data name="SkillsPage_LoadingSkills.Text" xml:space="preserve">
+    <value>Chargement des compétences…</value>
+  </data>
+  <data name="SkillsPage_NoSkillsInstalled.Text" xml:space="preserve">
+    <value>Aucune compétence installée</value>
+  </data>
+  <data name="SkillsPage_SkillsExtendYourAgent.Text" xml:space="preserve">
+    <value>Les compétences étendent les capacités de votre agent. Installez des compétences via la CLI ou ClawHub.</value>
+  </data>
+  <data name="UsagePage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>Passerelle déconnectée</value>
+  </data>
+  <data name="UsagePage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>Connectez-vous à une passerelle pour charger les données d'utilisation.</value>
+  </data>
+  <data name="UsagePage_OpenConnection.Content" xml:space="preserve">
+    <value>Ouvrir la connexion</value>
+  </data>
+  <data name="UsagePage_LoadingDailyCosts.Text" xml:space="preserve">
+    <value>Chargement des coûts quotidiens…</value>
+  </data>
+  <data name="UsagePage_NoDailyUsageFor.Text" xml:space="preserve">
+    <value>Aucune utilisation quotidienne pour cette période</value>
+  </data>
+  <data name="VoiceSettingsPage_TestVoiceInput.Text" xml:space="preserve">
+    <value>Tester l'entrée vocale</value>
+  </data>
+  <data name="VoiceSettingsPage_Record.Text" xml:space="preserve">
+    <value>Enregistrer</value>
+  </data>
+  <data name="WorkspacePage_LoadingWorkspaceFiles.Text" xml:space="preserve">
+    <value>Chargement des fichiers de l'espace de travail…</value>
+  </data>
+  <data name="ChatWindow_WebChatUnavailable.Text" xml:space="preserve">
+    <value>Chat Web indisponible</value>
+  </data>
+  <data name="ChatWindow_Retry.Content" xml:space="preserve">
+    <value>Réessayer</value>
+  </data>
+  <data name="ConnectionStatusWindow_ConnectionStatus.Text" xml:space="preserve">
+    <value>État de la connexion</value>
+  </data>
+  <data name="ConnectionStatusWindow_STATEMACHINE.Text" xml:space="preserve">
+    <value>MACHINE À ÉTATS</value>
+  </data>
+  <data name="ConnectionStatusWindow_OPERATOR.Text" xml:space="preserve">
+    <value>OPÉRATEUR</value>
+  </data>
+  <data name="ConnectionStatusWindow_Off.Text" xml:space="preserve">
+    <value>Désactivé</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connecting.Text" xml:space="preserve">
+    <value>Connexion en cours</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connected.Text" xml:space="preserve">
+    <value>Connecté</value>
+  </data>
+  <data name="ConnectionStatusWindow_Pairing.Text" xml:space="preserve">
+    <value>Appairage</value>
+  </data>
+  <data name="ConnectionStatusWindow_Error.Text" xml:space="preserve">
+    <value>Erreur</value>
+  </data>
+  <data name="ConnectionStatusWindow_NODE.Text" xml:space="preserve">
+    <value>NŒUD</value>
+  </data>
+  <data name="ConnectionStatusWindow_Off2.Text" xml:space="preserve">
+    <value>Désactivé</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connecting2.Text" xml:space="preserve">
+    <value>Connexion en cours</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connected2.Text" xml:space="preserve">
+    <value>Connecté</value>
+  </data>
+  <data name="ConnectionStatusWindow_Pairing2.Text" xml:space="preserve">
+    <value>Appairage</value>
+  </data>
+  <data name="ConnectionStatusWindow_Error2.Text" xml:space="preserve">
+    <value>Erreur</value>
+  </data>
+  <data name="ConnectionStatusWindow_GATEWAYS.Text" xml:space="preserve">
+    <value>PASSERELLES</value>
+  </data>
+  <data name="ConnectionStatusWindow_CREDENTIALS.Text" xml:space="preserve">
+    <value>IDENTIFIANTS</value>
+  </data>
+  <data name="ConnectionStatusWindow_SETUPCODE.Text" xml:space="preserve">
+    <value>CODE DE CONFIGURATION</value>
+  </data>
+  <data name="ConnectionStatusWindow_PasteASetupCode.Text" xml:space="preserve">
+    <value>Collez un code de configuration pour établir une connexion de bout en bout.</value>
+  </data>
+  <data name="ConnectionStatusWindow_PasteSetupCode.PlaceholderText" xml:space="preserve">
+    <value>Collez le code de configuration…</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connect.Content" xml:space="preserve">
+    <value>Connecter</value>
+  </data>
+  <data name="ConnectionStatusWindow_Disconnect.Content" xml:space="preserve">
+    <value>Déconnecter</value>
+  </data>
+  <data name="ConnectionStatusWindow_DIRECTCONNECT.Text" xml:space="preserve">
+    <value>CONNEXION DIRECTE</value>
+  </data>
+  <data name="ConnectionStatusWindow_ConnectWithAGateway.Text" xml:space="preserve">
+    <value>Connectez-vous avec une URL de passerelle et un jeton partagé (étendue admin).</value>
+  </data>
+  <data name="ConnectionStatusWindow_WsLocalhost18790.PlaceholderText" xml:space="preserve">
+    <value>ws://localhost:18790</value>
+  </data>
+  <data name="ConnectionStatusWindow_WsLocalhost18790.Text" xml:space="preserve">
+    <value>ws://localhost:18790</value>
+  </data>
+  <data name="ConnectionStatusWindow_WsLocalhost18790.Header" xml:space="preserve">
+    <value>URL de la passerelle</value>
+  </data>
+  <data name="ConnectionStatusWindow_SharedGatewayToken.PlaceholderText" xml:space="preserve">
+    <value>Jeton partagé de la passerelle</value>
+  </data>
+  <data name="ConnectionStatusWindow_SharedGatewayToken.Header" xml:space="preserve">
+    <value>Jeton</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connect2.Content" xml:space="preserve">
+    <value>Connecter</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHTunnel.Header" xml:space="preserve">
+    <value>Tunnel SSH</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHUser.Header" xml:space="preserve">
+    <value>Utilisateur SSH</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHUser.PlaceholderText" xml:space="preserve">
+    <value>user</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHHost.Header" xml:space="preserve">
+    <value>Hôte SSH</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHHost.PlaceholderText" xml:space="preserve">
+    <value>192.168.x.x</value>
+  </data>
+  <data name="ConnectionStatusWindow_RemotePort.Header" xml:space="preserve">
+    <value>Port distant</value>
+  </data>
+  <data name="ConnectionStatusWindow_LocalPort.Header" xml:space="preserve">
+    <value>Port local</value>
+  </data>
+  <data name="ConnectionStatusWindow_EVENTTIMELINE.Text" xml:space="preserve">
+    <value>CHRONOLOGIE DES ÉVÉNEMENTS</value>
+  </data>
+  <data name="ConnectionStatusWindow_Copy.Content" xml:space="preserve">
+    <value>Copier</value>
+  </data>
+  <data name="ConnectionStatusWindow_Clear.Content" xml:space="preserve">
+    <value>Effacer</value>
+  </data>
+  <data name="DiagnosticsBundleDialog_DiagnosticsBundle.Title" xml:space="preserve">
+    <value>Lot de diagnostics</value>
+  </data>
+  <data name="DiagnosticsBundleDialog_ReviewBeforeSharing.Title" xml:space="preserve">
+    <value>Examiner avant de partager</value>
+  </data>
+  <data name="DiagnosticsBundleDialog_ReviewBeforeSharing.Message" xml:space="preserve">
+    <value>Les jetons sensibles, les arguments de commande, les charges utiles et les enregistrements sont exclus par le générateur de lot.</value>
+  </data>
+  <data name="HubWindow_Disconnected.Text" xml:space="preserve">
+    <value>Déconnecté</value>
+  </data>
+  <data name="HubWindow_Op.Text" xml:space="preserve">
+    <value>Op.</value>
+  </data>
+  <data name="HubWindow_Node.Text" xml:space="preserve">
+    <value>Nœud</value>
+  </data>
+  <data name="HubWindow_Advanced.Content" xml:space="preserve">
+    <value>Avancé</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -3508,4 +3508,919 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="ConnectionStatusWindow.Title" xml:space="preserve">
     <value>Connection Status</value>
   </data>
+  <data name="BindingsPage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>Gateway losgekoppeld</value>
+  </data>
+  <data name="BindingsPage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>Maak verbinding met een gateway om bindingen te laden.</value>
+  </data>
+  <data name="BindingsPage_OpenConnection.Content" xml:space="preserve">
+    <value>Verbinding openen</value>
+  </data>
+  <data name="BindingsPage_LoadingBindings.Text" xml:space="preserve">
+    <value>Bindingen worden geladen…</value>
+  </data>
+  <data name="ConnectionPage_ApprovalsWaitingOnYou.Text" xml:space="preserve">
+    <value>Goedkeuringen wachten op u</value>
+  </data>
+  <data name="ConnectionPage_NotConnected.Text" xml:space="preserve">
+    <value>Niet verbonden</value>
+  </data>
+  <data name="ConnectionPage_Connect.Content" xml:space="preserve">
+    <value>Verbinden</value>
+  </data>
+  <data name="ConnectionPage_Operator.Text" xml:space="preserve">
+    <value>Bediener</value>
+  </data>
+  <data name="ConnectionPage_SendCommandsAndView.Text" xml:space="preserve">
+    <value>Stuur opdrachten en bekijk sessies op deze gateway vanaf deze pc.</value>
+  </data>
+  <data name="ConnectionPage_Inactive.Text" xml:space="preserve">
+    <value>Inactief</value>
+  </data>
+  <data name="ConnectionPage_SeeSessions.Content" xml:space="preserve">
+    <value>Sessies bekijken ›</value>
+  </data>
+  <data name="ConnectionPage_SeeInstances.Content" xml:space="preserve">
+    <value>Instanties bekijken ›</value>
+  </data>
+  <data name="ConnectionPage_NodeMode.Text" xml:space="preserve">
+    <value>Nodemodus</value>
+  </data>
+  <data name="ConnectionPage_WhenOnThisPC.Text" xml:space="preserve">
+    <value>Wanneer ingeschakeld, registreert deze pc zich als node en biedt onderstaande mogelijkheden aan agents via de gateway.</value>
+  </data>
+  <data name="ConnectionPage_NodeModeDisabled.Text" xml:space="preserve">
+    <value>Nodemodus uitgeschakeld</value>
+  </data>
+  <data name="ConnectionPage_Copy.Content" xml:space="preserve">
+    <value>Kopiëren</value>
+  </data>
+  <data name="ConnectionPage_Connect2.Content" xml:space="preserve">
+    <value>Verbinden</value>
+  </data>
+  <data name="ConnectionPage_ManagePermissions.Content" xml:space="preserve">
+    <value>Machtigingen beheren ›</value>
+  </data>
+  <data name="ConnectionPage_HelpUsFixThis.Text" xml:space="preserve">
+    <value>Help ons deze verbinding te herstellen:</value>
+  </data>
+  <data name="ConnectionPage_SSHTunnelIsDown.Text" xml:space="preserve">
+    <value>SSH-tunnel is uitgevallen.</value>
+  </data>
+  <data name="ConnectionPage_RestartTunnel.Content" xml:space="preserve">
+    <value>Tunnel opnieuw starten</value>
+  </data>
+  <data name="ConnectionPage_EditTunnelSettings.Content" xml:space="preserve">
+    <value>Tunnelinstellingen bewerken</value>
+  </data>
+  <data name="ConnectionPage_PasteANewSetup.Text" xml:space="preserve">
+    <value>Plak een nieuwe installatiecode van de gatewayhost.</value>
+  </data>
+  <data name="ConnectionPage_PasteSetupCodeHere.PlaceholderText" xml:space="preserve">
+    <value>Plak hier de installatiecode…</value>
+  </data>
+  <data name="ConnectionPage_Apply.Content" xml:space="preserve">
+    <value>Toepassen</value>
+  </data>
+  <data name="ConnectionPage_RunOnTheGateway.Text" xml:space="preserve">
+    <value>Uitvoeren op de gatewayhost:</value>
+  </data>
+  <data name="ConnectionPage_Copy2.Content" xml:space="preserve">
+    <value>Kopiëren</value>
+  </data>
+  <data name="ConnectionPage_Connect3.Content" xml:space="preserve">
+    <value>Verbinden</value>
+  </data>
+  <data name="ConnectionPage_Disconnect.Content" xml:space="preserve">
+    <value>Verbreken</value>
+  </data>
+  <data name="ConnectionPage_SavedGateways.Text" xml:space="preserve">
+    <value>Opgeslagen gateways</value>
+  </data>
+  <data name="ConnectionPage_Gateways.Text" xml:space="preserve">
+    <value>Gatewaylijst</value>
+  </data>
+  <data name="ConnectionPage_Scan.Text" xml:space="preserve">
+    <value>Scannen</value>
+  </data>
+  <data name="ConnectionPage_AddGateway.Text" xml:space="preserve">
+    <value>Gateway toevoegen</value>
+  </data>
+  <data name="ConnectionPage_NoSavedGatewaysYet.Text" xml:space="preserve">
+    <value>Nog geen opgeslagen gateways.</value>
+  </data>
+  <data name="ConnectionPage_DiscoveredOnYourNetwork.Text" xml:space="preserve">
+    <value>Ontdekt op uw netwerk</value>
+  </data>
+  <data name="ConnectionPage_AddAGateway.Text" xml:space="preserve">
+    <value>Een gateway toevoegen</value>
+  </data>
+  <data name="ConnectionPage_GetStartedInstallA.Title" xml:space="preserve">
+    <value>Aan de slag — installeer een lokale gateway</value>
+  </data>
+  <data name="ConnectionPage_GetStartedInstallA.Message" xml:space="preserve">
+    <value>De snelste manier om te starten: stelt een WSL-gehoste gateway in op deze pc en maakt deze de actieve verbinding.</value>
+  </data>
+  <data name="ConnectionPage_Install.Content" xml:space="preserve">
+    <value>Installeren</value>
+  </data>
+  <data name="ConnectionPage_OrConnectToAn.Text" xml:space="preserve">
+    <value>Of maak verbinding met een bestaande:</value>
+  </data>
+  <data name="ConnectionPage_Direct.Text" xml:space="preserve">
+    <value>Rechtstreeks</value>
+  </data>
+  <data name="ConnectionPage_URLToken.Text" xml:space="preserve">
+    <value>URL en token</value>
+  </data>
+  <data name="ConnectionPage_SetupCode.Text" xml:space="preserve">
+    <value>Installatiecode</value>
+  </data>
+  <data name="ConnectionPage_PasteQRPayload.Text" xml:space="preserve">
+    <value>QR-payload plakken</value>
+  </data>
+  <data name="ConnectionPage_EachMethodSupportsAn.Text" xml:space="preserve">
+    <value>Elke methode ondersteunt een optionele SSH-tunnel.</value>
+  </data>
+  <data name="ConnectionPage_OrLookForOne.Text" xml:space="preserve">
+    <value>Of zoek er een op uw netwerk.</value>
+  </data>
+  <data name="ConnectionPage_Scan2.Text" xml:space="preserve">
+    <value>Scannen</value>
+  </data>
+  <data name="ConnectionPage_DiscoveredOnYourNetwork2.Text" xml:space="preserve">
+    <value>Ontdekt op uw netwerk</value>
+  </data>
+  <data name="ConnectionPage_Back.Text" xml:space="preserve">
+    <value>Terug</value>
+  </data>
+  <data name="ConnectionPage_AddAGateway2.Text" xml:space="preserve">
+    <value>Een gateway toevoegen</value>
+  </data>
+  <data name="ConnectionPage_Direct2.Text" xml:space="preserve">
+    <value>Rechtstreeks</value>
+  </data>
+  <data name="ConnectionPage_SetupCode2.Text" xml:space="preserve">
+    <value>Installatiecode</value>
+  </data>
+  <data name="ConnectionPage_LocalWSL.Text" xml:space="preserve">
+    <value>Lokale WSL</value>
+  </data>
+  <data name="ConnectionPage_GatewayURL.Header" xml:space="preserve">
+    <value>Gateway-URL</value>
+  </data>
+  <data name="ConnectionPage_GatewayURL.PlaceholderText" xml:space="preserve">
+    <value>ws://host.local:18790</value>
+  </data>
+  <data name="ConnectionPage_SharedToken.Header" xml:space="preserve">
+    <value>Gedeelde token</value>
+  </data>
+  <data name="ConnectionPage_SharedToken.PlaceholderText" xml:space="preserve">
+    <value>Plak gedeelde gatewaytoken</value>
+  </data>
+  <data name="ConnectionPage_NameOptional.Header" xml:space="preserve">
+    <value>Naam (optioneel)</value>
+  </data>
+  <data name="ConnectionPage_NameOptional.PlaceholderText" xml:space="preserve">
+    <value>Mijn gateway</value>
+  </data>
+  <data name="ConnectionPage_PasteASetupCode.Text" xml:space="preserve">
+    <value>Plak een installatiecode van de QR van de gateway of de uitvoer van `openclaw qr`.</value>
+  </data>
+  <data name="ConnectionPage_PasteSetupCodeHere2.PlaceholderText" xml:space="preserve">
+    <value>Plak hier de installatiecode…</value>
+  </data>
+  <data name="ConnectionPage_Decode.Content" xml:space="preserve">
+    <value>Decoderen</value>
+  </data>
+  <data name="ConnectionPage_InstallANewWSL.Text" xml:space="preserve">
+    <value>Installeer een nieuwe WSL-gateway op deze pc en maak die de actieve verbinding. De installatiewizard installeert WSL indien nodig, richt de gateway in en koppelt dit apparaat automatisch.</value>
+  </data>
+  <data name="ConnectionPage_InstallLocalGateway.Content" xml:space="preserve">
+    <value>Lokale gateway installeren</value>
+  </data>
+  <data name="ConnectionPage_LocalWSLSetupIsn.Text" xml:space="preserve">
+    <value>Lokale WSL-installatie is op deze machine niet beschikbaar — de installatiewizard kon niet worden geïnitialiseerd.</value>
+  </data>
+  <data name="ConnectionPage_UseSSHTunnelOptional.Text" xml:space="preserve">
+    <value>SSH-tunnel gebruiken (optioneel)</value>
+  </data>
+  <data name="ConnectionPage_SSHUser.Header" xml:space="preserve">
+    <value>SSH-gebruiker</value>
+  </data>
+  <data name="ConnectionPage_SSHUser.PlaceholderText" xml:space="preserve">
+    <value>user</value>
+  </data>
+  <data name="ConnectionPage_SSHHost.Header" xml:space="preserve">
+    <value>SSH-host</value>
+  </data>
+  <data name="ConnectionPage_SSHHost.PlaceholderText" xml:space="preserve">
+    <value>machine-name</value>
+  </data>
+  <data name="ConnectionPage_RemotePort.Header" xml:space="preserve">
+    <value>Externe poort</value>
+  </data>
+  <data name="ConnectionPage_LocalPort.Header" xml:space="preserve">
+    <value>Lokale poort</value>
+  </data>
+  <data name="ConnectionPage_SaveAmpConnect.Content" xml:space="preserve">
+    <value>Opslaan &amp;amp; verbinden</value>
+  </data>
+  <data name="ConnectionPage_Cancel.Content" xml:space="preserve">
+    <value>Annuleren</value>
+  </data>
+  <data name="CronPage_CronJobs.Text" xml:space="preserve">
+    <value>⏱️ Cron-taken</value>
+  </data>
+  <data name="CronPage_Refresh.Text" xml:space="preserve">
+    <value>Vernieuwen</value>
+  </data>
+  <data name="CronPage_NewJob.Text" xml:space="preserve">
+    <value>Nieuwe taak</value>
+  </data>
+  <data name="CronPage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>Gateway losgekoppeld</value>
+  </data>
+  <data name="CronPage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>Maak verbinding met een gateway om cron-taken te laden.</value>
+  </data>
+  <data name="CronPage_OpenConnection.Content" xml:space="preserve">
+    <value>Verbinding openen</value>
+  </data>
+  <data name="CronPage_NewCronJob.Text" xml:space="preserve">
+    <value>Nieuwe Cron-taak</value>
+  </data>
+  <data name="CronPage_NAME.Text" xml:space="preserve">
+    <value>NAAM</value>
+  </data>
+  <data name="CronPage_MorningBrief.PlaceholderText" xml:space="preserve">
+    <value>Ochtendbriefing</value>
+  </data>
+  <data name="CronPage_SCHEDULE.Text" xml:space="preserve">
+    <value>PLANNING</value>
+  </data>
+  <data name="CronPage_Every.Content" xml:space="preserve">
+    <value>Elke</value>
+  </data>
+  <data name="CronPage_At.Content" xml:space="preserve">
+    <value>Om</value>
+  </data>
+  <data name="CronPage_Cron.Content" xml:space="preserve">
+    <value>Cron</value>
+  </data>
+  <data name="CronPage_QUICKPRESETS.Text" xml:space="preserve">
+    <value>SNELLE VOORINSTELLINGEN</value>
+  </data>
+  <data name="CronPage_Hourly.Content" xml:space="preserve">
+    <value>⏰ Elk uur</value>
+  </data>
+  <data name="CronPage_Daily9am.Content" xml:space="preserve">
+    <value>🌅 Dagelijks om 9.00 uur</value>
+  </data>
+  <data name="CronPage_Daily6pm.Content" xml:space="preserve">
+    <value>🌆 Dagelijks om 18.00 uur</value>
+  </data>
+  <data name="CronPage_Weekdays.Content" xml:space="preserve">
+    <value>💼 Weekdagen</value>
+  </data>
+  <data name="CronPage_Weekly.Content" xml:space="preserve">
+    <value>📅 Wekelijks</value>
+  </data>
+  <data name="CronPage_EXPRESSION.Text" xml:space="preserve">
+    <value>EXPRESSIE</value>
+  </data>
+  <data name="CronPage_TIMEZONE.Text" xml:space="preserve">
+    <value>TIJDZONE</value>
+  </data>
+  <data name="CronPage_Optional.PlaceholderText" xml:space="preserve">
+    <value>Optioneel</value>
+  </data>
+  <data name="CronPage_AmericaNewYork.Content" xml:space="preserve">
+    <value>America/New_York</value>
+  </data>
+  <data name="CronPage_AmericaChicago.Content" xml:space="preserve">
+    <value>America/Chicago</value>
+  </data>
+  <data name="CronPage_AmericaDenver.Content" xml:space="preserve">
+    <value>America/Denver</value>
+  </data>
+  <data name="CronPage_AmericaLosAngeles.Content" xml:space="preserve">
+    <value>America/Los_Angeles</value>
+  </data>
+  <data name="CronPage_EuropeLondon.Content" xml:space="preserve">
+    <value>Europe/London</value>
+  </data>
+  <data name="CronPage_EuropeBerlin.Content" xml:space="preserve">
+    <value>Europe/Berlin</value>
+  </data>
+  <data name="CronPage_AsiaTokyo.Content" xml:space="preserve">
+    <value>Asia/Tokyo</value>
+  </data>
+  <data name="CronPage_UTC.Content" xml:space="preserve">
+    <value>UTC</value>
+  </data>
+  <data name="CronPage_EVERY.Text" xml:space="preserve">
+    <value>ELKE</value>
+  </data>
+  <data name="CronPage_UNIT.Text" xml:space="preserve">
+    <value>EENHEID</value>
+  </data>
+  <data name="CronPage_Minutes.Content" xml:space="preserve">
+    <value>Minuten</value>
+  </data>
+  <data name="CronPage_Hours.Content" xml:space="preserve">
+    <value>Uren</value>
+  </data>
+  <data name="CronPage_Days.Content" xml:space="preserve">
+    <value>Dagen</value>
+  </data>
+  <data name="CronPage_RUNAT.Text" xml:space="preserve">
+    <value>UITVOEREN OM</value>
+  </data>
+  <data name="CronPage_Date.PlaceholderText" xml:space="preserve">
+    <value>Datum</value>
+  </data>
+  <data name="CronPage_330PM.PlaceholderText" xml:space="preserve">
+    <value>15:30</value>
+  </data>
+  <data name="CronPage_DeleteJobAfterIt.Content" xml:space="preserve">
+    <value>Taak verwijderen nadat deze is uitgevoerd</value>
+  </data>
+  <data name="CronPage_PROMPTPAYLOAD.Text" xml:space="preserve">
+    <value>INVOER / PAYLOAD</value>
+  </data>
+  <data name="CronPage_WhatShouldTheAgent.PlaceholderText" xml:space="preserve">
+    <value>Wat moet de agent doen?</value>
+  </data>
+  <data name="CronPage_DELIVERY.Text" xml:space="preserve">
+    <value>LEVERING</value>
+  </data>
+  <data name="CronPage_SilentNone.Content" xml:space="preserve">
+    <value>Stil (geen)</value>
+  </data>
+  <data name="CronPage_NotifyMeAnnounce.Content" xml:space="preserve">
+    <value>Stuur mij een melding (aankondigen)</value>
+  </data>
+  <data name="CronPage_CHANNEL.Text" xml:space="preserve">
+    <value>KANAAL</value>
+  </data>
+  <data name="CronPage_EGWebchat.PlaceholderText" xml:space="preserve">
+    <value>bijv. webchat</value>
+  </data>
+  <data name="CronPage_AdvancedOptions.Text" xml:space="preserve">
+    <value>Geavanceerde opties</value>
+  </data>
+  <data name="CronPage_SESSIONBEHAVIOR.Text" xml:space="preserve">
+    <value>SESSIEGEDRAG</value>
+  </data>
+  <data name="CronPage_NewSessionEachRun.Content" xml:space="preserve">
+    <value>Nieuwe sessie bij elke uitvoering</value>
+  </data>
+  <data name="CronPage_ResumeMainSession.Content" xml:space="preserve">
+    <value>Hoofdsessie hervatten</value>
+  </data>
+  <data name="CronPage_WAKEMODE.Text" xml:space="preserve">
+    <value>WAKMODUS</value>
+  </data>
+  <data name="CronPage_NowImmediate.Content" xml:space="preserve">
+    <value>Nu (onmiddellijk)</value>
+  </data>
+  <data name="CronPage_QueueWaitForIdle.Content" xml:space="preserve">
+    <value>Wachtrij (wachten op inactiviteit)</value>
+  </data>
+  <data name="CronPage_Cancel.Content" xml:space="preserve">
+    <value>Annuleren</value>
+  </data>
+  <data name="CronPage_CreateJob.Content" xml:space="preserve">
+    <value>Taak maken</value>
+  </data>
+  <data name="CronPage_LoadingCronJobs.Text" xml:space="preserve">
+    <value>Cron-taken worden geladen…</value>
+  </data>
+  <data name="CronPage_NoCronJobsConfigured.Text" xml:space="preserve">
+    <value>Geen cron-taken geconfigureerd</value>
+  </data>
+  <data name="CronPage_CronJobsWillAppear.Text" xml:space="preserve">
+    <value>Cron-taken verschijnen hier zodra ze via de gateway zijn geconfigureerd.</value>
+  </data>
+  <data name="DebugPage_Status.Title" xml:space="preserve">
+    <value>Toestand</value>
+  </data>
+  <data name="DebugPage_Copied.Title" xml:space="preserve">
+    <value>Gekopieerd</value>
+  </data>
+  <data name="DebugPage_NoOverride.Content" xml:space="preserve">
+    <value>Geen overschrijving</value>
+  </data>
+  <data name="DebugPage_ForceGatewayChatUI.Content" xml:space="preserve">
+    <value>Forceer chat-UI van gateway</value>
+  </data>
+  <data name="DebugPage_ForceCompanionChatUI.Content" xml:space="preserve">
+    <value>Forceer chat-UI van companion</value>
+  </data>
+  <data name="DebugPage_NoOverride2.Content" xml:space="preserve">
+    <value>Geen overschrijving</value>
+  </data>
+  <data name="DebugPage_ForceGatewayChatUI2.Content" xml:space="preserve">
+    <value>Forceer chat-UI van gateway</value>
+  </data>
+  <data name="DebugPage_ForceCompanionChatUI2.Content" xml:space="preserve">
+    <value>Forceer chat-UI van companion</value>
+  </data>
+  <data name="DebugPage_Refresh.Text" xml:space="preserve">
+    <value>Vernieuwen</value>
+  </data>
+  <data name="DebugPage_Copy.Text" xml:space="preserve">
+    <value>Kopiëren</value>
+  </data>
+  <data name="DebugPage_OpenFile.Text" xml:space="preserve">
+    <value>Bestand openen</value>
+  </data>
+  <data name="InstancesPage_PairingApprovalRequired.Text" xml:space="preserve">
+    <value>Goedkeuring voor koppelen vereist</value>
+  </data>
+  <data name="InstancesPage_ANodeHasConnected.Text" xml:space="preserve">
+    <value>Een node heeft verbinding gemaakt, maar zijn mogelijkheden worden pas geactiveerd nadat u het koppelverzoek hebt goedgekeurd.</value>
+  </data>
+  <data name="InstancesPage_ReviewOnConnectionPage.Content" xml:space="preserve">
+    <value>Bekijken op pagina Verbinding</value>
+  </data>
+  <data name="PermissionsPage_BackToConnection.Text" xml:space="preserve">
+    <value>Terug naar verbinding</value>
+  </data>
+  <data name="PermissionsPage_Permissions.Text" xml:space="preserve">
+    <value>Machtigingen</value>
+  </data>
+  <data name="PermissionsPage_NodeMode.Text" xml:space="preserve">
+    <value>Nodemodus</value>
+  </data>
+  <data name="PermissionsPage_WhenOnThisPC.Text" xml:space="preserve">
+    <value>Wanneer ingeschakeld, registreert deze pc zich als node en biedt onderstaande mogelijkheden aan agents via de gateway.</value>
+  </data>
+  <data name="PermissionsPage_Capabilities.Text" xml:space="preserve">
+    <value>Mogelijkheden</value>
+  </data>
+  <data name="PermissionsPage_ToggleIndividualFeaturesThat.Text" xml:space="preserve">
+    <value>Schakel afzonderlijke functies in of uit die agents van deze pc kunnen vragen.</value>
+  </data>
+  <data name="PermissionsPage_Integrations.Text" xml:space="preserve">
+    <value>Integraties</value>
+  </data>
+  <data name="PermissionsPage_DefaultAction.Text" xml:space="preserve">
+    <value>Standaardactie</value>
+  </data>
+  <data name="PermissionsPage_WhatHappensWhenA.Text" xml:space="preserve">
+    <value>Wat gebeurt er als een opdracht aan geen enkele regel hieronder voldoet.</value>
+  </data>
+  <data name="PermissionsPage_PatternsAreMatchedLeft.Text" xml:space="preserve">
+    <value>Patronen worden van links naar rechts vergeleken met de volledige opdrachtregel. Gebruik * als jokerteken. Wijzigingen worden automatisch opgeslagen.</value>
+  </data>
+  <data name="PermissionsPage_Saved.Text" xml:space="preserve">
+    <value>Opgeslagen</value>
+  </data>
+  <data name="PermissionsPage_0Rules.Text" xml:space="preserve">
+    <value>0 regels</value>
+  </data>
+  <data name="PermissionsPage_NoRulesYetAdd.Text" xml:space="preserve">
+    <value>Nog geen regels. Voeg hieronder een patroon toe om specifieke opdrachten toe te staan of te weigeren.</value>
+  </data>
+  <data name="PermissionsPage_WindowsPrivacy.Text" xml:space="preserve">
+    <value>Windows-privacy</value>
+  </data>
+  <data name="PermissionsPage_CameraMicrophoneAmpScreen.Text" xml:space="preserve">
+    <value>Toegang tot camera, microfoon &amp;amp; scherm</value>
+  </data>
+  <data name="PermissionsPage_SystemLevelPrivacyPermissions.Text" xml:space="preserve">
+    <value>Privacymachtigingen op systeemniveau worden beheerd door Windows. Open Windows-privacyinstellingen om OpenClaw toegang te verlenen of in te trekken.</value>
+  </data>
+  <data name="SandboxPage_NodeSandboxIsOn.Text" xml:space="preserve">
+    <value>Node-sandbox is ingeschakeld</value>
+  </data>
+  <data name="SandboxPage_ProgramsTheAgentRuns.Text" xml:space="preserve">
+    <value>Programma's die de agent op deze pc uitvoert zijn ingesloten.</value>
+  </data>
+  <data name="SandboxPage_WhatGetsContained.Text" xml:space="preserve">
+    <value>Wat er wordt ingesloten</value>
+  </data>
+  <data name="SandboxPage_SeeWhichCommandsThis.Text" xml:space="preserve">
+    <value>Bekijk welke opdrachten deze pagina dekt — en welke andere besturingselementen nodig hebben.</value>
+  </data>
+  <data name="SandboxPage_CommandsTheAgentRuns.Text" xml:space="preserve">
+    <value>Opdrachten die de agent via de Windows-node uitvoert (</value>
+  </data>
+  <data name="SandboxPage_SystemRun.Text" xml:space="preserve">
+    <value>system.run</value>
+  </data>
+  <data name="SandboxPage_AreContainedByThe.Text" xml:space="preserve">
+    <value>) worden ingesloten door onderstaande instellingen.</value>
+  </data>
+  <data name="SandboxPage_CommandsTheAgentRuns2.Text" xml:space="preserve">
+    <value>Opdrachten die de agent rechtstreeks op de gateway uitvoert niet. Als de gateway op WSL op deze pc draait, kunnen ze uw Windows-bestanden, klembord en netwerk bereiken — gebruik de exec-goedkeuringen van de gateway.</value>
+  </data>
+  <data name="SandboxPage_SandboxUnavailable.Title" xml:space="preserve">
+    <value>Sandbox niet beschikbaar</value>
+  </data>
+  <data name="SandboxPage_LearnMoreAboutMXC.Content" xml:space="preserve">
+    <value>Meer informatie over MXC-sandboxing</value>
+  </data>
+  <data name="SandboxPage_SecurityLevel.Text" xml:space="preserve">
+    <value>Beveiligingsniveau</value>
+  </data>
+  <data name="SandboxPage_OneClickToSet.Text" xml:space="preserve">
+    <value>Eén klik om alle besturingselementen hieronder in te stellen. Aangepaste mappen blijven zoals u ze hebt ingesteld.</value>
+  </data>
+  <data name="SandboxPage_LockedDown.Text" xml:space="preserve">
+    <value>🔒 Vergrendeld</value>
+  </data>
+  <data name="SandboxPage_NoInternetNoClipboard.Text" xml:space="preserve">
+    <value>Geen internet, geen klembord, geen standaard gebruikersmappen.</value>
+  </data>
+  <data name="SandboxPage_Recommended.Text" xml:space="preserve">
+    <value>🛡 Aanbevolen</value>
+  </data>
+  <data name="SandboxPage_InternetOnReadOnly.Text" xml:space="preserve">
+    <value>Internet aan. Alleen-lezen op Documenten, Downloads, Bureaublad. Klembord lezen.</value>
+  </data>
+  <data name="SandboxPage_Unprotected.Text" xml:space="preserve">
+    <value>⚠ Onbeschermd</value>
+  </data>
+  <data name="SandboxPage_InternetOnReadWrite.Text" xml:space="preserve">
+    <value>Internet aan. Lezen + schrijven op Documenten, Downloads, Bureaublad. Klembord lezen + schrijven.</value>
+  </data>
+  <data name="SandboxPage_CustomFolderGrantsStill.Title" xml:space="preserve">
+    <value>Aangepaste mapmachtigingen nog steeds actief</value>
+  </data>
+  <data name="SandboxPage_Files.Text" xml:space="preserve">
+    <value>📁 Bestanden</value>
+  </data>
+  <data name="SandboxPage_ByDefaultTheAgent.Text" xml:space="preserve">
+    <value>Standaard heeft de agent alleen een tijdelijke werkmap die hij kan lezen en schrijven. Geef hieronder toegang tot gebruikersmappen. SSH-sleutels, browserprofielen en OpenClaw's eigen instellingen worden altijd geblokkeerd.</value>
+  </data>
+  <data name="SandboxPage_Documents.Text" xml:space="preserve">
+    <value>Documenten</value>
+  </data>
+  <data name="SandboxPage_Blocked.Content" xml:space="preserve">
+    <value>Geblokkeerd</value>
+  </data>
+  <data name="SandboxPage_ReadOnly.Content" xml:space="preserve">
+    <value>Alleen-lezen</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite.Content" xml:space="preserve">
+    <value>Lezen &amp;amp; schrijven</value>
+  </data>
+  <data name="SandboxPage_Downloads.Text" xml:space="preserve">
+    <value>Downloadmap</value>
+  </data>
+  <data name="SandboxPage_Blocked2.Content" xml:space="preserve">
+    <value>Geblokkeerd</value>
+  </data>
+  <data name="SandboxPage_ReadOnly2.Content" xml:space="preserve">
+    <value>Alleen-lezen</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite2.Content" xml:space="preserve">
+    <value>Lezen &amp;amp; schrijven</value>
+  </data>
+  <data name="SandboxPage_Desktop.Text" xml:space="preserve">
+    <value>Bureaublad</value>
+  </data>
+  <data name="SandboxPage_Blocked3.Content" xml:space="preserve">
+    <value>Geblokkeerd</value>
+  </data>
+  <data name="SandboxPage_ReadOnly3.Content" xml:space="preserve">
+    <value>Alleen-lezen</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite3.Content" xml:space="preserve">
+    <value>Lezen &amp;amp; schrijven</value>
+  </data>
+  <data name="SandboxPage_ToolDirectoriesOnYour.Text" xml:space="preserve">
+    <value>Mapdirectory's op uw PATH krijgen ook alleen-lezen toegang binnen de sandbox, zodat opdrachtregelhulpprogramma's zoals git, node, python en dotnet bruikbaar zijn. Stationswortels worden nooit toegekend.</value>
+  </data>
+  <data name="SandboxPage_CustomFolders.Text" xml:space="preserve">
+    <value>Aangepaste mappen</value>
+  </data>
+  <data name="SandboxPage_CustomGrantsAreAdded.Text" xml:space="preserve">
+    <value>Aangepaste machtigingen worden toegevoegd bovenop de regels hierboven. Een map binnen Documenten/Downloads/Bureaublad toevoegen met bredere toegang overschrijft de rij-instelling voor dat pad.</value>
+  </data>
+  <data name="SandboxPage_Blocked4.Content" xml:space="preserve">
+    <value>Geblokkeerd</value>
+  </data>
+  <data name="SandboxPage_ReadOnly4.Content" xml:space="preserve">
+    <value>Alleen-lezen</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite4.Content" xml:space="preserve">
+    <value>Lezen &amp;amp; schrijven</value>
+  </data>
+  <data name="SandboxPage_NoCustomFoldersAdded.Text" xml:space="preserve">
+    <value>Geen aangepaste mappen toegevoegd.</value>
+  </data>
+  <data name="SandboxPage_AddFolder.Content" xml:space="preserve">
+    <value>Map toevoegen</value>
+  </data>
+  <data name="SandboxPage_Clipboard.Text" xml:space="preserve">
+    <value>📋 Klembord</value>
+  </data>
+  <data name="SandboxPage_ClipboardOftenContainsPasswords.Text" xml:space="preserve">
+    <value>Het klembord bevat vaak wachtwoorden, tokens en privétekst. Leestoegang kan deze lekken naar de agent (en via internet, indien ingeschakeld).</value>
+  </data>
+  <data name="SandboxPage_NoneDefault.Content" xml:space="preserve">
+    <value>Geen (standaard)</value>
+  </data>
+  <data name="SandboxPage_ReadAgentCanSee.Content" xml:space="preserve">
+    <value>Lezen — agent kan zien wat u hebt gekopieerd</value>
+  </data>
+  <data name="SandboxPage_WriteAgentCanReplace.Content" xml:space="preserve">
+    <value>Schrijven — agent kan uw klembord vervangen (kan het niet lezen)</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite5.Content" xml:space="preserve">
+    <value>Lezen &amp;amp; schrijven</value>
+  </data>
+  <data name="SandboxPage_Network.Text" xml:space="preserve">
+    <value>📡 Netwerk</value>
+  </data>
+  <data name="SandboxPage_AllowInternet.Header" xml:space="preserve">
+    <value>Internet toestaan</value>
+  </data>
+  <data name="SandboxPage_IfFileOrClipboard.Text" xml:space="preserve">
+    <value>Als bestand- of klembordleestoegang is ingeschakeld, kan de agent die gegevens via internet verzenden.</value>
+  </data>
+  <data name="SandboxPage_LocalNetworkDevicesAnd.Text" xml:space="preserve">
+    <value>Lokale netwerkapparaten en gedeelde mappen zijn nog niet inbegrepen.</value>
+  </data>
+  <data name="SandboxPage_Limits.Text" xml:space="preserve">
+    <value>⏱ Limieten</value>
+  </data>
+  <data name="SandboxPage_CommandTimeout30Sec.Text" xml:space="preserve">
+    <value>Time-out van opdracht: 30 sec</value>
+  </data>
+  <data name="SandboxPage_MaximumCapturedOutputTruncates.Text" xml:space="preserve">
+    <value>Maximaal vastgelegde uitvoer (afgekapt boven deze grens; beperkt geen schijf, geheugen of CPU):</value>
+  </data>
+  <data name="SandboxPage_1MiB.Content" xml:space="preserve">
+    <value>1 MiB</value>
+  </data>
+  <data name="SandboxPage_4MiBDefault.Content" xml:space="preserve">
+    <value>4 MiB (standaard)</value>
+  </data>
+  <data name="SandboxPage_16MiB.Content" xml:space="preserve">
+    <value>16 MiB</value>
+  </data>
+  <data name="SandboxPage_64MiB.Content" xml:space="preserve">
+    <value>64 MiB</value>
+  </data>
+  <data name="SessionsPage_BackToConnection.Text" xml:space="preserve">
+    <value>Terug naar verbinding</value>
+  </data>
+  <data name="SessionsPage_Sessions.Text" xml:space="preserve">
+    <value>Sessies</value>
+  </data>
+  <data name="SessionsPage_Refresh.Text" xml:space="preserve">
+    <value>Vernieuwen</value>
+  </data>
+  <data name="SessionsPage_All.Text" xml:space="preserve">
+    <value>Alle</value>
+  </data>
+  <data name="SessionsPage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>Gateway losgekoppeld</value>
+  </data>
+  <data name="SessionsPage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>Maak verbinding met een gateway om sessies te laden.</value>
+  </data>
+  <data name="SessionsPage_OpenConnection.Content" xml:space="preserve">
+    <value>Verbinding openen</value>
+  </data>
+  <data name="SessionsPage_LoadingSessions.Text" xml:space="preserve">
+    <value>Sessies worden geladen…</value>
+  </data>
+  <data name="SessionsPage_NoActiveSessions.Text" xml:space="preserve">
+    <value>Geen actieve sessies</value>
+  </data>
+  <data name="SessionsPage_Reset.Content" xml:space="preserve">
+    <value>Resetten</value>
+  </data>
+  <data name="SessionsPage_Compact.Content" xml:space="preserve">
+    <value>Compact maken</value>
+  </data>
+  <data name="SessionsPage_Delete.Content" xml:space="preserve">
+    <value>Verwijderen</value>
+  </data>
+  <data name="SettingsPage_Settings.Text" xml:space="preserve">
+    <value>Instellingen</value>
+  </data>
+  <data name="SettingsPage_General.Text" xml:space="preserve">
+    <value>Algemeen</value>
+  </data>
+  <data name="SettingsPage_Notifications.Text" xml:space="preserve">
+    <value>Meldingen</value>
+  </data>
+  <data name="SettingsPage_Privacy.Text" xml:space="preserve">
+    <value>Privacybeheer</value>
+  </data>
+  <data name="SettingsPage_LocalGateway.Text" xml:space="preserve">
+    <value>Lokale gateway</value>
+  </data>
+  <data name="SettingsPage_MSIXInstallationDetected.Title" xml:space="preserve">
+    <value>MSIX-installatie gedetecteerd</value>
+  </data>
+  <data name="SettingsPage_MSIXInstallationDetected.Message" xml:space="preserve">
+    <value>OpenClaw verwijderen via Windows Instellingen &amp;amp;#x2192; Apps zal de lokale gateway NIET opruimen (WSL-distributie, schijfafbeelding). Gebruik EERST Lokale gateway verwijderen hieronder, en verwijder daarna OpenClaw.</value>
+  </data>
+  <data name="SettingsPage_RemovesTheWSLDistro.Text" xml:space="preserve">
+    <value>Verwijdert de WSL-distributie (OpenClawGateway), de schijfafbeelding, het item voor automatisch starten en wist de gateway-referenties. Uw MCP-token blijft behouden. Onboarding wordt gereset.</value>
+  </data>
+  <data name="SettingsPage_RemoveLocalGateway.Content" xml:space="preserve">
+    <value>Lokale gateway verwijderen</value>
+  </data>
+  <data name="SettingsPage_Saved.Title" xml:space="preserve">
+    <value>Opgeslagen</value>
+  </data>
+  <data name="SkillsPage_Skills.Text" xml:space="preserve">
+    <value>🧩 Vaardigheden</value>
+  </data>
+  <data name="SkillsPage_AllAgents.Content" xml:space="preserve">
+    <value>Alle agents</value>
+  </data>
+  <data name="SkillsPage_Enabled.Text" xml:space="preserve">
+    <value>Ingeschakeld</value>
+  </data>
+  <data name="SkillsPage_Disabled.Text" xml:space="preserve">
+    <value>Uitgeschakeld</value>
+  </data>
+  <data name="SkillsPage_LoadingSkills.Text" xml:space="preserve">
+    <value>Vaardigheden worden geladen…</value>
+  </data>
+  <data name="SkillsPage_NoSkillsInstalled.Text" xml:space="preserve">
+    <value>Geen vaardigheden geïnstalleerd</value>
+  </data>
+  <data name="SkillsPage_SkillsExtendYourAgent.Text" xml:space="preserve">
+    <value>Vaardigheden breiden de mogelijkheden van uw agent uit. Installeer vaardigheden via de CLI of ClawHub.</value>
+  </data>
+  <data name="UsagePage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>Gateway losgekoppeld</value>
+  </data>
+  <data name="UsagePage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>Maak verbinding met een gateway om gebruiksgegevens te laden.</value>
+  </data>
+  <data name="UsagePage_OpenConnection.Content" xml:space="preserve">
+    <value>Verbinding openen</value>
+  </data>
+  <data name="UsagePage_LoadingDailyCosts.Text" xml:space="preserve">
+    <value>Dagelijkse kosten worden geladen…</value>
+  </data>
+  <data name="UsagePage_NoDailyUsageFor.Text" xml:space="preserve">
+    <value>Geen dagelijks gebruik voor deze periode</value>
+  </data>
+  <data name="VoiceSettingsPage_TestVoiceInput.Text" xml:space="preserve">
+    <value>Spraakinvoer testen</value>
+  </data>
+  <data name="VoiceSettingsPage_Record.Text" xml:space="preserve">
+    <value>Opnemen</value>
+  </data>
+  <data name="WorkspacePage_LoadingWorkspaceFiles.Text" xml:space="preserve">
+    <value>Werkruimtebestanden worden geladen…</value>
+  </data>
+  <data name="ChatWindow_WebChatUnavailable.Text" xml:space="preserve">
+    <value>Web-chat niet beschikbaar</value>
+  </data>
+  <data name="ChatWindow_Retry.Content" xml:space="preserve">
+    <value>Opnieuw proberen</value>
+  </data>
+  <data name="ConnectionStatusWindow_ConnectionStatus.Text" xml:space="preserve">
+    <value>Verbindingsstatus</value>
+  </data>
+  <data name="ConnectionStatusWindow_STATEMACHINE.Text" xml:space="preserve">
+    <value>STATUSMACHINE</value>
+  </data>
+  <data name="ConnectionStatusWindow_OPERATOR.Text" xml:space="preserve">
+    <value>BEDIENER</value>
+  </data>
+  <data name="ConnectionStatusWindow_Off.Text" xml:space="preserve">
+    <value>Uit</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connecting.Text" xml:space="preserve">
+    <value>Verbinden</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connected.Text" xml:space="preserve">
+    <value>Verbonden</value>
+  </data>
+  <data name="ConnectionStatusWindow_Pairing.Text" xml:space="preserve">
+    <value>Koppelen</value>
+  </data>
+  <data name="ConnectionStatusWindow_Error.Text" xml:space="preserve">
+    <value>Fout</value>
+  </data>
+  <data name="ConnectionStatusWindow_NODE.Text" xml:space="preserve">
+    <value>KNOOPPUNT</value>
+  </data>
+  <data name="ConnectionStatusWindow_Off2.Text" xml:space="preserve">
+    <value>Uit</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connecting2.Text" xml:space="preserve">
+    <value>Verbinden</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connected2.Text" xml:space="preserve">
+    <value>Verbonden</value>
+  </data>
+  <data name="ConnectionStatusWindow_Pairing2.Text" xml:space="preserve">
+    <value>Koppelen</value>
+  </data>
+  <data name="ConnectionStatusWindow_Error2.Text" xml:space="preserve">
+    <value>Fout</value>
+  </data>
+  <data name="ConnectionStatusWindow_GATEWAYS.Text" xml:space="preserve">
+    <value>POORTEN</value>
+  </data>
+  <data name="ConnectionStatusWindow_CREDENTIALS.Text" xml:space="preserve">
+    <value>REFERENTIES</value>
+  </data>
+  <data name="ConnectionStatusWindow_SETUPCODE.Text" xml:space="preserve">
+    <value>INSTALLATIECODE</value>
+  </data>
+  <data name="ConnectionStatusWindow_PasteASetupCode.Text" xml:space="preserve">
+    <value>Plak een installatiecode om end-to-end verbinding te maken.</value>
+  </data>
+  <data name="ConnectionStatusWindow_PasteSetupCode.PlaceholderText" xml:space="preserve">
+    <value>Plak installatiecode…</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connect.Content" xml:space="preserve">
+    <value>Verbinden</value>
+  </data>
+  <data name="ConnectionStatusWindow_Disconnect.Content" xml:space="preserve">
+    <value>Verbreken</value>
+  </data>
+  <data name="ConnectionStatusWindow_DIRECTCONNECT.Text" xml:space="preserve">
+    <value>DIRECT VERBINDEN</value>
+  </data>
+  <data name="ConnectionStatusWindow_ConnectWithAGateway.Text" xml:space="preserve">
+    <value>Maak verbinding met een gateway-URL en gedeelde token (admin-scope).</value>
+  </data>
+  <data name="ConnectionStatusWindow_WsLocalhost18790.PlaceholderText" xml:space="preserve">
+    <value>ws://localhost:18790</value>
+  </data>
+  <data name="ConnectionStatusWindow_WsLocalhost18790.Text" xml:space="preserve">
+    <value>ws://localhost:18790</value>
+  </data>
+  <data name="ConnectionStatusWindow_WsLocalhost18790.Header" xml:space="preserve">
+    <value>Gateway-URL</value>
+  </data>
+  <data name="ConnectionStatusWindow_SharedGatewayToken.PlaceholderText" xml:space="preserve">
+    <value>Gedeelde gatewaytoken</value>
+  </data>
+  <data name="ConnectionStatusWindow_SharedGatewayToken.Header" xml:space="preserve">
+    <value>Sleutel</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connect2.Content" xml:space="preserve">
+    <value>Verbinden</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHTunnel.Header" xml:space="preserve">
+    <value>SSH-tunnel</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHUser.Header" xml:space="preserve">
+    <value>SSH-gebruiker</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHUser.PlaceholderText" xml:space="preserve">
+    <value>user</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHHost.Header" xml:space="preserve">
+    <value>SSH-host</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHHost.PlaceholderText" xml:space="preserve">
+    <value>192.168.x.x</value>
+  </data>
+  <data name="ConnectionStatusWindow_RemotePort.Header" xml:space="preserve">
+    <value>Externe poort</value>
+  </data>
+  <data name="ConnectionStatusWindow_LocalPort.Header" xml:space="preserve">
+    <value>Lokale poort</value>
+  </data>
+  <data name="ConnectionStatusWindow_EVENTTIMELINE.Text" xml:space="preserve">
+    <value>GEBEURTENISTIJDLIJN</value>
+  </data>
+  <data name="ConnectionStatusWindow_Copy.Content" xml:space="preserve">
+    <value>Kopiëren</value>
+  </data>
+  <data name="ConnectionStatusWindow_Clear.Content" xml:space="preserve">
+    <value>Wissen</value>
+  </data>
+  <data name="DiagnosticsBundleDialog_DiagnosticsBundle.Title" xml:space="preserve">
+    <value>Diagnostiekbundel</value>
+  </data>
+  <data name="DiagnosticsBundleDialog_ReviewBeforeSharing.Title" xml:space="preserve">
+    <value>Controleer voor het delen</value>
+  </data>
+  <data name="DiagnosticsBundleDialog_ReviewBeforeSharing.Message" xml:space="preserve">
+    <value>Gevoelige tokens, opdrachtargumenten, payloads en opnames worden door de bundelmaker uitgesloten.</value>
+  </data>
+  <data name="HubWindow_Disconnected.Text" xml:space="preserve">
+    <value>Niet verbonden</value>
+  </data>
+  <data name="HubWindow_Op.Text" xml:space="preserve">
+    <value>Op.</value>
+  </data>
+  <data name="HubWindow_Node.Text" xml:space="preserve">
+    <value>Knooppunt</value>
+  </data>
+  <data name="HubWindow_Advanced.Content" xml:space="preserve">
+    <value>Geavanceerd</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -3507,4 +3507,919 @@
   <data name="ConnectionStatusWindow.Title" xml:space="preserve">
     <value>Connection Status</value>
   </data>
+  <data name="BindingsPage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>网关已断开</value>
+  </data>
+  <data name="BindingsPage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>请连接到网关以加载绑定。</value>
+  </data>
+  <data name="BindingsPage_OpenConnection.Content" xml:space="preserve">
+    <value>打开连接</value>
+  </data>
+  <data name="BindingsPage_LoadingBindings.Text" xml:space="preserve">
+    <value>正在加载绑定…</value>
+  </data>
+  <data name="ConnectionPage_ApprovalsWaitingOnYou.Text" xml:space="preserve">
+    <value>等待您的审批</value>
+  </data>
+  <data name="ConnectionPage_NotConnected.Text" xml:space="preserve">
+    <value>未连接</value>
+  </data>
+  <data name="ConnectionPage_Connect.Content" xml:space="preserve">
+    <value>连接</value>
+  </data>
+  <data name="ConnectionPage_Operator.Text" xml:space="preserve">
+    <value>操作员</value>
+  </data>
+  <data name="ConnectionPage_SendCommandsAndView.Text" xml:space="preserve">
+    <value>从此电脑向此网关发送命令并查看会话。</value>
+  </data>
+  <data name="ConnectionPage_Inactive.Text" xml:space="preserve">
+    <value>未激活</value>
+  </data>
+  <data name="ConnectionPage_SeeSessions.Content" xml:space="preserve">
+    <value>查看会话 ›</value>
+  </data>
+  <data name="ConnectionPage_SeeInstances.Content" xml:space="preserve">
+    <value>查看实例 ›</value>
+  </data>
+  <data name="ConnectionPage_NodeMode.Text" xml:space="preserve">
+    <value>节点模式</value>
+  </data>
+  <data name="ConnectionPage_WhenOnThisPC.Text" xml:space="preserve">
+    <value>启用后,此电脑将注册为节点,并通过网关向代理提供下列功能。</value>
+  </data>
+  <data name="ConnectionPage_NodeModeDisabled.Text" xml:space="preserve">
+    <value>节点模式已禁用</value>
+  </data>
+  <data name="ConnectionPage_Copy.Content" xml:space="preserve">
+    <value>复制</value>
+  </data>
+  <data name="ConnectionPage_Connect2.Content" xml:space="preserve">
+    <value>连接</value>
+  </data>
+  <data name="ConnectionPage_ManagePermissions.Content" xml:space="preserve">
+    <value>管理权限 ›</value>
+  </data>
+  <data name="ConnectionPage_HelpUsFixThis.Text" xml:space="preserve">
+    <value>帮助我们修复此连接:</value>
+  </data>
+  <data name="ConnectionPage_SSHTunnelIsDown.Text" xml:space="preserve">
+    <value>SSH 隧道已停止。</value>
+  </data>
+  <data name="ConnectionPage_RestartTunnel.Content" xml:space="preserve">
+    <value>重启隧道</value>
+  </data>
+  <data name="ConnectionPage_EditTunnelSettings.Content" xml:space="preserve">
+    <value>编辑隧道设置</value>
+  </data>
+  <data name="ConnectionPage_PasteANewSetup.Text" xml:space="preserve">
+    <value>粘贴来自网关主机的新设置代码。</value>
+  </data>
+  <data name="ConnectionPage_PasteSetupCodeHere.PlaceholderText" xml:space="preserve">
+    <value>在此粘贴设置代码…</value>
+  </data>
+  <data name="ConnectionPage_Apply.Content" xml:space="preserve">
+    <value>应用</value>
+  </data>
+  <data name="ConnectionPage_RunOnTheGateway.Text" xml:space="preserve">
+    <value>在网关主机上运行:</value>
+  </data>
+  <data name="ConnectionPage_Copy2.Content" xml:space="preserve">
+    <value>复制</value>
+  </data>
+  <data name="ConnectionPage_Connect3.Content" xml:space="preserve">
+    <value>连接</value>
+  </data>
+  <data name="ConnectionPage_Disconnect.Content" xml:space="preserve">
+    <value>断开连接</value>
+  </data>
+  <data name="ConnectionPage_SavedGateways.Text" xml:space="preserve">
+    <value>已保存的网关</value>
+  </data>
+  <data name="ConnectionPage_Gateways.Text" xml:space="preserve">
+    <value>网关</value>
+  </data>
+  <data name="ConnectionPage_Scan.Text" xml:space="preserve">
+    <value>扫描</value>
+  </data>
+  <data name="ConnectionPage_AddGateway.Text" xml:space="preserve">
+    <value>添加网关</value>
+  </data>
+  <data name="ConnectionPage_NoSavedGatewaysYet.Text" xml:space="preserve">
+    <value>尚无已保存的网关。</value>
+  </data>
+  <data name="ConnectionPage_DiscoveredOnYourNetwork.Text" xml:space="preserve">
+    <value>在您的网络上发现</value>
+  </data>
+  <data name="ConnectionPage_AddAGateway.Text" xml:space="preserve">
+    <value>添加网关</value>
+  </data>
+  <data name="ConnectionPage_GetStartedInstallA.Title" xml:space="preserve">
+    <value>开始使用 — 安装本地网关</value>
+  </data>
+  <data name="ConnectionPage_GetStartedInstallA.Message" xml:space="preserve">
+    <value>最快的入门方式:在此电脑上设置 WSL 托管的网关,并将其设为活动连接。</value>
+  </data>
+  <data name="ConnectionPage_Install.Content" xml:space="preserve">
+    <value>安装</value>
+  </data>
+  <data name="ConnectionPage_OrConnectToAn.Text" xml:space="preserve">
+    <value>或连接到现有网关:</value>
+  </data>
+  <data name="ConnectionPage_Direct.Text" xml:space="preserve">
+    <value>直接</value>
+  </data>
+  <data name="ConnectionPage_URLToken.Text" xml:space="preserve">
+    <value>URL + 令牌</value>
+  </data>
+  <data name="ConnectionPage_SetupCode.Text" xml:space="preserve">
+    <value>设置代码</value>
+  </data>
+  <data name="ConnectionPage_PasteQRPayload.Text" xml:space="preserve">
+    <value>粘贴 QR 负载</value>
+  </data>
+  <data name="ConnectionPage_EachMethodSupportsAn.Text" xml:space="preserve">
+    <value>每种方法都支持可选的 SSH 隧道。</value>
+  </data>
+  <data name="ConnectionPage_OrLookForOne.Text" xml:space="preserve">
+    <value>或在您的网络上查找。</value>
+  </data>
+  <data name="ConnectionPage_Scan2.Text" xml:space="preserve">
+    <value>扫描</value>
+  </data>
+  <data name="ConnectionPage_DiscoveredOnYourNetwork2.Text" xml:space="preserve">
+    <value>在您的网络上发现</value>
+  </data>
+  <data name="ConnectionPage_Back.Text" xml:space="preserve">
+    <value>返回</value>
+  </data>
+  <data name="ConnectionPage_AddAGateway2.Text" xml:space="preserve">
+    <value>添加网关</value>
+  </data>
+  <data name="ConnectionPage_Direct2.Text" xml:space="preserve">
+    <value>直接</value>
+  </data>
+  <data name="ConnectionPage_SetupCode2.Text" xml:space="preserve">
+    <value>设置代码</value>
+  </data>
+  <data name="ConnectionPage_LocalWSL.Text" xml:space="preserve">
+    <value>本地 WSL</value>
+  </data>
+  <data name="ConnectionPage_GatewayURL.Header" xml:space="preserve">
+    <value>网关 URL</value>
+  </data>
+  <data name="ConnectionPage_GatewayURL.PlaceholderText" xml:space="preserve">
+    <value>ws://host.local:18790</value>
+  </data>
+  <data name="ConnectionPage_SharedToken.Header" xml:space="preserve">
+    <value>共享令牌</value>
+  </data>
+  <data name="ConnectionPage_SharedToken.PlaceholderText" xml:space="preserve">
+    <value>粘贴共享网关令牌</value>
+  </data>
+  <data name="ConnectionPage_NameOptional.Header" xml:space="preserve">
+    <value>名称(可选)</value>
+  </data>
+  <data name="ConnectionPage_NameOptional.PlaceholderText" xml:space="preserve">
+    <value>我的网关</value>
+  </data>
+  <data name="ConnectionPage_PasteASetupCode.Text" xml:space="preserve">
+    <value>粘贴来自网关的 QR 码或 `openclaw qr` 输出的设置代码。</value>
+  </data>
+  <data name="ConnectionPage_PasteSetupCodeHere2.PlaceholderText" xml:space="preserve">
+    <value>在此粘贴设置代码…</value>
+  </data>
+  <data name="ConnectionPage_Decode.Content" xml:space="preserve">
+    <value>解码</value>
+  </data>
+  <data name="ConnectionPage_InstallANewWSL.Text" xml:space="preserve">
+    <value>在此电脑上安装新的 WSL 网关,并将其设为活动连接。设置向导将在需要时安装 WSL、配置网关,并自动配对此设备。</value>
+  </data>
+  <data name="ConnectionPage_InstallLocalGateway.Content" xml:space="preserve">
+    <value>安装本地网关</value>
+  </data>
+  <data name="ConnectionPage_LocalWSLSetupIsn.Text" xml:space="preserve">
+    <value>此电脑无法进行本地 WSL 设置 — 安装向导无法初始化。</value>
+  </data>
+  <data name="ConnectionPage_UseSSHTunnelOptional.Text" xml:space="preserve">
+    <value>使用 SSH 隧道(可选)</value>
+  </data>
+  <data name="ConnectionPage_SSHUser.Header" xml:space="preserve">
+    <value>SSH 用户</value>
+  </data>
+  <data name="ConnectionPage_SSHUser.PlaceholderText" xml:space="preserve">
+    <value>user</value>
+  </data>
+  <data name="ConnectionPage_SSHHost.Header" xml:space="preserve">
+    <value>SSH 主机</value>
+  </data>
+  <data name="ConnectionPage_SSHHost.PlaceholderText" xml:space="preserve">
+    <value>machine-name</value>
+  </data>
+  <data name="ConnectionPage_RemotePort.Header" xml:space="preserve">
+    <value>远程端口</value>
+  </data>
+  <data name="ConnectionPage_LocalPort.Header" xml:space="preserve">
+    <value>本地端口</value>
+  </data>
+  <data name="ConnectionPage_SaveAmpConnect.Content" xml:space="preserve">
+    <value>保存并连接</value>
+  </data>
+  <data name="ConnectionPage_Cancel.Content" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="CronPage_CronJobs.Text" xml:space="preserve">
+    <value>⏱️ Cron 任务</value>
+  </data>
+  <data name="CronPage_Refresh.Text" xml:space="preserve">
+    <value>刷新</value>
+  </data>
+  <data name="CronPage_NewJob.Text" xml:space="preserve">
+    <value>新建任务</value>
+  </data>
+  <data name="CronPage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>网关已断开</value>
+  </data>
+  <data name="CronPage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>请连接到网关以加载 cron 任务。</value>
+  </data>
+  <data name="CronPage_OpenConnection.Content" xml:space="preserve">
+    <value>打开连接</value>
+  </data>
+  <data name="CronPage_NewCronJob.Text" xml:space="preserve">
+    <value>新建 Cron 任务</value>
+  </data>
+  <data name="CronPage_NAME.Text" xml:space="preserve">
+    <value>名称</value>
+  </data>
+  <data name="CronPage_MorningBrief.PlaceholderText" xml:space="preserve">
+    <value>晨间简报</value>
+  </data>
+  <data name="CronPage_SCHEDULE.Text" xml:space="preserve">
+    <value>计划</value>
+  </data>
+  <data name="CronPage_Every.Content" xml:space="preserve">
+    <value>每</value>
+  </data>
+  <data name="CronPage_At.Content" xml:space="preserve">
+    <value>于</value>
+  </data>
+  <data name="CronPage_Cron.Content" xml:space="preserve">
+    <value>Cron</value>
+  </data>
+  <data name="CronPage_QUICKPRESETS.Text" xml:space="preserve">
+    <value>快速预设</value>
+  </data>
+  <data name="CronPage_Hourly.Content" xml:space="preserve">
+    <value>⏰ 每小时</value>
+  </data>
+  <data name="CronPage_Daily9am.Content" xml:space="preserve">
+    <value>🌅 每天上午 9 点</value>
+  </data>
+  <data name="CronPage_Daily6pm.Content" xml:space="preserve">
+    <value>🌆 每天下午 6 点</value>
+  </data>
+  <data name="CronPage_Weekdays.Content" xml:space="preserve">
+    <value>💼 工作日</value>
+  </data>
+  <data name="CronPage_Weekly.Content" xml:space="preserve">
+    <value>📅 每周</value>
+  </data>
+  <data name="CronPage_EXPRESSION.Text" xml:space="preserve">
+    <value>表达式</value>
+  </data>
+  <data name="CronPage_TIMEZONE.Text" xml:space="preserve">
+    <value>时区</value>
+  </data>
+  <data name="CronPage_Optional.PlaceholderText" xml:space="preserve">
+    <value>可选</value>
+  </data>
+  <data name="CronPage_AmericaNewYork.Content" xml:space="preserve">
+    <value>America/New_York</value>
+  </data>
+  <data name="CronPage_AmericaChicago.Content" xml:space="preserve">
+    <value>America/Chicago</value>
+  </data>
+  <data name="CronPage_AmericaDenver.Content" xml:space="preserve">
+    <value>America/Denver</value>
+  </data>
+  <data name="CronPage_AmericaLosAngeles.Content" xml:space="preserve">
+    <value>America/Los_Angeles</value>
+  </data>
+  <data name="CronPage_EuropeLondon.Content" xml:space="preserve">
+    <value>Europe/London</value>
+  </data>
+  <data name="CronPage_EuropeBerlin.Content" xml:space="preserve">
+    <value>Europe/Berlin</value>
+  </data>
+  <data name="CronPage_AsiaTokyo.Content" xml:space="preserve">
+    <value>Asia/Tokyo</value>
+  </data>
+  <data name="CronPage_UTC.Content" xml:space="preserve">
+    <value>UTC</value>
+  </data>
+  <data name="CronPage_EVERY.Text" xml:space="preserve">
+    <value>每</value>
+  </data>
+  <data name="CronPage_UNIT.Text" xml:space="preserve">
+    <value>单位</value>
+  </data>
+  <data name="CronPage_Minutes.Content" xml:space="preserve">
+    <value>分钟</value>
+  </data>
+  <data name="CronPage_Hours.Content" xml:space="preserve">
+    <value>小时</value>
+  </data>
+  <data name="CronPage_Days.Content" xml:space="preserve">
+    <value>天</value>
+  </data>
+  <data name="CronPage_RUNAT.Text" xml:space="preserve">
+    <value>运行时间</value>
+  </data>
+  <data name="CronPage_Date.PlaceholderText" xml:space="preserve">
+    <value>日期</value>
+  </data>
+  <data name="CronPage_330PM.PlaceholderText" xml:space="preserve">
+    <value>15:30</value>
+  </data>
+  <data name="CronPage_DeleteJobAfterIt.Content" xml:space="preserve">
+    <value>运行后删除任务</value>
+  </data>
+  <data name="CronPage_PROMPTPAYLOAD.Text" xml:space="preserve">
+    <value>提示 / 负载</value>
+  </data>
+  <data name="CronPage_WhatShouldTheAgent.PlaceholderText" xml:space="preserve">
+    <value>代理应该做什么?</value>
+  </data>
+  <data name="CronPage_DELIVERY.Text" xml:space="preserve">
+    <value>投递</value>
+  </data>
+  <data name="CronPage_SilentNone.Content" xml:space="preserve">
+    <value>静默(无)</value>
+  </data>
+  <data name="CronPage_NotifyMeAnnounce.Content" xml:space="preserve">
+    <value>通知我(通告)</value>
+  </data>
+  <data name="CronPage_CHANNEL.Text" xml:space="preserve">
+    <value>通道</value>
+  </data>
+  <data name="CronPage_EGWebchat.PlaceholderText" xml:space="preserve">
+    <value>例如 webchat</value>
+  </data>
+  <data name="CronPage_AdvancedOptions.Text" xml:space="preserve">
+    <value>高级选项</value>
+  </data>
+  <data name="CronPage_SESSIONBEHAVIOR.Text" xml:space="preserve">
+    <value>会话行为</value>
+  </data>
+  <data name="CronPage_NewSessionEachRun.Content" xml:space="preserve">
+    <value>每次运行新建会话</value>
+  </data>
+  <data name="CronPage_ResumeMainSession.Content" xml:space="preserve">
+    <value>恢复主会话</value>
+  </data>
+  <data name="CronPage_WAKEMODE.Text" xml:space="preserve">
+    <value>唤醒模式</value>
+  </data>
+  <data name="CronPage_NowImmediate.Content" xml:space="preserve">
+    <value>立即(即时)</value>
+  </data>
+  <data name="CronPage_QueueWaitForIdle.Content" xml:space="preserve">
+    <value>排队(等待空闲)</value>
+  </data>
+  <data name="CronPage_Cancel.Content" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="CronPage_CreateJob.Content" xml:space="preserve">
+    <value>创建任务</value>
+  </data>
+  <data name="CronPage_LoadingCronJobs.Text" xml:space="preserve">
+    <value>正在加载 cron 任务…</value>
+  </data>
+  <data name="CronPage_NoCronJobsConfigured.Text" xml:space="preserve">
+    <value>未配置 cron 任务</value>
+  </data>
+  <data name="CronPage_CronJobsWillAppear.Text" xml:space="preserve">
+    <value>通过网关配置 cron 任务后,它们将显示在此处。</value>
+  </data>
+  <data name="DebugPage_Status.Title" xml:space="preserve">
+    <value>状态</value>
+  </data>
+  <data name="DebugPage_Copied.Title" xml:space="preserve">
+    <value>已复制</value>
+  </data>
+  <data name="DebugPage_NoOverride.Content" xml:space="preserve">
+    <value>无覆盖</value>
+  </data>
+  <data name="DebugPage_ForceGatewayChatUI.Content" xml:space="preserve">
+    <value>强制使用网关聊天界面</value>
+  </data>
+  <data name="DebugPage_ForceCompanionChatUI.Content" xml:space="preserve">
+    <value>强制使用伴侣聊天界面</value>
+  </data>
+  <data name="DebugPage_NoOverride2.Content" xml:space="preserve">
+    <value>无覆盖</value>
+  </data>
+  <data name="DebugPage_ForceGatewayChatUI2.Content" xml:space="preserve">
+    <value>强制使用网关聊天界面</value>
+  </data>
+  <data name="DebugPage_ForceCompanionChatUI2.Content" xml:space="preserve">
+    <value>强制使用伴侣聊天界面</value>
+  </data>
+  <data name="DebugPage_Refresh.Text" xml:space="preserve">
+    <value>刷新</value>
+  </data>
+  <data name="DebugPage_Copy.Text" xml:space="preserve">
+    <value>复制</value>
+  </data>
+  <data name="DebugPage_OpenFile.Text" xml:space="preserve">
+    <value>打开文件</value>
+  </data>
+  <data name="InstancesPage_PairingApprovalRequired.Text" xml:space="preserve">
+    <value>需要配对审批</value>
+  </data>
+  <data name="InstancesPage_ANodeHasConnected.Text" xml:space="preserve">
+    <value>节点已连接,但在您批准配对请求之前,其功能不会激活。</value>
+  </data>
+  <data name="InstancesPage_ReviewOnConnectionPage.Content" xml:space="preserve">
+    <value>在“连接”页面查看</value>
+  </data>
+  <data name="PermissionsPage_BackToConnection.Text" xml:space="preserve">
+    <value>返回连接</value>
+  </data>
+  <data name="PermissionsPage_Permissions.Text" xml:space="preserve">
+    <value>权限</value>
+  </data>
+  <data name="PermissionsPage_NodeMode.Text" xml:space="preserve">
+    <value>节点模式</value>
+  </data>
+  <data name="PermissionsPage_WhenOnThisPC.Text" xml:space="preserve">
+    <value>启用后,此电脑将注册为节点,并通过网关向代理提供下列功能。</value>
+  </data>
+  <data name="PermissionsPage_Capabilities.Text" xml:space="preserve">
+    <value>功能</value>
+  </data>
+  <data name="PermissionsPage_ToggleIndividualFeaturesThat.Text" xml:space="preserve">
+    <value>切换代理可能从此电脑请求的各项功能。</value>
+  </data>
+  <data name="PermissionsPage_Integrations.Text" xml:space="preserve">
+    <value>集成</value>
+  </data>
+  <data name="PermissionsPage_DefaultAction.Text" xml:space="preserve">
+    <value>默认操作</value>
+  </data>
+  <data name="PermissionsPage_WhatHappensWhenA.Text" xml:space="preserve">
+    <value>当命令与下列任何规则都不匹配时发生什么。</value>
+  </data>
+  <data name="PermissionsPage_PatternsAreMatchedLeft.Text" xml:space="preserve">
+    <value>模式按从左到右的顺序与完整命令行匹配。使用 * 作为通配符。更改将自动保存。</value>
+  </data>
+  <data name="PermissionsPage_Saved.Text" xml:space="preserve">
+    <value>已保存</value>
+  </data>
+  <data name="PermissionsPage_0Rules.Text" xml:space="preserve">
+    <value>0 条规则</value>
+  </data>
+  <data name="PermissionsPage_NoRulesYetAdd.Text" xml:space="preserve">
+    <value>尚无规则。在下方添加模式以允许或拒绝特定命令。</value>
+  </data>
+  <data name="PermissionsPage_WindowsPrivacy.Text" xml:space="preserve">
+    <value>Windows 隐私</value>
+  </data>
+  <data name="PermissionsPage_CameraMicrophoneAmpScreen.Text" xml:space="preserve">
+    <value>摄像头、麦克风和屏幕访问</value>
+  </data>
+  <data name="PermissionsPage_SystemLevelPrivacyPermissions.Text" xml:space="preserve">
+    <value>系统级隐私权限由 Windows 管理。打开 Windows 隐私设置以授予或撤销 OpenClaw 访问权限。</value>
+  </data>
+  <data name="SandboxPage_NodeSandboxIsOn.Text" xml:space="preserve">
+    <value>节点沙盒已开启</value>
+  </data>
+  <data name="SandboxPage_ProgramsTheAgentRuns.Text" xml:space="preserve">
+    <value>代理在此电脑上运行的程序受到隔离。</value>
+  </data>
+  <data name="SandboxPage_WhatGetsContained.Text" xml:space="preserve">
+    <value>哪些内容受隔离</value>
+  </data>
+  <data name="SandboxPage_SeeWhichCommandsThis.Text" xml:space="preserve">
+    <value>查看此页面涵盖的命令 — 以及需要其他控件的命令。</value>
+  </data>
+  <data name="SandboxPage_CommandsTheAgentRuns.Text" xml:space="preserve">
+    <value>代理通过 Windows 节点运行的命令 (</value>
+  </data>
+  <data name="SandboxPage_SystemRun.Text" xml:space="preserve">
+    <value>system.run</value>
+  </data>
+  <data name="SandboxPage_AreContainedByThe.Text" xml:space="preserve">
+    <value>) 受下面的设置隔离。</value>
+  </data>
+  <data name="SandboxPage_CommandsTheAgentRuns2.Text" xml:space="preserve">
+    <value>代理直接在网关上运行的命令不受隔离。如果网关位于此电脑的 WSL 上,它们可能会访问您的 Windows 文件、剪贴板和网络 — 请使用网关的执行审批。</value>
+  </data>
+  <data name="SandboxPage_SandboxUnavailable.Title" xml:space="preserve">
+    <value>沙盒不可用</value>
+  </data>
+  <data name="SandboxPage_LearnMoreAboutMXC.Content" xml:space="preserve">
+    <value>详细了解 MXC 沙盒</value>
+  </data>
+  <data name="SandboxPage_SecurityLevel.Text" xml:space="preserve">
+    <value>安全级别</value>
+  </data>
+  <data name="SandboxPage_OneClickToSet.Text" xml:space="preserve">
+    <value>一键设置下面的每个控件。自定义文件夹保持您的设置。</value>
+  </data>
+  <data name="SandboxPage_LockedDown.Text" xml:space="preserve">
+    <value>🔒 锁定</value>
+  </data>
+  <data name="SandboxPage_NoInternetNoClipboard.Text" xml:space="preserve">
+    <value>无互联网、无剪贴板、无标准用户文件夹。</value>
+  </data>
+  <data name="SandboxPage_Recommended.Text" xml:space="preserve">
+    <value>🛡 推荐</value>
+  </data>
+  <data name="SandboxPage_InternetOnReadOnly.Text" xml:space="preserve">
+    <value>互联网开启。对“文档”、“下载”、“桌面”为只读。剪贴板可读。</value>
+  </data>
+  <data name="SandboxPage_Unprotected.Text" xml:space="preserve">
+    <value>⚠ 不受保护</value>
+  </data>
+  <data name="SandboxPage_InternetOnReadWrite.Text" xml:space="preserve">
+    <value>互联网开启。对“文档”、“下载”、“桌面”可读写。剪贴板可读写。</value>
+  </data>
+  <data name="SandboxPage_CustomFolderGrantsStill.Title" xml:space="preserve">
+    <value>自定义文件夹授权仍然有效</value>
+  </data>
+  <data name="SandboxPage_Files.Text" xml:space="preserve">
+    <value>📁 文件</value>
+  </data>
+  <data name="SandboxPage_ByDefaultTheAgent.Text" xml:space="preserve">
+    <value>默认情况下,代理只有一个可读写的临时工作区文件夹。在下方授予对用户文件夹的访问权限。SSH 密钥、浏览器配置文件和 OpenClaw 自身的设置始终被阻止。</value>
+  </data>
+  <data name="SandboxPage_Documents.Text" xml:space="preserve">
+    <value>文档</value>
+  </data>
+  <data name="SandboxPage_Blocked.Content" xml:space="preserve">
+    <value>已阻止</value>
+  </data>
+  <data name="SandboxPage_ReadOnly.Content" xml:space="preserve">
+    <value>只读</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite.Content" xml:space="preserve">
+    <value>读取与写入</value>
+  </data>
+  <data name="SandboxPage_Downloads.Text" xml:space="preserve">
+    <value>下载</value>
+  </data>
+  <data name="SandboxPage_Blocked2.Content" xml:space="preserve">
+    <value>已阻止</value>
+  </data>
+  <data name="SandboxPage_ReadOnly2.Content" xml:space="preserve">
+    <value>只读</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite2.Content" xml:space="preserve">
+    <value>读取与写入</value>
+  </data>
+  <data name="SandboxPage_Desktop.Text" xml:space="preserve">
+    <value>桌面</value>
+  </data>
+  <data name="SandboxPage_Blocked3.Content" xml:space="preserve">
+    <value>已阻止</value>
+  </data>
+  <data name="SandboxPage_ReadOnly3.Content" xml:space="preserve">
+    <value>只读</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite3.Content" xml:space="preserve">
+    <value>读取与写入</value>
+  </data>
+  <data name="SandboxPage_ToolDirectoriesOnYour.Text" xml:space="preserve">
+    <value>PATH 上的工具目录在沙盒内也以只读方式授予,因此 git、node、python 和 dotnet 等命令行工具可用。从不授予驱动器根目录。</value>
+  </data>
+  <data name="SandboxPage_CustomFolders.Text" xml:space="preserve">
+    <value>自定义文件夹</value>
+  </data>
+  <data name="SandboxPage_CustomGrantsAreAdded.Text" xml:space="preserve">
+    <value>自定义授权将在上述规则之上添加。在“文档/下载/桌面”内添加具有更宽访问权限的文件夹,将覆盖该路径的行级设置。</value>
+  </data>
+  <data name="SandboxPage_Blocked4.Content" xml:space="preserve">
+    <value>已阻止</value>
+  </data>
+  <data name="SandboxPage_ReadOnly4.Content" xml:space="preserve">
+    <value>只读</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite4.Content" xml:space="preserve">
+    <value>读取与写入</value>
+  </data>
+  <data name="SandboxPage_NoCustomFoldersAdded.Text" xml:space="preserve">
+    <value>尚未添加自定义文件夹。</value>
+  </data>
+  <data name="SandboxPage_AddFolder.Content" xml:space="preserve">
+    <value>添加文件夹</value>
+  </data>
+  <data name="SandboxPage_Clipboard.Text" xml:space="preserve">
+    <value>📋 剪贴板</value>
+  </data>
+  <data name="SandboxPage_ClipboardOftenContainsPasswords.Text" xml:space="preserve">
+    <value>剪贴板通常包含密码、令牌和私人文本。读取权限可能将这些泄露给代理(若启用,也会泄露到互联网)。</value>
+  </data>
+  <data name="SandboxPage_NoneDefault.Content" xml:space="preserve">
+    <value>无(默认)</value>
+  </data>
+  <data name="SandboxPage_ReadAgentCanSee.Content" xml:space="preserve">
+    <value>读取 — 代理可以看到您复制的内容</value>
+  </data>
+  <data name="SandboxPage_WriteAgentCanReplace.Content" xml:space="preserve">
+    <value>写入 — 代理可以替换您的剪贴板(无法读取)</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite5.Content" xml:space="preserve">
+    <value>读取与写入</value>
+  </data>
+  <data name="SandboxPage_Network.Text" xml:space="preserve">
+    <value>📡 网络</value>
+  </data>
+  <data name="SandboxPage_AllowInternet.Header" xml:space="preserve">
+    <value>允许互联网</value>
+  </data>
+  <data name="SandboxPage_IfFileOrClipboard.Text" xml:space="preserve">
+    <value>如果启用文件或剪贴板读取权限,代理可能会通过互联网发送这些数据。</value>
+  </data>
+  <data name="SandboxPage_LocalNetworkDevicesAnd.Text" xml:space="preserve">
+    <value>本地网络设备和共享尚未包含在内。</value>
+  </data>
+  <data name="SandboxPage_Limits.Text" xml:space="preserve">
+    <value>⏱ 限制</value>
+  </data>
+  <data name="SandboxPage_CommandTimeout30Sec.Text" xml:space="preserve">
+    <value>命令超时:30 秒</value>
+  </data>
+  <data name="SandboxPage_MaximumCapturedOutputTruncates.Text" xml:space="preserve">
+    <value>最大捕获输出(超过此值将被截断;不限制磁盘、内存或 CPU):</value>
+  </data>
+  <data name="SandboxPage_1MiB.Content" xml:space="preserve">
+    <value>1 MiB</value>
+  </data>
+  <data name="SandboxPage_4MiBDefault.Content" xml:space="preserve">
+    <value>4 MiB(默认)</value>
+  </data>
+  <data name="SandboxPage_16MiB.Content" xml:space="preserve">
+    <value>16 MiB</value>
+  </data>
+  <data name="SandboxPage_64MiB.Content" xml:space="preserve">
+    <value>64 MiB</value>
+  </data>
+  <data name="SessionsPage_BackToConnection.Text" xml:space="preserve">
+    <value>返回连接</value>
+  </data>
+  <data name="SessionsPage_Sessions.Text" xml:space="preserve">
+    <value>会话</value>
+  </data>
+  <data name="SessionsPage_Refresh.Text" xml:space="preserve">
+    <value>刷新</value>
+  </data>
+  <data name="SessionsPage_All.Text" xml:space="preserve">
+    <value>全部</value>
+  </data>
+  <data name="SessionsPage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>网关已断开</value>
+  </data>
+  <data name="SessionsPage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>请连接到网关以加载会话。</value>
+  </data>
+  <data name="SessionsPage_OpenConnection.Content" xml:space="preserve">
+    <value>打开连接</value>
+  </data>
+  <data name="SessionsPage_LoadingSessions.Text" xml:space="preserve">
+    <value>正在加载会话…</value>
+  </data>
+  <data name="SessionsPage_NoActiveSessions.Text" xml:space="preserve">
+    <value>无活动会话</value>
+  </data>
+  <data name="SessionsPage_Reset.Content" xml:space="preserve">
+    <value>重置</value>
+  </data>
+  <data name="SessionsPage_Compact.Content" xml:space="preserve">
+    <value>压缩</value>
+  </data>
+  <data name="SessionsPage_Delete.Content" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="SettingsPage_Settings.Text" xml:space="preserve">
+    <value>设置</value>
+  </data>
+  <data name="SettingsPage_General.Text" xml:space="preserve">
+    <value>常规</value>
+  </data>
+  <data name="SettingsPage_Notifications.Text" xml:space="preserve">
+    <value>通知</value>
+  </data>
+  <data name="SettingsPage_Privacy.Text" xml:space="preserve">
+    <value>隐私</value>
+  </data>
+  <data name="SettingsPage_LocalGateway.Text" xml:space="preserve">
+    <value>本地网关</value>
+  </data>
+  <data name="SettingsPage_MSIXInstallationDetected.Title" xml:space="preserve">
+    <value>检测到 MSIX 安装</value>
+  </data>
+  <data name="SettingsPage_MSIXInstallationDetected.Message" xml:space="preserve">
+    <value>通过 Windows 设置 &amp;amp;#x2192; 应用删除 OpenClaw 不会清理本地网关(WSL 发行版、磁盘映像)。请先使用下面的“删除本地网关”,然后再卸载 OpenClaw。</value>
+  </data>
+  <data name="SettingsPage_RemovesTheWSLDistro.Text" xml:space="preserve">
+    <value>删除 WSL 发行版 (OpenClawGateway)、其磁盘映像、自动启动项,并清除网关凭据。您的 MCP 令牌将被保留。引导将重置。</value>
+  </data>
+  <data name="SettingsPage_RemoveLocalGateway.Content" xml:space="preserve">
+    <value>删除本地网关</value>
+  </data>
+  <data name="SettingsPage_Saved.Title" xml:space="preserve">
+    <value>已保存</value>
+  </data>
+  <data name="SkillsPage_Skills.Text" xml:space="preserve">
+    <value>🧩 技能</value>
+  </data>
+  <data name="SkillsPage_AllAgents.Content" xml:space="preserve">
+    <value>所有代理</value>
+  </data>
+  <data name="SkillsPage_Enabled.Text" xml:space="preserve">
+    <value>已启用</value>
+  </data>
+  <data name="SkillsPage_Disabled.Text" xml:space="preserve">
+    <value>已禁用</value>
+  </data>
+  <data name="SkillsPage_LoadingSkills.Text" xml:space="preserve">
+    <value>正在加载技能…</value>
+  </data>
+  <data name="SkillsPage_NoSkillsInstalled.Text" xml:space="preserve">
+    <value>未安装技能</value>
+  </data>
+  <data name="SkillsPage_SkillsExtendYourAgent.Text" xml:space="preserve">
+    <value>技能扩展代理的能力。通过 CLI 或 ClawHub 安装技能。</value>
+  </data>
+  <data name="UsagePage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>网关已断开</value>
+  </data>
+  <data name="UsagePage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>请连接到网关以加载用量数据。</value>
+  </data>
+  <data name="UsagePage_OpenConnection.Content" xml:space="preserve">
+    <value>打开连接</value>
+  </data>
+  <data name="UsagePage_LoadingDailyCosts.Text" xml:space="preserve">
+    <value>正在加载每日费用…</value>
+  </data>
+  <data name="UsagePage_NoDailyUsageFor.Text" xml:space="preserve">
+    <value>此期间内无每日用量</value>
+  </data>
+  <data name="VoiceSettingsPage_TestVoiceInput.Text" xml:space="preserve">
+    <value>测试语音输入</value>
+  </data>
+  <data name="VoiceSettingsPage_Record.Text" xml:space="preserve">
+    <value>录制</value>
+  </data>
+  <data name="WorkspacePage_LoadingWorkspaceFiles.Text" xml:space="preserve">
+    <value>正在加载工作区文件…</value>
+  </data>
+  <data name="ChatWindow_WebChatUnavailable.Text" xml:space="preserve">
+    <value>网页聊天不可用</value>
+  </data>
+  <data name="ChatWindow_Retry.Content" xml:space="preserve">
+    <value>重试</value>
+  </data>
+  <data name="ConnectionStatusWindow_ConnectionStatus.Text" xml:space="preserve">
+    <value>连接状态</value>
+  </data>
+  <data name="ConnectionStatusWindow_STATEMACHINE.Text" xml:space="preserve">
+    <value>状态机</value>
+  </data>
+  <data name="ConnectionStatusWindow_OPERATOR.Text" xml:space="preserve">
+    <value>操作员</value>
+  </data>
+  <data name="ConnectionStatusWindow_Off.Text" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connecting.Text" xml:space="preserve">
+    <value>正在连接</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connected.Text" xml:space="preserve">
+    <value>已连接</value>
+  </data>
+  <data name="ConnectionStatusWindow_Pairing.Text" xml:space="preserve">
+    <value>正在配对</value>
+  </data>
+  <data name="ConnectionStatusWindow_Error.Text" xml:space="preserve">
+    <value>错误</value>
+  </data>
+  <data name="ConnectionStatusWindow_NODE.Text" xml:space="preserve">
+    <value>节点</value>
+  </data>
+  <data name="ConnectionStatusWindow_Off2.Text" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connecting2.Text" xml:space="preserve">
+    <value>正在连接</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connected2.Text" xml:space="preserve">
+    <value>已连接</value>
+  </data>
+  <data name="ConnectionStatusWindow_Pairing2.Text" xml:space="preserve">
+    <value>正在配对</value>
+  </data>
+  <data name="ConnectionStatusWindow_Error2.Text" xml:space="preserve">
+    <value>错误</value>
+  </data>
+  <data name="ConnectionStatusWindow_GATEWAYS.Text" xml:space="preserve">
+    <value>网关</value>
+  </data>
+  <data name="ConnectionStatusWindow_CREDENTIALS.Text" xml:space="preserve">
+    <value>凭据</value>
+  </data>
+  <data name="ConnectionStatusWindow_SETUPCODE.Text" xml:space="preserve">
+    <value>设置代码</value>
+  </data>
+  <data name="ConnectionStatusWindow_PasteASetupCode.Text" xml:space="preserve">
+    <value>粘贴设置代码以建立端到端连接。</value>
+  </data>
+  <data name="ConnectionStatusWindow_PasteSetupCode.PlaceholderText" xml:space="preserve">
+    <value>粘贴设置代码…</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connect.Content" xml:space="preserve">
+    <value>连接</value>
+  </data>
+  <data name="ConnectionStatusWindow_Disconnect.Content" xml:space="preserve">
+    <value>断开连接</value>
+  </data>
+  <data name="ConnectionStatusWindow_DIRECTCONNECT.Text" xml:space="preserve">
+    <value>直接连接</value>
+  </data>
+  <data name="ConnectionStatusWindow_ConnectWithAGateway.Text" xml:space="preserve">
+    <value>使用网关 URL 和共享令牌(管理员范围)连接。</value>
+  </data>
+  <data name="ConnectionStatusWindow_WsLocalhost18790.PlaceholderText" xml:space="preserve">
+    <value>ws://localhost:18790</value>
+  </data>
+  <data name="ConnectionStatusWindow_WsLocalhost18790.Text" xml:space="preserve">
+    <value>ws://localhost:18790</value>
+  </data>
+  <data name="ConnectionStatusWindow_WsLocalhost18790.Header" xml:space="preserve">
+    <value>网关 URL</value>
+  </data>
+  <data name="ConnectionStatusWindow_SharedGatewayToken.PlaceholderText" xml:space="preserve">
+    <value>共享网关令牌</value>
+  </data>
+  <data name="ConnectionStatusWindow_SharedGatewayToken.Header" xml:space="preserve">
+    <value>令牌</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connect2.Content" xml:space="preserve">
+    <value>连接</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHTunnel.Header" xml:space="preserve">
+    <value>SSH 隧道</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHUser.Header" xml:space="preserve">
+    <value>SSH 用户</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHUser.PlaceholderText" xml:space="preserve">
+    <value>user</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHHost.Header" xml:space="preserve">
+    <value>SSH 主机</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHHost.PlaceholderText" xml:space="preserve">
+    <value>192.168.x.x</value>
+  </data>
+  <data name="ConnectionStatusWindow_RemotePort.Header" xml:space="preserve">
+    <value>远程端口</value>
+  </data>
+  <data name="ConnectionStatusWindow_LocalPort.Header" xml:space="preserve">
+    <value>本地端口</value>
+  </data>
+  <data name="ConnectionStatusWindow_EVENTTIMELINE.Text" xml:space="preserve">
+    <value>事件时间线</value>
+  </data>
+  <data name="ConnectionStatusWindow_Copy.Content" xml:space="preserve">
+    <value>复制</value>
+  </data>
+  <data name="ConnectionStatusWindow_Clear.Content" xml:space="preserve">
+    <value>清除</value>
+  </data>
+  <data name="DiagnosticsBundleDialog_DiagnosticsBundle.Title" xml:space="preserve">
+    <value>诊断包</value>
+  </data>
+  <data name="DiagnosticsBundleDialog_ReviewBeforeSharing.Title" xml:space="preserve">
+    <value>分享前请审阅</value>
+  </data>
+  <data name="DiagnosticsBundleDialog_ReviewBeforeSharing.Message" xml:space="preserve">
+    <value>捆绑包生成器会排除敏感令牌、命令参数、负载和录制内容。</value>
+  </data>
+  <data name="HubWindow_Disconnected.Text" xml:space="preserve">
+    <value>已断开连接</value>
+  </data>
+  <data name="HubWindow_Op.Text" xml:space="preserve">
+    <value>操作</value>
+  </data>
+  <data name="HubWindow_Node.Text" xml:space="preserve">
+    <value>节点</value>
+  </data>
+  <data name="HubWindow_Advanced.Content" xml:space="preserve">
+    <value>高级</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -3507,4 +3507,919 @@
   <data name="ConnectionStatusWindow.Title" xml:space="preserve">
     <value>Connection Status</value>
   </data>
+  <data name="BindingsPage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>閘道已中斷</value>
+  </data>
+  <data name="BindingsPage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>請連接至閘道以載入繫結。</value>
+  </data>
+  <data name="BindingsPage_OpenConnection.Content" xml:space="preserve">
+    <value>開啟連線</value>
+  </data>
+  <data name="BindingsPage_LoadingBindings.Text" xml:space="preserve">
+    <value>正在載入繫結…</value>
+  </data>
+  <data name="ConnectionPage_ApprovalsWaitingOnYou.Text" xml:space="preserve">
+    <value>等待您的核准</value>
+  </data>
+  <data name="ConnectionPage_NotConnected.Text" xml:space="preserve">
+    <value>未連線</value>
+  </data>
+  <data name="ConnectionPage_Connect.Content" xml:space="preserve">
+    <value>連線</value>
+  </data>
+  <data name="ConnectionPage_Operator.Text" xml:space="preserve">
+    <value>操作員</value>
+  </data>
+  <data name="ConnectionPage_SendCommandsAndView.Text" xml:space="preserve">
+    <value>從這台電腦向此閘道傳送命令並檢視工作階段。</value>
+  </data>
+  <data name="ConnectionPage_Inactive.Text" xml:space="preserve">
+    <value>未啟用</value>
+  </data>
+  <data name="ConnectionPage_SeeSessions.Content" xml:space="preserve">
+    <value>檢視工作階段 ›</value>
+  </data>
+  <data name="ConnectionPage_SeeInstances.Content" xml:space="preserve">
+    <value>檢視執行個體 ›</value>
+  </data>
+  <data name="ConnectionPage_NodeMode.Text" xml:space="preserve">
+    <value>節點模式</value>
+  </data>
+  <data name="ConnectionPage_WhenOnThisPC.Text" xml:space="preserve">
+    <value>啟用後,這台電腦會註冊為節點,並透過閘道向代理提供下列功能。</value>
+  </data>
+  <data name="ConnectionPage_NodeModeDisabled.Text" xml:space="preserve">
+    <value>節點模式已停用</value>
+  </data>
+  <data name="ConnectionPage_Copy.Content" xml:space="preserve">
+    <value>複製</value>
+  </data>
+  <data name="ConnectionPage_Connect2.Content" xml:space="preserve">
+    <value>連線</value>
+  </data>
+  <data name="ConnectionPage_ManagePermissions.Content" xml:space="preserve">
+    <value>管理權限 ›</value>
+  </data>
+  <data name="ConnectionPage_HelpUsFixThis.Text" xml:space="preserve">
+    <value>協助我們修復此連線:</value>
+  </data>
+  <data name="ConnectionPage_SSHTunnelIsDown.Text" xml:space="preserve">
+    <value>SSH 通道已停止。</value>
+  </data>
+  <data name="ConnectionPage_RestartTunnel.Content" xml:space="preserve">
+    <value>重新啟動通道</value>
+  </data>
+  <data name="ConnectionPage_EditTunnelSettings.Content" xml:space="preserve">
+    <value>編輯通道設定</value>
+  </data>
+  <data name="ConnectionPage_PasteANewSetup.Text" xml:space="preserve">
+    <value>貼上來自閘道主機的新設定代碼。</value>
+  </data>
+  <data name="ConnectionPage_PasteSetupCodeHere.PlaceholderText" xml:space="preserve">
+    <value>在此貼上設定代碼…</value>
+  </data>
+  <data name="ConnectionPage_Apply.Content" xml:space="preserve">
+    <value>套用</value>
+  </data>
+  <data name="ConnectionPage_RunOnTheGateway.Text" xml:space="preserve">
+    <value>在閘道主機上執行:</value>
+  </data>
+  <data name="ConnectionPage_Copy2.Content" xml:space="preserve">
+    <value>複製</value>
+  </data>
+  <data name="ConnectionPage_Connect3.Content" xml:space="preserve">
+    <value>連線</value>
+  </data>
+  <data name="ConnectionPage_Disconnect.Content" xml:space="preserve">
+    <value>中斷連線</value>
+  </data>
+  <data name="ConnectionPage_SavedGateways.Text" xml:space="preserve">
+    <value>已儲存的閘道</value>
+  </data>
+  <data name="ConnectionPage_Gateways.Text" xml:space="preserve">
+    <value>閘道</value>
+  </data>
+  <data name="ConnectionPage_Scan.Text" xml:space="preserve">
+    <value>掃描</value>
+  </data>
+  <data name="ConnectionPage_AddGateway.Text" xml:space="preserve">
+    <value>新增閘道</value>
+  </data>
+  <data name="ConnectionPage_NoSavedGatewaysYet.Text" xml:space="preserve">
+    <value>尚無已儲存的閘道。</value>
+  </data>
+  <data name="ConnectionPage_DiscoveredOnYourNetwork.Text" xml:space="preserve">
+    <value>在您的網路上探索到</value>
+  </data>
+  <data name="ConnectionPage_AddAGateway.Text" xml:space="preserve">
+    <value>新增閘道</value>
+  </data>
+  <data name="ConnectionPage_GetStartedInstallA.Title" xml:space="preserve">
+    <value>開始使用 — 安裝本機閘道</value>
+  </data>
+  <data name="ConnectionPage_GetStartedInstallA.Message" xml:space="preserve">
+    <value>最快的入門方式:在這台電腦上設定由 WSL 託管的閘道,並將其設為使用中的連線。</value>
+  </data>
+  <data name="ConnectionPage_Install.Content" xml:space="preserve">
+    <value>安裝</value>
+  </data>
+  <data name="ConnectionPage_OrConnectToAn.Text" xml:space="preserve">
+    <value>或連線至現有閘道:</value>
+  </data>
+  <data name="ConnectionPage_Direct.Text" xml:space="preserve">
+    <value>直接</value>
+  </data>
+  <data name="ConnectionPage_URLToken.Text" xml:space="preserve">
+    <value>URL + 權杖</value>
+  </data>
+  <data name="ConnectionPage_SetupCode.Text" xml:space="preserve">
+    <value>設定代碼</value>
+  </data>
+  <data name="ConnectionPage_PasteQRPayload.Text" xml:space="preserve">
+    <value>貼上 QR 內容</value>
+  </data>
+  <data name="ConnectionPage_EachMethodSupportsAn.Text" xml:space="preserve">
+    <value>每種方法都支援選用的 SSH 通道。</value>
+  </data>
+  <data name="ConnectionPage_OrLookForOne.Text" xml:space="preserve">
+    <value>或在您的網路上尋找。</value>
+  </data>
+  <data name="ConnectionPage_Scan2.Text" xml:space="preserve">
+    <value>掃描</value>
+  </data>
+  <data name="ConnectionPage_DiscoveredOnYourNetwork2.Text" xml:space="preserve">
+    <value>在您的網路上探索到</value>
+  </data>
+  <data name="ConnectionPage_Back.Text" xml:space="preserve">
+    <value>返回</value>
+  </data>
+  <data name="ConnectionPage_AddAGateway2.Text" xml:space="preserve">
+    <value>新增閘道</value>
+  </data>
+  <data name="ConnectionPage_Direct2.Text" xml:space="preserve">
+    <value>直接</value>
+  </data>
+  <data name="ConnectionPage_SetupCode2.Text" xml:space="preserve">
+    <value>設定代碼</value>
+  </data>
+  <data name="ConnectionPage_LocalWSL.Text" xml:space="preserve">
+    <value>本機 WSL</value>
+  </data>
+  <data name="ConnectionPage_GatewayURL.Header" xml:space="preserve">
+    <value>閘道 URL</value>
+  </data>
+  <data name="ConnectionPage_GatewayURL.PlaceholderText" xml:space="preserve">
+    <value>ws://host.local:18790</value>
+  </data>
+  <data name="ConnectionPage_SharedToken.Header" xml:space="preserve">
+    <value>共用權杖</value>
+  </data>
+  <data name="ConnectionPage_SharedToken.PlaceholderText" xml:space="preserve">
+    <value>貼上共用閘道權杖</value>
+  </data>
+  <data name="ConnectionPage_NameOptional.Header" xml:space="preserve">
+    <value>名稱(選用)</value>
+  </data>
+  <data name="ConnectionPage_NameOptional.PlaceholderText" xml:space="preserve">
+    <value>我的閘道</value>
+  </data>
+  <data name="ConnectionPage_PasteASetupCode.Text" xml:space="preserve">
+    <value>貼上來自閘道的 QR 碼或 `openclaw qr` 輸出的設定代碼。</value>
+  </data>
+  <data name="ConnectionPage_PasteSetupCodeHere2.PlaceholderText" xml:space="preserve">
+    <value>在此貼上設定代碼…</value>
+  </data>
+  <data name="ConnectionPage_Decode.Content" xml:space="preserve">
+    <value>解碼</value>
+  </data>
+  <data name="ConnectionPage_InstallANewWSL.Text" xml:space="preserve">
+    <value>在這台電腦上安裝新的 WSL 閘道,並將其設為使用中的連線。安裝精靈會視需要安裝 WSL、佈建閘道,並自動配對這台裝置。</value>
+  </data>
+  <data name="ConnectionPage_InstallLocalGateway.Content" xml:space="preserve">
+    <value>安裝本機閘道</value>
+  </data>
+  <data name="ConnectionPage_LocalWSLSetupIsn.Text" xml:space="preserve">
+    <value>這台電腦無法進行本機 WSL 設定 — 安裝精靈無法初始化。</value>
+  </data>
+  <data name="ConnectionPage_UseSSHTunnelOptional.Text" xml:space="preserve">
+    <value>使用 SSH 通道(選用)</value>
+  </data>
+  <data name="ConnectionPage_SSHUser.Header" xml:space="preserve">
+    <value>SSH 使用者</value>
+  </data>
+  <data name="ConnectionPage_SSHUser.PlaceholderText" xml:space="preserve">
+    <value>user</value>
+  </data>
+  <data name="ConnectionPage_SSHHost.Header" xml:space="preserve">
+    <value>SSH 主機</value>
+  </data>
+  <data name="ConnectionPage_SSHHost.PlaceholderText" xml:space="preserve">
+    <value>machine-name</value>
+  </data>
+  <data name="ConnectionPage_RemotePort.Header" xml:space="preserve">
+    <value>遠端連接埠</value>
+  </data>
+  <data name="ConnectionPage_LocalPort.Header" xml:space="preserve">
+    <value>本機連接埠</value>
+  </data>
+  <data name="ConnectionPage_SaveAmpConnect.Content" xml:space="preserve">
+    <value>儲存並連線</value>
+  </data>
+  <data name="ConnectionPage_Cancel.Content" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="CronPage_CronJobs.Text" xml:space="preserve">
+    <value>⏱️ Cron 工作</value>
+  </data>
+  <data name="CronPage_Refresh.Text" xml:space="preserve">
+    <value>重新整理</value>
+  </data>
+  <data name="CronPage_NewJob.Text" xml:space="preserve">
+    <value>新增工作</value>
+  </data>
+  <data name="CronPage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>閘道已中斷</value>
+  </data>
+  <data name="CronPage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>請連接至閘道以載入 cron 工作。</value>
+  </data>
+  <data name="CronPage_OpenConnection.Content" xml:space="preserve">
+    <value>開啟連線</value>
+  </data>
+  <data name="CronPage_NewCronJob.Text" xml:space="preserve">
+    <value>新增 Cron 工作</value>
+  </data>
+  <data name="CronPage_NAME.Text" xml:space="preserve">
+    <value>名稱</value>
+  </data>
+  <data name="CronPage_MorningBrief.PlaceholderText" xml:space="preserve">
+    <value>晨間簡報</value>
+  </data>
+  <data name="CronPage_SCHEDULE.Text" xml:space="preserve">
+    <value>排程</value>
+  </data>
+  <data name="CronPage_Every.Content" xml:space="preserve">
+    <value>每</value>
+  </data>
+  <data name="CronPage_At.Content" xml:space="preserve">
+    <value>於</value>
+  </data>
+  <data name="CronPage_Cron.Content" xml:space="preserve">
+    <value>Cron</value>
+  </data>
+  <data name="CronPage_QUICKPRESETS.Text" xml:space="preserve">
+    <value>快速預設</value>
+  </data>
+  <data name="CronPage_Hourly.Content" xml:space="preserve">
+    <value>⏰ 每小時</value>
+  </data>
+  <data name="CronPage_Daily9am.Content" xml:space="preserve">
+    <value>🌅 每天上午 9 點</value>
+  </data>
+  <data name="CronPage_Daily6pm.Content" xml:space="preserve">
+    <value>🌆 每天下午 6 點</value>
+  </data>
+  <data name="CronPage_Weekdays.Content" xml:space="preserve">
+    <value>💼 平日</value>
+  </data>
+  <data name="CronPage_Weekly.Content" xml:space="preserve">
+    <value>📅 每週</value>
+  </data>
+  <data name="CronPage_EXPRESSION.Text" xml:space="preserve">
+    <value>運算式</value>
+  </data>
+  <data name="CronPage_TIMEZONE.Text" xml:space="preserve">
+    <value>時區</value>
+  </data>
+  <data name="CronPage_Optional.PlaceholderText" xml:space="preserve">
+    <value>選用</value>
+  </data>
+  <data name="CronPage_AmericaNewYork.Content" xml:space="preserve">
+    <value>America/New_York</value>
+  </data>
+  <data name="CronPage_AmericaChicago.Content" xml:space="preserve">
+    <value>America/Chicago</value>
+  </data>
+  <data name="CronPage_AmericaDenver.Content" xml:space="preserve">
+    <value>America/Denver</value>
+  </data>
+  <data name="CronPage_AmericaLosAngeles.Content" xml:space="preserve">
+    <value>America/Los_Angeles</value>
+  </data>
+  <data name="CronPage_EuropeLondon.Content" xml:space="preserve">
+    <value>Europe/London</value>
+  </data>
+  <data name="CronPage_EuropeBerlin.Content" xml:space="preserve">
+    <value>Europe/Berlin</value>
+  </data>
+  <data name="CronPage_AsiaTokyo.Content" xml:space="preserve">
+    <value>Asia/Tokyo</value>
+  </data>
+  <data name="CronPage_UTC.Content" xml:space="preserve">
+    <value>UTC</value>
+  </data>
+  <data name="CronPage_EVERY.Text" xml:space="preserve">
+    <value>每</value>
+  </data>
+  <data name="CronPage_UNIT.Text" xml:space="preserve">
+    <value>單位</value>
+  </data>
+  <data name="CronPage_Minutes.Content" xml:space="preserve">
+    <value>分鐘</value>
+  </data>
+  <data name="CronPage_Hours.Content" xml:space="preserve">
+    <value>小時</value>
+  </data>
+  <data name="CronPage_Days.Content" xml:space="preserve">
+    <value>天</value>
+  </data>
+  <data name="CronPage_RUNAT.Text" xml:space="preserve">
+    <value>執行時間</value>
+  </data>
+  <data name="CronPage_Date.PlaceholderText" xml:space="preserve">
+    <value>日期</value>
+  </data>
+  <data name="CronPage_330PM.PlaceholderText" xml:space="preserve">
+    <value>15:30</value>
+  </data>
+  <data name="CronPage_DeleteJobAfterIt.Content" xml:space="preserve">
+    <value>執行後刪除工作</value>
+  </data>
+  <data name="CronPage_PROMPTPAYLOAD.Text" xml:space="preserve">
+    <value>提示 / 內容</value>
+  </data>
+  <data name="CronPage_WhatShouldTheAgent.PlaceholderText" xml:space="preserve">
+    <value>代理應該做什麼?</value>
+  </data>
+  <data name="CronPage_DELIVERY.Text" xml:space="preserve">
+    <value>傳遞</value>
+  </data>
+  <data name="CronPage_SilentNone.Content" xml:space="preserve">
+    <value>靜默(無)</value>
+  </data>
+  <data name="CronPage_NotifyMeAnnounce.Content" xml:space="preserve">
+    <value>通知我(通告)</value>
+  </data>
+  <data name="CronPage_CHANNEL.Text" xml:space="preserve">
+    <value>通道</value>
+  </data>
+  <data name="CronPage_EGWebchat.PlaceholderText" xml:space="preserve">
+    <value>例如 webchat</value>
+  </data>
+  <data name="CronPage_AdvancedOptions.Text" xml:space="preserve">
+    <value>進階選項</value>
+  </data>
+  <data name="CronPage_SESSIONBEHAVIOR.Text" xml:space="preserve">
+    <value>工作階段行為</value>
+  </data>
+  <data name="CronPage_NewSessionEachRun.Content" xml:space="preserve">
+    <value>每次執行建立新工作階段</value>
+  </data>
+  <data name="CronPage_ResumeMainSession.Content" xml:space="preserve">
+    <value>繼續主要工作階段</value>
+  </data>
+  <data name="CronPage_WAKEMODE.Text" xml:space="preserve">
+    <value>喚醒模式</value>
+  </data>
+  <data name="CronPage_NowImmediate.Content" xml:space="preserve">
+    <value>立即(即時)</value>
+  </data>
+  <data name="CronPage_QueueWaitForIdle.Content" xml:space="preserve">
+    <value>佇列(等待閒置)</value>
+  </data>
+  <data name="CronPage_Cancel.Content" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="CronPage_CreateJob.Content" xml:space="preserve">
+    <value>建立工作</value>
+  </data>
+  <data name="CronPage_LoadingCronJobs.Text" xml:space="preserve">
+    <value>正在載入 cron 工作…</value>
+  </data>
+  <data name="CronPage_NoCronJobsConfigured.Text" xml:space="preserve">
+    <value>未設定 cron 工作</value>
+  </data>
+  <data name="CronPage_CronJobsWillAppear.Text" xml:space="preserve">
+    <value>透過閘道設定 cron 工作後,它們會顯示在此處。</value>
+  </data>
+  <data name="DebugPage_Status.Title" xml:space="preserve">
+    <value>狀態</value>
+  </data>
+  <data name="DebugPage_Copied.Title" xml:space="preserve">
+    <value>已複製</value>
+  </data>
+  <data name="DebugPage_NoOverride.Content" xml:space="preserve">
+    <value>無覆寫</value>
+  </data>
+  <data name="DebugPage_ForceGatewayChatUI.Content" xml:space="preserve">
+    <value>強制使用閘道聊天介面</value>
+  </data>
+  <data name="DebugPage_ForceCompanionChatUI.Content" xml:space="preserve">
+    <value>強制使用伴侶聊天介面</value>
+  </data>
+  <data name="DebugPage_NoOverride2.Content" xml:space="preserve">
+    <value>無覆寫</value>
+  </data>
+  <data name="DebugPage_ForceGatewayChatUI2.Content" xml:space="preserve">
+    <value>強制使用閘道聊天介面</value>
+  </data>
+  <data name="DebugPage_ForceCompanionChatUI2.Content" xml:space="preserve">
+    <value>強制使用伴侶聊天介面</value>
+  </data>
+  <data name="DebugPage_Refresh.Text" xml:space="preserve">
+    <value>重新整理</value>
+  </data>
+  <data name="DebugPage_Copy.Text" xml:space="preserve">
+    <value>複製</value>
+  </data>
+  <data name="DebugPage_OpenFile.Text" xml:space="preserve">
+    <value>開啟檔案</value>
+  </data>
+  <data name="InstancesPage_PairingApprovalRequired.Text" xml:space="preserve">
+    <value>需要配對核准</value>
+  </data>
+  <data name="InstancesPage_ANodeHasConnected.Text" xml:space="preserve">
+    <value>節點已連線,但在您核准配對要求之前,其功能不會啟用。</value>
+  </data>
+  <data name="InstancesPage_ReviewOnConnectionPage.Content" xml:space="preserve">
+    <value>在「連線」頁面檢視</value>
+  </data>
+  <data name="PermissionsPage_BackToConnection.Text" xml:space="preserve">
+    <value>返回連線</value>
+  </data>
+  <data name="PermissionsPage_Permissions.Text" xml:space="preserve">
+    <value>權限</value>
+  </data>
+  <data name="PermissionsPage_NodeMode.Text" xml:space="preserve">
+    <value>節點模式</value>
+  </data>
+  <data name="PermissionsPage_WhenOnThisPC.Text" xml:space="preserve">
+    <value>啟用後,這台電腦會註冊為節點,並透過閘道向代理提供下列功能。</value>
+  </data>
+  <data name="PermissionsPage_Capabilities.Text" xml:space="preserve">
+    <value>功能</value>
+  </data>
+  <data name="PermissionsPage_ToggleIndividualFeaturesThat.Text" xml:space="preserve">
+    <value>切換代理可能從這台電腦要求的各項功能。</value>
+  </data>
+  <data name="PermissionsPage_Integrations.Text" xml:space="preserve">
+    <value>整合</value>
+  </data>
+  <data name="PermissionsPage_DefaultAction.Text" xml:space="preserve">
+    <value>預設動作</value>
+  </data>
+  <data name="PermissionsPage_WhatHappensWhenA.Text" xml:space="preserve">
+    <value>當命令不符合下列任何規則時會發生什麼。</value>
+  </data>
+  <data name="PermissionsPage_PatternsAreMatchedLeft.Text" xml:space="preserve">
+    <value>模式由左至右與完整命令列比對。使用 * 作為萬用字元。變更會自動儲存。</value>
+  </data>
+  <data name="PermissionsPage_Saved.Text" xml:space="preserve">
+    <value>已儲存</value>
+  </data>
+  <data name="PermissionsPage_0Rules.Text" xml:space="preserve">
+    <value>0 條規則</value>
+  </data>
+  <data name="PermissionsPage_NoRulesYetAdd.Text" xml:space="preserve">
+    <value>尚無規則。在下方新增模式以允許或拒絕特定命令。</value>
+  </data>
+  <data name="PermissionsPage_WindowsPrivacy.Text" xml:space="preserve">
+    <value>Windows 隱私</value>
+  </data>
+  <data name="PermissionsPage_CameraMicrophoneAmpScreen.Text" xml:space="preserve">
+    <value>攝影機、麥克風與螢幕存取</value>
+  </data>
+  <data name="PermissionsPage_SystemLevelPrivacyPermissions.Text" xml:space="preserve">
+    <value>系統層級的隱私權限由 Windows 管理。開啟 Windows 隱私設定以授予或撤銷 OpenClaw 的存取權。</value>
+  </data>
+  <data name="SandboxPage_NodeSandboxIsOn.Text" xml:space="preserve">
+    <value>節點沙箱已開啟</value>
+  </data>
+  <data name="SandboxPage_ProgramsTheAgentRuns.Text" xml:space="preserve">
+    <value>代理在這台電腦上執行的程式受到隔離。</value>
+  </data>
+  <data name="SandboxPage_WhatGetsContained.Text" xml:space="preserve">
+    <value>哪些內容受隔離</value>
+  </data>
+  <data name="SandboxPage_SeeWhichCommandsThis.Text" xml:space="preserve">
+    <value>檢視此頁面涵蓋的命令 — 以及需要其他控制項的命令。</value>
+  </data>
+  <data name="SandboxPage_CommandsTheAgentRuns.Text" xml:space="preserve">
+    <value>代理透過 Windows 節點執行的命令 (</value>
+  </data>
+  <data name="SandboxPage_SystemRun.Text" xml:space="preserve">
+    <value>system.run</value>
+  </data>
+  <data name="SandboxPage_AreContainedByThe.Text" xml:space="preserve">
+    <value>) 受下方設定隔離。</value>
+  </data>
+  <data name="SandboxPage_CommandsTheAgentRuns2.Text" xml:space="preserve">
+    <value>代理直接在閘道上執行的命令則不受隔離。如果閘道位於這台電腦的 WSL 上,它們可能會存取您的 Windows 檔案、剪貼簿和網路 — 請使用閘道的執行核准。</value>
+  </data>
+  <data name="SandboxPage_SandboxUnavailable.Title" xml:space="preserve">
+    <value>沙箱無法使用</value>
+  </data>
+  <data name="SandboxPage_LearnMoreAboutMXC.Content" xml:space="preserve">
+    <value>深入了解 MXC 沙箱</value>
+  </data>
+  <data name="SandboxPage_SecurityLevel.Text" xml:space="preserve">
+    <value>安全等級</value>
+  </data>
+  <data name="SandboxPage_OneClickToSet.Text" xml:space="preserve">
+    <value>一鍵設定下方所有控制項。自訂資料夾會保留您的設定。</value>
+  </data>
+  <data name="SandboxPage_LockedDown.Text" xml:space="preserve">
+    <value>🔒 鎖定</value>
+  </data>
+  <data name="SandboxPage_NoInternetNoClipboard.Text" xml:space="preserve">
+    <value>無網際網路、無剪貼簿、無標準使用者資料夾。</value>
+  </data>
+  <data name="SandboxPage_Recommended.Text" xml:space="preserve">
+    <value>🛡 建議</value>
+  </data>
+  <data name="SandboxPage_InternetOnReadOnly.Text" xml:space="preserve">
+    <value>網際網路開啟。對「文件」、「下載」、「桌面」為唯讀。剪貼簿可讀。</value>
+  </data>
+  <data name="SandboxPage_Unprotected.Text" xml:space="preserve">
+    <value>⚠ 不受保護</value>
+  </data>
+  <data name="SandboxPage_InternetOnReadWrite.Text" xml:space="preserve">
+    <value>網際網路開啟。對「文件」、「下載」、「桌面」可讀寫。剪貼簿可讀寫。</value>
+  </data>
+  <data name="SandboxPage_CustomFolderGrantsStill.Title" xml:space="preserve">
+    <value>自訂資料夾授權仍然有效</value>
+  </data>
+  <data name="SandboxPage_Files.Text" xml:space="preserve">
+    <value>📁 檔案</value>
+  </data>
+  <data name="SandboxPage_ByDefaultTheAgent.Text" xml:space="preserve">
+    <value>預設情況下,代理只有一個可讀寫的暫存工作資料夾。在下方授予使用者資料夾的存取權限。SSH 金鑰、瀏覽器設定檔以及 OpenClaw 本身的設定一律會被封鎖。</value>
+  </data>
+  <data name="SandboxPage_Documents.Text" xml:space="preserve">
+    <value>文件</value>
+  </data>
+  <data name="SandboxPage_Blocked.Content" xml:space="preserve">
+    <value>已封鎖</value>
+  </data>
+  <data name="SandboxPage_ReadOnly.Content" xml:space="preserve">
+    <value>唯讀</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite.Content" xml:space="preserve">
+    <value>讀取與寫入</value>
+  </data>
+  <data name="SandboxPage_Downloads.Text" xml:space="preserve">
+    <value>下載</value>
+  </data>
+  <data name="SandboxPage_Blocked2.Content" xml:space="preserve">
+    <value>已封鎖</value>
+  </data>
+  <data name="SandboxPage_ReadOnly2.Content" xml:space="preserve">
+    <value>唯讀</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite2.Content" xml:space="preserve">
+    <value>讀取與寫入</value>
+  </data>
+  <data name="SandboxPage_Desktop.Text" xml:space="preserve">
+    <value>桌面</value>
+  </data>
+  <data name="SandboxPage_Blocked3.Content" xml:space="preserve">
+    <value>已封鎖</value>
+  </data>
+  <data name="SandboxPage_ReadOnly3.Content" xml:space="preserve">
+    <value>唯讀</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite3.Content" xml:space="preserve">
+    <value>讀取與寫入</value>
+  </data>
+  <data name="SandboxPage_ToolDirectoriesOnYour.Text" xml:space="preserve">
+    <value>PATH 上的工具目錄在沙箱內也以唯讀方式授予,因此 git、node、python 與 dotnet 等命令列工具可使用。一律不會授予磁碟機根目錄。</value>
+  </data>
+  <data name="SandboxPage_CustomFolders.Text" xml:space="preserve">
+    <value>自訂資料夾</value>
+  </data>
+  <data name="SandboxPage_CustomGrantsAreAdded.Text" xml:space="preserve">
+    <value>自訂授權會疊加於上述規則之上。在「文件/下載/桌面」內新增具有更寬權限的資料夾,會覆寫該路徑的行層級設定。</value>
+  </data>
+  <data name="SandboxPage_Blocked4.Content" xml:space="preserve">
+    <value>已封鎖</value>
+  </data>
+  <data name="SandboxPage_ReadOnly4.Content" xml:space="preserve">
+    <value>唯讀</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite4.Content" xml:space="preserve">
+    <value>讀取與寫入</value>
+  </data>
+  <data name="SandboxPage_NoCustomFoldersAdded.Text" xml:space="preserve">
+    <value>尚未新增自訂資料夾。</value>
+  </data>
+  <data name="SandboxPage_AddFolder.Content" xml:space="preserve">
+    <value>新增資料夾</value>
+  </data>
+  <data name="SandboxPage_Clipboard.Text" xml:space="preserve">
+    <value>📋 剪貼簿</value>
+  </data>
+  <data name="SandboxPage_ClipboardOftenContainsPasswords.Text" xml:space="preserve">
+    <value>剪貼簿通常包含密碼、權杖與私人文字。讀取權限可能會將這些洩露給代理(若已啟用,也會洩露至網際網路)。</value>
+  </data>
+  <data name="SandboxPage_NoneDefault.Content" xml:space="preserve">
+    <value>無(預設)</value>
+  </data>
+  <data name="SandboxPage_ReadAgentCanSee.Content" xml:space="preserve">
+    <value>讀取 — 代理可以看到您複製的內容</value>
+  </data>
+  <data name="SandboxPage_WriteAgentCanReplace.Content" xml:space="preserve">
+    <value>寫入 — 代理可以取代您的剪貼簿(無法讀取)</value>
+  </data>
+  <data name="SandboxPage_ReadAmpWrite5.Content" xml:space="preserve">
+    <value>讀取與寫入</value>
+  </data>
+  <data name="SandboxPage_Network.Text" xml:space="preserve">
+    <value>📡 網路</value>
+  </data>
+  <data name="SandboxPage_AllowInternet.Header" xml:space="preserve">
+    <value>允許網際網路</value>
+  </data>
+  <data name="SandboxPage_IfFileOrClipboard.Text" xml:space="preserve">
+    <value>如果啟用檔案或剪貼簿讀取權限,代理可能會透過網際網路傳送這些資料。</value>
+  </data>
+  <data name="SandboxPage_LocalNetworkDevicesAnd.Text" xml:space="preserve">
+    <value>尚未包含本機網路裝置與共用。</value>
+  </data>
+  <data name="SandboxPage_Limits.Text" xml:space="preserve">
+    <value>⏱ 限制</value>
+  </data>
+  <data name="SandboxPage_CommandTimeout30Sec.Text" xml:space="preserve">
+    <value>命令逾時:30 秒</value>
+  </data>
+  <data name="SandboxPage_MaximumCapturedOutputTruncates.Text" xml:space="preserve">
+    <value>最大擷取輸出(超過此值會被截斷;不限制磁碟、記憶體或 CPU):</value>
+  </data>
+  <data name="SandboxPage_1MiB.Content" xml:space="preserve">
+    <value>1 MiB</value>
+  </data>
+  <data name="SandboxPage_4MiBDefault.Content" xml:space="preserve">
+    <value>4 MiB(預設)</value>
+  </data>
+  <data name="SandboxPage_16MiB.Content" xml:space="preserve">
+    <value>16 MiB</value>
+  </data>
+  <data name="SandboxPage_64MiB.Content" xml:space="preserve">
+    <value>64 MiB</value>
+  </data>
+  <data name="SessionsPage_BackToConnection.Text" xml:space="preserve">
+    <value>返回連線</value>
+  </data>
+  <data name="SessionsPage_Sessions.Text" xml:space="preserve">
+    <value>工作階段</value>
+  </data>
+  <data name="SessionsPage_Refresh.Text" xml:space="preserve">
+    <value>重新整理</value>
+  </data>
+  <data name="SessionsPage_All.Text" xml:space="preserve">
+    <value>全部</value>
+  </data>
+  <data name="SessionsPage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>閘道已中斷</value>
+  </data>
+  <data name="SessionsPage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>請連接至閘道以載入工作階段。</value>
+  </data>
+  <data name="SessionsPage_OpenConnection.Content" xml:space="preserve">
+    <value>開啟連線</value>
+  </data>
+  <data name="SessionsPage_LoadingSessions.Text" xml:space="preserve">
+    <value>正在載入工作階段…</value>
+  </data>
+  <data name="SessionsPage_NoActiveSessions.Text" xml:space="preserve">
+    <value>沒有作用中的工作階段</value>
+  </data>
+  <data name="SessionsPage_Reset.Content" xml:space="preserve">
+    <value>重設</value>
+  </data>
+  <data name="SessionsPage_Compact.Content" xml:space="preserve">
+    <value>壓縮</value>
+  </data>
+  <data name="SessionsPage_Delete.Content" xml:space="preserve">
+    <value>刪除</value>
+  </data>
+  <data name="SettingsPage_Settings.Text" xml:space="preserve">
+    <value>設定</value>
+  </data>
+  <data name="SettingsPage_General.Text" xml:space="preserve">
+    <value>一般</value>
+  </data>
+  <data name="SettingsPage_Notifications.Text" xml:space="preserve">
+    <value>通知</value>
+  </data>
+  <data name="SettingsPage_Privacy.Text" xml:space="preserve">
+    <value>隱私</value>
+  </data>
+  <data name="SettingsPage_LocalGateway.Text" xml:space="preserve">
+    <value>本機閘道</value>
+  </data>
+  <data name="SettingsPage_MSIXInstallationDetected.Title" xml:space="preserve">
+    <value>偵測到 MSIX 安裝</value>
+  </data>
+  <data name="SettingsPage_MSIXInstallationDetected.Message" xml:space="preserve">
+    <value>透過 Windows 設定 &amp;amp;#x2192; 應用程式移除 OpenClaw 不會清除本機閘道(WSL 散發版、磁碟映像)。請先使用下方的「移除本機閘道」,然後再解除安裝 OpenClaw。</value>
+  </data>
+  <data name="SettingsPage_RemovesTheWSLDistro.Text" xml:space="preserve">
+    <value>移除 WSL 散發版 (OpenClawGateway)、其磁碟映像、自動啟動項目,並清除閘道認證。您的 MCP 權杖會保留。導覽流程將重設。</value>
+  </data>
+  <data name="SettingsPage_RemoveLocalGateway.Content" xml:space="preserve">
+    <value>移除本機閘道</value>
+  </data>
+  <data name="SettingsPage_Saved.Title" xml:space="preserve">
+    <value>已儲存</value>
+  </data>
+  <data name="SkillsPage_Skills.Text" xml:space="preserve">
+    <value>🧩 技能</value>
+  </data>
+  <data name="SkillsPage_AllAgents.Content" xml:space="preserve">
+    <value>所有代理</value>
+  </data>
+  <data name="SkillsPage_Enabled.Text" xml:space="preserve">
+    <value>已啟用</value>
+  </data>
+  <data name="SkillsPage_Disabled.Text" xml:space="preserve">
+    <value>已停用</value>
+  </data>
+  <data name="SkillsPage_LoadingSkills.Text" xml:space="preserve">
+    <value>正在載入技能…</value>
+  </data>
+  <data name="SkillsPage_NoSkillsInstalled.Text" xml:space="preserve">
+    <value>未安裝技能</value>
+  </data>
+  <data name="SkillsPage_SkillsExtendYourAgent.Text" xml:space="preserve">
+    <value>技能可擴充您代理的能力。透過 CLI 或 ClawHub 安裝技能。</value>
+  </data>
+  <data name="UsagePage_GatewayDisconnected.Title" xml:space="preserve">
+    <value>閘道已中斷</value>
+  </data>
+  <data name="UsagePage_GatewayDisconnected.Message" xml:space="preserve">
+    <value>請連接至閘道以載入使用量資料。</value>
+  </data>
+  <data name="UsagePage_OpenConnection.Content" xml:space="preserve">
+    <value>開啟連線</value>
+  </data>
+  <data name="UsagePage_LoadingDailyCosts.Text" xml:space="preserve">
+    <value>正在載入每日成本…</value>
+  </data>
+  <data name="UsagePage_NoDailyUsageFor.Text" xml:space="preserve">
+    <value>此期間內無每日使用量</value>
+  </data>
+  <data name="VoiceSettingsPage_TestVoiceInput.Text" xml:space="preserve">
+    <value>測試語音輸入</value>
+  </data>
+  <data name="VoiceSettingsPage_Record.Text" xml:space="preserve">
+    <value>錄製</value>
+  </data>
+  <data name="WorkspacePage_LoadingWorkspaceFiles.Text" xml:space="preserve">
+    <value>正在載入工作區檔案…</value>
+  </data>
+  <data name="ChatWindow_WebChatUnavailable.Text" xml:space="preserve">
+    <value>網頁聊天無法使用</value>
+  </data>
+  <data name="ChatWindow_Retry.Content" xml:space="preserve">
+    <value>重試</value>
+  </data>
+  <data name="ConnectionStatusWindow_ConnectionStatus.Text" xml:space="preserve">
+    <value>連線狀態</value>
+  </data>
+  <data name="ConnectionStatusWindow_STATEMACHINE.Text" xml:space="preserve">
+    <value>狀態機</value>
+  </data>
+  <data name="ConnectionStatusWindow_OPERATOR.Text" xml:space="preserve">
+    <value>操作員</value>
+  </data>
+  <data name="ConnectionStatusWindow_Off.Text" xml:space="preserve">
+    <value>關閉</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connecting.Text" xml:space="preserve">
+    <value>正在連線</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connected.Text" xml:space="preserve">
+    <value>已連線</value>
+  </data>
+  <data name="ConnectionStatusWindow_Pairing.Text" xml:space="preserve">
+    <value>正在配對</value>
+  </data>
+  <data name="ConnectionStatusWindow_Error.Text" xml:space="preserve">
+    <value>錯誤</value>
+  </data>
+  <data name="ConnectionStatusWindow_NODE.Text" xml:space="preserve">
+    <value>節點</value>
+  </data>
+  <data name="ConnectionStatusWindow_Off2.Text" xml:space="preserve">
+    <value>關閉</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connecting2.Text" xml:space="preserve">
+    <value>正在連線</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connected2.Text" xml:space="preserve">
+    <value>已連線</value>
+  </data>
+  <data name="ConnectionStatusWindow_Pairing2.Text" xml:space="preserve">
+    <value>正在配對</value>
+  </data>
+  <data name="ConnectionStatusWindow_Error2.Text" xml:space="preserve">
+    <value>錯誤</value>
+  </data>
+  <data name="ConnectionStatusWindow_GATEWAYS.Text" xml:space="preserve">
+    <value>閘道</value>
+  </data>
+  <data name="ConnectionStatusWindow_CREDENTIALS.Text" xml:space="preserve">
+    <value>認證</value>
+  </data>
+  <data name="ConnectionStatusWindow_SETUPCODE.Text" xml:space="preserve">
+    <value>設定代碼</value>
+  </data>
+  <data name="ConnectionStatusWindow_PasteASetupCode.Text" xml:space="preserve">
+    <value>貼上設定代碼以建立端對端連線。</value>
+  </data>
+  <data name="ConnectionStatusWindow_PasteSetupCode.PlaceholderText" xml:space="preserve">
+    <value>貼上設定代碼…</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connect.Content" xml:space="preserve">
+    <value>連線</value>
+  </data>
+  <data name="ConnectionStatusWindow_Disconnect.Content" xml:space="preserve">
+    <value>中斷連線</value>
+  </data>
+  <data name="ConnectionStatusWindow_DIRECTCONNECT.Text" xml:space="preserve">
+    <value>直接連線</value>
+  </data>
+  <data name="ConnectionStatusWindow_ConnectWithAGateway.Text" xml:space="preserve">
+    <value>使用閘道 URL 和共用權杖(管理員範圍)連線。</value>
+  </data>
+  <data name="ConnectionStatusWindow_WsLocalhost18790.PlaceholderText" xml:space="preserve">
+    <value>ws://localhost:18790</value>
+  </data>
+  <data name="ConnectionStatusWindow_WsLocalhost18790.Text" xml:space="preserve">
+    <value>ws://localhost:18790</value>
+  </data>
+  <data name="ConnectionStatusWindow_WsLocalhost18790.Header" xml:space="preserve">
+    <value>閘道 URL</value>
+  </data>
+  <data name="ConnectionStatusWindow_SharedGatewayToken.PlaceholderText" xml:space="preserve">
+    <value>共用閘道權杖</value>
+  </data>
+  <data name="ConnectionStatusWindow_SharedGatewayToken.Header" xml:space="preserve">
+    <value>權杖</value>
+  </data>
+  <data name="ConnectionStatusWindow_Connect2.Content" xml:space="preserve">
+    <value>連線</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHTunnel.Header" xml:space="preserve">
+    <value>SSH 通道</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHUser.Header" xml:space="preserve">
+    <value>SSH 使用者</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHUser.PlaceholderText" xml:space="preserve">
+    <value>user</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHHost.Header" xml:space="preserve">
+    <value>SSH 主機</value>
+  </data>
+  <data name="ConnectionStatusWindow_SSHHost.PlaceholderText" xml:space="preserve">
+    <value>192.168.x.x</value>
+  </data>
+  <data name="ConnectionStatusWindow_RemotePort.Header" xml:space="preserve">
+    <value>遠端連接埠</value>
+  </data>
+  <data name="ConnectionStatusWindow_LocalPort.Header" xml:space="preserve">
+    <value>本機連接埠</value>
+  </data>
+  <data name="ConnectionStatusWindow_EVENTTIMELINE.Text" xml:space="preserve">
+    <value>事件時間軸</value>
+  </data>
+  <data name="ConnectionStatusWindow_Copy.Content" xml:space="preserve">
+    <value>複製</value>
+  </data>
+  <data name="ConnectionStatusWindow_Clear.Content" xml:space="preserve">
+    <value>清除</value>
+  </data>
+  <data name="DiagnosticsBundleDialog_DiagnosticsBundle.Title" xml:space="preserve">
+    <value>診斷套件</value>
+  </data>
+  <data name="DiagnosticsBundleDialog_ReviewBeforeSharing.Title" xml:space="preserve">
+    <value>分享前請檢閱</value>
+  </data>
+  <data name="DiagnosticsBundleDialog_ReviewBeforeSharing.Message" xml:space="preserve">
+    <value>套件產生器會排除敏感權杖、命令引數、內容與錄製。</value>
+  </data>
+  <data name="HubWindow_Disconnected.Text" xml:space="preserve">
+    <value>已中斷連線</value>
+  </data>
+  <data name="HubWindow_Op.Text" xml:space="preserve">
+    <value>操作</value>
+  </data>
+  <data name="HubWindow_Node.Text" xml:space="preserve">
+    <value>節點</value>
+  </data>
+  <data name="HubWindow_Advanced.Content" xml:space="preserve">
+    <value>進階</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml
@@ -69,11 +69,11 @@
         <!-- WebView2 navigation error panel. -->
         <ScrollViewer x:Name="ErrorPanel" Grid.Row="1" Visibility="Collapsed" Padding="20">
             <StackPanel Spacing="12" VerticalAlignment="Center">
-                <TextBlock Text="Web Chat Unavailable" Style="{StaticResource SubtitleTextBlockStyle}"
+                <TextBlock x:Uid="ChatWindow_WebChatUnavailable" Text="Web Chat Unavailable" Style="{StaticResource SubtitleTextBlockStyle}"
                            Foreground="{ThemeResource SystemFillColorCriticalBrush}"/>
                 <TextBlock x:Name="ErrorText" TextWrapping="Wrap" IsTextSelectionEnabled="True"
                            FontFamily="Consolas" Style="{StaticResource CaptionTextBlockStyle}"/>
-                <Button Content="Retry" Click="OnRetry" HorizontalAlignment="Left"/>
+                <Button x:Uid="ChatWindow_Retry" Content="Retry" Click="OnRetry" HorizontalAlignment="Left"/>
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/src/OpenClaw.Tray.WinUI/Windows/ConnectionStatusWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/ConnectionStatusWindow.xaml
@@ -19,7 +19,7 @@
         </Grid.ColumnDefinitions>
 
         <!-- Title in the title bar area -->
-        <TextBlock Grid.ColumnSpan="2" Text="Connection Status" FontSize="12" FontWeight="SemiBold"
+        <TextBlock x:Uid="ConnectionStatusWindow_ConnectionStatus" Grid.ColumnSpan="2" Text="Connection Status" FontSize="12" FontWeight="SemiBold"
                    VerticalAlignment="Top" Margin="4,-28,0,0" Opacity="0.8"/>
 
         <!-- LEFT COLUMN: State Machine + Gateways + Credentials -->
@@ -27,7 +27,7 @@
         <StackPanel>
 
             <!-- State Machine Visual -->
-            <TextBlock Text="STATE MACHINE" FontWeight="Bold" FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="0,0,0,4" CharacterSpacing="100"/>
+            <TextBlock x:Uid="ConnectionStatusWindow_STATEMACHINE" Text="STATE MACHINE" FontWeight="Bold" FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="0,0,0,4" CharacterSpacing="100"/>
             <Grid Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="6" Padding="10" Margin="0,0,0,8">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -37,16 +37,16 @@
                 <!-- Operator flow -->
                 <StackPanel Grid.Row="0" Margin="0,0,0,6">
                     <StackPanel Orientation="Horizontal" Spacing="4" Margin="0,0,0,3">
-                        <TextBlock Text="OPERATOR" FontSize="9" FontWeight="Bold" Foreground="{ThemeResource TextFillColorSecondaryBrush}" CharacterSpacing="80" VerticalAlignment="Center" Width="65"/>
-                        <Border x:Name="OpDisconnected" CornerRadius="3" Padding="6,2"><TextBlock Text="Off" FontSize="10"/></Border>
+                        <TextBlock x:Uid="ConnectionStatusWindow_OPERATOR" Text="OPERATOR" FontSize="9" FontWeight="Bold" Foreground="{ThemeResource TextFillColorSecondaryBrush}" CharacterSpacing="80" VerticalAlignment="Center" Width="65"/>
+                        <Border x:Name="OpDisconnected" CornerRadius="3" Padding="6,2"><TextBlock x:Uid="ConnectionStatusWindow_Off" Text="Off" FontSize="10"/></Border>
                         <TextBlock Text="→" VerticalAlignment="Center" FontSize="9" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <Border x:Name="OpConnecting" CornerRadius="3" Padding="6,2"><TextBlock Text="Connecting" FontSize="10"/></Border>
+                        <Border x:Name="OpConnecting" CornerRadius="3" Padding="6,2"><TextBlock x:Uid="ConnectionStatusWindow_Connecting" Text="Connecting" FontSize="10"/></Border>
                         <TextBlock Text="→" VerticalAlignment="Center" FontSize="9" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <Border x:Name="OpConnected" CornerRadius="3" Padding="6,2"><TextBlock Text="Connected" FontSize="10"/></Border>
+                        <Border x:Name="OpConnected" CornerRadius="3" Padding="6,2"><TextBlock x:Uid="ConnectionStatusWindow_Connected" Text="Connected" FontSize="10"/></Border>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Spacing="4" Margin="69,0,0,0">
-                        <Border x:Name="OpPairing" CornerRadius="3" Padding="6,2"><TextBlock Text="Pairing" FontSize="10"/></Border>
-                        <Border x:Name="OpError" CornerRadius="3" Padding="6,2"><TextBlock Text="Error" FontSize="10"/></Border>
+                        <Border x:Name="OpPairing" CornerRadius="3" Padding="6,2"><TextBlock x:Uid="ConnectionStatusWindow_Pairing" Text="Pairing" FontSize="10"/></Border>
+                        <Border x:Name="OpError" CornerRadius="3" Padding="6,2"><TextBlock x:Uid="ConnectionStatusWindow_Error" Text="Error" FontSize="10"/></Border>
                     </StackPanel>
                     <TextBlock x:Name="OpDetailText" FontSize="9" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="69,2,0,0" TextWrapping="Wrap"/>
                 </StackPanel>
@@ -54,38 +54,38 @@
                 <!-- Node flow -->
                 <StackPanel Grid.Row="1">
                     <StackPanel Orientation="Horizontal" Spacing="4" Margin="0,0,0,3">
-                        <TextBlock Text="NODE" FontSize="9" FontWeight="Bold" Foreground="{ThemeResource TextFillColorSecondaryBrush}" CharacterSpacing="80" VerticalAlignment="Center" Width="65"/>
-                        <Border x:Name="NodeDisconnected" CornerRadius="3" Padding="6,2"><TextBlock Text="Off" FontSize="10"/></Border>
+                        <TextBlock x:Uid="ConnectionStatusWindow_NODE" Text="NODE" FontSize="9" FontWeight="Bold" Foreground="{ThemeResource TextFillColorSecondaryBrush}" CharacterSpacing="80" VerticalAlignment="Center" Width="65"/>
+                        <Border x:Name="NodeDisconnected" CornerRadius="3" Padding="6,2"><TextBlock x:Uid="ConnectionStatusWindow_Off2" Text="Off" FontSize="10"/></Border>
                         <TextBlock Text="→" VerticalAlignment="Center" FontSize="9" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <Border x:Name="NodeConnecting" CornerRadius="3" Padding="6,2"><TextBlock Text="Connecting" FontSize="10"/></Border>
+                        <Border x:Name="NodeConnecting" CornerRadius="3" Padding="6,2"><TextBlock x:Uid="ConnectionStatusWindow_Connecting2" Text="Connecting" FontSize="10"/></Border>
                         <TextBlock Text="→" VerticalAlignment="Center" FontSize="9" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <Border x:Name="NodeConnected" CornerRadius="3" Padding="6,2"><TextBlock Text="Connected" FontSize="10"/></Border>
+                        <Border x:Name="NodeConnected" CornerRadius="3" Padding="6,2"><TextBlock x:Uid="ConnectionStatusWindow_Connected2" Text="Connected" FontSize="10"/></Border>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Spacing="4" Margin="69,0,0,0">
-                        <Border x:Name="NodePairing" CornerRadius="3" Padding="6,2"><TextBlock Text="Pairing" FontSize="10"/></Border>
-                        <Border x:Name="NodeError" CornerRadius="3" Padding="6,2"><TextBlock Text="Error" FontSize="10"/></Border>
+                        <Border x:Name="NodePairing" CornerRadius="3" Padding="6,2"><TextBlock x:Uid="ConnectionStatusWindow_Pairing2" Text="Pairing" FontSize="10"/></Border>
+                        <Border x:Name="NodeError" CornerRadius="3" Padding="6,2"><TextBlock x:Uid="ConnectionStatusWindow_Error2" Text="Error" FontSize="10"/></Border>
                     </StackPanel>
                     <TextBlock x:Name="NodeDetailText" FontSize="9" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="69,2,0,0" TextWrapping="Wrap"/>
                 </StackPanel>
             </Grid>
 
             <!-- Gateways -->
-            <TextBlock Text="GATEWAYS" FontWeight="Bold" FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="0,0,0,4" CharacterSpacing="100"/>
+            <TextBlock x:Uid="ConnectionStatusWindow_GATEWAYS" Text="GATEWAYS" FontWeight="Bold" FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="0,0,0,4" CharacterSpacing="100"/>
             <StackPanel x:Name="GatewayListPanel" Spacing="3" Margin="0,0,0,8"/>
 
             <!-- Credentials -->
-            <TextBlock Text="CREDENTIALS" FontWeight="Bold" FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="0,0,0,4" CharacterSpacing="100"/>
+            <TextBlock x:Uid="ConnectionStatusWindow_CREDENTIALS" Text="CREDENTIALS" FontWeight="Bold" FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="0,0,0,4" CharacterSpacing="100"/>
             <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="6" Padding="10">
                 <TextBlock x:Name="CredentialsText" FontFamily="Consolas" FontSize="10.5" TextWrapping="Wrap" IsTextSelectionEnabled="True"/>
             </Border>
 
             <!-- Setup Code -->
-            <TextBlock Text="SETUP CODE" FontWeight="Bold" FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="0,8,0,4" CharacterSpacing="100"/>
+            <TextBlock x:Uid="ConnectionStatusWindow_SETUPCODE" Text="SETUP CODE" FontWeight="Bold" FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="0,8,0,4" CharacterSpacing="100"/>
             <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="6" Padding="10">
                 <StackPanel Spacing="6">
-                    <TextBlock Text="Paste a setup code to connect end-to-end." FontSize="10.5"
+                    <TextBlock x:Uid="ConnectionStatusWindow_PasteASetupCode" Text="Paste a setup code to connect end-to-end." FontSize="10.5"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                    <TextBox x:Name="SetupCodeBox" PlaceholderText="Paste setup code…" FontSize="11"
+                    <TextBox x:Uid="ConnectionStatusWindow_PasteSetupCode" x:Name="SetupCodeBox" PlaceholderText="Paste setup code…" FontSize="11"
                              TextChanged="OnSetupCodeChanged"/>
                     <TextBlock x:Name="SetupCodePreview" FontFamily="Consolas" FontSize="10"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap"/>
@@ -97,20 +97,20 @@
                         </Grid.ColumnDefinitions>
                         <TextBlock x:Name="SetupCodeResult" Grid.Column="0" FontSize="10.5"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}" VerticalAlignment="Center"/>
-                        <Button Grid.Column="1" x:Name="ConnectButton" Content="Connect" Click="OnConnect" Padding="8,3" FontSize="11"/>
-                        <Button Grid.Column="2" x:Name="DisconnectBtn" Content="Disconnect" Click="OnDisconnectClick" Padding="8,3" FontSize="11"/>
+                        <Button x:Uid="ConnectionStatusWindow_Connect" Grid.Column="1" x:Name="ConnectButton" Content="Connect" Click="OnConnect" Padding="8,3" FontSize="11"/>
+                        <Button x:Uid="ConnectionStatusWindow_Disconnect" Grid.Column="2" x:Name="DisconnectBtn" Content="Disconnect" Click="OnDisconnectClick" Padding="8,3" FontSize="11"/>
                     </Grid>
                 </StackPanel>
             </Border>
 
             <!-- Direct Connect (URL + Token) -->
-            <TextBlock Text="DIRECT CONNECT" FontWeight="Bold" FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="0,8,0,4" CharacterSpacing="100"/>
+            <TextBlock x:Uid="ConnectionStatusWindow_DIRECTCONNECT" Text="DIRECT CONNECT" FontWeight="Bold" FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Margin="0,8,0,4" CharacterSpacing="100"/>
             <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="6" Padding="10">
                 <StackPanel Spacing="6">
-                    <TextBlock Text="Connect with a gateway URL and shared token (admin scope)." FontSize="10.5"
+                    <TextBlock x:Uid="ConnectionStatusWindow_ConnectWithAGateway" Text="Connect with a gateway URL and shared token (admin scope)." FontSize="10.5"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                    <TextBox x:Name="DirectUrlBox" PlaceholderText="ws://localhost:18790" Text="ws://localhost:18790" FontSize="11" Header="Gateway URL"/>
-                    <TextBox x:Name="DirectTokenBox" PlaceholderText="Shared gateway token" FontSize="11" Header="Token"/>
+                    <TextBox x:Uid="ConnectionStatusWindow_WsLocalhost18790" x:Name="DirectUrlBox" PlaceholderText="ws://localhost:18790" Text="ws://localhost:18790" FontSize="11" Header="Gateway URL"/>
+                    <TextBox x:Uid="ConnectionStatusWindow_SharedGatewayToken" x:Name="DirectTokenBox" PlaceholderText="Shared gateway token" FontSize="11" Header="Token"/>
                     <Grid ColumnSpacing="6">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
@@ -118,12 +118,12 @@
                         </Grid.ColumnDefinitions>
                         <TextBlock x:Name="DirectConnectResult" Grid.Column="0" FontSize="10.5"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}" VerticalAlignment="Center"/>
-                        <Button Grid.Column="1" Content="Connect" Click="OnDirectConnect" Padding="8,3" FontSize="11"
+                        <Button x:Uid="ConnectionStatusWindow_Connect2" Grid.Column="1" Content="Connect" Click="OnDirectConnect" Padding="8,3" FontSize="11"
                                 Style="{ThemeResource AccentButtonStyle}"/>
                     </Grid>
 
                     <!-- SSH Tunnel -->
-                    <ToggleSwitch x:Name="DiagSshToggle" Header="SSH Tunnel" FontSize="11" Margin="0,4,0,0"
+                    <ToggleSwitch x:Uid="ConnectionStatusWindow_SSHTunnel" x:Name="DiagSshToggle" Header="SSH Tunnel" FontSize="11" Margin="0,4,0,0"
                                   Toggled="OnDiagSshToggled"/>
                     <StackPanel x:Name="DiagSshDetailsPanel" Spacing="4" Visibility="Collapsed">
                         <Grid ColumnSpacing="6">
@@ -131,16 +131,16 @@
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <TextBox x:Name="DiagSshUserBox" Grid.Column="0" Header="SSH User" PlaceholderText="user" FontSize="11"/>
-                            <TextBox x:Name="DiagSshHostBox" Grid.Column="1" Header="SSH Host" PlaceholderText="192.168.x.x" FontSize="11"/>
+                            <TextBox x:Uid="ConnectionStatusWindow_SSHUser" x:Name="DiagSshUserBox" Grid.Column="0" Header="SSH User" PlaceholderText="user" FontSize="11"/>
+                            <TextBox x:Uid="ConnectionStatusWindow_SSHHost" x:Name="DiagSshHostBox" Grid.Column="1" Header="SSH Host" PlaceholderText="192.168.x.x" FontSize="11"/>
                         </Grid>
                         <Grid ColumnSpacing="6">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <TextBox x:Name="DiagSshRemotePortBox" Grid.Column="0" Header="Remote Port" PlaceholderText="18789" Text="18789" FontSize="11"/>
-                            <TextBox x:Name="DiagSshLocalPortBox" Grid.Column="1" Header="Local Port" PlaceholderText="18790" Text="18790" FontSize="11"/>
+                            <TextBox x:Uid="ConnectionStatusWindow_RemotePort" x:Name="DiagSshRemotePortBox" Grid.Column="0" Header="Remote Port" PlaceholderText="18789" Text="18789" FontSize="11"/>
+                            <TextBox x:Uid="ConnectionStatusWindow_LocalPort" x:Name="DiagSshLocalPortBox" Grid.Column="1" Header="Local Port" PlaceholderText="18790" Text="18790" FontSize="11"/>
                         </Grid>
                     </StackPanel>
                 </StackPanel>
@@ -160,9 +160,9 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0" Text="EVENT TIMELINE" FontWeight="Bold" FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" VerticalAlignment="Center" CharacterSpacing="100"/>
-                <Button Grid.Column="1" Content="Copy" Click="OnCopyTimeline" Margin="0,0,4,0" Padding="6,2" FontSize="11"/>
-                <Button Grid.Column="2" Content="Clear" Click="OnClearTimeline" Padding="6,2" FontSize="11"/>
+                <TextBlock x:Uid="ConnectionStatusWindow_EVENTTIMELINE" Grid.Column="0" Text="EVENT TIMELINE" FontWeight="Bold" FontSize="11" Foreground="{ThemeResource TextFillColorSecondaryBrush}" VerticalAlignment="Center" CharacterSpacing="100"/>
+                <Button x:Uid="ConnectionStatusWindow_Copy" Grid.Column="1" Content="Copy" Click="OnCopyTimeline" Margin="0,0,4,0" Padding="6,2" FontSize="11"/>
+                <Button x:Uid="ConnectionStatusWindow_Clear" Grid.Column="2" Content="Clear" Click="OnClearTimeline" Padding="6,2" FontSize="11"/>
             </Grid>
             <ScrollViewer Grid.Row="1" x:Name="TimelineScroll"
                           Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" CornerRadius="6" Padding="10"

--- a/src/OpenClaw.Tray.WinUI/Windows/DiagnosticsBundleDialog.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/DiagnosticsBundleDialog.xaml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ContentDialog
+<ContentDialog x:Uid="DiagnosticsBundleDialog_DiagnosticsBundle"
     x:Class="OpenClawTray.Windows.DiagnosticsBundleDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -17,7 +17,7 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <InfoBar
+        <InfoBar x:Uid="DiagnosticsBundleDialog_ReviewBeforeSharing"
             Grid.Row="0"
             IsOpen="True"
             IsClosable="False"

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
@@ -62,19 +62,19 @@
                         Tapped="OnTitleBarStatusTapped">
                 <StackPanel Orientation="Horizontal" Spacing="6">
                     <Ellipse x:Name="TitleStatusDot" Width="8" Height="8" VerticalAlignment="Center" Fill="Gray"/>
-                    <TextBlock x:Name="TitleStatusText" Text="Disconnected"
+                    <TextBlock x:Uid="HubWindow_Disconnected" x:Name="TitleStatusText" Text="Disconnected"
                                FontSize="11" VerticalAlignment="Center" MinWidth="80"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                 </StackPanel>
                 <Border Background="{ThemeResource DividerStrokeColorDefaultBrush}" Width="1" Height="14" VerticalAlignment="Center"/>
                 <StackPanel Orientation="Horizontal" Spacing="4">
                     <Ellipse x:Name="TitleOpDot" Width="6" Height="6" VerticalAlignment="Center" Fill="Gray"/>
-                    <TextBlock x:Name="TitleOpLabel" Text="Op" FontSize="10" VerticalAlignment="Center"
+                    <TextBlock x:Uid="HubWindow_Op" x:Name="TitleOpLabel" Text="Op" FontSize="10" VerticalAlignment="Center"
                                Foreground="{ThemeResource TextFillColorTertiaryBrush}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Spacing="4">
                     <Ellipse x:Name="TitleNodeDot" Width="6" Height="6" VerticalAlignment="Center" Fill="Gray"/>
-                    <TextBlock x:Name="TitleNodeLabel" Text="Node" FontSize="10" VerticalAlignment="Center"
+                    <TextBlock x:Uid="HubWindow_Node" x:Name="TitleNodeLabel" Text="Node" FontSize="10" VerticalAlignment="Center"
                                Foreground="{ThemeResource TextFillColorTertiaryBrush}"/>
                 </StackPanel>
             </StackPanel>
@@ -150,7 +150,7 @@
                 <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Instances_Icon}"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <!-- Advanced — consolidates gateway-oriented pages -->
-            <NavigationViewItem x:Name="NavAdvanced" Content="Advanced" SelectsOnInvoked="False">
+            <NavigationViewItem x:Uid="HubWindow_Advanced" x:Name="NavAdvanced" Content="Advanced" SelectsOnInvoked="False">
                 <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Advanced_Icon}"/></NavigationViewItem.Icon>
                 <NavigationViewItem.MenuItems>
                     <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_94" Tag="agentevents" Content="Agent Events">

--- a/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
@@ -146,6 +146,29 @@ public class LocalizationValidationTests
         "ConnectionPage_NodePairing_Subtitle.Text",
         "AboutPage_MoreDiagnosticsLink.Content",
         "ConnectionStatusWindow.Title",
+        // Hard-coded XAML strings resolved by issue #491 — seeded English-only across
+        // all 5 locales using the deferred-translation pattern. Translations are a
+        // follow-up tracked separately. Same precedent as the PermissionsPage and
+        // InstancesPage runtime keys above.
+        "ConnectionPage_GatewayURL.PlaceholderText",
+        "ConnectionPage_SSHHost.PlaceholderText",
+        "ConnectionPage_SSHUser.PlaceholderText",
+        "ConnectionStatusWindow_SSHHost.PlaceholderText",
+        "ConnectionStatusWindow_SSHUser.PlaceholderText",
+        "ConnectionStatusWindow_WsLocalhost18790.PlaceholderText",
+        "ConnectionStatusWindow_WsLocalhost18790.Text",
+        "CronPage_AmericaChicago.Content",
+        "CronPage_AmericaDenver.Content",
+        "CronPage_AmericaLosAngeles.Content",
+        "CronPage_AmericaNewYork.Content",
+        "CronPage_AsiaTokyo.Content",
+        "CronPage_EuropeBerlin.Content",
+        "CronPage_EuropeLondon.Content",
+        "CronPage_UTC.Content",
+        "SandboxPage_16MiB.Content",
+        "SandboxPage_1MiB.Content",
+        "SandboxPage_64MiB.Content",
+        "SandboxPage_SystemRun.Text",
     };
 
     private static readonly string[] RequiredRuntimeOnboardingKeys =


### PR DESCRIPTION
Adds `x:Uid` and `Resources.resw` entries for **305 previously hard-coded strings** spanning 13 Pages and 4 Windows, then translates 286 user-facing keys into `fr-fr`, `nl-nl`, `zh-cn`, `zh-tw`.

## Per the issue #491 checklist

| # | Instruction | Status |
|---|---|---|
| 1 | Add `x:Uid` to each flagged element | ✅ |
| 2 | Add resource keys to every locale file | ✅ |
| 3 | Preserve `{0}`-style placeholders | ✅ (none in flagged set) |
| 4 | Leave protocol IDs / URLs / brand unchanged | ✅ — 19 invariants (`system.run`, `ws://…`, `192.168.x.x`, timezone IDs, `user`, `machine-name`, MiB units) seeded English in all 5 locales and registered in `InvariantOrDeferredResourceKeys` |
| 5 | Re-run audit (`-StrictHardcodedXaml`) + full test suite | ✅ |
| 6 | Provide translations for nl-nl / fr-fr / zh-tw / zh-cn | ✅ — 286 keys × 4 locales = 1,144 translations |

## Scope

Coverage was extended slightly beyond the 8 pages in the original audit because additional XAML files have been added since the issue was filed (Sessions/Settings/Skills/Usage/VoiceSettings/Workspace pages and ChatWindow / ConnectionStatusWindow / DiagnosticsBundleDialog / HubWindow).

## Validation

- `pwsh .\scripts\Test-Localization.ps1 -StrictHardcodedXaml` → **zero warnings**
- `./build.ps1` → all 4 projects built
- Shared tests → **1891 passed**, 29 skipped, 0 failed
- Tray tests → **1178 passed**, 0 failed (incl. all 10 `LocalizationValidationTests`)

## Notes

Translations are model-authored. Each is a one-line edit in the corresponding `Resources.resw` for any native-speaker corrections.

Closes #491