### PR TITLE
Refine companion navigation title bar

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2184,6 +2184,12 @@ On your gateway host (Mac/Linux), run:
   <data name="TitleText.Text" xml:space="preserve">
     <value>OpenClaw Windows Companion</value>
   </data>
+  <data name="NavPaneToggleButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Toggle navigation pane</value>
+  </data>
+  <data name="NavPaneToggleButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Toggle navigation pane</value>
+  </data>
   <data name="TitleStatusText.Text" xml:space="preserve">
     <value>Disconnected</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2136,6 +2136,12 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="TitleText.Text" xml:space="preserve">
     <value>OpenClaw Windows Companion</value>
   </data>
+  <data name="NavPaneToggleButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Basculer le volet de navigation</value>
+  </data>
+  <data name="NavPaneToggleButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Basculer le volet de navigation</value>
+  </data>
   <data name="TitleStatusText.Text" xml:space="preserve">
     <value>Déconnecté</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2137,6 +2137,12 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="TitleText.Text" xml:space="preserve">
     <value>OpenClaw Windows Companion</value>
   </data>
+  <data name="NavPaneToggleButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Navigatievenster in- of uitschakelen</value>
+  </data>
+  <data name="NavPaneToggleButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Navigatievenster in- of uitschakelen</value>
+  </data>
   <data name="TitleStatusText.Text" xml:space="preserve">
     <value>Verbinding verbroken</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2136,6 +2136,12 @@
   <data name="TitleText.Text" xml:space="preserve">
     <value>OpenClaw Windows Companion</value>
   </data>
+  <data name="NavPaneToggleButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>切换导航窗格</value>
+  </data>
+  <data name="NavPaneToggleButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>切换导航窗格</value>
+  </data>
   <data name="TitleStatusText.Text" xml:space="preserve">
     <value>已断开连接</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2136,6 +2136,12 @@
   <data name="TitleText.Text" xml:space="preserve">
     <value>OpenClaw Windows Companion</value>
   </data>
+  <data name="NavPaneToggleButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>切換導覽窗格</value>
+  </data>
+  <data name="NavPaneToggleButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>切換導覽窗格</value>
+  </data>
   <data name="TitleStatusText.Text" xml:space="preserve">
     <value>已中斷連線</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
@@ -18,26 +18,41 @@
         </Grid.RowDefinitions>
 
         <!-- Custom Title Bar -->
-        <Grid x:Name="AppTitleBar" Grid.Row="0" Padding="16,0,140,0">
+        <Grid x:Name="AppTitleBar" Grid.Row="0" Padding="9,0,140,0">
             <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
+            <Button x:Uid="NavPaneToggleButton" x:Name="NavPaneToggleButton" Grid.Column="0"
+                    AutomationProperties.Name="Toggle navigation pane"
+                    MinWidth="32" MinHeight="32"
+                    Padding="0" VerticalAlignment="Center"
+                    Background="Transparent"
+                    BorderBrush="Transparent"
+                    BorderThickness="0"
+                    ToolTipService.ToolTip="Toggle navigation pane"
+                    Click="OnNavPaneToggleButtonClick">
+                <FontIcon Glyph="&#xE700;"
+                          FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                          FontSize="16"/>
+            </Button>
+
             <!-- Icon + Title -->
-            <TextBlock Grid.Column="0" Text="🦞" FontSize="20" VerticalAlignment="Center" Margin="0,0,10,0"/>
-            <TextBlock x:Uid="TitleText" Grid.Column="1" x:Name="TitleText" Text="OpenClaw Windows Companion"
-                       FontSize="13" VerticalAlignment="Center"
-                       Style="{StaticResource CaptionTextBlockStyle}"/>
+            <TextBlock Grid.Column="1" Text="🦞" FontSize="18" VerticalAlignment="Center" Margin="8,0,8,0" Translation="0,-1,0"/>
+            <TextBlock x:Uid="TitleText" Grid.Column="2" x:Name="TitleText" Text="OpenClaw Windows Companion"
+                        FontSize="13" VerticalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}"/>
 
             <!-- Search box -->
-            <AutoSuggestBox x:Uid="TitleSearchBox" Grid.Column="2" x:Name="TitleSearchBox"
-                            PlaceholderText="Search… (Ctrl+E)"
-                            QueryIcon="Find"
-                            HorizontalAlignment="Stretch"
-                            MinWidth="200" MaxWidth="600"
+            <AutoSuggestBox x:Uid="TitleSearchBox" Grid.Column="3" x:Name="TitleSearchBox"
+                             PlaceholderText="Search… (Ctrl+E)"
+                             QueryIcon="Find"
+                             HorizontalAlignment="Stretch"
+                             MinWidth="200" MaxWidth="600"
                             Height="32" VerticalAlignment="Center"
                             Margin="16,0,16,0"
                             TextChanged="OnSearchTextChanged"
