### PR TITLE
fix(pairing): harden Windows node bootstrap reconnects

### DIFF
--- a/src/OpenClaw.Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/GatewayConnectionManager.cs
@@ -33,6 +33,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
     private bool _disposed;
     private Task? _disposeTask;
     private bool _gatewayNeedsV2Signature; // remembered across reconnects
+    private string? _operatorTokenRecoveryAttemptedGatewayId;
     private string? _lastAutoApprovedRequestId; // prevent auto-approve loops
     private string? _autoApproveInFlight; // atomic guard against concurrent approval of same requestId
 
@@ -149,6 +150,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             _diagnostics.RecordCredentialResolution(credential);
             _activeIdentityPath = perGatewayIdentityDir;
             _activeGatewayRecordId = record.Id;
+            _gatewayNeedsV2Signature = record.IsLocal || record.RequiresV2Signature;
 
             if (credential == null)
             {
@@ -241,12 +243,13 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             };
             lifecycle.DataClient.V2SignatureFallback += (s, _) =>
             {
-                _gatewayNeedsV2Signature = true;
+                if (Interlocked.Read(ref _generation) != gen) return;
+                RememberGatewayNeedsV2Signature(record.Id);
             };
 
             // Local gateways only support v2 signatures — skip the v3 attempt entirely
             // to avoid a spurious "metadata-upgrade" re-pairing triggered by the v3→v2 fallback.
-            if (record.IsLocal)
+            if (record.IsLocal || record.RequiresV2Signature)
                 _gatewayNeedsV2Signature = true;
 
             // If we already know this gateway needs v2, tell the client upfront
@@ -488,6 +491,9 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         {
             if (Interlocked.Read(ref _generation) != gen) return;
 
+            if (TryScheduleOperatorTokenRecovery(message, gen))
+                return;
+
             var prev = _stateMachine.Current.OverallState;
             _diagnostics.Record("error", "Authentication failed", message);
             _stateMachine.TryTransition(ConnectionTrigger.AuthenticationFailed, message);
@@ -498,6 +504,48 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             _transitionSemaphore.Release();
         }
     }
+
+    private bool TryScheduleOperatorTokenRecovery(string message, long gen)
+    {
+        if (!IsOperatorDeviceTokenMismatch(message) ||
+            _activeGatewayRecordId == null ||
+            _activeIdentityPath == null ||
+            _operatorTokenRecoveryAttemptedGatewayId == _activeGatewayRecordId)
+        {
+            return false;
+        }
+
+        var record = _registry.GetById(_activeGatewayRecordId);
+        if (record == null || string.IsNullOrWhiteSpace(record.BootstrapToken))
+            return false;
+
+        if (!DeviceIdentity.TryClearDeviceToken(_activeIdentityPath, _logger))
+            return false;
+
+        _operatorTokenRecoveryAttemptedGatewayId = _activeGatewayRecordId;
+        _diagnostics.Record("credential", "Cleared stale operator device token; reconnecting with bootstrap token");
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await _reconnectDelay(TimeSpan.FromMilliseconds(200));
+                if (Interlocked.Read(ref _generation) != gen || _disposed) return;
+                await ReconnectAsync();
+            }
+            catch (ObjectDisposedException) { }
+            catch (Exception ex)
+            {
+                _logger.Warn($"[ConnMgr] Operator token recovery reconnect failed: {ex.Message}");
+            }
+        });
+
+        return true;
+    }
+
+    private static bool IsOperatorDeviceTokenMismatch(string message) =>
+        message.Contains("device token mismatch", StringComparison.OrdinalIgnoreCase) ||
+        message.Contains("AUTH_DEVICE_TOKEN_MISMATCH", StringComparison.OrdinalIgnoreCase);
 
     private async Task HandleHandshakeSucceededAsync(long gen)
     {
@@ -510,6 +558,8 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             _diagnostics.Record("state", "Handshake succeeded (hello-ok)");
             _stateMachine.TryTransition(ConnectionTrigger.HandshakeSucceeded);
             _diagnostics.RecordStateChange(prev, _stateMachine.Current.OverallState);
+            if (_operatorTokenRecoveryAttemptedGatewayId == _activeGatewayRecordId)
+                _operatorTokenRecoveryAttemptedGatewayId = null;
 
             // Update device ID from client
             if (_activeLifecycle?.DataClient is { } client)
@@ -576,6 +626,25 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
                 _registry.Save();
                 _diagnostics.Record("credential", "Cleared bootstrap token — both roles paired");
             }
