### PR TITLE
feat: exec approvals store write path and coordinator side effects

### DIFF
--- a/src/OpenClaw.Shared/ExecApprovals/CanonicalCommandIdentity.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/CanonicalCommandIdentity.cs
@@ -2,36 +2,36 @@ using System.Collections.Generic;
 
 namespace OpenClaw.Shared.ExecApprovals;
 
-// Architectural barrier produced by PR3.
+// Architectural barrier between raw requests and the evaluation pipeline.
 // Equivalent to ExecHostValidatedRequest in the macOS reference, extended with resolution outputs.
-// No module from PR4 onward may accept ValidatedRunRequest as direct input (research doc 05 line 439).
-// Rail 15: a single canonical representation reused across evaluation, logging, prompting, execution.
+// No evaluation module may accept ValidatedRunRequest as direct input — this is the canonical handoff type.
+// A single canonical representation reused across evaluation, logging, prompting, and execution.
 public sealed class CanonicalCommandIdentity
 {
     // ── Normalization outputs ─────────────────────────────────────────────────
 
-    // Argv exactly as produced by PR2 (no trimming; coding contract process-argv-semantics).
+    // Argv as received from the normalizer (no trimming; callers must not modify).
     public IReadOnlyList<string> Command { get; }
 
     // Canonical display form generated from argv. Never rawCommand from the agent.
-    // Used by logging and prompting. Research doc 05 decision 2.
+    // Used by logging and prompting.
     public string DisplayCommand { get; }
 
     // Safe rawCommand for executable resolution. Null in Windows v1 (rawCommand not in
-    // system.run protocol; research doc 05 OQ-V4 / decision 10).
+    // the system.run protocol).
     public string? EvaluationRawCommand { get; }
 
     // ── Resolution outputs ────────────────────────────────────────────────────
 
-    // Singular resolution for the state machine (PR5).
+    // Singular resolution for the state machine.
     // Null if the primary executable cannot be determined.
     public ExecCommandResolution? Resolution { get; }
 
-    // Per-segment resolutions for the allowlist matcher (PR4/PR5).
+    // Per-segment resolutions for the allowlist matcher.
     // Empty list means fail-closed — no allowlist satisfaction possible.
     public IReadOnlyList<ExecCommandResolution> AllowlistResolutions { get; }
 
-    // Suggested allowlist patterns for prompt/UI (PR6). Not a security decision.
+    // Suggested allowlist patterns for prompt/UI. Not a security decision.
     public IReadOnlyList<string> AllowAlwaysPatterns { get; }
 
     // ── Request context (carried from ValidatedRunRequest) ────────────────────

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalEvaluation.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalEvaluation.cs
@@ -4,9 +4,9 @@ using System.Collections.Generic;
 namespace OpenClaw.Shared.ExecApprovals;
 
 // Aggregated evaluation context passed to the stateless evaluator.
-// Shape mirrors macOS ExecApprovalEvaluation struct (research doc 06).
+// Shape mirrors macOS ExecApprovalEvaluation struct.
 // Derived fields are computed once in the constructor and must not be recomputed by callers.
-// Research doc 06 stable conclusion 3: construction belongs to the coordinator (PR7), not the evaluator.
+// Construction belongs to the coordinator, not the evaluator.
 public sealed class ExecApprovalEvaluation
 {
     public IReadOnlyList<string> Command { get; }
@@ -17,7 +17,7 @@ public sealed class ExecApprovalEvaluation
     public IReadOnlyDictionary<string, string>? Env { get; }
 
     // Singular resolution — AllowlistResolutions[0], or null if the list is empty.
-    // Research doc 06: "resolution = allowlistResolutions.first" (not an independent call).
+    // Always the first element of AllowlistResolutions, not an independent resolver call.
     public ExecCommandResolution? Resolution { get; }
 
     public IReadOnlyList<ExecCommandResolution> AllowlistResolutions { get; }
@@ -25,11 +25,11 @@ public sealed class ExecApprovalEvaluation
     public IReadOnlyList<ExecAllowlistEntry> AllowlistMatches { get; }
 
     // true iff security==allowlist && resolutions.Count>0 && matches.Count==resolutions.Count.
-    // Research doc 06 derivation rule — must not be re-derived outside the constructor.
+    // Derived once in the constructor — must not be re-derived outside it.
     public bool AllowlistSatisfied { get; }
 
     // First match when AllowlistSatisfied; null otherwise.
-    // Research doc 06 R5: AllowlistMatch must be null when AllowlistSatisfied is false.
+    // Must be null when AllowlistSatisfied is false.
     public ExecAllowlistEntry? AllowlistMatch { get; }
 
     // Always false in v1. Kept as part of the conceptual model; activation deferred.

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2InputValidator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2InputValidator.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 namespace OpenClaw.Shared.ExecApprovals;
 
 /// <summary>
-/// Phase 1 of the V2 exec approval pipeline: structural input validation (rail 18, step 1).
+/// Phase 1 of the V2 exec approval pipeline: structural input validation.
 /// Parses a raw NodeInvokeRequest into a ValidatedRunRequest or returns validation-failed.
 /// Does not resolve executables, detect shell wrappers, or evaluate policy.
 /// </summary>

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2NormalizationStep.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2NormalizationStep.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 namespace OpenClaw.Shared.ExecApprovals;
 
 // Either a CanonicalCommandIdentity (IsResolved=true) or a typed denial (IsResolved=false).
-// Produced by ExecApprovalV2Normalizer; consumed by the coordinator pipeline (PR7).
+// Produced by ExecApprovalV2Normalizer; consumed by the coordinator pipeline.
 public sealed class ExecApprovalV2NormalizationOutcome
 {
     public bool IsResolved { get; }
@@ -29,7 +29,7 @@ public sealed class ExecApprovalV2NormalizationOutcome
         => new(error);
 }
 
-// Rail 18 steps 2-4: normalize command form → resolve executable → build canonical identity.
+// Steps 2-4 of the approval pipeline: normalize command form → resolve executable → build canonical identity.
 // Stateless — safe to call concurrently.
 public static class ExecApprovalV2Normalizer
 {
@@ -39,10 +39,10 @@ public static class ExecApprovalV2Normalizer
         var cwd = request.Cwd;
         var env = request.Env as IReadOnlyDictionary<string, string>;
 
-        // displayCommand is always derived from argv, never from rawCommand (research doc 05 decision 2).
+        // displayCommand is always derived from argv, never from rawCommand.
         var displayCommand = ShellQuoting.FormatExecCommand(argv);
 
-        // rawCommand is null in Windows v1 (system.run does not carry it; research doc 05 OQ-V4).
+        // rawCommand is null in Windows v1 (system.run does not carry it).
         // EvaluationRawCommand stays null — correct and documented conservative output.
         string? evaluationRawCommand = null;
 
@@ -50,7 +50,7 @@ public static class ExecApprovalV2Normalizer
         var resolution = ExecCommandResolver.Resolve(argv, cwd, env);
 
         // Multi-segment resolution for allowlist.
-        // Empty list is fail-closed: no allowlist satisfaction possible (research doc 04 R2).
+        // Empty list is fail-closed: no allowlist satisfaction possible.
         // An empty list is NOT itself a denial at this step — the evaluator decides.
         var allowlistResolutions = ExecCommandResolver.ResolveForAllowlist(
             argv, evaluationRawCommand, cwd, env);
@@ -58,7 +58,7 @@ public static class ExecApprovalV2Normalizer
         // UX patterns for prompting.
         var allowAlwaysPatterns = ExecCommandResolver.ResolveAllowAlwaysPatterns(argv, cwd, env);
 
-        // Rail 6: if argv is non-empty but resolution is entirely impossible, deny.
+        // If argv is non-empty but resolution is entirely impossible, deny.
         // "Ambiguous or inconsistent" → typed deny, not silent allow.
         if (resolution is null && allowlistResolutions.Count == 0)
             return Fail("executable-resolution-failed");

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2NullHandler.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2NullHandler.cs
@@ -4,7 +4,7 @@ namespace OpenClaw.Shared.ExecApprovals;
 
 /// <summary>
 /// Default V2 handler: always returns <see cref="ExecApprovalV2Code.Unavailable"/>.
-/// Keeps the V2 path inert until a real handler is installed (rail 19).
+/// Keeps the V2 path inert until a real handler is installed.
 /// Never throws, never falls through to legacy.
 /// </summary>
 public sealed class ExecApprovalV2NullHandler : IExecApprovalV2Handler

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2Result.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2Result.cs
@@ -1,7 +1,7 @@
 namespace OpenClaw.Shared.ExecApprovals;
 
 /// <summary>
-/// Stable result codes for the V2 exec approval path (rail 7).
+/// Stable result codes for the V2 exec approval path.
 /// </summary>
 public enum ExecApprovalV2Code
 {

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
@@ -8,10 +8,10 @@ using OpenClaw.Shared;
 namespace OpenClaw.Shared.ExecApprovals;
 
 // Full coordinator pipeline: validate → normalize → buildContext → evaluate(pass1) →
-// prompt/fallback → [persistAllowlistEntry stub] → evaluate(pass2) → final decision.
-// Rail 10: no WinUI types. Rail 17: SemaphoreSlim serializes the prompt+pass2 block.
-// Rail 19: not wired in production src in PR7 — verified by test 15.
-// Must be registered as singleton when wired (PR8+): the SemaphoreSlim is per-instance.
+// prompt/fallback → evaluate(pass2) → side effects → final decision.
+// UI-free: no WinUI types. A SemaphoreSlim serializes the prompt+pass2 block.
+// Not wired in production src — verified by ProductionWiring_CoordinatorNotReferencedInSrc test.
+// Must be registered as singleton when wired: the SemaphoreSlim is per-instance.
 public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
 {
     private readonly ExecApprovalsStore _store;
@@ -19,7 +19,7 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
     private readonly IExecApprovalV2PromptHandler _prompt;
     private readonly IOpenClawLogger _logger;
 
-    // Serializes the prompt call + second-pass block (rail 17).
+    // Serializes the prompt call + second-pass block.
     // Does NOT protect validate/normalize/buildContext — those are stateless.
     private readonly SemaphoreSlim _promptLock = new(1, 1);
 
@@ -90,14 +90,16 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
             identity.AllowAlwaysPatterns,
             matches);
 
-        // Step 4: first pass (approvalDecision always null in PR7 — CVE #8682, ADR-0002 Phase 2)
+        // Step 4: first pass (approvalDecision always null — pass2 decides based on user response)
         var pass1 = ExecApprovalEvaluator.Evaluate(context, null);
         if (pass1 is ExecHostPolicyDecision.DenyOutcome denyPass1)
             return LogAndReturn(denyPass1.Error, correlationId,
                 promptAttempted: false, fallbackUsed: false, canonical: context.DisplayCommand);
         if (pass1 is ExecHostPolicyDecision.AllowOutcome)
         {
-            // Pre-approved path (security=Full, ask=Off or allowlist satisfied): skip prompt
+            // Pre-approved path (security=Full, ask=Off or allowlist satisfied): skip prompt.
+            // Side effects fire before the log line, after the final allow decision is confirmed.
+            await RecordAllowlistUsageAsync(context).ConfigureAwait(false);
             _logger.Info($"[EXEC-APPROVALS] [{correlationId}] path=new " +
                 $"canonical=\"{SanitizeForLog(context.DisplayCommand)}\" decision=allow " +
                 $"reason=approved fallbackUsed=false promptAttempted=false");
@@ -105,9 +107,10 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
         }
         // RequiresPromptOutcome → continue to prompt/fallback block
 
-        // Steps 5-7: prompt/fallback + second pass (critical section)
+        // Steps 5-8: prompt/fallback + second pass (critical section) + side effect flag
         bool promptAttempted = false;
         bool fallbackUsed = false;
+        bool persistAllowlistEntry = false;
 
         await _promptLock.WaitAsync().ConfigureAwait(false);
         try
@@ -159,8 +162,6 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
                 followupDecision = FallbackDecision(context, resolved.Defaults.AskFallback);
             }
 
-            // Step 6: AddAllowlistEntry stub (PR9 implements for AllowAlways + security==Allowlist)
-
             // Step 7: second pass — must never return RequiresPrompt
             var pass2 = ExecApprovalEvaluator.Evaluate(context, followupDecision);
             if (pass2 is ExecHostPolicyDecision.DenyOutcome denyPass2)
@@ -173,14 +174,18 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
                 return LogAndReturn(ExecApprovalV2Result.InternalError("second-pass-requires-prompt"),
                     correlationId, promptAttempted, fallbackUsed, canonical: context.DisplayCommand);
             }
-            // AllowOutcome → fall through to steps 8-10
+            // pass2 is AllowOutcome — record whether AllowAlways was the prompt decision.
+            persistAllowlistEntry = followupDecision == ExecApprovalDecision.AllowAlways;
         }
         finally
         {
             _promptLock.Release();
         }
 
-        // Step 8: RecordAllowlistUse stub (PR9)
+        // Step 8: side effects — strictly after the final allow decision.
+        if (persistAllowlistEntry && context.Security == ExecSecurity.Allowlist)
+            await PersistAllowlistEntriesAsync(context).ConfigureAwait(false);
+        await RecordAllowlistUsageAsync(context).ConfigureAwait(false);
 
         // Step 9: final allow log
         _logger.Info($"[EXEC-APPROVALS] [{correlationId}] path=new " +
@@ -194,12 +199,43 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
         {
             // Outer safety net: any unhandled exception in buildContext, CanPresent, FallbackDecision,
             // or an out-of-range prompt outcome produces a typed deny instead of escaping HandleAsync.
-            // Rail 1: failures in the new path must never be silent or untyped.
+            // Failures must never be silent or untyped.
             var msg = $"[EXEC-APPROVALS] [{correlationId}] path=new " +
                 $"canonical=\"\" decision=deny reason=unexpected-exception " +
                 $"fallbackUsed=false promptAttempted=false";
             _logger.Error(msg, ex);
             return ExecApprovalV2Result.InternalError("unexpected-exception");
+        }
+    }
+
+    // Persists allowAlways patterns after an AllowAlways prompt decision (non-empty only).
+    // Caller guarantees Security == Allowlist (guard is in HandleAsync step 8).
+    private async Task PersistAllowlistEntriesAsync(ExecApprovalEvaluation context)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pattern in context.AllowAlwaysPatterns)
+        {
+            if (string.IsNullOrWhiteSpace(pattern) || !seen.Add(pattern)) continue;
+            await _store.AddAllowlistEntryAsync(context.AgentId, pattern).ConfigureAwait(false);
+        }
+    }
+
+    // Updates lastUsed* metadata for every matched allowlist entry after a final allow.
+    // Guard mirrors macOS recordAllowlistMatches: no-op unless security=allowlist and satisfied.
+    private async Task RecordAllowlistUsageAsync(ExecApprovalEvaluation context)
+    {
+        if (context.Security != ExecSecurity.Allowlist || !context.AllowlistSatisfied) return;
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < context.AllowlistMatches.Count; i++)
+        {
+            var pattern = context.AllowlistMatches[i].Pattern;
+            if (string.IsNullOrEmpty(pattern) || !seen.Add(pattern)) continue;
+            var resolvedPath = i < context.AllowlistResolutions.Count
+                ? context.AllowlistResolutions[i].ResolvedPath
+                : null;
+            await _store.RecordAllowlistUseAsync(
+                context.AgentId, pattern, context.DisplayCommand, resolvedPath)
+                .ConfigureAwait(false);
         }
     }
 
