### PR TITLE
Guard WebSocket lifecycle with connection generations

### DIFF
--- a/src/OpenClaw.Shared/WebSocketClientBase.cs
+++ b/src/OpenClaw.Shared/WebSocketClientBase.cs
@@ -309,7 +309,7 @@ public abstract class WebSocketClientBase : IDisposable
             {
                 if (!_cts.Token.IsCancellationRequested && ShouldAutoReconnect())
                 {
-                    await ReconnectWithBackoffAsync();
+                    await ReconnectWithBackoffAsync(ws, connectionGeneration);
                 }
             }
             // slopwatch-ignore: SW003 Shutdown cancellation or disposal is expected and the caller already preserves the safe state.
@@ -317,7 +317,9 @@ public abstract class WebSocketClientBase : IDisposable
         }
     }
 
-    protected async Task ReconnectWithBackoffAsync()
+    protected async Task ReconnectWithBackoffAsync(
+        ClientWebSocket? expectedSocket = null,
+        long expectedGeneration = 0)
     {
         if (Interlocked.CompareExchange(ref _reconnectLoopActive, 1, 0) != 0)
         {
@@ -326,7 +328,10 @@ public abstract class WebSocketClientBase : IDisposable
 
         try
         {
-            while (!_disposed && !_cts.Token.IsCancellationRequested && ShouldAutoReconnect())
+            while (!_disposed
+                && !_cts.Token.IsCancellationRequested
+                && ShouldAutoReconnect()
+                && IsReconnectOwner(expectedSocket, expectedGeneration))
             {
                 var delay = BackoffMs[Math.Min(_reconnectAttempts, BackoffMs.Length - 1)];
                 // Add 0-25% jitter to prevent thundering herd when multiple clients
@@ -339,16 +344,20 @@ public abstract class WebSocketClientBase : IDisposable
 
                 await Task.Delay(delay, _cts.Token);
 
-                if (_cts.Token.IsCancellationRequested || _disposed || !ShouldAutoReconnect())
+                if (_cts.Token.IsCancellationRequested
+                    || _disposed
+                    || !ShouldAutoReconnect()
+                    || !IsReconnectOwner(expectedSocket, expectedGeneration))
                 {
                     break;
                 }
 
                 // Safely dispose old socket
-                var oldSocket = _webSocket;
-                _webSocket = null;
-                try { oldSocket?.Dispose(); }
-                catch (Exception ex) { _logger.Debug($"WebSocketClientBase: Dispose of old WebSocket during reconnect threw: {ex.Message}"); }
+                var oldSocket = expectedSocket ?? _webSocket;
+                if (oldSocket != null)
+                {
+                    DisposeStaleSocket(oldSocket);
+                }
 
                 await ConnectAsync();
 
@@ -370,6 +379,9 @@ public abstract class WebSocketClientBase : IDisposable
             Interlocked.Exchange(ref _reconnectLoopActive, 0);
         }
     }
+
+    private bool IsReconnectOwner(ClientWebSocket? expectedSocket, long expectedGeneration) =>
+        expectedSocket is null || IsCurrentConnection(expectedSocket, expectedGeneration);
 
     /// <summary>Send a text message over the WebSocket. Thread-safe.</summary>
     protected async Task SendRawAsync(string message)

--- a/src/OpenClaw.Shared/WebSocketClientBase.cs
+++ b/src/OpenClaw.Shared/WebSocketClientBase.cs
@@ -21,6 +21,7 @@ public abstract class WebSocketClientBase : IDisposable
     private bool _disposed;
     private int _reconnectAttempts;
     private int _reconnectLoopActive;
+    private long _connectionGeneration;
     private readonly SemaphoreSlim _sendLock = new(1, 1);
     private static readonly int[] BackoffMs = { 1000, 2000, 4000, 8000, 15000, 30000, 60000 };
 
@@ -111,29 +112,38 @@ public abstract class WebSocketClientBase : IDisposable
             return;
         }
 
+        var connectGeneration = Interlocked.Increment(ref _connectionGeneration);
+        ClientWebSocket? ws = null;
+
         try
         {
             RaiseStatusChanged(ConnectionStatus.Connecting);
             _logger.Info($"Connecting to {ClientRole}: {GatewayUrlForDisplay}");
 
-            _webSocket = new ClientWebSocket();
-            _webSocket.Options.KeepAliveInterval = TimeSpan.FromSeconds(30);
+            ws = new ClientWebSocket();
+            ws.Options.KeepAliveInterval = TimeSpan.FromSeconds(30);
+            _webSocket = ws;
 
             // Set Origin header (convert ws/wss to http/https)
             var uri = new Uri(_gatewayUrl);
             var originScheme = uri.Scheme == "wss" ? "https" : "http";
             var origin = $"{originScheme}://{uri.Host}:{uri.Port}";
-            _webSocket.Options.SetRequestHeader("Origin", origin);
+            ws.Options.SetRequestHeader("Origin", origin);
 
             if (!string.IsNullOrEmpty(_credentials))
             {
                 var credentialsToEncode = GatewayUrlHelper.DecodeCredentials(_credentials);
-                _webSocket.Options.SetRequestHeader(
+                ws.Options.SetRequestHeader(
                     "Authorization",
                     $"Basic {Convert.ToBase64String(Encoding.UTF8.GetBytes(credentialsToEncode))}");
             }
 
-            await _webSocket.ConnectAsync(uri, _cts.Token);
+            await ws.ConnectAsync(uri, _cts.Token);
+            if (!IsCurrentConnection(ws, connectGeneration))
+            {
+                DisposeStaleSocket(ws);
+                return;
+            }
 
             // Don't reset _reconnectAttempts here — TCP connect succeeding doesn't mean
             // auth will succeed. Reset only after the full application-level handshake
@@ -141,19 +151,43 @@ public abstract class WebSocketClientBase : IDisposable
             _logger.Info($"{ClientRole} connected, waiting for challenge...");
 
             await OnConnectedAsync();
+            if (!IsCurrentConnection(ws, connectGeneration))
+            {
+                DisposeStaleSocket(ws);
+                return;
+            }
 
-            _ = Task.Run(() => ListenForMessagesAsync(), _cts.Token);
+            _ = Task.Run(() => ListenForMessagesAsync(ws, connectGeneration), _cts.Token);
         }
         catch (OperationCanceledException)
         {
+            if (ws != null)
+            {
+                DisposeStaleSocket(ws);
+            }
             _logger.Debug($"{ClientRole} connect canceled (likely shutdown)");
         }
         catch (ObjectDisposedException)
         {
+            if (ws != null)
+            {
+                DisposeStaleSocket(ws);
+            }
             _logger.Debug($"{ClientRole} connect aborted after dispose");
         }
         catch (Exception ex)
         {
+            if (ws != null && !IsCurrentConnection(ws, connectGeneration))
+            {
+                DisposeStaleSocket(ws);
+                _logger.Debug($"{ClientRole} stale connection failure ignored: {ex.Message}");
+                return;
+            }
+
+            if (ws != null)
+            {
+                DisposeStaleSocket(ws);
+            }
             _logger.Error($"{ClientRole} connection failed", ex);
             RaiseStatusChanged(ConnectionStatus.Error);
 
@@ -164,7 +198,23 @@ public abstract class WebSocketClientBase : IDisposable
         }
     }
 
-    private async Task ListenForMessagesAsync()
+    private bool IsCurrentConnection(ClientWebSocket ws, long generation) =>
+        !_disposed
+        && Interlocked.Read(ref _connectionGeneration) == generation
+        && ReferenceEquals(_webSocket, ws);
+
+    private void DisposeStaleSocket(ClientWebSocket ws)
+    {
+        if (ReferenceEquals(_webSocket, ws))
+        {
+            _webSocket = null;
+        }
+
+        // slopwatch-ignore: SW003 Cleanup is best-effort for superseded sockets.
+        try { ws.Dispose(); } catch { }
+    }
+
+    private async Task ListenForMessagesAsync(ClientWebSocket ws, long connectionGeneration)
     {
         // Rent a pooled buffer — consistent with the SendRawAsync hot path; avoids a large
         // (16–64 KB) heap allocation per connection that would otherwise land on the LOH.
@@ -173,10 +223,14 @@ public abstract class WebSocketClientBase : IDisposable
 
         try
         {
-            while (_webSocket?.State == WebSocketState.Open && !_cts.Token.IsCancellationRequested)
+            while (ws.State == WebSocketState.Open && !_cts.Token.IsCancellationRequested)
             {
-                var result = await _webSocket.ReceiveAsync(
+                var result = await ws.ReceiveAsync(
                     new ArraySegment<byte>(buffer, 0, ReceiveBufferSize), _cts.Token);
+                if (!IsCurrentConnection(ws, connectionGeneration))
+                {
+                    break;
+                }
 
                 if (result.MessageType == WebSocketMessageType.Text)
                 {
@@ -211,11 +265,14 @@ public abstract class WebSocketClientBase : IDisposable
                 }
                 else if (result.MessageType == WebSocketMessageType.Close)
                 {
-                    var closeStatus = _webSocket.CloseStatus?.ToString() ?? "unknown";
-                    var closeDesc = _webSocket.CloseStatusDescription ?? "no description";
+                    var closeStatus = ws.CloseStatus?.ToString() ?? "unknown";
+                    var closeDesc = ws.CloseStatusDescription ?? "no description";
                     _logger.Info($"Server closed connection: {closeStatus} - {closeDesc}");
-                    OnDisconnected();
-                    RaiseStatusChanged(ConnectionStatus.Disconnected);
+                    if (IsCurrentConnection(ws, connectionGeneration))
+                    {
+                        OnDisconnected();
+                        RaiseStatusChanged(ConnectionStatus.Disconnected);
+                    }
                     break;
                 }
             }
@@ -223,8 +280,11 @@ public abstract class WebSocketClientBase : IDisposable
         catch (WebSocketException ex) when (ex.WebSocketErrorCode == WebSocketError.ConnectionClosedPrematurely)
         {
             _logger.Warn("Connection closed prematurely");
-            OnDisconnected();
-            RaiseStatusChanged(ConnectionStatus.Disconnected);
+            if (IsCurrentConnection(ws, connectionGeneration))
+            {
+                OnDisconnected();
+                RaiseStatusChanged(ConnectionStatus.Disconnected);
+            }
         }
         // slopwatch-ignore: SW003 Shutdown cancellation or disposal is expected and the caller already preserves the safe state.
         catch (OperationCanceledException) { }
@@ -233,8 +293,11 @@ public abstract class WebSocketClientBase : IDisposable
         catch (Exception ex)
         {
             _logger.Error($"{ClientRole} listen error", ex);
-            OnError(ex);
-            RaiseStatusChanged(ConnectionStatus.Error);
+            if (IsCurrentConnection(ws, connectionGeneration))
+            {
+                OnError(ex);
+                RaiseStatusChanged(ConnectionStatus.Error);
+            }
         }
         finally
         {
@@ -242,7 +305,7 @@ public abstract class WebSocketClientBase : IDisposable
         }
 
         // Auto-reconnect if not intentionally disposed
-        if (!_disposed)
+        if (IsCurrentConnection(ws, connectionGeneration))
         {
             try
             {
@@ -392,6 +455,8 @@ public abstract class WebSocketClientBase : IDisposable
         _disposed = true;
 
         OnDisposing();
+
+        Interlocked.Increment(ref _connectionGeneration);
 
         // slopwatch-ignore: SW003 Cleanup is best-effort; failure cannot improve caller state and the original outcome is preserved.
         try { _cts.Cancel(); } catch { }

--- a/src/OpenClaw.Shared/WebSocketClientBase.cs
+++ b/src/OpenClaw.Shared/WebSocketClientBase.cs
@@ -359,6 +359,14 @@ public abstract class WebSocketClientBase : IDisposable
                     DisposeStaleSocket(oldSocket);
                 }
 
+                var currentSocket = _webSocket;
+                if (currentSocket != null
+                    && !ReferenceEquals(currentSocket, oldSocket)
+                    && IsSocketClosingOrClosed(currentSocket))
+                {
+                    DisposeStaleSocket(currentSocket);
+                }
+
                 await ConnectAsync();
 
                 if (IsConnected)
@@ -380,8 +388,22 @@ public abstract class WebSocketClientBase : IDisposable
         }
     }
 
-    private bool IsReconnectOwner(ClientWebSocket? expectedSocket, long expectedGeneration) =>
-        expectedSocket is null || IsCurrentConnection(expectedSocket, expectedGeneration);
+    private bool IsReconnectOwner(ClientWebSocket? expectedSocket, long expectedGeneration)
+    {
+        if (expectedSocket is null || IsCurrentConnection(expectedSocket, expectedGeneration))
+        {
+            return true;
+        }
+
+        var currentSocket = _webSocket;
+        return currentSocket is null || IsSocketClosingOrClosed(currentSocket);
+    }
+
+    private static bool IsSocketClosingOrClosed(ClientWebSocket ws) =>
+        ws.State is WebSocketState.CloseReceived
+            or WebSocketState.CloseSent
+            or WebSocketState.Closed
+            or WebSocketState.Aborted;
 
     /// <summary>Send a text message over the WebSocket. Thread-safe.</summary>
     protected async Task SendRawAsync(string message)

--- a/tests/OpenClaw.Shared.Tests/WebSocketClientBaseTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WebSocketClientBaseTests.cs
@@ -352,6 +352,67 @@ public class WebSocketClientBaseTests
         client.Dispose();
     }
 
+    [Fact]
+    public async Task ReconnectBackoff_ContinuesAfterFailedRetry_WhenNoNewerConnectionOwnsSocket()
+    {
+        using var server = new LoopbackWebSocketServer();
+        await server.StartAsync();
+        var client = new ReconnectBackoffRaceClient(server.WebSocketUrl, "token", _logger);
+        var statuses = new ConcurrentQueue<ConnectionStatus>();
+        client.StatusChanged += (_, s) => statuses.Enqueue(s);
+
+        await client.ConnectAsync();
+        await client.FirstConnected.WaitAsync(TimeSpan.FromSeconds(2));
+        await WaitForConditionAsync(() => server.AcceptedCount >= 1, TimeSpan.FromSeconds(2));
+
+        await server.CloseSocketAsync(0);
+        server.StopAccepting();
+
+        await WaitForConditionAsync(
+            () => statuses.Count(s => s == ConnectionStatus.Connecting) >= 4,
+            TimeSpan.FromSeconds(4));
+
+        Assert.Equal(1, client.OnConnectedCallCount);
+        Assert.True(_logger.Logs.Count(
+            line => line.Contains("reconnecting in", StringComparison.OrdinalIgnoreCase)) >= 2);
+
+        client.Dispose();
+    }
+
+    [Fact]
+    public async Task ReconnectBackoff_ReconnectsCurrentClosingSocket_WhenSupersededLoopIsActive()
+    {
+        using var server = new LoopbackWebSocketServer();
+        await server.StartAsync();
+        var client = new ReconnectBackoffRaceClient(server.WebSocketUrl, "token", _logger);
+        var statuses = new ConcurrentQueue<ConnectionStatus>();
+        client.StatusChanged += (_, s) => statuses.Enqueue(s);
+
+        await client.ConnectAsync();
+        await client.FirstConnected.WaitAsync(TimeSpan.FromSeconds(2));
+        await WaitForConditionAsync(() => server.AcceptedCount >= 1, TimeSpan.FromSeconds(2));
+
+        await server.CloseSocketAsync(0);
+        await WaitForConditionAsync(
+            () => statuses.Count(s => s == ConnectionStatus.Connecting) >= 2,
+            TimeSpan.FromSeconds(2));
+
+        await client.ConnectAsync();
+        await client.SecondConnected.WaitAsync(TimeSpan.FromSeconds(2));
+        await WaitForConditionAsync(() => server.AcceptedCount >= 2, TimeSpan.FromSeconds(2));
+
+        await server.CloseSocketAsync(1);
+
+        var reconnect = await Task.WhenAny(
+            client.ThirdConnected,
+            Task.Delay(TimeSpan.FromSeconds(3)));
+
+        Assert.Same(client.ThirdConnected, reconnect);
+        Assert.True(server.AcceptedCount >= 3);
+
+        client.Dispose();
+    }
+
     private static async Task WaitForConditionAsync(Func<bool> predicate, TimeSpan timeout)
     {
         var start = DateTime.UtcNow;
@@ -530,6 +591,13 @@ internal sealed class LoopbackWebSocketServer : IDisposable
                 "test close",
                 CancellationToken.None);
         }
+    }
+
+    public void StopAccepting()
+    {
+        _cts.Cancel();
+        try { _listener.Stop(); } catch { }
+        try { _acceptLoop?.Wait(TimeSpan.FromSeconds(1)); } catch { }
     }
 
     public void Dispose()

