### PR TITLE
Add OpenClaw Onboard settings card

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3139,6 +3139,18 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         }
     }
 
+    private async Task ShowGatewayWizardAsync()
+    {
+        await ShowOnboardingAsync();
+        var setupWindow = _setupWindow;
+        if (setupWindow == null)
+            return;
+
+        await setupWindow.WaitForInitialContentReadyAsync();
+        if (ReferenceEquals(_setupWindow, setupWindow) && !setupWindow.IsClosed)
+            setupWindow.NavigateToWizard();
+    }
+
     private void OnSetupAdvancedSetupRequested(object? sender, EventArgs e)
     {
         ShowHub("connection");
@@ -3338,6 +3350,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     void IAppCommands.ShowChat() => ShowChatWindow();
     void IAppCommands.CheckForUpdates() => _ = _updateCoordinator!.CheckForUpdatesUserInitiatedAsync();
     void IAppCommands.ShowOnboarding() => _ = ShowOnboardingAsync();
+    void IAppCommands.ShowGatewayWizard() => _ = ShowGatewayWizardAsync();
     void IAppCommands.ShowConnectionStatus() => ShowConnectionStatusWindow();
     void IAppCommands.NotifySettingsSaved() => OnSettingsSaved(this, EventArgs.Empty);
 

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3103,8 +3103,13 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
     private async Task ShowOnboardingAsync()
     {
+        await EnsureSetupWindowAsync();
+    }
+
+    private async Task<(SetupWindow? Window, bool CreatedNew)> EnsureSetupWindowAsync()
+    {
         if (_settings == null)
-            return;
+            return (null, false);
 
         if (_setupWindow != null)
         {
@@ -3112,7 +3117,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             await existingSetupWindow.WaitForInitialContentReadyAsync();
             if (ReferenceEquals(_setupWindow, existingSetupWindow) && !existingSetupWindow.IsClosed)
                 existingSetupWindow.BringToFrontForSetupLaunch();
-            return;
+            return (existingSetupWindow, false);
         }
 
         try
@@ -3132,19 +3137,31 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 setupWindow.BringToFrontForSetupLaunch();
                 Logger.Info("Opened tray-hosted setup window");
             }
+            return (setupWindow, true);
         }
         catch (Exception ex)
         {
             Logger.Error($"Failed to open setup window: {ex}");
+            return (null, false);
         }
     }
 
     private async Task ShowGatewayWizardAsync()
     {
-        await ShowOnboardingAsync();
-        var setupWindow = _setupWindow;
+        var (setupWindow, createdNew) = await EnsureSetupWindowAsync();
         if (setupWindow == null)
             return;
+
+        // Only steer a freshly created setup window to the gateway wizard. An
+        // already-open setup window may be mid-install on ProgressPage, whose
+        // Unloaded handler cancels the running setup pipeline — navigating it
+        // away would abort an in-progress install. In that case leave the
+        // existing window on its current page (already brought to the front).
+        if (!createdNew)
+        {
+            Logger.Info("Setup window already open; skipping direct gateway wizard navigation to avoid interrupting active setup");
+            return;
+        }
 
         await setupWindow.WaitForInitialContentReadyAsync();
         if (ReferenceEquals(_setupWindow, setupWindow) && !setupWindow.IsClosed)

--- a/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml
@@ -284,6 +284,34 @@
                     </Grid>
                 </Border>
 
+                <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1" CornerRadius="8"
+                        Padding="{StaticResource SettingsRowPadding}"
+                        AutomationProperties.AutomationId="OpenClawOnboardCard">
+                    <Grid ColumnSpacing="14">
+                        <Grid.ColumnDefinitions>
+                           <ColumnDefinition Width="*"/>
+                           <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="2">
+                           <TextBlock x:Uid="SettingsPage_OnboardWizard_Header"
+                                      Text="OpenClaw Onboard"
+                                      Style="{StaticResource BodyTextBlockStyle}"/>
+                           <TextBlock x:Uid="SettingsPage_OnboardWizard_Description"
+                                      Text="Open the OpenClaw onboarding on an installed Local Gateway. Skips WSL installation and jumps straight to configuration."
+                                      Style="{StaticResource CaptionTextBlockStyle}"
+                                      Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                      TextWrapping="Wrap"/>
+                        </StackPanel>
+                        <Button Grid.Column="1"
+                                x:Uid="SettingsPage_OpenOnboardWizard"
+                                Content="Open onboarding"
+                                Click="OnOpenGatewayWizard"
+                                AutomationProperties.AutomationId="OpenClawOnboardButton"/>
+                    </Grid>
+                </Border>
+
                 <Border x:Name="LocalGatewayExpander"
                         Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"

--- a/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml.cs
@@ -230,6 +230,11 @@ public sealed partial class SettingsPage : Page
         ((IAppCommands)CurrentApp).ShowOnboarding();
     }
 
