### PR TITLE
Add persistent Local Gateway setup card

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml
@@ -251,11 +251,38 @@
                     </Grid>
                 </Border>
 
-                <!-- ═════════ Local Gateway (conditional) ═════════ -->
+                <!-- ═════════ Local Gateway ═════════ -->
                 <TextBlock x:Uid="SettingsPage_LocalGateway" x:Name="LocalGatewaySectionHeader" Text="Local Gateway"
                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                           Margin="{StaticResource SectionHeaderMargin}"
-                           Visibility="Collapsed"/>
+                           Margin="{StaticResource SectionHeaderMargin}"/>
+
+                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1" CornerRadius="8"
+                        Padding="{StaticResource SettingsRowPadding}"
+                        AutomationProperties.AutomationId="LocalGatewaySetupCard">
+                    <Grid ColumnSpacing="14">
+                        <Grid.ColumnDefinitions>
+                           <ColumnDefinition Width="*"/>
+                           <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="2">
+                           <TextBlock x:Uid="SettingsPage_LocalGatewaySetup_Header"
+                                      Text="Set up or reconfigure Local Gateway"
+                                      Style="{StaticResource BodyTextBlockStyle}"/>
+                           <TextBlock x:Uid="SettingsPage_LocalGatewaySetup_Description"
+                                      Text="Launches setup to install an app-owned OpenClawGateway WSL distro or re-run provider and model setup for an existing one. Existing local gateways are only replaced after confirmation."
+                                      Style="{StaticResource CaptionTextBlockStyle}"
+                                      Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                      TextWrapping="Wrap"/>
+                        </StackPanel>
+                        <Button Grid.Column="1"
+                               x:Uid="SettingsPage_OpenLocalGatewaySetup"
+                               Content="Open setup"
+                               Click="OnOpenLocalGatewaySetup"
+                               AutomationProperties.AutomationId="OpenLocalGatewaySetupButton"/>
+                    </Grid>
+                </Border>
 
                 <Border x:Name="LocalGatewayExpander"
                         Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"

--- a/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml.cs
@@ -212,17 +212,21 @@ public sealed partial class SettingsPage : Page
     }
 
     /// <summary>
-    /// Returns Visible when a local gateway exists OR an uninstall has been initiated this
-    /// view session (latch). The latch prevents the section from collapsing mid-flight when
+    /// Returns Visible for the installed-gateway management card when a local gateway exists
+    /// OR an uninstall has been initiated this view session (latch). The latch prevents the
+    /// card from collapsing mid-flight when
     /// the engine deletes setup-state.json before the result InfoBar is shown.
-    /// Resets on page navigation — section hides again on clean Settings re-open.
+    /// Resets on page navigation — the card hides again on clean Settings re-open.
     /// </summary>
     private Visibility ComputeLocalGatewaySectionVisibility()
     {
-        var visibility = (_localGatewayInstalled || _uninstallInitiatedThisSession)
+        return (_localGatewayInstalled || _uninstallInitiatedThisSession)
             ? Visibility.Visible : Visibility.Collapsed;
-        LocalGatewaySectionHeader.Visibility = visibility;
-        return visibility;
+    }
+
+    private void OnOpenLocalGatewaySetup(object sender, RoutedEventArgs e)
+    {
+        ((IAppCommands)CurrentApp).ShowOnboarding();
     }
 
     private void OnTestNotification(object sender, RoutedEventArgs e)

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -4413,6 +4413,15 @@ On your gateway host (Mac/Linux), run:
   <data name="SettingsPage_LocalGateway.Text" xml:space="preserve">
     <value>Local Gateway</value>
   </data>
+  <data name="SettingsPage_LocalGatewaySetup_Header.Text" xml:space="preserve">
+    <value>Set up or reconfigure Local Gateway</value>
+  </data>
+  <data name="SettingsPage_LocalGatewaySetup_Description.Text" xml:space="preserve">
+    <value>Launches setup to install an app-owned OpenClawGateway WSL distro or re-run provider and model setup for an existing one. Existing local gateways are only replaced after confirmation.</value>
+  </data>
+  <data name="SettingsPage_OpenLocalGatewaySetup.Content" xml:space="preserve">
+    <value>Open setup</value>
+  </data>
   <data name="SettingsPage_MSIXInstallationDetected.Title" xml:space="preserve">
     <value>MSIX installation detected</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -4365,6 +4365,15 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="SettingsPage_LocalGateway.Text" xml:space="preserve">
     <value>Passerelle locale</value>
   </data>
+  <data name="SettingsPage_LocalGatewaySetup_Header.Text" xml:space="preserve">
+    <value>Configurer ou reconfigurer la passerelle locale</value>
+  </data>
+  <data name="SettingsPage_LocalGatewaySetup_Description.Text" xml:space="preserve">
+    <value>Lance la configuration pour installer une distribution WSL OpenClawGateway appartenant a l'application, ou relancer la configuration des fournisseurs et modeles pour une passerelle existante. Les passerelles locales existantes ne sont remplacees qu'apres confirmation.</value>
+  </data>
+  <data name="SettingsPage_OpenLocalGatewaySetup.Content" xml:space="preserve">
+    <value>Ouvrir la configuration</value>
+  </data>
   <data name="SettingsPage_MSIXInstallationDetected.Title" xml:space="preserve">
     <value>Installation MSIX détectée</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -4366,6 +4366,15 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="SettingsPage_LocalGateway.Text" xml:space="preserve">
     <value>Lokale gateway</value>
   </data>
