### PR TITLE
Reorganize Config page UI to follow Fluent guidelines

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml
@@ -3,95 +3,128 @@
     x:Class="OpenClawTray.Pages.ConfigPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:local="using:OpenClawTray.Controls">
 
-    <Grid Padding="24,16,24,16" RowSpacing="12" MaxWidth="900" HorizontalAlignment="Stretch">
+    <!-- Win11 Settings pattern: content is capped at a comfortable reading
+         width. Stretch + MaxWidth keeps every pane at the same width so the
+         layout doesn't shift when toggling Editor / Raw JSON or when the
+         selected field's detail content changes. -->
+    <Grid Padding="24,16,24,16" RowSpacing="12"
+          MaxWidth="900" HorizontalAlignment="Stretch">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
+        <!-- ───────── Page header ───────── -->
         <StackPanel Grid.Row="0" Spacing="4">
-            <StackPanel Orientation="Horizontal" Spacing="12">
-                <TextBlock x:Uid="ConfigPage_TextBlock_17" Text="⚙️ Config" Style="{StaticResource TitleTextBlockStyle}" VerticalAlignment="Center"/>
-                <Button x:Name="RefreshButton" Click="OnRefresh" VerticalAlignment="Center">
-                    <StackPanel Orientation="Horizontal" Spacing="6">
-                        <FontIcon Glyph="&#xE72C;" FontSize="14"/>
-                        <TextBlock x:Uid="ConfigPage_TextBlock_21" Text="Refresh"/>
-                    </StackPanel>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Column="0"
+                           x:Uid="ConfigPage_TextBlock_17" Text="Config"
+                           Style="{StaticResource TitleTextBlockStyle}"
+                           VerticalAlignment="Center"/>
+                <Button Grid.Column="1"
+                        x:Name="RefreshButton" Click="OnRefresh"
+                        VerticalAlignment="Center">
+                    <TextBlock x:Uid="ConfigPage_TextBlock_21" Text="Refresh"/>
                 </Button>
-            </StackPanel>
+            </Grid>
             <TextBlock x:Uid="ConfigSubtitle" x:Name="ConfigSubtitle"
                        Text="Editing gateway configuration (openclaw.json) fetched from the connected gateway"
                        Style="{StaticResource CaptionTextBlockStyle}"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
         </StackPanel>
 
-        <!-- Tabs: Editor + Raw JSON -->
-        <TabView Grid.Row="1" x:Name="ConfigTabs" IsAddTabButtonVisible="False"
-                 TabWidthMode="SizeToContent" SelectionChanged="OnConfigTabChanged">
-            <TabViewItem x:Uid="ConfigPage_TabViewItem_34" Header="Editor" IsClosable="False">
-                <Grid x:Name="SchemaTreeGrid">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="280"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
+        <!-- ───────── Segmented selector (Editor / Raw JSON) ───────── -->
+        <controls:SelectorBar Grid.Row="1" x:Name="ConfigSelector"
+                              SelectionChanged="OnConfigSelectorChanged"
+                              HorizontalAlignment="Left">
+            <controls:SelectorBarItem x:Name="EditorSelectorItem"
+                                      x:Uid="ConfigPage_TabViewItem_34"
+                                      Text="Editor" IsSelected="True" Tag="editor"/>
+            <controls:SelectorBarItem x:Name="RawJsonSelectorItem"
+                                      x:Uid="ConfigPage_TabViewItem_82"
+                                      Text="Raw JSON" Tag="raw"/>
+        </controls:SelectorBar>
 
-                    <Border Grid.Column="0"
-                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                            BorderThickness="1" CornerRadius="8" Margin="0,0,12,0">
-                        <TreeView x:Name="ConfigTree"
-                                  SelectionMode="Single"
-                                  ItemInvoked="OnTreeItemInvoked"
-                                  Padding="4"/>
-                    </Border>
+        <!-- ───────── Editor pane ───────── -->
+        <!-- Single card with internal 1px vertical divider so the tree and
+             the detail editor read as one surface (no 12px gutter). -->
+        <Border Grid.Row="2" x:Name="EditorPane"
+                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                BorderThickness="1" CornerRadius="8">
+            <Grid x:Name="SchemaTreeGrid">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="280"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
 
