### PR TITLE
Execute approved exec-approval commands as a resolved, shell-free argv

### DIFF
--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2Result.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2Result.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
+using OpenClaw.Shared;
 
 namespace OpenClaw.Shared.ExecApprovals;
 
@@ -14,6 +16,8 @@ namespace OpenClaw.Shared.ExecApprovals;
 /// </summary>
 public sealed record ExecApprovedExecution
 {
+    public const int MaxTimeoutMs = 600_000;
+
     public IReadOnlyList<string> Argv { get; }
     public string? Cwd { get; }
     public int TimeoutMs { get; }
@@ -28,13 +32,27 @@ public sealed record ExecApprovedExecution
         ArgumentNullException.ThrowIfNull(argv);
         if (argv.Count == 0)
             throw new ArgumentException("Approved execution requires a non-empty argv.", nameof(argv));
-        Argv = argv.ToArray();
+        if (timeoutMs <= 0)
+            throw new ArgumentOutOfRangeException(nameof(timeoutMs), timeoutMs, "Approved execution timeout must be positive.");
+
+        Argv = Array.AsReadOnly(argv.ToArray());
         Cwd = cwd;
-        TimeoutMs = timeoutMs;
+        TimeoutMs = Math.Min(timeoutMs, MaxTimeoutMs);
         Env = env is null
             ? null
-            : new Dictionary<string, string>(env, StringComparer.OrdinalIgnoreCase);
+            : new ReadOnlyDictionary<string, string>(
+                new Dictionary<string, string>(env, StringComparer.OrdinalIgnoreCase));
     }
+
+    public CommandRequest ToCommandRequest() => new()
+    {
+        Argv = Argv,
+        Cwd = Cwd,
+        TimeoutMs = TimeoutMs,
+        Env = Env is null
+            ? null
+            : new Dictionary<string, string>(Env, StringComparer.OrdinalIgnoreCase),
+    };
 }
 
 /// <summary>

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2Result.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2Result.cs
@@ -1,4 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
 namespace OpenClaw.Shared.ExecApprovals;
+
+/// <summary>
+/// What the caller must execute after an allow. <see cref="Argv"/> is the validated
+/// argument vector and <see cref="Env"/> is the sanitized environment built during
+/// evaluation. Neither may be re-derived from the raw request, and the argv must
+/// reach the process without a shell re-parsing it. The constructor takes defensive
+/// copies so the approved argv/env cannot be mutated through an aliased reference
+/// between approval and execution.
+/// </summary>
+public sealed record ExecApprovedExecution
+{
+    public IReadOnlyList<string> Argv { get; }
+    public string? Cwd { get; }
+    public int TimeoutMs { get; }
+    public IReadOnlyDictionary<string, string>? Env { get; }
+
+    public ExecApprovedExecution(
+        IReadOnlyList<string> argv,
+        string? cwd,
+        int timeoutMs,
+        IReadOnlyDictionary<string, string>? env)
+    {
+        ArgumentNullException.ThrowIfNull(argv);
+        if (argv.Count == 0)
+            throw new ArgumentException("Approved execution requires a non-empty argv.", nameof(argv));
+        Argv = argv.ToArray();
+        Cwd = cwd;
+        TimeoutMs = timeoutMs;
+        Env = env is null
+            ? null
+            : new Dictionary<string, string>(env, StringComparer.OrdinalIgnoreCase);
+    }
+}
 
 /// <summary>
 /// Stable result codes for the V2 exec approval path.
@@ -25,10 +62,25 @@ public sealed class ExecApprovalV2Result
     public ExecApprovalV2Code Code { get; }
     public string Reason { get; }
 
-    private ExecApprovalV2Result(ExecApprovalV2Code code, string reason)
+    /// <summary>
+    /// The command to execute. Non-null only on <see cref="ExecApprovalV2Code.Allow"/>.
+    /// Carries the validated argv and sanitized env so the caller never re-derives
+    /// them from the raw request.
+    /// </summary>
+    public ExecApprovedExecution? Execution { get; }
+
+    private ExecApprovalV2Result(ExecApprovalV2Code code, string reason, ExecApprovedExecution? execution = null)
     {
+        // Invariant: Allow must carry a payload; non-Allow must not. A null payload
+        // on Allow (or a payload on a deny) is a bug, not a representable state.
+        if (code == ExecApprovalV2Code.Allow && execution is null)
+            throw new ArgumentNullException(nameof(execution), "Allow result requires an execution payload.");
+        if (code != ExecApprovalV2Code.Allow && execution is not null)
+            throw new ArgumentException("Non-allow result must not carry an execution payload.", nameof(execution));
+
         Code = code;
         Reason = reason;
+        Execution = execution;
     }
 
     public static ExecApprovalV2Result Unavailable(string reason = "Handler not available")
@@ -55,8 +107,16 @@ public sealed class ExecApprovalV2Result
     public static ExecApprovalV2Result InternalError(string reason)
         => new(ExecApprovalV2Code.InternalError, reason);
 
-    public static ExecApprovalV2Result Allow()
-        => new(ExecApprovalV2Code.Allow, "approved");
+    /// <summary>
+    /// Approve the command and carry the execution payload the caller must run.
+    /// An allow without a payload is not a valid state — there is intentionally
+    /// no parameterless allow: the approved argv must reach the process verbatim.
+    /// </summary>
+    public static ExecApprovalV2Result Allow(ExecApprovedExecution execution)
+    {
+        ArgumentNullException.ThrowIfNull(execution);
+        return new(ExecApprovalV2Code.Allow, "approved", execution);
+    }
 
     public bool IsAllow => Code == ExecApprovalV2Code.Allow;
 

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
@@ -253,14 +253,14 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
             || resolvedPath.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase))
             return null;
 
-        // If the command is an env invocation with modifiers (VAR=val assignments or
+        // If any env wrapper in the chain carries modifiers (VAR=val assignments or
         // flags), the direct-argv payload cannot faithfully carry those semantics: the
         // modifier would be silently dropped, and the process would run in a different
-        // environment than the one that was approved. Fail closed rather than execute
-        // a command that differs from what was evaluated.
-        if (identity.Command.Count > 0
-            && ExecCommandToken.IsEnv(identity.Command[0].Trim())
-            && ExecEnvInvocationUnwrapper.HasModifiers(identity.Command))
+        // environment than the one that was approved. This walks the full unwrap chain
+        // so a nested form such as `env env FOO=bar node` is caught, not just the outer
+        // wrapper. Fail closed rather than execute a command that differs from what was
+        // evaluated.
+        if (ExecEnvInvocationUnwrapper.AnyWrapperHasModifiers(identity.Command))
             return null;
 
         // Transparent env wrappers (no modifiers) are safe to unwrap: the inner

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
@@ -244,11 +244,13 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
         if (string.IsNullOrEmpty(resolvedPath))
             return null;
 
-        // argv[0] = resolved absolute path; remaining args preserved verbatim.
-        var argv = new string[identity.Command.Count];
+        // Build argv from the effective command the resolver evaluated so approval
+        // and execution stay pinned to the same executable/argument identity.
+        var effective = ExecEnvInvocationUnwrapper.UnwrapForResolution(identity.Command);
+        var argv = new string[effective.Count];
         argv[0] = resolvedPath;
-        for (var i = 1; i < identity.Command.Count; i++)
-            argv[i] = identity.Command[i];
+        for (var i = 1; i < effective.Count; i++)
+            argv[i] = effective[i];
 
         return new ExecApprovedExecution(argv, identity.Cwd, identity.TimeoutMs, sanitizedEnv);
     }

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
@@ -244,8 +244,18 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
         if (string.IsNullOrEmpty(resolvedPath))
             return null;
 
