### PR TITLE
Make A2UI dataModelUpdate.valueArray first-class

### DIFF
--- a/src/OpenClaw.Tray.WinUI/A2UI/DataModel/DataModelStore.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/DataModel/DataModelStore.cs
@@ -105,6 +105,7 @@ public sealed class DataModelStore
             if (entry.Key.Length > MaxKeyLength) continue;
             if (entry.ValueString != null && entry.ValueString.Length > MaxStringValueLength) continue;
             if (!IsWithinDepth(entry.ValueMap, depth: 1, max: MaxValueMapDepth)) continue;
+            if (!IsWithinDepth(entry.ValueArray, depth: 1, max: MaxValueMapDepth)) continue;
 
             try
             {
@@ -130,12 +131,17 @@ public sealed class DataModelStore
             new DataModelObservable(model, _dispatcher).NotifyPaths(changed);
     }
 
-    private static bool IsWithinDepth(IReadOnlyList<Protocol.DataModelEntry>? map, int depth, int max)
+    private static bool IsWithinDepth(IReadOnlyList<Protocol.DataModelEntry>? children, int depth, int max)
     {
-        if (map == null) return true;
+        if (children == null) return true;
         if (depth > max) return false;
-        foreach (var e in map)
+        foreach (var e in children)
+        {
+            // Both nested maps and nested arrays add a level — bound either path
+            // so a deeply-nested valueArray can't bypass the valueMap depth cap.
             if (!IsWithinDepth(e.ValueMap, depth + 1, max)) return false;
+            if (!IsWithinDepth(e.ValueArray, depth + 1, max)) return false;
+        }
         return true;
     }
 

--- a/src/OpenClaw.Tray.WinUI/A2UI/DataModel/DataModelStore.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/DataModel/DataModelStore.cs
@@ -247,14 +247,14 @@ public sealed class DataModelStore
                     if (obj[tok] == null)
                     {
                         if (!createMissing) return (null, null, false, -1);
-                        var nextIsIndex = int.TryParse(tokens[i + 1], out _);
+                        var nextIsIndex = TryParseArrayIndex(tokens[i + 1], out _);
                         obj[tok] = nextIsIndex ? new JsonArray() : new JsonObject();
                     }
                     cursor = obj[tok];
                 }
                 else if (cursor is JsonArray arr)
                 {
-                    if (!int.TryParse(tok, out var ai)) return (null, null, false, -1);
+                    if (!TryParseArrayIndex(tok, out var ai)) return (null, null, false, -1);
                     while (createMissing && arr.Count <= ai) arr.Add(null);
                     if (ai < 0 || ai >= arr.Count) return (null, null, false, -1);
                     cursor = arr[ai];
@@ -266,9 +266,26 @@ public sealed class DataModelStore
             }
 
             var last = tokens[^1];
-            if (cursor is JsonArray finalArr && int.TryParse(last, out var idx))
+            if (cursor is JsonArray finalArr && TryParseArrayIndex(last, out var idx))
                 return (finalArr, last, true, idx);
             return (cursor, last, false, -1);
+        }
+
+        private static bool TryParseArrayIndex(string token, out int index)
+        {
+            index = -1;
+            if (token.Length == 0) return false;
+            if (token.Length > 1 && token[0] == '0') return false;
+
+            foreach (var c in token)
+                if (c < '0' || c > '9')
+                    return false;
+
+            return int.TryParse(
+                token,
+                System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out index);
         }
 
         private static List<string> SplitPointer(string pointer)
@@ -362,22 +379,55 @@ public sealed class DataModelObservable
             var current = key;
             while (true)
             {
-                List<Action>? subs;
-                lock (_model.Subscribers)
-                {
-                    _model.Subscribers.TryGetValue(current, out subs);
-                    subs = subs == null ? null : new List<Action>(subs);
-                }
-                if (subs != null)
-                {
-                    foreach (var s in subs)
-                        if (fired.Add(s)) Dispatch(s);
-                }
+                DispatchSubscribers(current, fired);
                 if (current == "/" || string.IsNullOrEmpty(current)) break;
                 var slash = current.LastIndexOf('/');
                 current = slash <= 0 ? "/" : current.Substring(0, slash);
             }
+
+            // Replacing a container at /x also changes /x/... descendants. Most
+            // component bindings subscribe to the exact leaf path they read, so
+            // notify those subtree subscribers as well.
+            DispatchDescendantSubscribers(key, fired);
         }
+    }
+
+    private void DispatchSubscribers(string key, HashSet<Action> fired)
+    {
+        List<Action>? subs;
+        lock (_model.Subscribers)
+        {
+            _model.Subscribers.TryGetValue(key, out subs);
+            subs = subs == null ? null : new List<Action>(subs);
+        }
+
+        if (subs == null) return;
+
+        foreach (var s in subs)
+            if (fired.Add(s))
+                Dispatch(s);
+    }
+
+    private void DispatchDescendantSubscribers(string key, HashSet<Action> fired)
+    {
+        List<Action> subs = [];
+        var prefix = key == "/" ? "/" : key + "/";
+
+        lock (_model.Subscribers)
+        {
+            foreach (var (subscriberPath, callbacks) in _model.Subscribers)
+            {
+                if (subscriberPath == key)
+                    continue;
+
+                if (key == "/" || subscriberPath.StartsWith(prefix, StringComparison.Ordinal))
+                    subs.AddRange(callbacks);
+            }
+        }
+
+        foreach (var s in subs)
+            if (fired.Add(s))
+                Dispatch(s);
     }
 
     internal void NotifyAllPaths()

--- a/src/OpenClaw.Tray.WinUI/A2UI/Protocol/A2UIProtocol.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Protocol/A2UIProtocol.cs
@@ -73,9 +73,9 @@ public sealed record A2UIComponentDef
 }
 
 /// <summary>
