### PR TITLE
Improve chat voice input readiness UX

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
@@ -785,10 +785,6 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
             })
             .Set(b => b.Opacity = showTools ? 1.0 : 0.55);
 
-        var settingsBtn = Props.OnSettingsClick is not null
-            ? IconButton("\uE713", "Settings", () => Props.OnSettingsClick())
-            : Empty();
-
         // Send button — always present so the user can queue follow-up messages
         // even while the assistant is responding.
         var defaultSendBrush = ChatVisualResolver.UserBubbleBrush(
@@ -1019,7 +1015,9 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
             // Wrapping in FlexRow caused the Button to stretch to the Star column width.
             var bottomRow = Grid([GridSize.Auto, GridSize.Star()], [GridSize.Auto],
                 combinedPill.HAlign(HorizontalAlignment.Left).Grid(row: 0, column: 0),
-                (FlexRow(attachBtn, voiceCancelBtn, voiceBtn, speakerBtn, toolToggleBtn, settingsBtn, actionBtn, stopBtn) with { ColumnGap = 4 })                    .HAlign(HorizontalAlignment.Right).Grid(row: 0, column: 1)
+                (FlexRow(attachBtn, voiceCancelBtn, voiceBtn, speakerBtn, toolToggleBtn, actionBtn, stopBtn) with { ColumnGap = 4 })
+                    .HAlign(HorizontalAlignment.Right)
+                    .Grid(row: 0, column: 1)
             );
 
             return VStack(0,
@@ -1037,7 +1035,7 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         }
 
         var actionsRow = Grid([GridSize.Star(), GridSize.Auto], [GridSize.Auto],
-            (FlexRow(attachBtn, voiceCancelBtn, voiceBtn, speakerBtn, toolToggleBtn, settingsBtn, actionBtn, stopBtn)
+            (FlexRow(attachBtn, voiceCancelBtn, voiceBtn, speakerBtn, toolToggleBtn, actionBtn, stopBtn)
                 with { ColumnGap = 4 })
             .HAlign(HorizontalAlignment.Right)
             .Grid(row: 0, column: 1)

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -662,51 +662,33 @@ public sealed partial class ChatPage : Page
 
     private async Task<string?> VoiceTranscribeAsync(CancellationToken cancellationToken, Action? onRecordingStarted)
     {
+        if (CurrentApp.Settings?.NodeSttEnabled != true)
+        {
+            await ShowVoiceSettingsDialogAsync(
+                LocalizationHelper.GetString("ChatVoiceDialog_InputOffTitle"),
+                LocalizationHelper.GetString("ChatVoiceDialog_InputOffMessage"),
+                NavigateToVoiceSettings);
+            return null;
+        }
+
         var voiceService = _hub?.VoiceServiceInstance;
         var host = _functionalHost;
-        if (voiceService is null) return null;
+        if (voiceService is null)
+        {
+            await ShowVoiceSettingsDialogAsync(
+                LocalizationHelper.GetString("ChatVoiceDialog_InputOffTitle"),
+                LocalizationHelper.GetString("ChatVoiceDialog_InputOffMessage"),
+                NavigateToVoiceSettings);
+            return null;
+        }
 
         // If the STT model isn't downloaded yet, prompt the user and open voice settings.
         if (!voiceService.IsModelDownloaded)
         {
-            var tcs = new TaskCompletionSource();
-            DispatcherQueue?.TryEnqueue(async () =>
-            {
-                try
-                {
-                    var dialog = new ContentDialog
-                    {
-                        Title = "Voice Model Required",
-                        Content = "The speech-to-text model needs to be installed before you can use voice input. Would you like to open Voice settings to install it?",
-                        PrimaryButtonText = "Open Voice Settings",
-                        CloseButtonText = "Cancel",
-                        XamlRoot = Content?.XamlRoot
-                    };
-                    // Light-dismiss: close when the user taps the smoke overlay.
-                    dialog.Opened += (s, _) =>
-                    {
-                        if (s is ContentDialog d)
-                        {
-                            foreach (var popup in Microsoft.UI.Xaml.Media.VisualTreeHelper.GetOpenPopupsForXamlRoot(d.XamlRoot))
-                            {
-                                if (popup.Child is UIElement overlay && overlay != d)
-                                {
-                                    overlay.Tapped += (_, _) => d.Hide();
-                                    break;
-                                }
-                            }
-                        }
-                    };
-                    var result = await dialog.ShowAsync();
-                    if (result == ContentDialogResult.Primary)
-                    {
-                        _hub?.NavigateTo("voice");
-                    }
-                }
-                catch { /* dialog already open or window closing */ }
-                finally { tcs.TrySetResult(); }
-            });
-            await tcs.Task;
+            await ShowVoiceSettingsDialogAsync(
+                LocalizationHelper.GetString("ChatVoiceDialog_ModelRequiredTitle"),
+                LocalizationHelper.GetString("ChatVoiceDialog_ModelRequiredMessage"),
+                NavigateToVoiceSettings);
             return null;
         }
 
@@ -734,6 +716,63 @@ public sealed partial class ChatPage : Page
             host?.SetVoiceTranscript(null);
             host?.SetVoiceAudioLevel(0f);
         }
+    }
+
+    private async Task ShowVoiceSettingsDialogAsync(string title, string message, Action openVoiceSettings)
+    {
+        var tcs = new TaskCompletionSource();
+        if (DispatcherQueue is null || !DispatcherQueue.TryEnqueue(async () =>
+        {
+            try
+            {
+                var dialog = new ContentDialog
+                {
+                    Title = title,
+                    Content = message,
+                    PrimaryButtonText = LocalizationHelper.GetString("ChatVoiceDialog_OpenVoiceSettings"),
+                    CloseButtonText = LocalizationHelper.GetString("ChatVoiceDialog_Dismiss"),
+                    XamlRoot = Content?.XamlRoot
+                };
+                dialog.Opened += (s, _) =>
+                {
+                    if (s is ContentDialog d)
+                    {
+                        foreach (var popup in Microsoft.UI.Xaml.Media.VisualTreeHelper.GetOpenPopupsForXamlRoot(d.XamlRoot))
+                        {
+                            if (popup.Child is UIElement overlay && overlay != d)
+                            {
+                                overlay.Tapped += (_, _) => d.Hide();
+                                break;
+                            }
+                        }
+                    }
+                };
+
+                if (await dialog.ShowAsync() == ContentDialogResult.Primary)
+                    openVoiceSettings();
+            }
+            catch (InvalidOperationException ex)
+            {
+                Logger.Warn($"Voice settings dialog could not be shown: {ex.Message}");
+            }
+            finally
+            {
+                tcs.TrySetResult();
+            }
+        }))
+        {
+            return;
+        }
+
+        await tcs.Task;
+    }
+
+    private void NavigateToVoiceSettings()
+    {
+        if (_hub is not null)
+            _hub.NavigateTo("voice");
+        else
+            (App.Current as App)?.ShowHub("voice");
     }
 
     private void OnAttachClicked()

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -731,6 +731,7 @@ public sealed partial class ChatPage : Page
                     Content = message,
                     PrimaryButtonText = LocalizationHelper.GetString("ChatVoiceDialog_OpenVoiceSettings"),
                     CloseButtonText = LocalizationHelper.GetString("ChatVoiceDialog_Dismiss"),
+                    DefaultButton = ContentDialogButton.Primary,
                     XamlRoot = Content?.XamlRoot
                 };
                 dialog.Opened += (s, _) =>

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
@@ -426,7 +426,6 @@ public sealed partial class PermissionsPage : Page
         {
             CurrentApp.Settings.TtsProvider = newProvider;
             CurrentApp.Settings.Save();
-            ((IAppCommands)CurrentApp).NotifySettingsSaved();
             TtsStatusText.Text = LocalizationHelper.Format(
                 "PermissionsPage_TtsStatus_DefaultProviderFormat", newProvider);
         }
@@ -469,7 +468,6 @@ public sealed partial class PermissionsPage : Page
         if (changed)
         {
             settings.Save();
-            ((IAppCommands)CurrentApp).NotifySettingsSaved();
             TtsElevenLabsApiKeyBox.Password =
                 string.IsNullOrEmpty(settings.TtsElevenLabsApiKey) ? "" : SavedApiKeySentinel;
             TtsStatusText.Text = LocalizationHelper.GetString("PermissionsPage_TtsStatus_ElevenLabsSaved");

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
@@ -37,6 +37,11 @@
                     BorderThickness="1" CornerRadius="8" Padding="16">
                 <StackPanel Spacing="12">
                     <TextBlock x:Uid="VoiceSettingsPage_ModelHeader" x:Name="ModelHeaderText" Text="Speech Model" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                    <TextBlock x:Uid="VoiceSettingsPage_ModelRequirementText" x:Name="ModelRequirementText"
+                               Text="Voice input is not ready until at least one speech model is downloaded."
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               TextWrapping="Wrap"/>
 
                     <ComboBox x:Uid="VoiceSettingsPage_ModelCombo" x:Name="ModelCombo" Header="Model Size"
                               SelectionChanged="OnModelChanged" Width="320">

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
@@ -148,9 +148,7 @@ public sealed partial class VoiceSettingsPage : Page
         }
         else
         {
-            ModelStatusText.Text = SttEnabledToggle.IsOn
-                ? L("VoiceSettingsPage_StatusDownloadRequiredActive")
-                : L("VoiceSettingsPage_StatusDownloadRequired");
+            ModelStatusText.Text = L("VoiceSettingsPage_StatusDownloadRequired");
             DownloadButtonText.Text = L("VoiceSettingsPage_ButtonDownloadModel");
             TestVoiceButton.Visibility = Visibility.Collapsed;
         }

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
@@ -148,7 +148,9 @@ public sealed partial class VoiceSettingsPage : Page
         }
         else
         {
-            ModelStatusText.Text = L("VoiceSettingsPage_StatusDownloadRequired");
+            ModelStatusText.Text = SttEnabledToggle.IsOn
+                ? L("VoiceSettingsPage_StatusDownloadRequiredActive")
+                : L("VoiceSettingsPage_StatusDownloadRequired");
             DownloadButtonText.Text = L("VoiceSettingsPage_ButtonDownloadModel");
             TestVoiceButton.Visibility = Visibility.Collapsed;
         }
