### PR TITLE
Hide reconfigure for setup-managed WSL gateways

### DIFF
--- a/docs/ONBOARDING_WIZARD.md
+++ b/docs/ONBOARDING_WIZARD.md
@@ -4,7 +4,7 @@ The onboarding wizard is now the V2 setup flow for installing a new app-owned lo
 
 ## Overview
 
-On first launch, the wizard appears only when there is no usable saved gateway connection. Users with any existing local or external gateway manage connections from the tray app's Connections tab and can start setup intentionally with **Install new WSL Gateway**.
+On first launch, the wizard appears only when there is no usable saved gateway connection. Users with existing gateways manage connections from the tray app's Connections tab. The local WSL setup affordance in Connections is shown only when setup has not already created an app-owned WSL gateway on this device.
 
 The V2 setup flow walks users through:
 

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1190,6 +1190,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         // Show "Reconfigure" if there's an existing setup, "Setup Guide" if fresh
         var hasExistingConfig = _settings != null
             && !StartupSetupState.RequiresSetup(_settings, IdentityDataPath, _gatewayRegistry);
+        var hasSetupManagedLocalWslGateway = WslKeepAlivePolicy.HasSetupManagedLocalGateway(_gatewayRegistry?.GetAll());
         var setupMenuLabel = hasExistingConfig
             ? LocalizationHelper.GetString("Menu_Reconfigure")
             : LocalizationHelper.GetString("Menu_SetupGuide");
@@ -1214,6 +1215,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             UsageCost = _appState?.UsageCost,
             Settings = _settings,
             SetupMenuLabel = setupMenuLabel,
+            ShowSetupMenuEntry = !hasSetupManagedLocalWslGateway,
         };
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -109,20 +109,13 @@ public sealed partial class ConnectionPage : Page
         var settings = CurrentApp.Settings;
         if (settings == null) return;
 
-        // Local-WSL install entry points. The hub only exposes
-        // OpenSetupAction on platforms where WSL tooling is wired up; if
-        // it's null we hide the entry points so the user isn't offered a
-        // button that does nothing.
+        // Local-WSL install entry points are only useful until setup has
+        // created its managed local WSL gateway record.
         //   • WelcomeLocalWslSetupCard — get-started CTA on the empty-state
         //     Welcome screen for first-run users.
         //   • AddLocalWslItem — third method tab inside the Add Gateway
         //     form, alongside Direct and Setup code.
-        var localSetupAvailable = true;
-        var localSetupVisibility = localSetupAvailable
-            ? Visibility.Visible
-            : Visibility.Collapsed;
-        WelcomeLocalWslSetupCard.Visibility = localSetupVisibility;
-        AddLocalWslItem.Visibility = localSetupVisibility;
+        UpdateLocalWslSetupVisibility();
 
         if (_connectionManager != null)
             _connectionManager.StateChanged += OnManagerStateChanged;
@@ -203,9 +196,27 @@ public sealed partial class ConnectionPage : Page
     {
         DispatcherQueue?.TryEnqueue(() =>
         {
+            UpdateLocalWslSetupVisibility();
             LoadSavedGateways();
             RefreshFromSnapshot(_lastSnapshot);
         });
+    }
+
+    private void UpdateLocalWslSetupVisibility()
+    {
+        var localSetupAvailable = !WslKeepAlivePolicy.HasSetupManagedLocalGateway(_gatewayRegistry?.GetAll());
+        var localSetupVisibility = localSetupAvailable
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+
+        WelcomeLocalWslSetupCard.Visibility = localSetupVisibility;
+        AddLocalWslItem.Visibility = localSetupVisibility;
+
+        if (!localSetupAvailable && AddLocalWslItem.IsSelected)
+        {
+            AddDirectItem.IsSelected = true;
+            ShowAddPane("direct");
+        }
     }
 
     // ─── Plan apply ───────────────────────────────────────────────────

--- a/src/OpenClaw.Tray.WinUI/Services/TrayMenuSnapshot.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/TrayMenuSnapshot.cs
@@ -32,4 +32,5 @@ internal sealed record TrayMenuSnapshot
     // ── Permisos y setup ──
     internal required SettingsManager? Settings { get; init; }
     internal required string SetupMenuLabel { get; init; }
+    internal required bool ShowSetupMenuEntry { get; init; }
 }

--- a/src/OpenClaw.Tray.WinUI/Services/TrayMenuStateBuilder.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/TrayMenuStateBuilder.cs
@@ -304,7 +304,10 @@ internal sealed class TrayMenuStateBuilder
 
         // Setup Guide / Reconfigure entry — label flips based on whether prior
         // configuration exists; routes to the existing "setup" action handler.
