### PR TITLE
fix(shared): remove libsodium from device identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,9 +397,9 @@ jobs:
       if: matrix.rid == 'win-arm64'
       shell: pwsh
       # -SkipNativeLoadProbe: an ARM64 runner CAN LoadLibrary ARM64 DLLs, but
-      # libsodium pulls in a long native dependency chain that may not all be
-      # in the payload here (WindowsAppSDK pieces, etc.). The probe is for x64
-      # parity; signature + presence is what we actually care about.
+      # the full tray native dependency chain may include components that are
+      # not in this payload here (WindowsAppSDK pieces, etc.). The probe is for
+      # x64 parity; signature + presence is what we actually care about.
       run: .\scripts\Test-ReleaseNativeDependencies.ps1 -PayloadPath publish -RequireAppLocalVCRuntime -SkipNativeLoadProbe
 
     - name: Verify GitVersion assembly metadata
@@ -635,8 +635,8 @@ jobs:
         }
 
     # Create ZIP files for Updatum auto-update (asset name must contain the RID).
-    # We ship both x64 and arm64 portables now that the build job produces a
-    # libsodium-compatible app-local VC runtime for both architectures (the
+    # We ship both x64 and arm64 portables now that the build job produces an
+    # app-local VC runtime for both architectures (the
     # arm64 leg sources its loose Microsoft.VC*.CRT DLLs from the VS install
     # on the windows-11-arm runner; see src/Directory.Build.targets).
     - name: Create x64 Release ZIP

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -107,9 +107,9 @@ verifier fails closed on unknown `.exe` files so future payload changes are
 reviewed deliberately.
 
 CI also checks native runtime dependencies before release packaging. Both the