@@ -166,6 +168,8 @@ public sealed partial class VoiceSettingsPage : Page
         CurrentApp.Settings.NodeSttEnabled = SttEnabledToggle.IsOn;
         CurrentApp.Settings.Save();
         UpdateCardVisibility();
+        UpdateModelStatus();
+        ((IAppCommands)CurrentApp).NotifySettingsSaved();
     }
 
     private void OnModelChanged(object sender, SelectionChangedEventArgs e)

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2688,9 +2688,6 @@ On your gateway host (Mac/Linux), run:
   <data name="VoiceSettingsPage_StatusDownloadRequired" xml:space="preserve">
     <value>⬇️ Download required</value>
   </data>
-  <data name="VoiceSettingsPage_StatusDownloadRequiredActive" xml:space="preserve">
-    <value>Download required before voice input works</value>
-  </data>
   <data name="VoiceSettingsPage_ModelRequirementText.Text" xml:space="preserve">
     <value>Voice input is not ready until at least one speech model is downloaded.</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2707,7 +2707,7 @@ On your gateway host (Mac/Linux), run:
     <value>Speech-to-Text is on, but voice input will not work until at least one speech model is downloaded.</value>
   </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
-    <value>Open Voice Settings</value>
+    <value>Open Voice &amp; Audio Settings</value>
   </data>
   <data name="ChatVoiceDialog_Dismiss" xml:space="preserve">
     <value>Dismiss</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2688,6 +2688,30 @@ On your gateway host (Mac/Linux), run:
   <data name="VoiceSettingsPage_StatusDownloadRequired" xml:space="preserve">
     <value>⬇️ Download required</value>
   </data>
