### PR TITLE
fix(exec): migrate approvals to custom state dir

### DIFF
--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalEvaluation.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalEvaluation.cs
@@ -24,6 +24,8 @@ public sealed class ExecApprovalEvaluation
     public IReadOnlyList<string> AllowAlwaysPatterns { get; }
     public IReadOnlyList<ExecAllowlistEntry> AllowlistMatches { get; }
 
+    public bool AllAllowlistResolutionsMatched { get; }
+
     // true iff security==allowlist && resolutions.Count>0 && matches.Count==resolutions.Count.
     // Research doc 06 derivation rule — must not be re-derived outside the constructor.
     public bool AllowlistSatisfied { get; }
@@ -70,9 +72,9 @@ public sealed class ExecApprovalEvaluation
 
         Resolution = allowlistResolutions.Count > 0 ? allowlistResolutions[0] : (ExecCommandResolution?)null;
 
-        AllowlistSatisfied = security == ExecSecurity.Allowlist
-            && allowlistResolutions.Count > 0
+        AllAllowlistResolutionsMatched = allowlistResolutions.Count > 0
             && allowlistMatches.Count == allowlistResolutions.Count;
+        AllowlistSatisfied = security == ExecSecurity.Allowlist && AllAllowlistResolutionsMatched;
 
         AllowlistMatch = AllowlistSatisfied ? allowlistMatches[0] : null;
     }

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsContracts.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsContracts.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace OpenClaw.Shared.ExecApprovals;
@@ -52,7 +53,8 @@ public sealed class ExecApprovalsDefaults
 {
     public ExecSecurity? Security { get; set; }
     public ExecAsk? Ask { get; set; }
-    public ExecAsk? AskFallback { get; set; }
+    [JsonConverter(typeof(ExecSecurityFallbackConverter))]
+    public ExecSecurity? AskFallback { get; set; }
     public bool? AutoAllowSkills { get; set; }
 }
 
@@ -60,7 +62,8 @@ public sealed class ExecApprovalsAgent
 {
     public ExecSecurity? Security { get; set; }
     public ExecAsk? Ask { get; set; }
-    public ExecAsk? AskFallback { get; set; }
+    [JsonConverter(typeof(ExecSecurityFallbackConverter))]
+    public ExecSecurity? AskFallback { get; set; }
     public bool? AutoAllowSkills { get; set; }
     public List<ExecAllowlistEntry>? Allowlist { get; set; }
 }
@@ -73,13 +76,45 @@ public sealed class ExecApprovalsFile
     public Dictionary<string, ExecApprovalsAgent>? Agents { get; set; }
 }
 
+internal sealed class ExecSecurityFallbackConverter : JsonConverter<ExecSecurity?>
+{
+    public override ExecSecurity? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null) return null;
+        if (reader.TokenType != JsonTokenType.String) throw new JsonException("askFallback must be a string");
+        return reader.GetString()?.ToLowerInvariant() switch
+        {
+            "deny" or "always" => ExecSecurity.Deny,
+            "allowlist" or "on-miss" => ExecSecurity.Allowlist,
+            "full" or "off" => ExecSecurity.Full,
+            var value => throw new JsonException($"Unsupported askFallback value: {value}"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, ExecSecurity? value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+        writer.WriteStringValue(value.Value switch
+        {
+            ExecSecurity.Deny => "deny",
+            ExecSecurity.Allowlist => "allowlist",
+            ExecSecurity.Full => "full",
+            _ => throw new JsonException($"Unsupported askFallback value: {value}"),
+        });
+    }
+}
+
 // ── Resolved/runtime contracts (not serialized) ───────────────────────────────
 
 public sealed class ExecApprovalsResolvedDefaults
 {
     public ExecSecurity Security { get; init; }
     public ExecAsk Ask { get; init; }
-    public ExecAsk AskFallback { get; init; }
+    public ExecSecurity AskFallback { get; init; }
     public bool AutoAllowSkills { get; init; }
 }
 

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
@@ -75,7 +75,9 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
         }
 
         var sanitizedEnv = envResult.Allowed as IReadOnlyDictionary<string, string>;
