### PR TITLE
Revamp config page editor

### DIFF
--- a/scripts/Test-Localization.ps1
+++ b/scripts/Test-Localization.ps1
@@ -59,12 +59,24 @@ function Test-IsLocalizableValue {
     return $true
 }
 
+function Test-IsSourceXaml {
+    param([System.IO.FileInfo]$File)
+
+    $relativePath = Get-RelativePath $winUiRoot $File.FullName
+    $segments = $relativePath -split '[\\/]'
+    # Build output can contain generated/copied XAML; only source XAML should drive localization findings.
+    return $segments -notcontains 'bin' -and $segments -notcontains 'obj'
+}
+
 function Get-XamlLocalizationFindings {
     $resourceKeys = Get-ResourceKeys
     $missingResources = [System.Collections.Generic.List[string]]::new()
     $hardcodedValues = [System.Collections.Generic.List[string]]::new()
 
-    Get-ChildItem -LiteralPath $winUiRoot -Recurse -Filter *.xaml | Sort-Object FullName | ForEach-Object {
+    Get-ChildItem -LiteralPath $winUiRoot -Recurse -Filter *.xaml -File |
+        Where-Object { Test-IsSourceXaml $_ } |
+        Sort-Object FullName |
+        ForEach-Object {
         $xamlPath = $_.FullName
         $relativePath = Get-RelativePath $repoRoot $xamlPath
         [xml]$xml = Get-Content -LiteralPath $xamlPath -Raw -Encoding UTF8

--- a/src/OpenClaw.Connection/OperatorScopeHelper.cs
+++ b/src/OpenClaw.Connection/OperatorScopeHelper.cs
@@ -6,4 +6,15 @@ public static class OperatorScopeHelper
         grantedScopes.Any(s =>
             s.Equals("operator.admin", StringComparison.OrdinalIgnoreCase) ||
             s.Equals("operator.pairing", StringComparison.OrdinalIgnoreCase));
+
+    public static bool CanReadConfig(IReadOnlyList<string> grantedScopes) =>
+        HasScope(grantedScopes, "operator.admin") ||
+        HasScope(grantedScopes, "operator.read");
+
+    public static bool CanWriteConfig(IReadOnlyList<string> grantedScopes) =>
+        HasScope(grantedScopes, "operator.admin") ||
+        HasScope(grantedScopes, "operator.write");
+
+    private static bool HasScope(IReadOnlyList<string> grantedScopes, string scope) =>
+        grantedScopes.Any(s => s.Equals(scope, StringComparison.OrdinalIgnoreCase));
 }

--- a/src/OpenClaw.Tray.WinUI/Controls/SchemaConfigEditor.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Controls/SchemaConfigEditor.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using OpenClawTray.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,11 +12,23 @@ using System.Text.RegularExpressions;
 
 namespace OpenClawTray.Controls;
 
+public sealed class SchemaConfigChangedEventArgs(
+    Dictionary<string, object?> changes,
+    Dictionary<string, string> validationErrors)
+    : EventArgs
+{
+    public Dictionary<string, object?> Changes { get; } = changes;
+    public Dictionary<string, string> ValidationErrors { get; } = validationErrors;
+}
+
 public sealed partial class SchemaConfigEditor : UserControl
 {
     private JsonElement _schema;
     private JsonElement _config;
-    private readonly Dictionary<string, object?> _changes = new();
+    private bool _loading;
+    private readonly Dictionary<string, object?> _changes = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string> _validationErrors = new(StringComparer.Ordinal);
+    private static readonly TimeSpan PatternValidationTimeout = TimeSpan.FromMilliseconds(200);
 
     private static readonly Regex CamelCaseSplitPattern = new(
         "([a-z])([A-Z])",
@@ -24,7 +37,8 @@ public sealed partial class SchemaConfigEditor : UserControl
     private static readonly SolidColorBrush SecondaryBrush =
         new(ColorHelper.FromArgb(255, 140, 150, 170));
 
-    public event EventHandler<Dictionary<string, object?>>? ConfigChanged;
+    public event EventHandler<SchemaConfigChangedEventArgs>? ConfigChanged;
+    public static object RemovePendingValue { get; } = new();
 
     public SchemaConfigEditor()
     {
@@ -33,25 +47,32 @@ public sealed partial class SchemaConfigEditor : UserControl
 
     public void LoadSchema(JsonElement schema, JsonElement config)
     {
+        _loading = true;
         _schema = schema;
         _config = config;
         _changes.Clear();
+        _validationErrors.Clear();
         FieldsPanel.Children.Clear();
 
         try
         {
             RenderSchemaNode("", schema, config, FieldsPanel, 0);
         }
-        catch { }
+        catch (Exception ex)
+        {
+            Logger.Error($"[SchemaConfigEditor] Failed to render schema editor: {ex}");
+        }
 
         // If schema rendering produced nothing, fall back to rendering config as editable fields
         if (FieldsPanel.Children.Count == 0 && config.ValueKind == JsonValueKind.Object)
         {
             RenderConfigDirectly("", config, FieldsPanel, 0);
         }
+        _loading = false;
     }
 
     public Dictionary<string, object?> GetChanges() => new(_changes);
+    public Dictionary<string, string> GetValidationErrors() => new(_validationErrors);
 
     /// <summary>
     /// JSON Schema's "type" keyword may be either a string ("object") or an
@@ -103,7 +124,8 @@ public sealed partial class SchemaConfigEditor : UserControl
                 }
                 else
                 {
-                    RenderField(childPath, prop.Name, childSchema, childConfig, parent);
+                    var required = IsRequired(schema, prop.Name);
+                    RenderField(childPath, prop.Name, childSchema, childConfig, parent, required);
                 }
             }
         }
@@ -149,12 +171,17 @@ public sealed partial class SchemaConfigEditor : UserControl
     }
 
     private void RenderField(string path, string name, JsonElement schema,
-        JsonElement config, StackPanel parent)
+        JsonElement config, StackPanel parent, bool required)
     {
         var label = GetLabel(path, name);
         var description = SafeGetString(schema, "description");
+        var title = SafeGetString(schema, "title");
+        if (!string.IsNullOrWhiteSpace(title))
+            label = title!;
         var type = ExtractSchemaType(schema) ?? "string";
         var isSensitive = IsSensitive(path);
+        var readOnly = schema.TryGetProperty("readOnly", out var readOnlyEl)
+            && readOnlyEl.ValueKind == JsonValueKind.True;
 
         // Resolve default value if config is missing
         var effectiveConfig = config;
@@ -164,41 +191,86 @@ public sealed partial class SchemaConfigEditor : UserControl
             effectiveConfig = defaultVal;
         }
 
+        var fieldPanel = new StackPanel
+        {
+            Spacing = 4,
+            Margin = new Thickness(0, 4, 0, 10)
+        };
+
+        var headerText = required ? $"{label} *" : label;
+        var errorBlock = CreateErrorBlock();
+
         UIElement control;
 
-        if (schema.TryGetProperty("enum", out var enumEl)
+        if (readOnly)
+        {
+            control = RenderReadOnlyField(headerText, effectiveConfig);
+        }
+        else if (schema.TryGetProperty("enum", out var enumEl)
             && enumEl.ValueKind == JsonValueKind.Array)
         {
-            control = RenderEnumField(path, label, description, enumEl, effectiveConfig);
+            control = RenderEnumField(path, headerText, enumEl, effectiveConfig,
+                value => StageValue(path, value, schema, required, errorBlock));
         }
         else if (type == "boolean")
         {
-            control = RenderBoolField(path, label, description, effectiveConfig);
+            control = RenderBoolField(path, headerText, effectiveConfig,
+                value => StageValue(path, value, schema, required, errorBlock));
         }
         else if (type == "integer" || type == "number")
         {
-            control = RenderNumberField(path, label, description, type!, schema, effectiveConfig);
+            control = RenderNumberField(path, headerText, type!, schema, effectiveConfig,
+                value => StageValue(path, value, schema, required, errorBlock));
         }
         else if (type == "array" && schema.TryGetProperty("items", out var itemsSchema))
         {
-            control = RenderArrayField(path, label, description, itemsSchema, effectiveConfig);
+            control = RenderArrayField(path, headerText, description, itemsSchema, effectiveConfig, errorBlock,
+                value => StageValue(path, value, schema, required, errorBlock));
         }
         else // string (default)
         {
             control = isSensitive
-                ? RenderSensitiveField(path, label, description, effectiveConfig)
-                : RenderStringField(path, label, description, effectiveConfig);
+                ? RenderSensitiveField(path, headerText, effectiveConfig,
+                    value => StageValue(path, value, schema, required, errorBlock))
+                : RenderStringField(path, headerText, effectiveConfig,
+                    value => StageValue(path, value, schema, required, errorBlock));
         }
 
-        parent.Children.Add(control);
+        if (readOnly && control is Control readOnlyControl)
+            readOnlyControl.IsEnabled = false;
+
+        fieldPanel.Children.Add(control);
+        if (!string.IsNullOrEmpty(description))
+        {
+            fieldPanel.Children.Add(new TextBlock
+            {
+                Text = description,
+                FontSize = 12,
+                Foreground = SecondaryBrush,
+                TextWrapping = TextWrapping.Wrap
+            });
+        }
+
+        if (schema.TryGetProperty("default", out var defaultEl) &&
+            defaultEl.ValueKind is not JsonValueKind.Object and not JsonValueKind.Array)
+        {
+            fieldPanel.Children.Add(new TextBlock
+            {
+                Text = $"Default: {FormatScalar(defaultEl)}",
+                FontSize = 11,
+                Foreground = SecondaryBrush,
+                TextWrapping = TextWrapping.Wrap
+            });
+        }
+
+        fieldPanel.Children.Add(errorBlock);
+        parent.Children.Add(fieldPanel);
     }
 
-    private UIElement RenderEnumField(string path, string label, string? description,
-        JsonElement enumEl, JsonElement config)
+    private UIElement RenderEnumField(string path, string label,
+        JsonElement enumEl, JsonElement config, Action<object?> onChanged)
     {
         var combo = new ComboBox { Header = label, MinWidth = 200 };
-        if (!string.IsNullOrEmpty(description))
-            ToolTipService.SetToolTip(combo, description);
 
         var currentVal = config.ValueKind == JsonValueKind.String ? config.GetString() : null;
         foreach (var item in enumEl.EnumerateArray())
@@ -210,29 +282,27 @@ public sealed partial class SchemaConfigEditor : UserControl
 
         combo.SelectionChanged += (s, e) =>
         {
-            _changes[path] = combo.SelectedItem as string;
-            ConfigChanged?.Invoke(this, _changes);
+            if (_loading) return;
+            onChanged(combo.SelectedItem as string);
         };
         return combo;
     }
 
-    private UIElement RenderBoolField(string path, string label, string? description,
-        JsonElement config)
+    private UIElement RenderBoolField(string path, string label,
+        JsonElement config, Action<object?> onChanged)
     {
         var toggle = new ToggleSwitch { Header = label };
-        if (!string.IsNullOrEmpty(description))
-            ToolTipService.SetToolTip(toggle, description);
         toggle.IsOn = config.ValueKind == JsonValueKind.True;
         toggle.Toggled += (s, e) =>
         {
-            _changes[path] = toggle.IsOn;
-            ConfigChanged?.Invoke(this, _changes);
+            if (_loading) return;
+            onChanged(toggle.IsOn);
         };
         return toggle;
     }
 
-    private UIElement RenderNumberField(string path, string label, string? description,
-        string type, JsonElement schema, JsonElement config)
+    private UIElement RenderNumberField(string path, string label,
+        string type, JsonElement schema, JsonElement config, Action<object?> onChanged)
     {
         var numBox = new NumberBox
         {
@@ -240,8 +310,6 @@ public sealed partial class SchemaConfigEditor : UserControl
             SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Compact,
             MinWidth = 200
         };
-        if (!string.IsNullOrEmpty(description))
-            ToolTipService.SetToolTip(numBox, description);
         if (config.ValueKind == JsonValueKind.Number)
             numBox.Value = config.GetDouble();
         if (schema.TryGetProperty("minimum", out var min))
@@ -251,18 +319,16 @@ public sealed partial class SchemaConfigEditor : UserControl
 
         numBox.ValueChanged += (s, e) =>
         {
-            _changes[path] = type == "integer" ? (object)(int)numBox.Value : numBox.Value;
-            ConfigChanged?.Invoke(this, _changes);
+            if (_loading) return;
+            onChanged(double.IsNaN(numBox.Value) ? null : ConfigEditorModel.CoerceNumber(numBox.Value, type));
         };
         return numBox;
     }
 
-    private UIElement RenderStringField(string path, string label, string? description,
-        JsonElement config)
+    private UIElement RenderStringField(string path, string label,
+        JsonElement config, Action<object?> onChanged)
     {
         var textBox = new TextBox { Header = label, MinWidth = 300 };
-        if (!string.IsNullOrEmpty(description))
-            ToolTipService.SetToolTip(textBox, description);
         if (config.ValueKind == JsonValueKind.String)
             textBox.Text = config.GetString() ?? "";
         else if (config.ValueKind != JsonValueKind.Undefined
@@ -271,33 +337,45 @@ public sealed partial class SchemaConfigEditor : UserControl
 
         textBox.TextChanged += (s, e) =>
         {
-            _changes[path] = textBox.Text;
-            ConfigChanged?.Invoke(this, _changes);
+            if (_loading) return;
+            onChanged(textBox.Text);
         };
         return textBox;
     }
 
-    private UIElement RenderSensitiveField(string path, string label, string? description,
-        JsonElement config)
+    private UIElement RenderSensitiveField(string path, string label,
+        JsonElement config, Action<object?> onChanged)
     {
-        var pwBox = new PasswordBox { Header = label, Width = 350 };
-        if (!string.IsNullOrEmpty(description))
-            ToolTipService.SetToolTip(pwBox, description);
-        if (config.ValueKind == JsonValueKind.String)
-            pwBox.Password = config.GetString() ?? "";
+        var pwBox = new PasswordBox
+        {
+            Header = label,
+            Width = 350,
+            PlaceholderText = config.ValueKind == JsonValueKind.String && !string.IsNullOrEmpty(config.GetString())
+                ? "Leave blank to keep existing value"
+                : ""
+        };
+        var hasExistingValue = config.ValueKind == JsonValueKind.String && !string.IsNullOrEmpty(config.GetString());
 
         pwBox.PasswordChanged += (s, e) =>
         {
-            _changes[path] = pwBox.Password;
-            ConfigChanged?.Invoke(this, _changes);
+            if (_loading) return;
+            onChanged(hasExistingValue && string.IsNullOrEmpty(pwBox.Password)
+                ? RemovePendingValue
+                : pwBox.Password);
         };
         return pwBox;
     }
 
     private UIElement RenderArrayField(string path, string label, string? description,
-        JsonElement itemsSchema, JsonElement config)
+        JsonElement itemsSchema, JsonElement config, TextBlock errorBlock, Action<object?> onChanged)
     {
-        var panel = new StackPanel { Spacing = 4 };
+        var itemType = ExtractSchemaType(itemsSchema) ?? "string";
+        if (itemType is not ("string" or "integer" or "number" or "boolean"))
+        {
+            return RenderJsonArrayField(path, label, description, config, errorBlock, onChanged);
+        }
+
+        var panel = new StackPanel { Spacing = 6 };
         panel.Children.Add(new TextBlock
         {
             Text = label,
@@ -314,13 +392,13 @@ public sealed partial class SchemaConfigEditor : UserControl
             });
         }
 
-        var itemsPanel = new StackPanel { Spacing = 2 };
+        var itemsPanel = new StackPanel { Spacing = 6 };
 
         if (config.ValueKind == JsonValueKind.Array)
         {
             foreach (var item in config.EnumerateArray())
             {
-                AddArrayItem(itemsPanel, path, item.GetString() ?? "");
+                AddArrayItem(itemsPanel, path, itemType, FormatScalar(item), onChanged);
             }
         }
 
@@ -328,56 +406,162 @@ public sealed partial class SchemaConfigEditor : UserControl
 
         var addBtn = new Button
         {
-            Content = "+ Add",
+            Content = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 6,
+                Children =
+                {
+                    new FontIcon { Glyph = "\uE710", FontSize = 12 },
+                    new TextBlock { Text = "Add item" }
+                }
+            },
             Margin = new Thickness(0, 4, 0, 0)
         };
         addBtn.Click += (s, e) =>
         {
-            AddArrayItem(itemsPanel, path, "");
-            UpdateArrayChanges(itemsPanel, path);
+            AddArrayItem(itemsPanel, path, itemType, "", onChanged);
+            UpdateArrayChanges(itemsPanel, path, itemType, onChanged);
         };
         panel.Children.Add(addBtn);
 
         return panel;
     }
 
