### PR TITLE
Add wizard recovery actions during auth waits

### DIFF
--- a/docs/ONBOARDING_WIZARD.md
+++ b/docs/ONBOARDING_WIZARD.md
@@ -36,7 +36,7 @@ Renders server-defined setup steps via RPC (`wizard.start` / `wizard.next`). The
 
 If the gateway doesn't support the wizard protocol or is unreachable, this screen shows an "offline" message and can be skipped.
 
-If the gateway restarts or the wizard connection is lost while setup is running, the wizard presents recovery choices to start the wizard again or skip it for now so the user is not trapped retrying a broken session.
+The wizard keeps recovery choices visible while setup steps are running so users can start the wizard again or skip it for now if an auth flow stalls. If the gateway restarts or the wizard connection is lost while setup is running, the same recovery choices are presented in the error state so the user is not trapped retrying a broken session.
 
 ### Permissions
 Checks 5 Windows permissions using native APIs and registry:

--- a/src/OpenClaw.SetupEngine.UI/Pages/WizardPage.xaml
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WizardPage.xaml
@@ -31,25 +31,44 @@
             </Border>
         </ScrollViewer>
 
-        <StackPanel Grid.Row="2"
-                    Orientation="Horizontal"
-                    HorizontalAlignment="Right"
-                    Spacing="12">
-            <Button x:Name="SecondaryButton" Content="Skip" Height="44"
-                    MinWidth="96"
-                    Click="Secondary_Click" IsEnabled="False" />
-            <Button x:Name="PrimaryButton" Content="Continue" Height="44"
-                    MinWidth="120"
-                    Click="Primary_Click" IsEnabled="False">
-                <Button.Resources>
-                    <SolidColorBrush x:Key="ButtonBackground" Color="#60C8F8" />
-                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#52B0DA" />
-                    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#469BBC" />
-                    <SolidColorBrush x:Key="ButtonForeground" Color="Black" />
-                    <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="Black" />
-                    <SolidColorBrush x:Key="ButtonForegroundPressed" Color="Black" />
-                </Button.Resources>
-            </Button>
-        </StackPanel>
+        <Grid Grid.Row="2" ColumnDefinitions="*,Auto">
+            <StackPanel x:Name="RecoveryActions"
+                        Grid.Column="0"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Left"
+                        Spacing="12"
+                        Visibility="Collapsed">
+                <Button x:Name="StartOverButton"
+                        Content="Start over"
+                        Height="44"
+                        MinWidth="104"
+                        Click="StartOver_Click" />
+                <Button x:Name="SkipWizardButton"
+                        Content="Skip wizard"
+                        Height="44"
+                        MinWidth="104"
+                        Click="SkipWizard_Click" />
+            </StackPanel>
+            <StackPanel Grid.Column="1"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        Spacing="12">
+                <Button x:Name="SecondaryButton" Content="Skip" Height="44"
+                        MinWidth="96"
+                        Click="Secondary_Click" IsEnabled="False" />
+                <Button x:Name="PrimaryButton" Content="Continue" Height="44"
+                        MinWidth="120"
+                        Click="Primary_Click" IsEnabled="False">
+                    <Button.Resources>
+                        <SolidColorBrush x:Key="ButtonBackground" Color="#60C8F8" />
+                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#52B0DA" />
+                        <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#469BBC" />
+                        <SolidColorBrush x:Key="ButtonForeground" Color="Black" />
+                        <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="Black" />
+                        <SolidColorBrush x:Key="ButtonForegroundPressed" Color="Black" />
+                    </Button.Resources>
+                </Button>
+            </StackPanel>
+        </Grid>
     </Grid>
 </Page>

--- a/src/OpenClaw.SetupEngine.UI/Pages/WizardPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WizardPage.xaml.cs
@@ -21,6 +21,7 @@ public sealed partial class WizardPage : Page
     private string _stepType = "";
     private bool _sensitive;
     private bool _errorState;
+    private int _operationGeneration;
     private int _wizardStepCount;
     private readonly Dictionary<string, int> _stepVisits = new(StringComparer.OrdinalIgnoreCase);
     private readonly List<WizardOption> _options = [];
@@ -45,9 +46,11 @@ public sealed partial class WizardPage : Page
 
     private async Task StartWizardAsync()
     {
+        var generation = AdvanceOperationGeneration();
         try
         {
             _errorState = false;
+            HideRecoveryActions();
             await DisconnectAsync();
             _sessionId = "";
             _wizardStepCount = 0;
@@ -57,10 +60,16 @@ public sealed partial class WizardPage : Page
             _client.StatusChanged += OnWizardClientStatusChanged;
             SetBusy("Starting wizard...");
             var payload = await _client.SendWizardRequestAsync("wizard.start", timeoutMs: 30_000);
+            if (generation != _operationGeneration)
+                return;
+
             await ApplyPayloadAsync(payload);
         }
         catch (Exception ex)
         {
+            if (generation != _operationGeneration)
+                return;
+
             await EnterWizardErrorAsync($"Gateway wizard failed: {ex.Message}");
         }
     }
