### PR TITLE
Use wxc-exec --probe for MXC host support; bump mxc-sdk to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "openclaw-windows-node-mxc",
       "version": "0.0.0",
       "dependencies": {
-        "@microsoft/mxc-sdk": "^0.6.1"
+        "@microsoft/mxc-sdk": "^0.7.0"
       }
     },
     "node_modules/@microsoft/mxc-sdk": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/mxc-sdk/-/mxc-sdk-0.6.1.tgz",
-      "integrity": "sha512-jpbJU/xfF4qLWcNMplDTUX/q13m2A6vYao1QN3lkZaQlzsRce95H+iU0Qu0wlweJZ2gx6eY1PRQU+/bnQki/dw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/mxc-sdk/-/mxc-sdk-0.7.0.tgz",
+      "integrity": "sha512-EWhz2pKkcPluZHAOI1yneV+JK0NO/3hdh7nABBb0x4PjyUWMeSWPTBAjtIu+BhtMYOqlaijSPZMZ0Hs/J4ZL4A==",
       "license": "MIT",
       "dependencies": {
         "node-pty": "^1.2.0-beta.12",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "MXC sandbox dependency used by the OpenClaw tray build to copy wxc-exec.exe into the app output.",
   "dependencies": {
-    "@microsoft/mxc-sdk": "^0.6.1"
+    "@microsoft/mxc-sdk": "^0.7.0"
   }
 }

--- a/src/OpenClaw.Shared/Mxc/DirectAppContainerExecutor.cs
+++ b/src/OpenClaw.Shared/Mxc/DirectAppContainerExecutor.cs
@@ -196,7 +196,7 @@ public sealed class DirectAppContainerExecutor : ISandboxExecutor
             $"cwd={(string.IsNullOrEmpty(config.Process.Cwd) ? "<null>" : "<set>")}; " +
             $"envKeys=[{string.Join(",", envKeys)}]; " +
             $"timeoutMs={config.Process.TimeoutMs?.ToString() ?? "<null>"}; " +
-            $"capabilities=[{string.Join(",", config.AppContainer?.Capabilities ?? Array.Empty<string>())}]; " +
+            $"capabilities=[{string.Join(",", config.ProcessContainer?.Capabilities ?? Array.Empty<string>())}]; " +
             $"readonlyCount={config.Filesystem?.ReadonlyPaths?.Length ?? 0}; " +
             $"readwriteCount={config.Filesystem?.ReadwritePaths?.Length ?? 0}; " +
             $"deniedCount={config.Filesystem?.DeniedPaths?.Length ?? 0}; " +

--- a/src/OpenClaw.Shared/Mxc/DirectAppContainerExecutor.cs
+++ b/src/OpenClaw.Shared/Mxc/DirectAppContainerExecutor.cs
@@ -43,12 +43,18 @@ public sealed class DirectAppContainerExecutor : ISandboxExecutor
     /// </summary>
     private const int Base64ConfigCharLimit = 25_000;
 
-    private readonly MxcAvailability _availability;
+    private readonly Func<MxcAvailability> _availabilityProvider;
     private readonly IOpenClawLogger _logger;
 
-    public DirectAppContainerExecutor(MxcAvailability availability, IOpenClawLogger? logger = null)
+    /// <summary>
+    /// Resolves availability lazily via <paramref name="availabilityProvider"/> so the
+    /// executor always sees the current probe verdict. A fixed snapshot would freeze a
+    /// startup probe error for the executor's lifetime even after the host recovers
+    /// (the re-probe would update the caller's gate but not this executor).
+    /// </summary>
+    public DirectAppContainerExecutor(Func<MxcAvailability> availabilityProvider, IOpenClawLogger? logger = null)
     {
-        _availability = availability;
+        _availabilityProvider = availabilityProvider ?? throw new ArgumentNullException(nameof(availabilityProvider));
         _logger = logger ?? NullLogger.Instance;
     }
 
@@ -56,11 +62,15 @@ public sealed class DirectAppContainerExecutor : ISandboxExecutor
         SandboxExecutionRequest request,
         CancellationToken ct = default)
     {
-        if (!_availability.IsAppContainerAvailable)
-            throw new SandboxUnavailableException(
-                _availability.UnsupportedReasons.FirstOrDefault() ?? "AppContainer unavailable");
+        // Resolve the live availability for THIS invocation so a transient startup
+        // probe error that has since recovered doesn't permanently fail us closed.
+        var availability = _availabilityProvider();
 
-        if (!_availability.IsWxcExecResolvable || string.IsNullOrEmpty(_availability.WxcExecPath))
+        if (!availability.IsAppContainerAvailable)
+            throw new SandboxUnavailableException(
+                availability.UnsupportedReasons.FirstOrDefault() ?? "AppContainer unavailable");
+
+        if (!availability.IsWxcExecResolvable || string.IsNullOrEmpty(availability.WxcExecPath))
             throw new SandboxUnavailableException("wxc-exec.exe not found");
 
         var capBytes = request.MaxOutputBytes is > 0 ? request.MaxOutputBytes.Value : DefaultMaxOutputBytes;
@@ -78,16 +88,16 @@ public sealed class DirectAppContainerExecutor : ISandboxExecutor
                 : config.Process.Cwd;
 
             WarnIfUnsupportedVolume(config);
-            LogConfig(config, configJson, request);
+            LogConfig(config, configJson, request, availability.WxcExecPath);
 
             MxcExecutor executor;
             try
             {
-                executor = new MxcExecutor(_availability.WxcExecPath, stdoutCapBytes: capInt, stderrCapBytes: capInt);
+                executor = new MxcExecutor(availability.WxcExecPath, stdoutCapBytes: capInt, stderrCapBytes: capInt);
             }
             catch (FileNotFoundException ex)
             {
-                throw new SandboxUnavailableException($"wxc-exec.exe not found at {_availability.WxcExecPath}", ex);
+                throw new SandboxUnavailableException($"wxc-exec.exe not found at {availability.WxcExecPath}", ex);
             }
 
             // Local timeout + caller cancellation. Mirror the builder's
@@ -178,7 +188,7 @@ public sealed class DirectAppContainerExecutor : ISandboxExecutor
         try { if (Directory.Exists(path)) Directory.Delete(path, recursive: true); } catch { /* best-effort */ }
     }
 
-    private void LogConfig(MxcConfig config, string configJson, SandboxExecutionRequest request)
+    private void LogConfig(MxcConfig config, string configJson, SandboxExecutionRequest request, string? wxcExecPath)
     {
         // Default: redacted summary. Field counts only; no paths, no command line,
         // no env values. Useful for verifying Sandbox UI settings round-tripped
@@ -190,7 +200,7 @@ public sealed class DirectAppContainerExecutor : ISandboxExecutor
 
         var summary =
             "[mxc] wxc-exec config (redacted) " +
-            $"wxcExec={_availability.WxcExecPath}; configBytes={Encoding.UTF8.GetByteCount(configJson)}; " +
+            $"wxcExec={wxcExecPath}; configBytes={Encoding.UTF8.GetByteCount(configJson)}; " +
             $"containerId={config.ContainerId}; version={config.Version}; " +
             $"commandLineLength={config.Process.CommandLine?.Length ?? 0}; " +
             $"cwd={(string.IsNullOrEmpty(config.Process.Cwd) ? "<null>" : "<set>")}; " +

--- a/src/OpenClaw.Shared/Mxc/MxcAvailability.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcAvailability.cs
@@ -5,15 +5,15 @@ using System.Text.Json;
 namespace OpenClaw.Shared.Mxc;
 
 /// <summary>
-/// Per-backend availability probe for MXC. Cached for the process lifetime.
+/// Per-backend availability probe for MXC. <see cref="Probe"/> is intended to be
+/// called once and its result cached by the caller (see NodeService).
 /// </summary>
 /// <remarks>
 /// Backends checked:
 /// <list type="bullet">
 /// <item><see cref="IsAppContainerAvailable"/> — the native <c>wxc-exec --probe</c>
 ///   reports a usable isolation tier on this host. This is the source of truth
-///   for "does this machine support the sandbox", replacing the old hardcoded
-///   Windows build/UBR table.</item>
+///   for "does this machine support the sandbox".</item>
 /// <item><see cref="IsWxcExecResolvable"/> — wxc-exec.exe found in the shipped tray output layout or via override.</item>
 /// <item><see cref="IsIsolationSessionAvailable"/> — requires a supported host plus IsolationProxy.exe in System32.</item>
 /// </list>
@@ -158,7 +158,7 @@ public sealed class MxcAvailability
         }
 
         // Ask the native binary whether this host can run the sandbox and at what
-        // isolation tier. Replaces the old hardcoded build 26300 / UBR 8289 gate.
+        // isolation tier.
         WxcProbeInvocation invocation;
         try
         {

--- a/src/OpenClaw.Shared/Mxc/MxcAvailability.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcAvailability.cs
@@ -46,10 +46,41 @@ public sealed class MxcAvailability
     public string? WxcExecPath { get; }
 
     /// <summary>
+    /// True when the availability verdict came from a <em>probe error</em>
+    /// (timeout, failure to launch <c>wxc-exec</c>, or unparseable output) rather
+    /// than a definitive answer (supported, or the host reporting unsupported).
+    /// Callers should treat an errored verdict as transient — re-probe instead of
+    /// caching it for the process lifetime — so a momentary glitch doesn't pin the
+    /// whole process to uncontained execution.
+    /// </summary>
+    public bool ProbeErrored { get; }
+
+    /// <summary>
+    /// Isolation tier the probe selected for this host (e.g. <c>base-container</c>,
+    /// <c>appcontainer-bfs</c>, <c>appcontainer-dacl</c>), or null when unsupported
+    /// / not probed. Informational; <see cref="IsDegradedContainment"/> is the
+    /// derived signal UX should react to.
+    /// </summary>
+    public string? IsolationTier { get; }
+
+    /// <summary>
+    /// True when the probe indicated the host needs host-DACL augmentation to
+    /// contain (a weaker, last-resort path).
+    /// </summary>
+    public bool NeedsDaclAugmentation { get; }
+
+    /// <summary>
     /// Human-readable list of reasons MXC may not be available. Empty when fully supported.
     /// Surface to UX so users know why the sandbox toggle is disabled.
     /// </summary>
     public IReadOnlyList<string> UnsupportedReasons { get; }
+
+    /// <summary>Tiers we consider full-strength containment. Anything else that
+    /// still contains (e.g. <c>appcontainer-dacl</c>, or an unrecognized future
+    /// tier string) is treated as degraded so UX can warn without dropping the
+    /// host all the way to uncontained.</summary>
+    private static readonly HashSet<string> FullStrengthTiers =
+        new(StringComparer.OrdinalIgnoreCase) { "base-container", "appcontainer-bfs" };
 
     /// <summary>True iff at least one MXC backend is supported AND
     /// <c>wxc-exec.exe</c> is resolvable. (Without wxc-exec the executor will refuse
@@ -58,18 +89,36 @@ public sealed class MxcAvailability
         (IsAppContainerAvailable || IsIsolationSessionAvailable)
         && IsWxcExecResolvable;
 
+    /// <summary>
+    /// True when MXC is available but only via a weaker, last-resort isolation tier
+    /// (DACL augmentation, or a tier we don't recognize as full-strength). Still
+    /// contained — surface as a warning, not a block; refusing would drop the host
+    /// to fully uncontained execution, which is strictly worse.
+    /// </summary>
+    public bool IsDegradedContainment =>
+        HasAnyBackend
+        && (NeedsDaclAugmentation
+            || string.IsNullOrEmpty(IsolationTier)
+            || !FullStrengthTiers.Contains(IsolationTier));
+
     public MxcAvailability(
         bool isAppContainerAvailable,
         bool isIsolationSessionAvailable,
         bool isWxcExecResolvable,
         string? wxcExecPath,
-        IReadOnlyList<string> unsupportedReasons)
+        IReadOnlyList<string> unsupportedReasons,
+        bool probeErrored = false,
+        string? isolationTier = null,
+        bool needsDaclAugmentation = false)
     {
         IsAppContainerAvailable = isAppContainerAvailable;
         IsIsolationSessionAvailable = isIsolationSessionAvailable;
         IsWxcExecResolvable = isWxcExecResolvable;
         WxcExecPath = wxcExecPath;
         UnsupportedReasons = unsupportedReasons;
+        ProbeErrored = probeErrored;
+        IsolationTier = isolationTier;
+        NeedsDaclAugmentation = needsDaclAugmentation;
     }
 
     /// <summary>
@@ -132,8 +181,11 @@ public sealed class MxcAvailability
             "IsolationProxy.exe");
         var isIsolationSessionSupported = isAppContainerSupported && File.Exists(isolationProxyPath);
 
+        var probeErrored = probe.Outcome == MxcProbeOutcome.ProbeError;
+
         log.Info(
             $"[mxc] availability: supported={isAppContainerSupported} " +
+            $"outcome={probe.Outcome} " +
             $"tier={probe.Tier ?? "<none>"} needsDaclAugmentation={probe.NeedsDaclAugmentation} " +
             $"isolation_session={isIsolationSessionSupported} " +
             $"wxc-exec={wxcPath} " +
@@ -145,30 +197,47 @@ public sealed class MxcAvailability
             isIsolationSessionSupported,
             isWxcExecResolvable: true,
             wxcPath,
-            reasons);
+            reasons,
+            probeErrored: probeErrored,
+            isolationTier: probe.Tier,
+            needsDaclAugmentation: probe.NeedsDaclAugmentation);
     }
 
     /// <summary>
