### PR TITLE
Redesign per-agent Workspace page with master-detail layout

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
@@ -94,6 +94,13 @@ public static class FluentIconCatalog
     public const string Develop = "\uE943";        // Code — engineering / explorations action
     public const string AgentEvents = "\uE81C";    // History — agent events feed
 
+    // ── Agents / Workspace surface ─────────────────────────────────
+    // Workspace concept (per-agent file viewer). Reuses the Folder
+    // metaphor because the workspace literally IS a folder; aliasing
+    // keeps call sites semantically distinct.
+    // See reference/concepts/states/workspace.md.
+    public const string Workspace = "\uE8DA";      // OpenLocal (alias of Folder)
+
     /// <summary>
     /// Builds a <see cref="FontIcon"/> for the given PUA glyph using the
     /// system-resolved <c>SymbolThemeFontFamily</c> so the icon honors

--- a/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml
@@ -2,62 +2,195 @@
 <Page
     x:Class="OpenClawTray.Pages.WorkspacePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:helpers="using:OpenClawTray.Helpers"
+    SizeChanged="OnPageSizeChanged">
 
-    <Grid RowSpacing="8" MaxWidth="900" HorizontalAlignment="Stretch">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
+    <Page.Resources>
+        <Style x:Key="WorkspaceMarkdownH1Style"
+               BasedOn="{StaticResource SubtitleTextBlockStyle}"
+               TargetType="TextBlock">
+            <Setter Property="Margin" Value="0,8,0,4"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="IsTextSelectionEnabled" Value="True"/>
+        </Style>
+        <Style x:Key="WorkspaceMarkdownH2Style"
+               BasedOn="{StaticResource BaseTextBlockStyle}"
+               TargetType="TextBlock">
+            <Setter Property="Margin" Value="0,12,0,4"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="IsTextSelectionEnabled" Value="True"/>
+        </Style>
+        <Style x:Key="WorkspaceMarkdownH3Style"
+               BasedOn="{StaticResource BodyStrongTextBlockStyle}"
+               TargetType="TextBlock">
+            <Setter Property="Margin" Value="0,12,0,4"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="IsTextSelectionEnabled" Value="True"/>
+        </Style>
+        <Style x:Key="WorkspaceMarkdownParagraphStyle"
+               BasedOn="{StaticResource BodyTextBlockStyle}"
+               TargetType="TextBlock">
+            <Setter Property="Margin" Value="0,0,0,8"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="IsTextSelectionEnabled" Value="True"/>
+        </Style>
+        <Style x:Key="WorkspaceMarkdownListItemStyle"
+               BasedOn="{StaticResource BodyTextBlockStyle}"
+               TargetType="TextBlock">
+            <Setter Property="Margin" Value="12,0,0,4"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="IsTextSelectionEnabled" Value="True"/>
+        </Style>
+        <Style x:Key="WorkspaceCodeTextStyle"
+               BasedOn="{StaticResource CaptionTextBlockStyle}"
+               TargetType="TextBlock">
+            <Setter Property="FontFamily" Value="Consolas"/>
+            <Setter Property="Foreground" Value="{ThemeResource TextFillColorPrimaryBrush}"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="IsTextSelectionEnabled" Value="True"/>
+        </Style>
+        <Style x:Key="WorkspaceCodeBlockStyle"
+               BasedOn="{StaticResource WorkspaceCodeTextStyle}"
+               TargetType="TextBlock">
+            <Setter Property="Margin" Value="0,4,0,12"/>
+            <Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}"/>
+        </Style>
+    </Page.Resources>
 
-        <!-- Header: title + path + refresh -->
-        <Grid Grid.Row="0" Padding="24,16,24,0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
+    <!-- ContentRoot.Width is set in code-behind to min(available, MaxWidth)
+         so the column stays centered with growing white side bars. -->
+    <Grid>
+        <Grid x:Name="ContentRoot"
+              HorizontalAlignment="Center"
+              MaxWidth="900"
+              Padding="24,16,24,16"
+              RowSpacing="12">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
 
-            <TextBlock x:Uid="WorkspacePage_TextBlock_22" Grid.Column="0" Text="📂 Workspace" Style="{StaticResource TitleTextBlockStyle}"
-                       VerticalAlignment="Center" Margin="0,0,16,0"/>
+            <Grid Grid.Row="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock x:Uid="WorkspacePage_TextBlock_22" Grid.Column="0"
+                           Text="Workspace"
+                           Style="{StaticResource TitleTextBlockStyle}"
+                           VerticalAlignment="Center"/>
+                <Button x:Name="RefreshButton" Grid.Column="1" Click="RefreshButton_Click"
+                        VerticalAlignment="Center">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Refresh, Mode=OneTime}"
+                                  FontSize="16"
+                                  IsTextScaleFactorEnabled="False"/>
+                        <TextBlock x:Uid="WorkspacePage_TextBlock_34" Text="Refresh"/>
+                    </StackPanel>
+                </Button>
+            </Grid>
 