-        IReadOnlyList<ExecAllowlistEntry> matches = resolved.Defaults.Security == ExecSecurity.Allowlist
+        var needsAllowlistMatches = resolved.Defaults.Security == ExecSecurity.Allowlist
+            || resolved.Defaults.AskFallback == ExecSecurity.Allowlist;
+        IReadOnlyList<ExecAllowlistEntry> matches = needsAllowlistMatches
             ? ExecAllowlistMatcher.MatchAll(resolved.Allowlist, identity.AllowlistResolutions)
             : [];
 
@@ -208,16 +210,16 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
     // ask=Always → Deny: human approval is a precondition; without UI the only safe outcome is deny.
     private static ExecApprovalDecision FallbackDecision(
         ExecApprovalEvaluation context,
-        ExecAsk askFallback)
+        ExecSecurity askFallback)
     {
-        return askFallback switch
+        var effectiveFallback = (ExecSecurity)Math.Min((int)context.Security, (int)askFallback);
+        return effectiveFallback switch
         {
-            ExecAsk.Off => ExecApprovalDecision.AllowOnce,
-            ExecAsk.OnMiss => context.AllowlistSatisfied
+            ExecSecurity.Full => ExecApprovalDecision.AllowOnce,
+            ExecSecurity.Allowlist => context.AllAllowlistResolutionsMatched
                 ? ExecApprovalDecision.AllowOnce
                 : ExecApprovalDecision.Deny,
-            ExecAsk.Always => ExecApprovalDecision.Deny,
-            ExecAsk.Deny => ExecApprovalDecision.Deny,
+            ExecSecurity.Deny => ExecApprovalDecision.Deny,
             _ => ExecApprovalDecision.Deny,  // defensive
         };
     }

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsStore.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsStore.cs
@@ -24,8 +24,16 @@ public sealed class ExecApprovalsStore
     };
 
     private readonly string _filePath;
+    private readonly string? _legacyFilePath;
     private readonly IOpenClawLogger _logger;
     private readonly SemaphoreSlim _lock = new(1, 1);
+
+    private enum LegacyMigrationStatus
+    {
+        NotNeeded,
+        Migrated,
+        Blocked,
+    }
 
     private enum LoadFileStatus
     {
@@ -37,8 +45,31 @@ public sealed class ExecApprovalsStore
     private readonly record struct LoadFileResult(LoadFileStatus Status, ExecApprovalsFile? File);
 
     public ExecApprovalsStore(string dataPath, IOpenClawLogger logger)
+        : this(
+            dataPath,
+            logger,
+            Environment.GetEnvironmentVariable("OPENCLAW_STATE_DIR"),
+            Environment.GetEnvironmentVariable("OPENCLAW_HOME"),
+            FirstUsablePathValue(
+                Environment.GetEnvironmentVariable("HOME"),
+                Environment.GetEnvironmentVariable("USERPROFILE"),
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)))
     {
-        _filePath = Path.Combine(dataPath, "exec-approvals.json");
+    }
+
+    internal ExecApprovalsStore(
+        string dataPath,
+        IOpenClawLogger logger,
+        string? stateDirOverride,
+        string? openClawHomeOverride = null,
+        string? osHomeOverride = null)
+    {
+        var stateDir = string.IsNullOrWhiteSpace(stateDirOverride)
+            ? dataPath
+            : ResolveStateDirPath(stateDirOverride, openClawHomeOverride, osHomeOverride);
+        _filePath = Path.Combine(stateDir, "exec-approvals.json");
+        var legacyFilePath = Path.Combine(dataPath, "exec-approvals.json");
+        _legacyFilePath = PathsEqual(_filePath, legacyFilePath) ? null : legacyFilePath;
         _logger = logger;
     }
 
@@ -47,6 +78,9 @@ public sealed class ExecApprovalsStore
     // No side effects; does not create the file. Used by the evaluator (PR5).
     public ExecApprovalsResolved ResolveReadOnly(string? agentId)
     {
+        if (_legacyFilePath is not null && File.Exists(_legacyFilePath) && !File.Exists(_filePath))
+            return UnmigratedLegacyFallback(agentId);
+
         var result = LoadFile();
         return result.Status != LoadFileStatus.Loaded || result.File is null
             ? DefaultResolved(NormalizeAgentId(agentId))
@@ -69,14 +103,19 @@ public sealed class ExecApprovalsStore
         }
     }
 
