### PR TITLE
Improve local test runtime gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,15 +267,26 @@ jobs:
       run: dotnet build tests/OpenClaw.E2ETests -c Debug -r win-x64
 
     - name: Run E2E Tests
-      run: >
-        dotnet test tests/OpenClaw.E2ETests
-        --no-build
-        -c Debug
-        -r win-x64
-        --verbosity normal
-        --results-directory TestResults/E2E
-        --logger "trx;LogFileName=OpenClaw.E2ETests.trx"
-        --logger "console;verbosity=detailed"
+      env:
+        OPENCLAW_RUN_E2E: 1
+      shell: pwsh
+      run: |
+        dotnet test tests/OpenClaw.E2ETests `
+          --no-build `
+          -c Debug `
+          -r win-x64 `
+          --verbosity normal `
+          --results-directory TestResults/E2E `
+          --logger "trx;LogFileName=OpenClaw.E2ETests.trx" `
+          --logger "console;verbosity=detailed"
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+        [xml]$trx = Get-Content TestResults\E2E\OpenClaw.E2ETests.trx
+        $executed = [int]$trx.TestRun.ResultSummary.Counters.executed
+        if ($executed -lt 1) {
+          Write-Error "E2E test run executed zero tests. Check OPENCLAW_RUN_E2E gating before merging."
+          exit 1
+        }
 
     - name: Upload E2E Test Results & Logs
       if: always()

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -468,7 +468,8 @@ Sensitive data (authentication tokens) are never logged.
 Two test projects cover the shared library and tray helpers:
 
 ```bash
-# Run all tests
+# Run local-dev tests. E2E is intentionally excluded from the solution and
+# runs in CI before merge; run it locally only when explicitly needed.
 dotnet test
 
 # Run with detailed output

--- a/docs/TEST_COVERAGE.md
+++ b/docs/TEST_COVERAGE.md
@@ -68,8 +68,13 @@ $env:OPENCLAW_REPO_ROOT = (Get-Location).Path
 dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore
 dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore
 
-# All tests in the solution
+# All local-dev tests in the solution. E2E is intentionally excluded from the
+# solution and runs in CI before merge; run it locally only when explicitly needed.
 dotnet test
+
+# Explicit local E2E run
+$env:OPENCLAW_RUN_E2E = "1"
+dotnet test .\tests\OpenClaw.E2ETests\OpenClaw.E2ETests.csproj -r win-x64
 
 # Single project
 dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj

--- a/tests/OpenClaw.E2ETests/E2EFactAttribute.cs
+++ b/tests/OpenClaw.E2ETests/E2EFactAttribute.cs
@@ -1,0 +1,24 @@
+using Xunit;
+
+namespace OpenClaw.E2ETests;
+
+/// <summary>
+/// E2E tests are intentionally opt-in for local development because they
+/// provision WSL, launch the tray, and dominate local test runtime. CI sets
+/// OPENCLAW_RUN_E2E=1 so these still run before merge.
+/// </summary>
+public sealed class E2EFactAttribute : FactAttribute
+{
+    public E2EFactAttribute()
+    {
+        if (!E2ETestGate.IsEnabled)
+            Skip = $"E2E tests disabled. Set {E2ETestGate.EnvVar}=1 to enable.";
+    }
+}
+
+internal static class E2ETestGate
+{
+    public const string EnvVar = "OPENCLAW_RUN_E2E";
+
+    public static bool IsEnabled => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(EnvVar));
+}

--- a/tests/OpenClaw.E2ETests/E2EFactAttribute.cs
+++ b/tests/OpenClaw.E2ETests/E2EFactAttribute.cs
@@ -20,5 +20,8 @@ internal static class E2ETestGate
 {
     public const string EnvVar = "OPENCLAW_RUN_E2E";
 
-    public static bool IsEnabled => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(EnvVar));
+    public static bool IsEnabled =>
+        Environment.GetEnvironmentVariable(EnvVar) is { } value &&
+        (string.Equals(value, "1", StringComparison.OrdinalIgnoreCase) ||
+         string.Equals(value, "true", StringComparison.OrdinalIgnoreCase));
 }

--- a/tests/OpenClaw.E2ETests/Setup/E2ESetupFixture.cs
+++ b/tests/OpenClaw.E2ETests/Setup/E2ESetupFixture.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using OpenClaw.E2ETests;
 using OpenClaw.SetupEngine;
 using OpenClaw.Shared;
 
