### PR TITLE
Fix mojibake in localized tray resources

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -138,7 +138,7 @@
     <value>EXTENSIBILITÉ</value>
   </data>
   <data name="StatusNodesHeader.Text" xml:space="preserve">
-    <value>NÅ’UDS</value>
+    <value>NŒUDS</value>
   </data>
   <data name="StatusRecentActivityHeader.Text" xml:space="preserve">
     <value>ACTIVITÉ RÉCENTE</value>
@@ -228,7 +228,7 @@
     <value>Ouvrir</value>
   </data>
   <data name="StatusCopyNodeInventoryButton.Content" xml:space="preserve">
-    <value>Copier l'inventaire des nÅ“uds</value>
+    <value>Copier l'inventaire des nœuds</value>
   </data>
   <data name="StatusOpenStreamButton.Content" xml:space="preserve">
     <value>Ouvrir le flux</value>
@@ -246,7 +246,7 @@
     <value>Utilisations</value>
   </data>
   <data name="ActivityFilterNodes.Content" xml:space="preserve">
-    <value>NÅ“uds</value>
+    <value>Nœuds</value>
   </data>
   <data name="ActivityFilterNotifications.Content" xml:space="preserve">
     <value>Alertes</value>
@@ -446,7 +446,7 @@
     <value>Diagnostics des capacités</value>
   </data>
   <data name="Menu_NodeInventory" xml:space="preserve">
-    <value>Inventaire des nÅ“uds</value>
+    <value>Inventaire des nœuds</value>
   </data>
   <data name="Menu_ChannelSummary" xml:space="preserve">
     <value>Résumé des canaux</value>
@@ -467,7 +467,7 @@
     <value>Séances ({0})</value>
   </data>
   <data name="Menu_NodesFormat" xml:space="preserve">
-    <value>NÅ“uds ({0})</value>
+    <value>Nœuds ({0})</value>
   </data>
   <data name="Menu_RecentActivityFormat" xml:space="preserve">
     <value>Activité récente ({0})</value>
@@ -872,19 +872,19 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>✅ Code de configuration décodé — appuyez sur Tester la connexion</value>
   </data>
   <data name="Setup_NodeModeTitle" xml:space="preserve">
-    <value>Activer le mode nÅ“ud (optionnel)</value>
+    <value>Activer le mode nœud (optionnel)</value>
   </data>
   <data name="Setup_NodeModeDescription" xml:space="preserve">
     <value>Le mode nœud permet à votre machine Windows d'exécuter des tâches pour OpenClaw — comme la capture d'écran, l'accès caméra et le dessin sur canevas.</value>
   </data>
   <data name="Setup_NodeModeSecurityTitle" xml:space="preserve">
-    <value>Activez le mode nÅ“ud uniquement pour les passerelles et agents de confiance</value>
+    <value>Activez le mode nœud uniquement pour les passerelles et agents de confiance</value>
   </data>
   <data name="Setup_NodeModeSecurityMessage" xml:space="preserve">
     <value>Les agents approuvés peuvent exécuter des commandes locales et accéder aux surfaces activées comme l'écran, la caméra, la localisation, le navigateur et le canevas. Vous pouvez désactiver des groupes de capacités plus tard dans Paramètres.</value>
   </data>
   <data name="Setup_NodeModeToggle" xml:space="preserve">
-    <value>Activer le mode nÅ“ud</value>
+    <value>Activer le mode nœud</value>
   </data>
   <data name="Setup_DeviceIdLoading" xml:space="preserve">
     <value>ID de l'appareil : chargement...</value>
@@ -1145,7 +1145,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Collez le token d'amorçage</value>
   </data>
   <data name="Onboarding_Connection_NodeMode" xml:space="preserve">
-    <value>Mode nÅ“ud</value>
+    <value>Mode nœud</value>
   </data>
   <data name="Onboarding_Connection_TestConnection" xml:space="preserve">
     <value>Tester la connexion</value>
@@ -1358,7 +1358,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Utilisateur SSH</value>
   </data>
   <data name="Onboarding_Connection_SshHost" xml:space="preserve">
-    <value>H├┤te SSH</value>
+    <value>Hôte SSH</value>
   </data>
   <data name="Onboarding_Connection_SshRemotePort" xml:space="preserve">
     <value>Port de la passerelle distante</value>
@@ -1765,7 +1765,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>user</value>
   </data>
   <data name="SshHostBox.Header" xml:space="preserve">
-    <value>H├┤te SSH</value>
+    <value>Hôte SSH</value>
   </data>
   <data name="SshHostBox.PlaceholderText" xml:space="preserve">
     <value>machine-name</value>
@@ -1867,7 +1867,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>URL de la passerelle</value>
   </data>
   <data name="DebugPage_TextBlock_61.Text" xml:space="preserve">
-    <value>Mode nÅ“ud</value>
+    <value>Mode nœud</value>
   </data>
   <data name="DebugPage_TextBlock_72.Text" xml:space="preserve">
     <value>Identité de l’appareil</value>
@@ -1957,7 +1957,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value> (désactivée)</value>
   </data>
   <data name="NodesPage_Rename_Title" xml:space="preserve">
-    <value>Renommer le nÅ“ud</value>
+    <value>Renommer le nœud</value>
   </data>
   <data name="NodesPage_Rename_Body" xml:space="preserve">
     <value>Choisissez un nouveau nom d'affichage pour {0}.</value>
@@ -1975,7 +1975,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Échec du renommage.</value>
   </data>
   <data name="NodesPage_Forget_Title" xml:space="preserve">
-    <value>Oublier le nÅ“ud ?</value>
+    <value>Oublier le nœud ?</value>
   </data>
   <data name="NodesPage_Forget_Body" xml:space="preserve">
     <value>Cela supprimera l'enregistrement du nœud ci-dessous dans la passerelle. Le nœud devra se réappairer pour pouvoir se reconnecter.</value>
@@ -1984,7 +1984,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Les sessions opérateur et de chat actives qui ciblent ce nœud perdront l'accès immédiatement.</value>
   </data>
   <data name="NodesPage_Forget_Primary" xml:space="preserve">
-    <value>Oublier le nÅ“ud</value>
+    <value>Oublier le nœud</value>
   </data>
   <data name="NodesPage_Forget_Error_Generic" xml:space="preserve">
     <value>Impossible d'oublier le nœud — passerelle inaccessible ou autorisation refusée.</value>
@@ -3673,7 +3673,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Voir les instances ›</value>
   </data>
   <data name="ConnectionPage_NodeMode.Text" xml:space="preserve">
-    <value>Mode nÅ“ud</value>
+    <value>Mode nœud</value>
   </data>
   <data name="ConnectionPage_WhenOnThisPC.Text" xml:space="preserve">
     <value>Lorsqu'il est activé, ce PC s'enregistre comme nœud et offre les capacités ci-dessous aux agents via la passerelle.</value>
@@ -4081,7 +4081,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Autorisations</value>
   </data>
   <data name="PermissionsPage_NodeMode.Text" xml:space="preserve">
-    <value>Mode nÅ“ud</value>
+    <value>Mode nœud</value>
   </data>
   <data name="PermissionsPage_WhenOnThisPC.Text" xml:space="preserve">
     <value>Lorsqu'il est activé, ce PC s'enregistre comme nœud et offre les capacités ci-dessous aux agents via la passerelle.</value>
@@ -4438,7 +4438,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Erreur</value>
   </data>
   <data name="ConnectionStatusWindow_NODE.Text" xml:space="preserve">
-    <value>NÅ’UD</value>
+    <value>NŒUD</value>
   </data>
   <data name="ConnectionStatusWindow_Off2.Text" xml:space="preserve">
     <value>Désactivé</value>
@@ -4546,7 +4546,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Op.</value>
   </data>
   <data name="HubWindow_Node.Text" xml:space="preserve">
-    <value>NÅ“ud</value>
+    <value>Nœud</value>
   </data>
   <data name="HubWindow_Advanced.Content" xml:space="preserve">
     <value>Avancé</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -18,262 +18,262 @@
     </xs:element>
   </xs:schema>
   <data name="SettingsConnectionHeader.Text" xml:space="preserve">
-    <value>è¿žæŽ¥</value>
+    <value>连接</value>
   </data>
   <data name="SettingsStartupHeader.Text" xml:space="preserve">
-    <value>å¯åŠ¨</value>
+    <value>启动</value>
   </data>
   <data name="SettingsNotificationsHeader.Text" xml:space="preserve">
-    <value>é€šçŸ¥</value>
+    <value>通知</value>
   </data>
   <data name="SettingsAdvancedHeader.Text" xml:space="preserve">
-    <value>é«˜çº§ï¼ˆå®žéªŒæ€§ï¼‰</value>
+    <value>高级（实验性）</value>
   </data>
   <data name="SettingsGatewayUrlTextBox.Header" xml:space="preserve">
-    <value>ç½‘å…³åœ°å€</value>
+    <value>网关地址</value>
   </data>
   <data name="SettingsGatewayUrlTextBox.PlaceholderText" xml:space="preserve">
-    <value>ws://localhost:18789 æˆ– https://host.tailnet.ts.net</value>
+    <value>ws://localhost:18789 或 https://host.tailnet.ts.net</value>
   </data>
   <data name="SettingsTokenTextBox.Header" xml:space="preserve">
-    <value>ä»¤ç‰Œ</value>
+    <value>令牌</value>
   </data>
   <data name="SettingsTokenTextBox.PlaceholderText" xml:space="preserve">
-    <value>æ‚¨çš„ API ä»¤ç‰Œ</value>
+    <value>您的 API 令牌</value>
   </data>
   <data name="SettingsAutoStartToggle.Header" xml:space="preserve">
-    <value>éš Windows è‡ªåŠ¨å¯åŠ¨</value>
+    <value>随 Windows 自动启动</value>
   </data>
   <data name="SettingsGlobalHotkeyToggle.Header" xml:space="preserve">
     <value>全局快捷键 (Ctrl+Alt+Shift+C → 快速发送)</value>
   </data>
   <data name="SettingsNotificationsToggle.Header" xml:space="preserve">
-    <value>æ˜¾ç¤ºé€šçŸ¥</value>
+    <value>显示通知</value>
   </data>
   <data name="SettingsNodeModeToggle.Header" xml:space="preserve">
-    <value>å¯ç”¨èŠ‚ç‚¹æ¨¡å¼</value>
+    <value>启用节点模式</value>
   </data>
   <data name="SettingsSoundComboBox.Header" xml:space="preserve">
-    <value>æç¤ºéŸ³</value>
+    <value>提示音</value>
   </data>
   <data name="SettingsSoundDefault.Content" xml:space="preserve">
-    <value>é»˜è®¤</value>
+    <value>默认</value>
   </data>
   <data name="SettingsSoundNone.Content" xml:space="preserve">
-    <value>æ— </value>
+    <value>无</value>
   </data>
   <data name="SettingsSoundSubtle.Content" xml:space="preserve">
-    <value>æŸ”å’Œ</value>
+    <value>柔和</value>
   </data>
   <data name="SettingsNotifyForLabel.Text" xml:space="preserve">
-    <value>æ˜¾ç¤ºä»¥ä¸‹ç±»åž‹é€šçŸ¥:</value>
+    <value>显示以下类型通知:</value>
   </data>
   <data name="SettingsNotifyFilterHint.Text" xml:space="preserve">
-    <value>æŒ‰æ¶ˆæ¯ä¸­çš„å…³é”®è¯è¿‡æ»¤ï¼ˆä¾‹å¦‚"é‚®ä»¶"ã€"æé†’"ï¼‰</value>
+    <value>按消息中的关键词过滤（例如"邮件"、"提醒"）</value>
   </data>
   <data name="SettingsNotifyHealthCb.Content" xml:space="preserve">
-    <value>å¥åº·è­¦æŠ¥</value>
+    <value>健康警报</value>
   </data>
   <data name="SettingsNotifyUrgentCb.Content" xml:space="preserve">
-    <value>ç´§æ€¥æ¶ˆæ¯</value>
+    <value>紧急消息</value>
   </data>
   <data name="SettingsNotifyReminderCb.Content" xml:space="preserve">
-    <value>æé†’</value>
+    <value>提醒</value>
   </data>
   <data name="SettingsNotifyEmailCb.Content" xml:space="preserve">
-    <value>é‚®ä»¶æ‘˜è¦</value>
+    <value>邮件摘要</value>
   </data>
   <data name="SettingsNotifyCalendarCb.Content" xml:space="preserve">
-    <value>æ—¥åŽ†äº‹ä»¶</value>
+    <value>日历事件</value>
   </data>
   <data name="SettingsNotifyBuildCb.Content" xml:space="preserve">
-    <value>æž„å»ºé€šçŸ¥</value>
+    <value>构建通知</value>
   </data>
   <data name="SettingsNotifyStockCb.Content" xml:space="preserve">
-    <value>è‚¡ç¥¨æé†’</value>
+    <value>股票提醒</value>
   </data>
   <data name="SettingsNotifyInfoCb.Content" xml:space="preserve">
-    <value>å¸¸è§„ä¿¡æ¯</value>
+    <value>常规信息</value>
   </data>
   <data name="SettingsTestConnectionButton.Content" xml:space="preserve">
-    <value>æµ‹è¯•</value>
+    <value>测试</value>
   </data>
   <data name="SettingsTestNotificationButton.Content" xml:space="preserve">
-    <value>å‘é€æµ‹è¯•é€šçŸ¥</value>
+    <value>发送测试通知</value>
   </data>
   <data name="SettingsSaveButton.Content" xml:space="preserve">
-    <value>ä¿å­˜</value>
+    <value>保存</value>
   </data>
   <data name="SettingsCancelButton.Content" xml:space="preserve">
-    <value>å–æ¶ˆ</value>
+    <value>取消</value>
   </data>
   <data name="SettingsNodeModeDescription.Text" xml:space="preserve">
-    <value>å¯ç”¨åŽï¼Œæ­¤ç”µè„‘å¯ä»¥æŽ¥æ”¶æ¥è‡ªä»£ç†çš„å‘½ä»¤ï¼ˆç”»å¸ƒã€æˆªå›¾ç­‰ï¼‰</value>
+    <value>启用后，此电脑可以接收来自代理的命令（画布、截图等）</value>
   </data>
   <data name="StatusUsageHeader.Text" xml:space="preserve">
-    <value>ç”¨é‡</value>
+    <value>用量</value>
   </data>
   <data name="StatusSessionsHeader.Text" xml:space="preserve">
-    <value>æ´»è·ƒä¼šè¯</value>
+    <value>活跃会话</value>
   </data>
   <data name="StatusChannelsHeader.Text" xml:space="preserve">
-    <value>é¢‘é“</value>
+    <value>频道</value>
   </data>
   <data name="StatusGatewayTopologyHeader.Text" xml:space="preserve">
-    <value>ç½‘å…³æ‹“æ‰‘</value>
+    <value>网关拓扑</value>
   </data>
   <data name="StatusSupportDebugHeader.Text" xml:space="preserve">
-    <value>æ”¯æŒå’Œè°ƒè¯•</value>
+    <value>支持和调试</value>
   </data>
   <data name="StatusPortDiagnosticsHeader.Text" xml:space="preserve">
-    <value>ç«¯å£è¯Šæ–­</value>
+    <value>端口诊断</value>
   </data>
   <data name="StatusPermissionsHeader.Text" xml:space="preserve">
-    <value>æƒé™</value>
+    <value>权限</value>
   </data>
   <data name="StatusCostTrendHeader.Text" xml:space="preserve">
-    <value>30 å¤©è´¹ç”¨è¶‹åŠ¿</value>
+    <value>30 天费用趋势</value>
   </data>
   <data name="StatusExtensibilityHeader.Text" xml:space="preserve">
-    <value>æ‰©å±•æ€§</value>
+    <value>扩展性</value>
   </data>
   <data name="StatusNodesHeader.Text" xml:space="preserve">
-    <value>èŠ‚ç‚¹</value>
+    <value>节点</value>
   </data>
   <data name="StatusRecentActivityHeader.Text" xml:space="preserve">
-    <value>æœ€è¿‘æ´»åŠ¨</value>
+    <value>最近活动</value>
   </data>
   <data name="StatusCostLabel.Text" xml:space="preserve">
-    <value>è´¹ç”¨ï¼ˆçª—å£æœŸï¼‰:</value>
+    <value>费用（窗口期）:</value>
   </data>
   <data name="StatusRequestsLabel.Text" xml:space="preserve">
-    <value>è¯·æ±‚ / ä»¤ç‰Œæ•°:</value>
+    <value>请求 / 令牌数:</value>
   </data>
   <data name="StatusProvidersLabel.Text" xml:space="preserve">
-    <value>æä¾›è€…:</value>
+    <value>提供者:</value>
   </data>
   <data name="StatusConnectedText.Text" xml:space="preserve">
-    <value>å·²è¿žæŽ¥</value>
+    <value>已连接</value>
   </data>
   <data name="StatusNoSessions.Text" xml:space="preserve">
-    <value>æ— æ´»è·ƒä¼šè¯</value>
+    <value>无活跃会话</value>
   </data>
   <data name="StatusNoNodes.Text" xml:space="preserve">
-    <value>æœªæŠ¥å‘ŠèŠ‚ç‚¹</value>
+    <value>未报告节点</value>
   </data>
   <data name="StatusNoRecentActivity.Text" xml:space="preserve">
-    <value>æ²¡æœ‰æœ€è¿‘æ´»åŠ¨</value>
+    <value>没有最近活动</value>
   </data>
   <data name="StatusExtensibilityDescription.Text" xml:space="preserve">
-    <value>é¢‘é“è®¾ç½®ã€æŠ€èƒ½å’Œè®¡åˆ’è‡ªåŠ¨åŒ–ç”±ç½‘å…³ç®¡ç†ã€‚è¿žæŽ¥çš„ç½‘å…³å…¬å¼€ç›¸åº”ä»ªè¡¨æ¿é¡µé¢æ—¶ï¼Œè¯·ä½¿ç”¨è¿™äº›é“¾æŽ¥ã€‚</value>
+    <value>频道设置、技能和计划自动化由网关管理。连接的网关公开相应仪表板页面时，请使用这些链接。</value>
   </data>
   <data name="StatusChannelSetupTitle.Text" xml:space="preserve">
-    <value>é¢‘é“è®¾ç½® / æž¶æž„</value>
+    <value>频道设置 / 架构</value>
   </data>
   <data name="StatusChannelSetupDescription.Text" xml:space="preserve">
-    <value>åœ¨å¯ç”¨æ—¶æ‰“å¼€é¢‘é“è®¾ç½®ï¼Œç”¨äºŽåŸºäºŽæž¶æž„çš„èº«ä»½éªŒè¯ã€äºŒç»´ç ã€ç™»å½•å’Œä»ªè¡¨æ¿æµç¨‹ã€‚</value>
+    <value>在可用时打开频道设置，用于基于架构的身份验证、二维码、登录和仪表板流程。</value>
   </data>
   <data name="StatusSkillsTitle.Text" xml:space="preserve">
-    <value>æŠ€èƒ½</value>
+    <value>技能</value>
   </data>
   <data name="StatusSkillsDescription.Text" xml:space="preserve">
-    <value>å½“è¿žæŽ¥çš„ç½‘å…³æ”¯æŒæ—¶ï¼Œæ‰“å¼€ç½‘å…³æŠ€èƒ½é…ç½®ã€‚</value>
+    <value>当连接的网关支持时，打开网关技能配置。</value>
   </data>
   <data name="StatusCronTitle.Text" xml:space="preserve">
-    <value>Cron / è®¡åˆ’</value>
+    <value>Cron / 计划</value>
   </data>
   <data name="StatusCronDescription.Text" xml:space="preserve">
-    <value>å½“è¿žæŽ¥çš„ç½‘å…³æ”¯æŒæ—¶ï¼Œæ‰“å¼€è®¡åˆ’è‡ªåŠ¨åŒ–æŽ§ä»¶ã€‚</value>
+    <value>当连接的网关支持时，打开计划自动化控件。</value>
   </data>
   <data name="StatusRefreshButton.Content" xml:space="preserve">
-    <value>åˆ·æ–°</value>
+    <value>刷新</value>
   </data>
   <data name="StatusOpenLogsButton.Content" xml:space="preserve">
-    <value>æ‰“å¼€æ—¥å¿—</value>
+    <value>打开日志</value>
   </data>
   <data name="StatusOpenConfigButton.Content" xml:space="preserve">
-    <value>æ‰“å¼€é…ç½®</value>
+    <value>打开配置</value>
   </data>
   <data name="StatusRefreshHealthButton.Content" xml:space="preserve">
-    <value>åˆ·æ–°å¥åº·çŠ¶æ€</value>
+    <value>刷新健康状态</value>
   </data>
   <data name="StatusOpenDiagnosticsJsonlButton.Content" xml:space="preserve">
-    <value>æ‰“å¼€è¯Šæ–­ JSONL</value>
+    <value>打开诊断 JSONL</value>
   </data>
   <data name="StatusCopySupportContextButton.Content" xml:space="preserve">
-    <value>å¤åˆ¶æ”¯æŒä¸Šä¸‹æ–‡</value>
+    <value>复制支持上下文</value>
   </data>
   <data name="StatusRestartSshTunnelButton.Content" xml:space="preserve">
-    <value>é‡å¯ SSH éš§é“</value>
+    <value>重启 SSH 隧道</value>
   </data>
   <data name="StatusCopyBrowserSetupButton.Content" xml:space="preserve">
-    <value>å¤åˆ¶æµè§ˆå™¨è®¾ç½®</value>
+    <value>复制浏览器设置</value>
   </data>
   <data name="StatusCopyDebugBundleButton.Content" xml:space="preserve">
-    <value>å¤åˆ¶è°ƒè¯•åŒ…</value>
+    <value>复制调试包</value>
   </data>
   <data name="StatusCheckUpdatesButton.Content" xml:space="preserve">
-    <value>æ£€æŸ¥æ›´æ–°</value>
+    <value>检查更新</value>
   </data>
   <data name="StatusCopyPortDiagnosticsButton.Content" xml:space="preserve">
-    <value>å¤åˆ¶ç«¯å£è¯Šæ–­</value>
+    <value>复制端口诊断</value>
   </data>
   <data name="StatusCopyButton.Content" xml:space="preserve">
-    <value>å¤åˆ¶</value>
+    <value>复制</value>
   </data>
   <data name="StatusSettingsButton.Content" xml:space="preserve">
-    <value>è®¾ç½®</value>
+    <value>设置</value>
   </data>
   <data name="StatusOpenButton.Content" xml:space="preserve">
-    <value>æ‰“å¼€</value>
+    <value>打开</value>
   </data>
   <data name="StatusCopyNodeInventoryButton.Content" xml:space="preserve">
-    <value>å¤åˆ¶èŠ‚ç‚¹æ¸…å•</value>
+    <value>复制节点清单</value>
   </data>
   <data name="StatusOpenStreamButton.Content" xml:space="preserve">
-    <value>æ‰“å¼€æµ</value>
+    <value>打开流</value>
   </data>
   <data name="ActivityStreamTitle.Text" xml:space="preserve">
     <value>⚡ 活动流</value>
   </data>
   <data name="ActivityFilterAll.Content" xml:space="preserve">
-    <value>å…¨éƒ¨æ´»åŠ¨</value>
+    <value>全部活动</value>
   </data>
   <data name="ActivityFilterSessions.Content" xml:space="preserve">
-    <value>ä¼šè¯</value>
+    <value>会话</value>
   </data>
   <data name="ActivityFilterUsage.Content" xml:space="preserve">
-    <value>ç”¨é‡</value>
+    <value>用量</value>
   </data>
   <data name="ActivityFilterNodes.Content" xml:space="preserve">
-    <value>èŠ‚ç‚¹</value>
+    <value>节点</value>
   </data>
   <data name="ActivityFilterNotifications.Content" xml:space="preserve">
-    <value>é€šçŸ¥</value>
+    <value>通知</value>
   </data>
   <data name="ActivityEmptyText.Text" xml:space="preserve">
-    <value>æš‚æ— æ´»åŠ¨</value>
+    <value>暂无活动</value>
   </data>
   <data name="ActivityOpenDashboardButton.Content" xml:space="preserve">
-    <value>æ‰“å¼€ä»ªè¡¨æ¿</value>
+    <value>打开仪表板</value>
   </data>
   <data name="ActivityClearAllButton.Content" xml:space="preserve">
-    <value>å…¨éƒ¨æ¸…é™¤</value>
+    <value>全部清除</value>
   </data>
   <data name="ActivityCloseButton.Content" xml:space="preserve">
-    <value>å…³é—­</value>
+    <value>关闭</value>
   </data>
   <data name="NotificationHistoryTitle.Text" xml:space="preserve">
     <value>📋 通知历史</value>
   </data>
   <data name="NotificationEmptyText.Text" xml:space="preserve">
-    <value>æš‚æ— é€šçŸ¥</value>
+    <value>暂无通知</value>
   </data>
   <data name="NotificationClearAllButton.Content" xml:space="preserve">
-    <value>å…¨éƒ¨æ¸…é™¤</value>
+    <value>全部清除</value>
   </data>
   <data name="NotificationCloseButton.Content" xml:space="preserve">
-    <value>å…³é—­</value>
+    <value>关闭</value>
   </data>
   <data name="WindowTitle_Settings" xml:space="preserve">
     <value>设置 — OpenClaw 托盘</value>
@@ -288,16 +288,16 @@
     <value>通知历史 — OpenClaw 托盘</value>
   </data>
   <data name="WindowTitle_WebChat" xml:space="preserve">
-    <value>OpenClaw èŠå¤©</value>
+    <value>OpenClaw 聊天</value>
   </data>
   <data name="WindowTitle_Welcome" xml:space="preserve">
-    <value>æ¬¢è¿Žä½¿ç”¨ OpenClaw</value>
+    <value>欢迎使用 OpenClaw</value>
   </data>
   <data name="WindowTitle_Update" xml:space="preserve">
-    <value>OpenClaw æ›´æ–°</value>
+    <value>OpenClaw 更新</value>
   </data>
   <data name="Status_Testing" xml:space="preserve">
-    <value>æµ‹è¯•ä¸­...</value>
+    <value>测试中...</value>
   </data>
   <data name="Status_Connected" xml:space="preserve">
     <value>✅ 连接成功！</value>
@@ -306,13 +306,13 @@
     <value>❌ 连接失败</value>
   </data>
   <data name="Welcome_Title" xml:space="preserve">
-    <value>æ¬¢è¿Žä½¿ç”¨ OpenClawï¼</value>
+    <value>欢迎使用 OpenClaw！</value>
   </data>
   <data name="Welcome_Description" xml:space="preserve">
-    <value>OpenClaw æ‰˜ç›˜æ˜¯ OpenClaw çš„ Windows ä¼´ä¾£åº”ç”¨ï¼Œä¸€ä¸ª AI é©±åŠ¨çš„ä¸ªäººåŠ©æ‰‹ã€‚</value>
+    <value>OpenClaw 托盘是 OpenClaw 的 Windows 伴侣应用，一个 AI 驱动的个人助手。</value>
   </data>
   <data name="Welcome_GettingStarted" xml:space="preserve">
-    <value>å¼€å§‹ä½¿ç”¨å‰ï¼Œæ‚¨éœ€è¦ï¼š</value>
+    <value>开始使用前，您需要：</value>
   </data>
   <data name="Welcome_NeedGateway" xml:space="preserve">
     <value>• 一个正在运行的 OpenClaw 网关</value>
@@ -324,90 +324,90 @@
     <value>📚 查看文档</value>
   </data>
   <data name="Welcome_LaterButton" xml:space="preserve">
-    <value>ç¨åŽ</value>
+    <value>稍后</value>
   </data>
   <data name="Welcome_OpenSettingsButton" xml:space="preserve">
-    <value>æ‰“å¼€è®¾ç½®</value>
+    <value>打开设置</value>
   </data>
   <data name="Update_VersionAvailable" xml:space="preserve">
     <value>🎉 版本 {0} 已可用！</value>
   </data>
   <data name="Update_CurrentVersion" xml:space="preserve">
-    <value>å½“å‰ç‰ˆæœ¬: {0}</value>
+    <value>当前版本: {0}</value>
   </data>
   <data name="Update_WhatsNew" xml:space="preserve">
-    <value>æ›´æ–°å†…å®¹:</value>
+    <value>更新内容:</value>
   </data>
   <data name="Update_SkipButton" xml:space="preserve">
-    <value>è·³è¿‡æ­¤ç‰ˆæœ¬</value>
+    <value>跳过此版本</value>
   </data>
   <data name="Update_RemindLaterButton" xml:space="preserve">
-    <value>ç¨åŽæé†’</value>
+    <value>稍后提醒</value>
   </data>
   <data name="Update_DownloadButton" xml:space="preserve">
-    <value>ä¸‹è½½å¹¶å®‰è£…</value>
+    <value>下载并安装</value>
   </data>
   <data name="Update_Title_UpToDate" xml:space="preserve">
-    <value>å·²æ˜¯æœ€æ–°ç‰ˆæœ¬</value>
+    <value>已是最新版本</value>
   </data>
   <data name="Update_Message_UpToDate" xml:space="preserve">
-    <value>æ‚¨æ­£åœ¨ä½¿ç”¨æœ€æ–°ç‰ˆæœ¬ (v{0})ã€‚</value>
+    <value>您正在使用最新版本 (v{0})。</value>
   </data>
   <data name="Update_Title_Failed" xml:space="preserve">
-    <value>æ— æ³•æ£€æŸ¥æ›´æ–°</value>
+    <value>无法检查更新</value>
   </data>
   <data name="Update_Message_Failed" xml:space="preserve">
-    <value>æ£€æŸ¥æ›´æ–°æ—¶å‡ºé”™ã€‚
+    <value>检查更新时出错。
 
 {0}</value>
   </data>
   <data name="Update_Title_Skipped" xml:space="preserve">
-    <value>å·²è·³è¿‡æ›´æ–°æ£€æŸ¥</value>
+    <value>已跳过更新检查</value>
   </data>
   <data name="Update_Message_Skipped_Debug" xml:space="preserve">
-    <value>è°ƒè¯•ç‰ˆæœ¬å·²ç¦ç”¨æ›´æ–°æ£€æŸ¥ã€‚</value>
+    <value>调试版本已禁用更新检查。</value>
   </data>
   <data name="Update_OK" xml:space="preserve">
-    <value>ç¡®å®š</value>
+    <value>确定</value>
   </data>
   <data name="Menu_OpenDashboard" xml:space="preserve">
-    <value>æ‰“å¼€ä»ªè¡¨æ¿</value>
+    <value>打开仪表板</value>
   </data>
   <data name="Menu_OpenWebChat" xml:space="preserve">
-    <value>æ‰“å¼€ç½‘é¡µèŠå¤©</value>
+    <value>打开网页聊天</value>
   </data>
   <data name="Menu_ActivityStream" xml:space="preserve">
-    <value>æ´»åŠ¨æµ...</value>
+    <value>活动流...</value>
   </data>
   <data name="Menu_NotificationHistory" xml:space="preserve">
-    <value>é€šçŸ¥åŽ†å²...</value>
+    <value>通知历史...</value>
   </data>
   <data name="Menu_RunHealthCheck" xml:space="preserve">
-    <value>è¿è¡Œå¥åº·æ£€æŸ¥</value>
+    <value>运行健康检查</value>
   </data>
   <data name="Menu_Settings" xml:space="preserve">
-    <value>è®¾ç½®...</value>
+    <value>设置...</value>
   </data>
   <data name="Menu_AutoStart" xml:space="preserve">
-    <value>è‡ªåŠ¨å¯åŠ¨</value>
+    <value>自动启动</value>
   </data>
   <data name="Menu_AutoStartEnabled" xml:space="preserve">
     <value>自动启动 ✓</value>
   </data>
   <data name="Menu_OpenLogFile" xml:space="preserve">
-    <value>æ‰“å¼€æ—¥å¿—æ–‡ä»¶</value>
+    <value>打开日志文件</value>
   </data>
   <data name="Menu_Exit" xml:space="preserve">
-    <value>é€€å‡º</value>
+    <value>退出</value>
   </data>
   <data name="Menu_CopyNodeSummary" xml:space="preserve">
-    <value>å¤åˆ¶èŠ‚ç‚¹æ‘˜è¦</value>
+    <value>复制节点摘要</value>
   </data>
   <data name="Menu_CheckForUpdates" xml:space="preserve">
-    <value>æ£€æŸ¥æ›´æ–°</value>
+    <value>检查更新</value>
   </data>
   <data name="Menu_SetupGuide" xml:space="preserve">
-    <value>è®¾ç½®æŒ‡å—...</value>
+    <value>设置指南...</value>
   </data>
   <data name="Menu_Reconfigure" xml:space="preserve">
     <value>重新配置…</value>
@@ -416,64 +416,64 @@
     <value>🧰 支持和调试</value>
   </data>
   <data name="Menu_OpenSupportFiles" xml:space="preserve">
-    <value>æ‰“å¼€æ”¯æŒæ–‡ä»¶</value>
+    <value>打开支持文件</value>
   </data>
   <data name="Menu_LogsFolder" xml:space="preserve">
-    <value>æ—¥å¿—æ–‡ä»¶å¤¹</value>
+    <value>日志文件夹</value>
   </data>
   <data name="Menu_ConfigFolder" xml:space="preserve">
-    <value>é…ç½®æ–‡ä»¶å¤¹</value>
+    <value>配置文件夹</value>
   </data>
   <data name="Menu_DiagnosticsFolder" xml:space="preserve">
-    <value>è¯Šæ–­æ–‡ä»¶å¤¹</value>
+    <value>诊断文件夹</value>
   </data>
   <data name="Menu_CopyDiagnostics" xml:space="preserve">
-    <value>å¤åˆ¶è¯Šæ–­</value>
+    <value>复制诊断</value>
   </data>
   <data name="Menu_SupportContext" xml:space="preserve">
-    <value>æ”¯æŒä¸Šä¸‹æ–‡</value>
+    <value>支持上下文</value>
   </data>
   <data name="Menu_DebugBundle" xml:space="preserve">
-    <value>è°ƒè¯•åŒ…</value>
+    <value>调试包</value>
   </data>
   <data name="Menu_BrowserSetup" xml:space="preserve">
-    <value>æµè§ˆå™¨è®¾ç½®</value>
+    <value>浏览器设置</value>
   </data>
   <data name="Menu_PortDiagnostics" xml:space="preserve">
-    <value>ç«¯å£è¯Šæ–­</value>
+    <value>端口诊断</value>
   </data>
   <data name="Menu_CapabilityDiagnostics" xml:space="preserve">
-    <value>åŠŸèƒ½è¯Šæ–­</value>
+    <value>功能诊断</value>
   </data>
   <data name="Menu_NodeInventory" xml:space="preserve">
-    <value>èŠ‚ç‚¹æ¸…å•</value>
+    <value>节点清单</value>
   </data>
   <data name="Menu_ChannelSummary" xml:space="preserve">
-    <value>é¢‘é“æ‘˜è¦</value>
+    <value>频道摘要</value>
   </data>
   <data name="Menu_ActivitySummary" xml:space="preserve">
-    <value>æ´»åŠ¨æ‘˜è¦</value>
+    <value>活动摘要</value>
   </data>
   <data name="Menu_ExtensibilitySummary" xml:space="preserve">
-    <value>æ‰©å±•æ€§æ‘˜è¦</value>
+    <value>扩展性摘要</value>
   </data>
   <data name="Menu_RestartSshTunnel" xml:space="preserve">
-    <value>é‡å¯ SSH éš§é“</value>
+    <value>重启 SSH 隧道</value>
   </data>
   <data name="Menu_StatusFormat" xml:space="preserve">
-    <value>çŠ¶æ€: {0}</value>
+    <value>状态: {0}</value>
   </data>
   <data name="Menu_SessionsFormat" xml:space="preserve">
-    <value>ä¼šè¯ ({0})</value>
+    <value>会话 ({0})</value>
   </data>
   <data name="Menu_NodesFormat" xml:space="preserve">
-    <value>èŠ‚ç‚¹ ({0})</value>
+    <value>节点 ({0})</value>
   </data>
   <data name="Menu_RecentActivityFormat" xml:space="preserve">
-    <value>æœ€è¿‘æ´»åŠ¨ ({0})</value>
+    <value>最近活动 ({0})</value>
   </data>
   <data name="Menu_NoUsageData" xml:space="preserve">
-    <value>æš‚æ— ç”¨é‡æ•°æ®</value>
+    <value>暂无用量数据</value>
   </data>
   <data name="Menu_ResetSession" xml:space="preserve">
     <value>↳ 重置会话</value>
@@ -497,88 +497,88 @@
     <value>⚪ 已断开</value>
   </data>
   <data name="TestNotification_Title" xml:space="preserve">
-    <value>æµ‹è¯•é€šçŸ¥</value>
+    <value>测试通知</value>
   </data>
   <data name="TestNotification_Body" xml:space="preserve">
-    <value>è¿™æ˜¯æ¥è‡ª OpenClaw æ‰˜ç›˜çš„æµ‹è¯•é€šçŸ¥ã€‚</value>
+    <value>这是来自 OpenClaw 托盘的测试通知。</value>
   </data>
   <data name="Status_LastCheckFormat" xml:space="preserve">
-    <value>ä¸Šæ¬¡æ£€æŸ¥: {0}</value>
+    <value>上次检查: {0}</value>
   </data>
   <data name="TimeAgo_JustNow" xml:space="preserve">
-    <value>åˆšåˆš</value>
+    <value>刚刚</value>
   </data>
   <data name="TimeAgo_MinutesFormat" xml:space="preserve">
-    <value>{0}åˆ†é’Ÿå‰</value>
+    <value>{0}分钟前</value>
   </data>
   <data name="TimeAgo_HoursFormat" xml:space="preserve">
-    <value>{0}å°æ—¶å‰</value>
+    <value>{0}小时前</value>
   </data>
   <data name="Activity_ClickToOpen" xml:space="preserve">
-    <value>ç‚¹å‡»åœ¨ä»ªè¡¨æ¿ä¸­æ‰“å¼€</value>
+    <value>点击在仪表板中打开</value>
   </data>
   <data name="TimeAgo_DaysFormat" xml:space="preserve">
-    <value>{0}å¤©å‰</value>
+    <value>{0}天前</value>
   </data>
   <data name="StatusDisplay_Connected" xml:space="preserve">
-    <value>å·²è¿žæŽ¥</value>
+    <value>已连接</value>
   </data>
   <data name="StatusDisplay_Connecting" xml:space="preserve">
-    <value>æ­£åœ¨è¿žæŽ¥</value>
+    <value>正在连接</value>
   </data>
   <data name="StatusDisplay_Disconnected" xml:space="preserve">
-    <value>å·²æ–­å¼€</value>
+    <value>已断开</value>
   </data>
   <data name="StatusDisplay_Error" xml:space="preserve">
-    <value>é”™è¯¯</value>
+    <value>错误</value>
   </data>
   <data name="StatusDisplay_Unknown" xml:space="preserve">
-    <value>æœªçŸ¥</value>
+    <value>未知</value>
   </data>
   <data name="Status_NotAvailable" xml:space="preserve">
-    <value>æ— </value>
+    <value>无</value>
   </data>
   <data name="WindowTitle_Canvas" xml:space="preserve">
-    <value>ç”»å¸ƒ</value>
+    <value>画布</value>
   </data>
   <data name="CanvasErrorTitle.Text" xml:space="preserve">
     <value>❌ 画布错误</value>
   </data>
   <data name="CanvasRetryButton.Content" xml:space="preserve">
-    <value>é‡è¯•</value>
+    <value>重试</value>
   </data>
   <data name="Canvas_ReadyTitle" xml:space="preserve">
     <value>🎨 画布就绪</value>
   </data>
   <data name="Canvas_WaitingForContent" xml:space="preserve">
-    <value>ç­‰å¾…å†…å®¹...</value>
+    <value>等待内容...</value>
   </data>
   <data name="A2UI_CanvasTitle" xml:space="preserve">
-    <value>ç”»å¸ƒ</value>
+    <value>画布</value>
   </data>
   <data name="A2UI_TabFallback" xml:space="preserve">
-    <value>é€‰é¡¹å¡</value>
+    <value>选项卡</value>
   </data>
   <data name="A2UI_ModalClose" xml:space="preserve">
-    <value>å…³é—­</value>
+    <value>关闭</value>
   </data>
   <data name="A2UI_DateTimeSelectDate" xml:space="preserve">
-    <value>é€‰æ‹©æ—¥æœŸ</value>
+    <value>选择日期</value>
   </data>
   <data name="A2UI_MultipleChoiceSelect" xml:space="preserve">
-    <value>é€‰æ‹©...</value>
+    <value>选择...</value>
   </data>
   <data name="A2UI_UnsupportedComponent" xml:space="preserve">
-    <value>ä¸æ”¯æŒçš„ç»„ä»¶: {0}</value>
+    <value>不支持的组件: {0}</value>
   </data>
   <data name="WebChatErrorTitle.Text" xml:space="preserve">
-    <value>ç½‘é¡µèŠå¤©ä¸å¯ç”¨</value>
+    <value>网页聊天不可用</value>
   </data>
   <data name="WebChatOpenBrowserButton.Content" xml:space="preserve">
-    <value>åœ¨æµè§ˆå™¨ä¸­æ‰“å¼€</value>
+    <value>在浏览器中打开</value>
   </data>
   <data name="WebChat_ConnectionError" xml:space="preserve">
-    <value>æ— æ³•è¿žæŽ¥åˆ° OpenClaw ç½‘å…³</value>
+    <value>无法连接到 OpenClaw 网关</value>
   </data>
   <data name="WebChat_ConnectionErrorDetail" xml:space="preserve">
     <value>网关 {0} 没有响应。
@@ -597,7 +597,7 @@
 • 或使用 SSH 隧道连接到 localhost 并继续使用 localhost 地址</value>
   </data>
   <data name="WebChat_InvalidUrl" xml:space="preserve">
-    <value>æ— æ•ˆçš„ç½‘å…³åœ°å€: {0}</value>
+    <value>无效的网关地址: {0}</value>
   </data>
   <data name="WebChat_SecureContextRequired" xml:space="preserve">
     <value>网页聊天需要安全上下文。
@@ -610,194 +610,194 @@
 • 或通过隧道连接到 localhost：ssh -N -L 18789:localhost:18789 &lt;服务器&gt;</value>
   </data>
   <data name="WindowTitle_TrayMenu" xml:space="preserve">
-    <value>OpenClaw èœå•</value>
+    <value>OpenClaw 菜单</value>
   </data>
   <data name="Toast_DeviceIdCopied" xml:space="preserve">
     <value>📋 设备 ID 已复制</value>
   </data>
   <data name="Toast_DeviceIdCopiedDetail" xml:space="preserve">
-    <value>è¿è¡Œ: openclaw devices approve {0}...</value>
+    <value>运行: openclaw devices approve {0}...</value>
   </data>
   <data name="Toast_NodeSummaryCopied" xml:space="preserve">
     <value>📋 节点摘要已复制</value>
   </data>
   <data name="Toast_NodeSummaryCopiedDetail" xml:space="preserve">
-    <value>å·²å¤åˆ¶ {0} ä¸ªèŠ‚ç‚¹åˆ°å‰ªè´´æ¿</value>
+    <value>已复制 {0} 个节点到剪贴板</value>
   </data>
   <data name="Toast_SessionActionFailed" xml:space="preserve">
     <value>❌ 会话操作失败</value>
   </data>
   <data name="Toast_SessionActionFailedDetail" xml:space="preserve">
-    <value>æ— æ³•å‘ç½‘å…³å‘é€è¯·æ±‚ã€‚</value>
+    <value>无法向网关发送请求。</value>
   </data>
   <data name="Toast_NodeModeActive" xml:space="preserve">
     <value>🔌 节点模式已激活</value>
   </data>
   <data name="Toast_NodeModeActiveDetail" xml:space="preserve">
-    <value>æ­¤ç”µè„‘çŽ°åœ¨å¯ä»¥æŽ¥æ”¶æ¥è‡ªä»£ç†çš„å‘½ä»¤ï¼ˆç”»å¸ƒã€æˆªå›¾ï¼‰</value>
+    <value>此电脑现在可以接收来自代理的命令（画布、截图）</value>
   </data>
   <data name="Toast_PairingPending" xml:space="preserve">
     <value>⏳ 等待配对批准</value>
   </data>
   <data name="Toast_PairingPendingDetail" xml:space="preserve">
-    <value>åœ¨ç½‘å…³ä¸Šè¿è¡Œ: openclaw devices approve {0}...</value>
+    <value>在网关上运行: openclaw devices approve {0}...</value>
   </data>
   <data name="Toast_CopyPairingCommand" xml:space="preserve">
-    <value>å¤åˆ¶æ‰¹å‡†å‘½ä»¤</value>
+    <value>复制批准命令</value>
   </data>
   <data name="Toast_PairingCommandCopied" xml:space="preserve">
-    <value>é…å¯¹å‘½ä»¤å·²å¤åˆ¶</value>
+    <value>配对命令已复制</value>
   </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ 节点已配对！</value>
   </data>
   <data name="Toast_NodePairedDetail" xml:space="preserve">
-    <value>æ­¤ç”µè„‘çŽ°åœ¨å¯ä»¥æŽ¥æ”¶æ¥è‡ªä»£ç†çš„å‘½ä»¤</value>
+    <value>此电脑现在可以接收来自代理的命令</value>
   </data>
   <data name="Toast_PairingRejected" xml:space="preserve">
     <value>❌ 配对被拒绝</value>
   </data>
   <data name="Toast_PairingRejectedDetail" xml:space="preserve">
-    <value>ç½‘å…³æ‹’ç»äº†æ­¤è®¾å¤‡çš„é…å¯¹è¯·æ±‚ã€‚</value>
+    <value>网关拒绝了此设备的配对请求。</value>
   </data>
   <data name="Toast_HealthCheck" xml:space="preserve">
-    <value>å¥åº·æ£€æŸ¥</value>
+    <value>健康检查</value>
   </data>
   <data name="Toast_HealthCheckNotConnected" xml:space="preserve">
-    <value>ç½‘å…³å°šæœªè¿žæŽ¥ã€‚</value>
+    <value>网关尚未连接。</value>
   </data>
   <data name="Toast_HealthCheckSent" xml:space="preserve">
-    <value>å¥åº·æ£€æŸ¥è¯·æ±‚å·²å‘é€ã€‚</value>
+    <value>健康检查请求已发送。</value>
   </data>
   <data name="Toast_HealthCheckFailed" xml:space="preserve">
-    <value>å¥åº·æ£€æŸ¥å¤±è´¥</value>
+    <value>健康检查失败</value>
   </data>
   <data name="Toast_ScreenCaptured" xml:space="preserve">
     <value>📸 屏幕已捕获</value>
   </data>
   <data name="Toast_ScreenCapturedDetail" xml:space="preserve">
-    <value>OpenClaw ä»£ç†æ•èŽ·äº†æ‚¨çš„å±å¹•</value>
+    <value>OpenClaw 代理捕获了您的屏幕</value>
   </data>
   <data name="Toast_CameraBlocked" xml:space="preserve">
     <value>📷 相机访问被阻止</value>
   </data>
   <data name="Toast_CameraBlockedDetail" xml:space="preserve">
-    <value>è¯·åœ¨ Windows éšç§è®¾ç½®ä¸­ä¸º OpenClaw Tray å¯ç”¨ç›¸æœºè®¿é—®</value>
+    <value>请在 Windows 隐私设置中为 OpenClaw Tray 启用相机访问</value>
   </data>
   <!-- ==================== Toast: Recording ==================== -->
   <data name="Toast_ScreenRecordingStarted" xml:space="preserve">
     <value>🔴 屏幕录制已开始</value>
   </data>
   <data name="Toast_ScreenRecordingStartedDetail" xml:space="preserve">
-    <value>OpenClaw ä»£ç†æ­£åœ¨å½•åˆ¶æ‚¨çš„å±å¹•</value>
+    <value>OpenClaw 代理正在录制您的屏幕</value>
   </data>
   <data name="Toast_ScreenRecordingComplete" xml:space="preserve">
     <value>✅ 屏幕录制已完成</value>
   </data>
   <data name="Toast_ScreenRecordingCompleteDetail" xml:space="preserve">
-    <value>å±å¹•å½•åˆ¶å·²å‘é€ç»™ä»£ç†</value>
+    <value>屏幕录制已发送给代理</value>
   </data>
   <data name="Toast_ScreenRecordingFailed" xml:space="preserve">
     <value>❌ 屏幕录制失败</value>
   </data>
   <data name="Toast_ScreenRecordingFailedDetail" xml:space="preserve">
-    <value>å½•åˆ¶å±å¹•æ—¶å‘ç”Ÿé”™è¯¯</value>
+    <value>录制屏幕时发生错误</value>
   </data>
   <data name="Toast_CameraRecordingStarted" xml:space="preserve">
     <value>🔴 摄像头录制已开始</value>
   </data>
   <data name="Toast_CameraRecordingStartedDetail" xml:space="preserve">
-    <value>OpenClaw ä»£ç†æ­£åœ¨ä»Žæ‚¨çš„æ‘„åƒå¤´å½•åˆ¶</value>
+    <value>OpenClaw 代理正在从您的摄像头录制</value>
   </data>
   <data name="Toast_CameraRecordingComplete" xml:space="preserve">
     <value>✅ 摄像头录制已完成</value>
   </data>
   <data name="Toast_CameraRecordingCompleteDetail" xml:space="preserve">
-    <value>æ‘„åƒå¤´å½•åˆ¶ç‰‡æ®µå·²å‘é€ç»™ä»£ç†</value>
+    <value>摄像头录制片段已发送给代理</value>
   </data>
   <!-- ==================== Recording Consent Dialog ==================== -->
   <data name="RecordingConsent_WindowTitle" xml:space="preserve">
     <value>OpenClaw · 权限请求</value>
   </data>
   <data name="RecordingConsent_ScreenTitle" xml:space="preserve">
-    <value>å…è®¸å±å¹•å½•åˆ¶ï¼Ÿ</value>
+    <value>允许屏幕录制？</value>
   </data>
   <data name="RecordingConsent_CameraTitle" xml:space="preserve">
-    <value>å…è®¸æ‘„åƒå¤´å½•åˆ¶ï¼Ÿ</value>
+    <value>允许摄像头录制？</value>
   </data>
   <data name="RecordingConsent_ScreenDescription" xml:space="preserve">
-    <value>ä»£ç†æ­£åœ¨è¯·æ±‚å½•åˆ¶æ‚¨çš„å±å¹•ã€‚è¿™å°†ä»Žæ‚¨çš„æ˜¾ç¤ºå™¨æ•èŽ·è§†é¢‘å¹¶å‘é€ç»™ä»£ç†ã€‚æ‚¨çš„é€‰æ‹©å°†è¢«è®°ä½ç”¨äºŽä»¥åŽçš„è¯·æ±‚ï¼Œç›´åˆ°æ‚¨åœ¨è®¾ç½®ä¸­æ›´æ”¹ã€‚</value>
+    <value>代理正在请求录制您的屏幕。这将从您的显示器捕获视频并发送给代理。您的选择将被记住用于以后的请求，直到您在设置中更改。</value>
   </data>
   <data name="RecordingConsent_CameraDescription" xml:space="preserve">
-    <value>ä»£ç†æ­£åœ¨è¯·æ±‚ä»Žæ‚¨çš„æ‘„åƒå¤´å½•åˆ¶ã€‚è¿™å°†ä»Žæ‚¨çš„ç½‘ç»œæ‘„åƒå¤´æ•èŽ·è§†é¢‘å¹¶å‘é€ç»™ä»£ç†ã€‚æ‚¨çš„é€‰æ‹©å°†è¢«è®°ä½ç”¨äºŽä»¥åŽçš„è¯·æ±‚ï¼Œç›´åˆ°æ‚¨åœ¨è®¾ç½®ä¸­æ›´æ”¹ã€‚</value>
+    <value>代理正在请求从您的摄像头录制。这将从您的网络摄像头捕获视频并发送给代理。您的选择将被记住用于以后的请求，直到您在设置中更改。</value>
   </data>
   <data name="RecordingConsent_Privacy" xml:space="preserve">
-    <value>æ‚¨å¯ä»¥ç¨åŽåœ¨è®¾ç½®ä¸­æ›´æ”¹æ­¤é¡¹ã€‚</value>
+    <value>您可以稍后在设置中更改此项。</value>
   </data>
   <data name="RecordingConsent_Allow" xml:space="preserve">
-    <value>å…è®¸å½•åˆ¶</value>
+    <value>允许录制</value>
   </data>
   <data name="RecordingConsent_Deny" xml:space="preserve">
-    <value>æ‹’ç»</value>
+    <value>拒绝</value>
   </data>
   <!-- ==================== Settings: Privacy ==================== -->
   <data name="Settings_PrivacyHeader" xml:space="preserve">
-    <value>éšç§</value>
+    <value>隐私</value>
   </data>
   <data name="Settings_PrivacyDescription" xml:space="preserve">
-    <value>æŽ§åˆ¶ä»£ç†å¯ä»¥åœ¨æ­¤è®¾å¤‡ä¸Šä½¿ç”¨å“ªäº›åŠŸèƒ½ã€‚</value>
+    <value>控制代理可以在此设备上使用哪些功能。</value>
   </data>
   <data name="Settings_AllowScreenRecording" xml:space="preserve">
-    <value>å…è®¸å±å¹•å½•åˆ¶</value>
+    <value>允许屏幕录制</value>
   </data>
   <data name="Settings_AllowCameraRecording" xml:space="preserve">
-    <value>å…è®¸æ‘„åƒå¤´å½•åˆ¶</value>
+    <value>允许摄像头录制</value>
   </data>
   <data name="SettingsPrivacyHeader.Text" xml:space="preserve">
-    <value>éšç§</value>
+    <value>隐私</value>
   </data>
   <data name="SettingsPrivacyDescription.Text" xml:space="preserve">
-    <value>é¢„å…ˆæ‰¹å‡†åŠŸèƒ½ï¼Œä»¥ä¾¿ä»£ç†æ— éœ€æ¯æ¬¡éƒ½è¯·æ±‚æƒé™ã€‚å½•åˆ¶å¼€å§‹å‰ä»ä¼šæ˜¾ç¤ºå€’è®¡æ—¶ã€‚</value>
+    <value>预先批准功能，以便代理无需每次都请求权限。录制开始前仍会显示倒计时。</value>
   </data>
   <data name="ScreenRecordingToggle.Header" xml:space="preserve">
-    <value>å…è®¸å±å¹•å½•åˆ¶</value>
+    <value>允许屏幕录制</value>
   </data>
   <data name="CameraRecordingToggle.Header" xml:space="preserve">
-    <value>å…è®¸æ‘„åƒå¤´å½•åˆ¶</value>
+    <value>允许摄像头录制</value>
   </data>
   <!-- ==================== Toast: Activity Stream Tip ==================== -->
   <data name="Toast_ActivityStreamTip" xml:space="preserve">
     <value>⚡ 新功能: 活动流</value>
   </data>
   <data name="Toast_ActivityStreamTipDetail" xml:space="preserve">
-    <value>æ‰“å¼€æ‰˜ç›˜èœå•å³å¯æŸ¥çœ‹å®žæ—¶ä¼šè¯ã€ç”¨é‡å’ŒèŠ‚ç‚¹æ´»åŠ¨ã€‚</value>
+    <value>打开托盘菜单即可查看实时会话、用量和节点活动。</value>
   </data>
   <data name="Toast_ActivityStreamTipButton" xml:space="preserve">
-    <value>æ‰“å¼€æ´»åŠ¨æµ</value>
+    <value>打开活动流</value>
   </data>
   <data name="Setup_Title" xml:space="preserve">
-    <value>OpenClaw è®¾ç½®</value>
+    <value>OpenClaw 设置</value>
   </data>
   <data name="Setup_StepConnect" xml:space="preserve">
     <value>第 1 步（共 3 步）— 连接</value>
   </data>
   <data name="Setup_ConnectTitle" xml:space="preserve">
-    <value>è¿žæŽ¥åˆ°æ‚¨çš„ç½‘å…³</value>
+    <value>连接到您的网关</value>
   </data>
   <data name="Setup_ConnectDescription" xml:space="preserve">
-    <value>åœ¨æ‚¨çš„ç½‘å…³ä¸»æœºï¼ˆMac/Linuxï¼‰ä¸Šè¿è¡Œä»¥ä¸‹å‘½ä»¤èŽ·å–è®¾ç½®ç ï¼š</value>
+    <value>在您的网关主机（Mac/Linux）上运行以下命令获取设置码：</value>
   </data>
   <data name="Setup_SetupCodeHeader" xml:space="preserve">
-    <value>è®¾ç½®ç </value>
+    <value>设置码</value>
   </data>
   <data name="Setup_SetupCodePlaceholder" xml:space="preserve">
-    <value>ç²˜è´´æ¥è‡ªç½‘å…³ä»ªè¡¨æ¿çš„è®¾ç½®ç </value>
+    <value>粘贴来自网关仪表板的设置码</value>
   </data>
   <data name="Setup_PasteSetupButton" xml:space="preserve">
-    <value>ç²˜è´´è®¾ç½®ç  / QR</value>
+    <value>粘贴设置码 / QR</value>
   </data>
   <data name="Setup_ImportQrButton" xml:space="preserve">
-    <value>å¯¼å…¥ QR å›¾ç‰‡...</value>
+    <value>导入 QR 图片...</value>
   </data>
   <data name="Setup_QrDecoded" xml:space="preserve">
     <value>✅ QR 图片已解码 — 请点击"测试连接"</value>
@@ -815,7 +815,7 @@
     <value>隐藏手动输入 ▴</value>
   </data>
   <data name="Setup_GatewayUrlHeader" xml:space="preserve">
-    <value>ç½‘å…³åœ°å€</value>
+    <value>网关地址</value>
   </data>
   <data name="Setup_GatewayUrlPlaceholder" xml:space="preserve">
     <value>ws://192.168.1.x:18789</value>
@@ -824,13 +824,13 @@
     <value>💡 支持 ws://、wss://、http:// 或 https://</value>
   </data>
   <data name="Setup_TokenHeader" xml:space="preserve">
-    <value>ç½‘å…³ä»¤ç‰Œ</value>
+    <value>网关令牌</value>
   </data>
   <data name="Setup_TokenPlaceholder" xml:space="preserve">
-    <value>åœ¨æ­¤ç²˜è´´æ‚¨çš„ä»¤ç‰Œ</value>
+    <value>在此粘贴您的令牌</value>
   </data>
   <data name="Setup_TestButton" xml:space="preserve">
-    <value>æµ‹è¯•è¿žæŽ¥</value>
+    <value>测试连接</value>
   </data>
   <data name="Setup_Testing" xml:space="preserve">
     <value>⏳ 正在连接网关...</value>
@@ -872,25 +872,25 @@
     <value>✅ 设置码已解码 — 请点击"测试连接"</value>
   </data>
   <data name="Setup_NodeModeTitle" xml:space="preserve">
-    <value>å¯ç”¨èŠ‚ç‚¹æ¨¡å¼ï¼ˆå¯é€‰ï¼‰</value>
+    <value>启用节点模式（可选）</value>
   </data>
   <data name="Setup_NodeModeDescription" xml:space="preserve">
     <value>节点模式允许您的 Windows 电脑为 OpenClaw 执行任务 — 如屏幕截图、摄像头访问和画布绘制。</value>
   </data>
   <data name="Setup_NodeModeSecurityTitle" xml:space="preserve">
-    <value>ä»…ä¸ºæ‚¨ä¿¡ä»»çš„ç½‘å…³å’Œä»£ç†å¯ç”¨èŠ‚ç‚¹æ¨¡å¼</value>
+    <value>仅为您信任的网关和代理启用节点模式</value>
   </data>
   <data name="Setup_NodeModeSecurityMessage" xml:space="preserve">
-    <value>å·²æ‰¹å‡†çš„ä»£ç†å¯ä»¥è¿è¡Œæœ¬åœ°å‘½ä»¤ï¼Œå¹¶å¯èƒ½è®¿é—®å·²å¯ç”¨çš„è®¾å¤‡è¡¨é¢ï¼Œä¾‹å¦‚å±å¹•ã€æ‘„åƒå¤´ã€ä½ç½®ã€æµè§ˆå™¨å’Œç”»å¸ƒã€‚æ‚¨ç¨åŽå¯ä»¥åœ¨è®¾ç½®ä¸­ç¦ç”¨èƒ½åŠ›ç»„ã€‚</value>
+    <value>已批准的代理可以运行本地命令，并可能访问已启用的设备表面，例如屏幕、摄像头、位置、浏览器和画布。您稍后可以在设置中禁用能力组。</value>
   </data>
   <data name="Setup_NodeModeToggle" xml:space="preserve">
-    <value>å¯ç”¨èŠ‚ç‚¹æ¨¡å¼</value>
+    <value>启用节点模式</value>
   </data>
   <data name="Setup_DeviceIdLoading" xml:space="preserve">
-    <value>è®¾å¤‡ IDï¼šåŠ è½½ä¸­...</value>
+    <value>设备 ID：加载中...</value>
   </data>
   <data name="Setup_DeviceIdFallback" xml:space="preserve">
-    <value>è®¾å¤‡ IDï¼šï¼ˆå°†åœ¨é¦–æ¬¡è¿žæŽ¥æ—¶ç”Ÿæˆï¼‰</value>
+    <value>设备 ID：（将在首次连接时生成）</value>
   </data>
   <data name="Setup_CopyDeviceId" xml:space="preserve">
     <value>📋 复制设备 ID</value>
@@ -899,7 +899,7 @@
     <value>✅ 已复制！</value>
   </data>
   <data name="Setup_ApproveInstructions" xml:space="preserve">
-    <value>è¦æ‰¹å‡†æ­¤èŠ‚ç‚¹ï¼Œè¯·åœ¨ç½‘å…³ä¸»æœºä¸Šè¿è¡Œï¼š</value>
+    <value>要批准此节点，请在网关主机上运行：</value>
   </data>
   <data name="Setup_ApproveHint" xml:space="preserve">
     <value>💡 您可以现在完成设置 — 配对将在后台继续。获得批准后会收到通知。</value>
@@ -908,16 +908,16 @@
     <value>🎉 一切就绪！</value>
   </data>
   <data name="Setup_DoneDescription" xml:space="preserve">
-    <value>OpenClaw æ‰˜ç›˜å°†è¿žæŽ¥åˆ°æ‚¨çš„ç½‘å…³å¹¶å¼€å§‹ç›‘æŽ§ã€‚</value>
+    <value>OpenClaw 托盘将连接到您的网关并开始监控。</value>
   </data>
   <data name="Setup_BackButton" xml:space="preserve">
-    <value>ä¸Šä¸€æ­¥</value>
+    <value>上一步</value>
   </data>
   <data name="Setup_NextButton" xml:space="preserve">
-    <value>ä¸‹ä¸€æ­¥</value>
+    <value>下一步</value>
   </data>
   <data name="Setup_FinishButton" xml:space="preserve">
-    <value>å®Œæˆ</value>
+    <value>完成</value>
   </data>
   <data name="Setup_StepNodeMode" xml:space="preserve">
     <value>第 2 步（共 3 步）— 节点模式</value>
@@ -926,112 +926,112 @@
     <value>第 3 步（共 3 步）— 完成</value>
   </data>
   <data name="SettingsDeveloperModeHeader.Text" xml:space="preserve">
-    <value>å¼€å‘è€…æ¨¡å¼</value>
+    <value>开发者模式</value>
   </data>
   <data name="SettingsMcpServerToggle.Header" xml:space="preserve">
-    <value>å¯ç”¨æœ¬åœ° MCP æœåŠ¡å™¨</value>
+    <value>启用本地 MCP 服务器</value>
   </data>
   <data name="SettingsMcpDescription.Text" xml:space="preserve">
-    <value>å‘æœ¬åœ° MCP å®¢æˆ·ç«¯ï¼ˆClaude Desktopã€Cursorã€Claude Codeï¼‰å…¬å¼€ç›¸åŒçš„èŠ‚ç‚¹åŠŸèƒ½ï¼ˆç³»ç»Ÿã€å±å¹•ã€æ‘„åƒå¤´ã€éº¦å…‹é£Žã€æ‰¬å£°å™¨ã€ç”»å¸ƒï¼‰ã€‚</value>
+    <value>向本地 MCP 客户端（Claude Desktop、Cursor、Claude Code）公开相同的节点功能（系统、屏幕、摄像头、麦克风、扬声器、画布）。</value>
   </data>
   <data name="SettingsMcpEndpointLabel.Text" xml:space="preserve">
-    <value>ç»ˆç»“ç‚¹ï¼š</value>
+    <value>终结点：</value>
   </data>
   <data name="SettingsMcpStatusLabel.Text" xml:space="preserve">
-    <value>çŠ¶æ€ï¼š</value>
+    <value>状态：</value>
   </data>
   <data name="Mcp_Status_Disabled" xml:space="preserve">
-    <value>å·²ç¦ç”¨</value>
+    <value>已禁用</value>
   </data>
   <data name="Mcp_Status_Listening" xml:space="preserve">
-    <value>æ­£åœ¨ç›‘å¬</value>
+    <value>正在监听</value>
   </data>
   <data name="Mcp_Status_Stopped" xml:space="preserve">
-    <value>å·²åœæ­¢</value>
+    <value>已停止</value>
   </data>
   <data name="Mcp_Status_WillStartOnSave" xml:space="preserve">
-    <value>ä¿å­˜åŽå°†å¯åŠ¨</value>
+    <value>保存后将启动</value>
   </data>
   <data name="Mcp_Status_WillStopOnSave" xml:space="preserve">
-    <value>ä¿å­˜åŽå°†åœæ­¢</value>
+    <value>保存后将停止</value>
   </data>
   <data name="Mcp_Status_FailedToStart" xml:space="preserve">
-    <value>å¯åŠ¨å¤±è´¥ï¼š</value>
+    <value>启动失败：</value>
   </data>
   <data name="SettingsMcpTokenLabel.Text" xml:space="preserve">
-    <value>Bearer ä»¤ç‰Œï¼š</value>
+    <value>Bearer 令牌：</value>
   </data>
   <data name="SettingsMcpTokenRevealButton.Content" xml:space="preserve">
-    <value>æ˜¾ç¤º</value>
+    <value>显示</value>
   </data>
   <data name="SettingsMcpTokenCopyButton.Content" xml:space="preserve">
-    <value>å¤åˆ¶</value>
+    <value>复制</value>
   </data>
   <data name="SettingsMcpTokenResetButton.Content" xml:space="preserve">
-    <value>é‡ç½®</value>
+    <value>重置</value>
   </data>
   <data name="SettingsMcpToken_RevealButton" xml:space="preserve">
-    <value>æ˜¾ç¤º</value>
+    <value>显示</value>
   </data>
   <data name="SettingsMcpToken_HideButton" xml:space="preserve">
-    <value>éšè—</value>
+    <value>隐藏</value>
   </data>
   <data name="SettingsMcpToken_NotGenerated" xml:space="preserve">
     <value>(未生成 — 启用 MCP 服务器并单击保存)</value>
   </data>
   <data name="SettingsMcpToken_StoredAtFormat" xml:space="preserve">
-    <value>ä¿å­˜ä½ç½®ï¼š{0}</value>
+    <value>保存位置：{0}</value>
   </data>
   <data name="SettingsMcpToken_HintFormat" xml:space="preserve">
-    <value>æ¯æ¬¡è¯·æ±‚éƒ½ä»¥ 'Authorization: Bearer &lt;token&gt;' å‘é€ã€‚ä¿å­˜ä½ç½®ï¼š{0}ã€‚</value>
+    <value>每次请求都以 'Authorization: Bearer &lt;token&gt;' 发送。保存位置：{0}。</value>
   </data>
   <data name="SettingsMcpToken_ResetToastTitle" xml:space="preserve">
-    <value>MCP ä»¤ç‰Œå·²é‡ç½®</value>
+    <value>MCP 令牌已重置</value>
   </data>
   <data name="SettingsMcpToken_ResetToastBody" xml:space="preserve">
-    <value>æ—§çš„ MCP Bearer ä»¤ç‰ŒçŽ°å·²å¤±æ•ˆã€‚</value>
+    <value>旧的 MCP Bearer 令牌现已失效。</value>
   </data>
   <data name="SettingsMcpToken_ResetFailedFormat" xml:space="preserve">
-    <value>é‡ç½®ä»¤ç‰Œå¤±è´¥ï¼š{0}</value>
+    <value>重置令牌失败：{0}</value>
   </data>
   <data name="SettingsMcpTokenResetDialog_Title" xml:space="preserve">
-    <value>é‡ç½® MCP Bearer ä»¤ç‰Œï¼Ÿ</value>
+    <value>重置 MCP Bearer 令牌？</value>
   </data>
   <data name="SettingsMcpTokenResetDialog_Body" xml:space="preserve">
-    <value>çŽ°æœ‰çš„æœ¬åœ° MCP å®¢æˆ·ç«¯ï¼ˆClaude Desktopã€Cursorã€Claude Codeï¼‰å°†åœæ­¢å·¥ä½œï¼Œç›´åˆ°æ‚¨ä½¿ç”¨æ–°ä»¤ç‰Œé‡æ–°é…ç½®å®ƒä»¬ã€‚</value>
+    <value>现有的本地 MCP 客户端（Claude Desktop、Cursor、Claude Code）将停止工作，直到您使用新令牌重新配置它们。</value>
   </data>
   <data name="SettingsMcpTokenResetDialog_PrimaryButton" xml:space="preserve">
-    <value>é‡ç½®</value>
+    <value>重置</value>
   </data>
   <data name="SettingsMcpTokenResetDialog_CloseButton" xml:space="preserve">
-    <value>å–æ¶ˆ</value>
+    <value>取消</value>
   </data>
   <data name="WindowTitle_Downloading" xml:space="preserve">
-    <value>æ­£åœ¨ä¸‹è½½æ›´æ–°...</value>
+    <value>正在下载更新...</value>
   </data>
   <data name="Download_ProgressText" xml:space="preserve">
-    <value>æ­£åœ¨ä¸‹è½½æ›´æ–°...</value>
+    <value>正在下载更新...</value>
   </data>
   <data name="UrlApproval_Caption" xml:space="preserve">
     <value>OpenClaw — 批准 URL</value>
   </data>
   <data name="UrlApproval_Body" xml:space="preserve">
-    <value>ä»£ç†å¸Œæœ›åœ¨æ‚¨çš„æµè§ˆå™¨ä¸­æ‰“å¼€é«˜é£Žé™©ç›®çš„åœ°ã€‚</value>
+    <value>代理希望在您的浏览器中打开高风险目的地。</value>
   </data>
   <data name="UrlApproval_NoReasons" xml:space="preserve">
-    <value>(æœªè®°å½•å…·ä½“åŽŸå› )</value>
+    <value>(未记录具体原因)</value>
   </data>
   <data name="UrlApproval_ZoneFormat" xml:space="preserve">
-    <value>åŒºåŸŸï¼š{0}</value>
+    <value>区域：{0}</value>
   </data>
   <data name="UrlApproval_AgentFormat" xml:space="preserve">
-    <value>ä»£ç†ï¼š{0}</value>
+    <value>代理：{0}</value>
   </data>
   <data name="UrlApproval_HostFormat" xml:space="preserve">
-    <value>ä¸»æœºï¼š{0}</value>
+    <value>主机：{0}</value>
   </data>
   <data name="UrlApproval_ReasonsHeader" xml:space="preserve">
-    <value>åŽŸå› ï¼š</value>
+    <value>原因：</value>
   </data>
   <data name="UrlApproval_YesHint" xml:space="preserve">
     <value>是 — 打开此 URL。</value>
@@ -1040,136 +1040,136 @@
     <value>否 — 阻止该请求。</value>
   </data>
   <data name="Onboarding_Title" xml:space="preserve">
-    <value>OpenClaw è®¾ç½®</value>
+    <value>OpenClaw 设置</value>
   </data>
   <data name="Onboarding_Back" xml:space="preserve">
-    <value>ä¸Šä¸€æ­¥</value>
+    <value>上一步</value>
   </data>
   <data name="Onboarding_Next" xml:space="preserve">
-    <value>ä¸‹ä¸€æ­¥</value>
+    <value>下一步</value>
   </data>
   <data name="Onboarding_Finish" xml:space="preserve">
-    <value>å®Œæˆ</value>
+    <value>完成</value>
   </data>
   <data name="Onboarding_IncompleteSetup_Title" xml:space="preserve">
-    <value>è®¾ç½®å°šæœªå®Œæˆ</value>
+    <value>设置尚未完成</value>
   </data>
   <data name="Onboarding_IncompleteSetup_Body" xml:space="preserve">
     <value>OpenClaw 仍需要完成设置，才能打开 Hub。请使用“返回”回到向导或连接步骤，修复缺失的设置，然后再次尝试“完成”。</value>
   </data>
   <data name="Onboarding_IncompleteSetup_Close" xml:space="preserve">
-    <value>ç¡®å®š</value>
+    <value>确定</value>
   </data>
   <data name="Onboarding_Welcome_Title" xml:space="preserve">
-    <value>æ¬¢è¿Žä½¿ç”¨ OpenClaw</value>
+    <value>欢迎使用 OpenClaw</value>
   </data>
   <data name="Onboarding_Welcome_Subtitle" xml:space="preserve">
-    <value>æ‚¨çš„ AI åŠ©æ‰‹ï¼Œå°±åœ¨ç³»ç»Ÿæ‰˜ç›˜ä¸­</value>
+    <value>您的 AI 助手，就在系统托盘中</value>
   </data>
   <data name="Onboarding_Welcome_SecurityTitle" xml:space="preserve">
-    <value>å®‰å…¨æç¤º</value>
+    <value>安全提示</value>
   </data>
   <data name="Onboarding_Welcome_SecurityBody" xml:space="preserve">
-    <value>OpenClaw è¿è¡Œä¸€ä¸ª AI ä»£ç†ï¼Œå®ƒå¯ä»¥ä»£è¡¨ä½ æ‰§è¡Œå‘½ä»¤ã€è¯»å–å’Œå†™å…¥æ–‡ä»¶ï¼Œå¹¶ä¸Žä½ çš„ç³»ç»Ÿäº¤äº’ã€‚</value>
+    <value>OpenClaw 运行一个 AI 代理，它可以代表你执行命令、读取和写入文件，并与你的系统交互。</value>
   </data>
   <data name="Onboarding_Welcome_TrustTitle" xml:space="preserve">
-    <value>æ‚¨çš„ä»£ç†å¯ä»¥ï¼š</value>
+    <value>您的代理可以：</value>
   </data>
   <data name="Onboarding_Welcome_Trust_Commands" xml:space="preserve">
-    <value>åœ¨æ‚¨çš„è®¡ç®—æœºä¸Šè¿è¡Œå‘½ä»¤</value>
+    <value>在您的计算机上运行命令</value>
   </data>
   <data name="Onboarding_Welcome_Trust_Files" xml:space="preserve">
-    <value>è¯»å–å’Œå†™å…¥æ–‡ä»¶</value>
+    <value>读取和写入文件</value>
   </data>
   <data name="Onboarding_Welcome_Trust_Screen" xml:space="preserve">
-    <value>æ•èŽ·å±å¹•æˆªå›¾</value>
+    <value>捕获屏幕截图</value>
   </data>
   <data name="Onboarding_Connection_Title" xml:space="preserve">
-    <value>é€‰æ‹©ç½‘å…³</value>
+    <value>选择网关</value>
   </data>
   <data name="Onboarding_Connection_Subtitle" xml:space="preserve">
-    <value>é€‰æ‹©æ‚¨å¸Œæœ›å¦‚ä½•è¿žæŽ¥åˆ° OpenClaw ç½‘å…³</value>
+    <value>选择您希望如何连接到 OpenClaw 网关</value>
   </data>
   <data name="Onboarding_Connection_Local" xml:space="preserve">
-    <value>æœ¬æœºï¼ˆæœ¬åœ°ï¼‰</value>
+    <value>本机（本地）</value>
   </data>
   <data name="Onboarding_Connection_Remote" xml:space="preserve">
-    <value>è¿œç¨‹ç½‘å…³</value>
+    <value>远程网关</value>
   </data>
   <data name="Onboarding_Connection_Later" xml:space="preserve">
-    <value>ç¨åŽé…ç½®</value>
+    <value>稍后配置</value>
   </data>
   <data name="Onboarding_Ready_Title" xml:space="preserve">
-    <value>ä¸€åˆ‡å°±ç»ªï¼</value>
+    <value>一切就绪！</value>
   </data>
   <data name="Onboarding_Ready_Subtitle" xml:space="preserve">
-    <value>OpenClaw å·²å‡†å¤‡å°±ç»ªã€‚å¯ä»¥å°è¯•ä»¥ä¸‹æ“ä½œï¼š</value>
+    <value>OpenClaw 已准备就绪。可以尝试以下操作：</value>
   </data>
   <data name="Onboarding_Ready_Feature_TrayMenu" xml:space="preserve">
-    <value>æ‰“å¼€èœå•æ é¢æ¿</value>
+    <value>打开菜单栏面板</value>
   </data>
   <data name="Onboarding_Ready_Feature_Channels" xml:space="preserve">
-    <value>è¿žæŽ¥æ¶ˆæ¯é¢‘é“</value>
+    <value>连接消息频道</value>
   </data>
   <data name="Onboarding_Ready_Feature_Voice" xml:space="preserve">
-    <value>è¯•ç”¨è¯­éŸ³å”¤é†’</value>
+    <value>试用语音唤醒</value>
   </data>
   <data name="Onboarding_Ready_Feature_Canvas" xml:space="preserve">
-    <value>ä½¿ç”¨ç”»å¸ƒ</value>
+    <value>使用画布</value>
   </data>
   <data name="Onboarding_Ready_Feature_Skills" xml:space="preserve">
-    <value>å¯ç”¨æŠ€èƒ½</value>
+    <value>启用技能</value>
   </data>
   <data name="Onboarding_Ready_LaunchAtLogin" xml:space="preserve">
-    <value>å¼€æœºæ—¶å¯åŠ¨ OpenClaw</value>
+    <value>开机时启动 OpenClaw</value>
   </data>
   <data name="Onboarding_Ready_ConfigureLater" xml:space="preserve">
-    <value>æ‚¨å¯ä»¥éšæ—¶ä»Žæ‰˜ç›˜èœå•é…ç½®ç½‘å…³è¿žæŽ¥ã€‚</value>
+    <value>您可以随时从托盘菜单配置网关连接。</value>
   </data>
   <data name="Onboarding_Ready_RemoteInfo" xml:space="preserve">
-    <value>è¯·ç¡®ä¿æ‚¨çš„è¿œç¨‹ç½‘å…³æ­£åœ¨è¿è¡Œä¸”å¯ä»¥è®¿é—®ã€‚</value>
+    <value>请确保您的远程网关正在运行且可以访问。</value>
   </data>
   <data name="Onboarding_Connection_SetupCode" xml:space="preserve">
-    <value>é…ç½®ç </value>
+    <value>配置码</value>
   </data>
   <data name="Onboarding_Connection_SetupCodePlaceholder" xml:space="preserve">
-    <value>ç‚¹å‡»ç²˜è´´é…ç½®ç </value>
+    <value>点击粘贴配置码</value>
   </data>
   <data name="Onboarding_Connection_GatewayUrl" xml:space="preserve">
-    <value>ç½‘å…³åœ°å€</value>
+    <value>网关地址</value>
   </data>
   <data name="Onboarding_Connection_Token" xml:space="preserve">
     <value>Token</value>
   </data>
   <data name="Onboarding_Connection_TokenPlaceholder" xml:space="preserve">
-    <value>ç²˜è´´å¼•å¯¼ Token</value>
+    <value>粘贴引导 Token</value>
   </data>
   <data name="Onboarding_Connection_NodeMode" xml:space="preserve">
-    <value>èŠ‚ç‚¹æ¨¡å¼</value>
+    <value>节点模式</value>
   </data>
   <data name="Onboarding_Connection_TestConnection" xml:space="preserve">
-    <value>æµ‹è¯•è¿žæŽ¥</value>
+    <value>测试连接</value>
   </data>
   <data name="Onboarding_Connection_Ready" xml:space="preserve">
-    <value>å‡†å¤‡è¿žæŽ¥</value>
+    <value>准备连接</value>
   </data>
   <data name="Onboarding_Connection_ConfigureLaterMsg" xml:space="preserve">
-    <value>æ‚¨å¯ä»¥ç¨åŽä»Žæ‰˜ç›˜èœå•é…ç½®ç½‘å…³è¿žæŽ¥ã€‚</value>
+    <value>您可以稍后从托盘菜单配置网关连接。</value>
   </data>
   <data name="Onboarding_Connection_StatusDecoded" xml:space="preserve">
-    <value>é…ç½®ç å·²è§£ç </value>
+    <value>配置码已解码</value>
   </data>
   <data name="Onboarding_Connection_StatusTokenRequired" xml:space="preserve">
-    <value>Token ä¸èƒ½ä¸ºç©º</value>
+    <value>Token 不能为空</value>
   </data>
   <data name="Onboarding_Connection_StatusConnecting" xml:space="preserve">
     <value>正在连接…</value>
   </data>
   <data name="Onboarding_Connection_StatusConnected" xml:space="preserve">
-    <value>å·²è¿žæŽ¥åˆ°ç½‘å…³</value>
+    <value>已连接到网关</value>
   </data>
   <data name="Onboarding_Connection_StatusPairing" xml:space="preserve">
-    <value>è®¾å¤‡éœ€è¦å®¡æ‰¹</value>
+    <value>设备需要审批</value>
   </data>
   <data name="Onboarding_Connection_StatusTokenMismatch" xml:space="preserve">
     <value>Token 不匹配 — 请检查您的引导 Token</value>
@@ -1178,124 +1178,124 @@
     <value>连接超时 (15s) — 请确认网关正在运行</value>
   </data>
   <data name="Onboarding_Permissions_Title" xml:space="preserve">
-    <value>æŽˆäºˆæƒé™</value>
+    <value>授予权限</value>
   </data>
   <data name="Onboarding_Permissions_Description" xml:space="preserve">
-    <value>å½“ OpenClaw å¯ä»¥å‘é€é€šçŸ¥ã€è®¿é—®æ‘„åƒå¤´å’Œéº¦å…‹é£Žã€æ•èŽ·å±å¹•å¹¶äº†è§£ä½ çš„ä½ç½®æ—¶æ•ˆæžœæœ€ä½³ã€‚è¯·åœ¨ä¸‹æ–¹æŽˆäºˆæƒé™ã€‚</value>
+    <value>当 OpenClaw 可以发送通知、访问摄像头和麦克风、捕获屏幕并了解你的位置时效果最佳。请在下方授予权限。</value>
   </data>
   <data name="Onboarding_Permissions_Refresh" xml:space="preserve">
-    <value>åˆ·æ–°çŠ¶æ€</value>
+    <value>刷新状态</value>
   </data>
   <data name="Onboarding_Permissions_OpenSettings" xml:space="preserve">
-    <value>æ‰“å¼€è®¾ç½®</value>
+    <value>打开设置</value>
   </data>
   <data name="Onboarding_Permissions_Checking" xml:space="preserve">
     <value>正在检查权限…</value>
   </data>
   <data name="Onboarding_Chat_Title" xml:space="preserve">
-    <value>è®¤è¯†æ‚¨çš„ä»£ç†</value>
+    <value>认识您的代理</value>
   </data>
   <data name="Onboarding_Chat_Loading" xml:space="preserve">
     <value>正在加载聊天…</value>
   </data>
   <data name="Onboarding_Wizard_Title" xml:space="preserve">
-    <value>é…ç½®ç½‘å…³</value>
+    <value>配置网关</value>
   </data>
   <data name="Onboarding_Wizard_Continue" xml:space="preserve">
-    <value>ç»§ç»­</value>
+    <value>继续</value>
   </data>
   <data name="Onboarding_Wizard_Skip" xml:space="preserve">
-    <value>è·³è¿‡</value>
+    <value>跳过</value>
   </data>
   <data name="Onboarding_Wizard_Complete" xml:space="preserve">
-    <value>ç½‘å…³é…ç½®å®Œæˆï¼</value>
+    <value>网关配置完成！</value>
   </data>
   <data name="Onboarding_Wizard_Offline" xml:space="preserve">
-    <value>ç½‘å…³å‘å¯¼ä¸å¯ç”¨</value>
+    <value>网关向导不可用</value>
   </data>
   <data name="Onboarding_Wizard_OfflineMessage" xml:space="preserve">
-    <value>ç½‘å…³æä¾›åŠ¨æ€é…ç½®æ­¥éª¤ï¼Œå°†åœ¨è¿žæŽ¥å»ºç«‹åŽæ‰§è¡Œã€‚</value>
+    <value>网关提供动态配置步骤，将在连接建立后执行。</value>
   </data>
   <data name="Onboarding_Perm_Notifications" xml:space="preserve">
-    <value>é€šçŸ¥</value>
+    <value>通知</value>
   </data>
   <data name="Onboarding_Perm_Camera" xml:space="preserve">
-    <value>æ‘„åƒå¤´</value>
+    <value>摄像头</value>
   </data>
   <data name="Onboarding_Perm_Microphone" xml:space="preserve">
-    <value>éº¦å…‹é£Ž</value>
+    <value>麦克风</value>
   </data>
   <data name="Onboarding_Perm_ScreenCapture" xml:space="preserve">
-    <value>å±å¹•æˆªå›¾</value>
+    <value>屏幕截图</value>
   </data>
   <data name="Onboarding_Perm_Location" xml:space="preserve">
-    <value>ä½ç½®ï¼ˆå¯é€‰ï¼‰</value>
+    <value>位置（可选）</value>
   </data>
   <data name="Onboarding_Perm_Enabled" xml:space="preserve">
-    <value>å·²å¯ç”¨</value>
+    <value>已启用</value>
   </data>
   <data name="Onboarding_Perm_EnabledDefault" xml:space="preserve">
-    <value>å·²å¯ç”¨ï¼ˆé»˜è®¤ï¼‰</value>
+    <value>已启用（默认）</value>
   </data>
   <data name="Onboarding_Perm_Disabled" xml:space="preserve">
-    <value>å·²ç¦ç”¨</value>
+    <value>已禁用</value>
   </data>
   <data name="Onboarding_Perm_DisabledManifest" xml:space="preserve">
-    <value>åœ¨åº”ç”¨æ¸…å•ä¸­å·²ç¦ç”¨</value>
+    <value>在应用清单中已禁用</value>
   </data>
   <data name="Onboarding_Perm_DisabledPolicy" xml:space="preserve">
-    <value>è¢«ç­–ç•¥ç¦ç”¨</value>
+    <value>被策略禁用</value>
   </data>
   <data name="Onboarding_Perm_DisabledUser" xml:space="preserve">
     <value>已禁用 — 打开设置以启用</value>
   </data>
   <data name="Onboarding_Perm_Allowed" xml:space="preserve">
-    <value>å·²å…è®¸</value>
+    <value>已允许</value>
   </data>
   <data name="Onboarding_Perm_DeniedUser" xml:space="preserve">
     <value>被拒绝 — 打开设置以允许</value>
   </data>
   <data name="Onboarding_Perm_DeniedSystem" xml:space="preserve">
-    <value>è¢«ç³»ç»Ÿç­–ç•¥æ‹’ç»</value>
+    <value>被系统策略拒绝</value>
   </data>
   <data name="Onboarding_Perm_NotDetermined" xml:space="preserve">
     <value>未确定 — 打开设置</value>
   </data>
   <data name="Onboarding_Perm_UnableToCheck" xml:space="preserve">
-    <value>æ— æ³•æ£€æŸ¥</value>
+    <value>无法检查</value>
   </data>
   <data name="Onboarding_Perm_NoCameraDetected" xml:space="preserve">
-    <value>æœªæ£€æµ‹åˆ°ç›¸æœº</value>
+    <value>未检测到相机</value>
   </data>
   <data name="Onboarding_Perm_NoMicDetected" xml:space="preserve">
-    <value>æœªæ£€æµ‹åˆ°éº¦å…‹é£Ž</value>
+    <value>未检测到麦克风</value>
   </data>
   <data name="Onboarding_Perm_ScreenCaptureAvailable" xml:space="preserve">
     <value>可用 — 每次截图使用选择器</value>
   </data>
   <data name="Onboarding_Perm_NotSupported" xml:space="preserve">
-    <value>æ­¤è®¾å¤‡ä¸æ”¯æŒ</value>
+    <value>此设备不支持</value>
   </data>
   <data name="Onboarding_Perm_LocationDisabledSystem" xml:space="preserve">
-    <value>ä½ç½®æœåŠ¡å·²åœ¨ç³»ç»ŸèŒƒå›´å†…ç¦ç”¨</value>
+    <value>位置服务已在系统范围内禁用</value>
   </data>
   <data name="Onboarding_Perm_LocationDisabledUser" xml:space="preserve">
-    <value>æ­¤ç”¨æˆ·çš„ä½ç½®å·²ç¦ç”¨</value>
+    <value>此用户的位置已禁用</value>
   </data>
   <data name="Onboarding_Perm_LocationEnabled" xml:space="preserve">
-    <value>ä½ç½®æœåŠ¡å·²å¯ç”¨</value>
+    <value>位置服务已启用</value>
   </data>
   <data name="Onboarding_Ready_Feature_TrayMenu_Subtitle" xml:space="preserve">
-    <value>ä»Žç³»ç»Ÿæ‰˜ç›˜è®¿é—®</value>
+    <value>从系统托盘访问</value>
   </data>
   <data name="Onboarding_Ready_Feature_Channels_Subtitle" xml:space="preserve">
     <value>设置 → 频道</value>
   </data>
   <data name="Onboarding_Ready_Feature_Voice_Subtitle" xml:space="preserve">
-    <value>ç”¨è¯­éŸ³å”¤é†’</value>
+    <value>用语音唤醒</value>
   </data>
   <data name="Onboarding_Ready_Feature_Canvas_Subtitle" xml:space="preserve">
-    <value>è§†è§‰å·¥ä½œåŒº</value>
+    <value>视觉工作区</value>
   </data>
   <data name="Onboarding_Ready_Feature_Skills_Subtitle" xml:space="preserve">
     <value>设置 → 技能</value>
@@ -1307,82 +1307,82 @@
     <value>速率限制 — 请稍等后重试</value>
   </data>
   <data name="Onboarding_Connection_RunOnGateway" xml:space="preserve">
-    <value>åœ¨æ‚¨çš„ç½‘å…³ä¸Šè¿è¡Œï¼š</value>
+    <value>在您的网关上运行：</value>
   </data>
   <data name="Onboarding_Connection_ClickToCopy" xml:space="preserve">
-    <value>ç‚¹å‡»å¤åˆ¶</value>
+    <value>点击复制</value>
   </data>
   <data name="Onboarding_Connection_CopyFailed" xml:space="preserve">
     <value>复制失败 — 点击重试</value>
   </data>
   <data name="Onboarding_Connection_Copied" xml:space="preserve">
-    <value>å·²å¤åˆ¶ï¼</value>
+    <value>已复制！</value>
   </data>
   <data name="Onboarding_Connection_StatusFailed" xml:space="preserve">
     <value>连接失败 — 请检查 URL 和令牌，然后重试</value>
   </data>
   <data name="Onboarding_Wizard_StepError" xml:space="preserve">
-    <value>å¤„ç†æ­¤æ­¥éª¤æ—¶å‡ºé”™</value>
+    <value>处理此步骤时出错</value>
   </data>
   <data name="Onboarding_Connection_StatusDetecting" xml:space="preserve">
-    <value>æ­£åœ¨æ£€æµ‹ç½‘å…³...</value>
+    <value>正在检测网关...</value>
   </data>
   <data name="Onboarding_Connection_StatusDetected" xml:space="preserve">
-    <value>å·²åœ¨å¼€å‘ç«¯å£æ£€æµ‹åˆ°ç½‘å…³</value>
+    <value>已在开发端口检测到网关</value>
   </data>
   <data name="Onboarding_Connection_StatusAuthenticating" xml:space="preserve">
-    <value>æ­£åœ¨éªŒè¯...</value>
+    <value>正在验证...</value>
   </data>
   <data name="Onboarding_Connection_Wsl" xml:space="preserve">
-    <value>WSL ç½‘å…³</value>
+    <value>WSL 网关</value>
   </data>
   <data name="Onboarding_Connection_Ssh" xml:space="preserve">
-    <value>SSH ΘÜºΘüô</value>
+    <value>SSH 隧道</value>
   </data>
   <data name="Onboarding_Connection_PasteSetup" xml:space="preserve">
-    <value>ç²˜è´´</value>
+    <value>粘贴</value>
   </data>
   <data name="Onboarding_Connection_QrButton" xml:space="preserve">
     <value>QR</value>
   </data>
   <data name="Onboarding_Connection_QrFilePickerTitle" xml:space="preserve">
-    <value>å¯¼å…¥äºŒç»´ç å›¾åƒ</value>
+    <value>导入二维码图像</value>
   </data>
   <data name="Onboarding_Connection_QrDecodeFailed" xml:space="preserve">
-    <value>æ— æ³•ä»Žæ­¤å›¾åƒè§£ç å®‰è£…ä»£ç </value>
+    <value>无法从此图像解码安装代码</value>
   </data>
   <data name="Onboarding_Connection_SshHint" xml:space="preserve">
-    <value>OpenClaw å°†åˆ›å»ºæ‰˜ç®¡ SSH éš§é“ï¼ŒæŠŠè¿œç¨‹ä¸»æœºä¸Šçš„ç½‘å…³ç«¯å£è½¬å‘åˆ°æ­¤ç”µè„‘ã€‚</value>
+    <value>OpenClaw 将创建托管 SSH 隧道，把远程主机上的网关端口转发到此电脑。</value>
   </data>
   <data name="Onboarding_Connection_SshUser" xml:space="preserve">
-    <value>SSH τö¿µê╖</value>
+    <value>SSH 用户</value>
   </data>
   <data name="Onboarding_Connection_SshHost" xml:space="preserve">
-    <value>SSH Σ╕╗µ£║</value>
+    <value>SSH 主机</value>
   </data>
   <data name="Onboarding_Connection_SshRemotePort" xml:space="preserve">
-    <value>è¿œç¨‹ç½‘å…³ç«¯å£</value>
+    <value>远程网关端口</value>
   </data>
   <data name="Onboarding_Connection_SshLocalPort" xml:space="preserve">
-    <value>æœ¬åœ°è½¬å‘ç«¯å£</value>
+    <value>本地转发端口</value>
   </data>
   <data name="Onboarding_Connection_SshPreviewLabel" xml:space="preserve">
-    <value>æ‰˜ç®¡éš§é“ï¼š</value>
+    <value>托管隧道：</value>
   </data>
   <data name="Onboarding_Connection_SshUserInvalid" xml:space="preserve">
-    <value>è¯·åœ¨è¿žæŽ¥å‰è¾“å…¥æœ‰æ•ˆçš„ SSH ç”¨æˆ·ã€‚</value>
+    <value>请在连接前输入有效的 SSH 用户。</value>
   </data>
   <data name="Onboarding_Connection_SshHostInvalid" xml:space="preserve">
-    <value>è¯·åœ¨è¿žæŽ¥å‰è¾“å…¥æœ‰æ•ˆçš„ SSH ä¸»æœºï¼ˆä¾‹å¦‚ mac-studio.localï¼‰ã€‚</value>
+    <value>请在连接前输入有效的 SSH 主机（例如 mac-studio.local）。</value>
   </data>
   <data name="Onboarding_Connection_TopologyDetectedFmt" xml:space="preserve">
-    <value>å·²æ£€æµ‹ï¼š{0}</value>
+    <value>已检测：{0}</value>
   </data>
   <data name="Onboarding_Connection_LaterStatus" xml:space="preserve">
     <value>您可以稍后在“设置”中配置网关。</value>
   </data>
   <data name="Onboarding_SetupWarning_Title" xml:space="preserve">
-    <value>è®¾ç½® OpenClaw</value>
+    <value>设置 OpenClaw</value>
   </data>
   <data name="Onboarding_SetupWarning_Body" xml:space="preserve">
     <value>OpenClaw 允许代理在此电脑上运行命令、读写文件以及捕获屏幕截图。仅在您信任的计算机上进行设置。
@@ -1390,64 +1390,64 @@
 ⚠️ 本地设置将安装一个专用于 OpenClaw 的小型 WSL Linux 实例。如果您希望连接到现有或远程网关，请选择“高级设置”。</value>
   </data>
   <data name="Onboarding_SetupWarning_SetupLocally" xml:space="preserve">
-    <value>æœ¬åœ°è®¾ç½®</value>
+    <value>本地设置</value>
   </data>
   <data name="Onboarding_SetupWarning_Advanced" xml:space="preserve">
-    <value>é«˜çº§è®¾ç½®</value>
+    <value>高级设置</value>
   </data>
   <data name="Onboarding_SetupWarning_ReplaceHeading" xml:space="preserve">
     <value>⚠️ 替换现有配置？</value>
   </data>
   <data name="Onboarding_SetupWarning_ReplaceBody" xml:space="preserve">
-    <value>ç»§ç»­æ“ä½œå°†æ–­å¼€ä¸Žå½“å‰ç½‘å…³çš„è¿žæŽ¥å¹¶ä¸¢å¤±æ‰€æœ‰è®¾ç½®ã€‚</value>
+    <value>继续操作将断开与当前网关的连接并丢失所有设置。</value>
   </data>
   <data name="Onboarding_SetupWarning_ReplaceConfirm" xml:space="preserve">
-    <value>æ›¿æ¢æˆ‘çš„è®¾ç½®</value>
+    <value>替换我的设置</value>
   </data>
   <data name="Onboarding_SetupWarning_ReplaceCancel" xml:space="preserve">
-    <value>ä¿ç•™æˆ‘çš„è®¾ç½®</value>
+    <value>保留我的设置</value>
   </data>
   <data name="Onboarding_LocalSetup_Title" xml:space="preserve">
-    <value>æ­£åœ¨æœ¬åœ°è®¾ç½®</value>
+    <value>正在本地设置</value>
   </data>
   <data name="Onboarding_LocalSetup_SubtitleIdle" xml:space="preserve">
-    <value>æ­£åœ¨è®¾ç½®æ‚¨çš„æœ¬åœ° OpenClaw ç½‘å…³ã€‚</value>
+    <value>正在设置您的本地 OpenClaw 网关。</value>
   </data>
   <data name="Onboarding_LocalSetup_SubtitleSuccess" xml:space="preserve">
-    <value>æœ¬åœ°ç½‘å…³å·²å°±ç»ªã€‚</value>
+    <value>本地网关已就绪。</value>
   </data>
   <data name="Onboarding_LocalSetup_Retry" xml:space="preserve">
-    <value>é‡è¯•</value>
+    <value>重试</value>
   </data>
   <data name="Onboarding_LocalSetup_TerminalFailure" xml:space="preserve">
-    <value>è®¾ç½®æœªå®Œæˆã€‚</value>
+    <value>设置未完成。</value>
   </data>
   <data name="Onboarding_LocalSetup_DiagnosticsHint" xml:space="preserve">
-    <value>è¯Šæ–­ï¼šaka.ms/wsllogs</value>
+    <value>诊断：aka.ms/wsllogs</value>
   </data>
   <data name="Onboarding_LocalSetup_Phase_Preflight" xml:space="preserve">
-    <value>æ­£åœ¨æ£€æŸ¥ç³»ç»Ÿ</value>
+    <value>正在检查系统</value>
   </data>
   <data name="Onboarding_LocalSetup_Phase_CreateInstance" xml:space="preserve">
-    <value>æ­£åœ¨å®‰è£… Ubuntu</value>
+    <value>正在安装 Ubuntu</value>
   </data>
   <data name="Onboarding_LocalSetup_Phase_Configure" xml:space="preserve">
-    <value>æ­£åœ¨é…ç½®å®žä¾‹</value>
+    <value>正在配置实例</value>
   </data>
   <data name="Onboarding_LocalSetup_Phase_InstallCli" xml:space="preserve">
-    <value>æ­£åœ¨å®‰è£… OpenClaw</value>
+    <value>正在安装 OpenClaw</value>
   </data>
   <data name="Onboarding_LocalSetup_Phase_PrepareConfig" xml:space="preserve">
-    <value>æ­£åœ¨å‡†å¤‡ç½‘å…³</value>
+    <value>正在准备网关</value>
   </data>
   <data name="Onboarding_LocalSetup_Phase_StartGateway" xml:space="preserve">
-    <value>æ­£åœ¨å¯åŠ¨ç½‘å…³</value>
+    <value>正在启动网关</value>
   </data>
   <data name="Onboarding_LocalSetup_Phase_MintToken" xml:space="preserve">
-    <value>æ­£åœ¨ç”Ÿæˆè®¾ç½®ä»£ç </value>
+    <value>正在生成设置代码</value>
   </data>
   <data name="AboutPage_TextBlock_10.Text" xml:space="preserve">
-    <value>å…³äºŽ</value>
+    <value>关于</value>
   </data>
   <data name="AboutPage_TextBlock_19.Text" xml:space="preserve">
     <value>OpenClaw Hub</value>
@@ -1456,37 +1456,37 @@
     <value>.NET 10 / WinUI 3 / WinAppSDK 1.8</value>
   </data>
   <data name="AboutPage_TextBlock_35.Text" xml:space="preserve">
-    <value>ç½‘å…³ä¿¡æ¯</value>
+    <value>网关信息</value>
   </data>
   <data name="AboutPage_TextBlock_48.Text" xml:space="preserve">
-    <value>ç‰ˆæœ¬ï¼š</value>
+    <value>版本：</value>
   </data>
   <data name="AboutPage_TextBlock_52.Text" xml:space="preserve">
-    <value>æ¨¡åž‹ï¼š</value>
+    <value>模型：</value>
   </data>
   <data name="AboutPage_TextBlock_56.Text" xml:space="preserve">
-    <value>èº«ä»½éªŒè¯æ¨¡å¼ï¼š</value>
+    <value>身份验证模式：</value>
   </data>
   <data name="AboutPage_TextBlock_60.Text" xml:space="preserve">
-    <value>è¿è¡Œæ—¶é—´ï¼š</value>
+    <value>运行时间：</value>
   </data>
   <data name="AboutPage_TextBlock_72.Text" xml:space="preserve">
-    <value>è°ƒè¯•</value>
+    <value>调试</value>
   </data>
   <data name="OpenLogButton.Content" xml:space="preserve">
-    <value>æ‰“å¼€æ—¥å¿—æ–‡ä»¶</value>
+    <value>打开日志文件</value>
   </data>
   <data name="OpenConfigButton.Content" xml:space="preserve">
-    <value>æ‰“å¼€é…ç½®æ–‡ä»¶å¤¹</value>
+    <value>打开配置文件夹</value>
   </data>
   <data name="CopySupportButton.Content" xml:space="preserve">
-    <value>å¤åˆ¶æ”¯æŒä¸Šä¸‹æ–‡</value>
+    <value>复制支持上下文</value>
   </data>
   <data name="CheckUpdatesButton.Content" xml:space="preserve">
-    <value>æ£€æŸ¥æ›´æ–°</value>
+    <value>检查更新</value>
   </data>
   <data name="AboutPage_TextBlock_91.Text" xml:space="preserve">
-    <value>é“¾æŽ¥</value>
+    <value>链接</value>
   </data>
   <data name="AboutPage_HyperlinkButton_92.Content" xml:space="preserve">
     <value>Documentation → openclaw.ai/docs</value>
@@ -1498,115 +1498,115 @@
     <value>Dashboard → openclaw://dashboard</value>
   </data>
   <data name="AgentEventsPage_TextBlock_18.Text" xml:space="preserve">
-    <value>ä»£ç†äº‹ä»¶</value>
+    <value>代理事件</value>
   </data>
   <data name="AgentFilterCombo.Header" xml:space="preserve">
-    <value>ä»£ç†</value>
+    <value>代理</value>
   </data>
   <data name="AgentFilterCombo.PlaceholderText" xml:space="preserve">
-    <value>æ‰€æœ‰ä»£ç†</value>
+    <value>所有代理</value>
   </data>
   <data name="AgentEventsPage_IntroText.Text" xml:space="preserve">
     <value>代理活动的实时流——工具调用、响应、错误和生命周期事件。</value>
   </data>
   <data name="AgentEventsPage_ComboBoxItem_26.Content" xml:space="preserve">
-    <value>æ‰€æœ‰ä»£ç†</value>
+    <value>所有代理</value>
   </data>
   <data name="AgentEventsPage_ToggleButton_36.Text" xml:space="preserve">
-    <value>å·¥å…·</value>
+    <value>工具</value>
   </data>
   <data name="AgentEventsPage_ToggleButton_37.Text" xml:space="preserve">
-    <value>åŠ©æ‰‹</value>
+    <value>助手</value>
   </data>
   <data name="AgentEventsPage_ToggleButton_38.Text" xml:space="preserve">
-    <value>é”™è¯¯</value>
+    <value>错误</value>
   </data>
   <data name="AgentEventsPage_ToggleButton_39.Text" xml:space="preserve">
-    <value>ç”Ÿå‘½å‘¨æœŸ</value>
+    <value>生命周期</value>
   </data>
   <data name="AgentEventsPage_ToggleButton_40.Text" xml:space="preserve">
-    <value>è®¡åˆ’</value>
+    <value>计划</value>
   </data>
   <data name="AgentEventsPage_ToggleButton_41.Text" xml:space="preserve">
-    <value>æ‰¹å‡†</value>
+    <value>批准</value>
   </data>
   <data name="AgentEventsPage_ToggleButton_42.Text" xml:space="preserve">
-    <value>æ€è€ƒä¸­</value>
+    <value>思考中</value>
   </data>
   <data name="AgentEventsPage_ToggleButton_43.Text" xml:space="preserve">
-    <value>è¡¥ä¸</value>
+    <value>补丁</value>
   </data>
   <data name="AgentEventsPage_TextBlock_96.Text" xml:space="preserve">
-    <value>è¿˜æ²¡æœ‰ä»£ç†äº‹ä»¶</value>
+    <value>还没有代理事件</value>
   </data>
   <data name="AgentEventsPage_TextBlock_99.Text" xml:space="preserve">
-    <value>ä»£ç†è¿è¡Œæ—¶ï¼Œå®žæ—¶ä»£ç†äº‹ä»¶ï¼ˆå·¥å…·è°ƒç”¨ã€å“åº”ã€é”™è¯¯ï¼‰å°†æ˜¾ç¤ºåœ¨æ­¤å¤„ã€‚</value>
+    <value>代理运行时，实时代理事件（工具调用、响应、错误）将显示在此处。</value>
   </data>
   <data name="ClearButton.Content" xml:space="preserve">
-    <value>æ¸…é™¤</value>
+    <value>清除</value>
   </data>
   <data name="ClearButton.Text" xml:space="preserve">
-    <value>æ¸…é™¤</value>
+    <value>清除</value>
   </data>
   <data name="BindingsPage_TextBlock_16.Text" xml:space="preserve">
-    <value>ç»‘å®š</value>
+    <value>绑定</value>
   </data>
   <data name="BindingsPage_TextBlock_17.Text" xml:space="preserve">
-    <value>æ¶ˆæ¯è·¯ç”±è§„åˆ™</value>
+    <value>消息路由规则</value>
   </data>
   <data name="BindingsPage_TextBlock_25.Text" xml:space="preserve">
-    <value>åˆ·æ–°</value>
+    <value>刷新</value>
   </data>
   <data name="CapabilitiesPage_TextBlock_10.Text" xml:space="preserve">
     <value>🖥️ 此计算机</value>
   </data>
   <data name="PermissionsPage_IntroText.Text" xml:space="preserve">
-    <value>é€šè¿‡ç½‘å…³æä¾›ç»™ä»£ç†çš„è®¾å¤‡åŠŸèƒ½ã€‚åˆ‡æ¢æ­¤è®¡ç®—æœºå¯ä»¥æ‰§è¡Œçš„æ“ä½œã€‚</value>
+    <value>通过网关提供给代理的设备功能。切换此计算机可以执行的操作。</value>
   </data>
   <data name="PermissionsPage_McpHeader.Text" xml:space="preserve">
-    <value>æœ¬åœ° MCP æœåŠ¡å™¨</value>
+    <value>本地 MCP 服务器</value>
   </data>
   <data name="PermissionsPage_McpDescription.Text" xml:space="preserve">
-    <value>é€šè¿‡ HTTP å‘ CLI å·¥å…·å’Œæœ¬åœ°é›†æˆå…¬å¼€åŠŸèƒ½ã€‚</value>
+    <value>通过 HTTP 向 CLI 工具和本地集成公开功能。</value>
   </data>
   <data name="PermissionsPage_McpEndpointLabel.Text" xml:space="preserve">
-    <value>ç»ˆç»“ç‚¹ï¼š</value>
+    <value>终结点：</value>
   </data>
   <data name="CopyMcpTokenButton.Content" xml:space="preserve">
-    <value>å¤åˆ¶ä»¤ç‰Œ</value>
+    <value>复制令牌</value>
   </data>
   <data name="CopyMcpUrlButton.Content" xml:space="preserve">
-    <value>å¤åˆ¶ URL</value>
+    <value>复制 URL</value>
   </data>
   <data name="CapabilitiesPage_TextBlock_66.Text" xml:space="preserve">
-    <value>èŠ‚ç‚¹çŠ¶æ€</value>
+    <value>节点状态</value>
   </data>
   <data name="NodeStatusText.Text" xml:space="preserve">
-    <value>èŠ‚ç‚¹æ¨¡å¼å·²ç¦ç”¨</value>
+    <value>节点模式已禁用</value>
   </data>
   <data name="ChannelsPage_TextBlock_10.Text" xml:space="preserve">
     <value>📡 频道</value>
   </data>
   <data name="ConnectionWarning.Title" xml:space="preserve">
-    <value>æœªè¿žæŽ¥</value>
+    <value>未连接</value>
   </data>
   <data name="ChannelsPage_TextBlock_22.Text" xml:space="preserve">
-    <value>æœªé…ç½®é¢‘é“</value>
+    <value>未配置频道</value>
   </data>
   <data name="ChatPage_TextBlock_53.Text" xml:space="preserve">
-    <value>è¿žæŽ¥åˆ°ç½‘å…³ä»¥å¼€å§‹èŠå¤©</value>
+    <value>连接到网关以开始聊天</value>
   </data>
   <data name="ChatPage_WaitingTitle.Text" xml:space="preserve">
     <value>等待聊天启动…</value>
   </data>
   <data name="ChatPage_WaitingStatusText.Text" xml:space="preserve">
-    <value>ç½‘å…³å·²è¿žæŽ¥ï¼›èŠå¤©ç•Œé¢ä»åœ¨ä¸Šçº¿ä¸­ã€‚</value>
+    <value>网关已连接；聊天界面仍在上线中。</value>
   </data>
   <data name="ConfigPage_TextBlock_17.Text" xml:space="preserve">
-    <value>é…ç½®</value>
+    <value>配置</value>
   </data>
   <data name="ConfigPage_TextBlock_21.Text" xml:space="preserve">
-    <value>åˆ·æ–°</value>
+    <value>刷新</value>
   </data>
   <data name="ConfigPage_OpenConnection.Content" xml:space="preserve">
     <value>打开连接</value>
@@ -1657,22 +1657,22 @@
     <value>放弃更改</value>
   </data>
   <data name="ConfigPage_TabViewItem_34.Text" xml:space="preserve">
-    <value>ç¼–è¾‘å™¨</value>
+    <value>编辑器</value>
   </data>
   <data name="DetailPath.Text" xml:space="preserve">
-    <value>é€‰æ‹©é…ç½®éƒ¨åˆ†</value>
+    <value>选择配置部分</value>
   </data>
 <data name="ConfigPage_TabViewItem_82.Text" xml:space="preserve">
-    <value>åŽŸå§‹ JSON</value>
+    <value>原始 JSON</value>
   </data>
   <data name="ConfigPage_TextBlock_95.Text" xml:space="preserve">
-    <value>æž¶æž„ä¸å¯ç”¨</value>
+    <value>架构不可用</value>
   </data>
   <data name="ConfigPage_TextBlock_98.Text" xml:space="preserve">
-    <value>æ— æ³•åŠ è½½ç½‘å…³é…ç½®æž¶æž„ã€‚è¯·ä½¿ç”¨ Web ä»ªè¡¨æ¿ç¼–è¾‘è®¾ç½®ã€‚</value>
+    <value>无法加载网关配置架构。请使用 Web 仪表板编辑设置。</value>
   </data>
   <data name="OpenDashboardButton.Content" xml:space="preserve">
-    <value>æ‰“å¼€ä»ªè¡¨æ¿</value>
+    <value>打开仪表板</value>
   </data>
   <data name="ConfigPage_ReconnectDialogTitle" xml:space="preserve">
     <value>Saving configuration</value>
@@ -1687,49 +1687,49 @@
     <value>Reconnecting...</value>
   </data>
   <data name="SaveButton.Content" xml:space="preserve">
-    <value>ä¿å­˜æ›´æ”¹</value>
+    <value>保存更改</value>
   </data>
   <data name="SaveButtonText.Text" xml:space="preserve">
-    <value>ä¿å­˜æ›´æ”¹</value>
+    <value>保存更改</value>
   </data>
   <data name="ConnectionPage_TextBlock_10.Text" xml:space="preserve">
     <value>🔗 连接</value>
   </data>
   <data name="ConnectionPage_TextBlock_11.Text" xml:space="preserve">
-    <value>æ“ä½œå‘˜å®¢æˆ·ç«¯å’ŒèŠ‚ç‚¹æœåŠ¡å…±åŒä½¿ç”¨çš„ç½‘å…³ç»ˆç»“ç‚¹ã€‚</value>
+    <value>操作员客户端和节点服务共同使用的网关终结点。</value>
   </data>
   <data name="AuthErrorBar.Title" xml:space="preserve">
-    <value>è¿žæŽ¥é”™è¯¯</value>
+    <value>连接错误</value>
   </data>
   <data name="StatusText.Text" xml:space="preserve">
-    <value>å·²æ–­å¼€è¿žæŽ¥</value>
+    <value>已断开连接</value>
   </data>
   <data name="ReconnectButton.Content" xml:space="preserve">
-    <value>é‡æ–°è¿žæŽ¥</value>
+    <value>重新连接</value>
   </data>
   <data name="OperatorStatusText.Text" xml:space="preserve">
     <value>操作员：—</value>
   </data>
   <data name="ConnectToggle.Header" xml:space="preserve">
-    <value>è¿žæŽ¥</value>
+    <value>连接</value>
   </data>
   <data name="ConnectionPage_TextBlock_76.Text" xml:space="preserve">
     <value>📡 可用网关</value>
   </data>
   <data name="ConnectionPage_TextBlock_84.Text" xml:space="preserve">
-    <value>æ‰«æ</value>
+    <value>扫描</value>
   </data>
   <data name="TokenPromptText.Text" xml:space="preserve">
-    <value>æ­¤ç½‘å…³éœ€è¦ä»¤ç‰Œæ‰èƒ½è¿žæŽ¥ã€‚</value>
+    <value>此网关需要令牌才能连接。</value>
   </data>
   <data name="ConnectionPage_Button_105.Content" xml:space="preserve">
-    <value>å–æ¶ˆ</value>
+    <value>取消</value>
   </data>
   <data name="TokenPromptConnectBtn.Content" xml:space="preserve">
-    <value>è¿žæŽ¥</value>
+    <value>连接</value>
   </data>
   <data name="ConnectionPage_TextBlock_111.Text" xml:space="preserve">
-    <value>åœ¨ç½‘å…³ä¸»æœºä¸Šè¿è¡Œ 'openclaw qr' èŽ·å–è®¾ç½®ä»£ç ï¼Œæˆ–åœ¨ç½‘å…³é…ç½®ä¸­æŸ¥æ‰¾ä»¤ç‰Œã€‚</value>
+    <value>在网关主机上运行 'openclaw qr' 获取设置代码，或在网关配置中查找令牌。</value>
   </data>
   <data name="GatewayEmptyText.Text" xml:space="preserve">
     <value>未找到网关。单击“扫描”进行搜索。</value>
@@ -1738,91 +1738,91 @@
     <value>🔑 设置代码</value>
   </data>
   <data name="ConnectionPage_TextBlock_129.Text" xml:space="preserve">
-    <value>ç²˜è´´æ¥è‡ª openclaw qr çš„è®¾ç½®ä»£ç </value>
+    <value>粘贴来自 openclaw qr 的设置代码</value>
   </data>
   <data name="ApplySetupCodeButton.Content" xml:space="preserve">
-    <value>åº”ç”¨</value>
+    <value>应用</value>
   </data>
   <data name="ConnectionPage_TextBlock_152.Text" xml:space="preserve">
-    <value>é«˜çº§è¿žæŽ¥è®¾ç½®</value>
+    <value>高级连接设置</value>
   </data>
   <data name="GatewayUrlTextBox.Header" xml:space="preserve">
-    <value>ç½‘å…³åœ°å€</value>
+    <value>网关地址</value>
   </data>
   <data name="TokenTextBox.Header" xml:space="preserve">
     <value>Token</value>
   </data>
   <data name="TestButton.Content" xml:space="preserve">
-    <value>æµ‹è¯•</value>
+    <value>测试</value>
   </data>
   <data name="SshToggle.Header" xml:space="preserve">
-    <value>SSH ΘÜºΘüô</value>
+    <value>SSH 隧道</value>
   </data>
   <data name="SshUserBox.Header" xml:space="preserve">
-    <value>SSH τö¿µê╖</value>
+    <value>SSH 用户</value>
   </data>
   <data name="SshUserBox.PlaceholderText" xml:space="preserve">
     <value>user</value>
   </data>
   <data name="SshHostBox.Header" xml:space="preserve">
-    <value>SSH Σ╕╗µ£║</value>
+    <value>SSH 主机</value>
   </data>
   <data name="SshHostBox.PlaceholderText" xml:space="preserve">
     <value>machine-name</value>
   </data>
   <data name="SshRemotePortBox.Header" xml:space="preserve">
-    <value>è¿œç¨‹ç«¯å£</value>
+    <value>远程端口</value>
   </data>
   <data name="SshLocalPortBox.Header" xml:space="preserve">
-    <value>æœ¬åœ°ç«¯å£</value>
+    <value>本地端口</value>
   </data>
   <data name="ConnectionPage_Button_190.Content" xml:space="preserve">
-    <value>ä¿å­˜</value>
+    <value>保存</value>
   </data>
   <data name="ConnectionPage_TextBlock_200.Text" xml:space="preserve">
     <value>🪪 此设备</value>
   </data>
   <data name="ConnectionPage_TextBlock_207.Text" xml:space="preserve">
-    <value>è®¾å¤‡ IDï¼š</value>
+    <value>设备 ID：</value>
   </data>
   <data name="CopyDeviceIdButton.Content" xml:space="preserve">
-    <value>å¤åˆ¶</value>
+    <value>复制</value>
   </data>
   <data name="ConnectionPage_TextBlock_219.Text" xml:space="preserve">
-    <value>åœ¨ç½‘å…³ä¸»æœºä¸Šè¿è¡Œæ­¤å‘½ä»¤ä»¥æ‰¹å‡†ï¼š</value>
+    <value>在网关主机上运行此命令以批准：</value>
   </data>
   <data name="CopyApprovalButton.Content" xml:space="preserve">
-    <value>å¤åˆ¶</value>
+    <value>复制</value>
   </data>
   <data name="ConnectionPage_TextBlock_243.Text" xml:space="preserve">
     <value>📋 连接日志</value>
   </data>
   <data name="ConnectionLogEmpty.Text" xml:space="preserve">
-    <value>æ²¡æœ‰æœ€è¿‘çš„è¿žæŽ¥äº‹ä»¶ã€‚</value>
+    <value>没有最近的连接事件。</value>
   </data>
   <data name="ConversationsPage_TextBlock_16.Text" xml:space="preserve">
-    <value>å¯¹è¯</value>
+    <value>对话</value>
   </data>
   <data name="ConversationsPage_ComboBoxItem_29.Content" xml:space="preserve">
-    <value>å…¨éƒ¨</value>
+    <value>全部</value>
   </data>
   <data name="ConversationsPage_ComboBoxItem_30.Content" xml:space="preserve">
-    <value>æŒ‰é¢‘é“</value>
+    <value>按频道</value>
   </data>
   <data name="ConversationsPage_ComboBoxItem_31.Content" xml:space="preserve">
-    <value>æŒ‰çŠ¶æ€</value>
+    <value>按状态</value>
   </data>
   <data name="ConversationsPage_TextBlock_37.Text" xml:space="preserve">
-    <value>åˆ·æ–°</value>
+    <value>刷新</value>
   </data>
   <data name="CronPage_TextBlock_10.Text" xml:space="preserve">
     <value>⏱️ Cron 作业</value>
   </data>
   <data name="CronPage_TextBlock_29.Text" xml:space="preserve">
-    <value>è®¡åˆ’ç¨‹åºçŠ¶æ€</value>
+    <value>计划程序状态</value>
   </data>
   <data name="SchedulerStatusText.Text" xml:space="preserve">
-    <value>å·²å¯ç”¨</value>
+    <value>已启用</value>
   </data>
   <data name="StorePathText.Text" xml:space="preserve">
     <value>Store: ~/.openclaw/cron.db</value>
@@ -1831,22 +1831,22 @@
     <value>下次唤醒：—</value>
   </data>
   <data name="CronPage_Button_80.Content" xml:space="preserve">
-    <value>ç«‹å³è¿è¡Œ</value>
+    <value>立即运行</value>
   </data>
   <data name="CronPage_TextBlock_90.Text" xml:space="preserve">
-    <value>ä¸Šæ¬¡è¿è¡Œï¼š</value>
+    <value>上次运行：</value>
   </data>
   <data name="CronPage_TextBlock_104.Text" xml:space="preserve">
-    <value>ä¸‹æ¬¡è¿è¡Œï¼š</value>
+    <value>下次运行：</value>
   </data>
   <data name="CronPage_TextBlock_120.Text" xml:space="preserve">
-    <value>æœªé…ç½® Cron ä½œä¸š</value>
+    <value>未配置 Cron 作业</value>
   </data>
   <data name="DebugPage_TextBlock_8.Text" xml:space="preserve">
     <value>🐛 调试</value>
   </data>
   <data name="DebugPage_TextBlock_14.Text" xml:space="preserve">
-    <value>æ—¥å¿—æŸ¥çœ‹å™¨</value>
+    <value>日志查看器</value>
   </data>
   <data name="DebugPage_Button_18.Content" xml:space="preserve">
     <value>⟳ 刷新</value>
@@ -1855,34 +1855,34 @@
     <value>📋 复制日志</value>
   </data>
   <data name="LogText.Text" xml:space="preserve">
-    <value>æ­£åœ¨åŠ è½½...</value>
+    <value>正在加载...</value>
   </data>
   <data name="DebugPage_TextBlock_38.Text" xml:space="preserve">
-    <value>è¿žæŽ¥çŠ¶æ€</value>
+    <value>连接状态</value>
   </data>
   <data name="DebugPage_TextBlock_52.Text" xml:space="preserve">
-    <value>æ“ä½œå‘˜çŠ¶æ€</value>
+    <value>操作员状态</value>
   </data>
   <data name="DebugPage_TextBlock_56.Text" xml:space="preserve">
-    <value>ç½‘å…³åœ°å€</value>
+    <value>网关地址</value>
   </data>
   <data name="DebugPage_TextBlock_61.Text" xml:space="preserve">
-    <value>èŠ‚ç‚¹æ¨¡å¼</value>
+    <value>节点模式</value>
   </data>
   <data name="DebugPage_TextBlock_72.Text" xml:space="preserve">
-    <value>è®¾å¤‡æ ‡è¯†</value>
+    <value>设备标识</value>
   </data>
   <data name="DebugPage_TextBlock_86.Text" xml:space="preserve">
-    <value>è®¾å¤‡ ID</value>
+    <value>设备 ID</value>
   </data>
   <data name="DebugPage_Button_91.Content" xml:space="preserve">
     <value>📋 复制</value>
   </data>
   <data name="DebugPage_TextBlock_94.Text" xml:space="preserve">
-    <value>å…¬é’¥</value>
+    <value>公钥</value>
   </data>
   <data name="DebugPage_TextBlock_108.Text" xml:space="preserve">
-    <value>è°ƒè¯•æ“ä½œ</value>
+    <value>调试操作</value>
   </data>
   <data name="DebugPage_Button_111.Content" xml:space="preserve">
     <value>📄 打开日志文件</value>
@@ -1897,31 +1897,31 @@
     <value>📋 复制支持上下文</value>
   </data>
   <data name="StatusHeadline.Text" xml:space="preserve">
-    <value>æœªè¿žæŽ¥åˆ°ç½‘å…³</value>
+    <value>未连接到网关</value>
   </data>
   <data name="ScanButton.Content" xml:space="preserve">
-    <value>æ‰«æç½‘å…³</value>
+    <value>扫描网关</value>
   </data>
   <data name="DashboardButton.Content" xml:space="preserve">
-    <value>æ‰“å¼€ä»ªè¡¨æ¿</value>
+    <value>打开仪表板</value>
   </data>
   <data name="ChatButton.Content" xml:space="preserve">
-    <value>æ‰“å¼€èŠå¤©</value>
+    <value>打开聊天</value>
   </data>
   <data name="HealthCheckButton.Content" xml:space="preserve">
-    <value>å¥åº·æ£€æŸ¥</value>
+    <value>健康检查</value>
   </data>
   <data name="RefreshButton.Content" xml:space="preserve">
     <value>⟳ 刷新</value>
   </data>
   <data name="NodesPage_Action_Rename" xml:space="preserve">
-    <value>é‡å‘½å</value>
+    <value>重命名</value>
   </data>
   <data name="NodesPage_Action_Forget" xml:space="preserve">
-    <value>å¿˜è®°</value>
+    <value>忘记</value>
   </data>
   <data name="NodesPage_Action_MoreOptions" xml:space="preserve">
-    <value>æ›´å¤šé€‰é¡¹</value>
+    <value>更多选项</value>
   </data>
   <data name="NodesPage_Label_Version" xml:space="preserve">
     <value>Version</value>
@@ -1930,154 +1930,154 @@
     <value>Hardware</value>
   </data>
   <data name="NodesPage_Label_Network" xml:space="preserve">
-    <value>ç½‘ç»œ</value>
+    <value>网络</value>
   </data>
   <data name="NodesPage_Label_Approved" xml:space="preserve">
-    <value>å·²æ‰¹å‡†</value>
+    <value>已批准</value>
   </data>
   <data name="NodesPage_Label_Connected" xml:space="preserve">
-    <value>å·²è¿žæŽ¥</value>
+    <value>已连接</value>
   </data>
   <data name="NodesPage_Label_LastSeen" xml:space="preserve">
-    <value>ä¸Šæ¬¡è§åˆ°</value>
+    <value>上次见到</value>
   </data>
   <data name="NodesPage_Label_Capabilities" xml:space="preserve">
-    <value>åŠŸèƒ½</value>
+    <value>功能</value>
   </data>
   <data name="NodesPage_Label_Permissions" xml:space="preserve">
-    <value>æƒé™</value>
+    <value>权限</value>
   </data>
   <data name="NodesPage_Label_PathEnv" xml:space="preserve">
     <value>PATH</value>
   </data>
   <data name="NodesPage_Commands_Header" xml:space="preserve">
-    <value>å‘½ä»¤ ({0})</value>
+    <value>命令 ({0})</value>
   </data>
   <data name="NodesPage_Command_DisabledSuffix" xml:space="preserve">
-    <value>ï¼ˆå·²ç¦ç”¨ï¼‰</value>
+    <value>（已禁用）</value>
   </data>
   <data name="NodesPage_Rename_Title" xml:space="preserve">
-    <value>é‡å‘½åèŠ‚ç‚¹</value>
+    <value>重命名节点</value>
   </data>
   <data name="NodesPage_Rename_Body" xml:space="preserve">
-    <value>ä¸º {0} é€‰æ‹©æ–°çš„æ˜¾ç¤ºåç§°ã€‚</value>
+    <value>为 {0} 选择新的显示名称。</value>
   </data>
   <data name="NodesPage_Rename_Placeholder" xml:space="preserve">
-    <value>æ˜¾ç¤ºåç§°</value>
+    <value>显示名称</value>
   </data>
   <data name="NodesPage_Rename_Primary" xml:space="preserve">
-    <value>é‡å‘½å</value>
+    <value>重命名</value>
   </data>
   <data name="NodesPage_Rename_Error_Empty" xml:space="preserve">
-    <value>æ˜¾ç¤ºåç§°ä¸èƒ½ä¸ºç©ºã€‚</value>
+    <value>显示名称不能为空。</value>
   </data>
   <data name="NodesPage_Rename_Error_Generic" xml:space="preserve">
-    <value>é‡å‘½åå¤±è´¥ã€‚</value>
+    <value>重命名失败。</value>
   </data>
   <data name="NodesPage_Forget_Title" xml:space="preserve">
-    <value>å¿˜è®°èŠ‚ç‚¹ï¼Ÿ</value>
+    <value>忘记节点？</value>
   </data>
   <data name="NodesPage_Forget_Body" xml:space="preserve">
-    <value>è¿™å°†ä»Žç½‘å…³ä¸­åˆ é™¤ä¸‹é¢èŠ‚ç‚¹çš„è®°å½•ã€‚èŠ‚ç‚¹éœ€è¦é‡æ–°é…å¯¹æ‰èƒ½å†æ¬¡è¿žæŽ¥ã€‚</value>
+    <value>这将从网关中删除下面节点的记录。节点需要重新配对才能再次连接。</value>
   </data>
   <data name="NodesPage_Forget_Warning" xml:space="preserve">
-    <value>é’ˆå¯¹è¯¥èŠ‚ç‚¹çš„æ´»åŠ¨æ“ä½œå‘˜å’ŒèŠå¤©ä¼šè¯å°†ç«‹å³å¤±åŽ»è®¿é—®æƒé™ã€‚</value>
+    <value>针对该节点的活动操作员和聊天会话将立即失去访问权限。</value>
   </data>
   <data name="NodesPage_Forget_Primary" xml:space="preserve">
-    <value>å¿˜è®°èŠ‚ç‚¹</value>
+    <value>忘记节点</value>
   </data>
   <data name="NodesPage_Forget_Error_Generic" xml:space="preserve">
     <value>无法忘记节点 — 网关不可达或权限被拒绝。</value>
   </data>
   <data name="NodesPage_Common_Cancel" xml:space="preserve">
-    <value>å–æ¶ˆ</value>
+    <value>取消</value>
   </data>
   <data name="PermissionsPage_TextBlock_8.Text" xml:space="preserve">
     <value>🔐 权限</value>
   </data>
   <data name="PermissionsPage_TextBlock_14.Text" xml:space="preserve">
-    <value>æ‰§è¡Œç­–ç•¥</value>
+    <value>执行策略</value>
   </data>
   <data name="PermissionsPage_TextBlock_17.Text" xml:space="preserve">
-    <value>æŽ§åˆ¶ä»£ç†å¯åœ¨æ­¤èŠ‚ç‚¹ä¸Šæ‰§è¡Œå“ªäº›å‘½ä»¤ã€‚è§„åˆ™ä¼šåŒ¹é…å®Œæ•´å‘½ä»¤è¡Œã€‚</value>
+    <value>控制代理可在此节点上执行哪些命令。规则会匹配完整命令行。</value>
   </data>
   <data name="DefaultActionCombo.Header" xml:space="preserve">
-    <value>é»˜è®¤æ“ä½œ</value>
+    <value>默认操作</value>
   </data>
   <data name="PermissionsPage_ComboBoxItem_23.Content" xml:space="preserve">
-    <value>æ‹’ç»</value>
+    <value>拒绝</value>
   </data>
   <data name="PermissionsPage_ComboBoxItem_24.Content" xml:space="preserve">
-    <value>å…è®¸</value>
+    <value>允许</value>
   </data>
   <data name="PermissionsPage_ComboBoxItem_25.Content" xml:space="preserve">
-    <value>è¯¢é—®</value>
+    <value>询问</value>
   </data>
   <data name="PermissionsPage_TextBlock_28.Text" xml:space="preserve">
-    <value>è§„åˆ™</value>
+    <value>规则</value>
   </data>
   <data name="NewRulePattern.PlaceholderText" xml:space="preserve">
-    <value>å‘½ä»¤æ¨¡å¼ï¼ˆä¾‹å¦‚ echo *ï¼‰</value>
+    <value>命令模式（例如 echo *）</value>
   </data>
   <data name="PermissionsPage_ComboBoxItem_54.Content" xml:space="preserve">
-    <value>å…è®¸</value>
+    <value>允许</value>
   </data>
   <data name="PermissionsPage_ComboBoxItem_55.Content" xml:space="preserve">
-    <value>æ‹’ç»</value>
+    <value>拒绝</value>
   </data>
   <data name="PermissionsPage_Button_57.Content" xml:space="preserve">
-    <value>æ·»åŠ è§„åˆ™</value>
+    <value>添加规则</value>
   </data>
   <data name="PermissionsPage_TextBlock_69.Text" xml:space="preserve">
-    <value>èŠ‚ç‚¹å…è®¸åˆ—è¡¨</value>
+    <value>节点允许列表</value>
   </data>
   <data name="PermissionsPage_TextBlock_72.Text" xml:space="preserve">
     <value>网关允许连接节点执行的命令。此列表为只读 — 请通过“配置”页面编辑。</value>
   </data>
   <data name="AllowlistEmpty.Text" xml:space="preserve">
-    <value>æ²¡æœ‰å¯ç”¨çš„å…è®¸åˆ—è¡¨æ•°æ®ã€‚è¯·å…ˆè¿žæŽ¥åˆ°ç½‘å…³ã€‚</value>
+    <value>没有可用的允许列表数据。请先连接到网关。</value>
   </data>
   <data name="PermissionsPage_TextBlock_92.Text" xml:space="preserve">
-    <value>ç³»ç»Ÿæƒé™</value>
+    <value>系统权限</value>
   </data>
   <data name="PermissionsPage_TextBlock_95.Text" xml:space="preserve">
-    <value>æ‘„åƒå¤´ã€éº¦å…‹é£Žå’Œå±å¹•æ•èŽ·çš„ç³»ç»Ÿæƒé™ã€‚è¿™äº›ç”± Windows éšç§è®¾ç½®ç®¡ç†ã€‚</value>
+    <value>摄像头、麦克风和屏幕捕获的系统权限。这些由 Windows 隐私设置管理。</value>
   </data>
   <data name="PermissionsPage_TextBlock_110.Text" xml:space="preserve">
     <value>📷 摄像头</value>
   </data>
   <data name="CameraPermStatus.Text" xml:space="preserve">
-    <value>æœªçŸ¥</value>
+    <value>未知</value>
   </data>
   <data name="PermissionsPage_TextBlock_114.Text" xml:space="preserve">
     <value>🎤 麦克风</value>
   </data>
   <data name="MicPermStatus.Text" xml:space="preserve">
-    <value>æœªçŸ¥</value>
+    <value>未知</value>
   </data>
   <data name="PermissionsPage_TextBlock_118.Text" xml:space="preserve">
     <value>🖥️ 屏幕捕获</value>
   </data>
   <data name="ScreenPermStatus.Text" xml:space="preserve">
-    <value>å¯ç”¨</value>
+    <value>可用</value>
   </data>
   <data name="PermissionsPage_Button_123.Content" xml:space="preserve">
-    <value>æ‰“å¼€ Windows éšç§è®¾ç½®</value>
+    <value>打开 Windows 隐私设置</value>
   </data>
   <data name="SessionsPage_TextBlock_10.Text" xml:space="preserve">
     <value>💬 会话</value>
   </data>
   <data name="SessionsPage_Button_57.Content" xml:space="preserve">
-    <value>é‡ç½®</value>
+    <value>重置</value>
   </data>
   <data name="SessionsPage_Button_59.Content" xml:space="preserve">
-    <value>åŽ‹ç¼©</value>
+    <value>压缩</value>
   </data>
   <data name="SessionsPage_Button_61.Content" xml:space="preserve">
-    <value>åˆ é™¤</value>
+    <value>删除</value>
   </data>
   <data name="SessionsPage_TextBlock_73.Text" xml:space="preserve">
-    <value>æ— æ´»è·ƒä¼šè¯</value>
+    <value>无活跃会话</value>
   </data>
   <data name="SessionsPage_TextBlock_84.Text" xml:space="preserve">
     <value>🤖 可用模型</value>
@@ -2086,109 +2086,109 @@
     <value>⚙️ 设置</value>
   </data>
   <data name="SettingsPage_TextBlock_17.Text" xml:space="preserve">
-    <value>æ­¤è®¡ç®—æœºçš„æœ¬åœ°åº”ç”¨é¦–é€‰é¡¹ã€‚</value>
+    <value>此计算机的本地应用首选项。</value>
   </data>
   <data name="SettingsPage_TextBlock_26.Text" xml:space="preserve">
-    <value>å¯åŠ¨</value>
+    <value>启动</value>
   </data>
   <data name="AutoStartToggle.Header" xml:space="preserve">
-    <value>éš Windows è‡ªåŠ¨å¯åŠ¨</value>
+    <value>随 Windows 自动启动</value>
   </data>
   <data name="GlobalHotkeyToggle.Header" xml:space="preserve">
     <value>全局热键（Ctrl+Alt+Shift+C → 快速发送）</value>
   </data>
   <data name="SettingsPage_TextBlock_41.Text" xml:space="preserve">
-    <value>é€šçŸ¥</value>
+    <value>通知</value>
   </data>
   <data name="NotificationsToggle.Header" xml:space="preserve">
-    <value>æ˜¾ç¤ºé€šçŸ¥</value>
+    <value>显示通知</value>
   </data>
   <data name="NotificationSoundComboBox.Header" xml:space="preserve">
-    <value>æç¤ºéŸ³</value>
+    <value>提示音</value>
   </data>
   <data name="SettingsPage_ComboBoxItem_48.Content" xml:space="preserve">
-    <value>é»˜è®¤</value>
+    <value>默认</value>
   </data>
   <data name="SettingsPage_ComboBoxItem_49.Content" xml:space="preserve">
-    <value>æ— </value>
+    <value>无</value>
   </data>
   <data name="SettingsPage_ComboBoxItem_50.Content" xml:space="preserve">
-    <value>æŸ”å’Œ</value>
+    <value>柔和</value>
   </data>
   <data name="SettingsPage_TextBlock_52.Text" xml:space="preserve">
-    <value>æ˜¾ç¤ºä»¥ä¸‹ç±»åž‹é€šçŸ¥:</value>
+    <value>显示以下类型通知:</value>
   </data>
   <data name="NotifyHealthCb.Content" xml:space="preserve">
-    <value>å¥åº·è­¦æŠ¥</value>
+    <value>健康警报</value>
   </data>
   <data name="NotifyUrgentCb.Content" xml:space="preserve">
-    <value>ç´§æ€¥æ¶ˆæ¯</value>
+    <value>紧急消息</value>
   </data>
   <data name="NotifyReminderCb.Content" xml:space="preserve">
-    <value>æé†’</value>
+    <value>提醒</value>
   </data>
   <data name="NotifyEmailCb.Content" xml:space="preserve">
-    <value>é‚®ä»¶æ‘˜è¦</value>
+    <value>邮件摘要</value>
   </data>
   <data name="NotifyCalendarCb.Content" xml:space="preserve">
-    <value>æ—¥åŽ†äº‹ä»¶</value>
+    <value>日历事件</value>
   </data>
   <data name="NotifyBuildCb.Content" xml:space="preserve">
-    <value>æž„å»ºé€šçŸ¥</value>
+    <value>构建通知</value>
   </data>
   <data name="NotifyStockCb.Content" xml:space="preserve">
-    <value>è‚¡ç¥¨æé†’</value>
+    <value>股票提醒</value>
   </data>
   <data name="NotifyInfoCb.Content" xml:space="preserve">
-    <value>å¸¸è§„ä¿¡æ¯</value>
+    <value>常规信息</value>
   </data>
   <data name="TestNotificationButton.Content" xml:space="preserve">
-    <value>å‘é€æµ‹è¯•é€šçŸ¥</value>
+    <value>发送测试通知</value>
   </data>
   <data name="CancelButton.Content" xml:space="preserve">
-    <value>å–æ¶ˆ</value>
+    <value>取消</value>
   </data>
   <data name="SkillsPage_TextBlock_10.Text" xml:space="preserve">
     <value>🧩 技能</value>
   </data>
   <data name="SkillsPage_ComboBoxItem_15.Content" xml:space="preserve">
-    <value>æ‰€æœ‰ä»£ç†</value>
+    <value>所有代理</value>
   </data>
   <data name="SkillsPage_TextBlock_81.Text" xml:space="preserve">
-    <value>æœªå®‰è£…æŠ€èƒ½</value>
+    <value>未安装技能</value>
   </data>
   <data name="MarketplaceLink.Content" xml:space="preserve">
     <value>浏览技能市场 →</value>
   </data>
   <data name="UsagePage_TextBlock_21.Text" xml:space="preserve">
-    <value>æ€»æˆæœ¬</value>
+    <value>总成本</value>
   </data>
   <data name="UsagePage_TextBlock_35.Text" xml:space="preserve">
-    <value>è¯·æ±‚</value>
+    <value>请求</value>
   </data>
   <data name="UsagePage_TextBlock_45.Text" xml:space="preserve">
-    <value>ä»¤ç‰Œ</value>
+    <value>令牌</value>
   </data>
   <data name="UsagePage_TextBlock_55.Text" xml:space="preserve">
-    <value>æä¾›ç¨‹åº</value>
+    <value>提供程序</value>
   </data>
   <data name="Period7DaysItem.Text" xml:space="preserve">
-    <value>7 å¤©</value>
+    <value>7 天</value>
   </data>
   <data name="Period30DaysItem.Text" xml:space="preserve">
-    <value>30 å¤©</value>
+    <value>30 天</value>
   </data>
   <data name="UsagePage_ProviderLoading.Text" xml:space="preserve">
     <value>正在加载提供程序…</value>
   </data>
   <data name="UsagePage_NoProviders.Text" xml:space="preserve">
-    <value>æœªé…ç½®ä»»ä½•æä¾›ç¨‹åº</value>
+    <value>未配置任何提供程序</value>
   </data>
   <data name="UsagePage_TextBlock_70.Text" xml:space="preserve">
-    <value>æä¾›ç¨‹åºæ˜Žç»†</value>
+    <value>提供程序明细</value>
   </data>
   <data name="UsagePage_TextBlock_100.Text" xml:space="preserve">
-    <value>æ¯æ—¥æˆæœ¬</value>
+    <value>每日成本</value>
   </data>
   <data name="WorkspacePage_TextBlock_22.Text" xml:space="preserve">
     <value>工作区</value>
@@ -2218,13 +2218,13 @@
     <value>(磁盘上找不到文件)</value>
   </data>
   <data name="WorkspacePage_TextBlock_34.Text" xml:space="preserve">
-    <value>åˆ·æ–°</value>
+    <value>刷新</value>
   </data>
   <data name="ChatWindow_TextBlock_29.Text" xml:space="preserve">
-    <value>èŠå¤©</value>
+    <value>聊天</value>
   </data>
   <data name="ChatWindow_TextBlock_60.Text" xml:space="preserve">
-    <value>è¿žæŽ¥åˆ°ç½‘å…³ä»¥å¼€å§‹èŠå¤©</value>
+    <value>连接到网关以开始聊天</value>
   </data>
   <data name="TitleText.Text" xml:space="preserve">
     <value>OpenClaw Windows Companion</value>
@@ -2236,178 +2236,178 @@
     <value>切换导航窗格</value>
   </data>
   <data name="TitleStatusText.Text" xml:space="preserve">
-    <value>å·²æ–­å¼€è¿žæŽ¥</value>
+    <value>已断开连接</value>
   </data>
   <data name="HubWindow_NavigationViewItem_79.Content" xml:space="preserve">
-    <value>ä¸»é¡µ</value>
+    <value>主页</value>
   </data>
   <data name="HubWindow_NavigationViewItem_82.Content" xml:space="preserve">
-    <value>èŠå¤©</value>
+    <value>聊天</value>
   </data>
   <data name="HubWindow_NavigationViewItemHeader_87.Content" xml:space="preserve">
-    <value>ç½‘å…³</value>
+    <value>网关</value>
   </data>
   <data name="HubWindow_NavigationViewItem_88.Content" xml:space="preserve">
-    <value>è¿žæŽ¥</value>
+    <value>连接</value>
   </data>
   <data name="HubWindow_NavigationViewItem_91.Content" xml:space="preserve">
-    <value>ä¼šè¯</value>
+    <value>会话</value>
   </data>
   <data name="ConversationsNavItem.Content" xml:space="preserve">
-    <value>å¯¹è¯</value>
+    <value>对话</value>
   </data>
   <data name="HubWindow_NavigationViewItem_94.Content" xml:space="preserve">
-    <value>ä»£ç†äº‹ä»¶</value>
+    <value>代理事件</value>
   </data>
   <data name="HubWindow_NavigationViewItem_97.Content" xml:space="preserve">
-    <value>æŠ€èƒ½</value>
+    <value>技能</value>
   </data>
   <data name="AgentsNavItem.Content" xml:space="preserve">
-    <value>ä»£ç†</value>
+    <value>代理</value>
   </data>
   <data name="DefaultAgentNavItem.Content" xml:space="preserve">
     <value>main</value>
   </data>
   <data name="HubWindow_NavigationViewItem_109.Content" xml:space="preserve">
-    <value>é¢‘é“</value>
+    <value>频道</value>
   </data>
   <data name="HubWindow_NavigationViewItem_112.Content" xml:space="preserve">
-    <value>å®žä¾‹</value>
+    <value>实例</value>
   </data>
   <data name="HubWindow_NavigationViewItem_115.Content" xml:space="preserve">
-    <value>ç»‘å®š</value>
+    <value>绑定</value>
   </data>
   <data name="HubWindow_NavigationViewItem_118.Content" xml:space="preserve">
-    <value>é…ç½®</value>
+    <value>配置</value>
   </data>
   <data name="HubWindow_NavigationViewItem_121.Content" xml:space="preserve">
-    <value>ç”¨é‡</value>
+    <value>用量</value>
   </data>
   <data name="HubWindow_NavigationViewItem_124.Content" xml:space="preserve">
     <value>Cron</value>
   </data>
   <data name="HubWindow_NavigationViewItemHeader_129.Content" xml:space="preserve">
-    <value>æ­¤è®¡ç®—æœº</value>
+    <value>此计算机</value>
   </data>
   <data name="HubWindow_NavigationViewItem_130.Content" xml:space="preserve">
-    <value>åŠŸèƒ½</value>
+    <value>功能</value>
   </data>
   <data name="HubWindow_NavigationViewItem_133.Content" xml:space="preserve">
-    <value>è®¾ç½®</value>
+    <value>设置</value>
   </data>
   <data name="HubWindow_NavigationViewItem_136.Content" xml:space="preserve">
-    <value>æƒé™</value>
+    <value>权限</value>
   </data>
   <data name="HubWindow_NavigationViewItem_145.Content" xml:space="preserve">
-    <value>è°ƒè¯•</value>
+    <value>调试</value>
   </data>
   <data name="HubWindow_NavigationViewItem_148.Content" xml:space="preserve">
-    <value>ä¿¡æ¯</value>
+    <value>信息</value>
   </data>
   <data name="Onboarding_UnknownPage" xml:space="preserve">
-    <value>æœªçŸ¥é¡µé¢</value>
+    <value>未知页面</value>
   </data>
   <data name="Onboarding_Retry" xml:space="preserve">
-    <value>é‡è¯•</value>
+    <value>重试</value>
   </data>
   <data name="Onboarding_Ready_NodeModeActive" xml:space="preserve">
     <value>🔌 节点模式已启用</value>
   </data>
   <data name="Onboarding_Ready_NodeModeActiveDetail" xml:space="preserve">
-    <value>æ­¤ç”µè„‘å°†ä½œä¸ºè¿œç¨‹è®¡ç®—èŠ‚ç‚¹è¿è¡Œã€‚ç½‘å…³å¯ä»¥åœ¨æ­¤è®¡ç®—æœºä¸Šè°ƒç”¨å±å¹•æ•èŽ·ã€æ‘„åƒå¤´å’Œç³»ç»Ÿå‘½ä»¤ã€‚</value>
+    <value>此电脑将作为远程计算节点运行。网关可以在此计算机上调用屏幕捕获、摄像头和系统命令。</value>
   </data>
   <data name="Onboarding_Ready_Node_ScreenCapture" xml:space="preserve">
-    <value>å±å¹•æ•èŽ·</value>
+    <value>屏幕捕获</value>
   </data>
   <data name="Onboarding_Ready_Node_ScreenCapture_Sub" xml:space="preserve">
-    <value>è¿œç¨‹å±å¹•è®¿é—®</value>
+    <value>远程屏幕访问</value>
   </data>
   <data name="Onboarding_Ready_Node_Camera" xml:space="preserve">
-    <value>æ‘„åƒå¤´</value>
+    <value>摄像头</value>
   </data>
   <data name="Onboarding_Ready_Node_Camera_Sub" xml:space="preserve">
-    <value>è¿œç¨‹æ‘„åƒå¤´è®¿é—®</value>
+    <value>远程摄像头访问</value>
   </data>
   <data name="Onboarding_Ready_Node_SystemCmd" xml:space="preserve">
-    <value>ç³»ç»Ÿå‘½ä»¤</value>
+    <value>系统命令</value>
   </data>
   <data name="Onboarding_Ready_Node_SystemCmd_Sub" xml:space="preserve">
-    <value>è¿œç¨‹å‘½ä»¤æ‰§è¡Œ</value>
+    <value>远程命令执行</value>
   </data>
   <data name="Onboarding_Ready_Node_Canvas" xml:space="preserve">
-    <value>Canvas æ¸²æŸ“</value>
+    <value>Canvas 渲染</value>
   </data>
   <data name="Onboarding_Ready_Node_Canvas_Sub" xml:space="preserve">
-    <value>å¯è§†å·¥ä½œåŒºè¾“å‡º</value>
+    <value>可视工作区输出</value>
   </data>
   <data name="Onboarding_Ready_Node_Notify" xml:space="preserve">
-    <value>é€šçŸ¥</value>
+    <value>通知</value>
   </data>
   <data name="Onboarding_Ready_Node_Notify_Sub" xml:space="preserve">
-    <value>ç³»ç»Ÿé€šçŸ¥</value>
+    <value>系统通知</value>
   </data>
   <data name="Onboarding_Wizard_Processing" xml:space="preserve">
     <value>⏳ 正在处理…</value>
   </data>
   <data name="Onboarding_Wizard_ErrorEmptyGatewayResponse" xml:space="preserve">
-    <value>ç½‘å…³è¿”å›žç©ºå“åº”</value>
+    <value>网关返回空响应</value>
   </data>
   <data name="Onboarding_Wizard_ErrorGatewayDisconnected" xml:space="preserve">
-    <value>ç½‘å…³å·²æ–­å¼€è¿žæŽ¥</value>
+    <value>网关已断开连接</value>
   </data>
   <data name="Onboarding_Wizard_ErrorGatewayDisconnectedDetail" xml:space="preserve">
     <value>与网关的连接已丢失。单击“下一步”跳过向导，或等待重新连接。</value>
   </data>
   <data name="Onboarding_Wizard_ErrorEmptyNextResponse" xml:space="preserve">
-    <value>ç½‘å…³å¯¹ wizard.next è¿”å›žäº†ç©ºå“åº”</value>
+    <value>网关对 wizard.next 返回了空响应</value>
   </data>
   <data name="Onboarding_Wizard_NoOptionsAvailable" xml:space="preserve">
-    <value>æ²¡æœ‰å¯ç”¨é€‰é¡¹</value>
+    <value>没有可用选项</value>
   </data>
   <data name="Onboarding_Wizard_Yes" xml:space="preserve">
-    <value>æ˜¯</value>
+    <value>是</value>
   </data>
   <data name="Onboarding_Wizard_NoSkip" xml:space="preserve">
-    <value>å¦ / è·³è¿‡</value>
+    <value>否 / 跳过</value>
   </data>
   <data name="Onboarding_Wizard_Waiting" xml:space="preserve">
-    <value>æ­£åœ¨ç­‰å¾…...</value>
+    <value>正在等待...</value>
   </data>
   <data name="Onboarding_Wizard_ClickNextToContinue" xml:space="preserve">
     <value>单击“下一步”继续。</value>
   </data>
   <data name="Onboarding_Wizard_ErrorTitle" xml:space="preserve">
-    <value>å‘å¯¼é”™è¯¯</value>
+    <value>向导错误</value>
   </data>
   <data name="Onboarding_Wizard_SkipWizard" xml:space="preserve">
-    <value>è·³è¿‡å‘å¯¼</value>
+    <value>跳过向导</value>
   </data>
   <data name="Onboarding_Wizard_ConnectingToGateway" xml:space="preserve">
-    <value>æ­£åœ¨è¿žæŽ¥åˆ°ç½‘å…³...</value>
+    <value>正在连接到网关...</value>
   </data>
   <data name="Onboarding_Wizard_ConnectionWaitDetail" xml:space="preserve">
-    <value>è¯·ç­‰å¾…è¿žæŽ¥å»ºç«‹...</value>
+    <value>请等待连接建立...</value>
   </data>
   <data name="PriorityInfoBar.Title" xml:space="preserve">
-    <value>è·¯ç”±ä¼˜å…ˆçº§</value>
+    <value>路由优先级</value>
   </data>
   <data name="PriorityInfoBar.Message" xml:space="preserve">
-    <value>ç»‘å®šæŽ§åˆ¶å“ªä¸ªä»£ç†å¤„ç†æ¯ä¸ªé¢‘é“çš„æ¶ˆæ¯ã€‚ä¼˜å…ˆçº§ï¼šå¯¹ç­‰ &gt; å¸æˆ· &gt; é¢‘é“ &gt; é»˜è®¤ã€‚</value>
+    <value>绑定控制哪个代理处理每个频道的消息。优先级：对等 &gt; 帐户 &gt; 频道 &gt; 默认。</value>
   </data>
   <data name="SingleAgentInfoBar.Title" xml:space="preserve">
-    <value>å•ä»£ç†æ¨¡å¼</value>
+    <value>单代理模式</value>
   </data>
   <data name="SingleAgentInfoBar.Message" xml:space="preserve">
-    <value>æ‰€æœ‰æ¶ˆæ¯éƒ½ä¼šè·¯ç”±åˆ°é»˜è®¤ä»£ç†ã€‚æ·»åŠ ç»‘å®šä»¥è¿›è¡Œå¤šä»£ç†è·¯ç”±ã€‚</value>
+    <value>所有消息都会路由到默认代理。添加绑定以进行多代理路由。</value>
   </data>
   <data name="ConfigSubtitle.Text" xml:space="preserve">
     <value>使用架构引导的表单编辑网关配置 (openclaw.json)。</value>
   </data>
   <data name="DetailPlaceholder.Text" xml:space="preserve">
-    <value>ä»Žæ ‘ä¸­é€‰æ‹©ä¸€ä¸ªéƒ¨åˆ†ä»¥ç¼–è¾‘å…¶è®¾ç½®ã€‚</value>
+    <value>从树中选择一个部分以编辑其设置。</value>
   </data>
   <data name="TokenPromptBox.PlaceholderText" xml:space="preserve">
-    <value>ç½‘å…³ä»¤ç‰Œ</value>
+    <value>网关令牌</value>
   </data>
   <data name="TokenPromptBox.Header" xml:space="preserve">
     <value>Token</value>
@@ -2416,25 +2416,25 @@
     <value>在此处粘贴设置代码…</value>
   </data>
   <data name="ConnectionWarning.Message" xml:space="preserve">
-    <value>è¿žæŽ¥åˆ°ç½‘å…³ä»¥æŸ¥çœ‹å¯¹è¯ã€‚</value>
+    <value>连接到网关以查看对话。</value>
   </data>
   <data name="EmptyState.Text" xml:space="preserve">
-    <value>æœªæ‰¾åˆ°ä¼šè¯</value>
+    <value>未找到会话</value>
   </data>
   <data name="NotWiredInfoBar.Title" xml:space="preserve">
-    <value>Cron API å°šæœªæŽ¥å…¥</value>
+    <value>Cron API 尚未接入</value>
   </data>
   <data name="NotWiredInfoBar.Message" xml:space="preserve">
-    <value>æ­£åœ¨æ˜¾ç¤ºç¤ºä¾‹æ•°æ®ã€‚OpenClawGatewayClient ä¸­å°šä¸æä¾› Cron ç®¡ç†æ–¹æ³•ã€‚</value>
+    <value>正在显示示例数据。OpenClawGatewayClient 中尚不提供 Cron 管理方法。</value>
   </data>
   <data name="FallbackInfoBar.Title" xml:space="preserve">
-    <value>å·¥ä½œåŒºæ–‡ä»¶</value>
+    <value>工作区文件</value>
   </data>
   <data name="ChatWindow_winexWindowEx_2.Title" xml:space="preserve">
     <value>OpenClaw Chat</value>
   </data>
   <data name="SearchBox.PlaceholderText" xml:space="preserve">
-    <value>é”®å…¥å‘½ä»¤...</value>
+    <value>键入命令...</value>
   </data>
   <data name="HubWindow_winexWindowEx_2.Title" xml:space="preserve">
     <value>OpenClaw</value>
@@ -2449,10 +2449,10 @@
     <value>OpenClaw Canvas</value>
   </data>
   <data name="CanvasWindowReloadToolTip.Content" xml:space="preserve">
-    <value>é‡æ–°åŠ è½½</value>
+    <value>重新加载</value>
   </data>
   <data name="CanvasReloadButton_AutomationName" xml:space="preserve">
-    <value>é‡æ–°åŠ è½½ Canvas</value>
+    <value>重新加载 Canvas</value>
   </data>
   <data name="TrayMenuWindow_winexWindowEx_2.Title" xml:space="preserve">
     <value>OpenClaw Menu</value>
@@ -2461,67 +2461,67 @@
     <value>使用量和成本</value>
   </data>
   <data name="ChatWindowOpenInBrowserToolTip.Content" xml:space="preserve">
-    <value>åœ¨æµè§ˆå™¨ä¸­æ‰“å¼€</value>
+    <value>在浏览器中打开</value>
   </data>
   <data name="ChatWindowCloseToolTip.Content" xml:space="preserve">
-    <value>å…³é—­</value>
+    <value>关闭</value>
   </data>
   <data name="ChatPageOpenInBrowserToolTip.Content" xml:space="preserve">
-    <value>åœ¨æµè§ˆå™¨ä¸­æ‰“å¼€</value>
+    <value>在浏览器中打开</value>
   </data>
   <data name="CronPageRemoveJobToolTip.Content" xml:space="preserve">
-    <value>åˆ é™¤ä»»åŠ¡</value>
+    <value>删除任务</value>
   </data>
   <data name="PermissionsPage_SttMoreSettingsLink.Content" xml:space="preserve">
     <value>更多语音设置…</value>
   </data>
   <data name="PermissionsPage_TtsElevenLabsApiKey.Header" xml:space="preserve">
-    <value>ElevenLabs API å¯†é’¥</value>
+    <value>ElevenLabs API 密钥</value>
   </data>
   <data name="PermissionsPage_TtsElevenLabsHelp.Text" xml:space="preserve">
-    <value>API å¯†é’¥ä½¿ç”¨ Windows DPAPI åŠ å¯†ä¿å­˜ã€‚ä¿®æ”¹å…¶ä»–å­—æ®µæ—¶å¦‚ä¿æŒä¸ºç©ºï¼Œåˆ™ä¿ç•™å…ˆå‰ä¿å­˜çš„å€¼ã€‚</value>
+    <value>API 密钥使用 Windows DPAPI 加密保存。修改其他字段时如保持为空，则保留先前保存的值。</value>
   </data>
   <data name="PermissionsPage_TtsElevenLabsModel.Header" xml:space="preserve">
-    <value>ElevenLabs æ¨¡åž‹</value>
+    <value>ElevenLabs 模型</value>
   </data>
   <data name="PermissionsPage_TtsElevenLabsModel.PlaceholderText" xml:space="preserve">
     <value>eleven_multilingual_v2</value>
   </data>
   <data name="PermissionsPage_TtsElevenLabsVoiceId.Header" xml:space="preserve">
-    <value>ElevenLabs è¯­éŸ³ ID</value>
+    <value>ElevenLabs 语音 ID</value>
   </data>
   <data name="PermissionsPage_TtsProviderComboBox.Header" xml:space="preserve">
-    <value>æä¾›ç¨‹åº</value>
+    <value>提供程序</value>
   </data>
   <data name="PermissionsPage_TtsProviderElevenLabs.Content" xml:space="preserve">
     <value>ElevenLabs</value>
   </data>
   <data name="PermissionsPage_TtsProviderPiper.Content" xml:space="preserve">
-    <value>Piperï¼ˆæœ¬åœ° MLï¼ŒæŽ¨èï¼‰</value>
+    <value>Piper（本地 ML，推荐）</value>
   </data>
   <data name="PermissionsPage_TtsProviderWindows.Content" xml:space="preserve">
-    <value>Windows å†…ç½®è¯­éŸ³</value>
+    <value>Windows 内置语音</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
     <value>语音和音频</value>
   </data>
   <data name="VoiceSettingsPage_PageDescription.Text" xml:space="preserve">
-    <value>é…ç½®è¯­éŸ³è½¬æ–‡å­—å’Œè¯­éŸ³äº¤äº’è®¾ç½®ã€‚æ‰€æœ‰è¯­éŸ³å¤„ç†å‡åœ¨æœ¬æœºæœ¬åœ°è¿è¡Œã€‚</value>
+    <value>配置语音转文字和语音交互设置。所有语音处理均在本机本地运行。</value>
   </data>
   <data name="VoiceSettingsPage_SttHeader.Text" xml:space="preserve">
-    <value>è¯­éŸ³è½¬æ–‡å­—</value>
+    <value>语音转文字</value>
   </data>
   <data name="VoiceSettingsPage_SttDescription.Text" xml:space="preserve">
-    <value>é€šè¿‡éº¦å…‹é£Žå¯ç”¨è¯­éŸ³è¾“å…¥ã€‚éœ€è¦ä¸‹è½½ Whisper æ¨¡åž‹ã€‚</value>
+    <value>通过麦克风启用语音输入。需要下载 Whisper 模型。</value>
   </data>
   <data name="VoiceSettingsPage_SttEnabledToggle.Header" xml:space="preserve">
-    <value>å¯ç”¨è¯­éŸ³è¾“å…¥</value>
+    <value>启用语音输入</value>
   </data>
   <data name="VoiceSettingsPage_ModelHeader.Text" xml:space="preserve">
-    <value>è¯­éŸ³æ¨¡åž‹</value>
+    <value>语音模型</value>
   </data>
   <data name="VoiceSettingsPage_ModelCombo.Header" xml:space="preserve">
-    <value>æ¨¡åž‹å¤§å°</value>
+    <value>模型大小</value>
   </data>
   <data name="VoiceSettingsPage_ModelTiny.Content" xml:space="preserve">
     <value>Tiny (~75 MB) — 快速,基础精度</value>
@@ -2533,79 +2533,79 @@
     <value>Small (~466 MB) — 高精度</value>
   </data>
   <data name="VoiceSettingsPage_DownloadButtonText.Text" xml:space="preserve">
-    <value>ä¸‹è½½æ¨¡åž‹</value>
+    <value>下载模型</value>
   </data>
   <data name="VoiceSettingsPage_LanguageHeader.Text" xml:space="preserve">
-    <value>è¯­è¨€</value>
+    <value>语言</value>
   </data>
   <data name="VoiceSettingsPage_LangAuto.Content" xml:space="preserve">
-    <value>è‡ªåŠ¨æ£€æµ‹</value>
+    <value>自动检测</value>
   </data>
   <data name="VoiceSettingsPage_LangEn.Content" xml:space="preserve">
-    <value>è‹±è¯­</value>
+    <value>英语</value>
   </data>
   <data name="VoiceSettingsPage_LangEs.Content" xml:space="preserve">
-    <value>è¥¿ç­ç‰™è¯­</value>
+    <value>西班牙语</value>
   </data>
   <data name="VoiceSettingsPage_LangFr.Content" xml:space="preserve">
-    <value>æ³•è¯­</value>
+    <value>法语</value>
   </data>
   <data name="VoiceSettingsPage_LangDe.Content" xml:space="preserve">
-    <value>å¾·è¯­</value>
+    <value>德语</value>
   </data>
   <data name="VoiceSettingsPage_LangJa.Content" xml:space="preserve">
-    <value>æ—¥è¯­</value>
+    <value>日语</value>
   </data>
   <data name="VoiceSettingsPage_LangZh.Content" xml:space="preserve">
-    <value>ä¸­æ–‡</value>
+    <value>中文</value>
   </data>
   <data name="VoiceSettingsPage_LangKo.Content" xml:space="preserve">
-    <value>éŸ©è¯­</value>
+    <value>韩语</value>
   </data>
   <data name="VoiceSettingsPage_LangPt.Content" xml:space="preserve">
-    <value>è‘¡è„ç‰™è¯­</value>
+    <value>葡萄牙语</value>
   </data>
   <data name="VoiceSettingsPage_LangIt.Content" xml:space="preserve">
-    <value>æ„å¤§åˆ©è¯­</value>
+    <value>意大利语</value>
   </data>
   <data name="VoiceSettingsPage_VoiceChatHeader.Text" xml:space="preserve">
-    <value>è¯­éŸ³èŠå¤©</value>
+    <value>语音聊天</value>
   </data>
   <data name="VoiceSettingsPage_SilenceSlider.Header" xml:space="preserve">
-    <value>é™éŸ³è¶…æ—¶(ç§’)</value>
+    <value>静音超时(秒)</value>
   </data>
   <data name="VoiceSettingsPage_TtsResponseToggle.Header" xml:space="preserve">
-    <value>æœ—è¯»å“åº”</value>
+    <value>朗读响应</value>
   </data>
   <data name="VoiceSettingsPage_AudioFeedbackToggle.Header" xml:space="preserve">
-    <value>éŸ³é¢‘åé¦ˆå£°éŸ³</value>
+    <value>音频反馈声音</value>
   </data>
   <data name="VoiceSettingsPage_VoiceHeader.Text" xml:space="preserve">
     <value>Companion 语音</value>
   </data>
   <data name="VoiceSettingsPage_VoiceDescription.Text" xml:space="preserve">
-    <value>é€‰æ‹©æœ—è¯»å“åº”æ—¶ä½¿ç”¨çš„è¯­éŸ³ã€‚</value>
+    <value>选择朗读响应时使用的语音。</value>
   </data>
   <data name="VoiceSettingsPage_TtsProviderCombo.Header" xml:space="preserve">
-    <value>æä¾›å•†</value>
+    <value>提供商</value>
   </data>
   <data name="VoiceSettingsPage_TtsPiper.Content" xml:space="preserve">
-    <value>Piper(æœ¬åœ°ç¥žç»è¯­éŸ³)</value>
+    <value>Piper(本地神经语音)</value>
   </data>
   <data name="VoiceSettingsPage_TtsWindows.Content" xml:space="preserve">
-    <value>Windows(å†…ç½®ç¥žç»è¯­éŸ³)</value>
+    <value>Windows(内置神经语音)</value>
   </data>
   <data name="VoiceSettingsPage_TtsElevenLabs.Content" xml:space="preserve">
-    <value>ElevenLabs(äº‘ç«¯,éœ€è¦ API å¯†é’¥)</value>
+    <value>ElevenLabs(云端,需要 API 密钥)</value>
   </data>
   <data name="VoiceSettingsPage_PiperVoiceCombo.Header" xml:space="preserve">
-    <value>è¯­éŸ³</value>
+    <value>语音</value>
   </data>
   <data name="VoiceSettingsPage_PiperDownloadButtonText.Text" xml:space="preserve">
-    <value>ä¸‹è½½è¯­éŸ³</value>
+    <value>下载语音</value>
   </data>
   <data name="VoiceSettingsPage_PiperDeleteButton.Content" xml:space="preserve">
-    <value>åˆ é™¤</value>
+    <value>删除</value>
   </data>
   <data name="VoiceSettingsPage_PiperPreviewButton.Content" xml:space="preserve">
     <value>预览</value>
@@ -2614,25 +2614,25 @@
     <value>预览</value>
   </data>
   <data name="VoiceSettingsPage_PiperInfoText.Text" xml:space="preserve">
-    <value>è¯­éŸ³ä»Ž sherpa-onnx é¡¹ç›®çš„ GitHub å‘å¸ƒç‰ˆä¸‹è½½(ä½Žè´¨é‡çº¦ 25 MB,é«˜è´¨é‡æœ€é«˜çº¦ 150 MB)ã€‚å®ƒä»¬å®Œå…¨åœ¨æœ¬æœºè¿è¡Œ;æ— éŸ³é¢‘ç¦»å¼€æ‚¨çš„è®¾å¤‡ã€‚</value>
+    <value>语音从 sherpa-onnx 项目的 GitHub 发布版下载(低质量约 25 MB,高质量最高约 150 MB)。它们完全在本机运行;无音频离开您的设备。</value>
   </data>
   <data name="VoiceSettingsPage_WindowsVoiceCombo.Header" xml:space="preserve">
-    <value>è¯­éŸ³</value>
+    <value>语音</value>
   </data>
   <data name="VoiceSettingsPage_PreviewVoiceButton.Content" xml:space="preserve">
     <value>预览语音</value>
   </data>
   <data name="VoiceSettingsPage_ElevenLabsApiKeyBox.Header" xml:space="preserve">
-    <value>API å¯†é’¥</value>
+    <value>API 密钥</value>
   </data>
   <data name="VoiceSettingsPage_ElevenLabsVoiceIdBox.Header" xml:space="preserve">
-    <value>è¯­éŸ³ ID</value>
+    <value>语音 ID</value>
   </data>
   <data name="VoiceSettingsPage_ElevenLabsModelBox.Header" xml:space="preserve">
-    <value>æ¨¡åž‹(å¯é€‰)</value>
+    <value>模型(可选)</value>
   </data>
   <data name="VoiceSettingsPage_PrivacyNote.Text" xml:space="preserve">
-    <value>æ‰€æœ‰è¯­éŸ³å¤„ç†å‡å®Œå…¨åœ¨æ‚¨çš„è®¾å¤‡ä¸Šè¿è¡Œã€‚ä¸ä¼šå‘ä»»ä½•äº‘æœåŠ¡å‘é€éŸ³é¢‘æ•°æ®ã€‚</value>
+    <value>所有语音处理均完全在您的设备上运行。不会向任何云服务发送音频数据。</value>
   </data>
   <data name="VoiceSettingsPage_StatusModelReady" xml:space="preserve">
     <value>✅ 模型就绪</value>
@@ -2662,25 +2662,25 @@
     <value>关闭</value>
   </data>
   <data name="VoiceSettingsPage_ButtonReDownload" xml:space="preserve">
-    <value>é‡æ–°ä¸‹è½½</value>
+    <value>重新下载</value>
   </data>
   <data name="VoiceSettingsPage_StatusDownloading" xml:space="preserve">
-    <value>æ­£åœ¨ä¸‹è½½...</value>
+    <value>正在下载...</value>
   </data>
   <data name="VoiceSettingsPage_StatusDownloadingPct" xml:space="preserve">
-    <value>æ­£åœ¨ä¸‹è½½... {0}%</value>
+    <value>正在下载... {0}%</value>
   </data>
   <data name="VoiceSettingsPage_StatusDownloadCanceled" xml:space="preserve">
-    <value>ä¸‹è½½å·²å–æ¶ˆ</value>
+    <value>下载已取消</value>
   </data>
   <data name="VoiceSettingsPage_StatusError" xml:space="preserve">
     <value>操作失败(参见 Debug 日志)</value>
   </data>
   <data name="VoiceSettingsPage_PiperButtonDownloaded" xml:space="preserve">
-    <value>å·²ä¸‹è½½</value>
+    <value>已下载</value>
   </data>
   <data name="VoiceSettingsPage_PiperVoiceReady" xml:space="preserve">
-    <value>è¯­éŸ³å·²åœ¨æ­¤ PC ä¸Šå°±ç»ª({0} MB)ã€‚</value>
+    <value>语音已在此 PC 上就绪({0} MB)。</value>
   </data>
   <data name="VoiceSettingsPage_PiperVoiceNotDownloaded" xml:space="preserve">
     <value>语音尚未下载。点击下载以获取模型(根据质量约 25–150 MB)。</value>
@@ -2701,52 +2701,52 @@
     <value>下载完成。正在提取…</value>
   </data>
   <data name="VoiceSettingsPage_PiperDownloadCanceled" xml:space="preserve">
-    <value>ä¸‹è½½å·²å–æ¶ˆã€‚</value>
+    <value>下载已取消。</value>
   </data>
   <data name="VoiceSettingsPage_PiperDownloadFailed" xml:space="preserve">
-    <value>ä¸‹è½½å¤±è´¥(å‚è§ Debug æ—¥å¿—)ã€‚</value>
+    <value>下载失败(参见 Debug 日志)。</value>
   </data>
   <data name="VoiceSettingsPage_PiperButtonRetry" xml:space="preserve">
-    <value>é‡è¯•ä¸‹è½½</value>
+    <value>重试下载</value>
   </data>
   <data name="VoiceSettingsPage_PiperDeleted" xml:space="preserve">
-    <value>å·²åˆ é™¤è¯­éŸ³ã€‚</value>
+    <value>已删除语音。</value>
   </data>
   <data name="VoiceSettingsPage_PiperDeleteFailed" xml:space="preserve">
-    <value>åˆ é™¤å¤±è´¥(å‚è§ Debug æ—¥å¿—)ã€‚</value>
+    <value>删除失败(参见 Debug 日志)。</value>
   </data>
   <data name="VoiceSettingsPage_CompanionPreviewText" xml:space="preserve">
-    <value>æ‚¨å¥½!è¿™æ˜¯æ‚¨çš„ Companion åœ¨è¯´è¯ã€‚</value>
+    <value>您好!这是您的 Companion 在说话。</value>
   </data>
   <data name="VoiceSettingsPage_PiperPreviewFailed" xml:space="preserve">
-    <value>é¢„è§ˆå¤±è´¥(å‚è§ Debug æ—¥å¿—)ã€‚</value>
+    <value>预览失败(参见 Debug 日志)。</value>
   </data>
   <data name="VoiceSettingsPage_VoiceErrorLoading" xml:space="preserve">
-    <value>åŠ è½½è¯­éŸ³æ—¶å‡ºé”™(å‚è§ Debug æ—¥å¿—)ã€‚</value>
+    <value>加载语音时出错(参见 Debug 日志)。</value>
   </data>
   <data name="VoiceSettingsPage_PreviewButtonPlaying" xml:space="preserve">
     <value>正在播放...</value>
   </data>
   <data name="VoiceOverlayWindow_HeaderText.Text" xml:space="preserve">
-    <value>Companion è¯­éŸ³</value>
+    <value>Companion 语音</value>
   </data>
   <data name="VoiceOverlayWindow_StatusBadge.Text" xml:space="preserve">
-    <value>å°±ç»ª</value>
+    <value>就绪</value>
   </data>
   <data name="VoiceOverlayWindow_EmptyStateText.Text" xml:space="preserve">
-    <value>æŒ‰å¼€å§‹å¹¶å¼€å§‹è¯´è¯</value>
+    <value>按开始并开始说话</value>
   </data>
   <data name="VoiceOverlayWindow_StatusText.Text" xml:space="preserve">
-    <value>æŒ‰å¼€å§‹ä»¥å¼€å§‹</value>
+    <value>按开始以开始</value>
   </data>
   <data name="VoiceOverlayWindow_StartStopText.Text" xml:space="preserve">
-    <value>å¼€å§‹è†å¬</value>
+    <value>开始聆听</value>
   </data>
   <data name="VoiceOverlayWindow_MuteButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>é™éŸ³</value>
+    <value>静音</value>
   </data>
   <data name="VoiceOverlayWindow_SettingsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>è¯­éŸ³è®¾ç½®</value>
+    <value>语音设置</value>
   </data>
   <data name="VoiceOverlayWindow_StatusListening" xml:space="preserve">
     <value>🗣️ 正在聆听...</value>
@@ -2755,148 +2755,148 @@
     <value>现在请说话 — 我在聆听</value>
   </data>
   <data name="VoiceOverlayWindow_StateInitializing" xml:space="preserve">
-    <value>æ­£åœ¨åˆå§‹åŒ–...</value>
+    <value>正在初始化...</value>
   </data>
   <data name="VoiceOverlayWindow_StateStarting" xml:space="preserve">
-    <value>æ­£åœ¨å¯åŠ¨</value>
+    <value>正在启动</value>
   </data>
   <data name="VoiceOverlayWindow_StateDownloadingModel" xml:space="preserve">
-    <value>æ­£åœ¨ä¸‹è½½è¯­éŸ³æ¨¡åž‹...</value>
+    <value>正在下载语音模型...</value>
   </data>
   <data name="VoiceOverlayWindow_StateDownloadingPct" xml:space="preserve">
-    <value>æ­£åœ¨ä¸‹è½½æ¨¡åž‹... {0}%</value>
+    <value>正在下载模型... {0}%</value>
   </data>
   <data name="VoiceOverlayWindow_StateLoadingModel" xml:space="preserve">
-    <value>æ­£åœ¨åŠ è½½è¯­éŸ³æ¨¡åž‹...</value>
+    <value>正在加载语音模型...</value>
   </data>
   <data name="VoiceOverlayWindow_StateStartingMic" xml:space="preserve">
-    <value>æ­£åœ¨å¯åŠ¨éº¦å…‹é£Ž...</value>
+    <value>正在启动麦克风...</value>
   </data>
   <data name="VoiceOverlayWindow_StateStopping" xml:space="preserve">
-    <value>æ­£åœ¨åœæ­¢...</value>
+    <value>正在停止...</value>
   </data>
   <data name="VoiceOverlayWindow_StateError" xml:space="preserve">
-    <value>é”™è¯¯</value>
+    <value>错误</value>
   </data>
   <data name="VoiceOverlayWindow_StatusError" xml:space="preserve">
-    <value>é‡åˆ°é”™è¯¯(å‚è§ Debug æ—¥å¿—)</value>
+    <value>遇到错误(参见 Debug 日志)</value>
   </data>
   <data name="VoiceOverlayWindow_StatusMuted" xml:space="preserve">
-    <value>å·²é™éŸ³</value>
+    <value>已静音</value>
   </data>
   <data name="VoiceOverlayWindow_StopText" xml:space="preserve">
-    <value>åœæ­¢</value>
+    <value>停止</value>
   </data>
   <data name="VoiceOverlayWindow_BadgeStopped" xml:space="preserve">
-    <value>å·²åœæ­¢</value>
+    <value>已停止</value>
   </data>
   <data name="VoiceOverlayWindow_BadgeStartingDots" xml:space="preserve">
-    <value>æ­£åœ¨å¯åŠ¨...</value>
+    <value>正在启动...</value>
   </data>
   <data name="VoiceOverlayWindow_BadgeListening" xml:space="preserve">
-    <value>æ­£åœ¨è†å¬</value>
+    <value>正在聆听</value>
   </data>
   <data name="VoiceOverlayWindow_BadgeProcessing" xml:space="preserve">
-    <value>æ­£åœ¨å¤„ç†...</value>
+    <value>正在处理...</value>
   </data>
   <data name="VoiceOverlayWindow_BadgeUnknown" xml:space="preserve">
-    <value>æœªçŸ¥</value>
+    <value>未知</value>
   </data>
   <data name="VoiceOverlayWindow_StatusInitMic" xml:space="preserve">
-    <value>æ­£åœ¨åˆå§‹åŒ–éº¦å…‹é£Ž...</value>
+    <value>正在初始化麦克风...</value>
   </data>
   <data name="VoiceOverlayWindow_StatusTranscribing" xml:space="preserve">
-    <value>æ­£åœ¨è½¬å½•æ‚¨çš„è¯­éŸ³...</value>
+    <value>正在转录您的语音...</value>
   </data>
   <data name="VoiceOverlayWindow_StatusErrorOccurred" xml:space="preserve">
-    <value>å‘ç”Ÿé”™è¯¯</value>
+    <value>发生错误</value>
   </data>
   <data name="VoiceOverlayWindow_winexWindowEx_2.Title" xml:space="preserve">
     <value>Companion Voice</value>
   </data>
   <data name="VoiceOverlayWindow_BadgeReady" xml:space="preserve">
-    <value>å°±ç»ª</value>
+    <value>就绪</value>
   </data>
   <data name="VoiceOverlayWindow_StatusReadyMessage" xml:space="preserve">
-    <value>æŒ‰å¼€å§‹ä»¥å¼€å§‹</value>
+    <value>按开始以开始</value>
   </data>
   <data name="VoiceOverlayWindow_ButtonStartListening" xml:space="preserve">
-    <value>å¼€å§‹è†å¬</value>
+    <value>开始聆听</value>
   </data>
   <data name="VoiceSettingsPage_ButtonDownloadModel" xml:space="preserve">
-    <value>ä¸‹è½½æ¨¡åž‹</value>
+    <value>下载模型</value>
   </data>
   <data name="VoiceSettingsPage_PiperButtonDownloadVoice" xml:space="preserve">
-    <value>ä¸‹è½½è¯­éŸ³</value>
+    <value>下载语音</value>
   </data>
   <data name="VoiceSettingsPage_PreviewVoiceButtonContent" xml:space="preserve">
     <value>预览语音</value>
   </data>
   <data name="DebugPage_TextBlock_OverridesHeader.Text" xml:space="preserve">
-    <value>è°ƒè¯•è¦†ç›–</value>
+    <value>调试覆盖</value>
   </data>
   <data name="DebugPage_TextBlock_OverridesCaption.Text" xml:space="preserve">
     <value>按聊天容器覆盖全局的“使用标准网关聊天界面”设置。应用重启后重置。</value>
   </data>
   <data name="DebugPage_TextBlock_HubChatLabel.Text" xml:space="preserve">
-    <value>ä¸­å¿ƒèŠå¤©é€‰é¡¹å¡ UIï¼š</value>
+    <value>中心聊天选项卡 UI：</value>
   </data>
   <data name="DebugPage_TextBlock_TrayChatLabel.Text" xml:space="preserve">
-    <value>æ‰˜ç›˜èŠå¤©å¼¹çª— UIï¼š</value>
+    <value>托盘聊天弹窗 UI：</value>
   </data>
   <data name="DebugPage_ChatOverride_NoOverride_Hub.Content" xml:space="preserve">
-    <value>ä¸è¦†ç›–</value>
+    <value>不覆盖</value>
   </data>
   <data name="DebugPage_ChatOverride_ForceLegacy_Hub.Content" xml:space="preserve">
-    <value>å¼ºåˆ¶ä½¿ç”¨ç½‘å…³èŠå¤© UI</value>
+    <value>强制使用网关聊天 UI</value>
   </data>
   <data name="DebugPage_ChatOverride_ForceNative_Hub.Content" xml:space="preserve">
-    <value>å¼ºåˆ¶ä½¿ç”¨ä¼´ä¾£èŠå¤© UI</value>
+    <value>强制使用伴侣聊天 UI</value>
   </data>
   <data name="DebugPage_ChatOverride_NoOverride_Tray.Content" xml:space="preserve">
-    <value>ä¸è¦†ç›–</value>
+    <value>不覆盖</value>
   </data>
   <data name="DebugPage_ChatOverride_ForceLegacy_Tray.Content" xml:space="preserve">
-    <value>å¼ºåˆ¶ä½¿ç”¨ç½‘å…³èŠå¤© UI</value>
+    <value>强制使用网关聊天 UI</value>
   </data>
   <data name="DebugPage_ChatOverride_ForceNative_Tray.Content" xml:space="preserve">
-    <value>å¼ºåˆ¶ä½¿ç”¨ä¼´ä¾£èŠå¤© UI</value>
+    <value>强制使用伴侣聊天 UI</value>
   </data>
   <data name="Chat_ZeroState_WelcomeTitle" xml:space="preserve">
-    <value>æ¬¢è¿Žä½¿ç”¨ OpenClaw</value>
+    <value>欢迎使用 OpenClaw</value>
   </data>
   <data name="Chat_ZeroState_WelcomeSubtitle" xml:space="preserve">
-    <value>ä»Šå¤©æˆ‘èƒ½å¸®ä½ åšä»€ä¹ˆï¼Ÿ</value>
+    <value>今天我能帮你做什么？</value>
   </data>
   <data name="Chat_Status_Done" xml:space="preserve">
-    <value>å®Œæˆ</value>
+    <value>完成</value>
   </data>
   <data name="Chat_Status_Running" xml:space="preserve">
-    <value>è¿è¡Œä¸­</value>
+    <value>运行中</value>
   </data>
   <data name="Chat_Status_Error" xml:space="preserve">
-    <value>é”™è¯¯</value>
+    <value>错误</value>
   </data>
   <data name="Chat_Status_Interrupted" xml:space="preserve">
-    <value>å·²ä¸­æ–­</value>
+    <value>已中断</value>
   </data>
   <data name="Chat_Timeline_LoadEarlier" xml:space="preserve">
-    <value>åŠ è½½æ›´æ—©çš„æ¶ˆæ¯</value>
+    <value>加载更早的消息</value>
   </data>
   <data name="Chat_Tool_CallLabel" xml:space="preserve">
-    <value>å·¥å…·è°ƒç”¨</value>
+    <value>工具调用</value>
   </data>
   <data name="Chat_Tool_OutputLabel" xml:space="preserve">
-    <value>å·¥å…·è¾“å‡º</value>
+    <value>工具输出</value>
   </data>
   <data name="Chat_Tool_ErrorLabel" xml:space="preserve">
-    <value>å·¥å…·é”™è¯¯</value>
+    <value>工具错误</value>
   </data>
   <data name="Chat_Tool_InputSection" xml:space="preserve">
-    <value>å·¥å…·è¾“å…¥</value>
+    <value>工具输入</value>
   </data>
   <data name="Chat_Tool_FooterLabel" xml:space="preserve">
-    <value>å·¥å…·</value>
+    <value>工具</value>
   </data>
   <data name="Chat_Tool_FooterWithTimeFormat" xml:space="preserve">
     <value>工具 · {0}</value>
@@ -2911,85 +2911,85 @@
     <value>{0} 正在思考…</value>
   </data>
   <data name="Chat_Composer_Reasoning_Default" xml:space="preserve">
-    <value>é»˜è®¤</value>
+    <value>默认</value>
   </data>
   <data name="Chat_Composer_Reasoning_Auto" xml:space="preserve">
-    <value>è‡ªåŠ¨</value>
+    <value>自动</value>
   </data>
   <data name="Chat_Composer_Reasoning_Maximum" xml:space="preserve">
-    <value>æœ€å¤§</value>
+    <value>最大</value>
   </data>
   <data name="Chat_Composer_Placeholder_Connected" xml:space="preserve">
-    <value>ç»™åŠ©æ‰‹å‘é€æ¶ˆæ¯ï¼ˆæŒ‰ Enter å‘é€ï¼‰</value>
+    <value>给助手发送消息（按 Enter 发送）</value>
   </data>
   <data name="Chat_Composer_Placeholder_Connecting" xml:space="preserve">
     <value>连接中…</value>
   </data>
   <data name="Chat_Composer_Placeholder_NotConnected" xml:space="preserve">
-    <value>æœªè¿žæŽ¥</value>
+    <value>未连接</value>
   </data>
   <data name="Chat_Composer_Placeholder_IncompatibleGateway" xml:space="preserve">
     <value>Gateway update required — incompatible version</value>
   </data>
   <data name="Chat_Composer_Tooltip_Attach" xml:space="preserve">
-    <value>é™„åŠ </value>
+    <value>附加</value>
   </data>
   <data name="Chat_Composer_Tooltip_Voice" xml:space="preserve">
-    <value>è¯­éŸ³</value>
+    <value>语音</value>
   </data>
   <data name="Chat_Voice_ListeningPrompt" xml:space="preserve">
     <value>正在聆听…</value>
   </data>
   <data name="Chat_Voice_Cancel" xml:space="preserve">
-    <value>å–æ¶ˆ</value>
+    <value>取消</value>
   </data>
   <data name="Chat_Composer_Tooltip_More" xml:space="preserve">
-    <value>æ›´å¤š</value>
+    <value>更多</value>
   </data>
   <data name="Chat_Composer_Tooltip_Send" xml:space="preserve">
-    <value>å‘é€</value>
+    <value>发送</value>
   </data>
   <data name="Chat_Composer_Tooltip_Stop" xml:space="preserve">
-    <value>åœæ­¢</value>
+    <value>停止</value>
   </data>
   <data name="Chat_Composer_AssistantWorking" xml:space="preserve">
     <value>助手正在工作…</value>
   </data>
   <data name="Chat_Assistant_Action_Copy" xml:space="preserve">
-    <value>å¤åˆ¶æ¶ˆæ¯</value>
+    <value>复制消息</value>
   </data>
   <data name="Chat_Assistant_Action_ReadAloud" xml:space="preserve">
-    <value>æœ—è¯»</value>
+    <value>朗读</value>
   </data>
   <data name="Chat_User_Action_Delete" xml:space="preserve">
-    <value>åˆ é™¤æ¶ˆæ¯</value>
+    <value>删除消息</value>
   </data>
   <data name="Chat_TruncationMarkerFormat" xml:space="preserve">
     <value> … [已截断 {0} 字节]</value>
   </data>
   <data name="Chat_Permission_Allow" xml:space="preserve">
-    <value>å…è®¸</value>
+    <value>允许</value>
   </data>
   <data name="Chat_Permission_Deny" xml:space="preserve">
-    <value>æ‹’ç»</value>
+    <value>拒绝</value>
   </data>
   <data name="Chat_Root_ConnectingToGateway" xml:space="preserve">
     <value>正在连接到网关…</value>
   </data>
   <data name="Chat_Root_EmptyState_SelectSession" xml:space="preserve">
-    <value>åœ¨ä¾§æ ä¸­é€‰æ‹©ä¸€ä¸ªä¼šè¯ä»¥å¼€å§‹èŠå¤©ã€‚</value>
+    <value>在侧栏中选择一个会话以开始聊天。</value>
   </data>
   <data name="Chat_Notification_SendFailed" xml:space="preserve">
-    <value>å‘é€å¤±è´¥</value>
+    <value>发送失败</value>
   </data>
   <data name="Chat_Notification_AbortFailed" xml:space="preserve">
-    <value>ä¸­æ­¢å¤±è´¥</value>
+    <value>中止失败</value>
   </data>
   <data name="Chat_Notification_LoadHistoryFailed" xml:space="preserve">
-    <value>åŠ è½½åŽ†å²å¤±è´¥</value>
+    <value>加载历史失败</value>
   </data>
   <data name="Chat_Notification_AssistantReplied" xml:space="preserve">
-    <value>åŠ©æ‰‹å·²å›žå¤</value>
+    <value>助手已回复</value>
   </data>
   <data name="Chat_Notification_ConnectionInterrupted" xml:space="preserve">
     <value>连接已断开 — 回复已中断。</value>
@@ -3001,7 +3001,7 @@
     <value>网关发送了缺少会话键的聊天时间线事件，OpenClaw 已将其忽略，以避免混淆时间线。如果此情况持续，请更新或重启网关。</value>
   </data>
   <data name="VoiceSettingsPage_TestVoiceButtonText.Text" xml:space="preserve">
-    <value>æµ‹è¯•è¯­éŸ³è¾“å…¥</value>
+    <value>测试语音输入</value>
   </data>
   <data name="PermissionsPage_FeaturesDescription_Enabled" xml:space="preserve">
     <value>Toggle individual features that agents may request from this PC.</value>
@@ -3187,7 +3187,7 @@
     <value>Resync</value>
   </data>
   <data name="InstancesPage_BackToConnectionText.Text" xml:space="preserve">
-    <value>è¿”å›žè¿žæŽ¥</value>
+    <value>返回连接</value>
   </data>
   <data name="ConnectionPage_NodePairing_Title.Text" xml:space="preserve">
     <value>🔗 Pending Operator/Node Pairing</value>
@@ -3235,16 +3235,16 @@
     <value>Copy node ID</value>
   </data>
   <data name="InstancesPage_TimeAgo_Seconds_Format" xml:space="preserve">
-    <value>{0}ç§’å‰</value>
+    <value>{0}秒前</value>
   </data>
   <data name="InstancesPage_TimeAgo_Minutes_Format" xml:space="preserve">
-    <value>{0}åˆ†é’Ÿå‰</value>
+    <value>{0}分钟前</value>
   </data>
   <data name="InstancesPage_TimeAgo_Hours_Format" xml:space="preserve">
-    <value>{0}å°æ—¶å‰</value>
+    <value>{0}小时前</value>
   </data>
   <data name="InstancesPage_TimeAgo_Days_Format" xml:space="preserve">
-    <value>{0}å¤©å‰</value>
+    <value>{0}天前</value>
   </data>
   <data name="V2_Window_Title" xml:space="preserve">
     <value>OpenClaw Setup</value>
@@ -3409,55 +3409,55 @@
     <value>Keep my setup</value>
   </data>
   <data name="FilterAllButton.Text" xml:space="preserve">
-    <value>å…¨éƒ¨</value>
+    <value>全部</value>
   </data>
   <data name="ChannelsPage_Title.Text" xml:space="preserve">
-    <value>é¢‘é“</value>
+    <value>频道</value>
   </data>
   <data name="ChannelsPage_Refresh.Text" xml:space="preserve">
-    <value>åˆ·æ–°</value>
+    <value>刷新</value>
   </data>
   <data name="ChannelsPage_ConfiguredHeader.Text" xml:space="preserve">
-    <value>å·²é…ç½®</value>
+    <value>已配置</value>
   </data>
   <data name="ChannelsPage_AvailableHeader.Text" xml:space="preserve">
-    <value>å¯ç”¨</value>
+    <value>可用</value>
   </data>
   <data name="ChatPageHomeToolTip.Content" xml:space="preserve">
-    <value>ä¸»é¡µ</value>
+    <value>主页</value>
   </data>
   <data name="ChatPageRefreshToolTip.Content" xml:space="preserve">
-    <value>åˆ·æ–°</value>
+    <value>刷新</value>
   </data>
   <data name="ChatPageDeveloperToolsToolTip.Content" xml:space="preserve">
-    <value>å¼€å‘äººå‘˜å·¥å…·</value>
+    <value>开发人员工具</value>
   </data>
   <data name="SettingsRow_AutoStart_Header.Text" xml:space="preserve">
-    <value>éš Windows å¯åŠ¨</value>
+    <value>随 Windows 启动</value>
   </data>
   <data name="SettingsRow_GlobalHotkey_Header.Text" xml:space="preserve">
-    <value>å¿«é€Ÿå‘é€çƒ­é”®</value>
+    <value>快速发送热键</value>
   </data>
   <data name="SettingsRow_LegacyChat_Header.Text" xml:space="preserve">
-    <value>ä½¿ç”¨ç½‘å…³çš„ Web èŠå¤©ç•Œé¢</value>
+    <value>使用网关的 Web 聊天界面</value>
   </data>
   <data name="SettingsRow_Notifications_Header.Text" xml:space="preserve">
-    <value>æ˜¾ç¤ºé€šçŸ¥</value>
+    <value>显示通知</value>
   </data>
   <data name="SettingsRow_NotifSound_Header.Text" xml:space="preserve">
-    <value>æç¤ºéŸ³</value>
+    <value>提示音</value>
   </data>
   <data name="SettingsRow_ScreenRec_Header.Text" xml:space="preserve">
-    <value>å…è®¸å±å¹•å½•åˆ¶</value>
+    <value>允许屏幕录制</value>
   </data>
   <data name="SettingsRow_CamRec_Header.Text" xml:space="preserve">
-    <value>å…è®¸æ‘„åƒå¤´å½•åˆ¶</value>
+    <value>允许摄像头录制</value>
   </data>
   <data name="HubWindow_NavigationViewItem_Voice.Content" xml:space="preserve">
-    <value>è¯­éŸ³å’ŒéŸ³é¢‘</value>
+    <value>语音和音频</value>
   </data>
   <data name="HubWindow_NavigationViewItem_Sandbox.Content" xml:space="preserve">
-    <value>æ²™ç›’</value>
+    <value>沙盒</value>
   </data>
   <data name="AboutPage_MoreDiagnosticsLink.Content" xml:space="preserve">
     <value>More diagnostics →</value>
@@ -3637,34 +3637,34 @@
     <value>Connection Status</value>
   </data>
   <data name="BindingsPage_GatewayDisconnected.Title" xml:space="preserve">
-    <value>ç½‘å…³å·²æ–­å¼€</value>
+    <value>网关已断开</value>
   </data>
   <data name="BindingsPage_GatewayDisconnected.Message" xml:space="preserve">
-    <value>è¯·è¿žæŽ¥åˆ°ç½‘å…³ä»¥åŠ è½½ç»‘å®šã€‚</value>
+    <value>请连接到网关以加载绑定。</value>
   </data>
   <data name="BindingsPage_OpenConnection.Content" xml:space="preserve">
-    <value>æ‰“å¼€è¿žæŽ¥</value>
+    <value>打开连接</value>
   </data>
   <data name="BindingsPage_LoadingBindings.Text" xml:space="preserve">
     <value>正在加载绑定…</value>
   </data>
   <data name="ConnectionPage_ApprovalsWaitingOnYou.Text" xml:space="preserve">
-    <value>ç­‰å¾…æ‚¨çš„å®¡æ‰¹</value>
+    <value>等待您的审批</value>
   </data>
   <data name="ConnectionPage_NotConnected.Text" xml:space="preserve">
-    <value>æœªè¿žæŽ¥</value>
+    <value>未连接</value>
   </data>
   <data name="ConnectionPage_Connect.Content" xml:space="preserve">
-    <value>è¿žæŽ¥</value>
+    <value>连接</value>
   </data>
   <data name="ConnectionPage_Operator.Text" xml:space="preserve">
-    <value>æ“ä½œå‘˜</value>
+    <value>操作员</value>
   </data>
   <data name="ConnectionPage_SendCommandsAndView.Text" xml:space="preserve">
-    <value>ä»Žæ­¤ç”µè„‘å‘æ­¤ç½‘å…³å‘é€å‘½ä»¤å¹¶æŸ¥çœ‹ä¼šè¯ã€‚</value>
+    <value>从此电脑向此网关发送命令并查看会话。</value>
   </data>
   <data name="ConnectionPage_Inactive.Text" xml:space="preserve">
-    <value>æœªæ¿€æ´»</value>
+    <value>未激活</value>
   </data>
   <data name="ConnectionPage_SeeSessions.Content" xml:space="preserve">
     <value>查看会话 ›</value>
@@ -3673,232 +3673,232 @@
     <value>查看实例 ›</value>
   </data>
   <data name="ConnectionPage_NodeMode.Text" xml:space="preserve">
-    <value>èŠ‚ç‚¹æ¨¡å¼</value>
+    <value>节点模式</value>
   </data>
   <data name="ConnectionPage_WhenOnThisPC.Text" xml:space="preserve">
-    <value>å¯ç”¨åŽ,æ­¤ç”µè„‘å°†æ³¨å†Œä¸ºèŠ‚ç‚¹,å¹¶é€šè¿‡ç½‘å…³å‘ä»£ç†æä¾›ä¸‹åˆ—åŠŸèƒ½ã€‚</value>
+    <value>启用后,此电脑将注册为节点,并通过网关向代理提供下列功能。</value>
   </data>
   <data name="ConnectionPage_NodeModeDisabled.Text" xml:space="preserve">
-    <value>èŠ‚ç‚¹æ¨¡å¼å·²ç¦ç”¨</value>
+    <value>节点模式已禁用</value>
   </data>
   <data name="ConnectionPage_Copy.Content" xml:space="preserve">
-    <value>å¤åˆ¶</value>
+    <value>复制</value>
   </data>
   <data name="ConnectionPage_Connect2.Content" xml:space="preserve">
-    <value>è¿žæŽ¥</value>
+    <value>连接</value>
   </data>
   <data name="ConnectionPage_ManagePermissions.Content" xml:space="preserve">
     <value>管理权限 ›</value>
   </data>
   <data name="ConnectionPage_HelpUsFixThis.Text" xml:space="preserve">
-    <value>å¸®åŠ©æˆ‘ä»¬ä¿®å¤æ­¤è¿žæŽ¥:</value>
+    <value>帮助我们修复此连接:</value>
   </data>
   <data name="ConnectionPage_SSHTunnelIsDown.Text" xml:space="preserve">
-    <value>SSH éš§é“å·²åœæ­¢ã€‚</value>
+    <value>SSH 隧道已停止。</value>
   </data>
   <data name="ConnectionPage_RestartTunnel.Content" xml:space="preserve">
-    <value>é‡å¯éš§é“</value>
+    <value>重启隧道</value>
   </data>
   <data name="ConnectionPage_EditTunnelSettings.Content" xml:space="preserve">
-    <value>ç¼–è¾‘éš§é“è®¾ç½®</value>
+    <value>编辑隧道设置</value>
   </data>
   <data name="ConnectionPage_PasteANewSetup.Text" xml:space="preserve">
-    <value>ç²˜è´´æ¥è‡ªç½‘å…³ä¸»æœºçš„æ–°è®¾ç½®ä»£ç ã€‚</value>
+    <value>粘贴来自网关主机的新设置代码。</value>
   </data>
   <data name="ConnectionPage_PasteSetupCodeHere.PlaceholderText" xml:space="preserve">
     <value>在此粘贴设置代码…</value>
   </data>
   <data name="ConnectionPage_Apply.Content" xml:space="preserve">
-    <value>åº”ç”¨</value>
+    <value>应用</value>
   </data>
   <data name="ConnectionPage_RunOnTheGateway.Text" xml:space="preserve">
-    <value>åœ¨ç½‘å…³ä¸»æœºä¸Šè¿è¡Œ:</value>
+    <value>在网关主机上运行:</value>
   </data>
   <data name="ConnectionPage_Copy2.Content" xml:space="preserve">
-    <value>å¤åˆ¶</value>
+    <value>复制</value>
   </data>
   <data name="ConnectionPage_Connect3.Content" xml:space="preserve">
-    <value>è¿žæŽ¥</value>
+    <value>连接</value>
   </data>
   <data name="ConnectionPage_Disconnect.Content" xml:space="preserve">
-    <value>æ–­å¼€è¿žæŽ¥</value>
+    <value>断开连接</value>
   </data>
   <data name="ConnectionPage_SavedGateways.Text" xml:space="preserve">
-    <value>å·²ä¿å­˜çš„ç½‘å…³</value>
+    <value>已保存的网关</value>
   </data>
   <data name="ConnectionPage_Gateways.Text" xml:space="preserve">
-    <value>ç½‘å…³</value>
+    <value>网关</value>
   </data>
   <data name="ConnectionPage_Scan.Text" xml:space="preserve">
-    <value>æ‰«æ</value>
+    <value>扫描</value>
   </data>
   <data name="ConnectionPage_AddGateway.Text" xml:space="preserve">
-    <value>æ·»åŠ ç½‘å…³</value>
+    <value>添加网关</value>
   </data>
   <data name="ConnectionPage_NoSavedGatewaysYet.Text" xml:space="preserve">
-    <value>å°šæ— å·²ä¿å­˜çš„ç½‘å…³ã€‚</value>
+    <value>尚无已保存的网关。</value>
   </data>
   <data name="ConnectionPage_DiscoveredOnYourNetwork.Text" xml:space="preserve">
-    <value>åœ¨æ‚¨çš„ç½‘ç»œä¸Šå‘çŽ°</value>
+    <value>在您的网络上发现</value>
   </data>
   <data name="ConnectionPage_AddAGateway.Text" xml:space="preserve">
-    <value>æ·»åŠ ç½‘å…³</value>
+    <value>添加网关</value>
   </data>
   <data name="ConnectionPage_GetStartedInstallA.Title" xml:space="preserve">
     <value>开始使用 — 安装本地网关</value>
   </data>
   <data name="ConnectionPage_GetStartedInstallA.Message" xml:space="preserve">
-    <value>æœ€å¿«çš„å…¥é—¨æ–¹å¼:åœ¨æ­¤ç”µè„‘ä¸Šè®¾ç½® WSL æ‰˜ç®¡çš„ç½‘å…³,å¹¶å°†å…¶è®¾ä¸ºæ´»åŠ¨è¿žæŽ¥ã€‚</value>
+    <value>最快的入门方式:在此电脑上设置 WSL 托管的网关,并将其设为活动连接。</value>
   </data>
   <data name="ConnectionPage_Install.Content" xml:space="preserve">
-    <value>å®‰è£…</value>
+    <value>安装</value>
   </data>
   <data name="ConnectionPage_OrConnectToAn.Text" xml:space="preserve">
-    <value>æˆ–è¿žæŽ¥åˆ°çŽ°æœ‰ç½‘å…³:</value>
+    <value>或连接到现有网关:</value>
   </data>
   <data name="ConnectionPage_Direct.Text" xml:space="preserve">
-    <value>ç›´æŽ¥</value>
+    <value>直接</value>
   </data>
   <data name="ConnectionPage_URLToken.Text" xml:space="preserve">
-    <value>URL + ä»¤ç‰Œ</value>
+    <value>URL + 令牌</value>
   </data>
   <data name="ConnectionPage_SetupCode.Text" xml:space="preserve">
-    <value>è®¾ç½®ä»£ç </value>
+    <value>设置代码</value>
   </data>
   <data name="ConnectionPage_PasteQRPayload.Text" xml:space="preserve">
-    <value>ç²˜è´´ QR è´Ÿè½½</value>
+    <value>粘贴 QR 负载</value>
   </data>
   <data name="ConnectionPage_EachMethodSupportsAn.Text" xml:space="preserve">
-    <value>æ¯ç§æ–¹æ³•éƒ½æ”¯æŒå¯é€‰çš„ SSH éš§é“ã€‚</value>
+    <value>每种方法都支持可选的 SSH 隧道。</value>
   </data>
   <data name="ConnectionPage_OrLookForOne.Text" xml:space="preserve">
-    <value>æˆ–åœ¨æ‚¨çš„ç½‘ç»œä¸ŠæŸ¥æ‰¾ã€‚</value>
+    <value>或在您的网络上查找。</value>
   </data>
   <data name="ConnectionPage_Scan2.Text" xml:space="preserve">
-    <value>æ‰«æ</value>
+    <value>扫描</value>
   </data>
   <data name="ConnectionPage_DiscoveredOnYourNetwork2.Text" xml:space="preserve">
-    <value>åœ¨æ‚¨çš„ç½‘ç»œä¸Šå‘çŽ°</value>
+    <value>在您的网络上发现</value>
   </data>
   <data name="ConnectionPage_Back.Text" xml:space="preserve">
-    <value>è¿”å›ž</value>
+    <value>返回</value>
   </data>
   <data name="ConnectionPage_AddAGateway2.Text" xml:space="preserve">
-    <value>æ·»åŠ ç½‘å…³</value>
+    <value>添加网关</value>
   </data>
   <data name="ConnectionPage_Direct2.Text" xml:space="preserve">
-    <value>ç›´æŽ¥</value>
+    <value>直接</value>
   </data>
   <data name="ConnectionPage_SetupCode2.Text" xml:space="preserve">
-    <value>è®¾ç½®ä»£ç </value>
+    <value>设置代码</value>
   </data>
   <data name="ConnectionPage_LocalWSL.Text" xml:space="preserve">
-    <value>æœ¬åœ° WSL</value>
+    <value>本地 WSL</value>
   </data>
   <data name="ConnectionPage_GatewayURL.Header" xml:space="preserve">
-    <value>ç½‘å…³ URL</value>
+    <value>网关 URL</value>
   </data>
   <data name="ConnectionPage_GatewayURL.PlaceholderText" xml:space="preserve">
     <value>ws://host.local:18790</value>
   </data>
   <data name="ConnectionPage_SharedToken.Header" xml:space="preserve">
-    <value>å…±äº«ä»¤ç‰Œ</value>
+    <value>共享令牌</value>
   </data>
   <data name="ConnectionPage_SharedToken.PlaceholderText" xml:space="preserve">
-    <value>ç²˜è´´å…±äº«ç½‘å…³ä»¤ç‰Œ</value>
+    <value>粘贴共享网关令牌</value>
   </data>
   <data name="ConnectionPage_NameOptional.Header" xml:space="preserve">
-    <value>åç§°(å¯é€‰)</value>
+    <value>名称(可选)</value>
   </data>
   <data name="ConnectionPage_NameOptional.PlaceholderText" xml:space="preserve">
-    <value>æˆ‘çš„ç½‘å…³</value>
+    <value>我的网关</value>
   </data>
   <data name="ConnectionPage_PasteASetupCode.Text" xml:space="preserve">
-    <value>ç²˜è´´æ¥è‡ªç½‘å…³çš„ QR ç æˆ– `openclaw qr` è¾“å‡ºçš„è®¾ç½®ä»£ç ã€‚</value>
+    <value>粘贴来自网关的 QR 码或 `openclaw qr` 输出的设置代码。</value>
   </data>
   <data name="ConnectionPage_PasteSetupCodeHere2.PlaceholderText" xml:space="preserve">
     <value>在此粘贴设置代码…</value>
   </data>
   <data name="ConnectionPage_Decode.Content" xml:space="preserve">
-    <value>è§£ç </value>
+    <value>解码</value>
   </data>
   <data name="ConnectionPage_InstallANewWSL.Text" xml:space="preserve">
-    <value>åœ¨æ­¤ç”µè„‘ä¸Šå®‰è£…æ–°çš„ WSL ç½‘å…³,å¹¶å°†å…¶è®¾ä¸ºæ´»åŠ¨è¿žæŽ¥ã€‚è®¾ç½®å‘å¯¼å°†åœ¨éœ€è¦æ—¶å®‰è£… WSLã€é…ç½®ç½‘å…³,å¹¶è‡ªåŠ¨é…å¯¹æ­¤è®¾å¤‡ã€‚</value>
+    <value>在此电脑上安装新的 WSL 网关,并将其设为活动连接。设置向导将在需要时安装 WSL、配置网关,并自动配对此设备。</value>
   </data>
   <data name="ConnectionPage_InstallLocalGateway.Content" xml:space="preserve">
-    <value>å®‰è£…æœ¬åœ°ç½‘å…³</value>
+    <value>安装本地网关</value>
   </data>
   <data name="ConnectionPage_LocalWSLSetupIsn.Text" xml:space="preserve">
     <value>此电脑无法进行本地 WSL 设置 — 安装向导无法初始化。</value>
   </data>
   <data name="ConnectionPage_UseSSHTunnelOptional.Text" xml:space="preserve">
-    <value>ä½¿ç”¨ SSH éš§é“(å¯é€‰)</value>
+    <value>使用 SSH 隧道(可选)</value>
   </data>
   <data name="ConnectionPage_SSHUser.Header" xml:space="preserve">
-    <value>SSH ç”¨æˆ·</value>
+    <value>SSH 用户</value>
   </data>
   <data name="ConnectionPage_SSHUser.PlaceholderText" xml:space="preserve">
     <value>user</value>
   </data>
   <data name="ConnectionPage_SSHHost.Header" xml:space="preserve">
-    <value>SSH ä¸»æœº</value>
+    <value>SSH 主机</value>
   </data>
   <data name="ConnectionPage_SSHHost.PlaceholderText" xml:space="preserve">
     <value>machine-name</value>
   </data>
   <data name="ConnectionPage_RemotePort.Header" xml:space="preserve">
-    <value>è¿œç¨‹ç«¯å£</value>
+    <value>远程端口</value>
   </data>
   <data name="ConnectionPage_LocalPort.Header" xml:space="preserve">
-    <value>æœ¬åœ°ç«¯å£</value>
+    <value>本地端口</value>
   </data>
   <data name="ConnectionPage_SaveAmpConnect.Content" xml:space="preserve">
-    <value>ä¿å­˜å¹¶è¿žæŽ¥</value>
+    <value>保存并连接</value>
   </data>
   <data name="ConnectionPage_Cancel.Content" xml:space="preserve">
-    <value>å–æ¶ˆ</value>
+    <value>取消</value>
   </data>
   <data name="CronPage_CronJobs.Text" xml:space="preserve">
     <value>⏱️ Cron 任务</value>
   </data>
   <data name="CronPage_Refresh.Text" xml:space="preserve">
-    <value>åˆ·æ–°</value>
+    <value>刷新</value>
   </data>
   <data name="CronPage_NewJob.Text" xml:space="preserve">
-    <value>æ–°å»ºä»»åŠ¡</value>
+    <value>新建任务</value>
   </data>
   <data name="CronPage_GatewayDisconnected.Title" xml:space="preserve">
-    <value>ç½‘å…³å·²æ–­å¼€</value>
+    <value>网关已断开</value>
   </data>
   <data name="CronPage_GatewayDisconnected.Message" xml:space="preserve">
-    <value>è¯·è¿žæŽ¥åˆ°ç½‘å…³ä»¥åŠ è½½ cron ä»»åŠ¡ã€‚</value>
+    <value>请连接到网关以加载 cron 任务。</value>
   </data>
   <data name="CronPage_OpenConnection.Content" xml:space="preserve">
-    <value>æ‰“å¼€è¿žæŽ¥</value>
+    <value>打开连接</value>
   </data>
   <data name="CronPage_NewCronJob.Text" xml:space="preserve">
-    <value>æ–°å»º Cron ä»»åŠ¡</value>
+    <value>新建 Cron 任务</value>
   </data>
   <data name="CronPage_NAME.Text" xml:space="preserve">
-    <value>åç§°</value>
+    <value>名称</value>
   </data>
   <data name="CronPage_MorningBrief.PlaceholderText" xml:space="preserve">
-    <value>æ™¨é—´ç®€æŠ¥</value>
+    <value>晨间简报</value>
   </data>
   <data name="CronPage_SCHEDULE.Text" xml:space="preserve">
-    <value>è®¡åˆ’</value>
+    <value>计划</value>
   </data>
   <data name="CronPage_Every.Content" xml:space="preserve">
-    <value>æ¯</value>
+    <value>每</value>
   </data>
   <data name="CronPage_At.Content" xml:space="preserve">
-    <value>äºŽ</value>
+    <value>于</value>
   </data>
   <data name="CronPage_Cron.Content" xml:space="preserve">
     <value>Cron</value>
   </data>
   <data name="CronPage_QUICKPRESETS.Text" xml:space="preserve">
-    <value>å¿«é€Ÿé¢„è®¾</value>
+    <value>快速预设</value>
   </data>
   <data name="CronPage_Hourly.Content" xml:space="preserve">
     <value>⏰ 每小时</value>
@@ -3916,13 +3916,13 @@
     <value>📅 每周</value>
   </data>
   <data name="CronPage_EXPRESSION.Text" xml:space="preserve">
-    <value>è¡¨è¾¾å¼</value>
+    <value>表达式</value>
   </data>
   <data name="CronPage_TIMEZONE.Text" xml:space="preserve">
-    <value>æ—¶åŒº</value>
+    <value>时区</value>
   </data>
   <data name="CronPage_Optional.PlaceholderText" xml:space="preserve">
-    <value>å¯é€‰</value>
+    <value>可选</value>
   </data>
   <data name="CronPage_AmericaNewYork.Content" xml:space="preserve">
     <value>America/New_York</value>
@@ -3949,220 +3949,220 @@
     <value>UTC</value>
   </data>
   <data name="CronPage_EVERY.Text" xml:space="preserve">
-    <value>æ¯</value>
+    <value>每</value>
   </data>
   <data name="CronPage_UNIT.Text" xml:space="preserve">
-    <value>å•ä½</value>
+    <value>单位</value>
   </data>
   <data name="CronPage_Minutes.Content" xml:space="preserve">
-    <value>åˆ†é’Ÿ</value>
+    <value>分钟</value>
   </data>
   <data name="CronPage_Hours.Content" xml:space="preserve">
-    <value>å°æ—¶</value>
+    <value>小时</value>
   </data>
   <data name="CronPage_Days.Content" xml:space="preserve">
-    <value>å¤©</value>
+    <value>天</value>
   </data>
   <data name="CronPage_RUNAT.Text" xml:space="preserve">
-    <value>è¿è¡Œæ—¶é—´</value>
+    <value>运行时间</value>
   </data>
   <data name="CronPage_Date.PlaceholderText" xml:space="preserve">
-    <value>æ—¥æœŸ</value>
+    <value>日期</value>
   </data>
   <data name="CronPage_330PM.PlaceholderText" xml:space="preserve">
     <value>15:30</value>
   </data>
   <data name="CronPage_DeleteJobAfterIt.Content" xml:space="preserve">
-    <value>è¿è¡ŒåŽåˆ é™¤ä»»åŠ¡</value>
+    <value>运行后删除任务</value>
   </data>
   <data name="CronPage_PROMPTPAYLOAD.Text" xml:space="preserve">
-    <value>æç¤º / è´Ÿè½½</value>
+    <value>提示 / 负载</value>
   </data>
   <data name="CronPage_WhatShouldTheAgent.PlaceholderText" xml:space="preserve">
-    <value>ä»£ç†åº”è¯¥åšä»€ä¹ˆ?</value>
+    <value>代理应该做什么?</value>
   </data>
   <data name="CronPage_DELIVERY.Text" xml:space="preserve">
-    <value>æŠ•é€’</value>
+    <value>投递</value>
   </data>
   <data name="CronPage_SilentNone.Content" xml:space="preserve">
-    <value>é™é»˜(æ— )</value>
+    <value>静默(无)</value>
   </data>
   <data name="CronPage_NotifyMeAnnounce.Content" xml:space="preserve">
-    <value>é€šçŸ¥æˆ‘(é€šå‘Š)</value>
+    <value>通知我(通告)</value>
   </data>
   <data name="CronPage_CHANNEL.Text" xml:space="preserve">
-    <value>é€šé“</value>
+    <value>通道</value>
   </data>
   <data name="CronPage_EGWebchat.PlaceholderText" xml:space="preserve">
-    <value>ä¾‹å¦‚ webchat</value>
+    <value>例如 webchat</value>
   </data>
   <data name="CronPage_AdvancedOptions.Text" xml:space="preserve">
-    <value>é«˜çº§é€‰é¡¹</value>
+    <value>高级选项</value>
   </data>
   <data name="CronPage_SESSIONBEHAVIOR.Text" xml:space="preserve">
-    <value>ä¼šè¯è¡Œä¸º</value>
+    <value>会话行为</value>
   </data>
   <data name="CronPage_NewSessionEachRun.Content" xml:space="preserve">
-    <value>æ¯æ¬¡è¿è¡Œæ–°å»ºä¼šè¯</value>
+    <value>每次运行新建会话</value>
   </data>
   <data name="CronPage_ResumeMainSession.Content" xml:space="preserve">
-    <value>æ¢å¤ä¸»ä¼šè¯</value>
+    <value>恢复主会话</value>
   </data>
   <data name="CronPage_WAKEMODE.Text" xml:space="preserve">
-    <value>å”¤é†’æ¨¡å¼</value>
+    <value>唤醒模式</value>
   </data>
   <data name="CronPage_NowImmediate.Content" xml:space="preserve">
-    <value>ç«‹å³(å³æ—¶)</value>
+    <value>立即(即时)</value>
   </data>
   <data name="CronPage_QueueWaitForIdle.Content" xml:space="preserve">
-    <value>æŽ’é˜Ÿ(ç­‰å¾…ç©ºé—²)</value>
+    <value>排队(等待空闲)</value>
   </data>
   <data name="CronPage_Cancel.Content" xml:space="preserve">
-    <value>å–æ¶ˆ</value>
+    <value>取消</value>
   </data>
   <data name="CronPage_CreateJob.Content" xml:space="preserve">
-    <value>åˆ›å»ºä»»åŠ¡</value>
+    <value>创建任务</value>
   </data>
   <data name="CronPage_LoadingCronJobs.Text" xml:space="preserve">
     <value>正在加载 cron 任务…</value>
   </data>
   <data name="CronPage_NoCronJobsConfigured.Text" xml:space="preserve">
-    <value>æœªé…ç½® cron ä»»åŠ¡</value>
+    <value>未配置 cron 任务</value>
   </data>
   <data name="CronPage_CronJobsWillAppear.Text" xml:space="preserve">
-    <value>é€šè¿‡ç½‘å…³é…ç½® cron ä»»åŠ¡åŽ,å®ƒä»¬å°†æ˜¾ç¤ºåœ¨æ­¤å¤„ã€‚</value>
+    <value>通过网关配置 cron 任务后,它们将显示在此处。</value>
   </data>
   <data name="DebugPage_Status.Title" xml:space="preserve">
-    <value>çŠ¶æ€</value>
+    <value>状态</value>
   </data>
   <data name="DebugPage_Copied.Title" xml:space="preserve">
-    <value>å·²å¤åˆ¶</value>
+    <value>已复制</value>
   </data>
   <data name="DebugPage_NoOverride.Content" xml:space="preserve">
-    <value>æ— è¦†ç›–</value>
+    <value>无覆盖</value>
   </data>
   <data name="DebugPage_ForceGatewayChatUI.Content" xml:space="preserve">
-    <value>å¼ºåˆ¶ä½¿ç”¨ç½‘å…³èŠå¤©ç•Œé¢</value>
+    <value>强制使用网关聊天界面</value>
   </data>
   <data name="DebugPage_ForceCompanionChatUI.Content" xml:space="preserve">
-    <value>å¼ºåˆ¶ä½¿ç”¨ä¼´ä¾£èŠå¤©ç•Œé¢</value>
+    <value>强制使用伴侣聊天界面</value>
   </data>
   <data name="DebugPage_NoOverride2.Content" xml:space="preserve">
-    <value>æ— è¦†ç›–</value>
+    <value>无覆盖</value>
   </data>
   <data name="DebugPage_ForceGatewayChatUI2.Content" xml:space="preserve">
-    <value>å¼ºåˆ¶ä½¿ç”¨ç½‘å…³èŠå¤©ç•Œé¢</value>
+    <value>强制使用网关聊天界面</value>
   </data>
   <data name="DebugPage_ForceCompanionChatUI2.Content" xml:space="preserve">
-    <value>å¼ºåˆ¶ä½¿ç”¨ä¼´ä¾£èŠå¤©ç•Œé¢</value>
+    <value>强制使用伴侣聊天界面</value>
   </data>
   <data name="DebugPage_Refresh.Text" xml:space="preserve">
-    <value>åˆ·æ–°</value>
+    <value>刷新</value>
   </data>
   <data name="DebugPage_Copy.Text" xml:space="preserve">
-    <value>å¤åˆ¶</value>
+    <value>复制</value>
   </data>
   <data name="DebugPage_OpenFile.Text" xml:space="preserve">
-    <value>æ‰“å¼€æ–‡ä»¶</value>
+    <value>打开文件</value>
   </data>
   <data name="InstancesPage_PairingApprovalRequired.Text" xml:space="preserve">
-    <value>éœ€è¦é…å¯¹å®¡æ‰¹</value>
+    <value>需要配对审批</value>
   </data>
   <data name="InstancesPage_ANodeHasConnected.Text" xml:space="preserve">
-    <value>èŠ‚ç‚¹å·²è¿žæŽ¥,ä½†åœ¨æ‚¨æ‰¹å‡†é…å¯¹è¯·æ±‚ä¹‹å‰,å…¶åŠŸèƒ½ä¸ä¼šæ¿€æ´»ã€‚</value>
+    <value>节点已连接,但在您批准配对请求之前,其功能不会激活。</value>
   </data>
   <data name="InstancesPage_ReviewOnConnectionPage.Content" xml:space="preserve">
     <value>在“连接”页面查看</value>
   </data>
   <data name="PermissionsPage_BackToConnection.Text" xml:space="preserve">
-    <value>è¿”å›žè¿žæŽ¥</value>
+    <value>返回连接</value>
   </data>
   <data name="PermissionsPage_Permissions.Text" xml:space="preserve">
-    <value>æƒé™</value>
+    <value>权限</value>
   </data>
   <data name="PermissionsPage_NodeMode.Text" xml:space="preserve">
-    <value>èŠ‚ç‚¹æ¨¡å¼</value>
+    <value>节点模式</value>
   </data>
   <data name="PermissionsPage_WhenOnThisPC.Text" xml:space="preserve">
-    <value>å¯ç”¨åŽ,æ­¤ç”µè„‘å°†æ³¨å†Œä¸ºèŠ‚ç‚¹,å¹¶é€šè¿‡ç½‘å…³å‘ä»£ç†æä¾›ä¸‹åˆ—åŠŸèƒ½ã€‚</value>
+    <value>启用后,此电脑将注册为节点,并通过网关向代理提供下列功能。</value>
   </data>
   <data name="PermissionsPage_Capabilities.Text" xml:space="preserve">
-    <value>åŠŸèƒ½</value>
+    <value>功能</value>
   </data>
   <data name="PermissionsPage_ToggleIndividualFeaturesThat.Text" xml:space="preserve">
-    <value>åˆ‡æ¢ä»£ç†å¯èƒ½ä»Žæ­¤ç”µè„‘è¯·æ±‚çš„å„é¡¹åŠŸèƒ½ã€‚</value>
+    <value>切换代理可能从此电脑请求的各项功能。</value>
   </data>
   <data name="PermissionsPage_Integrations.Text" xml:space="preserve">
-    <value>é›†æˆ</value>
+    <value>集成</value>
   </data>
   <data name="PermissionsPage_DefaultAction.Text" xml:space="preserve">
-    <value>é»˜è®¤æ“ä½œ</value>
+    <value>默认操作</value>
   </data>
   <data name="PermissionsPage_WhatHappensWhenA.Text" xml:space="preserve">
-    <value>å½“å‘½ä»¤ä¸Žä¸‹åˆ—ä»»ä½•è§„åˆ™éƒ½ä¸åŒ¹é…æ—¶å‘ç”Ÿä»€ä¹ˆã€‚</value>
+    <value>当命令与下列任何规则都不匹配时发生什么。</value>
   </data>
   <data name="PermissionsPage_PatternsAreMatchedLeft.Text" xml:space="preserve">
-    <value>æ¨¡å¼æŒ‰ä»Žå·¦åˆ°å³çš„é¡ºåºä¸Žå®Œæ•´å‘½ä»¤è¡ŒåŒ¹é…ã€‚ä½¿ç”¨ * ä½œä¸ºé€šé…ç¬¦ã€‚æ›´æ”¹å°†è‡ªåŠ¨ä¿å­˜ã€‚</value>
+    <value>模式按从左到右的顺序与完整命令行匹配。使用 * 作为通配符。更改将自动保存。</value>
   </data>
   <data name="PermissionsPage_Saved.Text" xml:space="preserve">
-    <value>å·²ä¿å­˜</value>
+    <value>已保存</value>
   </data>
   <data name="PermissionsPage_0Rules.Text" xml:space="preserve">
-    <value>0 æ¡è§„åˆ™</value>
+    <value>0 条规则</value>
   </data>
   <data name="PermissionsPage_NoRulesYetAdd.Text" xml:space="preserve">
-    <value>å°šæ— è§„åˆ™ã€‚åœ¨ä¸‹æ–¹æ·»åŠ æ¨¡å¼ä»¥å…è®¸æˆ–æ‹’ç»ç‰¹å®šå‘½ä»¤ã€‚</value>
+    <value>尚无规则。在下方添加模式以允许或拒绝特定命令。</value>
   </data>
   <data name="PermissionsPage_WindowsPrivacy.Text" xml:space="preserve">
-    <value>Windows éšç§</value>
+    <value>Windows 隐私</value>
   </data>
   <data name="PermissionsPage_CameraMicrophoneAmpScreen.Text" xml:space="preserve">
-    <value>æ‘„åƒå¤´ã€éº¦å…‹é£Žå’Œå±å¹•è®¿é—®</value>
+    <value>摄像头、麦克风和屏幕访问</value>
   </data>
   <data name="PermissionsPage_SystemLevelPrivacyPermissions.Text" xml:space="preserve">
-    <value>ç³»ç»Ÿçº§éšç§æƒé™ç”± Windows ç®¡ç†ã€‚æ‰“å¼€ Windows éšç§è®¾ç½®ä»¥æŽˆäºˆæˆ–æ’¤é”€ OpenClaw è®¿é—®æƒé™ã€‚</value>
+    <value>系统级隐私权限由 Windows 管理。打开 Windows 隐私设置以授予或撤销 OpenClaw 访问权限。</value>
   </data>
   <data name="SandboxPage_NodeSandboxIsOn.Text" xml:space="preserve">
-    <value>èŠ‚ç‚¹æ²™ç›’å·²å¼€å¯</value>
+    <value>节点沙盒已开启</value>
   </data>
   <data name="SandboxPage_ProgramsTheAgentRuns.Text" xml:space="preserve">
-    <value>ä»£ç†åœ¨æ­¤ç”µè„‘ä¸Šè¿è¡Œçš„ç¨‹åºå—åˆ°éš”ç¦»ã€‚</value>
+    <value>代理在此电脑上运行的程序受到隔离。</value>
   </data>
   <data name="SandboxPage_WhatGetsContained.Text" xml:space="preserve">
-    <value>å“ªäº›å†…å®¹å—éš”ç¦»</value>
+    <value>哪些内容受隔离</value>
   </data>
   <data name="SandboxPage_SeeWhichCommandsThis.Text" xml:space="preserve">
     <value>查看此页面涵盖的命令 — 以及需要其他控件的命令。</value>
   </data>
   <data name="SandboxPage_CommandsTheAgentRuns.Text" xml:space="preserve">
-    <value>ä»£ç†é€šè¿‡ Windows èŠ‚ç‚¹è¿è¡Œçš„å‘½ä»¤ (</value>
+    <value>代理通过 Windows 节点运行的命令 (</value>
   </data>
   <data name="SandboxPage_SystemRun.Text" xml:space="preserve">
     <value>system.run</value>
   </data>
   <data name="SandboxPage_AreContainedByThe.Text" xml:space="preserve">
-    <value>) å—ä¸‹é¢çš„è®¾ç½®éš”ç¦»ã€‚</value>
+    <value>) 受下面的设置隔离。</value>
   </data>
   <data name="SandboxPage_CommandsTheAgentRuns2.Text" xml:space="preserve">
     <value>代理直接在网关上运行的命令不受隔离。如果网关位于此电脑的 WSL 上,它们可能会访问您的 Windows 文件、剪贴板和网络 — 请使用网关的执行审批。</value>
   </data>
   <data name="SandboxPage_SandboxUnavailable.Title" xml:space="preserve">
-    <value>æ²™ç›’ä¸å¯ç”¨</value>
+    <value>沙盒不可用</value>
   </data>
   <data name="SandboxPage_LearnMoreAboutMXC.Content" xml:space="preserve">
-    <value>è¯¦ç»†äº†è§£ MXC æ²™ç›’</value>
+    <value>详细了解 MXC 沙盒</value>
   </data>
   <data name="SandboxPage_SecurityLevel.Text" xml:space="preserve">
-    <value>å®‰å…¨çº§åˆ«</value>
+    <value>安全级别</value>
   </data>
   <data name="SandboxPage_OneClickToSet.Text" xml:space="preserve">
-    <value>ä¸€é”®è®¾ç½®ä¸‹é¢çš„æ¯ä¸ªæŽ§ä»¶ã€‚è‡ªå®šä¹‰æ–‡ä»¶å¤¹ä¿æŒæ‚¨çš„è®¾ç½®ã€‚</value>
+    <value>一键设置下面的每个控件。自定义文件夹保持您的设置。</value>
   </data>
   <data name="SandboxPage_LockedDown.Text" xml:space="preserve">
     <value>🔒 锁定</value>
   </data>
   <data name="SandboxPage_NoInternetNoClipboard.Text" xml:space="preserve">
-    <value>æ— äº’è”ç½‘ã€æ— å‰ªè´´æ¿ã€æ— æ ‡å‡†ç”¨æˆ·æ–‡ä»¶å¤¹ã€‚</value>
+    <value>无互联网、无剪贴板、无标准用户文件夹。</value>
   </data>
   <data name="SandboxPage_Recommended.Text" xml:space="preserve">
     <value>🛡 推荐</value>
@@ -4177,82 +4177,82 @@
     <value>互联网开启。对“文档”、“下载”、“桌面”可读写。剪贴板可读写。</value>
   </data>
   <data name="SandboxPage_CustomFolderGrantsStill.Title" xml:space="preserve">
-    <value>è‡ªå®šä¹‰æ–‡ä»¶å¤¹æŽˆæƒä»ç„¶æœ‰æ•ˆ</value>
+    <value>自定义文件夹授权仍然有效</value>
   </data>
   <data name="SandboxPage_Files.Text" xml:space="preserve">
     <value>📁 文件</value>
   </data>
   <data name="SandboxPage_ByDefaultTheAgent.Text" xml:space="preserve">
-    <value>é»˜è®¤æƒ…å†µä¸‹,ä»£ç†åªæœ‰ä¸€ä¸ªå¯è¯»å†™çš„ä¸´æ—¶å·¥ä½œåŒºæ–‡ä»¶å¤¹ã€‚åœ¨ä¸‹æ–¹æŽˆäºˆå¯¹ç”¨æˆ·æ–‡ä»¶å¤¹çš„è®¿é—®æƒé™ã€‚SSH å¯†é’¥ã€æµè§ˆå™¨é…ç½®æ–‡ä»¶å’Œ OpenClaw è‡ªèº«çš„è®¾ç½®å§‹ç»ˆè¢«é˜»æ­¢ã€‚</value>
+    <value>默认情况下,代理只有一个可读写的临时工作区文件夹。在下方授予对用户文件夹的访问权限。SSH 密钥、浏览器配置文件和 OpenClaw 自身的设置始终被阻止。</value>
   </data>
   <data name="SandboxPage_Documents.Text" xml:space="preserve">
-    <value>æ–‡æ¡£</value>
+    <value>文档</value>
   </data>
   <data name="SandboxPage_Blocked.Content" xml:space="preserve">
-    <value>å·²é˜»æ­¢</value>
+    <value>已阻止</value>
   </data>
   <data name="SandboxPage_ReadOnly.Content" xml:space="preserve">
-    <value>åªè¯»</value>
+    <value>只读</value>
   </data>
   <data name="SandboxPage_ReadAmpWrite.Content" xml:space="preserve">
-    <value>è¯»å–ä¸Žå†™å…¥</value>
+    <value>读取与写入</value>
   </data>
   <data name="SandboxPage_Downloads.Text" xml:space="preserve">
-    <value>ä¸‹è½½</value>
+    <value>下载</value>
   </data>
   <data name="SandboxPage_Blocked2.Content" xml:space="preserve">
-    <value>å·²é˜»æ­¢</value>
+    <value>已阻止</value>
   </data>
   <data name="SandboxPage_ReadOnly2.Content" xml:space="preserve">
-    <value>åªè¯»</value>
+    <value>只读</value>
   </data>
   <data name="SandboxPage_ReadAmpWrite2.Content" xml:space="preserve">
-    <value>è¯»å–ä¸Žå†™å…¥</value>
+    <value>读取与写入</value>
   </data>
   <data name="SandboxPage_Desktop.Text" xml:space="preserve">
-    <value>æ¡Œé¢</value>
+    <value>桌面</value>
   </data>
   <data name="SandboxPage_Blocked3.Content" xml:space="preserve">
-    <value>å·²é˜»æ­¢</value>
+    <value>已阻止</value>
   </data>
   <data name="SandboxPage_ReadOnly3.Content" xml:space="preserve">
-    <value>åªè¯»</value>
+    <value>只读</value>
   </data>
   <data name="SandboxPage_ReadAmpWrite3.Content" xml:space="preserve">
-    <value>è¯»å–ä¸Žå†™å…¥</value>
+    <value>读取与写入</value>
   </data>
   <data name="SandboxPage_ToolDirectoriesOnYour.Text" xml:space="preserve">
-    <value>PATH ä¸Šçš„å·¥å…·ç›®å½•åœ¨æ²™ç›’å†…ä¹Ÿä»¥åªè¯»æ–¹å¼æŽˆäºˆ,å› æ­¤ gitã€nodeã€python å’Œ dotnet ç­‰å‘½ä»¤è¡Œå·¥å…·å¯ç”¨ã€‚ä»Žä¸æŽˆäºˆé©±åŠ¨å™¨æ ¹ç›®å½•ã€‚</value>
+    <value>PATH 上的工具目录在沙盒内也以只读方式授予,因此 git、node、python 和 dotnet 等命令行工具可用。从不授予驱动器根目录。</value>
   </data>
   <data name="SandboxPage_CustomFolders.Text" xml:space="preserve">
-    <value>è‡ªå®šä¹‰æ–‡ä»¶å¤¹</value>
+    <value>自定义文件夹</value>
   </data>
   <data name="SandboxPage_CustomGrantsAreAdded.Text" xml:space="preserve">
     <value>自定义授权将在上述规则之上添加。在“文档/下载/桌面”内添加具有更宽访问权限的文件夹,将覆盖该路径的行级设置。</value>
   </data>
   <data name="SandboxPage_Blocked4.Content" xml:space="preserve">
-    <value>å·²é˜»æ­¢</value>
+    <value>已阻止</value>
   </data>
   <data name="SandboxPage_ReadOnly4.Content" xml:space="preserve">
-    <value>åªè¯»</value>
+    <value>只读</value>
   </data>
   <data name="SandboxPage_ReadAmpWrite4.Content" xml:space="preserve">
-    <value>è¯»å–ä¸Žå†™å…¥</value>
+    <value>读取与写入</value>
   </data>
   <data name="SandboxPage_NoCustomFoldersAdded.Text" xml:space="preserve">
-    <value>å°šæœªæ·»åŠ è‡ªå®šä¹‰æ–‡ä»¶å¤¹ã€‚</value>
+    <value>尚未添加自定义文件夹。</value>
   </data>
   <data name="SandboxPage_AddFolder.Content" xml:space="preserve">
-    <value>æ·»åŠ æ–‡ä»¶å¤¹</value>
+    <value>添加文件夹</value>
   </data>
   <data name="SandboxPage_Clipboard.Text" xml:space="preserve">
     <value>📋 剪贴板</value>
   </data>
   <data name="SandboxPage_ClipboardOftenContainsPasswords.Text" xml:space="preserve">
-    <value>å‰ªè´´æ¿é€šå¸¸åŒ…å«å¯†ç ã€ä»¤ç‰Œå’Œç§äººæ–‡æœ¬ã€‚è¯»å–æƒé™å¯èƒ½å°†è¿™äº›æ³„éœ²ç»™ä»£ç†(è‹¥å¯ç”¨,ä¹Ÿä¼šæ³„éœ²åˆ°äº’è”ç½‘)ã€‚</value>
+    <value>剪贴板通常包含密码、令牌和私人文本。读取权限可能将这些泄露给代理(若启用,也会泄露到互联网)。</value>
   </data>
   <data name="SandboxPage_NoneDefault.Content" xml:space="preserve">
-    <value>æ— (é»˜è®¤)</value>
+    <value>无(默认)</value>
   </data>
   <data name="SandboxPage_ReadAgentCanSee.Content" xml:space="preserve">
     <value>读取 — 代理可以看到您复制的内容</value>
@@ -4261,34 +4261,34 @@
     <value>写入 — 代理可以替换您的剪贴板(无法读取)</value>
   </data>
   <data name="SandboxPage_ReadAmpWrite5.Content" xml:space="preserve">
-    <value>è¯»å–ä¸Žå†™å…¥</value>
+    <value>读取与写入</value>
   </data>
   <data name="SandboxPage_Network.Text" xml:space="preserve">
     <value>📡 网络</value>
   </data>
   <data name="SandboxPage_AllowInternet.Header" xml:space="preserve">
-    <value>å…è®¸äº’è”ç½‘</value>
+    <value>允许互联网</value>
   </data>
   <data name="SandboxPage_IfFileOrClipboard.Text" xml:space="preserve">
-    <value>å¦‚æžœå¯ç”¨æ–‡ä»¶æˆ–å‰ªè´´æ¿è¯»å–æƒé™,ä»£ç†å¯èƒ½ä¼šé€šè¿‡äº’è”ç½‘å‘é€è¿™äº›æ•°æ®ã€‚</value>
+    <value>如果启用文件或剪贴板读取权限,代理可能会通过互联网发送这些数据。</value>
   </data>
   <data name="SandboxPage_LocalNetworkDevicesAnd.Text" xml:space="preserve">
-    <value>æœ¬åœ°ç½‘ç»œè®¾å¤‡å’Œå…±äº«å°šæœªåŒ…å«åœ¨å†…ã€‚</value>
+    <value>本地网络设备和共享尚未包含在内。</value>
   </data>
   <data name="SandboxPage_Limits.Text" xml:space="preserve">
     <value>⏱ 限制</value>
   </data>
   <data name="SandboxPage_CommandTimeout30Sec.Text" xml:space="preserve">
-    <value>å‘½ä»¤è¶…æ—¶:30 ç§’</value>
+    <value>命令超时:30 秒</value>
   </data>
   <data name="SandboxPage_MaximumCapturedOutputTruncates.Text" xml:space="preserve">
-    <value>æœ€å¤§æ•èŽ·è¾“å‡º(è¶…è¿‡æ­¤å€¼å°†è¢«æˆªæ–­;ä¸é™åˆ¶ç£ç›˜ã€å†…å­˜æˆ– CPU):</value>
+    <value>最大捕获输出(超过此值将被截断;不限制磁盘、内存或 CPU):</value>
   </data>
   <data name="SandboxPage_1MiB.Content" xml:space="preserve">
     <value>1 MiB</value>
   </data>
   <data name="SandboxPage_4MiBDefault.Content" xml:space="preserve">
-    <value>4 MiB(é»˜è®¤)</value>
+    <value>4 MiB(默认)</value>
   </data>
   <data name="SandboxPage_16MiB.Content" xml:space="preserve">
     <value>16 MiB</value>
@@ -4297,190 +4297,190 @@
     <value>64 MiB</value>
   </data>
   <data name="SessionsPage_BackToConnection.Text" xml:space="preserve">
-    <value>è¿”å›žè¿žæŽ¥</value>
+    <value>返回连接</value>
   </data>
   <data name="SessionsPage_Sessions.Text" xml:space="preserve">
-    <value>ä¼šè¯</value>
+    <value>会话</value>
   </data>
   <data name="SessionsPage_Refresh.Text" xml:space="preserve">
-    <value>åˆ·æ–°</value>
+    <value>刷新</value>
   </data>
   <data name="SessionsPage_All.Text" xml:space="preserve">
-    <value>å…¨éƒ¨</value>
+    <value>全部</value>
   </data>
   <data name="SessionsPage_GatewayDisconnected.Title" xml:space="preserve">
-    <value>ç½‘å…³å·²æ–­å¼€</value>
+    <value>网关已断开</value>
   </data>
   <data name="SessionsPage_GatewayDisconnected.Message" xml:space="preserve">
-    <value>è¯·è¿žæŽ¥åˆ°ç½‘å…³ä»¥åŠ è½½ä¼šè¯ã€‚</value>
+    <value>请连接到网关以加载会话。</value>
   </data>
   <data name="SessionsPage_OpenConnection.Content" xml:space="preserve">
-    <value>æ‰“å¼€è¿žæŽ¥</value>
+    <value>打开连接</value>
   </data>
   <data name="SessionsPage_LoadingSessions.Text" xml:space="preserve">
     <value>正在加载会话…</value>
   </data>
   <data name="SessionsPage_NoActiveSessions.Text" xml:space="preserve">
-    <value>æ— æ´»åŠ¨ä¼šè¯</value>
+    <value>无活动会话</value>
   </data>
   <data name="SessionsPage_Reset.Text" xml:space="preserve">
-    <value>é‡ç½®</value>
+    <value>重置</value>
   </data>
   <data name="SessionsPage_Compact.Text" xml:space="preserve">
-    <value>åŽ‹ç¼©</value>
+    <value>压缩</value>
   </data>
   <data name="SessionsPage_Delete.Text" xml:space="preserve">
-    <value>åˆ é™¤</value>
+    <value>删除</value>
   </data>
   <data name="SettingsPage_Settings.Text" xml:space="preserve">
-    <value>è®¾ç½®</value>
+    <value>设置</value>
   </data>
   <data name="SettingsPage_General.Text" xml:space="preserve">
-    <value>å¸¸è§„</value>
+    <value>常规</value>
   </data>
   <data name="SettingsPage_Notifications.Text" xml:space="preserve">
-    <value>é€šçŸ¥</value>
+    <value>通知</value>
   </data>
   <data name="SettingsPage_Privacy.Text" xml:space="preserve">
-    <value>éšç§</value>
+    <value>隐私</value>
   </data>
   <data name="SettingsPage_LocalGateway.Text" xml:space="preserve">
-    <value>æœ¬åœ°ç½‘å…³</value>
+    <value>本地网关</value>
   </data>
   <data name="SettingsPage_MSIXInstallationDetected.Title" xml:space="preserve">
-    <value>æ£€æµ‹åˆ° MSIX å®‰è£…</value>
+    <value>检测到 MSIX 安装</value>
   </data>
   <data name="SettingsPage_MSIXInstallationDetected.Message" xml:space="preserve">
     <value>通过 Windows 设置 &amp;amp;#x2192; 应用删除 OpenClaw 不会清理本地网关(WSL 发行版、磁盘映像)。请先使用下面的“删除本地网关”,然后再卸载 OpenClaw。</value>
   </data>
   <data name="SettingsPage_RemovesTheWSLDistro.Text" xml:space="preserve">
-    <value>åˆ é™¤ WSL å‘è¡Œç‰ˆ (OpenClawGateway)ã€å…¶ç£ç›˜æ˜ åƒã€è‡ªåŠ¨å¯åŠ¨é¡¹,å¹¶æ¸…é™¤ç½‘å…³å‡­æ®ã€‚æ‚¨çš„ MCP ä»¤ç‰Œå°†è¢«ä¿ç•™ã€‚å¼•å¯¼å°†é‡ç½®ã€‚</value>
+    <value>删除 WSL 发行版 (OpenClawGateway)、其磁盘映像、自动启动项,并清除网关凭据。您的 MCP 令牌将被保留。引导将重置。</value>
   </data>
   <data name="SettingsPage_RemoveLocalGateway.Content" xml:space="preserve">
-    <value>åˆ é™¤æœ¬åœ°ç½‘å…³</value>
+    <value>删除本地网关</value>
   </data>
   <data name="SettingsPage_Saved.Title" xml:space="preserve">
-    <value>å·²ä¿å­˜</value>
+    <value>已保存</value>
   </data>
   <data name="SkillsPage_Skills.Text" xml:space="preserve">
     <value>🧩 技能</value>
   </data>
   <data name="SkillsPage_AllAgents.Content" xml:space="preserve">
-    <value>æ‰€æœ‰ä»£ç†</value>
+    <value>所有代理</value>
   </data>
   <data name="SkillsPage_Enabled.Text" xml:space="preserve">
-    <value>å·²å¯ç”¨</value>
+    <value>已启用</value>
   </data>
   <data name="SkillsPage_Disabled.Text" xml:space="preserve">
-    <value>å·²ç¦ç”¨</value>
+    <value>已禁用</value>
   </data>
   <data name="SkillsPage_LoadingSkills.Text" xml:space="preserve">
     <value>正在加载技能…</value>
   </data>
   <data name="SkillsPage_NoSkillsInstalled.Text" xml:space="preserve">
-    <value>æœªå®‰è£…æŠ€èƒ½</value>
+    <value>未安装技能</value>
   </data>
   <data name="SkillsPage_SkillsExtendYourAgent.Text" xml:space="preserve">
-    <value>æŠ€èƒ½æ‰©å±•ä»£ç†çš„èƒ½åŠ›ã€‚é€šè¿‡ CLI æˆ– ClawHub å®‰è£…æŠ€èƒ½ã€‚</value>
+    <value>技能扩展代理的能力。通过 CLI 或 ClawHub 安装技能。</value>
   </data>
   <data name="UsagePage_GatewayDisconnected.Title" xml:space="preserve">
-    <value>ç½‘å…³å·²æ–­å¼€</value>
+    <value>网关已断开</value>
   </data>
   <data name="UsagePage_GatewayDisconnected.Message" xml:space="preserve">
-    <value>è¯·è¿žæŽ¥åˆ°ç½‘å…³ä»¥åŠ è½½ç”¨é‡æ•°æ®ã€‚</value>
+    <value>请连接到网关以加载用量数据。</value>
   </data>
   <data name="UsagePage_OpenConnection.Content" xml:space="preserve">
-    <value>æ‰“å¼€è¿žæŽ¥</value>
+    <value>打开连接</value>
   </data>
   <data name="UsagePage_LoadingDailyCosts.Text" xml:space="preserve">
     <value>正在加载每日费用…</value>
   </data>
   <data name="UsagePage_NoDailyUsageFor.Text" xml:space="preserve">
-    <value>æ­¤æœŸé—´å†…æ— æ¯æ—¥ç”¨é‡</value>
+    <value>此期间内无每日用量</value>
   </data>
   <data name="VoiceSettingsPage_TestVoiceInput.Text" xml:space="preserve">
-    <value>æµ‹è¯•è¯­éŸ³è¾“å…¥</value>
+    <value>测试语音输入</value>
   </data>
   <data name="VoiceSettingsPage_Record.Text" xml:space="preserve">
-    <value>å½•åˆ¶</value>
+    <value>录制</value>
   </data>
   <data name="WorkspacePage_LoadingWorkspaceFiles.Text" xml:space="preserve">
     <value>正在加载工作区文件…</value>
   </data>
   <data name="ChatWindow_WebChatUnavailable.Text" xml:space="preserve">
-    <value>ç½‘é¡µèŠå¤©ä¸å¯ç”¨</value>
+    <value>网页聊天不可用</value>
   </data>
   <data name="ChatWindow_Retry.Content" xml:space="preserve">
-    <value>é‡è¯•</value>
+    <value>重试</value>
   </data>
   <data name="ConnectionStatusWindow_ConnectionStatus.Text" xml:space="preserve">
-    <value>è¿žæŽ¥çŠ¶æ€</value>
+    <value>连接状态</value>
   </data>
   <data name="ConnectionStatusWindow_STATEMACHINE.Text" xml:space="preserve">
-    <value>çŠ¶æ€æœº</value>
+    <value>状态机</value>
   </data>
   <data name="ConnectionStatusWindow_OPERATOR.Text" xml:space="preserve">
-    <value>æ“ä½œå‘˜</value>
+    <value>操作员</value>
   </data>
   <data name="ConnectionStatusWindow_Off.Text" xml:space="preserve">
-    <value>å…³é—­</value>
+    <value>关闭</value>
   </data>
   <data name="ConnectionStatusWindow_Connecting.Text" xml:space="preserve">
-    <value>æ­£åœ¨è¿žæŽ¥</value>
+    <value>正在连接</value>
   </data>
   <data name="ConnectionStatusWindow_Connected.Text" xml:space="preserve">
-    <value>å·²è¿žæŽ¥</value>
+    <value>已连接</value>
   </data>
   <data name="ConnectionStatusWindow_Pairing.Text" xml:space="preserve">
-    <value>æ­£åœ¨é…å¯¹</value>
+    <value>正在配对</value>
   </data>
   <data name="ConnectionStatusWindow_Error.Text" xml:space="preserve">
-    <value>é”™è¯¯</value>
+    <value>错误</value>
   </data>
   <data name="ConnectionStatusWindow_NODE.Text" xml:space="preserve">
-    <value>èŠ‚ç‚¹</value>
+    <value>节点</value>
   </data>
   <data name="ConnectionStatusWindow_Off2.Text" xml:space="preserve">
-    <value>å…³é—­</value>
+    <value>关闭</value>
   </data>
   <data name="ConnectionStatusWindow_Connecting2.Text" xml:space="preserve">
-    <value>æ­£åœ¨è¿žæŽ¥</value>
+    <value>正在连接</value>
   </data>
   <data name="ConnectionStatusWindow_Connected2.Text" xml:space="preserve">
-    <value>å·²è¿žæŽ¥</value>
+    <value>已连接</value>
   </data>
   <data name="ConnectionStatusWindow_Pairing2.Text" xml:space="preserve">
-    <value>æ­£åœ¨é…å¯¹</value>
+    <value>正在配对</value>
   </data>
   <data name="ConnectionStatusWindow_Error2.Text" xml:space="preserve">
-    <value>é”™è¯¯</value>
+    <value>错误</value>
   </data>
   <data name="ConnectionStatusWindow_GATEWAYS.Text" xml:space="preserve">
-    <value>ç½‘å…³</value>
+    <value>网关</value>
   </data>
   <data name="ConnectionStatusWindow_CREDENTIALS.Text" xml:space="preserve">
-    <value>å‡­æ®</value>
+    <value>凭据</value>
   </data>
   <data name="ConnectionStatusWindow_SETUPCODE.Text" xml:space="preserve">
-    <value>è®¾ç½®ä»£ç </value>
+    <value>设置代码</value>
   </data>
   <data name="ConnectionStatusWindow_PasteASetupCode.Text" xml:space="preserve">
-    <value>ç²˜è´´è®¾ç½®ä»£ç ä»¥å»ºç«‹ç«¯åˆ°ç«¯è¿žæŽ¥ã€‚</value>
+    <value>粘贴设置代码以建立端到端连接。</value>
   </data>
   <data name="ConnectionStatusWindow_PasteSetupCode.PlaceholderText" xml:space="preserve">
     <value>粘贴设置代码…</value>
   </data>
   <data name="ConnectionStatusWindow_Connect.Content" xml:space="preserve">
-    <value>è¿žæŽ¥</value>
+    <value>连接</value>
   </data>
   <data name="ConnectionStatusWindow_Disconnect.Content" xml:space="preserve">
-    <value>æ–­å¼€è¿žæŽ¥</value>
+    <value>断开连接</value>
   </data>
   <data name="ConnectionStatusWindow_DIRECTCONNECT.Text" xml:space="preserve">
-    <value>ç›´æŽ¥è¿žæŽ¥</value>
+    <value>直接连接</value>
   </data>
   <data name="ConnectionStatusWindow_ConnectWithAGateway.Text" xml:space="preserve">
-    <value>ä½¿ç”¨ç½‘å…³ URL å’Œå…±äº«ä»¤ç‰Œ(ç®¡ç†å‘˜èŒƒå›´)è¿žæŽ¥ã€‚</value>
+    <value>使用网关 URL 和共享令牌(管理员范围)连接。</value>
   </data>
   <data name="ConnectionStatusWindow_WsLocalhost18790.PlaceholderText" xml:space="preserve">
     <value>ws://localhost:18790</value>
@@ -4489,65 +4489,65 @@
     <value>ws://localhost:18790</value>
   </data>
   <data name="ConnectionStatusWindow_WsLocalhost18790.Header" xml:space="preserve">
-    <value>ç½‘å…³ URL</value>
+    <value>网关 URL</value>
   </data>
   <data name="ConnectionStatusWindow_SharedGatewayToken.PlaceholderText" xml:space="preserve">
-    <value>å…±äº«ç½‘å…³ä»¤ç‰Œ</value>
+    <value>共享网关令牌</value>
   </data>
   <data name="ConnectionStatusWindow_SharedGatewayToken.Header" xml:space="preserve">
-    <value>ä»¤ç‰Œ</value>
+    <value>令牌</value>
   </data>
   <data name="ConnectionStatusWindow_Connect2.Content" xml:space="preserve">
-    <value>è¿žæŽ¥</value>
+    <value>连接</value>
   </data>
   <data name="ConnectionStatusWindow_SSHTunnel.Header" xml:space="preserve">
-    <value>SSH éš§é“</value>
+    <value>SSH 隧道</value>
   </data>
   <data name="ConnectionStatusWindow_SSHUser.Header" xml:space="preserve">
-    <value>SSH ç”¨æˆ·</value>
+    <value>SSH 用户</value>
   </data>
   <data name="ConnectionStatusWindow_SSHUser.PlaceholderText" xml:space="preserve">
     <value>user</value>
   </data>
   <data name="ConnectionStatusWindow_SSHHost.Header" xml:space="preserve">
-    <value>SSH ä¸»æœº</value>
+    <value>SSH 主机</value>
   </data>
   <data name="ConnectionStatusWindow_SSHHost.PlaceholderText" xml:space="preserve">
     <value>192.168.x.x</value>
   </data>
   <data name="ConnectionStatusWindow_RemotePort.Header" xml:space="preserve">
-    <value>è¿œç¨‹ç«¯å£</value>
+    <value>远程端口</value>
   </data>
   <data name="ConnectionStatusWindow_LocalPort.Header" xml:space="preserve">
-    <value>æœ¬åœ°ç«¯å£</value>
+    <value>本地端口</value>
   </data>
   <data name="ConnectionStatusWindow_EVENTTIMELINE.Text" xml:space="preserve">
-    <value>äº‹ä»¶æ—¶é—´çº¿</value>
+    <value>事件时间线</value>
   </data>
   <data name="ConnectionStatusWindow_Copy.Content" xml:space="preserve">
-    <value>å¤åˆ¶</value>
+    <value>复制</value>
   </data>
   <data name="ConnectionStatusWindow_Clear.Content" xml:space="preserve">
-    <value>æ¸…é™¤</value>
+    <value>清除</value>
   </data>
   <data name="DiagnosticsBundleDialog_DiagnosticsBundle.Title" xml:space="preserve">
-    <value>è¯Šæ–­åŒ…</value>
+    <value>诊断包</value>
   </data>
   <data name="DiagnosticsBundleDialog_ReviewBeforeSharing.Title" xml:space="preserve">
-    <value>åˆ†äº«å‰è¯·å®¡é˜…</value>
+    <value>分享前请审阅</value>
   </data>
   <data name="DiagnosticsBundleDialog_ReviewBeforeSharing.Message" xml:space="preserve">
-    <value>æ†ç»‘åŒ…ç”Ÿæˆå™¨ä¼šæŽ’é™¤æ•æ„Ÿä»¤ç‰Œã€å‘½ä»¤å‚æ•°ã€è´Ÿè½½å’Œå½•åˆ¶å†…å®¹ã€‚</value>
+    <value>捆绑包生成器会排除敏感令牌、命令参数、负载和录制内容。</value>
   </data>
   <data name="HubWindow_Disconnected.Text" xml:space="preserve">
-    <value>å·²æ–­å¼€è¿žæŽ¥</value>
+    <value>已断开连接</value>
   </data>
   <data name="HubWindow_Op.Text" xml:space="preserve">
-    <value>æ“ä½œ</value>
+    <value>操作</value>
   </data>
   <data name="HubWindow_Node.Text" xml:space="preserve">
-    <value>èŠ‚ç‚¹</value>
+    <value>节点</value>
   </data>
   <data name="HubWindow_Advanced.Content" xml:space="preserve">
-    <value>é«˜çº§</value>
+    <value>高级</value>
   </data></root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -18,262 +18,262 @@
     </xs:element>
   </xs:schema>
   <data name="SettingsConnectionHeader.Text" xml:space="preserve">
-    <value>é€£ç·š</value>
+    <value>連線</value>
   </data>
   <data name="SettingsStartupHeader.Text" xml:space="preserve">
-    <value>å•Ÿå‹•</value>
+    <value>啟動</value>
   </data>
   <data name="SettingsNotificationsHeader.Text" xml:space="preserve">
-    <value>é€šçŸ¥</value>
+    <value>通知</value>
   </data>
   <data name="SettingsAdvancedHeader.Text" xml:space="preserve">
-    <value>é«˜ç´šï¼ˆå¯¦é©—æ€§ï¼‰</value>
+    <value>高級（實驗性）</value>
   </data>
   <data name="SettingsGatewayUrlTextBox.Header" xml:space="preserve">
-    <value>é–˜é“å™¨åœ°å€</value>
+    <value>閘道器地址</value>
   </data>
   <data name="SettingsGatewayUrlTextBox.PlaceholderText" xml:space="preserve">
-    <value>ws://localhost:18789 æˆ– https://host.tailnet.ts.net</value>
+    <value>ws://localhost:18789 或 https://host.tailnet.ts.net</value>
   </data>
   <data name="SettingsTokenTextBox.Header" xml:space="preserve">
-    <value>æ¬Šæ–</value>
+    <value>權杖</value>
   </data>
   <data name="SettingsTokenTextBox.PlaceholderText" xml:space="preserve">
-    <value>æ‚¨çš„ API Token</value>
+    <value>您的 API Token</value>
   </data>
   <data name="SettingsAutoStartToggle.Header" xml:space="preserve">
-    <value>é–‹æ©Ÿè‡ªå•Ÿå‹•</value>
+    <value>開機自啟動</value>
   </data>
   <data name="SettingsGlobalHotkeyToggle.Header" xml:space="preserve">
     <value>全域性快捷鍵 (Ctrl+Alt+Shift+C → 快速發送)</value>
   </data>
   <data name="SettingsNotificationsToggle.Header" xml:space="preserve">
-    <value>é¡¯ç¤ºé€šçŸ¥</value>
+    <value>顯示通知</value>
   </data>
   <data name="SettingsNodeModeToggle.Header" xml:space="preserve">
-    <value>å•Ÿç”¨ç¯€é»žæ¨¡å¼</value>
+    <value>啟用節點模式</value>
   </data>
   <data name="SettingsSoundComboBox.Header" xml:space="preserve">
-    <value>æç¤ºéŸ³</value>
+    <value>提示音</value>
   </data>
   <data name="SettingsSoundDefault.Content" xml:space="preserve">
-    <value>é è¨­</value>
+    <value>預設</value>
   </data>
   <data name="SettingsSoundNone.Content" xml:space="preserve">
-    <value>ç„¡</value>
+    <value>無</value>
   </data>
   <data name="SettingsSoundSubtle.Content" xml:space="preserve">
-    <value>æŸ”å’Œ</value>
+    <value>柔和</value>
   </data>
   <data name="SettingsNotifyForLabel.Text" xml:space="preserve">
-    <value>é¡¯ç¤ºä»¥ä¸‹åž‹åˆ¥é€šçŸ¥:</value>
+    <value>顯示以下型別通知:</value>
   </data>
   <data name="SettingsNotifyFilterHint.Text" xml:space="preserve">
-    <value>æŒ‰è¨Šæ¯ä¸­çš„é—œéµè©žéŽæ¿¾ï¼ˆä¾‹å¦‚"éƒµä»¶"ã€"æé†’"ï¼‰</value>
+    <value>按訊息中的關鍵詞過濾（例如"郵件"、"提醒"）</value>
   </data>
   <data name="SettingsNotifyHealthCb.Content" xml:space="preserve">
-    <value>å¥åº·è­¦å ±</value>
+    <value>健康警報</value>
   </data>
   <data name="SettingsNotifyUrgentCb.Content" xml:space="preserve">
-    <value>ç·Šæ€¥è¨Šæ¯</value>
+    <value>緊急訊息</value>
   </data>
   <data name="SettingsNotifyReminderCb.Content" xml:space="preserve">
-    <value>æé†’</value>
+    <value>提醒</value>
   </data>
   <data name="SettingsNotifyEmailCb.Content" xml:space="preserve">
-    <value>éƒµä»¶æ‘˜è¦</value>
+    <value>郵件摘要</value>
   </data>
   <data name="SettingsNotifyCalendarCb.Content" xml:space="preserve">
-    <value>æ—¥æ›†äº‹ä»¶</value>
+    <value>日曆事件</value>
   </data>
   <data name="SettingsNotifyBuildCb.Content" xml:space="preserve">
-    <value>æ§‹å»ºé€šçŸ¥</value>
+    <value>構建通知</value>
   </data>
   <data name="SettingsNotifyStockCb.Content" xml:space="preserve">
-    <value>è‚¡ç¥¨æé†’</value>
+    <value>股票提醒</value>
   </data>
   <data name="SettingsNotifyInfoCb.Content" xml:space="preserve">
-    <value>å¸¸è¦è³‡è¨Š</value>
+    <value>常規資訊</value>
   </data>
   <data name="SettingsTestConnectionButton.Content" xml:space="preserve">
-    <value>æ¸¬è©¦</value>
+    <value>測試</value>
   </data>
   <data name="SettingsTestNotificationButton.Content" xml:space="preserve">
-    <value>ç™¼é€æ¸¬è©¦é€šçŸ¥</value>
+    <value>發送測試通知</value>
   </data>
   <data name="SettingsSaveButton.Content" xml:space="preserve">
-    <value>å„²å­˜</value>
+    <value>儲存</value>
   </data>
   <data name="SettingsCancelButton.Content" xml:space="preserve">
-    <value>å–æ¶ˆ</value>
+    <value>取消</value>
   </data>
   <data name="SettingsNodeModeDescription.Text" xml:space="preserve">
-    <value>å•Ÿç”¨å¾Œï¼Œæ­¤é›»è…¦å¯ä»¥æŽ¥æ”¶ä¾†è‡ªä»£ç†çš„å‘½ä»¤ï¼ˆCanvasã€æˆªåœ–ç­‰ï¼‰</value>
+    <value>啟用後，此電腦可以接收來自代理的命令（Canvas、截圖等）</value>
   </data>
   <data name="StatusUsageHeader.Text" xml:space="preserve">
-    <value>ç”¨é‡</value>
+    <value>用量</value>
   </data>
   <data name="StatusSessionsHeader.Text" xml:space="preserve">
-    <value>æ´»èºæœƒè©±</value>
+    <value>活躍會話</value>
   </data>
   <data name="StatusChannelsHeader.Text" xml:space="preserve">
-    <value>é »é“</value>
+    <value>頻道</value>
   </data>
   <data name="StatusGatewayTopologyHeader.Text" xml:space="preserve">
-    <value>é–˜é“æ‹“æ’²</value>
+    <value>閘道拓撲</value>
   </data>
   <data name="StatusSupportDebugHeader.Text" xml:space="preserve">
-    <value>æ”¯æ´å’ŒåµéŒ¯</value>
+    <value>支援和偵錯</value>
   </data>
   <data name="StatusPortDiagnosticsHeader.Text" xml:space="preserve">
-    <value>é€£æŽ¥åŸ è¨ºæ–·</value>
+    <value>連接埠診斷</value>
   </data>
   <data name="StatusPermissionsHeader.Text" xml:space="preserve">
-    <value>æ¬Šé™</value>
+    <value>權限</value>
   </data>
   <data name="StatusCostTrendHeader.Text" xml:space="preserve">
-    <value>30 å¤©è²»ç”¨è¶¨å‹¢</value>
+    <value>30 天費用趨勢</value>
   </data>
   <data name="StatusExtensibilityHeader.Text" xml:space="preserve">
-    <value>æ“´å……æ€§</value>
+    <value>擴充性</value>
   </data>
   <data name="StatusNodesHeader.Text" xml:space="preserve">
-    <value>ç¯€é»ž</value>
+    <value>節點</value>
   </data>
   <data name="StatusRecentActivityHeader.Text" xml:space="preserve">
-    <value>æœ€è¿‘æ´»å‹•</value>
+    <value>最近活動</value>
   </data>
   <data name="StatusCostLabel.Text" xml:space="preserve">
-    <value>è²»ç”¨ï¼ˆè¦–çª—æœŸï¼‰:</value>
+    <value>費用（視窗期）:</value>
   </data>
   <data name="StatusRequestsLabel.Text" xml:space="preserve">
-    <value>è«‹æ±‚ / Tokenæ•¸:</value>
+    <value>請求 / Token數:</value>
   </data>
   <data name="StatusProvidersLabel.Text" xml:space="preserve">
-    <value>æä¾›è€…:</value>
+    <value>提供者:</value>
   </data>
   <data name="StatusConnectedText.Text" xml:space="preserve">
-    <value>å·²é€£ç·š</value>
+    <value>已連線</value>
   </data>
   <data name="StatusNoSessions.Text" xml:space="preserve">
-    <value>ç„¡æ´»èºæœƒè©±</value>
+    <value>無活躍會話</value>
   </data>
   <data name="StatusNoNodes.Text" xml:space="preserve">
-    <value>æœªå›žå ±ç¯€é»ž</value>
+    <value>未回報節點</value>
   </data>
   <data name="StatusNoRecentActivity.Text" xml:space="preserve">
-    <value>æ²’æœ‰æœ€è¿‘æ´»å‹•</value>
+    <value>沒有最近活動</value>
   </data>
   <data name="StatusExtensibilityDescription.Text" xml:space="preserve">
-    <value>é »é“è¨­å®šã€æŠ€èƒ½å’ŒæŽ’ç¨‹è‡ªå‹•åŒ–ç”±é–˜é“ç®¡ç†ã€‚é€£ç·šçš„é–˜é“å…¬é–‹ç›¸ç¬¦å„€è¡¨æ¿é é¢æ™‚ï¼Œè«‹ä½¿ç”¨é€™äº›é€£çµã€‚</value>
+    <value>頻道設定、技能和排程自動化由閘道管理。連線的閘道公開相符儀表板頁面時，請使用這些連結。</value>
   </data>
   <data name="StatusChannelSetupTitle.Text" xml:space="preserve">
-    <value>é »é“è¨­å®š / çµæ§‹æè¿°</value>
+    <value>頻道設定 / 結構描述</value>
   </data>
   <data name="StatusChannelSetupDescription.Text" xml:space="preserve">
-    <value>åœ¨å¯ç”¨æ™‚é–‹å•Ÿé »é“è¨­å®šï¼Œç”¨æ–¼çµæ§‹æè¿°å°Žå‘çš„é©—è­‰ã€QRã€ç™»å…¥å’Œå„€è¡¨æ¿æµç¨‹ã€‚</value>
+    <value>在可用時開啟頻道設定，用於結構描述導向的驗證、QR、登入和儀表板流程。</value>
   </data>
   <data name="StatusSkillsTitle.Text" xml:space="preserve">
-    <value>æŠ€èƒ½</value>
+    <value>技能</value>
   </data>
   <data name="StatusSkillsDescription.Text" xml:space="preserve">
-    <value>ç•¶é€£ç·šçš„é–˜é“æ”¯æ´æ™‚ï¼Œé–‹å•Ÿé–˜é“æŠ€èƒ½è¨­å®šã€‚</value>
+    <value>當連線的閘道支援時，開啟閘道技能設定。</value>
   </data>
   <data name="StatusCronTitle.Text" xml:space="preserve">
-    <value>Cron / æŽ’ç¨‹</value>
+    <value>Cron / 排程</value>
   </data>
   <data name="StatusCronDescription.Text" xml:space="preserve">
-    <value>ç•¶é€£ç·šçš„é–˜é“æ”¯æ´æ™‚ï¼Œé–‹å•ŸæŽ’ç¨‹è‡ªå‹•åŒ–æŽ§åˆ¶é …ã€‚</value>
+    <value>當連線的閘道支援時，開啟排程自動化控制項。</value>
   </data>
   <data name="StatusRefreshButton.Content" xml:space="preserve">
-    <value>é‡æ–°æ•´ç†</value>
+    <value>重新整理</value>
   </data>
   <data name="StatusOpenLogsButton.Content" xml:space="preserve">
-    <value>é–‹å•Ÿè¨˜éŒ„</value>
+    <value>開啟記錄</value>
   </data>
   <data name="StatusOpenConfigButton.Content" xml:space="preserve">
-    <value>é–‹å•Ÿè¨­å®š</value>
+    <value>開啟設定</value>
   </data>
   <data name="StatusRefreshHealthButton.Content" xml:space="preserve">
-    <value>é‡æ–°æ•´ç†å¥åº·ç‹€æ…‹</value>
+    <value>重新整理健康狀態</value>
   </data>
   <data name="StatusOpenDiagnosticsJsonlButton.Content" xml:space="preserve">
-    <value>é–‹å•Ÿè¨ºæ–· JSONL</value>
+    <value>開啟診斷 JSONL</value>
   </data>
   <data name="StatusCopySupportContextButton.Content" xml:space="preserve">
-    <value>è¤‡è£½æ”¯æ´å…§å®¹</value>
+    <value>複製支援內容</value>
   </data>
   <data name="StatusRestartSshTunnelButton.Content" xml:space="preserve">
-    <value>é‡æ–°å•Ÿå‹• SSH é€šé“</value>
+    <value>重新啟動 SSH 通道</value>
   </data>
   <data name="StatusCopyBrowserSetupButton.Content" xml:space="preserve">
-    <value>è¤‡è£½ç€è¦½å™¨è¨­å®š</value>
+    <value>複製瀏覽器設定</value>
   </data>
   <data name="StatusCopyDebugBundleButton.Content" xml:space="preserve">
-    <value>è¤‡è£½åµéŒ¯å¥—ä»¶</value>
+    <value>複製偵錯套件</value>
   </data>
   <data name="StatusCheckUpdatesButton.Content" xml:space="preserve">
-    <value>æª¢æŸ¥æ›´æ–°</value>
+    <value>檢查更新</value>
   </data>
   <data name="StatusCopyPortDiagnosticsButton.Content" xml:space="preserve">
-    <value>è¤‡è£½é€£æŽ¥åŸ è¨ºæ–·</value>
+    <value>複製連接埠診斷</value>
   </data>
   <data name="StatusCopyButton.Content" xml:space="preserve">
-    <value>è¤‡è£½</value>
+    <value>複製</value>
   </data>
   <data name="StatusSettingsButton.Content" xml:space="preserve">
-    <value>è¨­å®š</value>
+    <value>設定</value>
   </data>
   <data name="StatusOpenButton.Content" xml:space="preserve">
-    <value>é–‹å•Ÿ</value>
+    <value>開啟</value>
   </data>
   <data name="StatusCopyNodeInventoryButton.Content" xml:space="preserve">
-    <value>è¤‡è£½ç¯€é»žæ¸…å–®</value>
+    <value>複製節點清單</value>
   </data>
   <data name="StatusOpenStreamButton.Content" xml:space="preserve">
-    <value>é–‹å•Ÿä¸²æµ</value>
+    <value>開啟串流</value>
   </data>
   <data name="ActivityStreamTitle.Text" xml:space="preserve">
     <value>⚡ 串流活動</value>
   </data>
   <data name="ActivityFilterAll.Content" xml:space="preserve">
-    <value>å…¨éƒ¨æ´»å‹•</value>
+    <value>全部活動</value>
   </data>
   <data name="ActivityFilterSessions.Content" xml:space="preserve">
-    <value>æœƒè©±</value>
+    <value>會話</value>
   </data>
   <data name="ActivityFilterUsage.Content" xml:space="preserve">
-    <value>ç”¨é‡</value>
+    <value>用量</value>
   </data>
   <data name="ActivityFilterNodes.Content" xml:space="preserve">
-    <value>ç¯€é»ž</value>
+    <value>節點</value>
   </data>
   <data name="ActivityFilterNotifications.Content" xml:space="preserve">
-    <value>é€šçŸ¥</value>
+    <value>通知</value>
   </data>
   <data name="ActivityEmptyText.Text" xml:space="preserve">
-    <value>æš«ç„¡æ´»å‹•</value>
+    <value>暫無活動</value>
   </data>
   <data name="ActivityOpenDashboardButton.Content" xml:space="preserve">
-    <value>æ‰“é–‹å„€è¡¨æ¿</value>
+    <value>打開儀表板</value>
   </data>
   <data name="ActivityClearAllButton.Content" xml:space="preserve">
-    <value>å…¨éƒ¨æ¸…é™¤</value>
+    <value>全部清除</value>
   </data>
   <data name="ActivityCloseButton.Content" xml:space="preserve">
-    <value>é—œé–‰</value>
+    <value>關閉</value>
   </data>
   <data name="NotificationHistoryTitle.Text" xml:space="preserve">
     <value>📋 通知歷史</value>
   </data>
   <data name="NotificationEmptyText.Text" xml:space="preserve">
-    <value>æš«ç„¡é€šçŸ¥</value>
+    <value>暫無通知</value>
   </data>
   <data name="NotificationClearAllButton.Content" xml:space="preserve">
-    <value>å…¨éƒ¨æ¸…é™¤</value>
+    <value>全部清除</value>
   </data>
   <data name="NotificationCloseButton.Content" xml:space="preserve">
-    <value>é—œé–‰</value>
+    <value>關閉</value>
   </data>
   <data name="WindowTitle_Settings" xml:space="preserve">
     <value>設定 — OpenClaw 設定</value>
@@ -288,16 +288,16 @@
     <value>通知歷史 — OpenClaw 設定</value>
   </data>
   <data name="WindowTitle_WebChat" xml:space="preserve">
-    <value>OpenClaw èŠå¤©</value>
+    <value>OpenClaw 聊天</value>
   </data>
   <data name="WindowTitle_Welcome" xml:space="preserve">
-    <value>æ­¡è¿Žä½¿ç”¨ OpenClaw</value>
+    <value>歡迎使用 OpenClaw</value>
   </data>
   <data name="WindowTitle_Update" xml:space="preserve">
-    <value>OpenClaw æ›´æ–°</value>
+    <value>OpenClaw 更新</value>
   </data>
   <data name="Status_Testing" xml:space="preserve">
-    <value>æ¸¬è©¦ä¸­...</value>
+    <value>測試中...</value>
   </data>
   <data name="Status_Connected" xml:space="preserve">
     <value>✅ 連線成功！</value>
@@ -306,13 +306,13 @@
     <value>❌ 連線失敗</value>
   </data>
   <data name="Welcome_Title" xml:space="preserve">
-    <value>æ­¡è¿Žä½¿ç”¨ OpenClawï¼</value>
+    <value>歡迎使用 OpenClaw！</value>
   </data>
   <data name="Welcome_Description" xml:space="preserve">
-    <value>OpenClaw è¨­å®šæ˜¯ OpenClaw çš„ Windows ä¼´ä¾¶æ‡‰ç”¨ï¼Œä¸€å€‹ AI é©…å‹•çš„å€‹äººåŠ©æ‰‹ã€‚</value>
+    <value>OpenClaw 設定是 OpenClaw 的 Windows 伴侶應用，一個 AI 驅動的個人助手。</value>
   </data>
   <data name="Welcome_GettingStarted" xml:space="preserve">
-    <value>é–‹å§‹ä½¿ç”¨å‰ï¼Œæ‚¨éœ€è¦ï¼š</value>
+    <value>開始使用前，您需要：</value>
   </data>
   <data name="Welcome_NeedGateway" xml:space="preserve">
     <value>• 一個正在執行的 OpenClaw 閘道器</value>
@@ -324,90 +324,90 @@
     <value>📚 檢視文件</value>
   </data>
   <data name="Welcome_LaterButton" xml:space="preserve">
-    <value>ç¨å¾Œ</value>
+    <value>稍後</value>
   </data>
   <data name="Welcome_OpenSettingsButton" xml:space="preserve">
-    <value>æ‰“é–‹è¨­å®š</value>
+    <value>打開設定</value>
   </data>
   <data name="Update_VersionAvailable" xml:space="preserve">
     <value>🎉 版本 {0} 已可用！</value>
   </data>
   <data name="Update_CurrentVersion" xml:space="preserve">
-    <value>ç›®å‰ç‰ˆæœ¬: {0}</value>
+    <value>目前版本: {0}</value>
   </data>
   <data name="Update_WhatsNew" xml:space="preserve">
-    <value>æ›´æ–°å…§å®¹:</value>
+    <value>更新內容:</value>
   </data>
   <data name="Update_SkipButton" xml:space="preserve">
-    <value>è·³éŽæ­¤ç‰ˆæœ¬</value>
+    <value>跳過此版本</value>
   </data>
   <data name="Update_RemindLaterButton" xml:space="preserve">
-    <value>ç¨å¾Œæé†’</value>
+    <value>稍後提醒</value>
   </data>
   <data name="Update_DownloadButton" xml:space="preserve">
-    <value>ä¸‹è¼‰ä¸¦å®‰è£</value>
+    <value>下載並安裝</value>
   </data>
   <data name="Update_Title_UpToDate" xml:space="preserve">
-    <value>å·²æ˜¯æœ€æ–°ç‰ˆæœ¬</value>
+    <value>已是最新版本</value>
   </data>
   <data name="Update_Message_UpToDate" xml:space="preserve">
-    <value>æ‚¨æ­£åœ¨ä½¿ç”¨æœ€æ–°ç‰ˆæœ¬ (v{0})ã€‚</value>
+    <value>您正在使用最新版本 (v{0})。</value>
   </data>
   <data name="Update_Title_Failed" xml:space="preserve">
-    <value>ç„¡æ³•æª¢æŸ¥æ›´æ–°</value>
+    <value>無法檢查更新</value>
   </data>
   <data name="Update_Message_Failed" xml:space="preserve">
-    <value>æª¢æŸ¥æ›´æ–°æ™‚ç™¼ç”ŸéŒ¯èª¤ã€‚
+    <value>檢查更新時發生錯誤。
 
 {0}</value>
   </data>
   <data name="Update_Title_Skipped" xml:space="preserve">
-    <value>å·²ç•¥éŽæ›´æ–°æª¢æŸ¥</value>
+    <value>已略過更新檢查</value>
   </data>
   <data name="Update_Message_Skipped_Debug" xml:space="preserve">
-    <value>åµéŒ¯ç‰ˆæœ¬å·²åœç”¨æ›´æ–°æª¢æŸ¥ã€‚</value>
+    <value>偵錯版本已停用更新檢查。</value>
   </data>
   <data name="Update_OK" xml:space="preserve">
-    <value>ç¢ºå®š</value>
+    <value>確定</value>
   </data>
   <data name="Menu_OpenDashboard" xml:space="preserve">
-    <value>æ‰“é–‹å„€è¡¨æ¿</value>
+    <value>打開儀表板</value>
   </data>
   <data name="Menu_OpenWebChat" xml:space="preserve">
-    <value>æ‰“é–‹ç¶²é èŠå¤©</value>
+    <value>打開網頁聊天</value>
   </data>
   <data name="Menu_ActivityStream" xml:space="preserve">
-    <value>ä¸²æµæ´»å‹•...</value>
+    <value>串流活動...</value>
   </data>
   <data name="Menu_NotificationHistory" xml:space="preserve">
-    <value>é€šçŸ¥æ­·å²...</value>
+    <value>通知歷史...</value>
   </data>
   <data name="Menu_RunHealthCheck" xml:space="preserve">
-    <value>åŸ·è¡Œå¥åº·æª¢æŸ¥</value>
+    <value>執行健康檢查</value>
   </data>
   <data name="Menu_Settings" xml:space="preserve">
-    <value>è¨­å®š...</value>
+    <value>設定...</value>
   </data>
   <data name="Menu_AutoStart" xml:space="preserve">
-    <value>è‡ªå•Ÿå‹•</value>
+    <value>自啟動</value>
   </data>
   <data name="Menu_AutoStartEnabled" xml:space="preserve">
     <value>自啟動 ✓</value>
   </data>
   <data name="Menu_OpenLogFile" xml:space="preserve">
-    <value>æ‰“é–‹æ—¥èªŒæª”æ¡ˆ</value>
+    <value>打開日誌檔案</value>
   </data>
   <data name="Menu_Exit" xml:space="preserve">
-    <value>é€€å‡º</value>
+    <value>退出</value>
   </data>
   <data name="Menu_CopyNodeSummary" xml:space="preserve">
-    <value>è¤‡è£½ç¯€é»žæ‘˜è¦</value>
+    <value>複製節點摘要</value>
   </data>
   <data name="Menu_CheckForUpdates" xml:space="preserve">
-    <value>æª¢æŸ¥æ›´æ–°</value>
+    <value>檢查更新</value>
   </data>
   <data name="Menu_SetupGuide" xml:space="preserve">
-    <value>è¨­å®šæŒ‡å—...</value>
+    <value>設定指南...</value>
   </data>
   <data name="Menu_Reconfigure" xml:space="preserve">
     <value>重新設定…</value>
@@ -416,64 +416,64 @@
     <value>🧰 支援和偵錯</value>
   </data>
   <data name="Menu_OpenSupportFiles" xml:space="preserve">
-    <value>é–‹å•Ÿæ”¯æ´æª”æ¡ˆ</value>
+    <value>開啟支援檔案</value>
   </data>
   <data name="Menu_LogsFolder" xml:space="preserve">
-    <value>è¨˜éŒ„è³‡æ–™å¤¾</value>
+    <value>記錄資料夾</value>
   </data>
   <data name="Menu_ConfigFolder" xml:space="preserve">
-    <value>è¨­å®šè³‡æ–™å¤¾</value>
+    <value>設定資料夾</value>
   </data>
   <data name="Menu_DiagnosticsFolder" xml:space="preserve">
-    <value>è¨ºæ–·è³‡æ–™å¤¾</value>
+    <value>診斷資料夾</value>
   </data>
   <data name="Menu_CopyDiagnostics" xml:space="preserve">
-    <value>è¤‡è£½è¨ºæ–·</value>
+    <value>複製診斷</value>
   </data>
   <data name="Menu_SupportContext" xml:space="preserve">
-    <value>æ”¯æ´å…§å®¹</value>
+    <value>支援內容</value>
   </data>
   <data name="Menu_DebugBundle" xml:space="preserve">
-    <value>åµéŒ¯å¥—ä»¶</value>
+    <value>偵錯套件</value>
   </data>
   <data name="Menu_BrowserSetup" xml:space="preserve">
-    <value>ç€è¦½å™¨è¨­å®š</value>
+    <value>瀏覽器設定</value>
   </data>
   <data name="Menu_PortDiagnostics" xml:space="preserve">
-    <value>é€£æŽ¥åŸ è¨ºæ–·</value>
+    <value>連接埠診斷</value>
   </data>
   <data name="Menu_CapabilityDiagnostics" xml:space="preserve">
-    <value>åŠŸèƒ½è¨ºæ–·</value>
+    <value>功能診斷</value>
   </data>
   <data name="Menu_NodeInventory" xml:space="preserve">
-    <value>ç¯€é»žæ¸…å–®</value>
+    <value>節點清單</value>
   </data>
   <data name="Menu_ChannelSummary" xml:space="preserve">
-    <value>é »é“æ‘˜è¦</value>
+    <value>頻道摘要</value>
   </data>
   <data name="Menu_ActivitySummary" xml:space="preserve">
-    <value>æ´»å‹•æ‘˜è¦</value>
+    <value>活動摘要</value>
   </data>
   <data name="Menu_ExtensibilitySummary" xml:space="preserve">
-    <value>æ“´å……æ€§æ‘˜è¦</value>
+    <value>擴充性摘要</value>
   </data>
   <data name="Menu_RestartSshTunnel" xml:space="preserve">
-    <value>é‡æ–°å•Ÿå‹• SSH é€šé“</value>
+    <value>重新啟動 SSH 通道</value>
   </data>
   <data name="Menu_StatusFormat" xml:space="preserve">
-    <value>ç‹€æ…‹: {0}</value>
+    <value>狀態: {0}</value>
   </data>
   <data name="Menu_SessionsFormat" xml:space="preserve">
-    <value>æœƒè©± ({0})</value>
+    <value>會話 ({0})</value>
   </data>
   <data name="Menu_NodesFormat" xml:space="preserve">
-    <value>ç¯€é»ž ({0})</value>
+    <value>節點 ({0})</value>
   </data>
   <data name="Menu_RecentActivityFormat" xml:space="preserve">
-    <value>æœ€è¿‘æ´»å‹• ({0})</value>
+    <value>最近活動 ({0})</value>
   </data>
   <data name="Menu_NoUsageData" xml:space="preserve">
-    <value>æš«ç„¡ç”¨é‡æ•¸æ“š</value>
+    <value>暫無用量數據</value>
   </data>
   <data name="Menu_ResetSession" xml:space="preserve">
     <value>↳ 重置會話</value>
@@ -497,88 +497,88 @@
     <value>⚪ 中斷連線</value>
   </data>
   <data name="TestNotification_Title" xml:space="preserve">
-    <value>æ¸¬è©¦é€šçŸ¥</value>
+    <value>測試通知</value>
   </data>
   <data name="TestNotification_Body" xml:space="preserve">
-    <value>é€™æ˜¯ä¾†è‡ª OpenClaw è¨­å®šçš„æ¸¬è©¦é€šçŸ¥ã€‚</value>
+    <value>這是來自 OpenClaw 設定的測試通知。</value>
   </data>
   <data name="Status_LastCheckFormat" xml:space="preserve">
-    <value>ä¸Šæ¬¡æª¢æŸ¥: {0}</value>
+    <value>上次檢查: {0}</value>
   </data>
   <data name="TimeAgo_JustNow" xml:space="preserve">
-    <value>å‰›å‰›</value>
+    <value>剛剛</value>
   </data>
   <data name="TimeAgo_MinutesFormat" xml:space="preserve">
-    <value>{0}åˆ†é˜å‰</value>
+    <value>{0}分鐘前</value>
   </data>
   <data name="TimeAgo_HoursFormat" xml:space="preserve">
-    <value>{0}å°æ™‚å‰</value>
+    <value>{0}小時前</value>
   </data>
   <data name="Activity_ClickToOpen" xml:space="preserve">
-    <value>é»žé¸åœ¨å„€è¡¨æ¿ä¸­æ‰“é–‹</value>
+    <value>點選在儀表板中打開</value>
   </data>
   <data name="TimeAgo_DaysFormat" xml:space="preserve">
-    <value>{0}å¤©å‰</value>
+    <value>{0}天前</value>
   </data>
   <data name="StatusDisplay_Connected" xml:space="preserve">
-    <value>å·²é€£ç·š</value>
+    <value>已連線</value>
   </data>
   <data name="StatusDisplay_Connecting" xml:space="preserve">
-    <value>æ­£åœ¨é€£ç·š</value>
+    <value>正在連線</value>
   </data>
   <data name="StatusDisplay_Disconnected" xml:space="preserve">
-    <value>ä¸­æ–·é€£ç·š</value>
+    <value>中斷連線</value>
   </data>
   <data name="StatusDisplay_Error" xml:space="preserve">
-    <value>éŒ¯èª¤</value>
+    <value>錯誤</value>
   </data>
   <data name="StatusDisplay_Unknown" xml:space="preserve">
-    <value>æœªçŸ¥</value>
+    <value>未知</value>
   </data>
   <data name="Status_NotAvailable" xml:space="preserve">
-    <value>ç„¡</value>
+    <value>無</value>
   </data>
   <data name="WindowTitle_Canvas" xml:space="preserve">
-    <value>ç•«å¸ƒ</value>
+    <value>畫布</value>
   </data>
   <data name="CanvasErrorTitle.Text" xml:space="preserve">
     <value>❌ Canvas錯誤</value>
   </data>
   <data name="CanvasRetryButton.Content" xml:space="preserve">
-    <value>é‡è©¦</value>
+    <value>重試</value>
   </data>
   <data name="Canvas_ReadyTitle" xml:space="preserve">
     <value>🎨 Canvas就緒</value>
   </data>
   <data name="Canvas_WaitingForContent" xml:space="preserve">
-    <value>ç­‰å¾…å…§å®¹...</value>
+    <value>等待內容...</value>
   </data>
   <data name="A2UI_CanvasTitle" xml:space="preserve">
-    <value>ç•«å¸ƒ</value>
+    <value>畫布</value>
   </data>
   <data name="A2UI_TabFallback" xml:space="preserve">
-    <value>ç´¢å¼•æ¨™ç±¤</value>
+    <value>索引標籤</value>
   </data>
   <data name="A2UI_ModalClose" xml:space="preserve">
-    <value>é—œé–‰</value>
+    <value>關閉</value>
   </data>
   <data name="A2UI_DateTimeSelectDate" xml:space="preserve">
-    <value>é¸æ“‡æ—¥æœŸ</value>
+    <value>選擇日期</value>
   </data>
   <data name="A2UI_MultipleChoiceSelect" xml:space="preserve">
-    <value>é¸æ“‡...</value>
+    <value>選擇...</value>
   </data>
   <data name="A2UI_UnsupportedComponent" xml:space="preserve">
-    <value>ä¸æ”¯æ´çš„å…ƒä»¶: {0}</value>
+    <value>不支援的元件: {0}</value>
   </data>
   <data name="WebChatErrorTitle.Text" xml:space="preserve">
-    <value>ç¶²é èŠå¤©ä¸å¯ç”¨</value>
+    <value>網頁聊天不可用</value>
   </data>
   <data name="WebChatOpenBrowserButton.Content" xml:space="preserve">
-    <value>åœ¨ç€è¦½å™¨ä¸­æ‰“é–‹</value>
+    <value>在瀏覽器中打開</value>
   </data>
   <data name="WebChat_ConnectionError" xml:space="preserve">
-    <value>ç„¡æ³•é€£ç·šåˆ° OpenClaw é–˜é“å™¨</value>
+    <value>無法連線到 OpenClaw 閘道器</value>
   </data>
   <data name="WebChat_ConnectionErrorDetail" xml:space="preserve">
     <value>閘道器 {0} 沒有響應。
@@ -597,7 +597,7 @@
 • 或使用 SSH 隧道連線到 localhost 並繼續使用 localhost 地址</value>
   </data>
   <data name="WebChat_InvalidUrl" xml:space="preserve">
-    <value>ç„¡æ•ˆçš„é–˜é“å™¨åœ°å€: {0}</value>
+    <value>無效的閘道器地址: {0}</value>
   </data>
   <data name="WebChat_SecureContextRequired" xml:space="preserve">
     <value>網頁聊天需要安全上下文。
@@ -610,194 +610,194 @@
 • 或通過隧道連線到 localhost：ssh -N -L 18789:localhost:18789 &lt;伺服器&gt;</value>
   </data>
   <data name="WindowTitle_TrayMenu" xml:space="preserve">
-    <value>OpenClaw é¸é …</value>
+    <value>OpenClaw 選項</value>
   </data>
   <data name="Toast_DeviceIdCopied" xml:space="preserve">
     <value>📋 裝置 ID 已複製</value>
   </data>
   <data name="Toast_DeviceIdCopiedDetail" xml:space="preserve">
-    <value>åŸ·è¡Œ: openclaw devices approve {0}...</value>
+    <value>執行: openclaw devices approve {0}...</value>
   </data>
   <data name="Toast_NodeSummaryCopied" xml:space="preserve">
     <value>📋 節點摘要已複製</value>
   </data>
   <data name="Toast_NodeSummaryCopiedDetail" xml:space="preserve">
-    <value>å·²è¤‡è£½ {0} å€‹ç¯€é»žåˆ°å‰ªè²¼ç°¿</value>
+    <value>已複製 {0} 個節點到剪貼簿</value>
   </data>
   <data name="Toast_SessionActionFailed" xml:space="preserve">
     <value>❌ 會話操作失敗</value>
   </data>
   <data name="Toast_SessionActionFailedDetail" xml:space="preserve">
-    <value>ç„¡æ³•å‘é–˜é“å™¨ç™¼é€è«‹æ±‚ã€‚</value>
+    <value>無法向閘道器發送請求。</value>
   </data>
   <data name="Toast_NodeModeActive" xml:space="preserve">
     <value>🔌 節點模式已啟用</value>
   </data>
   <data name="Toast_NodeModeActiveDetail" xml:space="preserve">
-    <value>æ­¤é›»è…¦ç¾åœ¨å¯ä»¥æŽ¥æ”¶ä¾†è‡ªä»£ç†çš„å‘½ä»¤ï¼ˆCanvasã€æˆªåœ–ï¼‰</value>
+    <value>此電腦現在可以接收來自代理的命令（Canvas、截圖）</value>
   </data>
   <data name="Toast_PairingPending" xml:space="preserve">
     <value>⏳ 等待配對批準</value>
   </data>
   <data name="Toast_PairingPendingDetail" xml:space="preserve">
-    <value>åœ¨é–˜é“å™¨ä¸ŠåŸ·è¡Œ: openclaw devices approve {0}...</value>
+    <value>在閘道器上執行: openclaw devices approve {0}...</value>
   </data>
   <data name="Toast_CopyPairingCommand" xml:space="preserve">
-    <value>è¤‡è£½æ ¸å‡†å‘½ä»¤</value>
+    <value>複製核准命令</value>
   </data>
   <data name="Toast_PairingCommandCopied" xml:space="preserve">
-    <value>é…å°å‘½ä»¤å·²è¤‡è£½</value>
+    <value>配對命令已複製</value>
   </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ 節點已配對！</value>
   </data>
   <data name="Toast_NodePairedDetail" xml:space="preserve">
-    <value>æ­¤é›»è…¦ç¾åœ¨å¯ä»¥æŽ¥æ”¶ä¾†è‡ªä»£ç†çš„å‘½ä»¤</value>
+    <value>此電腦現在可以接收來自代理的命令</value>
   </data>
   <data name="Toast_PairingRejected" xml:space="preserve">
     <value>❌ 節點配對遭拒</value>
   </data>
   <data name="Toast_PairingRejectedDetail" xml:space="preserve">
-    <value>é–˜é“å™¨æ‹’çµ•äº†æ­¤è£ç½®çš„é…å°è«‹æ±‚ã€‚</value>
+    <value>閘道器拒絕了此裝置的配對請求。</value>
   </data>
   <data name="Toast_HealthCheck" xml:space="preserve">
-    <value>å¥åº·æª¢æŸ¥</value>
+    <value>健康檢查</value>
   </data>
   <data name="Toast_HealthCheckNotConnected" xml:space="preserve">
-    <value>é–˜é“å™¨å°šæœªé€£ç·šã€‚</value>
+    <value>閘道器尚未連線。</value>
   </data>
   <data name="Toast_HealthCheckSent" xml:space="preserve">
-    <value>å¥åº·æª¢æŸ¥è«‹æ±‚å·²ç™¼é€ã€‚</value>
+    <value>健康檢查請求已發送。</value>
   </data>
   <data name="Toast_HealthCheckFailed" xml:space="preserve">
-    <value>å¥åº·æª¢æŸ¥å¤±æ•—</value>
+    <value>健康檢查失敗</value>
   </data>
   <data name="Toast_ScreenCaptured" xml:space="preserve">
     <value>📸 螢幕已擷取</value>
   </data>
   <data name="Toast_ScreenCapturedDetail" xml:space="preserve">
-    <value>OpenClaw ä»£ç†æ“·å–äº†æ‚¨çš„èž¢å¹•</value>
+    <value>OpenClaw 代理擷取了您的螢幕</value>
   </data>
   <data name="Toast_CameraBlocked" xml:space="preserve">
     <value>📷 相機訪問被阻止</value>
   </data>
   <data name="Toast_CameraBlockedDetail" xml:space="preserve">
-    <value>è«‹åœ¨ Windows éš±ç§è¨­å®šä¸­ç‚º OpenClaw Tray å•Ÿç”¨ç›¸æ©Ÿè¨ªå•</value>
+    <value>請在 Windows 隱私設定中為 OpenClaw Tray 啟用相機訪問</value>
   </data>
   <!-- ==================== Toast: Recording ==================== -->
   <data name="Toast_ScreenRecordingStarted" xml:space="preserve">
     <value>🔴 螢幕錄製已開始</value>
   </data>
   <data name="Toast_ScreenRecordingStartedDetail" xml:space="preserve">
-    <value>OpenClaw ä»£ç†æ­£åœ¨éŒ„è£½æ‚¨çš„èž¢å¹•</value>
+    <value>OpenClaw 代理正在錄製您的螢幕</value>
   </data>
   <data name="Toast_ScreenRecordingComplete" xml:space="preserve">
     <value>✅ 螢幕錄製已完成</value>
   </data>
   <data name="Toast_ScreenRecordingCompleteDetail" xml:space="preserve">
-    <value>èž¢å¹•éŒ„è£½å·²å‚³é€çµ¦ä»£ç†</value>
+    <value>螢幕錄製已傳送給代理</value>
   </data>
   <data name="Toast_ScreenRecordingFailed" xml:space="preserve">
     <value>❌ 螢幕錄製失敗</value>
   </data>
   <data name="Toast_ScreenRecordingFailedDetail" xml:space="preserve">
-    <value>éŒ„è£½èž¢å¹•æ™‚ç™¼ç”ŸéŒ¯èª¤</value>
+    <value>錄製螢幕時發生錯誤</value>
   </data>
   <data name="Toast_CameraRecordingStarted" xml:space="preserve">
     <value>🔴 攝影機錄製已開始</value>
   </data>
   <data name="Toast_CameraRecordingStartedDetail" xml:space="preserve">
-    <value>OpenClaw ä»£ç†æ­£åœ¨å¾žæ‚¨çš„æ”å½±æ©ŸéŒ„è£½</value>
+    <value>OpenClaw 代理正在從您的攝影機錄製</value>
   </data>
   <data name="Toast_CameraRecordingComplete" xml:space="preserve">
     <value>✅ 攝影機錄製已完成</value>
   </data>
   <data name="Toast_CameraRecordingCompleteDetail" xml:space="preserve">
-    <value>æ”å½±æ©ŸéŒ„è£½ç‰‡æ®µå·²å‚³é€çµ¦ä»£ç†</value>
+    <value>攝影機錄製片段已傳送給代理</value>
   </data>
   <!-- ==================== Recording Consent Dialog ==================== -->
   <data name="RecordingConsent_WindowTitle" xml:space="preserve">
     <value>OpenClaw · 權限請求</value>
   </data>
   <data name="RecordingConsent_ScreenTitle" xml:space="preserve">
-    <value>å…è¨±èž¢å¹•éŒ„è£½ï¼Ÿ</value>
+    <value>允許螢幕錄製？</value>
   </data>
   <data name="RecordingConsent_CameraTitle" xml:space="preserve">
-    <value>å…è¨±æ”å½±æ©ŸéŒ„è£½ï¼Ÿ</value>
+    <value>允許攝影機錄製？</value>
   </data>
   <data name="RecordingConsent_ScreenDescription" xml:space="preserve">
-    <value>ä»£ç†æ­£åœ¨è«‹æ±‚éŒ„è£½æ‚¨çš„èž¢å¹•ã€‚é€™å°‡å¾žæ‚¨çš„é¡¯ç¤ºå™¨æ“·å–è¦–è¨Šä¸¦å‚³é€çµ¦ä»£ç†ã€‚æ‚¨çš„é¸æ“‡å°‡è¢«è¨˜ä½ç”¨æ–¼ä»¥å¾Œçš„è«‹æ±‚ï¼Œç›´åˆ°æ‚¨åœ¨è¨­å®šä¸­è®Šæ›´ã€‚</value>
+    <value>代理正在請求錄製您的螢幕。這將從您的顯示器擷取視訊並傳送給代理。您的選擇將被記住用於以後的請求，直到您在設定中變更。</value>
   </data>
   <data name="RecordingConsent_CameraDescription" xml:space="preserve">
-    <value>ä»£ç†æ­£åœ¨è«‹æ±‚å¾žæ‚¨çš„æ”å½±æ©ŸéŒ„è£½ã€‚é€™å°‡å¾žæ‚¨çš„ç¶²è·¯æ”å½±æ©Ÿæ“·å–è¦–è¨Šä¸¦å‚³é€çµ¦ä»£ç†ã€‚æ‚¨çš„é¸æ“‡å°‡è¢«è¨˜ä½ç”¨æ–¼ä»¥å¾Œçš„è«‹æ±‚ï¼Œç›´åˆ°æ‚¨åœ¨è¨­å®šä¸­è®Šæ›´ã€‚</value>
+    <value>代理正在請求從您的攝影機錄製。這將從您的網路攝影機擷取視訊並傳送給代理。您的選擇將被記住用於以後的請求，直到您在設定中變更。</value>
   </data>
   <data name="RecordingConsent_Privacy" xml:space="preserve">
-    <value>æ‚¨å¯ä»¥ç¨å¾Œåœ¨è¨­å®šä¸­è®Šæ›´æ­¤é …ã€‚</value>
+    <value>您可以稍後在設定中變更此項。</value>
   </data>
   <data name="RecordingConsent_Allow" xml:space="preserve">
-    <value>å…è¨±éŒ„è£½</value>
+    <value>允許錄製</value>
   </data>
   <data name="RecordingConsent_Deny" xml:space="preserve">
-    <value>æ‹’çµ•</value>
+    <value>拒絕</value>
   </data>
   <!-- ==================== Settings: Privacy ==================== -->
   <data name="Settings_PrivacyHeader" xml:space="preserve">
-    <value>éš±ç§</value>
+    <value>隱私</value>
   </data>
   <data name="Settings_PrivacyDescription" xml:space="preserve">
-    <value>æŽ§åˆ¶ä»£ç†å¯ä»¥åœ¨æ­¤è£ç½®ä¸Šä½¿ç”¨å“ªäº›åŠŸèƒ½ã€‚</value>
+    <value>控制代理可以在此裝置上使用哪些功能。</value>
   </data>
   <data name="Settings_AllowScreenRecording" xml:space="preserve">
-    <value>å…è¨±èž¢å¹•éŒ„è£½</value>
+    <value>允許螢幕錄製</value>
   </data>
   <data name="Settings_AllowCameraRecording" xml:space="preserve">
-    <value>å…è¨±æ”å½±æ©ŸéŒ„è£½</value>
+    <value>允許攝影機錄製</value>
   </data>
   <data name="SettingsPrivacyHeader.Text" xml:space="preserve">
-    <value>éš±ç§</value>
+    <value>隱私</value>
   </data>
   <data name="SettingsPrivacyDescription.Text" xml:space="preserve">
-    <value>é å…ˆæ ¸å‡†åŠŸèƒ½ï¼Œä»¥ä¾¿ä»£ç†ç„¡éœ€æ¯æ¬¡éƒ½è«‹æ±‚æ¬Šé™ã€‚éŒ„è£½é–‹å§‹å‰ä»æœƒé¡¯ç¤ºå€’æ•¸è¨ˆæ™‚ã€‚</value>
+    <value>預先核准功能，以便代理無需每次都請求權限。錄製開始前仍會顯示倒數計時。</value>
   </data>
   <data name="ScreenRecordingToggle.Header" xml:space="preserve">
-    <value>å…è¨±èž¢å¹•éŒ„è£½</value>
+    <value>允許螢幕錄製</value>
   </data>
   <data name="CameraRecordingToggle.Header" xml:space="preserve">
-    <value>å…è¨±æ”å½±æ©ŸéŒ„è£½</value>
+    <value>允許攝影機錄製</value>
   </data>
   <!-- ==================== Toast: Activity Stream Tip ==================== -->
   <data name="Toast_ActivityStreamTip" xml:space="preserve">
     <value>⚡ 新功能: 串流活動</value>
   </data>
   <data name="Toast_ActivityStreamTipDetail" xml:space="preserve">
-    <value>æ‰“é–‹è¨­å®šé¸é …å³å¯æª¢è¦–å¯¦æ™‚æœƒè©±ã€ç”¨é‡å’Œç¯€é»žæ´»å‹•ã€‚</value>
+    <value>打開設定選項即可檢視實時會話、用量和節點活動。</value>
   </data>
   <data name="Toast_ActivityStreamTipButton" xml:space="preserve">
-    <value>æ‰“é–‹ä¸²æµæ´»å‹•</value>
+    <value>打開串流活動</value>
   </data>
   <data name="Setup_Title" xml:space="preserve">
-    <value>OpenClaw è¨­å®š</value>
+    <value>OpenClaw 設定</value>
   </data>
   <data name="Setup_StepConnect" xml:space="preserve">
     <value>第 1 步（共 3 步）— 連線</value>
   </data>
   <data name="Setup_ConnectTitle" xml:space="preserve">
-    <value>é€£ç·šåˆ°æ‚¨çš„é–˜é“å™¨</value>
+    <value>連線到您的閘道器</value>
   </data>
   <data name="Setup_ConnectDescription" xml:space="preserve">
-    <value>åœ¨æ‚¨çš„é–˜é“å™¨ä¸»æ©Ÿï¼ˆMac/Linuxï¼‰ä¸ŠåŸ·è¡Œä»¥ä¸‹å‘½ä»¤å–å¾—è¨­å®šç¢¼ï¼š</value>
+    <value>在您的閘道器主機（Mac/Linux）上執行以下命令取得設定碼：</value>
   </data>
   <data name="Setup_SetupCodeHeader" xml:space="preserve">
-    <value>è¨­å®šç¢¼</value>
+    <value>設定碼</value>
   </data>
   <data name="Setup_SetupCodePlaceholder" xml:space="preserve">
-    <value>è²¼ä¸Šä¾†è‡ªé–˜é“å™¨å„€è¡¨æ¿çš„è¨­å®šç¢¼</value>
+    <value>貼上來自閘道器儀表板的設定碼</value>
   </data>
   <data name="Setup_PasteSetupButton" xml:space="preserve">
-    <value>è²¼ä¸Šè¨­å®šç¢¼ / QR</value>
+    <value>貼上設定碼 / QR</value>
   </data>
   <data name="Setup_ImportQrButton" xml:space="preserve">
-    <value>åŒ¯å…¥ QR åœ–ç‰‡...</value>
+    <value>匯入 QR 圖片...</value>
   </data>
   <data name="Setup_QrDecoded" xml:space="preserve">
     <value>✅ QR 圖片已解碼 — 請按「測試連線」</value>
@@ -815,7 +815,7 @@
     <value>隱藏手動輸入 ▴</value>
   </data>
   <data name="Setup_GatewayUrlHeader" xml:space="preserve">
-    <value>é–˜é“å™¨ç¶²å€</value>
+    <value>閘道器網址</value>
   </data>
   <data name="Setup_GatewayUrlPlaceholder" xml:space="preserve">
     <value>ws://192.168.1.x:18789</value>
@@ -824,13 +824,13 @@
     <value>💡 支援 ws://、wss://、http:// 或 https://</value>
   </data>
   <data name="Setup_TokenHeader" xml:space="preserve">
-    <value>é–˜é“å™¨æ¬Šæ–</value>
+    <value>閘道器權杖</value>
   </data>
   <data name="Setup_TokenPlaceholder" xml:space="preserve">
-    <value>åœ¨æ­¤è²¼ä¸Šæ‚¨çš„æ¬Šæ–</value>
+    <value>在此貼上您的權杖</value>
   </data>
   <data name="Setup_TestButton" xml:space="preserve">
-    <value>æ¸¬è©¦é€£ç·š</value>
+    <value>測試連線</value>
   </data>
   <data name="Setup_Testing" xml:space="preserve">
     <value>⏳ 正在連線到閘道器...</value>
@@ -872,25 +872,25 @@
     <value>✅ 設定碼已解碼 — 請點擊「測試連線」</value>
   </data>
   <data name="Setup_NodeModeTitle" xml:space="preserve">
-    <value>å•Ÿç”¨ç¯€é»žæ¨¡å¼ï¼ˆé¸ç”¨ï¼‰</value>
+    <value>啟用節點模式（選用）</value>
   </data>
   <data name="Setup_NodeModeDescription" xml:space="preserve">
     <value>節點模式允許您的 Windows 電腦為 OpenClaw 執行任務 — 如螢幕擷取、攝影機存取和畫布繪製。</value>
   </data>
   <data name="Setup_NodeModeSecurityTitle" xml:space="preserve">
-    <value>åªç‚ºæ‚¨ä¿¡ä»»çš„é–˜é“å’Œä»£ç†ç¨‹å¼å•Ÿç”¨ç¯€é»žæ¨¡å¼</value>
+    <value>只為您信任的閘道和代理程式啟用節點模式</value>
   </data>
   <data name="Setup_NodeModeSecurityMessage" xml:space="preserve">
-    <value>å·²æ ¸å‡†çš„ä»£ç†ç¨‹å¼å¯ä»¥åŸ·è¡Œæœ¬æ©Ÿå‘½ä»¤ï¼Œä¸¦å¯èƒ½å­˜å–å·²å•Ÿç”¨çš„è£ç½®ä»‹é¢ï¼Œä¾‹å¦‚èž¢å¹•ã€æ”å½±æ©Ÿã€ä½ç½®ã€ç€è¦½å™¨å’Œç•«å¸ƒã€‚æ‚¨ç¨å¾Œå¯ä»¥åœ¨è¨­å®šä¸­åœç”¨èƒ½åŠ›ç¾¤çµ„ã€‚</value>
+    <value>已核准的代理程式可以執行本機命令，並可能存取已啟用的裝置介面，例如螢幕、攝影機、位置、瀏覽器和畫布。您稍後可以在設定中停用能力群組。</value>
   </data>
   <data name="Setup_NodeModeToggle" xml:space="preserve">
-    <value>å•Ÿç”¨ç¯€é»žæ¨¡å¼</value>
+    <value>啟用節點模式</value>
   </data>
   <data name="Setup_DeviceIdLoading" xml:space="preserve">
-    <value>è£ç½® IDï¼šè¼‰å…¥ä¸­...</value>
+    <value>裝置 ID：載入中...</value>
   </data>
   <data name="Setup_DeviceIdFallback" xml:space="preserve">
-    <value>è£ç½® IDï¼šï¼ˆå°‡åœ¨é¦–æ¬¡é€£ç·šæ™‚ç”¢ç”Ÿï¼‰</value>
+    <value>裝置 ID：（將在首次連線時產生）</value>
   </data>
   <data name="Setup_CopyDeviceId" xml:space="preserve">
     <value>📋 複製裝置 ID</value>
@@ -899,7 +899,7 @@
     <value>✅ 已複製！</value>
   </data>
   <data name="Setup_ApproveInstructions" xml:space="preserve">
-    <value>è¦æ ¸å‡†æ­¤ç¯€é»žï¼Œè«‹åœ¨é–˜é“å™¨ä¸»æ©Ÿä¸ŠåŸ·è¡Œï¼š</value>
+    <value>要核准此節點，請在閘道器主機上執行：</value>
   </data>
   <data name="Setup_ApproveHint" xml:space="preserve">
     <value>💡 您可以現在完成設定 — 配對將在背景繼續。獲得核准後會收到通知。</value>
@@ -908,16 +908,16 @@
     <value>🎉 一切就緒！</value>
   </data>
   <data name="Setup_DoneDescription" xml:space="preserve">
-    <value>OpenClaw ç³»çµ±åŒ£å°‡é€£ç·šåˆ°æ‚¨çš„é–˜é“å™¨ä¸¦é–‹å§‹ç›£æŽ§ã€‚</value>
+    <value>OpenClaw 系統匣將連線到您的閘道器並開始監控。</value>
   </data>
   <data name="Setup_BackButton" xml:space="preserve">
-    <value>ä¸Šä¸€æ­¥</value>
+    <value>上一步</value>
   </data>
   <data name="Setup_NextButton" xml:space="preserve">
-    <value>ä¸‹ä¸€æ­¥</value>
+    <value>下一步</value>
   </data>
   <data name="Setup_FinishButton" xml:space="preserve">
-    <value>å®Œæˆ</value>
+    <value>完成</value>
   </data>
   <data name="Setup_StepNodeMode" xml:space="preserve">
     <value>第 2 步（共 3 步）— 節點模式</value>
@@ -926,112 +926,112 @@
     <value>第 3 步（共 3 步）— 完成</value>
   </data>
   <data name="SettingsDeveloperModeHeader.Text" xml:space="preserve">
-    <value>é–‹ç™¼äººå“¡æ¨¡å¼</value>
+    <value>開發人員模式</value>
   </data>
   <data name="SettingsMcpServerToggle.Header" xml:space="preserve">
-    <value>å•Ÿç”¨æœ¬æ©Ÿ MCP ä¼ºæœå™¨</value>
+    <value>啟用本機 MCP 伺服器</value>
   </data>
   <data name="SettingsMcpDescription.Text" xml:space="preserve">
-    <value>å‘æœ¬æ©Ÿ MCP ç”¨æˆ¶ç«¯ï¼ˆClaude Desktopã€Cursorã€Claude Codeï¼‰å…¬é–‹ç›¸åŒçš„ç¯€é»žåŠŸèƒ½ï¼ˆç³»çµ±ã€èž¢å¹•ã€æ”å½±æ©Ÿã€éº¥å…‹é¢¨ã€å–‡å­ã€ç•«å¸ƒï¼‰ã€‚</value>
+    <value>向本機 MCP 用戶端（Claude Desktop、Cursor、Claude Code）公開相同的節點功能（系統、螢幕、攝影機、麥克風、喇叭、畫布）。</value>
   </data>
   <data name="SettingsMcpEndpointLabel.Text" xml:space="preserve">
-    <value>ç«¯é»žï¼š</value>
+    <value>端點：</value>
   </data>
   <data name="SettingsMcpStatusLabel.Text" xml:space="preserve">
-    <value>ç‹€æ…‹ï¼š</value>
+    <value>狀態：</value>
   </data>
   <data name="Mcp_Status_Disabled" xml:space="preserve">
-    <value>å·²åœç”¨</value>
+    <value>已停用</value>
   </data>
   <data name="Mcp_Status_Listening" xml:space="preserve">
-    <value>ç›£è½ä¸­</value>
+    <value>監聽中</value>
   </data>
   <data name="Mcp_Status_Stopped" xml:space="preserve">
-    <value>å·²åœæ­¢</value>
+    <value>已停止</value>
   </data>
   <data name="Mcp_Status_WillStartOnSave" xml:space="preserve">
-    <value>å„²å­˜å¾Œå°‡å•Ÿå‹•</value>
+    <value>儲存後將啟動</value>
   </data>
   <data name="Mcp_Status_WillStopOnSave" xml:space="preserve">
-    <value>å„²å­˜å¾Œå°‡åœæ­¢</value>
+    <value>儲存後將停止</value>
   </data>
   <data name="Mcp_Status_FailedToStart" xml:space="preserve">
-    <value>å•Ÿå‹•å¤±æ•—ï¼š</value>
+    <value>啟動失敗：</value>
   </data>
   <data name="SettingsMcpTokenLabel.Text" xml:space="preserve">
-    <value>Bearer æ¬Šæ–ï¼š</value>
+    <value>Bearer 權杖：</value>
   </data>
   <data name="SettingsMcpTokenRevealButton.Content" xml:space="preserve">
-    <value>é¡¯ç¤º</value>
+    <value>顯示</value>
   </data>
   <data name="SettingsMcpTokenCopyButton.Content" xml:space="preserve">
-    <value>è¤‡è£½</value>
+    <value>複製</value>
   </data>
   <data name="SettingsMcpTokenResetButton.Content" xml:space="preserve">
-    <value>é‡è¨­</value>
+    <value>重設</value>
   </data>
   <data name="SettingsMcpToken_RevealButton" xml:space="preserve">
-    <value>é¡¯ç¤º</value>
+    <value>顯示</value>
   </data>
   <data name="SettingsMcpToken_HideButton" xml:space="preserve">
-    <value>éš±è—</value>
+    <value>隱藏</value>
   </data>
   <data name="SettingsMcpToken_NotGenerated" xml:space="preserve">
     <value>(尚未產生 — 啟用 MCP 伺服器並按儲存)</value>
   </data>
   <data name="SettingsMcpToken_StoredAtFormat" xml:space="preserve">
-    <value>å„²å­˜æ–¼ {0}</value>
+    <value>儲存於 {0}</value>
   </data>
   <data name="SettingsMcpToken_HintFormat" xml:space="preserve">
-    <value>æ¯æ¬¡è«‹æ±‚çš†ä»¥ 'Authorization: Bearer &lt;token&gt;' å‚³é€ã€‚å„²å­˜æ–¼ {0}ã€‚</value>
+    <value>每次請求皆以 'Authorization: Bearer &lt;token&gt;' 傳送。儲存於 {0}。</value>
   </data>
   <data name="SettingsMcpToken_ResetToastTitle" xml:space="preserve">
-    <value>MCP æ¬Šæ–å·²é‡è¨­</value>
+    <value>MCP 權杖已重設</value>
   </data>
   <data name="SettingsMcpToken_ResetToastBody" xml:space="preserve">
-    <value>èˆŠçš„ MCP Bearer æ¬Šæ–ç¾å·²å¤±æ•ˆã€‚</value>
+    <value>舊的 MCP Bearer 權杖現已失效。</value>
   </data>
   <data name="SettingsMcpToken_ResetFailedFormat" xml:space="preserve">
-    <value>é‡è¨­æ¬Šæ–å¤±æ•—ï¼š{0}</value>
+    <value>重設權杖失敗：{0}</value>
   </data>
   <data name="SettingsMcpTokenResetDialog_Title" xml:space="preserve">
-    <value>é‡è¨­ MCP Bearer æ¬Šæ–ï¼Ÿ</value>
+    <value>重設 MCP Bearer 權杖？</value>
   </data>
   <data name="SettingsMcpTokenResetDialog_Body" xml:space="preserve">
-    <value>ç¾æœ‰çš„æœ¬æ©Ÿ MCP ç”¨æˆ¶ç«¯ï¼ˆClaude Desktopã€Cursorã€Claude Codeï¼‰å°‡åœæ­¢é‹ä½œï¼Œç›´åˆ°æ‚¨ä½¿ç”¨æ–°æ¬Šæ–é‡æ–°è¨­å®šå®ƒå€‘ã€‚</value>
+    <value>現有的本機 MCP 用戶端（Claude Desktop、Cursor、Claude Code）將停止運作，直到您使用新權杖重新設定它們。</value>
   </data>
   <data name="SettingsMcpTokenResetDialog_PrimaryButton" xml:space="preserve">
-    <value>é‡è¨­</value>
+    <value>重設</value>
   </data>
   <data name="SettingsMcpTokenResetDialog_CloseButton" xml:space="preserve">
-    <value>å–æ¶ˆ</value>
+    <value>取消</value>
   </data>
   <data name="WindowTitle_Downloading" xml:space="preserve">
-    <value>æ­£åœ¨ä¸‹è¼‰æ›´æ–°...</value>
+    <value>正在下載更新...</value>
   </data>
   <data name="Download_ProgressText" xml:space="preserve">
-    <value>æ­£åœ¨ä¸‹è¼‰æ›´æ–°...</value>
+    <value>正在下載更新...</value>
   </data>
   <data name="UrlApproval_Caption" xml:space="preserve">
     <value>OpenClaw — 核准 URL</value>
   </data>
   <data name="UrlApproval_Body" xml:space="preserve">
-    <value>ä»£ç†æƒ³åœ¨æ‚¨çš„ç€è¦½å™¨ä¸­é–‹å•Ÿé«˜é¢¨éšªç›®æ¨™ã€‚</value>
+    <value>代理想在您的瀏覽器中開啟高風險目標。</value>
   </data>
   <data name="UrlApproval_NoReasons" xml:space="preserve">
-    <value>(æœªè¨˜éŒ„ç‰¹å®šåŽŸå› )</value>
+    <value>(未記錄特定原因)</value>
   </data>
   <data name="UrlApproval_ZoneFormat" xml:space="preserve">
-    <value>å€åŸŸï¼š{0}</value>
+    <value>區域：{0}</value>
   </data>
   <data name="UrlApproval_AgentFormat" xml:space="preserve">
-    <value>ä»£ç†ï¼š{0}</value>
+    <value>代理：{0}</value>
   </data>
   <data name="UrlApproval_HostFormat" xml:space="preserve">
-    <value>ä¸»æ©Ÿï¼š{0}</value>
+    <value>主機：{0}</value>
   </data>
   <data name="UrlApproval_ReasonsHeader" xml:space="preserve">
-    <value>åŽŸå› ï¼š</value>
+    <value>原因：</value>
   </data>
   <data name="UrlApproval_YesHint" xml:space="preserve">
     <value>是 — 開啟此 URL。</value>
@@ -1040,136 +1040,136 @@
     <value>否 — 封鎖此項。</value>
   </data>
   <data name="Onboarding_Title" xml:space="preserve">
-    <value>OpenClaw è¨­å®š</value>
+    <value>OpenClaw 設定</value>
   </data>
   <data name="Onboarding_Back" xml:space="preserve">
-    <value>ä¸Šä¸€æ­¥</value>
+    <value>上一步</value>
   </data>
   <data name="Onboarding_Next" xml:space="preserve">
-    <value>ä¸‹ä¸€æ­¥</value>
+    <value>下一步</value>
   </data>
   <data name="Onboarding_Finish" xml:space="preserve">
-    <value>å®Œæˆ</value>
+    <value>完成</value>
   </data>
   <data name="Onboarding_IncompleteSetup_Title" xml:space="preserve">
-    <value>è¨­å®šå°šæœªå®Œæˆ</value>
+    <value>設定尚未完成</value>
   </data>
   <data name="Onboarding_IncompleteSetup_Body" xml:space="preserve">
-    <value>OpenClaw ä»éœ€è¦å®Œæˆè¨­å®šï¼Œæ‰èƒ½é–‹å•Ÿ Hubã€‚è«‹ä½¿ç”¨ã€Œè¿”å›žã€å›žåˆ°ç²¾éˆæˆ–é€£ç·šæ­¥é©Ÿï¼Œä¿®æ­£ç¼ºå°‘çš„è¨­å®šï¼Œç„¶å¾Œå†æ¬¡å˜—è©¦ã€Œå®Œæˆã€ã€‚</value>
+    <value>OpenClaw 仍需要完成設定，才能開啟 Hub。請使用「返回」回到精靈或連線步驟，修正缺少的設定，然後再次嘗試「完成」。</value>
   </data>
   <data name="Onboarding_IncompleteSetup_Close" xml:space="preserve">
-    <value>ç¢ºå®š</value>
+    <value>確定</value>
   </data>
   <data name="Onboarding_Welcome_Title" xml:space="preserve">
-    <value>æ­¡è¿Žä½¿ç”¨ OpenClaw</value>
+    <value>歡迎使用 OpenClaw</value>
   </data>
   <data name="Onboarding_Welcome_Subtitle" xml:space="preserve">
-    <value>æ‚¨çš„ AI åŠ©æ‰‹ï¼Œå°±åœ¨ç³»çµ±åŒ£ä¸­</value>
+    <value>您的 AI 助手，就在系統匣中</value>
   </data>
   <data name="Onboarding_Welcome_SecurityTitle" xml:space="preserve">
-    <value>å®‰å…¨æ€§é€šçŸ¥</value>
+    <value>安全性通知</value>
   </data>
   <data name="Onboarding_Welcome_SecurityBody" xml:space="preserve">
-    <value>OpenClaw æœƒåŸ·è¡Œ AI ä»£ç†ç¨‹å¼ï¼Œå¯ä»£è¡¨ä½ åŸ·è¡Œå‘½ä»¤ã€è®€å¯«æª”æ¡ˆï¼Œä¸¦èˆ‡ä½ çš„ç³»çµ±äº’å‹•ã€‚</value>
+    <value>OpenClaw 會執行 AI 代理程式，可代表你執行命令、讀寫檔案，並與你的系統互動。</value>
   </data>
   <data name="Onboarding_Welcome_TrustTitle" xml:space="preserve">
-    <value>æ‚¨çš„ä»£ç†ç¨‹å¼å¯ä»¥ï¼š</value>
+    <value>您的代理程式可以：</value>
   </data>
   <data name="Onboarding_Welcome_Trust_Commands" xml:space="preserve">
-    <value>åœ¨æ‚¨çš„é›»è…¦ä¸ŠåŸ·è¡Œå‘½ä»¤</value>
+    <value>在您的電腦上執行命令</value>
   </data>
   <data name="Onboarding_Welcome_Trust_Files" xml:space="preserve">
-    <value>è®€å–å’Œå¯«å…¥æª”æ¡ˆ</value>
+    <value>讀取和寫入檔案</value>
   </data>
   <data name="Onboarding_Welcome_Trust_Screen" xml:space="preserve">
-    <value>æ“·å–èž¢å¹•æˆªåœ–</value>
+    <value>擷取螢幕截圖</value>
   </data>
   <data name="Onboarding_Connection_Title" xml:space="preserve">
-    <value>é¸æ“‡é–˜é“</value>
+    <value>選擇閘道</value>
   </data>
   <data name="Onboarding_Connection_Subtitle" xml:space="preserve">
-    <value>é¸æ“‡æ‚¨è¦å¦‚ä½•é€£ç·šåˆ° OpenClaw é–˜é“</value>
+    <value>選擇您要如何連線到 OpenClaw 閘道</value>
   </data>
   <data name="Onboarding_Connection_Local" xml:space="preserve">
-    <value>æœ¬æ©Ÿï¼ˆæœ¬åœ°ï¼‰</value>
+    <value>本機（本地）</value>
   </data>
   <data name="Onboarding_Connection_Remote" xml:space="preserve">
-    <value>é ç«¯é–˜é“</value>
+    <value>遠端閘道</value>
   </data>
   <data name="Onboarding_Connection_Later" xml:space="preserve">
-    <value>ç¨å¾Œè¨­å®š</value>
+    <value>稍後設定</value>
   </data>
   <data name="Onboarding_Ready_Title" xml:space="preserve">
-    <value>ä¸€åˆ‡å°±ç·’ï¼</value>
+    <value>一切就緒！</value>
   </data>
   <data name="Onboarding_Ready_Subtitle" xml:space="preserve">
-    <value>OpenClaw å·²æº–å‚™å°±ç·’ã€‚ä»¥ä¸‹æ˜¯å¯ä»¥å˜—è©¦çš„é …ç›®ï¼š</value>
+    <value>OpenClaw 已準備就緒。以下是可以嘗試的項目：</value>
   </data>
   <data name="Onboarding_Ready_Feature_TrayMenu" xml:space="preserve">
-    <value>é–‹å•ŸåŠŸèƒ½è¡¨åˆ—é¢æ¿</value>
+    <value>開啟功能表列面板</value>
   </data>
   <data name="Onboarding_Ready_Feature_Channels" xml:space="preserve">
-    <value>é€£æŽ¥è¨Šæ¯é »é“</value>
+    <value>連接訊息頻道</value>
   </data>
   <data name="Onboarding_Ready_Feature_Voice" xml:space="preserve">
-    <value>è©¦ç”¨èªžéŸ³å–šé†’</value>
+    <value>試用語音喚醒</value>
   </data>
   <data name="Onboarding_Ready_Feature_Canvas" xml:space="preserve">
-    <value>ä½¿ç”¨ç•«å¸ƒ</value>
+    <value>使用畫布</value>
   </data>
   <data name="Onboarding_Ready_Feature_Skills" xml:space="preserve">
-    <value>å•Ÿç”¨æŠ€èƒ½</value>
+    <value>啟用技能</value>
   </data>
   <data name="Onboarding_Ready_LaunchAtLogin" xml:space="preserve">
-    <value>é–‹æ©Ÿæ™‚å•Ÿå‹• OpenClaw</value>
+    <value>開機時啟動 OpenClaw</value>
   </data>
   <data name="Onboarding_Ready_ConfigureLater" xml:space="preserve">
-    <value>æ‚¨å¯ä»¥éš¨æ™‚å¾žç³»çµ±åŒ£é¸å–®è¨­å®šé–˜é“é€£ç·šã€‚</value>
+    <value>您可以隨時從系統匣選單設定閘道連線。</value>
   </data>
   <data name="Onboarding_Ready_RemoteInfo" xml:space="preserve">
-    <value>è«‹ç¢ºèªæ‚¨çš„é ç«¯é–˜é“æ­£åœ¨åŸ·è¡Œä¸”å¯ä»¥å­˜å–ã€‚</value>
+    <value>請確認您的遠端閘道正在執行且可以存取。</value>
   </data>
   <data name="Onboarding_Connection_SetupCode" xml:space="preserve">
-    <value>è¨­å®šç¢¼</value>
+    <value>設定碼</value>
   </data>
   <data name="Onboarding_Connection_SetupCodePlaceholder" xml:space="preserve">
-    <value>é»žæ“Šè²¼ä¸Šè¨­å®šç¢¼</value>
+    <value>點擊貼上設定碼</value>
   </data>
   <data name="Onboarding_Connection_GatewayUrl" xml:space="preserve">
-    <value>é–˜é“å™¨ç¶²å€</value>
+    <value>閘道器網址</value>
   </data>
   <data name="Onboarding_Connection_Token" xml:space="preserve">
     <value>Token</value>
   </data>
   <data name="Onboarding_Connection_TokenPlaceholder" xml:space="preserve">
-    <value>è²¼ä¸Šå¼•å°Ž Token</value>
+    <value>貼上引導 Token</value>
   </data>
   <data name="Onboarding_Connection_NodeMode" xml:space="preserve">
-    <value>ç¯€é»žæ¨¡å¼</value>
+    <value>節點模式</value>
   </data>
   <data name="Onboarding_Connection_TestConnection" xml:space="preserve">
-    <value>æ¸¬è©¦é€£ç·š</value>
+    <value>測試連線</value>
   </data>
   <data name="Onboarding_Connection_Ready" xml:space="preserve">
-    <value>æº–å‚™é€£ç·š</value>
+    <value>準備連線</value>
   </data>
   <data name="Onboarding_Connection_ConfigureLaterMsg" xml:space="preserve">
-    <value>æ‚¨å¯ä»¥ç¨å¾Œå¾žç³»çµ±åŒ£é¸å–®è¨­å®šé–˜é“é€£ç·šã€‚</value>
+    <value>您可以稍後從系統匣選單設定閘道連線。</value>
   </data>
   <data name="Onboarding_Connection_StatusDecoded" xml:space="preserve">
-    <value>è¨­å®šç¢¼å·²è§£ç¢¼</value>
+    <value>設定碼已解碼</value>
   </data>
   <data name="Onboarding_Connection_StatusTokenRequired" xml:space="preserve">
-    <value>Token ä¸èƒ½ç‚ºç©º</value>
+    <value>Token 不能為空</value>
   </data>
   <data name="Onboarding_Connection_StatusConnecting" xml:space="preserve">
     <value>正在連線…</value>
   </data>
   <data name="Onboarding_Connection_StatusConnected" xml:space="preserve">
-    <value>å·²é€£ç·šåˆ°é–˜é“</value>
+    <value>已連線到閘道</value>
   </data>
   <data name="Onboarding_Connection_StatusPairing" xml:space="preserve">
-    <value>è£ç½®éœ€è¦æ ¸å‡†</value>
+    <value>裝置需要核准</value>
   </data>
   <data name="Onboarding_Connection_StatusTokenMismatch" xml:space="preserve">
     <value>Token 不符 — 請檢查您的引導 Token</value>
@@ -1178,124 +1178,124 @@
     <value>連線逾時 (15s) — 請確認閘道正在執行</value>
   </data>
   <data name="Onboarding_Permissions_Title" xml:space="preserve">
-    <value>æŽˆäºˆæ¬Šé™</value>
+    <value>授予權限</value>
   </data>
   <data name="Onboarding_Permissions_Description" xml:space="preserve">
-    <value>ç•¶ OpenClaw å¯ä»¥å‚³é€é€šçŸ¥ã€å­˜å–ç›¸æ©Ÿå’Œéº¥å…‹é¢¨ã€æ“·å–èž¢å¹•ä¸¦çŸ¥é“ä½ çš„ä½ç½®æ™‚æ•ˆæžœæœ€ä½³ã€‚è«‹åœ¨ä¸‹æ–¹æŽˆèˆ‡æ¬Šé™ã€‚</value>
+    <value>當 OpenClaw 可以傳送通知、存取相機和麥克風、擷取螢幕並知道你的位置時效果最佳。請在下方授與權限。</value>
   </data>
   <data name="Onboarding_Permissions_Refresh" xml:space="preserve">
-    <value>é‡æ–°æ•´ç†ç‹€æ…‹</value>
+    <value>重新整理狀態</value>
   </data>
   <data name="Onboarding_Permissions_OpenSettings" xml:space="preserve">
-    <value>é–‹å•Ÿè¨­å®š</value>
+    <value>開啟設定</value>
   </data>
   <data name="Onboarding_Permissions_Checking" xml:space="preserve">
     <value>正在檢查權限…</value>
   </data>
   <data name="Onboarding_Chat_Title" xml:space="preserve">
-    <value>èªè­˜æ‚¨çš„ä»£ç†ç¨‹å¼</value>
+    <value>認識您的代理程式</value>
   </data>
   <data name="Onboarding_Chat_Loading" xml:space="preserve">
     <value>正在載入聊天…</value>
   </data>
   <data name="Onboarding_Wizard_Title" xml:space="preserve">
-    <value>è¨­å®šé–˜é“</value>
+    <value>設定閘道</value>
   </data>
   <data name="Onboarding_Wizard_Continue" xml:space="preserve">
-    <value>ç¹¼çºŒ</value>
+    <value>繼續</value>
   </data>
   <data name="Onboarding_Wizard_Skip" xml:space="preserve">
-    <value>ç•¥éŽ</value>
+    <value>略過</value>
   </data>
   <data name="Onboarding_Wizard_Complete" xml:space="preserve">
-    <value>é–˜é“è¨­å®šå®Œæˆï¼</value>
+    <value>閘道設定完成！</value>
   </data>
   <data name="Onboarding_Wizard_Offline" xml:space="preserve">
-    <value>é–˜é“ç²¾éˆç„¡æ³•ä½¿ç”¨</value>
+    <value>閘道精靈無法使用</value>
   </data>
   <data name="Onboarding_Wizard_OfflineMessage" xml:space="preserve">
-    <value>é–˜é“æä¾›å‹•æ…‹è¨­å®šæ­¥é©Ÿï¼Œå°‡åœ¨é€£ç·šå»ºç«‹å¾ŒåŸ·è¡Œã€‚</value>
+    <value>閘道提供動態設定步驟，將在連線建立後執行。</value>
   </data>
   <data name="Onboarding_Perm_Notifications" xml:space="preserve">
-    <value>é€šçŸ¥</value>
+    <value>通知</value>
   </data>
   <data name="Onboarding_Perm_Camera" xml:space="preserve">
-    <value>ç›¸æ©Ÿ</value>
+    <value>相機</value>
   </data>
   <data name="Onboarding_Perm_Microphone" xml:space="preserve">
-    <value>éº¥å…‹é¢¨</value>
+    <value>麥克風</value>
   </data>
   <data name="Onboarding_Perm_ScreenCapture" xml:space="preserve">
-    <value>èž¢å¹•æ“·å–</value>
+    <value>螢幕擷取</value>
   </data>
   <data name="Onboarding_Perm_Location" xml:space="preserve">
-    <value>ä½ç½®ï¼ˆé¸ç”¨ï¼‰</value>
+    <value>位置（選用）</value>
   </data>
   <data name="Onboarding_Perm_Enabled" xml:space="preserve">
-    <value>å·²å•Ÿç”¨</value>
+    <value>已啟用</value>
   </data>
   <data name="Onboarding_Perm_EnabledDefault" xml:space="preserve">
-    <value>å·²å•Ÿç”¨ï¼ˆé è¨­ï¼‰</value>
+    <value>已啟用（預設）</value>
   </data>
   <data name="Onboarding_Perm_Disabled" xml:space="preserve">
-    <value>å·²åœç”¨</value>
+    <value>已停用</value>
   </data>
   <data name="Onboarding_Perm_DisabledManifest" xml:space="preserve">
-    <value>åœ¨æ‡‰ç”¨ç¨‹å¼è³‡è¨Šæ¸…å–®ä¸­å·²åœç”¨</value>
+    <value>在應用程式資訊清單中已停用</value>
   </data>
   <data name="Onboarding_Perm_DisabledPolicy" xml:space="preserve">
-    <value>è¢«åŽŸå‰‡åœç”¨</value>
+    <value>被原則停用</value>
   </data>
   <data name="Onboarding_Perm_DisabledUser" xml:space="preserve">
     <value>已停用 — 開啟設定以啟用</value>
   </data>
   <data name="Onboarding_Perm_Allowed" xml:space="preserve">
-    <value>å·²å…è¨±</value>
+    <value>已允許</value>
   </data>
   <data name="Onboarding_Perm_DeniedUser" xml:space="preserve">
     <value>被拒絕 — 開啟設定以允許</value>
   </data>
   <data name="Onboarding_Perm_DeniedSystem" xml:space="preserve">
-    <value>è¢«ç³»çµ±åŽŸå‰‡æ‹’çµ•</value>
+    <value>被系統原則拒絕</value>
   </data>
   <data name="Onboarding_Perm_NotDetermined" xml:space="preserve">
     <value>未確定 — 開啟設定</value>
   </data>
   <data name="Onboarding_Perm_UnableToCheck" xml:space="preserve">
-    <value>ç„¡æ³•æª¢æŸ¥</value>
+    <value>無法檢查</value>
   </data>
   <data name="Onboarding_Perm_NoCameraDetected" xml:space="preserve">
-    <value>æœªåµæ¸¬åˆ°ç›¸æ©Ÿ</value>
+    <value>未偵測到相機</value>
   </data>
   <data name="Onboarding_Perm_NoMicDetected" xml:space="preserve">
-    <value>æœªåµæ¸¬åˆ°éº¥å…‹é¢¨</value>
+    <value>未偵測到麥克風</value>
   </data>
   <data name="Onboarding_Perm_ScreenCaptureAvailable" xml:space="preserve">
     <value>可用 — 每次擷取使用選擇器</value>
   </data>
   <data name="Onboarding_Perm_NotSupported" xml:space="preserve">
-    <value>æ­¤è£ç½®ä¸æ”¯æ´</value>
+    <value>此裝置不支援</value>
   </data>
   <data name="Onboarding_Perm_LocationDisabledSystem" xml:space="preserve">
-    <value>å®šä½æœå‹™å·²åœ¨ç³»çµ±ç¯„åœåœç”¨</value>
+    <value>定位服務已在系統範圍停用</value>
   </data>
   <data name="Onboarding_Perm_LocationDisabledUser" xml:space="preserve">
-    <value>æ­¤ä½¿ç”¨è€…çš„ä½ç½®å·²åœç”¨</value>
+    <value>此使用者的位置已停用</value>
   </data>
   <data name="Onboarding_Perm_LocationEnabled" xml:space="preserve">
-    <value>å®šä½æœå‹™å·²å•Ÿç”¨</value>
+    <value>定位服務已啟用</value>
   </data>
   <data name="Onboarding_Ready_Feature_TrayMenu_Subtitle" xml:space="preserve">
-    <value>å¾žç³»çµ±åŒ£å­˜å–</value>
+    <value>從系統匣存取</value>
   </data>
   <data name="Onboarding_Ready_Feature_Channels_Subtitle" xml:space="preserve">
     <value>設定 → 頻道</value>
   </data>
   <data name="Onboarding_Ready_Feature_Voice_Subtitle" xml:space="preserve">
-    <value>ç”¨èªžéŸ³å–šé†’</value>
+    <value>用語音喚醒</value>
   </data>
   <data name="Onboarding_Ready_Feature_Canvas_Subtitle" xml:space="preserve">
-    <value>è¦–è¦ºå·¥ä½œå€</value>
+    <value>視覺工作區</value>
   </data>
   <data name="Onboarding_Ready_Feature_Skills_Subtitle" xml:space="preserve">
     <value>設定 → 技能</value>
@@ -1307,82 +1307,82 @@
     <value>速率限制 — 請稍候再試</value>
   </data>
   <data name="Onboarding_Connection_RunOnGateway" xml:space="preserve">
-    <value>åœ¨æ‚¨çš„é–˜é“ä¸ŠåŸ·è¡Œï¼š</value>
+    <value>在您的閘道上執行：</value>
   </data>
   <data name="Onboarding_Connection_ClickToCopy" xml:space="preserve">
-    <value>é»žæ“Šè¤‡è£½</value>
+    <value>點擊複製</value>
   </data>
   <data name="Onboarding_Connection_CopyFailed" xml:space="preserve">
     <value>複製失敗 — 點擊重試</value>
   </data>
   <data name="Onboarding_Connection_Copied" xml:space="preserve">
-    <value>å·²è¤‡è£½ï¼</value>
+    <value>已複製！</value>
   </data>
   <data name="Onboarding_Connection_StatusFailed" xml:space="preserve">
     <value>連線失敗 — 請檢查 URL 和權杖，然後重試</value>
   </data>
   <data name="Onboarding_Wizard_StepError" xml:space="preserve">
-    <value>è™•ç†æ­¤æ­¥é©Ÿæ™‚ç™¼ç”ŸéŒ¯èª¤</value>
+    <value>處理此步驟時發生錯誤</value>
   </data>
   <data name="Onboarding_Connection_StatusDetecting" xml:space="preserve">
-    <value>æ­£åœ¨åµæ¸¬é–˜é“...</value>
+    <value>正在偵測閘道...</value>
   </data>
   <data name="Onboarding_Connection_StatusDetected" xml:space="preserve">
-    <value>å·²åœ¨é–‹ç™¼é€£æŽ¥åŸ åµæ¸¬åˆ°é–˜é“</value>
+    <value>已在開發連接埠偵測到閘道</value>
   </data>
   <data name="Onboarding_Connection_StatusAuthenticating" xml:space="preserve">
-    <value>æ­£åœ¨é©—è­‰...</value>
+    <value>正在驗證...</value>
   </data>
   <data name="Onboarding_Connection_Wsl" xml:space="preserve">
-    <value>WSL é–˜é“</value>
+    <value>WSL 閘道</value>
   </data>
   <data name="Onboarding_Connection_Ssh" xml:space="preserve">
-    <value>SSH ΘÇÜΘüô</value>
+    <value>SSH 通道</value>
   </data>
   <data name="Onboarding_Connection_PasteSetup" xml:space="preserve">
-    <value>è²¼ä¸Š</value>
+    <value>貼上</value>
   </data>
   <data name="Onboarding_Connection_QrButton" xml:space="preserve">
     <value>QR</value>
   </data>
   <data name="Onboarding_Connection_QrFilePickerTitle" xml:space="preserve">
-    <value>åŒ¯å…¥ QR å½±åƒ</value>
+    <value>匯入 QR 影像</value>
   </data>
   <data name="Onboarding_Connection_QrDecodeFailed" xml:space="preserve">
-    <value>ç„¡æ³•å¾žæ­¤å½±åƒè§£ç¢¼è¨­å®šä»£ç¢¼</value>
+    <value>無法從此影像解碼設定代碼</value>
   </data>
   <data name="Onboarding_Connection_SshHint" xml:space="preserve">
-    <value>OpenClaw å°‡å»ºç«‹å—æŽ§ SSH é€šé“ï¼Œå°‡é ç«¯ä¸»æ©Ÿä¸Šçš„é–˜é“é€£æŽ¥åŸ è½‰é€åˆ°æ­¤é›»è…¦ã€‚</value>
+    <value>OpenClaw 將建立受控 SSH 通道，將遠端主機上的閘道連接埠轉送到此電腦。</value>
   </data>
   <data name="Onboarding_Connection_SshUser" xml:space="preserve">
-    <value>SSH Σ╜┐τö¿ΦÇà</value>
+    <value>SSH 使用者</value>
   </data>
   <data name="Onboarding_Connection_SshHost" xml:space="preserve">
-    <value>SSH Σ╕╗µ⌐ƒ</value>
+    <value>SSH 主機</value>
   </data>
   <data name="Onboarding_Connection_SshRemotePort" xml:space="preserve">
-    <value>é ç«¯é–˜é“é€£æŽ¥åŸ </value>
+    <value>遠端閘道連接埠</value>
   </data>
   <data name="Onboarding_Connection_SshLocalPort" xml:space="preserve">
-    <value>æœ¬åœ°è½‰é€é€£æŽ¥åŸ </value>
+    <value>本地轉送連接埠</value>
   </data>
   <data name="Onboarding_Connection_SshPreviewLabel" xml:space="preserve">
-    <value>å—æŽ§é€šé“ï¼š</value>
+    <value>受控通道：</value>
   </data>
   <data name="Onboarding_Connection_SshUserInvalid" xml:space="preserve">
-    <value>é€£ç·šå‰è«‹è¼¸å…¥æœ‰æ•ˆçš„ SSH ä½¿ç”¨è€…ã€‚</value>
+    <value>連線前請輸入有效的 SSH 使用者。</value>
   </data>
   <data name="Onboarding_Connection_SshHostInvalid" xml:space="preserve">
-    <value>é€£ç·šå‰è«‹è¼¸å…¥æœ‰æ•ˆçš„ SSH ä¸»æ©Ÿï¼ˆä¾‹å¦‚ mac-studio.localï¼‰ã€‚</value>
+    <value>連線前請輸入有效的 SSH 主機（例如 mac-studio.local）。</value>
   </data>
   <data name="Onboarding_Connection_TopologyDetectedFmt" xml:space="preserve">
-    <value>å·²åµæ¸¬ï¼š{0}</value>
+    <value>已偵測：{0}</value>
   </data>
   <data name="Onboarding_Connection_LaterStatus" xml:space="preserve">
-    <value>æ‚¨å¯ä»¥ç¨å¾Œåœ¨ã€Œè¨­å®šã€ä¸­è¨­å®šé–˜é“ã€‚</value>
+    <value>您可以稍後在「設定」中設定閘道。</value>
   </data>
   <data name="Onboarding_SetupWarning_Title" xml:space="preserve">
-    <value>è¨­å®š OpenClaw</value>
+    <value>設定 OpenClaw</value>
   </data>
   <data name="Onboarding_SetupWarning_Body" xml:space="preserve">
     <value>OpenClaw 允許代理在此電腦上執行命令、讀寫檔案以及擷取螢幕畫面。僅在您信任的電腦上進行設定。
@@ -1390,64 +1390,64 @@
 ⚠️ 本機設定將安裝一個專用於 OpenClaw 的小型 WSL Linux 執行個體。如果您希望連線到現有或遠端閘道，請選擇「進階設定」。</value>
   </data>
   <data name="Onboarding_SetupWarning_SetupLocally" xml:space="preserve">
-    <value>æœ¬æ©Ÿè¨­å®š</value>
+    <value>本機設定</value>
   </data>
   <data name="Onboarding_SetupWarning_Advanced" xml:space="preserve">
-    <value>é€²éšŽè¨­å®š</value>
+    <value>進階設定</value>
   </data>
   <data name="Onboarding_SetupWarning_ReplaceHeading" xml:space="preserve">
     <value>⚠️ 取代現有設定？</value>
   </data>
   <data name="Onboarding_SetupWarning_ReplaceBody" xml:space="preserve">
-    <value>ç¹¼çºŒå°‡æœƒä¸­æ–·èˆ‡ç›®å‰é–˜é“çš„é€£ç·šä¸¦éºå¤±æ‰€æœ‰è¨­å®šã€‚</value>
+    <value>繼續將會中斷與目前閘道的連線並遺失所有設定。</value>
   </data>
   <data name="Onboarding_SetupWarning_ReplaceConfirm" xml:space="preserve">
-    <value>å–ä»£æˆ‘çš„è¨­å®š</value>
+    <value>取代我的設定</value>
   </data>
   <data name="Onboarding_SetupWarning_ReplaceCancel" xml:space="preserve">
-    <value>ä¿ç•™æˆ‘çš„è¨­å®š</value>
+    <value>保留我的設定</value>
   </data>
   <data name="Onboarding_LocalSetup_Title" xml:space="preserve">
-    <value>æ­£åœ¨æœ¬æ©Ÿè¨­å®š</value>
+    <value>正在本機設定</value>
   </data>
   <data name="Onboarding_LocalSetup_SubtitleIdle" xml:space="preserve">
-    <value>æ­£åœ¨è¨­å®šæ‚¨çš„æœ¬æ©Ÿ OpenClaw é–˜é“ã€‚</value>
+    <value>正在設定您的本機 OpenClaw 閘道。</value>
   </data>
   <data name="Onboarding_LocalSetup_SubtitleSuccess" xml:space="preserve">
-    <value>æœ¬æ©Ÿé–˜é“å·²å°±ç·’ã€‚</value>
+    <value>本機閘道已就緒。</value>
   </data>
   <data name="Onboarding_LocalSetup_Retry" xml:space="preserve">
-    <value>é‡è©¦</value>
+    <value>重試</value>
   </data>
   <data name="Onboarding_LocalSetup_TerminalFailure" xml:space="preserve">
-    <value>è¨­å®šæœªå®Œæˆã€‚</value>
+    <value>設定未完成。</value>
   </data>
   <data name="Onboarding_LocalSetup_DiagnosticsHint" xml:space="preserve">
-    <value>è¨ºæ–·ï¼šaka.ms/wsllogs</value>
+    <value>診斷：aka.ms/wsllogs</value>
   </data>
   <data name="Onboarding_LocalSetup_Phase_Preflight" xml:space="preserve">
-    <value>æ­£åœ¨æª¢æŸ¥ç³»çµ±</value>
+    <value>正在檢查系統</value>
   </data>
   <data name="Onboarding_LocalSetup_Phase_CreateInstance" xml:space="preserve">
-    <value>æ­£åœ¨å®‰è£ Ubuntu</value>
+    <value>正在安裝 Ubuntu</value>
   </data>
   <data name="Onboarding_LocalSetup_Phase_Configure" xml:space="preserve">
-    <value>æ­£åœ¨è¨­å®šåŸ·è¡Œå€‹é«”</value>
+    <value>正在設定執行個體</value>
   </data>
   <data name="Onboarding_LocalSetup_Phase_InstallCli" xml:space="preserve">
-    <value>æ­£åœ¨å®‰è£ OpenClaw</value>
+    <value>正在安裝 OpenClaw</value>
   </data>
   <data name="Onboarding_LocalSetup_Phase_PrepareConfig" xml:space="preserve">
-    <value>æ­£åœ¨æº–å‚™é–˜é“</value>
+    <value>正在準備閘道</value>
   </data>
   <data name="Onboarding_LocalSetup_Phase_StartGateway" xml:space="preserve">
-    <value>æ­£åœ¨å•Ÿå‹•é–˜é“</value>
+    <value>正在啟動閘道</value>
   </data>
   <data name="Onboarding_LocalSetup_Phase_MintToken" xml:space="preserve">
-    <value>æ­£åœ¨ç”¢ç”Ÿè¨­å®šç¢¼</value>
+    <value>正在產生設定碼</value>
   </data>
   <data name="AboutPage_TextBlock_10.Text" xml:space="preserve">
-    <value>é—œæ–¼</value>
+    <value>關於</value>
   </data>
   <data name="AboutPage_TextBlock_19.Text" xml:space="preserve">
     <value>OpenClaw Hub</value>
@@ -1456,37 +1456,37 @@
     <value>.NET 10 / WinUI 3 / WinAppSDK 1.8</value>
   </data>
   <data name="AboutPage_TextBlock_35.Text" xml:space="preserve">
-    <value>é–˜é“è³‡è¨Š</value>
+    <value>閘道資訊</value>
   </data>
   <data name="AboutPage_TextBlock_48.Text" xml:space="preserve">
-    <value>ç‰ˆæœ¬ï¼š</value>
+    <value>版本：</value>
   </data>
   <data name="AboutPage_TextBlock_52.Text" xml:space="preserve">
-    <value>æ¨¡åž‹ï¼š</value>
+    <value>模型：</value>
   </data>
   <data name="AboutPage_TextBlock_56.Text" xml:space="preserve">
-    <value>é©—è­‰æ¨¡å¼ï¼š</value>
+    <value>驗證模式：</value>
   </data>
   <data name="AboutPage_TextBlock_60.Text" xml:space="preserve">
-    <value>åŸ·è¡Œæ™‚é–“ï¼š</value>
+    <value>執行時間：</value>
   </data>
   <data name="AboutPage_TextBlock_72.Text" xml:space="preserve">
-    <value>åµéŒ¯</value>
+    <value>偵錯</value>
   </data>
   <data name="OpenLogButton.Content" xml:space="preserve">
-    <value>é–‹å•Ÿè¨˜éŒ„æª”</value>
+    <value>開啟記錄檔</value>
   </data>
   <data name="OpenConfigButton.Content" xml:space="preserve">
-    <value>é–‹å•Ÿè¨­å®šè³‡æ–™å¤¾</value>
+    <value>開啟設定資料夾</value>
   </data>
   <data name="CopySupportButton.Content" xml:space="preserve">
-    <value>è¤‡è£½æ”¯æ´å…§å®¹</value>
+    <value>複製支援內容</value>
   </data>
   <data name="CheckUpdatesButton.Content" xml:space="preserve">
-    <value>æª¢æŸ¥æ›´æ–°</value>
+    <value>檢查更新</value>
   </data>
   <data name="AboutPage_TextBlock_91.Text" xml:space="preserve">
-    <value>é€£çµ</value>
+    <value>連結</value>
   </data>
   <data name="AboutPage_HyperlinkButton_92.Content" xml:space="preserve">
     <value>Documentation → openclaw.ai/docs</value>
@@ -1498,115 +1498,115 @@
     <value>Dashboard → openclaw://dashboard</value>
   </data>
   <data name="AgentEventsPage_TextBlock_18.Text" xml:space="preserve">
-    <value>ä»£ç†ç¨‹å¼äº‹ä»¶</value>
+    <value>代理程式事件</value>
   </data>
   <data name="AgentFilterCombo.Header" xml:space="preserve">
-    <value>ä»£ç†ç¨‹å¼</value>
+    <value>代理程式</value>
   </data>
   <data name="AgentFilterCombo.PlaceholderText" xml:space="preserve">
-    <value>æ‰€æœ‰ä»£ç†ç¨‹å¼</value>
+    <value>所有代理程式</value>
   </data>
   <data name="AgentEventsPage_IntroText.Text" xml:space="preserve">
     <value>代理程式活動的即時串流——工具呼叫、回應、錯誤和生命週期事件。</value>
   </data>
   <data name="AgentEventsPage_ComboBoxItem_26.Content" xml:space="preserve">
-    <value>æ‰€æœ‰ä»£ç†ç¨‹å¼</value>
+    <value>所有代理程式</value>
   </data>
   <data name="AgentEventsPage_ToggleButton_36.Text" xml:space="preserve">
-    <value>å·¥å…·</value>
+    <value>工具</value>
   </data>
   <data name="AgentEventsPage_ToggleButton_37.Text" xml:space="preserve">
-    <value>åŠ©ç†</value>
+    <value>助理</value>
   </data>
   <data name="AgentEventsPage_ToggleButton_38.Text" xml:space="preserve">
-    <value>éŒ¯èª¤</value>
+    <value>錯誤</value>
   </data>
   <data name="AgentEventsPage_ToggleButton_39.Text" xml:space="preserve">
-    <value>ç”Ÿå‘½é€±æœŸ</value>
+    <value>生命週期</value>
   </data>
   <data name="AgentEventsPage_ToggleButton_40.Text" xml:space="preserve">
-    <value>è¨ˆç•«</value>
+    <value>計畫</value>
   </data>
   <data name="AgentEventsPage_ToggleButton_41.Text" xml:space="preserve">
-    <value>æ ¸å‡†</value>
+    <value>核准</value>
   </data>
   <data name="AgentEventsPage_ToggleButton_42.Text" xml:space="preserve">
-    <value>æ€è€ƒä¸­</value>
+    <value>思考中</value>
   </data>
   <data name="AgentEventsPage_ToggleButton_43.Text" xml:space="preserve">
-    <value>ä¿®è£œç¨‹å¼</value>
+    <value>修補程式</value>
   </data>
   <data name="AgentEventsPage_TextBlock_96.Text" xml:space="preserve">
-    <value>å°šç„¡ä»£ç†ç¨‹å¼äº‹ä»¶</value>
+    <value>尚無代理程式事件</value>
   </data>
   <data name="AgentEventsPage_TextBlock_99.Text" xml:space="preserve">
-    <value>ä»£ç†ç¨‹å¼åŸ·è¡Œæ™‚ï¼Œå³æ™‚ä»£ç†ç¨‹å¼äº‹ä»¶ (å·¥å…·å‘¼å«ã€å›žæ‡‰ã€éŒ¯èª¤) æœƒé¡¯ç¤ºåœ¨é€™è£¡ã€‚</value>
+    <value>代理程式執行時，即時代理程式事件 (工具呼叫、回應、錯誤) 會顯示在這裡。</value>
   </data>
   <data name="ClearButton.Content" xml:space="preserve">
-    <value>æ¸…é™¤</value>
+    <value>清除</value>
   </data>
   <data name="ClearButton.Text" xml:space="preserve">
-    <value>æ¸…é™¤</value>
+    <value>清除</value>
   </data>
   <data name="BindingsPage_TextBlock_16.Text" xml:space="preserve">
-    <value>ç¹«çµ</value>
+    <value>繫結</value>
   </data>
   <data name="BindingsPage_TextBlock_17.Text" xml:space="preserve">
-    <value>è¨Šæ¯è·¯ç”±è¦å‰‡</value>
+    <value>訊息路由規則</value>
   </data>
   <data name="BindingsPage_TextBlock_25.Text" xml:space="preserve">
-    <value>é‡æ–°æ•´ç†</value>
+    <value>重新整理</value>
   </data>
   <data name="CapabilitiesPage_TextBlock_10.Text" xml:space="preserve">
     <value>🖥️ 這部電腦</value>
   </data>
   <data name="PermissionsPage_IntroText.Text" xml:space="preserve">
-    <value>é€éŽé–˜é“æä¾›çµ¦ä»£ç†ç¨‹å¼çš„è£ç½®åŠŸèƒ½ã€‚åˆ‡æ›é€™éƒ¨é›»è…¦å¯ä»¥åŸ·è¡Œçš„å‹•ä½œã€‚</value>
+    <value>透過閘道提供給代理程式的裝置功能。切換這部電腦可以執行的動作。</value>
   </data>
   <data name="PermissionsPage_McpHeader.Text" xml:space="preserve">
-    <value>æœ¬æ©Ÿ MCP ä¼ºæœå™¨</value>
+    <value>本機 MCP 伺服器</value>
   </data>
   <data name="PermissionsPage_McpDescription.Text" xml:space="preserve">
-    <value>é€éŽ HTTP å‘ CLI å·¥å…·å’Œæœ¬æ©Ÿæ•´åˆå…¬é–‹åŠŸèƒ½ã€‚</value>
+    <value>透過 HTTP 向 CLI 工具和本機整合公開功能。</value>
   </data>
   <data name="PermissionsPage_McpEndpointLabel.Text" xml:space="preserve">
-    <value>ç«¯é»žï¼š</value>
+    <value>端點：</value>
   </data>
   <data name="CopyMcpTokenButton.Content" xml:space="preserve">
-    <value>è¤‡è£½æ¬Šæ–</value>
+    <value>複製權杖</value>
   </data>
   <data name="CopyMcpUrlButton.Content" xml:space="preserve">
-    <value>è¤‡è£½ URL</value>
+    <value>複製 URL</value>
   </data>
   <data name="CapabilitiesPage_TextBlock_66.Text" xml:space="preserve">
-    <value>ç¯€é»žç‹€æ…‹</value>
+    <value>節點狀態</value>
   </data>
   <data name="NodeStatusText.Text" xml:space="preserve">
-    <value>ç¯€é»žæ¨¡å¼å·²åœç”¨</value>
+    <value>節點模式已停用</value>
   </data>
   <data name="ChannelsPage_TextBlock_10.Text" xml:space="preserve">
     <value>📡 頻道</value>
   </data>
   <data name="ConnectionWarning.Title" xml:space="preserve">
-    <value>æœªé€£ç·š</value>
+    <value>未連線</value>
   </data>
   <data name="ChannelsPage_TextBlock_22.Text" xml:space="preserve">
-    <value>æœªè¨­å®šé »é“</value>
+    <value>未設定頻道</value>
   </data>
   <data name="ChatPage_TextBlock_53.Text" xml:space="preserve">
-    <value>é€£ç·šåˆ°é–˜é“ä»¥é–‹å§‹èŠå¤©</value>
+    <value>連線到閘道以開始聊天</value>
   </data>
   <data name="ChatPage_WaitingTitle.Text" xml:space="preserve">
     <value>等待聊天啟動…</value>
   </data>
   <data name="ChatPage_WaitingStatusText.Text" xml:space="preserve">
-    <value>é–˜é“å·²é€£æŽ¥ï¼›èŠå¤©ä»‹é¢ä»åœ¨ä¸Šç·šä¸­ã€‚</value>
+    <value>閘道已連接；聊天介面仍在上線中。</value>
   </data>
   <data name="ConfigPage_TextBlock_17.Text" xml:space="preserve">
-    <value>è¨­å®š</value>
+    <value>設定</value>
   </data>
   <data name="ConfigPage_TextBlock_21.Text" xml:space="preserve">
-    <value>é‡æ–°æ•´ç†</value>
+    <value>重新整理</value>
   </data>
   <data name="ConfigPage_OpenConnection.Content" xml:space="preserve">
     <value>開啟連線</value>
@@ -1657,22 +1657,22 @@
     <value>捨棄變更</value>
   </data>
   <data name="ConfigPage_TabViewItem_34.Text" xml:space="preserve">
-    <value>ç·¨è¼¯å™¨</value>
+    <value>編輯器</value>
   </data>
   <data name="DetailPath.Text" xml:space="preserve">
-    <value>é¸å–è¨­å®šå€æ®µ</value>
+    <value>選取設定區段</value>
   </data>
 <data name="ConfigPage_TabViewItem_82.Text" xml:space="preserve">
-    <value>åŽŸå§‹ JSON</value>
+    <value>原始 JSON</value>
   </data>
   <data name="ConfigPage_TextBlock_95.Text" xml:space="preserve">
-    <value>çµæ§‹æè¿°ç„¡æ³•ä½¿ç”¨</value>
+    <value>結構描述無法使用</value>
   </data>
   <data name="ConfigPage_TextBlock_98.Text" xml:space="preserve">
-    <value>ç„¡æ³•è¼‰å…¥é–˜é“è¨­å®šçµæ§‹æè¿°ã€‚è«‹ä½¿ç”¨ç¶²é å„€è¡¨æ¿ç·¨è¼¯è¨­å®šã€‚</value>
+    <value>無法載入閘道設定結構描述。請使用網頁儀表板編輯設定。</value>
   </data>
   <data name="OpenDashboardButton.Content" xml:space="preserve">
-    <value>é–‹å•Ÿå„€è¡¨æ¿</value>
+    <value>開啟儀表板</value>
   </data>
   <data name="ConfigPage_ReconnectDialogTitle" xml:space="preserve">
     <value>Saving configuration</value>
@@ -1687,142 +1687,142 @@
     <value>Reconnecting...</value>
   </data>
   <data name="SaveButton.Content" xml:space="preserve">
-    <value>å„²å­˜è®Šæ›´</value>
+    <value>儲存變更</value>
   </data>
   <data name="SaveButtonText.Text" xml:space="preserve">
-    <value>å„²å­˜è®Šæ›´</value>
+    <value>儲存變更</value>
   </data>
   <data name="ConnectionPage_TextBlock_10.Text" xml:space="preserve">
     <value>🔗 連線</value>
   </data>
   <data name="ConnectionPage_TextBlock_11.Text" xml:space="preserve">
-    <value>æ“ä½œå“¡ç”¨æˆ¶ç«¯å’Œç¯€é»žæœå‹™å…±åŒä½¿ç”¨çš„é–˜é“ç«¯é»žã€‚</value>
+    <value>操作員用戶端和節點服務共同使用的閘道端點。</value>
   </data>
   <data name="AuthErrorBar.Title" xml:space="preserve">
-    <value>é€£ç·šéŒ¯èª¤</value>
+    <value>連線錯誤</value>
   </data>
   <data name="StatusText.Text" xml:space="preserve">
-    <value>å·²ä¸­æ–·é€£ç·š</value>
+    <value>已中斷連線</value>
   </data>
   <data name="ReconnectButton.Content" xml:space="preserve">
-    <value>é‡æ–°é€£ç·š</value>
+    <value>重新連線</value>
   </data>
   <data name="OperatorStatusText.Text" xml:space="preserve">
     <value>操作員：—</value>
   </data>
   <data name="ConnectToggle.Header" xml:space="preserve">
-    <value>é€£ç·š</value>
+    <value>連線</value>
   </data>
   <data name="ConnectionPage_TextBlock_76.Text" xml:space="preserve">
     <value>📡 可用閘道</value>
   </data>
   <data name="ConnectionPage_TextBlock_84.Text" xml:space="preserve">
-    <value>æŽƒæ</value>
+    <value>掃描</value>
   </data>
   <data name="TokenPromptText.Text" xml:space="preserve">
-    <value>æ­¤é–˜é“éœ€è¦æ¬Šæ–æ‰èƒ½é€£ç·šã€‚</value>
+    <value>此閘道需要權杖才能連線。</value>
   </data>
   <data name="ConnectionPage_Button_105.Content" xml:space="preserve">
-    <value>å–æ¶ˆ</value>
+    <value>取消</value>
   </data>
   <data name="TokenPromptConnectBtn.Content" xml:space="preserve">
-    <value>é€£ç·š</value>
+    <value>連線</value>
   </data>
   <data name="ConnectionPage_TextBlock_111.Text" xml:space="preserve">
-    <value>åœ¨é–˜é“ä¸»æ©Ÿä¸ŠåŸ·è¡Œ 'openclaw qr' å–å¾—è¨­å®šç¢¼ï¼Œæˆ–åœ¨é–˜é“è¨­å®šä¸­å°‹æ‰¾æ¬Šæ–ã€‚</value>
+    <value>在閘道主機上執行 'openclaw qr' 取得設定碼，或在閘道設定中尋找權杖。</value>
   </data>
   <data name="GatewayEmptyText.Text" xml:space="preserve">
-    <value>æ‰¾ä¸åˆ°é–˜é“ã€‚æŒ‰ä¸€ä¸‹ã€ŒæŽƒæã€é€²è¡Œæœå°‹ã€‚</value>
+    <value>找不到閘道。按一下「掃描」進行搜尋。</value>
   </data>
   <data name="ConnectionPage_TextBlock_128.Text" xml:space="preserve">
     <value>🔑 設定碼</value>
   </data>
   <data name="ConnectionPage_TextBlock_129.Text" xml:space="preserve">
-    <value>è²¼ä¸Šä¾†è‡ª openclaw qr çš„è¨­å®šç¢¼</value>
+    <value>貼上來自 openclaw qr 的設定碼</value>
   </data>
   <data name="ApplySetupCodeButton.Content" xml:space="preserve">
-    <value>å¥—ç”¨</value>
+    <value>套用</value>
   </data>
   <data name="ConnectionPage_TextBlock_152.Text" xml:space="preserve">
-    <value>é€²éšŽé€£ç·šè¨­å®š</value>
+    <value>進階連線設定</value>
   </data>
   <data name="GatewayUrlTextBox.Header" xml:space="preserve">
-    <value>é–˜é“å™¨ç¶²å€</value>
+    <value>閘道器網址</value>
   </data>
   <data name="TokenTextBox.Header" xml:space="preserve">
     <value>Token</value>
   </data>
   <data name="TestButton.Content" xml:space="preserve">
-    <value>æ¸¬è©¦</value>
+    <value>測試</value>
   </data>
   <data name="SshToggle.Header" xml:space="preserve">
-    <value>SSH ΘÇÜΘüô</value>
+    <value>SSH 通道</value>
   </data>
   <data name="SshUserBox.Header" xml:space="preserve">
-    <value>SSH Σ╜┐τö¿ΦÇà</value>
+    <value>SSH 使用者</value>
   </data>
   <data name="SshUserBox.PlaceholderText" xml:space="preserve">
     <value>user</value>
   </data>
   <data name="SshHostBox.Header" xml:space="preserve">
-    <value>SSH Σ╕╗µ⌐ƒ</value>
+    <value>SSH 主機</value>
   </data>
   <data name="SshHostBox.PlaceholderText" xml:space="preserve">
     <value>machine-name</value>
   </data>
   <data name="SshRemotePortBox.Header" xml:space="preserve">
-    <value>é ç«¯é€£æŽ¥åŸ </value>
+    <value>遠端連接埠</value>
   </data>
   <data name="SshLocalPortBox.Header" xml:space="preserve">
-    <value>æœ¬æ©Ÿé€£æŽ¥åŸ </value>
+    <value>本機連接埠</value>
   </data>
   <data name="ConnectionPage_Button_190.Content" xml:space="preserve">
-    <value>å„²å­˜</value>
+    <value>儲存</value>
   </data>
   <data name="ConnectionPage_TextBlock_200.Text" xml:space="preserve">
     <value>🪪 此裝置</value>
   </data>
   <data name="ConnectionPage_TextBlock_207.Text" xml:space="preserve">
-    <value>è£ç½® IDï¼š</value>
+    <value>裝置 ID：</value>
   </data>
   <data name="CopyDeviceIdButton.Content" xml:space="preserve">
-    <value>è¤‡è£½</value>
+    <value>複製</value>
   </data>
   <data name="ConnectionPage_TextBlock_219.Text" xml:space="preserve">
-    <value>åœ¨é–˜é“ä¸»æ©Ÿä¸ŠåŸ·è¡Œæ­¤å‘½ä»¤ä»¥æ ¸å‡†ï¼š</value>
+    <value>在閘道主機上執行此命令以核准：</value>
   </data>
   <data name="CopyApprovalButton.Content" xml:space="preserve">
-    <value>è¤‡è£½</value>
+    <value>複製</value>
   </data>
   <data name="ConnectionPage_TextBlock_243.Text" xml:space="preserve">
     <value>📋 連線記錄</value>
   </data>
   <data name="ConnectionLogEmpty.Text" xml:space="preserve">
-    <value>æ²’æœ‰æœ€è¿‘çš„é€£ç·šäº‹ä»¶ã€‚</value>
+    <value>沒有最近的連線事件。</value>
   </data>
   <data name="ConversationsPage_TextBlock_16.Text" xml:space="preserve">
-    <value>äº¤è«‡</value>
+    <value>交談</value>
   </data>
   <data name="ConversationsPage_ComboBoxItem_29.Content" xml:space="preserve">
-    <value>å…¨éƒ¨</value>
+    <value>全部</value>
   </data>
   <data name="ConversationsPage_ComboBoxItem_30.Content" xml:space="preserve">
-    <value>ä¾é »é“</value>
+    <value>依頻道</value>
   </data>
   <data name="ConversationsPage_ComboBoxItem_31.Content" xml:space="preserve">
-    <value>ä¾ç‹€æ…‹</value>
+    <value>依狀態</value>
   </data>
   <data name="ConversationsPage_TextBlock_37.Text" xml:space="preserve">
-    <value>é‡æ–°æ•´ç†</value>
+    <value>重新整理</value>
   </data>
   <data name="CronPage_TextBlock_10.Text" xml:space="preserve">
     <value>⏱️ Cron 工作</value>
   </data>
   <data name="CronPage_TextBlock_29.Text" xml:space="preserve">
-    <value>æŽ’ç¨‹å™¨ç‹€æ…‹</value>
+    <value>排程器狀態</value>
   </data>
   <data name="SchedulerStatusText.Text" xml:space="preserve">
-    <value>å·²å•Ÿç”¨</value>
+    <value>已啟用</value>
   </data>
   <data name="StorePathText.Text" xml:space="preserve">
     <value>Store: ~/.openclaw/cron.db</value>
@@ -1831,22 +1831,22 @@
     <value>下次喚醒：—</value>
   </data>
   <data name="CronPage_Button_80.Content" xml:space="preserve">
-    <value>ç«‹å³åŸ·è¡Œ</value>
+    <value>立即執行</value>
   </data>
   <data name="CronPage_TextBlock_90.Text" xml:space="preserve">
-    <value>ä¸Šæ¬¡åŸ·è¡Œï¼š</value>
+    <value>上次執行：</value>
   </data>
   <data name="CronPage_TextBlock_104.Text" xml:space="preserve">
-    <value>ä¸‹æ¬¡åŸ·è¡Œï¼š</value>
+    <value>下次執行：</value>
   </data>
   <data name="CronPage_TextBlock_120.Text" xml:space="preserve">
-    <value>æœªè¨­å®š Cron å·¥ä½œ</value>
+    <value>未設定 Cron 工作</value>
   </data>
   <data name="DebugPage_TextBlock_8.Text" xml:space="preserve">
     <value>🐛 偵錯</value>
   </data>
   <data name="DebugPage_TextBlock_14.Text" xml:space="preserve">
-    <value>è¨˜éŒ„æª¢è¦–å™¨</value>
+    <value>記錄檢視器</value>
   </data>
   <data name="DebugPage_Button_18.Content" xml:space="preserve">
     <value>⟳ 重新整理</value>
@@ -1855,34 +1855,34 @@
     <value>📋 複製記錄</value>
   </data>
   <data name="LogText.Text" xml:space="preserve">
-    <value>æ­£åœ¨è¼‰å…¥...</value>
+    <value>正在載入...</value>
   </data>
   <data name="DebugPage_TextBlock_38.Text" xml:space="preserve">
-    <value>é€£ç·šç‹€æ…‹</value>
+    <value>連線狀態</value>
   </data>
   <data name="DebugPage_TextBlock_52.Text" xml:space="preserve">
-    <value>æ“ä½œå“¡ç‹€æ…‹</value>
+    <value>操作員狀態</value>
   </data>
   <data name="DebugPage_TextBlock_56.Text" xml:space="preserve">
-    <value>é–˜é“å™¨ç¶²å€</value>
+    <value>閘道器網址</value>
   </data>
   <data name="DebugPage_TextBlock_61.Text" xml:space="preserve">
-    <value>ç¯€é»žæ¨¡å¼</value>
+    <value>節點模式</value>
   </data>
   <data name="DebugPage_TextBlock_72.Text" xml:space="preserve">
-    <value>è£ç½®èº«åˆ†è­˜åˆ¥</value>
+    <value>裝置身分識別</value>
   </data>
   <data name="DebugPage_TextBlock_86.Text" xml:space="preserve">
-    <value>è£ç½® ID</value>
+    <value>裝置 ID</value>
   </data>
   <data name="DebugPage_Button_91.Content" xml:space="preserve">
     <value>📋 複製</value>
   </data>
   <data name="DebugPage_TextBlock_94.Text" xml:space="preserve">
-    <value>å…¬é–‹é‡‘é‘°</value>
+    <value>公開金鑰</value>
   </data>
   <data name="DebugPage_TextBlock_108.Text" xml:space="preserve">
-    <value>åµéŒ¯å‹•ä½œ</value>
+    <value>偵錯動作</value>
   </data>
   <data name="DebugPage_Button_111.Content" xml:space="preserve">
     <value>📄 開啟記錄檔</value>
@@ -1897,31 +1897,31 @@
     <value>📋 複製支援內容</value>
   </data>
   <data name="StatusHeadline.Text" xml:space="preserve">
-    <value>æœªé€£ç·šåˆ°é–˜é“</value>
+    <value>未連線到閘道</value>
   </data>
   <data name="ScanButton.Content" xml:space="preserve">
-    <value>æŽƒæé–˜é“</value>
+    <value>掃描閘道</value>
   </data>
   <data name="DashboardButton.Content" xml:space="preserve">
-    <value>é–‹å•Ÿå„€è¡¨æ¿</value>
+    <value>開啟儀表板</value>
   </data>
   <data name="ChatButton.Content" xml:space="preserve">
-    <value>é–‹å•ŸèŠå¤©</value>
+    <value>開啟聊天</value>
   </data>
   <data name="HealthCheckButton.Content" xml:space="preserve">
-    <value>å¥åº·æª¢æŸ¥</value>
+    <value>健康檢查</value>
   </data>
   <data name="RefreshButton.Content" xml:space="preserve">
     <value>⟳ 重新整理</value>
   </data>
   <data name="NodesPage_Action_Rename" xml:space="preserve">
-    <value>é‡æ–°å‘½å</value>
+    <value>重新命名</value>
   </data>
   <data name="NodesPage_Action_Forget" xml:space="preserve">
-    <value>å¿˜è¨˜</value>
+    <value>忘記</value>
   </data>
   <data name="NodesPage_Action_MoreOptions" xml:space="preserve">
-    <value>æ›´å¤šé¸é …</value>
+    <value>更多選項</value>
   </data>
   <data name="NodesPage_Label_Version" xml:space="preserve">
     <value>Version</value>
@@ -1930,154 +1930,154 @@
     <value>Hardware</value>
   </data>
   <data name="NodesPage_Label_Network" xml:space="preserve">
-    <value>ç¶²è·¯</value>
+    <value>網路</value>
   </data>
   <data name="NodesPage_Label_Approved" xml:space="preserve">
-    <value>å·²æ ¸å‡†</value>
+    <value>已核准</value>
   </data>
   <data name="NodesPage_Label_Connected" xml:space="preserve">
-    <value>å·²é€£ç·š</value>
+    <value>已連線</value>
   </data>
   <data name="NodesPage_Label_LastSeen" xml:space="preserve">
-    <value>ä¸Šæ¬¡çœ‹åˆ°</value>
+    <value>上次看到</value>
   </data>
   <data name="NodesPage_Label_Capabilities" xml:space="preserve">
-    <value>åŠŸèƒ½</value>
+    <value>功能</value>
   </data>
   <data name="NodesPage_Label_Permissions" xml:space="preserve">
-    <value>æ¬Šé™</value>
+    <value>權限</value>
   </data>
   <data name="NodesPage_Label_PathEnv" xml:space="preserve">
     <value>PATH</value>
   </data>
   <data name="NodesPage_Commands_Header" xml:space="preserve">
-    <value>å‘½ä»¤ ({0})</value>
+    <value>命令 ({0})</value>
   </data>
   <data name="NodesPage_Command_DisabledSuffix" xml:space="preserve">
-    <value>ï¼ˆå·²åœç”¨ï¼‰</value>
+    <value>（已停用）</value>
   </data>
   <data name="NodesPage_Rename_Title" xml:space="preserve">
-    <value>é‡æ–°å‘½åç¯€é»ž</value>
+    <value>重新命名節點</value>
   </data>
   <data name="NodesPage_Rename_Body" xml:space="preserve">
-    <value>ç‚º {0} é¸æ“‡æ–°çš„é¡¯ç¤ºåç¨±ã€‚</value>
+    <value>為 {0} 選擇新的顯示名稱。</value>
   </data>
   <data name="NodesPage_Rename_Placeholder" xml:space="preserve">
-    <value>é¡¯ç¤ºåç¨±</value>
+    <value>顯示名稱</value>
   </data>
   <data name="NodesPage_Rename_Primary" xml:space="preserve">
-    <value>é‡æ–°å‘½å</value>
+    <value>重新命名</value>
   </data>
   <data name="NodesPage_Rename_Error_Empty" xml:space="preserve">
-    <value>é¡¯ç¤ºåç¨±ä¸èƒ½ç‚ºç©ºã€‚</value>
+    <value>顯示名稱不能為空。</value>
   </data>
   <data name="NodesPage_Rename_Error_Generic" xml:space="preserve">
-    <value>é‡æ–°å‘½åå¤±æ•—ã€‚</value>
+    <value>重新命名失敗。</value>
   </data>
   <data name="NodesPage_Forget_Title" xml:space="preserve">
-    <value>å¿˜è¨˜ç¯€é»žï¼Ÿ</value>
+    <value>忘記節點？</value>
   </data>
   <data name="NodesPage_Forget_Body" xml:space="preserve">
-    <value>é€™å°‡å¾žé–˜é“ä¸­åˆªé™¤ä¸‹é¢ç¯€é»žçš„è¨˜éŒ„ã€‚ç¯€é»žéœ€è¦é‡æ–°é…å°æ‰èƒ½å†æ¬¡é€£ç·šã€‚</value>
+    <value>這將從閘道中刪除下面節點的記錄。節點需要重新配對才能再次連線。</value>
   </data>
   <data name="NodesPage_Forget_Warning" xml:space="preserve">
-    <value>é‡å°è©²ç¯€é»žçš„ä½œç”¨ä¸­æ“ä½œå“¡å’ŒèŠå¤©å·¥ä½œéšŽæ®µå°‡ç«‹å³å¤±åŽ»å­˜å–æ¬Šã€‚</value>
+    <value>針對該節點的作用中操作員和聊天工作階段將立即失去存取權。</value>
   </data>
   <data name="NodesPage_Forget_Primary" xml:space="preserve">
-    <value>å¿˜è¨˜ç¯€é»ž</value>
+    <value>忘記節點</value>
   </data>
   <data name="NodesPage_Forget_Error_Generic" xml:space="preserve">
     <value>無法忘記節點 — 閘道無法連線或權限遭拒。</value>
   </data>
   <data name="NodesPage_Common_Cancel" xml:space="preserve">
-    <value>å–æ¶ˆ</value>
+    <value>取消</value>
   </data>
   <data name="PermissionsPage_TextBlock_8.Text" xml:space="preserve">
     <value>🔐 權限</value>
   </data>
   <data name="PermissionsPage_TextBlock_14.Text" xml:space="preserve">
-    <value>åŸ·è¡ŒåŽŸå‰‡</value>
+    <value>執行原則</value>
   </data>
   <data name="PermissionsPage_TextBlock_17.Text" xml:space="preserve">
-    <value>æŽ§åˆ¶ä»£ç†ç¨‹å¼å¯åœ¨æ­¤ç¯€é»žä¸ŠåŸ·è¡Œå“ªäº›å‘½ä»¤ã€‚è¦å‰‡æœƒæ¯”å°å®Œæ•´å‘½ä»¤åˆ—ã€‚</value>
+    <value>控制代理程式可在此節點上執行哪些命令。規則會比對完整命令列。</value>
   </data>
   <data name="DefaultActionCombo.Header" xml:space="preserve">
-    <value>é è¨­å‹•ä½œ</value>
+    <value>預設動作</value>
   </data>
   <data name="PermissionsPage_ComboBoxItem_23.Content" xml:space="preserve">
-    <value>æ‹’çµ•</value>
+    <value>拒絕</value>
   </data>
   <data name="PermissionsPage_ComboBoxItem_24.Content" xml:space="preserve">
-    <value>å…è¨±</value>
+    <value>允許</value>
   </data>
   <data name="PermissionsPage_ComboBoxItem_25.Content" xml:space="preserve">
-    <value>è©¢å•</value>
+    <value>詢問</value>
   </data>
   <data name="PermissionsPage_TextBlock_28.Text" xml:space="preserve">
-    <value>è¦å‰‡</value>
+    <value>規則</value>
   </data>
   <data name="NewRulePattern.PlaceholderText" xml:space="preserve">
-    <value>å‘½ä»¤æ¨¡å¼ (ä¾‹å¦‚ echo *)</value>
+    <value>命令模式 (例如 echo *)</value>
   </data>
   <data name="PermissionsPage_ComboBoxItem_54.Content" xml:space="preserve">
-    <value>å…è¨±</value>
+    <value>允許</value>
   </data>
   <data name="PermissionsPage_ComboBoxItem_55.Content" xml:space="preserve">
-    <value>æ‹’çµ•</value>
+    <value>拒絕</value>
   </data>
   <data name="PermissionsPage_Button_57.Content" xml:space="preserve">
-    <value>æ–°å¢žè¦å‰‡</value>
+    <value>新增規則</value>
   </data>
   <data name="PermissionsPage_TextBlock_69.Text" xml:space="preserve">
-    <value>ç¯€é»žå…è¨±æ¸…å–®</value>
+    <value>節點允許清單</value>
   </data>
   <data name="PermissionsPage_TextBlock_72.Text" xml:space="preserve">
     <value>閘道允許已連線節點執行的命令。此清單為唯讀 — 請透過「設定」頁面編輯。</value>
   </data>
   <data name="AllowlistEmpty.Text" xml:space="preserve">
-    <value>æ²’æœ‰å¯ç”¨çš„å…è¨±æ¸…å–®è³‡æ–™ã€‚è«‹å…ˆé€£ç·šåˆ°é–˜é“ã€‚</value>
+    <value>沒有可用的允許清單資料。請先連線到閘道。</value>
   </data>
   <data name="PermissionsPage_TextBlock_92.Text" xml:space="preserve">
-    <value>ç³»çµ±æ¬Šé™</value>
+    <value>系統權限</value>
   </data>
   <data name="PermissionsPage_TextBlock_95.Text" xml:space="preserve">
-    <value>ç›¸æ©Ÿã€éº¥å…‹é¢¨å’Œèž¢å¹•æ“·å–çš„ç³»çµ±æ¬Šé™ã€‚é€™äº›ç”± Windows éš±ç§æ¬Šè¨­å®šç®¡ç†ã€‚</value>
+    <value>相機、麥克風和螢幕擷取的系統權限。這些由 Windows 隱私權設定管理。</value>
   </data>
   <data name="PermissionsPage_TextBlock_110.Text" xml:space="preserve">
     <value>📷 相機</value>
   </data>
   <data name="CameraPermStatus.Text" xml:space="preserve">
-    <value>æœªçŸ¥</value>
+    <value>未知</value>
   </data>
   <data name="PermissionsPage_TextBlock_114.Text" xml:space="preserve">
     <value>🎤 麥克風</value>
   </data>
   <data name="MicPermStatus.Text" xml:space="preserve">
-    <value>æœªçŸ¥</value>
+    <value>未知</value>
   </data>
   <data name="PermissionsPage_TextBlock_118.Text" xml:space="preserve">
     <value>🖥️ 螢幕擷取</value>
   </data>
   <data name="ScreenPermStatus.Text" xml:space="preserve">
-    <value>å¯ç”¨</value>
+    <value>可用</value>
   </data>
   <data name="PermissionsPage_Button_123.Content" xml:space="preserve">
-    <value>é–‹å•Ÿ Windows éš±ç§æ¬Šè¨­å®š</value>
+    <value>開啟 Windows 隱私權設定</value>
   </data>
   <data name="SessionsPage_TextBlock_10.Text" xml:space="preserve">
     <value>💬 工作階段</value>
   </data>
   <data name="SessionsPage_Button_57.Content" xml:space="preserve">
-    <value>é‡è¨­</value>
+    <value>重設</value>
   </data>
   <data name="SessionsPage_Button_59.Content" xml:space="preserve">
-    <value>å£“ç¸®</value>
+    <value>壓縮</value>
   </data>
   <data name="SessionsPage_Button_61.Content" xml:space="preserve">
-    <value>åˆªé™¤</value>
+    <value>刪除</value>
   </data>
   <data name="SessionsPage_TextBlock_73.Text" xml:space="preserve">
-    <value>ç„¡æ´»èºæœƒè©±</value>
+    <value>無活躍會話</value>
   </data>
   <data name="SessionsPage_TextBlock_84.Text" xml:space="preserve">
     <value>🤖 可用模型</value>
@@ -2086,109 +2086,109 @@
     <value>⚙️ 設定</value>
   </data>
   <data name="SettingsPage_TextBlock_17.Text" xml:space="preserve">
-    <value>é€™éƒ¨é›»è…¦çš„æœ¬æ©Ÿæ‡‰ç”¨ç¨‹å¼åå¥½è¨­å®šã€‚</value>
+    <value>這部電腦的本機應用程式偏好設定。</value>
   </data>
   <data name="SettingsPage_TextBlock_26.Text" xml:space="preserve">
-    <value>å•Ÿå‹•</value>
+    <value>啟動</value>
   </data>
   <data name="AutoStartToggle.Header" xml:space="preserve">
-    <value>é–‹æ©Ÿè‡ªå•Ÿå‹•</value>
+    <value>開機自啟動</value>
   </data>
   <data name="GlobalHotkeyToggle.Header" xml:space="preserve">
     <value>全域快速鍵 (Ctrl+Alt+Shift+C → 快速傳送)</value>
   </data>
   <data name="SettingsPage_TextBlock_41.Text" xml:space="preserve">
-    <value>é€šçŸ¥</value>
+    <value>通知</value>
   </data>
   <data name="NotificationsToggle.Header" xml:space="preserve">
-    <value>é¡¯ç¤ºé€šçŸ¥</value>
+    <value>顯示通知</value>
   </data>
   <data name="NotificationSoundComboBox.Header" xml:space="preserve">
-    <value>æç¤ºéŸ³</value>
+    <value>提示音</value>
   </data>
   <data name="SettingsPage_ComboBoxItem_48.Content" xml:space="preserve">
-    <value>é è¨­</value>
+    <value>預設</value>
   </data>
   <data name="SettingsPage_ComboBoxItem_49.Content" xml:space="preserve">
-    <value>ç„¡</value>
+    <value>無</value>
   </data>
   <data name="SettingsPage_ComboBoxItem_50.Content" xml:space="preserve">
-    <value>æŸ”å’Œ</value>
+    <value>柔和</value>
   </data>
   <data name="SettingsPage_TextBlock_52.Text" xml:space="preserve">
-    <value>é¡¯ç¤ºä»¥ä¸‹åž‹åˆ¥é€šçŸ¥:</value>
+    <value>顯示以下型別通知:</value>
   </data>
   <data name="NotifyHealthCb.Content" xml:space="preserve">
-    <value>å¥åº·è­¦å ±</value>
+    <value>健康警報</value>
   </data>
   <data name="NotifyUrgentCb.Content" xml:space="preserve">
-    <value>ç·Šæ€¥è¨Šæ¯</value>
+    <value>緊急訊息</value>
   </data>
   <data name="NotifyReminderCb.Content" xml:space="preserve">
-    <value>æé†’</value>
+    <value>提醒</value>
   </data>
   <data name="NotifyEmailCb.Content" xml:space="preserve">
-    <value>éƒµä»¶æ‘˜è¦</value>
+    <value>郵件摘要</value>
   </data>
   <data name="NotifyCalendarCb.Content" xml:space="preserve">
-    <value>æ—¥æ›†äº‹ä»¶</value>
+    <value>日曆事件</value>
   </data>
   <data name="NotifyBuildCb.Content" xml:space="preserve">
-    <value>æ§‹å»ºé€šçŸ¥</value>
+    <value>構建通知</value>
   </data>
   <data name="NotifyStockCb.Content" xml:space="preserve">
-    <value>è‚¡ç¥¨æé†’</value>
+    <value>股票提醒</value>
   </data>
   <data name="NotifyInfoCb.Content" xml:space="preserve">
-    <value>å¸¸è¦è³‡è¨Š</value>
+    <value>常規資訊</value>
   </data>
   <data name="TestNotificationButton.Content" xml:space="preserve">
-    <value>ç™¼é€æ¸¬è©¦é€šçŸ¥</value>
+    <value>發送測試通知</value>
   </data>
   <data name="CancelButton.Content" xml:space="preserve">
-    <value>å–æ¶ˆ</value>
+    <value>取消</value>
   </data>
   <data name="SkillsPage_TextBlock_10.Text" xml:space="preserve">
     <value>🧩 技能</value>
   </data>
   <data name="SkillsPage_ComboBoxItem_15.Content" xml:space="preserve">
-    <value>æ‰€æœ‰ä»£ç†ç¨‹å¼</value>
+    <value>所有代理程式</value>
   </data>
   <data name="SkillsPage_TextBlock_81.Text" xml:space="preserve">
-    <value>æœªå®‰è£æŠ€èƒ½</value>
+    <value>未安裝技能</value>
   </data>
   <data name="MarketplaceLink.Content" xml:space="preserve">
     <value>瀏覽技能市集 →</value>
   </data>
   <data name="UsagePage_TextBlock_21.Text" xml:space="preserve">
-    <value>ç¸½æˆæœ¬</value>
+    <value>總成本</value>
   </data>
   <data name="UsagePage_TextBlock_35.Text" xml:space="preserve">
-    <value>è¦æ±‚</value>
+    <value>要求</value>
   </data>
   <data name="UsagePage_TextBlock_45.Text" xml:space="preserve">
-    <value>æ¬Šæ–</value>
+    <value>權杖</value>
   </data>
   <data name="UsagePage_TextBlock_55.Text" xml:space="preserve">
-    <value>æä¾›è€…</value>
+    <value>提供者</value>
   </data>
   <data name="Period7DaysItem.Text" xml:space="preserve">
-    <value>7 å¤©</value>
+    <value>7 天</value>
   </data>
   <data name="Period30DaysItem.Text" xml:space="preserve">
-    <value>30 å¤©</value>
+    <value>30 天</value>
   </data>
   <data name="UsagePage_ProviderLoading.Text" xml:space="preserve">
     <value>正在載入提供者…</value>
   </data>
   <data name="UsagePage_NoProviders.Text" xml:space="preserve">
-    <value>æœªè¨­å®šä»»ä½•æä¾›è€…</value>
+    <value>未設定任何提供者</value>
   </data>
   <data name="UsagePage_TextBlock_70.Text" xml:space="preserve">
-    <value>æä¾›è€…æ˜Žç´°</value>
+    <value>提供者明細</value>
   </data>
   <data name="UsagePage_TextBlock_100.Text" xml:space="preserve">
-    <value>æ¯æ—¥æˆæœ¬</value>
+    <value>每日成本</value>
   </data>
   <data name="WorkspacePage_TextBlock_22.Text" xml:space="preserve">
     <value>工作區</value>
@@ -2218,13 +2218,13 @@
     <value>(磁碟上找不到檔案)</value>
   </data>
   <data name="WorkspacePage_TextBlock_34.Text" xml:space="preserve">
-    <value>é‡æ–°æ•´ç†</value>
+    <value>重新整理</value>
   </data>
   <data name="ChatWindow_TextBlock_29.Text" xml:space="preserve">
-    <value>èŠå¤©</value>
+    <value>聊天</value>
   </data>
   <data name="ChatWindow_TextBlock_60.Text" xml:space="preserve">
-    <value>é€£ç·šåˆ°é–˜é“ä»¥é–‹å§‹èŠå¤©</value>
+    <value>連線到閘道以開始聊天</value>
   </data>
   <data name="TitleText.Text" xml:space="preserve">
     <value>OpenClaw Windows Companion</value>
@@ -2236,178 +2236,178 @@
     <value>切換導覽窗格</value>
   </data>
   <data name="TitleStatusText.Text" xml:space="preserve">
-    <value>å·²ä¸­æ–·é€£ç·š</value>
+    <value>已中斷連線</value>
   </data>
   <data name="HubWindow_NavigationViewItem_79.Content" xml:space="preserve">
-    <value>é¦–é </value>
+    <value>首頁</value>
   </data>
   <data name="HubWindow_NavigationViewItem_82.Content" xml:space="preserve">
-    <value>èŠå¤©</value>
+    <value>聊天</value>
   </data>
   <data name="HubWindow_NavigationViewItemHeader_87.Content" xml:space="preserve">
-    <value>é–˜é“</value>
+    <value>閘道</value>
   </data>
   <data name="HubWindow_NavigationViewItem_88.Content" xml:space="preserve">
-    <value>é€£ç·š</value>
+    <value>連線</value>
   </data>
   <data name="HubWindow_NavigationViewItem_91.Content" xml:space="preserve">
-    <value>å·¥ä½œéšŽæ®µ</value>
+    <value>工作階段</value>
   </data>
   <data name="ConversationsNavItem.Content" xml:space="preserve">
-    <value>å°è©±</value>
+    <value>對話</value>
   </data>
   <data name="HubWindow_NavigationViewItem_94.Content" xml:space="preserve">
-    <value>ä»£ç†ç¨‹å¼äº‹ä»¶</value>
+    <value>代理程式事件</value>
   </data>
   <data name="HubWindow_NavigationViewItem_97.Content" xml:space="preserve">
-    <value>æŠ€èƒ½</value>
+    <value>技能</value>
   </data>
   <data name="AgentsNavItem.Content" xml:space="preserve">
-    <value>ä»£ç†ç¨‹å¼</value>
+    <value>代理程式</value>
   </data>
   <data name="DefaultAgentNavItem.Content" xml:space="preserve">
     <value>main</value>
   </data>
   <data name="HubWindow_NavigationViewItem_109.Content" xml:space="preserve">
-    <value>é »é“</value>
+    <value>頻道</value>
   </data>
   <data name="HubWindow_NavigationViewItem_112.Content" xml:space="preserve">
-    <value>å¯¦ä¾‹</value>
+    <value>實例</value>
   </data>
   <data name="HubWindow_NavigationViewItem_115.Content" xml:space="preserve">
-    <value>ç¹«çµ</value>
+    <value>繫結</value>
   </data>
   <data name="HubWindow_NavigationViewItem_118.Content" xml:space="preserve">
-    <value>è¨­å®š</value>
+    <value>設定</value>
   </data>
   <data name="HubWindow_NavigationViewItem_121.Content" xml:space="preserve">
-    <value>ç”¨é‡</value>
+    <value>用量</value>
   </data>
   <data name="HubWindow_NavigationViewItem_124.Content" xml:space="preserve">
     <value>Cron</value>
   </data>
   <data name="HubWindow_NavigationViewItemHeader_129.Content" xml:space="preserve">
-    <value>é€™éƒ¨é›»è…¦</value>
+    <value>這部電腦</value>
   </data>
   <data name="HubWindow_NavigationViewItem_130.Content" xml:space="preserve">
-    <value>åŠŸèƒ½</value>
+    <value>功能</value>
   </data>
   <data name="HubWindow_NavigationViewItem_133.Content" xml:space="preserve">
-    <value>è¨­å®š</value>
+    <value>設定</value>
   </data>
   <data name="HubWindow_NavigationViewItem_136.Content" xml:space="preserve">
-    <value>æ¬Šé™</value>
+    <value>權限</value>
   </data>
   <data name="HubWindow_NavigationViewItem_145.Content" xml:space="preserve">
-    <value>åµéŒ¯</value>
+    <value>偵錯</value>
   </data>
   <data name="HubWindow_NavigationViewItem_148.Content" xml:space="preserve">
-    <value>è³‡è¨Š</value>
+    <value>資訊</value>
   </data>
   <data name="Onboarding_UnknownPage" xml:space="preserve">
-    <value>æœªçŸ¥é é¢</value>
+    <value>未知頁面</value>
   </data>
   <data name="Onboarding_Retry" xml:space="preserve">
-    <value>é‡è©¦</value>
+    <value>重試</value>
   </data>
   <data name="Onboarding_Ready_NodeModeActive" xml:space="preserve">
     <value>🔌 節點模式已啟用</value>
   </data>
   <data name="Onboarding_Ready_NodeModeActiveDetail" xml:space="preserve">
-    <value>æ­¤é›»è…¦å°‡ä½œç‚ºé ç«¯è¨ˆç®—ç¯€é»žé‹ä½œã€‚é–˜é“å¯ä»¥åœ¨é€™éƒ¨é›»è…¦ä¸Šå«ç”¨èž¢å¹•æ“·å–ã€ç›¸æ©Ÿå’Œç³»çµ±å‘½ä»¤ã€‚</value>
+    <value>此電腦將作為遠端計算節點運作。閘道可以在這部電腦上叫用螢幕擷取、相機和系統命令。</value>
   </data>
   <data name="Onboarding_Ready_Node_ScreenCapture" xml:space="preserve">
-    <value>èž¢å¹•æ“·å–</value>
+    <value>螢幕擷取</value>
   </data>
   <data name="Onboarding_Ready_Node_ScreenCapture_Sub" xml:space="preserve">
-    <value>é ç«¯èž¢å¹•å­˜å–</value>
+    <value>遠端螢幕存取</value>
   </data>
   <data name="Onboarding_Ready_Node_Camera" xml:space="preserve">
-    <value>ç›¸æ©Ÿ</value>
+    <value>相機</value>
   </data>
   <data name="Onboarding_Ready_Node_Camera_Sub" xml:space="preserve">
-    <value>é ç«¯ç›¸æ©Ÿå­˜å–</value>
+    <value>遠端相機存取</value>
   </data>
   <data name="Onboarding_Ready_Node_SystemCmd" xml:space="preserve">
-    <value>ç³»çµ±å‘½ä»¤</value>
+    <value>系統命令</value>
   </data>
   <data name="Onboarding_Ready_Node_SystemCmd_Sub" xml:space="preserve">
-    <value>é ç«¯å‘½ä»¤åŸ·è¡Œ</value>
+    <value>遠端命令執行</value>
   </data>
   <data name="Onboarding_Ready_Node_Canvas" xml:space="preserve">
-    <value>Canvas ç®—ç¹ª</value>
+    <value>Canvas 算繪</value>
   </data>
   <data name="Onboarding_Ready_Node_Canvas_Sub" xml:space="preserve">
-    <value>è¦–è¦ºå·¥ä½œå€è¼¸å‡º</value>
+    <value>視覺工作區輸出</value>
   </data>
   <data name="Onboarding_Ready_Node_Notify" xml:space="preserve">
-    <value>é€šçŸ¥</value>
+    <value>通知</value>
   </data>
   <data name="Onboarding_Ready_Node_Notify_Sub" xml:space="preserve">
-    <value>ç³»çµ±é€šçŸ¥</value>
+    <value>系統通知</value>
   </data>
   <data name="Onboarding_Wizard_Processing" xml:space="preserve">
     <value>⏳ 正在處理…</value>
   </data>
   <data name="Onboarding_Wizard_ErrorEmptyGatewayResponse" xml:space="preserve">
-    <value>é–˜é“å‚³å›žç©ºå›žæ‡‰</value>
+    <value>閘道傳回空回應</value>
   </data>
   <data name="Onboarding_Wizard_ErrorGatewayDisconnected" xml:space="preserve">
-    <value>é–˜é“å·²ä¸­æ–·é€£ç·š</value>
+    <value>閘道已中斷連線</value>
   </data>
   <data name="Onboarding_Wizard_ErrorGatewayDisconnectedDetail" xml:space="preserve">
-    <value>èˆ‡é–˜é“çš„é€£ç·šå·²ä¸­æ–·ã€‚æŒ‰ä¸€ä¸‹ã€Œä¸‹ä¸€æ­¥ã€ç•¥éŽç²¾éˆï¼Œæˆ–ç­‰å¾…é‡æ–°é€£ç·šã€‚</value>
+    <value>與閘道的連線已中斷。按一下「下一步」略過精靈，或等待重新連線。</value>
   </data>
   <data name="Onboarding_Wizard_ErrorEmptyNextResponse" xml:space="preserve">
-    <value>é–˜é“é‡å° wizard.next å‚³å›žç©ºå›žæ‡‰</value>
+    <value>閘道針對 wizard.next 傳回空回應</value>
   </data>
   <data name="Onboarding_Wizard_NoOptionsAvailable" xml:space="preserve">
-    <value>æ²’æœ‰å¯ç”¨çš„é¸é …</value>
+    <value>沒有可用的選項</value>
   </data>
   <data name="Onboarding_Wizard_Yes" xml:space="preserve">
-    <value>æ˜¯</value>
+    <value>是</value>
   </data>
   <data name="Onboarding_Wizard_NoSkip" xml:space="preserve">
-    <value>å¦ / ç•¥éŽ</value>
+    <value>否 / 略過</value>
   </data>
   <data name="Onboarding_Wizard_Waiting" xml:space="preserve">
-    <value>æ­£åœ¨ç­‰å¾…...</value>
+    <value>正在等待...</value>
   </data>
   <data name="Onboarding_Wizard_ClickNextToContinue" xml:space="preserve">
-    <value>æŒ‰ä¸€ä¸‹ã€Œä¸‹ä¸€æ­¥ã€ç¹¼çºŒã€‚</value>
+    <value>按一下「下一步」繼續。</value>
   </data>
   <data name="Onboarding_Wizard_ErrorTitle" xml:space="preserve">
-    <value>ç²¾éˆéŒ¯èª¤</value>
+    <value>精靈錯誤</value>
   </data>
   <data name="Onboarding_Wizard_SkipWizard" xml:space="preserve">
-    <value>ç•¥éŽç²¾éˆ</value>
+    <value>略過精靈</value>
   </data>
   <data name="Onboarding_Wizard_ConnectingToGateway" xml:space="preserve">
-    <value>æ­£åœ¨é€£ç·šåˆ°é–˜é“...</value>
+    <value>正在連線到閘道...</value>
   </data>
   <data name="Onboarding_Wizard_ConnectionWaitDetail" xml:space="preserve">
-    <value>è«‹ç­‰å¾…é€£ç·šå»ºç«‹...</value>
+    <value>請等待連線建立...</value>
   </data>
   <data name="PriorityInfoBar.Title" xml:space="preserve">
-    <value>è·¯ç”±å„ªå…ˆé †åº</value>
+    <value>路由優先順序</value>
   </data>
   <data name="PriorityInfoBar.Message" xml:space="preserve">
-    <value>ç¹«çµæœƒæŽ§åˆ¶å“ªå€‹ä»£ç†ç¨‹å¼è™•ç†å„é »é“çš„è¨Šæ¯ã€‚å„ªå…ˆé †åºï¼šå°ç­‰ &gt; å¸³æˆ¶ &gt; é »é“ &gt; é è¨­ã€‚</value>
+    <value>繫結會控制哪個代理程式處理各頻道的訊息。優先順序：對等 &gt; 帳戶 &gt; 頻道 &gt; 預設。</value>
   </data>
   <data name="SingleAgentInfoBar.Title" xml:space="preserve">
-    <value>å–®ä¸€ä»£ç†ç¨‹å¼æ¨¡å¼</value>
+    <value>單一代理程式模式</value>
   </data>
   <data name="SingleAgentInfoBar.Message" xml:space="preserve">
-    <value>æ‰€æœ‰è¨Šæ¯éƒ½æœƒè·¯ç”±è‡³é è¨­ä»£ç†ç¨‹å¼ã€‚æ–°å¢žç¹«çµä»¥é€²è¡Œå¤šä»£ç†ç¨‹å¼è·¯ç”±ã€‚</value>
+    <value>所有訊息都會路由至預設代理程式。新增繫結以進行多代理程式路由。</value>
   </data>
   <data name="ConfigSubtitle.Text" xml:space="preserve">
     <value>使用結構描述引導的表單編輯閘道設定 (openclaw.json)。</value>
   </data>
   <data name="DetailPlaceholder.Text" xml:space="preserve">
-    <value>å¾žæ¨¹ç‹€ç›®éŒ„é¸å–å€æ®µä»¥ç·¨è¼¯å…¶è¨­å®šã€‚</value>
+    <value>從樹狀目錄選取區段以編輯其設定。</value>
   </data>
   <data name="TokenPromptBox.PlaceholderText" xml:space="preserve">
-    <value>é–˜é“æ¬Šæ–</value>
+    <value>閘道權杖</value>
   </data>
   <data name="TokenPromptBox.Header" xml:space="preserve">
     <value>Token</value>
@@ -2416,25 +2416,25 @@
     <value>在此貼上設定碼…</value>
   </data>
   <data name="ConnectionWarning.Message" xml:space="preserve">
-    <value>é€£ç·šåˆ°é–˜é“ä»¥æª¢è¦–äº¤è«‡ã€‚</value>
+    <value>連線到閘道以檢視交談。</value>
   </data>
   <data name="EmptyState.Text" xml:space="preserve">
-    <value>æ‰¾ä¸åˆ°å·¥ä½œéšŽæ®µ</value>
+    <value>找不到工作階段</value>
   </data>
   <data name="NotWiredInfoBar.Title" xml:space="preserve">
-    <value>Cron API å°šæœªæŽ¥ç·š</value>
+    <value>Cron API 尚未接線</value>
   </data>
   <data name="NotWiredInfoBar.Message" xml:space="preserve">
-    <value>æ­£åœ¨é¡¯ç¤ºç¯„ä¾‹è³‡æ–™ã€‚OpenClawGatewayClient ä¸­å°šæœªæä¾› Cron ç®¡ç†æ–¹æ³•ã€‚</value>
+    <value>正在顯示範例資料。OpenClawGatewayClient 中尚未提供 Cron 管理方法。</value>
   </data>
   <data name="FallbackInfoBar.Title" xml:space="preserve">
-    <value>å·¥ä½œå€æª”æ¡ˆ</value>
+    <value>工作區檔案</value>
   </data>
   <data name="ChatWindow_winexWindowEx_2.Title" xml:space="preserve">
     <value>OpenClaw Chat</value>
   </data>
   <data name="SearchBox.PlaceholderText" xml:space="preserve">
-    <value>è¼¸å…¥å‘½ä»¤...</value>
+    <value>輸入命令...</value>
   </data>
   <data name="HubWindow_winexWindowEx_2.Title" xml:space="preserve">
     <value>OpenClaw</value>
@@ -2449,10 +2449,10 @@
     <value>OpenClaw Canvas</value>
   </data>
   <data name="CanvasWindowReloadToolTip.Content" xml:space="preserve">
-    <value>é‡æ–°è¼‰å…¥</value>
+    <value>重新載入</value>
   </data>
   <data name="CanvasReloadButton_AutomationName" xml:space="preserve">
-    <value>é‡æ–°è¼‰å…¥ Canvas</value>
+    <value>重新載入 Canvas</value>
   </data>
   <data name="TrayMenuWindow_winexWindowEx_2.Title" xml:space="preserve">
     <value>OpenClaw Menu</value>
@@ -2461,67 +2461,67 @@
     <value>使用量與成本</value>
   </data>
   <data name="ChatWindowOpenInBrowserToolTip.Content" xml:space="preserve">
-    <value>åœ¨ç€è¦½å™¨ä¸­é–‹å•Ÿ</value>
+    <value>在瀏覽器中開啟</value>
   </data>
   <data name="ChatWindowCloseToolTip.Content" xml:space="preserve">
-    <value>é—œé–‰</value>
+    <value>關閉</value>
   </data>
   <data name="ChatPageOpenInBrowserToolTip.Content" xml:space="preserve">
-    <value>åœ¨ç€è¦½å™¨ä¸­é–‹å•Ÿ</value>
+    <value>在瀏覽器中開啟</value>
   </data>
   <data name="CronPageRemoveJobToolTip.Content" xml:space="preserve">
-    <value>åˆªé™¤å·¥ä½œ</value>
+    <value>刪除工作</value>
   </data>
   <data name="PermissionsPage_SttMoreSettingsLink.Content" xml:space="preserve">
     <value>更多語音設定…</value>
   </data>
   <data name="PermissionsPage_TtsElevenLabsApiKey.Header" xml:space="preserve">
-    <value>ElevenLabs API é‡‘é‘°</value>
+    <value>ElevenLabs API 金鑰</value>
   </data>
   <data name="PermissionsPage_TtsElevenLabsHelp.Text" xml:space="preserve">
-    <value>API é‡‘é‘°æœƒä½¿ç”¨ Windows DPAPI åŠ å¯†å„²å­˜ã€‚ä¿®æ”¹å…¶ä»–æ¬„ä½æ™‚è‹¥ä¿æŒç©ºç™½ï¼Œå‰‡ä¿ç•™å…ˆå‰å„²å­˜çš„å€¼ã€‚</value>
+    <value>API 金鑰會使用 Windows DPAPI 加密儲存。修改其他欄位時若保持空白，則保留先前儲存的值。</value>
   </data>
   <data name="PermissionsPage_TtsElevenLabsModel.Header" xml:space="preserve">
-    <value>ElevenLabs æ¨¡åž‹</value>
+    <value>ElevenLabs 模型</value>
   </data>
   <data name="PermissionsPage_TtsElevenLabsModel.PlaceholderText" xml:space="preserve">
     <value>eleven_multilingual_v2</value>
   </data>
   <data name="PermissionsPage_TtsElevenLabsVoiceId.Header" xml:space="preserve">
-    <value>ElevenLabs èªžéŸ³ ID</value>
+    <value>ElevenLabs 語音 ID</value>
   </data>
   <data name="PermissionsPage_TtsProviderComboBox.Header" xml:space="preserve">
-    <value>æä¾›è€…</value>
+    <value>提供者</value>
   </data>
   <data name="PermissionsPage_TtsProviderElevenLabs.Content" xml:space="preserve">
     <value>ElevenLabs</value>
   </data>
   <data name="PermissionsPage_TtsProviderPiper.Content" xml:space="preserve">
-    <value>Piperï¼ˆæœ¬æ©Ÿ MLï¼Œå»ºè­°ï¼‰</value>
+    <value>Piper（本機 ML，建議）</value>
   </data>
   <data name="PermissionsPage_TtsProviderWindows.Content" xml:space="preserve">
-    <value>Windows å…§å»ºèªžéŸ³</value>
+    <value>Windows 內建語音</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
     <value>語音與音訊</value>
   </data>
   <data name="VoiceSettingsPage_PageDescription.Text" xml:space="preserve">
-    <value>è¨­å®šèªžéŸ³è½‰æ–‡å­—å’ŒèªžéŸ³äº’å‹•è¨­å®šã€‚æ‰€æœ‰èªžéŸ³è™•ç†å‡åœ¨æœ¬æ©Ÿæœ¬åœ°åŸ·è¡Œã€‚</value>
+    <value>設定語音轉文字和語音互動設定。所有語音處理均在本機本地執行。</value>
   </data>
   <data name="VoiceSettingsPage_SttHeader.Text" xml:space="preserve">
-    <value>èªžéŸ³è½‰æ–‡å­—</value>
+    <value>語音轉文字</value>
   </data>
   <data name="VoiceSettingsPage_SttDescription.Text" xml:space="preserve">
-    <value>é€éŽéº¥å…‹é¢¨å•Ÿç”¨èªžéŸ³è¼¸å…¥ã€‚éœ€è¦ä¸‹è¼‰ Whisper æ¨¡åž‹ã€‚</value>
+    <value>透過麥克風啟用語音輸入。需要下載 Whisper 模型。</value>
   </data>
   <data name="VoiceSettingsPage_SttEnabledToggle.Header" xml:space="preserve">
-    <value>å•Ÿç”¨èªžéŸ³è¼¸å…¥</value>
+    <value>啟用語音輸入</value>
   </data>
   <data name="VoiceSettingsPage_ModelHeader.Text" xml:space="preserve">
-    <value>èªžéŸ³æ¨¡åž‹</value>
+    <value>語音模型</value>
   </data>
   <data name="VoiceSettingsPage_ModelCombo.Header" xml:space="preserve">
-    <value>æ¨¡åž‹å¤§å°</value>
+    <value>模型大小</value>
   </data>
   <data name="VoiceSettingsPage_ModelTiny.Content" xml:space="preserve">
     <value>Tiny (~75 MB) — 快速,基本精確度</value>
@@ -2533,79 +2533,79 @@
     <value>Small (~466 MB) — 高精確度</value>
   </data>
   <data name="VoiceSettingsPage_DownloadButtonText.Text" xml:space="preserve">
-    <value>ä¸‹è¼‰æ¨¡åž‹</value>
+    <value>下載模型</value>
   </data>
   <data name="VoiceSettingsPage_LanguageHeader.Text" xml:space="preserve">
-    <value>èªžè¨€</value>
+    <value>語言</value>
   </data>
   <data name="VoiceSettingsPage_LangAuto.Content" xml:space="preserve">
-    <value>è‡ªå‹•åµæ¸¬</value>
+    <value>自動偵測</value>
   </data>
   <data name="VoiceSettingsPage_LangEn.Content" xml:space="preserve">
-    <value>è‹±æ–‡</value>
+    <value>英文</value>
   </data>
   <data name="VoiceSettingsPage_LangEs.Content" xml:space="preserve">
-    <value>è¥¿ç­ç‰™æ–‡</value>
+    <value>西班牙文</value>
   </data>
   <data name="VoiceSettingsPage_LangFr.Content" xml:space="preserve">
-    <value>æ³•æ–‡</value>
+    <value>法文</value>
   </data>
   <data name="VoiceSettingsPage_LangDe.Content" xml:space="preserve">
-    <value>å¾·æ–‡</value>
+    <value>德文</value>
   </data>
   <data name="VoiceSettingsPage_LangJa.Content" xml:space="preserve">
-    <value>æ—¥æ–‡</value>
+    <value>日文</value>
   </data>
   <data name="VoiceSettingsPage_LangZh.Content" xml:space="preserve">
-    <value>ä¸­æ–‡</value>
+    <value>中文</value>
   </data>
   <data name="VoiceSettingsPage_LangKo.Content" xml:space="preserve">
-    <value>éŸ“æ–‡</value>
+    <value>韓文</value>
   </data>
   <data name="VoiceSettingsPage_LangPt.Content" xml:space="preserve">
-    <value>è‘¡è„ç‰™æ–‡</value>
+    <value>葡萄牙文</value>
   </data>
   <data name="VoiceSettingsPage_LangIt.Content" xml:space="preserve">
-    <value>ç¾©å¤§åˆ©æ–‡</value>
+    <value>義大利文</value>
   </data>
   <data name="VoiceSettingsPage_VoiceChatHeader.Text" xml:space="preserve">
-    <value>èªžéŸ³èŠå¤©</value>
+    <value>語音聊天</value>
   </data>
   <data name="VoiceSettingsPage_SilenceSlider.Header" xml:space="preserve">
-    <value>éœéŸ³é€¾æ™‚(ç§’)</value>
+    <value>靜音逾時(秒)</value>
   </data>
   <data name="VoiceSettingsPage_TtsResponseToggle.Header" xml:space="preserve">
-    <value>æœ—è®€å›žæ‡‰</value>
+    <value>朗讀回應</value>
   </data>
   <data name="VoiceSettingsPage_AudioFeedbackToggle.Header" xml:space="preserve">
-    <value>éŸ³è¨Šå›žé¥‹éŸ³æ•ˆ</value>
+    <value>音訊回饋音效</value>
   </data>
   <data name="VoiceSettingsPage_VoiceHeader.Text" xml:space="preserve">
     <value>Companion 語音</value>
   </data>
   <data name="VoiceSettingsPage_VoiceDescription.Text" xml:space="preserve">
-    <value>é¸æ“‡æœ—è®€å›žæ‡‰æ™‚ä½¿ç”¨çš„èªžéŸ³ã€‚</value>
+    <value>選擇朗讀回應時使用的語音。</value>
   </data>
   <data name="VoiceSettingsPage_TtsProviderCombo.Header" xml:space="preserve">
-    <value>æä¾›è€…</value>
+    <value>提供者</value>
   </data>
   <data name="VoiceSettingsPage_TtsPiper.Content" xml:space="preserve">
-    <value>Piper(æœ¬æ©Ÿç¥žç¶“èªžéŸ³)</value>
+    <value>Piper(本機神經語音)</value>
   </data>
   <data name="VoiceSettingsPage_TtsWindows.Content" xml:space="preserve">
-    <value>Windows(å…§å»ºç¥žç¶“èªžéŸ³)</value>
+    <value>Windows(內建神經語音)</value>
   </data>
   <data name="VoiceSettingsPage_TtsElevenLabs.Content" xml:space="preserve">
-    <value>ElevenLabs(é›²ç«¯,éœ€è¦ API é‡‘é‘°)</value>
+    <value>ElevenLabs(雲端,需要 API 金鑰)</value>
   </data>
   <data name="VoiceSettingsPage_PiperVoiceCombo.Header" xml:space="preserve">
-    <value>èªžéŸ³</value>
+    <value>語音</value>
   </data>
   <data name="VoiceSettingsPage_PiperDownloadButtonText.Text" xml:space="preserve">
-    <value>ä¸‹è¼‰èªžéŸ³</value>
+    <value>下載語音</value>
   </data>
   <data name="VoiceSettingsPage_PiperDeleteButton.Content" xml:space="preserve">
-    <value>åˆªé™¤</value>
+    <value>刪除</value>
   </data>
   <data name="VoiceSettingsPage_PiperPreviewButton.Content" xml:space="preserve">
     <value>預覽</value>
@@ -2614,25 +2614,25 @@
     <value>預覽</value>
   </data>
   <data name="VoiceSettingsPage_PiperInfoText.Text" xml:space="preserve">
-    <value>èªžéŸ³å¾ž sherpa-onnx å°ˆæ¡ˆçš„ GitHub ç™¼è¡Œç‰ˆä¸‹è¼‰(ä½Žå“è³ªç´„ 25 MB,é«˜å“è³ªæœ€é«˜ç´„ 150 MB)ã€‚å®ƒå€‘å®Œå…¨åœ¨æœ¬æ©ŸåŸ·è¡Œ;ç„¡éŸ³è¨Šé›¢é–‹æ‚¨çš„è£ç½®ã€‚</value>
+    <value>語音從 sherpa-onnx 專案的 GitHub 發行版下載(低品質約 25 MB,高品質最高約 150 MB)。它們完全在本機執行;無音訊離開您的裝置。</value>
   </data>
   <data name="VoiceSettingsPage_WindowsVoiceCombo.Header" xml:space="preserve">
-    <value>èªžéŸ³</value>
+    <value>語音</value>
   </data>
   <data name="VoiceSettingsPage_PreviewVoiceButton.Content" xml:space="preserve">
     <value>預覽語音</value>
   </data>
   <data name="VoiceSettingsPage_ElevenLabsApiKeyBox.Header" xml:space="preserve">
-    <value>API é‡‘é‘°</value>
+    <value>API 金鑰</value>
   </data>
   <data name="VoiceSettingsPage_ElevenLabsVoiceIdBox.Header" xml:space="preserve">
-    <value>èªžéŸ³ ID</value>
+    <value>語音 ID</value>
   </data>
   <data name="VoiceSettingsPage_ElevenLabsModelBox.Header" xml:space="preserve">
-    <value>æ¨¡åž‹(å¯é¸)</value>
+    <value>模型(可選)</value>
   </data>
   <data name="VoiceSettingsPage_PrivacyNote.Text" xml:space="preserve">
-    <value>æ‰€æœ‰èªžéŸ³è™•ç†å‡å®Œå…¨åœ¨æ‚¨çš„è£ç½®ä¸ŠåŸ·è¡Œã€‚ä¸æœƒå‘ä»»ä½•é›²ç«¯æœå‹™å‚³é€éŸ³è¨Šè³‡æ–™ã€‚</value>
+    <value>所有語音處理均完全在您的裝置上執行。不會向任何雲端服務傳送音訊資料。</value>
   </data>
   <data name="VoiceSettingsPage_StatusModelReady" xml:space="preserve">
     <value>✅ 模型就緒</value>
@@ -2662,25 +2662,25 @@
     <value>關閉</value>
   </data>
   <data name="VoiceSettingsPage_ButtonReDownload" xml:space="preserve">
-    <value>é‡æ–°ä¸‹è¼‰</value>
+    <value>重新下載</value>
   </data>
   <data name="VoiceSettingsPage_StatusDownloading" xml:space="preserve">
-    <value>æ­£åœ¨ä¸‹è¼‰...</value>
+    <value>正在下載...</value>
   </data>
   <data name="VoiceSettingsPage_StatusDownloadingPct" xml:space="preserve">
-    <value>æ­£åœ¨ä¸‹è¼‰... {0}%</value>
+    <value>正在下載... {0}%</value>
   </data>
   <data name="VoiceSettingsPage_StatusDownloadCanceled" xml:space="preserve">
-    <value>ä¸‹è¼‰å·²å–æ¶ˆ</value>
+    <value>下載已取消</value>
   </data>
   <data name="VoiceSettingsPage_StatusError" xml:space="preserve">
     <value>操作失敗(參見 Debug 日誌)</value>
   </data>
   <data name="VoiceSettingsPage_PiperButtonDownloaded" xml:space="preserve">
-    <value>å·²ä¸‹è¼‰</value>
+    <value>已下載</value>
   </data>
   <data name="VoiceSettingsPage_PiperVoiceReady" xml:space="preserve">
-    <value>èªžéŸ³å·²åœ¨æ­¤ PC ä¸Šå°±ç·’({0} MB)ã€‚</value>
+    <value>語音已在此 PC 上就緒({0} MB)。</value>
   </data>
   <data name="VoiceSettingsPage_PiperVoiceNotDownloaded" xml:space="preserve">
     <value>語音尚未下載。按下載以取得模型(根據品質約 25–150 MB)。</value>
@@ -2701,52 +2701,52 @@
     <value>下載完成。正在解壓縮…</value>
   </data>
   <data name="VoiceSettingsPage_PiperDownloadCanceled" xml:space="preserve">
-    <value>ä¸‹è¼‰å·²å–æ¶ˆã€‚</value>
+    <value>下載已取消。</value>
   </data>
   <data name="VoiceSettingsPage_PiperDownloadFailed" xml:space="preserve">
-    <value>ä¸‹è¼‰å¤±æ•—(åƒè¦‹ Debug æ—¥èªŒ)ã€‚</value>
+    <value>下載失敗(參見 Debug 日誌)。</value>
   </data>
   <data name="VoiceSettingsPage_PiperButtonRetry" xml:space="preserve">
-    <value>é‡è©¦ä¸‹è¼‰</value>
+    <value>重試下載</value>
   </data>
   <data name="VoiceSettingsPage_PiperDeleted" xml:space="preserve">
-    <value>å·²åˆªé™¤èªžéŸ³ã€‚</value>
+    <value>已刪除語音。</value>
   </data>
   <data name="VoiceSettingsPage_PiperDeleteFailed" xml:space="preserve">
-    <value>åˆªé™¤å¤±æ•—(åƒè¦‹ Debug æ—¥èªŒ)ã€‚</value>
+    <value>刪除失敗(參見 Debug 日誌)。</value>
   </data>
   <data name="VoiceSettingsPage_CompanionPreviewText" xml:space="preserve">
-    <value>æ‚¨å¥½!é€™æ˜¯æ‚¨çš„ Companion åœ¨èªªè©±ã€‚</value>
+    <value>您好!這是您的 Companion 在說話。</value>
   </data>
   <data name="VoiceSettingsPage_PiperPreviewFailed" xml:space="preserve">
-    <value>é è¦½å¤±æ•—(åƒè¦‹ Debug æ—¥èªŒ)ã€‚</value>
+    <value>預覽失敗(參見 Debug 日誌)。</value>
   </data>
   <data name="VoiceSettingsPage_VoiceErrorLoading" xml:space="preserve">
-    <value>è¼‰å…¥èªžéŸ³æ™‚ç™¼ç”ŸéŒ¯èª¤(åƒè¦‹ Debug æ—¥èªŒ)ã€‚</value>
+    <value>載入語音時發生錯誤(參見 Debug 日誌)。</value>
   </data>
   <data name="VoiceSettingsPage_PreviewButtonPlaying" xml:space="preserve">
     <value>正在播放...</value>
   </data>
   <data name="VoiceOverlayWindow_HeaderText.Text" xml:space="preserve">
-    <value>Companion èªžéŸ³</value>
+    <value>Companion 語音</value>
   </data>
   <data name="VoiceOverlayWindow_StatusBadge.Text" xml:space="preserve">
-    <value>å°±ç·’</value>
+    <value>就緒</value>
   </data>
   <data name="VoiceOverlayWindow_EmptyStateText.Text" xml:space="preserve">
-    <value>æŒ‰é–‹å§‹ä¸¦é–‹å§‹èªªè©±</value>
+    <value>按開始並開始說話</value>
   </data>
   <data name="VoiceOverlayWindow_StatusText.Text" xml:space="preserve">
-    <value>æŒ‰é–‹å§‹ä»¥é–‹å§‹</value>
+    <value>按開始以開始</value>
   </data>
   <data name="VoiceOverlayWindow_StartStopText.Text" xml:space="preserve">
-    <value>é–‹å§‹è†è½</value>
+    <value>開始聆聽</value>
   </data>
   <data name="VoiceOverlayWindow_MuteButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>éœéŸ³</value>
+    <value>靜音</value>
   </data>
   <data name="VoiceOverlayWindow_SettingsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>èªžéŸ³è¨­å®š</value>
+    <value>語音設定</value>
   </data>
   <data name="VoiceOverlayWindow_StatusListening" xml:space="preserve">
     <value>🗣️ 正在聆聽...</value>
@@ -2755,148 +2755,148 @@
     <value>現在請說話 — 我在聆聽</value>
   </data>
   <data name="VoiceOverlayWindow_StateInitializing" xml:space="preserve">
-    <value>æ­£åœ¨åˆå§‹åŒ–...</value>
+    <value>正在初始化...</value>
   </data>
   <data name="VoiceOverlayWindow_StateStarting" xml:space="preserve">
-    <value>æ­£åœ¨å•Ÿå‹•</value>
+    <value>正在啟動</value>
   </data>
   <data name="VoiceOverlayWindow_StateDownloadingModel" xml:space="preserve">
-    <value>æ­£åœ¨ä¸‹è¼‰èªžéŸ³æ¨¡åž‹...</value>
+    <value>正在下載語音模型...</value>
   </data>
   <data name="VoiceOverlayWindow_StateDownloadingPct" xml:space="preserve">
-    <value>æ­£åœ¨ä¸‹è¼‰æ¨¡åž‹... {0}%</value>
+    <value>正在下載模型... {0}%</value>
   </data>
   <data name="VoiceOverlayWindow_StateLoadingModel" xml:space="preserve">
-    <value>æ­£åœ¨è¼‰å…¥èªžéŸ³æ¨¡åž‹...</value>
+    <value>正在載入語音模型...</value>
   </data>
   <data name="VoiceOverlayWindow_StateStartingMic" xml:space="preserve">
-    <value>æ­£åœ¨å•Ÿå‹•éº¥å…‹é¢¨...</value>
+    <value>正在啟動麥克風...</value>
   </data>
   <data name="VoiceOverlayWindow_StateStopping" xml:space="preserve">
-    <value>æ­£åœ¨åœæ­¢...</value>
+    <value>正在停止...</value>
   </data>
   <data name="VoiceOverlayWindow_StateError" xml:space="preserve">
-    <value>éŒ¯èª¤</value>
+    <value>錯誤</value>
   </data>
   <data name="VoiceOverlayWindow_StatusError" xml:space="preserve">
-    <value>é‡åˆ°éŒ¯èª¤(åƒè¦‹ Debug æ—¥èªŒ)</value>
+    <value>遇到錯誤(參見 Debug 日誌)</value>
   </data>
   <data name="VoiceOverlayWindow_StatusMuted" xml:space="preserve">
-    <value>å·²éœéŸ³</value>
+    <value>已靜音</value>
   </data>
   <data name="VoiceOverlayWindow_StopText" xml:space="preserve">
-    <value>åœæ­¢</value>
+    <value>停止</value>
   </data>
   <data name="VoiceOverlayWindow_BadgeStopped" xml:space="preserve">
-    <value>å·²åœæ­¢</value>
+    <value>已停止</value>
   </data>
   <data name="VoiceOverlayWindow_BadgeStartingDots" xml:space="preserve">
-    <value>æ­£åœ¨å•Ÿå‹•...</value>
+    <value>正在啟動...</value>
   </data>
   <data name="VoiceOverlayWindow_BadgeListening" xml:space="preserve">
-    <value>æ­£åœ¨è†è½</value>
+    <value>正在聆聽</value>
   </data>
   <data name="VoiceOverlayWindow_BadgeProcessing" xml:space="preserve">
-    <value>æ­£åœ¨è™•ç†...</value>
+    <value>正在處理...</value>
   </data>
   <data name="VoiceOverlayWindow_BadgeUnknown" xml:space="preserve">
-    <value>æœªçŸ¥</value>
+    <value>未知</value>
   </data>
   <data name="VoiceOverlayWindow_StatusInitMic" xml:space="preserve">
-    <value>æ­£åœ¨åˆå§‹åŒ–éº¥å…‹é¢¨...</value>
+    <value>正在初始化麥克風...</value>
   </data>
   <data name="VoiceOverlayWindow_StatusTranscribing" xml:space="preserve">
-    <value>æ­£åœ¨è½‰éŒ„æ‚¨çš„èªžéŸ³...</value>
+    <value>正在轉錄您的語音...</value>
   </data>
   <data name="VoiceOverlayWindow_StatusErrorOccurred" xml:space="preserve">
-    <value>ç™¼ç”ŸéŒ¯èª¤</value>
+    <value>發生錯誤</value>
   </data>
   <data name="VoiceOverlayWindow_winexWindowEx_2.Title" xml:space="preserve">
     <value>Companion Voice</value>
   </data>
   <data name="VoiceOverlayWindow_BadgeReady" xml:space="preserve">
-    <value>å°±ç·’</value>
+    <value>就緒</value>
   </data>
   <data name="VoiceOverlayWindow_StatusReadyMessage" xml:space="preserve">
-    <value>æŒ‰é–‹å§‹ä»¥é–‹å§‹</value>
+    <value>按開始以開始</value>
   </data>
   <data name="VoiceOverlayWindow_ButtonStartListening" xml:space="preserve">
-    <value>é–‹å§‹è†è½</value>
+    <value>開始聆聽</value>
   </data>
   <data name="VoiceSettingsPage_ButtonDownloadModel" xml:space="preserve">
-    <value>ä¸‹è¼‰æ¨¡åž‹</value>
+    <value>下載模型</value>
   </data>
   <data name="VoiceSettingsPage_PiperButtonDownloadVoice" xml:space="preserve">
-    <value>ä¸‹è¼‰èªžéŸ³</value>
+    <value>下載語音</value>
   </data>
   <data name="VoiceSettingsPage_PreviewVoiceButtonContent" xml:space="preserve">
     <value>預覽語音</value>
   </data>
   <data name="DebugPage_TextBlock_OverridesHeader.Text" xml:space="preserve">
-    <value>åµéŒ¯è¦†å¯«</value>
+    <value>偵錯覆寫</value>
   </data>
   <data name="DebugPage_TextBlock_OverridesCaption.Text" xml:space="preserve">
-    <value>æŒ‰èŠå¤©å®¹å™¨è¦†å¯«å…¨åŸŸçš„ã€Œä½¿ç”¨æ¨™æº–é–˜é“èŠå¤©ä»‹é¢ã€è¨­å®šã€‚æ‡‰ç”¨ç¨‹å¼é‡æ–°å•Ÿå‹•å¾Œå°‡é‡è¨­ã€‚</value>
+    <value>按聊天容器覆寫全域的「使用標準閘道聊天介面」設定。應用程式重新啟動後將重設。</value>
   </data>
   <data name="DebugPage_TextBlock_HubChatLabel.Text" xml:space="preserve">
-    <value>ä¸­å¿ƒèŠå¤©åˆ†é  UIï¼š</value>
+    <value>中心聊天分頁 UI：</value>
   </data>
   <data name="DebugPage_TextBlock_TrayChatLabel.Text" xml:space="preserve">
-    <value>ç³»çµ±åŒ£èŠå¤©å½ˆå‡ºè¦–çª— UIï¼š</value>
+    <value>系統匣聊天彈出視窗 UI：</value>
   </data>
   <data name="DebugPage_ChatOverride_NoOverride_Hub.Content" xml:space="preserve">
-    <value>ä¸è¦†å¯«</value>
+    <value>不覆寫</value>
   </data>
   <data name="DebugPage_ChatOverride_ForceLegacy_Hub.Content" xml:space="preserve">
-    <value>å¼·åˆ¶ä½¿ç”¨é–˜é“èŠå¤© UI</value>
+    <value>強制使用閘道聊天 UI</value>
   </data>
   <data name="DebugPage_ChatOverride_ForceNative_Hub.Content" xml:space="preserve">
-    <value>å¼·åˆ¶ä½¿ç”¨ä¼´ä¾¶èŠå¤© UI</value>
+    <value>強制使用伴侶聊天 UI</value>
   </data>
   <data name="DebugPage_ChatOverride_NoOverride_Tray.Content" xml:space="preserve">
-    <value>ä¸è¦†å¯«</value>
+    <value>不覆寫</value>
   </data>
   <data name="DebugPage_ChatOverride_ForceLegacy_Tray.Content" xml:space="preserve">
-    <value>å¼·åˆ¶ä½¿ç”¨é–˜é“èŠå¤© UI</value>
+    <value>強制使用閘道聊天 UI</value>
   </data>
   <data name="DebugPage_ChatOverride_ForceNative_Tray.Content" xml:space="preserve">
-    <value>å¼·åˆ¶ä½¿ç”¨ä¼´ä¾¶èŠå¤© UI</value>
+    <value>強制使用伴侶聊天 UI</value>
   </data>
   <data name="Chat_ZeroState_WelcomeTitle" xml:space="preserve">
-    <value>æ­¡è¿Žä½¿ç”¨ OpenClaw</value>
+    <value>歡迎使用 OpenClaw</value>
   </data>
   <data name="Chat_ZeroState_WelcomeSubtitle" xml:space="preserve">
-    <value>ä»Šå¤©æˆ‘èƒ½å¹«ä½ åšä»€éº¼ï¼Ÿ</value>
+    <value>今天我能幫你做什麼？</value>
   </data>
   <data name="Chat_Status_Done" xml:space="preserve">
-    <value>å®Œæˆ</value>
+    <value>完成</value>
   </data>
   <data name="Chat_Status_Running" xml:space="preserve">
-    <value>åŸ·è¡Œä¸­</value>
+    <value>執行中</value>
   </data>
   <data name="Chat_Status_Error" xml:space="preserve">
-    <value>éŒ¯èª¤</value>
+    <value>錯誤</value>
   </data>
   <data name="Chat_Status_Interrupted" xml:space="preserve">
-    <value>å·²ä¸­æ–·</value>
+    <value>已中斷</value>
   </data>
   <data name="Chat_Timeline_LoadEarlier" xml:space="preserve">
-    <value>è¼‰å…¥è¼ƒæ—©çš„è¨Šæ¯</value>
+    <value>載入較早的訊息</value>
   </data>
   <data name="Chat_Tool_CallLabel" xml:space="preserve">
-    <value>å·¥å…·å‘¼å«</value>
+    <value>工具呼叫</value>
   </data>
   <data name="Chat_Tool_OutputLabel" xml:space="preserve">
-    <value>å·¥å…·è¼¸å‡º</value>
+    <value>工具輸出</value>
   </data>
   <data name="Chat_Tool_ErrorLabel" xml:space="preserve">
-    <value>å·¥å…·éŒ¯èª¤</value>
+    <value>工具錯誤</value>
   </data>
   <data name="Chat_Tool_InputSection" xml:space="preserve">
-    <value>å·¥å…·è¼¸å…¥</value>
+    <value>工具輸入</value>
   </data>
   <data name="Chat_Tool_FooterLabel" xml:space="preserve">
-    <value>å·¥å…·</value>
+    <value>工具</value>
   </data>
   <data name="Chat_Tool_FooterWithTimeFormat" xml:space="preserve">
     <value>工具 · {0}</value>
@@ -2911,85 +2911,85 @@
     <value>{0} 正在思考…</value>
   </data>
   <data name="Chat_Composer_Reasoning_Default" xml:space="preserve">
-    <value>é è¨­</value>
+    <value>預設</value>
   </data>
   <data name="Chat_Composer_Reasoning_Auto" xml:space="preserve">
-    <value>è‡ªå‹•</value>
+    <value>自動</value>
   </data>
   <data name="Chat_Composer_Reasoning_Maximum" xml:space="preserve">
-    <value>æœ€å¤§</value>
+    <value>最大</value>
   </data>
   <data name="Chat_Composer_Placeholder_Connected" xml:space="preserve">
-    <value>å‚³è¨Šæ¯çµ¦åŠ©ç†ï¼ˆæŒ‰ Enter å‚³é€ï¼‰</value>
+    <value>傳訊息給助理（按 Enter 傳送）</value>
   </data>
   <data name="Chat_Composer_Placeholder_Connecting" xml:space="preserve">
     <value>連線中…</value>
   </data>
   <data name="Chat_Composer_Placeholder_NotConnected" xml:space="preserve">
-    <value>æœªé€£ç·š</value>
+    <value>未連線</value>
   </data>
   <data name="Chat_Composer_Placeholder_IncompatibleGateway" xml:space="preserve">
     <value>Gateway update required — incompatible version</value>
   </data>
   <data name="Chat_Composer_Tooltip_Attach" xml:space="preserve">
-    <value>é™„åŠ </value>
+    <value>附加</value>
   </data>
   <data name="Chat_Composer_Tooltip_Voice" xml:space="preserve">
-    <value>èªžéŸ³</value>
+    <value>語音</value>
   </data>
   <data name="Chat_Voice_ListeningPrompt" xml:space="preserve">
     <value>正在聆聽…</value>
   </data>
   <data name="Chat_Voice_Cancel" xml:space="preserve">
-    <value>å–æ¶ˆ</value>
+    <value>取消</value>
   </data>
   <data name="Chat_Composer_Tooltip_More" xml:space="preserve">
-    <value>æ›´å¤š</value>
+    <value>更多</value>
   </data>
   <data name="Chat_Composer_Tooltip_Send" xml:space="preserve">
-    <value>å‚³é€</value>
+    <value>傳送</value>
   </data>
   <data name="Chat_Composer_Tooltip_Stop" xml:space="preserve">
-    <value>åœæ­¢</value>
+    <value>停止</value>
   </data>
   <data name="Chat_Composer_AssistantWorking" xml:space="preserve">
     <value>助理處理中…</value>
   </data>
   <data name="Chat_Assistant_Action_Copy" xml:space="preserve">
-    <value>è¤‡è£½è¨Šæ¯</value>
+    <value>複製訊息</value>
   </data>
   <data name="Chat_Assistant_Action_ReadAloud" xml:space="preserve">
-    <value>æœ—è®€</value>
+    <value>朗讀</value>
   </data>
   <data name="Chat_User_Action_Delete" xml:space="preserve">
-    <value>åˆªé™¤è¨Šæ¯</value>
+    <value>刪除訊息</value>
   </data>
   <data name="Chat_TruncationMarkerFormat" xml:space="preserve">
     <value> … [已截斷 {0} 位元組]</value>
   </data>
   <data name="Chat_Permission_Allow" xml:space="preserve">
-    <value>å…è¨±</value>
+    <value>允許</value>
   </data>
   <data name="Chat_Permission_Deny" xml:space="preserve">
-    <value>æ‹’çµ•</value>
+    <value>拒絕</value>
   </data>
   <data name="Chat_Root_ConnectingToGateway" xml:space="preserve">
     <value>連線到閘道中…</value>
   </data>
   <data name="Chat_Root_EmptyState_SelectSession" xml:space="preserve">
-    <value>åœ¨å´é‚Šæ¬„é¸æ“‡ä¸€å€‹å·¥ä½œéšŽæ®µä»¥é–‹å§‹èŠå¤©ã€‚</value>
+    <value>在側邊欄選擇一個工作階段以開始聊天。</value>
   </data>
   <data name="Chat_Notification_SendFailed" xml:space="preserve">
-    <value>å‚³é€å¤±æ•—</value>
+    <value>傳送失敗</value>
   </data>
   <data name="Chat_Notification_AbortFailed" xml:space="preserve">
-    <value>ä¸­æ­¢å¤±æ•—</value>
+    <value>中止失敗</value>
   </data>
   <data name="Chat_Notification_LoadHistoryFailed" xml:space="preserve">
-    <value>è¼‰å…¥æ­·å²è¨˜éŒ„å¤±æ•—</value>
+    <value>載入歷史記錄失敗</value>
   </data>
   <data name="Chat_Notification_AssistantReplied" xml:space="preserve">
-    <value>åŠ©ç†å·²å›žè¦†</value>
+    <value>助理已回覆</value>
   </data>
   <data name="Chat_Notification_ConnectionInterrupted" xml:space="preserve">
     <value>連線已中斷 — 回覆已中斷。</value>
@@ -3001,7 +3001,7 @@
     <value>閘道傳送了缺少工作階段金鑰的聊天時間軸事件，OpenClaw 已將其忽略，以避免混淆時間軸。如果此情況持續，請更新或重新啟動閘道。</value>
   </data>
   <data name="VoiceSettingsPage_TestVoiceButtonText.Text" xml:space="preserve">
-    <value>æ¸¬è©¦èªžéŸ³è¼¸å…¥</value>
+    <value>測試語音輸入</value>
   </data>
   <data name="PermissionsPage_FeaturesDescription_Enabled" xml:space="preserve">
     <value>Toggle individual features that agents may request from this PC.</value>
@@ -3187,7 +3187,7 @@
     <value>Resync</value>
   </data>
   <data name="InstancesPage_BackToConnectionText.Text" xml:space="preserve">
-    <value>è¿”å›žé€£ç·š</value>
+    <value>返回連線</value>
   </data>
   <data name="ConnectionPage_NodePairing_Title.Text" xml:space="preserve">
     <value>🔗 Pending Operator/Node Pairing</value>
@@ -3235,16 +3235,16 @@
     <value>Copy node ID</value>
   </data>
   <data name="InstancesPage_TimeAgo_Seconds_Format" xml:space="preserve">
-    <value>{0}ç§’å‰</value>
+    <value>{0}秒前</value>
   </data>
   <data name="InstancesPage_TimeAgo_Minutes_Format" xml:space="preserve">
-    <value>{0}åˆ†é˜å‰</value>
+    <value>{0}分鐘前</value>
   </data>
   <data name="InstancesPage_TimeAgo_Hours_Format" xml:space="preserve">
-    <value>{0}å°æ™‚å‰</value>
+    <value>{0}小時前</value>
   </data>
   <data name="InstancesPage_TimeAgo_Days_Format" xml:space="preserve">
-    <value>{0}å¤©å‰</value>
+    <value>{0}天前</value>
   </data>
   <data name="V2_Window_Title" xml:space="preserve">
     <value>OpenClaw Setup</value>
@@ -3409,55 +3409,55 @@
     <value>Keep my setup</value>
   </data>
   <data name="FilterAllButton.Text" xml:space="preserve">
-    <value>å…¨éƒ¨</value>
+    <value>全部</value>
   </data>
   <data name="ChannelsPage_Title.Text" xml:space="preserve">
-    <value>é »é“</value>
+    <value>頻道</value>
   </data>
   <data name="ChannelsPage_Refresh.Text" xml:space="preserve">
-    <value>é‡æ–°æ•´ç†</value>
+    <value>重新整理</value>
   </data>
   <data name="ChannelsPage_ConfiguredHeader.Text" xml:space="preserve">
-    <value>å·²è¨­å®š</value>
+    <value>已設定</value>
   </data>
   <data name="ChannelsPage_AvailableHeader.Text" xml:space="preserve">
-    <value>å¯ç”¨</value>
+    <value>可用</value>
   </data>
   <data name="ChatPageHomeToolTip.Content" xml:space="preserve">
-    <value>é¦–é </value>
+    <value>首頁</value>
   </data>
   <data name="ChatPageRefreshToolTip.Content" xml:space="preserve">
-    <value>é‡æ–°æ•´ç†</value>
+    <value>重新整理</value>
   </data>
   <data name="ChatPageDeveloperToolsToolTip.Content" xml:space="preserve">
-    <value>é–‹ç™¼äººå“¡å·¥å…·</value>
+    <value>開發人員工具</value>
   </data>
   <data name="SettingsRow_AutoStart_Header.Text" xml:space="preserve">
-    <value>éš¨ Windows å•Ÿå‹•</value>
+    <value>隨 Windows 啟動</value>
   </data>
   <data name="SettingsRow_GlobalHotkey_Header.Text" xml:space="preserve">
-    <value>å¿«é€Ÿå‚³é€å¿«é€Ÿéµ</value>
+    <value>快速傳送快速鍵</value>
   </data>
   <data name="SettingsRow_LegacyChat_Header.Text" xml:space="preserve">
-    <value>ä½¿ç”¨é–˜é“çš„ç¶²é èŠå¤©ä»‹é¢</value>
+    <value>使用閘道的網頁聊天介面</value>
   </data>
   <data name="SettingsRow_Notifications_Header.Text" xml:space="preserve">
-    <value>é¡¯ç¤ºé€šçŸ¥</value>
+    <value>顯示通知</value>
   </data>
   <data name="SettingsRow_NotifSound_Header.Text" xml:space="preserve">
-    <value>æç¤ºéŸ³</value>
+    <value>提示音</value>
   </data>
   <data name="SettingsRow_ScreenRec_Header.Text" xml:space="preserve">
-    <value>å…è¨±èž¢å¹•éŒ„è£½</value>
+    <value>允許螢幕錄製</value>
   </data>
   <data name="SettingsRow_CamRec_Header.Text" xml:space="preserve">
-    <value>å…è¨±ç›¸æ©ŸéŒ„è£½</value>
+    <value>允許相機錄製</value>
   </data>
   <data name="HubWindow_NavigationViewItem_Voice.Content" xml:space="preserve">
-    <value>èªžéŸ³èˆ‡éŸ³è¨Š</value>
+    <value>語音與音訊</value>
   </data>
   <data name="HubWindow_NavigationViewItem_Sandbox.Content" xml:space="preserve">
-    <value>æ²™ç›’</value>
+    <value>沙盒</value>
   </data>
   <data name="AboutPage_MoreDiagnosticsLink.Content" xml:space="preserve">
     <value>More diagnostics →</value>
@@ -3637,34 +3637,34 @@
     <value>Connection Status</value>
   </data>
   <data name="BindingsPage_GatewayDisconnected.Title" xml:space="preserve">
-    <value>é–˜é“å·²ä¸­æ–·</value>
+    <value>閘道已中斷</value>
   </data>
   <data name="BindingsPage_GatewayDisconnected.Message" xml:space="preserve">
-    <value>è«‹é€£æŽ¥è‡³é–˜é“ä»¥è¼‰å…¥ç¹«çµã€‚</value>
+    <value>請連接至閘道以載入繫結。</value>
   </data>
   <data name="BindingsPage_OpenConnection.Content" xml:space="preserve">
-    <value>é–‹å•Ÿé€£ç·š</value>
+    <value>開啟連線</value>
   </data>
   <data name="BindingsPage_LoadingBindings.Text" xml:space="preserve">
     <value>正在載入繫結…</value>
   </data>
   <data name="ConnectionPage_ApprovalsWaitingOnYou.Text" xml:space="preserve">
-    <value>ç­‰å¾…æ‚¨çš„æ ¸å‡†</value>
+    <value>等待您的核准</value>
   </data>
   <data name="ConnectionPage_NotConnected.Text" xml:space="preserve">
-    <value>æœªé€£ç·š</value>
+    <value>未連線</value>
   </data>
   <data name="ConnectionPage_Connect.Content" xml:space="preserve">
-    <value>é€£ç·š</value>
+    <value>連線</value>
   </data>
   <data name="ConnectionPage_Operator.Text" xml:space="preserve">
-    <value>æ“ä½œå“¡</value>
+    <value>操作員</value>
   </data>
   <data name="ConnectionPage_SendCommandsAndView.Text" xml:space="preserve">
-    <value>å¾žé€™å°é›»è…¦å‘æ­¤é–˜é“å‚³é€å‘½ä»¤ä¸¦æª¢è¦–å·¥ä½œéšŽæ®µã€‚</value>
+    <value>從這台電腦向此閘道傳送命令並檢視工作階段。</value>
   </data>
   <data name="ConnectionPage_Inactive.Text" xml:space="preserve">
-    <value>æœªå•Ÿç”¨</value>
+    <value>未啟用</value>
   </data>
   <data name="ConnectionPage_SeeSessions.Content" xml:space="preserve">
     <value>檢視工作階段 ›</value>
@@ -3673,232 +3673,232 @@
     <value>檢視執行個體 ›</value>
   </data>
   <data name="ConnectionPage_NodeMode.Text" xml:space="preserve">
-    <value>ç¯€é»žæ¨¡å¼</value>
+    <value>節點模式</value>
   </data>
   <data name="ConnectionPage_WhenOnThisPC.Text" xml:space="preserve">
-    <value>å•Ÿç”¨å¾Œ,é€™å°é›»è…¦æœƒè¨»å†Šç‚ºç¯€é»ž,ä¸¦é€éŽé–˜é“å‘ä»£ç†æä¾›ä¸‹åˆ—åŠŸèƒ½ã€‚</value>
+    <value>啟用後,這台電腦會註冊為節點,並透過閘道向代理提供下列功能。</value>
   </data>
   <data name="ConnectionPage_NodeModeDisabled.Text" xml:space="preserve">
-    <value>ç¯€é»žæ¨¡å¼å·²åœç”¨</value>
+    <value>節點模式已停用</value>
   </data>
   <data name="ConnectionPage_Copy.Content" xml:space="preserve">
-    <value>è¤‡è£½</value>
+    <value>複製</value>
   </data>
   <data name="ConnectionPage_Connect2.Content" xml:space="preserve">
-    <value>é€£ç·š</value>
+    <value>連線</value>
   </data>
   <data name="ConnectionPage_ManagePermissions.Content" xml:space="preserve">
     <value>管理權限 ›</value>
   </data>
   <data name="ConnectionPage_HelpUsFixThis.Text" xml:space="preserve">
-    <value>å”åŠ©æˆ‘å€‘ä¿®å¾©æ­¤é€£ç·š:</value>
+    <value>協助我們修復此連線:</value>
   </data>
   <data name="ConnectionPage_SSHTunnelIsDown.Text" xml:space="preserve">
-    <value>SSH é€šé“å·²åœæ­¢ã€‚</value>
+    <value>SSH 通道已停止。</value>
   </data>
   <data name="ConnectionPage_RestartTunnel.Content" xml:space="preserve">
-    <value>é‡æ–°å•Ÿå‹•é€šé“</value>
+    <value>重新啟動通道</value>
   </data>
   <data name="ConnectionPage_EditTunnelSettings.Content" xml:space="preserve">
-    <value>ç·¨è¼¯é€šé“è¨­å®š</value>
+    <value>編輯通道設定</value>
   </data>
   <data name="ConnectionPage_PasteANewSetup.Text" xml:space="preserve">
-    <value>è²¼ä¸Šä¾†è‡ªé–˜é“ä¸»æ©Ÿçš„æ–°è¨­å®šä»£ç¢¼ã€‚</value>
+    <value>貼上來自閘道主機的新設定代碼。</value>
   </data>
   <data name="ConnectionPage_PasteSetupCodeHere.PlaceholderText" xml:space="preserve">
     <value>在此貼上設定代碼…</value>
   </data>
   <data name="ConnectionPage_Apply.Content" xml:space="preserve">
-    <value>å¥—ç”¨</value>
+    <value>套用</value>
   </data>
   <data name="ConnectionPage_RunOnTheGateway.Text" xml:space="preserve">
-    <value>åœ¨é–˜é“ä¸»æ©Ÿä¸ŠåŸ·è¡Œ:</value>
+    <value>在閘道主機上執行:</value>
   </data>
   <data name="ConnectionPage_Copy2.Content" xml:space="preserve">
-    <value>è¤‡è£½</value>
+    <value>複製</value>
   </data>
   <data name="ConnectionPage_Connect3.Content" xml:space="preserve">
-    <value>é€£ç·š</value>
+    <value>連線</value>
   </data>
   <data name="ConnectionPage_Disconnect.Content" xml:space="preserve">
-    <value>ä¸­æ–·é€£ç·š</value>
+    <value>中斷連線</value>
   </data>
   <data name="ConnectionPage_SavedGateways.Text" xml:space="preserve">
-    <value>å·²å„²å­˜çš„é–˜é“</value>
+    <value>已儲存的閘道</value>
   </data>
   <data name="ConnectionPage_Gateways.Text" xml:space="preserve">
-    <value>é–˜é“</value>
+    <value>閘道</value>
   </data>
   <data name="ConnectionPage_Scan.Text" xml:space="preserve">
-    <value>æŽƒæ</value>
+    <value>掃描</value>
   </data>
   <data name="ConnectionPage_AddGateway.Text" xml:space="preserve">
-    <value>æ–°å¢žé–˜é“</value>
+    <value>新增閘道</value>
   </data>
   <data name="ConnectionPage_NoSavedGatewaysYet.Text" xml:space="preserve">
-    <value>å°šç„¡å·²å„²å­˜çš„é–˜é“ã€‚</value>
+    <value>尚無已儲存的閘道。</value>
   </data>
   <data name="ConnectionPage_DiscoveredOnYourNetwork.Text" xml:space="preserve">
-    <value>åœ¨æ‚¨çš„ç¶²è·¯ä¸ŠæŽ¢ç´¢åˆ°</value>
+    <value>在您的網路上探索到</value>
   </data>
   <data name="ConnectionPage_AddAGateway.Text" xml:space="preserve">
-    <value>æ–°å¢žé–˜é“</value>
+    <value>新增閘道</value>
   </data>
   <data name="ConnectionPage_GetStartedInstallA.Title" xml:space="preserve">
     <value>開始使用 — 安裝本機閘道</value>
   </data>
   <data name="ConnectionPage_GetStartedInstallA.Message" xml:space="preserve">
-    <value>æœ€å¿«çš„å…¥é–€æ–¹å¼:åœ¨é€™å°é›»è…¦ä¸Šè¨­å®šç”± WSL è¨—ç®¡çš„é–˜é“,ä¸¦å°‡å…¶è¨­ç‚ºä½¿ç”¨ä¸­çš„é€£ç·šã€‚</value>
+    <value>最快的入門方式:在這台電腦上設定由 WSL 託管的閘道,並將其設為使用中的連線。</value>
   </data>
   <data name="ConnectionPage_Install.Content" xml:space="preserve">
-    <value>å®‰è£</value>
+    <value>安裝</value>
   </data>
   <data name="ConnectionPage_OrConnectToAn.Text" xml:space="preserve">
-    <value>æˆ–é€£ç·šè‡³ç¾æœ‰é–˜é“:</value>
+    <value>或連線至現有閘道:</value>
   </data>
   <data name="ConnectionPage_Direct.Text" xml:space="preserve">
-    <value>ç›´æŽ¥</value>
+    <value>直接</value>
   </data>
   <data name="ConnectionPage_URLToken.Text" xml:space="preserve">
-    <value>URL + æ¬Šæ–</value>
+    <value>URL + 權杖</value>
   </data>
   <data name="ConnectionPage_SetupCode.Text" xml:space="preserve">
-    <value>è¨­å®šä»£ç¢¼</value>
+    <value>設定代碼</value>
   </data>
   <data name="ConnectionPage_PasteQRPayload.Text" xml:space="preserve">
-    <value>è²¼ä¸Š QR å…§å®¹</value>
+    <value>貼上 QR 內容</value>
   </data>
   <data name="ConnectionPage_EachMethodSupportsAn.Text" xml:space="preserve">
-    <value>æ¯ç¨®æ–¹æ³•éƒ½æ”¯æ´é¸ç”¨çš„ SSH é€šé“ã€‚</value>
+    <value>每種方法都支援選用的 SSH 通道。</value>
   </data>
   <data name="ConnectionPage_OrLookForOne.Text" xml:space="preserve">
-    <value>æˆ–åœ¨æ‚¨çš„ç¶²è·¯ä¸Šå°‹æ‰¾ã€‚</value>
+    <value>或在您的網路上尋找。</value>
   </data>
   <data name="ConnectionPage_Scan2.Text" xml:space="preserve">
-    <value>æŽƒæ</value>
+    <value>掃描</value>
   </data>
   <data name="ConnectionPage_DiscoveredOnYourNetwork2.Text" xml:space="preserve">
-    <value>åœ¨æ‚¨çš„ç¶²è·¯ä¸ŠæŽ¢ç´¢åˆ°</value>
+    <value>在您的網路上探索到</value>
   </data>
   <data name="ConnectionPage_Back.Text" xml:space="preserve">
-    <value>è¿”å›ž</value>
+    <value>返回</value>
   </data>
   <data name="ConnectionPage_AddAGateway2.Text" xml:space="preserve">
-    <value>æ–°å¢žé–˜é“</value>
+    <value>新增閘道</value>
   </data>
   <data name="ConnectionPage_Direct2.Text" xml:space="preserve">
-    <value>ç›´æŽ¥</value>
+    <value>直接</value>
   </data>
   <data name="ConnectionPage_SetupCode2.Text" xml:space="preserve">
-    <value>è¨­å®šä»£ç¢¼</value>
+    <value>設定代碼</value>
   </data>
   <data name="ConnectionPage_LocalWSL.Text" xml:space="preserve">
-    <value>æœ¬æ©Ÿ WSL</value>
+    <value>本機 WSL</value>
   </data>
   <data name="ConnectionPage_GatewayURL.Header" xml:space="preserve">
-    <value>é–˜é“ URL</value>
+    <value>閘道 URL</value>
   </data>
   <data name="ConnectionPage_GatewayURL.PlaceholderText" xml:space="preserve">
     <value>ws://host.local:18790</value>
   </data>
   <data name="ConnectionPage_SharedToken.Header" xml:space="preserve">
-    <value>å…±ç”¨æ¬Šæ–</value>
+    <value>共用權杖</value>
   </data>
   <data name="ConnectionPage_SharedToken.PlaceholderText" xml:space="preserve">
-    <value>è²¼ä¸Šå…±ç”¨é–˜é“æ¬Šæ–</value>
+    <value>貼上共用閘道權杖</value>
   </data>
   <data name="ConnectionPage_NameOptional.Header" xml:space="preserve">
-    <value>åç¨±(é¸ç”¨)</value>
+    <value>名稱(選用)</value>
   </data>
   <data name="ConnectionPage_NameOptional.PlaceholderText" xml:space="preserve">
-    <value>æˆ‘çš„é–˜é“</value>
+    <value>我的閘道</value>
   </data>
   <data name="ConnectionPage_PasteASetupCode.Text" xml:space="preserve">
-    <value>è²¼ä¸Šä¾†è‡ªé–˜é“çš„ QR ç¢¼æˆ– `openclaw qr` è¼¸å‡ºçš„è¨­å®šä»£ç¢¼ã€‚</value>
+    <value>貼上來自閘道的 QR 碼或 `openclaw qr` 輸出的設定代碼。</value>
   </data>
   <data name="ConnectionPage_PasteSetupCodeHere2.PlaceholderText" xml:space="preserve">
     <value>在此貼上設定代碼…</value>
   </data>
   <data name="ConnectionPage_Decode.Content" xml:space="preserve">
-    <value>è§£ç¢¼</value>
+    <value>解碼</value>
   </data>
   <data name="ConnectionPage_InstallANewWSL.Text" xml:space="preserve">
-    <value>åœ¨é€™å°é›»è…¦ä¸Šå®‰è£æ–°çš„ WSL é–˜é“,ä¸¦å°‡å…¶è¨­ç‚ºä½¿ç”¨ä¸­çš„é€£ç·šã€‚å®‰è£ç²¾éˆæœƒè¦–éœ€è¦å®‰è£ WSLã€ä½ˆå»ºé–˜é“,ä¸¦è‡ªå‹•é…å°é€™å°è£ç½®ã€‚</value>
+    <value>在這台電腦上安裝新的 WSL 閘道,並將其設為使用中的連線。安裝精靈會視需要安裝 WSL、佈建閘道,並自動配對這台裝置。</value>
   </data>
   <data name="ConnectionPage_InstallLocalGateway.Content" xml:space="preserve">
-    <value>å®‰è£æœ¬æ©Ÿé–˜é“</value>
+    <value>安裝本機閘道</value>
   </data>
   <data name="ConnectionPage_LocalWSLSetupIsn.Text" xml:space="preserve">
     <value>這台電腦無法進行本機 WSL 設定 — 安裝精靈無法初始化。</value>
   </data>
   <data name="ConnectionPage_UseSSHTunnelOptional.Text" xml:space="preserve">
-    <value>ä½¿ç”¨ SSH é€šé“(é¸ç”¨)</value>
+    <value>使用 SSH 通道(選用)</value>
   </data>
   <data name="ConnectionPage_SSHUser.Header" xml:space="preserve">
-    <value>SSH ä½¿ç”¨è€…</value>
+    <value>SSH 使用者</value>
   </data>
   <data name="ConnectionPage_SSHUser.PlaceholderText" xml:space="preserve">
     <value>user</value>
   </data>
   <data name="ConnectionPage_SSHHost.Header" xml:space="preserve">
-    <value>SSH ä¸»æ©Ÿ</value>
+    <value>SSH 主機</value>
   </data>
   <data name="ConnectionPage_SSHHost.PlaceholderText" xml:space="preserve">
     <value>machine-name</value>
   </data>
   <data name="ConnectionPage_RemotePort.Header" xml:space="preserve">
-    <value>é ç«¯é€£æŽ¥åŸ </value>
+    <value>遠端連接埠</value>
   </data>
   <data name="ConnectionPage_LocalPort.Header" xml:space="preserve">
-    <value>æœ¬æ©Ÿé€£æŽ¥åŸ </value>
+    <value>本機連接埠</value>
   </data>
   <data name="ConnectionPage_SaveAmpConnect.Content" xml:space="preserve">
-    <value>å„²å­˜ä¸¦é€£ç·š</value>
+    <value>儲存並連線</value>
   </data>
   <data name="ConnectionPage_Cancel.Content" xml:space="preserve">
-    <value>å–æ¶ˆ</value>
+    <value>取消</value>
   </data>
   <data name="CronPage_CronJobs.Text" xml:space="preserve">
     <value>⏱️ Cron 工作</value>
   </data>
   <data name="CronPage_Refresh.Text" xml:space="preserve">
-    <value>é‡æ–°æ•´ç†</value>
+    <value>重新整理</value>
   </data>
   <data name="CronPage_NewJob.Text" xml:space="preserve">
-    <value>æ–°å¢žå·¥ä½œ</value>
+    <value>新增工作</value>
   </data>
   <data name="CronPage_GatewayDisconnected.Title" xml:space="preserve">
-    <value>é–˜é“å·²ä¸­æ–·</value>
+    <value>閘道已中斷</value>
   </data>
   <data name="CronPage_GatewayDisconnected.Message" xml:space="preserve">
-    <value>è«‹é€£æŽ¥è‡³é–˜é“ä»¥è¼‰å…¥ cron å·¥ä½œã€‚</value>
+    <value>請連接至閘道以載入 cron 工作。</value>
   </data>
   <data name="CronPage_OpenConnection.Content" xml:space="preserve">
-    <value>é–‹å•Ÿé€£ç·š</value>
+    <value>開啟連線</value>
   </data>
   <data name="CronPage_NewCronJob.Text" xml:space="preserve">
-    <value>æ–°å¢ž Cron å·¥ä½œ</value>
+    <value>新增 Cron 工作</value>
   </data>
   <data name="CronPage_NAME.Text" xml:space="preserve">
-    <value>åç¨±</value>
+    <value>名稱</value>
   </data>
   <data name="CronPage_MorningBrief.PlaceholderText" xml:space="preserve">
-    <value>æ™¨é–“ç°¡å ±</value>
+    <value>晨間簡報</value>
   </data>
   <data name="CronPage_SCHEDULE.Text" xml:space="preserve">
-    <value>æŽ’ç¨‹</value>
+    <value>排程</value>
   </data>
   <data name="CronPage_Every.Content" xml:space="preserve">
-    <value>æ¯</value>
+    <value>每</value>
   </data>
   <data name="CronPage_At.Content" xml:space="preserve">
-    <value>æ–¼</value>
+    <value>於</value>
   </data>
   <data name="CronPage_Cron.Content" xml:space="preserve">
     <value>Cron</value>
   </data>
   <data name="CronPage_QUICKPRESETS.Text" xml:space="preserve">
-    <value>å¿«é€Ÿé è¨­</value>
+    <value>快速預設</value>
   </data>
   <data name="CronPage_Hourly.Content" xml:space="preserve">
     <value>⏰ 每小時</value>
@@ -3916,13 +3916,13 @@
     <value>📅 每週</value>
   </data>
   <data name="CronPage_EXPRESSION.Text" xml:space="preserve">
-    <value>é‹ç®—å¼</value>
+    <value>運算式</value>
   </data>
   <data name="CronPage_TIMEZONE.Text" xml:space="preserve">
-    <value>æ™‚å€</value>
+    <value>時區</value>
   </data>
   <data name="CronPage_Optional.PlaceholderText" xml:space="preserve">
-    <value>é¸ç”¨</value>
+    <value>選用</value>
   </data>
   <data name="CronPage_AmericaNewYork.Content" xml:space="preserve">
     <value>America/New_York</value>
@@ -3949,310 +3949,310 @@
     <value>UTC</value>
   </data>
   <data name="CronPage_EVERY.Text" xml:space="preserve">
-    <value>æ¯</value>
+    <value>每</value>
   </data>
   <data name="CronPage_UNIT.Text" xml:space="preserve">
-    <value>å–®ä½</value>
+    <value>單位</value>
   </data>
   <data name="CronPage_Minutes.Content" xml:space="preserve">
-    <value>åˆ†é˜</value>
+    <value>分鐘</value>
   </data>
   <data name="CronPage_Hours.Content" xml:space="preserve">
-    <value>å°æ™‚</value>
+    <value>小時</value>
   </data>
   <data name="CronPage_Days.Content" xml:space="preserve">
-    <value>å¤©</value>
+    <value>天</value>
   </data>
   <data name="CronPage_RUNAT.Text" xml:space="preserve">
-    <value>åŸ·è¡Œæ™‚é–“</value>
+    <value>執行時間</value>
   </data>
   <data name="CronPage_Date.PlaceholderText" xml:space="preserve">
-    <value>æ—¥æœŸ</value>
+    <value>日期</value>
   </data>
   <data name="CronPage_330PM.PlaceholderText" xml:space="preserve">
     <value>15:30</value>
   </data>
   <data name="CronPage_DeleteJobAfterIt.Content" xml:space="preserve">
-    <value>åŸ·è¡Œå¾Œåˆªé™¤å·¥ä½œ</value>
+    <value>執行後刪除工作</value>
   </data>
   <data name="CronPage_PROMPTPAYLOAD.Text" xml:space="preserve">
-    <value>æç¤º / å…§å®¹</value>
+    <value>提示 / 內容</value>
   </data>
   <data name="CronPage_WhatShouldTheAgent.PlaceholderText" xml:space="preserve">
-    <value>ä»£ç†æ‡‰è©²åšä»€éº¼?</value>
+    <value>代理應該做什麼?</value>
   </data>
   <data name="CronPage_DELIVERY.Text" xml:space="preserve">
-    <value>å‚³éž</value>
+    <value>傳遞</value>
   </data>
   <data name="CronPage_SilentNone.Content" xml:space="preserve">
-    <value>éœé»˜(ç„¡)</value>
+    <value>靜默(無)</value>
   </data>
   <data name="CronPage_NotifyMeAnnounce.Content" xml:space="preserve">
-    <value>é€šçŸ¥æˆ‘(é€šå‘Š)</value>
+    <value>通知我(通告)</value>
   </data>
   <data name="CronPage_CHANNEL.Text" xml:space="preserve">
-    <value>é€šé“</value>
+    <value>通道</value>
   </data>
   <data name="CronPage_EGWebchat.PlaceholderText" xml:space="preserve">
-    <value>ä¾‹å¦‚ webchat</value>
+    <value>例如 webchat</value>
   </data>
   <data name="CronPage_AdvancedOptions.Text" xml:space="preserve">
-    <value>é€²éšŽé¸é …</value>
+    <value>進階選項</value>
   </data>
   <data name="CronPage_SESSIONBEHAVIOR.Text" xml:space="preserve">
-    <value>å·¥ä½œéšŽæ®µè¡Œç‚º</value>
+    <value>工作階段行為</value>
   </data>
   <data name="CronPage_NewSessionEachRun.Content" xml:space="preserve">
-    <value>æ¯æ¬¡åŸ·è¡Œå»ºç«‹æ–°å·¥ä½œéšŽæ®µ</value>
+    <value>每次執行建立新工作階段</value>
   </data>
   <data name="CronPage_ResumeMainSession.Content" xml:space="preserve">
-    <value>ç¹¼çºŒä¸»è¦å·¥ä½œéšŽæ®µ</value>
+    <value>繼續主要工作階段</value>
   </data>
   <data name="CronPage_WAKEMODE.Text" xml:space="preserve">
-    <value>å–šé†’æ¨¡å¼</value>
+    <value>喚醒模式</value>
   </data>
   <data name="CronPage_NowImmediate.Content" xml:space="preserve">
-    <value>ç«‹å³(å³æ™‚)</value>
+    <value>立即(即時)</value>
   </data>
   <data name="CronPage_QueueWaitForIdle.Content" xml:space="preserve">
-    <value>ä½‡åˆ—(ç­‰å¾…é–’ç½®)</value>
+    <value>佇列(等待閒置)</value>
   </data>
   <data name="CronPage_Cancel.Content" xml:space="preserve">
-    <value>å–æ¶ˆ</value>
+    <value>取消</value>
   </data>
   <data name="CronPage_CreateJob.Content" xml:space="preserve">
-    <value>å»ºç«‹å·¥ä½œ</value>
+    <value>建立工作</value>
   </data>
   <data name="CronPage_LoadingCronJobs.Text" xml:space="preserve">
     <value>正在載入 cron 工作…</value>
   </data>
   <data name="CronPage_NoCronJobsConfigured.Text" xml:space="preserve">
-    <value>æœªè¨­å®š cron å·¥ä½œ</value>
+    <value>未設定 cron 工作</value>
   </data>
   <data name="CronPage_CronJobsWillAppear.Text" xml:space="preserve">
-    <value>é€éŽé–˜é“è¨­å®š cron å·¥ä½œå¾Œ,å®ƒå€‘æœƒé¡¯ç¤ºåœ¨æ­¤è™•ã€‚</value>
+    <value>透過閘道設定 cron 工作後,它們會顯示在此處。</value>
   </data>
   <data name="DebugPage_Status.Title" xml:space="preserve">
-    <value>ç‹€æ…‹</value>
+    <value>狀態</value>
   </data>
   <data name="DebugPage_Copied.Title" xml:space="preserve">
-    <value>å·²è¤‡è£½</value>
+    <value>已複製</value>
   </data>
   <data name="DebugPage_NoOverride.Content" xml:space="preserve">
-    <value>ç„¡è¦†å¯«</value>
+    <value>無覆寫</value>
   </data>
   <data name="DebugPage_ForceGatewayChatUI.Content" xml:space="preserve">
-    <value>å¼·åˆ¶ä½¿ç”¨é–˜é“èŠå¤©ä»‹é¢</value>
+    <value>強制使用閘道聊天介面</value>
   </data>
   <data name="DebugPage_ForceCompanionChatUI.Content" xml:space="preserve">
-    <value>å¼·åˆ¶ä½¿ç”¨ä¼´ä¾¶èŠå¤©ä»‹é¢</value>
+    <value>強制使用伴侶聊天介面</value>
   </data>
   <data name="DebugPage_NoOverride2.Content" xml:space="preserve">
-    <value>ç„¡è¦†å¯«</value>
+    <value>無覆寫</value>
   </data>
   <data name="DebugPage_ForceGatewayChatUI2.Content" xml:space="preserve">
-    <value>å¼·åˆ¶ä½¿ç”¨é–˜é“èŠå¤©ä»‹é¢</value>
+    <value>強制使用閘道聊天介面</value>
   </data>
   <data name="DebugPage_ForceCompanionChatUI2.Content" xml:space="preserve">
-    <value>å¼·åˆ¶ä½¿ç”¨ä¼´ä¾¶èŠå¤©ä»‹é¢</value>
+    <value>強制使用伴侶聊天介面</value>
   </data>
   <data name="DebugPage_Refresh.Text" xml:space="preserve">
-    <value>é‡æ–°æ•´ç†</value>
+    <value>重新整理</value>
   </data>
   <data name="DebugPage_Copy.Text" xml:space="preserve">
-    <value>è¤‡è£½</value>
+    <value>複製</value>
   </data>
   <data name="DebugPage_OpenFile.Text" xml:space="preserve">
-    <value>é–‹å•Ÿæª”æ¡ˆ</value>
+    <value>開啟檔案</value>
   </data>
   <data name="InstancesPage_PairingApprovalRequired.Text" xml:space="preserve">
-    <value>éœ€è¦é…å°æ ¸å‡†</value>
+    <value>需要配對核准</value>
   </data>
   <data name="InstancesPage_ANodeHasConnected.Text" xml:space="preserve">
-    <value>ç¯€é»žå·²é€£ç·š,ä½†åœ¨æ‚¨æ ¸å‡†é…å°è¦æ±‚ä¹‹å‰,å…¶åŠŸèƒ½ä¸æœƒå•Ÿç”¨ã€‚</value>
+    <value>節點已連線,但在您核准配對要求之前,其功能不會啟用。</value>
   </data>
   <data name="InstancesPage_ReviewOnConnectionPage.Content" xml:space="preserve">
-    <value>åœ¨ã€Œé€£ç·šã€é é¢æª¢è¦–</value>
+    <value>在「連線」頁面檢視</value>
   </data>
   <data name="PermissionsPage_BackToConnection.Text" xml:space="preserve">
-    <value>è¿”å›žé€£ç·š</value>
+    <value>返回連線</value>
   </data>
   <data name="PermissionsPage_Permissions.Text" xml:space="preserve">
-    <value>æ¬Šé™</value>
+    <value>權限</value>
   </data>
   <data name="PermissionsPage_NodeMode.Text" xml:space="preserve">
-    <value>ç¯€é»žæ¨¡å¼</value>
+    <value>節點模式</value>
   </data>
   <data name="PermissionsPage_WhenOnThisPC.Text" xml:space="preserve">
-    <value>å•Ÿç”¨å¾Œ,é€™å°é›»è…¦æœƒè¨»å†Šç‚ºç¯€é»ž,ä¸¦é€éŽé–˜é“å‘ä»£ç†æä¾›ä¸‹åˆ—åŠŸèƒ½ã€‚</value>
+    <value>啟用後,這台電腦會註冊為節點,並透過閘道向代理提供下列功能。</value>
   </data>
   <data name="PermissionsPage_Capabilities.Text" xml:space="preserve">
-    <value>åŠŸèƒ½</value>
+    <value>功能</value>
   </data>
   <data name="PermissionsPage_ToggleIndividualFeaturesThat.Text" xml:space="preserve">
-    <value>åˆ‡æ›ä»£ç†å¯èƒ½å¾žé€™å°é›»è…¦è¦æ±‚çš„å„é …åŠŸèƒ½ã€‚</value>
+    <value>切換代理可能從這台電腦要求的各項功能。</value>
   </data>
   <data name="PermissionsPage_Integrations.Text" xml:space="preserve">
-    <value>æ•´åˆ</value>
+    <value>整合</value>
   </data>
   <data name="PermissionsPage_DefaultAction.Text" xml:space="preserve">
-    <value>é è¨­å‹•ä½œ</value>
+    <value>預設動作</value>
   </data>
   <data name="PermissionsPage_WhatHappensWhenA.Text" xml:space="preserve">
-    <value>ç•¶å‘½ä»¤ä¸ç¬¦åˆä¸‹åˆ—ä»»ä½•è¦å‰‡æ™‚æœƒç™¼ç”Ÿä»€éº¼ã€‚</value>
+    <value>當命令不符合下列任何規則時會發生什麼。</value>
   </data>
   <data name="PermissionsPage_PatternsAreMatchedLeft.Text" xml:space="preserve">
-    <value>æ¨¡å¼ç”±å·¦è‡³å³èˆ‡å®Œæ•´å‘½ä»¤åˆ—æ¯”å°ã€‚ä½¿ç”¨ * ä½œç‚ºè¬ç”¨å­—å…ƒã€‚è®Šæ›´æœƒè‡ªå‹•å„²å­˜ã€‚</value>
+    <value>模式由左至右與完整命令列比對。使用 * 作為萬用字元。變更會自動儲存。</value>
   </data>
   <data name="PermissionsPage_Saved.Text" xml:space="preserve">
-    <value>å·²å„²å­˜</value>
+    <value>已儲存</value>
   </data>
   <data name="PermissionsPage_0Rules.Text" xml:space="preserve">
-    <value>0 æ¢è¦å‰‡</value>
+    <value>0 條規則</value>
   </data>
   <data name="PermissionsPage_NoRulesYetAdd.Text" xml:space="preserve">
-    <value>å°šç„¡è¦å‰‡ã€‚åœ¨ä¸‹æ–¹æ–°å¢žæ¨¡å¼ä»¥å…è¨±æˆ–æ‹’çµ•ç‰¹å®šå‘½ä»¤ã€‚</value>
+    <value>尚無規則。在下方新增模式以允許或拒絕特定命令。</value>
   </data>
   <data name="PermissionsPage_WindowsPrivacy.Text" xml:space="preserve">
-    <value>Windows éš±ç§</value>
+    <value>Windows 隱私</value>
   </data>
   <data name="PermissionsPage_CameraMicrophoneAmpScreen.Text" xml:space="preserve">
-    <value>æ”å½±æ©Ÿã€éº¥å…‹é¢¨èˆ‡èž¢å¹•å­˜å–</value>
+    <value>攝影機、麥克風與螢幕存取</value>
   </data>
   <data name="PermissionsPage_SystemLevelPrivacyPermissions.Text" xml:space="preserve">
-    <value>ç³»çµ±å±¤ç´šçš„éš±ç§æ¬Šé™ç”± Windows ç®¡ç†ã€‚é–‹å•Ÿ Windows éš±ç§è¨­å®šä»¥æŽˆäºˆæˆ–æ’¤éŠ· OpenClaw çš„å­˜å–æ¬Šã€‚</value>
+    <value>系統層級的隱私權限由 Windows 管理。開啟 Windows 隱私設定以授予或撤銷 OpenClaw 的存取權。</value>
   </data>
   <data name="SandboxPage_NodeSandboxIsOn.Text" xml:space="preserve">
-    <value>ç¯€é»žæ²™ç®±å·²é–‹å•Ÿ</value>
+    <value>節點沙箱已開啟</value>
   </data>
   <data name="SandboxPage_ProgramsTheAgentRuns.Text" xml:space="preserve">
-    <value>ä»£ç†åœ¨é€™å°é›»è…¦ä¸ŠåŸ·è¡Œçš„ç¨‹å¼å—åˆ°éš”é›¢ã€‚</value>
+    <value>代理在這台電腦上執行的程式受到隔離。</value>
   </data>
   <data name="SandboxPage_WhatGetsContained.Text" xml:space="preserve">
-    <value>å“ªäº›å…§å®¹å—éš”é›¢</value>
+    <value>哪些內容受隔離</value>
   </data>
   <data name="SandboxPage_SeeWhichCommandsThis.Text" xml:space="preserve">
     <value>檢視此頁面涵蓋的命令 — 以及需要其他控制項的命令。</value>
   </data>
   <data name="SandboxPage_CommandsTheAgentRuns.Text" xml:space="preserve">
-    <value>ä»£ç†é€éŽ Windows ç¯€é»žåŸ·è¡Œçš„å‘½ä»¤ (</value>
+    <value>代理透過 Windows 節點執行的命令 (</value>
   </data>
   <data name="SandboxPage_SystemRun.Text" xml:space="preserve">
     <value>system.run</value>
   </data>
   <data name="SandboxPage_AreContainedByThe.Text" xml:space="preserve">
-    <value>) å—ä¸‹æ–¹è¨­å®šéš”é›¢ã€‚</value>
+    <value>) 受下方設定隔離。</value>
   </data>
   <data name="SandboxPage_CommandsTheAgentRuns2.Text" xml:space="preserve">
     <value>代理直接在閘道上執行的命令則不受隔離。如果閘道位於這台電腦的 WSL 上,它們可能會存取您的 Windows 檔案、剪貼簿和網路 — 請使用閘道的執行核准。</value>
   </data>
   <data name="SandboxPage_SandboxUnavailable.Title" xml:space="preserve">
-    <value>æ²™ç®±ç„¡æ³•ä½¿ç”¨</value>
+    <value>沙箱無法使用</value>
   </data>
   <data name="SandboxPage_LearnMoreAboutMXC.Content" xml:space="preserve">
-    <value>æ·±å…¥äº†è§£ MXC æ²™ç®±</value>
+    <value>深入了解 MXC 沙箱</value>
   </data>
   <data name="SandboxPage_SecurityLevel.Text" xml:space="preserve">
-    <value>å®‰å…¨ç­‰ç´š</value>
+    <value>安全等級</value>
   </data>
   <data name="SandboxPage_OneClickToSet.Text" xml:space="preserve">
-    <value>ä¸€éµè¨­å®šä¸‹æ–¹æ‰€æœ‰æŽ§åˆ¶é …ã€‚è‡ªè¨‚è³‡æ–™å¤¾æœƒä¿ç•™æ‚¨çš„è¨­å®šã€‚</value>
+    <value>一鍵設定下方所有控制項。自訂資料夾會保留您的設定。</value>
   </data>
   <data name="SandboxPage_LockedDown.Text" xml:space="preserve">
     <value>🔒 鎖定</value>
   </data>
   <data name="SandboxPage_NoInternetNoClipboard.Text" xml:space="preserve">
-    <value>ç„¡ç¶²éš›ç¶²è·¯ã€ç„¡å‰ªè²¼ç°¿ã€ç„¡æ¨™æº–ä½¿ç”¨è€…è³‡æ–™å¤¾ã€‚</value>
+    <value>無網際網路、無剪貼簿、無標準使用者資料夾。</value>
   </data>
   <data name="SandboxPage_Recommended.Text" xml:space="preserve">
     <value>🛡 建議</value>
   </data>
   <data name="SandboxPage_InternetOnReadOnly.Text" xml:space="preserve">
-    <value>ç¶²éš›ç¶²è·¯é–‹å•Ÿã€‚å°ã€Œæ–‡ä»¶ã€ã€ã€Œä¸‹è¼‰ã€ã€ã€Œæ¡Œé¢ã€ç‚ºå”¯è®€ã€‚å‰ªè²¼ç°¿å¯è®€ã€‚</value>
+    <value>網際網路開啟。對「文件」、「下載」、「桌面」為唯讀。剪貼簿可讀。</value>
   </data>
   <data name="SandboxPage_Unprotected.Text" xml:space="preserve">
     <value>⚠ 不受保護</value>
   </data>
   <data name="SandboxPage_InternetOnReadWrite.Text" xml:space="preserve">
-    <value>ç¶²éš›ç¶²è·¯é–‹å•Ÿã€‚å°ã€Œæ–‡ä»¶ã€ã€ã€Œä¸‹è¼‰ã€ã€ã€Œæ¡Œé¢ã€å¯è®€å¯«ã€‚å‰ªè²¼ç°¿å¯è®€å¯«ã€‚</value>
+    <value>網際網路開啟。對「文件」、「下載」、「桌面」可讀寫。剪貼簿可讀寫。</value>
   </data>
   <data name="SandboxPage_CustomFolderGrantsStill.Title" xml:space="preserve">
-    <value>è‡ªè¨‚è³‡æ–™å¤¾æŽˆæ¬Šä»ç„¶æœ‰æ•ˆ</value>
+    <value>自訂資料夾授權仍然有效</value>
   </data>
   <data name="SandboxPage_Files.Text" xml:space="preserve">
     <value>📁 檔案</value>
   </data>
   <data name="SandboxPage_ByDefaultTheAgent.Text" xml:space="preserve">
-    <value>é è¨­æƒ…æ³ä¸‹,ä»£ç†åªæœ‰ä¸€å€‹å¯è®€å¯«çš„æš«å­˜å·¥ä½œè³‡æ–™å¤¾ã€‚åœ¨ä¸‹æ–¹æŽˆäºˆä½¿ç”¨è€…è³‡æ–™å¤¾çš„å­˜å–æ¬Šé™ã€‚SSH é‡‘é‘°ã€ç€è¦½å™¨è¨­å®šæª”ä»¥åŠ OpenClaw æœ¬èº«çš„è¨­å®šä¸€å¾‹æœƒè¢«å°éŽ–ã€‚</value>
+    <value>預設情況下,代理只有一個可讀寫的暫存工作資料夾。在下方授予使用者資料夾的存取權限。SSH 金鑰、瀏覽器設定檔以及 OpenClaw 本身的設定一律會被封鎖。</value>
   </data>
   <data name="SandboxPage_Documents.Text" xml:space="preserve">
-    <value>æ–‡ä»¶</value>
+    <value>文件</value>
   </data>
   <data name="SandboxPage_Blocked.Content" xml:space="preserve">
-    <value>å·²å°éŽ–</value>
+    <value>已封鎖</value>
   </data>
   <data name="SandboxPage_ReadOnly.Content" xml:space="preserve">
-    <value>å”¯è®€</value>
+    <value>唯讀</value>
   </data>
   <data name="SandboxPage_ReadAmpWrite.Content" xml:space="preserve">
-    <value>è®€å–èˆ‡å¯«å…¥</value>
+    <value>讀取與寫入</value>
   </data>
   <data name="SandboxPage_Downloads.Text" xml:space="preserve">
-    <value>ä¸‹è¼‰</value>
+    <value>下載</value>
   </data>
   <data name="SandboxPage_Blocked2.Content" xml:space="preserve">
-    <value>å·²å°éŽ–</value>
+    <value>已封鎖</value>
   </data>
   <data name="SandboxPage_ReadOnly2.Content" xml:space="preserve">
-    <value>å”¯è®€</value>
+    <value>唯讀</value>
   </data>
   <data name="SandboxPage_ReadAmpWrite2.Content" xml:space="preserve">
-    <value>è®€å–èˆ‡å¯«å…¥</value>
+    <value>讀取與寫入</value>
   </data>
   <data name="SandboxPage_Desktop.Text" xml:space="preserve">
-    <value>æ¡Œé¢</value>
+    <value>桌面</value>
   </data>
   <data name="SandboxPage_Blocked3.Content" xml:space="preserve">
-    <value>å·²å°éŽ–</value>
+    <value>已封鎖</value>
   </data>
   <data name="SandboxPage_ReadOnly3.Content" xml:space="preserve">
-    <value>å”¯è®€</value>
+    <value>唯讀</value>
   </data>
   <data name="SandboxPage_ReadAmpWrite3.Content" xml:space="preserve">
-    <value>è®€å–èˆ‡å¯«å…¥</value>
+    <value>讀取與寫入</value>
   </data>
   <data name="SandboxPage_ToolDirectoriesOnYour.Text" xml:space="preserve">
-    <value>PATH ä¸Šçš„å·¥å…·ç›®éŒ„åœ¨æ²™ç®±å…§ä¹Ÿä»¥å”¯è®€æ–¹å¼æŽˆäºˆ,å› æ­¤ gitã€nodeã€python èˆ‡ dotnet ç­‰å‘½ä»¤åˆ—å·¥å…·å¯ä½¿ç”¨ã€‚ä¸€å¾‹ä¸æœƒæŽˆäºˆç£ç¢Ÿæ©Ÿæ ¹ç›®éŒ„ã€‚</value>
+    <value>PATH 上的工具目錄在沙箱內也以唯讀方式授予,因此 git、node、python 與 dotnet 等命令列工具可使用。一律不會授予磁碟機根目錄。</value>
   </data>
   <data name="SandboxPage_CustomFolders.Text" xml:space="preserve">
-    <value>è‡ªè¨‚è³‡æ–™å¤¾</value>
+    <value>自訂資料夾</value>
   </data>
   <data name="SandboxPage_CustomGrantsAreAdded.Text" xml:space="preserve">
-    <value>è‡ªè¨‚æŽˆæ¬Šæœƒç–ŠåŠ æ–¼ä¸Šè¿°è¦å‰‡ä¹‹ä¸Šã€‚åœ¨ã€Œæ–‡ä»¶/ä¸‹è¼‰/æ¡Œé¢ã€å…§æ–°å¢žå…·æœ‰æ›´å¯¬æ¬Šé™çš„è³‡æ–™å¤¾,æœƒè¦†å¯«è©²è·¯å¾‘çš„è¡Œå±¤ç´šè¨­å®šã€‚</value>
+    <value>自訂授權會疊加於上述規則之上。在「文件/下載/桌面」內新增具有更寬權限的資料夾,會覆寫該路徑的行層級設定。</value>
   </data>
   <data name="SandboxPage_Blocked4.Content" xml:space="preserve">
-    <value>å·²å°éŽ–</value>
+    <value>已封鎖</value>
   </data>
   <data name="SandboxPage_ReadOnly4.Content" xml:space="preserve">
-    <value>å”¯è®€</value>
+    <value>唯讀</value>
   </data>
   <data name="SandboxPage_ReadAmpWrite4.Content" xml:space="preserve">
-    <value>è®€å–èˆ‡å¯«å…¥</value>
+    <value>讀取與寫入</value>
   </data>
   <data name="SandboxPage_NoCustomFoldersAdded.Text" xml:space="preserve">
-    <value>å°šæœªæ–°å¢žè‡ªè¨‚è³‡æ–™å¤¾ã€‚</value>
+    <value>尚未新增自訂資料夾。</value>
   </data>
   <data name="SandboxPage_AddFolder.Content" xml:space="preserve">
-    <value>æ–°å¢žè³‡æ–™å¤¾</value>
+    <value>新增資料夾</value>
   </data>
   <data name="SandboxPage_Clipboard.Text" xml:space="preserve">
     <value>📋 剪貼簿</value>
   </data>
   <data name="SandboxPage_ClipboardOftenContainsPasswords.Text" xml:space="preserve">
-    <value>å‰ªè²¼ç°¿é€šå¸¸åŒ…å«å¯†ç¢¼ã€æ¬Šæ–èˆ‡ç§äººæ–‡å­—ã€‚è®€å–æ¬Šé™å¯èƒ½æœƒå°‡é€™äº›æ´©éœ²çµ¦ä»£ç†(è‹¥å·²å•Ÿç”¨,ä¹Ÿæœƒæ´©éœ²è‡³ç¶²éš›ç¶²è·¯)ã€‚</value>
+    <value>剪貼簿通常包含密碼、權杖與私人文字。讀取權限可能會將這些洩露給代理(若已啟用,也會洩露至網際網路)。</value>
   </data>
   <data name="SandboxPage_NoneDefault.Content" xml:space="preserve">
-    <value>ç„¡(é è¨­)</value>
+    <value>無(預設)</value>
   </data>
   <data name="SandboxPage_ReadAgentCanSee.Content" xml:space="preserve">
     <value>讀取 — 代理可以看到您複製的內容</value>
@@ -4261,34 +4261,34 @@
     <value>寫入 — 代理可以取代您的剪貼簿(無法讀取)</value>
   </data>
   <data name="SandboxPage_ReadAmpWrite5.Content" xml:space="preserve">
-    <value>è®€å–èˆ‡å¯«å…¥</value>
+    <value>讀取與寫入</value>
   </data>
   <data name="SandboxPage_Network.Text" xml:space="preserve">
     <value>📡 網路</value>
   </data>
   <data name="SandboxPage_AllowInternet.Header" xml:space="preserve">
-    <value>å…è¨±ç¶²éš›ç¶²è·¯</value>
+    <value>允許網際網路</value>
   </data>
   <data name="SandboxPage_IfFileOrClipboard.Text" xml:space="preserve">
-    <value>å¦‚æžœå•Ÿç”¨æª”æ¡ˆæˆ–å‰ªè²¼ç°¿è®€å–æ¬Šé™,ä»£ç†å¯èƒ½æœƒé€éŽç¶²éš›ç¶²è·¯å‚³é€é€™äº›è³‡æ–™ã€‚</value>
+    <value>如果啟用檔案或剪貼簿讀取權限,代理可能會透過網際網路傳送這些資料。</value>
   </data>
   <data name="SandboxPage_LocalNetworkDevicesAnd.Text" xml:space="preserve">
-    <value>å°šæœªåŒ…å«æœ¬æ©Ÿç¶²è·¯è£ç½®èˆ‡å…±ç”¨ã€‚</value>
+    <value>尚未包含本機網路裝置與共用。</value>
   </data>
   <data name="SandboxPage_Limits.Text" xml:space="preserve">
     <value>⏱ 限制</value>
   </data>
   <data name="SandboxPage_CommandTimeout30Sec.Text" xml:space="preserve">
-    <value>å‘½ä»¤é€¾æ™‚:30 ç§’</value>
+    <value>命令逾時:30 秒</value>
   </data>
   <data name="SandboxPage_MaximumCapturedOutputTruncates.Text" xml:space="preserve">
-    <value>æœ€å¤§æ“·å–è¼¸å‡º(è¶…éŽæ­¤å€¼æœƒè¢«æˆªæ–·;ä¸é™åˆ¶ç£ç¢Ÿã€è¨˜æ†¶é«”æˆ– CPU):</value>
+    <value>最大擷取輸出(超過此值會被截斷;不限制磁碟、記憶體或 CPU):</value>
   </data>
   <data name="SandboxPage_1MiB.Content" xml:space="preserve">
     <value>1 MiB</value>
   </data>
   <data name="SandboxPage_4MiBDefault.Content" xml:space="preserve">
-    <value>4 MiB(é è¨­)</value>
+    <value>4 MiB(預設)</value>
   </data>
   <data name="SandboxPage_16MiB.Content" xml:space="preserve">
     <value>16 MiB</value>
@@ -4297,190 +4297,190 @@
     <value>64 MiB</value>
   </data>
   <data name="SessionsPage_BackToConnection.Text" xml:space="preserve">
-    <value>è¿”å›žé€£ç·š</value>
+    <value>返回連線</value>
   </data>
   <data name="SessionsPage_Sessions.Text" xml:space="preserve">
-    <value>å·¥ä½œéšŽæ®µ</value>
+    <value>工作階段</value>
   </data>
   <data name="SessionsPage_Refresh.Text" xml:space="preserve">
-    <value>é‡æ–°æ•´ç†</value>
+    <value>重新整理</value>
   </data>
   <data name="SessionsPage_All.Text" xml:space="preserve">
-    <value>å…¨éƒ¨</value>
+    <value>全部</value>
   </data>
   <data name="SessionsPage_GatewayDisconnected.Title" xml:space="preserve">
-    <value>é–˜é“å·²ä¸­æ–·</value>
+    <value>閘道已中斷</value>
   </data>
   <data name="SessionsPage_GatewayDisconnected.Message" xml:space="preserve">
-    <value>è«‹é€£æŽ¥è‡³é–˜é“ä»¥è¼‰å…¥å·¥ä½œéšŽæ®µã€‚</value>
+    <value>請連接至閘道以載入工作階段。</value>
   </data>
   <data name="SessionsPage_OpenConnection.Content" xml:space="preserve">
-    <value>é–‹å•Ÿé€£ç·š</value>
+    <value>開啟連線</value>
   </data>
   <data name="SessionsPage_LoadingSessions.Text" xml:space="preserve">
     <value>正在載入工作階段…</value>
   </data>
   <data name="SessionsPage_NoActiveSessions.Text" xml:space="preserve">
-    <value>æ²’æœ‰ä½œç”¨ä¸­çš„å·¥ä½œéšŽæ®µ</value>
+    <value>沒有作用中的工作階段</value>
   </data>
   <data name="SessionsPage_Reset.Text" xml:space="preserve">
-    <value>é‡è¨­</value>
+    <value>重設</value>
   </data>
   <data name="SessionsPage_Compact.Text" xml:space="preserve">
-    <value>å£“ç¸®</value>
+    <value>壓縮</value>
   </data>
   <data name="SessionsPage_Delete.Text" xml:space="preserve">
-    <value>åˆªé™¤</value>
+    <value>刪除</value>
   </data>
   <data name="SettingsPage_Settings.Text" xml:space="preserve">
-    <value>è¨­å®š</value>
+    <value>設定</value>
   </data>
   <data name="SettingsPage_General.Text" xml:space="preserve">
-    <value>ä¸€èˆ¬</value>
+    <value>一般</value>
   </data>
   <data name="SettingsPage_Notifications.Text" xml:space="preserve">
-    <value>é€šçŸ¥</value>
+    <value>通知</value>
   </data>
   <data name="SettingsPage_Privacy.Text" xml:space="preserve">
-    <value>éš±ç§</value>
+    <value>隱私</value>
   </data>
   <data name="SettingsPage_LocalGateway.Text" xml:space="preserve">
-    <value>æœ¬æ©Ÿé–˜é“</value>
+    <value>本機閘道</value>
   </data>
   <data name="SettingsPage_MSIXInstallationDetected.Title" xml:space="preserve">
-    <value>åµæ¸¬åˆ° MSIX å®‰è£</value>
+    <value>偵測到 MSIX 安裝</value>
   </data>
   <data name="SettingsPage_MSIXInstallationDetected.Message" xml:space="preserve">
-    <value>é€éŽ Windows è¨­å®š &amp;amp;#x2192; æ‡‰ç”¨ç¨‹å¼ç§»é™¤ OpenClaw ä¸æœƒæ¸…é™¤æœ¬æ©Ÿé–˜é“(WSL æ•£ç™¼ç‰ˆã€ç£ç¢Ÿæ˜ åƒ)ã€‚è«‹å…ˆä½¿ç”¨ä¸‹æ–¹çš„ã€Œç§»é™¤æœ¬æ©Ÿé–˜é“ã€,ç„¶å¾Œå†è§£é™¤å®‰è£ OpenClawã€‚</value>
+    <value>透過 Windows 設定 &amp;amp;#x2192; 應用程式移除 OpenClaw 不會清除本機閘道(WSL 散發版、磁碟映像)。請先使用下方的「移除本機閘道」,然後再解除安裝 OpenClaw。</value>
   </data>
   <data name="SettingsPage_RemovesTheWSLDistro.Text" xml:space="preserve">
-    <value>ç§»é™¤ WSL æ•£ç™¼ç‰ˆ (OpenClawGateway)ã€å…¶ç£ç¢Ÿæ˜ åƒã€è‡ªå‹•å•Ÿå‹•é …ç›®,ä¸¦æ¸…é™¤é–˜é“èªè­‰ã€‚æ‚¨çš„ MCP æ¬Šæ–æœƒä¿ç•™ã€‚å°Žè¦½æµç¨‹å°‡é‡è¨­ã€‚</value>
+    <value>移除 WSL 散發版 (OpenClawGateway)、其磁碟映像、自動啟動項目,並清除閘道認證。您的 MCP 權杖會保留。導覽流程將重設。</value>
   </data>
   <data name="SettingsPage_RemoveLocalGateway.Content" xml:space="preserve">
-    <value>ç§»é™¤æœ¬æ©Ÿé–˜é“</value>
+    <value>移除本機閘道</value>
   </data>
   <data name="SettingsPage_Saved.Title" xml:space="preserve">
-    <value>å·²å„²å­˜</value>
+    <value>已儲存</value>
   </data>
   <data name="SkillsPage_Skills.Text" xml:space="preserve">
     <value>🧩 技能</value>
   </data>
   <data name="SkillsPage_AllAgents.Content" xml:space="preserve">
-    <value>æ‰€æœ‰ä»£ç†</value>
+    <value>所有代理</value>
   </data>
   <data name="SkillsPage_Enabled.Text" xml:space="preserve">
-    <value>å·²å•Ÿç”¨</value>
+    <value>已啟用</value>
   </data>
   <data name="SkillsPage_Disabled.Text" xml:space="preserve">
-    <value>å·²åœç”¨</value>
+    <value>已停用</value>
   </data>
   <data name="SkillsPage_LoadingSkills.Text" xml:space="preserve">
     <value>正在載入技能…</value>
   </data>
   <data name="SkillsPage_NoSkillsInstalled.Text" xml:space="preserve">
-    <value>æœªå®‰è£æŠ€èƒ½</value>
+    <value>未安裝技能</value>
   </data>
   <data name="SkillsPage_SkillsExtendYourAgent.Text" xml:space="preserve">
-    <value>æŠ€èƒ½å¯æ“´å……æ‚¨ä»£ç†çš„èƒ½åŠ›ã€‚é€éŽ CLI æˆ– ClawHub å®‰è£æŠ€èƒ½ã€‚</value>
+    <value>技能可擴充您代理的能力。透過 CLI 或 ClawHub 安裝技能。</value>
   </data>
   <data name="UsagePage_GatewayDisconnected.Title" xml:space="preserve">
-    <value>é–˜é“å·²ä¸­æ–·</value>
+    <value>閘道已中斷</value>
   </data>
   <data name="UsagePage_GatewayDisconnected.Message" xml:space="preserve">
-    <value>è«‹é€£æŽ¥è‡³é–˜é“ä»¥è¼‰å…¥ä½¿ç”¨é‡è³‡æ–™ã€‚</value>
+    <value>請連接至閘道以載入使用量資料。</value>
   </data>
   <data name="UsagePage_OpenConnection.Content" xml:space="preserve">
-    <value>é–‹å•Ÿé€£ç·š</value>
+    <value>開啟連線</value>
   </data>
   <data name="UsagePage_LoadingDailyCosts.Text" xml:space="preserve">
     <value>正在載入每日成本…</value>
   </data>
   <data name="UsagePage_NoDailyUsageFor.Text" xml:space="preserve">
-    <value>æ­¤æœŸé–“å…§ç„¡æ¯æ—¥ä½¿ç”¨é‡</value>
+    <value>此期間內無每日使用量</value>
   </data>
   <data name="VoiceSettingsPage_TestVoiceInput.Text" xml:space="preserve">
-    <value>æ¸¬è©¦èªžéŸ³è¼¸å…¥</value>
+    <value>測試語音輸入</value>
   </data>
   <data name="VoiceSettingsPage_Record.Text" xml:space="preserve">
-    <value>éŒ„è£½</value>
+    <value>錄製</value>
   </data>
   <data name="WorkspacePage_LoadingWorkspaceFiles.Text" xml:space="preserve">
     <value>正在載入工作區檔案…</value>
   </data>
   <data name="ChatWindow_WebChatUnavailable.Text" xml:space="preserve">
-    <value>ç¶²é èŠå¤©ç„¡æ³•ä½¿ç”¨</value>
+    <value>網頁聊天無法使用</value>
   </data>
   <data name="ChatWindow_Retry.Content" xml:space="preserve">
-    <value>é‡è©¦</value>
+    <value>重試</value>
   </data>
   <data name="ConnectionStatusWindow_ConnectionStatus.Text" xml:space="preserve">
-    <value>é€£ç·šç‹€æ…‹</value>
+    <value>連線狀態</value>
   </data>
   <data name="ConnectionStatusWindow_STATEMACHINE.Text" xml:space="preserve">
-    <value>ç‹€æ…‹æ©Ÿ</value>
+    <value>狀態機</value>
   </data>
   <data name="ConnectionStatusWindow_OPERATOR.Text" xml:space="preserve">
-    <value>æ“ä½œå“¡</value>
+    <value>操作員</value>
   </data>
   <data name="ConnectionStatusWindow_Off.Text" xml:space="preserve">
-    <value>é—œé–‰</value>
+    <value>關閉</value>
   </data>
   <data name="ConnectionStatusWindow_Connecting.Text" xml:space="preserve">
-    <value>æ­£åœ¨é€£ç·š</value>
+    <value>正在連線</value>
   </data>
   <data name="ConnectionStatusWindow_Connected.Text" xml:space="preserve">
-    <value>å·²é€£ç·š</value>
+    <value>已連線</value>
   </data>
   <data name="ConnectionStatusWindow_Pairing.Text" xml:space="preserve">
-    <value>æ­£åœ¨é…å°</value>
+    <value>正在配對</value>
   </data>
   <data name="ConnectionStatusWindow_Error.Text" xml:space="preserve">
-    <value>éŒ¯èª¤</value>
+    <value>錯誤</value>
   </data>
   <data name="ConnectionStatusWindow_NODE.Text" xml:space="preserve">
-    <value>ç¯€é»ž</value>
+    <value>節點</value>
   </data>
   <data name="ConnectionStatusWindow_Off2.Text" xml:space="preserve">
-    <value>é—œé–‰</value>
+    <value>關閉</value>
   </data>
   <data name="ConnectionStatusWindow_Connecting2.Text" xml:space="preserve">
-    <value>æ­£åœ¨é€£ç·š</value>
+    <value>正在連線</value>
   </data>
   <data name="ConnectionStatusWindow_Connected2.Text" xml:space="preserve">
-    <value>å·²é€£ç·š</value>
+    <value>已連線</value>
   </data>
   <data name="ConnectionStatusWindow_Pairing2.Text" xml:space="preserve">
-    <value>æ­£åœ¨é…å°</value>
+    <value>正在配對</value>
   </data>
   <data name="ConnectionStatusWindow_Error2.Text" xml:space="preserve">
-    <value>éŒ¯èª¤</value>
+    <value>錯誤</value>
   </data>
   <data name="ConnectionStatusWindow_GATEWAYS.Text" xml:space="preserve">
-    <value>é–˜é“</value>
+    <value>閘道</value>
   </data>
   <data name="ConnectionStatusWindow_CREDENTIALS.Text" xml:space="preserve">
-    <value>èªè­‰</value>
+    <value>認證</value>
   </data>
   <data name="ConnectionStatusWindow_SETUPCODE.Text" xml:space="preserve">
-    <value>è¨­å®šä»£ç¢¼</value>
+    <value>設定代碼</value>
   </data>
   <data name="ConnectionStatusWindow_PasteASetupCode.Text" xml:space="preserve">
-    <value>è²¼ä¸Šè¨­å®šä»£ç¢¼ä»¥å»ºç«‹ç«¯å°ç«¯é€£ç·šã€‚</value>
+    <value>貼上設定代碼以建立端對端連線。</value>
   </data>
   <data name="ConnectionStatusWindow_PasteSetupCode.PlaceholderText" xml:space="preserve">
     <value>貼上設定代碼…</value>
   </data>
   <data name="ConnectionStatusWindow_Connect.Content" xml:space="preserve">
-    <value>é€£ç·š</value>
+    <value>連線</value>
   </data>
   <data name="ConnectionStatusWindow_Disconnect.Content" xml:space="preserve">
-    <value>ä¸­æ–·é€£ç·š</value>
+    <value>中斷連線</value>
   </data>
   <data name="ConnectionStatusWindow_DIRECTCONNECT.Text" xml:space="preserve">
-    <value>ç›´æŽ¥é€£ç·š</value>
+    <value>直接連線</value>
   </data>
   <data name="ConnectionStatusWindow_ConnectWithAGateway.Text" xml:space="preserve">
-    <value>ä½¿ç”¨é–˜é“ URL å’Œå…±ç”¨æ¬Šæ–(ç®¡ç†å“¡ç¯„åœ)é€£ç·šã€‚</value>
+    <value>使用閘道 URL 和共用權杖(管理員範圍)連線。</value>
   </data>
   <data name="ConnectionStatusWindow_WsLocalhost18790.PlaceholderText" xml:space="preserve">
     <value>ws://localhost:18790</value>
@@ -4489,65 +4489,65 @@
     <value>ws://localhost:18790</value>
   </data>
   <data name="ConnectionStatusWindow_WsLocalhost18790.Header" xml:space="preserve">
-    <value>é–˜é“ URL</value>
+    <value>閘道 URL</value>
   </data>
   <data name="ConnectionStatusWindow_SharedGatewayToken.PlaceholderText" xml:space="preserve">
-    <value>å…±ç”¨é–˜é“æ¬Šæ–</value>
+    <value>共用閘道權杖</value>
   </data>
   <data name="ConnectionStatusWindow_SharedGatewayToken.Header" xml:space="preserve">
-    <value>æ¬Šæ–</value>
+    <value>權杖</value>
   </data>
   <data name="ConnectionStatusWindow_Connect2.Content" xml:space="preserve">
-    <value>é€£ç·š</value>
+    <value>連線</value>
   </data>
   <data name="ConnectionStatusWindow_SSHTunnel.Header" xml:space="preserve">
-    <value>SSH é€šé“</value>
+    <value>SSH 通道</value>
   </data>
   <data name="ConnectionStatusWindow_SSHUser.Header" xml:space="preserve">
-    <value>SSH ä½¿ç”¨è€…</value>
+    <value>SSH 使用者</value>
   </data>
   <data name="ConnectionStatusWindow_SSHUser.PlaceholderText" xml:space="preserve">
     <value>user</value>
   </data>
   <data name="ConnectionStatusWindow_SSHHost.Header" xml:space="preserve">
-    <value>SSH ä¸»æ©Ÿ</value>
+    <value>SSH 主機</value>
   </data>
   <data name="ConnectionStatusWindow_SSHHost.PlaceholderText" xml:space="preserve">
     <value>192.168.x.x</value>
   </data>
   <data name="ConnectionStatusWindow_RemotePort.Header" xml:space="preserve">
-    <value>é ç«¯é€£æŽ¥åŸ </value>
+    <value>遠端連接埠</value>
   </data>
   <data name="ConnectionStatusWindow_LocalPort.Header" xml:space="preserve">
-    <value>æœ¬æ©Ÿé€£æŽ¥åŸ </value>
+    <value>本機連接埠</value>
   </data>
   <data name="ConnectionStatusWindow_EVENTTIMELINE.Text" xml:space="preserve">
-    <value>äº‹ä»¶æ™‚é–“è»¸</value>
+    <value>事件時間軸</value>
   </data>
   <data name="ConnectionStatusWindow_Copy.Content" xml:space="preserve">
-    <value>è¤‡è£½</value>
+    <value>複製</value>
   </data>
   <data name="ConnectionStatusWindow_Clear.Content" xml:space="preserve">
-    <value>æ¸…é™¤</value>
+    <value>清除</value>
   </data>
   <data name="DiagnosticsBundleDialog_DiagnosticsBundle.Title" xml:space="preserve">
-    <value>è¨ºæ–·å¥—ä»¶</value>
+    <value>診斷套件</value>
   </data>
   <data name="DiagnosticsBundleDialog_ReviewBeforeSharing.Title" xml:space="preserve">
-    <value>åˆ†äº«å‰è«‹æª¢é–±</value>
+    <value>分享前請檢閱</value>
   </data>
   <data name="DiagnosticsBundleDialog_ReviewBeforeSharing.Message" xml:space="preserve">
-    <value>å¥—ä»¶ç”¢ç”Ÿå™¨æœƒæŽ’é™¤æ•æ„Ÿæ¬Šæ–ã€å‘½ä»¤å¼•æ•¸ã€å…§å®¹èˆ‡éŒ„è£½ã€‚</value>
+    <value>套件產生器會排除敏感權杖、命令引數、內容與錄製。</value>
   </data>
   <data name="HubWindow_Disconnected.Text" xml:space="preserve">
-    <value>å·²ä¸­æ–·é€£ç·š</value>
+    <value>已中斷連線</value>
   </data>
   <data name="HubWindow_Op.Text" xml:space="preserve">
-    <value>æ“ä½œ</value>
+    <value>操作</value>
   </data>
   <data name="HubWindow_Node.Text" xml:space="preserve">
-    <value>ç¯€é»ž</value>
+    <value>節點</value>
   </data>
   <data name="HubWindow_Advanced.Content" xml:space="preserve">
-    <value>é€²éšŽ</value>
+    <value>進階</value>
   </data></root>

--- a/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
@@ -193,6 +195,14 @@ public class LocalizationValidationTests
         "Onboarding_Ready_Node_Notify_Sub",
     ];
 
+    private static readonly IReadOnlyDictionary<char, byte> Windows1252Bytes = BuildWindows1252ByteMap();
+
+    private static readonly IReadOnlyDictionary<char, byte> CodePage437Bytes = BuildCodePage437ByteMap();
+
+    private static readonly UTF8Encoding StrictUtf8 = new(
+        encoderShouldEmitUTF8Identifier: false,
+        throwOnInvalidBytes: true);
+
     private static string GetRepositoryRoot()
     {
         var envRepoRoot = Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT");
@@ -223,6 +233,139 @@ public class LocalizationValidationTests
                 e => e.Attribute("name")!.Value,
                 e => e.Element("value")?.Value ?? string.Empty);
     }
+
+    private static Dictionary<char, byte> BuildWindows1252ByteMap()
+    {
+        var map = Enumerable.Range(0, 256)
+            .ToDictionary(i => (char)i, i => (byte)i);
+
+        map['€'] = 0x80;
+        map['‚'] = 0x82;
+        map['ƒ'] = 0x83;
+        map['„'] = 0x84;
+        map['…'] = 0x85;
+        map['†'] = 0x86;
+        map['‡'] = 0x87;
+        map['ˆ'] = 0x88;
+        map['‰'] = 0x89;
+        map['Š'] = 0x8A;
+        map['‹'] = 0x8B;
+        map['Œ'] = 0x8C;
+        map['Ž'] = 0x8E;
+        map['‘'] = 0x91;
+        map['’'] = 0x92;
+        map['“'] = 0x93;
+        map['”'] = 0x94;
+        map['•'] = 0x95;
+        map['–'] = 0x96;
+        map['—'] = 0x97;
+        map['˜'] = 0x98;
+        map['™'] = 0x99;
+        map['š'] = 0x9A;
+        map['›'] = 0x9B;
+        map['œ'] = 0x9C;
+        map['ž'] = 0x9E;
+        map['Ÿ'] = 0x9F;
+
+        return map;
+    }
+
+    private static Dictionary<char, byte> BuildCodePage437ByteMap()
+    {
+        var map = Enumerable.Range(0, 128)
+            .ToDictionary(i => (char)i, i => (byte)i);
+
+        const string high =
+            "ÇüéâäàåçêëèïîìÄÅ" +
+            "ÉæÆôöòûùÿÖÜ¢£¥₧ƒ" +
+            "áíóúñÑªº¿⌐¬½¼¡«»" +
+            "░▒▓│┤╡╢╖╕╣║╗╝╜╛┐" +
+            "└┴┬├─┼╞╟╚╔╩╦╠═╬╧" +
+            "╨╤╥╙╘╒╓╫╪┘┌█▄▌▐▀" +
+            "αßΓπΣσµτΦΘΩδ∞φε∩" +
+            "≡±≥≤⌠⌡÷≈°∙·√ⁿ²■ ";
+
+        for (var i = 0; i < high.Length; i++)
+            map[high[i]] = (byte)(i + 128);
+
+        return map;
+    }
+
+    private static bool TryDecodeKnownMojibake(string value, out string decoded)
+    {
+        return TryDecodeMojibake(value, Windows1252Bytes, out decoded)
+            || TryDecodeMojibake(value, CodePage437Bytes, out decoded);
+    }
+
+    private static bool TryDecodeMojibake(
+        string value,
+        IReadOnlyDictionary<char, byte> byteMap,
+        out string decoded)
+    {
+        decoded = string.Empty;
+
+        for (var start = 0; start < value.Length; start++)
+        {
+            if (!byteMap.ContainsKey(value[start]))
+                continue;
+
+            var runEnd = start;
+            while (runEnd < value.Length && byteMap.ContainsKey(value[runEnd]))
+                runEnd++;
+
+            for (var length = runEnd - start; length >= 2; length--)
+            {
+                for (var offset = start; offset <= runEnd - length; offset++)
+                {
+                    var candidate = value.Substring(offset, length);
+                    if (TryDecodeMojibakeRun(candidate, byteMap, out decoded))
+                        return true;
+                }
+            }
+
+            start = runEnd;
+        }
+
+        return false;
+    }
+
+    private static bool TryDecodeMojibakeRun(
+        string value,
+        IReadOnlyDictionary<char, byte> byteMap,
+        out string decoded)
+    {
+        decoded = string.Empty;
+
+        if (!value.Any(c => c > 0x7F))
+            return false;
+
+        var bytes = new byte[value.Length];
+        for (var i = 0; i < value.Length; i++)
+            bytes[i] = byteMap[value[i]];
+
+        try
+        {
+            decoded = StrictUtf8.GetString(bytes);
+        }
+        catch (DecoderFallbackException)
+        {
+            return false;
+        }
+
+        return !string.Equals(decoded, value, StringComparison.Ordinal) && IsPlausibleDecodedMojibake(decoded);
+    }
+
+    private static bool IsPlausibleDecodedMojibake(string decoded) =>
+        decoded.Any(char.IsLetter) &&
+        decoded.All(c =>
+        {
+            var category = CharUnicodeInfo.GetUnicodeCategory(c);
+            return category != UnicodeCategory.Control &&
+                   category != UnicodeCategory.Format &&
+                   category != UnicodeCategory.NonSpacingMark &&
+                   category != UnicodeCategory.SpacingCombiningMark &&
+                   category != UnicodeCategory.EnclosingMark;
+        });
 
     private static bool IsNonLocalizableXamlValue(string value) =>
         string.IsNullOrWhiteSpace(value) ||
@@ -255,6 +398,26 @@ public class LocalizationValidationTests
         value.Contains("http://", StringComparison.Ordinal) ||
         value.Contains("https://", StringComparison.Ordinal) ||
         value.Contains("~/", StringComparison.Ordinal);
+
+    [Fact]
+    public void MojibakeDetector_FindsWindows1252Substrings()
+    {
+        Assert.True(TryDecodeKnownMojibake("连接状态 è¿ž 👍", out var decoded));
+        Assert.Contains("连", decoded, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MojibakeDetector_FindsCodePage437Substrings()
+    {
+        Assert.True(TryDecodeKnownMojibake("SSH ΘÜºΘüô", out var decoded));
+        Assert.Contains("隧道", decoded, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MojibakeDetector_AllowsLegitimateUnicode()
+    {
+        Assert.False(TryDecodeKnownMojibake("连接状态 Café 👍", out _));
+    }
 
     /// <summary>
     /// Keys whose value is a Latin-script loanword (e.g. "OK") that reads
@@ -505,6 +668,31 @@ public class LocalizationValidationTests
             Assert.True(duplicates.Count == 0,
                 $"Locale '{locale}' has duplicate keys: {string.Join(", ", duplicates)}");
         }
+    }
+
+    [Fact]
+    public void NoLocale_HasWindows1252MojibakeValues()
+    {
+        var stringsDir = GetStringsDirectory();
+        var localeDirs = Directory.GetDirectories(stringsDir);
+        var offenders = new List<string>();
+
+        foreach (var localeDir in localeDirs)
+        {
+            var locale = Path.GetFileName(localeDir);
+            var reswPath = Path.Combine(localeDir, "Resources.resw");
+            if (!File.Exists(reswPath)) continue;
+
+            foreach (var (key, value) in LoadResw(reswPath))
+            {
+                if (TryDecodeKnownMojibake(value, out var decoded))
+                    offenders.Add($"{locale}::{key} decodes to '{decoded}'");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            $"Found {offenders.Count} Windows-1252 mojibake resource value(s): " +
+            string.Join("; ", offenders.Take(20)));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- repair mojibake in fr-fr, zh-cn, and zh-tw tray resource files
- cover both confirmed corruption modes: Windows-1252-misdecoded UTF-8 and CP437/OEM-misdecoded UTF-8
- add localization validation tests that catch future mojibake regressions, including mixed Unicode strings

Fixes #583

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`