-                    <Border Grid.Column="1"
-                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                            BorderThickness="1" CornerRadius="8">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="*"/>
-                            </Grid.RowDefinitions>
+                <Border Grid.Column="0"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="0,0,1,0">
+                    <TreeView x:Name="ConfigTree"
+                              SelectionMode="Single"
+                              ItemInvoked="OnTreeItemInvoked"
+                              Padding="4"/>
+                </Border>
 
-                            <StackPanel Grid.Row="0" Padding="16,12" Spacing="4"
-                                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                                        BorderThickness="0,0,0,1">
-                                <TextBlock x:Uid="DetailPath" x:Name="DetailPath" Text="Select a config section"
-                                           Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                                <TextBlock x:Name="DetailType" Text=""
-                                           Style="{StaticResource CaptionTextBlockStyle}"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                            </StackPanel>
+                <Grid Grid.Column="1">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
 
-                            <ScrollViewer Grid.Row="1" Padding="16,8">
-                                <StackPanel x:Name="DetailPanel" Spacing="8">
-                                    <TextBlock x:Uid="DetailPlaceholder" x:Name="DetailPlaceholder"
-                                               Text="Select a section from the tree to edit its settings."
-                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                                </StackPanel>
-                            </ScrollViewer>
-                        </Grid>
-                    </Border>
+                    <StackPanel Grid.Row="0" Padding="16,12" Spacing="4"
+                                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                BorderThickness="0,0,0,1">
+                        <TextBlock x:Uid="DetailPath" x:Name="DetailPath" Text="Select a config section"
+                                   Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                        <TextBlock x:Name="DetailType" Text=""
+                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                    </StackPanel>
+
+                    <ScrollViewer Grid.Row="1" Padding="16,8"
+                                  HorizontalScrollMode="Disabled"
+                                  HorizontalScrollBarVisibility="Disabled">
+                        <StackPanel x:Name="DetailPanel" Spacing="8"
+                                    HorizontalAlignment="Stretch">
+                            <TextBlock x:Uid="DetailPlaceholder" x:Name="DetailPlaceholder"
+                                       Text="Select a section from the tree to edit its settings."
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                        </StackPanel>
+                    </ScrollViewer>
                 </Grid>
-            </TabViewItem>
-            <TabViewItem x:Uid="ConfigPage_TabViewItem_82" Header="Raw JSON" IsClosable="False">
-                <ScrollViewer Padding="16">
-                    <TextBlock x:Name="RawJsonText" FontFamily="Consolas" FontSize="12"
-                               IsTextSelectionEnabled="True" TextWrapping="Wrap"
-                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                </ScrollViewer>
-            </TabViewItem>
-        </TabView>
+            </Grid>
+        </Border>
 
-        <!-- No schema fallback -->
-        <StackPanel x:Name="NoSchemaPanel" Grid.Row="1" Visibility="Collapsed"
+        <!-- ───────── Raw JSON pane ───────── -->
+        <Border Grid.Row="2" x:Name="RawJsonPane" Visibility="Collapsed"
+                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                BorderThickness="1" CornerRadius="8">
+            <ScrollViewer Padding="16">
+                <TextBlock x:Name="RawJsonText"
+                           FontFamily="Consolas"
+                           Style="{StaticResource CaptionTextBlockStyle}"
+                           IsTextSelectionEnabled="True" TextWrapping="Wrap"
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+            </ScrollViewer>
+        </Border>
+
+        <!-- ───────── No-schema fallback ───────── -->
+        <StackPanel x:Name="NoSchemaPanel" Grid.Row="2" Visibility="Collapsed"
                     VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="12">
-            <TextBlock Text="⚙️" FontSize="48" HorizontalAlignment="Center"/>
+            <FontIcon Glyph="&#xE713;" FontSize="48" HorizontalAlignment="Center"
+                      Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
             <TextBlock x:Uid="ConfigPage_TextBlock_95" Text="Schema not available"
                        Style="{StaticResource SubtitleTextBlockStyle}"
                        HorizontalAlignment="Center"/>
@@ -103,9 +136,14 @@
                     HorizontalAlignment="Center" Style="{ThemeResource AccentButtonStyle}"/>
         </StackPanel>
 
-        <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right" Padding="0,8,0,0">
-            <TextBlock x:Name="SaveStatus" VerticalAlignment="Center" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-            <Button x:Uid="SaveButton" x:Name="SaveButton" Content="Save Changes" Style="{ThemeResource AccentButtonStyle}" Click="OnSave"/>
+        <!-- ───────── Save bar ───────── -->
+        <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8"
+                    HorizontalAlignment="Right" Padding="0,8,0,0">
+            <TextBlock x:Name="SaveStatus" VerticalAlignment="Center"
+                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+            <Button x:Uid="SaveButton" x:Name="SaveButton"
+                    Content="Save Changes"
+                    Style="{ThemeResource AccentButtonStyle}" Click="OnSave"/>
         </StackPanel>
     </Grid>
 </Page>