@@ -227,7 +263,7 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
         string correlationId)
         => new()
         {
-            DisplayCommand = context.DisplayCommand,  // NOT sanitized — presenter's responsibility (rail 11)
+            DisplayCommand = context.DisplayCommand,  // NOT sanitized — presenter's responsibility
             Cwd = identity.Cwd,
             Security = context.Security,
             Ask = context.Ask,
@@ -235,7 +271,7 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
             ResolvedPath = context.Resolution?.ResolvedPath,
             SessionKey = identity.SessionKey,
             CorrelationId = correlationId,
-            // Host omitted in PR7 (no gateway wiring yet)
+            // Host omitted (no gateway wiring yet)
         };
 
     // Anti log-injection: replaces control characters in DisplayCommand before writing to logs.

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsStore.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsStore.cs
@@ -10,7 +10,7 @@ using System.Text.Json.Serialization;
 namespace OpenClaw.Shared.ExecApprovals;
 
 // New store for exec-approvals.json. Separate from legacy ExecApprovalPolicy (exec-policy.json).
-// PR4 scope: read path only. Write path (recordAllowlistUse) is added in PR9.
+// Read path: ResolveReadOnly, LoadFile, EnsureFileAsync. Write path: AddAllowlistEntryAsync, RecordAllowlistUseAsync.
 public sealed class ExecApprovalsStore
 {
     // KebabCaseLower covers all macOS enum values: deny, allowlist, full, off, on-miss, always,
@@ -44,13 +44,82 @@ public sealed class ExecApprovalsStore
 
     // ── Public API ────────────────────────────────────────────────────────────
 
-    // No side effects; does not create the file. Used by the evaluator (PR5).
+    // No side effects; does not create the file.
     public ExecApprovalsResolved ResolveReadOnly(string? agentId)
     {
         var result = LoadFile();
         return result.Status != LoadFileStatus.Loaded || result.File is null
             ? DefaultResolved(NormalizeAgentId(agentId))
             : ResolveFromFile(result.File, agentId);
+    }
+
+    // Adds a new allowlist entry for the agent. Best-effort: never throws.
+    // Returns true if the entry is present after the call (added or already there),
+    // false if the pattern was empty or the write was skipped/failed.
+    // Pattern validation is non-empty only — parity with macOS.
+    public async Task<bool> AddAllowlistEntryAsync(string? agentId, string pattern)
+    {
+        var trimmed = pattern?.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            _logger.Debug("[EXEC-APPROVALS] AddAllowlistEntry skipped: empty pattern");
+            return false;
+        }
+        var key = NormalizeAgentId(agentId);
+        bool alreadyPresent = false;
+        var wrote = await UpdateFileAsync(file =>
+        {
+            var agents = file.Agents!;
+            if (!agents.TryGetValue(key, out var agent) || agent is null)
+            {
+                agent = new ExecApprovalsAgent();
+                agents[key] = agent;
+            }
+            var allowlist = agent.Allowlist ??= [];
+            // Dedup case-insensitive — consistent with NormalizeAllowlistEntries (OrdinalIgnoreCase HashSet).
+            if (allowlist.Any(e => string.Equals(
+                    e.Pattern?.Trim(), trimmed, StringComparison.OrdinalIgnoreCase)))
+            {
+                alreadyPresent = true;
+                return false;
+            }
+            allowlist.Add(new ExecAllowlistEntry
+            {
+                Id = Guid.NewGuid(),  // parity with macOS UUID()
+                Pattern = trimmed,
+                // LastUsedAt intentionally absent: macOS addAllowlistEntry only sets {id, pattern}.
+                // RecordAllowlistUseAsync stamps it on first successful use.
+            });
+            return true;
+        }).ConfigureAwait(false);
+        return wrote || alreadyPresent;
+    }
+
+    // Updates lastUsed* metadata for every allowlist entry whose pattern matches.
+    // Best-effort: never throws. No-op if the agent or pattern is not found.
+    // Returns true if at least one entry was updated and saved; false otherwise.
+    public Task<bool> RecordAllowlistUseAsync(
+        string? agentId, string pattern, string command, string? resolvedPath)
+    {
+        if (string.IsNullOrEmpty(pattern)) return Task.FromResult(false);
+        var key = NormalizeAgentId(agentId);
+        return UpdateFileAsync(file =>
+        {
+            if (!file.Agents!.TryGetValue(key, out var agent) || agent?.Allowlist is null)
+                return false;
+            var changed = false;
+            foreach (var entry in agent.Allowlist)
+            {
+                if (!string.Equals(entry.Pattern?.Trim(), pattern.Trim(),
+                        StringComparison.OrdinalIgnoreCase))
+                    continue;
+                entry.LastUsedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                entry.LastUsedCommand = command;        // STJ escapes control chars on serialize
+                entry.LastResolvedPath = resolvedPath;  // Id and Pattern preserved
+                changed = true;
+            }
+            return changed;
+        });
     }
 
     // Side-effecting resolve: creates the file if missing, initializes agents dict.