-    private void AddArrayItem(StackPanel itemsPanel, string path, string value)
+    private UIElement RenderJsonArrayField(string path, string label, string? description,
+        JsonElement config, TextBlock errorBlock, Action<object?> onChanged)
     {
-        var row = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 4 };
-        var textBox = new TextBox { Text = value, MinWidth = 250 };
-        textBox.TextChanged += (s, e) => UpdateArrayChanges(itemsPanel, path);
+        var panel = new StackPanel { Spacing = 6 };
+        panel.Children.Add(new InfoBar
+        {
+            IsOpen = true,
+            IsClosable = false,
+            Severity = InfoBarSeverity.Informational,
+            Title = label,
+            Message = "This array uses complex items. Edit its JSON below; local validation will run before Save is enabled."
+        });
+
+        if (!string.IsNullOrEmpty(description))
+        {
+            panel.Children.Add(new TextBlock
+            {
+                Text = description,
+                FontSize = 11,
+                Foreground = SecondaryBrush,
+                TextWrapping = TextWrapping.Wrap
+            });
+        }
+
+        var textBox = new TextBox
+        {
+            Text = config.ValueKind == JsonValueKind.Array
+                ? JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true })
+                : "[]",
+            AcceptsReturn = true,
+            TextWrapping = TextWrapping.NoWrap,
+            FontFamily = new FontFamily("Consolas"),
+            MinHeight = 120,
+            HorizontalAlignment = HorizontalAlignment.Stretch
+        };
+        textBox.TextChanged += (s, e) =>
+        {
+            if (_loading) return;
+            try
+            {
+                using var document = JsonDocument.Parse(textBox.Text);
+                if (document.RootElement.ValueKind != JsonValueKind.Array)
+                {
+                    _changes[path] = RemovePendingValue;
+                    SetValidationError(path, "Must be a JSON array.", errorBlock);
+                }
+                else
+                {
+                    onChanged(document.RootElement.Clone());
+                    return;
+                }
+            }
+            catch (JsonException ex)
+            {
+                _changes[path] = RemovePendingValue;
+                SetValidationError(path, $"Invalid JSON: {ex.Message}", errorBlock);
+            }
+            ConfigChanged?.Invoke(this, new SchemaConfigChangedEventArgs(GetChanges(), GetValidationErrors()));
+        };
+        panel.Children.Add(textBox);
+        return panel;
+    }
+
+    private void AddArrayItem(StackPanel itemsPanel, string path, string itemType, string value, Action<object?> onChanged)
+    {
+        var row = new Grid
+        {
+            ColumnSpacing = 10,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var textBox = new TextBox
+        {
+            Text = value,
+            MinWidth = 250,
+            Height = 34,
+            PlaceholderText = itemType switch
+            {
+                "boolean" => "true or false",
+                "integer" => "Integer value",
+                "number" => "Number value",
+                _ => "Value"
+            }
+        };
+        textBox.TextChanged += (s, e) =>
+        {
+            if (_loading) return;
+            UpdateArrayChanges(itemsPanel, path, itemType, onChanged);
+        };
 
         var removeBtn = new Button
         {
-            Content = "\u2715",
-            Width = 28,
-            Height = 28,
+            Content = new FontIcon { Glyph = "\uE74D", FontSize = 13 },
+            Height = 34,
+            Width = 34,
             Padding = new Thickness(0)
         };
+        ToolTipService.SetToolTip(removeBtn, "Remove item");
         removeBtn.Click += (s, e) =>
         {
-            itemsPanel.Children.Remove(row);
-            UpdateArrayChanges(itemsPanel, path);
+            if (row.Parent is Border border)
+                itemsPanel.Children.Remove(border);
+            UpdateArrayChanges(itemsPanel, path, itemType, onChanged);
         };
 
+        Grid.SetColumn(textBox, 0);
+        Grid.SetColumn(removeBtn, 1);
         row.Children.Add(textBox);
         row.Children.Add(removeBtn);
-        itemsPanel.Children.Add(row);
+        itemsPanel.Children.Add(new Border
+        {
+            Background = (Brush)Application.Current.Resources["CardBackgroundFillColorSecondaryBrush"],
+            BorderBrush = (Brush)Application.Current.Resources["CardStrokeColorDefaultBrush"],
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(8),
+            Padding = new Thickness(8, 7, 8, 7),
+            Child = row
+        });
     }
 
-    private void UpdateArrayChanges(StackPanel itemsPanel, string path)
+    private void UpdateArrayChanges(StackPanel itemsPanel, string path, string itemType, Action<object?> onChanged)
     {
-        var values = new List<string>();
+        var values = new List<object?>();
         foreach (var child in itemsPanel.Children)
         {
-            if (child is StackPanel row && row.Children.Count > 0
+            if (child is Border { Child: Grid row } && row.Children.Count > 0
                 && row.Children[0] is TextBox tb)
             {
-                values.Add(tb.Text);
+                values.Add(CoerceArrayItem(tb.Text, itemType));
             }
         }
-        _changes[path] = values.ToArray();
-        ConfigChanged?.Invoke(this, _changes);
+        onChanged(values.ToArray());
     }
 
     private static string GetLabel(string path, string name)
@@ -392,10 +576,215 @@ public sealed partial class SchemaConfigEditor : UserControl
 
     private static bool IsSensitive(string path)
     {
-        var lower = path.ToLowerInvariant();
-        return lower.Contains("token") || lower.Contains("secret")
-            || lower.Contains("password") || lower.Contains("apikey")
-            || lower.Contains("api_key");
+        var leaf = path.Split('.').Last().ToLowerInvariant();
+        return leaf.Contains("token") || leaf.Contains("secret")
+            || leaf.Contains("password") || leaf.Contains("apikey")
+            || leaf.Contains("api_key");
+    }
+
+    private static bool IsRequired(JsonElement parentSchema, string propName)
+    {
+        if (!parentSchema.TryGetProperty("required", out var required) ||
+            required.ValueKind != JsonValueKind.Array)
+            return false;
+
+        foreach (var item in required.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String &&
+                string.Equals(item.GetString(), propName, StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
+    }
+
+    private void StageValue(string path, object? value, JsonElement schema, bool required, TextBlock errorBlock)
+    {
+        _changes[path] = value;
+        var error = ValidateValue(value, schema, required);
+        SetValidationError(path, error, errorBlock);
+        ConfigChanged?.Invoke(this, new SchemaConfigChangedEventArgs(GetChanges(), GetValidationErrors()));
+    }
+
+    private static TextBlock CreateErrorBlock() => new()
+    {
+        Foreground = new SolidColorBrush(Colors.Firebrick),
+        FontSize = 12,
+        TextWrapping = TextWrapping.Wrap,
+        Visibility = Visibility.Collapsed
+    };
+
+    private void SetValidationError(string path, string? error, TextBlock errorBlock)
+    {
+        if (string.IsNullOrWhiteSpace(error))
+        {
+            _validationErrors.Remove(path);
+            errorBlock.Text = "";
+            errorBlock.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        _validationErrors[path] = error;
+        errorBlock.Text = error;
+        errorBlock.Visibility = Visibility.Visible;
+    }
+
+    private static string? ValidateValue(object? value, JsonElement schema, bool required)
+    {
+        if (ReferenceEquals(value, RemovePendingValue))
+            return null;
+
+        if (required && IsBlank(value))
+            return "This field is required.";
+
+        var expectedType = ExtractSchemaType(schema);
+        if (!IsBlank(value))
+        {
+            if (expectedType == "integer" && value is not int and not long)
+                return "Must be an integer.";
+            if (expectedType == "number" && value is not int and not long and not double)
+                return "Must be a number.";
+            if (expectedType == "boolean" && value is not bool)
+                return "Must be true or false.";
+            if (expectedType == "array" &&
+                value is not Array &&
+                value is not JsonElement { ValueKind: JsonValueKind.Array })
+                return "Must be a list.";
+        }
+
+        if (value is string text)
+        {
+            if (schema.TryGetProperty("minLength", out var minLength) &&
+                minLength.TryGetInt32(out var min) &&
+                text.Length < min)
+                return $"Must be at least {min} characters.";
+
+            if (schema.TryGetProperty("maxLength", out var maxLength) &&
+                maxLength.TryGetInt32(out var max) &&
+                text.Length > max)
+                return $"Must be {max} characters or fewer.";
+
+            if (schema.TryGetProperty("pattern", out var pattern) &&
+                pattern.ValueKind == JsonValueKind.String &&
+                pattern.GetString() is { Length: > 0 } regex)
+            {
+                try
+                {
+                    if (!Regex.IsMatch(text, regex, RegexOptions.None, PatternValidationTimeout))
+                        return "Does not match the expected format.";
+                }
+                catch (RegexMatchTimeoutException)
+                {
+                    return "Pattern validation timed out.";
+                }
+                catch (ArgumentException)
+                {
+                    return "Pattern validation is unavailable because the schema pattern is invalid.";
+                }
+            }
+        }
+
+        if (value is JsonElement jsonArray && jsonArray.ValueKind == JsonValueKind.Array)
+        {
+            if (schema.TryGetProperty("minItems", out var minItems) &&
+                minItems.TryGetInt32(out var min) &&
+                jsonArray.GetArrayLength() < min)
+                return $"Must include at least {min} item{(min == 1 ? "" : "s")}.";
+
+            if (schema.TryGetProperty("maxItems", out var maxItems) &&
+                maxItems.TryGetInt32(out var max) &&
+                jsonArray.GetArrayLength() > max)
+                return $"Must include {max} item{(max == 1 ? "" : "s")} or fewer.";
+
+            if (schema.TryGetProperty("items", out var itemSchema))
+            {
+                var index = 0;
+                foreach (var item in jsonArray.EnumerateArray())
+                {
+                    var itemError = ValidateValue(item, itemSchema, false);
+                    if (!string.IsNullOrWhiteSpace(itemError))
+                        return $"Item {index + 1}: {itemError}";
+                    index++;
+                }
+            }
+        }
+        else if (value is Array array)
+        {
+            if (schema.TryGetProperty("minItems", out var minItems) &&
+                minItems.TryGetInt32(out var min) &&
+                array.Length < min)
+                return $"Must include at least {min} item{(min == 1 ? "" : "s")}.";
+
+            if (schema.TryGetProperty("maxItems", out var maxItems) &&
+                maxItems.TryGetInt32(out var max) &&
+                array.Length > max)
+                return $"Must include {max} item{(max == 1 ? "" : "s")} or fewer.";
+
+            if (schema.TryGetProperty("items", out var itemSchema))
+            {
+                for (var i = 0; i < array.Length; i++)
+                {
+                    var itemError = ValidateValue(array.GetValue(i), itemSchema, false);
+                    if (!string.IsNullOrWhiteSpace(itemError))
+                        return $"Item {i + 1}: {itemError}";
+                }
+            }
+        }
+
+        if (value is long or int or double)
+        {
+            var number = Convert.ToDouble(value);
+            if (schema.TryGetProperty("minimum", out var minimum) &&
+                minimum.TryGetDouble(out var min) &&
+                number < min)
+                return $"Must be at least {min}.";
+
+            if (schema.TryGetProperty("maximum", out var maximum) &&
+                maximum.TryGetDouble(out var max) &&
+                number > max)
+                return $"Must be {max} or less.";
+        }
+
+        return null;
+    }
+
+    private static bool IsBlank(object? value) => value switch
+    {
+        null => true,
+        var removePending when ReferenceEquals(removePending, RemovePendingValue) => true,
+        string text => string.IsNullOrWhiteSpace(text),
+        Array array => array.Length == 0,
+        _ => false
+    };
+
+    private static object? CoerceArrayItem(string value, string itemType) => itemType switch
+    {
+        "integer" when long.TryParse(value, out var integer) => integer,
+        "number" when double.TryParse(value, out var number) => number,
+        "boolean" when bool.TryParse(value, out var boolean) => boolean,
+        _ => value
+    };
+
+    private static string FormatScalar(JsonElement value) => value.ValueKind switch
+    {
+        JsonValueKind.String => value.GetString() ?? "",
+        JsonValueKind.Number => value.GetRawText(),
+        JsonValueKind.True => "true",
+        JsonValueKind.False => "false",
+        JsonValueKind.Null => "null",
+        _ => value.ToString()
+    };
+
+    private static UIElement RenderReadOnlyField(string label, JsonElement config)
+    {
+        return new TextBox
+        {
+            Header = label,
+            Text = FormatScalar(config),
+            IsReadOnly = true,
+            MinWidth = 300,
+            Foreground = SecondaryBrush
+        };
     }
 
     /// <summary>Fallback: render config values directly as editable fields when no schema available.</summary>
@@ -428,7 +817,12 @@ public sealed partial class SchemaConfigEditor : UserControl
                 case JsonValueKind.True:
                 case JsonValueKind.False:
                     var toggle = new ToggleSwitch { Header = GetLabel(childPath, prop.Name), IsOn = value.ValueKind == JsonValueKind.True };
-                    toggle.Toggled += (s, e) => { _changes[childPath] = toggle.IsOn; ConfigChanged?.Invoke(this, _changes); };
+                    toggle.Toggled += (s, e) =>
+                    {
+                        if (_loading) return;
+                        _changes[childPath] = toggle.IsOn;
+                        ConfigChanged?.Invoke(this, new SchemaConfigChangedEventArgs(GetChanges(), GetValidationErrors()));
+                    };
                     parent.Children.Add(toggle);
                     break;
 
@@ -440,22 +834,44 @@ public sealed partial class SchemaConfigEditor : UserControl
                         SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Compact,
                         MinWidth = 200
                     };
-                    numBox.ValueChanged += (s, e) => { _changes[childPath] = numBox.Value; ConfigChanged?.Invoke(this, _changes); };
+                    numBox.ValueChanged += (s, e) =>
+                    {
+                        if (_loading) return;
+                        _changes[childPath] = numBox.Value;
+                        ConfigChanged?.Invoke(this, new SchemaConfigChangedEventArgs(GetChanges(), GetValidationErrors()));
+                    };
                     parent.Children.Add(numBox);
                     break;
 
                 case JsonValueKind.String:
                     if (IsSensitive(childPath))
                     {
-                        var pwBox = new PasswordBox { Header = GetLabel(childPath, prop.Name), Width = 350 };
-                        pwBox.Password = value.GetString() ?? "";
-                        pwBox.PasswordChanged += (s, e) => { _changes[childPath] = pwBox.Password; ConfigChanged?.Invoke(this, _changes); };
+                        var hasExistingValue = !string.IsNullOrEmpty(value.GetString());
+                        var pwBox = new PasswordBox
+                        {
+                            Header = GetLabel(childPath, prop.Name),
+                            Width = 350,
+                            PlaceholderText = hasExistingValue ? "Leave blank to keep existing value" : ""
+                        };
+                        pwBox.PasswordChanged += (s, e) =>
+                        {
+                            if (_loading) return;
+                            _changes[childPath] = hasExistingValue && string.IsNullOrEmpty(pwBox.Password)
+                                ? RemovePendingValue
+                                : pwBox.Password;
+                            ConfigChanged?.Invoke(this, new SchemaConfigChangedEventArgs(GetChanges(), GetValidationErrors()));
+                        };
                         parent.Children.Add(pwBox);
                     }
                     else
                     {
                         var textBox = new TextBox { Header = GetLabel(childPath, prop.Name), Text = value.GetString() ?? "", MinWidth = 300 };
-                        textBox.TextChanged += (s, e) => { _changes[childPath] = textBox.Text; ConfigChanged?.Invoke(this, _changes); };
+                        textBox.TextChanged += (s, e) =>
+                        {
+                            if (_loading) return;
+                            _changes[childPath] = textBox.Text;
+                            ConfigChanged?.Invoke(this, new SchemaConfigChangedEventArgs(GetChanges(), GetValidationErrors()));
+                        };
                         parent.Children.Add(textBox);
                     }
                     break;

--- a/src/OpenClaw.Tray.WinUI/Controls/SchemaConfigEditor.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Controls/SchemaConfigEditor.xaml.cs
@@ -576,10 +576,10 @@ public sealed partial class SchemaConfigEditor : UserControl
 
     private static bool IsSensitive(string path)
     {
-        var leaf = path.Split('.').Last().ToLowerInvariant();
-        return leaf.Contains("token") || leaf.Contains("secret")
-            || leaf.Contains("password") || leaf.Contains("apikey")
-            || leaf.Contains("api_key");
+        var normalizedPath = path.ToLowerInvariant();
+        return normalizedPath.Contains("token") || normalizedPath.Contains("secret")
+            || normalizedPath.Contains("password") || normalizedPath.Contains("apikey")
+            || normalizedPath.Contains("api_key");
     }
 
     private static bool IsRequired(JsonElement parentSchema, string propName)

--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -61,6 +61,7 @@
     <PackageReference Include="WinUIEx" Version="2.9.0" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.3.260402-preview2" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.3.260402-preview2" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="10.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.7" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.0" />
@@ -244,4 +245,3 @@
   </Target>
 
 </Project>
-

--- a/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml
@@ -4,142 +4,362 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:toolkit="using:CommunityToolkit.WinUI.Controls"
     xmlns:local="using:OpenClawTray.Controls">
 
-    <!-- Cap content width and stretch so panes don't shift size when toggling
-         Editor / Raw JSON or when the selected field changes. -->
-    <Grid Padding="24,16,24,16" RowSpacing="12"
-          MaxWidth="900" HorizontalAlignment="Stretch">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
+    <Grid Padding="24,20,24,16">
+        <Grid HorizontalAlignment="Stretch" RowSpacing="12">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
 
-        <!-- ───────── Page header ───────── -->
-        <StackPanel Grid.Row="0" Spacing="4">
-            <Grid>
+            <!-- Page header -->
+            <Grid Grid.Row="0" ColumnSpacing="16">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0"
-                           x:Uid="ConfigPage_TextBlock_17" Text="Config"
-                           Style="{StaticResource TitleTextBlockStyle}"
-                           VerticalAlignment="Center"/>
+                <StackPanel Grid.Column="0" Spacing="4">
+                    <TextBlock x:Uid="ConfigPage_TextBlock_17" Text="Config"
+                               Style="{StaticResource TitleTextBlockStyle}"/>
+                    <TextBlock x:Uid="ConfigSubtitle" x:Name="ConfigSubtitle"
+                               Text="Edit gateway configuration (openclaw.json) with a schema-guided form."
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               TextWrapping="Wrap"/>
+                    <TextBlock x:Name="ConfigMetaText"
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                               TextWrapping="Wrap"/>
+                </StackPanel>
                 <Button Grid.Column="1"
                         x:Name="RefreshButton" Click="OnRefresh"
                         VerticalAlignment="Center">
-                    <TextBlock x:Uid="ConfigPage_TextBlock_21" Text="Refresh"/>
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <FontIcon Glyph="&#xE72C;" FontSize="14"/>
+                        <TextBlock x:Uid="ConfigPage_TextBlock_21" Text="Refresh"/>
+                    </StackPanel>
                 </Button>
             </Grid>
-            <TextBlock x:Uid="ConfigSubtitle" x:Name="ConfigSubtitle"
-                       Text="Editing gateway configuration (openclaw.json) fetched from the connected gateway"
-                       Style="{StaticResource CaptionTextBlockStyle}"
-                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-        </StackPanel>
 
-        <!-- ───────── Segmented selector (Editor / Raw JSON) ───────── -->
-        <controls:SelectorBar Grid.Row="1" x:Name="ConfigSelector"
-                              SelectionChanged="OnConfigSelectorChanged"
-                              HorizontalAlignment="Left">
-            <controls:SelectorBarItem x:Name="EditorSelectorItem"
-                                      x:Uid="ConfigPage_TabViewItem_34"
-                                      Text="Editor" IsSelected="True" Tag="editor"/>
-            <controls:SelectorBarItem x:Name="RawJsonSelectorItem"
-                                      x:Uid="ConfigPage_TabViewItem_82"
-                                      Text="Raw JSON" Tag="raw"/>
-        </controls:SelectorBar>
+            <StackPanel Grid.Row="1" Spacing="8">
+                <InfoBar x:Name="ConnectionInfoBar"
+                         x:Uid="ConfigPage_ConnectionInfoBar"
+                         IsOpen="False"
+                         IsClosable="False"
+                         Visibility="Collapsed"
+                         Severity="Warning"
+                         Title="Gateway disconnected"
+                         Message="Connect to a gateway to load and save configuration.">
+                    <InfoBar.ActionButton>
+                        <Button x:Uid="ConfigPage_OpenConnection" Content="Open Connection" Click="OnOpenConnection"/>
+                    </InfoBar.ActionButton>
+                </InfoBar>
 
-        <!-- ───────── Editor pane ───────── -->
-        <Border Grid.Row="2" x:Name="EditorPane"
-                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                BorderThickness="1" CornerRadius="8">
-            <Grid x:Name="SchemaTreeGrid">
+                <InfoBar x:Name="PermissionInfoBar"
+                         IsOpen="False"
+                         IsClosable="False"
+                         Visibility="Collapsed"/>
+
+                <InfoBar x:Name="StatusInfoBar"
+                         IsOpen="False"
+                         IsClosable="True"
+                         Visibility="Collapsed"/>
+
+                <StackPanel x:Name="LoadingState" Orientation="Horizontal" Spacing="12"
+                            HorizontalAlignment="Center" Padding="0,8,0,0"
+                            Visibility="Collapsed">
+                    <ProgressRing IsActive="True" Width="20" Height="20"/>
+                    <TextBlock x:Uid="ConfigPage_LoadingText"
+                               Text="Loading gateway config..."
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               VerticalAlignment="Center"/>
+                </StackPanel>
+            </StackPanel>
+
+            <!-- Editor controls -->
+            <Grid Grid.Row="2" ColumnSpacing="16" Margin="0,4,0,0">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="280"/>
+                    <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
+                <TextBlock Grid.Column="0"
+                           x:Uid="ConfigPage_EditorLabel"
+                           Text="Editor"
+                           Style="{StaticResource BodyStrongTextBlockStyle}"
+                           VerticalAlignment="Center"/>
+                <StackPanel Grid.Column="1"
+                            Orientation="Horizontal"
+                            Spacing="10"
+                            VerticalAlignment="Center"
+                            HorizontalAlignment="Right">
+                    <TextBlock x:Name="SearchMetaText"
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                               VerticalAlignment="Center"/>
+                    <TextBox x:Name="ConfigSearchBox"
+                             x:Uid="ConfigSearchBox"
+                             PlaceholderText="Filter settings"
+                             TextChanged="OnSearchTextChanged"
+                             Width="320"
+                             Height="34"
+                             Padding="10,5"
+                             VerticalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
 
-                <Border Grid.Column="0"
-                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                        BorderThickness="0,0,1,0">
-                    <TreeView x:Name="ConfigTree"
-                              SelectionMode="Single"
-                              ItemInvoked="OnTreeItemInvoked"
-                              Padding="4"/>
-                </Border>
+            <!-- Editor pane -->
+            <Border Grid.Row="3"
+                    x:Name="EditorPane"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1" CornerRadius="8">
+                <Grid x:Name="SchemaTreeGrid" MinHeight="420" SizeChanged="OnSchemaTreeGridSizeChanged">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition x:Name="ConfigTreeColumn" Width="320" MinWidth="300"/>
+                        <ColumnDefinition Width="8"/>
+                        <ColumnDefinition x:Name="ConfigDetailColumn" Width="*" MinWidth="400"/>
+                        <ColumnDefinition Width="8"/>
+                        <ColumnDefinition x:Name="JsonPreviewColumn" Width="360"/>
+                    </Grid.ColumnDefinitions>
 
-                <Grid Grid.Column="1">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
+                    <Border Grid.Column="0"
+                            Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                            BorderThickness="0,0,1,0">
+                        <TreeView x:Name="ConfigTree"
+                                  SelectionMode="Single"
+                                  ItemInvoked="OnTreeItemInvoked"
+                                  Padding="8"/>
+                    </Border>
 
-                    <StackPanel Grid.Row="0" Padding="16,12" Spacing="4"
+                    <toolkit:GridSplitter Grid.Column="1"
+                                          ResizeDirection="Columns"
+                                          ResizeBehavior="PreviousAndNext"
+                                          HorizontalAlignment="Stretch"
+                                          VerticalAlignment="Stretch"
+                                          Background="{ThemeResource CardStrokeColorDefaultBrush}"/>
+
+                    <Grid Grid.Column="2">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+
+                        <Border Grid.Row="0"
+                                Padding="16,14"
                                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                                 BorderThickness="0,0,0,1">
-                        <TextBlock x:Uid="DetailPath" x:Name="DetailPath" Text="Select a config section"
-                                   Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                        <TextBlock x:Name="DetailType" Text=""
-                                   Style="{StaticResource CaptionTextBlockStyle}"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                    </StackPanel>
+                            <Grid ColumnSpacing="12">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Spacing="4">
+                                    <TextBlock x:Name="DetailBreadcrumb"
+                                               Style="{StaticResource CaptionTextBlockStyle}"
+                                               Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                                               TextWrapping="NoWrap"
+                                               TextTrimming="CharacterEllipsis"/>
+                                    <TextBlock x:Uid="DetailPath" x:Name="DetailPath" Text="Select a config section"
+                                               Style="{StaticResource SubtitleTextBlockStyle}"/>
+                                    <TextBlock x:Name="DetailType"
+                                               Style="{StaticResource CaptionTextBlockStyle}"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                               TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <Button Grid.Column="1"
+                                        x:Name="ToggleJsonPreviewButton"
+                                        x:Uid="ToggleJsonPreviewButton"
+                                        Content="Collapse JSON"
+                                        Click="OnToggleJsonPreview"
+                                        Margin="0,0,8,0"/>
+                                <Button Grid.Column="2"
+                                        x:Name="ResetSectionButton"
+                                        x:Uid="ResetSectionButton"
+                                        Content="Reset section"
+                                        Click="OnResetSection"
+                                        Visibility="Collapsed"/>
+                            </Grid>
+                        </Border>
 
-                    <ScrollViewer Grid.Row="1" Padding="16,8"
-                                  HorizontalScrollMode="Disabled"
-                                  HorizontalScrollBarVisibility="Disabled">
-                        <StackPanel x:Name="DetailPanel" Spacing="8"
-                                    HorizontalAlignment="Stretch">
-                            <TextBlock x:Uid="DetailPlaceholder" x:Name="DetailPlaceholder"
-                                       Text="Select a section from the tree to edit its settings."
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        </StackPanel>
-                    </ScrollViewer>
+                        <ScrollViewer Grid.Row="1" Padding="16,12"
+                                      HorizontalScrollMode="Disabled"
+                                      HorizontalScrollBarVisibility="Disabled">
+                            <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+                                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="8"
+                                    Padding="14">
+                                <StackPanel x:Name="DetailPanel" Spacing="8"
+                                           HorizontalAlignment="Stretch">
+                                    <TextBlock x:Uid="DetailPlaceholder" x:Name="DetailPlaceholder"
+                                              Text="Select a section from the tree to edit its settings."
+                                              Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                </StackPanel>
+                            </Border>
+                        </ScrollViewer>
+
+                        <Border x:Name="DetailLoadingOverlay"
+                                Grid.Row="1"
+                                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                Visibility="Collapsed">
+                            <StackPanel HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        Spacing="12">
+                                <ProgressRing IsActive="True" Width="24" Height="24"/>
+                                <TextBlock x:Name="DetailLoadingText"
+                                           x:Uid="DetailLoadingText"
+                                           Text="Loading section..."
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+
+                    <toolkit:GridSplitter Grid.Column="3"
+                                          x:Name="JsonPreviewSplitter"
+                                          ResizeDirection="Columns"
+                                          ResizeBehavior="PreviousAndNext"
+                                          HorizontalAlignment="Stretch"
+                                          VerticalAlignment="Stretch"
+                                          Background="{ThemeResource CardStrokeColorDefaultBrush}"/>
+
+                    <Border Grid.Column="4"
+                            x:Name="SelectedJsonPreviewPane"
+                            Background="{ThemeResource LayerFillColorDefaultBrush}"
+                            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                            BorderThickness="1,0,0,0">
+                        <Grid Padding="14" RowSpacing="10">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+                            <Grid ColumnSpacing="8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Spacing="2">
+                                    <TextBlock x:Uid="SelectedJsonPreviewTitle"
+                                               Text="JSON preview"
+                                               Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                    <TextBlock x:Name="SelectedJsonCaption"
+                                               x:Uid="SelectedJsonCaption"
+                                               Text="Compare the gateway value with the proposed unsaved value."
+                                               Style="{StaticResource CaptionTextBlockStyle}"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                               TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <Button Grid.Column="1"
+                                       x:Uid="CopySelectedJsonButton"
+                                       Content="Copy"
+                                       Click="OnCopySelectedJson"
+                                        VerticalAlignment="Top"/>
+                            </Grid>
+                            <Border Grid.Row="1"
+                                    Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="6"
+                                    Padding="10">
+                                <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                                              HorizontalScrollMode="Enabled">
+                                    <RichTextBlock x:Name="SelectedJsonDiffText"
+                                                   FontFamily="Consolas"
+                                                   FontSize="12"
+                                                   IsTextSelectionEnabled="True"
+                                                   TextWrapping="NoWrap"/>
+                                </ScrollViewer>
+                            </Border>
+                        </Grid>
+                    </Border>
                 </Grid>
-            </Grid>
-        </Border>
+            </Border>
 
-        <!-- ───────── Raw JSON pane ───────── -->
-        <Border Grid.Row="2" x:Name="RawJsonPane" Visibility="Collapsed"
-                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                BorderThickness="1" CornerRadius="8">
-            <ScrollViewer Padding="16">
-                <TextBlock x:Name="RawJsonText"
-                           FontFamily="Consolas"
-                           Style="{StaticResource CaptionTextBlockStyle}"
-                           IsTextSelectionEnabled="True" TextWrapping="Wrap"
-                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-            </ScrollViewer>
-        </Border>
+            <!-- No-schema fallback -->
+            <Border Grid.Row="3"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8"
+                    Visibility="{Binding Visibility, ElementName=NoSchemaPanel}">
+                <StackPanel x:Name="NoSchemaPanel"
+                            Visibility="Collapsed"
+                            VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="12">
+                    <FontIcon Glyph="&#xE713;" FontSize="48" HorizontalAlignment="Center"
+                              Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                    <TextBlock x:Uid="ConfigPage_TextBlock_95" Text="Schema not available"
+                               Style="{StaticResource SubtitleTextBlockStyle}"
+                               HorizontalAlignment="Center"/>
+                    <TextBlock x:Uid="ConfigPage_TextBlock_98" Text="The gateway configuration schema could not be loaded. Use the web dashboard to edit settings."
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               HorizontalAlignment="Center" TextWrapping="Wrap" MaxWidth="400"/>
+                    <Button x:Uid="OpenDashboardButton" x:Name="OpenDashboardButton" Content="Open Dashboard" Click="OnOpenDashboard"
+                            HorizontalAlignment="Center" Style="{ThemeResource AccentButtonStyle}"/>
+                </StackPanel>
+            </Border>
 
-        <!-- ───────── No-schema fallback ───────── -->
-        <StackPanel x:Name="NoSchemaPanel" Grid.Row="2" Visibility="Collapsed"
-                    VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="12">
-            <FontIcon Glyph="&#xE713;" FontSize="48" HorizontalAlignment="Center"
-                      Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-            <TextBlock x:Uid="ConfigPage_TextBlock_95" Text="Schema not available"
-                       Style="{StaticResource SubtitleTextBlockStyle}"
-                       HorizontalAlignment="Center"/>
-            <TextBlock x:Uid="ConfigPage_TextBlock_98" Text="The gateway configuration schema could not be loaded. Use the web dashboard to edit settings."
-                       Style="{StaticResource CaptionTextBlockStyle}"
-                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                       HorizontalAlignment="Center" TextWrapping="Wrap" MaxWidth="400"/>
-            <Button x:Uid="OpenDashboardButton" x:Name="OpenDashboardButton" Content="Open Dashboard" Click="OnOpenDashboard"
-                    HorizontalAlignment="Center" Style="{ThemeResource AccentButtonStyle}"/>
-        </StackPanel>
-
-        <!-- ───────── Save bar ───────── -->
-        <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8"
-                    HorizontalAlignment="Right" Padding="0,8,0,0">
-            <TextBlock x:Name="SaveStatus" VerticalAlignment="Center"
-                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-            <Button x:Uid="SaveButton" x:Name="SaveButton"
-                    Content="Save Changes"
-                    Style="{ThemeResource AccentButtonStyle}" Click="OnSave"/>
-        </StackPanel>
+            <!-- Save bar -->
+            <Border Grid.Row="4"
+                    Background="{ThemeResource AcrylicInAppFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8"
+                    Padding="12">
+                <Grid ColumnSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Spacing="6" VerticalAlignment="Center">
+                        <Border x:Name="SaveStatusPill"
+                                Background="{ThemeResource LayerFillColorDefaultBrush}"
+                                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                BorderThickness="1"
+                                CornerRadius="12"
+                                Padding="9,4"
+                                HorizontalAlignment="Left">
+                            <StackPanel Orientation="Horizontal" Spacing="7">
+                                <FontIcon x:Name="SaveStatusIcon"
+                                          Glyph="&#xE73E;"
+                                          FontSize="12"
+                                          Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                          VerticalAlignment="Center"/>
+                                <TextBlock x:Name="SaveStatus"
+                                           Style="{StaticResource BodyStrongTextBlockStyle}"
+                                           FontSize="13"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           TextWrapping="Wrap"/>
+                            </StackPanel>
+                        </Border>
+                        <TextBlock x:Name="AccessSummaryText"
+                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                                   TextWrapping="Wrap"/>
+                    </StackPanel>
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
+                        <Button x:Name="DiscardButton"
+                                x:Uid="DiscardButton"
+                                Content="Discard changes"
+                                Click="OnDiscardChanges"
+                                IsEnabled="False"/>
+                        <Button x:Name="SaveButton"
+                                IsEnabled="False"
+                                Style="{ThemeResource AccentButtonStyle}" Click="OnSave">
+                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                <FontIcon Glyph="&#xE74E;" FontSize="13"/>
+                                <TextBlock x:Uid="SaveButtonText" Text="Save Changes"/>
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </Grid>
     </Grid>
 </Page>

--- a/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
@@ -1,14 +1,20 @@
-using Microsoft.UI;
-using Microsoft.UI.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using OpenClaw.Connection;
+using OpenClaw.Shared;
+using OpenClawTray.Controls;
+using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 
 namespace OpenClawTray.Pages;
@@ -16,83 +22,178 @@ namespace OpenClawTray.Pages;
 public sealed partial class ConfigPage : Page
 {
     private static readonly JsonElement s_emptyObject = JsonDocument.Parse("{}").RootElement.Clone();
+    private const double JsonPreviewAutoCollapseWidth = 1040;
+    private const double JsonPreviewAutoExpandWidth = 1120;
+    private const double JsonPreviewMinWidth = 340;
 
     private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
     private AppState? _appState;
     private JsonElement? _lastConfig;
     private JsonElement? _lastSchema;
-    private string? _baseHash;
+    private ConfigEditorSnapshot _serverSnapshot = ConfigEditorSnapshot.Empty;
+    private ConfigEditorSnapshot _editSnapshot = ConfigEditorSnapshot.Empty;
+    private IOperatorGatewayClient? _permissionClient;
 
-    private JsonElement? _selectedElement;
     private string _selectedPath = "";
-    private readonly Dictionary<TreeViewNode, (string Path, JsonElement Element)> _nodeMap = new();
-    private readonly Dictionary<string, object?> _pendingChanges = new();
-
+    private string _searchText = "";
     private bool _showSchemaFallback;
+    private bool _loading;
+    private bool _saving;
+    private bool _initialized;
+    private bool _jsonPreviewVisible = true;
+    private bool _jsonPreviewCollapsedByUser;
+    private bool _refreshConfigAfterReconnect;
+    private bool _refreshConfigWhenGatewayAvailable;
+    private ContentDialog? _reconnectDialog;
+    private TextBlock? _reconnectDialogMessage;
+    private GridLength _jsonPreviewExpandedWidth = new(360);
+    private int _detailRenderVersion;
+    private string _selectedJsonCopyText = "";
+    private readonly DispatcherTimer _searchDebounceTimer = new() { Interval = TimeSpan.FromMilliseconds(250) };
+    private readonly DispatcherTimer _reconnectCompletionTimer = new() { Interval = TimeSpan.FromSeconds(3) };
+    private readonly DispatcherTimer _reconnectTimeoutTimer = new() { Interval = TimeSpan.FromSeconds(45) };
+    private readonly DispatcherTimer _statusDismissTimer = new() { Interval = TimeSpan.FromSeconds(4) };
+
+    private readonly Dictionary<TreeViewNode, (string Path, JsonElement Element)> _nodeMap = new();
+    private readonly Dictionary<string, object?> _pendingChanges = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string> _validationErrors = new(StringComparer.Ordinal);
 
     public ConfigPage()
     {
         InitializeComponent();
+        NavigationCacheMode = NavigationCacheMode.Required;
         Unloaded += (_, _) =>
         {
             if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+            UnsubscribePermissionClient();
+            _searchDebounceTimer.Stop();
+            _reconnectCompletionTimer.Stop();
+            _reconnectTimeoutTimer.Stop();
+            _statusDismissTimer.Stop();
+        };
+        StatusInfoBar.Closed += (_, _) =>
+        {
+            _statusDismissTimer.Stop();
+            SetInfoBarOpen(StatusInfoBar, false);
+        };
+        _searchDebounceTimer.Tick += (_, _) =>
+        {
+            _searchDebounceTimer.Stop();
+            RenderTree();
+            RestoreSelectedDetail();
+        };
+        _reconnectCompletionTimer.Tick += (_, _) =>
+        {
+            _reconnectCompletionTimer.Stop();
+            CompleteReconnectIfReady();
+        };
+        _reconnectTimeoutTimer.Tick += (_, _) =>
+        {
+            _reconnectTimeoutTimer.Stop();
+            HandleReconnectTimeout();
+        };
+        _statusDismissTimer.Tick += (_, _) =>
+        {
+            _statusDismissTimer.Stop();
+            SetInfoBarOpen(StatusInfoBar, false);
         };
     }
 
     public void Initialize()
     {
+        if (_appState != null)
+            _appState.PropertyChanged -= OnAppStateChanged;
+
         _appState = CurrentApp.AppState;
         _appState.PropertyChanged += OnAppStateChanged;
-        OpenClawTray.Services.Logger.Info("[ConfigPage] Initialize");
-        if (CurrentApp.GatewayClient != null)
+        SubscribePermissionClient(CurrentApp.GatewayClient);
+        Logger.Info("[ConfigPage] Initialize");
+        if (CompleteReconnectIfReady())
+            return;
+
+        if (!_initialized || !_serverSnapshot.HasRoot || !_lastSchema.HasValue)
         {
-            _ = CurrentApp.GatewayClient.RequestConfigSchemaAsync();
-            _ = CurrentApp.GatewayClient.RequestConfigAsync();
+            _initialized = true;
+            RefreshFromGateway();
+        }
+        else
+        {
+            SetInfoBarOpen(ConnectionInfoBar, CurrentApp.GatewayClient == null);
+            UpdatePermissionBanner();
+            UpdateMetaAndButtons();
         }
     }
 
     public void UpdateConfig(JsonElement config)
     {
         var configSnapshot = config.Clone();
-        try
+        RunOnUiThread(() =>
         {
-            OpenClawTray.Services.Logger.Info("[ConfigPage] UpdateConfig received");
-            _lastConfig = configSnapshot;
-
-            // Get baseHash from the config.get response
-            // The gateway returns a 'hash' field which is SHA256 of the raw file content
-            if (configSnapshot.TryGetProperty("baseHash", out var bh) && bh.ValueKind == JsonValueKind.String)
+            try
             {
-                _baseHash = bh.GetString();
-            }
-            else if (configSnapshot.TryGetProperty("hash", out var hashEl) && hashEl.ValueKind == JsonValueKind.String)
-            {
-                _baseHash = hashEl.GetString();
-            }
-            else if (configSnapshot.TryGetProperty("raw", out var rawEl) && rawEl.ValueKind == JsonValueKind.String)
-            {
-                // Fallback: compute from raw content
-                var rawContent = rawEl.GetString();
-                if (rawContent != null)
+                Logger.Info("[ConfigPage] UpdateConfig received");
+                if (GetConfigPermissionState() == ConfigPermissionState.NoRead)
                 {
-                    var bytes = System.Text.Encoding.UTF8.GetBytes(rawContent);
-                    var hash = System.Security.Cryptography.SHA256.HashData(bytes);
-                    _baseHash = Convert.ToHexStringLower(hash);
+                    ClearConfigViewForNoRead();
+                    UpdatePermissionBanner();
+                    UpdateMetaAndButtons();
+                    return;
                 }
+
+                _lastConfig = configSnapshot;
+                _serverSnapshot = ConfigEditorModel.CaptureSnapshot(configSnapshot);
+                if (_pendingChanges.Count == 0)
+                    _editSnapshot = _serverSnapshot;
+
+                if (configSnapshot.TryGetProperty("path", out var pathEl) &&
+                    pathEl.ValueKind == JsonValueKind.String)
+                    ConfigSubtitle.Text = $"Editing {pathEl.GetString()} via schema-guided form.";
+
+                _loading = false;
+                SetInfoBarOpen(ConnectionInfoBar, CurrentApp.GatewayClient == null);
+                UpdatePermissionBanner();
+                RenderTree();
+                RestoreSelectedDetail();
+                UpdateSelectedJsonPreviewForCurrentSelection();
+                UpdateMetaAndButtons();
             }
+            catch (Exception ex)
+            {
+                Logger.Error($"[ConfigPage] Failed to render config: {ex}");
+                ShowConfigRenderError("Config unavailable", "The gateway config could not be rendered. Refresh and try again.");
+            }
+        });
+    }
 
-            // Show file path in subtitle if available
-            if (configSnapshot.TryGetProperty("path", out var pathEl))
-                ConfigSubtitle.Text = $"Editing {pathEl.GetString()} via schema-driven form";
-
-            RenderTree();
-            UpdateRawJson();
-        }
-        catch (Exception ex)
+    public void UpdateConfigSchema(JsonElement schema)
+    {
+        var schemaSnapshot = schema.Clone();
+        RunOnUiThread(() =>
         {
-            OpenClawTray.Services.Logger.Error($"[ConfigPage] Failed to render config: {ex}");
-            ShowConfigRenderError();
-        }
+            try
+            {
+                if (GetConfigPermissionState() == ConfigPermissionState.NoRead)
+                {
+                    ClearConfigViewForNoRead();
+                    UpdatePermissionBanner();
+                    UpdateMetaAndButtons();
+                    return;
+                }
+
+                _lastSchema = schemaSnapshot;
+                _loading = false;
+                UpdatePermissionBanner();
+                RenderTree();
+                RestoreSelectedDetail();
+                UpdateSelectedJsonPreviewForCurrentSelection();
+                UpdateMetaAndButtons();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"[ConfigPage] Failed to render config schema: {ex}");
+                ShowConfigRenderError("Schema unavailable", "The gateway schema could not be rendered. Raw JSON remains available as a read-only preview.");
+            }
+        });
     }
 
     private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
@@ -105,24 +206,65 @@ public sealed partial class ConfigPage : Page
             case nameof(AppState.ConfigSchema):
                 if (_appState!.ConfigSchema.HasValue) UpdateConfigSchema(_appState.ConfigSchema.Value);
                 break;
+            case nameof(AppState.Status):
+                SubscribePermissionClient(CurrentApp.GatewayClient);
+                UpdateConnectionBanner();
+                UpdatePermissionBanner();
+                var configPermissionState = GetConfigPermissionState();
+                if (configPermissionState == ConfigPermissionState.Disconnected && _refreshConfigAfterReconnect)
+                {
+                    ShowStatus("Gateway restarting", "Saving changes. The gateway is restarting and will reconnect automatically.", InfoBarSeverity.Informational);
+                    ShowReconnectDialog(LocalizationHelper.GetString("ConfigPage_ReconnectDialogWaiting"));
+                }
+                else if (_refreshConfigAfterReconnect &&
+                         configPermissionState is (ConfigPermissionState.ReadOnly or ConfigPermissionState.ReadWrite))
+                {
+                    CompleteReconnectIfReady();
+                    return;
+                }
+                UpdateMetaAndButtons();
+                break;
         }
     }
 
