### PR TITLE
fix(pairing): allow node bootstrap startup

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Services/StartupSetupState.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/StartupSetupState.cs
@@ -79,6 +79,12 @@ internal static class StartupSetupState
         return HasStoredNodeDeviceToken(dataPath);
     }
 
+    internal static bool HasBootstrapGatewayRecord(GatewayRegistry? registry)
+    {
+        var active = registry?.GetActive();
+        return !string.IsNullOrWhiteSpace(active?.BootstrapToken);
+    }
+
     public static bool RequiresSetup(SettingsManager settings, string dataPath) =>
         RequiresSetup(settings, dataPath, registry: null);
 
@@ -91,7 +97,8 @@ internal static class StartupSetupState
 
         if (settings.EnableNodeMode)
         {
-            return !HasStoredNodeDeviceToken(dataPath);
+            return !HasStoredNodeDeviceToken(dataPath)
+                && !HasBootstrapGatewayRecord(registry);
         }
 
         if (registry is not null

--- a/tests/OpenClaw.Tray.Tests/StartupSetupStateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/StartupSetupStateTests.cs
@@ -230,6 +230,40 @@ public class StartupSetupStateTests
     }
 
     [Fact]
+    public void RequiresSetup_ReturnsFalse_WhenNodeModeHasActiveBootstrapGateway()
+    {
+        using var temp = TempSettings.Create();
+        var settings = new SettingsManager(temp.Path) { EnableNodeMode = true };
+        var registry = new GatewayRegistry(temp.Path);
+        registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "bootstrap-gateway",
+            Url = "wss://remote.example.com",
+            BootstrapToken = "bootstrap-token"
+        });
+        registry.SetActive("bootstrap-gateway");
+
+        Assert.False(StartupSetupState.RequiresSetup(settings, temp.Path, registry));
+        Assert.False(StartupSetupState.CanStartNodeGateway(settings, temp.Path));
+    }
+
+    [Fact]
+    public void RequiresSetup_ReturnsTrue_WhenNodeModeHasInactiveBootstrapGateway()
+    {
+        using var temp = TempSettings.Create();
+        var settings = new SettingsManager(temp.Path) { EnableNodeMode = true };
+        var registry = new GatewayRegistry(temp.Path);
+        registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "inactive-bootstrap-gateway",
+            Url = "wss://remote.example.com",
+            BootstrapToken = "bootstrap-token"
+        });
+
+        Assert.True(StartupSetupState.RequiresSetup(settings, temp.Path, registry));
+    }
+
+    [Fact]
     public async Task ClassifyAsync_ReturnsAppOwnedLocalWsl_WhenDistroAndLocalRegistryEvidenceExist()
     {
         using var temp = TempSettings.Create();


### PR DESCRIPTION
## Summary
- let node-mode startup proceed when the active gateway registry record still has a bootstrap setup-code token
- keep shared/operator-token records from bypassing node setup without a stored node token
- add startup setup tests for active vs inactive bootstrap gateway records

## Validation
- `git diff --check`
- not run locally: `./build.ps1` / `dotnet test` because this mac worktree has no `pwsh` or `dotnet`; draft PR CI is the validation surface

## Context
Crabbox alpha.12 install/signing verified, but fresh setup-code node bootstrap created a per-gateway identity file without exchanging/storing a node token. Startup was entering onboarding first because node mode ignored the registry bootstrap token, and onboarding could reset node mode before the connection manager connected.
