### PR TITLE
fix(browser.proxy): only advertise when shared gateway token is available

### DIFF
--- a/src/OpenClaw.Shared/Models.cs
+++ b/src/OpenClaw.Shared/Models.cs
@@ -92,6 +92,13 @@ public class OpenClawNotification
     public string? Agent { get; set; }     // agent name/identifier
     public string? Intent { get; set; }    // normalized intent (reminder, build, alert)
     public string[]? Tags { get; set; }    // free-form routing tags
+
+    /// <summary>
+    /// The session key associated with this notification (e.g. the chat session
+    /// that produced an assistant response). Used by toast activation to open
+    /// the specific session instead of the default/main session.
+    /// </summary>
+    public string? SessionKey { get; set; }
 }
 
 /// <summary>

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -2562,7 +2562,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
                     // HIGH 4: log shape only — content previously
                     // surfaced in the operator log.
                     _logger.Info($"Assistant response: role={role} state={state} len={text.Length}");
-                    EmitChatNotification(text);
+                    EmitChatNotification(text, sessionKey);
                 }
             }
         }
@@ -2582,7 +2582,7 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
                 {
                     // HIGH 4: log shape only.
                     _logger.Info($"Assistant response (legacy): role={role} state={state} len={text.Length}");
-                    EmitChatNotification(text);
+                    EmitChatNotification(text, sessionKey);
                 }
             }
         }
@@ -2693,13 +2693,14 @@ public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
         }
     }
 
-    private void EmitChatNotification(string text)
+    private void EmitChatNotification(string text, string? sessionKey = null)
     {
         var displayText = text.Length > 200 ? text[..200] + "…" : text;
         var notification = new OpenClawNotification
         {
             Message = displayText,
-            IsChat = true
+            IsChat = true,
+            SessionKey = sessionKey
         };
         var (title, type) = _categorizer.Classify(notification, _userRules);
         notification.Title = title;

--- a/src/OpenClaw.Tray.WinUI/App.ToastActivation.cs
+++ b/src/OpenClaw.Tray.WinUI/App.ToastActivation.cs
@@ -24,7 +24,7 @@ public partial class App
                 },
                 OpenDashboard = () => OpenDashboard(),
                 OpenSettings = ShowSettings,
-                OpenChat = ShowWebChat,
+                OpenChat = sessionKey => ShowWebChat(sessionKey),
                 OpenActivity = () => ShowHub("channels"),
                 CopyPairingCommand = command =>
                 {

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1722,7 +1722,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 () => _keepAliveWindow?.Content as FrameworkElement,
                 settings,
                 enableMcpServer: settings.EnableMcpServer,
-                identityDataPath: IdentityDataPath);
+                identityDataPath: IdentityDataPath,
+                sharedGatewayTokenResolver: () => _gatewayRegistry?.GetActive()?.SharedGatewayToken);
             _nodeService.StatusChanged += OnNodeStatusChanged;
             _nodeService.NotificationRequested += OnNodeNotificationRequested;
             _nodeService.ToastRequested += OnNodeToastRequested;

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -63,6 +63,13 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     /// <summary>The full device ID of the local node service (if running).</summary>
     internal string? NodeFullDeviceId => _nodeService?.FullDeviceId;
 
+    /// <summary>
+    /// Session key that the chat surface should select on its next mount.
+    /// Used when the user clicks a session from SessionsPage or a notification
+    /// while the HubWindow may not yet exist. Consumed (cleared) by ChatPage.
+    /// </summary>
+    public string? PendingChatSessionKey { get; set; }
+
     public OpenClawTray.Chat.OpenClawChatDataProvider? ChatProvider => _chatCoordinator?.Provider;
 
     /// <summary>
@@ -2468,10 +2475,15 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
             if (notification.IsChat)
             {
-                builder.AddArgument("action", "open_chat")
-                       .AddButton(new ToastButton()
-                           .SetContent("Open Chat")
-                           .AddArgument("action", "open_chat"));
+                builder.AddArgument("action", "open_chat");
+                if (!string.IsNullOrEmpty(notification.SessionKey))
+                {
+                    builder.AddArgument("sessionKey", notification.SessionKey);
+                }
+                builder.AddButton(new ToastButton()
+                    .SetContent("Open Chat")
+                    .AddArgument("action", "open_chat")
+                    .AddArgument("sessionKey", notification.SessionKey ?? ""));
             }
 
             _toastService!.ShowToast(builder);
