### PR TITLE
eng: enforce warning-clean builds

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -132,3 +132,9 @@ dotnet_naming_symbols.static_readonly_fields.required_modifiers = static, readon
 
 dotnet_naming_style.s_camel_case.capitalization = camel_case
 dotnet_naming_style.s_camel_case.required_prefix = s_
+
+# WinUI XAML type-info generation references WinUIEx.Icon, which is obsolete
+# in WinUIEx but is not used directly by our source. Keep CS0612 active for
+# source files and suppress it only for the generated type-info file.
+[**/XamlTypeInfo.g.cs]
+dotnet_diagnostic.CS0612.severity = none

--- a/openclaw-windows-node.slnx
+++ b/openclaw-windows-node.slnx
@@ -26,12 +26,6 @@
       <Platform Solution="*|x64" Project="x64" />
       <Platform Solution="*|ARM64" Project="ARM64" />
     </Project>
-    <Project Path="src/OpenClaw.SetupPreview/OpenClaw.SetupPreview.csproj">
-      <!-- WindowsAppSDK.SelfContained requires a concrete Platform (x64/ARM64); AnyCPU would need a RID. -->
-      <Platform Solution="*|Any CPU" Project="x64" />
-      <Platform Solution="*|x64" Project="x64" />
-      <Platform Solution="*|ARM64" Project="ARM64" />
-    </Project>
     <Project Path="src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj">
       <!-- WindowsAppSDK.SelfContained requires a concrete Platform (x64/ARM64); AnyCPU would need a RID. -->
       <Platform Solution="*|Any CPU" Project="x64" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,6 +8,10 @@
   -->
 
   <PropertyGroup>
+    <!-- Keep product builds warning-clean by default. Tests already set the same
+         policy in tests/Directory.Build.props. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
     <!-- Audit all package dependencies (direct + transitive) for known CVEs during restore.
          Defaults to "direct" in the SDK; "all" provides broader security coverage. -->
     <NuGetAuditMode>all</NuGetAuditMode>

--- a/src/OpenClaw.CommandPalette/Directory.Build.props
+++ b/src/OpenClaw.CommandPalette/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <Platforms>x64;ARM64</Platforms>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>Recommended</AnalysisMode>
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>

--- a/src/OpenClaw.CommandPalette/OpenClaw.CommandPalette.csproj
+++ b/src/OpenClaw.CommandPalette/OpenClaw.CommandPalette.csproj
@@ -10,7 +10,7 @@
     <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
 
-    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
+    <PublishProfile Condition="'$(Platform)' == 'x64' Or '$(Platform)' == 'ARM64'">win-$(Platform).pubxml</PublishProfile>
     <EnableMsixTooling>true</EnableMsixTooling>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/OpenClaw.SetupEngine/Program.cs
+++ b/src/OpenClaw.SetupEngine/Program.cs
@@ -1,5 +1,8 @@
+using System.Runtime.Versioning;
+
 namespace OpenClaw.SetupEngine;
 
+[SupportedOSPlatform("windows")]
 public static class Program
 {
     public static async Task<int> Main(string[] args)

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
@@ -143,14 +143,15 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
                         canonical: context.DisplayCommand);
                 }
 
-                // Exhaustive mapping without _ so the compiler warns if ExecApprovalPromptOutcome
-                // gains a new value. Allow is unreachable here — handled by the check above.
+                // Allow is unreachable here — handled by the check above. The fallback arm
+                // fails closed for invalid enum values that can still be cast at runtime.
                 followupDecision = promptResult switch
                 {
                     ExecApprovalPromptOutcome.Deny => ExecApprovalDecision.Deny,
                     ExecApprovalPromptOutcome.AllowOnce => ExecApprovalDecision.AllowOnce,
                     ExecApprovalPromptOutcome.AllowAlways => ExecApprovalDecision.AllowAlways,
                     ExecApprovalPromptOutcome.Allow => throw new UnreachableException("prompt-returned-allow handled above"),
+                    _ => throw new UnreachableException($"unknown prompt outcome: {promptResult}"),
                 };
             }
             else

