### PR TITLE
Scale gateway configuration timeout with config command count

### DIFF
--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -1224,7 +1224,14 @@ public sealed class ConfigureGatewayStep : SetupStep
 {
     internal const string DevicePairPublicUrlKey = "plugins.entries.device-pair.config.publicUrl";
     internal const string DevicePairEnabledKey = "plugins.entries.device-pair.enabled";
-    internal static readonly TimeSpan GatewayConfigurationTimeout = TimeSpan.FromSeconds(120);
+    // Each `openclaw config set` emitted below spawns the Node CLI fresh inside WSL; on a
+    // newly created distro with a cold cache that is ~4-5s apiece. Budget the step by how
+    // many config commands we actually emit -- BuildConfigCommands grows with the
+    // device-pair keys and every Gateway.ExtraConfig entry -- with a floor so the minimal
+    // path keeps generous headroom. A fixed cap silently regresses as the list grows.
+    internal static readonly TimeSpan ConfigBaseBudget = TimeSpan.FromSeconds(45);
+    internal static readonly TimeSpan PerConfigCommandBudget = TimeSpan.FromSeconds(15);
+    internal static readonly TimeSpan MinConfigurationTimeout = TimeSpan.FromSeconds(180);
 
     public override string Id => "configure-gateway";
     public override string DisplayName => "Configure gateway";
@@ -1277,13 +1284,14 @@ public sealed class ConfigureGatewayStep : SetupStep
             echo "GATEWAY_CONFIGURED"
             """;
 
-        var result = await ctx.Commands.RunInWslAsync(distro, script, GatewayConfigurationTimeout, env, ct);
+        var timeout = ComputeConfigurationTimeout(configCommands);
+        var result = await ctx.Commands.RunInWslAsync(distro, script, timeout, env, ct);
 
         if (result.ExitCode != 0 || !result.Stdout.Contains("GATEWAY_CONFIGURED"))
         {
             if (result.TimedOut)
                 return StepResult.Fail(
-                    $"Gateway configuration timed out after {GatewayConfigurationTimeout.TotalSeconds:0}s while running openclaw config inside WSL.");
+                    $"Gateway configuration timed out after {timeout.TotalSeconds:0}s while running openclaw config inside WSL.");
 
             return StepResult.Fail($"Gateway configuration failed (exit {result.ExitCode}): {result.Stderr}");
         }
@@ -1341,6 +1349,27 @@ public sealed class ConfigureGatewayStep : SetupStep
         }
 
         return configCommands;
+    }
+
+    // Budget = base + per-command, floored. Scales the WSL timeout with the number of
+    // `openclaw config set` invocations the step emits so it cannot silently regress as
+    // BuildConfigCommands grows.
+    internal static TimeSpan ComputeConfigurationTimeout(string configCommands)
+    {
+        var budget = ConfigBaseBudget + PerConfigCommandBudget * CountConfigSetCommands(configCommands);
+        return budget > MinConfigurationTimeout ? budget : MinConfigurationTimeout;
+    }
+
+    private static int CountConfigSetCommands(string configCommands)
+    {
+        var count = 0;
+        foreach (var line in configCommands.Split('\n'))
+        {
+            if (line.Contains("openclaw config set", StringComparison.Ordinal))
+                count++;
+        }
+
+        return count;
     }
 
     internal static string? GetDefaultDevicePairPublicUrl(GatewayConfig gw, int port) =>

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -935,7 +935,10 @@ public class SetupStepsTests : IDisposable
 
         Assert.True(result.IsSuccess);
         var wslCall = Assert.Single(commands.WslCalls);
-        Assert.Equal(ConfigureGatewayStep.GatewayConfigurationTimeout, wslCall.Timeout);
+        Assert.Equal(
+            ConfigureGatewayStep.ComputeConfigurationTimeout(wslCall.Command),
+            wslCall.Timeout);
+        Assert.True(wslCall.Timeout >= ConfigureGatewayStep.MinConfigurationTimeout);
     }
 
     [Fact]
@@ -950,8 +953,51 @@ public class SetupStepsTests : IDisposable
 
         Assert.Equal(StepOutcome.Failed, result.Outcome);
         var message = Assert.IsType<string>(result.Message);
-        Assert.Contains("Gateway configuration timed out after 120s", message);
+        Assert.Contains("Gateway configuration timed out after", message);
         Assert.DoesNotContain("exit -1", message);
+    }
+
+    [Fact]
+    public void ComputeConfigurationTimeout_ScalesWithConfigCommandCount()
+    {
+        // Each `openclaw config set` pays a cold Node start inside WSL. As more keys are
+        // configured the budget must grow, otherwise the step silently regresses toward a
+        // timeout (the failure mode the fixed 120s cap only partially closed).
+        var fewCommands = ConfigureGatewayStep.BuildConfigCommands(
+            new GatewayConfig { Bind = "lan" },
+            18789,
+            "'[]'");
+        var manyCommands = ConfigureGatewayStep.BuildConfigCommands(
+            new GatewayConfig
+            {
+                Bind = "loopback",
+                ExtraConfig = new Dictionary<string, string>
+                {
+                    ["gateway.extra.one"] = "1",
+                    ["gateway.extra.two"] = "2",
+                    ["gateway.extra.three"] = "3",
+                    ["gateway.extra.four"] = "4",
+                },
+            },
+            18789,
+            "'[]'");
+
+        var fewTimeout = ConfigureGatewayStep.ComputeConfigurationTimeout(fewCommands);
+        var manyTimeout = ConfigureGatewayStep.ComputeConfigurationTimeout(manyCommands);
+
+        Assert.True(
+            manyTimeout > fewTimeout,
+            $"Timeout should grow with config command count; few={fewTimeout}, many={manyTimeout}");
+    }
+
+    [Fact]
+    public void ComputeConfigurationTimeout_NeverBelowFloor()
+    {
+        // A minimal config set must still receive the safety floor, never base + one.
+        var timeout = ConfigureGatewayStep.ComputeConfigurationTimeout(
+            "openclaw config set gateway.mode local");
+
+        Assert.True(timeout >= ConfigureGatewayStep.MinConfigurationTimeout);
     }
 
     [Theory]


### PR DESCRIPTION
## Problem

#652 raised the WSL `configure-gateway` timeout 30s→120s, but the cap is **fixed** while `BuildConfigCommands` keeps growing — it appends `openclaw config set` calls for the device-pair public URL, `device-pair.enabled`, and every `Gateway.ExtraConfig` key. Each `config set` spawns the Node CLI fresh inside WSL (~4–5s apiece on a newly created distro with a cold cache), so a config-heavy setup can creep right back into the same timeout the fixed cap was meant to prevent.

## Change

Budget the step by the number of `config set` commands actually emitted, instead of a fixed value:

- `ConfigBaseBudget = 45s` + `PerConfigCommandBudget = 15s/command`, floored at `MinConfigurationTimeout = 180s`.
- `ComputeConfigurationTimeout(configCommands)` counts the emitted commands; `ExecuteAsync` uses it and reports the **computed** value in the timeout message (no hardcoded seconds).
- Today's ~8-command setup → `45 + 15×8 = 165s`, floored to 180s (~3–4× the observed per-command cost); extra config keys scale the budget up automatically.

## Tests

- New `ComputeConfigurationTimeout_ScalesWithConfigCommandCount` and `ComputeConfigurationTimeout_NeverBelowFloor`.
- Updated `ConfigureGateway_UsesExtendedTimeoutForWslConfig` to assert the computed value + floor (the old test pinned the now-removed constant) and `ConfigureGateway_ReturnsTimeoutSpecificFailure` to not hardcode the seconds. Tests assert the scaling/floor relationship rather than a magic number.

## Validation

Per `AGENTS.md`: `./build.ps1` ✅ (all 5 projects), SetupEngine tests ✅ 239, Shared ✅ 2049, Tray ✅ 958.

🤖 Generated with [Claude Code](https://claude.com/claude-code)