### PR TITLE
Tidy Usage page and recover from disconnected gateway

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml
@@ -59,7 +59,7 @@
                     <StackPanel Spacing="4">
                         <TextBlock x:Uid="UsagePage_TextBlock_45" Text="Tokens" Style="{StaticResource CaptionTextBlockStyle}"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <TextBlock x:Uid="TokenCountText" x:Name="TokenCountText" Text="—"
+                        <TextBlock x:Name="TokenCountText" Text="—"
                                    Style="{StaticResource SubtitleTextBlockStyle}"/>
                     </StackPanel>
                 </Border>

--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml
@@ -4,11 +4,11 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
+    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
     <Grid HorizontalAlignment="Stretch">
         <StackPanel Padding="24" Spacing="16" HorizontalAlignment="Stretch" MaxWidth="900">
 
-            <TextBlock x:Uid="UsagePage_TextBlock_10" Text="📊 Usage &amp; Cost" Style="{StaticResource TitleTextBlockStyle}"/>
+            <TextBlock x:Uid="UsagePage_TextBlock_10" Text="Usage &amp; Cost" Style="{StaticResource TitleTextBlockStyle}"/>
 
             <InfoBar x:Name="ConnectionInfoBar"
                      IsOpen="False" IsClosable="False" Severity="Warning"
@@ -27,43 +27,55 @@
                     <TextBlock x:Uid="UsagePage_TextBlock_21" Text="Total Cost" Style="{StaticResource CaptionTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                HorizontalAlignment="Center"/>
-                    <TextBlock x:Name="TotalCostText" Text="—" FontSize="28" FontWeight="SemiBold"
+                    <TextBlock x:Name="TotalCostText" Text="—"
+                               Style="{StaticResource TitleLargeTextBlockStyle}"
                                HorizontalAlignment="Center"/>
                 </StackPanel>
             </Border>
 
-            <!-- Stats row: 3 cards side by side -->
-            <StackPanel Orientation="Horizontal" Spacing="12">
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            <!-- Stats row: 3 equal cards that grow with available width. -->
+            <Grid ColumnSpacing="12">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Border Grid.Column="0"
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                         BorderThickness="1" CornerRadius="8" Padding="16" MinWidth="150">
                     <StackPanel Spacing="4">
                         <TextBlock x:Uid="UsagePage_TextBlock_35" Text="Requests" Style="{StaticResource CaptionTextBlockStyle}"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <TextBlock x:Name="RequestCountText" Text="—" FontSize="28" FontWeight="SemiBold"/>
+                        <TextBlock x:Name="RequestCountText" Text="—"
+                                   Style="{StaticResource SubtitleTextBlockStyle}"/>
                     </StackPanel>
                 </Border>
 
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                <Border Grid.Column="1"
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                         BorderThickness="1" CornerRadius="8" Padding="16" MinWidth="150">
                     <StackPanel Spacing="4">
                         <TextBlock x:Uid="UsagePage_TextBlock_45" Text="Tokens" Style="{StaticResource CaptionTextBlockStyle}"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <TextBlock x:Uid="TokenCountText" x:Name="TokenCountText" Text="—" FontSize="28" FontWeight="SemiBold"/>
+                        <TextBlock x:Uid="TokenCountText" x:Name="TokenCountText" Text="—"
+                                   Style="{StaticResource SubtitleTextBlockStyle}"/>
                     </StackPanel>
                 </Border>
 
-                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                <Border Grid.Column="2"
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                         BorderThickness="1" CornerRadius="8" Padding="16" MinWidth="150">
                     <StackPanel Spacing="4">
                         <TextBlock x:Uid="UsagePage_TextBlock_55" Text="Providers" Style="{StaticResource CaptionTextBlockStyle}"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <TextBlock x:Name="ProviderCountText" Text="—" FontSize="28" FontWeight="SemiBold"/>
+                        <TextBlock x:Name="ProviderCountText" Text="—"
+                                   Style="{StaticResource SubtitleTextBlockStyle}"/>
                     </StackPanel>
                 </Border>
-            </StackPanel>
+            </Grid>
 
             <!-- Provider Breakdown card — real-time provider status (independent of the time range below). -->
             <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"

