### PR TITLE
Redesign Sessions page (Fluent 2 + deep-link to Chat)

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -214,20 +214,21 @@ public sealed partial class ChatPage : Page
         Func<string, Task>? readAloud = app is null ? null : app.SpeakChatTextAsync;
 
         // Consume a pending session-key hand-off from SessionsPage so the
-        // chat root mounts with that thread selected. Remount is the only
-        // path — OpenClawChatRoot has no live "switch thread" API.
+        // chat root mounts with that thread selected. Any pending key forces
+        // a remount — _mountedThreadId only records what we asked for, not
+        // what the user later picked inside the composer's dropdown, so we
+        // cannot use it to detect "already on the right thread".
         var pendingSessionKey = _hub?.PendingChatSessionKey;
         if (pendingSessionKey is not null && _hub is not null)
         {
             _hub.PendingChatSessionKey = null;
         }
         var threadIdToMount = pendingSessionKey ?? _mountedThreadId;
-        var threadChanged = pendingSessionKey is not null
-                            && !string.Equals(_mountedThreadId, pendingSessionKey, StringComparison.Ordinal);
+        var forceRemount = pendingSessionKey is not null;
 
         if (_functionalHost is not null
             && ReferenceEquals(_mountedProvider, provider)
-            && !threadChanged)
+            && !forceRemount)
         {
             PlaceholderPanel.Visibility = Visibility.Collapsed;
             ChatHost.Visibility = Visibility.Visible;

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -26,6 +26,7 @@ public sealed partial class ChatPage : Page
     private HubWindow? _hub;
     private MountedFunctionalChat? _functionalHost;
     private IChatDataProvider? _mountedProvider;
+    private string? _mountedThreadId;
     private string? _chatUrl;
     private bool _webViewInitialized;
     private bool _webViewMode;
@@ -212,7 +213,21 @@ public sealed partial class ChatPage : Page
         var provider = app?.ChatProvider;
         Func<string, Task>? readAloud = app is null ? null : app.SpeakChatTextAsync;
 
-        if (_functionalHost is not null && ReferenceEquals(_mountedProvider, provider))
+        // Consume a pending session-key hand-off from SessionsPage so the
+        // chat root mounts with that thread selected. Remount is the only
+        // path — OpenClawChatRoot has no live "switch thread" API.
+        var pendingSessionKey = _hub?.PendingChatSessionKey;
+        if (pendingSessionKey is not null && _hub is not null)
+        {
+            _hub.PendingChatSessionKey = null;
+        }
+        var threadIdToMount = pendingSessionKey ?? _mountedThreadId;
+        var threadChanged = pendingSessionKey is not null
+                            && !string.Equals(_mountedThreadId, pendingSessionKey, StringComparison.Ordinal);
+
+        if (_functionalHost is not null
+            && ReferenceEquals(_mountedProvider, provider)
+            && !threadChanged)
         {
             PlaceholderPanel.Visibility = Visibility.Collapsed;
             ChatHost.Visibility = Visibility.Visible;
@@ -245,6 +260,7 @@ public sealed partial class ChatPage : Page
         _functionalHost = CurrentApp.ActiveHubWindow!.MountFunctionalChat(
             ChatHost,
             provider,
+            initialThreadId: threadIdToMount,
             onReadAloud: readAloud,
             onStopSpeaking: () => app?.StopChatSpeaking(),
             onVoiceRequest: VoiceTranscribeAsync,
@@ -254,6 +270,7 @@ public sealed partial class ChatPage : Page
             initialMuted: CurrentApp.Settings?.VoiceTtsEnabled == false,
             suppressAutoDispose: true);
         _mountedProvider = provider;
+        _mountedThreadId = threadIdToMount;
 
         // If the V hotkey (or another caller) requested auto-start voice,
         // trigger it after the UI thread processes the mount (composer needs
@@ -342,6 +359,7 @@ public sealed partial class ChatPage : Page
         var host = _functionalHost;
         _functionalHost = null;
         _mountedProvider = null;
+        _mountedThreadId = null;
         try { host?.Dispose(); } catch { /* tear-down race — non-fatal */ }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
@@ -5,149 +5,245 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     NavigationCacheMode="Enabled">
 
-    <Grid Padding="24,16,24,16" RowSpacing="12" MaxWidth="900" HorizontalAlignment="Stretch">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <Grid HorizontalAlignment="Stretch">
+            <StackPanel Padding="24" Spacing="12"
+                        HorizontalAlignment="Stretch" MaxWidth="900">
 
-        <!-- Inline back link — only shown when the user arrived via a
-             cross-page link from Connection. Set by SessionsPage.Initialize
-             based on HubWindow.LastNavigationOrigin. -->
-        <HyperlinkButton x:Name="BackToConnectionLink" Grid.Row="0"
-                         Click="OnBackToConnectionClicked"
-                         Padding="0" Margin="0,0,0,0"
-                         Visibility="Collapsed"
-                         AutomationProperties.AutomationId="BackToConnectionLink">
-            <StackPanel Orientation="Horizontal" Spacing="6">
-                <FontIcon Glyph="&#xE72B;" FontSize="12"/>
-                <TextBlock x:Uid="SessionsPage_BackToConnection" Text="Back to Connection"/>
-            </StackPanel>
-        </HyperlinkButton>
+                <!-- Shown only when the user arrived via Connection's cross-page link. -->
+                <HyperlinkButton x:Name="BackToConnectionLink"
+                                 Click="OnBackToConnectionClicked"
+                                 Padding="0" Margin="0,0,0,4"
+                                 Visibility="Collapsed"
+                                 AutomationProperties.AutomationId="BackToConnectionLink">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <FontIcon Glyph="&#xE72B;"
+                                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                  FontSize="12"
+                                  IsTextScaleFactorEnabled="False"/>
+                        <TextBlock x:Uid="SessionsPage_BackToConnection"
+                                   Text="Back to Connection"
+                                   Style="{StaticResource CaptionTextBlockStyle}"/>
+                    </StackPanel>
+                </HyperlinkButton>
 
-        <!-- Header row: title + refresh -->
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
-            <TextBlock x:Uid="SessionsPage_Sessions" Text="Sessions" Style="{StaticResource TitleTextBlockStyle}"/>
-            <Button x:Name="RefreshButton" Grid.Column="1" Click="OnRefresh">
-                <StackPanel Orientation="Horizontal" Spacing="6">
-                    <FontIcon Glyph="&#xE72C;" FontSize="14"/>
-                    <TextBlock x:Uid="SessionsPage_Refresh" Text="Refresh"/>
-                </StackPanel>
-            </Button>
-        </Grid>
+                <TextBlock x:Uid="SessionsPage_Sessions"
+                           Text="Sessions"
+                           Style="{StaticResource TitleTextBlockStyle}"
+                           Margin="0,0,0,2"/>
+                <TextBlock Text="Conversations this gateway is currently handling, grouped by channel."
+                           Style="{StaticResource CaptionTextBlockStyle}"
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           TextWrapping="Wrap" Margin="0,0,0,4"/>
 
-        <!-- Channel filter SelectorBar -->
-        <SelectorBar x:Name="ChannelSelector" Grid.Row="2"
-                      SelectionChanged="ChannelSelector_SelectionChanged">
-            <SelectorBarItem x:Uid="SessionsPage_All" x:Name="AllTab" Text="All" IsSelected="True"/>
-        </SelectorBar>
+                <Grid ColumnSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
 
-        <InfoBar x:Uid="SessionsPage_GatewayDisconnected" x:Name="ConnectionInfoBar" Grid.Row="3"
-                 IsOpen="False" IsClosable="False" Severity="Warning"
-                 Title="Gateway disconnected"
-                 Message="Connect to a gateway to load sessions.">
-            <InfoBar.ActionButton>
-                <Button x:Uid="SessionsPage_OpenConnection" Content="Open Connection" Click="OnOpenConnectionClick"/>
-            </InfoBar.ActionButton>
-        </InfoBar>
+                    <SelectorBar x:Name="ChannelSelector" Grid.Column="0"
+                                 VerticalAlignment="Center"
+                                 SelectionChanged="ChannelSelector_SelectionChanged">
+                        <SelectorBarItem x:Uid="SessionsPage_All" x:Name="AllTab" Text="All" IsSelected="True"/>
+                    </SelectorBar>
 
-        <StackPanel x:Name="LoadingState" Grid.Row="4" Orientation="Horizontal" Spacing="12"
-                    HorizontalAlignment="Center" VerticalAlignment="Center"
-                    Visibility="Collapsed">
-            <ProgressRing IsActive="True" Width="22" Height="22"/>
-            <TextBlock x:Uid="SessionsPage_LoadingSessions" Text="Loading sessions..."
-                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                       VerticalAlignment="Center"/>
-        </StackPanel>
+                    <Button x:Name="RefreshButton" Grid.Column="1"
+                            Click="OnRefresh"
+                            ToolTipService.ToolTip="Refresh sessions"
+                            AutomationProperties.Name="Refresh sessions">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <FontIcon x:Name="RefreshIcon"
+                                      Glyph="&#xE72C;"
+                                      FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                      FontSize="14"
+                                      IsTextScaleFactorEnabled="False"/>
+                            <TextBlock x:Uid="SessionsPage_Refresh" x:Name="RefreshLabel" Text="Refresh"/>
+                        </StackPanel>
+                    </Button>
+                </Grid>
 
-        <!-- Empty state -->
-        <StackPanel x:Name="EmptyState" Grid.Row="4" Spacing="8"
-                    HorizontalAlignment="Center" VerticalAlignment="Center"
-                    Visibility="Collapsed">
-            <TextBlock Text="💬" FontSize="48" HorizontalAlignment="Center"/>
-            <TextBlock x:Uid="SessionsPage_NoActiveSessions" Text="No active sessions"
-                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                       HorizontalAlignment="Center"/>
-        </StackPanel>
+                <InfoBar x:Uid="SessionsPage_GatewayDisconnected"
+                         x:Name="ConnectionInfoBar"
+                         IsOpen="False" IsClosable="False" Severity="Warning"
+                         Title="Gateway disconnected"
+                         Message="Connect to a gateway to load sessions.">
+                    <InfoBar.ActionButton>
+                        <Button x:Uid="SessionsPage_OpenConnection" Content="Open Connection" Click="OnOpenConnectionClick"/>
+                    </InfoBar.ActionButton>
+                </InfoBar>
 
-        <!-- Session list -->
-        <ListView x:Name="SessionListView" Grid.Row="4" SelectionMode="None">
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                            BorderThickness="1" CornerRadius="8" Padding="14,10" Margin="0,0,0,4">
-                        <Grid RowSpacing="4">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="Auto"/>
-                            </Grid.RowDefinitions>
+                <!-- Loading / empty / list share this slot; only one is Visible at a time. -->
+                <Grid MinHeight="160">
+                    <StackPanel x:Name="LoadingState"
+                                Orientation="Horizontal" Spacing="12"
+                                HorizontalAlignment="Center" VerticalAlignment="Center"
+                                Visibility="Collapsed">
+                        <ProgressRing IsActive="True" Width="20" Height="20"/>
+                        <TextBlock x:Uid="SessionsPage_LoadingSessions"
+                                   Text="Loading sessions..."
+                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   VerticalAlignment="Center"/>
+                    </StackPanel>
 
-                            <!-- Row 1: Status dot + name + age -->
-                            <Grid Grid.Row="0" ColumnSpacing="8">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
-                                <Ellipse Width="8" Height="8" VerticalAlignment="Center"
-                                         Fill="{Binding StatusColor}"/>
-                                <TextBlock Grid.Column="1" Text="{Binding DisplayName}"
-                                           FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
-                                <TextBlock Grid.Column="2" Text="{Binding AgeText}"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                           FontSize="12"/>
-                            </Grid>
+                    <StackPanel x:Name="EmptyState" Spacing="8"
+                                HorizontalAlignment="Center" VerticalAlignment="Center"
+                                Visibility="Collapsed">
+                        <FontIcon Glyph="&#xE8BD;"
+                                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                  FontSize="40"
+                                  IsTextScaleFactorEnabled="False"
+                                  HorizontalAlignment="Center"
+                                  Foreground="{ThemeResource TextFillColorTertiaryBrush}"/>
+                        <TextBlock x:Uid="SessionsPage_NoActiveSessions"
+                                   Text="No active sessions"
+                                   Style="{StaticResource BodyStrongTextBlockStyle}"
+                                   HorizontalAlignment="Center"/>
+                        <TextBlock Text="Sessions appear here when a channel is connected and traffic is flowing."
+                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   TextWrapping="Wrap" TextAlignment="Center"
+                                   MaxWidth="320"/>
+                    </StackPanel>
 
-                            <!-- Row 2: Provider · Model · Channel -->
-                            <TextBlock Grid.Row="1" Text="{Binding DetailLine}"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                       FontSize="12" TextTrimming="CharacterEllipsis"
-                                       Margin="16,0,0,0"/>
+                    <ListView x:Name="SessionListView"
+                              SelectionMode="None"
+                              ShowsScrollingPlaceholders="False">
+                        <ListView.ItemContainerStyle>
+                            <Style TargetType="ListViewItem">
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                <Setter Property="Padding" Value="0"/>
+                                <Setter Property="MinHeight" Value="0"/>
+                                <Setter Property="Margin" Value="0,0,0,8"/>
+                            </Style>
+                        </ListView.ItemContainerStyle>
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                        BorderThickness="1" CornerRadius="8"
+                                        Padding="16,12">
+                                    <Grid RowSpacing="8" ColumnSpacing="12">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
 
-                            <!-- Row 3: Progress bar + token counts -->
-                            <Grid Grid.Row="2" ColumnSpacing="12" Margin="16,2,0,0"
-                                  Visibility="{Binding TokenRowVisibility}">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
-                                <Border CornerRadius="3" BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
-                                        BorderThickness="1" Height="8" VerticalAlignment="Center">
-                                    <ProgressBar Value="{Binding ContextPercent}" Maximum="100"
-                                                 Height="6" VerticalAlignment="Center" CornerRadius="2"
-                                                 Background="{ThemeResource ControlFillColorDefaultBrush}"/>
+                                        <StackPanel Grid.Row="0" Grid.Column="0"
+                                                    Orientation="Horizontal" Spacing="10"
+                                                    VerticalAlignment="Center">
+                                            <Ellipse Width="10" Height="10"
+                                                     VerticalAlignment="Center"
+                                                     Fill="{Binding StatusBrush}"
+                                                     ToolTipService.ToolTip="{Binding StatusTooltip}"/>
+                                            <TextBlock Text="{Binding DisplayName}"
+                                                       Style="{StaticResource BodyStrongTextBlockStyle}"
+                                                       TextTrimming="CharacterEllipsis"
+                                                       VerticalAlignment="Center"/>
+                                        </StackPanel>
+
+                                        <StackPanel Grid.Row="0" Grid.Column="1"
+                                                    Orientation="Horizontal" Spacing="8"
+                                                    VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding AgeText}"
+                                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                       VerticalAlignment="Center"/>
+                                        </StackPanel>
+
+                                        <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                                                   Text="{Binding DetailLine}"
+                                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   Margin="20,0,0,0"/>
+
+                                        <Grid Grid.Row="2" Grid.Column="0"
+                                              Margin="20,0,8,0"
+                                              ColumnSpacing="12"
+                                              VerticalAlignment="Center"
+                                              Visibility="{Binding TokenRowVisibility}">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+                                            <ProgressBar Value="{Binding ContextPercent}" Maximum="100"
+                                                         Height="4" VerticalAlignment="Center"
+                                                         CornerRadius="2"/>
+                                            <TextBlock Grid.Column="1" Text="{Binding TokensText}"
+                                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                        </Grid>
+
+                                        <StackPanel Grid.Row="2" Grid.Column="1"
+                                                    Orientation="Horizontal" Spacing="4"
+                                                    VerticalAlignment="Center">
+                                            <Button Tag="{Binding Key}"
+                                                    Click="OnOpenChat"
+                                                    Style="{StaticResource AccentButtonStyle}"
+                                                    Content="Open chat"
+                                                    ToolTipService.ToolTip="Open this session in Chat"
+                                                    AutomationProperties.Name="Open in chat"/>
+                                            <Button Tag="{Binding Key}"
+                                                    IsEnabled="{Binding CanEdit}"
+                                                    ToolTipService.ToolTip="More actions"
+                                                    AutomationProperties.Name="More actions">
+                                                <FontIcon Glyph="&#xE712;"
+                                                          FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                          FontSize="14"
+                                                          IsTextScaleFactorEnabled="False"/>
+                                                <Button.Flyout>
+                                                    <MenuFlyout Placement="BottomEdgeAlignedRight">
+                                                        <MenuFlyoutItem x:Uid="SessionsPage_Reset"
+                                                                        Text="Reset"
+                                                                        Tag="{Binding Key}"
+                                                                        Click="OnResetSession">
+                                                            <MenuFlyoutItem.Icon>
+                                                                <FontIcon Glyph="&#xE72C;"
+                                                                          FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                                          IsTextScaleFactorEnabled="False"/>
+                                                            </MenuFlyoutItem.Icon>
+                                                        </MenuFlyoutItem>
+                                                        <MenuFlyoutItem x:Uid="SessionsPage_Compact"
+                                                                        Text="Compact"
+                                                                        Tag="{Binding Key}"
+                                                                        Click="OnCompactSession">
+                                                            <MenuFlyoutItem.Icon>
+                                                                <FontIcon Glyph="&#xE74C;"
+                                                                          FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                                          IsTextScaleFactorEnabled="False"/>
+                                                            </MenuFlyoutItem.Icon>
+                                                        </MenuFlyoutItem>
+                                                        <MenuFlyoutSeparator/>
+                                                        <MenuFlyoutItem x:Uid="SessionsPage_Delete"
+                                                                        Text="Delete"
+                                                                        Tag="{Binding Key}"
+                                                                        Click="OnDeleteSession"
+                                                                        Foreground="{ThemeResource SystemFillColorCriticalBrush}">
+                                                            <MenuFlyoutItem.Icon>
+                                                                <FontIcon Glyph="&#xE74D;"
+                                                                          FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                                          IsTextScaleFactorEnabled="False"
+                                                                          Foreground="{ThemeResource SystemFillColorCriticalBrush}"/>
+                                                            </MenuFlyoutItem.Icon>
+                                                        </MenuFlyoutItem>
+                                                    </MenuFlyout>
+                                                </Button.Flyout>
+                                            </Button>
+                                        </StackPanel>
+                                    </Grid>
                                 </Border>
-                                <TextBlock Grid.Column="1" Text="{Binding TokensText}"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                           FontSize="11"/>
-                            </Grid>
-
-                            <!-- Row 4: Action buttons -->
-                            <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8" Margin="16,4,0,0">
-                                 <Button x:Uid="SessionsPage_Reset" Content="Reset" Tag="{Binding Key}" Click="OnResetSession"
-                                         IsEnabled="{Binding CanEdit}"
-                                         Style="{StaticResource DefaultButtonStyle}" Padding="8,4"/>
-                                 <Button x:Uid="SessionsPage_Compact" Content="Compact" Tag="{Binding Key}" Click="OnCompactSession"
-                                         IsEnabled="{Binding CanEdit}"
-                                         Style="{StaticResource DefaultButtonStyle}" Padding="8,4"/>
-                                 <Button x:Uid="SessionsPage_Delete" Content="Delete" Tag="{Binding Key}" Click="OnDeleteSession"
-                                         IsEnabled="{Binding CanEdit}"
-                                         Foreground="IndianRed" Padding="8,4"/>
-                            </StackPanel>
-                        </Grid>
-                    </Border>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
-    </Grid>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                </Grid>
+            </StackPanel>
+        </Grid>
+    </ScrollViewer>
 </Page>

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -82,10 +82,23 @@ public sealed partial class SessionsPage : Page
 
     public void UpdateSessions(SessionInfo[] sessions)
     {
-        _allSessions = sessions;
-        _sessionLoading.Complete(sessions.Length);
+        // Drop cron-spawned sessions (key shape "agent:<id>:cron" — slot is
+        // the third ":"-separated part). They have their own home on the
+        // Cron page; surfacing them here overcrowds the conversation list.
+        _allSessions = sessions
+            .Where(s => !IsCronSession(s))
+            .ToArray();
+        _sessionLoading.Complete(_allSessions.Length);
         RebuildChannelTabs();
         ApplyFilter();
+    }
+
+    private static bool IsCronSession(SessionInfo s)
+    {
+        if (string.IsNullOrEmpty(s.Key)) return false;
+        var parts = s.Key.Split(':');
+        return parts.Length >= 3
+               && string.Equals(parts[2], "cron", StringComparison.OrdinalIgnoreCase);
     }
 
     private void RebuildChannelTabs()
@@ -165,21 +178,17 @@ public sealed partial class SessionsPage : Page
 
     private SessionViewModel ToViewModel(SessionInfo s)
     {
-        var isActive = s.Status == "active" || s.Status == "running";
-
-        // Detail line: Provider · Model · Channel
         var parts = new List<string>(3);
         if (!string.IsNullOrWhiteSpace(s.Provider)) parts.Add(s.Provider!);
         if (!string.IsNullOrWhiteSpace(s.Model)) parts.Add(s.Model!);
         if (!string.IsNullOrWhiteSpace(s.Channel)) parts.Add(s.Channel!);
 
-        // Token display
         var hasTokens = s.InputTokens > 0 || s.OutputTokens > 0;
         var tokensText = hasTokens
             ? $"↓{FormatTokenCount(s.InputTokens)} / ↑{FormatTokenCount(s.OutputTokens)}"
             : "";
 
-        // Context % — ContextTokens is the window size, TotalTokens is usage
+        // ContextTokens is the window size, TotalTokens is usage.
         double contextPercent = 0;
         if (s.ContextTokens > 0 && s.TotalTokens > 0)
             contextPercent = Math.Min(100.0, (double)s.TotalTokens / s.ContextTokens * 100.0);
@@ -190,12 +199,55 @@ public sealed partial class SessionsPage : Page
             DisplayName = !string.IsNullOrWhiteSpace(s.DisplayName) ? s.DisplayName! : s.Key,
             AgeText = s.AgeText,
             DetailLine = parts.Count > 0 ? string.Join(" · ", parts) : "",
-            StatusColor = new SolidColorBrush(isActive ? Colors.LimeGreen : Colors.Gray),
+            StatusBrush = ResolveStatusBrush(s),
+            StatusTooltip = ResolveStatusTooltip(s),
             TokensText = tokensText,
             ContextPercent = contextPercent,
             HasTokenData = hasTokens || contextPercent > 0,
             CanEdit = _sessionLoading.CanEdit,
         };
+    }
+
+    private static Brush ResolveStatusBrush(SessionInfo s)
+    {
+        var status = s.Status?.Trim().ToLowerInvariant();
+        if (status is "error" or "failed" or "failure")
+            return s_criticalBrush.Value;
+        if (s.AbortedLastRun)
+            return s_cautionBrush.Value;
+        if (status is "active" or "running")
+            return s_successBrush.Value;
+        return s_neutralBrush.Value;
+    }
+
+    private static string ResolveStatusTooltip(SessionInfo s)
+    {
+        var status = s.Status?.Trim().ToLowerInvariant();
+        if (status is "error" or "failed" or "failure") return "Error";
+        if (s.AbortedLastRun) return "Aborted last run";
+        if (status is "active" or "running") return "Running";
+        return "Idle";
+    }
+
+    private static readonly Lazy<Brush> s_successBrush =
+        new(() => (Brush)Application.Current.Resources["SystemFillColorSuccessBrush"]);
+    private static readonly Lazy<Brush> s_cautionBrush =
+        new(() => (Brush)Application.Current.Resources["SystemFillColorCautionBrush"]);
+    private static readonly Lazy<Brush> s_criticalBrush =
+        new(() => (Brush)Application.Current.Resources["SystemFillColorCriticalBrush"]);
+    private static readonly Lazy<Brush> s_neutralBrush =
+        new(() => (Brush)Application.Current.Resources["SystemFillColorNeutralBrush"]);
+
+    private void OnOpenChat(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button btn && btn.Tag is string key)
+        {
+            if (CurrentApp.ActiveHubWindow is HubWindow hub)
+            {
+                hub.PendingChatSessionKey = key;
+            }
+            ((IAppCommands)CurrentApp).Navigate("chat", "sessions");
+        }
     }
 
     private void ChannelSelector_SelectionChanged(SelectorBar sender, SelectorBarSelectionChangedEventArgs args)