@@ -58,7 +73,7 @@
             </AutoSuggestBox>
 
             <!-- Status indicator on the right (clickable → navigates to Connection page) -->
-            <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="12" VerticalAlignment="Center"
+            <StackPanel Grid.Column="4" Orientation="Horizontal" Spacing="12" VerticalAlignment="Center"
                         Tapped="OnTitleBarStatusTapped">
                 <StackPanel Orientation="Horizontal" Spacing="6">
                     <Ellipse x:Name="TitleStatusDot" Width="8" Height="8" VerticalAlignment="Center" Fill="Gray"/>
@@ -81,14 +96,22 @@
         </Grid>
 
         <!-- Main Content -->
-        <NavigationView Grid.Row="1"
-            x:Name="NavView"
-            IsBackButtonVisible="Collapsed"
-            IsSettingsVisible="False"
-            PaneDisplayMode="Left"
-            PaneOpening="OnNavPaneStateChanged"
-            PaneClosing="OnNavPaneStateChanged"
-            SelectionChanged="NavView_SelectionChanged">
+        <Grid x:Name="NavContentHost"
+              Grid.Row="1"
+              SizeChanged="OnNavContentHostSizeChanged">
+            <Grid.Clip>
+                <RectangleGeometry x:Name="NavContentClip"/>
+            </Grid.Clip>
+
+            <NavigationView
+                x:Name="NavView"
+                IsBackButtonVisible="Collapsed"
+                IsSettingsVisible="False"
+                IsPaneToggleButtonVisible="False"
+                PaneDisplayMode="Left"
+                PaneOpening="OnNavPaneStateChanged"
+                PaneClosing="OnNavPaneStateChanged"
+                SelectionChanged="NavView_SelectionChanged">
 
             <NavigationView.Resources>
                 <!-- Match Windows 11 Settings: ~22px colorful icons in a default-height row.
@@ -127,11 +150,11 @@
                 <SvgImageSource x:Key="Info_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Info.svg"/>
             </NavigationView.Resources>
 
-        <NavigationView.MenuItems>
-            <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_82" x:Name="NavChat" Tag="chat" Content="Chat">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Chat_Icon}"/></NavigationViewItem.Icon>
-            </NavigationViewItem>
-            <NavigationViewItemSeparator/>
+            <NavigationView.MenuItems>
+                <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_82" x:Name="NavChat" Tag="chat" Content="Chat">
+                    <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Chat_Icon}"/></NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItemSeparator/>
 
             <NavigationViewItemHeader x:Uid="HubWindow_NavigationViewItemHeader_87" x:Name="NavGatewayHeader" Content="Gateway"/>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_88" Tag="connection" Content="Connection">
@@ -202,16 +225,17 @@
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_148" Tag="info" Content="Info">
                 <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Info_Icon}"/></NavigationViewItem.Icon>
             </NavigationViewItem>
-        </NavigationView.FooterMenuItems>
+            </NavigationView.FooterMenuItems>
 
-        <Frame x:Name="ContentFrame" Navigated="OnContentFrameNavigated">
-            <Frame.ContentTransitions>
-                <TransitionCollection>
-                    <NavigationThemeTransition/>
-                </TransitionCollection>
-            </Frame.ContentTransitions>
-        </Frame>
-    </NavigationView>
+            <Frame x:Name="ContentFrame" Navigated="OnContentFrameNavigated">
+                <Frame.ContentTransitions>
+                    <TransitionCollection>
+                        <NavigationThemeTransition/>
+                    </TransitionCollection>
+                </Frame.ContentTransitions>
+            </Frame>
+        </NavigationView>
+        </Grid>
 
     </Grid>
 </winex:WindowEx>

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -178,9 +178,19 @@ public sealed partial class HubWindow : WindowEx
         NavView.OpenPaneLength = Math.Clamp(desired, minPane, maxPane);
     }
 
+    private void OnNavContentHostSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        NavContentClip.Rect = new global::Windows.Foundation.Rect(0, 0, e.NewSize.Width, e.NewSize.Height);
+    }
+
     private void OnTitleBarStatusTapped(object sender, Microsoft.UI.Xaml.Input.TappedRoutedEventArgs e)
     {
         NavigateTo("connection");
+    }
+
+    private void OnNavPaneToggleButtonClick(object sender, RoutedEventArgs e)
+    {
+        NavView.IsPaneOpen = !NavView.IsPaneOpen;
     }
 
     /// <summary>

