### PR TITLE
fix(ci): migrate release signing to Azure Artifact Signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,51 +408,6 @@ jobs:
           throw "ProductVersion '$actual' did not match GitVersion SemVer '$expected'."
         }
 
-    - name: Disable NuGet source mapping for signing
-      if: startsWith(github.ref, 'refs/tags/v') && matrix.rid != 'win-arm64'
-      shell: pwsh
-      run: |
-        if (Test-Path NuGet.Config) {
-          Rename-Item NuGet.Config NuGet.Config.signing.bak -Force
-        }
-
-    - name: Azure Login for Signing
-      if: startsWith(github.ref, 'refs/tags/v') && matrix.rid != 'win-arm64'
-      uses: azure/login@v3
-      with:
-        creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
-
-    - name: Stage OpenClaw Executables for Signing
-      if: startsWith(github.ref, 'refs/tags/v') && matrix.rid != 'win-arm64'
-      shell: pwsh
-      run: |
-        New-Item -ItemType Directory -Path signing-input -Force | Out-Null
-        New-Item -ItemType HardLink -Path signing-input\OpenClaw.Tray.WinUI.exe -Target publish\OpenClaw.Tray.WinUI.exe | Out-Null
-        New-Item -ItemType HardLink -Path signing-input\OpenClaw.SetupEngine.exe -Target publish\SetupEngine\OpenClaw.SetupEngine.exe | Out-Null
-        New-Item -ItemType HardLink -Path signing-input\OpenClaw.SetupEngine.UI.exe -Target publish\SetupEngine\OpenClaw.SetupEngine.UI.exe | Out-Null
-
-    - name: Sign OpenClaw Executables
-      if: startsWith(github.ref, 'refs/tags/v') && matrix.rid != 'win-arm64'
-      uses: azure/trusted-signing-action@v2
-      with:
-        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-        endpoint: https://wus2.codesigning.azure.net/
-        signing-account-name: hanselman
-        certificate-profile-name: WindowsEdgeLight
-        files-folder: signing-input
-        files-folder-filter: exe
-        files-folder-depth: 1
-        file-digest: SHA256
-        timestamp-rfc3161: http://timestamp.acs.microsoft.com
-        timestamp-digest: SHA256
-
-    - name: Verify Release Executable Signing Policy
-      if: startsWith(github.ref, 'refs/tags/v') && matrix.rid != 'win-arm64'
-      shell: pwsh
-      run: .\scripts\Test-ReleaseExecutableSignatures.ps1 -PayloadPath publish -RequireSignedOpenClaw
-
     - name: Upload Tray Artifact
       uses: actions/upload-artifact@v7
       with:
@@ -558,9 +513,11 @@ jobs:
     needs: [repo-hygiene, test, e2etests, build]
     if: startsWith(github.ref, 'refs/tags/v') && needs.repo-hygiene.result == 'success' && needs.test.result == 'success' && needs.e2etests.result == 'success' && needs.build.result == 'success' && !cancelled()
     runs-on: windows-latest
+    environment: release-signing
     permissions:
       actions: read
       contents: write
+      id-token: write
 
     steps:
     - uses: actions/checkout@v6
@@ -588,7 +545,17 @@ jobs:
     - name: Azure Login for Release Signing
       uses: azure/login@v3
       with:
-        creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Stage x64 OpenClaw Executables for Signing
+      shell: pwsh
+      run: |
+        New-Item -ItemType Directory -Path signing-input-x64 -Force | Out-Null
+        New-Item -ItemType HardLink -Path signing-input-x64\OpenClaw.Tray.WinUI.exe -Target artifacts\tray-win-x64\OpenClaw.Tray.WinUI.exe | Out-Null
+        New-Item -ItemType HardLink -Path signing-input-x64\OpenClaw.SetupEngine.exe -Target artifacts\tray-win-x64\SetupEngine\OpenClaw.SetupEngine.exe | Out-Null
+        New-Item -ItemType HardLink -Path signing-input-x64\OpenClaw.SetupEngine.UI.exe -Target artifacts\tray-win-x64\SetupEngine\OpenClaw.SetupEngine.UI.exe | Out-Null
 
     - name: Stage ARM64 OpenClaw Executables for Signing
       shell: pwsh