--- a/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml
@@ -6,10 +6,8 @@
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:local="using:OpenClawTray.Controls">
 
-    <!-- Win11 Settings pattern: content is capped at a comfortable reading
-         width. Stretch + MaxWidth keeps every pane at the same width so the
-         layout doesn't shift when toggling Editor / Raw JSON or when the
-         selected field's detail content changes. -->
+    <!-- Cap content width and stretch so panes don't shift size when toggling
+         Editor / Raw JSON or when the selected field changes. -->
     <Grid Padding="24,16,24,16" RowSpacing="12"
           MaxWidth="900" HorizontalAlignment="Stretch">
         <Grid.RowDefinitions>
@@ -55,8 +53,6 @@
         </controls:SelectorBar>
 
         <!-- ───────── Editor pane ───────── -->
-        <!-- Single card with internal 1px vertical divider so the tree and
-             the detail editor read as one surface (no 12px gutter). -->
         <Border Grid.Row="2" x:Name="EditorPane"
                 Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"

--- a/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
@@ -28,6 +28,8 @@ public sealed partial class ConfigPage : Page
     private readonly Dictionary<TreeViewNode, (string Path, JsonElement Element)> _nodeMap = new();
     private readonly Dictionary<string, object?> _pendingChanges = new();
 
+    private bool _showSchemaFallback;
+
     public ConfigPage()
     {
         InitializeComponent();
@@ -131,8 +133,8 @@ public sealed partial class ConfigPage : Page
         if (_lastSchema.HasValue)
         {
             // Schema-driven tree
-            NoSchemaPanel.Visibility = Visibility.Collapsed;
-            SchemaTreeGrid.Visibility = Visibility.Visible;
+            _showSchemaFallback = false;
+            ApplyPaneVisibility();
 
             var schema = _lastSchema.Value;
             var schemaRoot = schema.TryGetProperty("schema", out var sr) ? sr : schema;
@@ -141,16 +143,11 @@ public sealed partial class ConfigPage : Page
             BuildSchemaTreeNodes(ConfigTree.RootNodes, schemaRoot, configRoot, "");
             ExpandAll(ConfigTree.RootNodes);
         }
-        else if (_lastConfig.HasValue)
-        {
-            // No schema — show fallback panel
-            SchemaTreeGrid.Visibility = Visibility.Collapsed;
-            NoSchemaPanel.Visibility = Visibility.Visible;
-        }
         else
         {
-            SchemaTreeGrid.Visibility = Visibility.Collapsed;
-            NoSchemaPanel.Visibility = Visibility.Visible;
+            // No schema — show fallback panel (whether or not config loaded)
+            _showSchemaFallback = true;
+            ApplyPaneVisibility();
         }
     }
 
@@ -186,10 +183,26 @@ public sealed partial class ConfigPage : Page
 
     private void ShowConfigRenderError()
     {
-        SchemaTreeGrid.Visibility = Visibility.Collapsed;
-        NoSchemaPanel.Visibility = Visibility.Visible;
+        _showSchemaFallback = true;
+        ApplyPaneVisibility();
         SaveButton.IsEnabled = false;
         SaveStatus.Text = "Config unavailable";
+    }
+
+    /// <summary>
+    /// Reconciles which of the three Row 2 surfaces is visible:
+    /// the Editor card, the Raw JSON card, or the "no schema" fallback.
+    /// Called whenever schema state or the SelectorBar selection changes.
+    /// </summary>
+    private void ApplyPaneVisibility()
+    {
+        if (EditorPane is null || RawJsonPane is null || NoSchemaPanel is null) return;
+
+        var rawSelected = (ConfigSelector?.SelectedItem?.Tag as string) == "raw";
+
+        RawJsonPane.Visibility = rawSelected ? Visibility.Visible : Visibility.Collapsed;
+        EditorPane.Visibility  = (!rawSelected && !_showSchemaFallback) ? Visibility.Visible : Visibility.Collapsed;
+        NoSchemaPanel.Visibility = (!rawSelected && _showSchemaFallback) ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private void BuildSchemaTreeNodes(IList<TreeViewNode> parent, JsonElement schema, JsonElement? config, string basePath)
@@ -358,11 +371,9 @@ public sealed partial class ConfigPage : Page
 
     private void UpdateRawJson()
     {
-        // RawJsonText lives inside the second TabViewItem, whose content WinUI
-        // does not realize until the tab is first selected. Until then the
-        // x:Name field is null and touching .Text would NRE on the dispatcher
-        // queue — silently tearing down the app. OnConfigTabChanged calls us
-        // again once the tab is realized, so deferring here is safe.
+        // RawJsonText lives inside the Raw JSON pane; it's always realized
+        // (we just toggle Visibility), but keep the null guard for safety
+        // in case this is called before InitializeComponent finishes.
         if (RawJsonText is null) return;
 
         if (_lastConfig.HasValue)
@@ -385,10 +396,11 @@ public sealed partial class ConfigPage : Page
         }
     }
 
