### PR TITLE
Add assistant listen controls to Voice & Audio

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
@@ -16,6 +16,73 @@
                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                        TextWrapping="Wrap" Margin="0,0,0,8"/>
 
+            <!-- Assistant loop -->
+            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1" CornerRadius="8" Padding="16">
+                <StackPanel Spacing="12">
+                    <Grid ColumnSpacing="12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="Assistant" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                            <TextBlock Text="Always-listening assistant service and latest conversation turns."
+                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       TextWrapping="Wrap"/>
+                        </StackPanel>
+                        <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Top">
+                            <Button x:Name="AssistantRefreshButton" Click="OnAssistantRefreshClick" Padding="10,8"
+                                    ToolTipService.ToolTip="Refresh assistant status">
+                                <FontIcon Glyph="&#xE72C;" FontSize="14"/>
+                            </Button>
+                            <Button x:Name="AssistantStartButton" Click="OnAssistantStartClick"
+                                    Style="{StaticResource AccentButtonStyle}">
+                                <StackPanel Orientation="Horizontal" Spacing="6">
+                                    <FontIcon Glyph="&#xE768;" FontSize="14"/>
+                                    <TextBlock Text="Start"/>
+                                </StackPanel>
+                            </Button>
+                            <Button x:Name="AssistantStopButton" Click="OnAssistantStopClick">
+                                <StackPanel Orientation="Horizontal" Spacing="6">
+                                    <FontIcon Glyph="&#xE71A;" FontSize="14"/>
+                                    <TextBlock Text="Stop"/>
+                                </StackPanel>
+                            </Button>
+                        </StackPanel>
+                    </Grid>
+
+                    <Border Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                            CornerRadius="8" Padding="12">
+                        <Grid RowSpacing="4">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock x:Name="AssistantStatusText"
+                                       Text="Checking assistant status..."
+                                       Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                            <TextBlock x:Name="AssistantDetailText" Grid.Row="1"
+                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       TextWrapping="Wrap"/>
+                            <TextBlock x:Name="AssistantLastRefreshText" Grid.Row="2"
+                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       TextWrapping="Wrap"/>
+                        </Grid>
+                    </Border>
+
+                    <StackPanel Spacing="8">
+                        <TextBlock Text="Recent turns" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                        <StackPanel x:Name="AssistantTurnsPanel" Spacing="8"/>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
             <!-- Enable STT -->
             <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
@@ -27,14 +27,16 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <StackPanel Spacing="4">
-                            <TextBlock Text="Assistant" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                            <TextBlock Text="Always-listening assistant service and latest conversation turns."
-                                       Style="{StaticResource CaptionTextBlockStyle}"
-                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                       TextWrapping="Wrap"/>
+                            <TextBlock x:Uid="VoiceSettingsPage_AssistantHeader" Text="Assistant" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                            <TextBlock x:Uid="VoiceSettingsPage_AssistantDescription"
+                                      Text="Always-listening assistant service and latest conversation turns."
+                                      Style="{StaticResource CaptionTextBlockStyle}"
+                                      Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                      TextWrapping="Wrap"/>
                         </StackPanel>
                         <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Top">
-                            <Button x:Name="AssistantRefreshButton" Click="OnAssistantRefreshClick" Padding="10,8"
+                            <Button x:Uid="VoiceSettingsPage_AssistantRefreshButton"
+                                    x:Name="AssistantRefreshButton" Click="OnAssistantRefreshClick" Padding="10,8"
                                     ToolTipService.ToolTip="Refresh assistant status">
                                 <FontIcon Glyph="&#xE72C;" FontSize="14"/>
                             </Button>
@@ -42,13 +44,13 @@
                                     Style="{StaticResource AccentButtonStyle}">
                                 <StackPanel Orientation="Horizontal" Spacing="6">
                                     <FontIcon Glyph="&#xE768;" FontSize="14"/>
-                                    <TextBlock Text="Start"/>
+                                    <TextBlock x:Uid="VoiceSettingsPage_AssistantStartButtonText" Text="Start"/>
                                 </StackPanel>
                             </Button>
                             <Button x:Name="AssistantStopButton" Click="OnAssistantStopClick">
                                 <StackPanel Orientation="Horizontal" Spacing="6">
                                     <FontIcon Glyph="&#xE71A;" FontSize="14"/>
-                                    <TextBlock Text="Stop"/>
+                                    <TextBlock x:Uid="VoiceSettingsPage_AssistantStopButtonText" Text="Stop"/>
                                 </StackPanel>
                             </Button>
                         </StackPanel>
@@ -62,7 +64,8 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <TextBlock x:Name="AssistantStatusText"
+                            <TextBlock x:Uid="VoiceSettingsPage_AssistantStatusChecking"
+                                       x:Name="AssistantStatusText"
                                        Text="Checking assistant status..."
                                        Style="{StaticResource BodyStrongTextBlockStyle}"/>
                             <TextBlock x:Name="AssistantDetailText" Grid.Row="1"
@@ -77,7 +80,7 @@
                     </Border>
 
                     <StackPanel Spacing="8">
-                        <TextBlock Text="Recent turns" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                        <TextBlock x:Uid="VoiceSettingsPage_AssistantRecentTurnsHeader" Text="Recent turns" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                         <StackPanel x:Name="AssistantTurnsPanel" Spacing="8"/>
                     </StackPanel>
                 </StackPanel>

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
@@ -90,7 +90,7 @@ public sealed partial class VoiceSettingsPage : Page
         var bridge = EnsureAssistantBridge();
         SetAssistantBusy(true);
         AssistantStatusText.Text = "Starting assistant...";
-        AssistantDetailText.Text = "Starting always-listening mode with cloud-allowed routing and turn storage.";
+        AssistantDetailText.Text = "Starting always-listening mode with local assistant routing and turn storage.";
         try
         {
             var result = await bridge.StartListenServiceAsync(NewAssistantRequestToken());

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
@@ -19,6 +19,7 @@ public sealed partial class VoiceSettingsPage : Page
     private VoiceService? _voiceService;
     private AssistantBridgeService? _assistantBridgeService;
     private CancellationTokenSource? _assistantRequestCts;
+    private int _assistantOperationVersion;
     private bool _suppressEvents = true; // suppress until Initialize/LoadSettings runs
     // Per-asset CTS so a Piper download doesn't cancel an in-flight Whisper
     // download (and vice versa). Each download type owns its own token.
@@ -88,15 +89,15 @@ public sealed partial class VoiceSettingsPage : Page
     private async Task OnAssistantStartClickAsync()
     {
         var bridge = EnsureAssistantBridge();
-        SetAssistantBusy(true);
-        AssistantStatusText.Text = "Starting assistant...";
-        AssistantDetailText.Text = "Starting always-listening mode with local assistant routing and turn storage.";
+        var busyVersion = BeginAssistantOperation();
+        AssistantStatusText.Text = L("VoiceSettingsPage_AssistantStarting");
+        AssistantDetailText.Text = L("VoiceSettingsPage_AssistantStartingDetail");
         try
         {
             var result = await bridge.StartListenServiceAsync(NewAssistantRequestToken());
             if (!result.Success)
             {
-                AssistantStatusText.Text = "Assistant did not start";
+                AssistantStatusText.Text = L("VoiceSettingsPage_AssistantStartFailed");
                 AssistantDetailText.Text = result.ErrorMessage;
                 return;
             }
@@ -108,7 +109,7 @@ public sealed partial class VoiceSettingsPage : Page
         }
         finally
         {
-            SetAssistantBusy(false);
+            EndAssistantOperation(busyVersion);
         }
     }
 
@@ -121,15 +122,15 @@ public sealed partial class VoiceSettingsPage : Page
     private async Task OnAssistantStopClickAsync()
     {
         var bridge = EnsureAssistantBridge();
-        SetAssistantBusy(true);
-        AssistantStatusText.Text = "Stopping assistant...";
+        var busyVersion = BeginAssistantOperation();
+        AssistantStatusText.Text = L("VoiceSettingsPage_AssistantStopping");
         AssistantDetailText.Text = "";
         try
         {
             var result = await bridge.StopListenServiceAsync(NewAssistantRequestToken());
             if (!result.Success)
             {
-                AssistantStatusText.Text = "Assistant did not stop";
+                AssistantStatusText.Text = L("VoiceSettingsPage_AssistantStopFailed");
                 AssistantDetailText.Text = result.ErrorMessage;
                 return;
             }
@@ -141,14 +142,14 @@ public sealed partial class VoiceSettingsPage : Page
         }
         finally
         {
-            SetAssistantBusy(false);
+            EndAssistantOperation(busyVersion);
         }
     }
 
     private async Task RefreshAssistantAsync()
     {
         var bridge = EnsureAssistantBridge();
-        SetAssistantBusy(true);
+        var busyVersion = BeginAssistantOperation();
         try
         {
             var snapshot = await bridge.GetStatusAsync(NewAssistantRequestToken());
@@ -159,7 +160,7 @@ public sealed partial class VoiceSettingsPage : Page
         }
         finally
         {
-            SetAssistantBusy(false);
+            EndAssistantOperation(busyVersion);
         }
     }
 
@@ -188,17 +189,30 @@ public sealed partial class VoiceSettingsPage : Page
         AssistantStopButton.IsEnabled = !busy;
     }
 