-        // Build argv from the effective command the resolver evaluated so approval
-        // and execution stay pinned to the same executable/argument identity.
+        // If the command is an env invocation with modifiers (VAR=val assignments or
+        // flags), the direct-argv payload cannot faithfully carry those semantics: the
+        // modifier would be silently dropped, and the process would run in a different
+        // environment than the one that was approved. Fail closed rather than execute
+        // a command that differs from what was evaluated.
+        if (identity.Command.Count > 0
+            && ExecCommandToken.IsEnv(identity.Command[0].Trim())
+            && ExecEnvInvocationUnwrapper.HasModifiers(identity.Command))
+            return null;
+
+        // Transparent env wrappers (no modifiers) are safe to unwrap: the inner
+        // command is the real executable and the args are preserved verbatim.
         var effective = ExecEnvInvocationUnwrapper.UnwrapForResolution(identity.Command);
         var argv = new string[effective.Count];
         argv[0] = resolvedPath;

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
@@ -100,13 +100,19 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
         if (pass1 is ExecHostPolicyDecision.AllowOutcome)
         {
             // Pre-approved path (security=Full, ask=Off or allowlist satisfied): skip prompt.
+            // Fail closed if the approved executable cannot be pinned to a resolved path.
+            var preApprovedExecution = BuildApprovedExecution(identity, sanitizedEnv);
+            if (preApprovedExecution is null)
+                return LogAndReturn(ExecApprovalV2Result.InternalError("unresolved-executable-on-allow"),
+                    correlationId, promptAttempted: false, fallbackUsed: false, canonical: context.DisplayCommand);
+
             // Side effects are best-effort: a metadata write failure must not flip an allow to a deny.
             try { await RecordAllowlistUsageAsync(context).ConfigureAwait(false); }
             catch (Exception ex) { _logger.Warn($"[EXEC-APPROVALS] [{correlationId}] side-effect: record-usage failed (non-fatal): {ex.Message}"); }
             _logger.Info($"[EXEC-APPROVALS] [{correlationId}] path=new " +
                 $"canonical=\"{SanitizeForLog(context.DisplayCommand)}\" decision=allow " +
                 $"reason=approved fallbackUsed=false promptAttempted=false");
-            return ExecApprovalV2Result.Allow();
+            return ExecApprovalV2Result.Allow(preApprovedExecution);
         }
         // RequiresPromptOutcome → continue to prompt/fallback block
 
@@ -196,13 +202,19 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
         try { await RecordAllowlistUsageAsync(context).ConfigureAwait(false); }
         catch (Exception ex) { _logger.Warn($"[EXEC-APPROVALS] [{correlationId}] side-effect: record-usage failed (non-fatal): {ex.Message}"); }
 
-        // Step 9: final allow log
+        // Step 9: build payload from the resolved path; fail closed if unresolved.
+        var execution = BuildApprovedExecution(identity, sanitizedEnv);
+        if (execution is null)
+            return LogAndReturn(ExecApprovalV2Result.InternalError("unresolved-executable-on-allow"),
+                correlationId, promptAttempted, fallbackUsed, canonical: context.DisplayCommand);
+
+        // Step 9b: final allow log
         _logger.Info($"[EXEC-APPROVALS] [{correlationId}] path=new " +
             $"canonical=\"{SanitizeForLog(context.DisplayCommand)}\" decision=allow " +
             $"reason=approved fallbackUsed={fallbackUsed} promptAttempted={promptAttempted}");
 
         // Step 10: return Allow
-        return ExecApprovalV2Result.Allow();
+        return ExecApprovalV2Result.Allow(execution);
         }
         catch (Exception ex)
         {
@@ -215,6 +227,30 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
             _logger.Error(msg, ex);
             return ExecApprovalV2Result.InternalError("unexpected-exception");
         }
+    }
+
+    // Builds the approved execution payload from the RESOLVED executable path, never
+    // the raw argv[0]. The command must execute with the same canonical identity it
+    // was evaluated under: a relative argv[0] in the payload would let Windows
+    // re-resolve it against PATH/cwd at execution time (a hijack), and the
+    // direct-argv runner rejects non-absolute executables anyway. Returns null when
+    // the executable could not be resolved to a path — the caller fails closed
+    // rather than execute a command whose identity we cannot pin.
+    internal static ExecApprovedExecution? BuildApprovedExecution(
+        CanonicalCommandIdentity identity,
+        IReadOnlyDictionary<string, string>? sanitizedEnv)
+    {
+        var resolvedPath = identity.Resolution?.ResolvedPath;
+        if (string.IsNullOrEmpty(resolvedPath))
+            return null;
+
+        // argv[0] = resolved absolute path; remaining args preserved verbatim.
+        var argv = new string[identity.Command.Count];
+        argv[0] = resolvedPath;
+        for (var i = 1; i < identity.Command.Count; i++)
+            argv[i] = identity.Command[i];
+
+        return new ExecApprovedExecution(argv, identity.Cwd, identity.TimeoutMs, sanitizedEnv);
     }
 
     // Persists allowAlways patterns after an AllowAlways prompt decision (non-empty only).

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
@@ -245,6 +245,14 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
         if (string.IsNullOrEmpty(resolvedPath))
             return null;
 
+        // A batch script (.bat/.cmd) cannot run without cmd.exe, which re-parses the
+        // arguments and breaks the verbatim-argv guarantee. The direct-argv runner
+        // rejects these too; reject here as well so the fail-closed result is reached
+        // before any approval state is written, not after.
+        if (resolvedPath.EndsWith(".bat", StringComparison.OrdinalIgnoreCase)
+            || resolvedPath.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase))
+            return null;
+
         // If the command is an env invocation with modifiers (VAR=val assignments or
         // flags), the direct-argv payload cannot faithfully carry those semantics: the
         // modifier would be silently dropped, and the process would run in a different

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
@@ -192,7 +192,14 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
             _promptLock.Release();
         }
 
-        // Step 8: side effects — strictly after the final allow decision.
+        // Step 8: build payload before any store writes — a fail-closed payload result
+        // must not leave persistent allowlist state behind.
+        var execution = BuildApprovedExecution(identity, sanitizedEnv);
+        if (execution is null)
+            return LogAndReturn(ExecApprovalV2Result.InternalError("unresolved-executable-on-allow"),
+                correlationId, promptAttempted, fallbackUsed, canonical: context.DisplayCommand);
+
+        // Step 9: side effects — only reached when the payload is valid.
         // Each side effect is independently best-effort so a failure in one does not skip the other.
         if (persistAllowlistEntry && context.Security == ExecSecurity.Allowlist)
         {
@@ -202,13 +209,7 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
         try { await RecordAllowlistUsageAsync(context).ConfigureAwait(false); }
         catch (Exception ex) { _logger.Warn($"[EXEC-APPROVALS] [{correlationId}] side-effect: record-usage failed (non-fatal): {ex.Message}"); }
 
-        // Step 9: build payload from the resolved path; fail closed if unresolved.
-        var execution = BuildApprovedExecution(identity, sanitizedEnv);
-        if (execution is null)
-            return LogAndReturn(ExecApprovalV2Result.InternalError("unresolved-executable-on-allow"),
-                correlationId, promptAttempted, fallbackUsed, canonical: context.DisplayCommand);
-
-        // Step 9b: final allow log
+        // Step 10: final allow log
         _logger.Info($"[EXEC-APPROVALS] [{correlationId}] path=new " +
             $"canonical=\"{SanitizeForLog(context.DisplayCommand)}\" decision=allow " +
             $"reason=approved fallbackUsed={fallbackUsed} promptAttempted={promptAttempted}");

--- a/src/OpenClaw.Shared/ExecApprovals/ExecEnvInvocationUnwrapper.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecEnvInvocationUnwrapper.cs
@@ -81,6 +81,27 @@ internal static class ExecEnvInvocationUnwrapper
         return false;
     }
 
