### PR TITLE
Organize Bindings page to match Fluent / Win11 Settings pattern

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml
@@ -4,24 +4,26 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
-    <Grid HorizontalAlignment="Stretch">
-        <StackPanel Padding="24" Spacing="16" HorizontalAlignment="Stretch" MaxWidth="900">
+    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+        <StackPanel Padding="24" Spacing="8" HorizontalAlignment="Stretch" MaxWidth="900">
 
-            <Grid>
+            <!-- ───────── Page header ───────── -->
+            <Grid Margin="0,0,0,8">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel Spacing="4">
-                    <TextBlock x:Uid="BindingsPage_TextBlock_16" Text="🔀 Bindings" Style="{StaticResource TitleTextBlockStyle}"/>
+                <StackPanel Spacing="2">
+                    <TextBlock x:Uid="BindingsPage_TextBlock_16" Text="Bindings"
+                               Style="{StaticResource TitleTextBlockStyle}"/>
                     <TextBlock x:Uid="BindingsPage_TextBlock_17" Text="Message routing rules"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                               Style="{StaticResource CaptionTextBlockStyle}"/>
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               TextWrapping="Wrap"/>
                 </StackPanel>
                 <Button x:Name="RefreshButton" Grid.Column="1" Click="RefreshButton_Click"
                         VerticalAlignment="Center">
-                    <StackPanel Orientation="Horizontal" Spacing="6">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
                         <FontIcon Glyph="&#xE72C;" FontSize="14"/>
                         <TextBlock x:Uid="BindingsPage_TextBlock_25" Text="Refresh"/>
                     </StackPanel>
@@ -59,43 +61,56 @@
                            VerticalAlignment="Center"/>
             </StackPanel>
 
-            <ListView x:Name="BindingsList" SelectionMode="None" Visibility="Collapsed">
+            <ListView x:Name="BindingsList" SelectionMode="None" Visibility="Collapsed"
+                      HorizontalAlignment="Stretch"
+                      HorizontalContentAlignment="Stretch">
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                        <Setter Property="Padding" Value="0"/>
+                        <Setter Property="Margin" Value="0,4"/>
+                    </Style>
+                </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
                     <DataTemplate>
                         <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                                BorderThickness="1" CornerRadius="8" Padding="16" Margin="0,4">
-                            <Grid>
+                                BorderThickness="1" CornerRadius="8" Padding="16">
+                            <Grid ColumnSpacing="16">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto"/>
                                     <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
                                     <ColumnDefinition Width="Auto"/>
                                     <ColumnDefinition Width="*"/>
                                 </Grid.ColumnDefinitions>
 
                                 <!-- Channel icon + name -->
-                                <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center" Margin="0,0,16,0">
-                                    <TextBlock Text="{Binding ChannelIcon}" FontSize="18"/>
-                                    <TextBlock Text="{Binding Channel}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                                    <TextBlock Text="{Binding ChannelIcon}"
+                                               Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock Text="{Binding Channel}"
+                                               Style="{StaticResource BodyStrongTextBlockStyle}"
+                                               VerticalAlignment="Center"/>
                                 </StackPanel>
 
                                 <!-- Account + Peer -->
                                 <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
                                     <TextBlock Text="{Binding AccountId}"
                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                               FontSize="12"/>
+                                               Style="{StaticResource CaptionTextBlockStyle}"/>
                                     <TextBlock Text="{Binding PeerDisplay}"
-                                               FontSize="12"/>
+                                               Style="{StaticResource CaptionTextBlockStyle}"/>
                                 </StackPanel>
 
                                 <!-- Arrow -->
-                                <TextBlock Grid.Column="3" Text="→" FontSize="18"
-                                           VerticalAlignment="Center" Margin="12,0"/>
+                                <FontIcon Grid.Column="2" Glyph="&#xE72A;" FontSize="14"
+                                          VerticalAlignment="Center"
+                                          Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
 
                                 <!-- Agent -->
-                                <TextBlock Grid.Column="4" Text="{Binding AgentId}"
-                                           FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="3" Text="{Binding AgentId}"
+                                           Style="{StaticResource BodyStrongTextBlockStyle}"
+                                           VerticalAlignment="Center"/>
                             </Grid>
                         </Border>
                     </DataTemplate>
@@ -103,6 +118,5 @@
             </ListView>
 
         </StackPanel>
-    </Grid>
     </ScrollViewer>
 </Page>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -1588,7 +1588,7 @@ On your gateway host (Mac/Linux), run:
     <value>Clear</value>
   </data>
   <data name="BindingsPage_TextBlock_16.Text" xml:space="preserve">
-    <value>🔀 Bindings</value>
+    <value>Bindings</value>
   </data>
   <data name="BindingsPage_TextBlock_17.Text" xml:space="preserve">
     <value>Message routing rules</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -1540,7 +1540,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Effacer</value>
   </data>
   <data name="BindingsPage_TextBlock_16.Text" xml:space="preserve">
-    <value>🔀 Liaisons</value>
+    <value>Liaisons</value>
   </data>
   <data name="BindingsPage_TextBlock_17.Text" xml:space="preserve">
     <value>Règles de routage des messages</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -1541,7 +1541,7 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>Wissen</value>
   </data>
   <data name="BindingsPage_TextBlock_16.Text" xml:space="preserve">
-    <value>🔀 Koppelingen</value>
+    <value>Koppelingen</value>
   </data>
   <data name="BindingsPage_TextBlock_17.Text" xml:space="preserve">
     <value>Regels voor berichtroutering</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -1540,7 +1540,7 @@
     <value>清除</value>
   </data>
   <data name="BindingsPage_TextBlock_16.Text" xml:space="preserve">
-    <value>🔀 绑定</value>
+    <value>绑定</value>
   </data>
   <data name="BindingsPage_TextBlock_17.Text" xml:space="preserve">
     <value>消息路由规则</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -1540,7 +1540,7 @@
     <value>清除</value>
   </data>
   <data name="BindingsPage_TextBlock_16.Text" xml:space="preserve">
-    <value>🔀 繫結</value>
+    <value>繫結</value>
   </data>
   <data name="BindingsPage_TextBlock_17.Text" xml:space="preserve">
     <value>訊息路由規則</value>


### PR DESCRIPTION
Minimal UI-only cleanup of the Bindings page to align with the openclaw-design Fluent guidance.

- Drop the emoji from the page title; use system text styles in the row template instead of literal `FontSize`/`FontWeight`.
- Remove the redundant outer `Grid` so content centers with growing white side bars when the window widens (matches `PermissionsPage`: `StackPanel` with `HorizontalAlignment=Stretch` + `MaxWidth=900`).
- Replace the literal `→` `TextBlock` with a Segoe Fluent `FontIcon` (`E72A`) tinted via `TextFillColorSecondaryBrush`.
- Stretch `ListView` items to the full card width via `ItemContainerStyle`.

Validated: `./build.ps1` ✅, Shared.Tests ✅, Tray.Tests ✅.

<img width="1971" height="1327" alt="image" src="https://github.com/user-attachments/assets/7c6e6893-b0b9-4ab2-90d7-253eb125838a" />
