### PR TITLE
fix(setup): poll for port release instead of fixed 3 s delay after WSL shutdown

### DIFF
--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -276,7 +276,7 @@ public sealed class CleanupStaleDistroStep : SetupStep
 
             // Wait for port to be released
             ctx.Logger.Info("Waiting for port release after distro termination...");
-            await Task.Delay(3000, ct);
+            await PreflightPortStep.WaitForPortFreeAsync(ctx.Config.GatewayPort, ctx.Config.Gateway.Bind, ctx.Logger, ct);
             return StepResult.Ok($"Unregistered stale distro '{distro}'");
         }
 
@@ -596,23 +596,61 @@ public sealed class PreflightPortStep : SetupStep
     public override string DisplayName => "Check gateway port available";
     public override bool CanRetry => false;
 
-    public override Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)
+    public override async Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)
     {
         var port = ctx.Config.GatewayPort;
         var addresses = ctx.Config.Gateway.Bind.Equals("lan", StringComparison.OrdinalIgnoreCase)
             ? new[] { IPAddress.Any, IPAddress.IPv6Any }
             : [IPAddress.Loopback];
 
+        // Poll briefly in case WSL port forwarding proxy hasn't fully released the
+        // port yet (e.g. after wsl --shutdown in a prior cleanup step).
+        await WaitForPortFreeAsync(port, ctx.Config.Gateway.Bind, ctx.Logger, ct, maxWaitSeconds: 10);
+
         foreach (var address in addresses)
         {
             if (!CanBind(address, port, out var error))
-                return Task.FromResult(StepResult.Fail($"Port {port} is already in use for {DescribeBind(address)} ({error.SocketErrorCode})"));
+                return StepResult.Fail($"Port {port} is already in use for {DescribeBind(address)} ({error.SocketErrorCode})");
         }
 
-        return Task.FromResult(StepResult.Ok($"Port {port} is available"));
+        return StepResult.Ok($"Port {port} is available");
     }
 
-    private static bool CanBind(IPAddress address, int port, out SocketException error)
+    /// <summary>
+    /// Polls until all required addresses for <paramref name="port"/> can be bound,
+    /// or until <paramref name="maxWaitSeconds"/> elapses.  Silently returns if the
+    /// port never frees — <see cref="ExecuteAsync"/> will still hard-fail in that case.
+    /// </summary>
+    internal static async Task WaitForPortFreeAsync(
+        int port, string bind, SetupLogger logger, CancellationToken ct,
+        int maxWaitSeconds = 20)
+    {
+        var addresses = bind.Equals("lan", StringComparison.OrdinalIgnoreCase)
+            ? new[] { IPAddress.Any, IPAddress.IPv6Any }
+            : [IPAddress.Loopback];
+
+        var deadline = DateTime.UtcNow.AddSeconds(maxWaitSeconds);
+        var attempt = 0;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (addresses.All(a => CanBind(a, port, out _)))
+            {
+                if (attempt > 0)
+                    logger.Info($"Port {port} became free after {attempt * 500}ms");
+                return;
+            }
+
+            attempt++;
+            await Task.Delay(500, ct);
+        }
+
+        logger.Warn($"Port {port} still in use after {maxWaitSeconds}s poll — proceeding to hard check");
+    }
+
+    internal static bool CanBind(IPAddress address, int port, out SocketException error)
     {
         var listener = new TcpListener(address, port)
         {

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -213,6 +213,60 @@ public class SetupStepsTests : IDisposable
     }
 
     [Fact]
+    public async Task WaitForPortFree_ReturnsImmediately_WhenPortIsAlreadyFree()
+    {
+        var port = GetFreeTcpPort();
+        var logger = new SetupLogger(filePath: null, LogLevel.Trace);
+
+        // Should complete well within 1 second because the port is already free
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await PreflightPortStep.WaitForPortFreeAsync(port, "loopback", logger, cts.Token, maxWaitSeconds: 10);
+        // No assertion needed — completing without cancellation/timeout is the success condition
+    }
+
+    [Fact]
+    public async Task WaitForPortFree_PollsUntilPortReleased()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0) { ExclusiveAddressUse = true };
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var logger = new SetupLogger(filePath: null, LogLevel.Trace);
+
+        // Release the port after a short delay (simulates WSL proxy teardown lag)
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(400);
+            listener.Stop();
+        });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await PreflightPortStep.WaitForPortFreeAsync(port, "loopback", logger, cts.Token, maxWaitSeconds: 5);
+
+        // Port should now be free
+        Assert.True(PreflightPortStep.CanBind(IPAddress.Loopback, port, out _));
+    }
+
+    [Fact]
+    public async Task PreflightPort_Loopback_SucceedsAfterPortReleasedDuringPoll()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0) { ExclusiveAddressUse = true };
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        // Release after 300ms — simulates a slow WSL proxy shutdown
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(300);
+            listener.Stop();
+        });
+
+        var ctx = CreateContext(new SetupConfig { GatewayPort = port });
+        var result = await new PreflightPortStep().ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
     public async Task InstallCli_RejectsHttpUrl()
     {
         var ctx = CreateContext(new SetupConfig


### PR DESCRIPTION
## Problem

Setup fails at the `preflight-port` step with:

```
Step 'preflight-port' failed: Port 18789 is already in use for loopback bind (AddressAlreadyInUse)
```

**Root cause**: On Windows, after `wsl --terminate` + `wsl --shutdown`, the localhost-proxy process that WSL2 uses to forward `127.0.0.1:18789 → WSL2:18789` does not always release the port within the previous fixed 3-second `Task.Delay`.  Because `PreflightPortStep` has `CanRetry => false`, the first failed bind immediately aborts setup with no recovery path, leaving the user stuck with a broken install.

## Fix

Replace every fixed sleep-after-shutdown with an active **port-availability poll loop** (`WaitForPortFreeAsync`) that:

- Probes `CanBind` every **500 ms**
- Returns as soon as the port is confirmed free (fast-path: zero extra wait when cleanup was fast)
- Logs elapsed time if it had to wait
- Gives up and falls through to the hard check after a configurable ceiling (default **20 s** from `CleanupStaleDistroStep`, **10 s** inside `PreflightPortStep` itself as belt-and-suspenders)

### Changed files

| File | Change |
|------|--------|
| `SetupSteps.cs` | Add `WaitForPortFreeAsync` + make `CanBind` `internal static`; replace fixed `Task.Delay(3000)` in `CleanupStaleDistroStep`; add poll call at top of `PreflightPortStep.ExecuteAsync` |
| `SetupStepsTests.cs` | Three new tests: immediate return when port free, poll-until-released mid-wait, full `ExecuteAsync` succeeds after 300 ms simulated proxy lag |

## Test plan

- [x] `WaitForPortFree_ReturnsImmediately_WhenPortIsAlreadyFree` — no unnecessary delay on the happy path
- [x] `WaitForPortFree_PollsUntilPortReleased` — polling detects port release mid-wait
- [x] `PreflightPort_Loopback_SucceedsAfterPortReleasedDuringPoll` — full step succeeds when port frees within the window
- [x] Existing `PreflightPort_Loopback_SucceedsForAvailablePort` and `PreflightPort_Lan_FailsWhenAnyBindPortInUse` still pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)