+  <data name="VoiceSettingsPage_StatusDownloadRequiredActive" xml:space="preserve">
+    <value>Download required before voice input works</value>
+  </data>
+  <data name="VoiceSettingsPage_ModelRequirementText.Text" xml:space="preserve">
+    <value>Voice input is not ready until at least one speech model is downloaded.</value>
+  </data>
+  <data name="ChatVoiceDialog_InputOffTitle" xml:space="preserve">
+    <value>Voice Input Is Off</value>
+  </data>
+  <data name="ChatVoiceDialog_InputOffMessage" xml:space="preserve">
+    <value>Turn on Speech-to-Text in Voice settings, then download a speech model before using the microphone in chat.</value>
+  </data>
+  <data name="ChatVoiceDialog_ModelRequiredTitle" xml:space="preserve">
+    <value>Speech Model Required</value>
+  </data>
+  <data name="ChatVoiceDialog_ModelRequiredMessage" xml:space="preserve">
+    <value>Speech-to-Text is on, but voice input will not work until at least one speech model is downloaded.</value>
+  </data>
+  <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
+    <value>Open Voice Settings</value>
+  </data>
+  <data name="ChatVoiceDialog_Dismiss" xml:space="preserve">
+    <value>Dismiss</value>
+  </data>
   <data name="VoiceSettingsPage_ButtonReDownload" xml:space="preserve">
     <value>Re-download</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2640,9 +2640,6 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="VoiceSettingsPage_StatusDownloadRequired" xml:space="preserve">
     <value>⬇️ Téléchargement requis</value>
   </data>
