### PR TITLE
Fix QQSHI13 issue hardening pass

### DIFF
--- a/src/OpenClaw.Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/GatewayConnectionManager.cs
@@ -23,6 +23,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
     private readonly Func<GatewayRecord, string, bool>? _shouldStartNodeConnection;
     private readonly Func<TimeSpan, Task> _reconnectDelay;
     private readonly SemaphoreSlim _transitionSemaphore = new(1, 1);
+    private readonly object _disposeLock = new();
 
     private long _generation;
     private CancellationTokenSource? _operationCts;
@@ -30,6 +31,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
     private string? _activeIdentityPath; // identity directory for the active connection
     private string? _activeGatewayRecordId; // gateway record ID for node credential resolution
     private bool _disposed;
+    private Task? _disposeTask;
     private bool _gatewayNeedsV2Signature; // remembered across reconnects
     private string? _lastAutoApprovedRequestId; // prevent auto-approve loops
     private string? _autoApproveInFlight; // atomic guard against concurrent approval of same requestId
@@ -128,7 +130,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             oldCts?.Dispose();
 
             // Dispose old client
-            DisposeActiveClient();
+            await DisposeActiveClientAsync();
 
             // Update snapshot with gateway info
             _stateMachine.Current = _stateMachine.Current with
@@ -273,7 +275,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         await _transitionSemaphore.WaitAsync();
         try
         {
-            DisconnectCore();
+            await DisconnectCoreAsync();
         }
         finally
         {
@@ -282,10 +284,10 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
     }
 
     /// <summary>Core disconnect logic. Caller must hold <see cref="_transitionSemaphore"/>.</summary>
-    private void DisconnectCore()
+    private async Task DisconnectCoreAsync()
     {
         var prev = _stateMachine.Current.OverallState;
-        DisposeActiveClient();
+        await DisposeActiveClientAsync();
         _stateMachine.TryTransition(ConnectionTrigger.DisconnectRequested);
         _diagnostics.RecordStateChange(prev, _stateMachine.Current.OverallState);
         EmitStateChanged(prev);
@@ -297,7 +299,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         await _transitionSemaphore.WaitAsync();
         try
         {
-            DisconnectCore();
+            await DisconnectCoreAsync();
             await ConnectCoreAsync();
         }
         finally
@@ -312,7 +314,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         await _transitionSemaphore.WaitAsync();
         try
         {
-            DisconnectCore();
+            await DisconnectCoreAsync();
             // Stop tunnel when switching gateways — the new one may not need it.
             // Use a bounded timeout to avoid blocking all connection transitions.
             if (_tunnelManager?.IsActive == true)
@@ -767,7 +769,14 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         return true;
     }
 
-    private async void OnNodeStatusChanged(object? sender, ConnectionStatus status)
+    private void OnNodeStatusChanged(object? sender, ConnectionStatus status) =>
+        AsyncEventHandlerGuard.Run(
+            () => OnNodeStatusChangedAsync(status),
+            _logger,
+            nameof(OnNodeStatusChanged),
+            ex => _diagnostics.Record("node", "Node status handler failed", ex.Message));
+
+    private async Task OnNodeStatusChangedAsync(ConnectionStatus status)
     {
         _diagnostics.Record("node", $"Node status: {status}");
 
@@ -815,7 +824,14 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         }
     }
 
-    private async void OnNodePairingStatusChanged(object? sender, PairingStatusEventArgs e)
+    private void OnNodePairingStatusChanged(object? sender, PairingStatusEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            () => OnNodePairingStatusChangedAsync(e),
+            _logger,
+            nameof(OnNodePairingStatusChanged),
+            ex => _diagnostics.Record("node", "Node pairing handler failed", ex.Message));
+
+    private async Task OnNodePairingStatusChangedAsync(PairingStatusEventArgs e)
     {
         _diagnostics.Record("node", $"Node pairing: {e.Status}");
 
@@ -926,12 +942,13 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         StateChanged?.Invoke(this, snapshot);
     }
 
-    private void DisposeActiveClient()
+    private async Task DisposeActiveClientAsync()
     {
-        // Disconnect node first — run on threadpool to avoid sync context deadlocks
+        // Disconnect node first, but do not block the caller thread; shutdown
+        // and reconnect paths await this with a bounded timeout.
         if (_nodeConnector != null)
         {
-            try { Task.Run(() => _nodeConnector.DisconnectAsync()).Wait(TimeSpan.FromSeconds(2)); }
+            try { await WaitWithTimeoutAsync(_nodeConnector.DisconnectAsync(), TimeSpan.FromSeconds(2), "Node disconnect"); }
             catch (Exception ex) { _logger.Warn($"[ConnMgr] Node disconnect error: {ex.Message}"); }
         }
 
@@ -951,42 +968,116 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         }
     }
 
+    private async Task WaitWithTimeoutAsync(Task task, TimeSpan timeout, string operation)
+    {
+        var completed = await Task.WhenAny(task, Task.Delay(timeout)).ConfigureAwait(false);
+        if (completed != task)
+        {
+            _logger.Warn($"[ConnMgr] {operation} timed out after {timeout.TotalSeconds:F1}s");
+            return;
+        }
+
+        await task.ConfigureAwait(false);
+    }
+
     private void ThrowIfDisposed()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
     }
 
+    public ValueTask DisposeAsync()
+    {
+        var task = EnsureDisposeTask();
+        return new ValueTask(task);
+    }
+
     public void Dispose()
+    {
+        ObserveBackgroundFault(EnsureDisposeTask(), "[ConnMgr] Dispose error");
+    }
+
+    private Task EnsureDisposeTask()
+    {
+        lock (_disposeLock)
+        {
+            return _disposeTask ??= DisposeCoreAsync();
+        }
+    }
+
+    private async Task DisposeCoreAsync()
     {
         if (_disposed) return;
         _disposed = true;
+        _operationCts?.Cancel();
+
         // Unsubscribe from node events before disposing the semaphore
-        // to prevent async void handlers from crashing via ObjectDisposedException.
+        // to prevent guarded async handlers from racing the disposed semaphore.
         if (_nodeConnector != null)
         {
             _nodeConnector.StatusChanged -= OnNodeStatusChanged;
             _nodeConnector.PairingStatusChanged -= OnNodePairingStatusChanged;
         }
         // Acquire semaphore briefly to ensure no in-flight reconnect/switch is mid-transition.
-        // Use a short timeout — if something is stuck, proceed with disposal anyway.
-        try { _transitionSemaphore.Wait(TimeSpan.FromSeconds(2)); } catch { }
+        // Use a short timeout — if something is stuck, proceed with disposal anyway,
+        // but do not dispose the semaphore out from under the holder.
+        var semaphoreEntered = false;
+        try
+        {
+            semaphoreEntered = await _transitionSemaphore.WaitAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+            if (!semaphoreEntered)
+                _logger.Warn("[ConnMgr] Dispose timed out waiting for transition semaphore");
+        }
+        catch (ObjectDisposedException)
+        {
+            return;
+        }
+
         try
         {
             _stateMachine.TryTransition(ConnectionTrigger.Disposed);
-            DisposeActiveClient();
-            // Stop tunnel on app shutdown — run on threadpool with timeout to avoid stalling exit
+            await DisposeActiveClientAsync();
+            // Stop tunnel on app shutdown with timeout to avoid stalling exit.
             if (_tunnelManager?.IsActive == true)
             {
-                try { Task.Run(() => _tunnelManager.StopAsync()).Wait(TimeSpan.FromSeconds(3)); }
-                catch { /* shutting down — best effort */ }
+                try { await WaitWithTimeoutAsync(_tunnelManager.StopAsync(), TimeSpan.FromSeconds(3), "Tunnel stop"); }
+                catch (Exception ex) { _logger.Warn($"[ConnMgr] Tunnel stop error during dispose: {ex.Message}"); }
             }
-            _operationCts?.Cancel();
             _operationCts?.Dispose();
+            _operationCts = null;
         }
         finally
         {
-            try { _transitionSemaphore.Release(); } catch { }
-            _transitionSemaphore.Dispose();
+            if (semaphoreEntered)
+            {
+                try { _transitionSemaphore.Release(); } catch { }
+                _transitionSemaphore.Dispose();
+            }
+
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    private void ObserveBackgroundFault(Task task, string message)
+    {
+        if (task.IsFaulted)
+        {
+            _logger.Warn($"{message}: {task.Exception.GetBaseException().Message}");
+            return;
+        }
+
+        if (task.IsCanceled)
+        {
+            _logger.Warn($"{message}: canceled");
+            return;
+        }
+
+        if (!task.IsCompleted)
+        {
+            _ = task.ContinueWith(
+                t => _logger.Warn($"{message}: {t.Exception!.GetBaseException().Message}"),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
         }
     }
 }

--- a/src/OpenClaw.Connection/IGatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/IGatewayConnectionManager.cs
@@ -7,7 +7,7 @@ namespace OpenClaw.Connection;
 /// Manages operator connection, node connection, credential resolution,
 /// state transitions, and diagnostics.
 /// </summary>
-public interface IGatewayConnectionManager : IDisposable
+public interface IGatewayConnectionManager : IDisposable, IAsyncDisposable
 {
     // ─── State ───
     GatewayConnectionSnapshot CurrentSnapshot { get; }

--- a/src/OpenClaw.SetupEngine.UI/OpenClaw.SetupEngine.UI.csproj
+++ b/src/OpenClaw.SetupEngine.UI/OpenClaw.SetupEngine.UI.csproj
@@ -32,6 +32,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\OpenClaw.SetupEngine\OpenClaw.SetupEngine.csproj" />
+    <ProjectReference Include="..\OpenClaw.Shared\OpenClaw.Shared.csproj" />
   </ItemGroup>
 
   <!-- Reuse Setup assets from the Tray project -->

--- a/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
+using OpenClaw.Shared;
 using Windows.UI;
 
 namespace OpenClaw.SetupEngine.UI.Pages;
@@ -59,7 +60,13 @@ public sealed partial class ProgressPage : Page
         }
     }
 
-    private async void StartPipeline()
+    private void StartPipeline() =>
+        AsyncEventHandlerGuard.Run(
+            StartPipelineAsync,
+            NullLogger.Instance,
+            nameof(StartPipeline));
+
+    private async Task StartPipelineAsync()
     {
         var config = _config!;
         if (_runCts != null)

--- a/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using OpenClaw.SetupEngine;
+using OpenClaw.Shared;
 using System.Diagnostics;
 using System.Numerics;
 using Windows.UI;
@@ -57,7 +58,13 @@ public sealed partial class WelcomePage : Page
         visual.StartAnimation("Scale", pulse);
     }
 
-    private async void StartButton_Click(object sender, RoutedEventArgs e)
+    private void StartButton_Click(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            StartButtonClickAsync,
+            NullLogger.Instance,
+            nameof(StartButton_Click));
+
+    private async Task StartButtonClickAsync()
     {
         var dataDir = Environment.GetEnvironmentVariable("OPENCLAW_TRAY_DATA_DIR")
             ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "OpenClawTray");

--- a/src/OpenClaw.SetupEngine.UI/Pages/WizardPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WizardPage.xaml.cs
@@ -341,7 +341,13 @@ public sealed partial class WizardPage : Page
             : new SolidColorBrush(Microsoft.UI.Colors.Gray);
     }
 
