### PR TITLE
Fix About page diagnostics

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/AboutPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/AboutPage.xaml
@@ -21,7 +21,8 @@
                         <TextBlock x:Name="VersionText"
                                    Style="{StaticResource CaptionTextBlockStyle}"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <TextBlock x:Uid="AboutPage_TextBlock_23" Text=".NET 10 / WinUI 3 / WinAppSDK 1.8"
+                        <TextBlock x:Uid="AboutPage_TextBlock_23" x:Name="RuntimeStackText"
+                                   Text=".NET / WinUI / Windows App SDK"
                                    Style="{StaticResource CaptionTextBlockStyle}"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                     </StackPanel>
@@ -50,9 +51,9 @@
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                         <TextBlock x:Name="GatewayVersionText" Grid.Row="0" Grid.Column="1" Text="—"/>
 
-                        <TextBlock x:Uid="AboutPage_TextBlock_52" Grid.Row="1" Grid.Column="0" Text="Model:"
+                        <TextBlock x:Uid="AboutPage_TextBlock_52" Grid.Row="1" Grid.Column="0" Text="Protocol:"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        <TextBlock x:Name="GatewayModelText" Grid.Row="1" Grid.Column="1" Text="—"/>
+                        <TextBlock x:Name="GatewayProtocolText" Grid.Row="1" Grid.Column="1" Text="—"/>
 
                         <TextBlock x:Uid="AboutPage_TextBlock_56" Grid.Row="2" Grid.Column="0" Text="Auth mode:"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
@@ -94,7 +95,7 @@
                     BorderThickness="1" CornerRadius="8" Padding="16">
                 <StackPanel Spacing="8">
                     <TextBlock x:Uid="AboutPage_TextBlock_91" Text="Links" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                    <HyperlinkButton x:Uid="AboutPage_HyperlinkButton_92" Content="Documentation → openclaw.ai/docs"
+                    <HyperlinkButton x:Uid="AboutPage_HyperlinkButton_92" Content="Documentation → docs.openclaw.ai/platforms/windows"
                                      Click="OnDocumentationClick"/>
                     <HyperlinkButton x:Uid="AboutPage_HyperlinkButton_94" Content="GitHub → github.com/openclaw/openclaw-windows-node"
                                      Click="OnGitHubClick"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/AboutPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/AboutPage.xaml.cs
@@ -6,29 +6,60 @@ using OpenClawTray.Services;
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace OpenClawTray.Pages;
 
 public sealed partial class AboutPage : Page
 {
+    private const string DocumentationUrl = "https://docs.openclaw.ai/platforms/windows";
+    private const string GitHubUrl = "https://github.com/openclaw/openclaw-windows-node";
+
     private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
+    private readonly DispatcherTimer _uptimeRefreshTimer = new() { Interval = TimeSpan.FromSeconds(1) };
     private AppState? _appState;
+    private long? _sampledGatewayUptimeMs;
+    private DateTime _sampledGatewayUptimeUtc;
 
     public AboutPage()
     {
         InitializeComponent();
         VersionText.Text = AppVersionInfo.DisplayVersion;
-        Unloaded += (_, _) =>
+        RuntimeStackText.Text = BuildRuntimeStackDisplayText();
+        _uptimeRefreshTimer.Tick += OnUptimeRefreshTimerTick;
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        TryLoadGatewayInfo();
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        _uptimeRefreshTimer.Stop();
+        if (_appState != null)
         {
-            if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
-        };
+            _appState.PropertyChanged -= OnAppStateChanged;
+            _appState = null;
+        }
     }
 
     public void Initialize()
     {
-        _appState = CurrentApp.AppState!;
-        _appState.PropertyChanged += OnAppStateChanged;
+        var appState = CurrentApp.AppState!;
+        if (!ReferenceEquals(_appState, appState))
+        {
+            if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+            _appState = appState;
+            _appState.PropertyChanged += OnAppStateChanged;
+        }
+
         TryLoadGatewayInfo();
     }
 