@@ -129,7 +198,7 @@ public sealed class ExecApprovalsStore
             return new ExecApprovalsFile { Version = 1, Agents = [] };
         }
 
-        // socket intentionally omitted in Windows v1 (research doc 02 decision 3).
+        // socket intentionally omitted in Windows v1.
         var newFile = new ExecApprovalsFile { Version = 1, Agents = [] };
         await SaveFileAsync(newFile).ConfigureAwait(false);
         _logger.Info($"[EXEC-APPROVALS] Created {_filePath}");
@@ -154,6 +223,46 @@ public sealed class ExecApprovalsStore
             _logger.Error($"[EXEC-APPROVALS] Failed to save {_filePath} ({ex.Message})");
             try { if (File.Exists(tmp)) File.Delete(tmp); } catch { }
             throw;
+        }
+    }
+
+    // Best-effort mutate-and-save. Serialized by the store lock.
+    // Never throws. Refuses to overwrite a malformed file.
+    // Returns true if the file was mutated and saved; false if the mutate was a no-op,
+    // the file was malformed/invalid, or any I/O failure occurred.
+    private async Task<bool> UpdateFileAsync(Func<ExecApprovalsFile, bool> mutate)
+    {
+        await _lock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            var result = LoadFile();
+            if (result.Status == LoadFileStatus.Invalid)
+            {
+                _logger.Warn("[EXEC-APPROVALS] Refusing to write exec-approvals.json: "
+                    + "file is malformed or has an unsupported version");
+                return false;
+            }
+            var file = result.Status == LoadFileStatus.Loaded && result.File is not null
+                ? result.File
+                : new ExecApprovalsFile { Version = 1, Agents = [] };
+            file.Agents ??= new Dictionary<string, ExecApprovalsAgent>();
+
+            if (!mutate(file)) return false; // no-op: nothing to persist
+
+            await SaveFileAsync(file).ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            // Any failure (incl. transient IOException on the atomic move) degrades to a
+            // logged warning. The atomic write guarantees the file on disk is never left corrupt.
+            _logger.Warn($"[EXEC-APPROVALS] exec-approvals.json write failed "
+                + $"({ex.Message}); side effect skipped");
+            return false;
+        }
+        finally
+        {
+            _lock.Release();
         }
     }
 
