### PR TITLE
fix(chat): reset keyless diagnostic on reconnect

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -1028,6 +1028,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                 _locallyInitiatedThreads.Clear();
                 _localSentTexts.Clear();
                 _historyRetryCount.Clear();
+                System.Threading.Interlocked.Exchange(ref _keylessEventDiagnosticRaised, 0);
             }
             else
             {

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -2140,6 +2140,32 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
+    public async Task KeylessEvents_DiagnosticResetsOnReconnect()
+    {
+        var (bridge, provider, _, notifications) = CreateConnectedProviderWithNotifications("agent:main:main");
+        await provider.LoadAsync();
+
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "",
+            Role = "assistant",
+            Text = "first dropped payload"
+        });
+
+        Assert.Single(notifications, n => n.Title == "Chat_Notification_KeylessEventDropped");
+
+        bridge.RaiseStatus(ConnectionStatus.Disconnected);
+        bridge.RaiseStatus(ConnectionStatus.Connected);
+
+        bridge.RaiseAgent(MakeAgentEvent("assistant", """{"delta":"second dropped payload"}""", sessionKey: ""));
+
+        Assert.Equal(2, notifications.Count(n => n.Title == "Chat_Notification_KeylessEventDropped"));
+        Assert.DoesNotContain(notifications, n =>
+            (n.Title?.Contains("dropped payload") ?? false) ||
+            (n.Message?.Contains("dropped payload") ?? false));
+    }
+
+    [Fact]
     public async Task AgentEvent_WithEmptySessionKey_IsDroppedAndDiagnosed()
     {
         var (bridge, provider, snapshots, notifications) = CreateConnectedProviderWithNotifications("agent:main:main");


### PR DESCRIPTION
## Summary

- Fixes #458 by resetting the one-shot keyless chat/agent event diagnostic when the chat provider reconnects.
- Keeps the existing safety behavior: keyless inbound events are still dropped instead of routed into a synthetic `main` timeline.
- Adds a regression test that verifies a keyless event emits the visible diagnostic again after disconnect + reconnect, without exposing dropped payload content.

## Triage

Fix size: small, confidence >=95%. The scoped gap was that `_keylessEventDiagnosticRaised` survived reconnects, so users could lose the visible warning if a still-broken gateway emitted keyless events after reconnect.

## Validation

With `OPENCLAW_REPO_ROOT` set to this worktree via short path `C:\ocw458`:

- `./build.ps1`
- `dotnet build ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj`
- `dotnet build ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`

Note: initial full build from the generated long worktree path failed in WinAppSDK PRI generation (`CommunityToolkit.WinUI.Controls.SettingsControls.pri.xml` missing). Rerunning from a short junction path avoided that environment/path issue and passed.