### PR TITLE
Fix chat session routing from Sessions page and toast notifications

### DIFF
--- a/src/OpenClaw.Shared/Models.cs
+++ b/src/OpenClaw.Shared/Models.cs
@@ -106,6 +106,13 @@ public class OpenClawNotification
     public string? Agent { get; set; }     // agent name/identifier
     public string? Intent { get; set; }    // normalized intent (reminder, build, alert)
     public string[]? Tags { get; set; }    // free-form routing tags
+
+    /// <summary>
+    /// The session key associated with this notification (e.g. the chat session
+    /// that produced an assistant response). Used by toast activation to open
+    /// the specific session instead of the default/main session.
+    /// </summary>
+    public string? SessionKey { get; set; }
 }
 
 /// <summary>

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -3010,7 +3010,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
                     // HIGH 4: log shape only — content previously
                     // surfaced in the operator log.
                     _logger.Info($"Assistant response: role={role} state={state} len={text.Length}");
-                    EmitChatNotification(text);
+                    EmitChatNotification(text, sessionKey);
                 }
             }
         }
@@ -3030,7 +3030,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
                 {
                     // HIGH 4: log shape only.
                     _logger.Info($"Assistant response (legacy): role={role} state={state} len={text.Length}");
-                    EmitChatNotification(text);
+                    EmitChatNotification(text, sessionKey);
                 }
             }
         }
@@ -3170,13 +3170,14 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
         }
     }
 
-    private void EmitChatNotification(string text)
+    private void EmitChatNotification(string text, string? sessionKey = null)
     {
         var displayText = text.Length > 200 ? text[..200] + "…" : text;
         var notification = new OpenClawNotification
         {
             Message = displayText,
-            IsChat = true
+            IsChat = true,
+            SessionKey = sessionKey
         };
         var (title, type) = _categorizer.Classify(notification, _userRules);
         notification.Title = title;

--- a/src/OpenClaw.Tray.WinUI/App.ToastActivation.cs
+++ b/src/OpenClaw.Tray.WinUI/App.ToastActivation.cs
@@ -28,7 +28,7 @@ public partial class App
                 },
                 OpenDashboard = () => OpenDashboard(),
                 OpenSettings = ShowSettings,
-                OpenChat = ShowWebChat,
+                OpenChat = sessionKey => ShowWebChat(sessionKey),
                 OpenActivity = () => ShowHub("channels"),
                 CopyPairingCommand = command =>
                 {

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -64,6 +64,13 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     /// <summary>The full device ID of the local node service (if running).</summary>
     internal string? NodeFullDeviceId => _nodeService?.FullDeviceId;
 
+    /// <summary>
+    /// Session key that the chat surface should select on its next mount.
+    /// Used when the user clicks a session from SessionsPage or a notification
+    /// while the HubWindow may not yet exist. Consumed (cleared) by ChatPage.
+    /// </summary>
+    public string? PendingChatSessionKey { get; set; }
+
     public OpenClawTray.Chat.OpenClawChatDataProvider? ChatProvider => _chatCoordinator?.Provider;
 
     /// <summary>
@@ -2460,10 +2467,15 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
             if (notification.IsChat)
             {
-                builder.AddArgument("action", "open_chat")
-                       .AddButton(new ToastButton()
-                           .SetContent("Open Chat")
-                           .AddArgument("action", "open_chat"));
+                builder.AddArgument("action", "open_chat");
+                if (!string.IsNullOrEmpty(notification.SessionKey))
+                {
+                    builder.AddArgument("sessionKey", notification.SessionKey);
+                }
+                builder.AddButton(new ToastButton()
+                    .SetContent("Open Chat")
+                    .AddArgument("action", "open_chat")
+                    .AddArgument("sessionKey", notification.SessionKey ?? ""));
             }
 
             _toastService!.ShowToast(builder);
@@ -2869,7 +2881,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         }
     }
 
-    private void ShowWebChat()
+    private void ShowWebChat(string? sessionKey = null)
     {
         if (_settings == null) return;
         if (!TryResolveChatCredentials(out _, out _, out _, out var isBootstrapToken))
@@ -2886,6 +2898,17 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 "Chat",
                 "Gateway pairing is not complete");
             return;
