### PR TITLE
fix(updater): anchor WinUI runtime so closing UpdateDialog doesn't kill in-flight download

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -460,6 +460,16 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         // Register URI scheme on first run
         DeepLinkHandler.RegisterUriScheme();
 
+        // Anchor the WinUI runtime so transient windows (UpdateDialog,
+        // setup wizard, etc.) don't terminate the process when closed.
+        // WinUI 3 Desktop's default DispatcherShutdownMode is
+        // OnLastWindowClose — without this override, closing the
+        // UpdateDialog on the startup path (when it is the only window)
+        // would shut down the WinUI runtime mid-flight and kill the
+        // in-progress download/extraction. We still control shutdown
+        // explicitly via Application.Exit().
+        DispatcherShutdownMode = DispatcherShutdownMode.OnExplicitShutdown;
+
         // Check for updates before launching. Skip in test instances — no UI dialogs,
         // no network calls, no startup delay.
         if (DataDirOverride is null &&


### PR DESCRIPTION
## Summary

Fixes the silent failure of the in-app auto-updater. `UpdateDialog` is a `WindowEx` (its own WinUI Window), not a `ContentDialog`. On the startup update path it is the only window in the process. WinUI 3 Desktop's default `DispatcherShutdownMode` is `OnLastWindowClose`, so clicking **Download** (which calls `Close()` on the dialog) shuts down the WinUI runtime mid-extraction. The Updatum-managed `ZipFile.ExtractToDirectory` got ~199 of 1505 entries to disk before the process was terminated, the `.bat` that performs the in-place file replacement was never written, and the install dir was never updated. Because the shutdown comes from the native side it bypasses `AppDomain.ProcessExit`, so no `Process exiting (ExitCode=...)` line was logged and no managed exception was thrown — making the failure silent.

## Fix

Set `DispatcherShutdownMode = OnExplicitShutdown` at the top of `OnLaunchedAsync`. The WinUI runtime now exits only when we call `Application.Exit()` (which existing shutdown paths already do). The keep-alive window remains — it's still needed as a persistent XamlRoot host for ContentDialogs that fire when no Hub window is open.

This is the [documented Microsoft-recommended approach](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.application.dispatchershutdownmode) for WinUI Desktop apps that need to keep code running after all XAML windows are closed.

## Repro

Before this fix, on v0.5.0 or earlier installs:
1. Launch the tray
2. Update dialog appears offering v0.6.0
3. Click `Download`
4. Tray exits, no relaunch, install dir remains at v0.5.0

After this fix, locally verified by building a v0.5.1 installer with this change, installing over v0.5.0, then triggering the update to v0.6.0:

(Get-Item "$env:LocalAppData\OpenClawTray\OpenClaw.Tray.WinUI.exe").VersionInfo.ProductVersion
0.6.0+...


## Validation

- `.\build.ps1` — all projects built ✅
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj` — 2045 passed, 0 failed, 29 skipped ✅
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj` — 934 passed, 0 failed ✅
- Manual end-to-end upgrade smoke v0.5.1 → v0.6.0 ✅