### PR TITLE
fix(setup): parse WSL version independent of locale and accept hyphenated/localized labels

### DIFF
--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -37,6 +37,12 @@ internal static class WslConstants
 internal static class WslInstallSupport
 {
     private static readonly Version s_minDirectNamedInstallVersion = new(2, 4, 4);
+    private static readonly System.Text.RegularExpressions.Regex s_wslProductTokenRegex = new(
+        @"(?<![A-Za-z0-9])WSL(?![A-Za-z0-9])",
+        System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.CultureInvariant);
+    private static readonly System.Text.RegularExpressions.Regex s_semanticVersionRegex = new(
+        @"(?<![\d.])(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?(?![\d.])",
+        System.Text.RegularExpressions.RegexOptions.CultureInvariant);
     public const string UpdateUrl = "https://aka.ms/wslstorepage";
 
     public static string UpdateInstructions
@@ -54,33 +60,38 @@ internal static class WslInstallSupport
 
     public static bool TryParseWslVersion(string output, out Version version)
     {
-        // WSL outputs UTF-16LE on some Windows builds; after NUL-stripping the label may
-        // appear as the hyphenated form "WSL-Version:" instead of the English space form
-        // "WSL version:".  On non-English Windows, wsl.exe can also emit a fully localized
-        // label (e.g. German "WSL-Version:", Spanish "Versión de WSL:") or similar.
-        // The alternation below covers the confirmed variants without over-matching
-        // unrelated numeric output.
-        var match = System.Text.RegularExpressions.Regex.Match(
-            Normalize(output),
-            @"(?:WSL[\s\-]+version|vers[ií][oó]n\s+de\s+wsl):\s*(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?",
-            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-
-        if (!match.Success)
+        // Match the product token and version shape instead of localized label text.
+        // WSL is the stable product acronym; labels around it vary by Windows language
+        // and by UTF-16LE/NUL-stripped output shape.
+        foreach (var rawLine in Normalize(output).Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
         {
-            version = new Version();
-            return false;
+            var line = rawLine.Trim();
+            if (!s_wslProductTokenRegex.IsMatch(line))
+                continue;
+
+            var match = s_semanticVersionRegex.Match(line);
+            if (!match.Success)
+                continue;
+
+            version = ParseVersionMatch(match);
+            return true;
         }
 
+        version = new Version();
+        return false;
+    }
+
+    private static Version ParseVersionMatch(System.Text.RegularExpressions.Match match)
+    {
         var major = int.Parse(match.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
         var minor = int.Parse(match.Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture);
         var build = int.Parse(match.Groups[3].Value, System.Globalization.CultureInfo.InvariantCulture);
         var revision = match.Groups[4].Success
             ? int.Parse(match.Groups[4].Value, System.Globalization.CultureInfo.InvariantCulture)
             : -1;
-        version = revision >= 0
+        return revision >= 0
             ? new Version(major, minor, build, revision)
             : new Version(major, minor, build);
-        return true;
     }
 
     public static bool SupportsDirectNamedInstall(Version version)

--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -54,9 +54,15 @@ internal static class WslInstallSupport
 
     public static bool TryParseWslVersion(string output, out Version version)
     {
+        // WSL outputs UTF-16LE on some Windows builds; after NUL-stripping the label may
+        // appear as the hyphenated form "WSL-Version:" instead of the English space form
+        // "WSL version:".  On non-English Windows, wsl.exe can also emit a fully localized
+        // label (e.g. German "WSL-Version:", Spanish "Versión de WSL:") or similar.
+        // The alternation below covers the confirmed variants without over-matching
+        // unrelated numeric output.
         var match = System.Text.RegularExpressions.Regex.Match(
             Normalize(output),
-            @"WSL\s+version:\s*(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?",
+            @"(?:WSL[\s\-]+version|vers[ií][oó]n\s+de\s+wsl):\s*(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?",
             System.Text.RegularExpressions.RegexOptions.IgnoreCase);
 
         if (!match.Success)

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -505,6 +505,36 @@ public class SetupStepsTests : IDisposable
         Assert.Equal(2, distroVersion);
     }
 
+    // Regression: wsl.exe emits UTF-16LE on some Windows builds; after NUL-stripping
+    // the label becomes "WSL-Version:" (hyphenated). Non-English Windows also uses
+    // fully localized labels (e.g. Spanish "Versión de WSL:"). All variants must parse.
+    [Theory]
+    [InlineData("WSL version: 2.7.3.0")]                       // English (space)
+    [InlineData("WSL-Version: 2.7.7.0")]                       // German / NUL-stripped UTF-16
+    [InlineData("WSL-Version: 2.7.7.0\nKernelversion: 6.18.26.1-1\nWSLg-Version: 1.0.73.2\nWindows-Version: 10.0.26300.8553")] // German full block
+    [InlineData("Versión de WSL: 2.7.3.0")]                    // Spanish localized
+    [InlineData("Versión de WSL: 2.7.3.0\nKernel: 5.15.0.1")]  // Spanish with trailing lines
+    public void WslInstallSupport_TryParseWslVersion_HandlesLocalizedAndHyphenatedLabels(string output)
+    {
+        Assert.True(WslInstallSupport.TryParseWslVersion(output, out var version),
+            $"Expected TryParseWslVersion to succeed for: {output}");
+        Assert.True(WslInstallSupport.SupportsDirectNamedInstall(version),
+            $"Expected parsed version {version} to satisfy minimum install requirement");
+    }
+
+    [Theory]
+    [InlineData("WSL-Version: 2.7.7.0")]
+    [InlineData("Versión de WSL: 2.7.3.0")]
+    public void WslInstallSupport_TryParseWslVersion_NulStrippedUtf16_ParsesCorrectVersion(string raw)
+    {
+        // Simulate UTF-16LE NUL-byte injection then NUL-stripping.
+        var utf16Encoded = string.Join("\0", raw.ToCharArray()) + "\0";
+        var stripped = utf16Encoded.Replace("\0", "");
+        Assert.True(WslInstallSupport.TryParseWslVersion(stripped, out var version),
+            $"Expected TryParseWslVersion to succeed for NUL-stripped: {raw}");
+        Assert.True(version >= new Version(2, 4, 4));
+    }
+
     [Fact]
     public void WslInstallSupport_TryGetEnvironmentIssue_DetectsFirmwareVirtualizationOff()
     {

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -496,6 +496,7 @@ public class SetupStepsTests : IDisposable
     public void WslInstallSupport_ParsesVersionAndVerboseDistroList()
     {
         Assert.True(WslInstallSupport.TryParseWslVersion("WSL version: 2.7.3.0", out var version));
+        Assert.Equal(new Version(2, 7, 3, 0), version);
         Assert.True(WslInstallSupport.SupportsDirectNamedInstall(version));
 
         Assert.True(WslInstallSupport.TryGetDistroVersion(
@@ -505,34 +506,58 @@ public class SetupStepsTests : IDisposable
         Assert.Equal(2, distroVersion);
     }
 
-    // Regression: wsl.exe emits UTF-16LE on some Windows builds; after NUL-stripping
-    // the label becomes "WSL-Version:" (hyphenated). Non-English Windows also uses
-    // fully localized labels (e.g. Spanish "Versión de WSL:"). All variants must parse.
+    // Regression: wsl.exe emits UTF-16LE on some Windows builds, and localized
+    // Windows changes the human-readable label around the stable WSL product token.
     [Theory]
-    [InlineData("WSL version: 2.7.3.0")]                       // English (space)
-    [InlineData("WSL-Version: 2.7.7.0")]                       // German / NUL-stripped UTF-16
-    [InlineData("WSL-Version: 2.7.7.0\nKernelversion: 6.18.26.1-1\nWSLg-Version: 1.0.73.2\nWindows-Version: 10.0.26300.8553")] // German full block
-    [InlineData("Versión de WSL: 2.7.3.0")]                    // Spanish localized
-    [InlineData("Versión de WSL: 2.7.3.0\nKernel: 5.15.0.1")]  // Spanish with trailing lines
-    public void WslInstallSupport_TryParseWslVersion_HandlesLocalizedAndHyphenatedLabels(string output)
+    [InlineData("WSL version: 2.7.3.0", "2.7.3.0")]                       // English
+    [InlineData("WSL-Version: 2.7.7.0", "2.7.7.0")]                       // German / NUL-stripped UTF-16
+    [InlineData("WSL-Version: 2.7.7.0\nKernelversion: 6.18.26.1-1\nWSLg-Version: 1.0.73.2\nWindows-Version: 10.0.26300.8553", "2.7.7.0")]
+    [InlineData("Versión de WSL: 2.7.3.0", "2.7.3.0")]                    // Spanish
+    [InlineData("Versión de WSL: 2.7.3.0\nKernel: 5.15.0.1", "2.7.3.0")]  // Spanish with trailing lines
+    [InlineData("WSL バージョン: 2.7.8.0", "2.7.8.0")]                    // Japanese-style label
+    [InlineData("WSL版本: 2.7.9.0", "2.7.9.0")]                          // No separator after WSL
+    public void WslInstallSupport_TryParseWslVersion_HandlesLocalizedAndHyphenatedLabels(string output, string expectedVersion)
     {
         Assert.True(WslInstallSupport.TryParseWslVersion(output, out var version),
             $"Expected TryParseWslVersion to succeed for: {output}");
+        Assert.Equal(Version.Parse(expectedVersion), version);
         Assert.True(WslInstallSupport.SupportsDirectNamedInstall(version),
             $"Expected parsed version {version} to satisfy minimum install requirement");
     }
 
     [Theory]
-    [InlineData("WSL-Version: 2.7.7.0")]
-    [InlineData("Versión de WSL: 2.7.3.0")]
-    public void WslInstallSupport_TryParseWslVersion_NulStrippedUtf16_ParsesCorrectVersion(string raw)
+    [InlineData("WSL-Version: 2.7.7.0", "2.7.7.0")]
+    [InlineData("Versión de WSL: 2.7.3.0", "2.7.3.0")]
+    public void WslInstallSupport_TryParseWslVersion_NulStrippedUtf16_ParsesCorrectVersion(string raw, string expectedVersion)
     {
         // Simulate UTF-16LE NUL-byte injection then NUL-stripping.
         var utf16Encoded = string.Join("\0", raw.ToCharArray()) + "\0";
         var stripped = utf16Encoded.Replace("\0", "");
         Assert.True(WslInstallSupport.TryParseWslVersion(stripped, out var version),
             $"Expected TryParseWslVersion to succeed for NUL-stripped: {raw}");
-        Assert.True(version >= new Version(2, 4, 4));
+        Assert.Equal(Version.Parse(expectedVersion), version);
+    }
+
+    [Fact]
+    public void WslInstallSupport_TryParseWslVersion_IgnoresAdjacentWslAndWindowsVersionLines()
+    {
+        var output = "WSLg-Version: 1.0.73.2\n"
+            + "Windows-Version: 10.0.26300.8553\n"
+            + "Kernelversion: 6.18.26.1-1\n"
+            + "WSL-Version: 2.7.7.0\n";
+
+        Assert.True(WslInstallSupport.TryParseWslVersion(output, out var version));
+        Assert.Equal(new Version(2, 7, 7, 0), version);
+    }
+
+    [Fact]
+    public void WslInstallSupport_TryParseWslVersion_FailsWhenOnlyAdjacentComponentVersionsArePresent()
+    {
+        var output = "WSLg-Version: 1.0.73.2\n"
+            + "Windows-Version: 10.0.26300.8553\n"
+            + "Kernelversion: 6.18.26.1-1\n";
+
+        Assert.False(WslInstallSupport.TryParseWslVersion(output, out _));
     }
 
     [Fact]


### PR DESCRIPTION
Ports the two fix commits from `repo-assist/fix-issue-661-wsl-localized-version-564657b90072bd36` into `master`.

**Problem:**
preflight-wsl fails on WSL 2.5+ with UTF-16LE NUL-stripped output. The old regex only matched `"WSL version:"` (English, space-separated). NUL-stripped UTF-16 and localized Windows produce variant labels.

**Fix:**
Use WSL product token regex + semantic version regex, ignoring adjacent WSLg/Windows/Kernel version lines. Accept hyphenated `"WSL-Version:"` (German / NUL-stripped UTF-16), `"Versión de WSL:"` (Spanish), and other localized forms.

**Testing:** 7 new regression tests cover English, German/NUL-stripped, Spanish, Japanese, Chinese, NUL-byte simulation, and realistic multi-line wsl.exe --version output. All 208 SetupEngine.Tests pass.

Closes #661
