### PR TITLE
Clean up Cron page UI to follow Fluent guidelines

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
@@ -92,6 +92,7 @@ public static class FluentIconCatalog
     public const string Reset = "\uE72C";          // Refresh (alias) — Reconfigure / start over
     public const string Clear = "\uE74D";          // Delete — clear/reset a buffer
     public const string Develop = "\uE943";        // Code — engineering / explorations action
+    public const string Cron = "\uE787";           // Calendar — Cron / scheduled jobs (matches HubWindow search mapping)
 
     /// <summary>
     /// Builds a <see cref="FontIcon"/> for the given PUA glyph using the

--- a/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml
@@ -2,11 +2,12 @@
 <Page
     x:Class="OpenClawTray.Pages.CronPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:helpers="using:OpenClawTray.Helpers">
 
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
+    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
     <Grid HorizontalAlignment="Stretch">
-    <Grid Padding="24,16,24,16" MaxWidth="900" HorizontalAlignment="Stretch">
+    <Grid x:Name="PageRootGrid" Padding="24,16,24,16" MaxWidth="900" HorizontalAlignment="Stretch">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -25,32 +26,34 @@
                      <ColumnDefinition Width="Auto"/>
                      <ColumnDefinition Width="Auto"/>
                  </Grid.ColumnDefinitions>
-                 <TextBlock Text="⏱️ Cron Jobs" Style="{StaticResource TitleTextBlockStyle}" Grid.Column="0"/>
+                 <TextBlock Text="Cron Jobs" Style="{StaticResource TitleTextBlockStyle}" Grid.Column="0" VerticalAlignment="Center"/>
                  <TextBlock x:Name="JobCountText" Text="(0)" VerticalAlignment="Center" Grid.Column="1" Margin="8,0,0,0"
                             Style="{StaticResource CaptionTextBlockStyle}"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                 <Button x:Name="RefreshButton" Grid.Column="3" Click="OnRefreshClick" Padding="8,4" Margin="0,0,8,0">
-                     <StackPanel Orientation="Horizontal" Spacing="4">
-                         <FontIcon Glyph="&#xE72C;" FontSize="14"/>
-                         <TextBlock Text="Refresh" FontSize="13"/>
+                 <Button x:Name="RefreshButton" Grid.Column="3" Click="OnRefreshClick" Margin="0,0,8,0">
+                     <StackPanel Orientation="Horizontal" Spacing="8">
+                         <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Refresh, Mode=OneTime}" FontSize="14"/>
+                         <TextBlock Text="Refresh"/>
                      </StackPanel>
                  </Button>
-                 <Button x:Name="NewJobButton" Grid.Column="4" Click="OnNewJobClick" Padding="8,4">
-                     <StackPanel Orientation="Horizontal" Spacing="4">
-                         <FontIcon Glyph="&#xE710;" FontSize="14"/>
-                         <TextBlock Text="New Job" FontSize="13"/>
+                 <Button x:Name="NewJobButton" Grid.Column="4" Click="OnNewJobClick" Style="{StaticResource AccentButtonStyle}">
+                     <StackPanel Orientation="Horizontal" Spacing="8">
+                         <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Add, Mode=OneTime}" FontSize="14"/>
+                         <TextBlock Text="New job"/>
                     </StackPanel>
                 </Button>
             </Grid>
 
             <!-- Scheduler status row -->
             <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    CornerRadius="6" Padding="12,8">
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8" Padding="12,8">
                 <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                     <Ellipse x:Name="SchedulerStatusIndicator" Width="8" Height="8"
-                             Fill="Gray" VerticalAlignment="Center"/>
+                             Fill="{ThemeResource TextFillColorTertiaryBrush}" VerticalAlignment="Center"/>
                     <TextBlock x:Name="SchedulerStatusText" Text="—" VerticalAlignment="Center"
-                               FontSize="13"/>
+                               Style="{StaticResource BodyTextBlockStyle}"/>
                     <TextBlock x:Name="NextWakeText" Text="" VerticalAlignment="Center"
                                Style="{StaticResource CaptionTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
@@ -73,10 +76,12 @@
 
         <!-- Job creation/edit form -->
         <Border x:Name="JobFormPanel" Grid.Row="2" Visibility="Collapsed"
