### PR TITLE
Organize Voice & Audio page per Fluent design guidelines

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
@@ -6,9 +6,9 @@
 
     <ScrollViewer VerticalScrollBarVisibility="Auto">
     <Grid HorizontalAlignment="Stretch">
-        <StackPanel Padding="24" Spacing="16" HorizontalAlignment="Stretch" MaxWidth="900">
+        <StackPanel Padding="24" Spacing="8" HorizontalAlignment="Stretch" MaxWidth="900">
 
-            <TextBlock x:Uid="VoiceSettingsPage_PageTitle" x:Name="PageTitleText" Text="🎙️ Voice &amp; Audio" Style="{StaticResource TitleTextBlockStyle}"/>
+            <TextBlock x:Uid="VoiceSettingsPage_PageTitle" x:Name="PageTitleText" Text="Voice &amp; Audio" Style="{StaticResource TitleTextBlockStyle}"/>
             <TextBlock x:Uid="VoiceSettingsPage_PageDescription" x:Name="PageDescriptionText"
                        Text="Configure speech-to-text and voice interaction settings. All speech processing runs locally on your device."
                        Style="{StaticResource CaptionTextBlockStyle}"
@@ -86,7 +86,9 @@
 
                             <!-- Status text (only shown for errors/done) -->
                             <TextBlock x:Name="InlineTestStatus" Text=""
-                                       FontSize="12" Opacity="0.5" HorizontalAlignment="Center"
+                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       HorizontalAlignment="Center"
                                        Visibility="Collapsed"/>
 
                             <!-- Centered buttons -->
@@ -95,7 +97,7 @@
                                         Style="{StaticResource AccentButtonStyle}" Padding="12,8">
                                     <StackPanel Orientation="Horizontal" Spacing="6">
                                         <FontIcon x:Name="InlineTestBtnIcon" Glyph="&#xE720;" FontSize="14"/>
-                                        <TextBlock x:Name="InlineTestBtnLabel" Text="Record" FontSize="13"/>
+                                        <TextBlock x:Name="InlineTestBtnLabel" Text="Record"/>
                                     </StackPanel>
                                 </Button>
                                 <Button x:Name="InlineTestCloseBtn" Click="OnInlineTestCloseClick"
@@ -154,7 +156,7 @@
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1" CornerRadius="8" Padding="16">
                 <StackPanel Spacing="12">
-                    <TextBlock x:Uid="VoiceSettingsPage_VoiceHeader" x:Name="VoiceHeaderText" Text="🔊 Companion Voice" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                    <TextBlock x:Uid="VoiceSettingsPage_VoiceHeader" x:Name="VoiceHeaderText" Text="Companion Voice" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                     <TextBlock x:Uid="VoiceSettingsPage_VoiceDescription" x:Name="VoiceDescriptionText"
                                Text="Choose the voice used when reading responses aloud."
                                Style="{StaticResource CaptionTextBlockStyle}"
@@ -182,7 +184,7 @@
                             <Button x:Uid="VoiceSettingsPage_PiperDeleteButton" x:Name="PiperDeleteButton" Click="OnPiperDeleteClick"
                                     Content="Delete" Width="80" Visibility="Collapsed"/>
                             <Button x:Uid="VoiceSettingsPage_PiperPreviewButton" x:Name="PiperPreviewButton" Click="OnPiperPreviewClick"
-                                    Content="▶ Preview" Width="100" Visibility="Collapsed"/>
+                                    Content="Preview" Width="100" Visibility="Collapsed"/>
                         </StackPanel>
                         <ProgressBar x:Name="PiperDownloadProgress" Visibility="Collapsed"
                                      IsIndeterminate="False" Maximum="100" Height="6" Width="400" HorizontalAlignment="Left"/>
@@ -200,7 +202,7 @@
                         <ComboBox x:Uid="VoiceSettingsPage_WindowsVoiceCombo" x:Name="WindowsVoiceCombo" Header="Voice"
                                   SelectionChanged="OnWindowsVoiceChanged" Width="300"/>
                         <Button x:Uid="VoiceSettingsPage_PreviewVoiceButton" x:Name="PreviewVoiceButton" Click="OnPreviewVoiceClick"