--- a/tests/OpenClaw.Shared.Tests/WebSocketClientBaseTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WebSocketClientBaseTests.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.WebSockets;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -277,6 +281,45 @@ public class WebSocketClientBaseTests
         client.Dispose();
     }
 
+    [Fact]
+    public async Task ConnectAsync_StaleConnectionDoesNotStartListenerOnNewerSocket()
+    {
+        using var server = new LoopbackWebSocketServer();
+        await server.StartAsync();
+        var client = new BlockingFirstConnectClient(server.WebSocketUrl, "token", _logger);
+        var statuses = new ConcurrentQueue<ConnectionStatus>();
+        var unexpectedErrorStatus = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        client.StatusChanged += (_, s) => statuses.Enqueue(s);
+        client.StatusChanged += (_, s) =>
+        {
+            if (s == ConnectionStatus.Error)
+                unexpectedErrorStatus.TrySetResult();
+        };
+
+        var firstConnect = client.ConnectAsync();
+        await client.FirstConnectEntered.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var secondConnect = client.ConnectAsync();
+        await client.SecondConnectReturned.WaitAsync(TimeSpan.FromSeconds(2));
+
+        client.ReleaseFirstConnect();
+        await Task.WhenAll(firstConnect, secondConnect).WaitAsync(TimeSpan.FromSeconds(2));
+
+        // If the stale first ConnectAsync starts a listener after the second
+        // connection is current, two listeners race on the same ClientWebSocket
+        // and one reports a listen error.
+        var unexpected = await Task.WhenAny(
+            unexpectedErrorStatus.Task,
+            Task.Delay(TimeSpan.FromMilliseconds(250)));
+
+        Assert.Equal(2, client.OnConnectedCallCount);
+        Assert.NotSame(unexpectedErrorStatus.Task, unexpected);
+        Assert.Equal(0, client.OnErrorCallCount);
+        Assert.DoesNotContain(ConnectionStatus.Error, statuses);
+
+        client.Dispose();
+    }
+
     private static async Task WaitForConditionAsync(Func<bool> predicate, TimeSpan timeout)
     {
         var start = DateTime.UtcNow;
@@ -287,6 +330,135 @@ public class WebSocketClientBaseTests
 
             // slopwatch-ignore: SW004 Test delay is an intentional bounded async wait; replacing it would change the scenario under test.
             await Task.Delay(25);
+        }
+    }
+}
+
+internal sealed class BlockingFirstConnectClient : WebSocketClientBase
+{
+    private readonly TaskCompletionSource _firstConnectEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _releaseFirstConnect = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _secondConnectReturned = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _connectCallbacks;
+
+    public int OnConnectedCallCount => Volatile.Read(ref _connectCallbacks);
+    public int OnErrorCallCount { get; private set; }
+    public Task FirstConnectEntered => _firstConnectEntered.Task;
+    public Task SecondConnectReturned => _secondConnectReturned.Task;
+
+    public BlockingFirstConnectClient(string gatewayUrl, string token, IOpenClawLogger? logger = null)
+        : base(gatewayUrl, token, logger)
+    {
+    }
+
+    protected override int ReceiveBufferSize => 8192;
+    protected override string ClientRole => "race-test";
+    protected override bool ShouldAutoReconnect() => false;
+
+    protected override Task ProcessMessageAsync(string json) => Task.CompletedTask;
+
+    protected override async Task OnConnectedAsync()
+    {
+        var count = Interlocked.Increment(ref _connectCallbacks);
+        if (count == 1)
+        {
+            _firstConnectEntered.TrySetResult();
+            await _releaseFirstConnect.Task;
+            return;
+        }
+
+        _secondConnectReturned.TrySetResult();
+    }
+
+    protected override void OnError(Exception ex) => OnErrorCallCount++;
+
+    public void ReleaseFirstConnect() => _releaseFirstConnect.TrySetResult();
+}
+
+internal sealed class LoopbackWebSocketServer : IDisposable
+{
+    private readonly HttpListener _listener = new();
+    private readonly CancellationTokenSource _cts = new();
+    private readonly List<WebSocket> _acceptedSockets = new();
+    private Task? _acceptLoop;
+
+    public string WebSocketUrl { get; }
+
+    public LoopbackWebSocketServer()
+    {
+        var port = GetFreeTcpPort();
+        var prefix = $"http://127.0.0.1:{port}/";
+        _listener.Prefixes.Add(prefix);
+        WebSocketUrl = $"ws://127.0.0.1:{port}/";
+    }
+
+    public Task StartAsync()
+    {
+        _listener.Start();
+        _acceptLoop = Task.Run(AcceptLoopAsync);
+        return Task.CompletedTask;
+    }
+
+    private async Task AcceptLoopAsync()
+    {
+        while (!_cts.Token.IsCancellationRequested)
+        {
+            HttpListenerContext context;
+            try
+            {
+                context = await _listener.GetContextAsync();
+            }
+            catch (HttpListenerException) when (_cts.Token.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (ObjectDisposedException)
+            {
+                return;
+            }
+
+            if (!context.Request.IsWebSocketRequest)
+            {
+                context.Response.StatusCode = 400;
+                context.Response.Close();
+                continue;
+            }
+
+            var wsContext = await context.AcceptWebSocketAsync(subProtocol: null);
+            lock (_acceptedSockets)
+            {
+                _acceptedSockets.Add(wsContext.WebSocket);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        try { _listener.Stop(); } catch { }
+        try { _listener.Close(); } catch { }
+        lock (_acceptedSockets)
+        {
+            foreach (var socket in _acceptedSockets)
+            {
+                try { socket.Dispose(); } catch { }
+            }
+        }
+        try { _acceptLoop?.Wait(TimeSpan.FromSeconds(1)); } catch { }
+        _cts.Dispose();
+    }
+
+    private static int GetFreeTcpPort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
         }
     }
 }

--- a/tests/OpenClaw.Shared.Tests/WebSocketClientBaseTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WebSocketClientBaseTests.cs
@@ -320,6 +320,38 @@ public class WebSocketClientBaseTests
         client.Dispose();
     }
 
