### PR TITLE
fix(browser.proxy): use shared gateway token and gate registration on token availability

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1715,7 +1715,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 () => _keepAliveWindow?.Content as FrameworkElement,
                 settings,
                 enableMcpServer: settings.EnableMcpServer,
-                identityDataPath: IdentityDataPath);
+                identityDataPath: IdentityDataPath,
+                sharedGatewayTokenResolver: () => _gatewayRegistry?.GetActive()?.SharedGatewayToken);
             _nodeService.StatusChanged += OnNodeStatusChanged;
             _nodeService.NotificationRequested += OnNodeNotificationRequested;
             _nodeService.ToastRequested += OnNodeToastRequested;

--- a/src/OpenClaw.Tray.WinUI/Services/CommandCenterStateBuilder.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/CommandCenterStateBuilder.cs
@@ -196,8 +196,8 @@ internal sealed class CommandCenterStateBuilder
         {
             Severity = GatewayDiagnosticSeverity.Info,
             Category = "browser",
-            Title = "Browser proxy auth may need a gateway token",
-            Detail = "This Windows node is advertising browser.proxy without a saved gateway shared token. QR/bootstrap pairing can connect the node, but an authenticated browser-control host may still require the same gateway token in Settings.",
+            Title = "Browser proxy auth",
+            Detail = "browser.proxy requires a shared gateway token to authenticate with the browser control host. QR/bootstrap pairing alone does not provide this token; it must be saved in Settings > Gateway Token.",
             RepairAction = "Copy browser proxy auth guidance",
             CopyText = "If browser.proxy returns an auth error, enter the gateway shared token in Settings > Gateway Token, or configure the browser-control host to use auth compatible with the Windows node. Do not paste QR bootstrap tokens into the normal gateway token field."
         };

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -94,6 +94,7 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
     // single shared location, role distinction inside).
     private readonly string _identityDataPath;
     private string? _token;
+    private readonly Func<string?>? _sharedGatewayTokenResolver;
 
     // Authoritative capability list — populated by RegisterCapabilities and
     // shared with both the gateway client (when present) and the MCP bridge.
@@ -188,7 +189,8 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
         Func<FrameworkElement?>? rootProvider = null,
         SettingsManager? settings = null,
         bool enableMcpServer = false,