-x64 and ARM64 portable payloads must ship `vcruntime140.dll` next to every
-`libsodium.dll` copy. Both build legs source their loose VC runtime DLLs from
-the Visual Studio install on the CI runner (resolved via `vswhere` in
+x64 and ARM64 portable payloads must ship `vcruntime140.dll` in the payload
+root for the native speech stack. Both build legs source their loose VC runtime
+DLLs from the Visual Studio install on the CI runner (resolved via `vswhere` in
 `src\Directory.Build.targets`). This ensures the bundled CRT is new enough for
 `onnxruntime` — the `VCRuntime.CefSharp.140` NuGet is only used as a dev-time
 convenience for local `dotnet build` (not publish). The release validation
@@ -121,7 +121,7 @@ The release job must Authenticode-verify Microsoft's x64 and ARM64 Visual C++
 Runtime redistributables before passing the
 architecture-matching redistributable to Inno. The installer runs the
 redistributable before launching the tray so clean or stale Windows hosts can
-repair the runtime before Ed25519 device keys are generated or loaded, and it
+repair the runtime before native speech components initialize, and it
 skips the post-install tray launch if the runtime installer fails.
 
 The current Azure Artifact Signing resource is:

--- a/scripts/Test-ReleaseNativeDependencies.ps1
+++ b/scripts/Test-ReleaseNativeDependencies.ps1
@@ -3,10 +3,9 @@
     Verifies native release payload dependencies needed on clean Windows hosts.
 
 .DESCRIPTION
-    The Windows node uses NSec.Cryptography, which loads libsodium.dll. The
-    NuGet-provided Windows libsodium binary imports the Visual C++ runtime, so
-    app-local/installer payloads must make that runtime available before the
-    tray can generate or load device keys.
+    The Windows node ships native speech dependencies that import the Visual C++
+    runtime. Release payloads and installers must make that runtime available on
+    clean Windows hosts before the tray initializes those native components.
 #>
 [CmdletBinding()]
 param(
@@ -100,7 +99,6 @@ function Get-NativeLoadProbeFiles {
     )
 
     @(
-        Get-ChildItem -LiteralPath $Directory -File -Filter "libsodium.dll"
         Get-ChildItem -LiteralPath $Directory -File -Filter "onnxruntime.dll"
         Get-ChildItem -LiteralPath $Directory -File -Filter "sherpa-onnx.dll"
         Get-ChildItem -LiteralPath $Directory -File -Filter "sherpa-onnx-c-api.dll"
@@ -293,26 +291,15 @@ function Add-VCRuntimeVersionFloorErrors {
     }
 }
 
-$libsodiumFiles = @(
-    Get-ChildItem -LiteralPath $payloadRoot -Recurse -File -Filter libsodium.dll |
-        Sort-Object FullName
-)
-
-if ($libsodiumFiles.Count -eq 0) {
-    $errors.Add("Missing libsodium.dll under $payloadRoot.")
-}
-
-foreach ($libsodium in $libsodiumFiles) {
-    $runtimePath = Join-Path $libsodium.DirectoryName "vcruntime140.dll"
-    if ($RequireAppLocalVCRuntime -and -not (Test-Path -LiteralPath $runtimePath)) {
-        $errors.Add("Missing app-local vcruntime140.dll next to $(Get-RelativePath -Root $payloadRoot -Path $libsodium.FullName).")
+if ($RequireAppLocalVCRuntime) {
+    $runtimePath = Join-Path $payloadRoot "vcruntime140.dll"
+    if (-not (Test-Path -LiteralPath $runtimePath)) {
+        $errors.Add("Missing app-local vcruntime140.dll under $payloadRoot.")
     }
 
-    if ($RequireAppLocalVCRuntime) {
-        foreach ($runtimeFile in Get-VCRuntimeFiles -Directory $libsodium.DirectoryName) {
-            Add-MicrosoftSignatureErrors -File $runtimeFile
-            Add-VCRuntimeVersionFloorErrors -File $runtimeFile
-        }
+    foreach ($runtimeFile in Get-VCRuntimeFiles -Directory $payloadRoot) {
+        Add-MicrosoftSignatureErrors -File $runtimeFile
+        Add-VCRuntimeVersionFloorErrors -File $runtimeFile
     }
 }
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -49,9 +49,8 @@
       major version (Microsoft.VC143.CRT for VS 2022, Microsoft.VC145.CRT for
       VS 18). There is at most one Microsoft.VC*.CRT subdir per arch per redist
       version, so the * collapses to a single match. We limit to
-      vcruntime140*.dll + msvcp140*.dll to match the file set the x64 NuGet
-      ships (concrt140/vccorlib140/vcruntime140_threads aren't needed by
-      libsodium and aren't in the x64 payload either).
+      vcruntime140*.dll + msvcp140*.dll to match the file set required by the
+      native speech stack without carrying unrelated CRT DLLs.
 
       For x64 this replaces the stale NuGet-sourced items so publish always
       ships current DLLs from the VS install.
@@ -102,7 +101,7 @@
           AfterTargets="CopyOpenClawVCRuntimeToPublish"
           Condition="'$(PublishDir)' != '' and '$(OpenClawVCRuntimeArch)' != ''">
     <Error Condition="!Exists('$(PublishDir)vcruntime140.dll')"
-           Text="vcruntime140.dll missing from $(PublishDir). Clean Windows installs cannot load libsodium.dll without the VC runtime." />
+           Text="vcruntime140.dll missing from $(PublishDir). Clean Windows installs cannot load native speech dependencies without the VC runtime." />
   </Target>
 
 </Project>

--- a/src/OpenClaw.Shared/DeviceIdentity.cs
+++ b/src/OpenClaw.Shared/DeviceIdentity.cs
@@ -6,7 +6,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using OpenClaw.Shared.Mcp;
-using NSec.Cryptography;
+using Org.BouncyCastle.Math.EC.Rfc8032;
 
 namespace OpenClaw.Shared;
 
@@ -17,18 +17,16 @@ public class DeviceIdentity
 {
     private readonly string _keyPath;
     private readonly IOpenClawLogger _logger;
-    private Key? _privateKey;
-    private PublicKey? _publicKey;
+    private byte[]? _privateKey;
+    private byte[]? _publicKey;
     private string? _deviceId;
     private string? _deviceToken;
     private string[]? _deviceTokenScopes;
     private string? _nodeDeviceToken;
     private string[]? _nodeDeviceTokenScopes;
     
-    private static readonly SignatureAlgorithm Ed25519Algorithm = SignatureAlgorithm.Ed25519;
-    
     public string DeviceId => _deviceId ?? throw new InvalidOperationException("Device not initialized");
-    public string PublicKeyBase64Url => _publicKey != null ? Base64UrlEncode(_publicKey.Export(KeyBlobFormat.RawPublicKey)) : throw new InvalidOperationException("Device not initialized");
+    public string PublicKeyBase64Url => _publicKey != null ? Base64UrlEncode(_publicKey) : throw new InvalidOperationException("Device not initialized");
     public string? DeviceToken => _deviceToken;
     public IReadOnlyList<string>? DeviceTokenScopes => _deviceTokenScopes;
     public string? NodeDeviceToken => _nodeDeviceToken;
@@ -192,9 +190,9 @@ public class DeviceIdentity
                 return;
             }
             
-            var privateKeyBytes = Convert.FromBase64String(data.PrivateKeyBase64);
-            _privateKey = Key.Import(Ed25519Algorithm, privateKeyBytes, KeyBlobFormat.RawPrivateKey);
-            _publicKey = _privateKey.PublicKey;
+            _privateKey = Convert.FromBase64String(data.PrivateKeyBase64);
+            _publicKey = new byte[Ed25519.PublicKeySize];
+            Ed25519.GeneratePublicKey(_privateKey, 0, _publicKey, 0);
             _deviceId = data.DeviceId;
             _deviceToken = data.DeviceToken;
             _deviceTokenScopes = NormalizeScopes(data.DeviceTokenScopes);
@@ -214,12 +212,13 @@ public class DeviceIdentity
     {
         _logger.Info("Generating new Ed25519 device keypair...");
         
-        // Generate Ed25519 keypair using NSec
-        _privateKey = Key.Create(Ed25519Algorithm, new KeyCreationParameters { ExportPolicy = KeyExportPolicies.AllowPlaintextExport });
-        _publicKey = _privateKey.PublicKey;
+        _privateKey = new byte[Ed25519.SecretKeySize];
+        RandomNumberGenerator.Fill(_privateKey);
+        _publicKey = new byte[Ed25519.PublicKeySize];
+        Ed25519.GeneratePublicKey(_privateKey, 0, _publicKey, 0);
         
         // Get raw 32-byte public key
-        var publicKeyBytes = _publicKey.Export(KeyBlobFormat.RawPublicKey);
+        var publicKeyBytes = _publicKey;
         
         // Device ID is SHA256 hash of raw 32-byte public key (hex encoded)
         using var sha256 = SHA256.Create();
@@ -227,7 +226,7 @@ public class DeviceIdentity
         _deviceId = Convert.ToHexString(hashBytes).ToLowerInvariant();
         
         // Export private key for storage
-        var privateKeyBytes = _privateKey.Export(KeyBlobFormat.RawPrivateKey);
+        var privateKeyBytes = _privateKey;
         
         // Save to disk
         var data = new DeviceKeyData
@@ -268,7 +267,7 @@ public class DeviceIdentity
         
         // Sign with Ed25519
         var dataBytes = Encoding.UTF8.GetBytes(payload);
-        var signature = Ed25519Algorithm.Sign(_privateKey, dataBytes);
+        var signature = SignEd25519(dataBytes);
         
         // Return base64url encoded signature
         return Base64UrlEncode(signature);
@@ -304,7 +303,7 @@ public class DeviceIdentity
             deviceFamily);
 
         var dataBytes = Encoding.UTF8.GetBytes(payload);
-        var signature = Ed25519Algorithm.Sign(_privateKey, dataBytes);
+        var signature = SignEd25519(dataBytes);
         return Base64UrlEncode(signature);
     }
 
@@ -376,7 +375,7 @@ public class DeviceIdentity
             authToken);
 
         var dataBytes = Encoding.UTF8.GetBytes(payload);
-        var signature = Ed25519Algorithm.Sign(_privateKey, dataBytes);
+        var signature = SignEd25519(dataBytes);
         return Base64UrlEncode(signature);
     }
 
@@ -562,6 +561,16 @@ public class DeviceIdentity
         return ex.InnerException == null
             ? message
             : $"{message} (inner {ex.InnerException.GetType().Name}: {ex.InnerException.Message})";
+    }
+
+    private byte[] SignEd25519(byte[] data)
+    {
+        if (_privateKey == null)
+            throw new InvalidOperationException("Device not initialized");
+
+        var signature = new byte[Ed25519.SignatureSize];
+        Ed25519.Sign(_privateKey, 0, data, 0, data.Length, signature, 0);
+        return signature;
     }
     
     private static string Base64UrlEncode(byte[] data)

--- a/src/OpenClaw.Shared/OpenClaw.Shared.csproj
+++ b/src/OpenClaw.Shared/OpenClaw.Shared.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSec.Cryptography" Version="25.4.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
   </ItemGroup>
 
   <!-- Audio / Speech-to-Text (platform-agnostic components) -->
@@ -24,5 +24,4 @@
   </ItemGroup>
 
 </Project>
-
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -11,7 +11,6 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <OpenClawLibsodiumVersion>1.0.20.1</OpenClawLibsodiumVersion>
     <OpenClawVCRuntimeVersion>1.0.5</OpenClawVCRuntimeVersion>
     <!-- Audit direct + transitive dependencies for known CVEs during restore,
          matching the setting in src/Directory.Build.props. -->
@@ -36,13 +35,11 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
-  <Target Name="CopyWindowsNativeCryptoForTestHost" AfterTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
+  <Target Name="CopyWindowsNativeRuntimeForTestHost" AfterTargets="Build" Condition="'$(OS)' == 'Windows_NT'">
     <ItemGroup>
-      <OpenClawNativeCrypto Include="$(NuGetPackageRoot)libsodium\$(OpenClawLibsodiumVersion)\runtimes\win-x64\native\libsodium.dll" Condition="'$(PROCESSOR_ARCHITECTURE)' != 'ARM64' And Exists('$(NuGetPackageRoot)libsodium\$(OpenClawLibsodiumVersion)\runtimes\win-x64\native\libsodium.dll')" />
-      <OpenClawNativeCrypto Include="$(NuGetPackageRoot)libsodium\$(OpenClawLibsodiumVersion)\runtimes\win-arm64\native\libsodium.dll" Condition="'$(PROCESSOR_ARCHITECTURE)' == 'ARM64' And Exists('$(NuGetPackageRoot)libsodium\$(OpenClawLibsodiumVersion)\runtimes\win-arm64\native\libsodium.dll')" />
-      <OpenClawNativeCrypto Include="$(NuGetPackageRoot)vcruntime.cefsharp.140\$(OpenClawVCRuntimeVersion)\vc_redist\x64\*.dll" Condition="'$(PROCESSOR_ARCHITECTURE)' != 'ARM64' And Exists('$(NuGetPackageRoot)vcruntime.cefsharp.140\$(OpenClawVCRuntimeVersion)\vc_redist\x64\vcruntime140.dll')" />
+      <OpenClawNativeRuntime Include="$(NuGetPackageRoot)vcruntime.cefsharp.140\$(OpenClawVCRuntimeVersion)\vc_redist\x64\*.dll" Condition="'$(PROCESSOR_ARCHITECTURE)' != 'ARM64' And Exists('$(NuGetPackageRoot)vcruntime.cefsharp.140\$(OpenClawVCRuntimeVersion)\vc_redist\x64\vcruntime140.dll')" />
     </ItemGroup>
-    <Copy SourceFiles="@(OpenClawNativeCrypto)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(OpenClawNativeRuntime)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
   </Target>
 
 </Project>

--- a/tests/OpenClaw.Shared.Tests/DeviceIdentityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/DeviceIdentityTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using Xunit;
 using OpenClaw.Shared;
+using Org.BouncyCastle.Math.EC.Rfc8032;
 
 // slopwatch-ignore: SW002 Test intentionally disables obsolete warnings while covering legacy DeviceIdentity behavior.
 #pragma warning disable CS0618 // Obsolete - testing legacy methods
@@ -20,6 +21,18 @@ public class DeviceIdentityIntegrationTests
         var dir = Path.Combine(Path.GetTempPath(), "openclaw-test-" + Guid.NewGuid().ToString("N")[..8]);
         Directory.CreateDirectory(dir);
         return dir;
+    }
+
+    private static byte[] DecodeBase64Url(string value)
+    {
+        var padded = value.Replace('-', '+').Replace('_', '/');
+        switch (padded.Length % 4)
+        {
+            case 2: padded += "=="; break;
+            case 3: padded += "="; break;
+        }
+
+        return Convert.FromBase64String(padded);
     }
 
     [IntegrationFact]
@@ -76,6 +89,11 @@ public class DeviceIdentityIntegrationTests
             Assert.NotEmpty(sig1);
             // Ed25519 signature is 64 bytes → base64url is 86 chars (no padding)
             Assert.Equal(86, sig1.Length);
+
+            var publicKey = DecodeBase64Url(identity.PublicKeyBase64Url);
+            var signature = DecodeBase64Url(sig1);
+            var payloadBytes = Encoding.UTF8.GetBytes(identity.BuildDebugPayload("nonce1", 1000, "node-host", "tok"));
+            Assert.True(Ed25519.Verify(signature, 0, publicKey, 0, payloadBytes, 0, payloadBytes.Length));
         }
         finally { Directory.Delete(dir, true); }
     }