-    public void UpdateConfigSchema(JsonElement schema)
+    private void SubscribePermissionClient(IOperatorGatewayClient? client)
     {
-        var schemaSnapshot = schema.Clone();
-        try
+        if (ReferenceEquals(_permissionClient, client))
+            return;
+
+        UnsubscribePermissionClient();
+        _permissionClient = client;
+        if (_permissionClient != null)
+            _permissionClient.HandshakeSucceeded += OnGatewayHandshakeSucceeded;
+    }
+
+    private void UnsubscribePermissionClient()
+    {
+        if (_permissionClient != null)
+            _permissionClient.HandshakeSucceeded -= OnGatewayHandshakeSucceeded;
+        _permissionClient = null;
+    }
+
+    private void OnGatewayHandshakeSucceeded(object? sender, EventArgs e)
+    {
+        RunOnUiThread(() =>
         {
-            _lastSchema = schemaSnapshot;
-            // Re-render tree if config is already loaded
-            if (_lastConfig.HasValue)
-                RenderTree();
-        }
-        catch (Exception ex)
-        {
-            OpenClawTray.Services.Logger.Error($"[ConfigPage] Failed to render config schema: {ex}");
-            ShowConfigRenderError();
-        }
+            UpdatePermissionBanner();
+            var permissionState = GetConfigPermissionState();
+            if (CompleteReconnectIfReady())
+                return;
+
+            if (permissionState is ConfigPermissionState.ReadOnly or ConfigPermissionState.ReadWrite &&
+                !_loading &&
+                (!_serverSnapshot.HasRoot || !_lastSchema.HasValue))
+            {
+                RefreshFromGateway();
+            }
+            else
+            {
+                UpdateMetaAndButtons();
+            }
+        });
     }
 
     private void RenderTree()
@@ -132,39 +274,972 @@ public sealed partial class ConfigPage : Page
 
         if (_lastSchema.HasValue)
         {
-            // Schema-driven tree
             _showSchemaFallback = false;
             ApplyPaneVisibility();
 
-            var schema = _lastSchema.Value;
-            var schemaRoot = schema.TryGetProperty("schema", out var sr) ? sr : schema;
-            var configRoot = _lastConfig.HasValue ? ExtractConfigRoot(_lastConfig.Value) : (JsonElement?)null;
+            var schemaRoot = GetSchemaRoot(_lastSchema.Value);
+            var configRoot = _serverSnapshot.HasRoot ? _serverSnapshot.Root : (JsonElement?)null;
 
-            BuildSchemaTreeNodes(ConfigTree.RootNodes, schemaRoot, configRoot, "");
-            ExpandAll(ConfigTree.RootNodes);
+            var rootElement = configRoot ?? s_emptyObject;
+            var rootNode = new TreeViewNode { IsExpanded = true };
+            BuildSchemaTreeNodes(rootNode.Children, schemaRoot, configRoot, "");
+            var rootVisible = string.IsNullOrWhiteSpace(_searchText) ||
+                              MatchesSearch("", schemaRoot) ||
+                              rootNode.Children.Count > 0;
+            if (rootVisible)
+            {
+                var dirtyCount = CountPathsUnder("", _pendingChanges.Keys);
+                var invalidCount = CountPathsUnder("", _validationErrors.Keys);
+                var label = "Full config";
+                if (dirtyCount > 0) label += $" • {dirtyCount} changed";
+                if (invalidCount > 0) label += $" • {invalidCount} issue{(invalidCount == 1 ? "" : "s")}";
+                rootNode.Content = $"📁 {label}";
+                _nodeMap[rootNode] = ("", rootElement);
+                ConfigTree.RootNodes.Add(rootNode);
+            }
+            UpdateSearchMetaText();
         }
         else
         {
-            // No schema — show fallback panel (whether or not config loaded)
             _showSchemaFallback = true;
             ApplyPaneVisibility();
+            UpdateSearchMetaText();
         }
     }
 
-    private static JsonElement ExtractConfigRoot(JsonElement configResponse)
+    private bool BuildSchemaTreeNodes(IList<TreeViewNode> parent, JsonElement schema, JsonElement? config, string basePath)
     {
-        if (configResponse.TryGetProperty("parsed", out var parsed))
-            return parsed;
-        if (configResponse.TryGetProperty("config", out var config))
-            return config;
-        return configResponse;
+        if (!schema.TryGetProperty("properties", out var properties) ||
+            properties.ValueKind != JsonValueKind.Object)
+            return false;
+
+        var anyVisible = false;
+        foreach (var prop in properties.EnumerateObject().OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase))
+        {
+            var path = string.IsNullOrEmpty(basePath) ? prop.Name : $"{basePath}.{prop.Name}";
+            var propType = ExtractSchemaType(prop.Value);
+            if (propType != "object" && !prop.Value.TryGetProperty("properties", out _))
+                continue;
+
+            var configValue = config.HasValue && config.Value.TryGetProperty(prop.Name, out var cv)
+                ? (JsonElement?)cv
+                : null;
+
+            var node = new TreeViewNode();
+            var childVisible = BuildSchemaTreeNodes(node.Children, prop.Value, configValue, path);
+            var selfMatches = MatchesSearch(path, prop.Value);
+            if (!selfMatches && !childVisible && !string.IsNullOrWhiteSpace(_searchText))
+                continue;
+
+            var dirtyCount = CountPathsUnder(path, _pendingChanges.Keys);
+            var invalidCount = CountPathsUnder(path, _validationErrors.Keys);
+            var label = FriendlyLabel(prop.Name);
+            if (dirtyCount > 0) label += $" • {dirtyCount} changed";
+            if (invalidCount > 0) label += $" • {invalidCount} issue{(invalidCount == 1 ? "" : "s")}";
+
+            node.Content = $"📁 {label}";
+            node.IsExpanded = !string.IsNullOrWhiteSpace(_searchText) && (selfMatches || childVisible);
+            _nodeMap[node] = (path, configValue ?? s_emptyObject);
+            parent.Add(node);
+            anyVisible = true;
+        }
+
+        return anyVisible;
     }
 