--- a/tests/OpenClaw.Tray.Tests/DiagnosticsPageContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/DiagnosticsPageContractTests.cs
@@ -514,6 +514,45 @@ public sealed class DiagnosticsPageContractTests
     }
 
     [Fact]
+    public void HubWindow_NavPaneToggle_LivesInTitleBarAndHidesBuiltInToggle()
+    {
+        var xaml = Read("src", "OpenClaw.Tray.WinUI", "Windows", "HubWindow.xaml");
+        Assert.Contains("x:Uid=\"NavPaneToggleButton\"", xaml);
+        Assert.Contains("x:Name=\"NavPaneToggleButton\"", xaml);
+        Assert.Contains("Click=\"OnNavPaneToggleButtonClick\"", xaml);
+        Assert.Contains("AutomationProperties.Name=\"Toggle navigation pane\"", xaml);
+        Assert.Contains("ToolTipService.ToolTip=\"Toggle navigation pane\"", xaml);
+        Assert.Contains("MinWidth=\"32\" MinHeight=\"32\"", xaml);
+        Assert.Contains("Padding=\"9,0,140,0\"", xaml);
+        Assert.Contains("Background=\"Transparent\"", xaml);
+        Assert.Contains("BorderBrush=\"Transparent\"", xaml);
+        Assert.Contains("BorderThickness=\"0\"", xaml);
+        Assert.Contains("FontSize=\"16\"", xaml);
+        Assert.Contains("Text=\"\ud83e\udd9e\" FontSize=\"18\"", xaml);
+        Assert.Contains("Translation=\"0,-1,0\"", xaml);
+        Assert.Contains("IsPaneToggleButtonVisible=\"False\"", xaml);
+        Assert.Contains("x:Name=\"NavContentHost\"", xaml);
+        Assert.Contains("x:Name=\"NavContentClip\"", xaml);
+        Assert.Contains("SizeChanged=\"OnNavContentHostSizeChanged\"", xaml);
+        Assert.DoesNotContain("x:Name=\"TitleContentDivider\"", xaml);
+
+        var titleBarIndex = xaml.IndexOf("x:Name=\"AppTitleBar\"", StringComparison.Ordinal);
+        var toggleIndex = xaml.IndexOf("x:Name=\"NavPaneToggleButton\"", StringComparison.Ordinal);
+        var iconIndex = xaml.IndexOf("Text=\"\ud83e\udd9e\"", StringComparison.Ordinal);
+        var navViewIndex = xaml.IndexOf("x:Name=\"NavView\"", StringComparison.Ordinal);
+        Assert.True(titleBarIndex >= 0, "The hub title bar must exist.");
+        Assert.True(toggleIndex > titleBarIndex, "The nav pane toggle must live inside the title bar block.");
+        Assert.True(toggleIndex < iconIndex, "The nav pane toggle must appear before the app icon/title.");
+        Assert.True(toggleIndex < navViewIndex, "The nav pane toggle must be outside the NavigationView pane.");
+
+        var cs = Read("src", "OpenClaw.Tray.WinUI", "Windows", "HubWindow.xaml.cs");
+        Assert.Contains("private void OnNavPaneToggleButtonClick", cs);
+        Assert.Contains("NavView.IsPaneOpen = !NavView.IsPaneOpen;", cs);
+        Assert.Contains("private void OnNavContentHostSizeChanged", cs);
+        Assert.Contains("NavContentClip.Rect = new global::Windows.Foundation.Rect(0, 0, e.NewSize.Width, e.NewSize.Height);", cs);
+    }
+
+    [Fact]
     public void DebugPage_ObservesAppState_NotHubWindow()
     {
         // After Ranjesh's single-app-model rebase, the page must


### PR DESCRIPTION
<img width="722" height="543" alt="image" src="https://github.com/user-attachments/assets/ad133852-c073-4123-96dd-4d2865ef8ff3" />

This is intentionally a very small UI polish change for the companion app navigation shell. The goal is just to give the navigation menu a bit more usable vertical space and make the title bar/menu alignment feel cleaner without changing navigation behavior.

## Summary
- Move the hub hamburger toggle into the custom title bar and hide the built-in NavigationView pane toggle.
- Align the title-bar hamburger with the sidebar icon rail, remove the divider above the first nav item, and lightly tune the app icon size/position.
- Add localized automation name and tooltip resources for the icon-only toggle.
- Add a contract test covering the title-bar toggle, hidden built-in toggle, clipping host, and removed divider.

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`