### PR TITLE
fix(pairing): reconnect after device approval

### DIFF
--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -159,7 +159,8 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
 
     protected override bool ShouldAutoReconnect()
     {
-        return !_pairingRequiredAwaitingApproval && !_authFailed;
+        // PairingRequired must stay visible, but approval only takes effect on a fresh socket.
+        return !_authFailed;
     }
 
     protected override void OnDisconnected()

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -367,6 +367,14 @@ public class OpenClawGatewayClientTests
 
         public string? GetPairingRequiredRequestId() => _client.PairingRequiredRequestId;
 
+        public bool ShouldAutoReconnectForTest()
+        {
+            var method = typeof(OpenClawGatewayClient).GetMethod(
+                "ShouldAutoReconnect",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            return (bool)method!.Invoke(_client, null)!;
+        }
+
         public string GetSignatureTokenMode()
         {
             var field = typeof(OpenClawGatewayClient).GetField(
@@ -1828,6 +1836,31 @@ public class OpenClawGatewayClientTests
         """);
 
         Assert.True(helper.GetPairingRequiredFlag());
+    }
+
+    [Fact]
+    public void HandleRequestError_PairingRequired_KeepsAutoReconnectEnabled()
+    {
+        var helper = new GatewayClientTestHelper();
+        helper.TrackPendingRequest("req-pairing-retry", "connect");
+
+        helper.ProcessRawMessage("""
+        {
+            "type": "res",
+            "id": "req-pairing-retry",
+            "ok": false,
+            "error": {
+                "message": "pairing required for this device",
+                "details": {
+                    "code": "PAIRING_REQUIRED",
+                    "requestId": "abc-123"
+                }
+            }
+        }
+        """);
+
+        Assert.True(helper.GetPairingRequiredFlag());
+        Assert.True(helper.ShouldAutoReconnectForTest());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- keep gateway auto-reconnect enabled while device pairing is awaiting approval
- preserve the PairingRequired state so the UI still shows approval guidance
- add a regression test for pairing-required reconnect eligibility

## Validation
- `git diff --check origin/master...HEAD`
- Windows crabbox: `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --logger "console;verbosity=minimal"` (2039 passed, 29 skipped)
- Windows crabbox: `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --logger "console;verbosity=minimal"` (870 passed)
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/master --parallel-tests "git diff --check origin/master...HEAD"` (clean)

## Notes
- Full `./build.ps1` was attempted on the clean Windows crabbox image, but that image lacks Node.js and the Windows 10 SDK. CI should cover the full WinUI build on the proper runner image.