@@ -598,21 +565,35 @@ jobs:
         New-Item -ItemType HardLink -Path signing-input-arm64\OpenClaw.SetupEngine.exe -Target artifacts\tray-win-arm64\SetupEngine\OpenClaw.SetupEngine.exe | Out-Null
         New-Item -ItemType HardLink -Path signing-input-arm64\OpenClaw.SetupEngine.UI.exe -Target artifacts\tray-win-arm64\SetupEngine\OpenClaw.SetupEngine.UI.exe | Out-Null
 
-    - name: Sign ARM64 OpenClaw Executables
-      uses: azure/trusted-signing-action@v2
+    - name: Sign x64 OpenClaw Executables
+      uses: azure/artifact-signing-action@v2
       with:
-        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-        endpoint: https://wus2.codesigning.azure.net/
-        signing-account-name: hanselman
-        certificate-profile-name: WindowsEdgeLight
+        endpoint: https://eus.codesigning.azure.net/
+        signing-account-name: openclaw
+        certificate-profile-name: openclaw
+        files-folder: signing-input-x64
+        files-folder-filter: exe
+        files-folder-depth: 1
+        file-digest: SHA256
+        timestamp-rfc3161: http://timestamp.acs.microsoft.com
+        timestamp-digest: SHA256
+
+    - name: Sign ARM64 OpenClaw Executables
+      uses: azure/artifact-signing-action@v2
+      with:
+        endpoint: https://eus.codesigning.azure.net/
+        signing-account-name: openclaw
+        certificate-profile-name: openclaw
         files-folder: signing-input-arm64
         files-folder-filter: exe
         files-folder-depth: 1
         file-digest: SHA256
         timestamp-rfc3161: http://timestamp.acs.microsoft.com
         timestamp-digest: SHA256
+
+    - name: Verify x64 Release Executable Signing Policy
+      shell: pwsh
+      run: .\scripts\Test-ReleaseExecutableSignatures.ps1 -PayloadPath artifacts/tray-win-x64 -RequireSignedOpenClaw
 
     - name: Verify ARM64 Release Executable Signing Policy
       shell: pwsh
@@ -644,20 +625,12 @@ jobs:
         # Build installer
         & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion=${{ needs.test.outputs.majorMinorPatch }} /DMyAppArch=arm64 /Dpublish=publish-arm64 installer.iss
 
-    - name: Azure Login for Signing
-      uses: azure/login@v3
+    - name: Sign Installers
+      uses: azure/artifact-signing-action@v2
       with:
-        creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
-
-    - name: Sign Installer
-      uses: azure/trusted-signing-action@v2
-      with:
-        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-        endpoint: https://wus2.codesigning.azure.net/
-        signing-account-name: hanselman
-        certificate-profile-name: WindowsEdgeLight
+        endpoint: https://eus.codesigning.azure.net/
+        signing-account-name: openclaw
+        certificate-profile-name: openclaw
         files-folder: Output
         files-folder-filter: exe
         file-digest: SHA256
@@ -687,7 +660,7 @@ jobs:
           ### Features
           - 🦞 System tray integration with gateway status
           - 🔄 Auto-updates from GitHub Releases
-          - ✅ Code-signed with Azure Trusted Signing
+          - ✅ Code-signed with Azure Artifact Signing
 
           ### Requirements
           - Windows 10 version 1903 or later

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -100,12 +100,32 @@ CI enforces this with `scripts\Test-ReleaseExecutableSignatures.ps1`. The
 verifier fails closed on unknown `.exe` files so future payload changes are
 reviewed deliberately.
 
+The current Azure Artifact Signing resource is:
+
+- Account: `openclaw`
+- Certificate profile: `openclaw`
+- Endpoint: `https://eus.codesigning.azure.net/`
+- Public trust certificate subject:
+  `CN=OpenClaw Foundation, O=OpenClaw Foundation, L=Mill Valley, S=California, C=US`
+
+GitHub Actions authenticates with Azure through OIDC, not a stored client
+secret. The release job runs in the `release-signing` environment and requires:
+
+- `AZURE_CLIENT_ID`
+- `AZURE_TENANT_ID`
+- `AZURE_SUBSCRIPTION_ID`
+
+Do not add `AZURE_CLIENT_SECRET` back to the release workflow. The Entra app
+registration should have a federated credential for:
+`repo:openclaw/openclaw-windows-node:environment:release-signing`.
+
 ## How CI signs payload executables
 
 The release workflow does not recursively sign every `.exe`. Instead it creates