-  <data name="VoiceSettingsPage_StatusDownloadRequiredActive" xml:space="preserve">
-    <value>Téléchargement requis avant que la saisie vocale fonctionne</value>
-  </data>
   <data name="VoiceSettingsPage_ModelRequirementText.Text" xml:space="preserve">
     <value>La saisie vocale n'est pas prête tant qu'au moins un modèle vocal n'a pas été téléchargé.</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2659,7 +2659,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>La reconnaissance vocale est activée, mais la saisie vocale ne fonctionnera pas tant qu'au moins un modèle vocal n'aura pas été téléchargé.</value>
   </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
-    <value>Ouvrir les paramètres Voix</value>
+    <value>Ouvrir les paramètres Voix et audio</value>
   </data>
   <data name="ChatVoiceDialog_Dismiss" xml:space="preserve">
     <value>Fermer</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2640,6 +2640,30 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="VoiceSettingsPage_StatusDownloadRequired" xml:space="preserve">
     <value>⬇️ Téléchargement requis</value>
   </data>
+  <data name="VoiceSettingsPage_StatusDownloadRequiredActive" xml:space="preserve">
+    <value>Téléchargement requis avant que la saisie vocale fonctionne</value>
+  </data>
+  <data name="VoiceSettingsPage_ModelRequirementText.Text" xml:space="preserve">
+    <value>La saisie vocale n'est pas prête tant qu'au moins un modèle vocal n'a pas été téléchargé.</value>
+  </data>
+  <data name="ChatVoiceDialog_InputOffTitle" xml:space="preserve">
+    <value>La saisie vocale est désactivée</value>
+  </data>
+  <data name="ChatVoiceDialog_InputOffMessage" xml:space="preserve">
+    <value>Activez la reconnaissance vocale dans les paramètres Voix, puis téléchargez un modèle vocal avant d'utiliser le microphone dans le chat.</value>
+  </data>
+  <data name="ChatVoiceDialog_ModelRequiredTitle" xml:space="preserve">
+    <value>Modèle vocal requis</value>
+  </data>
+  <data name="ChatVoiceDialog_ModelRequiredMessage" xml:space="preserve">
+    <value>La reconnaissance vocale est activée, mais la saisie vocale ne fonctionnera pas tant qu'au moins un modèle vocal n'aura pas été téléchargé.</value>
+  </data>
+  <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
+    <value>Ouvrir les paramètres Voix</value>
+  </data>
+  <data name="ChatVoiceDialog_Dismiss" xml:space="preserve">
+    <value>Fermer</value>
+  </data>
   <data name="VoiceSettingsPage_ButtonReDownload" xml:space="preserve">
     <value>Retélécharger</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2641,9 +2641,6 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="VoiceSettingsPage_StatusDownloadRequired" xml:space="preserve">
     <value>⬇️ Download vereist</value>
   </data>