-    private async void Primary_Click(object sender, RoutedEventArgs e)
+    private void Primary_Click(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            PrimaryClickAsync,
+            NullLogger.Instance,
+            nameof(Primary_Click));
+
+    private async Task PrimaryClickAsync()
     {
         if (_errorState)
         {
@@ -352,7 +358,13 @@ public sealed partial class WizardPage : Page
         await SendCurrentAnswerAsync(skip: false);
     }
 
-    private async void Secondary_Click(object sender, RoutedEventArgs e)
+    private void Secondary_Click(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            SecondaryClickAsync,
+            NullLogger.Instance,
+            nameof(Secondary_Click));
+
+    private async Task SecondaryClickAsync()
     {
         if (_errorState)
         {

--- a/src/OpenClaw.Shared/AsyncEventHandlerGuard.cs
+++ b/src/OpenClaw.Shared/AsyncEventHandlerGuard.cs
@@ -1,0 +1,42 @@
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Runs async event-handler work behind a fault boundary so fire-and-forget UI
+/// and transport events cannot crash the process through an async void escape.
+/// </summary>
+public static class AsyncEventHandlerGuard
+{
+    public static void Run(
+        Func<Task> work,
+        IOpenClawLogger? logger = null,
+        string? operationName = null,
+        Action<Exception>? onError = null)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+        _ = RunCoreAsync(work, logger, operationName, onError);
+    }
+
+    private static async Task RunCoreAsync(
+        Func<Task> work,
+        IOpenClawLogger? logger,
+        string? operationName,
+        Action<Exception>? onError)
+    {
+        try
+        {
+            await work();
+        }
+        catch (OperationCanceledException ex)
+        {
+            logger?.Debug($"{FormatOperation(operationName)} canceled: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            logger?.Error($"{FormatOperation(operationName)} failed", ex);
+            onError?.Invoke(ex);
+        }
+    }
+
+    private static string FormatOperation(string? operationName) =>
+        string.IsNullOrWhiteSpace(operationName) ? "Async event handler" : operationName;
+}

--- a/src/OpenClaw.Shared/Mcp/McpHttpServer.cs
+++ b/src/OpenClaw.Shared/Mcp/McpHttpServer.cs
@@ -42,7 +42,7 @@ namespace OpenClaw.Shared.Mcp;
 ///   - Active handler tasks are tracked so Stop/Dispose can drain in-flight
 ///     work before tearing down the semaphore and capability services.
 /// </summary>
-public sealed class McpHttpServer : IDisposable
+public sealed class McpHttpServer : IDisposable, IAsyncDisposable
 {
     private const long MaxRequestBodyBytes = 4L * 1024 * 1024; // 4 MiB
     // 16 leaves headroom for parallel tool callers (e.g. an editor + Claude
@@ -75,9 +75,12 @@ public sealed class McpHttpServer : IDisposable
     private readonly SemaphoreSlim _handlerLimiter = new(MaxConcurrentHandlers, MaxConcurrentHandlers);
     private readonly object _activeLock = new();
     private readonly HashSet<Task> _activeHandlers = new();
+    private readonly object _shutdownLock = new();
     private Task? _acceptLoop;
+    private Task? _stopTask;
+    private Task? _disposeTask;
     private int _disposed;
-    private int _stopping;
+    private bool _resourcesDisposed;
 
     public int Port => _port;
     public string Endpoint => $"http://127.0.0.1:{_port}/";
@@ -411,11 +414,12 @@ public sealed class McpHttpServer : IDisposable
     /// </summary>
     public Task StopAsync(TimeSpan drainTimeout)
     {
-        // Idempotence is governed by _stopping (not _disposed) so that Dispose
-        // can call the same drain path *after* setting _disposed=1. The previous
-        // code keyed on _disposed and silently skipped the drain in that flow.
-        if (Interlocked.Exchange(ref _stopping, 1) != 0) return Task.CompletedTask;
-        return StopCoreAsync(drainTimeout);
+        lock (_shutdownLock)
+        {
+            // Return the in-flight stop so later callers still wait for the
+            // original drain instead of observing a false "already stopped".
+            return _stopTask ??= StopCoreAsync(drainTimeout);
+        }
     }
 
     private async Task StopCoreAsync(TimeSpan drainTimeout)
@@ -445,35 +449,87 @@ public sealed class McpHttpServer : IDisposable
         }
     }
 
+    public ValueTask DisposeAsync()
+    {
+        var task = EnsureDisposeTask();
+        return new ValueTask(task);
+    }
+
     public void Dispose()
     {
-        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
-        // Run the drain unconditionally on dispose. We can't go through the
-        // public StopAsync because a prior caller may already have set
-        // _stopping — we still need to wait for the drain to finish before
-        // tearing down the limiter and CTS.
-        if (Interlocked.Exchange(ref _stopping, 1) == 0)
+        ObserveBackgroundFault(EnsureDisposeTask(), "[MCP] Dispose error");
+    }
+
+    private Task EnsureDisposeTask()
+    {
+        lock (_shutdownLock)
         {
-            try { StopCoreAsync(DrainTimeout).GetAwaiter().GetResult(); }
-            catch (Exception ex) { _logger.Warn($"[MCP] Drain error: {ex.Message}"); }
-        }
-        else
-        {
-            // A prior StopAsync is in flight; wait briefly for it to finish so
-            // we don't dispose the limiter while a handler is still inside it.
-            lock (_activeLock)
+            if (_disposeTask != null)
             {
-                if (_activeHandlers.Count > 0)
-                {
-                    Task[] toAwait = new Task[_activeHandlers.Count];
-                    _activeHandlers.CopyTo(toAwait);
-                    try { Task.WhenAny(Task.WhenAll(toAwait), Task.Delay(DrainTimeout)).GetAwaiter().GetResult(); }
-                    catch { /* swallow — best-effort */ }
-                }
+                return _disposeTask;
             }
+
+            Interlocked.Exchange(ref _disposed, 1);
+            _disposeTask = DisposeCoreAsync();
+            return _disposeTask;
         }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        try
+        {
+            await StopAsync(DrainTimeout).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"[MCP] Drain error: {ex.Message}");
+        }
+        finally
+        {
+            DisposeResources();
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    private void DisposeResources()
+    {
+        lock (_shutdownLock)
+        {
+            if (_resourcesDisposed)
+            {
+                return;
+            }
+
+            _resourcesDisposed = true;
+        }
+
         try { _listener.Close(); } catch { /* already closed */ }
         _cts.Dispose();
         _handlerLimiter.Dispose();
+    }
+
+    private void ObserveBackgroundFault(Task task, string message)
+    {
+        if (task.IsFaulted)
+        {
+            _logger.Warn($"{message}: {task.Exception.GetBaseException().Message}");
+            return;
+        }
+
+        if (task.IsCanceled)
+        {
+            _logger.Warn($"{message}: canceled");
+            return;
+        }
+
+        if (!task.IsCompleted)
+        {
+            _ = task.ContinueWith(
+                t => _logger.Warn($"{message}: {t.Exception!.GetBaseException().Message}"),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
     }
 }

--- a/src/OpenClaw.Shared/SettingsData.cs
+++ b/src/OpenClaw.Shared/SettingsData.cs
@@ -6,7 +6,7 @@ namespace OpenClaw.Shared;
 /// <summary>
 /// Serializable settings data model. Used for JSON round-trip persistence.
 /// </summary>
-public class SettingsData
+public record class SettingsData
 {
     public string? GatewayUrl { get; set; }
     public bool UseSshTunnel { get; set; } = false;

--- a/src/OpenClaw.Tray.WinUI/App.ToastActivation.cs
+++ b/src/OpenClaw.Tray.WinUI/App.ToastActivation.cs
@@ -1,0 +1,50 @@
+using Microsoft.Toolkit.Uwp.Notifications;
+using OpenClawTray.Helpers;
+using OpenClawTray.Services;
+using System.Diagnostics;
+
+namespace OpenClawTray;
+
+public partial class App
+{
+    private void OnToastActivated(ToastNotificationActivatedEventArgsCompat args)
+    {
+        var arguments = ToastArguments.Parse(args.Argument);
+        var action = GetToastArgument(arguments, "action");
+
+        OnUiThread(() => ToastActivationRouter.Route(
+            action,
+            key => GetToastArgument(arguments, key),
+            new ToastActivationActions
+            {
+                OpenUrl = url =>
+                {
+                    try { Process.Start(new ProcessStartInfo(url) { UseShellExecute = true }); }
+                    catch { }
+                },
+                OpenDashboard = () => OpenDashboard(),
+                OpenSettings = ShowSettings,
+                OpenChat = ShowWebChat,
+                OpenActivity = () => ShowHub("channels"),
+                CopyPairingCommand = command =>
+                {
+                    CopyTextToClipboard(command);
+                    _toastService!.ShowToast(new ToastContentBuilder()
+                        .AddText(LocalizationHelper.GetString("Toast_PairingCommandCopied"))
+                        .AddText(command));
+                }
+            }));
+    }
+
+    private static string? GetToastArgument(ToastArguments arguments, string key)
+    {
+        return arguments.TryGetValue(key, out var value)
+            ? value
+            : null;
+    }
+
+    public static void CopyTextToClipboard(string text)
+    {
+        ClipboardHelper.CopyText(text);
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -362,7 +362,13 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         return null;
     }
 
-    protected override async void OnLaunched(LaunchActivatedEventArgs args)
+    protected override void OnLaunched(LaunchActivatedEventArgs args) =>
+        AsyncEventHandlerGuard.Run(
+            () => OnLaunchedAsync(args),
+            new AppLogger(),
+            nameof(OnLaunched));
+
+    private async Task OnLaunchedAsync(LaunchActivatedEventArgs args)
     {
         _startupArgs = Environment.GetCommandLineArgs();
         _dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
@@ -475,9 +481,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
         // Initialize tray icon FIRST (window-less pattern from WinUIEx).
         // The tray is application chrome and must always survive any failure
-        // in the onboarding wizard. OnLaunched is async void, so a synchronous
-        // throw inside the OnboardingWindow constructor would otherwise
-        // propagate through `await ShowOnboardingAsync()` and abort OnLaunched
+        // in the onboarding wizard. OnLaunched delegates through a guarded
+        // async boundary so onboarding failures are logged instead of escaping
         // before the tray ever initializes.
         InitializeTrayIcon();
         // Apply the user's saved default chat preset (if any) before any chat
@@ -837,7 +842,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         ShowTrayMenuPopup();
     }
 
-    private async void ShowTrayMenuPopup()
+    private void ShowTrayMenuPopup()
     {
         try
         {
@@ -3117,7 +3122,13 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     void IAppCommands.ShowConnectionStatus() => ShowConnectionStatusWindow();
     void IAppCommands.NotifySettingsSaved() => OnSettingsSaved(this, EventArgs.Empty);
 
-    private async void ToggleChannel(string channelName)
+    private void ToggleChannel(string channelName) =>
+        AsyncEventHandlerGuard.Run(
+            () => ToggleChannelAsync(channelName),
+            new AppLogger(),
+            nameof(ToggleChannel));
+
+    private async Task ToggleChannelAsync(string channelName)
     {
         var client = _connectionManager?.OperatorClient;
         if (client == null) return;
@@ -3941,56 +3952,14 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
     #endregion
 
-    #region Toast Activation
-
-    private void OnToastActivated(ToastNotificationActivatedEventArgsCompat args)
-    {
-        var arguments = ToastArguments.Parse(args.Argument);
-        
-        if (arguments.TryGetValue("action", out var action))
-        {
-            OnUiThread(() =>
-            {
-                switch (action)
-                {
-                    case "open_url" when arguments.TryGetValue("url", out var url):
-                        try { Process.Start(new ProcessStartInfo(url) { UseShellExecute = true }); }
-                        catch { }
-                        break;
-                    case "open_dashboard":
-                        OpenDashboard();
-                        break;
-                    case "open_settings":
-                        ShowSettings();
-                        break;
-                    case "open_chat":
-                        ShowWebChat();
-                        break;
-                    case "open_activity":
-                        // ActivityPage removed — redirect to Channels.
-                        ShowHub("channels");
-                        break;
-                    case "copy_pairing_command" when arguments.TryGetValue("command", out var command):
-                        CopyTextToClipboard(command);
-                        _toastService!.ShowToast(new ToastContentBuilder()
-                            .AddText(LocalizationHelper.GetString("Toast_PairingCommandCopied"))
-                            .AddText(command));
-                        break;
-                }
-            });
-        }
-    }
-
-    public static void CopyTextToClipboard(string text)
-    {
-        ClipboardHelper.CopyText(text);
-    }
-
-    #endregion
-
     #region Exit
 
     private void ExitApplication()
+    {
+        _ = ExitApplicationAsync();
+    }
+
+    private async Task ExitApplicationAsync()
     {
         if (_isExiting)
         {
@@ -4016,10 +3985,15 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         });
 
         // Dispose runtime services
-        SafeShutdownStep("gateway client", () =>
+        var connectionManager = _connectionManager;
+        if (connectionManager != null)
         {
-            _connectionManager?.Dispose();
-        });
+            await SafeShutdownStepAsync("gateway client", async () =>
+            {
+                await connectionManager.DisposeAsync();
+            });
+            _connectionManager = null;
+        }
 
         SafeShutdownStep("chat coordinator", () =>
         {
@@ -4027,17 +4001,25 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             _chatCoordinator = null;
         });
 
-        SafeShutdownStep("node service", () =>
+        var nodeService = _nodeService;
+        if (nodeService != null)
         {
-            _nodeService?.Dispose();
+            await SafeShutdownStepAsync("node service", async () =>
+            {
+                await nodeService.DisposeAsync();
+            });
             _nodeService = null;
-        });
+        }
 
-        SafeShutdownStep("standalone voice service", () =>
+        var standaloneVoiceService = _standaloneVoiceService;
+        if (standaloneVoiceService != null)
         {
-            _standaloneVoiceService?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            await SafeShutdownStepAsync("standalone voice service", async () =>
+            {
+                await standaloneVoiceService.DisposeAsync();
+            });
             _standaloneVoiceService = null;
-        });
+        }
 
         SafeShutdownStep("ssh tunnel service", () =>
         {
@@ -4095,6 +4077,20 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         {
             Logger.Info($"Shutdown: disposing {name}");
             action();
+            Logger.Info($"Shutdown: disposed {name}");
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Shutdown: failed disposing {name}: {ex.Message}");
+        }
+    }
+
+    private static async Task SafeShutdownStepAsync(string name, Func<Task> action)
+    {
+        try
+        {
+            Logger.Info($"Shutdown: disposing {name}");
+            await action();
             Logger.Info($"Shutdown: disposed {name}");
         }
         catch (Exception ex)
@@ -4161,7 +4157,13 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
     #endregion
 
-    private async void OnSshTunnelExited(object? sender, int exitCode)
+    private void OnSshTunnelExited(object? sender, int exitCode) =>
+        AsyncEventHandlerGuard.Run(
+            () => OnSshTunnelExitedAsync(exitCode),
+            new AppLogger(),
+            nameof(OnSshTunnelExited));
+
+    private async Task OnSshTunnelExitedAsync(int exitCode)
     {
         Logger.Warn($"SSH tunnel exited unexpectedly (code {exitCode}); restarting in 3s...");
         _sshTunnelService?.MarkRestarting(exitCode);

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
@@ -1,4 +1,5 @@
 using OpenClaw.Chat;
+using OpenClaw.Shared;
 using OpenClawTray.Helpers;
 using System;
 using System.Collections.Generic;
@@ -513,7 +514,13 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
         // can toggle to stop playback on a second press.
         var speakingEntryId = UseState<string?>(null, threadSafe: true);
 
-        async void AckAction(string entryId, string actionKey)
+        void AckAction(string entryId, string actionKey) =>
+            AsyncEventHandlerGuard.Run(
+                () => AckActionAsync(entryId, actionKey),
+                new OpenClawTray.AppLogger(),
+                nameof(AckAction));
+
+        async Task AckActionAsync(string entryId, string actionKey)
         {
             var key = entryId + "|" + actionKey;
             ackUpdate(prev =>
@@ -865,7 +872,13 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
             catch { /* clipboard contention — silently ignore */ }
         }
 
-        async void ReadAloud(string entryId, string text)
+        void ReadAloud(string entryId, string text) =>
+            AsyncEventHandlerGuard.Run(
+                () => ReadAloudAsync(entryId, text),
+                new OpenClawTray.AppLogger(),
+                nameof(ReadAloud));
+
+        async Task ReadAloudAsync(string entryId, string text)
         {
             if (string.IsNullOrEmpty(text)) return;
 

--- a/src/OpenClaw.Tray.WinUI/Pages/AboutPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/AboutPage.xaml.cs
@@ -93,7 +93,13 @@ public sealed partial class AboutPage : Page
         }
     }
 
-    private async void OnCopySupportClick(object sender, RoutedEventArgs e)
+    private void OnCopySupportClick(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnCopySupportClickAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnCopySupportClick));
+
+    private async Task OnCopySupportClickAsync()
     {
         try
         {

--- a/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
@@ -316,10 +316,11 @@ public sealed partial class ChannelsPage : Page
         return _configSnapshot.HasRoot;
     }
 
-    private async void OnRefreshAll(object sender, RoutedEventArgs e)
-    {
-        await RefreshAsync();
-    }
+    private void OnRefreshAll(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            () => RefreshAsync(),
+            new OpenClawTray.AppLogger(),
+            nameof(OnRefreshAll));
 
     private async Task RefreshAsync(bool probe = true)
     {

--- a/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
@@ -467,7 +467,13 @@ public sealed partial class ConfigPage : Page
         UpdateMetaAndButtons();
     }
 
-    private async void OnSave(object sender, RoutedEventArgs e)
+    private void OnSave(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnSaveAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnSave));
+
+    private async Task OnSaveAsync()
     {
         if (_saving) return;
 
@@ -1292,7 +1298,13 @@ public sealed partial class ConfigPage : Page
         return true;
     }
 
-    private async void OnTreeItemInvoked(TreeView sender, TreeViewItemInvokedEventArgs args)
+    private void OnTreeItemInvoked(TreeView sender, TreeViewItemInvokedEventArgs args) =>
+        AsyncEventHandlerGuard.Run(
+            () => OnTreeItemInvokedAsync(args),
+            new OpenClawTray.AppLogger(),
+            nameof(OnTreeItemInvoked));
+
+    private async Task OnTreeItemInvokedAsync(TreeViewItemInvokedEventArgs args)
     {
         if (args.InvokedItem is TreeViewNode node && _nodeMap.TryGetValue(node, out var entry))
         {

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -1503,7 +1503,13 @@ public sealed partial class ConnectionPage : Page
         RefreshFromSnapshot(_lastSnapshot);
     }
 
-    private async void OnApplyRepairCode(object sender, RoutedEventArgs e)
+    private void OnApplyRepairCode(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnApplyRepairCodeAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnApplyRepairCode));
+
+    private async Task OnApplyRepairCodeAsync()
     {
         var code = RecoveryRepairCodeBox.Text?.Trim();
         if (string.IsNullOrEmpty(code) || _connectionManager == null) return;
@@ -1522,7 +1528,13 @@ public sealed partial class ConnectionPage : Page
 
     // ─── Saved-gateway row actions ───────────────────────────────────
 
-    private async void OnConnectSavedGateway(object sender, RoutedEventArgs e)
+    private void OnConnectSavedGateway(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            () => OnConnectSavedGatewayAsync(sender),
+            new OpenClawTray.AppLogger(),
+            nameof(OnConnectSavedGateway));
+
+    private async Task OnConnectSavedGatewayAsync(object sender)
     {
         if (sender is not Button btn || btn.Tag is not string gwId) return;
         if (_gatewayRegistry == null || _connectionManager == null) return;
@@ -1603,7 +1615,13 @@ public sealed partial class ConnectionPage : Page
         RefreshFromSnapshot(_lastSnapshot);
     }
 
-    private async void OnSavedRowRemove(object sender, RoutedEventArgs e)
+    private void OnSavedRowRemove(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            () => OnSavedRowRemoveAsync(sender),
+            new OpenClawTray.AppLogger(),
+            nameof(OnSavedRowRemove));
+
+    private async Task OnSavedRowRemoveAsync(object sender)
     {
         if (sender is not MenuFlyoutItem item || item.Tag is not string gwId) return;
         var rec = _gatewayRegistry?.GetById(gwId);
@@ -1744,7 +1762,13 @@ public sealed partial class ConnectionPage : Page
         }
     }
 
-    private async void OnAddSave(object sender, RoutedEventArgs e)
+    private void OnAddSave(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnAddSaveAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnAddSave));
+
+    private async Task OnAddSaveAsync()
     {
         var tag = ActiveAddPaneTag();
         AddResultText.Text = "";
@@ -2161,7 +2185,13 @@ public sealed partial class ConnectionPage : Page
     /// Welcome inline Scan button. Toggles scan on/off; on completion
     /// populates whichever discovered-list panel is visible.
     /// </summary>
-    private async void OnScanGatewaysClicked(object sender, RoutedEventArgs e)
+    private void OnScanGatewaysClicked(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnScanGatewaysClickedAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnScanGatewaysClicked));
+
+    private async Task OnScanGatewaysClickedAsync()
     {
         if (_scanInProgress)
         {

--- a/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
@@ -406,14 +406,15 @@ public sealed partial class DebugPage : Page
 
     // ── Section 1: Share diagnostics with support ────────────────────
 
-    private async void OnCreateDiagnosticsBundle(object sender, RoutedEventArgs e)
-    {
-        await ShowBundlePreviewAsync(
-            title: "Diagnostics bundle",
-            buildText: CommandCenterTextHelper.BuildDebugBundle,
-            suggestedFileName: $"openclaw-diagnostics-{DateTime.Now:yyyyMMdd-HHmmss}.txt",
-            headerCaption: "This is the complete bundle that would be copied or saved.");
-    }
+    private void OnCreateDiagnosticsBundle(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            () => ShowBundlePreviewAsync(
+                title: "Diagnostics bundle",
+                buildText: CommandCenterTextHelper.BuildDebugBundle,
+                suggestedFileName: $"openclaw-diagnostics-{DateTime.Now:yyyyMMdd-HHmmss}.txt",
+                headerCaption: "This is the complete bundle that would be copied or saved."),
+            new OpenClawTray.AppLogger(),
+            nameof(OnCreateDiagnosticsBundle));
 
     private async Task ShowBundlePreviewAsync(
         string title,
@@ -673,7 +674,13 @@ public sealed partial class DebugPage : Page
         }
     }
 
-    private async void OnRelaunchOnboarding(object sender, RoutedEventArgs e)
+    private void OnRelaunchOnboarding(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnRelaunchOnboardingAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnRelaunchOnboarding));
+
+    private async Task OnRelaunchOnboardingAsync()
     {
         if (XamlRoot == null) return;
 

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
@@ -225,11 +225,14 @@ public sealed partial class PermissionsPage : Page
     /// page-locally so <see cref="UpdateSttEngineHint"/> can surface "downloading" /
     /// failure copy that's accurate regardless of which code path started the download.
     /// </summary>
-    private async void EnsureWhisperModelDownloadedAsync()
+    private void EnsureWhisperModelDownloadedAsync() =>
+        AsyncEventHandlerGuard.Run(
+            EnsureWhisperModelDownloadedCoreAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(EnsureWhisperModelDownloadedAsync));
+
+    private async Task EnsureWhisperModelDownloadedCoreAsync()
     {
-        // async void: ANY uncaught throw bypasses WinUI's UnhandledException handling
-        // and tears down the process. Keep every statement inside the try so we can't
-        // miss a constructor / IO / XAML access that fails before the await.
         var logger = new AppLogger();
         try
         {
@@ -267,7 +270,7 @@ public sealed partial class PermissionsPage : Page
         }
         catch (Exception ex)
         {
-            // Last-resort guard: log and swallow so async void can never crash the app.
+            // Last-resort guard: log and swallow so background work can never crash the app.
             logger.Error($"[PermissionsPage] EnsureWhisperModelDownloadedAsync unexpected failure: {ex}");
         }
     }

--- a/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
@@ -238,7 +238,13 @@ public sealed partial class SandboxPage : Page
         UnavailableActionBar.IsOpen = true;
     }
 
-    private async void OnUnavailableActionClick(object sender, RoutedEventArgs e)
+    private void OnUnavailableActionClick(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            () => OnUnavailableActionClickAsync(sender),
+            new OpenClawTray.AppLogger(),
+            nameof(OnUnavailableActionClick));
+
+    private async Task OnUnavailableActionClickAsync(object sender)
     {
         if (sender is not Button btn) return;
         var tag = btn.Tag as string;
@@ -460,7 +466,13 @@ public sealed partial class SandboxPage : Page
 
     // ── Event handlers ───────────────────────────────────────────────
 
-    private async void OnSandboxEnabledToggled(object sender, RoutedEventArgs e)
+    private void OnSandboxEnabledToggled(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnSandboxEnabledToggledAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnSandboxEnabledToggled));
+
+    private async Task OnSandboxEnabledToggledAsync()
     {
         if (_suppress) return;
         if (CurrentApp.Settings is not { } s) return;
@@ -556,8 +568,11 @@ public sealed partial class SandboxPage : Page
         Save();
     }
 
-    private async void OnAddCustomFolder(object sender, RoutedEventArgs e)
-        => await PickCustomFolderAsync(SandboxFolderAccess.ReadOnly);
+    private void OnAddCustomFolder(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            () => PickCustomFolderAsync(SandboxFolderAccess.ReadOnly),
+            new OpenClawTray.AppLogger(),
+            nameof(OnAddCustomFolder));
 
     private async System.Threading.Tasks.Task PickCustomFolderAsync(SandboxFolderAccess access)
     {

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -277,7 +277,13 @@ public sealed partial class SessionsPage : Page
         return null;
     }
 
-    private async void OnResetSession(object sender, RoutedEventArgs e)
+    private void OnResetSession(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            () => OnResetSessionAsync(sender),
+            new OpenClawTray.AppLogger(),
+            nameof(OnResetSession));
+
+    private async Task OnResetSessionAsync(object sender)
     {
         if (ResolveSessionKey(sender) is not string key) return;
         var client = CurrentApp.GatewayClient;
@@ -286,7 +292,13 @@ public sealed partial class SessionsPage : Page
         catch (Exception ex) { ShowActionFailure("Reset failed", ex); }
     }
 
-    private async void OnDeleteSession(object sender, RoutedEventArgs e)
+    private void OnDeleteSession(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            () => OnDeleteSessionAsync(sender),
+            new OpenClawTray.AppLogger(),
+            nameof(OnDeleteSession));
+
+    private async Task OnDeleteSessionAsync(object sender)
     {
         if (ResolveSessionKey(sender) is not string key) return;
         var client = CurrentApp.GatewayClient;
@@ -295,7 +307,13 @@ public sealed partial class SessionsPage : Page
         catch (Exception ex) { ShowActionFailure("Delete failed", ex); }
     }
 
-    private async void OnCompactSession(object sender, RoutedEventArgs e)
+    private void OnCompactSession(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            () => OnCompactSessionAsync(sender),
+            new OpenClawTray.AppLogger(),
+            nameof(OnCompactSession));
+
+    private async Task OnCompactSessionAsync(object sender)
     {
         if (ResolveSessionKey(sender) is not string key) return;
         var client = CurrentApp.GatewayClient;

--- a/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml.cs
@@ -237,7 +237,13 @@ public sealed partial class SettingsPage : Page
         catch { }
     }
 
-    private async void OnRemoveGateway(object sender, RoutedEventArgs e)
+    private void OnRemoveGateway(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnRemoveGatewayAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnRemoveGateway));
+
+    private async Task OnRemoveGatewayAsync()
     {
         var dialogContent = new StackPanel { Spacing = 8 };
         dialogContent.Children.Add(new TextBlock

--- a/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using OpenClaw.Shared;
 using OpenClawTray.Services;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -92,7 +93,13 @@ public sealed partial class SkillsPage : Page
             _ = client.RequestSkillsStatusAsync(GetSelectedAgentId());
     }
 
-    private async void OnToggleSkillClick(object sender, RoutedEventArgs e)
+    private void OnToggleSkillClick(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            () => OnToggleSkillClickAsync(sender),
+            new OpenClawTray.AppLogger(),
+            nameof(OnToggleSkillClick));
+
+    private async Task OnToggleSkillClickAsync(object sender)
     {
         if (sender is not Button btn || btn.Tag is not string skillKey) return;
         if (CurrentApp.GatewayClient == null) return;

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
@@ -212,7 +212,13 @@ public sealed partial class VoiceSettingsPage : Page
         CurrentApp.Settings.Save();
     }
 
-    private async void OnDownloadClick(object sender, RoutedEventArgs e)
+    private void OnDownloadClick(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnDownloadClickAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnDownloadClick));
+
+    private async Task OnDownloadClickAsync()
     {
         if (CurrentApp.Settings == null) return;
 
@@ -296,7 +302,7 @@ public sealed partial class VoiceSettingsPage : Page
 
     // â”€â”€ TTS Voice Selection â”€â”€
 
-    private async void OnTestVoiceClick(object sender, RoutedEventArgs e)
+    private void OnTestVoiceClick(object sender, RoutedEventArgs e)
     {
         if (CurrentApp.Settings == null) return;
 
@@ -310,7 +316,13 @@ public sealed partial class VoiceSettingsPage : Page
         InlineTestPillHost.Visibility = Visibility.Collapsed;
     }
 
-    private async void OnInlineTestCloseClick(object sender, RoutedEventArgs e)
+    private void OnInlineTestCloseClick(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnInlineTestCloseClickAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnInlineTestCloseClick));
+
+    private async Task OnInlineTestCloseClickAsync()
     {
         await StopInlineTestAsync();
         InlineTestArea.Visibility = Visibility.Collapsed;
@@ -382,7 +394,13 @@ public sealed partial class VoiceSettingsPage : Page
         InlineTestPillHost.Children.Add(_inlineTestPillContainer);
     }
 
-    private async void OnInlineTestStartClick(object sender, RoutedEventArgs e)
+    private void OnInlineTestStartClick(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnInlineTestStartClickAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnInlineTestStartClick));
+
+    private async Task OnInlineTestStartClickAsync()
     {
         if (CurrentApp.Settings == null) return;
         InlineTestStartBtn.IsEnabled = false;
@@ -617,7 +635,13 @@ public sealed partial class VoiceSettingsPage : Page
         PiperDownloadProgress.Visibility = Visibility.Collapsed;
     }
 
-    private async void OnPiperDownloadClick(object sender, RoutedEventArgs e)
+    private void OnPiperDownloadClick(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnPiperDownloadClickAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnPiperDownloadClick));
+
+    private async Task OnPiperDownloadClickAsync()
     {
         if (CurrentApp.Settings == null) return;
         if (PiperVoiceCombo.SelectedItem is not ComboBoxItem item || item.Tag is not string voiceId) return;
@@ -704,7 +728,13 @@ public sealed partial class VoiceSettingsPage : Page
         }
     }
 
-    private async void OnPiperPreviewClick(object sender, RoutedEventArgs e)
+    private void OnPiperPreviewClick(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnPiperPreviewClickAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnPiperPreviewClick));
+
+    private async Task OnPiperPreviewClickAsync()
     {
         if (CurrentApp.Settings == null) return;
         if (PiperVoiceCombo.SelectedItem is not ComboBoxItem item || item.Tag is not string voiceId) return;
@@ -808,7 +838,13 @@ public sealed partial class VoiceSettingsPage : Page
         }
     }
 
-    private async void OnPreviewVoiceClick(object sender, RoutedEventArgs e)
+    private void OnPreviewVoiceClick(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnPreviewVoiceClickAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnPreviewVoiceClick));
+
+    private async Task OnPreviewVoiceClickAsync()
     {
         if (CurrentApp.Settings == null) return;
 

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -20,15 +20,17 @@ namespace OpenClawTray.Services;
 /// <summary>
 /// Windows Node service - manages node connection and capabilities
 /// </summary>
-public sealed class NodeService : IDisposable
+public sealed class NodeService : IDisposable, IAsyncDisposable
 {
     private readonly IOpenClawLogger _logger;
     private readonly DispatcherQueue _dispatcherQueue;
     private readonly Func<FrameworkElement?> _rootProvider;
     private readonly SettingsManager? _settings;
     private readonly SemaphoreSlim _consentLock = new(1, 1);
+    private readonly object _disposeLock = new();
     private TaskCompletionSource<bool>? _screenConsentInFlight;
     private TaskCompletionSource<bool>? _cameraConsentInFlight;
+    private Task? _disposeTask;
     private WindowsNodeClient? _nodeClient;
     private CanvasWindow? _canvasWindow;
     // Invariant: _a2uiCanvasWindow is only read/written from the UI dispatcher
@@ -231,9 +233,9 @@ public sealed class NodeService : IDisposable
     /// <see cref="OpenClawTray.Services.Connection.NodeConnector"/>; call
     /// <c>GatewayConnectionManager.DisconnectAsync</c> to actually close the WebSocket.
     /// </summary>
-    public Task DisconnectAsync()
+    public async Task DisconnectAsync()
     {
-        StopMcpServer();
+        await StopMcpServerAsync().ConfigureAwait(false);
 
         WindowsNodeClient? previous;
         lock (_clientLock)
@@ -261,8 +263,6 @@ public sealed class NodeService : IDisposable
             _dispatcherQueue.TryEnqueue(() => _a2uiCanvasWindow.Close());
             _a2uiCanvasWindow = null;
         }
-
-        return Task.CompletedTask;
     }
     
     private void RegisterCapabilities()
@@ -655,13 +655,28 @@ public sealed class NodeService : IDisposable
 
     private void StopMcpServer()
     {
-        // McpHttpServer.Dispose drains in-flight handler tasks (CR-005) before
-        // returning, so by the time we tear down capability-backing services
-        // (camera/screen/canvas) on the next lines of Dispose/Disconnect there
-        // is no live handler still using them.
-        try { _mcpServer?.Dispose(); } catch (Exception ex) { _logger.Warn($"[MCP] Dispose error: {ex.Message}"); }
+        ObserveBackgroundFault(StopMcpServerAsync(), "[MCP] Dispose error");
+    }
+
+    private async Task StopMcpServerAsync()
+    {
+        // Awaited shutdown callers depend on this drain finishing before
+        // capability-backing services are torn down.
+        var server = _mcpServer;
         _mcpServer = null;
         _mcpStartupError = null;
+
+        if (server == null)
+            return;
+
+        try
+        {
+            await server.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"[MCP] Dispose error: {ex.Message}");
+        }
     }
 
     public string ResetMcpToken()
