### PR TITLE
fix(pairing): complete node bootstrap handoff

### DIFF
--- a/src/OpenClaw.Connection/ConnectionStateMachine.cs
+++ b/src/OpenClaw.Connection/ConnectionStateMachine.cs
@@ -49,7 +49,9 @@ internal sealed class ConnectionStateMachine
                 _operatorState is RoleConnectionState.Connecting or RoleConnectionState.Error,
 
             ConnectionTrigger.HandshakeSucceeded =>
-                _operatorState is RoleConnectionState.Connecting or RoleConnectionState.Error,
+                _operatorState is RoleConnectionState.Connecting
+                    or RoleConnectionState.PairingRequired
+                    or RoleConnectionState.Error,
 
             ConnectionTrigger.PairingPending =>
                 _operatorState is RoleConnectionState.Connecting or RoleConnectionState.Connected or RoleConnectionState.Error,

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -1549,9 +1549,9 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
                 }
             }
 
-            var newDeviceToken = _bootstrapPairAsNode
-                ? TryGetHandshakeDeviceTokenCore(payload, OperatorRole, allowDirectDeviceTokenFallback: false)
-                : TryGetHandshakeDeviceTokenCore(payload, preferredRole: null);
+            var newDeviceToken = !_bootstrapPairAsNode
+                ? TryGetHandshakeDeviceTokenCore(payload, preferredRole: null)
+                : TryGetHandshakeDeviceTokenCore(payload, OperatorRole, allowDirectDeviceTokenFallback: false);
             if (!string.IsNullOrWhiteSpace(newDeviceToken))
             {
                 var deviceTokenScopes = _bootstrapPairAsNode
@@ -2170,24 +2170,26 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
             return null;
         }
 
-        if (!string.IsNullOrWhiteSpace(preferredRole) &&
-            authPayload.TryGetProperty("deviceTokens", out var deviceTokens) &&
-            deviceTokens.ValueKind == JsonValueKind.Array)
+        if (!string.IsNullOrWhiteSpace(preferredRole))
         {
-            foreach (var entry in deviceTokens.EnumerateArray())
+            if (authPayload.TryGetProperty("deviceTokens", out var deviceTokens) &&
+                deviceTokens.ValueKind == JsonValueKind.Array)
             {
-                if (entry.ValueKind != JsonValueKind.Object)
-                    continue;
-
-                if (entry.TryGetProperty("role", out var role) &&
-                    role.ValueKind == JsonValueKind.String &&
-                    string.Equals(role.GetString(), preferredRole, StringComparison.OrdinalIgnoreCase) &&
-                    entry.TryGetProperty("deviceToken", out var roleToken) &&
-                    roleToken.ValueKind == JsonValueKind.String)
+                foreach (var entry in deviceTokens.EnumerateArray())
                 {
-                    var roleTokenValue = roleToken.GetString();
-                    if (!string.IsNullOrWhiteSpace(roleTokenValue))
-                        return roleTokenValue;
+                    if (entry.ValueKind != JsonValueKind.Object)
+                        continue;
+
+                    if (entry.TryGetProperty("role", out var role) &&
+                        role.ValueKind == JsonValueKind.String &&
+                        string.Equals(role.GetString(), preferredRole, StringComparison.OrdinalIgnoreCase) &&
+                        entry.TryGetProperty("deviceToken", out var roleToken) &&
+                        roleToken.ValueKind == JsonValueKind.String)
+                    {
+                        var roleTokenValue = roleToken.GetString();
+                        if (!string.IsNullOrWhiteSpace(roleTokenValue))
+                            return roleTokenValue;
+                    }
                 }
             }
 
@@ -2218,22 +2220,24 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
             return null;
         }
 