-            <TextBlock x:Name="WorkspacePathText" Grid.Column="1"
+            <TextBlock x:Name="WorkspacePathText" Grid.Row="1"
                        Style="{StaticResource CaptionTextBlockStyle}"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                       VerticalAlignment="Center"/>
+                       TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"/>
 
-            <Button x:Name="RefreshButton" Grid.Column="2" Click="RefreshButton_Click"
-                    VerticalAlignment="Center">
-                <StackPanel Orientation="Horizontal" Spacing="6">
-                    <FontIcon Glyph="&#xE72C;" FontSize="14"/>
-                    <TextBlock x:Uid="WorkspacePage_TextBlock_34" Text="Refresh"/>
+            <StackPanel Grid.Row="2">
+                <StackPanel x:Name="LoadingPanel" Visibility="Collapsed"
+                            HorizontalAlignment="Center" Spacing="8" Margin="0,24,0,0">
+                    <ProgressRing x:Name="LoadingRing" IsActive="False" Width="24" Height="24"
+                                  HorizontalAlignment="Center"/>
+                    <TextBlock x:Uid="WorkspacePage_LoadingWorkspaceFiles"
+                               Text="Loading workspace files…"
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               HorizontalAlignment="Center"/>
                 </StackPanel>
-            </Button>
-        </Grid>
-
-        <!-- Loading / Info -->
-        <StackPanel Grid.Row="1" Padding="24,0">
-            <StackPanel x:Name="LoadingPanel" Visibility="Collapsed"
-                        HorizontalAlignment="Center" Spacing="8" Margin="0,24,0,0">
-                <ProgressRing x:Name="LoadingRing" IsActive="False" Width="24" Height="24"
-                              HorizontalAlignment="Center"/>
-                <TextBlock x:Uid="WorkspacePage_LoadingWorkspaceFiles" Text="Loading workspace files…"
-                           Style="{StaticResource CaptionTextBlockStyle}"
-                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                           HorizontalAlignment="Center"/>
+                <InfoBar x:Uid="FallbackInfoBar" x:Name="FallbackInfoBar"
+                         IsOpen="False" IsClosable="False"
+                         Severity="Informational"
+                         Title="Workspace files"/>
             </StackPanel>
-            <InfoBar x:Uid="FallbackInfoBar" x:Name="FallbackInfoBar"
-                     IsOpen="False" IsClosable="False"
-                     Severity="Informational"
-                     Title="Workspace files"/>
-        </StackPanel>
 
-        <!-- File tabs — one tab per workspace file -->
-        <TabView x:Name="FileTabs" Grid.Row="2"
-                 IsAddTabButtonVisible="False"
-                 TabWidthMode="SizeToContent"
-                 SelectionChanged="FileTabs_SelectionChanged"
-                 Visibility="Collapsed"/>
+            <Border x:Name="BodyGrid" Grid.Row="3" Visibility="Collapsed"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" MinWidth="220"/>
+                        <ColumnDefinition Width="1"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="1"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <Border Grid.Row="0" Grid.Column="0" Padding="16,12,16,12">
+                        <TextBlock x:Uid="WorkspacePage_FilesHeader"
+                                   Text="Files"
+                                   Style="{StaticResource BodyStrongTextBlockStyle}"
+                                   VerticalAlignment="Center"/>
+                    </Border>
+
+                    <Grid Grid.Row="0" Grid.Column="2" Padding="16,8,12,8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Name="SelectedFileText" Grid.Column="0"
+                                   Style="{StaticResource BodyStrongTextBlockStyle}"
+                                   VerticalAlignment="Center"
+                                   TextWrapping="NoWrap"
+                                   TextTrimming="CharacterEllipsis"/>
+                        <controls:SelectorBar x:Name="ViewModeSelector" Grid.Column="1"
+                                              Visibility="Collapsed"
+                                              SelectionChanged="ViewModeSelector_SelectionChanged">
+                            <controls:SelectorBarItem x:Uid="WorkspacePage_ViewMode_Rendered"
+                                                      x:Name="ViewModeRenderedItem"
+                                                      Text="Rendered"
+                                                      IsSelected="True"/>
+                            <controls:SelectorBarItem x:Uid="WorkspacePage_ViewMode_Raw"
+                                                      x:Name="ViewModeRawItem"
+                                                      Text="Raw"/>
+                        </controls:SelectorBar>
+                    </Grid>
+
+                    <Border Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3"
+                            Background="{ThemeResource CardStrokeColorDefaultBrush}"/>
+                    <Border Grid.Row="2" Grid.Column="1"
+                            Background="{ThemeResource CardStrokeColorDefaultBrush}"/>
+
+                    <ListView x:Name="FileList" Grid.Row="2" Grid.Column="0"
+                              SelectionMode="Single"
+                              SelectionChanged="FileList_SelectionChanged"
+                              ShowsScrollingPlaceholders="False"
+                              Padding="4,4,4,8">
+                        <ListView.ItemContainerStyle>
+                            <Style TargetType="ListViewItem">
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                <Setter Property="Padding" Value="12,8"/>
+                                <Setter Property="Margin" Value="0"/>
+                                <Setter Property="CornerRadius" Value="4"/>
+                            </Style>
+                        </ListView.ItemContainerStyle>
+                    </ListView>
+
+                    <ScrollViewer Grid.Row="2" Grid.Column="2"
+                                  VerticalScrollBarVisibility="Auto"
+                                  HorizontalScrollBarVisibility="Auto"
+                                  Padding="16,12,16,16">
+                        <ContentPresenter x:Name="FileBodyPresenter"/>
+                    </ScrollViewer>
+                </Grid>
+            </Border>
+        </Grid>
     </Grid>
 </Page>

