### PR TITLE
Add gateway terminal controls

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
@@ -165,6 +165,17 @@
                                     Visibility="Collapsed"
                                     Click="OnStripPrimaryClicked"
                                     AutomationProperties.AutomationId="StripPrimaryAction"/>
+                            <Button x:Name="StripTerminalButton"
+                                    Width="32" Height="32" Padding="0"
+                                    Background="Transparent" BorderThickness="0"
+                                    Visibility="Collapsed"
+                                    Click="OnOpenGatewayTerminal"
+                                    ToolTipService.ToolTip="Open terminal"
+                                    AutomationProperties.Name="Open terminal"
+                                    AutomationProperties.AutomationId="StripTerminalAction">
+                                <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Terminal, Mode=OneTime}" FontSize="14"
+                                          Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                            </Button>
                             <!-- Disconnect/connect toggle. ON = connection is live (or attempting).
                                  Tap OFF → disconnect; tap ON (from off) → reconnect. -->
                             <Button x:Name="StripDashboardButton"
@@ -188,6 +199,88 @@
                                           AutomationProperties.AutomationId="ConnectionToggle"/>
                         </StackPanel>
                     </Grid>
+
+                    <!-- Host access controls — only for setup-managed WSL gateways.
+                         SSH gateways keep the top-right terminal affordance but
+                         do not expose lifecycle buttons. -->
+                    <StackPanel x:Name="GatewayHostControlsSection" Spacing="8" Visibility="Collapsed">
+                        <Border Height="1" Background="{ThemeResource CardStrokeColorDefaultBrush}" Margin="0,0,0,4"/>
+                        <Grid ColumnSpacing="14">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="36"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <FontIcon Grid.Column="0"
+                                      Glyph="{x:Bind helpers:FluentIconCatalog.Terminal, Mode=OneTime}"
+                                      FontSize="22"
+                                      VerticalAlignment="Center" HorizontalAlignment="Center"
+                                      AutomationProperties.AccessibilityView="Raw"/>
+                            <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
+                                <TextBlock x:Name="GatewayHostControlsTitleText"
+                                           Text="WSL gateway"
+                                           Style="{StaticResource BodyStrongTextBlockStyle}"
+                                           AutomationProperties.HeadingLevel="Level2"/>
+                                <TextBlock x:Name="GatewayHostControlsDescriptionText"
+                                           Text="Open a shell or manage the local gateway service in WSL."
+                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           TextWrapping="Wrap"/>
+                                <StackPanel x:Name="GatewayHostActionStatusPanel"
+                                            Orientation="Horizontal"
+                                            Spacing="6"
+                                            Margin="0,4,0,0"
+                                            Visibility="Collapsed">
+                                    <ProgressRing x:Name="GatewayHostActionProgress"
+                                                  Width="14" Height="14"
+                                                  IsActive="False"
+                                                  VerticalAlignment="Center"/>
+                                    <TextBlock x:Name="GatewayHostActionStatusText"
+                                               Text=""
+                                               Style="{StaticResource CaptionTextBlockStyle}"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                               TextWrapping="Wrap"
+                                               VerticalAlignment="Center"
+                                               AutomationProperties.LiveSetting="Polite"/>
+                                </StackPanel>
+                            </StackPanel>
+                            <StackPanel Grid.Column="2"
+                                        Orientation="Horizontal"
+                                        Spacing="8"
+                                        HorizontalAlignment="Right"
+                                        VerticalAlignment="Center">
+                                <Button x:Name="GatewayHostOpenTerminalButton"
+                                        Click="OnOpenGatewayTerminal"
+                                        ToolTipService.ToolTip="Open terminal"
+                                        AutomationProperties.Name="Open terminal"
+                                        AutomationProperties.AutomationId="GatewayHostOpenTerminalAction">
+                                    <StackPanel Orientation="Horizontal" Spacing="6">
+                                        <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Terminal, Mode=OneTime}" FontSize="12"
+                                                  AutomationProperties.AccessibilityView="Raw"/>
+                                        <TextBlock Text="Terminal" FontSize="13"/>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="GatewayHostStartButton"
+                                        Content="Start"
+                                        Click="OnStartGatewayClicked"
+                                        ToolTipService.ToolTip="Run openclaw gateway start in WSL"
+                                        AutomationProperties.Name="Start WSL gateway"
+                                        AutomationProperties.AutomationId="GatewayHostStartAction"/>
+                                <Button x:Name="GatewayHostStopButton"
+                                        Content="Stop"
+                                        Click="OnStopGatewayClicked"
+                                        ToolTipService.ToolTip="Run openclaw gateway stop in WSL"
+                                        AutomationProperties.Name="Stop WSL gateway"
+                                        AutomationProperties.AutomationId="GatewayHostStopAction"/>
+                                <Button x:Name="GatewayHostRestartButton"
+                                        Content="Restart"
+                                        Click="OnRestartGatewayClicked"
+                                        ToolTipService.ToolTip="Run openclaw gateway restart in WSL"
+                                        AutomationProperties.Name="Restart WSL gateway"
+                                        AutomationProperties.AutomationId="GatewayHostRestartAction"/>
+                            </StackPanel>
+                        </Grid>
+                    </StackPanel>
 
                     <!-- Operator section — visible only when there's an active operator session.
                          Mirrors the Permissions Node card pattern: 22-px icon

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -35,6 +35,8 @@ public sealed partial class ConnectionPage : Page
     private IGatewayConnectionManager? _connectionManager;
     private GatewayRegistry? _gatewayRegistry;
     private GatewayDiscoveryService? _discoveryService;