-        string? identityDataPath = null)
+        string? identityDataPath = null,
+        Func<string?>? sharedGatewayTokenResolver = null)
     {
         _logger = logger;
         _dispatcherQueue = dispatcherQueue;
@@ -197,6 +199,7 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
         _rootProvider = rootProvider ?? (() => null);
         _settings = settings;
         _enableMcpServer = enableMcpServer;
+        _sharedGatewayTokenResolver = sharedGatewayTokenResolver;
         _screenCaptureService = new ScreenCaptureService(logger);
         _screenRecordingService = new ScreenRecordingService(logger);
         _cameraCaptureService = new CameraCaptureService(logger);
@@ -361,17 +364,27 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
         _deviceCapability = new DeviceCapability(_logger, _deviceStatusProvider);
         Register(_deviceCapability);
 
-        // BrowserProxy needs a live gateway connection — only register when gateway is up.
+        // BrowserProxy needs a live gateway connection AND the shared gateway token
+        // for auth against the browser control host. If we only have a node device token,
+        // auth will fail — so only register when the shared token is available.
         if (_nodeClient != null && NodeCapabilityGating.ShouldRegisterBrowserProxy(_settings))
         {
-            _browserProxyCapability = new BrowserProxyCapability(
-                _logger,
-                _nodeClient.GatewayUrl,
-                _token,
-                sshRemoteGatewayPort: _settings?.UseSshTunnel == true
-                    ? _settings.SshTunnelRemotePort
-                    : null);
-            Register(_browserProxyCapability);
+            var sharedToken = _sharedGatewayTokenResolver?.Invoke();
+            if (!string.IsNullOrWhiteSpace(sharedToken))
+            {
+                _browserProxyCapability = new BrowserProxyCapability(
+                    _logger,
+                    _nodeClient.GatewayUrl,
+                    sharedToken,
+                    sshRemoteGatewayPort: _settings?.UseSshTunnel == true
+                        ? _settings.SshTunnelRemotePort
+                        : null);
+                Register(_browserProxyCapability);
+            }
+            else
+            {
+                _logger.Info("BrowserProxy capability skipped: no shared gateway token available for browser-control auth");
+            }
         }
 
         if (_nodeClient != null)


### PR DESCRIPTION
## Problem

The Windows node advertises the `browser.proxy` capability whenever a gateway connection exists and the user setting is enabled. However, the browser-control host running on `gatewayPort + 2` authenticates using the **shared gateway token**, not the node's device/bearer token.

As a result, a node that is paired via QR/bootstrap code (device token only) will:
1. Register `browser.proxy`.
2. Receive `browser.request` invocations from the gateway.
3. Proxy them to `http://<gateway>:<gatewayPort+2>` using `_token` (the node bearer/device token).
4. Be rejected with an authentication error by the browser-control host.

Upstream PR #741 was merged as a "gateway hardening" change, but it did not change the token passed to `BrowserProxyCapability` or gate registration on availability of the shared token. Current `main` still passes the node bearer token:

```csharp
// src/OpenClaw.Tray.WinUI/Services/NodeService.cs (current main)
_browserProxyCapability = new BrowserProxyCapability(
    _logger,
    _nodeClient.GatewayUrl,
    _token,   // <-- node bearer token, wrong for browser-control auth
    ...
```

And `NodeCapabilityGating.ShouldRegisterBrowserProxy` only checks the settings toggle, not token availability:

```csharp
// src/OpenClaw.Tray.WinUI/Services/NodeCapabilityGating.cs (current main)
public static bool ShouldRegisterBrowserProxy(SettingsManager? s) =>
    s?.NodeBrowserProxyEnabled != false;
```

## Fix

This PR makes `NodeService` only register `browser.proxy` when the active `GatewayRecord` has a `SharedGatewayToken`. When present, that token is passed to `BrowserProxyCapability` so the browser-control host accepts the proxy requests.

Key changes:
- `App.EnsureNodeService` now supplies a `sharedGatewayTokenResolver` that reads `_gatewayRegistry?.GetActive()?.SharedGatewayToken`.
- `NodeService.RegisterCapabilities` resolves the shared token before constructing `BrowserProxyCapability`. If absent, registration is skipped and a diagnostic log line explains why.
- The token passed to `BrowserProxyCapability` is changed from `_token` (node bearer token) to the resolved shared gateway token.
- Updated the Command Center diagnostic message to accurately describe the requirement.

## Why this is not a duplicate of upstream #741

Upstream PR #741 added registry-backed credential storage and a shared-token resolver, but **it did not update the browser proxy capability to use the shared token**. The capability registration path on `main` still passes `_token` (the WebSocket bearer token) to `BrowserProxyCapability`. The browser-control host, listening on the gateway's HTTP port + 2, expects HTTP `?token=` auth with the shared gateway token. Until that mismatch is fixed, browser proxy auth fails for any node that lacks a configured shared token.

This PR is intentionally minimal: it only changes the browser proxy registration path and does not touch chat session routing or any other feature.

## Verification

- Built and ran the patched tray app from a Windows temp copy (`C:\Users\Lenovo\AppData\Local\Temp\openclaw-build\`).
- Confirmed `browser.proxy` is **advertised** when a shared gateway token is configured.
- Confirmed `browser.proxy` is **not advertised** when only a QR/bootstrap device token is available.
- Confirmed browser proxy requests authenticate successfully against the browser-control host with the shared token.

## Scope

Minimal, targeted fix. Does not alter gateway or CLI behavior. Does not touch session routing.
