### PR TITLE
Make local WSL setup deterministic

### DIFF
--- a/docs/ONBOARDING_WIZARD.md
+++ b/docs/ONBOARDING_WIZARD.md
@@ -9,7 +9,7 @@ On first launch, the wizard appears only when there is no usable saved gateway c
 The V2 setup flow walks users through:
 
 1. **Welcome** — Greeting and introduction
-2. **Local setup progress** — App-owned `OpenClawGateway` WSL installation
+2. **Local setup progress** — Fresh app-owned `OpenClawGateway` WSL installation
 3. **Gateway setup** — Gateway-driven provider/model configuration hosted by `GatewayWizardPage`
 4. **Permissions** — Windows system permission review
 5. **All set** — Feature summary and completion
@@ -22,7 +22,7 @@ The setup flow no longer configures remote/manual gateways. The Welcome page's *
 Displays the OpenClaw lobster icon, app title, and a brief description. If an app-owned local WSL gateway already exists, the primary CTA reads **Install new WSL Gateway** and confirmation warns that the current OpenClaw WSL gateway and distro will be deleted. If only an external gateway exists, the CTA remains **Set up locally** and confirmation explains that the external connection remains available in Connections.
 
 ### Local setup progress
-Installs and connects a new app-owned `OpenClawGateway` WSL instance. When replacing an app-owned local gateway, the removal step is shown as part of progress and can be retried on failure.
+Installs and connects a new app-owned `OpenClawGateway` WSL instance from a clean WSL baseline. Setup does not export from or mutate an existing user Ubuntu distro; if WSL cannot create the named app-owned distro directly, setup fails with an actionable update message. When replacing an app-owned local gateway, the removal step is shown as part of progress and can be retried on failure.
 
 ### Wizard
 Renders server-defined setup steps via RPC (`wizard.start` / `wizard.next`). The gateway controls the flow — steps can be:

