### PR TITLE
fix: setup engine slow-machine fixes and config audit

### DIFF
--- a/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
@@ -88,6 +88,8 @@ public sealed partial class ProgressPage : Page
             var steps = BuildSteps(config);
             _pipeline = new SetupPipeline(steps);
             _pipeline.StepProgress += OnStepProgress;
+            _pipeline.RollbackConfirmationRequired = (stepId, message) =>
+                PromptRollbackConfirmation(stepId, message);
 
             var result = await Task.Run(() => _pipeline.RunAsync(ctx), cts.Token);
             sw.Stop();
@@ -246,6 +248,48 @@ public sealed partial class ProgressPage : Page
         => SetupStepFactory.BuildDefaultSteps()
             .Where(step => step is not RunGatewayWizardStep)
             .ToList();
+
+    /// <summary>
+    /// Prompts the user to confirm rollback after a step failure.
+    /// Called from the pipeline background thread; marshals to UI thread for the dialog.
+    /// </summary>
+    private Task<bool> PromptRollbackConfirmation(string stepId, string? message)
+    {
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var enqueued = DispatcherQueue.TryEnqueue(async () =>
+        {
+            try
+            {
+                var dialog = new ContentDialog
+                {
+                    Title = "Setup Failed",
+                    Content = $"Step '{stepId}' failed:\n{message ?? "Unknown error"}\n\nWould you like to rollback (undo all changes) or keep the current state for debugging?",
+                    PrimaryButtonText = "Rollback",
+                    SecondaryButtonText = "Keep for debugging",
+                    DefaultButton = ContentDialogButton.Primary,
+                    XamlRoot = this.XamlRoot,
+                };
+
+                var result = await dialog.ShowAsync();
+                // Dismiss (ESC/close) defaults to rollback — the safer choice after failure
+                tcs.TrySetResult(result != ContentDialogResult.Secondary);
+            }
+            catch (Exception ex)
+            {
+                // If dialog fails, default to rollback
+                tcs.TrySetResult(true);
+            }
+        });
+
+        if (!enqueued)
+        {
+            // Dispatcher shut down (window closed) — default to rollback to avoid hanging
+            tcs.TrySetResult(true);
+        }
+
+        return tcs.Task;
+    }
 }
 
 // ─── Step Row UI Element ───

--- a/src/OpenClaw.SetupEngine/SetupContext.cs
+++ b/src/OpenClaw.SetupEngine/SetupContext.cs
@@ -31,8 +31,9 @@ public sealed class SetupConfig
     public CapabilitiesConfig Capabilities { get; set; } = new();
     public TraySettingsConfig Settings { get; set; } = new();
     public PairingConfig Pairing { get; set; } = new();
+    public WizardConfig Wizard { get; set; } = new();
 
-    public string EffectiveGatewayUrl => GatewayUrl ?? $"ws://localhost:{GatewayPort}";
+    public string EffectiveGatewayUrl => GatewayUrl ?? $"ws://127.0.0.1:{GatewayPort}";
 
     public static SetupConfig LoadFromFile(string path)
     {
@@ -89,6 +90,8 @@ public sealed class WslConfig
     public bool UseWindowsTimezone { get; set; } = true;
     public string? Memory { get; set; }
     public string? Swap { get; set; }
+    public int CommandTimeoutSeconds { get; set; } = 60;
+    public int InstallTimeoutSeconds { get; set; } = 600;
 
     public static bool IsValidLinuxUserName(string value)
         => s_linuxUserNamePattern.IsMatch(value);
@@ -102,6 +105,7 @@ public sealed class GatewayConfig
     public string? InstallUrl { get; set; }
     public string? Version { get; set; }
     public int HealthTimeoutSeconds { get; set; } = 90;
+    public int WindowsPortTimeoutSeconds { get; set; } = 30;
     public string ReloadMode { get; set; } = "hot";
     public string AuthMode { get; set; } = "token";
     public Dictionary<string, string>? ExtraConfig { get; set; }
@@ -232,6 +236,15 @@ public sealed class PairingConfig
     // TODO: Wire OperatorScopes/NodeScopes/CliScopes into pairing requests
     // when the gateway protocol supports scoped token issuance.
     public int TimeoutSeconds { get; set; } = 60;
+    public int StabilizationDelaySeconds { get; set; } = 5;
+}
+
+// ─── Wizard Configuration ───
+
+public sealed class WizardConfig
+{
+    public int RequestTimeoutSeconds { get; set; } = 30;
+    public int AuthStepTimeoutSeconds { get; set; } = 300;
 }
 
 // ─── Step Result ───
@@ -273,6 +286,12 @@ public sealed class SetupContext
 
     // WSL PATH prefix using configured user
     public string WslPathPrefix => WslConstants.GetPathPrefix(Config.Wsl.User);
+
+    /// <summary>Standard timeout for WSL commands (probes, state changes, pairing CLIs).</summary>
+    public TimeSpan WslCommandTimeout => TimeSpan.FromSeconds(Config.Wsl.CommandTimeoutSeconds);
+
+    /// <summary>Extended timeout for network downloads and bulk I/O (distro import, CLI install).</summary>
+    public TimeSpan WslInstallTimeout => TimeSpan.FromSeconds(Config.Wsl.InstallTimeoutSeconds);
 
     public SetupContext(SetupConfig config, SetupLogger logger, TransactionJournal journal, CommandRunner commands, CancellationToken ct)
     {

--- a/src/OpenClaw.SetupEngine/SetupPipeline.cs
+++ b/src/OpenClaw.SetupEngine/SetupPipeline.cs
@@ -73,6 +73,14 @@ public sealed class SetupPipeline
 
     public event EventHandler<StepProgressEvent>? StepProgress;
 
+    /// <summary>
+    /// When set, the pipeline calls this delegate before rolling back on failure.
+    /// The delegate receives the failed step ID and error message, and returns true to rollback
+    /// or false to keep the current state for debugging. If null, rollback proceeds automatically
+    /// when <see cref="SetupConfig.RollbackOnFailure"/> is true (headless/CLI behavior).
+    /// </summary>
+    public Func<string, string?, Task<bool>>? RollbackConfirmationRequired { get; set; }
+
     public SetupPipeline(IEnumerable<SetupStep> steps)
     {
         _steps = steps.ToList();
@@ -162,8 +170,29 @@ public sealed class SetupPipeline
 
             if (ctx.Config.RollbackOnFailure)
             {
-                await RollbackFailedStep(step, ctx);
-                await RollbackCompletedSteps(ctx);
+                var shouldRollback = true;
+
+                if (RollbackConfirmationRequired != null)
+                {
+                    try
+                    {
+                        shouldRollback = await RollbackConfirmationRequired(step.Id, result.Message);
+                    }
+                    catch (Exception ex)
+                    {
+                        ctx.Logger.Warn($"Rollback confirmation callback failed: {ex.Message} — proceeding with rollback");
+                    }
+                }
+
+                if (shouldRollback)
+                {
+                    await RollbackFailedStep(step, ctx);
+                    await RollbackCompletedSteps(ctx);
+                }
+                else
+                {
+                    ctx.Logger.Info("Rollback skipped by user — keeping current state for debugging");
+                }
             }
 
             ctx.Journal.RecordPipelineEvent("pipeline_failed", $"step={step.Id}, message={result.Message}");

--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -58,7 +58,7 @@ public sealed class CleanupStaleDistroStep : SetupStep
     public override async Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)
     {
         var distro = ctx.DistroName!;
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], ctx.WslCommandTimeout, ct: ct);
         if (list.ExitCode != 0)
             return StepResult.Ok("WSL not available or no distros — nothing to clean");
 