-                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                Background="{ThemeResource LayerFillColorDefaultBrush}"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                BorderThickness="1"
                 CornerRadius="8" Padding="20" Margin="0,0,0,12">
             <StackPanel Spacing="16">
-                <TextBlock x:Name="FormTitle" Text="New Cron Job" Style="{StaticResource SubtitleTextBlockStyle}"/>
+                <TextBlock x:Name="FormTitle" Text="New cron job" Style="{StaticResource SubtitleTextBlockStyle}"/>
 
                 <!-- Row 1: Name + Schedule type -->
                 <Grid ColumnSpacing="12">
@@ -85,14 +90,12 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
                     <StackPanel Spacing="4" Grid.Column="0">
-                        <TextBlock Text="NAME" FontSize="11" FontWeight="SemiBold"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <TextBox x:Name="FormName" PlaceholderText="Morning brief" FontSize="13"/>
+                        <TextBlock Text="Name" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                        <TextBox x:Name="FormName" PlaceholderText="Morning brief"/>
                     </StackPanel>
                     <StackPanel Spacing="4" Grid.Column="1">
-                        <TextBlock Text="SCHEDULE" FontSize="11" FontWeight="SemiBold"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <ComboBox x:Name="FormScheduleKind" SelectedIndex="0" HorizontalAlignment="Stretch" FontSize="13"
+                        <TextBlock Text="Schedule" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                        <ComboBox x:Name="FormScheduleKind" SelectedIndex="0" HorizontalAlignment="Stretch"
                                   SelectionChanged="OnScheduleKindChanged">
                             <ComboBoxItem Content="Every" Tag="every"/>
                             <ComboBoxItem Content="At" Tag="at"/>
@@ -103,24 +106,18 @@
 
                 <!-- Schedule presets (cron only) -->
                 <StackPanel x:Name="CronFields" Spacing="8">
-                    <TextBlock Text="QUICK PRESETS" FontSize="11" FontWeight="SemiBold"
-                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                    <TextBlock Text="Quick presets" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                     <ItemsControl x:Name="PresetGrid">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <StackPanel Orientation="Horizontal" Spacing="6"/>
+                                <StackPanel Orientation="Horizontal" Spacing="8"/>
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
-                        <Button Content="⏰ Hourly" Tag="0 * * * *" Click="OnPresetClick"
-                                FontSize="11" Padding="10,6" CornerRadius="6"/>
-                        <Button Content="🌅 Daily 9am" Tag="0 9 * * *" Click="OnPresetClick"
-                                FontSize="11" Padding="10,6" CornerRadius="6"/>
-                        <Button Content="🌆 Daily 6pm" Tag="0 18 * * *" Click="OnPresetClick"
-                                FontSize="11" Padding="10,6" CornerRadius="6"/>
-                        <Button Content="💼 Weekdays" Tag="0 9 * * 1-5" Click="OnPresetClick"
-                                FontSize="11" Padding="10,6" CornerRadius="6"/>
-                        <Button Content="📅 Weekly" Tag="0 9 * * 1" Click="OnPresetClick"
-                                FontSize="11" Padding="10,6" CornerRadius="6"/>
+                        <Button Content="Hourly" Tag="0 * * * *" Click="OnPresetClick"/>
+                        <Button Content="Daily 9am" Tag="0 9 * * *" Click="OnPresetClick"/>
+                        <Button Content="Daily 6pm" Tag="0 18 * * *" Click="OnPresetClick"/>
+                        <Button Content="Weekdays" Tag="0 9 * * 1-5" Click="OnPresetClick"/>
+                        <Button Content="Weekly" Tag="0 9 * * 1" Click="OnPresetClick"/>
                     </ItemsControl>
 
                     <!-- Cron expression + timezone row -->
@@ -130,15 +127,13 @@
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
                         <StackPanel Spacing="4" Grid.Column="0">
-                            <TextBlock Text="EXPRESSION" FontSize="11" FontWeight="SemiBold"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                            <TextBlock Text="Expression" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                             <TextBox x:Name="FormCronExpr" PlaceholderText="0 9 * * *"
-                                     FontSize="13" FontFamily="Consolas"/>
+                                     FontFamily="Consolas"/>
                         </StackPanel>
                         <StackPanel Spacing="4" Grid.Column="1">