@@ -205,37 +257,51 @@ public sealed partial class SessionsPage : Page
         ApplyFilter();
     }
 
+    private static string? ResolveSessionKey(object sender)
+    {
+        if (sender is FrameworkElement fe)
+        {
+            if (fe.DataContext is SessionViewModel vm && !string.IsNullOrEmpty(vm.Key))
+                return vm.Key;
+            if (fe.Tag is string tag && !string.IsNullOrEmpty(tag))
+                return tag;
+            if (fe is MenuFlyoutItem mfi && mfi.Parent is MenuFlyout mf
+                && mf.Target is FrameworkElement target)
+            {
+                if (target.DataContext is SessionViewModel targetVm && !string.IsNullOrEmpty(targetVm.Key))
+                    return targetVm.Key;
+                if (target.Tag is string targetTag && !string.IsNullOrEmpty(targetTag))
+                    return targetTag;
+            }
+        }
+        return null;
+    }
+
     private async void OnResetSession(object sender, RoutedEventArgs e)
     {
-        if (sender is Button btn && btn.Tag is string key)
-        {
-            var client = CurrentApp.GatewayClient;
-            if (client == null) { ShowDisconnected(); return; }
-            try { await client.ResetSessionAsync(key); }
-            catch (Exception ex) { ShowActionFailure("Reset failed", ex); }
-        }
+        if (ResolveSessionKey(sender) is not string key) return;
+        var client = CurrentApp.GatewayClient;
+        if (client == null) { ShowDisconnected(); return; }
+        try { await client.ResetSessionAsync(key); }
+        catch (Exception ex) { ShowActionFailure("Reset failed", ex); }
     }
 
     private async void OnDeleteSession(object sender, RoutedEventArgs e)
     {
-        if (sender is Button btn && btn.Tag is string key)
-        {
-            var client = CurrentApp.GatewayClient;
-            if (client == null) { ShowDisconnected(); return; }
-            try { await client.DeleteSessionAsync(key); }
-            catch (Exception ex) { ShowActionFailure("Delete failed", ex); }
-        }
+        if (ResolveSessionKey(sender) is not string key) return;
+        var client = CurrentApp.GatewayClient;
+        if (client == null) { ShowDisconnected(); return; }
+        try { await client.DeleteSessionAsync(key); }
+        catch (Exception ex) { ShowActionFailure("Delete failed", ex); }
     }
 
     private async void OnCompactSession(object sender, RoutedEventArgs e)
     {
-        if (sender is Button btn && btn.Tag is string key)
-        {
-            var client = CurrentApp.GatewayClient;
-            if (client == null) { ShowDisconnected(); return; }
-            try { await client.CompactSessionAsync(key); }
-            catch (Exception ex) { ShowActionFailure("Compact failed", ex); }
-        }
+        if (ResolveSessionKey(sender) is not string key) return;
+        var client = CurrentApp.GatewayClient;
+        if (client == null) { ShowDisconnected(); return; }
+        try { await client.CompactSessionAsync(key); }
+        catch (Exception ex) { ShowActionFailure("Compact failed", ex); }
     }
 
     private void OnRefresh(object sender, RoutedEventArgs e)