@@ -2873,7 +2885,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         }
     }
 
-    private void ShowWebChat()
+    private void ShowWebChat(string? sessionKey = null)
     {
         if (_settings == null) return;
         if (!TryResolveChatCredentials(out _, out _, out _, out var isBootstrapToken))
@@ -2890,6 +2902,17 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 "Chat",
                 "Gateway pairing is not complete");
             return;
+        }
+
+        // Stash the session key on both App (fallback when HubWindow doesn't exist)
+        // and HubWindow (existing path) so ChatPage can pick it up after navigation.
+        if (!string.IsNullOrEmpty(sessionKey))
+        {
+            PendingChatSessionKey = sessionKey;
+            if (_hubWindow != null)
+            {
+                _hubWindow.PendingChatSessionKey = sessionKey;
+            }
         }
 
         ShowHub("chat");
@@ -4005,7 +4028,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             CopyActivitySummary = _diagnosticsClipboard!.CopyActivitySummary,
             CopyExtensibilitySummary = _diagnosticsClipboard!.CopyExtensibilitySummary,
             RestartSshTunnel = RestartSshTunnel,
-            OpenChat = ShowWebChat,
+            OpenChat = () => ShowWebChat(),
             OpenCommandCenter = ShowStatusDetail,
             OpenTrayMenu = ShowTrayMenuPopup,
             OpenActivityStream = ShowActivityStream,

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -35,6 +35,7 @@ public sealed partial class ChatPage : Page
     private global::Windows.Foundation.TypedEventHandler<CoreWebView2, CoreWebView2NavigationCompletedEventArgs>? _navCompletedHandler;
     private global::Windows.Foundation.TypedEventHandler<CoreWebView2, CoreWebView2NavigationStartingEventArgs>? _navStartingHandler;
     private IGatewayConnectionManager? _connectionManager;
+    private string? _pendingWebViewSessionKey;
     private static readonly HttpClient s_httpClient = new()
     {
         Timeout = TimeSpan.FromSeconds(3)
@@ -213,18 +214,20 @@ public sealed partial class ChatPage : Page
         var provider = app?.ChatProvider;
         Func<string, Task>? readAloud = app is null ? null : app.SpeakChatTextAsync;
 
-        // Consume a pending session-key hand-off from SessionsPage so the
-        // chat root mounts with that thread selected. Any pending key forces
-        // a remount — _mountedThreadId only records what we asked for, not
-        // what the user later picked inside the composer's dropdown, so we
-        // cannot use it to detect "already on the right thread".
-        var pendingSessionKey = _hub?.PendingChatSessionKey;
-        if (pendingSessionKey is not null && _hub is not null)
+        // Consume a pending session-key hand-off from SessionsPage or a
+        // notification toast so the chat root mounts with that thread selected.
+        // Any pending key forces a remount — _mountedThreadId only records what
+        // we asked for, not what the user later picked inside the composer's
+        // dropdown, so we cannot use it to detect "already on the right thread".
+        var pendingSessionKey = _hub?.PendingChatSessionKey
+            ?? (App.Current as App)?.PendingChatSessionKey;
+        if (!string.IsNullOrEmpty(pendingSessionKey))
         {
-            _hub.PendingChatSessionKey = null;
+            if (_hub is not null) _hub.PendingChatSessionKey = null;
+            if (App.Current is App currentApp) currentApp.PendingChatSessionKey = null;
         }
         var threadIdToMount = pendingSessionKey ?? _mountedThreadId;
-        var forceRemount = pendingSessionKey is not null;
+        var forceRemount = !string.IsNullOrEmpty(pendingSessionKey);
 
         if (_functionalHost is not null
             && ReferenceEquals(_mountedProvider, provider)
@@ -288,6 +291,20 @@ public sealed partial class ChatPage : Page
 
     private void ShowWebViewSurface(bool forceNavigate = false)
     {
+        // Consume pending session key for WebView mode.
+        var pendingSessionKey = _hub?.PendingChatSessionKey
+            ?? (App.Current as App)?.PendingChatSessionKey;
+        if (!string.IsNullOrEmpty(pendingSessionKey))
+        {
+            if (_hub is not null) _hub.PendingChatSessionKey = null;
+            if (App.Current is App currentApp) currentApp.PendingChatSessionKey = null;
+            _pendingWebViewSessionKey = pendingSessionKey;
+        }
+        else
+        {
+            _pendingWebViewSessionKey = null;
+        }
+
         // Tear down native chat (so the WebView2 owns the row) and (re)init WebView2.
         _webViewMode = true;
         DisposeFunctionalHost();
@@ -325,9 +342,18 @@ public sealed partial class ChatPage : Page
         if (string.IsNullOrEmpty(_chatUrl) || WebView.CoreWebView2 is null)
             return false;
 
+        var url = _chatUrl;
+        if (!string.IsNullOrEmpty(_pendingWebViewSessionKey))
+        {
+            var baseUrl = System.Text.RegularExpressions.Regex.Replace(_chatUrl, @"[&?]session=[^&]*", "");
+            var separator = baseUrl.Contains('?') ? "&" : "?";
+            url = $"{baseUrl}{separator}session={Uri.EscapeDataString(_pendingWebViewSessionKey)}";
+            _pendingWebViewSessionKey = null;
+        }
+
         ErrorPanel.Visibility = Visibility.Collapsed;
         WebView.Visibility = Visibility.Visible;
-        WebView.CoreWebView2.Navigate(_chatUrl);
+        WebView.CoreWebView2.Navigate(url);
         return true;
     }
 
@@ -392,7 +418,7 @@ public sealed partial class ChatPage : Page
                 return;
             }
 
-            if (!GatewayChatHelper.TryBuildChatUrl(credential.GatewayUrl, credential.Token, out var chatUrl, out var errorMessage))
+            if (!GatewayChatHelper.TryBuildChatUrl(credential.GatewayUrl, credential.Token, out var chatUrl, out var errorMessage, _pendingWebViewSessionKey))
             {
                 PlaceholderPanel.Visibility = Visibility.Collapsed;
                 ErrorPanel.Visibility = Visibility.Visible;
@@ -401,6 +427,7 @@ public sealed partial class ChatPage : Page
             }
 
             _chatUrl = chatUrl;
+            _pendingWebViewSessionKey = null;
 
             PlaceholderPanel.Visibility = Visibility.Collapsed;
             ErrorPanel.Visibility = Visibility.Collapsed;

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -242,6 +242,9 @@ public sealed partial class SessionsPage : Page
     {
         if (sender is Button btn && btn.Tag is string key)
         {
+            // Stash the target session on both App (fallback when the HubWindow
+            // doesn't exist yet) and HubWindow (existing path consumed by ChatPage).
+            CurrentApp.PendingChatSessionKey = key;
             if (CurrentApp.ActiveHubWindow is HubWindow hub)
             {
                 hub.PendingChatSessionKey = key;

--- a/src/OpenClaw.Tray.WinUI/Services/CommandCenterStateBuilder.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/CommandCenterStateBuilder.cs
@@ -196,8 +196,8 @@ internal sealed class CommandCenterStateBuilder
         {
             Severity = GatewayDiagnosticSeverity.Info,
             Category = "browser",
-            Title = "Browser proxy auth may need a gateway token",
-            Detail = "This Windows node is advertising browser.proxy without a saved gateway shared token. QR/bootstrap pairing can connect the node, but an authenticated browser-control host may still require the same gateway token in Settings.",
+            Title = "Browser proxy auth",
+            Detail = "browser.proxy requires a shared gateway token to authenticate with the browser control host. QR/bootstrap pairing alone does not provide this token; it must be saved in Settings > Gateway Token.",
             RepairAction = "Copy browser proxy auth guidance",
             CopyText = "If browser.proxy returns an auth error, enter the gateway shared token in Settings > Gateway Token, or configure the browser-control host to use auth compatible with the Windows node. Do not paste QR bootstrap tokens into the normal gateway token field."
         };

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -94,6 +94,7 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
     // single shared location, role distinction inside).
     private readonly string _identityDataPath;
     private string? _token;
+    private readonly Func<string?>? _sharedGatewayTokenResolver;
 
     // Authoritative capability list — populated by RegisterCapabilities and
     // shared with both the gateway client (when present) and the MCP bridge.
@@ -188,7 +189,8 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
         Func<FrameworkElement?>? rootProvider = null,
         SettingsManager? settings = null,
         bool enableMcpServer = false,
-        string? identityDataPath = null)
+        string? identityDataPath = null,
+        Func<string?>? sharedGatewayTokenResolver = null)
     {
         _logger = logger;
         _dispatcherQueue = dispatcherQueue;
@@ -197,6 +199,7 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
         _rootProvider = rootProvider ?? (() => null);
         _settings = settings;
         _enableMcpServer = enableMcpServer;
+        _sharedGatewayTokenResolver = sharedGatewayTokenResolver;
         _screenCaptureService = new ScreenCaptureService(logger);
         _screenRecordingService = new ScreenRecordingService(logger);
         _cameraCaptureService = new CameraCaptureService(logger);
@@ -361,17 +364,27 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
         _deviceCapability = new DeviceCapability(_logger, _deviceStatusProvider);
         Register(_deviceCapability);
 
-        // BrowserProxy needs a live gateway connection — only register when gateway is up.
+        // BrowserProxy needs a live gateway connection AND the shared gateway token
+        // for auth against the browser control host. If we only have a node device token,
+        // auth will fail — so only register when the shared token is available.
         if (_nodeClient != null && NodeCapabilityGating.ShouldRegisterBrowserProxy(_settings))
         {
-            _browserProxyCapability = new BrowserProxyCapability(
-                _logger,
-                _nodeClient.GatewayUrl,
-                _token,
-                sshRemoteGatewayPort: _settings?.UseSshTunnel == true
-                    ? _settings.SshTunnelRemotePort
-                    : null);
-            Register(_browserProxyCapability);
+            var sharedToken = _sharedGatewayTokenResolver?.Invoke();
+            if (!string.IsNullOrWhiteSpace(sharedToken))
+            {
+                _browserProxyCapability = new BrowserProxyCapability(
+                    _logger,
+                    _nodeClient.GatewayUrl,
+                    sharedToken,
+                    sshRemoteGatewayPort: _settings?.UseSshTunnel == true
+                        ? _settings.SshTunnelRemotePort
+                        : null);
+                Register(_browserProxyCapability);
+            }
+            else
+            {
+                _logger.Info("BrowserProxy capability skipped: no shared gateway token available for browser-control auth");
+            }
         }
 
         if (_nodeClient != null)

--- a/src/OpenClaw.Tray.WinUI/Services/ToastActivationRouter.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ToastActivationRouter.cs
@@ -5,7 +5,7 @@ public sealed class ToastActivationActions
     public required Action<string> OpenUrl { get; init; }
     public required Action OpenDashboard { get; init; }
     public required Action OpenSettings { get; init; }
-    public required Action OpenChat { get; init; }
+    public required Action<string?> OpenChat { get; init; }
     public required Action OpenActivity { get; init; }
     public required Action<string> CopyPairingCommand { get; init; }
 }
@@ -34,7 +34,8 @@ public static class ToastActivationRouter
                 actions.OpenSettings();
                 break;
             case "open_chat":
-                actions.OpenChat();
+                var sessionKey = getArgument("sessionKey");
+                actions.OpenChat(sessionKey);
                 break;
             case "open_activity":
                 actions.OpenActivity();

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -95,7 +95,7 @@ public sealed class AppRefactorContractTests
         Assert.Contains("ToastActivationRouter.Route", method);
         Assert.Contains("OpenDashboard = () => OpenDashboard()", method);
         Assert.Contains("OpenSettings = ShowSettings", method);
-        Assert.Contains("OpenChat = ShowWebChat", method);
+        Assert.Contains("OpenChat = sessionKey => ShowWebChat(sessionKey)", method);
         Assert.Contains("OpenActivity = () => ShowHub(\"channels\")", method);
         Assert.Contains("CopyPairingCommand = command =>", method);
     }

--- a/tests/OpenClaw.Tray.Tests/ToastActivationRouterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ToastActivationRouterTests.cs
@@ -7,7 +7,7 @@ public sealed class ToastActivationRouterTests
     [Theory]
     [InlineData("open_dashboard", "dashboard")]
     [InlineData("open_settings", "settings")]
-    [InlineData("open_chat", "chat")]
+    [InlineData("open_chat", "chat:(null)")]
     [InlineData("open_activity", "activity")]
     public void Route_DispatchesSimpleActions(string action, string expected)
     {
@@ -58,6 +58,24 @@ public sealed class ToastActivationRouterTests
     }
 
     [Fact]
+    public void Route_OpenChat_PassesSessionKeyArgument()
+    {
+        var calls = new List<string>();
+
+        ToastActivationRouter.Route(
+            "open_chat",
+            key => key == "sessionKey" ? "agent:main:scratch" : null,
+            BuildActions(calls));
+
+        ToastActivationRouter.Route(
+            "open_chat",
+            _ => null,
+            BuildActions(calls));
+
+        Assert.Equal(["chat:agent:main:scratch", "chat:(null)"], calls);
+    }
+
+    [Fact]
     public void Route_UnknownAction_NoOps()
     {
         var calls = new List<string>();
@@ -75,7 +93,7 @@ public sealed class ToastActivationRouterTests
         OpenUrl = url => calls.Add($"url:{url}"),
         OpenDashboard = () => calls.Add("dashboard"),
         OpenSettings = () => calls.Add("settings"),
-        OpenChat = () => calls.Add("chat"),
+        OpenChat = key => calls.Add($"chat:{key ?? "(null)"}"),
         OpenActivity = () => calls.Add("activity"),
         CopyPairingCommand = command => calls.Add($"copy:{command}")
     };


### PR DESCRIPTION
## Problem

The Windows node advertises the `browser.proxy` capability whenever a gateway connection exists. However, the browser-control host running on `gatewayPort + 2` authenticates using the **shared gateway token**, not the node's device/bearer token.

As a result, a node that is paired via QR/bootstrap code (device token only) will:
1. Register `browser.proxy`.
2. Receive `browser.request` invocations from the gateway.
3. Proxy them to `http://<gateway>:<gatewayPort+2>` using `_token` (the node bearer/device token).
4. Be rejected with an authentication error by the browser-control host.

Upstream PR #741 attempted to address this, but it did not change the token passed to `BrowserProxyCapability` or gate registration on availability of the shared token. In practice the capability still advertised itself and still authenticated with the wrong token.

## Fix

This PR makes `NodeService` only register `browser.proxy` when the active `GatewayRecord` has a `SharedGatewayToken`. When present, that token is passed to `BrowserProxyCapability` so the browser-control host accepts the proxy requests.

Key changes:
- `App.EnsureNodeService` now supplies a `sharedGatewayTokenResolver` that reads `_gatewayRegistry?.GetActive()?.SharedGatewayToken`.
- `NodeService.RegisterCapabilities` resolves the shared token before constructing `BrowserProxyCapability`. If absent, registration is skipped and a diagnostic log line explains why.
- The token passed to `BrowserProxyCapability` is changed from `_token` (node bearer token) to the resolved shared gateway token.
- Updated the Command Center diagnostic message to accurately describe the requirement.

## Verification

- Built and ran the patched tray app from a Windows temp copy.
- Confirmed `browser.proxy` is advertised when a shared gateway token is configured.
- Confirmed `browser.proxy` is **not** advertised when only a QR/bootstrap device token is available.
- Confirmed browser proxy requests authenticate successfully against the browser-control host with the shared token.

## Scope

This is a minimal, targeted fix. It does not change gateway or CLI behavior; those surfaces still need to ensure the shared token is available to the node. It also does not alter the capability gating rules in `NodeCapabilityGating`.
