### PR TITLE
Fix chat tool call visibility toggle

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
@@ -427,13 +427,13 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
             return () => ChatExplorationState.Changed -= h;
         }));
 
-        // Production chat uses stable visual defaults; Chat Exploration state
-        // is honored only inside the fake preview surface.
+        // Production chat uses stable visual defaults. Tool-call visibility is
+        // the one user-facing composer toggle that applies outside preview.
         var bubbleRadius     = Props.EnableExplorationControls ? ChatVisualResolver.BubbleCornerRadius() : new CornerRadius(16);
         var bubblePadding    = Props.EnableExplorationControls ? ChatVisualResolver.BubbleInnerPadding() : new Thickness(16, 12, 16, 12);
         var bubbleSideMargin = Props.EnableExplorationControls ? ChatVisualResolver.BubbleSideMargin() : 8;
         var showAsstBubbles  = !Props.EnableExplorationControls || ChatVisualResolver.ShowAssistantBubbles();
-        var showToolCalls    = !Props.EnableExplorationControls || ChatVisualResolver.ShowToolCalls();
+        var showToolCalls    = ChatVisualResolver.ShowToolCalls();
         var gutter           = Props.EnableExplorationControls ? ChatExplorationState.Gutter : 64;
         var messageGap       = Props.EnableExplorationControls ? ChatExplorationState.MessageGap : 12;
         var showUserAvatar   = Props.EnableExplorationControls && ChatVisualResolver.ShowUserAvatar();
@@ -468,7 +468,7 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
         // Track the last-seen CollapseToolChipsVersion so we clear expanded
         // state when the user toggles tool calls off (collapsed view should
         // start fresh when re-shown).
-        var collapseToolChipsVersion = Props.EnableExplorationControls ? ChatExplorationState.CollapseToolChipsVersion : 0;
+        var collapseToolChipsVersion = ChatExplorationState.CollapseToolChipsVersion;
         var lastCollapseVersion = UseRef(collapseToolChipsVersion);
         if (lastCollapseVersion.Current != collapseToolChipsVersion)
         {

--- a/tests/OpenClaw.Tray.Tests/ChatToolCallsToggleContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatToolCallsToggleContractTests.cs
@@ -1,0 +1,48 @@
+using System.Text.RegularExpressions;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class ChatToolCallsToggleContractTests
+{
+    [Fact]
+    public void ProductionTimeline_HonorsComposerToolCallVisibilityToggle()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Chat",
+            "OpenClawChatTimeline.cs"));
+
+        Assert.Matches(
+            new Regex(@"var\s+showToolCalls\s*=\s*ChatVisualResolver\.ShowToolCalls\(\)\s*;"),
+            source);
+        Assert.DoesNotContain(
+            "var showToolCalls    = !Props.EnableExplorationControls || ChatVisualResolver.ShowToolCalls();",
+            source);
+        Assert.Matches(
+            new Regex(@"var\s+collapseToolChipsVersion\s*=\s*ChatExplorationState\.CollapseToolChipsVersion\s*;"),
+            source);
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        var env = Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT");
+        if (!string.IsNullOrWhiteSpace(env) && Directory.Exists(env))
+            return env;
+
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "openclaw-windows-node.slnx")) &&
+                Directory.Exists(Path.Combine(directory.FullName, "src")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not find repository root.");
+    }
+}


### PR DESCRIPTION
## Summary

- Make the production chat timeline honor the composer "Show/Hide tool calls" toggle.
- Keep the collapse-version reset active in production so hidden/re-shown tool calls reopen collapsed.
- Add a contract test to prevent the production timeline from reintroducing the preview-only gate.

## Root cause

The composer button toggled `ChatExplorationState.ShowToolCalls`, but `OpenClawChatTimeline` forced `showToolCalls` to `true` whenever `EnableExplorationControls` was false. That gate was introduced during the chat visual/refactor work to keep preview-only styling knobs out of production, but this one value is also driven by a real production composer button.

## Related pattern check

I checked the other `EnableExplorationControls` gates in the chat timeline. The remaining gates are preview visual styling/defaults (bubble radius/padding, avatars, timestamps, burst style), not production composer controls. This fix intentionally leaves those preview-only gates in place.

## Validation

- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` (`2023 passed / 29 skipped`)
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` (`861 passed`)
- `git diff --check`