-  <data name="VoiceSettingsPage_StatusDownloadRequiredActive" xml:space="preserve">
-    <value>Download vereist voordat spraakinvoer werkt</value>
-  </data>
   <data name="VoiceSettingsPage_ModelRequirementText.Text" xml:space="preserve">
     <value>Spraakinvoer is pas klaar nadat ten minste één spraakmodel is gedownload.</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2660,7 +2660,7 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>Spraak-naar-tekst is ingeschakeld, maar spraakinvoer werkt pas nadat ten minste één spraakmodel is gedownload.</value>
   </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
-    <value>Spraakinstellingen openen</value>
+    <value>Spraak- en audio-instellingen openen</value>
   </data>
   <data name="ChatVoiceDialog_Dismiss" xml:space="preserve">
     <value>Sluiten</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2641,6 +2641,30 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="VoiceSettingsPage_StatusDownloadRequired" xml:space="preserve">
     <value>⬇️ Download vereist</value>
   </data>
+  <data name="VoiceSettingsPage_StatusDownloadRequiredActive" xml:space="preserve">
+    <value>Download vereist voordat spraakinvoer werkt</value>
+  </data>
+  <data name="VoiceSettingsPage_ModelRequirementText.Text" xml:space="preserve">
+    <value>Spraakinvoer is pas klaar nadat ten minste één spraakmodel is gedownload.</value>
+  </data>
+  <data name="ChatVoiceDialog_InputOffTitle" xml:space="preserve">
+    <value>Spraakinvoer is uitgeschakeld</value>
+  </data>
+  <data name="ChatVoiceDialog_InputOffMessage" xml:space="preserve">
+    <value>Schakel Spraak-naar-tekst in bij Spraakinstellingen en download daarna een spraakmodel voordat u de microfoon in de chat gebruikt.</value>
+  </data>
+  <data name="ChatVoiceDialog_ModelRequiredTitle" xml:space="preserve">
+    <value>Spraakmodel vereist</value>
+  </data>
+  <data name="ChatVoiceDialog_ModelRequiredMessage" xml:space="preserve">
+    <value>Spraak-naar-tekst is ingeschakeld, maar spraakinvoer werkt pas nadat ten minste één spraakmodel is gedownload.</value>
+  </data>
+  <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
+    <value>Spraakinstellingen openen</value>
+  </data>
+  <data name="ChatVoiceDialog_Dismiss" xml:space="preserve">
+    <value>Sluiten</value>
+  </data>
   <data name="VoiceSettingsPage_ButtonReDownload" xml:space="preserve">
     <value>Opnieuw downloaden</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2640,9 +2640,6 @@
   <data name="VoiceSettingsPage_StatusDownloadRequired" xml:space="preserve">
     <value>⬇️ 需要下载</value>
   </data>
-  <data name="VoiceSettingsPage_StatusDownloadRequiredActive" xml:space="preserve">
-    <value>需要先下载模型，语音输入才能使用</value>
-  </data>
   <data name="VoiceSettingsPage_ModelRequirementText.Text" xml:space="preserve">
     <value>至少下载一个语音模型后，语音输入才可使用。</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2659,7 +2659,7 @@
     <value>语音转文字已开启，但至少下载一个语音模型后，语音输入才会工作。</value>
   </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