+    [Fact]
+    public async Task ReconnectBackoff_DoesNotDisposeNewerConnection_WhenSupersededDuringDelay()
+    {
+        using var server = new LoopbackWebSocketServer();
+        await server.StartAsync();
+        var client = new ReconnectBackoffRaceClient(server.WebSocketUrl, "token", _logger);
+        var statuses = new ConcurrentQueue<ConnectionStatus>();
+        client.StatusChanged += (_, s) => statuses.Enqueue(s);
+
+        await client.ConnectAsync();
+        await client.FirstConnected.WaitAsync(TimeSpan.FromSeconds(2));
+        await WaitForConditionAsync(() => server.AcceptedCount >= 1, TimeSpan.FromSeconds(2));
+
+        await server.CloseSocketAsync(0);
+        await WaitForConditionAsync(
+            () => statuses.Count(s => s == ConnectionStatus.Connecting) >= 2,
+            TimeSpan.FromSeconds(2));
+
+        await client.ConnectAsync();
+        await client.SecondConnected.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var staleReconnectWon = await Task.WhenAny(
+            client.ThirdConnected,
+            Task.Delay(TimeSpan.FromMilliseconds(1800)));
+
+        Assert.NotSame(client.ThirdConnected, staleReconnectWon);
+        Assert.Equal(2, client.OnConnectedCallCount);
+        Assert.Equal(2, server.AcceptedCount);
+
+        client.Dispose();
+    }
+
     private static async Task WaitForConditionAsync(Func<bool> predicate, TimeSpan timeout)
     {
         var start = DateTime.UtcNow;
@@ -375,6 +407,47 @@ internal sealed class BlockingFirstConnectClient : WebSocketClientBase
     public void ReleaseFirstConnect() => _releaseFirstConnect.TrySetResult();
 }
 