-        if (!string.IsNullOrWhiteSpace(preferredRole) &&
-            authPayload.TryGetProperty("deviceTokens", out var deviceTokens) &&
-            deviceTokens.ValueKind == JsonValueKind.Array)
+        if (!string.IsNullOrWhiteSpace(preferredRole))
         {
-            foreach (var entry in deviceTokens.EnumerateArray())
+            if (authPayload.TryGetProperty("deviceTokens", out var deviceTokens) &&
+                deviceTokens.ValueKind == JsonValueKind.Array)
             {
-                if (entry.ValueKind != JsonValueKind.Object)
-                    continue;
-
-                if (entry.TryGetProperty("role", out var role) &&
-                    role.ValueKind == JsonValueKind.String &&
-                    string.Equals(role.GetString(), preferredRole, StringComparison.OrdinalIgnoreCase))
+                foreach (var entry in deviceTokens.EnumerateArray())
                 {
-                    return entry.TryGetProperty("scopes", out var roleScopes) && roleScopes.ValueKind == JsonValueKind.Array
-                        ? ReadStringArray(roleScopes)
-                        : [];
+                    if (entry.ValueKind != JsonValueKind.Object)
+                        continue;
+
+                    if (entry.TryGetProperty("role", out var role) &&
+                        role.ValueKind == JsonValueKind.String &&
+                        string.Equals(role.GetString(), preferredRole, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return entry.TryGetProperty("scopes", out var roleScopes) && roleScopes.ValueKind == JsonValueKind.Array
+                            ? ReadStringArray(roleScopes)
+                            : [];
+                    }
                 }
             }
 

--- a/tests/OpenClaw.Connection.Tests/ConnectionStateMachineTests.cs
+++ b/tests/OpenClaw.Connection.Tests/ConnectionStateMachineTests.cs
@@ -91,6 +91,18 @@ public class ConnectionStateMachineTests
     }
 
     [Fact]
+    public void PairingRequired_HandshakeSucceeded_TransitionsOperatorToConnected()
+    {
+        _sm.TryTransition(ConnectionTrigger.ConnectRequested);
+        _sm.TryTransition(ConnectionTrigger.PairingPending);
+
+        Assert.True(_sm.TryTransition(ConnectionTrigger.HandshakeSucceeded));
+        Assert.Equal(OverallConnectionState.Ready, _sm.Current.OverallState);
+        Assert.Equal(RoleConnectionState.Connected, _sm.Current.OperatorState);
+        Assert.False(_sm.Current.OperatorPairingRequired);
+    }
+
+    [Fact]
     public void PairingRequired_PairingRejected_TransitionsToError()
     {
         _sm.TryTransition(ConnectionTrigger.ConnectRequested);

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.Json;
 using Xunit;
@@ -16,14 +17,19 @@ public class OpenClawGatewayClientTests
 
         public OpenClawGatewayClient Client => _client;
 
-        public GatewayClientTestHelper(bool tokenIsBootstrapToken = false, bool bootstrapPairAsNode = false, string gatewayUrl = "ws://localhost:18789")
+        public GatewayClientTestHelper(
+            bool tokenIsBootstrapToken = false,
+            bool bootstrapPairAsNode = false,
+            string gatewayUrl = "ws://localhost:18789",
+            string? identityPath = null)
         {
             _client = new OpenClawGatewayClient(
                 gatewayUrl,
                 "test-token",
                 new TestLogger(),
                 tokenIsBootstrapToken,
-                bootstrapPairAsNode);
+                bootstrapPairAsNode,
+                identityPath);
         }
 
         public GatewayClientTestHelper(IOpenClawLogger logger)
@@ -343,6 +349,24 @@ public class OpenClawGatewayClientTests
             SetPrivateField("_connectAuthToken", token ?? "test-token");
         }
 
