### PR TITLE
Rename default branch references from master to main

### DIFF
--- a/.agents/skills/autoreview/SKILL.md
+++ b/.agents/skills/autoreview/SKILL.md
@@ -17,7 +17,7 @@ Use when:
 
 OpenClaw Windows Node specifics:
 
-- The release/default branch is `master`; the helper resolves `origin/HEAD` so do not hardcode `origin/main`.
+- The release/default branch is `main`; the helper resolves `origin/HEAD` so do not hardcode `origin/master`.
 - After review-triggered code changes, run the repo-required validation: `./build.ps1`, `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`, and `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`.
 - If the checkout is on macOS/Linux or lacks .NET/PowerShell/Windows SDK prerequisites, report the validation blocker clearly instead of pretending the Windows validation ran.
 - Do not send absolute local checkout paths, home-directory names, or private temp/worktree paths to review engines; use repo-relative labels or the repo name.
@@ -66,13 +66,13 @@ only proves there is no local patch.
 Branch/PR work:
 
 ```bash
-<autoreview-helper> --mode branch --base origin/master
+<autoreview-helper> --mode branch --base origin/main
 ```
 
 Optional review context is first-class:
 
 ```bash
-<autoreview-helper> --mode branch --base origin/master --prompt-file /tmp/review-notes.md --dataset /tmp/evidence.json
+<autoreview-helper> --mode branch --base origin/main --prompt-file /tmp/review-notes.md --dataset /tmp/evidence.json
 ```
 
 If an open PR exists, use its actual base:
@@ -91,7 +91,7 @@ Committed single change:
 or with the helper:
 
 Use commit review for already-landed or already-pushed work on the default
-branch. Reviewing clean `master` against `origin/master` is usually an empty
+branch. Reviewing clean `main` against `origin/main` is usually an empty
 diff after push. For a small stack, review each commit explicitly or review the
 branch before merging with `--base`.
 

--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -255,11 +255,11 @@ def default_branch(repo: Path) -> str:
     ).strip()
     if remote_head.startswith("origin/"):
         return remote_head.removeprefix("origin/")
-    for candidate in ("master", "main"):
+    for candidate in ("main", "master"):
         result = run(["git", "rev-parse", "--verify", f"origin/{candidate}"], repo, check=False)
         if result.returncode == 0:
             return candidate
-    return "master"
+    return "main"
 
 
 def default_base_ref(repo: Path) -> str:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: Build and Test
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [ main, master ]
     tags: [ 'v*' ]
   pull_request:
-    branches: [ master, main ]
+    branches: [ main, master ]
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ on:
       - "package-lock.json"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [master, main]
+    branches: [main, master]
     paths:
       - ".github/codeql/**"
       - ".github/workflows/**"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -532,8 +532,8 @@ The repository uses GitHub Actions for continuous integration and release automa
 **Workflow File:** `.github/workflows/ci.yml`
 
 **Trigger Events:**
-- Push to `main` or `master` branch
-- Pull requests to `main` or `master`
+- Push to `main` branch
+- Pull requests to `main`
 - Git tags matching `v*` (e.g., `v1.2.3`) for releases
 
 ### Gateway LKG version automation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Useful reports include:
 
 - affected version or commit SHA,
 - impacted component or file path,
-- reproduction steps or a proof of concept against latest `master`,
+- reproduction steps or a proof of concept against latest `main`,
 - actual impact and the OpenClaw trust boundary crossed,
 - Windows version and architecture,
 - suggested remediation when practical.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,17 +1,17 @@
 # Releasing OpenClaw Windows Hub
 
 This repo uses **GitVersion + CI** for release versioning. The canonical release
-flow is **tag-driven**: merge to `master`, tag `master`, and let GitHub Actions
+flow is **tag-driven**: merge to `main`, tag `main`, and let GitHub Actions
 build/sign/publish release artifacts.
 
 ## Release checklist
 
-1. Start clean on current `master`.
+1. Start clean on current `main`.
 
    ```powershell
-   git switch master
-   git fetch origin master --prune
-   git reset --hard origin/master
+   git switch main
+   git fetch origin main --prune
+   git reset --hard origin/main
    git clean -fd
    git status --short --branch
    ```
@@ -26,13 +26,13 @@ build/sign/publish release artifacts.
      "Paused for alpha"
    ```
 
-3. Create a new tag from `origin/master`. Prefer a new alpha tag over moving a
+3. Create a new tag from `origin/main`. Prefer a new alpha tag over moving a
    previously failed tag.
 
    ```powershell
    $tag = "v0.6.0-alpha.4"