@@ -81,7 +81,7 @@ public sealed class CleanupStaleDistroStep : SetupStep
             {
                 ctx.Logger.Info($"Removing orphaned WSL directory: {wslDir}");
                 // Shut down WSL VM to release VHD locks
-                await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--shutdown"], TimeSpan.FromSeconds(30), ct: ct);
+                await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--shutdown"], ctx.WslCommandTimeout, ct: ct);
                 await Task.Delay(2000, ct);
 
                 // Retry deletion — VHD may still be locked briefly after WSL shutdown
@@ -111,17 +111,17 @@ public sealed class CleanupStaleDistroStep : SetupStep
         ctx.Logger.Decision($"Found existing distro '{distro}'", "terminating and unregistering");
 
         // Terminate first (stops gateway service), then shut WSL down to release VHD/port locks.
-        await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--terminate", distro], TimeSpan.FromSeconds(30), ct: ct);
-        await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--shutdown"], TimeSpan.FromSeconds(30), ct: ct);
+        await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--terminate", distro], ctx.WslCommandTimeout, ct: ct);
+        await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--shutdown"], ctx.WslCommandTimeout, ct: ct);
         await Task.Delay(2000, ct); // Let port release
 
-        var unregister = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--unregister", distro], TimeSpan.FromSeconds(60), ct: ct);
+        var unregister = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--unregister", distro], ctx.WslCommandTimeout, ct: ct);
         if (unregister.ExitCode != 0)
         {
             ctx.Logger.Warn($"First unregister attempt failed (exit {unregister.ExitCode}); forcing WSL shutdown and retrying");
-            await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--shutdown"], TimeSpan.FromSeconds(30), ct: ct);
+            await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--shutdown"], ctx.WslCommandTimeout, ct: ct);
             await Task.Delay(3000, ct);
-            unregister = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--unregister", distro], TimeSpan.FromSeconds(60), ct: ct);
+            unregister = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--unregister", distro], ctx.WslCommandTimeout, ct: ct);
         }
 
         if (unregister.ExitCode == 0)
@@ -255,14 +255,14 @@ public sealed class PreflightWslStep : SetupStep
 
     public override async Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)
     {
-        var versionResult = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--version"], TimeSpan.FromSeconds(5), ct: ct);
+        var versionResult = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--version"], ctx.WslCommandTimeout, ct: ct);
         if (versionResult.ExitCode != 0 && LooksUnavailable(versionResult))
         {
             var installResult = await InstallWslPlatformAsync(ctx, ct);
             if (!installResult.IsSuccess)
                 return installResult;
 
-            versionResult = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--version"], TimeSpan.FromSeconds(5), ct: ct);
+            versionResult = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--version"], ctx.WslCommandTimeout, ct: ct);
         }
 
         if (versionResult.ExitCode != 0)
@@ -300,7 +300,7 @@ public sealed class PreflightWslStep : SetupStep
             if (process.ExitCode != 0)
                 return StepResult.Fail($"WSL platform install failed with exit code {process.ExitCode}.");
 
-            var probe = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--version"], TimeSpan.FromSeconds(5), ct: ct);
+            var probe = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--version"], ctx.WslCommandTimeout, ct: ct);
             if (probe.ExitCode != 0 || LooksUnavailable(probe))
                 return StepResult.Terminal("WSL platform install completed, but Windows still reports WSL unavailable. Reboot Windows, then run setup again.");
 
@@ -415,21 +415,21 @@ public sealed class CreateWslInstanceStep : SetupStep
             var exportPath = Path.Combine(tempDir, "base.tar");
             var export = await ctx.Commands.RunAsync(
                 WslConstants.WslExePath, ["--export", baseDistro, exportPath],
-                TimeSpan.FromMinutes(5), ct: ct);
+                ctx.WslInstallTimeout, ct: ct);
 
             if (export.ExitCode != 0)
             {
                 ctx.Logger.Warn($"Base distro export failed (exit {export.ExitCode}); attempting to install {baseDistro}");
                 var install = await ctx.Commands.RunAsync(
                     WslConstants.WslExePath, ["--install", baseDistro, "--no-launch"],
-                    TimeSpan.FromMinutes(5), ct: ct);
+                    ctx.WslInstallTimeout, ct: ct);
 
                 if (install.ExitCode != 0 && !install.Stdout.Contains("already installed", StringComparison.OrdinalIgnoreCase))
                     return StepResult.Fail($"Failed to install base distro '{baseDistro}' (exit {install.ExitCode}): {install.Stderr}");
 
                 export = await ctx.Commands.RunAsync(
                     WslConstants.WslExePath, ["--export", baseDistro, exportPath],
-                    TimeSpan.FromMinutes(5), ct: ct);
+                    ctx.WslInstallTimeout, ct: ct);
             }
 
             if (export.ExitCode != 0)
@@ -440,7 +440,7 @@ public sealed class CreateWslInstanceStep : SetupStep
 
             var import = await ctx.Commands.RunAsync(
                 WslConstants.WslExePath, ["--import", distro, installPath, exportPath, "--version", "2"],
-                TimeSpan.FromMinutes(5), ct: ct);
+                ctx.WslInstallTimeout, ct: ct);
 
             if (import.ExitCode != 0)
                 return StepResult.Fail($"Failed to import distro: {import.Stderr}");
