### PR TITLE
Fix configured model filtering and test SDK bump

### DIFF
--- a/src/OpenClaw.Shared/Models.cs
+++ b/src/OpenClaw.Shared/Models.cs
@@ -1889,6 +1889,7 @@ public class ModelInfo
     public string? Provider { get; set; }
     public int? ContextWindow { get; set; }
     public bool IsConfigured { get; set; }
+    public bool HasConfiguredFlag { get; set; }
 
     public string DisplayName => Name ?? Id;
 }
@@ -1981,4 +1982,3 @@ public class DiscoveredGateway
         }
     }
 }
-

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -3560,13 +3560,16 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
             {
                 foreach (var item in modelsArray.EnumerateArray())
                 {
+                    var hasConfiguredFlag = item.TryGetProperty("configured", out var cfg)
+                                            && (cfg.ValueKind == JsonValueKind.True || cfg.ValueKind == JsonValueKind.False);
                     var model = new ModelInfo
                     {
                         Id = item.TryGetProperty("id", out var id) ? id.GetString() ?? "" : "",
                         Name = item.TryGetProperty("name", out var name) ? name.GetString() : null,
                         Provider = item.TryGetProperty("provider", out var prov) ? prov.GetString() : null,
                         ContextWindow = item.TryGetProperty("contextWindow", out var cw) && cw.ValueKind == JsonValueKind.Number ? cw.GetInt32() : null,
-                        IsConfigured = item.TryGetProperty("configured", out var cfg) && cfg.ValueKind == JsonValueKind.True
+                        IsConfigured = hasConfiguredFlag && cfg.ValueKind == JsonValueKind.True,
+                        HasConfiguredFlag = hasConfiguredFlag
                     };
                     if (!string.IsNullOrEmpty(model.Id))
                         info.Models.Add(model);

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -1150,6 +1150,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         var list = new List<string>(info.Models.Count);
         foreach (var m in info.Models)
         {
+            if (m.HasConfiguredFlag && !m.IsConfigured) continue;
             var id = m.Id;
             if (string.IsNullOrEmpty(id)) continue;
             if (seen.Add(id)) list.Add(id);

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -26,7 +26,7 @@
       dotnet-coverage uses a runtime profiler that does. CI installs the tool and
       wraps each `dotnet test` invocation with `dotnet-coverage collect`.
     -->
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="VCRuntime.CefSharp.140" Version="$(OpenClawVCRuntimeVersion)" PrivateAssets="all" ExcludeAssets="build" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -246,6 +246,24 @@ public class OpenClawGatewayClientTests
             InvokePrivatePayloadParser("ParseSessions", payloadJson);
         }
 
+        public ModelsListInfo ParseModelsListPayload(string payloadJson)
+        {
+            ModelsListInfo? parsed = null;
+            EventHandler<ModelsListInfo> handler = (_, models) => parsed = models;
+            _client.ModelsListUpdated += handler;
+
+            try
+            {
+                InvokePrivatePayloadParser("ParseModelsList", payloadJson);
+            }
+            finally
+            {
+                _client.ModelsListUpdated -= handler;
+            }
+
+            return parsed ?? new ModelsListInfo();
+        }
+
         private void InvokePrivatePayloadParser(string methodName, string payloadJson)
         {
             using var doc = JsonDocument.Parse(payloadJson);
@@ -706,6 +724,43 @@ public class OpenClawGatewayClientTests
 
         Assert.Contains(logger.Logs, log => log == $"DEBUG: Agent event received: stream=tool len={rawMessage.Length}");
         Assert.DoesNotContain(logger.Logs, log => log.Contains("super-secret", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void ParseModelsList_PreservesConfiguredFlagPresence()
+    {
+        var helper = new GatewayClientTestHelper();
+
+        var models = helper.ParseModelsListPayload("""
+        {
+          "models": [
+            { "id": "gpt-5.4", "configured": true },
+            { "id": "gpt-5.5", "configured": false },
+            { "id": "legacy-gateway-model" }
+          ]
+        }
+        """);
+
+        Assert.Collection(
+            models.Models,
+            model =>
+            {
+                Assert.Equal("gpt-5.4", model.Id);
+                Assert.True(model.HasConfiguredFlag);
+                Assert.True(model.IsConfigured);
+            },
+            model =>
+            {
+                Assert.Equal("gpt-5.5", model.Id);
+                Assert.True(model.HasConfiguredFlag);
+                Assert.False(model.IsConfigured);
+            },
+            model =>
+            {
+                Assert.Equal("legacy-gateway-model", model.Id);
+                Assert.False(model.HasConfiguredFlag);
+                Assert.False(model.IsConfigured);
+            });
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -1175,6 +1175,28 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
+    public async Task ModelsListUpdated_FiltersExplicitlyUnconfiguredModels()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        await provider.LoadAsync();
+        snapshots.Clear();
+
+        bridge.RaiseModels(new ModelsListInfo
+        {
+            Models = new List<ModelInfo>
+            {
+                new() { Id = "gpt-5.4", IsConfigured = true, HasConfiguredFlag = true },
+                new() { Id = "gpt-5.5", IsConfigured = false, HasConfiguredFlag = true },
+                new() { Id = "legacy-gateway-model" }
+            }
+        });
+
+        Assert.Equal(
+            new[] { "gpt-5.4", "legacy-gateway-model" },
+            snapshots[^1].AvailableModels);
+    }
+
+    [Fact]
     public async Task ModelsListUpdated_DedupesDisplayNames()
     {
         var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });


### PR DESCRIPTION
## Summary
- filter explicitly unconfigured gateway models out of the chat model selector while preserving older gateway payloads that omit `configured`
- preserve the `configured` flag presence when parsing `models.list`
- bump `Microsoft.NET.Test.Sdk` from 18.4.0 to 18.6.0

Fixes #684.
Fixes #705.

## Validation
- `OPENCLAW_REPO_ROOT=D:\github\copilot-worktrees\moltbot-windows-hub\shanselman-sturdy-bassoon; .\build.ps1`
- `OPENCLAW_REPO_ROOT=D:\github\copilot-worktrees\moltbot-windows-hub\shanselman-sturdy-bassoon; dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`
- `OPENCLAW_REPO_ROOT=D:\github\copilot-worktrees\moltbot-windows-hub\shanselman-sturdy-bassoon; dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`
