### PR TITLE
docs: refresh local run and script guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,14 @@ dotnet build src/OpenClaw.Tray.WinUI -r win-x64 -p:PackageMsix=true    # x64 MSI
 ### Run Tray App
 
 ```powershell
-# Run the exe directly (path includes runtime identifier)
-.\src\OpenClaw.Tray.WinUI\bin\Debug\net10.0-windows10.0.19041.0\win-arm64\OpenClaw.Tray.WinUI.exe  # ARM64
-.\src\OpenClaw.Tray.WinUI\bin\Debug\net10.0-windows10.0.19041.0\win-x64\OpenClaw.Tray.WinUI.exe    # x64
+# Build and launch through the Windows App SDK activation path
+.\run-app-local.ps1
+
+# If you already built, skip rebuild and launch the existing Debug output
+.\run-app-local.ps1 -NoBuild
+
+# Manual equivalent (replace win-x64 with win-arm64 on ARM64)
+winapp run ".\src\OpenClaw.Tray.WinUI\bin\Debug\net10.0-windows10.0.22621.0\win-x64" --manifest ".\src\OpenClaw.Tray.WinUI\Package.appxmanifest" --debug-output
 ```
 
 ### Run CLI WebSocket Validator
@@ -434,4 +439,3 @@ MIT License - see [LICENSE](LICENSE)
 ---
 
 *Formerly known as Moltbot, formerly known as Clawdbot*
-

