### PR TITLE
Settings page: match canonical page sizing (centered Stretch+MaxWidth=900)

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml
@@ -10,13 +10,18 @@
     </Page.Resources>
 
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-
-        <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto" Padding="24,24,24,24">
-            <StackPanel Spacing="8" HorizontalAlignment="Stretch" MaxWidth="900">
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <!--
+                Grid wrapper is required: ScrollViewer measures its direct
+                child with infinite available width, which makes
+                Stretch+MaxWidth collapse to the child's natural width and
+                left-shift the column. A Grid in between gives the
+                StackPanel a finite viewport-width slot so Stretch fills
+                up to MaxWidth and centers with growing side margins.
+                (Pattern matches ConnectionPage / SkillsPage.)
+            -->
+            <Grid HorizontalAlignment="Stretch">
+                <StackPanel Padding="24" Spacing="8" HorizontalAlignment="Stretch" MaxWidth="900">
 
                 <!-- Page header -->
                 <TextBlock Text="Settings"
@@ -285,14 +290,16 @@
                 </Border>
 
             </StackPanel>
+            </Grid>
         </ScrollViewer>
 
         <!-- Saved indicator (transient, auto-hides) -->
-        <InfoBar x:Name="SavedInfoBar" Grid.Row="1"
+        <InfoBar x:Name="SavedInfoBar"
                  IsOpen="False" IsClosable="False"
                  Severity="Success"
                  Title="Saved"
                  HorizontalAlignment="Right"
+                 VerticalAlignment="Bottom"
                  Margin="0,0,24,12"
                  MaxWidth="200"/>
     </Grid>


### PR DESCRIPTION
Align the Settings page layout with the rest of the Companion Settings pages (ConnectionPage / SkillsPage / PermissionsPage). Before this change, Settings rendered left-shifted vs. other pages at wide window widths.

**Fix**
- Move `Padding=24` from `ScrollViewer` onto the inner `StackPanel`.
- Add the canonical `<Grid HorizontalAlignment=\"Stretch\">` wrapper inside the `ScrollViewer` so the StackPanel's `Stretch + MaxWidth=900` measures against a finite viewport width and centers with growing side margins (instead of collapsing to the children's natural width).
- Collapse the previous two-row outer Grid into a single-cell Grid; the `SavedInfoBar` now floats as a bottom-right overlay (`VerticalAlignment=Bottom`), matching the rest of the pages.

**Validation**
- `./build.ps1` ✅
- Manual: launched tray locally and confirmed Settings now centers identically to Permissions, with two equal side bars as the window grows past 900px.
<img width="1980" height="1346" alt="image" src="https://github.com/user-attachments/assets/93202817-5f12-4b1e-88ca-152e5b59725f" />
