### PR TITLE
fix: usage cost off-by-one drop & rename Agent Events to Event Stream

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/AgentEventsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/AgentEventsPage.xaml
@@ -16,10 +16,16 @@
 
         <StackPanel Grid.Row="0" Spacing="4" Margin="0,0,0,12">
             <StackPanel Orientation="Horizontal" Spacing="8">
-                <TextBlock x:Uid="AgentEventsPage_TextBlock_18" Text="Agent Events"
-                           Style="{StaticResource TitleTextBlockStyle}"/>
-                <TextBlock x:Name="CountText" Text="(0)"
-                           VerticalAlignment="Bottom" Margin="0,0,0,6"
+                <TextBlock x:Uid="AgentEventsPage_TextBlock_18" Text="Event Stream" Style="{StaticResource TitleTextBlockStyle}"/>
+                <Border x:Name="LiveBadge" CornerRadius="4" Padding="6,2,8,3" VerticalAlignment="Center"
+                        Background="#20FF4444">
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                        <Ellipse x:Name="LiveDot" Width="6" Height="6" Fill="#FFFF4444" VerticalAlignment="Center"/>
+                        <TextBlock x:Name="LiveText" Text="Live" FontSize="11" FontWeight="SemiBold"
+                                   Foreground="#FFFF4444" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Border>
+                <TextBlock x:Name="CountText" Text="(0)" VerticalAlignment="Center"
                            Style="{StaticResource CaptionTextBlockStyle}"
                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
             </StackPanel>
@@ -51,21 +57,7 @@
             </Button>
         </Grid>
 
-        <ScrollViewer Grid.Row="2" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled"
-                      Margin="0,0,0,8">
-            <SelectorBar x:Name="FilterSelector"
-                         SelectionChanged="OnFilterSelectionChanged">
-                <SelectorBarItem x:Uid="FilterAllButton" x:Name="FilterAllButton" Text="All" Tag="all" IsSelected="True"/>
-                <SelectorBarItem x:Uid="AgentEventsPage_ToggleButton_36" Text="Tool" Tag="tool"/>
-                <SelectorBarItem x:Uid="AgentEventsPage_ToggleButton_37" Text="Assistant" Tag="assistant"/>
-                <SelectorBarItem x:Uid="AgentEventsPage_ToggleButton_38" Text="Error" Tag="error"/>
-                <SelectorBarItem x:Uid="AgentEventsPage_ToggleButton_39" Text="Lifecycle" Tag="lifecycle"/>
-                <SelectorBarItem x:Uid="AgentEventsPage_ToggleButton_40" Text="Plan" Tag="plan"/>
-                <SelectorBarItem x:Uid="AgentEventsPage_ToggleButton_41" Text="Approval" Tag="approval"/>
-                <SelectorBarItem x:Uid="AgentEventsPage_ToggleButton_42" Text="Thinking" Tag="thinking"/>
-                <SelectorBarItem x:Uid="AgentEventsPage_ToggleButton_43" Text="Patch" Tag="patch"/>
-            </SelectorBar>
-        </ScrollViewer>
+        <!-- Filter bar — removed; agent dropdown + live badge provide enough context -->
 
         <ListView x:Name="EventsList" Grid.Row="3"
                   SelectionMode="None"
@@ -142,16 +134,14 @@
             </ListView.ItemTemplate>
         </ListView>
 
-        <StackPanel x:Name="EmptyState" Grid.Row="3"
-                    VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="12">
-            <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.AgentEvents, Mode=OneTime}"
-                      FontSize="48" IsTextScaleFactorEnabled="False"
-                      Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-                      HorizontalAlignment="Center"/>
-            <TextBlock x:Uid="AgentEventsPage_TextBlock_96" Text="No agent events yet"
+        <!-- Empty state -->
+        <StackPanel x:Name="EmptyState" Grid.Row="2"
+                    VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8">
+            <TextBlock Text="🤖" FontSize="48" HorizontalAlignment="Center"/>
+            <TextBlock x:Uid="AgentEventsPage_TextBlock_96" Text="No events in this session"
                        Style="{StaticResource SubtitleTextBlockStyle}"
                        HorizontalAlignment="Center"/>