+    public void MigrateLegacyFileIfNeeded() => TryMigrateLegacyFile();
+
     // ── File I/O ──────────────────────────────────────────────────────────────
 
     private LoadFileResult LoadFile()
+        => LoadFile(_filePath);
+
+    private LoadFileResult LoadFile(string filePath)
     {
-        if (!File.Exists(_filePath)) return new LoadFileResult(LoadFileStatus.Missing, null);
+        if (!File.Exists(filePath)) return new LoadFileResult(LoadFileStatus.Missing, null);
         try
         {
-            var json = File.ReadAllText(_filePath);
+            var json = File.ReadAllText(filePath);
             var file = JsonSerializer.Deserialize<ExecApprovalsFile>(json, JsonOptions);
             if (file is null)
             {
@@ -105,6 +144,9 @@ public sealed class ExecApprovalsStore
 
     private async Task<ExecApprovalsFile> EnsureFileAsync()
     {
+        if (TryMigrateLegacyFile() == LegacyMigrationStatus.Blocked)
+            return UnmigratedLegacyFallbackFile();
+
         var result = LoadFile();
         if (result.Status == LoadFileStatus.Loaded && result.File is not null)
         {
@@ -135,6 +177,118 @@ public sealed class ExecApprovalsStore
         _logger.Info($"[EXEC-APPROVALS] Created {_filePath}");
         return newFile;
     }
+
+    private LegacyMigrationStatus TryMigrateLegacyFile()
+    {
+        if (_legacyFilePath is null || !File.Exists(_legacyFilePath) || File.Exists(_filePath))
+            return LegacyMigrationStatus.NotNeeded;
+
+        var legacyResult = LoadFile(_legacyFilePath);
+        if (legacyResult.Status != LoadFileStatus.Loaded || legacyResult.File is null)
+        {
+            _logger.Warn($"[EXEC-APPROVALS] Legacy approvals at {_legacyFilePath} could not be migrated; applying default-deny without creating {_filePath}");
+            return LegacyMigrationStatus.Blocked;
+        }
+
+        var targetDir = Path.GetDirectoryName(_filePath)!;
+        var archivePath = NextArchivePath(_legacyFilePath);
+        var tempPath = Path.Combine(targetDir, $".exec-approvals-migration-{Guid.NewGuid():N}.tmp");
+        try
+        {
+            Directory.CreateDirectory(targetDir);
+            var data = File.ReadAllBytes(_legacyFilePath);
+            using (var stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            {
+                stream.Write(data);
+                stream.Flush(flushToDisk: true);
+            }
+            File.Move(tempPath, _filePath);
+            try
+            {
+                File.Move(_legacyFilePath, archivePath);
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn($"[EXEC-APPROVALS] Migrated approvals to {_filePath}, but could not archive {_legacyFilePath} ({ex.Message})");
+                return LegacyMigrationStatus.Migrated;
+            }
+            _logger.Info($"[EXEC-APPROVALS] Migrated {_legacyFilePath} to {_filePath}; archived source as {archivePath}");
+            return LegacyMigrationStatus.Migrated;
+        }
+        catch (IOException) when (File.Exists(_filePath))
+        {
+            try { if (File.Exists(tempPath)) File.Delete(tempPath); } catch { }
+            return LegacyMigrationStatus.NotNeeded;
+        }
+        catch (Exception ex)
+        {
+            try { if (File.Exists(tempPath)) File.Delete(tempPath); } catch { }
+            _logger.Warn($"[EXEC-APPROVALS] Failed to migrate {_legacyFilePath} to {_filePath} ({ex.Message}); applying default-deny without creating a replacement file");
+            return LegacyMigrationStatus.Blocked;
+        }
+    }
+
+    private static string NextArchivePath(string legacyFilePath)
+    {
+        var archivePath = $"{legacyFilePath}.migrated";
+        return File.Exists(archivePath) ? $"{archivePath}-{Guid.NewGuid():N}" : archivePath;
+    }
+
+    private static bool PathsEqual(string left, string right) =>
+        string.Equals(Path.GetFullPath(left), Path.GetFullPath(right), StringComparison.OrdinalIgnoreCase);
+
+    private static string ResolveStateDirPath(
+        string stateDirOverride,
+        string? openClawHomeOverride,
+        string? osHomeOverride)
+    {
+        var osHome = NormalizePathValue(osHomeOverride) ?? Environment.CurrentDirectory;
+        var openClawHome = NormalizePathValue(openClawHomeOverride);
+        var effectiveHome = openClawHome is null
+            ? Path.GetFullPath(osHome)
+            : Path.GetFullPath(ExpandHomePrefix(openClawHome, osHome));
+        return Path.GetFullPath(ExpandHomePrefix(stateDirOverride.Trim(), effectiveHome));
+    }
+
+    private static string ExpandHomePrefix(string path, string home) =>
+        path == "~"
+            ? home
+            : path.StartsWith($"~{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                || path.StartsWith($"~{Path.AltDirectorySeparatorChar}", StringComparison.Ordinal)
+                ? Path.Combine(home, path[2..])
+                : path;
+
+    private static string? NormalizePathValue(string? value)
+    {
+        var trimmed = value?.Trim();
+        return string.IsNullOrEmpty(trimmed) || trimmed is "undefined" or "null" ? null : trimmed;
+    }
+
+    private static string? FirstUsablePathValue(params string?[] values)
+    {
+        foreach (var value in values)
+        {
+            var normalized = NormalizePathValue(value);
+            if (normalized is not null) return normalized;
+        }
+        return null;
+    }
+
+    private static ExecApprovalsFile UnmigratedLegacyFallbackFile() =>
+        new()
+        {
+            Version = 1,
+            Defaults = new ExecApprovalsDefaults
+            {
+                Security = ExecSecurity.Deny,
+                Ask = ExecAsk.Always,
+                AskFallback = ExecSecurity.Deny,
+            },
+            Agents = [],
+        };
+
+    private static ExecApprovalsResolved UnmigratedLegacyFallback(string? agentId) =>
+        ResolveFromFile(UnmigratedLegacyFallbackFile(), agentId);
 
     private async Task SaveFileAsync(ExecApprovalsFile file)
     {
@@ -276,7 +430,7 @@ public sealed class ExecApprovalsStore
         // Cascade: agentEntry → wildcard → defaults → systemDefault
         var security = agentEntry?.Security ?? wildcardEntry?.Security ?? defaults?.Security ?? ExecSecurity.Deny;
         var ask = agentEntry?.Ask ?? wildcardEntry?.Ask ?? defaults?.Ask ?? ExecAsk.OnMiss;
-        var askFallback = agentEntry?.AskFallback ?? wildcardEntry?.AskFallback ?? defaults?.AskFallback ?? ExecAsk.Deny;
+        var askFallback = agentEntry?.AskFallback ?? wildcardEntry?.AskFallback ?? defaults?.AskFallback ?? ExecSecurity.Deny;
         var autoAllowSkills = agentEntry?.AutoAllowSkills ?? wildcardEntry?.AutoAllowSkills ?? defaults?.AutoAllowSkills ?? false;
 
         // Allowlist: wildcard first, then agent; then normalize dropInvalid=true.
@@ -307,7 +461,7 @@ public sealed class ExecApprovalsStore
             {
                 Security = ExecSecurity.Deny,
                 Ask = ExecAsk.OnMiss,
-                AskFallback = ExecAsk.Deny,
+                AskFallback = ExecSecurity.Deny,
                 AutoAllowSkills = false,
             },
             Allowlist = [],

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -7,6 +7,7 @@ using Microsoft.Toolkit.Uwp.Notifications;
 using Microsoft.UI.Dispatching;
 using OpenClaw.Shared;
 using OpenClaw.Shared.Capabilities;
+using OpenClaw.Shared.ExecApprovals;
 using OpenClaw.Shared.Mcp;
 using OpenClaw.Shared.Mxc;
 using OpenClawTray.A2UI.Actions;
@@ -267,6 +268,8 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
     
     private void RegisterCapabilities()
     {
+        new ExecApprovalsStore(_dataPath, _logger).MigrateLegacyFileIfNeeded();
+
         // Hold the lock across the entire rebuild. The body is sync construction
         // (no awaits), so the lock is held briefly and an MCP tools/list arriving
         // mid-rebuild waits for a consistent snapshot rather than seeing a half-

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
@@ -96,17 +96,17 @@ public class ExecApprovalsCoordinatorTests : IDisposable
     {
         WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always","askFallback":"deny"}}""");
         var result = await MakeCoordinator().HandleAsync(DefaultReq(), "c4");
-        // FallbackDecision(ExecAsk.Deny) → ExecApprovalDecision.Deny → pass2 step2 → UserDenied
+        // FallbackDecision(ExecSecurity.Deny) → ExecApprovalDecision.Deny → pass2 step2 → UserDenied
         Assert.Equal(ExecApprovalV2Code.UserDenied, result.Code);
         Assert.Equal("user-denied", result.Reason);
     }
 
-    // ── 5. ask=always, canPresent=false, askFallback=off → Allow ─────────────
+    // ── 5. ask=always, canPresent=false, askFallback=full → Allow ────────────
 
     [Fact]
-    public async Task AskAlways_CannotPresent_FallbackOff_ReturnsAllow()
+    public async Task AskAlways_CannotPresent_FallbackFull_ReturnsAllow()
     {
-        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always","askFallback":"off"}}""");
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always","askFallback":"full"}}""");
         var log = new CapturingLogger();
         var result = await MakeCoordinator(logger: log).HandleAsync(DefaultReq(), "c5");
         Assert.True(result.IsAllow);
@@ -208,14 +208,14 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         Assert.Equal(ExecApprovalV2Code.AllowlistMiss, result.Code);
     }
 
-    // ── 13. FallbackDecision(ask=Always) → Deny, not AllowOnce ───────────────
+    // ── 13. FallbackDecision(deny) → Deny, not AllowOnce ────────────────────
 
     [Fact]
-    public async Task FallbackDecision_AskFallbackAlways_ReturnsDeny()
+    public async Task FallbackDecision_AskFallbackDeny_ReturnsDeny()
     {
-        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always","askFallback":"always"}}""");
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always","askFallback":"deny"}}""");
         var result = await MakeCoordinator().HandleAsync(DefaultReq(), "c13");
-        // ExecAsk.Always → ExecApprovalDecision.Deny → pass2 → UserDenied (fail-safe)
+        // ExecSecurity.Deny → ExecApprovalDecision.Deny → pass2 → UserDenied (fail-safe)
         Assert.False(result.IsAllow);
         Assert.NotEqual(ExecApprovalV2Code.Allow, result.Code);
     }
@@ -416,17 +416,51 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         Assert.True(id.All(c => char.IsAsciiHexDigit(c)), $"Expected 32 hex chars, got: {id}");
     }
 
-    // ── 23. FallbackDecision(OnMiss, AllowlistSatisfied=false) → Deny ─────────
+    // ── 23. FallbackDecision(Allowlist, unsatisfied) → Deny ──────────────────
 
     [Fact]
-    public async Task FallbackDecision_AskFallbackOnMiss_NotSatisfied_ReturnsDeny()
+    public async Task FallbackDecision_AskFallbackAllowlist_NotSatisfied_ReturnsDeny()
     {
         // security=full, ask=always → RequiresPrompt in pass1
-        // canPresent=false → FallbackDecision(context, ExecAsk.OnMiss)
+        // canPresent=false → FallbackDecision(context, ExecSecurity.Allowlist)
         // AllowlistSatisfied=false (security=Full, not Allowlist) → Deny
-        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always","askFallback":"on-miss"}}""");
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always","askFallback":"allowlist"}}""");
         var result = await MakeCoordinator().HandleAsync(DefaultReq(), "c23");
         Assert.False(result.IsAllow);
+    }
+
+    [Fact]
+    public async Task FallbackDecision_AskFallbackAllowlist_Matched_ReturnsAllow()
+    {
+        WriteStoreFile("""
+        {
+          "version": 1,
+          "defaults": { "security": "full", "ask": "always", "askFallback": "allowlist" },
+          "agents": { "main": { "allowlist": [{ "pattern": "**/where.exe" }] } }
+        }
+        """);
+
+        var result = await MakeCoordinator().HandleAsync(
+            Req("""{"command":["where.exe","cmd.exe"]}"""),
+            "c23-match");
+
+        Assert.True(result.IsAllow);
+    }
+
+    [Fact]
+    public async Task FallbackDecision_FullFallback_DoesNotBypassAllowlistSecurity()
+    {
+        WriteStoreFile("""
+        {
+          "version": 1,
+          "defaults": { "security": "allowlist", "ask": "always", "askFallback": "full" }
+        }
+        """);
+
+        var result = await MakeCoordinator().HandleAsync(DefaultReq(), "c23-clamp");
+
+        Assert.False(result.IsAllow);
+        Assert.Equal(ExecApprovalV2Code.UserDenied, result.Code);
     }
 
     // ── 24. Outer safety net — CanPresent throws → InternalError, not exception ───

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalsStoreTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalsStoreTests.cs
@@ -28,6 +28,8 @@ public class ExecApprovalsStoreTests : IDisposable
 
     private ExecApprovalsStore Store() => new(_dir, _log);
 
