### PR TITLE
Fix tray menu toggle flicker

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -2437,10 +2437,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         _suspendConnectionToggleEvent = true;
         try
         {
-            if (toggle.IsOn != shouldBeOn)
-                toggle.IsOn = shouldBeOn;
-
-            toggle.IsEnabled = canToggle;
+            TrayMenuWindow.SetMenuToggleSwitchState(toggle, shouldBeOn, canToggle);
             ToolTipService.SetToolTip(toggle,
                 shouldBeOn ? "Connected - toggle off to disconnect"
                     : status == ConnectionStatus.Connecting ? "Connecting..."

--- a/src/OpenClaw.Tray.WinUI/Services/TrayMenuStateBuilder.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/TrayMenuStateBuilder.cs
@@ -94,21 +94,11 @@ internal sealed class TrayMenuStateBuilder
         Grid.SetColumn(brandRow, 0);
         brandGrid.Children.Add(brandRow);
 
-        var connectionToggle = new ToggleSwitch
-        {
-            IsOn = isConnected,
-            OnContent = string.Empty,
-            OffContent = string.Empty,
-            VerticalAlignment = VerticalAlignment.Center,
-            MinWidth = 0,
-            Width = 40,
-            HorizontalAlignment = HorizontalAlignment.Right,
-            Margin = new Thickness(0),
-            IsEnabled = _snapshot.CurrentStatus == ConnectionStatus.Connected
-                || _snapshot.CurrentStatus == ConnectionStatus.Disconnected
-                || _snapshot.CurrentStatus == ConnectionStatus.Error
-        };
-        AutomationProperties.SetName(connectionToggle, "Gateway connection");
+        var canToggleConnection = _snapshot.CurrentStatus == ConnectionStatus.Connected
+            || _snapshot.CurrentStatus == ConnectionStatus.Disconnected
+            || _snapshot.CurrentStatus == ConnectionStatus.Error;
+        var connectionToggle = TrayMenuWindow.CreateMenuToggleSwitch(isConnected, "Gateway connection", canToggleConnection);
+        connectionToggle.Margin = new Thickness(0);
         ToolTipService.SetToolTip(connectionToggle,
             isConnected ? "Connected - toggle off to disconnect" : "Disconnected - toggle on to connect");
         connectionToggle.Toggled += (s, ev) =>

--- a/src/OpenClaw.Tray.WinUI/Services/TrayMenuStateBuilder.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/TrayMenuStateBuilder.cs
@@ -97,7 +97,7 @@ internal sealed class TrayMenuStateBuilder
         var canToggleConnection = _snapshot.CurrentStatus == ConnectionStatus.Connected
             || _snapshot.CurrentStatus == ConnectionStatus.Disconnected
             || _snapshot.CurrentStatus == ConnectionStatus.Error;
-        var connectionToggle = TrayMenuWindow.CreateMenuToggleSwitch(isConnected, "Gateway connection", canToggleConnection);
+        var connectionToggle = menu.CreateMenuToggleSwitch(isConnected, "Gateway connection", canToggleConnection);
         connectionToggle.Margin = new Thickness(0);
         ToolTipService.SetToolTip(connectionToggle,
             isConnected ? "Connected - toggle off to disconnect" : "Disconnected - toggle on to connect");

--- a/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml
@@ -4,6 +4,7 @@
     x:Class="OpenClawTray.Windows.TrayMenuWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
     xmlns:winex="using:WinUIEx"
     Title="OpenClaw Menu"
     Width="320"
@@ -12,6 +13,147 @@
     <!-- Acrylic backdrop applied in code-behind via BackdropHelper -->
 
     <Grid x:Name="RootGrid" Background="Transparent">
+        <Grid.Resources>
+            <Style x:Key="TrayMenuInstantToggleSwitchStyle" TargetType="ToggleSwitch">
+                <Setter Property="Foreground" Value="{ThemeResource ToggleSwitchContentForeground}" />
+                <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+                <Setter Property="FocusVisualMargin" Value="-7,-3,-7,-3" />
+                <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ToggleSwitch">
+                            <Grid Background="{TemplateBinding Background}"
+                                  BorderBrush="{TemplateBinding BorderBrush}"
+                                  BorderThickness="{TemplateBinding BorderThickness}"
+                                  CornerRadius="{TemplateBinding CornerRadius}">
+                                <VisualStateManager.VisualStateGroups>
+                                    <VisualStateGroup x:Name="CommonStates">
+                                        <VisualState x:Name="Normal">
+                                            <VisualState.Setters>
+                                                <Setter Target="OuterBorder.Fill" Value="{ThemeResource ToggleSwitchFillOff}" />
+                                                <Setter Target="OuterBorder.Stroke" Value="{ThemeResource ToggleSwitchStrokeOff}" />
+                                                <Setter Target="SwitchKnobBounds.Fill" Value="{ThemeResource ToggleSwitchFillOn}" />
+                                                <Setter Target="SwitchKnobBounds.Stroke" Value="{ThemeResource ToggleSwitchStrokeOn}" />
+                                                <Setter Target="SwitchKnobOn.Background" Value="{ThemeResource ToggleSwitchKnobFillOn}" />
+                                                <Setter Target="SwitchKnobOff.Fill" Value="{ThemeResource ToggleSwitchKnobFillOff}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="PointerOver">
+                                            <VisualState.Setters>
+                                                <Setter Target="OuterBorder.Fill" Value="{ThemeResource ToggleSwitchFillOffPointerOver}" />
+                                                <Setter Target="OuterBorder.Stroke" Value="{ThemeResource ToggleSwitchStrokeOffPointerOver}" />
+                                                <Setter Target="SwitchKnobBounds.Fill" Value="{ThemeResource ToggleSwitchFillOnPointerOver}" />
+                                                <Setter Target="SwitchKnobBounds.Stroke" Value="{ThemeResource ToggleSwitchStrokeOnPointerOver}" />
+                                                <Setter Target="SwitchKnobOn.Background" Value="{ThemeResource ToggleSwitchKnobFillOnPointerOver}" />
+                                                <Setter Target="SwitchKnobOff.Fill" Value="{ThemeResource ToggleSwitchKnobFillOffPointerOver}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="Pressed">
+                                            <VisualState.Setters>
+                                                <Setter Target="OuterBorder.Fill" Value="{ThemeResource ToggleSwitchFillOffPressed}" />
+                                                <Setter Target="OuterBorder.Stroke" Value="{ThemeResource ToggleSwitchStrokeOffPressed}" />
+                                                <Setter Target="SwitchKnobBounds.Fill" Value="{ThemeResource ToggleSwitchFillOnPressed}" />
+                                                <Setter Target="SwitchKnobBounds.Stroke" Value="{ThemeResource ToggleSwitchStrokeOnPressed}" />
+                                                <Setter Target="SwitchKnobOn.Background" Value="{ThemeResource ToggleSwitchKnobFillOnPressed}" />
+                                                <Setter Target="SwitchKnobOff.Fill" Value="{ThemeResource ToggleSwitchKnobFillOffPressed}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="Disabled">
+                                            <VisualState.Setters>
+                                                <Setter Target="OuterBorder.Fill" Value="{ThemeResource ToggleSwitchFillOffDisabled}" />
+                                                <Setter Target="OuterBorder.Stroke" Value="{ThemeResource ToggleSwitchStrokeOffDisabled}" />
+                                                <Setter Target="SwitchKnobBounds.Fill" Value="{ThemeResource ToggleSwitchFillOnDisabled}" />
+                                                <Setter Target="SwitchKnobBounds.Stroke" Value="{ThemeResource ToggleSwitchStrokeOnDisabled}" />
+                                                <Setter Target="SwitchKnobOn.Background" Value="{ThemeResource ToggleSwitchKnobFillOnDisabled}" />
+                                                <Setter Target="SwitchKnobOff.Fill" Value="{ThemeResource ToggleSwitchKnobFillOffDisabled}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                    </VisualStateGroup>
+
+                                    <VisualStateGroup x:Name="ToggleStates">
+                                        <VisualState x:Name="Off">
+                                            <VisualState.Setters>
+                                                <Setter Target="KnobTranslateTransform.X" Value="0" />
+                                                <Setter Target="OuterBorder.Opacity" Value="1" />
+                                                <Setter Target="SwitchKnobBounds.Opacity" Value="0" />
+                                                <Setter Target="SwitchKnobOn.Opacity" Value="0" />
+                                                <Setter Target="SwitchKnobOff.Opacity" Value="1" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="On">
+                                            <VisualState.Setters>
+                                                <Setter Target="KnobTranslateTransform.X" Value="20" />
+                                                <Setter Target="OuterBorder.Opacity" Value="0" />
+                                                <Setter Target="SwitchKnobBounds.Opacity" Value="1" />
+                                                <Setter Target="SwitchKnobOn.Opacity" Value="1" />
+                                                <Setter Target="SwitchKnobOff.Opacity" Value="0" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                    </VisualStateGroup>
+                                </VisualStateManager.VisualStateGroups>
+
+                                <Grid Width="40"
+                                      Height="20"
+                                      Control.IsTemplateFocusTarget="True">
+                                    <Rectangle x:Name="OuterBorder"
+                                               Width="40"
+                                               Height="20"
+                                               RadiusX="10"
+                                               RadiusY="10"
+                                               Fill="{ThemeResource ToggleSwitchFillOff}"
+                                               Stroke="{ThemeResource ToggleSwitchStrokeOff}"
+                                               StrokeThickness="{ThemeResource ToggleSwitchOuterBorderStrokeThickness}" />
+                                    <Rectangle x:Name="SwitchKnobBounds"
+                                               Width="40"
+                                               Height="20"
+                                               RadiusX="10"
+                                               RadiusY="10"
+                                               Fill="{ThemeResource ToggleSwitchFillOn}"
+                                               Stroke="{ThemeResource ToggleSwitchStrokeOn}"
+                                               StrokeThickness="{ThemeResource ToggleSwitchOnStrokeThickness}"
+                                               Opacity="0" />
+                                    <Grid x:Name="SwitchKnob"
+                                          Width="20"
+                                          Height="20"
+                                          HorizontalAlignment="Left">
+                                        <Border x:Name="SwitchKnobOn"
+                                                Width="12"
+                                                Height="12"
+                                                Margin="0,0,1,0"
+                                                HorizontalAlignment="Center"
+                                                Background="{ThemeResource ToggleSwitchKnobFillOn}"
+                                                BorderBrush="{ThemeResource ToggleSwitchKnobStrokeOn}"
+                                                BackgroundSizing="OuterBorderEdge"
+                                                CornerRadius="7"
+                                                Opacity="0" />
+                                        <Rectangle x:Name="SwitchKnobOff"
+                                                   Width="12"
+                                                   Height="12"
+                                                   Margin="-1,0,0,0"
+                                                   HorizontalAlignment="Center"
+                                                   Fill="{ThemeResource ToggleSwitchKnobFillOff}"
+                                                   RadiusX="7"
+                                                   RadiusY="7" />
+                                        <Grid.RenderTransform>
+                                            <TranslateTransform x:Name="KnobTranslateTransform" />
+                                        </Grid.RenderTransform>
+                                    </Grid>
+                                    <primitives:Thumb x:Name="SwitchThumb"
+                                                      AutomationProperties.AccessibilityView="Raw">
+                                        <primitives:Thumb.Template>
+                                            <ControlTemplate TargetType="primitives:Thumb">
+                                                <Rectangle Fill="Transparent" />
+                                            </ControlTemplate>
+                                        </primitives:Thumb.Template>
+                                    </primitives:Thumb>
+                                </Grid>
+                            </Grid>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+        </Grid.Resources>
+
         <Border Background="Transparent"
                 BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
                 BorderThickness="1"

--- a/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
@@ -147,6 +147,31 @@ public sealed partial class TrayMenuWindow : WindowEx
     private Brush SecondaryTextBrush =>
         _secondaryTextBrush ??= (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"];
 
+    internal static ToggleSwitch CreateMenuToggleSwitch(bool isOn, string automationName, bool isEnabled = true)
+    {
+        var toggle = new ToggleSwitch
+        {
+            IsOn = isOn,
+            OnContent = string.Empty,
+            OffContent = string.Empty,
+            MinWidth = 0,
+            Width = 40,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            VerticalAlignment = VerticalAlignment.Center,
+            IsEnabled = isEnabled,
+            Style = (Style)Application.Current.Resources["TrayMenuInstantToggleSwitchStyle"]
+        };
+        AutomationProperties.SetName(toggle, automationName);
+        return toggle;
+    }
+
+    internal static void SetMenuToggleSwitchState(ToggleSwitch toggle, bool isOn, bool isEnabled)
+    {
+        toggle.IsEnabled = isEnabled;
+        if (toggle.IsOn != isOn)
+            toggle.IsOn = isOn;
+    }
+
     public TrayMenuWindow() : this(ownerMenu: null)
     {
     }
@@ -378,7 +403,6 @@ public sealed partial class TrayMenuWindow : WindowEx
         {
             button.Background = s_transparentBrush;
         };
-
         MenuPanel.Children.Add(button);
         _itemCount++;
     }
@@ -598,15 +622,7 @@ public sealed partial class TrayMenuWindow : WindowEx
         AutomationProperties.SetAccessibilityView(stateLabel, AccessibilityView.Raw);
         trailing.Children.Add(stateLabel);
 
-        var toggle = new ToggleSwitch
-        {
-            IsOn = isOn,
-            OnContent = null,
-            OffContent = null,
-            MinWidth = 0,
-            VerticalAlignment = VerticalAlignment.Center
-        };
-        AutomationProperties.SetName(toggle, title);
+        var toggle = CreateMenuToggleSwitch(isOn, title);
         toggle.Toggled += (s, e) =>
         {
             stateLabel.Text = toggle.IsOn ? "On" : "Off";
@@ -1312,7 +1328,7 @@ public sealed class TrayMenuFlyoutItem
     public bool IsToggle { get; set; }
     public bool IsOn { get; set; }
 
-    // Optional secondary description text shown below the title (for ToggleSwitch rows).
+    // Optional secondary description text shown below the title (for toggle rows).
     public string? Description { get; set; }
 
     // Free-form content: when set, the renderer drops the row in via

--- a/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/TrayMenuWindow.xaml.cs
@@ -147,7 +147,7 @@ public sealed partial class TrayMenuWindow : WindowEx
     private Brush SecondaryTextBrush =>
         _secondaryTextBrush ??= (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"];
 
-    internal static ToggleSwitch CreateMenuToggleSwitch(bool isOn, string automationName, bool isEnabled = true)
+    internal ToggleSwitch CreateMenuToggleSwitch(bool isOn, string automationName, bool isEnabled = true)
     {
         var toggle = new ToggleSwitch
         {
@@ -159,7 +159,7 @@ public sealed partial class TrayMenuWindow : WindowEx
             HorizontalAlignment = HorizontalAlignment.Right,
             VerticalAlignment = VerticalAlignment.Center,
             IsEnabled = isEnabled,
-            Style = (Style)Application.Current.Resources["TrayMenuInstantToggleSwitchStyle"]
+            Style = (Style)RootGrid.Resources["TrayMenuInstantToggleSwitchStyle"]
         };
         AutomationProperties.SetName(toggle, automationName);
         return toggle;


### PR DESCRIPTION

<img width="349" height="484" alt="image" src="https://github.com/user-attachments/assets/e69b8166-0e59-4cb5-814f-61480a64c1eb" />

## Summary
The tray menu rebuilt fresh WinUI toggles on each open, which exposed the default switch reposition animation as a visible off-to-on flicker. This change keeps the standard WinUI switch visuals while making the tray menu switch state apply instantly.

- Add a tray-menu-local `ToggleSwitch` template that preserves the WinUI switch dimensions, radii, and theme resources.
- Remove the `RepositionThemeAnimation` path only for tray menu toggles, so the connection and permissions toggles do not flicker when menus open.
- Route the gateway connection and permissions toggles through a shared helper so state updates stay centralized.
- Resolve the menu-local style from the `TrayMenuWindow` instance so the popup can open reliably after scoping the style locally.

## XAML review notes
- Uses existing `ToggleSwitch*` theme resources for Light/Dark/High Contrast behavior.
- Scopes the style to `TrayMenuWindow` to avoid broad app-wide control template changes.
- Does not alter the public `ToggleSwitch` shape, brushes, or sizing.

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`