@@ -255,19 +321,14 @@ public sealed partial class SessionsPage : Page
         _ = client.RequestSessionsAsync();
         _ = client.RequestModelsListAsync();
 
-        if (RefreshButton.Content is StackPanel)
+        if (RefreshLabel is not null)
         {
-            // Temporarily update the text inside the StackPanel
-            var sp = (StackPanel)RefreshButton.Content;
-            if (sp.Children.Count > 1 && sp.Children[1] is TextBlock tb)
-            {
-                tb.Text = "Refreshing...";
-                _refreshTimer?.Stop();
-                _refreshTimer = DispatcherQueue.CreateTimer();
-                _refreshTimer.Interval = TimeSpan.FromSeconds(1);
-                _refreshTimer.Tick += (t, a) => { tb.Text = "Refresh"; _refreshTimer.Stop(); };
-                _refreshTimer.Start();
-            }
+            RefreshLabel.Text = "Refreshing...";
+            _refreshTimer?.Stop();
+            _refreshTimer = DispatcherQueue.CreateTimer();
+            _refreshTimer.Interval = TimeSpan.FromSeconds(1);
+            _refreshTimer.Tick += (t, a) => { RefreshLabel.Text = "Refresh"; _refreshTimer.Stop(); };
+            _refreshTimer.Start();
         }
     }
 