-                            <TextBlock Text="TIMEZONE" FontSize="11" FontWeight="SemiBold"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                            <ComboBox x:Name="FormTimezone" HorizontalAlignment="Stretch" FontSize="13"
+                            <TextBlock Text="Timezone" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                            <ComboBox x:Name="FormTimezone" HorizontalAlignment="Stretch"
                                       PlaceholderText="Optional">
                                 <ComboBoxItem Content="America/New_York" Tag="America/New_York"/>
                                 <ComboBoxItem Content="America/Chicago" Tag="America/Chicago"/>
@@ -161,15 +156,13 @@
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
                         <StackPanel Spacing="4" Grid.Column="0">
-                            <TextBlock Text="EVERY" FontSize="11" FontWeight="SemiBold"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                            <TextBox x:Name="FormEveryValue" Text="30" FontSize="13"
+                            <TextBlock Text="Every" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                            <TextBox x:Name="FormEveryValue" Text="30"
                                      InputScope="Number"/>
                         </StackPanel>
                         <StackPanel Spacing="4" Grid.Column="1">
-                            <TextBlock Text="UNIT" FontSize="11" FontWeight="SemiBold"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                            <ComboBox x:Name="FormEveryUnit" SelectedIndex="0" HorizontalAlignment="Stretch" FontSize="13">
+                            <TextBlock Text="Unit" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                            <ComboBox x:Name="FormEveryUnit" SelectedIndex="0" HorizontalAlignment="Stretch">
                                 <ComboBoxItem Content="Minutes" Tag="60000"/>
                                 <ComboBoxItem Content="Hours" Tag="3600000"/>
                                 <ComboBoxItem Content="Days" Tag="86400000"/>
@@ -180,8 +173,7 @@
 
                 <!-- At fields -->
                 <StackPanel x:Name="AtFields" Spacing="4" Visibility="Collapsed">
-                    <TextBlock Text="RUN AT" FontSize="11" FontWeight="SemiBold"
-                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                    <TextBlock Text="Run at" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                     <StackPanel Orientation="Horizontal" Spacing="12">
                         <CalendarDatePicker x:Name="FormAtDate" PlaceholderText="Date"
                                             DateFormat="{}{month.abbreviated} {day.integer}, {year.full}"/>
@@ -189,15 +181,14 @@
                                  InputScope="TimeHour"/>
                     </StackPanel>
                     <CheckBox x:Name="FormDeleteAfterRun" Content="Delete job after it runs" IsChecked="True"
-                              FontSize="12" Margin="0,4,0,0"/>
+                              Margin="0,4,0,0"/>
                 </StackPanel>
 
                 <!-- Prompt -->
                 <StackPanel Spacing="4">
-                    <TextBlock Text="PROMPT / PAYLOAD" FontSize="11" FontWeight="SemiBold"
-                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                    <TextBlock Text="Prompt / payload" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                     <TextBox x:Name="FormMessage" PlaceholderText="What should the agent do?"
-                             AcceptsReturn="True" TextWrapping="Wrap" MinHeight="72" MaxHeight="140" FontSize="13"/>
+                             AcceptsReturn="True" TextWrapping="Wrap" MinHeight="72" MaxHeight="140"/>
                 </StackPanel>
 
                 <!-- Row: Delivery + Channel -->
@@ -207,25 +198,24 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
                     <StackPanel Spacing="4" Grid.Column="0">
-                        <TextBlock Text="DELIVERY" FontSize="11" FontWeight="SemiBold"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <ComboBox x:Name="FormDeliveryMode" SelectedIndex="0" HorizontalAlignment="Stretch" FontSize="13"
+                        <TextBlock Text="Delivery" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                        <ComboBox x:Name="FormDeliveryMode" SelectedIndex="0" HorizontalAlignment="Stretch"
                                   SelectionChanged="OnDeliveryModeChanged">
                             <ComboBoxItem Content="Silent (none)" Tag="none"/>
                             <ComboBoxItem Content="Notify me (announce)" Tag="announce"/>
                         </ComboBox>
                     </StackPanel>
                     <StackPanel x:Name="DeliveryChannelPanel" Spacing="4" Grid.Column="1" Visibility="Collapsed">