@@ -51,6 +52,16 @@ public sealed class E2ESetupFixture : IAsyncLifetime
 
     public E2ESetupFixture()
     {
+        if (!E2ETestGate.IsEnabled)
+        {
+            _distroName = "OpenClawE2E-disabled";
+            DataDir = string.Empty;
+            LocalAppDataRoot = string.Empty;
+            ArtifactDir = string.Empty;
+            _configPath = string.Empty;
+            return;
+        }
+
         var runId = Guid.NewGuid().ToString("N")[..8];
         _distroName = $"OpenClawE2E-{runId}";
 
@@ -76,6 +87,9 @@ public sealed class E2ESetupFixture : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        if (!E2ETestGate.IsEnabled)
+            return;
+
         // ── Phase 1: Run SetupEngine CLI ──
         Log("Phase 1: Running SetupEngine CLI pipeline...");
         var setupLogPath = Path.Combine(ArtifactDir, "setup-engine.jsonl");
@@ -134,6 +148,9 @@ public sealed class E2ESetupFixture : IAsyncLifetime
 
     public async Task DisposeAsync()
     {
+        if (!E2ETestGate.IsEnabled)
+            return;
+
         Log("Teardown starting...");
 
         // 1. Dispose MCP client

--- a/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using OpenClaw.E2ETests;
 using OpenClaw.SetupEngine;
 
 namespace OpenClaw.E2ETests.Setup;
@@ -30,7 +31,7 @@ public class SetupAndConnectTests
             throw new InvalidOperationException("E2E fixture MCP client not initialized");
     }
 
-    [Fact]
+    [E2EFact]
     public async Task FullSetup_TrayConnects_OperatorAndNode()
     {
         // Call app.status and verify the tray is fully connected
@@ -52,7 +53,7 @@ public class SetupAndConnectTests
         Assert.True(nodePaired, $"nodePaired should be true; full status: {rawJson}");
     }
 
-    [Fact]
+    [E2EFact]
     public async Task FullSetup_NodeCapabilities_Propagated()
     {
         using var doc = await _fixture.Client!.CallToolExpectSuccessAsync("app.nodes");
@@ -93,7 +94,7 @@ public class SetupAndConnectTests
             $"Expected node IsOnline=true; node: {windowsNode.GetRawText()}");
     }
 
-    [Fact]
+    [E2EFact]
     public async Task FullSetup_WslAndGatewayConfiguration_FilesValidated()
     {
         var wslConf = await _fixture.RunInWslAsync("cat /etc/wsl.conf", TimeSpan.FromSeconds(15));
@@ -160,7 +161,7 @@ public class SetupAndConnectTests
         Assert.Contains(Directory.EnumerateFiles(identityDir), path => Path.GetFileName(path).Contains("device-key", StringComparison.OrdinalIgnoreCase));
     }
 
-    [Fact]
+    [E2EFact]
     public async Task FullSetup_TrayStartsWslKeepAlive()
     {
         var logLine = await _fixture.WaitForTrayKeepAliveStartedAsync();
@@ -175,7 +176,7 @@ public class SetupAndConnectTests
         Assert.Contains("sleep infinity", keepAlive.Stdout);
     }
 
-    [Fact]
+    [E2EFact]
     public async Task FullSetup_DashboardLink_UsesSharedGatewayTokenFragmentAfterPairing()
     {
         using var dashboardDoc = await _fixture.Client!.CallToolExpectSuccessAsync("app.dashboard.url");
@@ -205,7 +206,7 @@ public class SetupAndConnectTests
             $"Expected dashboard/shared-token request to succeed, got HTTP {status}; stderr={result.Stderr}");
     }
 