@@ -456,10 +456,10 @@ public sealed class CreateWslInstanceStep : SetupStep
     public override async Task RollbackAsync(SetupContext ctx, CancellationToken ct)
     {
         var distro = ctx.DistroName!;
-        await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--terminate", distro], TimeSpan.FromSeconds(30), ct: ct);
-        await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--shutdown"], TimeSpan.FromSeconds(30), ct: ct);
+        await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--terminate", distro], ctx.WslCommandTimeout, ct: ct);
+        await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--shutdown"], ctx.WslCommandTimeout, ct: ct);
         await Task.Delay(2000, ct); // Let port/VHD locks release
-        await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--unregister", distro], TimeSpan.FromSeconds(60), ct: ct);
+        await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--unregister", distro], ctx.WslCommandTimeout, ct: ct);
 
         // VHD parent dir cleanup (mirrors old uninstall step 5a)
         var localDataPath = ctx.LocalDataDir;
@@ -541,14 +541,14 @@ useWindowsTimezone={wsl.UseWindowsTimezone.ToString().ToLower()}
             echo "CONFIGURED_OK"
             """;
 
-        var result = await ctx.Commands.RunInWslAsync(distro, script, TimeSpan.FromSeconds(60), ct: ct, user: "root");
+        var result = await ctx.Commands.RunInWslAsync(distro, script, ctx.WslCommandTimeout, ct: ct, user: "root");
 
         if (result.ExitCode != 0 || !result.Stdout.Contains("CONFIGURED_OK"))
             return StepResult.Fail($"Configuration failed: {result.Stderr}");
 
         // Restart WSL to apply wsl.conf (systemd)
         ctx.Logger.Info("Restarting WSL to apply configuration (systemd)");
-        await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--terminate", distro], TimeSpan.FromSeconds(30), ct: ct);
+        await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--terminate", distro], ctx.WslCommandTimeout, ct: ct);
         await Task.Delay(2000, ct); // Let WSL settle
 
         return StepResult.Ok("WSL instance configured");
@@ -566,7 +566,7 @@ public sealed class ValidateWslLockdownStep : SetupStep
         var distro = ctx.DistroName!;
         var wsl = ctx.Config.Wsl;
 
-        var readConf = await ctx.Commands.RunInWslAsync(distro, "cat /etc/wsl.conf", TimeSpan.FromSeconds(15), ct: ct);
+        var readConf = await ctx.Commands.RunInWslAsync(distro, "cat /etc/wsl.conf", ctx.WslCommandTimeout, ct: ct);
         if (readConf.ExitCode != 0)
             return StepResult.Terminal("Cannot read /etc/wsl.conf - WSL configuration may not have been applied");
 
@@ -601,7 +601,7 @@ public sealed class ValidateWslLockdownStep : SetupStep
             + dirChecks
             + "echo LOCKDOWN_VALID\n";
 
-        var verify = await ctx.Commands.RunInWslAsync(distro, verifyScript, TimeSpan.FromSeconds(30), ct: ct);
+        var verify = await ctx.Commands.RunInWslAsync(distro, verifyScript, ctx.WslCommandTimeout, ct: ct);
 
         ctx.Logger.Debug($"Lockdown verify exit={verify.ExitCode} stdout={verify.Stdout.Trim()} stderr={verify.Stderr.Trim()}");
 
@@ -730,7 +730,7 @@ public sealed class InstallCliStep : SetupStep
         // Shell-quote the URL and enforce TLS
         var escapedUrl = installUrl.Replace("'", "'\\''");
         var installScript = $"curl -fsSL --proto '=https' --tlsv1.2 '{escapedUrl}' | bash";
-        var result = await ctx.Commands.RunInWslAsync(distro, installScript, TimeSpan.FromMinutes(5), ct: ct);
+        var result = await ctx.Commands.RunInWslAsync(distro, installScript, ctx.WslInstallTimeout, ct: ct);
 
         if (result.ExitCode != 0)
             return StepResult.Fail($"CLI install failed (exit {result.ExitCode}): {result.Stderr}");
@@ -745,7 +745,7 @@ public sealed class InstallCliStep : SetupStep
 
         foreach (var (cmd, executablePath) in verifyCommands)
         {
-            var verify = await ctx.Commands.RunInWslAsync(distro, cmd, TimeSpan.FromSeconds(15), ct: ct);
+            var verify = await ctx.Commands.RunInWslAsync(distro, cmd, ctx.WslCommandTimeout, ct: ct);
             if (verify.ExitCode == 0 && !string.IsNullOrWhiteSpace(verify.Stdout))
             {
                 if (executablePath != null)
@@ -789,7 +789,7 @@ public sealed class InstallCliStep : SetupStep
             var link = await ctx.Commands.RunInWslAsync(
                 distro,
                 linkCommand,
-                TimeSpan.FromSeconds(15),
+                ctx.WslCommandTimeout,
                 ct: ct,
                 user: "root");
 
@@ -800,7 +800,7 @@ public sealed class InstallCliStep : SetupStep
         var bareVerify = await ctx.Commands.RunInWslAsync(
             distro,
             $"env -i HOME=/home/{user} USER={user} PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin openclaw --version",
-            TimeSpan.FromSeconds(15),
+            ctx.WslCommandTimeout,
             ct: ct);
 
         if (bareVerify.ExitCode != 0 || string.IsNullOrWhiteSpace(bareVerify.Stdout))
@@ -813,7 +813,7 @@ public sealed class InstallCliStep : SetupStep
     public override async Task RollbackAsync(SetupContext ctx, CancellationToken ct)
     {
         var user = ctx.Config.Wsl.User;
-        await ctx.Commands.RunInWslAsync(ctx.DistroName!, $"rm -rf /opt/openclaw /home/{user}/.openclaw /usr/local/bin/openclaw", TimeSpan.FromSeconds(30), ct: ct, user: "root");
+        await ctx.Commands.RunInWslAsync(ctx.DistroName!, $"rm -rf /opt/openclaw /home/{user}/.openclaw /usr/local/bin/openclaw", ctx.WslCommandTimeout, ct: ct, user: "root");
     }
 }
 
@@ -872,7 +872,7 @@ public sealed class ConfigureGatewayStep : SetupStep
             echo "GATEWAY_CONFIGURED"
             """;
 
-        var result = await ctx.Commands.RunInWslAsync(distro, script, TimeSpan.FromSeconds(30), env, ct);
+        var result = await ctx.Commands.RunInWslAsync(distro, script, ctx.WslCommandTimeout, env, ct);
 
         if (result.ExitCode != 0 || !result.Stdout.Contains("GATEWAY_CONFIGURED"))
             return StepResult.Fail($"Gateway configuration failed (exit {result.ExitCode}): {result.Stderr}");
@@ -934,7 +934,7 @@ public sealed class InstallGatewayServiceStep : SetupStep
         var distro = ctx.DistroName!;
 
         var result = await ctx.Commands.RunInWslAsync(
-            distro, $"{ctx.WslPathPrefix} && openclaw gateway install --force", TimeSpan.FromSeconds(60), ct: ct);
+            distro, $"{ctx.WslPathPrefix} && openclaw gateway install --force", ctx.WslCommandTimeout, ct: ct);
 
         if (result.ExitCode != 0)
             return StepResult.Fail($"Service install failed (exit {result.ExitCode}): {result.Stderr}");
@@ -944,7 +944,7 @@ public sealed class InstallGatewayServiceStep : SetupStep
 
     public override async Task RollbackAsync(SetupContext ctx, CancellationToken ct)
     {
-        await ctx.Commands.RunInWslAsync(ctx.DistroName!, $"{ctx.WslPathPrefix} && openclaw gateway uninstall", TimeSpan.FromSeconds(30), ct: ct);
+        await ctx.Commands.RunInWslAsync(ctx.DistroName!, $"{ctx.WslPathPrefix} && openclaw gateway uninstall", ctx.WslCommandTimeout, ct: ct);
     }
 }
 
@@ -962,11 +962,12 @@ public sealed class StartGatewayStep : SetupStep
         // Check for port conflicts before starting
         var portCheck = await ctx.Commands.RunInWslAsync(
             distro, $"ss -tlnp 2>/dev/null | grep ':{ctx.Config.GatewayPort}\\b' || true",
-            TimeSpan.FromSeconds(10), ct: ct);
+            ctx.WslCommandTimeout, ct: ct);
 
         if (!string.IsNullOrWhiteSpace(portCheck.Stdout) && portCheck.Stdout.Contains($":{ctx.Config.GatewayPort}"))
         {
-            if (!portCheck.Stdout.Contains("openclaw", StringComparison.OrdinalIgnoreCase))
+            if (!portCheck.Stdout.Contains("openclaw", StringComparison.OrdinalIgnoreCase)
+                && !portCheck.Stdout.Contains("node", StringComparison.OrdinalIgnoreCase))
             {
                 ctx.Logger.Warn($"Port {ctx.Config.GatewayPort} is in use by another process:\n{portCheck.Stdout.Trim()}");
                 return StepResult.Fail(
@@ -978,7 +979,7 @@ public sealed class StartGatewayStep : SetupStep
 
         // Start the service
         var start = await ctx.Commands.RunInWslAsync(
-            distro, $"{pathCmd} && openclaw gateway start", TimeSpan.FromSeconds(30), ct: ct);
+            distro, $"{pathCmd} && openclaw gateway start", ctx.WslCommandTimeout, ct: ct);
 
         if (start.ExitCode != 0)
         {
@@ -989,10 +990,10 @@ public sealed class StartGatewayStep : SetupStep
                 await ctx.Commands.RunInWslAsync(
                     distro,
                     "systemctl --user reset-failed openclaw-gateway.service",
-                    TimeSpan.FromSeconds(10),
+                    ctx.WslCommandTimeout,
                     ct: ct);
                 await Task.Delay(2000, ct);
-                start = await ctx.Commands.RunInWslAsync(distro, $"{pathCmd} && openclaw gateway start", TimeSpan.FromSeconds(30), ct: ct);
+                start = await ctx.Commands.RunInWslAsync(distro, $"{pathCmd} && openclaw gateway start", ctx.WslCommandTimeout, ct: ct);
                 if (start.ExitCode != 0)
                     return StepResult.Fail($"Gateway start failed after reset: {start.Stderr}");
             }
@@ -1012,12 +1013,19 @@ public sealed class StartGatewayStep : SetupStep
 
             var status = await ctx.Commands.RunInWslAsync(
                 distro, "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:" + ctx.Config.GatewayPort + "/ --max-time 3",
-                TimeSpan.FromSeconds(10), ct: ct);
+                ctx.WslCommandTimeout, ct: ct);
 
             if (status.ExitCode == 0 && status.Stdout.Trim() is "200" or "401" or "403")
             {
-                ctx.Logger.Info($"Gateway is accepting connections (HTTP {status.Stdout.Trim()})");
-                return StepResult.Ok("Gateway running");
+                ctx.Logger.Info($"Gateway is accepting connections inside WSL (HTTP {status.Stdout.Trim()})");
+
+                // WSL2 mirrored networking: port may be healthy inside WSL but not yet
+                // forwarded to the Windows host. Verify Windows-side reachability.
+                var windowsReachable = await WaitForWindowsPortReachable(ctx, ct);
+                if (windowsReachable)
+                    return StepResult.Ok("Gateway running");
+
+                return StepResult.Fail($"Gateway is healthy inside WSL but not reachable from Windows on port {ctx.Config.GatewayPort}. WSL2 port forwarding may not be working.");
             }
 
             ctx.Logger.Debug($"Gateway not yet accepting connections (curl exit={status.ExitCode}, response={status.Stdout.Trim()})");
@@ -1029,13 +1037,13 @@ public sealed class StartGatewayStep : SetupStep
         var statusResult = await ctx.Commands.RunInWslAsync(
             distro,
             "systemctl --user status openclaw-gateway.service 2>&1 || true",
-            TimeSpan.FromSeconds(10),
+            ctx.WslCommandTimeout,
             ct: ct);
 
         var journal = await ctx.Commands.RunInWslAsync(
             distro,
             "journalctl --user-unit openclaw-gateway.service --no-pager -n 30 2>&1 || true",
-            TimeSpan.FromSeconds(10),
+            ctx.WslCommandTimeout,
             ct: ct);
 
         var redactedStatus = RedactTokens(statusResult.Stdout);
@@ -1044,6 +1052,45 @@ public sealed class StartGatewayStep : SetupStep
         ctx.Logger.Error($"Gateway health timeout.\nService status:\n{redactedStatus}\nJournal:\n{redactedJournal}");
 
         return StepResult.Fail($"Gateway did not become healthy within {ctx.Config.Gateway.HealthTimeoutSeconds}s");
+    }
+
+    /// <summary>
+    /// Polls http://127.0.0.1:{port} from the Windows side to verify WSL2 port forwarding is active.
+    /// WSL2 mirrored networking can have a delay between the gateway being healthy inside WSL
+    /// and the port being reachable from the Windows host.
+    /// </summary>
+    private static async Task<bool> WaitForWindowsPortReachable(SetupContext ctx, CancellationToken ct)
+    {
+        var timeoutSeconds = ctx.Config.Gateway.WindowsPortTimeoutSeconds;
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(timeoutSeconds);
+        ctx.Logger.Info("Verifying gateway is reachable from Windows...");
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                var resp = await http.GetAsync($"http://127.0.0.1:{ctx.Config.GatewayPort}/", ct);
+                var code = (int)resp.StatusCode;
+                if (code is 200 or 401 or 403)
+                {
+                    ctx.Logger.Info($"Gateway reachable from Windows (HTTP {code})");
+                    return true;
+                }
+                ctx.Logger.Debug($"Windows port check: unexpected HTTP {code}");
+            }
+            catch (Exception ex)
+            {
+                ctx.Logger.Debug($"Windows port check: {ex.GetType().Name} — {ex.Message}");
+            }
+
+            await Task.Delay(1000, ct);
+        }
+
+        ctx.Logger.Error($"Gateway not reachable from Windows within {timeoutSeconds}s");
+        return false;
     }
 
     internal static string RedactTokens(string text)