-    /// Parse the JSON emitted by <c>wxc-exec --probe</c> into a support verdict.
-    /// A non-zero exit, empty/garbage output, or a missing isolation tier all
-    /// mean the host cannot run the sandbox. Exposed for unit testing.
+    /// Parse the JSON emitted by <c>wxc-exec --probe</c> into a support verdict,
+    /// classifying the outcome as <see cref="MxcProbeOutcome.Supported"/>,
+    /// <see cref="MxcProbeOutcome.UnsupportedHost"/> (the binary ran and reported
+    /// no usable tier), or <see cref="MxcProbeOutcome.ProbeError"/> (we could not
+    /// get a verdict — our timeout/launch sentinel, or exit 0 with no usable
+    /// output). Probe errors are transient and should be re-probed, not cached.
+    /// Exposed for unit testing.
     /// </summary>
     internal static MxcProbeResult ParseProbeOutput(int exitCode, string? stdout, string? stderr)
     {
+        // Negative exit codes are our own sentinels (timeout / failed to launch)
+        // set by RunWxcExecProbe and Probe's catch — we never actually ran the
+        // probe to a verdict, so treat as a transient error rather than a
+        // definitive "unsupported host".
+        if (exitCode < 0)
+        {
+            var detail = FirstNonEmpty(stderr, stdout);
+            return Error(
+                $"Could not determine MXC sandbox support (wxc-exec --probe did not complete{(detail is null ? "" : $": {Summarize(detail)}")}).");
+        }
+
+        // A positive non-zero exit is the binary running and reporting that this
+        // host cannot sandbox — a definitive, non-retryable verdict.
         if (exitCode != 0)
         {
             var detail = FirstNonEmpty(stderr, stdout);
-            return new MxcProbeResult(
-                Supported: false,
-                Tier: null,
-                NeedsDaclAugmentation: false,
-                Warnings: Array.Empty<string>(),
-                FailureReason: $"This Windows host does not support the MXC sandbox (wxc-exec --probe exited {exitCode}{(detail is null ? "" : $": {Summarize(detail)}")}).");
+            return Unsupported(
+                $"This Windows host does not support the MXC sandbox (wxc-exec --probe exited {exitCode}{(detail is null ? "" : $": {Summarize(detail)}")}).");
         }
 
+        // Exit 0 but no/garbled output is a binary anomaly, not a clear answer —
+        // treat as a (retryable) probe error rather than silently "unsupported".
         if (string.IsNullOrWhiteSpace(stdout))
-            return new MxcProbeResult(false, null, false, Array.Empty<string>(),
-                "This Windows host does not support the MXC sandbox (wxc-exec --probe returned no output).");
+            return Error("Could not determine MXC sandbox support (wxc-exec --probe returned no output).");
 
         try
         {
@@ -179,8 +248,7 @@ public sealed class MxcAvailability
                 || tierEl.ValueKind != JsonValueKind.String
                 || string.IsNullOrWhiteSpace(tierEl.GetString()))
             {
-                return new MxcProbeResult(false, null, false, Array.Empty<string>(),
-                    "This Windows host does not support the MXC sandbox (wxc-exec --probe did not report an isolation tier).");
+                return Error("Could not determine MXC sandbox support (wxc-exec --probe did not report an isolation tier).");
             }
 
             var needsDacl = root.TryGetProperty("needsDaclAugmentation", out var d)
@@ -197,13 +265,18 @@ public sealed class MxcAvailability
                 }
             }
 
-            return new MxcProbeResult(true, tierEl.GetString(), needsDacl, warnings, null);
+            return new MxcProbeResult(MxcProbeOutcome.Supported, tierEl.GetString(), needsDacl, warnings, null);
         }
         catch (JsonException ex)
         {
-            return new MxcProbeResult(false, null, false, Array.Empty<string>(),
-                $"This Windows host does not support the MXC sandbox (wxc-exec --probe returned unparseable output: {ex.Message}).");
+            return Error($"Could not determine MXC sandbox support (wxc-exec --probe returned unparseable output: {ex.Message}).");
         }
+
+        static MxcProbeResult Unsupported(string reason) =>
+            new(MxcProbeOutcome.UnsupportedHost, null, false, Array.Empty<string>(), reason);
+
+        static MxcProbeResult Error(string reason) =>
+            new(MxcProbeOutcome.ProbeError, null, false, Array.Empty<string>(), reason);
     }
 
     private static string? FirstNonEmpty(params string?[] values)
@@ -266,8 +339,8 @@ public sealed class MxcAvailability
         catch (AggregateException)
         {
             // A pipe read faulted (e.g. stream disposed). Treat as no output;
-            // ParseProbeOutput will fall back to "unsupported" for exit 0 with
-            // empty stdout, and surface stderr if the exit code was non-zero.
+            // ParseProbeOutput classifies exit 0 with empty stdout as a (retryable)
+            // probe error, and surfaces stderr if the exit code was non-zero.
         }
 
         return new WxcProbeInvocation(
@@ -343,10 +416,32 @@ public sealed class MxcAvailability
 /// <summary>Raw result of invoking <c>wxc-exec --probe</c>.</summary>
 internal readonly record struct WxcProbeInvocation(int ExitCode, string StdOut, string StdErr);
 
+/// <summary>
+/// Classification of a <c>wxc-exec --probe</c> attempt.
+/// </summary>
+internal enum MxcProbeOutcome
+{
+    /// <summary>The probe ran and reported a usable isolation tier.</summary>
+    Supported,
+
+    /// <summary>The probe ran and definitively reported the host cannot sandbox.</summary>
+    UnsupportedHost,
+
+    /// <summary>
+    /// We could not obtain a verdict (timeout, failure to launch, or exit 0 with
+    /// no usable output). Transient/indeterminate — should be re-probed, not cached.
+    /// </summary>
+    ProbeError,
+}
+
 /// <summary>Parsed host-support verdict derived from <c>wxc-exec --probe</c> output.</summary>
 internal sealed record MxcProbeResult(
-    bool Supported,
+    MxcProbeOutcome Outcome,
     string? Tier,
     bool NeedsDaclAugmentation,
     IReadOnlyList<string> Warnings,
-    string? FailureReason);
+    string? FailureReason)
+{
+    /// <summary>Convenience: true only for <see cref="MxcProbeOutcome.Supported"/>.</summary>
+    public bool Supported => Outcome == MxcProbeOutcome.Supported;
+}

--- a/src/OpenClaw.Shared/Mxc/MxcAvailability.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcAvailability.cs
@@ -224,26 +224,43 @@ public sealed class MxcAvailability
                 $"Could not determine MXC sandbox support (wxc-exec --probe {what}{(detail is null ? "" : $": {Summarize(detail)}")}).");
         }
 
-        // The process ran to completion. A non-zero exit is the binary reporting that
-        // this host cannot sandbox — a definitive, non-retryable verdict. (Genuine
-        // infrastructure failures — timeout / failed launch — are captured above via
-        // status, so they never reach this branch and get cached as "unsupported".)
-        if (exitCode != 0)
-        {
-            var detail = FirstNonEmpty(stderr, stdout);
-            return Unsupported(
-                $"This Windows host does not support the MXC sandbox (wxc-exec --probe exited {exitCode}{(detail is null ? "" : $": {Summarize(detail)}")}).");
-        }
-
-        // Exit 0 but no/garbled output is a binary anomaly, not a clear answer —
+        // No/garbled output is a binary anomaly, not a clear answer —
         // treat as a (retryable) probe error rather than silently "unsupported".
         if (string.IsNullOrWhiteSpace(stdout))
-            return Error("Could not determine MXC sandbox support (wxc-exec --probe returned no output).");
+        {
+            var detail = FirstNonEmpty(stderr);
+            return Error(
+                $"Could not determine MXC sandbox support (wxc-exec --probe {(exitCode == 0 ? "returned no output" : $"exited {exitCode}")}{(detail is null ? "" : $": {Summarize(detail)}")}).");
+        }
 
         try
         {
             using var doc = JsonDocument.Parse(stdout);
             var root = doc.RootElement;
+            var warnings = ReadWarnings(root);
+
+            if (TryGetString(root, "error") is { } error)
+            {
+                return Unsupported(
+                    $"This Windows host does not support the MXC sandbox (wxc-exec --probe reported: {Summarize(error)}).",
+                    warnings);
+            }
+
+            if (root.TryGetProperty("supported", out var supportedEl)
+                && supportedEl.ValueKind == JsonValueKind.False)
+            {
+                return Unsupported(
+                    "This Windows host does not support the MXC sandbox (wxc-exec --probe reported no usable isolation tier).",
+                    warnings);
+            }
+
+            if (exitCode != 0)
+            {
+                var detail = FirstNonEmpty(stderr, stdout);
+                return Error(
+                    $"Could not determine MXC sandbox support (wxc-exec --probe exited {exitCode}{(detail is null ? "" : $": {Summarize(detail)}")}).");
+            }
+
             if (root.ValueKind != JsonValueKind.Object
                 || !root.TryGetProperty("tier", out var tierEl)
                 || tierEl.ValueKind != JsonValueKind.String
@@ -255,29 +272,53 @@ public sealed class MxcAvailability
             var needsDacl = root.TryGetProperty("needsDaclAugmentation", out var d)
                 && d.ValueKind == JsonValueKind.True;
 
-            var warnings = new List<string>();
-            if (root.TryGetProperty("warnings", out var w) && w.ValueKind == JsonValueKind.Array)
-            {
-                foreach (var item in w.EnumerateArray())
-                {
-                    if (item.ValueKind != JsonValueKind.String) continue;
-                    var s = item.GetString();
-                    if (!string.IsNullOrWhiteSpace(s)) warnings.Add(s);
-                }
-            }
-
             return new MxcProbeResult(MxcProbeOutcome.Supported, tierEl.GetString(), needsDacl, warnings, null);
         }
         catch (JsonException ex)
         {
-            return Error($"Could not determine MXC sandbox support (wxc-exec --probe returned unparseable output: {ex.Message}).");
+            var detail = FirstNonEmpty(stderr, stdout);
+            return Error(
+                $"Could not determine MXC sandbox support (wxc-exec --probe {(exitCode == 0 ? "returned unparseable output" : $"exited {exitCode}")}: {Summarize(detail ?? ex.Message)}).");
         }
 
-        static MxcProbeResult Unsupported(string reason) =>
-            new(MxcProbeOutcome.UnsupportedHost, null, false, Array.Empty<string>(), reason);
+        static MxcProbeResult Unsupported(string reason, IReadOnlyList<string>? warnings = null) =>
+            new(MxcProbeOutcome.UnsupportedHost, null, false, warnings ?? Array.Empty<string>(), reason);
 
         static MxcProbeResult Error(string reason) =>
             new(MxcProbeOutcome.ProbeError, null, false, Array.Empty<string>(), reason);
+
+        static string? TryGetString(JsonElement root, string propertyName)
+        {
+            if (root.ValueKind != JsonValueKind.Object
+                || !root.TryGetProperty(propertyName, out var property)
+                || property.ValueKind != JsonValueKind.String)
+            {
+                return null;
+            }
+
+            var value = property.GetString();
+            return string.IsNullOrWhiteSpace(value) ? null : value;
+        }
+
+        static List<string> ReadWarnings(JsonElement root)
+        {
+            var warnings = new List<string>();
+            if (root.ValueKind != JsonValueKind.Object
+                || !root.TryGetProperty("warnings", out var w)
+                || w.ValueKind != JsonValueKind.Array)
+            {
+                return warnings;
+            }
+
+            foreach (var item in w.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.String) continue;
+                var s = item.GetString();
+                if (!string.IsNullOrWhiteSpace(s)) warnings.Add(s);
+            }
+
+            return warnings;
+        }
     }
 
     private static string? FirstNonEmpty(params string?[] values)

--- a/src/OpenClaw.Shared/Mxc/MxcAvailability.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcAvailability.cs
@@ -1,4 +1,6 @@
-using Microsoft.Win32;
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
 
 namespace OpenClaw.Shared.Mxc;
 
@@ -8,9 +10,12 @@ namespace OpenClaw.Shared.Mxc;
 /// <remarks>
 /// Backends checked:
 /// <list type="bullet">
-/// <item><see cref="IsAppContainerAvailable"/> — Windows 11 build 26300 with UBR &gt;= 8289, x64 / arm64.</item>
+/// <item><see cref="IsAppContainerAvailable"/> — the native <c>wxc-exec --probe</c>
+///   reports a usable isolation tier on this host. This is the source of truth
+///   for "does this machine support the sandbox", replacing the old hardcoded
+///   Windows build/UBR table.</item>
 /// <item><see cref="IsWxcExecResolvable"/> — wxc-exec.exe found in the shipped tray output layout or via override.</item>
-/// <item><see cref="IsIsolationSessionAvailable"/> — requires AppContainer plus IsolationProxy.exe in System32.</item>
+/// <item><see cref="IsIsolationSessionAvailable"/> — requires a supported host plus IsolationProxy.exe in System32.</item>
 /// </list>
 /// </remarks>
 public sealed class MxcAvailability
@@ -22,14 +27,18 @@ public sealed class MxcAvailability
     /// </summary>
     public const string WxcExecOverrideEnvVar = "OPENCLAW_WXC_EXEC";
 
-    private const int SupportedBuild = 26300;
-
-    // TODO: This is all temporary and a moment in time; feature gate this correctly ASAP.
     /// <summary>
-    /// Temporary MXC support table: only build 26300 with UBR 8289+ is enabled.
-    /// All other builds are blocked until validated and the table is updated.
+    /// Bound on how long we wait for <c>wxc-exec --probe</c> before treating the
+    /// host as unable to run the sandbox.
     /// </summary>
-    private const int MinSupportedUbr = 8289;
+    private const int ProbeTimeoutMs = 15_000;
+
+    /// <summary>
+    /// Minimum time allowed for draining stdout/stderr after the probe process
+    /// exits, so a process that exits right at the deadline doesn't false-timeout
+    /// while its (tiny) output is still being read.
+    /// </summary>
+    private const int MinReadDrainMs = 2_000;
 
     public bool IsAppContainerAvailable { get; }
     public bool IsIsolationSessionAvailable { get; }
@@ -65,9 +74,21 @@ public sealed class MxcAvailability
 
     /// <summary>
     /// Probe the running environment. Designed to be called once at app startup
-    /// and the result cached.
+    /// and the result cached. Host support is determined by the native
+    /// <c>wxc-exec --probe</c> command rather than a hardcoded build/UBR table,
+    /// so newer Windows builds light up automatically without a code change.
     /// </summary>
     public static MxcAvailability Probe(IOpenClawLogger? logger = null)
+        => Probe(logger, probeRunner: null);
+
+    /// <summary>
+    /// Test seam for <see cref="Probe(IOpenClawLogger?)"/>. <paramref name="probeRunner"/>
+    /// substitutes the <c>wxc-exec --probe</c> invocation; production passes
+    /// <c>null</c> to spawn the real process.
+    /// </summary>
+    internal static MxcAvailability Probe(
+        IOpenClawLogger? logger,
+        Func<string, WxcProbeInvocation>? probeRunner)
     {
         var log = logger ?? NullLogger.Instance;
         var reasons = new List<string>();
@@ -78,79 +99,202 @@ public sealed class MxcAvailability
             return new MxcAvailability(false, false, false, null, reasons);
         }
 