-   if ((git rev-parse HEAD) -ne (git rev-parse origin/master)) {
-       throw "HEAD is not origin/master; do not tag."
+   if ((git rev-parse HEAD) -ne (git rev-parse origin/main)) {
+       throw "HEAD is not origin/main; do not tag."
    }
    git tag -a $tag -m "OpenClaw Windows Hub $tag"
    git push origin $tag
@@ -189,14 +189,14 @@ Expected:
 
 Do not keep moving a tag repeatedly from chat unless you are certain GitHub and
 local refs agree. Prefer a fresh alpha tag (`alpha.N+1`) after the fix is merged
-to `master`.
+to `main`.
 
 Use these commands to inspect state:
 
 ```powershell
 git status --short --branch
 git rev-parse HEAD
-git rev-parse origin/master
+git rev-parse origin/main
 git ls-remote --tags origin "refs/tags/v0.6.0-alpha*"
 
 gh run list --repo openclaw/openclaw-windows-node `
@@ -204,7 +204,7 @@ gh run list --repo openclaw/openclaw-windows-node `
   --limit 10
 ```
 
-Only tag when `HEAD == origin/master`.
+Only tag when `HEAD == origin/main`.
 
 ## Versioning rules
 

--- a/run-app-local.ps1
+++ b/run-app-local.ps1
@@ -25,8 +25,6 @@
 .PARAMETER AllowNonMain
     Allow launching from a branch other than main.
 
-    -AllowNonMaster is kept as a deprecated alias for one transition cycle.
-
 .PARAMETER Isolated
     Set OPENCLAW_TRAY_DATA_DIR to a stable temp directory unique to this worktree
     and branch so multiple local launches can run side-by-side.
@@ -74,7 +72,6 @@ param(
     [ValidateSet("Debug", "Release")]
     [string]$Configuration = "Debug",
 
-    [Alias("AllowNonMaster")]
     [switch]$AllowNonMain,
 
     [switch]$Isolated,

--- a/run-app-local.ps1
+++ b/run-app-local.ps1
@@ -12,8 +12,8 @@
     Use -Isolated (or -DataDir) to run multiple worktrees side-by-side without
     sharing settings, logs, run markers, device identities, or mutex names.
 
-    By default this helper refuses to run outside `master` to avoid accidentally
-    launching a stale or experimental worktree. Use -AllowNonMaster when you
+    By default this helper refuses to run outside `main` to avoid accidentally
+    launching a stale or experimental worktree. Use -AllowNonMain when you
     intentionally want to preview a PR or feature branch.
 
 .PARAMETER NoBuild
@@ -22,8 +22,10 @@
 .PARAMETER Configuration
     Build/output configuration to use. Defaults to Debug.
 
-.PARAMETER AllowNonMaster
-    Allow launching from a branch other than master.
+.PARAMETER AllowNonMain
+    Allow launching from a branch other than main.
+
+    -AllowNonMaster is kept as a deprecated alias for one transition cycle.
 
 .PARAMETER Isolated
     Set OPENCLAW_TRAY_DATA_DIR to a stable temp directory unique to this worktree
@@ -60,7 +62,7 @@
     .\run-app-local.ps1 -Isolated
 
 .EXAMPLE
-    .\run-app-local.ps1 -Configuration Release -Isolated -UpdateChannel alpha -AllowNonMaster
+    .\run-app-local.ps1 -Configuration Release -Isolated -UpdateChannel alpha -AllowNonMain
 
 .EXAMPLE
     .\run-app-local.ps1 -UseWinApp -NoBuild
@@ -72,7 +74,8 @@ param(
     [ValidateSet("Debug", "Release")]
     [string]$Configuration = "Debug",
 
-    [switch]$AllowNonMaster,
+    [Alias("AllowNonMaster")]
+    [switch]$AllowNonMain,
 
     [switch]$Isolated,
 
@@ -127,8 +130,8 @@ function Get-ShortHash {
 }
 
 $branch = (git -C $repoRoot rev-parse --abbrev-ref HEAD).Trim()
-if ($branch -ne "master" -and -not $AllowNonMaster) {
-    throw "Refusing to run: current branch is '$branch', expected 'master'. Use -AllowNonMaster to preview this branch intentionally."
+if ($branch -ne "main" -and -not $AllowNonMain) {
+    throw "Refusing to run: current branch is '$branch', expected 'main'. Use -AllowNonMain to preview this branch intentionally."
 }
 
 if (-not $NoBuild) {


### PR DESCRIPTION
Clawsweeper bot assumes a default branch of 'main' in some cases. See 
https://github.com/openclaw/clawsweeper/issues/252

We will rename the master branch to main. We need to update all references to master in the repo.

Do not merge until the default branch has actually been renamed.



GitHub default branch is renaming from master to main. Update repository content that hard-codes the old name so contributors, CI, release tooling, and dev scripts all work against main.

Graceful transition: CI workflow triggers list both [main, master].

Deliberately NOT changed:

- Third-party URLs (github/gitignore, snakers4/silero-vad) that reference upstream master branches

- UX terminology (Master switch, Master toggle, master control region) in tray pages and settings - unrelated to git

- GitVersion.yml regex ^(master|main)$ already accepts both

Validation: ./build.ps1, Shared.Tests (2045/29 skipped), Tray.Tests (940), YAML lint on workflows, autoreview --help, run-app-local.ps1 Get-Help shows -AllowNonMain with -AllowNonMaster alias.