+    private ExecApprovalsStore Store(string stateDir) => new(_dir, _log, stateDir);
+
     private string FilePath => Path.Combine(_dir, "exec-approvals.json");
 
     private void WriteFile(string json) => File.WriteAllText(FilePath, json);
@@ -42,7 +44,7 @@ public class ExecApprovalsStoreTests : IDisposable
         Assert.Equal("main", resolved.AgentId);
         Assert.Equal(ExecSecurity.Deny, resolved.Defaults.Security);
         Assert.Equal(ExecAsk.OnMiss, resolved.Defaults.Ask);
-        Assert.Equal(ExecAsk.Deny, resolved.Defaults.AskFallback);
+        Assert.Equal(ExecSecurity.Deny, resolved.Defaults.AskFallback);
         Assert.False(resolved.Defaults.AutoAllowSkills);
         Assert.Empty(resolved.Allowlist);
         Assert.Null(resolved.SocketToken);
@@ -130,7 +132,7 @@ public class ExecApprovalsStoreTests : IDisposable
 
         Assert.Equal(ExecSecurity.Allowlist, resolved.Defaults.Security);
         Assert.Equal(ExecAsk.OnMiss, resolved.Defaults.Ask);
-        Assert.Equal(ExecAsk.Deny, resolved.Defaults.AskFallback);
+        Assert.Equal(ExecSecurity.Deny, resolved.Defaults.AskFallback);
     }
 
     [Fact]