@@ -1062,7 +1109,7 @@ public sealed class StartGatewayStep : SetupStep
         var distro = ctx.DistroName!;
 
         // Check if distro is running before trying systemctl stop
-        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], ctx.WslCommandTimeout, ct: ct);
         var distros = list.Stdout
             .Replace("\0", "").Replace("\uFEFF", "")
             .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
@@ -1075,7 +1122,7 @@ public sealed class StartGatewayStep : SetupStep
         }
 
         // Check distro state — only stop if Running
-        var verbose = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--verbose"], TimeSpan.FromSeconds(15), ct: ct);
+        var verbose = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--verbose"], ctx.WslCommandTimeout, ct: ct);
         var isRunning = verbose.Stdout
             .Replace("\0", "").Replace("\uFEFF", "")
             .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
@@ -1095,7 +1142,7 @@ public sealed class StartGatewayStep : SetupStep
         {
             await ctx.Commands.RunInWslAsync(
                 distro, "bash -c 'systemctl --user stop openclaw-gateway 2>&1 || true'",
-                TimeSpan.FromSeconds(10), ct: cts.Token);
+                ctx.WslCommandTimeout, ct: cts.Token);
             ctx.Logger.Info("[Uninstall] Stopped gateway service");
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
@@ -1129,7 +1176,7 @@ public sealed class MintBootstrapTokenStep : SetupStep
         };
 
         var mint = await ctx.Commands.RunInWslAsync(
-            distro, $"{ctx.WslPathPrefix} && openclaw qr --json", TimeSpan.FromSeconds(30), env, ct);
+            distro, $"{ctx.WslPathPrefix} && openclaw qr --json", ctx.WslCommandTimeout, env, ct);
 
         if (mint.ExitCode == 0 && !string.IsNullOrWhiteSpace(mint.Stdout))
         {
@@ -1239,7 +1286,7 @@ public sealed class PairOperatorStep : SetupStep
             // Phase 1: Initial connect (may get PAIRING_REQUIRED)
             client = new OpenClawGatewayClient(gatewayUrl, token, logger: wsLogger, identityPath: identityPath);
             client.UseV2Signature = true; // Local gateway uses v2 signature format
-            var phase1Result = await WaitForConnectionOrPairing(client, ctx, TimeSpan.FromSeconds(15), ct);
+            var phase1Result = await WaitForConnectionOrPairing(client, ctx, TimeSpan.FromSeconds(ctx.Config.Pairing.TimeoutSeconds), ct);
 
             if (phase1Result == ConnectionOutcome.Connected)
             {
@@ -1269,7 +1316,7 @@ public sealed class PairOperatorStep : SetupStep
                 // Phase 2: Reconnect — the device should now be approved
                 client = new OpenClawGatewayClient(gatewayUrl, token, logger: wsLogger, identityPath: identityPath);
                 client.UseV2Signature = true;
-                var phase2Result = await WaitForConnectionOrPairing(client, ctx, TimeSpan.FromSeconds(20), ct);
+                var phase2Result = await WaitForConnectionOrPairing(client, ctx, TimeSpan.FromSeconds(ctx.Config.Pairing.TimeoutSeconds), ct);
 
                 if (phase2Result == ConnectionOutcome.Connected)
                 {
@@ -1330,7 +1377,7 @@ public sealed class PairOperatorStep : SetupStep
         // Without this delay, the gateway accepts the deviceToken connect within grace
         // but would later reject the tray's identical connect as "metadata-upgrade".
         ctx.Logger.Info("Waiting for gateway grace period to expire before finalization...");
-        await Task.Delay(TimeSpan.FromSeconds(5), ct);
+        await Task.Delay(TimeSpan.FromSeconds(ctx.Config.Pairing.StabilizationDelaySeconds), ct);
 
         // Connect exactly as the tray would: pass deviceToken as the credential
         var finalClient = new OpenClawGatewayClient(gatewayUrl, deviceToken, logger: wsLogger, identityPath: identityPath);
@@ -1338,7 +1385,7 @@ public sealed class PairOperatorStep : SetupStep
 
         try
         {
-            var result = await WaitForConnectionOrPairing(finalClient, ctx, TimeSpan.FromSeconds(15), ct);
+            var result = await WaitForConnectionOrPairing(finalClient, ctx, TimeSpan.FromSeconds(ctx.Config.Pairing.TimeoutSeconds), ct);
 
             if (result == ConnectionOutcome.Connected)
             {
@@ -1364,7 +1411,7 @@ public sealed class PairOperatorStep : SetupStep
                 // One more connect to confirm
                 finalClient = new OpenClawGatewayClient(gatewayUrl, deviceToken, logger: wsLogger, identityPath: identityPath);
                 finalClient.UseV2Signature = true;
-                var finalResult = await WaitForConnectionOrPairing(finalClient, ctx, TimeSpan.FromSeconds(15), ct);
+                var finalResult = await WaitForConnectionOrPairing(finalClient, ctx, TimeSpan.FromSeconds(ctx.Config.Pairing.TimeoutSeconds), ct);
 
                 if (finalResult == ConnectionOutcome.Connected)
                 {
@@ -1402,7 +1449,7 @@ public sealed class PairOperatorStep : SetupStep
             var preview = await ctx.Commands.RunInWslAsync(
                 distro,
                 $"""{ctx.WslPathPrefix} && openclaw devices approve --latest --json""",
-                TimeSpan.FromSeconds(30), env, ct);
+                ctx.WslCommandTimeout, env, ct);
 
             ctx.Logger.Info($"Approve preview: exit={preview.ExitCode}");
 
@@ -1428,7 +1475,7 @@ public sealed class PairOperatorStep : SetupStep
         var approve = await ctx.Commands.RunInWslAsync(
             distro,
             $"""{ctx.WslPathPrefix} && {ApprovalRequestHelper.ApprovalCommand(ApprovalRequestKind.Device)}""",
-            TimeSpan.FromSeconds(30), approvalEnv, ct);
+            ctx.WslCommandTimeout, approvalEnv, ct);
 
         ctx.Logger.Info($"Approve result: exit={approve.ExitCode}");
 
@@ -1450,16 +1497,14 @@ public sealed class PairOperatorStep : SetupStep
             ctx.Logger.Debug($"Operator connection status: {status}");
             if (status == ConnectionStatus.Connected)
                 tcs.TrySetResult(ConnectionOutcome.Connected);
-            else if (status == ConnectionStatus.Error)
-                tcs.TrySetResult(ConnectionOutcome.Error);
             else if (status == ConnectionStatus.Disconnected)
             {
                 // Check if pairing was required — client sets IsPairingRequired before disconnect
                 if (client.IsPairingRequired)
                     tcs.TrySetResult(ConnectionOutcome.PairingRequired);
-                else
-                    tcs.TrySetResult(ConnectionOutcome.Error);
+                // Otherwise let the WebSocket auto-reconnect retry; timeout catches dead gateways
             }
+            // Error: let auto-reconnect handle transient failures; timeout catches dead gateways
         }
 
         client.StatusChanged += OnStatusChanged;
@@ -1575,7 +1620,7 @@ public sealed class PairOperatorStep : SetupStep
 
             if (string.IsNullOrWhiteSpace(token)) return;
 
-            var gatewayUrl = ctx.GatewayUrl ?? "ws://localhost:18789";
+            var gatewayUrl = ctx.GatewayUrl ?? ctx.Config.EffectiveGatewayUrl;
             var httpBase = gatewayUrl
                 .Replace("ws://", "http://", StringComparison.OrdinalIgnoreCase)
                 .Replace("wss://", "https://", StringComparison.OrdinalIgnoreCase)
@@ -1622,7 +1667,7 @@ public sealed class PairNodeStep : SetupStep
         try
         {
             using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
-            var resp = await http.GetAsync($"http://localhost:{ctx.Config.GatewayPort}/", ct);
+            var resp = await http.GetAsync($"http://127.0.0.1:{ctx.Config.GatewayPort}/", ct);
             ctx.Logger.Debug($"Gateway health check: HTTP {(int)resp.StatusCode}");
         }
         catch (Exception ex)
@@ -1642,7 +1687,7 @@ public sealed class PairNodeStep : SetupStep
             // Register capabilities BEFORE connect — gateway stores them from hello message
             RegisterCapabilitiesFromConfig(client, ctx);
 
-            var outcome = await WaitForNodeConnection(client, ctx, TimeSpan.FromSeconds(15), ct);
+            var outcome = await WaitForNodeConnection(client, ctx, TimeSpan.FromSeconds(ctx.Config.Pairing.TimeoutSeconds), ct);
 
             if (outcome.Outcome == NodeConnectionOutcome.Connected)
             {
@@ -1672,7 +1717,7 @@ public sealed class PairNodeStep : SetupStep
                 client.UseV2Signature = true;
                 RegisterCapabilitiesFromConfig(client, ctx);
 
-                outcome = await WaitForNodeConnection(client, ctx, TimeSpan.FromSeconds(20), ct);
+                outcome = await WaitForNodeConnection(client, ctx, TimeSpan.FromSeconds(ctx.Config.Pairing.TimeoutSeconds), ct);
                 if (outcome.Outcome == NodeConnectionOutcome.Connected)
                 {
                     ctx.NodeDeviceId = client.ShortDeviceId;
@@ -1728,14 +1773,14 @@ public sealed class PairNodeStep : SetupStep
 
         // Wait for grace period (same as operator finalization)
         ctx.Logger.Info("Waiting for gateway grace period before node finalization...");
-        await Task.Delay(TimeSpan.FromSeconds(5), ct);
+        await Task.Delay(TimeSpan.FromSeconds(ctx.Config.Pairing.StabilizationDelaySeconds), ct);
 
         var finalClient = new WindowsNodeClient(gatewayUrl, nodeToken, identityPath, logger: wsLogger);
         finalClient.UseV2Signature = true;
 
         try
         {
-            var result = await WaitForNodeConnection(finalClient, ctx, TimeSpan.FromSeconds(15), ct);
+            var result = await WaitForNodeConnection(finalClient, ctx, TimeSpan.FromSeconds(ctx.Config.Pairing.TimeoutSeconds), ct);
 
             if (result.Outcome == NodeConnectionOutcome.Connected)
             {
@@ -1758,7 +1803,7 @@ public sealed class PairNodeStep : SetupStep
 
                 finalClient = new WindowsNodeClient(gatewayUrl, nodeToken, identityPath, logger: wsLogger);
                 finalClient.UseV2Signature = true;
-                var finalResult = await WaitForNodeConnection(finalClient, ctx, TimeSpan.FromSeconds(15), ct);
+                var finalResult = await WaitForNodeConnection(finalClient, ctx, TimeSpan.FromSeconds(ctx.Config.Pairing.TimeoutSeconds), ct);
 
                 if (finalResult.Outcome == NodeConnectionOutcome.Connected)
                 {
@@ -1796,15 +1841,13 @@ public sealed class PairNodeStep : SetupStep
             ctx.Logger.Debug($"Node connection status: {status}");
             if (status == ConnectionStatus.Connected)
                 tcs.TrySetResult(new NodeConnectionResult(NodeConnectionOutcome.Connected));
-            else if (status == ConnectionStatus.Error)
-                tcs.TrySetResult(new NodeConnectionResult(NodeConnectionOutcome.Error));
             else if (status == ConnectionStatus.Disconnected)
             {
                 if (client.IsPendingApproval)
                     tcs.TrySetResult(new NodeConnectionResult(NodeConnectionOutcome.PairingRequired, pairingRequestId));
-                else
-                    tcs.TrySetResult(new NodeConnectionResult(NodeConnectionOutcome.Error));
+                // Otherwise let the WebSocket auto-reconnect retry; timeout catches dead gateways
             }
+            // Error: let auto-reconnect handle transient failures; timeout catches dead gateways
         }
 
         void OnPairingStatusChanged(object? sender, PairingStatusEventArgs args)
@@ -1848,7 +1891,7 @@ public sealed class PairNodeStep : SetupStep
             var pending = await ctx.Commands.RunInWslAsync(
                 distro,
                 $"""{ctx.WslPathPrefix} && openclaw nodes list --json""",
-                TimeSpan.FromSeconds(30), env, ct);
+                ctx.WslCommandTimeout, env, ct);
 
             ctx.Logger.Info($"Node pending list: exit={pending.ExitCode}");
 
@@ -1874,7 +1917,7 @@ public sealed class PairNodeStep : SetupStep
         var approve = await ctx.Commands.RunInWslAsync(
             distro,
             $"""{ctx.WslPathPrefix} && {ApprovalRequestHelper.ApprovalCommand(approvalKind)}""",
-            TimeSpan.FromSeconds(30), approvalEnv, ct);
+            ctx.WslCommandTimeout, approvalEnv, ct);
 
         ctx.Logger.Info($"Node approve result: exit={approve.ExitCode}");
 
@@ -1934,7 +1977,7 @@ public sealed class VerifyEndToEndStep : SetupStep
         // Verify gateway is still healthy
         var distro = ctx.DistroName!;
         var status = await ctx.Commands.RunInWslAsync(
-            distro, $"{ctx.WslPathPrefix} && openclaw gateway status --json", TimeSpan.FromSeconds(15), ct: ct);
+            distro, $"{ctx.WslPathPrefix} && openclaw gateway status --json", ctx.WslCommandTimeout, ct: ct);
 
         if (status.ExitCode != 0 || !status.Stdout.Contains("running", StringComparison.OrdinalIgnoreCase))
             return StepResult.Fail("Gateway is not running");
@@ -1997,7 +2040,7 @@ public sealed class VerifyEndToEndStep : SetupStep
             var preview = await ctx.Commands.RunInWslAsync(
                 distro,
                 $"""{pathPrefix} && openclaw devices approve --latest --json""",
-                TimeSpan.FromSeconds(15), env, ct);
+                ctx.WslCommandTimeout, env, ct);
 
             if (preview.Stdout.Contains("No pending", StringComparison.OrdinalIgnoreCase) ||
                 preview.Stderr.Contains("No pending", StringComparison.OrdinalIgnoreCase))
@@ -2013,7 +2056,7 @@ public sealed class VerifyEndToEndStep : SetupStep
                 var approve = await ctx.Commands.RunInWslAsync(
                     distro,
                     $"""{pathPrefix} && {ApprovalRequestHelper.ApprovalCommand(ApprovalRequestKind.Device)}""",
-                    TimeSpan.FromSeconds(15), approvalEnv, ct);
+                    ctx.WslCommandTimeout, approvalEnv, ct);
 
                 if (approve.ExitCode != 0)
                     return StepResult.Fail($"Device approval drain failed for {parsed.RequestId} (exit {approve.ExitCode}): {approve.Stdout.Trim()} {approve.Stderr.Trim()}".Trim());
@@ -2045,7 +2088,7 @@ public sealed class VerifyEndToEndStep : SetupStep
             var nodeList = await ctx.Commands.RunInWslAsync(
                 distro,
                 $"""{pathPrefix} && openclaw nodes list --json""",
-                TimeSpan.FromSeconds(15), env, ct);
+                ctx.WslCommandTimeout, env, ct);
 
             var parsed = ApprovalRequestHelper.TryReadPendingRequestIds(nodeList.Stdout.Trim());
             if (!parsed.Success)
@@ -2066,7 +2109,7 @@ public sealed class VerifyEndToEndStep : SetupStep
                 var approve = await ctx.Commands.RunInWslAsync(
                     distro,
                     $"""{pathPrefix} && {ApprovalRequestHelper.ApprovalCommand(ApprovalRequestKind.Node)}""",
-                    TimeSpan.FromSeconds(15), approvalEnv, ct);
+                    ctx.WslCommandTimeout, approvalEnv, ct);
 
                 if (approve.ExitCode != 0)
                     return StepResult.Fail($"Node approval drain failed for {requestId} (exit {approve.ExitCode}): {approve.Stdout.Trim()} {approve.Stderr.Trim()}".Trim());
