### PR TITLE
Add Run gateway doctor action to the Diagnostics page

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
@@ -93,6 +93,7 @@ public static class FluentIconCatalog
     public const string Clear = "\uE74D";          // Delete — clear/reset a buffer
     public const string Develop = "\uE943";        // Code — engineering / explorations action
     public const string AgentEvents = "\uE81C";    // History — agent events feed
+    public const string Doctor = "\uE95E";         // Health — "Run gateway doctor" health-check action
 
     // ── Agents / Workspace surface ─────────────────────────────────
     // Workspace concept (per-agent file viewer). Reuses the Folder

--- a/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml
@@ -85,6 +85,32 @@
                         </controls:InfoBar.Content>
                     </controls:InfoBar>
 
+                    <!-- Gateway — shown only when the active gateway is an
+                         app-managed WSL distro we can run commands in
+                         (CanControlWslGateway). Hidden for SSH/remote
+                         gateways. Visibility is driven from code-behind in
+                         UpdateGatewayDoctorCard(). -->
+                    <StackPanel x:Name="GatewayDoctorSection"
+                                Spacing="{StaticResource DiagSettingsCardSpacing}"
+                                Visibility="Collapsed">
+                        <TextBlock x:Uid="DiagnosticsPage_Section_Gateway"
+                                   Text="Gateway"
+                                   Style="{StaticResource DiagSectionHeaderTextBlockStyle}"/>
+
+                        <toolkit:SettingsCard x:Uid="DiagnosticsPage_Card_Doctor"
+                                              x:Name="GatewayDoctorCard"
+                                              Header="Run gateway doctor"
+                                              Description="Opens a terminal and runs openclaw doctor to check the local gateway for problems."
+                                              IsClickEnabled="True"
+                                              Click="OnRunGatewayDoctor"
+                                              AutomationProperties.AutomationId="DiagnosticsRunGatewayDoctor">
+                            <toolkit:SettingsCard.HeaderIcon>
+                                <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Doctor, Mode=OneTime}"
+                                          FontFamily="{ThemeResource SymbolThemeFontFamily}"/>
+                            </toolkit:SettingsCard.HeaderIcon>
+                        </toolkit:SettingsCard>
+                    </StackPanel>
+
                     <!-- Share diagnostics with support -->
                     <TextBlock x:Uid="DiagnosticsPage_Section_Share"
                                Text="Share diagnostics with support"

--- a/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
@@ -43,6 +43,12 @@ public sealed partial class DebugPage : Page
     private AppState? _appState;
     private bool _suppressOverrideChange;
 
+    private IGatewayTerminalLauncher? _terminalLauncher;
+    private GatewayHostAccessPlan _doctorAccessPlan = GatewayHostAccessPlan.None();
+
+    private IGatewayTerminalLauncher TerminalLauncher =>
+        _terminalLauncher ??= new GatewayTerminalLauncher(new OpenClawTray.AppLogger());
+
     private static readonly string LocalAppData = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "OpenClawTray");
     private static readonly string LogPath = Path.Combine(LocalAppData, "openclaw-tray.log");
@@ -107,6 +113,7 @@ public sealed partial class DebugPage : Page
         // (per docs/DATA_FLOW_ARCHITECTURE.md reactive-by-default ethos).
         CurrentApp.SettingsChanged += OnSettingsChanged;
         UpdateStatusInfoBar();
+        UpdateGatewayDoctorCard();
         LoadDeviceIdentity();
         LoadChatSurfaceOverrides();
     }
@@ -118,11 +125,16 @@ public sealed partial class DebugPage : Page
             case nameof(AppState.Status):
             case nameof(AppState.GatewaySelf):
                 UpdateStatusInfoBar();
+                UpdateGatewayDoctorCard();
                 break;
         }
     }
 
-    private void OnSettingsChanged(object? sender, EventArgs e) => UpdateStatusInfoBar();
+    private void OnSettingsChanged(object? sender, EventArgs e)
+    {
+        UpdateStatusInfoBar();
+        UpdateGatewayDoctorCard();
+    }
 
     /// <summary>
     /// Reset detail-mode state when the user navigates to a different
@@ -178,6 +190,40 @@ public sealed partial class DebugPage : Page
 
     private void OnManageOnConnection(object sender, RoutedEventArgs e)
         => ((IAppCommands)CurrentApp).Navigate("connection");