@@ -1906,9 +1921,28 @@ public sealed class NodeService : IDisposable
 
     #endregion
     
+    public ValueTask DisposeAsync()
+    {
+        var task = EnsureDisposeTask();
+        return new ValueTask(task);
+    }
+
     public void Dispose()
     {
-        StopMcpServer();
+        ObserveBackgroundFault(EnsureDisposeTask(), "[NodeService] Dispose error");
+    }
+
+    private Task EnsureDisposeTask()
+    {
+        lock (_disposeLock)
+        {
+            return _disposeTask ??= DisposeCoreAsync();
+        }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        await StopMcpServerAsync().ConfigureAwait(false);
 
         WindowsNodeClient? client;
         lock (_clientLock)
@@ -1924,7 +1958,12 @@ public sealed class NodeService : IDisposable
         try { _cameraCaptureService?.Dispose(); } catch { /* ignore */ }
         try { _screenRecordingService?.Dispose(); } catch { /* ignore */ }
         try { _textToSpeechService?.Dispose(); } catch { /* ignore */ }
-        try { _voiceService?.DisposeAsync().AsTask().GetAwaiter().GetResult(); } catch { /* ignore */ }
+        var voiceService = _voiceService;
+        _voiceService = null;
+        if (voiceService != null)
+        {
+            try { await voiceService.DisposeAsync().ConfigureAwait(false); } catch { /* ignore */ }
+        }
         // MediaResolver owns SocketsHttpHandler + HttpClient (disposeHandler:true);
         // without disposal the connection pool survives node teardown/recreate.
         try { _mediaResolver?.Dispose(); } catch { /* ignore */ }
@@ -1950,6 +1989,32 @@ public sealed class NodeService : IDisposable
             var window = _a2uiCanvasWindow;
             _a2uiCanvasWindow = null;
             _dispatcherQueue.TryEnqueue(() => { try { window?.Close(); } catch { } });
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private void ObserveBackgroundFault(Task task, string message)
+    {
+        if (task.IsFaulted)
+        {
+            _logger.Warn($"{message}: {task.Exception.GetBaseException().Message}");
+            return;
+        }
+
+        if (task.IsCanceled)
+        {
+            _logger.Warn($"{message}: canceled");
+            return;
+        }
+
+        if (!task.IsCompleted)
+        {
+            _ = task.ContinueWith(
+                t => _logger.Warn($"{message}: {t.Exception!.GetBaseException().Message}"),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
         }
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
@@ -27,14 +27,15 @@ public class SettingsManager
     public event EventHandler? Saved;
 
     private readonly object _saveLock = new();
+    private SettingsData _data = CreateDefaultData();
 
     // Connection
-    public string GatewayUrl { get; set; } = "ws://localhost:18789";
-    public bool UseSshTunnel { get; set; } = false;
-    public string SshTunnelUser { get; set; } = "";
-    public string SshTunnelHost { get; set; } = "";
-    public int SshTunnelRemotePort { get; set; } = 18789;
-    public int SshTunnelLocalPort { get; set; } = 18789;
+    public string GatewayUrl { get => _data.GatewayUrl ?? "ws://localhost:18789"; set => _data = _data with { GatewayUrl = value }; }
+    public bool UseSshTunnel { get => _data.UseSshTunnel; set => _data = _data with { UseSshTunnel = value }; }
+    public string SshTunnelUser { get => _data.SshTunnelUser ?? ""; set => _data = _data with { SshTunnelUser = value }; }
+    public string SshTunnelHost { get => _data.SshTunnelHost ?? ""; set => _data = _data with { SshTunnelHost = value }; }
+    public int SshTunnelRemotePort { get => _data.SshTunnelRemotePort <= 0 ? 18789 : _data.SshTunnelRemotePort; set => _data = _data with { SshTunnelRemotePort = value }; }
+    public int SshTunnelLocalPort { get => _data.SshTunnelLocalPort <= 0 ? 18789 : _data.SshTunnelLocalPort; set => _data = _data with { SshTunnelLocalPort = value }; }
     public string? LegacyToken { get; private set; }
     public string? LegacyBootstrapToken { get; private set; }
     public bool HasLegacyGatewayCredentials =>
@@ -42,32 +43,36 @@ public class SettingsManager
         !string.IsNullOrWhiteSpace(LegacyBootstrapToken);
 
     // Startup
-    public bool AutoStart { get; set; } = true;
-    public bool GlobalHotkeyEnabled { get; set; } = true;
+    public bool AutoStart { get => _data.AutoStart; set => _data = _data with { AutoStart = value }; }
+    public bool GlobalHotkeyEnabled { get => _data.GlobalHotkeyEnabled; set => _data = _data with { GlobalHotkeyEnabled = value }; }
     /// <summary>
     /// One-shot gate: set to true after the post-onboarding "first-run" bootstrap
     /// kickoff message has been injected into the chat exactly once.
     /// </summary>
-    public bool HasInjectedFirstRunBootstrap { get; set; } = false;
+    public bool HasInjectedFirstRunBootstrap { get => _data.HasInjectedFirstRunBootstrap; set => _data = _data with { HasInjectedFirstRunBootstrap = value }; }
 
     // Notifications
-    public bool ShowNotifications { get; set; } = true;
-    public string NotificationSound { get; set; } = "Default";
+    public bool ShowNotifications { get => _data.ShowNotifications; set => _data = _data with { ShowNotifications = value }; }
+    public string NotificationSound { get => _data.NotificationSound ?? "Default"; set => _data = _data with { NotificationSound = value }; }
     
     // Notification filters
-    public bool NotifyHealth { get; set; } = true;
-    public bool NotifyUrgent { get; set; } = true;
-    public bool NotifyReminder { get; set; } = true;
-    public bool NotifyEmail { get; set; } = true;
-    public bool NotifyCalendar { get; set; } = true;
-    public bool NotifyBuild { get; set; } = true;
-    public bool NotifyStock { get; set; } = true;
-    public bool NotifyInfo { get; set; } = true;
+    public bool NotifyHealth { get => _data.NotifyHealth; set => _data = _data with { NotifyHealth = value }; }
+    public bool NotifyUrgent { get => _data.NotifyUrgent; set => _data = _data with { NotifyUrgent = value }; }
+    public bool NotifyReminder { get => _data.NotifyReminder; set => _data = _data with { NotifyReminder = value }; }
+    public bool NotifyEmail { get => _data.NotifyEmail; set => _data = _data with { NotifyEmail = value }; }
+    public bool NotifyCalendar { get => _data.NotifyCalendar; set => _data = _data with { NotifyCalendar = value }; }
+    public bool NotifyBuild { get => _data.NotifyBuild; set => _data = _data with { NotifyBuild = value }; }
+    public bool NotifyStock { get => _data.NotifyStock; set => _data = _data with { NotifyStock = value }; }
+    public bool NotifyInfo { get => _data.NotifyInfo; set => _data = _data with { NotifyInfo = value }; }
 
     // Enhanced categorization
-    public bool NotifyChatResponses { get; set; } = true;
-    public bool PreferStructuredCategories { get; set; } = true;
-    public List<OpenClaw.Shared.UserNotificationRule> UserRules { get; set; } = new();
+    public bool NotifyChatResponses { get => _data.NotifyChatResponses; set => _data = _data with { NotifyChatResponses = value }; }
+    public bool PreferStructuredCategories { get => _data.PreferStructuredCategories; set => _data = _data with { PreferStructuredCategories = value }; }
+    public List<OpenClaw.Shared.UserNotificationRule> UserRules
+    {
+        get => _data.UserRules ??= new();
+        set => _data = _data with { UserRules = value ?? new() };
+    }
 
     // User interface
     /// <summary>
@@ -75,72 +80,80 @@ public class SettingsManager
     /// native chat surface in both the Hub Chat tab and tray Chat popup.
     /// Default false (native).
     /// </summary>
-    public bool UseLegacyWebChat { get; set; } = false;
+    public bool UseLegacyWebChat { get => _data.UseLegacyWebChat; set => _data = _data with { UseLegacyWebChat = value }; }
 
     // Node mode(gateway WebSocket connection — separate from MCP)
-    public bool EnableNodeMode { get; set; } = false;
-    public bool NodeCanvasEnabled { get; set; } = true;
-    public bool NodeScreenEnabled { get; set; } = true;
-    public bool NodeCameraEnabled { get; set; } = true;
-    public bool ScreenRecordingConsentGiven { get; set; } = false;
-    public bool CameraRecordingConsentGiven { get; set; } = false;
-    public bool NodeLocationEnabled { get; set; } = true;
-    public bool NodeBrowserProxyEnabled { get; set; } = true;
+    public bool EnableNodeMode { get => _data.EnableNodeMode; set => _data = _data with { EnableNodeMode = value }; }
+    public bool NodeCanvasEnabled { get => _data.NodeCanvasEnabled; set => _data = _data with { NodeCanvasEnabled = value }; }
+    public bool NodeScreenEnabled { get => _data.NodeScreenEnabled; set => _data = _data with { NodeScreenEnabled = value }; }
+    public bool NodeCameraEnabled { get => _data.NodeCameraEnabled; set => _data = _data with { NodeCameraEnabled = value }; }
+    public bool ScreenRecordingConsentGiven { get => _data.ScreenRecordingConsentGiven; set => _data = _data with { ScreenRecordingConsentGiven = value }; }
+    public bool CameraRecordingConsentGiven { get => _data.CameraRecordingConsentGiven; set => _data = _data with { CameraRecordingConsentGiven = value }; }
+    public bool NodeLocationEnabled { get => _data.NodeLocationEnabled; set => _data = _data with { NodeLocationEnabled = value }; }
+    public bool NodeBrowserProxyEnabled { get => _data.NodeBrowserProxyEnabled; set => _data = _data with { NodeBrowserProxyEnabled = value }; }
     /// <summary>
     /// Master switch for the <c>system.run</c> / <c>system.run.prepare</c>
     /// commands. Per-command exec approvals still apply when this is on;
     /// flipping it off removes those commands from the declared capability
     /// entirely. Default <c>true</c> (backward compatible).
     /// </summary>
-    public bool NodeSystemRunEnabled { get; set; } = true;
-    public bool NodeSttEnabled { get; set; } = false;
+    public bool NodeSystemRunEnabled { get => _data.NodeSystemRunEnabled; set => _data = _data with { NodeSystemRunEnabled = value }; }
+    public bool NodeSttEnabled { get => _data.NodeSttEnabled; set => _data = _data with { NodeSttEnabled = value }; }
     /// <summary>STT language: "auto" for Whisper auto-detect, or a BCP-47 tag like "en-US".</summary>
-    public string SttLanguage { get; set; } = "auto";
+    public string SttLanguage { get => string.IsNullOrWhiteSpace(_data.SttLanguage) ? "auto" : _data.SttLanguage; set => _data = _data with { SttLanguage = value }; }
     /// <summary>Whisper model size: "tiny", "base", or "small".</summary>
-    public string SttModelName { get; set; } = "base";
+    public string SttModelName { get => string.IsNullOrWhiteSpace(_data.SttModelName) ? "base" : _data.SttModelName; set => _data = _data with { SttModelName = value }; }
     /// <summary>Seconds of silence before auto-submit in voice chat mode.</summary>
-    public float SttSilenceTimeout { get; set; } = 1.5f;
+    public float SttSilenceTimeout { get => _data.SttSilenceTimeout > 0 ? _data.SttSilenceTimeout : 1.5f; set => _data = _data with { SttSilenceTimeout = value }; }
     /// <summary>Enable TTS playback of responses during voice sessions.</summary>
-    public bool VoiceTtsEnabled { get; set; } = true;
+    public bool VoiceTtsEnabled { get => _data.VoiceTtsEnabled; set => _data = _data with { VoiceTtsEnabled = value }; }
     /// <summary>Play audio feedback chimes on listen start/stop.</summary>
-    public bool VoiceAudioFeedback { get; set; } = true;
-    public bool NodeTtsEnabled { get; set; } = false;
-    public string TtsProvider { get; set; } = TtsCapability.PiperProvider;
-    public string TtsElevenLabsApiKey { get; set; } = "";
-    public string TtsElevenLabsModel { get; set; } = "";
-    public string TtsElevenLabsVoiceId { get; set; } = "";
-    public string TtsWindowsVoiceId { get; set; } = "";
+    public bool VoiceAudioFeedback { get => _data.VoiceAudioFeedback; set => _data = _data with { VoiceAudioFeedback = value }; }
+    public bool NodeTtsEnabled { get => _data.NodeTtsEnabled; set => _data = _data with { NodeTtsEnabled = value }; }
+    public string TtsProvider { get => string.IsNullOrWhiteSpace(_data.TtsProvider) ? TtsCapability.PiperProvider : _data.TtsProvider; set => _data = _data with { TtsProvider = value }; }
+    public string TtsElevenLabsApiKey { get => _data.TtsElevenLabsApiKey ?? ""; set => _data = _data with { TtsElevenLabsApiKey = value }; }
+    public string TtsElevenLabsModel { get => _data.TtsElevenLabsModel ?? ""; set => _data = _data with { TtsElevenLabsModel = value }; }
+    public string TtsElevenLabsVoiceId { get => _data.TtsElevenLabsVoiceId ?? ""; set => _data = _data with { TtsElevenLabsVoiceId = value }; }
+    public string TtsWindowsVoiceId { get => _data.TtsWindowsVoiceId ?? ""; set => _data = _data with { TtsWindowsVoiceId = value }; }
     /// <summary>Hub NavigationView pane expanded (true) vs compact (false). Default true.</summary>
-    public bool HubNavPaneOpen { get; set; } = true;
+    public bool HubNavPaneOpen { get => _data.HubNavPaneOpen; set => _data = _data with { HubNavPaneOpen = value }; }
     /// <summary>Piper voice identifier, e.g. "en_US-amy-low".</summary>
-    public string TtsPiperVoiceId { get; set; } = "en_US-amy-low";
+    public string TtsPiperVoiceId { get => string.IsNullOrWhiteSpace(_data.TtsPiperVoiceId) ? "en_US-amy-low" : _data.TtsPiperVoiceId; set => _data = _data with { TtsPiperVoiceId = value }; }
     // Local MCP HTTP server (independent of EnableNodeMode)
-    public bool EnableMcpServer { get; set; } = false;
+    public bool EnableMcpServer { get => _data.EnableMcpServer; set => _data = _data with { EnableMcpServer = value }; }
     /// <summary>
     /// Hostnames the A2UI image renderer is allowed to fetch over HTTPS.
     /// Empty by default — agents can still ship inline data: images. The
     /// runtime never bypasses this list, so it is the single switch keeping
     /// agent JSON from issuing arbitrary outbound HTTP from the tray process.
     /// </summary>
-    public List<string> A2UIImageHosts { get; set; } = new();
-    public bool HasSeenActivityStreamTip { get; set; } = false;
-    public string SkippedUpdateTag { get; set; } = "";
-    public string? PreferredGatewayId { get; set; }
+    public List<string> A2UIImageHosts
+    {
+        get => _data.A2UIImageHosts ??= new();
+        set => _data = _data with { A2UIImageHosts = value ?? new() };
+    }
+    public bool HasSeenActivityStreamTip { get => _data.HasSeenActivityStreamTip; set => _data = _data with { HasSeenActivityStreamTip = value }; }
+    public string SkippedUpdateTag { get => _data.SkippedUpdateTag ?? ""; set => _data = _data with { SkippedUpdateTag = value }; }
+    public string? PreferredGatewayId { get => _data.PreferredGatewayId; set => _data = _data with { PreferredGatewayId = value }; }
 
     // ── MXC sandbox ─────────────────────────────────────────────────────
     /// <summary>Master switch for system.run containment. When true (default), system.run runs sandboxed and is denied if MXC is unavailable. When false, system.run runs on host like before.</summary>
-    public bool SystemRunSandboxEnabled { get; set; } = true;
+    public bool SystemRunSandboxEnabled { get => _data.SystemRunSandboxEnabled; set => _data = _data with { SystemRunSandboxEnabled = value }; }
     /// <summary>When sandboxed, allow system.run commands to reach the public internet. Default false.</summary>
-    public bool SystemRunAllowOutbound { get; set; } = false;
+    public bool SystemRunAllowOutbound { get => _data.SystemRunAllowOutbound; set => _data = _data with { SystemRunAllowOutbound = value }; }
 
     // ── MXC sandbox: additional knobs (Sandbox page) ─────────────────
-    public SandboxClipboardMode SandboxClipboard { get; set; } = SandboxClipboardMode.None;
-    public SandboxFolderAccess? SandboxDocumentsAccess { get; set; }
-    public SandboxFolderAccess? SandboxDownloadsAccess { get; set; }
-    public SandboxFolderAccess? SandboxDesktopAccess { get; set; }
-    public List<SandboxCustomFolder> SandboxCustomFolders { get; set; } = new();
-    public int SandboxTimeoutMs { get; set; } = 30_000;
-    public long SandboxMaxOutputBytes { get; set; } = 4 * 1024 * 1024;
+    public SandboxClipboardMode SandboxClipboard { get => _data.SandboxClipboard; set => _data = _data with { SandboxClipboard = value }; }
+    public SandboxFolderAccess? SandboxDocumentsAccess { get => _data.SandboxDocumentsAccess; set => _data = _data with { SandboxDocumentsAccess = value }; }
+    public SandboxFolderAccess? SandboxDownloadsAccess { get => _data.SandboxDownloadsAccess; set => _data = _data with { SandboxDownloadsAccess = value }; }
+    public SandboxFolderAccess? SandboxDesktopAccess { get => _data.SandboxDesktopAccess; set => _data = _data with { SandboxDesktopAccess = value }; }
+    public List<SandboxCustomFolder> SandboxCustomFolders
+    {
+        get => _data.SandboxCustomFolders ??= new();
+        set => _data = _data with { SandboxCustomFolders = value ?? new() };
+    }
+    public int SandboxTimeoutMs { get => _data.SandboxTimeoutMs > 0 ? _data.SandboxTimeoutMs : 30_000; set => _data = _data with { SandboxTimeoutMs = value }; }
+    public long SandboxMaxOutputBytes { get => _data.SandboxMaxOutputBytes > 0 ? _data.SandboxMaxOutputBytes : 4 * 1024 * 1024; set => _data = _data with { SandboxMaxOutputBytes = value }; }
 
     public SettingsManager() : this(GetDefaultSettingsDirectory())
     {
@@ -169,6 +182,7 @@ public class SettingsManager
     {
         LegacyToken = null;
         LegacyBootstrapToken = null;
+        _data = CreateDefaultData();
 
         try
         {
@@ -179,85 +193,7 @@ public class SettingsManager
                 var loaded = SettingsData.FromJson(json);
                 if (loaded != null)
                 {
-                    GatewayUrl = loaded.GatewayUrl ?? GatewayUrl;
-                    UseSshTunnel = loaded.UseSshTunnel;
-                    SshTunnelUser = loaded.SshTunnelUser ?? SshTunnelUser;
-                    SshTunnelHost = loaded.SshTunnelHost ?? SshTunnelHost;
-                    SshTunnelRemotePort = loaded.SshTunnelRemotePort <= 0 ? SshTunnelRemotePort : loaded.SshTunnelRemotePort;
-                    SshTunnelLocalPort = loaded.SshTunnelLocalPort <= 0 ? SshTunnelLocalPort : loaded.SshTunnelLocalPort;
-                    AutoStart = loaded.AutoStart;
-                    GlobalHotkeyEnabled = loaded.GlobalHotkeyEnabled;
-                    HasInjectedFirstRunBootstrap = loaded.HasInjectedFirstRunBootstrap;
-                    ShowNotifications = loaded.ShowNotifications;
-                    NotificationSound = loaded.NotificationSound ?? NotificationSound;
-                    NotifyHealth = loaded.NotifyHealth;
-                    NotifyUrgent = loaded.NotifyUrgent;
-                    NotifyReminder = loaded.NotifyReminder;
-                    NotifyEmail = loaded.NotifyEmail;
-                    NotifyCalendar = loaded.NotifyCalendar;
-                    NotifyBuild = loaded.NotifyBuild;
-                    NotifyStock = loaded.NotifyStock;
-                    NotifyInfo = loaded.NotifyInfo;
-                    EnableNodeMode = loaded.EnableNodeMode;
-                    NodeCanvasEnabled = loaded.NodeCanvasEnabled;
-                    NodeScreenEnabled = loaded.NodeScreenEnabled;
-                    NodeCameraEnabled = loaded.NodeCameraEnabled;
-                    ScreenRecordingConsentGiven = loaded.ScreenRecordingConsentGiven;
-                    CameraRecordingConsentGiven = loaded.CameraRecordingConsentGiven;
-                    NodeLocationEnabled = loaded.NodeLocationEnabled;
-                    NodeBrowserProxyEnabled = loaded.NodeBrowserProxyEnabled;
-                    NodeSystemRunEnabled = loaded.NodeSystemRunEnabled;
-                    NodeSttEnabled = loaded.NodeSttEnabled;
-                    SttLanguage = string.IsNullOrWhiteSpace(loaded.SttLanguage) ? SttLanguage : loaded.SttLanguage;
-                    SttModelName = string.IsNullOrWhiteSpace(loaded.SttModelName) ? SttModelName : loaded.SttModelName;
-                    SttSilenceTimeout = loaded.SttSilenceTimeout > 0 ? loaded.SttSilenceTimeout : SttSilenceTimeout;
-                    VoiceTtsEnabled = loaded.VoiceTtsEnabled;
-                    VoiceAudioFeedback = loaded.VoiceAudioFeedback;
-                    NodeTtsEnabled = loaded.NodeTtsEnabled;
-                    TtsProvider = string.IsNullOrWhiteSpace(loaded.TtsProvider) ? TtsProvider : loaded.TtsProvider;
-                    TtsElevenLabsApiKey = UnprotectSettingSecret(loaded.TtsElevenLabsApiKey) ?? TtsElevenLabsApiKey;
-                    TtsElevenLabsModel = loaded.TtsElevenLabsModel ?? TtsElevenLabsModel;
-                    TtsElevenLabsVoiceId = loaded.TtsElevenLabsVoiceId ?? TtsElevenLabsVoiceId;
-                    TtsWindowsVoiceId = loaded.TtsWindowsVoiceId ?? TtsWindowsVoiceId;
-                    HubNavPaneOpen = loaded.HubNavPaneOpen;
-                    TtsPiperVoiceId = string.IsNullOrWhiteSpace(loaded.TtsPiperVoiceId) ? TtsPiperVoiceId : loaded.TtsPiperVoiceId;
-                    EnableMcpServer = loaded.EnableMcpServer;
-                    A2UIImageHosts = loaded.A2UIImageHosts ?? new List<string>();
-                    // Legacy McpOnlyMode migration:
-                    //   true  → node off (no gateway), MCP on
-                    //   false → leave MCP off; the user has not opted in to a
-                    //           local HTTP server. Earlier dev builds tied MCP
-                    //           to EnableNodeMode silently — we deliberately
-                    //           do *not* re-enable MCP for those users on
-                    //           upgrade. They can flip the toggle in Settings.
-                    if (loaded.McpOnlyMode is bool legacyMcpOnly && legacyMcpOnly)
-                    {
-                        EnableMcpServer = true;
-                        EnableNodeMode = false;
-                    }
-                    HasSeenActivityStreamTip = loaded.HasSeenActivityStreamTip;
-                    SkippedUpdateTag = loaded.SkippedUpdateTag ?? SkippedUpdateTag;
-                    PreferredGatewayId = loaded.PreferredGatewayId ?? PreferredGatewayId;
-                    NotifyChatResponses = loaded.NotifyChatResponses;
-                    PreferStructuredCategories = loaded.PreferStructuredCategories;
-                    UseLegacyWebChat = loaded.UseLegacyWebChat;
-                    if (loaded.UserRules != null)
-                        UserRules = loaded.UserRules;
-
-                    // MXC sandbox settings
-                    SystemRunSandboxEnabled = loaded.SystemRunSandboxEnabled;
-                    SystemRunAllowOutbound = loaded.SystemRunAllowOutbound;
-
-                    // MXC sandbox settings (Sandbox page)
-                    SandboxClipboard = loaded.SandboxClipboard;
-                    SandboxDocumentsAccess = loaded.SandboxDocumentsAccess;
-                    SandboxDownloadsAccess = loaded.SandboxDownloadsAccess;
-                    SandboxDesktopAccess = loaded.SandboxDesktopAccess;
-                    SandboxCustomFolders = loaded.SandboxCustomFolders ?? new();
-                    if (loaded.SandboxTimeoutMs > 0)
-                        SandboxTimeoutMs = loaded.SandboxTimeoutMs;
-                    if (loaded.SandboxMaxOutputBytes > 0)
-                        SandboxMaxOutputBytes = loaded.SandboxMaxOutputBytes;
+                    _data = NormalizeLoadedData(loaded);
                 }
             }
         }
@@ -268,6 +204,126 @@ public class SettingsManager
             LegacyBootstrapToken = null;
         }
     }
+
+    private static SettingsData CreateDefaultData() => new()
+    {
+        GatewayUrl = "ws://localhost:18789",
+        UseSshTunnel = false,
+        SshTunnelUser = "",
+        SshTunnelHost = "",
+        SshTunnelRemotePort = 18789,
+        SshTunnelLocalPort = 18789,
+        AutoStart = true,
+        GlobalHotkeyEnabled = true,
+        HasInjectedFirstRunBootstrap = false,
+        ShowNotifications = true,
+        NotificationSound = "Default",
+        NotifyHealth = true,
+        NotifyUrgent = true,
+        NotifyReminder = true,
+        NotifyEmail = true,
+        NotifyCalendar = true,
+        NotifyBuild = true,
+        NotifyStock = true,
+        NotifyInfo = true,
+        NotifyChatResponses = true,
+        PreferStructuredCategories = true,
+        UserRules = new(),
+        UseLegacyWebChat = false,
+        EnableNodeMode = false,
+        NodeCanvasEnabled = true,
+        NodeScreenEnabled = true,
+        NodeCameraEnabled = true,
+        ScreenRecordingConsentGiven = false,
+        CameraRecordingConsentGiven = false,
+        NodeLocationEnabled = true,
+        NodeBrowserProxyEnabled = true,
+        NodeSystemRunEnabled = true,
+        NodeSttEnabled = false,
+        SttLanguage = "auto",
+        SttModelName = "base",
+        SttSilenceTimeout = 1.5f,
+        VoiceTtsEnabled = true,
+        VoiceAudioFeedback = true,
+        NodeTtsEnabled = false,
+        TtsProvider = TtsCapability.PiperProvider,
+        TtsElevenLabsApiKey = "",
+        TtsElevenLabsModel = "",
+        TtsElevenLabsVoiceId = "",
+        TtsWindowsVoiceId = "",
+        HubNavPaneOpen = true,
+        TtsPiperVoiceId = "en_US-amy-low",
+        EnableMcpServer = false,
+        A2UIImageHosts = new(),
+        HasSeenActivityStreamTip = false,
+        SkippedUpdateTag = "",
+        PreferredGatewayId = null,
+        SystemRunSandboxEnabled = true,
+        SystemRunAllowOutbound = false,
+        SandboxClipboard = SandboxClipboardMode.None,
+        SandboxDocumentsAccess = null,
+        SandboxDownloadsAccess = null,
+        SandboxDesktopAccess = null,
+        SandboxCustomFolders = new(),
+        SandboxTimeoutMs = 30_000,
+        SandboxMaxOutputBytes = 4 * 1024 * 1024
+    };
+
+    private static SettingsData NormalizeLoadedData(SettingsData loaded)
+    {
+        var defaults = CreateDefaultData();
+        var data = loaded with
+        {
+            GatewayUrl = loaded.GatewayUrl ?? defaults.GatewayUrl,
+            SshTunnelUser = loaded.SshTunnelUser ?? defaults.SshTunnelUser,
+            SshTunnelHost = loaded.SshTunnelHost ?? defaults.SshTunnelHost,
+            SshTunnelRemotePort = loaded.SshTunnelRemotePort <= 0 ? defaults.SshTunnelRemotePort : loaded.SshTunnelRemotePort,
+            SshTunnelLocalPort = loaded.SshTunnelLocalPort <= 0 ? defaults.SshTunnelLocalPort : loaded.SshTunnelLocalPort,
+            NotificationSound = loaded.NotificationSound ?? defaults.NotificationSound,
+            SttLanguage = string.IsNullOrWhiteSpace(loaded.SttLanguage) ? defaults.SttLanguage : loaded.SttLanguage,
+            SttModelName = string.IsNullOrWhiteSpace(loaded.SttModelName) ? defaults.SttModelName : loaded.SttModelName,
+            SttSilenceTimeout = loaded.SttSilenceTimeout > 0 ? loaded.SttSilenceTimeout : defaults.SttSilenceTimeout,
+            TtsProvider = string.IsNullOrWhiteSpace(loaded.TtsProvider) ? defaults.TtsProvider : loaded.TtsProvider,
+            TtsElevenLabsApiKey = UnprotectSettingSecret(loaded.TtsElevenLabsApiKey) ?? defaults.TtsElevenLabsApiKey,
+            TtsElevenLabsModel = loaded.TtsElevenLabsModel ?? defaults.TtsElevenLabsModel,
+            TtsElevenLabsVoiceId = loaded.TtsElevenLabsVoiceId ?? defaults.TtsElevenLabsVoiceId,
+            TtsWindowsVoiceId = loaded.TtsWindowsVoiceId ?? defaults.TtsWindowsVoiceId,
+            TtsPiperVoiceId = string.IsNullOrWhiteSpace(loaded.TtsPiperVoiceId) ? defaults.TtsPiperVoiceId : loaded.TtsPiperVoiceId,
+            A2UIImageHosts = loaded.A2UIImageHosts is { Count: > 0 } hosts ? new List<string>(hosts) : new(),
+            SkippedUpdateTag = loaded.SkippedUpdateTag ?? defaults.SkippedUpdateTag,
+            PreferredGatewayId = loaded.PreferredGatewayId ?? defaults.PreferredGatewayId,
+            UserRules = loaded.UserRules != null ? new List<UserNotificationRule>(loaded.UserRules) : new(),
+            SandboxCustomFolders = CloneSandboxCustomFolders(loaded.SandboxCustomFolders),
+            SandboxTimeoutMs = loaded.SandboxTimeoutMs > 0 ? loaded.SandboxTimeoutMs : defaults.SandboxTimeoutMs,
+            SandboxMaxOutputBytes = loaded.SandboxMaxOutputBytes > 0 ? loaded.SandboxMaxOutputBytes : defaults.SandboxMaxOutputBytes,
+            McpOnlyMode = null
+        };
+
+        // Legacy McpOnlyMode migration:
+        //   true  -> node off (no gateway), MCP on
+        //   false -> leave MCP off; the user has not opted in to a local HTTP server.
+        if (loaded.McpOnlyMode is true)
+        {
+            data = data with
+            {
+                EnableMcpServer = true,
+                EnableNodeMode = false
+            };
+        }
+
+        return data;
+    }
+
+    private static List<SandboxCustomFolder> CloneSandboxCustomFolders(IEnumerable<SandboxCustomFolder>? folders) =>
+        folders is null
+            ? new List<SandboxCustomFolder>()
+            : folders
+                .Select(folder => new SandboxCustomFolder
+                {
+                    Path = folder.Path,
+                    Access = folder.Access
+                })
+                .ToList();
 
     private void LoadLegacyGatewayCredentials(string json)
     {
@@ -295,74 +351,34 @@ public class SettingsManager
     }
 
     /// <summary>
-    /// Creates a snapshot of current settings as an immutable SettingsData record.
-    /// Used for settings change classification (no DPAPI protection applied).
+    /// Creates a detached snapshot of current settings. No DPAPI protection is
+    /// applied here; Save applies it to a second clone for on-disk storage only.
     /// </summary>
-    public SettingsData ToSettingsData() => new()
+    public SettingsData ToSettingsData() => _data with
     {
         GatewayUrl = GatewayUrl,
-        // Token and BootstrapToken are no longer written — GatewayRegistry is the source of truth
-        UseSshTunnel = UseSshTunnel,
         SshTunnelUser = SshTunnelUser,
         SshTunnelHost = SshTunnelHost,
         SshTunnelRemotePort = SshTunnelRemotePort,
         SshTunnelLocalPort = SshTunnelLocalPort,
-        AutoStart = AutoStart,
-        GlobalHotkeyEnabled = GlobalHotkeyEnabled,
-        HasInjectedFirstRunBootstrap = HasInjectedFirstRunBootstrap,
-        ShowNotifications = ShowNotifications,
         NotificationSound = NotificationSound,
-        NotifyHealth = NotifyHealth,
-        NotifyUrgent = NotifyUrgent,
-        NotifyReminder = NotifyReminder,
-        NotifyEmail = NotifyEmail,
-        NotifyCalendar = NotifyCalendar,
-        NotifyBuild = NotifyBuild,
-        NotifyStock = NotifyStock,
-        NotifyInfo = NotifyInfo,
-        EnableNodeMode = EnableNodeMode,
-        NodeCanvasEnabled = NodeCanvasEnabled,
-        NodeScreenEnabled = NodeScreenEnabled,
-        NodeCameraEnabled = NodeCameraEnabled,
-        ScreenRecordingConsentGiven = ScreenRecordingConsentGiven,
-        CameraRecordingConsentGiven = CameraRecordingConsentGiven,
-        NodeLocationEnabled = NodeLocationEnabled,
-        NodeBrowserProxyEnabled = NodeBrowserProxyEnabled,
-        NodeSystemRunEnabled = NodeSystemRunEnabled,
-        NodeSttEnabled = NodeSttEnabled,
         SttLanguage = SttLanguage,
         SttModelName = SttModelName,
         SttSilenceTimeout = SttSilenceTimeout,
-        VoiceTtsEnabled = VoiceTtsEnabled,
-        VoiceAudioFeedback = VoiceAudioFeedback,
-        NodeTtsEnabled = NodeTtsEnabled,
         TtsProvider = TtsProvider,
         TtsElevenLabsApiKey = TtsElevenLabsApiKey,
         TtsElevenLabsModel = string.IsNullOrWhiteSpace(TtsElevenLabsModel) ? null : TtsElevenLabsModel,
         TtsElevenLabsVoiceId = string.IsNullOrWhiteSpace(TtsElevenLabsVoiceId) ? null : TtsElevenLabsVoiceId,
         TtsWindowsVoiceId = string.IsNullOrWhiteSpace(TtsWindowsVoiceId) ? null : TtsWindowsVoiceId,
-        HubNavPaneOpen = HubNavPaneOpen,
         TtsPiperVoiceId = TtsPiperVoiceId,
-        EnableMcpServer = EnableMcpServer,
         A2UIImageHosts = A2UIImageHosts.Count == 0 ? null : new List<string>(A2UIImageHosts),
-        HasSeenActivityStreamTip = HasSeenActivityStreamTip,
         SkippedUpdateTag = string.IsNullOrWhiteSpace(SkippedUpdateTag) ? null : SkippedUpdateTag,
         PreferredGatewayId = string.IsNullOrWhiteSpace(PreferredGatewayId) ? null : PreferredGatewayId,
-        NotifyChatResponses = NotifyChatResponses,
-        PreferStructuredCategories = PreferStructuredCategories,
-        UseLegacyWebChat = UseLegacyWebChat,
-        UserRules = UserRules,
-        // MXC sandbox settings
-        SystemRunSandboxEnabled = SystemRunSandboxEnabled,
-        SystemRunAllowOutbound = SystemRunAllowOutbound,
-        // MXC sandbox settings (Sandbox page)
-        SandboxClipboard = SandboxClipboard,
-        SandboxDocumentsAccess = SandboxDocumentsAccess,
-        SandboxDownloadsAccess = SandboxDownloadsAccess,
-        SandboxDesktopAccess = SandboxDesktopAccess,
-        SandboxCustomFolders = SandboxCustomFolders.Count == 0 ? null : new List<SandboxCustomFolder>(SandboxCustomFolders),
+        UserRules = new List<UserNotificationRule>(UserRules),
+        SandboxCustomFolders = SandboxCustomFolders.Count == 0 ? null : CloneSandboxCustomFolders(SandboxCustomFolders),
         SandboxTimeoutMs = SandboxTimeoutMs,
-        SandboxMaxOutputBytes = SandboxMaxOutputBytes
+        SandboxMaxOutputBytes = SandboxMaxOutputBytes,
+        McpOnlyMode = null
     };
 
     public void Save()

--- a/src/OpenClaw.Tray.WinUI/Services/ToastActivationRouter.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ToastActivationRouter.cs
@@ -1,0 +1,49 @@
+namespace OpenClawTray.Services;
+
+public sealed class ToastActivationActions
+{
+    public required Action<string> OpenUrl { get; init; }
+    public required Action OpenDashboard { get; init; }
+    public required Action OpenSettings { get; init; }
+    public required Action OpenChat { get; init; }
+    public required Action OpenActivity { get; init; }
+    public required Action<string> CopyPairingCommand { get; init; }
+}
+
+public static class ToastActivationRouter
+{
+    public static void Route(
+        string? action,
+        Func<string, string?> getArgument,
+        ToastActivationActions actions)
+    {
+        ArgumentNullException.ThrowIfNull(getArgument);
+        ArgumentNullException.ThrowIfNull(actions);
+
+        switch (action)
+        {
+            case "open_url":
+                var url = getArgument("url");
+                if (!string.IsNullOrWhiteSpace(url))
+                    actions.OpenUrl(url);
+                break;
+            case "open_dashboard":
+                actions.OpenDashboard();
+                break;
+            case "open_settings":
+                actions.OpenSettings();
+                break;
+            case "open_chat":
+                actions.OpenChat();
+                break;
+            case "open_activity":
+                actions.OpenActivity();
+                break;
+            case "copy_pairing_command":
+                var command = getArgument("command");
+                if (!string.IsNullOrWhiteSpace(command))
+                    actions.CopyPairingCommand(command);
+                break;
+        }
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Windows/CanvasWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/CanvasWindow.xaml.cs
@@ -52,6 +52,8 @@ public sealed partial class CanvasWindow : WindowEx
 
     private readonly DispatcherQueue? _dispatcherQueue;
     private TypedEventHandler<CoreWebView2, CoreWebView2WebMessageReceivedEventArgs>? _webMessageReceivedHandler;
+    private TypedEventHandler<CoreWebView2, CoreWebView2WebResourceRequestedEventArgs>? _webResourceRequestedHandler;
+    private string? _webResourceRequestedFilter;
 
     /// <summary>
     /// Fired when the SPA sends a message to the native side via
@@ -147,6 +149,7 @@ public sealed partial class CanvasWindow : WindowEx
             _trustedGatewayOrigin = $"{httpScheme}://{uri.Host}:{uri.Port}";
             _gatewayOriginForRewrite = _trustedGatewayOrigin;
             Logger.Info($"[Canvas] Trusted gateway origin: {_trustedGatewayOrigin}");
+            ConfigureGatewayAuthHeaderInjection();
         }
         catch (Exception ex)
         {
@@ -237,7 +240,13 @@ public sealed partial class CanvasWindow : WindowEx
         InitializeWebViewAsync();
     }
     
-    private async void InitializeWebViewAsync()
+    private void InitializeWebViewAsync() =>
+        AsyncEventHandlerGuard.Run(
+            InitializeWebViewCoreAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(InitializeWebViewAsync));
+
+    private async Task InitializeWebViewCoreAsync()
     {
         try
         {
@@ -298,23 +307,7 @@ public sealed partial class CanvasWindow : WindowEx
             };
             CanvasWebView.CoreWebView2.WebMessageReceived += _webMessageReceivedHandler;
 
-            // Inject auth token for gateway requests
-            if (!string.IsNullOrEmpty(_trustedGatewayOrigin) && !string.IsNullOrEmpty(_gatewayToken))
-            {
-                var gatewayFilter = $"{_trustedGatewayOrigin}/*";
-                CanvasWebView.CoreWebView2.AddWebResourceRequestedFilter(gatewayFilter, CoreWebView2WebResourceContext.All);
-                var trustedOrigin = _trustedGatewayOrigin;
-                var token = _gatewayToken;
-                CanvasWebView.CoreWebView2.WebResourceRequested += (s, args) =>
-                {
-                    // Only inject auth for requests to the trusted gateway origin
-                    if (args.Request.Uri.StartsWith(trustedOrigin, StringComparison.OrdinalIgnoreCase))
-                    {
-                        args.Request.Headers.SetHeader("Authorization", $"Bearer {token}");
-                    }
-                };
-                Logger.Info("[Canvas] WebView2 auth header injection configured for gateway requests");
-            }
+            ConfigureGatewayAuthHeaderInjection();
 
             // Handle navigation events
             CanvasWebView.CoreWebView2.NavigationCompleted += OnNavigationCompleted;
@@ -383,6 +376,52 @@ public sealed partial class CanvasWindow : WindowEx
             _webViewReadyTcs.TrySetException(ex);
         }
     }
+
+    private void ConfigureGatewayAuthHeaderInjection()
+    {
+        var coreWebView2 = CanvasWebView.CoreWebView2;
+        if (coreWebView2 == null)
+            return;
+
+        RemoveGatewayAuthHeaderInjection(coreWebView2);
+
+        if (string.IsNullOrEmpty(_trustedGatewayOrigin) || string.IsNullOrEmpty(_gatewayToken))
+            return;
+
+        _webResourceRequestedFilter = $"{_trustedGatewayOrigin}/*";
+        _webResourceRequestedHandler = OnGatewayWebResourceRequested;
+        coreWebView2.AddWebResourceRequestedFilter(_webResourceRequestedFilter, CoreWebView2WebResourceContext.All);
+        coreWebView2.WebResourceRequested += _webResourceRequestedHandler;
+        Logger.Info("[Canvas] WebView2 auth header injection configured for gateway requests");
+    }
+
+    private void RemoveGatewayAuthHeaderInjection(CoreWebView2 coreWebView2)
+    {
+        if (_webResourceRequestedHandler != null)
+        {
+            coreWebView2.WebResourceRequested -= _webResourceRequestedHandler;
+            _webResourceRequestedHandler = null;
+        }
+
+        if (!string.IsNullOrEmpty(_webResourceRequestedFilter))
+        {
+            coreWebView2.RemoveWebResourceRequestedFilter(_webResourceRequestedFilter, CoreWebView2WebResourceContext.All);
+            _webResourceRequestedFilter = null;
+        }
+    }
+
+    private void OnGatewayWebResourceRequested(CoreWebView2 sender, CoreWebView2WebResourceRequestedEventArgs args)
+    {
+        var trustedOrigin = _trustedGatewayOrigin;
+        var token = _gatewayToken;
+        if (string.IsNullOrEmpty(trustedOrigin) || string.IsNullOrEmpty(token))
+            return;
+
+        if (IsUriForOrigin(args.Request.Uri, trustedOrigin))
+        {
+            args.Request.Headers.SetHeader("Authorization", $"Bearer {token}");
+        }
+    }
     
     private void OnNavigationCompleted(CoreWebView2 sender, CoreWebView2NavigationCompletedEventArgs args)
     {
@@ -434,16 +473,23 @@ public sealed partial class CanvasWindow : WindowEx
     private void OnWindowClosed(object sender, WindowEventArgs args)
     {
         IsClosed = true;
+        _gatewayToken = null;
 
         if (CanvasWebView.CoreWebView2 != null)
         {
             if (_webMessageReceivedHandler != null)
+            {
                 CanvasWebView.CoreWebView2.WebMessageReceived -= _webMessageReceivedHandler;
+                _webMessageReceivedHandler = null;
+            }
+            RemoveGatewayAuthHeaderInjection(CanvasWebView.CoreWebView2);
             CanvasWebView.CoreWebView2.NavigationCompleted -= OnNavigationCompleted;
         }
 
         _canvasWatcher?.Dispose();
         _canvasWatcher = null;
+        _trustedGatewayOrigin = null;
+        _gatewayOriginForRewrite = null;
     }
     
     private void OnRetryClick(object sender, RoutedEventArgs e)
@@ -645,6 +691,15 @@ public sealed partial class CanvasWindow : WindowEx
             return false;
         
         return uri.AbsolutePath.StartsWith("/__openclaw__/a2ui/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsUriForOrigin(string uri, string origin)
+    {
+        return uri.StartsWith(origin, StringComparison.OrdinalIgnoreCase) &&
+            (uri.Length == origin.Length ||
+             uri[origin.Length] == '/' ||
+             uri[origin.Length] == '?' ||
+             uri[origin.Length] == '#');
     }
     
     private Task EnsureWebViewReadyAsync()

--- a/src/OpenClaw.Tray.WinUI/Windows/ConnectionStatusWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/ConnectionStatusWindow.xaml.cs
@@ -287,7 +287,13 @@ public sealed partial class ConnectionStatusWindow : WindowEx
             SetupCodePreview.Text = $"✗ {decoded.Error}";
     }
 
-    private async void OnConnect(object sender, RoutedEventArgs e)
+    private void OnConnect(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnConnectAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnConnect));
+
+    private async Task OnConnectAsync()
     {
         if (_manager == null) return;
 
@@ -319,7 +325,13 @@ public sealed partial class ConnectionStatusWindow : WindowEx
         }
     }
 
-    private async void OnDisconnectClick(object sender, RoutedEventArgs e)
+    private void OnDisconnectClick(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnDisconnectClickAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnDisconnectClick));
+
+    private async Task OnDisconnectClickAsync()
     {
         if (_manager == null) return;
         await _manager.DisconnectAsync();
@@ -331,7 +343,13 @@ public sealed partial class ConnectionStatusWindow : WindowEx
         DiagSshDetailsPanel.Visibility = DiagSshToggle.IsOn ? Visibility.Visible : Visibility.Collapsed;
     }
 