@@ -213,7 +215,7 @@ public class ExecApprovalsStoreTests : IDisposable
 
         Assert.Equal(ExecSecurity.Deny, resolved.Defaults.Security);
         Assert.Equal(ExecAsk.OnMiss, resolved.Defaults.Ask);
-        Assert.Equal(ExecAsk.Deny, resolved.Defaults.AskFallback);
+        Assert.Equal(ExecSecurity.Deny, resolved.Defaults.AskFallback);
         Assert.False(resolved.Defaults.AutoAllowSkills);
     }
 
@@ -492,6 +494,105 @@ public class ExecApprovalsStoreTests : IDisposable
         Assert.Empty(temps);
     }
 
+    [Fact]
+    public void ResolveReadOnly_CustomStateDir_FailsClosedUntilMigration()
+    {
+        WriteFile(MinimalFileWithAgent("main", "allowlist"));
+        var stateDir = Path.Combine(_dir, "custom-state");
+
+        var resolved = Store(stateDir).ResolveReadOnly("main");
+
+        Assert.Equal(ExecSecurity.Deny, resolved.Defaults.Security);
+        Assert.Equal(ExecAsk.Always, resolved.Defaults.Ask);
+        Assert.False(File.Exists(Path.Combine(stateDir, "exec-approvals.json")));
+        Assert.True(File.Exists(FilePath));
+        Assert.False(File.Exists($"{FilePath}.migrated"));
+        Assert.DoesNotContain(_log.Infos, message => message.Contains("Migrated"));
+    }
+
+    [Fact]
+    public void MigrateLegacyFileIfNeeded_CustomStateDir_MigratesLegacyFile()
+    {
+        WriteFile("""
+        {
+          "version": 1,
+          "socket": { "path": "legacy.sock", "token": "socket-token" },
+          "defaults": { "askFallback": "off" },
+          "agents": {
+            "main": {
+              "security": "allowlist",
+              "allowlist": [{ "pattern": "tool.exe", "argPattern": "^safe$" }]
+            }
+          }
+        }
+        """);
+        var stateDir = Path.Combine(_dir, "custom-state");
+
+        var store = Store(stateDir);
+        store.MigrateLegacyFileIfNeeded();
+        var resolved = store.ResolveReadOnly("main");
+
+        Assert.Equal(ExecSecurity.Allowlist, resolved.Defaults.Security);
+        Assert.Equal(ExecSecurity.Full, resolved.Defaults.AskFallback);
+        Assert.Equal("socket-token", resolved.SocketToken);
+        Assert.True(File.Exists(Path.Combine(stateDir, "exec-approvals.json")));
+        Assert.Contains("\"argPattern\": \"^safe$\"", File.ReadAllText(Path.Combine(stateDir, "exec-approvals.json")));
+        Assert.False(File.Exists(FilePath));
+        Assert.True(File.Exists($"{FilePath}.migrated"));
+        Assert.Contains(_log.Infos, message => message.Contains("Migrated"));
+    }
+
+    [Fact]
+    public void ResolveReadOnly_CustomStateDir_TargetWinsOverLegacyFile()
+    {
+        WriteFile(MinimalFileWithAgent("main", "deny"));
+        var stateDir = Path.Combine(_dir, "custom-state");
+        Directory.CreateDirectory(stateDir);
+        File.WriteAllText(
+            Path.Combine(stateDir, "exec-approvals.json"),
+            MinimalFileWithAgent("main", "full"));
+
+        var resolved = Store(stateDir).ResolveReadOnly("main");
+
+        Assert.Equal(ExecSecurity.Full, resolved.Defaults.Security);
+        Assert.True(File.Exists(FilePath));
+        Assert.False(File.Exists($"{FilePath}.migrated"));
+    }
+
+    [Fact]
+    public async Task ResolveAsync_CustomStateDir_InvalidLegacyFile_FailsClosedWithoutReplacement()
+    {
+        WriteFile("{ bad json }");
+        var stateDir = Path.Combine(_dir, "custom-state");
+
+        var resolved = await Store(stateDir).ResolveAsync("main");
+
+        Assert.Equal(ExecSecurity.Deny, resolved.Defaults.Security);
+        Assert.Equal(ExecAsk.Always, resolved.Defaults.Ask);
+        Assert.False(File.Exists(Path.Combine(stateDir, "exec-approvals.json")));
+        Assert.Equal("{ bad json }", File.ReadAllText(FilePath));
+        Assert.Contains(_log.Warnings, message => message.Contains("could not be migrated"));
+    }
+
+    [Fact]
+    public async Task ResolveAsync_HomeRelativeStateDir_UsesOpenClawHome()
+    {
+        WriteFile(MinimalFileWithAgent("main", "full"));
+        var openClawHome = Path.Combine(_dir, "effective-home");
+        var stateDirOverride = $"~{Path.DirectorySeparatorChar}custom-state";
+        var store = new ExecApprovalsStore(
+            _dir,
+            _log,
+            stateDirOverride,
+            openClawHomeOverride: openClawHome,
+            osHomeOverride: Path.Combine(_dir, "os-home"));
+
+        var resolved = await store.ResolveAsync("main");
+
+        Assert.Equal(ExecSecurity.Full, resolved.Defaults.Security);
+        Assert.True(File.Exists(Path.Combine(openClawHome, "custom-state", "exec-approvals.json")));
+    }
+
     // ── AutoAllowSkills ───────────────────────────────────────────────────────
 
     [Fact]