--- a/src/OpenClaw.Tray.WinUI/A2UI/Hosting/A2UIRouter.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Hosting/A2UIRouter.cs
@@ -136,7 +136,7 @@ public sealed class A2UIRouter
                 if (host == null) break;
                 host.BeginRendering(br.Root, br.Styles);
                 SurfaceRendered?.Invoke(this, host);
-                _logger.Info($"[A2UI] beginRendering '{LogSafe(br.SurfaceId)}' root='{LogSafe(br.Root)}' (catalog={LogSafe(br.CatalogId) ?? "default"})");
+                _logger.Info($"[A2UI] beginRendering '{LogSafe(br.SurfaceId)}' root='{LogSafe(br.Root)}' (catalog={LogSafe(br.CatalogId ?? "default")})");
                 _telemetry.Push(br.SurfaceId, "beginRendering", 1);
                 break;
             }
@@ -144,7 +144,7 @@ public sealed class A2UIRouter
             case DataModelUpdateMessage dmu:
             {
                 _dataModel.ApplyDataModelUpdate(dmu.SurfaceId, dmu.Path, dmu.Contents);
-                _logger.Debug($"[A2UI] dataModelUpdate '{LogSafe(dmu.SurfaceId)}' path='{LogSafe(dmu.Path) ?? "/"}' ({dmu.Contents.Count} entry(ies))");
+                _logger.Debug($"[A2UI] dataModelUpdate '{LogSafe(dmu.SurfaceId)}' path='{LogSafe(dmu.Path ?? "/")}' ({dmu.Contents.Count} entry(ies))");
                 _telemetry.Push(dmu.SurfaceId, "dataModelUpdate", dmu.Contents.Count);
                 break;
             }

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -612,7 +612,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         StartDeepLinkServer();
 
         // Register global hotkey if enabled
-        if (_settings.GlobalHotkeyEnabled)
+        if (_settings?.GlobalHotkeyEnabled == true)
         {
             _globalHotkey = new GlobalHotkeyService();
             _globalHotkey.VoiceHotkeyPressed += OnVoiceHotkeyPressed;
@@ -3262,7 +3262,9 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     //    UpdateDialog + download + install. Prevents two parallel installs
     //    without holding a lock across user interaction.
     private readonly System.Threading.SemaphoreSlim _updateCheckGate = new(1, 1);
+#if !DEBUG
     private int _updateInstallInProgress;
+#endif
 
     private async Task<bool> CheckForUpdatesAsync(bool userInitiated = false)
     {

--- a/src/OpenClaw.Tray.WinUI/Chat/Explorations/FakeChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/Explorations/FakeChatDataProvider.cs
@@ -24,7 +24,11 @@ public sealed class FakeChatDataProvider : IChatDataProvider
     public string DisplayName => "Demo (preview)";
 
     public event EventHandler<ChatDataChangedEventArgs>? Changed;
-    public event EventHandler<ChatProviderNotificationEventArgs>? NotificationRequested;
+    public event EventHandler<ChatProviderNotificationEventArgs>? NotificationRequested
+    {
+        add { }
+        remove { }
+    }
 
     public FakeChatDataProvider()
     {

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
@@ -197,7 +197,7 @@ public sealed class OpenClawChatRoot : Component
                 return null;
 
             return nativeForMeta.GetEntryMetadata(selectedIdForMetadata);
-        }, selectedIdForMetadata ?? string.Empty, snapshot);
+        }, selectedIdForMetadata ?? string.Empty, snapshot is null ? string.Empty : snapshot);
 
         // Preview override (G) — only honored when the chat is bound to a
         // fake provider (i.e. the explorations window). Real production

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
@@ -435,23 +435,6 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
             StoreSessionOffset(prevSessionIdRef.Current, sv.VerticalOffset);
         }
 
