### PR TITLE
Preserve wizard option wire values

### DIFF
--- a/src/OpenClaw.SetupEngine.UI/Pages/WizardPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WizardPage.xaml.cs
@@ -25,7 +25,7 @@ public sealed partial class WizardPage : Page
     private int _operationGeneration;
     private int _wizardStepCount;
     private readonly Dictionary<string, int> _stepVisits = new(StringComparer.OrdinalIgnoreCase);
-    private readonly List<WizardOption> _options = [];
+    private readonly List<WizardOptionValue> _options = [];
     // Tails the WSL gateway log and surfaces openclaw plugin console.log output
     // (OAuth URLs, install fallback messages, etc) inline on the active step.
     // wizard.payload frames don't carry this content.
@@ -260,22 +260,7 @@ public sealed partial class WizardPage : Page
             return true;
 
         _options.Clear();
-        if (step.TryGetProperty("options", out var options) && options.ValueKind == JsonValueKind.Array)
-        {
-            foreach (var option in options.EnumerateArray())
-            {
-                var value = option.ValueKind == JsonValueKind.Object && option.TryGetProperty("value", out var valueProp)
-                    ? valueProp.ToString()
-                    : option.ToString();
-                var label = option.ValueKind == JsonValueKind.Object && option.TryGetProperty("label", out var labelProp)
-                    ? labelProp.ToString()
-                    : value;
-                var hint = option.ValueKind == JsonValueKind.Object && option.TryGetProperty("hint", out var hintProp)
-                    ? hintProp.ToString()
-                    : "";
-                _options.Add(new(value, label, hint));
-            }
-        }
+        _options.AddRange(WizardAnswerBuilder.ReadOptions(step));
 
         if (!WizardSelection.HasSelectableOptions(_stepType, _options.Select(o => o.Value).ToArray()))
         {
@@ -291,7 +276,7 @@ public sealed partial class WizardPage : Page
                 SelectOptions.Children.Add(new RadioButton
                 {
                     Content = BuildOptionContent(option),
-                    Tag = option.Value,
+                    Tag = option,
                     GroupName = $"wizard-step-{_stepId}",
                     Padding = new Thickness(8, 6, 8, 6),
                     Margin = new Thickness(0, 0, 0, 2),
@@ -300,7 +285,7 @@ public sealed partial class WizardPage : Page
                 });
             }
 
-            var initialValue = initial.ValueKind == JsonValueKind.String ? initial.GetString() : null;
+            var initialValue = WizardAnswerBuilder.ValueKeys(initial).FirstOrDefault();
             var index = WizardSelection.SelectedIndex(initialValue, _options.Select(o => o.Value).ToArray());
             if (index >= 0 && index < SelectOptions.Children.Count && SelectOptions.Children[index] is RadioButton radio)
                 radio.IsChecked = true;