@@ -520,7 +621,7 @@ public class ExecApprovalsStoreTests : IDisposable
             {
                 Security = ExecSecurity.Allowlist,
                 Ask = ExecAsk.OnMiss,
-                AskFallback = ExecAsk.Off,
+                AskFallback = ExecSecurity.Full,
                 AutoAllowSkills = false,
             },
             Agents = [],
@@ -530,7 +631,7 @@ public class ExecApprovalsStoreTests : IDisposable
 
         Assert.Contains("\"allowlist\"", json);
         Assert.Contains("\"on-miss\"", json);
-        Assert.Contains("\"off\"", json);
+        Assert.Contains("\"full\"", json);
     }
 
     [Fact]
@@ -573,7 +674,7 @@ public class ExecApprovalsStoreTests : IDisposable
         WriteFile("""
         {
           "version": 1,
-          "defaults": { "security": "full", "ask": "always", "askFallback": "on-miss", "autoAllowSkills": true },
+          "defaults": { "security": "full", "ask": "always", "askFallback": "allowlist", "autoAllowSkills": true },
           "agents": {}
         }
         """);
@@ -582,7 +683,7 @@ public class ExecApprovalsStoreTests : IDisposable
 
         Assert.Equal(ExecSecurity.Full, resolved.Defaults.Security);
         Assert.Equal(ExecAsk.Always, resolved.Defaults.Ask);