+  <data name="SettingsPage_LocalGatewaySetup_Header.Text" xml:space="preserve">
+    <value>Lokale gateway instellen of opnieuw configureren</value>
+  </data>
+  <data name="SettingsPage_LocalGatewaySetup_Description.Text" xml:space="preserve">
+    <value>Start de setup om een app-beheerde OpenClawGateway WSL-distributie te installeren, of de provider- en modelsetup opnieuw uit te voeren voor een bestaande gateway. Bestaande lokale gateways worden alleen na bevestiging vervangen.</value>
+  </data>
+  <data name="SettingsPage_OpenLocalGatewaySetup.Content" xml:space="preserve">
+    <value>Setup openen</value>
+  </data>
   <data name="SettingsPage_MSIXInstallationDetected.Title" xml:space="preserve">
     <value>MSIX-installatie gedetecteerd</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -4365,6 +4365,15 @@
   <data name="SettingsPage_LocalGateway.Text" xml:space="preserve">
     <value>本地网关</value>
   </data>
+  <data name="SettingsPage_LocalGatewaySetup_Header.Text" xml:space="preserve">
+    <value>设置或重新配置本地网关</value>
+  </data>
+  <data name="SettingsPage_LocalGatewaySetup_Description.Text" xml:space="preserve">
+    <value>启动设置以安装由应用管理的 OpenClawGateway WSL 发行版，或为现有网关重新运行提供商和模型设置。只有在确认后才会替换现有本地网关。</value>
+  </data>
+  <data name="SettingsPage_OpenLocalGatewaySetup.Content" xml:space="preserve">
+    <value>打开设置</value>
+  </data>
   <data name="SettingsPage_MSIXInstallationDetected.Title" xml:space="preserve">
     <value>检测到 MSIX 安装</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -4365,6 +4365,15 @@
   <data name="SettingsPage_LocalGateway.Text" xml:space="preserve">
     <value>本機閘道</value>
   </data>
+  <data name="SettingsPage_LocalGatewaySetup_Header.Text" xml:space="preserve">
+    <value>設定或重新設定本機閘道</value>
+  </data>
+  <data name="SettingsPage_LocalGatewaySetup_Description.Text" xml:space="preserve">
+    <value>啟動設定以安裝由應用程式管理的 OpenClawGateway WSL 散發版，或為現有閘道重新執行提供者和模型設定。只有在確認後才會取代現有本機閘道。</value>
+  </data>
+  <data name="SettingsPage_OpenLocalGatewaySetup.Content" xml:space="preserve">
+    <value>開啟設定</value>
+  </data>
   <data name="SettingsPage_MSIXInstallationDetected.Title" xml:space="preserve">
     <value>偵測到 MSIX 安裝</value>
   </data>


### PR DESCRIPTION
## Summary

Adds a persistent **Local Gateway** setup card to the Settings page so users can always relaunch setup after installing a local WSL gateway. Previously, the setup/reconfigure affordance was hidden once an app-owned WSL gateway existed, making it harder to discover how to rerun setup or provider/model configuration.

The new card:

- Always appears in the Settings page's Local Gateway section.
- Uses clear copy explaining that it launches setup for a new app-owned `OpenClawGateway` WSL distro or reruns provider/model setup for an existing local gateway.
- Reuses the existing onboarding/setup command path instead of adding new setup logic.
- Keeps the destructive **Remove Local Gateway** management card conditional on an installed gateway.
- Adds localized strings for all current locales: `en-us`, `fr-fr`, `nl-nl`, `zh-cn`, and `zh-tw`.

## Screenshot

![Settings page showing the persistent Local Gateway setup card](https://gist.githubusercontent.com/ranjeshj/59183f9be40a66895edb69b9a28bf9be/raw/openclaw-local-gateway-setup-card.svg)

## Review

Ran the repo `autoreview` helper with a Hanselman-style high-signal prompt. The default Codex review engine was unavailable in this environment, so I used the installed Copilot engine with the helper's explicit unsandboxed-tools opt-in.

Command:

```powershell
$env:PYTHONUTF8='1'; $env:AUTOREVIEW_ALLOW_UNSANDBOXED_TOOLS='1'; python .agents\skills\autoreview\scripts\autoreview --mode local --engine copilot --prompt "Hanselman-style review: be practical and high-signal. Focus only on correctness, maintainability, localization, UX discoverability, accessibility, and security issues that should block this small settings-page change. Do not nitpick style."
```

Result: `autoreview clean: no accepted/actionable findings reported`.

## Validation

- `./build.ps1` ✅
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` ✅ 2074 total, 2045 passed, 29 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` ✅ 934 total, 934 passed

The first `--no-restore` test invocation hit the repo-documented fresh-worktree no-op behavior, so I ran both test projects once with restore enabled and then reran the required `--no-restore` commands successfully.