-    <value>打开语音设置</value>
+    <value>打开语音和音频设置</value>
   </data>
   <data name="ChatVoiceDialog_Dismiss" xml:space="preserve">
     <value>关闭</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2640,6 +2640,30 @@
   <data name="VoiceSettingsPage_StatusDownloadRequired" xml:space="preserve">
     <value>⬇️ 需要下载</value>
   </data>
+  <data name="VoiceSettingsPage_StatusDownloadRequiredActive" xml:space="preserve">
+    <value>需要先下载模型，语音输入才能使用</value>
+  </data>
+  <data name="VoiceSettingsPage_ModelRequirementText.Text" xml:space="preserve">
+    <value>至少下载一个语音模型后，语音输入才可使用。</value>
+  </data>
+  <data name="ChatVoiceDialog_InputOffTitle" xml:space="preserve">
+    <value>语音输入已关闭</value>
+  </data>
+  <data name="ChatVoiceDialog_InputOffMessage" xml:space="preserve">
+    <value>请在语音设置中开启语音转文字，然后下载语音模型，才能在聊天中使用麦克风。</value>
+  </data>
+  <data name="ChatVoiceDialog_ModelRequiredTitle" xml:space="preserve">
+    <value>需要语音模型</value>
+  </data>
+  <data name="ChatVoiceDialog_ModelRequiredMessage" xml:space="preserve">
+    <value>语音转文字已开启，但至少下载一个语音模型后，语音输入才会工作。</value>
+  </data>
+  <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
+    <value>打开语音设置</value>
+  </data>
+  <data name="ChatVoiceDialog_Dismiss" xml:space="preserve">
+    <value>关闭</value>
+  </data>
   <data name="VoiceSettingsPage_ButtonReDownload" xml:space="preserve">
     <value>é‡æ–°ä¸‹è½½</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2640,9 +2640,6 @@
   <data name="VoiceSettingsPage_StatusDownloadRequired" xml:space="preserve">
     <value>⬇️ 需要下載</value>
   </data>
-  <data name="VoiceSettingsPage_StatusDownloadRequiredActive" xml:space="preserve">
-    <value>需要先下載模型，語音輸入才能使用</value>
-  </data>
   <data name="VoiceSettingsPage_ModelRequirementText.Text" xml:space="preserve">
     <value>至少下載一個語音模型後，語音輸入才可使用。</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2659,7 +2659,7 @@
     <value>語音轉文字已開啟，但至少下載一個語音模型後，語音輸入才會運作。</value>
   </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
-    <value>開啟語音設定</value>
+    <value>開啟語音和音訊設定</value>
   </data>
   <data name="ChatVoiceDialog_Dismiss" xml:space="preserve">
     <value>關閉</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2640,6 +2640,30 @@
   <data name="VoiceSettingsPage_StatusDownloadRequired" xml:space="preserve">
     <value>⬇️ 需要下載</value>
   </data>
+  <data name="VoiceSettingsPage_StatusDownloadRequiredActive" xml:space="preserve">
+    <value>需要先下載模型，語音輸入才能使用</value>
+  </data>
+  <data name="VoiceSettingsPage_ModelRequirementText.Text" xml:space="preserve">
+    <value>至少下載一個語音模型後，語音輸入才可使用。</value>
+  </data>
+  <data name="ChatVoiceDialog_InputOffTitle" xml:space="preserve">
+    <value>語音輸入已關閉</value>
+  </data>
+  <data name="ChatVoiceDialog_InputOffMessage" xml:space="preserve">
+    <value>請在語音設定中開啟語音轉文字，然後下載語音模型，才能在聊天中使用麥克風。</value>
+  </data>
+  <data name="ChatVoiceDialog_ModelRequiredTitle" xml:space="preserve">
+    <value>需要語音模型</value>
+  </data>
+  <data name="ChatVoiceDialog_ModelRequiredMessage" xml:space="preserve">
+    <value>語音轉文字已開啟，但至少下載一個語音模型後，語音輸入才會運作。</value>
+  </data>
+  <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
+    <value>開啟語音設定</value>
+  </data>
+  <data name="ChatVoiceDialog_Dismiss" xml:space="preserve">
+    <value>關閉</value>
+  </data>
   <data name="VoiceSettingsPage_ButtonReDownload" xml:space="preserve">
     <value>é‡æ–°ä¸‹è¼‰</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