-            <TextBlock x:Uid="AgentEventsPage_TextBlock_99" Text="Real-time agent events (tool calls, responses, errors) will appear here as agents run."
+            <TextBlock x:Uid="AgentEventsPage_TextBlock_99" Text="Events stream here in real-time as agents run. History clears when the app restarts."
                        Style="{StaticResource CaptionTextBlockStyle}"
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                        HorizontalAlignment="Center" TextWrapping="Wrap" MaxWidth="320"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/AgentEventsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/AgentEventsPage.xaml.cs
@@ -13,7 +13,6 @@ public sealed partial class AgentEventsPage : Page
 {
     private const int MaxEvents = 400;
     private readonly List<AgentEventInfo> _allEvents = new();
-    private string _activeFilter = "all";
     private string? _agentIdFilter;
     private bool _filterDirty;
     private AppState? _appState;
@@ -84,6 +83,35 @@ public sealed partial class AgentEventsPage : Page
         _appState.AgentEventAdded += OnAgentEventAdded;
         _appState.PropertyChanged += OnAppStateChanged;
         PopulateAgentFilter(hub);
+        UpdateLiveBadge();
+    }
+
+    private void UpdateLiveBadge()
+    {
+        var connected = _appState?.Status == ConnectionStatus.Connected;
+        DispatcherQueue?.TryEnqueue(() =>
+        {
+            if (connected)
+            {
+                LiveDot.Fill = new Microsoft.UI.Xaml.Media.SolidColorBrush(
+                    Microsoft.UI.ColorHelper.FromArgb(255, 255, 68, 68));
+                LiveText.Text = "Live";
+                LiveText.Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(
+                    Microsoft.UI.ColorHelper.FromArgb(255, 255, 68, 68));
+                LiveBadge.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(
+                    Microsoft.UI.ColorHelper.FromArgb(32, 255, 68, 68));
+            }
+            else
+            {
+                LiveDot.Fill = new Microsoft.UI.Xaml.Media.SolidColorBrush(
+                    Microsoft.UI.ColorHelper.FromArgb(255, 128, 128, 128));
+                LiveText.Text = "Offline";
+                LiveText.Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(
+                    Microsoft.UI.ColorHelper.FromArgb(255, 128, 128, 128));
+                LiveBadge.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(
+                    Microsoft.UI.ColorHelper.FromArgb(32, 128, 128, 128));
+            }
+        });
     }
 
     private void OnAppStateChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -92,6 +120,10 @@ public sealed partial class AgentEventsPage : Page
         {
             _allEvents.Clear();
             ApplyFilter();
+        }
+        else if (e.PropertyName == nameof(AppState.Status))
+        {
+            UpdateLiveBadge();
         }
     }
 
@@ -131,12 +163,6 @@ public sealed partial class AgentEventsPage : Page
         }
     }
 
