### PR TITLE
Preserve alpha release tags in GitVersion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,16 @@ jobs:
       id: gitversion
       uses: gittools/actions/gitversion/execute@v4
 
+    - name: Verify tag version output
+      if: startsWith(github.ref, 'refs/tags/v')
+      shell: pwsh
+      run: |
+        $expected = "${{ github.ref_name }}" -replace '^v', ''
+        $actual = "${{ steps.gitversion.outputs.semVer }}"
+        if ($actual -ne $expected) {
+          throw "GitVersion SemVer '$actual' did not match tag '$expected'."
+        }
+
     - name: Restore dependencies
       run: dotnet restore
 

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -5,7 +5,7 @@ assembly-versioning-scheme: MajorMinorPatch
 branches:
   main:
     regex: ^(master|main)$
-    label: ''
+    label: alpha
     increment: Patch
 
 ignore:

--- a/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/VersioningContractTests.cs
@@ -59,6 +59,23 @@ public sealed class VersioningContractTests
     }
 
     [Fact]
+    public void GitVersion_MainBranchPreservesAlphaReleaseTags()
+    {
+        var repoRoot = GetRepositoryRoot();
+        var configPath = Path.Combine(repoRoot, "GitVersion.yml");
+        var config = File.ReadAllText(configPath);
+        var mainBranchMatch = Regex.Match(
+            config,
+            @"(?ms)^  main:\s*$\r?\n(?<body>.*?)(?=^  \S|\z)",
+            RegexOptions.CultureInvariant);
+
+        Assert.True(mainBranchMatch.Success, "GitVersion.yml must configure the main branch.");
+        Assert.Matches(
+            @"(?m)^\s+label:\s*'?alpha'?\s*$",
+            mainBranchMatch.Groups["body"].Value);
+    }
+
+    [Fact]
     public void ActiveCodeAndTests_DoNotContainStaleReleaseVersion()
     {
         var repoRoot = GetRepositoryRoot();


### PR DESCRIPTION
## Summary
- configure GitVersion's main branch label so exact `vX.Y.Z-alpha.N` tags resolve to the tagged SemVer
- add a tag-build guard that fails if GitVersion output disagrees with the tag name
- add a regression test for the GitVersion main-branch alpha contract

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`
- `git diff --check`