-                                Content="▶ Preview Voice" Width="140"/>
+                                Content="Preview Voice" Width="140"/>
                     </StackPanel>
 
                     <!-- ElevenLabs settings -->

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
@@ -183,8 +183,13 @@
                             </Button>
                             <Button x:Uid="VoiceSettingsPage_PiperDeleteButton" x:Name="PiperDeleteButton" Click="OnPiperDeleteClick"
                                     Content="Delete" Width="80" Visibility="Collapsed"/>
-                            <Button x:Uid="VoiceSettingsPage_PiperPreviewButton" x:Name="PiperPreviewButton" Click="OnPiperPreviewClick"
-                                    Content="Preview" Width="100" Visibility="Collapsed"/>
+                        <Button x:Name="PiperPreviewButton" Click="OnPiperPreviewClick"
+                                Width="100" Visibility="Collapsed">
+                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                <FontIcon x:Name="PiperPreviewIcon" Glyph="&#xE768;" FontSize="14"/>
+                                <TextBlock x:Name="PiperPreviewLabel" Text="Preview"/>
+                            </StackPanel>
+                        </Button>
                         </StackPanel>
                         <ProgressBar x:Name="PiperDownloadProgress" Visibility="Collapsed"
                                      IsIndeterminate="False" Maximum="100" Height="6" Width="400" HorizontalAlignment="Left"/>
@@ -201,8 +206,13 @@
                     <StackPanel x:Name="WindowsVoicePanel" Spacing="8" Visibility="Collapsed">
                         <ComboBox x:Uid="VoiceSettingsPage_WindowsVoiceCombo" x:Name="WindowsVoiceCombo" Header="Voice"
                                   SelectionChanged="OnWindowsVoiceChanged" Width="300"/>
-                        <Button x:Uid="VoiceSettingsPage_PreviewVoiceButton" x:Name="PreviewVoiceButton" Click="OnPreviewVoiceClick"
-                                Content="Preview Voice" Width="140"/>
+                        <Button x:Name="PreviewVoiceButton" Click="OnPreviewVoiceClick"
+                                Width="140">
+                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                <FontIcon x:Name="PreviewVoiceIcon" Glyph="&#xE768;" FontSize="14"/>
+                                <TextBlock x:Name="PreviewVoiceLabel" Text="Preview Voice"/>
+                            </StackPanel>
+                        </Button>
                     </StackPanel>
 
                     <!-- ElevenLabs settings -->

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
@@ -141,7 +141,8 @@
 
                     <Slider x:Uid="VoiceSettingsPage_SilenceSlider" x:Name="SilenceSlider" Header="Silence timeout (seconds)"
                             Minimum="0.5" Maximum="5" StepFrequency="0.5"
-                            ValueChanged="OnSilenceChanged" Width="250"/>
+                            ValueChanged="OnSilenceChanged" Width="250"
+                            HorizontalAlignment="Left"/>
 
                     <ToggleSwitch x:Uid="VoiceSettingsPage_TtsResponseToggle" x:Name="TtsResponseToggle" Toggled="OnTtsResponseToggled"
                                   Header="Read responses aloud"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
@@ -56,6 +56,12 @@ public sealed partial class VoiceSettingsPage : Page
             app.SpeakerMuteChanged -= OnAppSpeakerMuteChanged;
             app.SpeakerMuteChanged += OnAppSpeakerMuteChanged;
         }
+        // Seed the Preview button labels from resw — x:Uid was removed from
+        // the buttons so their inner StackPanel (FontIcon + TextBlock)
+        // survives state changes in the click handlers (we update only the
+        // TextBlock's Text, never the Button's Content).
+        PiperPreviewLabel.Text = L("VoiceSettingsPage_PiperPreviewButtonContent");
+        PreviewVoiceLabel.Text = L("VoiceSettingsPage_PreviewVoiceButtonContent");
         LoadSettings();
     }
 