-    private async void OnDirectConnect(object sender, RoutedEventArgs e)
+    private void OnDirectConnect(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnDirectConnectAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnDirectConnect));
+
+    private async Task OnDirectConnectAsync()
     {
         if (_manager == null || _registry == null) return;
 

--- a/src/OpenClaw.Tray.WinUI/Windows/SetupWizardWindow.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/SetupWizardWindow.cs
@@ -581,7 +581,13 @@ public sealed class SetupWizardWindow : WindowEx
             ? DateTimeOffset.FromUnixTimeMilliseconds(value)
             : DateTimeOffset.FromUnixTimeSeconds(value);
 
-    private async void OnPasteSetupFromClipboard(object sender, RoutedEventArgs e)
+    private void OnPasteSetupFromClipboard(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnPasteSetupFromClipboardAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnPasteSetupFromClipboard));
+
+    private async Task OnPasteSetupFromClipboardAsync()
     {
         try
         {
@@ -614,7 +620,13 @@ public sealed class SetupWizardWindow : WindowEx
         }
     }
 
-    private async void OnImportQrImage(object sender, RoutedEventArgs e)
+    private void OnImportQrImage(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnImportQrImageAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnImportQrImage));
+
+    private async Task OnImportQrImageAsync()
     {
         try
         {
@@ -715,7 +727,13 @@ public sealed class SetupWizardWindow : WindowEx
         UpdatePairingStatusText();
     }
 
-    private async void OnTestConnection(object sender, RoutedEventArgs e)
+    private void OnTestConnection(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnTestConnectionAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnTestConnection));
+
+    private async Task OnTestConnectionAsync()
     {
         _draftGatewayUrl = _gatewayUrlBox.Text.Trim();
         _draftToken = _tokenBox.Text;

--- a/src/OpenClaw.Tray.WinUI/Windows/VoiceOverlayWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/VoiceOverlayWindow.xaml.cs
@@ -265,7 +265,13 @@ public sealed partial class VoiceOverlayWindow : WindowEx
         }
     }
 
