### PR TITLE
Add inbound pairing approval dialog (Mac-parity)

### DIFF
--- a/docs/CONNECTION_ARCHITECTURE.md
+++ b/docs/CONNECTION_ARCHITECTURE.md
@@ -168,6 +168,12 @@ Setup codes (from QR scan or paste) decode to `{ url, bootstrapToken }` via `Set
 
 **Auto-approval**: When the node requires pairing and the operator has `operator.admin` or `operator.pairing` scope, `GatewayConnectionManager` automatically approves the node pairing request, waits 1 second, then reconnects the node.
 
+## Inbound pairing approval (operator)
+
+When **another** device or node requests pairing, the gateway broadcasts `device.pair.requested` / `node.pair.requested` to operators with pairing scope. `OpenClawGatewayClient` refreshes the pending lists and raises `DevicePairListUpdated` / `NodePairListUpdated`, which `GatewayService` forwards via its `PairListsChanged` event.
+
+`PairingApprovalCoordinator` (tray) reconciles those snapshots through the pure `PairingApprovalQueue` (OpenClaw.Connection) into add/resolve deltas, de-duplicating, suppressing already-decided requests, and filtering out the local node's own pending request (handled by the auto-approve path above). For genuinely new requests — when `ShowPairingApprovalDialog` is enabled and the operator holds pairing scope — it raises `ApprovalRequested`, and the app presents a focused **`PairingApprovalDialog`** plus an awareness toast (with a "Review" action). The dialog shows the requester's identity and the **operator scopes being granted** (mapped to friendly text by `PairingScopeDescriptions`), with Approve / Reject / Decide-later. Approve is briefly disabled on each new request to prevent click-through. Approve/Reject call the `IOperatorGatewayClient.{Device,Node}Pair{Approve,Reject}Async` RPCs; the queue advances and the dialog closes when empty. The existing Connections-page "Pending approvals" banner remains as the passive fallback when the dialog is disabled. Pure queue/scope logic is unit-tested in `OpenClaw.Connection.Tests`.
+
 ## SSH tunnel integration
 
 `SshTunnelService` manages an SSH local port-forward process. `SshTunnelManager` wraps it behind `ISshTunnelManager` for the connection manager.

--- a/src/OpenClaw.Connection/PairingApprovalQueue.cs
+++ b/src/OpenClaw.Connection/PairingApprovalQueue.cs
@@ -38,15 +38,18 @@ public sealed class PairingApprovalDelta
 ///
 /// Responsibilities:
 /// <list type="bullet">
-///   <item>Merge device + node pending lists into a single ordered queue (oldest first).</item>
+///   <item>Merge device + node pending lists into a single ordered queue (oldest first). A null
+///         list for a kind means "no update for that kind" (its prior entries are carried forward),
+///         NOT "that kind is now empty" — so a partial snapshot never silently drops or confirms.</item>
 ///   <item>Filter out the local node's own pairing request (handled by the auto-approve path)
-///         so the operator is never prompted to approve their own machine.</item>
+///         so the operator is never prompted to approve their own machine. Matches against any of
+///         the node's advertised identifiers (device id and/or gateway node id).</item>
 ///   <item>Drop entries with no usable id and de-duplicate by <see cref="PendingApproval.Key"/>.</item>
 ///   <item>Treat a submitted approve/reject as <em>optimistic-pending</em> — suppress it from the
 ///         actionable set, but only report it <see cref="PairingApprovalDelta.ConfirmedDecisions">
-///         confirmed</see> once the gateway actually drops it from the pending list. If the gateway
-///         never acts within <see cref="SubmissionResolveTimeoutMs"/>, re-surface the request so a
-///         lost decision is retried rather than hidden forever (and no false success is reported).</item>
+///         confirmed</see> once the gateway actually drops it from a provided list for that kind. If
+///         the gateway never acts within <see cref="SubmissionResolveTimeoutMs"/>, re-surface the
+///         request so a lost decision is retried rather than hidden forever.</item>
 /// </list>
 /// Not thread-safe; the coordinator marshals all calls onto a single dispatcher thread.
 /// </summary>
@@ -72,37 +75,50 @@ public sealed class PairingApprovalQueue
     public bool IsEmpty => Current.Count == 0;
 
     /// <summary>
-    /// Reconcile a fresh snapshot. <paramref name="ownNodeDeviceId"/>, when provided, filters out the
-    /// local Windows node's own pending node request. <paramref name="nowMs"/> is a monotonic timestamp
-    /// (e.g. <see cref="Environment.TickCount64"/>) used to expire stale submissions. When
-    /// <paramref name="deferNodeRequests"/> is true, node requests are excluded entirely (used while
-    /// the local node's own device id is not yet known, so we never prompt for our own machine).
+    /// Reconcile a fresh snapshot. <paramref name="ownNodeDeviceIds"/>, when provided, filters out the
+    /// local Windows node's own pending node request (matched against any advertised id).
+    /// <paramref name="nowMs"/> is a monotonic timestamp (e.g. <see cref="Environment.TickCount64"/>)
+    /// used to expire stale submissions. A null <paramref name="devices"/> or <paramref name="nodes"/>
+    /// means that kind has no fresh snapshot: its existing entries are carried forward and its
+    /// submissions are neither confirmed nor expired this round.
     /// </summary>
     public PairingApprovalDelta Reconcile(
         DevicePairingListInfo? devices,
         PairingListInfo? nodes,
-        string? ownNodeDeviceId = null,
-        long nowMs = 0,
-        bool deferNodeRequests = false)
+        IReadOnlyCollection<string>? ownNodeDeviceIds = null,
+        long nowMs = 0)
     {
-        var incoming = BuildIncoming(devices, nodes, ownNodeDeviceId, deferNodeRequests);
+        var devicesProvided = devices is not null;
+        var nodesProvided = nodes is not null;
+        bool KindProvided(PairingApprovalKind kind) =>
+            kind == PairingApprovalKind.Device ? devicesProvided : nodesProvided;
+
+        var incoming = BuildIncoming(devices, nodes, ownNodeDeviceIds);
         var incomingByKey = new Dictionary<string, PendingApproval>(StringComparer.Ordinal);
         foreach (var item in incoming)
             incomingByKey[item.Key] = item; // last wins on duplicate ids
 
-        // Confirmed resolutions: decisions we submitted whose request has now left the pending list.
+        // Carry forward prior entries whose kind had NO fresh snapshot — a missing list is "no
+        // update", not "now empty", so we never drop or resolve a kind we didn't actually hear about.
+        foreach (var kv in _current)
+            if (!KindProvided(kv.Value.Kind) && !incomingByKey.ContainsKey(kv.Key))
+                incomingByKey[kv.Key] = kv.Value;
+
+        // Confirmed resolutions: decisions we submitted whose request has now left a PROVIDED list.
         // This — not the send-ack — is the authoritative "the gateway accepted it" signal.
         var confirmed = new List<PairingApprovalResolution>();
         foreach (var sub in _submitted.Values)
-            if (!incomingByKey.ContainsKey(sub.Approval.Key))
+            if (KindProvided(sub.Approval.Kind) && !incomingByKey.ContainsKey(sub.Approval.Key))
                 confirmed.Add(new PairingApprovalResolution(sub.Approval, sub.Approved));
         foreach (var c in confirmed)
             _submitted.Remove(c.Approval.Key);
 
-        // Expire submissions the gateway hasn't acted on in time → drop suppression so they re-surface
-        // (a lost/rejected decision is retried instead of being hidden indefinitely).
+        // Expire submissions the gateway hasn't acted on in time (in a provided list) → drop
+        // suppression so they re-surface (a lost/rejected decision is retried, not hidden forever).
         var expired = _submitted
-            .Where(kv => incomingByKey.ContainsKey(kv.Key) && nowMs - kv.Value.SubmittedAtMs >= SubmissionResolveTimeoutMs)
+            .Where(kv => KindProvided(kv.Value.Approval.Kind)
+                && incomingByKey.ContainsKey(kv.Key)
+                && nowMs - kv.Value.SubmittedAtMs >= SubmissionResolveTimeoutMs)
             .Select(kv => kv.Key)
             .ToArray();
         foreach (var k in expired)
@@ -125,7 +141,7 @@ public sealed class PairingApprovalQueue
             .Where(key => !incomingByKey.ContainsKey(key))
             .ToArray();
 
-        // Swap in the new snapshot.
+        // Swap in the new snapshot (includes carried-forward entries for non-provided kinds).
         _current.Clear();
         foreach (var kvp in incomingByKey)
             _current[kvp.Key] = kvp.Value;
@@ -165,8 +181,7 @@ public sealed class PairingApprovalQueue
     private static List<PendingApproval> BuildIncoming(
         DevicePairingListInfo? devices,
         PairingListInfo? nodes,
-        string? ownNodeDeviceId,
-        bool deferNodeRequests)
+        IReadOnlyCollection<string>? ownNodeDeviceIds)
     {
         var list = new List<PendingApproval>();
 
@@ -180,13 +195,13 @@ public sealed class PairingApprovalQueue
             }
         }
 
-        if (!deferNodeRequests && nodes?.Pending is { Count: > 0 })
+        if (nodes?.Pending is { Count: > 0 })
         {
             foreach (var req in nodes.Pending)
             {
                 var approval = PendingApproval.FromNode(req);
                 if (!approval.IsActionable) continue;
-                if (IsOwnNode(approval, ownNodeDeviceId)) continue;
+                if (IsOwnNode(approval, ownNodeDeviceIds)) continue;
                 list.Add(approval);
             }
         }
@@ -194,8 +209,13 @@ public sealed class PairingApprovalQueue
         return list;
     }
 
-    private static bool IsOwnNode(PendingApproval approval, string? ownNodeDeviceId) =>
-        !string.IsNullOrWhiteSpace(ownNodeDeviceId)
-        && !string.IsNullOrEmpty(approval.DeviceId)
-        && approval.DeviceId.Equals(ownNodeDeviceId, StringComparison.OrdinalIgnoreCase);
+    private static bool IsOwnNode(PendingApproval approval, IReadOnlyCollection<string>? ownNodeDeviceIds)
+    {
+        if (ownNodeDeviceIds is null || ownNodeDeviceIds.Count == 0) return false;
+        if (string.IsNullOrEmpty(approval.DeviceId)) return false;
+        foreach (var id in ownNodeDeviceIds)
+            if (!string.IsNullOrWhiteSpace(id) && approval.DeviceId.Equals(id, StringComparison.OrdinalIgnoreCase))
+                return true;
+        return false;
+    }
 }

--- a/src/OpenClaw.Connection/PairingApprovalQueue.cs
+++ b/src/OpenClaw.Connection/PairingApprovalQueue.cs
@@ -34,7 +34,7 @@ public sealed class PairingApprovalDelta
 /// device/node pair-list snapshots (the gateway re-sends the full list on every
 /// <c>*.pair.requested</c>/<c>*.pair.resolved</c> event) into add/resolve deltas the
 /// presentation layer can act on without re-prompting for requests it has already shown
-/// or already decided.
+/// or that are awaiting resolution of a submitted decision.
 ///
 /// Responsibilities:
 /// <list type="bullet">

--- a/src/OpenClaw.Connection/PairingApprovalQueue.cs
+++ b/src/OpenClaw.Connection/PairingApprovalQueue.cs
@@ -5,19 +5,28 @@ using OpenClaw.Shared;
 
 namespace OpenClaw.Connection;
 
+/// <summary>A pairing decision the gateway has now confirmed by removing it from the pending list.</summary>
+public sealed record PairingApprovalResolution(PendingApproval Approval, bool Approved);
+
 /// <summary>The result of reconciling a fresh pair-list snapshot against prior state.</summary>
 public sealed class PairingApprovalDelta
 {
-    /// <summary>Requests that are newly surfaced and prompt-worthy (not previously known, not already decided).</summary>
+    /// <summary>Requests that are newly surfaced and prompt-worthy (not previously known, not awaiting resolution).</summary>
     public IReadOnlyList<PendingApproval> Added { get; init; } = Array.Empty<PendingApproval>();
 
     /// <summary>Keys (<see cref="PendingApproval.Key"/>) that were present last time but have now left the list.</summary>
     public IReadOnlyList<string> ResolvedKeys { get; init; } = Array.Empty<string>();
 
-    /// <summary>All currently actionable pending approvals (excludes ones the local user already decided).</summary>
+    /// <summary>
+    /// Decisions the local user submitted that the gateway has now confirmed (the request left the
+    /// pending list). These — not the send-ack — are the source of truth for "approved/rejected".
+    /// </summary>
+    public IReadOnlyList<PairingApprovalResolution> ConfirmedDecisions { get; init; } = Array.Empty<PairingApprovalResolution>();
+
+    /// <summary>All currently actionable pending approvals (excludes ones awaiting resolution).</summary>
     public IReadOnlyList<PendingApproval> Current { get; init; } = Array.Empty<PendingApproval>();
 
-    public bool HasChanges => Added.Count > 0 || ResolvedKeys.Count > 0;
+    public bool HasChanges => Added.Count > 0 || ResolvedKeys.Count > 0 || ConfirmedDecisions.Count > 0;
 }
 
 /// <summary>
@@ -33,20 +42,28 @@ public sealed class PairingApprovalDelta
 ///   <item>Filter out the local node's own pairing request (handled by the auto-approve path)
 ///         so the operator is never prompted to approve their own machine.</item>
 ///   <item>Drop entries with no usable id and de-duplicate by <see cref="PendingApproval.Key"/>.</item>
-///   <item>Suppress re-prompting for a request the local user already approved/rejected until the
-///         gateway confirms by dropping it from the list.</item>
+///   <item>Treat a submitted approve/reject as <em>optimistic-pending</em> — suppress it from the
+///         actionable set, but only report it <see cref="PairingApprovalDelta.ConfirmedDecisions">
+///         confirmed</see> once the gateway actually drops it from the pending list. If the gateway
+///         never acts within <see cref="SubmissionResolveTimeoutMs"/>, re-surface the request so a
+///         lost decision is retried rather than hidden forever (and no false success is reported).</item>
 /// </list>
 /// Not thread-safe; the coordinator marshals all calls onto a single dispatcher thread.
 /// </summary>
 public sealed class PairingApprovalQueue
 {
+    /// <summary>How long a submitted-but-unresolved decision is suppressed before it is re-surfaced.</summary>
+    public const long SubmissionResolveTimeoutMs = 10_000;
+
     private readonly Dictionary<string, PendingApproval> _current = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _decided = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Submission> _submitted = new(StringComparer.Ordinal);
+
+    private readonly record struct Submission(PendingApproval Approval, bool Approved, long SubmittedAtMs);
 
     /// <summary>Snapshot of currently actionable approvals, oldest first.</summary>
     public IReadOnlyList<PendingApproval> Current =>
         _current.Values
-            .Where(a => !_decided.Contains(a.Key))
+            .Where(a => !_submitted.ContainsKey(a.Key))
             .OrderBy(a => a.Ts)
             .ThenBy(a => a.Key, StringComparer.Ordinal)
             .ToArray();
@@ -56,24 +73,51 @@ public sealed class PairingApprovalQueue
 
     /// <summary>
     /// Reconcile a fresh snapshot. <paramref name="ownNodeDeviceId"/>, when provided, filters out the
-    /// local Windows node's own pending node request so we don't prompt the user to approve themselves.
+    /// local Windows node's own pending node request. <paramref name="nowMs"/> is a monotonic timestamp
+    /// (e.g. <see cref="Environment.TickCount64"/>) used to expire stale submissions. When
+    /// <paramref name="deferNodeRequests"/> is true, node requests are excluded entirely (used while
+    /// the local node's own device id is not yet known, so we never prompt for our own machine).
     /// </summary>
     public PairingApprovalDelta Reconcile(
         DevicePairingListInfo? devices,
         PairingListInfo? nodes,
-        string? ownNodeDeviceId = null)
+        string? ownNodeDeviceId = null,
+        long nowMs = 0,
+        bool deferNodeRequests = false)
     {
-        var incoming = BuildIncoming(devices, nodes, ownNodeDeviceId);
+        var incoming = BuildIncoming(devices, nodes, ownNodeDeviceId, deferNodeRequests);
         var incomingByKey = new Dictionary<string, PendingApproval>(StringComparer.Ordinal);
         foreach (var item in incoming)
             incomingByKey[item.Key] = item; // last wins on duplicate ids
 
+        // Confirmed resolutions: decisions we submitted whose request has now left the pending list.
+        // This — not the send-ack — is the authoritative "the gateway accepted it" signal.
+        var confirmed = new List<PairingApprovalResolution>();
+        foreach (var sub in _submitted.Values)
+            if (!incomingByKey.ContainsKey(sub.Approval.Key))
+                confirmed.Add(new PairingApprovalResolution(sub.Approval, sub.Approved));
+        foreach (var c in confirmed)
+            _submitted.Remove(c.Approval.Key);
+
+        // Expire submissions the gateway hasn't acted on in time → drop suppression so they re-surface
+        // (a lost/rejected decision is retried instead of being hidden indefinitely).
+        var expired = _submitted
+            .Where(kv => incomingByKey.ContainsKey(kv.Key) && nowMs - kv.Value.SubmittedAtMs >= SubmissionResolveTimeoutMs)
+            .Select(kv => kv.Key)
+            .ToArray();
+        foreach (var k in expired)
+            _submitted.Remove(k);
+        var expiredSet = new HashSet<string>(expired, StringComparer.Ordinal);
+
+        // Added: genuinely new requests, plus expired-and-re-surfaced ones. Skip anything still
+        // awaiting resolution.
         var added = new List<PendingApproval>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
         foreach (var item in incoming)
         {
-            if (_current.ContainsKey(item.Key)) continue; // already known
-            if (_decided.Contains(item.Key)) continue;    // user already acted; awaiting gateway drop
-            if (added.Any(a => a.Key == item.Key)) continue;
+            if (_submitted.ContainsKey(item.Key)) continue;                                   // awaiting resolution
+            if (_current.ContainsKey(item.Key) && !expiredSet.Contains(item.Key)) continue;   // already known
+            if (!seen.Add(item.Key)) continue;
             added.Add(item);
         }
 
@@ -86,43 +130,43 @@ public sealed class PairingApprovalQueue
         foreach (var kvp in incomingByKey)
             _current[kvp.Key] = kvp.Value;
 
-        // Forget decisions for requests that have now left the list — a future request that
-        // happens to reuse the id is a genuinely new prompt.
-        _decided.RemoveWhere(key => !incomingByKey.ContainsKey(key));
-
         return new PairingApprovalDelta
         {
             Added = added,
             ResolvedKeys = resolvedKeys,
+            ConfirmedDecisions = confirmed,
             Current = Current,
         };
     }
 
     /// <summary>
-    /// Mark a request as locally decided (approved/rejected) so it is not re-surfaced while the
-    /// gateway catches up and the same id is still echoed in the pending list.
+    /// Record that the local user submitted an approve/reject for a request. The request is suppressed
+    /// from the actionable set (so the UI advances) but remains tracked until the gateway confirms by
+    /// dropping it from the pending list, or until <see cref="SubmissionResolveTimeoutMs"/> elapses.
     /// </summary>
-    public void MarkDecided(string key)
+    public void MarkSubmitted(PendingApproval approval, bool approved, long nowMs)
     {
-        if (!string.IsNullOrEmpty(key))
-            _decided.Add(key);
+        if (approval is null || string.IsNullOrEmpty(approval.Key))
+            return;
+        _submitted[approval.Key] = new Submission(approval, approved, nowMs);
     }
 
-    /// <summary>Look up a currently-tracked approval by its key.</summary>
+    /// <summary>Look up a currently-actionable approval by its key (excludes ones awaiting resolution).</summary>
     public PendingApproval? Find(string key) =>
-        _current.TryGetValue(key, out var value) && !_decided.Contains(key) ? value : null;
+        !_submitted.ContainsKey(key) && _current.TryGetValue(key, out var value) ? value : null;
 
     /// <summary>Clears all state (e.g. on disconnect / gateway switch).</summary>
     public void Reset()
     {
         _current.Clear();
-        _decided.Clear();
+        _submitted.Clear();
     }
 
     private static List<PendingApproval> BuildIncoming(
         DevicePairingListInfo? devices,
         PairingListInfo? nodes,
-        string? ownNodeDeviceId)
+        string? ownNodeDeviceId,
+        bool deferNodeRequests)
     {
         var list = new List<PendingApproval>();
 
@@ -136,7 +180,7 @@ public sealed class PairingApprovalQueue
             }
         }
 
-        if (nodes?.Pending is { Count: > 0 })
+        if (!deferNodeRequests && nodes?.Pending is { Count: > 0 })
         {
             foreach (var req in nodes.Pending)
             {

--- a/src/OpenClaw.Connection/PairingApprovalQueue.cs
+++ b/src/OpenClaw.Connection/PairingApprovalQueue.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenClaw.Shared;
+
+namespace OpenClaw.Connection;
+
+/// <summary>The result of reconciling a fresh pair-list snapshot against prior state.</summary>
+public sealed class PairingApprovalDelta
+{
+    /// <summary>Requests that are newly surfaced and prompt-worthy (not previously known, not already decided).</summary>
+    public IReadOnlyList<PendingApproval> Added { get; init; } = Array.Empty<PendingApproval>();
+
+    /// <summary>Keys (<see cref="PendingApproval.Key"/>) that were present last time but have now left the list.</summary>
+    public IReadOnlyList<string> ResolvedKeys { get; init; } = Array.Empty<string>();
+
+    /// <summary>All currently actionable pending approvals (excludes ones the local user already decided).</summary>
+    public IReadOnlyList<PendingApproval> Current { get; init; } = Array.Empty<PendingApproval>();
+
+    public bool HasChanges => Added.Count > 0 || ResolvedKeys.Count > 0;
+}
+
+/// <summary>
+/// Pure, UI-agnostic diff engine for inbound pairing approvals. Translates successive
+/// device/node pair-list snapshots (the gateway re-sends the full list on every
+/// <c>*.pair.requested</c>/<c>*.pair.resolved</c> event) into add/resolve deltas the
+/// presentation layer can act on without re-prompting for requests it has already shown
+/// or already decided.
+///
+/// Responsibilities:
+/// <list type="bullet">
+///   <item>Merge device + node pending lists into a single ordered queue (oldest first).</item>
+///   <item>Filter out the local node's own pairing request (handled by the auto-approve path)
+///         so the operator is never prompted to approve their own machine.</item>
+///   <item>Drop entries with no usable id and de-duplicate by <see cref="PendingApproval.Key"/>.</item>
+///   <item>Suppress re-prompting for a request the local user already approved/rejected until the
+///         gateway confirms by dropping it from the list.</item>
+/// </list>
+/// Not thread-safe; the coordinator marshals all calls onto a single dispatcher thread.
+/// </summary>
+public sealed class PairingApprovalQueue
+{
+    private readonly Dictionary<string, PendingApproval> _current = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _decided = new(StringComparer.Ordinal);
+
+    /// <summary>Snapshot of currently actionable approvals, oldest first.</summary>
+    public IReadOnlyList<PendingApproval> Current =>
+        _current.Values
+            .Where(a => !_decided.Contains(a.Key))
+            .OrderBy(a => a.Ts)
+            .ThenBy(a => a.Key, StringComparer.Ordinal)
+            .ToArray();
+
+    /// <summary>True when there are no actionable approvals.</summary>
+    public bool IsEmpty => Current.Count == 0;
+
+    /// <summary>
+    /// Reconcile a fresh snapshot. <paramref name="ownNodeDeviceId"/>, when provided, filters out the
+    /// local Windows node's own pending node request so we don't prompt the user to approve themselves.
+    /// </summary>
+    public PairingApprovalDelta Reconcile(
+        DevicePairingListInfo? devices,
+        PairingListInfo? nodes,
+        string? ownNodeDeviceId = null)
+    {
+        var incoming = BuildIncoming(devices, nodes, ownNodeDeviceId);
+        var incomingByKey = new Dictionary<string, PendingApproval>(StringComparer.Ordinal);
+        foreach (var item in incoming)
+            incomingByKey[item.Key] = item; // last wins on duplicate ids
+
+        var added = new List<PendingApproval>();
+        foreach (var item in incoming)
+        {
+            if (_current.ContainsKey(item.Key)) continue; // already known
+            if (_decided.Contains(item.Key)) continue;    // user already acted; awaiting gateway drop
+            if (added.Any(a => a.Key == item.Key)) continue;
+            added.Add(item);
+        }
+
+        var resolvedKeys = _current.Keys
+            .Where(key => !incomingByKey.ContainsKey(key))
+            .ToArray();
+
+        // Swap in the new snapshot.
+        _current.Clear();
+        foreach (var kvp in incomingByKey)
+            _current[kvp.Key] = kvp.Value;
+
+        // Forget decisions for requests that have now left the list — a future request that
+        // happens to reuse the id is a genuinely new prompt.
+        _decided.RemoveWhere(key => !incomingByKey.ContainsKey(key));
+
+        return new PairingApprovalDelta
+        {
+            Added = added,
+            ResolvedKeys = resolvedKeys,
+            Current = Current,
+        };
+    }
+
+    /// <summary>
+    /// Mark a request as locally decided (approved/rejected) so it is not re-surfaced while the
+    /// gateway catches up and the same id is still echoed in the pending list.
+    /// </summary>
+    public void MarkDecided(string key)
+    {
+        if (!string.IsNullOrEmpty(key))
+            _decided.Add(key);
+    }
+
+    /// <summary>Look up a currently-tracked approval by its key.</summary>
+    public PendingApproval? Find(string key) =>
+        _current.TryGetValue(key, out var value) && !_decided.Contains(key) ? value : null;
+
+    /// <summary>Clears all state (e.g. on disconnect / gateway switch).</summary>
+    public void Reset()
+    {
+        _current.Clear();
+        _decided.Clear();
+    }
+
+    private static List<PendingApproval> BuildIncoming(
+        DevicePairingListInfo? devices,
+        PairingListInfo? nodes,
+        string? ownNodeDeviceId)
+    {
+        var list = new List<PendingApproval>();
+
+        if (devices?.Pending is { Count: > 0 })
+        {
+            foreach (var req in devices.Pending)
+            {
+                var approval = PendingApproval.FromDevice(req);
+                if (approval.IsActionable)
+                    list.Add(approval);
+            }
+        }
+
+        if (nodes?.Pending is { Count: > 0 })
+        {
+            foreach (var req in nodes.Pending)
+            {
+                var approval = PendingApproval.FromNode(req);
+                if (!approval.IsActionable) continue;
+                if (IsOwnNode(approval, ownNodeDeviceId)) continue;
+                list.Add(approval);
+            }
+        }
+
+        return list;
+    }
+
+    private static bool IsOwnNode(PendingApproval approval, string? ownNodeDeviceId) =>
+        !string.IsNullOrWhiteSpace(ownNodeDeviceId)
+        && !string.IsNullOrEmpty(approval.DeviceId)
+        && approval.DeviceId.Equals(ownNodeDeviceId, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/OpenClaw.Connection/PairingScopeDescriptions.cs
+++ b/src/OpenClaw.Connection/PairingScopeDescriptions.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenClaw.Connection;
+
+/// <summary>
+/// Maps gateway operator scope identifiers to short, human-readable descriptions so a person
+/// approving a pairing request understands what access they are granting — mirroring the
+/// friendly scope list shown by the macOS pairing prompt.
+///
+/// Returns canonical English fallbacks; the presentation layer may override any entry with a
+/// localized resource keyed by scope before falling back to <see cref="Describe"/>.
+/// </summary>
+public static class PairingScopeDescriptions
+{
+    private static readonly IReadOnlyDictionary<string, string> Map =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["operator.admin"] = "Admin access",
+            ["operator.read"] = "Read OpenClaw data",
+            ["operator.write"] = "Send messages and make changes",
+            ["operator.approvals"] = "Manage approvals",
+            ["operator.pairing"] = "Pair and repair devices",
+            ["operator.talk.secrets"] = "Use Talk credentials",
+        };
+
+    /// <summary>True when a friendly description exists for the scope; false for unknown scopes.</summary>
+    public static bool IsKnown(string scope) =>
+        !string.IsNullOrWhiteSpace(scope) && Map.ContainsKey(scope.Trim());
+
+    /// <summary>
+    /// Returns a friendly description for a scope, or the raw scope string (trimmed) when unknown
+    /// so the approver still sees exactly what was requested rather than nothing.
+    /// </summary>
+    public static string Describe(string scope)
+    {
+        if (string.IsNullOrWhiteSpace(scope)) return string.Empty;
+        var trimmed = scope.Trim();
+        return Map.TryGetValue(trimmed, out var friendly) ? friendly : trimmed;
+    }
+
+    /// <summary>Describes a set of scopes, dropping blanks and de-duplicating while preserving order.</summary>
+    public static IReadOnlyList<string> DescribeAll(IEnumerable<string>? scopes)
+    {
+        if (scopes == null) return Array.Empty<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = new List<string>();
+        foreach (var scope in scopes)
+        {
+            if (string.IsNullOrWhiteSpace(scope)) continue;
+            if (!seen.Add(scope.Trim())) continue;
+            result.Add(Describe(scope));
+        }
+        return result;
+    }
+}

--- a/src/OpenClaw.Connection/PendingApproval.cs
+++ b/src/OpenClaw.Connection/PendingApproval.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenClaw.Shared;
+
+namespace OpenClaw.Connection;
+
+/// <summary>Whether a pending pairing approval is for a device (operator-class client) or a node.</summary>
+public enum PairingApprovalKind
+{
+    Device,
+    Node,
+}
+
+/// <summary>
+/// Unified, UI-agnostic view of a single inbound pairing request that a local operator
+/// (with <c>operator.pairing</c>/<c>operator.admin</c> scope) can approve or reject.
+/// Built from either a <see cref="DevicePairingRequest"/> or a node <see cref="PairingRequest"/>
+/// so the presentation layer can render and act on both kinds uniformly.
+/// </summary>
+public sealed class PendingApproval
+{
+    public PairingApprovalKind Kind { get; init; }
+
+    /// <summary>Gateway request id used to approve/reject. May be empty on legacy gateways.</summary>
+    public string RequestId { get; init; } = "";
+
+    /// <summary>Device id (device requests) or node id (node requests).</summary>
+    public string DeviceId { get; init; } = "";
+
+    public string? DisplayName { get; init; }
+    public string? Platform { get; init; }
+    public string? Role { get; init; }
+
+    /// <summary>Requested operator scopes (device requests only; empty for nodes).</summary>
+    public IReadOnlyList<string> Scopes { get; init; } = Array.Empty<string>();
+
+    public string? RemoteIp { get; init; }
+    public string? Version { get; init; }
+    public bool IsRepair { get; init; }
+    public double Ts { get; init; }
+
+    /// <summary>
+    /// The id passed to the gateway approve/reject RPC. Prefers <see cref="RequestId"/> and
+    /// falls back to <see cref="DeviceId"/> so legacy gateways that omit a request id are still
+    /// actionable (mirrors the per-row fallback already used by the Connection page cards).
+    /// </summary>
+    public string DecisionId => string.IsNullOrEmpty(RequestId) ? DeviceId : RequestId;
+
+    /// <summary>Stable identity for dedup/diffing across list refreshes.</summary>
+    public string Key => $"{Kind}:{DecisionId}";
+
+    /// <summary>True when the request carries no usable id and therefore cannot be acted on.</summary>
+    public bool IsActionable => !string.IsNullOrEmpty(DecisionId);
+
+    public static PendingApproval FromDevice(DevicePairingRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return new PendingApproval
+        {
+            Kind = PairingApprovalKind.Device,
+            RequestId = request.RequestId,
+            DeviceId = request.DeviceId,
+            DisplayName = request.DisplayName,
+            Platform = request.Platform,
+            Role = string.IsNullOrWhiteSpace(request.Role) ? "operator" : request.Role,
+            Scopes = request.Scopes is { Length: > 0 }
+                ? request.Scopes.Where(s => !string.IsNullOrWhiteSpace(s)).ToArray()
+                : Array.Empty<string>(),
+            RemoteIp = NormalizeIp(request.RemoteIp),
+            IsRepair = request.IsRepair,
+            Ts = request.Ts,
+        };
+    }
+
+    public static PendingApproval FromNode(PairingRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return new PendingApproval
+        {
+            Kind = PairingApprovalKind.Node,
+            RequestId = request.RequestId,
+            DeviceId = request.NodeId,
+            DisplayName = request.DisplayName,
+            Platform = request.Platform,
+            Role = "node",
+            Scopes = Array.Empty<string>(),
+            RemoteIp = NormalizeIp(request.RemoteIp),
+            Version = request.Version,
+            IsRepair = request.IsRepair,
+            Ts = request.Ts,
+        };
+    }
+
+    /// <summary>Strips the IPv4-mapped IPv6 prefix the gateway sometimes emits (mirrors the Mac client).</summary>
+    private static string? NormalizeIp(string? ip)
+    {
+        if (string.IsNullOrWhiteSpace(ip)) return ip;
+        const string mappedPrefix = "::ffff:";
+        return ip.StartsWith(mappedPrefix, StringComparison.OrdinalIgnoreCase)
+            ? ip[mappedPrefix.Length..]
+            : ip;
+    }
+}

--- a/src/OpenClaw.Shared/SettingsData.cs
+++ b/src/OpenClaw.Shared/SettingsData.cs
@@ -32,6 +32,12 @@ public record class SettingsData
     public bool NotifyBuild { get; set; } = true;
     public bool NotifyStock { get; set; } = true;
     public bool NotifyInfo { get; set; } = true;
+    /// <summary>
+    /// When true (default), inbound device/node pairing requests are surfaced as a focused
+    /// approval dialog plus an awareness toast. When false they appear only in the Connections
+    /// page "Pending approvals" banner (passive). Auto-approval of the local node is unaffected.
+    /// </summary>
+    public bool ShowPairingApprovalDialog { get; set; } = true;
     public bool EnableNodeMode { get; set; } = false;
     public bool NodeCanvasEnabled { get; set; } = true;
     public bool NodeScreenEnabled { get; set; } = true;

--- a/src/OpenClaw.Tray.WinUI/App.ToastActivation.cs
+++ b/src/OpenClaw.Tray.WinUI/App.ToastActivation.cs
@@ -32,7 +32,8 @@ public partial class App
                     _toastService!.ShowToast(new ToastContentBuilder()
                         .AddText(LocalizationHelper.GetString("Toast_PairingCommandCopied"))
                         .AddText(command));
-                }
+                },
+                ReviewPairing = ShowPairingApprovalDialog,
             }));
     }
 

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -138,6 +138,9 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private AppState? _appState;
     internal AppState? AppState => _appState;
     private GatewayService? _gatewayService;
+    private PairingApprovalCoordinator? _pairingApprovalCoordinator;
+    private OpenClawTray.Dialogs.PairingApprovalDialog? _pairingApprovalDialog;
+    private Microsoft.UI.Dispatching.DispatcherQueueTimer? _pairingApprovalPollTimer;
     private CancellationTokenSource? _deepLinkCts;
     private bool _isExiting;
     
@@ -431,6 +434,28 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
         _diagnosticsClipboard = new DiagnosticsClipboardService(BuildCommandCenterState);
         _toastService = new ToastService(() => _settings);
+
+        // Inbound pairing approvals: surface a focused dialog + awareness toast when another
+        // device/node requests pairing (Mac-parity). Getters are lazy so this can be created
+        // before the connection manager / node service exist.
+        _pairingApprovalCoordinator = new PairingApprovalCoordinator(
+            getClient: () => _connectionManager?.OperatorClient,
+            getOwnNodeDeviceId: () => _nodeService?.FullDeviceId,
+            isPromptEnabled: () => _settings?.ShowPairingApprovalDialog ?? true,
+            logger: new AppLogger());
+        _pairingApprovalCoordinator.ApprovalRequested += OnPairingApprovalRequested;
+        _pairingApprovalCoordinator.DecisionCompleted += OnPairingDecisionCompleted;
+        _gatewayService.PairListsChanged += OnPairListsChanged;
+
+        // Safety-net poll: the gateway broadcasts pair requests with dropIfSlow=true, so a busy
+        // socket can silently drop a "device wants to connect" event and the operator would never
+        // be prompted. A periodic reconcile recovers any missed request. RefreshFromGatewayAsync
+        // no-ops unless connected with approval scope, so this is idle-cheap.
+        _pairingApprovalPollTimer = _dispatcherQueue!.CreateTimer();
+        _pairingApprovalPollTimer.Interval = TimeSpan.FromSeconds(20);
+        _pairingApprovalPollTimer.IsRepeating = true;
+        _pairingApprovalPollTimer.Tick += (_, _) => _ = _pairingApprovalCoordinator?.RefreshFromGatewayAsync();
+        _pairingApprovalPollTimer.Start();
 
         DiagnosticsJsonlService.Write("app.start", new
         {
@@ -1643,6 +1668,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         else
         {
             _chatCoordinator?.SetOperatorClient(null);
+            _pairingApprovalCoordinator?.Reset();
         }
 
         RaiseChatProviderChanged();
@@ -2185,7 +2211,13 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private void OnPairingStatusChanged(object? sender, OpenClaw.Shared.PairingStatusEventArgs args)
     {
         Logger.Info($"Pairing status: {args.Status}");
-        
+
+        // The local node's own device id may have just become known. Re-run the
+        // approval reconcile so the own-node filter drops any self pairing request
+        // rather than prompting the operator to approve their own machine.
+        OnUiThread(() => _pairingApprovalCoordinator?.OnPairListsUpdated(
+            _appState?.DevicePairList, _appState?.NodePairList));
+
         try
         {
             if (args.Status == OpenClaw.Shared.PairingStatus.Pending)
@@ -2912,6 +2944,84 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             _gatewayRegistry,
             _connectionManager);
         _connectionStatusWindow.Activate();
+    }
+
+    // ─── Inbound pairing approvals ───────────────────────────────────────
+
+    /// <summary>Feeds fresh device/node pending pair-lists into the approval coordinator.</summary>
+    private void OnPairListsChanged(object? sender, EventArgs e)
+    {
+        _pairingApprovalCoordinator?.OnPairListsUpdated(_appState?.DevicePairList, _appState?.NodePairList);
+    }
+
+    /// <summary>A new inbound pairing request arrived — present the focused dialog and an awareness toast.</summary>
+    private void OnPairingApprovalRequested(object? sender, PendingApproval approval)
+    {
+        OnUiThread(() =>
+        {
+            ShowPairingApprovalDialog();
+
+            var name = string.IsNullOrWhiteSpace(approval.DisplayName)
+                ? approval.DeviceId
+                : approval.DisplayName!;
+            AddRecentActivity(
+                LocalizationHelper.GetString("Toast_PairingRequestTitle"),
+                category: "pairing",
+                dashboardPath: "connection",
+                details: name);
+
+            var bodyKey = approval.Kind == PairingApprovalKind.Node
+                ? "Toast_PairingRequestBodyNode"
+                : "Toast_PairingRequestBody";
+            _toastService?.ShowToast(new ToastContentBuilder()
+                .AddText(LocalizationHelper.GetString("Toast_PairingRequestTitle"))
+                .AddText(string.Format(LocalizationHelper.GetString(bodyKey), name))
+                .AddButton(new ToastButton()
+                    .SetContent(LocalizationHelper.GetString("Toast_PairingReview"))
+                    .AddArgument("action", "review_pairing")),
+                "pairing-request",
+                approval.DecisionId);
+        });
+    }
+
+    /// <summary>After a decision succeeds, confirm with a toast + activity entry.</summary>
+    private void OnPairingDecisionCompleted(object? sender, PairingDecisionResult result)
+    {
+        if (!result.Success) return; // failures are retried in the dialog
+        OnUiThread(() =>
+        {
+            var name = string.IsNullOrWhiteSpace(result.Approval.DisplayName)
+                ? result.Approval.DeviceId
+                : result.Approval.DisplayName!;
+            var titleKey = result.Approved ? "Toast_PairingApprovedTitle" : "Toast_PairingRejectedTitle";
+            var bodyKey = result.Approved ? "Toast_PairingApprovedBody" : "Toast_PairingRejectedBody";
+            AddRecentActivity(
+                LocalizationHelper.GetString(titleKey),
+                category: "pairing",
+                dashboardPath: "connection",
+                details: name);
+            _toastService?.ShowToast(new ToastContentBuilder()
+                .AddText(LocalizationHelper.GetString(titleKey))
+                .AddText(string.Format(LocalizationHelper.GetString(bodyKey), name)),
+                "pairing-decided",
+                result.Approval.DecisionId);
+        });
+    }
+
+    /// <summary>Opens (or re-focuses) the inbound pairing approval dialog when there is something to decide.</summary>
+    private void ShowPairingApprovalDialog()
+    {
+        if (_pairingApprovalCoordinator == null) return;
+        if (_pairingApprovalCoordinator.Current.Count == 0) return;
+
+        if (_pairingApprovalDialog is { IsClosed: false } existing)
+        {
+            existing.ShowForeground();
+            return;
+        }
+
+        _pairingApprovalDialog = new OpenClawTray.Dialogs.PairingApprovalDialog(_pairingApprovalCoordinator);
+        _pairingApprovalDialog.ShowForeground();
     }
 
     private void RestartSshTunnel()
@@ -4162,6 +4272,14 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         {
             _sshTunnelService?.Dispose();
             _sshTunnelService = null;
+        });
+
+        SafeShutdownStep("pairing approval", () =>
+        {
+            _pairingApprovalPollTimer?.Stop();
+            _pairingApprovalPollTimer = null;
+            _pairingApprovalDialog?.Close();
+            _pairingApprovalDialog = null;
         });
 
         // Close windows explicitly for deterministic shutdown tracing.

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3004,10 +3004,10 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         });
     }
 
-    /// <summary>After a decision succeeds, confirm with a toast + activity entry.</summary>
+    /// <summary>After a decision is confirmed by the gateway, surface a confirmation toast + activity entry.</summary>
     private void OnPairingDecisionCompleted(object? sender, PairingDecisionResult result)
     {
-        if (!result.Success) return; // failures are retried in the dialog
+        if (!result.Success) return; // defensive — the coordinator only raises this for confirmed decisions
         OnUiThread(() =>
         {
             var name = string.IsNullOrWhiteSpace(result.Approval.DisplayName)

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -441,6 +441,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         _pairingApprovalCoordinator = new PairingApprovalCoordinator(
             getClient: () => _connectionManager?.OperatorClient,
             getOwnNodeDeviceId: () => _nodeService?.FullDeviceId,
+            isLocalNodeActive: () => _settings?.EnableNodeMode == true,
             isPromptEnabled: () => _settings?.ShowPairingApprovalDialog ?? true,
             logger: new AppLogger());
         _pairingApprovalCoordinator.ApprovalRequested += OnPairingApprovalRequested;
@@ -2959,7 +2960,11 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     {
         OnUiThread(() =>
         {
-            ShowPairingApprovalDialog();
+            // Only steal foreground when the dialog isn't already open. On a reconnect burst the
+            // gateway re-pushes every pending request at once; the first opens + foregrounds the
+            // dialog, the rest just enqueue into it without repeated focus-stealing.
+            var alreadyOpen = _pairingApprovalDialog is { IsClosed: false };
+            ShowPairingApprovalDialog(bringToFront: !alreadyOpen);
 
             var name = string.IsNullOrWhiteSpace(approval.DisplayName)
                 ? approval.DeviceId
@@ -3009,14 +3014,16 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     }
 
     /// <summary>Opens (or re-focuses) the inbound pairing approval dialog when there is something to decide.</summary>
-    private void ShowPairingApprovalDialog()
+    private void ShowPairingApprovalDialog() => ShowPairingApprovalDialog(bringToFront: true);
+
+    private void ShowPairingApprovalDialog(bool bringToFront)
     {
         if (_pairingApprovalCoordinator == null) return;
         if (_pairingApprovalCoordinator.Current.Count == 0) return;
 
         if (_pairingApprovalDialog is { IsClosed: false } existing)
         {
-            existing.ShowForeground();
+            if (bringToFront) existing.ShowForeground();
             return;
         }
 

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3034,7 +3034,11 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private void ShowPairingApprovalDialog(bool bringToFront)
     {
         if (_pairingApprovalCoordinator == null) return;
-        if (_pairingApprovalCoordinator.Current.Count == 0) return;
+        if (_pairingApprovalCoordinator.Current.Count == 0)
+        {
+            ShowStatusDetail();
+            return;
+        }
 
         if (_pairingApprovalDialog is { IsClosed: false } existing)
         {

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -440,8 +440,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         // before the connection manager / node service exist.
         _pairingApprovalCoordinator = new PairingApprovalCoordinator(
             getClient: () => _connectionManager?.OperatorClient,
-            getOwnNodeDeviceId: () => _nodeService?.FullDeviceId,
-            isLocalNodeActive: () => _settings?.EnableNodeMode == true,
+            getOwnNodeIds: BuildOwnNodeIds,
             isPromptEnabled: () => _settings?.ShowPairingApprovalDialog ?? true,
             logger: new AppLogger());
         _pairingApprovalCoordinator.ApprovalRequested += OnPairingApprovalRequested;
@@ -2953,6 +2952,22 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private void OnPairListsChanged(object? sender, EventArgs e)
     {
         _pairingApprovalCoordinator?.OnPairListsUpdated(_appState?.DevicePairList, _appState?.NodePairList);
+    }
+
+    /// <summary>
+    /// All identifiers the local Windows node may be known by in the gateway's pending node list,
+    /// so the approval coordinator never prompts the operator to approve their own machine. The node
+    /// advertises itself as <c>NodeId ?? FullDeviceId</c>; we offer both so the own-node filter is
+    /// robust to either identifier space.
+    /// </summary>
+    private IReadOnlyCollection<string> BuildOwnNodeIds()
+    {
+        var ids = new List<string>(2);
+        var fullDeviceId = _nodeService?.FullDeviceId;
+        if (!string.IsNullOrWhiteSpace(fullDeviceId)) ids.Add(fullDeviceId);
+        var nodeId = _nodeService?.NodeId;
+        if (!string.IsNullOrWhiteSpace(nodeId) && !ids.Contains(nodeId)) ids.Add(nodeId);
+        return ids;
     }
 
     /// <summary>A new inbound pairing request arrived — present the focused dialog and an awareness toast.</summary>

--- a/src/OpenClaw.Tray.WinUI/Dialogs/PairingApprovalDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/PairingApprovalDialog.cs
@@ -200,12 +200,15 @@ public sealed class PairingApprovalDialog : WindowEx
 
     private void OnApprovalsChanged(object? sender, EventArgs e)
     {
+        if (IsClosed) return;
         if (DispatcherQueue.HasThreadAccess) Render();
         else DispatcherQueue.TryEnqueue(Render);
     }
 
     private void Render()
     {
+        if (IsClosed) return;
+
         var current = _coordinator.Current;
         if (current.Count == 0)
         {
@@ -391,32 +394,42 @@ public sealed class PairingApprovalDialog : WindowEx
     private async System.Threading.Tasks.Task DecideAsync(bool approve)
     {
         if (_busy || _currentKey == null) return;
+        var decisionKey = _currentKey;
         _busy = true;
         _approveButton.IsEnabled = false;
         _rejectButton.IsEnabled = false;
         _laterButton.IsEnabled = false;
+
+        bool ok;
         try
         {
             // Success drives a coordinator ApprovalsChanged -> Render() which advances or closes.
-            var ok = approve
-                ? await _coordinator.ApproveAsync(_currentKey)
-                : await _coordinator.RejectAsync(_currentKey);
-            if (!ok)
-            {
-                // Re-enable so the user can retry; keep the approve guard satisfied (already shown a while).
-                _busy = false;
-                _approveButton.IsEnabled = true;
-                _rejectButton.IsEnabled = true;
-                _laterButton.IsEnabled = true;
-            }
+            ok = approve
+                ? await _coordinator.ApproveAsync(decisionKey)
+                : await _coordinator.RejectAsync(decisionKey);
         }
         catch
         {
+            ok = false;
+        }
+
+        // The window may have closed (disconnect -> Reset -> Close) or the queue may have advanced
+        // to a different request while the RPC was in flight. Only touch UI if we're still on a live
+        // window showing the same request — otherwise this stale continuation must not mutate state.
+        if (IsClosed || !string.Equals(_currentKey, decisionKey, StringComparison.Ordinal))
+            return;
+
+        if (!ok)
+        {
+            // Re-enable the secondary actions and RE-ARM the approve guard (don't force-enable
+            // Approve — that would defeat the anti-clickthrough delay on the retry).
             _busy = false;
-            _approveButton.IsEnabled = true;
             _rejectButton.IsEnabled = true;
             _laterButton.IsEnabled = true;
+            ArmApproveGuard();
         }
+        // On success, leave buttons disabled; the pending ApprovalsChanged -> Render() will advance
+        // to the next request (re-enabling) or close the dialog.
     }
 
     private void OnWindowClosed(object sender, WindowEventArgs args)

--- a/src/OpenClaw.Tray.WinUI/Dialogs/PairingApprovalDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/PairingApprovalDialog.cs
@@ -1,0 +1,451 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using OpenClaw.Connection;
+using OpenClawTray.Helpers;
+using OpenClawTray.Services;
+using System;
+using System.Runtime.InteropServices;
+using WinUIEx;
+
+namespace OpenClawTray.Dialogs;
+
+/// <summary>
+/// Focused approval surface for inbound pairing requests (devices / nodes asking to join the
+/// gateway). Presents one request at a time with full identity + the operator scopes being
+/// granted, mirroring the macOS pairing prompt. Acts on the live <see cref="PairingApprovalCoordinator"/>
+/// and advances through the queue as decisions are made or requests are resolved elsewhere.
+///
+/// Security posture: Approve is never the default-focused button and stays disabled for a short
+/// delay after a request appears so the dialog cannot be "click-through" approved by a stray
+/// keypress/click. Reject and "Decide later" are always available.
+/// </summary>
+public sealed class PairingApprovalDialog : WindowEx
+{
+    [DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+    private static readonly IntPtr HWND_TOPMOST = new(-1);
+    private static readonly IntPtr HWND_NOTOPMOST = new(-2);
+    private const uint SWP_NOMOVE = 0x0002;
+    private const uint SWP_NOSIZE = 0x0001;
+
+    private static readonly TimeSpan ApproveArmDelay = TimeSpan.FromMilliseconds(1500);
+
+    private readonly PairingApprovalCoordinator _coordinator;
+    private readonly StackPanel _bodyPanel;
+    private readonly TextBlock _headingText;
+    private readonly TextBlock _queueChip;
+    private readonly Button _approveButton;
+    private readonly Button _rejectButton;
+    private readonly Button _laterButton;
+
+    private DispatcherTimer? _armTimer;
+    private string? _currentKey;
+    private bool _busy;
+
+    public bool IsClosed { get; private set; }
+
+    public PairingApprovalDialog(PairingApprovalCoordinator coordinator)
+    {
+        _coordinator = coordinator ?? throw new ArgumentNullException(nameof(coordinator));
+
+        Title = LocalizationHelper.GetString("PairingApproval_WindowTitle");
+        this.SetWindowSize(460, 460);
+        this.CenterOnScreen();
+        this.SetIcon("Assets\\openclaw.ico");
+        SystemBackdrop = new MicaBackdrop();
+        ExtendsContentIntoTitleBar = true;
+
+        // ── Custom title bar ──
+        var titleBar = new Grid { Height = 48, Padding = new Thickness(16, 0, 140, 0) };
+        titleBar.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        titleBar.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        var titleIcon = new TextBlock { Text = "🦞", FontSize = 16, VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(0, 0, 8, 0) };
+        Grid.SetColumn(titleIcon, 0);
+        titleBar.Children.Add(titleIcon);
+        var titleText = new TextBlock
+        {
+            Text = LocalizationHelper.GetString("PairingApproval_WindowTitle"),
+            FontSize = 13,
+            VerticalAlignment = VerticalAlignment.Center,
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+        };
+        Grid.SetColumn(titleText, 1);
+        titleBar.Children.Add(titleText);
+        SetTitleBar(titleBar);
+
+        // ── Layout: [title][header][scrollable body][buttons] ──
+        var outerGrid = new Grid();
+        outerGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(48) });
+        outerGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+        Grid.SetRow(titleBar, 0);
+        outerGrid.Children.Add(titleBar);
+
+        var root = new Grid { Padding = new Thickness(28, 8, 28, 24), RowSpacing = 14 };
+        root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto }); // header
+        root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }); // body
+        root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto }); // buttons
+
+        // Header: shield glyph + heading + queue chip
+        var header = new Grid { ColumnSpacing = 12 };
+        header.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        header.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        header.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var shield = new FontIcon
+        {
+            Glyph = "\uE72E", // shield
+            FontSize = 28,
+            Foreground = ResolveBrush("SystemFillColorCautionBrush"),
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        Grid.SetColumn(shield, 0);
+        header.Children.Add(shield);
+
+        _headingText = new TextBlock
+        {
+            Style = (Style)Application.Current.Resources["SubtitleTextBlockStyle"],
+            VerticalAlignment = VerticalAlignment.Center,
+            TextWrapping = TextWrapping.Wrap,
+        };
+        Grid.SetColumn(_headingText, 1);
+        header.Children.Add(_headingText);
+
+        _queueChip = new TextBlock
+        {
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            Foreground = ResolveBrush("TextFillColorSecondaryBrush"),
+            VerticalAlignment = VerticalAlignment.Center,
+            Visibility = Visibility.Collapsed,
+        };
+        Grid.SetColumn(_queueChip, 2);
+        header.Children.Add(_queueChip);
+
+        Grid.SetRow(header, 0);
+        root.Children.Add(header);
+
+        // Body (scrollable detail card)
+        _bodyPanel = new StackPanel { Spacing = 12 };
+        var scroll = new ScrollViewer
+        {
+            Content = _bodyPanel,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+        };
+        Grid.SetRow(scroll, 1);
+        root.Children.Add(scroll);
+
+        // Buttons: [Reject] [Decide later] ............ [Approve]
+        var buttonGrid = new Grid { ColumnSpacing = 8 };
+        buttonGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        buttonGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        buttonGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        buttonGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        _rejectButton = new Button { Content = BuildButtonContent("\uE711", "SystemFillColorCriticalBrush", LocalizationHelper.GetString("PairingApproval_Reject")) };
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(_rejectButton, "PairingRejectAction");
+        _rejectButton.Click += async (_, _) => await DecideAsync(approve: false);
+        Grid.SetColumn(_rejectButton, 0);
+        buttonGrid.Children.Add(_rejectButton);
+
+        _laterButton = new Button { Content = LocalizationHelper.GetString("PairingApproval_Later") };
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(_laterButton, "PairingLaterAction");
+        _laterButton.Click += (_, _) => Close(); // dismiss without deciding; request stays pending
+        Grid.SetColumn(_laterButton, 1);
+        buttonGrid.Children.Add(_laterButton);
+
+        _approveButton = new Button
+        {
+            Content = BuildButtonContent("\uE73E", null, LocalizationHelper.GetString("PairingApproval_Approve")),
+            Style = (Style)Application.Current.Resources["AccentButtonStyle"],
+        };
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(_approveButton, "PairingApproveAction");
+        _approveButton.Click += async (_, _) => await DecideAsync(approve: true);
+        Grid.SetColumn(_approveButton, 3);
+        buttonGrid.Children.Add(_approveButton);
+
+        Grid.SetRow(buttonGrid, 2);
+        root.Children.Add(buttonGrid);
+
+        Grid.SetRow(root, 1);
+        outerGrid.Children.Add(root);
+        Content = outerGrid;
+
+        _coordinator.ApprovalsChanged += OnApprovalsChanged;
+        Closed += OnWindowClosed;
+
+        Render();
+    }
+
+    /// <summary>Activates the dialog and forces it to the foreground (it may open from a background event).</summary>
+    public void ShowForeground()
+    {
+        Activate();
+        try
+        {
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            if (hwnd != IntPtr.Zero)
+            {
+                SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+                SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+                SetForegroundWindow(hwnd);
+            }
+        }
+        catch { /* best-effort */ }
+    }
+
+    private void OnApprovalsChanged(object? sender, EventArgs e)
+    {
+        if (DispatcherQueue.HasThreadAccess) Render();
+        else DispatcherQueue.TryEnqueue(Render);
+    }
+
+    private void Render()
+    {
+        var current = _coordinator.Current;
+        if (current.Count == 0)
+        {
+            // Nothing left to decide — close.
+            Close();
+            return;
+        }
+
+        var approval = current[0];
+        var keyChanged = !string.Equals(_currentKey, approval.Key, StringComparison.Ordinal);
+
+        // The queue chip always reflects the latest count, even when the
+        // front-of-queue request is unchanged.
+        if (current.Count > 1)
+        {
+            _queueChip.Text = string.Format(LocalizationHelper.GetString("PairingApproval_MoreWaiting"), current.Count - 1);
+            _queueChip.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            _queueChip.Visibility = Visibility.Collapsed;
+        }
+
+        // If the request at the front of the queue hasn't changed (an unrelated
+        // list refresh arrived), do NOT rebuild the card, reset the in-flight
+        // decision guard, or re-arm the approve delay — that would let a second
+        // click through while a decision is still in flight for this same request.
+        if (!keyChanged)
+            return;
+
+        _currentKey = approval.Key;
+        _headingText.Text = LocalizationHelper.GetString(
+            approval.Kind == PairingApprovalKind.Node ? "PairingApproval_NodeHeading" : "PairingApproval_DeviceHeading");
+
+        // Kind-aware approve label ("Approve device" / "Approve node") to reinforce intent.
+        _approveButton.Content = BuildButtonContent(
+            "\uE73E",
+            null,
+            LocalizationHelper.GetString(approval.Kind == PairingApprovalKind.Node
+                ? "PairingApproval_ApproveNode"
+                : "PairingApproval_ApproveDevice"));
+
+        _bodyPanel.Children.Clear();
+        _bodyPanel.Children.Add(BuildDetailCard(approval));
+
+        // Fresh request — reset interaction state and re-arm the approve guard.
+        _busy = false;
+        _rejectButton.IsEnabled = true;
+        _laterButton.IsEnabled = true;
+        ArmApproveGuard();
+    }
+
+    private Border BuildDetailCard(PendingApproval approval)
+    {
+        var card = new Border
+        {
+            Background = ResolveBrush("CardBackgroundFillColorDefaultBrush"),
+            BorderBrush = ResolveBrush("CardStrokeColorDefaultBrush"),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(8),
+            Padding = new Thickness(16),
+        };
+        var stack = new StackPanel { Spacing = 10 };
+
+        var name = string.IsNullOrWhiteSpace(approval.DisplayName)
+            ? (string.IsNullOrEmpty(approval.DeviceId)
+                ? LocalizationHelper.GetString("PairingApproval_UnknownDevice")
+                : approval.DeviceId)
+            : approval.DisplayName!;
+
+        stack.Children.Add(new TextBlock
+        {
+            Text = name,
+            Style = (Style)Application.Current.Resources["BodyStrongTextBlockStyle"],
+            TextWrapping = TextWrapping.Wrap,
+        });
+
+        var detailParts = new System.Collections.Generic.List<string>
+        {
+            string.IsNullOrWhiteSpace(approval.Platform)
+                ? LocalizationHelper.GetString("PairingApproval_UnknownPlatform")
+                : approval.Platform!,
+        };
+        if (!string.IsNullOrWhiteSpace(approval.Role)) detailParts.Add(approval.Role!);
+        if (!string.IsNullOrWhiteSpace(approval.Version)) detailParts.Add($"v{approval.Version}");
+        stack.Children.Add(new TextBlock
+        {
+            Text = string.Join("  ·  ", detailParts),
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            Foreground = ResolveBrush("TextFillColorSecondaryBrush"),
+            TextWrapping = TextWrapping.Wrap,
+        });
+
+        // Friendly scope list (device requests only).
+        if (approval.Scopes.Count > 0)
+        {
+            stack.Children.Add(new TextBlock
+            {
+                Text = LocalizationHelper.GetString("PairingApproval_AccessRequested"),
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                Foreground = ResolveBrush("TextFillColorSecondaryBrush"),
+                Margin = new Thickness(0, 4, 0, 0),
+            });
+            foreach (var label in PairingScopeDescriptions.DescribeAll(approval.Scopes))
+            {
+                var row = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+                row.Children.Add(new FontIcon
+                {
+                    Glyph = "\uE73E",
+                    FontSize = 12,
+                    Foreground = ResolveBrush("TextFillColorSecondaryBrush"),
+                    VerticalAlignment = VerticalAlignment.Center,
+                });
+                row.Children.Add(new TextBlock { Text = label, TextWrapping = TextWrapping.Wrap, VerticalAlignment = VerticalAlignment.Center });
+                stack.Children.Add(row);
+            }
+        }
+
+        // Repair badge.
+        if (approval.IsRepair)
+        {
+            stack.Children.Add(new TextBlock
+            {
+                Text = LocalizationHelper.GetString("PairingApproval_RepairBadge"),
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                Foreground = ResolveBrush("SystemFillColorCautionBrush"),
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 4, 0, 0),
+            });
+        }
+
+        // Footer: truncated id · ip (monospace, tertiary).
+        var footerParts = new System.Collections.Generic.List<string>();
+        if (!string.IsNullOrEmpty(approval.DeviceId))
+            footerParts.Add($"ID {TruncateId(approval.DeviceId)}");
+        if (!string.IsNullOrWhiteSpace(approval.RemoteIp))
+            footerParts.Add($"IP {approval.RemoteIp}");
+        if (footerParts.Count > 0)
+        {
+            stack.Children.Add(new TextBlock
+            {
+                Text = string.Join("  ·  ", footerParts),
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                Foreground = ResolveBrush("TextFillColorTertiaryBrush"),
+                FontFamily = new FontFamily("Consolas"),
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 6, 0, 0),
+            });
+        }
+
+        // Reassurance line.
+        stack.Children.Add(new TextBlock
+        {
+            Text = LocalizationHelper.GetString("PairingApproval_Subtitle"),
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            Foreground = ResolveBrush("TextFillColorSecondaryBrush"),
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(0, 8, 0, 0),
+        });
+
+        card.Child = stack;
+        return card;
+    }
+
+    private void ArmApproveGuard()
+    {
+        _armTimer?.Stop();
+        _approveButton.IsEnabled = false;
+        ToolTipService.SetToolTip(_approveButton, LocalizationHelper.GetString("PairingApproval_ApproveHint"));
+        _armTimer = new DispatcherTimer { Interval = ApproveArmDelay };
+        _armTimer.Tick += (_, _) =>
+        {
+            _armTimer?.Stop();
+            if (!_busy)
+            {
+                _approveButton.IsEnabled = true;
+                ToolTipService.SetToolTip(_approveButton, null);
+            }
+        };
+        _armTimer.Start();
+    }
+
+    private async System.Threading.Tasks.Task DecideAsync(bool approve)
+    {
+        if (_busy || _currentKey == null) return;
+        _busy = true;
+        _approveButton.IsEnabled = false;
+        _rejectButton.IsEnabled = false;
+        _laterButton.IsEnabled = false;
+        try
+        {
+            // Success drives a coordinator ApprovalsChanged -> Render() which advances or closes.
+            var ok = approve
+                ? await _coordinator.ApproveAsync(_currentKey)
+                : await _coordinator.RejectAsync(_currentKey);
+            if (!ok)
+            {
+                // Re-enable so the user can retry; keep the approve guard satisfied (already shown a while).
+                _busy = false;
+                _approveButton.IsEnabled = true;
+                _rejectButton.IsEnabled = true;
+                _laterButton.IsEnabled = true;
+            }
+        }
+        catch
+        {
+            _busy = false;
+            _approveButton.IsEnabled = true;
+            _rejectButton.IsEnabled = true;
+            _laterButton.IsEnabled = true;
+        }
+    }
+
+    private void OnWindowClosed(object sender, WindowEventArgs args)
+    {
+        IsClosed = true;
+        _armTimer?.Stop();
+        _coordinator.ApprovalsChanged -= OnApprovalsChanged;
+        Closed -= OnWindowClosed;
+    }
+
+    private static StackPanel BuildButtonContent(string glyph, string? glyphBrushKey, string label)
+    {
+        var stack = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6, VerticalAlignment = VerticalAlignment.Center };
+        var icon = new FontIcon { Glyph = glyph, FontSize = 14, VerticalAlignment = VerticalAlignment.Center };
+        if (glyphBrushKey != null)
+            icon.Foreground = ResolveBrush(glyphBrushKey);
+        stack.Children.Add(icon);
+        stack.Children.Add(new TextBlock { Text = label, VerticalAlignment = VerticalAlignment.Center });
+        return stack;
+    }
+
+    private static string TruncateId(string id)
+    {
+        if (string.IsNullOrEmpty(id) || id.Length <= 20) return id;
+        return $"{id[..8]}…{id[^7..]}";
+    }
+
+    private static Brush ResolveBrush(string themeKey) =>
+        Application.Current.Resources.TryGetValue(themeKey, out var value) && value is Brush brush
+            ? brush
+            : new SolidColorBrush(Microsoft.UI.Colors.Transparent);
+}

--- a/src/OpenClaw.Tray.WinUI/Services/GatewayService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/GatewayService.cs
@@ -23,6 +23,8 @@ internal sealed class GatewayService
     public event EventHandler<string>? AuthenticationFailed;
     public event EventHandler<SessionCommandResult>? SessionCommandCompleted;
     public event EventHandler<OpenClawNotification>? NotificationReceived;
+    /// <summary>Raised (on the UI thread) whenever the node or device pending pair-list changes.</summary>
+    public event EventHandler? PairListsChanged;
 
     // Throttle / dedup state (moved from App)
     private DateTime _lastPreviewRequestUtc = DateTime.MinValue;
@@ -190,6 +192,10 @@ internal sealed class GatewayService
             if (status == ConnectionStatus.Disconnected || status == ConnectionStatus.Error)
             {
                 _state.ClearCachedData();
+                // Pair lists were just cleared — notify the approval coordinator so it
+                // reconciles to empty (resolving any open approvals / closing the dialog)
+                // instead of leaving stale state until the operator client is swapped out.
+                PairListsChanged?.Invoke(this, EventArgs.Empty);
             }
 
             ConnectionStatusChanged?.Invoke(this, status);
@@ -492,13 +498,21 @@ internal sealed class GatewayService
     private void OnNodePairListUpdated(object? sender, PairingListInfo data)
     {
         if (sender != _currentClient) return;
-        EnqueueModelUpdate(() => _state.NodePairList = data);
+        EnqueueModelUpdate(() =>
+        {
+            _state.NodePairList = data;
+            PairListsChanged?.Invoke(this, EventArgs.Empty);
+        });
     }
 
     private void OnDevicePairListUpdated(object? sender, DevicePairingListInfo data)
     {
         if (sender != _currentClient) return;
-        EnqueueModelUpdate(() => _state.DevicePairList = data);
+        EnqueueModelUpdate(() =>
+        {
+            _state.DevicePairList = data;
+            PairListsChanged?.Invoke(this, EventArgs.Empty);
+        });
     }
 
     private void OnModelsListUpdated(object? sender, ModelsListInfo data)

--- a/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCoordinator.cs
@@ -252,14 +252,15 @@ public sealed class PairingApprovalCoordinator
             if (ok)
             {
                 // Send-ack only means the frame left the socket, NOT that the gateway accepted it.
-                // But first re-validate the connection: a disconnect may have raced the await (and
-                // already Reset() the queue). Recording a submission now would strand a likely-dropped
-                // frame and risk a later false confirmation, so treat it as not completed instead —
-                // the request re-surfaces on reconnect for a clean retry.
+                // But first re-validate the exact connection: a disconnect/reconnect may have raced
+                // the await (and already Reset() the queue). Recording a submission against a new
+                // client would strand a likely-dropped frame and risk a later false confirmation, so
+                // treat it as not completed instead — the request re-surfaces on reconnect for a
+                // clean retry.
                 var liveClient = _getClient();
-                if (liveClient is not { IsConnectedToGateway: true })
+                if (!ReferenceEquals(liveClient, client) || !CanApproveWith(liveClient))
                 {
-                    _logger.Info("[PairApproval] Connection lost during decision; not recording optimistic submission");
+                    _logger.Info("[PairApproval] Connection changed during decision; not recording optimistic submission");
                     return false;
                 }
 

--- a/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCoordinator.cs
@@ -39,21 +39,18 @@ public sealed class PairingApprovalCoordinator
     private readonly HashSet<string> _inFlight = new(StringComparer.Ordinal);
     private bool _pollInFlight;
     private readonly Func<IOperatorGatewayClient?> _getClient;
-    private readonly Func<string?> _getOwnNodeDeviceId;
-    private readonly Func<bool> _isLocalNodeActive;
+    private readonly Func<IReadOnlyCollection<string>?> _getOwnNodeIds;
     private readonly Func<bool> _isPromptEnabled;
     private readonly IOpenClawLogger _logger;
 
     public PairingApprovalCoordinator(
         Func<IOperatorGatewayClient?> getClient,
-        Func<string?> getOwnNodeDeviceId,
-        Func<bool> isLocalNodeActive,
+        Func<IReadOnlyCollection<string>?> getOwnNodeIds,
         Func<bool> isPromptEnabled,
         IOpenClawLogger logger)
     {
         _getClient = getClient ?? throw new ArgumentNullException(nameof(getClient));
-        _getOwnNodeDeviceId = getOwnNodeDeviceId ?? throw new ArgumentNullException(nameof(getOwnNodeDeviceId));
-        _isLocalNodeActive = isLocalNodeActive ?? throw new ArgumentNullException(nameof(isLocalNodeActive));
+        _getOwnNodeIds = getOwnNodeIds ?? throw new ArgumentNullException(nameof(getOwnNodeIds));
         _isPromptEnabled = isPromptEnabled ?? throw new ArgumentNullException(nameof(isPromptEnabled));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -92,16 +89,11 @@ public sealed class PairingApprovalCoordinator
             return;
         }
 
-        // While the local node is active but its own device id is not yet known, exclude node
-        // requests entirely so we never prompt the operator to approve their own machine before
-        // the own-node filter can recognize it. They re-surface once the id is known.
-        var ownNodeId = _getOwnNodeDeviceId();
-        var deferNodes = _isLocalNodeActive() && string.IsNullOrEmpty(ownNodeId);
-
         PairingApprovalDelta delta;
         try
         {
-            delta = _queue.Reconcile(devices, nodes, ownNodeId, Environment.TickCount64, deferNodes);
+            // A null list for a kind = no fresh snapshot (carried forward), not "now empty".
+            delta = _queue.Reconcile(devices, nodes, _getOwnNodeIds(), Environment.TickCount64);
         }
         catch (Exception ex)
         {
@@ -137,7 +129,7 @@ public sealed class PairingApprovalCoordinator
             return;
 
         // Only prompt when the user hasn't opted out and we actually have the scope to act.
-        if (!_isPromptEnabled() || !CanApprove)
+        if (!_isPromptEnabled() || !CanApproveWith(client))
             return;
 
         foreach (var added in delta.Added)
@@ -264,6 +256,17 @@ public sealed class PairingApprovalCoordinator
             if (ok)
             {
                 // Send-ack only means the frame left the socket, NOT that the gateway accepted it.
+                // But first re-validate the connection: a disconnect may have raced the await (and
+                // already Reset() the queue). Recording a submission now would strand a likely-dropped
+                // frame and risk a later false confirmation, so treat it as not completed instead —
+                // the request re-surfaces on reconnect for a clean retry.
+                var liveClient = _getClient();
+                if (liveClient is not { IsConnectedToGateway: true })
+                {
+                    _logger.Info("[PairApproval] Connection lost during decision; not recording optimistic submission");
+                    return false;
+                }
+
                 // Record the decision as optimistic-pending so the UI advances, but defer the
                 // success confirmation until the gateway drops the request from the pending list
                 // (surfaced as a ConfirmedDecision on a later reconcile). If it never does, the
@@ -274,9 +277,9 @@ public sealed class PairingApprovalCoordinator
                 try
                 {
                     if (approval.Kind == PairingApprovalKind.Device)
-                        await client.RequestDevicePairListAsync();
+                        await liveClient.RequestDevicePairListAsync();
                     else
-                        await client.RequestNodePairListAsync();
+                        await liveClient.RequestNodePairListAsync();
                 }
                 catch (Exception ex)
                 {

--- a/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCoordinator.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using OpenClaw.Connection;
+using OpenClaw.Shared;
+
+namespace OpenClawTray.Services;
+
+/// <summary>Outcome of a single approve/reject decision, surfaced for confirmation toasts/activity.</summary>
+public sealed class PairingDecisionResult
+{
+    public required PendingApproval Approval { get; init; }
+
+    /// <summary>True when the user approved, false when rejected.</summary>
+    public required bool Approved { get; init; }
+
+    /// <summary>True when the gateway RPC succeeded.</summary>
+    public required bool Success { get; init; }
+}
+
+/// <summary>
+/// Orchestrates inbound pairing approvals (devices and nodes requesting to join the gateway).
+/// Bridges the pure <see cref="PairingApprovalQueue"/> to the live operator client and the tray
+/// presentation layer:
+/// <list type="bullet">
+///   <item>Consumes pair-list snapshots from <see cref="GatewayService"/>.</item>
+///   <item>Raises <see cref="ApprovalRequested"/> for genuinely new requests so the app can present
+///         the approval window + an awareness toast (gated by scope and the user setting).</item>
+///   <item>Raises <see cref="ApprovalsChanged"/> whenever the actionable set changes so an open
+///         window refreshes.</item>
+///   <item>Executes approve/reject via the operator client and reports <see cref="DecisionCompleted"/>.</item>
+/// </list>
+/// All members are expected to be invoked on the UI dispatcher thread (the gateway service marshals
+/// list updates there), so no internal locking is required.
+/// </summary>
+public sealed class PairingApprovalCoordinator
+{
+    private readonly PairingApprovalQueue _queue = new();
+    private readonly HashSet<string> _inFlight = new(StringComparer.Ordinal);
+    private bool _pollInFlight;
+    private readonly Func<IOperatorGatewayClient?> _getClient;
+    private readonly Func<string?> _getOwnNodeDeviceId;
+    private readonly Func<bool> _isPromptEnabled;
+    private readonly IOpenClawLogger _logger;
+
+    public PairingApprovalCoordinator(
+        Func<IOperatorGatewayClient?> getClient,
+        Func<string?> getOwnNodeDeviceId,
+        Func<bool> isPromptEnabled,
+        IOpenClawLogger logger)
+    {
+        _getClient = getClient ?? throw new ArgumentNullException(nameof(getClient));
+        _getOwnNodeDeviceId = getOwnNodeDeviceId ?? throw new ArgumentNullException(nameof(getOwnNodeDeviceId));
+        _isPromptEnabled = isPromptEnabled ?? throw new ArgumentNullException(nameof(isPromptEnabled));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>Raised for each newly-arrived, actionable request the user should be prompted to decide.</summary>
+    public event EventHandler<PendingApproval>? ApprovalRequested;
+
+    /// <summary>Raised whenever the actionable approval set changes (add, resolve, or decision).</summary>
+    public event EventHandler? ApprovalsChanged;
+
+    /// <summary>Raised after an approve/reject RPC completes (success or failure).</summary>
+    public event EventHandler<PairingDecisionResult>? DecisionCompleted;
+
+    /// <summary>The current actionable approvals, oldest first.</summary>
+    public IReadOnlyList<PendingApproval> Current => _queue.Current;
+
+    /// <summary>True when the connected operator can approve pairings (has admin/pairing scope).</summary>
+    public bool CanApprove => CanApproveWith(_getClient());
+
+    /// <summary>
+    /// Feed a fresh device/node pair-list snapshot. Diffs against prior state and raises the
+    /// appropriate presentation events. Safe to call with nulls (treated as empty lists).
+    /// </summary>
+    public void OnPairListsUpdated(DevicePairingListInfo? devices, PairingListInfo? nodes)
+    {
+        PairingApprovalDelta delta;
+        try
+        {
+            delta = _queue.Reconcile(devices, nodes, _getOwnNodeDeviceId());
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"[PairApproval] Reconcile failed: {ex.Message}");
+            return;
+        }
+
+        if (!delta.HasChanges)
+            return;
+
+        ApprovalsChanged?.Invoke(this, EventArgs.Empty);
+
+        if (delta.Added.Count == 0)
+            return;
+
+        // Only prompt when the user hasn't opted out and we actually have the scope to act.
+        if (!_isPromptEnabled() || !CanApprove)
+            return;
+
+        foreach (var added in delta.Added)
+        {
+            try
+            {
+                ApprovalRequested?.Invoke(this, added);
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn($"[PairApproval] ApprovalRequested handler threw: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Safety-net refresh: asks the gateway to re-send the pending pair lists. The gateway
+    /// broadcasts pair requests with <c>dropIfSlow=true</c>, so a congested socket can silently
+    /// drop a "device wants to connect" event; a periodic refresh ensures the request is still
+    /// picked up (and the in-page banner stays current). No-op unless the operator is connected
+    /// with approval scope. <see cref="OpenClawGatewayClient"/> already short-circuits these
+    /// requests on gateways that don't support pair lists, so this is cheap on older gateways.
+    /// </summary>
+    public async Task RefreshFromGatewayAsync()
+    {
+        // Non-reentrant: if a wedged-but-"connected" transport makes a refresh hang, don't let the
+        // 20s timer stack up more tracked requests on top of it.
+        if (_pollInFlight)
+            return;
+
+        var client = _getClient();
+        if (!CanApproveWith(client))
+            return;
+
+        _pollInFlight = true;
+        try
+        {
+            try { await client!.RequestDevicePairListAsync(); }
+            catch (Exception ex) { _logger.Info($"[PairApproval] Device pair-list poll failed: {ex.Message}"); }
+
+            try { await client!.RequestNodePairListAsync(); }
+            catch (Exception ex) { _logger.Info($"[PairApproval] Node pair-list poll failed: {ex.Message}"); }
+        }
+        finally
+        {
+            _pollInFlight = false;
+        }
+    }
+
+    /// <summary>Approve the request identified by <paramref name="key"/> (<see cref="PendingApproval.Key"/>).</summary>
+    public Task<bool> ApproveAsync(string key) => DecideAsync(key, approve: true);
+
+    /// <summary>Reject the request identified by <paramref name="key"/>.</summary>
+    public Task<bool> RejectAsync(string key) => DecideAsync(key, approve: false);
+
+    /// <summary>Look up a tracked approval by key (for the window to render details).</summary>
+    public PendingApproval? Find(string key) => _queue.Find(key);
+
+    /// <summary>Clear all tracked state (e.g. on disconnect or gateway switch).</summary>
+    public void Reset()
+    {
+        _queue.Reset();
+        ApprovalsChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private async Task<bool> DecideAsync(string key, bool approve)
+    {
+        var approval = _queue.Find(key);
+        if (approval == null)
+        {
+            _logger.Info($"[PairApproval] Decision for unknown/decided key '{key}' ignored");
+            return false;
+        }
+
+        // Guard against a double decision for the same request — e.g. a stray
+        // second click that slips through while the approve/reject RPC is still
+        // in flight. Single-threaded (UI dispatcher), so a HashSet is sufficient.
+        if (!_inFlight.Add(key))
+        {
+            _logger.Info($"[PairApproval] Decision already in flight for '{key}'");
+            return false;
+        }
+
+        try
+        {
+            var client = _getClient();
+            // Re-check connection AND approval scope at decision time — the dialog may have been
+            // open while scope was revoked or the operator reconnected with fewer scopes. The
+            // approve/reject frame is "send-acknowledged" (not gateway-acked), so guarding here
+            // avoids attempting an out-of-scope decision the gateway would silently reject.
+            if (client is not { IsConnectedToGateway: true }
+                || !OperatorScopeHelper.CanApproveDevices(client.GrantedOperatorScopes))
+            {
+                _logger.Warn("[PairApproval] Operator can no longer approve pairings (disconnected or scope lost); decision aborted");
+                return false;
+            }
+
+            bool ok = false;
+            try
+            {
+                ok = (approval.Kind, approve) switch
+                {
+                    (PairingApprovalKind.Device, true) => await client.DevicePairApproveAsync(approval.DecisionId),
+                    (PairingApprovalKind.Device, false) => await client.DevicePairRejectAsync(approval.DecisionId),
+                    (PairingApprovalKind.Node, true) => await client.NodePairApproveAsync(approval.DecisionId),
+                    (PairingApprovalKind.Node, false) => await client.NodePairRejectAsync(approval.DecisionId),
+                    _ => false,
+                };
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn($"[PairApproval] {(approve ? "Approve" : "Reject")} RPC failed: {ex.Message}");
+                ok = false;
+            }
+
+            if (ok)
+            {
+                _queue.MarkDecided(key);
+                // Nudge the gateway to re-send the list so the resolved entry drops promptly.
+                try
+                {
+                    if (approval.Kind == PairingApprovalKind.Device)
+                        await client.RequestDevicePairListAsync();
+                    else
+                        await client.RequestNodePairListAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.Info($"[PairApproval] Post-decision list refresh failed: {ex.Message}");
+                }
+
+                ApprovalsChanged?.Invoke(this, EventArgs.Empty);
+            }
+
+            DecisionCompleted?.Invoke(this, new PairingDecisionResult
+            {
+                Approval = approval,
+                Approved = approve,
+                Success = ok,
+            });
+
+            return ok;
+        }
+        finally
+        {
+            _inFlight.Remove(key);
+        }
+    }
+
+    private static bool CanApproveWith(IOperatorGatewayClient? client) =>
+        client is { IsConnectedToGateway: true }
+        && OperatorScopeHelper.CanApproveDevices(client.GrantedOperatorScopes);
+}

--- a/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCoordinator.cs
@@ -6,7 +6,7 @@ using OpenClaw.Shared;
 
 namespace OpenClawTray.Services;
 
-/// <summary>Outcome of a single approve/reject decision, surfaced for confirmation toasts/activity.</summary>
+/// <summary>Outcome of a confirmed approve/reject decision, surfaced for confirmation toasts/activity.</summary>
 public sealed class PairingDecisionResult
 {
     public required PendingApproval Approval { get; init; }
@@ -14,7 +14,7 @@ public sealed class PairingDecisionResult
     /// <summary>True when the user approved, false when rejected.</summary>
     public required bool Approved { get; init; }
 
-    /// <summary>True when the gateway RPC succeeded.</summary>
+    /// <summary>True when the gateway confirmed the decision (the request left the pending list).</summary>
     public required bool Success { get; init; }
 }
 
@@ -28,7 +28,8 @@ public sealed class PairingDecisionResult
 ///         the approval window + an awareness toast (gated by scope and the user setting).</item>
 ///   <item>Raises <see cref="ApprovalsChanged"/> whenever the actionable set changes so an open
 ///         window refreshes.</item>
-///   <item>Executes approve/reject via the operator client and reports <see cref="DecisionCompleted"/>.</item>
+///   <item>Executes approve/reject via the operator client and, once the gateway confirms the
+///         decision (the request leaves the pending list), reports <see cref="DecisionCompleted"/>.</item>
 /// </list>
 /// All members are expected to be invoked on the UI dispatcher thread (the gateway service marshals
 /// list updates there), so no internal locking is required.
@@ -70,12 +71,10 @@ public sealed class PairingApprovalCoordinator
     /// <summary>The current actionable approvals, oldest first.</summary>
     public IReadOnlyList<PendingApproval> Current => _queue.Current;
 
-    /// <summary>True when the connected operator can approve pairings (has admin/pairing scope).</summary>
-    public bool CanApprove => CanApproveWith(_getClient());
-
     /// <summary>
     /// Feed a fresh device/node pair-list snapshot. Diffs against prior state and raises the
-    /// appropriate presentation events. Safe to call with nulls (treated as empty lists).
+    /// appropriate presentation events. A null list for a kind means "no fresh snapshot for that
+    /// kind" — its prior entries are carried forward rather than treated as resolved.
     /// </summary>
     public void OnPairListsUpdated(DevicePairingListInfo? devices, PairingListInfo? nodes)
     {
@@ -185,9 +184,6 @@ public sealed class PairingApprovalCoordinator
     /// <summary>Reject the request identified by <paramref name="key"/>.</summary>
     public Task<bool> RejectAsync(string key) => DecideAsync(key, approve: false);
 
-    /// <summary>Look up a tracked approval by key (for the window to render details).</summary>
-    public PendingApproval? Find(string key) => _queue.Find(key);
-
     /// <summary>Clear all tracked state (e.g. on disconnect or gateway switch).</summary>
     public void Reset()
     {
@@ -202,7 +198,7 @@ public sealed class PairingApprovalCoordinator
         var approval = _queue.Find(key);
         if (approval == null)
         {
-            _logger.Info($"[PairApproval] Decision for unknown/decided key '{key}' ignored");
+            _logger.Info($"[PairApproval] Decision for unknown or already-submitted key '{key}' ignored");
             return false;
         }
 

--- a/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCoordinator.cs
@@ -40,17 +40,20 @@ public sealed class PairingApprovalCoordinator
     private bool _pollInFlight;
     private readonly Func<IOperatorGatewayClient?> _getClient;
     private readonly Func<string?> _getOwnNodeDeviceId;
+    private readonly Func<bool> _isLocalNodeActive;
     private readonly Func<bool> _isPromptEnabled;
     private readonly IOpenClawLogger _logger;
 
     public PairingApprovalCoordinator(
         Func<IOperatorGatewayClient?> getClient,
         Func<string?> getOwnNodeDeviceId,
+        Func<bool> isLocalNodeActive,
         Func<bool> isPromptEnabled,
         IOpenClawLogger logger)
     {
         _getClient = getClient ?? throw new ArgumentNullException(nameof(getClient));
         _getOwnNodeDeviceId = getOwnNodeDeviceId ?? throw new ArgumentNullException(nameof(getOwnNodeDeviceId));
+        _isLocalNodeActive = isLocalNodeActive ?? throw new ArgumentNullException(nameof(isLocalNodeActive));
         _isPromptEnabled = isPromptEnabled ?? throw new ArgumentNullException(nameof(isPromptEnabled));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -61,7 +64,10 @@ public sealed class PairingApprovalCoordinator
     /// <summary>Raised whenever the actionable approval set changes (add, resolve, or decision).</summary>
     public event EventHandler? ApprovalsChanged;
 
-    /// <summary>Raised after an approve/reject RPC completes (success or failure).</summary>
+    /// <summary>
+    /// Raised when a submitted approve/reject is CONFIRMED by the gateway (the request left the
+    /// pending list). This is the authoritative success signal — it does not fire on send-ack alone.
+    /// </summary>
     public event EventHandler<PairingDecisionResult>? DecisionCompleted;
 
     /// <summary>The current actionable approvals, oldest first.</summary>
@@ -76,10 +82,26 @@ public sealed class PairingApprovalCoordinator
     /// </summary>
     public void OnPairListsUpdated(DevicePairingListInfo? devices, PairingListInfo? nodes)
     {
+        // If we're not connected, an empty/missing list reflects lost visibility — NOT that
+        // requests resolved. Clearing silently here prevents a still-pending submitted decision
+        // from being mis-reported as a confirmed success on disconnect, and drops stale approvals.
+        var client = _getClient();
+        if (client is not { IsConnectedToGateway: true })
+        {
+            Reset();
+            return;
+        }
+
+        // While the local node is active but its own device id is not yet known, exclude node
+        // requests entirely so we never prompt the operator to approve their own machine before
+        // the own-node filter can recognize it. They re-surface once the id is known.
+        var ownNodeId = _getOwnNodeDeviceId();
+        var deferNodes = _isLocalNodeActive() && string.IsNullOrEmpty(ownNodeId);
+
         PairingApprovalDelta delta;
         try
         {
-            delta = _queue.Reconcile(devices, nodes, _getOwnNodeDeviceId());
+            delta = _queue.Reconcile(devices, nodes, ownNodeId, Environment.TickCount64, deferNodes);
         }
         catch (Exception ex)
         {
@@ -89,6 +111,25 @@ public sealed class PairingApprovalCoordinator
 
         if (!delta.HasChanges)
             return;
+
+        // A submitted decision the gateway has now confirmed (request left the pending list) is the
+        // authoritative success signal — report it so the app shows the "approved/rejected" toast.
+        foreach (var resolved in delta.ConfirmedDecisions)
+        {
+            try
+            {
+                DecisionCompleted?.Invoke(this, new PairingDecisionResult
+                {
+                    Approval = resolved.Approval,
+                    Approved = resolved.Approved,
+                    Success = true,
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn($"[PairApproval] DecisionCompleted handler threw: {ex.Message}");
+            }
+        }
 
         ApprovalsChanged?.Invoke(this, EventArgs.Empty);
 
@@ -159,6 +200,8 @@ public sealed class PairingApprovalCoordinator
     public void Reset()
     {
         _queue.Reset();
+        _inFlight.Clear();
+        _pollInFlight = false;
         ApprovalsChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -170,6 +213,12 @@ public sealed class PairingApprovalCoordinator
             _logger.Info($"[PairApproval] Decision for unknown/decided key '{key}' ignored");
             return false;
         }
+
+        // Legacy gateways may omit a request id; DecisionId then falls back to the device/node id.
+        // The gateway may ignore that, but the confirmed-resolution model handles it gracefully: the
+        // request simply isn't confirmed, expires, and re-surfaces — no permanent hide, no false toast.
+        if (string.IsNullOrEmpty(approval.RequestId))
+            _logger.Info($"[PairApproval] No request id; submitting decision with device/node id fallback for '{key}'");
 
         // Guard against a double decision for the same request — e.g. a stray
         // second click that slips through while the approve/reject RPC is still
@@ -214,8 +263,14 @@ public sealed class PairingApprovalCoordinator
 
             if (ok)
             {
-                _queue.MarkDecided(key);
-                // Nudge the gateway to re-send the list so the resolved entry drops promptly.
+                // Send-ack only means the frame left the socket, NOT that the gateway accepted it.
+                // Record the decision as optimistic-pending so the UI advances, but defer the
+                // success confirmation until the gateway drops the request from the pending list
+                // (surfaced as a ConfirmedDecision on a later reconcile). If it never does, the
+                // submission expires and the request re-surfaces for retry.
+                _queue.MarkSubmitted(approval, approve, Environment.TickCount64);
+
+                // Nudge the gateway to re-send the list so the resolved entry drops (and confirms) promptly.
                 try
                 {
                     if (approval.Kind == PairingApprovalKind.Device)
@@ -230,13 +285,6 @@ public sealed class PairingApprovalCoordinator
 
                 ApprovalsChanged?.Invoke(this, EventArgs.Empty);
             }
-
-            DecisionCompleted?.Invoke(this, new PairingDecisionResult
-            {
-                Approval = approval,
-                Approved = approve,
-                Success = ok,
-            });
 
             return ok;
         }

--- a/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
@@ -84,6 +84,8 @@ public class SettingsManager
 
     // Node mode(gateway WebSocket connection — separate from MCP)
     public bool EnableNodeMode { get => _data.EnableNodeMode; set => _data = _data with { EnableNodeMode = value }; }
+    /// <summary>Master switch for the focused inbound-pairing approval dialog + awareness toast.</summary>
+    public bool ShowPairingApprovalDialog { get => _data.ShowPairingApprovalDialog; set => _data = _data with { ShowPairingApprovalDialog = value }; }
     public bool NodeCanvasEnabled { get => _data.NodeCanvasEnabled; set => _data = _data with { NodeCanvasEnabled = value }; }
     public bool NodeScreenEnabled { get => _data.NodeScreenEnabled; set => _data = _data with { NodeScreenEnabled = value }; }
     public bool NodeCameraEnabled { get => _data.NodeCameraEnabled; set => _data = _data with { NodeCameraEnabled = value }; }

--- a/src/OpenClaw.Tray.WinUI/Services/ToastActivationRouter.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ToastActivationRouter.cs
@@ -8,6 +8,7 @@ public sealed class ToastActivationActions
     public required Action OpenChat { get; init; }
     public required Action OpenActivity { get; init; }
     public required Action<string> CopyPairingCommand { get; init; }
+    public required Action ReviewPairing { get; init; }
 }
 
 public static class ToastActivationRouter
@@ -43,6 +44,9 @@ public static class ToastActivationRouter
                 var command = getArgument("command");
                 if (!string.IsNullOrWhiteSpace(command))
                     actions.CopyPairingCommand(command);
+                break;
+            case "review_pairing":
+                actions.ReviewPairing();
                 break;
         }
     }

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -689,6 +689,75 @@ Use one of these options:
   <data name="Toast_PairingCommandCopied" xml:space="preserve">
     <value>Pairing command copied</value>
   </data>
+  <data name="Toast_PairingRequestTitle" xml:space="preserve">
+    <value>Pairing request</value>
+  </data>
+  <data name="Toast_PairingRequestBody" xml:space="preserve">
+    <value>{0} wants to connect</value>
+  </data>
+  <data name="Toast_PairingRequestBodyNode" xml:space="preserve">
+    <value>{0} wants to connect as a node</value>
+  </data>
+  <data name="Toast_PairingReview" xml:space="preserve">
+    <value>Review</value>
+  </data>
+  <data name="Toast_PairingApprovedTitle" xml:space="preserve">
+    <value>Pairing approved</value>
+  </data>
+  <data name="Toast_PairingApprovedBody" xml:space="preserve">
+    <value>{0} can now connect</value>
+  </data>
+  <data name="Toast_PairingRejectedTitle" xml:space="preserve">
+    <value>Pairing rejected</value>
+  </data>
+  <data name="Toast_PairingRejectedBody" xml:space="preserve">
+    <value>{0} was not allowed to connect</value>
+  </data>
+  <data name="PairingApproval_WindowTitle" xml:space="preserve">
+    <value>Pairing request</value>
+  </data>
+  <data name="PairingApproval_DeviceHeading" xml:space="preserve">
+    <value>A device wants to connect</value>
+  </data>
+  <data name="PairingApproval_NodeHeading" xml:space="preserve">
+    <value>A node wants to connect</value>
+  </data>
+  <data name="PairingApproval_Subtitle" xml:space="preserve">
+    <value>Only approve if you recognize this request. You can remove it later in Connection settings.</value>
+  </data>
+  <data name="PairingApproval_AccessRequested" xml:space="preserve">
+    <value>Access requested</value>
+  </data>
+  <data name="PairingApproval_RepairBadge" xml:space="preserve">
+    <value>Re-pair request — the device token will rotate.</value>
+  </data>
+  <data name="PairingApproval_Approve" xml:space="preserve">
+    <value>Approve</value>
+  </data>
+  <data name="PairingApproval_ApproveDevice" xml:space="preserve">
+    <value>Approve device</value>
+  </data>
+  <data name="PairingApproval_ApproveNode" xml:space="preserve">
+    <value>Approve node</value>
+  </data>
+  <data name="PairingApproval_Reject" xml:space="preserve">
+    <value>Reject</value>
+  </data>
+  <data name="PairingApproval_Later" xml:space="preserve">
+    <value>Decide later</value>
+  </data>
+  <data name="PairingApproval_MoreWaiting" xml:space="preserve">
+    <value>{0} more waiting</value>
+  </data>
+  <data name="PairingApproval_ApproveHint" xml:space="preserve">
+    <value>Approve becomes available in a moment</value>
+  </data>
+  <data name="PairingApproval_UnknownDevice" xml:space="preserve">
+    <value>Unknown device</value>
+  </data>
+  <data name="PairingApproval_UnknownPlatform" xml:space="preserve">
+    <value>Unknown platform</value>
+  </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ Node Paired!</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -648,6 +648,75 @@ Utilisez l'une de ces options :
   <data name="Toast_PairingCommandCopied" xml:space="preserve">
     <value>Commande de jumelage copiée</value>
   </data>
+  <data name="Toast_PairingRequestTitle" xml:space="preserve">
+    <value>Demande de jumelage</value>
+  </data>
+  <data name="Toast_PairingRequestBody" xml:space="preserve">
+    <value>{0} souhaite se connecter</value>
+  </data>
+  <data name="Toast_PairingRequestBodyNode" xml:space="preserve">
+    <value>{0} souhaite se connecter en tant que nœud</value>
+  </data>
+  <data name="Toast_PairingReview" xml:space="preserve">
+    <value>Examiner</value>
+  </data>
+  <data name="Toast_PairingApprovedTitle" xml:space="preserve">
+    <value>Jumelage approuvé</value>
+  </data>
+  <data name="Toast_PairingApprovedBody" xml:space="preserve">
+    <value>{0} peut désormais se connecter</value>
+  </data>
+  <data name="Toast_PairingRejectedTitle" xml:space="preserve">
+    <value>Jumelage refusé</value>
+  </data>
+  <data name="Toast_PairingRejectedBody" xml:space="preserve">
+    <value>{0} n'a pas été autorisé à se connecter</value>
+  </data>
+  <data name="PairingApproval_WindowTitle" xml:space="preserve">
+    <value>Demande de jumelage</value>
+  </data>
+  <data name="PairingApproval_DeviceHeading" xml:space="preserve">
+    <value>Un appareil souhaite se connecter</value>
+  </data>
+  <data name="PairingApproval_NodeHeading" xml:space="preserve">
+    <value>Un nœud souhaite se connecter</value>
+  </data>
+  <data name="PairingApproval_Subtitle" xml:space="preserve">
+    <value>N'approuvez que si vous reconnaissez cette demande. Vous pourrez la supprimer plus tard dans les paramètres de connexion.</value>
+  </data>
+  <data name="PairingApproval_AccessRequested" xml:space="preserve">
+    <value>Accès demandé</value>
+  </data>
+  <data name="PairingApproval_RepairBadge" xml:space="preserve">
+    <value>Demande de réappairage — le jeton de l'appareil sera renouvelé.</value>
+  </data>
+  <data name="PairingApproval_Approve" xml:space="preserve">
+    <value>Approuver</value>
+  </data>
+  <data name="PairingApproval_ApproveDevice" xml:space="preserve">
+    <value>Approuver l'appareil</value>
+  </data>
+  <data name="PairingApproval_ApproveNode" xml:space="preserve">
+    <value>Approuver le nœud</value>
+  </data>
+  <data name="PairingApproval_Reject" xml:space="preserve">
+    <value>Refuser</value>
+  </data>
+  <data name="PairingApproval_Later" xml:space="preserve">
+    <value>Décider plus tard</value>
+  </data>
+  <data name="PairingApproval_MoreWaiting" xml:space="preserve">
+    <value>{0} en attente</value>
+  </data>
+  <data name="PairingApproval_ApproveHint" xml:space="preserve">
+    <value>L'approbation sera disponible dans un instant</value>
+  </data>
+  <data name="PairingApproval_UnknownDevice" xml:space="preserve">
+    <value>Appareil inconnu</value>
+  </data>
+  <data name="PairingApproval_UnknownPlatform" xml:space="preserve">
+    <value>Plateforme inconnue</value>
+  </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ Noeud appairé!</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -649,6 +649,75 @@ Gebruik een van deze opties:
   <data name="Toast_PairingCommandCopied" xml:space="preserve">
     <value>Koppelingsopdracht gekopieerd</value>
   </data>
+  <data name="Toast_PairingRequestTitle" xml:space="preserve">
+    <value>Koppelingsverzoek</value>
+  </data>
+  <data name="Toast_PairingRequestBody" xml:space="preserve">
+    <value>{0} wil verbinding maken</value>
+  </data>
+  <data name="Toast_PairingRequestBodyNode" xml:space="preserve">
+    <value>{0} wil verbinding maken als node</value>
+  </data>
+  <data name="Toast_PairingReview" xml:space="preserve">
+    <value>Bekijken</value>
+  </data>
+  <data name="Toast_PairingApprovedTitle" xml:space="preserve">
+    <value>Koppeling goedgekeurd</value>
+  </data>
+  <data name="Toast_PairingApprovedBody" xml:space="preserve">
+    <value>{0} kan nu verbinding maken</value>
+  </data>
+  <data name="Toast_PairingRejectedTitle" xml:space="preserve">
+    <value>Koppeling geweigerd</value>
+  </data>
+  <data name="Toast_PairingRejectedBody" xml:space="preserve">
+    <value>{0} mocht geen verbinding maken</value>
+  </data>
+  <data name="PairingApproval_WindowTitle" xml:space="preserve">
+    <value>Koppelingsverzoek</value>
+  </data>
+  <data name="PairingApproval_DeviceHeading" xml:space="preserve">
+    <value>Een apparaat wil verbinding maken</value>
+  </data>
+  <data name="PairingApproval_NodeHeading" xml:space="preserve">
+    <value>Een node wil verbinding maken</value>
+  </data>
+  <data name="PairingApproval_Subtitle" xml:space="preserve">
+    <value>Keur dit alleen goed als je dit verzoek herkent. Je kunt het later verwijderen in de verbindingsinstellingen.</value>
+  </data>
+  <data name="PairingApproval_AccessRequested" xml:space="preserve">
+    <value>Gevraagde toegang</value>
+  </data>
+  <data name="PairingApproval_RepairBadge" xml:space="preserve">
+    <value>Verzoek om opnieuw te koppelen — het apparaattoken wordt vernieuwd.</value>
+  </data>
+  <data name="PairingApproval_Approve" xml:space="preserve">
+    <value>Goedkeuren</value>
+  </data>
+  <data name="PairingApproval_ApproveDevice" xml:space="preserve">
+    <value>Apparaat goedkeuren</value>
+  </data>
+  <data name="PairingApproval_ApproveNode" xml:space="preserve">
+    <value>Node goedkeuren</value>
+  </data>
+  <data name="PairingApproval_Reject" xml:space="preserve">
+    <value>Weigeren</value>
+  </data>
+  <data name="PairingApproval_Later" xml:space="preserve">
+    <value>Later beslissen</value>
+  </data>
+  <data name="PairingApproval_MoreWaiting" xml:space="preserve">
+    <value>Nog {0} in wachtrij</value>
+  </data>
+  <data name="PairingApproval_ApproveHint" xml:space="preserve">
+    <value>Goedkeuren komt zo beschikbaar</value>
+  </data>
+  <data name="PairingApproval_UnknownDevice" xml:space="preserve">
+    <value>Onbekend apparaat</value>
+  </data>
+  <data name="PairingApproval_UnknownPlatform" xml:space="preserve">
+    <value>Onbekend platform</value>
+  </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ Node gekoppeld!</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -648,6 +648,75 @@
   <data name="Toast_PairingCommandCopied" xml:space="preserve">
     <value>配对命令已复制</value>
   </data>
+  <data name="Toast_PairingRequestTitle" xml:space="preserve">
+    <value>配对请求</value>
+  </data>
+  <data name="Toast_PairingRequestBody" xml:space="preserve">
+    <value>{0} 想要连接</value>
+  </data>
+  <data name="Toast_PairingRequestBodyNode" xml:space="preserve">
+    <value>{0} 想要作为节点连接</value>
+  </data>
+  <data name="Toast_PairingReview" xml:space="preserve">
+    <value>查看</value>
+  </data>
+  <data name="Toast_PairingApprovedTitle" xml:space="preserve">
+    <value>配对已批准</value>
+  </data>
+  <data name="Toast_PairingApprovedBody" xml:space="preserve">
+    <value>{0} 现在可以连接</value>
+  </data>
+  <data name="Toast_PairingRejectedTitle" xml:space="preserve">
+    <value>配对已拒绝</value>
+  </data>
+  <data name="Toast_PairingRejectedBody" xml:space="preserve">
+    <value>{0} 未获允许连接</value>
+  </data>
+  <data name="PairingApproval_WindowTitle" xml:space="preserve">
+    <value>配对请求</value>
+  </data>
+  <data name="PairingApproval_DeviceHeading" xml:space="preserve">
+    <value>有设备想要连接</value>
+  </data>
+  <data name="PairingApproval_NodeHeading" xml:space="preserve">
+    <value>有节点想要连接</value>
+  </data>
+  <data name="PairingApproval_Subtitle" xml:space="preserve">
+    <value>仅在您认识此请求时才批准。稍后可在“连接”设置中将其移除。</value>
+  </data>
+  <data name="PairingApproval_AccessRequested" xml:space="preserve">
+    <value>请求的访问权限</value>
+  </data>
+  <data name="PairingApproval_RepairBadge" xml:space="preserve">
+    <value>重新配对请求——设备令牌将轮换。</value>
+  </data>
+  <data name="PairingApproval_Approve" xml:space="preserve">
+    <value>批准</value>
+  </data>
+  <data name="PairingApproval_ApproveDevice" xml:space="preserve">
+    <value>批准设备</value>
+  </data>
+  <data name="PairingApproval_ApproveNode" xml:space="preserve">
+    <value>批准节点</value>
+  </data>
+  <data name="PairingApproval_Reject" xml:space="preserve">
+    <value>拒绝</value>
+  </data>
+  <data name="PairingApproval_Later" xml:space="preserve">
+    <value>稍后决定</value>
+  </data>
+  <data name="PairingApproval_MoreWaiting" xml:space="preserve">
+    <value>还有 {0} 个等待</value>
+  </data>
+  <data name="PairingApproval_ApproveHint" xml:space="preserve">
+    <value>批准将在稍后可用</value>
+  </data>
+  <data name="PairingApproval_UnknownDevice" xml:space="preserve">
+    <value>未知设备</value>
+  </data>
+  <data name="PairingApproval_UnknownPlatform" xml:space="preserve">
+    <value>未知平台</value>
+  </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ 节点已配对！</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -648,6 +648,75 @@
   <data name="Toast_PairingCommandCopied" xml:space="preserve">
     <value>配對命令已複製</value>
   </data>
+  <data name="Toast_PairingRequestTitle" xml:space="preserve">
+    <value>配對要求</value>
+  </data>
+  <data name="Toast_PairingRequestBody" xml:space="preserve">
+    <value>{0} 想要連線</value>
+  </data>
+  <data name="Toast_PairingRequestBodyNode" xml:space="preserve">
+    <value>{0} 想要作為節點連線</value>
+  </data>
+  <data name="Toast_PairingReview" xml:space="preserve">
+    <value>檢視</value>
+  </data>
+  <data name="Toast_PairingApprovedTitle" xml:space="preserve">
+    <value>配對已核准</value>
+  </data>
+  <data name="Toast_PairingApprovedBody" xml:space="preserve">
+    <value>{0} 現在可以連線</value>
+  </data>
+  <data name="Toast_PairingRejectedTitle" xml:space="preserve">
+    <value>配對已拒絕</value>
+  </data>
+  <data name="Toast_PairingRejectedBody" xml:space="preserve">
+    <value>{0} 未獲允許連線</value>
+  </data>
+  <data name="PairingApproval_WindowTitle" xml:space="preserve">
+    <value>配對要求</value>
+  </data>
+  <data name="PairingApproval_DeviceHeading" xml:space="preserve">
+    <value>有裝置想要連線</value>
+  </data>
+  <data name="PairingApproval_NodeHeading" xml:space="preserve">
+    <value>有節點想要連線</value>
+  </data>
+  <data name="PairingApproval_Subtitle" xml:space="preserve">
+    <value>僅在您認得此要求時才核准。稍後可在「連線」設定中將其移除。</value>
+  </data>
+  <data name="PairingApproval_AccessRequested" xml:space="preserve">
+    <value>要求的存取權限</value>
+  </data>
+  <data name="PairingApproval_RepairBadge" xml:space="preserve">
+    <value>重新配對要求——裝置權杖將輪替。</value>
+  </data>
+  <data name="PairingApproval_Approve" xml:space="preserve">
+    <value>核准</value>
+  </data>
+  <data name="PairingApproval_ApproveDevice" xml:space="preserve">
+    <value>核准裝置</value>
+  </data>
+  <data name="PairingApproval_ApproveNode" xml:space="preserve">
+    <value>核准節點</value>
+  </data>
+  <data name="PairingApproval_Reject" xml:space="preserve">
+    <value>拒絕</value>
+  </data>
+  <data name="PairingApproval_Later" xml:space="preserve">
+    <value>稍後決定</value>
+  </data>
+  <data name="PairingApproval_MoreWaiting" xml:space="preserve">
+    <value>還有 {0} 個等待</value>
+  </data>
+  <data name="PairingApproval_ApproveHint" xml:space="preserve">
+    <value>核准將在稍後可用</value>
+  </data>
+  <data name="PairingApproval_UnknownDevice" xml:space="preserve">
+    <value>未知裝置</value>
+  </data>
+  <data name="PairingApproval_UnknownPlatform" xml:space="preserve">
+    <value>未知平台</value>
+  </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ 節點已配對！</value>
   </data>

--- a/tests/OpenClaw.Connection.Tests/PairingApprovalQueueTests.cs
+++ b/tests/OpenClaw.Connection.Tests/PairingApprovalQueueTests.cs
@@ -1,0 +1,278 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenClaw.Connection;
+using OpenClaw.Shared;
+using Xunit;
+
+namespace OpenClaw.Connection.Tests;
+
+public class PendingApprovalTests
+{
+    [Fact]
+    public void FromDevice_MapsAllFields_AndNormalizesIp()
+    {
+        var req = new DevicePairingRequest
+        {
+            RequestId = "req-1",
+            DeviceId = "dev-1",
+            DisplayName = "Bedroom iPad",
+            Platform = "iPadOS",
+            Role = "operator",
+            Scopes = new[] { "operator.read", "", "operator.admin" },
+            RemoteIp = "::ffff:192.168.1.50",
+            IsRepair = true,
+            Ts = 1234,
+        };
+
+        var a = PendingApproval.FromDevice(req);
+
+        Assert.Equal(PairingApprovalKind.Device, a.Kind);
+        Assert.Equal("req-1", a.RequestId);
+        Assert.Equal("dev-1", a.DeviceId);
+        Assert.Equal("Bedroom iPad", a.DisplayName);
+        Assert.Equal("iPadOS", a.Platform);
+        Assert.Equal("operator", a.Role);
+        Assert.Equal(new[] { "operator.read", "operator.admin" }, a.Scopes);
+        Assert.Equal("192.168.1.50", a.RemoteIp);
+        Assert.True(a.IsRepair);
+        Assert.Equal(1234, a.Ts);
+    }
+
+    [Fact]
+    public void FromDevice_DefaultsRoleToOperator_WhenMissing()
+    {
+        var a = PendingApproval.FromDevice(new DevicePairingRequest { RequestId = "r", DeviceId = "d" });
+        Assert.Equal("operator", a.Role);
+    }
+
+    [Fact]
+    public void FromNode_MapsFields_AndHasNoScopes()
+    {
+        var req = new PairingRequest
+        {
+            RequestId = "req-2",
+            NodeId = "node-9",
+            DisplayName = "Studio PC",
+            Platform = "windows",
+            Version = "1.2.3",
+            RemoteIp = "10.0.0.4",
+            Ts = 99,
+        };
+
+        var a = PendingApproval.FromNode(req);
+
+        Assert.Equal(PairingApprovalKind.Node, a.Kind);
+        Assert.Equal("node-9", a.DeviceId);
+        Assert.Equal("node", a.Role);
+        Assert.Empty(a.Scopes);
+        Assert.Equal("1.2.3", a.Version);
+    }
+
+    [Fact]
+    public void DecisionId_PrefersRequestId_FallsBackToDeviceId()
+    {
+        Assert.Equal("req", PendingApproval.FromDevice(new DevicePairingRequest { RequestId = "req", DeviceId = "dev" }).DecisionId);
+        Assert.Equal("dev", PendingApproval.FromDevice(new DevicePairingRequest { RequestId = "", DeviceId = "dev" }).DecisionId);
+    }
+
+    [Fact]
+    public void Key_IsKindScoped()
+    {
+        var device = PendingApproval.FromDevice(new DevicePairingRequest { RequestId = "same", DeviceId = "x" });
+        var node = PendingApproval.FromNode(new PairingRequest { RequestId = "same", NodeId = "y" });
+        Assert.NotEqual(device.Key, node.Key);
+    }
+
+    [Fact]
+    public void IsActionable_FalseWhenNoIds()
+    {
+        Assert.False(PendingApproval.FromNode(new PairingRequest { RequestId = "", NodeId = "" }).IsActionable);
+        Assert.True(PendingApproval.FromDevice(new DevicePairingRequest { RequestId = "", DeviceId = "d" }).IsActionable);
+    }
+}
+
+public class PairingApprovalQueueTests
+{
+    private static DevicePairingListInfo Devices(params DevicePairingRequest[] reqs) =>
+        new() { Pending = reqs.ToList() };
+
+    private static PairingListInfo Nodes(params PairingRequest[] reqs) =>
+        new() { Pending = reqs.ToList() };
+
+    private static DevicePairingRequest Device(string id, double ts = 0, string[]? scopes = null) =>
+        new() { RequestId = id, DeviceId = $"d-{id}", DisplayName = id, Ts = ts, Scopes = scopes };
+
+    private static PairingRequest Node(string id, string? nodeId = null, double ts = 0) =>
+        new() { RequestId = id, NodeId = nodeId ?? $"n-{id}", DisplayName = id, Ts = ts };
+
+    [Fact]
+    public void Reconcile_SurfacesNewDeviceAndNodeRequests()
+    {
+        var q = new PairingApprovalQueue();
+        var delta = q.Reconcile(Devices(Device("a")), Nodes(Node("b")));
+
+        Assert.Equal(2, delta.Added.Count);
+        Assert.Empty(delta.ResolvedKeys);
+        Assert.Equal(2, delta.Current.Count);
+    }
+
+    [Fact]
+    public void Reconcile_DoesNotReAddKnownRequest()
+    {
+        var q = new PairingApprovalQueue();
+        q.Reconcile(Devices(Device("a")), null);
+        var second = q.Reconcile(Devices(Device("a")), null);
+
+        Assert.Empty(second.Added);
+        Assert.Single(second.Current);
+    }
+
+    [Fact]
+    public void Reconcile_ReportsResolvedWhenRequestLeaves()
+    {
+        var q = new PairingApprovalQueue();
+        q.Reconcile(Devices(Device("a")), null);
+        var delta = q.Reconcile(Devices(), null);
+
+        Assert.Single(delta.ResolvedKeys);
+        Assert.Equal("Device:a", delta.ResolvedKeys[0]);
+        Assert.Empty(delta.Current);
+    }
+
+    [Fact]
+    public void Reconcile_FiltersOwnNodeRequest()
+    {
+        var q = new PairingApprovalQueue();
+        var delta = q.Reconcile(null, Nodes(Node("self", nodeId: "MY-NODE"), Node("other", nodeId: "OTHER")), ownNodeDeviceId: "my-node");
+
+        Assert.Single(delta.Added);
+        Assert.Equal("other", delta.Added[0].RequestId);
+    }
+
+    [Fact]
+    public void Reconcile_DropsUnactionableEntries()
+    {
+        var q = new PairingApprovalQueue();
+        var delta = q.Reconcile(null, Nodes(new PairingRequest { RequestId = "", NodeId = "" }));
+        Assert.Empty(delta.Added);
+    }
+
+    [Fact]
+    public void Reconcile_DedupsDuplicateIds()
+    {
+        var q = new PairingApprovalQueue();
+        var delta = q.Reconcile(Devices(Device("a"), Device("a")), null);
+        Assert.Single(delta.Added);
+    }
+
+    [Fact]
+    public void Reconcile_OrdersCurrentByTimestamp()
+    {
+        var q = new PairingApprovalQueue();
+        var delta = q.Reconcile(Devices(Device("late", ts: 200), Device("early", ts: 100)), null);
+        Assert.Equal("early", delta.Current[0].RequestId);
+        Assert.Equal("late", delta.Current[1].RequestId);
+    }
+
+    [Fact]
+    public void MarkDecided_SuppressesReSurfacingWhileStillPending()
+    {
+        var q = new PairingApprovalQueue();
+        var first = q.Reconcile(Devices(Device("a")), null);
+        q.MarkDecided(first.Added[0].Key);
+
+        var second = q.Reconcile(Devices(Device("a")), null); // gateway still echoes it
+        Assert.Empty(second.Added);
+        Assert.Empty(second.Current); // decided => not actionable
+    }
+
+    [Fact]
+    public void MarkDecided_ForgottenAfterRequestLeaves_AllowsFutureReSurface()
+    {
+        var q = new PairingApprovalQueue();
+        var first = q.Reconcile(Devices(Device("a")), null);
+        q.MarkDecided(first.Added[0].Key);
+
+        q.Reconcile(Devices(), null);                 // request leaves -> decision forgotten
+        var third = q.Reconcile(Devices(Device("a")), null); // same id returns as genuinely new
+
+        Assert.Single(third.Added);
+    }
+
+    [Fact]
+    public void Find_ReturnsTrackedButNotDecided()
+    {
+        var q = new PairingApprovalQueue();
+        var delta = q.Reconcile(Devices(Device("a")), null);
+        var key = delta.Added[0].Key;
+
+        Assert.NotNull(q.Find(key));
+        q.MarkDecided(key);
+        Assert.Null(q.Find(key));
+    }
+
+    [Fact]
+    public void Reset_ClearsEverything()
+    {
+        var q = new PairingApprovalQueue();
+        q.Reconcile(Devices(Device("a")), null);
+        q.Reset();
+        Assert.True(q.IsEmpty);
+
+        // After reset the same request surfaces again.
+        var delta = q.Reconcile(Devices(Device("a")), null);
+        Assert.Single(delta.Added);
+    }
+}
+
+public class PairingScopeDescriptionsTests
+{
+    [Theory]
+    [InlineData("operator.admin", "Admin access")]
+    [InlineData("operator.read", "Read OpenClaw data")]
+    [InlineData("operator.write", "Send messages and make changes")]
+    [InlineData("operator.approvals", "Manage approvals")]
+    [InlineData("operator.pairing", "Pair and repair devices")]
+    [InlineData("operator.talk.secrets", "Use Talk credentials")]
+    [InlineData("OPERATOR.ADMIN", "Admin access")]
+    public void Describe_ReturnsFriendlyLabel_ForKnownScope(string scope, string expected)
+    {
+        Assert.Equal(expected, PairingScopeDescriptions.Describe(scope));
+    }
+
+    [Fact]
+    public void Describe_ReturnsRawScope_ForUnknown()
+    {
+        Assert.Equal("custom.scope", PairingScopeDescriptions.Describe(" custom.scope "));
+    }
+
+    [Fact]
+    public void Describe_ReturnsEmpty_ForBlank()
+    {
+        Assert.Equal(string.Empty, PairingScopeDescriptions.Describe("   "));
+    }
+
+    [Fact]
+    public void DescribeAll_DropsBlanksAndDeduplicates_PreservingOrder()
+    {
+        var result = PairingScopeDescriptions.DescribeAll(
+            new[] { "operator.admin", "", "operator.admin", "operator.read" });
+        Assert.Equal(new[] { "Admin access", "Read OpenClaw data" }, result);
+    }
+
+    [Fact]
+    public void DescribeAll_ReturnsEmpty_ForNull()
+    {
+        Assert.Empty(PairingScopeDescriptions.DescribeAll(null));
+    }
+
+    [Theory]
+    [InlineData("operator.admin", true)]
+    [InlineData("unknown.scope", false)]
+    [InlineData("", false)]
+    public void IsKnown_ReflectsMapMembership(string scope, bool expected)
+    {
+        Assert.Equal(expected, PairingScopeDescriptions.IsKnown(scope));
+    }
+}

--- a/tests/OpenClaw.Connection.Tests/PairingApprovalQueueTests.cs
+++ b/tests/OpenClaw.Connection.Tests/PairingApprovalQueueTests.cs
@@ -176,40 +176,89 @@ public class PairingApprovalQueueTests
     }
 
     [Fact]
-    public void MarkDecided_SuppressesReSurfacingWhileStillPending()
+    public void MarkSubmitted_SuppressesFromActionableSet()
     {
         var q = new PairingApprovalQueue();
         var first = q.Reconcile(Devices(Device("a")), null);
-        q.MarkDecided(first.Added[0].Key);
+        q.MarkSubmitted(first.Added[0], approved: true, nowMs: 1000);
 
-        var second = q.Reconcile(Devices(Device("a")), null); // gateway still echoes it
+        var second = q.Reconcile(Devices(Device("a")), null, nowMs: 1100); // gateway still echoes it
         Assert.Empty(second.Added);
-        Assert.Empty(second.Current); // decided => not actionable
+        Assert.Empty(second.Current); // submitted => not actionable
+        Assert.Empty(second.ConfirmedDecisions); // not yet resolved
     }
 
     [Fact]
-    public void MarkDecided_ForgottenAfterRequestLeaves_AllowsFutureReSurface()
+    public void MarkSubmitted_ConfirmsDecisionWhenRequestLeavesList()
     {
         var q = new PairingApprovalQueue();
         var first = q.Reconcile(Devices(Device("a")), null);
-        q.MarkDecided(first.Added[0].Key);
+        q.MarkSubmitted(first.Added[0], approved: true, nowMs: 1000);
 
-        q.Reconcile(Devices(), null);                 // request leaves -> decision forgotten
-        var third = q.Reconcile(Devices(Device("a")), null); // same id returns as genuinely new
-
-        Assert.Single(third.Added);
+        // Gateway accepted -> request drops from the pending list -> confirmed.
+        var delta = q.Reconcile(Devices(), null, nowMs: 1200);
+        Assert.Single(delta.ConfirmedDecisions);
+        Assert.True(delta.ConfirmedDecisions[0].Approved);
+        Assert.Equal("a", delta.ConfirmedDecisions[0].Approval.RequestId);
+        Assert.True(delta.HasChanges);
     }
 
     [Fact]
-    public void Find_ReturnsTrackedButNotDecided()
+    public void MarkSubmitted_ConfirmsRejectionWithCorrectFlag()
+    {
+        var q = new PairingApprovalQueue();
+        var first = q.Reconcile(Devices(Device("a")), null);
+        q.MarkSubmitted(first.Added[0], approved: false, nowMs: 0);
+
+        var delta = q.Reconcile(Devices(), null, nowMs: 100);
+        Assert.Single(delta.ConfirmedDecisions);
+        Assert.False(delta.ConfirmedDecisions[0].Approved);
+    }
+
+    [Fact]
+    public void MarkSubmitted_ReSurfacesAfterTimeoutWhenGatewayNeverActs()
+    {
+        var q = new PairingApprovalQueue();
+        var first = q.Reconcile(Devices(Device("a")), null, nowMs: 0);
+        q.MarkSubmitted(first.Added[0], approved: true, nowMs: 0);
+
+        // Still echoed, before timeout: suppressed, not re-added.
+        var before = q.Reconcile(Devices(Device("a")), null, nowMs: PairingApprovalQueue.SubmissionResolveTimeoutMs - 1);
+        Assert.Empty(before.Added);
+        Assert.Empty(before.Current);
+        Assert.Empty(before.ConfirmedDecisions);
+
+        // Past timeout, still echoed: re-surfaced for retry, NOT confirmed.
+        var after = q.Reconcile(Devices(Device("a")), null, nowMs: PairingApprovalQueue.SubmissionResolveTimeoutMs + 1);
+        Assert.Single(after.Added);
+        Assert.Single(after.Current);
+        Assert.Empty(after.ConfirmedDecisions);
+    }
+
+    [Fact]
+    public void Reconcile_DefersNodeRequestsWhenAsked()
+    {
+        var q = new PairingApprovalQueue();
+        var deferred = q.Reconcile(Devices(Device("dev")), Nodes(Node("n1")), deferNodeRequests: true);
+        Assert.Single(deferred.Added); // only the device
+        Assert.Equal("dev", deferred.Added[0].RequestId);
+
+        // Once no longer deferred, the node request surfaces.
+        var resumed = q.Reconcile(Devices(Device("dev")), Nodes(Node("n1")), deferNodeRequests: false);
+        Assert.Single(resumed.Added);
+        Assert.Equal(PairingApprovalKind.Node, resumed.Added[0].Kind);
+    }
+
+    [Fact]
+    public void Find_ReturnsTrackedButNotSubmitted()
     {
         var q = new PairingApprovalQueue();
         var delta = q.Reconcile(Devices(Device("a")), null);
-        var key = delta.Added[0].Key;
+        var approval = delta.Added[0];
 
-        Assert.NotNull(q.Find(key));
-        q.MarkDecided(key);
-        Assert.Null(q.Find(key));
+        Assert.NotNull(q.Find(approval.Key));
+        q.MarkSubmitted(approval, approved: true, nowMs: 0);
+        Assert.Null(q.Find(approval.Key));
     }
 
     [Fact]

--- a/tests/OpenClaw.Connection.Tests/PairingApprovalQueueTests.cs
+++ b/tests/OpenClaw.Connection.Tests/PairingApprovalQueueTests.cs
@@ -144,10 +144,24 @@ public class PairingApprovalQueueTests
     public void Reconcile_FiltersOwnNodeRequest()
     {
         var q = new PairingApprovalQueue();
-        var delta = q.Reconcile(null, Nodes(Node("self", nodeId: "MY-NODE"), Node("other", nodeId: "OTHER")), ownNodeDeviceId: "my-node");
+        var delta = q.Reconcile(null, Nodes(Node("self", nodeId: "MY-NODE"), Node("other", nodeId: "OTHER")), ownNodeDeviceIds: new[] { "my-node" });
 
         Assert.Single(delta.Added);
         Assert.Equal("other", delta.Added[0].RequestId);
+    }
+
+    [Fact]
+    public void Reconcile_FiltersOwnNodeByAnyAdvertisedId()
+    {
+        var q = new PairingApprovalQueue();
+        // The own node may surface under its device id OR its gateway node id — both must filter.
+        var delta = q.Reconcile(
+            null,
+            Nodes(Node("a", nodeId: "device-fingerprint"), Node("b", nodeId: "gateway-node-id"), Node("c", nodeId: "remote")),
+            ownNodeDeviceIds: new[] { "device-fingerprint", "gateway-node-id" });
+
+        Assert.Single(delta.Added);
+        Assert.Equal("c", delta.Added[0].RequestId);
     }
 
     [Fact]
@@ -236,17 +250,39 @@ public class PairingApprovalQueueTests
     }
 
     [Fact]
-    public void Reconcile_DefersNodeRequestsWhenAsked()
+    public void Reconcile_NullListForKind_CarriesForwardAndDoesNotConfirm()
     {
         var q = new PairingApprovalQueue();
-        var deferred = q.Reconcile(Devices(Device("dev")), Nodes(Node("n1")), deferNodeRequests: true);
-        Assert.Single(deferred.Added); // only the device
-        Assert.Equal("dev", deferred.Added[0].RequestId);
+        // Two kinds present.
+        var first = q.Reconcile(Devices(Device("dev")), Nodes(Node("n1")), nowMs: 0);
+        Assert.Equal(2, first.Current.Count);
 
-        // Once no longer deferred, the node request surfaces.
-        var resumed = q.Reconcile(Devices(Device("dev")), Nodes(Node("n1")), deferNodeRequests: false);
-        Assert.Single(resumed.Added);
-        Assert.Equal(PairingApprovalKind.Node, resumed.Added[0].Kind);
+        // Submit the device decision (optimistic-pending).
+        var dev = first.Added.First(a => a.Kind == PairingApprovalKind.Device);
+        q.MarkSubmitted(dev, approved: true, nowMs: 0);
+
+        // A node-only update arrives (device list is null = no fresh device snapshot). The device
+        // submission must NOT be confirmed by its absence, and the node entry must survive.
+        var nodeOnly = q.Reconcile(null, Nodes(Node("n1")), nowMs: 100);
+        Assert.Empty(nodeOnly.ConfirmedDecisions);
+        Assert.Contains(nodeOnly.Current, a => a.Kind == PairingApprovalKind.Node);
+
+        // When the device list genuinely returns without the request, it confirms.
+        var deviceResolved = q.Reconcile(Devices(), Nodes(Node("n1")), nowMs: 200);
+        Assert.Single(deviceResolved.ConfirmedDecisions);
+        Assert.Equal("dev", deviceResolved.ConfirmedDecisions[0].Approval.RequestId);
+    }
+
+    [Fact]
+    public void Reconcile_NullNodeList_DoesNotDropExistingNodeRequests()
+    {
+        var q = new PairingApprovalQueue();
+        q.Reconcile(Devices(Device("dev")), Nodes(Node("n1")));
+
+        // Device-only refresh (node list null): the node request must not vanish.
+        var delta = q.Reconcile(Devices(Device("dev")), null);
+        Assert.Contains(delta.Current, a => a.Kind == PairingApprovalKind.Node && a.RequestId == "n1");
+        Assert.DoesNotContain("Node:n1", delta.ResolvedKeys);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -57,6 +57,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\GatewayNavVisibilityDebouncePolicy.cs" Link="Services\GatewayNavVisibilityDebouncePolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeInvokeActivityFormatter.cs" Link="Services\NodeInvokeActivityFormatter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeCapabilityGating.cs" Link="Services\NodeCapabilityGating.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\PairingApprovalCoordinator.cs" Link="Services\PairingApprovalCoordinator.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ToastActivationRouter.cs" Link="Services\ToastActivationRouter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\TrayTooltipFormatter.cs" Link="Helpers\TrayTooltipFormatter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\GatewayDashboardUrlBuilder.cs" Link="Helpers\GatewayDashboardUrlBuilder.cs" />

--- a/tests/OpenClaw.Tray.Tests/PairingApprovalCoordinatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/PairingApprovalCoordinatorTests.cs
@@ -1,0 +1,177 @@
+using System.Text.Json;
+using OpenClaw.Shared;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class PairingApprovalCoordinatorTests
+{
+    [Fact]
+    public async Task ApproveAsync_WhenClientChangesBeforeAck_DoesNotMarkSubmitted()
+    {
+        var originalClient = new FakeOperatorGatewayClient();
+        var replacementClient = new FakeOperatorGatewayClient();
+        var approveGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        originalClient.DeviceApproveResult = approveGate.Task;
+        IOperatorGatewayClient? currentClient = originalClient;
+        var coordinator = NewCoordinator(() => currentClient);
+
+        coordinator.OnPairListsUpdated(Devices(Device("req-1")), null);
+        var approval = Assert.Single(coordinator.Current);
+
+        var approveTask = coordinator.ApproveAsync(approval.Key);
+        Assert.Equal(1, originalClient.DeviceApproveCalls);
+
+        currentClient = replacementClient;
+        approveGate.SetResult(true);
+        var result = await approveTask;
+
+        Assert.False(result);
+        Assert.Single(coordinator.Current);
+        Assert.Equal(0, originalClient.DeviceListRequests);
+        Assert.Equal(0, replacementClient.DeviceListRequests);
+    }
+
+    [Fact]
+    public async Task ApproveAsync_WhenSameClientAcks_RecordsSubmissionAndRefreshesList()
+    {
+        var client = new FakeOperatorGatewayClient();
+        var coordinator = NewCoordinator(() => client);
+
+        coordinator.OnPairListsUpdated(Devices(Device("req-1")), null);
+        var approval = Assert.Single(coordinator.Current);
+
+        var result = await coordinator.ApproveAsync(approval.Key);
+
+        Assert.True(result);
+        Assert.Empty(coordinator.Current);
+        Assert.Equal(1, client.DeviceApproveCalls);
+        Assert.Equal(1, client.DeviceListRequests);
+    }
+
+    private static PairingApprovalCoordinator NewCoordinator(Func<IOperatorGatewayClient?> getClient) =>
+        new(
+            getClient,
+            getOwnNodeIds: () => Array.Empty<string>(),
+            isPromptEnabled: () => true,
+            logger: NullLogger.Instance);
+
+    private static DevicePairingListInfo Devices(params DevicePairingRequest[] requests) =>
+        new() { Pending = requests.ToList() };
+
+    private static DevicePairingRequest Device(string requestId) =>
+        new()
+        {
+            RequestId = requestId,
+            DeviceId = $"device-{requestId}",
+            DisplayName = requestId,
+            Scopes = ["operator.read"],
+        };
+
+#pragma warning disable CS0067
+    private sealed class FakeOperatorGatewayClient : IOperatorGatewayClient
+    {
+        public Task<bool> DeviceApproveResult { get; set; } = Task.FromResult(true);
+        public int DeviceApproveCalls { get; private set; }
+        public int DeviceListRequests { get; private set; }
+        public string? OperatorDeviceId => "operator";
+        public IReadOnlyList<string> GrantedOperatorScopes { get; set; } = ["operator.admin"];
+        public bool IsConnectedToGateway { get; set; } = true;
+        public string? MainSessionKey => "main";
+        public bool HasHandshakeSnapshot => true;
+
+        public event EventHandler<OpenClawNotification>? NotificationReceived;
+        public event EventHandler<AgentActivity>? ActivityChanged;
+        public event EventHandler<ChannelHealth[]>? ChannelHealthUpdated;
+        public event EventHandler<SessionInfo[]>? SessionsUpdated;
+        public event EventHandler<GatewayUsageInfo>? UsageUpdated;
+        public event EventHandler<GatewayUsageStatusInfo>? UsageStatusUpdated;
+        public event EventHandler<GatewayCostUsageInfo>? UsageCostUpdated;
+        public event EventHandler<GatewayNodeInfo[]>? NodesUpdated;
+        public event EventHandler<SessionsPreviewPayloadInfo>? SessionPreviewUpdated;
+        public event EventHandler<SessionCommandResult>? SessionCommandCompleted;
+        public event EventHandler<GatewaySelfInfo>? GatewaySelfUpdated;
+        public event EventHandler<JsonElement>? CronListUpdated;
+        public event EventHandler<JsonElement>? CronStatusUpdated;
+        public event EventHandler<JsonElement>? CronRunsUpdated;
+        public event EventHandler<JsonElement>? SkillsStatusUpdated;
+        public event EventHandler<JsonElement>? ConfigUpdated;
+        public event EventHandler<JsonElement>? ConfigSchemaUpdated;
+        public event EventHandler<AgentEventInfo>? AgentEventReceived;
+        public event EventHandler<PairingListInfo>? NodePairListUpdated;
+        public event EventHandler<DevicePairingListInfo>? DevicePairListUpdated;
+        public event EventHandler<ModelsListInfo>? ModelsListUpdated;
+        public event EventHandler<PresenceEntry[]>? PresenceUpdated;
+        public event EventHandler<JsonElement>? AgentsListUpdated;
+        public event EventHandler<JsonElement>? AgentFilesListUpdated;
+        public event EventHandler<JsonElement>? AgentFileContentUpdated;
+        public event EventHandler<AgentEventInfo>? ChatEventReceived;
+        public event EventHandler<ConnectionStatus>? StatusChanged;
+        public event EventHandler<string>? AuthenticationFailed;
+        public event EventHandler<DeviceTokenReceivedEventArgs>? DeviceTokenReceived;
+        public event EventHandler? HandshakeSucceeded;
+
+        public void SetUserRules(IReadOnlyList<UserNotificationRule>? rules) { }
+        public void SetPreferStructuredCategories(bool value) { }
+        public Task SendChatMessageAsync(string message, string? sessionKey = null) => Task.CompletedTask;
+        public Task<ChatSendResult> SendChatMessageForRunAsync(string message, string? sessionKey = null) => Task.FromResult(new ChatSendResult());
+        public Task CheckHealthAsync() => Task.CompletedTask;
+        public Task RequestSessionsAsync(string? agentId = null) => Task.CompletedTask;
+        public Task RequestUsageAsync() => Task.CompletedTask;
+        public Task RequestNodesAsync() => Task.CompletedTask;
+        public Task RequestUsageStatusAsync() => Task.CompletedTask;
+        public Task RequestUsageCostAsync(int days = 30) => Task.CompletedTask;
+        public Task RequestSessionPreviewAsync(string[] keys, int limit = 12, int maxChars = 240) => Task.CompletedTask;
+        public Task<bool> PatchSessionAsync(string key, string? model = null, string? thinkingLevel = null, string? verboseLevel = null) => Task.FromResult(false);
+        public Task<bool> ResetSessionAsync(string key) => Task.FromResult(false);
+        public Task<bool> DeleteSessionAsync(string key, bool deleteTranscript = true) => Task.FromResult(false);
+        public Task<bool> CompactSessionAsync(string key, int maxLines = 400) => Task.FromResult(false);
+        public Task RequestCronListAsync() => Task.CompletedTask;
+        public Task RequestCronStatusAsync() => Task.CompletedTask;
+        public Task<bool> RunCronJobAsync(string jobId, bool force = true) => Task.FromResult(false);
+        public Task<bool> RemoveCronJobAsync(string jobId) => Task.FromResult(false);
+        public Task<bool> AddCronJobAsync(object jobDefinition) => Task.FromResult(false);
+        public Task<bool> UpdateCronJobAsync(string id, object patch) => Task.FromResult(false);
+        public Task RequestCronRunsAsync(string? id = null, int limit = 20, int offset = 0) => Task.CompletedTask;
+        public Task RequestSkillsStatusAsync(string? agentId = null) => Task.CompletedTask;
+        public Task<bool> InstallSkillAsync(string skillId) => Task.FromResult(false);
+        public Task<bool> SetSkillEnabledAsync(string skillKey, bool enabled) => Task.FromResult(false);
+        public Task RequestConfigAsync() => Task.CompletedTask;
+        public Task RequestConfigSchemaAsync() => Task.CompletedTask;
+        public Task<bool> SetConfigAsync(string path, object value) => Task.FromResult(false);
+        public Task<bool> PatchConfigAsync(JsonElement fullConfig, string? baseHash) => Task.FromResult(false);
+        public Task<ConfigPatchResult> PatchConfigDetailedAsync(JsonElement fullConfig, string? baseHash, int timeoutMs = 15000) =>
+            Task.FromResult(new ConfigPatchResult { Ok = false, Error = "stub" });
+        public Task RequestAgentsListAsync() => Task.CompletedTask;
+        public Task RequestAgentFilesListAsync(string agentId = "main") => Task.CompletedTask;
+        public Task RequestAgentFileGetAsync(string agentId, string name) => Task.CompletedTask;
+        public Task RequestModelsListAsync() => Task.CompletedTask;
+        public Task RequestNodePairListAsync() => Task.CompletedTask;
+        public Task<bool> NodePairApproveAsync(string requestId) => Task.FromResult(false);
+        public Task<bool> NodePairRejectAsync(string requestId) => Task.FromResult(false);
+        public Task<NodeForgetResult> NodePairRemoveAsync(string nodeId) => Task.FromResult(new NodeForgetResult(false, "stub"));
+        public Task<NodeRenameResult> NodeRenameAsync(string nodeId, string displayName) => Task.FromResult(new NodeRenameResult(false, ErrorMessage: "stub"));
+        public Task RequestDevicePairListAsync()
+        {
+            DeviceListRequests++;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> DevicePairApproveAsync(string requestId)
+        {
+            DeviceApproveCalls++;
+            return DeviceApproveResult;
+        }
+
+        public Task<bool> DevicePairRejectAsync(string requestId) => Task.FromResult(false);
+        public Task<bool> StartChannelAsync(string channelName) => Task.FromResult(false);
+        public Task<ChannelStartResult?> StartChannelDetailedAsync(string channelName, int timeoutMs = 12000) => Task.FromResult<ChannelStartResult?>(null);
+        public Task<bool> StopChannelAsync(string channelName) => Task.FromResult(false);
+        public Task<ChannelsStatusSnapshot?> GetChannelsStatusAsync(bool probe = false, int timeoutMs = 12000) => Task.FromResult<ChannelsStatusSnapshot?>(null);
+        public Task<bool> LogoutChannelAsync(string channelName, int timeoutMs = 12000) => Task.FromResult(false);
+        public Task<WebLoginStartResult?> WebLoginStartAsync(bool force = false, int timeoutMs = 30000) => Task.FromResult<WebLoginStartResult?>(null);
+        public Task<WebLoginWaitResult?> WebLoginWaitAsync(string? currentQrDataUrl = null, int timeoutMs = 30000) => Task.FromResult<WebLoginWaitResult?>(null);
+        public Task<JsonElement> SendWizardRequestAsync(string method, object? parameters = null, int timeoutMs = 30000) => Task.FromResult(default(JsonElement));
+    }
+#pragma warning restore CS0067
+}

--- a/tests/OpenClaw.Tray.Tests/ToastActivationRouterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ToastActivationRouterTests.cs
@@ -58,6 +58,19 @@ public sealed class ToastActivationRouterTests
     }
 
     [Fact]
+    public void Route_ReviewPairing_InvokesReviewAction()
+    {
+        var calls = new List<string>();
+
+        ToastActivationRouter.Route(
+            "review_pairing",
+            _ => null,
+            BuildActions(calls));
+
+        Assert.Equal(["review"], calls);
+    }
+
+    [Fact]
     public void Route_UnknownAction_NoOps()
     {
         var calls = new List<string>();
@@ -77,6 +90,7 @@ public sealed class ToastActivationRouterTests
         OpenSettings = () => calls.Add("settings"),
         OpenChat = () => calls.Add("chat"),
         OpenActivity = () => calls.Add("activity"),
-        CopyPairingCommand = command => calls.Add($"copy:{command}")
+        CopyPairingCommand = command => calls.Add($"copy:{command}"),
+        ReviewPairing = () => calls.Add("review")
     };
 }


### PR DESCRIPTION
## What & why

When another device or node requests pairing with the gateway, the Windows operator now gets a **focused approval dialog + awareness toast** — matching the macOS `DevicePairingApprovalPrompter` / `NodePairingApprovalPrompter` — instead of only a passive "Pending approvals" banner that's easy to miss.

The plumbing already existed: the client receives the gateway's real-time `device.pair.requested` / `node.pair.requested` push events, but only refreshed an in-memory list. This PR adds the missing "last mile": a proactive, transparent, security-conscious decision surface.

## How it works

**Pure core (`OpenClaw.Connection`, fully unit-tested)**
- `PendingApproval` — unified device/node request model (ID truncation, `::ffff:` IP normalization, repair flag)
- `PairingApprovalQueue` — diff engine producing `Added` / `ResolvedKeys` / `ConfirmedDecisions`. A submitted approve/reject is **optimistic-pending**: suppressed from the actionable set so the UI advances, but only reported **confirmed** once the gateway drops it from the pending list (the authoritative signal — the approve/reject RPC only confirms the frame was *sent*). If the gateway never acts within 10s the submission expires and the request re-surfaces. A null list for a kind means "no fresh snapshot" (carried forward), never "now empty". Own-node requests are filtered by matching any advertised id.
- `PairingScopeDescriptions` — operator scope → friendly label (ported from the Mac prompt)

**Orchestration + UI (`OpenClaw.Tray.WinUI`)**
- `PairingApprovalCoordinator` — bridges the queue to the live operator client; gated on `operator.pairing`/`admin` scope + the `ShowPairingApprovalDialog` setting; in-flight + reconnect-race guards; a 20s safety-net reconcile poll that recovers requests dropped by the gateway's `dropIfSlow=true` broadcast
- `PairingApprovalDialog` — code-built `WindowEx` (sidesteps the documented XAML-compiler bug); shows requester identity + **the operator scopes being granted**, kind-aware Approve label, **~1.5s anti-clickthrough delay**, queue navigation, Approve / Reject / Decide-later
- Wiring: `GatewayService.PairListsChanged` feed, awareness + confirmation toasts, `review_pairing` toast action, reset on disconnect, foreground-steal limited to once per reconnect burst, shutdown teardown
- New `ShowPairingApprovalDialog` setting (default **on**); the in-page banner remains as the passive fallback

Localized across all 5 locales (en/fr/nl/zh-CN/zh-TW); `CONNECTION_ARCHITECTURE.md` updated.

## Security posture
- Approve is never the default button and is briefly disabled per request (anti click-through)
- Connection **and** approval scope are re-checked at decision time (not just connection)
- The dialog shows exactly which operator scopes are being granted, in plain language
- The local node's own pairing is never prompted (handled by the separate auto-approve path)

## Reviewer guide
- Logic to scrutinize: `PairingApprovalQueue.Reconcile` (the optimistic-pending state machine) and `PairingApprovalCoordinator.DecideAsync` / `OnPairListsUpdated`.
- Decision semantics: a confirmation toast fires on **confirmed resolution** (request left the pending list), not on send-ack.
- **Known, accepted limitations** (documented, not bugs): in a rare multi-operator race the confirmation toast may show the wrong verb (the gateway remains the source of truth, visible in the devices list); a submitted decision can be delayed re-surfacing if approval scope is lost mid-connection (self-heals on reconnect). Both stem from the approve/reject RPC being send-acked rather than gateway-acked; fully closing them would require a response-aware RPC that reaches into the auto-approve core path + ConnectionPage and depends on unverified gateway reply behavior — intentionally out of scope.

## Validation
- `./build.ps1` — all 5 projects ✅
- `OpenClaw.Connection.Tests` ✅ 303 (incl. confirmed-resolution / timeout-resurface / null-list / own-id-set cases)
- `OpenClaw.Shared.Tests` ✅ 2049 · `OpenClaw.Tray.Tests` ✅ 959

Runtime popup behavior should be confirmed with a manual smoke test against a live gateway (per AGENTS.md).