-        var (build, ubr) = ReadWindowsBuildAndUbr();
-        var windowsSupportReason = GetWindowsBuildUnsupportedReason(build, ubr);
-        if (windowsSupportReason is not null)
-            reasons.Add(windowsSupportReason);
-
-        var isAppContainerSupported = windowsSupportReason is null;
-
+        // wxc-exec is the source of truth for host support, so resolve it first.
+        // Without the binary we cannot probe and therefore report unavailable.
         var (wxcResolvable, wxcPath) = ResolveWxcExec();
-        if (!wxcResolvable)
+        if (!wxcResolvable || string.IsNullOrEmpty(wxcPath))
+        {
             reasons.Add($"wxc-exec.exe not found. Set {WxcExecOverrideEnvVar} or build the tray app to copy it into the output folder.");
+            return new MxcAvailability(false, false, false, null, reasons);
+        }
+
+        // Ask the native binary whether this host can run the sandbox and at what
+        // isolation tier. Replaces the old hardcoded build 26300 / UBR 8289 gate.
+        WxcProbeInvocation invocation;
+        try
+        {
+            invocation = (probeRunner ?? RunWxcExecProbe)(wxcPath);
+        }
+        catch (Exception ex)
+        {
+            invocation = new WxcProbeInvocation(-1, string.Empty, $"Failed to launch wxc-exec --probe: {ex.Message}");
+        }
+
+        var probe = ParseProbeOutput(invocation.ExitCode, invocation.StdOut, invocation.StdErr);
+        var isAppContainerSupported = probe.Supported;
+        if (!isAppContainerSupported)
+            reasons.Add(probe.FailureReason ?? "This Windows host does not support the MXC sandbox (wxc-exec --probe reported no usable tier).");
 
         // isolation_session additionally requires Feature_IsoBrokerSessionApis on the OS
         // and IsolationProxy.exe in System32. We currently only check file presence.
         var isolationProxyPath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.System),
             "IsolationProxy.exe");
-        var isIsolationSessionSupported = isAppContainerSupported
-            && wxcResolvable
-            && File.Exists(isolationProxyPath);
+        var isIsolationSessionSupported = isAppContainerSupported && File.Exists(isolationProxyPath);
 
         log.Info(
-            $"[mxc] availability: appcontainer={isAppContainerSupported} " +
+            $"[mxc] availability: supported={isAppContainerSupported} " +
+            $"tier={probe.Tier ?? "<none>"} needsDaclAugmentation={probe.NeedsDaclAugmentation} " +
             $"isolation_session={isIsolationSessionSupported} " +
-            $"wxc-exec={(wxcResolvable ? wxcPath : "<missing>")} " +
+            $"wxc-exec={wxcPath} " +
+            $"warnings=[{string.Join(", ", probe.Warnings)}] " +
             $"reasons=[{string.Join(", ", reasons)}]");
 
         return new MxcAvailability(
             isAppContainerSupported,
             isIsolationSessionSupported,
-            wxcResolvable,
+            isWxcExecResolvable: true,
             wxcPath,
             reasons);
     }
 
-    internal static string? GetWindowsBuildUnsupportedReason(int build, int ubr)
+    /// <summary>
+    /// Parse the JSON emitted by <c>wxc-exec --probe</c> into a support verdict.
+    /// A non-zero exit, empty/garbage output, or a missing isolation tier all
+    /// mean the host cannot run the sandbox. Exposed for unit testing.
+    /// </summary>
+    internal static MxcProbeResult ParseProbeOutput(int exitCode, string? stdout, string? stderr)
     {
-        if (build != SupportedBuild)
-            return $"Windows build {build} is not MXC supported build {SupportedBuild}.";
-
-        if (ubr < MinSupportedUbr)
+        if (exitCode != 0)
         {
-            return
-                $"Windows UBR {ubr} below MXC minimum {MinSupportedUbr} " +
-                $"(for build {SupportedBuild}). " +
-                "Install latest cumulative update.";
+            var detail = FirstNonEmpty(stderr, stdout);
+            return new MxcProbeResult(
+                Supported: false,
+                Tier: null,
+                NeedsDaclAugmentation: false,
+                Warnings: Array.Empty<string>(),
+                FailureReason: $"This Windows host does not support the MXC sandbox (wxc-exec --probe exited {exitCode}{(detail is null ? "" : $": {Summarize(detail)}")}).");
         }
 
-        return null;
-    }
-
-    private static (int build, int ubr) ReadWindowsBuildAndUbr()
-    {
-        var build = Environment.OSVersion.Version.Build;
-        var ubr = 0;
-        if (!OperatingSystem.IsWindows())
-            return (build, ubr);
+        if (string.IsNullOrWhiteSpace(stdout))
+            return new MxcProbeResult(false, null, false, Array.Empty<string>(),
+                "This Windows host does not support the MXC sandbox (wxc-exec --probe returned no output).");
 
         try
         {
-#pragma warning disable CA1416 // OperatingSystem.IsWindows() guard above; analyzer doesn't recognize it through callee.
-            using var key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
-            var value = key?.GetValue("UBR");
-            if (value is int ubrInt)
-                ubr = ubrInt;
-#pragma warning restore CA1416
+            using var doc = JsonDocument.Parse(stdout);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object
+                || !root.TryGetProperty("tier", out var tierEl)
+                || tierEl.ValueKind != JsonValueKind.String
+                || string.IsNullOrWhiteSpace(tierEl.GetString()))
+            {
+                return new MxcProbeResult(false, null, false, Array.Empty<string>(),
+                    "This Windows host does not support the MXC sandbox (wxc-exec --probe did not report an isolation tier).");
+            }
+
+            var needsDacl = root.TryGetProperty("needsDaclAugmentation", out var d)
+                && d.ValueKind == JsonValueKind.True;
+
+            var warnings = new List<string>();
+            if (root.TryGetProperty("warnings", out var w) && w.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in w.EnumerateArray())
+                {
+                    if (item.ValueKind != JsonValueKind.String) continue;
+                    var s = item.GetString();
+                    if (!string.IsNullOrWhiteSpace(s)) warnings.Add(s);
+                }
+            }
+
+            return new MxcProbeResult(true, tierEl.GetString(), needsDacl, warnings, null);
         }
-        catch
+        catch (JsonException ex)
         {
-            // Best-effort registry read; failure leaves ubr = 0 which fails the gate.
+            return new MxcProbeResult(false, null, false, Array.Empty<string>(),
+                $"This Windows host does not support the MXC sandbox (wxc-exec --probe returned unparseable output: {ex.Message}).");
+        }
+    }
+
+    private static string? FirstNonEmpty(params string?[] values)
+    {
+        foreach (var v in values)
+            if (!string.IsNullOrWhiteSpace(v)) return v!.Trim();
+        return null;
+    }
+
+    private static string Summarize(string text)
+    {
+        var collapsed = text.Replace("\r", " ").Replace("\n", " ").Trim();
+        return collapsed.Length <= 200 ? collapsed : collapsed[..200] + "…";
+    }
+
+    /// <summary>
+    /// Spawn <c>wxc-exec --probe</c> and capture its exit code and output.
+    /// Bounded by <see cref="ProbeTimeoutMs"/>; a timeout reports a non-zero exit.
+    /// </summary>
+    private static WxcProbeInvocation RunWxcExecProbe(string wxcExecPath)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = wxcExecPath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
+            },
+        };
+        process.StartInfo.ArgumentList.Add("--probe");
+
+        process.Start();
+        // Read both pipes async to avoid a full-pipe deadlock.
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+
+        var sw = Stopwatch.StartNew();
+        if (!process.WaitForExit(ProbeTimeoutMs))
+            return KillAndTimeout(process, stdoutTask, stderrTask);
+
+        // WaitForExit(int) returns as soon as the immediate child exits, but the
+        // async readers only complete once the WRITE end of each pipe closes. If
+        // wxc-exec spawned a descendant that inherited the redirected handles
+        // (the SDK ships sandbox daemon/guest helpers), the pipes can stay open
+        // after the child exits and an unbounded GetResult() would hang past the
+        // timeout. So bound the drain with whatever time is left in the budget
+        // (with a small floor so a near-deadline exit doesn't false-timeout).
+        var elapsedMs = (int)Math.Min(sw.ElapsedMilliseconds, ProbeTimeoutMs);
+        var drainBudgetMs = Math.Max(ProbeTimeoutMs - elapsedMs, MinReadDrainMs);
+        try
+        {
+            if (!Task.WhenAll(stdoutTask, stderrTask).Wait(drainBudgetMs))
+                return KillAndTimeout(process, stdoutTask, stderrTask);
+        }
+        catch (AggregateException)
+        {
+            // A pipe read faulted (e.g. stream disposed). Treat as no output;
+            // ParseProbeOutput will fall back to "unsupported" for exit 0 with
+            // empty stdout, and surface stderr if the exit code was non-zero.
         }
 
-        return (build, ubr);
+        return new WxcProbeInvocation(
+            process.ExitCode,
+            stdoutTask.Status == TaskStatus.RanToCompletion ? stdoutTask.Result : string.Empty,
+            stderrTask.Status == TaskStatus.RanToCompletion ? stderrTask.Result : string.Empty);
     }
+
+    /// <summary>
+    /// Kill the probe process tree and return a timeout invocation. Observes the
+    /// abandoned read tasks so a later fault doesn't surface as an unobserved
+    /// task exception when the process/streams are disposed.
+    /// </summary>
+    private static WxcProbeInvocation KillAndTimeout(Process process, Task stdoutTask, Task stderrTask)
+    {
+        try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+        ObserveQuietly(stdoutTask);
+        ObserveQuietly(stderrTask);
+        return new WxcProbeInvocation(-1, string.Empty, "wxc-exec --probe timed out.");
+    }
+
+    private static void ObserveQuietly(Task task) =>
+        _ = task.ContinueWith(
+            static t => { _ = t.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
 
     private static (bool resolvable, string? path) ResolveWxcExec()
     {
@@ -195,3 +339,14 @@ public sealed class MxcAvailability
         _ => "x64",
     };
 }
+
+/// <summary>Raw result of invoking <c>wxc-exec --probe</c>.</summary>
+internal readonly record struct WxcProbeInvocation(int ExitCode, string StdOut, string StdErr);
+
+/// <summary>Parsed host-support verdict derived from <c>wxc-exec --probe</c> output.</summary>
+internal sealed record MxcProbeResult(
+    bool Supported,
+    string? Tier,
+    bool NeedsDaclAugmentation,
+    IReadOnlyList<string> Warnings,
+    string? FailureReason);

--- a/src/OpenClaw.Shared/Mxc/MxcAvailability.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcAvailability.cs
@@ -166,10 +166,10 @@ public sealed class MxcAvailability
         }
         catch (Exception ex)
         {
-            invocation = new WxcProbeInvocation(-1, string.Empty, $"Failed to launch wxc-exec --probe: {ex.Message}");
+            invocation = new WxcProbeInvocation(WxcProbeStatus.LaunchFailed, 0, string.Empty, $"Failed to launch wxc-exec --probe: {ex.Message}");
         }
 
-        var probe = ParseProbeOutput(invocation.ExitCode, invocation.StdOut, invocation.StdErr);
+        var probe = ParseProbeOutput(invocation.Status, invocation.ExitCode, invocation.StdOut, invocation.StdErr);
         var isAppContainerSupported = probe.Supported;
         if (!isAppContainerSupported)
             reasons.Add(probe.FailureReason ?? "This Windows host does not support the MXC sandbox (wxc-exec --probe reported no usable tier).");
@@ -204,29 +204,30 @@ public sealed class MxcAvailability
     }
 
     /// <summary>
-    /// Parse the JSON emitted by <c>wxc-exec --probe</c> into a support verdict,
+    /// Parse the result of a <c>wxc-exec --probe</c> attempt into a support verdict,
     /// classifying the outcome as <see cref="MxcProbeOutcome.Supported"/>,
-    /// <see cref="MxcProbeOutcome.UnsupportedHost"/> (the binary ran and reported
-    /// no usable tier), or <see cref="MxcProbeOutcome.ProbeError"/> (we could not
-    /// get a verdict — our timeout/launch sentinel, or exit 0 with no usable
+    /// <see cref="MxcProbeOutcome.UnsupportedHost"/> (the binary ran to completion and
+    /// reported no usable tier), or <see cref="MxcProbeOutcome.ProbeError"/> (we could
+    /// not get a verdict: timeout, launch failure, or a completed run with no usable
     /// output). Probe errors are transient and should be re-probed, not cached.
     /// Exposed for unit testing.
     /// </summary>
-    internal static MxcProbeResult ParseProbeOutput(int exitCode, string? stdout, string? stderr)
+    internal static MxcProbeResult ParseProbeOutput(WxcProbeStatus status, int exitCode, string? stdout, string? stderr)
     {
-        // Negative exit codes are our own sentinels (timeout / failed to launch)
-        // set by RunWxcExecProbe and Probe's catch — we never actually ran the
-        // probe to a verdict, so treat as a transient error rather than a
-        // definitive "unsupported host".
-        if (exitCode < 0)
+        // We never obtained a verdict — our own infrastructure failure, not a host
+        // decision. Always transient/retryable, regardless of any exit code.
+        if (status != WxcProbeStatus.Completed)
         {
             var detail = FirstNonEmpty(stderr, stdout);
+            var what = status == WxcProbeStatus.TimedOut ? "timed out" : "could not be launched";
             return Error(
-                $"Could not determine MXC sandbox support (wxc-exec --probe did not complete{(detail is null ? "" : $": {Summarize(detail)}")}).");
+                $"Could not determine MXC sandbox support (wxc-exec --probe {what}{(detail is null ? "" : $": {Summarize(detail)}")}).");
         }
 