-    private async void OnStartStopClick(object sender, RoutedEventArgs e)
+    private void OnStartStopClick(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnStartStopClickAsync,
+            _logger,
+            nameof(OnStartStopClick));
+
+    private async Task OnStartStopClickAsync()
     {
         try
         {
@@ -319,7 +325,13 @@ public sealed partial class VoiceOverlayWindow : WindowEx
         }
     }
 
-    private async void OnMuteClick(object sender, RoutedEventArgs e)
+    private void OnMuteClick(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnMuteClickAsync,
+            _logger,
+            nameof(OnMuteClick));
+
+    private async Task OnMuteClickAsync()
     {
         _isMuted = !_isMuted;
         MuteIcon.Glyph = _isMuted ? "\uE74F" : "\uE767"; // Muted / Volume

--- a/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
+++ b/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
@@ -175,6 +175,29 @@ public class GatewayConnectionManagerTests : IDisposable
     }
 
     [Fact]
+    public async Task DisposeAsync_AwaitsNodeDisconnect()
+    {
+        SetupGateway("gw-1", "wss://test");
+        _resolver.OperatorCredential = new GatewayCredential("tok", false, "test");
+        var nodeConnector = new BlockingNodeDisconnectConnector();
+        await using var manager = new GatewayConnectionManager(
+            _resolver, _factory, _registry, NullLogger.Instance,
+            nodeConnector: nodeConnector);
+
+        await manager.ConnectAsync("gw-1");
+        nodeConnector.BlockDisconnects = true;
+
+        var disposeTask = manager.DisposeAsync().AsTask();
+        await nodeConnector.DisconnectStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.False(disposeTask.IsCompleted);
+
+        nodeConnector.AllowDisconnect.SetResult(true);
+        await disposeTask.WaitAsync(TimeSpan.FromSeconds(2));
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => manager.ConnectAsync("gw-1"));
+    }
+
+    [Fact]
     public void Diagnostics_IsAccessible()
     {
         Assert.NotNull(_manager.Diagnostics);
@@ -577,6 +600,39 @@ public class GatewayConnectionManagerTests : IDisposable
         }
 
         public Task DisconnectAsync() => Task.CompletedTask;