-        menu.AddMenuItem(_snapshot.SetupMenuLabel, FluentIconCatalog.Build(FluentIconCatalog.Setup), "setup");
+        if (_snapshot.ShowSetupMenuEntry)
+        {
+            menu.AddMenuItem(_snapshot.SetupMenuLabel, FluentIconCatalog.Build(FluentIconCatalog.Setup), "setup");
+        }
 
         // ── Footer ──
         menu.AddSeparator();

--- a/src/OpenClaw.Tray.WinUI/Services/WslKeepAlivePolicy.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/WslKeepAlivePolicy.cs
@@ -5,6 +5,9 @@ namespace OpenClawTray.Services;
 
 internal static class WslKeepAlivePolicy
 {
+    private const string DefaultSetupManagedDistroName = "OpenClawGateway";
+    private const string DefaultSetupManagedFriendlyName = "Local (OpenClawGateway)";
+
     public static bool ShouldStart(GatewayRecord? activeRecord, string? legacyGatewayUrl)
     {
         if (activeRecord is not null)
@@ -36,7 +39,7 @@ internal static class WslKeepAlivePolicy
             return environmentOverride;
 #endif
 
-        return "OpenClawGateway";
+        return DefaultSetupManagedDistroName;
     }
 
     public static IReadOnlyList<string> FindStaleSetupManagedDistroNames(
@@ -46,7 +49,7 @@ internal static class WslKeepAlivePolicy
     {
         var managedLocalDistros = records
             .Where(IsSetupManagedLocalRecord)
-            .Select(r => r.SetupManagedDistroName)
+            .Select(GetSetupManagedDistroName)
             .Where(name => !string.IsNullOrWhiteSpace(name))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
@@ -60,6 +63,9 @@ internal static class WslKeepAlivePolicy
             .Select(distro => distro!)
             .ToArray();
     }
+
+    public static bool HasSetupManagedLocalGateway(IEnumerable<GatewayRecord>? records) =>
+        records?.Any(IsSetupManagedLocalRecord) == true;
 
     public static bool IsKeepaliveCommandLine(string? commandLine, string distroName)
     {
@@ -90,14 +96,29 @@ internal static class WslKeepAlivePolicy
         }
     }
 
-    private static bool IsSetupManagedLocalRecord(GatewayRecord record)
+    public static bool IsSetupManagedLocalRecord(GatewayRecord record)
     {
         if (record.SshTunnel is not null)
             return false;
 
-        if (string.IsNullOrWhiteSpace(record.SetupManagedDistroName))
-            return false;
+        if (!string.IsNullOrWhiteSpace(record.SetupManagedDistroName))
+            return record.IsLocal || LocalGatewayUrlClassifier.IsLocalGatewayUrl(record.Url);
 
-        return record.IsLocal || LocalGatewayUrlClassifier.IsLocalGatewayUrl(record.Url);
+        return IsLegacyDefaultSetupManagedLocalRecord(record);
     }
+
+    private static string? GetSetupManagedDistroName(GatewayRecord record)
+    {
+        if (!string.IsNullOrWhiteSpace(record.SetupManagedDistroName))
+            return record.SetupManagedDistroName;
+
+        return IsLegacyDefaultSetupManagedLocalRecord(record)
+            ? DefaultSetupManagedDistroName
+            : null;
+    }
+
+    private static bool IsLegacyDefaultSetupManagedLocalRecord(GatewayRecord record) =>
+        record.IsLocal
+        && LocalGatewayUrlClassifier.IsLocalGatewayUrl(record.Url)
+        && string.Equals(record.FriendlyName, DefaultSetupManagedFriendlyName, StringComparison.Ordinal);
 }

--- a/tests/OpenClaw.Tray.Tests/WslKeepAlivePolicyTests.cs
+++ b/tests/OpenClaw.Tray.Tests/WslKeepAlivePolicyTests.cs
@@ -72,6 +72,118 @@ public class WslKeepAlivePolicyTests
     }
 
     [Fact]