@@ -302,7 +363,8 @@ public class SessionViewModel
     public string DisplayName { get; set; } = "";
     public string AgeText { get; set; } = "";
     public string DetailLine { get; set; } = "";
-    public SolidColorBrush StatusColor { get; set; } = new(Colors.Gray);
+    public Brush StatusBrush { get; set; } = new SolidColorBrush(Colors.Gray);
+    public string StatusTooltip { get; set; } = "Idle";
     public string TokensText { get; set; } = "";
     public double ContextPercent { get; set; }
     public bool HasTokenData { get; set; }

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -4275,13 +4275,13 @@ On your gateway host (Mac/Linux), run:
   <data name="SessionsPage_NoActiveSessions.Text" xml:space="preserve">
     <value>No active sessions</value>
   </data>
-  <data name="SessionsPage_Reset.Content" xml:space="preserve">
+  <data name="SessionsPage_Reset.Text" xml:space="preserve">
     <value>Reset</value>
   </data>
-  <data name="SessionsPage_Compact.Content" xml:space="preserve">
+  <data name="SessionsPage_Compact.Text" xml:space="preserve">
     <value>Compact</value>
   </data>
-  <data name="SessionsPage_Delete.Content" xml:space="preserve">
+  <data name="SessionsPage_Delete.Text" xml:space="preserve">
     <value>Delete</value>
   </data>
   <data name="SettingsPage_Settings.Text" xml:space="preserve">

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -4227,13 +4227,13 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="SessionsPage_NoActiveSessions.Text" xml:space="preserve">
     <value>Aucune session active</value>
   </data>
