### PR TITLE
Clear chat history after session reset

### DIFF
--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -2395,7 +2395,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
                 RunId = payload.TryGetProperty("runId", out var rid) ? rid.GetString() ?? "" : "",
                 Seq = payload.TryGetProperty("seq", out var seqProp) && seqProp.ValueKind == JsonValueKind.Number ? seqProp.GetInt32() : 0,
                 Stream = payload.TryGetProperty("stream", out var streamProp2) ? streamProp2.GetString() ?? "" : "",
-                Ts = payload.TryGetProperty("ts", out var tsProp) && tsProp.ValueKind == JsonValueKind.Number ? tsProp.GetDouble() : 0,
+                Ts = ExtractChatTimestampMs(payload),
                 Data = payload.TryGetProperty("data", out var dataProp) ? dataProp.Clone() : default,
                 SessionKey = sessionKey,
                 Summary = payload.TryGetProperty("summary", out var sumProp) ? sumProp.GetString() : null
@@ -2554,12 +2554,15 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
         // from common locations so any reasonable shape lights up the chat
         // footer pills.
         var (inTok, outTok, respTok, ctxPct) = ExtractChatUsage(payload);
+        var tsMs = ExtractChatTimestampMs(payload);
 
         // Try new format: payload.message.role + payload.message.content[].text
         if (payload.TryGetProperty("message", out var message))
         {
             var role = message.TryGetProperty("role", out var roleProp) ? roleProp.GetString() ?? "" : "";
             var state = payload.TryGetProperty("state", out var stateProp) ? stateProp.GetString() : null;
+            if (tsMs == 0)
+                tsMs = ExtractChatTimestampMs(message);
 
             // Usage block may also live on the inner ``message`` object.
             if (inTok is null && outTok is null && respTok is null && ctxPct is null)
@@ -2570,7 +2573,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
                 var text = ExtractMessageText(message);
                 if (string.IsNullOrEmpty(text)) return;
 
-                EmitChatMessageReceived(sessionKey, role, text, state, inTok, outTok, respTok, ctxPct);
+                EmitChatMessageReceived(sessionKey, role, text, state, tsMs, inTok, outTok, respTok, ctxPct);
 
                 if (role == "assistant" && string.Equals(state, "final", StringComparison.OrdinalIgnoreCase))
                 {
@@ -2591,7 +2594,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
 
             if (!string.IsNullOrEmpty(text))
             {
-                EmitChatMessageReceived(sessionKey, role, text, state, inTok, outTok, respTok, ctxPct);
+                EmitChatMessageReceived(sessionKey, role, text, state, tsMs, inTok, outTok, respTok, ctxPct);
 
                 if (role == "assistant")
                 {
@@ -2653,7 +2656,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
         return (input, output, response, ctx);
     }
 
-    private void EmitChatMessageReceived(string sessionKey, string role, string text, string? state,
+    private void EmitChatMessageReceived(string sessionKey, string role, string text, string? state, long tsMs,
         int? inputTokens = null, int? outputTokens = null, int? responseTokens = null, int? contextPct = null)
     {
         try
@@ -2664,6 +2667,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
                 Role = role,
                 Text = text,
                 State = state,
+                Ts = tsMs,
                 InputTokens = inputTokens,
                 OutputTokens = outputTokens,
                 ResponseTokens = responseTokens,
@@ -2674,6 +2678,34 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
         {
             _logger.Warn($"ChatMessageReceived handler threw: {ex.Message}");
         }
+    }
+
+    private static long ExtractChatTimestampMs(JsonElement node)
+    {
+        if (node.ValueKind != JsonValueKind.Object)
+            return 0;
+
+        foreach (var key in new[] { "timestamp", "ts" })
+        {
+            if (!node.TryGetProperty(key, out var value) ||
+                value.ValueKind != JsonValueKind.Number ||
+                !value.TryGetDouble(out var raw))
+            {
+                continue;
+            }
+
+            var ms = raw > 10_000_000_000 ? raw : raw * 1000;
+            try
+            {
+                return DateTimeOffset.FromUnixTimeMilliseconds((long)ms).ToUnixTimeMilliseconds();
+            }
+            catch
+            {
+                continue;
+            }
+        }
+
+        return 0;
     }
 
     private void EmitRawChatEvent(JsonElement payload)

--- a/src/OpenClaw.Tray.WinUI/Chat/IChatGatewayBridge.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/IChatGatewayBridge.cs
@@ -35,6 +35,7 @@ public interface IChatGatewayBridge : IDisposable
     void StartProactiveBootstrap();
 
     Task SendChatMessageAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null);
+    Task<ChatSendResult> SendChatMessageForRunAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null);
     Task PatchSessionModelAsync(string sessionKey, string model);
     Task PatchSessionThinkingLevelAsync(string sessionKey, string thinkingLevel);
     Task<ChatHistoryInfo> RequestChatHistoryAsync(string? sessionKey);
@@ -42,6 +43,7 @@ public interface IChatGatewayBridge : IDisposable
 
     event EventHandler<ConnectionStatus>? StatusChanged;
     event EventHandler<SessionInfo[]>? SessionsUpdated;
+    event EventHandler<SessionCommandResult>? SessionCommandCompleted;
     event EventHandler<ChatMessageInfo>? ChatMessageReceived;
     event EventHandler<AgentEventInfo>? AgentEventReceived;
     event EventHandler<ModelsListInfo>? ModelsListUpdated;
@@ -55,6 +57,7 @@ public sealed class GatewayClientChatBridge : IChatGatewayBridge
     private readonly OpenClawGatewayClient _client;
     private readonly EventHandler<ConnectionStatus> _statusChangedHandler;
     private readonly EventHandler<SessionInfo[]> _sessionsUpdatedHandler;
+    private readonly EventHandler<SessionCommandResult> _sessionCommandCompletedHandler;
     private readonly EventHandler<ChatMessageInfo> _chatMessageReceivedHandler;
     private readonly EventHandler<AgentEventInfo> _agentEventReceivedHandler;
     private readonly EventHandler<ModelsListInfo> _modelsListUpdatedHandler;
@@ -88,6 +91,7 @@ public sealed class GatewayClientChatBridge : IChatGatewayBridge
             }
         };
         _sessionsUpdatedHandler = (s, e) => SessionsUpdated?.Invoke(s, e);
+        _sessionCommandCompletedHandler = (s, e) => SessionCommandCompleted?.Invoke(s, e);
         _chatMessageReceivedHandler = (s, e) => ChatMessageReceived?.Invoke(s, e);
         _agentEventReceivedHandler = (s, e) => AgentEventReceived?.Invoke(s, e);
         _modelsListUpdatedHandler = (s, e) =>
@@ -111,6 +115,7 @@ public sealed class GatewayClientChatBridge : IChatGatewayBridge
         // ``IsConnectedToGateway``. ``volatile`` covers atomic reads.
         _client.StatusChanged += _statusChangedHandler;
         _client.SessionsUpdated += _sessionsUpdatedHandler;
+        _client.SessionCommandCompleted += _sessionCommandCompletedHandler;
         _client.ChatMessageReceived += _chatMessageReceivedHandler;
         _client.AgentEventReceived += _agentEventReceivedHandler;
         _client.ModelsListUpdated += _modelsListUpdatedHandler;
@@ -150,6 +155,9 @@ public sealed class GatewayClientChatBridge : IChatGatewayBridge
     public Task SendChatMessageAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null) =>
         _client.SendChatMessageAsync(message, sessionKey, sessionId, attachments);
 
+    public Task<ChatSendResult> SendChatMessageForRunAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null) =>
+        _client.SendChatMessageForRunAsync(message, sessionKey, sessionId, attachments);
+
     public Task PatchSessionModelAsync(string sessionKey, string model) =>
         _client.PatchSessionAsync(sessionKey, model: model);
 
@@ -163,6 +171,7 @@ public sealed class GatewayClientChatBridge : IChatGatewayBridge
 
     public event EventHandler<ConnectionStatus>? StatusChanged;
     public event EventHandler<SessionInfo[]>? SessionsUpdated;
+    public event EventHandler<SessionCommandResult>? SessionCommandCompleted;
     public event EventHandler<ChatMessageInfo>? ChatMessageReceived;
     public event EventHandler<AgentEventInfo>? AgentEventReceived;
     public event EventHandler<ModelsListInfo>? ModelsListUpdated;
@@ -174,15 +183,16 @@ public sealed class GatewayClientChatBridge : IChatGatewayBridge
 
         _client.StatusChanged -= _statusChangedHandler;
         _client.SessionsUpdated -= _sessionsUpdatedHandler;
+        _client.SessionCommandCompleted -= _sessionCommandCompletedHandler;
         _client.ChatMessageReceived -= _chatMessageReceivedHandler;
         _client.AgentEventReceived -= _agentEventReceivedHandler;
         _client.ModelsListUpdated -= _modelsListUpdatedHandler;
 
         StatusChanged = null;
         SessionsUpdated = null;
+        SessionCommandCompleted = null;
         ChatMessageReceived = null;
         AgentEventReceived = null;
         ModelsListUpdated = null;
     }
 }
-

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -3064,8 +3064,10 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         if (IsResetIgnoredRunLocked(threadId, evt.RunId, evt))
             return true;
 
+        var eventTsMs = evt.Ts > 0 ? (long)evt.Ts : 0L;
+        var cutoff = GetResetCutoffUtcMsLocked(threadId);
         if (!_resetAwaitingUserMessage.Contains(threadId))
-            return false;
+            return IsPreResetTimestampLocked(threadId, eventTsMs, cutoff);
 
         if (IsAcceptedPostResetLifecycleStartLocked(threadId, evt, _resetLifecycleStartSequence + 1))
         {
@@ -3073,8 +3075,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             return false;
         }
 
