### PR TITLE
Fix local dev setup: Node.js prereq, log link, WSL diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
         dotnet-version: 10.0.x
 
     - name: Cache NuGet packages
+      continue-on-error: true
       uses: actions/cache@v5
       with:
         path: ~/.nuget/packages
@@ -290,6 +291,7 @@ jobs:
         dotnet-version: 10.0.x
 
     - name: Cache NuGet packages
+      continue-on-error: true
       uses: actions/cache@v5
       with:
         path: ~/.nuget/packages
@@ -358,6 +360,7 @@ jobs:
         dotnet-version: 10.0.x
 
     - name: Cache NuGet packages
+      continue-on-error: true
       uses: actions/cache@v5
       with:
         path: ~/.nuget/packages
@@ -447,6 +450,7 @@ jobs:
         dotnet --version
 
     - name: Cache NuGet packages
+      continue-on-error: true
       uses: actions/cache@v5
       with:
         path: ~/.nuget/packages

--- a/README.md
+++ b/README.md
@@ -67,15 +67,25 @@ dotnet build src/OpenClaw.Tray.WinUI -r win-x64 -p:PackageMsix=true    # x64 MSI
 ### Run Tray App
 
 ```powershell
-# Build and launch through the Windows App SDK activation path
+# Build and launch the unpackaged WinUI tray app
 .\run-app-local.ps1
 
 # If you already built, skip rebuild and launch the existing Debug output
 .\run-app-local.ps1 -NoBuild
 
-# Manual equivalent (replace win-x64 with win-arm64 on ARM64)
-winapp run ".\src\OpenClaw.Tray.WinUI\bin\Debug\net10.0-windows10.0.22621.0\win-x64" --manifest ".\src\OpenClaw.Tray.WinUI\Package.appxmanifest" --debug-output
+# Run isolated from your normal tray settings so multiple worktrees can run together
+.\run-app-local.ps1 -Isolated
+
+# Alpha update testing from a Release build
+.\run-app-local.ps1 -Configuration Release -Isolated -UpdateChannel alpha
+
+# Optional: launch through WinAppCLI with Package.appxmanifest
+.\run-app-local.ps1 -UseWinApp -NoBuild
 ```
+
+The default path starts the unpackaged executable directly. `-UseWinApp` requires
+Microsoft WinAppCLI (`winget install Microsoft.WinAppCLI`) and is only needed when
+you want manifest/MSIX-adjacent launch validation.
 
 ### Run CLI WebSocket Validator
 

--- a/build.ps1
+++ b/build.ps1
@@ -267,7 +267,9 @@ if ($failCount -eq 0) {
             $winUIOutputDirectory = ".\$winUIProjectDirectory\bin\$Configuration\$winUITargetFramework\$rid"
             $winUIManifestPath = ".\$winUIProjectDirectory\Package.appxmanifest"
             Write-Host "  WinUI:    .\run-app-local.ps1 -NoBuild" -ForegroundColor White
-            Write-Host "            winapp run `"$winUIOutputDirectory`" --manifest `"$winUIManifestPath`" --debug-output" -ForegroundColor DarkGray
+            Write-Host "  Isolated: .\run-app-local.ps1 -NoBuild -Isolated" -ForegroundColor White
+            Write-Host "  WinApp:   .\run-app-local.ps1 -NoBuild -UseWinApp" -ForegroundColor White
+            Write-Host "            Direct launch is default. -UseWinApp runs: winapp run `"$winUIOutputDirectory`" --manifest `"$winUIManifestPath`" --debug-output" -ForegroundColor DarkGray
         } else {
             Write-Warning "Unable to determine WinUI target framework from $winUIProjectPath"
         }

--- a/build.ps1
+++ b/build.ps1
@@ -90,6 +90,29 @@ if (-not $dotnetVersion) {
     }
 }
 