--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
@@ -161,13 +161,24 @@ public sealed partial class UsagePage : Page
 
     public void UpdateUsageCost(GatewayCostUsageInfo cost)
     {
-        if (cost.Days != _currentPeriodDays)
-            return;
-
         if (cost.UpdatedAt < _lastAppliedUsageCostUpdatedAtUtc)
             return;
 
+        // The Windows tray fires usage.cost twice per refresh: once via
+        // RequestUsageAsync() (always days=30) and once directly via the
+        // selector (currently 7 or 30). If the gateway ignores the `days`
+        // request param or only replies to one of the two, the page used to
+        // reject the response that didn't match _currentPeriodDays and the
+        // spinner ran forever. Accept whatever days the server returns and,
+        // when the selector is out of sync, silently snap it to that period
+        // so the header isn't lying about what data the user sees.
+        if (cost.Days > 0 && cost.Days != _currentPeriodDays)
+        {
+            SyncSelectorToServerDays(cost.Days);
+        }
+
         _lastAppliedUsageCostUpdatedAtUtc = cost.UpdatedAt;
+        ConnectionInfoBar.IsOpen = false;
         TotalCostText.Text = $"${cost.Totals.TotalCost:F2}";
         TokenCountText.Text = FormatLargeNumber(cost.Totals.TotalTokens);
 
@@ -180,8 +191,24 @@ public sealed partial class UsagePage : Page
         UpdateDailyCostLoadingVisuals();
     }
 
