### PR TITLE
fix(updater): point auto-updater at openclaw/openclaw-windows-node

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -32,7 +32,7 @@ namespace OpenClawTray;
 
 public partial class App : Application, OpenClawTray.Services.IAppCommands
 {
-    internal static readonly UpdatumManager AppUpdater = new("shanselman", "openclaw-windows-hub")
+    internal static readonly UpdatumManager AppUpdater = new("openclaw", "openclaw-windows-node")
     {
         FetchOnlyLatestRelease = true,
         InstallUpdateSingleFileExecutableName = "OpenClaw.Tray.WinUI",


### PR DESCRIPTION
The Updatum auto-updater was querying GitHub releases at shanselman/openclaw-windows-hub, which is not where this repository publishes releases. Releases are tagged and published from openclaw/openclaw-windows-node, so the in-app update check was effectively dead — it never returned new versions to users.

Repoint UpdatumManager at the correct owner/repo so installed builds can discover and download published releases via the existing update flow.