@@ -239,7 +348,7 @@ public sealed class ExecApprovalsStore
     // Mirrors macOS normalizeAllowlistEntries.
     // dropInvalid=false: discard only null/empty patterns; keep non-empty ones regardless of validity.
     // dropInvalid=true: same in v1 — pattern validity beyond non-empty is enforced by the allowlist
-    //   matcher in PR5, not here. The flag is preserved for API symmetry with macOS.
+    //   matcher, not here. The flag is preserved for API symmetry with macOS.
     internal static List<ExecAllowlistEntry> NormalizeAllowlistEntries(
         IEnumerable<ExecAllowlistEntry> entries, bool dropInvalid)
     {

--- a/src/OpenClaw.Shared/ExecApprovals/ExecCommandResolution.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecCommandResolution.cs
@@ -69,7 +69,7 @@ internal static class ExecCommandResolver
             {
                 var token = ParseFirstToken(segment);
                 if (token is null) return [];
-                // -EncodedCommand and aliases in segment position: fail-closed (research doc 04 S1).
+                // -EncodedCommand and aliases in segment position: fail-closed.
                 if (SegmentUsesEncodedCommand(segment, token)) return [];
                 var res = ResolveExecutable(token, cwd, env);
                 if (res is null) return [];
@@ -494,7 +494,7 @@ internal static class ExecCommandResolver
     private static string TryNormalizePath(string path)
     {
         // GetFullPath resolves . and .. but does not expand 8.3 short names.
-        // Full GetLongPathName P/Invoke is left as OQ-R1 in the research docs.
+        // Full GetLongPathName P/Invoke is a known gap — short names not expanded.
         try { return Path.GetFullPath(path); }
         catch { return path; } // hostile path must not throw out of resolution
     }

--- a/src/OpenClaw.Shared/ExecApprovals/ExecShellWrapperNormalizer.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecShellWrapperNormalizer.cs
@@ -7,7 +7,7 @@ namespace OpenClaw.Shared.ExecApprovals;
 // Differs from the legacy ExecShellWrapperParser.Expand (BFS multi-level, string-based).
 // This normalizer operates on argv (IReadOnlyList<string>) and performs one level of
 // wrapper detection, with recursive env-prefix unwrapping up to MaxWrapperDepth.
-// Rail 18 step 2: normalize command form.
+// Step 2 of the approval pipeline: normalize command form.
 internal static class ExecShellWrapperNormalizer
 {
     private enum WrapperKind { Posix, Cmd, PowerShell }
@@ -35,7 +35,7 @@ internal static class ExecShellWrapperNormalizer
     internal static readonly ParsedWrapper NotWrapper = new(false, null);
 
     // Detects a single-level shell wrapper in argv.
-    // rawCommand is always null in Windows v1 (not in system.run protocol; research doc 05 OQ-V4).
+    // rawCommand is always null in Windows v1 (not in the system.run protocol).
     // Detection is on argv only; rawCommand is accepted for API compatibility with future use.
     internal static ParsedWrapper Extract(IReadOnlyList<string> command, string? rawCommand = null)
         => ExtractInner(command, rawCommand, 0);

--- a/src/OpenClaw.Shared/ExecApprovals/ICanPresentEvaluator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ICanPresentEvaluator.cs
@@ -1,20 +1,20 @@
 namespace OpenClaw.Shared.ExecApprovals;
 
 // Determines whether the coordinator can present a UI prompt for this request.
-// Doc 08 F1 lists four inputs to canPresent: requestSessionKey, activeSessionKey,
+// Four inputs to canPresent: requestSessionKey, activeSessionKey,
 // lastInputSeconds, desktopInteractive. Only requestSessionKey is passed by the
 // coordinator — the other three are encapsulated inside the implementation:
 //   activeSessionKey: provided by whatever tracks the active tray session.
-//   lastInputSeconds: read via Win32 GetLastInputInfo (OQ-F1).
-//   desktopInteractive: read via OpenInputDesktop / WTSQuerySessionInformation (OQ-F1).
-// Keeping these out of the interface keeps the coordinator UI-free (rail 10) and
+//   lastInputSeconds: read via Win32 GetLastInputInfo.
+//   desktopInteractive: read via OpenInputDesktop / WTSQuerySessionInformation.
+// Keeping these out of the interface keeps the coordinator UI-free and
 // testable without Win32. Must never throw — fail to false (no UI available).
 public interface ICanPresentEvaluator
 {
     bool CanPresent(string? requestSessionKey);
 }
 
-// Default for PR7: UI not wired yet. Everything routes to FallbackDecision.
+// Default: UI not wired. Everything routes to FallbackDecision.
 public sealed class AlwaysCannotPresentEvaluator : ICanPresentEvaluator
 {
     public static readonly AlwaysCannotPresentEvaluator Instance = new();

--- a/src/OpenClaw.Shared/ExecApprovals/IExecApprovalV2Handler.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/IExecApprovalV2Handler.cs
@@ -3,9 +3,9 @@ using System.Threading.Tasks;
 namespace OpenClaw.Shared.ExecApprovals;
 
 /// <summary>
-/// Seam for the V2 exec approval path (rail 10: UI-free, no WinUI types).
+/// Seam for the V2 exec approval path. Implementations must be UI-free (no WinUI types).
 /// Implementations decide whether a system.run request is allowed.
-/// In PR1 only the NullHandler exists; real evaluation arrives in later PRs.
+/// The NullHandler is the default; production wiring installs the real coordinator.
 /// </summary>
 public interface IExecApprovalV2Handler
 {

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
@@ -448,6 +448,151 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         Assert.Contains(log.Errors, e => e.Contains("unexpected-exception"));
     }
 
+    // ── PR8: allowlist persistence and use recording ──────────────────────────
+
+    // A. AllowAlways + security=allowlist → entry persisted in store.
+    [Fact]
+    public async Task AllowAlways_Allowlist_PersistsEntry()
+    {
+        WriteStoreFile("""{"version":1,"agents":{"main":{"security":"allowlist","ask":"always"}}}""");
+        var result = await MakeCoordinator(
+            canPresent: AlwaysCanPresentEvaluator.Instance,
+            prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.AllowAlways))
+            .HandleAsync(Req("""{"command":["cmd"]}"""), "pr8-A");
+
+        Assert.True(result.IsAllow);
+        var resolved = new ExecApprovalsStore(_dir, NullLogger.Instance).ResolveReadOnly("main");
+        Assert.Single(resolved.Allowlist);
+        Assert.NotNull(resolved.Allowlist[0].Pattern);
+        Assert.Contains("cmd", resolved.Allowlist[0].Pattern, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // B. AllowAlways + security=full → guard fails, no allowlist entry written.
+    [Fact]
+    public async Task AllowAlways_SecurityFull_DoesNotPersist()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always"}}""");
+        var result = await MakeCoordinator(
+            canPresent: AlwaysCanPresentEvaluator.Instance,
+            prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.AllowAlways))
+            .HandleAsync(Req("""{"command":["cmd"]}"""), "pr8-B");
+
+        Assert.True(result.IsAllow);
+        var json = File.ReadAllText(Path.Combine(_dir, "exec-approvals.json"));
+        Assert.DoesNotContain("allowlist", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // C. Pre-approved path (pass1 = Allow) → RecordAllowlistUse fires and updates LastUsedCommand.
+    [Fact]
+    public async Task AllowPreapproved_RecordsAllowlistUse()
+    {
+        WriteStoreFile("""
+        {
+          "version": 1,
+          "agents": {
+            "main": {
+              "security": "allowlist",
+              "ask": "off",
+              "allowlist": [{ "pattern": "**/cmd.exe" }]
+            }
+          }
+        }
+        """);
+        var result = await MakeCoordinator().HandleAsync(Req("""{"command":["cmd"]}"""), "pr8-C");
+
+        Assert.True(result.IsAllow);
+        var resolved = new ExecApprovalsStore(_dir, NullLogger.Instance).ResolveReadOnly("main");
+        Assert.Single(resolved.Allowlist);
+        Assert.NotNull(resolved.Allowlist[0].LastUsedCommand);
+    }
+
+    // D. AllowOnce → persistAllowlistEntry=false, no entry written.
+    [Fact]
+    public async Task AllowOnce_DoesNotPersistEntry()
+    {
+        WriteStoreFile("""{"version":1,"agents":{"main":{"security":"allowlist","ask":"always"}}}""");
+        var result = await MakeCoordinator(
+            canPresent: AlwaysCanPresentEvaluator.Instance,
+            prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.AllowOnce))
+            .HandleAsync(Req("""{"command":["cmd"]}"""), "pr8-D");
+
+        Assert.True(result.IsAllow);
+        var resolved = new ExecApprovalsStore(_dir, NullLogger.Instance).ResolveReadOnly("main");
+        Assert.Empty(resolved.Allowlist);
+    }
+
+    // E. AllowAlways called twice for the same command → exactly one entry (dedup in store).
+    [Fact]
+    public async Task AllowAlways_Idempotent_SingleEntry()
+    {
+        WriteStoreFile("""{"version":1,"agents":{"main":{"security":"allowlist","ask":"always"}}}""");
+        var coordinator = MakeCoordinator(
+            canPresent: AlwaysCanPresentEvaluator.Instance,
+            prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.AllowAlways));
+
+        await coordinator.HandleAsync(Req("""{"command":["cmd"]}"""), "pr8-E1");
+        await coordinator.HandleAsync(Req("""{"command":["cmd"]}"""), "pr8-E2");
+
+        var resolved = new ExecApprovalsStore(_dir, NullLogger.Instance).ResolveReadOnly("main");
+        Assert.Single(resolved.Allowlist);
+    }
+
+    // F. Prompt path (ask=always + AllowlistSatisfied=true + AllowOnce) →
+    //    RecordAllowlistUse fires in the post-pass2 branch (not just the pass1 branch).
+    [Fact]
+    public async Task AllowOnce_AllowlistSatisfied_RecordsUseInPostPass2Branch()
+    {
+        WriteStoreFile("""
+        {
+          "version": 1,
+          "agents": {
+            "main": {
+              "security": "allowlist",
+              "ask": "always",
+              "allowlist": [{ "pattern": "**/cmd.exe" }]
+            }
+          }
+        }
+        """);
+        var result = await MakeCoordinator(
+            canPresent: AlwaysCanPresentEvaluator.Instance,
+            prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.AllowOnce))
+            .HandleAsync(Req("""{"command":["cmd"]}"""), "pr8-F");
+
+        Assert.True(result.IsAllow);
+        var resolved = new ExecApprovalsStore(_dir, NullLogger.Instance).ResolveReadOnly("main");
+        Assert.Single(resolved.Allowlist);
+        Assert.NotNull(resolved.Allowlist[0].LastUsedCommand);
+    }
+
+    // G. Fallback path (canPresent=false) + AllowlistSatisfied=true → RecordAllowlistUse fires.
+    [Fact]
+    public async Task Fallback_AllowlistSatisfied_RecordsUse()
+    {
+        // askFallback=off → FallbackDecision=AllowOnce → pass2=Allow. AllowlistSatisfied=true
+        // because cmd.exe resolves and **/cmd.exe matches. RecordAllowlistUsageAsync must fire.
+        WriteStoreFile("""
+        {
+          "version": 1,
+          "agents": {
+            "main": {
+              "security": "allowlist",
+              "ask": "always",
+              "askFallback": "off",
+              "allowlist": [{ "pattern": "**/cmd.exe" }]
+            }
+          }
+        }
+        """);
+        // canPresent=false (default) → fallback path; askFallback=off → AllowOnce → Allow
+        var result = await MakeCoordinator().HandleAsync(Req("""{"command":["cmd"]}"""), "pr8-G");
+
+        Assert.True(result.IsAllow);
+        var resolved = new ExecApprovalsStore(_dir, NullLogger.Instance).ResolveReadOnly("main");
+        Assert.Single(resolved.Allowlist);
+        Assert.NotNull(resolved.Allowlist[0].LastUsedCommand);
+    }
+
     // ── Test doubles ──────────────────────────────────────────────────────────
 
     private sealed class FixedDecisionPromptHandler : IExecApprovalV2PromptHandler

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalsStoreTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalsStoreTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using OpenClaw.Shared;
@@ -710,6 +711,280 @@ public class ExecApprovalsStoreTests : IDisposable
         var defaults = new ExecApprovalsDefaults { AskFallback = ExecAsk.Deny };
         var json = JsonSerializer.Serialize(defaults, ExecApprovalsStore.JsonOptions);
         Assert.Contains("\"deny\"", json);
+    }
+
+    // ── Write path: AddAllowlistEntryAsync ───────────────────────────────────
+
+    [Fact]
+    public async Task AddAllowlistEntryAsync_ExistingFile_AddsEntryWithIdAndMetadata()
+    {
+        WriteFile(MinimalFile());
+        var store = Store();
+        var result = await store.AddAllowlistEntryAsync("main", "**/git.exe");
+
+        Assert.True(result);
+        var resolved = store.ResolveReadOnly("main");
+        Assert.Single(resolved.Allowlist);
+        var entry = resolved.Allowlist[0];
+        Assert.Equal("**/git.exe", entry.Pattern);
+        Assert.NotNull(entry.Id);
+        Assert.Null(entry.LastUsedAt); // macOS addAllowlistEntry: {id, pattern} only — no lastUsedAt on creation
+    }
+
+    [Fact]
+    public async Task AddAllowlistEntryAsync_DuplicatePattern_NotAddedCaseInsensitive()
+    {
+        WriteFile(MinimalFile());
+        var store = Store();
+        var first = await store.AddAllowlistEntryAsync("main", "**/git.exe");
+        var second = await store.AddAllowlistEntryAsync("main", "**/GIT.EXE");
+
+        Assert.True(first);
+        Assert.True(second); // already present → true
+        Assert.Single(store.ResolveReadOnly("main").Allowlist);
+    }
+
+    [Fact]
+    public async Task AddAllowlistEntryAsync_EmptyOrWhitespacePattern_ReturnsFalse()
+    {
+        WriteFile(MinimalFile());
+        var store = Store();
+
+        Assert.False(await store.AddAllowlistEntryAsync("main", ""));
+        Assert.False(await store.AddAllowlistEntryAsync("main", "   "));
+        Assert.Empty(store.ResolveReadOnly("main").Allowlist);
+    }
+
+    [Fact]
+    public async Task AddAllowlistEntryAsync_NoFile_CreatesFileWithEntry()
+    {
+        var store = Store();
+        var result = await store.AddAllowlistEntryAsync("main", "**/git.exe");
+
+        Assert.True(result);
+        Assert.True(File.Exists(FilePath));
+        var resolved = store.ResolveReadOnly("main");
+        Assert.Single(resolved.Allowlist);
+        Assert.Equal("**/git.exe", resolved.Allowlist[0].Pattern);
+    }
+
+    [Fact]
+    public async Task AddAllowlistEntryAsync_MalformedFile_RefusesToWriteAndWarns()
+    {
+        WriteFile("{ bad json }");
+        var original = File.ReadAllText(FilePath);
+        var store = Store();
+
+        var result = await store.AddAllowlistEntryAsync("main", "**/git.exe");
+
+        Assert.False(result);
+        Assert.Equal(original, File.ReadAllText(FilePath));
+        Assert.Contains(_log.Warnings, w => w.Contains("Refusing to write"));
+    }
+
+    [Fact]
+    public async Task AddAllowlistEntryAsync_AtomicWrite_NoTempFileLeft()
+    {
+        WriteFile(MinimalFile());
+        await Store().AddAllowlistEntryAsync("main", "**/git.exe");
+
+        Assert.Empty(Directory.GetFiles(_dir, "*.tmp"));
+    }
+
+    [Fact]
+    public async Task AddAllowlistEntryAsync_NewAgent_CreatesAgentWithEntry()
+    {
+        WriteFile("""{"version":1,"agents":{}}""");
+        var store = Store();
+        var result = await store.AddAllowlistEntryAsync("agent-xyz", "**/git.exe");
+
+        Assert.True(result);
+        Assert.Single(store.ResolveReadOnly("agent-xyz").Allowlist);
+    }
+
+    // ── Write path: RecordAllowlistUseAsync ──────────────────────────────────
+
+    [Fact]
+    public async Task RecordAllowlistUseAsync_UpdatesMetadataAndPreservesIdAndPattern()
+    {
+        var id = Guid.NewGuid();
+        WriteFile($$"""
+        {
+          "version": 1,
+          "agents": {
+            "main": {
+              "allowlist": [
+                { "id": "{{id}}", "pattern": "**/git.exe" }
+              ]
+            }
+          }
+        }
+        """);
+        var store = Store();
+        var result = await store.RecordAllowlistUseAsync("main", "**/git.exe", "git status", "/usr/bin/git");
+
+        Assert.True(result);
+        var entry = store.ResolveReadOnly("main").Allowlist[0];
+        Assert.Equal(id, entry.Id);
+        Assert.Equal("**/git.exe", entry.Pattern);
+        Assert.NotNull(entry.LastUsedAt);
+        Assert.Equal("git status", entry.LastUsedCommand);
+        Assert.Equal("/usr/bin/git", entry.LastResolvedPath);
+    }
+
+    [Fact]
+    public async Task RecordAllowlistUseAsync_PatternNotPresent_ReturnsFalse()
+    {
+        WriteFile("""
+        {
+          "version": 1,
+          "agents": {
+            "main": { "allowlist": [{ "pattern": "**/git.exe" }] }
+          }
+        }
+        """);
+        var store = Store();
+        var result = await store.RecordAllowlistUseAsync("main", "**/rg.exe", "rg foo", null);
+
+        Assert.False(result);
+        Assert.Null(store.ResolveReadOnly("main").Allowlist[0].LastUsedCommand);
+    }
+
+    [Fact]
+    public async Task RecordAllowlistUseAsync_AgentNotPresent_ReturnsFalse()
+    {
+        WriteFile("""{"version":1,"agents":{}}""");
+        var store = Store();
+        var result = await store.RecordAllowlistUseAsync("nonexistent", "**/git.exe", "git status", null);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task RecordAllowlistUseAsync_MalformedFile_ReturnsFalse()
+    {
+        WriteFile("{ bad json }");
+        var store = Store();
+        var result = await store.RecordAllowlistUseAsync("main", "**/git.exe", "git status", null);
+
+        Assert.False(result);
+        Assert.Equal("{ bad json }", File.ReadAllText(FilePath));
+    }
+
+    [Fact]
+    public async Task RecordAllowlistUseAsync_DoesNotTouchOtherEntries()
+    {
+        WriteFile("""
+        {
+          "version": 1,
+          "agents": {
+            "main": {
+              "allowlist": [
+                { "pattern": "**/git.exe" },
+                { "pattern": "**/rg.exe" }
+              ]
+            }
+          }
+        }
+        """);
+        var store = Store();
+        await store.RecordAllowlistUseAsync("main", "**/git.exe", "git status", null);
+
+        var allowlist = store.ResolveReadOnly("main").Allowlist;
+        Assert.NotNull(allowlist.First(e => e.Pattern == "**/git.exe").LastUsedCommand);
+        Assert.Null(allowlist.First(e => e.Pattern == "**/rg.exe").LastUsedCommand);
+    }
+
+    [Fact]
+    public async Task RecordAllowlistUseAsync_BestEffort_IoExceptionReturnsFalse()
+    {
+        // Entry present so the mutate lambda returns true (pattern found → something to update).
+        // Without a matching entry the mutate would be a no-op and UpdateFileAsync would return
+        // false before reaching SaveFileAsync — that is the not-found path, not the IOException path.
+        WriteFile("""
+        {
+          "version": 1,
+          "agents": {
+            "main": {
+              "allowlist": [{ "pattern": "**/git.exe" }]
+            }
+          }
+        }
+        """);
+        var store = Store();
+
+        // FileShare.Read: LoadFile succeeds; File.Move(tmp, target, overwrite:true) fails
+        // because the target is open without write/delete sharing → IOException degraded-save path.
+        using (var fs = new FileStream(FilePath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
+        {
+            var result = await store.RecordAllowlistUseAsync("main", "**/git.exe", "git status", null);
+            Assert.False(result);           // IOException absorbed, no exception escaped
+            Assert.NotEmpty(_log.Warnings); // write failure logged as Warn
+        }
+    }
+
+    // ── Round-trip and integration ────────────────────────────────────────────
+
+    [Fact]
+    public async Task AddAllowlistEntry_RoundTrip_ResolvedByReadPath()
+    {
+        WriteFile(MinimalFile());
+        var store = Store();
+        await store.AddAllowlistEntryAsync("main", "**/git.exe");
+
+        var resolved = store.ResolveReadOnly("main");
+        Assert.Single(resolved.Allowlist);
+        Assert.Equal("**/git.exe", resolved.Allowlist[0].Pattern);
+    }
+
+    [Fact]
+    public async Task RoundTrip_WrittenFileIsValidJsonWithCorrectFields()
+    {
+        WriteFile(MinimalFile());
+        var store = Store();
+        await store.AddAllowlistEntryAsync("main", "**/git.exe");
+        // lastUsedAt is absent on creation; RecordAllowlistUseAsync stamps it on first use.
+        await store.RecordAllowlistUseAsync("main", "**/git.exe", "git status", null);
+
+        var json = File.ReadAllText(FilePath);
+        using var doc = System.Text.Json.JsonDocument.Parse(json); // valid JSON
+        Assert.Equal(1, doc.RootElement.GetProperty("version").GetInt32());
+        // lastUsedAt must be a JSON number (Unix epoch ms), not a string.
+        var lastUsedAt = doc.RootElement
+            .GetProperty("agents").GetProperty("main")
+            .GetProperty("allowlist")[0].GetProperty("lastUsedAt");
+        Assert.Equal(System.Text.Json.JsonValueKind.Number, lastUsedAt.ValueKind);
+    }
+
+    [Fact]
+    public async Task AddAllowlistEntryAsync_Concurrency_SamePattern_SingleEntry()
+    {
+        WriteFile(MinimalFile());
+        var store = Store();
+        var tasks = Enumerable.Range(0, 5)
+            .Select(_ => store.AddAllowlistEntryAsync("main", "**/git.exe"))
+            .ToList();
+        await Task.WhenAll(tasks);
+
+        Assert.Single(store.ResolveReadOnly("main").Allowlist);
+    }
+
+    [Fact]
+    public async Task AddAllowlistEntryAsync_BestEffort_IoExceptionReturnsFalse()
+    {
+        // FileShare.Read: LoadFile (File.ReadAllText / FileAccess.Read) succeeds because
+        // read-sharing is granted. File.Move(tmp, target, overwrite:true) fails because the
+        // target is open without write/delete sharing. This exercises the IOException degraded-save
+        // path, not the malformed-file refusal branch.
+        WriteFile(MinimalFile());
+        var store = Store();
+
+        using (var fs = new FileStream(FilePath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
+        {
+            var result = await store.AddAllowlistEntryAsync("main", "**/git.exe");
+            Assert.False(result);                // IOException absorbed, no exception escaped
+            Assert.NotEmpty(_log.Warnings);      // write failure logged as Warn
+        }
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Adds the write path to `ExecApprovalsStore` and wires the two side-effect calls into `ExecApprovalsCoordinator`.

**Store — new public API:**
- `AddAllowlistEntryAsync(agentId, pattern)` — persists a new allowlist entry after an AllowAlways prompt decision. Deduplicates on write (OrdinalIgnoreCase). Returns `true` if present after the call (added or already there), `false` on empty pattern or I/O failure. New entries carry `{id, pattern}` only — `lastUsedAt` is absent on creation, matching macOS `addAllowlistEntry` behavior, and is stamped by `RecordAllowlistUseAsync` on first use.
- `RecordAllowlistUseAsync(agentId, pattern, command, resolvedPath)` — updates `lastUsedAt`, `lastUsedCommand`, and `lastResolvedPath` for every matching entry after a final allow. Returns `false` if pattern not found or on I/O failure.

**Store — private infrastructure:**
- `UpdateFileAsync(mutate)` — load → mutate → atomic save, serialized by the existing `SemaphoreSlim`. Never throws. Refuses to overwrite a malformed file. Handles transient `IOException` on the atomic move as a degraded path: logs `Warn`, no retry.

**Coordinator — side effects wired:**
- `RecordAllowlistUsageAsync` fires on both allow exit points: the pass1 pre-approved branch and the post-pass2 branch. Both are required to cover the common allowlist-satisfied case.
- `PersistAllowlistEntriesAsync` fires only after pass2 = Allow and `followupDecision == AllowAlways`, strictly outside the `_promptLock` block.
- Both helpers are best-effort: a store I/O failure is absorbed and does not affect the final `Allow` result.

**Not wired in production yet:** the coordinator is still not referenced in any production `src/` file. The `ProductionWiring_CoordinatorNotReferencedInSrc` test remains green.

## Design notes

Side effects fire strictly after the final allow decision is confirmed — not before the second evaluator pass as in the macOS socket path. This is a deliberate structural safety choice: the macOS sequence is "persist before pass2" (and relies on the proof that `Evaluate(context, AllowAlways)` always produces Allow); this implementation prefers safety-by-structure over proof-by-argument.

Pattern validation in `AddAllowlistEntryAsync` is non-empty only, matching macOS parity. Basename-only patterns are inert at match time but not rejected at persist time.

## Testing

145 tests passing, 0 failures. 24 new tests added in this change (17 store, 7 coordinator).

Store tests cover: success paths, dedup, not-found, malformed-file refusal, I/O failure degradation on both mutators (using `FileShare.Read` so `LoadFile` succeeds but `File.Move` is blocked), concurrency (5 concurrent writes produce a single entry), and round-trip JSON validation.

Coordinator tests cover: AllowAlways persistence, non-allowlist security guard, duplicate pattern dedup, allowlist usage recording, allowlist-not-satisfied guard, pass1 pre-approved path, and fallback path with allowlist satisfied.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>