--- a/build.ps1
+++ b/build.ps1
@@ -265,7 +265,10 @@ if ($failCount -eq 0) {
         $winUIProjectDirectory = (Split-Path -Parent $winUIProjectPath).Replace("/", "\")
 
         if ($winUITargetFramework) {
-            Write-Host "  WinUI:    .\$winUIProjectDirectory\bin\$Configuration\$winUITargetFramework\$rid\OpenClaw.Tray.WinUI.exe" -ForegroundColor White
+            $winUIOutputDirectory = ".\$winUIProjectDirectory\bin\$Configuration\$winUITargetFramework\$rid"
+            $winUIManifestPath = ".\$winUIProjectDirectory\Package.appxmanifest"
+            Write-Host "  WinUI:    .\run-app-local.ps1 -NoBuild" -ForegroundColor White
+            Write-Host "            winapp run `"$winUIOutputDirectory`" --manifest `"$winUIManifestPath`" --debug-output" -ForegroundColor DarkGray
         } else {
             Write-Warning "Unable to determine WinUI target framework from $winUIProjectPath"
         }

--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -72,7 +72,7 @@ Set the `OPENCLAW_LANGUAGE` environment variable before launching the app:
 
 ```powershell
 $env:OPENCLAW_LANGUAGE = "fr-fr"  # or nl-nl, zh-cn, zh-tw
-.\src\OpenClaw.Tray.WinUI\bin\Debug\net10.0-windows10.0.19041.0\win-x64\OpenClaw.Tray.WinUI.exe
+.\run-app-local.ps1 -NoBuild
 ```
 
 This overrides `LocalizationHelper.GetString()` calls for menus, toasts, dialogs, and the onboarding wizard. The language is validated against the supported locale list.

--- a/run-app-local.ps1
+++ b/run-app-local.ps1
@@ -1,0 +1,86 @@
+<#
+.SYNOPSIS
+    Builds and launches the WinUI tray app for local development.
+
+.DESCRIPTION
+    Uses `winapp run` with the app package manifest so local launches match the
+    Windows App SDK activation path used during validation. Do not launch the
+    generated OpenClaw.Tray.WinUI.exe directly; direct EXE startup bypasses the
+    manifest/package identity path and can hide launch-time issues.
+
+    By default this helper refuses to run outside `master` to avoid accidentally
+    launching a stale or experimental worktree. Use -AllowNonMaster when you
+    intentionally want to preview a PR or feature branch.
+
+.PARAMETER NoBuild
+    Skip the build step and launch the existing Debug output.
+
+.PARAMETER Configuration
+    Build/output configuration to use. Defaults to Debug.
+
+.PARAMETER AllowNonMaster
+    Allow launching from a branch other than master.
+
+.EXAMPLE
+    .\run-app-local.ps1
+
+.EXAMPLE
+    .\run-app-local.ps1 -NoBuild
+
+.EXAMPLE
+    .\run-app-local.ps1 -AllowNonMaster
+#>
+[CmdletBinding()]
+param(
+    [switch]$NoBuild,
+
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Debug",
+
+    [switch]$AllowNonMaster
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $repoRoot
+
+$branch = (git rev-parse --abbrev-ref HEAD).Trim()
+if ($branch -ne "master" -and -not $AllowNonMaster) {
+    throw "Refusing to run: current branch is '$branch', expected 'master'. Use -AllowNonMaster to preview this branch intentionally."
+}
+
+if (-not $NoBuild) {
+    & "$repoRoot\build.ps1" -Configuration $Configuration
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+}
+
+$winapp = Get-Command winapp -ErrorAction SilentlyContinue
+if (-not $winapp) {
+    throw "winapp CLI was not found. Install Microsoft WinAppCLI or run this from an environment where winapp is on PATH."
+}
+
+$projectPath = Join-Path $repoRoot "src\OpenClaw.Tray.WinUI\OpenClaw.Tray.WinUI.csproj"
+$manifestPath = Join-Path $repoRoot "src\OpenClaw.Tray.WinUI\Package.appxmanifest"
+[xml]$projectXml = Get-Content -LiteralPath $projectPath -Raw -Encoding UTF8
+$targetFramework = ($projectXml.Project.PropertyGroup | Where-Object { $_.TargetFramework } | Select-Object -First 1).TargetFramework
+if (-not $targetFramework) {
+    throw "Unable to determine TargetFramework from $projectPath."
+}
+
+$architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+$runtimeIdentifier = if ($architecture -eq [System.Runtime.InteropServices.Architecture]::Arm64) { "win-arm64" } else { "win-x64" }
+$outputDir = Join-Path $repoRoot "src\OpenClaw.Tray.WinUI\bin\$Configuration\$targetFramework\$runtimeIdentifier"
+
+if (-not (Test-Path $outputDir)) {
+    throw "Build output folder not found: $outputDir. Run without -NoBuild first."
+}
+if (-not (Test-Path $manifestPath)) {
+    throw "Manifest not found: $manifestPath."
+}
+
+Write-Host "Launching OpenClaw Tray with winapp ($runtimeIdentifier, $Configuration)..."
+& $winapp.Source run $outputDir --manifest $manifestPath --debug-output
+exit $LASTEXITCODE

--- a/scripts/Test-Localization.ps1
+++ b/scripts/Test-Localization.ps1
@@ -1,3 +1,28 @@
+<#
+.SYNOPSIS
+    Validates WinUI localization resources and selected localization tests.
+
+.DESCRIPTION
+    Checks source XAML for controls with x:Uid values that are missing matching
+    Resources.resw entries. It also reports candidate hard-coded localizable XAML
+    strings so localization gaps are visible during review.
+
+    By default the script also runs the focused tray localization test filters.
+    Use -SkipDotNetTests when you only want the static XAML/resource scan.
+
+.PARAMETER StrictHardcodedXaml
+    Treat candidate hard-coded XAML strings as errors instead of warnings.
+
+.PARAMETER SkipDotNetTests
+    Skip the focused dotnet test invocation and only run the static scan.
+
+.EXAMPLE
+    .\scripts\Test-Localization.ps1
+
+.EXAMPLE
+    .\scripts\Test-Localization.ps1 -StrictHardcodedXaml
+#>
+[CmdletBinding()]
 param(
     [switch]$StrictHardcodedXaml,
     [switch]$SkipDotNetTests

--- a/tools/cmdpal-dev.ps1
+++ b/tools/cmdpal-dev.ps1
@@ -1,6 +1,23 @@
-# Command Palette Development Script
-# Usage: .\tools\cmdpal-dev.ps1 [build|deploy|remove|cycle]
+<#
+.SYNOPSIS
+    Build, deploy, remove, or inspect the OpenClaw Command Palette extension.
 
+.DESCRIPTION
+    Developer helper for the Command Palette project. It builds the extension
+    for the current CPU architecture, registers loose package files for local
+    testing, removes any installed OpenClaw package, or performs the full
+    remove/build/deploy cycle.
+
+.PARAMETER Action
+    Operation to run: build, deploy, remove, status, or cycle. Defaults to cycle.
+
+.EXAMPLE
+    .\tools\cmdpal-dev.ps1 cycle
+
+.EXAMPLE
+    .\tools\cmdpal-dev.ps1 status
+#>
+[CmdletBinding()]
 param(
     [Parameter(Position=0)]
     [ValidateSet('build', 'deploy', 'remove', 'cycle', 'status')]


### PR DESCRIPTION
## Summary

- Add the tracked `run-app-local.ps1` wrapper used by the launch docs.
- Replace direct tray EXE launch docs with `run-app-local.ps1` / `winapp run --manifest`.
- Update `build.ps1` success output to show the supported launch path.
- Add comment-based help to `scripts/Test-Localization.ps1` and `tools/cmdpal-dev.ps1`.

## ClawSweeper follow-up

ClawSweeper was correct: the first revision referenced `run-app-local.ps1`, but that file was only present locally via `.git/info/exclude` and was not tracked in the PR tree. Commit `c0cb5d3c` adds the wrapper explicitly.

## After-fix proof

```powershell
--- wrapper presence proof ---
100644 c1dafe2fa7cb5ed5e7d17fe49cc104f153796c17 0 run-app-local.ps1

--- wrapper syntax parse ---
run-app-local.ps1 parse ok

--- wrapper help proof ---
-NoBuild [<SwitchParameter>]
    Skip the build step and launch the existing Debug output.

--- build.ps1 ---
All builds succeeded!

To run:
  WinUI:    .\run-app-local.ps1 -NoBuild
            winapp run ".\src\OpenClaw.Tray.WinUI\bin\Debug\net10.0-windows10.0.22621.0\win-x64" --manifest ".\src\OpenClaw.Tray.WinUI\Package.appxmanifest" --debug-output
```

## Validation

- `git ls-files --stage -- run-app-local.ps1`
- PowerShell parser check for `run-app-local.ps1`
- `Get-Help .\run-app-local.ps1 -Parameter NoBuild`
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` (`2023 passed / 29 skipped`)
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` (`860 passed`)
- `git diff --cached --check`