+internal sealed class ReconnectBackoffRaceClient : WebSocketClientBase
+{
+    private readonly TaskCompletionSource _firstConnected = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _secondConnected = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _thirdConnected = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _connectCallbacks;
+
+    public int OnConnectedCallCount => Volatile.Read(ref _connectCallbacks);
+    public Task FirstConnected => _firstConnected.Task;
+    public Task SecondConnected => _secondConnected.Task;
+    public Task ThirdConnected => _thirdConnected.Task;
+
+    public ReconnectBackoffRaceClient(string gatewayUrl, string token, IOpenClawLogger? logger = null)
+        : base(gatewayUrl, token, logger)
+    {
+    }
+
+    protected override int ReceiveBufferSize => 8192;
+    protected override string ClientRole => "reconnect-race-test";
+    protected override Task ProcessMessageAsync(string json) => Task.CompletedTask;
+
+    protected override Task OnConnectedAsync()
+    {
+        var count = Interlocked.Increment(ref _connectCallbacks);
+        switch (count)
+        {
+            case 1:
+                _firstConnected.TrySetResult();
+                break;
+            case 2:
+                _secondConnected.TrySetResult();
+                break;
+            case 3:
+                _thirdConnected.TrySetResult();
+                break;
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
 internal sealed class LoopbackWebSocketServer : IDisposable
 {
     private readonly HttpListener _listener = new();
@@ -383,6 +456,16 @@ internal sealed class LoopbackWebSocketServer : IDisposable
     private Task? _acceptLoop;
 
     public string WebSocketUrl { get; }
+    public int AcceptedCount
+    {
+        get
+        {
+            lock (_acceptedSockets)
+            {
+                return _acceptedSockets.Count;
+            }
+        }
+    }
 
     public LoopbackWebSocketServer()
     {
@@ -429,6 +512,23 @@ internal sealed class LoopbackWebSocketServer : IDisposable
             {
                 _acceptedSockets.Add(wsContext.WebSocket);
             }
+        }
+    }
+
+    public async Task CloseSocketAsync(int index)
+    {
+        WebSocket socket;
+        lock (_acceptedSockets)
+        {
+            socket = _acceptedSockets[index];
+        }
+
+        if (socket.State == WebSocketState.Open)
+        {
+            await socket.CloseOutputAsync(
+                WebSocketCloseStatus.NormalClosure,
+                "test close",
+                CancellationToken.None);
         }
     }
 


### PR DESCRIPTION
Fixes #696.

## Summary
- add a per-connection generation guard so stale connect/listen work cannot act on newer WebSocket connections
- make listen loops operate on their captured socket and skip stale message, disconnect, error, and reconnect handling
- add a loopback WebSocket regression test for overlapping connects

## Validation
- .\build.ps1
- dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore
- dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore
- dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore
- dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore --filter "FullyQualifiedName~WebSocketClientBaseTests"
- git diff --check

## Review
- Ran Hanselman-style dual-model adversarial review and addressed the actionable findings: stale text message processing and test flake risk.



## Proof
![WebSocketClientBase tests passing](https://raw.githubusercontent.com/christineyan4/openclaw-windows-node/pr-proof-assets/pr-proof/739-websocket-tests.png)