-/// Single dataModelUpdate.contents entry. Exactly one of Value*/ValueMap is
-/// expected on the wire; we expose them all and let the store apply whichever
-/// is set.
+/// Single dataModelUpdate.contents entry. Exactly one of
+/// Value*/ValueMap/ValueArray is expected on the wire; we expose them all and
+/// let the store apply whichever is set.
 /// </summary>
 public sealed record DataModelEntry
 {
@@ -85,6 +85,12 @@ public sealed record DataModelEntry
     public bool? ValueBoolean { get; init; }
     /// <summary>An adjacency-list map: each item is itself a DataModelEntry.</summary>
     public IReadOnlyList<DataModelEntry>? ValueMap { get; init; }
+    /// <summary>
+    /// An ordered array (v0.8 <c>valueArray</c>): each item is a value-typed
+    /// <see cref="DataModelEntry"/> whose <see cref="Key"/> is ignored. Items
+    /// may themselves be scalars, maps, or nested arrays.
+    /// </summary>
+    public IReadOnlyList<DataModelEntry>? ValueArray { get; init; }
 
     /// <summary>Convert this entry's value to a JsonNode for storage.</summary>
     public JsonNode? ToJsonNode()
@@ -98,6 +104,13 @@ public sealed record DataModelEntry
             foreach (var entry in ValueMap)
                 obj[entry.Key] = entry.ToJsonNode();
             return obj;
+        }
+        if (ValueArray != null)
+        {
+            var arr = new JsonArray();
+            foreach (var entry in ValueArray)
+                arr.Add(entry.ToJsonNode());
+            return arr;
         }
         return null;
     }
@@ -350,6 +363,7 @@ public static class A2UIMessageParser
             ValueNumber = e["valueNumber"] is JsonValue jvn && jvn.TryGetValue<double>(out var n) ? n : null,
             ValueBoolean = e["valueBoolean"] is JsonValue jvb && jvb.TryGetValue<bool>(out var b) ? b : null,
             ValueMap = ParseValueMap(e["valueMap"] as JsonArray),
+            ValueArray = ParseValueArray(e["valueArray"] as JsonArray),
         };
         return entry;
     }
@@ -365,6 +379,61 @@ public static class A2UIMessageParser
             if (nested != null) list.Add(nested);
         }
         return list;
+    }
+
+    /// <summary>
+    /// Parse a v0.8 <c>valueArray</c>. Each element is a value-typed object
+    /// with no key (e.g. <c>{ "valueString": "admin" }</c>). For robustness we
+    /// also tolerate bare primitives (<c>["a", 1, true]</c>) that an agent may
+    /// emit. A JSON <c>null</c> element is preserved as an explicit null slot so
+    /// array indices stay stable for position-sensitive consumers — matching how
+    /// a value-less wrapped object (<c>{}</c>) round-trips. Elements of an
+    /// unsupported kind are dropped, matching <see cref="ParseValueMap"/>'s
+    /// skip-bad-item tolerance.
+    /// </summary>
+    private static IReadOnlyList<DataModelEntry>? ParseValueArray(JsonArray? arr)
+    {
+        if (arr == null) return null;
+        var list = new List<DataModelEntry>(arr.Count);
+        foreach (var item in arr)
+        {
+            // A JSON null element surfaces as a C# null inside the JsonArray.
+            // Preserve it as a value-less entry (ToJsonNode → null) rather than
+            // dropping it, so [a, null, b] stays length 3.
+            if (item is null) { list.Add(NullArrayElement); continue; }
+            var element = ParseArrayElement(item);
+            if (element != null) list.Add(element);
+        }
+        return list;
+    }
+
+    /// <summary>Shared value-less entry representing a JSON null array slot.</summary>
+    private static readonly DataModelEntry NullArrayElement = new() { Key = string.Empty };
+
+    private static DataModelEntry? ParseArrayElement(JsonNode? item)
+    {
+        if (item is JsonObject e)
+        {
+            return new DataModelEntry
+            {
+                Key = string.Empty,
+                ValueString = OptionalString(e, "valueString"),
+                ValueNumber = e["valueNumber"] is JsonValue jvn && jvn.TryGetValue<double>(out var n) ? n : null,
+                ValueBoolean = e["valueBoolean"] is JsonValue jvb && jvb.TryGetValue<bool>(out var b) ? b : null,
+                ValueMap = ParseValueMap(e["valueMap"] as JsonArray),
+                ValueArray = ParseValueArray(e["valueArray"] as JsonArray),
+            };
+        }
+        // Bare primitive tolerance. Check string first (a JSON number/bool does
+        // not satisfy TryGetValue<string>), then bool (a JSON number does not
+        // satisfy TryGetValue<bool>), then number.
+        if (item is JsonValue v)
+        {
+            if (v.TryGetValue<string>(out var s)) return new DataModelEntry { Key = string.Empty, ValueString = s };
+            if (v.TryGetValue<bool>(out var bl)) return new DataModelEntry { Key = string.Empty, ValueBoolean = bl };
+            if (v.TryGetValue<double>(out var d)) return new DataModelEntry { Key = string.Empty, ValueNumber = d };
+        }
+        return null;
     }
 
     private static string RequireString(JsonObject o, string key)

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/IComponentRenderer.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/IComponentRenderer.cs
@@ -164,7 +164,12 @@ public sealed class RenderContext
     {
         if (SecretPaths == null) return;
         if (string.IsNullOrEmpty(path)) return;
-        SecretPaths.Add(NormalizePath(path));
+        var normalized = NormalizePath(path);
+        SecretPaths.Add(normalized);
+
+        var canonical = SecretRedactor.CanonicalizeLenientArrayIndices(normalized);
+        if (!string.Equals(canonical, normalized, StringComparison.Ordinal))
+            SecretPaths.Add(canonical);
     }
 
     /// <summary>True if <paramref name="path"/> is a secret path (registered or matches denylist).</summary>
@@ -210,7 +215,11 @@ public sealed class RenderContext
                 var path = val.Path!;
                 if (!IsAllowedPath(path, allowed)) continue;
                 if (IsSecretPath(path)) continue;
-                result[key] = DataModel.Read(path)?.DeepClone();
+                var clone = DataModel.Read(path)?.DeepClone();
+                var registered = SecretPaths == null
+                    ? System.Collections.Frozen.FrozenSet<string>.Empty
+                    : (IReadOnlySet<string>)SecretPaths;
+                result[key] = SecretRedactor.RedactInPlace(clone, path, registered);
             }
         }
         return result;

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/SecretRedactor.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/SecretRedactor.cs
@@ -50,11 +50,27 @@ internal static class SecretRedactor
         if (string.IsNullOrEmpty(path)) return false;
         var normalized = Normalize(path);
         if (registered.Contains(normalized)) return true;