@@ -36,6 +67,7 @@ public sealed partial class AboutPage : Page
     {
         switch (e.PropertyName)
         {
+            case nameof(AppState.Status):
             case nameof(AppState.GatewaySelf):
                 RefreshGatewayInfo();
                 break;
@@ -50,14 +82,17 @@ public sealed partial class AboutPage : Page
         if (CurrentApp.AppState?.Status == OpenClaw.Shared.ConnectionStatus.Connected && self != null)
         {
             GatewayVersionText.Text = self.VersionText;
-            GatewayModelText.Text = self.Protocol.HasValue ? $"protocol v{self.Protocol}" : "unknown";
+            GatewayProtocolText.Text = self.Protocol.HasValue ? $"v{self.Protocol}" : "unknown";
             GatewayAuthText.Text = string.IsNullOrWhiteSpace(self.AuthMode) ? "unknown" : self.AuthMode;
-            GatewayUptimeText.Text = self.UptimeText;
+            CaptureGatewayUptimeSample(self);
+            RefreshGatewayUptimeText();
         }
         else
         {
+            _sampledGatewayUptimeMs = null;
+            _uptimeRefreshTimer.Stop();
             GatewayVersionText.Text = "—";
-            GatewayModelText.Text = "—";
+            GatewayProtocolText.Text = "—";
             GatewayAuthText.Text = "—";
             GatewayUptimeText.Text = "—";
         }
@@ -65,31 +100,19 @@ public sealed partial class AboutPage : Page
 
     private void OnOpenLogClick(object sender, RoutedEventArgs e)
     {
-        try
-        {
-            var logPath = System.IO.Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "OpenClawTray", "openclaw-tray.log");
-            Process.Start(new ProcessStartInfo(logPath) { UseShellExecute = true });
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"Failed to open log file: {ex.Message}");
-        }
+        OpenShellTarget(Logger.LogFilePath, "log file");
     }
 
     private void OnOpenConfigClick(object sender, RoutedEventArgs e)
     {
         try
         {
-            var configPath = System.IO.Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "OpenClawTray");
-            Process.Start(new ProcessStartInfo(configPath) { UseShellExecute = true });
+            System.IO.Directory.CreateDirectory(SettingsManager.SettingsDirectoryPath);
+            OpenShellTarget(SettingsManager.SettingsDirectoryPath, "config folder");
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is System.IO.IOException or UnauthorizedAccessException or InvalidOperationException or Win32Exception)
         {
-            System.Diagnostics.Debug.WriteLine($"Failed to open config folder: {ex.Message}");
+            Logger.Warn($"Failed to open config folder: {ex.Message}");
         }
     }
 
@@ -101,34 +124,27 @@ public sealed partial class AboutPage : Page
 
     private async Task OnCopySupportClickAsync()
     {
-        try
+        // Unified with the richer CommandCenterTextHelper.BuildSupportContext
+        // that the Diagnostics page uses, sourced from App's authoritative
+        // CommandCenterState builder. Falls back to a minimal local
+        // string only when the state isn't available yet (cold start).
+        string context;
+        var state = CurrentApp.BuildCommandCenterState();
+        if (state != null)
         {
-            // Unified with the richer CommandCenterTextHelper.BuildSupportContext
-            // that the Diagnostics page uses, sourced from App's authoritative
-            // CommandCenterState builder. Falls back to a minimal local
-            // string only when the state isn't available yet (cold start).
-            string context;
-            var state = CurrentApp.BuildCommandCenterState();
-            if (state != null)
-            {
-                context = OpenClawTray.Helpers.CommandCenterTextHelper.BuildSupportContext(state);
-            }
-            else
-            {
-                context = $"OpenClaw Hub {AppVersionInfo.DisplayVersion}\n"
-                    + $"OS: {Environment.OSVersion}\n"
-                    + $"Runtime: {System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}\n"
-                    + $"Connection: {CurrentApp.AppState?.Status}\n"
-                    + $"Gateway: {CurrentApp.Settings?.GetEffectiveGatewayUrl() ?? "n/a"}\n";
-            }
+            context = OpenClawTray.Helpers.CommandCenterTextHelper.BuildSupportContext(state);
+        }
+        else
+        {
+            context = $"OpenClaw Hub {AppVersionInfo.DisplayVersion}\n"
+                + $"OS: {Environment.OSVersion}\n"
+                + $"Runtime: {System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}\n"
+                + $"Connection: {CurrentApp.AppState?.Status}\n"
+                + $"Gateway: {CurrentApp.Settings?.GetEffectiveGatewayUrl() ?? "n/a"}\n";
+        }
 
-            ClipboardHelper.CopyText(context);
-            await Task.CompletedTask;
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"Failed to copy support context: {ex.Message}");
-        }
+        ClipboardHelper.CopyText(context);
+        await Task.CompletedTask;
     }
 
     private void OnCheckUpdatesClick(object sender, RoutedEventArgs e)