-        var cutoff = GetResetCutoffUtcMsLocked(threadId);
-        if (IsPreResetTimestampLocked(threadId, evt.Ts > 0 ? (long)evt.Ts : 0L, cutoff))
+        if (IsPreResetTimestampLocked(threadId, eventTsMs, cutoff))
             return true;
 
         if (IsLifecycleStart(evt))

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -61,6 +61,7 @@ internal static class LocalizationHelper
 /// </remarks>
 public sealed class OpenClawChatDataProvider : IChatDataProvider
 {
+    private const long ResetTimestampToleranceMs = 1000;
     /// <summary>
     /// Process-wide cache mapping an attachment's filename to its raw image
     /// bytes. Populated by <see cref="SendMessageAsync"/> for image
@@ -94,6 +95,18 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     private readonly Dictionary<string, string> _sessionIds = new();      // sessionKey → immutable sessionId
     private readonly HashSet<string> _historyLoaded = new();              // sessionKey
     private readonly HashSet<string> _historyInFlight = new();            // sessionKey
+    private readonly Dictionary<string, long> _resetVersions = new(); // sessionKey -> reset generation
+    private readonly Dictionary<string, long> _resetCutoffUtcMs = new(); // sessionKey -> local reset time
+    private readonly HashSet<string> _resetAwaitingUserMessage = new(); // threads reset and waiting for first post-reset turn
+    private readonly Dictionary<string, HashSet<string>> _resetIgnoredRunIds = new(); // sessionKey -> pre-reset run IDs to drop
+    private readonly Dictionary<string, HashSet<string>> _resetAcceptedRunIds = new(); // sessionKey -> post-reset run IDs allowed to open the gate
+    private readonly Dictionary<string, long> _resetLocalSendWithoutRunVersions = new(); // sessionKey -> reset generation for no-runId sends
+    private readonly Dictionary<string, long> _resetLocalSendWithoutRunStartSequences = new(); // sessionKey -> lifecycle sequence at local send start
+    private readonly Dictionary<string, long> _resetLocalEchoSequences = new(); // sessionKey -> lifecycle sequence when local echo was observed
+    private readonly Dictionary<string, List<PendingResetLifecycleStart>> _resetPendingLifecycleStarts = new(); // sessionKey -> lifecycle.start seen before proof
+    private long _resetLifecycleStartSequence;
+    private readonly HashSet<string> _resetRemoteUserSeen = new(); // threads with a fresh remote post-reset user frame
+    private readonly Dictionary<string, string> _resetClearedSessionIds = new(); // sessionKey -> sessionId cleared by reset
     // Per-session cache of tool metadata from live SSE events.
     // Keyed by gateway sessionId (immutable UUID).  Persisted to disk
     // so that history reconstruction on restart can recover tool names.
@@ -185,6 +198,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
 
         _bridge.StatusChanged += OnStatusChanged;
         _bridge.SessionsUpdated += OnSessionsUpdated;
+        _bridge.SessionCommandCompleted += OnSessionCommandCompleted;
         _bridge.ChatMessageReceived += OnChatMessageReceived;
         _bridge.AgentEventReceived += OnAgentEventReceived;
         _bridge.ModelsListUpdated += OnModelsListUpdated;
@@ -261,8 +275,12 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         // 1. Optimistically add the user message + flag turn active.
         ChatDataSnapshot snapshot;
         string? sessionId;
+        long sendResetVersion;
+        long sendStartedLifecycleSequence;
         lock (_gate)
         {
+            sendResetVersion = GetResetVersionLocked(threadId);
+            sendStartedLifecycleSequence = _resetLifecycleStartSequence;
             var current = GetOrCreateTimelineLocked(threadId);
             var beforeNextId = current.NextId;
             _timelines[threadId] = ChatTimelineReducer.AddLocalUser(current, displayText, nonce);
@@ -297,22 +315,56 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         // 2. Send to gateway.
         try
         {
-            await _bridge.SendChatMessageAsync(trimmed, threadId, sessionId, attachments);
-            if (hasAttachments)
-                CacheAttachmentMeta(sessionId, threadId, trimmed, attachments!, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+            var sendResult = await _bridge.SendChatMessageForRunAsync(trimmed, threadId, sessionId, attachments);
+            bool sendStillCurrent;
+            lock (_gate)
+            {
+                sendStillCurrent = GetResetVersionLocked(threadId) == sendResetVersion;
+                if (!sendStillCurrent)
+                {
+                    if (!string.IsNullOrEmpty(sendResult.RunId))
+                        AddResetIgnoredRunIdLocked(threadId, sendResult.RunId!);
+                }
+                else if (!string.IsNullOrEmpty(sendResult.RunId))
+                {
+                    AddResetAcceptedRunIdLocked(threadId, sendResult.RunId!);
+                }
+                else if (_resetAwaitingUserMessage.Contains(threadId))
+                {
+                    _resetLocalSendWithoutRunVersions[threadId] = sendResetVersion;
+                    _resetLocalSendWithoutRunStartSequences[threadId] = sendStartedLifecycleSequence;
+                    TryOpenResetGateFromPendingLifecycleLocked(threadId, acceptedRunId: null);
+                }
+            }
+
+            if (hasAttachments && sendStillCurrent)
+                CacheAttachmentMeta(sessionId, threadId, trimmed, attachments!, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), sendResetVersion);
         }
         catch (Exception ex)
         {
+            bool sendStillCurrent;
+            ChatDataSnapshot? failureSnapshot = null;
             lock (_gate)
             {
-                RemovePendingLocalEchoLocked(threadId, trimmed);
-                _locallyInitiatedThreads.Remove(threadId);
+                sendStillCurrent = GetResetVersionLocked(threadId) == sendResetVersion;
+                if (sendStillCurrent)
+                {
+                    RemovePendingLocalEchoLocked(threadId, trimmed);
+                    _locallyInitiatedThreads.Remove(threadId);
+                    failureSnapshot = ApplyEventLocked(
+                        threadId,
+                        TruncateChatEvent(new ChatErrorEvent($"Send failed: {ex.Message}")),
+                        meta: null);
+                    failureSnapshot = ApplyEventLocked(threadId, new ChatTurnEndEvent(), meta: null);
+                }
             }
+
+            if (!sendStillCurrent)
+                return;
 
             // Surface as an error in the timeline + notification — keeps the
             // user message visible so they can edit/retry.
-            ApplyEventAndPublish(threadId, new ChatErrorEvent($"Send failed: {ex.Message}"));
-            ApplyEventAndPublish(threadId, new ChatTurnEndEvent());
+            Publish(failureSnapshot!);
             RaiseNotification(new ChatProviderNotification(
                 ChatProviderNotificationKind.Error, threadId, LocalizationHelper.GetString("Chat_Notification_SendFailed"), ex.Message));
             throw;
@@ -400,10 +452,12 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         cancellationToken.ThrowIfCancellationRequested();
         if (string.IsNullOrEmpty(threadId)) return;
 
+        long requestResetVersion;
         lock (_gate)
         {
             if (!force && _historyLoaded.Contains(threadId)) return;
             if (!_historyInFlight.Add(threadId)) return; // another loader already in progress
+            requestResetVersion = GetResetVersionLocked(threadId);
         }
 
         try
@@ -413,6 +467,12 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             ChatDataSnapshot snapshot;
             lock (_gate)
             {
+                if (GetResetVersionLocked(threadId) != requestResetVersion)
+                {
+                    Logger.Info($"[ChatHistory] Ignoring stale history for reset thread '{threadId}'");
+                    return;
+                }
+
                 if (!string.IsNullOrEmpty(history.SessionId))
                     _sessionIds[threadId] = history.SessionId!;
 
@@ -458,7 +518,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
 
                 // Load cached tool metadata for this session to restore tool names
                 // that the gateway strips from history responses.
-                var cachedTools = GetCachedToolMetaForSession(history.SessionId);
+                var cachedTools = GetCachedToolMetaForSession(history.SessionId, threadId);
                 if (cachedTools is not null)
                     Logger.Info($"[ChatHistory] Found {cachedTools.Count} cached tool metadata entries for session");
 
@@ -970,6 +1030,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         SaveToolMetaCache();
         _bridge.StatusChanged -= OnStatusChanged;
         _bridge.SessionsUpdated -= OnSessionsUpdated;
+        _bridge.SessionCommandCompleted -= OnSessionCommandCompleted;
         _bridge.ChatMessageReceived -= OnChatMessageReceived;
         _bridge.AgentEventReceived -= OnAgentEventReceived;
         _bridge.ModelsListUpdated -= OnModelsListUpdated;
@@ -1095,6 +1156,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         lock (_gate)
         {
             _sessions = sessions ?? Array.Empty<SessionInfo>();
+            SeedSessionIdsFromSessionsLocked(_sessions);
             _sessionsListReceived = true;
             EnsureTimelinesForSessionsLocked();
             snapshot = BuildSnapshotLocked();
@@ -1125,6 +1187,27 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         {
             _ = LoadHistoryAsync(threadId, force: false);
         }
+    }
+
+    private void OnSessionCommandCompleted(object? sender, SessionCommandResult result)
+    {
+        if (result is not { Ok: true } ||
+            !string.Equals(result.Method, "sessions.reset", StringComparison.Ordinal) ||
+            string.IsNullOrWhiteSpace(result.Key))
+        {
+            return;
+        }
+
+        ChatDataSnapshot snapshot;
+        ResetClearPersistence persistence;
+        lock (_gate)
+        {
+            persistence = ClearThreadHistoryAfterResetLocked(result.Key);
+            snapshot = BuildSnapshotLocked();
+        }
+
+        Publish(snapshot);
+        PersistClearedResetState(persistence);
     }
 
     private void OnModelsListUpdated(object? sender, ModelsListInfo info)
@@ -1193,17 +1276,30 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         // Suppress chat messages for threads that were aborted by the user.
         // Chat messages don't carry a runId, so we use thread-level suppression.
         var msgThreadId = message.SessionKey;
+        var role = message.Role ?? "";
+        var roleLower = role.ToLowerInvariant();
+        var rawText = message.Text ?? string.Empty;
         lock (_gate)
         {
+            if (ShouldDropChatMessageAfterResetLocked(msgThreadId, roleLower, rawText, message.Ts, out var consumeEchoText))
+            {
+                if (consumeEchoText is not null &&
+                    _localSentTexts.TryGetValue(msgThreadId, out var resetEchoQueue) &&
+                    resetEchoQueue.Count > 0)
+                {
+                    TryConsumeLocalEchoLocked(msgThreadId, resetEchoQueue, consumeEchoText);
+                }
+
+                Logger.Debug($"[Reset] Dropping stale chat message after reset for threadId='{msgThreadId}' role='{roleLower}'");
+                return;
+            }
+
             if (_abortedThreads.Contains(msgThreadId))
             {
                 Logger.Debug($"[ABORT] Suppressed ChatMessage for threadId='{msgThreadId}' (role={message.Role})");
                 return;
             }
         }
-
-        var role = message.Role ?? "";
-        var roleLower = role.ToLowerInvariant();
 
         // User messages from the SSE stream. System control notes are rendered
         // as dim status entries. Normal user messages: suppress echoes of
@@ -1219,7 +1315,6 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             // this thread, render a dim audit-trail status so the user
             // can still see that an approval decision was made elsewhere
             // (preserves audit signal).
-            var rawText = message.Text ?? string.Empty;
             if (LooksLikeApprovalSlashCommand(rawText))
             {
                 var slashEcho = rawText.Trim();
@@ -1357,6 +1452,15 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             return;
         }
         var threadId = evt.SessionKey;
+
+        lock (_gate)
+        {
+            if (ShouldDropAgentEventAfterResetLocked(evt, threadId))
+            {
+                Logger.Debug($"[Reset] Dropping stale agent event after reset for threadId='{threadId}' stream='{evt.Stream}' runId='{evt.RunId}'");
+                return;
+            }
+        }
 
         // Always update run tracking first (state maintenance must not be skipped).
         UpdateActiveRunId(evt, threadId);
@@ -1635,6 +1739,14 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     /// </summary>
     private async Task FetchRemoteUserMessageAsync(string threadId)
     {
+        long requestResetVersion;
+        long resetCutoffUtcMs;
+        lock (_gate)
+        {
+            requestResetVersion = GetResetVersionLocked(threadId);
+            resetCutoffUtcMs = GetResetCutoffUtcMsLocked(threadId);
+        }
+
         try
         {
             var history = await _bridge.RequestChatHistoryAsync(threadId);
@@ -1656,10 +1768,19 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             }
             if (lastUser is null || string.IsNullOrEmpty(lastUser.Text)) return;
 
+            ChatDataSnapshot? snapshotToPublish = null;
+
             // Check if we already have this user message as the last User entry
             // in the timeline (avoid duplicates on reconnect/reload).
             lock (_gate)
             {
+                if (GetResetVersionLocked(threadId) != requestResetVersion ||
+                    IsPreResetTimestampLocked(threadId, lastUser.Ts, resetCutoffUtcMs))
+                {
+                    Logger.Info($"[REMOTE] Ignoring stale remote user backfill after reset for threadId='{threadId}'");
+                    return;
+                }
+
                 if (_timelines.TryGetValue(threadId, out var tl))
                 {
                     for (int i = tl.Entries.Count - 1; i >= 0; i--)
@@ -1672,13 +1793,15 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                         }
                     }
                 }
+
+                var meta = BuildLiveMetaLocked(threadId, lastUser.Ts);
+                snapshotToPublish = ApplyEventLocked(
+                    threadId,
+                    new ChatUserMessageEvent(TruncateForChatEntry(lastUser.Text)),
+                    meta);
             }
 
-            ChatEntryMetadata? meta;
-            lock (_gate) { meta = BuildLiveMetaLocked(threadId, lastUser.Ts); }
-            ApplyEventAndPublish(threadId,
-                new ChatUserMessageEvent(TruncateForChatEntry(lastUser.Text)),
-                meta);
+            Publish(snapshotToPublish);
             Logger.Info($"[REMOTE] Injected remote user message for threadId='{threadId}' len={lastUser.Text.Length}");
         }
         catch (Exception ex)
@@ -2709,52 +2832,57 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         ChatDataSnapshot snapshot;
         lock (_gate)
         {
-            var current = GetOrCreateTimelineLocked(threadId);
-            var beforeIds = new HashSet<string>(current.Entries.Count);
-            for (int i = 0; i < current.Entries.Count; i++) beforeIds.Add(current.Entries[i].Id);
-
-            var next = ChatTimelineReducer.Apply(current, evt);
-            _timelines[threadId] = next;
-
-            // Capture metadata for any newly-created entries. Updates to
-            // existing entries (e.g. UpsertAssistant on the active assistant)
-            // intentionally don't overwrite — the original creation timestamp
-            // for the turn is more useful than the most-recent-delta time.
-            // EXCEPTION: if the new metadata carries usage tokens (only
-            // emitted on terminal frames), merge them into the existing entry
-            // so the footer pills (↑/↓/R/ctx%) light up at end-of-turn.
-            if (meta is not null)
-            {
-                var threadMeta = GetOrCreateThreadMetaLocked(threadId);
-                var hasUsage = meta.InputTokens is not null || meta.OutputTokens is not null
-                    || meta.ResponseTokens is not null || meta.ContextPercent is not null;
-                for (int i = 0; i < next.Entries.Count; i++)
-                {
-                    var id = next.Entries[i].Id;
-                    var isNew = !beforeIds.Contains(id);
-                    if (isNew && !threadMeta.ContainsKey(id))
-                    {
-                        threadMeta[id] = meta;
-                    }
-                    else if (hasUsage && threadMeta.TryGetValue(id, out var existing)
-                        && (existing.InputTokens is null && existing.OutputTokens is null))
-                    {
-                        // Merge usage onto the existing assistant entry whose
-                        // text was just upserted by this final delta.
-                        threadMeta[id] = existing with
-                        {
-                            InputTokens = meta.InputTokens ?? existing.InputTokens,
-                            OutputTokens = meta.OutputTokens ?? existing.OutputTokens,
-                            ResponseTokens = meta.ResponseTokens ?? existing.ResponseTokens,
-                            ContextPercent = meta.ContextPercent ?? existing.ContextPercent
-                        };
-                    }
-                }
-            }
-
-            snapshot = BuildSnapshotLocked();
+            snapshot = ApplyEventLocked(threadId, evt, meta);
         }
         Publish(snapshot);
+    }
+
+    private ChatDataSnapshot ApplyEventLocked(string threadId, ChatEvent evt, ChatEntryMetadata? meta)
+    {
+        var current = GetOrCreateTimelineLocked(threadId);
+        var beforeIds = new HashSet<string>(current.Entries.Count);
+        for (int i = 0; i < current.Entries.Count; i++) beforeIds.Add(current.Entries[i].Id);
+
+        var next = ChatTimelineReducer.Apply(current, evt);
+        _timelines[threadId] = next;
+
+        // Capture metadata for any newly-created entries. Updates to
+        // existing entries (e.g. UpsertAssistant on the active assistant)
+        // intentionally don't overwrite — the original creation timestamp
+        // for the turn is more useful than the most-recent-delta time.
+        // EXCEPTION: if the new metadata carries usage tokens (only
+        // emitted on terminal frames), merge them into the existing entry
+        // so the footer pills (↑/↓/R/ctx%) light up at end-of-turn.
+        if (meta is not null)
+        {
+            var threadMeta = GetOrCreateThreadMetaLocked(threadId);
+            var hasUsage = meta.InputTokens is not null || meta.OutputTokens is not null
+                || meta.ResponseTokens is not null || meta.ContextPercent is not null;
+            for (int i = 0; i < next.Entries.Count; i++)
+            {
+                var id = next.Entries[i].Id;
+                var isNew = !beforeIds.Contains(id);
+                if (isNew && !threadMeta.ContainsKey(id))
+                {
+                    threadMeta[id] = meta;
+                }
+                else if (hasUsage && threadMeta.TryGetValue(id, out var existing)
+                    && (existing.InputTokens is null && existing.OutputTokens is null))
+                {
+                    // Merge usage onto the existing assistant entry whose
+                    // text was just upserted by this final delta.
+                    threadMeta[id] = existing with
+                    {
+                        InputTokens = meta.InputTokens ?? existing.InputTokens,
+                        OutputTokens = meta.OutputTokens ?? existing.OutputTokens,
+                        ResponseTokens = meta.ResponseTokens ?? existing.ResponseTokens,
+                        ContextPercent = meta.ContextPercent ?? existing.ContextPercent
+                    };
+                }
+            }
+        }
+
+        return BuildSnapshotLocked();
     }
 
     private Dictionary<string, ChatEntryMetadata> GetOrCreateThreadMetaLocked(string threadId)
@@ -2767,6 +2895,319 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         return meta;
     }
 