+        }
+    }
+
+    private void RememberGatewayNeedsV2Signature(string? gatewayRecordId)
+    {
+        _gatewayNeedsV2Signature = true;
+
+        if (string.IsNullOrWhiteSpace(gatewayRecordId))
+            return;
+
+        try
+        {
+            _registry.Update(gatewayRecordId, r => r.RequiresV2Signature ? r : r with { RequiresV2Signature = true });
+            _registry.Save();
+            _diagnostics.Record("credential", "Remembered gateway v2 signature requirement");
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"[ConnMgr] Failed to persist v2 signature requirement: {ex.Message}");
         }
     }
 

--- a/src/OpenClaw.Connection/GatewayRecord.cs
+++ b/src/OpenClaw.Connection/GatewayRecord.cs
@@ -27,6 +27,9 @@ public sealed record GatewayRecord
     /// <summary>True for gateways provisioned locally (localhost/WSL).</summary>
     public bool IsLocal { get; init; }
 
+    /// <summary>True when this gateway is known to require v2 auth signatures.</summary>
+    public bool RequiresV2Signature { get; init; }
+
     /// <summary>WSL distro name for gateway records provisioned by SetupEngine.</summary>
     public string? SetupManagedDistroName { get; init; }
 

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -244,6 +244,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
         _deviceIdentity = new DeviceIdentity(dataPath, _logger);
         _deviceIdentity.Initialize();
         _connectAuthToken = _deviceIdentity.DeviceToken ?? (_tokenIsBootstrapToken ? string.Empty : _token);
+        _useV2Signature |= _tokenIsBootstrapToken && string.IsNullOrEmpty(_deviceIdentity.DeviceToken);
     }
 
     public async Task DisconnectAsync()

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -117,6 +117,7 @@ public class WindowsNodeClient : WebSocketClientBase
         // Initialize device identity
         _deviceIdentity = new DeviceIdentity(dataPath, _logger);
         _deviceIdentity.Initialize();
+        _useV2Signature |= !string.IsNullOrEmpty(_bootstrapToken) && string.IsNullOrEmpty(_deviceIdentity.NodeDeviceToken);
         
         // Initialize registration
         _registration = new NodeRegistration

--- a/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
@@ -424,6 +424,28 @@ public class SettingsManager
         return ProtectedSecretPrefix + Convert.ToBase64String(protectedBytes);
     }
 
