### PR TITLE
Add Gateway system.run MXC runtime E2E proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,16 +293,19 @@ jobs:
     needs: repo-hygiene
     if: ${{ !cancelled() }}
     runs-on: windows-latest
-    timeout-minutes: 25
+    timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: setup-connect
+            timeout_minutes: 45
             filter: "FullyQualifiedName~OpenClaw.E2ETests.Setup.SetupAndConnectTests|FullyQualifiedName~OpenClaw.E2ETests.Setup.MxcSetupAndConnectTests"
           - name: revocation-recovery
+            timeout_minutes: 25
             filter: FullyQualifiedName~OpenClaw.E2ETests.Setup.RevocationAndRecoveryTests
           - name: network-recovery
+            timeout_minutes: 25
             filter: FullyQualifiedName~OpenClaw.E2ETests.Setup.NetworkRecoveryTests
     steps:
     - name: Fail if repo hygiene failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,7 @@ jobs:
       matrix:
         include:
           - name: setup-connect
-            filter: FullyQualifiedName~OpenClaw.E2ETests.Setup.SetupAndConnectTests
+            filter: "FullyQualifiedName~OpenClaw.E2ETests.Setup.SetupAndConnectTests|FullyQualifiedName~OpenClaw.E2ETests.Setup.MxcSetupAndConnectTests"
           - name: revocation-recovery
             filter: FullyQualifiedName~OpenClaw.E2ETests.Setup.RevocationAndRecoveryTests
           - name: network-recovery
@@ -365,6 +365,36 @@ jobs:
         if ($executed -lt 1) {
           Write-Error "E2E shard '${{ matrix.name }}' executed zero tests. Check OPENCLAW_RUN_E2E gating/filter before merging."
           exit 1
+        }
+        if ("${{ matrix.name }}" -eq "setup-connect") {
+          $mxcProofNames = @(
+            "RealGateway_SystemRun_ExecutesThroughWindowsNodeMxcSandbox",
+            "RealGateway_SystemRun_BlocksWritesToTrayDataDirectoryInMxcSandbox"
+          )
+
+          foreach ($mxcProofName in $mxcProofNames) {
+            $mxcProof = @($trx.TestRun.Results.UnitTestResult | Where-Object { $_.testName -like "*$mxcProofName*" }) | Select-Object -First 1
+            if ($null -eq $mxcProof) {
+              Write-Error "E2E shard '${{ matrix.name }}' did not report the MXC proof test '$mxcProofName'. Check the setup-connect filter before merging."
+              exit 1
+            }
+
+            $mxcOutcome = [string]$mxcProof.outcome
+            if ($mxcOutcome -eq "Passed") {
+              Write-Host "MXC E2E proof passed: $mxcProofName"
+            } elseif ($mxcOutcome -eq "NotExecuted" -or $mxcOutcome -eq "Skipped") {
+              $mxcSkipReason = @($mxcProof.Output.ErrorInfo.Message, $mxcProof.Output.StdOut) |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                Select-Object -First 1
+              if ([string]::IsNullOrWhiteSpace($mxcSkipReason)) {
+                $mxcSkipReason = "skip reason was not present in the trx output"
+              }
+              Write-Warning "MXC E2E proof skipped: $mxcProofName; $mxcSkipReason"
+            } else {
+              Write-Error "MXC E2E proof '$mxcProofName' had unexpected outcome '$mxcOutcome'."
+              exit 1
+            }
+          }
         }
 
     - name: Upload E2E Test Results & Logs

