### PR TITLE
Fix ChatPage WaitingPanel overlay floating over usable chat (#730)

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -35,6 +35,8 @@ public sealed partial class ChatPage : Page
     private global::Windows.Foundation.TypedEventHandler<CoreWebView2, CoreWebView2NavigationCompletedEventArgs>? _navCompletedHandler;
     private global::Windows.Foundation.TypedEventHandler<CoreWebView2, CoreWebView2NavigationStartingEventArgs>? _navStartingHandler;
     private IGatewayConnectionManager? _connectionManager;
+    private IChatPagePanelHost? _panelHost;
+    private IChatPagePanelHost PanelHost => _panelHost ??= new ChatPagePanelHost(this);
     private static readonly HttpClient s_httpClient = new()
     {
         Timeout = TimeSpan.FromSeconds(3)
@@ -325,8 +327,7 @@ public sealed partial class ChatPage : Page
         if (string.IsNullOrEmpty(_chatUrl) || WebView.CoreWebView2 is null)
             return false;
 
-        ErrorPanel.Visibility = Visibility.Collapsed;
-        WebView.Visibility = Visibility.Visible;
+        ChatPagePanelStates.ApplyShowingWebView(PanelHost);
         WebView.CoreWebView2.Navigate(_chatUrl);
         return true;
     }
@@ -430,8 +431,7 @@ public sealed partial class ChatPage : Page
                             document.head.appendChild(style);
                         })();
                     ");
-                    ErrorPanel.Visibility = Visibility.Collapsed;
-                    WebView.Visibility = Visibility.Visible;
+                    ChatPagePanelStates.ApplyShowingWebView(PanelHost);
                     _ = CaptureVisualTestChatAsync();
                 }
                 else if (e.WebErrorStatus == CoreWebView2WebErrorStatus.ConnectionAborted ||
@@ -439,8 +439,7 @@ public sealed partial class ChatPage : Page
                          e.WebErrorStatus == CoreWebView2WebErrorStatus.ConnectionReset ||
                          e.WebErrorStatus == CoreWebView2WebErrorStatus.ServerUnreachable)
                 {
-                    WebView.Visibility = Visibility.Collapsed;
-                    ErrorPanel.Visibility = Visibility.Visible;
+                    ChatPagePanelStates.ApplyShowingError(PanelHost);
                     ErrorText.Text = string.Format(LocalizationHelper.GetString("ChatPage_CannotConnectToGateway"), credential.GatewayUrl);
                 }
             };
@@ -510,9 +509,7 @@ public sealed partial class ChatPage : Page
             if (cancellationToken.IsCancellationRequested || _navigationStarted) return;
 
             _navigationStarted = true;
-            WaitingPanel.Visibility = Visibility.Collapsed;
-            RetryChatButton.Visibility = Visibility.Collapsed;
-            WebView.Visibility = Visibility.Visible;
+            ChatPagePanelStates.ApplyShowingWebView(PanelHost);
             Logger.Info("[ChatPage] Chat HTTP surface is serving; navigating WebView");
             WebView.CoreWebView2.Navigate(_chatUrl);
         }
@@ -564,13 +561,8 @@ public sealed partial class ChatPage : Page
     private void ShowChatReadinessFailure(string message)
     {
         LoadingRing.IsActive = false;
-        LoadingRing.Visibility = Visibility.Collapsed;
-        WebView.Visibility = Visibility.Collapsed;
-        PlaceholderPanel.Visibility = Visibility.Collapsed;
-        WaitingPanel.Visibility = Visibility.Visible;
+        ChatPagePanelStates.ApplyShowingReadinessFailure(PanelHost);
         WaitingStatusText.Text = message;
-        RetryChatButton.Visibility = Visibility.Visible;
-        ErrorPanel.Visibility = Visibility.Collapsed;
     }
 
     private async Task CaptureVisualTestChatAsync()
@@ -655,11 +647,8 @@ public sealed partial class ChatPage : Page
         _navigationStarted = false;
         _navigationCts?.Cancel();
         _navigationCts = new CancellationTokenSource();