+
+        public void Dispose() { }
+    }
+
+    private sealed class BlockingNodeDisconnectConnector : INodeConnector
+    {
+        public TaskCompletionSource<bool> DisconnectStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource<bool> AllowDisconnect { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public bool BlockDisconnects { get; set; }
+        public bool IsConnected => true;
+        public PairingStatus PairingStatus => PairingStatus.Paired;
+        public string? NodeDeviceId => "blocking-node";
+        public NodeConnectionMode Mode => NodeConnectionMode.Gateway;
+
+#pragma warning disable CS0067 // Events required by interface but not fired in tests
+        public event EventHandler<ConnectionStatus>? StatusChanged;
+        public event EventHandler<PairingStatusEventArgs>? PairingStatusChanged;
+        public event EventHandler<NodeClientCreatedEventArgs>? ClientCreated;
+#pragma warning restore CS0067
+
+        public Task ConnectAsync(string gatewayUrl, GatewayCredential credential, string identityPath, bool useV2Signature = false)
+            => Task.CompletedTask;
+
+        public async Task DisconnectAsync()
+        {
+            if (!BlockDisconnects)
+            {
+                return;
+            }
+
+            DisconnectStarted.SetResult(true);
+            await AllowDisconnect.Task;
+        }
 
         public void Dispose() { }
     }

--- a/tests/OpenClaw.Connection.Tests/OperatorScopeHelperTests.cs
+++ b/tests/OpenClaw.Connection.Tests/OperatorScopeHelperTests.cs
@@ -179,5 +179,6 @@ public class ChatNavigationReadinessTests
         public Task<SetupCodeResult> ApplySetupCodeAsync(string setupCode) => Task.FromResult(new SetupCodeResult(SetupCodeOutcome.InvalidCode));
         public Task<SetupCodeResult> ConnectWithSharedTokenAsync(string gatewayUrl, string token, SshTunnelConfig? sshTunnel = null) => Task.FromResult(new SetupCodeResult(SetupCodeOutcome.InvalidCode));
         public void Dispose() { }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/tests/OpenClaw.Shared.Tests/McpHttpServerTests.cs
+++ b/tests/OpenClaw.Shared.Tests/McpHttpServerTests.cs
@@ -348,6 +348,57 @@ public class McpHttpServerTests
     }
 
     [Fact]
