### PR TITLE
Skills page: align with Fluent / Win 11 Settings conventions

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml
@@ -4,89 +4,72 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <Grid Padding="24,16,24,16" MaxWidth="900" HorizontalAlignment="Center">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Padding="24,16,24,16" Spacing="8"
+                    MaxWidth="900" HorizontalAlignment="Center">
 
-        <!-- Header -->
-        <StackPanel Grid.Row="0" Spacing="8" Margin="0,0,0,12">
-            <StackPanel Orientation="Horizontal" Spacing="8">
+            <!-- Header -->
+            <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,0,0,4">
                 <TextBlock Text="Skills" Style="{StaticResource TitleTextBlockStyle}"/>
                 <TextBlock x:Name="CountText" Text="" VerticalAlignment="Center"
                            Style="{StaticResource CaptionTextBlockStyle}"
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
             </StackPanel>
-            <ComboBox x:Uid="AgentFilterCombo" x:Name="AgentFilterCombo" Header="Agent" MinWidth="200">
-                <ComboBoxItem Content="All Agents" Tag="" IsSelected="True"/>
-            </ComboBox>
+            <ComboBox x:Uid="AgentFilterCombo" x:Name="AgentFilterCombo" Header="Agent"
+                      MinWidth="200" Margin="0,0,0,8"/>
+
+            <!-- Skills Groups -->
+            <StackPanel x:Name="SkillsGroups" Spacing="8" Visibility="Collapsed">
+
+                <Expander x:Name="EnabledExpander"
+                          IsExpanded="True"
+                          HorizontalAlignment="Stretch"
+                          HorizontalContentAlignment="Stretch">
+                    <Expander.Header>
+                        <TextBlock x:Name="EnabledHeaderText" Text="Enabled"
+                                   Style="{StaticResource BodyStrongTextBlockStyle}"
+                                   VerticalAlignment="Center"/>
+                    </Expander.Header>
+                    <StackPanel x:Name="EnabledPanel" Spacing="4"/>
+                </Expander>
+
+                <Expander x:Name="DisabledExpander"
+                          IsExpanded="True"
+                          HorizontalAlignment="Stretch"
+                          HorizontalContentAlignment="Stretch"
+                          Visibility="Collapsed">
+                    <Expander.Header>
+                        <TextBlock x:Name="DisabledHeaderText" Text="Disabled"
+                                   Style="{StaticResource BodyStrongTextBlockStyle}"
+                                   VerticalAlignment="Center"/>
+                    </Expander.Header>
+                    <StackPanel x:Name="DisabledPanel" Spacing="4"/>
+                </Expander>
+            </StackPanel>
+
+            <!-- Loading State -->
+            <StackPanel x:Name="LoadingState" Orientation="Horizontal" Spacing="12"
+                        HorizontalAlignment="Center" Margin="0,32,0,0"
+                        Visibility="Collapsed">
+                <ProgressRing IsActive="True" Width="24" Height="24"/>
+                <TextBlock Text="Loading skills..."
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           VerticalAlignment="Center"/>
+            </StackPanel>
+
+            <!-- Empty State -->
+            <StackPanel x:Name="EmptyState" Visibility="Collapsed"
+                        HorizontalAlignment="Center" Spacing="8" Margin="0,48,0,0">
+                <FontIcon Glyph="&#xEA86;" FontSize="48" HorizontalAlignment="Center"
+                          Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                <TextBlock Text="No skills installed"
+                           Style="{StaticResource SubtitleTextBlockStyle}"
+                           HorizontalAlignment="Center"/>
+                <TextBlock Text="Skills extend your agent's capabilities. Install skills via the CLI or ClawHub."
+                           Style="{StaticResource CaptionTextBlockStyle}"
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           HorizontalAlignment="Center" TextWrapping="Wrap" MaxWidth="320"/>
+            </StackPanel>
         </StackPanel>
