### PR TITLE
fix(release): source ARM64 VC runtime from VS install, ship ARM64 portable ZIP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,6 +399,15 @@ jobs:
       shell: pwsh
       run: .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath publish -RequireAppLocalVCRuntime
 
+    - name: Verify ARM64 Native Runtime Payload
+      if: matrix.rid == 'win-arm64'
+      shell: pwsh
+      # -SkipNativeLoadProbe: an ARM64 runner CAN LoadLibrary ARM64 DLLs, but
+      # libsodium pulls in a long native dependency chain that may not all be
+      # in the payload here (WindowsAppSDK pieces, etc.). The probe is for x64
+      # parity; signature + presence is what we actually care about.
+      run: .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath publish -RequireAppLocalVCRuntime -SkipNativeLoadProbe
+
     - name: Verify GitVersion assembly metadata
       shell: pwsh
       run: |
@@ -608,6 +617,13 @@ jobs:
       shell: pwsh
       run: .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath artifacts/tray-win-x64 -RequireAppLocalVCRuntime
 
+    - name: Verify ARM64 Release Native Dependencies
+      shell: pwsh
+      # -SkipNativeLoadProbe: this release job runs on the x64 windows-latest
+      # runner and cannot LoadLibrary an ARM64 DLL. The signature and presence
+      # checks still run.
+      run: .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath artifacts/tray-win-arm64 -RequireAppLocalVCRuntime -SkipNativeLoadProbe
+
     - name: Download Visual C++ Runtime Redistributables
       shell: pwsh
       run: |
@@ -628,10 +644,18 @@ jobs:
           }
         }
 