-        // A positive non-zero exit is the binary running and reporting that this
-        // host cannot sandbox — a definitive, non-retryable verdict.
+        // The process ran to completion. A non-zero exit is the binary reporting that
+        // this host cannot sandbox — a definitive, non-retryable verdict. (Genuine
+        // infrastructure failures — timeout / failed launch — are captured above via
+        // status, so they never reach this branch and get cached as "unsupported".)
         if (exitCode != 0)
         {
             var detail = FirstNonEmpty(stderr, stdout);
@@ -344,6 +345,7 @@ public sealed class MxcAvailability
         }
 
         return new WxcProbeInvocation(
+            WxcProbeStatus.Completed,
             process.ExitCode,
             stdoutTask.Status == TaskStatus.RanToCompletion ? stdoutTask.Result : string.Empty,
             stderrTask.Status == TaskStatus.RanToCompletion ? stderrTask.Result : string.Empty);
@@ -359,7 +361,7 @@ public sealed class MxcAvailability
         try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
         ObserveQuietly(stdoutTask);
         ObserveQuietly(stderrTask);
-        return new WxcProbeInvocation(-1, string.Empty, "wxc-exec --probe timed out.");
+        return new WxcProbeInvocation(WxcProbeStatus.TimedOut, 0, string.Empty, "wxc-exec --probe timed out.");
     }
 
     private static void ObserveQuietly(Task task) =>
@@ -413,8 +415,24 @@ public sealed class MxcAvailability
     };
 }
 
-/// <summary>Raw result of invoking <c>wxc-exec --probe</c>.</summary>
-internal readonly record struct WxcProbeInvocation(int ExitCode, string StdOut, string StdErr);
+/// <summary>Outcome of attempting to run <c>wxc-exec --probe</c> (distinct from the
+/// host verdict it produces). Lets us tell our own infrastructure failures
+/// (timeout / launch failure) apart from a process that actually completed.</summary>
+internal enum WxcProbeStatus
+{
+    /// <summary>The process ran to completion; <c>ExitCode</c> and output are meaningful.</summary>
+    Completed,
+
+    /// <summary>The process did not exit within the timeout and was killed.</summary>
+    TimedOut,
+
+    /// <summary>The process could not be started at all.</summary>
+    LaunchFailed,
+}
+
+/// <summary>Raw result of invoking <c>wxc-exec --probe</c>. <c>ExitCode</c> is only
+/// meaningful when <c>Status</c> is <see cref="WxcProbeStatus.Completed"/>.</summary>
+internal readonly record struct WxcProbeInvocation(WxcProbeStatus Status, int ExitCode, string StdOut, string StdErr);
 
 /// <summary>
 /// Classification of a <c>wxc-exec --probe</c> attempt.