@@ -504,54 +504,34 @@ public sealed partial class ChatWindow : WindowEx
 
     private async Task<string?> VoiceTranscribeAsync(CancellationToken cancellationToken, Action? onRecordingStarted)
     {
-        var voiceService = (App.Current as App)?.VoiceServiceInstance;
+        var app = App.Current as App;
+        if (app is null || app.Settings?.NodeSttEnabled != true)
+        {
+            await ShowVoiceSettingsDialogAsync(
+                LocalizationHelper.GetString("ChatVoiceDialog_InputOffTitle"),
+                LocalizationHelper.GetString("ChatVoiceDialog_InputOffMessage"),
+                () => app?.ShowHub("voice"));
+            return null;
+        }
+
+        var voiceService = app.VoiceServiceInstance;
         var host = _functionalHost;
-        if (voiceService is null) return null;
+        if (voiceService is null)
+        {
+            await ShowVoiceSettingsDialogAsync(
+                LocalizationHelper.GetString("ChatVoiceDialog_InputOffTitle"),
+                LocalizationHelper.GetString("ChatVoiceDialog_InputOffMessage"),
+                () => app.ShowHub("voice"));
+            return null;
+        }
 
         // If the STT model isn't downloaded yet, prompt the user and open voice settings.
         if (!voiceService.IsModelDownloaded)
         {
-            // Must dispatch to UI thread — this method runs on a background thread.
-            var tcs = new TaskCompletionSource();
-            DispatcherQueue?.TryEnqueue(async () =>
-            {
-                try
-                {
-                    var dialog = new ContentDialog
-                    {
-                        Title = "Voice Model Required",
-                        Content = "The speech-to-text model needs to be installed before you can use voice input. Would you like to open Voice settings to install it?",
-                        PrimaryButtonText = "Open Voice Settings",
-                        CloseButtonText = "Cancel",
-                        XamlRoot = Content?.XamlRoot
-                    };
-                    // Light-dismiss: close when the user taps the smoke overlay.
-                    dialog.Opened += (s, _) =>
-                    {
-                        if (s is ContentDialog d)
-                        {
-                            // The smoke-screen overlay is the first open popup whose
-                            // child is NOT the dialog itself.
-                            foreach (var popup in Microsoft.UI.Xaml.Media.VisualTreeHelper.GetOpenPopupsForXamlRoot(d.XamlRoot))
-                            {
-                                if (popup.Child is UIElement overlay && overlay != d)
-                                {
-                                    overlay.Tapped += (_, _) => d.Hide();
-                                    break;
-                                }
-                            }
-                        }
-                    };
-                    var result = await dialog.ShowAsync();
-                    if (result == ContentDialogResult.Primary)
-                    {
-                        (App.Current as App)?.ShowHub("voice");
-                    }
-                }
-                catch { /* dialog already open or window closing */ }
-                finally { tcs.TrySetResult(); }
-            });
-            await tcs.Task;
+            await ShowVoiceSettingsDialogAsync(
+                LocalizationHelper.GetString("ChatVoiceDialog_ModelRequiredTitle"),
+                LocalizationHelper.GetString("ChatVoiceDialog_ModelRequiredMessage"),
+                () => app.ShowHub("voice"));
             return null;
         }
 
@@ -578,6 +558,55 @@ public sealed partial class ChatWindow : WindowEx
             host?.SetVoiceTranscript(null);
             host?.SetVoiceAudioLevel(0f);
         }
