### PR TITLE
fix(node): reconnect and report app version after restart

### DIFF
--- a/src/OpenClaw.Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/GatewayConnectionManager.cs
@@ -101,6 +101,30 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         }
     }
 
+    public async Task ConnectNodeOnlyAsync(string? gatewayId = null)
+    {
+        ThrowIfDisposed();
+        var prevState = _stateMachine.Current.OverallState;
+        var prepared = false;
+
+        await _transitionSemaphore.WaitAsync();
+        try
+        {
+            prepared = await PrepareNodeOnlyConnectCoreAsync(gatewayId);
+        }
+        finally
+        {
+            _transitionSemaphore.Release();
+        }
+
+        if (!prepared)
+            return;
+
+        var started = await StartNodeConnectionAsync();
+        if (started)
+            EmitStateChanged(prevState);
+    }
+
     /// <summary>Core connect logic. Caller must hold <see cref="_transitionSemaphore"/>.</summary>
     private async Task ConnectCoreAsync(string? gatewayId = null)
     {
@@ -270,6 +294,102 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
                     _logger.Error($"[ConnMgr] Connect failed: {ex.Message}");
                 }
             }, ct);
+    }
+
+    /// <summary>
+    /// Starts the node role without requiring an operator credential. This is the
+    /// durable tray restart path for already-paired Windows nodes whose registry
+    /// record only has a persisted NodeDeviceToken.
+    /// </summary>
+    private async Task<bool> PrepareNodeOnlyConnectCoreAsync(string? gatewayId = null)
+    {
+        var id = gatewayId ?? _registry.ActiveGatewayId;
+        if (id == null)
+        {
+            _logger.Warn("[ConnMgr] No gateway ID specified and no active gateway for node-only connect");
+            return false;
+        }
+
+        var record = _registry.GetById(id);
+        if (record == null)
+        {
+            _logger.Warn($"[ConnMgr] Gateway {id} not found in registry for node-only connect");
+            return false;
+        }
+
+        var perGatewayIdentityDir = _registry.GetIdentityDirectory(record.Id);
+        if (!Directory.Exists(perGatewayIdentityDir))
+            Directory.CreateDirectory(perGatewayIdentityDir);
+
+        var nodeCredential = _credentialResolver.ResolveNode(record, perGatewayIdentityDir);
+        if (nodeCredential == null)
+        {
+            _logger.Warn("[ConnMgr] No node credential available for node-only connect");
+            _diagnostics.Record("node", "No node credential available for node-only connect");
+            return false;
+        }
+
+        var gen = Interlocked.Increment(ref _generation);
+        var oldCts = Interlocked.Exchange(ref _operationCts, new CancellationTokenSource());
+        oldCts?.Cancel();
+        oldCts?.Dispose();
+
+        await DisposeActiveClientAsync();
+
+        _activeIdentityPath = perGatewayIdentityDir;
+        _activeGatewayRecordId = record.Id;
+        _gatewayNeedsV2Signature = record.IsLocal || record.RequiresV2Signature;
+        _stateMachine.Current = _stateMachine.Current with
+        {
+            GatewayId = record.Id,
+            GatewayUrl = record.Url,
+            GatewayName = record.FriendlyName
+        };
+
+        _diagnostics.RecordCredentialResolution(nodeCredential);
+        _diagnostics.Record("node", $"Starting node-only connection to {record.Url}",
+            $"Credential source: {nodeCredential.Source}");
+
+        if (!await TryStartTunnelForNodeOnlyAsync(record))
+            return false;
+
+        return Interlocked.Read(ref _generation) == gen;
+    }
+
+    private async Task<bool> TryStartTunnelForNodeOnlyAsync(GatewayRecord record)
+    {
+        if (record.SshTunnel == null)
+            return true;
+
+        if (_tunnelManager == null)
+        {
+            _diagnostics.Record("tunnel", "No tunnel manager available; using configured local tunnel URL for node-only connect");
+            return true;
+        }
+
+        var tunnel = record.SshTunnel;
+        if (string.IsNullOrWhiteSpace(tunnel.User) ||
+            string.IsNullOrWhiteSpace(tunnel.Host) ||
+            tunnel.RemotePort is < 1 or > 65535 ||
+            tunnel.LocalPort is < 1 or > 65535)
+        {
+            _logger.Warn("[ConnMgr] SSH tunnel config is incomplete for node-only connect");
+            _diagnostics.Record("tunnel", "SSH tunnel config is incomplete for node-only connect");
+            return false;
+        }
+
+        try
+        {
+            var connectUrl = await _tunnelManager.StartAsync(tunnel, _operationCts!.Token);
+            _diagnostics.Record("tunnel", $"SSH tunnel started for node-only connect → {connectUrl}");
+            return true;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.Error($"[ConnMgr] SSH tunnel start failed for node-only connect: {ex.Message}");
+            _diagnostics.Record("tunnel", "SSH tunnel start failed for node-only connect", ex.Message);
+            return false;
+        }
     }
 
     public async Task DisconnectAsync()

--- a/src/OpenClaw.Connection/IGatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/IGatewayConnectionManager.cs
@@ -20,6 +20,7 @@ public interface IGatewayConnectionManager : IDisposable, IAsyncDisposable
 
     // ─── Lifecycle ───
     Task ConnectAsync(string? gatewayId = null);
+    Task ConnectNodeOnlyAsync(string? gatewayId = null);
     Task DisconnectAsync();
     Task ReconnectAsync();
     Task SwitchGatewayAsync(string gatewayId);