--- a/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml.cs
@@ -1,10 +1,14 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
+using Microsoft.UI.Xaml.Media;
 using OpenClaw.Shared;
+using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Text;
 using System.Text.Json;
 
 namespace OpenClawTray.Pages;
@@ -13,8 +17,14 @@ public sealed partial class WorkspacePage : Page
 {
     private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private AppState? _appState;
-    private readonly Dictionary<string, TabViewItem> _fileTabs = new(StringComparer.OrdinalIgnoreCase);
-    private bool _tabsPopulated;
+
+    // file name (case-insensitive) → its list item
+    private readonly Dictionary<string, ListViewItem> _fileItems = new(StringComparer.OrdinalIgnoreCase);
+
+    // file name → raw text content (null = missing on disk, absent = not loaded yet)
+    private readonly Dictionary<string, string?> _fileContent = new(StringComparer.OrdinalIgnoreCase);
+
+    private bool _renderMarkdown = true;
 
     /// <summary>Set by HubWindow before <see cref="Initialize"/> to specify the active agent scope.</summary>
     public string AgentId { get; set; } = "main";
@@ -29,12 +39,21 @@ public sealed partial class WorkspacePage : Page
         };
     }
 
+    private void OnPageSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        var available = e.NewSize.Width;
+        if (double.IsNaN(available) || available <= 0) return;
+        var max = ContentRoot.MaxWidth;
+        ContentRoot.Width = double.IsNaN(max) || double.IsInfinity(max)
+            ? available
+            : Math.Min(available, max);
+    }
+
     public void Initialize()
     {
         _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
 
-        // Check per-agent cache first, then fall back to single-slot cache
         if (_appState.TryGetCachedAgentFilesList(AgentId, out var cachedData))
         {
             UpdateAgentFilesList(cachedData);
@@ -43,23 +62,23 @@ public sealed partial class WorkspacePage : Page
 
         var hasMatchingCache = _appState?.AgentFilesList.HasValue == true &&
             string.Equals(_appState?.AgentFilesListAgentId, AgentId, StringComparison.OrdinalIgnoreCase);
-        var status = CurrentApp.AppState?.Status ?? OpenClaw.Shared.ConnectionStatus.Disconnected;
-        if (CurrentApp.GatewayClient != null && status == OpenClaw.Shared.ConnectionStatus.Connected && !hasMatchingCache)
+        var status = CurrentApp.AppState?.Status ?? ConnectionStatus.Disconnected;
+        if (CurrentApp.GatewayClient != null && status == ConnectionStatus.Connected && !hasMatchingCache)
         {
             FallbackInfoBar.IsOpen = false;
             LoadingRing.IsActive = true;
             LoadingPanel.Visibility = Visibility.Visible;
-            ClearTabs();
+            ClearFiles();
             _ = CurrentApp.GatewayClient.RequestAgentFilesListAsync(AgentId);
         }
         else if (hasMatchingCache)
         {
             UpdateAgentFilesList(_appState!.AgentFilesList!.Value);
         }
-        else if (CurrentApp.GatewayClient == null || status != OpenClaw.Shared.ConnectionStatus.Connected)
+        else if (CurrentApp.GatewayClient == null || status != ConnectionStatus.Connected)
         {
             FallbackInfoBar.IsOpen = true;
-            FallbackInfoBar.Message = "Connect to gateway to view workspace files.";
+            FallbackInfoBar.Message = LocalizationHelper.GetString("WorkspacePage_DisconnectedMessage");
         }
     }
 
@@ -80,7 +99,7 @@ public sealed partial class WorkspacePage : Page
     {
         LoadingRing.IsActive = false;
         LoadingPanel.Visibility = Visibility.Collapsed;
-        ClearTabs();
+        ClearFiles();
 
         if (data.TryGetProperty("workspace", out var workspaceEl))
         {
@@ -98,26 +117,20 @@ public sealed partial class WorkspacePage : Page
                 bool exists = !fileEl.TryGetProperty("exists", out var existsEl) || existsEl.ValueKind != JsonValueKind.False;
 
                 if (!string.IsNullOrEmpty(name) && exists)
-                {
-                    AddFileTab(name, size);
-                }
+                    AddFileItem(name, size);
             }
         }
 
-        if (FileTabs.TabItems.Count == 0)
+        if (_fileItems.Count == 0)
         {
             FallbackInfoBar.IsOpen = true;
-            FallbackInfoBar.Message = "No workspace files found for this agent.";
-            FileTabs.Visibility = Visibility.Collapsed;
+            FallbackInfoBar.Message = LocalizationHelper.GetString("WorkspacePage_NoFilesMessage");
+            BodyGrid.Visibility = Visibility.Collapsed;
         }
         else
         {
-            FileTabs.Visibility = Visibility.Visible;
-            FileTabs.SelectedIndex = 0;
-            _tabsPopulated = true;
-            // Explicitly fetch first tab content (SelectionChanged may not fire for programmatic index set)
-            if (FileTabs.SelectedItem is TabViewItem firstTab && firstTab.Tag is string firstName && CurrentApp.GatewayClient != null)
-                _ = CurrentApp.GatewayClient.RequestAgentFileGetAsync(AgentId, firstName);
+            BodyGrid.Visibility = Visibility.Visible;
+            FileList.SelectedIndex = 0;
         }
     }
 