@@ -143,26 +159,171 @@ public sealed partial class AboutPage : Page
 
     private void OnDocumentationClick(object sender, RoutedEventArgs e)
     {
-        try
-        {
-            Process.Start(new ProcessStartInfo("https://openclaw.ai/docs") { UseShellExecute = true });
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"Failed to open docs: {ex.Message}");
-        }
+        OpenShellTarget(DocumentationUrl, "documentation");
     }
 
     private void OnGitHubClick(object sender, RoutedEventArgs e)
     {
+        OpenShellTarget(GitHubUrl, "GitHub");
+    }
+
+    private static void OpenShellTarget(string target, string label)
+    {
+        if (string.IsNullOrWhiteSpace(target))
+        {
+            Logger.Warn($"Failed to open {label}: target is empty");
+            return;
+        }
+
         try
         {
-            Process.Start(new ProcessStartInfo("https://github.com/openclaw/openclaw-windows-node") { UseShellExecute = true });
+            Process.Start(new ProcessStartInfo(target) { UseShellExecute = true });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is Win32Exception or InvalidOperationException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
         {
-            System.Diagnostics.Debug.WriteLine($"Failed to open GitHub: {ex.Message}");
+            Logger.Warn($"Failed to open {label}: {ex.Message}");
         }
+    }
+
+    private static string BuildRuntimeStackDisplayText()
+    {
+        var dotNet = RuntimeInformation.FrameworkDescription;
+        var winUi = ResolveWinUiDisplayName();
+        var windowsAppSdk = ResolveWindowsAppSdkDisplayName();
+
+        return $"{dotNet} / {winUi} / {windowsAppSdk}";
+    }
+
+    private static string ResolveWinUiDisplayName()
+    {
+        var version = typeof(Microsoft.UI.Xaml.Application).Assembly.GetName().Version;
+        return version is { Major: > 0 }
+            ? $"WinUI {version.Major}"
+            : "WinUI";
+    }
+
+    private static string ResolveWindowsAppSdkDisplayName()
+    {
+        if (TryResolveWindowsAppSdkPackageVersionFromDeps() is { Length: > 0 } packageVersion)
+        {
+            return $"Windows App SDK {packageVersion}";
+        }
+
+        return ResolveWindowsAppSdkDisplayNameFromFileVersion();
+    }
+
+    private static string ResolveWindowsAppSdkDisplayNameFromFileVersion()
+    {
+        var xamlNativePath = Path.Combine(AppContext.BaseDirectory, "Microsoft.ui.xaml.dll");
+        if (File.Exists(xamlNativePath))
+        {
+            try
+            {
+                var productVersion = FileVersionInfo.GetVersionInfo(xamlNativePath).ProductVersion;
+                if (!string.IsNullOrWhiteSpace(productVersion))
+                {
+                    return $"Windows App SDK {StripBuildMetadata(productVersion)}";
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+            {
+                Logger.Warn($"Failed to read Windows App SDK version from {xamlNativePath}: {ex.Message}");
+            }
+        }
+
+        return "Windows App SDK";
+    }
+
+    private static string? TryResolveWindowsAppSdkPackageVersionFromDeps()
+    {
+        var assemblyName = Assembly.GetEntryAssembly()?.GetName().Name;
+        if (string.IsNullOrWhiteSpace(assemblyName))
+            return null;
+
+        var depsPath = Path.Combine(AppContext.BaseDirectory, $"{assemblyName}.deps.json");
+        if (!File.Exists(depsPath))
+            return null;
+
+        try
+        {
+            using var stream = File.OpenRead(depsPath);
+            using var document = JsonDocument.Parse(stream);
+            if (!document.RootElement.TryGetProperty("libraries", out var libraries) ||
+                libraries.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            foreach (var library in libraries.EnumerateObject())
+            {
+                const string packagePrefix = "Microsoft.WindowsAppSDK/";
+                if (library.Name.StartsWith(packagePrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return StripBuildMetadata(library.Name[packagePrefix.Length..]);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or ArgumentException)
+        {
+            Logger.Warn($"Failed to read Windows App SDK package version from {depsPath}: {ex.Message}");
+        }
+
+        return null;
+    }
+
+    private static string StripBuildMetadata(string version)
+    {
+        var plus = version.IndexOf('+', StringComparison.Ordinal);
+        return plus >= 0 ? version[..plus] : version;
+    }
+
+    private void CaptureGatewayUptimeSample(GatewaySelfInfo self)
+    {
+        if (!self.UptimeMs.HasValue)
+        {
+            _sampledGatewayUptimeMs = null;
+            _uptimeRefreshTimer.Stop();
+            return;
+        }
+
+        if (_sampledGatewayUptimeMs != self.UptimeMs.Value)
+        {
+            _sampledGatewayUptimeMs = self.UptimeMs.Value;
+            _sampledGatewayUptimeUtc = DateTime.UtcNow;
+        }
+
+        if (!_uptimeRefreshTimer.IsEnabled)
+            _uptimeRefreshTimer.Start();
+    }
+
+    private void OnUptimeRefreshTimerTick(object? sender, object e)
+    {
+        RefreshGatewayUptimeText();
+    }
+
+    private void RefreshGatewayUptimeText()
+    {
+        if (CurrentApp.AppState?.Status != OpenClaw.Shared.ConnectionStatus.Connected ||
+            !_sampledGatewayUptimeMs.HasValue)
+        {
+            _uptimeRefreshTimer.Stop();
+            GatewayUptimeText.Text = "—";
+            return;
+        }
+
+        var elapsedMs = Math.Max(0, (DateTime.UtcNow - _sampledGatewayUptimeUtc).TotalMilliseconds);
+        GatewayUptimeText.Text = FormatDuration(TimeSpan.FromMilliseconds(_sampledGatewayUptimeMs.Value + elapsedMs));
+    }
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        if (duration.TotalDays >= 1)
+            return $"{(int)duration.TotalDays}d {duration.Hours}h";
+        if (duration.TotalHours >= 1)
+            return $"{(int)duration.TotalHours}h {duration.Minutes}m";
+        if (duration.TotalMinutes >= 1)
+            return $"{(int)duration.TotalMinutes}m {duration.Seconds}s";
+        return $"{Math.Max(0, (int)duration.TotalSeconds)}s";
     }
 
     private void OnDashboardClick(object sender, RoutedEventArgs e)

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -1501,7 +1501,7 @@ On your gateway host (Mac/Linux), run:
     <value>OpenClaw Hub</value>
   </data>
   <data name="AboutPage_TextBlock_23.Text" xml:space="preserve">
-    <value>.NET 10 / WinUI 3 / WinAppSDK 1.8</value>
+    <value>.NET / WinUI / Windows App SDK</value>
   </data>
   <data name="AboutPage_TextBlock_35.Text" xml:space="preserve">
     <value>Gateway Info</value>
@@ -1510,7 +1510,7 @@ On your gateway host (Mac/Linux), run:
     <value>Version:</value>
   </data>
   <data name="AboutPage_TextBlock_52.Text" xml:space="preserve">
-    <value>Model:</value>
+    <value>Protocol:</value>
   </data>
   <data name="AboutPage_TextBlock_56.Text" xml:space="preserve">
     <value>Auth mode:</value>
@@ -1537,7 +1537,7 @@ On your gateway host (Mac/Linux), run:
     <value>Links</value>
   </data>
   <data name="AboutPage_HyperlinkButton_92.Content" xml:space="preserve">
-    <value>Documentation → openclaw.ai/docs</value>
+    <value>Documentation → docs.openclaw.ai/platforms/windows</value>
   </data>
   <data name="AboutPage_HyperlinkButton_94.Content" xml:space="preserve">
     <value>GitHub → github.com/openclaw/openclaw-windows-node</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -1453,7 +1453,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>OpenClaw Hub</value>
   </data>
   <data name="AboutPage_TextBlock_23.Text" xml:space="preserve">
-    <value>.NET 10 / WinUI 3 / WinAppSDK 1.8</value>
+    <value>.NET / WinUI / Windows App SDK</value>
   </data>
   <data name="AboutPage_TextBlock_35.Text" xml:space="preserve">
     <value>Infos passerelle</value>
@@ -1462,7 +1462,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Version :</value>
   </data>
   <data name="AboutPage_TextBlock_52.Text" xml:space="preserve">
-    <value>Modèle :</value>
+    <value>Protocole :</value>
   </data>
   <data name="AboutPage_TextBlock_56.Text" xml:space="preserve">
     <value>Mode d’authentification :</value>
@@ -1489,7 +1489,7 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Liens</value>
   </data>
   <data name="AboutPage_HyperlinkButton_92.Content" xml:space="preserve">
-    <value>Documentation → openclaw.ai/docs</value>
+    <value>Documentation → docs.openclaw.ai/platforms/windows</value>
   </data>
   <data name="AboutPage_HyperlinkButton_94.Content" xml:space="preserve">
     <value>GitHub → github.com/openclaw/openclaw-windows-node</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -1454,7 +1454,7 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>OpenClaw Hub</value>
   </data>
   <data name="AboutPage_TextBlock_23.Text" xml:space="preserve">
-    <value>.NET 10 / WinUI 3 / WinAppSDK 1.8</value>
+    <value>.NET / WinUI / Windows App SDK</value>
   </data>
   <data name="AboutPage_TextBlock_35.Text" xml:space="preserve">
     <value>Gatewaygegevens</value>
@@ -1463,7 +1463,7 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>Versie:</value>
   </data>
   <data name="AboutPage_TextBlock_52.Text" xml:space="preserve">
-    <value>Modelnaam:</value>
+    <value>Protocolversie:</value>
   </data>
   <data name="AboutPage_TextBlock_56.Text" xml:space="preserve">
     <value>Verificatiemodus:</value>
@@ -1490,7 +1490,7 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>Koppelingen</value>
   </data>
   <data name="AboutPage_HyperlinkButton_92.Content" xml:space="preserve">
-    <value>Documentation → openclaw.ai/docs</value>
+    <value>Documentation → docs.openclaw.ai/platforms/windows</value>
   </data>
   <data name="AboutPage_HyperlinkButton_94.Content" xml:space="preserve">
     <value>GitHub → github.com/openclaw/openclaw-windows-node</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -1453,7 +1453,7 @@
     <value>OpenClaw Hub</value>
   </data>
   <data name="AboutPage_TextBlock_23.Text" xml:space="preserve">
-    <value>.NET 10 / WinUI 3 / WinAppSDK 1.8</value>
+    <value>.NET / WinUI / Windows App SDK</value>
   </data>
   <data name="AboutPage_TextBlock_35.Text" xml:space="preserve">
     <value>网关信息</value>
@@ -1462,7 +1462,7 @@
     <value>版本：</value>
   </data>
   <data name="AboutPage_TextBlock_52.Text" xml:space="preserve">
-    <value>模型：</value>
+    <value>协议：</value>
   </data>
   <data name="AboutPage_TextBlock_56.Text" xml:space="preserve">
     <value>身份验证模式：</value>
@@ -1489,7 +1489,7 @@
     <value>链接</value>
   </data>
   <data name="AboutPage_HyperlinkButton_92.Content" xml:space="preserve">
-    <value>Documentation → openclaw.ai/docs</value>
+    <value>Documentation → docs.openclaw.ai/platforms/windows</value>
   </data>
   <data name="AboutPage_HyperlinkButton_94.Content" xml:space="preserve">
     <value>GitHub → github.com/openclaw/openclaw-windows-node</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -1453,7 +1453,7 @@
     <value>OpenClaw Hub</value>
   </data>
   <data name="AboutPage_TextBlock_23.Text" xml:space="preserve">
-    <value>.NET 10 / WinUI 3 / WinAppSDK 1.8</value>
+    <value>.NET / WinUI / Windows App SDK</value>
   </data>
   <data name="AboutPage_TextBlock_35.Text" xml:space="preserve">
     <value>閘道資訊</value>
@@ -1462,7 +1462,7 @@
     <value>版本：</value>
   </data>
   <data name="AboutPage_TextBlock_52.Text" xml:space="preserve">
-    <value>模型：</value>
+    <value>通訊協定：</value>
   </data>
   <data name="AboutPage_TextBlock_56.Text" xml:space="preserve">
     <value>驗證模式：</value>
@@ -1489,7 +1489,7 @@
     <value>連結</value>
   </data>
   <data name="AboutPage_HyperlinkButton_92.Content" xml:space="preserve">
-    <value>Documentation → openclaw.ai/docs</value>
+    <value>Documentation → docs.openclaw.ai/platforms/windows</value>
   </data>
   <data name="AboutPage_HyperlinkButton_94.Content" xml:space="preserve">
     <value>GitHub → github.com/openclaw/openclaw-windows-node</value>


### PR DESCRIPTION
## Summary
- Fix the About page documentation link to the Windows docs (`docs.openclaw.ai/platforms/windows`).
- Replace stale/hard-coded runtime text with values resolved from the running app: .NET runtime, WinUI major version, and full Windows App SDK package version from the app `.deps.json` (fallback to DLL metadata).
- Rename Gateway Info `Model` to `Protocol`, use source-of-truth log/config paths, harden shell launch failures, and keep uptime fresh while the About page is visible.
- Update localized About page resources for the corrected runtime placeholder, protocol label, and docs link.

## Screenshot / manual verification
The updated About page was manually verified from the provided screenshot. It shows:
- `.NET 10.0.8 / WinUI 3 / Windows App SDK 2.1.3`
- `Protocol: v4`
- refreshed uptime (`3h 10m` in the screenshot)
- corrected docs link: `docs.openclaw.ai/platforms/windows`

Screenshot source in this session: `C:\Users\ranjeshj\AppData\Local\Temp\copilot-image-102f59.png`.

> Note: GitHub CLI/REST does not support uploading local binary PR attachments from this environment, so the image itself is not embedded in the PR body.

## Code review
Ran two adversarial review rounds (Opus + Codex). Addressed the actionable robustness findings:
- Hardened Windows App SDK metadata lookup.
- Hardened shell target handling for empty/malformed targets.
- Added a visible-page uptime ticker based on the latest gateway uptime sample.

Remaining review notes were low/disputed and intentionally left as-is:
- Support-context copy is already protected by `AsyncEventHandlerGuard`.
- Runtime localization of `unknown`/duration units is broader existing behavior, not introduced by this fix.

## Validation
- [x] `./build.ps1`
- [x] `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- [x] `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`