+    // Returns true when any env wrapper in the full unwrap chain carries modifiers
+    // (VAR=val assignments or flags), including nested forms such as `env env FOO=bar node`.
+    // UnwrapForResolution strips every level for resolution, so checking only the outer
+    // wrapper would let an inner modifier slip through and be dropped from execution.
+    internal static bool AnyWrapperHasModifiers(IReadOnlyList<string> command)
+    {
+        var current = command;
+        for (var depth = 0; depth < MaxWrapperDepth; depth++)
+        {
+            if (current.Count == 0) break;
+            var token = current[0].Trim();
+            if (token.Length == 0) break;
+            if (!ExecCommandToken.IsEnv(token)) break;
+            if (HasModifiers(current)) return true;
+            var unwrapped = Unwrap(current);
+            if (unwrapped is null || unwrapped.Count == 0) break;
+            current = unwrapped;
+        }
+        return false;
+    }
+
     // Iteratively strips env wrappers for executable resolution only.
     internal static IReadOnlyList<string> UnwrapForResolution(IReadOnlyList<string> command)
     {

--- a/src/OpenClaw.Shared/ICommandRunner.cs
+++ b/src/OpenClaw.Shared/ICommandRunner.cs
@@ -12,7 +12,15 @@ public class CommandRequest
 {
     /// <summary>The command to execute (e.g., "echo hello" or "Get-Process")</summary>
     public string Command { get; set; } = "";
-    
+
+    /// <summary>
+    /// When set, execute this argv directly with no shell between policy and the
+    /// process: FileName = Argv[0], the rest go through ProcessStartInfo.ArgumentList
+    /// verbatim. Takes precedence over Command/Args/Shell, which are ignored.
+    /// Null = legacy shell-wrapped path.
+    /// </summary>
+    public IReadOnlyList<string>? Argv { get; set; }
+
     /// <summary>Optional arguments array</summary>
     public string[]? Args { get; set; }
     

--- a/src/OpenClaw.Shared/LocalCommandRunner.cs
+++ b/src/OpenClaw.Shared/LocalCommandRunner.cs
@@ -25,14 +25,22 @@ public class LocalCommandRunner : ICommandRunner
     
     public async Task<CommandResult> RunAsync(CommandRequest request, CancellationToken ct = default)
     {
-        var (fileName, arguments) = BuildProcessArgs(request);
-        
-        _logger.Info($"[EXEC] {fileName} {arguments}");
-        
+        ExecutionPlan plan;
+        try
+        {
+            plan = PlanExecution(request);
+        }
+        catch (ArgumentException ex)
+        {
+            // Fail-closed: an invalid approved argv (empty, relative, or batch
+            // executable) must not fall back to a shell or crash the host.
+            _logger.Error($"[EXEC] Rejected command: {ex.Message}");
+            return new CommandResult { Stderr = ex.Message, ExitCode = -1 };
+        }
+
         var psi = new ProcessStartInfo
         {
-            FileName = fileName,
-            Arguments = arguments,
+            FileName = plan.FileName,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
@@ -40,6 +48,21 @@ public class LocalCommandRunner : ICommandRunner
             StandardOutputEncoding = Encoding.UTF8,
             StandardErrorEncoding = Encoding.UTF8
         };
+
+        if (plan.IsDirectArgv)
+        {
+            // The approved argv reaches the process verbatim via ArgumentList, with
+            // no shell re-parsing it. Log the arg count, not the values — args may
+            // carry secrets.
+            foreach (var arg in plan.ArgList!)
+                psi.ArgumentList.Add(arg);
+            _logger.Info($"[EXEC] {plan.FileName} ({plan.ArgList!.Count} args, direct argv)");
+        }
+        else
+        {
+            psi.Arguments = plan.Arguments;
+            _logger.Info($"[EXEC] {plan.FileName} {plan.Arguments}");
+        }
         
         if (!string.IsNullOrEmpty(request.Cwd))
         {
@@ -162,6 +185,53 @@ public class LocalCommandRunner : ICommandRunner
         return result;
     }
     
+    /// <summary>
+    /// Decides how the process is launched: direct-argv (no shell) when the request
+    /// carries an approved <see cref="CommandRequest.Argv"/>, otherwise the legacy
+    /// shell-wrapped path. Kept separate from <see cref="RunAsync"/> so the decision
+    /// is unit-testable without spawning a process.
+    /// </summary>
+    internal static ExecutionPlan PlanExecution(CommandRequest request)
+    {
+        // Argv set (non-null) means the caller approved a direct-argv execution and
+        // it takes precedence (ICommandRunner contract). An empty argv is a malformed
+        // approved payload, not a request to fall back to the shell — fail closed.
+        if (request.Argv is { } argv)
+        {
+            if (argv.Count == 0)
+                throw new ArgumentException("Direct-argv mode requires a non-empty argv.", nameof(request));
+            ValidateDirectExecutable(argv[0]);
+            return ExecutionPlan.Direct(argv);
+        }
+
+        var (fileName, arguments) = BuildProcessArgs(request);
+        return ExecutionPlan.Shell(fileName, arguments);
+    }
+
+    /// <summary>
+    /// Fail-closed guard for direct-argv mode. The approved executable must be a
+    /// fully-qualified path so Windows never guesses argv[0] from PATH/cwd (e.g. a
+    /// "C:\Program.exe" hijack), and must not be a batch script: .bat/.cmd cannot
+    /// run without cmd.exe, which re-parses arguments and breaks the verbatim-argv
+    /// guarantee. Both are bugs in the approval layer, not recoverable states —
+    /// throw rather than degrade to a shell.
+    /// </summary>
+    private static void ValidateDirectExecutable(string executable)
+    {
+        if (string.IsNullOrWhiteSpace(executable))
+            throw new ArgumentException("Direct-argv executable (argv[0]) must not be empty.", nameof(executable));
+
+        if (!Path.IsPathFullyQualified(executable))
+            throw new ArgumentException(
+                $"Direct-argv executable must be a fully-qualified path, got: {executable}", nameof(executable));
+
+        var ext = Path.GetExtension(executable);
+        if (ext.Equals(".bat", StringComparison.OrdinalIgnoreCase) ||
+            ext.Equals(".cmd", StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException(
+                $"Direct-argv mode cannot guarantee argv fidelity for batch scripts: {executable}", nameof(executable));
+    }
+
     private static (string fileName, string arguments) BuildProcessArgs(CommandRequest request)
     {
         var shell = request.Shell ?? "powershell";
@@ -183,6 +253,42 @@ public class LocalCommandRunner : ICommandRunner
         return ("powershell.exe", $"-NoProfile -NonInteractive -Command {command}");
     }
     
+    /// <summary>
+    /// How <see cref="LocalCommandRunner"/> will launch the process. Either direct-argv
+    /// (<see cref="ArgList"/> non-null, no shell) or shell-wrapped (<see cref="Arguments"/>).
+    /// </summary>
+    internal sealed class ExecutionPlan
+    {
+        public string FileName { get; }
+
+        /// <summary>Argv[1..] passed verbatim via ArgumentList. Non-null = direct-argv mode.</summary>
+        public IReadOnlyList<string>? ArgList { get; }
+
+        /// <summary>Single command-line string for the shell-wrapped legacy path.</summary>
+        public string? Arguments { get; }
+
+        public bool IsDirectArgv => ArgList is not null;
+
+        private ExecutionPlan(string fileName, IReadOnlyList<string>? argList, string? arguments)
+        {
+            FileName = fileName;
+            ArgList = argList;
+            Arguments = arguments;
+        }
+
+        public static ExecutionPlan Direct(IReadOnlyList<string> argv)
+        {
+            // argv preserved verbatim (no trimming).
+            var rest = new string[argv.Count - 1];
+            for (var i = 1; i < argv.Count; i++)
+                rest[i - 1] = argv[i];
+            return new ExecutionPlan(argv[0], rest, null);
+        }
+
+        public static ExecutionPlan Shell(string fileName, string arguments)
+            => new(fileName, null, arguments);
+    }
+
     private void KillProcess(Process process)
     {
         try

--- a/src/OpenClaw.Shared/Mxc/MxcCommandRunner.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcCommandRunner.cs
@@ -71,6 +71,25 @@ public sealed class MxcCommandRunner : ICommandRunner
             return await _hostFallback.RunAsync(request, ct);
         }
 
+        // A direct-argv request reaching the sandbox cannot be honored: the sandbox
+        // protocol only carries the legacy command/shell/args fields, so serializing
+        // would silently run something other than the approved argv. Fail closed until
+        // the sandbox transport carries argv faithfully. The host-fallback branches
+        // above keep working because the host runner does honor Argv.
+        if (request.Argv is not null)
+        {
+            _logger.Warn("[mxc] system.run BLOCKED: direct-argv request reached the sandbox, " +
+                "which has no argv transport yet. Failing closed rather than running the legacy fields.");
+            return new CommandResult
+            {
+                Stdout = string.Empty,
+                Stderr = "Sandboxed system.run cannot execute a direct-argv command yet.",
+                ExitCode = -1,
+                TimedOut = false,
+                DurationMs = 0,
+            };
+        }
+
         var settingsDirectoryPath = _settingsDirectoryPathProvider();
         var policy = MxcPolicyBuilder.ForSystemRun(settings, settingsDirectoryPath);
         var argsJson = SerializeArgs(request);

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
@@ -525,10 +525,30 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         Assert.NotEqual(new[] { @"C:\Program Files\Git\bin\git.exe", "git", "status" }, exec.Argv);
     }
 
+    [Fact]
+    public void BuildApprovedExecution_NestedTransparentEnvWrapper_EmitsUnwrappedPayload()
+    {
+        // A nested env wrapper with no modifiers (`env env git status`) is transparent:
+        // the inner command is the real executable and the args are preserved verbatim.
+        var resolution = new ExecCommandResolution(
+            RawExecutable: "git",
+            ResolvedPath: @"C:\Program Files\Git\bin\git.exe",
+            ExecutableName: "git.exe",
+            Cwd: null);
+        var identity = MakeIdentity(new[] { "env", "env", "git", "status" }, resolution);
+
+        var exec = ExecApprovalsCoordinator.BuildApprovedExecution(identity, sanitizedEnv: null);
+
+        Assert.NotNull(exec);
+        Assert.Equal(new[] { @"C:\Program Files\Git\bin\git.exe", "status" }, exec!.Argv);
+    }
+
     [Theory]
     [InlineData("env", "FOO=bar", "node", "script.js")]
     [InlineData("env", "-i", "node", "script.js")]
     [InlineData("env", "--unset=FOO", "node", "script.js")]
+    [InlineData("env", "env", "FOO=bar", "node", "script.js")] // nested modifier on the inner wrapper
+    [InlineData("env", "env", "-i", "node", "script.js")]
     public void BuildApprovedExecution_ReturnsNull_WhenEnvHasModifiers(params string[] command)
     {
         // A modified env wrapper (assignments or flags) cannot be faithfully represented

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
@@ -525,6 +525,25 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         Assert.NotEqual(new[] { @"C:\Program Files\Git\bin\git.exe", "git", "status" }, exec.Argv);
     }
 
+    [Theory]
+    [InlineData("env", "FOO=bar", "node", "script.js")]
+    [InlineData("env", "-i", "node", "script.js")]
+    [InlineData("env", "--unset=FOO", "node", "script.js")]
+    public void BuildApprovedExecution_ReturnsNull_WhenEnvHasModifiers(params string[] command)
+    {
+        // A modified env wrapper (assignments or flags) cannot be faithfully represented
+        // in a direct-argv payload without the wrapper, so the payload must fail closed
+        // rather than silently drop the modifier and run in a different environment.
+        var resolution = new ExecCommandResolution(
+            RawExecutable: "node",
+            ResolvedPath: @"C:\Program Files\nodejs\node.exe",
+            ExecutableName: "node.exe",
+            Cwd: null);
+        var identity = MakeIdentity(command, resolution);
+
+        Assert.Null(ExecApprovalsCoordinator.BuildApprovedExecution(identity, sanitizedEnv: null));
+    }
+
     [Fact]
     public async Task Allow_UnresolvedExecutable_FailsClosedViaHandleAsync()
     {

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
@@ -584,6 +584,24 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         Assert.Null(ExecApprovalsCoordinator.BuildApprovedExecution(identity, sanitizedEnv: null));
     }
 
+    [Theory]
+    [InlineData(@"C:\scripts\deploy.bat")]
+    [InlineData(@"C:\scripts\deploy.cmd")]
+    [InlineData(@"C:\scripts\DEPLOY.BAT")]
+    public void BuildApprovedExecution_ReturnsNull_WhenResolvedToBatchScript(string resolvedPath)
+    {
+        // A batch script needs cmd.exe, which re-parses arguments and breaks the
+        // verbatim-argv guarantee, so the payload must fail closed before any approval
+        // state is written rather than emit a payload the runner will later reject.
+        var resolution = new ExecCommandResolution(
+            RawExecutable: "deploy",
+            ResolvedPath: resolvedPath,
+            ExecutableName: System.IO.Path.GetFileName(resolvedPath),
+            Cwd: null);
+        var identity = MakeIdentity(new[] { "deploy", "arg" }, resolution);
+        Assert.Null(ExecApprovalsCoordinator.BuildApprovedExecution(identity, sanitizedEnv: null));
+    }
+
     [Fact]
     public void V2Result_IsAllow_FalseForAllDenyCodes()
     {

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
@@ -558,6 +558,24 @@ public class ExecApprovalsCoordinatorTests : IDisposable
     }
 
     [Fact]
+    public async Task Allow_ModifiedEnvWrapper_FailsClosedWithNoStoreWrite()
+    {
+        // A modified env wrapper is approved (security=allowlist, ask=always, AllowAlways) but
+        // the payload cannot carry the modifier semantics faithfully. The result must be
+        // InternalError and the store must not be modified — no new allowlist entry persisted.
+        const string initialStore = """{"version":1,"defaults":{"security":"allowlist","ask":"always"}}""";
+        WriteStoreFile(initialStore);
+        var req = Req("""{"command":["env","FOO=bar","cmd","/c","echo","hello"]}""");
+        var result = await MakeCoordinator(
+            canPresent: AlwaysCanPresentEvaluator.Instance,
+            prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.AllowAlways))
+            .HandleAsync(req, "env-modifier-no-persist");
+        Assert.Equal(ExecApprovalV2Code.InternalError, result.Code);
+        var storeText = File.ReadAllText(Path.Combine(_dir, "exec-approvals.json"));
+        Assert.Equal(initialStore, storeText);
+    }
+
+    [Fact]
     public void BuildApprovedExecution_ReturnsNull_WhenExecutableUnresolved()
     {
         // No resolved path → caller must fail closed rather than execute a command

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
@@ -380,18 +380,48 @@ public class ExecApprovalsCoordinatorTests : IDisposable
 
     [Fact]
     public void ExecApprovedExecution_NullArgv_Throws()
-        => Assert.Throws<ArgumentNullException>(() => new ExecApprovedExecution(null!, cwd: null, timeoutMs: 0, env: null));
+        => Assert.Throws<ArgumentNullException>(() => new ExecApprovedExecution(null!, cwd: null, timeoutMs: 1000, env: null));
 
     [Fact]
     public void ExecApprovedExecution_EmptyArgv_Throws()
-        => Assert.Throws<ArgumentException>(() => new ExecApprovedExecution(Array.Empty<string>(), cwd: null, timeoutMs: 0, env: null));
+        => Assert.Throws<ArgumentException>(() => new ExecApprovedExecution(Array.Empty<string>(), cwd: null, timeoutMs: 1000, env: null));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void ExecApprovedExecution_NonPositiveTimeout_Throws(int timeoutMs)
+        => Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new ExecApprovedExecution(new[] { "cmd" }, cwd: null, timeoutMs, env: null));
+
+    [Fact]
+    public void ExecApprovedExecution_ClampsTimeoutToSystemRunMaximum()
+    {
+        var exec = new ExecApprovedExecution(
+            new[] { "cmd" },
+            cwd: null,
+            timeoutMs: int.MaxValue,
+            env: null);
+
+        Assert.Equal(ExecApprovedExecution.MaxTimeoutMs, exec.TimeoutMs);
+    }
 
     [Fact]
     public void ExecApprovedExecution_CopiesArgvDefensively()
     {
         var argv = new[] { "cmd", "/c", "echo" };
-        var exec = new ExecApprovedExecution(argv, cwd: null, timeoutMs: 0, env: null);
+        var exec = new ExecApprovedExecution(argv, cwd: null, timeoutMs: 1000, env: null);
         argv[0] = "TAMPERED"; // mutate the source after construction
+        Assert.Equal("cmd", exec.Argv[0]);
+    }
+
+    [Fact]
+    public void ExecApprovedExecution_ArgvCannotBeMutatedThroughReturnedCollection()
+    {
+        var exec = new ExecApprovedExecution(new[] { "cmd", "/c" }, cwd: null, timeoutMs: 1000, env: null);
+        var list = Assert.IsAssignableFrom<IList<string>>(exec.Argv);
+
+        Assert.True(list.IsReadOnly);
+        Assert.Throws<NotSupportedException>(() => list[0] = "TAMPERED");
         Assert.Equal("cmd", exec.Argv[0]);
     }
 
@@ -399,8 +429,42 @@ public class ExecApprovalsCoordinatorTests : IDisposable
     public void ExecApprovedExecution_CopiesEnvDefensively()
     {
         var env = new Dictionary<string, string> { ["FOO"] = "bar" };
-        var exec = new ExecApprovedExecution(new[] { "x" }, cwd: null, timeoutMs: 0, env: env);
+        var exec = new ExecApprovedExecution(new[] { "x" }, cwd: null, timeoutMs: 1000, env: env);
         env["FOO"] = "TAMPERED"; // mutate the source after construction
+        Assert.Equal("bar", exec.Env!["FOO"]);
+    }
+
+    [Fact]
+    public void ExecApprovedExecution_EnvCannotBeMutatedThroughReturnedDictionary()
+    {
+        var exec = new ExecApprovedExecution(
+            new[] { "cmd" },
+            cwd: null,
+            timeoutMs: 1000,
+            env: new Dictionary<string, string> { ["FOO"] = "bar" });
+
+        var dict = Assert.IsAssignableFrom<IDictionary<string, string>>(exec.Env);
+        Assert.True(dict.IsReadOnly);
+        Assert.Throws<NotSupportedException>(() => dict["FOO"] = "TAMPERED");
+        Assert.Equal("bar", exec.Env!["FOO"]);
+    }
+
+    [Fact]
+    public void ExecApprovedExecution_ToCommandRequest_CarriesAllApprovedExecutionFields()
+    {
+        var exec = new ExecApprovedExecution(
+            new[] { @"C:\Windows\System32\cmd.exe", "/c", "echo", "hello" },
+            cwd: @"C:\work",
+            timeoutMs: 1234,
+            env: new Dictionary<string, string> { ["FOO"] = "bar" });
+
+        var request = exec.ToCommandRequest();
+
+        Assert.Same(exec.Argv, request.Argv);
+        Assert.Equal(exec.Cwd, request.Cwd);
+        Assert.Equal(exec.TimeoutMs, request.TimeoutMs);
+        Assert.Equal("bar", request.Env!["FOO"]);
+        request.Env["FOO"] = "caller-mutation";
         Assert.Equal("bar", exec.Env!["FOO"]);
     }
 
@@ -481,7 +545,7 @@ public class ExecApprovalsCoordinatorTests : IDisposable
     // end-to-end path.
 
     private static CanonicalCommandIdentity MakeIdentity(
-        string[] command, ExecCommandResolution? resolution)
+        string[] command, ExecCommandResolution? resolution, int timeoutMs = 1000)
         => new(
             command,
             displayCommand: string.Join(' ', command),
@@ -489,7 +553,7 @@ public class ExecApprovalsCoordinatorTests : IDisposable
             resolution: resolution,
             allowlistResolutions: Array.Empty<ExecCommandResolution>(),
             allowAlwaysPatterns: Array.Empty<string>(),
-            cwd: null, timeoutMs: 0, env: null, agentId: null, sessionKey: null);
+            cwd: null, timeoutMs, env: null, agentId: null, sessionKey: null);
 
     [Fact]
     public void BuildApprovedExecution_UsesResolvedPathAsArgv0()
@@ -505,6 +569,25 @@ public class ExecApprovalsCoordinatorTests : IDisposable
 
         Assert.NotNull(exec);
         Assert.Equal(new[] { @"C:\Program Files\Git\bin\git.exe", "status" }, exec!.Argv);
+    }
+
+    [Fact]
+    public void BuildApprovedExecution_ClampsPayloadTimeout()
+    {
+        var resolution = new ExecCommandResolution(
+            RawExecutable: "git",
+            ResolvedPath: @"C:\Program Files\Git\bin\git.exe",
+            ExecutableName: "git.exe",
+            Cwd: null);
+        var identity = MakeIdentity(
+            new[] { "git", "status" },
+            resolution,
+            timeoutMs: int.MaxValue);
+
+        var exec = ExecApprovalsCoordinator.BuildApprovedExecution(identity, sanitizedEnv: null);
+
+        Assert.NotNull(exec);
+        Assert.Equal(ExecApprovedExecution.MaxTimeoutMs, exec!.TimeoutMs);
     }
 
     [Fact]

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
@@ -13,9 +13,8 @@ using OpenClaw.Shared.ExecApprovals;
 namespace OpenClaw.Shared.Tests;
 
 /// <summary>