+    private void SyncSelectorToServerDays(int days)
+    {
+        // Only the two SelectorBar items are valid targets; ignore anything
+        // else (e.g. server-defaulted 14 days) and just keep the user's pick.
+        if (days != 7 && days != 30) return;
+        _currentPeriodDays = days;
+        var target = days == 30 ? Period30DaysItem : Period7DaysItem;
+        if (!ReferenceEquals(PeriodSelector.SelectedItem, target))
+        {
+            PeriodSelector.SelectionChanged -= OnPeriodSelectionChanged;
+            try { PeriodSelector.SelectedItem = target; }
+            finally { PeriodSelector.SelectionChanged += OnPeriodSelectionChanged; }
+        }
+    }
+
     public void UpdateUsageStatus(GatewayUsageStatusInfo status)
     {
+        ConnectionInfoBar.IsOpen = false;
         ProviderCountText.Text = status.Providers.Count.ToString();
         ProviderListView.ItemsSource = status.Providers.Select(p => new ProviderRow
         {
@@ -231,7 +258,7 @@ public sealed partial class UsagePage : Page
         DailyListView.Visibility = _dailyCostLoading.ShouldShowContent ? Visibility.Visible : Visibility.Collapsed;
         // After Fail() the state is !IsRefreshing && !HasLoaded, which leaves the
         // card visually empty (no spinner, no rows, no message). Surface a
-        // disconnected message in that case so the page never looks frozen.
+        // message in that case so the page never looks frozen.
         bool failed = !_dailyCostLoading.IsRefreshing && !_dailyCostLoading.HasLoaded;
         DailyEmptyText.Text = failed ? DisconnectedListMessage : DailyEmptyMessage;
         DailyEmptyText.Visibility = (_dailyCostLoading.ShouldShowEmpty || failed) ? Visibility.Visible : Visibility.Collapsed;

--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
@@ -14,11 +14,16 @@ public sealed partial class UsagePage : Page
 {
     private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private AppState? _appState;
+    private IOperatorGatewayClient? _trackedClient;
     // Default matches the XAML-selected Period7DaysItem (IsSelected="True").
     private int _currentPeriodDays = 7;
     private readonly AsyncListLoadingState _providerLoading = new();
     private readonly AsyncListLoadingState _dailyCostLoading = new();
     private DateTime _lastAppliedUsageCostUpdatedAtUtc = DateTime.MinValue;
+
+    private const string DailyEmptyMessage = "No daily usage for this period";
+    private const string ProviderEmptyMessage = "No providers configured";
+    private const string DisconnectedListMessage = "Couldn't load. Check your gateway connection.";
 
     public UsagePage()
     {
@@ -26,6 +31,7 @@ public sealed partial class UsagePage : Page
         Unloaded += (_, _) =>
         {
             if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+            DetachClient();
         };
     }
 
@@ -34,40 +40,95 @@ public sealed partial class UsagePage : Page
         if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
         _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
+
         var client = CurrentApp.GatewayClient;
-        if (client != null)
-        {
-            ConnectionInfoBar.IsOpen = false;
-            // Apply cached data immediately, then request fresh.
-            if (_appState?.Usage != null) UpdateUsage(_appState.Usage);
-            // Only apply cached cost data when its period matches the current
-            // selection — otherwise the daily list briefly shows e.g. 30-day
-            // data while the selector reads "7 Days".
-            if (_appState?.UsageCost != null && _appState.UsageCost.Days == _currentPeriodDays)
-            {
-                UpdateUsageCost(_appState.UsageCost);
-                _dailyCostLoading.BeginRefresh();
-            }
-            else
-            {
-                _dailyCostLoading.BeginInitialRefresh();
-            }
-            if (_appState?.UsageStatus != null) UpdateUsageStatus(_appState.UsageStatus);
-            else _providerLoading.BeginInitialRefresh();
-            UpdateDailyCostLoadingVisuals();
-            UpdateProviderLoadingVisuals();
-            _ = client.RequestUsageAsync();
-            _ = client.RequestUsageCostAsync(_currentPeriodDays);
-            _ = client.RequestUsageStatusAsync();
-        }
-        else
+        AttachClient(client);
+
+        // A non-null client may still be disconnected (e.g. WebSocket reconnecting).
+        // The underlying RequestUsage*/RequestUsageCost*/RequestUsageStatus calls
+        // silently no-op when !IsConnectedToGateway, so without this check the
+        // page would spin its progress rings forever — see user reports of
+        // "page not loading, no values".
+        if (client == null || !client.IsConnectedToGateway)
         {
             _providerLoading.Fail();
             _dailyCostLoading.Fail();
             ShowDisconnected();
             UpdateProviderLoadingVisuals();
             UpdateDailyCostLoadingVisuals();
+            return;
         }
+
+        ConnectionInfoBar.IsOpen = false;
+        // Apply cached data immediately, then request fresh.
+        if (_appState?.Usage != null) UpdateUsage(_appState.Usage);
+        // Only apply cached cost data when its period matches the current
+        // selection — otherwise the daily list briefly shows e.g. 30-day
+        // data while the selector reads "7 Days".
+        if (_appState?.UsageCost != null && _appState.UsageCost.Days == _currentPeriodDays)
+        {
+            UpdateUsageCost(_appState.UsageCost);
+            _dailyCostLoading.BeginRefresh();
+        }
+        else
+        {
+            _dailyCostLoading.BeginInitialRefresh();
+        }
+        if (_appState?.UsageStatus != null) UpdateUsageStatus(_appState.UsageStatus);
+        else _providerLoading.BeginInitialRefresh();
+        UpdateDailyCostLoadingVisuals();
+        UpdateProviderLoadingVisuals();
+        RequestRefresh(client);
+    }
+
+    private void AttachClient(IOperatorGatewayClient? client)
+    {
+        if (ReferenceEquals(_trackedClient, client)) return;
+        DetachClient();
+        _trackedClient = client;
+        if (_trackedClient != null)
+        {
+            _trackedClient.StatusChanged += OnClientStatusChanged;
+        }
+    }
+
+    private void DetachClient()
+    {
+        if (_trackedClient != null)
+        {
+            _trackedClient.StatusChanged -= OnClientStatusChanged;
+            _trackedClient = null;
+        }
+    }
+
+    private void OnClientStatusChanged(object? sender, ConnectionStatus status)
+    {
+        // Recover automatically when the gateway comes online while the page
+        // is open (otherwise the user is stuck on the disconnected info bar
+        // with stale cards until they navigate away and back).
+        if (sender is not IOperatorGatewayClient client) return;
+        if (!client.IsConnectedToGateway) return;
+
+        var dispatcher = DispatcherQueue;
+        if (dispatcher == null) return;
+        dispatcher.TryEnqueue(() =>
+        {
+            if (_trackedClient != client) return;
+            ConnectionInfoBar.IsOpen = false;
+            if (!_dailyCostLoading.HasLoaded) _dailyCostLoading.BeginInitialRefresh();
+            else _dailyCostLoading.BeginRefresh();
+            if (!_providerLoading.HasLoaded) _providerLoading.BeginInitialRefresh();
+            UpdateDailyCostLoadingVisuals();
+            UpdateProviderLoadingVisuals();
+            RequestRefresh(client);
+        });
+    }
+
+    private void RequestRefresh(IOperatorGatewayClient client)
+    {
+        _ = client.RequestUsageAsync();
+        _ = client.RequestUsageCostAsync(_currentPeriodDays);
+        _ = client.RequestUsageStatusAsync();
     }
 
     private void OnOpenConnectionClick(object sender, RoutedEventArgs e)
@@ -130,7 +191,6 @@ public sealed partial class UsagePage : Page
             Status = p.Error ?? "",
         }).ToList();
 
-        bool hasProviders = status.Providers.Count > 0;
         _providerLoading.Complete(status.Providers.Count);
         UpdateProviderLoadingVisuals();
     }