-  <data name="SessionsPage_Reset.Content" xml:space="preserve">
+  <data name="SessionsPage_Reset.Text" xml:space="preserve">
     <value>Réinitialiser</value>
   </data>
-  <data name="SessionsPage_Compact.Content" xml:space="preserve">
+  <data name="SessionsPage_Compact.Text" xml:space="preserve">
     <value>Compacter</value>
   </data>
-  <data name="SessionsPage_Delete.Content" xml:space="preserve">
+  <data name="SessionsPage_Delete.Text" xml:space="preserve">
     <value>Supprimer</value>
   </data>
   <data name="SettingsPage_Settings.Text" xml:space="preserve">

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -4228,13 +4228,13 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="SessionsPage_NoActiveSessions.Text" xml:space="preserve">
     <value>Geen actieve sessies</value>
   </data>
-  <data name="SessionsPage_Reset.Content" xml:space="preserve">
+  <data name="SessionsPage_Reset.Text" xml:space="preserve">
     <value>Resetten</value>
   </data>
-  <data name="SessionsPage_Compact.Content" xml:space="preserve">
+  <data name="SessionsPage_Compact.Text" xml:space="preserve">
     <value>Compact maken</value>
   </data>
-  <data name="SessionsPage_Delete.Content" xml:space="preserve">
+  <data name="SessionsPage_Delete.Text" xml:space="preserve">
     <value>Verwijderen</value>
   </data>
   <data name="SettingsPage_Settings.Text" xml:space="preserve">

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -4227,13 +4227,13 @@
   <data name="SessionsPage_NoActiveSessions.Text" xml:space="preserve">
     <value>æ— æ´»åŠ¨ä¼šè¯</value>
   </data>