-/// Tests for PR7: ExecApprovalsCoordinator full pipeline.
-/// Covers rail 8 (observability), rail 10 (UI-free), rail 17 (concurrency),
-/// rail 19 (production wiring inert), env injection guard, and log injection prevention.
+/// Tests for ExecApprovalsCoordinator: full pipeline, observability, UI-free guarantee,
+/// concurrency, production wiring inert by default, env injection guard, and log injection prevention.
 /// </summary>
 public class ExecApprovalsCoordinatorTests : IDisposable
 {
@@ -353,7 +352,7 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         Assert.All(results, r => Assert.Equal(ExecApprovalV2Code.UserDenied, r.Code));
     }
 
-    // ── 22a. ExecApprovalV2Result — new codes constructible (InternalError, Allow) ──
+    // ExecApprovalV2Result — new codes constructible (InternalError, Allow)
 
     [Fact]
     public void V2Result_InternalError_CodeAndReason()
@@ -405,7 +404,7 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         Assert.Equal("bar", exec.Env!["FOO"]);
     }
 
-    // ── 22b. Allow payload carries the canonical argv on both allow exits ──
+    // Allow payload carries the canonical argv on both allow exits
 
     [Fact]
     public async Task Allow_PreApproved_CarriesCanonicalArgvPayload()