-    # Create ZIP file for Updatum auto-update (needs "win-x64" in filename)
+    # Create ZIP files for Updatum auto-update (asset name must contain the RID).
+    # We ship both x64 and arm64 portables now that the build job produces a
+    # libsodium-compatible app-local VC runtime for both architectures (the
+    # arm64 leg sources its loose Microsoft.VC*.CRT DLLs from the VS install
+    # on the windows-11-arm runner; see src/Directory.Build.targets).
     - name: Create x64 Release ZIP
       run: |
         Compress-Archive -Path artifacts/tray-win-x64/* -DestinationPath OpenClawTray-${{ needs.test.outputs.semVer }}-win-x64.zip
+
+    - name: Create arm64 Release ZIP
+      run: |
+        Compress-Archive -Path artifacts/tray-win-arm64/* -DestinationPath OpenClawTray-${{ needs.test.outputs.semVer }}-win-arm64.zip
 
     # Inno Setup installer for x64
     - name: Install Inno Setup
@@ -651,7 +675,10 @@ jobs:
         # Prepare arm64 files
         mkdir publish-arm64
         copy artifacts/tray-win-arm64/* publish-arm64/ -Recurse
-        .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath publish-arm64 -RequireInstallerVCRedist -InstallerVCRedistPath vc_redist.arm64.exe -SkipNativeLoadProbe
+        # -RequireAppLocalVCRuntime: arm64 payload now ships VC runtime DLLs from the build job.
+        # -SkipNativeLoadProbe:      this verifier runs on the x64 release runner and cannot
+        #                             LoadLibrary an arm64 DLL.
+        .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath publish-arm64 -RequireAppLocalVCRuntime -RequireInstallerVCRedist -InstallerVCRedistPath vc_redist.arm64.exe -SkipNativeLoadProbe
         # Build installer
         & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion=${{ needs.test.outputs.majorMinorPatch }} /DMyAppArch=arm64 /Dpublish=publish-arm64 /DvcRedist=vc_redist.arm64.exe installer.iss
 
@@ -675,6 +702,7 @@ jobs:
           Output/OpenClawCompanion-Setup-x64.exe
           Output/OpenClawCompanion-Setup-arm64.exe
           OpenClawTray-${{ needs.test.outputs.semVer }}-win-x64.zip
+          OpenClawTray-${{ needs.test.outputs.semVer }}-win-arm64.zip
         prerelease: ${{ contains(github.ref_name, '-') }}
         make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
         body: |
@@ -684,6 +712,7 @@ jobs:
           - **Installer (x64)**: `OpenClawCompanion-Setup-x64.exe` - Intel/AMD 64-bit
           - **Installer (ARM64)**: `OpenClawCompanion-Setup-arm64.exe` - Windows on ARM (Surface, etc.)
           - **Portable x64**: `OpenClawTray-${{ needs.test.outputs.semVer }}-win-x64.zip`
+          - **Portable ARM64**: `OpenClawTray-${{ needs.test.outputs.semVer }}-win-arm64.zip`
 
           ### Features
           - 🦞 System tray integration with gateway status

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -69,8 +69,9 @@ For the current alpha flow, ship only:
 - Inno setup installers:
   - `OpenClawCompanion-Setup-x64.exe`
   - `OpenClawCompanion-Setup-arm64.exe`
-- Portable ZIP payload for Updatum:
+- Portable ZIP payloads for Updatum:
   - `OpenClawTray-<version>-win-x64.zip`
+  - `OpenClawTray-<version>-win-arm64.zip`
 
 MSIX artifacts are intentionally paused for alpha while we focus on the Inno
 installer path and signed portable update payloads. Re-enable MSIX only when we
@@ -99,15 +100,18 @@ CI enforces this with `scripts\Test-ReleaseExecutableSignatures.ps1`. The
 verifier fails closed on unknown `.exe` files so future payload changes are
 reviewed deliberately.
 
-CI also checks native runtime dependencies before release packaging. The x64
-portable payload must ship `vcruntime140.dll` next to every `libsodium.dll`
-copy. The release job must Authenticode-verify Microsoft's x64 and ARM64 Visual
-C++ Runtime redistributables before passing the architecture-matching
-redistributable to Inno. The installer runs the redistributable before launching
-the tray so clean or stale Windows hosts can repair the runtime before Ed25519
-device keys are generated or loaded, and it skips the post-install tray launch
-if the runtime installer fails. ARM64 portable ZIPs are paused until the release
-pipeline has a trusted app-local ARM64 VC runtime source.
+CI also checks native runtime dependencies before release packaging. Both the
+x64 and ARM64 portable payloads must ship `vcruntime140.dll` next to every
+`libsodium.dll` copy. The x64 build leg sources its loose VC runtime DLLs from
+the `VCRuntime.CefSharp.140` NuGet package; the ARM64 build leg sources its
+DLLs from the Visual Studio install on the `windows-11-arm` runner (resolved
+via `vswhere` in `src\Directory.Build.targets`). The release job must
+Authenticode-verify Microsoft's x64 and ARM64 Visual C++ Runtime
+redistributables before passing the architecture-matching redistributable to
+Inno. The installer runs the redistributable before launching the tray so
+clean or stale Windows hosts can repair the runtime before Ed25519 device keys
+are generated or loaded, and it skips the post-install tray launch if the
+runtime installer fails.
 
 The current Azure Artifact Signing resource is:
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -4,15 +4,72 @@
     <OpenClawVCRuntimePackageVersion>1.0.5</OpenClawVCRuntimePackageVersion>
     <OpenClawVCRuntimePackageRoot>$(NuGetPackageRoot)vcruntime.cefsharp.140\$(OpenClawVCRuntimePackageVersion)\vc_redist\</OpenClawVCRuntimePackageRoot>
     <OpenClawVCRuntimeArch Condition="'$(RuntimeIdentifier)' == 'win-x64'">x64</OpenClawVCRuntimeArch>
+    <OpenClawVCRuntimeArch Condition="'$(RuntimeIdentifier)' == 'win-arm64'">arm64</OpenClawVCRuntimeArch>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(OpenClawVCRuntimeArch)' != ''">
-    <OpenClawVCRuntimeFiles Include="$(OpenClawVCRuntimePackageRoot)$(OpenClawVCRuntimeArch)\*.dll" />
+  <!--
+    x64 ships loose VC runtime DLLs sourced from the VCRuntime.CefSharp.140
+    NuGet package, so devs don't need a Visual Studio install to build/publish.
+
+    ARM64 is resolved at publish time from the local Visual Studio install via
+    ResolveOpenClawVCRuntimeArm64FromVSInstall — the existing NuGet ships no
+    ARM64 binaries and Microsoft does not publish a comparable NuGet for the
+    loose ARM64 redist DLLs.
+
+    Local 'dotnet build -r win-arm64' intentionally does NOT require a VS
+    install (so cross-compile sanity checks keep working on x64 dev boxes).
+    The VS-install requirement only kicks in at publish time, which is what
+    the release pipeline actually runs on the windows-11-arm runner.
+  -->
+  <ItemGroup Condition="'$(OpenClawVCRuntimeArch)' == 'x64'">
+    <OpenClawVCRuntimeFiles Include="$(OpenClawVCRuntimePackageRoot)x64\*.dll" />
   </ItemGroup>
+
+  <Target Name="ResolveOpenClawVCRuntimeArm64FromVSInstall"
+          Condition="'$(OpenClawVCRuntimeArch)' == 'arm64'">
+
+    <PropertyGroup>
+      <_OpenClawVsWherePath>$(MSBuildProgramFiles32)\Microsoft Visual Studio\Installer\vswhere.exe</_OpenClawVsWherePath>
+    </PropertyGroup>
+
+    <Error Condition="!Exists('$(_OpenClawVsWherePath)')"
+           Text="vswhere.exe not found at '$(_OpenClawVsWherePath)'. Publishing for win-arm64 requires a Visual Studio install with the C++ Redistributable (Microsoft.VisualStudio.Component.VC.Redist.14.Latest) component. Install Visual Studio 2022 or later with that component, or publish for win-x64 instead." />
+
+    <Exec Command="&quot;$(_OpenClawVsWherePath)&quot; -latest -products * -requires Microsoft.VisualStudio.Component.VC.Redist.14.Latest -property installationPath"
+          ConsoleToMSBuild="true"
+          IgnoreExitCode="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_OpenClawVsInstallRoot" />
+    </Exec>
+
+    <Error Condition="'$(_OpenClawVsInstallRoot)' == '' or !Exists('$(_OpenClawVsInstallRoot)')"
+           Text="vswhere did not find a Visual Studio install with the C++ Redistributable (Microsoft.VisualStudio.Component.VC.Redist.14.Latest) component (got '$(_OpenClawVsInstallRoot)'). Install that component via the Visual Studio Installer (Individual Components tab), or publish for win-x64 instead." />
+
+    <!--
+      Glob the loose CRT DLLs. The Microsoft.VC*.CRT folder name carries the VS
+      major version (Microsoft.VC143.CRT for VS 2022, Microsoft.VC145.CRT for
+      VS 18). There is at most one Microsoft.VC*.CRT subdir per arch per redist
+      version, so the * collapses to a single match. We limit to
+      vcruntime140*.dll + msvcp140*.dll to match the file set the x64 NuGet
+      ships (concrt140/vccorlib140/vcruntime140_threads aren't needed by
+      libsodium and aren't in the x64 payload either).
+    -->
+    <ItemGroup>
+      <OpenClawVCRuntimeFiles Include="$(_OpenClawVsInstallRoot)\VC\Redist\MSVC\*\arm64\Microsoft.VC*.CRT\vcruntime140*.dll" />
+      <OpenClawVCRuntimeFiles Include="$(_OpenClawVsInstallRoot)\VC\Redist\MSVC\*\arm64\Microsoft.VC*.CRT\msvcp140*.dll" />
+    </ItemGroup>
+
+    <Error Condition="'@(OpenClawVCRuntimeFiles)' == ''"
+           Text="No ARM64 VC++ Runtime DLLs were found under '$(_OpenClawVsInstallRoot)\VC\Redist\MSVC\*\arm64\Microsoft.VC*.CRT\'. Install the 'C++ ARM64/ARM64EC build tools' and 'C++ Redistributable Update' Visual Studio components." />
+  </Target>
 
   <Target Name="CopyOpenClawVCRuntimeToOutput"
           AfterTargets="Build"
-          Condition="'$(OpenClawVCRuntimeArch)' != '' and '@(OpenClawVCRuntimeFiles)' != ''">
+          Condition="'$(OpenClawVCRuntimeArch)' == 'x64' and '@(OpenClawVCRuntimeFiles)' != ''">
+    <!--
+      x64-only on purpose. ARM64 publishes its runtime through the publish-only
+      target below so that local 'dotnet build -r win-arm64' does not require
+      a Visual Studio install.
+    -->
     <Copy SourceFiles="@(OpenClawVCRuntimeFiles)"
           DestinationFolder="$(TargetDir)"
           SkipUnchangedFiles="true" />
@@ -20,7 +77,8 @@
 
   <Target Name="CopyOpenClawVCRuntimeToPublish"
           AfterTargets="Publish"
-          Condition="'$(PublishDir)' != '' and '$(OpenClawVCRuntimeArch)' != '' and '@(OpenClawVCRuntimeFiles)' != ''">
+          DependsOnTargets="ResolveOpenClawVCRuntimeArm64FromVSInstall"
+          Condition="'$(PublishDir)' != '' and '$(OpenClawVCRuntimeArch)' != ''">
     <Copy SourceFiles="@(OpenClawVCRuntimeFiles)"
           DestinationFolder="$(PublishDir)"
           SkipUnchangedFiles="true" />

--- a/tests/OpenClaw.Tray.Tests/ReleaseSigningWorkflowTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ReleaseSigningWorkflowTests.cs
@@ -59,17 +59,18 @@ public sealed class ReleaseSigningWorkflowTests
 
         Assert.Contains("Test-ReleaseNativeDependencies.ps1 -PayloadPath publish -RequireAppLocalVCRuntime", workflow);
         Assert.Contains("Test-ReleaseNativeDependencies.ps1 -PayloadPath artifacts/tray-win-x64 -RequireAppLocalVCRuntime", workflow);
+        Assert.Contains("Test-ReleaseNativeDependencies.ps1 -PayloadPath artifacts/tray-win-arm64 -RequireAppLocalVCRuntime -SkipNativeLoadProbe", workflow);
         Assert.Contains("https://aka.ms/vc14/vc_redist.x64.exe", workflow);
         Assert.Contains("https://aka.ms/vc14/vc_redist.arm64.exe", workflow);
         Assert.Contains("Get-AuthenticodeSignature -LiteralPath $redist.Path", workflow);
         Assert.Contains("O=Microsoft Corporation", workflow);
         Assert.Contains("-InstallerVCRedistPath vc_redist.x64.exe", workflow);
-        Assert.Contains("publish-arm64 -RequireInstallerVCRedist -InstallerVCRedistPath vc_redist.arm64.exe -SkipNativeLoadProbe", workflow);
+        Assert.Contains("publish-arm64 -RequireAppLocalVCRuntime -RequireInstallerVCRedist -InstallerVCRedistPath vc_redist.arm64.exe -SkipNativeLoadProbe", workflow);
         Assert.Contains("/DvcRedist=vc_redist.x64.exe", workflow);
         Assert.Contains("/DvcRedist=vc_redist.arm64.exe", workflow);
         Assert.DoesNotContain("copy vc_redist.x64.exe publish-x64", workflow);
         Assert.DoesNotContain("copy vc_redist.x64.exe publish-arm64", workflow);
-        Assert.DoesNotContain("win-arm64.zip", workflow);
+        Assert.Contains("OpenClawTray-${{ needs.test.outputs.semVer }}-win-arm64.zip", workflow);
         Assert.Contains("AfterInstall: InstallVCRuntime", installer);
         Assert.Contains("Exec(", installer);
         Assert.Contains("ResultCode = 3010", installer);
@@ -83,6 +84,7 @@ public sealed class ReleaseSigningWorkflowTests
         Assert.Contains("OpenClawNativeDependencyProbe", verifier);
         Assert.Contains("SkipNativeLoadProbe", verifier);
         Assert.Contains("CopyOpenClawVCRuntimeToPublish", targets);
+        Assert.Contains("ResolveOpenClawVCRuntimeArm64FromVSInstall", targets);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

The `VCRuntime.CefSharp.140` NuGet that supplies our x64 app-local VC++ Runtime DLLs **ships no ARM64 binaries**, and Microsoft does not publish a NuGet alternative. Previously we worked around this by **pausing the ARM64 portable ZIP entirely** — only the ARM64 installer (with bundled `vc_redist.arm64.exe`) shipped, leaving Updatum portable updates broken for ARM64 users.

The `windows-11-arm` CI runner already has **Visual Studio with the C++ Redistributable component** installed, which lays down loose `Microsoft.VC*.CRT\arm64\*.dll` files signed by Microsoft. This PR resolves those at publish time via `vswhere` and copies them app-local next to `libsodium.dll`, mirroring what the NuGet does for x64.

## Design notes

- **`vswhere` is the canonical entry point** — ships with every Visual Studio Installer at a stable path; works regardless of edition (Community/Professional/Enterprise) and across VS major versions (`Microsoft.VC143.CRT` for VS 2022, `Microsoft.VC145.CRT` for VS 18). The glob `VC\Redist\MSVC\*\arm64\Microsoft.VC*.CRT\*.dll` handles both.
- **VS install required only at *publish* time, not at *build* time** — local `dotnet build -r win-arm64` (e.g. cross-compile sanity check on an x64 dev box) keeps working without a VS install. The strict check kicks in only when producing a deployable payload. See the `CopyOpenClawVCRuntimeToOutput` condition (x64-only) vs. `CopyOpenClawVCRuntimeToPublish` (both arches).
- **x64 path unchanged** — still sources from the `VCRuntime.CefSharp.140` NuGet, no Visual Studio dependency for x64 publishes.

## Files

- `src/Directory.Build.targets` — new `ResolveOpenClawVCRuntimeArm64FromVSInstall` target with clear errors when vswhere/VS/component are missing
- `.github/workflows/ci.yml` — ARM64 build + release verify both gain `-RequireAppLocalVCRuntime`; new `Create arm64 Release ZIP` step; new ZIP added to release files + body
- `docs/RELEASING.md` — removes the "ARM64 portable ZIPs paused" sentence; documents where ARM64 runtime DLLs come from
- `tests/OpenClaw.Tray.Tests/ReleaseSigningWorkflowTests.cs` — asserts the new ARM64 verifier call, the win-arm64.zip publish, and the new target name

## Local verification

On a dev box with VS 18 + ARM64 components installed:

```
dotnet publish .\src\OpenClaw.Tray.WinUI\OpenClaw.Tray.WinUI.csproj `
  -c Release -r win-arm64 --self-contained `
  -o publish-arm64-probe -v:minimal
```

All 9 expected DLLs landed in the publish dir (`vcruntime140*.dll`, `msvcp140*.dll`), every one with a valid `CN=Microsoft Corporation` Authenticode signature.

## Validation

- `.\build.ps1` ✅
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj` — 2045 passed, 29 skipped, 0 failed ✅
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj` — 934 passed, 0 failed ✅ (includes the updated `ReleaseSigningWorkflowTests`)

End-to-end ARM64 ZIP installation can only be fully validated by a tagged release that exercises the `windows-11-arm` runner — that's the next step.