-
-        <!-- Skills Groups -->
-        <Grid x:Name="SkillsGroups" Grid.Row="1" Visibility="Collapsed">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
-
-            <!-- Sticky Enabled Header -->
-            <Button x:Name="EnabledHeaderBtn" Grid.Row="0" HorizontalAlignment="Stretch"
-                    HorizontalContentAlignment="Left" Padding="12,8,12,8" Margin="0,0,0,2"
-                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    BorderThickness="0" CornerRadius="4">
-                <StackPanel Orientation="Horizontal" Spacing="6">
-                    <FontIcon x:Name="EnabledChevron" Glyph="&#xE70E;" FontSize="10" VerticalAlignment="Center"/>
-                    <TextBlock x:Name="EnabledHeaderText" Text="Enabled"
-                               Style="{StaticResource BodyStrongTextBlockStyle}"
-                               VerticalAlignment="Center"/>
-                </StackPanel>
-            </Button>
-
-            <!-- Scrollable card content -->
-            <ScrollViewer x:Name="SkillsScroller" Grid.Row="1" VerticalScrollBarVisibility="Auto">
-                <StackPanel Spacing="0">
-                    <StackPanel x:Name="EnabledPanel" Spacing="0"/>
-
-                    <!-- Disabled Header (scrolls with content) -->
-                    <Button x:Name="DisabledHeaderBtn" HorizontalAlignment="Stretch"
-                            HorizontalContentAlignment="Left" Padding="12,8,12,8" Margin="0,8,0,2"
-                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                            BorderThickness="0" CornerRadius="4" Visibility="Collapsed">
-                        <StackPanel Orientation="Horizontal" Spacing="6">
-                            <FontIcon x:Name="DisabledChevron" Glyph="&#xE70E;" FontSize="10" VerticalAlignment="Center"/>
-                            <TextBlock x:Name="DisabledHeaderText" Text="Disabled"
-                                       Style="{StaticResource BodyStrongTextBlockStyle}"
-                                       VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </Button>
-                    <StackPanel x:Name="DisabledPanel" Spacing="0"/>
-                </StackPanel>
-            </ScrollViewer>
-        </Grid>
-
-        <!-- Loading State -->
-        <StackPanel x:Name="LoadingState" Grid.Row="1" Orientation="Horizontal" Spacing="12"
-                    HorizontalAlignment="Center" VerticalAlignment="Center"
-                    Visibility="Collapsed">
-            <ProgressRing IsActive="True" Width="22" Height="22"/>
-            <TextBlock Text="Loading skills..."
-                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                       VerticalAlignment="Center"/>
-        </StackPanel>
-
-        <!-- Empty State -->
-        <StackPanel x:Name="EmptyState" Grid.Row="1" Visibility="Collapsed"
-                    VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8">
-            <FontIcon Glyph="&#xEA86;" FontSize="48" HorizontalAlignment="Center"
-                      Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-            <TextBlock Text="No skills installed"
-                       Style="{StaticResource SubtitleTextBlockStyle}"
-                       HorizontalAlignment="Center"/>
-            <TextBlock Text="Skills extend your agent's capabilities. Install skills via the CLI or ClawHub."
-                       Style="{StaticResource CaptionTextBlockStyle}"
-                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                       HorizontalAlignment="Center" TextWrapping="Wrap" MaxWidth="320"/>
-        </StackPanel>
-    </Grid>
+    </ScrollViewer>
 </Page>

--- a/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml
@@ -37,7 +37,8 @@
                     BorderThickness="0" CornerRadius="4">
                 <StackPanel Orientation="Horizontal" Spacing="6">
                     <FontIcon x:Name="EnabledChevron" Glyph="&#xE70E;" FontSize="10" VerticalAlignment="Center"/>
-                    <TextBlock x:Name="EnabledHeaderText" Text="Enabled" FontWeight="SemiBold" FontSize="13"
+                    <TextBlock x:Name="EnabledHeaderText" Text="Enabled"
+                               Style="{StaticResource BodyStrongTextBlockStyle}"
                                VerticalAlignment="Center"/>
                 </StackPanel>
             </Button>
@@ -54,7 +55,8 @@
                             BorderThickness="0" CornerRadius="4" Visibility="Collapsed">
                         <StackPanel Orientation="Horizontal" Spacing="6">
                             <FontIcon x:Name="DisabledChevron" Glyph="&#xE70E;" FontSize="10" VerticalAlignment="Center"/>