@@ -448,8 +447,8 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         Assert.Equal(new[] { "/c", "echo", "hello" }, result.Execution.Argv.Skip(1).ToArray());
     }
 
-    // ── 22c. End-to-end handoff: coordinator payload → runner plan (no shell) ──
-    // Guards against the two halves of the PR drifting apart: the payload the
+    // End-to-end handoff: coordinator payload → runner plan (no shell)
+    // Guards against coordinator and runner drifting apart: the payload the
     // coordinator emits must be directly executable by LocalCommandRunner without
     // any shell. Previously the coordinator emitted the raw argv ("cmd") which the
     // direct-argv runner rejects.
@@ -461,7 +460,7 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         Assert.True(result.IsAllow);
 
         // Map the approved payload to a CommandRequest exactly as the production
-        // production caller will, then verify the resulting plan is non-shell.
+        // caller will, then verify the resulting plan is non-shell.
         var plan = LocalCommandRunner.PlanExecution(new CommandRequest
         {
             Argv = result.Execution!.Argv,
@@ -475,7 +474,7 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         Assert.EndsWith("cmd.exe", plan.FileName, StringComparison.OrdinalIgnoreCase);
     }
 
-    // ── 22d. Allow payload is built from the RESOLVED path, fail-closed if unresolved ──
+    // Allow payload is built from the RESOLVED path, fail-closed if unresolved
     // The PATH cannot be injected through the request (the env sanitizer blocks it —
     // the anti-hijack guard itself), so the unresolved-executable branch is covered by
     // testing BuildApprovedExecution directly rather than via a filesystem-dependent
@@ -506,6 +505,24 @@ public class ExecApprovalsCoordinatorTests : IDisposable
 
         Assert.NotNull(exec);
         Assert.Equal(new[] { @"C:\Program Files\Git\bin\git.exe", "status" }, exec!.Argv);
+    }
+
+    [Fact]
+    public void BuildApprovedExecution_UsesEffectiveCommandWhenEnvWrapperWasUnwrapped()
+    {
+        var resolution = new ExecCommandResolution(
+            RawExecutable: "git",
+            ResolvedPath: @"C:\Program Files\Git\bin\git.exe",
+            ExecutableName: "git.exe",
+            Cwd: null);
+        var identity = MakeIdentity(new[] { "env", "git", "status" }, resolution);
+
+        var exec = ExecApprovalsCoordinator.BuildApprovedExecution(identity, sanitizedEnv: null);
+
+        Assert.NotNull(exec);
+        Assert.Equal(2, exec!.Argv.Count);
+        Assert.Equal(new[] { @"C:\Program Files\Git\bin\git.exe", "status" }, exec.Argv);
+        Assert.NotEqual(new[] { @"C:\Program Files\Git\bin\git.exe", "git", "status" }, exec.Argv);
     }
 
     [Fact]

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
@@ -367,10 +367,167 @@ public class ExecApprovalsCoordinatorTests : IDisposable
     [Fact]
     public void V2Result_Allow_IsAllowTrueAndReasonApproved()
     {
-        var r = ExecApprovalV2Result.Allow();
+        var exec = new ExecApprovedExecution(new[] { "git", "status" }, cwd: null, timeoutMs: 1000, env: null);
+        var r = ExecApprovalV2Result.Allow(exec);
         Assert.Equal(ExecApprovalV2Code.Allow, r.Code);
         Assert.Equal("approved", r.Reason);
         Assert.True(r.IsAllow);
+        Assert.Same(exec, r.Execution);
+    }
+
+    [Fact]
+    public void V2Result_Allow_NullPayload_Throws()
+        => Assert.Throws<ArgumentNullException>(() => ExecApprovalV2Result.Allow(null!));
+
+    [Fact]
+    public void ExecApprovedExecution_NullArgv_Throws()
+        => Assert.Throws<ArgumentNullException>(() => new ExecApprovedExecution(null!, cwd: null, timeoutMs: 0, env: null));
+
+    [Fact]
+    public void ExecApprovedExecution_EmptyArgv_Throws()
+        => Assert.Throws<ArgumentException>(() => new ExecApprovedExecution(Array.Empty<string>(), cwd: null, timeoutMs: 0, env: null));
+
+    [Fact]
+    public void ExecApprovedExecution_CopiesArgvDefensively()
+    {
+        var argv = new[] { "cmd", "/c", "echo" };
+        var exec = new ExecApprovedExecution(argv, cwd: null, timeoutMs: 0, env: null);
+        argv[0] = "TAMPERED"; // mutate the source after construction
+        Assert.Equal("cmd", exec.Argv[0]);
+    }
+
+    [Fact]
+    public void ExecApprovedExecution_CopiesEnvDefensively()
+    {
+        var env = new Dictionary<string, string> { ["FOO"] = "bar" };
+        var exec = new ExecApprovedExecution(new[] { "x" }, cwd: null, timeoutMs: 0, env: env);
+        env["FOO"] = "TAMPERED"; // mutate the source after construction
+        Assert.Equal("bar", exec.Env!["FOO"]);
+    }
+
+    // ── 22b. Allow payload carries the canonical argv on both allow exits ──
+
+    [Fact]
+    public async Task Allow_PreApproved_CarriesCanonicalArgvPayload()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"off"}}""");
+        var result = await MakeCoordinator().HandleAsync(DefaultReq(), "payload-pre");
+        Assert.True(result.IsAllow);
+        Assert.NotNull(result.Execution);
+        // argv[0] is the RESOLVED absolute path, not the raw "cmd".
+        Assert.True(Path.IsPathFullyQualified(result.Execution!.Argv[0]));
+        Assert.EndsWith("cmd.exe", result.Execution.Argv[0], StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(new[] { "/c", "echo", "hello" }, result.Execution.Argv.Skip(1).ToArray());
+        Assert.Null(result.Execution.Env); // DefaultReq carries no env
+    }
+
+    [Fact]
+    public async Task Allow_CarriesSanitizedEnvInPayload()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"off"}}""");
+        // A non-blocked env variable must survive sanitization and reach the payload.
+        var req = Req("""{"command":["cmd","/c","echo","hello"],"env":{"FOO":"bar"}}""");
+        var result = await MakeCoordinator().HandleAsync(req, "payload-env");
+        Assert.True(result.IsAllow);
+        Assert.NotNull(result.Execution!.Env);
+        Assert.Equal("bar", result.Execution.Env!["FOO"]);
+    }
+
+    [Fact]
+    public async Task Allow_PostPrompt_CarriesCanonicalArgvPayload()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"always"}}""");
+        var result = await MakeCoordinator(
+            canPresent: AlwaysCanPresentEvaluator.Instance,
+            prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.AllowOnce))
+            .HandleAsync(DefaultReq(), "payload-post");
+        Assert.True(result.IsAllow);
+        Assert.NotNull(result.Execution);
+        Assert.True(Path.IsPathFullyQualified(result.Execution!.Argv[0]));
+        Assert.EndsWith("cmd.exe", result.Execution.Argv[0], StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(new[] { "/c", "echo", "hello" }, result.Execution.Argv.Skip(1).ToArray());
+    }
+
+    // ── 22c. End-to-end handoff: coordinator payload → runner plan (no shell) ──
+    // Guards against the two halves of the PR drifting apart: the payload the
+    // coordinator emits must be directly executable by LocalCommandRunner without
+    // any shell. Previously the coordinator emitted the raw argv ("cmd") which the
+    // direct-argv runner rejects.
+    [Fact]
+    public async Task Allow_Payload_IsAcceptedByDirectArgvRunner()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"off"}}""");
+        var result = await MakeCoordinator().HandleAsync(DefaultReq(), "handoff");
+        Assert.True(result.IsAllow);
+
+        // Map the approved payload to a CommandRequest exactly as the production
+        // production caller will, then verify the resulting plan is non-shell.
+        var plan = LocalCommandRunner.PlanExecution(new CommandRequest
+        {
+            Argv = result.Execution!.Argv,
+            Cwd = result.Execution.Cwd,
+            TimeoutMs = result.Execution.TimeoutMs,
+            Env = result.Execution.Env is null ? null : new Dictionary<string, string>(result.Execution.Env),
+        });
+
+        Assert.True(plan.IsDirectArgv);
+        Assert.Null(plan.Arguments); // no shell-wrapped command line
+        Assert.EndsWith("cmd.exe", plan.FileName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── 22d. Allow payload is built from the RESOLVED path, fail-closed if unresolved ──
+    // The PATH cannot be injected through the request (the env sanitizer blocks it —
+    // the anti-hijack guard itself), so the unresolved-executable branch is covered by
+    // testing BuildApprovedExecution directly rather than via a filesystem-dependent
+    // end-to-end path.
+
+    private static CanonicalCommandIdentity MakeIdentity(
+        string[] command, ExecCommandResolution? resolution)
+        => new(
+            command,
+            displayCommand: string.Join(' ', command),
+            evaluationRawCommand: null,
+            resolution: resolution,
+            allowlistResolutions: Array.Empty<ExecCommandResolution>(),
+            allowAlwaysPatterns: Array.Empty<string>(),
+            cwd: null, timeoutMs: 0, env: null, agentId: null, sessionKey: null);
+
+    [Fact]
+    public void BuildApprovedExecution_UsesResolvedPathAsArgv0()
+    {
+        var resolution = new ExecCommandResolution(
+            RawExecutable: "git",
+            ResolvedPath: @"C:\Program Files\Git\bin\git.exe",
+            ExecutableName: "git.exe",
+            Cwd: null);
+        var identity = MakeIdentity(new[] { "git", "status" }, resolution);
+
+        var exec = ExecApprovalsCoordinator.BuildApprovedExecution(identity, sanitizedEnv: null);
+
+        Assert.NotNull(exec);
+        Assert.Equal(new[] { @"C:\Program Files\Git\bin\git.exe", "status" }, exec!.Argv);
+    }
+
+    [Fact]
+    public async Task Allow_UnresolvedExecutable_FailsClosedViaHandleAsync()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"off"}}""");
+        // A bare name on no PATH resolves to a null path but is still a valid command,
+        // so security=full approves it. The payload cannot pin an absolute executable,
+        // so the allow must fail closed rather than execute an unpinnable command.
+        var req = Req("""{"command":["zzz-nonexistent-tool-9c3f1a7b"]}""");
+        var result = await MakeCoordinator().HandleAsync(req, "unresolved");
+        Assert.Equal(ExecApprovalV2Code.InternalError, result.Code);
+        Assert.Equal("unresolved-executable-on-allow", result.Reason);
+    }
+
+    [Fact]
+    public void BuildApprovedExecution_ReturnsNull_WhenExecutableUnresolved()
+    {
+        // No resolved path → caller must fail closed rather than execute a command
+        // whose identity cannot be pinned.
+        var identity = MakeIdentity(new[] { "ghost", "arg" }, resolution: null);
+        Assert.Null(ExecApprovalsCoordinator.BuildApprovedExecution(identity, sanitizedEnv: null));
     }
 
     [Fact]

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcCommandRunnerTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcCommandRunnerTests.cs
@@ -257,6 +257,47 @@ public class MxcCommandRunnerTests
         Assert.Null(fallback.LastRequest);
     }
 
+    [Fact]
+    public async Task RunAsync_SandboxEnabled_DirectArgv_FailsClosed_DoesNotSerializeLegacy()
+    {
+        // A direct-argv request cannot be carried by the sandbox protocol yet, so the
+        // runner must fail closed rather than silently serialize the legacy command
+        // fields and run something other than the approved argv.
+        var executor = new FakeSandboxExecutor();
+        var fallback = new FakeCommandRunner { Result = new CommandResult { ExitCode = 0, Stdout = "host" } };
+        var runner = NewRunner(executor, fallback, NewSettings(sandboxEnabled: true));
+
+        var result = await runner.RunAsync(new CommandRequest
+        {
+            Argv = new[] { @"C:\Windows\System32\whoami.exe" },
+            Command = "should-be-ignored",
+        });
+
+        Assert.Equal(-1, result.ExitCode);
+        // Neither the sandbox executor nor the host fallback ran the command.
+        Assert.Null(executor.LastRequest);
+        Assert.Null(fallback.LastRequest);
+    }
+
+    [Fact]
+    public async Task RunAsync_SandboxUnavailable_DirectArgv_FallsBackToHostThatHonorsArgv()
+    {
+        // When the sandbox is unavailable the request routes to the host runner, which
+        // does honor Argv. The fail-closed guard must not interfere with that path.
+        var executor = new FakeSandboxExecutor();
+        var fallback = new FakeCommandRunner { Result = new CommandResult { ExitCode = 0, Stdout = "host" } };
+        var runner = NewRunner(
+            executor, fallback, NewSettings(sandboxEnabled: true), sandboxAvailable: false);
+
+        var argv = new[] { @"C:\Windows\System32\whoami.exe" };
+        var result = await runner.RunAsync(new CommandRequest { Argv = argv });
+
+        Assert.Equal("host", result.Stdout);
+        Assert.NotNull(fallback.LastRequest);
+        Assert.Same(argv, fallback.LastRequest!.Argv);
+        Assert.Null(executor.LastRequest);
+    }
+
     private sealed class FakeSandboxExecutor : ISandboxExecutor
     {
         public string Name => "fake";

--- a/tests/OpenClaw.Shared.Tests/SystemRunTests.cs
+++ b/tests/OpenClaw.Shared.Tests/SystemRunTests.cs
@@ -830,3 +830,129 @@ public class LocalCommandRunnerIntegrationTests
             $"Command took {sw.ElapsedMilliseconds}ms — expected < 3000ms (possible WaitForExitAsync hang regression)");
     }
 }
+
+/// <summary>
+/// Unit tests for LocalCommandRunner.PlanExecution — the direct-argv vs shell-wrapped
+/// decision for the exec-approvals direct-argv path. Always-on: no process is spawned.
+/// </summary>
+public class LocalCommandRunnerPlanTests
+{
+    [Fact]
+    public void DirectArgv_UsesArgv0AsFileName_AndNoShell()
+    {
+        var plan = LocalCommandRunner.PlanExecution(new CommandRequest
+        {
+            Argv = new[] { "C:\\tools\\where.exe", "dotnet" },
+            // These must be ignored when Argv is present.
+            Command = "Get-Process",
+            Shell = "powershell",
+            Args = new[] { "ignored" },
+        });
+
+        Assert.True(plan.IsDirectArgv);
+        Assert.Equal("C:\\tools\\where.exe", plan.FileName);
+        Assert.Equal(new[] { "dotnet" }, plan.ArgList);
+        Assert.Null(plan.Arguments);
+    }
+
+    [Fact]
+    public void DirectArgv_PreservesArgumentsVerbatim_NoTrimNoMangle()
+    {
+        // Arguments are passed through untouched. The nasty cases (whitespace, empty,
+        // quotes, backslashes, shell metacharacters, Unicode) are round-tripped by
+        // ProcessStartInfo.ArgumentList at the OS boundary; here we only assert our
+        // planner does not alter them.
+        var args = new[]
+        {
+            "  leading-and-trailing  ",
+            "",
+            "with \"quotes\"",
+            "trailing\\",
+            "% ! & | ^ > < ( )",
+            "café-ünïcode-日本語",
+        };
+        var argv = new List<string> { "C:\\probe.exe" };
+        argv.AddRange(args);
+
+        var plan = LocalCommandRunner.PlanExecution(new CommandRequest { Argv = argv });
+
+        Assert.True(plan.IsDirectArgv);
+        Assert.Equal("C:\\probe.exe", plan.FileName);
+        Assert.Equal(args, plan.ArgList);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void DirectArgv_RejectsEmptyExecutable(string exe)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            LocalCommandRunner.PlanExecution(new CommandRequest { Argv = new[] { exe } }));
+    }
+
+    [Theory]
+    [InlineData("where.exe")]          // bare name → Windows would guess from PATH
+    [InlineData("tools\\probe.exe")]   // relative path
+    [InlineData("\\probe.exe")]        // rooted but not fully qualified
+    public void DirectArgv_RejectsNonAbsoluteExecutable(string exe)
+    {
+        // argv[0] must be a fully-qualified path so Windows never guesses the
+        // executable (Program.exe hijack).
+        Assert.Throws<ArgumentException>(() =>
+            LocalCommandRunner.PlanExecution(new CommandRequest { Argv = new[] { exe } }));
+    }
+
+    [Theory]
+    [InlineData("C:\\scripts\\deploy.bat")]
+    [InlineData("C:\\scripts\\deploy.cmd")]
+    [InlineData("C:\\scripts\\DEPLOY.BAT")]
+    public void DirectArgv_RejectsBatchScripts(string exe)
+    {
+        // .bat/.cmd need cmd.exe, which re-parses args and breaks the verbatim-argv
+        // guarantee.
+        Assert.Throws<ArgumentException>(() =>
+            LocalCommandRunner.PlanExecution(new CommandRequest { Argv = new[] { exe, "arg" } }));
+    }
+
+    [Fact]
+    public void DirectArgv_SingleElement_HasEmptyArgList()
+    {
+        var plan = LocalCommandRunner.PlanExecution(new CommandRequest
+        {
+            Argv = new[] { "C:\\Windows\\System32\\whoami.exe" },
+        });
+
+        Assert.True(plan.IsDirectArgv);
+        Assert.Empty(plan.ArgList!);
+    }
+
+    [Fact]
+    public void LegacyPath_WhenArgvNull_WrapsInPowerShell()
+    {
+        var plan = LocalCommandRunner.PlanExecution(new CommandRequest
+        {
+            Command = "Write-Output hi",
+            Shell = "powershell",
+        });
+
+        Assert.False(plan.IsDirectArgv);
+        Assert.Null(plan.ArgList);
+        Assert.Equal("powershell.exe", plan.FileName);
+        Assert.Contains("Write-Output hi", plan.Arguments);
+    }
+
+    [Fact]
+    public void DirectArgv_WhenArgvEmptyButNotNull_ThrowsNotFallback()
+    {
+        // A non-null but empty Argv is a malformed approved payload. It must fail
+        // closed, never silently fall back to the shell (ICommandRunner contract:
+        // only null Argv means legacy).
+        Assert.Throws<ArgumentException>(() =>
+            LocalCommandRunner.PlanExecution(new CommandRequest
+            {
+                Argv = System.Array.Empty<string>(),
+                Command = "echo hi",
+                Shell = "cmd",
+            }));
+    }
+}


### PR DESCRIPTION
## Summary

The exec-approvals V2 path could decide to allow a command but had no way to run
it: the allow result carried no payload, and the local runner could only execute
through a shell that re-tokenizes the command. This change makes an approved
command executable exactly as it was evaluated.

- The allow result now carries the approved execution payload: the validated
  argument vector with its executable resolved to an absolute path, the sanitized
  environment, the working directory, and the timeout. argv[0] is the resolved
  path, never the raw command token, so the executable cannot be re-resolved
  against PATH or the working directory at execution time. If the executable
  cannot be resolved, the allow fails closed.
- LocalCommandRunner gains a direct-argv mode: when a request carries an argv,
  the process is launched with ProcessStartInfo.ArgumentList and
  UseShellExecute=false, so the approved arguments reach the process verbatim
  with no shell re-parsing them. The legacy shell-wrapped path is unchanged when
  no argv is supplied.
- When the approved command uses a transparent `env` wrapper (e.g. `["env", "git",
  "status"]`), the payload is built from the effective argv the resolver evaluated,
  not the original request tail, so the approved and executed command identity
  match exactly.

## Safety

The payload builder fails closed before any approval state is written, so a
command that cannot be represented faithfully never leaves an allowlist entry
or usage record behind. It rejects:

- An unresolved executable (no absolute path to pin the command identity to).
- A batch script (.bat/.cmd), which needs cmd.exe and would re-parse the arguments.
- An `env` wrapper carrying modifiers (VAR=val assignments or flags such as `-i`
  or `--unset`), whose environment semantics a direct-argv payload cannot carry,
  including nested forms such as `env env FOO=bar node`, whose modifier the resolver
  would otherwise strip. Transparent `env` wrappers (including nested) are unwrapped safely.

The direct-argv runner enforces the same guards independently:

- An empty argv, a non-absolute executable (which Windows would otherwise guess
  from PATH/cwd), or a batch script are rejected rather than degraded to a shell.
- A non-null but empty argv is treated as invalid, never as a request to fall
  back to the shell.
- Argument values are not written to logs in direct mode; only the executable
  name and the argument count are logged.
- The payload takes defensive copies of argv and env so it cannot be mutated
  between approval and execution.

The sandboxed runner has no argv transport yet, so it fails closed rather than
degrade silently: when sandboxing is available and enabled and a request carries
a direct argv, it is blocked instead of being serialized as the legacy command
fields. When sandboxing is unavailable or disabled, the request routes to the
host runner, which does honor argv.

## Scope

This adds the capability to execute an approved command faithfully. It does not
enable the new path in production: wiring the coordinator behind its feature flag,
and a faithful argv transport for the sandboxed runner, are separate changes. The
new path stays unreachable until those land, and the sandbox fails closed in the
interim.

## Proof

A standalone program approves a command carrying deliberately hostile arguments
(spaces, an empty string, an embedded quote, a trailing backslash, shell
metacharacters, a tab, and Unicode with an emoji), runs it through the real
coordinator and the real runner, and has the launched child process dump the argv
it actually received. Each argument is shown with its character length and its
exact UTF-8 bytes in hex, so a space, a tab, and an empty string are
distinguishable rather than ambiguous on screen. No pass/fail verdict is printed
by the program: the three blocks are compared by reading the bytes.

- APPROVED — what was handed to the coordinator.
- PAYLOAD — what the coordinator emitted (argv[0] resolved to an absolute path,
  arguments unchanged).
- RECEIVED — what the child process got, dumped by the child itself.

APPROVED and RECEIVED match byte for byte; PAYLOAD is the same arguments with the
resolved executable as argv[0].

_Proof output below:_

<img width="1350" height="719" alt="Captura de pantalla 2026-06-21 145455" src="https://github.com/user-attachments/assets/7f0c58ca-dfc9-400b-b52c-edfeabc13c9e" />

## Testing

Local validation after latest changes:

```
./build.ps1 (full solution build) — succeeded, 0 errors, 0 warnings
dotnet test OpenClaw.Shared.Tests  — 2333 passing, 0 failed
dotnet test OpenClaw.Tray.Tests    — 1088 passing, 0 failed
```

Coverage includes: launch-planning decision (direct-argv vs legacy, verbatim
argument preservation, fail-closed guards), payload builder (resolved path becomes
argv[0]; unresolved executable, batch script, and modified env wrapper each produce
no payload), empty-argv guard, sanitized environment in payload, end-to-end
coordinator→runner handoff without shell, regression for transparent env wrapper,
no allowlist persistence when the payload fails closed, and the sandboxed runner
failing closed on a direct-argv request while the host fallback still honors argv.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>