+        }
+
+        // Stash the session key on both App (fallback when HubWindow doesn't exist)
+        // and HubWindow (existing path) so ChatPage can pick it up after navigation.
+        if (!string.IsNullOrEmpty(sessionKey))
+        {
+            PendingChatSessionKey = sessionKey;
+            if (_hubWindow != null)
+            {
+                _hubWindow.PendingChatSessionKey = sessionKey;
+            }
         }
 
         ShowHub("chat");
@@ -3550,7 +3573,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             CopyActivitySummary = _diagnosticsClipboard!.CopyActivitySummary,
             CopyExtensibilitySummary = _diagnosticsClipboard!.CopyExtensibilitySummary,
             RestartSshTunnel = RestartSshTunnel,
-            OpenChat = ShowWebChat,
+            OpenChat = () => ShowWebChat(),
             OpenCommandCenter = ShowStatusDetail,
             OpenTrayMenu = ShowTrayMenuPopup,
             OpenActivityStream = ShowActivityStream,

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -2910,6 +2910,14 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 _hubWindow.PendingChatSessionKey = sessionKey;
             }
         }
+        else
+        {
+            PendingChatSessionKey = null;
+            if (_hubWindow != null)
+            {
+                _hubWindow.PendingChatSessionKey = null;
+            }
+        }
 
         ShowHub("chat");
     }

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -423,16 +423,15 @@ public sealed partial class ChatPage : Page
                 return;
             }
 
-            if (!GatewayChatHelper.TryBuildChatUrl(credential.GatewayUrl, credential.Token, out var chatUrl, out var errorMessage, _pendingWebViewSessionKey))
+            if (!GatewayChatHelper.TryBuildChatUrl(credential.GatewayUrl, credential.Token, out var chatUrl, out var errorMessage))
             {
                 PlaceholderPanel.Visibility = Visibility.Collapsed;
                 ErrorPanel.Visibility = Visibility.Visible;
                 ErrorText.Text = errorMessage;
                 return;
             }
-
             _chatUrl = chatUrl;
-            _pendingWebViewSessionKey = null;
+            _chatUrl = chatUrl;
 
             PlaceholderPanel.Visibility = Visibility.Collapsed;
             ErrorPanel.Visibility = Visibility.Collapsed;
@@ -541,7 +540,8 @@ public sealed partial class ChatPage : Page
             _navigationStarted = true;
             ChatPagePanelStates.ApplyShowingWebView(PanelHost);
             Logger.Info("[ChatPage] Chat HTTP surface is serving; navigating WebView");
-            WebView.CoreWebView2.Navigate(_chatUrl);
+            if (!NavigateWebViewToCurrentChatUrl())
+                ShowMissingChatCredentialError();
         }
         // slopwatch-ignore: SW003 Shutdown cancellation or disposal is expected and the caller already preserves the safe state.
         catch (OperationCanceledException)

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -37,6 +37,7 @@ public sealed partial class ChatPage : Page
     private IGatewayConnectionManager? _connectionManager;
     private IChatPagePanelHost? _panelHost;
     private IChatPagePanelHost PanelHost => _panelHost ??= new ChatPagePanelHost(this);