-                        <TextBlock Text="CHANNEL" FontSize="11" FontWeight="SemiBold"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <TextBox x:Name="FormDeliveryChannel" PlaceholderText="e.g. webchat" FontSize="13"/>
+                        <TextBlock Text="Channel" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                        <TextBox x:Name="FormDeliveryChannel" PlaceholderText="e.g. webchat"/>
                     </StackPanel>
                 </Grid>
 
                 <!-- Advanced options -->
                 <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
                     <Expander.Header>
-                        <TextBlock Text="Advanced options" FontSize="12"
+                        <TextBlock Text="Advanced options"
+                                   Style="{StaticResource BodyTextBlockStyle}"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                     </Expander.Header>
                     <StackPanel Spacing="12" Margin="0,4,0,0">
@@ -236,17 +226,15 @@
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
                             <StackPanel Spacing="4" Grid.Column="0">
-                                <TextBlock Text="SESSION BEHAVIOR" FontSize="11" FontWeight="SemiBold"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                                <ComboBox x:Name="FormSessionTarget" SelectedIndex="0" HorizontalAlignment="Stretch" FontSize="13">
+                                <TextBlock Text="Session behavior" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                <ComboBox x:Name="FormSessionTarget" SelectedIndex="0" HorizontalAlignment="Stretch">
                                     <ComboBoxItem Content="New session each run" Tag="isolated"/>
                                     <ComboBoxItem Content="Resume main session" Tag="main"/>
                                 </ComboBox>
                             </StackPanel>
                             <StackPanel Spacing="4" Grid.Column="1">
-                                <TextBlock Text="WAKE MODE" FontSize="11" FontWeight="SemiBold"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                                <ComboBox x:Name="FormWakeMode" SelectedIndex="0" HorizontalAlignment="Stretch" FontSize="13">
+                                <TextBlock Text="Wake mode" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                <ComboBox x:Name="FormWakeMode" SelectedIndex="0" HorizontalAlignment="Stretch">
                                     <ComboBoxItem Content="Now (immediate)" Tag="now"/>
                                     <ComboBoxItem Content="Queue (wait for idle)" Tag="queue"/>
                                 </ComboBox>
@@ -256,14 +244,16 @@
                 </Expander>
 
                 <!-- Validation error -->
-                <TextBlock x:Name="FormError" Text="" Foreground="IndianRed" FontSize="12"
+                <TextBlock x:Name="FormError" Text=""
+                           Style="{StaticResource CaptionTextBlockStyle}"
+                           Foreground="{ThemeResource SystemFillColorCriticalBrush}"
                            Visibility="Collapsed" TextWrapping="Wrap"/>
 
                 <!-- Buttons -->
                 <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right" Margin="0,4,0,0">
-                    <Button x:Name="FormCancelButton" Content="Cancel" Click="OnFormCancelClick" Padding="16,8"/>
-                    <Button x:Name="FormSaveButton" Content="Create Job" Click="OnFormSaveClick"
-                            Style="{StaticResource AccentButtonStyle}" Padding="16,8" FontWeight="SemiBold"/>
+                    <Button x:Name="FormCancelButton" Content="Cancel" Click="OnFormCancelClick"/>
+                    <Button x:Name="FormSaveButton" Content="Create job" Click="OnFormSaveClick"
+                            Style="{StaticResource AccentButtonStyle}"/>
                 </StackPanel>
             </StackPanel>
         </Border>
@@ -279,6 +269,7 @@
                      Visibility="Visible">
              <ProgressRing IsActive="True" Width="22" Height="22"/>
              <TextBlock Text="Loading cron jobs..."
+                        Style="{StaticResource BodyTextBlockStyle}"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         VerticalAlignment="Center"/>
          </StackPanel>
@@ -287,7 +278,9 @@
          <StackPanel x:Name="EmptyState" Grid.Row="4"
                      VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8"
                      Visibility="Collapsed">
-            <TextBlock Text="⏱️" FontSize="48" HorizontalAlignment="Center"/>
+            <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Cron, Mode=OneTime}"
+                      FontSize="32" HorizontalAlignment="Center"
+                      Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
             <TextBlock Text="No cron jobs configured"
                        Style="{StaticResource SubtitleTextBlockStyle}"
                        HorizontalAlignment="Center"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
@@ -170,18 +170,18 @@ public sealed partial class CronPage : Page
         _ = CurrentApp.GatewayClient.RemoveCronJobAsync(jobId);
     }
 