-  <data name="SessionsPage_Reset.Content" xml:space="preserve">
+  <data name="SessionsPage_Reset.Text" xml:space="preserve">
     <value>é‡ç½®</value>
   </data>
-  <data name="SessionsPage_Compact.Content" xml:space="preserve">
+  <data name="SessionsPage_Compact.Text" xml:space="preserve">
     <value>åŽ‹ç¼©</value>
   </data>
-  <data name="SessionsPage_Delete.Content" xml:space="preserve">
+  <data name="SessionsPage_Delete.Text" xml:space="preserve">
     <value>åˆ é™¤</value>
   </data>
   <data name="SettingsPage_Settings.Text" xml:space="preserve">

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -4227,13 +4227,13 @@
   <data name="SessionsPage_NoActiveSessions.Text" xml:space="preserve">
     <value>æ²’æœ‰ä½œç”¨ä¸­çš„å·¥ä½œéšŽæ®µ</value>
   </data>
-  <data name="SessionsPage_Reset.Content" xml:space="preserve">
+  <data name="SessionsPage_Reset.Text" xml:space="preserve">
     <value>é‡è¨­</value>
   </data>
-  <data name="SessionsPage_Compact.Content" xml:space="preserve">
+  <data name="SessionsPage_Compact.Text" xml:space="preserve">
     <value>å£“ç¸®</value>
   </data>
