### PR TITLE
docs: add locked-down WSL gateway admin guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This monorepo contains the Windows hub, shared client libraries, and CLI utiliti
 
 > **End-user installer?** See [docs/SETUP.md](docs/SETUP.md) for a step-by-step installation guide (no build required).
 >
-> **Managed WSL gateway?** Local setup creates a locked-down app-owned `OpenClawGateway` distro. See [docs/WSL_GATEWAY_ADMIN.md](docs/WSL_GATEWAY_ADMIN.md) for sudo/root command equivalents and safe file-editing instructions.
+> **Managed WSL gateway?** Local setup creates a locked-down app-owned `OpenClawGateway` distro. See [docs/WSL_GATEWAY_ADMIN.md](docs/WSL_GATEWAY_ADMIN.md) for editing `openclaw.json` as the `openclaw` user and using root for protected-file administration.
 
 ### Prerequisites
 - Windows 10 (20H2+) or Windows 11

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This monorepo contains the Windows hub, shared client libraries, and CLI utiliti
 ## 🚀 Quick Start
 
 > **End-user installer?** See [docs/SETUP.md](docs/SETUP.md) for a step-by-step installation guide (no build required).
+>
+> **Managed WSL gateway?** Local setup creates a locked-down app-owned `OpenClawGateway` distro. See [docs/WSL_GATEWAY_ADMIN.md](docs/WSL_GATEWAY_ADMIN.md) for sudo/root command equivalents and safe file-editing instructions.
 
 ### Prerequisites
 - Windows 10 (20H2+) or Windows 11

--- a/docs/ONBOARDING_WIZARD.md
+++ b/docs/ONBOARDING_WIZARD.md
@@ -24,6 +24,8 @@ Displays the OpenClaw lobster icon, app title, and a brief description. If an ap
 ### Local setup progress
 Installs and connects a new app-owned `OpenClawGateway` WSL instance from a clean WSL baseline. Setup does not export from or mutate an existing user Ubuntu distro; if WSL cannot create the named app-owned distro directly, setup fails with an actionable update message. When replacing an app-owned local gateway, the removal step is shown as part of progress and can be retried on failure.
 
+The managed distro is locked down and is not intended to be a normal interactive Ubuntu profile. For sudo-style commands, root shells, and safe file-editing paths inside the distro, see [Managing the locked-down WSL gateway](WSL_GATEWAY_ADMIN.md).
+
 ### Wizard
 Renders server-defined setup steps via RPC (`wizard.start` / `wizard.next`). The gateway controls the flow — steps can be:
 - **Note** — informational messages

--- a/docs/ONBOARDING_WIZARD.md
+++ b/docs/ONBOARDING_WIZARD.md
@@ -24,7 +24,7 @@ Displays the OpenClaw lobster icon, app title, and a brief description. If an ap
 ### Local setup progress
 Installs and connects a new app-owned `OpenClawGateway` WSL instance from a clean WSL baseline. Setup does not export from or mutate an existing user Ubuntu distro; if WSL cannot create the named app-owned distro directly, setup fails with an actionable update message. When replacing an app-owned local gateway, the removal step is shown as part of progress and can be retried on failure.
 