+
+    // ── Gateway doctor (app-managed WSL only) ────────────────────────
+
+    /// <summary>
+    /// Show the "Run gateway doctor" card only when the active gateway is an
+    /// app-managed WSL distro we can run commands in (CanControlWslGateway).
+    /// SSH/remote gateways have no such control surface, so the section stays
+    /// collapsed. Mirrors ConnectionPage's gateway-host gating.
+    /// </summary>
+    private void UpdateGatewayDoctorCard()
+    {
+        var activeRecord = CurrentApp.Registry?.GetActive();
+        _doctorAccessPlan = GatewayHostAccessClassifier.Classify(activeRecord);
+        GatewayDoctorSection.Visibility = _doctorAccessPlan.CanControlWslGateway
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+    }
+
+    private void OnRunGatewayDoctor(object sender, RoutedEventArgs e)
+    {
+        if (!_doctorAccessPlan.CanControlWslGateway)
+        {
+            return;
+        }
+
+        try
+        {
+            TerminalLauncher.OpenGatewayDoctor(_doctorAccessPlan);
+        }
+        catch (Exception ex)
+        {
+            OpenClawTray.Services.Logger.Warn($"[DebugPage] Failed to launch gateway doctor: {ex.Message}");
+        }
+    }
 
     // ── Detail view (recent log) ─────────────────────────────────────
 

--- a/src/OpenClaw.Tray.WinUI/Services/GatewayTerminalLauncher.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/GatewayTerminalLauncher.cs
@@ -7,6 +7,8 @@ namespace OpenClawTray.Services;
 internal interface IGatewayTerminalLauncher
 {
     void Open(GatewayHostAccessPlan accessPlan);
+
+    void OpenGatewayDoctor(GatewayHostAccessPlan accessPlan);
 }
 
 internal sealed record GatewayTerminalLaunchCommand(
@@ -29,6 +31,61 @@ internal static class GatewayTerminalLaunchCommandBuilder
             GatewayTerminalTarget.Ssh => BuildSshCommand(accessPlan, windowsTerminalPath),
             _ => throw new InvalidOperationException("Gateway terminal access is not available.")
         };
+    }
+
+    // Runs `openclaw doctor` in the app-managed WSL gateway, then `exec bash`
+    // so the terminal stays interactive after doctor exits. doctor is a rich
+    // terminal TUI and frequently exits non-zero for advisory findings, so we
+    // neither capture its output nor gate the keep-open on its exit code — the
+    // `|| true` absorbs the non-zero exit and `exec bash` always runs.
+    //
+    // IMPORTANT: the keep-open uses `&&` / `|| true &&`, NOT `;`. Windows Terminal
+    // treats `;` in its command line as a tab/pane delimiter and splits on it even
+    // inside a quoted argument, so `openclaw doctor; exec bash` breaks (wt tries to
+    // launch " exec bash" → error 0x80070002). `&&` / `||` are not wt delimiters,
+    // so the command passes through wt intact (verified with the app's
+    // ProcessStartInfo.ArgumentList quoting), letting doctor open in a themed
+    // Windows Terminal tab — matching the Connection page's Open terminal action.
+    public static GatewayTerminalLaunchCommand BuildGatewayDoctor(GatewayHostAccessPlan accessPlan, string? windowsTerminalPath)
+    {
+        if (accessPlan.TerminalTarget != GatewayTerminalTarget.Wsl || string.IsNullOrWhiteSpace(accessPlan.DistroName))
+        {
+            throw new InvalidOperationException("Running gateway doctor requires an app-managed WSL gateway.");
+        }
+
+        var distroName = accessPlan.DistroName!;
+        var script = $"{WslGatewayControlCommandBuilder.OpenClawWslPathPrefix} && openclaw doctor || true && exec bash";
+
+        if (!string.IsNullOrWhiteSpace(windowsTerminalPath))
+        {
+            return new GatewayTerminalLaunchCommand(
+                windowsTerminalPath,
+                new ReadOnlyCollection<string>([
+                    "new-tab",
+                    "--title",
+                    $"OpenClaw doctor ({distroName})",
+                    "wsl.exe",
+                    "-d",
+                    distroName,
+                    "--",
+                    "bash",
+                    "-lc",
+                    script
+                ]),
+                true);
+        }
+
+        return new GatewayTerminalLaunchCommand(
+            "wsl.exe",
+            new ReadOnlyCollection<string>([
+                "-d",
+                distroName,
+                "--",
+                "bash",
+                "-lc",
+                script
+            ]),
+            false);
     }
 
     private static GatewayTerminalLaunchCommand BuildWslCommand(GatewayHostAccessPlan accessPlan, string? windowsTerminalPath)