--- a/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
@@ -396,11 +396,16 @@ public class SystemCapability : NodeCapabilityBase
         if (_approvalPolicy != null)
         {
             var approval = _approvalPolicy.Evaluate(fullCommand, shell);
-            if (!await EnsureApprovedAsync(fullCommand, shell, approval))
+            var approvalCheck = await EnsureApprovedAsync(fullCommand, shell, approval);
+            if (!approvalCheck.Allowed)
             {
                 Logger.Warn($"system.run DENIED: {fullCommand} ({approval.Reason})");
                 return Error($"Command denied by exec policy: {approval.Reason}");
             }
+
+            var outerApprovalCoversNestedTargets =
+                approvalCheck.PromptDecisionKind != null ||
+                IsExactAllowRuleForCommand(approval, fullCommand);
 
             var parseResult = ExecShellWrapperParser.Expand(fullCommand, shell);
             if (!string.IsNullOrWhiteSpace(parseResult.Error))
@@ -412,7 +417,18 @@ public class SystemCapability : NodeCapabilityBase
             foreach (var target in parseResult.Targets)
             {
                 var innerApproval = _approvalPolicy.Evaluate(target.Command, target.Shell);
-                if (!await EnsureApprovedAsync(target.Command, target.Shell, innerApproval))
+                if (outerApprovalCoversNestedTargets && !IsExplicitDeny(innerApproval))
+                {
+                    if (!innerApproval.Allowed)
+                    {
+                        Logger.Info(
+                            $"system.run nested approval covered by approved wrapper: {target.Command} ({innerApproval.Reason})");
+                    }
+                    continue;
+                }
+
+                var innerApprovalCheck = await EnsureApprovedAsync(target.Command, target.Shell, innerApproval);
+                if (!innerApprovalCheck.Allowed)
                 {
                     Logger.Warn($"system.run DENIED: {target.Command} ({innerApproval.Reason})");
                     return Error($"Command denied by exec policy: {innerApproval.Reason}");
@@ -448,17 +464,17 @@ public class SystemCapability : NodeCapabilityBase
         }
     }
 
-    private async Task<bool> EnsureApprovedAsync(
+    private async Task<ExecApprovalCheckResult> EnsureApprovedAsync(
         string command,
         string? shell,
         ExecApprovalResult approval,
         CancellationToken cancellationToken = default)
     {
         if (approval.Allowed)
-            return true;
+            return new ExecApprovalCheckResult(true, null);
 
         if (approval.Action != ExecApprovalAction.Prompt || _promptHandler == null || _approvalPolicy == null)
-            return false;
+            return new ExecApprovalCheckResult(false, null);
 
         var decision = await _promptHandler.RequestAsync(new ExecApprovalPromptRequest
         {
@@ -471,7 +487,7 @@ public class SystemCapability : NodeCapabilityBase
         if (decision.Kind == ExecApprovalPromptDecisionKind.Deny)
         {
             Logger.Warn($"system.run DENIED by prompt: {command} ({decision.Reason})");
-            return false;
+            return new ExecApprovalCheckResult(false, decision.Kind);
         }
 
         if (decision.Kind == ExecApprovalPromptDecisionKind.AlwaysAllow)
@@ -494,12 +510,28 @@ public class SystemCapability : NodeCapabilityBase
         }
 
         Logger.Info($"system.run APPROVED by prompt: {command} ({decision.Kind})");
-        return true;
+        return new ExecApprovalCheckResult(true, decision.Kind);
     }
 
     private static bool CanPersistExactAllowRule(string command) =>
         !string.IsNullOrWhiteSpace(command) &&
         command.IndexOfAny(['*', '?']) < 0;
+
+    private static bool IsExactAllowRuleForCommand(ExecApprovalResult approval, string command) =>
+        approval.Allowed &&
+        approval.Action == ExecApprovalAction.Allow &&
+        !string.IsNullOrWhiteSpace(approval.MatchedPattern) &&
+        approval.MatchedPattern.IndexOfAny(['*', '?']) < 0 &&
+        string.Equals(approval.MatchedPattern, command, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsExplicitDeny(ExecApprovalResult approval) =>
+        !approval.Allowed &&
+        approval.Action == ExecApprovalAction.Deny &&
+        !string.IsNullOrWhiteSpace(approval.MatchedPattern);
+
+    private readonly record struct ExecApprovalCheckResult(
+        bool Allowed,
+        ExecApprovalPromptDecisionKind? PromptDecisionKind);
     
     private NodeInvokeResponse HandleExecApprovalsGet()
     {

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -1172,6 +1172,8 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
                 role, requestedScopes, signatureToken,
                 OperatorPlatform, OperatorDeviceFamily);
 
+        var appVersion = AppVersionInfo.Version;
+
         // Use "cli" client ID for native apps - no browser security checks
         var msg = new
         {
@@ -1185,7 +1187,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
                 client = new
                 {
                     id = OperatorClientId,  // Native client ID
-                    version = "1.0.0",
+                    version = appVersion,
                     platform = OperatorPlatform,
                     mode = OperatorClientMode,
                     displayName = OperatorClientDisplayName
@@ -1197,7 +1199,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
                 permissions = new { },
                 auth = BuildAuthPayload(),
                 locale = "en-US",
-                userAgent = "openclaw-windows-tray/1.0.0",
+                userAgent = $"openclaw-windows-tray/{appVersion}",
                 device = new
                 {
                     id = _deviceIdentity.DeviceId,

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -123,7 +123,7 @@ public class WindowsNodeClient : WebSocketClientBase
         _registration = new NodeRegistration
         {
             Id = _deviceIdentity.DeviceId,
-            Version = "1.0.0",
+            Version = AppVersionInfo.Version,
             Platform = WindowsPlatform,
             DeviceFamily = WindowsDeviceFamily,
             DisplayName = $"Windows Node ({Environment.MachineName})"

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1428,12 +1428,25 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     /// </summary>
     private bool TryConnectGatewayIfCredentialAvailable(GatewayRecord record, string context)
     {
-        if (_connectionManager == null)
+        if (_connectionManager == null || _gatewayRegistry == null)
             return false;
 
-        var credential = ResolveStartupOperatorCredential(record);
+        var resolver = new CredentialResolver(DeviceIdentityFileReader.Instance);
+        var identityDir = _gatewayRegistry.GetIdentityDirectory(record.Id);
+        var credential = ResolveStartupOperatorCredential(record, resolver, identityDir);
         if (credential == null)
         {
+            var nodeCredential = ResolveStartupNodeCredential(record, resolver, identityDir);
+            if (nodeCredential != null && ShouldInitializeNodeService())
+            {
+                Logger.Info(
+                    $"Connecting node-only gateway during {context}: {record.Url} ({nodeCredential.Source})");
+                ObserveBackgroundFault(
+                    _connectionManager.ConnectNodeOnlyAsync(record.Id),
+                    $"[App] Startup node-only gateway connect failed during {context}");
+                return true;
+            }
+
             Logger.Info($"Active gateway has no usable credential — skipping {context} connect");
             return false;
         }
@@ -1472,13 +1485,14 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         }
     }
 
-    private OpenClaw.Connection.GatewayCredential? ResolveStartupOperatorCredential(GatewayRecord record)
+    private OpenClaw.Connection.GatewayCredential? ResolveStartupOperatorCredential(
+        GatewayRecord record,
+        CredentialResolver resolver,
+        string identityDir)
     {
         if (_gatewayRegistry == null)
             return null;
 
-        var resolver = new CredentialResolver(DeviceIdentityFileReader.Instance);
-        var identityDir = _gatewayRegistry.GetIdentityDirectory(record.Id);
         var credential = resolver.ResolveOperator(record, identityDir);
         if (credential != null)
             return credential;
@@ -1493,6 +1507,50 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         }
 
         return null;
+    }
+
+    private OpenClaw.Connection.GatewayCredential? ResolveStartupNodeCredential(
+        GatewayRecord record,
+        CredentialResolver resolver,
+        string identityDir)
+    {
+        var credential = resolver.ResolveNode(record, identityDir);
+        if (credential != null)
+            return credential;
+
+        var effectiveUrl = _settings?.GetEffectiveGatewayUrl();
+        if (string.IsNullOrWhiteSpace(effectiveUrl) ||
+            !string.Equals(record.Url, effectiveUrl, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        credential = resolver.ResolveNode(record, SettingsManager.SettingsDirectoryPath);
+        if (credential == null)
+            return null;
+
+        TryCopyLegacyIdentityToGateway(record.Id, identityDir);
+        return credential;
+    }
+
+    private static void TryCopyLegacyIdentityToGateway(string gatewayId, string identityDir)
+    {
+        var legacyIdentityPath = Path.Combine(SettingsManager.SettingsDirectoryPath, "device-key-ed25519.json");
+        var newIdentityPath = Path.Combine(identityDir, "device-key-ed25519.json");
+        if (!File.Exists(legacyIdentityPath) || File.Exists(newIdentityPath))
+            return;
+
+        try
+        {
+            if (!Directory.Exists(identityDir))
+                Directory.CreateDirectory(identityDir);
+            File.Copy(legacyIdentityPath, newIdentityPath, overwrite: false);
+            Logger.Info($"[GatewayRegistry] Copied legacy identity into active gateway {gatewayId}");
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Failed to copy legacy identity file for gateway {gatewayId}: {ex.Message}");
+        }
     }
 
     private void TryMigrateLegacyGatewaySettings(string gatewayUrl, IOpenClawLogger logger)

--- a/src/OpenClaw.Tray.WinUI/Services/ExecApprovalPromptService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ExecApprovalPromptService.cs
@@ -196,10 +196,14 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
                 if (messageResult < 0)
                     throw new InvalidOperationException("Could not read approval prompt window message");
 
+                if (message.message == WindowMessagePromptCompleted)
+                    break;
+
                 TranslateMessage(ref message);
                 DispatchMessageW(ref message);
             }
 
+            CleanupWindow();
             return _decision;
         }
 
@@ -317,6 +321,7 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
                     {
                         Prompts.Remove(hwnd);
                     }
+                    prompt._hwnd = IntPtr.Zero;
                     prompt._completed = true;
                     return IntPtr.Zero;
                 default:
@@ -344,6 +349,9 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
 
         private void Complete(int buttonId)
         {
+            if (_completed)
+                return;
+
             _decision = buttonId switch
             {
                 AllowOnceButtonId => ExecApprovalPromptDecision.AllowOnce(),
@@ -352,10 +360,27 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
             };
             _completed = true;
             if (_hwnd != IntPtr.Zero)
-                DestroyWindow(_hwnd);
+                ShowWindow(_hwnd, ShowWindowCommandHide);
+
+            if (_hwnd != IntPtr.Zero)
+                PostMessageW(_hwnd, WindowMessageClose, IntPtr.Zero, IntPtr.Zero);
 
             if (_threadId != 0)
                 PostThreadMessageW(_threadId, WindowMessagePromptCompleted, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        private void CleanupWindow()
+        {
+            if (_hwnd == IntPtr.Zero)
+                return;
+
+            var hwnd = _hwnd;
+            _hwnd = IntPtr.Zero;
+            lock (PromptLock)
+            {
+                Prompts.Remove(hwnd);
+            }
+            DestroyWindow(hwnd);
         }
 
         private static int ButtonIdFromWParam(IntPtr wParam) => (int)((long)wParam & 0xffff);
@@ -418,6 +443,9 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
         private static extern bool DestroyWindow(IntPtr hwnd);
 
         [DllImport("user32.dll")]
+        private static extern bool PostMessageW(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("user32.dll")]
         private static extern bool ShowWindow(IntPtr hwnd, int nCmdShow);
 
         [DllImport("user32.dll")]
@@ -463,6 +491,7 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
         private const int SystemMetricScreenWidth = 0;
         private const int SystemMetricScreenHeight = 1;
         private const int DefaultGuiFont = 17;
+        private const int ShowWindowCommandHide = 0;
         private const int ShowWindowCommandShow = 5;
         private const int ColorWindow = 5;
 

--- a/src/OpenClaw.Tray.WinUI/Services/ExecApprovalPromptService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ExecApprovalPromptService.cs
@@ -138,6 +138,7 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
         private IntPtr _allowOnceButtonHwnd;
         private IntPtr _alwaysAllowButtonHwnd;
         private IntPtr _denyButtonHwnd;
+        private uint _threadId;
         private ExecApprovalPromptDecision _decision = ExecApprovalPromptDecision.Deny();
         private bool _completed;
 
@@ -149,6 +150,7 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
         public ExecApprovalPromptDecision Show()
         {
             EnsureClassRegistered();
+            _threadId = GetCurrentThreadId();
 
             var x = Math.Max(0, (GetSystemMetrics(SystemMetricScreenWidth) - WindowWidth) / 2);
             var y = Math.Max(0, (GetSystemMetrics(SystemMetricScreenHeight) - WindowHeight) / 2);
@@ -351,6 +353,9 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
             _completed = true;
             if (_hwnd != IntPtr.Zero)
                 DestroyWindow(_hwnd);
+
+            if (_threadId != 0)
+                PostThreadMessageW(_threadId, WindowMessagePromptCompleted, IntPtr.Zero, IntPtr.Zero);
         }
 
         private static int ButtonIdFromWParam(IntPtr wParam) => (int)((long)wParam & 0xffff);
@@ -436,6 +441,12 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
         [DllImport("user32.dll")]
         private static extern void PostQuitMessage(int nExitCode);
 
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool PostThreadMessageW(uint idThread, uint msg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("kernel32.dll")]
+        private static extern uint GetCurrentThreadId();
+
         [DllImport("user32.dll")]
         private static extern int GetSystemMetrics(int nIndex);
 
@@ -459,6 +470,7 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
         private const uint WindowMessageClose = 0x0010;
         private const uint WindowMessageDestroy = 0x0002;
         private const uint WindowMessageSetFont = 0x0030;
+        private const uint WindowMessagePromptCompleted = 0x8000;
 
         private const uint WindowExStyleDialogModalFrame = 0x00000001;
         private const uint WindowExStyleTopMost = 0x00000008;

--- a/src/OpenClaw.Tray.WinUI/Services/ExecApprovalPromptService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ExecApprovalPromptService.cs
@@ -1,8 +1,8 @@
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using OpenClaw.Shared;
 using System;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,8 +10,6 @@ namespace OpenClawTray.Services;
 
 public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
 {
-    private readonly DispatcherQueue _dispatcherQueue;
-    private readonly Func<FrameworkElement?> _rootProvider;
     private readonly IOpenClawLogger _logger;
 
     public ExecApprovalPromptService(
@@ -19,8 +17,6 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
         Func<FrameworkElement?> rootProvider,
         IOpenClawLogger logger)
     {
-        _dispatcherQueue = dispatcherQueue;
-        _rootProvider = rootProvider;
         _logger = logger;
     }
 
@@ -32,55 +28,11 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
         if (cancellationToken.IsCancellationRequested)
             return Task.FromResult(ExecApprovalPromptDecision.Deny("Approval prompt was cancelled"));
 
-        if (!_dispatcherQueue.TryEnqueue(async () =>
+        var thread = new Thread(() =>
         {
             try
             {
-                var root = _rootProvider();
-                if (root?.XamlRoot == null)
-                {
-                    _logger.Warn("[ExecApproval] Cannot show prompt because no XamlRoot is available");
-                    tcs.TrySetResult(ExecApprovalPromptDecision.Deny("No desktop prompt surface is available"));
-                    return;
-                }
-
-                var content = new StackPanel { Spacing = 8 };
-                content.Children.Add(new TextBlock
-                {
-                    Text = "A remote agent wants to run a local command on this Windows machine.",
-                    TextWrapping = TextWrapping.Wrap
-                });
-                content.Children.Add(new TextBlock
-                {
-                    Text = request.Command,
-                    FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Consolas"),
-                    TextWrapping = TextWrapping.WrapWholeWords
-                });
-                content.Children.Add(new TextBlock
-                {
-                    Text = $"Shell: {request.Shell ?? "auto"}\nReason: {request.Reason}",
-                    TextWrapping = TextWrapping.Wrap
-                });
-
-                var dialog = new ContentDialog
-                {
-                    Title = "Approve local command?",
-                    Content = content,
-                    PrimaryButtonText = "Allow once",
-                    SecondaryButtonText = "Always allow",
-                    CloseButtonText = "Deny",
-                    DefaultButton = ContentDialogButton.Close,
-                    XamlRoot = root.XamlRoot
-                };
-
-                var result = await dialog.ShowAsync();
-                var decision = result switch
-                {
-                    ContentDialogResult.Primary => ExecApprovalPromptDecision.AllowOnce(),
-                    ContentDialogResult.Secondary => ExecApprovalPromptDecision.AlwaysAllow(),
-                    _ => ExecApprovalPromptDecision.Deny()
-                };
-
+                var decision = ShowTaskDialog(request);
                 _logger.Info($"[ExecApproval] Prompt decision: {decision.Kind}");
                 tcs.TrySetResult(decision);
             }
@@ -89,12 +41,208 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
                 _logger.Warn($"[ExecApproval] Prompt failed: {ex.Message}");
                 tcs.TrySetResult(ExecApprovalPromptDecision.Deny("Approval prompt failed"));
             }
-        }))
+        })
         {
-            _logger.Warn("[ExecApproval] Failed to enqueue prompt on UI thread");
-            tcs.TrySetResult(ExecApprovalPromptDecision.Deny("Unable to show approval prompt"));
-        }
+            IsBackground = true,
+            Name = "OpenClaw Exec Approval Prompt"
+        };
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
 
         return tcs.Task;
+    }
+
+    private static ExecApprovalPromptDecision ShowTaskDialog(ExecApprovalPromptRequest request)
+    {
+        var text =
+            "A remote agent wants to run a local command on this Windows machine." +
+            Environment.NewLine + Environment.NewLine +
+            request.Command +
+            Environment.NewLine + Environment.NewLine +
+            $"Shell: {request.Shell ?? "auto"}" +
+            Environment.NewLine +
+            $"Reason: {request.Reason}";
+
+        var buttons = new[]
+        {
+            new TaskDialogButton(AllowOnceButtonId, "Allow once"),
+            new TaskDialogButton(AlwaysAllowButtonId, "Always allow"),
+            new TaskDialogButton(DenyButtonId, "Deny")
+        };
+
+        var buttonsPtr = IntPtr.Zero;
+        try
+        {
+            var buttonSize = Marshal.SizeOf<TaskDialogButton>();
+            buttonsPtr = Marshal.AllocHGlobal(buttonSize * buttons.Length);
+            for (var i = 0; i < buttons.Length; i++)
+            {
+                Marshal.StructureToPtr(buttons[i], buttonsPtr + i * buttonSize, false);
+            }
+
+            var config = new TaskDialogConfig
+            {
+                cbSize = (uint)Marshal.SizeOf<TaskDialogConfig>(),
+                dwFlags = TaskDialogFlags.AllowDialogCancellation,
+                pszWindowTitle = "Approve local command?",
+                pszMainInstruction = "Approve local command?",
+                pszContent = text,
+                cButtons = (uint)buttons.Length,
+                pButtons = buttonsPtr,
+                nDefaultButton = DenyButtonId,
+                cxWidth = 260
+            };
+
+            var hresult = TaskDialogIndirect(ref config, out var button, out _, out _);
+            if (hresult < 0)
+                Marshal.ThrowExceptionForHR(hresult);
+
+            return button switch
+            {
+                AllowOnceButtonId => ExecApprovalPromptDecision.AllowOnce(),
+                AlwaysAllowButtonId => ExecApprovalPromptDecision.AlwaysAllow(),
+                _ => ExecApprovalPromptDecision.Deny()
+            };
+        }
+        catch (DllNotFoundException)
+        {
+            return ShowMessageBoxFallback(text);
+        }
+        catch (EntryPointNotFoundException)
+        {
+            return ShowMessageBoxFallback(text);
+        }
+        finally
+        {
+            if (buttonsPtr != IntPtr.Zero)
+            {
+                var buttonSize = Marshal.SizeOf<TaskDialogButton>();
+                for (var i = 0; i < buttons.Length; i++)
+                {
+                    Marshal.DestroyStructure<TaskDialogButton>(buttonsPtr + i * buttonSize);
+                }
+                Marshal.FreeHGlobal(buttonsPtr);
+            }
+        }
+    }
+
+    private static ExecApprovalPromptDecision ShowMessageBoxFallback(string text)
+    {
+        var fallbackText = text +
+            Environment.NewLine + Environment.NewLine +
+            "Yes = Allow once" +
+            Environment.NewLine +
+            "No or Cancel = Deny";
+
+        var result = MessageBoxW(
+            IntPtr.Zero,
+            fallbackText,
+            "Approve local command?",
+            MessageBoxFlags.YesNoCancel |
+            MessageBoxFlags.IconWarning |
+            MessageBoxFlags.TopMost |
+            MessageBoxFlags.SetForeground |
+            MessageBoxFlags.DefaultButton3);
+
+        return result switch
+        {
+            MessageBoxYes => ExecApprovalPromptDecision.AllowOnce(),
+            _ => ExecApprovalPromptDecision.Deny()
+        };
+    }
+
+    [DllImport("comctl32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern int TaskDialogIndirect(
+        ref TaskDialogConfig taskConfig,
+        out int button,
+        out int radioButton,
+        [MarshalAs(UnmanagedType.Bool)] out bool verificationFlagChecked);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern int MessageBoxW(IntPtr hWnd, string text, string caption, MessageBoxFlags type);
+
+    private const int AllowOnceButtonId = 1001;
+    private const int AlwaysAllowButtonId = 1002;
+    private const int DenyButtonId = 1003;
+    private const int MessageBoxYes = 6;
+
+    [Flags]
+    private enum TaskDialogFlags : uint
+    {
+        AllowDialogCancellation = 0x0008
+    }
+
+    [Flags]
+    private enum MessageBoxFlags : uint
+    {
+        YesNoCancel = 0x00000003,
+        IconWarning = 0x00000030,
+        DefaultButton3 = 0x00000200,
+        TopMost = 0x00040000,
+        SetForeground = 0x00010000
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct TaskDialogButton
+    {
+        public int nButtonID;
+
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string pszButtonText;
+
+        public TaskDialogButton(int id, string text)
+        {
+            nButtonID = id;
+            pszButtonText = text;
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct TaskDialogConfig
+    {
+        public uint cbSize;
+        public IntPtr hwndParent;
+        public IntPtr hInstance;
+        public TaskDialogFlags dwFlags;
+        public uint dwCommonButtons;
+
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string? pszWindowTitle;
+
+        public IntPtr hMainIcon;
+
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string? pszMainInstruction;
+
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string? pszContent;
+
+        public uint cButtons;
+        public IntPtr pButtons;
+        public int nDefaultButton;
+        public uint cRadioButtons;
+        public IntPtr pRadioButtons;
+        public int nDefaultRadioButton;
+
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string? pszVerificationText;
+
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string? pszExpandedInformation;
+
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string? pszExpandedControlText;
+
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string? pszCollapsedControlText;
+
+        public IntPtr hFooterIcon;
+
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string? pszFooter;
+
+        public IntPtr pfCallback;
+        public IntPtr lpCallbackData;
+        public uint cxWidth;
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Services/ExecApprovalPromptService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ExecApprovalPromptService.cs
@@ -2,6 +2,7 @@ using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using OpenClaw.Shared;
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,7 +33,7 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
         {
             try
             {
-                var decision = ShowTaskDialog(request);
+                var decision = ShowNativePrompt(request);
                 _logger.Info($"[ExecApproval] Prompt decision: {decision.Kind}");
                 tcs.TrySetResult(decision);
             }
@@ -52,77 +53,24 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
         return tcs.Task;
     }
 
-    private static ExecApprovalPromptDecision ShowTaskDialog(ExecApprovalPromptRequest request)
+    private static ExecApprovalPromptDecision ShowNativePrompt(ExecApprovalPromptRequest request)
     {
         var text =
             "A remote agent wants to run a local command on this Windows machine." +
-            Environment.NewLine + Environment.NewLine +
+            "\r\n\r\n" +
             request.Command +
-            Environment.NewLine + Environment.NewLine +
+            "\r\n\r\n" +
             $"Shell: {request.Shell ?? "auto"}" +
-            Environment.NewLine +
+            "\r\n" +
             $"Reason: {request.Reason}";
 
-        var buttons = new[]
-        {
-            new TaskDialogButton(AllowOnceButtonId, "Allow once"),
-            new TaskDialogButton(AlwaysAllowButtonId, "Always allow"),
-            new TaskDialogButton(DenyButtonId, "Deny")
-        };
-
-        var buttonsPtr = IntPtr.Zero;
         try
         {
-            var buttonSize = Marshal.SizeOf<TaskDialogButton>();
-            buttonsPtr = Marshal.AllocHGlobal(buttonSize * buttons.Length);
-            for (var i = 0; i < buttons.Length; i++)
-            {
-                Marshal.StructureToPtr(buttons[i], buttonsPtr + i * buttonSize, false);
-            }
-
-            var config = new TaskDialogConfig
-            {
-                cbSize = (uint)Marshal.SizeOf<TaskDialogConfig>(),
-                dwFlags = TaskDialogFlags.AllowDialogCancellation,
-                pszWindowTitle = "Approve local command?",
-                pszMainInstruction = "Approve local command?",
-                pszContent = text,
-                cButtons = (uint)buttons.Length,
-                pButtons = buttonsPtr,
-                nDefaultButton = DenyButtonId,
-                cxWidth = 260
-            };
-
-            var hresult = TaskDialogIndirect(ref config, out var button, out _, out _);
-            if (hresult < 0)
-                Marshal.ThrowExceptionForHR(hresult);
-
-            return button switch
-            {
-                AllowOnceButtonId => ExecApprovalPromptDecision.AllowOnce(),
-                AlwaysAllowButtonId => ExecApprovalPromptDecision.AlwaysAllow(),
-                _ => ExecApprovalPromptDecision.Deny()
-            };
+            return new NativePromptWindow(text).Show();
         }
-        catch (DllNotFoundException)
+        catch
         {
             return ShowMessageBoxFallback(text);
-        }
-        catch (EntryPointNotFoundException)
-        {
-            return ShowMessageBoxFallback(text);
-        }
-        finally
-        {
-            if (buttonsPtr != IntPtr.Zero)
-            {
-                var buttonSize = Marshal.SizeOf<TaskDialogButton>();
-                for (var i = 0; i < buttons.Length; i++)
-                {
-                    Marshal.DestroyStructure<TaskDialogButton>(buttonsPtr + i * buttonSize);
-                }
-                Marshal.FreeHGlobal(buttonsPtr);
-            }
         }
     }
 
@@ -151,13 +99,6 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
         };
     }
 
-    [DllImport("comctl32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern int TaskDialogIndirect(
-        ref TaskDialogConfig taskConfig,
-        out int button,
-        out int radioButton,
-        [MarshalAs(UnmanagedType.Bool)] out bool verificationFlagChecked);
-
     [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
     private static extern int MessageBoxW(IntPtr hWnd, string text, string caption, MessageBoxFlags type);
 
@@ -165,12 +106,6 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
     private const int AlwaysAllowButtonId = 1002;
     private const int DenyButtonId = 1003;
     private const int MessageBoxYes = 6;
-
-    [Flags]
-    private enum TaskDialogFlags : uint
-    {
-        AllowDialogCancellation = 0x0008
-    }
 
     [Flags]
     private enum MessageBoxFlags : uint
@@ -182,67 +117,344 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
         SetForeground = 0x00010000
     }
 
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-    private struct TaskDialogButton
+    private sealed class NativePromptWindow
     {
-        public int nButtonID;
+        private const string WindowClassName = "OpenClawExecApprovalPrompt";
+        private const int WindowWidth = 640;
+        private const int WindowHeight = 420;
+        private const int ButtonWidth = 120;
+        private const int ButtonHeight = 32;
+        private const int ButtonTop = 340;
+        private const int ButtonGap = 12;
 
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public string pszButtonText;
+        private static readonly object ClassLock = new();
+        private static readonly object PromptLock = new();
+        private static readonly Dictionary<IntPtr, NativePromptWindow> Prompts = new();
+        private static readonly WndProc WindowProc = StaticWndProc;
+        private static bool _classRegistered;
 
-        public TaskDialogButton(int id, string text)
+        private readonly string _text;
+        private IntPtr _hwnd;
+        private ExecApprovalPromptDecision _decision = ExecApprovalPromptDecision.Deny();
+        private bool _completed;
+
+        public NativePromptWindow(string text)
         {
-            nButtonID = id;
-            pszButtonText = text;
+            _text = text;
         }
-    }
 
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-    private struct TaskDialogConfig
-    {
-        public uint cbSize;
-        public IntPtr hwndParent;
-        public IntPtr hInstance;
-        public TaskDialogFlags dwFlags;
-        public uint dwCommonButtons;
+        public ExecApprovalPromptDecision Show()
+        {
+            EnsureClassRegistered();
 
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public string? pszWindowTitle;
+            var x = Math.Max(0, (GetSystemMetrics(SystemMetricScreenWidth) - WindowWidth) / 2);
+            var y = Math.Max(0, (GetSystemMetrics(SystemMetricScreenHeight) - WindowHeight) / 2);
 
-        public IntPtr hMainIcon;
+            _hwnd = CreateWindowExW(
+                WindowExStyleTopMost | WindowExStyleDialogModalFrame,
+                WindowClassName,
+                "Approve local command?",
+                WindowStyleCaption | WindowStyleSystemMenu | WindowStyleVisible,
+                x,
+                y,
+                WindowWidth,
+                WindowHeight,
+                IntPtr.Zero,
+                IntPtr.Zero,
+                GetModuleHandleW(null),
+                IntPtr.Zero);
 
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public string? pszMainInstruction;
+            if (_hwnd == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Could not create approval prompt window");
+            }
 
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public string? pszContent;
+            lock (PromptLock)
+            {
+                Prompts[_hwnd] = this;
+            }
 
-        public uint cButtons;
-        public IntPtr pButtons;
-        public int nDefaultButton;
-        public uint cRadioButtons;
-        public IntPtr pRadioButtons;
-        public int nDefaultRadioButton;
+            CreateControls(_hwnd);
+            ShowWindow(_hwnd, ShowWindowCommandShow);
+            UpdateWindow(_hwnd);
+            SetForegroundWindow(_hwnd);
 
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public string? pszVerificationText;
+            while (!_completed)
+            {
+                var messageResult = GetMessageW(out var message, IntPtr.Zero, 0, 0);
+                if (messageResult == 0)
+                {
+                    PostQuitMessage(message.wParam.ToInt32());
+                    break;
+                }
 
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public string? pszExpandedInformation;
+                if (messageResult < 0)
+                    throw new InvalidOperationException("Could not read approval prompt window message");
 
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public string? pszExpandedControlText;
+                TranslateMessage(ref message);
+                DispatchMessageW(ref message);
+            }
 
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public string? pszCollapsedControlText;
+            return _decision;
+        }
 
-        public IntPtr hFooterIcon;
+        private static void EnsureClassRegistered()
+        {
+            lock (ClassLock)
+            {
+                if (_classRegistered)
+                    return;
 
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public string? pszFooter;
+                var wndClass = new WindowClass
+                {
+                    lpfnWndProc = WindowProc,
+                    hInstance = GetModuleHandleW(null),
+                    hbrBackground = new IntPtr(ColorWindow + 1),
+                    lpszClassName = WindowClassName
+                };
 
-        public IntPtr pfCallback;
-        public IntPtr lpCallbackData;
-        public uint cxWidth;
+                if (RegisterClassW(ref wndClass) == 0)
+                {
+                    var error = Marshal.GetLastWin32Error();
+                    if (error != ErrorClassAlreadyExists)
+                        throw new InvalidOperationException($"Could not register approval prompt window class: {error}");
+                }
+
+                _classRegistered = true;
+            }
+        }
+
+        private void CreateControls(IntPtr hwnd)
+        {
+            var font = GetStockObject(DefaultGuiFont);
+            CreateChild(hwnd, "STATIC", "Approve local command?", 20, 18, 590, 24, StaticStyleLeft, 0, font);
+            CreateChild(
+                hwnd,
+                "EDIT",
+                _text,
+                20,
+                52,
+                590,
+                265,
+                WindowStyleVerticalScroll | EditStyleMultiline | EditStyleReadOnly | EditStyleAutoVerticalScroll | EditStyleWantReturn,
+                0,
+                font,
+                WindowExStyleClientEdge);
+
+            var totalButtonWidth = ButtonWidth * 3 + ButtonGap * 2;
+            var firstLeft = WindowWidth - 20 - totalButtonWidth;
+            CreateChild(hwnd, "BUTTON", "Allow once", firstLeft, ButtonTop, ButtonWidth, ButtonHeight, ButtonStylePushButton, AllowOnceButtonId, font);
+            CreateChild(hwnd, "BUTTON", "Always allow", firstLeft + ButtonWidth + ButtonGap, ButtonTop, ButtonWidth, ButtonHeight, ButtonStylePushButton, AlwaysAllowButtonId, font);
+            var denyButton = CreateChild(hwnd, "BUTTON", "Deny", firstLeft + (ButtonWidth + ButtonGap) * 2, ButtonTop, ButtonWidth, ButtonHeight, ButtonStyleDefaultPushButton, DenyButtonId, font);
+            SetFocus(denyButton);
+        }
+
+        private static IntPtr CreateChild(
+            IntPtr parent,
+            string className,
+            string text,
+            int x,
+            int y,
+            int width,
+            int height,
+            uint controlStyle,
+            int id,
+            IntPtr font,
+            uint extendedStyle = 0)
+        {
+            var hwnd = CreateWindowExW(
+                extendedStyle,
+                className,
+                text,
+                WindowStyleChild | WindowStyleVisible | controlStyle,
+                x,
+                y,
+                width,
+                height,
+                parent,
+                new IntPtr(id),
+                GetModuleHandleW(null),
+                IntPtr.Zero);
+
+            if (hwnd != IntPtr.Zero && font != IntPtr.Zero)
+                SendMessageW(hwnd, WindowMessageSetFont, font, new IntPtr(1));
+
+            return hwnd;
+        }
+
+        private static IntPtr StaticWndProc(IntPtr hwnd, uint message, IntPtr wParam, IntPtr lParam)
+        {
+            NativePromptWindow? prompt;
+            lock (PromptLock)
+            {
+                Prompts.TryGetValue(hwnd, out prompt);
+            }
+
+            if (prompt == null)
+                return DefWindowProcW(hwnd, message, wParam, lParam);
+
+            switch (message)
+            {
+                case WindowMessageCommand:
+                    var buttonId = ButtonIdFromWParam(wParam);
+                    if (buttonId is AllowOnceButtonId or AlwaysAllowButtonId or DenyButtonId)
+                    {
+                        prompt.Complete(buttonId);
+                        return IntPtr.Zero;
+                    }
+
+                    return DefWindowProcW(hwnd, message, wParam, lParam);
+                case WindowMessageClose:
+                    prompt.Complete(DenyButtonId);
+                    return IntPtr.Zero;
+                case WindowMessageDestroy:
+                    lock (PromptLock)
+                    {
+                        Prompts.Remove(hwnd);
+                    }
+                    prompt._completed = true;
+                    return IntPtr.Zero;
+                default:
+                    return DefWindowProcW(hwnd, message, wParam, lParam);
+            }
+        }
+
+        private void Complete(int buttonId)
+        {
+            _decision = buttonId switch
+            {
+                AllowOnceButtonId => ExecApprovalPromptDecision.AllowOnce(),
+                AlwaysAllowButtonId => ExecApprovalPromptDecision.AlwaysAllow(),
+                _ => ExecApprovalPromptDecision.Deny()
+            };
+            _completed = true;
+            if (_hwnd != IntPtr.Zero)
+                DestroyWindow(_hwnd);
+        }
+
+        private static int ButtonIdFromWParam(IntPtr wParam) => (int)((long)wParam & 0xffff);
+
+        private delegate IntPtr WndProc(IntPtr hwnd, uint message, IntPtr wParam, IntPtr lParam);
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct WindowClass
+        {
+            public uint style;
+            public WndProc lpfnWndProc;
+            public int cbClsExtra;
+            public int cbWndExtra;
+            public IntPtr hInstance;
+            public IntPtr hIcon;
+            public IntPtr hCursor;
+            public IntPtr hbrBackground;
+
+            [MarshalAs(UnmanagedType.LPWStr)]
+            public string? lpszMenuName;
+
+            [MarshalAs(UnmanagedType.LPWStr)]
+            public string lpszClassName;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct Message
+        {
+            public IntPtr hwnd;
+            public uint message;
+            public IntPtr wParam;
+            public IntPtr lParam;
+            public uint time;
+            public int ptX;
+            public int ptY;
+        }
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern ushort RegisterClassW(ref WindowClass lpWndClass);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr CreateWindowExW(
+            uint dwExStyle,
+            string lpClassName,
+            string lpWindowName,
+            uint dwStyle,
+            int x,
+            int y,
+            int nWidth,
+            int nHeight,
+            IntPtr hWndParent,
+            IntPtr hMenu,
+            IntPtr hInstance,
+            IntPtr lpParam);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr DefWindowProcW(IntPtr hwnd, uint message, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        private static extern bool DestroyWindow(IntPtr hwnd);
+
+        [DllImport("user32.dll")]
+        private static extern bool ShowWindow(IntPtr hwnd, int nCmdShow);
+
+        [DllImport("user32.dll")]
+        private static extern bool UpdateWindow(IntPtr hwnd);
+
+        [DllImport("user32.dll")]
+        private static extern bool SetForegroundWindow(IntPtr hwnd);
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr SetFocus(IntPtr hwnd);
+
+        [DllImport("user32.dll")]
+        private static extern int GetMessageW(out Message lpMsg, IntPtr hWnd, uint wMsgFilterMin, uint wMsgFilterMax);
+
+        [DllImport("user32.dll")]
+        private static extern bool TranslateMessage(ref Message lpMsg);
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr DispatchMessageW(ref Message lpMsg);
+
+        [DllImport("user32.dll")]
+        private static extern void PostQuitMessage(int nExitCode);
+
+        [DllImport("user32.dll")]
+        private static extern int GetSystemMetrics(int nIndex);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr SendMessageW(IntPtr hwnd, uint message, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr GetModuleHandleW(string? lpModuleName);
+
+        [DllImport("gdi32.dll")]
+        private static extern IntPtr GetStockObject(int fnObject);
+
+        private const int ErrorClassAlreadyExists = 1410;
+        private const int SystemMetricScreenWidth = 0;
+        private const int SystemMetricScreenHeight = 1;
+        private const int DefaultGuiFont = 17;
+        private const int ShowWindowCommandShow = 5;
+        private const int ColorWindow = 5;
+
+        private const uint WindowMessageCommand = 0x0111;
+        private const uint WindowMessageClose = 0x0010;
+        private const uint WindowMessageDestroy = 0x0002;
+        private const uint WindowMessageSetFont = 0x0030;
+
+        private const uint WindowExStyleDialogModalFrame = 0x00000001;
+        private const uint WindowExStyleTopMost = 0x00000008;
+        private const uint WindowExStyleClientEdge = 0x00000200;
+
+        private const uint WindowStyleCaption = 0x00C00000;
+        private const uint WindowStyleSystemMenu = 0x00080000;
+        private const uint WindowStyleVisible = 0x10000000;
+        private const uint WindowStyleChild = 0x40000000;
+        private const uint WindowStyleVerticalScroll = 0x00200000;
+
+        private const uint StaticStyleLeft = 0x00000000;
+        private const uint EditStyleMultiline = 0x00000004;
+        private const uint EditStyleAutoVerticalScroll = 0x00000040;
+        private const uint EditStyleReadOnly = 0x00000800;
+        private const uint EditStyleWantReturn = 0x00001000;
+        private const uint ButtonStylePushButton = 0x00000000;
+        private const uint ButtonStyleDefaultPushButton = 0x00000001;
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Services/ExecApprovalPromptService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ExecApprovalPromptService.cs
@@ -135,6 +135,9 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
 
         private readonly string _text;
         private IntPtr _hwnd;
+        private IntPtr _allowOnceButtonHwnd;
+        private IntPtr _alwaysAllowButtonHwnd;
+        private IntPtr _denyButtonHwnd;
         private ExecApprovalPromptDecision _decision = ExecApprovalPromptDecision.Deny();
         private bool _completed;
 
@@ -243,10 +246,10 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
 
             var totalButtonWidth = ButtonWidth * 3 + ButtonGap * 2;
             var firstLeft = WindowWidth - 20 - totalButtonWidth;
-            CreateChild(hwnd, "BUTTON", "Allow once", firstLeft, ButtonTop, ButtonWidth, ButtonHeight, ButtonStylePushButton, AllowOnceButtonId, font);
-            CreateChild(hwnd, "BUTTON", "Always allow", firstLeft + ButtonWidth + ButtonGap, ButtonTop, ButtonWidth, ButtonHeight, ButtonStylePushButton, AlwaysAllowButtonId, font);
-            var denyButton = CreateChild(hwnd, "BUTTON", "Deny", firstLeft + (ButtonWidth + ButtonGap) * 2, ButtonTop, ButtonWidth, ButtonHeight, ButtonStyleDefaultPushButton, DenyButtonId, font);
-            SetFocus(denyButton);
+            _allowOnceButtonHwnd = CreateChild(hwnd, "BUTTON", "Allow once", firstLeft, ButtonTop, ButtonWidth, ButtonHeight, ButtonStylePushButton, AllowOnceButtonId, font);
+            _alwaysAllowButtonHwnd = CreateChild(hwnd, "BUTTON", "Always allow", firstLeft + ButtonWidth + ButtonGap, ButtonTop, ButtonWidth, ButtonHeight, ButtonStylePushButton, AlwaysAllowButtonId, font);
+            _denyButtonHwnd = CreateChild(hwnd, "BUTTON", "Deny", firstLeft + (ButtonWidth + ButtonGap) * 2, ButtonTop, ButtonWidth, ButtonHeight, ButtonStyleDefaultPushButton, DenyButtonId, font);
+            SetFocus(_denyButtonHwnd);
         }
 
         private static IntPtr CreateChild(
@@ -296,10 +299,10 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
             switch (message)
             {
                 case WindowMessageCommand:
-                    var buttonId = ButtonIdFromWParam(wParam);
-                    if (buttonId is AllowOnceButtonId or AlwaysAllowButtonId or DenyButtonId)
+                    var buttonId = prompt.ResolveButtonCommand(wParam, lParam);
+                    if (buttonId.HasValue)
                     {
-                        prompt.Complete(buttonId);
+                        prompt.Complete(buttonId.Value);
                         return IntPtr.Zero;
                     }
 
@@ -317,6 +320,24 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
                 default:
                     return DefWindowProcW(hwnd, message, wParam, lParam);
             }
+        }
+
+        private int? ResolveButtonCommand(IntPtr wParam, IntPtr lParam)
+        {
+            var buttonId = ButtonIdFromWParam(wParam);
+            if (buttonId is AllowOnceButtonId or AlwaysAllowButtonId or DenyButtonId)
+                return buttonId;
+
+            if (lParam == _allowOnceButtonHwnd)
+                return AllowOnceButtonId;
+
+            if (lParam == _alwaysAllowButtonHwnd)
+                return AlwaysAllowButtonId;
+
+            if (lParam == _denyButtonHwnd)
+                return DenyButtonId;
+
+            return null;
         }
 
         private void Complete(int buttonId)

--- a/src/OpenClaw.Tray.WinUI/app.manifest
+++ b/src/OpenClaw.Tray.WinUI/app.manifest
@@ -16,4 +16,16 @@
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>
+
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*" />
+    </dependentAssembly>
+  </dependency>
 </assembly>

--- a/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
+++ b/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
@@ -498,6 +498,62 @@ public class GatewayConnectionManagerTests : IDisposable
     }
 
     [Fact]
+    public async Task ConnectNodeOnlyAsync_UsesNodeCredential_WhenOperatorCredentialMissing()
+    {
+        SetupGateway("gw-1", "wss://test");
+        _resolver.OperatorCredential = null;
+        _resolver.NodeCredential = new GatewayCredential(
+            "node-token",
+            IsBootstrapToken: false,
+            Source: CredentialResolver.SourceNodeDeviceToken);
+        var node = new CountingNodeConnector();
+        using var manager = new GatewayConnectionManager(
+            _resolver,
+            _factory,
+            _registry,
+            NullLogger.Instance,
+            nodeConnector: node);
+
+        await manager.ConnectNodeOnlyAsync("gw-1");
+
+        Assert.Empty(_factory.CreatedCredentials);
+        Assert.Equal(1, node.ConnectCount);
+        Assert.Equal("wss://test", node.LastGatewayUrl);
+    }
+
+    [Fact]
+    public async Task ConnectNodeOnlyAsync_StartsSshTunnel_WhenGatewayUsesTunnel()
+    {
+        _registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "gw-ssh",
+            Url = "wss://remote.example",
+            SshTunnel = new SshTunnelConfig("user", "host.example", 18789, 45678)
+        });
+        _registry.SetActive("gw-ssh");
+        _resolver.OperatorCredential = null;
+        _resolver.NodeCredential = new GatewayCredential(
+            "node-token",
+            IsBootstrapToken: false,
+            Source: CredentialResolver.SourceNodeDeviceToken);
+        var node = new CountingNodeConnector();
+        var tunnel = new CountingTunnelManager();
+        using var manager = new GatewayConnectionManager(
+            _resolver,
+            _factory,
+            _registry,
+            NullLogger.Instance,
+            nodeConnector: node,
+            tunnelManager: tunnel);
+
+        await manager.ConnectNodeOnlyAsync("gw-ssh");
+
+        Assert.Equal(1, tunnel.StartCount);
+        Assert.Equal("host.example", tunnel.LastConfig?.Host);
+        Assert.Equal("ws://localhost:45678", node.LastGatewayUrl);
+    }
+
+    [Fact]
     public async Task EnsureNodeConnectedAsync_HappyPath_ReturnsWhenPaired()
     {
         SetupGateway("gw-1", "wss://test");
@@ -803,6 +859,31 @@ public class GatewayConnectionManagerTests : IDisposable
 
             DisconnectStarted.SetResult(true);
             await AllowDisconnect.Task;
+        }
+
+        public void Dispose() { }
+    }
+
+    private sealed class CountingTunnelManager : ISshTunnelManager
+    {
+        public int StartCount { get; private set; }
+        public SshTunnelConfig? LastConfig { get; private set; }
+        public bool IsActive => StartCount > 0;
+        public string? LocalTunnelUrl { get; private set; }
+
+        public Task<string> StartAsync(SshTunnelConfig config, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            StartCount++;
+            LastConfig = config;
+            LocalTunnelUrl = $"ws://localhost:{config.LocalPort}";
+            return Task.FromResult(LocalTunnelUrl);
+        }
+
+        public Task StopAsync()
+        {
+            LocalTunnelUrl = null;
+            return Task.CompletedTask;
         }
 
         public void Dispose() { }

--- a/tests/OpenClaw.Connection.Tests/OperatorScopeHelperTests.cs
+++ b/tests/OpenClaw.Connection.Tests/OperatorScopeHelperTests.cs
@@ -172,6 +172,7 @@ public class ChatNavigationReadinessTests
         };
 
         public Task ConnectAsync(string? gatewayId = null) => Task.CompletedTask;
+        public Task ConnectNodeOnlyAsync(string? gatewayId = null) => Task.CompletedTask;
         public Task DisconnectAsync() => Task.CompletedTask;
         public Task ReconnectAsync() => Task.CompletedTask;
         public Task SwitchGatewayAsync(string gatewayId) => Task.CompletedTask;

--- a/tests/OpenClaw.Shared.Tests/SystemRunTests.cs
+++ b/tests/OpenClaw.Shared.Tests/SystemRunTests.cs
@@ -431,6 +431,42 @@ public class SystemRunTests
     }
 
     [Fact]
+    public async Task SystemRun_WithPromptPolicy_PromptsOnceForShellWrapper_WhenUserApprovesOnce()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var logger = new ExecTestLogger();
+            var policy = new ExecApprovalPolicy(tempDir, logger);
+            policy.SetRules(Array.Empty<ExecApprovalRule>(), ExecApprovalAction.Prompt);
+            var runner = new FakeCommandRunner();
+            var prompt = new FakePromptHandler(ExecApprovalPromptDecision.AllowOnce());
+            var cap = new SystemCapability(logger);
+            cap.SetCommandRunner(runner);
+            cap.SetApprovalPolicy(policy);
+            cap.SetPromptHandler(prompt);
+
+            var res = await cap.ExecuteAsync(new NodeInvokeRequest
+            {
+                Id = "prompt-wrapper-1",
+                Command = "system.run",
+                Args = Parse("""{"command":"cmd /c echo hello"}""")
+            });
+
+            Assert.True(res.Ok, res.Error);
+            Assert.NotNull(runner.LastRequest);
+            Assert.Equal(1, prompt.CallCount);
+            Assert.Empty(policy.Rules);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { }
+        }
+    }
+
+    [Fact]
     public async Task SystemRun_WithPromptPolicy_PersistsExactAllowRule_WhenUserAlwaysAllows()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"test-{Guid.NewGuid():N}");
@@ -457,6 +493,88 @@ public class SystemRunTests
             Assert.Single(policy.Rules);
             Assert.Equal("whoami", policy.Rules[0].Pattern);
             Assert.Equal(ExecApprovalAction.Allow, policy.Rules[0].Action);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task SystemRun_WithPromptPolicy_AlwaysAllowWrapperPersistsSingleRule_AndCoversRepeat()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var logger = new ExecTestLogger();
+            var policy = new ExecApprovalPolicy(tempDir, logger);
+            policy.SetRules(Array.Empty<ExecApprovalRule>(), ExecApprovalAction.Prompt);
+            var runner = new FakeCommandRunner();
+            var prompt = new FakePromptHandler(ExecApprovalPromptDecision.AlwaysAllow());
+            var cap = new SystemCapability(logger);
+            cap.SetCommandRunner(runner);
+            cap.SetApprovalPolicy(policy);
+            cap.SetPromptHandler(prompt);
+
+            var req = new NodeInvokeRequest
+            {
+                Id = "prompt-wrapper-2",
+                Command = "system.run",
+                Args = Parse("""{"command":"cmd /c echo repeat"}""")
+            };
+
+            var first = await cap.ExecuteAsync(req);
+            Assert.True(first.Ok, first.Error);
+            Assert.Equal(1, prompt.CallCount);
+            Assert.Single(policy.Rules);
+            Assert.Equal("cmd /c echo repeat", policy.Rules[0].Pattern);
+
+            var second = await cap.ExecuteAsync(req);
+            Assert.True(second.Ok, second.Error);
+            Assert.Equal(1, prompt.CallCount);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task SystemRun_WithPromptPolicy_StillDeniesExplicitBlockedShellWrapperPayload()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var logger = new ExecTestLogger();
+            var policy = new ExecApprovalPolicy(tempDir, logger);
+            policy.SetRules(
+                new[]
+                {
+                    new ExecApprovalRule { Pattern = "del *", Action = ExecApprovalAction.Deny }
+                },
+                ExecApprovalAction.Prompt);
+            var runner = new FakeCommandRunner();
+            var prompt = new FakePromptHandler(ExecApprovalPromptDecision.AllowOnce());
+            var cap = new SystemCapability(logger);
+            cap.SetCommandRunner(runner);
+            cap.SetApprovalPolicy(policy);
+            cap.SetPromptHandler(prompt);
+
+            var res = await cap.ExecuteAsync(new NodeInvokeRequest
+            {
+                Id = "prompt-wrapper-3",
+                Command = "system.run",
+                Args = Parse("""{"command":"cmd /c del C:\\important.txt"}""")
+            });
+
+            Assert.False(res.Ok);
+            Assert.Contains("denied", res.Error!, StringComparison.OrdinalIgnoreCase);
+            Assert.Null(runner.LastRequest);
+            Assert.Equal(1, prompt.CallCount);
         }
         finally
         {
@@ -525,10 +643,15 @@ public class SystemRunTests
             _decision = decision;
         }
 
+        public int CallCount { get; private set; }
+
         public Task<ExecApprovalPromptDecision> RequestAsync(
             ExecApprovalPromptRequest request,
-            CancellationToken cancellationToken = default) =>
-            Task.FromResult(_decision);
+            CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult(_decision);
+        }
     }
 }
 