+        public string? GetStoredOperatorDeviceToken()
+        {
+            var identityField = typeof(OpenClawGatewayClient).GetField(
+                "_deviceIdentity",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var identity = identityField!.GetValue(_client)!;
+            return (string?)identity.GetType().GetProperty("DeviceToken")!.GetValue(identity);
+        }
+
+        public string? GetStoredNodeDeviceToken()
+        {
+            var identityField = typeof(OpenClawGatewayClient).GetField(
+                "_deviceIdentity",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var identity = identityField!.GetValue(_client)!;
+            return (string?)identity.GetType().GetProperty("NodeDeviceToken")!.GetValue(identity);
+        }
+
         public string GetFallbackDeviceId()
         {
             var identityField = typeof(OpenClawGatewayClient).GetField(
@@ -411,6 +435,9 @@ public class OpenClawGatewayClientTests
             return events;
         }
     }
+
+    private static string CreateTempIdentityPath() =>
+        Path.Combine(Path.GetTempPath(), "OpenClawGatewayClientTests", Guid.NewGuid().ToString("N"));
 
     [Fact]
     public void OperatorConnect_FreshDevice_RequestsBootstrapHandoffScopes()
@@ -536,7 +563,10 @@ public class OpenClawGatewayClientTests
     [Fact]
     public void BootstrapNodeHandoff_FreshDevice_RequestsNodeRoleWithoutScopes()
     {
-        var helper = new GatewayClientTestHelper(tokenIsBootstrapToken: true, bootstrapPairAsNode: true);
+        var helper = new GatewayClientTestHelper(
+            tokenIsBootstrapToken: true,
+            bootstrapPairAsNode: true,
+            identityPath: CreateTempIdentityPath());
         helper.SetDeviceTokenForTest(null);
 
         var auth = helper.BuildAuthPayload();
@@ -546,6 +576,69 @@ public class OpenClawGatewayClientTests
         Assert.Equal("test-token", auth["bootstrapToken"]);
         Assert.False(auth.ContainsKey("token"));
         Assert.False(auth.ContainsKey("deviceToken"));
+    }
+
+    [Fact]
+    public void BootstrapNodeHandoff_HelloOkWithNodeRole_DoesNotStorePrimaryNodeTokenAsOperator()
+    {
+        var helper = new GatewayClientTestHelper(
+            tokenIsBootstrapToken: true,
+            bootstrapPairAsNode: true,
+            identityPath: CreateTempIdentityPath());
+        helper.SetDeviceTokenForTest(null);
+
+        helper.ProcessRawMessage("""
+        {
+          "type": "res",
+          "id": "req-hello-node",
+          "payload": {
+            "type": "hello-ok",
+            "auth": {
+              "deviceToken": "node-token",
+              "role": "node",
+              "scopes": []
+            }
+          }
+        }
+        """);
+
+        Assert.Equal("node-token", helper.GetStoredNodeDeviceToken());
+        Assert.Null(helper.GetStoredOperatorDeviceToken());
+    }
+
+    [Fact]
+    public void BootstrapNodeHandoff_HelloOkWithOperatorHandoffToken_StoresOperatorToken()
+    {
+        var helper = new GatewayClientTestHelper(
+            tokenIsBootstrapToken: true,
+            bootstrapPairAsNode: true,
+            identityPath: CreateTempIdentityPath());
+        helper.SetDeviceTokenForTest(null);
+
+        helper.ProcessRawMessage("""
+        {
+          "type": "res",
+          "id": "req-hello-node",
+          "payload": {
+            "type": "hello-ok",
+            "auth": {
+              "deviceToken": "node-token",
+              "role": "node",
+              "scopes": [],
+              "deviceTokens": [
+                {
+                  "deviceToken": "operator-token",
+                  "role": "operator",
+                  "scopes": ["operator.read"]
+                }
+              ]
+            }
+          }
+        }
+        """);
+
+        Assert.Equal("node-token", helper.GetStoredNodeDeviceToken());
+        Assert.Equal("operator-token", helper.GetStoredOperatorDeviceToken());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- allow a post-approval `hello-ok` to move the connection state out of `PairingRequired`
- avoid storing a node bootstrap handoff token as the operator `DeviceToken`
- add regression coverage for the state transition and node-role token persistence

## Validation
- Local `dotnet test` blocked: `dotnet` is not installed on this machine
- Crabbox alpha.13 repro: signed install and node pairing reached pending/approval on desktop2; restart exposed operator token mismatch before this fix
- CI will run required Windows build/test gates on this draft PR