--- a/docs/SETUP_ENGINE_REDESIGN.md
+++ b/docs/SETUP_ENGINE_REDESIGN.md
@@ -164,12 +164,12 @@ Executed sequentially. Each step is a small class (30–120 lines) in `SetupStep
 
 | # | Step Class | What It Does |
 |---|-----------|-------------|
-| 1 | `CleanupStaleDistroStep` | Unregister leftover WSL distro if `CleanBeforeRun` |
-| 2 | `CleanupStaleGatewayStep` | Stop orphaned gateway service, remove config |
-| 3 | `PreflightOsStep` | Validate Windows 64-bit, version ≥ 22H2 |
-| 4 | `PreflightWslStep` | Verify WSL installed and version ≥ 2 |
+| 1 | `PreflightOsStep` | Validate Windows 64-bit, version ≥ 22H2 |
+| 2 | `PreflightWslStep` | Verify WSL is installed and supports direct named clean installs |
+| 3 | `CleanupStaleDistroStep` | Unregister leftover app-owned WSL distro and remove its VHD directory if `CleanBeforeRun` |
+| 4 | `CleanupStaleGatewayStep` | Stop orphaned gateway service, remove config |
 | 5 | `PreflightPortStep` | Check gateway port is available |
-| 6 | `CreateWslInstanceStep` | Export base distro → import as new instance |
+| 6 | `CreateWslInstanceStep` | Directly install a fresh app-owned WSL distro; never export a user's Ubuntu distro |
 | 7 | `ConfigureWslInstanceStep` | Write wsl.conf, create user, set dirs |
 | 8 | `ValidateWslLockdownStep` | Verify WSL isolation settings are applied |
 | 9 | `InstallCliStep` | Run install script inside WSL |

--- a/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml
@@ -43,6 +43,10 @@
                     <TextBlock x:Name="ErrorText" TextWrapping="Wrap"
                                FontSize="13" FontFamily="Cascadia Code,Consolas,monospace"
                                Foreground="#FF6B6B" />
+                    <HyperlinkButton x:Name="HelpLink"
+                                     Visibility="Collapsed"
+                                     Padding="0"
+                                     FontSize="13" />
                     <HyperlinkButton x:Name="ViewLogLink" Content="View full log →"
                                      Click="ViewLog_Click" Padding="0"
                                      FontSize="13" />

--- a/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
@@ -9,6 +10,7 @@ namespace OpenClaw.SetupEngine.UI.Pages;
 
 public sealed partial class CompletePage : Page
 {
+    private static readonly Regex s_urlRegex = new(@"https?://[^\s)]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private string? _logPath;
 
     public CompletePage()
@@ -30,26 +32,59 @@ public sealed partial class CompletePage : Page
                 TitleText.Text = "All set!";
                 SubtitleText.Text = "OpenClaw is ready to go";
                 ErrorCard.Visibility = Visibility.Collapsed;
+                HelpLink.Visibility = Visibility.Collapsed;
             }
             else
             {
+                var errorMessage = args.ErrorMessage ?? "Unknown error";
+                var helpUrl = ExtractHelpUrl(errorMessage);
+
                 SuccessIcon.Visibility = Visibility.Collapsed;
                 FailureIcon.Visibility = Visibility.Visible;
                 TitleText.Text = "Setup failed";
-                SubtitleText.Text = args.ErrorMessage ?? "An error occurred during setup";
+                SubtitleText.Text = helpUrl is null
+                    ? args.ErrorMessage ?? "An error occurred during setup"
+                    : "Follow the steps below to resolve the setup issue and retry.";
                 NodeModeBanner.Visibility = Visibility.Collapsed;
                 StartupRow.Visibility = Visibility.Collapsed;
                 LaunchButton.Content = "Close";
 
                 // Show error card with details and log link
                 ErrorCard.Visibility = Visibility.Visible;
-                ErrorText.Text = args.ErrorMessage ?? "Unknown error";
+                ErrorText.Text = errorMessage;
+                if (helpUrl != null)
+                {
+                    HelpLink.Content = errorMessage.Contains("WSL", StringComparison.OrdinalIgnoreCase)
+                        ? "Update WSL →"
+                        : "Open help link →";
+                    HelpLink.NavigateUri = helpUrl;
+                    HelpLink.Visibility = Visibility.Visible;
+                }
+                else
+                {
+                    HelpLink.Visibility = Visibility.Collapsed;
+                }
                 if (args.LogPath != null)
+                {
                     ViewLogLink.Content = $"View full log → {Path.GetFileName(args.LogPath)}";
+                    ViewLogLink.Visibility = Visibility.Visible;
+                }
                 else
                     ViewLogLink.Visibility = Visibility.Collapsed;
             }
         }
+    }
+
+    private static Uri? ExtractHelpUrl(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return null;
+
+        var match = s_urlRegex.Match(text);
+        if (!match.Success)
+            return null;
+
+        return Uri.TryCreate(match.Value, UriKind.Absolute, out var uri) ? uri : null;
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)

--- a/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
@@ -23,9 +23,10 @@ public sealed partial class ProgressPage : Page
     // Map pipeline step IDs to display groups (N:1)
     private static readonly (string GroupId, string DisplayName, string[] StepIds)[] StepGroups =
     [
+        ("preflight", "Check system", ["preflight-os", "preflight-wsl"]),
         ("cleanup", "Removing existing gateway", ["cleanup-distro", "cleanup-gateway"]),
-        ("preflight", "Check system", ["preflight-os", "preflight-wsl", "preflight-port"]),
-        ("wsl-create", "Installing Ubuntu", ["wsl-create"]),
+        ("port", "Checking gateway port", ["preflight-port"]),
+        ("wsl-create", "Installing clean WSL gateway", ["wsl-create"]),
         ("wsl-configure", "Configuring instance", ["wsl-configure", "validate-wsl-lockdown"]),
         ("install-cli", "Installing OpenClaw", ["install-cli"]),
         ("configure", "Preparing gateway", ["configure-gateway", "install-service"]),

--- a/src/OpenClaw.SetupEngine/CommandRunner.cs
+++ b/src/OpenClaw.SetupEngine/CommandRunner.cs
@@ -7,7 +7,27 @@ namespace OpenClaw.SetupEngine;
 
 public sealed record CommandResult(int ExitCode, string Stdout, string Stderr, TimeSpan Elapsed, bool TimedOut);
 
-public sealed class CommandRunner
+public interface ICommandRunner
+{
+    Task<CommandResult> RunAsync(
+        string executable,
+        string[] arguments,
+        TimeSpan timeout,
+        IReadOnlyDictionary<string, string>? environment = null,
+        string? workingDirectory = null,
+        string? stdinInput = null,
+        CancellationToken ct = default);
+
+    Task<CommandResult> RunInWslAsync(
+        string distroName,
+        string command,
+        TimeSpan timeout,
+        IReadOnlyDictionary<string, string>? environment = null,
+        CancellationToken ct = default,
+        string? user = null);
+}
+
+public sealed class CommandRunner : ICommandRunner
 {
     private readonly SetupLogger _logger;
     private const int DrainTimeoutMs = 5000; // bounded drain for orphan WSL processes

--- a/src/OpenClaw.SetupEngine/SetupContext.cs
+++ b/src/OpenClaw.SetupEngine/SetupContext.cs
@@ -9,7 +9,7 @@ public sealed class SetupConfig
 {
     public string DistroName { get; set; } = "OpenClawGateway";
     public int GatewayPort { get; set; } = 18789;
-    public string BaseDistro { get; set; } = "";
+    public string BaseDistro { get; set; } = "Ubuntu-24.04";
     public bool SkipPermissions { get; set; }
     public bool SkipWizard { get; set; }
     public bool Headless { get; set; }
@@ -255,7 +255,7 @@ public sealed class SetupContext
     public SetupConfig Config { get; }
     public SetupLogger Logger { get; }
     public TransactionJournal Journal { get; }
-    public CommandRunner Commands { get; }
+    public ICommandRunner Commands { get; }
     public CancellationToken CancellationToken { get; }
 
     // Accumulated state from steps
@@ -274,7 +274,7 @@ public sealed class SetupContext
     // WSL PATH prefix using configured user
     public string WslPathPrefix => WslConstants.GetPathPrefix(Config.Wsl.User);
 
-    public SetupContext(SetupConfig config, SetupLogger logger, TransactionJournal journal, CommandRunner commands, CancellationToken ct)
+    public SetupContext(SetupConfig config, SetupLogger logger, TransactionJournal journal, ICommandRunner commands, CancellationToken ct)
     {
         Config = config;
         Logger = logger;

--- a/src/OpenClaw.SetupEngine/SetupPipeline.cs
+++ b/src/OpenClaw.SetupEngine/SetupPipeline.cs
@@ -42,10 +42,10 @@ public static class SetupStepFactory
     {
         return
         [
-            new CleanupStaleDistroStep(),
-            new CleanupStaleGatewayStep(),
             new PreflightOsStep(),
             new PreflightWslStep(),
+            new CleanupStaleDistroStep(),
+            new CleanupStaleGatewayStep(),
             new PreflightPortStep(),
             new CreateWslInstanceStep(),
             new ConfigureWslInstanceStep(),

--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -34,6 +34,85 @@ internal static class WslConstants
     public const string PathPrefix = """export PATH="/home/openclaw/.openclaw/bin:/opt/openclaw/bin:/usr/local/bin:$PATH" """;
 }
 
+internal static class WslInstallSupport
+{
+    private static readonly Version s_minDirectNamedInstallVersion = new(2, 4, 4);
+
+    public static IReadOnlyList<string> ParseQuietDistroList(string output)
+        => Normalize(output)
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+            .Select(d => d.Trim().TrimStart('*').Trim())
+            .Where(d => d.Length > 0)
+            .ToArray();
+
+    public static bool ContainsDistro(string output, string distroName)
+        => ParseQuietDistroList(output).Any(d => d.Equals(distroName, StringComparison.OrdinalIgnoreCase));
+
+    public static bool TryParseWslVersion(string output, out Version version)
+    {
+        var match = System.Text.RegularExpressions.Regex.Match(
+            Normalize(output),
+            @"WSL\s+version:\s*(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+        if (!match.Success)
+        {
+            version = new Version();
+            return false;
+        }
+
+        var major = int.Parse(match.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
+        var minor = int.Parse(match.Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture);
+        var build = int.Parse(match.Groups[3].Value, System.Globalization.CultureInfo.InvariantCulture);
+        var revision = match.Groups[4].Success
+            ? int.Parse(match.Groups[4].Value, System.Globalization.CultureInfo.InvariantCulture)
+            : -1;
+        version = revision >= 0
+            ? new Version(major, minor, build, revision)
+            : new Version(major, minor, build);
+        return true;
+    }
+
+    public static bool SupportsDirectNamedInstall(Version version)
+        => version.CompareTo(s_minDirectNamedInstallVersion) >= 0;
+
+    public static string[] BuildDirectInstallArgs(string baseDistro, string distroName, string installPath)
+        =>
+        [
+            "--install",
+            "--distribution",
+            baseDistro,
+            "--name",
+            distroName,
+            "--location",
+            installPath,
+            "--no-launch",
+            "--web-download"
+        ];
+
+    public static bool TryGetDistroVersion(string verboseOutput, string distroName, out int version)
+    {
+        foreach (var rawLine in Normalize(verboseOutput).Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            var line = rawLine.Trim().TrimStart('*').Trim();
+            if (line.Length == 0 || line.StartsWith("NAME", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var parts = line.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 3 || !parts[0].Equals(distroName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            return int.TryParse(parts[^1], out version);
+        }
+
+        version = 0;
+        return false;
+    }
+
+    public static string Normalize(string value)
+        => value.Replace("\0", "").Replace("\uFEFF", "");
+}
+
 // Adapter to bridge SetupLogger → IOpenClawLogger for WebSocket clients
 internal sealed class SetupOpenClawLogger(SetupLogger logger) : IOpenClawLogger
 {
@@ -58,25 +137,18 @@ public sealed class CleanupStaleDistroStep : SetupStep
     public override async Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)
     {
         var distro = ctx.DistroName!;
+        var wslDir = Path.Combine(ctx.LocalDataDir, "wsl", distro);
         var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
         if (list.ExitCode != 0)
-            return StepResult.Ok("WSL not available or no distros — nothing to clean");
+            return StepResult.Ok("WSL not available or no distros - nothing to clean");
 
-        // wsl.exe outputs UTF-16 with potential BOM/null chars — normalize aggressively
-        var distros = list.Stdout
-            .Replace("\0", "")
-            .Replace("\uFEFF", "")
-            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
-            .Select(d => d.Trim())
-            .Where(d => d.Length > 0)
-            .ToList();
+        var distros = WslInstallSupport.ParseQuietDistroList(list.Stdout);
 
         ctx.Logger.Debug($"Found WSL distros: [{string.Join(", ", distros)}]");
 
         if (!distros.Any(d => d.Equals(distro, StringComparison.OrdinalIgnoreCase)))
         {
             // Distro not registered, but disk directory may still exist from prior crash
-            var wslDir = Path.Combine(ctx.LocalDataDir, "wsl", distro);
             if (Directory.Exists(wslDir))
             {
                 ctx.Logger.Info($"Removing orphaned WSL directory: {wslDir}");
@@ -84,25 +156,9 @@ public sealed class CleanupStaleDistroStep : SetupStep
                 await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--shutdown"], TimeSpan.FromSeconds(30), ct: ct);
                 await Task.Delay(2000, ct);
 
-                // Retry deletion — VHD may still be locked briefly after WSL shutdown
-                for (int attempt = 0; attempt < 3; attempt++)
-                {
-                    try
-                    {
-                        Directory.Delete(wslDir, recursive: true);
-                        break;
-                    }
-                    catch (IOException) when (attempt < 2)
-                    {
-                        ctx.Logger.Warn($"VHD directory still locked, retrying in {(attempt + 1) * 2}s...");
-                        await Task.Delay(TimeSpan.FromSeconds((attempt + 1) * 2), ct);
-                    }
-                    catch (UnauthorizedAccessException) when (attempt < 2)
-                    {
-                        ctx.Logger.Warn($"VHD directory access denied, retrying in {(attempt + 1) * 2}s...");
-                        await Task.Delay(TimeSpan.FromSeconds((attempt + 1) * 2), ct);
-                    }
-                }
+                var delete = await DeleteDistroDirectoryWithRetries(ctx, wslDir, ct);
+                if (!delete.IsSuccess)
+                    return delete;
             }
             ctx.Logger.Decision("No stale distro found", "skip cleanup");
             return StepResult.Ok("No stale distro to clean");
@@ -127,12 +183,9 @@ public sealed class CleanupStaleDistroStep : SetupStep
         if (unregister.ExitCode == 0)
         {
             // Also remove the on-disk WSL vhdx directory (--import fails if it exists)
-            var wslDir = Path.Combine(ctx.LocalDataDir, "wsl", distro);
-            if (Directory.Exists(wslDir))
-            {
-                ctx.Logger.Info($"Removing leftover WSL directory: {wslDir}");
-                Directory.Delete(wslDir, recursive: true);
-            }
+            var delete = await DeleteDistroDirectoryWithRetries(ctx, wslDir, ct);
+            if (!delete.IsSuccess)
+                return delete;
 
             // Wait for port to be released
             ctx.Logger.Info("Waiting for port release after distro termination...");
@@ -141,6 +194,71 @@ public sealed class CleanupStaleDistroStep : SetupStep
         }
 
         return StepResult.Fail($"Failed to unregister distro: {unregister.Stderr}");
+    }
+
+    internal static async Task<StepResult> DeleteDistroDirectoryWithRetries(SetupContext ctx, string wslDir, CancellationToken ct)
+    {
+        Exception? lastError = null;
+
+        for (var attempt = 0; attempt < 4; attempt++)
+        {
+            try
+            {
+                if (File.Exists(wslDir))
+                {
+                    if (File.GetAttributes(wslDir).HasFlag(FileAttributes.ReparsePoint))
+                        return StepResult.Fail($"App-owned WSL path '{wslDir}' is a reparse point; remove it manually and retry setup.");
+
+                    ctx.Logger.Info($"Removing app-owned WSL file at install path: {wslDir}");
+                    File.Delete(wslDir);
+                }
+                else if (Directory.Exists(wslDir))
+                {
+                    if (new DirectoryInfo(wslDir).Attributes.HasFlag(FileAttributes.ReparsePoint))
+                        return StepResult.Fail($"App-owned WSL directory '{wslDir}' is a reparse point; remove it manually and retry setup.");
+
+                    ctx.Logger.Info($"Removing app-owned WSL directory: {wslDir}");
+                    Directory.Delete(wslDir, recursive: true);
+                }
+
+                var parent = Path.GetDirectoryName(wslDir);
+                if (!string.IsNullOrWhiteSpace(parent) &&
+                    Directory.Exists(parent) &&
+                    !Directory.EnumerateFileSystemEntries(parent).Any())
+                {
+                    Directory.Delete(parent);
+                    ctx.Logger.Info("Deleted empty wsl\\ parent directory");
+                }
+
+                return StepResult.Ok("WSL directory removed");
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return StepResult.Ok("WSL directory already absent");
+            }
+            catch (IOException ex)
+            {
+                lastError = ex;
+                if (attempt >= 3)
+                    break;
+
+                ctx.Logger.Warn($"VHD directory still locked, retrying in {(attempt + 1) * 2}s...");
+                await Task.Delay(TimeSpan.FromSeconds((attempt + 1) * 2), ct);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                lastError = ex;
+                if (attempt >= 3)
+                    break;
+
+                ctx.Logger.Warn($"VHD directory access denied, retrying in {(attempt + 1) * 2}s...");
+                await Task.Delay(TimeSpan.FromSeconds((attempt + 1) * 2), ct);
+            }
+        }
+
+        return StepResult.Fail(
+            $"Failed to remove app-owned WSL directory '{wslDir}'. Close any process using the OpenClaw WSL distro and retry setup."
+            + (lastError is null ? "" : $" Last error: {lastError.Message}"));
     }
 }
 
@@ -266,9 +384,22 @@ public sealed class PreflightWslStep : SetupStep
         }
 
         if (versionResult.ExitCode != 0)
+        {
+            if (LooksTooOldForVersionCommand(versionResult))
+                return StepResult.Terminal("WSL is installed but too old for clean app-owned gateway setup. Update WSL from Microsoft Store or run `wsl --update`, then retry setup.");
+
             return StepResult.Terminal($"WSL is not available. {FirstUsefulLine(versionResult)}");
+        }
+
+        var versionOutput = NormalizeWslOutput($"{versionResult.Stdout}\n{versionResult.Stderr}");
+        if (!WslInstallSupport.TryParseWslVersion(versionOutput, out var wslVersion))
+            return StepResult.Terminal("WSL version output did not include a parseable WSL version. Update WSL from Microsoft Store or run `wsl --update`, then retry setup.");
+
+        if (!WslInstallSupport.SupportsDirectNamedInstall(wslVersion))
+            return StepResult.Terminal($"WSL {wslVersion} cannot create a clean app-owned OpenClaw gateway distro. Update WSL with `wsl --update`, then retry setup.");
 
         ctx.Logger.Info($"WSL version output: {NormalizeWslOutput(versionResult.Stdout).Trim()}");
+        ctx.Logger.Info($"WSL direct named install is supported (version {wslVersion})");
         return StepResult.Ok("WSL available");
     }
 
@@ -323,6 +454,14 @@ public sealed class PreflightWslStep : SetupStep
             || text.Contains("Windows Subsystem for Linux has no installed distributions", StringComparison.OrdinalIgnoreCase)
             || text.Contains("not recognized", StringComparison.OrdinalIgnoreCase)
             || text.Contains("not installed", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool LooksTooOldForVersionCommand(CommandResult result)
+    {
+        var text = NormalizeWslOutput($"{result.Stdout}\n{result.Stderr}");
+        return text.Contains("Invalid command line option", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("unrecognized option", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("unknown option", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string NormalizeWslOutput(string value)
@@ -396,62 +535,149 @@ public sealed class CreateWslInstanceStep : SetupStep
 {
     public override string Id => "wsl-create";
     public override string DisplayName => "Create WSL instance";
-    public override RetryPolicy Retry => new(MaxAttempts: 2, InitialDelay: TimeSpan.FromSeconds(5));
+    public override bool CanRetry => false;
 
     public override async Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)
     {
         var distro = ctx.DistroName!;
-        var baseDistro = ctx.Config.BaseDistro;
+        var baseDistro = ctx.Config.BaseDistro.Trim();
 
-        ctx.Logger.Info($"Creating WSL distro '{distro}' from base '{baseDistro}'");
+        if (string.IsNullOrWhiteSpace(baseDistro))
+            return StepResult.Terminal("BaseDistro is required for fresh WSL gateway setup.");
 
-        // Import as our named distro
-        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-setup-{ctx.Logger.RunId}");
-        Directory.CreateDirectory(tempDir);
+        var installPath = Path.Combine(ctx.LocalDataDir, "wsl", distro);
+        ctx.Logger.Info($"Creating clean app-owned WSL distro '{distro}' from '{baseDistro}' at '{installPath}'");
 
-        try
+        var existing = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        if (existing.ExitCode != 0)
+            return StepResult.Fail($"Failed to list WSL distros before creating '{distro}': {existing.Stderr}");
+
+        if (WslInstallSupport.ContainsDistro(existing.Stdout, distro))
+            return StepResult.Fail($"Target WSL distro '{distro}' still exists after cleanup; refusing to create a new gateway over unknown state.");
+
+        var pathCheck = EnsureInstallPathReady(installPath);
+        if (!pathCheck.IsSuccess)
+            return pathCheck;
+
+        Directory.CreateDirectory(Path.GetDirectoryName(installPath)!);
+
+        var installArgs = WslInstallSupport.BuildDirectInstallArgs(baseDistro, distro, installPath);
+        ctx.Logger.Info($"Installing fresh WSL distro with arguments: {string.Join(' ', installArgs)}");
+        var install = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            installArgs,
+            TimeSpan.FromMinutes(15),
+            ct: ct);
+
+        if (install.ExitCode != 0)
         {
-            // Export base → import as our distro name
-            var exportPath = Path.Combine(tempDir, "base.tar");
-            var export = await ctx.Commands.RunAsync(
-                WslConstants.WslExePath, ["--export", baseDistro, exportPath],
-                TimeSpan.FromMinutes(5), ct: ct);
-
-            if (export.ExitCode != 0)
-            {
-                ctx.Logger.Warn($"Base distro export failed (exit {export.ExitCode}); attempting to install {baseDistro}");
-                var install = await ctx.Commands.RunAsync(
-                    WslConstants.WslExePath, ["--install", baseDistro, "--no-launch"],
-                    TimeSpan.FromMinutes(5), ct: ct);
-
-                if (install.ExitCode != 0 && !install.Stdout.Contains("already installed", StringComparison.OrdinalIgnoreCase))
-                    return StepResult.Fail($"Failed to install base distro '{baseDistro}' (exit {install.ExitCode}): {install.Stderr}");
-
-                export = await ctx.Commands.RunAsync(
-                    WslConstants.WslExePath, ["--export", baseDistro, exportPath],
-                    TimeSpan.FromMinutes(5), ct: ct);
-            }
-
-            if (export.ExitCode != 0)
-                return StepResult.Fail($"Failed to export base distro: {export.Stderr}");
-
-            var installPath = Path.Combine(ctx.LocalDataDir, "wsl", distro);
-            Directory.CreateDirectory(installPath);
-
-            var import = await ctx.Commands.RunAsync(
-                WslConstants.WslExePath, ["--import", distro, installPath, exportPath, "--version", "2"],
-                TimeSpan.FromMinutes(5), ct: ct);
-
-            if (import.ExitCode != 0)
-                return StepResult.Fail($"Failed to import distro: {import.Stderr}");
-
-            return StepResult.Ok($"Created WSL2 distro '{distro}'");
+            var cleanupError = await CleanupPartialInstall(ctx, distro, installPath, ct);
+            return StepResult.Fail(
+                $"Fresh WSL install failed for '{distro}' from '{baseDistro}' (exit {install.ExitCode}): {FirstNonEmpty(install.Stderr, install.Stdout)}{cleanupError}");
         }
-        finally
+
+        var verify = await VerifyFreshDistro(ctx, distro, installPath, ct);
+        if (!verify.IsSuccess)
         {
-            try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+            var cleanupError = await CleanupPartialInstall(ctx, distro, installPath, ct);
+            return StepResult.Fail($"{verify.Message}{cleanupError}");
         }
+
+        return verify;
     }
+
+    private static StepResult EnsureInstallPathReady(string installPath)
+    {
+        if (File.Exists(installPath))
+        {
+            if (File.GetAttributes(installPath).HasFlag(FileAttributes.ReparsePoint))
+                return StepResult.Fail($"App-owned WSL install path '{installPath}' is a reparse point; remove it manually and retry setup.");
+
+            File.Delete(installPath);
+            return StepResult.Ok();
+        }
+
+        if (!Directory.Exists(installPath))
+            return StepResult.Ok();
+
+        if (new DirectoryInfo(installPath).Attributes.HasFlag(FileAttributes.ReparsePoint))
+            return StepResult.Fail($"App-owned WSL install directory '{installPath}' is a reparse point; remove it manually and retry setup.");
+
+        if (Directory.EnumerateFileSystemEntries(installPath).Any())
+        {
+            return StepResult.Fail(
+                $"App-owned WSL install directory '{installPath}' still contains files after cleanup; refusing to create a new gateway over unknown state.");
+        }
+
+        Directory.Delete(installPath);
+        return StepResult.Ok();
+    }
+
+    private static async Task<StepResult> VerifyFreshDistro(SetupContext ctx, string distro, string installPath, CancellationToken ct)
+    {
+        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        if (list.ExitCode != 0 || !WslInstallSupport.ContainsDistro(list.Stdout, distro))
+            return StepResult.Fail($"Fresh WSL install did not register expected distro '{distro}'.");
+
+        var verbose = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--verbose"], TimeSpan.FromSeconds(15), ct: ct);
+        if (verbose.ExitCode != 0 || !WslInstallSupport.TryGetDistroVersion(verbose.Stdout, distro, out var version))
+            return StepResult.Fail($"Fresh WSL install registered '{distro}', but setup could not verify it is WSL2.");
+
+        if (version != 2)
+            return StepResult.Fail($"Fresh WSL install registered '{distro}' as WSL{version}; WSL2 is required.");
+
+        var probe = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["-d", distro, "-u", "root", "--", "sh", "-lc", "id -u && test -d / && echo OPENCLAW_FRESH_WSL_READY"],
+            TimeSpan.FromSeconds(30),
+            ct: ct);
+
+        if (probe.ExitCode != 0 || !probe.Stdout.Contains("OPENCLAW_FRESH_WSL_READY", StringComparison.Ordinal))
+            return StepResult.Fail($"Fresh WSL distro '{distro}' could not run a root verification command: {FirstNonEmpty(probe.Stderr, probe.Stdout)}");
+
+        return StepResult.Ok($"Created clean WSL2 distro '{distro}' at '{installPath}'");
+    }
+
+    private static async Task<string> CleanupPartialInstall(SetupContext ctx, string distro, string installPath, CancellationToken ct)
+    {
+        var cleanupErrors = new List<string>();
+        var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
+        var distroExists = list.ExitCode == 0 && WslInstallSupport.ContainsDistro(list.Stdout, distro);
+
+        if (!distroExists && !Directory.Exists(installPath) && !File.Exists(installPath))
+            return "";
+
+        if (distroExists)
+        {
+            var terminate = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--terminate", distro], TimeSpan.FromSeconds(30), ct: ct);
+            if (terminate.ExitCode != 0)
+                cleanupErrors.Add($"terminate exit {terminate.ExitCode}: {FirstNonEmpty(terminate.Stderr, terminate.Stdout)}");
+
+            var unregister = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--unregister", distro], TimeSpan.FromSeconds(60), ct: ct);
+            if (unregister.ExitCode != 0)
+            {
+                ctx.Logger.Warn($"Partial install unregister failed (exit {unregister.ExitCode}); forcing WSL shutdown and retrying");
+                var shutdown = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--shutdown"], TimeSpan.FromSeconds(30), ct: ct);
+                if (shutdown.ExitCode != 0)
+                    cleanupErrors.Add($"shutdown exit {shutdown.ExitCode}: {FirstNonEmpty(shutdown.Stderr, shutdown.Stdout)}");
+
+                unregister = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--unregister", distro], TimeSpan.FromSeconds(60), ct: ct);
+                if (unregister.ExitCode != 0)
+                    cleanupErrors.Add($"unregister exit {unregister.ExitCode}: {FirstNonEmpty(unregister.Stderr, unregister.Stdout)}");
+            }
+        }
+
+        var delete = await CleanupStaleDistroStep.DeleteDistroDirectoryWithRetries(ctx, installPath, ct);
+        if (!delete.IsSuccess)
+            cleanupErrors.Add(delete.Message ?? "install directory cleanup failed");
+
+        return cleanupErrors.Count == 0
+            ? ""
+            : $" Partial app-owned distro cleanup also failed: {string.Join("; ", cleanupErrors)}";
+    }
+
+    private static string FirstNonEmpty(params string[] values)
+        => values.Select(v => v.Trim()).FirstOrDefault(v => v.Length > 0) ?? "no output";
 
     public override async Task RollbackAsync(SetupContext ctx, CancellationToken ct)
     {

--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -37,6 +37,10 @@ internal static class WslConstants
 internal static class WslInstallSupport
 {
     private static readonly Version s_minDirectNamedInstallVersion = new(2, 4, 4);
+    public const string UpdateUrl = "https://aka.ms/wslstorepage";
+
+    public static string UpdateInstructions
+        => $"Update WSL from the Microsoft Store page ({UpdateUrl}), then retry setup.";
 
     public static IReadOnlyList<string> ParseQuietDistroList(string output)
         => Normalize(output)
@@ -386,17 +390,17 @@ public sealed class PreflightWslStep : SetupStep
         if (versionResult.ExitCode != 0)
         {
             if (LooksTooOldForVersionCommand(versionResult))
-                return StepResult.Terminal("WSL is installed but too old for clean app-owned gateway setup. Update WSL from Microsoft Store or run `wsl --update`, then retry setup.");
+                return StepResult.Terminal($"WSL is installed but too old for clean app-owned gateway setup. {WslInstallSupport.UpdateInstructions}");
 
             return StepResult.Terminal($"WSL is not available. {FirstUsefulLine(versionResult)}");
         }
 
         var versionOutput = NormalizeWslOutput($"{versionResult.Stdout}\n{versionResult.Stderr}");
         if (!WslInstallSupport.TryParseWslVersion(versionOutput, out var wslVersion))
-            return StepResult.Terminal("WSL version output did not include a parseable WSL version. Update WSL from Microsoft Store or run `wsl --update`, then retry setup.");
+            return StepResult.Terminal($"WSL version output did not include a parseable WSL version. {WslInstallSupport.UpdateInstructions}");
 
         if (!WslInstallSupport.SupportsDirectNamedInstall(wslVersion))
-            return StepResult.Terminal($"WSL {wslVersion} cannot create a clean app-owned OpenClaw gateway distro. Update WSL with `wsl --update`, then retry setup.");
+            return StepResult.Terminal($"WSL {wslVersion} cannot create a clean app-owned OpenClaw gateway distro. {WslInstallSupport.UpdateInstructions}");
 
         ctx.Logger.Info($"WSL version output: {NormalizeWslOutput(versionResult.Stdout).Trim()}");
         ctx.Logger.Info($"WSL direct named install is supported (version {wslVersion})");
@@ -641,39 +645,79 @@ public sealed class CreateWslInstanceStep : SetupStep
     private static async Task<string> CleanupPartialInstall(SetupContext ctx, string distro, string installPath, CancellationToken ct)
     {
         var cleanupErrors = new List<string>();
+        var installPathExists = Directory.Exists(installPath) || File.Exists(installPath);
         var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
-        var distroExists = list.ExitCode == 0 && WslInstallSupport.ContainsDistro(list.Stdout, distro);
+        var registrationStateKnown = list.ExitCode == 0;
+        var distroExists = registrationStateKnown && WslInstallSupport.ContainsDistro(list.Stdout, distro);
+        var canDeleteInstallPath = registrationStateKnown && !distroExists;
 
-        if (!distroExists && !Directory.Exists(installPath) && !File.Exists(installPath))
-            return "";
-
-        if (distroExists)
+        if (!registrationStateKnown)
         {
-            var terminate = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--terminate", distro], TimeSpan.FromSeconds(30), ct: ct);
-            if (terminate.ExitCode != 0)
-                cleanupErrors.Add($"terminate exit {terminate.ExitCode}: {FirstNonEmpty(terminate.Stderr, terminate.Stdout)}");
-
-            var unregister = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--unregister", distro], TimeSpan.FromSeconds(60), ct: ct);
-            if (unregister.ExitCode != 0)
-            {
-                ctx.Logger.Warn($"Partial install unregister failed (exit {unregister.ExitCode}); forcing WSL shutdown and retrying");
-                var shutdown = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--shutdown"], TimeSpan.FromSeconds(30), ct: ct);
-                if (shutdown.ExitCode != 0)
-                    cleanupErrors.Add($"shutdown exit {shutdown.ExitCode}: {FirstNonEmpty(shutdown.Stderr, shutdown.Stdout)}");
-
-                unregister = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--unregister", distro], TimeSpan.FromSeconds(60), ct: ct);
-                if (unregister.ExitCode != 0)
-                    cleanupErrors.Add($"unregister exit {unregister.ExitCode}: {FirstNonEmpty(unregister.Stderr, unregister.Stdout)}");
-            }
+            ctx.Logger.Warn($"Partial install cleanup could not list WSL distros (exit {list.ExitCode}); attempting best-effort unregister for '{distro}' before deleting app-owned files");
+            canDeleteInstallPath = await TryUnregisterPartialInstall(ctx, distro, cleanupErrors, ct);
+        }
+        else if (distroExists)
+        {
+            canDeleteInstallPath = await TryUnregisterPartialInstall(ctx, distro, cleanupErrors, ct);
         }
 
-        var delete = await CleanupStaleDistroStep.DeleteDistroDirectoryWithRetries(ctx, installPath, ct);
-        if (!delete.IsSuccess)
-            cleanupErrors.Add(delete.Message ?? "install directory cleanup failed");
+        if (!canDeleteInstallPath)
+        {
+            if (!registrationStateKnown)
+            {
+                cleanupErrors.Insert(0,
+                    $"could not confirm whether distro '{distro}' is still registered: {FirstNonEmpty(list.Stderr, list.Stdout)}");
+            }
+
+            if (installPathExists)
+            {
+                cleanupErrors.Add(
+                    $"skipped deleting app-owned install path '{installPath}' until distro '{distro}' is confirmed unregistered");
+            }
+        }
+        else if (installPathExists)
+        {
+            var delete = await CleanupStaleDistroStep.DeleteDistroDirectoryWithRetries(ctx, installPath, ct);
+            if (!delete.IsSuccess)
+                cleanupErrors.Add(delete.Message ?? "install directory cleanup failed");
+        }
 
         return cleanupErrors.Count == 0
             ? ""
             : $" Partial app-owned distro cleanup also failed: {string.Join("; ", cleanupErrors)}";
+    }
+
+    private static async Task<bool> TryUnregisterPartialInstall(SetupContext ctx, string distro, List<string> cleanupErrors, CancellationToken ct)
+    {
+        var terminate = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--terminate", distro], TimeSpan.FromSeconds(30), ct: ct);
+        if (terminate.ExitCode != 0 && !IsMissingDistroResult(terminate))
+            cleanupErrors.Add($"terminate exit {terminate.ExitCode}: {FirstNonEmpty(terminate.Stderr, terminate.Stdout)}");
+
+        var unregister = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--unregister", distro], TimeSpan.FromSeconds(60), ct: ct);
+        if (unregister.ExitCode == 0 || IsMissingDistroResult(unregister))
+            return true;
+
+        ctx.Logger.Warn($"Partial install unregister failed (exit {unregister.ExitCode}); forcing WSL shutdown and retrying");
+        var shutdown = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--shutdown"], TimeSpan.FromSeconds(30), ct: ct);
+        if (shutdown.ExitCode != 0)
+            cleanupErrors.Add($"shutdown exit {shutdown.ExitCode}: {FirstNonEmpty(shutdown.Stderr, shutdown.Stdout)}");
+
+        unregister = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--unregister", distro], TimeSpan.FromSeconds(60), ct: ct);
+        if (unregister.ExitCode == 0 || IsMissingDistroResult(unregister))
+            return true;
+
+        cleanupErrors.Add($"unregister exit {unregister.ExitCode}: {FirstNonEmpty(unregister.Stderr, unregister.Stdout)}");
+        return false;
+    }
+
+    private static bool IsMissingDistroResult(CommandResult result)
+    {
+        if (result.ExitCode == 0)
+            return false;
+
+        var output = FirstNonEmpty(result.Stderr, result.Stdout);
+        return output.Contains("There is no distribution with the supplied name", StringComparison.OrdinalIgnoreCase) ||
+               output.Contains("WSL_E_DISTRO_NOT_FOUND", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string FirstNonEmpty(params string[] values)
@@ -1856,6 +1900,10 @@ public sealed class PairNodeStep : SetupStep
             return StepResult.Fail($"Gateway not reachable before node pairing: {ex.Message}");
         }
 
+        var drainResult = await VerifyEndToEndStep.DrainPendingDeviceApprovalsAsync(ctx, ct);
+        if (!drainResult.IsSuccess)
+            return drainResult;
+
         var wsLogger = new SetupOpenClawLogger(ctx.Logger);
         WindowsNodeClient? client = null;
 
@@ -2207,12 +2255,12 @@ public sealed class VerifyEndToEndStep : SetupStep
         return StepResult.Ok("Gateway running; operator finalized; settings written for tray.");
     }
 
-    private static async Task<StepResult> DrainPendingApprovalsAsync(SetupContext ctx, CancellationToken ct)
+    internal static async Task<StepResult> DrainPendingDeviceApprovalsAsync(SetupContext ctx, CancellationToken ct)
     {
         var distro = ctx.DistroName!;
         var token = ctx.SharedGatewayToken ?? ctx.BootstrapToken;
         if (string.IsNullOrWhiteSpace(token))
-            return StepResult.Fail("No gateway token available to drain pending approvals");
+            return StepResult.Fail("No gateway token available to drain pending device approvals");
 
         var pathPrefix = ctx.WslPathPrefix;
         var env = new Dictionary<string, string> { ["OPENCLAW_GATEWAY_TOKEN"] = token };
@@ -2265,6 +2313,24 @@ public sealed class VerifyEndToEndStep : SetupStep
 
             return StepResult.Fail($"Could not select pending device approval for drain (exit {preview.ExitCode}): {parsed.Error ?? preview.Stderr.Trim()}");
         }
+
+        return StepResult.Ok("Pending device approvals drained");
+    }
+
+    private static async Task<StepResult> DrainPendingApprovalsAsync(SetupContext ctx, CancellationToken ct)
+    {
+        var deviceDrainResult = await DrainPendingDeviceApprovalsAsync(ctx, ct);
+        if (!deviceDrainResult.IsSuccess)
+            return deviceDrainResult;
+
+        var distro = ctx.DistroName!;
+        var token = ctx.SharedGatewayToken ?? ctx.BootstrapToken;
+        if (string.IsNullOrWhiteSpace(token))
+            return StepResult.Fail("No gateway token available to drain pending approvals");
+
+        var pathPrefix = ctx.WslPathPrefix;
+        var env = new Dictionary<string, string> { ["OPENCLAW_GATEWAY_TOKEN"] = token };
+        const int maxDrainIterations = 10;
 
         for (var i = 0; i < maxDrainIterations; i++)
         {

--- a/src/OpenClaw.SetupEngine/default-config.json
+++ b/src/OpenClaw.SetupEngine/default-config.json
@@ -4,7 +4,7 @@
   "DistroName": "OpenClawGateway",
   // Gateway WebSocket port (tray connects here)
   "GatewayPort": 18789,
-  // Base Ubuntu distro to export/import from
+  // Ubuntu release to install as a fresh app-owned WSL gateway distro
   "BaseDistro": "Ubuntu-24.04",
   // Run without UI prompts
   "Headless": true,

--- a/tests/OpenClaw.SetupEngine.Tests/SetupConfigTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupConfigTests.cs
@@ -24,6 +24,7 @@ public class SetupConfigTests : IDisposable
         var config = new SetupConfig();
         Assert.Equal("OpenClawGateway", config.DistroName);
         Assert.Equal(18789, config.GatewayPort);
+        Assert.Equal("Ubuntu-24.04", config.BaseDistro);
         Assert.False(config.Headless);
         Assert.False(config.DryRun);
         Assert.Equal("trace", config.LogLevel);

--- a/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
@@ -61,6 +61,10 @@ public class SetupPipelineTests
         var steps = SetupStepFactory.BuildDefaultSteps();
 
         Assert.Equal(18, steps.Count);
+        Assert.IsType<PreflightOsStep>(steps[0]);
+        Assert.IsType<PreflightWslStep>(steps[1]);
+        Assert.IsType<CleanupStaleDistroStep>(steps[2]);
+        Assert.IsType<CleanupStaleGatewayStep>(steps[3]);
         Assert.Contains(steps, s => s is ValidateWslLockdownStep);
         Assert.Contains(steps, s => s is RunGatewayWizardStep);
         Assert.IsType<StartKeepaliveStep>(steps[^1]);

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -237,6 +237,7 @@ public class SetupStepsTests : IDisposable
 
         Assert.Equal(StepOutcome.FailedTerminal, result.Outcome);
         Assert.Contains("Update WSL", result.Message);
+        Assert.Contains(WslInstallSupport.UpdateUrl, result.Message);
     }
 
     [Fact]
@@ -252,7 +253,7 @@ public class SetupStepsTests : IDisposable
 
         Assert.Equal(StepOutcome.FailedTerminal, result.Outcome);
         Assert.Contains("too old", result.Message);
-        Assert.Contains("wsl --update", result.Message);
+        Assert.Contains(WslInstallSupport.UpdateUrl, result.Message);
     }
 
     [Fact]
@@ -320,6 +321,83 @@ public class SetupStepsTests : IDisposable
 
         Assert.Equal(StepOutcome.Failed, result.Outcome);
         Assert.Contains("download failed", result.Message);
+        Assert.DoesNotContain(commands.Calls, c => c.Arguments.SequenceEqual(["--shutdown"]));
+    }
+
+    [Fact]
+    public async Task CreateWslInstance_PartialCleanupSkipsInstallPathDeleteWhenDistroStateIsUnknown()
+    {
+        var listCalls = 0;
+        var installPath = "";
+        var commands = new FakeCommandRunner(args =>
+        {
+            if (args.SequenceEqual(["--list", "--quiet"]))
+            {
+                listCalls++;
+                return listCalls == 1 ? Ok("") : Fail("list failed");
+            }
+            if (args.Contains("--install"))
+            {
+                Directory.CreateDirectory(installPath);
+                File.WriteAllText(Path.Combine(installPath, "ext4.vhdx"), "partial");
+                return Fail("download failed");
+            }
+            if (args.SequenceEqual(["--terminate", "OpenClawGateway"]))
+                return Fail("terminate unavailable");
+            if (args.SequenceEqual(["--unregister", "OpenClawGateway"]))
+                return Fail("unregister unavailable");
+            if (args.SequenceEqual(["--shutdown"]))
+                return Ok();
+
+            return Fail($"unexpected args: {string.Join(' ', args)}");
+        });
+        var ctx = CreateContext(commands: commands);
+        installPath = Path.Combine(ctx.LocalDataDir, "wsl", "OpenClawGateway");
+
+        var result = await new CreateWslInstanceStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, result.Outcome);
+        Assert.Contains("download failed", result.Message);
+        Assert.Contains("could not confirm whether distro 'OpenClawGateway' is still registered", result.Message);
+        Assert.Contains("skipped deleting app-owned install path", result.Message);
+        Assert.True(File.Exists(Path.Combine(installPath, "ext4.vhdx")));
+    }
+
+    [Fact]
+    public async Task CreateWslInstance_PartialCleanupDeletesInstallPathWhenListFailsButDistroIsAlreadyGone()
+    {
+        var listCalls = 0;
+        var installPath = "";
+        var commands = new FakeCommandRunner(args =>
+        {
+            if (args.SequenceEqual(["--list", "--quiet"]))
+            {
+                listCalls++;
+                return listCalls == 1 ? Ok("") : Fail("list failed");
+            }
+            if (args.Contains("--install"))
+            {
+                Directory.CreateDirectory(installPath);
+                File.WriteAllText(Path.Combine(installPath, "ext4.vhdx"), "partial");
+                return Fail("download failed");
+            }
+            if (args.SequenceEqual(["--terminate", "OpenClawGateway"]) ||
+                args.SequenceEqual(["--unregister", "OpenClawGateway"]))
+            {
+                return Fail("There is no distribution with the supplied name.");
+            }
+
+            return Fail($"unexpected args: {string.Join(' ', args)}");
+        });
+        var ctx = CreateContext(commands: commands);
+        installPath = Path.Combine(ctx.LocalDataDir, "wsl", "OpenClawGateway");
+
+        var result = await new CreateWslInstanceStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, result.Outcome);
+        Assert.Contains("download failed", result.Message);
+        Assert.DoesNotContain("Partial app-owned distro cleanup also failed", result.Message);
+        Assert.False(Directory.Exists(installPath));
         Assert.DoesNotContain(commands.Calls, c => c.Arguments.SequenceEqual(["--shutdown"]));
     }
 

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -8,29 +8,36 @@ namespace OpenClaw.SetupEngine.Tests;
 public class SetupStepsTests : IDisposable
 {
     private readonly string _tempDir;
+    private readonly string _localTempDir;
     private readonly string? _prevDataDir;
+    private readonly string? _prevLocalDataDir;
 
     public SetupStepsTests()
     {
         _tempDir = Path.Combine(Path.GetTempPath(), $"steps-test-{Guid.NewGuid():N}");
+        _localTempDir = Path.Combine(Path.GetTempPath(), $"steps-local-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
+        Directory.CreateDirectory(_localTempDir);
         _prevDataDir = Environment.GetEnvironmentVariable("OPENCLAW_TRAY_DATA_DIR");
+        _prevLocalDataDir = Environment.GetEnvironmentVariable("OPENCLAW_TRAY_LOCAL_DATA_DIR");
         Environment.SetEnvironmentVariable("OPENCLAW_TRAY_DATA_DIR", _tempDir);
+        Environment.SetEnvironmentVariable("OPENCLAW_TRAY_LOCAL_DATA_DIR", _localTempDir);
     }
 
     public void Dispose()
     {
         Environment.SetEnvironmentVariable("OPENCLAW_TRAY_DATA_DIR", _prevDataDir);
+        Environment.SetEnvironmentVariable("OPENCLAW_TRAY_LOCAL_DATA_DIR", _prevLocalDataDir);
         try { Directory.Delete(_tempDir, recursive: true); } catch { }
+        try { Directory.Delete(_localTempDir, recursive: true); } catch { }
     }
 
-    private SetupContext CreateContext(SetupConfig? config = null)
+    private SetupContext CreateContext(SetupConfig? config = null, ICommandRunner? commands = null)
     {
         var cfg = config ?? new SetupConfig { CleanBeforeRun = true };
         var logger = new SetupLogger(filePath: null, LogLevel.Trace);
         var journal = new TransactionJournal(filePath: null);
-        var commands = new CommandRunner(logger);
-        return new SetupContext(cfg, logger, journal, commands, CancellationToken.None);
+        return new SetupContext(cfg, logger, journal, commands ?? new CommandRunner(logger), CancellationToken.None);
     }
 
     // ─── CleanupStaleGatewayStep: Preserve non-local records ───
@@ -215,6 +222,185 @@ public class SetupStepsTests : IDisposable
 
         Assert.Equal(StepOutcome.Failed, result.Outcome);
         Assert.Contains("HTTPS", result.Message);
+    }
+
+    [Fact]
+    public async Task PreflightWsl_FailsForUnsupportedDirectInstallVersion()
+    {
+        var commands = new FakeCommandRunner(args =>
+            args is ["--version"]
+                ? Ok("WSL version: 2.3.0.0\n")
+                : Ok());
+        var ctx = CreateContext(commands: commands);
+
+        var result = await new PreflightWslStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.FailedTerminal, result.Outcome);
+        Assert.Contains("Update WSL", result.Message);
+    }
+
+    [Fact]
+    public async Task PreflightWsl_FailsWithUpdateMessageWhenVersionCommandIsUnsupported()
+    {
+        var commands = new FakeCommandRunner(args =>
+            args is ["--version"]
+                ? new CommandResult(1, "", "Invalid command line option: --version", TimeSpan.Zero, TimedOut: false)
+                : Ok());
+        var ctx = CreateContext(commands: commands);
+
+        var result = await new PreflightWslStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.FailedTerminal, result.Outcome);
+        Assert.Contains("too old", result.Message);
+        Assert.Contains("wsl --update", result.Message);
+    }
+
+    [Fact]
+    public async Task CreateWslInstance_UsesDirectFreshInstallAndDoesNotExportBaseDistro()
+    {
+        var installed = false;
+        var commands = new FakeCommandRunner(args =>
+        {
+            if (args.SequenceEqual(["--list", "--quiet"]))
+                return Ok(installed ? "OpenClawGateway\n" : "");
+            if (args.Contains("--install"))
+            {
+                installed = true;
+                return Ok("Installing Ubuntu-24.04\n");
+            }
+            if (args.SequenceEqual(["--list", "--verbose"]))
+                return Ok("  NAME              STATE           VERSION\n* OpenClawGateway   Stopped         2\n");
+            if (args.SequenceEqual(["-d", "OpenClawGateway", "-u", "root", "--", "sh", "-lc", "id -u && test -d / && echo OPENCLAW_FRESH_WSL_READY"]))
+                return Ok("0\nOPENCLAW_FRESH_WSL_READY\n");
+
+            return Fail($"unexpected args: {string.Join(' ', args)}");
+        });
+        var ctx = CreateContext(commands: commands);
+
+        var result = await new CreateWslInstanceStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Message);
+        Assert.DoesNotContain(commands.Calls, c => c.Arguments.Contains("--export"));
+        Assert.DoesNotContain(commands.Calls, c =>
+            c.Arguments is ["--terminate", "Ubuntu-24.04"] or ["--unregister", "Ubuntu-24.04"]);
+
+        var installCall = Assert.Single(commands.Calls, c => c.Arguments.Contains("--install"));
+        Assert.Contains("--distribution", installCall.Arguments);
+        Assert.Contains("Ubuntu-24.04", installCall.Arguments);
+        Assert.Contains("--name", installCall.Arguments);
+        Assert.Contains("OpenClawGateway", installCall.Arguments);
+        Assert.Contains("--location", installCall.Arguments);
+        Assert.Contains(Path.Combine(ctx.LocalDataDir, "wsl", "OpenClawGateway"), installCall.Arguments);
+        Assert.Contains("--web-download", installCall.Arguments);
+    }
+
+    [Fact]
+    public async Task CreateWslInstance_PartialCleanupAvoidsGlobalShutdownWhenUnregisterSucceeds()
+    {
+        var listCalls = 0;
+        var commands = new FakeCommandRunner(args =>
+        {
+            if (args.SequenceEqual(["--list", "--quiet"]))
+            {
+                listCalls++;
+                return Ok(listCalls == 1 ? "" : "OpenClawGateway\n");
+            }
+            if (args.Contains("--install"))
+                return Fail("download failed");
+            if (args.SequenceEqual(["--terminate", "OpenClawGateway"]))
+                return Ok();
+            if (args.SequenceEqual(["--unregister", "OpenClawGateway"]))
+                return Ok();
+
+            return Fail($"unexpected args: {string.Join(' ', args)}");
+        });
+        var ctx = CreateContext(commands: commands);
+
+        var result = await new CreateWslInstanceStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, result.Outcome);
+        Assert.Contains("download failed", result.Message);
+        Assert.DoesNotContain(commands.Calls, c => c.Arguments.SequenceEqual(["--shutdown"]));
+    }
+
+    [Fact]
+    public async Task CreateWslInstance_FailsWhenTargetDistroStillExists()
+    {
+        var commands = new FakeCommandRunner(args =>
+            args.SequenceEqual(["--list", "--quiet"])
+                ? Ok("OpenClawGateway\n")
+                : Fail($"unexpected args: {string.Join(' ', args)}"));
+        var ctx = CreateContext(commands: commands);
+
+        var result = await new CreateWslInstanceStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, result.Outcome);
+        Assert.Contains("still exists after cleanup", result.Message);
+        Assert.DoesNotContain(commands.Calls, c => c.Arguments.Contains("--install"));
+    }
+
+    [Fact]
+    public async Task CreateWslInstance_FailsWhenInstallDirectoryIsDirty()
+    {
+        var commands = new FakeCommandRunner(args =>
+            args.SequenceEqual(["--list", "--quiet"])
+                ? Ok("")
+                : Fail($"unexpected args: {string.Join(' ', args)}"));
+        var ctx = CreateContext(commands: commands);
+        var installPath = Path.Combine(ctx.LocalDataDir, "wsl", "OpenClawGateway");
+        Directory.CreateDirectory(installPath);
+        File.WriteAllText(Path.Combine(installPath, "ext4.vhdx"), "stale");
+
+        var result = await new CreateWslInstanceStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, result.Outcome);
+        Assert.Contains("still contains files after cleanup", result.Message);
+        Assert.DoesNotContain(commands.Calls, c => c.Arguments.Contains("--install"));
+    }
+
+    [Fact]
+    public async Task CreateWslInstance_RemovesStaleFileAtInstallPathBeforeInstalling()
+    {
+        var installed = false;
+        var commands = new FakeCommandRunner(args =>
+        {
+            if (args.SequenceEqual(["--list", "--quiet"]))
+                return Ok(installed ? "OpenClawGateway\n" : "");
+            if (args.Contains("--install"))
+            {
+                installed = true;
+                return Ok("Installing Ubuntu-24.04\n");
+            }
+            if (args.SequenceEqual(["--list", "--verbose"]))
+                return Ok("  NAME              STATE           VERSION\n* OpenClawGateway   Stopped         2\n");
+            if (args.SequenceEqual(["-d", "OpenClawGateway", "-u", "root", "--", "sh", "-lc", "id -u && test -d / && echo OPENCLAW_FRESH_WSL_READY"]))
+                return Ok("0\nOPENCLAW_FRESH_WSL_READY\n");
+
+            return Fail($"unexpected args: {string.Join(' ', args)}");
+        });
+        var ctx = CreateContext(commands: commands);
+        var installPath = Path.Combine(ctx.LocalDataDir, "wsl", "OpenClawGateway");
+        Directory.CreateDirectory(Path.GetDirectoryName(installPath)!);
+        File.WriteAllText(installPath, "stale");
+
+        var result = await new CreateWslInstanceStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Message);
+        Assert.False(File.Exists(installPath));
+        Assert.Contains(commands.Calls, c => c.Arguments.Contains("--install"));
+    }
+
+    [Fact]
+    public void WslInstallSupport_ParsesVersionAndVerboseDistroList()
+    {
+        Assert.True(WslInstallSupport.TryParseWslVersion("WSL version: 2.7.3.0", out var version));
+        Assert.True(WslInstallSupport.SupportsDirectNamedInstall(version));
+
+        Assert.True(WslInstallSupport.TryGetDistroVersion(
+            "  NAME              STATE           VERSION\n* OpenClawGateway   Stopped         2\n",
+            "OpenClawGateway",
+            out var distroVersion));
+        Assert.Equal(2, distroVersion);
     }
 
     private static int GetFreeTcpPort()
@@ -576,5 +762,38 @@ public class SetupStepsTests : IDisposable
         var props = typeof(PairingConfig).GetProperties();
         var scopeProps = props.Where(p => p.Name.Contains("Scope", StringComparison.OrdinalIgnoreCase)).ToList();
         Assert.Empty(scopeProps);
+    }
+
+    private static CommandResult Ok(string stdout = "", string stderr = "")
+        => new(0, stdout, stderr, TimeSpan.Zero, TimedOut: false);
+
+    private static CommandResult Fail(string stderr = "")
+        => new(1, "", stderr, TimeSpan.Zero, TimedOut: false);
+
+    private sealed class FakeCommandRunner(Func<string[], CommandResult> run) : ICommandRunner
+    {
+        public List<(string Executable, string[] Arguments)> Calls { get; } = [];
+
+        public Task<CommandResult> RunAsync(
+            string executable,
+            string[] arguments,
+            TimeSpan timeout,
+            IReadOnlyDictionary<string, string>? environment = null,
+            string? workingDirectory = null,
+            string? stdinInput = null,
+            CancellationToken ct = default)
+        {
+            Calls.Add((executable, arguments));
+            return Task.FromResult(run(arguments));
+        }
+
+        public Task<CommandResult> RunInWslAsync(
+            string distroName,
+            string command,
+            TimeSpan timeout,
+            IReadOnlyDictionary<string, string>? environment = null,
+            CancellationToken ct = default,
+            string? user = null)
+            => throw new NotSupportedException("RunInWslAsync is not expected in these tests.");
     }
 }

--- a/tests/OpenClaw.Tray.Tests/StartupSetupStateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/StartupSetupStateTests.cs
@@ -244,7 +244,12 @@ public class StartupSetupStateTests
         });
         var wsl = new FakeWslCommandRunner([new WslDistroInfo("OpenClawGateway", "Stopped", 2)]);
 
-        var kind = await SetupExistingGatewayClassifier.ClassifyAsync(registry, settings, temp.Path, wsl);
+        var kind = await SetupExistingGatewayClassifier.ClassifyAsync(
+            registry,
+            settings,
+            temp.Path,
+            wsl,
+            localDataPath: temp.Path);
 
         Assert.Equal(SetupExistingGatewayKind.AppOwnedLocalWsl, kind);
     }
@@ -263,7 +268,12 @@ public class StartupSetupStateTests
         });
         var wsl = new FakeWslCommandRunner([new WslDistroInfo("OpenClawGateway", "Stopped", 2)]);
 
-        var kind = await SetupExistingGatewayClassifier.ClassifyAsync(registry, settings, temp.Path, wsl);
+        var kind = await SetupExistingGatewayClassifier.ClassifyAsync(
+            registry,
+            settings,
+            temp.Path,
+            wsl,
+            localDataPath: temp.Path);
 
         Assert.Equal(SetupExistingGatewayKind.ExternalOnly, kind);
     }
@@ -276,7 +286,12 @@ public class StartupSetupStateTests
         var registry = new GatewayRegistry(temp.Path);
         var wsl = new FakeWslCommandRunner([new WslDistroInfo("OpenClawGateway", "Stopped", 2)]);
 
-        var kind = await SetupExistingGatewayClassifier.ClassifyAsync(registry, settings, temp.Path, wsl);
+        var kind = await SetupExistingGatewayClassifier.ClassifyAsync(
+            registry,
+            settings,
+            temp.Path,
+            wsl,
+            localDataPath: temp.Path);
 
         Assert.Equal(SetupExistingGatewayKind.None, kind);
     }


### PR DESCRIPTION
## Summary

This PR makes local gateway setup deterministic by removing the hidden dependency on an existing local Ubuntu distro. Setup now creates a fresh app-owned WSL gateway distro directly from the configured Ubuntu release every run, and fails explicitly when the host WSL version or install path cannot support that clean-start contract.

## What changed

- Replaced the old `wsl --export Ubuntu-24.04` / `wsl --import` flow with direct named install:
  - `wsl --install --distribution <BaseDistro> --name <DistroName> --location <app-owned path> --no-launch --web-download`
- Reinterpreted `BaseDistro` as the Ubuntu release to install from a clean WSL baseline, not a local source distro to export.
- Added WSL capability preflight before destructive cleanup so unsupported hosts fail before setup removes existing app-owned state.
- Reordered setup pipeline so OS/WSL preflight runs before cleanup, with the port check still after cleanup.
- Hardened cleanup and rollback behavior:
  - removes stale app-owned install directories with retry handling
  - deletes stale regular files at the target install path
  - rejects reparse points/symlinks at the install path with a clear error
  - avoids global `wsl --shutdown` during partial install cleanup when `--unregister` succeeds
- Improved unsupported/old WSL messaging so inbox WSL versions that do not support `wsl --version` tell users to update WSL.
- Updated setup UI progress text and docs to describe a clean WSL gateway install rather than cloning/exporting Ubuntu.
- Added regression tests covering direct install, no export/import behavior, no base distro mutation, install-path validation, WSL version parsing, cleanup behavior, and pipeline order.

## Motivation

The previous setup path could be poisoned by a missing or corrupted local `Ubuntu-24.04` distro because setup reused it as the export source. This PR makes setup predictable for users, support, and CI by always creating the gateway from a clean WSL install baseline and surfacing hard failures instead of falling back to hidden reuse paths.

## Validation

- `./build.ps1` — passed
- `dotnet test ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj --no-restore --tl:off` — passed, 181 tests
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore --tl:off` — passed, 2022 passed / 29 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore --tl:off` — passed, 843 tests
- `OPENCLAW_RUN_E2E=1 dotnet test ./tests/OpenClaw.E2ETests/OpenClaw.E2ETests.csproj -r win-arm64 --tl:off` — passed 3 consecutive runs, each 6 passed / 0 failed / 0 skipped

## Review notes

A Hanselman/adversarial review was run before finalizing. Follow-up fixes from that review are included: less disruptive partial cleanup, clearer old-WSL handling, and more robust install-path checks.
