### PR TITLE
fix(release): bundle VC runtime dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,11 @@ jobs:
         mkdir publish\SetupEngine
         copy publish-setup\* publish\SetupEngine\ -Recurse
 
+    - name: Verify x64 Native Runtime Payload
+      if: matrix.rid == 'win-x64'
+      shell: pwsh
+      run: .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath publish -RequireAppLocalVCRuntime
+
     - name: Verify GitVersion assembly metadata
       shell: pwsh
       run: |
@@ -599,11 +604,34 @@ jobs:
       shell: pwsh
       run: .\scripts\Test-ReleaseExecutableSignatures.ps1 -PayloadPath artifacts/tray-win-arm64 -RequireSignedOpenClaw
 
-    # Create ZIP files for Updatum auto-update (needs "win-x64" in filename)
-    - name: Create Release ZIPs
+    - name: Verify x64 Release Native Dependencies
+      shell: pwsh
+      run: .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath artifacts/tray-win-x64 -RequireAppLocalVCRuntime
+
+    - name: Download Visual C++ Runtime Redistributables
+      shell: pwsh
+      run: |
+        $redists = @(
+          @{ Uri = "https://aka.ms/vc14/vc_redist.x64.exe"; Path = "vc_redist.x64.exe" },
+          @{ Uri = "https://aka.ms/vc14/vc_redist.arm64.exe"; Path = "vc_redist.arm64.exe" }
+        )
+
+        foreach ($redist in $redists) {
+          Invoke-WebRequest -Uri $redist.Uri -OutFile $redist.Path
+          $signature = Get-AuthenticodeSignature -LiteralPath $redist.Path
+          if ($signature.Status -ne "Valid") {
+            throw "$($redist.Path) Authenticode signature was $($signature.Status)."
+          }
+          $subject = if ($signature.SignerCertificate) { $signature.SignerCertificate.Subject } else { "" }
+          if ($subject -notmatch "O=Microsoft Corporation") {
+            throw "$($redist.Path) signer was not Microsoft Corporation: $subject"
+          }
+        }
+
+    # Create ZIP file for Updatum auto-update (needs "win-x64" in filename)
+    - name: Create x64 Release ZIP
       run: |
         Compress-Archive -Path artifacts/tray-win-x64/* -DestinationPath OpenClawTray-${{ needs.test.outputs.semVer }}-win-x64.zip
-        Compress-Archive -Path artifacts/tray-win-arm64/* -DestinationPath OpenClawTray-${{ needs.test.outputs.semVer }}-win-arm64.zip
 
     # Inno Setup installer for x64
     - name: Install Inno Setup
@@ -614,16 +642,18 @@ jobs:
         # Prepare x64 files
         mkdir publish-x64
         copy artifacts/tray-win-x64/* publish-x64/ -Recurse
+        .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath publish-x64 -RequireAppLocalVCRuntime -RequireInstallerVCRedist -InstallerVCRedistPath vc_redist.x64.exe
         # Build installer
-        & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion=${{ needs.test.outputs.majorMinorPatch }} /DMyAppArch=x64 /Dpublish=publish-x64 installer.iss
+        & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion=${{ needs.test.outputs.majorMinorPatch }} /DMyAppArch=x64 /Dpublish=publish-x64 /DvcRedist=vc_redist.x64.exe installer.iss
 
     - name: Build arm64 Installer
       run: |
         # Prepare arm64 files
         mkdir publish-arm64
         copy artifacts/tray-win-arm64/* publish-arm64/ -Recurse
+        .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath publish-arm64 -RequireInstallerVCRedist -InstallerVCRedistPath vc_redist.arm64.exe -SkipNativeLoadProbe
         # Build installer
-        & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion=${{ needs.test.outputs.majorMinorPatch }} /DMyAppArch=arm64 /Dpublish=publish-arm64 installer.iss
+        & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion=${{ needs.test.outputs.majorMinorPatch }} /DMyAppArch=arm64 /Dpublish=publish-arm64 /DvcRedist=vc_redist.arm64.exe installer.iss
 
     - name: Sign Installers
       uses: azure/artifact-signing-action@v2
@@ -645,7 +675,6 @@ jobs:
           Output/OpenClawCompanion-Setup-x64.exe
           Output/OpenClawCompanion-Setup-arm64.exe
           OpenClawTray-${{ needs.test.outputs.semVer }}-win-x64.zip
-          OpenClawTray-${{ needs.test.outputs.semVer }}-win-arm64.zip
         prerelease: ${{ contains(github.ref_name, '-') }}
         make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
         body: |
@@ -655,7 +684,6 @@ jobs:
           - **Installer (x64)**: `OpenClawCompanion-Setup-x64.exe` - Intel/AMD 64-bit
           - **Installer (ARM64)**: `OpenClawCompanion-Setup-arm64.exe` - Windows on ARM (Surface, etc.)
           - **Portable x64**: `OpenClawTray-${{ needs.test.outputs.semVer }}-win-x64.zip`
-          - **Portable ARM64**: `OpenClawTray-${{ needs.test.outputs.semVer }}-win-arm64.zip`
 
           ### Features
           - 🦞 System tray integration with gateway status

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -69,9 +69,8 @@ For the current alpha flow, ship only:
 - Inno setup installers:
   - `OpenClawCompanion-Setup-x64.exe`
   - `OpenClawCompanion-Setup-arm64.exe`
-- Portable ZIP payloads for Updatum:
+- Portable ZIP payload for Updatum:
   - `OpenClawTray-<version>-win-x64.zip`
-  - `OpenClawTray-<version>-win-arm64.zip`
 
 MSIX artifacts are intentionally paused for alpha while we focus on the Inno
 installer path and signed portable update payloads. Re-enable MSIX only when we
@@ -99,6 +98,16 @@ Third-party/runtime executables that must not be OpenClaw-signed:
 CI enforces this with `scripts\Test-ReleaseExecutableSignatures.ps1`. The
 verifier fails closed on unknown `.exe` files so future payload changes are
 reviewed deliberately.
+
+CI also checks native runtime dependencies before release packaging. The x64
+portable payload must ship `vcruntime140.dll` next to every `libsodium.dll`
+copy. The release job must Authenticode-verify Microsoft's x64 and ARM64 Visual
+C++ Runtime redistributables before passing the architecture-matching
+redistributable to Inno. The installer runs the redistributable before launching
+the tray so clean or stale Windows hosts can repair the runtime before Ed25519
+device keys are generated or loaded, and it skips the post-install tray launch
+if the runtime installer fails. ARM64 portable ZIPs are paused until the release
+pipeline has a trusted app-local ARM64 VC runtime source.
 
 The current Azure Artifact Signing resource is:
 
@@ -150,10 +159,10 @@ The release job should:
 2. Authenticate to Azure with OIDC in the `release-signing` environment.
 3. Sign only the OpenClaw-owned EXEs in both payloads.
 4. Verify executable signing policy.
-5. Create portable ZIPs.
+5. Create the portable x64 ZIP.
 6. Build Inno installers.
 7. Sign installers.
-8. Create a GitHub prerelease with installer and ZIP assets only.
+8. Create a GitHub prerelease with installer and x64 ZIP assets only.
 
 ## Post-release verification
 

--- a/installer.iss
+++ b/installer.iss
@@ -62,6 +62,12 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
   #error SetupEngine.UI payload missing. Publish OpenClaw.SetupEngine.UI into {#publish}\SetupEngine before compiling the installer.
 #endif
 
+; vcRedist should point at the architecture-matching Visual C++ Runtime
+; redistributable in CI release builds.
+#ifndef vcRedist
+  #define vcRedist ""
+#endif
+
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 Name: "startupicon"; Description: "Start OpenClaw Companion when Windows starts"; GroupDescription: "Startup:"; Flags: unchecked
@@ -71,6 +77,9 @@ Name: "startupicon"; Description: "Start OpenClaw Companion when Windows starts"
 Source: "{#publish}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 ; WSL gateway uninstall helper copied to {tmp} by [Code] during uninstall.
 Source: "scripts\Uninstall-LocalGateway.ps1"; DestDir: "{app}"; Flags: ignoreversion
+#if vcRedist != ""
+Source: "{#vcRedist}"; DestDir: "{tmp}"; DestName: "vc_redist.exe"; Flags: deleteafterinstall; AfterInstall: InstallVCRuntime
+#endif
 
 [Registry]
 Root: HKCU; Subkey: "Software\Classes\openclaw"; ValueType: string; ValueName: ""; ValueData: "URL:OpenClaw Protocol"; Flags: uninsdeletekey
@@ -89,13 +98,56 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: de
 Name: "{userstartup}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: startupicon
 
 [Run]
-Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent; Check: ShouldLaunchTray
 
 [Code]
 var
+  VCRuntimeInstallSucceeded: Boolean;
   LocalGatewayCleanupChoiceInitialized: Boolean;
   LocalGatewayCleanupRequested: Boolean;
   LocalGatewayCleanupSucceeded: Boolean;
+
+#if vcRedist != ""
+procedure InstallVCRuntime;
+var
+  ResultCode: Integer;
+  Started: Boolean;
+begin
+  VCRuntimeInstallSucceeded := False;
+  Log('Running bundled Visual C++ Runtime redistributable.');
+  Started :=
+    Exec(
+      ExpandConstant('{tmp}\vc_redist.exe'),
+      '/install /quiet /norestart',
+      '',
+      SW_HIDE,
+      ewWaitUntilTerminated,
+      ResultCode);
+
+  if not Started then
+  begin
+    Log('Failed to start Visual C++ Runtime redistributable. System error: ' + IntToStr(ResultCode) + '.');
+    Exit;
+  end;
+
+  VCRuntimeInstallSucceeded := (ResultCode = 0) or (ResultCode = 3010) or (ResultCode = 1641);
+  if VCRuntimeInstallSucceeded then
+    Log('Visual C++ Runtime redistributable exited with success code ' + IntToStr(ResultCode) + '.')
+  else
+    Log('Visual C++ Runtime redistributable failed with exit code ' + IntToStr(ResultCode) + '.');
+end;
+#endif
+
+function ShouldLaunchTray: Boolean;
+begin
+#if vcRedist != ""
+  Result := VCRuntimeInstallSucceeded;
+  if not Result then
+    Log('Skipping post-install tray launch because Visual C++ Runtime installation did not succeed.');
+#else
+  Result := True;
+#endif
+end;
 
 procedure EnsureLocalGatewayCleanupChoice;
 begin

--- a/scripts/Test-ReleaseNativeDependencies.ps1
+++ b/scripts/Test-ReleaseNativeDependencies.ps1
@@ -1,0 +1,149 @@
+<#
+.SYNOPSIS
+    Verifies native release payload dependencies needed on clean Windows hosts.
+
+.DESCRIPTION
+    The Windows node uses NSec.Cryptography, which loads libsodium.dll. The
+    NuGet-provided Windows libsodium binary imports the Visual C++ runtime, so
+    app-local/installer payloads must make that runtime available before the
+    tray can generate or load device keys.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PayloadPath,
+
+    [switch]$RequireAppLocalVCRuntime,
+
+    [switch]$RequireInstallerVCRedist,
+
+    [string]$InstallerVCRedistPath,
+
+    [switch]$SkipNativeLoadProbe
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$payloadRoot = (Resolve-Path -LiteralPath $PayloadPath).Path
+$errors = New-Object System.Collections.Generic.List[string]
+$runningOnWindows = $env:OS -eq "Windows_NT"
+$shouldProbeNativeLoad = $runningOnWindows -and -not $SkipNativeLoadProbe
+
+if ($shouldProbeNativeLoad -and
+    -not ([System.Management.Automation.PSTypeName]"OpenClawNativeDependencyProbe").Type) {
+    Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class OpenClawNativeDependencyProbe {
+    [DllImport("kernel32", SetLastError=true, CharSet=CharSet.Unicode)]
+    public static extern IntPtr LoadLibrary(string lpFileName);
+
+    [DllImport("kernel32", SetLastError=true, CharSet=CharSet.Unicode)]
+    public static extern bool SetDllDirectory(string lpPathName);
+}
+"@
+}
+
+function Get-RelativePath {
+    param(
+        [Parameter(Mandatory = $true)][string]$Root,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    [System.IO.Path]::GetRelativePath($Root, $Path).Replace('/', '\')
+}
+
+function Add-MicrosoftSignatureErrors {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.FileInfo]$File
+    )
+
+    if (-not $runningOnWindows) {
+        return
+    }
+
+    $signature = Get-AuthenticodeSignature -LiteralPath $File.FullName
+    if ($signature.Status -ne "Valid") {
+        $errors.Add("Microsoft runtime file $(Get-RelativePath -Root $payloadRoot -Path $File.FullName) has Authenticode status $($signature.Status).")
+        return
+    }
+
+    $subject = if ($signature.SignerCertificate) { $signature.SignerCertificate.Subject } else { "" }
+    if ($subject -notmatch "O=Microsoft Corporation") {
+        $errors.Add("Microsoft runtime file $(Get-RelativePath -Root $payloadRoot -Path $File.FullName) was not signed by Microsoft Corporation: $subject")
+    }
+}
+
+function Get-VCRuntimeFiles {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Directory
+    )
+
+    @(
+        Get-ChildItem -LiteralPath $Directory -File -Filter "vcruntime140*.dll"
+        Get-ChildItem -LiteralPath $Directory -File -Filter "msvcp140*.dll"
+        Get-ChildItem -LiteralPath $Directory -File -Filter "concrt140.dll"
+    ) | Sort-Object FullName -Unique
+}
+
+$libsodiumFiles = @(
+    Get-ChildItem -LiteralPath $payloadRoot -Recurse -File -Filter libsodium.dll |
+        Sort-Object FullName
+)
+
+if ($libsodiumFiles.Count -eq 0) {
+    $errors.Add("Missing libsodium.dll under $payloadRoot.")
+}
+
+foreach ($libsodium in $libsodiumFiles) {
+    $runtimePath = Join-Path $libsodium.DirectoryName "vcruntime140.dll"
+    if ($RequireAppLocalVCRuntime -and -not (Test-Path -LiteralPath $runtimePath)) {
+        $errors.Add("Missing app-local vcruntime140.dll next to $(Get-RelativePath -Root $payloadRoot -Path $libsodium.FullName).")
+    }
+
+    if ($RequireAppLocalVCRuntime) {
+        foreach ($runtimeFile in Get-VCRuntimeFiles -Directory $libsodium.DirectoryName) {
+            Add-MicrosoftSignatureErrors -File $runtimeFile
+        }
+    }
+
+    if ($shouldProbeNativeLoad) {
+        [OpenClawNativeDependencyProbe]::SetDllDirectory($libsodium.DirectoryName) | Out-Null
+        Push-Location $libsodium.DirectoryName
+        try {
+            $handle = [OpenClawNativeDependencyProbe]::LoadLibrary("libsodium.dll")
+            $lastError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        } finally {
+            Pop-Location
+        }
+
+        if ($handle -eq [IntPtr]::Zero) {
+            $errors.Add("libsodium.dll failed to load from $(Get-RelativePath -Root $payloadRoot -Path $libsodium.FullName) (Win32 error $lastError).")
+        }
+    }
+}
+
+if ($RequireInstallerVCRedist) {
+    $redist = if ([string]::IsNullOrWhiteSpace($InstallerVCRedistPath)) {
+        Join-Path $payloadRoot "vc_redist.x64.exe"
+    } else {
+        $InstallerVCRedistPath
+    }
+
+    if (-not (Test-Path -LiteralPath $redist)) {
+        $errors.Add("Missing bundled Visual C++ Runtime redistributable at $redist.")
+    } elseif ($runningOnWindows) {
+        Add-MicrosoftSignatureErrors -File (Get-Item -LiteralPath $redist)
+    }
+}
+
+if ($errors.Count -gt 0) {
+    $errors | ForEach-Object { Write-Error $_ }
+    exit 1
+}
+
+Write-Host "Release native dependency policy passed." -ForegroundColor Green

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="6.4.0" PrivateAssets="all" />
+    <PackageReference Include="VCRuntime.CefSharp.140" Version="1.0.5" PrivateAssets="all" ExcludeAssets="build" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,36 @@
+<Project>
+
+  <PropertyGroup>
+    <OpenClawVCRuntimePackageVersion>1.0.5</OpenClawVCRuntimePackageVersion>
+    <OpenClawVCRuntimePackageRoot>$(NuGetPackageRoot)vcruntime.cefsharp.140\$(OpenClawVCRuntimePackageVersion)\vc_redist\</OpenClawVCRuntimePackageRoot>
+    <OpenClawVCRuntimeArch Condition="'$(RuntimeIdentifier)' == 'win-x64'">x64</OpenClawVCRuntimeArch>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(OpenClawVCRuntimeArch)' != ''">
+    <OpenClawVCRuntimeFiles Include="$(OpenClawVCRuntimePackageRoot)$(OpenClawVCRuntimeArch)\*.dll" />
+  </ItemGroup>
+
+  <Target Name="CopyOpenClawVCRuntimeToOutput"
+          AfterTargets="Build"
+          Condition="'$(OpenClawVCRuntimeArch)' != '' and '@(OpenClawVCRuntimeFiles)' != ''">
+    <Copy SourceFiles="@(OpenClawVCRuntimeFiles)"
+          DestinationFolder="$(TargetDir)"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+  <Target Name="CopyOpenClawVCRuntimeToPublish"
+          AfterTargets="Publish"
+          Condition="'$(PublishDir)' != '' and '$(OpenClawVCRuntimeArch)' != '' and '@(OpenClawVCRuntimeFiles)' != ''">
+    <Copy SourceFiles="@(OpenClawVCRuntimeFiles)"
+          DestinationFolder="$(PublishDir)"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+  <Target Name="ValidateOpenClawVCRuntimePublished"
+          AfterTargets="CopyOpenClawVCRuntimeToPublish"
+          Condition="'$(PublishDir)' != '' and '$(OpenClawVCRuntimeArch)' != ''">
+    <Error Condition="!Exists('$(PublishDir)vcruntime140.dll')"
+           Text="vcruntime140.dll missing from $(PublishDir). Clean Windows installs cannot load libsodium.dll without the VC runtime." />
+  </Target>
+
+</Project>

--- a/src/OpenClaw.Shared/DeviceIdentity.cs
+++ b/src/OpenClaw.Shared/DeviceIdentity.cs
@@ -205,7 +205,7 @@ public class DeviceIdentity
         }
         catch (Exception ex)
         {
-            _logger.Error($"Failed to load device key: {ex.Message}");
+            _logger.Error($"Failed to load device key: {DescribeException(ex)}");
             GenerateNew();
         }
     }
@@ -552,6 +552,14 @@ public class DeviceIdentity
             .Distinct(StringComparer.Ordinal)
             .ToArray();
         return normalized.Length == 0 ? null : normalized;
+    }
+
+    private static string DescribeException(Exception ex)
+    {
+        var message = $"{ex.GetType().Name}: {ex.Message}";
+        return ex.InnerException == null
+            ? message
+            : $"{message} (inner {ex.InnerException.GetType().Name}: {ex.InnerException.Message})";
     }
     
     private static string Base64UrlEncode(byte[] data)

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1442,8 +1442,34 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             ? "last successful gateway"
             : "credentialed gateway";
         Logger.Info($"Connecting to {connectionKind} during {context}: {record.Url} ({credential.Source})");
-        _ = _connectionManager.ConnectAsync(record.Id);
+        ObserveBackgroundFault(
+            _connectionManager.ConnectAsync(record.Id),
+            $"[App] Startup gateway connect failed during {context}");
         return true;
+    }
+
+    private static void ObserveBackgroundFault(Task task, string message)
+    {
+        if (task.IsFaulted)
+        {
+            Logger.Error($"{message}: {task.Exception.GetBaseException().Message}");
+            return;
+        }
+
+        if (task.IsCanceled)
+        {
+            Logger.Warn($"{message}: canceled");
+            return;
+        }
+
+        if (!task.IsCompleted)
+        {
+            _ = task.ContinueWith(
+                t => Logger.Error($"{message}: {t.Exception!.GetBaseException().Message}"),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
     }
 
     private OpenClaw.Connection.GatewayCredential? ResolveStartupOperatorCredential(GatewayRecord record)

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,6 +12,7 @@
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <OpenClawLibsodiumVersion>1.0.20.1</OpenClawLibsodiumVersion>
+    <OpenClawVCRuntimeVersion>1.0.5</OpenClawVCRuntimeVersion>
     <!-- Audit direct + transitive dependencies for known CVEs during restore,
          matching the setting in src/Directory.Build.props. -->
     <NuGetAuditMode>all</NuGetAuditMode>
@@ -26,6 +27,7 @@
       wraps each `dotnet test` invocation with `dotnet-coverage collect`.
     -->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="VCRuntime.CefSharp.140" Version="$(OpenClawVCRuntimeVersion)" PrivateAssets="all" ExcludeAssets="build" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
@@ -38,6 +40,7 @@
     <ItemGroup>
       <OpenClawNativeCrypto Include="$(NuGetPackageRoot)libsodium\$(OpenClawLibsodiumVersion)\runtimes\win-x64\native\libsodium.dll" Condition="'$(PROCESSOR_ARCHITECTURE)' != 'ARM64' And Exists('$(NuGetPackageRoot)libsodium\$(OpenClawLibsodiumVersion)\runtimes\win-x64\native\libsodium.dll')" />
       <OpenClawNativeCrypto Include="$(NuGetPackageRoot)libsodium\$(OpenClawLibsodiumVersion)\runtimes\win-arm64\native\libsodium.dll" Condition="'$(PROCESSOR_ARCHITECTURE)' == 'ARM64' And Exists('$(NuGetPackageRoot)libsodium\$(OpenClawLibsodiumVersion)\runtimes\win-arm64\native\libsodium.dll')" />
+      <OpenClawNativeCrypto Include="$(NuGetPackageRoot)vcruntime.cefsharp.140\$(OpenClawVCRuntimeVersion)\vc_redist\x64\*.dll" Condition="'$(PROCESSOR_ARCHITECTURE)' != 'ARM64' And Exists('$(NuGetPackageRoot)vcruntime.cefsharp.140\$(OpenClawVCRuntimeVersion)\vc_redist\x64\vcruntime140.dll')" />
     </ItemGroup>
     <Copy SourceFiles="@(OpenClawNativeCrypto)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
   </Target>

--- a/tests/OpenClaw.Tray.Tests/ReleaseSigningWorkflowTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ReleaseSigningWorkflowTests.cs
@@ -49,6 +49,43 @@ public sealed class ReleaseSigningWorkflowTests
     }
 
     [Fact]
+    public void ReleaseWorkflow_BundlesAndVerifiesNativeRuntimeDependencies()
+    {
+        var root = GetRepositoryRoot();
+        var workflow = File.ReadAllText(Path.Combine(root, ".github", "workflows", "ci.yml"));
+        var installer = File.ReadAllText(Path.Combine(root, "installer.iss"));
+        var verifier = File.ReadAllText(Path.Combine(root, "scripts", "Test-ReleaseNativeDependencies.ps1"));
+        var targets = File.ReadAllText(Path.Combine(root, "src", "Directory.Build.targets"));
+
+        Assert.Contains("Test-ReleaseNativeDependencies.ps1 -PayloadPath publish -RequireAppLocalVCRuntime", workflow);
+        Assert.Contains("Test-ReleaseNativeDependencies.ps1 -PayloadPath artifacts/tray-win-x64 -RequireAppLocalVCRuntime", workflow);
+        Assert.Contains("https://aka.ms/vc14/vc_redist.x64.exe", workflow);
+        Assert.Contains("https://aka.ms/vc14/vc_redist.arm64.exe", workflow);
+        Assert.Contains("Get-AuthenticodeSignature -LiteralPath $redist.Path", workflow);
+        Assert.Contains("O=Microsoft Corporation", workflow);
+        Assert.Contains("-InstallerVCRedistPath vc_redist.x64.exe", workflow);
+        Assert.Contains("publish-arm64 -RequireInstallerVCRedist -InstallerVCRedistPath vc_redist.arm64.exe -SkipNativeLoadProbe", workflow);
+        Assert.Contains("/DvcRedist=vc_redist.x64.exe", workflow);
+        Assert.Contains("/DvcRedist=vc_redist.arm64.exe", workflow);
+        Assert.DoesNotContain("copy vc_redist.x64.exe publish-x64", workflow);
+        Assert.DoesNotContain("copy vc_redist.x64.exe publish-arm64", workflow);
+        Assert.DoesNotContain("win-arm64.zip", workflow);
+        Assert.Contains("AfterInstall: InstallVCRuntime", installer);
+        Assert.Contains("Exec(", installer);
+        Assert.Contains("ResultCode = 3010", installer);
+        Assert.Contains("ShouldLaunchTray", installer);
+        Assert.Contains("Skipping post-install tray launch", installer);
+        Assert.DoesNotContain(@"Filename: ""{tmp}\vc_redist.exe""", installer);
+        Assert.Contains("Get-AuthenticodeSignature -LiteralPath $File.FullName", verifier);
+        Assert.Contains("Get-VCRuntimeFiles", verifier);
+        Assert.Contains("vcruntime140.dll", verifier);
+        Assert.Contains("libsodium.dll", verifier);
+        Assert.Contains("OpenClawNativeDependencyProbe", verifier);
+        Assert.Contains("SkipNativeLoadProbe", verifier);
+        Assert.Contains("CopyOpenClawVCRuntimeToPublish", targets);
+    }
+
+    [Fact]
     public void ReleaseWorkflow_PausesMsixForAlpha()
     {
         var workflow = File.ReadAllText(Path.Combine(GetRepositoryRoot(), ".github", "workflows", "ci.yml"));


### PR DESCRIPTION
## Summary
- ship x64 VC runtime DLLs app-local next to libsodium in build/test/publish outputs
- add a release native-dependency verifier that checks libsodium loadability plus Microsoft Authenticode signatures for app-local runtime DLLs and VC redistributables
- bundle architecture-matching Microsoft VC redistributables for Inno installers, run them before tray launch, and skip launch if runtime install fails
- pause the ARM64 portable ZIP until we have a trusted app-local ARM64 VC runtime source; ARM64 installer still ships with the ARM64 redist
- improve startup/native dependency logging for device identity and background gateway connect failures

## Validation
- Windows Crabbox cbx_c658ca6b0701: `./build.ps1` passed
- Windows Crabbox cbx_c658ca6b0701: shared tests warm passed: 2038 passed, 29 skipped, 0 failed
- Windows Crabbox cbx_c658ca6b0701: tray tests warm passed: 870 passed, 0 failed
- Windows Crabbox cbx_c658ca6b0701: shared tests `--no-restore` passed: 2038 passed, 29 skipped, 0 failed
- Windows Crabbox cbx_c658ca6b0701: tray tests `--no-restore` passed: 870 passed, 0 failed
- Windows Crabbox cbx_c658ca6b0701: release proof passed for x64 publish payload with SetupEngine, x64/ARM64 Microsoft redist signature checks, app-local VCRT signature checks, libsodium LoadLibrary probe, and ARM64-redist skip-probe path
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean: no accepted/actionable findings

## Notes
Draft because the signed prerelease recut plus full pond pairing / exec-approval validation are still pending.