@@ -370,13 +388,7 @@ public class DeviceIdentityIntegrationTests
             Assert.DoesNotContain("=", pubKey);
             
             // Decode and verify Ed25519 public key is exactly 32 bytes
-            var padded = pubKey.Replace('-', '+').Replace('_', '/');
-            switch (padded.Length % 4)
-            {
-                case 2: padded += "=="; break;
-                case 3: padded += "="; break;
-            }
-            var bytes = Convert.FromBase64String(padded);
+            var bytes = DecodeBase64Url(pubKey);
             Assert.Equal(32, bytes.Length);
         }
         finally { Directory.Delete(dir, true); }

--- a/tests/OpenClaw.Tray.Tests/ReleaseSigningWorkflowTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ReleaseSigningWorkflowTests.cs
@@ -82,7 +82,7 @@ public sealed class ReleaseSigningWorkflowTests
         Assert.Contains("Get-AuthenticodeSignature -LiteralPath $File.FullName", verifier);
         Assert.Contains("Get-VCRuntimeFiles", verifier);
         Assert.Contains("vcruntime140.dll", verifier);
-        Assert.Contains("libsodium.dll", verifier);
+        Assert.DoesNotContain("libsodium.dll", verifier);
         Assert.Contains("OpenClawNativeDependencyProbe", verifier);
         Assert.Contains("Microsoft.ML.OnnxRuntime.dll", verifier);
         Assert.Contains("onnxruntime.dll", verifier);