@@ -129,83 +142,395 @@ public sealed partial class WorkspacePage : Page
         var content = fileEl.TryGetProperty("content", out var contentEl) ? contentEl.GetString() ?? "" : "";
         bool missing = fileEl.TryGetProperty("missing", out var missingEl) && missingEl.ValueKind == JsonValueKind.True;
 
-        if (string.IsNullOrEmpty(name) || !_fileTabs.TryGetValue(name, out var tab)) return;
+        if (string.IsNullOrEmpty(name) || !_fileItems.ContainsKey(name)) return;
 
-        var textBlock = new TextBlock
+        _fileContent[name] = missing ? null : content;
+
+        if (FileList.SelectedItem is ListViewItem selected &&
+            selected.Tag is string selectedName &&
+            string.Equals(selectedName, name, StringComparison.OrdinalIgnoreCase))
         {
-            Text = missing ? "(file not found on disk)" : content,
-            TextWrapping = TextWrapping.Wrap,
-            IsTextSelectionEnabled = true,
-            FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Consolas"),
-            FontSize = 12,
-            Padding = new Thickness(16)
-        };
-
-        var scrollViewer = new ScrollViewer
-        {
-            Content = textBlock,
-            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-            HorizontalAlignment = HorizontalAlignment.Stretch
-        };
-
-        tab.Content = scrollViewer;
-
-        // WinUI TabView doesn't visually refresh when Content changes on the selected tab.
-        // Force re-render by cycling the selection.
-        if (FileTabs.SelectedItem == tab)
-        {
-            FileTabs.SelectedItem = null;
-            FileTabs.SelectedItem = tab;
+            RenderSelectedFile();
         }
     }
 