-a temporary signing input directory with hardlinks to only the OpenClaw-owned
-executables, then runs Azure Trusted Signing on that allowlist. Because these
-are NTFS hardlinks, signing the staged file signs the real payload file.
+temporary signing input directories with hardlinks to only the OpenClaw-owned
+executables from the x64 and ARM64 payloads, then runs Azure Artifact Signing on
+those allowlists. Because these are NTFS hardlinks, signing the staged file
+signs the real payload file.
 
 After signing, CI verifies the actual payload directory, not the staging folder.
 If hardlink signing does not affect the payload, the verifier fails before
@@ -127,12 +147,13 @@ MSIX jobs may appear as skipped while MSIX is paused.
 The release job should:
 
 1. Download x64/ARM64 tray payload artifacts.
-2. Sign only the OpenClaw-owned EXEs.
-3. Verify executable signing policy.
-4. Create portable ZIPs.
-5. Build Inno installers.
-6. Sign installers.
-7. Create a GitHub prerelease with installer and ZIP assets only.
+2. Authenticate to Azure with OIDC in the `release-signing` environment.
+3. Sign only the OpenClaw-owned EXEs in both payloads.
+4. Verify executable signing policy.
+5. Create portable ZIPs.
+6. Build Inno installers.
+7. Sign installers.
+8. Create a GitHub prerelease with installer and ZIP assets only.
 
 ## Post-release verification
 

--- a/scripts/Test-ReleaseExecutableSignatures.ps1
+++ b/scripts/Test-ReleaseExecutableSignatures.ps1
@@ -24,7 +24,7 @@ param(
 
     [switch]$RequireSignedOpenClaw,
 
-    [string]$OpenClawSignerPattern = "hanselman|OpenClaw|Scott Hanselman"
+    [string]$OpenClawSignerPattern = "OpenClaw Foundation"
 )
 
 Set-StrictMode -Version Latest

--- a/src/OpenClaw.Tray.WinUI/Package.appxmanifest
+++ b/src/OpenClaw.Tray.WinUI/Package.appxmanifest
@@ -6,20 +6,20 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-  <!-- IMPORTANT: Publisher must exactly match Azure Trusted Signing certificate subject.
-       Check your certificate profile at: Azure Portal > Trusted Signing > hanselman > WindowsEdgeLight
+  <!-- IMPORTANT: Publisher must exactly match the Azure Artifact Signing certificate subject.
+       Check your certificate profile at: Azure Portal > Artifact Signing > openclaw > openclaw
        Update the Publisher= value below to match. -->
   <!-- Version is patched at build time by the SyncAppxManifestVersionTarget in
        OpenClaw.Tray.WinUI.csproj from $(Version) (see docs/VERSIONING.md).
        The 0.0.0.0 below is a sentinel and is never shipped. -->
   <Identity
     Name="OpenClaw.Companion"
-    Publisher="CN=Scott Hanselman, O=Scott Hanselman, L=Forest Grove, S=Oregon, C=US"
+    Publisher="CN=OpenClaw Foundation, O=OpenClaw Foundation, L=Mill Valley, S=California, C=US"
     Version="0.0.0.0" />
 
   <Properties>
     <DisplayName>OpenClaw Companion</DisplayName>
-    <PublisherDisplayName>Scott Hanselman</PublisherDisplayName>
+    <PublisherDisplayName>OpenClaw Foundation</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
 