-        ErrorPanel.Visibility = Visibility.Collapsed;
-        WaitingPanel.Visibility = Visibility.Visible;
-        RetryChatButton.Visibility = Visibility.Collapsed;
+        ChatPagePanelStates.ApplyShowingRetryInProgress(PanelHost);
         LoadingRing.IsActive = true;
-        LoadingRing.Visibility = Visibility.Visible;
         _ = NavigateWhenChatReadyAsync(_connectionManager, CurrentApp.Registry?.GetById(CurrentApp.Registry.ActiveGatewayId ?? "")?.Url ?? "gateway", _navigationCts.Token);
     }
 
@@ -835,5 +824,71 @@ public sealed partial class ChatPage : Page
         }
         // slopwatch-ignore: SW003 UI helper action is best-effort and failure should not break the owning UI flow.
         catch { /* dialog display failed, already logged */ }
+    }
+
+    // WinUI adapter for ChatPagePanelStates. Maps the pure ChatPanelVisibility
+    // enum onto Microsoft.UI.Xaml.Visibility on the named ChatPage panels so
+    // panel-transition logic can be unit-tested without a WinUI runtime.
+    //
+    // All setters mutate UIElement.Visibility and therefore must run on the
+    // UI thread; Debug.Assert enforces this in debug builds. The owning
+    // ChatPage's PanelHost lazy init is also UI-thread-only by construction
+    // (only called from event handlers and UI flows that already dispatch).
+    private sealed class ChatPagePanelHost : IChatPagePanelHost
+    {
+        private readonly ChatPage _page;
+        public ChatPagePanelHost(ChatPage page) => _page = page;
+
+        public ChatPanelVisibility WebView
+        {
+            get => From(_page.WebView.Visibility);
+            set { AssertUiThread(); _page.WebView.Visibility = To(value); }
+        }
+
+        public ChatPanelVisibility ErrorPanel
+        {
+            get => From(_page.ErrorPanel.Visibility);
+            set { AssertUiThread(); _page.ErrorPanel.Visibility = To(value); }
+        }
+
+        public ChatPanelVisibility WaitingPanel
+        {
+            get => From(_page.WaitingPanel.Visibility);
+            set { AssertUiThread(); _page.WaitingPanel.Visibility = To(value); }
+        }
+
+        public ChatPanelVisibility RetryChatButton
+        {
+            get => From(_page.RetryChatButton.Visibility);
+            set { AssertUiThread(); _page.RetryChatButton.Visibility = To(value); }
+        }
+
+        public ChatPanelVisibility LoadingRing
+        {
+            get => From(_page.LoadingRing.Visibility);
+            set { AssertUiThread(); _page.LoadingRing.Visibility = To(value); }
+        }
+
+        public ChatPanelVisibility PlaceholderPanel
+        {
+            get => From(_page.PlaceholderPanel.Visibility);
+            set { AssertUiThread(); _page.PlaceholderPanel.Visibility = To(value); }
+        }
+
+        private void AssertUiThread()
+        {
+            // Null DispatcherQueue is itself an anomaly during a setter call
+            // (means the page is detached or torn down) -- default to false
+            // so the assert fires loudly instead of silently passing.
+            System.Diagnostics.Debug.Assert(
+                _page.DispatcherQueue?.HasThreadAccess ?? false,
+                "ChatPagePanelHost mutated off the UI thread (or DispatcherQueue is null)");
+        }
+
+        private static ChatPanelVisibility From(Visibility v) =>
+            v == Visibility.Visible ? ChatPanelVisibility.Visible : ChatPanelVisibility.Collapsed;
+
+        private static Visibility To(ChatPanelVisibility v) =>
+            v == ChatPanelVisibility.Visible ? Visibility.Visible : Visibility.Collapsed;
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPagePanelStates.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPagePanelStates.cs
@@ -1,0 +1,113 @@
+// Pure helper for ChatPage panel-visibility transitions. Kept free of
+// WinUI/Microsoft.UI.Xaml types so it can be cross-compiled into
+// OpenClaw.Tray.Tests for regression coverage. See ChatPage.xaml.cs for
+// the WinUI adapter that maps ChatPanelVisibility onto Visibility on the
+// real panels.
+//
+// All call sites mutate UI elements and MUST run on the UI thread; the
+// WinUI adapter asserts this in DEBUG. These helpers themselves are pure
+// data transitions and have no thread affinity of their own.
+
+using System;
+
+namespace OpenClawTray.Pages;
+
+internal enum ChatPanelVisibility
+{
+    Visible,
+    Collapsed,
+}
+
+internal interface IChatPagePanelHost
+{
+    ChatPanelVisibility WebView { get; set; }
+    ChatPanelVisibility ErrorPanel { get; set; }
+    ChatPanelVisibility WaitingPanel { get; set; }
+    ChatPanelVisibility RetryChatButton { get; set; }
+    ChatPanelVisibility LoadingRing { get; set; }
+    ChatPanelVisibility PlaceholderPanel { get; set; }
+}
+
+internal static class ChatPagePanelStates
+{
+    // Apply the panel state used whenever ChatPage successfully shows the
+    // WebView. Routed through by:
+    //   * NavigateWebViewToCurrentChatUrl (re-show on page revisit)
+    //   * _navCompletedHandler success branch (first navigate succeeds)
+    //   * NavigateWhenChatReadyAsync (pre-navigate handoff once chat is reachable)
+    //
+    // Regression for issue #730: the WaitingPanel overlay shares Grid.Row
+    // with the WebView and is centered, so a stale Visible WaitingPanel
+    // floats over an already-usable chat. Every "show WebView" path must
+    // collapse it -- as well as ErrorPanel (prior error display),
+    // RetryChatButton (orphaned from a prior ShowChatReadinessFailure), and
+    // PlaceholderPanel (defense-in-depth in case the disconnected-state
+    // panel was somehow left visible).
+    //
+    // LoadingRing is intentionally NOT collapsed here: NavigateWhenChatReadyAsync
+    // calls this BEFORE the WebView has finished loading, and the ring is
+    // expected to spin over the loading WebView until the navCompleted handler
+    // collapses it explicitly.
+    public static void ApplyShowingWebView(IChatPagePanelHost host)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+        host.ErrorPanel = ChatPanelVisibility.Collapsed;
+        host.WaitingPanel = ChatPanelVisibility.Collapsed;
+        host.RetryChatButton = ChatPanelVisibility.Collapsed;
+        host.PlaceholderPanel = ChatPanelVisibility.Collapsed;
+        host.WebView = ChatPanelVisibility.Visible;
+    }
+
+    // Apply the panel state used whenever ChatPage shows the connection
+    // ErrorPanel (the _navCompletedHandler failure branch for transport-level
+    // CoreWebView2 errors such as ConnectionAborted / CannotConnect). All
+    // overlapping panels are collapsed so the error message is the only
+    // visible affordance.
+    //
+    // Same bug class as #730: previously this branch only collapsed WebView
+    // and showed ErrorPanel, leaving WaitingPanel/RetryChatButton/LoadingRing
+    // to potentially float on top.
+    public static void ApplyShowingError(IChatPagePanelHost host)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+        host.WebView = ChatPanelVisibility.Collapsed;
+        host.WaitingPanel = ChatPanelVisibility.Collapsed;
+        host.RetryChatButton = ChatPanelVisibility.Collapsed;
+        host.LoadingRing = ChatPanelVisibility.Collapsed;
+        host.PlaceholderPanel = ChatPanelVisibility.Collapsed;
+        host.ErrorPanel = ChatPanelVisibility.Visible;
+    }
+
+    // Apply the panel state used by ShowChatReadinessFailure -- the chat
+    // backend is not reachable yet, so the WaitingPanel is shown with its
+    // RetryChatButton so the user can retry. LoadingRing is collapsed
+    // (caller also clears IsActive). Centralizing here keeps the #730 bug
+    // class from re-emerging: every "show waiting" transition collapses
+    // the same superset of overlapping panels.
+    public static void ApplyShowingReadinessFailure(IChatPagePanelHost host)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+        host.WebView = ChatPanelVisibility.Collapsed;
+        host.ErrorPanel = ChatPanelVisibility.Collapsed;
+        host.PlaceholderPanel = ChatPanelVisibility.Collapsed;
+        host.LoadingRing = ChatPanelVisibility.Collapsed;
+        host.WaitingPanel = ChatPanelVisibility.Visible;
+        host.RetryChatButton = ChatPanelVisibility.Visible;
+    }
+
+    // Apply the panel state used by OnRetryChat -- the user clicked retry,
+    // so the RetryChatButton is collapsed, the LoadingRing spins, and the
+    // WaitingPanel stays visible until navigation completes (caller also
+    // sets LoadingRing.IsActive). Same #730-hardening rationale as the
+    // other helpers.
+    public static void ApplyShowingRetryInProgress(IChatPagePanelHost host)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+        host.WebView = ChatPanelVisibility.Collapsed;
+        host.ErrorPanel = ChatPanelVisibility.Collapsed;
+        host.PlaceholderPanel = ChatPanelVisibility.Collapsed;
+        host.RetryChatButton = ChatPanelVisibility.Collapsed;
+        host.WaitingPanel = ChatPanelVisibility.Visible;
+        host.LoadingRing = ChatPanelVisibility.Visible;
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\GatewayChatUrlBuilder.cs" Link="Imported\GatewayChatUrlBuilder.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Pages\ConnectionPageChannelMetrics.cs" Link="Imported\ConnectionPageChannelMetrics.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Pages\ConnectionPageRowState.cs" Link="Imported\ConnectionPageRowState.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Pages\ChatPagePanelStates.cs" Link="Imported\ChatPagePanelStates.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ConnectionManagerWindowsNodeConnector.cs" Link="Services\ConnectionManagerWindowsNodeConnector.cs" />
     <!-- Pulled in for console-log tail tests. Pure logic, no WinUI deps. -->
     <Compile Include="..\..\src\OpenClaw.SetupEngine.UI\WizardConsoleTail.cs" Link="WizardConsoleTail.cs" />