-    private void OnFilterSelectionChanged(SelectorBar sender, SelectorBarSelectionChangedEventArgs args)
-    {
-        var tag = sender.SelectedItem?.Tag as string;
-        _activeFilter = string.IsNullOrEmpty(tag) ? "all" : tag;
-        ApplyFilter();
-    }
 
     private void ApplyFilter()
     {
@@ -146,10 +172,6 @@ public sealed partial class AgentEventsPage : Page
         if (!string.IsNullOrEmpty(_agentIdFilter))
             filtered = filtered.Where(e => e.SessionKey != null &&
                 e.SessionKey.StartsWith($"agent:{_agentIdFilter}:", StringComparison.OrdinalIgnoreCase));
-
-        // Filter by stream type (use ResolvedStream so "item" events with kind:"tool" match the Tool filter)
-        if (_activeFilter != "all")
-            filtered = filtered.Where(e => e.ResolvedStream.Equals(_activeFilter, StringComparison.OrdinalIgnoreCase));
 
         var list = filtered.ToList();
         EventsList.ItemsSource = list;

--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
@@ -43,7 +43,7 @@ public sealed partial class UsagePage : Page
             // Only apply cached cost data when its period matches the current
             // selection — otherwise the daily list briefly shows e.g. 30-day
             // data while the selector reads "7 Days".
-            if (_appState?.UsageCost != null && _appState.UsageCost.Days == _currentPeriodDays)
+            if (_appState?.UsageCost != null && Math.Abs(_appState.UsageCost.Days - _currentPeriodDays) <= 1)
             {
                 UpdateUsageCost(_appState.UsageCost);
                 _dailyCostLoading.BeginRefresh();
@@ -100,7 +100,10 @@ public sealed partial class UsagePage : Page
 
     public void UpdateUsageCost(GatewayCostUsageInfo cost)
     {
-        if (cost.Days != _currentPeriodDays)
+        // The gateway computes 'days' as Math.ceil(range / DAY_MS) + 1,
+        // which is off by one from the requested period (e.g. 8 for a 7-day
+        // request). Allow ±1 tolerance so the response is not silently dropped.
+        if (Math.Abs(cost.Days - _currentPeriodDays) > 1)
             return;
 
         if (cost.UpdatedAt < _lastAppliedUsageCostUpdatedAtUtc)

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -1546,7 +1546,7 @@ On your gateway host (Mac/Linux), run:
     <value>Dashboard → openclaw://dashboard</value>
   </data>
   <data name="AgentEventsPage_TextBlock_18.Text" xml:space="preserve">
-    <value>Agent Events</value>
+    <value>Event Stream</value>
   </data>
   <data name="AgentFilterCombo.Header" xml:space="preserve">
     <value>Agent</value>
@@ -1585,10 +1585,10 @@ On your gateway host (Mac/Linux), run:
     <value>Patch</value>
   </data>
   <data name="AgentEventsPage_TextBlock_96.Text" xml:space="preserve">
-    <value>No agent events yet</value>
+    <value>No events in this session</value>
   </data>
   <data name="AgentEventsPage_TextBlock_99.Text" xml:space="preserve">
-    <value>Real-time agent events (tool calls, responses, errors) will appear here as agents run.</value>
+    <value>Events stream here in real-time as agents run. History clears when the app restarts.</value>
   </data>
   <data name="ClearButton.Content" xml:space="preserve">
     <value>Clear</value>
@@ -2215,7 +2215,7 @@ On your gateway host (Mac/Linux), run:
     <value>Conversations</value>
   </data>
   <data name="HubWindow_NavigationViewItem_94.Content" xml:space="preserve">
-    <value>Agent Events</value>
+    <value>Event Stream</value>
   </data>
   <data name="HubWindow_NavigationViewItem_97.Content" xml:space="preserve">
     <value>Skills</value>

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
@@ -153,7 +153,7 @@
             <NavigationViewItem x:Uid="HubWindow_Advanced" x:Name="NavAdvanced" Content="Advanced" SelectsOnInvoked="False">
                 <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Advanced_Icon}"/></NavigationViewItem.Icon>
                 <NavigationViewItem.MenuItems>
-                    <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_94" Tag="agentevents" Content="Agent Events">
+                    <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_94" Tag="agentevents" Content="Event Stream">
                         <NavigationViewItem.Icon><ImageIcon Source="{StaticResource AgentEvents_Icon}"/></NavigationViewItem.Icon>
                     </NavigationViewItem>
                     <NavigationViewItem x:Uid="AgentsNavItem" x:Name="AgentsNavItem" Content="Agents" SelectsOnInvoked="False" IsExpanded="True">

--- a/tests/OpenClaw.Tray.Tests/AsyncListLoadingPageWiringTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AsyncListLoadingPageWiringTests.cs
@@ -50,7 +50,7 @@ public sealed class AsyncListLoadingPageWiringTests
     {
         var source = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", "UsagePage.xaml.cs");
 
-        Assert.Contains("cost.Days != _currentPeriodDays", source);
+        Assert.Contains("Math.Abs(cost.Days - _currentPeriodDays) > 1", source);
         Assert.Contains("cost.UpdatedAt < _lastAppliedUsageCostUpdatedAtUtc", source);
         Assert.Contains("_dailyCostLoading.BeginInitialRefresh()", source);
     }


### PR DESCRIPTION
## Changes

### Usage cost fix
- The gateway computes daily cost \days\ as \Math.ceil(range / DAY_MS) + 1\, returning e.g. 8 days for a 7-day request. The client previously compared with strict equality (\!=\), silently dropping valid responses. Now uses \Math.Abs(cost.Days - _currentPeriodDays) > 1\ to tolerate ±1 variance.

### Event Stream rename & filter removal
- Renamed **Agent Events** → **Event Stream** across nav, page title, and localized resource strings (\.resw\)
- Removed all filter buttons from the events page — the agent dropdown and live badge provide sufficient context
- Updated empty state messaging to clarify events are session-scoped and clear on restart

### Test update
- Updated \UsagePage_GuardsStalePeriodResponses\ assertion to match the new tolerance logic