### PR TITLE
Sandbox page: match Permissions width and soften gateway-scope copy

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml
@@ -2,8 +2,8 @@
 <Page x:Class="OpenClawTray.Pages.SandboxPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <ScrollViewer Padding="24">
-        <StackPanel Spacing="16" HorizontalAlignment="Stretch" MaxWidth="900">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Padding="24" Spacing="16" HorizontalAlignment="Stretch" MaxWidth="900">
 
             <!-- Prominent status header: big shield icon + Title-styled name +
                  secondary subtitle + master toggle. Restored from the pre-L2
@@ -109,7 +109,7 @@
                                   VerticalAlignment="Top"
                                   Margin="0,2,0,0" />
                         <TextBlock Grid.Column="1"
-                                   Text="Commands the agent runs directly on the gateway aren't. If the gateway is on WSL on this PC they can reach your Windows files, clipboard, and network — use the gateway's exec approvals."
+                                   Text="Commands the agent runs directly on the gateway aren't. If the gateway is on this PC they may still be able to reach your Windows files, clipboard, and network — check your gateway's configuration."
                                    TextWrapping="Wrap" />
                     </Grid>
                 </StackPanel>


### PR DESCRIPTION
Two minor Sandbox page polish changes:

- **Width parity with Permissions.** Move `Padding=24` from the `ScrollViewer` onto the inner `StackPanel` so the page uses the same `MaxWidth=900` + 24px content padding as `PermissionsPage`.
- **Soften the gateway-scope caveat.** In the "What gets contained" expander, drop the WSL-specific phrasing and the prescriptive "use the gateway's exec approvals" tail; instead, tell users that if the gateway is on this PC it *may still* be able to reach Windows files/clipboard/network and to check their gateway's configuration.

Verified: `./build.ps1` clean; tray launches and renders updated copy.

<img width="1971" height="1341" alt="image" src="https://github.com/user-attachments/assets/c453b649-2884-4610-b524-1d820efc9c4f" />