+    private void OnOpenGatewayWizard(object sender, RoutedEventArgs e)
+    {
+        ((IAppCommands)CurrentApp).ShowGatewayWizard();
+    }
+
     private void OnTestNotification(object sender, RoutedEventArgs e)
     {
         try

--- a/src/OpenClaw.Tray.WinUI/Services/IAppCommands.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/IAppCommands.cs
@@ -16,6 +16,7 @@ internal interface IAppCommands
     void ShowChat();
     void CheckForUpdates();
     void ShowOnboarding();
+    void ShowGatewayWizard();
     void ShowConnectionStatus();
     void NotifySettingsSaved();
 }

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -4425,6 +4425,15 @@ On your gateway host (Mac/Linux), run:
   <data name="SettingsPage_OpenLocalGatewaySetup.Content" xml:space="preserve">
     <value>Open setup</value>
   </data>
+  <data name="SettingsPage_OnboardWizard_Header.Text" xml:space="preserve">
+    <value>OpenClaw Onboard</value>
+  </data>
+  <data name="SettingsPage_OnboardWizard_Description.Text" xml:space="preserve">
+    <value>Open the OpenClaw onboarding on an installed Local Gateway. Skips WSL installation and jumps straight to configuration.</value>
+  </data>
+  <data name="SettingsPage_OpenOnboardWizard.Content" xml:space="preserve">
+    <value>Open onboarding</value>
+  </data>
   <data name="SettingsPage_MSIXInstallationDetected.Title" xml:space="preserve">
     <value>MSIX installation detected</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -4377,6 +4377,15 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="SettingsPage_OpenLocalGatewaySetup.Content" xml:space="preserve">
     <value>Ouvrir la configuration</value>
   </data>
+  <data name="SettingsPage_OnboardWizard_Header.Text" xml:space="preserve">
+    <value>OpenClaw Onboard</value>
+  </data>
+  <data name="SettingsPage_OnboardWizard_Description.Text" xml:space="preserve">
+    <value>Ouvrez l'intégration OpenClaw sur une passerelle locale installée. Ignore l'installation de WSL et passe directement à la configuration.</value>
+  </data>
+  <data name="SettingsPage_OpenOnboardWizard.Content" xml:space="preserve">
+    <value>Ouvrir l'intégration</value>
+  </data>
   <data name="SettingsPage_MSIXInstallationDetected.Title" xml:space="preserve">
     <value>Installation MSIX détectée</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -4378,6 +4378,15 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="SettingsPage_OpenLocalGatewaySetup.Content" xml:space="preserve">
     <value>Setup openen</value>
   </data>
+  <data name="SettingsPage_OnboardWizard_Header.Text" xml:space="preserve">
+    <value>OpenClaw Onboard</value>
+  </data>
+  <data name="SettingsPage_OnboardWizard_Description.Text" xml:space="preserve">
+    <value>Open de OpenClaw onboarding op een geïnstalleerde lokale gateway. Slaat de WSL-installatie over en gaat direct naar de configuratie.</value>
+  </data>
+  <data name="SettingsPage_OpenOnboardWizard.Content" xml:space="preserve">
+    <value>Onboarding openen</value>
+  </data>
   <data name="SettingsPage_MSIXInstallationDetected.Title" xml:space="preserve">
     <value>MSIX-installatie gedetecteerd</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -4377,6 +4377,15 @@
   <data name="SettingsPage_OpenLocalGatewaySetup.Content" xml:space="preserve">
     <value>打开设置</value>
   </data>
+  <data name="SettingsPage_OnboardWizard_Header.Text" xml:space="preserve">
+    <value>OpenClaw Onboard</value>
+  </data>
+  <data name="SettingsPage_OnboardWizard_Description.Text" xml:space="preserve">
+    <value>在已安装的本地网关上打开 OpenClaw 引导。跳过 WSL 安装，直接进入配置。</value>
+  </data>
+  <data name="SettingsPage_OpenOnboardWizard.Content" xml:space="preserve">
+    <value>打开引导</value>
+  </data>
   <data name="SettingsPage_MSIXInstallationDetected.Title" xml:space="preserve">
     <value>检测到 MSIX 安装</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -4377,6 +4377,15 @@
   <data name="SettingsPage_OpenLocalGatewaySetup.Content" xml:space="preserve">
     <value>開啟設定</value>
   </data>