--- a/tests/OpenClaw.Tray.Tests/ReleaseSigningWorkflowTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ReleaseSigningWorkflowTests.cs
@@ -7,12 +7,20 @@ public sealed class ReleaseSigningWorkflowTests
     {
         var workflow = File.ReadAllText(Path.Combine(GetRepositoryRoot(), ".github", "workflows", "ci.yml"));
 
-        Assert.Contains("Stage OpenClaw Executables for Signing", workflow);
-        Assert.Contains(@"New-Item -ItemType HardLink -Path signing-input\OpenClaw.Tray.WinUI.exe -Target publish\OpenClaw.Tray.WinUI.exe", workflow);
-        Assert.Contains(@"New-Item -ItemType HardLink -Path signing-input\OpenClaw.SetupEngine.exe -Target publish\SetupEngine\OpenClaw.SetupEngine.exe", workflow);
-        Assert.Contains(@"New-Item -ItemType HardLink -Path signing-input\OpenClaw.SetupEngine.UI.exe -Target publish\SetupEngine\OpenClaw.SetupEngine.UI.exe", workflow);
-        Assert.Contains("Sign OpenClaw Executables", workflow);
-        Assert.Contains("files-folder: signing-input", workflow);
+        Assert.DoesNotContain("azure/trusted-signing-action", workflow);
+        Assert.DoesNotContain("AZURE_CLIENT_SECRET", workflow);
+        Assert.Contains("environment: release-signing", workflow);
+        Assert.Contains("id-token: write", workflow);
+        Assert.Contains("uses: azure/artifact-signing-action@v2", workflow);
+        Assert.Contains("endpoint: https://eus.codesigning.azure.net/", workflow);
+        Assert.Contains("signing-account-name: openclaw", workflow);
+        Assert.Contains("certificate-profile-name: openclaw", workflow);
+        Assert.Contains("Stage x64 OpenClaw Executables for Signing", workflow);
+        Assert.Contains(@"New-Item -ItemType HardLink -Path signing-input-x64\OpenClaw.Tray.WinUI.exe -Target artifacts\tray-win-x64\OpenClaw.Tray.WinUI.exe", workflow);
+        Assert.Contains(@"New-Item -ItemType HardLink -Path signing-input-x64\OpenClaw.SetupEngine.exe -Target artifacts\tray-win-x64\SetupEngine\OpenClaw.SetupEngine.exe", workflow);
+        Assert.Contains(@"New-Item -ItemType HardLink -Path signing-input-x64\OpenClaw.SetupEngine.UI.exe -Target artifacts\tray-win-x64\SetupEngine\OpenClaw.SetupEngine.UI.exe", workflow);
+        Assert.Contains("Sign x64 OpenClaw Executables", workflow);
+        Assert.Contains("files-folder: signing-input-x64", workflow);
         Assert.Contains("Stage ARM64 OpenClaw Executables for Signing", workflow);
         Assert.Contains(@"New-Item -ItemType HardLink -Path signing-input-arm64\OpenClaw.Tray.WinUI.exe -Target artifacts\tray-win-arm64\OpenClaw.Tray.WinUI.exe", workflow);
         Assert.Contains(@"New-Item -ItemType HardLink -Path signing-input-arm64\OpenClaw.SetupEngine.exe -Target artifacts\tray-win-arm64\SetupEngine\OpenClaw.SetupEngine.exe", workflow);
@@ -29,7 +37,7 @@ public sealed class ReleaseSigningWorkflowTests
         var workflow = File.ReadAllText(Path.Combine(GetRepositoryRoot(), ".github", "workflows", "ci.yml"));
         var verifier = File.ReadAllText(Path.Combine(GetRepositoryRoot(), "scripts", "Test-ReleaseExecutableSignatures.ps1"));
 
-        Assert.Contains("Test-ReleaseExecutableSignatures.ps1 -PayloadPath publish -RequireSignedOpenClaw", workflow);
+        Assert.Contains("Test-ReleaseExecutableSignatures.ps1 -PayloadPath artifacts/tray-win-x64 -RequireSignedOpenClaw", workflow);
         Assert.Contains("Test-ReleaseExecutableSignatures.ps1 -PayloadPath artifacts/tray-win-arm64 -RequireSignedOpenClaw", workflow);
         Assert.Contains(@"^OpenClaw\.Tray\.WinUI\.exe$", verifier);
         Assert.Contains(@"^SetupEngine\\OpenClaw\.SetupEngine\.exe$", verifier);


### PR DESCRIPTION
## Summary
- move release signing to Azure Artifact Signing on the `openclaw` account/profile in East US
- switch GitHub Actions Azure auth from client-secret JSON to OIDC in the `release-signing` environment
- sign both x64 and ARM64 payload executables in the release job before zipping/installers
- update the release docs, MSIX publisher subject, signer verifier, and workflow tests for the OpenClaw Foundation cert

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `git diff --check`
- Azure CLI verified `openclaw` signing account/profile are active and the GitHub OIDC app has `Artifact Signing Certificate Profile Signer` on the profile scope
- GitHub signing smoke with direct OIDC IDs passed: https://github.com/openclaw/openclaw-windows-node/actions/runs/26642787219
- GitHub signing smoke with refreshed repo secrets passed: https://github.com/openclaw/openclaw-windows-node/actions/runs/26642979324

Local required gates blocked on this mac:
- `./build.ps1` -> permission denied for direct ps1 execution in zsh
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` -> `dotnet` not installed
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` -> `dotnet` not installed