+
+        var canonical = CanonicalizeLenientArrayIndices(normalized);
+        if (!string.Equals(canonical, normalized, StringComparison.Ordinal)
+            && registered.Contains(canonical))
+        {
+            return true;
+        }
+
         // Any ancestor of the path counts: obscuring "/credentials" should hide "/credentials/password" too.
         foreach (var prefix in registered)
         {
-            if (prefix.Length == 0 || prefix == "/") continue;
-            if (normalized.StartsWith(prefix + "/", StringComparison.Ordinal)) return true;
+            var normalizedPrefix = Normalize(prefix);
+            if (normalizedPrefix.Length == 0 || normalizedPrefix == "/") continue;
+            if (IsPathOrDescendant(normalized, normalizedPrefix)) return true;
+
+            var canonicalPrefix = CanonicalizeLenientArrayIndices(normalizedPrefix);
+            if (!string.Equals(canonicalPrefix, normalizedPrefix, StringComparison.Ordinal)
+                && IsPathOrDescendant(normalized, canonicalPrefix))
+            {
+                return true;
+            }
         }
         return MatchesDenylist(normalized);
     }
@@ -66,6 +82,7 @@ internal static class SecretRedactor
     public static JsonNode? Redact(JsonNode? root, IReadOnlySet<string> registered)
     {
         if (root == null) return null;
+        if (IsSecret("/", registered)) return JsonValue.Create("[REDACTED]");
         return RedactNode(root.DeepClone(), "/", registered);
     }
 
@@ -76,7 +93,19 @@ internal static class SecretRedactor
     public static JsonNode? RedactInPlace(JsonNode? root, IReadOnlySet<string> registered)
     {
         if (root == null) return null;
+        if (IsSecret("/", registered)) return JsonValue.Create("[REDACTED]");
         return RedactNode(root, "/", registered);
+    }
+
+    public static JsonNode? RedactInPlace(JsonNode? root, string rootPath, IReadOnlySet<string> registered)
+    {
+        if (root == null) return null;
+
+        var normalizedRootPath = Normalize(rootPath);
+        if (IsSecret(normalizedRootPath, registered))
+            return JsonValue.Create("[REDACTED]");
+
+        return RedactNode(root, normalizedRootPath, registered);
     }
 
     private static JsonNode? RedactNode(JsonNode? node, string path, IReadOnlySet<string> registered)
@@ -157,6 +186,41 @@ internal static class SecretRedactor
 
     private static string Normalize(string p) =>
         string.IsNullOrEmpty(p) ? "/" : (p[0] == '/' ? p : "/" + p);
+
+    private static bool IsPathOrDescendant(string path, string prefix) =>
+        string.Equals(path, prefix, StringComparison.Ordinal)
+        || path.StartsWith(prefix + "/", StringComparison.Ordinal);
+
+    internal static string CanonicalizeLenientArrayIndices(string path)
+    {
+        var normalized = Normalize(path);
+        if (normalized == "/") return normalized;
+
+        var parts = normalized.Substring(1).Split('/');
+        var changed = false;
+        for (var i = 0; i < parts.Length; i++)
+        {
+            var decoded = parts[i].Replace("~1", "/").Replace("~0", "~");
+            if (!int.TryParse(
+                    decoded,
+                    System.Globalization.NumberStyles.Integer,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out var index)
+                || index < 0)
+            {
+                continue;
+            }
+
+            var canonical = index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            if (string.Equals(decoded, canonical, StringComparison.Ordinal))
+                continue;
+
+            parts[i] = EncodeSegment(canonical);
+            changed = true;
+        }
+
+        return changed ? "/" + string.Join("/", parts) : normalized;
+    }
 
     private static string EncodeSegment(string key) =>
         key.Replace("~", "~0").Replace("/", "~1");

--- a/src/OpenClaw.Tray.WinUI/A2UI/Rendering/SecretRedactor.cs
+++ b/src/OpenClaw.Tray.WinUI/A2UI/Rendering/SecretRedactor.cs
@@ -107,8 +107,19 @@ internal static class SecretRedactor
             {
                 var childPath = path == "/" ? "/" + i : path + "/" + i;
                 var current = arr[i];
-                var replaced = RedactNode(current, childPath, registered);
-                if (!ReferenceEquals(replaced, current)) arr[i] = replaced;
+                // Mirror the object branch: a registered/denylisted element path
+                // (e.g. an obscured TextField bound to "/codes/0") must be
+                // redacted, not just recursed into — a scalar element would
+                // otherwise pass through unchanged and leak via canvas.a2ui.dump.
+                if (IsSecret(childPath, registered))
+                {
+                    arr[i] = JsonValue.Create("[REDACTED]");
+                }
+                else
+                {
+                    var replaced = RedactNode(current, childPath, registered);
+                    if (!ReferenceEquals(replaced, current)) arr[i] = replaced;
+                }
             }
             return arr;
         }

--- a/src/skills/windows-a2ui/SKILL.md
+++ b/src/skills/windows-a2ui/SKILL.md
@@ -71,9 +71,13 @@ A `path` is a JSON Pointer into the surface's data model. The renderer subscribe
   { "key": "first",  "valueString": "Alice" },
   { "key": "last",   "valueString": "Smith" }
 ] }