-    private void AddFileTab(string fileName, long size)
+    private void AddFileItem(string fileName, long size)
     {
-        var header = fileName;
-        if (size > 0) header += $" ({FormatSize(size)})";
-
-        var tab = new TabViewItem
+        var stack = new StackPanel { Spacing = 2 };
+        stack.Children.Add(new TextBlock
         {
-            Header = header,
-            IsClosable = false,
-            Tag = fileName,
-            Content = new StackPanel
+            Text = fileName,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            TextWrapping = TextWrapping.NoWrap
+        });
+        if (size > 0)
+        {
+            stack.Children.Add(new TextBlock
             {
-                HorizontalAlignment = HorizontalAlignment.Center,
-                VerticalAlignment = VerticalAlignment.Center,
-                Children =
+                Text = FormatSize(size),
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]
+            });
+        }
+
+        var item = new ListViewItem { Content = stack, Tag = fileName };
+        _fileItems[fileName] = item;
+        FileList.Items.Add(item);
+    }
+
+    private void ClearFiles()
+    {
+        FileList.Items.Clear();
+        _fileItems.Clear();
+        _fileContent.Clear();
+        FileBodyPresenter.Content = null;
+        SelectedFileText.Text = string.Empty;
+        BodyGrid.Visibility = Visibility.Collapsed;
+        ViewModeSelector.Visibility = Visibility.Collapsed;
+    }
+
+    private void FileList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (FileList.SelectedItem is not ListViewItem selected ||
+            selected.Tag is not string fileName)
+        {
+            return;
+        }
+
+        bool isMarkdown = IsMarkdown(fileName);
+        ViewModeSelector.Visibility = isMarkdown ? Visibility.Visible : Visibility.Collapsed;
+        SelectedFileText.Text = fileName;
+
+        if (_fileContent.ContainsKey(fileName))
+        {
+            RenderSelectedFile();
+        }
+        else
+        {
+            ShowLoadingBody();
+            if (CurrentApp.GatewayClient != null)
+                _ = CurrentApp.GatewayClient.RequestAgentFileGetAsync(AgentId, fileName);
+        }
+    }
+
+    private void ViewModeSelector_SelectionChanged(SelectorBar sender, SelectorBarSelectionChangedEventArgs args)
+    {
+        _renderMarkdown = ViewModeSelector.SelectedItem == ViewModeRenderedItem;
+        RenderSelectedFile();
+    }
+
+    private void ShowLoadingBody()
+    {
+        var loading = new StackPanel
+        {
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            Spacing = 8
+        };
+        loading.Children.Add(new ProgressRing { IsActive = true, Width = 24, Height = 24 });
+        loading.Children.Add(new TextBlock
+        {
+            Text = LocalizationHelper.GetString("WorkspacePage_LoadingContent"),
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]
+        });
+        FileBodyPresenter.Content = loading;
+    }
+
+    private void RenderSelectedFile()
+    {
+        if (FileList.SelectedItem is not ListViewItem selected ||
+            selected.Tag is not string fileName)
+        {
+            FileBodyPresenter.Content = null;
+            return;
+        }
+
+        if (!_fileContent.TryGetValue(fileName, out var content))
+        {
+            ShowLoadingBody();
+            return;
+        }
+
+        if (content == null)
+        {
+            FileBodyPresenter.Content = new TextBlock
+            {
+                Text = LocalizationHelper.GetString("WorkspacePage_MissingFile"),
+                Style = (Style)Application.Current.Resources["BodyTextBlockStyle"],
+                Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]
+            };
+            return;
+        }
+
+        if (IsMarkdown(fileName) && _renderMarkdown)
+        {
+            FileBodyPresenter.Content = BuildMarkdownView(content);
+        }
+        else
+        {
+            FileBodyPresenter.Content = BuildRawView(content);
+        }
+    }
+
+    private UIElement BuildRawView(string content)
+    {
+        return new TextBlock
+        {
+            Text = content,
+            Style = (Style)Resources["WorkspaceCodeTextStyle"],
+        };
+    }
+
+    private static bool IsMarkdown(string fileName)
+    {
+        return fileName.EndsWith(".md", StringComparison.OrdinalIgnoreCase) ||
+               fileName.EndsWith(".markdown", StringComparison.OrdinalIgnoreCase);
+    }
+
+    // Minimal Markdown renderer: ATX headings, paragraphs, lists, fenced
+    // code, inline `code`, **bold**, *italic*. Links render as label only.
+    // Block styles come from Page.Resources so no raw FontSize is used.
+
+    private UIElement BuildMarkdownView(string markdown)
+    {
+        var root = new StackPanel { Spacing = 0 };
+
+        var h1 = (Style)Resources["WorkspaceMarkdownH1Style"];
+        var h2 = (Style)Resources["WorkspaceMarkdownH2Style"];
+        var h3 = (Style)Resources["WorkspaceMarkdownH3Style"];
+        var para = (Style)Resources["WorkspaceMarkdownParagraphStyle"];
+        var listItem = (Style)Resources["WorkspaceMarkdownListItemStyle"];
+        var codeBlock = (Style)Resources["WorkspaceCodeBlockStyle"];
+
+        var lines = markdown.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+        int i = 0;
+        while (i < lines.Length)
+        {
+            var line = lines[i];
+
+            if (line.TrimStart().StartsWith("```", StringComparison.Ordinal))
+            {
+                var code = new StringBuilder();
+                i++;
+                while (i < lines.Length && !lines[i].TrimStart().StartsWith("```", StringComparison.Ordinal))
                 {
-                    new ProgressRing { IsActive = true, Width = 24, Height = 24 },
-                    new TextBlock
+                    if (code.Length > 0) code.Append('\n');
+                    code.Append(lines[i]);
+                    i++;
+                }
+                if (i < lines.Length) i++; // skip closing ```
+                root.Children.Add(new TextBlock
+                {
+                    Text = code.ToString(),
+                    Style = codeBlock
+                });
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                i++;
+                continue;
+            }
+
+            if (TryParseHeading(line, out var headingLevel, out var headingText))
+            {
+                var headingStyle = headingLevel switch
+                {
+                    1 => h1,
+                    2 => h2,
+                    _ => h3, // h3..h6 all share BodyStrong styling
+                };
+                root.Children.Add(BuildInlineTextBlock(headingText, headingStyle));
+                i++;
+                continue;
+            }
+
+            if (IsListItem(line, out _, out _))
+            {
+                while (i < lines.Length && IsListItem(lines[i], out var marker, out var body))
+                {
+                    root.Children.Add(BuildInlineTextBlock(marker + body, listItem));
+                    i++;
+                }
+                continue;
+            }
+
+            // Paragraph: absorb continuation lines until a block-ending marker
+            var sb = new StringBuilder(line);
+            i++;
+            while (i < lines.Length)
+            {
+                var next = lines[i];
+                if (string.IsNullOrWhiteSpace(next)) break;
+                if (TryParseHeading(next, out _, out _)) break;
+                if (next.TrimStart().StartsWith("```", StringComparison.Ordinal)) break;
+                if (IsListItem(next, out _, out _)) break;
+                sb.Append(' ').Append(next.Trim());
+                i++;
+            }
+            root.Children.Add(BuildInlineTextBlock(sb.ToString(), para));
+        }
+
+        return root;
+    }
+
+    private static TextBlock BuildInlineTextBlock(string text, Style style)
+    {
+        var tb = new TextBlock { Style = style };
+        AppendInlineMarkdown(tb.Inlines, text);
+        return tb;
+    }
+
+    // ATX heading: 1–6 leading `#`, then at least one space, then the text.
+    // Optional trailing `#`s (closing sequence) are stripped.
+    private static bool TryParseHeading(string line, out int level, out string text)
+    {
+        level = 0;
+        text = string.Empty;
+        int i = 0;
+        while (i < line.Length && line[i] == '#' && i < 6) i++;
+        if (i == 0 || i >= line.Length || line[i] != ' ') return false;
+        level = i;
+        var body = line[(i + 1)..].TrimEnd();
+        // Strip optional closing # # # sequence
+        int end = body.Length;
+        while (end > 0 && body[end - 1] == '#') end--;
+        if (end < body.Length && (end == 0 || body[end - 1] == ' '))
+            body = body[..end].TrimEnd();
+        text = body;
+        return true;
+    }
+
+    private static bool IsListItem(string line, out string marker, out string body)
+    {
+        marker = "";
+        body = "";
+        var trimmed = line.TrimStart();
+        if (trimmed.StartsWith("- ", StringComparison.Ordinal) ||
+            trimmed.StartsWith("* ", StringComparison.Ordinal))
+        {
+            marker = "•  ";
+            body = trimmed[2..];
+            return true;
+        }
+        // numbered: digits + "." + space
+        int dot = trimmed.IndexOf('.');
+        if (dot > 0 && dot < trimmed.Length - 1 && trimmed[dot + 1] == ' ')
+        {
+            bool allDigits = true;
+            for (int k = 0; k < dot; k++)
+                if (!char.IsDigit(trimmed[k])) { allDigits = false; break; }
+            if (allDigits)
+            {
+                marker = trimmed[..(dot + 1)] + "  ";
+                body = trimmed[(dot + 2)..];
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void AppendInlineMarkdown(InlineCollection inlines, string text)
+    {
+        text = StripLinks(text);
+
+        int i = 0;
+        var buf = new StringBuilder();
+        void FlushPlain()
+        {
+            if (buf.Length == 0) return;
+            inlines.Add(new Run { Text = buf.ToString() });
+            buf.Clear();
+        }
+
+        while (i < text.Length)
+        {
+            if (text[i] == '`')
+            {
+                int end = text.IndexOf('`', i + 1);
+                if (end > i)
+                {
+                    FlushPlain();
+                    inlines.Add(new Run
                     {
-                        Text = "Loading content…",
-                        Margin = new Thickness(0, 8, 0, 0),
-                        Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]
+                        Text = text.Substring(i + 1, end - i - 1),
+                        FontFamily = new FontFamily("Consolas")
+                    });
+                    i = end + 1;
+                    continue;
+                }
+            }
+            if (i + 1 < text.Length && text[i] == '*' && text[i + 1] == '*')
+            {
+                int end = text.IndexOf("**", i + 2, StringComparison.Ordinal);
+                if (end > i + 1)
+                {
+                    FlushPlain();
+                    var bold = new Bold();
+                    bold.Inlines.Add(new Run { Text = text.Substring(i + 2, end - i - 2) });
+                    inlines.Add(bold);
+                    i = end + 2;
+                    continue;
+                }
+            }
+            // Italic: single asterisk, not part of a bold ** pair
+            if (text[i] == '*' &&
+                (i == 0 || text[i - 1] != '*') &&
+                (i + 1 >= text.Length || text[i + 1] != '*'))
+            {
+                int end = -1;
+                for (int k = i + 1; k < text.Length; k++)
+                {
+                    if (text[k] == '*' && (k + 1 >= text.Length || text[k + 1] != '*'))
+                    {
+                        end = k;
+                        break;
+                    }
+                }
+                if (end > i)
+                {
+                    FlushPlain();
+                    var italic = new Italic();
+                    italic.Inlines.Add(new Run { Text = text.Substring(i + 1, end - i - 1) });
+                    inlines.Add(italic);
+                    i = end + 1;
+                    continue;
+                }
+            }
+
+            buf.Append(text[i]);
+            i++;
+        }
+        FlushPlain();
+    }
+
+    private static string StripLinks(string text)
+    {
+        // [label](url) → label; non-nested only.
+        var sb = new StringBuilder(text.Length);
+        int i = 0;
+        while (i < text.Length)
+        {
+            if (text[i] == '[')
+            {
+                int closeBracket = text.IndexOf(']', i + 1);
+                if (closeBracket > i && closeBracket + 1 < text.Length && text[closeBracket + 1] == '(')
+                {
+                    int closeParen = text.IndexOf(')', closeBracket + 2);
+                    if (closeParen > closeBracket)
+                    {
+                        sb.Append(text, i + 1, closeBracket - i - 1);
+                        i = closeParen + 1;
+                        continue;
                     }
                 }
             }
-        };
-
-        _fileTabs[fileName] = tab;
-        FileTabs.TabItems.Add(tab);
-    }
-
-    private void ClearTabs()
-    {
-        FileTabs.TabItems.Clear();
-        _fileTabs.Clear();
-        _tabsPopulated = false;
-        FileTabs.Visibility = Visibility.Collapsed;
-    }
-
-    private void FileTabs_SelectionChanged(object sender, SelectionChangedEventArgs e)
-    {
-        // Lazy load on tab select if content is still placeholder
-        if (FileTabs.SelectedItem is TabViewItem tab && tab.Tag is string fileName &&
-            tab.Content is StackPanel && CurrentApp.GatewayClient != null)
-        {
-            _ = CurrentApp.GatewayClient.RequestAgentFileGetAsync(AgentId, fileName);
+            sb.Append(text[i]);
+            i++;
         }
+        return sb.ToString();
     }
 
     private void RefreshButton_Click(object sender, RoutedEventArgs e)
@@ -215,7 +540,7 @@ public sealed partial class WorkspacePage : Page
             LoadingRing.IsActive = true;
             LoadingPanel.Visibility = Visibility.Visible;
             FallbackInfoBar.IsOpen = false;
-            ClearTabs();
+            ClearFiles();
             _ = CurrentApp.GatewayClient.RequestAgentFilesListAsync(AgentId);
         }
     }

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2179,7 +2179,28 @@ On your gateway host (Mac/Linux), run:
     <value>Daily Cost</value>
   </data>
   <data name="WorkspacePage_TextBlock_22.Text" xml:space="preserve">