-                            <TextBlock x:Name="DisabledHeaderText" Text="Disabled" FontWeight="SemiBold" FontSize="13"
+                            <TextBlock x:Name="DisabledHeaderText" Text="Disabled"
+                                       Style="{StaticResource BodyStrongTextBlockStyle}"
                                        VerticalAlignment="Center"/>
                         </StackPanel>
                     </Button>
@@ -76,7 +78,8 @@
         <!-- Empty State -->
         <StackPanel x:Name="EmptyState" Grid.Row="1" Visibility="Collapsed"
                     VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8">
-            <TextBlock Text="🧩" FontSize="48" HorizontalAlignment="Center"/>
+            <FontIcon Glyph="&#xEA86;" FontSize="48" HorizontalAlignment="Center"
+                      Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
             <TextBlock Text="No skills installed"
                        Style="{StaticResource SubtitleTextBlockStyle}"
                        HorizontalAlignment="Center"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml
@@ -5,8 +5,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel Padding="24,16,24,16" Spacing="8"
-                    MaxWidth="900" HorizontalAlignment="Center">
+        <Grid HorizontalAlignment="Stretch">
+            <StackPanel Padding="24" Spacing="8"
+                        HorizontalAlignment="Stretch" MaxWidth="900">
 
             <!-- Header -->
             <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,0,0,4">
@@ -70,6 +71,7 @@
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                            HorizontalAlignment="Center" TextWrapping="Wrap" MaxWidth="320"/>
             </StackPanel>
-        </StackPanel>
+            </StackPanel>
+        </Grid>
     </ScrollViewer>
 </Page>

--- a/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml
@@ -4,7 +4,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <Grid Padding="24,16,24,16" MaxWidth="900" HorizontalAlignment="Stretch">
+    <Grid Padding="24,16,24,16" MaxWidth="900" HorizontalAlignment="Center">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
@@ -13,7 +13,7 @@
         <!-- Header -->
         <StackPanel Grid.Row="0" Spacing="8" Margin="0,0,0,12">
             <StackPanel Orientation="Horizontal" Spacing="8">
-                <TextBlock Text="🧩 Skills" Style="{StaticResource TitleTextBlockStyle}"/>
+                <TextBlock Text="Skills" Style="{StaticResource TitleTextBlockStyle}"/>
                 <TextBlock x:Name="CountText" Text="" VerticalAlignment="Center"
                            Style="{StaticResource CaptionTextBlockStyle}"
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml.cs
@@ -26,19 +26,6 @@ public sealed partial class SkillsPage : Page
         {
             if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
         };
-        EnabledHeaderBtn.Click += (s, e) =>
-        {
-            _enabledExpanded = !_enabledExpanded;
-            EnabledChevron.Glyph = _enabledExpanded ? "\uE70E" : "\uE70D";
-            EnabledPanel.Visibility = _enabledExpanded ? Visibility.Visible : Visibility.Collapsed;
-            if (!_enabledExpanded) SkillsScroller.ChangeView(null, 0, null, disableAnimation: false);
-        };
-        DisabledHeaderBtn.Click += (s, e) =>
-        {
-            _disabledExpanded = !_disabledExpanded;
-            DisabledChevron.Glyph = _disabledExpanded ? "\uE70E" : "\uE70D";
-            DisabledPanel.Visibility = _disabledExpanded ? Visibility.Visible : Visibility.Collapsed;
-        };
     }
 
     public void Initialize()
@@ -198,9 +185,6 @@ public sealed partial class SkillsPage : Page
         RebuildCards();
     }
 
-    private bool _enabledExpanded = true;
-    private bool _disabledExpanded = true;
-
     private void RebuildCards()
     {
         LoadingState.Visibility = Visibility.Collapsed;
@@ -217,9 +201,7 @@ public sealed partial class SkillsPage : Page
 
         EnabledHeaderText.Text = $"Enabled ({enabled.Count})";
         DisabledHeaderText.Text = $"Disabled ({disabled.Count})";
-        DisabledHeaderBtn.Visibility = disabled.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
-        DisabledPanel.Visibility = _disabledExpanded ? Visibility.Visible : Visibility.Collapsed;
-        EnabledPanel.Visibility = _enabledExpanded ? Visibility.Visible : Visibility.Collapsed;
+        DisabledExpander.Visibility = disabled.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
 
         var total = _allSkills.Count;
         CountText.Text = total > 0 ? $"({enabled.Count}/{total} enabled)" : "";

--- a/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml.cs
@@ -1,4 +1,3 @@
-using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
@@ -7,7 +6,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Text.Json;
-using Windows.UI;
 
 namespace OpenClawTray.Pages;
 
@@ -239,18 +237,24 @@ public sealed partial class SkillsPage : Page
         var nameRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8, Opacity = contentOpacity };
         nameRow.Children.Add(new TextBlock { Text = s.Name, FontSize = 13, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold, VerticalAlignment = VerticalAlignment.Center });
 