### PR DESCRIPTION
## Summary

- replace `NSec.Cryptography`/`libsodium` device identity signing with managed BouncyCastle Ed25519 using the same raw 32-byte private/public key and 64-byte signature shapes
- remove test-host `libsodium.dll` copying and retarget release native dependency checks to the remaining native speech/ONNX runtime payload
- update release docs, CI comments, and release workflow tests so the native runtime policy no longer requires a deleted libsodium payload

## Context

This was exposed while validating https://github.com/openclaw/openclaw-windows-node/pull/744 on a Windows 11 ARM64 VM: `DeviceIdentity` failed during static initialization because NSec could not load `libsodium.dll` or its ARM64 VC runtime dependency. The cleaner fix is to remove that native dependency from identity signing entirely rather than add another fragile ARM64 test-host copy path.

## Verification

- Windows 11 ARM64 VM: `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj` → 2251 passed
- Windows 11 ARM64 VM: `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` → 2251 passed
- Windows 11 ARM64 VM: `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj` → 1040 passed
- Windows 11 ARM64 VM: `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` → 1040 passed
- Windows 11 ARM64 VM: built output check found no `libsodium.dll` under the shared/tray test outputs
- Windows 11 ARM64 VM: `dotnet list .\src\OpenClaw.Shared\OpenClaw.Shared.csproj package --include-transitive | findstr /i "NSec libsodium BouncyCastle"` → only `BouncyCastle.Cryptography 2.6.2`
- local: `git diff --check`
- local: autoreview clean with `/Users/vincentkoc/GIT/_Perso/openclaw/.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`

`./build.ps1` was attempted on the same Windows ARM64 VM but is environment-blocked there: missing Git, Node.js, and Windows 10 SDK. The required shared/tray test projects do build and pass on that VM.
