### PR TITLE
Use ARM64-aware WSL virtualization guidance

### DIFF
--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using OpenClaw.Connection;
 using OpenClaw.Shared;
@@ -90,18 +91,20 @@ internal static class WslInstallSupport
     // sentences are not, and over-broad fallbacks just create false
     // positives.
     public static bool TryGetEnvironmentIssue(string output, out string message)
+        => TryGetEnvironmentIssue(output, RuntimeInformation.OSArchitecture, out message);
+
+    internal static bool TryGetEnvironmentIssue(string output, Architecture osArchitecture, out string message)
     {
         var text = Normalize(output);
 
-        // Firmware virtualization off (VT-x/AMD-V disabled in BIOS/UEFI).
+        // Firmware virtualization off.
         // wsl.exe emits this when the Windows feature is installed but the
         // CPU virtualization extension is turned off; remediation requires
         // a trip into firmware settings, not `wsl --install`.
         if (Contains(text, "virtualization is not enabled"))
         {
             message = "WSL2 requires hardware virtualization, but it is disabled in firmware. "
-                + "Enable VT-x/AMD-V (Intel VT or AMD SVM) in your computer's BIOS/UEFI settings, "
-                + "reboot, then retry setup.";
+                + GetVirtualizationDisabledRemediation(osArchitecture);
             return true;
         }
 
@@ -124,6 +127,14 @@ internal static class WslInstallSupport
 
         static bool Contains(string haystack, string needle)
             => haystack.Contains(needle, StringComparison.OrdinalIgnoreCase);
+
+        static string GetVirtualizationDisabledRemediation(Architecture architecture)
+            => architecture == Architecture.Arm64
+                ? "Enable virtualization in your device's UEFI settings (look for 'Virtualization Support' or similar). "
+                    + "On managed ARM64 devices, this may be controlled by your organization's Intune policy "
+                    + "(Memory Integrity / Pluton / HVCI). Reboot, then retry setup."
+                : "Enable VT-x/AMD-V (Intel VT or AMD SVM) in your computer's BIOS/UEFI settings, "
+                    + "reboot, then retry setup.";
     }
 
     public static string[] BuildDirectInstallArgs(string baseDistro, string distroName, string installPath)

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -1,6 +1,7 @@
 using OpenClaw.Connection;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 
 namespace OpenClaw.SetupEngine.Tests;
 
@@ -512,9 +513,28 @@ public class SetupStepsTests : IDisposable
             "WSL2 is unable to start since virtualization is not enabled on this machine. "
             + "Please ensure the 'Virtual Machine Platform' optional component is enabled "
             + "and virtualization is turned on in your computer's firmware settings.",
+            Architecture.X64,
             out var message));
         Assert.Contains("BIOS", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("VT-x", message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("virtualization", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void WslInstallSupport_TryGetEnvironmentIssue_UsesArm64FirmwareWordingOnArm64()
+    {
+        Assert.True(WslInstallSupport.TryGetEnvironmentIssue(
+            "WSL2 is unable to start since virtualization is not enabled on this machine. "
+            + "Please ensure the 'Virtual Machine Platform' optional component is enabled "
+            + "and virtualization is turned on in your computer's firmware settings.",
+            Architecture.Arm64,
+            out var message));
+        Assert.Contains("ARM64", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("UEFI", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Virtualization Support", message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("VT-x", message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("AMD-V", message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("SVM", message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -561,7 +581,6 @@ public class SetupStepsTests : IDisposable
 
         Assert.Equal(StepOutcome.FailedTerminal, result.Outcome);
         Assert.Contains("virtualization", result.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("BIOS", result.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #593.

## Summary
- Branches the `preflight-wsl` virtualization-disabled remediation wording on `RuntimeInformation.OSArchitecture`.
- Keeps existing VT-x/AMD-V BIOS guidance for x64/x86 and uses UEFI/managed-device wording for ARM64.
- Adds focused SetupEngine tests for both x64 and ARM64 wording, including assertions that ARM64 copy omits VT-x, AMD-V, and SVM.

## Review
- Fix size: small/tiny surgical change, >=95% confidence.
- Two critical review passes completed: checked user-impact wording, x64 behavior preservation, overengineering risk, testability, and the pre-existing localized WSL-output concern. Locale/HRESULT detection remains out of scope because this PR only changes copy after the existing branch fires.

## Validation
- `OPENCLAW_REPO_ROOT` set to this worktree.
- `./build.ps1` passed via short local junction to the same worktree; direct long-path run hit a WinUI MakePri path-length failure at a 266-character generated `.pri.xml` path.
- `dotnet build ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj`, then `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore --no-build`: 2074 total, 0 failed, 2045 succeeded, 29 skipped.
- `dotnet build ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj`, then `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore --no-build`: 934 total, 0 failed.
- `dotnet build ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj`, then `dotnet test ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj --no-restore --no-build`: 198 total, 0 failed.