@@ -204,6 +213,7 @@ public sealed partial class WizardPage : Page
         ErrorText.Visibility = Visibility.Collapsed;
         BusyRing.Visibility = Visibility.Collapsed;
         BusyRing.IsActive = false;
+        ShowRecoveryActions();
         StatusText.Text = "Answer the gateway setup question";
         PrimaryButton.IsEnabled = !WizardSelection.RequiresAnswer(_stepType);
         SecondaryButton.IsEnabled = true;
@@ -395,10 +405,32 @@ public sealed partial class WizardPage : Page
         await SendCurrentAnswerAsync(skip: true);
     }
 
+    private void StartOver_Click(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            StartOverAsync,
+            NullLogger.Instance,
+            nameof(StartOver_Click));
+
+    private async Task StartOverAsync()
+    {
+        AdvanceOperationGeneration();
+        HideRecoveryActions();
+        SetBusy("Starting over...");
+        await CancelCurrentSessionAsync();
+        await StartWizardAsync();
+    }
+
+    private void SkipWizard_Click(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            SkipWizardAsync,
+            NullLogger.Instance,
+            nameof(SkipWizard_Click));
+
     private async Task SendCurrentAnswerAsync(bool skip)
     {
         if (_client == null) return;
 
+        var generation = _operationGeneration;
         try
         {
             object? answerValue = null;
@@ -428,10 +460,16 @@ public sealed partial class WizardPage : Page
             }
 
             var payload = await _client.SendWizardRequestAsync("wizard.next", parameters, timeoutMs: TimeoutForCurrentStep());
+            if (generation != _operationGeneration)
+                return;
+
             await ApplyPayloadAsync(payload);
         }
         catch (Exception ex)
         {
+            if (generation != _operationGeneration)
+                return;
+
             await EnterWizardErrorAsync(ex.Message);
         }
     }
@@ -639,6 +677,7 @@ public sealed partial class WizardPage : Page
         SecondaryButton.Content = "Skip wizard";
         SecondaryButton.IsEnabled = true;
         SecondaryButton.Visibility = Visibility.Visible;
+        HideRecoveryActions();
     }
 
     private async Task EnterWizardErrorAsync(string detail)
@@ -653,6 +692,18 @@ public sealed partial class WizardPage : Page
 
     private async Task SkipWizardAsync()
     {
+        AdvanceOperationGeneration();
+        HideRecoveryActions();
+        SetBusy("Skipping wizard...");
+        await CancelCurrentSessionAsync();
+        if (_config!.SkipPermissions)
+            App.MainWindow?.NavigateToComplete(true, TimeSpan.Zero, _config.LogPath);
+        else
+            App.MainWindow?.NavigateToPermissions();
+    }
+
+    private async Task CancelCurrentSessionAsync()
+    {
         if (_client != null && !string.IsNullOrWhiteSpace(_sessionId))
         {
             try { await _client.SendWizardRequestAsync("wizard.cancel", new { sessionId = _sessionId }, timeoutMs: 10_000); }
@@ -660,10 +711,25 @@ public sealed partial class WizardPage : Page
         }
 
         await DisconnectAsync();
-        if (_config!.SkipPermissions)
-            App.MainWindow?.NavigateToComplete(true, TimeSpan.Zero, _config.LogPath);
-        else
-            App.MainWindow?.NavigateToPermissions();
+    }
+
+    private int AdvanceOperationGeneration() => unchecked(++_operationGeneration);
+
+    private void ShowRecoveryActions()
+    {
+        if (_errorState)
+            return;
+
+        RecoveryActions.Visibility = Visibility.Visible;
+        StartOverButton.IsEnabled = true;
+        SkipWizardButton.IsEnabled = true;
+    }
+
+    private void HideRecoveryActions()
+    {
+        RecoveryActions.Visibility = Visibility.Collapsed;
+        StartOverButton.IsEnabled = false;
+        SkipWizardButton.IsEnabled = false;
     }
 
     private async Task DisconnectAsync()


### PR DESCRIPTION
## Summary
- Add persistent Start over and Skip wizard recovery actions while gateway wizard steps are active
- Preserve existing Continue/Skip answer buttons and error-state recovery behavior
- Ignore stale wizard responses after recovery actions and document the updated onboarding wizard behavior

Fixes #640.

## Validation
- `OPENCLAW_REPO_ROOT=C:\Users\ranjeshj\.copilot\repos\copilot-worktrees\openclaw-windows-node\ranjeshj-issue-640-config-wizard-browser-links-for-auth-wri-04cb2f .\build.ps1` initially hit a WinUI MakePri generated-file path issue under the long worktree path
- Reran via short junction path with `OPENCLAW_REPO_ROOT=C:\ocw640`: `.uild.ps1` passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` passed
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` passed