+    private IGatewayTerminalLauncher? _terminalLauncher;
+    private WslGatewayController? _wslGatewayController;
 
     // ─── UI state ───
     private UserIntent _userIntent = UserIntent.None;
@@ -42,6 +44,10 @@ public sealed partial class ConnectionPage : Page
     private bool _suppressNodeModeToggle;
     private bool _suppressConnectionToggle;
     private ConnectionPagePlan _currentPlan = new();
+    private GatewayHostAccessPlan _activeHostAccessPlan = GatewayHostAccessPlan.None();
+    private bool _gatewayHostActionInProgress;
+    private CancellationTokenSource? _gatewayHostActionCts;
+    private string? _gatewayHostStatusGatewayId;
 
     // Tracks which gateway record the Add Gateway form is currently editing
     // (set by OnSavedRowEdit / OnEditTunnelSettings; null = creating a brand
@@ -83,6 +89,14 @@ public sealed partial class ConnectionPage : Page
     {
         InitializeComponent();
     }
+
+    private IGatewayTerminalLauncher TerminalLauncher =>
+        _terminalLauncher ??= new GatewayTerminalLauncher(new OpenClawTray.AppLogger());
+
+    private WslGatewayController WslGatewayController =>
+        _wslGatewayController ??= new WslGatewayController(
+            new WslExeCommandRunner(new OpenClawTray.AppLogger()),
+            new OpenClawTray.AppLogger());
 
     // ─── Initialization ───────────────────────────────────────────────
 
@@ -166,6 +180,13 @@ public sealed partial class ConnectionPage : Page
             _reconnectMaskTimer.Tick -= OnReconnectMaskTimeout;
             _reconnectMaskTimer = null;
         }
+        _gatewayHostActionCts?.Cancel();
+        if (!_gatewayHostActionInProgress)
+        {
+            _gatewayHostActionCts?.Dispose();
+            _gatewayHostActionCts = null;
+        }
+        _gatewayHostActionInProgress = false;
         if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
     }
 
@@ -305,6 +326,7 @@ public sealed partial class ConnectionPage : Page
 
         // ─── Status strip ───
         ApplyStripVisuals(plan);
+        ApplyGatewayHostAccess(plan);
 
         // ─── Cards (only meaningful when we have an operator session
         // and we're not in a focused sub-view) ───
@@ -401,6 +423,71 @@ public sealed partial class ConnectionPage : Page
 
         // Glance chips (presence • channels • $today • topology) — when connected.
         ApplyGlanceChips(plan, hasActive && toggleOn);
+    }
+
+    private void ApplyGatewayHostAccess(ConnectionPagePlan plan)
+    {
+        var activeRecord = _gatewayRegistry?.GetActive();
+        _activeHostAccessPlan = GatewayHostAccessClassifier.Classify(activeRecord);
+        if (_gatewayHostStatusGatewayId is not null &&
+            !string.Equals(_gatewayHostStatusGatewayId, _activeHostAccessPlan.GatewayId, StringComparison.Ordinal))
+        {
+            ClearGatewayHostActionStatus();
+        }
+
+        var showInPageMode = plan.Mode is ConnectionPageMode.Cockpit or ConnectionPageMode.Recovery;
+        var showTerminal = showInPageMode &&
+                           _activeHostAccessPlan.CanOpenTerminal &&
+                           !_activeHostAccessPlan.CanControlWslGateway;
+        StripTerminalButton.Visibility = showTerminal ? Visibility.Visible : Visibility.Collapsed;
+        StripTerminalButton.IsEnabled = !_gatewayHostActionInProgress;
+        ToolTipService.SetToolTip(StripTerminalButton, _activeHostAccessPlan.TerminalTooltip);
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(
+            StripTerminalButton,
+            _activeHostAccessPlan.TerminalLabel);
+
+        var showWslControls = showInPageMode && _activeHostAccessPlan.CanControlWslGateway;
+        GatewayHostControlsSection.Visibility = showWslControls ? Visibility.Visible : Visibility.Collapsed;
+        if (!showWslControls)
+        {
+            ClearGatewayHostActionStatus();
+            return;
+        }
+
+        GatewayHostControlsTitleText.Text = "WSL gateway";
+        GatewayHostControlsDescriptionText.Text =
+            $"Open a shell or manage the local gateway service in {_activeHostAccessPlan.DistroName}.";
+        GatewayHostOpenTerminalButton.IsEnabled = !_gatewayHostActionInProgress && _activeHostAccessPlan.CanOpenTerminal;
+        GatewayHostStartButton.IsEnabled = !_gatewayHostActionInProgress;
+        GatewayHostStopButton.IsEnabled = !_gatewayHostActionInProgress;
+        GatewayHostRestartButton.IsEnabled = !_gatewayHostActionInProgress;
+        GatewayHostActionProgress.IsActive = _gatewayHostActionInProgress;
+        GatewayHostActionProgress.Visibility = _gatewayHostActionInProgress ? Visibility.Visible : Visibility.Collapsed;
+        GatewayHostActionStatusPanel.Visibility = _gatewayHostActionInProgress || !string.IsNullOrWhiteSpace(GatewayHostActionStatusText.Text)
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+        ToolTipService.SetToolTip(GatewayHostOpenTerminalButton, _activeHostAccessPlan.TerminalTooltip);
+    }
+
+    private void SetGatewayHostActionStatus(string message, bool isError = false)
+    {
+        _gatewayHostStatusGatewayId = string.IsNullOrWhiteSpace(message) ? null : _activeHostAccessPlan.GatewayId;
+        GatewayHostActionStatusText.Text = message;
+        GatewayHostActionStatusText.Foreground = isError
+            ? ResolveBrush("SystemFillColorCriticalBrush")
+            : ResolveBrush("TextFillColorSecondaryBrush");
+        GatewayHostActionStatusPanel.Visibility = string.IsNullOrWhiteSpace(message) && !_gatewayHostActionInProgress
+            ? Visibility.Collapsed
+            : Visibility.Visible;
+    }
+
+    private void ClearGatewayHostActionStatus()
+    {
+        _gatewayHostStatusGatewayId = null;
+        GatewayHostActionStatusText.Text = string.Empty;
+        GatewayHostActionStatusPanel.Visibility = _gatewayHostActionInProgress
+            ? Visibility.Visible
+            : Visibility.Collapsed;
     }
 
     /// <summary>