@@ -105,6 +162,23 @@ internal sealed class GatewayTerminalLauncher(IOpenClawLogger logger) : IGateway
         }
     }
 
+    public void OpenGatewayDoctor(GatewayHostAccessPlan accessPlan)
+    {
+        // Mirror Open(): prefer a Windows Terminal tab, fall back to direct wsl.exe.
+        var terminalPath = TryFindWindowsTerminalPath();
+        var command = GatewayTerminalLaunchCommandBuilder.BuildGatewayDoctor(accessPlan, terminalPath);
+
+        try
+        {
+            Start(command);
+        }
+        catch (Exception ex) when (command.UsesWindowsTerminal)
+        {
+            logger.Warn($"Windows Terminal launch failed; falling back to direct terminal process: {ex.Message}");
+            Start(GatewayTerminalLaunchCommandBuilder.BuildGatewayDoctor(accessPlan, null));
+        }
+    }
+
     internal static string? TryFindWindowsTerminalPath()
     {
         foreach (var candidate in GetWindowsTerminalCandidates().Distinct(StringComparer.OrdinalIgnoreCase))
@@ -138,7 +212,11 @@ internal sealed class GatewayTerminalLauncher(IOpenClawLogger logger) : IGateway
         var startInfo = new ProcessStartInfo
         {
             FileName = command.FileName,
-            UseShellExecute = false
+            // Direct console apps (wsl.exe / ssh.exe — the doctor terminal and the
+            // Open-terminal fallback) need ShellExecute so Windows allocates a
+            // visible console window. Windows Terminal opens its own window, so it
+            // keeps the lighter CreateProcess path.
+            UseShellExecute = !command.UsesWindowsTerminal
         };
 
         foreach (var argument in command.Arguments)

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -3558,6 +3558,15 @@ On your gateway host (Mac/Linux), run:
   <data name="DiagnosticsPage_ManageOnConnection.Content" xml:space="preserve">
     <value>Manage on Connection page</value>
   </data>
+  <data name="DiagnosticsPage_Section_Gateway.Text" xml:space="preserve">
+    <value>Gateway</value>
+  </data>
+  <data name="DiagnosticsPage_Card_Doctor.Header" xml:space="preserve">
+    <value>Run gateway doctor</value>
+  </data>
+  <data name="DiagnosticsPage_Card_Doctor.Description" xml:space="preserve">
+    <value>Opens a terminal and runs openclaw doctor to check the local gateway for problems.</value>
+  </data>
   <data name="DiagnosticsPage_Section_Share.Text" xml:space="preserve">
     <value>Share diagnostics with support</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -3510,6 +3510,15 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="DiagnosticsPage_ManageOnConnection.Content" xml:space="preserve">
     <value>Manage on Connection page</value>
   </data>
+  <data name="DiagnosticsPage_Section_Gateway.Text" xml:space="preserve">
+    <value>Gateway</value>
+  </data>
+  <data name="DiagnosticsPage_Card_Doctor.Header" xml:space="preserve">
+    <value>Run gateway doctor</value>
+  </data>
+  <data name="DiagnosticsPage_Card_Doctor.Description" xml:space="preserve">
+    <value>Opens a terminal and runs openclaw doctor to check the local gateway for problems.</value>
+  </data>
   <data name="DiagnosticsPage_Section_Share.Text" xml:space="preserve">
     <value>Share diagnostics with support</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -3511,6 +3511,15 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="DiagnosticsPage_ManageOnConnection.Content" xml:space="preserve">
     <value>Manage on Connection page</value>
   </data>
+  <data name="DiagnosticsPage_Section_Gateway.Text" xml:space="preserve">
+    <value>Gateway</value>
+  </data>
+  <data name="DiagnosticsPage_Card_Doctor.Header" xml:space="preserve">
+    <value>Run gateway doctor</value>
+  </data>
+  <data name="DiagnosticsPage_Card_Doctor.Description" xml:space="preserve">
+    <value>Opens a terminal and runs openclaw doctor to check the local gateway for problems.</value>
+  </data>
   <data name="DiagnosticsPage_Section_Share.Text" xml:space="preserve">
     <value>Share diagnostics with support</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -3510,6 +3510,15 @@
   <data name="DiagnosticsPage_ManageOnConnection.Content" xml:space="preserve">
     <value>Manage on Connection page</value>
   </data>
+  <data name="DiagnosticsPage_Section_Gateway.Text" xml:space="preserve">
+    <value>Gateway</value>
+  </data>
+  <data name="DiagnosticsPage_Card_Doctor.Header" xml:space="preserve">
+    <value>Run gateway doctor</value>
+  </data>
+  <data name="DiagnosticsPage_Card_Doctor.Description" xml:space="preserve">
+    <value>Opens a terminal and runs openclaw doctor to check the local gateway for problems.</value>
+  </data>
   <data name="DiagnosticsPage_Section_Share.Text" xml:space="preserve">
     <value>Share diagnostics with support</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -3510,6 +3510,15 @@
   <data name="DiagnosticsPage_ManageOnConnection.Content" xml:space="preserve">
     <value>Manage on Connection page</value>
   </data>
+  <data name="DiagnosticsPage_Section_Gateway.Text" xml:space="preserve">
+    <value>Gateway</value>
+  </data>
+  <data name="DiagnosticsPage_Card_Doctor.Header" xml:space="preserve">
+    <value>Run gateway doctor</value>
+  </data>
+  <data name="DiagnosticsPage_Card_Doctor.Description" xml:space="preserve">
+    <value>Opens a terminal and runs openclaw doctor to check the local gateway for problems.</value>
+  </data>
   <data name="DiagnosticsPage_Section_Share.Text" xml:space="preserve">
     <value>Share diagnostics with support</value>
   </data>

--- a/tests/OpenClaw.Tray.Tests/DiagnosticsPageContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/DiagnosticsPageContractTests.cs
@@ -63,6 +63,31 @@ public sealed class DiagnosticsPageContractTests
     }
 
     [Fact]
+    public void DebugPage_GatewayDoctorCard_IsGatedOnWslControlAndRunsDoctor()
+    {
+        var xaml = Read("src", "OpenClaw.Tray.WinUI", "Pages", "DebugPage.xaml");
+        var cs = Read("src", "OpenClaw.Tray.WinUI", "Pages", "DebugPage.xaml.cs");
+
+        // Whole-row clickable card that runs the doctor handler and uses the
+        // catalog Doctor glyph (not a literal or chevron).
+        Assert.Matches(
+            new System.Text.RegularExpressions.Regex(
+                @"x:Uid=""DiagnosticsPage_Card_Doctor""[\s\S]{0,500}IsClickEnabled=""True""[\s\S]{0,200}Click=""OnRunGatewayDoctor"""),
+            xaml);
+        Assert.Contains("FluentIconCatalog.Doctor", xaml);
+
+        // Section is collapsed by default; visibility is driven by the
+        // app-managed-WSL control gate (CanControlWslGateway), and the handler
+        // launches a terminal via OpenGatewayDoctor rather than capturing output.
+        Assert.Matches(
+            new System.Text.RegularExpressions.Regex(
+                @"x:Name=""GatewayDoctorSection""[\s\S]{0,200}Visibility=""Collapsed"""),
+            xaml);
+        Assert.Contains("CanControlWslGateway", cs);
+        Assert.Contains("OpenGatewayDoctor", cs);
+    }
+
+    [Fact]
     public void DebugPage_SurfacesAllExistingDiagnosticCommands()
     {
         var xaml = Read("src", "OpenClaw.Tray.WinUI", "Pages", "DebugPage.xaml");

--- a/tests/OpenClaw.Tray.Tests/GatewayTerminalLaunchCommandBuilderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/GatewayTerminalLaunchCommandBuilderTests.cs
@@ -77,4 +77,69 @@ public class GatewayTerminalLaunchCommandBuilderTests
         Assert.Throws<InvalidOperationException>(() =>
             GatewayTerminalLaunchCommandBuilder.Build(access, windowsTerminalPath: null));
     }