+    private readonly record struct ResetClearPersistence(
+        bool SaveAbortedIds,
+        bool SaveToolMeta,
+        bool SaveAttachmentMeta);
+
+    private long GetResetVersionLocked(string threadId) =>
+        _resetVersions.TryGetValue(threadId, out var version) ? version : 0;
+
+    private long GetResetCutoffUtcMsLocked(string threadId) =>
+        _resetCutoffUtcMs.TryGetValue(threadId, out var cutoff) ? cutoff : 0;
+
+    private ResetClearPersistence ClearThreadHistoryAfterResetLocked(string threadId)
+    {
+        var oldSessionId = _sessionIds.TryGetValue(threadId, out var sid) ? sid : null;
+        var saveToolMeta = false;
+        var saveAttachmentMeta = false;
+        var saveAbortedIds = _persistedAbortedIds.Remove(threadId);
+
+        if (!string.IsNullOrEmpty(oldSessionId))
+        {
+            saveToolMeta = _toolMetaCache.Remove(oldSessionId);
+            saveAttachmentMeta = _attachmentMetaCache.Remove(oldSessionId);
+            _resetClearedSessionIds[threadId] = oldSessionId;
+        }
+        else
+        {
+            _resetClearedSessionIds.Remove(threadId);
+        }
+        saveToolMeta = _toolMetaCache.Remove(threadId) || saveToolMeta;
+        saveAttachmentMeta = _attachmentMetaCache.Remove(threadId) || saveAttachmentMeta;
+
+        if (saveToolMeta)
+            _toolMetaSaveVersion++;
+
+        if (_activeRunIds.TryGetValue(threadId, out var activeRunId) && !string.IsNullOrEmpty(activeRunId))
+            AddResetIgnoredRunIdLocked(threadId, activeRunId);
+
+        _resetVersions[threadId] = GetResetVersionLocked(threadId) + 1;
+        _resetCutoffUtcMs[threadId] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        _resetAwaitingUserMessage.Add(threadId);
+        _timelines[threadId] = ChatTimelineState.Initial() with { HistoryLoaded = true };
+        _entryMeta.Remove(threadId);
+        _sessionIds.Remove(threadId);
+        _historyLoaded.Add(threadId);
+        _historyRetryCount.Remove(threadId);
+        _activeRunIds.Remove(threadId);
+        _pendingAbortCounts.Remove(threadId);
+        _abortedThreads.Remove(threadId);
+        _locallyInitiatedThreads.Remove(threadId);
+        _localSentTexts.Remove(threadId);
+        _resetAcceptedRunIds.Remove(threadId);
+        _resetLocalSendWithoutRunVersions.Remove(threadId);
+        _resetLocalSendWithoutRunStartSequences.Remove(threadId);
+        _resetLocalEchoSequences.Remove(threadId);
+        _resetPendingLifecycleStarts.Remove(threadId);
+        _resetRemoteUserSeen.Remove(threadId);
+
+        return new ResetClearPersistence(saveAbortedIds, saveToolMeta, saveAttachmentMeta);
+    }
+
+    private void PersistClearedResetState(ResetClearPersistence persistence)
+    {
+        if (persistence.SaveAbortedIds)
+            SaveAbortedIds();
+        if (persistence.SaveToolMeta)
+            SaveToolMetaCache();
+        if (persistence.SaveAttachmentMeta)
+            SaveAttachmentMetaCache();
+    }
+
+    private void AddResetIgnoredRunIdLocked(string threadId, string runId)
+    {
+        if (!_resetIgnoredRunIds.TryGetValue(threadId, out var set))
+        {
+            set = new HashSet<string>(StringComparer.Ordinal);
+            _resetIgnoredRunIds[threadId] = set;
+        }
+        set.Add(runId);
+    }
+
+    private void AddResetAcceptedRunIdLocked(string threadId, string runId)
+    {
+        if (!_resetAwaitingUserMessage.Contains(threadId))
+            return;
+
+        if (!_resetAcceptedRunIds.TryGetValue(threadId, out var set))
+        {
+            set = new HashSet<string>(StringComparer.Ordinal);
+            _resetAcceptedRunIds[threadId] = set;
+        }
+        set.Add(runId);
+        TryOpenResetGateFromPendingLifecycleLocked(threadId, acceptedRunId: runId);
+    }
+
+    private readonly record struct PendingResetLifecycleStart(AgentEventInfo Event, long Sequence);
+
+    private bool ShouldDropChatMessageAfterResetLocked(
+        string threadId,
+        string roleLower,
+        string rawText,
+        long tsMs,
+        out string? consumeEchoText)
+    {
+        consumeEchoText = null;
+        if (!_resetAwaitingUserMessage.Contains(threadId))
+        {
+            return IsPreResetTimestampLocked(threadId, tsMs, GetResetCutoffUtcMsLocked(threadId));
+        }
+
+        var isFreshUser = roleLower == "user" &&
+            !LooksLikeApprovalSlashCommand(rawText) &&
+            !LooksLikeSystemControlNote(rawText) &&
+            !IsPreResetTimestampLocked(threadId, tsMs, GetResetCutoffUtcMsLocked(threadId));
+
+        if (isFreshUser &&
+            _localSentTexts.TryGetValue(threadId, out var echoQueue) &&
+            echoQueue.Count > 0 &&
+            string.Equals(echoQueue.Peek().Text, rawText.Trim(), StringComparison.Ordinal))
+        {
+            consumeEchoText = rawText.Trim();
+            _resetLocalEchoSequences[threadId] = _resetLifecycleStartSequence;
+            if (TryOpenResetGateFromPendingLifecycleLocked(threadId, acceptedRunId: null))
+                return false;
+        }
+        else if (isFreshUser && tsMs > 0)
+        {
+            _resetRemoteUserSeen.Add(threadId);
+            if (TryOpenResetGateFromPendingLifecycleLocked(threadId, acceptedRunId: null))
+                return false;
+        }
+
+        return true;
+    }
+
+    private bool ShouldDropAgentEventAfterResetLocked(AgentEventInfo evt, string threadId)
+    {
+        if (IsResetIgnoredRunLocked(threadId, evt.RunId, evt))
+            return true;
+
+        if (!_resetAwaitingUserMessage.Contains(threadId))
+            return false;
+
+        if (IsAcceptedPostResetLifecycleStartLocked(threadId, evt, _resetLifecycleStartSequence + 1))
+        {
+            OpenResetGateForLifecycleStartLocked(threadId, evt);
+            return false;
+        }
+
+        var cutoff = GetResetCutoffUtcMsLocked(threadId);
+        if (IsPreResetTimestampLocked(threadId, evt.Ts > 0 ? (long)evt.Ts : 0L, cutoff))
+            return true;
+
+        if (IsLifecycleStart(evt))
+            BufferResetLifecycleStartLocked(threadId, evt);
+
+        return true;
+    }
+
+    private bool IsAcceptedPostResetLifecycleStartLocked(string threadId, AgentEventInfo evt, long lifecycleStartSequence)
+    {
+        if (!IsLifecycleStart(evt))
+            return false;
+
+        if (!string.IsNullOrEmpty(evt.RunId) &&
+            _resetAcceptedRunIds.TryGetValue(threadId, out var acceptedRunIds) &&
+            acceptedRunIds.Contains(evt.RunId))
+        {
+            return true;
+        }
+
+        if (_resetLocalSendWithoutRunVersions.TryGetValue(threadId, out var localSendVersion) &&
+            localSendVersion == GetResetVersionLocked(threadId) &&
+            _resetLocalSendWithoutRunStartSequences.TryGetValue(threadId, out var localSendStartSequence) &&
+        _resetLocalEchoSequences.TryGetValue(threadId, out var localEchoSequence) &&
+        localEchoSequence >= localSendStartSequence &&
+        lifecycleStartSequence > localSendStartSequence &&
+        evt.Ts > 0 &&
+        !IsPreResetTimestampLocked(threadId, (long)evt.Ts, GetResetCutoffUtcMsLocked(threadId)))
+        {
+            return true;
+        }
+
+        return _resetRemoteUserSeen.Contains(threadId) &&
+            !IsPreResetTimestampLocked(threadId, evt.Ts > 0 ? (long)evt.Ts : 0L, GetResetCutoffUtcMsLocked(threadId));
+    }
+
+    private void BufferResetLifecycleStartLocked(string threadId, AgentEventInfo evt)
+    {
+        if (!_resetPendingLifecycleStarts.TryGetValue(threadId, out var pending))
+        {
+            pending = new List<PendingResetLifecycleStart>();
+            _resetPendingLifecycleStarts[threadId] = pending;
+        }
+
+        if (!string.IsNullOrEmpty(evt.RunId) &&
+            pending.Exists(e => string.Equals(e.Event.RunId, evt.RunId, StringComparison.Ordinal)))
+        {
+            return;
+        }
+
+        pending.Add(new PendingResetLifecycleStart(evt, ++_resetLifecycleStartSequence));
+        if (pending.Count > 8)
+            pending.RemoveRange(0, pending.Count - 8);
+    }
+
+    private bool TryOpenResetGateFromPendingLifecycleLocked(string threadId, string? acceptedRunId)
+    {
+        if (!_resetAwaitingUserMessage.Contains(threadId) ||
+            !_resetPendingLifecycleStarts.TryGetValue(threadId, out var pending))
+        {
+            return false;
+        }
+
+        for (var i = 0; i < pending.Count; i++)
+        {
+            var pendingStart = pending[i];
+            var evt = pendingStart.Event;
+            if (acceptedRunId is not null)
+            {
+                if (!string.Equals(evt.RunId, acceptedRunId, StringComparison.Ordinal))
+                    continue;
+            }
+            else if (!IsAcceptedPostResetLifecycleStartLocked(threadId, evt, pendingStart.Sequence))
+            {
+                continue;
+            }
+
+            pending.RemoveAt(i);
+            OpenResetGateForLifecycleStartLocked(threadId, evt);
+            return true;
+        }
+
+        return false;
+    }
+
+    private void OpenResetGateForLifecycleStartLocked(string threadId, AgentEventInfo evt)
+    {
+        _resetAwaitingUserMessage.Remove(threadId);
+        _resetRemoteUserSeen.Remove(threadId);
+        _resetLocalSendWithoutRunVersions.Remove(threadId);
+        _resetLocalSendWithoutRunStartSequences.Remove(threadId);
+        _resetLocalEchoSequences.Remove(threadId);
+        _resetPendingLifecycleStarts.Remove(threadId);
+
+        if (!string.IsNullOrEmpty(evt.RunId))
+        {
+            _activeRunIds[threadId] = evt.RunId;
+            if (_resetAcceptedRunIds.TryGetValue(threadId, out var acceptedRunIds))
+            {
+                acceptedRunIds.Remove(evt.RunId);
+                if (acceptedRunIds.Count == 0)
+                    _resetAcceptedRunIds.Remove(threadId);
+            }
+        }
+    }
+
+    private bool IsResetIgnoredRunLocked(string threadId, string? runId, AgentEventInfo evt)
+    {
+        if (string.IsNullOrEmpty(runId) ||
+            !_resetIgnoredRunIds.TryGetValue(threadId, out var runIds) ||
+            !runIds.Contains(runId))
+        {
+            return false;
+        }
+
+        if (IsTerminalRunEvent(evt))
+        {
+            runIds.Remove(runId);
+            if (runIds.Count == 0)
+                _resetIgnoredRunIds.Remove(threadId);
+        }
+
+        return true;
+    }
+
+    private bool IsPreResetTimestampLocked(string threadId, long eventTsMs, long resetCutoffUtcMs)
+    {
+        if (eventTsMs <= 0 || resetCutoffUtcMs <= 0)
+            return false;
+
+        return _resetVersions.ContainsKey(threadId) &&
+            eventTsMs + ResetTimestampToleranceMs <= resetCutoffUtcMs;
+    }
+
+    private static bool IsLifecycleStart(AgentEventInfo evt) =>
+        string.Equals(evt.Stream, "lifecycle", StringComparison.OrdinalIgnoreCase) &&
+        evt.Data.ValueKind == System.Text.Json.JsonValueKind.Object &&
+        evt.Data.TryGetProperty("phase", out var phaseProp) &&
+        string.Equals(phaseProp.GetString(), "start", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsTerminalRunEvent(AgentEventInfo evt)
+    {
+        if (string.Equals(evt.Stream, "lifecycle", StringComparison.OrdinalIgnoreCase) &&
+            evt.Data.ValueKind == System.Text.Json.JsonValueKind.Object &&
+            evt.Data.TryGetProperty("phase", out var phaseProp))
+        {
+            var phase = phaseProp.GetString();
+            return string.Equals(phase, "end", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(phase, "error", StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (string.Equals(evt.Stream, "job", StringComparison.OrdinalIgnoreCase) &&
+            evt.Data.ValueKind == System.Text.Json.JsonValueKind.Object &&
+            evt.Data.TryGetProperty("state", out var stateProp))
+        {
+            var state = stateProp.GetString();
+            return string.Equals(state, "done", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(state, "error", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
     private ChatEntryMetadata BuildLiveMetaLocked(string threadId, long? tsMs = null)
     {
         var ts = tsMs is { } v && v > 0
@@ -2774,6 +3215,25 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             : (DateTimeOffset?)DateTimeOffset.Now;
         var session = Array.Find(_sessions, s => s.Key == threadId);
         return new ChatEntryMetadata(ts, session?.Model);
+    }
+
+    private void SeedSessionIdsFromSessionsLocked(IEnumerable<SessionInfo> sessions)
+    {
+        foreach (var session in sessions)
+        {
+            if (!string.IsNullOrWhiteSpace(session.Key) &&
+                !string.IsNullOrWhiteSpace(session.SessionId))
+            {
+                if (_resetClearedSessionIds.TryGetValue(session.Key, out var clearedSessionId) &&
+                    string.Equals(clearedSessionId, session.SessionId, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                _sessionIds[session.Key] = session.SessionId!;
+                _resetClearedSessionIds.Remove(session.Key);
+            }
+        }
     }
 
     private ChatTimelineState GetOrCreateTimelineLocked(string threadId)
@@ -3283,7 +3743,8 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         string threadId,
         string text,
         IReadOnlyList<ChatAttachment> attachments,
-        long tsMs)
+        long tsMs,
+        long? expectedResetVersion = null)
     {
         if (attachments.Count == 0)
             return;
@@ -3303,6 +3764,12 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         {
             if (_disposed)
                 return;
+
+            if (expectedResetVersion is { } version &&
+                GetResetVersionLocked(threadId) != version)
+            {
+                return;
+            }
 
             var key = !string.IsNullOrEmpty(sessionId) ? sessionId! : threadId;
             if (!_attachmentMetaCache.TryGetValue(key, out var list))
@@ -3524,13 +3991,14 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             if (_disposed)
                 return;
 
-            if (!_sessionIds.TryGetValue(threadId, out var sessionId) || string.IsNullOrEmpty(sessionId))
-                return;
+            var key = _sessionIds.TryGetValue(threadId, out var sessionId) && !string.IsNullOrEmpty(sessionId)
+                ? sessionId
+                : threadId;
 
-            if (!_toolMetaCache.TryGetValue(sessionId, out var list))
+            if (!_toolMetaCache.TryGetValue(key, out var list))
             {
                 list = new List<CachedToolMeta>();
-                _toolMetaCache[sessionId] = list;
+                _toolMetaCache[key] = list;
             }
 
             // Deduplicate by timestamp (same tool event shouldn't be cached twice)
@@ -3556,13 +4024,27 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     /// Look up cached tool metadata for a session's history reconstruction.
     /// Returns a queue of entries sorted by timestamp for sequential consumption.
     /// </summary>
-    private Queue<CachedToolMeta>? GetCachedToolMetaForSession(string? sessionId)
+    private Queue<CachedToolMeta>? GetCachedToolMetaForSession(string? sessionId, string threadId)
     {
-        if (string.IsNullOrEmpty(sessionId)) return null;
+        if (string.IsNullOrEmpty(sessionId) && string.IsNullOrEmpty(threadId)) return null;
         lock (_gate)
         {
-            if (_toolMetaCache.TryGetValue(sessionId!, out var list) && list.Count > 0)
-                return new Queue<CachedToolMeta>(list.OrderBy(e => e.Ts));
+            var entries = new List<CachedToolMeta>();
+            if (!string.IsNullOrEmpty(sessionId) &&
+                _toolMetaCache.TryGetValue(sessionId!, out var sessionEntries))
+            {
+                entries.AddRange(sessionEntries);
+            }
+
+            if (!string.IsNullOrEmpty(threadId) &&
+                (string.IsNullOrEmpty(sessionId) || !string.Equals(sessionId, threadId, StringComparison.Ordinal)) &&
+                _toolMetaCache.TryGetValue(threadId, out var threadEntries))
+            {
+                entries.AddRange(threadEntries);
+            }
+
+            if (entries.Count > 0)
+                return new Queue<CachedToolMeta>(entries.OrderBy(e => e.Ts));
         }
         return null;
     }
@@ -3595,11 +4077,26 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     /// </summary>
     private async Task PersistAbortedMessageIdAsync(string threadId)
     {
+        long requestResetVersion;
+        lock (_gate)
+        {
+            requestResetVersion = GetResetVersionLocked(threadId);
+        }
+
         await _persistLock.WaitAsync().ConfigureAwait(false);
         try
         {
             await Task.Delay(500).ConfigureAwait(false); // let gateway finalize
             var history = await _bridge.RequestChatHistoryAsync(threadId).ConfigureAwait(false);
+
+            lock (_gate)
+            {
+                if (GetResetVersionLocked(threadId) != requestResetVersion)
+                {
+                    Logger.Info($"[ABORT-PERSIST] Ignoring stale abort persistence after reset for thread {threadId}");
+                    return;
+                }
+            }
 
             var newAbortedIds = new List<string>();
             var msgs = history.Messages;
@@ -3644,6 +4141,12 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
 
             lock (_gate)
             {
+                if (GetResetVersionLocked(threadId) != requestResetVersion)
+                {
+                    Logger.Info($"[ABORT-PERSIST] Ignoring stale abort persistence write after reset for thread {threadId}");
+                    return;
+                }
+
                 if (!_persistedAbortedIds.TryGetValue(threadId, out var set))
                 {
                     set = new HashSet<string>();

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -104,6 +104,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     private readonly Dictionary<string, long> _resetLocalSendWithoutRunStartSequences = new(); // sessionKey -> lifecycle sequence at local send start
     private readonly Dictionary<string, long> _resetLocalEchoSequences = new(); // sessionKey -> lifecycle sequence when local echo was observed
     private readonly Dictionary<string, List<PendingResetLifecycleStart>> _resetPendingLifecycleStarts = new(); // sessionKey -> lifecycle.start seen before proof
+    private readonly HashSet<string> _resetRemoteBackfillInFlight = new(); // threads proving a timestamp-less remote user frame via history
     private long _resetLifecycleStartSequence;
     private readonly HashSet<string> _resetRemoteUserSeen = new(); // threads with a fresh remote post-reset user frame
     private readonly Dictionary<string, string> _resetClearedSessionIds = new(); // sessionKey -> sessionId cleared by reset
@@ -1281,7 +1282,13 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         var rawText = message.Text ?? string.Empty;
         lock (_gate)
         {
-            if (ShouldDropChatMessageAfterResetLocked(msgThreadId, roleLower, rawText, message.Ts, out var consumeEchoText))
+            if (ShouldDropChatMessageAfterResetLocked(
+                msgThreadId,
+                roleLower,
+                rawText,
+                message.Ts,
+                out var consumeEchoText,
+                out var requestRemoteBackfill))
             {
                 if (consumeEchoText is not null &&
                     _localSentTexts.TryGetValue(msgThreadId, out var resetEchoQueue) &&
@@ -1289,6 +1296,9 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                 {
                     TryConsumeLocalEchoLocked(msgThreadId, resetEchoQueue, consumeEchoText);
                 }
+
+                if (requestRemoteBackfill)
+                    _ = FetchRemoteUserMessageAsync(msgThreadId, openResetGateOnSuccess: true);
 
                 Logger.Debug($"[Reset] Dropping stale chat message after reset for threadId='{msgThreadId}' role='{roleLower}'");
                 return;
@@ -1737,7 +1747,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     /// Fetch the latest user message from history for a remotely-initiated turn.
     /// Called when lifecycle.start arrives for a thread we didn't locally initiate.
     /// </summary>
-    private async Task FetchRemoteUserMessageAsync(string threadId)
+    private async Task FetchRemoteUserMessageAsync(string threadId, bool openResetGateOnSuccess = false)
     {
         long requestResetVersion;
         long resetCutoffUtcMs;
@@ -1794,6 +1804,12 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                     }
                 }
 
+                if (openResetGateOnSuccess)
+                {
+                    _resetRemoteUserSeen.Add(threadId);
+                    TryOpenResetGateFromPendingLifecycleLocked(threadId, acceptedRunId: null);
+                }
+
                 var meta = BuildLiveMetaLocked(threadId, lastUser.Ts);
                 snapshotToPublish = ApplyEventLocked(
                     threadId,
@@ -1807,6 +1823,13 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         catch (Exception ex)
         {
             Logger.Warn($"[REMOTE] Failed to fetch remote user message for threadId='{threadId}': {ex.Message}");
+        }
+        finally
+        {
+            if (openResetGateOnSuccess)
+            {
+                lock (_gate) { _resetRemoteBackfillInFlight.Remove(threadId); }
+            }
         }
     }
 
@@ -2950,6 +2973,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         _resetLocalSendWithoutRunStartSequences.Remove(threadId);
         _resetLocalEchoSequences.Remove(threadId);
         _resetPendingLifecycleStarts.Remove(threadId);
+        _resetRemoteBackfillInFlight.Remove(threadId);
         _resetRemoteUserSeen.Remove(threadId);
 
         return new ResetClearPersistence(saveAbortedIds, saveToolMeta, saveAttachmentMeta);
@@ -2996,9 +3020,11 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         string roleLower,
         string rawText,
         long tsMs,
-        out string? consumeEchoText)
+        out string? consumeEchoText,
+        out bool requestRemoteBackfill)
     {
         consumeEchoText = null;
+        requestRemoteBackfill = false;
         if (!_resetAwaitingUserMessage.Contains(threadId))
         {
             return IsPreResetTimestampLocked(threadId, tsMs, GetResetCutoffUtcMsLocked(threadId));
@@ -3024,6 +3050,10 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             _resetRemoteUserSeen.Add(threadId);
             if (TryOpenResetGateFromPendingLifecycleLocked(threadId, acceptedRunId: null))
                 return false;
+        }
+        else if (isFreshUser && _resetRemoteBackfillInFlight.Add(threadId))
+        {
+            requestRemoteBackfill = true;
         }
 
         return true;

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -116,6 +116,15 @@ public class OpenClawGatewayClientTests
             method!.Invoke(_client, new object[] { json });
         }
 
+        public long ExtractChatTimestampMs(string payloadJson)
+        {
+            using var document = JsonDocument.Parse(payloadJson);
+            var method = typeof(OpenClawGatewayClient).GetMethod(
+                "ExtractChatTimestampMs",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            return (long)method!.Invoke(null, new object[] { document.RootElement.Clone() })!;
+        }
+
         public SessionInfo[] GetSessionList()
         {
             return _client.GetSessionList();
@@ -456,6 +465,16 @@ public class OpenClawGatewayClientTests
 
     private static string CreateTempIdentityPath() =>
         Path.Combine(Path.GetTempPath(), "OpenClawGatewayClientTests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void ExtractChatTimestampMs_FallsBackFromInvalidTimestampToTs()
+    {
+        var helper = new GatewayClientTestHelper();
+
+        var ts = helper.ExtractChatTimestampMs("""{"timestamp":999999999999999999999999999999,"ts":1712345678}""");
+
+        Assert.Equal(1_712_345_678_000, ts);
+    }
 
     [Fact]
     public void OperatorConnect_FreshDevice_RequestsBootstrapHandoffScopes()

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -679,6 +679,45 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
+    public async Task SessionResetCompletion_DropsLatePreResetAgentEventAfterGateOpens()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        await provider.LoadAsync();
+        var preResetTs = DateTimeOffset.UtcNow.AddSeconds(-5).ToUnixTimeMilliseconds();
+        var resetTs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        bridge.RaiseSessionCommandCompleted(new SessionCommandResult
+        {
+            Method = "sessions.reset",
+            Ok = true,
+            Key = "main"
+        });
+
+        bridge.SendResults.Enqueue(new ChatSendResult { RunId = "new-run" });
+        await provider.SendMessageAsync("main", "after reset local");
+        var freshStart = MakeAgentEvent("lifecycle", """{"phase":"start"}""", runId: "new-run");
+        freshStart.Ts = resetTs + 2_000;
+        bridge.RaiseAgent(freshStart);
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "assistant",
+            State = "final",
+            Text = "fresh response",
+            Ts = resetTs + 2_000
+        });
+
+        var staleAgent = MakeAgentEvent("assistant", """{"delta":"stale agent after gate"}""");
+        staleAgent.Ts = preResetTs;
+        bridge.RaiseAgent(staleAgent);
+
+        var latest = snapshots[^1];
+        Assert.Contains(latest.Timelines["main"].Entries, e =>
+            e.Kind == ChatTimelineItemKind.Assistant && e.Text == "fresh response");
+        Assert.DoesNotContain(latest.Timelines["main"].Entries, e =>
+            e.Text.Contains("stale agent", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task SessionResetCompletion_LifecycleStartBeforeSendResultOpensAfterRunAccepted()
     {
         var sendGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -16,6 +16,7 @@ public class OpenClawChatDataProviderTests
         public List<string> SentMessages { get; } = new();
         public List<string?> SentSessionKeys { get; } = new();
         public List<string?> SentSessionIds { get; } = new();
+        public Queue<ChatSendResult> SendResults { get; } = new();
         public List<string> AbortedRunIds { get; } = new();
         public Func<string, string?, string?, Task>? SendBehavior { get; set; }
         public Func<string?, Task<ChatHistoryInfo>>? HistoryBehavior { get; set; }
@@ -28,11 +29,17 @@ public class OpenClawChatDataProviderTests
         public void StartProactiveBootstrap() { }
 
         public Task SendChatMessageAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null)
+            => SendChatMessageForRunAsync(message, sessionKey, sessionId, attachments);
+
+        public async Task<ChatSendResult> SendChatMessageForRunAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null)
         {
             SentMessages.Add(message);
             SentSessionKeys.Add(sessionKey);
             SentSessionIds.Add(sessionId);
-            return SendBehavior?.Invoke(message, sessionKey, sessionId) ?? Task.CompletedTask;
+            if (SendBehavior is not null)
+                await SendBehavior(message, sessionKey, sessionId);
+
+            return SendResults.Count > 0 ? SendResults.Dequeue() : new ChatSendResult();
         }
 
         public Task PatchSessionModelAsync(string sessionKey, string model) => Task.CompletedTask;
@@ -52,6 +59,7 @@ public class OpenClawChatDataProviderTests
 
         public event EventHandler<ConnectionStatus>? StatusChanged;
         public event EventHandler<SessionInfo[]>? SessionsUpdated;
+        public event EventHandler<SessionCommandResult>? SessionCommandCompleted;
         public event EventHandler<ChatMessageInfo>? ChatMessageReceived;
         public event EventHandler<AgentEventInfo>? AgentEventReceived;
         public event EventHandler<ModelsListInfo>? ModelsListUpdated;
@@ -59,6 +67,7 @@ public class OpenClawChatDataProviderTests
 
         public void RaiseStatus(ConnectionStatus s) { CurrentStatus = s; StatusChanged?.Invoke(this, s); }
         public void RaiseSessions(SessionInfo[] s) { Sessions = s; SessionsUpdated?.Invoke(this, s); }
+        public void RaiseSessionCommandCompleted(SessionCommandResult result) => SessionCommandCompleted?.Invoke(this, result);
         public void RaiseChat(ChatMessageInfo m) => ChatMessageReceived?.Invoke(this, m);
         public void RaiseAgent(AgentEventInfo a) => AgentEventReceived?.Invoke(this, a);
         public void RaiseModels(ModelsListInfo m) { CurrentModels = m; ModelsListUpdated?.Invoke(this, m); }
@@ -385,6 +394,525 @@ public class OpenClawChatDataProviderTests
         Assert.True(snap.Timelines.ContainsKey("main"));
         Assert.True(snap.Timelines.ContainsKey("sub:abc"));
         Assert.Equal("main", snap.DefaultThreadId);
+    }
+
+    [Fact]
+    public async Task SessionResetCompletion_ClearsThreadTimelineAndIgnoresStaleHistory()
+    {
+        var historyTcs = new TaskCompletionSource<ChatHistoryInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        bridge.HistoryBehavior = _ => historyTcs.Task;
+        await provider.LoadAsync();
+        var historyTask = provider.LoadHistoryAsync("main");
+        await provider.SendMessageAsync("main", "hi");
+        snapshots.Clear();
+
+        bridge.RaiseSessionCommandCompleted(new SessionCommandResult
+        {
+            Method = "sessions.reset",
+            Ok = true,
+            Key = "main"
+        });
+
+        var resetSnapshot = snapshots[^1];
+        Assert.Empty(resetSnapshot.Timelines["main"].Entries);
+        Assert.True(resetSnapshot.Timelines["main"].HistoryLoaded);
+
+        historyTcs.SetResult(new ChatHistoryInfo
+        {
+            SessionKey = "main",
+            Messages = new[]
+            {
+                new ChatMessageInfo
+                {
+                    SessionKey = "main",
+                    Role = "assistant",
+                    Text = "old history",
+                    Ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                }
+            }
+        });
+        await historyTask;
+
+        var latest = snapshots[^1];
+        Assert.Empty(latest.Timelines["main"].Entries);
+        Assert.True(latest.Timelines["main"].HistoryLoaded);
+
+        await provider.SendMessageAsync("main", "after reset");
+
+        latest = snapshots[^1];
+        var entry = Assert.Single(latest.Timelines["main"].Entries);
+        Assert.Equal(ChatTimelineItemKind.User, entry.Kind);
+        Assert.Equal("after reset", entry.Text);
+    }
+
+    [Fact]
+    public async Task SessionResetCompletion_DropsLateLiveEventsUntilNewUserMessage()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        await provider.LoadAsync();
+        bridge.RaiseAgent(MakeAgentEvent("lifecycle", """{"phase":"start"}""", runId: "old-run"));
+        snapshots.Clear();
+
+        bridge.RaiseSessionCommandCompleted(new SessionCommandResult
+        {
+            Method = "sessions.reset",
+            Ok = true,
+            Key = "main"
+        });
+
+        bridge.RaiseAgent(MakeAgentEvent("assistant", """{"delta":"stale agent"}""", runId: "old-run"));
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "assistant",
+            State = "final",
+            Text = "stale chat"
+        });
+
+        var latest = snapshots[^1];
+        Assert.Empty(latest.Timelines["main"].Entries);
+
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "user",
+            Text = "new remote message",
+            Ts = DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeMilliseconds()
+        });
+        var freshStart = MakeAgentEvent("lifecycle", """{"phase":"start"}""", runId: "new-run");
+        freshStart.Ts = DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeMilliseconds();
+        bridge.RaiseAgent(freshStart);
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "user",
+            Text = "new remote message",
+            Ts = DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeMilliseconds()
+        });
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "assistant",
+            State = "final",
+            Text = "new response"
+        });
+
+        latest = snapshots[^1];
+        Assert.Contains(latest.Timelines["main"].Entries, e =>
+            e.Kind == ChatTimelineItemKind.User && e.Text == "new remote message");
+        Assert.Contains(latest.Timelines["main"].Entries, e =>
+            e.Kind == ChatTimelineItemKind.Assistant && e.Text == "new response");
+        Assert.DoesNotContain(latest.Timelines["main"].Entries, e =>
+            e.Text.Contains("stale", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task SessionResetCompletion_LocalSendDoesNotReopenGateForStaleChatFrames()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        await provider.LoadAsync();
+        bridge.RaiseAgent(MakeAgentEvent("lifecycle", """{"phase":"start"}""", runId: "old-run"));
+        bridge.RaiseSessionCommandCompleted(new SessionCommandResult
+        {
+            Method = "sessions.reset",
+            Ok = true,
+            Key = "main"
+        });
+
+        bridge.SendResults.Enqueue(new ChatSendResult { RunId = "new-run" });
+        await provider.SendMessageAsync("main", "after reset local");
+        snapshots.Clear();
+
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "user",
+            Text = "stale user echo"
+        });
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "assistant",
+            State = "final",
+            Text = "stale assistant"
+        });
+
+        var latest = await provider.LoadAsync();
+        Assert.Single(latest.Timelines["main"].Entries, e =>
+            e.Kind == ChatTimelineItemKind.User && e.Text == "after reset local");
+        Assert.DoesNotContain(latest.Timelines["main"].Entries, e =>
+            e.Text.Contains("stale", StringComparison.Ordinal));
+
+        bridge.SendResults.Enqueue(new ChatSendResult { RunId = "new-run-2" });
+        await provider.SendMessageAsync("main", "second after reset");
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "user",
+            Text = "second after reset"
+        });
+
+        latest = await provider.LoadAsync();
+        Assert.Single(latest.Timelines["main"].Entries, e =>
+            e.Kind == ChatTimelineItemKind.User && e.Text == "second after reset");
+
+        var freshStart = MakeAgentEvent("lifecycle", """{"phase":"start"}""", runId: "new-run");
+        freshStart.Ts = DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeMilliseconds();
+        bridge.RaiseAgent(freshStart);
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "assistant",
+            State = "final",
+            Text = "fresh assistant"
+        });
+
+        latest = snapshots[^1];
+        Assert.Contains(latest.Timelines["main"].Entries, e =>
+            e.Kind == ChatTimelineItemKind.Assistant && e.Text == "fresh assistant");
+    }
+
+    [Fact]
+    public async Task SessionResetCompletion_LateUnknownLifecycleStartDoesNotReopenGate()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        await provider.LoadAsync();
+        bridge.RaiseSessionCommandCompleted(new SessionCommandResult
+        {
+            Method = "sessions.reset",
+            Ok = true,
+            Key = "main"
+        });
+
+        var staleStart = MakeAgentEvent("lifecycle", """{"phase":"start"}""", runId: "old-run");
+        staleStart.Ts = DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeMilliseconds();
+        bridge.RaiseAgent(staleStart);
+        bridge.RaiseAgent(MakeAgentEvent("assistant", """{"delta":"stale old run"}""", runId: "old-run"));
+
+        var latest = snapshots[^1];
+        Assert.Empty(latest.Timelines["main"].Entries);
+
+        bridge.SendResults.Enqueue(new ChatSendResult { RunId = "new-run" });
+        await provider.SendMessageAsync("main", "after reset local");
+        var freshStart = MakeAgentEvent("lifecycle", """{"phase":"start"}""", runId: "new-run");
+        freshStart.Ts = DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeMilliseconds();
+        bridge.RaiseAgent(freshStart);
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "assistant",
+            State = "final",
+            Text = "fresh response"
+        });
+
+        latest = snapshots[^1];
+        Assert.DoesNotContain(latest.Timelines["main"].Entries, e =>
+            e.Text.Contains("stale", StringComparison.Ordinal));
+        Assert.Contains(latest.Timelines["main"].Entries, e =>
+            e.Kind == ChatTimelineItemKind.Assistant && e.Text == "fresh response");
+    }
+
+    [Fact]
+    public async Task SessionResetCompletion_LifecycleStartBeforeSendResultOpensAfterRunAccepted()
+    {
+        var sendGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        bridge.SendBehavior = (_, _, _) => sendGate.Task;
+        await provider.LoadAsync();
+        bridge.RaiseSessionCommandCompleted(new SessionCommandResult
+        {
+            Method = "sessions.reset",
+            Ok = true,
+            Key = "main"
+        });
+
+        var sendTask = provider.SendMessageAsync("main", "after reset local");
+        var earlyStart = MakeAgentEvent("lifecycle", """{"phase":"start"}""", runId: "new-run");
+        earlyStart.Ts = DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeMilliseconds();
+        bridge.RaiseAgent(earlyStart);
+        bridge.SendResults.Enqueue(new ChatSendResult { RunId = "new-run" });
+        sendGate.SetResult();
+        await sendTask;
+
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "assistant",
+            State = "final",
+            Text = "fresh response"
+        });
+
+        var latest = snapshots[^1];
+        Assert.Contains(latest.Timelines["main"].Entries, e =>
+            e.Kind == ChatTimelineItemKind.User && e.Text == "after reset local");
+        Assert.Contains(latest.Timelines["main"].Entries, e =>
+            e.Kind == ChatTimelineItemKind.Assistant && e.Text == "fresh response");
+    }
+
+    [Fact]
+    public async Task SessionResetCompletion_PreResetSendResultAfterResetDoesNotReopenGate()
+    {
+        var sendStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sendGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        bridge.SendBehavior = (_, _, _) =>
+        {
+            sendStarted.TrySetResult();
+            return sendGate.Task;
+        };
+        await provider.LoadAsync();
+
+        var staleSendTask = provider.SendMessageAsync("main", "before reset");
+        await sendStarted.Task;
+        bridge.RaiseSessionCommandCompleted(new SessionCommandResult
+        {
+            Method = "sessions.reset",
+            Ok = true,
+            Key = "main"
+        });
+        snapshots.Clear();
+
+        bridge.SendResults.Enqueue(new ChatSendResult { RunId = "old-run" });
+        sendGate.SetResult();
+        await staleSendTask;
+
+        var staleStart = MakeAgentEvent("lifecycle", """{"phase":"start"}""", runId: "old-run");
+        staleStart.Ts = DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeMilliseconds();
+        bridge.RaiseAgent(staleStart);
+        bridge.RaiseAgent(MakeAgentEvent("assistant", """{"delta":"stale old run"}""", runId: "old-run"));
+
+        var latest = snapshots.Count > 0 ? snapshots[^1] : await provider.LoadAsync();
+        Assert.Empty(latest.Timelines["main"].Entries);
+    }
+
+    [Fact]
+    public async Task SessionResetCompletion_PostResetSendWithoutRunIdCanOpenOnFreshLifecycleStart()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        await provider.LoadAsync();
+        bridge.RaiseSessionCommandCompleted(new SessionCommandResult
+        {
+            Method = "sessions.reset",
+            Ok = true,
+            Key = "main"
+        });
+
+        bridge.SendResults.Enqueue(new ChatSendResult());
+        await provider.SendMessageAsync("main", "after reset local");
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "user",
+            Text = "after reset local"
+        });
+
+        var freshStart = MakeAgentEvent("lifecycle", """{"phase":"start"}""", runId: "gateway-run");
+        freshStart.Ts = DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeMilliseconds();
+        bridge.RaiseAgent(freshStart);
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "assistant",
+            State = "final",
+            Text = "fresh response"
+        });
+
+        var latest = snapshots[^1];
+        Assert.Contains(latest.Timelines["main"].Entries, e =>
+            e.Kind == ChatTimelineItemKind.User && e.Text == "after reset local");
+        Assert.Contains(latest.Timelines["main"].Entries, e =>
+            e.Kind == ChatTimelineItemKind.Assistant && e.Text == "fresh response");
+    }
+
+    [Fact]
+    public async Task SessionResetCompletion_NoRunFallbackIgnoresBufferedStartBeforeLocalSend()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        await provider.LoadAsync();
+        bridge.RaiseSessionCommandCompleted(new SessionCommandResult
+        {
+            Method = "sessions.reset",
+            Ok = true,
+            Key = "main"
+        });
+
+        var staleStart = MakeAgentEvent("lifecycle", """{"phase":"start"}""", runId: "stale-run");
+        staleStart.Ts = DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeMilliseconds();
+        bridge.RaiseAgent(staleStart);
+        bridge.SendResults.Enqueue(new ChatSendResult());
+        await provider.SendMessageAsync("main", "after reset local");
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "user",
+            Text = "after reset local"
+        });
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "assistant",
+            State = "final",
+            Text = "stale response"
+        });
+
+        var latest = await provider.LoadAsync();
+        Assert.Single(latest.Timelines["main"].Entries, e =>
+            e.Kind == ChatTimelineItemKind.User && e.Text == "after reset local");
+        Assert.DoesNotContain(latest.Timelines["main"].Entries, e =>
+            e.Text.Contains("stale", StringComparison.Ordinal));
+
+        var freshStart = MakeAgentEvent("lifecycle", """{"phase":"start"}""", runId: "fresh-run");
+        freshStart.Ts = DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeMilliseconds();
+        bridge.RaiseAgent(freshStart);
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "assistant",
+            State = "final",
+            Text = "fresh response"
+        });
+
+        latest = snapshots[^1];
+        Assert.Contains(latest.Timelines["main"].Entries, e =>
+            e.Kind == ChatTimelineItemKind.Assistant && e.Text == "fresh response");
+    }
+
+    [Fact]
+    public async Task SessionResetCompletion_PreResetSendFailureAfterResetDoesNotAppendError()
+    {
+        var sendStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sendGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (bridge, provider, snapshots, notifications) = CreateProvider(new[] { MainSession() });
+        bridge.SendBehavior = (_, _, _) =>
+        {
+            sendStarted.TrySetResult();
+            return sendGate.Task;
+        };
+        await provider.LoadAsync();
+
+        var staleSendTask = provider.SendMessageAsync("main", "before reset");
+        await sendStarted.Task;
+        bridge.RaiseSessionCommandCompleted(new SessionCommandResult
+        {
+            Method = "sessions.reset",
+            Ok = true,
+            Key = "main"
+        });
+        snapshots.Clear();
+
+        sendGate.SetException(new InvalidOperationException("old send failed"));
+        await staleSendTask;
+
+        var latest = snapshots.Count > 0 ? snapshots[^1] : await provider.LoadAsync();
+        Assert.Empty(latest.Timelines["main"].Entries);
+        Assert.DoesNotContain(notifications, n => n.Message == "old send failed");
+    }
+
+    [Fact]
+    public async Task SessionResetCompletion_StaleSendFailureDoesNotClearCurrentEchoState()
+    {
+        var sendStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var staleSendGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sendCount = 0;
+        var (bridge, provider, snapshots, notifications) = CreateProvider(new[] { MainSession() });
+        bridge.SendBehavior = (_, _, _) =>
+        {
+            if (System.Threading.Interlocked.Increment(ref sendCount) == 1)
+            {
+                sendStarted.TrySetResult();
+                return staleSendGate.Task;
+            }
+
+            return Task.CompletedTask;
+        };
+        await provider.LoadAsync();
+
+        var staleSendTask = provider.SendMessageAsync("main", "same text");
+        await sendStarted.Task;
+        bridge.RaiseSessionCommandCompleted(new SessionCommandResult
+        {
+            Method = "sessions.reset",
+            Ok = true,
+            Key = "main"
+        });
+
+        bridge.SendResults.Enqueue(new ChatSendResult { RunId = "new-run" });
+        await provider.SendMessageAsync("main", "same text");
+        snapshots.Clear();
+
+        staleSendGate.SetException(new InvalidOperationException("old send failed"));
+        await staleSendTask;
+
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "user",
+            Text = "same text"
+        });
+
+        var latest = await provider.LoadAsync();
+        Assert.Single(latest.Timelines["main"].Entries, e =>
+            e.Kind == ChatTimelineItemKind.User && e.Text == "same text");
+        Assert.DoesNotContain(notifications, n => n.Message == "old send failed");
+
+        var freshStart = MakeAgentEvent("lifecycle", """{"phase":"start"}""", runId: "new-run");
+        freshStart.Ts = DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeMilliseconds();
+        bridge.RaiseAgent(freshStart);
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "assistant",
+            State = "final",
+            Text = "fresh response"
+        });
+
+        latest = snapshots[^1];
+        Assert.Contains(latest.Timelines["main"].Entries, e =>
+            e.Kind == ChatTimelineItemKind.Assistant && e.Text == "fresh response");
+    }
+
+    [Fact]
+    public async Task SessionResetCompletion_IgnoresInFlightRemoteUserBackfill()
+    {
+        var backfillStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var historyTcs = new TaskCompletionSource<ChatHistoryInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        bridge.HistoryBehavior = _ =>
+        {
+            backfillStarted.TrySetResult();
+            return historyTcs.Task;
+        };
+        await provider.LoadAsync();
+
+        bridge.RaiseAgent(MakeAgentEvent("lifecycle", """{"phase":"start"}""", runId: "run-remote"));
+        await backfillStarted.Task;
+        bridge.RaiseSessionCommandCompleted(new SessionCommandResult
+        {
+            Method = "sessions.reset",
+            Ok = true,
+            Key = "main"
+        });
+        snapshots.Clear();
+
+        historyTcs.SetResult(new ChatHistoryInfo
+        {
+            SessionKey = "main",
+            Messages = new[]
+            {
+                new ChatMessageInfo
+                {
+                    SessionKey = "main",
+                    Role = "user",
+                    Text = "old remote user",
+                    Ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                }
+            }
+        });
+        await Task.Delay(100);
+
+        var latest = snapshots.Count > 0 ? snapshots[^1] : await provider.LoadAsync();
+        Assert.Empty(latest.Timelines["main"].Entries);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -508,6 +508,71 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
+    public async Task SessionResetCompletion_TimestamplessRemoteUserCanOpenGateViaHistoryBackfill()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        bridge.HistoryBehavior = _ => Task.FromResult(new ChatHistoryInfo
+        {
+            SessionKey = "main",
+            Messages = new[]
+            {
+                new ChatMessageInfo
+                {
+                    SessionKey = "main",
+                    Role = "user",
+                    Text = "remote no timestamp",
+                    Ts = 0
+                }
+            }
+        });
+        await provider.LoadAsync();
+        bridge.RaiseSessionCommandCompleted(new SessionCommandResult
+        {
+            Method = "sessions.reset",
+            Ok = true,
+            Key = "main"
+        });
+        snapshots.Clear();
+
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "user",
+            Text = "remote no timestamp",
+            Ts = 0
+        });
+
+        for (var i = 0; i < 20; i++)
+        {
+            if (snapshots.Count > 0 &&
+                snapshots[^1].Timelines["main"].Entries.Any(e =>
+                    e.Kind == ChatTimelineItemKind.User &&
+                    e.Text == "remote no timestamp"))
+            {
+                break;
+            }
+            await Task.Delay(10);
+        }
+
+        var freshStart = MakeAgentEvent("lifecycle", """{"phase":"start"}""", runId: "remote-run");
+        freshStart.Ts = DateTimeOffset.UtcNow.AddSeconds(1).ToUnixTimeMilliseconds();
+        bridge.RaiseAgent(freshStart);
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "assistant",
+            State = "final",
+            Text = "remote response"
+        });
+
+        var latest = snapshots[^1];
+        Assert.Contains(latest.Timelines["main"].Entries, e =>
+            e.Kind == ChatTimelineItemKind.User && e.Text == "remote no timestamp");
+        Assert.Contains(latest.Timelines["main"].Entries, e =>
+            e.Kind == ChatTimelineItemKind.Assistant && e.Text == "remote response");
+    }
+
+    [Fact]
     public async Task SessionResetCompletion_LocalSendDoesNotReopenGateForStaleChatFrames()
     {
         var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });

--- a/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
@@ -170,6 +170,66 @@ public class ToolMetaCacheTests
         Assert.Empty(Directory.EnumerateFiles(tempDir.DirectoryPath, "*.tmp"));
     }
 
+    [Fact]
+    public async Task CacheToolMeta_WithoutSessionId_FallsBackToThreadKey()
+    {
+        using var tempDir = new TempDirectory();
+        var cachePath = Path.Combine(tempDir.DirectoryPath, "tool-metadata.json");
+        var provider = new OpenClawChatDataProvider(new FakeBridge(), post: null, toolMetaCacheFilePath: cachePath);
+
+        provider.CacheToolMeta("main", 1_000, "bash", "echo after reset");
+
+        await provider.DisposeAsync();
+
+        var json = File.ReadAllText(cachePath);
+        var cache = JsonSerializer.Deserialize<Dictionary<string, List<OpenClawChatDataProvider.CachedToolMeta>>>(json);
+
+        Assert.NotNull(cache);
+        Assert.True(cache!.TryGetValue("main", out var entries));
+        var entry = Assert.Single(entries!);
+        Assert.Equal("bash", entry.ToolName);
+        Assert.Equal("echo after reset", entry.Label);
+    }
+
+    [Fact]
+    public async Task Reset_DoesNotReseedClearedSessionIdFromStaleSessionsList()
+    {
+        using var tempDir = new TempDirectory();
+        var cachePath = Path.Combine(tempDir.DirectoryPath, "tool-metadata.json");
+        var bridge = new FakeBridge
+        {
+            History = new ChatHistoryInfo
+            {
+                SessionKey = "main",
+                SessionId = "old-session"
+            }
+        };
+        var provider = new OpenClawChatDataProvider(bridge, post: null, toolMetaCacheFilePath: cachePath);
+        await provider.LoadHistoryAsync("main");
+
+        bridge.RaiseSessionCommandCompleted(new SessionCommandResult
+        {
+            Method = "sessions.reset",
+            Ok = true,
+            Key = "main"
+        });
+        bridge.RaiseSessions(new[]
+        {
+            new SessionInfo { Key = "main", IsMain = true, SessionId = "old-session" }
+        });
+        provider.CacheToolMeta("main", 1_000, "bash", "echo after reset");
+
+        await provider.DisposeAsync();
+
+        var json = File.ReadAllText(cachePath);
+        var cache = JsonSerializer.Deserialize<Dictionary<string, List<OpenClawChatDataProvider.CachedToolMeta>>>(json);
+
+        Assert.NotNull(cache);
+        Assert.False(cache!.ContainsKey("old-session"));
+        Assert.True(cache.TryGetValue("main", out var entries));
+        Assert.Equal("echo after reset", Assert.Single(entries!).Label);
+    }
+
     private sealed class FakeBridge : IChatGatewayBridge
     {
         public bool IsConnected { get; set; }
@@ -182,17 +242,20 @@ public class ToolMetaCacheTests
         public ModelsListInfo? GetCurrentModelsList() => null;
         public void StartProactiveBootstrap() { }
         public Task SendChatMessageAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null) => Task.CompletedTask;
