### PR TITLE
fix(agents): sync autoreview scope guard

### DIFF
--- a/.agents/skills/autoreview/SKILL.md
+++ b/.agents/skills/autoreview/SKILL.md
@@ -1,26 +1,19 @@
 ---
 name: autoreview
-description: "Auto Review closeout. Codex review is the default when no engine is set and is the recommended reviewer."
+description: "Pre-commit/ship code review: Codex default; optional Claude, Pi, Droid, Copilot, or OpenCode."
 ---
 
 # Auto Review
 
 Run the bundled structured review helper as a closeout check. This is code review, not Guardian `auto_review` approval routing.
 
-Codex review is the default when no engine is set. It usually delivers the best review results and should remain the normal final closeout engine.
+Codex review is the default when no engine is set. It uses `gpt-5.5` by default, usually delivers the best review results, and should remain the normal final closeout engine. Claude review is optional and uses `claude-fable-5` by default.
 
 Use when:
 
-- user asks for Codex review / Claude review / autoreview / second-model review
+- user asks for Codex review / Claude review / Pi review / Droid review / OpenCode review / autoreview / second-model review
 - after non-trivial code edits, before final/commit/ship
 - reviewing a local branch or PR branch after fixes
-
-OpenClaw Windows Node specifics:
-
-- The release/default branch is `main`; the helper resolves `origin/HEAD` so do not hardcode `origin/master`.
-- After review-triggered code changes, run the repo-required validation: `./build.ps1`, `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`, and `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`.
-- If the checkout is on macOS/Linux or lacks .NET/PowerShell/Windows SDK prerequisites, report the validation blocker clearly instead of pretending the Windows validation ran.
-- Do not send absolute local checkout paths, home-directory names, or private temp/worktree paths to review engines; use repo-relative labels or the repo name.
 
 ## Contract
 
@@ -29,7 +22,9 @@ OpenClaw Windows Node specifics:
 - Read dependency docs/source/types when the finding depends on external behavior.
 - Reject unrealistic edge cases, speculative risks, broad rewrites, and fixes that over-complicate the codebase.
 - Prefer small fixes at the right ownership boundary; no refactor unless it clearly improves the bug class.
-- Keep going until structured review returns no accepted/actionable findings.
+- When an accepted finding shows a bug class or repeated pattern, inspect the current PR scope for sibling instances before fixing.
+- Fix the scoped bug class at once when practical; stop at touched surfaces, owner boundaries, and clear follow-up territory.
+- Keep going until structured review returns no accepted/actionable findings only while the work remains inside the original task scope.
 - If a review-triggered fix changes code, rerun focused tests and rerun the structured review helper.
 - For security-audit suppression changes, verify accepted findings remain auditable: suppressed findings stay in structured output, active output keeps an unsuppressible suppression notice, and aggregate findings cannot hide unrelated active risk.
 - Never switch or override the requested review engine/model. If the review hits model capacity, retry the same command a few times with the same engine/model.
@@ -38,7 +33,8 @@ OpenClaw Windows Node specifics:
 - Do not kill a review just because it has been quiet for 2-5 minutes, or because it is still running under the 30-minute window. Inspect the process only after missing multiple expected heartbeats, after 30 minutes, or after an obviously failed subprocess; prefer letting the same helper command finish.
 - Tools are useful in review mode. The helper allows read-only inspection tools and web search by default so reviewers can check dependency contracts, upstream docs, and current behavior.
 - Security perspective is always included, but it should not cripple legitimate functionality. Report security findings only when the change creates a concrete, actionable risk or removes an important safety check.
-- For regression provenance, if no blamed PR is traceable, use the blamed commit as the provenance: commit SHA, date, and author username. Do not guess a merger or frame missing PR metadata as a separate finding.
+- For regression provenance, keep roles separate: blamed code author, blamed PR author, PR merger/committer, current PR author, and PR/date. If no blamed PR is traceable, use the blamed commit as the provenance: commit SHA, date, and author username. Do not guess a merger or frame missing PR metadata as a separate finding.
+- If the blamed PR was merged by `clawsweeper[bot]` or another automation, identify the human trigger when practical. Check timeline/comments first; if rate-limited, use gitcrawl/cache or public PR HTML. Look for maintainer commands such as `@clawsweeper automerge`, `/landpr`, or labels/status comments that armed automerge. Report `automerge triggered by @login`; if not found, say trigger unknown.
 - Do not invoke built-in `codex review`, nested reviewers, or reviewer panels from inside the review. The helper builds one bundle, calls one selected engine, validates one structured result, and stops.
 - Stop as soon as the helper exits 0 with no accepted/actionable findings. Do not run an extra review just to get a nicer "clean" line, a second opinion, or clearer closeout wording.
 - Treat the helper's successful exit plus absence of actionable findings as the clean review result, even if the underlying Codex CLI output is terse.
@@ -48,12 +44,75 @@ OpenClaw Windows Node specifics:
 - If Gitcrawl reports a portable manifest mismatch, source/runtime DB health error, or stale portable-store checkout, run `gitcrawl doctor --json` and inspect `source_db_health`, `runtime_db_health`, and `portable_store_status` before falling back to live GitHub.
 - Do not push just to review. Push only when the user requested push/ship/PR update.
 
+## Scope Governor
+
+Autoreview is a closeout gate, not permission to rewrite the task.
+
+Before the first review, freeze a scope baseline: original request or issue, target branch, intended behavior, owner boundary, changed files, and non-test LOC. For inherited or already-bloated branches, use the intended PR diff as the baseline rather than accepting all existing branch drift.
+
+Before patching a finding, classify it:
+
+- **In-scope blocker**: the finding is introduced by the current diff, affects the same owner boundary, and can be fixed without changing the task's contract.
+- **Follow-up**: the finding is real but belongs to an adjacent bug class, sibling surface, cleanup, or broader hardening track.
+- **Stop-and-escalate**: the finding requires a new protocol/config/storage/public API contract, a different owner boundary, a release-process change, or a design choice outside the original request.
+
+Stop patching and report the scope break instead of continuing when:
+
+- a narrow PR turns into an architecture change, protocol change, migration, or release-process change;
+- the diff grows past 2x the original files or non-test LOC without explicit approval to expand scope;
+- two review-triggered patch cycles have not converged; pause and reclassify every remaining finding before another edit;
+- the best fix is "define the canonical contract first" rather than another local inference layer;
+- fixing the accepted finding would make the PR no longer describe the same behavior, issue, or owner boundary.
+
+After the two-cycle pause, continue only when every remaining accepted finding is still an in-scope blocker. Otherwise preserve the useful analysis, identify the smallest safe landed subset if one exists, and open or request a follow-up for the larger fix. Do not keep committing speculative fixes just to satisfy the reviewer.
+
+Do not stack or push review-triggered fix commits while scope classification or focused proof is unresolved. Keep exploratory edits local until the cycle is proven in scope; if scope breaks, remove them from the landing lane instead of preserving them as branch history.
+
+Critical exceptions must be explicit: active data loss, crash, broken install/upgrade, release blocker, or concrete security exposure. If the exception is not one of those, it is not critical enough to blow up scope.
+
+## Release Branches And Release Process
+
+On release, beta, stable, hotfix, signing, notarization, appcast, package-publish, or release-check work, use freeze discipline even when the branch name is not release-like:
+
+- Fix only release blockers, failed release infrastructure, exact backports, install/upgrade breakage, data loss, crashes, or concrete security exposure.
+- Treat non-blocking autoreview findings as follow-ups for `main`, not reasons to broaden the release branch.
+- Do not introduce new product behavior, config surface, protocol shape, migration, plugin ownership, docs narrative, or process policy unless it directly unblocks the release.
+- Keep proof tied to the release target: exact branch/ref, failing check or shipped-risk reason, smallest command/proof, and whether the fix must also forward-port to `main`.
+- If review discovers a real but non-critical design problem during release closeout, stop with a follow-up issue/PR plan; do not use the release branch as the refactor lane.
+
+## Skill Path (set once)
+
+Set the skill script paths once, then use `"$AUTOREVIEW"` and `"$AUTOREVIEW_HARNESS"` in the examples below.
+
+Choose one:
+
+```bash
+# Project-local skill in the current repo:
+export AUTOREVIEW=".agents/skills/autoreview/scripts/autoreview"
+export AUTOREVIEW_HARNESS=".agents/skills/autoreview/scripts/test-review-harness"
+```
+
+```bash
+# Source checkout of openclaw/agent-skills:
+export AUTOREVIEW="skills/autoreview/scripts/autoreview"
+export AUTOREVIEW_HARNESS="skills/autoreview/scripts/test-review-harness"
+```
+
+```bash
+# Global skill:
+export AGENTS_HOME="${AGENTS_HOME:-$HOME/.agents}"
+export AUTOREVIEW="$AGENTS_HOME/skills/autoreview/scripts/autoreview"
+export AUTOREVIEW_HARNESS="$AGENTS_HOME/skills/autoreview/scripts/test-review-harness"
+```
+
+When using Claude Code, set `AGENTS_HOME="$HOME/.claude"` for global skills. Project-local skills live under `.claude/skills/` in the current repo.
+
 ## Pick Target
 
 Dirty local work:
 
 ```bash
-<autoreview-helper> --mode local
+"$AUTOREVIEW" --mode local
 ```
 
 Use this only when the patch is actually unstaged/staged/untracked in the
@@ -66,41 +125,39 @@ only proves there is no local patch.
 Branch/PR work:
 
 ```bash
-<autoreview-helper> --mode branch --base origin/main
+"$AUTOREVIEW" --mode branch --base origin/main
 ```
 
-Optional review context is first-class:
+Optional review context is first-class. Prompt files and datasets must be repo-relative so review bundles cannot pull arbitrary host files:
 
 ```bash
-<autoreview-helper> --mode branch --base origin/main --prompt-file /tmp/review-notes.md --dataset /tmp/evidence.json
+"$AUTOREVIEW" --mode branch --base origin/main --prompt-file review-notes.md --dataset evidence.json
 ```
 
 If an open PR exists, use its actual base:
 
 ```bash
 base=$(gh pr view --json baseRefName --jq .baseRefName)
-<autoreview-helper> --mode branch --base "origin/$base"
+"$AUTOREVIEW" --mode branch --base "origin/$base"
 ```
 
 Committed single change:
 
 ```bash
-<autoreview-helper> --mode commit --commit HEAD
+"$AUTOREVIEW" --mode commit --commit HEAD
 ```
 
-or with the helper:
-
-Use commit review for already-landed or already-pushed work on the default
-branch. Reviewing clean `main` against `origin/main` is usually an empty
-diff after push. For a small stack, review each commit explicitly or review the
-branch before merging with `--base`.
+Use commit review for already-landed or already-pushed work on `main`. Reviewing
+clean `main` against `origin/main` is usually an empty diff after push. For a
+small stack, review each commit explicitly or review the branch before merging
+with `--base`.
 
 ## Parallel Closeout
 
 Format first if formatting can change line locations. Then it is OK to run tests and review in parallel:
 
 ```bash
-scripts/autoreview --parallel-tests "<focused test command>"
+"$AUTOREVIEW" --parallel-tests "<focused test command>"
 ```
 
 On Windows, the default `--parallel-tests` shell preserves the platform `cmd.exe`
@@ -114,30 +171,112 @@ Tradeoff: tests may force code changes that stale the review. If tests or review
 Run multiple reviewers against one frozen bundle:
 
 ```bash
-<autoreview-helper> --reviewers codex,claude
+"$AUTOREVIEW" --reviewers codex,claude,pi,droid
 ```
 
 `--panel` is shorthand for Codex plus Claude unless `--engine` changes the first reviewer:
 
 ```bash
-<autoreview-helper> --panel
+"$AUTOREVIEW" --panel
 ```
 
 Set reviewer models and thinking/effort explicitly:
 
 ```bash
-<autoreview-helper> --reviewers codex,claude --model codex=gpt-5.1 --thinking codex=high --model claude=sonnet --thinking claude=max
+"$AUTOREVIEW" --reviewers codex,claude --model codex=gpt-5.5 --thinking codex=high --model claude=claude-fable-5 --thinking claude=max
 ```
 
-Inline syntax is also supported:
+Inline syntax is also supported for simple model IDs:
 
 ```bash
-<autoreview-helper> --reviewers codex:gpt-5.1:high,claude:sonnet:max
+"$AUTOREVIEW" --reviewers codex:gpt-5.5:high,claude:claude-fable-5:max
 ```
 