-        Assert.Equal(ExecAsk.OnMiss, resolved.Defaults.AskFallback);
+        Assert.Equal(ExecSecurity.Allowlist, resolved.Defaults.AskFallback);
         Assert.True(resolved.Defaults.AutoAllowSkills);
     }
 
@@ -626,14 +727,14 @@ public class ExecApprovalsStoreTests : IDisposable
         WriteFile("""
         {
           "version": 1,
-          "agents": { "*": { "ask": "always", "askFallback": "on-miss", "autoAllowSkills": true } }
+          "agents": { "*": { "ask": "always", "askFallback": "allowlist", "autoAllowSkills": true } }
         }
         """);
 
         var resolved = Store().ResolveReadOnly("any-agent");
 
         Assert.Equal(ExecAsk.Always, resolved.Defaults.Ask);
-        Assert.Equal(ExecAsk.OnMiss, resolved.Defaults.AskFallback);
+        Assert.Equal(ExecSecurity.Allowlist, resolved.Defaults.AskFallback);
         Assert.True(resolved.Defaults.AutoAllowSkills);
     }
 
@@ -707,9 +808,22 @@ public class ExecApprovalsStoreTests : IDisposable
     [Fact]
     public void JsonOptions_ExecAskDeny_SerializesAsDeny()
     {
-        var defaults = new ExecApprovalsDefaults { AskFallback = ExecAsk.Deny };
+        var defaults = new ExecApprovalsDefaults { AskFallback = ExecSecurity.Deny };
         var json = JsonSerializer.Serialize(defaults, ExecApprovalsStore.JsonOptions);
         Assert.Contains("\"deny\"", json);
+    }
+
+    [Theory]
+    [InlineData("off", ExecSecurity.Full)]
+    [InlineData("on-miss", ExecSecurity.Allowlist)]
+    [InlineData("always", ExecSecurity.Deny)]
+    public void ResolveReadOnly_LegacyAskFallback_MapsToSecurity(string legacyValue, ExecSecurity expected)
+    {
+        WriteFile($"{{\"version\":1,\"defaults\":{{\"askFallback\":\"{legacyValue}\"}},\"agents\":{{}}}}");
+
+        var resolved = Store().ResolveReadOnly("main");
+
+        Assert.Equal(expected, resolved.Defaults.AskFallback);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- honor `OPENCLAW_STATE_DIR` for the Windows exec-approvals V2 store
- migrate the existing tray approvals file atomically during node capability startup, archive the source, and fail closed while migration is blocked
- align `askFallback` with OpenClaw's security-valued contract while preserving legacy `off` / `on-miss` / `always` files
- preserve raw approval JSON during migration so unknown restrictions such as `argPattern` are not dropped
- clamp fallback permissions to the active security policy and evaluate allowlist matches when fallback uses allowlist mode

## Context

This mirrors the state-dir approvals migration landed in OpenClaw at https://github.com/openclaw/openclaw/commit/adad27d7448e5cf453451d8e2a136d6771728c58 (`fix(exec): honor state dir approvals`).

The Windows app keeps `%LOCALAPPDATA%\OpenClawTray` as its default approvals root. When `OPENCLAW_STATE_DIR` is explicitly set, it migrates the existing file to that target instead of silently starting with a new policy.

## Verification

- Windows 11 ARM64 Parallels VM: `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore --filter FullyQualifiedName~ExecApprovals` — 131 passed
- `git diff --check`
- autoreview: clean, no accepted/actionable findings

Broader repo gates were attempted but are environment-blocked on the clean VM:

- `./build.ps1` requires Git, Node.js, and the Windows 10 SDK in addition to the installed repo-pinned .NET 10 SDK
- full shared tests: 2014 passed, 203 failed, 29 skipped; failures are the existing ARM64 `libsodium` native dependency load error
- tray tests: 1025 passed, 15 failed; failures are the same ARM64 `libsodium` native dependency load error
