### PR TITLE
Fall back to Copilot autoreview when Codex is unavailable

### DIFF
--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -299,6 +299,18 @@ def resolve_command(name: str) -> str:
     raise SystemExit(f"review engine executable not found: {name}. Install it or pass the matching --*-bin option.")
 
 
+def command_exists(name: str) -> bool:
+    return shutil.which(name) is not None
+
+
+def choose_default_engine(args: argparse.Namespace) -> str:
+    if command_exists(args.codex_bin):
+        return "codex"
+    if command_exists(args.copilot_bin) and allow_unsandboxed_tools():
+        return "copilot"
+    return "codex"
+
+
 def bounded(text: str, limit: int = 180_000) -> str:
     if len(text) <= limit:
         return text
@@ -1102,7 +1114,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--mode", choices=["auto", "local", "uncommitted", "branch", "commit"], default="auto")
     parser.add_argument("--base")
     parser.add_argument("--commit", default="HEAD")
-    parser.add_argument("--engine", choices=ENGINES, default=os.environ.get("AUTOREVIEW_ENGINE", "codex"))
+    parser.add_argument("--engine", choices=ENGINES, default=os.environ.get("AUTOREVIEW_ENGINE"))
     parser.add_argument("--reviewers", help="Comma-separated review panel, e.g. codex,claude or codex:gpt-5:high.")
     parser.add_argument("--panel", action="store_true", help="Run a Codex/Claude review panel unless --engine changes the first reviewer.")
     parser.add_argument("--model", action="append", help="Model for all reviewers or engine=model. Repeatable.")
@@ -1143,6 +1155,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--expect-findings", action="store_true", help="Treat findings as success; for harness acceptance tests.")
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
+    if args.engine is None:
+        args.engine = choose_default_engine(args)
     if args.engine not in ENGINES:
         raise SystemExit(f"invalid --engine/AUTOREVIEW_ENGINE: {args.engine}")
     return args


### PR DESCRIPTION
## Summary

Update the repo-local `autoreview` helper so implicit/default review engine selection checks the local environment before choosing an engine.

When Codex is installed, the helper still uses Codex by default. When Codex is unavailable but Copilot CLI is installed, the helper can fall back to Copilot only when the existing `AUTOREVIEW_ALLOW_UNSANDBOXED_TOOLS=1` opt-in is present, preserving the helper's safety gate for Copilot's unsandboxed file tools.

## What changed

- Add command availability checks for review engine binaries.
- Change the implicit engine default from hardcoded `codex` to environment-aware selection.
- Preserve explicit `--engine` / `AUTOREVIEW_ENGINE` behavior.
- Preserve Copilot's existing unsandboxed-tools opt-in requirement.

## Validation

- `python .agents\skills\autoreview\scripts\autoreview --mode branch --base origin/master --dry-run` selects `codex` when Copilot opt-in is not set and Codex is unavailable.
- `AUTOREVIEW_ALLOW_UNSANDBOXED_TOOLS=1` dry run selects `copilot` when Codex is unavailable.
- Structured autoreview on this branch: clean.
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — 2045 passed, 29 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — 936 passed