+# Check Node.js + npm (WinUI build runs `npm ci` to restore @microsoft/mxc-sdk
+# so it can copy wxc-exec.exe into the build output)
+$nodeVersion = $null
+try { $nodeVersion = & node --version 2>$null } catch {}
+if (-not $nodeVersion) {
+    Write-Error "Node.js not found (required by WinUI build to restore @microsoft/mxc-sdk)"
+    Write-Info "Install via: winget install OpenJS.NodeJS.LTS"
+    Write-Info "Or download from: https://nodejs.org/"
+    $issues += "Missing Node.js"
+} else {
+    Write-Success "Node.js: $nodeVersion"
+
+    $npmVersion = $null
+    try { $npmVersion = & npm --version 2>$null } catch {}
+    if (-not $npmVersion) {
+        Write-Error "npm not found on PATH (WinUI build invokes `npm ci`)"
+        Write-Info "npm normally ships with Node.js - reinstall Node.js or repair the install"
+        $issues += "Missing npm"
+    } else {
+        Write-Success "npm: $npmVersion"
+    }
+}
+
 # Check Windows SDK (for WinUI)
 $windowsSdkPath = "${env:ProgramFiles(x86)}\Windows Kits\10\Include"
 if (Test-Path $windowsSdkPath) {
@@ -269,7 +292,7 @@ if ($failCount -eq 0) {
             Write-Host "  WinUI:    .\run-app-local.ps1 -NoBuild" -ForegroundColor White
             Write-Host "  Isolated: .\run-app-local.ps1 -NoBuild -Isolated" -ForegroundColor White
             Write-Host "  WinApp:   .\run-app-local.ps1 -NoBuild -UseWinApp" -ForegroundColor White
-            Write-Host "            Direct launch is default. -UseWinApp runs: winapp run `"$winUIOutputDirectory`" --manifest `"$winUIManifestPath`" --debug-output" -ForegroundColor DarkGray
+            Write-Host "            Direct launch is default. -UseWinApp runs: winapp run `"$winUIOutputDirectory`" --manifest `"$winUIManifestPath`" --executable `"OpenClaw.Tray.WinUI.exe`" --debug-output" -ForegroundColor DarkGray
         } else {
             Write-Warning "Unable to determine WinUI target framework from $winUIProjectPath"
         }

--- a/run-app-local.ps1
+++ b/run-app-local.ps1
@@ -3,10 +3,14 @@
     Builds and launches the WinUI tray app for local development.
 
 .DESCRIPTION
-    Uses `winapp run` with the app package manifest so local launches match the
-    Windows App SDK activation path used during validation. Do not launch the
-    generated OpenClaw.Tray.WinUI.exe directly; direct EXE startup bypasses the
-    manifest/package identity path and can hide launch-time issues.
+    Builds the tray app, then launches the unpackaged WinUI executable directly
+    for the common local-development path.
+
+    Use -UseWinApp when you specifically want Microsoft WinAppCLI (`winapp run`)
+    to launch with Package.appxmanifest for packaged/MSIX-adjacent validation.
+
+    Use -Isolated (or -DataDir) to run multiple worktrees side-by-side without
+    sharing settings, logs, run markers, device identities, or mutex names.
 
     By default this helper refuses to run outside `master` to avoid accidentally
     launching a stale or experimental worktree. Use -AllowNonMaster when you
@@ -21,6 +25,31 @@
 .PARAMETER AllowNonMaster
     Allow launching from a branch other than master.
 
+.PARAMETER Isolated
+    Set OPENCLAW_TRAY_DATA_DIR to a stable temp directory unique to this worktree
+    and branch so multiple local launches can run side-by-side.
+
+.PARAMETER DataDir
+    Set OPENCLAW_TRAY_DATA_DIR to an explicit directory for this launch.
+
+.PARAMETER UpdateChannel
+    Set OPENCLAW_UPDATE_CHANNEL for this launch. Use alpha for prerelease update
+    testing after building a lower-version Release baseline.
+
+.PARAMETER UseWinApp
+    Launch through Microsoft WinAppCLI (`winapp run`) with Package.appxmanifest
+    instead of directly starting the unpackaged executable.
+
+.PARAMETER NoDebugOutput
+    With -UseWinApp, launch without winapp --debug-output.
+
+.PARAMETER Wait
+    Wait for the launched process to exit. Direct launches return immediately by
+    default after printing the PID.
+
+.PARAMETER DryRun
+    Print the launch command and environment without starting the app.
+
 .EXAMPLE
     .\run-app-local.ps1
 
@@ -28,7 +57,13 @@
     .\run-app-local.ps1 -NoBuild
 
 .EXAMPLE
-    .\run-app-local.ps1 -AllowNonMaster
+    .\run-app-local.ps1 -Isolated
+
+.EXAMPLE
+    .\run-app-local.ps1 -Configuration Release -Isolated -UpdateChannel alpha -AllowNonMaster
+
+.EXAMPLE
+    .\run-app-local.ps1 -UseWinApp -NoBuild
 #>
 [CmdletBinding()]
 param(
@@ -37,7 +72,22 @@ param(
     [ValidateSet("Debug", "Release")]
     [string]$Configuration = "Debug",
 
-    [switch]$AllowNonMaster
+    [switch]$AllowNonMaster,
+
+    [switch]$Isolated,
+
+    [string]$DataDir,
+
+    [ValidateSet("stable", "alpha", "prerelease")]
+    [string]$UpdateChannel,
+
+    [switch]$UseWinApp,
+
+    [switch]$NoDebugOutput,
+
+    [switch]$Wait,
+
+    [switch]$DryRun
 )
 
 $ErrorActionPreference = "Stop"
@@ -45,7 +95,38 @@ $ErrorActionPreference = "Stop"
 $repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 Set-Location $repoRoot
 
-$branch = (git rev-parse --abbrev-ref HEAD).Trim()
+function Resolve-FullPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $expanded = [Environment]::ExpandEnvironmentVariables($Path)
+    if ([System.IO.Path]::IsPathRooted($expanded)) {
+        return [System.IO.Path]::GetFullPath($expanded)
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path $repoRoot $expanded))
+}
+
+function Get-SafePathSegment {
+    param([Parameter(Mandatory = $true)][string]$Value)
+
+    $safe = [regex]::Replace($Value, "[^A-Za-z0-9._-]+", "-").Trim("-")
+    if ($safe) { return $safe }
+    return "default"
+}
+
+function Get-ShortHash {
+    param([Parameter(Mandatory = $true)][string]$Value)
+
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = $sha.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Value.ToLowerInvariant()))
+        return -join ($bytes[0..3] | ForEach-Object { $_.ToString("x2") })
+    } finally {
+        $sha.Dispose()
+    }
+}
+
+$branch = (git -C $repoRoot rev-parse --abbrev-ref HEAD).Trim()
 if ($branch -ne "master" -and -not $AllowNonMaster) {
     throw "Refusing to run: current branch is '$branch', expected 'master'. Use -AllowNonMaster to preview this branch intentionally."
 }
