### PR TITLE
Fix tool output accessibility labels

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
@@ -1993,6 +1993,7 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                 // ▼ when collapsed (action: click to expand down).
                 var chevron = effectiveExpanded ? "▲" : "▼";
                 var stepCountLabel = $"{stepCount} step{(stepCount == 1 ? "" : "s")}";
+                var taskListHeaderAutomationName = $"{summaryLine}, {stepCountLabel}, {taskStatusText}, {(effectiveExpanded ? "expanded" : "collapsed")}";
 
                 Action toggleTaskList = () =>
                 {
@@ -2004,6 +2005,7 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
 
                 // Per-step rows (used only when expanded).
                 var stepRows = new System.Collections.Generic.List<Element>();
+                var stepAutomationSummaries = new System.Collections.Generic.List<string>();
                 for (int i = 0; i < entries.Count; i++)
                 {
                     var e = entries[i];
@@ -2012,6 +2014,7 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                     var prefix = StepPrefix(i);
                     var labelText = string.IsNullOrEmpty(prefix) ? label : $"{prefix} {label}";
                     var summary = ShortSummary(e);
+                    stepAutomationSummaries.Add(string.IsNullOrEmpty(summary) ? labelText : $"{labelText}: {summary}");
 
                     stepRows.Add(
                         (FlexRow(
@@ -2054,19 +2057,21 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                         .Set(t => { t.FontSize = 11; }).VAlign(VerticalAlignment.Center)
                 ) with { ColumnGap = 8 }).Margin(0, 0, 0, 0);
 
-                var headerButton = Button(headerContent, toggleTaskList).Set(b =>
-                {
-                    b.HorizontalAlignment = HorizontalAlignment.Stretch;
-                    b.HorizontalContentAlignment = HorizontalAlignment.Stretch;
-                    b.Padding = bubblePadding;
-                    b.CornerRadius = new CornerRadius(bubbleRadius.TopLeft, bubbleRadius.TopRight, effectiveExpanded ? 0 : bubbleRadius.BottomRight, effectiveExpanded ? 0 : bubbleRadius.BottomLeft);
-                }).Resources(r => r
-                    .Set("ButtonBackground", new SolidColorBrush(Colors.Transparent))
-                    .Set("ButtonBackgroundPointerOver", themeBrush("SubtleFillColorTertiaryBrush"))
-                    .Set("ButtonBackgroundPressed", themeBrush("SubtleFillColorSecondaryBrush"))
-                    .Set("ButtonBorderBrush", new SolidColorBrush(Colors.Transparent))
-                    .Set("ButtonBorderBrushPointerOver", new SolidColorBrush(Colors.Transparent))
-                    .Set("ButtonBorderBrushPressed", new SolidColorBrush(Colors.Transparent)));
+                var headerButton = Button(headerContent, toggleTaskList)
+                    .AutomationName(taskListHeaderAutomationName)
+                    .Set(b =>
+                    {
+                        b.HorizontalAlignment = HorizontalAlignment.Stretch;
+                        b.HorizontalContentAlignment = HorizontalAlignment.Stretch;
+                        b.Padding = bubblePadding;
+                        b.CornerRadius = new CornerRadius(bubbleRadius.TopLeft, bubbleRadius.TopRight, effectiveExpanded ? 0 : bubbleRadius.BottomRight, effectiveExpanded ? 0 : bubbleRadius.BottomLeft);
+                    }).Resources(r => r
+                        .Set("ButtonBackground", new SolidColorBrush(Colors.Transparent))
+                        .Set("ButtonBackgroundPointerOver", themeBrush("SubtleFillColorTertiaryBrush"))
+                        .Set("ButtonBackgroundPressed", themeBrush("SubtleFillColorSecondaryBrush"))
+                        .Set("ButtonBorderBrush", new SolidColorBrush(Colors.Transparent))
+                        .Set("ButtonBorderBrushPointerOver", new SolidColorBrush(Colors.Transparent))
+                        .Set("ButtonBorderBrushPressed", new SolidColorBrush(Colors.Transparent)));
 
                 var cardChildren = new System.Collections.Generic.List<Element> { headerButton };
                 if (effectiveExpanded)
@@ -2075,6 +2080,7 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                     // header + body read as one unit but the divide is clear.
                     cardChildren.Add(
                         Border(VStack(8, stepRows.ToArray()))
+                            .AutomationName($"Tool steps for: {summaryLine}. {string.Join("; ", stepAutomationSummaries)}")
                             .Set(b =>
                             {
                                 b.Padding = bubblePadding;

--- a/tests/OpenClaw.Tray.Tests/ChatToolCallsToggleContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatToolCallsToggleContractTests.cs
@@ -25,6 +25,27 @@ public sealed class ChatToolCallsToggleContractTests
             source);
     }
 
+    [Fact]
+    public void TaskListToolBurst_LabelsHeaderAndExpandedBodyForScreenReaders()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Chat",
+            "OpenClawChatTimeline.cs"));
+
+        Assert.Matches(
+            new Regex(@"var\s+taskListHeaderAutomationName\s*=\s*\$""\{summaryLine\},\s*\{stepCountLabel\},\s*\{taskStatusText\},\s*\{"),
+            source);
+        Assert.Matches(
+            new Regex(@"var\s+headerButton\s*=\s*Button\(headerContent,\s*toggleTaskList\)\s*\.AutomationName\(taskListHeaderAutomationName\)", RegexOptions.Singleline),
+            source);
+        Assert.Matches(
+            new Regex(@"\.AutomationName\(\$""Tool steps for:\s*\{summaryLine\}\.\s*\{string\.Join\("";\s*"",\s*stepAutomationSummaries\)\}""\)", RegexOptions.Singleline),
+            source);
+    }
+
     private static string GetRepositoryRoot()
     {
         var env = Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT");


### PR DESCRIPTION
## Summary
- Add explicit automation text to TaskList tool-output headers with summary, step count, status, and expanded/collapsed state.
- Add an automation name to the expanded TaskList body that summarizes the tool steps while preserving the header-only button/body sibling structure.
- Add a source-level regression test to keep the TaskList header/body automation labels in place.

Closes #590.

## Review notes
- Fix size: small, confidence >=95% after two critical review passes.
- The change is intentionally limited to automation metadata and does not restructure the click target, preserving the text-selection behavior.

## Validation
- `./build.ps1` from the direct long worktree path still hits a Windows App SDK PRI path-length/generated-file failure in WinUI (`CommunityToolkit.WinUI.Controls.SettingsControls.pri.xml`). The same worktree passed `./build.ps1` with `OPENCLAW_REPO_ROOT` set to the real worktree and cwd shortened through a temporary `C:\oc590` junction.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` passed: 2074 total, 0 failed, 2045 succeeded, 29 skipped.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` passed: 935 total, 0 failed.