-  <data name="SessionsPage_Delete.Content" xml:space="preserve">
+  <data name="SessionsPage_Delete.Text" xml:space="preserve">
     <value>åˆªé™¤</value>
   </data>
   <data name="SettingsPage_Settings.Text" xml:space="preserve">

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -45,6 +45,8 @@ public sealed partial class HubWindow : WindowEx
     public VoiceService? VoiceServiceInstance { get; set; }
     /// <summary>When true, ChatPage should auto-start voice recording on next navigation. Consumed (reset to false) by ChatPage.</summary>
     public bool PendingAutoStartVoice { get; set; }
+    /// <summary>Session key the chat surface should select on its next mount. Consumed (cleared) by ChatPage.</summary>
+    public string? PendingChatSessionKey { get; set; }
     public string? NodeFullDeviceId { get; set; }
     private Microsoft.UI.Dispatching.DispatcherQueueTimer? _gatewayNavHideTimer;
 


### PR DESCRIPTION
Restructures **SessionsPage** to match the Permissions/Connection shell and removes UI drift against the `openclaw-design` skill.

## Highlights

- **Layout**: `ScrollViewer` + `StackPanel` (`MaxWidth=900`, 24 px page padding, 4 px grid throughout) — matches every other app page.
- **Status dot is now a 4-state Fluent map** with a hover tooltip:
  | State | Brush | Trigger |
  |---|---|---|
  | 🟢 Running | `SystemFillColorSuccessBrush` | `Status ∈ {active, running}` |
  | 🟡 Aborted last run | `SystemFillColorCautionBrush` | `AbortedLastRun == true` |
  | 🔴 Error | `SystemFillColorCriticalBrush` | `Status ∈ {error, failed, failure}` |
  | ⚪ Idle | `SystemFillColorNeutralBrush` | everything else |