-    /// <summary>
-    /// JSON Schema's "type" keyword may be either a string ("object") or an
-    /// array of strings (["string","null"]). Returns the first non-null type
-    /// when an array is encountered, or null if "type" is missing/unsupported.
-    /// </summary>
+    private void RestoreSelectedDetail()
+    {
+        if (!_serverSnapshot.HasRoot || !_lastSchema.HasValue)
+            return;
+
+        if (TryGetElementAtPath(_serverSnapshot.Root, _selectedPath, out var element))
+        {
+            ShowDetail(_selectedPath, element);
+            return;
+        }
+
+        _selectedPath = "";
+        ShowDetail("", _serverSnapshot.Root);
+    }
+
+    private void ShowDetail(string path, JsonElement element)
+    {
+        if (!_lastSchema.HasValue)
+            return;
+
+        DetailPanel.Children.Clear();
+        DetailPlaceholder.Visibility = Visibility.Collapsed;
+        _selectedPath = path;
+        DetailBreadcrumb.Text = BuildBreadcrumb(path);
+        DetailPath.Text = string.IsNullOrEmpty(path) ? "Full config" : FriendlyLabel(path.Split('.').Last());
+
+        var nodeSchema = ResolveSchemaAtPath(GetSchemaRoot(_lastSchema.Value), path);
+        var displayElement = ConfigEditorModel.ApplyRelativeChanges(element, path, _pendingChanges);
+        var sectionDirty = CountPathsUnder(path, _pendingChanges.Keys) > 0;
+        ResetSectionButton.Visibility = sectionDirty ? Visibility.Visible : Visibility.Collapsed;
+        UpdateSelectedJsonPreview(path, element, displayElement);
+
+        if (string.IsNullOrEmpty(path))
+        {
+            DetailType.Text = displayElement.ValueKind == JsonValueKind.Object
+                ? $"Root object · {displayElement.EnumerateObject().Count()} top-level properties"
+                : displayElement.ValueKind.ToString();
+            if (TryBuildRootLeafSchema(nodeSchema, out var leafSchema))
+            {
+                var editor = new SchemaConfigEditor();
+                editor.LoadSchema(leafSchema, displayElement);
+                editor.ConfigChanged += (_, args) => ApplyEditorChanges(path, args);
+                DetailPanel.Children.Add(editor);
+            }
+            else
+            {
+                DetailPanel.Children.Add(new TextBlock
+                {
+                    Text = "Select a child section to edit fields. The full root config is available in the JSON preview.",
+                    Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+                    TextWrapping = TextWrapping.Wrap
+                });
+            }
+            return;
+        }
+
+        if (nodeSchema.HasValue && nodeSchema.Value.TryGetProperty("description", out var desc) &&
+            desc.ValueKind == JsonValueKind.String)
+        {
+            DetailType.Text = desc.GetString() ?? "";
+        }
+        else
+        {
+            DetailType.Text = displayElement.ValueKind == JsonValueKind.Object
+                ? $"Object · {displayElement.EnumerateObject().Count()} properties"
+                : displayElement.ValueKind.ToString();
+        }
+
+        if (nodeSchema.HasValue && displayElement.ValueKind == JsonValueKind.Object)
+        {
+            var editor = new SchemaConfigEditor();
+            editor.LoadSchema(nodeSchema.Value, displayElement);
+            editor.IsEnabled = !IsConfigEditingLocked(GetConfigPermissionState());
+            editor.ConfigChanged += (_, args) => ApplyEditorChanges(path, args);
+            DetailPanel.Children.Add(editor);
+            return;
+        }
+
+        DetailPanel.Children.Add(new TextBlock
+        {
+            Text = "This section is shown in the JSON preview because the schema shape is not editable in the form yet.",
+            Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+            TextWrapping = TextWrapping.Wrap
+        });
+    }
+
+    private void ApplyEditorChanges(string sectionPath, SchemaConfigChangedEventArgs args)
+    {
+        if (IsConfigEditingLocked(GetConfigPermissionState()))
+            return;
+
+        if (_pendingChanges.Count == 0 && _serverSnapshot.HasRoot)
+            _editSnapshot = _serverSnapshot;
+
+        foreach (var (path, value) in args.Changes)
+        {
+            var fullPath = string.IsNullOrEmpty(sectionPath) ? path : $"{sectionPath}.{path}";
+            if (ReferenceEquals(value, SchemaConfigEditor.RemovePendingValue))
+            {
+                _pendingChanges.Remove(fullPath);
+                _validationErrors.Remove(fullPath);
+            }
+            else
+            {
+                _pendingChanges[fullPath] = value;
+            }
+        }
+
+        RemoveSectionEntries(sectionPath, _validationErrors);
+        foreach (var (path, error) in args.ValidationErrors)
+        {
+            var fullPath = string.IsNullOrEmpty(sectionPath) ? path : $"{sectionPath}.{path}";
+            _validationErrors[fullPath] = error;
+        }
+
+        RenderTree();
+        UpdateSelectedJsonPreviewForCurrentSelection();
+        UpdateMetaAndButtons();
+    }
+
+    private async void OnSave(object sender, RoutedEventArgs e)
+    {
+        if (_saving) return;
+
+        if (_pendingChanges.Count == 0)
+        {
+            ShowStatus("No changes", "There is nothing to save.", InfoBarSeverity.Informational);
+            return;
+        }
+
+        if (_validationErrors.Count > 0)
+        {
+            var first = _validationErrors.First();
+            ShowStatus("Fix validation errors", $"{first.Key}: {first.Value}", InfoBarSeverity.Error);
+            UpdateMetaAndButtons();
+            return;
+        }
+
+        var client = CurrentApp.GatewayClient;
+        if (client == null)
+        {
+            ShowStatus("Not connected", "Connect to a gateway before saving config.", InfoBarSeverity.Error);
+            UpdateMetaAndButtons();
+            return;
+        }
+
+        if (!OperatorScopeHelper.CanWriteConfig(client.GrantedOperatorScopes))
+        {
+            ShowStatus("Config is read-only", "This operator token does not have operator.write permission, so config changes cannot be saved.", InfoBarSeverity.Warning);
+            UpdatePermissionBanner();
+            UpdateMetaAndButtons();
+            return;
+        }
+
+        var saveBase = _editSnapshot.HasRoot ? _editSnapshot : _serverSnapshot;
+        if (!saveBase.HasRoot)
+        {
+            ShowStatus("Config not loaded", "Refresh the gateway config before saving.", InfoBarSeverity.Error);
+            UpdateMetaAndButtons();
+            return;
+        }
+
+        _saving = true;
+        UpdateMetaAndButtons();
+        ShowStatus("Saving config…", $"Writing {_pendingChanges.Count} change(s) to the gateway.", InfoBarSeverity.Informational);
+
+        try
+        {
+            var updated = ConfigEditorModel.ApplyChanges(saveBase.Root, _pendingChanges);
+            var result = await client.PatchConfigDetailedAsync(updated, saveBase.BaseHash);
+            if (!result.Ok)
+            {
+                if (result.LooksLikeStaleBaseHash)
+                {
+                    _ = client.RequestConfigAsync();
+                    ShowStatus(
+                        "Gateway config changed elsewhere",
+                        $"Your edits are preserved. The latest config is being refreshed; review the form and try Save again. Details: {result.Error ?? "stale config hash"}",
+                        InfoBarSeverity.Warning);
+                }
+                else
+                {
+                    ShowStatus(
+                        "Save failed",
+                        result.Error ?? "The gateway rejected the config update. Your changes are preserved.",
+                        InfoBarSeverity.Error);
+                }
+                return;
+            }
+
+            _pendingChanges.Clear();
+            _validationErrors.Clear();
+            _editSnapshot = ConfigEditorSnapshot.Empty;
+            _refreshConfigAfterReconnect = true;
+            _refreshConfigWhenGatewayAvailable = true;
+            ShowReconnectDialog(LocalizationHelper.GetString("ConfigPage_ReconnectDialogAccepted"));
+            ShowStatus("Gateway restarting", "Saving changes. The gateway is restarting and will reconnect automatically.", InfoBarSeverity.Informational);
+            _reconnectCompletionTimer.Stop();
+            _reconnectCompletionTimer.Start();
+            _reconnectTimeoutTimer.Stop();
+            _reconnectTimeoutTimer.Start();
+        }
+        catch (Exception ex)
+        {
+            ShowStatus("Save failed", $"{ex.Message} Your changes are preserved.", InfoBarSeverity.Error);
+        }
+        finally
+        {
+            _saving = false;
+            UpdateMetaAndButtons();
+            RestoreSelectedDetail();
+            UpdateSelectedJsonPreviewForCurrentSelection();
+        }
+    }
+
+    private void OnRefresh(object sender, RoutedEventArgs e)
+    {
+        RefreshFromGateway();
+    }
+
+    private void RefreshFromGateway()
+    {
+        UpdateConnectionBanner();
+        var permissionState = GetConfigPermissionState();
+        if (CurrentApp.GatewayClient == null)
+        {
+            _loading = false;
+            UpdatePermissionBanner();
+            UpdateMetaAndButtons();
+            return;
+        }
+
+        if (permissionState == ConfigPermissionState.Checking)
+        {
+            _loading = false;
+            SaveStatus.Text = "Checking config permissions…";
+            UpdatePermissionBanner();
+            UpdateMetaAndButtons();
+            return;
+        }
+
+        if (permissionState == ConfigPermissionState.NoRead)
+        {
+            ClearConfigViewForNoRead();
+            UpdatePermissionBanner();
+            UpdateMetaAndButtons();
+            return;
+        }
+
+        _loading = true;
+        LoadingState.Visibility = Visibility.Visible;
+        SaveStatus.Text = "Refreshing…";
+        UpdatePermissionBanner();
+        _ = CurrentApp.GatewayClient.RequestConfigSchemaAsync();
+        _ = CurrentApp.GatewayClient.RequestConfigAsync();
+        UpdateMetaAndButtons();
+    }
+
+    private void UpdateConnectionBanner()
+    {
+        SetInfoBarOpen(ConnectionInfoBar, GetConfigPermissionState() == ConfigPermissionState.Disconnected);
+    }
+
+    private void OnSearchTextChanged(object sender, TextChangedEventArgs e)
+    {
+        _searchText = ConfigSearchBox.Text.Trim();
+        _searchDebounceTimer.Stop();
+        _searchDebounceTimer.Start();
+    }
+
+    private void OnDiscardChanges(object sender, RoutedEventArgs e)
+    {
+        _pendingChanges.Clear();
+        _validationErrors.Clear();
+        _editSnapshot = ConfigEditorSnapshot.Empty;
+        ShowStatus("Changes discarded", "The form is back to the last config loaded from the gateway.", InfoBarSeverity.Informational);
+        RenderTree();
+        RestoreSelectedDetail();
+        UpdateSelectedJsonPreviewForCurrentSelection();
+        UpdateMetaAndButtons();
+    }
+
+    private void OnResetSection(object sender, RoutedEventArgs e)
+    {
+        RemoveSectionEntries(_selectedPath, _pendingChanges);
+        RemoveSectionEntries(_selectedPath, _validationErrors);
+        var sectionLabel = string.IsNullOrEmpty(_selectedPath) ? "Full config" : _selectedPath;
+        ShowStatus("Section reset", $"{sectionLabel} is back to the last loaded gateway value.", InfoBarSeverity.Informational);
+        RenderTree();
+        RestoreSelectedDetail();
+        UpdateSelectedJsonPreviewForCurrentSelection();
+        UpdateMetaAndButtons();
+    }
+
+    private void OnOpenConnection(object sender, RoutedEventArgs e)
+    {
+        ((IAppCommands)CurrentApp).Navigate("connection");
+    }
+
+    private void OnOpenDashboard(object sender, RoutedEventArgs e)
+    {
+        ((IAppCommands)CurrentApp).OpenDashboard("config");
+    }
+
+    private void OnCopySelectedJson(object sender, RoutedEventArgs e)
+    {
+        var package = new global::Windows.ApplicationModel.DataTransfer.DataPackage();
+        package.SetText(_selectedJsonCopyText);
+        global::Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(package);
+        ShowStatus("Copied JSON diff", "The selected section diff was copied to the clipboard.", InfoBarSeverity.Success);
+    }
+
+    private void OnToggleJsonPreview(object sender, RoutedEventArgs e)
+    {
+        _jsonPreviewCollapsedByUser = _jsonPreviewVisible;
+        _jsonPreviewVisible = !_jsonPreviewVisible;
+        ApplyJsonPreviewVisibility();
+    }
+
+    private void OnSchemaTreeGridSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        if (_jsonPreviewVisible && e.NewSize.Width < JsonPreviewAutoCollapseWidth)
+        {
+            _jsonPreviewVisible = false;
+            ApplyJsonPreviewVisibility();
+        }
+        else if (!_jsonPreviewVisible && !_jsonPreviewCollapsedByUser && e.NewSize.Width >= JsonPreviewAutoExpandWidth)
+        {
+            _jsonPreviewVisible = true;
+            ApplyJsonPreviewVisibility();
+        }
+    }
+
+    private void ApplyPaneVisibility()
+    {
+        if (EditorPane is null || NoSchemaPanel is null) return;
+
+        EditorPane.Visibility = !_showSchemaFallback ? Visibility.Visible : Visibility.Collapsed;
+        NoSchemaPanel.Visibility = _showSchemaFallback ? Visibility.Visible : Visibility.Collapsed;
+        ConfigSearchBox.Visibility = !_showSchemaFallback ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private void UpdateSelectedJsonPreviewForCurrentSelection()
+    {
+        if (SelectedJsonDiffText is null)
+            return;
+
+        var previewSnapshot = GetPreviewSnapshot();
+        if (!previewSnapshot.HasRoot)
+        {
+            SelectedJsonCaption.Text = "Select a section to preview its JSON.";
+            RenderJsonDiff("{}", "{}");
+            return;
+        }
+
+        var element = TryGetElementAtPath(previewSnapshot.Root, _selectedPath, out var current)
+            ? current
+            : s_emptyObject;
+        UpdateSelectedJsonPreview(_selectedPath, element, ConfigEditorModel.ApplyRelativeChanges(element, _selectedPath, _pendingChanges));
+    }
+
+    private ConfigEditorSnapshot GetPreviewSnapshot() =>
+        _pendingChanges.Count > 0 && _editSnapshot.HasRoot ? _editSnapshot : _serverSnapshot;
+
+    private void UpdateSelectedJsonPreview(string path, JsonElement gatewayElement, JsonElement proposedElement)
+    {
+        if (SelectedJsonDiffText is null)
+            return;
+
+        try
+        {
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            var gatewayJson = JsonSerializer.Serialize(gatewayElement, options);
+            var dirtyCount = CountPathsUnder(path, _pendingChanges.Keys);
+            var label = string.IsNullOrEmpty(path) ? "Full config" : path;
+            if (string.IsNullOrEmpty(path))
+            {
+                var proposedJson = dirtyCount > 0
+                    ? JsonSerializer.Serialize(ConfigEditorModel.ApplyChanges(gatewayElement, _pendingChanges), options)
+                    : gatewayJson;
+                RenderJsonDiff(gatewayJson, proposedJson);
+                SelectedJsonCaption.Text = dirtyCount > 0
+                    ? $"{label}: {dirtyCount} unsaved change{(dirtyCount == 1 ? "" : "s")} highlighted below."
+                    : $"{label}: no unsaved edits.";
+            }
+            else
+            {
+                var proposedJson = JsonSerializer.Serialize(proposedElement, options);
+                RenderJsonDiff(gatewayJson, proposedJson);
+                SelectedJsonCaption.Text = dirtyCount > 0
+                    ? $"{label}: {dirtyCount} unsaved change{(dirtyCount == 1 ? "" : "s")} highlighted below."
+                    : $"{label}: proposed value matches the last loaded gateway config.";
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"[ConfigPage] Failed to build selected JSON preview: {ex.Message}");
+            SelectedJsonCaption.Text = "Selected section JSON preview is unavailable.";
+            RenderJsonDiff(gatewayElement.GetRawText(), proposedElement.GetRawText());
+        }
+    }
+
+    private void RenderJsonDiff(string gatewayJson, string proposedJson)
+    {
+        SelectedJsonDiffText.Blocks.Clear();
+        var paragraph = new Paragraph();
+        var defaultBrush = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"];
+        var addedBrush = new SolidColorBrush(Microsoft.UI.Colors.LightGreen);
+        var removedBrush = new SolidColorBrush(Microsoft.UI.Colors.IndianRed);
+
+        var copyLines = new List<string>();
+        void AddLine(JsonDiffLine line)
+        {
+            var changeBrush = line.Kind == JsonDiffLineKind.Removed ? removedBrush : addedBrush;
+            copyLines.Add(line.CopyText);
+            paragraph.Inlines.Add(new Run
+            {
+                Text = line.Prefix,
+                Foreground = line.Kind == JsonDiffLineKind.Unchanged ? defaultBrush : changeBrush
+            });
+            foreach (var segment in line.Segments)
+            {
+                paragraph.Inlines.Add(new Run
+                {
+                    Text = segment.Text,
+                    Foreground = line.Kind == JsonDiffLineKind.Unchanged || !segment.IsChanged ? defaultBrush : changeBrush
+                });
+            }
+            paragraph.Inlines.Add(new LineBreak());
+        }
+
+        foreach (var line in JsonDiffFormatter.CreateDiff(gatewayJson, proposedJson))
+            AddLine(line);
+
+        _selectedJsonCopyText = string.Join(Environment.NewLine, copyLines);
+        SelectedJsonDiffText.Blocks.Add(paragraph);
+    }
+
+    private void ApplyJsonPreviewVisibility()
+    {
+        if (_jsonPreviewVisible)
+        {
+            JsonPreviewColumn.MinWidth = JsonPreviewMinWidth;
+            JsonPreviewColumn.Width = _jsonPreviewExpandedWidth;
+        }
+        else
+        {
+            if (JsonPreviewColumn.Width.Value > 0)
+                _jsonPreviewExpandedWidth = JsonPreviewColumn.Width;
+            JsonPreviewColumn.MinWidth = 0;
+            JsonPreviewColumn.Width = new GridLength(0);
+        }
+
+        SelectedJsonPreviewPane.Visibility = _jsonPreviewVisible ? Visibility.Visible : Visibility.Collapsed;
+        JsonPreviewSplitter.Visibility = _jsonPreviewVisible ? Visibility.Visible : Visibility.Collapsed;
+        ToggleJsonPreviewButton.Content = LocalizationHelper.GetString(_jsonPreviewVisible
+            ? "ToggleJsonPreviewButton.Content"
+            : "ToggleJsonPreviewButton_Show.Content");
+    }
+
+    private void UpdateSearchMetaText()
+    {
+        if (SearchMetaText is null)
+            return;
+
+        if (string.IsNullOrWhiteSpace(_searchText))
+        {
+            SearchMetaText.Text = "";
+            return;
+        }
+
+        var visibleCount = CountVisibleTreeNodes(ConfigTree.RootNodes);
+        SearchMetaText.Text = visibleCount == 0
+            ? "No matches"
+            : $"{visibleCount} shown";
+    }
+
+    private void UpdateMetaAndButtons()
+    {
+        LoadingState.Visibility = _loading ? Visibility.Visible : Visibility.Collapsed;
+        var dirtyCount = _pendingChanges.Count;
+        var invalidCount = _validationErrors.Count;
+        var permissionState = GetConfigPermissionState();
+        var canWriteConfig = permissionState == ConfigPermissionState.ReadWrite;
+        var editingLocked = IsConfigEditingLocked(permissionState);
+        ConfigMetaText.Text = dirtyCount == 0
+            ? "No unsaved changes."
+            : $"{dirtyCount} unsaved change{(dirtyCount == 1 ? "" : "s")}" +
+              (invalidCount > 0 ? $" · {invalidCount} validation issue{(invalidCount == 1 ? "" : "s")}" : "");
+
+        SaveStatus.Text = BuildSaveStatusText(permissionState, dirtyCount, invalidCount);
+        SaveStatusIcon.Glyph = BuildSaveStatusGlyph(permissionState, dirtyCount, invalidCount);
+        AccessSummaryText.Text = BuildAccessSummaryText(permissionState, dirtyCount, invalidCount);
+        SetDetailEditingEnabled(!editingLocked);
+        ResetSectionButton.IsEnabled = !editingLocked;
+
+        SaveButton.IsEnabled = !_saving && !_loading && canWriteConfig && dirtyCount > 0 && invalidCount == 0;
+        DiscardButton.IsEnabled = !editingLocked && dirtyCount > 0;
+    }
+
+    private bool IsConfigEditingLocked(ConfigPermissionState permissionState) =>
+        _saving ||
+        _refreshConfigAfterReconnect ||
+        permissionState is ConfigPermissionState.Disconnected or ConfigPermissionState.Checking or ConfigPermissionState.NoRead;
+
+    private void SetDetailEditingEnabled(bool isEnabled)
+    {
+        foreach (var child in DetailPanel.Children)
+        {
+            if (child is Control control)
+                control.IsEnabled = isEnabled;
+        }
+    }
+
+    private string BuildSaveStatusText(ConfigPermissionState permissionState, int dirtyCount, int invalidCount)
+    {
+        if (_saving)
+            return "Saving…";
+        if (permissionState == ConfigPermissionState.Disconnected)
+            return _refreshConfigAfterReconnect ? "Gateway restarting…" : "Connect to a gateway to edit";
+        if (permissionState == ConfigPermissionState.Checking)
+            return "Checking permissions…";
+        if (permissionState == ConfigPermissionState.NoRead)
+            return "Config unavailable: missing operator.read";
+        if (permissionState == ConfigPermissionState.ReadOnly && dirtyCount > 0)
+            return "Read-only: missing operator.write";
+        if (invalidCount > 0)
+            return "Fix validation errors before saving";
+        if (dirtyCount > 0)
+            return "Unsaved changes";
+        return "No unsaved changes";
+    }
+
+    private string BuildSaveStatusGlyph(ConfigPermissionState permissionState, int dirtyCount, int invalidCount)
+    {
+        if (_saving)
+            return "\uE895";
+        if (permissionState is ConfigPermissionState.Disconnected or ConfigPermissionState.NoRead)
+            return "\uE783";
+        if (permissionState == ConfigPermissionState.Checking || _refreshConfigAfterReconnect)
+            return "\uE895";
+        if (invalidCount > 0 || permissionState == ConfigPermissionState.ReadOnly && dirtyCount > 0)
+            return "\uE7BA";
+        if (dirtyCount > 0)
+            return "\uE70F";
+        return "\uE73E";
+    }
+
+    private void CompleteGatewayReconnect(bool refreshLatestConfig)
+    {
+        _refreshConfigAfterReconnect = false;
+        _refreshConfigWhenGatewayAvailable = false;
+        _reconnectCompletionTimer.Stop();
+        _reconnectTimeoutTimer.Stop();
+        DismissReconnectDialog();
+        ShowStatus(
+            "Gateway reconnected",
+            refreshLatestConfig
+                ? "Configuration saved and the gateway connection is back. Refreshing the latest config."
+                : "Configuration saved and the latest gateway config is loaded.",
+            InfoBarSeverity.Success);
+
+        if (refreshLatestConfig)
+            RefreshFromGateway();
+    }
+
+    private bool CompleteReconnectIfReady()
+    {
+        if ((!_refreshConfigAfterReconnect && !_refreshConfigWhenGatewayAvailable) ||
+            GetConfigPermissionState() is not (ConfigPermissionState.ReadOnly or ConfigPermissionState.ReadWrite))
+            return false;
+
+        CompleteGatewayReconnect(refreshLatestConfig: true);
+        return true;
+    }
+
+    private void HandleReconnectTimeout()
+    {
+        if (!_refreshConfigAfterReconnect)
+            return;
+
+        if (CompleteReconnectIfReady())
+            return;
+
+        _refreshConfigAfterReconnect = false;
+        _refreshConfigWhenGatewayAvailable = true;
+        _reconnectCompletionTimer.Stop();
+        DismissReconnectDialog();
+        ShowStatus(
+            "Gateway still reconnecting",
+            "The config save was accepted, but the gateway has not reconnected yet. You can keep this page open or use Connection to check status.",
+            InfoBarSeverity.Warning);
+        UpdateMetaAndButtons();
+    }
+
+    private void ShowReconnectDialog(string message)
+    {
+        if (_reconnectDialog != null)
+        {
+            if (_reconnectDialogMessage != null)
+                _reconnectDialogMessage.Text = message;
+            return;
+        }
+
+        if (XamlRoot == null)
+            return;
+
+        _reconnectDialogMessage = new TextBlock
+        {
+            Text = message,
+            TextWrapping = TextWrapping.Wrap,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+
+        var content = new StackPanel { Spacing = 12 };
+        content.Children.Add(new TextBlock
+        {
+            Text = LocalizationHelper.GetString("ConfigPage_ReconnectDialogBody"),
+            TextWrapping = TextWrapping.Wrap
+        });
+
+        content.Children.Add(new ProgressRing
+        {
+            IsActive = true,
+            Width = 32,
+            Height = 32,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center
+        });
+        content.Children.Add(_reconnectDialogMessage);
+
+        var dialog = new ContentDialog
+        {
+            Title = LocalizationHelper.GetString("ConfigPage_ReconnectDialogTitle"),
+            Content = content,
+            XamlRoot = XamlRoot
+        };
+
+        _reconnectDialog = dialog;
+        dialog.Closed += (_, _) =>
+        {
+            if (ReferenceEquals(_reconnectDialog, dialog))
+            {
+                _reconnectDialog = null;
+                _reconnectDialogMessage = null;
+            }
+        };
+
+        _ = ShowReconnectDialogAsync(dialog);
+    }
+
+    private async Task ShowReconnectDialogAsync(ContentDialog dialog)
+    {
+        try
+        {
+            await dialog.ShowAsync();
+        }
+        catch (InvalidOperationException ex)
+        {
+            Logger.Warn($"[ConfigPage] Could not show reconnect dialog because another dialog is open: {ex.Message}");
+            if (ReferenceEquals(_reconnectDialog, dialog))
+            {
+                _reconnectDialog = null;
+                _reconnectDialogMessage = null;
+            }
+        }
+        catch (COMException ex)
+        {
+            Logger.Warn($"[ConfigPage] Could not show reconnect dialog because its XamlRoot is unavailable: {ex.Message}");
+            if (ReferenceEquals(_reconnectDialog, dialog))
+            {
+                _reconnectDialog = null;
+                _reconnectDialogMessage = null;
+            }
+        }
+    }
+
+    private void DismissReconnectDialog()
+    {
+        if (_reconnectDialog == null)
+            return;
+
+        try
+        {
+            _reconnectDialog.Hide();
+        }
+        catch (InvalidOperationException ex)
+        {
+            Logger.Warn($"[ConfigPage] Could not dismiss reconnect dialog: {ex.Message}");
+        }
+        catch (COMException ex)
+        {
+            Logger.Warn($"[ConfigPage] Could not dismiss reconnect dialog: {ex.Message}");
+        }
+    }
+
+    private static string BuildAccessSummaryText(ConfigPermissionState permissionState, int dirtyCount, int invalidCount)
+    {
+        var access = permissionState switch
+        {
+            ConfigPermissionState.Disconnected => "Disconnected",
+            ConfigPermissionState.Checking => "Checking access",
+            ConfigPermissionState.NoRead => "No config read access",
+            ConfigPermissionState.ReadOnly => "Read-only access",
+            ConfigPermissionState.ReadWrite => "Read/write access",
+            _ => "Unknown access"
+        };
+        var changes = $"{dirtyCount} change{(dirtyCount == 1 ? "" : "s")}";
+        var validation = invalidCount == 0
+            ? "Local validation clean"
+            : $"{invalidCount} validation issue{(invalidCount == 1 ? "" : "s")}";
+        return $"{access} · {changes} · {validation}";
+    }
+
+    private void ShowConfigRenderError(string title, string message)
+    {
+        _loading = false;
+        _showSchemaFallback = true;
+        ApplyPaneVisibility();
+        ShowStatus(title, message, InfoBarSeverity.Error);
+        UpdateMetaAndButtons();
+    }
+
+    private void ShowStatus(string title, string message, InfoBarSeverity severity)
+    {
+        _statusDismissTimer.Stop();
+        StatusInfoBar.Title = title;
+        StatusInfoBar.Message = message;
+        StatusInfoBar.Severity = severity;
+        SetInfoBarOpen(StatusInfoBar, true);
+
+        if (!_refreshConfigAfterReconnect &&
+            severity is InfoBarSeverity.Success or InfoBarSeverity.Informational)
+        {
+            _statusDismissTimer.Start();
+        }
+    }
+
+    private static void SetInfoBarOpen(InfoBar bar, bool open)
+    {
+        bar.IsOpen = open;
+        bar.Visibility = open ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private enum ConfigPermissionState
+    {
+        Disconnected,
+        Checking,
+        NoRead,
+        ReadOnly,
+        ReadWrite,
+    }
+
+    private ConfigPermissionState GetConfigPermissionState()
+    {
+        var client = CurrentApp.GatewayClient;
+        if (client == null || !client.IsConnectedToGateway)
+            return ConfigPermissionState.Disconnected;
+
+        if (!client.HasHandshakeSnapshot)
+            return ConfigPermissionState.Checking;
+
+        var scopes = client.GrantedOperatorScopes;
+        if (!OperatorScopeHelper.CanReadConfig(scopes))
+            return ConfigPermissionState.NoRead;
+
+        return OperatorScopeHelper.CanWriteConfig(scopes)
+            ? ConfigPermissionState.ReadWrite
+            : ConfigPermissionState.ReadOnly;
+    }
+
+    private void UpdatePermissionBanner()
+    {
+        if (PermissionInfoBar is null)
+            return;
+
+        switch (GetConfigPermissionState())
+        {
+            case ConfigPermissionState.Checking:
+                PermissionInfoBar.Title = "Checking config permissions";
+                PermissionInfoBar.Message = "Waiting for the gateway to report this operator's permissions.";
+                PermissionInfoBar.Severity = InfoBarSeverity.Informational;
+                SetInfoBarOpen(PermissionInfoBar, true);
+                break;
+            case ConfigPermissionState.NoRead:
+                ClearConfigViewForNoRead();
+                PermissionInfoBar.Title = "Config unavailable";
+                PermissionInfoBar.Message = "This operator token lacks operator.read permission, so the gateway config cannot be loaded here.";
+                PermissionInfoBar.Severity = InfoBarSeverity.Error;
+                SetInfoBarOpen(PermissionInfoBar, true);
+                break;
+            case ConfigPermissionState.ReadOnly:
+                PermissionInfoBar.Title = "Config is read-only";
+                PermissionInfoBar.Message = "This operator token can read config but lacks operator.write permission. You can inspect and validate drafts, but Save is disabled.";
+                PermissionInfoBar.Severity = InfoBarSeverity.Warning;
+                SetInfoBarOpen(PermissionInfoBar, true);
+                break;
+            default:
+                SetInfoBarOpen(PermissionInfoBar, false);
+                break;
+        }
+    }
+
+    private void ClearConfigViewForNoRead()
+    {
+        _detailRenderVersion++;
+        _loading = false;
+        _lastConfig = null;
+        _lastSchema = null;
+        _serverSnapshot = ConfigEditorSnapshot.Empty;
+        _editSnapshot = ConfigEditorSnapshot.Empty;
+        _pendingChanges.Clear();
+        _validationErrors.Clear();
+        _selectedPath = "";
+        _showSchemaFallback = true;
+        ConfigTree.RootNodes.Clear();
+        DetailPanel.Children.Clear();
+        DetailPlaceholder.Text = "Config cannot be loaded because this operator token does not have read permission.";
+        DetailPlaceholder.Visibility = Visibility.Visible;
+        DetailBreadcrumb.Text = "";
+        DetailPath.Text = "Config unavailable";
+        DetailType.Text = "Missing operator.read permission";
+        ResetSectionButton.Visibility = Visibility.Collapsed;
+        RenderJsonDiff("{}", "{}");
+        SelectedJsonCaption.Text = "Config preview is unavailable without read permission.";
+        ApplyPaneVisibility();
+    }
+
+    private static bool TryBuildRootLeafSchema(JsonElement? rootSchema, out JsonElement leafSchema)
+    {
+        leafSchema = default;
+        if (!rootSchema.HasValue ||
+            !rootSchema.Value.TryGetProperty("properties", out var properties) ||
+            properties.ValueKind != JsonValueKind.Object)
+            return false;
+
+        var leafProperties = new JsonObject();
+        foreach (var prop in properties.EnumerateObject())
+        {
+            var propType = ExtractSchemaType(prop.Value);
+            if (propType == "object" || prop.Value.TryGetProperty("properties", out _))
+                continue;
+
+            leafProperties[prop.Name] = JsonNode.Parse(prop.Value.GetRawText());
+        }
+
+        if (leafProperties.Count == 0)
+            return false;
+
+        var schemaObject = new JsonObject
+        {
+            ["type"] = "object",
+            ["properties"] = leafProperties
+        };
+
+        if (rootSchema.Value.TryGetProperty("required", out var required) &&
+            required.ValueKind == JsonValueKind.Array)
+        {
+            var requiredLeaves = new JsonArray();
+            foreach (var item in required.EnumerateArray())
+            {
+                if (item.ValueKind == JsonValueKind.String &&
+                    item.GetString() is { } name &&
+                    leafProperties.ContainsKey(name))
+                    requiredLeaves.Add(name);
+            }
+
+            if (requiredLeaves.Count > 0)
+                schemaObject["required"] = requiredLeaves;
+        }
+
+        using var document = JsonDocument.Parse(schemaObject.ToJsonString());
+        leafSchema = document.RootElement.Clone();
+        return true;
+    }
+
+    private void RunOnUiThread(Action action)
+    {
+        if (DispatcherQueue.HasThreadAccess)
+        {
+            action();
+        }
+        else
+        {
+            DispatcherQueue.TryEnqueue(() => action());
+        }
+    }
+
+    private static JsonElement GetSchemaRoot(JsonElement schema)
+    {
+        return schema.TryGetProperty("schema", out var schemaRoot) ? schemaRoot : schema;
+    }
+
     private static string? ExtractSchemaType(JsonElement schemaNode)
     {
         if (!schemaNode.TryGetProperty("type", out var typeEl)) return null;
@@ -181,164 +1256,6 @@ public sealed partial class ConfigPage : Page
         return null;
     }
 
-    private void ShowConfigRenderError()
-    {
-        _showSchemaFallback = true;
-        ApplyPaneVisibility();
-        SaveButton.IsEnabled = false;
-        SaveStatus.Text = "Config unavailable";
-    }
-
-    /// <summary>
-    /// Reconciles which Row 2 surface is visible: Editor, Raw JSON, or
-    /// the "no schema" fallback.
-    /// </summary>
-    private void ApplyPaneVisibility()
-    {
-        if (EditorPane is null || RawJsonPane is null || NoSchemaPanel is null) return;
-
-        var rawSelected = (ConfigSelector?.SelectedItem?.Tag as string) == "raw";
-
-        RawJsonPane.Visibility = rawSelected ? Visibility.Visible : Visibility.Collapsed;
-        EditorPane.Visibility  = (!rawSelected && !_showSchemaFallback) ? Visibility.Visible : Visibility.Collapsed;
-        NoSchemaPanel.Visibility = (!rawSelected && _showSchemaFallback) ? Visibility.Visible : Visibility.Collapsed;
-    }
-
-    private void BuildSchemaTreeNodes(IList<TreeViewNode> parent, JsonElement schema, JsonElement? config, string basePath)
-    {
-        if (!schema.TryGetProperty("properties", out var properties) ||
-            properties.ValueKind != JsonValueKind.Object) return;
-
-        foreach (var prop in properties.EnumerateObject().OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase))
-        {
-            var path = string.IsNullOrEmpty(basePath) ? prop.Name : $"{basePath}.{prop.Name}";
-            var node = new TreeViewNode();
-
-            var desc = prop.Value.TryGetProperty("description", out var descEl) && descEl.ValueKind == JsonValueKind.String
-                ? descEl.GetString() : null;
-            var label = string.IsNullOrEmpty(desc) ? prop.Name : $"{prop.Name} — {desc}";
-
-            var propType = ExtractSchemaType(prop.Value);
-            var configValue = config.HasValue && config.Value.TryGetProperty(prop.Name, out var cv) ? (JsonElement?)cv : null;
-
-            if (propType == "object" || (prop.Value.TryGetProperty("properties", out _)))
-            {
-                node.Content = $"📁 {prop.Name}";
-                node.IsExpanded = true;
-                // Store config value if available, otherwise empty object (not the schema!)
-                var nodeElement = configValue ?? s_emptyObject;
-                _nodeMap[node] = (path, nodeElement);
-                BuildSchemaTreeNodes(node.Children, prop.Value, configValue, path);
-                parent.Add(node);
-            }
-            // Leaf nodes are not shown in the tree — they appear as edit controls
-            // in the detail panel when their parent folder is selected
-        }
-    }
-
-    private void OnOpenDashboard(object sender, RoutedEventArgs e)
-    {
-        ((IAppCommands)CurrentApp).OpenDashboard("config");
-    }
-
-    private static void ExpandAll(IList<TreeViewNode> nodes)
-    {
-        foreach (var node in nodes)
-        {
-            node.IsExpanded = true;
-            if (node.Children.Count > 0)
-                ExpandAll(node.Children);
-        }
-    }
-
-    private async void OnSave(object sender, RoutedEventArgs e)
-    {
-        // Capture changes from the currently displayed editor
-        if (DetailPanel.Children.Count > 0 && DetailPanel.Children[0] is Controls.SchemaConfigEditor activeEditor)
-        {
-            foreach (var kv in activeEditor.GetChanges())
-            {
-                var fullPath = string.IsNullOrEmpty(_selectedPath)
-                    ? kv.Key
-                    : (string.IsNullOrEmpty(kv.Key) ? _selectedPath : $"{_selectedPath}.{kv.Key}");
-                _pendingChanges[fullPath] = kv.Value;
-            }
-        }
-
-        if (_pendingChanges.Count == 0)
-        {
-            SaveStatus.Text = "No changes";
-            return;
-        }
-
-        if (CurrentApp.GatewayClient == null || !_lastConfig.HasValue)
-        {
-            SaveStatus.Text = "Not connected";
-            return;
-        }
-
-        // Build the full config with changes applied
-        // The config.get response has { path, exists, raw, parsed } — use parsed
-        var configRoot = _lastConfig.Value.TryGetProperty("parsed", out var pr) ? pr
-            : (_lastConfig.Value.TryGetProperty("config", out var cr) ? cr : _lastConfig.Value);
-        var configDict = JsonSerializer.Deserialize<Dictionary<string, object?>>(configRoot.GetRawText(),
-            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
-            ?? new Dictionary<string, object?>();
-
-        // Apply dot-path changes to the config dict
-        foreach (var kv in _pendingChanges)
-        {
-            SetNestedValue(configDict, kv.Key, kv.Value);
-        }
-
-        // Serialize back and send as raw
-        var updatedJson = JsonSerializer.Serialize(configDict, new JsonSerializerOptions { WriteIndented = true });
-        var updatedElement = JsonDocument.Parse(updatedJson).RootElement;
-
-        SaveButton.IsEnabled = false;
-        SaveStatus.Text = "Saving...";
-        try
-        {
-            var ok = await CurrentApp.GatewayClient.PatchConfigAsync(updatedElement, _baseHash);
-            SaveStatus.Text = ok ? "✓ Saved" : "✗ Save failed — changes preserved";
-
-            if (ok)
-            {
-                _pendingChanges.Clear();
-                _ = CurrentApp.GatewayClient.RequestConfigAsync();
-            }
-        }
-        catch (Exception) { SaveStatus.Text = "✗ Save failed — changes preserved"; }
-        finally { SaveButton.IsEnabled = true; }
-    }
-
-    private static void SetNestedValue(Dictionary<string, object?> dict, string dotPath, object? value)
-    {
-        var segments = dotPath.Split('.');
-        var current = dict;
-        for (int i = 0; i < segments.Length - 1; i++)
-        {
-            if (current.TryGetValue(segments[i], out var existing) && existing is JsonElement je && je.ValueKind == JsonValueKind.Object)
-            {
-                var child = JsonSerializer.Deserialize<Dictionary<string, object?>>(je.GetRawText()) ?? new();
-                current[segments[i]] = child;
-                current = child;
-            }
-            else if (existing is Dictionary<string, object?> childDict)
-            {
-                current = childDict;
-            }
-            else
-            {
-                var newChild = new Dictionary<string, object?>();
-                current[segments[i]] = newChild;
-                current = newChild;
-            }
-        }
-        current[segments[^1]] = value;
-    }
-
-    /// <summary>Walk the JSON Schema tree to find the sub-schema at a dot-separated path.</summary>
     private static JsonElement? ResolveSchemaAtPath(JsonElement schema, string path)
     {
         if (string.IsNullOrEmpty(path)) return schema;
@@ -358,431 +1275,140 @@ public sealed partial class ConfigPage : Page
         return current;
     }
 
-    private void OnRefresh(object sender, RoutedEventArgs e)
+    private static bool TryGetElementAtPath(JsonElement root, string path, out JsonElement element)
     {
-        if (CurrentApp.GatewayClient != null)
+        element = root;
+        if (root.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+            return false;
+
+        foreach (var segment in path.Split('.', StringSplitOptions.RemoveEmptyEntries))
         {
-            SaveStatus.Text = "";
-            _ = CurrentApp.GatewayClient.RequestConfigSchemaAsync();
-            _ = CurrentApp.GatewayClient.RequestConfigAsync();
+            if (element.ValueKind != JsonValueKind.Object ||
+                !element.TryGetProperty(segment, out element))
+                return false;
         }
+
+        return true;
     }
 
-    private void UpdateRawJson()
-    {
-        if (RawJsonText is null) return;
-
-        if (_lastConfig.HasValue)
-        {
-            try
-            {
-                var options = new JsonSerializerOptions { WriteIndented = true };
-                var configRoot = _lastConfig.Value.TryGetProperty("parsed", out var pr) ? pr
-                    : (_lastConfig.Value.TryGetProperty("config", out var cr) ? cr : _lastConfig.Value);
-                RawJsonText.Text = JsonSerializer.Serialize(configRoot, options);
-            }
-            catch
-            {
-                RawJsonText.Text = _lastConfig.Value.GetRawText();
-            }
-        }
-        else
-        {
-            RawJsonText.Text = "No config loaded.";
-        }
-    }
-
-    private void OnConfigSelectorChanged(SelectorBar sender, SelectorBarSelectionChangedEventArgs args)
-    {
-        ApplyPaneVisibility();
-
-        if ((sender.SelectedItem?.Tag as string) == "raw")
-            UpdateRawJson();
-    }
-
-    // ── Fallback TreeView methods (used when schema is unavailable) ──
-
-    private void BuildTreeNodes(IList<TreeViewNode> parent, JsonElement element, string basePath, int depth = 0)
-    {
-        if (element.ValueKind != JsonValueKind.Object) return;
-
-        foreach (var prop in element.EnumerateObject())
-        {
-            var path = string.IsNullOrEmpty(basePath) ? prop.Name : $"{basePath}.{prop.Name}";
-            var node = new TreeViewNode();
-
-            if (prop.Value.ValueKind == JsonValueKind.Object)
-            {
-                bool hasObjectOrArrayChild = false;
-                foreach (var child in prop.Value.EnumerateObject())
-                {
-                    if (child.Value.ValueKind == JsonValueKind.Object || child.Value.ValueKind == JsonValueKind.Array)
-                    { hasObjectOrArrayChild = true; break; }
-                }
-
-                node.Content = $"📁 {prop.Name}";
-                node.IsExpanded = depth < 1;
-                _nodeMap[node] = (path, prop.Value);
-                BuildTreeNodes(node.Children, prop.Value, path, depth + 1);
-            }
-            else if (prop.Value.ValueKind == JsonValueKind.Array)
-            {
-                node.Content = $"📋 {prop.Name} [{prop.Value.GetArrayLength()}]";
-                _nodeMap[node] = (path, prop.Value);
-                int idx = 0;
-                foreach (var item in prop.Value.EnumerateArray())
-                {
-                    if (item.ValueKind == JsonValueKind.Object)
-                    {
-                        var childNode = new TreeViewNode();
-                        var itemPath = $"{path}[{idx}]";
-                        var label = TryGetLabel(item) ?? $"[{idx}]";
-                        childNode.Content = $"  {label}";
-                        _nodeMap[childNode] = (itemPath, item);
-                        node.Children.Add(childNode);
-                    }
-                    idx++;
-                }
-            }
-            else
-            {
-                continue;
-            }
-
-            parent.Add(node);
-        }
-    }
-
-    private void OnTreeItemInvoked(TreeView sender, TreeViewItemInvokedEventArgs args)
+    private async void OnTreeItemInvoked(TreeView sender, TreeViewItemInvokedEventArgs args)
     {
         if (args.InvokedItem is TreeViewNode node && _nodeMap.TryGetValue(node, out var entry))
         {
-            _selectedElement = entry.Element;
-            _selectedPath = entry.Path;
-            ShowDetail(entry.Path, entry.Element);
+            await ShowDetailWithProgress(entry.Path, entry.Element);
         }
     }
 
-    private void ShowDetail(string path, JsonElement element)
+    private async Task ShowDetailWithProgress(string path, JsonElement element)
     {
-        DetailPanel.Children.Clear();
-        DetailPlaceholder.Visibility = Visibility.Collapsed;
-        DetailPath.Text = path;
+        var renderVersion = ++_detailRenderVersion;
+        DetailPath.Text = string.IsNullOrEmpty(path) ? "Full config" : path;
+        DetailType.Text = "Loading section...";
+        ResetSectionButton.Visibility = Visibility.Collapsed;
+        DetailLoadingText.Text = string.IsNullOrEmpty(path)
+            ? LocalizationHelper.GetString("ConfigPage_LoadingFullConfigPreview")
+            : LocalizationHelper.Format("ConfigPage_LoadingSectionFormat", path);
+        DetailLoadingOverlay.Visibility = Visibility.Visible;
+        await Task.Delay(50);
 
-        // Try to find schema for this path
-        JsonElement? nodeSchema = null;
-        if (_lastSchema.HasValue)
-        {
-            var schema = _lastSchema.Value;
-            var schemaRoot = schema.TryGetProperty("schema", out var sr) ? sr : schema;
-            nodeSchema = ResolveSchemaAtPath(schemaRoot, path);
-        }
+        if (renderVersion != _detailRenderVersion)
+            return;
 
-        // Show description from schema if available
-        if (nodeSchema.HasValue && nodeSchema.Value.TryGetProperty("description", out var desc)
-            && desc.ValueKind == JsonValueKind.String)
+        try
         {
-            DetailType.Text = desc.GetString() ?? "";
+            ShowDetail(path, element);
+            UpdateMetaAndButtons();
         }
-        else
+        finally
         {
-            switch (element.ValueKind)
+            if (renderVersion == _detailRenderVersion)
+                DetailLoadingOverlay.Visibility = Visibility.Collapsed;
+        }
+    }
+
+    private bool MatchesSearch(string path, JsonElement schemaNode)
+    {
+        if (string.IsNullOrWhiteSpace(_searchText))
+            return true;
+
+        if (path.Contains(_searchText, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (schemaNode.TryGetProperty("title", out var title) &&
+            title.ValueKind == JsonValueKind.String &&
+            (title.GetString()?.Contains(_searchText, StringComparison.OrdinalIgnoreCase) == true))
+            return true;
+
+        if (schemaNode.TryGetProperty("description", out var desc) &&
+            desc.ValueKind == JsonValueKind.String &&
+            (desc.GetString()?.Contains(_searchText, StringComparison.OrdinalIgnoreCase) == true))
+            return true;
+
+        if (schemaNode.TryGetProperty("properties", out var properties) &&
+            properties.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in properties.EnumerateObject())
             {
-                case JsonValueKind.Object: DetailType.Text = $"Object · {element.EnumerateObject().Count()} properties"; break;
-                case JsonValueKind.Array: DetailType.Text = $"Array · {element.GetArrayLength()} items"; break;
-                default: DetailType.Text = element.ValueKind.ToString(); break;
+                var childPath = string.IsNullOrEmpty(path) ? property.Name : $"{path}.{property.Name}";
+                if (MatchesSearch(childPath, property.Value))
+                    return true;
             }
         }
 
-        // Use schema editor for this subtree
-        if (nodeSchema.HasValue && element.ValueKind == JsonValueKind.Object)
+        return false;
+    }
+
+    private static int CountPathsUnder(string sectionPath, IEnumerable<string> paths)
+    {
+        var prefix = sectionPath + ".";
+        if (string.IsNullOrEmpty(sectionPath))
+            return paths.Count();
+
+        return paths.Count(p => string.Equals(p, sectionPath, StringComparison.Ordinal) ||
+                                p.StartsWith(prefix, StringComparison.Ordinal));
+    }
+
+    private static void RemoveSectionEntries<T>(string sectionPath, Dictionary<string, T> values)
+    {
+        var prefix = sectionPath + ".";
+        if (string.IsNullOrEmpty(sectionPath))
         {
-            var editor = new Controls.SchemaConfigEditor();
-            editor.LoadSchema(nodeSchema.Value, element);
-            editor.ConfigChanged += (s, changes) =>
-            {
-                foreach (var kv in changes)
-                {
-                    var fullPath = string.IsNullOrEmpty(kv.Key) ? path : $"{path}.{kv.Key}";
-                    _pendingChanges[fullPath] = kv.Value;
-                }
-            };
-            DetailPanel.Children.Add(editor);
+            values.Clear();
             return;
         }
 
-        switch (element.ValueKind)
+        foreach (var key in values.Keys
+                     .Where(k => string.Equals(k, sectionPath, StringComparison.Ordinal) ||
+                                 k.StartsWith(prefix, StringComparison.Ordinal))
+                     .ToList())
         {
-            case JsonValueKind.Object:
-                DetailType.Text = $"Object · {element.EnumerateObject().Count()} properties";
-                foreach (var prop in element.EnumerateObject())
-                {
-                    var row = new Grid { Margin = new Thickness(0, 6, 0, 6) };
-                    row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(180) });
-                    row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-
-                    var keyBlock = new TextBlock
-                    {
-                        Text = prop.Name,
-                        FontWeight = FontWeights.SemiBold,
-                        VerticalAlignment = VerticalAlignment.Center,
-                        FontSize = 13
-                    };
-                    Grid.SetColumn(keyBlock, 0);
-                    row.Children.Add(keyBlock);
-
-                    var propPath = $"{path}.{prop.Name}";
-                    var editControl = CreateEditableControl(prop.Value, propPath);
-                    Grid.SetColumn(editControl, 1);
-                    row.Children.Add(editControl);
-
-                    DetailPanel.Children.Add(row);
-
-                    DetailPanel.Children.Add(new Border
-                    {
-                        Height = 1,
-                        Background = (Brush)Application.Current.Resources["DividerStrokeColorDefaultBrush"],
-                        Margin = new Thickness(0, 2, 0, 2),
-                        Opacity = 0.3
-                    });
-                }
-                break;
-
-            case JsonValueKind.Array:
-                DetailType.Text = $"Array · {element.GetArrayLength()} items";
-                int idx = 0;
-                foreach (var item in element.EnumerateArray())
-                {
-                    var card = new Border
-                    {
-                        Background = (Brush)Application.Current.Resources["CardBackgroundFillColorSecondaryBrush"],
-                        CornerRadius = new CornerRadius(6),
-                        Padding = new Thickness(12, 8, 12, 8),
-                        Margin = new Thickness(0, 4, 0, 4)
-                    };
-
-                    if (item.ValueKind == JsonValueKind.Object)
-                    {
-                        var sp = new StackPanel { Spacing = 4 };
-                        sp.Children.Add(new TextBlock
-                        {
-                            Text = TryGetLabel(item) ?? $"Item {idx}",
-                            FontWeight = FontWeights.SemiBold,
-                            FontSize = 13
-                        });
-                        foreach (var sub in item.EnumerateObject())
-                        {
-                            var subRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
-                            subRow.Children.Add(new TextBlock
-                            {
-                                Text = sub.Name,
-                                Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
-                                FontSize = 12, Width = 140
-                            });
-                            subRow.Children.Add(new TextBlock
-                            {
-                                Text = FormatValue(sub.Value),
-                                FontFamily = new FontFamily("Consolas"),
-                                FontSize = 12,
-                                IsTextSelectionEnabled = true,
-                                TextWrapping = TextWrapping.Wrap
-                            });
-                            sp.Children.Add(subRow);
-                        }
-                        card.Child = sp;
-                    }
-                    else
-                    {
-                        card.Child = new TextBlock
-                        {
-                            Text = FormatValue(item),
-                            FontFamily = new FontFamily("Consolas"),
-                            IsTextSelectionEnabled = true
-                        };
-                    }
-                    DetailPanel.Children.Add(card);
-                    idx++;
-                }
-                break;
-
-            default:
-                DetailType.Text = element.ValueKind.ToString();
-                var valueText = new TextBlock
-                {
-                    Text = FormatValue(element),
-                    FontFamily = new FontFamily("Consolas"),
-                    FontSize = 16,
-                    IsTextSelectionEnabled = true,
-                    TextWrapping = TextWrapping.Wrap,
-                    Margin = new Thickness(0, 8, 0, 8)
-                };
-                DetailPanel.Children.Add(valueText);
-                break;
+            values.Remove(key);
         }
     }
 
-    private FrameworkElement CreateEditableControl(JsonElement value, string configPath)
+    private static string FriendlyLabel(string name)
     {
-        switch (value.ValueKind)
+        var result = System.Text.RegularExpressions.Regex.Replace(name, "([a-z])([A-Z])", "$1 $2");
+        result = result.Replace("_", " ");
+        return result.Length == 0 ? name : char.ToUpperInvariant(result[0]) + result[1..];
+    }
+
+    private static string BuildBreadcrumb(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return "Full config";
+
+        return "Full config / " + string.Join(" / ", path.Split('.').Select(FriendlyLabel));
+    }
+
+    private static int CountVisibleTreeNodes(IList<TreeViewNode> nodes)
+    {
+        var count = 0;
+        foreach (var node in nodes)
         {
-            case JsonValueKind.String:
-                var str = value.GetString() ?? "";
-                var isSecret = configPath.Contains("token", StringComparison.OrdinalIgnoreCase) ||
-                              configPath.Contains("password", StringComparison.OrdinalIgnoreCase) ||
-                              configPath.Contains("secret", StringComparison.OrdinalIgnoreCase);
-                var textBox = new TextBox
-                {
-                    Text = str,
-                    FontFamily = new FontFamily("Consolas"),
-                    FontSize = 13,
-                    MinWidth = 200,
-                    Tag = configPath
-                };
-                if (isSecret && str.Length > 8)
-                {
-                    textBox.Text = str[..4] + "••••••••";
-                    textBox.IsReadOnly = true;
-                    textBox.Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"];
-                }
-                else
-                {
-                    textBox.LostFocus += (s, e) => OnValueEdited(configPath, textBox.Text);
-                }
-                return textBox;
-
-            case JsonValueKind.Number:
-                var numBox = new TextBox
-                {
-                    Text = value.GetRawText(),
-                    FontFamily = new FontFamily("Consolas"),
-                    FontSize = 13,
-                    MinWidth = 100,
-                    Tag = configPath
-                };
-                numBox.LostFocus += (s, e) =>
-                {
-                    if (int.TryParse(numBox.Text, out var intVal))
-                        OnValueEdited(configPath, intVal);
-                    else if (double.TryParse(numBox.Text, out var dblVal))
-                        OnValueEdited(configPath, dblVal);
-                };
-                return numBox;
-
-            case JsonValueKind.True:
-            case JsonValueKind.False:
-                var toggle = new ToggleSwitch
-                {
-                    IsOn = value.GetBoolean(),
-                    OnContent = "true",
-                    OffContent = "false",
-                    MinWidth = 0,
-                    Tag = configPath
-                };
-                toggle.Toggled += (s, e) => OnValueEdited(configPath, toggle.IsOn);
-                return toggle;
-
-            case JsonValueKind.Null:
-                return new TextBlock
-                {
-                    Text = "null",
-                    FontStyle = global::Windows.UI.Text.FontStyle.Italic,
-                    Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
-                    FontSize = 13,
-                    VerticalAlignment = VerticalAlignment.Center
-                };
-
-            case JsonValueKind.Object:
-                var objPanel = new StackPanel { Spacing = 2 };
-                foreach (var sub in value.EnumerateObject())
-                {
-                    var subRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6 };
-                    subRow.Children.Add(new TextBlock
-                    {
-                        Text = $"{sub.Name}:",
-                        FontSize = 12,
-                        Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]
-                    });
-                    subRow.Children.Add(new TextBlock
-                    {
-                        Text = FormatValue(sub.Value),
-                        FontFamily = new FontFamily("Consolas"),
-                        FontSize = 12
-                    });
-                    objPanel.Children.Add(subRow);
-                }
-                return objPanel;
-
-            case JsonValueKind.Array:
-                var arr = value;
-                bool allStr = true;
-                foreach (var item in arr.EnumerateArray())
-                    if (item.ValueKind != JsonValueKind.String) { allStr = false; break; }
-
-                if (allStr && arr.GetArrayLength() <= 30)
-                {
-                    return new TextBlock
-                    {
-                        Text = string.Join(", ", arr.EnumerateArray().Select(v => v.GetString())),
-                        FontFamily = new FontFamily("Consolas"),
-                        FontSize = 12,
-                        TextWrapping = TextWrapping.Wrap,
-                        IsTextSelectionEnabled = true
-                    };
-                }
-                return new TextBlock
-                {
-                    Text = $"[ {arr.GetArrayLength()} items ]",
-                    Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
-                    FontSize = 12
-                };
-
-            default:
-                return new TextBlock { Text = value.GetRawText(), FontFamily = new FontFamily("Consolas"), FontSize = 13 };
+            count++;
+            count += CountVisibleTreeNodes(node.Children);
         }
+        return count;
     }
-
-    private void OnValueEdited(string configPath, object newValue)
-    {
-        if (CurrentApp.GatewayClient == null) return;
-
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                var success = await CurrentApp.GatewayClient.SetConfigAsync(configPath, newValue);
-                DispatcherQueue?.TryEnqueue(() =>
-                {
-                    SaveStatus.Text = success
-                        ? $"✅ Sent {configPath}"
-                        : $"❌ Failed to save {configPath}";
-                    if (success && CurrentApp.GatewayClient != null)
-                        _ = CurrentApp.GatewayClient.RequestConfigAsync();
-                });
-            }
-            catch (Exception ex)
-            {
-                DispatcherQueue?.TryEnqueue(() => SaveStatus.Text = $"❌ {ex.Message}");
-            }
-        });
-    }
-
-    private static string? TryGetLabel(JsonElement obj)
-    {
-        foreach (var key in new[] { "name", "id", "displayName", "key", "title" })
-        {
-            if (obj.TryGetProperty(key, out var val) && val.ValueKind == JsonValueKind.String)
-                return val.GetString();
-        }
-        return null;
-    }
-
-    private static string FormatValue(JsonElement value) => value.ValueKind switch
-    {
-        JsonValueKind.String => value.GetString() ?? "",
-        JsonValueKind.Number => value.GetRawText(),
-        JsonValueKind.True => "true",
-        JsonValueKind.False => "false",
-        JsonValueKind.Null => "null",
-        _ => value.GetRawText()
-    };
 }

