### PR TITLE
Fix release metadata verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,14 +389,13 @@ jobs:
       run: |
         $expected = "${{ needs.test.outputs.semVer }}"
         $assemblyPath = Resolve-Path "publish\OpenClaw.Tray.WinUI.dll"
-        $assembly = [System.Reflection.Assembly]::LoadFile($assemblyPath)
-        $attribute = $assembly.GetCustomAttributes([System.Reflection.AssemblyInformationalVersionAttribute], $false) | Select-Object -First 1
-        if (-not $attribute) {
-          throw "OpenClaw.Tray.WinUI.dll is missing AssemblyInformationalVersionAttribute."
+        $metadata = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($assemblyPath)
+        if ([string]::IsNullOrWhiteSpace($metadata.ProductVersion)) {
+          throw "OpenClaw.Tray.WinUI.dll is missing ProductVersion metadata."
         }
-        $actual = $attribute.InformationalVersion -replace '\+.*$', ''
+        $actual = $metadata.ProductVersion -replace '\+.*$', ''
         if ($actual -ne $expected) {
-          throw "AssemblyInformationalVersion '$actual' did not match GitVersion SemVer '$expected'."
+          throw "ProductVersion '$actual' did not match GitVersion SemVer '$expected'."
         }
 
     - name: Disable NuGet source mapping for signing


### PR DESCRIPTION
## Summary
- avoid loading the published .NET 10 tray assembly in PowerShell during release validation
- read `ProductVersion` from file metadata instead and compare it to GitVersion SemVer

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`
- `git diff --check`