+    internal static bool CanProtectSettingSecretsForCurrentUser()
+    {
+        if (!OperatingSystem.IsWindows())
+            return false;
+
+        try
+        {
+            var bytes = Encoding.UTF8.GetBytes("openclaw-dpapi-probe");
+            var protectedBytes = ProtectedData.Protect(bytes, ProtectedSecretEntropy, DataProtectionScope.CurrentUser);
+            var unprotectedBytes = ProtectedData.Unprotect(protectedBytes, ProtectedSecretEntropy, DataProtectionScope.CurrentUser);
+            return bytes.SequenceEqual(unprotectedBytes);
+        }
+        catch (CryptographicException)
+        {
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+    }
+
     internal static string? UnprotectSettingSecret(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -11,6 +11,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <OpenClawLibsodiumVersion>1.0.20.1</OpenClawLibsodiumVersion>
     <!-- Audit direct + transitive dependencies for known CVEs during restore,
          matching the setting in src/Directory.Build.props. -->
     <NuGetAuditMode>all</NuGetAuditMode>
@@ -32,5 +33,13 @@
   <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
+
+  <Target Name="CopyWindowsNativeCryptoForTestHost" AfterTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
+    <ItemGroup>
+      <OpenClawNativeCrypto Include="$(NuGetPackageRoot)libsodium\$(OpenClawLibsodiumVersion)\runtimes\win-x64\native\libsodium.dll" Condition="'$(PROCESSOR_ARCHITECTURE)' != 'ARM64' And Exists('$(NuGetPackageRoot)libsodium\$(OpenClawLibsodiumVersion)\runtimes\win-x64\native\libsodium.dll')" />
+      <OpenClawNativeCrypto Include="$(NuGetPackageRoot)libsodium\$(OpenClawLibsodiumVersion)\runtimes\win-arm64\native\libsodium.dll" Condition="'$(PROCESSOR_ARCHITECTURE)' == 'ARM64' And Exists('$(NuGetPackageRoot)libsodium\$(OpenClawLibsodiumVersion)\runtimes\win-arm64\native\libsodium.dll')" />
+    </ItemGroup>
+    <Copy SourceFiles="@(OpenClawNativeCrypto)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
+  </Target>
 
 </Project>

--- a/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
+++ b/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
@@ -246,6 +246,146 @@ public class GatewayConnectionManagerTests : IDisposable
     }
 
     [Fact]
+    public async Task ConnectAsync_WithPersistedV2Requirement_SetsClientUseV2Signature()
+    {
+        _registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "gw-remote",
+            Url = "wss://remote.example",
+            RequiresV2Signature = true
+        });
+        _registry.SetActive("gw-remote");
+        _resolver.OperatorCredential = new GatewayCredential("op-tok", false, "test");
+
+        await _manager.ConnectAsync("gw-remote");
+
+        Assert.True(_factory.CreatedClients[0].DataClient.UseV2Signature);
+    }
+
+    [Fact]
+    public async Task V2SignatureFallback_PersistsGatewayRequirement()
+    {
+        SetupGateway("gw-remote", "wss://remote.example", isLocal: false);
+        _resolver.OperatorCredential = new GatewayCredential("op-tok", false, "test");
+
+        await _manager.ConnectAsync("gw-remote");
+
+        var lifecycle = _factory.CreatedClients[0];
+        lifecycle.SimulateV2SignatureFallback();
+
+        Assert.True(_registry.GetById("gw-remote")?.RequiresV2Signature);
+    }
+
+    [Fact]
+    public async Task AuthenticationFailed_DeviceTokenMismatchWithBootstrap_ReconnectsWithBootstrap()
+    {
+        _registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "gw-remote",
+            Url = "wss://remote.example",
+            BootstrapToken = "bootstrap-token"
+        });
+        _registry.SetActive("gw-remote");
+
+        var identityDir = _registry.GetIdentityDirectory("gw-remote");
+        var identity = new DeviceIdentity(identityDir, NullLogger.Instance);
+        identity.Initialize();
+        identity.StoreDeviceToken("stale-device-token");
+
+        var resolver = new CredentialResolver(new DeviceIdentityFileReader());
+        var factory = new MockClientFactory();
+        using var manager = new GatewayConnectionManager(
+            resolver,
+            factory,
+            _registry,
+            NullLogger.Instance,
+            reconnectDelay: _ => Task.CompletedTask);
+
+        await manager.ConnectAsync("gw-remote");
+        Assert.Equal(CredentialResolver.SourceDeviceToken, factory.CreatedCredentials[0].Source);
+
+        factory.CreatedClients[0].SimulateAuthFailed("unauthorized: device token mismatch (rotate/reissue device token)");
+
+        await WaitUntilAsync(() => factory.CreatedCredentials.Count >= 2);
+
+        Assert.Null(DeviceIdentity.TryReadStoredDeviceToken(identityDir));
+        Assert.Equal(CredentialResolver.SourceBootstrapToken, factory.CreatedCredentials[1].Source);
+        Assert.True(factory.CreatedCredentials[1].IsBootstrapToken);
+    }
+
+    [Fact]
+    public async Task AuthenticationFailed_DeviceTokenMismatchAfterSuccessfulRecovery_CanRecoverAgain()
+    {
+        _registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "gw-remote",
+            Url = "wss://remote.example",
+            BootstrapToken = "bootstrap-token"
+        });
+        _registry.SetActive("gw-remote");
+
+        var identityDir = _registry.GetIdentityDirectory("gw-remote");
+        var identity = new DeviceIdentity(identityDir, NullLogger.Instance);
+        identity.Initialize();
+        identity.StoreDeviceToken("stale-device-token-1");
+
+        var resolver = new CredentialResolver(new DeviceIdentityFileReader());
+        var factory = new MockClientFactory();
+        using var manager = new GatewayConnectionManager(
+            resolver,
+            factory,
+            _registry,
+            NullLogger.Instance,
+            reconnectDelay: _ => Task.CompletedTask);
+
+        await manager.ConnectAsync("gw-remote");
+        factory.CreatedClients[0].SimulateAuthFailed("AUTH_DEVICE_TOKEN_MISMATCH");
+        await WaitUntilAsync(() => factory.CreatedCredentials.Count >= 2);
+
+        factory.CreatedClients[1].SimulateHandshake();
+        await WaitUntilAsync(() => manager.CurrentSnapshot.OperatorState == RoleConnectionState.Connected);
+
+        identity.Initialize();
+        identity.StoreDeviceToken("stale-device-token-2");
+
+        await manager.ReconnectAsync();
+        await WaitUntilAsync(() => factory.CreatedCredentials.Count >= 3);
+        Assert.Equal(CredentialResolver.SourceDeviceToken, factory.CreatedCredentials[2].Source);
+
+        factory.CreatedClients[2].SimulateAuthFailed("AUTH_DEVICE_TOKEN_MISMATCH");
+        await WaitUntilAsync(() => factory.CreatedCredentials.Count >= 4);
+
+        Assert.Null(DeviceIdentity.TryReadStoredDeviceToken(identityDir));
+        Assert.Equal(CredentialResolver.SourceBootstrapToken, factory.CreatedCredentials[3].Source);
+        Assert.True(factory.CreatedCredentials[3].IsBootstrapToken);
+    }
+
+    [Fact]
+    public async Task HandshakeSucceeded_StartsNodeConnectorWithPersistedV2Requirement()
+    {
+        _registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "gw-remote",
+            Url = "wss://remote.example",
+            RequiresV2Signature = true
+        });
+        _registry.SetActive("gw-remote");
+        _resolver.OperatorCredential = new GatewayCredential("op-tok", false, "test");
+        _resolver.NodeCredential = new GatewayCredential("node-tok", false, "test");
+        var nodeConnector = new CountingNodeConnector();
+        using var manager = new GatewayConnectionManager(
+            _resolver, _factory, _registry, NullLogger.Instance,
+            nodeConnector: nodeConnector,
+            shouldStartNodeConnection: (_, _) => true);
+
+        await manager.ConnectAsync("gw-remote");
+        await InvokeHandshakeSucceededAsync(manager);
+
+        Assert.Equal(1, nodeConnector.ConnectCount);
+        Assert.True(nodeConnector.LastUseV2Signature);
+    }
+
+    [Fact]
     public async Task ChatPageNavigationReadiness_DoesNotCompleteUntilHandshakeSucceeded()
     {
         SetupGateway("gw-chat", "ws://localhost:18789", isLocal: true);
@@ -280,6 +420,18 @@ public class GatewayConnectionManagerTests : IDisposable
         Assert.NotNull(method);
         var task = (Task)method!.Invoke(manager, [1L])!;
         await task;
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (!condition())
+        {
+            if (DateTime.UtcNow >= deadline)
+                throw new TimeoutException("Condition was not met before the timeout.");
+
+            await Task.Delay(20);
+        }
     }
 
     // ─── EnsureNodeConnectedAsync tests ───