@@ -314,14 +299,14 @@ public sealed partial class WizardPage : Page
         {
             MultiOptions.Visibility = Visibility.Visible;
             var initialValues = initial.ValueKind == JsonValueKind.Array
-                ? initial.EnumerateArray().Select(v => v.ToString()).ToHashSet(StringComparer.Ordinal)
+                ? initial.EnumerateArray().Select(WizardAnswerBuilder.ValueKey).ToHashSet(StringComparer.Ordinal)
                 : [];
             foreach (var option in _options)
             {
                 var checkBox = new CheckBox
                 {
                     Content = BuildOptionContent(option),
-                    Tag = option.Value,
+                    Tag = option,
                     IsChecked = initialValues.Contains(option.Value),
                     Padding = new Thickness(8, 6, 8, 6),
                     Margin = new Thickness(0, 0, 0, 2),
@@ -339,7 +324,7 @@ public sealed partial class WizardPage : Page
         return true;
     }
 
-    private static FrameworkElement BuildOptionContent(WizardOption option)
+    private static FrameworkElement BuildOptionContent(WizardOptionValue option)
     {
         var panel = new StackPanel
         {
@@ -492,11 +477,14 @@ public sealed partial class WizardPage : Page
             "confirm" => true,
             "select" => SelectOptions.Children.OfType<RadioButton>()
                 .FirstOrDefault(r => r.IsChecked == true)
-                ?.Tag?.ToString() ?? "",
+                ?.Tag is WizardOptionValue option
+                    ? option.RawValue
+                    : "",
             "multiselect" => MultiOptions.Children.OfType<CheckBox>()
                 .Where(c => c.IsChecked == true)
-                .Select(c => c.Tag?.ToString() ?? "")
-                .Where(v => v.Length > 0)
+                .Select(c => c.Tag as WizardOptionValue)
+                .OfType<WizardOptionValue>()
+                .Select(option => option.RawValue)
                 .ToArray(),
             "text" => _sensitive ? SecretInput.Password : TextInput.Text,
             _ => "true"
@@ -517,12 +505,12 @@ public sealed partial class WizardPage : Page
         {
             "select" => SelectOptions.Children.OfType<RadioButton>()
                 .Where(r => r.IsChecked == true)
-                .Select(r => r.Tag?.ToString() ?? "")
+                .Select(r => r.Tag is WizardOptionValue option ? option.Value : "")
                 .Where(v => v.Length > 0)
                 .ToArray(),
             "multiselect" => MultiOptions.Children.OfType<CheckBox>()
                 .Where(c => c.IsChecked == true)
-                .Select(c => c.Tag?.ToString() ?? "")
+                .Select(c => c.Tag is WizardOptionValue option ? option.Value : "")
                 .Where(v => v.Length > 0)
                 .ToArray(),
             _ => []
@@ -826,6 +814,4 @@ public sealed partial class WizardPage : Page
         "text" => "Enter value",
         _ => "Setup"
     };
-
-    private sealed record WizardOption(string Value, string Label, string Hint);
 }

--- a/src/OpenClaw.SetupEngine/SetupWizardRunner.cs
+++ b/src/OpenClaw.SetupEngine/SetupWizardRunner.cs
@@ -337,18 +337,7 @@ public sealed class SetupWizardRunner
 
     private static object AnswerValueForWire(WizardPayload step, string answer)
     {
-        if (step.StepType == "confirm" && bool.TryParse(answer, out var booleanAnswer))
-            return booleanAnswer;
-
-        if (step.StepType == "multiselect")
-        {
-            if (string.Equals(answer, "__skip__", StringComparison.Ordinal))
-                return new[] { "__skip__" };
-
-            return SplitMultiSelect(answer);
-        }
-
-        return answer;
+        return WizardAnswerBuilder.BuildWireValue(step.StepType, answer, step.Options);
     }
 
     private static string? InferTextAnswer(WizardPayload step)
@@ -366,7 +355,7 @@ public sealed class SetupWizardRunner
     {
         if (step.StepType == "select")
         {
-            if (!step.Options.Any(o => string.Equals(o.Value, answer, StringComparison.Ordinal)))
+            if (!WizardAnswerBuilder.TryFindOption(step.Options, answer, out _))
             {
                 var source = configuredAnswer ? "configured" : "default";
                 return AnswerResolution.Fail($"The {source} answer for wizard step '{step.StepId}' is not one of the gateway-provided options.");
@@ -374,14 +363,11 @@ public sealed class SetupWizardRunner
         }
         else if (step.StepType == "multiselect")
         {
-            var values = SplitMultiSelect(answer);
-            if (values.Length == 0)
+            if (!WizardAnswerBuilder.TryResolveOptions(step.Options, answer, out var values))
                 return AnswerResolution.Fail($"Gateway wizard step '{step.StepId}' requires at least one selected value.");
 
-            var validValues = step.Options.Select(o => o.Value).ToHashSet(StringComparer.Ordinal);
-            var invalid = values.FirstOrDefault(v => !validValues.Contains(v));
-            if (invalid != null)
-                return AnswerResolution.Fail($"Wizard step '{step.StepId}' has invalid selected value '{invalid}'.");
+            if (values.Length == 0)
+                return AnswerResolution.Fail($"Gateway wizard step '{step.StepId}' requires at least one selected value.");
         }
 
         return AnswerResolution.Ok(answer);
@@ -463,9 +449,6 @@ public sealed class SetupWizardRunner
         return !string.IsNullOrWhiteSpace(messageKey) ? messageKey : stepId;
     }
 
-    private static string[] SplitMultiSelect(string stepInput) =>
-        stepInput.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
     private static string NormalizeKey(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -480,8 +463,6 @@ public sealed class SetupWizardRunner
         public static AnswerResolution Fail(string error) => new(false, false, "", error);
     }
 
-    private sealed record WizardOption(string Value, string Label, string Hint);
-
     private sealed record WizardPayload(
         bool IsDone,
         string? SessionId,
@@ -493,7 +474,7 @@ public sealed class SetupWizardRunner
         bool Sensitive,
         int StepIndex,
         int TotalSteps,
-        IReadOnlyList<WizardOption> Options,
+        IReadOnlyList<WizardOptionValue> Options,
         string? Error)
     {
         public static WizardPayload Parse(JsonElement payload)
@@ -522,30 +503,14 @@ public sealed class SetupWizardRunner
                 var title = step.TryGetProperty("title", out var titleProperty) ? titleProperty.ToString() : "";
                 var message = step.TryGetProperty("message", out var messageProperty) ? messageProperty.ToString() : "";
                 var stepId = step.TryGetProperty("id", out var idProperty) ? idProperty.ToString() : "";
-                var initialValue = step.TryGetProperty("initialValue", out var initialProperty) ? initialProperty.ToString() : "";
+                var initialValue = step.TryGetProperty("initialValue", out var initialProperty)
+                    ? WizardAnswerBuilder.ValueKey(initialProperty)
+                    : "";
                 var sensitive = step.TryGetProperty("sensitive", out var sensitiveProperty) && sensitiveProperty.ValueKind == JsonValueKind.True;
                 var stepIndex = payload.TryGetProperty("stepIndex", out var indexProperty) && indexProperty.TryGetInt32(out var index) ? index : 0;
                 var totalSteps = payload.TryGetProperty("totalSteps", out var totalProperty) && totalProperty.TryGetInt32(out var total) ? total : 0;
 
-                var options = new List<WizardOption>();
-                if (step.TryGetProperty("options", out var optionsProperty) && optionsProperty.ValueKind == JsonValueKind.Array)
-                {
-                    foreach (var option in optionsProperty.EnumerateArray())
-                    {
-                        if (option.ValueKind == JsonValueKind.Object)
-                        {
-                            var label = option.TryGetProperty("label", out var labelProperty) ? labelProperty.ToString() : "";
-                            var value = option.TryGetProperty("value", out var valueProperty) ? valueProperty.ToString() : label;
-                            var hint = option.TryGetProperty("hint", out var hintProperty) ? hintProperty.ToString() : "";
-                            options.Add(new(value, label, hint));
-                        }
-                        else
-                        {
-                            var value = option.ToString();
-                            options.Add(new(value, value, ""));
-                        }
-                    }
-                }
+                var options = WizardAnswerBuilder.ReadOptions(step);
 
                 return new(false, sessionId, stepId, type, title, message, initialValue, sensitive, stepIndex, totalSteps, options, null);
             }
@@ -565,7 +530,7 @@ public sealed class SetupWizardRunner
         string Message,
         bool Sensitive,
         string? SuggestedAnswer,
-        IReadOnlyList<WizardOption> Options)
+        IReadOnlyList<WizardOptionValue> Options)
     {
         public static WizardTemplateStep From(WizardPayload payload)
         {

--- a/src/OpenClaw.SetupEngine/WizardAnswerBuilder.cs
+++ b/src/OpenClaw.SetupEngine/WizardAnswerBuilder.cs
@@ -1,0 +1,210 @@
+using System.Text.Json;
+
+namespace OpenClaw.SetupEngine;
+
+public sealed record WizardOptionValue(string Value, string Label, string Hint, JsonElement RawValue);
+
+public static class WizardAnswerBuilder
+{
+    public static IReadOnlyList<WizardOptionValue> ReadOptions(JsonElement step)
+    {
+        if (step.ValueKind != JsonValueKind.Object
+            || !step.TryGetProperty("options", out var options)
+            || options.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var result = new List<WizardOptionValue>();
+        foreach (var option in options.EnumerateArray())
+        {
+            result.Add(ReadOption(option));
+        }
+
+        return result;
+    }
+
+    public static string ValueKey(JsonElement value) => value.ValueKind switch
+    {
+        JsonValueKind.String => value.GetString() ?? string.Empty,
+        JsonValueKind.Null => "null",
+        JsonValueKind.Undefined => string.Empty,
+        _ => JsonSerializer.Serialize(value)
+    };
+
+    public static string[] ValueKeys(JsonElement value)
+    {
+        if (value.ValueKind == JsonValueKind.Array)
+            return value.EnumerateArray().Select(ValueKey).ToArray();
+
+        var key = ValueKey(value);
+        return string.IsNullOrEmpty(key) ? [] : [key];
+    }
+
+    public static object BuildWireValue(string stepType, string answer, IReadOnlyList<WizardOptionValue> options)
+    {
+        if (stepType == "confirm" && bool.TryParse(answer, out var booleanAnswer))
+            return booleanAnswer;
+
+        if (stepType == "select" && TryFindOption(options, answer, out var option))
+            return option.RawValue;
+
+        if (stepType == "multiselect")
+        {
+            if (string.Equals(answer, "__skip__", StringComparison.Ordinal))
+                return new[] { "__skip__" };
+
+            if (TryResolveOptions(options, answer, out var selectedOptions))
+                return selectedOptions.Select(selected => selected.RawValue).ToArray();
+
+            return SplitMultiSelect(answer);
+        }
+
+        return answer;
+    }
+
+    public static bool TryFindOption(IReadOnlyList<WizardOptionValue> options, string answer, out WizardOptionValue option)
+    {
+        var exact = options.FirstOrDefault(candidate => string.Equals(candidate.Value, answer, StringComparison.Ordinal));
+        if (exact is not null)
+        {
+            option = exact;
+            return true;
+        }
+
+        if (!TryParseJson(answer, out var parsed))
+        {
+            option = null!;
+            return false;
+        }
+
+        using (parsed)
+        {
+            return TryFindOption(options, parsed.RootElement, out option);
+        }
+    }
+
+    public static bool TryResolveOptions(IReadOnlyList<WizardOptionValue> options, string answer, out WizardOptionValue[] selectedOptions)
+    {
+        if (TryParseJson(answer, out var parsed))
+        {
+            using (parsed)
+            {
+                if (parsed.RootElement.ValueKind == JsonValueKind.Array)
+                {
+                    var selected = new List<WizardOptionValue>();
+                    foreach (var item in parsed.RootElement.EnumerateArray())
+                    {
+                        if (!TryFindOption(options, item, out var option))
+                        {
+                            selectedOptions = [];
+                            return false;
+                        }
+
+                        selected.Add(option);
+                    }
+
+                    selectedOptions = selected.ToArray();
+                    return selectedOptions.Length > 0;
+                }
+            }
+        }
+
+        var values = SplitMultiSelect(answer);
+        if (values.Length == 0)
+        {
+            selectedOptions = [];
+            return false;
+        }
+
+        var resolved = new List<WizardOptionValue>(values.Length);
+        foreach (var value in values)
+        {
+            if (!TryFindOption(options, value, out var option))
+            {
+                selectedOptions = [];
+                return false;
+            }
+
+            resolved.Add(option);
+        }
+
+        selectedOptions = resolved.ToArray();
+        return true;
+    }
+
+    public static string[] SplitMultiSelect(string stepInput) =>
+        stepInput.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    private static WizardOptionValue ReadOption(JsonElement option)
+    {
+        if (option.ValueKind != JsonValueKind.Object)
+        {
+            var raw = option.Clone();
+            var value = ValueKey(raw);
+            return new(value, value, string.Empty, raw);
+        }
+
+        var label = option.TryGetProperty("label", out var labelProperty)
+            ? DisplayText(labelProperty)
+            : string.Empty;
+        var hint = option.TryGetProperty("hint", out var hintProperty)
+            ? DisplayText(hintProperty)
+            : string.Empty;
+
+        if (option.TryGetProperty("value", out var valueProperty))
+        {
+            var raw = valueProperty.Clone();
+            var value = ValueKey(raw);
+            return new(value, string.IsNullOrWhiteSpace(label) ? value : label, hint, raw);
+        }
+
+        var fallback = string.IsNullOrWhiteSpace(label) ? DisplayText(option) : label;
+        return new(fallback, fallback, hint, JsonSerializer.SerializeToElement(fallback));
+    }
+
+    private static string DisplayText(JsonElement element) => element.ValueKind switch
+    {
+        JsonValueKind.String => element.GetString() ?? string.Empty,
+        JsonValueKind.Null or JsonValueKind.Undefined => string.Empty,
+        _ => JsonSerializer.Serialize(element)
+    };
+
+    private static bool TryFindOption(IReadOnlyList<WizardOptionValue> options, JsonElement answer, out WizardOptionValue option)
+    {
+        var key = ValueKey(answer);
+        var exact = options.FirstOrDefault(candidate => string.Equals(candidate.Value, key, StringComparison.Ordinal));
+        if (exact is not null)
+        {
+            option = exact;
+            return true;
+        }
+
+        var structural = options.FirstOrDefault(candidate => JsonElement.DeepEquals(candidate.RawValue, answer));
+        if (structural is not null)
+        {
+            option = structural;
+            return true;
+        }
+
+        option = null!;
+        return false;
+    }
+
+    private static bool TryParseJson(string value, out JsonDocument document)
+    {
+        document = null!;
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        try
+        {
+            document = JsonDocument.Parse(value);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+}

--- a/tests/OpenClaw.SetupEngine.Tests/WizardAnswerBuilderTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/WizardAnswerBuilderTests.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+
+namespace OpenClaw.SetupEngine.Tests;
+
+public class WizardAnswerBuilderTests
+{
+    [Fact]
+    public void ReadOptions_UsesCanonicalKeysForRawPrimitiveAndObjectValues()
+    {
+        var step = ParseElement("""
+            {
+              "options": [
+                { "label": "Bool", "value": true },
+                { "label": "Number", "value": 42 },
+                { "label": "Object", "value": { "id": 1, "name": "matrix" } },
+                "plain"
+              ]
+            }
+            """);
+
+        var options = WizardAnswerBuilder.ReadOptions(step);
+
+        Assert.Collection(
+            options,
+            option => Assert.Equal("true", option.Value),
+            option => Assert.Equal("42", option.Value),
+            option => Assert.Equal("""{"id":1,"name":"matrix"}""", option.Value),
+            option => Assert.Equal("plain", option.Value));
+    }
+
+    [Fact]
+    public void BuildWireValue_SelectPreservesNumericOptionValue()
+    {
+        var options = ReadOptions("""{"options":[{"label":"Number","value":42}]}""");
+
+        var wireValue = WizardAnswerBuilder.BuildWireValue("select", "42", options);
+
+        Assert.Equal("""{"value":42}""", SerializeValue(wireValue));
+    }
+
+    [Fact]
+    public void BuildWireValue_SelectPreservesBooleanOptionValue()
+    {
+        var options = ReadOptions("""{"options":[{"label":"Enabled","value":true}]}""");
+
+        var wireValue = WizardAnswerBuilder.BuildWireValue("select", "true", options);
+
+        Assert.Equal("""{"value":true}""", SerializeValue(wireValue));
+    }
+
+    [Fact]
+    public void BuildWireValue_SelectPreservesObjectOptionValue()
+    {
+        var options = ReadOptions("""{"options":[{"label":"Matrix","value":{"id":1,"name":"matrix"}}]}""");
+
+        var wireValue = WizardAnswerBuilder.BuildWireValue("select", """{"id":1,"name":"matrix"}""", options);
+
+        Assert.Equal("""{"value":{"id":1,"name":"matrix"}}""", SerializeValue(wireValue));
+    }
+
+    [Fact]
+    public void BuildWireValue_MultiselectPreservesRawOptionValues()
+    {
+        var options = ReadOptions("""
+            {
+              "options": [
+                { "label": "Enabled", "value": true },
+                { "label": "Number", "value": 42 },
+                { "label": "Matrix", "value": { "id": 1 } }
+              ]
+            }
+            """);
+
+        var wireValue = WizardAnswerBuilder.BuildWireValue("multiselect", """[true,42,{"id":1}]""", options);
+
+        Assert.Equal("""{"value":[true,42,{"id":1}]}""", SerializeValue(wireValue));
+    }
+
+    [Fact]
+    public void BuildWireValue_ConfirmFalseStaysBooleanFalse()
+    {
+        var wireValue = WizardAnswerBuilder.BuildWireValue("confirm", "false", []);
+
+        Assert.Equal("""{"value":false}""", SerializeValue(wireValue));
+    }
+
+    [Fact]
+    public void BuildWireValue_NoteAckKeepsExistingStringShape()
+    {
+        var wireValue = WizardAnswerBuilder.BuildWireValue("note", "true", []);
+
+        Assert.Equal("""{"value":"true"}""", SerializeValue(wireValue));
+    }
+
+    [Fact]
+    public void BuildWireValue_MultiselectSkipKeepsSentinelStringArray()
+    {
+        var wireValue = WizardAnswerBuilder.BuildWireValue("multiselect", "__skip__", []);
+
+        Assert.Equal("""{"value":["__skip__"]}""", SerializeValue(wireValue));
+    }
+
+    private static IReadOnlyList<WizardOptionValue> ReadOptions(string stepJson) =>
+        WizardAnswerBuilder.ReadOptions(ParseElement(stepJson));
+
+    private static JsonElement ParseElement(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private static string SerializeValue(object value) =>
+        JsonSerializer.Serialize(new { value });
+}


### PR DESCRIPTION
## What

Makes the Windows setup wizard send the gateway the **exact, type-preserved option value** (the "wire value") for `select`, `multiselect`, and `confirm` steps, instead of a stringified/coerced version.

A new pure helper, `WizardAnswerBuilder`, becomes the single source of truth for reading wizard options and building the `wizard.next` answer payload. Both the interactive UI (`WizardPage.xaml.cs`) and the headless runner (`SetupWizardRunner.cs`) route through it, so they can no longer drift apart.

## The problem

The gateway wizard protocol (`openclaw/openclaw`) defines option values and answer values as **arbitrary JSON**, not strings:

```ts
// packages/gateway-protocol/src/schema/wizard.ts
WizardStepOptionSchema = { value: Type.Unknown(), label, hint? }
WizardAnswerSchema     = { stepId, value: Type.Optional(Type.Unknown()) }
// initialValue is Type.Unknown() too
```

Crucially, **the gateway does no normalization on the way back in**. `wizard.next` hands the raw client value straight to the onboard runner, cast to the expected type — there is no server-side option-matching or coercion for `select`/`multiselect`:

```ts
// src/wizard/session.ts
async answer(stepId, value) { ...; deferred.resolve(value); } // raw value, untouched
async select<T>(...)      { return res as T; }                // no matching, no coercion
async multiselect<T>(...) { return (Array.isArray(res) ? res : []) as T[]; }
```

So whatever JSON type the client sends is fed directly into the runner's `===` comparisons and config writes. The macOS reference client honors this and sends the **raw typed value**:

```swift
// apps/macos/.../WizardCommand.swift
return option.value?.value ?? option.label      // raw decoded JSON value
answerPayload["value"] = ProtoAnyCodable(answer) // type preserved on the wire
```

The Windows client was the **outlier**. It stringified everything when reading options and when building the answer:

```csharp
// before
var value = option.TryGetProperty("value", out var v) ? v.ToString() : option.ToString();
// ...
Tag = option.Value,                          // string
"select" => ...?.Tag?.ToString() ?? "",      // string answer
```

For options whose wire value is **not a plain string** — a number (`42`), boolean (`true`), or JSON object (`{ "id": 1 }`) — Windows would send `"42"` / `"true"` / `"{\"id\":1}"`. Because the gateway forwards that raw to the runner, the runner receives the wrong-typed value and the step misbehaves (failed equality match, wrong config value written).

> **Scope:** Every option in the gateway's **core** onboarding flow currently uses string values (provider ids, `"__skip__"`, `"__keep__"`, `String(enum)`, …), so the built-in flow was not broken in practice. This fix matters for **plugin / extension-defined setup surfaces** that can legally use non-string `value`/`initialValue`, for **parity with the macOS reference client**, and for **protocol correctness / future-proofing**. It is defensive alignment with the `value: unknown` contract, not a patch for a presently-broken core step.

## The fix

New `WizardAnswerBuilder` (in `OpenClaw.SetupEngine`) plus a `WizardOptionValue` record that carries both a canonical string key and the original JSON:

```csharp
public sealed record WizardOptionValue(string Value, string Label, string Hint, JsonElement RawValue);
```

- **`ReadOptions(step)`** — parses each option once, preserving the original value as a cloned `JsonElement` (`RawValue`) so it outlives the source document. Object options use `label`/`value`/`hint`; bare scalar options become their own value/label.
- **`ValueKey(value)` / `ValueKeys(value)`** — derive a stable string key for UI selection/dedup/`initialValue` matching (strings pass through; everything else is canonical JSON). This key is used only for matching/UI, never as the wire value.
- **`BuildWireValue(stepType, answer, options)`** — produces the value actually sent to the gateway:
  - `confirm` → real boolean (`bool.TryParse`)
  - `select` → the matched option's `RawValue` (original JSON type)
  - `multiselect` → array of matched options' `RawValue`s; `"__skip__"` sentinel and comma-string fallback preserved
  - everything else → unchanged string passthrough
- **`TryFindOption` / `TryResolveOptions`** — match an answer to options **exact-key-first, then structural** (`JsonElement.DeepEquals`). Exact-key-first means a string option whose value literally looks like JSON (e.g. `"true"`) is never mis-parsed into a boolean.

Call sites now use the typed value:

| File | Change |
|------|--------|
| `WizardPage.xaml.cs` | `_options` is `List<WizardOptionValue>`; radio/checkbox `Tag` holds the full option; `TryBuildAnswerValue` emits `option.RawValue` (and an array of raw values for multiselect); UI selection logic still uses the string `Value` |
| `SetupWizardRunner.cs` | `AnswerValueForWire` delegates to `BuildWireValue`; `ValidateAnswer` uses `TryFindOption`/`TryResolveOptions`; duplicate `WizardOption` record and `SplitMultiSelect` removed; `initialValue` parsed via `ValueKey` |

Net effect: string-valued options behave exactly as before (verified), while numeric/boolean/object option values now round-trip with their original JSON type — matching the gateway contract and the macOS client.

## Files changed

- **`src/OpenClaw.SetupEngine/WizardAnswerBuilder.cs`** — new shared helper + `WizardOptionValue` record
- **`src/OpenClaw.SetupEngine/SetupWizardRunner.cs`** — route through the helper; drop duplicated option/split logic
- **`src/OpenClaw.SetupEngine.UI/Pages/WizardPage.xaml.cs`** — preserve raw values through `Tag`; typed option list
- **`tests/OpenClaw.SetupEngine.Tests/WizardAnswerBuilderTests.cs`** — new unit tests

## Testing

- `./build.ps1` — all projects build clean (0 warnings)
- Tray tests: **1025 passed**
- Shared tests: **2211 passed**
- `OpenClaw.SetupEngine.Tests`: **247 passed** (incl. 8 new `WizardAnswerBuilder` cases covering numeric/boolean/object preservation for select & multiselect, `confirm` boolean, `note` string passthrough, and the `__skip__` sentinel)

(Rebased onto `main`; clean single commit.)