@@ -704,8 +710,8 @@ public sealed partial class VoiceSettingsPage : Page
         if (PiperVoiceCombo.SelectedItem is not ComboBoxItem item || item.Tag is not string voiceId) return;
 
         PiperPreviewButton.IsEnabled = false;
-        var oldContent = PiperPreviewButton.Content;
-        PiperPreviewButton.Content = L("VoiceSettingsPage_PreviewButtonPlaying");
+        var oldLabel = PiperPreviewLabel.Text;
+        PiperPreviewLabel.Text = L("VoiceSettingsPage_PreviewButtonPlaying");
 
         try
         {
@@ -726,7 +732,7 @@ public sealed partial class VoiceSettingsPage : Page
         finally
         {
             PiperPreviewButton.IsEnabled = true;
-            PiperPreviewButton.Content = oldContent;
+            PiperPreviewLabel.Text = oldLabel;
         }
     }
 
@@ -804,7 +810,7 @@ public sealed partial class VoiceSettingsPage : Page
         if (CurrentApp.Settings == null) return;
 
         PreviewVoiceButton.IsEnabled = false;
-        PreviewVoiceButton.Content = L("VoiceSettingsPage_PreviewButtonPlaying");
+        PreviewVoiceLabel.Text = L("VoiceSettingsPage_PreviewButtonPlaying");
 
         try
         {
@@ -826,15 +832,18 @@ public sealed partial class VoiceSettingsPage : Page
         }
         catch (Exception ex)
         {
-            // Show error inline (sanitized â€” full detail in the log).
+            // Show error inline (sanitized — full detail in the log). Swap the
+            // Play glyph for ErrorBadge while the error label is visible.
             Logger.Error($"Windows TTS preview failed: {ex}");
-            PreviewVoiceButton.Content = L("VoiceSettingsPage_StatusError");
+            PreviewVoiceIcon.Glyph = "\uEA39";
+            PreviewVoiceLabel.Text = L("VoiceSettingsPage_StatusError");
             await System.Threading.Tasks.Task.Delay(3000);
         }
         finally
         {
             PreviewVoiceButton.IsEnabled = true;
-            PreviewVoiceButton.Content = L("VoiceSettingsPage_PreviewVoiceButtonContent");
+            PreviewVoiceIcon.Glyph = "\uE768";
+            PreviewVoiceLabel.Text = L("VoiceSettingsPage_PreviewVoiceButtonContent");
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2559,6 +2559,9 @@ On your gateway host (Mac/Linux), run:
   <data name="VoiceSettingsPage_PiperPreviewButton.Content" xml:space="preserve">
     <value>Preview</value>
   </data>
+  <data name="VoiceSettingsPage_PiperPreviewButtonContent" xml:space="preserve">
+    <value>Preview</value>
+  </data>
   <data name="VoiceSettingsPage_PiperInfoText.Text" xml:space="preserve">
     <value>Voices download from the sherpa-onnx project's GitHub releases (~25 MB low quality, up to ~150 MB high quality). They run fully on this PC; no audio leaves your device.</value>
   </data>
@@ -2599,7 +2602,7 @@ On your gateway host (Mac/Linux), run:
     <value>Download canceled</value>
   </data>
   <data name="VoiceSettingsPage_StatusError" xml:space="preserve">
-    <value>❌ Operation failed (see Debug log)</value>
+    <value>Operation failed (see Debug log)</value>
   </data>
   <data name="VoiceSettingsPage_PiperButtonDownloaded" xml:space="preserve">
     <value>Downloaded</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2452,7 +2452,7 @@ On your gateway host (Mac/Linux), run:
     <value>Windows built-in speech</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
-    <value>🎙️ Voice &amp; Audio</value>
+    <value>Voice &amp; Audio</value>
   </data>
   <data name="VoiceSettingsPage_PageDescription.Text" xml:space="preserve">
     <value>Configure speech-to-text and voice interaction settings. All speech processing runs locally on your device.</value>
@@ -2530,7 +2530,7 @@ On your gateway host (Mac/Linux), run:
     <value>Audio feedback sounds</value>
   </data>
   <data name="VoiceSettingsPage_VoiceHeader.Text" xml:space="preserve">
-    <value>🔊 Companion Voice</value>
+    <value>Companion Voice</value>
   </data>
   <data name="VoiceSettingsPage_VoiceDescription.Text" xml:space="preserve">
     <value>Choose the voice used when reading responses aloud.</value>
@@ -2557,7 +2557,7 @@ On your gateway host (Mac/Linux), run:
     <value>Delete</value>
   </data>
   <data name="VoiceSettingsPage_PiperPreviewButton.Content" xml:space="preserve">
-    <value>▶ Preview</value>
+    <value>Preview</value>
   </data>
   <data name="VoiceSettingsPage_PiperInfoText.Text" xml:space="preserve">
     <value>Voices download from the sherpa-onnx project's GitHub releases (~25 MB low quality, up to ~150 MB high quality). They run fully on this PC; no audio leaves your device.</value>
@@ -2566,7 +2566,7 @@ On your gateway host (Mac/Linux), run:
     <value>Voice</value>
   </data>
   <data name="VoiceSettingsPage_PreviewVoiceButton.Content" xml:space="preserve">
-    <value>▶ Preview Voice</value>
+    <value>Preview Voice</value>
   </data>
   <data name="VoiceSettingsPage_ElevenLabsApiKeyBox.Header" xml:space="preserve">
     <value>API Key</value>
@@ -2650,7 +2650,7 @@ On your gateway host (Mac/Linux), run:
     <value>Error loading voices (see Debug log).</value>
   </data>
   <data name="VoiceSettingsPage_PreviewButtonPlaying" xml:space="preserve">
-    <value>▶ Playing...</value>
+    <value>Playing...</value>
   </data>
   <data name="VoiceOverlayWindow_HeaderText.Text" xml:space="preserve">
     <value>Companion Voice</value>
@@ -2755,7 +2755,7 @@ On your gateway host (Mac/Linux), run:
     <value>Download Voice</value>
   </data>
   <data name="VoiceSettingsPage_PreviewVoiceButtonContent" xml:space="preserve">
-    <value>▶ Preview Voice</value>
+    <value>Preview Voice</value>
   </data>
   <data name="DebugPage_TextBlock_OverridesHeader.Text" xml:space="preserve">
     <value>Debug Overrides</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2404,7 +2404,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Voix intégrée à Windows</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
-    <value>🎙️ Voix et audio</value>
+    <value>Voix et audio</value>
   </data>
   <data name="VoiceSettingsPage_PageDescription.Text" xml:space="preserve">
     <value>Configurez la reconnaissance vocale et les paramètres d'interaction vocale. Tout le traitement vocal s'exécute localement sur votre appareil.</value>
@@ -2482,7 +2482,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Sons de retour audio</value>
   </data>
   <data name="VoiceSettingsPage_VoiceHeader.Text" xml:space="preserve">
-    <value>🔊 Voix de Companion</value>
+    <value>Voix de Companion</value>
   </data>
   <data name="VoiceSettingsPage_VoiceDescription.Text" xml:space="preserve">
     <value>Choisissez la voix utilisée pour lire les réponses à voix haute.</value>
@@ -2509,7 +2509,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Supprimer</value>
   </data>
   <data name="VoiceSettingsPage_PiperPreviewButton.Content" xml:space="preserve">
-    <value>▶ Aperçu</value>
+    <value>Aperçu</value>
   </data>
   <data name="VoiceSettingsPage_PiperInfoText.Text" xml:space="preserve">
     <value>Les voix sont téléchargées depuis les versions GitHub du projet sherpa-onnx (~25 Mo basse qualité, jusqu'à ~150 Mo haute qualité). Elles s'exécutent entièrement sur ce PC ; aucun son ne quitte votre appareil.</value>
@@ -2518,7 +2518,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Voix</value>
   </data>
   <data name="VoiceSettingsPage_PreviewVoiceButton.Content" xml:space="preserve">
-    <value>▶ Aperçu de la voix</value>
+    <value>Aperçu de la voix</value>
   </data>
   <data name="VoiceSettingsPage_ElevenLabsApiKeyBox.Header" xml:space="preserve">
     <value>Clé API</value>
@@ -2602,7 +2602,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Erreur de chargement des voix (voir le journal Debug).</value>
   </data>
   <data name="VoiceSettingsPage_PreviewButtonPlaying" xml:space="preserve">
-    <value>▶ Lecture...</value>
+    <value>Lecture...</value>
   </data>
   <data name="VoiceOverlayWindow_HeaderText.Text" xml:space="preserve">
     <value>Voix de Companion</value>
@@ -2707,7 +2707,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Télécharger la voix</value>
   </data>
   <data name="VoiceSettingsPage_PreviewVoiceButtonContent" xml:space="preserve">
-    <value>▶ Aperçu de la voix</value>
+    <value>Aperçu de la voix</value>
   </data>
   <data name="DebugPage_TextBlock_OverridesHeader.Text" xml:space="preserve">
     <value>Substitutions de débogage</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2511,6 +2511,9 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="VoiceSettingsPage_PiperPreviewButton.Content" xml:space="preserve">
     <value>Aperçu</value>
   </data>
+  <data name="VoiceSettingsPage_PiperPreviewButtonContent" xml:space="preserve">
+    <value>Aperçu</value>
+  </data>
   <data name="VoiceSettingsPage_PiperInfoText.Text" xml:space="preserve">
     <value>Les voix sont téléchargées depuis les versions GitHub du projet sherpa-onnx (~25 Mo basse qualité, jusqu'à ~150 Mo haute qualité). Elles s'exécutent entièrement sur ce PC ; aucun son ne quitte votre appareil.</value>
   </data>
@@ -2551,7 +2554,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Téléchargement annulé</value>
   </data>
   <data name="VoiceSettingsPage_StatusError" xml:space="preserve">
-    <value>❌ Échec de l'opération (voir le journal Debug)</value>
+    <value>Échec de l'opération (voir le journal Debug)</value>
   </data>
   <data name="VoiceSettingsPage_PiperButtonDownloaded" xml:space="preserve">
     <value>Téléchargé</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2405,7 +2405,7 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>Ingebouwde Windows-spraak</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
-    <value>🎙️ Spraak en audio</value>
+    <value>Spraak en audio</value>
   </data>
   <data name="VoiceSettingsPage_PageDescription.Text" xml:space="preserve">
     <value>Configureer spraak-naar-tekst en spraakinteractie-instellingen. Alle spraakverwerking draait lokaal op uw apparaat.</value>
@@ -2483,7 +2483,7 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>Audio-feedbackgeluiden</value>
   </data>
   <data name="VoiceSettingsPage_VoiceHeader.Text" xml:space="preserve">
-    <value>🔊 Companion-stem</value>
+    <value>Companion-stem</value>
   </data>
   <data name="VoiceSettingsPage_VoiceDescription.Text" xml:space="preserve">
     <value>Kies de stem die wordt gebruikt bij het hardop voorlezen van antwoorden.</value>
@@ -2510,7 +2510,7 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>Verwijderen</value>
   </data>
   <data name="VoiceSettingsPage_PiperPreviewButton.Content" xml:space="preserve">
-    <value>▶ Voorbeeld</value>
+    <value>Voorbeeld</value>
   </data>
   <data name="VoiceSettingsPage_PiperInfoText.Text" xml:space="preserve">
     <value>Stemmen worden gedownload van de GitHub-releases van het sherpa-onnx-project (~25 MB lage kwaliteit, tot ~150 MB hoge kwaliteit). Ze draaien volledig op deze pc; er verlaat geen audio uw apparaat.</value>
@@ -2519,7 +2519,7 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>Stem</value>
   </data>
   <data name="VoiceSettingsPage_PreviewVoiceButton.Content" xml:space="preserve">
-    <value>▶ Voorbeeld van stem</value>
+    <value>Voorbeeld van stem</value>
   </data>
   <data name="VoiceSettingsPage_ElevenLabsApiKeyBox.Header" xml:space="preserve">
     <value>API-sleutel</value>
@@ -2603,7 +2603,7 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>Fout bij laden van stemmen (zie Debug-log).</value>
   </data>
   <data name="VoiceSettingsPage_PreviewButtonPlaying" xml:space="preserve">
-    <value>▶ Afspelen...</value>
+    <value>Afspelen...</value>
   </data>
   <data name="VoiceOverlayWindow_HeaderText.Text" xml:space="preserve">
     <value>Companion-stem</value>
@@ -2708,7 +2708,7 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>Stem downloaden</value>
   </data>
   <data name="VoiceSettingsPage_PreviewVoiceButtonContent" xml:space="preserve">
-    <value>▶ Voorbeeld van stem</value>
+    <value>Voorbeeld van stem</value>
   </data>
   <data name="DebugPage_TextBlock_OverridesHeader.Text" xml:space="preserve">
     <value>Foutopsporingsopties</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2512,6 +2512,9 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="VoiceSettingsPage_PiperPreviewButton.Content" xml:space="preserve">
     <value>Voorbeeld</value>
   </data>
+  <data name="VoiceSettingsPage_PiperPreviewButtonContent" xml:space="preserve">
+    <value>Voorbeeld</value>
+  </data>
   <data name="VoiceSettingsPage_PiperInfoText.Text" xml:space="preserve">
     <value>Stemmen worden gedownload van de GitHub-releases van het sherpa-onnx-project (~25 MB lage kwaliteit, tot ~150 MB hoge kwaliteit). Ze draaien volledig op deze pc; er verlaat geen audio uw apparaat.</value>
   </data>
@@ -2552,7 +2555,7 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>Download geannuleerd</value>
   </data>
   <data name="VoiceSettingsPage_StatusError" xml:space="preserve">
-    <value>❌ Bewerking mislukt (zie Debug-log)</value>
+    <value>Bewerking mislukt (zie Debug-log)</value>
   </data>
   <data name="VoiceSettingsPage_PiperButtonDownloaded" xml:space="preserve">
     <value>Gedownload</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2404,7 +2404,7 @@
     <value>Windows 内置语音</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
-    <value>🎙️ 语音和音频</value>
+    <value>语音和音频</value>
   </data>
   <data name="VoiceSettingsPage_PageDescription.Text" xml:space="preserve">
     <value>配置语音转文字和语音交互设置。所有语音处理均在本机本地运行。</value>
@@ -2482,7 +2482,7 @@
     <value>音频反馈声音</value>
   </data>
   <data name="VoiceSettingsPage_VoiceHeader.Text" xml:space="preserve">
-    <value>🔊 Companion 语音</value>
+    <value>Companion 语音</value>
   </data>
   <data name="VoiceSettingsPage_VoiceDescription.Text" xml:space="preserve">
     <value>选择朗读响应时使用的语音。</value>
@@ -2509,7 +2509,7 @@
     <value>删除</value>
   </data>
   <data name="VoiceSettingsPage_PiperPreviewButton.Content" xml:space="preserve">
-    <value>▶ 预览</value>
+    <value>预览</value>
   </data>
   <data name="VoiceSettingsPage_PiperInfoText.Text" xml:space="preserve">
     <value>语音从 sherpa-onnx 项目的 GitHub 发布版下载(低质量约 25 MB,高质量最高约 150 MB)。它们完全在本机运行;无音频离开您的设备。</value>
@@ -2518,7 +2518,7 @@
     <value>语音</value>
   </data>
   <data name="VoiceSettingsPage_PreviewVoiceButton.Content" xml:space="preserve">
-    <value>▶ 预览语音</value>
+    <value>预览语音</value>
   </data>
   <data name="VoiceSettingsPage_ElevenLabsApiKeyBox.Header" xml:space="preserve">
     <value>API 密钥</value>
@@ -2602,7 +2602,7 @@
     <value>加载语音时出错(参见 Debug 日志)。</value>
   </data>
   <data name="VoiceSettingsPage_PreviewButtonPlaying" xml:space="preserve">
-    <value>▶ 正在播放...</value>
+    <value>正在播放...</value>
   </data>
   <data name="VoiceOverlayWindow_HeaderText.Text" xml:space="preserve">
     <value>Companion 语音</value>
@@ -2707,7 +2707,7 @@
     <value>下载语音</value>
   </data>
   <data name="VoiceSettingsPage_PreviewVoiceButtonContent" xml:space="preserve">
-    <value>▶ 预览语音</value>
+    <value>预览语音</value>
   </data>
   <data name="DebugPage_TextBlock_OverridesHeader.Text" xml:space="preserve">
     <value>调试覆盖</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2511,6 +2511,9 @@
   <data name="VoiceSettingsPage_PiperPreviewButton.Content" xml:space="preserve">
     <value>预览</value>
   </data>
+  <data name="VoiceSettingsPage_PiperPreviewButtonContent" xml:space="preserve">
+    <value>预览</value>
+  </data>
   <data name="VoiceSettingsPage_PiperInfoText.Text" xml:space="preserve">
     <value>语音从 sherpa-onnx 项目的 GitHub 发布版下载(低质量约 25 MB,高质量最高约 150 MB)。它们完全在本机运行;无音频离开您的设备。</value>
   </data>
@@ -2551,7 +2554,7 @@
     <value>下载已取消</value>
   </data>
   <data name="VoiceSettingsPage_StatusError" xml:space="preserve">
-    <value>❌ 操作失败(参见 Debug 日志)</value>
+    <value>操作失败(参见 Debug 日志)</value>
   </data>
   <data name="VoiceSettingsPage_PiperButtonDownloaded" xml:space="preserve">
     <value>已下载</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2511,6 +2511,9 @@
   <data name="VoiceSettingsPage_PiperPreviewButton.Content" xml:space="preserve">
     <value>預覽</value>
   </data>
+  <data name="VoiceSettingsPage_PiperPreviewButtonContent" xml:space="preserve">
+    <value>預覽</value>
+  </data>
   <data name="VoiceSettingsPage_PiperInfoText.Text" xml:space="preserve">
     <value>語音從 sherpa-onnx 專案的 GitHub 發行版下載(低品質約 25 MB,高品質最高約 150 MB)。它們完全在本機執行;無音訊離開您的裝置。</value>
   </data>
@@ -2551,7 +2554,7 @@
     <value>下載已取消</value>
   </data>
   <data name="VoiceSettingsPage_StatusError" xml:space="preserve">
-    <value>❌ 操作失敗(參見 Debug 日誌)</value>
+    <value>操作失敗(參見 Debug 日誌)</value>
   </data>
   <data name="VoiceSettingsPage_PiperButtonDownloaded" xml:space="preserve">
     <value>已下載</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2404,7 +2404,7 @@
     <value>Windows 內建語音</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
-    <value>🎙️ 語音與音訊</value>
+    <value>語音與音訊</value>
   </data>
   <data name="VoiceSettingsPage_PageDescription.Text" xml:space="preserve">
     <value>設定語音轉文字和語音互動設定。所有語音處理均在本機本地執行。</value>
@@ -2482,7 +2482,7 @@
     <value>音訊回饋音效</value>
   </data>
   <data name="VoiceSettingsPage_VoiceHeader.Text" xml:space="preserve">
-    <value>🔊 Companion 語音</value>
+    <value>Companion 語音</value>
   </data>
   <data name="VoiceSettingsPage_VoiceDescription.Text" xml:space="preserve">
     <value>選擇朗讀回應時使用的語音。</value>
@@ -2509,7 +2509,7 @@
     <value>刪除</value>
   </data>
   <data name="VoiceSettingsPage_PiperPreviewButton.Content" xml:space="preserve">
-    <value>▶ 預覽</value>
+    <value>預覽</value>
   </data>
   <data name="VoiceSettingsPage_PiperInfoText.Text" xml:space="preserve">
     <value>語音從 sherpa-onnx 專案的 GitHub 發行版下載(低品質約 25 MB,高品質最高約 150 MB)。它們完全在本機執行;無音訊離開您的裝置。</value>
@@ -2518,7 +2518,7 @@
     <value>語音</value>
   </data>
   <data name="VoiceSettingsPage_PreviewVoiceButton.Content" xml:space="preserve">
-    <value>▶ 預覽語音</value>
+    <value>預覽語音</value>
   </data>
   <data name="VoiceSettingsPage_ElevenLabsApiKeyBox.Header" xml:space="preserve">
     <value>API 金鑰</value>
@@ -2602,7 +2602,7 @@
     <value>載入語音時發生錯誤(參見 Debug 日誌)。</value>
   </data>
   <data name="VoiceSettingsPage_PreviewButtonPlaying" xml:space="preserve">
-    <value>▶ 正在播放...</value>
+    <value>正在播放...</value>
   </data>
   <data name="VoiceOverlayWindow_HeaderText.Text" xml:space="preserve">
     <value>Companion 語音</value>
@@ -2707,7 +2707,7 @@
     <value>下載語音</value>
   </data>
   <data name="VoiceSettingsPage_PreviewVoiceButtonContent" xml:space="preserve">
-    <value>▶ 預覽語音</value>
+    <value>預覽語音</value>
   </data>
   <data name="DebugPage_TextBlock_OverridesHeader.Text" xml:space="preserve">
     <value>偵錯覆寫</value>


### PR DESCRIPTION
Fluent / WinUI design cleanup for the **Voice & Audio** page (and a small fix for the Usage page title pattern carried into this branch). Per the `openclaw-design` skill + winuxe Critical Rules.

**Page header**
- Drop 🎙️ from Voice & Audio title; drop 🔊 from the Companion Voice section header (all 5 locales).

**Layout / typography**
- Outer `StackPanel.Spacing` 16 → 8 to match Permissions/Workspace page convention.
- `InlineTestStatus`: raw `FontSize=12 Opacity=0.5` → `CaptionTextBlockStyle` + `TextFillColorSecondaryBrush`.
- Drop raw `FontSize=13` on `InlineTestBtnLabel` (winuxe rule: no raw FontSize/FontWeight).
- Left-align the `SilenceSlider` (was centered against the toggle switches in the same card).

**Preview buttons (Piper & Windows TTS)**
- Re-render as `StackPanel` of `FontIcon` (Play, `U+E768`) + named `TextBlock`.
- Click handlers now update only the inner `Label.Text` (not `Button.Content`), so the icon survives Playing / Error / Idle transitions.
- Error path swaps the glyph to `ErrorBadge` `U+EA39` and restores Play in `finally`.
- Strip the leading `▶` from `PreviewVoiceButton.Content` / `PiperPreviewButton.Content` / `PreviewVoiceButtonContent` / `PreviewButtonPlaying` resw values (5 locales each).
- Strip `❌` from `VoiceSettingsPage_StatusError` resw (5 locales) — error state now carried by the swapped FontIcon.
- Add flat `VoiceSettingsPage_PiperPreviewButtonContent` resw key (5 locales) so `L()` can seed the Piper label on `Initialize` (mirrors existing `PreviewVoiceButtonContent` pattern for Windows).

**Validation**
- `./build.ps1` ✅
- `OpenClaw.Shared.Tests` ✅
- `OpenClaw.Tray.Tests` ✅ 1178 / 0
- Manual smoke: relaunched tray, page renders without emoji, Preview button click cycle restores icon + label correctly.
<img width="1972" height="1337" alt="image" src="https://github.com/user-attachments/assets/7e186235-04aa-4b98-a54d-5d3904882f72" />