--- a/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
@@ -42,6 +42,42 @@ public class WindowsNodeClientTests
         }
     }
 
+    [Fact]
+    public void Constructor_UsesAppVersionForRegistrationAndConnectMessage()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+        AppVersionInfo.TestOverride = "0.6.0-alpha.14";
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+
+            var registrationField = typeof(WindowsNodeClient).GetField(
+                "_registration",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var reg = (NodeRegistration)registrationField!.GetValue(client)!;
+            Assert.Equal("0.6.0-alpha.14", reg.Version);
+
+            using var doc = JsonDocument.Parse(InvokeBuildNodeConnectMessage(client));
+            var parameters = doc.RootElement.GetProperty("params");
+            Assert.Equal(
+                "0.6.0-alpha.14",
+                parameters.GetProperty("client").GetProperty("version").GetString());
+            Assert.Equal(
+                "openclaw-windows-node/0.6.0-alpha.14",
+                parameters.GetProperty("userAgent").GetString());
+        }
+        finally
+        {
+            AppVersionInfo.TestOverride = null;
+            if (Directory.Exists(dataPath))
+            {
+                Directory.Delete(dataPath, true);
+            }
+        }
+    }
+
     /// <summary>
     /// Regression test: when hello-ok includes auth.deviceToken, PairingStatusChanged must
     /// fire exactly once — not twice (once from the token block and again from the DeviceToken

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -72,6 +72,19 @@ public sealed class AppRefactorContractTests
     }
 
     [Fact]