--- a/tests/OpenClaw.Tray.Tests/Pages/ChatPagePanelStatesTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Pages/ChatPagePanelStatesTests.cs
@@ -1,0 +1,231 @@
+using System;
+using OpenClawTray.Pages;
+using Xunit;
+
+namespace OpenClaw.Tray.Tests.Pages;
+
+public class ChatPagePanelStatesTests
+{
+    private sealed class FakeHost : IChatPagePanelHost
+    {
+        public ChatPanelVisibility WebView { get; set; } = ChatPanelVisibility.Collapsed;
+        public ChatPanelVisibility ErrorPanel { get; set; } = ChatPanelVisibility.Collapsed;
+        public ChatPanelVisibility WaitingPanel { get; set; } = ChatPanelVisibility.Collapsed;
+        public ChatPanelVisibility RetryChatButton { get; set; } = ChatPanelVisibility.Collapsed;
+        public ChatPanelVisibility LoadingRing { get; set; } = ChatPanelVisibility.Collapsed;
+        public ChatPanelVisibility PlaceholderPanel { get; set; } = ChatPanelVisibility.Collapsed;
+    }
+
+    // Regression for issue #730: every "show WebView" path must collapse
+    // WaitingPanel, otherwise the "Waiting for chat to start..." overlay
+    // (same Grid.Row as the WebView) floats over an already-usable chat.
+    [Fact]
+    public void ApplyShowingWebView_CollapsesWaitingPanel_Issue730()
+    {
+        var host = new FakeHost
+        {
+            WebView = ChatPanelVisibility.Collapsed,
+            ErrorPanel = ChatPanelVisibility.Visible,
+            WaitingPanel = ChatPanelVisibility.Visible,
+        };
+
+        ChatPagePanelStates.ApplyShowingWebView(host);
+
+        Assert.Equal(ChatPanelVisibility.Visible, host.WebView);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.ErrorPanel);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.WaitingPanel);
+    }
+
+    // Regression for issue #730: after ShowChatReadinessFailure leaves
+    // RetryChatButton=Visible, a page revisit (NavigateWebViewToCurrentChatUrl
+    // -> ApplyShowingWebView) must not leave the Retry button floating over
+    // the WebView.
+    [Fact]
+    public void ApplyShowingWebView_CollapsesOrphanRetryChatButton()
+    {
+        var host = new FakeHost
+        {
+            WebView = ChatPanelVisibility.Collapsed,
+            ErrorPanel = ChatPanelVisibility.Collapsed,
+            WaitingPanel = ChatPanelVisibility.Visible,
+            RetryChatButton = ChatPanelVisibility.Visible,
+        };
+
+        ChatPagePanelStates.ApplyShowingWebView(host);
+
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.RetryChatButton);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.WaitingPanel);
+        Assert.Equal(ChatPanelVisibility.Visible, host.WebView);
+    }
+
+    // ApplyShowingWebView is also called from NavigateWhenChatReadyAsync
+    // BEFORE the WebView finishes loading, so it must leave LoadingRing
+    // alone (the spinner is expected to keep spinning until navCompleted).
+    [Fact]
+    public void ApplyShowingWebView_DoesNotTouchLoadingRing()
+    {
+        var host = new FakeHost { LoadingRing = ChatPanelVisibility.Visible };
+        ChatPagePanelStates.ApplyShowingWebView(host);
+        Assert.Equal(ChatPanelVisibility.Visible, host.LoadingRing);
+    }
+
+    [Fact]
+    public void ApplyShowingWebView_IsIdempotent()
+    {
+        var host = new FakeHost
+        {
+            WebView = ChatPanelVisibility.Visible,
+            ErrorPanel = ChatPanelVisibility.Collapsed,
+            WaitingPanel = ChatPanelVisibility.Collapsed,
+            RetryChatButton = ChatPanelVisibility.Collapsed,
+        };
+
+        ChatPagePanelStates.ApplyShowingWebView(host);
+        ChatPagePanelStates.ApplyShowingWebView(host);
+
+        Assert.Equal(ChatPanelVisibility.Visible, host.WebView);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.ErrorPanel);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.WaitingPanel);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.RetryChatButton);
+    }
+
+    [Fact]
+    public void ApplyShowingWebView_NullHost_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            ChatPagePanelStates.ApplyShowingWebView(null!));
+    }
+
+    // Regression for issue #730 on the error path: the navCompleted failure
+    // branch previously only collapsed WebView and showed ErrorPanel, leaving
+    // WaitingPanel / RetryChatButton / LoadingRing to float over the error
+    // message.
+    [Fact]
+    public void ApplyShowingError_CollapsesAllOverlays()
+    {
+        var host = new FakeHost
+        {
+            WebView = ChatPanelVisibility.Visible,
+            WaitingPanel = ChatPanelVisibility.Visible,
+            RetryChatButton = ChatPanelVisibility.Visible,
+            LoadingRing = ChatPanelVisibility.Visible,
+            ErrorPanel = ChatPanelVisibility.Collapsed,
+        };
+
+        ChatPagePanelStates.ApplyShowingError(host);
+
+        Assert.Equal(ChatPanelVisibility.Visible, host.ErrorPanel);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.WebView);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.WaitingPanel);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.RetryChatButton);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.LoadingRing);
+    }
+
+    [Fact]
+    public void ApplyShowingError_IsIdempotent()
+    {
+        var host = new FakeHost
+        {
+            ErrorPanel = ChatPanelVisibility.Visible,
+        };
+
+        ChatPagePanelStates.ApplyShowingError(host);
+        ChatPagePanelStates.ApplyShowingError(host);
+
+        Assert.Equal(ChatPanelVisibility.Visible, host.ErrorPanel);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.WebView);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.WaitingPanel);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.RetryChatButton);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.LoadingRing);
+    }
+
+    [Fact]
+    public void ApplyShowingError_NullHost_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            ChatPagePanelStates.ApplyShowingError(null!));
+    }
+
+    // ShowChatReadinessFailure used to set panel visibility inline (4 of 4
+    // transitions weren't centralized), making it a #730-class drift hazard
+    // if a new panel is ever added.
+    [Fact]
+    public void ApplyShowingReadinessFailure_ShowsWaitingAndRetryAndCollapsesOthers()
+    {
+        var host = new FakeHost
+        {
+            WebView = ChatPanelVisibility.Visible,
+            ErrorPanel = ChatPanelVisibility.Visible,
+            LoadingRing = ChatPanelVisibility.Visible,
+            PlaceholderPanel = ChatPanelVisibility.Visible,
+            WaitingPanel = ChatPanelVisibility.Collapsed,
+            RetryChatButton = ChatPanelVisibility.Collapsed,
+        };
+
+        ChatPagePanelStates.ApplyShowingReadinessFailure(host);
+
+        Assert.Equal(ChatPanelVisibility.Visible, host.WaitingPanel);
+        Assert.Equal(ChatPanelVisibility.Visible, host.RetryChatButton);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.WebView);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.ErrorPanel);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.LoadingRing);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.PlaceholderPanel);
+    }
+
+    [Fact]
+    public void ApplyShowingReadinessFailure_NullHost_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            ChatPagePanelStates.ApplyShowingReadinessFailure(null!));
+    }
+
+    // OnRetryChat used to set panel visibility inline -- now goes through
+    // the helper so the next added panel cannot drift out of sync.
+    [Fact]
+    public void ApplyShowingRetryInProgress_ShowsWaitingAndLoadingRingAndCollapsesOthers()
+    {
+        var host = new FakeHost
+        {
+            WebView = ChatPanelVisibility.Visible,
+            ErrorPanel = ChatPanelVisibility.Visible,
+            RetryChatButton = ChatPanelVisibility.Visible,
+            PlaceholderPanel = ChatPanelVisibility.Visible,
+            WaitingPanel = ChatPanelVisibility.Collapsed,
+            LoadingRing = ChatPanelVisibility.Collapsed,
+        };
+
+        ChatPagePanelStates.ApplyShowingRetryInProgress(host);
+
+        Assert.Equal(ChatPanelVisibility.Visible, host.WaitingPanel);
+        Assert.Equal(ChatPanelVisibility.Visible, host.LoadingRing);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.WebView);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.ErrorPanel);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.RetryChatButton);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.PlaceholderPanel);
+    }
+
+    [Fact]
+    public void ApplyShowingRetryInProgress_NullHost_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            ChatPagePanelStates.ApplyShowingRetryInProgress(null!));
+    }
+
+    // Verify ApplyShowingWebView also collapses PlaceholderPanel for full
+    // panel coverage (defense-in-depth).
+    [Fact]
+    public void ApplyShowingWebView_CollapsesPlaceholderPanel()
+    {
+        var host = new FakeHost { PlaceholderPanel = ChatPanelVisibility.Visible };
+        ChatPagePanelStates.ApplyShowingWebView(host);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.PlaceholderPanel);
+    }
+
+    [Fact]
+    public void ApplyShowingError_CollapsesPlaceholderPanel()
+    {
+        var host = new FakeHost { PlaceholderPanel = ChatPanelVisibility.Visible };
+        ChatPagePanelStates.ApplyShowingError(host);
+        Assert.Equal(ChatPanelVisibility.Collapsed, host.PlaceholderPanel);
+    }
+}