-    private void OnToggleEnabledClick(object sender, RoutedEventArgs e)
+    private void OnEnabledToggleChanged(object sender, RoutedEventArgs e)
     {
-        var jobId = (sender as Button)?.Tag as string;
+        if (sender is not ToggleSwitch ts) return;
+        var jobId = ts.Tag as string;
         if (string.IsNullOrEmpty(jobId)) return;
         if (!_cronLoading.CanEdit) return;
         if (CurrentApp.GatewayClient == null) { ShowDisconnected(); return; }
 
         var vm = _jobs.Find(j => j.Id == jobId);
-        if (vm != null)
-        {
-            _ = CurrentApp.GatewayClient.UpdateCronJobAsync(jobId, new { enabled = !vm.IsEnabled });
-        }
+        if (vm == null) return;
+        if (ts.IsOn == vm.IsEnabled) return; // no-op (e.g., programmatic init)
+        _ = CurrentApp.GatewayClient.UpdateCronJobAsync(jobId, new { enabled = ts.IsOn });
     }
 
     // --- Job creation/edit form ---
@@ -736,15 +736,13 @@ public sealed partial class CronPage : Page
                 if (status == "ok" || status == "success")
                 {
                     vm.LastResult = "success";
-                    vm.ResultBadgeBackground = new SolidColorBrush(Color.FromArgb(40, 76, 175, 80));
-                    vm.ResultBadgeForeground = new SolidColorBrush(Colors.LimeGreen);
+                    vm.ResultBadgeForeground = (SolidColorBrush)Application.Current.Resources["SystemFillColorSuccessBrush"];
                     vm.ResultBadgeVisibility = Visibility.Visible;
                 }
                 else if (!string.IsNullOrEmpty(status) && status != "none")
                 {
                     vm.LastResult = status;
-                    vm.ResultBadgeBackground = new SolidColorBrush(Color.FromArgb(40, 224, 85, 69));
-                    vm.ResultBadgeForeground = new SolidColorBrush(Color.FromArgb(255, 224, 85, 69));
+                    vm.ResultBadgeForeground = (SolidColorBrush)Application.Current.Resources["SystemFillColorCriticalBrush"];
                     vm.ResultBadgeVisibility = Visibility.Visible;
                 }
             }
@@ -753,15 +751,13 @@ public sealed partial class CronPage : Page
                 if (okEl.ValueKind == JsonValueKind.True)
                 {
                     vm.LastResult = "success";
-                    vm.ResultBadgeBackground = new SolidColorBrush(Color.FromArgb(40, 76, 175, 80));
-                    vm.ResultBadgeForeground = new SolidColorBrush(Colors.LimeGreen);
+                    vm.ResultBadgeForeground = (SolidColorBrush)Application.Current.Resources["SystemFillColorSuccessBrush"];
                     vm.ResultBadgeVisibility = Visibility.Visible;
                 }
                 else if (okEl.ValueKind == JsonValueKind.False)
                 {
                     vm.LastResult = "fail";
-                    vm.ResultBadgeBackground = new SolidColorBrush(Color.FromArgb(40, 224, 85, 69));
-                    vm.ResultBadgeForeground = new SolidColorBrush(Color.FromArgb(255, 224, 85, 69));
+                    vm.ResultBadgeForeground = (SolidColorBrush)Application.Current.Resources["SystemFillColorCriticalBrush"];
                     vm.ResultBadgeVisibility = Visibility.Visible;
                 }
             }
@@ -844,7 +840,9 @@ public sealed partial class CronPage : Page
         DispatcherQueue?.TryEnqueue(() =>
         {
             SchedulerStatusText.Text = enabled ? "Enabled" : "Disabled";
-            SchedulerStatusIndicator.Fill = new SolidColorBrush(enabled ? Colors.LimeGreen : Colors.Gray);
+            SchedulerStatusIndicator.Fill = enabled
+                ? (Brush)Application.Current.Resources["SystemFillColorSuccessBrush"]
+                : (Brush)Application.Current.Resources["SystemFillColorNeutralBrush"];
             StorePathText.Text = storePath;
             NextWakeText.Text = $"· Next wake: {nextWake}";
         });