-    <value>📂 Workspace</value>
+    <value>Workspace</value>
+  </data>
+  <data name="WorkspacePage_FilesHeader.Text" xml:space="preserve">
+    <value>Files</value>
+  </data>
+  <data name="WorkspacePage_ViewMode_Rendered.Text" xml:space="preserve">
+    <value>Rendered</value>
+  </data>
+  <data name="WorkspacePage_ViewMode_Raw.Text" xml:space="preserve">
+    <value>Raw</value>
+  </data>
+  <data name="WorkspacePage_DisconnectedMessage" xml:space="preserve">
+    <value>Connect to gateway to view workspace files.</value>
+  </data>
+  <data name="WorkspacePage_NoFilesMessage" xml:space="preserve">
+    <value>No workspace files found for this agent.</value>
+  </data>
+  <data name="WorkspacePage_LoadingContent" xml:space="preserve">
+    <value>Loading content…</value>
+  </data>
+  <data name="WorkspacePage_MissingFile" xml:space="preserve">
+    <value>(file not found on disk)</value>
   </data>
   <data name="WorkspacePage_TextBlock_34.Text" xml:space="preserve">
     <value>Refresh</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2131,7 +2131,28 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Coût quotidien</value>
   </data>
   <data name="WorkspacePage_TextBlock_22.Text" xml:space="preserve">