-    [Fact]
+    [E2EFact]
     public async Task FullSetup_OpenClawCommand_IsOnDefaultWslPath()
     {
         var loginShell = await _fixture.RunInWslAsync("bash -lc 'openclaw --version'", TimeSpan.FromSeconds(15));

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalV2PromptAdapterTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalV2PromptAdapterTests.cs
@@ -155,18 +155,11 @@ public class ExecApprovalV2PromptAdapterTests
     [Fact]
     public void ProductionWiring_NullPromptHandler_NotReferencedInSrc()
     {
-        var repoRoot = FindRepoRoot();
-        Assert.NotNull(repoRoot);
-
-        var srcDir = Path.Combine(repoRoot!, "src");
-        var violations = Directory
-            .GetFiles(srcDir, "*.cs", SearchOption.AllDirectories)
-            .Where(f => !f.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar, StringComparison.Ordinal)
-                     && !f.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar, StringComparison.Ordinal))
-            .Where(f => !f.EndsWith("ExecApprovalV2NullPromptHandler.cs",
+        var violations = ProductionSourceFiles.All
+            .Where(f => !f.Path.EndsWith("ExecApprovalV2NullPromptHandler.cs",
                                      StringComparison.OrdinalIgnoreCase))
-            .Where(f => File.ReadAllText(f)
-                .Contains("ExecApprovalV2NullPromptHandler", StringComparison.Ordinal))
+            .Where(f => f.Text.Contains("ExecApprovalV2NullPromptHandler", StringComparison.Ordinal))
+            .Select(f => f.Path)
             .ToList();
 
         Assert.Empty(violations);
@@ -191,15 +184,4 @@ public class ExecApprovalV2PromptAdapterTests
             => Task.FromResult(_outcome);
     }
 
-    private static string? FindRepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null)
-        {
-            if (File.Exists(Path.Combine(dir.FullName, "openclaw-windows-node.slnx")))
-                return dir.FullName;
-            dir = dir.Parent;
-        }
-        return null;
-    }
 }

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalV2RoutingTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalV2RoutingTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -365,29 +364,13 @@ public class ExecApprovalV2RoutingTests
     [Fact]
     public void ProductionWiring_SetV2Handler_NotCalledInSrc()
     {
-        var repoRoot = FindRepoRoot();
-        Assert.NotNull(repoRoot);
-
-        var srcDir = Path.Combine(repoRoot, "src");
-        var violations = Directory
-            .GetFiles(srcDir, "*.cs", SearchOption.AllDirectories)
-            .Where(f => !f.EndsWith("SystemCapability.cs", StringComparison.OrdinalIgnoreCase))
-            .Where(f => File.ReadAllText(f).Contains("SetV2Handler", StringComparison.Ordinal))
+        var violations = ProductionSourceFiles.All
+            .Where(f => !f.Path.EndsWith("SystemCapability.cs", StringComparison.OrdinalIgnoreCase))
+            .Where(f => f.Text.Contains("SetV2Handler", StringComparison.Ordinal))
+            .Select(f => f.Path)
             .ToList();
 
         Assert.Empty(violations);
-    }
-
-    private static string? FindRepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null)
-        {
-            if (File.Exists(Path.Combine(dir.FullName, "openclaw-windows-node.slnx")))
-                return dir.FullName;
-            dir = dir.Parent;
-        }
-        return null;
     }
 
     // -------------------------------------------------------------------------

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
@@ -246,13 +246,10 @@ public class ExecApprovalsCoordinatorTests : IDisposable
     [Fact]
     public void ProductionWiring_CoordinatorNotReferencedInSrc()
     {
-        var repoRoot = FindRepoRoot();
-        Assert.NotNull(repoRoot);
-        var srcDir = Path.Combine(repoRoot, "src");
-        var violations = Directory
-            .GetFiles(srcDir, "*.cs", SearchOption.AllDirectories)
-            .Where(f => !f.EndsWith("ExecApprovalsCoordinator.cs", StringComparison.OrdinalIgnoreCase))
-            .Where(f => File.ReadAllText(f).Contains("ExecApprovalsCoordinator", StringComparison.Ordinal))
+        var violations = ProductionSourceFiles.All
+            .Where(f => !f.Path.EndsWith("ExecApprovalsCoordinator.cs", StringComparison.OrdinalIgnoreCase))
+            .Where(f => f.Text.Contains("ExecApprovalsCoordinator", StringComparison.Ordinal))
+            .Select(f => f.Path)
             .ToList();
         Assert.Empty(violations);
     }
@@ -488,15 +485,4 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         public void Error(string m, Exception? _ = null) => Errors.Add(m);
     }
 
-    private static string? FindRepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null)
-        {
-            if (File.Exists(Path.Combine(dir.FullName, "openclaw-windows-node.slnx")))
-                return dir.FullName;
-            dir = dir.Parent;
-        }
-        return null;
-    }
 }