@@ -55,11 +136,6 @@ if (-not $NoBuild) {
     if ($LASTEXITCODE -ne 0) {
         exit $LASTEXITCODE
     }
-}
-
-$winapp = Get-Command winapp -ErrorAction SilentlyContinue
-if (-not $winapp) {
-    throw "winapp CLI was not found. Install Microsoft WinAppCLI or run this from an environment where winapp is on PATH."
 }
 
 $projectPath = Join-Path $repoRoot "src\OpenClaw.Tray.WinUI\OpenClaw.Tray.WinUI.csproj"
@@ -73,14 +149,95 @@ if (-not $targetFramework) {
 $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
 $runtimeIdentifier = if ($architecture -eq [System.Runtime.InteropServices.Architecture]::Arm64) { "win-arm64" } else { "win-x64" }
 $outputDir = Join-Path $repoRoot "src\OpenClaw.Tray.WinUI\bin\$Configuration\$targetFramework\$runtimeIdentifier"
+$exePath = Join-Path $outputDir "OpenClaw.Tray.WinUI.exe"
 
 if (-not (Test-Path $outputDir)) {
     throw "Build output folder not found: $outputDir. Run without -NoBuild first."
 }
-if (-not (Test-Path $manifestPath)) {
+if (-not (Test-Path $exePath)) {
+    throw "Tray executable not found: $exePath. Run without -NoBuild first."
+}
+
+$winapp = $null
+if ($UseWinApp) {
+    $winapp = Get-Command winapp -ErrorAction SilentlyContinue
+    if (-not $winapp) {
+        throw "winapp CLI was not found. Install Microsoft WinAppCLI (winget install Microsoft.WinAppCLI) or run /winui-setup."
+    }
+}
+
+if ($UseWinApp -and -not (Test-Path $manifestPath)) {
     throw "Manifest not found: $manifestPath."
 }
 
-Write-Host "Launching OpenClaw Tray with winapp ($runtimeIdentifier, $Configuration)..."
-& $winapp.Source run $outputDir --manifest $manifestPath --debug-output
-exit $LASTEXITCODE
+$previousDataDir = $env:OPENCLAW_TRAY_DATA_DIR
+$previousUpdateChannel = $env:OPENCLAW_UPDATE_CHANNEL
+$exitCode = 0
+
+try {
+    $effectiveDataDir = $null
+    if ($DataDir) {
+        $effectiveDataDir = Resolve-FullPath $DataDir
+    } elseif ($Isolated) {
+        $repoName = Get-SafePathSegment (Split-Path -Leaf $repoRoot)
+        $safeBranch = Get-SafePathSegment $branch
+        $repoHash = Get-ShortHash $repoRoot
+        $effectiveDataDir = Join-Path $env:TEMP "OpenClawTray\$repoName-$safeBranch-$repoHash"
+    }
+
+    if ($effectiveDataDir) {
+        New-Item -ItemType Directory -Path $effectiveDataDir -Force | Out-Null
+        $env:OPENCLAW_TRAY_DATA_DIR = $effectiveDataDir
+    }
+
+    if ($UpdateChannel) {
+        $env:OPENCLAW_UPDATE_CHANNEL = $UpdateChannel
+    }
+
+    if ($UseWinApp) {
+        $winappArgs = @("run", $outputDir, "--manifest", $manifestPath)
+        if (-not $NoDebugOutput) {
+            $winappArgs += "--debug-output"
+        }
+    }
+
+    Write-Host "Launching OpenClaw Tray" -ForegroundColor Cyan
+    Write-Host "  Branch:        $branch"
+    Write-Host "  Configuration: $Configuration"
+    Write-Host "  Runtime:       $runtimeIdentifier"
+    Write-Host "  Output:        $outputDir"
+    Write-Host "  Mode:          $(if ($UseWinApp) { 'WinAppCLI manifest activation' } else { 'Direct unpackaged executable' })"
+    if ($env:OPENCLAW_TRAY_DATA_DIR) {
+        Write-Host "  Data dir:      $env:OPENCLAW_TRAY_DATA_DIR"
+    }
+    if ($env:OPENCLAW_UPDATE_CHANNEL) {
+        Write-Host "  Update channel: $env:OPENCLAW_UPDATE_CHANNEL"
+    }
+    if ($UseWinApp) {
+        Write-Host "  Launcher:      $($winapp.Source)"
+        Write-Host "  Command:       winapp $($winappArgs -join ' ')"
+    } else {
+        Write-Host "  Launcher:      $exePath"
+    }
+
+    if ($DryRun) {
+        return
+    }
+
+    if ($UseWinApp) {
+        & $winapp.Source @winappArgs
+        $exitCode = $LASTEXITCODE
+    } elseif ($Wait) {
+        $process = Start-Process -FilePath $exePath -WorkingDirectory $outputDir -Wait -PassThru
+        $exitCode = $process.ExitCode
+    } else {
+        $process = Start-Process -FilePath $exePath -WorkingDirectory $outputDir -PassThru
+        Write-Host "Started OpenClaw Tray (PID: $($process.Id))" -ForegroundColor Green
+        $exitCode = 0
+    }
+} finally {
+    $env:OPENCLAW_TRAY_DATA_DIR = $previousDataDir
+    $env:OPENCLAW_UPDATE_CHANNEL = $previousUpdateChannel
+}
+
+exit $exitCode

--- a/run-app-local.ps1
+++ b/run-app-local.ps1
@@ -195,7 +195,7 @@ try {
     }
 
     if ($UseWinApp) {
-        $winappArgs = @("run", $outputDir, "--manifest", $manifestPath)
+        $winappArgs = @("run", $outputDir, "--manifest", $manifestPath, "--executable", "OpenClaw.Tray.WinUI.exe")
         if (-not $NoDebugOutput) {
             $winappArgs += "--debug-output"
         }

--- a/src/OpenClaw.SetupEngine.UI/LogFileLauncher.cs
+++ b/src/OpenClaw.SetupEngine.UI/LogFileLauncher.cs
@@ -1,0 +1,100 @@
+using System.Diagnostics;
+
+namespace OpenClaw.SetupEngine.UI;
+
+internal static class LogFileLauncher
+{
+    // When running under MSIX with package identity, writes to
+    // %APPDATA% / %LOCALAPPDATA% are silently redirected to a per-package
+    // container under %LOCALAPPDATA%\Packages\<PFN>\LocalCache. The app sees
+    // and uses the unredirected path, but external tools like Explorer.exe
+    // do not honor that redirect, so /select with the unredirected path
+    // fails and Explorer opens the default folder. Translate the path so
+    // both the displayed text and the Explorer launch reference the real
+    // on-disk location.
+    public static string ResolveRealPath(string logPath)
+    {
+        if (string.IsNullOrWhiteSpace(logPath))
+            return logPath;
+
+        var pfn = TryGetPackageFamilyName();
+        if (pfn == null)
+            return logPath;
+
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var packageRoot = Path.Combine(localAppData, "Packages", pfn);
+
+        // Already inside the package container — nothing to translate.
+        if (logPath.StartsWith(packageRoot, StringComparison.OrdinalIgnoreCase))
+            return logPath;
+
+        var roaming = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        if (TryStrip(logPath, roaming, out var roamingRest))
+            return Path.Combine(packageRoot, "LocalCache", "Roaming", roamingRest);
+
+        if (TryStrip(logPath, localAppData, out var localRest))
+            return Path.Combine(packageRoot, "LocalCache", "Local", localRest);
+
+        return logPath;
+    }
+
+    public static void RevealInExplorer(string? logPath)
+    {
+        if (string.IsNullOrWhiteSpace(logPath))
+            return;
+
+        var realPath = ResolveRealPath(logPath);
+
+        try
+        {
+            if (File.Exists(realPath))
+            {
+                Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{realPath}\"")
+                {
+                    UseShellExecute = true,
+                });
+                return;
+            }
+
+            var dir = Path.GetDirectoryName(realPath);
+            if (!string.IsNullOrWhiteSpace(dir) && Directory.Exists(dir))
+            {
+                Process.Start(new ProcessStartInfo("explorer.exe", $"\"{dir}\"")
+                {
+                    UseShellExecute = true,
+                });
+            }
+        }
+        catch
+        {
+            // best effort — the link is informational
+        }
+    }
+
+    private static bool TryStrip(string path, string prefix, out string rest)
+    {
+        rest = string.Empty;
+        if (string.IsNullOrEmpty(prefix))
+            return false;
+
+        var sep = Path.DirectorySeparatorChar;
+        if (!path.StartsWith(prefix + sep, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        rest = path.Substring(prefix.Length + 1);
+        return true;
+    }
+
+    private static string? TryGetPackageFamilyName()
+    {
+        try
+        {
+            return Windows.ApplicationModel.Package.Current.Id.FamilyName;
+        }
+        catch
+        {
+            // Unpackaged process — no virtualization in play.
+            return null;
+        }
+    }
+}

--- a/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/CompletePage.xaml.cs
@@ -67,7 +67,9 @@ public sealed partial class CompletePage : Page
                 }
                 if (args.LogPath != null)
                 {
-                    ViewLogLink.Content = $"View full log → {Path.GetFileName(args.LogPath)}";
+                    var displayPath = LogFileLauncher.ResolveRealPath(args.LogPath);
+                    ViewLogLink.Content = $"View full log → {displayPath}";
+                    ToolTipService.SetToolTip(ViewLogLink, displayPath);
                     ViewLogLink.Visibility = Visibility.Visible;
                 }
                 else
@@ -114,8 +116,7 @@ public sealed partial class CompletePage : Page
 
     private void ViewLog_Click(object sender, RoutedEventArgs e)
     {
-        if (_logPath != null && File.Exists(_logPath))
-            Process.Start(new ProcessStartInfo(_logPath) { UseShellExecute = true });
+        LogFileLauncher.RevealInExplorer(_logPath);
     }
 
     private static void LaunchTray()

--- a/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/ProgressPage.xaml.cs
@@ -243,11 +243,7 @@ public sealed partial class ProgressPage : Page
 
     private void OpenLog_Click(object sender, RoutedEventArgs e)
     {
-        var logPath = _config?.LogPath;
-        if (!string.IsNullOrWhiteSpace(logPath) && File.Exists(logPath))
-        {
-            Process.Start(new ProcessStartInfo(logPath) { UseShellExecute = true });
-        }
+        LogFileLauncher.RevealInExplorer(_config?.LogPath);
     }
 
     private static List<SetupStep> BuildSteps(SetupConfig config)

--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -80,6 +80,52 @@ internal static class WslInstallSupport
     public static bool SupportsDirectNamedInstall(Version version)
         => version.CompareTo(s_minDirectNamedInstallVersion) >= 0;
 
+    // Detects well-known environment problems reported by `wsl --status`
+    // (or by other wsl.exe commands that surface the same diagnostic
+    // strings). Returns a user-facing remediation message when the output
+    // matches a known pattern; returns false otherwise.
+    //
+    // Only match on text we've actually observed wsl.exe emit. Hex HRESULT
+    // codes are stable across UI languages and Windows builds; English
+    // sentences are not, and over-broad fallbacks just create false
+    // positives.
+    public static bool TryGetEnvironmentIssue(string output, out string message)
+    {
+        var text = Normalize(output);
+
+        // Firmware virtualization off (VT-x/AMD-V disabled in BIOS/UEFI).
+        // wsl.exe emits this when the Windows feature is installed but the
+        // CPU virtualization extension is turned off; remediation requires
+        // a trip into firmware settings, not `wsl --install`.
+        if (Contains(text, "virtualization is not enabled"))
+        {
+            message = "WSL2 requires hardware virtualization, but it is disabled in firmware. "
+                + "Enable VT-x/AMD-V (Intel VT or AMD SVM) in your computer's BIOS/UEFI settings, "
+                + "reboot, then retry setup.";
+            return true;
+        }
+
+        // Required Windows feature missing (Virtual Machine Platform and/or
+        // Hyper-V). 0x80370102 = HCS_E_SERVICE_NOT_AVAILABLE, emitted verbatim
+        // by wsl.exe as "The virtual machine could not be started because a
+        // required feature is not installed." The same remediation
+        // (`wsl --install --no-distribution`) addresses both features.
+        if (Contains(text, "0x80370102"))
+        {
+            message = "WSL2 needs the Windows 'Virtual Machine Platform' / Hyper-V platform "
+                + "support, which is not currently enabled. Run `wsl --install --no-distribution` "
+                + "from an elevated PowerShell (or enable 'Virtual Machine Platform' under 'Turn "
+                + "Windows features on or off'), reboot, then retry setup.";
+            return true;
+        }
+
+        message = string.Empty;
+        return false;
+
+        static bool Contains(string haystack, string needle)
+            => haystack.Contains(needle, StringComparison.OrdinalIgnoreCase);
+    }
+
     public static string[] BuildDirectInstallArgs(string baseDistro, string distroName, string installPath)
         =>
         [
@@ -404,7 +450,35 @@ public sealed class PreflightWslStep : SetupStep
 
         ctx.Logger.Info($"WSL version output: {NormalizeWslOutput(versionResult.Stdout).Trim()}");
         ctx.Logger.Info($"WSL direct named install is supported (version {wslVersion})");
+
+        // wsl --version can succeed even when the WSL2 platform itself is
+        // unusable (Virtual Machine Platform component disabled, hardware
+        // virtualization off in firmware, Hyper-V missing, ...). Surface
+        // that diagnostic now so the user gets an actionable message
+        // before pipeline reaches the actual `wsl --install` step.
+        var statusIssue = await DetectEnvironmentIssueAsync(ctx, ct);
+        if (statusIssue != null)
+            return StepResult.Terminal(statusIssue);
+
         return StepResult.Ok("WSL available");
+    }
+
+    internal static async Task<string?> DetectEnvironmentIssueAsync(SetupContext ctx, CancellationToken ct)
+    {
+        var status = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["--status"],
+            TimeSpan.FromSeconds(10),
+            ct: ct);
+
+        var combined = $"{status.Stdout}\n{status.Stderr}";
+        if (WslInstallSupport.TryGetEnvironmentIssue(combined, out var message))
+        {
+            ctx.Logger.Warn($"WSL environment issue detected: {NormalizeWslOutput(combined).Trim()}");
+            return message;
+        }
+
+        return null;
     }
 
     private static async Task<StepResult> InstallWslPlatformAsync(SetupContext ctx, CancellationToken ct)
@@ -621,7 +695,11 @@ public sealed class CreateWslInstanceStep : SetupStep
     {
         var list = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--quiet"], TimeSpan.FromSeconds(15), ct: ct);
         if (list.ExitCode != 0 || !WslInstallSupport.ContainsDistro(list.Stdout, distro))
-            return StepResult.Fail($"Fresh WSL install did not register expected distro '{distro}'.");
+        {
+            var environmentIssue = await PreflightWslStep.DetectEnvironmentIssueAsync(ctx, ct);
+            var baseMessage = $"Fresh WSL install did not register expected distro '{distro}'.";
+            return StepResult.Fail(environmentIssue != null ? $"{baseMessage} {environmentIssue}" : baseMessage);
+        }
 
         var verbose = await ctx.Commands.RunAsync(WslConstants.WslExePath, ["--list", "--verbose"], TimeSpan.FromSeconds(15), ct: ct);
         if (verbose.ExitCode != 0 || !WslInstallSupport.TryGetDistroVersion(verbose.Stdout, distro, out var version))

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -505,6 +505,106 @@ public class SetupStepsTests : IDisposable
         Assert.Equal(2, distroVersion);
     }
 
+    [Fact]
+    public void WslInstallSupport_TryGetEnvironmentIssue_DetectsFirmwareVirtualizationOff()
+    {
+        Assert.True(WslInstallSupport.TryGetEnvironmentIssue(
+            "WSL2 is unable to start since virtualization is not enabled on this machine. "
+            + "Please ensure the 'Virtual Machine Platform' optional component is enabled "
+            + "and virtualization is turned on in your computer's firmware settings.",
+            out var message));
+        Assert.Contains("BIOS", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("virtualization", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void WslInstallSupport_TryGetEnvironmentIssue_DetectsCanonical0x80370102Error()
+    {
+        // This is the actual error wsl.exe emits on modern Windows builds when
+        // the Virtual Machine Platform / Hyper-V feature is disabled.
+        Assert.True(WslInstallSupport.TryGetEnvironmentIssue(
+            "WSL 2 requires an update to its kernel component.\n"
+            + "For information please visit https://aka.ms/wsl2kernel\n"
+            + "Error: 0x80370102 The virtual machine could not be started because a "
+            + "required feature is not installed.",
+            out var message));
+        Assert.Contains("Virtual Machine Platform", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("wsl --install --no-distribution", message);
+    }
+
+    [Fact]
+    public void WslInstallSupport_TryGetEnvironmentIssue_ReturnsFalseForHealthyStatus()
+    {
+        Assert.False(WslInstallSupport.TryGetEnvironmentIssue(
+            "Default Distribution: OpenClawGateway\nDefault Version: 2\n",
+            out var message));
+        Assert.Equal(string.Empty, message);
+    }
+
+    [Fact]
+    public async Task PreflightWsl_FailsTerminalWhenVirtualizationDisabledInFirmware()
+    {
+        var commands = new FakeCommandRunner(args =>
+        {
+            if (args is ["--version"])
+                return Ok("WSL version: 2.7.3.0\n");
+            if (args is ["--status"])
+                return Ok(
+                    "WSL2 is unable to start since virtualization is not enabled on this machine. "
+                    + "Please ensure the 'Virtual Machine Platform' optional component is enabled "
+                    + "and virtualization is turned on in your computer's firmware settings.");
+            return Ok();
+        });
+        var ctx = CreateContext(commands: commands);
+
+        var result = await new PreflightWslStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.FailedTerminal, result.Outcome);
+        Assert.Contains("virtualization", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("BIOS", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PreflightWsl_FailsTerminalWhenWslEmitsHcsServiceNotAvailable()
+    {
+        var commands = new FakeCommandRunner(args =>
+        {
+            if (args is ["--version"])
+                return Ok("WSL version: 2.7.3.0\n");
+            if (args is ["--status"])
+                return Ok(
+                    "WSL 2 requires an update to its kernel component.\n"
+                    + "Error: 0x80370102 The virtual machine could not be started because a "
+                    + "required feature is not installed.");
+            return Ok();
+        });
+        var ctx = CreateContext(commands: commands);
+
+        var result = await new PreflightWslStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.FailedTerminal, result.Outcome);
+        Assert.Contains("Virtual Machine Platform", result.Message);
+        Assert.Contains("wsl --install --no-distribution", result.Message);
+    }
+
+    [Fact]
+    public async Task PreflightWsl_SucceedsWhenStatusOutputIsHealthy()
+    {
+        var commands = new FakeCommandRunner(args =>
+        {
+            if (args is ["--version"])
+                return Ok("WSL version: 2.7.3.0\n");
+            if (args is ["--status"])
+                return Ok("Default Distribution: OpenClawGateway\nDefault Version: 2\n");
+            return Ok();
+        });
+        var ctx = CreateContext(commands: commands);
+
+        var result = await new PreflightWslStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Success, result.Outcome);
+    }
+
     private static int GetFreeTcpPort()
     {
         var listener = new TcpListener(IPAddress.Loopback, 0);


### PR DESCRIPTION
Fix local dev setup: Node.js prereq, log link, WSL diagnostics

Three small fixes layered on PR #573 to make local dev/run more
reliable when the WinUI tray hits setup failures:

1. build.ps1: detect missing Node.js / npm before invoking the
   tray build, and emit an actionable hint pointing at the
   nodejs.org installer. Avoids confusing C# build errors when
   the prereq is missing.

2. LogFileLauncher (SetupEngine.UI): wire up the "open log"
   hyperlink on CompletePage / ProgressPage so it actually opens
   the failure log in Explorer (via /select), and translate the
   MSIX virtualized path back to a real %LOCALAPPDATA% path so
   the file is reachable outside the packaged process.

3. SetupSteps.TryGetEnvironmentIssue (SetupEngine): match WSL
   environment diagnostics against output wsl.exe actually emits.
   The previous matcher keyed on a fabricated "Virtual Machine
   Platform" + "optional component" phrase that modern wsl.exe
   does not produce, so the VM Platform / Hyper-V branch never
   fired in practice. Replace with two checks grounded in
   observed wsl.exe output:
   - "virtualization is not enabled" (older firmware-virt-off
      message)
   - "0x80370102" (HCS_E_SERVICE_NOT_AVAILABLE -- the canonical,
      locale-independent HRESULT for a missing Virtual Machine
      Platform / Hyper-V feature)
   Tests updated to use real wsl.exe output samples.

Also: run-app-local.ps1 passes --executable "OpenClaw.Tray.WinUI.exe"
in the -UseWinApp path so the wrapper launches the WinUI tray when
running unpackaged.