@@ -2126,14 +2169,14 @@ public sealed class VerifyEndToEndStep : SetupStep
 
         // Wait for grace period to expire so this connect is treated as a real metadata change
         ctx.Logger.Info("Waiting for grace period before final operator handshake...");
-        await Task.Delay(TimeSpan.FromSeconds(5), ct);
+        await Task.Delay(TimeSpan.FromSeconds(ctx.Config.Pairing.StabilizationDelaySeconds), ct);
 
         var client = new OpenClawGatewayClient(gatewayUrl, deviceToken, logger: wsLogger, identityPath: identityPath);
         client.UseV2Signature = true;
 
         try
         {
-            var result = await PairOperatorStep.WaitForConnectionOrPairing(client, ctx, TimeSpan.FromSeconds(15), ct);
+            var result = await PairOperatorStep.WaitForConnectionOrPairing(client, ctx, TimeSpan.FromSeconds(ctx.Config.Pairing.TimeoutSeconds), ct);
 
             if (result == PairOperatorStep.ConnectionOutcome.Connected)
             {
@@ -2164,7 +2207,7 @@ public sealed class VerifyEndToEndStep : SetupStep
                 ctx.Logger.Info("Reconnecting with shared token to get fresh device token after approval");
                 client = new OpenClawGatewayClient(gatewayUrl, ctx.SharedGatewayToken!, logger: wsLogger, identityPath: identityPath);
                 client.UseV2Signature = true;
-                var confirmResult = await PairOperatorStep.WaitForConnectionOrPairing(client, ctx, TimeSpan.FromSeconds(15), ct);
+                var confirmResult = await PairOperatorStep.WaitForConnectionOrPairing(client, ctx, TimeSpan.FromSeconds(ctx.Config.Pairing.TimeoutSeconds), ct);
 
                 if (confirmResult == PairOperatorStep.ConnectionOutcome.Connected)
                 {

--- a/src/OpenClaw.SetupEngine/SetupWizardRunner.cs
+++ b/src/OpenClaw.SetupEngine/SetupWizardRunner.cs
@@ -59,7 +59,7 @@ public sealed class SetupWizardRunner
         try
         {
             client = CreateWizardClient(credential, identityPath, wsLogger);
-            var connection = await PairOperatorStep.WaitForConnectionOrPairing(client, _ctx, TimeSpan.FromSeconds(20), ct);
+            var connection = await PairOperatorStep.WaitForConnectionOrPairing(client, _ctx, TimeSpan.FromSeconds(_ctx.Config.Pairing.TimeoutSeconds), ct);
             if (connection == PairOperatorStep.ConnectionOutcome.PairingRequired && _ctx.Config.AutoApprovePairing)
             {
                 _ctx.Logger.Info("Wizard operator pairing required — auto-approving");
@@ -72,14 +72,14 @@ public sealed class SetupWizardRunner
 
                 await Task.Delay(2000, ct);
                 client = CreateWizardClient(credential, identityPath, wsLogger);
-                connection = await PairOperatorStep.WaitForConnectionOrPairing(client, _ctx, TimeSpan.FromSeconds(20), ct);
+                connection = await PairOperatorStep.WaitForConnectionOrPairing(client, _ctx, TimeSpan.FromSeconds(_ctx.Config.Pairing.TimeoutSeconds), ct);
             }
 
             if (connection != PairOperatorStep.ConnectionOutcome.Connected)
                 return StepResult.Fail($"Cannot run gateway wizard because operator connection failed: {connection}");
 
             _ctx.Logger.Info("Starting gateway wizard");
-            var payload = await client.SendWizardRequestAsync("wizard.start", timeoutMs: 30_000);
+            var payload = await client.SendWizardRequestAsync("wizard.start", timeoutMs: _ctx.Config.Wizard.RequestTimeoutSeconds * 1000);
             wizardStarted = true;
 
             var visits = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
@@ -170,14 +170,14 @@ public sealed class SetupWizardRunner
 
                     await Task.Delay(TimeSpan.FromSeconds(3), ct);
                     client = CreateWizardClient(credential, identityPath, wsLogger);
-                    var reconnect = await PairOperatorStep.WaitForConnectionOrPairing(client, _ctx, TimeSpan.FromSeconds(30), ct);
+                    var reconnect = await PairOperatorStep.WaitForConnectionOrPairing(client, _ctx, TimeSpan.FromSeconds(_ctx.Config.Pairing.TimeoutSeconds), ct);
                     if (reconnect != PairOperatorStep.ConnectionOutcome.Connected)
                         return StepResult.Fail($"Gateway wizard reconnect failed after restart: {reconnect}");
 
                     sessionId = "";
                     visits.Clear();
                     discoveredSteps.Clear();
-                    payload = await client.SendWizardRequestAsync("wizard.start", timeoutMs: 30_000);
+                    payload = await client.SendWizardRequestAsync("wizard.start", timeoutMs: _ctx.Config.Wizard.RequestTimeoutSeconds * 1000);
                 }
             }
 
@@ -222,7 +222,7 @@ public sealed class SetupWizardRunner
         try
         {
             _ctx.Logger.Warn("Cancelling gateway wizard session");
-            await client.SendWizardRequestAsync("wizard.cancel", new { sessionId }, timeoutMs: 10_000);
+            await client.SendWizardRequestAsync("wizard.cancel", new { sessionId }, timeoutMs: _ctx.Config.Wizard.RequestTimeoutSeconds * 1000);
         }
         catch (Exception ex)
         {
@@ -237,7 +237,7 @@ public sealed class SetupWizardRunner
             var result = await _ctx.Commands.RunInWslAsync(
                 _ctx.DistroName!,
                 $"{_ctx.WslPathPrefix} && openclaw config set gateway.reload.mode hybrid",
-                TimeSpan.FromSeconds(15),
+                _ctx.WslCommandTimeout,
                 ct: CancellationToken.None);
 
             if (result.ExitCode == 0)
@@ -417,16 +417,17 @@ public sealed class SetupWizardRunner
         return false;
     }
 
-    private static int TimeoutFor(WizardPayload step)
+    private int TimeoutFor(WizardPayload step)
     {
         var text = $"{step.Title} {step.Message}";
-        return text.Contains("device", StringComparison.OrdinalIgnoreCase)
+        var isAuthStep = text.Contains("device", StringComparison.OrdinalIgnoreCase)
             || text.Contains("authorize", StringComparison.OrdinalIgnoreCase)
             || text.Contains("login", StringComparison.OrdinalIgnoreCase)
             || text.Contains("sign in", StringComparison.OrdinalIgnoreCase)
-            || text.Contains("oauth", StringComparison.OrdinalIgnoreCase)
-            ? 300_000
-            : 30_000;
+            || text.Contains("oauth", StringComparison.OrdinalIgnoreCase);
+        return (isAuthStep
+            ? _ctx.Config.Wizard.AuthStepTimeoutSeconds
+            : _ctx.Config.Wizard.RequestTimeoutSeconds) * 1000;
     }
 
     private static bool IsRestartLikeWizardDisconnect(Exception ex)

--- a/src/OpenClaw.SetupEngine/SetupWizardRunner.cs
+++ b/src/OpenClaw.SetupEngine/SetupWizardRunner.cs
@@ -169,8 +169,11 @@ public sealed class SetupWizardRunner
                     client.Dispose();
 
                     await Task.Delay(TimeSpan.FromSeconds(3), ct);
+                    await WaitForGatewayReachableAfterRestart(ct);
                     client = CreateWizardClient(credential, identityPath, wsLogger);
-                    var reconnect = await PairOperatorStep.WaitForConnectionOrPairing(client, _ctx, TimeSpan.FromSeconds(_ctx.Config.Pairing.TimeoutSeconds), ct);
+                    var reconnectTimeout = TimeSpan.FromSeconds(
+                        Math.Max(_ctx.Config.Pairing.TimeoutSeconds, _ctx.Config.Gateway.HealthTimeoutSeconds));
+                    var reconnect = await PairOperatorStep.WaitForConnectionOrPairing(client, _ctx, reconnectTimeout, ct);
                     if (reconnect != PairOperatorStep.ConnectionOutcome.Connected)
                         return StepResult.Fail($"Gateway wizard reconnect failed after restart: {reconnect}");
 
@@ -249,6 +252,37 @@ public sealed class SetupWizardRunner
         {
             _ctx.Logger.Warn($"Failed to reset gateway.reload.mode after wizard: {ex.Message}");
         }
+    }
+
+    private async Task WaitForGatewayReachableAfterRestart(CancellationToken ct)
+    {
+        var gatewayPort = _ctx.Config.GatewayPort;
+        var timeoutSeconds = Math.Max(15, _ctx.Config.Gateway.HealthTimeoutSeconds);
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(timeoutSeconds);
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                var resp = await http.GetAsync($"http://127.0.0.1:{gatewayPort}/", ct);
+                var code = (int)resp.StatusCode;
+                if (code is 200 or 401 or 403)
+                {
+                    _ctx.Logger.Info($"Gateway reachable after restart (HTTP {code})");
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                _ctx.Logger.Debug($"Gateway restart wait: {ex.GetType().Name} — {ex.Message}");
+            }
+
+            await Task.Delay(1000, ct);
+        }
+
+        _ctx.Logger.Warn($"Gateway did not become HTTP-reachable within {timeoutSeconds}s after restart; attempting reconnect anyway");
     }
 
     private string WriteAnswerTemplate(IReadOnlyList<WizardTemplateStep> discoveredSteps, WizardPayload? missingStep)