--- a/tests/OpenClaw.Shared.Tests/ProductionSourceFiles.cs
+++ b/tests/OpenClaw.Shared.Tests/ProductionSourceFiles.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace OpenClaw.Shared.Tests;
+
+internal static class ProductionSourceFiles
+{
+    private static readonly Lazy<IReadOnlyList<SourceFileSnapshot>> SourceFiles = new(LoadSourceFiles);
+
+    public static IReadOnlyList<SourceFileSnapshot> All => SourceFiles.Value;
+
+    private static IReadOnlyList<SourceFileSnapshot> LoadSourceFiles()
+    {
+        var repoRoot = FindRepoRoot();
+        var srcDir = Path.Combine(repoRoot, "src");
+
+        return Directory
+            .GetFiles(srcDir, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !IsBuildOutputPath(path))
+            .Select(path => new SourceFileSnapshot(path, File.ReadAllText(path)))
+            .ToArray();
+    }
+
+    private static bool IsBuildOutputPath(string path) =>
+        path.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar, StringComparison.Ordinal) ||
+        path.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar, StringComparison.Ordinal);
+
+    private static string FindRepoRoot()
+    {
+        var envRoot = Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT");
+        if (!string.IsNullOrWhiteSpace(envRoot) &&
+            File.Exists(Path.Combine(envRoot, "openclaw-windows-node.slnx")))
+        {
+            return envRoot;
+        }
+
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "openclaw-windows-node.slnx")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate openclaw-windows-node.slnx from test base directory.");
+    }
+}
+
+internal sealed record SourceFileSnapshot(string Path, string Text);

--- a/tests/OpenClaw.Shared.Tests/SystemRunTests.cs
+++ b/tests/OpenClaw.Shared.Tests/SystemRunTests.cs
@@ -651,8 +651,8 @@ public class LocalCommandRunnerIntegrationTests
         var result = await runner.RunAsync(new CommandRequest
         {
             Command = "this-command-does-not-exist-12345",
-            Shell = "powershell",
-            TimeoutMs = 10000
+            Shell = "cmd",
+            TimeoutMs = 5000
         });
 
         Assert.NotEqual(0, result.ExitCode);

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -1847,10 +1847,12 @@ public class OpenClawChatDataProviderTests
         // When sessions arrive after the connection is already established,
         // the provider should automatically load history for new threads.
         var historyRequested = new List<string?>();
+        var historyLoaded = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var (bridge, provider, snapshots, _) = CreateProvider();
         bridge.HistoryBehavior = key =>
         {
             historyRequested.Add(key);
+            historyLoaded.TrySetResult();
             return Task.FromResult(new ChatHistoryInfo
             {
                 SessionKey = key ?? "",
@@ -1868,8 +1870,8 @@ public class OpenClawChatDataProviderTests
 
         bridge.RaiseSessions(new[] { MainSession() });
 
-        // Give fire-and-forget history load time to complete.
-        await Task.Delay(200);
+        var completed = await Task.WhenAny(historyLoaded.Task, Task.Delay(TimeSpan.FromSeconds(1)));
+        Assert.Same(historyLoaded.Task, completed);
 
         Assert.Contains("main", historyRequested);
     }
@@ -1912,9 +1914,17 @@ public class OpenClawChatDataProviderTests
 
         // Transition to Connected — should reload the "main" timeline even
         // though LoadHistoryAsync was never successfully called before.
+        var historyLoaded = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        bridge.HistoryBehavior = key =>
+        {
+            historyRequested.Add(key);
+            historyLoaded.TrySetResult();
+            return Task.FromResult(new ChatHistoryInfo { SessionKey = key ?? "" });
+        };
         bridge.RaiseStatus(ConnectionStatus.Connected);
 
-        await Task.Delay(200);
+        var completed = await Task.WhenAny(historyLoaded.Task, Task.Delay(TimeSpan.FromSeconds(1)));
+        Assert.Same(historyLoaded.Task, completed);
 
         Assert.Contains("main", historyRequested);
     }


### PR DESCRIPTION
## Summary
- gate E2E tests behind `OPENCLAW_RUN_E2E=1` for local development while keeping CI E2E execution enabled
- add a CI hard guard that fails if the E2E TRX reports zero executed tests
- speed up selected test-only waits/source scans without changing product behavior
- document local-dev vs explicit E2E test commands

## Before / after
- Original full timed run including E2E + SetupEngine: 282.87s -> local-dev default 70.69s (-75.0%)
- Comparable local solution project set excluding E2E + SetupEngine: 75.69s -> 70.69s (-6.6%)
- `Run_InvalidCommand_ReturnsError`: 2.905s -> 0.036s
- Production-wiring source scans combined: 0.836s -> 0.410s
- Two converted chat fire-and-forget waits combined: ~0.424s -> ~0.003s
- Local E2E skip verification: 6 skipped, 7ms test duration

## Validation
- `dotnet test .\tests\OpenClaw.E2ETests\OpenClaw.E2ETests.csproj --no-restore --tl:off -r win-arm64 --filter "FullyQualifiedName~SetupAndConnectTests"`
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore --tl:off --filter "ProductionWiring"`
- `.\build.ps1`
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore --tl:off`
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore --tl:off`
- `git diff --check`