### PR TITLE
Detect unsupported WSL status during setup preflight

### DIFF
--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -137,6 +137,19 @@ internal static class WslInstallSupport
             return true;
         }
 
+        // Observed from `wsl --status` when WSL2 cannot start because the
+        // host still needs Virtual Machine Platform and/or firmware
+        // virtualization enabled, even though `wsl --version` succeeds.
+        if (Contains(text, "WSL2 is not supported with your current machine configuration"))
+        {
+            message = "WSL2 is not supported with the current machine configuration. "
+                + "Enable the Windows 'Virtual Machine Platform' support by running "
+                + "`wsl --install --no-distribution` from an elevated PowerShell (or enable "
+                + "'Virtual Machine Platform' under 'Turn Windows features on or off'), ensure "
+                + "hardware virtualization is enabled in BIOS/UEFI, reboot, then retry setup.";
+            return true;
+        }
+
         // Required Windows feature missing (Virtual Machine Platform and/or
         // Hyper-V). 0x80370102 = HCS_E_SERVICE_NOT_AVAILABLE, emitted verbatim
         // by wsl.exe as "The virtual machine could not be started because a

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -644,6 +644,22 @@ public class SetupStepsTests : IDisposable
     }
 
     [Fact]
+    public void WslInstallSupport_TryGetEnvironmentIssue_DetectsUnsupportedMachineConfigurationStatus()
+    {
+        var status = NulSeparated("Default Version: 2\r\n\r\n"
+            + "WSL2 is not supported with your current machine configuration.\r\n\r\n"
+            + "Please enable the \"Virtual Machine Platform\" optional component and ensure virtualization is enabled in the BIOS.\r\n\r\n"
+            + "Enable \"Virtual Machine Platform\" by running: wsl.exe --install --no-distribution\r\n\r\n"
+            + "For information please visit https://aka.ms/enablevirtualization\r\n");
+
+        Assert.True(WslInstallSupport.TryGetEnvironmentIssue(status, out var message));
+        Assert.Contains("Virtual Machine Platform", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("virtualization", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("wsl --install --no-distribution", message);
+        Assert.Contains("reboot", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void WslInstallSupport_TryGetEnvironmentIssue_ReturnsFalseForHealthyStatus()
     {
         Assert.False(WslInstallSupport.TryGetEnvironmentIssue(
@@ -697,6 +713,33 @@ public class SetupStepsTests : IDisposable
         Assert.Equal(StepOutcome.FailedTerminal, result.Outcome);
         Assert.Contains("Virtual Machine Platform", result.Message);
         Assert.Contains("wsl --install --no-distribution", result.Message);
+    }
+
+    [Fact]
+    public async Task PreflightWsl_FailsTerminalWhenStatusReportsUnsupportedMachineConfiguration()
+    {
+        var commands = new FakeCommandRunner(args =>
+        {
+            if (args is ["--version"])
+                return Ok("WSL version: 2.5.9.0\n");
+            if (args is ["--status"])
+                return Ok(NulSeparated(
+                    "Default Version: 2\r\n\r\n"
+                    + "WSL2 is not supported with your current machine configuration.\r\n\r\n"
+                    + "Please enable the \"Virtual Machine Platform\" optional component and ensure virtualization is enabled in the BIOS.\r\n\r\n"
+                    + "Enable \"Virtual Machine Platform\" by running: wsl.exe --install --no-distribution\r\n\r\n"
+                    + "For information please visit https://aka.ms/enablevirtualization\r\n"));
+            return Fail($"unexpected args: {string.Join(' ', args)}");
+        });
+        var ctx = CreateContext(commands: commands);
+
+        var result = await new PreflightWslStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(StepOutcome.FailedTerminal, result.Outcome);
+        Assert.Contains("Virtual Machine Platform", result.Message);
+        Assert.Contains("virtualization", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("wsl --install --no-distribution", result.Message);
+        Assert.DoesNotContain(commands.Calls, c => c.Arguments.Contains("--install"));
     }
 
     [Fact]
@@ -1281,6 +1324,9 @@ public class SetupStepsTests : IDisposable
 
     private static CommandResult TimedOut()
         => new(-1, "", "", TimeSpan.FromSeconds(30), TimedOut: true);
+
+    private static string NulSeparated(string value)
+        => string.Join("\0", value.ToCharArray()) + "\0";
 
     private sealed class FakeCommandRunner(
         Func<string[], CommandResult> run,


### PR DESCRIPTION
Closes #775.

Adds the observed `wsl --status` unsupported-machine diagnostic to WSL environment issue detection, so setup stops during preflight with Virtual Machine Platform and virtualization reboot guidance before attempting distro creation.

Adds regression coverage for the NUL-separated status output shape from the attached setup log and the preflight failure path.