-        void QueueScrollToOffset(Microsoft.UI.Xaml.Controls.ScrollViewer sv, string? sessionId, double targetOffset, bool disableAnimation, bool suppressAutoFollow)
-        {
-            suppressAutoFollowRef.Current = suppressAutoFollow;
-            sv.DispatcherQueue.TryEnqueue(() =>
-            {
-                var target = ClampOffset(targetOffset, sv.ScrollableHeight);
-                sv.ChangeView(null, target, null, disableAnimation);
-                lastVerticalOffsetRef.Current = target;
-                lastScrollableHeightRef.Current = sv.ScrollableHeight;
-                isFollowingRef.Current = sv.ScrollableHeight - target <= FollowThreshold;
-                StoreSessionOffset(sessionId, target);
-
-                if (suppressAutoFollow)
-                    sv.DispatcherQueue.TryEnqueue(() => suppressAutoFollowRef.Current = false);
-            });
-        }
-
         void QueueScrollToBottom(Microsoft.UI.Xaml.Controls.ScrollViewer sv, string? sessionId, bool disableAnimation)
         {
             isFollowingRef.Current = true;
@@ -610,12 +593,6 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
 
         ChatEntryMetadata? MetaFor(string id) =>
             meta is not null && meta.TryGetValue(id, out var m) ? m : null;
-
-        Element FooterCaption(string text, HorizontalAlignment align) =>
-            Caption(text)
-                .Foreground(chatStampFg)
-                .Set(t => t.FontSize = 11)
-                .HAlign(align);
 
         // Hover-revealed action icon (copy / read aloud / trash). Opacity 0
         // and not hit-testable until the entry is hovered, then fades in
@@ -1467,7 +1444,7 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                     aggregateStatus = ChatToolCallStatus.Interrupted;
             }
             var (taskStatusText, taskStatusBg, _) = ResolveStatus(new ChatTimelineItem(
-                Id: "agg", Kind: ChatTimelineItemKind.ToolCall, Text: null,
+                Id: "agg", Kind: ChatTimelineItemKind.ToolCall, Text: string.Empty,
                 ToolName: null, ToolResult: aggregateStatus, ToolOutput: null));
 
             string? StepPrefix(int i) => showStepNumbers ? $"{i + 1}." : null;
@@ -1480,12 +1457,6 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
             // "Task · 3 steps · 8:16 PM" — used by FooterReframe + as the
             // companion line under the TaskHeader card. Keeps the time so
             // users still get the chronology.
-            string TaskFooter()
-            {
-                var stepsLabel = $"Task · {stepCount} step{(stepCount == 1 ? "" : "s")}";
-                return string.IsNullOrEmpty(timeStr) ? stepsLabel : $"{stepsLabel} · {timeStr}";
-            }
-
             Element CardOf(Element[] rowEls) => Border(VStack(0, rowEls))
                 .Background(toolCardBgBrush)
                 .WithBorder(toolCardBorderBrush, toolCardBorderThickness)

--- a/src/OpenClaw.Tray.WinUI/Dialogs/RecordingConsentDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/RecordingConsentDialog.cs
@@ -172,7 +172,7 @@ public sealed class RecordingConsentDialog : WindowEx
         Logger.Info($"[RecordingConsent] {type} recording consent dialog shown");
     }
 
-    public new Task<bool> ShowAsync()
+    public Task<bool> ShowAsync()
     {
         Activate();
 

--- a/src/OpenClaw.Tray.WinUI/Dialogs/UpdateDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/UpdateDialog.cs
@@ -114,7 +114,7 @@ public sealed class UpdateDialog : WindowEx
         Logger.Info($"[Update] Update dialog shown for version {version}");
     }
 
-    public new Task<UpdateDialogResult> ShowAsync()
+    public Task<UpdateDialogResult> ShowAsync()
     {
         Activate();
         return _tcs.Task;

--- a/src/OpenClaw.Tray.WinUI/Dialogs/WelcomeDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/WelcomeDialog.cs
@@ -161,7 +161,7 @@ public sealed class WelcomeDialog : WindowEx
         Logger.Info("[Welcome] Welcome dialog shown");
     }
 