+    private int BeginAssistantOperation()
+    {
+        var version = Interlocked.Increment(ref _assistantOperationVersion);
+        SetAssistantBusy(true);
+        return version;
+    }
+
+    private void EndAssistantOperation(int version)
+    {
+        if (Volatile.Read(ref _assistantOperationVersion) == version)
+            SetAssistantBusy(false);
+    }
+
     private void RenderAssistantSnapshot(AssistantBridgeSnapshot snapshot)
     {
         if (!snapshot.IsAvailable)
         {
-            AssistantStatusText.Text = "Assistant bridge unavailable";
+            AssistantStatusText.Text = L("VoiceSettingsPage_AssistantBridgeUnavailable");
             AssistantDetailText.Text = snapshot.ErrorMessage;
             AssistantLastRefreshText.Text = "";
             AssistantTurnsPanel.Children.Clear();
             AssistantTurnsPanel.Children.Add(new TextBlock
             {
-                Text = "No assistant turns loaded.",
+                Text = L("VoiceSettingsPage_AssistantNoTurnsLoaded"),
                 Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
                 Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
                 TextWrapping = TextWrapping.Wrap
@@ -207,32 +221,33 @@ public sealed partial class VoiceSettingsPage : Page
         }
 
         var listen = snapshot.ListenService;
-        var status = string.IsNullOrWhiteSpace(listen.Status) ? "unknown" : listen.Status;
+        var unknown = L("VoiceSettingsPage_AssistantUnknown");
+        var status = string.IsNullOrWhiteSpace(listen.Status) ? unknown : listen.Status;
         AssistantStatusText.Text = listen.IsRunning
-            ? $"Assistant listening (PID {listen.Pid?.ToString() ?? "unknown"})"
+            ? Lf("VoiceSettingsPage_AssistantListeningFormat", listen.Pid?.ToString(CultureInfo.CurrentCulture) ?? unknown)
             : listen.IsStopped
-                ? "Assistant stopped"
-                : $"Assistant {status}";
+                ? L("VoiceSettingsPage_AssistantStopped")
+                : Lf("VoiceSettingsPage_AssistantStatusFormat", status);
 
         var details = new[]
         {
-            string.IsNullOrWhiteSpace(listen.Transcriber) ? "" : $"Transcriber: {listen.Transcriber}",
-            string.IsNullOrWhiteSpace(snapshot.PreferredInputDevice) ? "" : $"Mic: {snapshot.PreferredInputDevice}",
-            string.IsNullOrWhiteSpace(snapshot.PreferredOutputDevice) ? "" : $"Speaker: {snapshot.PreferredOutputDevice}",
-            listen.AllowCloud ? "Cloud routing: on" : "Cloud routing: off",
-            listen.SpeakAloud ? "Speech output: on" : "Speech output: off"
+            string.IsNullOrWhiteSpace(listen.Transcriber) ? "" : Lf("VoiceSettingsPage_AssistantTranscriberFormat", listen.Transcriber),
+            string.IsNullOrWhiteSpace(snapshot.PreferredInputDevice) ? "" : Lf("VoiceSettingsPage_AssistantMicFormat", snapshot.PreferredInputDevice),
+            string.IsNullOrWhiteSpace(snapshot.PreferredOutputDevice) ? "" : Lf("VoiceSettingsPage_AssistantSpeakerFormat", snapshot.PreferredOutputDevice),
+            Lf("VoiceSettingsPage_AssistantCloudRoutingFormat", listen.AllowCloud ? L("VoiceSettingsPage_AssistantOn") : L("VoiceSettingsPage_AssistantOff")),
+            Lf("VoiceSettingsPage_AssistantSpeechOutputFormat", listen.SpeakAloud ? L("VoiceSettingsPage_AssistantOn") : L("VoiceSettingsPage_AssistantOff"))
         }.Where(s => !string.IsNullOrWhiteSpace(s));
         AssistantDetailText.Text = string.Join(" | ", details);
         AssistantLastRefreshText.Text = string.IsNullOrWhiteSpace(snapshot.GeneratedAt)
             ? ""
-            : $"Last bridge update: {snapshot.GeneratedAt}";
+            : Lf("VoiceSettingsPage_AssistantLastBridgeUpdateFormat", snapshot.GeneratedAt);
 
         AssistantTurnsPanel.Children.Clear();
         if (snapshot.RecentTurns.Count == 0)
         {
             AssistantTurnsPanel.Children.Add(new TextBlock
             {
-                Text = "No conversation turns yet.",
+                Text = L("VoiceSettingsPage_AssistantNoConversationTurns"),
                 Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
                 Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
                 TextWrapping = TextWrapping.Wrap
@@ -247,26 +262,29 @@ public sealed partial class VoiceSettingsPage : Page
     private static Border CreateAssistantTurnView(AssistantTurnSnapshot turn)
     {
         var panel = new StackPanel { Spacing = 6 };
-        var source = string.IsNullOrWhiteSpace(turn.Source) ? "assistant" : turn.Source;
+        var source = string.IsNullOrWhiteSpace(turn.Source) ? L("VoiceSettingsPage_AssistantSourceDefault") : turn.Source;
+        var stage = string.IsNullOrWhiteSpace(turn.Stage) ? L("VoiceSettingsPage_AssistantUnknown") : turn.Stage;
         var model = string.IsNullOrWhiteSpace(turn.Provider)
             ? turn.ModelProfile
             : $"{turn.Provider} {turn.ModelProfile}".Trim();
-        var latency = turn.TotalMs is int ms ? $" | {ms} ms" : "";
+        var metadata = turn.TotalMs is int ms
+            ? Lf("VoiceSettingsPage_AssistantTurnMetadataWithLatencyFormat", source, stage, ms.ToString(CultureInfo.CurrentCulture))
+            : Lf("VoiceSettingsPage_AssistantTurnMetadataFormat", source, stage);
         panel.Children.Add(new TextBlock
         {
-            Text = $"{source} | {turn.Stage}{latency}".Trim(' ', '|'),
+            Text = metadata,
             Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
             Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
             TextWrapping = TextWrapping.Wrap
         });
         panel.Children.Add(new TextBlock
         {
-            Text = $"You: {TrimForDisplay(turn.InputText)}",
+            Text = Lf("VoiceSettingsPage_AssistantUserTurnFormat", TrimForDisplay(turn.InputText)),
             TextWrapping = TextWrapping.Wrap
         });
         panel.Children.Add(new TextBlock
         {
-            Text = $"OpenClaw: {TrimForDisplay(turn.ResponseText)}",
+            Text = Lf("VoiceSettingsPage_AssistantResponseTurnFormat", TrimForDisplay(turn.ResponseText)),
             TextWrapping = TextWrapping.Wrap
         });
         if (!string.IsNullOrWhiteSpace(model))
@@ -292,7 +310,7 @@ public sealed partial class VoiceSettingsPage : Page
     private static string TrimForDisplay(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
-            return "(empty)";
+            return L("VoiceSettingsPage_AssistantEmptyValue");
         value = value.Trim();
         return value.Length <= 220 ? value : value[..217] + "...";
     }

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
@@ -17,6 +17,8 @@ public sealed partial class VoiceSettingsPage : Page
 {
     private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private VoiceService? _voiceService;
+    private AssistantBridgeService? _assistantBridgeService;
+    private CancellationTokenSource? _assistantRequestCts;
     private bool _suppressEvents = true; // suppress until Initialize/LoadSettings runs
     // Per-asset CTS so a Piper download doesn't cancel an in-flight Whisper
     // download (and vice versa). Each download type owns its own token.
@@ -34,9 +36,12 @@ public sealed partial class VoiceSettingsPage : Page
         {
             UpdateModelStatus();
             UpdatePiperVoiceState();
+            _ = RefreshAssistantAsync();
         };
         Unloaded += async (_, _) =>
         {
+            CancelAssistantRequest();
+
             if (App.Current is App app)
                 app.SpeakerMuteChanged -= OnAppSpeakerMuteChanged;
 
@@ -52,6 +57,7 @@ public sealed partial class VoiceSettingsPage : Page
     public void Initialize(VoiceService? voiceService)
     {
         _voiceService = voiceService;
+        _assistantBridgeService ??= new AssistantBridgeService(new AppLogger());
         if (App.Current is App app)
         {
             app.SpeakerMuteChanged -= OnAppSpeakerMuteChanged;
@@ -64,6 +70,231 @@ public sealed partial class VoiceSettingsPage : Page
         PiperPreviewLabel.Text = L("VoiceSettingsPage_PiperPreviewButtonContent");
         PreviewVoiceLabel.Text = L("VoiceSettingsPage_PreviewVoiceButtonContent");
         LoadSettings();
+        _ = RefreshAssistantAsync();
+    }
+
+    private void OnAssistantRefreshClick(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            RefreshAssistantAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnAssistantRefreshClick));
+
+    private void OnAssistantStartClick(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnAssistantStartClickAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnAssistantStartClick));
+
+    private async Task OnAssistantStartClickAsync()
+    {
+        var bridge = EnsureAssistantBridge();
+        SetAssistantBusy(true);
+        AssistantStatusText.Text = "Starting assistant...";
+        AssistantDetailText.Text = "Starting always-listening mode with cloud-allowed routing and turn storage.";
+        try
+        {
+            var result = await bridge.StartListenServiceAsync(NewAssistantRequestToken());
+            if (!result.Success)
+            {
+                AssistantStatusText.Text = "Assistant did not start";
+                AssistantDetailText.Text = result.ErrorMessage;
+                return;
+            }
+
+            await RefreshAssistantAsync();
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        finally
+        {
+            SetAssistantBusy(false);
+        }
+    }
+
+    private void OnAssistantStopClick(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            OnAssistantStopClickAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnAssistantStopClick));
+
+    private async Task OnAssistantStopClickAsync()
+    {
+        var bridge = EnsureAssistantBridge();
+        SetAssistantBusy(true);
+        AssistantStatusText.Text = "Stopping assistant...";
+        AssistantDetailText.Text = "";
+        try
+        {
+            var result = await bridge.StopListenServiceAsync(NewAssistantRequestToken());
+            if (!result.Success)
+            {
+                AssistantStatusText.Text = "Assistant did not stop";
+                AssistantDetailText.Text = result.ErrorMessage;
+                return;
+            }
+
+            await RefreshAssistantAsync();
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        finally
+        {
+            SetAssistantBusy(false);
+        }
+    }
+
+    private async Task RefreshAssistantAsync()
+    {
+        var bridge = EnsureAssistantBridge();
+        SetAssistantBusy(true);
+        try
+        {
+            var snapshot = await bridge.GetStatusAsync(NewAssistantRequestToken());
+            RenderAssistantSnapshot(snapshot);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        finally
+        {
+            SetAssistantBusy(false);
+        }
+    }
+
+    private AssistantBridgeService EnsureAssistantBridge() =>
+        _assistantBridgeService ??= new AssistantBridgeService(new AppLogger());
+
+    private CancellationToken NewAssistantRequestToken()
+    {
+        CancelAssistantRequest();
+        _assistantRequestCts = new CancellationTokenSource();
+        return _assistantRequestCts.Token;
+    }
+
+    private void CancelAssistantRequest()
+    {
+        try { _assistantRequestCts?.Cancel(); }
+        catch (Exception ex) { Logger.Debug($"VoiceSettingsPage: assistant request cancel failed: {ex.Message}"); }
+        _assistantRequestCts?.Dispose();
+        _assistantRequestCts = null;
+    }
+
+    private void SetAssistantBusy(bool busy)
+    {
+        AssistantRefreshButton.IsEnabled = !busy;
+        AssistantStartButton.IsEnabled = !busy;
+        AssistantStopButton.IsEnabled = !busy;
+    }
+
+    private void RenderAssistantSnapshot(AssistantBridgeSnapshot snapshot)
+    {
+        if (!snapshot.IsAvailable)
+        {
+            AssistantStatusText.Text = "Assistant bridge unavailable";
+            AssistantDetailText.Text = snapshot.ErrorMessage;
+            AssistantLastRefreshText.Text = "";
+            AssistantTurnsPanel.Children.Clear();
+            AssistantTurnsPanel.Children.Add(new TextBlock
+            {
+                Text = "No assistant turns loaded.",
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+                TextWrapping = TextWrapping.Wrap
+            });
+            return;
+        }
+
+        var listen = snapshot.ListenService;
+        var status = string.IsNullOrWhiteSpace(listen.Status) ? "unknown" : listen.Status;
+        AssistantStatusText.Text = listen.IsRunning
+            ? $"Assistant listening (PID {listen.Pid?.ToString() ?? "unknown"})"
+            : listen.IsStopped
+                ? "Assistant stopped"
+                : $"Assistant {status}";
+
+        var details = new[]
+        {
+            string.IsNullOrWhiteSpace(listen.Transcriber) ? "" : $"Transcriber: {listen.Transcriber}",
+            string.IsNullOrWhiteSpace(snapshot.PreferredInputDevice) ? "" : $"Mic: {snapshot.PreferredInputDevice}",
+            string.IsNullOrWhiteSpace(snapshot.PreferredOutputDevice) ? "" : $"Speaker: {snapshot.PreferredOutputDevice}",
+            listen.AllowCloud ? "Cloud routing: on" : "Cloud routing: off",
+            listen.SpeakAloud ? "Speech output: on" : "Speech output: off"
+        }.Where(s => !string.IsNullOrWhiteSpace(s));
+        AssistantDetailText.Text = string.Join(" | ", details);
+        AssistantLastRefreshText.Text = string.IsNullOrWhiteSpace(snapshot.GeneratedAt)
+            ? ""
+            : $"Last bridge update: {snapshot.GeneratedAt}";
+
+        AssistantTurnsPanel.Children.Clear();
+        if (snapshot.RecentTurns.Count == 0)
+        {
+            AssistantTurnsPanel.Children.Add(new TextBlock
+            {
+                Text = "No conversation turns yet.",
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+                TextWrapping = TextWrapping.Wrap
+            });
+            return;
+        }
+
+        foreach (var turn in snapshot.RecentTurns.Take(5))
+            AssistantTurnsPanel.Children.Add(CreateAssistantTurnView(turn));
+    }
+
+    private static Border CreateAssistantTurnView(AssistantTurnSnapshot turn)
+    {
+        var panel = new StackPanel { Spacing = 6 };
+        var source = string.IsNullOrWhiteSpace(turn.Source) ? "assistant" : turn.Source;
+        var model = string.IsNullOrWhiteSpace(turn.Provider)
+            ? turn.ModelProfile
+            : $"{turn.Provider} {turn.ModelProfile}".Trim();
+        var latency = turn.TotalMs is int ms ? $" | {ms} ms" : "";
+        panel.Children.Add(new TextBlock
+        {
+            Text = $"{source} | {turn.Stage}{latency}".Trim(' ', '|'),
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+            TextWrapping = TextWrapping.Wrap
+        });
+        panel.Children.Add(new TextBlock
+        {
+            Text = $"You: {TrimForDisplay(turn.InputText)}",
+            TextWrapping = TextWrapping.Wrap
+        });
+        panel.Children.Add(new TextBlock
+        {
+            Text = $"OpenClaw: {TrimForDisplay(turn.ResponseText)}",
+            TextWrapping = TextWrapping.Wrap
+        });
+        if (!string.IsNullOrWhiteSpace(model))
+        {
+            panel.Children.Add(new TextBlock
+            {
+                Text = model,
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+                TextWrapping = TextWrapping.Wrap
+            });
+        }
+
+        return new Border
+        {
+            Child = panel,
+            Background = (Brush)Application.Current.Resources["CardBackgroundFillColorSecondaryBrush"],
+            CornerRadius = new CornerRadius(8),
+            Padding = new Thickness(12)
+        };
+    }
+
+    private static string TrimForDisplay(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return "(empty)";
+        value = value.Trim();
+        return value.Length <= 220 ? value : value[..217] + "...";
     }
 
     private void OnAppSpeakerMuteChanged(bool muted)

--- a/src/OpenClaw.Tray.WinUI/Services/AssistantBridgeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AssistantBridgeService.cs
@@ -1,6 +1,7 @@
 using OpenClaw.Shared;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
@@ -16,6 +17,7 @@ internal sealed class AssistantBridgeService
     private readonly IOpenClawLogger _logger;
     private readonly string _userId;
     private readonly Func<OpenClawCliLauncher?> _launcherResolver;
+    private readonly TimeSpan _timeout;
 
     public AssistantBridgeService(IOpenClawLogger logger, string userId = "owner")
         : this(logger, userId, ResolveOpenClawCli)
@@ -25,11 +27,13 @@ internal sealed class AssistantBridgeService
     internal AssistantBridgeService(
         IOpenClawLogger logger,
         string userId,
-        Func<OpenClawCliLauncher?> launcherResolver)
+        Func<OpenClawCliLauncher?> launcherResolver,
+        TimeSpan? commandTimeout = null)
     {
         _logger = logger;
         _userId = string.IsNullOrWhiteSpace(userId) ? "owner" : userId;
         _launcherResolver = launcherResolver;
+        _timeout = commandTimeout ?? DefaultTimeout;
     }
 
     public async Task<AssistantBridgeSnapshot> GetStatusAsync(CancellationToken cancellationToken = default)
@@ -51,7 +55,7 @@ internal sealed class AssistantBridgeService
 
     public Task<AssistantCommandResult> StartListenServiceAsync(CancellationToken cancellationToken = default) =>
         RunCommandAsync(
-            ["assistant", "listen-service", "start", "--user", _userId, "--allow-cloud", "--store-turn", "--json"],
+            ["assistant", "listen-service", "start", "--user", _userId, "--store-turn", "--json"],
             cancellationToken);
 
     public Task<AssistantCommandResult> StopListenServiceAsync(CancellationToken cancellationToken = default) =>
@@ -90,21 +94,38 @@ internal sealed class AssistantBridgeService
         foreach (var arg in args)
             psi.ArgumentList.Add(arg);
 
-        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeoutCts.CancelAfter(DefaultTimeout);
-
         try
         {
-            using var process = Process.Start(psi);
-            if (process == null)
+            using var process = new Process { StartInfo = psi };
+            if (!process.Start())
                 return AssistantProcessResult.Failed("Could not start the OpenClaw backend command.");
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(_timeout);
 
             var stdoutTask = process.StandardOutput.ReadToEndAsync(timeoutCts.Token);
             var stderrTask = process.StandardError.ReadToEndAsync(timeoutCts.Token);
-            await process.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
+            var timedOut = false;
+            try
+            {
+                await process.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                timedOut = true;
+                TryKillProcessTree(process);
+            }
+            catch (OperationCanceledException)
+            {
+                TryKillProcessTree(process);
+                throw;
+            }
 
-            var stdout = await stdoutTask.ConfigureAwait(false);
-            var stderr = await stderrTask.ConfigureAwait(false);
+            var stdout = await ReadProcessStreamAsync(stdoutTask).ConfigureAwait(false);
+            var stderr = await ReadProcessStreamAsync(stderrTask).ConfigureAwait(false);
+            if (timedOut)
+                return AssistantProcessResult.Failed("OpenClaw backend command timed out.");
+
             if (process.ExitCode != 0)
             {
                 var detail = string.IsNullOrWhiteSpace(stderr) ? "OpenClaw backend command failed." : stderr.Trim();
@@ -113,14 +134,51 @@ internal sealed class AssistantBridgeService
 
             return new AssistantProcessResult(true, stdout, "");
         }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
-            return AssistantProcessResult.Failed("OpenClaw backend command timed out.");
+            throw;
         }
         catch (Exception ex)
         {
             _logger.Warn($"Assistant bridge command failed to start: {ex.Message}");
             return AssistantProcessResult.Failed("OpenClaw backend command could not be started.");
+        }
+    }
+
+    private static async Task<string> ReadProcessStreamAsync(Task<string> streamTask)
+    {
+        try
+        {
+            return await streamTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return "";
+        }
+        catch (IOException)
+        {
+            return "";
+        }
+        catch (ObjectDisposedException)
+        {
+            return "";
+        }
+    }
+
+    private static void TryKillProcessTree(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch (InvalidOperationException)
+        {
+        }
+        catch (Win32Exception)
+        {
+        }
+        catch (NotSupportedException)
+        {
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Services/AssistantBridgeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AssistantBridgeService.cs
@@ -1,0 +1,306 @@
+using OpenClaw.Shared;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenClawTray.Services;
+
+internal sealed class AssistantBridgeService
+{
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(20);
+    private readonly IOpenClawLogger _logger;
+    private readonly string _userId;
+    private readonly Func<OpenClawCliLauncher?> _launcherResolver;
+
+    public AssistantBridgeService(IOpenClawLogger logger, string userId = "owner")
+        : this(logger, userId, ResolveOpenClawCli)
+    {
+    }
+
+    internal AssistantBridgeService(
+        IOpenClawLogger logger,
+        string userId,
+        Func<OpenClawCliLauncher?> launcherResolver)
+    {
+        _logger = logger;
+        _userId = string.IsNullOrWhiteSpace(userId) ? "owner" : userId;
+        _launcherResolver = launcherResolver;
+    }
+
+    public async Task<AssistantBridgeSnapshot> GetStatusAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await RunOpenClawAsync(["dashboard", "bridge", "status", "--user", _userId, "--json"], cancellationToken);
+        if (!result.Success)
+            return AssistantBridgeSnapshot.Unavailable(result.ErrorMessage);
+
+        try
+        {
+            return ParseStatus(result.Stdout);
+        }
+        catch (JsonException ex)
+        {
+            _logger.Warn($"Assistant bridge status JSON could not be parsed: {ex.Message}");
+            return AssistantBridgeSnapshot.Unavailable("OpenClaw returned status JSON the Companion could not read.");
+        }
+    }
+
+    public Task<AssistantCommandResult> StartListenServiceAsync(CancellationToken cancellationToken = default) =>
+        RunCommandAsync(
+            ["assistant", "listen-service", "start", "--user", _userId, "--allow-cloud", "--store-turn", "--json"],
+            cancellationToken);
+
+    public Task<AssistantCommandResult> StopListenServiceAsync(CancellationToken cancellationToken = default) =>
+        RunCommandAsync(
+            ["assistant", "listen-service", "stop", "--user", _userId, "--json"],
+            cancellationToken);
+
+    private async Task<AssistantCommandResult> RunCommandAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
+    {
+        var result = await RunOpenClawAsync(args, cancellationToken);
+        return new AssistantCommandResult(result.Success, result.ErrorMessage);
+    }
+
+    private async Task<AssistantProcessResult> RunOpenClawAsync(
+        IReadOnlyList<string> args,
+        CancellationToken cancellationToken)
+    {
+        var launcher = _launcherResolver();
+        if (launcher == null)
+            return AssistantProcessResult.Failed("OpenClaw backend checkout was not found. Set OPENCLAW_BACKEND_ROOT or keep it at D:\\Projects\\OpenClaw.");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = launcher.ExecutablePath,
+            WorkingDirectory = launcher.WorkingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8
+        };
+
+        foreach (var arg in launcher.PrefixArgs)
+            psi.ArgumentList.Add(arg);
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(DefaultTimeout);
+
+        try
+        {
+            using var process = Process.Start(psi);
+            if (process == null)
+                return AssistantProcessResult.Failed("Could not start the OpenClaw backend command.");
+
+            var stdoutTask = process.StandardOutput.ReadToEndAsync(timeoutCts.Token);
+            var stderrTask = process.StandardError.ReadToEndAsync(timeoutCts.Token);
+            await process.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
+
+            var stdout = await stdoutTask.ConfigureAwait(false);
+            var stderr = await stderrTask.ConfigureAwait(false);
+            if (process.ExitCode != 0)
+            {
+                var detail = string.IsNullOrWhiteSpace(stderr) ? "OpenClaw backend command failed." : stderr.Trim();
+                return AssistantProcessResult.Failed(detail);
+            }
+
+            return new AssistantProcessResult(true, stdout, "");
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return AssistantProcessResult.Failed("OpenClaw backend command timed out.");
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"Assistant bridge command failed to start: {ex.Message}");
+            return AssistantProcessResult.Failed("OpenClaw backend command could not be started.");
+        }
+    }
+
+    internal static AssistantBridgeSnapshot ParseStatus(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        var generatedAt = ReadString(root, "generated_at");
+        var assistant = ReadObject(root, "assistant");
+        var voice = ReadObject(root, "voice");
+
+        var listen = AssistantListenServiceSnapshot.Empty;
+        if (assistant.HasValue && assistant.Value.TryGetProperty("listen_service", out var listenElement))
+        {
+            listen = new AssistantListenServiceSnapshot(
+                ReadString(listenElement, "status"),
+                ReadBool(listenElement, "configured"),
+                ReadNullableInt(listenElement, "pid"),
+                ReadBool(listenElement, "stop_requested"),
+                ReadBool(listenElement, "allow_cloud"),
+                ReadBool(listenElement, "speak_aloud"),
+                ReadString(listenElement, "transcriber"),
+                ReadString(listenElement, "input_mode"),
+                ReadString(listenElement, "log_file"));
+        }
+
+        var turns = new List<AssistantTurnSnapshot>();
+        if (assistant.HasValue && assistant.Value.TryGetProperty("recent_turns", out var recentTurns) &&
+            recentTurns.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var turn in recentTurns.EnumerateArray())
+            {
+                turns.Add(new AssistantTurnSnapshot(
+                    ReadString(turn, "created_at"),
+                    ReadString(turn, "source"),
+                    ReadString(turn, "input_text"),
+                    ReadString(turn, "display_response_text"),
+                    ReadString(turn, "provider"),
+                    ReadString(turn, "model_profile"),
+                    ReadString(turn, "stage"),
+                    ReadNullableInt(turn, "total_ms")));
+            }
+        }
+
+        return new AssistantBridgeSnapshot(
+            true,
+            "",
+            generatedAt,
+            ReadString(root, "user_id"),
+            ReadString(voice, "preferred_input_device"),
+            ReadString(voice, "preferred_output_device"),
+            listen,
+            turns);
+    }
+
+    internal static OpenClawCliLauncher? ResolveOpenClawCli()
+    {
+        foreach (var root in CandidateBackendRoots())
+        {
+            var normalizedRoot = Environment.ExpandEnvironmentVariables(root);
+            if (string.IsNullOrWhiteSpace(normalizedRoot))
+                continue;
+
+            var openclawExe = Path.Combine(normalizedRoot, ".venv", "Scripts", "openclaw.exe");
+            if (File.Exists(openclawExe))
+                return new OpenClawCliLauncher(openclawExe, normalizedRoot, []);
+
+            var pythonExe = Path.Combine(normalizedRoot, ".venv", "Scripts", "python.exe");
+            if (File.Exists(pythonExe))
+                return new OpenClawCliLauncher(pythonExe, normalizedRoot, ["-m", "openclaw.cli"]);
+        }
+
+        return null;
+    }
+
+    internal static IReadOnlyList<string> CandidateBackendRoots()
+    {
+        var candidates = new List<string>();
+        var overrideRoot = Environment.GetEnvironmentVariable("OPENCLAW_BACKEND_ROOT");
+        if (!string.IsNullOrWhiteSpace(overrideRoot))
+            candidates.Add(overrideRoot);
+
+        candidates.Add(@"D:\Projects\OpenClaw");
+        candidates.Add(Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            "Projects",
+            "OpenClaw"));
+        candidates.Add(Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            "source",
+            "repos",
+            "OpenClaw"));
+
+        return candidates;
+    }
+
+    private static JsonElement? ReadObject(JsonElement? parent, string name)
+    {
+        if (parent is not { } element || element.ValueKind != JsonValueKind.Object)
+            return null;
+        return element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.Object
+            ? value
+            : null;
+    }
+
+    private static string ReadString(JsonElement? parent, string name)
+    {
+        if (parent is not { } element || element.ValueKind != JsonValueKind.Object)
+            return "";
+        return element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString() ?? ""
+            : "";
+    }
+
+    private static bool ReadBool(JsonElement parent, string name) =>
+        parent.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.True;
+
+    private static int? ReadNullableInt(JsonElement parent, string name)
+    {
+        if (!parent.TryGetProperty(name, out var value))
+            return null;
+        return value.ValueKind == JsonValueKind.Number && value.TryGetInt32(out var parsed)
+            ? parsed
+            : null;
+    }
+
+    private sealed record AssistantProcessResult(bool Success, string Stdout, string ErrorMessage)
+    {
+        public static AssistantProcessResult Failed(string errorMessage) => new(false, "", errorMessage);
+    }
+}
+
+internal sealed record OpenClawCliLauncher(
+    string ExecutablePath,
+    string WorkingDirectory,
+    IReadOnlyList<string> PrefixArgs);
+
+internal sealed record AssistantCommandResult(bool Success, string ErrorMessage);
+
+internal sealed record AssistantBridgeSnapshot(
+    bool IsAvailable,
+    string ErrorMessage,
+    string GeneratedAt,
+    string UserId,
+    string PreferredInputDevice,
+    string PreferredOutputDevice,
+    AssistantListenServiceSnapshot ListenService,
+    IReadOnlyList<AssistantTurnSnapshot> RecentTurns)
+{
+    public static AssistantBridgeSnapshot Unavailable(string errorMessage) =>
+        new(false, errorMessage, "", "", "", "", AssistantListenServiceSnapshot.Empty, []);
+}
+
+internal sealed record AssistantListenServiceSnapshot(
+    string Status,
+    bool Configured,
+    int? Pid,
+    bool StopRequested,
+    bool AllowCloud,
+    bool SpeakAloud,
+    string Transcriber,
+    string InputMode,
+    string LogFile)
+{
+    public static AssistantListenServiceSnapshot Empty { get; } =
+        new("", false, null, false, false, false, "", "", "");
+
+    public bool IsRunning => string.Equals(Status, "running", StringComparison.OrdinalIgnoreCase);
+
+    public bool IsStopped =>
+        string.Equals(Status, "stopped", StringComparison.OrdinalIgnoreCase) ||
+        (StopRequested && string.Equals(Status, "stop-requested", StringComparison.OrdinalIgnoreCase));
+}
+
+internal sealed record AssistantTurnSnapshot(
+    string CreatedAt,
+    string Source,
+    string InputText,
+    string ResponseText,
+    string Provider,
+    string ModelProfile,
+    string Stage,
+    int? TotalMs);

--- a/src/OpenClaw.Tray.WinUI/Services/AssistantBridgeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AssistantBridgeService.cs
@@ -16,7 +16,7 @@ internal sealed class AssistantBridgeService
     private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(20);
     private readonly IOpenClawLogger _logger;
     private readonly string _userId;
-    private readonly Func<OpenClawCliLauncher?> _launcherResolver;
+    private readonly OpenClawCliLauncher? _launcher;
     private readonly TimeSpan _timeout;
 
     public AssistantBridgeService(IOpenClawLogger logger, string userId = "owner")
@@ -32,8 +32,25 @@ internal sealed class AssistantBridgeService
     {
         _logger = logger;
         _userId = string.IsNullOrWhiteSpace(userId) ? "owner" : userId;
-        _launcherResolver = launcherResolver;
+        _launcher = launcherResolver();
         _timeout = commandTimeout ?? DefaultTimeout;
+
+        var overrideRoot = Environment.GetEnvironmentVariable("OPENCLAW_BACKEND_ROOT");
+        if (!string.IsNullOrWhiteSpace(overrideRoot))
+        {
+            if (TryNormalizeBackendRoot(overrideRoot, out var normalizedOverrideRoot))
+            {
+                if (_launcher != null &&
+                    string.Equals(_launcher.WorkingDirectory, normalizedOverrideRoot, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.Info($"Assistant bridge using OPENCLAW_BACKEND_ROOT launcher at '{_launcher.WorkingDirectory}'.");
+                }
+            }
+            else
+            {
+                _logger.Warn("Assistant bridge ignored OPENCLAW_BACKEND_ROOT because it is not a fully qualified local checkout under a trusted parent.");
+            }
+        }
     }
 
     public async Task<AssistantBridgeSnapshot> GetStatusAsync(CancellationToken cancellationToken = default)
@@ -73,9 +90,9 @@ internal sealed class AssistantBridgeService
         IReadOnlyList<string> args,
         CancellationToken cancellationToken)
     {
-        var launcher = _launcherResolver();
+        var launcher = _launcher;
         if (launcher == null)
-            return AssistantProcessResult.Failed("OpenClaw backend checkout was not found. Set OPENCLAW_BACKEND_ROOT or keep it at D:\\Projects\\OpenClaw.");
+            return AssistantProcessResult.Failed(BuildBackendNotFoundMessage());
 
         var psi = new ProcessStartInfo
         {
@@ -238,8 +255,7 @@ internal sealed class AssistantBridgeService
     {
         foreach (var root in CandidateBackendRoots())
         {
-            var normalizedRoot = Environment.ExpandEnvironmentVariables(root);
-            if (string.IsNullOrWhiteSpace(normalizedRoot))
+            if (!TryNormalizeBackendRoot(root, out var normalizedRoot))
                 continue;
 
             var openclawExe = Path.Combine(normalizedRoot, ".venv", "Scripts", "openclaw.exe");
@@ -252,6 +268,18 @@ internal sealed class AssistantBridgeService
         }
 
         return null;
+    }
+
+    internal static string BuildBackendNotFoundMessage()
+    {
+        var searchedRoots = CandidateBackendRoots()
+            .Select(root => TryNormalizeBackendRoot(root, out var normalizedRoot) ? normalizedRoot : root)
+            .Where(root => !string.IsNullOrWhiteSpace(root))
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+
+        return "OpenClaw backend checkout was not found. Set OPENCLAW_BACKEND_ROOT to a fully qualified local checkout under D:\\Projects, %USERPROFILE%\\Projects, or %USERPROFILE%\\source\\repos. Searched: " +
+            string.Join("; ", searchedRoots) +
+            ".";
     }
 
     internal static IReadOnlyList<string> CandidateBackendRoots()
@@ -273,6 +301,63 @@ internal sealed class AssistantBridgeService
             "OpenClaw"));
 
         return candidates;
+    }
+
+    internal static bool TryNormalizeBackendRoot(string root, out string normalizedRoot)
+    {
+        normalizedRoot = "";
+        if (string.IsNullOrWhiteSpace(root))
+            return false;
+
+        var expandedRoot = Environment.ExpandEnvironmentVariables(root.Trim());
+        if (string.IsNullOrWhiteSpace(expandedRoot) || !Path.IsPathFullyQualified(expandedRoot))
+            return false;
+
+        try
+        {
+            normalizedRoot = Path.GetFullPath(expandedRoot);
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+        catch (PathTooLongException)
+        {
+            return false;
+        }
+
+        if (normalizedRoot.StartsWith(@"\\", StringComparison.Ordinal))
+            return false;
+
+        var candidateRoot = normalizedRoot;
+        return TrustedBackendParentRoots()
+            .Any(parent => IsSameOrUnderPath(candidateRoot, parent));
+    }
+
+    private static IEnumerable<string> TrustedBackendParentRoots()
+    {
+        yield return @"D:\Projects";
+
+        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(userProfile))
+            yield break;
+
+        yield return Path.Combine(userProfile, "Projects");
+        yield return Path.Combine(userProfile, "source", "repos");
+    }
+
+    private static bool IsSameOrUnderPath(string path, string parent)
+    {
+        var normalizedParent = Path.GetFullPath(parent)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var normalizedPath = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        return string.Equals(normalizedPath, normalizedParent, StringComparison.OrdinalIgnoreCase) ||
+            normalizedPath.StartsWith(normalizedParent + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
     }
 
     private static JsonElement? ReadObject(JsonElement? parent, string name)

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2637,6 +2637,105 @@ On your gateway host (Mac/Linux), run:
   <data name="VoiceSettingsPage_PageDescription.Text" xml:space="preserve">
     <value>Configure speech-to-text and voice interaction settings. All speech processing runs locally on your device.</value>
   </data>
+  <data name="VoiceSettingsPage_AssistantHeader.Text" xml:space="preserve">
+    <value>Assistant</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantDescription.Text" xml:space="preserve">
+    <value>Always-listening assistant service and latest conversation turns.</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantRefreshButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Refresh assistant status</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartButtonText.Text" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopButtonText.Text" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStatusChecking.Text" xml:space="preserve">
+    <value>Checking assistant status...</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantRecentTurnsHeader.Text" xml:space="preserve">
+    <value>Recent turns</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStarting" xml:space="preserve">
+    <value>Starting assistant...</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartingDetail" xml:space="preserve">
+    <value>Starting always-listening mode with local assistant routing and turn storage.</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartFailed" xml:space="preserve">
+    <value>Assistant did not start</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopping" xml:space="preserve">
+    <value>Stopping assistant...</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopFailed" xml:space="preserve">
+    <value>Assistant did not stop</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantBridgeUnavailable" xml:space="preserve">
+    <value>Assistant bridge unavailable</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantNoTurnsLoaded" xml:space="preserve">
+    <value>No assistant turns loaded.</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantUnknown" xml:space="preserve">
+    <value>unknown</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantListeningFormat" xml:space="preserve">
+    <value>Assistant listening (PID {0})</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopped" xml:space="preserve">
+    <value>Assistant stopped</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStatusFormat" xml:space="preserve">
+    <value>Assistant {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantTranscriberFormat" xml:space="preserve">
+    <value>Transcriber: {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantMicFormat" xml:space="preserve">
+    <value>Mic: {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantSpeakerFormat" xml:space="preserve">
+    <value>Speaker: {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantCloudRoutingFormat" xml:space="preserve">
+    <value>Cloud routing: {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantSpeechOutputFormat" xml:space="preserve">
+    <value>Speech output: {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantOn" xml:space="preserve">
+    <value>on</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantOff" xml:space="preserve">
+    <value>off</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantLastBridgeUpdateFormat" xml:space="preserve">
+    <value>Last bridge update: {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantNoConversationTurns" xml:space="preserve">
+    <value>No conversation turns yet.</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantSourceDefault" xml:space="preserve">
+    <value>assistant</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantTurnMetadataFormat" xml:space="preserve">
+    <value>{0} | {1}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantTurnMetadataWithLatencyFormat" xml:space="preserve">
+    <value>{0} | {1} | {2} ms</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantUserTurnFormat" xml:space="preserve">
+    <value>You: {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantResponseTurnFormat" xml:space="preserve">
+    <value>OpenClaw: {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantEmptyValue" xml:space="preserve">
+    <value>(empty)</value>
+  </data>
   <data name="VoiceSettingsPage_SttHeader.Text" xml:space="preserve">
     <value>Speech-to-Text</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2589,6 +2589,105 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="VoiceSettingsPage_PageDescription.Text" xml:space="preserve">
     <value>Configurez la reconnaissance vocale et les paramètres d'interaction vocale. Tout le traitement vocal s'exécute localement sur votre appareil.</value>
   </data>
+  <data name="VoiceSettingsPage_AssistantHeader.Text" xml:space="preserve">
+    <value>Assistant vocal</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantDescription.Text" xml:space="preserve">
+    <value>Service d'assistant toujours à l'écoute et derniers tours de conversation.</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantRefreshButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Actualiser l'état de l'assistant</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartButtonText.Text" xml:space="preserve">
+    <value>Démarrer</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopButtonText.Text" xml:space="preserve">
+    <value>Arrêter</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStatusChecking.Text" xml:space="preserve">
+    <value>Vérification de l'état de l'assistant...</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantRecentTurnsHeader.Text" xml:space="preserve">
+    <value>Tours récents</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStarting" xml:space="preserve">
+    <value>Démarrage de l'assistant...</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartingDetail" xml:space="preserve">
+    <value>Démarrage du mode toujours à l'écoute avec routage local de l'assistant et stockage des tours.</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartFailed" xml:space="preserve">
+    <value>L'assistant n'a pas démarré</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopping" xml:space="preserve">
+    <value>Arrêt de l'assistant...</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopFailed" xml:space="preserve">
+    <value>L'assistant ne s'est pas arrêté</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantBridgeUnavailable" xml:space="preserve">
+    <value>Pont assistant indisponible</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantNoTurnsLoaded" xml:space="preserve">
+    <value>Aucun tour d'assistant chargé.</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantUnknown" xml:space="preserve">
+    <value>inconnu</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantListeningFormat" xml:space="preserve">
+    <value>Assistant à l'écoute (PID {0})</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopped" xml:space="preserve">
+    <value>Assistant arrêté</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStatusFormat" xml:space="preserve">
+    <value>État de l'assistant : {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantTranscriberFormat" xml:space="preserve">
+    <value>Transcripteur : {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantMicFormat" xml:space="preserve">
+    <value>Micro : {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantSpeakerFormat" xml:space="preserve">
+    <value>Haut-parleur : {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantCloudRoutingFormat" xml:space="preserve">
+    <value>Routage cloud : {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantSpeechOutputFormat" xml:space="preserve">
+    <value>Sortie vocale : {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantOn" xml:space="preserve">
+    <value>activé</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantOff" xml:space="preserve">
+    <value>désactivé</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantLastBridgeUpdateFormat" xml:space="preserve">
+    <value>Dernière mise à jour du pont : {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantNoConversationTurns" xml:space="preserve">
+    <value>Aucun tour de conversation pour le moment.</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantSourceDefault" xml:space="preserve">
+    <value>l'assistant</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantTurnMetadataFormat" xml:space="preserve">
+    <value>{0} / {1}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantTurnMetadataWithLatencyFormat" xml:space="preserve">
+    <value>{0} | {1} | {2} ms de latence</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantUserTurnFormat" xml:space="preserve">
+    <value>Vous : {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantResponseTurnFormat" xml:space="preserve">
+    <value>OpenClaw : {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantEmptyValue" xml:space="preserve">
+    <value>(vide)</value>
+  </data>
   <data name="VoiceSettingsPage_SttHeader.Text" xml:space="preserve">
     <value>Reconnaissance vocale</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2590,6 +2590,105 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="VoiceSettingsPage_PageDescription.Text" xml:space="preserve">
     <value>Configureer spraak-naar-tekst en spraakinteractie-instellingen. Alle spraakverwerking draait lokaal op uw apparaat.</value>
   </data>
+  <data name="VoiceSettingsPage_AssistantHeader.Text" xml:space="preserve">
+    <value>Assistent</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantDescription.Text" xml:space="preserve">
+    <value>Altijd luisterende assistentservice en nieuwste gespreksbeurten.</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantRefreshButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Assistentstatus vernieuwen</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartButtonText.Text" xml:space="preserve">
+    <value>Starten</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopButtonText.Text" xml:space="preserve">
+    <value>Stoppen</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStatusChecking.Text" xml:space="preserve">
+    <value>Assistentstatus controleren...</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantRecentTurnsHeader.Text" xml:space="preserve">
+    <value>Recente beurten</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStarting" xml:space="preserve">
+    <value>Assistent starten...</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartingDetail" xml:space="preserve">
+    <value>Altijd-luisterende modus starten met lokale assistentroutering en opslag van beurten.</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartFailed" xml:space="preserve">
+    <value>Assistent is niet gestart</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopping" xml:space="preserve">
+    <value>Assistent stoppen...</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopFailed" xml:space="preserve">
+    <value>Assistent is niet gestopt</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantBridgeUnavailable" xml:space="preserve">
+    <value>Assistentbrug niet beschikbaar</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantNoTurnsLoaded" xml:space="preserve">
+    <value>Geen assistentbeurten geladen.</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantUnknown" xml:space="preserve">
+    <value>onbekend</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantListeningFormat" xml:space="preserve">
+    <value>Assistent luistert (PID {0})</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopped" xml:space="preserve">
+    <value>Assistent gestopt</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStatusFormat" xml:space="preserve">
+    <value>Assistent {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantTranscriberFormat" xml:space="preserve">
+    <value>Transcriptie: {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantMicFormat" xml:space="preserve">
+    <value>Microfoon: {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantSpeakerFormat" xml:space="preserve">
+    <value>Luidspreker: {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantCloudRoutingFormat" xml:space="preserve">
+    <value>Cloudroutering: {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantSpeechOutputFormat" xml:space="preserve">
+    <value>Spraakuitvoer: {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantOn" xml:space="preserve">
+    <value>aan</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantOff" xml:space="preserve">
+    <value>uit</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantLastBridgeUpdateFormat" xml:space="preserve">
+    <value>Laatste brugupdate: {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantNoConversationTurns" xml:space="preserve">
+    <value>Nog geen gespreksbeurten.</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantSourceDefault" xml:space="preserve">
+    <value>assistent</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantTurnMetadataFormat" xml:space="preserve">
+    <value>{0} / {1}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantTurnMetadataWithLatencyFormat" xml:space="preserve">
+    <value>{0} | {1} | {2} ms vertraging</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantUserTurnFormat" xml:space="preserve">
+    <value>Jij: {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantResponseTurnFormat" xml:space="preserve">
+    <value>OpenClaw-antwoord: {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantEmptyValue" xml:space="preserve">
+    <value>(leeg)</value>
+  </data>
   <data name="VoiceSettingsPage_SttHeader.Text" xml:space="preserve">
     <value>Spraak-naar-tekst</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2589,6 +2589,105 @@
   <data name="VoiceSettingsPage_PageDescription.Text" xml:space="preserve">
     <value>配置语音转文字和语音交互设置。所有语音处理均在本机本地运行。</value>
   </data>
+  <data name="VoiceSettingsPage_AssistantHeader.Text" xml:space="preserve">
+    <value>助手</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantDescription.Text" xml:space="preserve">
+    <value>始终监听的助手服务和最新对话轮次。</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantRefreshButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>刷新助手状态</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartButtonText.Text" xml:space="preserve">
+    <value>启动</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopButtonText.Text" xml:space="preserve">
+    <value>停止</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStatusChecking.Text" xml:space="preserve">
+    <value>正在检查助手状态...</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantRecentTurnsHeader.Text" xml:space="preserve">
+    <value>最近轮次</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStarting" xml:space="preserve">
+    <value>正在启动助手...</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartingDetail" xml:space="preserve">
+    <value>正在启动始终监听模式，并使用本地助手路由和轮次存储。</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartFailed" xml:space="preserve">
+    <value>助手未启动</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopping" xml:space="preserve">
+    <value>正在停止助手...</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopFailed" xml:space="preserve">
+    <value>助手未停止</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantBridgeUnavailable" xml:space="preserve">
+    <value>助手桥不可用</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantNoTurnsLoaded" xml:space="preserve">
+    <value>未加载助手轮次。</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantUnknown" xml:space="preserve">
+    <value>未知</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantListeningFormat" xml:space="preserve">
+    <value>助手正在监听 (PID {0})</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopped" xml:space="preserve">
+    <value>助手已停止</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStatusFormat" xml:space="preserve">
+    <value>助手 {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantTranscriberFormat" xml:space="preserve">
+    <value>转录器：{0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantMicFormat" xml:space="preserve">
+    <value>麦克风：{0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantSpeakerFormat" xml:space="preserve">
+    <value>扬声器：{0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantCloudRoutingFormat" xml:space="preserve">
+    <value>云路由：{0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantSpeechOutputFormat" xml:space="preserve">
+    <value>语音输出：{0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantOn" xml:space="preserve">
+    <value>开启</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantOff" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantLastBridgeUpdateFormat" xml:space="preserve">
+    <value>上次桥更新：{0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantNoConversationTurns" xml:space="preserve">
+    <value>还没有对话轮次。</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantSourceDefault" xml:space="preserve">
+    <value>助手</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantTurnMetadataFormat" xml:space="preserve">
+    <value>{0} / {1}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantTurnMetadataWithLatencyFormat" xml:space="preserve">
+    <value>{0} | {1} | {2} 毫秒</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantUserTurnFormat" xml:space="preserve">
+    <value>你：{0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantResponseTurnFormat" xml:space="preserve">
+    <value>OpenClaw：{0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantEmptyValue" xml:space="preserve">
+    <value>（空）</value>
+  </data>
   <data name="VoiceSettingsPage_SttHeader.Text" xml:space="preserve">
     <value>语音转文字</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2589,6 +2589,105 @@
   <data name="VoiceSettingsPage_PageDescription.Text" xml:space="preserve">
     <value>設定語音轉文字和語音互動設定。所有語音處理均在本機本地執行。</value>
   </data>
+  <data name="VoiceSettingsPage_AssistantHeader.Text" xml:space="preserve">
+    <value>助理</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantDescription.Text" xml:space="preserve">
+    <value>永遠聆聽的助理服務和最新對話輪次。</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantRefreshButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>重新整理助理狀態</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartButtonText.Text" xml:space="preserve">
+    <value>啟動</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopButtonText.Text" xml:space="preserve">
+    <value>停止</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStatusChecking.Text" xml:space="preserve">
+    <value>正在檢查助理狀態...</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantRecentTurnsHeader.Text" xml:space="preserve">
+    <value>最近輪次</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStarting" xml:space="preserve">
+    <value>正在啟動助理...</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartingDetail" xml:space="preserve">
+    <value>正在啟動永遠聆聽模式，並使用本機助理路由和輪次儲存。</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartFailed" xml:space="preserve">
+    <value>助理未啟動</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopping" xml:space="preserve">
+    <value>正在停止助理...</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopFailed" xml:space="preserve">
+    <value>助理未停止</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantBridgeUnavailable" xml:space="preserve">
+    <value>助理橋接器無法使用</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantNoTurnsLoaded" xml:space="preserve">
+    <value>未載入助理輪次。</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantUnknown" xml:space="preserve">
+    <value>未知</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantListeningFormat" xml:space="preserve">
+    <value>助理正在聆聽 (PID {0})</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopped" xml:space="preserve">
+    <value>助理已停止</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStatusFormat" xml:space="preserve">
+    <value>助理 {0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantTranscriberFormat" xml:space="preserve">
+    <value>轉錄器：{0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantMicFormat" xml:space="preserve">
+    <value>麥克風：{0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantSpeakerFormat" xml:space="preserve">
+    <value>喇叭：{0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantCloudRoutingFormat" xml:space="preserve">
+    <value>雲端路由：{0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantSpeechOutputFormat" xml:space="preserve">
+    <value>語音輸出：{0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantOn" xml:space="preserve">
+    <value>開啟</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantOff" xml:space="preserve">
+    <value>關閉</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantLastBridgeUpdateFormat" xml:space="preserve">
+    <value>上次橋接器更新：{0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantNoConversationTurns" xml:space="preserve">
+    <value>尚無對話輪次。</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantSourceDefault" xml:space="preserve">
+    <value>助理</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantTurnMetadataFormat" xml:space="preserve">
+    <value>{0} / {1}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantTurnMetadataWithLatencyFormat" xml:space="preserve">
+    <value>{0} | {1} | {2} 毫秒</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantUserTurnFormat" xml:space="preserve">
+    <value>你：{0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantResponseTurnFormat" xml:space="preserve">
+    <value>OpenClaw：{0}</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantEmptyValue" xml:space="preserve">
+    <value>（空）</value>
+  </data>
   <data name="VoiceSettingsPage_SttHeader.Text" xml:space="preserve">
     <value>語音轉文字</value>
   </data>

--- a/tests/OpenClaw.Tray.Tests/AssistantBridgeServiceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AssistantBridgeServiceTests.cs
@@ -1,4 +1,6 @@
+using OpenClaw.Shared;
 using OpenClawTray.Services;
+using System.Diagnostics;
 
 namespace OpenClaw.Tray.Tests;
 
@@ -85,6 +87,149 @@ public sealed class AssistantBridgeServiceTests
         {
             Environment.SetEnvironmentVariable("OPENCLAW_BACKEND_ROOT", oldValue);
             try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task StartListenServiceAsync_DefaultsToLocalAssistantRouting()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "OpenClaw.Tray.Tests", Guid.NewGuid().ToString("N"));
+        var argsPath = Path.Combine(root, "args.txt");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var scriptPath = Path.Combine(root, "capture-args.ps1");
+            File.WriteAllText(
+                scriptPath,
+                $"Set-Content -LiteralPath {PsQuote(argsPath)} -Value ($args -join [Environment]::NewLine)");
+            var launcher = PowerShellScriptLauncher(scriptPath, root);
+            var service = new AssistantBridgeService(
+                NullLogger.Instance,
+                "owner",
+                () => launcher);
+
+            var result = await service.StartListenServiceAsync();
+
+            Assert.True(result.Success, result.ErrorMessage);
+            var args = File.ReadAllLines(argsPath);
+            Assert.Contains("assistant", args);
+            Assert.Contains("listen-service", args);
+            Assert.Contains("start", args);
+            Assert.Contains("--store-turn", args);
+            Assert.Contains("--json", args);
+            Assert.DoesNotContain("--allow-cloud", args);
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task StartListenServiceAsync_KillsTimedOutBackendCommand()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "OpenClaw.Tray.Tests", Guid.NewGuid().ToString("N"));
+        var pidPath = Path.Combine(root, "pid.txt");
+        Directory.CreateDirectory(root);
+        int? pid = null;
+        try
+        {
+            var scriptPath = Path.Combine(root, "sleep.ps1");
+            File.WriteAllText(
+                scriptPath,
+                $"Set-Content -LiteralPath {PsQuote(pidPath)} -Value $PID; Start-Sleep -Seconds 30");
+            var launcher = PowerShellScriptLauncher(scriptPath, root);
+            var service = new AssistantBridgeService(
+                NullLogger.Instance,
+                "owner",
+                () => launcher,
+                TimeSpan.FromSeconds(2));
+
+            var result = await service.StartListenServiceAsync();
+
+            Assert.False(result.Success);
+            Assert.Contains("timed out", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+            pid = await ReadPidAsync(pidPath);
+            Assert.True(
+                await WaitForProcessExitAsync(pid.Value),
+                $"Expected timed-out backend process {pid.Value} to be killed.");
+        }
+        finally
+        {
+            if (pid is int runningPid)
+                TryKillProcess(runningPid);
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    private static OpenClawCliLauncher PowerShellScriptLauncher(string scriptPath, string workingDirectory)
+    {
+        var exe = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.System),
+            "WindowsPowerShell",
+            "v1.0",
+            "powershell.exe");
+        if (!File.Exists(exe))
+            exe = "powershell.exe";
+
+        return new OpenClawCliLauncher(
+            exe,
+            workingDirectory,
+            ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", scriptPath]);
+    }
+
+    private static string PsQuote(string value) => "'" + value.Replace("'", "''") + "'";
+
+    private static async Task<int> ReadPidAsync(string pidPath)
+    {
+        for (var i = 0; i < 50; i++)
+        {
+            if (File.Exists(pidPath) &&
+                int.TryParse((await File.ReadAllTextAsync(pidPath)).Trim(), out var pid))
+            {
+                return pid;
+            }
+
+            await Task.Delay(100);
+        }
+
+        Assert.Fail("Timed-out backend command did not write its process id.");
+        return 0;
+    }
+
+    private static async Task<bool> WaitForProcessExitAsync(int pid)
+    {
+        for (var i = 0; i < 50; i++)
+        {
+            try
+            {
+                using var process = Process.GetProcessById(pid);
+                if (process.HasExited)
+                    return true;
+            }
+            catch (ArgumentException)
+            {
+                return true;
+            }
+
+            await Task.Delay(100);
+        }
+
+        return false;
+    }
+
+    private static void TryKillProcess(int pid)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            process.Kill(entireProcessTree: true);
+        }
+        catch (ArgumentException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
         }
     }
 }

--- a/tests/OpenClaw.Tray.Tests/AssistantBridgeServiceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AssistantBridgeServiceTests.cs
@@ -1,0 +1,90 @@
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class AssistantBridgeServiceTests
+{
+    [Fact]
+    public void ParseStatus_ReadsListenServiceAndRecentTurns()
+    {
+        const string json = """
+        {
+          "generated_at": "2026-06-21T19:40:30+00:00",
+          "user_id": "owner",
+          "assistant": {
+            "listen_service": {
+              "allow_cloud": true,
+              "configured": true,
+              "input_mode": "always-listening",
+              "log_file": "C:\\Users\\RipauvGohil\\AppData\\Local\\OpenClaw\\runtime\\assistant-listen-owner.log",
+              "pid": 20656,
+              "speak_aloud": true,
+              "status": "running",
+              "transcriber": "local-whisper"
+            },
+            "recent_turns": [
+              {
+                "created_at": "2026-06-21T19:26:59+00:00",
+                "source": "local-whisper",
+                "input_text": "OpenClaw, say only live voice smoke ok.",
+                "display_response_text": "live voice smoke ok",
+                "provider": "local-openai-compatible",
+                "model_profile": "local-private",
+                "stage": "answered",
+                "total_ms": 23502
+              }
+            ]
+          },
+          "voice": {
+            "preferred_input_device": "Microphone (Yeti Nano)",
+            "preferred_output_device": "LG TV SSCR2 (NVIDIA High Definition Audio)"
+          }
+        }
+        """;
+
+        var snapshot = AssistantBridgeService.ParseStatus(json);
+
+        Assert.True(snapshot.IsAvailable);
+        Assert.Equal("owner", snapshot.UserId);
+        Assert.Equal("2026-06-21T19:40:30+00:00", snapshot.GeneratedAt);
+        Assert.Equal("Microphone (Yeti Nano)", snapshot.PreferredInputDevice);
+        Assert.Equal("LG TV SSCR2 (NVIDIA High Definition Audio)", snapshot.PreferredOutputDevice);
+        Assert.True(snapshot.ListenService.IsRunning);
+        Assert.True(snapshot.ListenService.AllowCloud);
+        Assert.True(snapshot.ListenService.SpeakAloud);
+        Assert.Equal(20656, snapshot.ListenService.Pid);
+        Assert.Equal("local-whisper", snapshot.ListenService.Transcriber);
+        Assert.Single(snapshot.RecentTurns);
+        Assert.Equal("OpenClaw, say only live voice smoke ok.", snapshot.RecentTurns[0].InputText);
+        Assert.Equal("live voice smoke ok", snapshot.RecentTurns[0].ResponseText);
+        Assert.Equal(23502, snapshot.RecentTurns[0].TotalMs);
+    }
+
+    [Fact]
+    public void ResolveOpenClawCli_PrefersBackendRootEnvironmentOverride()
+    {
+        var oldValue = Environment.GetEnvironmentVariable("OPENCLAW_BACKEND_ROOT");
+        var root = Path.Combine(Path.GetTempPath(), "OpenClaw.Tray.Tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var scripts = Path.Combine(root, ".venv", "Scripts");
+            Directory.CreateDirectory(scripts);
+            var exe = Path.Combine(scripts, "openclaw.exe");
+            File.WriteAllText(exe, "");
+
+            Environment.SetEnvironmentVariable("OPENCLAW_BACKEND_ROOT", root);
+
+            var launcher = AssistantBridgeService.ResolveOpenClawCli();
+
+            Assert.NotNull(launcher);
+            Assert.Equal(exe, launcher!.ExecutablePath);
+            Assert.Equal(root, launcher.WorkingDirectory);
+            Assert.Empty(launcher.PrefixArgs);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OPENCLAW_BACKEND_ROOT", oldValue);
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/AssistantBridgeServiceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AssistantBridgeServiceTests.cs
@@ -66,7 +66,11 @@ public sealed class AssistantBridgeServiceTests
     public void ResolveOpenClawCli_PrefersBackendRootEnvironmentOverride()
     {
         var oldValue = Environment.GetEnvironmentVariable("OPENCLAW_BACKEND_ROOT");
-        var root = Path.Combine(Path.GetTempPath(), "OpenClaw.Tray.Tests", Guid.NewGuid().ToString("N"));
+        var root = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            "Projects",
+            "OpenClaw.Tray.Tests",
+            Guid.NewGuid().ToString("N"));
         try
         {
             var scripts = Path.Combine(root, ".venv", "Scripts");
@@ -88,6 +92,61 @@ public sealed class AssistantBridgeServiceTests
             Environment.SetEnvironmentVariable("OPENCLAW_BACKEND_ROOT", oldValue);
             try { Directory.Delete(root, recursive: true); } catch { }
         }
+    }
+
+    [Fact]
+    public void ResolveOpenClawCli_IgnoresBackendRootOutsideTrustedParents()
+    {
+        var oldValue = Environment.GetEnvironmentVariable("OPENCLAW_BACKEND_ROOT");
+        var root = Path.Combine(Path.GetTempPath(), "OpenClaw.Tray.Tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var scripts = Path.Combine(root, ".venv", "Scripts");
+            Directory.CreateDirectory(scripts);
+            var exe = Path.Combine(scripts, "openclaw.exe");
+            File.WriteAllText(exe, "");
+
+            Environment.SetEnvironmentVariable("OPENCLAW_BACKEND_ROOT", root);
+
+            var launcher = AssistantBridgeService.ResolveOpenClawCli();
+
+            Assert.True(
+                launcher == null || !string.Equals(launcher.ExecutablePath, exe, StringComparison.OrdinalIgnoreCase),
+                "OPENCLAW_BACKEND_ROOT should not execute arbitrary binaries outside trusted checkout parents.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OPENCLAW_BACKEND_ROOT", oldValue);
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void TryNormalizeBackendRoot_RejectsRelativePaths()
+    {
+        Assert.False(AssistantBridgeService.TryNormalizeBackendRoot("OpenClaw", out _));
+    }
+
+    [Fact]
+    public void TryNormalizeBackendRoot_AcceptsTrustedCheckoutParents()
+    {
+        var root = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            "Projects",
+            "OpenClaw");
+
+        Assert.True(AssistantBridgeService.TryNormalizeBackendRoot(root, out var normalizedRoot));
+        Assert.Equal(Path.GetFullPath(root), normalizedRoot);
+    }
+
+    [Fact]
+    public void BuildBackendNotFoundMessage_ListsSearchedLocations()
+    {
+        var message = AssistantBridgeService.BuildBackendNotFoundMessage();
+
+        Assert.Contains("Searched:", message);
+        Assert.Contains(@"D:\Projects\OpenClaw", message);
+        Assert.Contains("OPENCLAW_BACKEND_ROOT", message);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ConfigEditorModel.cs" Link="Services\ConfigEditorModel.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\JsonDiffFormatter.cs" Link="Services\JsonDiffFormatter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\AppState.cs" Link="Services\AppState.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\AssistantBridgeService.cs" Link="Services\AssistantBridgeService.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\Logger.cs" Link="Services\Logger.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SettingsManager.cs" Link="Services\SettingsManager.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\OnboardingChatBootstrapper.cs" Link="Services\OnboardingChatBootstrapper.cs" />


### PR DESCRIPTION
Adds a native Companion GUI surface for the OpenClaw assistant MVP on the existing Voice & Audio page.

Changes:
- Adds AssistantBridgeService to call the local OpenClaw backend bridge/listen-service commands.
- Adds an Assistant card to Voice & Audio with Refresh, Start, Stop, live listen-service status, selected mic/speaker, and recent input/output turns.
- Resolves the local backend through OPENCLAW_BACKEND_ROOT or the default D:\Projects\OpenClaw checkout, so dev builds do not depend on PATH.
- Handles backend stop-requested metadata as a stopped UI state when rendering the card.
- Adds focused tests for bridge JSON parsing and backend launcher resolution.

Validation:
- dotnet test tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore: 1100 passed.
- dotnet build src\OpenClaw.Tray.WinUI\OpenClaw.Tray.WinUI.csproj -r win-x64 --no-restore: succeeded, 0 warnings, 0 errors.
- Live backend start/status/stop smoke through D:\Projects\OpenClaw\.venv\Scripts\openclaw.exe succeeded.
- Rebuilt local Companion launched from the Debug win-x64 output and connected as the Windows node.

Notes:
- This intentionally reuses the existing native Voice & Audio page and the backend listen-service bridge instead of creating a separate UI.
- No changes to the backend repository in this PR.