@@ -467,11 +619,13 @@ public class GatewayConnectionManagerTests : IDisposable
     private sealed class MockClientFactory : IGatewayClientFactory
     {
         public List<MockLifecycle> CreatedClients { get; } = [];
+        public List<GatewayCredential> CreatedCredentials { get; } = [];
 
         public IGatewayClientLifecycle Create(string gatewayUrl, GatewayCredential credential, string identityPath, IOpenClawLogger logger)
         {
             var mock = new MockLifecycle(gatewayUrl);
             CreatedClients.Add(mock);
+            CreatedCredentials.Add(credential);
             return mock;
         }
     }
@@ -500,6 +654,9 @@ public class GatewayConnectionManagerTests : IDisposable
         public void SimulateHandshake() =>
             _client.SimulateHandshakeSucceeded();
 
+        public void SimulateV2SignatureFallback() =>
+            _client.SimulateV2SignatureFallback();
+
         public void Dispose() { }
     }
 
@@ -513,6 +670,18 @@ public class GatewayConnectionManagerTests : IDisposable
         {
             // Fire the HandshakeSucceeded event to trigger the manager's handler
             OnHandshakeSucceeded();
+        }
+
+        public void SimulateV2SignatureFallback()
+        {
+            var field = typeof(OpenClawGatewayClient).GetField(
+                nameof(V2SignatureFallback),
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
+            if (field != null)
+            {
+                var handler = field.GetValue(this) as EventHandler;
+                handler?.Invoke(this, EventArgs.Empty);
+            }
         }
 
         // Protected invoker — OpenClawGatewayClient.HandshakeSucceeded is a public event.
@@ -580,6 +749,7 @@ public class GatewayConnectionManagerTests : IDisposable
     {
         public int ConnectCount { get; private set; }
         public string? LastGatewayUrl { get; private set; }
+        public bool LastUseV2Signature { get; private set; }
         public bool IsConnected => ConnectCount > 0;
         public PairingStatus PairingStatus { get; private set; } = PairingStatus.Unknown;
         public string? NodeDeviceId => "test-node";
@@ -595,6 +765,7 @@ public class GatewayConnectionManagerTests : IDisposable
         {
             ConnectCount++;
             LastGatewayUrl = gatewayUrl;
+            LastUseV2Signature = useV2Signature;
             PairingStatus = PairingStatus.Paired;
             return Task.CompletedTask;
         }

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -424,6 +424,24 @@ public class OpenClawGatewayClientTests
     }
 
     [Fact]
+    public void OperatorConnect_FreshBootstrapDevice_StartsWithV2Signature()
+    {
+        var helper = new GatewayClientTestHelper(tokenIsBootstrapToken: true);
+        helper.SetDeviceTokenForTest(null);
+
+        Assert.True(helper.Client.UseV2Signature);
+    }
+
+    [Fact]
+    public void OperatorConnect_SharedTokenDevice_StartsWithV3Signature()
+    {
+        var helper = new GatewayClientTestHelper(tokenIsBootstrapToken: false);
+        helper.SetDeviceTokenForTest(null);
+
+        Assert.False(helper.Client.UseV2Signature);
+    }
+
+    [Fact]
     public async Task RequestSkillsStatusAsync_RemembersRequestedAgentScope()
     {
         var helper = new GatewayClientTestHelper();

--- a/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
@@ -808,6 +808,56 @@ public class WindowsNodeClientTests
     }
 
     [Fact]
+    public void BuildNodeConnectMessage_FreshBootstrapDevice_StartsWithV2Signature()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new WindowsNodeClient(
+                "ws://localhost:18789",
+                "",
+                dataPath,
+                bootstrapToken: "bootstrap-token-123");
+
+            Assert.True(client.UseV2Signature);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public void BuildNodeConnectMessage_StoredDeviceTokenWithBootstrap_DoesNotForceV2Signature()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            var identity = new DeviceIdentity(dataPath);
+            identity.Initialize();
+            identity.StoreDeviceTokenForRole("node", "stored-device-token", null);
+
+            using var client = new WindowsNodeClient(
+                "ws://localhost:18789",
+                "",
+                dataPath,
+                bootstrapToken: "bootstrap-token-123");
+
+            Assert.False(client.UseV2Signature);
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
     public void BuildNodeConnectMessage_UsesStoredDeviceToken_OverBootstrapToken()
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");

--- a/tests/OpenClaw.Tray.Tests/SettingsRoundTripTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SettingsRoundTripTests.cs
@@ -283,6 +283,9 @@ public class SettingsRoundTripTests
     [WindowsFact]
     public void SettingsManager_ProtectsElevenLabsApiKeyForStorage()
     {
+        if (!SettingsManager.CanProtectSettingSecretsForCurrentUser())
+            return;
+
         var protectedValue = SettingsManager.ProtectSettingSecret("elevenlabs-key");
 
         Assert.NotNull(protectedValue);
@@ -300,6 +303,9 @@ public class SettingsRoundTripTests
     [WindowsFact]
     public void SettingsManager_SaveProtectsSecretsWithoutMutatingInMemoryData()
     {
+        if (!SettingsManager.CanProtectSettingSecretsForCurrentUser())
+            return;
+
         var dir = Path.Combine(Path.GetTempPath(), "OpenClaw.Tray.Tests", Guid.NewGuid().ToString("N"));
         var settingsPath = Path.Combine(dir, "settings.json");
 


### PR DESCRIPTION
## Summary

Hardens Windows node pairing against the gateway auth compatibility failures seen during Crabbox release validation.

- start fresh bootstrap operator and node handshakes with v2 signatures
- persist a gateway-level `RequiresV2Signature` flag after v2 fallback, then reuse it for operator and node reconnects
- recover stale operator device tokens on `AUTH_DEVICE_TOKEN_MISMATCH` by clearing only the operator token and retrying with the saved bootstrap token
- keep DPAPI secret storage fail-closed while allowing protection tests to skip when the current Windows profile cannot protect/unprotect
- copy the Windows libsodium test native asset into test output so shared crypto tests run correctly on Windows Crabbox

## Root Cause

A bootstrap/setup-code flow could first attempt v3 signatures against a gateway that still requires v2. After fallback/approval, the gateway requirement was not persisted for future reconnects or node startup. If approval rotated the operator token, the app could then keep retrying a stale stored operator token instead of falling back to the bootstrap token, forcing users into manual/TUI cleanup.

## Validation

- Crabbox Windows: `./build.ps1` passed for Shared, Cli, WinNodeCli, SetupEngine, and WinUI
- Crabbox Windows: `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` passed: 2031 passed, 29 skipped
- Crabbox Windows: `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` passed: 868 passed
- Crabbox Windows: `dotnet test ./tests/OpenClaw.Connection.Tests/OpenClaw.Connection.Tests.csproj --no-restore --filter "FullyQualifiedName~GatewayConnectionManagerTests"` passed: 30 passed
- Repo autoreview skill: clean after fixes
- Live Crabbox Azure smoke: setup-code pairing connected operator and Windows node, node reconnected after restart with stored token, and `exec.approvals.node.get` returned the node approval policy through the gateway/node call path

## Follow-up Found During Smoke

`exec.approvals.node.set` currently exposes a gateway/node schema mismatch: gateway-side validation expects the newer `version/agents` file shape, while the node read path returns the legacy approval-policy shape. `exec.approvals.node.get` is working and covered the critical read/invoke path for this release pass.