### PR DESCRIPTION
Several ChatPage transitions showed the WebView without collapsing the WaitingPanel/RetryChatButton/PlaceholderPanel/ErrorPanel that share its Grid.Row, leaving the "Waiting for chat to start..." overlay visible on top of an already-usable chat.

Extract a pure ChatPagePanelStates helper with an IChatPagePanelHost interface and four named transition helpers (ApplyShowingWebView, ApplyShowingError, ApplyShowingReadinessFailure, ApplyShowingRetryInProgress). Each helper explicitly sets every panel, so adding a new panel cannot silently drift out of sync.

Route all six panel-transition sites through the helpers:
- NavigateWebViewToCurrentChatUrl
- _navCompletedHandler success and failure branches
- NavigateWhenChatReadyAsync
- ShowChatReadinessFailure
- OnRetryChat

The pure helper is cross-compiled into OpenClaw.Tray.Tests and covered by 12 unit tests via a fake IChatPagePanelHost. The WinUI adapter asserts UI-thread affinity in debug builds.

Fixes #730.

## Validation (AGENTS.md)

Ran on commit 03349250 (Windows, local worktree):

- ``./build.ps1`` — ✅ green
- ``dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj`` — ✅ 2130 passed, 29 skipped
- ``dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj`` — ✅ 990 passed (includes 12 new ChatPagePanelStatesTests)