--- a/src/OpenClaw.SetupEngine/default-config.json
+++ b/src/OpenClaw.SetupEngine/default-config.json
@@ -36,12 +36,15 @@
   "LogLevel": "trace",
   // Override log file path (null = %APPDATA%\OpenClawTray\Logs\Setup\)
   "LogPath": null,
-  // Override gateway WebSocket URL (null = ws://localhost:{GatewayPort})
+  // Override gateway WebSocket URL (null = ws://127.0.0.1:{GatewayPort})
   "GatewayUrl": null,
   // Pre-shared bootstrap token (null = auto-mint during setup)
   "BootstrapToken": null,
   // Rollback completed steps on failure (transactional undo)
   "RollbackOnFailure": false,
+  // Max seconds for a single rollback step (e.g. distro unregister) before it is forcefully cancelled.
+  // Increase on slow machines where WSL teardown takes longer than usual.
+  "RollbackTimeoutSeconds": 60,
 
   // ─── WSL Instance Configuration ───
   // Controls wsl.conf and distro user setup
@@ -63,7 +66,15 @@
     // WSL memory limit (null = WSL default, e.g. "4GB")
     "Memory": null,
     // WSL swap limit (null = WSL default, e.g. "2GB")
-    "Swap": null
+    "Swap": null,
+    // Max seconds for standard WSL commands before they are killed as hung.
+    // Covers: distro probes, systemd checks, wsl.conf writes, service starts, pairing CLIs.
+    // Fast machines finish instantly; this is a safety net, not a delay. Raise for slow I/O.
+    "CommandTimeoutSeconds": 60,
+    // Max seconds for long-running WSL operations before they are killed as hung.
+    // Covers: distro export/import, CLI download & install, apt operations.
+    // These involve network I/O and large file copies — keep generous for slow connections.
+    "InstallTimeoutSeconds": 600
   },
 
   // ─── Gateway Configuration ───