-The managed distro is locked down and is not intended to be a normal interactive Ubuntu profile. For sudo-style commands, root shells, and safe file-editing paths inside the distro, see [Managing the locked-down WSL gateway](WSL_GATEWAY_ADMIN.md).
+The managed distro is locked down and is not intended to be a normal interactive Ubuntu profile. For editing `openclaw.json` as the `openclaw` user and using root for protected-file administration, see [Managing the locked-down WSL gateway](WSL_GATEWAY_ADMIN.md).
 
 ### Wizard
 Renders server-defined setup steps via RPC (`wizard.start` / `wizard.next`). The gateway controls the flow — steps can be:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -142,6 +142,10 @@ Download and install WebView2 from [Microsoft](https://developer.microsoft.com/m
 - See the log at `%LOCALAPPDATA%\OpenClawTray\openclaw-tray.log` for connection errors.
 - For easy-button setup, repair, or remove failures, start with `%LOCALAPPDATA%\OpenClawTray\Logs\Setup\easy-setup-latest.txt`; Copilot CLI/debugging tools can use `%LOCALAPPDATA%\OpenClawTray\Logs\Setup\easy-setup-latest.jsonl`.
 
+### Need to inspect or edit the managed WSL gateway
+
+Local setup creates a locked-down app-owned `OpenClawGateway` distro rather than a general-purpose user Ubuntu profile. Use `wsl.exe -d OpenClawGateway --user root -- ...` for sudo-style admin commands, and use the WSL filesystem share or root shell for file edits. See [Managing the locked-down WSL gateway](WSL_GATEWAY_ADMIN.md) for examples.
+
 ### "Not yet paired" message on reconnect
 
 If the tray shows **Pending approval** after reconnecting, run the approval command shown in the tray or log:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -144,7 +144,7 @@ Download and install WebView2 from [Microsoft](https://developer.microsoft.com/m
 
 ### Need to inspect or edit the managed WSL gateway
 
-Local setup creates a locked-down app-owned `OpenClawGateway` distro rather than a general-purpose user Ubuntu profile. Use `wsl.exe -d OpenClawGateway --user root -- ...` for sudo-style admin commands, and use the WSL filesystem share or root shell for file edits. See [Managing the locked-down WSL gateway](WSL_GATEWAY_ADMIN.md) for examples.
+Local setup creates a locked-down app-owned `OpenClawGateway` distro rather than a general-purpose user Ubuntu profile. Edit `openclaw.json` from inside WSL as the `openclaw` user, and reserve `wsl.exe -d OpenClawGateway --user root -- ...` for protected-file administration. See [Managing the locked-down WSL gateway](WSL_GATEWAY_ADMIN.md) for examples.
 
 ### "Not yet paired" message on reconnect
 

--- a/docs/WSL_GATEWAY_ADMIN.md
+++ b/docs/WSL_GATEWAY_ADMIN.md
@@ -1,0 +1,104 @@
+# Managing the locked-down WSL gateway
+
+Local setup creates an app-owned WSL distro named `OpenClawGateway` by default. It is not a general-purpose Ubuntu profile: the gateway runs as the `openclaw` Linux user, Windows interop is disabled inside WSL, Windows drive automounts are disabled inside WSL, and there is no password-based `sudo` flow.
+
+Use these rules:
+
+- Run normal gateway and config commands as `openclaw`.
+- Run sudo-style protected-file commands as `root` from Windows with `wsl.exe --user root`.
+- Use double quotes around `bash -lc "..."`; single quotes do not work from Command Prompt.
+- Do not edit through the Windows WSL share for this locked-down config; use a WSL shell as `openclaw` instead.
+- Do not edit the VHD or `%LOCALAPPDATA%\OpenClawTray\wsl` storage directly.
+
+If your setup used a custom distro name, replace `OpenClawGateway` in the examples below.
+
+## Check the managed distro
+
+```powershell
+# Lists WSL distros and shows whether OpenClawGateway is running.
+wsl.exe --list --verbose
+
+# Opens a one-shot shell as the gateway user and prints the user plus current directory.
+wsl.exe -d OpenClawGateway --user openclaw -- bash -lc "whoami && pwd"
+
+# Opens a one-shot shell as root and prints root identity details.
+wsl.exe -d OpenClawGateway --user root -- bash -lc "whoami && id"
+```
+
+## Update `openclaw.json`
+
+Most gateway configuration lives in:
+
+```text
+/home/openclaw/.openclaw/openclaw.json
+```
+
+Because the distro is locked down, edit this file from inside WSL as the `openclaw` user instead of editing it through the Windows filesystem share. The edit commands in this section intentionally change files; the inspection commands in the rest of this guide are read-only.
+
+1. Open a shell as the gateway user:
+
+   ```powershell
+   # Opens an interactive shell as the gateway user.
+   wsl.exe -d OpenClawGateway --user openclaw -- bash
+   ```
+
+2. In that shell, back up and edit the config:
+
+   ```bash
+   # Moves into the OpenClaw config directory.
+   cd /home/openclaw/.openclaw
+
+   # Creates a backup copy before editing.
+   cp openclaw.json openclaw.json.bak
+
+   # Opens openclaw.json in the nano editor.
+   nano openclaw.json
+
+   # Verifies that openclaw.json is still valid JSON.
+   python3 -m json.tool openclaw.json > /dev/null
+   ```
+
+   If `nano` is not available, use `vi openclaw.json`.
+
+3. If the change does not take effect, reconnect or restart the gateway from OpenClaw Companion.
+
+Read-only checks for the config:
+
+```powershell
+# Shows ownership, permissions, size, and timestamp for openclaw.json.
+wsl.exe -d OpenClawGateway --user openclaw -- bash -lc "ls -l /home/openclaw/.openclaw/openclaw.json"
+
+# Verifies that openclaw.json is valid JSON without printing it.
+wsl.exe -d OpenClawGateway --user openclaw -- bash -lc "python3 -m json.tool /home/openclaw/.openclaw/openclaw.json > /dev/null"
+
+# Prints the first 120 lines of openclaw.json for inspection.
+wsl.exe -d OpenClawGateway --user openclaw -- bash -lc "sed -n '1,120p' /home/openclaw/.openclaw/openclaw.json"
+```
+
+## Inspect gateway state
+
+Run gateway service checks as `openclaw`:
+
+```powershell
+# Shows the user service status without paging; succeeds even if the service is inactive.
+wsl.exe -d OpenClawGateway --user openclaw -- bash -lc "systemctl --user status openclaw-gateway.service --no-pager || true"
+
+# Shows the most recent gateway service journal entries without paging.
+wsl.exe -d OpenClawGateway --user openclaw -- bash -lc "journalctl --user-unit openclaw-gateway.service --no-pager -n 80 || true"
+
+# Shows ownership and permissions for the app-owned gateway directories.
+wsl.exe -d OpenClawGateway --user openclaw -- bash -lc "ls -ld /home/openclaw/.openclaw /var/lib/openclaw /var/log/openclaw /opt/openclaw"
+```
+
+Do not run `systemctl --user` as `root`; that checks root's user service manager, not the gateway's service.
+
+## Use root instead of sudo
+
+There is no interactive sudo password prompt. Open a root shell only when you intentionally need to inspect or change protected files:
+
+```powershell
+# Opens an interactive root shell for intentional protected-file work.
+wsl.exe -d OpenClawGateway --user root -- bash
+```
+
+Keep gateway-owned files under `/home/openclaw/.openclaw`, `/var/lib/openclaw`, `/var/log/openclaw`, and `/opt/openclaw` owned by `openclaw:openclaw`.

--- a/docs/WSL_GATEWAY_ADMIN.md
+++ b/docs/WSL_GATEWAY_ADMIN.md
@@ -71,9 +71,11 @@ wsl.exe -d OpenClawGateway --user openclaw -- bash -lc "ls -l /home/openclaw/.op
 # Verifies that openclaw.json is valid JSON without printing it.
 wsl.exe -d OpenClawGateway --user openclaw -- bash -lc "python3 -m json.tool /home/openclaw/.openclaw/openclaw.json > /dev/null"
 
-# Prints the first 120 lines of openclaw.json for inspection.
-wsl.exe -d OpenClawGateway --user openclaw -- bash -lc "sed -n '1,120p' /home/openclaw/.openclaw/openclaw.json"
+# Prints only the top-level config keys, not secret values.
+wsl.exe -d OpenClawGateway --user openclaw -- python3 -c "import json; data=json.load(open('/home/openclaw/.openclaw/openclaw.json')); print('\n'.join(sorted(data.keys())))"
 ```
+
+Do not paste or share the full `openclaw.json` file. It can contain gateway tokens, private endpoints, provider settings, or other secrets; redact those values before sharing diagnostics.
 
 ## Inspect gateway state
 


### PR DESCRIPTION
## Summary
- Add a locked-down WSL gateway admin guide focused on the `openclaw` user, root/sudo-style access, and editing `openclaw.json` from inside WSL
- Link the guide from README, setup troubleshooting, and onboarding docs
- Keep documented inspection commands read-only and explain each command inline

## Validation
- Validated documented WSL commands against the local `OpenClawGateway` instance
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`