-    public new Task<ContentDialogResult> ShowAsync()
+    public Task<ContentDialogResult> ShowAsync()
     {
         Activate();
         return _tcs.Task;

--- a/src/OpenClaw.Tray.WinUI/Pages/AboutPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/AboutPage.xaml.cs
@@ -12,7 +12,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class AboutPage : Page
 {
-    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private AppState? _appState;
 
     public AboutPage()
@@ -27,7 +27,7 @@ public sealed partial class AboutPage : Page
 
     public void Initialize()
     {
-        _appState = CurrentApp.AppState;
+        _appState = CurrentApp.AppState!;
         _appState.PropertyChanged += OnAppStateChanged;
         TryLoadGatewayInfo();
     }

--- a/src/OpenClaw.Tray.WinUI/Pages/AgentEventsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/AgentEventsPage.xaml.cs
@@ -79,7 +79,7 @@ public sealed partial class AgentEventsPage : Page
 
     public void Initialize(HubWindow hub)
     {
-        _appState = ((App)Application.Current).AppState;
+        _appState = ((App)Application.Current!).AppState!;
         _appState.AgentEventAdded += OnAgentEventAdded;
         _appState.PropertyChanged += OnAppStateChanged;
         PopulateAgentFilter(hub);

--- a/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml.cs
@@ -10,7 +10,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class BindingsPage : Page
 {
-    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private AppState? _appState;
     private readonly AsyncListLoadingState _bindingsLoading = new();
 
@@ -26,7 +26,7 @@ public sealed partial class BindingsPage : Page
     public void Initialize()
     {
         if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
-        _appState = CurrentApp.AppState;
+        _appState = CurrentApp.AppState!;
         _appState.PropertyChanged += OnAppStateChanged;
         // Use cached config if available
         if (_appState?.Config.HasValue == true)

--- a/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
@@ -32,7 +32,7 @@ namespace OpenClawTray.Pages;
 /// </summary>
 public sealed partial class ChannelsPage : Page
 {
-    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private AppState? _appState;
 
     /// <summary>
@@ -170,7 +170,7 @@ public sealed partial class ChannelsPage : Page
     /// </summary>
     public void Initialize()
     {
-        _appState = CurrentApp.AppState;
+        _appState = CurrentApp.AppState!;
         if (_appState != null)
             _appState.PropertyChanged += OnAppStateChanged;
 

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -22,7 +22,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class ChatPage : Page
 {
-    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private HubWindow? _hub;
     private MountedFunctionalChat? _functionalHost;
     private IChatDataProvider? _mountedProvider;
@@ -276,7 +276,7 @@ public sealed partial class ChatPage : Page
         // If the V hotkey (or another caller) requested auto-start voice,
         // trigger it after the UI thread processes the mount (composer needs
         // to render first so TriggerVoiceRecording is registered).
-        if (_hub.PendingAutoStartVoice)
+        if (_hub?.PendingAutoStartVoice == true)
         {
             _hub.PendingAutoStartVoice = false;
             DispatcherQueue?.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
@@ -487,7 +487,7 @@ public sealed partial class ChatPage : Page
             }
 
             Logger.Info("[ChatPage] Operator handshake ready; probing chat HTTP surface");
-            ready = await ProbeChatSurfaceAsync(_chatUrl, TimeSpan.FromSeconds(30), cancellationToken);
+            ready = await ProbeChatSurfaceAsync(_chatUrl!, TimeSpan.FromSeconds(30), cancellationToken);
             if (!ready)
             {
                 ShowChatReadinessFailure($"Timed out waiting for chat at {gatewayUrl}. Retry once the gateway is ready.");

--- a/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
@@ -26,7 +26,7 @@ public sealed partial class ConfigPage : Page
     private const double JsonPreviewAutoExpandWidth = 1120;
     private const double JsonPreviewMinWidth = 340;
 
-    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private AppState? _appState;
     private JsonElement? _lastConfig;
     private JsonElement? _lastSchema;
@@ -104,7 +104,7 @@ public sealed partial class ConfigPage : Page
         if (_appState != null)
             _appState.PropertyChanged -= OnAppStateChanged;
 
-        _appState = CurrentApp.AppState;
+        _appState = CurrentApp.AppState!;
         _appState.PropertyChanged += OnAppStateChanged;
         SubscribePermissionClient(CurrentApp.GatewayClient);
         Logger.Info("[ConfigPage] Initialize");

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -30,7 +30,7 @@ namespace OpenClawTray.Pages;
 public sealed partial class ConnectionPage : Page
 {
     // ─── DI / services ───
-    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private AppState? _appState;
     private IGatewayConnectionManager? _connectionManager;
     private GatewayRegistry? _gatewayRegistry;
@@ -88,7 +88,7 @@ public sealed partial class ConnectionPage : Page
 
     public void Initialize()
     {
-        _appState = ((App)Application.Current).AppState;
+        _appState = ((App)Application.Current!).AppState!;
         _appState.PropertyChanged += OnAppStateChanged;
         _connectionManager = CurrentApp.ConnectionManager;
         _gatewayRegistry = CurrentApp.Registry;
@@ -2055,10 +2055,10 @@ public sealed partial class ConnectionPage : Page
 
         if (settings != null)
         {
-            settings.GatewayUrl = prevGatewayUrl;
+            settings.GatewayUrl = prevGatewayUrl ?? string.Empty;
             settings.UseSshTunnel = prevUseSsh;
-            settings.SshTunnelUser = prevSshUser;
-            settings.SshTunnelHost = prevSshHost;
+            settings.SshTunnelUser = prevSshUser ?? string.Empty;
+            settings.SshTunnelHost = prevSshHost ?? string.Empty;
             settings.SshTunnelRemotePort = prevSshRemotePort;
             settings.SshTunnelLocalPort = prevSshLocalPort;
             settings.Save();
@@ -2446,7 +2446,7 @@ public sealed partial class ConnectionPage : Page
             // could act on the wrong one — disable those rows so the user
             // is forced to approve via the gateway-host CLI instead.
             var ambiguousIds = ComputeAmbiguousFallbackIds(
-                data.Pending.Select(r => (r.RequestId, r.DeviceId)));
+                data.Pending.Select(r => (RequestId: (string?)r.RequestId, FallbackId: (string?)r.DeviceId)));
             foreach (var req in data.Pending)
             {
                 bool ambiguous = req.RequestId == null
@@ -2472,7 +2472,7 @@ public sealed partial class ConnectionPage : Page
             // the same NodeId and no RequestId, disable approve/deny on
             // those rows so the user can't pick the wrong target.
             var ambiguousIds = ComputeAmbiguousFallbackIds(
-                data.Pending.Select(r => (r.RequestId, NodeId: r.NodeId)));
+                data.Pending.Select(r => (RequestId: (string?)r.RequestId, FallbackId: (string?)r.NodeId)));
             foreach (var req in data.Pending)
             {
                 bool ambiguous = req.RequestId == null

--- a/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
@@ -17,7 +17,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class CronPage : Page
 {
-    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private AppState? _appState;
     private List<CronJobViewModel> _jobs = new();
     private Border? _editingCard = null; // card hidden during inline edit
@@ -40,7 +40,7 @@ public sealed partial class CronPage : Page
     public void Initialize()
     {
         if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
-        _appState = CurrentApp.AppState;
+        _appState = CurrentApp.AppState!;
         _appState.PropertyChanged += OnAppStateChanged;
         var client = CurrentApp.GatewayClient;
         if (client != null)
@@ -139,7 +139,8 @@ public sealed partial class CronPage : Page
                 DispatcherQueue?.TryEnqueue(() =>
                 {
                     _runningJobIds.Remove(jobId);
-                    _ = CurrentApp.GatewayClient?.RequestCronListAsync();
+                    var client = CurrentApp.GatewayClient;
+                    if (client != null) _ = client.RequestCronListAsync();
                 });
             }
         });
@@ -153,7 +154,8 @@ public sealed partial class CronPage : Page
                 DispatcherQueue?.TryEnqueue(() =>
                 {
                     _runningJobIds.Remove(jobId);
-                    _ = CurrentApp.GatewayClient?.RequestCronListAsync();
+                    var client = CurrentApp.GatewayClient;
+                    if (client != null) _ = client.RequestCronListAsync();
                 });
             }
         });

--- a/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
@@ -38,7 +38,7 @@ namespace OpenClawTray.Pages;
 /// </summary>
 public sealed partial class DebugPage : Page
 {
-    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
 
     private AppState? _appState;
     private bool _suppressOverrideChange;
@@ -100,7 +100,7 @@ public sealed partial class DebugPage : Page
         if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
         CurrentApp.SettingsChanged -= OnSettingsChanged;
 
-        _appState = CurrentApp.AppState;
+        _appState = CurrentApp.AppState!;
         if (_appState != null) _appState.PropertyChanged += OnAppStateChanged;
         // Listen for Settings → Save round-trips so the gateway URL in
         // the top InfoBar updates without waiting for a Status flip

--- a/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml.cs
@@ -26,7 +26,7 @@ namespace OpenClawTray.Pages;
 /// </summary>
 public sealed partial class InstancesPage : Page
 {
-    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private AppState? _appState;
 
     public InstancesPage()
@@ -50,7 +50,7 @@ public sealed partial class InstancesPage : Page
             : Visibility.Collapsed;
 
         if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
-        _appState = CurrentApp.AppState;
+        _appState = CurrentApp.AppState!;
         _appState.PropertyChanged += OnAppStateChanged;
 
         Rerender();

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
@@ -17,7 +17,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class PermissionsPage : Page
 {
-    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private bool _suppressMcpToggle;
     private bool _suppressTtsProviderChange;
     private readonly List<ToggleSwitch> _featureToggles = new();

--- a/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
@@ -12,7 +12,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class SandboxPage : Page
 {
-    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private bool _suppress;
     private bool _dialogOpen;
     private OpenClaw.Shared.Mxc.MxcAvailability? _cachedAvailability;

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -14,7 +14,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class SessionsPage : Page
 {
-    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private AppState? _appState;
     private SessionInfo[]? _allSessions;
     private string _activeChannel = "all";
@@ -35,7 +35,7 @@ public sealed partial class SessionsPage : Page
     {
         // Guard against duplicate subscriptions (NavigationCacheMode reuses page)
         if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
-        _appState = CurrentApp.AppState;
+        _appState = CurrentApp.AppState!;
         _appState.PropertyChanged += OnAppStateChanged;
 
         // Show "← Back to Connection" only when the user arrived from

--- a/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml.cs
@@ -12,7 +12,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class SettingsPage : Page
 {
-    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private bool _initialized;
     private bool _saving;
     private bool _loading;

--- a/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml.cs
@@ -11,7 +11,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class SkillsPage : Page
 {
-    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private AppState? _appState;
     private List<SkillData> _allSkills = new();
 
@@ -28,7 +28,7 @@ public sealed partial class SkillsPage : Page
 
     public void Initialize()
     {
-        _appState = CurrentApp.AppState;
+        _appState = CurrentApp.AppState!;
         _appState.PropertyChanged += OnAppStateChanged;
         PopulateAgentFilter();
 

--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml.cs
@@ -13,7 +13,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class UsagePage : Page
 {
-    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private AppState? _appState;
     private IOperatorGatewayClient? _trackedClient;
     // Default matches the XAML-selected Period7DaysItem (IsSelected="True").
@@ -41,7 +41,7 @@ public sealed partial class UsagePage : Page
     public void Initialize()
     {
         if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
-        _appState = CurrentApp.AppState;
+        _appState = CurrentApp.AppState!;
         _appState.PropertyChanged += OnAppStateChanged;
         if (CurrentApp.ConnectionManager != null)
         {

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
@@ -14,7 +14,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class VoiceSettingsPage : Page
 {
-    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private VoiceService? _voiceService;
     private bool _suppressEvents = true; // suppress until Initialize/LoadSettings runs
     // Per-asset CTS so a Piper download doesn't cancel an in-flight Whisper

--- a/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml.cs
@@ -15,7 +15,7 @@ namespace OpenClawTray.Pages;
 
 public sealed partial class WorkspacePage : Page
 {
-    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current;
+    private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private AppState? _appState;
 
     // file name (case-insensitive) → its list item
@@ -51,7 +51,7 @@ public sealed partial class WorkspacePage : Page
 
     public void Initialize()
     {
-        _appState = CurrentApp.AppState;
+        _appState = CurrentApp.AppState!;
         _appState.PropertyChanged += OnAppStateChanged;
 
         if (_appState.TryGetCachedAgentFilesList(AgentId, out var cachedData))

--- a/src/OpenClaw.Tray.WinUI/Services/AudioPipeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AudioPipeline.cs
@@ -137,9 +137,10 @@ public sealed class AudioPipeline : IAsyncDisposable
             _vadChunkCount = 0;
 
             SetState(AudioPipelineState.Listening);
+            var captureFormat = _captureFormat ?? throw new InvalidOperationException("Audio capture format was not initialized.");
             var sttStatus = _stt.IsModelLoaded ? "loaded" : "NOT loaded";
-            _logger.Info($"Audio pipeline started: {_captureFormat.SampleRate}Hz {_captureFormat.BitsPerSample}bit {_captureFormat.Channels}ch → 16kHz mono, VAD=energy, STT={sttStatus}");
-            DiagnosticMessage?.Invoke($"Mic: {_captureFormat.SampleRate}Hz, STT model: {sttStatus}");
+            _logger.Info($"Audio pipeline started: {captureFormat.SampleRate}Hz {captureFormat.BitsPerSample}bit {captureFormat.Channels}ch → 16kHz mono, VAD=energy, STT={sttStatus}");
+            DiagnosticMessage?.Invoke($"Mic: {captureFormat.SampleRate}Hz, STT model: {sttStatus}");
         }
         catch (System.Runtime.InteropServices.COMException ex) when (
             ex.HResult == unchecked((int)0x80070005) || // E_ACCESSDENIED

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -329,7 +329,8 @@ public sealed class NodeService : IDisposable
 
         if (NodeCapabilityGating.ShouldRegisterTts(_settings))
         {
-            _textToSpeechService ??= new TextToSpeechService(_logger, _settings);
+            var settings = _settings ?? throw new InvalidOperationException("Settings are required to register text-to-speech.");
+            _textToSpeechService ??= new TextToSpeechService(_logger, settings);
             _ttsCapability = new TtsCapability(_logger);
             _ttsCapability.SpeakRequested += OnTtsSpeakAsync;
             Register(_ttsCapability);
@@ -344,7 +345,8 @@ public sealed class NodeService : IDisposable
             // builds. When the Whisper model isn't downloaded yet, the
             // handlers return a clear error pointing the caller at the
             // Voice Settings page; there is no automatic fallback.
-            _voiceService ??= new VoiceService(_logger, _settings);
+            var settings = _settings ?? throw new InvalidOperationException("Settings are required to register speech-to-text.");
+            _voiceService ??= new VoiceService(_logger, settings);
             _sttCapability = new SttCapability(_logger);
             _sttCapability.TranscribeRequested += OnSttTranscribeAsync;
             _sttCapability.ListenRequested += OnSttListenAsync;

--- a/src/OpenClaw.Tray.WinUI/Services/ScreenRecordingService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ScreenRecordingService.cs
@@ -268,7 +268,7 @@ internal sealed class ScreenRecordingService : IDisposable
             throw new InvalidOperationException("D3D11 device creation returned a null device.");
 
         var iid = IID_DXGIDevice;
-        hr = Marshal.QueryInterface(d3dPtr, ref iid, out var dxgiPtr);
+        hr = Marshal.QueryInterface(d3dPtr, in iid, out var dxgiPtr);
         Marshal.Release(d3dPtr);
         Marshal.ThrowExceptionForHR(hr);
         if (dxgiPtr == IntPtr.Zero)

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -64,7 +64,6 @@ public sealed partial class HubWindow : WindowEx
     public string? LastSkillsAgentId { get; private set; }
     public System.Text.Json.JsonElement? LastAgentFilesList { get; private set; }
     public string? LastAgentFilesListAgentId { get; private set; }
-    private string? _pendingAgentFilesListAgentId;
 
 
     // Event for settings saved (App.xaml.cs subscribes)
@@ -456,7 +455,7 @@ public sealed partial class HubWindow : WindowEx
                 var gatewayTags = new HashSet<string> { "chat", "sessions", "skills", "channels", "instances", "agentevents", "bindings", "config", "usage", "cron", "workspace" };
                 if (currentTag != null && (gatewayTags.Contains(currentTag) || currentTag.StartsWith("agent:")))
                 {
-                    foreach (NavigationViewItem item in NavView.MenuItems.OfType<NavigationViewItem>())
+                    foreach (NavigationViewItem item in NavView!.MenuItems.OfType<NavigationViewItem>())
                     {
                         if (item.Tag as string == "connection")
                         {

--- a/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
+++ b/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
@@ -9,7 +9,6 @@ using Microsoft.UI.Xaml.Media.Imaging;
 using System.Globalization;
 using Windows.UI;
 using Windows.UI.Text;
-using OpenClawTray.Services;
 using WinGrid = Microsoft.UI.Xaml.Controls.Grid;
 
 namespace OpenClawTray.FunctionalUI.Core
@@ -1728,7 +1727,7 @@ internal sealed class UiRenderer(Action requestRender)
     {
         if (sender is RadioButtons { Tag: RadioButtonsElement element } rb)
         {
-            Logger.Debug($"[WizardDiag] RadioButtons.SelectionChanged: idx={rb.SelectedIndex} itemCount={rb.Items?.Count ?? 0}");
+            System.Diagnostics.Debug.WriteLine($"[WizardDiag] RadioButtons.SelectionChanged: idx={rb.SelectedIndex} itemCount={rb.Items?.Count ?? 0}");
             element.OnSelectionChanged?.Invoke(rb.SelectedIndex);
         }
     }

--- a/src/OpenClawTray.FunctionalUI/OpenClawTray.FunctionalUI.csproj
+++ b/src/OpenClawTray.FunctionalUI/OpenClawTray.FunctionalUI.csproj
@@ -17,7 +17,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\OpenClaw.Shared\OpenClaw.Shared.csproj" />
-    <Compile Include="..\OpenClaw.Tray.WinUI\Services\Logger.cs" Link="Services\Logger.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/OpenClaw.E2ETests/OpenClaw.E2ETests.csproj
+++ b/tests/OpenClaw.E2ETests/OpenClaw.E2ETests.csproj
@@ -2,10 +2,14 @@
 
   <PropertyGroup>
     <!--
+      E2E tests are Windows-only: they call SetupEngine's Program.Main which
+      is marked [SupportedOSPlatform("windows")]. Override the default TFM
+      from Directory.Build.props so CA1416 doesn't fire.
       CI builds with -r win-x64 plus no-restore. Without RuntimeIdentifiers
       declared here, the top-level dotnet restore produces only default-RID
       assets and the no-restore build fails with NETSDK1047.
     -->
+    <TargetFramework>net10.0-windows</TargetFramework>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- Enable `TreatWarningsAsErrors` by default for product projects, including the CommandPalette subtree.
- Fix product/test warning backlog exposed by warning-as-error builds.
- Scope the generated WinUIEx `Icon` obsolete warning suppression to `**/XamlTypeInfo.g.cs` via `.editorconfig`.
- Remove stale `SetupPreview` from the solution build after upstream deleted its OnboardingV2 dependency.

## Validation
- Product default warning-as-error sweep passed for all current `src` solution projects.
- `./build.ps1` passed.
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore --tl:off` passed: 1958 passed, 29 skipped.
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore --tl:off` passed: 843 passed.

## Behavior notes
- No shipped runtime product behavior change intended.
- `SetupPreview` removal is a developer/build-surface cleanup only; the preview referenced UI code already removed upstream.