### PR TITLE
fix(build): capture dotnet stderr without aborting

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -287,6 +287,16 @@ Write-Info "Runtime identifier: $rid"
 
 $buildResults = @{}
 
+function Invoke-DotNetCaptured($arguments) {
+    $previousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        return & dotnet @arguments 2>&1
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+}
+
 function Build-Project($name, $path, $useRid = $false) {
     Write-Host "`nBuilding $name..." -ForegroundColor White
     
@@ -295,12 +305,12 @@ function Build-Project($name, $path, $useRid = $false) {
         return $false
     }
     
+    $dotnetArgs = @("build", $path, "-c", $Configuration)
     # WinUI requires runtime identifier for self-contained WebView2 support
     if ($useRid) {
-        $result = & dotnet build $path -c $Configuration -r $rid 2>&1
-    } else {
-        $result = & dotnet build $path -c $Configuration 2>&1
+        $dotnetArgs += @("-r", $rid)
     }
+    $result = Invoke-DotNetCaptured $dotnetArgs
     $exitCode = $LASTEXITCODE
     
     if ($exitCode -eq 0) {


### PR DESCRIPTION
## Summary
- capture `dotnet build` output through an argument-array helper so native stderr does not trip PowerShell `$ErrorActionPreference = Stop`
- keep `$LASTEXITCODE` as the build success/failure source of truth

## Validation
- fresh Azure normal Windows validation: `./build.ps1` passed
- fresh Azure normal Windows validation: built and ran `OpenClaw.Shared.Tests` with `--no-restore` after an explicit test-project build; command exited 0
- fresh Azure normal Windows validation: built and ran `OpenClaw.Tray.Tests` with `--no-restore`; 976 passed
- final Azure Windows WSL2 smoke: POSIX sync/exec, `git`, `rsync`, WSLInterop, PowerShell bridge, and `wsl.exe --list --verbose` passed
- final Azure native Windows smoke: PowerShell, Git, hostname, sync/exec passed
- `.agents/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings
