### PR TITLE
Use app notifications for background issues

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3032,11 +3032,19 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         var reasonText = availability.UnsupportedReasons.Count > 0
             ? string.Join("  ·  ", availability.UnsupportedReasons)
             : LocalizationHelper.GetString("AppNotification_SandboxUnavailable_DefaultReason");
+        var blockHostFallback = _settings?.SystemRunBlockHostFallbackWhenMxcUnavailable == true;
+        var mode = blockHostFallback ? "blocked" : "host-fallback";
+        var title = blockHostFallback
+            ? LocalizationHelper.GetString("AppNotification_SandboxUnavailableBlocked_Title")
+            : LocalizationHelper.GetString("AppNotification_SandboxUnavailable_Title");
+        var message = blockHostFallback
+            ? LocalizationHelper.Format("AppNotification_SandboxUnavailableBlocked_MessageFormat", reasonText)
+            : LocalizationHelper.Format("AppNotification_SandboxUnavailable_MessageFormat", reasonText);
 
         PublishSandboxRiskNotification(
-            $"unavailable:{reasonText}",
-            LocalizationHelper.GetString("AppNotification_SandboxUnavailable_Title"),
-            reasonText);
+            $"unavailable:{mode}:{reasonText}",
+            title,
+            message);
     }
 
     private void PublishSandboxRiskNotification(string riskKey, string title, string message)

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -209,6 +209,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
     private const string ConnectionIssueNotificationId = "connection:issue";
     private const string ConnectionIssueNotificationDedupeKey = "connection:issue";
+    private const string SandboxRiskNotificationId = "sandbox:risk";
+    private const string SandboxRiskNotificationDedupeKey = "sandbox:risk";
     private static readonly TimeSpan SandboxRiskProbeRefreshInterval = TimeSpan.FromMinutes(5);
     
     // Node service (optional, enabled in settings)
@@ -3050,10 +3052,10 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             "sandbox",
             "system.run",
             AppNotificationSeverity.Warning,
-            $"sandbox:{riskKey}",
+            SandboxRiskNotificationDedupeKey,
             "sandbox",
             LocalizationHelper.GetString("AppNotification_ActionOpenSandbox"),
-            id: "sandbox:risk");
+            id: SandboxRiskNotificationId);
     }
 
     private void ClearSandboxRiskNotification()

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using OpenClaw.Shared;
 using OpenClaw.Shared.Capabilities;
+using OpenClaw.Shared.Mxc;
 using OpenClawTray.Dialogs;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
@@ -196,6 +197,11 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private DiagnosticsClipboardService? _diagnosticsClipboard;
     private ToastService? _toastService;
     private AppNotificationService? _appNotificationService;
+    internal AppNotificationService? AppNotifications => _appNotificationService;
+    private string? _lastAuthFailureNotificationMessage;
+    private string? _lastConnectionIssueNotificationKey;
+    private readonly Dictionary<string, string> _reportedChannelIssueSignatures = new(StringComparer.OrdinalIgnoreCase);
+    private string? _lastSandboxRiskNotificationKey;
     
     // Node service (optional, enabled in settings)
     private NodeService? _nodeService;
@@ -488,6 +494,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         _diagnosticsClipboard = new DiagnosticsClipboardService(BuildCommandCenterState);
         _toastService = new ToastService(() => _settings);
         _appNotificationService = new AppNotificationService();
+        PublishSandboxRiskNotificationIfNeeded();
 
         // Inbound pairing approvals: surface a focused dialog + awareness toast when another
         // device/node requests pairing (Mac-parity). Getters are lazy so this can be created
@@ -1806,6 +1813,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             if (_appState != null) _appState.Status = mapped;
             UpdateTrayIcon();
             SyncConnectionToggle(mapped);
+            UpdateConnectionIssueNotification(snap);
             if (mapped is ConnectionStatus.Connected or ConnectionStatus.Disconnected or ConnectionStatus.Error)
             {
                 // Dismiss the tray menu on state change — it will capture fresh data on next open
@@ -2176,6 +2184,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             else if (args.Status == OpenClaw.Shared.PairingStatus.Paired)
             {
                 RefreshGatewayNodes("node paired");
+                ClearPairingAppNotifications(args.DeviceId);
                 // Bug 3: idempotency guard — only show "Node paired" toast/activity once
                 // per device per session. WS reconnects re-fire Paired; suppress duplicates.
                 var deviceKey = args.DeviceId ?? string.Empty;
@@ -2196,6 +2205,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             }
             else if (args.Status == OpenClaw.Shared.PairingStatus.Rejected)
             {
+                _appNotificationService?.Dismiss(BuildPairingPendingNotificationId(args.DeviceId));
+                ShowPairingRejectedAppNotification(args.DeviceId, args.Message);
                 AddRecentActivity("Node pairing rejected", category: "node", dashboardPath: "nodes", nodeId: args.DeviceId, details: args.Message ?? LocalizationHelper.GetString("Toast_PairingRejectedDetail"));
                 _toastService!.ShowToast(new ToastContentBuilder()
                     .AddText(LocalizationHelper.GetString("Toast_PairingRejected"))
@@ -2234,6 +2245,18 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     public static string BuildPairingApprovalCommand(string deviceId) =>
         $"openclaw devices approve {deviceId}";
 
+    private static string BuildPairingPendingNotificationId(string deviceId) =>
+        $"node-pairing-pending:{deviceId.Trim().ToLowerInvariant()}";
+
+    private static string BuildPairingRejectedNotificationId(string deviceId) =>
+        $"node-pairing-rejected:{deviceId.Trim().ToLowerInvariant()}";
+
+    private void ClearPairingAppNotifications(string deviceId)
+    {
+        _appNotificationService?.Dismiss(BuildPairingPendingNotificationId(deviceId));
+        _appNotificationService?.Dismiss(BuildPairingRejectedNotificationId(deviceId));
+    }
+
     private static string DeviceIdForLog(string? deviceId)
     {
         if (string.IsNullOrWhiteSpace(deviceId))
@@ -2252,6 +2275,17 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         var shortDeviceId = deviceId.Length > 16 ? deviceId[..16] : deviceId;
 
         AddRecentActivity("Node pairing pending", category: "node", dashboardPath: "nodes", nodeId: deviceId);
+        AppNotificationPublisher.Show(
+            _appNotificationService,
+            LocalizationHelper.GetString("Toast_PairingPending"),
+            string.Format(LocalizationHelper.GetString("Toast_PairingPendingDetail"), shortDeviceId),
+            "node",
+            "pairing",
+            AppNotificationSeverity.Warning,
+            $"node-pairing-pending:{deviceId}",
+            "connection",
+            LocalizationHelper.GetString("AppNotification_ActionOpenConnection"),
+            id: BuildPairingPendingNotificationId(deviceId));
         _toastService!.ShowToast(new ToastContentBuilder()
             .AddText(LocalizationHelper.GetString("Toast_PairingPending"))
             .AddText(string.Format(LocalizationHelper.GetString("Toast_PairingPendingDetail"), shortDeviceId))
@@ -2262,7 +2296,109 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             "node-pairing-pending",
             deviceId);
     }
-    
+
+    private void ShowPairingRejectedAppNotification(string deviceId, string? detail)
+    {
+        AppNotificationPublisher.Show(
+            _appNotificationService,
+            LocalizationHelper.GetString("Toast_PairingRejected"),
+            detail ?? LocalizationHelper.GetString("Toast_PairingRejectedDetail"),
+            "node",
+            "pairing",
+            AppNotificationSeverity.Error,
+            $"node-pairing-rejected:{deviceId}",
+            "connection",
+            LocalizationHelper.GetString("AppNotification_ActionOpenConnection"),
+            id: BuildPairingRejectedNotificationId(deviceId));
+    }
+
+    private void UpdateConnectionIssueNotification(GatewayConnectionSnapshot snapshot)
+    {
+        if (!TryBuildConnectionIssueNotification(snapshot, out var title, out var message, out var severity, out var category, out var key))
+        {
+            _lastConnectionIssueNotificationKey = null;
+            _appNotificationService?.Dismiss("connection:issue");
+            return;
+        }
+
+        if (string.Equals(_lastConnectionIssueNotificationKey, key, StringComparison.Ordinal))
+            return;
+
+        _lastConnectionIssueNotificationKey = key;
+        AppNotificationPublisher.Show(
+            _appNotificationService,
+            title,
+            message,
+            "connection",
+            category,
+            severity,
+            $"connection:{key}",
+            "connection",
+            LocalizationHelper.GetString("AppNotification_ActionOpenConnection"),
+            id: "connection:issue");
+    }
+
+    private static bool TryBuildConnectionIssueNotification(
+        GatewayConnectionSnapshot snapshot,
+        out string title,
+        out string message,
+        out AppNotificationSeverity severity,
+        out string category,
+        out string key)
+    {
+        title = "";
+        message = "";
+        severity = AppNotificationSeverity.Warning;
+        category = "lifecycle";
+        key = "";
+
+        if (snapshot.OverallState == OverallConnectionState.Error)
+        {
+            title = LocalizationHelper.GetString("AppNotification_GatewayConnectionFailed_Title");
+            message = snapshot.OperatorError ?? LocalizationHelper.GetString("AppNotification_GatewayConnectionFailed_DefaultMessage");
+            severity = AppNotificationSeverity.Error;
+            key = $"operator-error:{message}";
+            return true;
+        }
+
+        if (snapshot.OperatorPairingRequired)
+        {
+            title = LocalizationHelper.GetString("AppNotification_GatewayPairingRequired_Title");
+            message = string.IsNullOrWhiteSpace(snapshot.OperatorDeviceId)
+                ? LocalizationHelper.GetString("AppNotification_GatewayPairingRequired_GenericMessage")
+                : LocalizationHelper.Format(
+                    "AppNotification_GatewayPairingRequired_DeviceMessageFormat",
+                    DeviceIdForLog(snapshot.OperatorDeviceId));
+            category = "pairing";
+            key = $"operator-pairing:{snapshot.OperatorDeviceId ?? "unknown"}";
+            return true;
+        }
+
+        if (snapshot.OverallState == OverallConnectionState.Degraded)
+        {
+            if (snapshot.NodeState == RoleConnectionState.Error)
+            {
+                title = LocalizationHelper.GetString("AppNotification_WindowsNodeConnectionFailed_Title");
+                message = snapshot.NodeError ?? LocalizationHelper.GetString("AppNotification_WindowsNodeConnectionFailed_DefaultMessage");
+                severity = AppNotificationSeverity.Error;
+                category = "node";
+                key = $"node-error:{message}";
+                return true;
+            }
+
+            if (snapshot.NodeState == RoleConnectionState.RateLimited)
+            {
+                title = LocalizationHelper.GetString("AppNotification_WindowsNodeRateLimited_Title");
+                message = snapshot.NodeError ?? LocalizationHelper.GetString("AppNotification_WindowsNodeRateLimited_DefaultMessage");
+                category = "node";
+                key = $"node-rate-limited:{message}";
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private void OnNodeNotificationRequested(object? sender, OpenClaw.Shared.Capabilities.SystemNotifyArgs args)
     {
         AddRecentActivity(args.Title, category: "node", dashboardPath: "nodes", details: args.Body);
@@ -2507,6 +2643,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         if (status == ConnectionStatus.Connected && _appState != null)
         {
             _appState.AuthFailureMessage = null;
+            _lastAuthFailureNotificationMessage = null;
+            _appNotificationService?.Dismiss("connection:authentication-failed");
         }
 
         UpdateTrayIcon();
@@ -2560,6 +2698,22 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         if (_appState != null)
         {
             _appState.AuthFailureMessage = message;
+        }
+
+        if (!string.Equals(_lastAuthFailureNotificationMessage, message, StringComparison.Ordinal))
+        {
+            _lastAuthFailureNotificationMessage = message;
+            AppNotificationPublisher.Show(
+                _appNotificationService,
+                LocalizationHelper.GetString("AppNotification_GatewayAuthenticationFailed_Title"),
+                message,
+                "connection",
+                "authentication",
+                AppNotificationSeverity.Error,
+                "connection:authentication-failed",
+                "connection",
+                LocalizationHelper.GetString("AppNotification_ActionOpenConnection"),
+                id: "connection:authentication-failed");
         }
     }
 
@@ -2697,10 +2851,137 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             case nameof(AppState.Nodes):
                 UpdateStatusDetailWindow();
                 break;
+            case nameof(AppState.Channels):
+                UpdateChannelIssueNotifications(_appState.Channels);
+                UpdateStatusDetailWindow();
+                break;
             case nameof(AppState.CurrentActivity):
                 UpdateTrayIcon();
                 break;
         }
+    }
+
+    private void UpdateChannelIssueNotifications(ChannelHealth[] channels)
+    {
+        var currentIssueNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var channel in channels)
+        {
+            if (!TryBuildChannelIssueNotification(channel, out var title, out var message, out var signature))
+                continue;
+
+            currentIssueNames.Add(channel.Name);
+            if (_reportedChannelIssueSignatures.TryGetValue(channel.Name, out var existingSignature) &&
+                string.Equals(existingSignature, signature, StringComparison.Ordinal))
+                continue;
+
+            _reportedChannelIssueSignatures[channel.Name] = signature;
+            AppNotificationPublisher.Show(
+                _appNotificationService,
+                title,
+                message,
+                "channels",
+                "status",
+                AppNotificationSeverity.Error,
+                $"channels:{channel.Name}:status-error",
+                "channels",
+                LocalizationHelper.GetString("AppNotification_ActionOpenChannels"),
+                id: BuildChannelIssueNotificationId(channel.Name));
+        }
+
+        foreach (var channelName in _reportedChannelIssueSignatures.Keys.Except(currentIssueNames).ToList())
+        {
+            _reportedChannelIssueSignatures.Remove(channelName);
+            _appNotificationService?.Dismiss(BuildChannelIssueNotificationId(channelName));
+        }
+    }
+
+    private static bool TryBuildChannelIssueNotification(
+        ChannelHealth channel,
+        out string title,
+        out string message,
+        out string signature)
+    {
+        title = "";
+        message = "";
+        signature = "";
+
+        if (string.IsNullOrWhiteSpace(channel.Name))
+            return false;
+
+        var status = channel.Status?.Trim() ?? "";
+        var hasExplicitError = !string.IsNullOrWhiteSpace(channel.Error);
+        var hasErrorStatus = !string.IsNullOrWhiteSpace(status) &&
+            !ChannelHealth.IsHealthyStatus(status) &&
+            !ChannelHealth.IsIntermediateStatus(status) &&
+            !status.Equals("not configured", StringComparison.OrdinalIgnoreCase) &&
+            !status.Equals("unknown", StringComparison.OrdinalIgnoreCase);
+
+        if (!hasExplicitError && !hasErrorStatus)
+            return false;
+
+        var displayName = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(channel.Name);
+        title = LocalizationHelper.Format("AppNotification_ChannelNeedsAttention_TitleFormat", displayName);
+        message = hasExplicitError
+            ? channel.Error!.Trim()
+            : LocalizationHelper.Format("AppNotification_ChannelNeedsAttention_StatusMessageFormat", channel.Name, status);
+        signature = $"{status}|{message}";
+        return true;
+    }
+
+    private static string BuildChannelIssueNotificationId(string channelName) =>
+        $"channel-issue:{channelName.Trim().ToLowerInvariant()}";
+
+    private void PublishSandboxRiskNotificationIfNeeded()
+    {
+        if (_settings is null || _appNotificationService is null)
+            return;
+
+        string? riskKey = null;
+        string? title = null;
+        string? message = null;
+
+        if (!_settings.SystemRunSandboxEnabled)
+        {
+            riskKey = "disabled";
+            title = LocalizationHelper.GetString("AppNotification_SandboxDisabled_Title");
+            message = LocalizationHelper.GetString("AppNotification_SandboxDisabled_Message");
+        }
+        else
+        {
+            var availability = MxcAvailability.Probe(new AppLogger());
+            if (!availability.HasAnyBackend)
+            {
+                var reasonText = availability.UnsupportedReasons.Count > 0
+                    ? string.Join("  ·  ", availability.UnsupportedReasons)
+                    : LocalizationHelper.GetString("AppNotification_SandboxUnavailable_DefaultReason");
+                riskKey = $"unavailable:{reasonText}";
+                title = LocalizationHelper.GetString("AppNotification_SandboxUnavailable_Title");
+                message = reasonText;
+            }
+        }
+
+        if (riskKey is null)
+        {
+            _lastSandboxRiskNotificationKey = null;
+            _appNotificationService.ClearSource("sandbox");
+            return;
+        }
+
+        if (string.Equals(_lastSandboxRiskNotificationKey, riskKey, StringComparison.Ordinal))
+            return;
+
+        _lastSandboxRiskNotificationKey = riskKey;
+        AppNotificationPublisher.Show(
+            _appNotificationService,
+            title!,
+            message!,
+            "sandbox",
+            "system.run",
+            AppNotificationSeverity.Warning,
+            $"sandbox:{riskKey}",
+            "sandbox",
+            LocalizationHelper.GetString("AppNotification_ActionOpenSandbox"),
+            id: "sandbox:risk");
     }
 
 
@@ -2955,6 +3236,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         _previousSettingsSnapshot = currentSnapshot;
         SyncActiveGatewayBrowserProxyForward();
         Logger.Info($"[SETTINGS] Change impact: {impact}");
+        PublishSandboxRiskNotificationIfNeeded();
 
         switch (impact)
         {

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -202,6 +202,14 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private string? _lastConnectionIssueNotificationKey;
     private readonly Dictionary<string, string> _reportedChannelIssueSignatures = new(StringComparer.OrdinalIgnoreCase);
     private string? _lastSandboxRiskNotificationKey;
+    private MxcAvailability? _sandboxRiskAvailabilityCache;
+    private bool _sandboxRiskProbeInFlight;
+    private int _sandboxRiskProbeGeneration;
+    private DateTimeOffset _lastSandboxRiskProbeStartedAt;
+
+    private const string ConnectionIssueNotificationId = "connection:issue";
+    private const string ConnectionIssueNotificationDedupeKey = "connection:issue";
+    private static readonly TimeSpan SandboxRiskProbeRefreshInterval = TimeSpan.FromMinutes(5);
     
     // Node service (optional, enabled in settings)
     private NodeService? _nodeService;
@@ -2317,7 +2325,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         if (!TryBuildConnectionIssueNotification(snapshot, out var title, out var message, out var severity, out var category, out var key))
         {
             _lastConnectionIssueNotificationKey = null;
-            _appNotificationService?.Dismiss("connection:issue");
+            _appNotificationService?.Dismiss(ConnectionIssueNotificationId);
             return;
         }
 
@@ -2332,10 +2340,10 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             "connection",
             category,
             severity,
-            $"connection:{key}",
+            ConnectionIssueNotificationDedupeKey,
             "connection",
             LocalizationHelper.GetString("AppNotification_ActionOpenConnection"),
-            id: "connection:issue");
+            id: ConnectionIssueNotificationId);
     }
 
     private static bool TryBuildConnectionIssueNotification(
@@ -2936,45 +2944,109 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         if (_settings is null || _appNotificationService is null)
             return;
 
-        string? riskKey = null;
-        string? title = null;
-        string? message = null;
-
         if (!_settings.SystemRunSandboxEnabled)
         {
-            riskKey = "disabled";
-            title = LocalizationHelper.GetString("AppNotification_SandboxDisabled_Title");
-            message = LocalizationHelper.GetString("AppNotification_SandboxDisabled_Message");
-        }
-        else
-        {
-            var availability = MxcAvailability.Probe(new AppLogger());
-            if (!availability.HasAnyBackend)
-            {
-                var reasonText = availability.UnsupportedReasons.Count > 0
-                    ? string.Join("  ·  ", availability.UnsupportedReasons)
-                    : LocalizationHelper.GetString("AppNotification_SandboxUnavailable_DefaultReason");
-                riskKey = $"unavailable:{reasonText}";
-                title = LocalizationHelper.GetString("AppNotification_SandboxUnavailable_Title");
-                message = reasonText;
-            }
-        }
-
-        if (riskKey is null)
-        {
-            _lastSandboxRiskNotificationKey = null;
-            _appNotificationService.ClearSource("sandbox");
+            _sandboxRiskProbeGeneration++;
+            _sandboxRiskProbeInFlight = false;
+            PublishSandboxRiskNotification(
+                "disabled",
+                LocalizationHelper.GetString("AppNotification_SandboxDisabled_Title"),
+                LocalizationHelper.GetString("AppNotification_SandboxDisabled_Message"));
             return;
         }
 
+        if (_sandboxRiskAvailabilityCache is { } cachedAvailability)
+            PublishSandboxRiskNotification(cachedAvailability);
+        else
+            ClearSandboxRiskNotification();
+
+        StartSandboxRiskProbeIfNeeded();
+    }
+
+    private void StartSandboxRiskProbeIfNeeded()
+    {
+        if (_settings is not { SystemRunSandboxEnabled: true })
+            return;
+
+        var now = DateTimeOffset.UtcNow;
+        if (_sandboxRiskProbeInFlight)
+            return;
+
+        if (_sandboxRiskAvailabilityCache is { ProbeErrored: false } &&
+            now - _lastSandboxRiskProbeStartedAt < SandboxRiskProbeRefreshInterval)
+        {
+            return;
+        }
+
+        _sandboxRiskProbeInFlight = true;
+        _lastSandboxRiskProbeStartedAt = now;
+        var generation = ++_sandboxRiskProbeGeneration;
+
+        _ = Task.Run(() => MxcAvailability.Probe(new AppLogger()))
+            .ContinueWith(
+                task => OnUiThread(() => CompleteSandboxRiskProbe(generation, task)),
+                CancellationToken.None,
+                TaskContinuationOptions.None,
+                TaskScheduler.Default);
+    }
+
+    private void CompleteSandboxRiskProbe(int generation, Task<MxcAvailability> task)
+    {
+        if (generation != _sandboxRiskProbeGeneration)
+            return;
+
+        _sandboxRiskProbeInFlight = false;
+
+        MxcAvailability availability;
+        if (task.Status == TaskStatus.RanToCompletion)
+        {
+            availability = task.Result;
+        }
+        else
+        {
+            var message = task.Exception?.GetBaseException().Message ?? LocalizationHelper.GetString("SandboxPage_ProbeErrorReason");
+            Logger.Warn($"Sandbox availability probe failed: {message}");
+            availability = new MxcAvailability(
+                false,
+                false,
+                false,
+                null,
+                new[] { message },
+                probeErrored: true);
+        }
+
+        _sandboxRiskAvailabilityCache = availability;
+        PublishSandboxRiskNotification(availability);
+    }
+
+    private void PublishSandboxRiskNotification(MxcAvailability availability)
+    {
+        if (availability.HasAnyBackend)
+        {
+            ClearSandboxRiskNotification();
+            return;
+        }
+
+        var reasonText = availability.UnsupportedReasons.Count > 0
+            ? string.Join("  ·  ", availability.UnsupportedReasons)
+            : LocalizationHelper.GetString("AppNotification_SandboxUnavailable_DefaultReason");
+
+        PublishSandboxRiskNotification(
+            $"unavailable:{reasonText}",
+            LocalizationHelper.GetString("AppNotification_SandboxUnavailable_Title"),
+            reasonText);
+    }
+
+    private void PublishSandboxRiskNotification(string riskKey, string title, string message)
+    {
         if (string.Equals(_lastSandboxRiskNotificationKey, riskKey, StringComparison.Ordinal))
             return;
 
         _lastSandboxRiskNotificationKey = riskKey;
         AppNotificationPublisher.Show(
             _appNotificationService,
-            title!,
-            message!,
+            title,
+            message,
             "sandbox",
             "system.run",
             AppNotificationSeverity.Warning,
@@ -2982,6 +3054,12 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             "sandbox",
             LocalizationHelper.GetString("AppNotification_ActionOpenSandbox"),
             id: "sandbox:risk");
+    }
+
+    private void ClearSandboxRiskNotification()
+    {
+        _lastSandboxRiskNotificationKey = null;
+        _appNotificationService?.ClearSource("sandbox");
     }
 
 

--- a/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml.cs
@@ -28,6 +28,8 @@ public sealed partial class ConfigPage : Page
     private const double JsonPreviewMinWidth = 340;
 
     private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
+    private static string L(string key) => LocalizationHelper.GetString(key);
+    private static string Lf(string key, params object?[] args) => LocalizationHelper.Format(key, args);
     private AppState? _appState;
     private JsonElement? _lastConfig;
     private JsonElement? _lastSchema;
@@ -148,7 +150,7 @@ public sealed partial class ConfigPage : Page
 
                 if (configSnapshot.TryGetProperty("path", out var pathEl) &&
                     pathEl.ValueKind == JsonValueKind.String)
-                    ConfigSubtitle.Text = $"Editing {pathEl.GetString()} via schema-guided form.";
+                    ConfigSubtitle.Text = Lf("ConfigPage_EditingPathFormat", pathEl.GetString());
 
                 _loading = false;
                 SetInfoBarOpen(ConnectionInfoBar, CurrentApp.GatewayClient == null);
@@ -161,7 +163,9 @@ public sealed partial class ConfigPage : Page
             catch (Exception ex)
             {
                 Logger.Error($"[ConfigPage] Failed to render config: {ex}");
-                ShowConfigRenderError("Config unavailable", "The gateway config could not be rendered. Refresh and try again.");
+                ShowConfigRenderError(
+                    L("ConfigPage_RenderConfigUnavailableTitle"),
+                    L("ConfigPage_RenderConfigUnavailableMessage"));
             }
         });
     }
@@ -192,7 +196,9 @@ public sealed partial class ConfigPage : Page
             catch (Exception ex)
             {
                 Logger.Error($"[ConfigPage] Failed to render config schema: {ex}");
-                ShowConfigRenderError("Schema unavailable", "The gateway schema could not be rendered. Raw JSON remains available as a read-only preview.");
+                ShowConfigRenderError(
+                    L("ConfigPage_RenderSchemaUnavailableTitle"),
+                    L("ConfigPage_RenderSchemaUnavailableMessage"));
             }
         });
     }
@@ -214,7 +220,10 @@ public sealed partial class ConfigPage : Page
                 var configPermissionState = GetConfigPermissionState();
                 if (configPermissionState == ConfigPermissionState.Disconnected && _refreshConfigAfterReconnect)
                 {
-                    ShowStatus("Gateway restarting", "Saving changes. The gateway is restarting and will reconnect automatically.", InfoBarSeverity.Informational);
+                    ShowStatus(
+                        L("ConfigPage_StatusGatewayRestartingTitle"),
+                        L("ConfigPage_StatusGatewayRestartingMessage"),
+                        InfoBarSeverity.Informational);
                     ShowReconnectDialog(LocalizationHelper.GetString("ConfigPage_ReconnectDialogWaiting"));
                 }
                 else if (_refreshConfigAfterReconnect &&
@@ -480,14 +489,20 @@ public sealed partial class ConfigPage : Page
 
         if (_pendingChanges.Count == 0)
         {
-            ShowStatus("No changes", "There is nothing to save.", InfoBarSeverity.Informational);
+            ShowStatus(
+                L("ConfigPage_StatusNoChangesTitle"),
+                L("ConfigPage_StatusNoChangesMessage"),
+                InfoBarSeverity.Informational);
             return;
         }
 
         if (_validationErrors.Count > 0)
         {
             var first = _validationErrors.First();
-            ShowStatus("Fix validation errors", $"{first.Key}: {first.Value}", InfoBarSeverity.Error);
+            ShowStatus(
+                L("ConfigPage_StatusFixValidationErrorsTitle"),
+                Lf("ConfigPage_StatusValidationErrorMessageFormat", first.Key, first.Value),
+                InfoBarSeverity.Error);
             UpdateMetaAndButtons();
             return;
         }
@@ -495,14 +510,20 @@ public sealed partial class ConfigPage : Page
         var client = CurrentApp.GatewayClient;
         if (client == null)
         {
-            ShowStatus("Not connected", "Connect to a gateway before saving config.", InfoBarSeverity.Error);
+            ShowStatus(
+                L("ConfigPage_StatusNotConnectedTitle"),
+                L("ConfigPage_StatusNotConnectedMessage"),
+                InfoBarSeverity.Error);
             UpdateMetaAndButtons();
             return;
         }
 
         if (!OperatorScopeHelper.CanWriteConfig(client.GrantedOperatorScopes))
         {
-            ShowStatus("Config is read-only", "This operator token does not have operator.write permission, so config changes cannot be saved.", InfoBarSeverity.Warning);
+            ShowStatus(
+                L("ConfigPage_ConfigIsReadOnly"),
+                L("ConfigPage_StatusReadOnlyMessage"),
+                InfoBarSeverity.Warning);
             UpdatePermissionBanner();
             UpdateMetaAndButtons();
             return;
@@ -511,14 +532,20 @@ public sealed partial class ConfigPage : Page
         var saveBase = _editSnapshot.HasRoot ? _editSnapshot : _serverSnapshot;
         if (!saveBase.HasRoot)
         {
-            ShowStatus("Config not loaded", "Refresh the gateway config before saving.", InfoBarSeverity.Error);
+            ShowStatus(
+                L("ConfigPage_StatusConfigNotLoadedTitle"),
+                L("ConfigPage_StatusConfigNotLoadedMessage"),
+                InfoBarSeverity.Error);
             UpdateMetaAndButtons();
             return;
         }
 
         _saving = true;
         UpdateMetaAndButtons();
-        ShowStatus("Saving config…", $"Writing {_pendingChanges.Count} change(s) to the gateway.", InfoBarSeverity.Informational);
+        ShowStatus(
+            L("ConfigPage_StatusSavingConfigTitle"),
+            Lf("ConfigPage_StatusSavingConfigMessageFormat", _pendingChanges.Count),
+            InfoBarSeverity.Informational);
 
         try
         {
@@ -531,15 +558,17 @@ public sealed partial class ConfigPage : Page
                     _editSnapshot = ConfigEditorSnapshot.Empty;
                     _ = client.RequestConfigAsync();
                     ShowStatus(
-                        "Gateway config changed elsewhere",
-                        $"Your edits are preserved. The latest config is being refreshed; review the form and try Save again. Details: {result.Error ?? "stale config hash"}",
+                        L("ConfigPage_StatusStaleConfigTitle"),
+                        Lf(
+                            "ConfigPage_StatusStaleConfigMessageFormat",
+                            result.Error ?? L("ConfigPage_StatusStaleConfigDefaultDetail")),
                         InfoBarSeverity.Warning);
                 }
                 else
                 {
                     ShowStatus(
-                        "Save failed",
-                        result.Error ?? "The gateway rejected the config update. Your changes are preserved.",
+                        L("ConfigPage_StatusSaveFailedTitle"),
+                        result.Error ?? L("ConfigPage_StatusSaveRejectedMessage"),
                         InfoBarSeverity.Error);
                 }
                 return;
@@ -551,7 +580,10 @@ public sealed partial class ConfigPage : Page
             _refreshConfigAfterReconnect = true;
             _refreshConfigWhenGatewayAvailable = true;
             ShowReconnectDialog(LocalizationHelper.GetString("ConfigPage_ReconnectDialogAccepted"));
-            ShowStatus("Gateway restarting", "Saving changes. The gateway is restarting and will reconnect automatically.", InfoBarSeverity.Informational);
+            ShowStatus(
+                L("ConfigPage_StatusGatewayRestartingTitle"),
+                L("ConfigPage_StatusGatewayRestartingMessage"),
+                InfoBarSeverity.Informational);
             _reconnectCompletionTimer.Stop();
             _reconnectCompletionTimer.Start();
             _reconnectTimeoutTimer.Stop();
@@ -559,7 +591,10 @@ public sealed partial class ConfigPage : Page
         }
         catch (Exception ex)
         {
-            ShowStatus("Save failed", $"{ex.Message} Your changes are preserved.", InfoBarSeverity.Error);
+            ShowStatus(
+                L("ConfigPage_StatusSaveFailedTitle"),
+                Lf("ConfigPage_StatusSaveExceptionMessageFormat", ex.Message),
+                InfoBarSeverity.Error);
         }
         finally
         {
@@ -590,7 +625,7 @@ public sealed partial class ConfigPage : Page
         if (permissionState == ConfigPermissionState.Checking)
         {
             _loading = false;
-            SaveStatus.Text = "Checking config permissions…";
+            SaveStatus.Text = L("ConfigPage_SaveStatusCheckingConfigPermissions");
             UpdatePermissionBanner();
             UpdateMetaAndButtons();
             return;
@@ -606,7 +641,7 @@ public sealed partial class ConfigPage : Page
 
         _loading = true;
         LoadingState.Visibility = Visibility.Visible;
-        SaveStatus.Text = "Refreshing…";
+        SaveStatus.Text = L("ConfigPage_SaveStatusRefreshing");
         UpdatePermissionBanner();
         _ = CurrentApp.GatewayClient.RequestConfigSchemaAsync();
         _ = CurrentApp.GatewayClient.RequestConfigAsync();
@@ -630,7 +665,10 @@ public sealed partial class ConfigPage : Page
         _pendingChanges.Clear();
         _validationErrors.Clear();
         _editSnapshot = ConfigEditorSnapshot.Empty;
-        ShowStatus("Changes discarded", "The form is back to the last config loaded from the gateway.", InfoBarSeverity.Informational);
+        ShowStatus(
+            L("ConfigPage_StatusChangesDiscardedTitle"),
+            L("ConfigPage_StatusChangesDiscardedMessage"),
+            InfoBarSeverity.Informational);
         RenderTree();
         RestoreSelectedDetail();
         UpdateSelectedJsonPreviewForCurrentSelection();
@@ -641,8 +679,11 @@ public sealed partial class ConfigPage : Page
     {
         RemoveSectionEntries(_selectedPath, _pendingChanges);
         RemoveSectionEntries(_selectedPath, _validationErrors);
-        var sectionLabel = string.IsNullOrEmpty(_selectedPath) ? "Full config" : _selectedPath;
-        ShowStatus("Section reset", $"{sectionLabel} is back to the last loaded gateway value.", InfoBarSeverity.Informational);
+        var sectionLabel = string.IsNullOrEmpty(_selectedPath) ? L("ConfigPage_FullConfig") : _selectedPath;
+        ShowStatus(
+            L("ConfigPage_StatusSectionResetTitle"),
+            Lf("ConfigPage_StatusSectionResetMessageFormat", sectionLabel),
+            InfoBarSeverity.Informational);
         RenderTree();
         RestoreSelectedDetail();
         UpdateSelectedJsonPreviewForCurrentSelection();
@@ -664,7 +705,10 @@ public sealed partial class ConfigPage : Page
         var package = new global::Windows.ApplicationModel.DataTransfer.DataPackage();
         package.SetText(_selectedJsonCopyText);
         global::Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(package);
-        ShowStatus("Copied JSON diff", "The selected section diff was copied to the clipboard.", InfoBarSeverity.Success);
+        ShowStatus(
+            L("ConfigPage_StatusCopiedJsonDiffTitle"),
+            L("ConfigPage_StatusCopiedJsonDiffMessage"),
+            InfoBarSeverity.Success);
     }
 
     private void OnToggleJsonPreview(object sender, RoutedEventArgs e)
@@ -841,9 +885,10 @@ public sealed partial class ConfigPage : Page
         var canWriteConfig = permissionState == ConfigPermissionState.ReadWrite;
         var editingLocked = IsConfigEditingLocked(permissionState);
         ConfigMetaText.Text = dirtyCount == 0
-            ? "No unsaved changes."
-            : $"{dirtyCount} unsaved change{(dirtyCount == 1 ? "" : "s")}" +
-              (invalidCount > 0 ? $" · {invalidCount} validation issue{(invalidCount == 1 ? "" : "s")}" : "");
+            ? L("ConfigPage_MetaNoUnsavedChanges")
+            : invalidCount > 0
+                ? Lf("ConfigPage_MetaUnsavedChangesWithValidationFormat", dirtyCount, invalidCount)
+                : Lf("ConfigPage_MetaUnsavedChangesFormat", dirtyCount);
 
         SaveStatus.Text = BuildSaveStatusText(permissionState, dirtyCount, invalidCount);
         SaveStatusIcon.Glyph = BuildSaveStatusGlyph(permissionState, dirtyCount, invalidCount);
@@ -872,20 +917,22 @@ public sealed partial class ConfigPage : Page
     private string BuildSaveStatusText(ConfigPermissionState permissionState, int dirtyCount, int invalidCount)
     {
         if (_saving)
-            return "Saving…";
+            return L("ConfigPage_SaveStatusSaving");
         if (permissionState == ConfigPermissionState.Disconnected)
-            return _refreshConfigAfterReconnect ? "Gateway restarting…" : "Connect to a gateway to edit";
+            return _refreshConfigAfterReconnect
+                ? L("ConfigPage_SaveStatusGatewayRestarting")
+                : L("ConfigPage_SaveStatusConnectToGateway");
         if (permissionState == ConfigPermissionState.Checking)
-            return "Checking permissions…";
+            return L("ConfigPage_SaveStatusCheckingPermissions");
         if (permissionState == ConfigPermissionState.NoRead)
-            return "Config unavailable: missing operator.read";
+            return L("ConfigPage_SaveStatusMissingRead");
         if (permissionState == ConfigPermissionState.ReadOnly && dirtyCount > 0)
-            return "Read-only: missing operator.write";
+            return L("ConfigPage_SaveStatusReadOnlyMissingWrite");
         if (invalidCount > 0)
-            return "Fix validation errors before saving";
+            return L("ConfigPage_SaveStatusFixValidationBeforeSaving");
         if (dirtyCount > 0)
-            return "Unsaved changes";
-        return "No unsaved changes";
+            return L("ConfigPage_SaveStatusUnsavedChanges");
+        return L("ConfigPage_SaveStatusNoUnsavedChanges");
     }
 
     private string BuildSaveStatusGlyph(ConfigPermissionState permissionState, int dirtyCount, int invalidCount)
@@ -911,10 +958,10 @@ public sealed partial class ConfigPage : Page
         _reconnectTimeoutTimer.Stop();
         DismissReconnectDialog();
         ShowStatus(
-            "Gateway reconnected",
+            L("ConfigPage_StatusGatewayReconnectedTitle"),
             refreshLatestConfig
-                ? "Configuration saved and the gateway connection is back. Refreshing the latest config."
-                : "Configuration saved and the latest gateway config is loaded.",
+                ? L("ConfigPage_StatusGatewayReconnectedRefreshingMessage")
+                : L("ConfigPage_StatusGatewayReconnectedLoadedMessage"),
             InfoBarSeverity.Success);
 
         if (refreshLatestConfig)
@@ -944,8 +991,8 @@ public sealed partial class ConfigPage : Page
         _reconnectCompletionTimer.Stop();
         DismissReconnectDialog();
         ShowStatus(
-            "Gateway still reconnecting",
-            "The config save was accepted, but the gateway has not reconnected yet. You can keep this page open or use Connection to check status.",
+            L("ConfigPage_StatusGatewayStillReconnectingTitle"),
+            L("ConfigPage_StatusGatewayStillReconnectingMessage"),
             InfoBarSeverity.Warning);
         UpdateMetaAndButtons();
     }
@@ -1055,18 +1102,18 @@ public sealed partial class ConfigPage : Page
     {
         var access = permissionState switch
         {
-            ConfigPermissionState.Disconnected => "Disconnected",
-            ConfigPermissionState.Checking => "Checking access",
-            ConfigPermissionState.NoRead => "No config read access",
-            ConfigPermissionState.ReadOnly => "Read-only access",
-            ConfigPermissionState.ReadWrite => "Read/write access",
-            _ => "Unknown access"
+            ConfigPermissionState.Disconnected => L("ConfigPage_AccessDisconnected"),
+            ConfigPermissionState.Checking => L("ConfigPage_AccessChecking"),
+            ConfigPermissionState.NoRead => L("ConfigPage_AccessNoRead"),
+            ConfigPermissionState.ReadOnly => L("ConfigPage_AccessReadOnly"),
+            ConfigPermissionState.ReadWrite => L("ConfigPage_AccessReadWrite"),
+            _ => L("ConfigPage_AccessUnknown")
         };
-        var changes = $"{dirtyCount} change{(dirtyCount == 1 ? "" : "s")}";
+        var changes = Lf("ConfigPage_AccessChangesFormat", dirtyCount);
         var validation = invalidCount == 0
-            ? "Local validation clean"
-            : $"{invalidCount} validation issue{(invalidCount == 1 ? "" : "s")}";
-        return $"{access} · {changes} · {validation}";
+            ? L("ConfigPage_AccessValidationClean")
+            : Lf("ConfigPage_AccessValidationIssuesFormat", invalidCount);
+        return Lf("ConfigPage_AccessSummaryFormat", access, changes, validation);
     }
 
     private void ShowConfigRenderError(string title, string message)
@@ -1135,20 +1182,20 @@ public sealed partial class ConfigPage : Page
         {
             case ConfigPermissionState.Checking:
                 PermissionInfoBar.Title = LocalizationHelper.GetString("ConfigPage_CheckingConfigPermissions");
-                PermissionInfoBar.Message = "Waiting for the gateway to report this operator's permissions.";
+                PermissionInfoBar.Message = L("ConfigPage_CheckingConfigPermissionsMessage");
                 PermissionInfoBar.Severity = InfoBarSeverity.Informational;
                 SetInfoBarOpen(PermissionInfoBar, true);
                 break;
             case ConfigPermissionState.NoRead:
                 ClearConfigViewForNoRead();
                 PermissionInfoBar.Title = LocalizationHelper.GetString("ConfigPage_ConfigUnavailable");
-                PermissionInfoBar.Message = "This operator token lacks operator.read permission, so the gateway config cannot be loaded here.";
+                PermissionInfoBar.Message = L("ConfigPage_ConfigUnavailableMessage");
                 PermissionInfoBar.Severity = InfoBarSeverity.Error;
                 SetInfoBarOpen(PermissionInfoBar, true);
                 break;
             case ConfigPermissionState.ReadOnly:
                 PermissionInfoBar.Title = LocalizationHelper.GetString("ConfigPage_ConfigIsReadOnly");
-                PermissionInfoBar.Message = "This operator token can read config but lacks operator.write permission. You can inspect and validate drafts, but Save is disabled.";
+                PermissionInfoBar.Message = L("ConfigPage_ConfigIsReadOnlyMessage");
                 PermissionInfoBar.Severity = InfoBarSeverity.Warning;
                 SetInfoBarOpen(PermissionInfoBar, true);
                 break;

--- a/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
@@ -146,9 +146,16 @@ public sealed partial class CronPage : Page
                 var result = t.IsCompletedSuccessfully ? t.Result : null;
                 if (t.IsFaulted || result?.Enqueued != true)
                 {
-                    // Request failed or gateway declined to enqueue the run.
+                    var detail = t.IsFaulted
+                        ? t.Exception?.GetBaseException().Message ?? LocalizationHelper.GetString("AppNotification_CronRunFailed_DefaultDetail")
+                        : result?.Reason ?? result?.Error ?? LocalizationHelper.GetString("AppNotification_CronRunRejectedDetail");
                     ClearRunningJob(jobId);
-                    ShowRunNotStartedNotification(vm?.Name ?? jobId, result?.Reason ?? result?.Error);
+                    ShowRunNotStartedNotification(vm?.Name ?? jobId, detail);
+                    ShowCronAppNotification(
+                        LocalizationHelper.GetString("AppNotification_CronRunFailed_Title"),
+                        LocalizationHelper.Format("AppNotification_CronRunFailed_MessageFormat", vm?.Name ?? jobId, detail),
+                        AppNotificationSeverity.Error,
+                        $"cron:{jobId}:run-failed");
                     if (client != null) _ = client.RequestCronListAsync();
                     return;
                 }
@@ -644,6 +651,24 @@ public sealed partial class CronPage : Page
         });
     }
 
+    private static void ShowCronAppNotification(
+        string title,
+        string message,
+        AppNotificationSeverity severity,
+        string dedupeKey)
+    {
+        AppNotificationPublisher.Show(
+            CurrentApp.AppNotifications,
+            title,
+            message,
+            "cron",
+            "jobs",
+            severity,
+            dedupeKey,
+            "cron",
+            LocalizationHelper.GetString("AppNotification_ActionOpenCron"));
+    }
+
     private static string? GetSelectedTag(ComboBox combo)
     {
         return (combo.SelectedItem as ComboBoxItem)?.Tag as string;
@@ -995,7 +1020,7 @@ public sealed partial class CronPage : Page
                 ? (Brush)Application.Current.Resources["SystemFillColorSuccessBrush"]
                 : (Brush)Application.Current.Resources["SystemFillColorNeutralBrush"];
             StorePathText.Text = storePath;
-            NextWakeText.Text = $"· Next wake: {nextWake}";
+            NextWakeText.Text = LocalizationHelper.Format("CronPage_NextWakeFormat", nextWake);
         });
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
@@ -155,7 +155,9 @@ public sealed partial class DebugPage : Page
     private void UpdateStatusInfoBar()
     {
         var gatewayUrl = CurrentApp.Settings?.GetEffectiveGatewayUrl();
-        var gatewayDisplay = string.IsNullOrWhiteSpace(gatewayUrl) ? "no gateway configured" : gatewayUrl;
+        var gatewayDisplay = string.IsNullOrWhiteSpace(gatewayUrl)
+            ? LocalizationHelper.GetString("DebugPage_NoGatewayConfigured")
+            : gatewayUrl;
         var status = _appState?.Status ?? ConnectionStatus.Disconnected;
 
         switch (status)
@@ -163,27 +165,27 @@ public sealed partial class DebugPage : Page
             case ConnectionStatus.Connected:
                 StatusInfoBar.Severity = InfoBarSeverity.Success;
                 StatusInfoBar.Title = LocalizationHelper.GetConnectionStatusText(status);
-                StatusInfoBar.Message = $"OpenClaw is connected to {gatewayDisplay}.";
+                StatusInfoBar.Message = LocalizationHelper.Format("DebugPage_StatusConnectedFormat", gatewayDisplay);
                 break;
             case ConnectionStatus.Connecting:
                 StatusInfoBar.Severity = InfoBarSeverity.Informational;
                 StatusInfoBar.Title = LocalizationHelper.GetConnectionStatusText(status);
-                StatusInfoBar.Message = $"Connecting to {gatewayDisplay}…";
+                StatusInfoBar.Message = LocalizationHelper.Format("DebugPage_StatusConnectingFormat", gatewayDisplay);
                 break;
             case ConnectionStatus.Disconnected:
                 StatusInfoBar.Severity = InfoBarSeverity.Warning;
                 StatusInfoBar.Title = LocalizationHelper.GetConnectionStatusText(status);
-                StatusInfoBar.Message = $"Not connected. Gateway: {gatewayDisplay}.";
+                StatusInfoBar.Message = LocalizationHelper.Format("DebugPage_StatusDisconnectedFormat", gatewayDisplay);
                 break;
             case ConnectionStatus.Error:
                 StatusInfoBar.Severity = InfoBarSeverity.Error;
                 StatusInfoBar.Title = LocalizationHelper.GetConnectionStatusText(status);
-                StatusInfoBar.Message = $"Last gateway: {gatewayDisplay}. See the event timeline.";
+                StatusInfoBar.Message = LocalizationHelper.Format("DebugPage_StatusErrorFormat", gatewayDisplay);
                 break;
             default:
                 StatusInfoBar.Severity = InfoBarSeverity.Informational;
                 StatusInfoBar.Title = LocalizationHelper.GetConnectionStatusText(status);
-                StatusInfoBar.Message = $"Gateway: {gatewayDisplay}.";
+                StatusInfoBar.Message = LocalizationHelper.Format("DebugPage_StatusGatewayFormat", gatewayDisplay);
                 break;
         }
     }
@@ -248,8 +250,8 @@ public sealed partial class DebugPage : Page
 
         if (mode == DetailMode.Log)
         {
-            DetailTitle.Text = "Recent log";
-            DetailCaption.Text = $"Last 200 lines of {LogPath}. Severity is parsed from [info]/[warn]/[error] tags.";
+            DetailTitle.Text = LocalizationHelper.GetString("DebugPage_RecentLogTitle");
+            DetailCaption.Text = LocalizationHelper.Format("DebugPage_RecentLogCaptionFormat", LogPath);
             DetailOpenFileButton.Visibility = Visibility.Visible;
             DetailRefreshButton.Visibility = Visibility.Visible;
             _ = LoadLogFileAsync(_detailGeneration);
@@ -552,7 +554,7 @@ public sealed partial class DebugPage : Page
 
     private void ShowCopyFeedback(string label)
     {
-        CopyFeedbackInfoBar.Message = $"{label} copied to clipboard.";
+        CopyFeedbackInfoBar.Message = LocalizationHelper.Format("DebugPage_CopyFeedbackFormat", label);
         CopyFeedbackInfoBar.IsOpen = true;
 
         if (_copyFeedbackTimer == null)

--- a/src/OpenClaw.Tray.WinUI/Pages/NotificationsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/NotificationsPage.xaml.cs
@@ -154,8 +154,25 @@ public sealed partial class NotificationsPage : Page
         private static string? LocalizeMetadataValue(string? value) => value switch
         {
             null or "" => null,
+            "authentication" => LocalizationHelper.GetString("NotificationsPage_MetadataAuthentication"),
+            "bindings" => LocalizationHelper.GetString("NotificationsPage_MetadataBindings"),
+            "channels" => LocalizationHelper.GetString("NotificationsPage_MetadataChannels"),
+            "config" => LocalizationHelper.GetString("NotificationsPage_MetadataConfig"),
+            "connection" => LocalizationHelper.GetString("NotificationsPage_MetadataConnection"),
+            "cron" => LocalizationHelper.GetString("NotificationsPage_MetadataCron"),
             "exec-approval" => LocalizationHelper.GetString("NotificationsPage_MetadataSourceExecApproval"),
+            "gateway" => LocalizationHelper.GetString("NotificationsPage_MetadataGateway"),
+            "jobs" => LocalizationHelper.GetString("NotificationsPage_MetadataJobs"),
+            "load" => LocalizationHelper.GetString("NotificationsPage_MetadataLoad"),
+            "lifecycle" => LocalizationHelper.GetString("NotificationsPage_MetadataLifecycle"),
+            "local-gateway" => LocalizationHelper.GetString("NotificationsPage_MetadataLocalGateway"),
             "node.invoke" => LocalizationHelper.GetString("NotificationsPage_MetadataCategoryNodeInvoke"),
+            "node" => LocalizationHelper.GetString("NotificationsPage_MetadataNode"),
+            "pairing" => LocalizationHelper.GetString("NotificationsPage_MetadataPairing"),
+            "sandbox" => LocalizationHelper.GetString("NotificationsPage_MetadataSandbox"),
+            "settings" => LocalizationHelper.GetString("NotificationsPage_MetadataSettings"),
+            "status" => LocalizationHelper.GetString("NotificationsPage_MetadataStatus"),
+            "system.run" => LocalizationHelper.GetString("NotificationsPage_MetadataSystemRun"),
             _ => value
         };
     }

--- a/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using OpenClaw.Shared;
+using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using System;
 using System.Collections.ObjectModel;
@@ -13,6 +14,8 @@ namespace OpenClawTray.Pages;
 public sealed partial class SandboxPage : Page
 {
     private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
+    private static string L(string key) => LocalizationHelper.GetString(key);
+    private static string Lf(string key, params object?[] args) => LocalizationHelper.Format(key, args);
     private bool _suppress;
     private bool _dialogOpen;
 
@@ -256,15 +259,15 @@ public sealed partial class SandboxPage : Page
             }
             else
             {
-                SandboxStatusTitle.Text = "Node Sandbox is on";
-                SandboxStatusSubtext.Text = "Programs the agent runs on this PC are contained.";
+                SandboxStatusTitle.Text = L("SandboxPage_StatusOnTitle");
+                SandboxStatusSubtext.Text = L("SandboxPage_StatusOnSubtext");
             }
         }
         else
         {
             SandboxStatusIcon.Text = "⚠";
-            SandboxStatusTitle.Text = "Node Sandbox is off — high risk";
-            SandboxStatusSubtext.Text = "Programs the agent runs on this PC are not contained.";
+            SandboxStatusTitle.Text = L("SandboxPage_StatusOffTitle");
+            SandboxStatusSubtext.Text = L("SandboxPage_StatusOffSubtext");
         }
     }
 
@@ -288,7 +291,7 @@ public sealed partial class SandboxPage : Page
         var reasons = availability.UnsupportedReasons;
         var reasonText = reasons.Count > 0
             ? string.Join("  ·  ", reasons)
-            : "MXC sandboxing primitives are not available on this machine.";
+            : L("SandboxPage_UnavailableDefaultReason");
 
         // A transient probe error (timeout / couldn't launch / garbled output) is NOT
         // the same as the host being unsupported — don't push the user at Windows
@@ -320,31 +323,48 @@ public sealed partial class SandboxPage : Page
         }
         else if (isWindowsIssue)
         {
+<<<<<<< HEAD
             UnavailableActionBar.Title = "Your Windows version doesn't support sandboxing yet";
             UnavailableActionMessage.Text =
                 $"{reasonText}\n\n{unavailableBehavior}Sandboxing requires a recent Windows build with the AppContainer primitives shipped. " +
                 "Install the latest Windows updates (or join the Windows Insider Program for the newest builds) to enable containment.";
             UnavailablePrimaryButton.Content = "Open Windows Update";
+=======
+            UnavailableActionBar.Title = L("SandboxPage_WindowsUnsupportedTitle");
+            UnavailableActionMessage.Text = Lf("SandboxPage_WindowsUnsupportedMessageFormat", reasonText);
+            UnavailablePrimaryButton.Content = L("SandboxPage_OpenWindowsUpdate");
+>>>>>>> 0d964cd4 (Use app notifications for background issues)
             UnavailablePrimaryButton.Tag = "windowsupdate";
             UnavailablePrimaryButton.Visibility = Visibility.Visible;
         }
         else if (isSetupIssue)
         {
+<<<<<<< HEAD
             UnavailableActionBar.Title = "Sandboxing components are missing";
             UnavailableActionMessage.Text =
                 $"{reasonText}\n\nThe wxc-exec binary couldn't be located. {unavailableBehavior}" +
                 "If this is a developer build, build the tray app so wxc-exec.exe is copied into the output folder. " +
                 "Otherwise reinstall the companion app to restore sandboxing.";
             UnavailablePrimaryButton.Content = "Show install instructions";
+=======
+            UnavailableActionBar.Title = L("SandboxPage_ComponentsMissingTitle");
+            UnavailableActionMessage.Text = Lf("SandboxPage_ComponentsMissingMessageFormat", reasonText);
+            UnavailablePrimaryButton.Content = L("SandboxPage_ShowInstallInstructions");
+>>>>>>> 0d964cd4 (Use app notifications for background issues)
             UnavailablePrimaryButton.Tag = "install";
             UnavailablePrimaryButton.Visibility = Visibility.Visible;
         }
         else
         {
+<<<<<<< HEAD
             UnavailableActionBar.Title = blockHostFallback
                 ? "Sandbox unavailable — commands blocked"
                 : "Sandbox unavailable — host fallback";
             UnavailableActionMessage.Text = $"{reasonText}\n\n{unavailableBehavior}";
+=======
+            UnavailableActionBar.Title = L("SandboxPage_UnavailableTitle");
+            UnavailableActionMessage.Text = reasonText;
+>>>>>>> 0d964cd4 (Use app notifications for background issues)
             UnavailablePrimaryButton.Visibility = Visibility.Collapsed;
         }
 
@@ -581,6 +601,7 @@ public sealed partial class SandboxPage : Page
     {
         if (_suppress) return;
         CurrentApp.Settings?.Save();
+        ((IAppCommands)CurrentApp).NotifySettingsSaved();
         UpdatePresetHighlight();
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
@@ -56,7 +56,7 @@ public sealed partial class SandboxPage : Page
             // "Checking…": synthesize an errored result so the UI shows Retry.
             _cachedAvailability = new OpenClaw.Shared.Mxc.MxcAvailability(
                 false, false, false, null,
-                new[] { "Couldn't check sandbox availability." }, probeErrored: true);
+                new[] { L("SandboxPage_ProbeErrorReason") }, probeErrored: true);
         }
         finally
         {
@@ -226,18 +226,18 @@ public sealed partial class SandboxPage : Page
 
             if (enabled && blockHostFallback)
             {
-                SandboxStatusTitle.Text = "Node Sandbox unavailable — commands blocked";
-                SandboxStatusSubtext.Text = "Containment isn't available on this PC, and strict fallback blocking is on, so agent-started commands are blocked.";
+                SandboxStatusTitle.Text = L("SandboxPage_StatusUnavailableBlockedTitle");
+                SandboxStatusSubtext.Text = L("SandboxPage_StatusUnavailableBlockedSubtext");
             }
             else if (enabled)
             {
-                SandboxStatusTitle.Text = "Node Sandbox unavailable — host fallback";
-                SandboxStatusSubtext.Text = "Containment isn't available on this PC, so agent-started commands run on the host without sandbox protection.";
+                SandboxStatusTitle.Text = L("SandboxPage_StatusUnavailableTitle");
+                SandboxStatusSubtext.Text = L("SandboxPage_StatusUnavailableSubtext");
             }
             else
             {
-                SandboxStatusTitle.Text = "Node Sandbox is off — host execution";
-                SandboxStatusSubtext.Text = "Containment isn't available and Node Sandbox is off, so agent-started commands run on the host without sandbox protection.";
+                SandboxStatusTitle.Text = L("SandboxPage_StatusUnavailableOffTitle");
+                SandboxStatusSubtext.Text = L("SandboxPage_StatusUnavailableOffSubtext");
             }
             return;
         }
@@ -307,64 +307,40 @@ public sealed partial class SandboxPage : Page
         var isSetupIssue = !availability.IsWxcExecResolvable;
         var blockHostFallback = sandboxEnabled
             && (CurrentApp.Settings?.SystemRunBlockHostFallbackWhenMxcUnavailable ?? false);
-        var unavailableBehavior = blockHostFallback
-            ? "Commands are blocked while sandboxing is unavailable because strict fallback blocking is enabled. "
-            : "Commands will run on the host without sandbox protection while sandboxing is unavailable. ";
+        var unavailableBehavior = L(blockHostFallback
+            ? "SandboxPage_UnavailableBehaviorBlocked"
+            : "SandboxPage_UnavailableBehaviorHostFallback");
 
         if (isProbeError)
         {
-            UnavailableActionBar.Title = "Couldn't verify sandbox availability";
-            UnavailableActionMessage.Text =
-                $"{reasonText}\n\nThe sandbox capability check didn't complete, so commands run uncontained for now. " +
-                "This is usually transient (a slow or blocked check) — retry, and if it persists check whether security software is blocking wxc-exec.";
-            UnavailablePrimaryButton.Content = "Retry";
+            UnavailableActionBar.Title = L("SandboxPage_ProbeErrorTitle");
+            UnavailableActionMessage.Text = Lf("SandboxPage_ProbeErrorMessageFormat", reasonText, unavailableBehavior);
+            UnavailablePrimaryButton.Content = L("SandboxPage_Retry");
             UnavailablePrimaryButton.Tag = "retry";
             UnavailablePrimaryButton.Visibility = Visibility.Visible;
         }
         else if (isWindowsIssue)
         {
-<<<<<<< HEAD
-            UnavailableActionBar.Title = "Your Windows version doesn't support sandboxing yet";
-            UnavailableActionMessage.Text =
-                $"{reasonText}\n\n{unavailableBehavior}Sandboxing requires a recent Windows build with the AppContainer primitives shipped. " +
-                "Install the latest Windows updates (or join the Windows Insider Program for the newest builds) to enable containment.";
-            UnavailablePrimaryButton.Content = "Open Windows Update";
-=======
             UnavailableActionBar.Title = L("SandboxPage_WindowsUnsupportedTitle");
-            UnavailableActionMessage.Text = Lf("SandboxPage_WindowsUnsupportedMessageFormat", reasonText);
+            UnavailableActionMessage.Text = Lf("SandboxPage_WindowsUnsupportedMessageFormat", reasonText, unavailableBehavior);
             UnavailablePrimaryButton.Content = L("SandboxPage_OpenWindowsUpdate");
->>>>>>> 0d964cd4 (Use app notifications for background issues)
             UnavailablePrimaryButton.Tag = "windowsupdate";
             UnavailablePrimaryButton.Visibility = Visibility.Visible;
         }
         else if (isSetupIssue)
         {
-<<<<<<< HEAD
-            UnavailableActionBar.Title = "Sandboxing components are missing";
-            UnavailableActionMessage.Text =
-                $"{reasonText}\n\nThe wxc-exec binary couldn't be located. {unavailableBehavior}" +
-                "If this is a developer build, build the tray app so wxc-exec.exe is copied into the output folder. " +
-                "Otherwise reinstall the companion app to restore sandboxing.";
-            UnavailablePrimaryButton.Content = "Show install instructions";
-=======
             UnavailableActionBar.Title = L("SandboxPage_ComponentsMissingTitle");
-            UnavailableActionMessage.Text = Lf("SandboxPage_ComponentsMissingMessageFormat", reasonText);
+            UnavailableActionMessage.Text = Lf("SandboxPage_ComponentsMissingMessageFormat", reasonText, unavailableBehavior);
             UnavailablePrimaryButton.Content = L("SandboxPage_ShowInstallInstructions");
->>>>>>> 0d964cd4 (Use app notifications for background issues)
             UnavailablePrimaryButton.Tag = "install";
             UnavailablePrimaryButton.Visibility = Visibility.Visible;
         }
         else
         {
-<<<<<<< HEAD
             UnavailableActionBar.Title = blockHostFallback
-                ? "Sandbox unavailable — commands blocked"
-                : "Sandbox unavailable — host fallback";
+                ? L("SandboxPage_UnavailableBlockedTitle")
+                : L("SandboxPage_UnavailableTitle");
             UnavailableActionMessage.Text = $"{reasonText}\n\n{unavailableBehavior}";
-=======
-            UnavailableActionBar.Title = L("SandboxPage_UnavailableTitle");
-            UnavailableActionMessage.Text = reasonText;
->>>>>>> 0d964cd4 (Use app notifications for background issues)
             UnavailablePrimaryButton.Visibility = Visibility.Collapsed;
         }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml.cs
@@ -347,15 +347,15 @@ public sealed partial class SettingsPage : Page
                 OpenClawOnboardCard.Visibility = Visibility.Collapsed;
                 ApplyUninstallUiState(UninstallUiState.Success);
                 UninstallResultBar.Severity = InfoBarSeverity.Success;
-                UninstallResultBar.Title = "Local gateway removed";
-                UninstallResultBar.Message = "Setup is reset; you can re-run setup from the tray menu.";
+                UninstallResultBar.Title = LocalizationHelper.GetString("SettingsPage_LocalGatewayRemovedTitle");
+                UninstallResultBar.Message = LocalizationHelper.GetString("SettingsPage_LocalGatewayRemovedMessage");
                 UninstallResultBar.ActionButton = null;
                 UninstallResultBar.IsOpen = true;
             }
             else
             {
                 ApplyUninstallUiState(UninstallUiState.Failure);
-                var errorMsg = "Removal completed with errors. Check logs for details.";
+                var errorMsg = LocalizationHelper.GetString("SettingsPage_LocalGatewayRemovalErrorsMessage");
                 if (File.Exists(jsonOutput))
                 {
                     try
@@ -394,8 +394,8 @@ public sealed partial class SettingsPage : Page
 
             ApplyUninstallUiState(UninstallUiState.Failure);
             UninstallResultBar.Severity = InfoBarSeverity.Warning;
-            UninstallResultBar.Title = "Removal cancelled";
-            UninstallResultBar.Message = "Gateway may be in a partially-removed state. Review logs or retry.";
+            UninstallResultBar.Title = LocalizationHelper.GetString("SettingsPage_LocalGatewayRemovalCancelledTitle");
+            UninstallResultBar.Message = LocalizationHelper.GetString("SettingsPage_LocalGatewayRemovalCancelledMessage");
             UninstallResultBar.ActionButton = null;
             UninstallResultBar.IsOpen = true;
         }
@@ -436,7 +436,7 @@ public sealed partial class SettingsPage : Page
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "OpenClawTray", "Logs");
 
-        var viewLogsButton = new Button { Content = "View Logs" };
+        var viewLogsButton = new Button { Content = LocalizationHelper.GetString("SettingsPage_ViewLogs") };
         viewLogsButton.Click += (_, _) =>
         {
             try { System.Diagnostics.Process.Start("explorer.exe", logsPath); }
@@ -444,7 +444,7 @@ public sealed partial class SettingsPage : Page
         };
 
         UninstallResultBar.Severity = InfoBarSeverity.Error;
-        UninstallResultBar.Title = "Removal failed";
+        UninstallResultBar.Title = LocalizationHelper.GetString("SettingsPage_LocalGatewayRemovalFailedTitle");
         UninstallResultBar.Message = message;
         UninstallResultBar.ActionButton = viewLogsButton;
         UninstallResultBar.IsOpen = true;
@@ -456,7 +456,7 @@ public sealed partial class SettingsPage : Page
         {
             case UninstallUiState.Idle:
             case UninstallUiState.Failure:
-                RemoveGatewayButton.Content = "Remove Local Gateway";
+                RemoveGatewayButton.Content = LocalizationHelper.GetString("SettingsPage_RemoveLocalGatewayButton");
                 RemoveGatewayButton.IsEnabled = true;
                 RemoveGatewayButton.Visibility = Visibility.Visible;
                 GatewayBodyText.Text = GatewayIdleBodyText;
@@ -474,13 +474,13 @@ public sealed partial class SettingsPage : Page
                 });
                 sp.Children.Add(new TextBlock
                 {
-                    Text = "Removing distro\u2026",
+                    Text = LocalizationHelper.GetString("SettingsPage_RemovingDistro"),
                     VerticalAlignment = VerticalAlignment.Center
                 });
                 RemoveGatewayButton.Content = sp;
                 RemoveGatewayButton.IsEnabled = false;
                 RemoveGatewayButton.Visibility = Visibility.Visible;
-                GatewayBodyText.Text = "Removing the local gateway. This may take 10\u201330 seconds\u2026";
+                GatewayBodyText.Text = LocalizationHelper.GetString("SettingsPage_RemovingLocalGatewayMessage");
                 break;
             }
 

--- a/src/OpenClaw.Tray.WinUI/Services/AppNotificationPublisher.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AppNotificationPublisher.cs
@@ -1,0 +1,33 @@
+namespace OpenClawTray.Services;
+
+internal static class AppNotificationPublisher
+{
+    public static void Show(
+        AppNotificationService? service,
+        string title,
+        string message,
+        string source,
+        string category,
+        AppNotificationSeverity severity,
+        string dedupeKey,
+        string actionRoute,
+        string actionLabel,
+        string? id = null)
+    {
+        if (service is null)
+            return;
+
+        service.Show(new AppNotification
+        {
+            Id = id ?? "",
+            Title = title,
+            Message = message,
+            Source = source,
+            Category = category,
+            Severity = severity,
+            DedupeKey = dedupeKey,
+            ActionRoute = actionRoute,
+            ActionLabel = actionLabel
+        });
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -3220,7 +3220,20 @@ On your gateway host (Mac/Linux), run:
     <value>Agent-started Windows commands will run without sandbox containment until Node Sandbox is turned back on.</value>
   </data>
   <data name="AppNotification_SandboxUnavailable_Title" xml:space="preserve">
-    <value>Sandbox unavailable — commands run uncontained</value>
+    <value>Sandbox unavailable — host fallback</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailable_MessageFormat" xml:space="preserve">
+    <value>{0}
+
+Commands will run on the host without sandbox protection while sandboxing is unavailable.</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailableBlocked_Title" xml:space="preserve">
+    <value>Sandbox unavailable — commands blocked</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailableBlocked_MessageFormat" xml:space="preserve">
+    <value>{0}
+
+Commands are blocked while sandboxing is unavailable because strict fallback blocking is enabled.</value>
   </data>
   <data name="AppNotification_SandboxUnavailable_DefaultReason" xml:space="preserve">
     <value>MXC sandboxing primitives are not available on this machine.</value>
@@ -6293,10 +6306,22 @@ Check your connection settings and try again.</value>
     <value>{0} copied to clipboard.</value>
   </data>
   <data name="SandboxPage_StatusUnavailableTitle" xml:space="preserve">
-    <value>Node Sandbox unavailable — commands run uncontained</value>
+    <value>Node Sandbox unavailable — host fallback</value>
   </data>
   <data name="SandboxPage_StatusUnavailableSubtext" xml:space="preserve">
-    <value>Containment isn't available on this PC, so commands run without sandbox protection.</value>
+    <value>Containment isn't available on this PC, so agent-started commands run on the host without sandbox protection.</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableBlockedTitle" xml:space="preserve">
+    <value>Node Sandbox unavailable — commands blocked</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableBlockedSubtext" xml:space="preserve">
+    <value>Containment isn't available on this PC, and strict fallback blocking is on, so agent-started commands are blocked.</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableOffTitle" xml:space="preserve">
+    <value>Node Sandbox is off — host execution</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableOffSubtext" xml:space="preserve">
+    <value>Containment isn't available and Node Sandbox is off, so agent-started commands run on the host without sandbox protection.</value>
   </data>
   <data name="SandboxPage_StatusOnTitle" xml:space="preserve">
     <value>Node Sandbox is on</value>
@@ -6313,11 +6338,29 @@ Check your connection settings and try again.</value>
   <data name="SandboxPage_UnavailableDefaultReason" xml:space="preserve">
     <value>MXC sandboxing primitives are not available on this machine.</value>
   </data>
+  <data name="SandboxPage_ProbeErrorReason" xml:space="preserve">
+    <value>Couldn't check sandbox availability.</value>
+  </data>
+  <data name="SandboxPage_UnavailableBehaviorHostFallback" xml:space="preserve">
+    <value>Commands will run on the host without sandbox protection while sandboxing is unavailable.</value>
+  </data>
+  <data name="SandboxPage_UnavailableBehaviorBlocked" xml:space="preserve">
+    <value>Commands are blocked while sandboxing is unavailable because strict fallback blocking is enabled.</value>
+  </data>
+  <data name="SandboxPage_ProbeErrorTitle" xml:space="preserve">
+    <value>Couldn't verify sandbox availability</value>
+  </data>
+  <data name="SandboxPage_ProbeErrorMessageFormat" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;{1} The sandbox capability check didn't complete. This is usually transient (a slow or blocked check) — retry, and if it persists check whether security software is blocking wxc-exec.</value>
+  </data>
+  <data name="SandboxPage_Retry" xml:space="preserve">
+    <value>Retry</value>
+  </data>
   <data name="SandboxPage_WindowsUnsupportedTitle" xml:space="preserve">
     <value>Your Windows version doesn't support sandboxing yet</value>
   </data>
   <data name="SandboxPage_WindowsUnsupportedMessageFormat" xml:space="preserve">
-    <value>{0}&#x0A;&#x0A;Commands run uncontained on this machine — sandboxing requires a recent Windows build with the AppContainer primitives shipped. Install the latest Windows updates (or join the Windows Insider Program for the newest builds) to enable containment.</value>
+    <value>{0}&#x0A;&#x0A;{1} Sandboxing requires a recent Windows build with the AppContainer primitives shipped. Install the latest Windows updates (or join the Windows Insider Program for the newest builds) to enable containment.</value>
   </data>
   <data name="SandboxPage_OpenWindowsUpdate" xml:space="preserve">
     <value>Open Windows Update</value>
@@ -6326,13 +6369,16 @@ Check your connection settings and try again.</value>
     <value>Sandboxing components are missing</value>
   </data>
   <data name="SandboxPage_ComponentsMissingMessageFormat" xml:space="preserve">
-    <value>{0}&#x0A;&#x0A;The wxc-exec binary couldn't be located, so commands run uncontained. If this is a developer build, build the tray app so wxc-exec.exe is copied into the output folder. Otherwise reinstall the companion app to restore sandboxing.</value>
+    <value>{0}&#x0A;&#x0A;The wxc-exec binary couldn't be located. {1} If this is a developer build, build the tray app so wxc-exec.exe is copied into the output folder. Otherwise reinstall the companion app to restore sandboxing.</value>
   </data>
   <data name="SandboxPage_ShowInstallInstructions" xml:space="preserve">
     <value>Show install instructions</value>
   </data>
   <data name="SandboxPage_UnavailableTitle" xml:space="preserve">
-    <value>Sandbox unavailable — commands run uncontained</value>
+    <value>Sandbox unavailable — host fallback</value>
+  </data>
+  <data name="SandboxPage_UnavailableBlockedTitle" xml:space="preserve">
+    <value>Sandbox unavailable — commands blocked</value>
   </data>
   <data name="SettingsPage_LocalGatewayRemovedTitle" xml:space="preserve">
     <value>Local gateway removed</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -3165,6 +3165,78 @@ On your gateway host (Mac/Linux), run:
   <data name="AppNotification_ShowMore" xml:space="preserve">
     <value>Show more</value>
   </data>
+  <data name="AppNotification_ActionOpenConnection" xml:space="preserve">
+    <value>Open Connection</value>
+  </data>
+  <data name="AppNotification_ActionOpenChannels" xml:space="preserve">
+    <value>Open Channels</value>
+  </data>
+  <data name="AppNotification_ActionOpenSandbox" xml:space="preserve">
+    <value>Open Sandbox</value>
+  </data>
+  <data name="AppNotification_ActionOpenCron" xml:space="preserve">
+    <value>Open Cron</value>
+  </data>
+  <data name="AppNotification_GatewayAuthenticationFailed_Title" xml:space="preserve">
+    <value>Gateway authentication failed</value>
+  </data>
+  <data name="AppNotification_GatewayConnectionFailed_Title" xml:space="preserve">
+    <value>Gateway connection failed</value>
+  </data>
+  <data name="AppNotification_GatewayConnectionFailed_DefaultMessage" xml:space="preserve">
+    <value>OpenClaw could not connect to the active gateway.</value>
+  </data>
+  <data name="AppNotification_GatewayPairingRequired_Title" xml:space="preserve">
+    <value>Gateway pairing approval required</value>
+  </data>
+  <data name="AppNotification_GatewayPairingRequired_GenericMessage" xml:space="preserve">
+    <value>Open Connection to complete gateway pairing.</value>
+  </data>
+  <data name="AppNotification_GatewayPairingRequired_DeviceMessageFormat" xml:space="preserve">
+    <value>Open Connection to approve device {0}.</value>
+  </data>
+  <data name="AppNotification_WindowsNodeConnectionFailed_Title" xml:space="preserve">
+    <value>Windows node connection failed</value>
+  </data>
+  <data name="AppNotification_WindowsNodeConnectionFailed_DefaultMessage" xml:space="preserve">
+    <value>The gateway is connected, but this Windows node is not available.</value>
+  </data>
+  <data name="AppNotification_WindowsNodeRateLimited_Title" xml:space="preserve">
+    <value>Windows node connection rate-limited</value>
+  </data>
+  <data name="AppNotification_WindowsNodeRateLimited_DefaultMessage" xml:space="preserve">
+    <value>The gateway is connected, but this Windows node is temporarily rate-limited.</value>
+  </data>
+  <data name="AppNotification_ChannelNeedsAttention_TitleFormat" xml:space="preserve">
+    <value>{0} channel needs attention</value>
+  </data>
+  <data name="AppNotification_ChannelNeedsAttention_StatusMessageFormat" xml:space="preserve">
+    <value>The gateway reports {0} as {1}.</value>
+  </data>
+  <data name="AppNotification_SandboxDisabled_Title" xml:space="preserve">
+    <value>Node Sandbox is off — commands run uncontained</value>
+  </data>
+  <data name="AppNotification_SandboxDisabled_Message" xml:space="preserve">
+    <value>Agent-started Windows commands will run without sandbox containment until Node Sandbox is turned back on.</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailable_Title" xml:space="preserve">
+    <value>Sandbox unavailable — commands run uncontained</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailable_DefaultReason" xml:space="preserve">
+    <value>MXC sandboxing primitives are not available on this machine.</value>
+  </data>
+  <data name="AppNotification_CronRunFailed_Title" xml:space="preserve">
+    <value>Cron job did not start</value>
+  </data>
+  <data name="AppNotification_CronRunFailed_DefaultDetail" xml:space="preserve">
+    <value>The request failed.</value>
+  </data>
+  <data name="AppNotification_CronRunRejectedDetail" xml:space="preserve">
+    <value>The gateway rejected the cron.run request.</value>
+  </data>
+  <data name="AppNotification_CronRunFailed_MessageFormat" xml:space="preserve">
+    <value>{0}: {1}</value>
+  </data>
   <data name="NotificationsPage_Title.Text" xml:space="preserve">
     <value>Notifications</value>
   </data>
@@ -3188,6 +3260,57 @@ On your gateway host (Mac/Linux), run:
   </data>
   <data name="NotificationsPage_MetadataCategoryNodeInvoke" xml:space="preserve">
     <value>Node command</value>
+  </data>
+  <data name="NotificationsPage_MetadataAuthentication" xml:space="preserve">
+    <value>Authentication</value>
+  </data>
+  <data name="NotificationsPage_MetadataBindings" xml:space="preserve">
+    <value>Bindings</value>
+  </data>
+  <data name="NotificationsPage_MetadataChannels" xml:space="preserve">
+    <value>Channels</value>
+  </data>
+  <data name="NotificationsPage_MetadataConfig" xml:space="preserve">
+    <value>Config</value>
+  </data>
+  <data name="NotificationsPage_MetadataConnection" xml:space="preserve">
+    <value>Connection</value>
+  </data>
+  <data name="NotificationsPage_MetadataCron" xml:space="preserve">
+    <value>Cron</value>
+  </data>
+  <data name="NotificationsPage_MetadataGateway" xml:space="preserve">
+    <value>Gateway</value>
+  </data>
+  <data name="NotificationsPage_MetadataJobs" xml:space="preserve">
+    <value>Jobs</value>
+  </data>
+  <data name="NotificationsPage_MetadataLoad" xml:space="preserve">
+    <value>Load</value>
+  </data>
+  <data name="NotificationsPage_MetadataLifecycle" xml:space="preserve">
+    <value>Lifecycle</value>
+  </data>
+  <data name="NotificationsPage_MetadataLocalGateway" xml:space="preserve">
+    <value>Local gateway</value>
+  </data>
+  <data name="NotificationsPage_MetadataNode" xml:space="preserve">
+    <value>Node</value>
+  </data>
+  <data name="NotificationsPage_MetadataPairing" xml:space="preserve">
+    <value>Pairing</value>
+  </data>
+  <data name="NotificationsPage_MetadataSandbox" xml:space="preserve">
+    <value>Sandbox</value>
+  </data>
+  <data name="NotificationsPage_MetadataSettings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="NotificationsPage_MetadataStatus" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="NotificationsPage_MetadataSystemRun" xml:space="preserve">
+    <value>system.run</value>
   </data>
   <data name="Chat_Permission_Title" xml:space="preserve">
     <value>Exec approval needed</value>
@@ -5952,6 +6075,312 @@ Check your connection settings and try again.</value>
   </data>
   <data name="ConfigPage_ConfigUnavailable" xml:space="preserve">
     <value>Config unavailable</value>
+  </data>
+  <data name="ConfigPage_EditingPathFormat" xml:space="preserve">
+    <value>Editing {0} via schema-guided form.</value>
+  </data>
+  <data name="ConfigPage_RenderConfigUnavailableTitle" xml:space="preserve">
+    <value>Config unavailable</value>
+  </data>
+  <data name="ConfigPage_RenderConfigUnavailableMessage" xml:space="preserve">
+    <value>The gateway config could not be rendered. Refresh and try again.</value>
+  </data>
+  <data name="ConfigPage_RenderSchemaUnavailableTitle" xml:space="preserve">
+    <value>Schema unavailable</value>
+  </data>
+  <data name="ConfigPage_RenderSchemaUnavailableMessage" xml:space="preserve">
+    <value>The gateway schema could not be rendered. Raw JSON remains available as a read-only preview.</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayRestartingTitle" xml:space="preserve">
+    <value>Gateway restarting</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayRestartingMessage" xml:space="preserve">
+    <value>Saving changes. The gateway is restarting and will reconnect automatically.</value>
+  </data>
+  <data name="ConfigPage_StatusNoChangesTitle" xml:space="preserve">
+    <value>No changes</value>
+  </data>
+  <data name="ConfigPage_StatusNoChangesMessage" xml:space="preserve">
+    <value>There is nothing to save.</value>
+  </data>
+  <data name="ConfigPage_StatusFixValidationErrorsTitle" xml:space="preserve">
+    <value>Fix validation errors</value>
+  </data>
+  <data name="ConfigPage_StatusValidationErrorMessageFormat" xml:space="preserve">
+    <value>{0}: {1}</value>
+  </data>
+  <data name="ConfigPage_StatusNotConnectedTitle" xml:space="preserve">
+    <value>Not connected</value>
+  </data>
+  <data name="ConfigPage_StatusNotConnectedMessage" xml:space="preserve">
+    <value>Connect to a gateway before saving config.</value>
+  </data>
+  <data name="ConfigPage_StatusReadOnlyMessage" xml:space="preserve">
+    <value>This operator token does not have operator.write permission, so config changes cannot be saved.</value>
+  </data>
+  <data name="ConfigPage_StatusConfigNotLoadedTitle" xml:space="preserve">
+    <value>Config not loaded</value>
+  </data>
+  <data name="ConfigPage_StatusConfigNotLoadedMessage" xml:space="preserve">
+    <value>Refresh the gateway config before saving.</value>
+  </data>
+  <data name="ConfigPage_StatusSavingConfigTitle" xml:space="preserve">
+    <value>Saving config…</value>
+  </data>
+  <data name="ConfigPage_StatusSavingConfigMessageFormat" xml:space="preserve">
+    <value>Writing {0} change(s) to the gateway.</value>
+  </data>
+  <data name="ConfigPage_StatusStaleConfigTitle" xml:space="preserve">
+    <value>Gateway config changed elsewhere</value>
+  </data>
+  <data name="ConfigPage_StatusStaleConfigMessageFormat" xml:space="preserve">
+    <value>Your edits are preserved. The latest config is being refreshed; review the form and try Save again. Details: {0}</value>
+  </data>
+  <data name="ConfigPage_StatusStaleConfigDefaultDetail" xml:space="preserve">
+    <value>stale config hash</value>
+  </data>
+  <data name="ConfigPage_StatusSaveFailedTitle" xml:space="preserve">
+    <value>Save failed</value>
+  </data>
+  <data name="ConfigPage_StatusSaveRejectedMessage" xml:space="preserve">
+    <value>The gateway rejected the config update. Your changes are preserved.</value>
+  </data>
+  <data name="ConfigPage_StatusSaveExceptionMessageFormat" xml:space="preserve">
+    <value>{0} Your changes are preserved.</value>
+  </data>
+  <data name="ConfigPage_SaveStatusCheckingConfigPermissions" xml:space="preserve">
+    <value>Checking config permissions…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusRefreshing" xml:space="preserve">
+    <value>Refreshing…</value>
+  </data>
+  <data name="ConfigPage_StatusChangesDiscardedTitle" xml:space="preserve">
+    <value>Changes discarded</value>
+  </data>
+  <data name="ConfigPage_StatusChangesDiscardedMessage" xml:space="preserve">
+    <value>The form is back to the last config loaded from the gateway.</value>
+  </data>
+  <data name="ConfigPage_FullConfig" xml:space="preserve">
+    <value>Full config</value>
+  </data>
+  <data name="ConfigPage_StatusSectionResetTitle" xml:space="preserve">
+    <value>Section reset</value>
+  </data>
+  <data name="ConfigPage_StatusSectionResetMessageFormat" xml:space="preserve">
+    <value>{0} is back to the last loaded gateway value.</value>
+  </data>
+  <data name="ConfigPage_StatusCopiedJsonDiffTitle" xml:space="preserve">
+    <value>Copied JSON diff</value>
+  </data>
+  <data name="ConfigPage_StatusCopiedJsonDiffMessage" xml:space="preserve">
+    <value>The selected section diff was copied to the clipboard.</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayReconnectedTitle" xml:space="preserve">
+    <value>Gateway reconnected</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayReconnectedRefreshingMessage" xml:space="preserve">
+    <value>Configuration saved and the gateway connection is back. Refreshing the latest config.</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayReconnectedLoadedMessage" xml:space="preserve">
+    <value>Configuration saved and the latest gateway config is loaded.</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayStillReconnectingTitle" xml:space="preserve">
+    <value>Gateway still reconnecting</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayStillReconnectingMessage" xml:space="preserve">
+    <value>The config save was accepted, but the gateway has not reconnected yet. You can keep this page open or use Connection to check status.</value>
+  </data>
+  <data name="ConfigPage_CheckingConfigPermissionsMessage" xml:space="preserve">
+    <value>Waiting for the gateway to report this operator's permissions.</value>
+  </data>
+  <data name="ConfigPage_ConfigUnavailableMessage" xml:space="preserve">
+    <value>This operator token lacks operator.read permission, so the gateway config cannot be loaded here.</value>
+  </data>
+  <data name="ConfigPage_ConfigIsReadOnlyMessage" xml:space="preserve">
+    <value>This operator token can read config but lacks operator.write permission. You can inspect and validate drafts, but Save is disabled.</value>
+  </data>
+  <data name="ConfigPage_MetaNoUnsavedChanges" xml:space="preserve">
+    <value>No unsaved changes.</value>
+  </data>
+  <data name="ConfigPage_MetaUnsavedChangesFormat" xml:space="preserve">
+    <value>{0} unsaved change(s)</value>
+  </data>
+  <data name="ConfigPage_MetaUnsavedChangesWithValidationFormat" xml:space="preserve">
+    <value>{0} unsaved change(s) · {1} validation issue(s)</value>
+  </data>
+  <data name="ConfigPage_SaveStatusSaving" xml:space="preserve">
+    <value>Saving…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusGatewayRestarting" xml:space="preserve">
+    <value>Gateway restarting…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusConnectToGateway" xml:space="preserve">
+    <value>Connect to a gateway to edit</value>
+  </data>
+  <data name="ConfigPage_SaveStatusCheckingPermissions" xml:space="preserve">
+    <value>Checking permissions…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusMissingRead" xml:space="preserve">
+    <value>Config unavailable: missing operator.read</value>
+  </data>
+  <data name="ConfigPage_SaveStatusReadOnlyMissingWrite" xml:space="preserve">
+    <value>Read-only: missing operator.write</value>
+  </data>
+  <data name="ConfigPage_SaveStatusFixValidationBeforeSaving" xml:space="preserve">
+    <value>Fix validation errors before saving</value>
+  </data>
+  <data name="ConfigPage_SaveStatusUnsavedChanges" xml:space="preserve">
+    <value>Unsaved changes</value>
+  </data>
+  <data name="ConfigPage_SaveStatusNoUnsavedChanges" xml:space="preserve">
+    <value>No unsaved changes</value>
+  </data>
+  <data name="ConfigPage_AccessDisconnected" xml:space="preserve">
+    <value>Disconnected</value>
+  </data>
+  <data name="ConfigPage_AccessChecking" xml:space="preserve">
+    <value>Checking access</value>
+  </data>
+  <data name="ConfigPage_AccessNoRead" xml:space="preserve">
+    <value>No config read access</value>
+  </data>
+  <data name="ConfigPage_AccessReadOnly" xml:space="preserve">
+    <value>Read-only access</value>
+  </data>
+  <data name="ConfigPage_AccessReadWrite" xml:space="preserve">
+    <value>Read/write access</value>
+  </data>
+  <data name="ConfigPage_AccessUnknown" xml:space="preserve">
+    <value>Unknown access</value>
+  </data>
+  <data name="ConfigPage_AccessChangesFormat" xml:space="preserve">
+    <value>{0} change(s)</value>
+  </data>
+  <data name="ConfigPage_AccessValidationClean" xml:space="preserve">
+    <value>Local validation clean</value>
+  </data>
+  <data name="ConfigPage_AccessValidationIssuesFormat" xml:space="preserve">
+    <value>{0} validation issue(s)</value>
+  </data>
+  <data name="ConfigPage_AccessSummaryFormat" xml:space="preserve">
+    <value>{0} · {1} · {2}</value>
+  </data>
+  <data name="DebugPage_NoGatewayConfigured" xml:space="preserve">
+    <value>no gateway configured</value>
+  </data>
+  <data name="DebugPage_StatusConnectedFormat" xml:space="preserve">
+    <value>OpenClaw is connected to {0}.</value>
+  </data>
+  <data name="DebugPage_StatusConnectingFormat" xml:space="preserve">
+    <value>Connecting to {0}…</value>
+  </data>
+  <data name="DebugPage_StatusDisconnectedFormat" xml:space="preserve">
+    <value>Not connected. Gateway: {0}.</value>
+  </data>
+  <data name="DebugPage_StatusErrorFormat" xml:space="preserve">
+    <value>Last gateway: {0}. See the event timeline.</value>
+  </data>
+  <data name="DebugPage_StatusGatewayFormat" xml:space="preserve">
+    <value>Gateway: {0}.</value>
+  </data>
+  <data name="DebugPage_RecentLogTitle" xml:space="preserve">
+    <value>Recent log</value>
+  </data>
+  <data name="DebugPage_RecentLogCaptionFormat" xml:space="preserve">
+    <value>Last 200 lines of {0}. Severity is parsed from [info]/[warn]/[error] tags.</value>
+  </data>
+  <data name="DebugPage_CopyFeedbackFormat" xml:space="preserve">
+    <value>{0} copied to clipboard.</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableTitle" xml:space="preserve">
+    <value>Node Sandbox unavailable — commands run uncontained</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableSubtext" xml:space="preserve">
+    <value>Containment isn't available on this PC, so commands run without sandbox protection.</value>
+  </data>
+  <data name="SandboxPage_StatusOnTitle" xml:space="preserve">
+    <value>Node Sandbox is on</value>
+  </data>
+  <data name="SandboxPage_StatusOnSubtext" xml:space="preserve">
+    <value>Programs the agent runs on this PC are contained.</value>
+  </data>
+  <data name="SandboxPage_StatusOffTitle" xml:space="preserve">
+    <value>Node Sandbox is off — high risk</value>
+  </data>
+  <data name="SandboxPage_StatusOffSubtext" xml:space="preserve">
+    <value>Programs the agent runs on this PC are not contained.</value>
+  </data>
+  <data name="SandboxPage_UnavailableDefaultReason" xml:space="preserve">
+    <value>MXC sandboxing primitives are not available on this machine.</value>
+  </data>
+  <data name="SandboxPage_WindowsUnsupportedTitle" xml:space="preserve">
+    <value>Your Windows version doesn't support sandboxing yet</value>
+  </data>
+  <data name="SandboxPage_WindowsUnsupportedMessageFormat" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;Commands run uncontained on this machine — sandboxing requires a recent Windows build with the AppContainer primitives shipped. Install the latest Windows updates (or join the Windows Insider Program for the newest builds) to enable containment.</value>
+  </data>
+  <data name="SandboxPage_OpenWindowsUpdate" xml:space="preserve">
+    <value>Open Windows Update</value>
+  </data>
+  <data name="SandboxPage_ComponentsMissingTitle" xml:space="preserve">
+    <value>Sandboxing components are missing</value>
+  </data>
+  <data name="SandboxPage_ComponentsMissingMessageFormat" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;The wxc-exec binary couldn't be located, so commands run uncontained. If this is a developer build, build the tray app so wxc-exec.exe is copied into the output folder. Otherwise reinstall the companion app to restore sandboxing.</value>
+  </data>
+  <data name="SandboxPage_ShowInstallInstructions" xml:space="preserve">
+    <value>Show install instructions</value>
+  </data>
+  <data name="SandboxPage_UnavailableTitle" xml:space="preserve">
+    <value>Sandbox unavailable — commands run uncontained</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovedTitle" xml:space="preserve">
+    <value>Local gateway removed</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovedMessage" xml:space="preserve">
+    <value>Setup is reset; you can re-run setup from the tray menu.</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalErrorsMessage" xml:space="preserve">
+    <value>Removal completed with errors. Check logs for details.</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalCancelledTitle" xml:space="preserve">
+    <value>Removal cancelled</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalCancelledMessage" xml:space="preserve">
+    <value>Gateway may be in a partially-removed state. Review logs or retry.</value>
+  </data>
+  <data name="SettingsPage_ViewLogs" xml:space="preserve">
+    <value>View Logs</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalFailedTitle" xml:space="preserve">
+    <value>Removal failed</value>
+  </data>
+  <data name="SettingsPage_RemoveLocalGatewayButton" xml:space="preserve">
+    <value>Remove Local Gateway</value>
+  </data>
+  <data name="SettingsPage_RemovingDistro" xml:space="preserve">
+    <value>Removing distro…</value>
+  </data>
+  <data name="SettingsPage_RemovingLocalGatewayMessage" xml:space="preserve">
+    <value>Removing the local gateway. This may take 10–30 seconds…</value>
+  </data>
+  <data name="CronPage_NextWakeFormat" xml:space="preserve">
+    <value>· Next wake: {0}</value>
+  </data>
+  <data name="ChatWindow_UnableToLoadChatCredentials" xml:space="preserve">
+    <value>Unable to load chat. The gateway URL or token is not available.</value>
+  </data>
+  <data name="ChatWindow_UnableToLoadChatRetryFormat" xml:space="preserve">
+    <value>Unable to load chat. Please try again. ({0})</value>
+  </data>
+  <data name="ChatWindow_WebViewFailedFormat" xml:space="preserve">
+    <value>WebView2 failed: {0}</value>
+  </data>
+  <data name="CanvasWindow_WebViewInitFailedFormat" xml:space="preserve">
+    <value>Failed to initialize WebView2: {0}</value>
+  </data>
+  <data name="CanvasWindow_NavigationFailedFormat" xml:space="preserve">
+    <value>Navigation failed: {0}</value>
   </data>
   <data name="ConnectionPage_GatewayHostControlsDescription_Format" xml:space="preserve">
     <value>Open a shell or manage the local gateway service in {0}.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -3148,7 +3148,20 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
     <value>Les commandes Windows lancées par l'agent s'exécuteront sans confinement jusqu'à ce que le Sandbox du nœud soit réactivé.</value>
   </data>
   <data name="AppNotification_SandboxUnavailable_Title" xml:space="preserve">
-    <value>Sandbox indisponible — les commandes s'exécutent sans confinement</value>
+    <value>Sandbox indisponible — repli sur l'hôte</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailable_MessageFormat" xml:space="preserve">
+    <value>{0}
+
+Les commandes s'exécuteront sur l'hôte sans protection de sandbox tant que le sandboxing est indisponible.</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailableBlocked_Title" xml:space="preserve">
+    <value>Sandbox indisponible — commandes bloquées</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailableBlocked_MessageFormat" xml:space="preserve">
+    <value>{0}
+
+Les commandes sont bloquées tant que le sandboxing est indisponible, car le blocage strict du repli est activé.</value>
   </data>
   <data name="AppNotification_SandboxUnavailable_DefaultReason" xml:space="preserve">
     <value>Les primitives de sandboxing MXC ne sont pas disponibles sur cette machine.</value>
@@ -6245,10 +6258,22 @@ Vérifiez vos paramètres de connexion et réessayez.</value>
     <value>{0} copié dans le presse-papiers.</value>
   </data>
   <data name="SandboxPage_StatusUnavailableTitle" xml:space="preserve">
-    <value>Sandbox du nœud indisponible — les commandes s'exécutent sans confinement</value>
+    <value>Sandbox du nœud indisponible — repli sur l'hôte</value>
   </data>
   <data name="SandboxPage_StatusUnavailableSubtext" xml:space="preserve">
-    <value>Le confinement n'est pas disponible sur ce PC ; les commandes s'exécutent donc sans protection de sandbox.</value>
+    <value>Le confinement n'est pas disponible sur ce PC ; les commandes lancées par l'agent s'exécutent donc sur l'hôte sans protection de sandbox.</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableBlockedTitle" xml:space="preserve">
+    <value>Sandbox du nœud indisponible — commandes bloquées</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableBlockedSubtext" xml:space="preserve">
+    <value>Le confinement n'est pas disponible sur ce PC et le blocage strict du repli est activé ; les commandes lancées par l'agent sont donc bloquées.</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableOffTitle" xml:space="preserve">
+    <value>Le Sandbox du nœud est désactivé — exécution sur l'hôte</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableOffSubtext" xml:space="preserve">
+    <value>Le confinement n'est pas disponible et le Sandbox du nœud est désactivé ; les commandes lancées par l'agent s'exécutent donc sur l'hôte sans protection de sandbox.</value>
   </data>
   <data name="SandboxPage_StatusOnTitle" xml:space="preserve">
     <value>Le Sandbox du nœud est activé</value>
@@ -6265,11 +6290,29 @@ Vérifiez vos paramètres de connexion et réessayez.</value>
   <data name="SandboxPage_UnavailableDefaultReason" xml:space="preserve">
     <value>Les primitives de sandboxing MXC ne sont pas disponibles sur cette machine.</value>
   </data>
+  <data name="SandboxPage_ProbeErrorReason" xml:space="preserve">
+    <value>Impossible de vérifier la disponibilité du sandbox.</value>
+  </data>
+  <data name="SandboxPage_UnavailableBehaviorHostFallback" xml:space="preserve">
+    <value>Les commandes s'exécuteront sur l'hôte sans protection de sandbox tant que le sandboxing est indisponible.</value>
+  </data>
+  <data name="SandboxPage_UnavailableBehaviorBlocked" xml:space="preserve">
+    <value>Les commandes sont bloquées tant que le sandboxing est indisponible, car le blocage strict du repli est activé.</value>
+  </data>
+  <data name="SandboxPage_ProbeErrorTitle" xml:space="preserve">
+    <value>Impossible de vérifier la disponibilité du sandbox</value>
+  </data>
+  <data name="SandboxPage_ProbeErrorMessageFormat" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;{1} La vérification des capacités du sandbox ne s'est pas terminée. C'est généralement transitoire (vérification lente ou bloquée) — réessayez, et si le problème persiste, vérifiez si un logiciel de sécurité bloque wxc-exec.</value>
+  </data>
+  <data name="SandboxPage_Retry" xml:space="preserve">
+    <value>Réessayer</value>
+  </data>
   <data name="SandboxPage_WindowsUnsupportedTitle" xml:space="preserve">
     <value>Votre version de Windows ne prend pas encore en charge le sandboxing</value>
   </data>
   <data name="SandboxPage_WindowsUnsupportedMessageFormat" xml:space="preserve">
-    <value>{0}&#x0A;&#x0A;Les commandes s'exécutent sans confinement sur cette machine — le sandboxing nécessite une version récente de Windows avec les primitives AppContainer. Installez les dernières mises à jour Windows (ou rejoignez le programme Windows Insider pour les versions les plus récentes) afin d'activer le confinement.</value>
+    <value>{0}&#x0A;&#x0A;{1} Le sandboxing nécessite une version récente de Windows avec les primitives AppContainer. Installez les dernières mises à jour Windows (ou rejoignez le programme Windows Insider pour les versions les plus récentes) afin d'activer le confinement.</value>
   </data>
   <data name="SandboxPage_OpenWindowsUpdate" xml:space="preserve">
     <value>Ouvrir Windows Update</value>
@@ -6278,13 +6321,16 @@ Vérifiez vos paramètres de connexion et réessayez.</value>
     <value>Des composants de sandboxing sont manquants</value>
   </data>
   <data name="SandboxPage_ComponentsMissingMessageFormat" xml:space="preserve">
-    <value>{0}&#x0A;&#x0A;Le binaire wxc-exec est introuvable ; les commandes s'exécutent donc sans confinement. S'il s'agit d'une build développeur, compilez l'application Tray pour copier wxc-exec.exe dans le dossier de sortie. Sinon, réinstallez le compagnon pour restaurer le sandboxing.</value>
+    <value>{0}&#x0A;&#x0A;Le binaire wxc-exec est introuvable. {1} S'il s'agit d'une build développeur, compilez l'application Tray pour copier wxc-exec.exe dans le dossier de sortie. Sinon, réinstallez le compagnon pour restaurer le sandboxing.</value>
   </data>
   <data name="SandboxPage_ShowInstallInstructions" xml:space="preserve">
     <value>Afficher les instructions d'installation</value>
   </data>
   <data name="SandboxPage_UnavailableTitle" xml:space="preserve">
-    <value>Sandbox indisponible — les commandes s'exécutent sans confinement</value>
+    <value>Sandbox indisponible — repli sur l'hôte</value>
+  </data>
+  <data name="SandboxPage_UnavailableBlockedTitle" xml:space="preserve">
+    <value>Sandbox indisponible — commandes bloquées</value>
   </data>
   <data name="SettingsPage_LocalGatewayRemovedTitle" xml:space="preserve">
     <value>Passerelle locale supprimée</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -3093,6 +3093,78 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="AppNotification_ShowMore" xml:space="preserve">
     <value>Afficher plus</value>
   </data>
+  <data name="AppNotification_ActionOpenConnection" xml:space="preserve">
+    <value>Ouvrir Connexion</value>
+  </data>
+  <data name="AppNotification_ActionOpenChannels" xml:space="preserve">
+    <value>Ouvrir Canaux</value>
+  </data>
+  <data name="AppNotification_ActionOpenSandbox" xml:space="preserve">
+    <value>Ouvrir Sandbox</value>
+  </data>
+  <data name="AppNotification_ActionOpenCron" xml:space="preserve">
+    <value>Ouvrir Cron</value>
+  </data>
+  <data name="AppNotification_GatewayAuthenticationFailed_Title" xml:space="preserve">
+    <value>Échec de l'authentification de la passerelle</value>
+  </data>
+  <data name="AppNotification_GatewayConnectionFailed_Title" xml:space="preserve">
+    <value>Échec de la connexion à la passerelle</value>
+  </data>
+  <data name="AppNotification_GatewayConnectionFailed_DefaultMessage" xml:space="preserve">
+    <value>OpenClaw n'a pas pu se connecter à la passerelle active.</value>
+  </data>
+  <data name="AppNotification_GatewayPairingRequired_Title" xml:space="preserve">
+    <value>Approbation d'appairage de la passerelle requise</value>
+  </data>
+  <data name="AppNotification_GatewayPairingRequired_GenericMessage" xml:space="preserve">
+    <value>Ouvrez Connexion pour terminer l'appairage de la passerelle.</value>
+  </data>
+  <data name="AppNotification_GatewayPairingRequired_DeviceMessageFormat" xml:space="preserve">
+    <value>Ouvrez Connexion pour approuver l'appareil {0}.</value>
+  </data>
+  <data name="AppNotification_WindowsNodeConnectionFailed_Title" xml:space="preserve">
+    <value>Échec de la connexion du nœud Windows</value>
+  </data>
+  <data name="AppNotification_WindowsNodeConnectionFailed_DefaultMessage" xml:space="preserve">
+    <value>La passerelle est connectée, mais ce nœud Windows n'est pas disponible.</value>
+  </data>
+  <data name="AppNotification_WindowsNodeRateLimited_Title" xml:space="preserve">
+    <value>Connexion du nœud Windows limitée</value>
+  </data>
+  <data name="AppNotification_WindowsNodeRateLimited_DefaultMessage" xml:space="preserve">
+    <value>La passerelle est connectée, mais ce nœud Windows est temporairement limité.</value>
+  </data>
+  <data name="AppNotification_ChannelNeedsAttention_TitleFormat" xml:space="preserve">
+    <value>Le canal {0} nécessite une attention</value>
+  </data>
+  <data name="AppNotification_ChannelNeedsAttention_StatusMessageFormat" xml:space="preserve">
+    <value>La passerelle signale {0} comme {1}.</value>
+  </data>
+  <data name="AppNotification_SandboxDisabled_Title" xml:space="preserve">
+    <value>Le Sandbox du nœud est désactivé — les commandes s'exécutent sans confinement</value>
+  </data>
+  <data name="AppNotification_SandboxDisabled_Message" xml:space="preserve">
+    <value>Les commandes Windows lancées par l'agent s'exécuteront sans confinement jusqu'à ce que le Sandbox du nœud soit réactivé.</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailable_Title" xml:space="preserve">
+    <value>Sandbox indisponible — les commandes s'exécutent sans confinement</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailable_DefaultReason" xml:space="preserve">
+    <value>Les primitives de sandboxing MXC ne sont pas disponibles sur cette machine.</value>
+  </data>
+  <data name="AppNotification_CronRunFailed_Title" xml:space="preserve">
+    <value>La tâche Cron n'a pas démarré</value>
+  </data>
+  <data name="AppNotification_CronRunFailed_DefaultDetail" xml:space="preserve">
+    <value>La demande a échoué.</value>
+  </data>
+  <data name="AppNotification_CronRunRejectedDetail" xml:space="preserve">
+    <value>La passerelle a rejeté la demande cron.run.</value>
+  </data>
+  <data name="AppNotification_CronRunFailed_MessageFormat" xml:space="preserve">
+    <value>{0} : {1}</value>
+  </data>
   <data name="NotificationsPage_Title.Text" xml:space="preserve">
     <value>Alertes</value>
   </data>
@@ -3140,6 +3212,57 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   </data>
   <data name="AppNotification_ExecApprovalPending_AgentSlotLabelFormat" xml:space="preserve">
     <value>{0} / {1}</value>
+  </data>
+  <data name="NotificationsPage_MetadataAuthentication" xml:space="preserve">
+    <value>Authentification</value>
+  </data>
+  <data name="NotificationsPage_MetadataBindings" xml:space="preserve">
+    <value>Liaisons</value>
+  </data>
+  <data name="NotificationsPage_MetadataChannels" xml:space="preserve">
+    <value>Canaux</value>
+  </data>
+  <data name="NotificationsPage_MetadataConfig" xml:space="preserve">
+    <value>Configuration</value>
+  </data>
+  <data name="NotificationsPage_MetadataConnection" xml:space="preserve">
+    <value>Connexion</value>
+  </data>
+  <data name="NotificationsPage_MetadataCron" xml:space="preserve">
+    <value>Cron</value>
+  </data>
+  <data name="NotificationsPage_MetadataGateway" xml:space="preserve">
+    <value>Passerelle</value>
+  </data>
+  <data name="NotificationsPage_MetadataJobs" xml:space="preserve">
+    <value>Tâches</value>
+  </data>
+  <data name="NotificationsPage_MetadataLoad" xml:space="preserve">
+    <value>Chargement</value>
+  </data>
+  <data name="NotificationsPage_MetadataLifecycle" xml:space="preserve">
+    <value>Cycle de vie</value>
+  </data>
+  <data name="NotificationsPage_MetadataLocalGateway" xml:space="preserve">
+    <value>Passerelle locale</value>
+  </data>
+  <data name="NotificationsPage_MetadataNode" xml:space="preserve">
+    <value>Nœud</value>
+  </data>
+  <data name="NotificationsPage_MetadataPairing" xml:space="preserve">
+    <value>Appairage</value>
+  </data>
+  <data name="NotificationsPage_MetadataSandbox" xml:space="preserve">
+    <value>Bac à sable</value>
+  </data>
+  <data name="NotificationsPage_MetadataSettings" xml:space="preserve">
+    <value>Paramètres</value>
+  </data>
+  <data name="NotificationsPage_MetadataStatus" xml:space="preserve">
+    <value>État</value>
+  </data>
+  <data name="NotificationsPage_MetadataSystemRun" xml:space="preserve">
+    <value>system.run</value>
   </data>
   <data name="Chat_Permission_Title" xml:space="preserve">
     <value>Approbation d'exécution requise</value>
@@ -5897,13 +6020,319 @@ Vérifiez vos paramètres de connexion et réessayez.</value>
     <value>Waiting for gateway health</value>
   </data>
   <data name="ConfigPage_CheckingConfigPermissions" xml:space="preserve">
-    <value>Checking config permissions</value>
+    <value>Vérification des autorisations de configuration</value>
   </data>
   <data name="ConfigPage_ConfigIsReadOnly" xml:space="preserve">
-    <value>Config is read-only</value>
+    <value>La configuration est en lecture seule</value>
   </data>
   <data name="ConfigPage_ConfigUnavailable" xml:space="preserve">
-    <value>Config unavailable</value>
+    <value>Configuration indisponible</value>
+  </data>
+  <data name="ConfigPage_EditingPathFormat" xml:space="preserve">
+    <value>Modification de {0} via le formulaire guidé par schéma.</value>
+  </data>
+  <data name="ConfigPage_RenderConfigUnavailableTitle" xml:space="preserve">
+    <value>Configuration indisponible</value>
+  </data>
+  <data name="ConfigPage_RenderConfigUnavailableMessage" xml:space="preserve">
+    <value>La configuration de la passerelle n'a pas pu être affichée. Actualisez et réessayez.</value>
+  </data>
+  <data name="ConfigPage_RenderSchemaUnavailableTitle" xml:space="preserve">
+    <value>Schéma indisponible</value>
+  </data>
+  <data name="ConfigPage_RenderSchemaUnavailableMessage" xml:space="preserve">
+    <value>Le schéma de la passerelle n'a pas pu être affiché. Le JSON brut reste disponible en aperçu en lecture seule.</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayRestartingTitle" xml:space="preserve">
+    <value>Redémarrage de la passerelle</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayRestartingMessage" xml:space="preserve">
+    <value>Enregistrement des modifications. La passerelle redémarre et se reconnectera automatiquement.</value>
+  </data>
+  <data name="ConfigPage_StatusNoChangesTitle" xml:space="preserve">
+    <value>Aucune modification</value>
+  </data>
+  <data name="ConfigPage_StatusNoChangesMessage" xml:space="preserve">
+    <value>Il n'y a rien à enregistrer.</value>
+  </data>
+  <data name="ConfigPage_StatusFixValidationErrorsTitle" xml:space="preserve">
+    <value>Corriger les erreurs de validation</value>
+  </data>
+  <data name="ConfigPage_StatusValidationErrorMessageFormat" xml:space="preserve">
+    <value>{0} : {1}</value>
+  </data>
+  <data name="ConfigPage_StatusNotConnectedTitle" xml:space="preserve">
+    <value>Non connecté</value>
+  </data>
+  <data name="ConfigPage_StatusNotConnectedMessage" xml:space="preserve">
+    <value>Connectez-vous à une passerelle avant d'enregistrer la configuration.</value>
+  </data>
+  <data name="ConfigPage_StatusReadOnlyMessage" xml:space="preserve">
+    <value>Ce jeton opérateur ne dispose pas de l'autorisation operator.write ; les modifications de configuration ne peuvent donc pas être enregistrées.</value>
+  </data>
+  <data name="ConfigPage_StatusConfigNotLoadedTitle" xml:space="preserve">
+    <value>Configuration non chargée</value>
+  </data>
+  <data name="ConfigPage_StatusConfigNotLoadedMessage" xml:space="preserve">
+    <value>Actualisez la configuration de la passerelle avant d'enregistrer.</value>
+  </data>
+  <data name="ConfigPage_StatusSavingConfigTitle" xml:space="preserve">
+    <value>Enregistrement de la configuration…</value>
+  </data>
+  <data name="ConfigPage_StatusSavingConfigMessageFormat" xml:space="preserve">
+    <value>Écriture de {0} modification(s) vers la passerelle.</value>
+  </data>
+  <data name="ConfigPage_StatusStaleConfigTitle" xml:space="preserve">
+    <value>La configuration de la passerelle a changé ailleurs</value>
+  </data>
+  <data name="ConfigPage_StatusStaleConfigMessageFormat" xml:space="preserve">
+    <value>Vos modifications sont conservées. La dernière configuration est en cours d'actualisation ; vérifiez le formulaire et réessayez Enregistrer. Détails : {0}</value>
+  </data>
+  <data name="ConfigPage_StatusStaleConfigDefaultDetail" xml:space="preserve">
+    <value>hachage de configuration obsolète</value>
+  </data>
+  <data name="ConfigPage_StatusSaveFailedTitle" xml:space="preserve">
+    <value>Échec de l'enregistrement</value>
+  </data>
+  <data name="ConfigPage_StatusSaveRejectedMessage" xml:space="preserve">
+    <value>La passerelle a rejeté la mise à jour de configuration. Vos modifications sont conservées.</value>
+  </data>
+  <data name="ConfigPage_StatusSaveExceptionMessageFormat" xml:space="preserve">
+    <value>{0} Vos modifications sont conservées.</value>
+  </data>
+  <data name="ConfigPage_SaveStatusCheckingConfigPermissions" xml:space="preserve">
+    <value>Vérification des autorisations de configuration…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusRefreshing" xml:space="preserve">
+    <value>Actualisation…</value>
+  </data>
+  <data name="ConfigPage_StatusChangesDiscardedTitle" xml:space="preserve">
+    <value>Modifications ignorées</value>
+  </data>
+  <data name="ConfigPage_StatusChangesDiscardedMessage" xml:space="preserve">
+    <value>Le formulaire est revenu à la dernière configuration chargée depuis la passerelle.</value>
+  </data>
+  <data name="ConfigPage_FullConfig" xml:space="preserve">
+    <value>Configuration complète</value>
+  </data>
+  <data name="ConfigPage_StatusSectionResetTitle" xml:space="preserve">
+    <value>Section réinitialisée</value>
+  </data>
+  <data name="ConfigPage_StatusSectionResetMessageFormat" xml:space="preserve">
+    <value>{0} est revenu à la dernière valeur chargée depuis la passerelle.</value>
+  </data>
+  <data name="ConfigPage_StatusCopiedJsonDiffTitle" xml:space="preserve">
+    <value>Diff JSON copié</value>
+  </data>
+  <data name="ConfigPage_StatusCopiedJsonDiffMessage" xml:space="preserve">
+    <value>Le diff de la section sélectionnée a été copié dans le presse-papiers.</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayReconnectedTitle" xml:space="preserve">
+    <value>Passerelle reconnectée</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayReconnectedRefreshingMessage" xml:space="preserve">
+    <value>Configuration enregistrée et connexion à la passerelle rétablie. Actualisation de la dernière configuration.</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayReconnectedLoadedMessage" xml:space="preserve">
+    <value>Configuration enregistrée et dernière configuration de la passerelle chargée.</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayStillReconnectingTitle" xml:space="preserve">
+    <value>La passerelle se reconnecte encore</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayStillReconnectingMessage" xml:space="preserve">
+    <value>L'enregistrement de la configuration a été accepté, mais la passerelle ne s'est pas encore reconnectée. Vous pouvez garder cette page ouverte ou utiliser Connexion pour vérifier l'état.</value>
+  </data>
+  <data name="ConfigPage_CheckingConfigPermissionsMessage" xml:space="preserve">
+    <value>En attente du rapport des autorisations de cet opérateur par la passerelle.</value>
+  </data>
+  <data name="ConfigPage_ConfigUnavailableMessage" xml:space="preserve">
+    <value>Ce jeton opérateur ne dispose pas de l'autorisation operator.read ; la configuration de la passerelle ne peut donc pas être chargée ici.</value>
+  </data>
+  <data name="ConfigPage_ConfigIsReadOnlyMessage" xml:space="preserve">
+    <value>Ce jeton opérateur peut lire la configuration, mais ne dispose pas de l'autorisation operator.write. Vous pouvez inspecter et valider les brouillons, mais Enregistrer est désactivé.</value>
+  </data>
+  <data name="ConfigPage_MetaNoUnsavedChanges" xml:space="preserve">
+    <value>Aucune modification non enregistrée.</value>
+  </data>
+  <data name="ConfigPage_MetaUnsavedChangesFormat" xml:space="preserve">
+    <value>{0} modification(s) non enregistrée(s)</value>
+  </data>
+  <data name="ConfigPage_MetaUnsavedChangesWithValidationFormat" xml:space="preserve">
+    <value>{0} modification(s) non enregistrée(s) · {1} problème(s) de validation</value>
+  </data>
+  <data name="ConfigPage_SaveStatusSaving" xml:space="preserve">
+    <value>Enregistrement…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusGatewayRestarting" xml:space="preserve">
+    <value>Redémarrage de la passerelle…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusConnectToGateway" xml:space="preserve">
+    <value>Connectez-vous à une passerelle pour modifier</value>
+  </data>
+  <data name="ConfigPage_SaveStatusCheckingPermissions" xml:space="preserve">
+    <value>Vérification des autorisations…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusMissingRead" xml:space="preserve">
+    <value>Configuration indisponible : operator.read manquant</value>
+  </data>
+  <data name="ConfigPage_SaveStatusReadOnlyMissingWrite" xml:space="preserve">
+    <value>Lecture seule : operator.write manquant</value>
+  </data>
+  <data name="ConfigPage_SaveStatusFixValidationBeforeSaving" xml:space="preserve">
+    <value>Corrigez les erreurs de validation avant d'enregistrer</value>
+  </data>
+  <data name="ConfigPage_SaveStatusUnsavedChanges" xml:space="preserve">
+    <value>Modifications non enregistrées</value>
+  </data>
+  <data name="ConfigPage_SaveStatusNoUnsavedChanges" xml:space="preserve">
+    <value>Aucune modification non enregistrée</value>
+  </data>
+  <data name="ConfigPage_AccessDisconnected" xml:space="preserve">
+    <value>Déconnecté</value>
+  </data>
+  <data name="ConfigPage_AccessChecking" xml:space="preserve">
+    <value>Vérification de l'accès</value>
+  </data>
+  <data name="ConfigPage_AccessNoRead" xml:space="preserve">
+    <value>Aucun accès en lecture à la configuration</value>
+  </data>
+  <data name="ConfigPage_AccessReadOnly" xml:space="preserve">
+    <value>Accès en lecture seule</value>
+  </data>
+  <data name="ConfigPage_AccessReadWrite" xml:space="preserve">
+    <value>Accès en lecture/écriture</value>
+  </data>
+  <data name="ConfigPage_AccessUnknown" xml:space="preserve">
+    <value>Accès inconnu</value>
+  </data>
+  <data name="ConfigPage_AccessChangesFormat" xml:space="preserve">
+    <value>{0} modification(s)</value>
+  </data>
+  <data name="ConfigPage_AccessValidationClean" xml:space="preserve">
+    <value>Validation locale correcte</value>
+  </data>
+  <data name="ConfigPage_AccessValidationIssuesFormat" xml:space="preserve">
+    <value>{0} problème(s) de validation</value>
+  </data>
+  <data name="ConfigPage_AccessSummaryFormat" xml:space="preserve">
+    <value>{0} · {1} · {2}</value>
+  </data>
+  <data name="DebugPage_NoGatewayConfigured" xml:space="preserve">
+    <value>aucune passerelle configurée</value>
+  </data>
+  <data name="DebugPage_StatusConnectedFormat" xml:space="preserve">
+    <value>OpenClaw est connecté à {0}.</value>
+  </data>
+  <data name="DebugPage_StatusConnectingFormat" xml:space="preserve">
+    <value>Connexion à {0}…</value>
+  </data>
+  <data name="DebugPage_StatusDisconnectedFormat" xml:space="preserve">
+    <value>Non connecté. Passerelle : {0}.</value>
+  </data>
+  <data name="DebugPage_StatusErrorFormat" xml:space="preserve">
+    <value>Dernière passerelle : {0}. Consultez la chronologie des événements.</value>
+  </data>
+  <data name="DebugPage_StatusGatewayFormat" xml:space="preserve">
+    <value>Passerelle : {0}.</value>
+  </data>
+  <data name="DebugPage_RecentLogTitle" xml:space="preserve">
+    <value>Journal récent</value>
+  </data>
+  <data name="DebugPage_RecentLogCaptionFormat" xml:space="preserve">
+    <value>Les 200 dernières lignes de {0}. La gravité est analysée à partir des balises [info]/[warn]/[error].</value>
+  </data>
+  <data name="DebugPage_CopyFeedbackFormat" xml:space="preserve">
+    <value>{0} copié dans le presse-papiers.</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableTitle" xml:space="preserve">
+    <value>Sandbox du nœud indisponible — les commandes s'exécutent sans confinement</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableSubtext" xml:space="preserve">
+    <value>Le confinement n'est pas disponible sur ce PC ; les commandes s'exécutent donc sans protection de sandbox.</value>
+  </data>
+  <data name="SandboxPage_StatusOnTitle" xml:space="preserve">
+    <value>Le Sandbox du nœud est activé</value>
+  </data>
+  <data name="SandboxPage_StatusOnSubtext" xml:space="preserve">
+    <value>Les programmes exécutés par l'agent sur ce PC sont confinés.</value>
+  </data>
+  <data name="SandboxPage_StatusOffTitle" xml:space="preserve">
+    <value>Le Sandbox du nœud est désactivé — risque élevé</value>
+  </data>
+  <data name="SandboxPage_StatusOffSubtext" xml:space="preserve">
+    <value>Les programmes exécutés par l'agent sur ce PC ne sont pas confinés.</value>
+  </data>
+  <data name="SandboxPage_UnavailableDefaultReason" xml:space="preserve">
+    <value>Les primitives de sandboxing MXC ne sont pas disponibles sur cette machine.</value>
+  </data>
+  <data name="SandboxPage_WindowsUnsupportedTitle" xml:space="preserve">
+    <value>Votre version de Windows ne prend pas encore en charge le sandboxing</value>
+  </data>
+  <data name="SandboxPage_WindowsUnsupportedMessageFormat" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;Les commandes s'exécutent sans confinement sur cette machine — le sandboxing nécessite une version récente de Windows avec les primitives AppContainer. Installez les dernières mises à jour Windows (ou rejoignez le programme Windows Insider pour les versions les plus récentes) afin d'activer le confinement.</value>
+  </data>
+  <data name="SandboxPage_OpenWindowsUpdate" xml:space="preserve">
+    <value>Ouvrir Windows Update</value>
+  </data>
+  <data name="SandboxPage_ComponentsMissingTitle" xml:space="preserve">
+    <value>Des composants de sandboxing sont manquants</value>
+  </data>
+  <data name="SandboxPage_ComponentsMissingMessageFormat" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;Le binaire wxc-exec est introuvable ; les commandes s'exécutent donc sans confinement. S'il s'agit d'une build développeur, compilez l'application Tray pour copier wxc-exec.exe dans le dossier de sortie. Sinon, réinstallez le compagnon pour restaurer le sandboxing.</value>
+  </data>
+  <data name="SandboxPage_ShowInstallInstructions" xml:space="preserve">
+    <value>Afficher les instructions d'installation</value>
+  </data>
+  <data name="SandboxPage_UnavailableTitle" xml:space="preserve">
+    <value>Sandbox indisponible — les commandes s'exécutent sans confinement</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovedTitle" xml:space="preserve">
+    <value>Passerelle locale supprimée</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovedMessage" xml:space="preserve">
+    <value>La configuration est réinitialisée ; vous pouvez relancer la configuration depuis le menu de la barre d'état.</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalErrorsMessage" xml:space="preserve">
+    <value>La suppression s'est terminée avec des erreurs. Consultez les journaux pour plus de détails.</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalCancelledTitle" xml:space="preserve">
+    <value>Suppression annulée</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalCancelledMessage" xml:space="preserve">
+    <value>La passerelle peut être dans un état partiellement supprimé. Consultez les journaux ou réessayez.</value>
+  </data>
+  <data name="SettingsPage_ViewLogs" xml:space="preserve">
+    <value>Afficher les journaux</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalFailedTitle" xml:space="preserve">
+    <value>Échec de la suppression</value>
+  </data>
+  <data name="SettingsPage_RemoveLocalGatewayButton" xml:space="preserve">
+    <value>Supprimer la passerelle locale</value>
+  </data>
+  <data name="SettingsPage_RemovingDistro" xml:space="preserve">
+    <value>Suppression de la distribution…</value>
+  </data>
+  <data name="SettingsPage_RemovingLocalGatewayMessage" xml:space="preserve">
+    <value>Suppression de la passerelle locale. Cela peut prendre 10 à 30 secondes…</value>
+  </data>
+  <data name="CronPage_NextWakeFormat" xml:space="preserve">
+    <value>· Prochain réveil : {0}</value>
+  </data>
+  <data name="ChatWindow_UnableToLoadChatCredentials" xml:space="preserve">
+    <value>Impossible de charger le chat. L'URL ou le jeton de la passerelle n'est pas disponible.</value>
+  </data>
+  <data name="ChatWindow_UnableToLoadChatRetryFormat" xml:space="preserve">
+    <value>Impossible de charger le chat. Réessayez. ({0})</value>
+  </data>
+  <data name="ChatWindow_WebViewFailedFormat" xml:space="preserve">
+    <value>Échec de WebView2 : {0}</value>
+  </data>
+  <data name="CanvasWindow_WebViewInitFailedFormat" xml:space="preserve">
+    <value>Échec de l'initialisation de WebView2 : {0}</value>
+  </data>
+  <data name="CanvasWindow_NavigationFailedFormat" xml:space="preserve">
+    <value>Échec de la navigation : {0}</value>
   </data>
   <data name="ConnectionPage_GatewayHostControlsDescription_Format" xml:space="preserve">
     <value>Open a shell or manage the local gateway service in {0}.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -3149,7 +3149,20 @@ Voer op uw gateway-host (Mac/Linux) uit:
     <value>Door agents gestarte Windows-opdrachten worden zonder sandboxbeperking uitgevoerd totdat Node-sandbox weer is ingeschakeld.</value>
   </data>
   <data name="AppNotification_SandboxUnavailable_Title" xml:space="preserve">
-    <value>Sandbox niet beschikbaar — opdrachten worden onbeperkt uitgevoerd</value>
+    <value>Sandbox niet beschikbaar — host-fallback</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailable_MessageFormat" xml:space="preserve">
+    <value>{0}
+
+Opdrachten worden op de host uitgevoerd zonder sandboxbescherming zolang sandboxing niet beschikbaar is.</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailableBlocked_Title" xml:space="preserve">
+    <value>Sandbox niet beschikbaar — opdrachten geblokkeerd</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailableBlocked_MessageFormat" xml:space="preserve">
+    <value>{0}
+
+Opdrachten worden geblokkeerd zolang sandboxing niet beschikbaar is, omdat strikte fallbackblokkering is ingeschakeld.</value>
   </data>
   <data name="AppNotification_SandboxUnavailable_DefaultReason" xml:space="preserve">
     <value>MXC-sandboxprimitieven zijn niet beschikbaar op deze machine.</value>
@@ -6246,10 +6259,22 @@ Controleer uw verbindingsinstellingen en probeer het opnieuw.</value>
     <value>{0} gekopieerd naar klembord.</value>
   </data>
   <data name="SandboxPage_StatusUnavailableTitle" xml:space="preserve">
-    <value>Node-sandbox niet beschikbaar — opdrachten worden onbeperkt uitgevoerd</value>
+    <value>Node-sandbox niet beschikbaar — host-fallback</value>
   </data>
   <data name="SandboxPage_StatusUnavailableSubtext" xml:space="preserve">
-    <value>Containment is niet beschikbaar op deze pc, dus opdrachten worden zonder sandboxbescherming uitgevoerd.</value>
+    <value>Containment is niet beschikbaar op deze pc, dus opdrachten die de agent start, worden op de host uitgevoerd zonder sandboxbescherming.</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableBlockedTitle" xml:space="preserve">
+    <value>Node-sandbox niet beschikbaar — opdrachten geblokkeerd</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableBlockedSubtext" xml:space="preserve">
+    <value>Containment is niet beschikbaar op deze pc en strikte fallbackblokkering staat aan, dus opdrachten die de agent start, worden geblokkeerd.</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableOffTitle" xml:space="preserve">
+    <value>Node-sandbox is uitgeschakeld — hostuitvoering</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableOffSubtext" xml:space="preserve">
+    <value>Containment is niet beschikbaar en Node-sandbox is uitgeschakeld, dus opdrachten die de agent start, worden op de host uitgevoerd zonder sandboxbescherming.</value>
   </data>
   <data name="SandboxPage_StatusOnTitle" xml:space="preserve">
     <value>Node-sandbox is ingeschakeld</value>
@@ -6266,11 +6291,29 @@ Controleer uw verbindingsinstellingen en probeer het opnieuw.</value>
   <data name="SandboxPage_UnavailableDefaultReason" xml:space="preserve">
     <value>MXC-sandboxprimitieven zijn niet beschikbaar op deze machine.</value>
   </data>
+  <data name="SandboxPage_ProbeErrorReason" xml:space="preserve">
+    <value>Kan de beschikbaarheid van de sandbox niet controleren.</value>
+  </data>
+  <data name="SandboxPage_UnavailableBehaviorHostFallback" xml:space="preserve">
+    <value>Opdrachten worden op de host uitgevoerd zonder sandboxbescherming zolang sandboxing niet beschikbaar is.</value>
+  </data>
+  <data name="SandboxPage_UnavailableBehaviorBlocked" xml:space="preserve">
+    <value>Opdrachten worden geblokkeerd zolang sandboxing niet beschikbaar is, omdat strikte fallbackblokkering is ingeschakeld.</value>
+  </data>
+  <data name="SandboxPage_ProbeErrorTitle" xml:space="preserve">
+    <value>Kan de beschikbaarheid van de sandbox niet verifiëren</value>
+  </data>
+  <data name="SandboxPage_ProbeErrorMessageFormat" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;{1} De sandboxcapaciteitscontrole is niet voltooid. Dit is meestal tijdelijk (een trage of geblokkeerde controle) — probeer het opnieuw en controleer, als het probleem blijft bestaan, of beveiligingssoftware wxc-exec blokkeert.</value>
+  </data>
+  <data name="SandboxPage_Retry" xml:space="preserve">
+    <value>Opnieuw proberen</value>
+  </data>
   <data name="SandboxPage_WindowsUnsupportedTitle" xml:space="preserve">
     <value>Uw Windows-versie ondersteunt sandboxing nog niet</value>
   </data>
   <data name="SandboxPage_WindowsUnsupportedMessageFormat" xml:space="preserve">
-    <value>{0}&#x0A;&#x0A;Opdrachten worden onbeperkt op deze machine uitgevoerd — sandboxing vereist een recente Windows-build met de AppContainer-primitieven. Installeer de nieuwste Windows-updates (of neem deel aan het Windows Insider-programma voor de nieuwste builds) om containment in te schakelen.</value>
+    <value>{0}&#x0A;&#x0A;{1} Sandboxing vereist een recente Windows-build met de AppContainer-primitieven. Installeer de nieuwste Windows-updates (of neem deel aan het Windows Insider-programma voor de nieuwste builds) om containment in te schakelen.</value>
   </data>
   <data name="SandboxPage_OpenWindowsUpdate" xml:space="preserve">
     <value>Windows Update openen</value>
@@ -6279,13 +6322,16 @@ Controleer uw verbindingsinstellingen en probeer het opnieuw.</value>
     <value>Sandboxing-onderdelen ontbreken</value>
   </data>
   <data name="SandboxPage_ComponentsMissingMessageFormat" xml:space="preserve">
-    <value>{0}&#x0A;&#x0A;Het binaire bestand wxc-exec is niet gevonden, dus opdrachten worden onbeperkt uitgevoerd. Als dit een ontwikkelaarsbuild is, bouw dan de tray-app zodat wxc-exec.exe naar de uitvoermap wordt gekopieerd. Installeer anders de companion-app opnieuw om sandboxing te herstellen.</value>
+    <value>{0}&#x0A;&#x0A;Het binaire bestand wxc-exec is niet gevonden. {1} Als dit een ontwikkelaarsbuild is, bouw dan de tray-app zodat wxc-exec.exe naar de uitvoermap wordt gekopieerd. Installeer anders de companion-app opnieuw om sandboxing te herstellen.</value>
   </data>
   <data name="SandboxPage_ShowInstallInstructions" xml:space="preserve">
     <value>Installatie-instructies weergeven</value>
   </data>
   <data name="SandboxPage_UnavailableTitle" xml:space="preserve">
-    <value>Sandbox niet beschikbaar — opdrachten worden onbeperkt uitgevoerd</value>
+    <value>Sandbox niet beschikbaar — host-fallback</value>
+  </data>
+  <data name="SandboxPage_UnavailableBlockedTitle" xml:space="preserve">
+    <value>Sandbox niet beschikbaar — opdrachten geblokkeerd</value>
   </data>
   <data name="SettingsPage_LocalGatewayRemovedTitle" xml:space="preserve">
     <value>Lokale gateway verwijderd</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -3094,6 +3094,78 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="AppNotification_ShowMore" xml:space="preserve">
     <value>Meer weergeven</value>
   </data>
+  <data name="AppNotification_ActionOpenConnection" xml:space="preserve">
+    <value>Verbinding openen</value>
+  </data>
+  <data name="AppNotification_ActionOpenChannels" xml:space="preserve">
+    <value>Kanalen openen</value>
+  </data>
+  <data name="AppNotification_ActionOpenSandbox" xml:space="preserve">
+    <value>Sandbox openen</value>
+  </data>
+  <data name="AppNotification_ActionOpenCron" xml:space="preserve">
+    <value>Cron openen</value>
+  </data>
+  <data name="AppNotification_GatewayAuthenticationFailed_Title" xml:space="preserve">
+    <value>Gatewayverificatie mislukt</value>
+  </data>
+  <data name="AppNotification_GatewayConnectionFailed_Title" xml:space="preserve">
+    <value>Gatewayverbinding mislukt</value>
+  </data>
+  <data name="AppNotification_GatewayConnectionFailed_DefaultMessage" xml:space="preserve">
+    <value>OpenClaw kon geen verbinding maken met de actieve gateway.</value>
+  </data>
+  <data name="AppNotification_GatewayPairingRequired_Title" xml:space="preserve">
+    <value>Goedkeuring voor gatewaykoppeling vereist</value>
+  </data>
+  <data name="AppNotification_GatewayPairingRequired_GenericMessage" xml:space="preserve">
+    <value>Open Verbinding om de gatewaykoppeling te voltooien.</value>
+  </data>
+  <data name="AppNotification_GatewayPairingRequired_DeviceMessageFormat" xml:space="preserve">
+    <value>Open Verbinding om apparaat {0} goed te keuren.</value>
+  </data>
+  <data name="AppNotification_WindowsNodeConnectionFailed_Title" xml:space="preserve">
+    <value>Windows-nodeverbinding mislukt</value>
+  </data>
+  <data name="AppNotification_WindowsNodeConnectionFailed_DefaultMessage" xml:space="preserve">
+    <value>De gateway is verbonden, maar deze Windows-node is niet beschikbaar.</value>
+  </data>
+  <data name="AppNotification_WindowsNodeRateLimited_Title" xml:space="preserve">
+    <value>Windows-nodeverbinding beperkt</value>
+  </data>
+  <data name="AppNotification_WindowsNodeRateLimited_DefaultMessage" xml:space="preserve">
+    <value>De gateway is verbonden, maar deze Windows-node is tijdelijk beperkt.</value>
+  </data>
+  <data name="AppNotification_ChannelNeedsAttention_TitleFormat" xml:space="preserve">
+    <value>Kanaal {0} heeft aandacht nodig</value>
+  </data>
+  <data name="AppNotification_ChannelNeedsAttention_StatusMessageFormat" xml:space="preserve">
+    <value>De gateway meldt {0} als {1}.</value>
+  </data>
+  <data name="AppNotification_SandboxDisabled_Title" xml:space="preserve">
+    <value>Node-sandbox is uitgeschakeld — opdrachten worden onbeperkt uitgevoerd</value>
+  </data>
+  <data name="AppNotification_SandboxDisabled_Message" xml:space="preserve">
+    <value>Door agents gestarte Windows-opdrachten worden zonder sandboxbeperking uitgevoerd totdat Node-sandbox weer is ingeschakeld.</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailable_Title" xml:space="preserve">
+    <value>Sandbox niet beschikbaar — opdrachten worden onbeperkt uitgevoerd</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailable_DefaultReason" xml:space="preserve">
+    <value>MXC-sandboxprimitieven zijn niet beschikbaar op deze machine.</value>
+  </data>
+  <data name="AppNotification_CronRunFailed_Title" xml:space="preserve">
+    <value>Cron-taak is niet gestart</value>
+  </data>
+  <data name="AppNotification_CronRunFailed_DefaultDetail" xml:space="preserve">
+    <value>De aanvraag is mislukt.</value>
+  </data>
+  <data name="AppNotification_CronRunRejectedDetail" xml:space="preserve">
+    <value>De gateway heeft de cron.run-aanvraag geweigerd.</value>
+  </data>
+  <data name="AppNotification_CronRunFailed_MessageFormat" xml:space="preserve">
+    <value>{0} — {1}</value>
+  </data>
   <data name="NotificationsPage_Title.Text" xml:space="preserve">
     <value>Meldingen</value>
   </data>
@@ -3141,6 +3213,57 @@ Voer op uw gateway-host (Mac/Linux) uit:
   </data>
   <data name="AppNotification_ExecApprovalPending_AgentSlotLabelFormat" xml:space="preserve">
     <value>{0} / {1}</value>
+  </data>
+  <data name="NotificationsPage_MetadataAuthentication" xml:space="preserve">
+    <value>Verificatie</value>
+  </data>
+  <data name="NotificationsPage_MetadataBindings" xml:space="preserve">
+    <value>Bindingen</value>
+  </data>
+  <data name="NotificationsPage_MetadataChannels" xml:space="preserve">
+    <value>Kanalen</value>
+  </data>
+  <data name="NotificationsPage_MetadataConfig" xml:space="preserve">
+    <value>Configuratie</value>
+  </data>
+  <data name="NotificationsPage_MetadataConnection" xml:space="preserve">
+    <value>Verbinding</value>
+  </data>
+  <data name="NotificationsPage_MetadataCron" xml:space="preserve">
+    <value>Cron</value>
+  </data>
+  <data name="NotificationsPage_MetadataGateway" xml:space="preserve">
+    <value>Gatewaydienst</value>
+  </data>
+  <data name="NotificationsPage_MetadataJobs" xml:space="preserve">
+    <value>Taken</value>
+  </data>
+  <data name="NotificationsPage_MetadataLoad" xml:space="preserve">
+    <value>Laden</value>
+  </data>
+  <data name="NotificationsPage_MetadataLifecycle" xml:space="preserve">
+    <value>Levenscyclus</value>
+  </data>
+  <data name="NotificationsPage_MetadataLocalGateway" xml:space="preserve">
+    <value>Lokale gateway</value>
+  </data>
+  <data name="NotificationsPage_MetadataNode" xml:space="preserve">
+    <value>Knooppunt</value>
+  </data>
+  <data name="NotificationsPage_MetadataPairing" xml:space="preserve">
+    <value>Koppeling</value>
+  </data>
+  <data name="NotificationsPage_MetadataSandbox" xml:space="preserve">
+    <value>Zandbak</value>
+  </data>
+  <data name="NotificationsPage_MetadataSettings" xml:space="preserve">
+    <value>Instellingen</value>
+  </data>
+  <data name="NotificationsPage_MetadataStatus" xml:space="preserve">
+    <value>Toestand</value>
+  </data>
+  <data name="NotificationsPage_MetadataSystemRun" xml:space="preserve">
+    <value>system.run</value>
   </data>
   <data name="Chat_Permission_Title" xml:space="preserve">
     <value>Goedkeuring voor uitvoering vereist</value>
@@ -5898,13 +6021,319 @@ Controleer uw verbindingsinstellingen en probeer het opnieuw.</value>
     <value>Waiting for gateway health</value>
   </data>
   <data name="ConfigPage_CheckingConfigPermissions" xml:space="preserve">
-    <value>Checking config permissions</value>
+    <value>Configuratiemachtigingen controleren</value>
   </data>
   <data name="ConfigPage_ConfigIsReadOnly" xml:space="preserve">
-    <value>Config is read-only</value>
+    <value>Configuratie is alleen-lezen</value>
   </data>
   <data name="ConfigPage_ConfigUnavailable" xml:space="preserve">
-    <value>Config unavailable</value>
+    <value>Configuratie niet beschikbaar</value>
+  </data>
+  <data name="ConfigPage_EditingPathFormat" xml:space="preserve">
+    <value>{0} bewerken via schema-gestuurd formulier.</value>
+  </data>
+  <data name="ConfigPage_RenderConfigUnavailableTitle" xml:space="preserve">
+    <value>Configuratie niet beschikbaar</value>
+  </data>
+  <data name="ConfigPage_RenderConfigUnavailableMessage" xml:space="preserve">
+    <value>De gatewayconfiguratie kon niet worden weergegeven. Vernieuw en probeer het opnieuw.</value>
+  </data>
+  <data name="ConfigPage_RenderSchemaUnavailableTitle" xml:space="preserve">
+    <value>Schema niet beschikbaar</value>
+  </data>
+  <data name="ConfigPage_RenderSchemaUnavailableMessage" xml:space="preserve">
+    <value>Het gatewayschema kon niet worden weergegeven. Ruwe JSON blijft beschikbaar als alleen-lezen voorbeeld.</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayRestartingTitle" xml:space="preserve">
+    <value>Gateway wordt opnieuw gestart</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayRestartingMessage" xml:space="preserve">
+    <value>Wijzigingen worden opgeslagen. De gateway wordt opnieuw gestart en maakt automatisch opnieuw verbinding.</value>
+  </data>
+  <data name="ConfigPage_StatusNoChangesTitle" xml:space="preserve">
+    <value>Geen wijzigingen</value>
+  </data>
+  <data name="ConfigPage_StatusNoChangesMessage" xml:space="preserve">
+    <value>Er is niets om op te slaan.</value>
+  </data>
+  <data name="ConfigPage_StatusFixValidationErrorsTitle" xml:space="preserve">
+    <value>Validatiefouten oplossen</value>
+  </data>
+  <data name="ConfigPage_StatusValidationErrorMessageFormat" xml:space="preserve">
+    <value>{0} — {1}</value>
+  </data>
+  <data name="ConfigPage_StatusNotConnectedTitle" xml:space="preserve">
+    <value>Niet verbonden</value>
+  </data>
+  <data name="ConfigPage_StatusNotConnectedMessage" xml:space="preserve">
+    <value>Maak verbinding met een gateway voordat u de configuratie opslaat.</value>
+  </data>
+  <data name="ConfigPage_StatusReadOnlyMessage" xml:space="preserve">
+    <value>Dit operatortoken heeft geen operator.write-machtiging, dus configuratiewijzigingen kunnen niet worden opgeslagen.</value>
+  </data>
+  <data name="ConfigPage_StatusConfigNotLoadedTitle" xml:space="preserve">
+    <value>Configuratie niet geladen</value>
+  </data>
+  <data name="ConfigPage_StatusConfigNotLoadedMessage" xml:space="preserve">
+    <value>Vernieuw de gatewayconfiguratie voordat u opslaat.</value>
+  </data>
+  <data name="ConfigPage_StatusSavingConfigTitle" xml:space="preserve">
+    <value>Configuratie opslaan…</value>
+  </data>
+  <data name="ConfigPage_StatusSavingConfigMessageFormat" xml:space="preserve">
+    <value>{0} wijziging(en) naar de gateway schrijven.</value>
+  </data>
+  <data name="ConfigPage_StatusStaleConfigTitle" xml:space="preserve">
+    <value>Gatewayconfiguratie is elders gewijzigd</value>
+  </data>
+  <data name="ConfigPage_StatusStaleConfigMessageFormat" xml:space="preserve">
+    <value>Uw bewerkingen blijven behouden. De nieuwste configuratie wordt vernieuwd; controleer het formulier en probeer opnieuw op te slaan. Details: {0}</value>
+  </data>
+  <data name="ConfigPage_StatusStaleConfigDefaultDetail" xml:space="preserve">
+    <value>verouderde configuratiehash</value>
+  </data>
+  <data name="ConfigPage_StatusSaveFailedTitle" xml:space="preserve">
+    <value>Opslaan mislukt</value>
+  </data>
+  <data name="ConfigPage_StatusSaveRejectedMessage" xml:space="preserve">
+    <value>De gateway heeft de configuratie-update geweigerd. Uw wijzigingen blijven behouden.</value>
+  </data>
+  <data name="ConfigPage_StatusSaveExceptionMessageFormat" xml:space="preserve">
+    <value>{0} Uw wijzigingen blijven behouden.</value>
+  </data>
+  <data name="ConfigPage_SaveStatusCheckingConfigPermissions" xml:space="preserve">
+    <value>Configuratiemachtigingen controleren…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusRefreshing" xml:space="preserve">
+    <value>Vernieuwen…</value>
+  </data>
+  <data name="ConfigPage_StatusChangesDiscardedTitle" xml:space="preserve">
+    <value>Wijzigingen genegeerd</value>
+  </data>
+  <data name="ConfigPage_StatusChangesDiscardedMessage" xml:space="preserve">
+    <value>Het formulier is teruggezet naar de laatst geladen configuratie van de gateway.</value>
+  </data>
+  <data name="ConfigPage_FullConfig" xml:space="preserve">
+    <value>Volledige configuratie</value>
+  </data>
+  <data name="ConfigPage_StatusSectionResetTitle" xml:space="preserve">
+    <value>Sectie opnieuw ingesteld</value>
+  </data>
+  <data name="ConfigPage_StatusSectionResetMessageFormat" xml:space="preserve">
+    <value>{0} is teruggezet naar de laatst geladen gatewaywaarde.</value>
+  </data>
+  <data name="ConfigPage_StatusCopiedJsonDiffTitle" xml:space="preserve">
+    <value>JSON-diff gekopieerd</value>
+  </data>
+  <data name="ConfigPage_StatusCopiedJsonDiffMessage" xml:space="preserve">
+    <value>De diff van de geselecteerde sectie is naar het klembord gekopieerd.</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayReconnectedTitle" xml:space="preserve">
+    <value>Gateway opnieuw verbonden</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayReconnectedRefreshingMessage" xml:space="preserve">
+    <value>Configuratie opgeslagen en de gatewayverbinding is terug. De nieuwste configuratie wordt vernieuwd.</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayReconnectedLoadedMessage" xml:space="preserve">
+    <value>Configuratie opgeslagen en de nieuwste gatewayconfiguratie is geladen.</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayStillReconnectingTitle" xml:space="preserve">
+    <value>Gateway maakt nog steeds opnieuw verbinding</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayStillReconnectingMessage" xml:space="preserve">
+    <value>Het opslaan van de configuratie is geaccepteerd, maar de gateway heeft nog geen nieuwe verbinding gemaakt. U kunt deze pagina open houden of Verbinding gebruiken om de status te controleren.</value>
+  </data>
+  <data name="ConfigPage_CheckingConfigPermissionsMessage" xml:space="preserve">
+    <value>Wachten tot de gateway de machtigingen van deze operator meldt.</value>
+  </data>
+  <data name="ConfigPage_ConfigUnavailableMessage" xml:space="preserve">
+    <value>Dit operatortoken mist de operator.read-machtiging, dus de gatewayconfiguratie kan hier niet worden geladen.</value>
+  </data>
+  <data name="ConfigPage_ConfigIsReadOnlyMessage" xml:space="preserve">
+    <value>Dit operatortoken kan de configuratie lezen, maar mist de operator.write-machtiging. U kunt concepten bekijken en valideren, maar Opslaan is uitgeschakeld.</value>
+  </data>
+  <data name="ConfigPage_MetaNoUnsavedChanges" xml:space="preserve">
+    <value>Geen niet-opgeslagen wijzigingen.</value>
+  </data>
+  <data name="ConfigPage_MetaUnsavedChangesFormat" xml:space="preserve">
+    <value>{0} niet-opgeslagen wijziging(en)</value>
+  </data>
+  <data name="ConfigPage_MetaUnsavedChangesWithValidationFormat" xml:space="preserve">
+    <value>{0} niet-opgeslagen wijziging(en) · {1} validatieproble(e)m(en)</value>
+  </data>
+  <data name="ConfigPage_SaveStatusSaving" xml:space="preserve">
+    <value>Opslaan…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusGatewayRestarting" xml:space="preserve">
+    <value>Gateway wordt opnieuw gestart…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusConnectToGateway" xml:space="preserve">
+    <value>Maak verbinding met een gateway om te bewerken</value>
+  </data>
+  <data name="ConfigPage_SaveStatusCheckingPermissions" xml:space="preserve">
+    <value>Machtigingen controleren…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusMissingRead" xml:space="preserve">
+    <value>Configuratie niet beschikbaar: operator.read ontbreekt</value>
+  </data>
+  <data name="ConfigPage_SaveStatusReadOnlyMissingWrite" xml:space="preserve">
+    <value>Alleen-lezen: operator.write ontbreekt</value>
+  </data>
+  <data name="ConfigPage_SaveStatusFixValidationBeforeSaving" xml:space="preserve">
+    <value>Los validatiefouten op voordat u opslaat</value>
+  </data>
+  <data name="ConfigPage_SaveStatusUnsavedChanges" xml:space="preserve">
+    <value>Niet-opgeslagen wijzigingen</value>
+  </data>
+  <data name="ConfigPage_SaveStatusNoUnsavedChanges" xml:space="preserve">
+    <value>Geen niet-opgeslagen wijzigingen</value>
+  </data>
+  <data name="ConfigPage_AccessDisconnected" xml:space="preserve">
+    <value>Verbinding verbroken</value>
+  </data>
+  <data name="ConfigPage_AccessChecking" xml:space="preserve">
+    <value>Toegang controleren</value>
+  </data>
+  <data name="ConfigPage_AccessNoRead" xml:space="preserve">
+    <value>Geen leestoegang tot configuratie</value>
+  </data>
+  <data name="ConfigPage_AccessReadOnly" xml:space="preserve">
+    <value>Alleen-lezen toegang</value>
+  </data>
+  <data name="ConfigPage_AccessReadWrite" xml:space="preserve">
+    <value>Lees-/schrijftoegang</value>
+  </data>
+  <data name="ConfigPage_AccessUnknown" xml:space="preserve">
+    <value>Onbekende toegang</value>
+  </data>
+  <data name="ConfigPage_AccessChangesFormat" xml:space="preserve">
+    <value>{0} wijziging(en)</value>
+  </data>
+  <data name="ConfigPage_AccessValidationClean" xml:space="preserve">
+    <value>Lokale validatie in orde</value>
+  </data>
+  <data name="ConfigPage_AccessValidationIssuesFormat" xml:space="preserve">
+    <value>{0} validatieproble(e)m(en)</value>
+  </data>
+  <data name="ConfigPage_AccessSummaryFormat" xml:space="preserve">
+    <value>{0} · {1} · {2}</value>
+  </data>
+  <data name="DebugPage_NoGatewayConfigured" xml:space="preserve">
+    <value>geen gateway geconfigureerd</value>
+  </data>
+  <data name="DebugPage_StatusConnectedFormat" xml:space="preserve">
+    <value>OpenClaw is verbonden met {0}.</value>
+  </data>
+  <data name="DebugPage_StatusConnectingFormat" xml:space="preserve">
+    <value>Verbinding maken met {0}…</value>
+  </data>
+  <data name="DebugPage_StatusDisconnectedFormat" xml:space="preserve">
+    <value>Niet verbonden. Gateway: {0}.</value>
+  </data>
+  <data name="DebugPage_StatusErrorFormat" xml:space="preserve">
+    <value>Laatste gateway: {0}. Bekijk de gebeurtenistijdlijn.</value>
+  </data>
+  <data name="DebugPage_StatusGatewayFormat" xml:space="preserve">
+    <value>Gatewaydienst: {0}.</value>
+  </data>
+  <data name="DebugPage_RecentLogTitle" xml:space="preserve">
+    <value>Recent logboek</value>
+  </data>
+  <data name="DebugPage_RecentLogCaptionFormat" xml:space="preserve">
+    <value>Laatste 200 regels van {0}. Ernst wordt afgeleid uit [info]/[warn]/[error]-tags.</value>
+  </data>
+  <data name="DebugPage_CopyFeedbackFormat" xml:space="preserve">
+    <value>{0} gekopieerd naar klembord.</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableTitle" xml:space="preserve">
+    <value>Node-sandbox niet beschikbaar — opdrachten worden onbeperkt uitgevoerd</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableSubtext" xml:space="preserve">
+    <value>Containment is niet beschikbaar op deze pc, dus opdrachten worden zonder sandboxbescherming uitgevoerd.</value>
+  </data>
+  <data name="SandboxPage_StatusOnTitle" xml:space="preserve">
+    <value>Node-sandbox is ingeschakeld</value>
+  </data>
+  <data name="SandboxPage_StatusOnSubtext" xml:space="preserve">
+    <value>Programma's die de agent op deze pc uitvoert, zijn ingesloten.</value>
+  </data>
+  <data name="SandboxPage_StatusOffTitle" xml:space="preserve">
+    <value>Node-sandbox is uitgeschakeld — hoog risico</value>
+  </data>
+  <data name="SandboxPage_StatusOffSubtext" xml:space="preserve">
+    <value>Programma's die de agent op deze pc uitvoert, zijn niet ingesloten.</value>
+  </data>
+  <data name="SandboxPage_UnavailableDefaultReason" xml:space="preserve">
+    <value>MXC-sandboxprimitieven zijn niet beschikbaar op deze machine.</value>
+  </data>
+  <data name="SandboxPage_WindowsUnsupportedTitle" xml:space="preserve">
+    <value>Uw Windows-versie ondersteunt sandboxing nog niet</value>
+  </data>
+  <data name="SandboxPage_WindowsUnsupportedMessageFormat" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;Opdrachten worden onbeperkt op deze machine uitgevoerd — sandboxing vereist een recente Windows-build met de AppContainer-primitieven. Installeer de nieuwste Windows-updates (of neem deel aan het Windows Insider-programma voor de nieuwste builds) om containment in te schakelen.</value>
+  </data>
+  <data name="SandboxPage_OpenWindowsUpdate" xml:space="preserve">
+    <value>Windows Update openen</value>
+  </data>
+  <data name="SandboxPage_ComponentsMissingTitle" xml:space="preserve">
+    <value>Sandboxing-onderdelen ontbreken</value>
+  </data>
+  <data name="SandboxPage_ComponentsMissingMessageFormat" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;Het binaire bestand wxc-exec is niet gevonden, dus opdrachten worden onbeperkt uitgevoerd. Als dit een ontwikkelaarsbuild is, bouw dan de tray-app zodat wxc-exec.exe naar de uitvoermap wordt gekopieerd. Installeer anders de companion-app opnieuw om sandboxing te herstellen.</value>
+  </data>
+  <data name="SandboxPage_ShowInstallInstructions" xml:space="preserve">
+    <value>Installatie-instructies weergeven</value>
+  </data>
+  <data name="SandboxPage_UnavailableTitle" xml:space="preserve">
+    <value>Sandbox niet beschikbaar — opdrachten worden onbeperkt uitgevoerd</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovedTitle" xml:space="preserve">
+    <value>Lokale gateway verwijderd</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovedMessage" xml:space="preserve">
+    <value>Setup is opnieuw ingesteld; u kunt setup opnieuw uitvoeren vanuit het traymenu.</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalErrorsMessage" xml:space="preserve">
+    <value>Verwijderen is voltooid met fouten. Controleer de logboeken voor details.</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalCancelledTitle" xml:space="preserve">
+    <value>Verwijderen geannuleerd</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalCancelledMessage" xml:space="preserve">
+    <value>Gateway bevindt zich mogelijk in een gedeeltelijk verwijderde staat. Controleer logboeken of probeer opnieuw.</value>
+  </data>
+  <data name="SettingsPage_ViewLogs" xml:space="preserve">
+    <value>Logboeken weergeven</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalFailedTitle" xml:space="preserve">
+    <value>Verwijderen mislukt</value>
+  </data>
+  <data name="SettingsPage_RemoveLocalGatewayButton" xml:space="preserve">
+    <value>Lokale gateway verwijderen</value>
+  </data>
+  <data name="SettingsPage_RemovingDistro" xml:space="preserve">
+    <value>Distro verwijderen…</value>
+  </data>
+  <data name="SettingsPage_RemovingLocalGatewayMessage" xml:space="preserve">
+    <value>De lokale gateway wordt verwijderd. Dit kan 10–30 seconden duren…</value>
+  </data>
+  <data name="CronPage_NextWakeFormat" xml:space="preserve">
+    <value>· Volgende wake: {0}</value>
+  </data>
+  <data name="ChatWindow_UnableToLoadChatCredentials" xml:space="preserve">
+    <value>Kan chat niet laden. De gateway-URL of het token is niet beschikbaar.</value>
+  </data>
+  <data name="ChatWindow_UnableToLoadChatRetryFormat" xml:space="preserve">
+    <value>Kan chat niet laden. Probeer het opnieuw. ({0})</value>
+  </data>
+  <data name="ChatWindow_WebViewFailedFormat" xml:space="preserve">
+    <value>WebView2 is mislukt: {0}</value>
+  </data>
+  <data name="CanvasWindow_WebViewInitFailedFormat" xml:space="preserve">
+    <value>Kan WebView2 niet initialiseren: {0}</value>
+  </data>
+  <data name="CanvasWindow_NavigationFailedFormat" xml:space="preserve">
+    <value>Navigatie mislukt: {0}</value>
   </data>
   <data name="ConnectionPage_GatewayHostControlsDescription_Format" xml:space="preserve">
     <value>Open a shell or manage the local gateway service in {0}.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -3148,7 +3148,20 @@
     <value>在重新启用节点沙盒之前，代理启动的 Windows 命令将在没有沙盒隔离的情况下运行。</value>
   </data>
   <data name="AppNotification_SandboxUnavailable_Title" xml:space="preserve">
-    <value>沙盒不可用 — 命令将不受限制地运行</value>
+    <value>沙盒不可用 — 回退到主机</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailable_MessageFormat" xml:space="preserve">
+    <value>{0}
+
+在沙盒不可用期间，命令将在主机上运行，且没有沙盒保护。</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailableBlocked_Title" xml:space="preserve">
+    <value>沙盒不可用 — 命令已阻止</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailableBlocked_MessageFormat" xml:space="preserve">
+    <value>{0}
+
+由于已启用严格回退阻止，沙盒不可用期间命令会被阻止。</value>
   </data>
   <data name="AppNotification_SandboxUnavailable_DefaultReason" xml:space="preserve">
     <value>此计算机上没有可用的 MXC 沙盒基元。</value>
@@ -6246,10 +6259,22 @@
     <value>{0} 已复制到剪贴板。</value>
   </data>
   <data name="SandboxPage_StatusUnavailableTitle" xml:space="preserve">
-    <value>节点沙盒不可用 — 命令将不受限制地运行</value>
+    <value>节点沙盒不可用 — 回退到主机</value>
   </data>
   <data name="SandboxPage_StatusUnavailableSubtext" xml:space="preserve">
-    <value>此电脑上无法使用隔离，因此命令将在没有沙盒保护的情况下运行。</value>
+    <value>此电脑上无法使用隔离，因此代理启动的命令会在主机上运行，且没有沙盒保护。</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableBlockedTitle" xml:space="preserve">
+    <value>节点沙盒不可用 — 命令已阻止</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableBlockedSubtext" xml:space="preserve">
+    <value>此电脑上无法使用隔离，并且已启用严格回退阻止，因此代理启动的命令会被阻止。</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableOffTitle" xml:space="preserve">
+    <value>节点沙盒已关闭 — 主机执行</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableOffSubtext" xml:space="preserve">
+    <value>隔离不可用且节点沙盒已关闭，因此代理启动的命令会在主机上运行，且没有沙盒保护。</value>
   </data>
   <data name="SandboxPage_StatusOnTitle" xml:space="preserve">
     <value>节点沙盒已开启</value>
@@ -6266,11 +6291,29 @@
   <data name="SandboxPage_UnavailableDefaultReason" xml:space="preserve">
     <value>此计算机上没有可用的 MXC 沙盒基元。</value>
   </data>
+  <data name="SandboxPage_ProbeErrorReason" xml:space="preserve">
+    <value>无法检查沙盒可用性。</value>
+  </data>
+  <data name="SandboxPage_UnavailableBehaviorHostFallback" xml:space="preserve">
+    <value>在沙盒不可用期间，命令将在主机上运行，且没有沙盒保护。</value>
+  </data>
+  <data name="SandboxPage_UnavailableBehaviorBlocked" xml:space="preserve">
+    <value>由于已启用严格回退阻止，沙盒不可用期间命令会被阻止。</value>
+  </data>
+  <data name="SandboxPage_ProbeErrorTitle" xml:space="preserve">
+    <value>无法验证沙盒可用性</value>
+  </data>
+  <data name="SandboxPage_ProbeErrorMessageFormat" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;{1} 沙盒功能检查未完成。这通常是暂时性的（检查缓慢或被阻止）— 请重试；如果问题仍然存在，请检查安全软件是否阻止了 wxc-exec。</value>
+  </data>
+  <data name="SandboxPage_Retry" xml:space="preserve">
+    <value>重试</value>
+  </data>
   <data name="SandboxPage_WindowsUnsupportedTitle" xml:space="preserve">
     <value>你的 Windows 版本尚不支持沙盒</value>
   </data>
   <data name="SandboxPage_WindowsUnsupportedMessageFormat" xml:space="preserve">
-    <value>{0}&#x0A;&#x0A;此计算机上的命令将不受限制地运行 — 沙盒需要包含 AppContainer 基元的较新 Windows 版本。请安装最新 Windows 更新（或加入 Windows 预览体验计划以获取最新版本）以启用隔离。</value>
+    <value>{0}&#x0A;&#x0A;{1} 沙盒需要包含 AppContainer 基元的较新 Windows 版本。请安装最新 Windows 更新（或加入 Windows 预览体验计划以获取最新版本）以启用隔离。</value>
   </data>
   <data name="SandboxPage_OpenWindowsUpdate" xml:space="preserve">
     <value>打开 Windows 更新</value>
@@ -6279,13 +6322,16 @@
     <value>缺少沙盒组件</value>
   </data>
   <data name="SandboxPage_ComponentsMissingMessageFormat" xml:space="preserve">
-    <value>{0}&#x0A;&#x0A;找不到 wxc-exec 二进制文件，因此命令将不受限制地运行。如果这是开发者版本，请生成托盘应用，以便将 wxc-exec.exe 复制到输出文件夹。否则请重新安装伴侣应用以恢复沙盒。</value>
+    <value>{0}&#x0A;&#x0A;找不到 wxc-exec 二进制文件。{1} 如果这是开发者版本，请生成托盘应用，以便将 wxc-exec.exe 复制到输出文件夹。否则请重新安装伴侣应用以恢复沙盒。</value>
   </data>
   <data name="SandboxPage_ShowInstallInstructions" xml:space="preserve">
     <value>显示安装说明</value>
   </data>
   <data name="SandboxPage_UnavailableTitle" xml:space="preserve">
-    <value>沙盒不可用 — 命令将不受限制地运行</value>
+    <value>沙盒不可用 — 回退到主机</value>
+  </data>
+  <data name="SandboxPage_UnavailableBlockedTitle" xml:space="preserve">
+    <value>沙盒不可用 — 命令已阻止</value>
   </data>
   <data name="SettingsPage_LocalGatewayRemovedTitle" xml:space="preserve">
     <value>本地网关已移除</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -3093,6 +3093,78 @@
   <data name="AppNotification_ShowMore" xml:space="preserve">
     <value>显示更多</value>
   </data>
+  <data name="AppNotification_ActionOpenConnection" xml:space="preserve">
+    <value>打开连接</value>
+  </data>
+  <data name="AppNotification_ActionOpenChannels" xml:space="preserve">
+    <value>打开频道</value>
+  </data>
+  <data name="AppNotification_ActionOpenSandbox" xml:space="preserve">
+    <value>打开沙盒</value>
+  </data>
+  <data name="AppNotification_ActionOpenCron" xml:space="preserve">
+    <value>打开 Cron</value>
+  </data>
+  <data name="AppNotification_GatewayAuthenticationFailed_Title" xml:space="preserve">
+    <value>网关身份验证失败</value>
+  </data>
+  <data name="AppNotification_GatewayConnectionFailed_Title" xml:space="preserve">
+    <value>网关连接失败</value>
+  </data>
+  <data name="AppNotification_GatewayConnectionFailed_DefaultMessage" xml:space="preserve">
+    <value>OpenClaw 无法连接到活动网关。</value>
+  </data>
+  <data name="AppNotification_GatewayPairingRequired_Title" xml:space="preserve">
+    <value>需要批准网关配对</value>
+  </data>
+  <data name="AppNotification_GatewayPairingRequired_GenericMessage" xml:space="preserve">
+    <value>打开“连接”以完成网关配对。</value>
+  </data>
+  <data name="AppNotification_GatewayPairingRequired_DeviceMessageFormat" xml:space="preserve">
+    <value>打开“连接”以批准设备 {0}。</value>
+  </data>
+  <data name="AppNotification_WindowsNodeConnectionFailed_Title" xml:space="preserve">
+    <value>Windows 节点连接失败</value>
+  </data>
+  <data name="AppNotification_WindowsNodeConnectionFailed_DefaultMessage" xml:space="preserve">
+    <value>网关已连接，但此 Windows 节点不可用。</value>
+  </data>
+  <data name="AppNotification_WindowsNodeRateLimited_Title" xml:space="preserve">
+    <value>Windows 节点连接受到速率限制</value>
+  </data>
+  <data name="AppNotification_WindowsNodeRateLimited_DefaultMessage" xml:space="preserve">
+    <value>网关已连接，但此 Windows 节点暂时受到速率限制。</value>
+  </data>
+  <data name="AppNotification_ChannelNeedsAttention_TitleFormat" xml:space="preserve">
+    <value>{0} 频道需要注意</value>
+  </data>
+  <data name="AppNotification_ChannelNeedsAttention_StatusMessageFormat" xml:space="preserve">
+    <value>网关报告 {0} 为 {1}。</value>
+  </data>
+  <data name="AppNotification_SandboxDisabled_Title" xml:space="preserve">
+    <value>节点沙盒已关闭 — 命令将不受限制地运行</value>
+  </data>
+  <data name="AppNotification_SandboxDisabled_Message" xml:space="preserve">
+    <value>在重新启用节点沙盒之前，代理启动的 Windows 命令将在没有沙盒隔离的情况下运行。</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailable_Title" xml:space="preserve">
+    <value>沙盒不可用 — 命令将不受限制地运行</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailable_DefaultReason" xml:space="preserve">
+    <value>此计算机上没有可用的 MXC 沙盒基元。</value>
+  </data>
+  <data name="AppNotification_CronRunFailed_Title" xml:space="preserve">
+    <value>Cron 作业未启动</value>
+  </data>
+  <data name="AppNotification_CronRunFailed_DefaultDetail" xml:space="preserve">
+    <value>请求失败。</value>
+  </data>
+  <data name="AppNotification_CronRunRejectedDetail" xml:space="preserve">
+    <value>网关拒绝了 cron.run 请求。</value>
+  </data>
+  <data name="AppNotification_CronRunFailed_MessageFormat" xml:space="preserve">
+    <value>{0}：{1}</value>
+  </data>
   <data name="NotificationsPage_Title.Text" xml:space="preserve">
     <value>通知</value>
   </data>
@@ -3140,6 +3212,57 @@
   </data>
   <data name="AppNotification_ExecApprovalPending_AgentSlotLabelFormat" xml:space="preserve">
     <value>{0} / {1}</value>
+  </data>
+  <data name="NotificationsPage_MetadataAuthentication" xml:space="preserve">
+    <value>身份验证</value>
+  </data>
+  <data name="NotificationsPage_MetadataBindings" xml:space="preserve">
+    <value>绑定</value>
+  </data>
+  <data name="NotificationsPage_MetadataChannels" xml:space="preserve">
+    <value>频道</value>
+  </data>
+  <data name="NotificationsPage_MetadataConfig" xml:space="preserve">
+    <value>配置</value>
+  </data>
+  <data name="NotificationsPage_MetadataConnection" xml:space="preserve">
+    <value>连接</value>
+  </data>
+  <data name="NotificationsPage_MetadataCron" xml:space="preserve">
+    <value>Cron</value>
+  </data>
+  <data name="NotificationsPage_MetadataGateway" xml:space="preserve">
+    <value>网关</value>
+  </data>
+  <data name="NotificationsPage_MetadataJobs" xml:space="preserve">
+    <value>作业</value>
+  </data>
+  <data name="NotificationsPage_MetadataLoad" xml:space="preserve">
+    <value>加载</value>
+  </data>
+  <data name="NotificationsPage_MetadataLifecycle" xml:space="preserve">
+    <value>生命周期</value>
+  </data>
+  <data name="NotificationsPage_MetadataLocalGateway" xml:space="preserve">
+    <value>本地网关</value>
+  </data>
+  <data name="NotificationsPage_MetadataNode" xml:space="preserve">
+    <value>节点</value>
+  </data>
+  <data name="NotificationsPage_MetadataPairing" xml:space="preserve">
+    <value>配对</value>
+  </data>
+  <data name="NotificationsPage_MetadataSandbox" xml:space="preserve">
+    <value>沙盒</value>
+  </data>
+  <data name="NotificationsPage_MetadataSettings" xml:space="preserve">
+    <value>设置</value>
+  </data>
+  <data name="NotificationsPage_MetadataStatus" xml:space="preserve">
+    <value>状态</value>
+  </data>
+  <data name="NotificationsPage_MetadataSystemRun" xml:space="preserve">
+    <value>system.run</value>
   </data>
   <data name="Chat_Permission_Title" xml:space="preserve">
     <value>需要执行批准</value>
@@ -5898,13 +6021,319 @@
     <value>Waiting for gateway health</value>
   </data>
   <data name="ConfigPage_CheckingConfigPermissions" xml:space="preserve">
-    <value>Checking config permissions</value>
+    <value>正在检查配置权限</value>
   </data>
   <data name="ConfigPage_ConfigIsReadOnly" xml:space="preserve">
-    <value>Config is read-only</value>
+    <value>配置为只读</value>
   </data>
   <data name="ConfigPage_ConfigUnavailable" xml:space="preserve">
-    <value>Config unavailable</value>
+    <value>配置不可用</value>
+  </data>
+  <data name="ConfigPage_EditingPathFormat" xml:space="preserve">
+    <value>正在通过架构引导表单编辑 {0}。</value>
+  </data>
+  <data name="ConfigPage_RenderConfigUnavailableTitle" xml:space="preserve">
+    <value>配置不可用</value>
+  </data>
+  <data name="ConfigPage_RenderConfigUnavailableMessage" xml:space="preserve">
+    <value>无法呈现网关配置。请刷新后重试。</value>
+  </data>
+  <data name="ConfigPage_RenderSchemaUnavailableTitle" xml:space="preserve">
+    <value>架构不可用</value>
+  </data>
+  <data name="ConfigPage_RenderSchemaUnavailableMessage" xml:space="preserve">
+    <value>无法呈现网关架构。原始 JSON 仍可作为只读预览使用。</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayRestartingTitle" xml:space="preserve">
+    <value>网关正在重启</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayRestartingMessage" xml:space="preserve">
+    <value>正在保存更改。网关正在重启，并将自动重新连接。</value>
+  </data>
+  <data name="ConfigPage_StatusNoChangesTitle" xml:space="preserve">
+    <value>没有更改</value>
+  </data>
+  <data name="ConfigPage_StatusNoChangesMessage" xml:space="preserve">
+    <value>没有需要保存的内容。</value>
+  </data>
+  <data name="ConfigPage_StatusFixValidationErrorsTitle" xml:space="preserve">
+    <value>修复验证错误</value>
+  </data>
+  <data name="ConfigPage_StatusValidationErrorMessageFormat" xml:space="preserve">
+    <value>{0}：{1}</value>
+  </data>
+  <data name="ConfigPage_StatusNotConnectedTitle" xml:space="preserve">
+    <value>未连接</value>
+  </data>
+  <data name="ConfigPage_StatusNotConnectedMessage" xml:space="preserve">
+    <value>保存配置前请先连接到网关。</value>
+  </data>
+  <data name="ConfigPage_StatusReadOnlyMessage" xml:space="preserve">
+    <value>此操作员令牌没有 operator.write 权限，因此无法保存配置更改。</value>
+  </data>
+  <data name="ConfigPage_StatusConfigNotLoadedTitle" xml:space="preserve">
+    <value>配置未加载</value>
+  </data>
+  <data name="ConfigPage_StatusConfigNotLoadedMessage" xml:space="preserve">
+    <value>保存前请刷新网关配置。</value>
+  </data>
+  <data name="ConfigPage_StatusSavingConfigTitle" xml:space="preserve">
+    <value>正在保存配置…</value>
+  </data>
+  <data name="ConfigPage_StatusSavingConfigMessageFormat" xml:space="preserve">
+    <value>正在向网关写入 {0} 项更改。</value>
+  </data>
+  <data name="ConfigPage_StatusStaleConfigTitle" xml:space="preserve">
+    <value>网关配置已在其他位置更改</value>
+  </data>
+  <data name="ConfigPage_StatusStaleConfigMessageFormat" xml:space="preserve">
+    <value>你的编辑已保留。正在刷新最新配置；请检查表单并再次尝试保存。详细信息：{0}</value>
+  </data>
+  <data name="ConfigPage_StatusStaleConfigDefaultDetail" xml:space="preserve">
+    <value>过期的配置哈希</value>
+  </data>
+  <data name="ConfigPage_StatusSaveFailedTitle" xml:space="preserve">
+    <value>保存失败</value>
+  </data>
+  <data name="ConfigPage_StatusSaveRejectedMessage" xml:space="preserve">
+    <value>网关拒绝了配置更新。你的更改已保留。</value>
+  </data>
+  <data name="ConfigPage_StatusSaveExceptionMessageFormat" xml:space="preserve">
+    <value>{0} 你的更改已保留。</value>
+  </data>
+  <data name="ConfigPage_SaveStatusCheckingConfigPermissions" xml:space="preserve">
+    <value>正在检查配置权限…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusRefreshing" xml:space="preserve">
+    <value>正在刷新…</value>
+  </data>
+  <data name="ConfigPage_StatusChangesDiscardedTitle" xml:space="preserve">
+    <value>更改已放弃</value>
+  </data>
+  <data name="ConfigPage_StatusChangesDiscardedMessage" xml:space="preserve">
+    <value>表单已恢复为上次从网关加载的配置。</value>
+  </data>
+  <data name="ConfigPage_FullConfig" xml:space="preserve">
+    <value>完整配置</value>
+  </data>
+  <data name="ConfigPage_StatusSectionResetTitle" xml:space="preserve">
+    <value>部分已重置</value>
+  </data>
+  <data name="ConfigPage_StatusSectionResetMessageFormat" xml:space="preserve">
+    <value>{0} 已恢复为上次加载的网关值。</value>
+  </data>
+  <data name="ConfigPage_StatusCopiedJsonDiffTitle" xml:space="preserve">
+    <value>已复制 JSON 差异</value>
+  </data>
+  <data name="ConfigPage_StatusCopiedJsonDiffMessage" xml:space="preserve">
+    <value>所选部分的差异已复制到剪贴板。</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayReconnectedTitle" xml:space="preserve">
+    <value>网关已重新连接</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayReconnectedRefreshingMessage" xml:space="preserve">
+    <value>配置已保存，网关连接已恢复。正在刷新最新配置。</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayReconnectedLoadedMessage" xml:space="preserve">
+    <value>配置已保存，并已加载最新的网关配置。</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayStillReconnectingTitle" xml:space="preserve">
+    <value>网关仍在重新连接</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayStillReconnectingMessage" xml:space="preserve">
+    <value>配置保存已被接受，但网关尚未重新连接。你可以保持此页面打开，或使用“连接”检查状态。</value>
+  </data>
+  <data name="ConfigPage_CheckingConfigPermissionsMessage" xml:space="preserve">
+    <value>正在等待网关报告此操作员的权限。</value>
+  </data>
+  <data name="ConfigPage_ConfigUnavailableMessage" xml:space="preserve">
+    <value>此操作员令牌缺少 operator.read 权限，因此无法在此处加载网关配置。</value>
+  </data>
+  <data name="ConfigPage_ConfigIsReadOnlyMessage" xml:space="preserve">
+    <value>此操作员令牌可以读取配置，但缺少 operator.write 权限。你可以检查并验证草稿，但“保存”已禁用。</value>
+  </data>
+  <data name="ConfigPage_MetaNoUnsavedChanges" xml:space="preserve">
+    <value>没有未保存的更改。</value>
+  </data>
+  <data name="ConfigPage_MetaUnsavedChangesFormat" xml:space="preserve">
+    <value>{0} 项未保存的更改</value>
+  </data>
+  <data name="ConfigPage_MetaUnsavedChangesWithValidationFormat" xml:space="preserve">
+    <value>{0} 项未保存的更改 · {1} 个验证问题</value>
+  </data>
+  <data name="ConfigPage_SaveStatusSaving" xml:space="preserve">
+    <value>正在保存…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusGatewayRestarting" xml:space="preserve">
+    <value>网关正在重启…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusConnectToGateway" xml:space="preserve">
+    <value>连接到网关以编辑</value>
+  </data>
+  <data name="ConfigPage_SaveStatusCheckingPermissions" xml:space="preserve">
+    <value>正在检查权限…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusMissingRead" xml:space="preserve">
+    <value>配置不可用：缺少 operator.read</value>
+  </data>
+  <data name="ConfigPage_SaveStatusReadOnlyMissingWrite" xml:space="preserve">
+    <value>只读：缺少 operator.write</value>
+  </data>
+  <data name="ConfigPage_SaveStatusFixValidationBeforeSaving" xml:space="preserve">
+    <value>保存前请修复验证错误</value>
+  </data>
+  <data name="ConfigPage_SaveStatusUnsavedChanges" xml:space="preserve">
+    <value>未保存的更改</value>
+  </data>
+  <data name="ConfigPage_SaveStatusNoUnsavedChanges" xml:space="preserve">
+    <value>没有未保存的更改</value>
+  </data>
+  <data name="ConfigPage_AccessDisconnected" xml:space="preserve">
+    <value>已断开连接</value>
+  </data>
+  <data name="ConfigPage_AccessChecking" xml:space="preserve">
+    <value>正在检查访问权限</value>
+  </data>
+  <data name="ConfigPage_AccessNoRead" xml:space="preserve">
+    <value>没有配置读取访问权限</value>
+  </data>
+  <data name="ConfigPage_AccessReadOnly" xml:space="preserve">
+    <value>只读访问权限</value>
+  </data>
+  <data name="ConfigPage_AccessReadWrite" xml:space="preserve">
+    <value>读/写访问权限</value>
+  </data>
+  <data name="ConfigPage_AccessUnknown" xml:space="preserve">
+    <value>未知访问权限</value>
+  </data>
+  <data name="ConfigPage_AccessChangesFormat" xml:space="preserve">
+    <value>{0} 项更改</value>
+  </data>
+  <data name="ConfigPage_AccessValidationClean" xml:space="preserve">
+    <value>本地验证通过</value>
+  </data>
+  <data name="ConfigPage_AccessValidationIssuesFormat" xml:space="preserve">
+    <value>{0} 个验证问题</value>
+  </data>
+  <data name="ConfigPage_AccessSummaryFormat" xml:space="preserve">
+    <value>{0} · {1} · {2}</value>
+  </data>
+  <data name="DebugPage_NoGatewayConfigured" xml:space="preserve">
+    <value>未配置网关</value>
+  </data>
+  <data name="DebugPage_StatusConnectedFormat" xml:space="preserve">
+    <value>OpenClaw 已连接到 {0}。</value>
+  </data>
+  <data name="DebugPage_StatusConnectingFormat" xml:space="preserve">
+    <value>正在连接到 {0}…</value>
+  </data>
+  <data name="DebugPage_StatusDisconnectedFormat" xml:space="preserve">
+    <value>未连接。网关：{0}。</value>
+  </data>
+  <data name="DebugPage_StatusErrorFormat" xml:space="preserve">
+    <value>上次网关：{0}。请查看事件时间线。</value>
+  </data>
+  <data name="DebugPage_StatusGatewayFormat" xml:space="preserve">
+    <value>网关：{0}。</value>
+  </data>
+  <data name="DebugPage_RecentLogTitle" xml:space="preserve">
+    <value>最近日志</value>
+  </data>
+  <data name="DebugPage_RecentLogCaptionFormat" xml:space="preserve">
+    <value>{0} 的最后 200 行。严重性根据 [info]/[warn]/[error] 标记解析。</value>
+  </data>
+  <data name="DebugPage_CopyFeedbackFormat" xml:space="preserve">
+    <value>{0} 已复制到剪贴板。</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableTitle" xml:space="preserve">
+    <value>节点沙盒不可用 — 命令将不受限制地运行</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableSubtext" xml:space="preserve">
+    <value>此电脑上无法使用隔离，因此命令将在没有沙盒保护的情况下运行。</value>
+  </data>
+  <data name="SandboxPage_StatusOnTitle" xml:space="preserve">
+    <value>节点沙盒已开启</value>
+  </data>
+  <data name="SandboxPage_StatusOnSubtext" xml:space="preserve">
+    <value>代理在此电脑上运行的程序会被隔离。</value>
+  </data>
+  <data name="SandboxPage_StatusOffTitle" xml:space="preserve">
+    <value>节点沙盒已关闭 — 高风险</value>
+  </data>
+  <data name="SandboxPage_StatusOffSubtext" xml:space="preserve">
+    <value>代理在此电脑上运行的程序不会被隔离。</value>
+  </data>
+  <data name="SandboxPage_UnavailableDefaultReason" xml:space="preserve">
+    <value>此计算机上没有可用的 MXC 沙盒基元。</value>
+  </data>
+  <data name="SandboxPage_WindowsUnsupportedTitle" xml:space="preserve">
+    <value>你的 Windows 版本尚不支持沙盒</value>
+  </data>
+  <data name="SandboxPage_WindowsUnsupportedMessageFormat" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;此计算机上的命令将不受限制地运行 — 沙盒需要包含 AppContainer 基元的较新 Windows 版本。请安装最新 Windows 更新（或加入 Windows 预览体验计划以获取最新版本）以启用隔离。</value>
+  </data>
+  <data name="SandboxPage_OpenWindowsUpdate" xml:space="preserve">
+    <value>打开 Windows 更新</value>
+  </data>
+  <data name="SandboxPage_ComponentsMissingTitle" xml:space="preserve">
+    <value>缺少沙盒组件</value>
+  </data>
+  <data name="SandboxPage_ComponentsMissingMessageFormat" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;找不到 wxc-exec 二进制文件，因此命令将不受限制地运行。如果这是开发者版本，请生成托盘应用，以便将 wxc-exec.exe 复制到输出文件夹。否则请重新安装伴侣应用以恢复沙盒。</value>
+  </data>
+  <data name="SandboxPage_ShowInstallInstructions" xml:space="preserve">
+    <value>显示安装说明</value>
+  </data>
+  <data name="SandboxPage_UnavailableTitle" xml:space="preserve">
+    <value>沙盒不可用 — 命令将不受限制地运行</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovedTitle" xml:space="preserve">
+    <value>本地网关已移除</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovedMessage" xml:space="preserve">
+    <value>设置已重置；你可以从托盘菜单重新运行设置。</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalErrorsMessage" xml:space="preserve">
+    <value>移除已完成但出现错误。请查看日志了解详细信息。</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalCancelledTitle" xml:space="preserve">
+    <value>移除已取消</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalCancelledMessage" xml:space="preserve">
+    <value>网关可能处于部分移除状态。请查看日志或重试。</value>
+  </data>
+  <data name="SettingsPage_ViewLogs" xml:space="preserve">
+    <value>查看日志</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalFailedTitle" xml:space="preserve">
+    <value>移除失败</value>
+  </data>
+  <data name="SettingsPage_RemoveLocalGatewayButton" xml:space="preserve">
+    <value>移除本地网关</value>
+  </data>
+  <data name="SettingsPage_RemovingDistro" xml:space="preserve">
+    <value>正在移除发行版…</value>
+  </data>
+  <data name="SettingsPage_RemovingLocalGatewayMessage" xml:space="preserve">
+    <value>正在移除本地网关。这可能需要 10–30 秒…</value>
+  </data>
+  <data name="CronPage_NextWakeFormat" xml:space="preserve">
+    <value>· 下次唤醒：{0}</value>
+  </data>
+  <data name="ChatWindow_UnableToLoadChatCredentials" xml:space="preserve">
+    <value>无法加载聊天。网关 URL 或令牌不可用。</value>
+  </data>
+  <data name="ChatWindow_UnableToLoadChatRetryFormat" xml:space="preserve">
+    <value>无法加载聊天。请重试。({0})</value>
+  </data>
+  <data name="ChatWindow_WebViewFailedFormat" xml:space="preserve">
+    <value>WebView2 失败：{0}</value>
+  </data>
+  <data name="CanvasWindow_WebViewInitFailedFormat" xml:space="preserve">
+    <value>无法初始化 WebView2：{0}</value>
+  </data>
+  <data name="CanvasWindow_NavigationFailedFormat" xml:space="preserve">
+    <value>导航失败：{0}</value>
   </data>
   <data name="ConnectionPage_GatewayHostControlsDescription_Format" xml:space="preserve">
     <value>Open a shell or manage the local gateway service in {0}.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -3148,7 +3148,20 @@
     <value>在重新啟用節點沙箱之前，代理程式啟動的 Windows 命令將在沒有沙箱隔離的情況下執行。</value>
   </data>
   <data name="AppNotification_SandboxUnavailable_Title" xml:space="preserve">
-    <value>沙箱無法使用 — 命令將不受限制地執行</value>
+    <value>沙箱無法使用 — 回退到主機</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailable_MessageFormat" xml:space="preserve">
+    <value>{0}
+
+在沙箱無法使用期間，命令將在主機上執行，且沒有沙箱保護。</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailableBlocked_Title" xml:space="preserve">
+    <value>沙箱無法使用 — 命令已封鎖</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailableBlocked_MessageFormat" xml:space="preserve">
+    <value>{0}
+
+由於已啟用嚴格回退封鎖，沙箱無法使用期間命令會被封鎖。</value>
   </data>
   <data name="AppNotification_SandboxUnavailable_DefaultReason" xml:space="preserve">
     <value>此電腦上沒有可用的 MXC 沙箱基元。</value>
@@ -6246,10 +6259,22 @@
     <value>{0} 已複製到剪貼簿。</value>
   </data>
   <data name="SandboxPage_StatusUnavailableTitle" xml:space="preserve">
-    <value>節點沙箱無法使用 — 命令將不受限制地執行</value>
+    <value>節點沙箱無法使用 — 回退到主機</value>
   </data>
   <data name="SandboxPage_StatusUnavailableSubtext" xml:space="preserve">
-    <value>此電腦上無法使用隔離，因此命令會在沒有沙箱保護的情況下執行。</value>
+    <value>此電腦上無法使用隔離，因此代理程式啟動的命令會在主機上執行，且沒有沙箱保護。</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableBlockedTitle" xml:space="preserve">
+    <value>節點沙箱無法使用 — 命令已封鎖</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableBlockedSubtext" xml:space="preserve">
+    <value>此電腦上無法使用隔離，且已啟用嚴格回退封鎖，因此代理程式啟動的命令會被封鎖。</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableOffTitle" xml:space="preserve">
+    <value>節點沙箱已關閉 — 主機執行</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableOffSubtext" xml:space="preserve">
+    <value>隔離無法使用且節點沙箱已關閉，因此代理程式啟動的命令會在主機上執行，且沒有沙箱保護。</value>
   </data>
   <data name="SandboxPage_StatusOnTitle" xml:space="preserve">
     <value>節點沙箱已開啟</value>
@@ -6266,11 +6291,29 @@
   <data name="SandboxPage_UnavailableDefaultReason" xml:space="preserve">
     <value>此電腦上沒有可用的 MXC 沙箱基元。</value>
   </data>
+  <data name="SandboxPage_ProbeErrorReason" xml:space="preserve">
+    <value>無法檢查沙箱可用性。</value>
+  </data>
+  <data name="SandboxPage_UnavailableBehaviorHostFallback" xml:space="preserve">
+    <value>在沙箱無法使用期間，命令將在主機上執行，且沒有沙箱保護。</value>
+  </data>
+  <data name="SandboxPage_UnavailableBehaviorBlocked" xml:space="preserve">
+    <value>由於已啟用嚴格回退封鎖，沙箱無法使用期間命令會被封鎖。</value>
+  </data>
+  <data name="SandboxPage_ProbeErrorTitle" xml:space="preserve">
+    <value>無法驗證沙箱可用性</value>
+  </data>
+  <data name="SandboxPage_ProbeErrorMessageFormat" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;{1} 沙箱功能檢查未完成。這通常是暫時性的（檢查緩慢或遭封鎖）— 請重試；如果問題仍然存在，請檢查安全性軟體是否封鎖了 wxc-exec。</value>
+  </data>
+  <data name="SandboxPage_Retry" xml:space="preserve">
+    <value>重試</value>
+  </data>
   <data name="SandboxPage_WindowsUnsupportedTitle" xml:space="preserve">
     <value>您的 Windows 版本尚不支援沙箱</value>
   </data>
   <data name="SandboxPage_WindowsUnsupportedMessageFormat" xml:space="preserve">
-    <value>{0}&#x0A;&#x0A;此電腦上的命令將不受限制地執行 — 沙箱需要包含 AppContainer 基元的較新 Windows 版本。請安裝最新 Windows 更新（或加入 Windows 測試人員計畫以取得最新版本）以啟用隔離。</value>
+    <value>{0}&#x0A;&#x0A;{1} 沙箱需要包含 AppContainer 基元的較新 Windows 版本。請安裝最新 Windows 更新（或加入 Windows 測試人員計畫以取得最新版本）以啟用隔離。</value>
   </data>
   <data name="SandboxPage_OpenWindowsUpdate" xml:space="preserve">
     <value>開啟 Windows Update</value>
@@ -6279,13 +6322,16 @@
     <value>缺少沙箱元件</value>
   </data>
   <data name="SandboxPage_ComponentsMissingMessageFormat" xml:space="preserve">
-    <value>{0}&#x0A;&#x0A;找不到 wxc-exec 二進位檔，因此命令將不受限制地執行。如果這是開發人員組建，請建置托盤應用程式，讓 wxc-exec.exe 複製到輸出資料夾。否則請重新安裝伴侶應用程式以還原沙箱。</value>
+    <value>{0}&#x0A;&#x0A;找不到 wxc-exec 二進位檔。{1} 如果這是開發人員組建，請建置托盤應用程式，讓 wxc-exec.exe 複製到輸出資料夾。否則請重新安裝伴侶應用程式以還原沙箱。</value>
   </data>
   <data name="SandboxPage_ShowInstallInstructions" xml:space="preserve">
     <value>顯示安裝指示</value>
   </data>
   <data name="SandboxPage_UnavailableTitle" xml:space="preserve">
-    <value>沙箱無法使用 — 命令將不受限制地執行</value>
+    <value>沙箱無法使用 — 回退到主機</value>
+  </data>
+  <data name="SandboxPage_UnavailableBlockedTitle" xml:space="preserve">
+    <value>沙箱無法使用 — 命令已封鎖</value>
   </data>
   <data name="SettingsPage_LocalGatewayRemovedTitle" xml:space="preserve">
     <value>本機閘道已移除</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -3093,6 +3093,78 @@
   <data name="AppNotification_ShowMore" xml:space="preserve">
     <value>顯示更多</value>
   </data>
+  <data name="AppNotification_ActionOpenConnection" xml:space="preserve">
+    <value>開啟連線</value>
+  </data>
+  <data name="AppNotification_ActionOpenChannels" xml:space="preserve">
+    <value>開啟頻道</value>
+  </data>
+  <data name="AppNotification_ActionOpenSandbox" xml:space="preserve">
+    <value>開啟沙箱</value>
+  </data>
+  <data name="AppNotification_ActionOpenCron" xml:space="preserve">
+    <value>開啟 Cron</value>
+  </data>
+  <data name="AppNotification_GatewayAuthenticationFailed_Title" xml:space="preserve">
+    <value>閘道驗證失敗</value>
+  </data>
+  <data name="AppNotification_GatewayConnectionFailed_Title" xml:space="preserve">
+    <value>閘道連線失敗</value>
+  </data>
+  <data name="AppNotification_GatewayConnectionFailed_DefaultMessage" xml:space="preserve">
+    <value>OpenClaw 無法連線到作用中閘道。</value>
+  </data>
+  <data name="AppNotification_GatewayPairingRequired_Title" xml:space="preserve">
+    <value>需要核准閘道配對</value>
+  </data>
+  <data name="AppNotification_GatewayPairingRequired_GenericMessage" xml:space="preserve">
+    <value>開啟「連線」以完成閘道配對。</value>
+  </data>
+  <data name="AppNotification_GatewayPairingRequired_DeviceMessageFormat" xml:space="preserve">
+    <value>開啟「連線」以核准裝置 {0}。</value>
+  </data>
+  <data name="AppNotification_WindowsNodeConnectionFailed_Title" xml:space="preserve">
+    <value>Windows 節點連線失敗</value>
+  </data>
+  <data name="AppNotification_WindowsNodeConnectionFailed_DefaultMessage" xml:space="preserve">
+    <value>閘道已連線，但此 Windows 節點無法使用。</value>
+  </data>
+  <data name="AppNotification_WindowsNodeRateLimited_Title" xml:space="preserve">
+    <value>Windows 節點連線受到速率限制</value>
+  </data>
+  <data name="AppNotification_WindowsNodeRateLimited_DefaultMessage" xml:space="preserve">
+    <value>閘道已連線，但此 Windows 節點暫時受到速率限制。</value>
+  </data>
+  <data name="AppNotification_ChannelNeedsAttention_TitleFormat" xml:space="preserve">
+    <value>{0} 頻道需要注意</value>
+  </data>
+  <data name="AppNotification_ChannelNeedsAttention_StatusMessageFormat" xml:space="preserve">
+    <value>閘道回報 {0} 為 {1}。</value>
+  </data>
+  <data name="AppNotification_SandboxDisabled_Title" xml:space="preserve">
+    <value>節點沙箱已關閉 — 命令將不受限制地執行</value>
+  </data>
+  <data name="AppNotification_SandboxDisabled_Message" xml:space="preserve">
+    <value>在重新啟用節點沙箱之前，代理程式啟動的 Windows 命令將在沒有沙箱隔離的情況下執行。</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailable_Title" xml:space="preserve">
+    <value>沙箱無法使用 — 命令將不受限制地執行</value>
+  </data>
+  <data name="AppNotification_SandboxUnavailable_DefaultReason" xml:space="preserve">
+    <value>此電腦上沒有可用的 MXC 沙箱基元。</value>
+  </data>
+  <data name="AppNotification_CronRunFailed_Title" xml:space="preserve">
+    <value>Cron 作業未啟動</value>
+  </data>
+  <data name="AppNotification_CronRunFailed_DefaultDetail" xml:space="preserve">
+    <value>要求失敗。</value>
+  </data>
+  <data name="AppNotification_CronRunRejectedDetail" xml:space="preserve">
+    <value>閘道拒絕了 cron.run 要求。</value>
+  </data>
+  <data name="AppNotification_CronRunFailed_MessageFormat" xml:space="preserve">
+    <value>{0}：{1}</value>
+  </data>
   <data name="NotificationsPage_Title.Text" xml:space="preserve">
     <value>通知</value>
   </data>
@@ -3140,6 +3212,57 @@
   </data>
   <data name="AppNotification_ExecApprovalPending_AgentSlotLabelFormat" xml:space="preserve">
     <value>{0} / {1}</value>
+  </data>
+  <data name="NotificationsPage_MetadataAuthentication" xml:space="preserve">
+    <value>驗證</value>
+  </data>
+  <data name="NotificationsPage_MetadataBindings" xml:space="preserve">
+    <value>繫結</value>
+  </data>
+  <data name="NotificationsPage_MetadataChannels" xml:space="preserve">
+    <value>頻道</value>
+  </data>
+  <data name="NotificationsPage_MetadataConfig" xml:space="preserve">
+    <value>設定</value>
+  </data>
+  <data name="NotificationsPage_MetadataConnection" xml:space="preserve">
+    <value>連線</value>
+  </data>
+  <data name="NotificationsPage_MetadataCron" xml:space="preserve">
+    <value>Cron</value>
+  </data>
+  <data name="NotificationsPage_MetadataGateway" xml:space="preserve">
+    <value>閘道</value>
+  </data>
+  <data name="NotificationsPage_MetadataJobs" xml:space="preserve">
+    <value>作業</value>
+  </data>
+  <data name="NotificationsPage_MetadataLoad" xml:space="preserve">
+    <value>載入</value>
+  </data>
+  <data name="NotificationsPage_MetadataLifecycle" xml:space="preserve">
+    <value>生命週期</value>
+  </data>
+  <data name="NotificationsPage_MetadataLocalGateway" xml:space="preserve">
+    <value>本機閘道</value>
+  </data>
+  <data name="NotificationsPage_MetadataNode" xml:space="preserve">
+    <value>節點</value>
+  </data>
+  <data name="NotificationsPage_MetadataPairing" xml:space="preserve">
+    <value>配對</value>
+  </data>
+  <data name="NotificationsPage_MetadataSandbox" xml:space="preserve">
+    <value>沙箱</value>
+  </data>
+  <data name="NotificationsPage_MetadataSettings" xml:space="preserve">
+    <value>設定</value>
+  </data>
+  <data name="NotificationsPage_MetadataStatus" xml:space="preserve">
+    <value>狀態</value>
+  </data>
+  <data name="NotificationsPage_MetadataSystemRun" xml:space="preserve">
+    <value>system.run</value>
   </data>
   <data name="Chat_Permission_Title" xml:space="preserve">
     <value>需要執行核准</value>
@@ -5898,13 +6021,319 @@
     <value>Waiting for gateway health</value>
   </data>
   <data name="ConfigPage_CheckingConfigPermissions" xml:space="preserve">
-    <value>Checking config permissions</value>
+    <value>正在檢查設定權限</value>
   </data>
   <data name="ConfigPage_ConfigIsReadOnly" xml:space="preserve">
-    <value>Config is read-only</value>
+    <value>設定為唯讀</value>
   </data>
   <data name="ConfigPage_ConfigUnavailable" xml:space="preserve">
-    <value>Config unavailable</value>
+    <value>設定無法使用</value>
+  </data>
+  <data name="ConfigPage_EditingPathFormat" xml:space="preserve">
+    <value>正在透過架構引導表單編輯 {0}。</value>
+  </data>
+  <data name="ConfigPage_RenderConfigUnavailableTitle" xml:space="preserve">
+    <value>設定無法使用</value>
+  </data>
+  <data name="ConfigPage_RenderConfigUnavailableMessage" xml:space="preserve">
+    <value>無法呈現閘道設定。請重新整理後再試一次。</value>
+  </data>
+  <data name="ConfigPage_RenderSchemaUnavailableTitle" xml:space="preserve">
+    <value>架構無法使用</value>
+  </data>
+  <data name="ConfigPage_RenderSchemaUnavailableMessage" xml:space="preserve">
+    <value>無法呈現閘道架構。原始 JSON 仍可作為唯讀預覽使用。</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayRestartingTitle" xml:space="preserve">
+    <value>閘道正在重新啟動</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayRestartingMessage" xml:space="preserve">
+    <value>正在儲存變更。閘道正在重新啟動，並會自動重新連線。</value>
+  </data>
+  <data name="ConfigPage_StatusNoChangesTitle" xml:space="preserve">
+    <value>沒有變更</value>
+  </data>
+  <data name="ConfigPage_StatusNoChangesMessage" xml:space="preserve">
+    <value>沒有需要儲存的內容。</value>
+  </data>
+  <data name="ConfigPage_StatusFixValidationErrorsTitle" xml:space="preserve">
+    <value>修正驗證錯誤</value>
+  </data>
+  <data name="ConfigPage_StatusValidationErrorMessageFormat" xml:space="preserve">
+    <value>{0}：{1}</value>
+  </data>
+  <data name="ConfigPage_StatusNotConnectedTitle" xml:space="preserve">
+    <value>未連線</value>
+  </data>
+  <data name="ConfigPage_StatusNotConnectedMessage" xml:space="preserve">
+    <value>儲存設定前請先連線到閘道。</value>
+  </data>
+  <data name="ConfigPage_StatusReadOnlyMessage" xml:space="preserve">
+    <value>此操作員權杖沒有 operator.write 權限，因此無法儲存設定變更。</value>
+  </data>
+  <data name="ConfigPage_StatusConfigNotLoadedTitle" xml:space="preserve">
+    <value>設定未載入</value>
+  </data>
+  <data name="ConfigPage_StatusConfigNotLoadedMessage" xml:space="preserve">
+    <value>儲存前請重新整理閘道設定。</value>
+  </data>
+  <data name="ConfigPage_StatusSavingConfigTitle" xml:space="preserve">
+    <value>正在儲存設定…</value>
+  </data>
+  <data name="ConfigPage_StatusSavingConfigMessageFormat" xml:space="preserve">
+    <value>正在將 {0} 項變更寫入閘道。</value>
+  </data>
+  <data name="ConfigPage_StatusStaleConfigTitle" xml:space="preserve">
+    <value>閘道設定已在其他位置變更</value>
+  </data>
+  <data name="ConfigPage_StatusStaleConfigMessageFormat" xml:space="preserve">
+    <value>您的編輯已保留。正在重新整理最新設定；請檢閱表單並再次嘗試儲存。詳細資料：{0}</value>
+  </data>
+  <data name="ConfigPage_StatusStaleConfigDefaultDetail" xml:space="preserve">
+    <value>過期的設定雜湊</value>
+  </data>
+  <data name="ConfigPage_StatusSaveFailedTitle" xml:space="preserve">
+    <value>儲存失敗</value>
+  </data>
+  <data name="ConfigPage_StatusSaveRejectedMessage" xml:space="preserve">
+    <value>閘道拒絕了設定更新。您的變更已保留。</value>
+  </data>
+  <data name="ConfigPage_StatusSaveExceptionMessageFormat" xml:space="preserve">
+    <value>{0} 您的變更已保留。</value>
+  </data>
+  <data name="ConfigPage_SaveStatusCheckingConfigPermissions" xml:space="preserve">
+    <value>正在檢查設定權限…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusRefreshing" xml:space="preserve">
+    <value>正在重新整理…</value>
+  </data>
+  <data name="ConfigPage_StatusChangesDiscardedTitle" xml:space="preserve">
+    <value>變更已捨棄</value>
+  </data>
+  <data name="ConfigPage_StatusChangesDiscardedMessage" xml:space="preserve">
+    <value>表單已回復為上次從閘道載入的設定。</value>
+  </data>
+  <data name="ConfigPage_FullConfig" xml:space="preserve">
+    <value>完整設定</value>
+  </data>
+  <data name="ConfigPage_StatusSectionResetTitle" xml:space="preserve">
+    <value>區段已重設</value>
+  </data>
+  <data name="ConfigPage_StatusSectionResetMessageFormat" xml:space="preserve">
+    <value>{0} 已回復為上次載入的閘道值。</value>
+  </data>
+  <data name="ConfigPage_StatusCopiedJsonDiffTitle" xml:space="preserve">
+    <value>已複製 JSON 差異</value>
+  </data>
+  <data name="ConfigPage_StatusCopiedJsonDiffMessage" xml:space="preserve">
+    <value>所選區段的差異已複製到剪貼簿。</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayReconnectedTitle" xml:space="preserve">
+    <value>閘道已重新連線</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayReconnectedRefreshingMessage" xml:space="preserve">
+    <value>設定已儲存，閘道連線已恢復。正在重新整理最新設定。</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayReconnectedLoadedMessage" xml:space="preserve">
+    <value>設定已儲存，且已載入最新的閘道設定。</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayStillReconnectingTitle" xml:space="preserve">
+    <value>閘道仍在重新連線</value>
+  </data>
+  <data name="ConfigPage_StatusGatewayStillReconnectingMessage" xml:space="preserve">
+    <value>設定儲存已被接受，但閘道尚未重新連線。您可以保持此頁面開啟，或使用「連線」檢查狀態。</value>
+  </data>
+  <data name="ConfigPage_CheckingConfigPermissionsMessage" xml:space="preserve">
+    <value>正在等待閘道回報此操作員的權限。</value>
+  </data>
+  <data name="ConfigPage_ConfigUnavailableMessage" xml:space="preserve">
+    <value>此操作員權杖缺少 operator.read 權限，因此無法在此載入閘道設定。</value>
+  </data>
+  <data name="ConfigPage_ConfigIsReadOnlyMessage" xml:space="preserve">
+    <value>此操作員權杖可以讀取設定，但缺少 operator.write 權限。您可以檢查並驗證草稿，但「儲存」已停用。</value>
+  </data>
+  <data name="ConfigPage_MetaNoUnsavedChanges" xml:space="preserve">
+    <value>沒有未儲存的變更。</value>
+  </data>
+  <data name="ConfigPage_MetaUnsavedChangesFormat" xml:space="preserve">
+    <value>{0} 項未儲存的變更</value>
+  </data>
+  <data name="ConfigPage_MetaUnsavedChangesWithValidationFormat" xml:space="preserve">
+    <value>{0} 項未儲存的變更 · {1} 個驗證問題</value>
+  </data>
+  <data name="ConfigPage_SaveStatusSaving" xml:space="preserve">
+    <value>正在儲存…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusGatewayRestarting" xml:space="preserve">
+    <value>閘道正在重新啟動…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusConnectToGateway" xml:space="preserve">
+    <value>連線到閘道以編輯</value>
+  </data>
+  <data name="ConfigPage_SaveStatusCheckingPermissions" xml:space="preserve">
+    <value>正在檢查權限…</value>
+  </data>
+  <data name="ConfigPage_SaveStatusMissingRead" xml:space="preserve">
+    <value>設定無法使用：缺少 operator.read</value>
+  </data>
+  <data name="ConfigPage_SaveStatusReadOnlyMissingWrite" xml:space="preserve">
+    <value>唯讀：缺少 operator.write</value>
+  </data>
+  <data name="ConfigPage_SaveStatusFixValidationBeforeSaving" xml:space="preserve">
+    <value>儲存前請修正驗證錯誤</value>
+  </data>
+  <data name="ConfigPage_SaveStatusUnsavedChanges" xml:space="preserve">
+    <value>未儲存的變更</value>
+  </data>
+  <data name="ConfigPage_SaveStatusNoUnsavedChanges" xml:space="preserve">
+    <value>沒有未儲存的變更</value>
+  </data>
+  <data name="ConfigPage_AccessDisconnected" xml:space="preserve">
+    <value>已中斷連線</value>
+  </data>
+  <data name="ConfigPage_AccessChecking" xml:space="preserve">
+    <value>正在檢查存取權</value>
+  </data>
+  <data name="ConfigPage_AccessNoRead" xml:space="preserve">
+    <value>沒有設定讀取存取權</value>
+  </data>
+  <data name="ConfigPage_AccessReadOnly" xml:space="preserve">
+    <value>唯讀存取權</value>
+  </data>
+  <data name="ConfigPage_AccessReadWrite" xml:space="preserve">
+    <value>讀取/寫入存取權</value>
+  </data>
+  <data name="ConfigPage_AccessUnknown" xml:space="preserve">
+    <value>未知存取權</value>
+  </data>
+  <data name="ConfigPage_AccessChangesFormat" xml:space="preserve">
+    <value>{0} 項變更</value>
+  </data>
+  <data name="ConfigPage_AccessValidationClean" xml:space="preserve">
+    <value>本機驗證通過</value>
+  </data>
+  <data name="ConfigPage_AccessValidationIssuesFormat" xml:space="preserve">
+    <value>{0} 個驗證問題</value>
+  </data>
+  <data name="ConfigPage_AccessSummaryFormat" xml:space="preserve">
+    <value>{0} · {1} · {2}</value>
+  </data>
+  <data name="DebugPage_NoGatewayConfigured" xml:space="preserve">
+    <value>未設定閘道</value>
+  </data>
+  <data name="DebugPage_StatusConnectedFormat" xml:space="preserve">
+    <value>OpenClaw 已連線到 {0}。</value>
+  </data>
+  <data name="DebugPage_StatusConnectingFormat" xml:space="preserve">
+    <value>正在連線到 {0}…</value>
+  </data>
+  <data name="DebugPage_StatusDisconnectedFormat" xml:space="preserve">
+    <value>未連線。閘道：{0}。</value>
+  </data>
+  <data name="DebugPage_StatusErrorFormat" xml:space="preserve">
+    <value>上次閘道：{0}。請查看事件時間軸。</value>
+  </data>
+  <data name="DebugPage_StatusGatewayFormat" xml:space="preserve">
+    <value>閘道：{0}。</value>
+  </data>
+  <data name="DebugPage_RecentLogTitle" xml:space="preserve">
+    <value>最近記錄</value>
+  </data>
+  <data name="DebugPage_RecentLogCaptionFormat" xml:space="preserve">
+    <value>{0} 的最後 200 行。嚴重性會從 [info]/[warn]/[error] 標籤解析。</value>
+  </data>
+  <data name="DebugPage_CopyFeedbackFormat" xml:space="preserve">
+    <value>{0} 已複製到剪貼簿。</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableTitle" xml:space="preserve">
+    <value>節點沙箱無法使用 — 命令將不受限制地執行</value>
+  </data>
+  <data name="SandboxPage_StatusUnavailableSubtext" xml:space="preserve">
+    <value>此電腦上無法使用隔離，因此命令會在沒有沙箱保護的情況下執行。</value>
+  </data>
+  <data name="SandboxPage_StatusOnTitle" xml:space="preserve">
+    <value>節點沙箱已開啟</value>
+  </data>
+  <data name="SandboxPage_StatusOnSubtext" xml:space="preserve">
+    <value>代理程式在此電腦上執行的程式會被隔離。</value>
+  </data>
+  <data name="SandboxPage_StatusOffTitle" xml:space="preserve">
+    <value>節點沙箱已關閉 — 高風險</value>
+  </data>
+  <data name="SandboxPage_StatusOffSubtext" xml:space="preserve">
+    <value>代理程式在此電腦上執行的程式不會被隔離。</value>
+  </data>
+  <data name="SandboxPage_UnavailableDefaultReason" xml:space="preserve">
+    <value>此電腦上沒有可用的 MXC 沙箱基元。</value>
+  </data>
+  <data name="SandboxPage_WindowsUnsupportedTitle" xml:space="preserve">
+    <value>您的 Windows 版本尚不支援沙箱</value>
+  </data>
+  <data name="SandboxPage_WindowsUnsupportedMessageFormat" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;此電腦上的命令將不受限制地執行 — 沙箱需要包含 AppContainer 基元的較新 Windows 版本。請安裝最新 Windows 更新（或加入 Windows 測試人員計畫以取得最新版本）以啟用隔離。</value>
+  </data>
+  <data name="SandboxPage_OpenWindowsUpdate" xml:space="preserve">
+    <value>開啟 Windows Update</value>
+  </data>
+  <data name="SandboxPage_ComponentsMissingTitle" xml:space="preserve">
+    <value>缺少沙箱元件</value>
+  </data>
+  <data name="SandboxPage_ComponentsMissingMessageFormat" xml:space="preserve">
+    <value>{0}&#x0A;&#x0A;找不到 wxc-exec 二進位檔，因此命令將不受限制地執行。如果這是開發人員組建，請建置托盤應用程式，讓 wxc-exec.exe 複製到輸出資料夾。否則請重新安裝伴侶應用程式以還原沙箱。</value>
+  </data>
+  <data name="SandboxPage_ShowInstallInstructions" xml:space="preserve">
+    <value>顯示安裝指示</value>
+  </data>
+  <data name="SandboxPage_UnavailableTitle" xml:space="preserve">
+    <value>沙箱無法使用 — 命令將不受限制地執行</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovedTitle" xml:space="preserve">
+    <value>本機閘道已移除</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovedMessage" xml:space="preserve">
+    <value>設定已重設；您可以從托盤功能表重新執行設定。</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalErrorsMessage" xml:space="preserve">
+    <value>移除已完成但發生錯誤。請查看記錄以取得詳細資料。</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalCancelledTitle" xml:space="preserve">
+    <value>移除已取消</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalCancelledMessage" xml:space="preserve">
+    <value>閘道可能處於部分移除狀態。請查看記錄或重試。</value>
+  </data>
+  <data name="SettingsPage_ViewLogs" xml:space="preserve">
+    <value>檢視記錄</value>
+  </data>
+  <data name="SettingsPage_LocalGatewayRemovalFailedTitle" xml:space="preserve">
+    <value>移除失敗</value>
+  </data>
+  <data name="SettingsPage_RemoveLocalGatewayButton" xml:space="preserve">
+    <value>移除本機閘道</value>
+  </data>
+  <data name="SettingsPage_RemovingDistro" xml:space="preserve">
+    <value>正在移除散發套件…</value>
+  </data>
+  <data name="SettingsPage_RemovingLocalGatewayMessage" xml:space="preserve">
+    <value>正在移除本機閘道。這可能需要 10–30 秒…</value>
+  </data>
+  <data name="CronPage_NextWakeFormat" xml:space="preserve">
+    <value>· 下次喚醒：{0}</value>
+  </data>
+  <data name="ChatWindow_UnableToLoadChatCredentials" xml:space="preserve">
+    <value>無法載入聊天。閘道 URL 或權杖無法使用。</value>
+  </data>
+  <data name="ChatWindow_UnableToLoadChatRetryFormat" xml:space="preserve">
+    <value>無法載入聊天。請重試。({0})</value>
+  </data>
+  <data name="ChatWindow_WebViewFailedFormat" xml:space="preserve">
+    <value>WebView2 失敗：{0}</value>
+  </data>
+  <data name="CanvasWindow_WebViewInitFailedFormat" xml:space="preserve">
+    <value>無法初始化 WebView2：{0}</value>
+  </data>
+  <data name="CanvasWindow_NavigationFailedFormat" xml:space="preserve">
+    <value>瀏覽失敗：{0}</value>
   </data>
   <data name="ConnectionPage_GatewayHostControlsDescription_Format" xml:space="preserve">
     <value>Open a shell or manage the local gateway service in {0}.</value>

--- a/src/OpenClaw.Tray.WinUI/Windows/CanvasWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/CanvasWindow.xaml.cs
@@ -430,7 +430,7 @@ public sealed partial class CanvasWindow : WindowEx
         {
             LoadingRing.IsActive = false;
             ErrorPanel.Visibility = Visibility.Visible;
-            ErrorText.Text = $"Failed to initialize WebView2: {ex.Message}";
+            ErrorText.Text = LocalizationHelper.Format("CanvasWindow_WebViewInitFailedFormat", ex.Message);
             _webViewReadyTcs.TrySetException(ex);
         }
     }
@@ -502,7 +502,7 @@ public sealed partial class CanvasWindow : WindowEx
             // Show error for failed navigation
             ErrorPanel.Visibility = Visibility.Visible;
             CanvasWebView.Visibility = Visibility.Collapsed;
-            ErrorText.Text = $"Navigation failed: {args.WebErrorStatus}";
+            ErrorText.Text = LocalizationHelper.Format("CanvasWindow_NavigationFailedFormat", args.WebErrorStatus);
         }
         else
         {

--- a/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
@@ -239,7 +239,7 @@ public sealed partial class ChatWindow : WindowEx
         WebView.Visibility = Visibility.Collapsed;
         PlaceholderPanel.Visibility = Visibility.Collapsed;
         ErrorPanel.Visibility = Visibility.Visible;
-        ErrorText.Text = "Unable to load chat. The gateway URL or token is not available.";
+        ErrorText.Text = LocalizationHelper.GetString("ChatWindow_UnableToLoadChatCredentials");
     }
 
     private void StopWebViewNavigation()
@@ -287,7 +287,7 @@ public sealed partial class ChatWindow : WindowEx
                 LoadingRing.Visibility = Visibility.Collapsed;
                 WebView.Visibility = Visibility.Collapsed;
                 ErrorPanel.Visibility = Visibility.Visible;
-                ErrorText.Text = "Unable to load chat. The gateway URL or token is not available.";
+                ErrorText.Text = LocalizationHelper.GetString("ChatWindow_UnableToLoadChatCredentials");
                 return;
             }
 
@@ -305,7 +305,7 @@ public sealed partial class ChatWindow : WindowEx
                 LoadingRing.Visibility = Visibility.Collapsed;
                 WebView.Visibility = Visibility.Collapsed;
                 ErrorPanel.Visibility = Visibility.Visible;
-                ErrorText.Text = $"Unable to load chat. Please try again. ({ex.Message})";
+                ErrorText.Text = LocalizationHelper.Format("ChatWindow_UnableToLoadChatRetryFormat", ex.Message);
                 Logger.Warn($"ChatWindow.RefreshCredentials navigate failed: {ex.Message}");
             }
         }
@@ -372,7 +372,7 @@ public sealed partial class ChatWindow : WindowEx
             LoadingRing.Visibility = Visibility.Collapsed;
             PlaceholderPanel.Visibility = Visibility.Collapsed;
             ErrorPanel.Visibility = Visibility.Visible;
-            ErrorText.Text = $"WebView2 failed: {ex.Message}";
+            ErrorText.Text = LocalizationHelper.Format("ChatWindow_WebViewFailedFormat", ex.Message);
         }
     }
 

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -310,6 +310,29 @@ public sealed class AppRefactorContractTests
         Assert.True(guardIndex < setIconIndex, "Liveness guard must run before SetIcon");
     }
 
+    [Fact]
+    public void AppNotifications_ConnectionIssueUsesStableDedupeKey()
+    {
+        var source = ReadAppSources();
+        var method = ExtractMethod(source, "UpdateConnectionIssueNotification");
+
+        Assert.Contains("private const string ConnectionIssueNotificationDedupeKey = \"connection:issue\"", source);
+        Assert.Contains("ConnectionIssueNotificationDedupeKey", method);
+        Assert.DoesNotContain("$\"connection:{key}\"", method);
+    }
+
+    [Fact]
+    public void AppNotifications_SandboxRiskProbeRunsOffUiPath()
+    {
+        var source = ReadAppSources();
+        var publishMethod = ExtractMethod(source, "PublishSandboxRiskNotificationIfNeeded");
+        var probeMethod = ExtractMethod(source, "StartSandboxRiskProbeIfNeeded");
+
+        Assert.DoesNotContain("MxcAvailability.Probe", publishMethod);
+        Assert.Contains("Task.Run(() => MxcAvailability.Probe", probeMethod);
+        Assert.Contains("ContinueWith", probeMethod);
+    }
+
     private static string ReadCoordinatorSource()
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -333,6 +333,18 @@ public sealed class AppRefactorContractTests
         Assert.Contains("ContinueWith", probeMethod);
     }
 
+    [Fact]
+    public void AppNotifications_SandboxRiskUsesStableDedupeKey()
+    {
+        var source = ReadAppSources();
+
+        Assert.Contains("private const string SandboxRiskNotificationId = \"sandbox:risk\"", source);
+        Assert.Contains("private const string SandboxRiskNotificationDedupeKey = \"sandbox:risk\"", source);
+        Assert.Contains("SandboxRiskNotificationDedupeKey", source);
+        Assert.Contains("id: SandboxRiskNotificationId", source);
+        Assert.DoesNotContain("$\"sandbox:{riskKey}\"", source);
+    }
+
     private static string ReadCoordinatorSource()
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -345,6 +345,19 @@ public sealed class AppRefactorContractTests
         Assert.DoesNotContain("$\"sandbox:{riskKey}\"", source);
     }
 
+    [Fact]
+    public void AppNotifications_SandboxRiskMessageReflectsStrictFallbackBlocking()
+    {
+        var source = ReadAppSources();
+        var method = ExtractMethod(source, "PublishSandboxRiskNotification");
+
+        Assert.Contains("SystemRunBlockHostFallbackWhenMxcUnavailable", method);
+        Assert.Contains("AppNotification_SandboxUnavailableBlocked_Title", method);
+        Assert.Contains("AppNotification_SandboxUnavailableBlocked_MessageFormat", method);
+        Assert.Contains("host-fallback", method);
+        Assert.Contains("blocked", method);
+    }
+
     private static string ReadCoordinatorSource()
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();

--- a/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
@@ -60,6 +60,11 @@ public class LocalizationValidationTests
         // Sample IDs / brand identifiers — same across locales.
         "VoiceSettingsPage_ElevenLabsVoiceIdBox.PlaceholderText",
         "VoiceSettingsPage_ElevenLabsModelBox.PlaceholderText",
+        // Capability command identifier — should match the wire/API name.
+        "NotificationsPage_MetadataSystemRun",
+        // Punctuation-only layout format; localized parts are supplied by
+        // separate placeholders and should keep the same visual separator.
+        "ConfigPage_AccessSummaryFormat",
         // NodesPage detail labels — "Version", "Hardware", and "PATH" are
         // technical loanwords that read the same in every supported locale
         // in this app's audience. Translating them adds no clarity and


### PR DESCRIPTION
## Summary
- promote background connection, pairing, channel, sandbox, and cron issues into app-level notifications
- keep active-page-only feedback local to avoid duplicate UI
- localize new notification/status strings across supported locales

## Validation
- .\build.ps1
- dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore
- dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore

## Screenshots of newly implemented notifications

<img width="1730" height="1514" alt="image" src="https://github.com/user-attachments/assets/b1ee0127-5aab-4462-aa5b-ca227c3bc741" />

<img width="1730" height="1119" alt="image" src="https://github.com/user-attachments/assets/e83e563b-b4af-4089-9460-c4fe040aa137" />
