### PR TITLE
[codex] Keep native gateway out of WSL recovery

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Services/SetupExistingGatewayClassifier.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SetupExistingGatewayClassifier.cs
@@ -106,10 +106,7 @@ public static class SetupExistingGatewayClassifier
     private static bool HasLocalSetupEvidence(GatewayRegistry? registry, string localDataPath)
     {
         if (registry is not null
-            && registry.GetAll().Any(record =>
-                record.IsLocal
-                && record.SshTunnel is null
-                && LocalGatewayUrlClassifier.IsLocalGatewayUrl(record.Url)))
+            && registry.GetAll().Any(WslKeepAlivePolicy.IsSetupManagedLocalRecord))
         {
             return true;
         }

--- a/src/OpenClaw.Tray.WinUI/Services/WslKeepAlivePolicy.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/WslKeepAlivePolicy.cs
@@ -10,17 +10,12 @@ internal static class WslKeepAlivePolicy
 
     public static bool ShouldStart(GatewayRecord? activeRecord, string? legacyGatewayUrl)
     {
+        _ = legacyGatewayUrl;
+
         if (activeRecord is not null)
-        {
-            if (activeRecord.SshTunnel is not null)
-                return false;
+            return IsSetupManagedLocalRecord(activeRecord);
 
-            return activeRecord.IsLocal
-                || !string.IsNullOrWhiteSpace(activeRecord.SetupManagedDistroName)
-                || LocalGatewayUrlClassifier.IsLocalGatewayUrl(activeRecord.Url);
-        }
-
-        return LocalGatewayUrlClassifier.IsLocalGatewayUrl(legacyGatewayUrl ?? string.Empty);
+        return false;
     }
 
     public static string? ResolveDistroName(

--- a/tests/OpenClaw.Tray.Tests/StartupSetupStateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/StartupSetupStateTests.cs
@@ -274,6 +274,7 @@ public class StartupSetupStateTests
             Id = "local-gateway",
             Url = "ws://localhost:18789",
             IsLocal = true,
+            SetupManagedDistroName = "OpenClawGateway",
             SharedGatewayToken = "shared-token"
         });
         var wsl = new FakeWslCommandRunner([new WslDistroInfo("OpenClawGateway", "Stopped", 2)]);
@@ -286,6 +287,32 @@ public class StartupSetupStateTests
             localDataPath: temp.Path);
 
         Assert.Equal(SetupExistingGatewayKind.AppOwnedLocalWsl, kind);
+    }
+
+    [Fact]
+    public async Task ClassifyAsync_TreatsNativeLoopbackGatewayAsExternalOnly_EvenWhenOpenClawGatewayDistroExists()
+    {
+        using var temp = TempSettings.Create();
+        var settings = new SettingsManager(temp.Path);
+        var registry = new GatewayRegistry(temp.Path);
+        registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "native-gateway",
+            Url = "wss://127.0.0.1:18789",
+            FriendlyName = "Desktop-A Native Gateway",
+            IsLocal = true,
+            SharedGatewayToken = "shared-token"
+        });
+        var wsl = new FakeWslCommandRunner([new WslDistroInfo("OpenClawGateway", "Stopped", 2)]);
+
+        var kind = await SetupExistingGatewayClassifier.ClassifyAsync(
+            registry,
+            settings,
+            temp.Path,
+            wsl,
+            localDataPath: temp.Path);
+
+        Assert.Equal(SetupExistingGatewayKind.ExternalOnly, kind);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/WslKeepAlivePolicyTests.cs
+++ b/tests/OpenClaw.Tray.Tests/WslKeepAlivePolicyTests.cs
@@ -20,6 +20,20 @@ public class WslKeepAlivePolicyTests
     }
 
     [Fact]
+    public void ShouldStart_DoesNotStartForManualNativeLocalRecord()
+    {
+        var record = new GatewayRecord
+        {
+            Id = "native-local",
+            Url = "wss://127.0.0.1:18789",
+            FriendlyName = "Desktop-A Native Gateway",
+            IsLocal = true,
+        };
+
+        Assert.False(WslKeepAlivePolicy.ShouldStart(record, legacyGatewayUrl: null));
+    }
+
+    [Fact]
     public void ShouldStart_DoesNotFallBackToLegacyLocalUrl_WhenActiveRecordIsRemote()
     {
         var record = new GatewayRecord
@@ -47,9 +61,9 @@ public class WslKeepAlivePolicyTests
     }
 
     [Fact]
-    public void ShouldStart_FallsBackToLegacyLocalUrl_WhenNoActiveRecordExists()
+    public void ShouldStart_DoesNotFallBackToLegacyLocalUrl_WhenNoActiveRecordExists()
     {
-        Assert.True(WslKeepAlivePolicy.ShouldStart(activeRecord: null, "ws://127.0.0.1:18789"));
+        Assert.False(WslKeepAlivePolicy.ShouldStart(activeRecord: null, "ws://127.0.0.1:18789"));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Keeps Windows-native local gateways out of the WSL/Docker recovery path.

## What changed

- `WslKeepAlivePolicy.ShouldStart` now starts WSL keepalive only for setup-managed local gateway records.
- `SetupExistingGatewayClassifier` now treats only setup-managed local records, or valid setup-state evidence, as app-owned WSL setup evidence.
- Added regression tests for native loopback gateways such as `Desktop-A Native Gateway`.

## Why

A Windows-native gateway can be local and loopback-bound without being managed by the old WSL/Docker setup. Treating every local loopback record as app-owned WSL evidence can incorrectly restart or recover the WSL/Docker path after the user has moved to the native Windows gateway.

## Validation

- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --filter "FullyQualifiedName~WslKeepAlivePolicyTests|FullyQualifiedName~StartupSetupStateTests"`: passed, 45 tests
- `.\build.ps1`: passed
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`: passed, 1075 tests
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`: exited 0
- `git diff --check`: passed