-        var badgeBg = s.IsEnabled
-            ? new SolidColorBrush(Color.FromArgb(40, 76, 175, 80))
-            : new SolidColorBrush(Color.FromArgb(40, 230, 168, 23));
-        var badgeFg = s.IsEnabled
-            ? new SolidColorBrush(Colors.LimeGreen)
-            : new SolidColorBrush(Color.FromArgb(255, 230, 168, 23));
+        var badgeBgKey = s.IsEnabled ? "SystemFillColorSuccessBackgroundBrush" : "ControlFillColorSecondaryBrush";
+        var badgeFgKey = s.IsEnabled ? "SystemFillColorSuccessBrush" : "TextFillColorSecondaryBrush";
         var badge = new Border
         {
-            CornerRadius = new CornerRadius(4), Padding = new Thickness(6, 2, 6, 2),
-            Background = badgeBg, VerticalAlignment = VerticalAlignment.Center
+            CornerRadius = new CornerRadius(10),
+            MinHeight = 20,
+            Padding = new Thickness(8, 2, 8, 2),
+            Background = (Brush)Application.Current.Resources[badgeBgKey],
+            VerticalAlignment = VerticalAlignment.Center
         };
-        badge.Child = new TextBlock { Text = s.IsEnabled ? "enabled" : "disabled", FontSize = 10, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold, Foreground = badgeFg, VerticalAlignment = VerticalAlignment.Center };
+        badge.Child = new TextBlock
+        {
+            Text = s.IsEnabled ? "Enabled" : "Disabled",
+            FontSize = 11,
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+            Foreground = (Brush)Application.Current.Resources[badgeFgKey],
+            VerticalAlignment = VerticalAlignment.Center
+        };
         nameRow.Children.Add(badge);
         Grid.SetRow(nameRow, 0);
         Grid.SetColumn(nameRow, 0);


### PR DESCRIPTION
Tidy up the Skills page UI to match Fluent / Win 11 Settings conventions used elsewhere in the app (PermissionsPage, ConnectionPage, DebugPage). UI-only — no behavior changes.

## What

- **Title**: drop the 🧩 emoji.
- **Sizing**: switch to the canonical `Padding=24`, `HorizontalAlignment=Stretch`, `MaxWidth=900` inside a Grid wrapper, so the page centers in a fixed-width column and grows white side bars as the window widens (ConnectionPage pattern — Grid is needed because the page's initial visible content is narrower than the cap).
- **Group headers**: replace the hand-rolled `Button` + chevron + manual collapse state for Enabled / Disabled with stock WinUI `Expander` (~35 fewer lines of code-behind).
- **Empty state**: swap the 🧩 emoji for the Segoe Fluent Puzzle glyph (U+EA86) so it renders correctly across themes / HC.
- **Typography**: drop raw `FontWeight`/`FontSize` on the group headers in favor of `BodyStrongTextBlockStyle`.
- **Status pills**: replace the hand-mixed LimeGreen / amber ARGB colors on Enabled / Disabled badges with the canonical `SystemFillColorSuccess(Background)?Brush` / `ControlFillColorSecondaryBrush` token pairs (matching `ChannelsPage.BuildBadge`). Fixes a low-contrast pill in light theme and brings the pill into Fluent + High Contrast compliance.

## Validation

- `./build.ps1` ✅
- `dotnet test ./tests/OpenClaw.Shared.Tests --no-restore` ✅
- `dotnet test ./tests/OpenClaw.Tray.Tests --no-restore` ✅
- Manually verified in the running tray app.

<img width="2002" height="1486" alt="image" src="https://github.com/user-attachments/assets/2b1a3863-0055-43dc-a9b9-6baf7b5eec6d" />