+    public void HasSetupManagedLocalGateway_ReturnsTrueForSetupManagedLocalRecord()
+    {
+        var records = new[]
+        {
+            new GatewayRecord
+            {
+                Id = "local",
+                Url = "ws://localhost:18789",
+                IsLocal = true,
+                SetupManagedDistroName = "OpenClawGateway",
+            },
+        };
+
+        Assert.True(WslKeepAlivePolicy.HasSetupManagedLocalGateway(records));
+    }
+
+    [Fact]
+    public void HasSetupManagedLocalGateway_ReturnsTrueForLegacyDefaultSetupManagedLocalRecord()
+    {
+        var records = new[]
+        {
+            new GatewayRecord
+            {
+                Id = "legacy-local",
+                Url = "ws://localhost:18789",
+                FriendlyName = "Local (OpenClawGateway)",
+                IsLocal = true,
+            },
+        };
+
+        Assert.True(WslKeepAlivePolicy.HasSetupManagedLocalGateway(records));
+    }
+
+    [Fact]
+    public void HasSetupManagedLocalGateway_ReturnsFalseForManualLocalRecord()
+    {
+        var records = new[]
+        {
+            new GatewayRecord
+            {
+                Id = "manual-local",
+                Url = "ws://localhost:18789",
+                IsLocal = true,
+            },
+        };
+
+        Assert.False(WslKeepAlivePolicy.HasSetupManagedLocalGateway(records));
+    }
+
+    [Fact]
+    public void HasSetupManagedLocalGateway_ReturnsFalseForSshTunnelRecord()
+    {
+        var records = new[]
+        {
+            new GatewayRecord
+            {
+                Id = "ssh",
+                Url = "ws://127.0.0.1:18789",
+                IsLocal = true,
+                SetupManagedDistroName = "OpenClawGateway",
+                SshTunnel = new SshTunnelConfig("user", "example.test", 18789, 18789),
+            },
+        };
+
+        Assert.False(WslKeepAlivePolicy.HasSetupManagedLocalGateway(records));
+    }
+
+    [Fact]
+    public void HasSetupManagedLocalGateway_ReturnsFalseForRemoteRecord()
+    {
+        var records = new[]
+        {
+            new GatewayRecord
+            {
+                Id = "remote",
+                Url = "wss://gateway.example.test",
+                SetupManagedDistroName = "OpenClawGateway",
+            },
+        };
+
+        Assert.False(WslKeepAlivePolicy.HasSetupManagedLocalGateway(records));
+    }
+
+    [Fact]
+    public void HasSetupManagedLocalGateway_ReturnsFalseForNullRecords()
+    {
+        Assert.False(WslKeepAlivePolicy.HasSetupManagedLocalGateway(null));
+    }
+
+    [Fact]
+    public void FindStaleSetupManagedDistroNames_PreservesLegacyDefaultLocalDistro()
+    {
+        var records = new[]
+        {
+            new GatewayRecord
+            {
+                Id = "legacy-local",
+                Url = "ws://localhost:18789",
+                FriendlyName = "Local (OpenClawGateway)",
+                IsLocal = true,
+            },
+        };
+
+        var stale = WslKeepAlivePolicy.FindStaleSetupManagedDistroNames(
+            records,
+            ["OpenClawGateway"],
+            setupStateDistroName: null);
+
+        Assert.Empty(stale);
+    }
+
+    [Fact]
     public void FindStaleSetupManagedDistroNames_PreservesRegisteredLocalDistro_WhenRemoteIsActive()
     {
         var records = new[]


### PR DESCRIPTION
## Summary
- Hide the tray setup/reconfigure entry when a setup-managed local WSL gateway already exists.
- Gate the Connections page Local WSL setup affordances with the same setup-managed gateway predicate.
- Preserve legacy setup-managed local gateway detection and add behavioral coverage.

## Behavior proof
- Local visual check captured the requested proof screenshots, but they are intentionally not committed to the repository.
- Setup-managed WSL gateway exists: tray setup/reconfigure entry is hidden.
- Setup-managed WSL gateway exists: Connections page shows gateway management, not Local WSL install.
- No setup-managed WSL gateway record: Connections page shows the local WSL install affordance.

## Reset / reinstall route
- Existing setup-managed WSL users should manage the gateway from Connections (`Terminal`, `Start`, `Stop`, `Restart`).
- To reinstall/reset the setup-managed WSL gateway, use the existing Settings removal/reset flow to remove the local gateway; once the setup-managed gateway record is absent, the Connections local WSL install affordance is shown again.
- The `openclaw://setup` deep link remains available as an explicit setup entry point; this PR only removes the redundant tray setup/reconfigure affordance when setup has already created a WSL gateway.

## Validation
- ./build.ps1
- dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore
- dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore

## Review
- Hanselman dual-model review completed; no high-consensus blocking issues found.