@@ -1096,10 +1094,11 @@ public sealed partial class CronPage : Page
 
     private Grid? FindParentGrid()
     {
-        // The page's main Grid is inside the ScrollViewer
-        if (this.Content is ScrollViewer sv && sv.Content is Grid g)
-            return g;
-        return null;
+        // The page's main Grid (with row definitions) is named PageRootGrid;
+        // it sits inside an outer wrapper Grid inside the ScrollViewer. Returning
+        // the wrapper instead would lose the row definitions and cause the form
+        // to overlap other rows of the inner grid.
+        return PageRootGrid;
     }
 
     // --- Card building ---
@@ -1121,6 +1120,8 @@ public sealed partial class CronPage : Page
             Margin = new Thickness(0, 2, 0, 0),
             CornerRadius = new CornerRadius(6),
             Background = (Brush)Application.Current.Resources["CardBackgroundFillColorDefaultBrush"],
+            BorderBrush = (Brush)Application.Current.Resources["CardStrokeColorDefaultBrush"],
+            BorderThickness = new Thickness(1),
             Opacity = vm.CardOpacity
         };
 
@@ -1129,15 +1130,15 @@ public sealed partial class CronPage : Page
         grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
         grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
 
-        // Row 0: Name + badges + chevron
-        var headerGrid = new Grid();
-        headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto }); // 0: name
-        headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto }); // 1: schedule
-        headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto }); // 2: enabled
-        headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto }); // 3: result
-        headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto }); // 4: running
-        headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) }); // 5: spacer
-        headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto }); // 6: chevron
+        // Row 0: Name + badges + spacer + toggle + chevron
+        var headerGrid = new Grid { VerticalAlignment = VerticalAlignment.Center };
+        headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });               // 0: name
+        headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });               // 1: schedule
+        headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });               // 2: result
+        headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });               // 3: running
+        headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) }); // 4: spacer
+        headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });               // 5: toggle
+        headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });               // 6: chevron
 
         var nameText = new TextBlock { Text = vm.Name, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold, FontSize = 14, VerticalAlignment = VerticalAlignment.Center };
         Grid.SetColumn(nameText, 0);
@@ -1147,32 +1148,22 @@ public sealed partial class CronPage : Page
         {
             CornerRadius = new CornerRadius(4), Padding = new Thickness(6, 2, 6, 2), Margin = new Thickness(8, 0, 0, 0),
             VerticalAlignment = VerticalAlignment.Center,
-            Background = (Brush)Application.Current.Resources["CardBackgroundFillColorSecondaryBrush"]
+            Background = (Brush)Application.Current.Resources["SubtleFillColorSecondaryBrush"]
         };
         scheduleBadge.Child = new TextBlock { Text = vm.Schedule, FontSize = 10, FontFamily = new FontFamily("Consolas"), Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"] };
         Grid.SetColumn(scheduleBadge, 1);
         headerGrid.Children.Add(scheduleBadge);
 
-        var enabledBadge = new Border
-        {
-            CornerRadius = new CornerRadius(4), Padding = new Thickness(6, 2, 6, 2), Margin = new Thickness(4, 0, 0, 0),
-            VerticalAlignment = VerticalAlignment.Center,
-            Background = vm.EnabledBadgeBackground
-        };
-        enabledBadge.Child = new TextBlock { Text = vm.EnabledText, FontSize = 10, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold, Foreground = vm.EnabledBadgeForeground };
-        Grid.SetColumn(enabledBadge, 2);
-        headerGrid.Children.Add(enabledBadge);
-
         if (vm.ResultBadgeVisibility == Visibility.Visible)
         {
             var resultBadge = new Border
             {
-                CornerRadius = new CornerRadius(4), Padding = new Thickness(5, 2, 5, 2), Margin = new Thickness(4, 0, 0, 0),
+                CornerRadius = new CornerRadius(4), Padding = new Thickness(6, 2, 6, 2), Margin = new Thickness(4, 0, 0, 0),
                 VerticalAlignment = VerticalAlignment.Center,
-                Background = vm.ResultBadgeBackground
+                Background = (Brush)Application.Current.Resources["SubtleFillColorSecondaryBrush"]
             };
             resultBadge.Child = new TextBlock { Text = vm.LastResult, FontSize = 10, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold, Foreground = vm.ResultBadgeForeground };
-            Grid.SetColumn(resultBadge, 3);
+            Grid.SetColumn(resultBadge, 2);
             headerGrid.Children.Add(resultBadge);
         }
 
@@ -1183,12 +1174,31 @@ public sealed partial class CronPage : Page
             {
                 CornerRadius = new CornerRadius(4), Padding = new Thickness(6, 2, 6, 2), Margin = new Thickness(4, 0, 0, 0),
                 VerticalAlignment = VerticalAlignment.Center,
-                Background = new SolidColorBrush(Color.FromArgb(40, 33, 150, 243))
+                Background = (Brush)Application.Current.Resources["SubtleFillColorSecondaryBrush"]
             };
-            runningBadge.Child = new TextBlock { Text = "⏳ Running", FontSize = 10, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold, Foreground = new SolidColorBrush(Color.FromArgb(255, 100, 181, 246)) };
-            Grid.SetColumn(runningBadge, 4);
+            runningBadge.Child = new TextBlock { Text = "Running", FontSize = 10, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold, Foreground = (Brush)Application.Current.Resources["SystemFillColorAttentionBrush"] };
+            Grid.SetColumn(runningBadge, 3);
             headerGrid.Children.Add(runningBadge);
         }