@@ -152,9 +212,10 @@ public sealed partial class UsagePage : Page
         _dailyCostLoading.BeginInitialRefresh();
         UpdateDailyCostLoadingVisuals();
 
-        if (CurrentApp.GatewayClient != null)
+        var client = CurrentApp.GatewayClient;
+        if (client != null && client.IsConnectedToGateway)
         {
-            _ = CurrentApp.GatewayClient.RequestUsageCostAsync(days);
+            _ = client.RequestUsageCostAsync(days);
         }
         else
         {
@@ -168,7 +229,12 @@ public sealed partial class UsagePage : Page
     {
         DailyLoadingPanel.Visibility = _dailyCostLoading.ShouldShowLoading ? Visibility.Visible : Visibility.Collapsed;
         DailyListView.Visibility = _dailyCostLoading.ShouldShowContent ? Visibility.Visible : Visibility.Collapsed;
-        DailyEmptyText.Visibility = _dailyCostLoading.ShouldShowEmpty ? Visibility.Visible : Visibility.Collapsed;
+        // After Fail() the state is !IsRefreshing && !HasLoaded, which leaves the
+        // card visually empty (no spinner, no rows, no message). Surface a
+        // disconnected message in that case so the page never looks frozen.
+        bool failed = !_dailyCostLoading.IsRefreshing && !_dailyCostLoading.HasLoaded;
+        DailyEmptyText.Text = failed ? DisconnectedListMessage : DailyEmptyMessage;
+        DailyEmptyText.Visibility = (_dailyCostLoading.ShouldShowEmpty || failed) ? Visibility.Visible : Visibility.Collapsed;
         PeriodSelector.IsEnabled = _dailyCostLoading.CanEdit;
     }
 
@@ -176,7 +242,9 @@ public sealed partial class UsagePage : Page
     {
         ProviderLoadingPanel.Visibility = _providerLoading.ShouldShowLoading ? Visibility.Visible : Visibility.Collapsed;
         ProviderListView.Visibility = _providerLoading.ShouldShowContent ? Visibility.Visible : Visibility.Collapsed;
-        ProviderEmptyText.Visibility = _providerLoading.ShouldShowEmpty ? Visibility.Visible : Visibility.Collapsed;
+        bool failed = !_providerLoading.IsRefreshing && !_providerLoading.HasLoaded;
+        ProviderEmptyText.Text = failed ? DisconnectedListMessage : ProviderEmptyMessage;
+        ProviderEmptyText.Visibility = (_providerLoading.ShouldShowEmpty || failed) ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private void ShowDisconnected()

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2145,9 +2145,6 @@ On your gateway host (Mac/Linux), run:
   <data name="UsagePage_TextBlock_45.Text" xml:space="preserve">
     <value>Tokens</value>
   </data>
-  <data name="TokenCountText.Text" xml:space="preserve">
-    <value>284.5K</value>
-  </data>
   <data name="UsagePage_TextBlock_55.Text" xml:space="preserve">
     <value>Providers</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2407,7 +2407,7 @@ On your gateway host (Mac/Linux), run:
     <value>OpenClaw Menu</value>
   </data>
   <data name="UsagePage_TextBlock_10.Text" xml:space="preserve">
-    <value>📊 Usage &amp; Cost</value>
+    <value>Usage &amp; Cost</value>
   </data>
   <data name="ChatWindowOpenInBrowserToolTip.Content" xml:space="preserve">
     <value>Open in Companion app</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2097,9 +2097,6 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="UsagePage_TextBlock_45.Text" xml:space="preserve">
     <value>Jetons</value>
   </data>
-  <data name="TokenCountText.Text" xml:space="preserve">
-    <value>284.5K</value>
-  </data>
   <data name="UsagePage_TextBlock_55.Text" xml:space="preserve">
     <value>Fournisseurs</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2359,7 +2359,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>OpenClaw Menu</value>
   </data>
   <data name="UsagePage_TextBlock_10.Text" xml:space="preserve">
-    <value>📊 Utilisation et coût</value>
+    <value>Utilisation et coût</value>
   </data>
   <data name="ChatWindowOpenInBrowserToolTip.Content" xml:space="preserve">
     <value>Ouvrir dans le navigateur</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2098,9 +2098,6 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="UsagePage_TextBlock_45.Text" xml:space="preserve">
     <value>Toegangstokens</value>
   </data>
-  <data name="TokenCountText.Text" xml:space="preserve">
-    <value>284.5K</value>
-  </data>
   <data name="UsagePage_TextBlock_55.Text" xml:space="preserve">
     <value>Aanbieders</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2360,7 +2360,7 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>OpenClaw Menu</value>
   </data>
   <data name="UsagePage_TextBlock_10.Text" xml:space="preserve">
-    <value>📊 Gebruik en kosten</value>
+    <value>Gebruik en kosten</value>
   </data>
   <data name="ChatWindowOpenInBrowserToolTip.Content" xml:space="preserve">
     <value>Openen in browser</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2097,9 +2097,6 @@
   <data name="UsagePage_TextBlock_45.Text" xml:space="preserve">
     <value>令牌</value>
   </data>
-  <data name="TokenCountText.Text" xml:space="preserve">
-    <value>284.5K</value>
-  </data>
   <data name="UsagePage_TextBlock_55.Text" xml:space="preserve">
     <value>提供程序</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2359,7 +2359,7 @@
     <value>OpenClaw Menu</value>
   </data>
   <data name="UsagePage_TextBlock_10.Text" xml:space="preserve">
-    <value>📊 使用量和成本</value>
+    <value>使用量和成本</value>
   </data>
   <data name="ChatWindowOpenInBrowserToolTip.Content" xml:space="preserve">
     <value>在浏览器中打开</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2097,9 +2097,6 @@
   <data name="UsagePage_TextBlock_45.Text" xml:space="preserve">
     <value>權杖</value>
   </data>
-  <data name="TokenCountText.Text" xml:space="preserve">
-    <value>284.5K</value>
-  </data>
   <data name="UsagePage_TextBlock_55.Text" xml:space="preserve">
     <value>提供者</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2359,7 +2359,7 @@
     <value>OpenClaw Menu</value>
   </data>
   <data name="UsagePage_TextBlock_10.Text" xml:space="preserve">
-    <value>📊 使用量與成本</value>
+    <value>使用量與成本</value>
   </data>
   <data name="ChatWindowOpenInBrowserToolTip.Content" xml:space="preserve">
     <value>在瀏覽器中開啟</value>


### PR DESCRIPTION
## Summary

Cleans up the Usage page and fixes the "page not loading / no values" report.

## Layout (openclaw-design + winuxe)

- Removed 📊 emoji from the page title (no emoji on WinUI surfaces); updated 5 resw locales.
- Switched the 3 stat cards from a horizontal `StackPanel` to a 3-column `Grid` (equal widths) so they share available width cleanly.
- Replaced raw `FontSize`/`FontWeight` with Fluent typography styles (`TitleLargeTextBlockStyle` for the hero Total Cost, `SubtitleTextBlockStyle` for the small stats) per winuxe Critical Rule #4.
- Kept `MaxWidth=900` to match Permissions/Connection/Settings.

## Bug fix: page not loading

Root cause: `OpenClawGatewayClient.RequestUsage*` calls silently no-op when `!IsConnectedToGateway`. Navigating while the WebSocket was reconnecting left the progress rings spinning forever and after `Fail()` the visual helpers hid loading, content, **and** empty — leaving completely blank cards.

- Treat `client == null || !client.IsConnectedToGateway` as disconnected in `Initialize` and `SelectPeriod`.
- Subscribe to `client.StatusChanged` so the page self-heals when the gateway comes online later (re-fires the three requests on the UI thread); unsubscribe in `Unloaded`.
- Surface a "Couldn't load. Check your gateway connection." message when loading state is failed-and-never-loaded.

## Validation

- `./build.ps1` ✅
- Tray tests: 1178 passed ✅
- Shared tests: 1890 passed ✅ (29 skipped)
<img width="1651" height="1233" alt="image" src="https://github.com/user-attachments/assets/64dd12e0-709c-489c-a71d-6387aa08239b" />