-Codex maps thinking to `model_reasoning_effort` and accepts `low`, `medium`,
-`high`, or `xhigh`. Claude maps thinking to `--effort` and also accepts `max`.
-Engines without a real thinking knob reject `--thinking`.
+For models with slashes or extra colons, prefer keyed form:
+
+```bash
+"$AUTOREVIEW" --engine pi --model anthropic/claude-sonnet-4 --thinking high
+"$AUTOREVIEW" --engine opencode --model opencode/north-mini-code-free --thinking high
+"$AUTOREVIEW" --engine droid --model claude-opus-4-8 --thinking low
+"$AUTOREVIEW" --reviewers codex,pi --model codex=gpt-5.5 --model pi=anthropic/claude-sonnet-4
+"$AUTOREVIEW" --reviewers codex,opencode --model codex=gpt-5.5 --model opencode=opencode/north-mini-code-free
+"$AUTOREVIEW" --reviewers codex,droid --model codex=gpt-5.5 --model droid=claude-opus-4-8
+```
+
+## Models and thinking
+
+The helper accepts `--model` globally or per engine (`engine=model`) and `--thinking` globally or per engine (`engine=level`). Repeat either flag for multiple reviewers.
+
+Recommended model defaults:
+
+| Engine | Default model | Source note |
+|--------|---------------|-------------|
+| **codex** (default) | `gpt-5.5` | OpenAI's current GPT-5.5 alias |
+| **claude** | `claude-fable-5` | Anthropic's most capable widely released Claude model |
+
+CLI flags and environment variables override these defaults. Droid, Copilot, Pi, and OpenCode do not get built-in model defaults here because their provider catalogs are external to the Codex/Claude closeout path and may vary by installation.
+
+| Engine | Model flag | Example model IDs | Thinking flag | Accepted levels |
+|--------|------------|-------------------|---------------|-----------------|
+| **codex** (default) | `codex --model X exec ...` | `gpt-5.5`, `gpt-5.5-2026-04-23` | `-c model_reasoning_effort=Y` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh` |
+| **claude** | `claude --model X` | `claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5` | `--effort Y` | `low`, `medium`, `high`, `xhigh`, `max` |
+| **droid** | `droid exec --model X` | `claude-opus-4-8`, Factory model IDs | `-r, --reasoning-effort Y` | `off`, `none`, `low`, `medium`, `high` |
+| **copilot** | `copilot --model X` | `gpt-5.2`, Copilot model aliases | not supported | n/a |
+| **pi** | `pi --model X` | `anthropic/claude-sonnet-4`, `openai/gpt-4o` | `--thinking Y` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh` |
+| **opencode** | `opencode run -m X` | `opencode/north-mini-code-free`, OpenCode provider/model IDs | `--variant Y` | `minimal`, `low`, `medium`, `high`, `max` |
+
+Claude also supports `--fallback-model a,b` for availability-based fallback chains ([model-config](https://code.claude.com/docs/en/model-config)). Current Claude docs note that auth, billing, rate-limit, request-size, and transport errors do not trigger fallback, and the changelog documents interactive-session support in `v2.1.166`.
+
+Examples matching current `main` behavior:
+
+```bash
+# Codex with explicit model and reasoning
+"$AUTOREVIEW" --engine codex --model gpt-5.5 --thinking high
+
+# Claude Code aliases or full model names, with optional availability fallback
+"$AUTOREVIEW" --engine claude --model claude-fable-5 --thinking max
+"$AUTOREVIEW" --engine claude --model claude-fable-5 --fallback-model claude-opus-4-8,claude-sonnet-4-6
+
+# Factory Droid with explicit model and reasoning effort
+"$AUTOREVIEW" --engine droid --model claude-opus-4-8 --thinking low
+
+# GitHub Copilot (model only; no thinking knob)
+"$AUTOREVIEW" --engine copilot --model gpt-5.2
+
+# Pi with explicit model and thinking level
+"$AUTOREVIEW" --engine pi --model anthropic/claude-sonnet-4 --thinking high --pi-bin pi
+
+# OpenCode with explicit provider/model and variant
+"$AUTOREVIEW" --engine opencode --model opencode/north-mini-code-free --thinking high
+```
+
+### Environment defaults
+
+CLI flags take precedence over environment variables.
+
+| Variable | Purpose |
+|----------|---------|
+| `AUTOREVIEW_MODEL` | Override the built-in default `--model` for all engines |
+| `AUTOREVIEW_THINKING` | Default `--thinking` for all engines |
+| `AUTOREVIEW_FALLBACK_MODEL` | Default Claude `--fallback-model` chain |
+| `AUTOREVIEW_<ENGINE>_MODEL` | Per-engine model override, for example `AUTOREVIEW_CODEX_MODEL=gpt-5.5` |
+| `AUTOREVIEW_<ENGINE>_THINKING` | Per-engine thinking override |
+| `AUTOREVIEW_CLAUDE_FALLBACK_MODEL` | Claude-only fallback chain |
+
+Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Droid maps thinking to `-r, --reasoning-effort`. Pi maps thinking to `--thinking`. OpenCode maps thinking to `--variant`. Copilot rejects `--thinking`. Only Claude accepts `--fallback-model`; global CLI/env fallback requires at least one Claude reviewer, and engine-specific fallback overrides require that reviewer to be selected. Non-Claude fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
+
+## Review engine isolation
+
+When autoreview runs inside the repository under review, external reviewer CLIs must not load project-local trust or configuration that the branch controls.
+
+| Engine | Isolation flags | Reference |
+|--------|-----------------|-----------|
+| **codex** | Auth-only config overrides, `-c project_doc_max_bytes=0`, repo `trust_level="untrusted"`, `exec --ignore-user-config --ignore-rules`, plus read-only sandbox | Codex CLI `exec --help` |
+| **claude** | `--safe-mode --setting-sources user --strict-mcp-config --disallowedTools mcp__*` plus explicit `--allowedTools` (`--safe-mode` requires Claude Code `v2.1.169+`) | Claude Code [CLI reference](https://code.claude.com/docs/en/cli-reference) |
+| **pi** | `--no-approve --no-session --no-context-files --no-extensions --no-skills --no-prompt-templates --no-themes`, plus read-only tool allowlist | Pi CLI `--help`; requires Pi `v0.79.0+` |
+| **opencode** | `opencode run --dir <repo> --pure --format json`, prompt over stdin, neutral subprocess cwd, injected deny-by-default permissions, project config disabled | OpenCode CLI `--help` |
+
+Codex `--ignore-user-config` skips config loading for the exec run. Autoreview reconstructs only the documented `cli_auth_credentials_store`, `forced_login_method`, and `forced_chatgpt_workspace_id` settings from `CODEX_HOME/config.toml`, keeping authentication and workspace restrictions usable without forwarding unrelated user configuration. The explicit repo trust override and zero project-doc budget keep reviewed-repo `AGENTS.md` and `.codex/` trust surfaces out of the review prompt. `--ignore-rules` skips user/project execpolicy rules. Claude `--safe-mode` disables project hooks, skills, plugins, MCP servers, and CLAUDE.md while preserving normal authentication, model selection, built-in tools, and permissions; managed settings policy can still apply. `--setting-sources user` avoids project/local settings from the reviewed checkout, and current Claude Code docs note the project-skill blocking behavior was fixed in `v2.1.69`. `--strict-mcp-config` and `--disallowedTools mcp__*` keep MCP unavailable to the review run. `--bare` is not used here because Claude's headless docs say it skips OAuth and keychain reads. Pi `--no-approve` ignores project-local files for one run; the helper requires Pi `v0.79.0+` plus help output that advertises every required isolation flag because older legacy binaries can ignore unknown flags. The current package is `@earendil-works/pi-coding-agent`; deprecated `@mariozechner/pi-coding-agent` `0.73.x` is intentionally rejected. Pi version/help probes and the review command run from neutral temporary directories, not the reviewed repo. Pi `--no-context-files` removes `AGENTS.md`/`CLAUDE.md`, the resource-disable flags keep `.pi` extensions, skills, prompts, and themes out of the run, `--no-session` avoids writing review sessions, and the read-only allowlist omits `bash`, `edit`, and `write`. OpenCode starts from a neutral temporary directory, points at the reviewed repo with `--dir`, disables project config through `OPENCODE_DISABLE_PROJECT_CONFIG=1`, and injects `OPENCODE_CONFIG_CONTENT`; permissions default to deny, allow read/grep/glob, preserve OpenCode's `.env` ask rules, and gate `websearch`/`webfetch` with `--no-web-search`. The injected config also clears command/instruction/plugin arrays and disables write/edit/bash/task/skill/todowrite tools without changing user auth storage. The helper sends the review prompt over stdin rather than argv and extracts the final structured JSON from `type: "text"` events. OpenCode rejects `--no-tools`.
 
 ## Context Efficiency
 
@@ -145,26 +284,28 @@ Run the helper directly so target selection, engine choice, structured validatio
 
 ## Helper
 
-OpenClaw Windows Node repo-local helper:
+After setting `AUTOREVIEW` and `AUTOREVIEW_HARNESS` above:
 
 ```bash
-.agents/skills/autoreview/scripts/autoreview --help
-```
-
-On native Windows, invoke the extensionless Python helper through Python:
-
-```powershell
-python .agents\skills\autoreview\scripts\autoreview --help
+"$AUTOREVIEW" --help
 ```
 
 The smoke harness has thin shell wrappers over a shared Python implementation:
 
 ```bash
-.agents/skills/autoreview/scripts/test-review-harness --fixture benign --engine codex
+"$AUTOREVIEW_HARNESS" --fixture benign --engine codex
 ```
 
+On native Windows, invoke the extensionless Python helper through Python:
+
 ```powershell
-.agents\skills\autoreview\scripts\test-review-harness.ps1 -Fixture benign -Engine codex
+python skills\autoreview\scripts\autoreview --help
+```
+
+and the smoke harness:
+
+```powershell
+skills\autoreview\scripts\test-review-harness.ps1 -Fixture benign -Engine codex
 ```
 
 The helper:
@@ -172,20 +313,22 @@ The helper:
 - chooses dirty local changes first
 - accepts `--mode uncommitted` as an alias for `--mode local`
 - otherwise uses current PR base if `gh pr view` works
-- otherwise uses the remote default branch for non-default branches
-- supports `--engine codex`, `claude`, `droid`, and `copilot`; default is `AUTOREVIEW_ENGINE` or `codex`; Codex should remain the default when nothing is set
-- use `--mode commit --commit <ref>` for already-committed work, especially clean default-branch work after landing
+- otherwise uses `origin/main` for non-main branches
+- does not fetch automatically during branch review; the selected base ref must already resolve locally
+- supports `--engine codex`, `claude`, `droid`, `copilot`, `pi`, and `opencode`; default is `AUTOREVIEW_ENGINE` or `codex`; Codex should remain the default when nothing is set
+- resolves bare `git`, `gh`, reviewer, and PowerShell shell commands from absolute `PATH` entries only, never from the reviewed checkout; explicit relative `--*-bin` paths are resolved from the reviewed repository root
+- use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
 - should be left in `--mode auto` or forced to `--mode branch` for PR/branch work; do not force `--mode local` after committing
 - writes only to stdout unless `--output`, `--json-output`, or live streamed engine stderr is set
-- supports `--dry-run`, `--parallel-tests`, `--parallel-tests-shell`, `--prompt`, `--prompt-file`, `--dataset`, `--no-tools`, `--no-web-search`, and commit refs
+- supports `--dry-run`, `--parallel-tests`, `--parallel-tests-shell`, `--prompt`, repo-relative `--prompt-file`, repo-relative `--dataset`, `--no-tools`, `--no-web-search`, and commit refs
 - supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
-- supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model` and `--thinking`
-- allows read-only tools and web search by default only for sandboxed Codex review; forbids nested review in the prompt; Codex is run through `codex exec` with read-only sandbox and structured output
-- disables non-Codex unsandboxed reviewer tools by default; set `AUTOREVIEW_ALLOW_UNSANDBOXED_TOOLS=1` only when that tradeoff is intentional
-- invokes reviewer engines from sanitized temporary workspaces so local home/worktree paths are not exposed; set `AUTOREVIEW_SAFE_TMP` if the default neutral temp root is unavailable
-- writes Codex sidecar files and the full change bundle inside the sanitized workspace as `schema.json`, `output.json`, `CHANGE_BUNDLE.md`, or `prompt.txt` for read-only inspection
-- redacts common local home-directory path shapes from review bundles, omits symlink contents from text bundles, and omits raw symlink patch bodies
-- caps patch, untracked-file, and local-bundle text with explicit truncation markers so dirty checkouts cannot silently create unbounded prompts
+- supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model`, `--thinking`, and Claude `--fallback-model`
+- uses built-in model defaults `codex=gpt-5.5` and `claude=claude-fable-5`; honors `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`, and per-engine `AUTOREVIEW_<ENGINE>_MODEL` / `AUTOREVIEW_<ENGINE>_THINKING` environment overrides when CLI flags are omitted
+- allows read-only tools and web search by default where the selected CLI supports them; forbids nested review in the prompt; Codex is run through `codex exec` with auth-only user settings, read-only sandbox, reviewed-repo instruction/config/rule isolation flags, and structured output
+- runs Claude with `--safe-mode` (`v2.1.169+`), `--setting-sources user`, MCP disabled, explicit allowed tools, and `--fallback-model` when set, so reviewed-repo hooks/skills/MCP do not affect the review run while normal auth still works; managed settings policy can still apply
+- runs Droid with `droid exec` in read-only mode, forwards `--model` and `-r, --reasoning-effort`, and switches `--output-format` to `stream-json` when streaming is enabled
+- runs Pi `v0.79.0+` from neutral temporary directories with `--no-approve`, `--no-session`, disabled Pi context/resource loading, and built-in read-only tools (`read,grep,find,ls`) when tools are enabled
+- runs OpenCode with `opencode run --dir <repo> --pure --format json` from a neutral temporary directory, forwards `--model` and `--variant`, injects deny-by-default permissions, disables project config loading, and passes the review prompt over stdin
 - prints `review still running: <engine> elapsed=<seconds>s pid=<pid>` to stderr at long-running intervals while waiting for the selected review engine, unless streamed output or compact Codex activity has been visible recently
 - prints `autoreview clean: no accepted/actionable findings reported` when the selected review command exits 0
 - exits nonzero when accepted/actionable findings are present

--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -2,13 +2,13 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import concurrent.futures
 import copy
 import json
 import os
 import queue
 import re
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -19,22 +19,87 @@ from pathlib import Path
 from typing import Any, Callable
 
 
-ENGINES = ("codex", "claude", "droid", "copilot")
-THINKING_LEVELS_BY_ENGINE = {
-    "codex": {"low", "medium", "high", "xhigh"},
-    "claude": {"low", "medium", "high", "xhigh", "max"},
-    "droid": set(),
-    "copilot": set(),
-}
-PATCH_LIMIT = 180_000
-UNTRACKED_FILE_LIMIT = 180_000
-BUNDLE_LIMIT = 500_000
-MIN_UNTRACKED_BUDGET = 1_000
-PRIVATE_PATH_PATTERNS = (
-    re.compile(r"/" r"Users/" r"[^\r\n'\"`<>]+"),
-    re.compile(r"/" r"home/" r"[^\r\n'\"`<>]+"),
-    re.compile(r"[A-Za-z]:[\\/]+Users[\\/]+[^\r\n'\"`<>]+", re.IGNORECASE),
+ENGINES = ("codex", "claude", "droid", "copilot", "pi", "opencode")
+SAFE_GIT_CONFIG_ARGS = (
+    "-c",
+    "core.fsmonitor=false",
+    "-c",
+    "core.pager=cat",
+    "-c",
+    "diff.external=",
+    "-c",
+    "diff.renames=false",
+    "-c",
+    "pager.diff=cat",
+    "-c",
+    "pager.log=cat",
+    "-c",
+    "pager.show=cat",
 )
+SAFE_DIFF_FLAGS = ("--no-ext-diff", "--no-textconv", "--no-renames")
+ENGINE_GIT_CONFIG_OVERRIDES = (
+    ("core.fsmonitor", "false"),
+    ("core.pager", "cat"),
+    ("diff.external", ""),
+    ("diff.renames", "false"),
+    ("pager.diff", "cat"),
+    ("pager.log", "cat"),
+    ("pager.show", "cat"),
+)
+SENSITIVE_PATH_PARTS = {
+    ".aws",
+    ".azure",
+    ".config/gcloud",
+    ".docker",
+    ".gnupg",
+    ".ssh",
+    "private",
+    "secrets",
+}
+SENSITIVE_NAME_PATTERNS = [
+    re.compile(r"(^|/)\.env($|[._/-])", re.IGNORECASE),
+    re.compile(r"(^|/)(id_rsa|id_dsa|id_ecdsa|id_ed25519)(\.pub)?$", re.IGNORECASE),
+    re.compile(r"\.(pem|p12|pfx|key)$", re.IGNORECASE),
+    re.compile(
+        r"(^|/)[^/]*(secret|token|credential|credentials|service[-_]?account|private[-_]?key|apikey|api[-_]?key)[^/]*$",
+        re.IGNORECASE,
+    ),
+]
+SECRET_VALUE_PATTERNS = [
+    re.compile(r"-----BEGIN (?:RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY-----"),
+    re.compile(
+        r"(?i)(api[_-]?key|token|secret|password)\s*[:=]\s*(?:[\"'][A-Za-z0-9_./+=-]{12,}[\"']|[A-Za-z0-9_+=/-]{20,})"
+    ),
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._-]{20,}"),
+    re.compile(r"\b(?:sk|rk|pk|org|proj)-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bnpm_[A-Za-z0-9]{20,}\b"),
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b"),
+    re.compile(r"\b(?:A3T|AKIA|ASIA)[A-Z0-9]{16}\b"),
+    re.compile(r"\bAIza[0-9A-Za-z_-]{35}\b"),
+    re.compile(r"\bya29\.[0-9A-Za-z_-]{20,}\b"),
+]
+MAX_BUNDLE_TEXT_BYTES = 180_000
+DEFAULT_ENGINE_PATHS = ("/usr/local/bin", "/usr/bin", "/bin")
+DEFAULT_MODEL_BY_ENGINE = {
+    "codex": "gpt-5.5",
+    "claude": "claude-fable-5",
+}
+THINKING_LEVELS_BY_ENGINE = {
+    "codex": {"none", "minimal", "low", "medium", "high", "xhigh"},
+    "claude": {"low", "medium", "high", "xhigh", "max"},
+    "droid": {"off", "none", "low", "medium", "high"},
+    "copilot": set(),
+    "pi": {"off", "minimal", "low", "medium", "high", "xhigh"},
+    "opencode": {"minimal", "low", "medium", "high", "max"},
+}
+CLAUDE_SAFE_MODE_MIN_VERSION = (2, 1, 169)
+# Pi's reviewed-repo trust override first appears in the current
+# @earendil-works/pi-coding-agent 0.79.0 CLI line. Older legacy binaries can
+# ignore unknown flags, so the Pi engine must fail closed below this floor.
+PI_TRUST_ISOLATION_MIN_VERSION = (0, 79, 0)
 
 
 SCHEMA: dict[str, Any] = {
@@ -91,7 +156,14 @@ SCHEMA: dict[str, Any] = {
 }
 
 
-def run(args: list[str], cwd: Path, *, input_text: str | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+def run(
+    args: list[str],
+    cwd: Path,
+    *,
+    input_text: str | None = None,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
         args,
         cwd=cwd,
@@ -99,11 +171,256 @@ def run(args: list[str], cwd: Path, *, input_text: str | None = None, check: boo
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env=env,
     )
     if check and result.returncode != 0:
         cmd = " ".join(args)
         raise SystemExit(f"command failed ({result.returncode}): {cmd}\n{result.stderr or result.stdout}")
     return result
+
+
+def subprocess_env(extra: dict[str, str] | None) -> dict[str, str] | None:
+    if not extra:
+        return None
+    merged = os.environ.copy()
+    merged.update(extra)
+    return merged
+
+
+def safe_git_env() -> dict[str, str]:
+    return {
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_SYSTEM": os.devnull,
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_TERMINAL_PROMPT": "0",
+        "HOME": os.environ.get("HOME", str(Path.home())),
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "PATH": os.pathsep.join(DEFAULT_ENGINE_PATHS),
+    }
+
+
+def safe_engine_path(repo: Path, extra_paths: list[Path] | None = None) -> str:
+    entries: list[str] = []
+    resolved_repo = repo.resolve()
+
+    def add(path: str | Path) -> None:
+        candidate = Path(path).expanduser()
+        if not candidate.is_absolute() or not candidate.exists():
+            return
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            return
+        if is_within(resolved, resolved_repo):
+            return
+        value = str(resolved)
+        if value not in entries:
+            entries.append(value)
+
+    for path in extra_paths or []:
+        add(path)
+    for part in os.environ.get("PATH", "").split(os.pathsep):
+        if part:
+            add(part)
+    for path in DEFAULT_ENGINE_PATHS:
+        add(path)
+    return os.pathsep.join(entries)
+
+
+def safe_engine_env(
+    repo: Path,
+    extra_paths: list[Path] | None = None,
+    extra: dict[str, str] | None = None,
+) -> dict[str, str]:
+    blocked_exact = {
+        "BASH_ENV",
+        "ENV",
+        "GIT_CONFIG",
+        "GIT_CONFIG_GLOBAL",
+        "GIT_CONFIG_NOSYSTEM",
+        "GIT_CONFIG_SYSTEM",
+        "GIT_OPTIONAL_LOCKS",
+        "GIT_TERMINAL_PROMPT",
+        "LD_PRELOAD",
+        "NODE_OPTIONS",
+        "PYTHONHOME",
+        "PYTHONPATH",
+    }
+    blocked_prefixes = ("GIT_", "DYLD_")
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in blocked_exact and not any(key.startswith(prefix) for prefix in blocked_prefixes)
+    }
+    env["PATH"] = safe_engine_path(repo, extra_paths)
+    env["GIT_CONFIG_COUNT"] = str(len(ENGINE_GIT_CONFIG_OVERRIDES))
+    for index, (key, value) in enumerate(ENGINE_GIT_CONFIG_OVERRIDES):
+        env[f"GIT_CONFIG_KEY_{index}"] = key
+        env[f"GIT_CONFIG_VALUE_{index}"] = value
+    env.update(extra or {})
+    return env
+
+
+def parse_ps_time(value: str) -> float:
+    try:
+        day_text, clock = value.strip().split("-", 1) if "-" in value else ("0", value.strip())
+        parts = clock.split(":")
+        if not parts or len(parts) > 3:
+            return 0.0
+        total = float(parts[-1])
+        if len(parts) >= 2:
+            total += int(parts[-2]) * 60
+        if len(parts) == 3:
+            total += int(parts[-3]) * 3600
+        return int(day_text) * 86400 + total
+    except (IndexError, ValueError):
+        return 0.0
+
+
+def process_pids(repo: Path, pid: int) -> list[str]:
+    ps = find_command("ps", repo)
+    if not ps:
+        return [str(pid)]
+    result = subprocess.run(
+        [ps, "-A", "-o", "pid=", "-o", "ppid="],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if result.returncode != 0:
+        return [str(pid)]
+    pids = [str(pid)]
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if len(fields) == 2 and fields[1] == str(pid):
+            pids.append(fields[0])
+    return pids
+
+
+def sample_process_metrics(repo: Path, pid: int) -> tuple[float, float, int, str] | None:
+    ps = find_command("ps", repo)
+    if not ps:
+        return None
+    try:
+        result = subprocess.run(
+            [
+                ps,
+                "-o",
+                "state=",
+                "-o",
+                "rss=",
+                "-o",
+                "time=",
+                "-p",
+                ",".join(process_pids(repo, pid)),
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+
+    cpu_seconds = 0.0
+    rss_kb = 0
+    states: list[str] = []
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if len(fields) < 3:
+            continue
+        states.append(fields[0][:1] or "?")
+        try:
+            rss_kb += int(fields[1])
+        except ValueError:
+            pass
+        cpu_seconds += parse_ps_time(fields[2])
+    if not states:
+        return None
+    return (time.monotonic(), cpu_seconds, rss_kb, ",".join(sorted(set(states))))
+
+
+def format_process_metrics(
+    previous: tuple[float, float, int, str] | None,
+    current: tuple[float, float, int, str] | None,
+) -> str:
+    if current is None:
+        return ""
+    interval = max(0.0, current[0] - previous[0]) if previous else 0.0
+    cpu_delta = max(0.0, current[1] - previous[1]) if previous else 0.0
+    cpu_percent = (cpu_delta / interval * 100) if interval > 0 else 0.0
+    rss_mb = int(round(current[2] / 1024))
+    interval_seconds = int(interval) if interval else 0
+    return (
+        f" cpu={cpu_delta:.1f}s/{interval_seconds}s({cpu_percent:.0f}%)"
+        f" rss={rss_mb}M state={current[3]}"
+    )
+
+
+def emit_heartbeat(
+    label: str,
+    repo: Path,
+    started: float,
+    proc: subprocess.Popen,
+    metrics: tuple[float, float, int, str] | None,
+) -> tuple[float, float, int, str] | None:
+    elapsed = int(time.monotonic() - started)
+    next_metrics = sample_process_metrics(repo, proc.pid)
+    metrics_text = format_process_metrics(metrics, next_metrics)
+    print(f"review still running: {label} elapsed={elapsed}s pid={proc.pid}{metrics_text}", file=sys.stderr, flush=True)
+    return next_metrics or metrics
+
+
+def opencode_review_config(web_search: bool = True) -> dict[str, Any]:
+    permission: dict[str, Any] = {
+        "*": "deny",
+        "read": {
+            "*": "allow",
+            "*.env": "ask",
+            "*.env.*": "ask",
+            "*.env.example": "allow",
+        },
+        "grep": "allow",
+        "glob": "allow",
+    }
+    if web_search:
+        permission["websearch"] = "allow"
+        permission["webfetch"] = "allow"
+    else:
+        permission["websearch"] = "deny"
+        permission["webfetch"] = "deny"
+    return {
+        "$schema": "https://opencode.ai/config.json",
+        "autoupdate": False,
+        "command": {},
+        "instructions": [],
+        "plugin": [],
+        "permission": permission,
+        "share": "disabled",
+        "tools": {
+            "bash": False,
+            "edit": False,
+            "skill": False,
+            "task": False,
+            "todowrite": False,
+            "write": False,
+        },
+    }
+
+
+def opencode_review_env(web_search: bool = True) -> dict[str, str]:
+    return {
+        "OPENCODE_DISABLE_PROJECT_CONFIG": "1",
+        "OPENCODE_CONFIG_CONTENT": json.dumps(opencode_review_config(web_search), separators=(",", ":")),
+        "OPENCODE_DISABLE_AUTOUPDATE": "1",
+        "OPENCODE_DISABLE_AUTOCOMPACT": "1",
+        "OPENCODE_DISABLE_MODELS_FETCH": "1",
+    }
 
 
 def run_with_heartbeat(
@@ -115,7 +432,10 @@ def run_with_heartbeat(
     heartbeat_seconds: int = 60,
     stream_output: bool = False,
     stream_display: Callable[[str, str], str | None] | None = None,
+    env: dict[str, str] | None = None,
+    resolve_root: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
+    resolve_root = resolve_root or cwd
     if stream_output:
         return run_with_stream(
             args,
@@ -124,6 +444,8 @@ def run_with_heartbeat(
             label=label,
             heartbeat_seconds=heartbeat_seconds,
             stream_display=stream_display,
+            env=env,
+            resolve_root=resolve_root,
         )
     started = time.monotonic()
     proc = subprocess.Popen(
@@ -133,8 +455,10 @@ def run_with_heartbeat(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        env=env,
     )
     first_communicate = True
+    metrics = sample_process_metrics(resolve_root, proc.pid)
     while True:
         try:
             stdout, stderr = proc.communicate(
@@ -144,8 +468,7 @@ def run_with_heartbeat(
             return subprocess.CompletedProcess(args, int(proc.returncode or 0), stdout, stderr)
         except subprocess.TimeoutExpired:
             first_communicate = False
-            elapsed = int(time.monotonic() - started)
-            print(f"review still running: {label} elapsed={elapsed}s pid={proc.pid}", file=sys.stderr, flush=True)
+            metrics = emit_heartbeat(label, resolve_root, started, proc, metrics)
 
 
 def run_with_stream(
@@ -156,6 +479,8 @@ def run_with_stream(
     label: str,
     heartbeat_seconds: int,
     stream_display: Callable[[str, str], str | None] | None,
+    env: dict[str, str] | None = None,
+    resolve_root: Path,
 ) -> subprocess.CompletedProcess[str]:
     started = time.monotonic()
     proc = subprocess.Popen(
@@ -166,6 +491,7 @@ def run_with_stream(
         stderr=subprocess.PIPE,
         text=True,
         bufsize=1,
+        env=env,
     )
     events: queue.Queue[tuple[str, str | None]] = queue.Queue()
     stdout_parts: list[str] = []
@@ -195,14 +521,14 @@ def run_with_stream(
         thread.start()
     stdin_thread = threading.Thread(target=write_stdin, daemon=True)
     stdin_thread.start()
+    metrics = sample_process_metrics(resolve_root, proc.pid)
 
     open_streams = 2
     while open_streams:
         try:
             name, line = events.get(timeout=heartbeat_seconds)
         except queue.Empty:
-            elapsed = int(time.monotonic() - started)
-            print(f"review still running: {label} elapsed={elapsed}s pid={proc.pid}", file=sys.stderr, flush=True)
+            metrics = emit_heartbeat(label, resolve_root, started, proc, metrics)
             continue
         if line is None:
             open_streams -= 1
@@ -225,45 +551,48 @@ def run_with_stream(
 
 
 def git(repo: Path, *args: str, check: bool = True) -> str:
-    return run(["git", *args], repo, check=check).stdout
+    return run(
+        [resolve_command("git", repo), "--no-optional-locks", *SAFE_GIT_CONFIG_ARGS, *args],
+        repo,
+        check=check,
+        env=safe_git_env(),
+    ).stdout
+
+
+def git_path_list(repo: Path, *args: str, check: bool = True) -> list[str]:
+    return [path for path in git(repo, *args, check=check).split("\0") if path]
 
 
 def repo_root() -> Path:
+    start = Path.cwd().resolve()
+    unsafe_root = discover_repo_root(start) or start
+    git_bin = find_command("git", unsafe_root)
+    if not git_bin:
+        raise SystemExit("git executable not found. Install Git or add it to PATH.")
     result = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
+        [git_bin, "--no-optional-locks", *SAFE_GIT_CONFIG_ARGS, "rev-parse", "--show-toplevel"],
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env=safe_git_env(),
     )
     if result.returncode != 0:
         raise SystemExit("autoreview must run inside a git repository")
     return Path(result.stdout.strip()).resolve()
 
 
+def discover_repo_root(start: Path) -> Path | None:
+    current = start
+    while True:
+        if (current / ".git").exists():
+            return current
+        if current.parent == current:
+            return None
+        current = current.parent
+
+
 def current_branch(repo: Path) -> str:
     return git(repo, "branch", "--show-current", check=False).strip() or "detached"
-
-
-def default_branch(repo: Path) -> str:
-    remote_head = git(
-        repo,
-        "symbolic-ref",
-        "--quiet",
-        "--short",
-        "refs/remotes/origin/HEAD",
-        check=False,
-    ).strip()
-    if remote_head.startswith("origin/"):
-        return remote_head.removeprefix("origin/")
-    for candidate in ("main", "master"):
-        result = run(["git", "rev-parse", "--verify", f"origin/{candidate}"], repo, check=False)
-        if result.returncode == 0:
-            return candidate
-    return "main"
-
-
-def default_base_ref(repo: Path) -> str:
-    return f"origin/{default_branch(repo)}"
 
 
 def is_dirty(repo: Path) -> bool:
@@ -273,18 +602,17 @@ def is_dirty(repo: Path) -> bool:
 def choose_target(repo: Path, mode: str, base_ref: str | None) -> tuple[str, str | None]:
     mode = "local" if mode == "uncommitted" else mode
     branch = current_branch(repo)
-    default = default_branch(repo)
     if mode == "local" or (mode == "auto" and is_dirty(repo)):
         return "local", None
     if mode == "commit":
         return "commit", None
-    if mode == "branch" or (mode == "auto" and branch != default):
-        return "branch", base_ref or detect_pr_base(repo) or default_base_ref(repo)
-    raise SystemExit(f"no review target: clean {default} checkout and no forced mode")
+    if mode == "branch" or (mode == "auto" and branch != "main"):
+        return "branch", base_ref or detect_pr_base(repo) or "origin/main"
+    raise SystemExit("no review target: clean main checkout and no forced mode")
 
 
 def detect_pr_base(repo: Path) -> str | None:
-    gh_bin = shutil.which("gh")
+    gh_bin = find_command("gh", repo)
     if not gh_bin:
         return None
     result = run([gh_bin, "pr", "view", "--json", "baseRefName", "--jq", ".baseRefName"], repo, check=False)
@@ -292,104 +620,87 @@ def detect_pr_base(repo: Path) -> str | None:
     return f"origin/{base}" if result.returncode == 0 and base else None
 
 
-def resolve_command(name: str) -> str:
-    resolved = shutil.which(name)
+def resolve_command(name: str, repo: Path) -> str:
+    resolved = find_command(name, repo)
     if resolved:
         return resolved
-    raise SystemExit(f"review engine executable not found: {name}. Install it or pass the matching --*-bin option.")
+    raise SystemExit(f"executable not found: {name}. Install it or pass an explicit trusted path when supported.")
 
 
-def command_exists(name: str) -> bool:
-    return shutil.which(name) is not None
+def find_command(name: str, repo: Path) -> str | None:
+    command = Path(name)
+    if has_directory_component(name, command):
+        base = command if command.is_absolute() else repo / command
+        return first_executable_candidate(base)
+    for part in os.environ.get("PATH", "").split(os.pathsep):
+        if not part or part == ".":
+            continue
+        path_part = Path(part)
+        if not path_part.is_absolute():
+            continue
+        try:
+            resolved_part = path_part.resolve()
+            resolved_repo = repo.resolve()
+        except OSError:
+            continue
+        if is_within(resolved_part, resolved_repo):
+            continue
+        found = first_executable_candidate(resolved_part / name, reject_root=resolved_repo)
+        if found:
+            return found
+    return None
 
 
-def choose_default_engine(args: argparse.Namespace) -> str:
-    if command_exists(args.codex_bin):
-        return "codex"
-    if command_exists(args.copilot_bin) and allow_unsandboxed_tools():
-        return "copilot"
-    return "codex"
+def is_within(path: Path, root: Path) -> bool:
+    return path == root or path.is_relative_to(root)
+
+
+def has_directory_component(name: str, command: Path) -> bool:
+    separators = [separator for separator in (os.sep, os.altsep) if separator]
+    return command.is_absolute() or bool(command.drive) or any(separator in name for separator in separators)
+
+
+def first_executable_candidate(path: Path, *, reject_root: Path | None = None) -> str | None:
+    if os.name == "nt" and not path.suffix:
+        extensions = [ext for ext in os.environ.get("PATHEXT", ".COM;.EXE;.BAT;.CMD").split(";") if ext]
+        candidates = [path.with_suffix(ext.lower()) for ext in extensions]
+        candidates.extend(path.with_suffix(ext.upper()) for ext in extensions)
+        candidates.append(path)
+    else:
+        candidates = [path]
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            if reject_root is not None:
+                try:
+                    if is_within(candidate.resolve(), reject_root):
+                        continue
+                except OSError:
+                    continue
+            return str(candidate)
+    return None
+
+
+def validate_git_ref(repo: Path, ref: str, label: str) -> str:
+    if not ref or ref.startswith("-") or ":" in ref or "\0" in ref or any(char.isspace() for char in ref):
+        raise SystemExit(f"unsafe {label} ref: {ref}")
+    result = git(
+        repo,
+        "rev-parse",
+        "--verify",
+        "--quiet",
+        "--end-of-options",
+        f"{ref}^{{commit}}",
+        check=False,
+    )
+    if not result:
+        raise SystemExit(f"unknown {label} ref: {ref}")
+    return ref
 
 
 def bounded(text: str, limit: int = 180_000) -> str:
     if len(text) <= limit:
         return text
     return text[:limit] + f"\n\n[truncated at {limit} characters]\n"
-
-
-def redact_private_paths(text: str) -> str:
-    redacted = text
-    for pattern in PRIVATE_PATH_PATTERNS:
-        redacted = pattern.sub("[redacted-local-path]", redacted)
-    return redacted
-
-
-def sanitize_git_patch(patch: str) -> str:
-    blocks: list[list[str]] = []
-    current: list[str] = []
-    for line in patch.splitlines(keepends=True):
-        if line.startswith("diff --git ") and current:
-            blocks.append(current)
-            current = []
-        current.append(line)
-    if current:
-        blocks.append(current)
-
-    sanitized: list[str] = []
-    for block in blocks:
-        sanitized.extend(sanitize_symlink_diff_block(block))
-    return redact_private_paths("".join(sanitized))
-
-
-def sanitize_symlink_diff_block(block: list[str]) -> list[str]:
-    old_symlink = any(line.startswith(("deleted file mode 120000", "old mode 120000")) for line in block)
-    new_symlink = any(line.startswith(("new file mode 120000", "new mode 120000")) for line in block)
-    mode_line_seen = any(is_symlink_mode_line(line) for line in block)
-    if is_symlink_index_only_block(block, mode_line_seen):
-        old_symlink = True
-        new_symlink = True
-    if not old_symlink and not new_symlink:
-        return block
-
-    result: list[str] = []
-    omitted_old = False
-    omitted_new = False
-    in_hunk = False
-    for line in block:
-        if line.startswith("@@"):
-            in_hunk = True
-            result.append(line)
-            continue
-        if in_hunk and old_symlink and line.startswith("-") and not line.startswith("--- "):
-            if not omitted_old:
-                result.append("-[symlink target omitted]\n")
-                omitted_old = True
-            continue
-        if in_hunk and new_symlink and line.startswith("+") and not line.startswith("+++ "):
-            if not omitted_new:
-                result.append("+[symlink target omitted]\n")
-                omitted_new = True
-            continue
-        if in_hunk and old_symlink and new_symlink and line.startswith(" "):
-            continue
-        result.append(line)
-    return result
-
-
-def is_symlink_index_only_block(block: list[str], mode_line_seen: bool) -> bool:
-    return not mode_line_seen and any(is_symlink_index_line(line) for line in block)
-
-
-def is_symlink_index_line(line: str) -> bool:
-    if not line.startswith("index "):
-        return False
-    parts = line.split()
-    return len(parts) >= 3 and parts[-1] == "120000"
-
-
-def is_symlink_mode_line(line: str) -> bool:
-    prefixes = ("new file mode ", "deleted file mode ", "old mode ", "new mode ")
-    return line.startswith(prefixes) and line.strip().endswith("120000")
 
 
 def bounded_field(text: str, limit: int) -> str:
@@ -399,91 +710,199 @@ def bounded_field(text: str, limit: int) -> str:
     return text[: max(0, limit - len(suffix))] + suffix
 
 
-def read_text(path: Path, limit: int | None = 40_000, display_path: str | None = None) -> str:
-    label = display_path or path.name
-    if path.is_symlink():
-        return f"[symlink omitted: {label}]"
+def read_prefix(path: Path, limit: int) -> tuple[bytes, bool]:
     try:
-        data = path.read_bytes()
-    except OSError:
-        return f"[unreadable: {label}]"
+        with path.open("rb") as handle:
+            data = handle.read(limit + 1)
+    except OSError as exc:
+        raise SystemExit(f"unreadable file: {path}: {exc}") from exc
+    return data[:limit], len(data) > limit
+
+
+def read_text(path: Path, limit: int = MAX_BUNDLE_TEXT_BYTES) -> str:
+    try:
+        data, truncated = read_prefix(path, limit)
+    except SystemExit as exc:
+        return f"[unreadable: {exc}]"
     if b"\0" in data:
         return "[binary file omitted]"
-    text = redact_private_paths(data.decode("utf-8", errors="replace"))
-    if limit is None:
-        return text
-    return bounded(text, limit)
+    text = data.decode("utf-8", errors="replace")
+    if len(text) > limit:
+        text = text[:limit]
+        truncated = True
+    if truncated:
+        return text + f"\n\n[truncated at {limit} characters]\n"
+    return text
+
+
+def path_has_sensitive_part(rel: str | Path) -> bool:
+    normalized = Path(rel).as_posix().lower()
+    if "/.config/gcloud/" in f"/{normalized}/":
+        return True
+    return any(part.lower() in SENSITIVE_PATH_PARTS for part in Path(rel).parts)
+
+
+def raw_repo_path_has_symlink_component(repo: Path, rel_path: Path) -> bool:
+    current = repo.resolve()
+    for part in rel_path.parts:
+        current = current / part
+        if current.is_symlink():
+            return True
+        if not current.exists():
+            break
+    return False
+
+
+def secret_text_risk(text: str) -> bool:
+    return any(pattern.search(text) for pattern in SECRET_VALUE_PATTERNS)
+
+
+def require_no_secret_values(label: str, text: str) -> None:
+    if secret_text_risk(text):
+        raise SystemExit(
+            "refusing to include secret-like content in review bundle; "
+            f"clean or redact {label} before running autoreview"
+        )
+
+
+def file_bundle_risk(
+    repo: Path,
+    path: Path,
+    rel: str,
+    *,
+    allow_binary_omission: bool = False,
+) -> str | None:
+    normalized = rel.replace(os.sep, "/")
+    if path_has_sensitive_part(normalized):
+        return "sensitive path"
+    for pattern in SENSITIVE_NAME_PATTERNS:
+        if pattern.search(normalized):
+            return "sensitive filename"
+    if path.is_symlink():
+        return "symlink"
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError as exc:
+        return f"unreadable file: {exc}"
+    if not is_within(resolved, repo.resolve()):
+        return "path outside repository"
+    if not path.is_file():
+        return "not a regular file"
+    try:
+        data, _ = read_prefix(path, MAX_BUNDLE_TEXT_BYTES)
+    except SystemExit as exc:
+        return str(exc)
+    if b"\0" in data:
+        return None if allow_binary_omission else "binary file"
+    if secret_text_risk(data.decode("utf-8", errors="replace")):
+        return "secret-like content"
+    return None
+
+
+def safe_untracked_files(repo: Path) -> list[str]:
+    files = git_path_list(repo, "ls-files", "--others", "--exclude-standard", "-z")
+    blocked: list[str] = []
+    included: list[str] = []
+    for rel in files:
+        risk = file_bundle_risk(repo, repo / rel, rel, allow_binary_omission=True)
+        if risk:
+            blocked.append(f"{rel} ({risk})")
+        else:
+            included.append(rel)
+    if blocked:
+        details = "\n".join(f"- {item}" for item in blocked[:20])
+        more = f"\n... {len(blocked) - 20} more" if len(blocked) > 20 else ""
+        raise SystemExit(
+            "refusing to include untracked sensitive files in review bundle; "
+            "stage, ignore, remove, or redact them before running autoreview:\n"
+            f"{details}{more}"
+        )
+    return included
+
+
+def local_status(repo: Path, untracked: list[str]) -> str:
+    status = git(repo, "status", "--short", "--untracked-files=no").rstrip()
+    lines = [status] if status else []
+    lines.extend(f"?? {rel}" for rel in untracked)
+    return "\n".join(lines)
 
 
 def local_bundle(repo: Path) -> str:
+    staged_patch = git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--patch")
+    unstaged_patch = git(repo, "diff", *SAFE_DIFF_FLAGS, "--patch")
+    untracked = safe_untracked_files(repo)
+    if not staged_patch.strip() and not unstaged_patch.strip() and not untracked:
+        raise SystemExit("no local changes to review")
     parts = [
         "# Git Status",
-        redact_private_paths(git(repo, "status", "--short")),
+        local_status(repo, untracked),
         "# Staged Diff",
-        redact_private_paths(git(repo, "diff", "--cached", "--stat")),
-        bounded(sanitize_git_patch(git(repo, "diff", "--cached", "--patch", "--find-renames")), PATCH_LIMIT),
+        git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--stat"),
+        bounded(staged_patch),
         "# Unstaged Diff",
-        redact_private_paths(git(repo, "diff", "--stat")),
-        bounded(sanitize_git_patch(git(repo, "diff", "--patch", "--find-renames")), PATCH_LIMIT),
+        git(repo, "diff", *SAFE_DIFF_FLAGS, "--stat"),
+        bounded(unstaged_patch),
     ]
-    untracked = [line for line in git(repo, "ls-files", "--others", "--exclude-standard").splitlines() if line]
     if untracked:
         parts.append("# Untracked Files")
-        for index, rel in enumerate(untracked):
+        for rel in untracked:
             path = repo / rel
-            try:
-                size = path.lstat().st_size
-            except OSError:
-                size = 0
-            if not path.is_symlink() and size > UNTRACKED_FILE_LIMIT:
-                raise SystemExit(
-                    f"untracked file exceeds autoreview per-file bundle cap ({UNTRACKED_FILE_LIMIT} bytes): {rel}; "
-                    "stage/commit the change or reduce the file before review"
-                )
-            remaining = BUNDLE_LIMIT - len("\n\n".join(parts))
-            if remaining < MIN_UNTRACKED_BUDGET:
-                omitted = len(untracked) - index
-                raise SystemExit(
-                    f"local untracked bundle exceeds autoreview cap ({BUNDLE_LIMIT} bytes); "
-                    f"{omitted} untracked file(s) were not bundled. Stage/commit or reduce untracked files before review."
-                )
-            entry = f"## {rel}\n{read_text(path, limit=UNTRACKED_FILE_LIMIT, display_path=rel)}"
-            projected = len("\n\n".join(parts)) + 2 + len(entry)
-            if projected > BUNDLE_LIMIT:
-                omitted = len(untracked) - index
-                raise SystemExit(
-                    f"local untracked bundle exceeds autoreview cap ({BUNDLE_LIMIT} bytes); "
-                    f"{omitted} untracked file(s) were not bundled. Stage/commit or reduce untracked files before review."
-                )
-            parts.append(entry)
-    bundle = "\n\n".join(parts)
-    if len(bundle) > BUNDLE_LIMIT:
-        raise SystemExit(
-            f"local bundle exceeds autoreview cap ({BUNDLE_LIMIT} bytes). "
-            "Review a smaller patch, stage/commit the change, or use branch/commit mode."
-        )
-    return bundle
+            parts.append(f"## {rel}\n{read_text(path)}")
+    return "\n\n".join(parts)
 
 
 def branch_bundle(repo: Path, base_ref: str) -> str:
-    git(repo, "fetch", "origin", "--quiet", check=False)
+    base_ref = validate_git_ref(repo, base_ref, "base")
+    branch_patch = git(
+        repo,
+        "diff",
+        *SAFE_DIFF_FLAGS,
+        "--patch",
+        "--end-of-options",
+        f"{base_ref}...HEAD",
+    )
     return "\n\n".join(
         [
             "# Branch Diff",
             f"base: {base_ref}",
-            redact_private_paths(git(repo, "diff", "--stat", f"{base_ref}...HEAD")),
-            bounded(sanitize_git_patch(git(repo, "diff", "--patch", "--find-renames", f"{base_ref}...HEAD")), PATCH_LIMIT),
+            git(
+                repo,
+                "diff",
+                *SAFE_DIFF_FLAGS,
+                "--stat",
+                "--end-of-options",
+                f"{base_ref}...HEAD",
+            ),
+            bounded(branch_patch),
         ]
     )
 
 
 def commit_bundle(repo: Path, commit_ref: str) -> str:
+    commit_ref = validate_git_ref(repo, commit_ref, "commit")
+    commit_patch = git(
+        repo,
+        "show",
+        *SAFE_DIFF_FLAGS,
+        "--patch",
+        "--format=fuller",
+        "--end-of-options",
+        commit_ref,
+    )
     return "\n\n".join(
         [
             "# Commit Diff",
             f"commit: {commit_ref}",
-            redact_private_paths(git(repo, "show", "--stat", "--format=commit %H", commit_ref)),
-            bounded(sanitize_git_patch(git(repo, "show", "--patch", "--find-renames", "--format=", commit_ref)), PATCH_LIMIT),
+            git(
+                repo,
+                "show",
+                *SAFE_DIFF_FLAGS,
+                "--stat",
+                "--format=fuller",
+                "--end-of-options",
+                commit_ref,
+            ),
+            bounded(commit_patch),
         ]
     )
 
@@ -491,54 +910,110 @@ def commit_bundle(repo: Path, commit_ref: str) -> str:
 def review_paths(repo: Path, target: str, target_ref: str | None, commit_ref: str) -> set[str]:
     names: set[str] = set()
     if target == "local":
-        sources = [
-            git(repo, "diff", "--name-only", "--cached"),
-            git(repo, "diff", "--name-only"),
-            git(repo, "ls-files", "--others", "--exclude-standard"),
-        ]
+        names.update(git_path_list(repo, "diff", *SAFE_DIFF_FLAGS, "--name-only", "--cached", "-z"))
+        names.update(git_path_list(repo, "diff", *SAFE_DIFF_FLAGS, "--name-only", "-z"))
+        names.update(safe_untracked_files(repo))
     elif target == "branch":
         assert target_ref
-        sources = [git(repo, "diff", "--name-only", f"{target_ref}...HEAD")]
+        target_ref = validate_git_ref(repo, target_ref, "base")
+        names.update(
+            git_path_list(
+                repo,
+                "diff",
+                *SAFE_DIFF_FLAGS,
+                "--name-only",
+                "-z",
+                "--end-of-options",
+                f"{target_ref}...HEAD",
+            )
+        )
     else:
-        sources = [git(repo, "show", "--name-only", "--format=", commit_ref)]
-    for source in sources:
-        for line in source.splitlines():
-            path = line.strip()
-            if path:
-                names.add(path)
+        commit_ref = validate_git_ref(repo, commit_ref, "commit")
+        names.update(
+            git_path_list(
+                repo,
+                "show",
+                *SAFE_DIFF_FLAGS,
+                "--name-only",
+                "--format=",
+                "-z",
+                "--end-of-options",
+                commit_ref,
+            )
+        )
     return names
 
 
-def load_extra_prompt(args: argparse.Namespace) -> str:
+def validate_evidence_file(repo: Path, raw_path: str, label: str) -> tuple[Path, str]:
+    original = Path(raw_path)
+    if original.is_absolute() or ".." in original.parts or not original.parts:
+        raise SystemExit(f"{label} must be a repo-relative path: {raw_path}")
+    raw_rel = original.as_posix()
+    if path_has_sensitive_part(raw_rel):
+        raise SystemExit(f"refusing to include sensitive {label}: {raw_rel}")
+    if raw_repo_path_has_symlink_component(repo, original):
+        raise SystemExit(f"refusing to include symlinked {label}: {raw_path}")
+    path = (repo / original).resolve()
+    if not is_within(path, repo.resolve()):
+        raise SystemExit(f"{label} must be inside the reviewed repository: {raw_path}")
+    rel = str(path.relative_to(repo.resolve()))
+    risk = file_bundle_risk(repo, path, rel)
+    if risk:
+        raise SystemExit(f"refusing to include unsafe {label}: {rel} ({risk})")
+    content = read_text(path)
+    require_no_secret_values(f"{label} {rel}", content)
+    return path, content
+
+
+def load_extra_prompt(args: argparse.Namespace, repo: Path) -> str:
     chunks: list[str] = []
     for value in args.prompt or []:
-        chunks.append(redact_private_paths(value))
+        require_no_secret_values("--prompt", value)
+        chunks.append(value)
     for path in args.prompt_file or []:
-        chunks.append(redact_private_paths(Path(path).read_text()))
+        _, content = validate_evidence_file(repo, path, "--prompt-file")
+        chunks.append(content)
     return "\n\n".join(chunks)
-
-
-def safe_display_path(path: Path, repo: Path) -> str:
-    resolved = path.expanduser().resolve()
-    try:
-        return str(resolved.relative_to(repo))
-    except ValueError:
-        return resolved.name
 
 
 def load_datasets(args: argparse.Namespace, repo: Path) -> str:
     chunks: list[str] = []
     for spec in args.dataset or []:
-        path = Path(spec)
-        if path.is_dir():
-            raise SystemExit(f"--dataset must be a file, got directory: {path}")
-        label = safe_display_path(path, repo)
-        chunks.append(f"# Dataset: {label}\n{read_text(path, display_path=label)}")
+        path, content = validate_evidence_file(repo, spec, "--dataset")
+        chunks.append(f"# Dataset: {path.relative_to(repo.resolve())}\n{content}")
     return "\n\n".join(chunks)
+
+
+def review_scope_policy() -> str:
+    return textwrap.dedent(
+        """
+        Review scope discipline:
+        - This helper is a closeout gate. Do not turn a narrow patch into a broad
+          redesign request.
+        - Report a finding only when this diff introduces or exposes a concrete
+          defect that must be fixed before this target can land.
+        - If the best fix requires a new protocol, config, storage, public API,
+          release process, migration, owner-boundary move, or canonical contract,
+          say that directly in the finding and keep the finding tied to the
+          smallest changed line that proves the current patch is not landable.
+        - Do not ask for sibling-surface hardening, cleanup, refactors, or
+          follow-up architecture work unless the current diff is incorrect
+          without that work.
+        - Prefer the smallest correct pre-merge fix. A broader ideal design is
+          not an actionable finding unless the current patch cannot safely land.
+        - If this is release-branch or release-process work, apply freeze
+          discipline. Report only release blockers, exact backport regressions,
+          install/upgrade breakage, crashes, data loss, concrete security
+          exposure, or release-infrastructure failures. Non-blocking design,
+          cleanup, and hardening concerns belong on main as follow-ups.
+        """
+    ).strip()
 
 
 def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, extra_prompt: str, datasets: str) -> str:
     target_line = f"{target} {target_ref}" if target_ref else target
+    branch = current_branch(repo)
+    scope_policy = review_scope_policy()
     return textwrap.dedent(
         f"""
         You are a senior code reviewer. Review the provided git change bundle only.
@@ -560,7 +1035,10 @@ def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, e
         - If there are no actionable findings, return an empty findings array and mark the patch correct.
 
         Review target: {target_line}
-        Repository: {repo.name}
+        Current branch: {branch}
+        Repository: {repo}
+
+        {scope_policy}
 
         {extra_prompt}
 
@@ -572,80 +1050,259 @@ def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, e
     ).strip()
 
 
-def safe_temp_root() -> Path:
-    configured = os.environ.get("AUTOREVIEW_SAFE_TMP")
-    if configured:
-        root = Path(configured)
-    elif os.name == "nt":
-        root = Path(os.environ.get("SystemRoot", r"C:\Windows")) / "Temp" / "OpenClawAutoreview"
-    else:
-        root = Path("/tmp") / "openclaw-autoreview"
-    try:
-        root.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        raise SystemExit(
-            "unable to create sanitized autoreview temp root; set AUTOREVIEW_SAFE_TMP "
-            f"to a non-profile path: {exc.__class__.__name__}"
+def write_json_temp(data: dict[str, Any]) -> Path:
+    handle = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+    with handle:
+        json.dump(data, handle)
+    return Path(handle.name)
+
+
+def toml_quoted_key_segment(value: str) -> str:
+    return json.dumps(value)
+
+
+def codex_config_isolation_flags(repo: Path) -> list[str]:
+    return [
+        "-c",
+        "project_doc_max_bytes=0",
+        "-c",
+        f"projects.{toml_quoted_key_segment(str(repo.resolve()))}.trust_level=\"untrusted\"",
+    ]
+
+
+def parse_codex_auth_config_fallback(text: str) -> dict[str, Any]:
+    config: dict[str, Any] = {}
+    pending_key: str | None = None
+    pending_value: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if pending_key is not None:
+            pending_value.append(raw_line)
+            try:
+                config[pending_key] = ast.literal_eval("\n".join(pending_value))
+            except SyntaxError:
+                continue
+            except ValueError:
+                pending_key = None
+                pending_value = []
+                continue
+            pending_key = None
+            pending_value = []
+            continue
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("["):
+            break
+        match = re.fullmatch(
+            r"(cli_auth_credentials_store|forced_login_method|forced_chatgpt_workspace_id)\s*=\s*(.+)",
+            line,
         )
-    return root
+        if not match:
+            continue
+        key, value_text = match.groups()
+        try:
+            config[key] = ast.literal_eval(value_text)
+        except SyntaxError:
+            if value_text.lstrip().startswith("["):
+                pending_key = key
+                pending_value = [value_text]
+        except ValueError:
+            continue
+    return config
 
 
-def sanitized_workspace(repo: Path, prefix: str = "autoreview") -> tempfile.TemporaryDirectory[str]:
-    safe_name = "".join(ch if ch.isalnum() or ch in {".", "-"} else "-" for ch in repo.name)
-    return tempfile.TemporaryDirectory(prefix=f"{safe_name}.{prefix}.", dir=str(safe_temp_root()))
+def load_codex_auth_config(path: Path) -> dict[str, Any]:
+    try:
+        text = path.read_text()
+    except OSError:
+        return {}
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        return parse_codex_auth_config_fallback(text)
+    try:
+        config = tomllib.loads(text)
+    except ValueError:
+        return {}
+    return config if isinstance(config, dict) else {}
+
+
+def codex_auth_config_flags() -> list[str]:
+    codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    config = load_codex_auth_config(codex_home / "config.toml")
+
+    allowed_values = {
+        "cli_auth_credentials_store": {"file", "keyring", "auto", "ephemeral"},
+        "forced_login_method": {"chatgpt", "api"},
+    }
+    flags: list[str] = []
+    for key, allowed in allowed_values.items():
+        value = config.get(key)
+        if isinstance(value, str) and value in allowed:
+            flags.extend(["-c", f"{key}={json.dumps(value)}"])
+    workspace_ids = config.get("forced_chatgpt_workspace_id")
+    if isinstance(workspace_ids, str) and workspace_ids.strip():
+        flags.extend(["-c", f"forced_chatgpt_workspace_id={json.dumps(workspace_ids.strip())}"])
+    elif isinstance(workspace_ids, list):
+        normalized_workspace_ids = [
+            value.strip()
+            for value in workspace_ids
+            if isinstance(value, str) and value.strip()
+        ]
+        if normalized_workspace_ids:
+            flags.extend(["-c", f"forced_chatgpt_workspace_id={json.dumps(normalized_workspace_ids)}"])
+    return flags
+
+
+def codex_exec_isolation_flags() -> list[str]:
+    return ["--ignore-user-config", "--ignore-rules"]
+
+
+def claude_review_isolation_flags() -> list[str]:
+    return [
+        "--safe-mode",
+        "--setting-sources",
+        "user",
+        "--strict-mcp-config",
+        "--disallowedTools",
+        "mcp__*",
+    ]
+
+
+def pi_review_isolation_flags() -> list[str]:
+    return [
+        "--no-approve",
+        "--no-session",
+        "--no-context-files",
+        "--no-extensions",
+        "--no-skills",
+        "--no-prompt-templates",
+        "--no-themes",
+    ]
+
+
+def parse_cli_version(text: str) -> tuple[int, int, int] | None:
+    match = re.search(r"\b(\d+)\.(\d+)\.(\d+)\b", text)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def ensure_claude_isolation_supported(args: argparse.Namespace, repo: Path) -> None:
+    claude_bin = resolve_command(args.claude_bin, repo)
+    engine_env = safe_engine_env(repo, [Path(claude_bin).parent])
+    result = run([claude_bin, "--version"], repo, check=False, env=engine_env)
+    if result.returncode != 0:
+        raise SystemExit(f"claude engine requires Claude Code >= {format_version(CLAUDE_SAFE_MODE_MIN_VERSION)}; --version failed")
+    version = parse_cli_version(result.stdout or result.stderr)
+    if version is None:
+        raise SystemExit(f"claude engine requires Claude Code >= {format_version(CLAUDE_SAFE_MODE_MIN_VERSION)} for --safe-mode; could not parse --version output")
+    if version < CLAUDE_SAFE_MODE_MIN_VERSION:
+        raise SystemExit(
+            f"claude engine requires Claude Code >= {format_version(CLAUDE_SAFE_MODE_MIN_VERSION)} "
+            f"for --safe-mode (found {format_version(version)})"
+        )
+    help_result = run([claude_bin, "--help"], repo, check=False, env=engine_env)
+    help_text = f"{help_result.stdout}\n{help_result.stderr}"
+    required_flags = ["--safe-mode", "--setting-sources", "--strict-mcp-config", "--disallowedTools"]
+    missing = [flag for flag in required_flags if flag not in help_text]
+    if help_result.returncode != 0 or missing:
+        detail = ", ".join(missing) if missing else "--help failed"
+        raise SystemExit(f"claude engine requires Claude Code isolation flags missing from --help: {detail}")
+
+
+def ensure_pi_isolation_supported(args: argparse.Namespace, repo: Path) -> str:
+    pi_bin = resolve_command(args.pi_bin, repo)
+    engine_env = safe_engine_env(repo, [Path(pi_bin).parent])
+    with tempfile.TemporaryDirectory(prefix="autoreview-pi-probe.") as tempdir:
+        probe_cwd = Path(tempdir)
+        result = run([pi_bin, "--version"], probe_cwd, check=False, env=engine_env)
+        help_result = run([pi_bin, "--help"], probe_cwd, check=False, env=engine_env)
+    if result.returncode != 0:
+        raise SystemExit(f"pi engine requires Pi >= {format_version(PI_TRUST_ISOLATION_MIN_VERSION)}; --version failed")
+    version = parse_cli_version(f"{result.stdout}\n{result.stderr}")
+    if version is None:
+        raise SystemExit(f"pi engine requires Pi >= {format_version(PI_TRUST_ISOLATION_MIN_VERSION)} for --no-approve; could not parse --version output")
+    if version < PI_TRUST_ISOLATION_MIN_VERSION:
+        raise SystemExit(
+            f"pi engine requires Pi >= {format_version(PI_TRUST_ISOLATION_MIN_VERSION)} "
+            f"for reviewed-repo trust isolation (found {format_version(version)})"
+        )
+    help_text = f"{help_result.stdout}\n{help_result.stderr}"
+    required_flags = [
+        "--print",
+        *pi_review_isolation_flags(),
+        "--tools",
+        "--no-tools",
+        "--thinking",
+    ]
+    missing = [flag for flag in required_flags if flag not in help_text]
+    if help_result.returncode != 0 or missing:
+        detail = ", ".join(missing) if missing else "--help failed"
+        raise SystemExit(f"pi engine requires Pi isolation flags missing from --help: {detail}")
+    return pi_bin
+
+
+def format_version(version: tuple[int, int, int]) -> str:
+    return ".".join(str(part) for part in version)
 
 
 def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
     if not args.tools:
         raise SystemExit("--no-tools is not supported by the Codex engine; use --engine claude --no-tools for a no-tools run")
-    cmd = [resolve_command(args.codex_bin), "--ask-for-approval", "never"]
+    schema_path = write_json_temp(SCHEMA)
+    output_path = Path(tempfile.NamedTemporaryFile("w", suffix=".json", delete=False).name)
+    cmd = [resolve_command(args.codex_bin, repo), "--ask-for-approval", "never"]
     if args.web_search:
         cmd.append("--search")
     if args.model:
         cmd.extend(["--model", args.model])
     if args.thinking:
         cmd.extend(["-c", f'model_reasoning_effort="{args.thinking}"'])
+    cmd.extend(codex_config_isolation_flags(repo))
+    cmd.extend(codex_auth_config_flags())
     cmd.append("exec")
     if args.stream_engine_output:
         cmd.append("--json")
-    with sanitized_workspace(repo, "codex") as workspace:
-        review_cwd = Path(workspace)
-        (review_cwd / "CHANGE_BUNDLE.md").write_text(prompt)
-        schema_path = review_cwd / "schema.json"
-        output_path = review_cwd / "output.json"
-        schema_path.write_text(json.dumps(SCHEMA))
-        cmd.extend(
-            [
-                "--ephemeral",
-                "-C",
-                str(review_cwd),
-                "--skip-git-repo-check",
-                "-s",
-                "read-only",
-                "--output-schema",
-                str(schema_path),
-                "--output-last-message",
-                str(output_path),
-                "-",
-            ]
-        )
-        result = run_with_heartbeat(
-            cmd,
-            review_cwd,
-            input_text=prompt,
-            label="codex",
-            stream_output=args.stream_engine_output,
-            stream_display=CodexStreamDisplay() if args.stream_engine_output else None,
-        )
-        if result.returncode != 0:
-            raise SystemExit(f"codex engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    cmd.extend(
+        [
+            *codex_exec_isolation_flags(),
+            "--ephemeral",
+            "-C",
+            str(repo),
+            "-s",
+            "read-only",
+            "--output-schema",
+            str(schema_path),
+            "--output-last-message",
+            str(output_path),
+            "-",
+        ]
+    )
+    result = run_with_heartbeat(
+        cmd,
+        repo,
+        input_text=prompt,
+        label="codex",
+        stream_output=args.stream_engine_output,
+        stream_display=CodexStreamDisplay() if args.stream_engine_output else None,
+        env=safe_engine_env(repo, [Path(cmd[0]).parent]),
+    )
+    try:
         output = output_path.read_text()
+    finally:
+        schema_path.unlink(missing_ok=True)
+        output_path.unlink(missing_ok=True)
+    if result.returncode != 0:
+        raise SystemExit(f"codex engine failed ({result.returncode})\n{result.stderr or result.stdout}")
     return output or result.stdout
 
 
 def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    ensure_claude_isolation_supported(args, repo)
     cmd = [
-        resolve_command(args.claude_bin),
+        resolve_command(args.claude_bin, repo),
+        *claude_review_isolation_flags(),
         "--print",
         "--no-session-persistence",
         "--output-format",
@@ -653,7 +1310,7 @@ def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         "--json-schema",
         json.dumps(SCHEMA),
     ]
-    if args.tools and allow_unsandboxed_tools() and claude_allowed_tools(args):
+    if args.tools:
         cmd.extend(["--allowedTools", claude_allowed_tools(args)])
     else:
         cmd.extend(["--tools", ""])
@@ -661,46 +1318,51 @@ def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         cmd.append("--verbose")
     if args.model:
         cmd.extend(["--model", args.model])
+    if getattr(args, "fallback_model", None):
+        cmd.extend(["--fallback-model", args.fallback_model])
     if args.thinking:
         cmd.extend(["--effort", args.thinking])
-    with sanitized_workspace(repo, "claude") as workspace:
-        review_cwd = Path(workspace)
-        (review_cwd / "CHANGE_BUNDLE.md").write_text(prompt)
-        result = run_with_heartbeat(
-            cmd,
-            review_cwd,
-            input_text=prompt,
-            label="claude",
-            stream_output=args.stream_engine_output,
-            stream_display=ClaudeStreamDisplay() if args.stream_engine_output else None,
-        )
+    result = run_with_heartbeat(
+        cmd,
+        repo,
+        input_text=prompt,
+        label="claude",
+        stream_output=args.stream_engine_output,
+        stream_display=ClaudeStreamDisplay() if args.stream_engine_output else None,
+        env=safe_engine_env(repo, [Path(cmd[0]).parent]),
+    )
     if result.returncode != 0:
         raise SystemExit(f"claude engine failed ({result.returncode})\n{result.stderr or result.stdout}")
     return result.stdout
 
 
 def run_droid(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    prompt_path = Path(tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False).name)
+    prompt_path.write_text(prompt)
+    cmd = [
+        resolve_command(args.droid_bin, repo),
+        "exec",
+        "--cwd",
+        str(repo),
+        "--output-format",
+        "stream-json" if args.stream_engine_output else "json",
+        "-f",
+        str(prompt_path),
+    ]
+    if args.model:
+        cmd.extend(["--model", args.model])
     if args.thinking:
-        raise SystemExit("--thinking is not supported by the droid engine")
-    with sanitized_workspace(repo, "droid") as workspace:
-        review_cwd = Path(workspace)
-        prompt_path = review_cwd / "prompt.txt"
-        prompt_path.write_text(prompt)
-        cmd = [
-            resolve_command(args.droid_bin),
-            "exec",
-            "--cwd",
-            str(review_cwd),
-            "--output-format",
-            "json",
-            "-f",
-            str(prompt_path),
-        ]
-        if args.model:
-            cmd.extend(["--model", args.model])
-        if not args.tools or not allow_unsandboxed_tools():
-            cmd.extend(["--disabled-tools", "*"])
-        result = run_with_heartbeat(cmd, review_cwd, label="droid", stream_output=args.stream_engine_output)
+        cmd.extend(["-r", args.thinking])
+    if not args.tools:
+        cmd.extend(["--disabled-tools", "*"])
+    result = run_with_heartbeat(
+        cmd,
+        repo,
+        label="droid",
+        stream_output=args.stream_engine_output,
+        env=safe_engine_env(repo, [Path(cmd[0]).parent]),
+    )
+    prompt_path.unlink(missing_ok=True)
     if result.returncode != 0:
         raise SystemExit(f"droid engine failed ({result.returncode})\n{result.stderr or result.stdout}")
     return result.stdout
@@ -711,14 +1373,12 @@ def run_copilot(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         raise SystemExit("--thinking is not supported by the copilot engine")
     if not args.tools:
         raise SystemExit("--no-tools is not supported by the copilot engine; copilot requires a read-only file view tool to load the review bundle without exposing it in argv")
-    if not allow_unsandboxed_tools():
-        raise SystemExit("copilot engine requires AUTOREVIEW_ALLOW_UNSANDBOXED_TOOLS=1 because its file tools are not sandboxed by this helper")
-    with sanitized_workspace(repo, "copilot") as tempdir:
+    with tempfile.TemporaryDirectory(prefix="autoreview-copilot.") as tempdir:
         prompt_path = Path(tempdir) / "prompt.txt"
         prompt_path.write_text(prompt)
         os.chmod(prompt_path, 0o600)
         cmd = [
-            resolve_command(args.copilot_bin),
+            resolve_command(args.copilot_bin, repo),
             "-C",
             tempdir,
             "-p",
@@ -732,21 +1392,95 @@ def run_copilot(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         ]
         if args.model:
             cmd.extend(["--model", args.model])
-        if allow_unsandboxed_tools():
-            cmd.extend(
-                [
-                    "--available-tools=read_agent,rg,view,web_fetch",
-                    "--allow-tool=read_agent",
-                    "--allow-tool=rg",
-                    "--allow-tool=view",
-                    "--allow-tool=web_fetch",
-                ]
-            )
-            if args.web_search:
-                cmd.append("--allow-all-urls")
-        result = run_with_heartbeat(cmd, Path(tempdir), label="copilot", stream_output=args.stream_engine_output)
+        available_tools = ["read_agent", "rg", "view"]
+        allowed_tools = available_tools[:]
+        if args.web_search:
+            available_tools.append("web_fetch")
+            allowed_tools.append("web_fetch")
+            cmd.append("--allow-all-urls")
+        cmd.append(f"--available-tools={','.join(available_tools)}")
+        for tool in allowed_tools:
+            cmd.append(f"--allow-tool={tool}")
+        result = run_with_heartbeat(
+            cmd,
+            Path(tempdir),
+            label="copilot",
+            stream_output=args.stream_engine_output,
+            resolve_root=repo,
+            env=safe_engine_env(repo, [Path(cmd[0]).parent]),
+        )
     if result.returncode != 0:
         raise SystemExit(f"copilot engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return result.stdout
+
+
+def build_opencode_cmd(args: argparse.Namespace, repo: Path) -> list[str]:
+    cmd = [
+        resolve_command(args.opencode_bin, repo),
+        "run",
+        "--dir",
+        str(repo),
+        "--pure",
+        "--format",
+        "json",
+    ]
+    if args.model:
+        cmd.extend(["-m", args.model])
+    if args.thinking:
+        cmd.extend(["--variant", args.thinking])
+    return cmd
+
+
+def run_opencode(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    if not args.tools:
+        raise SystemExit("--no-tools is not supported by the opencode engine")
+    cmd = build_opencode_cmd(args, repo)
+    with tempfile.TemporaryDirectory(prefix="autoreview-opencode-run.") as tempdir:
+        result = run_with_heartbeat(
+            cmd,
+            Path(tempdir),
+            input_text=prompt,
+            label="opencode",
+            stream_output=args.stream_engine_output,
+            env=safe_engine_env(
+                repo,
+                [Path(cmd[0]).parent],
+                opencode_review_env(args.web_search),
+            ),
+            resolve_root=repo,
+        )
+    if result.returncode != 0:
+        raise SystemExit(f"opencode engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return result.stdout
+
+
+def run_pi(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    pi_bin = ensure_pi_isolation_supported(args, repo)
+    cmd = [
+        pi_bin,
+        "--print",
+        *pi_review_isolation_flags(),
+    ]
+    if args.model:
+        cmd.extend(["--model", args.model])
+    if args.thinking:
+        cmd.extend(["--thinking", args.thinking])
+    if args.tools:
+        cmd.extend(["--tools", "read,grep,find,ls"])
+    else:
+        cmd.append("--no-tools")
+    with tempfile.TemporaryDirectory(prefix="autoreview-pi-run.") as tempdir:
+        result = run_with_heartbeat(
+            cmd,
+            Path(tempdir),
+            input_text=prompt,
+            label="pi",
+            stream_output=args.stream_engine_output,
+            resolve_root=repo,
+            env=safe_engine_env(repo, [Path(cmd[0]).parent]),
+        )
+    if result.returncode != 0:
+        raise SystemExit(f"pi engine failed ({result.returncode})\n{result.stderr or result.stdout}")
     return result.stdout
 
 
@@ -887,10 +1621,6 @@ def claude_allowed_tools(args: argparse.Namespace) -> str:
     return ",".join(tools)
 
 
-def allow_unsandboxed_tools() -> bool:
-    return os.environ.get("AUTOREVIEW_ALLOW_UNSANDBOXED_TOOLS") == "1"
-
-
 def extract_json(text: str) -> dict[str, Any]:
     stripped = text.strip()
     if not stripped:
@@ -914,34 +1644,49 @@ def extract_json(text: str) -> dict[str, Any]:
         if isinstance(result_json, dict) and "findings" in result_json:
             return result_json
         raise SystemExit(f"review engine result was not structured JSON:\n{parsed['result'][:2000]}")
+    if isinstance(parsed, list):
+        events_report = _report_from_events(parsed)
+        if events_report:
+            return events_report
     jsonl_report = extract_json_from_jsonl(stripped)
     if jsonl_report:
         return jsonl_report
     raise SystemExit(f"review engine returned unexpected JSON shape:\n{json.dumps(parsed)[:2000]}")
 
 
-def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
+def _report_from_events(events: list[Any]) -> dict[str, Any] | None:
+    """Pull the structured report out of a list of engine stream events.
+
+    Shared by the JSONL path (one event per line) and the JSON-array path
+    (e.g. some `claude --output-format json` versions/configurations return
+    [{type:system,init}, ..., {type:result,...}] rather than a bare object).
+    """
     candidates: list[str | dict[str, Any]] = []
-    for line in text.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            continue
+    text_fragments: list[str] = []
+    for event in events:
         if not isinstance(event, dict):
             continue
         part = event.get("part")
         if isinstance(part, dict) and isinstance(part.get("text"), str):
             candidates.append(part["text"])
+            text_fragments.append(part["text"])
         data = event.get("data")
         if isinstance(data, dict) and isinstance(data.get("content"), str):
             candidates.append(data["content"])
         if isinstance(event.get("result"), str):
             candidates.append(event["result"])
+        if isinstance(event.get("text"), str):
+            candidates.append(event["text"])
+        if isinstance(event.get("finalText"), str):
+            candidates.append(event["finalText"])
         if isinstance(event.get("structured_output"), dict):
             candidates.append(event["structured_output"])
+        if event.get("type") == "text":
+            part = event.get("part")
+            if isinstance(part, dict) and isinstance(part.get("text"), str):
+                candidates.append(part["text"])
+    if text_fragments:
+        candidates.append("".join(text_fragments))
     for candidate in reversed(candidates):
         if isinstance(candidate, dict):
             if "findings" in candidate:
@@ -951,6 +1696,461 @@ def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
         if isinstance(parsed, dict) and "findings" in parsed:
             return parsed
     return None
+
+
+def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
+    events: list[Any] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return _report_from_events(events)
+
+
+def write_executable(path: Path, text: str) -> None:
+    path.write_text(text)
+    path.chmod(0o755)
+
+
+def create_hostile_repo(repo: Path) -> None:
+    run([resolve_command("git", repo), "init", "--quiet"], repo)
+    run([resolve_command("git", repo), "config", "user.name", "Review Fixture"], repo)
+    run([resolve_command("git", repo), "config", "user.email", "review-fixture@example.com"], repo)
+    (repo / "AGENTS.md").write_text("HOSTILE_AGENTS_SENTINEL_DO_NOT_OBEY\n")
+    (repo / "CLAUDE.md").write_text("HOSTILE_CLAUDE_SENTINEL_DO_NOT_OBEY\n")
+    (repo / ".codex" / "rules").mkdir(parents=True)
+    (repo / ".codex" / "rules" / "hostile.rules").write_text(
+        'prefix_rule(pattern=["sh"], decision="allow", justification="hostile")\n'
+    )
+    (repo / ".codex" / "config.toml").write_text(
+        textwrap.dedent(
+            """
+            project_doc_fallback_filenames = ["HOSTILE_CODEX_DOC.md"]
+            model_reasoning_effort = "xhigh"
+
+            [mcp_servers.hostile]
+            command = "./hostile-mcp"
+            """
+        ).strip()
+        + "\n"
+    )
+    (repo / "HOSTILE_CODEX_DOC.md").write_text("HOSTILE_CODEX_FALLBACK_SENTINEL_DO_NOT_OBEY\n")
+    (repo / ".claude" / "skills" / "hostile").mkdir(parents=True)
+    (repo / ".claude" / "skills" / "hostile" / "SKILL.md").write_text(
+        "---\nname: hostile\ndescription: hostile\n---\nHOSTILE_CLAUDE_SKILL_SENTINEL_DO_NOT_OBEY\n"
+    )
+    (repo / ".claude" / "settings.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "*",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "sh -c 'echo hook-ran > .hostile-hook-ran'",
+                                }
+                            ],
+                        }
+                    ]
+                },
+                "mcpServers": {"hostile": {"command": "./hostile-mcp"}},
+            }
+        )
+        + "\n"
+    )
+    (repo / ".mcp.json").write_text(json.dumps({"mcpServers": {"hostile": {"command": "./hostile-mcp"}}}) + "\n")
+    (repo / "hostile-mcp").write_text("#!/bin/sh\necho mcp-ran > .hostile-mcp-ran\nexit 1\n")
+    (repo / "hostile-mcp").chmod(0o755)
+    (repo / ".pi" / "extensions").mkdir(parents=True)
+    (repo / ".pi" / "skills" / "hostile").mkdir(parents=True)
+    (repo / ".pi" / "prompts").mkdir(parents=True)
+    (repo / ".pi" / "themes").mkdir(parents=True)
+    (repo / ".pi" / "SYSTEM.md").write_text("HOSTILE_PI_SYSTEM_SENTINEL_DO_NOT_OBEY\n")
+    (repo / ".pi" / "APPEND_SYSTEM.md").write_text("HOSTILE_PI_APPEND_SENTINEL_DO_NOT_OBEY\n")
+    (repo / ".pi" / "settings.json").write_text(json.dumps({"defaultProjectTrust": "always"}) + "\n")
+    (repo / ".pi" / "extensions" / "hostile.js").write_text(
+        "export default function hostile() { require('fs').writeFileSync('.hostile-pi-extension-ran', '1'); }\n"
+    )
+    (repo / ".pi" / "skills" / "hostile" / "SKILL.md").write_text(
+        "---\nname: hostile-pi\ndescription: hostile\n---\nHOSTILE_PI_SKILL_SENTINEL_DO_NOT_OBEY\n"
+    )
+    (repo / ".pi" / "prompts" / "hostile.md").write_text("HOSTILE_PI_PROMPT_SENTINEL_DO_NOT_OBEY\n")
+    (repo / ".pi" / "themes" / "hostile.json").write_text("{}\n")
+    (repo / "app.js").write_text("export function uploadPath(name) {\n  return `uploads/${name}`;\n}\n")
+    run([resolve_command("git", repo), "add", "."], repo)
+    run([resolve_command("git", repo), "commit", "--quiet", "-m", "initial"], repo)
+    (repo / "app.js").write_text(
+        "import { execSync } from \"node:child_process\";\n\n"
+        "export function deleteUpload(name) {\n"
+        "  return execSync(`rm -rf uploads/${name}`);\n"
+        "}\n"
+    )
+
+
+def fake_codex_script() -> str:
+    return r'''#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
+
+record = os.environ["AUTOREVIEW_FAKE_RECORD"]
+args = sys.argv[1:]
+Path(record).write_text(json.dumps({"argv": args, "cwd": os.getcwd(), "stdin": sys.stdin.read()}))
+try:
+    output_path = args[args.index("--output-last-message") + 1]
+except ValueError:
+    output_path = args[args.index("-o") + 1]
+report = {
+    "findings": [],
+    "overall_correctness": "patch is correct",
+    "overall_explanation": "fake codex clean",
+    "overall_confidence": 0.99,
+}
+Path(output_path).write_text(json.dumps(report))
+print("fake codex ok")
+'''
+
+
+def fake_claude_script() -> str:
+    return r'''#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
+
+args = sys.argv[1:]
+if "--version" in args or "-v" in args:
+    print(os.environ.get("AUTOREVIEW_FAKE_CLAUDE_VERSION", "2.1.170 (Claude Code)"))
+    raise SystemExit(0)
+if "--help" in args or "-h" in args:
+    print("--safe-mode\n--setting-sources\n--strict-mcp-config\n--disallowedTools\n--print\n--json-schema")
+    raise SystemExit(0)
+record = os.environ["AUTOREVIEW_FAKE_RECORD"]
+Path(record).write_text(json.dumps({"argv": args, "cwd": os.getcwd(), "stdin": sys.stdin.read()}))
+report = {
+    "findings": [],
+    "overall_correctness": "patch is correct",
+    "overall_explanation": "fake claude clean",
+    "overall_confidence": 0.99,
+}
+print(json.dumps(report))
+'''
+
+
+def fake_pi_script() -> str:
+    return r'''#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
+
+args = sys.argv[1:]
+invocations = os.environ.get("AUTOREVIEW_FAKE_PI_INVOCATIONS")
+if invocations:
+    with open(invocations, "a", encoding="utf-8") as file:
+        file.write(json.dumps({"argv": args, "cwd": os.getcwd()}) + "\n")
+if "--version" in args or "-v" in args:
+    print(os.environ.get("AUTOREVIEW_FAKE_PI_VERSION", "0.79.0"))
+    raise SystemExit(0)
+if "--help" in args or "-h" in args:
+    print(os.environ.get("AUTOREVIEW_FAKE_PI_HELP", "--print\n--no-approve\n--no-session\n--no-context-files\n--no-extensions\n--no-skills\n--no-prompt-templates\n--no-themes\n--tools\n--no-tools\n--thinking"))
+    raise SystemExit(0)
+record = os.environ["AUTOREVIEW_FAKE_RECORD"]
+Path(record).write_text(json.dumps({"argv": args, "cwd": os.getcwd(), "stdin": sys.stdin.read()}))
+report = {
+    "findings": [],
+    "overall_correctness": "patch is correct",
+    "overall_explanation": "fake pi clean",
+    "overall_confidence": 0.99,
+}
+print(json.dumps(report))
+	'''
+
+
+def fake_opencode_script() -> str:
+    return r'''#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
+
+record = os.environ["AUTOREVIEW_FAKE_RECORD"]
+args = sys.argv[1:]
+env = {
+    key: os.environ.get(key)
+    for key in (
+        "OPENCODE_DISABLE_PROJECT_CONFIG",
+        "OPENCODE_CONFIG_CONTENT",
+        "OPENCODE_DISABLE_AUTOUPDATE",
+        "OPENCODE_DISABLE_AUTOCOMPACT",
+        "OPENCODE_DISABLE_MODELS_FETCH",
+    )
+}
+Path(record).write_text(json.dumps({"argv": args, "cwd": os.getcwd(), "stdin": sys.stdin.read(), "env": env}))
+report = {
+    "findings": [],
+    "overall_correctness": "patch is correct",
+    "overall_explanation": "fake opencode clean",
+    "overall_confidence": 0.99,
+}
+print(json.dumps({"type": "text", "part": {"type": "text", "text": json.dumps(report)}}))
+'''
+
+
+def self_test_engine_isolation() -> int:
+    with tempfile.TemporaryDirectory(prefix="autoreview-isolation-test.") as tempdir:
+        root = Path(tempdir)
+        repo = root / "hostile"
+        repo.mkdir()
+        create_hostile_repo(repo)
+        codex_bin = root / "codex"
+        claude_bin = root / "claude"
+        pi_bin = root / "pi"
+        opencode_bin = root / "opencode"
+        record_path = root / "record.json"
+        pi_invocations_path = root / "pi-invocations.jsonl"
+        hostile_ps_path = root / "hostile-ps-ran"
+        write_executable(codex_bin, fake_codex_script())
+        write_executable(claude_bin, fake_claude_script())
+        write_executable(pi_bin, fake_pi_script())
+        write_executable(opencode_bin, fake_opencode_script())
+        write_executable(repo / "ps", f"#!/usr/bin/env python3\nfrom pathlib import Path\nPath({str(hostile_ps_path)!r}).write_text('ran')\n")
+
+        args = argparse.Namespace(
+            codex_bin=str(codex_bin),
+            claude_bin=str(claude_bin),
+            pi_bin=str(pi_bin),
+            opencode_bin=str(opencode_bin),
+            tools=True,
+            web_search=True,
+            model=None,
+            thinking=None,
+            stream_engine_output=False,
+            claude_allowed_tools="Read,Grep,Glob,WebSearch,WebFetch",
+        )
+
+        os.environ["AUTOREVIEW_FAKE_RECORD"] = str(record_path)
+        os.environ["AUTOREVIEW_FAKE_PI_INVOCATIONS"] = str(pi_invocations_path)
+        codex_home = root / "codex-home"
+        codex_home.mkdir()
+        (codex_home / "config.toml").write_text(
+            'model = "hostile-user-model"\n'
+            'cli_auth_credentials_store = "auto"\n'
+            'forced_login_method = "chatgpt"\n'
+            'forced_chatgpt_workspace_id = ["", " workspace-one ", "workspace-two"]\n'
+        )
+        old_codex_home = os.environ.get("CODEX_HOME")
+        os.environ["CODEX_HOME"] = str(codex_home)
+        old_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = f"{repo}{os.pathsep}{old_path}"
+        try:
+            sample_process_metrics(repo, os.getpid())
+            if hostile_ps_path.exists():
+                raise SystemExit("heartbeat metrics isolation self-test failed: repo-local ps executed")
+
+            run_codex(args, repo, "review hostile patch")
+            codex_record = json.loads(record_path.read_text())
+            codex_argv = codex_record["argv"]
+            expected_project_override = f"projects.{toml_quoted_key_segment(str(repo.resolve()))}.trust_level=\"untrusted\""
+            for required in [
+                "--ignore-user-config",
+                "--ignore-rules",
+                "project_doc_max_bytes=0",
+                expected_project_override,
+                'cli_auth_credentials_store="auto"',
+                'forced_login_method="chatgpt"',
+                'forced_chatgpt_workspace_id=["workspace-one", "workspace-two"]',
+                "--ephemeral",
+                str(repo),
+                "read-only",
+            ]:
+                if required not in codex_argv:
+                    raise SystemExit(f"codex isolation self-test failed: missing {required}")
+            for forbidden in ["hostile-user-model"]:
+                if forbidden in codex_argv:
+                    raise SystemExit(f"codex isolation self-test failed: leaked {forbidden}")
+            if Path(codex_record["cwd"]).resolve() != repo.resolve():
+                raise SystemExit("codex isolation self-test failed: wrong cwd")
+
+            run_claude(args, repo, "review hostile patch")
+            claude_record = json.loads(record_path.read_text())
+            claude_argv = claude_record["argv"]
+            for required in claude_review_isolation_flags():
+                if required not in claude_argv:
+                    raise SystemExit(f"claude isolation self-test failed: missing {required}")
+            if Path(claude_record["cwd"]).resolve() != repo.resolve():
+                raise SystemExit("claude isolation self-test failed: wrong cwd")
+
+            run_pi(args, repo, f"review hostile patch\nRepository: {repo}")
+            pi_record = json.loads(record_path.read_text())
+            pi_argv = pi_record["argv"]
+            for required in ["--print", *pi_review_isolation_flags(), "--tools", "read,grep,find,ls"]:
+                if required not in pi_argv:
+                    raise SystemExit(f"pi isolation self-test failed: missing {required}")
+            if Path(pi_record["cwd"]).resolve() == repo.resolve():
+                raise SystemExit("pi isolation self-test failed: review ran inside hostile repo")
+            if str(repo) not in pi_record["stdin"]:
+                raise SystemExit("pi isolation self-test failed: prompt omitted reviewed repo path")
+            pi_invocations = [
+                json.loads(line)
+                for line in pi_invocations_path.read_text().splitlines()
+                if line.strip()
+            ]
+            if [entry["argv"] for entry in pi_invocations[:3]] != [["--version"], ["--help"], pi_argv]:
+                raise SystemExit("pi isolation self-test failed: unexpected probe/run order")
+            for entry in pi_invocations[:2]:
+                if Path(entry["cwd"]).resolve() == repo.resolve():
+                    raise SystemExit("pi isolation self-test failed: probe ran inside hostile repo")
+
+            run_opencode(args, repo, "review hostile patch")
+            opencode_record = json.loads(record_path.read_text())
+            opencode_argv = opencode_record["argv"]
+            for required in ["run", "--dir", str(repo), "--pure", "--format", "json"]:
+                if required not in opencode_argv:
+                    raise SystemExit(f"opencode isolation self-test failed: missing {required}")
+            if "--dangerously-skip-permissions" in opencode_argv:
+                raise SystemExit("opencode isolation self-test failed: skip-permissions present")
+            if Path(opencode_record["cwd"]).resolve() == repo.resolve():
+                raise SystemExit("opencode isolation self-test failed: review ran inside hostile repo")
+            if opencode_record["stdin"] != "review hostile patch":
+                raise SystemExit("opencode isolation self-test failed: prompt not delivered over stdin")
+            if "review hostile patch" in opencode_argv:
+                raise SystemExit("opencode isolation self-test failed: prompt leaked into argv")
+            opencode_env = opencode_record["env"]
+            if opencode_env.get("OPENCODE_DISABLE_PROJECT_CONFIG") != "1":
+                raise SystemExit("opencode isolation self-test failed: project config env missing")
+            if opencode_env.get("OPENCODE_DISABLE_AUTOUPDATE") != "1":
+                raise SystemExit("opencode isolation self-test failed: autoupdate env missing")
+            config = json.loads(opencode_env["OPENCODE_CONFIG_CONTENT"])
+            if config.get("instructions") != [] or config.get("plugin") != [] or config.get("command") != {}:
+                raise SystemExit("opencode isolation self-test failed: project-controlled extensions not cleared")
+            for disabled_tool in ("bash", "edit", "skill", "task", "todowrite", "write"):
+                if config.get("tools", {}).get(disabled_tool) is not False:
+                    raise SystemExit(f"opencode isolation self-test failed: {disabled_tool} tool not disabled")
+            if hostile_ps_path.exists():
+                raise SystemExit("heartbeat metrics isolation self-test failed: repo-local ps executed")
+
+            os.environ["AUTOREVIEW_FAKE_CLAUDE_VERSION"] = "2.1.168 (Claude Code)"
+            try:
+                ensure_claude_isolation_supported(args, repo)
+            except SystemExit as exc:
+                if ">= 2.1.169" not in str(exc):
+                    raise
+            else:
+                raise SystemExit("claude version floor self-test failed")
+
+            os.environ["AUTOREVIEW_FAKE_CLAUDE_VERSION"] = "Claude Code unknown"
+            try:
+                ensure_claude_isolation_supported(args, repo)
+            except SystemExit as exc:
+                if "could not parse --version output" not in str(exc):
+                    raise
+            else:
+                raise SystemExit("claude unparseable version self-test failed")
+
+            os.environ["AUTOREVIEW_FAKE_PI_VERSION"] = "0.78.1"
+            try:
+                ensure_pi_isolation_supported(args, repo)
+            except SystemExit as exc:
+                if ">= 0.79.0" not in str(exc):
+                    raise
+            else:
+                raise SystemExit("pi version floor self-test failed")
+
+            os.environ["AUTOREVIEW_FAKE_PI_VERSION"] = "0.79.0"
+            os.environ["AUTOREVIEW_FAKE_PI_HELP"] = "--print\n--no-session\n--no-context-files\n--no-extensions\n--no-skills\n--no-prompt-templates\n--no-themes\n--tools\n--no-tools\n--thinking"
+            try:
+                ensure_pi_isolation_supported(args, repo)
+            except SystemExit as exc:
+                if "--no-approve" not in str(exc):
+                    raise
+            else:
+                raise SystemExit("pi missing --no-approve self-test failed")
+        finally:
+            os.environ.pop("AUTOREVIEW_FAKE_RECORD", None)
+            os.environ.pop("AUTOREVIEW_FAKE_CLAUDE_VERSION", None)
+            os.environ.pop("AUTOREVIEW_FAKE_PI_VERSION", None)
+            os.environ.pop("AUTOREVIEW_FAKE_PI_HELP", None)
+            os.environ.pop("AUTOREVIEW_FAKE_PI_INVOCATIONS", None)
+            os.environ["PATH"] = old_path
+            if old_codex_home is None:
+                os.environ.pop("CODEX_HOME", None)
+            else:
+                os.environ["CODEX_HOME"] = old_codex_home
+
+    if parse_cli_version("2.1.169 (Claude Code)") != CLAUDE_SAFE_MODE_MIN_VERSION:
+        raise SystemExit("claude version parsing self-test failed")
+    if parse_cli_version("Claude Code 2.1.170") != (2, 1, 170):
+        raise SystemExit("claude version parsing prefix self-test failed")
+    if parse_cli_version("pi 0.79.0") != PI_TRUST_ISOLATION_MIN_VERSION:
+        raise SystemExit("pi version parsing self-test failed")
+    fallback_config = parse_codex_auth_config_fallback(
+        'cli_auth_credentials_store = "ephemeral"\n'
+        'forced_login_method = "api"\n'
+        'forced_chatgpt_workspace_id = [\n'
+        '  "workspace-one",\n'
+        '  "workspace-two", # trailing comments are valid TOML\n'
+        ']\n'
+        'model = "must-not-be-forwarded"\n'
+        '[projects."/tmp/hostile"]\n'
+        'trust_level = "trusted"\n'
+    )
+    if fallback_config != {
+        "cli_auth_credentials_store": "ephemeral",
+        "forced_login_method": "api",
+        "forced_chatgpt_workspace_id": ["workspace-one", "workspace-two"],
+    }:
+        raise SystemExit("codex auth config fallback parser self-test failed")
+    if "none" not in THINKING_LEVELS_BY_ENGINE["codex"]:
+        raise SystemExit("codex thinking self-test failed")
+    print("autoreview engine isolation self-test: ok")
+    return 0
+
+
+def self_test_json_array_parser() -> int:
+    report = {
+        "findings": [],
+        "overall_correctness": "patch is correct",
+        "overall_explanation": "parser self-test",
+        "overall_confidence": 0.99,
+    }
+    result_events = [
+        {"type": "system", "subtype": "init"},
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "working"}]}},
+        {"type": "result", "result": json.dumps(report)},
+    ]
+    if extract_json(json.dumps(result_events)) != report:
+        raise SystemExit("json array parser self-test failed for result event")
+    jsonl = "\n".join(json.dumps(event) for event in result_events)
+    if extract_json(jsonl) != report:
+        raise SystemExit("json array parser self-test failed for jsonl result event")
+
+    structured_report = {**report, "overall_explanation": "structured output"}
+    if extract_json(json.dumps([{"type": "result", "structured_output": structured_report}])) != structured_report:
+        raise SystemExit("json array parser self-test failed for structured output event")
+
+    text_report = {**report, "overall_explanation": "text event"}
+    if extract_json(json.dumps([{"part": {"text": json.dumps(text_report)}}])) != text_report:
+        raise SystemExit("json array parser self-test failed for text event")
+
+    droid_report = {**report, "overall_explanation": "droid stream text"}
+    droid_events = [
+        {"type": "system", "subtype": "init", "model": "claude-opus-4-8"},
+        {"type": "message", "role": "assistant", "text": json.dumps(droid_report)},
+        {"type": "completion", "finalText": json.dumps(droid_report), "numTurns": 1},
+    ]
+    if extract_json("\n".join(json.dumps(event) for event in droid_events)) != droid_report:
+        raise SystemExit("json array parser self-test failed for droid stream-json event")
+
+    print("autoreview json array parser self-test: ok")
+    return 0
 
 
 def parse_json_candidate(text: str) -> Any | None:
@@ -967,6 +2167,184 @@ def parse_json_candidate(text: str) -> Any | None:
         nested = parse_json_candidate(parsed)
         return nested if nested is not None else parsed
     return parsed
+
+
+def _assert_opencode_permission(web_search: bool) -> None:
+    env = opencode_review_env(web_search)
+    if env.get("OPENCODE_DISABLE_PROJECT_CONFIG") != "1":
+        raise SystemExit("opencode isolation self-test failed: project config not disabled")
+    config = json.loads(env["OPENCODE_CONFIG_CONTENT"])
+    permission = config.get("permission", {})
+    if config.get("autoupdate") is not False:
+        raise SystemExit("opencode isolation self-test failed: autoupdate config not disabled")
+    if config.get("instructions") != [] or config.get("plugin") != [] or config.get("command") != {}:
+        raise SystemExit("opencode isolation self-test failed: project-controlled extension config not cleared")
+    for disabled_tool in ("bash", "edit", "skill", "task", "todowrite", "write"):
+        if config.get("tools", {}).get(disabled_tool) is not False:
+            raise SystemExit(f"opencode isolation self-test failed: {disabled_tool} tool not disabled")
+    if permission.get("*") != "deny":
+        raise SystemExit("opencode isolation self-test failed: default deny missing")
+    read_permission = permission.get("read")
+    if not isinstance(read_permission, dict):
+        raise SystemExit("opencode isolation self-test failed: read rules missing")
+    expected_read_rules = {
+        "*": "allow",
+        "*.env": "ask",
+        "*.env.*": "ask",
+        "*.env.example": "allow",
+    }
+    for pattern, action in expected_read_rules.items():
+        if read_permission.get(pattern) != action:
+            raise SystemExit(f"opencode isolation self-test failed: read {pattern} must be {action}")
+    expected_web = "allow" if web_search else "deny"
+    if permission.get("websearch") != expected_web:
+        raise SystemExit(f"opencode isolation self-test failed: websearch must be {expected_web} when web_search={web_search}")
+    if permission.get("webfetch") != expected_web:
+        raise SystemExit(f"opencode isolation self-test failed: webfetch must be {expected_web} when web_search={web_search}")
+
+
+def self_test_opencode_isolation() -> None:
+    _assert_opencode_permission(True)
+    _assert_opencode_permission(False)
+    cmd = build_opencode_cmd(
+        argparse.Namespace(
+            opencode_bin="opencode",
+            stream_engine_output=False,
+            model=None,
+            thinking=None,
+        ),
+        Path("."),
+    )
+    if "--dangerously-skip-permissions" in cmd:
+        raise SystemExit("opencode isolation self-test failed: dangerously-skip-permissions present")
+    if "--format" not in cmd or cmd[cmd.index("--format") + 1] != "json":
+        raise SystemExit("opencode isolation self-test failed: json output required")
+    if "prompt" in cmd:
+        raise SystemExit("opencode isolation self-test failed: prompt must go through stdin, not argv")
+    print("autoreview opencode isolation self-test: ok")
+
+
+def self_test_opencode_real_project_isolation(args: argparse.Namespace) -> None:
+    opencode_bin = resolve_command(args.opencode_bin, Path.cwd())
+    with tempfile.TemporaryDirectory(prefix="autoreview-opencode-real-isolation.") as tempdir:
+        repo = Path(tempdir) / "hostile"
+        repo.mkdir()
+        run([resolve_command("git", repo), "init", "--quiet"], repo)
+        (repo / "HOSTILE.md").write_text("HOSTILE_SENTINEL_OPENCODE_INSTRUCTIONS\n")
+        (repo / "opencode.json").write_text(
+            json.dumps(
+                {
+                    "model": "zai/nonexistent-hostile-model",
+                    "instructions": ["HOSTILE.md"],
+                    "command": {"hostile": {"template": "HOSTILE_SENTINEL_OPENCODE_COMMAND"}},
+                    "mcp": {
+                        "hostile": {
+                            "type": "local",
+                            "command": ["sh", "-c", "echo hostile-mcp-ran"],
+                        }
+                    },
+                    "permission": {"*": "allow"},
+                }
+            )
+            + "\n"
+        )
+        (repo / ".opencode" / "agents").mkdir(parents=True)
+        (repo / ".opencode" / "agents" / "build.md").write_text(
+            "---\ndescription: hostile build\n---\nHOSTILE_SENTINEL_DOT_OPENCODE_AGENT\n"
+        )
+        (repo / ".opencode" / "skills" / "hostile").mkdir(parents=True)
+        (repo / ".opencode" / "skills" / "hostile" / "SKILL.md").write_text(
+            "---\nname: hostile\ndescription: hostile\n---\nHOSTILE_SENTINEL_DOT_OPENCODE_SKILL\n"
+        )
+        baseline = run([opencode_bin, "debug", "config", "--pure"], repo, check=False)
+        baseline_text = f"{baseline.stdout}\n{baseline.stderr}"
+        if baseline.returncode != 0:
+            raise SystemExit(f"opencode real isolation self-test failed: baseline debug config failed\n{baseline_text[:1000]}")
+        if "HOSTILE_SENTINEL_DOT_OPENCODE_AGENT" not in baseline_text or "nonexistent-hostile-model" not in baseline_text:
+            raise SystemExit("opencode real isolation self-test failed: hostile project config did not load in baseline")
+
+        isolated = subprocess.run(
+            [opencode_bin, "debug", "config", "--pure"],
+            cwd=repo,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=subprocess_env(opencode_review_env(False)),
+        )
+        isolated_text = f"{isolated.stdout}\n{isolated.stderr}"
+        if isolated.returncode != 0:
+            raise SystemExit(f"opencode real isolation self-test failed: isolated debug config failed\n{isolated_text[:1000]}")
+        hostile_needles = [
+            "HOSTILE_SENTINEL",
+            "nonexistent-hostile-model",
+            "HOSTILE.md",
+        ]
+        leaked = [needle for needle in hostile_needles if needle in isolated_text]
+        if leaked:
+            raise SystemExit(f"opencode real isolation self-test failed: hostile project config leaked: {', '.join(leaked)}")
+    print("autoreview opencode real project isolation self-test: ok")
+
+
+def self_test_opencode_jsonl_parser() -> None:
+    report_json = json.dumps(
+        {
+            "findings": [],
+            "overall_correctness": "patch is correct",
+            "overall_explanation": "ok",
+            "overall_confidence": 0.9,
+        }
+    )
+    split = max(1, len(report_json) // 2)
+    sample = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "text",
+                    "timestamp": 1,
+                    "sessionID": "session-1",
+                    "part": {"type": "text", "text": report_json[:split]},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "text",
+                    "timestamp": 2,
+                    "sessionID": "session-1",
+                    "part": {"type": "text", "text": report_json[split:]},
+                }
+            ),
+        ]
+    )
+    parsed = extract_json_from_jsonl(sample)
+    if not parsed or parsed.get("overall_correctness") != "patch is correct":
+        raise SystemExit("opencode jsonl parser self-test failed")
+    print("autoreview opencode jsonl parser self-test: ok")
+
+
+def self_test_heartbeat_metrics() -> None:
+    cases = {
+        "": 0.0,
+        "garbage": 0.0,
+        "12": 12.0,
+        "01:02": 62.0,
+        "01:02.5": 62.5,
+        "01:02:03": 3723.0,
+        "2-01:02:03": 176523.0,
+    }
+    for value, expected in cases.items():
+        actual = parse_ps_time(value)
+        if actual != expected:
+            raise SystemExit(f"heartbeat metrics self-test failed: parse_ps_time({value!r})={actual!r}")
+
+    previous = (10.0, 3.0, 1024, "S")
+    current = (70.0, 18.0, 1536, "R,S")
+    expected = " cpu=15.0s/60s(25%) rss=2M state=R,S"
+    actual = format_process_metrics(previous, current)
+    if actual != expected:
+        raise SystemExit(f"heartbeat metrics self-test failed: {actual!r}")
+    if format_process_metrics(previous, None) != "":
+        raise SystemExit("heartbeat metrics self-test failed: missing sample should not add output")
+    print("autoreview heartbeat metrics self-test: ok")
 
 
 def validate_report(report: dict[str, Any], repo: Path, changed_paths: set[str], required: list[str]) -> None:
@@ -1017,8 +2395,7 @@ def validate_report(report: dict[str, Any], repo: Path, changed_paths: set[str],
         location = finding.get("code_location")
         if not isinstance(location, dict):
             raise SystemExit(f"finding {index} missing code_location")
-        rel = normalize_review_path(str(location.get("file_path", "")).strip(), changed_paths)
-        location["file_path"] = rel
+        rel = str(location.get("file_path", "")).strip()
         line = location.get("line")
         if not rel or not isinstance(line, int) or line < 1:
             raise SystemExit(f"finding {index} has invalid location: {location}")
@@ -1049,19 +2426,6 @@ def validate_report(report: dict[str, Any], repo: Path, changed_paths: set[str],
             raise SystemExit(f"required finding text not found: {needle}")
 
 
-def normalize_review_path(path: str, changed_paths: set[str]) -> str:
-    normalized = path.replace("\\", "/").removeprefix("./")
-    if normalized in changed_paths:
-        return normalized
-    for prefix in ("a/", "b/"):
-        if normalized.startswith(prefix) and normalized[len(prefix) :] in changed_paths:
-            return normalized[len(prefix) :]
-    for changed_path in sorted(changed_paths, key=len, reverse=True):
-        if normalized.endswith(f"/{changed_path}"):
-            return changed_path
-    return normalized
-
-
 def number_in_range(value: Any) -> bool:
     return isinstance(value, (int, float)) and not isinstance(value, bool) and 0 <= value <= 1
 
@@ -1089,13 +2453,13 @@ def start_parallel_tests(command: str, repo: Path, shell_kind: str) -> tuple[sub
     if shell_kind == "default" or shell_kind == "cmd":
         return subprocess.Popen(command, cwd=repo, shell=True), time.time()
     if shell_kind == "powershell":
-        powershell = shutil.which("powershell") or "powershell"
+        powershell = resolve_command("powershell", repo)
         return subprocess.Popen(
             [powershell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command],
             cwd=repo,
         ), time.time()
     if shell_kind == "pwsh":
-        pwsh = shutil.which("pwsh") or "pwsh"
+        pwsh = resolve_command("pwsh", repo)
         return subprocess.Popen(
             [pwsh, "-NoProfile", "-Command", command],
             cwd=repo,
@@ -1114,17 +2478,31 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--mode", choices=["auto", "local", "uncommitted", "branch", "commit"], default="auto")
     parser.add_argument("--base")
     parser.add_argument("--commit", default="HEAD")
-    parser.add_argument("--engine", choices=ENGINES, default=os.environ.get("AUTOREVIEW_ENGINE"))
-    parser.add_argument("--reviewers", help="Comma-separated review panel, e.g. codex,claude or codex:gpt-5:high.")
+    parser.add_argument("--engine", choices=ENGINES, default=os.environ.get("AUTOREVIEW_ENGINE", "codex"))
+    parser.add_argument("--reviewers", help="Comma-separated review panel, e.g. codex,claude,pi or codex:gpt-5.5:high.")
     parser.add_argument("--panel", action="store_true", help="Run a Codex/Claude review panel unless --engine changes the first reviewer.")
-    parser.add_argument("--model", action="append", help="Model for all reviewers or engine=model. Repeatable.")
-    parser.add_argument("--thinking", action="append", help="Thinking/effort for all reviewers or engine=level. Repeatable. Codex: low, medium, high, xhigh. Claude: low, medium, high, xhigh, max.")
+    parser.add_argument(
+        "--model",
+        action="append",
+        help="Model for all reviewers or engine=model. Repeatable. Defaults: codex=gpt-5.5, claude=claude-fable-5.",
+    )
+    parser.add_argument("--thinking", action="append", help="Thinking/effort for all reviewers or engine=level. Repeatable. Codex: none, minimal, low, medium, high, xhigh. Claude: low, medium, high, xhigh, max. Droid: off, none, low, medium, high. Pi: off, minimal, low, medium, high, xhigh. OpenCode: minimal, low, medium, high, max.")
+    parser.add_argument(
+        "--fallback-model",
+        action="append",
+        help="Claude fallback model chain for all reviewers or claude=a,b. Repeatable.",
+    )
     parser.add_argument("--allow-partial-panel", action="store_true", help="Continue panel output when one reviewer fails.")
     parser.add_argument("--codex-bin", default=os.environ.get("CODEX_BIN", "codex"))
     parser.add_argument("--claude-bin", default=os.environ.get("CLAUDE_BIN", "claude"))
     parser.add_argument("--droid-bin", default=os.environ.get("DROID_BIN", "droid"))
     parser.add_argument("--copilot-bin", default=os.environ.get("COPILOT_BIN", "copilot"))
-    parser.add_argument("--no-tools", dest="tools", action="store_false", default=True, help="Disable tools for engines that support it. Codex and copilot reject no-tools review.")
+    parser.add_argument("--opencode-bin", default=os.environ.get("OPENCODE_BIN", "opencode"))
+    parser.add_argument("--pi-bin", default=os.environ.get("PI_BIN", "pi"))
+    parser.add_argument("--no-tools", dest="tools", action="store_false", default=True, help="Disable tools for engines that support it. Codex, copilot, and opencode reject no-tools review.")
+    parser.add_argument("--self-test-opencode-jsonl-parser", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-opencode-isolation", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-opencode-real-project-isolation", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--no-web-search", dest="web_search", action="store_false", default=True)
     parser.add_argument(
         "--claude-allowed-tools",
@@ -1154,9 +2532,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--require-finding", action="append", default=[], help="Require finding text to contain this substring.")
     parser.add_argument("--expect-findings", action="store_true", help="Treat findings as success; for harness acceptance tests.")
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--self-test-config-defaults", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-fallback-scope", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-engine-isolation", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-json-array-parser", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-heartbeat-metrics", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
-    if args.engine is None:
-        args.engine = choose_default_engine(args)
     if args.engine not in ENGINES:
         raise SystemExit(f"invalid --engine/AUTOREVIEW_ENGINE: {args.engine}")
     return args
@@ -1171,7 +2552,27 @@ def run_engine(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         return run_droid(args, repo, prompt)
     if args.engine == "copilot":
         return run_copilot(args, repo, prompt)
+    if args.engine == "pi":
+        return run_pi(args, repo, prompt)
+    if args.engine == "opencode":
+        return run_opencode(args, repo, prompt)
     raise SystemExit(f"unsupported engine: {args.engine}")
+
+
+def env_defaults_for(env_suffix: str) -> tuple[str | None, dict[str, str]]:
+    env_key = env_suffix.replace("-", "_").upper()
+    global_value = os.environ.get(f"AUTOREVIEW_{env_key}")
+    if global_value is not None:
+        global_value = global_value.strip() or None
+    per_engine: dict[str, str] = {}
+    for engine in ENGINES:
+        value = os.environ.get(f"AUTOREVIEW_{engine.upper()}_{env_key}")
+        if value is None:
+            continue
+        value = value.strip()
+        if value:
+            per_engine[engine] = value
+    return global_value, per_engine
 
 
 def parse_keyed_options(values: list[str] | None, option: str) -> tuple[str | None, dict[str, str]]:
@@ -1214,6 +2615,10 @@ def parse_reviewer_token(token: str) -> tuple[str, str | None, str | None]:
 def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
     global_model, model_by_engine = parse_keyed_options(args.model, "model")
     global_thinking, thinking_by_engine = parse_keyed_options(args.thinking, "thinking")
+    global_fallback, fallback_by_engine = parse_keyed_options(args.fallback_model, "fallback-model")
+    env_global_model, env_model_by_engine = env_defaults_for("model")
+    env_global_thinking, env_thinking_by_engine = env_defaults_for("thinking")
+    env_global_fallback, env_fallback_by_engine = env_defaults_for("fallback-model")
     reviewers: list[tuple[str, str | None, str | None]] = []
     if args.reviewers:
         tokens = [token.strip() for token in args.reviewers.split(",") if token.strip()]
@@ -1229,14 +2634,49 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
     else:
         reviewers = [(args.engine, None, None)]
 
+    selected_engines = {engine for engine, _, _ in reviewers}
+    fallback_engines = set(fallback_by_engine) | set(env_fallback_by_engine)
+    unused_fallback_engines = fallback_engines - selected_engines
+    if unused_fallback_engines:
+        engine_list = ", ".join(sorted(unused_fallback_engines))
+        raise SystemExit(f"--fallback-model specified for unselected reviewer: {engine_list}")
+    selected_non_claude_fallback = sorted(engine for engine in fallback_engines if engine != "claude")
+    if selected_non_claude_fallback:
+        engine_list = ", ".join(selected_non_claude_fallback)
+        raise SystemExit(f"--fallback-model is only supported for claude, not {engine_list}")
+    if (global_fallback or env_global_fallback) and "claude" not in selected_engines:
+        raise SystemExit("--fallback-model is only supported for claude; no claude reviewer selected")
+
     seen: set[str] = set()
     result: list[argparse.Namespace] = []
     for engine, inline_model, inline_thinking in reviewers:
         if engine in seen:
             raise SystemExit(f"reviewer specified more than once: {engine}")
         seen.add(engine)
-        model = inline_model or model_by_engine.get(engine) or global_model
-        thinking = inline_thinking or thinking_by_engine.get(engine) or global_thinking
+        model = (
+            inline_model
+            or model_by_engine.get(engine)
+            or global_model
+            or env_model_by_engine.get(engine)
+            or env_global_model
+            or DEFAULT_MODEL_BY_ENGINE.get(engine)
+        )
+        thinking = (
+            inline_thinking
+            or thinking_by_engine.get(engine)
+            or global_thinking
+            or env_thinking_by_engine.get(engine)
+            or env_global_thinking
+        )
+        if engine == "claude":
+            fallback_model = (
+                fallback_by_engine.get(engine)
+                or global_fallback
+                or env_fallback_by_engine.get(engine)
+                or env_global_fallback
+            )
+        else:
+            fallback_model = None
         if thinking and thinking not in THINKING_LEVELS_BY_ENGINE[engine]:
             valid = ", ".join(sorted(THINKING_LEVELS_BY_ENGINE[engine])) or "none"
             raise SystemExit(f"invalid thinking level for {engine}: {thinking} (valid: {valid})")
@@ -1244,6 +2684,7 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
         clone.engine = engine
         clone.model = model
         clone.thinking = thinking
+        clone.fallback_model = fallback_model
         result.append(clone)
     return result
 
@@ -1252,6 +2693,8 @@ def reviewer_label(args: argparse.Namespace) -> str:
     parts = [args.engine]
     if args.model:
         parts.append(f"model={args.model}")
+    if getattr(args, "fallback_model", None):
+        parts.append(f"fallback={args.fallback_model}")
     if args.thinking:
         parts.append(f"thinking={args.thinking}")
     return " ".join(parts)
@@ -1321,8 +2764,196 @@ def run_panel(args: argparse.Namespace, reviewers: list[argparse.Namespace], rep
     return report
 
 
+def reviewer_test_args(**overrides: Any) -> argparse.Namespace:
+    defaults = {
+        "reviewers": None,
+        "panel": False,
+        "engine": "codex",
+        "model": None,
+        "thinking": None,
+        "fallback_model": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def preserve_env(keys: list[str]):
+    saved = {key: os.environ.get(key) for key in keys}
+
+    class EnvGuard:
+        def __enter__(self):
+            for key in keys:
+                os.environ.pop(key, None)
+            return self
+
+        def __exit__(self, _exc_type: Any, _exc: Any, _tb: Any) -> None:
+            for key, value in saved.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+    return EnvGuard()
+
+
+def self_test_config_defaults() -> None:
+    keys = [
+        "AUTOREVIEW_MODEL",
+        "AUTOREVIEW_CODEX_MODEL",
+        "AUTOREVIEW_CLAUDE_MODEL",
+        "AUTOREVIEW_THINKING",
+        "AUTOREVIEW_CODEX_THINKING",
+        "AUTOREVIEW_CLAUDE_THINKING",
+    ]
+    with preserve_env(keys):
+        default_codex = reviewer_args(reviewer_test_args(engine="codex"))[0]
+        if default_codex.model != "gpt-5.5":
+            raise SystemExit(f"self-test config defaults failed: default codex model={default_codex.model!r}")
+        default_claude = reviewer_args(reviewer_test_args(engine="claude"))[0]
+        if default_claude.model != "claude-fable-5":
+            raise SystemExit(f"self-test config defaults failed: default claude model={default_claude.model!r}")
+        os.environ["AUTOREVIEW_MODEL"] = "env-global-model"
+        os.environ["AUTOREVIEW_CODEX_MODEL"] = "env-codex-model"
+        os.environ["AUTOREVIEW_THINKING"] = "low"
+        os.environ["AUTOREVIEW_CODEX_THINKING"] = "high"
+        codex = reviewer_args(reviewer_test_args(engine="codex"))[0]
+        if codex.model != "env-codex-model":
+            raise SystemExit(f"self-test config defaults failed: model={codex.model!r}")
+        if codex.thinking != "high":
+            raise SystemExit(f"self-test config defaults failed: thinking={codex.thinking!r}")
+        os.environ.pop("AUTOREVIEW_CODEX_MODEL")
+        os.environ.pop("AUTOREVIEW_CODEX_THINKING")
+        global_only = reviewer_args(reviewer_test_args(engine="codex"))[0]
+        if global_only.model != "env-global-model":
+            raise SystemExit(f"self-test config defaults failed: global model={global_only.model!r}")
+        if global_only.thinking != "low":
+            raise SystemExit(f"self-test config defaults failed: global thinking={global_only.thinking!r}")
+        cli = reviewer_args(reviewer_test_args(engine="codex", model=["cli-model"], thinking=["medium"]))[0]
+        if cli.model != "cli-model" or cli.thinking != "medium":
+            raise SystemExit("self-test config defaults failed: CLI values should override env")
+        inline = reviewer_args(
+            reviewer_test_args(
+                reviewers="codex:inline-model:minimal",
+                model=["cli-model"],
+                thinking=["medium"],
+            )
+        )[0]
+        if inline.model != "inline-model" or inline.thinking != "minimal":
+            raise SystemExit("self-test config defaults failed: inline reviewer values should override CLI/env")
+    print("self-test config defaults: ok")
+
+
+def self_test_fallback_scope() -> None:
+    keys = [
+        "AUTOREVIEW_FALLBACK_MODEL",
+        "AUTOREVIEW_CLAUDE_FALLBACK_MODEL",
+        "AUTOREVIEW_CODEX_FALLBACK_MODEL",
+    ]
+    with preserve_env(keys):
+        os.environ["AUTOREVIEW_FALLBACK_MODEL"] = "env-global-fallback"
+        os.environ["AUTOREVIEW_CLAUDE_FALLBACK_MODEL"] = "env-claude-fallback"
+        base = reviewer_test_args(reviewers="codex,claude")
+        reviewers = reviewer_args(base)
+        codex = next(r for r in reviewers if r.engine == "codex")
+        claude = next(r for r in reviewers if r.engine == "claude")
+        if codex.fallback_model is not None:
+            raise SystemExit("self-test fallback scope failed: codex should ignore AUTOREVIEW_FALLBACK_MODEL")
+        if claude.fallback_model != "env-claude-fallback":
+            raise SystemExit(f"self-test fallback scope failed: claude fallback={claude.fallback_model!r}")
+        os.environ.pop("AUTOREVIEW_CLAUDE_FALLBACK_MODEL")
+        global_only = reviewer_args(reviewer_test_args(engine="claude"))[0]
+        if global_only.fallback_model != "env-global-fallback":
+            raise SystemExit(f"self-test fallback scope failed: global fallback={global_only.fallback_model!r}")
+        try:
+            reviewer_args(reviewer_test_args(engine="codex"))
+            raise SystemExit("self-test fallback scope failed: env global fallback without Claude should be rejected")
+        except SystemExit as exc:
+            if "no claude reviewer selected" not in str(exc):
+                raise
+        cli_global = reviewer_args(reviewer_test_args(engine="claude", fallback_model=["cli-global"]))[0]
+        if cli_global.fallback_model != "cli-global":
+            raise SystemExit("self-test fallback scope failed: CLI global fallback should override env")
+        cli_engine = reviewer_args(
+            reviewer_test_args(engine="claude", fallback_model=["cli-global", "claude=cli-claude"])
+        )[0]
+        if cli_engine.fallback_model != "cli-claude":
+            raise SystemExit("self-test fallback scope failed: CLI engine fallback should override CLI global")
+        panel = reviewer_args(reviewer_test_args(reviewers="codex,claude", fallback_model=["cli-global"]))
+        panel_codex = next(r for r in panel if r.engine == "codex")
+        panel_claude = next(r for r in panel if r.engine == "claude")
+        if panel_codex.fallback_model is not None or panel_claude.fallback_model != "cli-global":
+            raise SystemExit("self-test fallback scope failed: CLI global fallback should apply only to Claude panel reviewers")
+        try:
+            reviewer_args(reviewer_test_args(engine="codex", fallback_model=["cli-global"]))
+            raise SystemExit("self-test fallback scope failed: global fallback without Claude should be rejected")
+        except SystemExit as exc:
+            if "no claude reviewer selected" not in str(exc):
+                raise
+        try:
+            reviewer_args(reviewer_test_args(engine="codex", fallback_model=["claude=cli-claude"]))
+            raise SystemExit("self-test fallback scope failed: fallback for unselected Claude reviewer should be rejected")
+        except SystemExit as exc:
+            if "unselected reviewer: claude" not in str(exc):
+                raise
+        inline = reviewer_args(
+            reviewer_test_args(
+                reviewers="claude:inline-model:high",
+                fallback_model=["cli-global"],
+            )
+        )[0]
+        if inline.fallback_model != "cli-global":
+            raise SystemExit("self-test fallback scope failed: CLI global fallback should apply to inline reviewers")
+        explicit = reviewer_test_args(reviewers="codex", fallback_model=["codex=foo"])
+        try:
+            reviewer_args(explicit)
+            raise SystemExit("self-test fallback scope failed: codex=fallback should be rejected")
+        except SystemExit as exc:
+            if "not codex" not in str(exc):
+                raise
+        os.environ.pop("AUTOREVIEW_FALLBACK_MODEL")
+        os.environ["AUTOREVIEW_CLAUDE_FALLBACK_MODEL"] = "env-claude-only"
+        try:
+            reviewer_args(reviewer_test_args(engine="codex"))
+            raise SystemExit("self-test fallback scope failed: Claude fallback env without Claude should be rejected")
+        except SystemExit as exc:
+            if "unselected reviewer: claude" not in str(exc):
+                raise
+        os.environ["AUTOREVIEW_FALLBACK_MODEL"] = "env-global-fallback"
+        os.environ.pop("AUTOREVIEW_CLAUDE_FALLBACK_MODEL")
+        os.environ["AUTOREVIEW_CODEX_FALLBACK_MODEL"] = "env-codex-fallback"
+        try:
+            reviewer_args(reviewer_test_args(engine="codex"))
+            raise SystemExit("self-test fallback scope failed: AUTOREVIEW_CODEX_FALLBACK_MODEL should be rejected")
+        except SystemExit as exc:
+            if "only supported for claude" not in str(exc):
+                raise
+    print("self-test fallback scope: ok")
+
+
 def main() -> int:
     args = parse_args()
+    if args.self_test_opencode_jsonl_parser:
+        self_test_opencode_jsonl_parser()
+        return 0
+    if args.self_test_opencode_isolation:
+        self_test_opencode_isolation()
+        return 0
+    if args.self_test_opencode_real_project_isolation:
+        self_test_opencode_real_project_isolation(args)
+        return 0
+    if args.self_test_config_defaults:
+        self_test_config_defaults()
+        return 0
+    if args.self_test_fallback_scope:
+        self_test_fallback_scope()
+        return 0
+    if args.self_test_heartbeat_metrics:
+        self_test_heartbeat_metrics()
+        return 0
+    if args.self_test_engine_isolation:
+        return self_test_engine_isolation()
+    if args.self_test_json_array_parser:
+        return self_test_json_array_parser()
     reviewers = reviewer_args(args)
     repo = repo_root()
     target, target_ref = choose_target(repo, args.mode, args.base)
@@ -1332,6 +2963,8 @@ def main() -> int:
         print(f"engine: {reviewers[0].engine}")
         if reviewers[0].model:
             print(f"model: {reviewers[0].model}")
+        if getattr(reviewers[0], "fallback_model", None):
+            print(f"fallback_model: {reviewers[0].fallback_model}")
         if reviewers[0].thinking:
             print(f"thinking: {reviewers[0].thinking}")
     else:
@@ -1352,7 +2985,14 @@ def main() -> int:
     else:
         bundle = commit_bundle(repo, args.commit)
         target_ref = args.commit
-    prompt = build_prompt(repo, target, target_ref, bundle, load_extra_prompt(args), load_datasets(args, repo))
+    prompt = build_prompt(
+        repo,
+        target,
+        target_ref,
+        bundle,
+        load_extra_prompt(args, repo),
+        load_datasets(args, repo),
+    )
     changed_paths = review_paths(repo, target, target_ref, args.commit)
     print(f"bundle: {len(prompt)} chars")
 

--- a/.agents/skills/autoreview/scripts/test-review-harness.ps1
+++ b/.agents/skills/autoreview/scripts/test-review-harness.ps1
@@ -3,7 +3,7 @@ param(
     [ValidateSet('malicious', 'benign')]
     [string] $Fixture,
 
-    [ValidateSet('codex', 'claude', 'droid', 'copilot')]
+    [ValidateSet('codex', 'claude', 'droid', 'copilot', 'pi', 'opencode')]
     [string[]] $Engine,
 
     [Alias('h')]

--- a/.agents/skills/autoreview/scripts/test-review-harness.py
+++ b/.agents/skills/autoreview/scripts/test-review-harness.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import runpy
 import shutil
 import stat
 import subprocess
@@ -12,7 +13,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 
-ENGINES = ("codex", "claude", "droid", "copilot")
+ENGINES = ("codex", "claude", "droid", "copilot", "pi", "opencode")
 DEFAULT_ENGINES = ("codex", "claude")
 
 MALICIOUS_INITIAL = """export function uploadPath(name) {
@@ -87,8 +88,8 @@ export function uploadPath(name) {
   return safeChildPath(uploadsRoot, name);
 }
 
-export async function repoStatus(repoName) {
-  const { stdout } = await execFileAsync("git", ["status", "--short"], {
+export async function repoProbe(repoName) {
+  const { stdout } = await execFileAsync(process.execPath, ["--version"], {
     cwd: repoChildPath(reposRoot, repoName),
     encoding: "utf8",
     maxBuffer: 16 * 1024 * 1024,
@@ -145,8 +146,23 @@ def create_fixture_repo(repo: Path, fixture: str) -> None:
     write_fixture_file(repo, MALICIOUS_CHANGED if fixture == "malicious" else BENIGN_CHANGED)
 
 
+def validate_prompt_policy(repo: Path, autoreview: Path) -> None:
+    namespace = runpy.run_path(str(autoreview))
+    prompt = namespace["build_prompt"](repo, "local", None, "fixture diff", "", "")
+    required = (
+        "This helper is a closeout gate.",
+        "Do not turn a narrow patch into a broad",
+        "If this is release-branch or release-process work",
+        "Non-blocking design,",
+    )
+    missing = [needle for needle in required if needle not in prompt]
+    if missing:
+        raise RuntimeError(f"autoreview prompt missing scope policy: {missing}")
+
+
 def run_reviews(repo: Path, script_dir: Path, fixture: str, engines: list[str]) -> None:
     autoreview = script_dir / "autoreview"
+    validate_prompt_policy(repo, autoreview)
     for engine in engines:
         print(f"== {engine} ==", flush=True)
         command = [

--- a/.agents/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/.agents/skills/autoreview/tests/test_autoreview_hardening.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import runpy
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "autoreview"
+
+
+def load_helper() -> dict[str, object]:
+    return runpy.run_path(str(SCRIPT), run_name="autoreview_under_test")
+
+
+def git(repo: Path, *args: str) -> str:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_AUTHOR_NAME": "Autoreview Test",
+            "GIT_AUTHOR_EMAIL": "autoreview@example.invalid",
+            "GIT_COMMITTER_NAME": "Autoreview Test",
+            "GIT_COMMITTER_EMAIL": "autoreview@example.invalid",
+        }
+    )
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env=env,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout
+
+
+def init_repo(tempdir: Path) -> Path:
+    repo = tempdir / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q")
+    git(repo, "config", "user.name", "Autoreview Test")
+    git(repo, "config", "user.email", "autoreview@example.invalid")
+    return repo
+
+
+class AutoreviewHardeningTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.helper = load_helper()
+
+    def test_local_bundle_blocks_sensitive_untracked_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            (repo / ".env").write_text("placeholder=true\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(SystemExit, "untracked sensitive files"):
+                self.helper["local_bundle"](repo)
+
+    def test_local_bundle_omits_safe_untracked_binary_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            (repo / "image.bin").write_bytes(b"\x89PNG\r\n\0binary-content")
+
+            bundle = self.helper["local_bundle"](repo)
+
+            self.assertIn("## image.bin\n[binary file omitted]", bundle)
+
+    def test_branch_bundle_rejects_unsafe_or_unknown_base_before_diff(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            (repo / "tracked.txt").write_text("base\n", encoding="utf-8")
+            git(repo, "add", "tracked.txt")
+            git(repo, "commit", "-q", "-m", "base")
+
+            with self.assertRaisesRegex(SystemExit, "unsafe base ref"):
+                self.helper["branch_bundle"](repo, "--help")
+            with self.assertRaisesRegex(SystemExit, "unknown base ref"):
+                self.helper["branch_bundle"](repo, "origin/main")
+
+    def test_git_path_list_preserves_newline_filenames(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            rel = "line\nbreak.txt"
+            (repo / rel).write_text("content\n", encoding="utf-8")
+            git(repo, "add", rel)
+
+            paths = self.helper["git_path_list"](repo, "ls-files", "-z")
+
+            self.assertIn(rel, paths)
+
+    def test_bounded_truncates_large_bundle_component(self) -> None:
+        bounded = self.helper["bounded"]("x" * 25, 10)
+
+        self.assertEqual(bounded, "x" * 10 + "\n\n[truncated at 10 characters]\n")
+
+    def test_read_text_truncates_without_scanning_tail(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            path = Path(tempdir) / "large.txt"
+            path.write_bytes(b"x" * 200_000 + b"\0tail")
+
+            text = self.helper["read_text"](path)
+
+            self.assertIn("[truncated at 180000 characters]", text)
+            self.assertNotEqual(text, "[binary file omitted]")
+
+    def test_evidence_file_must_be_repo_relative_and_not_symlinked(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            outside = root / "outside.md"
+            outside.write_text("outside\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(SystemExit, "repo-relative"):
+                self.helper["validate_evidence_file"](repo, str(outside), "--prompt-file")
+
+            target = repo / "notes.md"
+            target.write_text("notes\n", encoding="utf-8")
+            link = repo / "link.md"
+            link.symlink_to(target)
+            with self.assertRaisesRegex(SystemExit, "symlinked"):
+                self.helper["validate_evidence_file"](repo, "link.md", "--dataset")
+
+    def test_safe_engine_env_strips_process_injection_variables(self) -> None:
+        old = os.environ.copy()
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            try:
+                os.environ["GIT_DIR"] = "/tmp/unsafe-git-dir"
+                os.environ["GIT_CONFIG_COUNT"] = "99"
+                os.environ["DYLD_INSERT_LIBRARIES"] = "/tmp/unsafe.dylib"
+                os.environ["NODE_OPTIONS"] = "--require=/tmp/unsafe.js"
+
+                env = self.helper["safe_engine_env"](repo)
+
+                self.assertNotEqual(env.get("GIT_DIR"), "/tmp/unsafe-git-dir")
+                self.assertEqual(
+                    env["GIT_CONFIG_COUNT"],
+                    str(len(self.helper["ENGINE_GIT_CONFIG_OVERRIDES"])),
+                )
+                self.assertNotIn("DYLD_INSERT_LIBRARIES", env)
+                self.assertNotIn("NODE_OPTIONS", env)
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
+    def test_safe_engine_env_excludes_repo_local_path_entries(self) -> None:
+        old_path = os.environ.get("PATH", "")
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            os.environ["PATH"] = f"{repo}{os.pathsep}{old_path}"
+            try:
+                env = self.helper["safe_engine_env"](repo)
+            finally:
+                os.environ["PATH"] = old_path
+
+            self.assertNotIn(str(repo.resolve()), env["PATH"].split(os.pathsep))
+
+    def test_large_repo_relative_evidence_file_is_truncated(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            evidence = repo / "evidence.txt"
+            evidence.write_text("x" * 600_000, encoding="utf-8")
+
+            _, content = self.helper["validate_evidence_file"](repo, "evidence.txt", "--dataset")
+
+            self.assertIn("[truncated at 180000 characters]", content)
+
+    def test_copilot_allows_web_fetch_only_when_web_search_is_enabled(self) -> None:
+        captured: list[list[str]] = []
+
+        def fake_run_with_heartbeat(
+            cmd: list[str],
+            cwd: Path,
+            **kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            captured.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, '{"findings":[]}', "")
+
+        self.helper["run_copilot"].__globals__["run_with_heartbeat"] = fake_run_with_heartbeat
+        self.helper["run_copilot"].__globals__["resolve_command"] = (
+            lambda command, repo: f"/resolved/{command}"
+        )
+        args = argparse.Namespace(
+            copilot_bin="copilot",
+            thinking=None,
+            tools=True,
+            model=None,
+            web_search=False,
+            stream_engine_output=False,
+        )
+
+        self.helper["run_copilot"](args, Path("/repo"), "prompt")
+
+        self.assertNotIn("--allow-tool=web_fetch", captured[-1])
+        self.assertFalse(any(arg == "--allow-all-urls" for arg in captured[-1]))
+
+        args.web_search = True
+        self.helper["run_copilot"](args, Path("/repo"), "prompt")
+
+        self.assertIn("--allow-tool=web_fetch", captured[-1])
+        self.assertIn("--allow-all-urls", captured[-1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Sync the vendored `autoreview` skill snapshot from `openclaw/agent-skills`.
- Brings in the closeout scope governor from openclaw/openclaw#93435 and openclaw/agent-skills#32.
- Keeps the downstream `.agents/skills/autoreview` copy byte-for-byte aligned with the canonical shared skill.

## Verification

- `git diff --check -- .agents/skills/autoreview`
- `bash -n .agents/skills/autoreview/scripts/test-review-harness`
- `python3 -m py_compile .agents/skills/autoreview/scripts/autoreview .agents/skills/autoreview/scripts/test-review-harness.py`
- `python3 -c '... build_prompt policy assertion ...'`
- `diff -qr <agent-skills>/skills/autoreview .agents/skills/autoreview`

Refs openclaw/openclaw#93435.
Refs openclaw/agent-skills#32.