+    private string? _pendingWebViewSessionKey;
     private static readonly HttpClient s_httpClient = new()
     {
         Timeout = TimeSpan.FromSeconds(3)
@@ -215,18 +216,20 @@ public sealed partial class ChatPage : Page
         var provider = app?.ChatProvider;
         Func<string, Task>? readAloud = app is null ? null : app.SpeakChatTextAsync;
 
-        // Consume a pending session-key hand-off from SessionsPage so the
-        // chat root mounts with that thread selected. Any pending key forces
-        // a remount — _mountedThreadId only records what we asked for, not
-        // what the user later picked inside the composer's dropdown, so we
-        // cannot use it to detect "already on the right thread".
-        var pendingSessionKey = _hub?.PendingChatSessionKey;
-        if (pendingSessionKey is not null && _hub is not null)
+        // Consume a pending session-key hand-off from SessionsPage or a
+        // notification toast so the chat root mounts with that thread selected.
+        // Any pending key forces a remount — _mountedThreadId only records what
+        // we asked for, not what the user later picked inside the composer's
+        // dropdown, so we cannot use it to detect "already on the right thread".
+        var pendingSessionKey = _hub?.PendingChatSessionKey
+            ?? (App.Current as App)?.PendingChatSessionKey;
+        if (!string.IsNullOrEmpty(pendingSessionKey))
         {
-            _hub.PendingChatSessionKey = null;
+            if (_hub is not null) _hub.PendingChatSessionKey = null;
+            if (App.Current is App currentApp) currentApp.PendingChatSessionKey = null;
         }
         var threadIdToMount = pendingSessionKey ?? _mountedThreadId;
-        var forceRemount = pendingSessionKey is not null;
+        var forceRemount = !string.IsNullOrEmpty(pendingSessionKey);
 
         if (_functionalHost is not null
             && ReferenceEquals(_mountedProvider, provider)
@@ -290,6 +293,20 @@ public sealed partial class ChatPage : Page
 
     private void ShowWebViewSurface(bool forceNavigate = false)
     {
+        // Consume pending session key for WebView mode.
+        var pendingSessionKey = _hub?.PendingChatSessionKey
+            ?? (App.Current as App)?.PendingChatSessionKey;
+        if (!string.IsNullOrEmpty(pendingSessionKey))
+        {
+            if (_hub is not null) _hub.PendingChatSessionKey = null;
+            if (App.Current is App currentApp) currentApp.PendingChatSessionKey = null;
+            _pendingWebViewSessionKey = pendingSessionKey;
+        }
+        else
+        {
+            _pendingWebViewSessionKey = null;
+        }
+
         // Tear down native chat (so the WebView2 owns the row) and (re)init WebView2.
         _webViewMode = true;
         DisposeFunctionalHost();
@@ -328,7 +345,19 @@ public sealed partial class ChatPage : Page
             return false;
 
         ChatPagePanelStates.ApplyShowingWebView(PanelHost);
-        WebView.CoreWebView2.Navigate(_chatUrl);
+
+        var url = _chatUrl;
+        if (!string.IsNullOrEmpty(_pendingWebViewSessionKey))
+        {
+            var baseUrl = System.Text.RegularExpressions.Regex.Replace(_chatUrl, @"[&?]session=[^&]*", "");
+            var separator = baseUrl.Contains('?') ? "&" : "?";
+            url = $"{baseUrl}{separator}session={Uri.EscapeDataString(_pendingWebViewSessionKey)}";
+            _pendingWebViewSessionKey = null;
+        }
+
+        ErrorPanel.Visibility = Visibility.Collapsed;
+        WebView.Visibility = Visibility.Visible;
+        WebView.CoreWebView2.Navigate(url);
         return true;
     }
 
@@ -394,7 +423,7 @@ public sealed partial class ChatPage : Page
                 return;
             }
 
-            if (!GatewayChatHelper.TryBuildChatUrl(credential.GatewayUrl, credential.Token, out var chatUrl, out var errorMessage))
+            if (!GatewayChatHelper.TryBuildChatUrl(credential.GatewayUrl, credential.Token, out var chatUrl, out var errorMessage, _pendingWebViewSessionKey))
             {
                 PlaceholderPanel.Visibility = Visibility.Collapsed;
                 ErrorPanel.Visibility = Visibility.Visible;
@@ -403,6 +432,7 @@ public sealed partial class ChatPage : Page
             }
 
             _chatUrl = chatUrl;
+            _pendingWebViewSessionKey = null;
 
             PlaceholderPanel.Visibility = Visibility.Collapsed;
             ErrorPanel.Visibility = Visibility.Collapsed;

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -243,6 +243,9 @@ public sealed partial class SessionsPage : Page
     {
         if (sender is Button btn && btn.Tag is string key)
         {
+            // Stash the target session on both App (fallback when the HubWindow
+            // doesn't exist yet) and HubWindow (existing path consumed by ChatPage).
+            CurrentApp.PendingChatSessionKey = key;
             if (CurrentApp.ActiveHubWindow is HubWindow hub)
             {
                 hub.PendingChatSessionKey = key;

--- a/src/OpenClaw.Tray.WinUI/Services/ToastActivationRouter.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ToastActivationRouter.cs
@@ -5,7 +5,7 @@ public sealed class ToastActivationActions
     public required Action<string> OpenUrl { get; init; }
     public required Action OpenDashboard { get; init; }
     public required Action OpenSettings { get; init; }
-    public required Action OpenChat { get; init; }
+    public required Action<string?> OpenChat { get; init; }
     public required Action OpenActivity { get; init; }
     public required Action<string> CopyPairingCommand { get; init; }
 }
@@ -34,7 +34,8 @@ public static class ToastActivationRouter
                 actions.OpenSettings();
                 break;
             case "open_chat":
-                actions.OpenChat();
+                var sessionKey = getArgument("sessionKey");
+                actions.OpenChat(sessionKey);
                 break;
             case "open_activity":
                 actions.OpenActivity();

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -101,6 +101,41 @@ public sealed class AppRefactorContractTests
     }
 
     [Fact]
+    public void ShowWebChat_ClearsStalePendingSessionKeyOnPlainOpen()
+    {
+        var source = ReadAppSources();
+        var method = ExtractMethod(source, "ShowWebChat");
+
+        Assert.Contains("PendingChatSessionKey = sessionKey;", method);
+        Assert.Contains("_hubWindow.PendingChatSessionKey = sessionKey;", method);
+        Assert.Contains("PendingChatSessionKey = null;", method);
+        Assert.Contains("_hubWindow.PendingChatSessionKey = null;", method);
+        AssertInOrder(
+            method,
+            "if (!string.IsNullOrEmpty(sessionKey))",
+            "PendingChatSessionKey = sessionKey;",
+            "else",
+            "PendingChatSessionKey = null;",
+            "ShowHub(\"chat\");");
+    }
+
+    [Fact]
+    public void ChatWebView_KeepsBaseChatUrlSeparateFromPendingSessionKey()
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.Tray.WinUI", "Pages", "ChatPage.xaml.cs"));
+        var init = ExtractMethod(source, "InitializeWebViewAsync");
+        var readiness = ExtractMethod(source, "NavigateWhenChatReadyAsync");
+
+        Assert.Contains("GatewayChatHelper.TryBuildChatUrl(credential.GatewayUrl, credential.Token, out var chatUrl, out var errorMessage)", init);
+        Assert.DoesNotContain("GatewayChatHelper.TryBuildChatUrl(credential.GatewayUrl, credential.Token, out var chatUrl, out var errorMessage, _pendingWebViewSessionKey)", init);
+        Assert.Contains("_chatUrl = chatUrl;", init);
+        Assert.DoesNotContain("_pendingWebViewSessionKey = null;", init);
+        Assert.Contains("NavigateWebViewToCurrentChatUrl()", readiness);
+        Assert.DoesNotContain("WebView.CoreWebView2.Navigate(_chatUrl)", readiness);
+    }
+
+    [Fact]
     public void Shutdown_Order_PreservesAwaitedTeardownBeforeExit()
     {
         var source = ReadAppSources();

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -95,7 +95,7 @@ public sealed class AppRefactorContractTests
         Assert.Contains("ToastActivationRouter.Route", method);
         Assert.Contains("OpenDashboard = () => OpenDashboard()", method);
         Assert.Contains("OpenSettings = ShowSettings", method);
-        Assert.Contains("OpenChat = ShowWebChat", method);
+        Assert.Contains("OpenChat = sessionKey => ShowWebChat(sessionKey)", method);
         Assert.Contains("OpenActivity = () => ShowHub(\"channels\")", method);
         Assert.Contains("CopyPairingCommand = command =>", method);
     }

--- a/tests/OpenClaw.Tray.Tests/ToastActivationRouterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ToastActivationRouterTests.cs
@@ -7,7 +7,7 @@ public sealed class ToastActivationRouterTests
     [Theory]
     [InlineData("open_dashboard", "dashboard")]
     [InlineData("open_settings", "settings")]
-    [InlineData("open_chat", "chat")]
+    [InlineData("open_chat", "chat:(null)")]
     [InlineData("open_activity", "activity")]
     public void Route_DispatchesSimpleActions(string action, string expected)
     {
@@ -58,6 +58,24 @@ public sealed class ToastActivationRouterTests
     }
 
     [Fact]
+    public void Route_OpenChat_PassesSessionKeyArgument()
+    {
+        var calls = new List<string>();
+
+        ToastActivationRouter.Route(
+            "open_chat",
+            key => key == "sessionKey" ? "agent:main:scratch" : null,
+            BuildActions(calls));
+
+        ToastActivationRouter.Route(
+            "open_chat",
+            _ => null,
+            BuildActions(calls));
+
+        Assert.Equal(["chat:agent:main:scratch", "chat:(null)"], calls);
+    }
+
+    [Fact]
     public void Route_UnknownAction_NoOps()
     {
         var calls = new List<string>();
@@ -75,7 +93,7 @@ public sealed class ToastActivationRouterTests
         OpenUrl = url => calls.Add($"url:{url}"),
         OpenDashboard = () => calls.Add("dashboard"),
         OpenSettings = () => calls.Add("settings"),
-        OpenChat = () => calls.Add("chat"),
+        OpenChat = key => calls.Add($"chat:{key ?? "(null)"}"),
         OpenActivity = () => calls.Add("activity"),
         CopyPairingCommand = command => calls.Add($"copy:{command}")
     };


### PR DESCRIPTION
## Problem

Clicking a session entry in the **Sessions** tab, or clicking a **chat toast notification**, always opened the default/main session instead of the specific session that was selected or that produced the notification.

## Root Cause

The session routing path had gaps at every hand-off point:

1. **Gateway → Notification**: `OpenClawNotification` had no `SessionKey` property, so chat toasts couldn't carry the source session.
2. **Toast → App**: `ToastActivationRouter.OpenChat` was `Action` (no parameters), so the toast's `sessionKey` argument was ignored.
3. **App → ChatPage**: `ShowWebChat` didn't accept or forward a session key. `ChatPage` only checked `_hub?.PendingChatSessionKey`, which is `null` when the HubWindow doesn't exist (background notifications, closed window).
4. **ChatPage (FunctionalUI)**: The `pendingSessionKey is not null` guard treated `""` as a valid key, and the provider fallback to `_mountedThreadId` could return a stale default.
5. **ChatPage (WebView)**: The WebView path never appended `&session={key}` to the chat URL — it always navigated to the bare gateway root.

## Changes

### Commit 1: Thread session key through chat notifications
- **`OpenClawNotification`**: Add `SessionKey` property.
- **`OpenClawGatewayClient.EmitChatNotification`**: Accept `sessionKey` parameter (from `HandleChatEvent` payload) and set it on the notification.

### Commit 2: Fix chat session routing from Sessions page and toast notifications
- **`App.PendingChatSessionKey`**: New fallback property when `HubWindow` doesn't exist. Consumed (cleared) by `ChatPage`.
- **`App.ShowWebChat(string? sessionKey)`**: Accepts session key, stashes it on both `App` and `HubWindow` so `ChatPage` can pick it up after navigation.
- **`ToastActivationRouter`**: `OpenChat` changed from `Action` → `Action<string?>`. Reads `sessionKey` from toast arguments and passes it through.
- **`App.OnGatewayNotificationReceived`**: Embeds `sessionKey` in chat toast body arguments and the "Open Chat" toast button.
- **`ChatPage` (FunctionalUI)**:
  - Consumes pending key from `_hub?.PendingChatSessionKey` **and** `(App.Current as App)?.PendingChatSessionKey`
  - `!string.IsNullOrEmpty()` guard so `""` is treated as null
  - Clears both sources after consumption
  - `forceRemount = !string.IsNullOrEmpty(pendingSessionKey)` ensures a remount when a key arrives
- **`ChatPage` (WebView)**:
  - New `_pendingWebViewSessionKey` field
  - `ShowWebViewSurface`: consumes pending key from `HubWindow` or `App` fallbacks
  - `NavigateWebViewToCurrentChatUrl`: appends `&session={key}` to the URL (deduping any existing `session` param)
  - `InitializeWebViewAsync`: passes `_pendingWebViewSessionKey` through `GatewayChatHelper.TryBuildChatUrl`
- **`SessionsPage.OnOpenChat`**: Writes key to `CurrentApp.PendingChatSessionKey` (fallback) in addition to `hub.PendingChatSessionKey`.
- **Tests**: Updated `ToastActivationRouterTests` and `AppRefactorContractTests` for the new `Action<string?>` contract. Added `Route_OpenChat_PassesSessionKeyArgument`.

## Test Results

```
dotnet test tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
  Passed! - Failed: 0, Passed: 871, Skipped: 2, Total: 873
```

## Verification Steps

1. Open the tray app, connect to a gateway with multiple sessions.
2. **Sessions tab**: Click "Open chat" on a non-default session — should open that specific session.
3. **Toast notification**: Trigger an assistant response in a non-default session, click the toast — should open that specific session.
4. **WebView mode**: Enable "Use standard Gateway Chat interface" in Settings, repeat steps 2–3 — the WebView should navigate to `?token=...&session={key}`.
