### PR TITLE
Fix speech input test native VAD crash

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Services/AudioPipeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AudioPipeline.cs
@@ -18,8 +18,6 @@ public sealed class AudioPipeline : IAsyncDisposable
 {
     private readonly IOpenClawLogger _logger;
     private readonly SpeechToTextService _stt;
-    private readonly VoiceActivityDetector _vad;
-
     private WasapiCapture? _capture;
     private WaveFormat? _captureFormat;
     private AudioPipelineOptions _options = new();
@@ -40,6 +38,8 @@ public sealed class AudioPipeline : IAsyncDisposable
     // State
     private AudioPipelineState _state = AudioPipelineState.Stopped;
     private CancellationTokenSource? _cts;
+    private const int PipelineSampleRate = 16000;
+    private const int VadChunkSamples = 512;
 
     // Backpressure: cap how many transcription Task.Run callbacks may be
     // outstanding at once. Each holds its own copy of the audio samples
@@ -94,11 +94,10 @@ public sealed class AudioPipeline : IAsyncDisposable
     /// <summary>When true, incoming audio is ignored (prevents echo during TTS playback).</summary>
     public bool IsMuted { get; set; }
 
-    public AudioPipeline(IOpenClawLogger logger, SpeechToTextService stt, VoiceActivityDetector vad)
+    public AudioPipeline(IOpenClawLogger logger, SpeechToTextService stt)
     {
         _logger = logger;
         _stt = stt;
-        _vad = vad;
     }
 
     /// <summary>Start capturing and processing audio.</summary>
@@ -111,7 +110,7 @@ public sealed class AudioPipeline : IAsyncDisposable
         _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         // Calculate silence threshold: how many VAD chunks = silence timeout
-        float chunkDurationSec = (float)VoiceActivityDetector.ChunkSamples / VoiceActivityDetector.SampleRate;
+        float chunkDurationSec = (float)VadChunkSamples / PipelineSampleRate;
         _silenceChunksThreshold = Math.Max(1, (int)(options.SilenceTimeoutSeconds / chunkDurationSec));
 
         SetState(AudioPipelineState.Starting);
@@ -331,10 +330,10 @@ public sealed class AudioPipeline : IAsyncDisposable
 
     private void ProcessVadChunks()
     {
-        while (_resampleBuffer.Count >= VoiceActivityDetector.ChunkSamples)
+        while (_resampleBuffer.Count >= VadChunkSamples)
         {
-            var chunk = _resampleBuffer.GetRange(0, VoiceActivityDetector.ChunkSamples).ToArray();
-            _resampleBuffer.RemoveRange(0, VoiceActivityDetector.ChunkSamples);
+            var chunk = _resampleBuffer.GetRange(0, VadChunkSamples).ToArray();
+            _resampleBuffer.RemoveRange(0, VadChunkSamples);
 
             // Compute RMS energy of this chunk
             float energy = 0;
@@ -387,7 +386,7 @@ public sealed class AudioPipeline : IAsyncDisposable
                     _silenceChunksCount = 0;
 
                     // Only transcribe if we had enough speech (not just a brief noise)
-                    var durationSec = (float)samples.Length / VoiceActivityDetector.SampleRate;
+                    var durationSec = (float)samples.Length / PipelineSampleRate;
                     if (_speechChunkCount < 10) // less than ~320ms of actual speech
                     {
                         try { DiagnosticMessage?.Invoke("Speak now — I'm listening"); } catch { }
@@ -445,7 +444,7 @@ public sealed class AudioPipeline : IAsyncDisposable
         }
 
         // Skip very short segments (< 0.3 seconds)
-        if (samples.Length < VoiceActivityDetector.SampleRate * 0.3f)
+        if (samples.Length < PipelineSampleRate * 0.3f)
         {
             DiagnosticMessage?.Invoke("Segment too short, skipped");
             return;

--- a/src/OpenClaw.Tray.WinUI/Services/VoiceService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/VoiceService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,14 +27,10 @@ public sealed class VoiceService : IAsyncDisposable
     private readonly IOpenClawLogger _logger;
     private readonly SettingsManager _settings;
     private readonly SpeechToTextService _stt;
-    private readonly VoiceActivityDetector _vad;
     private readonly WhisperModelManager _modelManager;
     private AudioPipeline? _pipeline;
     private VoiceMode _currentMode = VoiceMode.Inactive;
     private CancellationTokenSource? _sessionCts;
-
-    // Path to the bundled Silero VAD model (deployed with the app)
-    private string? _vadModelPath;
 
     /// <summary>Current voice interaction mode.</summary>
     public VoiceMode CurrentMode => _currentMode;
@@ -106,7 +101,6 @@ public sealed class VoiceService : IAsyncDisposable
         _logger = logger;
         _settings = settings;
         _stt = new SpeechToTextService(logger);
-        _vad = new VoiceActivityDetector(logger);
         _modelManager = new WhisperModelManager(SettingsManager.SettingsDirectoryPath, logger);
     }
 
@@ -118,26 +112,6 @@ public sealed class VoiceService : IAsyncDisposable
         IProgress<(long downloaded, long total)>? downloadProgress = null,
         CancellationToken cancellationToken = default)
     {
-        // Load VAD model
-        if (!_vad.IsLoaded)
-        {
-            var vadPath = FindVadModelPath();
-            if (vadPath == null)
-            {
-                // Auto-download Silero VAD model
-                DiagnosticMessage?.Invoke("Downloading voice activity model…");
-                vadPath = await DownloadVadModelAsync(cancellationToken);
-            }
-            if (vadPath != null)
-            {
-                _vad.LoadModel(vadPath);
-            }
-            else
-            {
-                _logger.Info("Silero VAD model not found — VAD will be unavailable");
-            }
-        }
-
         // Download Whisper model if needed
         var modelName = _settings.SttModelName;
         if (!_modelManager.IsModelDownloaded(modelName))
@@ -172,7 +146,7 @@ public sealed class VoiceService : IAsyncDisposable
         SetMode(VoiceMode.PushToTalk);
 
         _sessionCts = new CancellationTokenSource();
-        _pipeline = new AudioPipeline(_logger, _stt, _vad);
+        _pipeline = new AudioPipeline(_logger, _stt);
         WirePipelineEvents(_pipeline);
 
         var options = new AudioPipelineOptions
@@ -214,7 +188,7 @@ public sealed class VoiceService : IAsyncDisposable
         SetMode(VoiceMode.VoiceChat);
 
         _sessionCts = new CancellationTokenSource();
-        _pipeline = new AudioPipeline(_logger, _stt, _vad);
+        _pipeline = new AudioPipeline(_logger, _stt);
         WirePipelineEvents(_pipeline);
 
         var options = new AudioPipelineOptions
@@ -276,7 +250,7 @@ public sealed class VoiceService : IAsyncDisposable
         using var timeoutCts = new CancellationTokenSource(args.TimeoutMs);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 
-        var pipeline = new AudioPipeline(_logger, _stt, _vad);
+        var pipeline = new AudioPipeline(_logger, _stt);
         WirePipelineEvents(pipeline);
         var tcs = new TaskCompletionSource<SttListenResult>();
         var sw = Stopwatch.StartNew();
@@ -368,7 +342,7 @@ public sealed class VoiceService : IAsyncDisposable
 
         await EnsureInitializedAsync();
 
-        var pipeline = new AudioPipeline(_logger, _stt, _vad);
+        var pipeline = new AudioPipeline(_logger, _stt);
         var sw = Stopwatch.StartNew();
         try
         {
@@ -504,91 +478,9 @@ public sealed class VoiceService : IAsyncDisposable
         _logger.Info($"Voice mode changed: {mode}");
     }
 
-    /// <summary>
-    /// Locate the Silero VAD ONNX model. Looks in the app's Assets folder
-    /// and the models directory.
-    /// </summary>
-    private string? FindVadModelPath()
-    {
-        if (_vadModelPath != null && File.Exists(_vadModelPath))
-            return _vadModelPath;
-
-        // Check Assets directory (deployed with the app)
-        var assetsPath = Path.Combine(AppContext.BaseDirectory, "Assets", "silero_vad.onnx");
-        if (File.Exists(assetsPath))
-        {
-            _vadModelPath = assetsPath;
-            return assetsPath;
-        }
-
-        // Check models directory
-        var modelsPath = Path.Combine(SettingsManager.SettingsDirectoryPath, "models", "silero_vad.onnx");
-        if (File.Exists(modelsPath))
-        {
-            _vadModelPath = modelsPath;
-            return modelsPath;
-        }
-
-        return null;
-    }
-
-    private const string VadDownloadUrl = SileroVadModelManifest.DownloadUrl;
-
-    /// <summary>Download the Silero VAD ONNX model if not already present.
-    /// SHA-256 is verified before the atomic rename so a tampered or
-    /// truncated file never lands at the canonical path. See
-    /// <see cref="SileroVadModelManifest"/>.</summary>
-    private async Task<string?> DownloadVadModelAsync(CancellationToken cancellationToken)
-    {
-        var destPath = Path.Combine(SettingsManager.SettingsDirectoryPath, "models", SileroVadModelManifest.FileName);
-        if (File.Exists(destPath))
-            return destPath;
-
-        _logger.Info("Downloading Silero VAD model...");
-        Directory.CreateDirectory(Path.GetDirectoryName(destPath)!);
-        var tempPath = destPath + ".tmp";
-        try
-        {
-            using var http = new System.Net.Http.HttpClient();
-            http.Timeout = TimeSpan.FromMinutes(5);
-            using var response = await http.GetAsync(VadDownloadUrl, cancellationToken);
-            response.EnsureSuccessStatusCode();
-            using (var fs = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
-            {
-                await response.Content.CopyToAsync(fs, cancellationToken);
-            }
-
-            // SECURITY: verify SHA-256 BEFORE the atomic rename so a
-            // tampered file never reaches ONNX Runtime.
-            using (var sha = System.Security.Cryptography.SHA256.Create())
-            using (var verifyStream = new FileStream(tempPath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, useAsync: true))
-            {
-                var actual = await sha.ComputeHashAsync(verifyStream, cancellationToken);
-                var actualHex = Convert.ToHexString(actual).ToLowerInvariant();
-                if (!string.Equals(actualHex, SileroVadModelManifest.Sha256, StringComparison.OrdinalIgnoreCase))
-                {
-                    throw new System.Security.SecurityException(
-                        "Silero VAD model failed integrity check. The downloaded file does not match the pinned SHA-256.");
-                }
-            }
-
-            File.Move(tempPath, destPath, overwrite: true);
-            _logger.Info($"Silero VAD model downloaded and verified ({new FileInfo(destPath).Length:N0} bytes)");
-            _vadModelPath = destPath;
-            return destPath;
-        }
-        catch (Exception ex)
-        {
-            _logger.Error("Failed to download VAD model", ex);
-            try { if (File.Exists(tempPath)) File.Delete(tempPath); } catch { }
-            return null;
-        }
-    }
-
     public async ValueTask DisposeAsync()
     {
         await StopAsync();
         _stt.Dispose();
-        _vad.Dispose();
     }
 }

--- a/tests/OpenClaw.Tray.Tests/SpeechInputContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SpeechInputContractTests.cs
@@ -1,0 +1,46 @@
+namespace OpenClaw.Tray.Tests;
+
+public sealed class SpeechInputContractTests
+{
+    private static string RepoRoot()
+    {
+        var env = Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT");
+        if (!string.IsNullOrWhiteSpace(env) && Directory.Exists(env))
+            return env;
+
+        var d = new DirectoryInfo(AppContext.BaseDirectory);
+        while (d != null)
+        {
+            if (File.Exists(Path.Combine(d.FullName, "openclaw-windows-node.slnx")) &&
+                Directory.Exists(Path.Combine(d.FullName, "src")))
+                return d.FullName;
+            d = d.Parent;
+        }
+
+        throw new InvalidOperationException(
+            "Could not find repository root. Set OPENCLAW_REPO_ROOT to the repo path.");
+    }
+
+    private static string Read(params string[] parts)
+        => File.ReadAllText(Path.Combine(new[] { RepoRoot() }.Concat(parts).ToArray()));
+
+    [Fact]
+    public void VoiceService_DoesNotLoadNativeVad_OnRecordStartup()
+    {
+        var cs = Read("src", "OpenClaw.Tray.WinUI", "Services", "VoiceService.cs");
+
+        Assert.DoesNotContain("new VoiceActivityDetector", cs);
+        Assert.DoesNotContain(".LoadModel(vad", cs, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("DownloadVadModelAsync", cs);
+    }
+
+    [Fact]
+    public void AudioPipeline_UsesManagedEnergyVad_NotNativeVad()
+    {
+        var cs = Read("src", "OpenClaw.Tray.WinUI", "Services", "AudioPipeline.cs");
+
+        Assert.DoesNotContain("VoiceActivityDetector", cs);
+        Assert.Contains("energy >= startThreshold", cs);
+        Assert.Contains("energy >= stayThreshold", cs);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #683.

This removes the unused native Silero/ONNX VAD startup path from the tray speech input flow. The live `AudioPipeline` already uses managed RMS/energy VAD, so `VoiceService` no longer downloads/loads the native VAD model before starting microphone capture. `AudioPipeline` keeps the same 16 kHz / 512-sample chunk behavior through local constants instead of referencing `VoiceActivityDetector`.

## Repro validation

A/B validation was performed with the old runtime conditions from the crash report:

- **A / repro:** v0.6.0 portable x64 with app-local `msvcp140.dll` **14.29.30142.1** reproduced the Speech Input Test crash.
- **B / fix:** `fix-683-speech-input-crash` Release x64 portable using the same old app-local `msvcp140.dll` **14.29.30142.1** and copied gateway/model state did not crash on the same Speech Input Test flow.

This validates the fix under the reproduced crash conditions, though it does not identify the exact native faulting instruction.

## Tests

- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — 2045 passed, 29 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — 936 passed

## Review

Ran a Hanselman-style dual-model review. No blocking findings. The only shared note was low-severity source-contract test fragility, consistent with existing WinUI contract-test patterns in this repo.

## Evidence

Video proof: attached in PR comment
