### PR TITLE
Guard release executable signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,7 +396,15 @@ jobs:
       with:
         creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
 
-    - name: Sign Executable
+    - name: Stage OpenClaw Executables for Signing
+      if: startsWith(github.ref, 'refs/tags/v') && matrix.rid != 'win-arm64'
+      shell: pwsh
+      run: |
+        New-Item -ItemType Directory -Path signing-input -Force | Out-Null
+        New-Item -ItemType HardLink -Path signing-input\OpenClaw.Tray.WinUI.exe -Target publish\OpenClaw.Tray.WinUI.exe | Out-Null
+        New-Item -ItemType HardLink -Path signing-input\OpenClaw.SetupEngine.UI.exe -Target publish\SetupEngine\OpenClaw.SetupEngine.UI.exe | Out-Null
+
+    - name: Sign OpenClaw Executables
       if: startsWith(github.ref, 'refs/tags/v') && matrix.rid != 'win-arm64'
       uses: azure/trusted-signing-action@v2
       with:
@@ -406,12 +414,17 @@ jobs:
         endpoint: https://wus2.codesigning.azure.net/
         signing-account-name: hanselman
         certificate-profile-name: WindowsEdgeLight
-        files-folder: publish
+        files-folder: signing-input
         files-folder-filter: exe
-        files-folder-recurse: true
+        files-folder-depth: 1
         file-digest: SHA256
         timestamp-rfc3161: http://timestamp.acs.microsoft.com
         timestamp-digest: SHA256
+
+    - name: Verify Release Executable Signing Policy
+      if: startsWith(github.ref, 'refs/tags/v') && matrix.rid != 'win-arm64'
+      shell: pwsh
+      run: .\scripts\Test-ReleaseExecutableSignatures.ps1 -PayloadPath publish -RequireSignedOpenClaw
 
     - name: Upload Tray Artifact
       uses: actions/upload-artifact@v7
@@ -574,7 +587,14 @@ jobs:
       with:
         creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
 
-    - name: Sign ARM64 Executables
+    - name: Stage ARM64 OpenClaw Executables for Signing
+      shell: pwsh
+      run: |
+        New-Item -ItemType Directory -Path signing-input-arm64 -Force | Out-Null
+        New-Item -ItemType HardLink -Path signing-input-arm64\OpenClaw.Tray.WinUI.exe -Target artifacts\tray-win-arm64\OpenClaw.Tray.WinUI.exe | Out-Null
+        New-Item -ItemType HardLink -Path signing-input-arm64\OpenClaw.SetupEngine.UI.exe -Target artifacts\tray-win-arm64\SetupEngine\OpenClaw.SetupEngine.UI.exe | Out-Null
+
+    - name: Sign ARM64 OpenClaw Executables
       uses: azure/trusted-signing-action@v2
       with:
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -583,12 +603,16 @@ jobs:
         endpoint: https://wus2.codesigning.azure.net/
         signing-account-name: hanselman
         certificate-profile-name: WindowsEdgeLight
-        files-folder: artifacts/tray-win-arm64
+        files-folder: signing-input-arm64
         files-folder-filter: exe
-        files-folder-recurse: true
+        files-folder-depth: 1
         file-digest: SHA256
         timestamp-rfc3161: http://timestamp.acs.microsoft.com
         timestamp-digest: SHA256
+
+    - name: Verify ARM64 Release Executable Signing Policy
+      shell: pwsh
+      run: .\scripts\Test-ReleaseExecutableSignatures.ps1 -PayloadPath artifacts/tray-win-arm64 -RequireSignedOpenClaw
 
     - name: Sign Release MSIX Packages
       if: steps.msix-x64.outcome == 'success' || steps.msix-arm64.outcome == 'success'