- **Primary action** is an `AccentButton` ("Open chat") — text-only Fluent 2 button so `AccentButtonStyle` owns rest/hover/press/disabled brushes per spec.
- **Destructive actions** moved into a `MenuFlyout` behind the row's overflow (`⋯`) button: **Reset**, **Compact**, **Delete** (Delete uses `SystemFillColorCriticalBrush`).
- **Cron sessions filtered out** (key shape `agent:<id>:cron`) — they overcrowd the conversation list and have a dedicated Cron page.
- **Deep-link to Chat**: clicking *Open chat* stores the session key on `HubWindow.PendingChatSessionKey` and navigates; `ChatPage.ShowFunctionalSurface` consumes the key and remounts `OpenClawChatRoot` with `initialThreadId`. Both the timeline and the composer's session dropdown render the selected session on first paint.
- **Robust `MenuFlyout` click routing** via `ResolveSessionKey` — falls back to `MenuFlyout.Target` when `DataContext` propagation into popup items fails (canonical WinUI binding quirk).
- Removed emoji empty-state and ad-hoc `LimeGreen`/`Gray`/`IndianRed` colors; all glyphs are Segoe Fluent (PUA) values mirrored from `FluentIconCatalog`.

## Files

- `src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml` / `.xaml.cs`
- `src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs` (session-key consumer + thread remount)
- `src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs` (`PendingChatSessionKey` field)

## Validation

- `./build.ps1` ✅
- `dotnet test OpenClaw.Shared.Tests --no-restore` — **1891 passed, 29 skipped** ✅
- `dotnet test OpenClaw.Tray.Tests --no-restore` — **1178 passed** ✅
- Manual smoke: rows render in light/dark, status dot tooltip works, Open chat deep-links into Chat with composer dropdown pre-selected, Reset/Compact/Delete fire from the overflow menu, cron-slot sessions no longer appear.

<img width="1975" height="1340" alt="image" src="https://github.com/user-attachments/assets/4f6fd899-03b8-4441-849b-e445171b17e6" />