+
+        // Inline enabled/disabled toggle (right-aligned, before chevron).
+        // Stop tapped from bubbling so the card doesn't toggle expand state.
+        var enabledToggle = new ToggleSwitch
+        {
+            Tag = vm.Id,
+            IsOn = vm.IsEnabled,
+            OnContent = string.Empty,
+            OffContent = string.Empty,
+            MinWidth = 0,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(8, 0, 8, 0),
+            IsEnabled = _cronLoading.CanEdit
+        };
+        ToolTipService.SetToolTip(enabledToggle, vm.IsEnabled ? "Disable job" : "Enable job");
+        enabledToggle.Toggled += OnEnabledToggleChanged;
+        enabledToggle.Tapped += (s, ev) => { ev.Handled = true; };
+        Grid.SetColumn(enabledToggle, 5);
+        headerGrid.Children.Add(enabledToggle);
 
         var chevron = new FontIcon { Glyph = "\uE70D", FontSize = 10, VerticalAlignment = VerticalAlignment.Center, Foreground = (Brush)Application.Current.Resources["TextFillColorTertiaryBrush"] };
         Grid.SetColumn(chevron, 6);
@@ -1269,8 +1279,6 @@ public sealed partial class CronPage : Page
             runNowBtn.Opacity = 0.4;
         }
         buttonsPanel.Children.Add(runNowBtn);
-
-        buttonsPanel.Children.Add(MakeActionButton(vm.ToggleEnabledGlyph, vm.ToggleEnabledText, vm.Id, OnToggleEnabledClick));
 
         var editBtn = MakeActionButton("\uE70F", "Edit", vm.Id, OnEditJobClick);
         if (jobDisabled) editBtn.Opacity = 0.4;
@@ -1592,7 +1600,7 @@ public sealed partial class CronPage : Page
         var metaParts = new List<string>();
         if (!string.IsNullOrEmpty(model)) metaParts.Add(model);
         if (totalTokens > 0) metaParts.Add($"{totalTokens:N0} tokens");
-        if (delivered) metaParts.Add("delivered ✓");
+        if (delivered) metaParts.Add("delivered");
         else if (!string.IsNullOrEmpty(deliveryStatus)) metaParts.Add(deliveryStatus);
 
         if (metaParts.Count > 0)
@@ -1709,16 +1717,8 @@ public sealed partial class CronPage : Page
         public bool IsEnabled { get; set; } = true;
         public bool IsExpanded { get; set; } = false;
         public double CardOpacity => IsEnabled ? 1.0 : 0.5;
-        public string EnabledText => IsEnabled ? "enabled" : "disabled";
-        public SolidColorBrush EnabledBadgeBackground => IsEnabled
-            ? new SolidColorBrush(Color.FromArgb(40, 76, 175, 80))
-            : new SolidColorBrush(Color.FromArgb(40, 230, 168, 23));
-        public SolidColorBrush EnabledBadgeForeground => IsEnabled
-            ? new SolidColorBrush(Colors.LimeGreen)
-            : new SolidColorBrush(Color.FromArgb(255, 230, 168, 23));
         public string LastRunTime { get; set; } = "—";
         public string LastResult { get; set; } = "";