+    public void Startup_NodeOnlyReconnect_UsesNodeCredentialAndLegacyIdentityFallback()
+    {
+        var source = ReadAppSources();
+        var connectMethod = ExtractMethod(source, "TryConnectGatewayIfCredentialAvailable");
+        var nodeCredentialMethod = ExtractMethod(source, "ResolveStartupNodeCredential");
+
+        Assert.Contains("ResolveStartupNodeCredential(record, resolver, identityDir)", connectMethod);
+        Assert.Contains("_connectionManager.ConnectNodeOnlyAsync(record.Id)", connectMethod);
+        Assert.Contains("resolver.ResolveNode(record, SettingsManager.SettingsDirectoryPath)", nodeCredentialMethod);
+        Assert.Contains("TryCopyLegacyIdentityToGateway(record.Id, identityDir)", nodeCredentialMethod);
+    }
+
+    [Fact]
     public void ToastActivation_RoutesOnUiThread()
     {
         var source = ReadAppSources();
@@ -127,7 +140,7 @@ public sealed class AppRefactorContractTests
     {
         var match = Regex.Match(
             source,
-            $@"(?m)^\s*(?:private|protected|public|internal)\s+(?:async\s+)?(?:Task(?:<[^>]+>)?|void|bool|string\??|IntPtr)\s+{Regex.Escape(methodName)}\s*\(");
+            $@"(?m)^\s*(?:private|protected|public|internal)\s+(?:async\s+)?(?:Task(?:<[^>]+>)?|void|bool|string\??|IntPtr|OpenClaw\.Connection\.GatewayCredential\?)\s+{Regex.Escape(methodName)}\s*\(");
         Assert.True(match.Success, $"Could not find method {methodName}.");
 
         var brace = source.IndexOf('{', match.Index);


### PR DESCRIPTION
## Summary
- replace hardcoded `1.0.0` Windows node/tray handshake version fields with `AppVersionInfo.Version`
- reconnect already-paired Windows nodes on startup using the persisted node device token instead of requiring bootstrap/shared credentials
- preserve credential precedence so startup does not downgrade a paired node from its device token back to bootstrap/shared tokens
- fix the native exec approval prompt loop so real button clicks wake the pending approval path
- avoid double exec-approval prompts for approved shell wrappers while still honoring explicit inner deny rules
- add regression coverage for node-only reconnect, SSH tunnel startup, startup fallback wiring, and shell-wrapper exec approvals

## Validation
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean on the branch after the earlier review fixes
- CI Build and Test run `26730526429` on `21984db`: repo-hygiene, test, e2etests, build win-x64, and build win-arm64 all passed
- staged current x64 PR artifact on an Azure crabbox: product version `0.6.0-PullRequest613.737`; PR artifact is expected unsigned
- node identity/version check on current artifact: active paired node stayed on the same device identity, connected=true, pending=0, version reports `0.6.0-PullRequest613.737`
- restart hardening checks on current artifact:
  - Windows tray restart through repaired task launcher: same active node reconnected, pending=0, version `.737`
  - Linux gateway restart: same active node reconnected, pending=0, version `.737`
  - Windows VM reboot + tray task start: same active node reconnected, pending=0, version `.737`
  - credential files stayed on node device token; no shared/bootstrap token downgrade observed
- exec approval interactive matrix on current artifact using real mouse input:
  - Deny clicked and returned policy denial instead of hanging
  - Allow once clicked and `node.invoke system.run` returned stdout `PR613_ALLOW_ONCE_737`; no rule persisted
  - Always allow clicked and `node.invoke system.run` returned stdout `PR613_ALWAYS_737`; exactly one wrapper allow rule persisted
  - Repeated the exact always-allowed command without starting the clicker; it succeeded without a new prompt
- restored the crabbox approval policy to its original `defaultAction=deny`, 22-rule state after testing

## Known Follow-Up
- The extracted-artifact scheduled task has no reboot trigger, so the reboot smoke is intentionally "VM reboot + tray task start", not autostart validation.
- A stale disconnected paired node with version `1.0.0` still exists in the gateway registry, but no duplicate pending request was created and the active node stayed stable.
- PR artifacts are unsigned. The Azure Trusted Signing release workflow remains the path for signed alpha/beta release artifacts.