-    <value>📂 Espace de travail</value>
+    <value>Espace de travail</value>
+  </data>
+  <data name="WorkspacePage_FilesHeader.Text" xml:space="preserve">
+    <value>Fichiers</value>
+  </data>
+  <data name="WorkspacePage_ViewMode_Rendered.Text" xml:space="preserve">
+    <value>Rendu</value>
+  </data>
+  <data name="WorkspacePage_ViewMode_Raw.Text" xml:space="preserve">
+    <value>Brut</value>
+  </data>
+  <data name="WorkspacePage_DisconnectedMessage" xml:space="preserve">
+    <value>Connectez-vous à la passerelle pour afficher les fichiers de l'espace de travail.</value>
+  </data>
+  <data name="WorkspacePage_NoFilesMessage" xml:space="preserve">
+    <value>Aucun fichier d'espace de travail trouvé pour cet agent.</value>
+  </data>
+  <data name="WorkspacePage_LoadingContent" xml:space="preserve">
+    <value>Chargement du contenu…</value>
+  </data>
+  <data name="WorkspacePage_MissingFile" xml:space="preserve">
+    <value>(fichier introuvable sur le disque)</value>
   </data>
   <data name="WorkspacePage_TextBlock_34.Text" xml:space="preserve">
     <value>Actualiser</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2132,7 +2132,28 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>Dagelijkse kosten</value>
   </data>
   <data name="WorkspacePage_TextBlock_22.Text" xml:space="preserve">
-    <value>📂 Werkruimte</value>
+    <value>Werkruimte</value>
+  </data>
+  <data name="WorkspacePage_FilesHeader.Text" xml:space="preserve">
+    <value>Bestanden</value>
+  </data>
+  <data name="WorkspacePage_ViewMode_Rendered.Text" xml:space="preserve">
+    <value>Weergegeven</value>
+  </data>
+  <data name="WorkspacePage_ViewMode_Raw.Text" xml:space="preserve">
+    <value>Onbewerkt</value>
+  </data>
+  <data name="WorkspacePage_DisconnectedMessage" xml:space="preserve">
+    <value>Maak verbinding met de gateway om werkruimtebestanden te bekijken.</value>
+  </data>
+  <data name="WorkspacePage_NoFilesMessage" xml:space="preserve">
+    <value>Geen werkruimtebestanden gevonden voor deze agent.</value>
+  </data>
+  <data name="WorkspacePage_LoadingContent" xml:space="preserve">
+    <value>Inhoud laden…</value>
+  </data>
+  <data name="WorkspacePage_MissingFile" xml:space="preserve">
+    <value>(bestand niet gevonden op schijf)</value>
   </data>
   <data name="WorkspacePage_TextBlock_34.Text" xml:space="preserve">
     <value>Vernieuwen</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2131,7 +2131,28 @@
     <value>æ¯æ—¥æˆæœ¬</value>
   </data>
   <data name="WorkspacePage_TextBlock_22.Text" xml:space="preserve">