+    }
+
+    private async Task ShowVoiceSettingsDialogAsync(string title, string message, Action openVoiceSettings)
+    {
+        var tcs = new TaskCompletionSource();
+        if (DispatcherQueue is null || !DispatcherQueue.TryEnqueue(async () =>
+        {
+            try
+            {
+                var dialog = new ContentDialog
+                {
+                    Title = title,
+                    Content = message,
+                    PrimaryButtonText = LocalizationHelper.GetString("ChatVoiceDialog_OpenVoiceSettings"),
+                    CloseButtonText = LocalizationHelper.GetString("ChatVoiceDialog_Dismiss"),
+                    XamlRoot = Content?.XamlRoot
+                };
+                dialog.Opened += (s, _) =>
+                {
+                    if (s is ContentDialog d)
+                    {
+                        foreach (var popup in Microsoft.UI.Xaml.Media.VisualTreeHelper.GetOpenPopupsForXamlRoot(d.XamlRoot))
+                        {
+                            if (popup.Child is UIElement overlay && overlay != d)
+                            {
+                                overlay.Tapped += (_, _) => d.Hide();
+                                break;
+                            }
+                        }
+                    }
+                };
+
+                if (await dialog.ShowAsync() == ContentDialogResult.Primary)
+                    openVoiceSettings();
+            }
+            catch (InvalidOperationException ex)
+            {
+                Logger.Warn($"Voice settings dialog could not be shown: {ex.Message}");
+            }
+            finally
+            {
+                tcs.TrySetResult();
+            }
+        }))
+        {
+            return;
+        }
+
+        await tcs.Task;
     }
 
     private async Task PickAndAttachFileAsync()

--- a/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
@@ -573,6 +573,7 @@ public sealed partial class ChatWindow : WindowEx
                     Content = message,
                     PrimaryButtonText = LocalizationHelper.GetString("ChatVoiceDialog_OpenVoiceSettings"),
                     CloseButtonText = LocalizationHelper.GetString("ChatVoiceDialog_Dismiss"),
+                    DefaultButton = ContentDialogButton.Primary,
                     XamlRoot = Content?.XamlRoot
                 };
                 dialog.Opened += (s, _) =>


### PR DESCRIPTION

<img width="904" height="188" alt="image" src="https://github.com/user-attachments/assets/fed4849b-2c25-48e0-a70a-1a994ed21f27" />
<img width="826" height="433" alt="image" src="https://github.com/user-attachments/assets/aaabbfdb-7756-4db4-b8d6-ccaa9ad640c5" />


## Summary
- Remove the redundant settings gear from the native chat composer action row.
- Keep the voice button visible, but route unready states through clear dialogs:
  - STT off explains that Speech-to-Text must be enabled and a speech model downloaded.
  - STT on with no model explains that voice input requires at least one downloaded speech model.
- Use `Open Voice & Audio Settings` as the primary dialog action and make it the default/accent button; keep `Dismiss` as the safe close action.
- Add Voice settings copy clarifying that voice input is not ready until a speech model is downloaded, while keeping the adjacent status text short to avoid overflow at narrow widths or high text scale.
- Notify settings changes immediately when the STT toggle changes so chat state refreshes without restart.
- Avoid connection loading for TTS provider / ElevenLabs detail changes; only actual node capability toggles should reload capabilities.
- Localize the new user-facing strings across existing locales.

## XAML / UX review
- ContentDialog button order follows Windows guidance: primary do-it action on the left, safe close action on the right.
- Primary dialog action uses `DefaultButton = ContentDialogButton.Primary` for the accent treatment.
- New Voice settings copy uses `CaptionTextBlockStyle`, `TextFillColorSecondaryBrush`, and `TextWrapping="Wrap"`.
- Kept long explanatory text out of the horizontal model status row to avoid text scaling/localization overflow.

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — 2051 total / 0 failed
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — 843 total / 0 failed

Note: build validation required stopping the running `OpenClaw.Tray.WinUI.exe` instance that was locking the output binary.