@@ -75,8 +86,13 @@
     "InstallUrl": null,
     // Pin gateway version (null = latest)
     "Version": null,
-    // Seconds to wait for gateway health endpoint before failing
+    // Max seconds to poll the gateway health endpoint (inside WSL) before declaring startup failed.
+    // The gateway is polled repeatedly; fast starts resolve in seconds. Raise for cold-start on ARM64.
     "HealthTimeoutSeconds": 90,
+    // Max seconds to wait for the gateway port to become reachable from the Windows host.
+    // WSL2 mirrored networking has a delay between gateway healthy inside WSL and port forwarded to Windows.
+    // Only relevant on WSL2; WSL1 forwards instantly.
+    "WindowsPortTimeoutSeconds": 30,
     // Config reload strategy: "hot" (no restart), "restart"
     "ReloadMode": "hot",
     // Auth mode: "token" (shared secret)
@@ -125,7 +141,22 @@
   // ─── Pairing Configuration ───
   // Controls timeouts for device pairing
   "Pairing": {
-    // Max seconds to wait for pairing handshake
-    "TimeoutSeconds": 60
+    // Max seconds to wait for the WebSocket pairing handshake (operator or node) to complete.
+    // Covers connect → PairingRequired → paired-with-device-token flow. Raise for slow gateways.
+    "TimeoutSeconds": 60,
+    // Fixed delay after pairing succeeds before running verification.
+    // Gives the gateway time to persist pairing state and propagate events.
+    "StabilizationDelaySeconds": 5
+  },
+
+  // ─── Wizard Configuration ───
+  // Controls timeouts for gateway setup wizard requests
+  "Wizard": {
+    // Max seconds to wait for a single wizard step HTTP response (select/submit/navigate).
+    // Most steps respond in <1s; this catches gateway hangs during config.
+    "RequestTimeoutSeconds": 30,
+    // Max seconds to wait for wizard steps that involve external auth (OAuth device flow, API key validation).
+    // These block on user interaction in a browser — keep generous.
+    "AuthStepTimeoutSeconds": 300
   }
 }

