### PR TITLE
refactor: extract StartupInputConfigurator from App.xaml.cs

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -199,19 +199,10 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             "OpenClawTray");
     private static readonly string CrashLogPath = Path.Combine(DataPath, "crash.log");
     private static readonly AppRunMarker s_runMarker = new(Path.Combine(DataPath, "run.marker"));
-    private const string DisableMouseInPointerEnv = "OPENCLAW_DISABLE_MOUSE_IN_POINTER";
-
-    [DllImport("user32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool EnableMouseInPointer([MarshalAs(UnmanagedType.Bool)] bool fEnable);
-
-    [DllImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool IsMouseInPointerEnabled();
 
     public App()
     {
-        ConfigureMouseInPointerInput();
+        StartupInputConfigurator.Configure();
 
         // Language override for localization testing (e.g., OPENCLAW_LANGUAGE=zh-CN)
         var langOverride = Environment.GetEnvironmentVariable("OPENCLAW_LANGUAGE");
@@ -236,56 +227,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
         AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
     }
-
-    private static void ConfigureMouseInPointerInput()
-    {
-        if (IsTruthyEnvVar(Environment.GetEnvironmentVariable(DisableMouseInPointerEnv)))
-        {
-            Logger.Warn($"[Input] Mouse-in-pointer startup configuration disabled by {DisableMouseInPointerEnv}=1.");
-            return;
-        }
-
-        try
-        {
-            var before = IsMouseInPointerEnabled();
-            if (before)
-            {
-                Logger.Info("[Input] Mouse-in-pointer was already enabled before WinUI initialization.");
-                return;
-            }
-
-            var enabled = EnableMouseInPointer(true);
-            var error = enabled ? 0 : Marshal.GetLastWin32Error();
-            var after = IsMouseInPointerEnabled();
-            if (enabled && after)
-            {
-                Logger.Info("[Input] Enabled mouse-in-pointer before WinUI initialization for precision touchpad scrolling.");
-            }
-            else
-            {
-                Logger.Warn($"[Input] EnableMouseInPointer(true) did not enable mouse-in-pointer. Before={before}, After={after}, LastError={error}.");
-            }
-        }
-        catch (DllNotFoundException ex)
-        {
-            Logger.Warn($"[Input] EnableMouseInPointer startup configuration failed: {ex.Message}");
-        }
-        catch (EntryPointNotFoundException ex)
-        {
-            Logger.Warn($"[Input] EnableMouseInPointer startup configuration failed: {ex.Message}");
-        }
-        catch (SEHException ex)
-        {
-            Logger.Warn($"[Input] EnableMouseInPointer startup configuration failed: {ex.Message}");
-        }
-    }
-
-    private static bool IsTruthyEnvVar(string? value) =>
-        value is not null &&
-        (string.Equals(value, "1", StringComparison.OrdinalIgnoreCase) ||
-         string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
-         string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase) ||
-         string.Equals(value, "on", StringComparison.OrdinalIgnoreCase));
 
     private void OnUnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
     {

--- a/src/OpenClaw.Tray.WinUI/Services/StartupInputConfigurator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/StartupInputConfigurator.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace OpenClawTray.Services;
+
+/// <summary>
+/// Configures process-wide mouse-in-pointer input before WinUI initialization
+/// so precision touchpad scrolling works. Best-effort; failures are logged and
+/// never propagate. Must run before <c>InitializeComponent()</c>.
+/// </summary>
+internal static class StartupInputConfigurator
+{
+    private const string DisableMouseInPointerEnv = "OPENCLAW_DISABLE_MOUSE_IN_POINTER";
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool EnableMouseInPointer([MarshalAs(UnmanagedType.Bool)] bool fEnable);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsMouseInPointerEnabled();
+
+    public static void Configure()
+    {
+        if (IsTruthyEnvVar(Environment.GetEnvironmentVariable(DisableMouseInPointerEnv)))
+        {
+            Logger.Warn($"[Input] Mouse-in-pointer startup configuration disabled by {DisableMouseInPointerEnv}=1.");
+            return;
+        }
+
+        try
+        {
+            var before = IsMouseInPointerEnabled();
+            if (before)
+            {
+                Logger.Info("[Input] Mouse-in-pointer was already enabled before WinUI initialization.");
+                return;
+            }
+
+            var enabled = EnableMouseInPointer(true);
+            var error = enabled ? 0 : Marshal.GetLastWin32Error();
+            var after = IsMouseInPointerEnabled();
+            if (enabled && after)
+            {
+                Logger.Info("[Input] Enabled mouse-in-pointer before WinUI initialization for precision touchpad scrolling.");
+            }
+            else
+            {
+                Logger.Warn($"[Input] EnableMouseInPointer(true) did not enable mouse-in-pointer. Before={before}, After={after}, LastError={error}.");
+            }
+        }
+        catch (DllNotFoundException ex)
+        {
+            Logger.Warn($"[Input] EnableMouseInPointer startup configuration failed: {ex.Message}");
+        }
+        catch (EntryPointNotFoundException ex)
+        {
+            Logger.Warn($"[Input] EnableMouseInPointer startup configuration failed: {ex.Message}");
+        }
+        catch (SEHException ex)
+        {
+            Logger.Warn($"[Input] EnableMouseInPointer startup configuration failed: {ex.Message}");
+        }
+    }
+
+    private static bool IsTruthyEnvVar(string? value) =>
+        value is not null &&
+        (string.Equals(value, "1", StringComparison.OrdinalIgnoreCase) ||
+         string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
+         string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase) ||
+         string.Equals(value, "on", StringComparison.OrdinalIgnoreCase));
+}


### PR DESCRIPTION
## Summary

`App.xaml.cs` configured mouse-in-pointer input inline in its constructor:
a P/Invoke pair, an env-var opt-out, and the enable logic that turns on
precision touchpad scrolling before WinUI starts. This moves that concern
into a dedicated `StartupInputConfigurator`.

## What changed

- New `Services/StartupInputConfigurator.cs` — holds the mouse-in-pointer
  startup configuration: the `EnableMouseInPointer` / `IsMouseInPointerEnabled`
  P/Invokes, the `OPENCLAW_DISABLE_MOUSE_IN_POINTER` opt-out, the truthy-env
  parsing, and the enable-and-verify logic.
- `App.xaml.cs` — the constructor now calls `StartupInputConfigurator.Configure()`
  in the same spot, before `InitializeComponent()`; the original private methods
  and P/Invoke declarations are removed.

Pure extraction. The class is static with no App state: the moved code read
no instance fields, so nothing is passed in. Logging strings, guard order,
captured values, and caught exceptions (`DllNotFoundException`,
`EntryPointNotFoundException`, `SEHException`) are identical to the original.

## Testing

- `dotnet build src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj -r win-x64`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj`

No new tests: this is a behavior-preserving move of process-wide input setup
that was not unit-tested before and is not behavior-changed here.

## Proof

Manual run after the extraction. The configurator fires through the new type
on startup, before WinUI initialization, identical to the pre-refactor path:

<img width="1115" height="628" alt="Captura de pantalla 2026-05-31 001546" src="https://github.com/user-attachments/assets/52ae7cf2-36df-409d-a7f9-7cec444f8ac9" />



```

[2026-05-31 00:14:32.053] [INFO] [Input] Enabled mouse-in-pointer before WinUI initialization for precision touchpad scrolling.
```

## Notes

No behavior change is intended. The seam (`Configure()` before
`InitializeComponent()`) and the enable-and-verify logic are preserved exactly.

Addresses part of #554.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