+    public async Task DisposeAsync_DuringInFlightHandler_DoesNotSurfaceObjectDisposedException()
+    {
+        var release = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cap = new GatedCapability(release);
+        var (server, http, _) = BootWith(cap);
+
+        var unobserved = new List<Exception>();
+        EventHandler<UnobservedTaskExceptionEventArgs> handler = (_, e) =>
+        {
+            foreach (var ex in e.Exception.InnerExceptions) unobserved.Add(ex);
+            e.SetObserved();
+        };
+        TaskScheduler.UnobservedTaskException += handler;
+
+        try
+        {
+            var inflight = Task.Run(async () =>
+            {
+                try
+                {
+                    await http.PostAsync("/", new StringContent(
+                        @"{""jsonrpc"":""2.0"",""id"":1,""method"":""tools/call"",""params"":{""name"":""gate.wait""}}",
+                        Encoding.UTF8, "application/json"));
+                }
+                catch { /* socket may close on shutdown; not what we're testing */ }
+            });
+
+            var entered = await Task.WhenAny(cap.Entered, Task.Delay(2000));
+            Assert.Equal(cap.Entered, entered);
+
+            var disposeTask = server.DisposeAsync().AsTask();
+            release.TrySetResult(true);
+            await disposeTask;
+            await inflight;
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            Assert.DoesNotContain(unobserved, e => e is ObjectDisposedException);
+            Assert.DoesNotContain(unobserved, e => e is SemaphoreFullException);
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= handler;
+            release.TrySetResult(true);
+            http.Dispose();
+        }
+    }
+
+    [Fact]
     public async Task SlowBody_TimesOut_FreesHandlerSlot()
     {
         // CR-003: a client that opens a POST and dribbles bytes must not pin

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -1,0 +1,187 @@
+using System.Text.RegularExpressions;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class AppRefactorContractTests
+{
+    [Fact]
+    public void Startup_UsesConnectionManagerAsOnlyGatewayClientOwner()
+    {
+        var source = ReadAppSources();
+
+        Assert.Contains("new CredentialResolver", source);
+        Assert.Contains("new GatewayClientFactory", source);
+        Assert.Contains("new NodeConnector", source);
+        Assert.Contains("_connectionManager = new GatewayConnectionManager", source);
+        Assert.Contains("nodeConnector.ClientCreated +=", source);
+        Assert.Contains("_nodeService.AttachClient(args.Client, args.BearerToken)", source);
+        Assert.Contains("_connectionManager.OperatorClientChanged += OnOperatorClientChanged", source);
+        Assert.Contains("_connectionManager.StateChanged += OnManagerStateChanged", source);
+        Assert.DoesNotMatch(new Regex(@"\bnew\s+OpenClawGatewayClient\s*\(", RegexOptions.Multiline), source);
+        Assert.DoesNotMatch(new Regex(@"\bnew\s+WindowsNodeClient\s*\(", RegexOptions.Multiline), source);
+    }
+
+    [Fact]
+    public void Startup_Order_PreservesInitializationInvariants()
+    {
+        var source = ReadAppSources();
+
+        AssertInOrder(
+            source,
+            "_settings = new SettingsManager();",
+            "CheckForUpdatesAsync();",
+            "ToastNotificationManagerCompat.OnActivated += OnToastActivated;",
+            "InitializeTrayIcon();",
+            "_gatewayRegistry = new GatewayRegistry",
+            "_connectionManager = new GatewayConnectionManager",
+            "await ShowOnboardingAsync();",
+            "EnsureNodeService(_settings);",
+            "InitializeGatewayClient();",
+            "StartDeepLinkServer();");
+    }
+
+    [Fact]
+    public void McpOnlyStartup_DoesNotRequireGatewayCredentials()
+    {
+        var source = ReadAppSources();
+
+        var method = ExtractMethod(source, "TryStartLocalMcpOnlyNode");
+        Assert.Contains("!_settings.EnableMcpServer || _settings.EnableNodeMode", method);
+        Assert.Contains("EnsureNodeService(_settings)", method);
+        Assert.Contains("StartLocalOnlyAsync()", method);
+        Assert.Contains("WireAppCapabilityHandlers()", method);
+
+        var init = ExtractMethod(source, "InitializeGatewayClient");
+        AssertInOrder(init, "TryStartLocalMcpOnlyNode();", "Gateway URL not configured");
+        AssertInOrder(init, "TryStartLocalMcpOnlyNode()", "No stored device token");
+        Assert.Contains("Active gateway has no usable credential", source);
+    }
+
+    [Fact]
+    public void LegacyCredentialMigration_StaysRegistryBacked()
+    {
+        var source = ReadAppSources();
+        var method = ExtractMethod(source, "TryMigrateLegacyGatewaySettings");
+
+        Assert.Contains("_gatewayRegistry.MigrateFromSettings", method);
+        Assert.Contains("_settings.LegacyToken", method);
+        Assert.Contains("_settings.LegacyBootstrapToken", method);
+        Assert.Contains("SettingsManager.SettingsDirectoryPath", method);
+        Assert.DoesNotContain("SharedGatewayToken =", method);
+        Assert.DoesNotContain("BootstrapToken =", method);
+    }
+
+    [Fact]
+    public void ToastActivation_RoutesOnUiThread()
+    {
+        var source = ReadAppSources();
+        var method = ExtractMethod(source, "OnToastActivated");
+
+        Assert.Contains("ToastArguments.Parse(args.Argument)", method);
+        Assert.Contains("OnUiThread(() =>", method);
+        Assert.Contains("ToastActivationRouter.Route", method);
+        Assert.Contains("OpenDashboard = () => OpenDashboard()", method);
+        Assert.Contains("OpenSettings = ShowSettings", method);
+        Assert.Contains("OpenChat = ShowWebChat", method);
+        Assert.Contains("OpenActivity = () => ShowHub(\"channels\")", method);
+        Assert.Contains("CopyPairingCommand = command =>", method);
+    }
+
+    [Fact]
+    public void Shutdown_Order_PreservesAwaitedTeardownBeforeExit()
+    {
+        var source = ReadAppSources();
+        var method = ExtractMethod(source, "ExitApplicationAsync");
+
+        AssertInOrder(
+            method,
+            "_deepLinkCts.Cancel()",
+            "global hotkey",
+            "gateway client",
+            "connectionManager.DisposeAsync()",
+            "chat coordinator",
+            "node service",
+            "nodeService.DisposeAsync()",
+            "standalone voice service",
+            "standaloneVoiceService.DisposeAsync()",
+            "ssh tunnel service",
+            "tray icon",
+            "single-instance mutex",
+            "deep link token source",
+            "Exit();");
+    }
+
+    private static string ReadAppSources()
+    {
+        var root = GetRepositoryRoot();
+        var appDir = Path.Combine(root, "src", "OpenClaw.Tray.WinUI");
+        return string.Join(
+            "\n",
+            Directory
+                .EnumerateFiles(appDir, "App*.cs", SearchOption.TopDirectoryOnly)
+                .OrderBy(Path.GetFileName)
+                .Select(File.ReadAllText));
+    }
+
+    private static string ExtractMethod(string source, string methodName)
+    {
+        var match = Regex.Match(
+            source,
+            $@"(?m)^\s*(?:private|protected|public|internal)\s+(?:async\s+)?(?:Task(?:<[^>]+>)?|void|bool|string\??|IntPtr)\s+{Regex.Escape(methodName)}\s*\(");
+        Assert.True(match.Success, $"Could not find method {methodName}.");
+
+        var brace = source.IndexOf('{', match.Index);
+        Assert.True(brace >= 0, $"Could not find body for method {methodName}.");
+
+        var depth = 0;
+        for (var index = brace; index < source.Length; index++)
+        {
+            if (source[index] == '{')
+            {
+                depth++;
+            }
+            else if (source[index] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return source.Substring(match.Index, index - match.Index + 1);
+                }
+            }
+        }
+
+        throw new InvalidOperationException($"Could not extract method {methodName}.");
+    }
+
+    private static void AssertInOrder(string source, params string[] markers)
+    {
+        var current = -1;
+        foreach (var marker in markers)
+        {
+            var next = source.IndexOf(marker, current + 1, StringComparison.Ordinal);
+            Assert.True(next >= 0, $"Could not find marker after index {current}: {marker}");
+            current = next;
+        }
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        var env = Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT");
+        if (!string.IsNullOrWhiteSpace(env) && Directory.Exists(env))
+            return env;
+
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "openclaw-windows-node.slnx")) &&
+                Directory.Exists(Path.Combine(directory.FullName, "src")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not find repository root.");
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\GatewayNavVisibilityDebouncePolicy.cs" Link="Services\GatewayNavVisibilityDebouncePolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeInvokeActivityFormatter.cs" Link="Services\NodeInvokeActivityFormatter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeCapabilityGating.cs" Link="Services\NodeCapabilityGating.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ToastActivationRouter.cs" Link="Services\ToastActivationRouter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\TrayTooltipFormatter.cs" Link="Helpers\TrayTooltipFormatter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\GatewayDashboardUrlBuilder.cs" Link="Helpers\GatewayDashboardUrlBuilder.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\TrayStateSnapshot.cs" Link="Services\TrayStateSnapshot.cs" />

--- a/tests/OpenClaw.Tray.Tests/SettingsRoundTripTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SettingsRoundTripTests.cs
@@ -297,6 +297,71 @@ public class SettingsRoundTripTests
         Assert.Null(SettingsManager.UnprotectSettingSecret("dpapi:not-base64"));
     }
 
