### PR TITLE
Extend gateway configuration timeout

### DIFF
--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -1191,6 +1191,7 @@ public sealed class InstallCliStep : SetupStep
 public sealed class ConfigureGatewayStep : SetupStep
 {
     internal const string DevicePairPublicUrlKey = "plugins.entries.device-pair.config.publicUrl";
+    internal static readonly TimeSpan GatewayConfigurationTimeout = TimeSpan.FromSeconds(120);
 
     public override string Id => "configure-gateway";
     public override string DisplayName => "Configure gateway";
@@ -1243,10 +1244,16 @@ public sealed class ConfigureGatewayStep : SetupStep
             echo "GATEWAY_CONFIGURED"
             """;
 
-        var result = await ctx.Commands.RunInWslAsync(distro, script, TimeSpan.FromSeconds(30), env, ct);
+        var result = await ctx.Commands.RunInWslAsync(distro, script, GatewayConfigurationTimeout, env, ct);
 
         if (result.ExitCode != 0 || !result.Stdout.Contains("GATEWAY_CONFIGURED"))
+        {
+            if (result.TimedOut)
+                return StepResult.Fail(
+                    $"Gateway configuration timed out after {GatewayConfigurationTimeout.TotalSeconds:0}s while running openclaw config inside WSL.");
+
             return StepResult.Fail($"Gateway configuration failed (exit {result.ExitCode}): {result.Stderr}");
+        }
 
         ctx.Logger.StateChange("shared_gateway_token", null, "[SET]");
         return StepResult.Ok("Gateway configured");

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -738,6 +738,37 @@ public class SetupStepsTests : IDisposable
             commands);
     }
 
+    [Fact]
+    public async Task ConfigureGateway_UsesExtendedTimeoutForWslConfig()
+    {
+        var commands = new FakeCommandRunner(
+            _ => Ok(),
+            (_, _, _) => Ok("GATEWAY_CONFIGURED"));
+        var ctx = CreateContext(commands: commands);
+
+        var result = await new ConfigureGatewayStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var wslCall = Assert.Single(commands.WslCalls);
+        Assert.Equal(ConfigureGatewayStep.GatewayConfigurationTimeout, wslCall.Timeout);
+    }
+
+    [Fact]
+    public async Task ConfigureGateway_ReturnsTimeoutSpecificFailure()
+    {
+        var commands = new FakeCommandRunner(
+            _ => Ok(),
+            (_, _, timeout) => new CommandResult(-1, "", "", timeout, TimedOut: true));
+        var ctx = CreateContext(commands: commands);
+
+        var result = await new ConfigureGatewayStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Failed, result.Outcome);
+        var message = Assert.IsType<string>(result.Message);
+        Assert.Contains("Gateway configuration timed out after 120s", message);
+        Assert.DoesNotContain("exit -1", message);
+    }
+
     [Theory]
     [InlineData("""{"bootstrapToken":"boot-token"}""", "boot-token", "bootstrapToken")]
     [InlineData("""{"setupCode":"setup-code"}""", "setup-code", "setupCode")]
@@ -972,9 +1003,12 @@ public class SetupStepsTests : IDisposable
     private static CommandResult Fail(string stderr = "")
         => new(1, "", stderr, TimeSpan.Zero, TimedOut: false);
 
-    private sealed class FakeCommandRunner(Func<string[], CommandResult> run) : ICommandRunner
+    private sealed class FakeCommandRunner(
+        Func<string[], CommandResult> run,
+        Func<string, string, TimeSpan, CommandResult>? runInWsl = null) : ICommandRunner
     {
         public List<(string Executable, string[] Arguments)> Calls { get; } = [];
+        public List<(string DistroName, string Command, TimeSpan Timeout)> WslCalls { get; } = [];
 
         public Task<CommandResult> RunAsync(
             string executable,
@@ -996,6 +1030,12 @@ public class SetupStepsTests : IDisposable
             IReadOnlyDictionary<string, string>? environment = null,
             CancellationToken ct = default,
             string? user = null)
-            => throw new NotSupportedException("RunInWslAsync is not expected in these tests.");
+        {
+            if (runInWsl == null)
+                throw new NotSupportedException("RunInWslAsync is not expected in these tests.");
+
+            WslCalls.Add((distroName, command, timeout));
+            return Task.FromResult(runInWsl(distroName, command, timeout));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend the WSL gateway configuration step timeout from 30s to 120s
- return a timeout-specific setup failure message instead of the generic empty `exit -1` error
- add setup-engine tests for the extended timeout and timeout-specific failure path

Fixes #638.

## Validation
- `OPENCLAW_REPO_ROOT=...; .\build.ps1`
- `OPENCLAW_REPO_ROOT=...; dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`
- `OPENCLAW_REPO_ROOT=...; dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`
- `OPENCLAW_REPO_ROOT=...; dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-build --no-restore` — 2074 total, 0 failed, 2045 passed, 29 skipped
- `OPENCLAW_REPO_ROOT=...; dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-build --no-restore` — 934 total, 0 failed
- `OPENCLAW_REPO_ROOT=...; dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-build --no-restore` — 199 total, 0 failed