### PR TITLE
refactor: extract AppCrashLogger from App.xaml.cs

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -197,7 +197,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             Environment.GetEnvironmentVariable("OPENCLAW_TRAY_APPDATA_DIR")
                 ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
             "OpenClawTray");
-    private static readonly string CrashLogPath = Path.Combine(DataPath, "crash.log");
+    private readonly AppCrashLogger _crashLogger = new(Path.Combine(DataPath, "crash.log"));
     private static readonly AppRunMarker s_runMarker = new(Path.Combine(DataPath, "run.marker"));
     private const string DisableMouseInPointerEnv = "OPENCLAW_DISABLE_MOUSE_IN_POINTER";
 
@@ -289,18 +289,18 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
     private void OnUnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
     {
-        LogCrash("UnhandledException", e.Exception);
+        _crashLogger.Log("UnhandledException", e.Exception);
         e.Handled = true; // Try to prevent crash
     }
 
     private void OnDomainUnhandledException(object sender, System.UnhandledExceptionEventArgs e)
     {
-        LogCrash("DomainUnhandledException", e.ExceptionObject as Exception);
+        _crashLogger.Log("DomainUnhandledException", e.ExceptionObject as Exception);
     }
 
     private void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
     {
-        LogCrash("UnobservedTaskException", e.Exception);
+        _crashLogger.Log("UnobservedTaskException", e.Exception);
         e.SetObserved(); // Prevent crash
     }
     
@@ -312,33 +312,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             Logger.Info($"Process exiting (ExitCode={Environment.ExitCode})");
         }
         catch { }
-    }
-
-    private static void LogCrash(string source, Exception? ex)
-    {
-        try
-        {
-            var dir = Path.GetDirectoryName(CrashLogPath);
-            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
-                Directory.CreateDirectory(dir);
-
-            var message = $"\n[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] {source}\n{ex}\n";
-            File.AppendAllText(CrashLogPath, message);
-        }
-        catch { /* Can't log the crash logger crash */ }
-        
-        try
-        {
-            if (ex != null)
-            {
-                Logger.Error($"CRASH {source}: {ex}");
-            }
-            else
-            {
-                Logger.Error($"CRASH {source}");
-            }
-        }
-        catch { /* Ignore logging failures */ }
     }
 
     private void OnUiThread(Microsoft.UI.Dispatching.DispatcherQueueHandler action) => _dispatcherQueue?.TryEnqueue(action);
@@ -871,7 +844,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         }
         catch (Exception ex)
         {
-            LogCrash("ShowTrayMenuPopup", ex);
+            _crashLogger.Log("ShowTrayMenuPopup", ex);
             Logger.Error($"Failed to show tray menu: {ex.Message}");
         }
     }

--- a/src/OpenClaw.Tray.WinUI/Services/AppCrashLogger.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AppCrashLogger.cs
@@ -1,0 +1,40 @@
+namespace OpenClawTray.Services;
+
+/// <summary>
+/// Writes crash details to a log file and the application logger. Hooked from the WinUI,
+/// CLR domain, and TaskScheduler unhandled-exception events, which may fire on the UI
+/// thread or background threads.
+/// </summary>
+internal sealed class AppCrashLogger
+{
+    private readonly string _path;
+
+    public AppCrashLogger(string path) => _path = path;
+
+    public void Log(string source, Exception? ex)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_path);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            var message = $"\n[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] {source}\n{ex}\n";
+            File.AppendAllText(_path, message);
+        }
+        catch { /* Can't log the crash logger crash */ }
+
+        try
+        {
+            if (ex != null)
+            {
+                Logger.Error($"CRASH {source}: {ex}");
+            }
+            else
+            {
+                Logger.Error($"CRASH {source}");
+            }
+        }
+        catch { /* Ignore logging failures */ }
+    }
+}


### PR DESCRIPTION
## Summary
Extract the crash-logging sink out of `App.xaml.cs` into a small dedicated
`AppCrashLogger`, mirroring the existing `AppRunMarker`. Pure refactor, no
behavior change.

## What changed
- New `Services/AppCrashLogger.cs`: takes the crash-log path in its constructor
  and exposes `Log(string source, Exception? ex)` — the exact body of the former
  static `LogCrash` (append to `crash.log` + `Logger.Error`).
- `App.xaml.cs`: removed the static `CrashLogPath` field and the static
  `LogCrash` method; added a `_crashLogger` field. The three unhandled-exception
  handlers and the `ShowTrayMenuPopup` catch now delegate to it.

## Testing
- `dotnet build` clean (0 warnings, 0 errors).
- Tray test suite green (872 tests).

## Proof
Forced a crash at runtime (a temporary throw on a background thread, **not part
of this change**) to exercise the extracted logger through
`OnDomainUnhandledException`. `crash.log` received the expected entry:

<img width="1115" height="628" alt="Captura de pantalla 2026-05-31 011319" src="https://github.com/user-attachments/assets/e61fdd45-d454-43dc-8d40-a0f957dd795c" />

```
[2026-05-31 01:12:38.464] DomainUnhandledException
System.InvalidOperationException: ProofCrash #554
```
(screenshot below)

## Notes
Behavior is byte-for-byte identical: same timestamp format, same append mode,
same two-stage exception swallowing, same `Logger.Error` calls. No locking added
(the original had none). `OnProcessExit` / `s_runMarker` are untouched.

Addresses part of #554.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