+
+    [Fact]
+    public void BuildGatewayDoctor_WithWindowsTerminal_OpensThemedTabWithSemicolonFreeKeepOpen()
+    {
+        var access = GatewayHostAccessClassifier.Classify(new GatewayRecord
+        {
+            Id = "local",
+            Url = "ws://127.0.0.1:18789",
+            SetupManagedDistroName = "OpenClawGateway",
+        });
+
+        var command = GatewayTerminalLaunchCommandBuilder.BuildGatewayDoctor(
+            access, @"C:\Users\me\AppData\Local\Microsoft\WindowsApps\wt.exe");
+
+        // Keep-open must NOT contain ';': Windows Terminal splits its command line
+        // on ';' even inside quotes. We use '|| true && exec bash' instead.
+        var script = $"{WslGatewayControlCommandBuilder.OpenClawWslPathPrefix} && openclaw doctor || true && exec bash";
+        Assert.DoesNotContain(";", script);
+        Assert.Equal(@"C:\Users\me\AppData\Local\Microsoft\WindowsApps\wt.exe", command.FileName);
+        Assert.True(command.UsesWindowsTerminal);
+        Assert.Equal([
+            "new-tab",
+            "--title",
+            "OpenClaw doctor (OpenClawGateway)",
+            "wsl.exe",
+            "-d",
+            "OpenClawGateway",
+            "--",
+            "bash",
+            "-lc",
+            script
+        ], command.Arguments);
+    }
+
+    [Fact]
+    public void BuildGatewayDoctor_WithoutWindowsTerminal_FallsBackToWslExe()
+    {
+        var access = GatewayHostAccessClassifier.Classify(new GatewayRecord
+        {
+            Id = "local",
+            Url = "ws://127.0.0.1:18789",
+            SetupManagedDistroName = "OpenClawGateway",
+        });
+
+        var command = GatewayTerminalLaunchCommandBuilder.BuildGatewayDoctor(access, windowsTerminalPath: null);
+
+        var script = $"{WslGatewayControlCommandBuilder.OpenClawWslPathPrefix} && openclaw doctor || true && exec bash";
+        Assert.Equal("wsl.exe", command.FileName);
+        Assert.False(command.UsesWindowsTerminal);
+        Assert.Equal(["-d", "OpenClawGateway", "--", "bash", "-lc", script], command.Arguments);
+    }
+
+    [Fact]
+    public void BuildGatewayDoctor_RejectsSshGateway()
+    {
+        var access = GatewayHostAccessClassifier.Classify(new GatewayRecord
+        {
+            Id = "ssh",
+            Url = "ws://127.0.0.1:18789",
+            SshTunnel = new SshTunnelConfig("alice", "gateway.example.test", 18789, 18790),
+        });
+
+        Assert.Throws<InvalidOperationException>(() =>
+            GatewayTerminalLaunchCommandBuilder.BuildGatewayDoctor(access, windowsTerminalPath: null));
+    }
 }


### PR DESCRIPTION
## Summary

Adds a **Run gateway doctor** action to the Diagnostics page (`DebugPage`). The card opens a terminal in the app-managed WSL gateway, runs `openclaw doctor`, and leaves an interactive shell open so the operator can read the diagnostic report.

## Behavior

- Shown **only** when the active gateway is an app-managed WSL distro (`GatewayHostAccessPlan.CanControlWslGateway`). Hidden for SSH/remote/none.
- Reuses the same launcher path as the Connection page's **Open terminal** (`GatewayTerminalLauncher` / `GatewayHostAccessClassifier`): opens a themed Windows Terminal tab, with a direct `wsl.exe` fallback.
- The card lives in a conditional **Gateway** section above *Share diagnostics with support*; visibility is recomputed in `Initialize()` and on `AppState`/`Settings` changes.

## Why the keep-open avoids `;`

The keep-open command is `<PATH prefix> && openclaw doctor || true && exec bash` — deliberately **no `;`**. Windows Terminal treats `;` in its command line as a tab/pane delimiter and splits on it *even inside a quoted argument*, which caused `error 0x80070002` when launching. `&&`/`||` are not wt delimiters, so the command passes through intact (verified by reproducing the app's `ProcessStartInfo.ArgumentList` quoting). `|| true` absorbs doctor's frequent advisory non-zero exit so `exec bash` always runs.

`Start()` now uses `UseShellExecute = !command.UsesWindowsTerminal` so the direct `wsl.exe`/`ssh.exe` paths get a visible console window.

## UX rationale

`openclaw doctor` is a rich terminal TUI (banner, box-drawing, step spinners, ANSI color) that exits non-zero for advisory findings. Capturing it headless produces mojibake and an unreliable pass/fail signal, so the action is terminal-first (the operator reads the report directly).

## Changes

- `GatewayTerminalLauncher.cs` — `BuildGatewayDoctor` + `OpenGatewayDoctor`; `Start()` shell-execute tweak.
- `FluentIconCatalog.cs` — new `Doctor` glyph (U+E95E).
- `DebugPage.xaml` / `.cs` — Gateway section, card, gating + handler.
- `Resources.resw` (en-us + 4 locales) — 3 new keys.
- Tests — command-builder tests + Diagnostics page contract test.

## Validation

- `./build.ps1` ✅
- `dotnet test OpenClaw.Tray.Tests` — **962 passed** ✅
- `dotnet test OpenClaw.Shared.Tests` — **2049 passed** ✅
- Manual smoke on a real `OpenClawGateway` WSL distro: card appears, opens the themed terminal tab, runs doctor, drops to an interactive shell.
- Code review: no actionable findings.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