--- a/docs/WINDOWS_NODE_TESTING.md
+++ b/docs/WINDOWS_NODE_TESTING.md
@@ -129,6 +129,29 @@ When the node connects, it advertises these capabilities:
   dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --filter "FullyQualifiedName~Mxc"
   ```
 
+### Full Gateway `system.run` MXC runtime proof
+- The focused E2E below provisions a fresh WSL Gateway, starts an isolated tray instance, sets a local exec approval rule through MCP, invokes `system.run` through the real Gateway `node.invoke` path, and verifies tray MXC diagnostics show contained `mxc-direct-appc` execution for both allowed execution and denied writes to the tray data directory.
+- Run it when validating the Gateway/Windows node runtime path, not just direct MCP or shared library behavior.
+- When reproducing this manually against an existing Gateway, make sure `gateway.nodes.allowCommands` includes `system.run`, `system.run.prepare`, and `system.which`, then approve any `pending-reapproval` request with `openclaw nodes approve <pendingRequestId>`. The node can advertise `system.run` while the Gateway still blocks it until both gates are updated.
+
+  ```powershell
+  .\build.ps1
+  $env:OPENCLAW_REPO_ROOT = (Get-Location).Path
+  $env:OPENCLAW_RUN_E2E = "1"
+  dotnet test .\tests\OpenClaw.E2ETests\OpenClaw.E2ETests.csproj `
+    --no-restore `
+    --filter "FullyQualifiedName~RealGateway_SystemRun_ExecutesThroughWindowsNodeMxcSandbox" `
+    --logger "console;verbosity=normal" `
+    -r win-x64
+  ```
+
+- Expected proof markers:
+  - Gateway response contains `OPENCLAW_GATEWAY_SYSTEM_RUN_MXC_OK` with `exitCode=0`.
+  - The denied-write proof targets a fresh file under the isolated tray data directory, returns non-zero, and leaves that file absent.
+  - `openclaw-tray.log` contains `[mxc] system.run sandbox request` with `executor=mxc-direct-appc`, `contained=True`, and `shell=cmd`.
+  - `openclaw-tray.log` contains `[mxc] system.run sandbox result` with `containment=mxc` for both the successful execution and the denied write.
+- E2E artifacts are written under `TestResults\E2E\<run-id>` and skip known secret-bearing files such as gateway records and settings.
+
 ## Remaining Work (Roadmap)
 
 1. ~~**system.run + exec approvals**~~ ✅ Implemented

--- a/src/OpenClaw.Shared/Mxc/MxcConfigBuilder.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcConfigBuilder.cs
@@ -65,7 +65,6 @@ public static class MxcConfigBuilder
         if (request is null) throw new ArgumentNullException(nameof(request));
         if (string.IsNullOrWhiteSpace(scratchDir)) throw new ArgumentException("scratchDir required", nameof(scratchDir));
         if (context is null) throw new ArgumentNullException(nameof(context));
-        var deniedPathExists = context.DeniedPathExists ?? PathExists;
         var readonlyGrantIsBackendSafe = context.ReadonlyGrantIsBackendSafe ?? IsBackendSafeReadonlyGrant;
 
         var policy = request.Policy;
@@ -107,13 +106,11 @@ public static class MxcConfigBuilder
             rwFromPolicy.Add(scratchDir);
 
         // denied list from policy (settings dir, ~/.ssh, browser profiles, ...).
-        // Use the full list for local allow-list filtering, but do not emit
-        // known host profile roots to the MXC DACL fallback: those paths often
-        // cannot be prepared and make the sandbox fail before command launch.
+        // Keep the full list for local allow-list filtering, but do not emit
+        // filesystem.deniedPaths to wxc-exec. Windows MXC 0.7 rejects that field;
+        // omitted grants remain denied by default inside the AppContainer.
         var deniedForFiltering = (policy?.Filesystem?.DeniedPaths ?? Array.Empty<string>()).ToList();
-        var deniedForBackend = deniedForFiltering
-            .Where(path => ShouldEmitDeniedPathToBackend(path, deniedPathExists))
-            .ToList();
+        string[]? deniedForBackend = null;
 
         // cwd auto-grant — AppContainer does not auto-grant the working
         // directory. Give ungranted cwd read access so shells can start, but
@@ -188,7 +185,7 @@ public static class MxcConfigBuilder
             {
                 ReadonlyPaths = roFromPolicy.ToArray(),
                 ReadwritePaths = rwFromPolicy.ToArray(),
-                DeniedPaths = deniedForBackend.ToArray(),
+                DeniedPaths = deniedForBackend,
                 // SDK output didn't include clearPolicyOnExit even when the
                 // input policy had it set, so we omit it here too.
                 ClearPolicyOnExit = null,
@@ -385,59 +382,6 @@ public static class MxcConfigBuilder
             .ToList();
     }
 
-    private static bool ShouldEmitDeniedPathToBackend(string path, Func<string, bool> pathExists)
-    {
-        var normalized = NormalizePath(path);
-        if (string.IsNullOrWhiteSpace(normalized))
-            return false;
-
-        foreach (var hostProfileRoot in HostProfileDenyRoots())
-        {
-            var root = NormalizePath(hostProfileRoot);
-            if (!string.IsNullOrWhiteSpace(root) && IsSameOrNested(normalized, root))
-                return false;
-        }
-
-        try
-        {
-            if (!pathExists(normalized))
-                return false;
-        }
-        catch
-        {
-            return false;
-        }
-
-        return true;
-    }
-
-    private static bool PathExists(string path) => Directory.Exists(path) || File.Exists(path);
-
-    private static IEnumerable<string> HostProfileDenyRoots()
-    {
-        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-
-        if (!string.IsNullOrWhiteSpace(userProfile))
-        {
-            yield return Path.Combine(userProfile, ".ssh");
-        }
-
-        if (!string.IsNullOrWhiteSpace(localAppData))
-        {
-            yield return Path.Combine(localAppData, "Google", "Chrome", "User Data");
-            yield return Path.Combine(localAppData, "Microsoft", "Edge", "User Data");
-            yield return Path.Combine(localAppData, "BraveSoftware", "Brave-Browser", "User Data");
-        }
-
-        if (!string.IsNullOrWhiteSpace(appData))
-        {
-            yield return Path.Combine(appData, "Mozilla", "Firefox", "Profiles");
-            yield return Path.Combine(appData, "Microsoft", "Windows", "PowerShell", "PSReadLine");
-        }
-    }
-
     private static bool IsCoveredBy(string candidate, IEnumerable<string> ancestors)
     {
         var nc = NormalizePath(candidate);
@@ -538,7 +482,6 @@ public static class MxcConfigBuilder
 internal sealed record MxcConfigBuildContext(
     string? ContainerId = null,
     string? PathEnvVar = null,
-    Func<string, bool>? DeniedPathExists = null,
     Func<string, bool>? ReadonlyGrantIsBackendSafe = null)
 {
     public static MxcConfigBuildContext Default { get; } = new();

--- a/tests/OpenClaw.E2ETests/E2EFactAttribute.cs
+++ b/tests/OpenClaw.E2ETests/E2EFactAttribute.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using OpenClaw.Shared.Mxc;
 
 namespace OpenClaw.E2ETests;
 
@@ -14,6 +15,132 @@ public sealed class E2EFactAttribute : FactAttribute
         if (!E2ETestGate.IsEnabled)
             Skip = $"E2E tests disabled. Set {E2ETestGate.EnvVar}=1 to enable.";
     }
+}
+
+/// <summary>
+/// Focused E2E tests that require MXC support must not fail the regular E2E
+/// shard on Windows runners where the Gateway path works but MXC is unavailable.
+/// </summary>
+public sealed class MxcE2EFactAttribute : FactAttribute
+{
+    public MxcE2EFactAttribute()
+    {
+        Skip = MxcE2ETestGate.SkipReason;
+    }
+}
+
+internal static class MxcE2ETestGate
+{
+    private static readonly Lazy<string?> s_skipReason = new(GetSkipReason);
+
+    public static string? SkipReason => s_skipReason.Value;
+
+    private static string? GetSkipReason()
+    {
+        if (!E2ETestGate.IsEnabled)
+            return $"E2E tests disabled. Set {E2ETestGate.EnvVar}=1 to enable.";
+
+        try
+        {
+            var availability = MxcAvailability.Probe();
+            var hasBackend = availability.IsAppContainerAvailable || availability.IsIsolationSessionAvailable;
+            if (!hasBackend)
+            {
+                var reason = availability.UnsupportedReasons.Count == 0
+                    ? "MXC backend is unavailable."
+                    : string.Join("; ", availability.UnsupportedReasons);
+                return $"MXC E2E test skipped: {reason}";
+            }
+
+            if (!availability.IsWxcExecResolvable && !HasE2EWxcExec())
+            {
+                var reason = availability.UnsupportedReasons.Count == 0
+                    ? "wxc-exec.exe is unavailable."
+                    : string.Join("; ", availability.UnsupportedReasons);
+                return $"MXC E2E test skipped: {reason}";
+            }
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return $"MXC E2E test skipped: availability probe failed ({ex.GetType().Name}: {ex.Message}).";
+        }
+    }
+
+    private static bool HasE2EWxcExec()
+    {
+        var overridePath = Environment.GetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar);
+        if (FileExists(overridePath))
+            return true;
+
+        foreach (var repoRoot in CandidateRepoRoots())
+        {
+            var arch = GetSdkArchString();
+            if (FileExists(Path.Combine(repoRoot, "node_modules", "@microsoft", "mxc-sdk", "bin", arch, "wxc-exec.exe")))
+                return true;
+
+            var trayBin = Path.Combine(repoRoot, "src", "OpenClaw.Tray.WinUI", "bin");
+            if (Directory.Exists(trayBin))
+            {
+                try
+                {
+                    if (Directory.EnumerateFiles(trayBin, "wxc-exec.exe", SearchOption.AllDirectories).Any())
+                        return true;
+                }
+                catch
+                {
+                    // Discovery-only guard; a failed search should become an
+                    // ordinary MXC skip rather than a discovery failure.
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<string> CandidateRepoRoots()
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var start in new[]
+        {
+            Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT"),
+            Directory.GetCurrentDirectory(),
+            AppContext.BaseDirectory,
+        })
+        {
+            if (string.IsNullOrWhiteSpace(start))
+                continue;
+
+            var dir = Directory.Exists(start)
+                ? new DirectoryInfo(start)
+                : new FileInfo(start).Directory;
+            while (dir is not null)
+            {
+                if (File.Exists(Path.Combine(dir.FullName, "package.json"))
+                    && Directory.Exists(Path.Combine(dir.FullName, "src", "OpenClaw.Tray.WinUI")))
+                {
+                    if (seen.Add(dir.FullName))
+                        yield return dir.FullName;
+                    break;
+                }
+                dir = dir.Parent;
+            }
+        }
+    }
+
+    private static bool FileExists(string? path)
+    {
+        try { return !string.IsNullOrWhiteSpace(path) && File.Exists(path); }
+        catch { return false; }
+    }
+
+    private static string GetSdkArchString() => System.Runtime.InteropServices.RuntimeInformation.OSArchitecture switch
+    {
+        System.Runtime.InteropServices.Architecture.Arm64 => "arm64",
+        System.Runtime.InteropServices.Architecture.X64 => "x64",
+        _ => "x64",
+    };
 }
 
 internal static class E2ETestGate

--- a/tests/OpenClaw.E2ETests/E2EFactAttribute.cs
+++ b/tests/OpenClaw.E2ETests/E2EFactAttribute.cs
@@ -42,7 +42,7 @@ internal static class MxcE2ETestGate
 
         try
         {
-            var availability = MxcAvailability.Probe();
+            var availability = ProbeAvailabilityForE2E();
             var hasBackend = availability.IsAppContainerAvailable || availability.IsIsolationSessionAvailable;
             if (!hasBackend)
             {
@@ -52,7 +52,7 @@ internal static class MxcE2ETestGate
                 return $"MXC E2E test skipped: {reason}";
             }
 
-            if (!availability.IsWxcExecResolvable && !HasE2EWxcExec())
+            if (!availability.IsWxcExecResolvable && !TryFindE2EWxcExec(out _))
             {
                 var reason = availability.UnsupportedReasons.Count == 0
                     ? "wxc-exec.exe is unavailable."
@@ -68,25 +68,56 @@ internal static class MxcE2ETestGate
         }
     }
 
-    private static bool HasE2EWxcExec()
+    private static MxcAvailability ProbeAvailabilityForE2E()
+    {
+        if (TryFindE2EWxcExec(out var wxcExecPath))
+        {
+            var previousOverride = Environment.GetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar);
+            try
+            {
+                Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, wxcExecPath);
+                return MxcAvailability.Probe();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, previousOverride);
+            }
+        }
+
+        return MxcAvailability.Probe();
+    }
+
+    private static bool TryFindE2EWxcExec(out string? path)
     {
         var overridePath = Environment.GetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar);
         if (FileExists(overridePath))
+        {
+            path = overridePath;
             return true;
+        }
 
         foreach (var repoRoot in CandidateRepoRoots())
         {
             var arch = GetSdkArchString();
-            if (FileExists(Path.Combine(repoRoot, "node_modules", "@microsoft", "mxc-sdk", "bin", arch, "wxc-exec.exe")))
+            var nodeModulesWxcExec = Path.Combine(repoRoot, "node_modules", "@microsoft", "mxc-sdk", "bin", arch, "wxc-exec.exe");
+            if (FileExists(nodeModulesWxcExec))
+            {
+                path = nodeModulesWxcExec;
                 return true;
+            }
 
             var trayBin = Path.Combine(repoRoot, "src", "OpenClaw.Tray.WinUI", "bin");
             if (Directory.Exists(trayBin))
             {
                 try
                 {
-                    if (Directory.EnumerateFiles(trayBin, "wxc-exec.exe", SearchOption.AllDirectories).Any())
+                    var trayWxcExec = Directory.EnumerateFiles(trayBin, "wxc-exec.exe", SearchOption.AllDirectories)
+                        .FirstOrDefault(file => file.EndsWith(Path.Combine("mxc", arch, "wxc-exec.exe"), StringComparison.OrdinalIgnoreCase));
+                    if (FileExists(trayWxcExec))
+                    {
+                        path = trayWxcExec;
                         return true;
+                    }
                 }
                 catch
                 {
@@ -96,6 +127,7 @@ internal static class MxcE2ETestGate
             }
         }
 
+        path = null;
         return false;
     }
 

--- a/tests/OpenClaw.E2ETests/Setup/E2ESetupFixture.cs
+++ b/tests/OpenClaw.E2ETests/Setup/E2ESetupFixture.cs
@@ -22,6 +22,8 @@ namespace OpenClaw.E2ETests.Setup;
 /// </summary>
 public sealed class E2ESetupFixture : IAsyncLifetime
 {
+    private readonly Action<Dictionary<string, object>>? _settingsPatch;
+
     /// <summary>
     /// Persistent artifact directory that survives test cleanup.
     /// CI uploads this as a test artifact for post-mortem debugging.
@@ -51,7 +53,14 @@ public sealed class E2ESetupFixture : IAsyncLifetime
     private Process? _trayProcess;
 
     public E2ESetupFixture()
+        : this(settingsPatch: null)
     {
+    }
+
+    internal E2ESetupFixture(Action<Dictionary<string, object>>? settingsPatch)
+    {
+        _settingsPatch = settingsPatch;
+
         if (!E2ETestGate.IsEnabled)
         {
             _distroName = "OpenClawE2E-disabled";
@@ -257,7 +266,7 @@ public sealed class E2ESetupFixture : IAsyncLifetime
         File.WriteAllText(_configPath, json);
     }
 
-    private static void PatchSettingsForMcp(string settingsPath)
+    private void PatchSettingsForMcp(string settingsPath)
     {
         var json = File.ReadAllText(settingsPath);
         var settings = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json) ?? [];
@@ -269,6 +278,7 @@ public sealed class E2ESetupFixture : IAsyncLifetime
         merged["HasSeenActivityStreamTip"] = true;
         merged["ShowNotifications"] = false;
         merged["GlobalHotkeyEnabled"] = false;
+        _settingsPatch?.Invoke(merged);
         File.WriteAllText(settingsPath, JsonSerializer.Serialize(merged, new JsonSerializerOptions { WriteIndented = true }));
     }
 

--- a/tests/OpenClaw.E2ETests/Setup/MxcE2ESetupFixture.cs
+++ b/tests/OpenClaw.E2ETests/Setup/MxcE2ESetupFixture.cs
@@ -24,7 +24,11 @@ public sealed class MxcE2ESetupFixture : IAsyncLifetime
         if (MxcE2ETestGate.SkipReason is not null)
             return;
 
-        _inner = new E2ESetupFixture(settings => settings["SandboxTimeoutMs"] = 120_000);
+        _inner = new E2ESetupFixture(settings =>
+        {
+            settings["SandboxTimeoutMs"] = 120_000;
+            settings["SystemRunBlockHostFallbackWhenMxcUnavailable"] = true;
+        });
         await _inner.InitializeAsync();
     }
 

--- a/tests/OpenClaw.E2ETests/Setup/MxcE2ESetupFixture.cs
+++ b/tests/OpenClaw.E2ETests/Setup/MxcE2ESetupFixture.cs
@@ -3,6 +3,8 @@ using Xunit;
 
 namespace OpenClaw.E2ETests.Setup;
 
+// AssemblyInfo disables parallelization for the whole E2E assembly; this separate
+// collection exists so the MXC gate can skip before initializing WSL/tray state.
 [CollectionDefinition("E2E MXC Setup", DisableParallelization = true)]
 public sealed class MxcE2ESetupCollection : ICollectionFixture<MxcE2ESetupFixture> { }
 

--- a/tests/OpenClaw.E2ETests/Setup/MxcE2ESetupFixture.cs
+++ b/tests/OpenClaw.E2ETests/Setup/MxcE2ESetupFixture.cs
@@ -24,7 +24,7 @@ public sealed class MxcE2ESetupFixture : IAsyncLifetime
         if (MxcE2ETestGate.SkipReason is not null)
             return;
 
-        _inner = new E2ESetupFixture();
+        _inner = new E2ESetupFixture(settings => settings["SandboxTimeoutMs"] = 120_000);
         await _inner.InitializeAsync();
     }
 

--- a/tests/OpenClaw.E2ETests/Setup/MxcE2ESetupFixture.cs
+++ b/tests/OpenClaw.E2ETests/Setup/MxcE2ESetupFixture.cs
@@ -1,0 +1,34 @@
+using OpenClaw.E2ETests;
+using Xunit;
+
+namespace OpenClaw.E2ETests.Setup;
+
+[CollectionDefinition("E2E MXC Setup", DisableParallelization = true)]
+public sealed class MxcE2ESetupCollection : ICollectionFixture<MxcE2ESetupFixture> { }
+
+/// <summary>
+/// Gates the expensive setup fixture before xUnit initializes WSL/tray state for
+/// MXC-only proofs. Method-level skips are too late for collection fixtures.
+/// </summary>
+public sealed class MxcE2ESetupFixture : IAsyncLifetime
+{
+    private E2ESetupFixture? _inner;
+
+    public E2ESetupFixture Inner => _inner
+        ?? throw new InvalidOperationException($"MXC E2E fixture was not initialized: {MxcE2ETestGate.SkipReason ?? "unknown reason"}");
+
+    public async Task InitializeAsync()
+    {
+        if (MxcE2ETestGate.SkipReason is not null)
+            return;
+
+        _inner = new E2ESetupFixture();
+        await _inner.InitializeAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_inner is not null)
+            await _inner.DisposeAsync();
+    }
+}

--- a/tests/OpenClaw.E2ETests/Setup/MxcSetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/MxcSetupAndConnectTests.cs
@@ -100,7 +100,8 @@ public sealed class MxcSetupAndConnectTests
     {
         const string marker = "OPENCLAW_GATEWAY_SYSTEM_RUN_MXC_DENIED";
         var blockedPath = Path.Combine(_fixture.DataDir, $"mxc-denied-write-{Guid.NewGuid():N}.txt");
-        var blockedPathForCmd = blockedPath.Replace(Path.DirectorySeparatorChar, '/');
+        var blockedPathForCmd = blockedPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var sourcePathForCmd = "%TEMP%\\openclaw-mxc-denied-source.txt";
 
         await AssertPrimaryTrayReadyAndGatewayCliHealthyAsync();
         await SetExecApprovalForSystemRunProofAsync();
@@ -117,7 +118,7 @@ public sealed class MxcSetupAndConnectTests
             command = "system.run",
             @params = new
             {
-                command = $"echo {marker} > {CmdQuote(blockedPathForCmd)}",
+                command = $"echo {marker} > {CmdQuote(sourcePathForCmd)} && copy /Y {CmdQuote(sourcePathForCmd)} {CmdQuote(blockedPathForCmd)}",
                 shell = "cmd",
                 timeoutMs = SystemRunProofTimeoutMs
             },
@@ -147,12 +148,13 @@ public sealed class MxcSetupAndConnectTests
         var stderr = payload.TryGetProperty("stderr", out var stderrElement)
             ? stderrElement.GetString() ?? ""
             : "";
+        var combinedOutput = stdout + stderr;
 
         // The shell's access-denied text is localized; the load-bearing proof is no timeout,
         // non-zero denied-write exit, no file creation, and MXC containment in the tray log.
         Assert.NotEqual(0, exitCode);
-        Assert.True(stderr.Length > 0, $"Expected denied write to emit stderr; payload: {payload.GetRawText()}");
-        Assert.DoesNotContain(marker, stdout, StringComparison.Ordinal);
+        Assert.True(combinedOutput.Length > 0, $"Expected denied write to emit output; payload: {payload.GetRawText()}");
+        Assert.DoesNotContain(marker, combinedOutput, StringComparison.Ordinal);
         Assert.False(File.Exists(blockedPath),
             $"MXC sandbox should not create files inside the tray data/settings directory: {blockedPath}");
 

--- a/tests/OpenClaw.E2ETests/Setup/MxcSetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/MxcSetupAndConnectTests.cs
@@ -1,0 +1,429 @@
+using System.Text.Json;
+using OpenClaw.SetupEngine;
+
+namespace OpenClaw.E2ETests.Setup;
+
+[Collection("E2E MXC Setup")]
+public sealed class MxcSetupAndConnectTests
+{
+    private readonly E2ESetupFixture _fixture;
+
+    public MxcSetupAndConnectTests(MxcE2ESetupFixture fixture)
+    {
+        _fixture = fixture.Inner;
+
+        if (_fixture.SetupError is not null)
+            throw new InvalidOperationException($"E2E setup failed: {_fixture.SetupError}");
+        if (_fixture.Client is null)
+            throw new InvalidOperationException("E2E fixture MCP client not initialized");
+    }
+
+    [MxcE2EFact]
+    public async Task RealGateway_SystemRun_ExecutesThroughWindowsNodeMxcSandbox()
+    {
+        const string marker = "OPENCLAW_GATEWAY_SYSTEM_RUN_MXC_OK";
+
+        await AssertPrimaryTrayReadyAndGatewayCliHealthyAsync();
+        await SetExecApprovalForSystemRunProofAsync();
+
+        var gateway = _fixture.ReadActiveGatewayRecord();
+        var env = GatewayTokenEnv(gateway.SharedGatewayToken);
+        var nodeId = _fixture.ReadActiveGatewayDeviceId();
+        var logCursor = GetTrayLogCursor();
+        var invokeParams = JsonSerializer.Serialize(new
+        {
+            nodeId,
+            command = "system.run",
+            @params = new
+            {
+                command = $"echo {marker}",
+                shell = "cmd",
+                timeoutMs = 10_000
+            },
+            timeoutMs = 30_000,
+            idempotencyKey = Guid.NewGuid().ToString("N")
+        });
+
+        var invoke = await _fixture.RunInWslAsync(
+            $"openclaw gateway call node.invoke --params {ShellSingleQuote(invokeParams)} --json --timeout 45000",
+            TimeSpan.FromSeconds(45),
+            env);
+
+        AssertCommandSucceeded(invoke, "invoke Windows node system.run through real gateway");
+        Assert.Contains(marker, invoke.Stdout, StringComparison.Ordinal);
+
+        using var invokeDoc = JsonDocument.Parse(ExtractJsonObject(invoke.Stdout));
+        var responseShape = string.Join(",", invokeDoc.RootElement.EnumerateObject().Select(property => property.Name));
+        Console.WriteLine($"[E2E] gateway node.invoke system.run response shape: {responseShape}");
+        if (invokeDoc.RootElement.TryGetProperty("ok", out var ok))
+        {
+            Assert.True(ok.GetBoolean(), $"Expected gateway node.invoke ok=true; response: {invokeDoc.RootElement.GetRawText()}");
+        }
+
+        var payload = ReadNodeInvokePayload(invokeDoc.RootElement);
+        Assert.Equal(0, payload.GetProperty("exitCode").GetInt32());
+        if (payload.TryGetProperty("timedOut", out var timedOut))
+            Assert.False(timedOut.GetBoolean(), $"system.run timed out; payload: {payload.GetRawText()}");
+
+        var stdout = payload.GetProperty("stdout").GetString() ?? "";
+        Assert.Contains(marker, stdout, StringComparison.Ordinal);
+        var stderrLength = payload.TryGetProperty("stderr", out var stderr)
+            ? (stderr.GetString() ?? "").Length
+            : 0;
+        Console.WriteLine($"[E2E] gateway system.run payload: exitCode=0; stdout={stdout.Trim()}; stderrLength={stderrLength}");
+
+        var requestLog = await WaitForTrayLogLineContainingAsync(
+            TimeSpan.FromSeconds(30),
+            logCursor,
+            "[mxc] system.run sandbox request",
+            "executor=mxc-direct-appc",
+            "contained=True",
+            "shell=cmd");
+        var resultLog = await WaitForTrayLogLineContainingAsync(
+            TimeSpan.FromSeconds(30),
+            logCursor,
+            "[mxc] system.run sandbox result",
+            "exitCode=0",
+            "containment=mxc");
+
+        Console.WriteLine($"[E2E] MXC request diagnostic: {requestLog}");
+        Console.WriteLine($"[E2E] MXC result diagnostic: {resultLog}");
+    }
+
+    [MxcE2EFact]
+    public async Task RealGateway_SystemRun_BlocksWritesToTrayDataDirectoryInMxcSandbox()
+    {
+        const string marker = "OPENCLAW_GATEWAY_SYSTEM_RUN_MXC_DENIED";
+        var blockedPath = Path.Combine(_fixture.DataDir, $"mxc-denied-write-{Guid.NewGuid():N}.txt");
+        var blockedPathForCmd = blockedPath.Replace(Path.DirectorySeparatorChar, '/');
+
+        await AssertPrimaryTrayReadyAndGatewayCliHealthyAsync();
+        await SetExecApprovalForSystemRunProofAsync();
+
+        Assert.False(File.Exists(blockedPath), $"Unexpected pre-existing MXC deny proof file: {blockedPath}");
+
+        var gateway = _fixture.ReadActiveGatewayRecord();
+        var env = GatewayTokenEnv(gateway.SharedGatewayToken);
+        var nodeId = _fixture.ReadActiveGatewayDeviceId();
+        var logCursor = GetTrayLogCursor();
+        var invokeParams = JsonSerializer.Serialize(new
+        {
+            nodeId,
+            command = "system.run",
+            @params = new
+            {
+                command = $"echo {marker} > {CmdQuote(blockedPathForCmd)}",
+                shell = "cmd",
+                timeoutMs = 10_000
+            },
+            timeoutMs = 30_000,
+            idempotencyKey = Guid.NewGuid().ToString("N")
+        });
+
+        var invoke = await _fixture.RunInWslAsync(
+            $"openclaw gateway call node.invoke --params {ShellSingleQuote(invokeParams)} --json --timeout 45000",
+            TimeSpan.FromSeconds(45),
+            env);
+
+        AssertCommandSucceeded(invoke, "invoke Windows node system.run denied-write proof through real gateway");
+
+        using var invokeDoc = JsonDocument.Parse(ExtractJsonObject(invoke.Stdout));
+        if (invokeDoc.RootElement.TryGetProperty("ok", out var ok))
+        {
+            Assert.True(ok.GetBoolean(), $"Expected gateway node.invoke ok=true; response: {invokeDoc.RootElement.GetRawText()}");
+        }
+
+        var payload = ReadNodeInvokePayload(invokeDoc.RootElement);
+        var exitCode = payload.GetProperty("exitCode").GetInt32();
+        if (payload.TryGetProperty("timedOut", out var timedOut))
+            Assert.False(timedOut.GetBoolean(), $"denied-write proof timed out; payload: {payload.GetRawText()}");
+
+        var stdout = payload.GetProperty("stdout").GetString() ?? "";
+        var stderr = payload.TryGetProperty("stderr", out var stderrElement)
+            ? stderrElement.GetString() ?? ""
+            : "";
+
+        // The shell's access-denied text is localized; the load-bearing proof is no timeout,
+        // non-zero denied-write exit, no file creation, and MXC containment in the tray log.
+        Assert.NotEqual(0, exitCode);
+        Assert.True(stderr.Length > 0, $"Expected denied write to emit stderr; payload: {payload.GetRawText()}");
+        Assert.DoesNotContain(marker, stdout, StringComparison.Ordinal);
+        Assert.False(File.Exists(blockedPath),
+            $"MXC sandbox should not create files inside the tray data/settings directory: {blockedPath}");
+
+        var requestLog = await WaitForTrayLogLineContainingAsync(
+            TimeSpan.FromSeconds(30),
+            logCursor,
+            "[mxc] system.run sandbox request",
+            "executor=mxc-direct-appc",
+            "contained=True",
+            "shell=cmd");
+        var resultLog = await WaitForTrayLogLineContainingAsync(
+            TimeSpan.FromSeconds(30),
+            logCursor,
+            "[mxc] system.run sandbox result",
+            $"exitCode={exitCode}",
+            "containment=mxc");
+
+        Console.WriteLine(
+            $"[E2E] MXC denied-write payload: exitCode={exitCode}; stdoutLength={stdout.Length}; stderrLength={stderr.Length}; fileExists={File.Exists(blockedPath)}");
+        Console.WriteLine($"[E2E] MXC denied-write request diagnostic: {requestLog}");
+        Console.WriteLine($"[E2E] MXC denied-write result diagnostic: {resultLog}");
+    }
+
+    private async Task AssertPrimaryTrayReadyAndGatewayCliHealthyAsync()
+    {
+        await _fixture.WaitForConnectionReady();
+        await _fixture.WaitForNodeListReady();
+
+        var gateway = _fixture.ReadActiveGatewayRecord();
+        var env = GatewayTokenEnv(gateway.SharedGatewayToken);
+
+        var devices = await _fixture.RunInWslAsync("openclaw devices list --json", TimeSpan.FromSeconds(30), env);
+        AssertCommandSucceeded(devices, "list gateway devices before MXC proof");
+        AssertNoPendingRequests(devices.Stdout);
+
+        var nodes = await _fixture.RunInWslAsync("openclaw nodes list --json", TimeSpan.FromSeconds(30), env);
+        AssertCommandSucceeded(nodes, "list gateway nodes before MXC proof");
+        AssertNoPendingRequests(nodes.Stdout);
+        Assert.Contains("windows", nodes.Stdout, StringComparison.OrdinalIgnoreCase);
+
+        var allowCommands = await _fixture.RunInWslAsync(
+            "openclaw config get gateway.nodes.allowCommands --json",
+            TimeSpan.FromSeconds(30),
+            env);
+        AssertCommandSucceeded(allowCommands, "read gateway.nodes.allowCommands before MXC proof");
+        using var allowCommandsDoc = JsonDocument.Parse(ExtractJsonValue(allowCommands.Stdout));
+        var allowed = ReadStringArray(allowCommandsDoc.RootElement);
+        Assert.Contains(allowed, command => command == "system.run");
+        Assert.Contains(allowed, command => command == "system.run.prepare");
+        Assert.Contains(allowed, command => command == "system.which");
+        Console.WriteLine("[E2E] gateway.nodes.allowCommands includes system.run/system.run.prepare/system.which");
+
+        using var statusDoc = await _fixture.Client!.CallToolExpectSuccessAsync("app.status");
+        AssertReadyStatus(statusDoc.RootElement);
+        AssertOperatorCanApproveNodeTrust(statusDoc.RootElement);
+    }
+
+    private async Task SetExecApprovalForSystemRunProofAsync()
+    {
+        using var policy = await _fixture.Client!.CallToolExpectSuccessAsync("system.execApprovals.get");
+        var baseHash = policy.RootElement.GetProperty("hash").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(baseHash));
+
+        using var updated = await _fixture.Client!.CallToolExpectSuccessAsync("system.execApprovals.set", new
+        {
+            baseHash,
+            defaultAction = "deny",
+            rules = new object[]
+            {
+                new { pattern = "echo *", action = "allow", description = "E2E Gateway system.run MXC proof", enabled = true },
+            },
+        });
+
+        Assert.True(updated.RootElement.GetProperty("updated").GetBoolean());
+        Console.WriteLine("[E2E] exec approval policy prepared for Gateway system.run proof: defaultAction=deny; allow=echo *");
+    }
+
+    private TrayLogCursor GetTrayLogCursor()
+    {
+        var logPath = Path.Combine(_fixture.DataDir, "openclaw-tray.log");
+        var rotatedLogPath = logPath + ".old";
+        var currentInfo = File.Exists(logPath) ? new FileInfo(logPath) : null;
+        var rotatedInfo = File.Exists(rotatedLogPath) ? new FileInfo(rotatedLogPath) : null;
+        return new TrayLogCursor(
+            currentInfo is not null,
+            currentInfo?.Length ?? 0,
+            currentInfo?.CreationTimeUtc,
+            rotatedInfo?.Length ?? -1,
+            rotatedInfo?.CreationTimeUtc,
+            rotatedInfo?.LastWriteTimeUtc);
+    }
+
+    private async Task<string> WaitForTrayLogLineContainingAsync(TimeSpan timeout, TrayLogCursor cursor, params string[] fragments)
+    {
+        var logPath = Path.Combine(_fixture.DataDir, "openclaw-tray.log");
+        var deadline = DateTime.UtcNow.Add(timeout);
+        var tail = "";
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (File.Exists(logPath) || File.Exists(logPath + ".old"))
+            {
+                var lines = await ReadTrayLogLinesSinceAsync(logPath, cursor);
+                tail = string.Join(Environment.NewLine, lines.TakeLast(20));
+                var match = lines.LastOrDefault(line =>
+                    fragments.All(fragment => line.Contains(fragment, StringComparison.Ordinal)));
+                if (match is not null)
+                    return match;
+            }
+
+            await Task.Delay(500);
+        }
+
+        throw new TimeoutException(
+            $"Timed out waiting for tray log fragments [{string.Join(", ", fragments)}]. Log path: {logPath}. Tail: {tail}");
+    }
+
+    private static async Task<string[]> ReadTrayLogLinesSinceAsync(string logPath, TrayLogCursor cursor)
+    {
+        var lines = new List<string>();
+        var rotatedLogPath = logPath + ".old";
+        var rotationObserved = CurrentLogGenerationChanged(logPath, cursor) || RotatedLogChanged(rotatedLogPath, cursor);
+        if (rotationObserved && File.Exists(rotatedLogPath))
+        {
+            lines.AddRange(await ReadLogLinesFromOffsetAsync(rotatedLogPath, cursor.CurrentLength));
+        }
+
+        if (File.Exists(logPath))
+        {
+            lines.AddRange(await ReadLogLinesFromOffsetAsync(logPath, rotationObserved ? 0 : cursor.CurrentLength));
+        }
+
+        return lines.ToArray();
+    }
+
+    private static bool RotatedLogChanged(string rotatedLogPath, TrayLogCursor cursor)
+    {
+        if (!File.Exists(rotatedLogPath))
+            return false;
+
+        var info = new FileInfo(rotatedLogPath);
+        return info.Length != cursor.RotatedLength
+            || info.CreationTimeUtc != cursor.RotatedCreationUtc
+            || info.LastWriteTimeUtc != cursor.RotatedLastWriteUtc;
+    }
+
+    private static bool CurrentLogGenerationChanged(string logPath, TrayLogCursor cursor)
+    {
+        if (!cursor.CurrentExists)
+            return false;
+
+        if (!File.Exists(logPath))
+            return false;
+
+        var info = new FileInfo(logPath);
+        return info.CreationTimeUtc != cursor.CurrentCreationUtc;
+    }
+
+    private static async Task<string[]> ReadLogLinesFromOffsetAsync(string logPath, long startOffset)
+    {
+        await using var stream = new FileStream(logPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        var seekOffset = Math.Min(startOffset, stream.Length);
+        stream.Seek(seekOffset, SeekOrigin.Begin);
+
+        using var reader = new StreamReader(stream);
+        var text = await reader.ReadToEndAsync();
+        return text.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private static void AssertReadyStatus(JsonElement root)
+    {
+        var rawJson = root.GetRawText();
+        var connectionStatus = root.GetProperty("connectionStatus").GetString();
+        Assert.True(connectionStatus is "Ready" or "Connected",
+            $"connectionStatus should be Ready or Connected, got '{connectionStatus}'; full status: {rawJson}");
+        Assert.True(root.GetProperty("nodeConnected").GetBoolean(), $"nodeConnected should be true; full status: {rawJson}");
+        Assert.True(root.GetProperty("nodePaired").GetBoolean(), $"nodePaired should be true; full status: {rawJson}");
+    }
+
+    private static void AssertOperatorCanApproveNodeTrust(JsonElement root)
+    {
+        var rawJson = root.GetRawText();
+        Assert.True(root.TryGetProperty("operatorScopes", out var scopes), $"operatorScopes missing from app.status: {rawJson}");
+        var values = ReadStringArray(scopes);
+        Assert.Contains(values, scope => string.Equals(scope, "operator.admin", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(values, scope => string.Equals(scope, "operator.pairing", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string[] ReadStringArray(JsonElement element)
+    {
+        Assert.Equal(JsonValueKind.Array, element.ValueKind);
+        return element.EnumerateArray()
+            .Select(item => item.GetString())
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value!)
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static void AssertNoPendingRequests(string output)
+    {
+        using var doc = JsonDocument.Parse(ExtractJsonObject(output));
+        if (doc.RootElement.TryGetProperty("pending", out var pending))
+        {
+            Assert.Equal(JsonValueKind.Array, pending.ValueKind);
+            Assert.Equal(0, pending.GetArrayLength());
+        }
+    }
+
+    private static void AssertCommandSucceeded(CommandResult result, string description)
+    {
+        Assert.False(result.TimedOut, $"{description} timed out");
+        Assert.Equal(0, result.ExitCode);
+    }
+
+    private static Dictionary<string, string> GatewayTokenEnv(string? sharedGatewayToken)
+    {
+        Assert.False(string.IsNullOrWhiteSpace(sharedGatewayToken));
+        return new Dictionary<string, string> { ["OPENCLAW_GATEWAY_TOKEN"] = sharedGatewayToken! };
+    }
+
+    private static string ExtractJsonObject(string output)
+    {
+        var start = output.IndexOf('{');
+        var end = output.LastIndexOf('}');
+        Assert.True(start >= 0 && end > start, $"Expected JSON object in output: {output}");
+        return output[start..(end + 1)];
+    }
+
+    private static string ExtractJsonValue(string output)
+    {
+        var objectStart = output.IndexOf('{');
+        var arrayStart = output.IndexOf('[');
+        var start = objectStart switch
+        {
+            >= 0 when arrayStart >= 0 => Math.Min(objectStart, arrayStart),
+            >= 0 => objectStart,
+            _ => arrayStart
+        };
+
+        Assert.True(start >= 0, $"Expected JSON value in output: {output}");
+        var endChar = output[start] == '{' ? '}' : ']';
+        var end = output.LastIndexOf(endChar);
+        Assert.True(end > start, $"Expected JSON value in output: {output}");
+        return output[start..(end + 1)];
+    }
+
+    private static JsonElement ReadNodeInvokePayload(JsonElement root)
+    {
+        if (root.TryGetProperty("payload", out var payload) &&
+            payload.ValueKind == JsonValueKind.Object)
+        {
+            return payload.Clone();
+        }
+
+        if (root.TryGetProperty("payloadJSON", out var payloadJson) &&
+            payloadJson.ValueKind == JsonValueKind.String &&
+            !string.IsNullOrWhiteSpace(payloadJson.GetString()))
+        {
+            using var doc = JsonDocument.Parse(payloadJson.GetString()!);
+            return doc.RootElement.Clone();
+        }
+
+        throw new InvalidDataException($"Gateway node.invoke response did not include a payload object: {root.GetRawText()}");
+    }
+
+    private static string ShellSingleQuote(string value) => "'" + value.Replace("'", "'\"'\"'") + "'";
+
+    private static string CmdQuote(string value) => "\"" + value.Replace("\"", "\"\"") + "\"";
+
+    private sealed record TrayLogCursor(
+        bool CurrentExists,
+        long CurrentLength,
+        DateTime? CurrentCreationUtc,
+        long RotatedLength,
+        DateTime? RotatedCreationUtc,
+        DateTime? RotatedLastWriteUtc);
+}

--- a/tests/OpenClaw.E2ETests/Setup/MxcSetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/MxcSetupAndConnectTests.cs
@@ -6,6 +6,11 @@ namespace OpenClaw.E2ETests.Setup;
 [Collection("E2E MXC Setup")]
 public sealed class MxcSetupAndConnectTests
 {
+    private const int SystemRunProofTimeoutMs = 60_000;
+    private const int NodeInvokeProofTimeoutMs = 90_000;
+    private const int GatewayCliProofTimeoutMs = 120_000;
+    private static readonly TimeSpan GatewayCliProofProcessTimeout = TimeSpan.FromSeconds(130);
+
     private readonly E2ESetupFixture _fixture;
 
     public MxcSetupAndConnectTests(MxcE2ESetupFixture fixture)
@@ -38,15 +43,15 @@ public sealed class MxcSetupAndConnectTests
             {
                 command = $"echo {marker}",
                 shell = "cmd",
-                timeoutMs = 10_000
+                timeoutMs = SystemRunProofTimeoutMs
             },
-            timeoutMs = 30_000,
+            timeoutMs = NodeInvokeProofTimeoutMs,
             idempotencyKey = Guid.NewGuid().ToString("N")
         });
 
         var invoke = await _fixture.RunInWslAsync(
-            $"openclaw gateway call node.invoke --params {ShellSingleQuote(invokeParams)} --json --timeout 45000",
-            TimeSpan.FromSeconds(45),
+            $"openclaw gateway call node.invoke --params {ShellSingleQuote(invokeParams)} --json --timeout {GatewayCliProofTimeoutMs}",
+            GatewayCliProofProcessTimeout,
             env);
 
         AssertCommandSucceeded(invoke, "invoke Windows node system.run through real gateway");
@@ -114,15 +119,15 @@ public sealed class MxcSetupAndConnectTests
             {
                 command = $"echo {marker} > {CmdQuote(blockedPathForCmd)}",
                 shell = "cmd",
-                timeoutMs = 10_000
+                timeoutMs = SystemRunProofTimeoutMs
             },
-            timeoutMs = 30_000,
+            timeoutMs = NodeInvokeProofTimeoutMs,
             idempotencyKey = Guid.NewGuid().ToString("N")
         });
 
         var invoke = await _fixture.RunInWslAsync(
-            $"openclaw gateway call node.invoke --params {ShellSingleQuote(invokeParams)} --json --timeout 45000",
-            TimeSpan.FromSeconds(45),
+            $"openclaw gateway call node.invoke --params {ShellSingleQuote(invokeParams)} --json --timeout {GatewayCliProofTimeoutMs}",
+            GatewayCliProofProcessTimeout,
             env);
 
         AssertCommandSucceeded(invoke, "invoke Windows node system.run denied-write proof through real gateway");

--- a/tests/OpenClaw.E2ETests/Setup/MxcSetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/MxcSetupAndConnectTests.cs
@@ -239,7 +239,7 @@ public sealed class MxcSetupAndConnectTests
         });
 
         Assert.True(updated.RootElement.GetProperty("updated").GetBoolean());
-        Console.WriteLine("[E2E] exec approval policy prepared for Gateway system.run proof: defaultAction=deny; allow=echo *");
+        Console.WriteLine("[E2E] exec approval policy prepared for Gateway system.run proof: defaultAction=deny; allow=echo *, copy /Y *openclaw-mxc-denied-source.txt*");
     }
 
     private TrayLogCursor GetTrayLogCursor()

--- a/tests/OpenClaw.E2ETests/Setup/MxcSetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/MxcSetupAndConnectTests.cs
@@ -227,6 +227,14 @@ public sealed class MxcSetupAndConnectTests
             rules = new object[]
             {
                 new { pattern = "echo *", action = "allow", description = "E2E Gateway system.run MXC proof", enabled = true },
+                new
+                {
+                    pattern = "copy /Y *openclaw-mxc-denied-source.txt*",
+                    action = "allow",
+                    shells = new[] { "cmd" },
+                    description = "E2E Gateway system.run MXC denied-write proof",
+                    enabled = true
+                },
             },
         });
 

--- a/tests/OpenClaw.E2ETests/Setup/MxcSetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/MxcSetupAndConnectTests.cs
@@ -98,7 +98,8 @@ public sealed class MxcSetupAndConnectTests
     [MxcE2EFact]
     public async Task RealGateway_SystemRun_BlocksWritesToTrayDataDirectoryInMxcSandbox()
     {
-        const string marker = "OPENCLAW_GATEWAY_SYSTEM_RUN_MXC_DENIED";
+        const string sourcePayload = "OPENCLAW_GATEWAY_SYSTEM_RUN_MXC_DENIED_PAYLOAD";
+        const string sourceReadyMarker = "OPENCLAW_GATEWAY_SYSTEM_RUN_MXC_SOURCE_READY";
         var blockedPath = Path.Combine(_fixture.DataDir, $"mxc-denied-write-{Guid.NewGuid():N}.txt");
         var blockedPathForCmd = blockedPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         var sourcePathForCmd = "%TEMP%\\openclaw-mxc-denied-source.txt";
@@ -118,7 +119,7 @@ public sealed class MxcSetupAndConnectTests
             command = "system.run",
             @params = new
             {
-                command = $"echo {marker} > {CmdQuote(sourcePathForCmd)} && copy /Y {CmdQuote(sourcePathForCmd)} {CmdQuote(blockedPathForCmd)}",
+                command = $"echo {sourcePayload} > {CmdQuote(sourcePathForCmd)} && echo {sourceReadyMarker} && copy /Y {CmdQuote(sourcePathForCmd)} {CmdQuote(blockedPathForCmd)}",
                 shell = "cmd",
                 timeoutMs = SystemRunProofTimeoutMs
             },
@@ -150,11 +151,12 @@ public sealed class MxcSetupAndConnectTests
             : "";
         var combinedOutput = stdout + stderr;
 
-        // The shell's access-denied text is localized; the load-bearing proof is no timeout,
-        // non-zero denied-write exit, no file creation, and MXC containment in the tray log.
+        // The shell's access-denied text is localized; sourceReadyMarker proves the
+        // scratch source was created before the denied destination copy was attempted.
         Assert.NotEqual(0, exitCode);
         Assert.True(combinedOutput.Length > 0, $"Expected denied write to emit output; payload: {payload.GetRawText()}");
-        Assert.DoesNotContain(marker, combinedOutput, StringComparison.Ordinal);
+        Assert.Contains(sourceReadyMarker, combinedOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain(sourcePayload, combinedOutput, StringComparison.Ordinal);
         Assert.False(File.Exists(blockedPath),
             $"MXC sandbox should not create files inside the tray data/settings directory: {blockedPath}");
 

--- a/tests/OpenClaw.E2ETests/Setup/MxcSetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/MxcSetupAndConnectTests.cs
@@ -226,10 +226,43 @@ public sealed class MxcSetupAndConnectTests
             defaultAction = "deny",
             rules = new object[]
             {
-                new { pattern = "echo *", action = "allow", description = "E2E Gateway system.run MXC proof", enabled = true },
                 new
                 {
-                    pattern = "copy /Y *openclaw-mxc-denied-source.txt*",
+                    pattern = "echo OPENCLAW_GATEWAY_SYSTEM_RUN_MXC_OK",
+                    action = "allow",
+                    shells = new[] { "cmd" },
+                    description = "E2E Gateway system.run MXC success proof",
+                    enabled = true
+                },
+                new
+                {
+                    pattern = "echo OPENCLAW_GATEWAY_SYSTEM_RUN_MXC_DENIED_PAYLOAD > *openclaw-mxc-denied-source.txt\"" +
+                              " && echo OPENCLAW_GATEWAY_SYSTEM_RUN_MXC_SOURCE_READY" +
+                              " && copy /Y *openclaw-mxc-denied-source.txt\" *mxc-denied-write-*.txt\"",
+                    action = "allow",
+                    shells = new[] { "cmd" },
+                    description = "E2E Gateway system.run MXC denied-write wrapper proof",
+                    enabled = true
+                },
+                new
+                {
+                    pattern = "echo OPENCLAW_GATEWAY_SYSTEM_RUN_MXC_DENIED_PAYLOAD > *openclaw-mxc-denied-source.txt\"",
+                    action = "allow",
+                    shells = new[] { "cmd" },
+                    description = "E2E Gateway system.run MXC denied-write source prep",
+                    enabled = true
+                },
+                new
+                {
+                    pattern = "echo OPENCLAW_GATEWAY_SYSTEM_RUN_MXC_SOURCE_READY",
+                    action = "allow",
+                    shells = new[] { "cmd" },
+                    description = "E2E Gateway system.run MXC denied-write source marker",
+                    enabled = true
+                },
+                new
+                {
+                    pattern = "copy /Y *openclaw-mxc-denied-source.txt\" *mxc-denied-write-*.txt\"",
                     action = "allow",
                     shells = new[] { "cmd" },
                     description = "E2E Gateway system.run MXC denied-write proof",
@@ -239,7 +272,7 @@ public sealed class MxcSetupAndConnectTests
         });
 
         Assert.True(updated.RootElement.GetProperty("updated").GetBoolean());
-        Console.WriteLine("[E2E] exec approval policy prepared for Gateway system.run proof: defaultAction=deny; allow=echo *, copy /Y *openclaw-mxc-denied-source.txt*");
+        Console.WriteLine("[E2E] exec approval policy prepared for Gateway system.run proof: defaultAction=deny; allow=scoped cmd MXC proof commands");
     }
 
     private TrayLogCursor GetTrayLogCursor()

--- a/tests/OpenClaw.E2ETests/Setup/MxcSetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/MxcSetupAndConnectTests.cs
@@ -102,7 +102,7 @@ public sealed class MxcSetupAndConnectTests
         const string sourceReadyMarker = "OPENCLAW_GATEWAY_SYSTEM_RUN_MXC_SOURCE_READY";
         var blockedPath = Path.Combine(_fixture.DataDir, $"mxc-denied-write-{Guid.NewGuid():N}.txt");
         var blockedPathForCmd = blockedPath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        var sourcePathForCmd = "%TEMP%\\openclaw-mxc-denied-source.txt";
+        var sourcePathForCmd = "%TEMP%/openclaw-mxc-denied-source.txt";
 
         await AssertPrimaryTrayReadyAndGatewayCliHealthyAsync();
         await SetExecApprovalForSystemRunProofAsync();

--- a/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-balanced.json
+++ b/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-balanced.json
@@ -14,15 +14,6 @@
       "C:\\Golden\\Documents",
       "C:\\Golden\\Downloads",
       "C:\\Golden\\Desktop"
-    ],
-    "deniedPaths": [
-      "C:\\Golden\\Settings",
-      "C:\\Golden\\.ssh",
-      "C:\\Golden\\Chrome",
-      "C:\\Golden\\Edge",
-      "C:\\Golden\\Brave",
-      "C:\\Golden\\Firefox",
-      "C:\\Golden\\PSReadLine"
     ]
   },
   "ui": {

--- a/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-custom.json
+++ b/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-custom.json
@@ -13,15 +13,6 @@
     ],
     "readonlyPaths": [
       "C:\\Golden\\Documents"
-    ],
-    "deniedPaths": [
-      "C:\\Golden\\Settings",
-      "C:\\Golden\\.ssh",
-      "C:\\Golden\\Chrome",
-      "C:\\Golden\\Edge",
-      "C:\\Golden\\Brave",
-      "C:\\Golden\\Firefox",
-      "C:\\Golden\\PSReadLine"
     ]
   },
   "ui": {

--- a/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-locked-down.json
+++ b/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-locked-down.json
@@ -10,16 +10,7 @@
     "readwritePaths": [
       "C:\\Golden\\Scratch"
     ],
-    "readonlyPaths": [],
-    "deniedPaths": [
-      "C:\\Golden\\Settings",
-      "C:\\Golden\\.ssh",
-      "C:\\Golden\\Chrome",
-      "C:\\Golden\\Edge",
-      "C:\\Golden\\Brave",
-      "C:\\Golden\\Firefox",
-      "C:\\Golden\\PSReadLine"
-    ]
+    "readonlyPaths": []
   },
   "ui": {
     "disable": true,

--- a/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-permissive.json
+++ b/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-permissive.json
@@ -13,16 +13,7 @@
       "C:\\Golden\\Desktop",
       "C:\\Golden\\Scratch"
     ],
-    "readonlyPaths": [],
-    "deniedPaths": [
-      "C:\\Golden\\Settings",
-      "C:\\Golden\\.ssh",
-      "C:\\Golden\\Chrome",
-      "C:\\Golden\\Edge",
-      "C:\\Golden\\Brave",
-      "C:\\Golden\\Firefox",
-      "C:\\Golden\\PSReadLine"
-    ]
+    "readonlyPaths": []
   },
   "ui": {
     "disable": true,

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcConfigBuilderTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcConfigBuilderTests.cs
@@ -42,8 +42,6 @@ public class MxcConfigBuilderTests
         P.Settings, P.Ssh, P.Chrome, P.Edge, P.Brave, P.Firefox, P.PsRead,
     };
 
-    private static readonly Func<string, bool> DeniedPathExists = _ => true;
-
     private static SandboxPolicy LockedDownPolicy() => new(
         Version: MxcPolicyBuilder.SupportedPolicyVersion,
         Filesystem: new FilesystemPolicy(
@@ -99,7 +97,6 @@ public class MxcConfigBuilderTests
         string scratchDir = P.Scratch,
         string? containerId = null,
         string? pathEnvVar = "",
-        Func<string, bool>? deniedPathExists = null,
         Func<string, bool>? readonlyGrantIsBackendSafe = null) =>
         MxcConfigBuilder.Build(
             request,
@@ -107,7 +104,6 @@ public class MxcConfigBuilderTests
             new MxcConfigBuildContext(
                 ContainerId: containerId,
                 PathEnvVar: pathEnvVar,
-                DeniedPathExists: deniedPathExists ?? DeniedPathExists,
                 ReadonlyGrantIsBackendSafe: readonlyGrantIsBackendSafe));
 
     private static string ExpectedSystemCmdExe()
@@ -295,7 +291,7 @@ public class MxcConfigBuilderTests
     }
 
     [Fact]
-    public void Build_FiltersHostProfileDeniedPathsBeforeBackendEmissionButStillFiltersAllows()
+    public void Build_OmitsDeniedPathsBeforeBackendEmissionButStillFiltersAllows()
     {
         var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         if (string.IsNullOrWhiteSpace(localAppData))
@@ -323,22 +319,20 @@ public class MxcConfigBuilderTests
 
         Assert.DoesNotContain(chromeProfile, config.Filesystem!.ReadwritePaths!, StringComparer.OrdinalIgnoreCase);
         Assert.DoesNotContain(userProfile, config.Filesystem.ReadwritePaths!, StringComparer.OrdinalIgnoreCase);
-        Assert.DoesNotContain(chromeProfile, config.Filesystem.DeniedPaths!, StringComparer.OrdinalIgnoreCase);
-        Assert.DoesNotContain(sshPath, config.Filesystem.DeniedPaths!, StringComparer.OrdinalIgnoreCase);
-        Assert.Contains(settingsDeny, config.Filesystem.DeniedPaths!, StringComparer.OrdinalIgnoreCase);
+        Assert.Null(config.Filesystem.DeniedPaths);
     }
 
     [Fact]
-    public void Build_FiltersMissingDeniedPathsBeforeBackendEmissionButStillFiltersAllows()
+    public void Build_RemovesParentReadwriteGrantContainingDeniedSettingsDirectory_WhenDeniedPathsAreNotEmitted()
     {
         var parent = "C:\\Users\\example\\AppData\\Roaming";
-        var missingSettingsDeny = Path.Combine(parent, "OpenClawTray");
+        var settingsDeny = Path.Combine(parent, "OpenClawTray");
         var policy = new SandboxPolicy(
             Version: MxcPolicyBuilder.SupportedPolicyVersion,
             Filesystem: new FilesystemPolicy(
-                ReadwritePaths: new[] { parent },
+                ReadwritePaths: new[] { parent, settingsDeny },
                 ReadonlyPaths: Array.Empty<string>(),
-                DeniedPaths: new[] { missingSettingsDeny },
+                DeniedPaths: new[] { settingsDeny },
                 ClearPolicyOnExit: true),
             Network: new NetworkPolicy(false, false),
             Ui: new UiPolicy(false, ClipboardPolicy.None, false),
@@ -346,11 +340,38 @@ public class MxcConfigBuilderTests
 
         var config = BuildConfig(
             RequestFor(policy),
-            pathEnvVar: "",
-            deniedPathExists: _ => false);
+            pathEnvVar: "");
 
         Assert.DoesNotContain(parent, config.Filesystem!.ReadwritePaths!, StringComparer.OrdinalIgnoreCase);
-        Assert.DoesNotContain(missingSettingsDeny, config.Filesystem.DeniedPaths!, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain(settingsDeny, config.Filesystem.ReadwritePaths!, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain(settingsDeny, config.Filesystem.ReadonlyPaths!, StringComparer.OrdinalIgnoreCase);
+        Assert.Null(config.Filesystem.DeniedPaths);
+    }
+
+    [Fact]
+    public void Build_RemovesParentReadonlyGrantContainingDeniedSettingsDirectory_WhenDeniedPathsAreNotEmitted()
+    {
+        var parent = "C:\\Users\\example\\AppData\\Roaming";
+        var settingsDeny = Path.Combine(parent, "OpenClawTray");
+        var policy = new SandboxPolicy(
+            Version: MxcPolicyBuilder.SupportedPolicyVersion,
+            Filesystem: new FilesystemPolicy(
+                ReadwritePaths: Array.Empty<string>(),
+                ReadonlyPaths: new[] { parent, settingsDeny },
+                DeniedPaths: new[] { settingsDeny },
+                ClearPolicyOnExit: true),
+            Network: new NetworkPolicy(false, false),
+            Ui: new UiPolicy(false, ClipboardPolicy.None, false),
+            TimeoutMs: 30_000);
+
+        var config = BuildConfig(
+            RequestFor(policy),
+            pathEnvVar: "");
+
+        Assert.DoesNotContain(parent, config.Filesystem!.ReadonlyPaths!, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain(settingsDeny, config.Filesystem.ReadwritePaths!, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain(settingsDeny, config.Filesystem.ReadonlyPaths!, StringComparer.OrdinalIgnoreCase);
+        Assert.Null(config.Filesystem.DeniedPaths);
     }
 
     [Fact]


### PR DESCRIPTION
Tracking issue: #784
Stacked after: #786

## Summary

This PR adds focused runtime proof for the real Gateway path:

Gateway -> node.invoke -> Windows node -> system.run -> MXC process containment.

It is intentionally stacked after #786. A focused compare for the PR3 delta is:

https://github.com/TheAngryPit/openclaw-windows-node/compare/feature/mxc-26200-sdk-0-7-validation...feature/gateway-system-run-mxc-e2e

## What Changed

- Adds focused Gateway MXC E2E coverage to the setup suite.
- Moves the MXC proof into its own gated E2E MXC Setup collection so non-MXC runners skip before heavy setup.
- Probes the discovered `wxc-exec.exe` path before deciding whether to skip, avoiding false skips when the test output itself lacks the MXC helper but the built app/SDK path has it.
- Provisions a fresh WSL Gateway, starts an isolated tray instance, prepares local exec approval, invokes `system.run` through `openclaw gateway call node.invoke`, and verifies MXC diagnostics in the tray log.
- Adds a denied-write proof that verifies MXC containment prevents writing into the tray data/settings directory.
- Asserts `gateway.nodes.allowCommands` includes `system.run`, `system.run.prepare`, and `system.which` before invoking the proof path.
- Documents the focused runtime proof command and required evidence markers in `docs/WINDOWS_NODE_TESTING.md`.

## Validation

Final local validation for PR3 head `020d861e`, stacked on PR2 head `442de02a`, on Windows build `26200.8737`:

- `.\build.ps1` passed without setting `$env:OS`.
- Inherited/focused Shared MXC/system.run coverage passed: `141` passed, `0` failed, `0` skipped.
- Inherited/focused Tray settings/installer coverage passed: `28` passed, `0` failed, `0` skipped.
- `dotnet build tests\OpenClaw.E2ETests\OpenClaw.E2ETests.csproj -c Debug -r win-x64 --no-restore -p:UseSharedCompilation=false` passed with `0` warnings, `0` errors.
- `OPENCLAW_RUN_E2E=1 dotnet test tests\OpenClaw.E2ETests\OpenClaw.E2ETests.csproj --no-build -c Debug -r win-x64 --filter "FullyQualifiedName~OpenClaw.E2ETests.Setup.MxcSetupAndConnectTests" --logger "trx;LogFileName=OpenClaw.E2ETests.pr3-current-26200-8737.trx"` passed: `2` passed, `0` failed, `0` skipped.

## Installed-App Runtime Proof

The top-of-stack app was built, installed, launched, and tested through the real installed Gateway/Windows Node path on the same Windows build:

- Installed executable: `%LOCALAPPDATA%\OpenClawTray\OpenClaw.Tray.WinUI.exe`.
- Installed product version includes `Sha.020d861eb50d605afa400aa16d89e240c9c85c5d`.
- Gateway CLI environment: `OpenClawGateway` WSL distro, `OpenClaw 2026.6.10`.
- Connected Windows node version: `0.6.4-tap-pr3-gateway-mxc-e2e-on-pr2-770522b.1`.
- Node command count: `19`.
- `system.run`: available.

Success proof:

- Marker: `OPENCLAW_REAL_APP_MXC_26200_8737_OK_f636bbaf`.
- Result: `exitCode=0`, `timedOut=false`, marker present in stdout.
- Tray log: `executor=mxc-direct-appc`, `contained=True`, `wxcExec=<set>`, `version=0.7.0-alpha`, `envKeys=[]`, `network={defaultPolicy=block,enforcementMode=capabilities}`, final `containment=mxc`.

Denied-write proof:

- Marker: `OPENCLAW_REAL_APP_MXC_26200_8737_DENIED_d1d8822f`.
- Command attempted to write under `%LOCALAPPDATA%\OpenClawTray`.
- Result: `exitCode=1`, `timedOut=false`, marker absent from stdout, `stderrLen=42`.
- Target file was not created.
- Tray log: `executor=mxc-direct-appc`, `contained=True`, final `containment=mxc`, `stdoutChars=0`, `stderrChars=42`.

## Scope Limits

- Broad full-suite green is not claimed.
- Full profile migration proof is not claimed.
- Local external autoreview was attempted for this stack earlier, but the local approval layer blocked external disclosure of local branch code; it was not bypassed, so this PR does not claim clean external autoreview proof.

Refs #784