+  <data name="SettingsPage_OnboardWizard_Header.Text" xml:space="preserve">
+    <value>OpenClaw Onboard</value>
+  </data>
+  <data name="SettingsPage_OnboardWizard_Description.Text" xml:space="preserve">
+    <value>在已安裝的本機閘道上開啟 OpenClaw 引導。略過 WSL 安裝，直接進入設定。</value>
+  </data>
+  <data name="SettingsPage_OpenOnboardWizard.Content" xml:space="preserve">
+    <value>開啟引導</value>
+  </data>
   <data name="SettingsPage_MSIXInstallationDetected.Title" xml:space="preserve">
     <value>偵測到 MSIX 安裝</value>
   </data>

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -133,6 +133,11 @@ public sealed class AppRefactorContractTests
         Assert.Contains("setupWindow.SetupCompleted += OnSetupCompleted", source);
         Assert.Contains("ShowGatewayWizardAsync", source);
         Assert.Contains("setupWindow.NavigateToWizard()", source);
+        // Direct onboarding must not hijack an already-open setup window: it
+        // only navigates a freshly created window so it cannot cancel an
+        // in-progress install running on ProgressPage.
+        Assert.Contains("EnsureSetupWindowAsync", source);
+        Assert.Contains("if (!createdNew)", source);
         Assert.Contains("RestartAfterSetupAsync", source);
         Assert.Contains("\"--post-setup-restart\"", source);
         Assert.Contains("\"--wait-for-pid\"", source);

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -131,6 +131,8 @@ public sealed class AppRefactorContractTests
 
         Assert.Contains("new SetupWindow()", source);
         Assert.Contains("setupWindow.SetupCompleted += OnSetupCompleted", source);
+        Assert.Contains("ShowGatewayWizardAsync", source);
+        Assert.Contains("setupWindow.NavigateToWizard()", source);
         Assert.Contains("RestartAfterSetupAsync", source);
         Assert.Contains("\"--post-setup-restart\"", source);
         Assert.Contains("\"--wait-for-pid\"", source);

--- a/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
@@ -49,6 +49,9 @@ public class LocalizationValidationTests
         "VoiceOverlayWindow_winexWindowEx_2.Title",
         // Brand name — identical across all locales.
         "ConnectionPage_TopologyTailscale",
+        // Product/feature name — "OpenClaw Onboard" is kept identical across
+        // all locales (the card's description and button are translated).
+        "SettingsPage_OnboardWizard_Header.Text",
         "PermissionsPage_TtsElevenLabsModel.PlaceholderText",
         "PermissionsPage_TtsProviderElevenLabs.Content",
         // Sample IDs / brand identifiers — same across locales.


### PR DESCRIPTION
## Summary

Adds a dedicated **OpenClaw Onboard** card to the Local Gateway section of Companion Settings. Its **Open onboarding** button opens the hosted setup window and jumps straight to the gateway onboarding step, skipping WSL installation.

This is useful when a Local Gateway is already installed and you just want to (re)run the gateway-driven onboarding/configuration without going through the full first-run install flow.

## Changes

- **New `ShowGatewayWizard` app command** (`IAppCommands` + `App.xaml.cs`) — hosts `SetupWindow`, waits for initial content, then calls `NavigateToWizard()` so Welcome / Capabilities / install / Progress pages are skipped.
- **Settings UI** (`SettingsPage.xaml` / `.xaml.cs`) — the existing Local Gateway setup card keeps its single **Open setup** button; a new **OpenClaw Onboard** card is added below it with header, description, and an **Open onboarding** button.
- **Localization** — new `SettingsPage_OnboardWizard_Header`, `SettingsPage_OnboardWizard_Description`, and `SettingsPage_OpenOnboardWizard.Content` strings across all 5 locales (en-us, fr-fr, nl-nl, zh-cn, zh-tw).
- **Tests** — `AppRefactorContractTests` extended to assert the direct onboarding entrypoint (`ShowGatewayWizardAsync` + `setupWindow.NavigateToWizard()`) stays in the tray process.

## Validation

- `./build.ps1` — all projects build
- `dotnet test ./tests/OpenClaw.Shared.Tests/...` — pass
- `dotnet test ./tests/OpenClaw.Tray.Tests/...` — pass
- Launched locally and verified the **OpenClaw Onboard** card renders in the Local Gateway section.
<img width="982" height="642" alt="image" src="https://github.com/user-attachments/assets/071675f9-4501-4ef5-b6bc-c96d8eeb63b6" />