@@ -989,6 +1076,7 @@ public sealed partial class ConnectionPage : Page
             foreach (var gw in all)
             {
                 var isActive = active != null && active.Id == gw.Id;
+                var hostAccess = GatewayHostAccessClassifier.Classify(gw);
                 items.Add(new SavedGatewayRow
                 {
                     Id = gw.Id,
@@ -997,6 +1085,9 @@ public sealed partial class ConnectionPage : Page
                     IsActive = isActive,
                     LastConnectedRelative = FormatRelative(gw.LastConnected),
                     HasSshTunnel = gw.SshTunnel != null,
+                    HasWslGateway = hostAccess.IsWslManaged,
+                    HasHostTerminal = hostAccess.CanOpenTerminal,
+                    HostTerminalLabel = hostAccess.TerminalLabel,
                     AuthModeLabel = isActive && !string.IsNullOrEmpty(activeAuthMode)
                         ? activeAuthMode!
                         : InferAuthModeLabel(gw),
@@ -1019,6 +1110,9 @@ public sealed partial class ConnectionPage : Page
               .Append(r.DisplayName).Append('/').Append(r.Url ?? "").Append('/')
               .Append(r.LastConnectedRelative ?? "")
               .Append('/').Append(r.HasSshTunnel ? '1' : '0').Append('/')
+              .Append(r.HasWslGateway ? '1' : '0').Append('/')
+              .Append(r.HasHostTerminal ? '1' : '0').Append('/')
+              .Append(r.HostTerminalLabel ?? "").Append('/')
               .Append(r.AuthModeLabel ?? "").Append(';');
         }
         var fp = sb.ToString();
@@ -1186,6 +1280,15 @@ public sealed partial class ConnectionPage : Page
                 Foreground = ResolveBrush("TextFillColorSecondaryBrush"),
             });
         }
