### PR TITLE
fix(tests): isolate locale and device identity from host environment

### DIFF
--- a/src/OpenClaw.Shared/ChatAttachment.cs
+++ b/src/OpenClaw.Shared/ChatAttachment.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
@@ -126,8 +127,8 @@ public sealed class ChatAttachment
         return bytes switch
         {
             < 1024 => $"{bytes} B",
-            < 1024 * 1024 => $"{bytes / 1024.0:F1} KB",
-            _ => $"{bytes / (1024.0 * 1024.0):F1} MB"
+            < 1024 * 1024 => $"{(bytes / 1024.0).ToString("F1", CultureInfo.InvariantCulture)} KB",
+            _ => $"{(bytes / (1024.0 * 1024.0)).ToString("F1", CultureInfo.InvariantCulture)} MB"
         };
     }
 }

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -461,8 +461,9 @@ public class OpenClawGatewayClientTests
     [Fact]
     public void OperatorConnect_FreshBootstrapDevice_StartsWithV2Signature()
     {
-        var helper = new GatewayClientTestHelper(tokenIsBootstrapToken: true);
-        helper.SetDeviceTokenForTest(null);
+        var tmpDir = Path.Combine(Path.GetTempPath(), $"oca-gw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tmpDir);
+        var helper = new GatewayClientTestHelper(tokenIsBootstrapToken: true, identityPath: tmpDir);
 
         Assert.True(helper.Client.UseV2Signature);
     }
@@ -470,8 +471,9 @@ public class OpenClawGatewayClientTests
     [Fact]
     public void OperatorConnect_SharedTokenDevice_StartsWithV3Signature()
     {
-        var helper = new GatewayClientTestHelper(tokenIsBootstrapToken: false);
-        helper.SetDeviceTokenForTest(null);
+        var tmpDir = Path.Combine(Path.GetTempPath(), $"oca-gw-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tmpDir);
+        var helper = new GatewayClientTestHelper(tokenIsBootstrapToken: false, identityPath: tmpDir);
 
         Assert.False(helper.Client.UseV2Signature);
     }


### PR DESCRIPTION
## What

Fixes two test isolation bugs that caused failures on machines with non-English locale or with the app installed and paired.

**`ChatAttachment.FormatBytes` — locale-sensitive decimal separator**

`$"{val:F1}"` respects the host thread culture. On systems with a non-English decimal separator (e.g., Spanish locale uses comma), the output was `"1,5 KB"` instead of `"1.5 KB"`. Fixed by using `ToString("F1", CultureInfo.InvariantCulture)`.

**`OpenClawGatewayClient` signature tests — device identity leaking from host**

`OperatorConnect_FreshBootstrapDevice_StartsWithV2Signature` and `OperatorConnect_SharedTokenDevice_StartsWithV3Signature` passed `null` as `identityPath`, so the client read the real device identity from `%APPDATA%\OpenClawTray`. On machines where the app is installed and paired, `_deviceIdentity.DeviceToken` is non-null during construction, which sets `_useV2Signature` to `false` before `SetDeviceTokenForTest(null)` is ever called. Fixed by passing a fresh temp directory so the tests start with no device state on disk.

## Testing

Both fixes verified locally. All 3 previously failing tests now pass. Full shared test suite: 2080/2080 passed.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>