-    private void OnConfigTabChanged(object sender, SelectionChangedEventArgs e)
+    private void OnConfigSelectorChanged(SelectorBar sender, SelectorBarSelectionChangedEventArgs args)
     {
-        // Refresh raw JSON when switching to it
-        if (ConfigTabs.SelectedIndex == 1)
+        ApplyPaneVisibility();
+
+        if ((sender.SelectedItem?.Tag as string) == "raw")
             UpdateRawJson();
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
@@ -190,9 +190,8 @@ public sealed partial class ConfigPage : Page
     }
 
     /// <summary>
-    /// Reconciles which of the three Row 2 surfaces is visible:
-    /// the Editor card, the Raw JSON card, or the "no schema" fallback.
-    /// Called whenever schema state or the SelectorBar selection changes.
+    /// Reconciles which Row 2 surface is visible: Editor, Raw JSON, or
+    /// the "no schema" fallback.
     /// </summary>
     private void ApplyPaneVisibility()
     {
@@ -371,9 +370,6 @@ public sealed partial class ConfigPage : Page
 
     private void UpdateRawJson()
     {
-        // RawJsonText lives inside the Raw JSON pane; it's always realized
-        // (we just toggle Visibility), but keep the null guard for safety
-        // in case this is called before InitializeComponent finishes.
         if (RawJsonText is null) return;
 
         if (_lastConfig.HasValue)

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -1642,18 +1642,18 @@ On your gateway host (Mac/Linux), run:
     <value>The gateway is connected; the chat surface is still coming online.</value>
   </data>
   <data name="ConfigPage_TextBlock_17.Text" xml:space="preserve">
-    <value>⚙️ Config</value>
+    <value>Config</value>
   </data>
   <data name="ConfigPage_TextBlock_21.Text" xml:space="preserve">
     <value>Refresh</value>
   </data>
-  <data name="ConfigPage_TabViewItem_34.Header" xml:space="preserve">
+  <data name="ConfigPage_TabViewItem_34.Text" xml:space="preserve">
     <value>Editor</value>
   </data>
   <data name="DetailPath.Text" xml:space="preserve">
     <value>Select a config section</value>
   </data>
-  <data name="ConfigPage_TabViewItem_82.Header" xml:space="preserve">
+  <data name="ConfigPage_TabViewItem_82.Text" xml:space="preserve">
     <value>Raw JSON</value>
   </data>
   <data name="ConfigPage_TextBlock_95.Text" xml:space="preserve">

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -1594,18 +1594,18 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>La passerelle est connectée ; l'interface de chat est encore en cours de démarrage.</value>
   </data>
   <data name="ConfigPage_TextBlock_17.Text" xml:space="preserve">
-    <value>⚙️ Configuration</value>
+    <value>Configuration</value>
   </data>
   <data name="ConfigPage_TextBlock_21.Text" xml:space="preserve">
     <value>Actualiser</value>
   </data>
-  <data name="ConfigPage_TabViewItem_34.Header" xml:space="preserve">
+  <data name="ConfigPage_TabViewItem_34.Text" xml:space="preserve">
     <value>Éditeur</value>
   </data>
   <data name="DetailPath.Text" xml:space="preserve">
     <value>Sélectionnez une section de configuration</value>
   </data>
-  <data name="ConfigPage_TabViewItem_82.Header" xml:space="preserve">
+  <data name="ConfigPage_TabViewItem_82.Text" xml:space="preserve">
     <value>JSON brut</value>
   </data>
   <data name="ConfigPage_TextBlock_95.Text" xml:space="preserve">

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -1595,18 +1595,18 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>De gateway is verbonden; het chatoppervlak wordt nog geladen.</value>
   </data>
   <data name="ConfigPage_TextBlock_17.Text" xml:space="preserve">
-    <value>⚙️ Configuratie</value>
+    <value>Configuratie</value>
   </data>
   <data name="ConfigPage_TextBlock_21.Text" xml:space="preserve">
     <value>Vernieuwen</value>
   </data>
-  <data name="ConfigPage_TabViewItem_34.Header" xml:space="preserve">
+  <data name="ConfigPage_TabViewItem_34.Text" xml:space="preserve">
     <value>Bewerker</value>
   </data>
   <data name="DetailPath.Text" xml:space="preserve">
     <value>Selecteer een configuratiesectie</value>
   </data>
-  <data name="ConfigPage_TabViewItem_82.Header" xml:space="preserve">
+  <data name="ConfigPage_TabViewItem_82.Text" xml:space="preserve">
     <value>Ruwe JSON</value>
   </data>
   <data name="ConfigPage_TextBlock_95.Text" xml:space="preserve">

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -1594,18 +1594,18 @@
     <value>网关已连接；聊天界面仍在上线中。</value>
   </data>
   <data name="ConfigPage_TextBlock_17.Text" xml:space="preserve">
-    <value>⚙️ 配置</value>
+    <value>配置</value>
   </data>
   <data name="ConfigPage_TextBlock_21.Text" xml:space="preserve">
     <value>刷新</value>
   </data>
-  <data name="ConfigPage_TabViewItem_34.Header" xml:space="preserve">
+  <data name="ConfigPage_TabViewItem_34.Text" xml:space="preserve">
     <value>编辑器</value>
   </data>
   <data name="DetailPath.Text" xml:space="preserve">
     <value>选择配置部分</value>
   </data>
-  <data name="ConfigPage_TabViewItem_82.Header" xml:space="preserve">
+  <data name="ConfigPage_TabViewItem_82.Text" xml:space="preserve">
     <value>原始 JSON</value>
   </data>
   <data name="ConfigPage_TextBlock_95.Text" xml:space="preserve">

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -1594,18 +1594,18 @@
     <value>閘道已連接；聊天介面仍在上線中。</value>
   </data>
   <data name="ConfigPage_TextBlock_17.Text" xml:space="preserve">
-    <value>⚙️ 設定</value>
+    <value>設定</value>
   </data>
   <data name="ConfigPage_TextBlock_21.Text" xml:space="preserve">
     <value>重新整理</value>
   </data>
-  <data name="ConfigPage_TabViewItem_34.Header" xml:space="preserve">
+  <data name="ConfigPage_TabViewItem_34.Text" xml:space="preserve">
     <value>編輯器</value>
   </data>
   <data name="DetailPath.Text" xml:space="preserve">
     <value>選取設定區段</value>
   </data>
-  <data name="ConfigPage_TabViewItem_82.Header" xml:space="preserve">
+  <data name="ConfigPage_TabViewItem_82.Text" xml:space="preserve">
     <value>原始 JSON</value>
   </data>
   <data name="ConfigPage_TextBlock_95.Text" xml:space="preserve">


### PR DESCRIPTION
Reorganizes the Config page UI to follow Fluent / Win11 Settings guidelines. UI-only — no behavior changes.

**Changes**
- Remove gear emoji from page title (stripped from all 5 locale resw files)
- Replace `TabView` with `SelectorBar` (segmented control) for Editor / Raw JSON
- Move `Refresh` button to the right of the title
- Cap content at `MaxWidth=900` with stretch alignment so Editor and Raw JSON panes are always the same width and the editor no longer resizes with the selected field
- Merge tree + detail into a single card with a 1px internal divider (removes the 12px gutter)
- Replace fallback emoji with Segoe Fluent `FontIcon`; replace raw `FontSize` with `CaptionTextBlockStyle`
- Add `ApplyPaneVisibility()` helper to reconcile Editor / Raw JSON / no-schema fallback in one place

**Validation**
- `./build.ps1` ✅
- Shared.Tests --no-restore: 1891 passed / 29 skipped ✅
- Tray.Tests --no-restore: 1178 passed ✅

<img width="2016" height="1487" alt="image" src="https://github.com/user-attachments/assets/376513aa-04a3-40f3-a51b-5c82ec37c953" />