--- a/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
@@ -147,7 +147,7 @@ public class SetupAndConnectTests
         Assert.Equal(expectedCommands, effectiveCommands.Order(StringComparer.OrdinalIgnoreCase).ToArray());
 
         var gateway = _fixture.ReadActiveGatewayRecord();
-        Assert.Equal($"ws://localhost:{_fixture.GatewayPort}", gateway.GatewayUrl);
+        Assert.Equal($"ws://127.0.0.1:{_fixture.GatewayPort}", gateway.GatewayUrl);
 
         var settingsPath = Path.Combine(_fixture.DataDir, "settings.json");
         var gatewaysPath = Path.Combine(_fixture.DataDir, "gateways.json");
@@ -190,7 +190,7 @@ public class SetupAndConnectTests
         Assert.True(usesSharedGatewayToken, $"Expected tray dashboard link to use the shared HTTP gateway token; source={credentialSource}");
         Assert.False(hasTokenQuery, $"Expected tray dashboard link to avoid token query strings; source={credentialSource}");
         Assert.NotNull(dashboardUrl);
-        Assert.StartsWith($"http://localhost:{_fixture.GatewayPort}", dashboardUrl);
+        Assert.StartsWith($"http://127.0.0.1:{_fixture.GatewayPort}", dashboardUrl);
         Assert.Contains("#token=", dashboardUrl);
         Console.WriteLine($"[E2E] tray dashboard URL source={credentialSource}; tokenQuery={hasTokenQuery}; length={dashboardUrl!.Length}");
 

--- a/tests/OpenClaw.SetupEngine.Tests/SetupConfigTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupConfigTests.cs
@@ -63,7 +63,7 @@ public class SetupConfigTests : IDisposable
     public void EffectiveGatewayUrl_UsesPort()
     {
         var config = new SetupConfig { GatewayPort = 9999 };
-        Assert.Equal("ws://localhost:9999", config.EffectiveGatewayUrl);
+        Assert.Equal("ws://127.0.0.1:9999", config.EffectiveGatewayUrl);
     }
 
     [Fact]

--- a/tests/OpenClaw.SetupEngine.Tests/SetupContextTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupContextTests.cs
@@ -113,7 +113,7 @@ public class SetupContextTests
     {
         var config = new SetupConfig { GatewayPort = 5555 };
         var ctx = CreateContext(config);
-        Assert.Equal("ws://localhost:5555", ctx.GatewayUrl);
+        Assert.Equal("ws://127.0.0.1:5555", ctx.GatewayUrl);
     }
 
     private static SetupContext CreateContext(SetupConfig? config = null)


### PR DESCRIPTION
## Setup Engine: Slow-Machine Fixes & Config Audit

### ⚠️ Validation pending — manual testing on slow ARM64 machines required.

---

### Summary

Fixes 7 bugs found during setup testing on slow ARM64 machines with WSL2 mirrored networking. Also includes a full audit of hardcoded config values, extracting them into `default-config.json` for configurability, and fixes from a dual-model adversarial code review.

### 🔴 Critical Fixes (2)

**1. WebSocket default URL uses `localhost` → IPv6 resolution failure**
- `SetupContext.EffectiveGatewayUrl` defaulted to `ws://localhost:{port}`. .NET resolves `localhost` to IPv6 `[::1]` first, but WSL2 mirrored networking only forwards IPv4 (`127.0.0.1`). Health checks using `127.0.0.1` passed, but WebSocket connections to `localhost` got "connection refused" for 3m40s across all retries.
- **Fix:** Changed all gateway URLs from `localhost` to `127.0.0.1`.

**2. `PairNodeStep` health check also used `localhost` (IPv6)**
- Same IPv6 bug in `PairNodeStep`'s pre-connect gateway health check.
- **Fix:** Changed to `http://127.0.0.1:{port}`.

### 🟠 High-Priority Fixes (2)

**3. `WaitForConnectionOrPairing` resolves immediately on first Error/Disconnected**
- The method resolved the `TaskCompletionSource` on the first `Error` or non-pairing `Disconnected` event, killing the connection before the WebSocket client's built-in auto-reconnect could retry. On slow machines with WSL2 port-forwarding lag, pairing always failed after ~40s.
- **Fix:** Removed immediate resolution on `Error`/`Disconnected`. Only resolve on `Connected` or `PairingRequired`. Timeout catches genuinely unreachable gateways.

**4. `StartGatewayStep` only checked health from inside WSL, not from Windows**
- With WSL2 mirrored networking, the gateway port can be healthy inside WSL but not yet forwarded to the Windows host.
- **Fix:** Added `WaitForWindowsPortReachable()` — polls `http://127.0.0.1:{port}` from the Windows side after the WSL health check passes.

### 🟡 Medium Fix (1)

**5. Hardcoded 15s/20s pairing timeouts too short for slow machines**
- **Fix:** All replaced with `Pairing.TimeoutSeconds` (default 60s) for configurability.

### 🟢 Low-Priority Fixes (2)

**6. Port conflict detection missed "node" gateway processes**
- The gateway runs as `node … openclaw … gateway`. If the process name appeared as "node", it would falsely report a port conflict.
- **Fix:** Now matches both "openclaw" and "node".

**7. No way to disable rollback for debugging setup failures**
- **Fix:** Added rollback confirmation dialog in UI mode. Users can choose to keep the current state for debugging.

### 🔧 Bonus Fix

**`TryRevokeOperatorTokenAsync` used hardcoded `ws://localhost:18789`**
- Fallback URL was hardcoded instead of using configured `EffectiveGatewayUrl`.

### 📋 Config Audit

Replaced `CommandTimeoutMultiplier` (1 multiplier × 48 individual timeout values) with a simpler 2-tier model:

| Config | Default | Purpose |
|--------|---------|---------|
| `CommandTimeoutSeconds` | 60 | Standard WSL commands (probes, state changes, pairing CLIs) |
| `InstallTimeoutSeconds` | 600 | Network downloads and bulk I/O (distro import, CLI install) |
| `WindowsPortTimeoutSeconds` | 30 | WSL2 port forwarding delay |
| `StabilizationDelaySeconds` | 5 | Post-pairing grace period |
| `RollbackTimeoutSeconds` | 60 | Per-step rollback kill timeout |
| `Wizard.RequestTimeoutSeconds` | 30 | Normal wizard step response |
| `Wizard.AuthStepTimeoutSeconds` | 300 | Auth/OAuth wizard steps |

All timeouts are "kill if hung" safety nets — fast machines finish instantly; raising timeouts has zero cost on fast machines.

### 🔍 Adversarial Code Review Fixes

Dual-model review (Claude Opus + GPT Codex) found and fixed:
- **`TryEnqueue` deadlock** — if `DispatcherQueue` is shut down (window closed), `TaskCompletionSource` was never completed, deadlocking the pipeline. Now checks return value and defaults to rollback.
- **Dialog dismiss default** — ESC/close on rollback dialog incorrectly defaulted to "keep for debugging". Now defaults to rollback (safer).

### Files Changed (6)

- `src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs` — Rollback confirmation dialog
- `src/OpenClaw.SetupEngine/SetupContext.cs` — Config classes, timeout helpers
- `src/OpenClaw.SetupEngine/SetupPipeline.cs` — Rollback confirmation callback
- `src/OpenClaw.SetupEngine/SetupSteps.cs` — All 7 bug fixes + timeout extraction
- `src/OpenClaw.SetupEngine/SetupWizardRunner.cs` — Wizard timeout extraction
- `src/OpenClaw.SetupEngine/default-config.json` — All new config entries with comments