-    <value>📂 工作区</value>
+    <value>工作区</value>
+  </data>
+  <data name="WorkspacePage_FilesHeader.Text" xml:space="preserve">
+    <value>文件</value>
+  </data>
+  <data name="WorkspacePage_ViewMode_Rendered.Text" xml:space="preserve">
+    <value>渲染</value>
+  </data>
+  <data name="WorkspacePage_ViewMode_Raw.Text" xml:space="preserve">
+    <value>原始</value>
+  </data>
+  <data name="WorkspacePage_DisconnectedMessage" xml:space="preserve">
+    <value>连接到网关以查看工作区文件。</value>
+  </data>
+  <data name="WorkspacePage_NoFilesMessage" xml:space="preserve">
+    <value>此代理未找到工作区文件。</value>
+  </data>
+  <data name="WorkspacePage_LoadingContent" xml:space="preserve">
+    <value>正在加载内容…</value>
+  </data>
+  <data name="WorkspacePage_MissingFile" xml:space="preserve">
+    <value>(磁盘上找不到文件)</value>
   </data>
   <data name="WorkspacePage_TextBlock_34.Text" xml:space="preserve">
     <value>åˆ·æ–°</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2131,7 +2131,28 @@
     <value>æ¯æ—¥æˆæœ¬</value>
   </data>
   <data name="WorkspacePage_TextBlock_22.Text" xml:space="preserve">
-    <value>📂 工作區</value>
+    <value>工作區</value>
+  </data>
+  <data name="WorkspacePage_FilesHeader.Text" xml:space="preserve">
+    <value>檔案</value>
+  </data>
+  <data name="WorkspacePage_ViewMode_Rendered.Text" xml:space="preserve">
+    <value>渲染</value>
+  </data>
+  <data name="WorkspacePage_ViewMode_Raw.Text" xml:space="preserve">
+    <value>原始</value>
+  </data>
+  <data name="WorkspacePage_DisconnectedMessage" xml:space="preserve">
+    <value>連線至閘道以檢視工作區檔案。</value>
+  </data>
+  <data name="WorkspacePage_NoFilesMessage" xml:space="preserve">
+    <value>此代理沒有找到工作區檔案。</value>
+  </data>
+  <data name="WorkspacePage_LoadingContent" xml:space="preserve">
+    <value>正在載入內容…</value>
+  </data>
+  <data name="WorkspacePage_MissingFile" xml:space="preserve">
+    <value>(磁碟上找不到檔案)</value>
   </data>
   <data name="WorkspacePage_TextBlock_34.Text" xml:space="preserve">
     <value>é‡æ–°æ•´ç†</value>

--- a/tests/OpenClaw.Tray.Tests/FluentIconCatalogTests.cs
+++ b/tests/OpenClaw.Tray.Tests/FluentIconCatalogTests.cs
@@ -27,6 +27,8 @@ public sealed class FluentIconCatalogTests
         "Brand",
         // Diagnostics surface (see src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml).
         "Bug", "Briefcase", "Folder", "Copy", "Document", "Refresh", "Reset", "Clear", "Develop",
+        // Workspace surface (see src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml).
+        "Workspace",
     };
 
     private static string ReadCatalogSource()


### PR DESCRIPTION
Redesigns the per-agent **Workspace** page with a Win 11 Settings-style master-detail layout and a markdown viewer toggle.

## What changed

- **Master-detail card** — ListView of files on the left, content on the right, sharing one bordered card with aligned header row (no floating-card alignment gap). Replaces the previous TabView.
- **Rendered / Raw SelectorBar** for `.md` files, with an in-process minimal markdown renderer (h1-h6, paragraphs, lists, fenced code, inline bold / italic / code, link labels).
- **Centered column** that grows symmetric white side bars as the window widens; MaxWidth=900 mirrors the Permissions page.
- **No emoji** on the page title (Segoe Fluent only).

## Design-skill alignment (`openclaw-design`)

- Added `FluentIconCatalog.Workspace` (OpenLocal U+E8DA) + `FluentIconCatalogTests` pin.
- Refresh button now binds to `FluentIconCatalog.Refresh` with `IsTextScaleFactorEnabled=False`.
- All markdown / raw / code-block typography goes through `Page.Resources` Styles `BasedOn` system text styles - no raw `FontSize` / `FontWeight`.
- `ListViewItem` margin moved off the 1px off-grid value.
- InfoBar / loading / missing-file copy moved to `resw` across all five locales.

## Validation

- `./build.ps1` - all four projects succeeded.
- `OpenClaw.Shared.Tests` - 1891 passed / 29 skipped.
- `OpenClaw.Tray.Tests` - 1178 passed.

## Screens

The unified card now keeps the file selector and content perfectly aligned at the top, with the Rendered/Raw toggle sitting in the right header next to the selected filename.

<img width="2003" height="1477" alt="image" src="https://github.com/user-attachments/assets/6964381b-6560-4b3f-bc20-27c78e161213" />
