### PR TITLE
fix(pairing): bootstrap setup codes as node first

### DIFF
--- a/src/OpenClaw.Connection/GatewayClientFactory.cs
+++ b/src/OpenClaw.Connection/GatewayClientFactory.cs
@@ -19,6 +19,7 @@ public sealed class GatewayClientFactory : IGatewayClientFactory
             credential.Token,
             logger,
             tokenIsBootstrapToken: credential.IsBootstrapToken,
+            bootstrapPairAsNode: credential.IsBootstrapToken,
             identityPath: identityPath);
 
         return new GatewayClientLifecycleAdapter(client);

--- a/tests/OpenClaw.Connection.Tests/GatewayClientFactoryTests.cs
+++ b/tests/OpenClaw.Connection.Tests/GatewayClientFactoryTests.cs
@@ -1,0 +1,62 @@
+using System.Reflection;
+using OpenClaw.Shared;
+using Xunit;
+
+namespace OpenClaw.Connection.Tests;
+
+public sealed class GatewayClientFactoryTests
+{
+    [Fact]
+    public void Create_BootstrapCredential_PairsAsNode()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "openclaw-gateway-factory-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            using var lifecycle = new GatewayClientFactory().Create(
+                "ws://127.0.0.1:18789",
+                new GatewayCredential("bootstrap-token", IsBootstrapToken: true, Source: "test"),
+                tempDir,
+                NullLogger.Instance);
+
+            Assert.Equal("node", GetConnectRole(lifecycle.DataClient));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Create_SharedCredential_PairsAsOperator()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "openclaw-gateway-factory-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            using var lifecycle = new GatewayClientFactory().Create(
+                "ws://127.0.0.1:18789",
+                new GatewayCredential("shared-token", IsBootstrapToken: false, Source: "test"),
+                tempDir,
+                NullLogger.Instance);
+
+            Assert.Equal("operator", GetConnectRole(lifecycle.DataClient));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private static string GetConnectRole(OpenClawGatewayClient client)
+    {
+        var method = typeof(OpenClawGatewayClient).GetMethod(
+            "GetConnectRole",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+        return Assert.IsType<string>(method.Invoke(client, null));
+    }
+}


### PR DESCRIPTION
## Summary
- make setup-code bootstrap gateway clients pair as `node` first so the gateway can apply the native QR/setup bootstrap profile
- preserve shared-token startup as normal operator pairing
- add regression coverage for bootstrap vs shared credential role selection

## Pond evidence so far
- `v0.6.0-alpha.11` signed x64 installer verified on Azure Windows desktop crabbox:
  - installer SHA-256 matched release digest
  - installer Authenticode status: `Valid`
  - installed EXE Authenticode status: `Valid`
  - product version: `0.6.0-alpha.11+Branch.master.Sha.7f19e8109358a061345d9c6ca071bbbf76190704.7f19e8109358a061345d9c6ca071bbbf76190704`
- fresh setup-code bootstrap on the signed alpha.11 app reproduced the bug this PR fixes:
  - tray connected with `record.BootstrapToken`
  - client requested `operator`
  - gateway returned `PAIRING_REQUIRED`
  - gateway showed a pending operator device from the Windows desktop box instead of an auto-paired node

## Validation
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/master --parallel-tests "git diff --check"`

## Not run locally
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`

The local macOS worktree has no `dotnet`; the existing Windows crabbox source-validation image currently lacks the full Windows build prerequisites and its SSH path wedged during fresh sync. CI should cover the full Windows build/test gate; after that I’ll cut the next alpha and rerun the pond install/pairing/exec-approval proof.