+        public Task<ChatSendResult> SendChatMessageForRunAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null) => Task.FromResult(new ChatSendResult());
         public Task PatchSessionModelAsync(string sessionKey, string model) => Task.CompletedTask;
         public Task PatchSessionThinkingLevelAsync(string sessionKey, string thinkingLevel) => Task.CompletedTask;
         public Task<ChatHistoryInfo> RequestChatHistoryAsync(string? sessionKey) => Task.FromResult(History);
         public Task SendChatAbortAsync(string runId, string? sessionKey = null) => Task.CompletedTask;
         public event EventHandler<ConnectionStatus>? StatusChanged;
         public event EventHandler<SessionInfo[]>? SessionsUpdated;
+        public event EventHandler<SessionCommandResult>? SessionCommandCompleted;
         public event EventHandler<ChatMessageInfo>? ChatMessageReceived;
         public event EventHandler<AgentEventInfo>? AgentEventReceived;
         public event EventHandler<ModelsListInfo>? ModelsListUpdated;
         public void RaiseStatus(ConnectionStatus status) => StatusChanged?.Invoke(this, status);
         public void RaiseSessions(SessionInfo[] sessions) => SessionsUpdated?.Invoke(this, sessions);
+        public void RaiseSessionCommandCompleted(SessionCommandResult result) => SessionCommandCompleted?.Invoke(this, result);
         public void RaiseChat(ChatMessageInfo message) => ChatMessageReceived?.Invoke(this, message);
         public void RaiseAgent(AgentEventInfo evt) => AgentEventReceived?.Invoke(this, evt);
         public void RaiseModels(ModelsListInfo models) => ModelsListUpdated?.Invoke(this, models);


### PR DESCRIPTION
## Summary
- Clear the native Chat page timeline when a Sessions page reset completes.
- Fence stale pre-reset history, live chat/agent events, remote backfill, abort persistence, local echo state, send completions, and tool metadata/session-id reseeding.
- Add regression coverage for reset races and timestamp/session-id edge cases.

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — 2200 passed, 29 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — 1005 passed

## Review
- Dual-model review ran repeatedly until both final reviewers reported no actionable findings.

## Proof Screenshots
Before the session reset:
<img width="1730" height="962" alt="image" src="https://github.com/user-attachments/assets/92964c82-0ff1-4d67-be49-b2caac205ad1" />

After the session reset:
<img width="1730" height="962" alt="image" src="https://github.com/user-attachments/assets/1c821b38-c043-4748-9b67-36b89734f557" />