### PR TITLE
Improve wizard restart recovery

### DIFF
--- a/docs/ONBOARDING_WIZARD.md
+++ b/docs/ONBOARDING_WIZARD.md
@@ -34,6 +34,8 @@ Renders server-defined setup steps via RPC (`wizard.start` / `wizard.next`). The
 
 If the gateway doesn't support the wizard protocol or is unreachable, this screen shows an "offline" message and can be skipped.
 
+If the gateway restarts or the wizard connection is lost while setup is running, the wizard presents recovery choices to start the wizard again or skip it for now so the user is not trapped retrying a broken session.
+
 ### Permissions
 Checks 5 Windows permissions using native APIs and registry:
 - Notifications (Toast capability)

--- a/src/OpenClaw.SetupEngine.UI/Pages/WizardPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WizardPage.xaml.cs
@@ -54,13 +54,14 @@ public sealed partial class WizardPage : Page
             _stepVisits.Clear();
             SetBusy("Connecting to gateway...");
             _client = await ConnectClientAsync();
+            _client.StatusChanged += OnWizardClientStatusChanged;
             SetBusy("Starting wizard...");
             var payload = await _client.SendWizardRequestAsync("wizard.start", timeoutMs: 30_000);
             await ApplyPayloadAsync(payload);
         }
         catch (Exception ex)
         {
-            ShowError($"Gateway wizard failed: {ex.Message}");
+            await EnterWizardErrorAsync($"Gateway wizard failed: {ex.Message}");
         }
     }
 
@@ -117,6 +118,25 @@ public sealed partial class WizardPage : Page
         {
             client.StatusChanged -= OnStatusChanged;
         }
+    }
+
+    private void OnWizardClientStatusChanged(object? sender, ConnectionStatus status)
+    {
+        if (status is not (ConnectionStatus.Disconnected or ConnectionStatus.Error))
+            return;
+
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            if (_errorState
+                || _client == null
+                || !ReferenceEquals(sender, _client)
+                || string.IsNullOrWhiteSpace(_sessionId))
+            {
+                return;
+            }
+
+            _ = EnterWizardErrorAsync("Gateway connection was lost while the wizard was running.");
+        });
     }
 
     private async Task ApplyPayloadAsync(JsonElement payload)
@@ -400,7 +420,7 @@ public sealed partial class WizardPage : Page
         }
         catch (Exception ex)
         {
-            ShowError(ex.Message);
+            await EnterWizardErrorAsync(ex.Message);
         }
     }
 
@@ -602,11 +622,21 @@ public sealed partial class WizardPage : Page
         StatusText.Text = "Wizard needs attention";
         ErrorText.Text = message;
         ErrorText.Visibility = Visibility.Visible;
-        PrimaryButton.Content = "Retry";
+        PrimaryButton.Content = "Start wizard again";
         PrimaryButton.IsEnabled = true;
         SecondaryButton.Content = "Skip wizard";
         SecondaryButton.IsEnabled = true;
         SecondaryButton.Visibility = Visibility.Visible;
+    }
+
+    private async Task EnterWizardErrorAsync(string detail)
+    {
+        if (_errorState)
+            return;
+
+        _errorState = true;
+        await DisconnectAsync();
+        ShowError(detail);
     }
 
     private async Task SkipWizardAsync()
@@ -626,10 +656,12 @@ public sealed partial class WizardPage : Page
 
     private async Task DisconnectAsync()
     {
-        if (_client == null) return;
-        try { await _client.DisconnectAsync(); } catch { }
-        _client.Dispose();
+        var client = _client;
+        if (client == null) return;
         _client = null;
+        client.StatusChanged -= OnWizardClientStatusChanged;
+        try { await client.DisconnectAsync(); } catch { }
+        client.Dispose();
     }
 
     private static string DisplayTitleFor(string stepType) => stepType switch


### PR DESCRIPTION
## Summary

- Detect gateway disconnect/error while the setup wizard has an active session and move the page into recovery instead of leaving a stale wizard step on screen.
- Change the recovery primary action from `Retry` to `Start wizard again`, while keeping `Skip wizard` available so users can continue setup without being trapped in a broken session.
- Dispose/unsubscribe the stale gateway client before showing recovery, and make the recovery path one-shot so simultaneous disconnect/RPC-failure paths cannot race into duplicate error handling.
- Document the expected gateway restart / connection-loss recovery behavior in the onboarding wizard docs.

## Testing

Required validation:

- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore --tl:off`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore --tl:off`

Full test sweep with E2E enabled:

- `OPENCLAW_RUN_E2E=1 dotnet test ./tests/OpenClaw.Connection.Tests/OpenClaw.Connection.Tests.csproj --no-restore --no-build --tl:off` — 256 passed
- `OPENCLAW_RUN_E2E=1 dotnet test ./tests/OpenClaw.E2ETests/OpenClaw.E2ETests.csproj --no-restore --no-build --tl:off` — 6 passed
- `OPENCLAW_RUN_E2E=1 dotnet test ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj --no-restore --no-build --tl:off` — 173 passed
- `OPENCLAW_RUN_E2E=1 dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore --no-build --tl:off` — 2022 passed, 29 skipped
- `OPENCLAW_RUN_E2E=1 dotnet test ./tests/OpenClaw.Tray.IntegrationTests/OpenClaw.Tray.IntegrationTests.csproj --no-restore --no-build --tl:off` — 18 skipped
- `OPENCLAW_RUN_E2E=1 dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore --no-build --tl:off` — 843 passed
- `OPENCLAW_RUN_E2E=1 dotnet test ./tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj --no-restore --no-build --tl:off -r win-arm64` — 62 passed
- `OPENCLAW_RUN_E2E=1 dotnet test ./tests/OpenClaw.WinNode.Cli.Tests/OpenClaw.WinNode.Cli.Tests.csproj --no-restore --no-build --tl:off` — 120 passed
- `OPENCLAW_RUN_E2E=1 dotnet test ./tests/OpenClawTray.FunctionalUI.Tests/OpenClawTray.FunctionalUI.Tests.csproj --no-restore --no-build --tl:off -r win-arm64` — 10 passed

Review:

- Ran a Hanselman dual-model adversarial review of the staged changes.
- Fixed the high-consensus re-entrancy issue by setting the wizard error guard before awaiting disconnect.
- Folded in the low-consensus hardening suggestion by moving wizard-client state checks onto the UI dispatcher.