+        if (row.HasWslGateway)
+        {
+            sub.Children.Add(new TextBlock
+            {
+                Text = "• WSL",
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                Foreground = ResolveBrush("TextFillColorSecondaryBrush"),
+            });
+        }
         if (!string.IsNullOrEmpty(row.LastConnectedRelative) && !row.IsActive)
         {
             sub.Children.Add(new TextBlock
@@ -1253,6 +1356,12 @@ public sealed partial class ConnectionPage : Page
         var openDashboard = new MenuFlyoutItem { Text = "Open dashboard", Tag = row.Id };
         openDashboard.Click += OnSavedRowOpenDashboard;
         flyout.Items.Add(openDashboard);
+        if (row.HasHostTerminal)
+        {
+            var openTerminal = new MenuFlyoutItem { Text = row.HostTerminalLabel, Tag = row.Id };
+            openTerminal.Click += OnSavedRowOpenTerminal;
+            flyout.Items.Add(openTerminal);
+        }
         if (hasLiveAffordance)
         {
             // Whenever the row is in a state where Disconnect makes sense
@@ -1310,6 +1419,9 @@ public sealed partial class ConnectionPage : Page
         public bool IsActive { get; init; }
         public string LastConnectedRelative { get; init; } = "";
         public bool HasSshTunnel { get; init; }
+        public bool HasWslGateway { get; init; }
+        public bool HasHostTerminal { get; init; }
+        public string HostTerminalLabel { get; init; } = "";
         public string AuthModeLabel { get; init; } = "";
     }
 
@@ -1426,6 +1538,183 @@ public sealed partial class ConnectionPage : Page
     private void OnOpenDashboard(object sender, RoutedEventArgs e)
     {
         ((IAppCommands)CurrentApp).OpenDashboard();
+    }
+
+    private void OnOpenGatewayTerminal(object sender, RoutedEventArgs e)
+    {
+        OpenGatewayTerminal(_activeHostAccessPlan, showInlineStatus: true);
+    }
+
+    private void OnSavedRowOpenTerminal(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuFlyoutItem item || item.Tag is not string gwId) return;
+        var record = _gatewayRegistry?.GetById(gwId);
+        var accessPlan = GatewayHostAccessClassifier.Classify(record);
+        OpenGatewayTerminal(accessPlan, showInlineStatus: record?.Id == _gatewayRegistry?.GetActive()?.Id);
+    }
+
+    private void OpenGatewayTerminal(GatewayHostAccessPlan accessPlan, bool showInlineStatus)
+    {
+        if (!accessPlan.CanOpenTerminal)
+        {
+            ShowGatewayHostFailure(
+                "Terminal unavailable",
+                accessPlan.DisabledReason ?? "This gateway does not have terminal access.",
+                showInlineStatus);
+            return;
+        }
+
+        try
+        {
+            TerminalLauncher.Open(accessPlan);
+        }
+        catch (Exception ex)
+        {
+            Services.Logger.Warn($"[ConnectionPage] Failed to open gateway terminal: {ex.Message}");
+            ShowGatewayHostFailure("Terminal failed", ex.Message, showInlineStatus);
+        }
+    }
+
+    private void OnStartGatewayClicked(object sender, RoutedEventArgs e)
+    {
+        _ = RunWslGatewayControlAsync(WslGatewayControlAction.Start);
+    }
+
+    private void OnStopGatewayClicked(object sender, RoutedEventArgs e)
+    {
+        _ = RunWslGatewayControlAsync(WslGatewayControlAction.Stop);
+    }
+
+    private void OnRestartGatewayClicked(object sender, RoutedEventArgs e)
+    {
+        _ = RunWslGatewayControlAsync(WslGatewayControlAction.Restart);
+    }
+
+    private async Task RunWslGatewayControlAsync(WslGatewayControlAction action)
+    {
+        if (_gatewayHostActionInProgress)
+        {
+            return;
+        }
+
+        var activeRecord = _gatewayRegistry?.GetActive();
+        var accessPlan = GatewayHostAccessClassifier.Classify(activeRecord);
+        if (!accessPlan.CanControlWslGateway || string.IsNullOrWhiteSpace(accessPlan.DistroName))
+        {
+            SetGatewayHostActionStatus("This gateway is not an app-managed WSL gateway.", isError: true);
+            return;
+        }
+
+        var cts = new CancellationTokenSource();
+        _gatewayHostActionCts = cts;
+        var cancellationToken = cts.Token;
+        _gatewayHostActionInProgress = true;
+        ApplyGatewayHostAccess(_currentPlan);
+        var verb = WslGatewayControlCommandBuilder.ToVerb(action);
+        SetGatewayHostActionStatus($"{ActionInProgressLabel(action)} gateway in {accessPlan.DistroName}…");
+
+        try
+        {
+            if (action == WslGatewayControlAction.Stop && _connectionManager != null)
+            {
+                try
+                {
+                    await _connectionManager.DisconnectAsync();
+                }
+                catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+                {
+                    Services.Logger.Warn($"[ConnectionPage] Disconnect before WSL gateway stop failed; continuing stop: {ex.Message}");
+                }
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var result = await WslGatewayController.RunAsync(accessPlan.DistroName!, action, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!result.Success)
+            {
+                var details = string.IsNullOrWhiteSpace(result.OutputSummary)
+                    ? $"wsl.exe exited with code {result.ExitCode}."
+                    : result.OutputSummary;
+                SetGatewayHostActionStatus($"{UppercaseFirst(verb)} failed: {details}", isError: true);
+                return;
+            }
+
+            if (action == WslGatewayControlAction.Stop)
+            {
+                SetGatewayHostActionStatus("Gateway stopped.");
+                RefreshFromSnapshot(_connectionManager?.CurrentSnapshot ?? _lastSnapshot);
+                return;
+            }
+
+            SetGatewayHostActionStatus($"Gateway {PastTense(action)}. Reconnecting…");
+            BeginReconnectMask();
+            ((IAppCommands)CurrentApp).Reconnect();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            Services.Logger.Info($"[ConnectionPage] WSL gateway {verb} cancelled.");
+        }
+        catch (Exception ex)
+        {
+            Services.Logger.Warn($"[ConnectionPage] WSL gateway {verb} failed: {ex.Message}");
+            SetGatewayHostActionStatus($"{UppercaseFirst(verb)} failed: {ex.Message}", isError: true);
+        }
+        finally
+        {
+            _gatewayHostActionInProgress = false;
+            if (ReferenceEquals(_gatewayHostActionCts, cts))
+            {
+                _gatewayHostActionCts = null;
+            }
+            cts.Dispose();
+            if (IsLoaded)
+            {
+                ApplyGatewayHostAccess(_currentPlan);
+            }
+        }
+    }
+
+    private void ShowGatewayHostFailure(string title, string message, bool preferInlineStatus)
+    {
+        if (preferInlineStatus && GatewayHostControlsSection.Visibility == Visibility.Visible)
+        {
+            SetGatewayHostActionStatus(message, isError: true);
+            return;
+        }
+
+        AuthErrorBar.Title = title;
+        AuthErrorBar.Message = message;
+        AuthErrorBar.Severity = InfoBarSeverity.Error;
+        AuthErrorBar.IsOpen = true;
+    }
+
+    private static string UppercaseFirst(string value)
+    {
+        return string.IsNullOrEmpty(value)
+            ? value
+            : char.ToUpperInvariant(value[0]) + value[1..];
+    }
+
+    private static string PastTense(WslGatewayControlAction action)
+    {
+        return action switch
+        {
+            WslGatewayControlAction.Start => "started",
+            WslGatewayControlAction.Restart => "restarted",
+            WslGatewayControlAction.Stop => "stopped",
+            _ => "updated"
+        };
+    }
+
+    private static string ActionInProgressLabel(WslGatewayControlAction action)
+    {
+        return action switch
+        {
+            WslGatewayControlAction.Start => "Starting",
+            WslGatewayControlAction.Stop => "Stopping",
+            WslGatewayControlAction.Restart => "Restarting",
+            _ => "Updating"
+        };
     }
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/Services/GatewayHostAccess.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/GatewayHostAccess.cs
@@ -1,0 +1,93 @@
+using OpenClaw.Connection;
+
+namespace OpenClawTray.Services;
+
+internal enum GatewayTerminalTarget
+{
+    None,
+    Wsl,
+    Ssh
+}
+
+internal sealed record GatewayHostAccessPlan(
+    string? GatewayId,
+    GatewayTerminalTarget TerminalTarget,
+    string? DistroName,
+    string? SshUser,
+    string? SshHost,
+    bool CanControlWslGateway,
+    string TerminalLabel,
+    string TerminalTooltip,
+    string? DisabledReason)
+{
+    public bool CanOpenTerminal => TerminalTarget != GatewayTerminalTarget.None;
+
+    public bool IsWslManaged => !string.IsNullOrWhiteSpace(DistroName);
+
+    public static GatewayHostAccessPlan None(string? gatewayId = null, string? disabledReason = null)
+    {
+        return new GatewayHostAccessPlan(
+            gatewayId,
+            GatewayTerminalTarget.None,
+            null,
+            null,
+            null,
+            false,
+            "Open terminal",
+            disabledReason ?? "This gateway does not have WSL or SSH terminal access.",
+            disabledReason ?? "This gateway does not have WSL or SSH terminal access.");
+    }
+}
+
+internal static class GatewayHostAccessClassifier
+{
+    public static GatewayHostAccessPlan Classify(GatewayRecord? record)
+    {
+        if (record is null)
+        {
+            return GatewayHostAccessPlan.None();
+        }
+
+        var distroName = Normalize(record.SetupManagedDistroName);
+        var sshUser = Normalize(record.SshTunnel?.User);
+        var sshHost = Normalize(record.SshTunnel?.Host);
+
+        if (distroName is not null)
+        {
+            return new GatewayHostAccessPlan(
+                record.Id,
+                GatewayTerminalTarget.Wsl,
+                distroName,
+                sshUser,
+                sshHost,
+                true,
+                "Open terminal",
+                $"Open a terminal in the {distroName} WSL gateway.",
+                null);
+        }
+
+        if (sshUser is not null && sshHost is not null)
+        {
+            return new GatewayHostAccessPlan(
+                record.Id,
+                GatewayTerminalTarget.Ssh,
+                null,
+                sshUser,
+                sshHost,
+                false,
+                "Open SSH terminal",
+                $"Open an SSH terminal to {sshUser}@{sshHost}.",
+                null);
+        }
+
+        return GatewayHostAccessPlan.None(
+            record.Id,
+            "This gateway was not created with WSL and does not have an SSH tunnel.");
+    }
+
+    private static string? Normalize(string? value)
+    {
+        var trimmed = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/GatewayTerminalLauncher.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/GatewayTerminalLauncher.cs
@@ -1,0 +1,155 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using OpenClaw.Shared;
+
+namespace OpenClawTray.Services;
+
+internal interface IGatewayTerminalLauncher
+{
+    void Open(GatewayHostAccessPlan accessPlan);
+}
+
+internal sealed record GatewayTerminalLaunchCommand(
+    string FileName,
+    IReadOnlyList<string> Arguments,
+    bool UsesWindowsTerminal);
+
+internal static class GatewayTerminalLaunchCommandBuilder
+{
+    public static GatewayTerminalLaunchCommand Build(GatewayHostAccessPlan accessPlan, string? windowsTerminalPath)
+    {
+        if (!accessPlan.CanOpenTerminal)
+        {
+            throw new InvalidOperationException(accessPlan.DisabledReason ?? "Gateway terminal access is not available.");
+        }
+
+        return accessPlan.TerminalTarget switch
+        {
+            GatewayTerminalTarget.Wsl => BuildWslCommand(accessPlan, windowsTerminalPath),
+            GatewayTerminalTarget.Ssh => BuildSshCommand(accessPlan, windowsTerminalPath),
+            _ => throw new InvalidOperationException("Gateway terminal access is not available.")
+        };
+    }
+
+    private static GatewayTerminalLaunchCommand BuildWslCommand(GatewayHostAccessPlan accessPlan, string? windowsTerminalPath)
+    {
+        var distroName = RequireValue(accessPlan.DistroName, "WSL distro name is required.");
+        if (!string.IsNullOrWhiteSpace(windowsTerminalPath))
+        {
+            return new GatewayTerminalLaunchCommand(
+                windowsTerminalPath,
+                new ReadOnlyCollection<string>([
+                    "new-tab",
+                    "--title",
+                    $"OpenClaw Gateway ({distroName})",
+                    "wsl.exe",
+                    "-d",
+                    distroName
+                ]),
+                true);
+        }
+
+        return new GatewayTerminalLaunchCommand(
+            "wsl.exe",
+            new ReadOnlyCollection<string>(["-d", distroName]),
+            false);
+    }
+
+    private static GatewayTerminalLaunchCommand BuildSshCommand(GatewayHostAccessPlan accessPlan, string? windowsTerminalPath)
+    {
+        var user = RequireValue(accessPlan.SshUser, "SSH user is required.");
+        var host = RequireValue(accessPlan.SshHost, "SSH host is required.");
+        var endpoint = $"{user}@{host}";
+
+        if (!string.IsNullOrWhiteSpace(windowsTerminalPath))
+        {
+            return new GatewayTerminalLaunchCommand(
+                windowsTerminalPath,
+                new ReadOnlyCollection<string>([
+                    "new-tab",
+                    "--title",
+                    $"OpenClaw SSH Gateway ({host})",
+                    "ssh.exe",
+                    endpoint
+                ]),
+                true);
+        }
+
+        return new GatewayTerminalLaunchCommand(
+            "ssh.exe",
+            new ReadOnlyCollection<string>([endpoint]),
+            false);
+    }
+
+    private static string RequireValue(string? value, string message)
+    {
+        return string.IsNullOrWhiteSpace(value) ? throw new InvalidOperationException(message) : value;
+    }
+}
+
+internal sealed class GatewayTerminalLauncher(IOpenClawLogger logger) : IGatewayTerminalLauncher
+{
+    public void Open(GatewayHostAccessPlan accessPlan)
+    {
+        var terminalPath = TryFindWindowsTerminalPath();
+        var command = GatewayTerminalLaunchCommandBuilder.Build(accessPlan, terminalPath);
+
+        try
+        {
+            Start(command);
+        }
+        catch (Exception ex) when (command.UsesWindowsTerminal)
+        {
+            logger.Warn($"Windows Terminal launch failed; falling back to direct terminal process: {ex.Message}");
+            Start(GatewayTerminalLaunchCommandBuilder.Build(accessPlan, null));
+        }
+    }
+
+    internal static string? TryFindWindowsTerminalPath()
+    {
+        foreach (var candidate in GetWindowsTerminalCandidates().Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> GetWindowsTerminalCandidates()
+    {
+        var localAppData = Environment.GetEnvironmentVariable("LOCALAPPDATA");
+        if (!string.IsNullOrWhiteSpace(localAppData))
+        {
+            yield return Path.Combine(localAppData, "Microsoft", "WindowsApps", "wt.exe");
+        }
+
+        var specialLocalAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (!string.IsNullOrWhiteSpace(specialLocalAppData))
+        {
+            yield return Path.Combine(specialLocalAppData, "Microsoft", "WindowsApps", "wt.exe");
+        }
+    }
+
+    private static void Start(GatewayTerminalLaunchCommand command)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = command.FileName,
+            UseShellExecute = false
+        };
+
+        foreach (var argument in command.Arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        var process = Process.Start(startInfo);
+        if (process is null)
+        {
+            throw new InvalidOperationException($"Unable to launch {command.FileName}.");
+        }
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/WslGatewayController.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/WslGatewayController.cs
@@ -1,0 +1,94 @@
+using System.Collections.ObjectModel;
+using OpenClaw.Shared;
+
+namespace OpenClawTray.Services;
+
+public enum WslGatewayControlAction
+{
+    Start,
+    Stop,
+    Restart
+}
+
+internal sealed record WslGatewayControlResult(
+    string DistroName,
+    WslGatewayControlAction Action,
+    int ExitCode,
+    string StandardOutput,
+    string StandardError)
+{
+    public bool Success => ExitCode == 0;
+
+    public string OutputSummary
+    {
+        get
+        {
+            var summary = string.IsNullOrWhiteSpace(StandardOutput) ? StandardError : StandardOutput;
+            return string.IsNullOrWhiteSpace(summary) ? string.Empty : summary.Trim();
+        }
+    }
+}
+
+internal static class WslGatewayControlCommandBuilder
+{
+    internal const string OpenClawWslPathPrefix = "export PATH=\"/home/openclaw/.openclaw/bin:/opt/openclaw/bin:/usr/local/bin:$PATH\"";
+
+    public static IReadOnlyList<string> Build(WslGatewayControlAction action)
+    {
+        return new ReadOnlyCollection<string>([
+            "bash",
+            "-lc",
+            $"{OpenClawWslPathPrefix} && openclaw gateway {ToVerb(action)}"
+        ]);
+    }
+
+    public static string ToVerb(WslGatewayControlAction action)
+    {
+        return action switch
+        {
+            WslGatewayControlAction.Start => "start",
+            WslGatewayControlAction.Stop => "stop",
+            WslGatewayControlAction.Restart => "restart",
+            _ => throw new ArgumentOutOfRangeException(nameof(action), action, "Unsupported WSL gateway action.")
+        };
+    }
+}
+
+internal sealed class WslGatewayController(IWslCommandRunner commandRunner, IOpenClawLogger logger)
+{
+    public async Task<WslGatewayControlResult> RunAsync(
+        string distroName,
+        WslGatewayControlAction action,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(distroName))
+        {
+            throw new ArgumentException("WSL distro name is required.", nameof(distroName));
+        }
+
+        var normalizedDistroName = distroName.Trim();
+        var distros = await commandRunner.ListDistrosAsync(cancellationToken).ConfigureAwait(false);
+        if (!distros.Any(distro => string.Equals(distro.Name, normalizedDistroName, StringComparison.OrdinalIgnoreCase)))
+        {
+            return new WslGatewayControlResult(
+                normalizedDistroName,
+                action,
+                -1,
+                string.Empty,
+                $"WSL distro '{normalizedDistroName}' is not registered.");
+        }
+
+        logger.Info($"Running OpenClaw gateway {WslGatewayControlCommandBuilder.ToVerb(action)} in WSL distro '{normalizedDistroName}'.");
+        var result = await commandRunner.RunInDistroAsync(
+            normalizedDistroName,
+            WslGatewayControlCommandBuilder.Build(action),
+            cancellationToken).ConfigureAwait(false);
+
+        return new WslGatewayControlResult(
+            normalizedDistroName,
+            action,
+            result.ExitCode,
+            result.StandardOutput,
+            result.StandardError);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/GatewayHostAccessTests.cs
+++ b/tests/OpenClaw.Tray.Tests/GatewayHostAccessTests.cs
@@ -1,0 +1,80 @@
+using OpenClaw.Connection;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public class GatewayHostAccessTests
+{
+    [Fact]
+    public void Classify_UsesWslManagedDistro_WhenRecordWasCreatedBySetup()
+    {
+        var record = new GatewayRecord
+        {
+            Id = "local",
+            Url = "ws://127.0.0.1:18789",
+            IsLocal = true,
+            SetupManagedDistroName = "OpenClawGateway",
+        };
+
+        var access = GatewayHostAccessClassifier.Classify(record);
+
+        Assert.Equal(GatewayTerminalTarget.Wsl, access.TerminalTarget);
+        Assert.True(access.CanOpenTerminal);
+        Assert.True(access.CanControlWslGateway);
+        Assert.Equal("OpenClawGateway", access.DistroName);
+    }
+
+    [Fact]
+    public void Classify_UsesSshTerminal_WhenRecordHasOnlySshTunnel()
+    {
+        var record = new GatewayRecord
+        {
+            Id = "ssh",
+            Url = "ws://127.0.0.1:18789",
+            SshTunnel = new SshTunnelConfig("alice", "gateway.example.test", 18789, 18789),
+        };
+
+        var access = GatewayHostAccessClassifier.Classify(record);
+
+        Assert.Equal(GatewayTerminalTarget.Ssh, access.TerminalTarget);
+        Assert.True(access.CanOpenTerminal);
+        Assert.False(access.CanControlWslGateway);
+        Assert.Equal("alice", access.SshUser);
+        Assert.Equal("gateway.example.test", access.SshHost);
+    }
+
+    [Fact]
+    public void Classify_PrefersWslTerminal_WhenRecordHasWslAndSshMetadata()
+    {
+        var record = new GatewayRecord
+        {
+            Id = "mixed",
+            Url = "ws://127.0.0.1:18789",
+            SetupManagedDistroName = "OpenClawGateway",
+            SshTunnel = new SshTunnelConfig("alice", "gateway.example.test", 18789, 18789),
+        };
+
+        var access = GatewayHostAccessClassifier.Classify(record);
+
+        Assert.Equal(GatewayTerminalTarget.Wsl, access.TerminalTarget);
+        Assert.True(access.CanControlWslGateway);
+        Assert.Equal("OpenClawGateway", access.DistroName);
+    }
+
+    [Fact]
+    public void Classify_DisablesTerminal_WhenRecordHasNoHostAccessMetadata()
+    {
+        var record = new GatewayRecord
+        {
+            Id = "remote",
+            Url = "wss://gateway.example.test",
+        };
+
+        var access = GatewayHostAccessClassifier.Classify(record);
+
+        Assert.Equal(GatewayTerminalTarget.None, access.TerminalTarget);
+        Assert.False(access.CanOpenTerminal);
+        Assert.False(access.CanControlWslGateway);
+        Assert.NotNull(access.DisabledReason);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/GatewayTerminalLaunchCommandBuilderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/GatewayTerminalLaunchCommandBuilderTests.cs
@@ -1,0 +1,80 @@
+using OpenClaw.Connection;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public class GatewayTerminalLaunchCommandBuilderTests
+{
+    [Fact]
+    public void Build_WslWithWindowsTerminal_UsesExplicitTerminalPathAndPositionalArguments()
+    {
+        var access = GatewayHostAccessClassifier.Classify(new GatewayRecord
+        {
+            Id = "local",
+            Url = "ws://127.0.0.1:18789",
+            SetupManagedDistroName = "OpenClawGateway",
+        });
+
+        var command = GatewayTerminalLaunchCommandBuilder.Build(access, @"C:\Users\me\AppData\Local\Microsoft\WindowsApps\wt.exe");
+
+        Assert.Equal(@"C:\Users\me\AppData\Local\Microsoft\WindowsApps\wt.exe", command.FileName);
+        Assert.True(command.UsesWindowsTerminal);
+        Assert.Equal([
+            "new-tab",
+            "--title",
+            "OpenClaw Gateway (OpenClawGateway)",
+            "wsl.exe",
+            "-d",
+            "OpenClawGateway"
+        ], command.Arguments);
+    }
+
+    [Fact]
+    public void Build_WslWithoutWindowsTerminal_FallsBackToWslExe()
+    {
+        var access = GatewayHostAccessClassifier.Classify(new GatewayRecord
+        {
+            Id = "local",
+            Url = "ws://127.0.0.1:18789",
+            SetupManagedDistroName = "OpenClawGateway",
+        });
+
+        var command = GatewayTerminalLaunchCommandBuilder.Build(access, windowsTerminalPath: null);
+
+        Assert.Equal("wsl.exe", command.FileName);
+        Assert.False(command.UsesWindowsTerminal);
+        Assert.Equal(["-d", "OpenClawGateway"], command.Arguments);
+    }
+
+    [Fact]
+    public void Build_SshTerminal_UsesUserAtHostWithoutTunnelForwardingArguments()
+    {
+        var access = GatewayHostAccessClassifier.Classify(new GatewayRecord
+        {
+            Id = "ssh",
+            Url = "ws://127.0.0.1:18789",
+            SshTunnel = new SshTunnelConfig("alice", "gateway.example.test", 18789, 18790),
+        });
+
+        var command = GatewayTerminalLaunchCommandBuilder.Build(access, windowsTerminalPath: null);
+
+        Assert.Equal("ssh.exe", command.FileName);
+        Assert.Equal(["alice@gateway.example.test"], command.Arguments);
+        Assert.DoesNotContain("-N", command.Arguments);
+        Assert.DoesNotContain("-L", command.Arguments);
+        Assert.DoesNotContain("-p", command.Arguments);
+    }
+
+    [Fact]
+    public void Build_RejectsRecordsWithoutTerminalAccess()
+    {
+        var access = GatewayHostAccessClassifier.Classify(new GatewayRecord
+        {
+            Id = "remote",
+            Url = "wss://gateway.example.test",
+        });
+
+        Assert.Throws<InvalidOperationException>(() =>
+            GatewayTerminalLaunchCommandBuilder.Build(access, windowsTerminalPath: null));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -46,6 +46,9 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\OnboardingChatBootstrapper.cs" Link="Services\OnboardingChatBootstrapper.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\StartupSetupState.cs" Link="Services\StartupSetupState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SetupExistingGatewayClassifier.cs" Link="Services\SetupExistingGatewayClassifier.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\GatewayHostAccess.cs" Link="Services\GatewayHostAccess.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\GatewayTerminalLauncher.cs" Link="Services\GatewayTerminalLauncher.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\WslGatewayController.cs" Link="Services\WslGatewayController.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\WslCommandRunner.cs" Link="Services\WslCommandRunner.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\WslKeepAlivePolicy.cs" Link="Services\WslKeepAlivePolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\GatewayConnectorInterfaces.cs" Link="Services\GatewayConnectorInterfaces.cs" />

--- a/tests/OpenClaw.Tray.Tests/WslGatewayControllerTests.cs
+++ b/tests/OpenClaw.Tray.Tests/WslGatewayControllerTests.cs
@@ -1,0 +1,97 @@
+using OpenClaw.Shared;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public class WslGatewayControllerTests
+{
+    [Theory]
+    [InlineData(WslGatewayControlAction.Start, "start")]
+    [InlineData(WslGatewayControlAction.Stop, "stop")]
+    [InlineData(WslGatewayControlAction.Restart, "restart")]
+    public void Build_UsesBashLoginShellPathPrefixAndGatewayCommand(WslGatewayControlAction action, string verb)
+    {
+        var command = WslGatewayControlCommandBuilder.Build(action);
+
+        Assert.Equal(["bash", "-lc"], command.Take(2).ToArray());
+        Assert.Equal(
+            $"{WslGatewayControlCommandBuilder.OpenClawWslPathPrefix} && openclaw gateway {verb}",
+            command[2]);
+    }
+
+    [Fact]
+    public async Task RunAsync_InvokesGatewayCommandInsideRegisteredDistro()
+    {
+        var runner = new FakeWslCommandRunner
+        {
+            Distros = [new WslDistroInfo("OpenClawGateway", "Running", 2)],
+            Result = new WslCommandResult(0, "started", string.Empty),
+        };
+        var controller = new WslGatewayController(runner, NullLogger.Instance);
+
+        var result = await controller.RunAsync("OpenClawGateway", WslGatewayControlAction.Start);
+
+        Assert.True(result.Success);
+        Assert.Equal("OpenClawGateway", runner.LastDistroName);
+        Assert.Equal(WslGatewayControlCommandBuilder.Build(WslGatewayControlAction.Start), runner.LastDistroCommand);
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsFailure_WhenDistroIsNotRegistered()
+    {
+        var runner = new FakeWslCommandRunner
+        {
+            Distros = [new WslDistroInfo("OtherGateway", "Running", 2)],
+        };
+        var controller = new WslGatewayController(runner, NullLogger.Instance);
+
+        var result = await controller.RunAsync("OpenClawGateway", WslGatewayControlAction.Restart);
+
+        Assert.False(result.Success);
+        Assert.Equal(-1, result.ExitCode);
+        Assert.Null(runner.LastDistroCommand);
+        Assert.Contains("not registered", result.StandardError);
+    }
+
+    private sealed class FakeWslCommandRunner : IWslCommandRunner
+    {
+        public IReadOnlyList<WslDistroInfo> Distros { get; init; } = [];
+        public WslCommandResult Result { get; init; } = new(0, string.Empty, string.Empty);
+        public string? LastDistroName { get; private set; }
+        public IReadOnlyList<string>? LastDistroCommand { get; private set; }
+
+        public Task<WslCommandResult> RunAsync(
+            IReadOnlyList<string> arguments,
+            CancellationToken cancellationToken = default,
+            IReadOnlyDictionary<string, string>? environment = null)
+        {
+            return Task.FromResult(Result);
+        }
+
+        public Task<IReadOnlyList<WslDistroInfo>> ListDistrosAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Distros);
+        }
+
+        public Task<WslCommandResult> TerminateDistroAsync(string name, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Result);
+        }
+
+        public Task<WslCommandResult> UnregisterDistroAsync(string name, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Result);
+        }
+
+        public Task<WslCommandResult> RunInDistroAsync(
+            string name,
+            IReadOnlyList<string> command,
+            CancellationToken cancellationToken = default,
+            IReadOnlyDictionary<string, string>? environment = null)
+        {
+            LastDistroName = name;
+            LastDistroCommand = command;
+            return Task.FromResult(Result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add Connection page terminal access for setup-managed WSL gateways and SSH-tunneled gateway hosts
- Add WSL-only gateway Start, Stop, and Restart actions using `openclaw gateway` commands inside the managed distro
- Add pure classifier, terminal command, WSL controller tests, and staged UX polish from review feedback

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`