--- a/scripts/Test-ReleaseExecutableSignatures.ps1
+++ b/scripts/Test-ReleaseExecutableSignatures.ps1
@@ -1,0 +1,112 @@
+<#
+.SYNOPSIS
+    Verifies release payload executable signing policy.
+
+.DESCRIPTION
+    Classifies every .exe in a release payload. OpenClaw-owned executables must
+    be signed when -RequireSignedOpenClaw is passed. Third-party executables,
+    including wxc-exec.exe, must not be signed by the OpenClaw release signer.
+    Unknown executables fail closed.
+
+.PARAMETER PayloadPath
+    Root directory of the release payload to inspect.
+
+.PARAMETER RequireSignedOpenClaw
+    Require OpenClaw-owned executables to have valid Authenticode signatures.
+
+.PARAMETER OpenClawSignerPattern
+    Regex used to identify the OpenClaw release signer in signer subjects.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PayloadPath,
+
+    [switch]$RequireSignedOpenClaw,
+
+    [string]$OpenClawSignerPattern = "hanselman|OpenClaw|Scott Hanselman"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$payloadRoot = (Resolve-Path -LiteralPath $PayloadPath).Path
+
+function Get-RelativePath {
+    param(
+        [Parameter(Mandatory = $true)][string]$Root,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    [System.IO.Path]::GetRelativePath($Root, $Path).Replace('/', '\')
+}
+
+function Get-ExecutableClassification {
+    param([Parameter(Mandatory = $true)][string]$RelativePath)
+
+    switch -Regex ($RelativePath) {
+        '^OpenClaw\.Tray\.WinUI\.exe$' { return "OpenClawOwned" }
+        '^SetupEngine\\OpenClaw\.SetupEngine\.UI\.exe$' { return "OpenClawOwned" }
+        '^tools\\mxc\\[^\\]+\\wxc-exec\.exe$' { return "ThirdPartyExcluded" }
+        default { return "Unknown" }
+    }
+}
+
+$executables = @(
+    Get-ChildItem -LiteralPath $payloadRoot -Recurse -File -Filter *.exe |
+        Sort-Object FullName |
+        ForEach-Object {
+            $relativePath = Get-RelativePath -Root $payloadRoot -Path $_.FullName
+            $signature = Get-AuthenticodeSignature -LiteralPath $_.FullName
+            $signerSubject = if ($signature.SignerCertificate) { $signature.SignerCertificate.Subject } else { "" }
+            [pscustomobject]@{
+                RelativePath = $relativePath
+                Classification = Get-ExecutableClassification -RelativePath $relativePath
+                SignatureStatus = $signature.Status.ToString()
+                SignerSubject = $signerSubject
+            }
+        }
+)
+
+if ($executables.Count -eq 0) {
+    throw "No executables found under $payloadRoot."
+}
+
+$executables | Format-Table -AutoSize
+
+$errors = New-Object System.Collections.Generic.List[string]
+
+foreach ($exe in $executables) {
+    switch ($exe.Classification) {
+        "OpenClawOwned" {
+            if ($RequireSignedOpenClaw -and $exe.SignatureStatus -ne "Valid") {
+                $errors.Add("OpenClaw executable is not validly signed: $($exe.RelativePath) [$($exe.SignatureStatus)]")
+            }
+        }
+        "ThirdPartyExcluded" {
+            if ($exe.SignatureStatus -eq "Valid" -and $exe.SignerSubject -match $OpenClawSignerPattern) {
+                $errors.Add("Third-party executable appears to be signed by OpenClaw release signer: $($exe.RelativePath) [$($exe.SignerSubject)]")
+            }
+        }
+        default {
+            $errors.Add("Unknown executable in release payload: $($exe.RelativePath)")
+        }
+    }
+}
+
+if (-not ($executables | Where-Object RelativePath -eq "OpenClaw.Tray.WinUI.exe")) {
+    $errors.Add("Missing OpenClaw.Tray.WinUI.exe.")
+}
+if (-not ($executables | Where-Object RelativePath -eq "SetupEngine\OpenClaw.SetupEngine.UI.exe")) {
+    $errors.Add("Missing SetupEngine\OpenClaw.SetupEngine.UI.exe.")
+}
+if (-not ($executables | Where-Object RelativePath -match '^tools\\mxc\\[^\\]+\\wxc-exec\.exe$')) {
+    $errors.Add("Missing tools\mxc\<arch>\wxc-exec.exe third-party executable.")
+}
+
+if ($errors.Count -gt 0) {
+    $errors | ForEach-Object { Write-Error $_ }
+    exit 1
+}
+
+Write-Host "Release executable signing policy passed." -ForegroundColor Green

--- a/tests/OpenClaw.Tray.Tests/ReleaseSigningWorkflowTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ReleaseSigningWorkflowTests.cs
@@ -1,0 +1,58 @@
+namespace OpenClaw.Tray.Tests;
+
+public sealed class ReleaseSigningWorkflowTests
+{
+    [Fact]
+    public void ReleaseWorkflow_SignsOnlyOpenClawOwnedPayloadExecutables()
+    {
+        var workflow = File.ReadAllText(Path.Combine(GetRepositoryRoot(), ".github", "workflows", "ci.yml"));
+
+        Assert.Contains("Stage OpenClaw Executables for Signing", workflow);
+        Assert.Contains(@"New-Item -ItemType HardLink -Path signing-input\OpenClaw.Tray.WinUI.exe -Target publish\OpenClaw.Tray.WinUI.exe", workflow);
+        Assert.Contains(@"New-Item -ItemType HardLink -Path signing-input\OpenClaw.SetupEngine.UI.exe -Target publish\SetupEngine\OpenClaw.SetupEngine.UI.exe", workflow);
+        Assert.Contains("Sign OpenClaw Executables", workflow);
+        Assert.Contains("files-folder: signing-input", workflow);
+        Assert.Contains("Stage ARM64 OpenClaw Executables for Signing", workflow);
+        Assert.Contains(@"New-Item -ItemType HardLink -Path signing-input-arm64\OpenClaw.Tray.WinUI.exe -Target artifacts\tray-win-arm64\OpenClaw.Tray.WinUI.exe", workflow);
+        Assert.Contains(@"New-Item -ItemType HardLink -Path signing-input-arm64\OpenClaw.SetupEngine.UI.exe -Target artifacts\tray-win-arm64\SetupEngine\OpenClaw.SetupEngine.UI.exe", workflow);
+        Assert.Contains("Sign ARM64 OpenClaw Executables", workflow);
+        Assert.Contains("files-folder: signing-input-arm64", workflow);
+        Assert.Contains("files-folder-filter: exe", workflow);
+        Assert.DoesNotContain("files-folder-recurse: true", workflow);
+    }
+
+    [Fact]
+    public void ReleaseWorkflow_VerifiesExecutableSigningPolicy()
+    {
+        var workflow = File.ReadAllText(Path.Combine(GetRepositoryRoot(), ".github", "workflows", "ci.yml"));
+        var verifier = File.ReadAllText(Path.Combine(GetRepositoryRoot(), "scripts", "Test-ReleaseExecutableSignatures.ps1"));
+
+        Assert.Contains("Test-ReleaseExecutableSignatures.ps1 -PayloadPath publish -RequireSignedOpenClaw", workflow);
+        Assert.Contains("Test-ReleaseExecutableSignatures.ps1 -PayloadPath artifacts/tray-win-arm64 -RequireSignedOpenClaw", workflow);
+        Assert.Contains(@"^OpenClaw\.Tray\.WinUI\.exe$", verifier);
+        Assert.Contains(@"^SetupEngine\\OpenClaw\.SetupEngine\.UI\.exe$", verifier);
+        Assert.Contains(@"^tools\\mxc\\[^\\]+\\wxc-exec\.exe$", verifier);
+        Assert.Contains("Unknown executable in release payload", verifier);
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        var env = Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT");
+        if (!string.IsNullOrWhiteSpace(env) && Directory.Exists(env))
+            return env;
+
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "openclaw-windows-node.slnx")) &&
+                Directory.Exists(Path.Combine(directory.FullName, "src")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not find repository root.");
+    }
+}


### PR DESCRIPTION
## Summary

- Add a release payload executable signing verifier.
- Stop recursively signing every `.exe` in release payloads.
- Stage hardlinks only for OpenClaw-owned EXEs before Azure Trusted Signing:
  - `OpenClaw.Tray.WinUI.exe`
  - `SetupEngine\OpenClaw.SetupEngine.UI.exe`
- Explicitly classify `tools\mxc\<arch>\wxc-exec.exe` as third-party/excluded.
- Add workflow contract tests.

## Validation

- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` (`2023 passed / 29 skipped`)
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` (`863 passed`)
- verifier script parse/fake-payload checks
- `git diff --check`