--- a/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
@@ -521,6 +521,7 @@ public sealed partial class ConfigPage : Page
             {
                 if (result.LooksLikeStaleBaseHash)
                 {
+                    _editSnapshot = ConfigEditorSnapshot.Empty;
                     _ = client.RequestConfigAsync();
                     ShowStatus(
                         "Gateway config changed elsewhere",

--- a/src/OpenClaw.Tray.WinUI/Services/ConfigEditorModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ConfigEditorModel.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace OpenClawTray.Services;
+
+internal sealed record ConfigEditorSnapshot(JsonElement Root, string? BaseHash)
+{
+    public static ConfigEditorSnapshot Empty { get; } = new(default, null);
+
+    public bool HasRoot => Root.ValueKind is not JsonValueKind.Undefined and not JsonValueKind.Null;
+}
+
+internal static class ConfigEditorModel
+{
+    public static ConfigEditorSnapshot CaptureSnapshot(JsonElement configResponse)
+    {
+        var root = ExtractConfigRoot(configResponse);
+        var baseHash = ExtractBaseHash(configResponse);
+        return new ConfigEditorSnapshot(root.Clone(), baseHash);
+    }
+
+    public static JsonElement ExtractConfigRoot(JsonElement configResponse)
+    {
+        if (configResponse.TryGetProperty("parsed", out var parsed))
+            return parsed;
+        if (configResponse.TryGetProperty("config", out var config))
+            return config;
+        return configResponse;
+    }
+
+    public static string? ExtractBaseHash(JsonElement configResponse)
+    {
+        if (configResponse.TryGetProperty("baseHash", out var baseHash) &&
+            baseHash.ValueKind == JsonValueKind.String)
+            return baseHash.GetString();
+
+        if (configResponse.TryGetProperty("hash", out var hash) &&
+            hash.ValueKind == JsonValueKind.String)
+            return hash.GetString();
+
+        if (configResponse.TryGetProperty("raw", out var raw) &&
+            raw.ValueKind == JsonValueKind.String &&
+            raw.GetString() is { } rawContent)
+        {
+            var bytes = System.Text.Encoding.UTF8.GetBytes(rawContent);
+            var computedHash = System.Security.Cryptography.SHA256.HashData(bytes);
+            return Convert.ToHexStringLower(computedHash);
+        }
+
+        return null;
+    }
+
+    public static JsonElement ApplyChanges(JsonElement root, IReadOnlyDictionary<string, object?> changes)
+    {
+        var node = JsonNode.Parse(root.GetRawText()) ?? new JsonObject();
+        foreach (var (path, value) in changes)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                continue;
+
+            if (value?.GetType() == typeof(object))
+                continue;
+
+            SetPath(node, path, JsonSerializer.SerializeToNode(value));
+        }
+
+        using var document = JsonDocument.Parse(node.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+        return document.RootElement.Clone();
+    }
+
+    public static Dictionary<string, object?> RelativeChangesFor(
+        string sectionPath,
+        IReadOnlyDictionary<string, object?> changes)
+    {
+        var relative = new Dictionary<string, object?>(StringComparer.Ordinal);
+        var prefix = string.IsNullOrEmpty(sectionPath) ? "" : sectionPath + ".";
+
+        foreach (var (path, value) in changes)
+        {
+            if (string.IsNullOrEmpty(sectionPath))
+            {
+                relative[path] = value;
+            }
+            else if (path.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                relative[path[prefix.Length..]] = value;
+            }
+        }
+
+        return relative;
+    }
+
+    public static JsonElement ApplyRelativeChanges(
+        JsonElement section,
+        string sectionPath,
+        IReadOnlyDictionary<string, object?> changes)
+    {
+        var relative = RelativeChangesFor(sectionPath, changes);
+        return relative.Count == 0 ? section.Clone() : ApplyChanges(section, relative);
+    }
+
+    public static object? CoerceNumber(double value, string schemaType)
+    {
+        if (schemaType == "integer")
+        {
+            if (value > long.MaxValue || value < long.MinValue)
+                return value;
+
+            return Convert.ToInt64(Math.Truncate(value), CultureInfo.InvariantCulture);
+        }
+
+        return value;
+    }
+
+    private static void SetPath(JsonNode node, string dotPath, JsonNode? value)
+    {
+        var segments = dotPath.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0)
+            return;
+
+        var current = node;
+        for (var i = 0; i < segments.Length - 1; i++)
+        {
+            var segment = segments[i];
+            if (current is not JsonObject obj)
+                return;
+
+            if (obj[segment] is not JsonObject child)
+            {
+                child = new JsonObject();
+                obj[segment] = child;
+            }
+
+            current = child;
+        }
+
+        if (current is JsonObject target)
+            target[segments[^1]] = value;
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/GatewayNavVisibilityDebouncePolicy.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/GatewayNavVisibilityDebouncePolicy.cs
@@ -26,4 +26,7 @@ internal static class GatewayNavVisibilityDebouncePolicy
 
     public static bool ShouldHideAfterDelay(ConnectionStatus status) =>
         status != ConnectionStatus.Connected;
+
+    public static bool ShouldKeepCurrentPageVisibleDuringDisconnect(string? currentTag) =>
+        string.Equals(currentTag, "config", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/OpenClaw.Tray.WinUI/Services/JsonDiffFormatter.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/JsonDiffFormatter.cs
@@ -1,0 +1,208 @@
+namespace OpenClawTray.Services;
+
+public enum JsonDiffLineKind
+{
+    Unchanged,
+    Removed,
+    Added,
+}
+
+public sealed record JsonDiffSegment(string Text, bool IsChanged);
+
+public sealed record JsonDiffLine(JsonDiffLineKind Kind, IReadOnlyList<JsonDiffSegment> Segments)
+{
+    public string Prefix => Kind switch
+    {
+        JsonDiffLineKind.Removed => "- ",
+        JsonDiffLineKind.Added => "+ ",
+        _ => "  "
+    };
+
+    public string Text => string.Concat(Segments.Select(s => s.Text));
+
+    public string CopyText => Prefix + Text;
+}
+
+public static class JsonDiffFormatter
+{
+    public static IReadOnlyList<JsonDiffLine> CreateDiff(string originalJson, string proposedJson)
+    {
+        var diffOps = BuildLineDiff(
+            originalJson.Replace("\r\n", "\n").Split('\n'),
+            proposedJson.Replace("\r\n", "\n").Split('\n'));
+        var lines = new List<JsonDiffLine>(diffOps.Count);
+
+        for (var i = 0; i < diffOps.Count; i++)
+        {
+            var op = diffOps[i];
+            if (op.Kind == JsonDiffLineKind.Unchanged)
+            {
+                lines.Add(CreateLine(op.Kind, [new JsonDiffSegment(op.Text, false)]));
+                continue;
+            }
+
+            if (op.Kind == JsonDiffLineKind.Removed &&
+                i + 1 < diffOps.Count &&
+                diffOps[i + 1].Kind == JsonDiffLineKind.Added &&
+                LooksLikeReplacement(op.Text, diffOps[i + 1].Text))
+            {
+                var added = diffOps[++i];
+                lines.Add(CreateLine(JsonDiffLineKind.Removed, BuildInlineSegments(op.Text, added.Text)));
+                lines.Add(CreateLine(JsonDiffLineKind.Added, BuildInlineSegments(added.Text, op.Text)));
+                continue;
+            }
+
+            lines.Add(CreateLine(op.Kind, [new JsonDiffSegment(op.Text, true)]));
+        }
+
+        return lines;
+    }
+
+    private static JsonDiffLine CreateLine(JsonDiffLineKind kind, IReadOnlyList<JsonDiffSegment> segments) =>
+        new(kind, segments);
+
+    private static IReadOnlyList<JsonDiffSegment> BuildInlineSegments(string text, string comparison)
+    {
+        var sharedPrefix = 0;
+        while (sharedPrefix < text.Length &&
+               sharedPrefix < comparison.Length &&
+               text[sharedPrefix] == comparison[sharedPrefix])
+        {
+            sharedPrefix++;
+        }
+
+        var sharedSuffix = 0;
+        while (sharedSuffix < text.Length - sharedPrefix &&
+               sharedSuffix < comparison.Length - sharedPrefix &&
+               text[text.Length - 1 - sharedSuffix] == comparison[comparison.Length - 1 - sharedSuffix])
+        {
+            sharedSuffix++;
+        }
+
+        var segments = new List<JsonDiffSegment>(3);
+        var changedLength = text.Length - sharedPrefix - sharedSuffix;
+        if (sharedPrefix > 0)
+            segments.Add(new JsonDiffSegment(text[..sharedPrefix], false));
+        if (changedLength > 0)
+            segments.Add(new JsonDiffSegment(text.Substring(sharedPrefix, changedLength), true));
+        if (sharedSuffix > 0)
+            segments.Add(new JsonDiffSegment(text[^sharedSuffix..], false));
+        if (segments.Count == 0)
+            segments.Add(new JsonDiffSegment(text, false));
+        return segments;
+    }
+
+    private readonly record struct DiffOp(JsonDiffLineKind Kind, string Text);
+
+    private static List<DiffOp> BuildLineDiff(string[] originalLines, string[] proposedLines)
+    {
+        var prefix = 0;
+        while (prefix < originalLines.Length &&
+               prefix < proposedLines.Length &&
+               string.Equals(originalLines[prefix], proposedLines[prefix], StringComparison.Ordinal))
+        {
+            prefix++;
+        }
+
+        var suffix = 0;
+        while (suffix < originalLines.Length - prefix &&
+               suffix < proposedLines.Length - prefix &&
+               string.Equals(
+                   originalLines[originalLines.Length - 1 - suffix],
+                   proposedLines[proposedLines.Length - 1 - suffix],
+                   StringComparison.Ordinal))
+        {
+            suffix++;
+        }
+
+        var result = new List<DiffOp>(originalLines.Length + proposedLines.Length);
+        for (var i = 0; i < prefix; i++)
+            result.Add(new DiffOp(JsonDiffLineKind.Unchanged, originalLines[i]));
+
+        var originalLength = originalLines.Length - prefix - suffix;
+        var proposedLength = proposedLines.Length - prefix - suffix;
+        if ((long)originalLength * proposedLength > 1_000_000)
+        {
+            for (var i = prefix; i < originalLines.Length - suffix; i++)
+                result.Add(new DiffOp(JsonDiffLineKind.Removed, originalLines[i]));
+            for (var i = prefix; i < proposedLines.Length - suffix; i++)
+                result.Add(new DiffOp(JsonDiffLineKind.Added, proposedLines[i]));
+            AppendSuffix(result, originalLines, suffix);
+            return result;
+        }
+
+        var lcs = new int[originalLength + 1, proposedLength + 1];
+
+        for (var i = originalLength - 1; i >= 0; i--)
+        {
+            for (var j = proposedLength - 1; j >= 0; j--)
+            {
+                lcs[i, j] = string.Equals(originalLines[prefix + i], proposedLines[prefix + j], StringComparison.Ordinal)
+                    ? lcs[i + 1, j + 1] + 1
+                    : Math.Max(lcs[i + 1, j], lcs[i, j + 1]);
+            }
+        }
+
+        var originalIndex = 0;
+        var proposedIndex = 0;
+        while (originalIndex < originalLength && proposedIndex < proposedLength)
+        {
+            var originalLine = originalLines[prefix + originalIndex];
+            var proposedLine = proposedLines[prefix + proposedIndex];
+            if (string.Equals(originalLine, proposedLine, StringComparison.Ordinal))
+            {
+                result.Add(new DiffOp(JsonDiffLineKind.Unchanged, originalLine));
+                originalIndex++;
+                proposedIndex++;
+            }
+            else if (lcs[originalIndex + 1, proposedIndex] >= lcs[originalIndex, proposedIndex + 1])
+            {
+                result.Add(new DiffOp(JsonDiffLineKind.Removed, originalLine));
+                originalIndex++;
+            }
+            else
+            {
+                result.Add(new DiffOp(JsonDiffLineKind.Added, proposedLine));
+                proposedIndex++;
+            }
+        }
+
+        while (originalIndex < originalLength)
+            result.Add(new DiffOp(JsonDiffLineKind.Removed, originalLines[prefix + originalIndex++]));
+
+        while (proposedIndex < proposedLength)
+            result.Add(new DiffOp(JsonDiffLineKind.Added, proposedLines[prefix + proposedIndex++]));
+
+        AppendSuffix(result, originalLines, suffix);
+        return result;
+    }
+
+    private static void AppendSuffix(List<DiffOp> result, string[] originalLines, int suffix)
+    {
+        for (var i = originalLines.Length - suffix; i < originalLines.Length; i++)
+            result.Add(new DiffOp(JsonDiffLineKind.Unchanged, originalLines[i]));
+    }
+
+    private static bool LooksLikeReplacement(string originalLine, string proposedLine)
+    {
+        var originalTrimmed = originalLine.TrimStart();
+        var proposedTrimmed = proposedLine.TrimStart();
+        if (originalTrimmed.Length == 0 || proposedTrimmed.Length == 0)
+            return false;
+
+        if (originalTrimmed[0] is '{' or '}' or '[' or ']' ||
+            proposedTrimmed[0] is '{' or '}' or '[' or ']')
+            return false;
+
+        var sharedPrefix = 0;
+        while (sharedPrefix < originalLine.Length &&
+               sharedPrefix < proposedLine.Length &&
+               originalLine[sharedPrefix] == proposedLine[sharedPrefix])
+        {
+            sharedPrefix++;
+        }
+
+        var longest = Math.Max(originalLine.Length, proposedLine.Length);
+        return longest > 0 && sharedPrefix >= longest / 2;
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -713,8 +713,14 @@ public sealed class NodeService : IDisposable
         if (_nodeClient == null)
             return null;
 
-        var capabilities = _nodeClient.Capabilities.Select(c => c.Category).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
-        var commands = _nodeClient.Capabilities.SelectMany(c => c.Commands).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        INodeCapability[] capabilitySnapshot;
+        lock (_capabilitiesLock)
+        {
+            capabilitySnapshot = _capabilities.ToArray();
+        }
+
+        var capabilities = capabilitySnapshot.Select(c => c.Category).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        var commands = capabilitySnapshot.SelectMany(c => c.Commands).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
 
         return new GatewayNodeInfo
         {

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -1656,6 +1656,54 @@ On your gateway host (Mac/Linux), run:
   <data name="ConfigPage_TextBlock_21.Text" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="ConfigPage_OpenConnection.Content" xml:space="preserve">
+    <value>Open Connection</value>
+  </data>
+  <data name="ConfigPage_ConnectionInfoBar.Title" xml:space="preserve">
+    <value>Gateway disconnected</value>
+  </data>
+  <data name="ConfigPage_ConnectionInfoBar.Message" xml:space="preserve">
+    <value>Connect to a gateway to load and save configuration.</value>
+  </data>
+  <data name="ConfigPage_LoadingText.Text" xml:space="preserve">
+    <value>Loading gateway config...</value>
+  </data>
+  <data name="ConfigPage_EditorLabel.Text" xml:space="preserve">
+    <value>Editor</value>
+  </data>
+  <data name="ConfigSearchBox.PlaceholderText" xml:space="preserve">
+    <value>Filter settings</value>
+  </data>
+  <data name="ToggleJsonPreviewButton.Content" xml:space="preserve">
+    <value>Collapse JSON</value>
+  </data>
+  <data name="ToggleJsonPreviewButton_Show.Content" xml:space="preserve">
+    <value>Show JSON</value>
+  </data>
+  <data name="ResetSectionButton.Content" xml:space="preserve">
+    <value>Reset section</value>
+  </data>
+  <data name="DetailLoadingText.Text" xml:space="preserve">
+    <value>Loading section...</value>
+  </data>
+  <data name="ConfigPage_LoadingFullConfigPreview" xml:space="preserve">
+    <value>Loading full config preview...</value>
+  </data>
+  <data name="ConfigPage_LoadingSectionFormat" xml:space="preserve">
+    <value>Loading {0}...</value>
+  </data>
+  <data name="SelectedJsonPreviewTitle.Text" xml:space="preserve">
+    <value>JSON preview</value>
+  </data>
+  <data name="SelectedJsonCaption.Text" xml:space="preserve">
+    <value>Compare the gateway value with the proposed unsaved value.</value>
+  </data>
+  <data name="CopySelectedJsonButton.Content" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="DiscardButton.Content" xml:space="preserve">
+    <value>Discard changes</value>
+  </data>
   <data name="ConfigPage_TabViewItem_34.Text" xml:space="preserve">
     <value>Editor</value>
   </data>
@@ -1674,7 +1722,22 @@ On your gateway host (Mac/Linux), run:
   <data name="OpenDashboardButton.Content" xml:space="preserve">
     <value>Open Dashboard</value>
   </data>
+  <data name="ConfigPage_ReconnectDialogTitle" xml:space="preserve">
+    <value>Saving configuration</value>
+  </data>
+  <data name="ConfigPage_ReconnectDialogBody" xml:space="preserve">
+    <value>OpenClaw is applying your edits. The gateway may restart briefly and reconnect automatically.</value>
+  </data>
+  <data name="ConfigPage_ReconnectDialogAccepted" xml:space="preserve">
+    <value>Gateway is restarting...</value>
+  </data>
+  <data name="ConfigPage_ReconnectDialogWaiting" xml:space="preserve">
+    <value>Reconnecting...</value>
+  </data>
   <data name="SaveButton.Content" xml:space="preserve">
+    <value>Save Changes</value>
+  </data>
+  <data name="SaveButtonText.Text" xml:space="preserve">
     <value>Save Changes</value>
   </data>
   <data name="ConnectionPage_TextBlock_10.Text" xml:space="preserve">
@@ -2386,7 +2449,7 @@ On your gateway host (Mac/Linux), run:
     <value>All messages route to the default agent. Add bindings for multi-agent routing.</value>
   </data>
   <data name="ConfigSubtitle.Text" xml:space="preserve">
-    <value>Editing gateway configuration (openclaw.json) fetched from the connected gateway</value>
+    <value>Edit gateway configuration (openclaw.json) with a schema-guided form.</value>
   </data>
   <data name="DetailPlaceholder.Text" xml:space="preserve">
     <value>Select a section from the tree to edit its settings.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -1608,6 +1608,54 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="ConfigPage_TextBlock_21.Text" xml:space="preserve">
     <value>Actualiser</value>
   </data>
+  <data name="ConfigPage_OpenConnection.Content" xml:space="preserve">
+    <value>Ouvrir la connexion</value>
+  </data>
+  <data name="ConfigPage_ConnectionInfoBar.Title" xml:space="preserve">
+    <value>Passerelle déconnectée</value>
+  </data>
+  <data name="ConfigPage_ConnectionInfoBar.Message" xml:space="preserve">
+    <value>Connectez-vous à une passerelle pour charger et enregistrer la configuration.</value>
+  </data>
+  <data name="ConfigPage_LoadingText.Text" xml:space="preserve">
+    <value>Chargement de la configuration de la passerelle...</value>
+  </data>
+  <data name="ConfigPage_EditorLabel.Text" xml:space="preserve">
+    <value>Éditeur</value>
+  </data>
+  <data name="ConfigSearchBox.PlaceholderText" xml:space="preserve">
+    <value>Filtrer les paramètres</value>
+  </data>
+  <data name="ToggleJsonPreviewButton.Content" xml:space="preserve">
+    <value>Réduire JSON</value>
+  </data>
+  <data name="ToggleJsonPreviewButton_Show.Content" xml:space="preserve">
+    <value>Afficher JSON</value>
+  </data>
+  <data name="ResetSectionButton.Content" xml:space="preserve">
+    <value>Réinitialiser la section</value>
+  </data>
+  <data name="DetailLoadingText.Text" xml:space="preserve">
+    <value>Chargement de la section...</value>
+  </data>
+  <data name="ConfigPage_LoadingFullConfigPreview" xml:space="preserve">
+    <value>Chargement de l’aperçu complet de la configuration...</value>
+  </data>
+  <data name="ConfigPage_LoadingSectionFormat" xml:space="preserve">
+    <value>Chargement de {0}...</value>
+  </data>
+  <data name="SelectedJsonPreviewTitle.Text" xml:space="preserve">
+    <value>Aperçu JSON</value>
+  </data>
+  <data name="SelectedJsonCaption.Text" xml:space="preserve">
+    <value>Comparez la valeur de la passerelle avec la valeur non enregistrée proposée.</value>
+  </data>
+  <data name="CopySelectedJsonButton.Content" xml:space="preserve">
+    <value>Copier</value>
+  </data>
+  <data name="DiscardButton.Content" xml:space="preserve">
+    <value>Ignorer les modifications</value>
+  </data>
   <data name="ConfigPage_TabViewItem_34.Text" xml:space="preserve">
     <value>Éditeur</value>
   </data>
@@ -1626,7 +1674,22 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="OpenDashboardButton.Content" xml:space="preserve">
     <value>Ouvrir le tableau de bord</value>
   </data>
+  <data name="ConfigPage_ReconnectDialogTitle" xml:space="preserve">
+    <value>Saving configuration</value>
+  </data>
+  <data name="ConfigPage_ReconnectDialogBody" xml:space="preserve">
+    <value>OpenClaw is applying your edits. The gateway may restart briefly and reconnect automatically.</value>
+  </data>
+  <data name="ConfigPage_ReconnectDialogAccepted" xml:space="preserve">
+    <value>Gateway is restarting...</value>
+  </data>
+  <data name="ConfigPage_ReconnectDialogWaiting" xml:space="preserve">
+    <value>Reconnecting...</value>
+  </data>
   <data name="SaveButton.Content" xml:space="preserve">
+    <value>Enregistrer les modifications</value>
+  </data>
+  <data name="SaveButtonText.Text" xml:space="preserve">
     <value>Enregistrer les modifications</value>
   </data>
   <data name="ConnectionPage_TextBlock_10.Text" xml:space="preserve">
@@ -2338,7 +2401,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Tous les messages sont acheminés vers l’agent par défaut. Ajoutez des liaisons pour le routage multi-agent.</value>
   </data>
   <data name="ConfigSubtitle.Text" xml:space="preserve">
-    <value>Modification de la configuration de la passerelle (openclaw.json) récupérée depuis la passerelle connectée</value>
+    <value>Modifiez la configuration de la passerelle (openclaw.json) avec un formulaire guidé par schéma.</value>
   </data>
   <data name="DetailPlaceholder.Text" xml:space="preserve">
     <value>Sélectionnez une section dans l’arborescence pour modifier ses paramètres.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -1609,6 +1609,54 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="ConfigPage_TextBlock_21.Text" xml:space="preserve">
     <value>Vernieuwen</value>
   </data>
+  <data name="ConfigPage_OpenConnection.Content" xml:space="preserve">
+    <value>Verbinding openen</value>
+  </data>
+  <data name="ConfigPage_ConnectionInfoBar.Title" xml:space="preserve">
+    <value>Gateway niet verbonden</value>
+  </data>
+  <data name="ConfigPage_ConnectionInfoBar.Message" xml:space="preserve">
+    <value>Maak verbinding met een gateway om configuratie te laden en op te slaan.</value>
+  </data>
+  <data name="ConfigPage_LoadingText.Text" xml:space="preserve">
+    <value>Gatewayconfiguratie laden...</value>
+  </data>
+  <data name="ConfigPage_EditorLabel.Text" xml:space="preserve">
+    <value>Bewerker</value>
+  </data>
+  <data name="ConfigSearchBox.PlaceholderText" xml:space="preserve">
+    <value>Instellingen filteren</value>
+  </data>
+  <data name="ToggleJsonPreviewButton.Content" xml:space="preserve">
+    <value>JSON samenvouwen</value>
+  </data>
+  <data name="ToggleJsonPreviewButton_Show.Content" xml:space="preserve">
+    <value>JSON tonen</value>
+  </data>
+  <data name="ResetSectionButton.Content" xml:space="preserve">
+    <value>Sectie resetten</value>
+  </data>
+  <data name="DetailLoadingText.Text" xml:space="preserve">
+    <value>Sectie laden...</value>
+  </data>
+  <data name="ConfigPage_LoadingFullConfigPreview" xml:space="preserve">
+    <value>Volledig configuratievoorbeeld laden...</value>
+  </data>
+  <data name="ConfigPage_LoadingSectionFormat" xml:space="preserve">
+    <value>{0} laden...</value>
+  </data>
+  <data name="SelectedJsonPreviewTitle.Text" xml:space="preserve">
+    <value>JSON-voorbeeld</value>
+  </data>
+  <data name="SelectedJsonCaption.Text" xml:space="preserve">
+    <value>Vergelijk de gatewaywaarde met de voorgestelde niet-opgeslagen waarde.</value>
+  </data>
+  <data name="CopySelectedJsonButton.Content" xml:space="preserve">
+    <value>Kopiëren</value>
+  </data>
+  <data name="DiscardButton.Content" xml:space="preserve">
+    <value>Wijzigingen negeren</value>
+  </data>
   <data name="ConfigPage_TabViewItem_34.Text" xml:space="preserve">
     <value>Bewerker</value>
   </data>
@@ -1627,7 +1675,22 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="OpenDashboardButton.Content" xml:space="preserve">
     <value>Dashboard openen</value>
   </data>
+  <data name="ConfigPage_ReconnectDialogTitle" xml:space="preserve">
+    <value>Saving configuration</value>
+  </data>
+  <data name="ConfigPage_ReconnectDialogBody" xml:space="preserve">
+    <value>OpenClaw is applying your edits. The gateway may restart briefly and reconnect automatically.</value>
+  </data>
+  <data name="ConfigPage_ReconnectDialogAccepted" xml:space="preserve">
+    <value>Gateway is restarting...</value>
+  </data>
+  <data name="ConfigPage_ReconnectDialogWaiting" xml:space="preserve">
+    <value>Reconnecting...</value>
+  </data>
   <data name="SaveButton.Content" xml:space="preserve">
+    <value>Wijzigingen opslaan</value>
+  </data>
+  <data name="SaveButtonText.Text" xml:space="preserve">
     <value>Wijzigingen opslaan</value>
   </data>
   <data name="ConnectionPage_TextBlock_10.Text" xml:space="preserve">
@@ -2339,7 +2402,7 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>Alle berichten worden naar de standaardagent gerouteerd. Voeg koppelingen toe voor routering met meerdere agents.</value>
   </data>
   <data name="ConfigSubtitle.Text" xml:space="preserve">
-    <value>Gatewayconfiguratie (openclaw.json) bewerken die is opgehaald van de verbonden gateway</value>
+    <value>Bewerk gatewayconfiguratie (openclaw.json) met een schemagestuurd formulier.</value>
   </data>
   <data name="DetailPlaceholder.Text" xml:space="preserve">
     <value>Selecteer een sectie in de boomstructuur om de instellingen te bewerken.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -1608,6 +1608,54 @@
   <data name="ConfigPage_TextBlock_21.Text" xml:space="preserve">
     <value>åˆ·æ–°</value>
   </data>
+  <data name="ConfigPage_OpenConnection.Content" xml:space="preserve">
+    <value>打开连接</value>
+  </data>
+  <data name="ConfigPage_ConnectionInfoBar.Title" xml:space="preserve">
+    <value>网关已断开连接</value>
+  </data>
+  <data name="ConfigPage_ConnectionInfoBar.Message" xml:space="preserve">
+    <value>连接到网关以加载并保存配置。</value>
+  </data>
+  <data name="ConfigPage_LoadingText.Text" xml:space="preserve">
+    <value>正在加载网关配置...</value>
+  </data>
+  <data name="ConfigPage_EditorLabel.Text" xml:space="preserve">
+    <value>编辑器</value>
+  </data>
+  <data name="ConfigSearchBox.PlaceholderText" xml:space="preserve">
+    <value>筛选设置</value>
+  </data>
+  <data name="ToggleJsonPreviewButton.Content" xml:space="preserve">
+    <value>折叠 JSON</value>
+  </data>
+  <data name="ToggleJsonPreviewButton_Show.Content" xml:space="preserve">
+    <value>显示 JSON</value>
+  </data>
+  <data name="ResetSectionButton.Content" xml:space="preserve">
+    <value>重置部分</value>
+  </data>
+  <data name="DetailLoadingText.Text" xml:space="preserve">
+    <value>正在加载部分...</value>
+  </data>
+  <data name="ConfigPage_LoadingFullConfigPreview" xml:space="preserve">
+    <value>正在加载完整配置预览...</value>
+  </data>
+  <data name="ConfigPage_LoadingSectionFormat" xml:space="preserve">
+    <value>正在加载 {0}...</value>
+  </data>
+  <data name="SelectedJsonPreviewTitle.Text" xml:space="preserve">
+    <value>JSON 预览</value>
+  </data>
+  <data name="SelectedJsonCaption.Text" xml:space="preserve">
+    <value>比较网关值和建议的未保存值。</value>
+  </data>
+  <data name="CopySelectedJsonButton.Content" xml:space="preserve">
+    <value>复制</value>
+  </data>
+  <data name="DiscardButton.Content" xml:space="preserve">
+    <value>放弃更改</value>
+  </data>
   <data name="ConfigPage_TabViewItem_34.Text" xml:space="preserve">
     <value>ç¼–è¾‘å™¨</value>
   </data>
@@ -1626,7 +1674,22 @@
   <data name="OpenDashboardButton.Content" xml:space="preserve">
     <value>æ‰“å¼€ä»ªè¡¨æ¿</value>
   </data>
+  <data name="ConfigPage_ReconnectDialogTitle" xml:space="preserve">
+    <value>Saving configuration</value>
+  </data>
+  <data name="ConfigPage_ReconnectDialogBody" xml:space="preserve">
+    <value>OpenClaw is applying your edits. The gateway may restart briefly and reconnect automatically.</value>
+  </data>
+  <data name="ConfigPage_ReconnectDialogAccepted" xml:space="preserve">
+    <value>Gateway is restarting...</value>
+  </data>
+  <data name="ConfigPage_ReconnectDialogWaiting" xml:space="preserve">
+    <value>Reconnecting...</value>
+  </data>
   <data name="SaveButton.Content" xml:space="preserve">
+    <value>ä¿å­˜æ›´æ”¹</value>
+  </data>
+  <data name="SaveButtonText.Text" xml:space="preserve">
     <value>ä¿å­˜æ›´æ”¹</value>
   </data>
   <data name="ConnectionPage_TextBlock_10.Text" xml:space="preserve">
@@ -2338,7 +2401,7 @@
     <value>æ‰€æœ‰æ¶ˆæ¯éƒ½ä¼šè·¯ç”±åˆ°é»˜è®¤ä»£ç†ã€‚æ·»åŠ ç»‘å®šä»¥è¿›è¡Œå¤šä»£ç†è·¯ç”±ã€‚</value>
   </data>
   <data name="ConfigSubtitle.Text" xml:space="preserve">
-    <value>æ­£åœ¨ç¼–è¾‘ä»Žå·²è¿žæŽ¥ç½‘å…³èŽ·å–çš„ç½‘å…³é…ç½® (openclaw.json)</value>
+    <value>使用架构引导的表单编辑网关配置 (openclaw.json)。</value>
   </data>
   <data name="DetailPlaceholder.Text" xml:space="preserve">
     <value>ä»Žæ ‘ä¸­é€‰æ‹©ä¸€ä¸ªéƒ¨åˆ†ä»¥ç¼–è¾‘å…¶è®¾ç½®ã€‚</value>
@@ -4467,4 +4530,3 @@
   <data name="HubWindow_Advanced.Content" xml:space="preserve">
     <value>é«˜çº§</value>
   </data></root>
-

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -1608,6 +1608,54 @@
   <data name="ConfigPage_TextBlock_21.Text" xml:space="preserve">
     <value>é‡æ–°æ•´ç†</value>
   </data>
+  <data name="ConfigPage_OpenConnection.Content" xml:space="preserve">
+    <value>開啟連線</value>
+  </data>
+  <data name="ConfigPage_ConnectionInfoBar.Title" xml:space="preserve">
+    <value>閘道已中斷連線</value>
+  </data>
+  <data name="ConfigPage_ConnectionInfoBar.Message" xml:space="preserve">
+    <value>連線到閘道以載入並儲存設定。</value>
+  </data>
+  <data name="ConfigPage_LoadingText.Text" xml:space="preserve">
+    <value>正在載入閘道設定...</value>
+  </data>
+  <data name="ConfigPage_EditorLabel.Text" xml:space="preserve">
+    <value>編輯器</value>
+  </data>
+  <data name="ConfigSearchBox.PlaceholderText" xml:space="preserve">
+    <value>篩選設定</value>
+  </data>
+  <data name="ToggleJsonPreviewButton.Content" xml:space="preserve">
+    <value>摺疊 JSON</value>
+  </data>
+  <data name="ToggleJsonPreviewButton_Show.Content" xml:space="preserve">
+    <value>顯示 JSON</value>
+  </data>
+  <data name="ResetSectionButton.Content" xml:space="preserve">
+    <value>重設區段</value>
+  </data>
+  <data name="DetailLoadingText.Text" xml:space="preserve">
+    <value>正在載入區段...</value>
+  </data>
+  <data name="ConfigPage_LoadingFullConfigPreview" xml:space="preserve">
+    <value>正在載入完整設定預覽...</value>
+  </data>
+  <data name="ConfigPage_LoadingSectionFormat" xml:space="preserve">
+    <value>正在載入 {0}...</value>
+  </data>
+  <data name="SelectedJsonPreviewTitle.Text" xml:space="preserve">
+    <value>JSON 預覽</value>
+  </data>
+  <data name="SelectedJsonCaption.Text" xml:space="preserve">
+    <value>比較閘道值與建議的未儲存值。</value>
+  </data>
+  <data name="CopySelectedJsonButton.Content" xml:space="preserve">
+    <value>複製</value>
+  </data>
+  <data name="DiscardButton.Content" xml:space="preserve">
+    <value>捨棄變更</value>
+  </data>
   <data name="ConfigPage_TabViewItem_34.Text" xml:space="preserve">
     <value>ç·¨è¼¯å™¨</value>
   </data>
@@ -1626,7 +1674,22 @@
   <data name="OpenDashboardButton.Content" xml:space="preserve">
     <value>é–‹å•Ÿå„€è¡¨æ¿</value>
   </data>
+  <data name="ConfigPage_ReconnectDialogTitle" xml:space="preserve">
+    <value>Saving configuration</value>
+  </data>
+  <data name="ConfigPage_ReconnectDialogBody" xml:space="preserve">
+    <value>OpenClaw is applying your edits. The gateway may restart briefly and reconnect automatically.</value>
+  </data>
+  <data name="ConfigPage_ReconnectDialogAccepted" xml:space="preserve">
+    <value>Gateway is restarting...</value>
+  </data>
+  <data name="ConfigPage_ReconnectDialogWaiting" xml:space="preserve">
+    <value>Reconnecting...</value>
+  </data>
   <data name="SaveButton.Content" xml:space="preserve">
+    <value>å„²å­˜è®Šæ›´</value>
+  </data>
+  <data name="SaveButtonText.Text" xml:space="preserve">
     <value>å„²å­˜è®Šæ›´</value>
   </data>
   <data name="ConnectionPage_TextBlock_10.Text" xml:space="preserve">
@@ -2338,7 +2401,7 @@
     <value>æ‰€æœ‰è¨Šæ¯éƒ½æœƒè·¯ç”±è‡³é è¨­ä»£ç†ç¨‹å¼ã€‚æ–°å¢žç¹«çµä»¥é€²è¡Œå¤šä»£ç†ç¨‹å¼è·¯ç”±ã€‚</value>
   </data>
   <data name="ConfigSubtitle.Text" xml:space="preserve">
-    <value>æ­£åœ¨ç·¨è¼¯å¾žå·²é€£ç·šé–˜é“æ“·å–çš„é–˜é“è¨­å®š (openclaw.json)</value>
+    <value>使用結構描述引導的表單編輯閘道設定 (openclaw.json)。</value>
   </data>
   <data name="DetailPlaceholder.Text" xml:space="preserve">
     <value>å¾žæ¨¹ç‹€ç›®éŒ„é¸å–å€æ®µä»¥ç·¨è¼¯å…¶è¨­å®šã€‚</value>
@@ -4467,4 +4530,3 @@
   <data name="HubWindow_Advanced.Content" xml:space="preserve">
     <value>é€²éšŽ</value>
   </data></root>
-

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -435,18 +435,24 @@ public sealed partial class HubWindow : WindowEx
         try
         {
             var vis = connected ? Visibility.Visible : Visibility.Collapsed;
+            var currentTag = _currentNavTag ?? (NavView?.SelectedItem as NavigationViewItem)?.Tag as string;
+            var keepCurrentGatewayPageVisible = !connected &&
+                GatewayNavVisibilityDebouncePolicy.ShouldKeepCurrentPageVisibleDuringDisconnect(currentTag);
+
             NavChat.Visibility = vis;
             NavSessions.Visibility = vis;
             NavSkills.Visibility = vis;
             NavChannels.Visibility = vis;
             NavInstances.Visibility = vis;
             NavCron.Visibility = vis;
-            NavAdvanced.Visibility = vis;
+            NavAdvanced.Visibility = keepCurrentGatewayPageVisible ? Visibility.Visible : vis;
             NavGatewaySeparator.Visibility = vis;
 
             if (!connected)
             {
-                var currentTag = (NavView?.SelectedItem as NavigationViewItem)?.Tag as string;
+                if (keepCurrentGatewayPageVisible)
+                    return;
+
                 var gatewayTags = new HashSet<string> { "chat", "sessions", "skills", "channels", "instances", "agentevents", "bindings", "config", "usage", "cron", "workspace" };
                 if (currentTag != null && (gatewayTags.Contains(currentTag) || currentTag.StartsWith("agent:")))
                 {

--- a/tests/OpenClaw.Tray.Tests/ConfigEditorModelTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ConfigEditorModelTests.cs
@@ -1,0 +1,136 @@
+using System.Text.Json;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public class ConfigEditorModelTests
+{
+    [Fact]
+    public void CaptureSnapshot_UsesParsedRootAndBaseHash()
+    {
+        using var document = JsonDocument.Parse("""
+        {
+          "path": "/tmp/openclaw.json",
+          "baseHash": "abc123",
+          "parsed": {
+            "gateway": {
+              "reload": {
+                "mode": "hybrid"
+              }
+            }
+          }
+        }
+        """);
+
+        var snapshot = ConfigEditorModel.CaptureSnapshot(document.RootElement);
+
+        Assert.True(snapshot.HasRoot);
+        Assert.Equal("abc123", snapshot.BaseHash);
+        Assert.Equal("hybrid", snapshot.Root.GetProperty("gateway").GetProperty("reload").GetProperty("mode").GetString());
+    }
+
+    [Fact]
+    public void ApplyChanges_UpdatesNestedValuesAndPreservesUnrelatedConfig()
+    {
+        using var document = JsonDocument.Parse("""
+        {
+          "gateway": {
+            "reload": {
+              "mode": "hybrid",
+              "interval": 5
+            }
+          },
+          "channels": {
+            "slack": {
+              "enabled": false
+            }
+          }
+        }
+        """);
+
+        var updated = ConfigEditorModel.ApplyChanges(
+            document.RootElement,
+            new Dictionary<string, object?>
+            {
+                ["gateway.reload.mode"] = "manual",
+                ["gateway.reload.interval"] = 10L,
+                ["channels.slack.enabled"] = true,
+            });
+
+        Assert.Equal("manual", updated.GetProperty("gateway").GetProperty("reload").GetProperty("mode").GetString());
+        Assert.Equal(10, updated.GetProperty("gateway").GetProperty("reload").GetProperty("interval").GetInt64());
+        Assert.True(updated.GetProperty("channels").GetProperty("slack").GetProperty("enabled").GetBoolean());
+    }
+
+    [Fact]
+    public void ApplyRelativeChanges_OverlaysOnlySelectedSectionDrafts()
+    {
+        using var document = JsonDocument.Parse("""
+        {
+          "mode": "hybrid",
+          "interval": 5
+        }
+        """);
+
+        var updated = ConfigEditorModel.ApplyRelativeChanges(
+            document.RootElement,
+            "gateway.reload",
+            new Dictionary<string, object?>
+            {
+                ["gateway.reload.mode"] = "manual",
+                ["gateway.other.value"] = "ignored"
+            });
+
+        Assert.Equal("manual", updated.GetProperty("mode").GetString());
+        Assert.Equal(5, updated.GetProperty("interval").GetInt32());
+        Assert.False(updated.TryGetProperty("other", out _));
+    }
+
+    [Fact]
+    public void ApplyChanges_AcceptsJsonElementArrayValues()
+    {
+        using var document = JsonDocument.Parse("""
+        {
+          "routes": []
+        }
+        """);
+        using var routes = JsonDocument.Parse("""
+        [
+          { "name": "primary", "enabled": true }
+        ]
+        """);
+
+        var updated = ConfigEditorModel.ApplyChanges(
+            document.RootElement,
+            new Dictionary<string, object?>
+            {
+                ["routes"] = routes.RootElement.Clone(),
+            });
+
+        var route = updated.GetProperty("routes")[0];
+        Assert.Equal("primary", route.GetProperty("name").GetString());
+        Assert.True(route.GetProperty("enabled").GetBoolean());
+    }
+
+    [Fact]
+    public void ApplyChanges_IgnoresUnsupportedPlainObjectValues()
+    {
+        using var document = JsonDocument.Parse("""
+        {
+          "secret": "existing",
+          "mode": "hybrid"
+        }
+        """);
+
+        var updated = ConfigEditorModel.ApplyChanges(
+            document.RootElement,
+            new Dictionary<string, object?>
+            {
+                ["secret"] = new object(),
+                ["mode"] = "manual",
+            });
+
+        Assert.Equal("existing", updated.GetProperty("secret").GetString());
+        Assert.Equal("manual", updated.GetProperty("mode").GetString());
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/GatewayNavVisibilityDebouncePolicyTests.cs
+++ b/tests/OpenClaw.Tray.Tests/GatewayNavVisibilityDebouncePolicyTests.cs
@@ -49,4 +49,21 @@ public class GatewayNavVisibilityDebouncePolicyTests
     {
         Assert.True(GatewayNavVisibilityDebouncePolicy.ShouldHideAfterDelay(status));
     }
+
+    [Theory]
+    [InlineData("config")]
+    [InlineData("CONFIG")]
+    public void ConfigPage_RemainsVisibleDuringDisconnect(string tag)
+    {
+        Assert.True(GatewayNavVisibilityDebouncePolicy.ShouldKeepCurrentPageVisibleDuringDisconnect(tag));
+    }
+
+    [Theory]
+    [InlineData("connection")]
+    [InlineData("channels")]
+    [InlineData(null)]
+    public void OtherPages_DoNotOptOutOfDisconnectNavigation(string? tag)
+    {
+        Assert.False(GatewayNavVisibilityDebouncePolicy.ShouldKeepCurrentPageVisibleDuringDisconnect(tag));
+    }
 }

--- a/tests/OpenClaw.Tray.Tests/JsonDiffFormatterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/JsonDiffFormatterTests.cs
@@ -1,0 +1,98 @@
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public class JsonDiffFormatterTests
+{
+    [Fact]
+    public void CreateDiff_WhenArrayItemAdded_DoesNotMarkFollowingItemsAsChanged()
+    {
+        var original = """
+        {
+          "items": [
+            "alpha",
+            "charlie"
+          ]
+        }
+        """;
+        var proposed = """
+        {
+          "items": [
+            "alpha",
+            "bravo",
+            "charlie"
+          ]
+        }
+        """;
+
+        var diff = JsonDiffFormatter.CreateDiff(original, proposed);
+
+        Assert.Contains(diff, line => line.Kind == JsonDiffLineKind.Added && line.Text.Trim() == "\"bravo\",");
+        Assert.Contains(diff, line => line.Kind == JsonDiffLineKind.Unchanged && line.Text.Trim() == "\"charlie\"");
+        Assert.DoesNotContain(diff, line => line.Kind != JsonDiffLineKind.Unchanged && line.Text.Trim() == "\"charlie\"");
+    }
+
+    [Fact]
+    public void CreateDiff_WhenArrayItemRemoved_DoesNotMarkFollowingItemsAsChanged()
+    {
+        var original = """
+        {
+          "items": [
+            "alpha",
+            "bravo",
+            "charlie"
+          ]
+        }
+        """;
+        var proposed = """
+        {
+          "items": [
+            "alpha",
+            "charlie"
+          ]
+        }
+        """;
+
+        var diff = JsonDiffFormatter.CreateDiff(original, proposed);
+
+        Assert.Contains(diff, line => line.Kind == JsonDiffLineKind.Removed && line.Text.Trim() == "\"bravo\",");
+        Assert.Contains(diff, line => line.Kind == JsonDiffLineKind.Unchanged && line.Text.Trim() == "\"charlie\"");
+        Assert.DoesNotContain(diff, line => line.Kind != JsonDiffLineKind.Unchanged && line.Text.Trim() == "\"charlie\"");
+    }
+
+    [Fact]
+    public void CreateDiff_WhenStringChanged_ProducesInlineChangedSegment()
+    {
+        var original = """
+        {
+          "value": "screen.record"
+        }
+        """;
+        var proposed = """
+        {
+          "value": "screen.snapshot"
+        }
+        """;
+
+        var diff = JsonDiffFormatter.CreateDiff(original, proposed);
+        var removed = Assert.Single(diff, line => line.Kind == JsonDiffLineKind.Removed);
+        var added = Assert.Single(diff, line => line.Kind == JsonDiffLineKind.Added);
+
+        Assert.Contains(removed.Segments, segment => segment.IsChanged && segment.Text.Contains("record", StringComparison.Ordinal));
+        Assert.Contains(added.Segments, segment => segment.IsChanged && segment.Text.Contains("snapshot", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CreateDiff_WhenNoChanges_ReturnsOnlyUnchangedLines()
+    {
+        var json = """
+        {
+          "value": true
+        }
+        """;
+
+        var diff = JsonDiffFormatter.CreateDiff(json, json);
+
+        Assert.All(diff, line => Assert.Equal(JsonDiffLineKind.Unchanged, line.Kind));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
@@ -157,6 +157,14 @@ public class LocalizationValidationTests
         "ConnectionStatusWindow_SSHUser.PlaceholderText",
         "ConnectionStatusWindow_WsLocalhost18790.PlaceholderText",
         "ConnectionStatusWindow_WsLocalhost18790.Text",
+        // ConfigPage runtime reconnect dialog strings — seeded English-only
+        // across all locales until translations land. Fetched at runtime via
+        // LocalizationHelper and follows the deferred-translation pattern used
+        // by other recently added runtime strings above.
+        "ConfigPage_ReconnectDialogAccepted",
+        "ConfigPage_ReconnectDialogBody",
+        "ConfigPage_ReconnectDialogTitle",
+        "ConfigPage_ReconnectDialogWaiting",
         "CronPage_AmericaChicago.Content",
         "CronPage_AmericaDenver.Content",
         "CronPage_AmericaLosAngeles.Content",

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -38,6 +38,8 @@
   <ItemGroup>
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\DeepLinkHandler.cs" Link="Services\DeepLinkHandler.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\DeepLinkSecurityPolicy.cs" Link="Services\DeepLinkSecurityPolicy.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ConfigEditorModel.cs" Link="Services\ConfigEditorModel.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\JsonDiffFormatter.cs" Link="Services\JsonDiffFormatter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\AppState.cs" Link="Services\AppState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\Logger.cs" Link="Services\Logger.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SettingsManager.cs" Link="Services\SettingsManager.cs" />

--- a/tests/OpenClaw.Tray.Tests/OperatorScopeHelperTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OperatorScopeHelperTests.cs
@@ -1,0 +1,24 @@
+using OpenClaw.Connection;
+
+namespace OpenClaw.Tray.Tests;
+
+public class OperatorScopeHelperTests
+{
+    [Fact]
+    public void CanReadConfig_AllowsAdminOrReadScope()
+    {
+        Assert.True(OperatorScopeHelper.CanReadConfig(["operator.admin"]));
+        Assert.True(OperatorScopeHelper.CanReadConfig(["operator.read"]));
+        Assert.False(OperatorScopeHelper.CanReadConfig(["operator.write"]));
+        Assert.False(OperatorScopeHelper.CanReadConfig([]));
+    }
+
+    [Fact]
+    public void CanWriteConfig_AllowsAdminOrWriteScope()
+    {
+        Assert.True(OperatorScopeHelper.CanWriteConfig(["operator.admin"]));
+        Assert.True(OperatorScopeHelper.CanWriteConfig(["operator.write"]));
+        Assert.False(OperatorScopeHelper.CanWriteConfig(["operator.read"]));
+        Assert.False(OperatorScopeHelper.CanWriteConfig([]));
+    }
+}


### PR DESCRIPTION
## Summary
- Revamps the WinUI Config page into a schema-guided editor with tree navigation, detail editing, search, JSON diff preview, and a sticky save bar.
- Adds permission-aware read/write/no-read/disconnected states so unavailable edits and saves are explicit in the UI.
- Improves save/reconnect UX with a restart dialog, transient config-page retention, and a timeout escape path if the gateway does not reconnect promptly.
- Adds responsive column minimums and auto-collapses JSON preview when space is constrained.

## Screenshot
![Config page revamp](https://raw.githubusercontent.com/ranjeshj/openclaw-windows-node/pr-assets/config-page/.github/pr-assets/config-page-pr-screenshot.png)

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — 1958 passed / 29 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — 843 passed