+{ "key": "tags",     "valueArray": [
+  { "valueString": "admin" },
+  { "valueString": "beta" }
+] }
 ```
 
-Exactly one of `valueString` / `valueNumber` / `valueBoolean` / `valueMap` should be set per entry. `valueMap` is a recursive adjacency list (each item is itself an entry). Arrays of strings are not first-class on the data-model side — store them as a `path` consumed by `MultipleChoice.selections` or by a literalArray default.
+Exactly one of `valueString` / `valueNumber` / `valueBoolean` / `valueMap` / `valueArray` should be set per entry. `valueMap` is a recursive adjacency list (each item is itself an entry). `valueArray` is an ordered list whose items are value-typed entries with no `key` (they may be scalars, maps, or nested arrays) — this is the first-class way to seed an array the renderer consumes, e.g. `MultipleChoice.selections`. Bare-primitive arrays (`["a","b"]`) are also tolerated.
 
 ## Components
 

--- a/tests/OpenClaw.Tray.Tests/A2UIDataModelArrayTests.cs
+++ b/tests/OpenClaw.Tray.Tests/A2UIDataModelArrayTests.cs
@@ -1,0 +1,182 @@
+using System.Linq;
+using System.Text.Json.Nodes;
+using OpenClawTray.A2UI.Protocol;
+using Xunit;
+
+namespace OpenClaw.Tray.Tests;
+
+/// <summary>
+/// Conformance tests for the v0.8 <c>dataModelUpdate.valueArray</c> typed value.
+///
+/// The protocol (docs/a2ui/protocol.md §2.2 and data-and-actions.md) lists
+/// <c>valueArray</c> alongside <c>valueString/Number/Boolean/valueMap</c> as the
+/// unambiguous way to seed an array into the data model — e.g. for
+/// <c>MultipleChoice.selections</c>. These tests pin that the parser produces a
+/// real <see cref="JsonArray"/> (it previously dropped the value entirely).
+/// </summary>
+public sealed class A2UIDataModelArrayTests
+{
+    /// <summary>Parse a single dataModelUpdate line and return the entry with the given key.</summary>
+    private static DataModelEntry EntryFor(string jsonl, string key)
+    {
+        var msg = Assert.IsType<DataModelUpdateMessage>(A2UIMessageParser.ParseLine(jsonl));
+        return msg.Contents.Single(c => c.Key == key);
+    }
+
+    [Fact]
+    public void ValueArray_OfStrings_ParsesToJsonArray()
+    {
+        const string jsonl =
+            """{"dataModelUpdate":{"surfaceId":"s","contents":[{"key":"tags","valueArray":[{"valueString":"admin"},{"valueString":"beta"}]}]}}""";
+
+        var node = EntryFor(jsonl, "tags").ToJsonNode();
+
+        var arr = Assert.IsType<JsonArray>(node);
+        Assert.Equal(new[] { "admin", "beta" }, arr.Select(n => n!.GetValue<string>()));
+    }
+
+    [Fact]
+    public void ValueArray_OfMixedScalars_PreservesTypes()
+    {
+        const string jsonl =
+            """{"dataModelUpdate":{"surfaceId":"s","contents":[{"key":"mixed","valueArray":[{"valueString":"x"},{"valueNumber":7},{"valueBoolean":true}]}]}}""";
+
+        var arr = Assert.IsType<JsonArray>(EntryFor(jsonl, "mixed").ToJsonNode());
+
+        Assert.Equal(3, arr.Count);
+        Assert.Equal("x", arr[0]!.GetValue<string>());
+        Assert.Equal(7, arr[1]!.GetValue<double>());
+        Assert.True(arr[2]!.GetValue<bool>());
+    }
+
+    [Fact]
+    public void ValueArray_OfMaps_ProducesArrayOfObjects()
+    {
+        const string jsonl =
+            """{"dataModelUpdate":{"surfaceId":"s","contents":[{"key":"rows","valueArray":[""" +
+                """{"valueMap":[{"key":"id","valueNumber":1},{"key":"name","valueString":"Ada"}]},""" +
+                """{"valueMap":[{"key":"id","valueNumber":2},{"key":"name","valueString":"Bob"}]}""" +
+            """]}]}}""";
+
+        var arr = Assert.IsType<JsonArray>(EntryFor(jsonl, "rows").ToJsonNode());
+
+        Assert.Equal(2, arr.Count);
+        var first = Assert.IsType<JsonObject>(arr[0]);
+        Assert.Equal(1, first["id"]!.GetValue<double>());
+        Assert.Equal("Ada", first["name"]!.GetValue<string>());
+        var second = Assert.IsType<JsonObject>(arr[1]);
+        Assert.Equal("Bob", second["name"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ValueArray_Nested_ProducesArrayOfArrays()
+    {
+        const string jsonl =
+            """{"dataModelUpdate":{"surfaceId":"s","contents":[{"key":"grid","valueArray":[""" +
+                """{"valueArray":[{"valueNumber":1},{"valueNumber":2}]},""" +
+                """{"valueArray":[{"valueNumber":3}]}""" +
+            """]}]}}""";
+
+        var arr = Assert.IsType<JsonArray>(EntryFor(jsonl, "grid").ToJsonNode());
+
+        var inner0 = Assert.IsType<JsonArray>(arr[0]);
+        Assert.Equal(new double[] { 1, 2 }, inner0.Select(n => n!.GetValue<double>()));
+        var inner1 = Assert.IsType<JsonArray>(arr[1]);
+        Assert.Equal(new double[] { 3 }, inner1.Select(n => n!.GetValue<double>()));
+    }
+
+    [Fact]
+    public void ValueArray_BarePrimitiveElements_AreTolerated()
+    {
+        // An agent may emit a JSON array of bare primitives rather than the
+        // wrapped { "valueString": ... } shape. We round-trip those too.
+        const string jsonl =
+            """{"dataModelUpdate":{"surfaceId":"s","contents":[{"key":"vals","valueArray":["a",2,false]}]}}""";
+
+        var arr = Assert.IsType<JsonArray>(EntryFor(jsonl, "vals").ToJsonNode());
+
+        Assert.Equal(3, arr.Count);
+        Assert.Equal("a", arr[0]!.GetValue<string>());
+        Assert.Equal(2, arr[1]!.GetValue<double>());
+        Assert.False(arr[2]!.GetValue<bool>());
+    }
+
+    [Fact]
+    public void ValueArray_Empty_ProducesEmptyArray()
+    {
+        const string jsonl =
+            """{"dataModelUpdate":{"surfaceId":"s","contents":[{"key":"empty","valueArray":[]}]}}""";
+
+        var arr = Assert.IsType<JsonArray>(EntryFor(jsonl, "empty").ToJsonNode());
+        Assert.Empty(arr);
+    }
+
+    [Fact]
+    public void ValueArray_SelectionsShape_MatchesMultipleChoiceMultiRead()
+    {
+        // MultipleChoice (multi) reads selections as a JsonArray of strings; an
+        // agent seeds the initial selection through valueArray. Pin the exact
+        // shape MultipleChoice.ResolveMulti expects.
+        const string jsonl =
+            """{"dataModelUpdate":{"surfaceId":"s","path":"/form","contents":[{"key":"picked","valueArray":[{"valueString":"red"},{"valueString":"blue"}]}]}}""";
+
+        var msg = Assert.IsType<DataModelUpdateMessage>(A2UIMessageParser.ParseLine(jsonl));
+        Assert.Equal("/form", msg.Path);
+        var arr = Assert.IsType<JsonArray>(msg.Contents.Single().ToJsonNode());
+        Assert.Equal(new[] { "red", "blue" }, arr.Select(n => n!.GetValue<string>()));
+    }
+
+    [Fact]
+    public void ValueArray_NullElement_PreservedAsNullSlot()
+    {
+        // A JSON null element keeps its position so index-sensitive consumers
+        // don't see a shifted array.
+        const string jsonl =
+            """{"dataModelUpdate":{"surfaceId":"s","contents":[{"key":"vals","valueArray":[{"valueString":"a"},null,{"valueString":"b"}]}]}}""";
+
+        var arr = Assert.IsType<JsonArray>(EntryFor(jsonl, "vals").ToJsonNode());
+
+        Assert.Equal(3, arr.Count);
+        Assert.Equal("a", arr[0]!.GetValue<string>());
+        Assert.Null(arr[1]);
+        Assert.Equal("b", arr[2]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ValueArray_ValuelessObjectElement_PreservedAsNullSlot()
+    {
+        // A wrapped element carrying no recognized value also yields a null slot
+        // — consistent with the bare-null case above.
+        const string jsonl =
+            """{"dataModelUpdate":{"surfaceId":"s","contents":[{"key":"vals","valueArray":[{},{"valueString":"b"}]}]}}""";
+
+        var arr = Assert.IsType<JsonArray>(EntryFor(jsonl, "vals").ToJsonNode());
+
+        Assert.Equal(2, arr.Count);
+        Assert.Null(arr[0]);
+        Assert.Equal("b", arr[1]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ValueMap_StillParses_NoRegression()
+    {
+        const string jsonl =
+            """{"dataModelUpdate":{"surfaceId":"s","contents":[{"key":"user","valueMap":[{"key":"first","valueString":"Ada"},{"key":"last","valueString":"Lovelace"}]}]}}""";
+
+        var obj = Assert.IsType<JsonObject>(EntryFor(jsonl, "user").ToJsonNode());
+        Assert.Equal("Ada", obj["first"]!.GetValue<string>());
+        Assert.Equal("Lovelace", obj["last"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ScalarEntries_StillParse_NoRegression()
+    {
+        const string jsonl =
+            """{"dataModelUpdate":{"surfaceId":"s","contents":[{"key":"name","valueString":"Ada"},{"key":"age","valueNumber":36},{"key":"active","valueBoolean":true}]}}""";
+
+        var msg = Assert.IsType<DataModelUpdateMessage>(A2UIMessageParser.ParseLine(jsonl));
+        Assert.Equal("Ada", msg.Contents.Single(c => c.Key == "name").ToJsonNode()!.GetValue<string>());
+        Assert.Equal(36, msg.Contents.Single(c => c.Key == "age").ToJsonNode()!.GetValue<double>());
+        Assert.True(msg.Contents.Single(c => c.Key == "active").ToJsonNode()!.GetValue<bool>());
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/SecretRedactorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SecretRedactorTests.cs
@@ -96,6 +96,17 @@ public sealed class SecretRedactorTests
     }
 
     [Fact]
+    public void RedactInPlace_RootRegistered_RedactsWholeRoot()
+    {
+        var registered = new HashSet<string> { "/" };
+        var root = JsonNode.Parse("""{ "value": "1234", "profile": { "name": "alice" } }""")!;
+
+        var redacted = SecretRedactor.RedactInPlace(root, registered)!;
+
+        Assert.Equal("[REDACTED]", redacted.GetValue<string>());
+    }
+
+    [Fact]
     public void Redact_RegisteredSecretInsideArray_IsRedacted()
     {
         // An obscured TextField bound to "/codes/0" registers that element path.
@@ -110,6 +121,22 @@ public sealed class SecretRedactorTests
         var arr = Assert.IsType<JsonArray>(redacted["codes"]);
         Assert.Equal("[REDACTED]", (string?)arr[0]);
         Assert.Equal("5678", (string?)arr[1]);
+    }
+
+    [Theory]
+    [InlineData("/codes/01")]
+    [InlineData("/codes/+1")]
+    [InlineData("/codes/ 1")]
+    public void Redact_NonCanonicalRegisteredArrayIndex_RedactsCanonicalElement(string registeredPath)
+    {
+        var registered = new HashSet<string> { registeredPath };
+        var root = JsonNode.Parse("""{ "codes": ["1234", "5678"] }""")!;
+
+        var redacted = SecretRedactor.Redact(root, registered)!;
+
+        var arr = Assert.IsType<JsonArray>(redacted["codes"]);
+        Assert.Equal("1234", (string?)arr[0]);
+        Assert.Equal("[REDACTED]", (string?)arr[1]);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/SecretRedactorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SecretRedactorTests.cs
@@ -94,4 +94,46 @@ public sealed class SecretRedactorTests
         Assert.False(SecretRedactor.IsSecret("/profile/name", registered));
         Assert.True(SecretRedactor.IsSecret("/profile/password", registered));
     }
+
+    [Fact]
+    public void Redact_RegisteredSecretInsideArray_IsRedacted()
+    {
+        // An obscured TextField bound to "/codes/0" registers that element path.
+        // After a valueArray seeds "/codes" as ["1234","5678"], the snapshot/dump
+        // path must redact the registered element — arrays previously only
+        // recursed (leaving scalar elements untouched).
+        var registered = new HashSet<string> { "/codes/0" };
+        var root = JsonNode.Parse("""{ "codes": ["1234", "5678"] }""")!;
+
+        var redacted = SecretRedactor.Redact(root, registered)!;
+
+        var arr = Assert.IsType<JsonArray>(redacted["codes"]);
+        Assert.Equal("[REDACTED]", (string?)arr[0]);
+        Assert.Equal("5678", (string?)arr[1]);
+    }
+
+    [Fact]
+    public void Redact_RegisteredArrayParent_RedactsWholeArray()
+    {
+        // Registering the array's parent path redacts the entire array value.
+        var registered = new HashSet<string> { "/codes" };
+        var root = JsonNode.Parse("""{ "codes": ["1234", "5678"] }""")!;
+
+        var redacted = SecretRedactor.Redact(root, registered)!;
+
+        Assert.Equal("[REDACTED]", (string?)redacted["codes"]);
+    }
+
+    [Fact]
+    public void Redact_DenylistedScalarInsideArray_IsRedacted()
+    {
+        // A denylisted segment on an array-element path is caught too.
+        var root = JsonNode.Parse("""{ "items": [ { "token": "abc" }, { "name": "ok" } ] }""")!;
+
+        var redacted = SecretRedactor.Redact(root, NoRegistered)!;
+
+        var arr = Assert.IsType<JsonArray>(redacted["items"]);
+        Assert.Equal("[REDACTED]", (string?)arr[0]!["token"]);
+        Assert.Equal("ok", (string?)arr[1]!["name"]);
+    }
 }

--- a/tests/OpenClaw.Tray.UITests/A2UI.cs
+++ b/tests/OpenClaw.Tray.UITests/A2UI.cs
@@ -128,6 +128,30 @@ public static class A2UI
     }
 
     /// <summary>
+    /// Build a dataModelUpdate line that writes a single v0.8 <c>valueArray</c>
+    /// of strings at <paramref name="key"/>. Mirrors how an agent seeds an
+    /// array-shaped value (e.g. <c>MultipleChoice.selections</c>) into the data
+    /// model — the array channel that was previously dropped on the wire.
+    /// </summary>
+    public static string DataUpdateStringArray(string surfaceId, string key, params string[] values)
+    {
+        var arr = new JsonArray();
+        foreach (var v in values) arr.Add(new JsonObject { ["valueString"] = v });
+        var contents = new JsonArray
+        {
+            new JsonObject { ["key"] = key, ["valueArray"] = arr },
+        };
+        return new JsonObject
+        {
+            ["dataModelUpdate"] = new JsonObject
+            {
+                ["surfaceId"] = surfaceId,
+                ["contents"] = contents,
+            },
+        }.ToJsonString();
+    }
+
+    /// <summary>
     /// Theme-styles object suitable for the <c>styles</c> argument of
     /// <see cref="Surface"/>. Mirrors what <see cref="OpenClawTray.A2UI.Theming.A2UITheme.Parse"/>
     /// reads on the wire.

--- a/tests/OpenClaw.Tray.UITests/A2UIControlMatrixTests.cs
+++ b/tests/OpenClaw.Tray.UITests/A2UIControlMatrixTests.cs
@@ -491,6 +491,62 @@ public sealed class A2UIControlMatrixTests
             Assert.Equal(4, lv.Items.Count);
         });
 
+    /// <summary>
+    /// End-to-end proof that a v0.8 <c>dataModelUpdate.valueArray</c> flows
+    /// through parser → <c>DataModelStore</c> → renderer. A multi-select
+    /// MultipleChoice bound to <c>/picked</c> is seeded with <c>["g","b"]</c>
+    /// via <c>valueArray</c>; the rendered ListView must preselect those two
+    /// options, and the surface snapshot must carry the array. Before the fix
+    /// the parser dropped the value and nothing was selected.
+    /// </summary>
+    [Fact]
+    public async Task MultipleChoice_Multi_ValueArraySeed_PreselectsAndSnapshots()
+    {
+        var surface = Surface("s", "mc", new[]
+        {
+            Component("mc", "MultipleChoice", new()
+            {
+                ["maxAllowedSelections"] = 3,
+                ["selections"] = Path("/picked"),
+                ["options"] = new System.Text.Json.Nodes.JsonArray
+                {
+                    Option("Red", "r"),
+                    Option("Green", "g"),
+                    Option("Blue", "b"),
+                },
+            }),
+        });
+        // Insert the valueArray seed between surfaceUpdate and beginRendering so
+        // the initial render reads it (the agent's typical "seed then render").
+        var nl = surface.IndexOf('\n');
+        var jsonl = surface.Substring(0, nl) + "\n"
+            + DataUpdateStringArray("s", "picked", "g", "b")
+            + surface.Substring(nl);
+
+        await _ui.PauseAsync("MultipleChoice multi ← valueArray seed");
+        await _ui.ResetContainerAsync();
+        await _ui.RunOnUIAsync(() =>
+        {
+            var harness = BuildHarness(_ui);
+            harness.Router.Push(jsonl);
+            Assert.NotNull(harness.LastSurface);
+
+            // Parser → store → snapshot round-trip: the array landed in the model.
+            var snapshot = harness.LastSurface!.GetSnapshot();
+            var picked = Assert.IsType<System.Text.Json.Nodes.JsonArray>(snapshot["dataModel"]!["picked"]);
+            Assert.Equal(new[] { "g", "b" }, picked.Select(n => n!.GetValue<string>()));
+
+            // Renderer read it: Green + Blue are preselected.
+            var lv = FindLogical<ListView>(harness.LastSurface.RootElement).Single();
+            var selected = lv.SelectedItems.OfType<ListViewItem>()
+                .Select(i => i.Tag as string)
+                .OrderBy(s => s, System.StringComparer.Ordinal)
+                .ToArray();
+            Assert.Equal(new[] { "b", "g" }, selected);
+        });
+        await _ui.PauseAsync();
+    }
+
     [Fact]
     public Task Slider_LiteralValue_AppliesRangeAndValue() => RunAsync(
         "Slider literal value",

--- a/tests/OpenClaw.Tray.UITests/A2UIDataModelStoreTests.cs
+++ b/tests/OpenClaw.Tray.UITests/A2UIDataModelStoreTests.cs
@@ -1,7 +1,11 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
+using OpenClawTray.A2UI.Rendering;
 using OpenClawTray.A2UI.Protocol;
+using OpenClawTray.A2UI.Theming;
 using Xunit;
 using static OpenClaw.Tray.UITests.TestSupport;
 
@@ -44,6 +48,110 @@ public sealed class A2UIDataModelStoreTests
             var node = harness.DataModel.Read("s", "/form/picked");
             var arr = Assert.IsType<JsonArray>(node);
             Assert.Equal(new[] { "g", "b" }, arr.Select(n => n!.GetValue<string>()));
+        });
+    }
+
+    [Fact]
+    public async Task ApplyDataModelUpdate_ValueArray_NotifiesElementPathSubscribers()
+    {
+        await _ui.RunOnUIAsync(() =>
+        {
+            var harness = BuildHarness(_ui);
+            var observable = harness.DataModel.GetOrCreate("s");
+            var notifications = 0;
+            using var subscription = observable.Subscribe("/codes/0", () => notifications++);
+
+            harness.DataModel.ApplyDataModelUpdate("s", null, new[]
+            {
+                new DataModelEntry
+                {
+                    Key = "codes",
+                    ValueArray = new[]
+                    {
+                        new DataModelEntry { Key = string.Empty, ValueString = "1234" },
+                    },
+                },
+            });
+
+            Assert.Equal(1, notifications);
+            Assert.Equal("1234", observable.ReadString("/codes/0"));
+        });
+    }
+
+    [Theory]
+    [InlineData("/codes/01")]
+    [InlineData("/codes/+1")]
+    [InlineData("/codes/ 1")]
+    public async Task Read_NonCanonicalArrayIndex_DoesNotResolve(string pointer)
+    {
+        await _ui.RunOnUIAsync(() =>
+        {
+            var harness = BuildHarness(_ui);
+            harness.DataModel.ApplyDataModelUpdate("s", null, new[]
+            {
+                new DataModelEntry
+                {
+                    Key = "codes",
+                    ValueArray = new[]
+                    {
+                        new DataModelEntry { Key = string.Empty, ValueString = "1234" },
+                        new DataModelEntry { Key = string.Empty, ValueString = "5678" },
+                    },
+                },
+            });
+
+            Assert.Null(harness.DataModel.Read("s", pointer));
+        });
+    }
+
+    [Theory]
+    [InlineData("/codes/1")]
+    [InlineData("/codes/01")]
+    public async Task BuildActionContext_RedactsRegisteredSecretArrayElement_WhenParentPathIsRequested(string secretPath)
+    {
+        await _ui.RunOnUIAsync(() =>
+        {
+            var ctx = BuildRenderContext(
+                JsonNode.Parse("""{ "codes": ["1234", "5678"] }""")!.AsObject(),
+                secretPath);
+            var source = BuildSourceComponent("""{ "dataBinding": ["/codes"] }""");
+            var action = JsonNode.Parse("""
+            {
+                "context": [
+                    { "key": "codes", "value": { "path": "/codes" } }
+                ]
+            }
+            """);
+
+            var result = ctx.BuildActionContext(source, action)!;
+
+            var codes = Assert.IsType<JsonArray>(result["codes"]);
+            Assert.Equal("1234", (string?)codes[0]);
+            Assert.Equal("[REDACTED]", (string?)codes[1]);
+        });
+    }
+
+    [Fact]
+    public async Task BuildActionContext_RedactsDenylistedDescendant_WhenParentPathIsRequested()
+    {
+        await _ui.RunOnUIAsync(() =>
+        {
+            var ctx = BuildRenderContext(
+                JsonNode.Parse("""{ "profile": { "name": "alice", "password": "p@ss" } }""")!.AsObject());
+            var source = BuildSourceComponent("""{ "dataBinding": ["/profile"] }""");
+            var action = JsonNode.Parse("""
+            {
+                "context": [
+                    { "key": "profile", "value": { "path": "/profile" } }
+                ]
+            }
+            """);
+
+            var result = ctx.BuildActionContext(source, action)!;
+
+            var profile = Assert.IsType<JsonObject>(result["profile"]);
+            Assert.Equal("alice", (string?)profile["name"]);
+            Assert.Equal("[REDACTED]", (string?)profile["password"]);
         });
     }
 
@@ -92,4 +200,32 @@ public sealed class A2UIDataModelStoreTests
             inner = new DataModelEntry { Key = "n", ValueMap = new[] { inner } };
         return new DataModelEntry { Key = key, ValueMap = new[] { inner } };
     }
+
+    private RenderContext BuildRenderContext(JsonObject seed, string? secretPath = null)
+    {
+        var harness = BuildHarness(_ui);
+        var observable = harness.DataModel.GetOrCreate("s", seed);
+        var secretPaths = new HashSet<string>(StringComparer.Ordinal);
+        var ctx = new RenderContext
+        {
+            SurfaceId = "s",
+            DataModel = observable,
+            Actions = harness.Actions,
+            Theme = A2UITheme.Empty,
+            BuildChild = _ => null,
+            Subscriptions = new Dictionary<string, IDisposable>(),
+            SecretPaths = secretPaths,
+        };
+
+        ctx.MarkSecretPath(secretPath);
+        return ctx;
+    }
+
+    private static A2UIComponentDef BuildSourceComponent(string propertiesJson) =>
+        new()
+        {
+            Id = "button",
+            ComponentName = "Button",
+            Properties = JsonNode.Parse(propertiesJson)!.AsObject(),
+        };
 }

--- a/tests/OpenClaw.Tray.UITests/A2UIDataModelStoreTests.cs
+++ b/tests/OpenClaw.Tray.UITests/A2UIDataModelStoreTests.cs
@@ -1,0 +1,95 @@
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using OpenClawTray.A2UI.Protocol;
+using Xunit;
+using static OpenClaw.Tray.UITests.TestSupport;
+
+namespace OpenClaw.Tray.UITests;
+
+/// <summary>
+/// Store-level coverage for the v0.8 <c>valueArray</c> data-model value driving
+/// the production <see cref="OpenClawTray.A2UI.DataModel.DataModelStore"/>.
+///
+/// These run on the UI thread because the store is dispatcher-affine. The parser
+/// happy paths live in OpenClaw.Tray.Tests/A2UIDataModelArrayTests; here we pin
+/// the bits that only the store enforces: array landing at a (base) path, and
+/// the depth guard that bounds nested arrays the same way it bounds nested maps.
+/// The depth guard is exercised by constructing <see cref="DataModelEntry"/>
+/// objects directly — JSONL would hit System.Text.Json's MaxDepth first.
+/// </summary>
+[Collection(UICollection.Name)]
+public sealed class A2UIDataModelStoreTests
+{
+    private readonly UIThreadFixture _ui;
+    public A2UIDataModelStoreTests(UIThreadFixture ui) => _ui = ui;
+
+    [Fact]
+    public async Task ApplyDataModelUpdate_ValueArray_LandsAtBasePath()
+    {
+        await _ui.RunOnUIAsync(() =>
+        {
+            var harness = BuildHarness(_ui);
+            var entry = new DataModelEntry
+            {
+                Key = "picked",
+                ValueArray = new[]
+                {
+                    new DataModelEntry { Key = string.Empty, ValueString = "g" },
+                    new DataModelEntry { Key = string.Empty, ValueString = "b" },
+                },
+            };
+            harness.DataModel.ApplyDataModelUpdate("s", "/form", new[] { entry });
+
+            var node = harness.DataModel.Read("s", "/form/picked");
+            var arr = Assert.IsType<JsonArray>(node);
+            Assert.Equal(new[] { "g", "b" }, arr.Select(n => n!.GetValue<string>()));
+        });
+    }
+
+    [Fact]
+    public async Task ApplyDataModelUpdate_OverDeepValueArray_IsDroppedByDepthGuard()
+    {
+        await _ui.RunOnUIAsync(() =>
+        {
+            var harness = BuildHarness(_ui);
+
+            // Shallow array survives; a >32-deep nest is rejected by the same
+            // guard that bounds valueMap, so the path stays unset.
+            harness.DataModel.ApplyDataModelUpdate("s", null, new[] { DeepArrayEntry("shallow", 4) });
+            harness.DataModel.ApplyDataModelUpdate("s", null, new[] { DeepArrayEntry("tooDeep", 40) });
+
+            Assert.IsType<JsonArray>(harness.DataModel.Read("s", "/shallow"));
+            Assert.Null(harness.DataModel.Read("s", "/tooDeep"));
+        });
+    }
+
+    [Fact]
+    public async Task ApplyDataModelUpdate_OverDeepValueMap_StillDropped_NoRegression()
+    {
+        await _ui.RunOnUIAsync(() =>
+        {
+            var harness = BuildHarness(_ui);
+            harness.DataModel.ApplyDataModelUpdate("s", null, new[] { DeepMapEntry("deepMap", 40) });
+            Assert.Null(harness.DataModel.Read("s", "/deepMap"));
+        });
+    }
+
+    /// <summary>Build an entry whose value is <paramref name="depth"/> nested valueArrays.</summary>
+    private static DataModelEntry DeepArrayEntry(string key, int depth)
+    {
+        DataModelEntry inner = new() { Key = string.Empty, ValueString = "x" };
+        for (int i = 0; i < depth; i++)
+            inner = new DataModelEntry { Key = string.Empty, ValueArray = new[] { inner } };
+        return new DataModelEntry { Key = key, ValueArray = new[] { inner } };
+    }
+
+    /// <summary>Build an entry whose value is <paramref name="depth"/> nested valueMaps.</summary>
+    private static DataModelEntry DeepMapEntry(string key, int depth)
+    {
+        DataModelEntry inner = new() { Key = "leaf", ValueString = "x" };
+        for (int i = 0; i < depth; i++)
+            inner = new DataModelEntry { Key = "n", ValueMap = new[] { inner } };
+        return new DataModelEntry { Key = key, ValueMap = new[] { inner } };
+    }
+}


### PR DESCRIPTION
## Summary

The v0.8 `dataModelUpdate.valueArray` typed value was **silently dropped** by the native WinUI A2UI parser — `DataModelEntry` had no `ValueArray` field and `ToJsonNode()` returned `null` for it. Only `valueString`/`valueNumber`/`valueBoolean`/`valueMap` were handled.

This broke seeding an array into a surface's data model — most visibly a multi-select `MultipleChoice` bound to a path could never be pre-populated — even though `valueArray` is part of the v0.8 protocol (`docs/a2ui/protocol.md` §2.2 and `docs/a2ui/data-and-actions.md`).

## What changed

- **Parser** (`A2UIProtocol.cs`): add `DataModelEntry.ValueArray`; `ToJsonNode()` emits a real `JsonArray`; new `ParseValueArray`/`ParseArrayElement` handle value-typed object elements (`{"valueString":"x"}`), bare-primitive tolerance (`["a",1,true]`), nested maps/arrays, and preserve a JSON `null` (or value-less `{}`) as a **stable index slot** so position-sensitive consumers don't see shifted indices.
- **DoS guard** (`DataModelStore.cs`): the existing 32-deep depth bound now recurses `valueArray` as well as `valueMap`, so deep nesting can't be smuggled in through an array.
- **Security** (`SecretRedactor.cs`): the `JsonArray` redaction branch now checks each element path against the registered/denylist set **before** recursing (mirroring the object branch). Previously arrays only recursed, so a secret seeded into an array (e.g. an obscured `TextField` bound to `/codes/0`) could leak through `canvas.a2ui.dump`.
- **Docs** (`SKILL.md`): correct the stale "arrays are not first-class" note.

## Why it's safe

- Purely additive on the wire; existing scalar/`valueMap` behavior is unchanged and regression-tested.
- `System.Text.Json` `TryGetValue<T>` is strict (no cross-kind coercion), so the bare-primitive string→bool→number detection can't mis-tag a value.
- Malformed "both map and array set" deterministically prefers the map; never throws.
- The redaction change can only **over**-redact, never under-redact.

## Tests

- `A2UIDataModelArrayTests.cs` (new) — parser coverage: strings, mixed scalars, maps, nested arrays, bare primitives, empty, and null/value-less slots, plus `valueMap`/scalar regressions.
- `SecretRedactorTests.cs` — array-redaction regressions: registered element, registered array parent, denylisted scalar inside an array.
- `A2UIDataModelStoreTests.cs` (new) — store base-path landing + `valueArray` depth-guard rejection + `valueMap` depth regression.
- `A2UIControlMatrixTests.cs` — end-to-end: `MultipleChoice` (multi) seeded via `valueArray` asserts both the snapshot array **and** the rendered ListView preselection (parser → store → renderer round-trip).

## Validation

`./build.ps1` (all projects), `OpenClaw.Shared.Tests`, `OpenClaw.Tray.Tests`, and the A2UI `OpenClaw.Tray.UITests` all pass (`OPENCLAW_REPO_ROOT` set per AGENTS.md).

## Proof

I ran temporary proof-only harnesses locally to print the actual behavior, then removed those harnesses so they are not part of this PR.

### Parser + redaction behavior

Input behavior exercised:

```json
{"dataModelUpdate":{"surfaceId":"s","path":"/form","contents":[{"key":"picked","valueArray":[{"valueString":"red"},{"valueString":"blue"}]}]}}
```

Terminal output from the proof run:

```text
valueArray path: /form
valueArray stored JSON: ["red","blue"]
registered secret paths: /codes/0
redacted dump JSON: {"codes":["[REDACTED]","5678"]}
```

This proves the parser stores a real JSON array at the scoped path and that a registered secret array element is redacted instead of leaking through dump/snapshot output.

### WinUI rendered state behavior

The WinUI proof seeded a multi-select `MultipleChoice` with:

```json
{"dataModelUpdate":{"surfaceId":"s","contents":[{"key":"picked","valueArray":[{"valueString":"g"},{"valueString":"b"}]}]}}
```

Terminal output from the proof run:

```text
snapshot dataModel.picked JSON: ["g","b"]
rendered ListView selected tags: b,g
```

This proves the value flows through parser → data model store → surface snapshot → native WinUI renderer: the snapshot carries the JSON array and the rendered `ListView` has Green/Blue preselected.

## Known limitations (pre-existing, out of scope)

- Nested array/map **breadth** is bounded only by the 1 MiB line cap — identical to the existing `valueMap` behavior; a shared element-count budget would be a separate change.
- `BuildActionContext` deep-clones a non-secret subtree without redacting nested secret-named descendants — pre-existing, applies to `valueMap` too, not introduced here.
