### PR TITLE
한국어 윈도우 패치

### DIFF
--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -56,8 +56,8 @@ internal static class WslInstallSupport
     {
         var match = System.Text.RegularExpressions.Regex.Match(
             Normalize(output),
-            @"WSL\s+version:\s*(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?",
-            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+            @"^\s*WSL\s+\D*?(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Multiline);
 
         if (!match.Success)
         {

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -281,6 +281,20 @@ public class SetupStepsTests : IDisposable
     }
 
     [Fact]
+    public async Task PreflightWsl_SucceedsWithLocalizedVersionLabel()
+    {
+        var commands = new FakeCommandRunner(args =>
+            args is ["--version"]
+                ? Ok("WSL 버전: 2.7.3.0\n커널 버전: 6.6.114.1-1\nWSLg 버전: 1.0.73\n")
+                : Ok());
+        var ctx = CreateContext(commands: commands);
+
+        var result = await new PreflightWslStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.Success, result.Outcome);
+    }
+
+    [Fact]
     public async Task CreateWslInstance_UsesDirectFreshInstallAndDoesNotExportBaseDistro()
     {
         var installed = false;


### PR DESCRIPTION
## Summary

- Parse `wsl --version` output when Windows localizes the `version` label.
- Keep the parser anchored to the `WSL` line so it does not accidentally match `WSLg`.
- Add a regression test for Korean Windows output: `WSL 버전: 2.7.3.0`.

## Root cause

The preflight parser normalized NUL/BOM characters but still required the English label `WSL version:`. On non-English Windows installs, `wsl.exe --version` can emit localized labels, for example `WSL 버전: 2.7.3.0`, which caused setup to stop with:

`WSL version output did not include a parseable WSL version.`

## Korean Windows behavior proof

This was reproduced and verified on Korean Windows 10.0.26200 with WSL 2.7.3.0. Because the fix is not yet released, I applied the equivalent parser behavior to the installed setup engine, then reran setup.

Relevant redacted setup log lines:

```text
WSL version output: WSL 버전: 2.7.3.0
커널 버전: 6.6.114.1-1
WSLg 버전: 1.0.73
MSRDC 버전: 1.2.6676
Direct3D 버전: 1.611.1-81528511
DXCore 버전: 10.0.26100.1-240331-1435.ge-release
Windows 버전: 10.0.26200.8457

WSL direct named install is supported (version 2.7.3.0)
step.completed: preflight-wsl -> Success
step.completed: verify-e2e -> Success
step.completed: run-wizard -> Success
step.completed: start-keepalive -> Success
Pipeline completed successfully in 191.4s
```

Post-setup live gateway proof from the same machine:

```text
OpenClaw 2026.5.28 (e932160)
openclaw gateway status --json
service.loaded=true
service.loadedText=enabled
programArguments=[... "openclaw/dist/index.js", "gateway", "--port", "18789"]
```

## Validation

Environment: Windows 10.0.26200, .NET SDK 10.0.108 installed user-local via `dotnet-install.ps1`.

```text
dotnet --info
.NET SDK Version: 10.0.108
OS Version: 10.0.26200
RID: win-x64
```

Required repository validation:

```text
./build.ps1
Shared built successfully
Cli built successfully
WinNodeCli built successfully
SetupEngine built successfully
WinUI built successfully
All builds succeeded
```

```text
dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore
Passed: 2045, Failed: 0, Skipped: 29, Total: 2074
```

```text
dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
Passed: 934, Failed: 0, Total: 934
```

Focused regression validation for this PR:

```text
dotnet test ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj --filter PreflightWsl
Passed: 6, Failed: 0, Total: 6

PreflightWsl_SucceedsWithLocalizedVersionLabel passed
Logged parsed localized output:
WSL 버전: 2.7.3.0
WSLg 버전: 1.0.73
WSL direct named install is supported (version 2.7.3.0)
```