--- a/src/OpenClaw.Shared/Mxc/MxcCommandRunner.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcCommandRunner.cs
@@ -51,11 +51,12 @@ public sealed class MxcCommandRunner : ICommandRunner
     {
         var settings = _settingsProvider();
 
-        // When MXC sandboxing isn't available on this host (e.g. Windows 10,
-        // build != 26300, UBR < 8289, or missing wxc-exec.exe), fall back to the host runner
-        // so the agent can still execute commands instead of being completely
-        // blocked. The Sandbox page is read-only in that state and tells the
-        // user their commands are running uncontained.
+        // When MXC sandboxing isn't available on this host (e.g. Windows 10, an
+        // older build whose wxc-exec --probe reports no usable isolation tier, or
+        // missing wxc-exec.exe), fall back to the host runner so the agent can
+        // still execute commands instead of being completely blocked. The Sandbox
+        // page is read-only in that state and tells the user their commands are
+        // running uncontained.
         if (!_isSandboxAvailable())
         {
             _logger.Warn(

--- a/src/OpenClaw.Shared/Mxc/MxcCommandRunner.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcCommandRunner.cs
@@ -51,6 +51,12 @@ public sealed class MxcCommandRunner : ICommandRunner
     {
         var settings = _settingsProvider();
 
+        if (!settings.SystemRunSandboxEnabled)
+        {
+            _logger.Info("[mxc] sandbox=disabled; routing system.run through host runner");
+            return await _hostFallback.RunAsync(request, ct);
+        }
+
         // When MXC sandboxing isn't available on this host (e.g. Windows 10, an
         // older build whose wxc-exec --probe reports no usable isolation tier, or
         // missing wxc-exec.exe), fall back to the host runner so the agent can
@@ -63,12 +69,6 @@ public sealed class MxcCommandRunner : ICommandRunner
                 "[mxc] system.run UNCONTAINED: sandbox unavailable on this host. " +
                 "Commands will run on the host without containment. " +
                 "Update Windows to enable sandboxing.");
-            return await _hostFallback.RunAsync(request, ct);
-        }
-
-        if (!settings.SystemRunSandboxEnabled)
-        {
-            _logger.Info("[mxc] sandbox=disabled; routing system.run through host runner");
             return await _hostFallback.RunAsync(request, ct);
         }
 

--- a/src/OpenClaw.Shared/Mxc/MxcConfig.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcConfig.cs
@@ -22,9 +22,9 @@ public sealed record MxcConfig
     [JsonPropertyName("process")]
     public required MxcProcess Process { get; init; }
 
-    [JsonPropertyName("appContainer")]
+    [JsonPropertyName("processContainer")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public MxcAppContainer? AppContainer { get; init; }
+    public MxcProcessContainer? ProcessContainer { get; init; }
 
     [JsonPropertyName("filesystem")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -61,7 +61,7 @@ public sealed record MxcProcess
     public int? TimeoutMs { get; init; }
 }
 
-public sealed record MxcAppContainer
+public sealed record MxcProcessContainer
 {
     [JsonPropertyName("capabilities")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/OpenClaw.Shared/Mxc/MxcConfigBuilder.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcConfigBuilder.cs
@@ -116,7 +116,7 @@ public static class MxcConfigBuilder
             Injection = false,
         };
 
-        var appContainerUi = new MxcBaseProcessUi
+        var processContainerUi = new MxcBaseProcessUi
         {
             Isolation = "container",
             DesktopSystemControl = false,
@@ -129,7 +129,7 @@ public static class MxcConfigBuilder
             Version = MxcPolicyBuilder.SupportedPolicyVersion,
             ContainerId = containerId ?? Guid.NewGuid().ToString("N"),
             // Top-level "containment" is intentionally omitted; the SDK doesn't
-            // emit it either. Isolation lives in appContainer.ui.isolation.
+            // emit it either. Isolation lives in processContainer.ui.isolation.
             Process = new MxcProcess
             {
                 CommandLine = commandLine,
@@ -137,11 +137,11 @@ public static class MxcConfigBuilder
                 Env = env,
                 TimeoutMs = timeoutMs,
             },
-            AppContainer = new MxcAppContainer
+            ProcessContainer = new MxcProcessContainer
             {
                 LeastPrivilege = false,
                 Capabilities = capabilities.ToArray(),
-                Ui = appContainerUi,
+                Ui = processContainerUi,
             },
             Filesystem = new MxcFilesystem
             {

--- a/src/OpenClaw.Shared/Mxc/MxcPolicyBuilder.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcPolicyBuilder.cs
@@ -25,9 +25,9 @@ namespace OpenClaw.Shared.Mxc;
 public static class MxcPolicyBuilder
 {
     /// <summary>
-    /// Policy schema version. @microsoft/mxc-sdk 0.1.8 accepts 0.4.0-alpha
-    /// through 0.5.0-alpha; keep the documented 0.4.0-alpha schema until we
-    /// intentionally adopt a newer MXC policy contract.
+    /// Policy schema version. @microsoft/mxc-sdk 0.7.0 still lists 0.4.0-alpha as a
+    /// supported (stable) config schema; keep the documented 0.4.0-alpha schema
+    /// until we intentionally adopt a newer MXC policy contract.
     /// </summary>
     public const string SupportedPolicyVersion = "0.4.0-alpha";
 

--- a/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
@@ -44,20 +44,27 @@ public sealed partial class SandboxPage : Page
         _availabilityProbeInFlight = true;
         try
         {
-            var availability = await System.Threading.Tasks.Task.Run(
+            _cachedAvailability = await System.Threading.Tasks.Task.Run(
                 static () => OpenClaw.Shared.Mxc.MxcAvailability.Probe());
-
-            _cachedAvailability = availability;
+        }
+        catch (Exception)
+        {
+            // Probe() is designed not to throw, but never leave the page stuck in
+            // "Checking…": synthesize an errored result so the UI shows Retry.
+            _cachedAvailability = new OpenClaw.Shared.Mxc.MxcAvailability(
+                false, false, false, null,
+                new[] { "Couldn't check sandbox availability." }, probeErrored: true);
         }
         finally
         {
             _availabilityProbeInFlight = false;
-        }
 
-        // await resumed us on the UI thread (DispatcherQueue sync context), so it
-        // is safe to touch controls here. Re-render the bits that depend on the probe.
-        UpdateSandboxStatusCard();
-        UpdateControlsEnabledState();
+            // await resumed us on the UI thread (DispatcherQueue sync context), so it
+            // is safe to touch controls here. Always re-render — on both the happy
+            // path and the failure path — so the page never stays in "Checking…".
+            UpdateSandboxStatusCard();
+            UpdateControlsEnabledState();
+        }
     }
 
     // ── Quick-preset definitions ─────────────────────────────────────

--- a/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
@@ -15,18 +15,36 @@ public sealed partial class SandboxPage : Page
     private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private bool _suppress;
     private bool _dialogOpen;
-    private OpenClaw.Shared.Mxc.MxcAvailability? _cachedAvailability;
 
     public ObservableCollection<CustomFolderRow> CustomFolders { get; } = new();
 
     /// <summary>
-    /// Cached MxcAvailability for the lifetime of this page instance. Probe() does
-    /// registry reads and filesystem walks; we don't need to repeat that work on every
-    /// toggle/preset change. The result is stable as long as the OS doesn't change
-    /// under us, which is fine for a settings page.
+    /// Cached MxcAvailability for the lifetime of this page instance, or null until
+    /// the first background probe completes. Probe() spawns <c>wxc-exec --probe</c>
+    /// (up to ~15s on a misbehaving host) plus filesystem walks, so we never run it
+    /// on the UI thread; <see cref="RefreshAvailabilityAsync"/> populates this
+    /// off-thread and re-renders. Availability-driven UI treats null as "checking".
     /// </summary>
-    private OpenClaw.Shared.Mxc.MxcAvailability GetAvailability()
-        => _cachedAvailability ??= OpenClaw.Shared.Mxc.MxcAvailability.Probe();
+    private OpenClaw.Shared.Mxc.MxcAvailability? _cachedAvailability;
+
+    /// <summary>
+    /// Probe MXC availability off the UI thread (once), cache it, then refresh the
+    /// availability-driven UI. No-op once a result is cached.
+    /// </summary>
+    private async System.Threading.Tasks.Task RefreshAvailabilityAsync()
+    {
+        if (_cachedAvailability is not null) return;
+
+        var availability = await System.Threading.Tasks.Task.Run(
+            static () => OpenClaw.Shared.Mxc.MxcAvailability.Probe());
+
+        _cachedAvailability = availability;
+
+        // await resumed us on the UI thread (DispatcherQueue sync context), so it
+        // is safe to touch controls here. Re-render the bits that depend on the probe.
+        UpdateSandboxStatusCard();
+        UpdateControlsEnabledState();
+    }
 
     // ── Quick-preset definitions ─────────────────────────────────────
     //
@@ -90,6 +108,15 @@ public sealed partial class SandboxPage : Page
         LoadState();
         ProbeStatus();
         UpdateControlsEnabledState();
+
+        // Kick off the (potentially slow) MXC probe off the UI thread. The page
+        // renders a neutral "checking" state until it completes, then re-renders
+        // with the real availability — so the settings UI never blocks on
+        // wxc-exec --probe.
+        AsyncEventHandlerGuard.Run(
+            RefreshAvailabilityAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(RefreshAvailabilityAsync));
     }
 
     // ── Load + probe ─────────────────────────────────────────────────
@@ -150,12 +177,22 @@ public sealed partial class SandboxPage : Page
     /// </summary>
     private void UpdateSandboxStatusCard()
     {
-        var availability = GetAvailability();
+        var availability = _cachedAvailability;
         var enabled = SandboxEnabledToggle.IsOn;
-        var available = availability.HasAnyBackend;
 
         UpdateUnavailableActionBar(availability);
 
+        if (availability is null)
+        {
+            // Probe still running on the background thread — neutral interim state.
+            SandboxStatusIcon.Text = "⏳";
+            SandboxStatusTitle.Text = "Checking sandbox availability…";
+            SandboxStatusSubtext.Text = "Verifying that this PC can contain commands the agent runs.";
+            SandboxEnabledToggle.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        var available = availability.HasAnyBackend;
         if (!available)
         {
             SandboxStatusIcon.Text = "⚠";
@@ -188,9 +225,10 @@ public sealed partial class SandboxPage : Page
     ///   - wxc-exec.exe missing → "Show install instructions"
     ///   - Anything else → no primary action, just the learn-more hyperlink
     /// </summary>
-    private void UpdateUnavailableActionBar(OpenClaw.Shared.Mxc.MxcAvailability availability)
+    private void UpdateUnavailableActionBar(OpenClaw.Shared.Mxc.MxcAvailability? availability)
     {
-        if (availability.HasAnyBackend)
+        // Null = still probing; hide the bar until we have a verdict.
+        if (availability is null || availability.HasAnyBackend)
         {
             UnavailableActionBar.IsOpen = false;
             return;
@@ -201,9 +239,9 @@ public sealed partial class SandboxPage : Page
             ? string.Join("  ·  ", reasons)
             : "MXC sandboxing primitives are not available on this machine.";
 
-        var isWindowsIssue = reasons.Any(r =>
-            r.Contains("Windows build", StringComparison.OrdinalIgnoreCase) ||
-            r.Contains("Windows UBR", StringComparison.OrdinalIgnoreCase));
+        // wxc-exec is present but the host probe reported no usable tier → the
+        // Windows host itself doesn't support the sandbox (vs. a missing binary).
+        var isWindowsIssue = availability.IsWxcExecResolvable && !availability.IsAppContainerAvailable;
 
         var isSetupIssue = !availability.IsWxcExecResolvable;
 
@@ -273,8 +311,9 @@ public sealed partial class SandboxPage : Page
     /// </summary>
     private void UpdateControlsEnabledState()
     {
-        var availability = GetAvailability();
-        var available = availability.HasAnyBackend;
+        // Null availability = still probing; treat as not-yet-active so the
+        // controls stay dimmed until the background probe resolves.
+        var available = _cachedAvailability?.HasAnyBackend ?? false;
         var sandboxOn = SandboxEnabledToggle.IsOn;
         var active = available && sandboxOn;
 

--- a/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
@@ -256,7 +256,7 @@ public sealed partial class SandboxPage : Page
     /// Shows or hides the prominent "Sandbox unavailable" InfoBar based on availability,
     /// and categorizes the failure mode so we can suggest a relevant action:
     ///   - probe errored (transient) → "Retry"
-    ///   - Windows build/UBR too old → "Open Windows Update"
+    ///   - host doesn't support sandboxing → "Open Windows Update"
     ///   - wxc-exec.exe missing → "Show install instructions"
     ///   - Anything else → no primary action, just the learn-more hyperlink
     /// </summary>

--- a/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
@@ -33,7 +33,10 @@ public sealed partial class SandboxPage : Page
     /// </summary>
     private async System.Threading.Tasks.Task RefreshAvailabilityAsync()
     {
-        if (_cachedAvailability is not null) return;
+        // Re-probe when we have no result yet, or the last one was a transient
+        // probe error. A definitive verdict (supported / host-unsupported) is kept
+        // for the page-instance lifetime.
+        if (_cachedAvailability is { ProbeErrored: false }) return;
 
         var availability = await System.Threading.Tasks.Task.Run(
             static () => OpenClaw.Shared.Mxc.MxcAvailability.Probe());
@@ -207,8 +210,21 @@ public sealed partial class SandboxPage : Page
         if (enabled)
         {
             SandboxStatusIcon.Text = "🛡";
-            SandboxStatusTitle.Text = "Node Sandbox is on";
-            SandboxStatusSubtext.Text = "Programs the agent runs on this PC are contained.";
+            if (availability.IsDegradedContainment)
+            {
+                // Contained, but only via a weaker, last-resort isolation tier
+                // (e.g. DACL augmentation). Surface as a caution rather than a block.
+                SandboxStatusTitle.Text = "Node Sandbox is on — limited containment";
+                SandboxStatusSubtext.Text =
+                    "Programs the agent runs are contained, but this PC only supports a fallback isolation tier" +
+                    $"{(string.IsNullOrEmpty(availability.IsolationTier) ? "" : $" ({availability.IsolationTier})")}. " +
+                    "Containment is weaker than on a fully supported build; install the latest Windows updates to strengthen it.";
+            }
+            else
+            {
+                SandboxStatusTitle.Text = "Node Sandbox is on";
+                SandboxStatusSubtext.Text = "Programs the agent runs on this PC are contained.";
+            }
         }
         else
         {

--- a/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
@@ -26,10 +26,12 @@ public sealed partial class SandboxPage : Page
     /// off-thread and re-renders. Availability-driven UI treats null as "checking".
     /// </summary>
     private OpenClaw.Shared.Mxc.MxcAvailability? _cachedAvailability;
+    private bool _availabilityProbeInFlight;
 
     /// <summary>
     /// Probe MXC availability off the UI thread (once), cache it, then refresh the
-    /// availability-driven UI. No-op once a result is cached.
+    /// availability-driven UI. No-op once a definitive result is cached or while a
+    /// probe is already running.
     /// </summary>
     private async System.Threading.Tasks.Task RefreshAvailabilityAsync()
     {
@@ -37,11 +39,20 @@ public sealed partial class SandboxPage : Page
         // probe error. A definitive verdict (supported / host-unsupported) is kept
         // for the page-instance lifetime.
         if (_cachedAvailability is { ProbeErrored: false }) return;
+        if (_availabilityProbeInFlight) return;
 
-        var availability = await System.Threading.Tasks.Task.Run(
-            static () => OpenClaw.Shared.Mxc.MxcAvailability.Probe());
+        _availabilityProbeInFlight = true;
+        try
+        {
+            var availability = await System.Threading.Tasks.Task.Run(
+                static () => OpenClaw.Shared.Mxc.MxcAvailability.Probe());
 
-        _cachedAvailability = availability;
+            _cachedAvailability = availability;
+        }
+        finally
+        {
+            _availabilityProbeInFlight = false;
+        }
 
         // await resumed us on the UI thread (DispatcherQueue sync context), so it
         // is safe to touch controls here. Re-render the bits that depend on the probe.
@@ -237,6 +248,7 @@ public sealed partial class SandboxPage : Page
     /// <summary>
     /// Shows or hides the prominent "Sandbox unavailable" InfoBar based on availability,
     /// and categorizes the failure mode so we can suggest a relevant action:
+    ///   - probe errored (transient) → "Retry"
     ///   - Windows build/UBR too old → "Open Windows Update"
     ///   - wxc-exec.exe missing → "Show install instructions"
     ///   - Anything else → no primary action, just the learn-more hyperlink
@@ -255,13 +267,30 @@ public sealed partial class SandboxPage : Page
             ? string.Join("  ·  ", reasons)
             : "MXC sandboxing primitives are not available on this machine.";
 
-        // wxc-exec is present but the host probe reported no usable tier → the
-        // Windows host itself doesn't support the sandbox (vs. a missing binary).
-        var isWindowsIssue = availability.IsWxcExecResolvable && !availability.IsAppContainerAvailable;
+        // A transient probe error (timeout / couldn't launch / garbled output) is NOT
+        // the same as the host being unsupported — don't push the user at Windows
+        // Update. Offer a retry; the next probe may succeed.
+        var isProbeError = availability.ProbeErrored;
+
+        // wxc-exec is present and the probe gave a definitive negative → the Windows
+        // host itself doesn't support the sandbox (vs. a missing binary).
+        var isWindowsIssue = !isProbeError
+            && availability.IsWxcExecResolvable
+            && !availability.IsAppContainerAvailable;
 
         var isSetupIssue = !availability.IsWxcExecResolvable;
 
-        if (isWindowsIssue)
+        if (isProbeError)
+        {
+            UnavailableActionBar.Title = "Couldn't verify sandbox availability";
+            UnavailableActionMessage.Text =
+                $"{reasonText}\n\nThe sandbox capability check didn't complete, so commands run uncontained for now. " +
+                "This is usually transient (a slow or blocked check) — retry, and if it persists check whether security software is blocking wxc-exec.";
+            UnavailablePrimaryButton.Content = "Retry";
+            UnavailablePrimaryButton.Tag = "retry";
+            UnavailablePrimaryButton.Visibility = Visibility.Visible;
+        }
+        else if (isWindowsIssue)
         {
             UnavailableActionBar.Title = "Your Windows version doesn't support sandboxing yet";
             UnavailableActionMessage.Text =
@@ -302,6 +331,17 @@ public sealed partial class SandboxPage : Page
     {
         if (sender is not Button btn) return;
         var tag = btn.Tag as string;
+
+        // Transient probe error → clear the cached verdict and re-probe off-thread.
+        if (tag == "retry")
+        {
+            _cachedAvailability = null;
+            UpdateSandboxStatusCard();
+            UpdateControlsEnabledState();
+            await RefreshAvailabilityAsync();
+            return;
+        }
+
         try
         {
             var uri = tag switch

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -509,11 +509,23 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
     /// </summary>
     private ICommandRunner BuildSystemRunRunner()
     {
-        var availability = GetOrProbeMxcAvailability();
         var hostRunner = new LocalCommandRunner(_logger);
         var executor = new DirectAppContainerExecutor(GetOrProbeMxcAvailability, _logger);
 
-        if (availability.HasAnyBackend)
+        // Do NOT probe synchronously here: this runs while _capabilitiesLock is held
+        // (RegisterCapabilities), and a blocking wxc-exec --probe (~15s) would stall
+        // capability registration / reconnect. Log from a non-blocking peek; the
+        // first real probe happens lazily on the first system.run via the
+        // availability gate / executor provider below (off any of our locks).
+        var peeked = PeekMxcAvailability();
+        if (peeked is null)
+        {
+            _logger.Info(
+                $"[mxc] system.run runner = MxcCommandRunner " +
+                $"(executor={executor.Name}; MXC availability probe deferred to first use; " +
+                $"sandboxEnabled={(_settings?.SystemRunSandboxEnabled ?? true)})");
+        }
+        else if (peeked.HasAnyBackend)
         {
             _logger.Info(
                 $"[mxc] system.run runner = MxcCommandRunner " +
@@ -525,7 +537,7 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
             // !_isSandboxAvailable() guard will route to the host fallback
             // for every call; the executor is constructed only to satisfy
             // the constructor contract and is never invoked.
-            var reason = string.Join("; ", availability.UnsupportedReasons);
+            var reason = string.Join("; ", peeked.UnsupportedReasons);
             _logger.Info($"[mxc] system.run runner = MxcCommandRunner (MXC unavailable, commands will run uncontained: {reason})");
         }
 
@@ -536,8 +548,8 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
             () => SnapshotSettings(),
             () => settingsDirectory,
             // Re-probe on demand when sandbox availability is checked: returns the
-            // cached definitive verdict, or re-probes after a transient error /
-            // a prior SandboxUnavailableException-driven invalidation.
+            // cached definitive verdict, or re-probes (single-flight) after a
+            // transient error / a prior SandboxUnavailableException-driven invalidation.
             () => GetOrProbeMxcAvailability().HasAnyBackend,
             invalidateAvailability: InvalidateMxcAvailability,
             _logger);
@@ -578,47 +590,102 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
     }
 
     private MxcAvailability? _mxcAvailability;
-    private DateTime _mxcAvailabilityProbedAtUtc;
+    private DateTime _mxcNextProbeAllowedAtUtc;
+    private Task<MxcAvailability>? _mxcProbeInFlight;
     private readonly object _mxcAvailabilityLock = new();
 
     /// <summary>
     /// Minimum interval before re-probing after a transient probe error. Bounds the
-    /// cost of re-spawning <c>wxc-exec --probe</c> on every command while a probe
-    /// error persists, while still letting a momentary glitch self-heal quickly.
+    /// cost of re-spawning <c>wxc-exec --probe</c> while a probe error persists,
+    /// while still letting a momentary glitch self-heal quickly.
     /// </summary>
     private static readonly TimeSpan MxcProbeRetryInterval = TimeSpan.FromSeconds(5);
 
     /// <summary>
-    /// Return the cached MXC availability, re-probing when needed. Definitive
-    /// verdicts (supported / host-unsupported) are cached for the process lifetime;
-    /// a transient probe error (<see cref="MxcAvailability.ProbeErrored"/>) is NOT
-    /// cached permanently — we re-probe (throttled by <see cref="MxcProbeRetryInterval"/>)
-    /// so a momentary glitch doesn't pin the whole process to uncontained execution.
-    /// Serialized by <see cref="_mxcAvailabilityLock"/> so concurrent <c>system.run</c>
-    /// calls can't spawn a storm of probe processes; the retry timestamp is set
-    /// before probing so a slow (timeout) probe doesn't let waiters pile on more.
+    /// Return the current MXC availability, probing if needed. Definitive verdicts
+    /// (supported / host-unsupported) are cached for the process lifetime; a transient
+    /// probe error (<see cref="MxcAvailability.ProbeErrored"/>) is NOT cached
+    /// permanently — once the retry window opens we re-probe so a momentary glitch
+    /// doesn't pin the whole process to uncontained execution.
     /// </summary>
+    /// <remarks>
+    /// The blocking probe (<c>wxc-exec --probe</c>, up to ~15s) is NEVER run while
+    /// holding <see cref="_mxcAvailabilityLock"/>: concurrent callers share a single
+    /// in-flight probe (single-flight) and wait on it OUTSIDE the lock, so a slow
+    /// probe can't serialize unrelated callers or stall lock users. The retry window
+    /// opens only AFTER a probe completes, so a 15s timeout can't immediately permit a
+    /// back-to-back re-probe.
+    /// </remarks>
     private MxcAvailability GetOrProbeMxcAvailability()
     {
+        Task<MxcAvailability> probe;
         lock (_mxcAvailabilityLock)
         {
-            if (_mxcAvailability is { ProbeErrored: false } cached)
-                return cached;
+            // Definitive verdict — cached for the process lifetime.
+            if (_mxcAvailability is { ProbeErrored: false } definitive)
+                return definitive;
 
-            if (_mxcAvailability is { ProbeErrored: true }
-                && DateTime.UtcNow - _mxcAvailabilityProbedAtUtc < MxcProbeRetryInterval)
-                return _mxcAvailability;
+            // Transient error — keep serving it (routes to uncontained) until the
+            // retry window opens, so we don't re-probe on every command.
+            if (_mxcAvailability is { ProbeErrored: true } errored
+                && _mxcProbeInFlight is null
+                && DateTime.UtcNow < _mxcNextProbeAllowedAtUtc)
+                return errored;
 
-            _mxcAvailabilityProbedAtUtc = DateTime.UtcNow;
-            _mxcAvailability = MxcAvailability.Probe(_logger);
-            return _mxcAvailability;
+            // Start a probe if none is running, otherwise join the in-flight one.
+            probe = _mxcProbeInFlight ??= Task.Run(ProbeAndStoreMxcAvailability);
         }
+
+        // Wait OUTSIDE the lock so other callers / lock users aren't blocked.
+        return probe.GetAwaiter().GetResult();
+    }
+
+    private MxcAvailability ProbeAndStoreMxcAvailability()
+    {
+        MxcAvailability result;
+        try
+        {
+            result = MxcAvailability.Probe(_logger);
+        }
+        catch (Exception ex)
+        {
+            // Probe() is designed not to throw, but never let an unexpected fault
+            // poison the single-flight slot or leak out of the shared task.
+            _logger.Warn($"[mxc] availability probe threw unexpectedly: {ex.GetType().Name}: {ex.Message}");
+            result = new MxcAvailability(
+                false, false, false, null,
+                new[] { "MXC availability probe failed unexpectedly." }, probeErrored: true);
+        }
+
+        lock (_mxcAvailabilityLock)
+        {
+            _mxcAvailability = result;
+            // Open the retry window only AFTER completion so a slow (timeout) probe
+            // doesn't immediately allow a back-to-back re-probe.
+            _mxcNextProbeAllowedAtUtc = DateTime.UtcNow + MxcProbeRetryInterval;
+            _mxcProbeInFlight = null;
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Non-blocking read of the cached MXC availability for diagnostics/logging.
+    /// Returns null when nothing has been probed yet. Never spawns or waits on a
+    /// probe, so it is safe to call while holding other locks (e.g. _capabilitiesLock).
+    /// </summary>
+    private MxcAvailability? PeekMxcAvailability()
+    {
+        lock (_mxcAvailabilityLock)
+            return _mxcAvailability;
     }
 
     private void InvalidateMxcAvailability()
     {
         lock (_mxcAvailabilityLock)
+        {
             _mxcAvailability = null;
+            _mxcNextProbeAllowedAtUtc = default;
+        }
     }
 
     private void StartMcpServer()

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -509,7 +509,7 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
     /// </summary>
     private ICommandRunner BuildSystemRunRunner()
     {
-        var availability = _mxcAvailability ??= MxcAvailability.Probe(_logger);
+        var availability = GetOrProbeMxcAvailability();
         var hostRunner = new LocalCommandRunner(_logger);
         var executor = new DirectAppContainerExecutor(availability, _logger);
 
@@ -535,9 +535,10 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
             hostRunner,
             () => SnapshotSettings(),
             () => settingsDirectory,
-            // Re-probe on demand if the cache was invalidated by a prior
-            // SandboxUnavailableException (see invalidateAvailability below).
-            () => (_mxcAvailability ??= MxcAvailability.Probe(_logger)).HasAnyBackend,
+            // Re-probe on demand when sandbox availability is checked: returns the
+            // cached definitive verdict, or re-probes after a transient error /
+            // a prior SandboxUnavailableException-driven invalidation.
+            () => GetOrProbeMxcAvailability().HasAnyBackend,
             invalidateAvailability: () => _mxcAvailability = null,
             _logger);
     }
@@ -577,6 +578,35 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
     }
 
     private MxcAvailability? _mxcAvailability;
+    private DateTime _mxcAvailabilityProbedAtUtc;
+
+    /// <summary>
+    /// Minimum interval before re-probing after a transient probe error. Bounds the
+    /// cost of re-spawning <c>wxc-exec --probe</c> on every command while a probe
+    /// error persists, while still letting a momentary glitch self-heal quickly.
+    /// </summary>
+    private static readonly TimeSpan MxcProbeRetryInterval = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Return the cached MXC availability, re-probing when needed. Definitive
+    /// verdicts (supported / host-unsupported) are cached for the process lifetime;
+    /// a transient probe error (<see cref="MxcAvailability.ProbeErrored"/>) is NOT
+    /// cached permanently — we re-probe (throttled by <see cref="MxcProbeRetryInterval"/>)
+    /// so a momentary glitch doesn't pin the whole process to uncontained execution.
+    /// </summary>
+    private MxcAvailability GetOrProbeMxcAvailability()
+    {
+        if (_mxcAvailability is { ProbeErrored: false } cached)
+            return cached;
+
+        if (_mxcAvailability is { ProbeErrored: true }
+            && DateTime.UtcNow - _mxcAvailabilityProbedAtUtc < MxcProbeRetryInterval)
+            return _mxcAvailability;
+
+        _mxcAvailability = MxcAvailability.Probe(_logger);
+        _mxcAvailabilityProbedAtUtc = DateTime.UtcNow;
+        return _mxcAvailability;
+    }
 
     private void StartMcpServer()
     {

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -511,7 +511,7 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
     {
         var availability = GetOrProbeMxcAvailability();
         var hostRunner = new LocalCommandRunner(_logger);
-        var executor = new DirectAppContainerExecutor(availability, _logger);
+        var executor = new DirectAppContainerExecutor(GetOrProbeMxcAvailability, _logger);
 
         if (availability.HasAnyBackend)
         {
@@ -539,7 +539,7 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
             // cached definitive verdict, or re-probes after a transient error /
             // a prior SandboxUnavailableException-driven invalidation.
             () => GetOrProbeMxcAvailability().HasAnyBackend,
-            invalidateAvailability: () => _mxcAvailability = null,
+            invalidateAvailability: InvalidateMxcAvailability,
             _logger);
     }
 
@@ -579,6 +579,7 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
 
     private MxcAvailability? _mxcAvailability;
     private DateTime _mxcAvailabilityProbedAtUtc;
+    private readonly object _mxcAvailabilityLock = new();
 
     /// <summary>
     /// Minimum interval before re-probing after a transient probe error. Bounds the
@@ -593,19 +594,31 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
     /// a transient probe error (<see cref="MxcAvailability.ProbeErrored"/>) is NOT
     /// cached permanently — we re-probe (throttled by <see cref="MxcProbeRetryInterval"/>)
     /// so a momentary glitch doesn't pin the whole process to uncontained execution.
+    /// Serialized by <see cref="_mxcAvailabilityLock"/> so concurrent <c>system.run</c>
+    /// calls can't spawn a storm of probe processes; the retry timestamp is set
+    /// before probing so a slow (timeout) probe doesn't let waiters pile on more.
     /// </summary>
     private MxcAvailability GetOrProbeMxcAvailability()
     {
-        if (_mxcAvailability is { ProbeErrored: false } cached)
-            return cached;
+        lock (_mxcAvailabilityLock)
+        {
+            if (_mxcAvailability is { ProbeErrored: false } cached)
+                return cached;
 
-        if (_mxcAvailability is { ProbeErrored: true }
-            && DateTime.UtcNow - _mxcAvailabilityProbedAtUtc < MxcProbeRetryInterval)
+            if (_mxcAvailability is { ProbeErrored: true }
+                && DateTime.UtcNow - _mxcAvailabilityProbedAtUtc < MxcProbeRetryInterval)
+                return _mxcAvailability;
+
+            _mxcAvailabilityProbedAtUtc = DateTime.UtcNow;
+            _mxcAvailability = MxcAvailability.Probe(_logger);
             return _mxcAvailability;
+        }
+    }
 
-        _mxcAvailability = MxcAvailability.Probe(_logger);
-        _mxcAvailabilityProbedAtUtc = DateTime.UtcNow;
-        return _mxcAvailability;
+    private void InvalidateMxcAvailability()
+    {
+        lock (_mxcAvailabilityLock)
+            _mxcAvailability = null;
     }
 
     private void StartMcpServer()

--- a/tests/OpenClaw.Shared.Tests/Mxc/DirectAppContainerExecutorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/DirectAppContainerExecutorTests.cs
@@ -36,7 +36,7 @@ public class DirectAppContainerExecutorTests
             isWxcExecResolvable: false,
             wxcExecPath: null,
             unsupportedReasons: new[] { "test reason" });
-        var executor = new DirectAppContainerExecutor(availability, NullLogger.Instance);
+        var executor = new DirectAppContainerExecutor(() => availability, NullLogger.Instance);
 
         var ex = await Assert.ThrowsAsync<SandboxUnavailableException>(() => executor.ExecuteAsync(NewRequest()));
         Assert.Contains("test reason", ex.Message);
@@ -51,7 +51,7 @@ public class DirectAppContainerExecutorTests
             isWxcExecResolvable: false,
             wxcExecPath: null,
             unsupportedReasons: Array.Empty<string>());
-        var executor = new DirectAppContainerExecutor(availability, NullLogger.Instance);
+        var executor = new DirectAppContainerExecutor(() => availability, NullLogger.Instance);
 
         var ex = await Assert.ThrowsAsync<SandboxUnavailableException>(() => executor.ExecuteAsync(NewRequest()));
         Assert.Contains("wxc-exec.exe not found", ex.Message);
@@ -66,17 +66,54 @@ public class DirectAppContainerExecutorTests
             isWxcExecResolvable: true,
             wxcExecPath: "C:\\does\\not\\exist\\wxc-exec.exe",
             unsupportedReasons: Array.Empty<string>());
-        var executor = new DirectAppContainerExecutor(availability, NullLogger.Instance);
+        var executor = new DirectAppContainerExecutor(() => availability, NullLogger.Instance);
 
         // MxcExecutor's ctor throws FileNotFoundException → wrapped in SandboxUnavailableException.
         await Assert.ThrowsAsync<SandboxUnavailableException>(() => executor.ExecuteAsync(NewRequest()));
     }
 
     [Fact]
+    public async Task ExecuteAsync_ResolvesAvailabilityPerCall_PicksUpRecovery()
+    {
+        // Simulates a transient startup probe error that later recovers. The executor
+        // must read the provider on each call, not freeze the first snapshot — else a
+        // momentary startup glitch would pin it to "unavailable" for its lifetime.
+        var calls = 0;
+        var unavailable = new MxcAvailability(
+            isAppContainerAvailable: false,
+            isIsolationSessionAvailable: false,
+            isWxcExecResolvable: true,
+            wxcExecPath: null,
+            unsupportedReasons: new[] { "transient probe error" },
+            probeErrored: true);
+        var recoveredButPathMissing = new MxcAvailability(
+            isAppContainerAvailable: true,
+            isIsolationSessionAvailable: false,
+            isWxcExecResolvable: true,
+            wxcExecPath: "C:\\does\\not\\exist\\wxc-exec.exe",
+            unsupportedReasons: Array.Empty<string>());
+
+        var executor = new DirectAppContainerExecutor(
+            () => { calls++; return calls == 1 ? unavailable : recoveredButPathMissing; },
+            NullLogger.Instance);
+
+        // First call: unavailable → throws with the transient reason.
+        var ex1 = await Assert.ThrowsAsync<SandboxUnavailableException>(() => executor.ExecuteAsync(NewRequest()));
+        Assert.Contains("transient probe error", ex1.Message);
+
+        // Second call: provider now reports available (path just doesn't exist on
+        // disk). The DIFFERENT failure proves the executor re-resolved availability
+        // instead of reusing the first (unavailable) snapshot.
+        var ex2 = await Assert.ThrowsAsync<SandboxUnavailableException>(() => executor.ExecuteAsync(NewRequest()));
+        Assert.Contains("wxc-exec.exe not found at", ex2.Message);
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
     public void Name_IsStableForTelemetry()
     {
         var availability = new MxcAvailability(false, false, false, null, Array.Empty<string>());
-        var executor = new DirectAppContainerExecutor(availability, NullLogger.Instance);
+        var executor = new DirectAppContainerExecutor(() => availability, NullLogger.Instance);
         Assert.Equal("mxc-direct-appc", executor.Name);
         Assert.True(executor.IsContained);
     }

--- a/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-balanced.json
+++ b/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-balanced.json
@@ -34,7 +34,7 @@
     "defaultPolicy": "allow",
     "enforcementMode": "capabilities"
   },
-  "appContainer": {
+  "processContainer": {
     "leastPrivilege": false,
     "capabilities": [
       "internetClient"

--- a/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-custom.json
+++ b/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-custom.json
@@ -33,7 +33,7 @@
     "defaultPolicy": "allow",
     "enforcementMode": "capabilities"
   },
-  "appContainer": {
+  "processContainer": {
     "leastPrivilege": false,
     "capabilities": [
       "internetClient"

--- a/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-locked-down.json
+++ b/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-locked-down.json
@@ -30,7 +30,7 @@
     "defaultPolicy": "block",
     "enforcementMode": "capabilities"
   },
-  "appContainer": {
+  "processContainer": {
     "leastPrivilege": false,
     "capabilities": [],
     "ui": {

--- a/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-permissive.json
+++ b/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-permissive.json
@@ -33,7 +33,7 @@
     "defaultPolicy": "allow",
     "enforcementMode": "capabilities"
   },
-  "appContainer": {
+  "processContainer": {
     "leastPrivilege": false,
     "capabilities": [
       "internetClient"

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcAvailabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcAvailabilityTests.cs
@@ -68,6 +68,7 @@ public class MxcAvailabilityTests
     public void ParseProbeOutput_ValidTier_ReportsSupported()
     {
         var result = MxcAvailability.ParseProbeOutput(
+            WxcProbeStatus.Completed,
             exitCode: 0,
             stdout: "{\"tier\":\"base-container\",\"needsDaclAugmentation\":false,\"warnings\":[]}",
             stderr: "");
@@ -84,6 +85,7 @@ public class MxcAvailabilityTests
     public void ParseProbeOutput_CapturesWarningsAndDaclFlag()
     {
         var result = MxcAvailability.ParseProbeOutput(
+            WxcProbeStatus.Completed,
             exitCode: 0,
             stdout: "{\"tier\":\"appcontainer-dacl\",\"needsDaclAugmentation\":true,\"warnings\":[\"fell back to dacl\"]}",
             stderr: "");
@@ -96,14 +98,15 @@ public class MxcAvailabilityTests
     }
 
     [Fact]
-    public void ParseProbeOutput_PositiveNonZeroExit_ReportsUnsupportedHost()
+    public void ParseProbeOutput_CompletedNonZeroExit_ReportsUnsupportedHost()
     {
         var result = MxcAvailability.ParseProbeOutput(
+            WxcProbeStatus.Completed,
             exitCode: 1,
             stdout: "",
             stderr: "unsupported os");
 
-        // The binary ran and returned a definitive negative — not a probe error.
+        // The binary ran to completion and returned a definitive negative — not a probe error.
         Assert.Equal(MxcProbeOutcome.UnsupportedHost, result.Outcome);
         Assert.False(result.Supported);
         Assert.Null(result.Tier);
@@ -111,19 +114,44 @@ public class MxcAvailabilityTests
         Assert.Contains("does not support", result.FailureReason!);
     }
 
-    [Theory]
-    [InlineData(-1, "wxc-exec --probe timed out.")]
-    [InlineData(-1, "Failed to launch wxc-exec --probe: access denied")]
-    public void ParseProbeOutput_NegativeExitSentinel_ReportsProbeError(int exitCode, string stderr)
+    [Fact]
+    public void ParseProbeOutput_TimedOutStatus_ReportsProbeError()
     {
-        // Negative exit is our own timeout/launch sentinel — we never got a verdict,
-        // so it's a transient probe error, NOT a definitive "unsupported host".
-        var result = MxcAvailability.ParseProbeOutput(exitCode, stdout: "", stderr: stderr);
+        // Timeout is our own infrastructure failure — transient, regardless of exit code.
+        var result = MxcAvailability.ParseProbeOutput(
+            WxcProbeStatus.TimedOut, exitCode: 0, stdout: "", stderr: "wxc-exec --probe timed out.");
 
         Assert.Equal(MxcProbeOutcome.ProbeError, result.Outcome);
         Assert.False(result.Supported);
         Assert.NotNull(result.FailureReason);
         Assert.Contains("Could not determine", result.FailureReason!);
+    }
+
+    [Fact]
+    public void ParseProbeOutput_LaunchFailedStatus_ReportsProbeError()
+    {
+        var result = MxcAvailability.ParseProbeOutput(
+            WxcProbeStatus.LaunchFailed, exitCode: 0, stdout: "", stderr: "Failed to launch wxc-exec --probe: access denied");
+
+        Assert.Equal(MxcProbeOutcome.ProbeError, result.Outcome);
+        Assert.False(result.Supported);
+        Assert.NotNull(result.FailureReason);
+        Assert.Contains("Could not determine", result.FailureReason!);
+    }
+
+    [Fact]
+    public void ParseProbeOutput_NonCompletedStatus_IgnoresExitCode()
+    {
+        // Even a "successful-looking" exit code must not flip a timeout/launch failure
+        // into a definitive verdict — the status wins.
+        var result = MxcAvailability.ParseProbeOutput(
+            WxcProbeStatus.TimedOut,
+            exitCode: 0,
+            stdout: "{\"tier\":\"base-container\"}",
+            stderr: "");
+
+        Assert.Equal(MxcProbeOutcome.ProbeError, result.Outcome);
+        Assert.Null(result.Tier);
     }
 
     [Theory]
@@ -132,11 +160,11 @@ public class MxcAvailabilityTests
     [InlineData("{\"needsDaclAugmentation\":false}")]
     [InlineData("{\"tier\":\"\"}")]
     [InlineData("not json at all")]
-    public void ParseProbeOutput_ExitZeroButNoUsableOutput_ReportsProbeError(string stdout)
+    public void ParseProbeOutput_CompletedExitZeroButNoUsableOutput_ReportsProbeError(string stdout)
     {
         // Exit 0 with missing/garbled output is a binary anomaly, not a clear
         // "unsupported" verdict — treat as retryable probe error.
-        var result = MxcAvailability.ParseProbeOutput(exitCode: 0, stdout: stdout, stderr: "");
+        var result = MxcAvailability.ParseProbeOutput(WxcProbeStatus.Completed, exitCode: 0, stdout: stdout, stderr: "");
 
         Assert.Equal(MxcProbeOutcome.ProbeError, result.Outcome);
         Assert.False(result.Supported);
@@ -194,7 +222,7 @@ public class MxcAvailabilityTests
 
             var availability = MxcAvailability.Probe(
                 NullLogger.Instance,
-                _ => new WxcProbeInvocation(0, "{\"tier\":\"base-container\",\"warnings\":[]}", string.Empty));
+                _ => new WxcProbeInvocation(WxcProbeStatus.Completed, 0, "{\"tier\":\"base-container\",\"warnings\":[]}", string.Empty));
 
             Assert.True(availability.IsAppContainerAvailable);
             Assert.True(availability.IsWxcExecResolvable);
@@ -224,7 +252,7 @@ public class MxcAvailabilityTests
 
             var availability = MxcAvailability.Probe(
                 NullLogger.Instance,
-                _ => new WxcProbeInvocation(1, string.Empty, "unsupported os build"));
+                _ => new WxcProbeInvocation(WxcProbeStatus.Completed, 1, string.Empty, "unsupported os build"));
 
             // wxc-exec is present, but the host probe said no → not a setup issue,
             // and a definitive verdict (exit 1) is NOT a transient probe error.
@@ -252,10 +280,10 @@ public class MxcAvailabilityTests
         {
             Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, fakeExe);
 
-            // Negative exit = our timeout/launch sentinel → transient probe error.
+            // TimedOut status → transient probe error.
             var availability = MxcAvailability.Probe(
                 NullLogger.Instance,
-                _ => new WxcProbeInvocation(-1, string.Empty, "wxc-exec --probe timed out."));
+                _ => new WxcProbeInvocation(WxcProbeStatus.TimedOut, 0, string.Empty, "wxc-exec --probe timed out."));
 
             Assert.True(availability.IsWxcExecResolvable);
             Assert.False(availability.IsAppContainerAvailable);
@@ -284,6 +312,7 @@ public class MxcAvailabilityTests
             var availability = MxcAvailability.Probe(
                 NullLogger.Instance,
                 _ => new WxcProbeInvocation(
+                    WxcProbeStatus.Completed,
                     0,
                     "{\"tier\":\"appcontainer-dacl\",\"needsDaclAugmentation\":true,\"warnings\":[\"fallback\"]}",
                     string.Empty));

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcAvailabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcAvailabilityTests.cs
@@ -72,6 +72,7 @@ public class MxcAvailabilityTests
             stdout: "{\"tier\":\"base-container\",\"needsDaclAugmentation\":false,\"warnings\":[]}",
             stderr: "");
 
+        Assert.Equal(MxcProbeOutcome.Supported, result.Outcome);
         Assert.True(result.Supported);
         Assert.Equal("base-container", result.Tier);
         Assert.False(result.NeedsDaclAugmentation);
@@ -87,6 +88,7 @@ public class MxcAvailabilityTests
             stdout: "{\"tier\":\"appcontainer-dacl\",\"needsDaclAugmentation\":true,\"warnings\":[\"fell back to dacl\"]}",
             stderr: "");
 
+        Assert.Equal(MxcProbeOutcome.Supported, result.Outcome);
         Assert.True(result.Supported);
         Assert.Equal("appcontainer-dacl", result.Tier);
         Assert.True(result.NeedsDaclAugmentation);
@@ -94,17 +96,34 @@ public class MxcAvailabilityTests
     }
 
     [Fact]
-    public void ParseProbeOutput_NonZeroExit_ReportsUnsupported()
+    public void ParseProbeOutput_PositiveNonZeroExit_ReportsUnsupportedHost()
     {
         var result = MxcAvailability.ParseProbeOutput(
             exitCode: 1,
             stdout: "",
             stderr: "unsupported os");
 
+        // The binary ran and returned a definitive negative — not a probe error.
+        Assert.Equal(MxcProbeOutcome.UnsupportedHost, result.Outcome);
         Assert.False(result.Supported);
         Assert.Null(result.Tier);
         Assert.NotNull(result.FailureReason);
         Assert.Contains("does not support", result.FailureReason!);
+    }
+
+    [Theory]
+    [InlineData(-1, "wxc-exec --probe timed out.")]
+    [InlineData(-1, "Failed to launch wxc-exec --probe: access denied")]
+    public void ParseProbeOutput_NegativeExitSentinel_ReportsProbeError(int exitCode, string stderr)
+    {
+        // Negative exit is our own timeout/launch sentinel — we never got a verdict,
+        // so it's a transient probe error, NOT a definitive "unsupported host".
+        var result = MxcAvailability.ParseProbeOutput(exitCode, stdout: "", stderr: stderr);
+
+        Assert.Equal(MxcProbeOutcome.ProbeError, result.Outcome);
+        Assert.False(result.Supported);
+        Assert.NotNull(result.FailureReason);
+        Assert.Contains("Could not determine", result.FailureReason!);
     }
 
     [Theory]
@@ -113,13 +132,53 @@ public class MxcAvailabilityTests
     [InlineData("{\"needsDaclAugmentation\":false}")]
     [InlineData("{\"tier\":\"\"}")]
     [InlineData("not json at all")]
-    public void ParseProbeOutput_MissingOrInvalidTier_ReportsUnsupported(string stdout)
+    public void ParseProbeOutput_ExitZeroButNoUsableOutput_ReportsProbeError(string stdout)
     {
+        // Exit 0 with missing/garbled output is a binary anomaly, not a clear
+        // "unsupported" verdict — treat as retryable probe error.
         var result = MxcAvailability.ParseProbeOutput(exitCode: 0, stdout: stdout, stderr: "");
 
+        Assert.Equal(MxcProbeOutcome.ProbeError, result.Outcome);
         Assert.False(result.Supported);
         Assert.Null(result.Tier);
         Assert.NotNull(result.FailureReason);
+    }
+
+    [Theory]
+    [InlineData("base-container", false, false)]
+    [InlineData("appcontainer-bfs", false, false)]
+    [InlineData("appcontainer-dacl", false, true)]
+    [InlineData("base-container", true, true)]   // needsDaclAugmentation forces degraded
+    [InlineData("some-future-tier", false, true)] // unrecognized tier => degraded
+    public void IsDegradedContainment_ReflectsTierAndDaclFlag(string tier, bool needsDacl, bool expectedDegraded)
+    {
+        var availability = new MxcAvailability(
+            isAppContainerAvailable: true,
+            isIsolationSessionAvailable: false,
+            isWxcExecResolvable: true,
+            wxcExecPath: "C:\\fake\\wxc-exec.exe",
+            unsupportedReasons: Array.Empty<string>(),
+            isolationTier: tier,
+            needsDaclAugmentation: needsDacl);
+
+        Assert.True(availability.HasAnyBackend);
+        Assert.Equal(expectedDegraded, availability.IsDegradedContainment);
+    }
+
+    [Fact]
+    public void IsDegradedContainment_FalseWhenNoBackend()
+    {
+        var availability = new MxcAvailability(
+            isAppContainerAvailable: false,
+            isIsolationSessionAvailable: false,
+            isWxcExecResolvable: true,
+            wxcExecPath: "C:\\fake\\wxc-exec.exe",
+            unsupportedReasons: new[] { "nope" },
+            isolationTier: "appcontainer-dacl",
+            needsDaclAugmentation: true);
+
+        Assert.False(availability.HasAnyBackend);
+        Assert.False(availability.IsDegradedContainment);
     }
 
     [Fact]
@@ -141,6 +200,9 @@ public class MxcAvailabilityTests
             Assert.True(availability.IsWxcExecResolvable);
             Assert.Equal(fakeExe, availability.WxcExecPath);
             Assert.Empty(availability.UnsupportedReasons);
+            Assert.False(availability.ProbeErrored);
+            Assert.Equal("base-container", availability.IsolationTier);
+            Assert.False(availability.IsDegradedContainment);
         }
         finally
         {
@@ -164,11 +226,75 @@ public class MxcAvailabilityTests
                 NullLogger.Instance,
                 _ => new WxcProbeInvocation(1, string.Empty, "unsupported os build"));
 
-            // wxc-exec is present, but the host probe said no → not a setup issue.
+            // wxc-exec is present, but the host probe said no → not a setup issue,
+            // and a definitive verdict (exit 1) is NOT a transient probe error.
             Assert.True(availability.IsWxcExecResolvable);
             Assert.False(availability.IsAppContainerAvailable);
             Assert.False(availability.HasAnyBackend);
             Assert.NotEmpty(availability.UnsupportedReasons);
+            Assert.False(availability.ProbeErrored);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, null);
+            try { File.Delete(fakeExe); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public void Probe_WhenProbeTimesOut_ReportsProbeErrored()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var fakeExe = Path.Combine(Path.GetTempPath(), $"wxc-fake-{Guid.NewGuid():N}.exe");
+        File.WriteAllText(fakeExe, string.Empty);
+        try
+        {
+            Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, fakeExe);
+
+            // Negative exit = our timeout/launch sentinel → transient probe error.
+            var availability = MxcAvailability.Probe(
+                NullLogger.Instance,
+                _ => new WxcProbeInvocation(-1, string.Empty, "wxc-exec --probe timed out."));
+
+            Assert.True(availability.IsWxcExecResolvable);
+            Assert.False(availability.IsAppContainerAvailable);
+            Assert.False(availability.HasAnyBackend);
+            Assert.True(availability.ProbeErrored);
+            Assert.NotEmpty(availability.UnsupportedReasons);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, null);
+            try { File.Delete(fakeExe); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public void Probe_WhenProbeReportsDaclTier_ReportsDegraded()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var fakeExe = Path.Combine(Path.GetTempPath(), $"wxc-fake-{Guid.NewGuid():N}.exe");
+        File.WriteAllText(fakeExe, string.Empty);
+        try
+        {
+            Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, fakeExe);
+
+            var availability = MxcAvailability.Probe(
+                NullLogger.Instance,
+                _ => new WxcProbeInvocation(
+                    0,
+                    "{\"tier\":\"appcontainer-dacl\",\"needsDaclAugmentation\":true,\"warnings\":[\"fallback\"]}",
+                    string.Empty));
+
+            // Still contained (don't downgrade to uncontained), but flagged degraded.
+            Assert.True(availability.IsAppContainerAvailable);
+            Assert.True(availability.HasAnyBackend);
+            Assert.True(availability.IsDegradedContainment);
+            Assert.Equal("appcontainer-dacl", availability.IsolationTier);
+            Assert.True(availability.NeedsDaclAugmentation);
+            Assert.False(availability.ProbeErrored);
         }
         finally
         {

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcAvailabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcAvailabilityTests.cs
@@ -64,30 +64,116 @@ public class MxcAvailabilityTests
         Assert.True(availability.HasAnyBackend);
     }
 
-    [Theory]
-    [InlineData(26299, 9999, "is not MXC supported build 26300")]
-    [InlineData(26300, 8288, "Windows UBR 8288 below MXC minimum 8289")]
-    [InlineData(26301, 9999, "is not MXC supported build 26300")]
-    [InlineData(27999, 9999, "is not MXC supported build 26300")]
-    [InlineData(28000, 9999, "is not MXC supported build 26300")]
-    public void GetWindowsBuildUnsupportedReason_RejectsUnsupportedBuilds(
-        int build,
-        int ubr,
-        string expectedReason)
+    [Fact]
+    public void ParseProbeOutput_ValidTier_ReportsSupported()
     {
-        var reason = MxcAvailability.GetWindowsBuildUnsupportedReason(build, ubr);
+        var result = MxcAvailability.ParseProbeOutput(
+            exitCode: 0,
+            stdout: "{\"tier\":\"base-container\",\"needsDaclAugmentation\":false,\"warnings\":[]}",
+            stderr: "");
 
-        Assert.NotNull(reason);
-        Assert.Contains(expectedReason, reason);
+        Assert.True(result.Supported);
+        Assert.Equal("base-container", result.Tier);
+        Assert.False(result.NeedsDaclAugmentation);
+        Assert.Empty(result.Warnings);
+        Assert.Null(result.FailureReason);
+    }
+
+    [Fact]
+    public void ParseProbeOutput_CapturesWarningsAndDaclFlag()
+    {
+        var result = MxcAvailability.ParseProbeOutput(
+            exitCode: 0,
+            stdout: "{\"tier\":\"appcontainer-dacl\",\"needsDaclAugmentation\":true,\"warnings\":[\"fell back to dacl\"]}",
+            stderr: "");
+
+        Assert.True(result.Supported);
+        Assert.Equal("appcontainer-dacl", result.Tier);
+        Assert.True(result.NeedsDaclAugmentation);
+        Assert.Equal(new[] { "fell back to dacl" }, result.Warnings);
+    }
+
+    [Fact]
+    public void ParseProbeOutput_NonZeroExit_ReportsUnsupported()
+    {
+        var result = MxcAvailability.ParseProbeOutput(
+            exitCode: 1,
+            stdout: "",
+            stderr: "unsupported os");
+
+        Assert.False(result.Supported);
+        Assert.Null(result.Tier);
+        Assert.NotNull(result.FailureReason);
+        Assert.Contains("does not support", result.FailureReason!);
     }
 
     [Theory]
-    [InlineData(26300, 8289)]
-    [InlineData(26300, 9999)]
-    public void GetWindowsBuildUnsupportedReason_AllowsSupportedBuilds(int build, int ubr)
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("{\"needsDaclAugmentation\":false}")]
+    [InlineData("{\"tier\":\"\"}")]
+    [InlineData("not json at all")]
+    public void ParseProbeOutput_MissingOrInvalidTier_ReportsUnsupported(string stdout)
     {
-        var reason = MxcAvailability.GetWindowsBuildUnsupportedReason(build, ubr);
+        var result = MxcAvailability.ParseProbeOutput(exitCode: 0, stdout: stdout, stderr: "");
 
-        Assert.Null(reason);
+        Assert.False(result.Supported);
+        Assert.Null(result.Tier);
+        Assert.NotNull(result.FailureReason);
+    }
+
+    [Fact]
+    public void Probe_WhenProbeReportsTier_ReportsAvailable()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var fakeExe = Path.Combine(Path.GetTempPath(), $"wxc-fake-{Guid.NewGuid():N}.exe");
+        File.WriteAllText(fakeExe, string.Empty);
+        try
+        {
+            Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, fakeExe);
+
+            var availability = MxcAvailability.Probe(
+                NullLogger.Instance,
+                _ => new WxcProbeInvocation(0, "{\"tier\":\"base-container\",\"warnings\":[]}", string.Empty));
+
+            Assert.True(availability.IsAppContainerAvailable);
+            Assert.True(availability.IsWxcExecResolvable);
+            Assert.Equal(fakeExe, availability.WxcExecPath);
+            Assert.Empty(availability.UnsupportedReasons);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, null);
+            try { File.Delete(fakeExe); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public void Probe_WhenProbeReportsNoTier_ReportsUnavailableWithReason()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var fakeExe = Path.Combine(Path.GetTempPath(), $"wxc-fake-{Guid.NewGuid():N}.exe");
+        File.WriteAllText(fakeExe, string.Empty);
+        try
+        {
+            Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, fakeExe);
+
+            var availability = MxcAvailability.Probe(
+                NullLogger.Instance,
+                _ => new WxcProbeInvocation(1, string.Empty, "unsupported os build"));
+
+            // wxc-exec is present, but the host probe said no → not a setup issue.
+            Assert.True(availability.IsWxcExecResolvable);
+            Assert.False(availability.IsAppContainerAvailable);
+            Assert.False(availability.HasAnyBackend);
+            Assert.NotEmpty(availability.UnsupportedReasons);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, null);
+            try { File.Delete(fakeExe); } catch { /* best-effort */ }
+        }
     }
 }

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcAvailabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcAvailabilityTests.cs
@@ -98,20 +98,36 @@ public class MxcAvailabilityTests
     }
 
     [Fact]
-    public void ParseProbeOutput_CompletedNonZeroExit_ReportsUnsupportedHost()
+    public void ParseProbeOutput_CompletedNonZeroExit_ReportsProbeError()
     {
         var result = MxcAvailability.ParseProbeOutput(
             WxcProbeStatus.Completed,
             exitCode: 1,
             stdout: "",
-            stderr: "unsupported os");
+            stderr: "unknown option --probe");
 
-        // The binary ran to completion and returned a definitive negative — not a probe error.
-        Assert.Equal(MxcProbeOutcome.UnsupportedHost, result.Outcome);
+        Assert.Equal(MxcProbeOutcome.ProbeError, result.Outcome);
         Assert.False(result.Supported);
         Assert.Null(result.Tier);
         Assert.NotNull(result.FailureReason);
-        Assert.Contains("does not support", result.FailureReason!);
+        Assert.Contains("Could not determine", result.FailureReason!);
+    }
+
+    [Fact]
+    public void ParseProbeOutput_CompletedJsonError_ReportsUnsupportedHost()
+    {
+        var result = MxcAvailability.ParseProbeOutput(
+            WxcProbeStatus.Completed,
+            exitCode: 1,
+            stdout: "{\"error\":\"unsupported Windows build\",\"warnings\":[\"need newer host\"]}",
+            stderr: "");
+
+        Assert.Equal(MxcProbeOutcome.UnsupportedHost, result.Outcome);
+        Assert.False(result.Supported);
+        Assert.Null(result.Tier);
+        Assert.Equal(["need newer host"], result.Warnings);
+        Assert.NotNull(result.FailureReason);
+        Assert.Contains("unsupported Windows build", result.FailureReason!);
     }
 
     [Fact]
@@ -254,13 +270,11 @@ public class MxcAvailabilityTests
                 NullLogger.Instance,
                 _ => new WxcProbeInvocation(WxcProbeStatus.Completed, 1, string.Empty, "unsupported os build"));
 
-            // wxc-exec is present, but the host probe said no → not a setup issue,
-            // and a definitive verdict (exit 1) is NOT a transient probe error.
             Assert.True(availability.IsWxcExecResolvable);
             Assert.False(availability.IsAppContainerAvailable);
             Assert.False(availability.HasAnyBackend);
             Assert.NotEmpty(availability.UnsupportedReasons);
-            Assert.False(availability.ProbeErrored);
+            Assert.True(availability.ProbeErrored);
         }
         finally
         {

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcCommandRunnerIntegrationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcCommandRunnerIntegrationTests.cs
@@ -50,7 +50,7 @@ public class MxcCommandRunnerIntegrationTests
             return null;
         }
 
-        var executor = new DirectAppContainerExecutor(availability, new ConsoleLogger());
+        var executor = new DirectAppContainerExecutor(() => availability, new ConsoleLogger());
 
         var settings = new SettingsData
         {

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcCommandRunnerTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcCommandRunnerTests.cs
@@ -61,12 +61,25 @@ public class MxcCommandRunnerTests
         {
             Result = new CommandResult { ExitCode = 0, Stdout = "host" },
         };
-        var runner = NewRunner(executor, fallback, NewSettings(sandboxEnabled: false));
+        var availabilityChecks = 0;
+        var runner = new MxcCommandRunner(
+            executor,
+            fallback,
+            () => NewSettings(sandboxEnabled: false),
+            () => "C:\\test\\settings",
+            () =>
+            {
+                availabilityChecks++;
+                return true;
+            },
+            invalidateAvailability: null,
+            NullLogger.Instance);
 
         var result = await runner.RunAsync(new CommandRequest { Command = "echo hi" });
 
         Assert.Equal("host", result.Stdout);
         Assert.NotNull(fallback.LastRequest);
+        Assert.Equal(0, availabilityChecks);
         // Executor must not have been touched.
         Assert.Null(executor.LastRequest);
     }
@@ -101,9 +114,8 @@ public class MxcCommandRunnerTests
     [Fact]
     public async Task RunAsync_MxcUnavailable_FallsBackToHost_WithSandboxToggleOn()
     {
-        // Same as the toggle-off variant — the !_isSandboxAvailable() short-circuit
-        // fires before either the toggle check or the executor path, and both
-        // routes lead to the host fallback.
+        // With sandboxing enabled, unavailable MXC is detected before the
+        // executor path and routes to the host fallback.
         var executor = new FakeSandboxExecutor { ThrowsUnavailable = true, UnavailableReason = "MXC missing" };
         var fallback = new FakeCommandRunner
         {

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcConfigBuilderTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcConfigBuilderTests.cs
@@ -173,7 +173,7 @@ public class MxcConfigBuilderTests
     {
         var policy = BalancedPolicy();
         var config = MxcConfigBuilder.Build(RequestFor(policy), P.Scratch, pathEnvVar: "");
-        Assert.Contains("internetClient", config.AppContainer!.Capabilities!);
+        Assert.Contains("internetClient", config.ProcessContainer!.Capabilities!);
         Assert.Equal("allow", config.Network!.DefaultPolicy);
     }
 
@@ -182,7 +182,7 @@ public class MxcConfigBuilderTests
     {
         var policy = LockedDownPolicy();
         var config = MxcConfigBuilder.Build(RequestFor(policy), P.Scratch, pathEnvVar: "");
-        Assert.DoesNotContain("internetClient", config.AppContainer!.Capabilities!);
+        Assert.DoesNotContain("internetClient", config.ProcessContainer!.Capabilities!);
         Assert.Equal("block", config.Network!.DefaultPolicy);
     }
 
@@ -428,14 +428,14 @@ public class MxcConfigBuilderTests
     {
         // commandLine/cwd/env/timeoutMs live under "process" — the SDK leaves
         // process empty when called with createConfigFromPolicy and we add
-        // these ourselves. appContainer.name is a per-invocation random hex
+        // these ourselves. processContainer.name is a per-invocation random hex
         // that we stripped from the goldens.
         return fullPath is
             "$.process.commandLine" or
             "$.process.cwd" or
             "$.process.env" or
             "$.process.timeoutMs" or
-            "$.appContainer.name";
+            "$.processContainer.name";
     }
 
     private static void AssertNodeEqual(object? expected, object? actual, string path)

--- a/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
@@ -195,7 +195,7 @@ public sealed class InstallerIssAssertionTests
 
         Assert.Contains("private ICommandRunner BuildSystemRunRunner()", nodeService);
         Assert.Contains("MxcAvailability.Probe(_logger)", nodeService);
-        Assert.Contains("new DirectAppContainerExecutor(availability, _logger)", nodeService);
+        Assert.Contains("new DirectAppContainerExecutor(GetOrProbeMxcAvailability, _logger)", nodeService);
         Assert.Contains("return new MxcCommandRunner(", nodeService);
     }
 


### PR DESCRIPTION
## Why

We were pinned to `@microsoft/mxc-sdk@0.6.1` and gating MXC sandbox availability with a **hardcoded Windows build/UBR table** (`build == 26300 && UBR >= 8289`) — the one carrying a `TODO: this is all temporary; feature gate this correctly ASAP`. That table was already producing **false negatives on current Windows builds** (verified: build 26632 was wrongly rejected, even though `wxc-exec --probe` reports it fully supported at the best `base-container` tier).

The SDK already ships the right answer: the native **`wxc-exec --probe`** command returns `{"tier", "needsDaclAugmentation", "warnings"}` with exit 0 when the host can run the sandbox. This PR switches to that, bumps the SDK, and adopts the renamed config schema field.

## What changed

- **Probe-based availability.** `MxcAvailability.Probe()` resolves `wxc-exec.exe`, runs `wxc-exec --probe`, and parses the JSON to decide support — replacing the build/UBR table (and removing the stale `TODO` + registry read). So newer Windows builds light up with no code change.
- **Bump `@microsoft/mxc-sdk` `^0.6.1` -> `^0.7.0`** + refreshed lockfile.
- **Rename config wire key `appContainer` -> `processContainer`** to match the 0.7.0 schema (old name is now a deprecated alias). Updated the config model, builder, executor log, the 4 golden fixtures, and tests.
- **Off-UI-thread probe.** `SandboxPage` probes on a background thread (renders a neutral "Checking…" state) and the failure-mode branch no longer string-matches reason text.

## Robustness (incorporates three review passes: code-review, GPT-5.5 rubber-duck, and a dual-model Opus+Codex adversarial review)

- **Probe error vs. unsupported host.** Probe attempts are classified `WxcProbeStatus {Completed, TimedOut, LaunchFailed}` and outcomes `MxcProbeOutcome {Supported, UnsupportedHost, ProbeError}`. A **transient** error (timeout / failed launch / garbled output) is distinguished from a **definitive** "host unsupported" verdict, and surfaced as `MxcAvailability.ProbeErrored`.
- **Self-healing without pinning uncontained.** Definitive verdicts are cached for the process lifetime; a transient error is re-probed. `DirectAppContainerExecutor` resolves availability **lazily** per call (a frozen snapshot would pin a startup glitch to uncontained for the executor's lifetime even after recovery).
- **No blocking probe under a lock.** `NodeService.GetOrProbeMxcAvailability` runs the ~15s probe via a **single-flight** shared task and waits on it **outside** the availability lock; capability registration uses a non-blocking peek so it never stalls on `_capabilitiesLock`. The retry window opens only **after** a probe completes (no back-to-back re-probe when timeout > retry interval).
- **Bounded probe spawn.** `RunWxcExecProbe` bounds the stdout/stderr drain with the remaining timeout budget (not just process exit), so a handle-inheriting descendant (the SDK ships sandbox daemon/guest helpers) can't hang the probe; abandoned reads are observed on the kill path.
- **Degraded isolation tier.** `IsolationTier` / `NeedsDaclAugmentation` / `IsDegradedContainment` are exposed. A weaker tier (`appcontainer-dacl`) is **accepted-but-flagged** (the Sandbox page shows a "limited containment" caution) rather than blocked — refusing would drop the host to **fully uncontained**, which is strictly worse.
- **Sandbox page never gets stuck.** A probe error shows "Couldn't verify sandbox availability" with a **Retry**; an unexpected probe fault is caught and re-rendered so the page can't hang in "Checking…".

## Validation

- `./build.ps1` — all projects incl. WinUI (0.7.0 restored, `wxc-exec` ship-validated)
- Shared tests — **2064 passed / 0 failed** (probe status/outcome classification, `ProbeErrored`, degraded-tier, lazy-executor recovery, bounded-probe)
- Tray tests — **958 passed / 0 failed**

---
🤖 Authored with Copilot CLI.