-        public SolidColorBrush ResultBadgeBackground { get; set; } = new(Colors.Gray);
         public SolidColorBrush ResultBadgeForeground { get; set; } = new(Colors.White);
         public Visibility ResultBadgeVisibility { get; set; } = Visibility.Collapsed;
         public string NextRunTime { get; set; } = "—";
@@ -1738,9 +1738,6 @@ public sealed partial class CronPage : Page
         public Visibility WakeModeVisibility { get; set; } = Visibility.Collapsed;
         public string DeliveryText { get; set; } = "";
         public Visibility DeliveryVisibility { get; set; } = Visibility.Collapsed;
-        public string ToggleEnabledLabel => IsEnabled ? "⏸ Disable" : "▶ Enable";
-        public string ToggleEnabledGlyph => IsEnabled ? "\uE7E8" : "\uE768";
-        public string ToggleEnabledText => IsEnabled ? "Disable" : "Enable";
         public string Description { get; set; } = "";
         public Visibility DescriptionVisibility { get; set; } = Visibility.Collapsed;
         public string DetailLine { get; set; } = "";

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
@@ -149,6 +149,9 @@
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_112" x:Name="NavInstances" Tag="instances" Content="Instances">
                 <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Instances_Icon}"/></NavigationViewItem.Icon>
             </NavigationViewItem>
+            <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_124" x:Name="NavCron" Tag="cron" Content="Cron">
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Cron_Icon}"/></NavigationViewItem.Icon>
+            </NavigationViewItem>
             <!-- Advanced — consolidates gateway-oriented pages -->
             <NavigationViewItem x:Name="NavAdvanced" Content="Advanced" SelectsOnInvoked="False">
                 <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Advanced_Icon}"/></NavigationViewItem.Icon>
@@ -172,9 +175,6 @@
                     </NavigationViewItem>
                     <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_121" Tag="usage" Content="Usage">
                         <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Usage_Icon}"/></NavigationViewItem.Icon>
-                    </NavigationViewItem>
-                    <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_124" Tag="cron" Content="Cron">
-                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Cron_Icon}"/></NavigationViewItem.Icon>
                     </NavigationViewItem>
                 </NavigationViewItem.MenuItems>
             </NavigationViewItem>

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -428,6 +428,7 @@ public sealed partial class HubWindow : WindowEx
             NavSkills.Visibility = vis;
             NavChannels.Visibility = vis;
             NavInstances.Visibility = vis;
+            NavCron.Visibility = vis;
             NavAdvanced.Visibility = vis;
             NavGatewaySeparator.Visibility = vis;
 


### PR DESCRIPTION
Cleans up the Cron Jobs page to follow Fluent / WinUI guidelines (UI-only).

## Changes

- **Sidebar:** moved Cron out of the Advanced submenu to a top-level Gateway item directly above Advanced; visibility now gated on gateway-connected state alongside the other gateway pages.
- **Page header:** removed the emoji icon; sentence-case typography; New job promoted to `AccentButtonStyle`; status dot uses `SystemFillColorSuccess/NeutralBrush`.
- **Layout:** content grows centered up to `MaxWidth=900` with growing side bars, matching Permissions/Sessions/etc.
- **Job cards:** replaced the Enable/Disable action button with a right-aligned `ToggleSwitch` in the header; removed redundant detail-panel button and dead VM members; added card stroke for crisper edges.
- **Status badges:** swapped hard-coded ARGB greens/reds for `SystemFillColorSuccess/Critical/Attention/Neutral` so the success text is readable (fixes green-on-green).
- **New-job form:** now opaque (`LayerFillColorDefaultBrush`) and reparents into the row-defined `PageRootGrid` so it no longer overlaps the job list.
- **Iconography:** added `FluentIconCatalog.Cron` (Calendar, U+E787); removed remaining emojis from page title, preset buttons, empty state, status badges, and toggle labels.
- **Typography:** input/section labels use `BodyStrongTextBlockStyle` and other typography tokens; removed literal `FontSize`/`FontWeight`.

## Validation

- ✅ `./build.ps1`
- ✅ Shared tests: 1891 passed / 29 skipped
- ✅ Tray tests: 1178 passed

<img width="1987" height="1470" alt="image" src="https://github.com/user-attachments/assets/490ca315-0183-4ffc-82bf-c047653638b2" />