+    [WindowsFact]
+    public void SettingsManager_SaveProtectsSecretsWithoutMutatingInMemoryData()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "OpenClaw.Tray.Tests", Guid.NewGuid().ToString("N"));
+        var settingsPath = Path.Combine(dir, "settings.json");
+
+        try
+        {
+            var settings = new SettingsManager(dir)
+            {
+                TtsElevenLabsApiKey = "elevenlabs-key"
+            };
+
+            settings.Save();
+            Assert.Equal("elevenlabs-key", settings.TtsElevenLabsApiKey);
+
+            using (var saved = JsonDocument.Parse(File.ReadAllText(settingsPath)))
+            {
+                var stored = saved.RootElement.GetProperty(nameof(SettingsData.TtsElevenLabsApiKey)).GetString();
+                Assert.StartsWith("dpapi:", stored);
+                Assert.DoesNotContain("elevenlabs-key", stored);
+            }
+
+            settings.Save();
+            Assert.Equal("elevenlabs-key", settings.TtsElevenLabsApiKey);
+
+            var reloaded = new SettingsManager(dir);
+            Assert.Equal("elevenlabs-key", reloaded.TtsElevenLabsApiKey);
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SettingsManager_ToSettingsData_ReturnsDetachedMutableLists()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "OpenClaw.Tray.Tests", Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var settings = new SettingsManager(dir);
+            settings.A2UIImageHosts.Add("images.example.test");
+            settings.SandboxCustomFolders.Add(new SandboxCustomFolder
+            {
+                Path = "C:\\Temp\\OpenClaw",
+                Access = SandboxFolderAccess.ReadOnly
+            });
+
+            var snapshot = settings.ToSettingsData();
+            snapshot.A2UIImageHosts!.Add("mutated.example.test");
+            snapshot.SandboxCustomFolders![0].Path = "C:\\Mutated";
+
+            Assert.Equal(["images.example.test"], settings.A2UIImageHosts);
+            Assert.Equal("C:\\Temp\\OpenClaw", settings.SandboxCustomFolders[0].Path);
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]

--- a/tests/OpenClaw.Tray.Tests/ToastActivationRouterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ToastActivationRouterTests.cs
@@ -1,0 +1,82 @@
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class ToastActivationRouterTests
+{
+    [Theory]
+    [InlineData("open_dashboard", "dashboard")]
+    [InlineData("open_settings", "settings")]
+    [InlineData("open_chat", "chat")]
+    [InlineData("open_activity", "activity")]
+    public void Route_DispatchesSimpleActions(string action, string expected)
+    {
+        var calls = new List<string>();
+
+        ToastActivationRouter.Route(
+            action,
+            _ => null,
+            BuildActions(calls));
+
+        Assert.Equal([expected], calls);
+    }
+
+    [Fact]
+    public void Route_OpenUrl_RequiresUrlArgument()
+    {
+        var calls = new List<string>();
+
+        ToastActivationRouter.Route(
+            "open_url",
+            key => key == "url" ? "https://example.test/" : null,
+            BuildActions(calls));
+
+        ToastActivationRouter.Route(
+            "open_url",
+            _ => null,
+            BuildActions(calls));
+
+        Assert.Equal(["url:https://example.test/"], calls);
+    }
+
+    [Fact]
+    public void Route_CopyPairingCommand_RequiresCommandArgument()
+    {
+        var calls = new List<string>();
+
+        ToastActivationRouter.Route(
+            "copy_pairing_command",
+            key => key == "command" ? "openclaw pair approve abc" : null,
+            BuildActions(calls));
+
+        ToastActivationRouter.Route(
+            "copy_pairing_command",
+            _ => null,
+            BuildActions(calls));
+
+        Assert.Equal(["copy:openclaw pair approve abc"], calls);
+    }
+
+    [Fact]
+    public void Route_UnknownAction_NoOps()
+    {
+        var calls = new List<string>();
+
+        ToastActivationRouter.Route(
+            "unknown",
+            _ => throw new InvalidOperationException("arguments should not be read"),
+            BuildActions(calls));
+
+        Assert.Empty(calls);
+    }
+
+    private static ToastActivationActions BuildActions(List<string> calls) => new()
+    {
+        OpenUrl = url => calls.Add($"url:{url}"),
+        OpenDashboard = () => calls.Add("dashboard"),
+        OpenSettings = () => calls.Add("settings"),
+        OpenChat = () => calls.Add("chat"),
+        OpenActivity = () => calls.Add("activity"),
+        CopyPairingCommand = command => calls.Add($"copy:{command}")
+    };
+}

--- a/tests/OpenClaw.Tray.Tests/TrayMenuWindowMarkupTests.cs
+++ b/tests/OpenClaw.Tray.Tests/TrayMenuWindowMarkupTests.cs
@@ -44,6 +44,50 @@ public class TrayMenuWindowMarkupTests
     }
 
     [Fact]
+    public void CanvasWindow_CleansUpGatewayAuthWebResourceHandler()
+    {
+        var sourcePath = Path.Combine(
+            GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Windows",
+            "CanvasWindow.xaml.cs");
+
+        var source = File.ReadAllText(sourcePath);
+
+        Assert.Contains("_webResourceRequestedHandler = OnGatewayWebResourceRequested", source);
+        Assert.Contains("WebResourceRequested += _webResourceRequestedHandler", source);
+        Assert.Contains("WebResourceRequested -= _webResourceRequestedHandler", source);
+        Assert.Contains("RemoveWebResourceRequestedFilter", source);
+        Assert.Contains("_gatewayToken = null", source);
+        Assert.Contains("_trustedGatewayOrigin = null", source);
+        Assert.Contains("IsUriForOrigin(args.Request.Uri, trustedOrigin)", source);
+        Assert.DoesNotContain("WebResourceRequested += (", source);
+    }
+
+    [Fact]
+    public void Source_DoesNotDeclareAsyncVoidHandlers()
+    {
+        var sourceRoot = Path.Combine(GetRepositoryRoot(), "src");
+        var offenders = Directory
+            .EnumerateFiles(sourceRoot, "*.cs", SearchOption.AllDirectories)
+            .SelectMany(file =>
+            {
+                var source = File.ReadAllText(file);
+                return Regex.Matches(
+                        source,
+                        @"(?m)^\s*(?:(?:public|private|protected|internal)\s+)?(?:override\s+)?async\s+void\s+[A-Za-z_][A-Za-z0-9_]*\s*\(")
+                    .Select(match => $"{Path.GetRelativePath(sourceRoot, file)}:{LineNumber(source, match.Index)}");
+            })
+            .ToArray();
+
+        Assert.True(
+            offenders.Length == 0,
+            "Async event handlers must delegate through AsyncEventHandlerGuard instead of declaring async void: " +
+            string.Join(", ", offenders));
+    }
+
+    [Fact]
     public void CommandPalette_HasCommandCenterEntryPoint()
     {
         var sourcePath = Path.Combine(
@@ -467,4 +511,7 @@ public class TrayMenuWindowMarkupTests
 
         throw new InvalidOperationException("Could not find repository root.");
     }
+
+    private static int LineNumber(string source, int index) =>
+        source.AsSpan(0, index).Count('\n') + 1;
 }


### PR DESCRIPTION
## Summary

Addresses the QQSHI13 issue set with a staged hardening pass:

- fixes CanvasWindow WebView2 auth handler lifecycle and stale-token capture (#556)
- adds awaitable shutdown/disposal paths for MCP, NodeService, GatewayConnectionManager, and app exit (#553)
- replaces source async-void handlers with guarded Task delegation (#552)
- refactors SettingsManager to use SettingsData-backed state while preserving schema, legacy migration, and DPAPI behavior (#555)
- adds #554 App refactor contracts and extracts a small tested toast activation seam; broad ConnectionPage/App decomposition is intentionally left for follow-up

## Issue coverage

| Issue | Status |
|---|---|
| #556 CanvasWindow WebView2 leak/stale token | Addressed |
| #553 sync-over-async disposal | Addressed for reported services |
| #552 async void crash hazards | Addressed; regression test prevents new source async-void handlers |
| #555 SettingsManager manual mapping | Addressed pragmatically with record-backed SettingsData state |
| #554 god files | Safe first stage only; follow-up needed for larger ConnectionPage/App extraction |

## Validation

- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Connection.Tests/OpenClaw.Connection.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`
- local isolated tray smoke
- local tray run using existing settings