### PR TITLE
Add resilient TTS fallback and readiness status

### DIFF
--- a/src/OpenClaw.SetupEngine/SetupContext.cs
+++ b/src/OpenClaw.SetupEngine/SetupContext.cs
@@ -143,7 +143,7 @@ public sealed class CapabilitiesConfig
         if (Screen) result.Add(("screen", ["screen.snapshot", "screen.record"]));
         if (Camera) result.Add(("camera", ["camera.list", "camera.snap", "camera.clip"]));
         if (Location) result.Add(("location", ["location.get"]));
-        if (Tts) result.Add(("tts", ["tts.speak"]));
+        if (Tts) result.Add(("tts", ["tts.speak", "tts.status"]));
         if (Stt) result.Add(("stt", ["stt.transcribe", "stt.listen", "stt.status"]));
         if (Device) result.Add(("device", ["device.info", "device.status"]));
         if (Browser) result.Add(("browser", ["browser.proxy"]));

--- a/src/OpenClaw.Shared/Audio/PiperVoiceManager.cs
+++ b/src/OpenClaw.Shared/Audio/PiperVoiceManager.cs
@@ -27,9 +27,9 @@ namespace OpenClaw.Shared.Audio;
 ///
 /// Each voice is ~50 MB compressed, ~80 MB extracted (with espeak data).
 ///
-/// **TODO (pre-GA):** SHA-256 verification of downloaded tarballs before
-/// extraction (Audio_FollowUps.md §2). The current implementation trusts
-/// HTTPS + the system trust chain only.
+/// **Integrity:** downloaded tarballs are SHA-256-verified against the pinned
+/// hash in <see cref="AvailableVoices"/> before extraction; a mismatch is a
+/// hard failure and the partial file is deleted (see Audio_FollowUps.md §2).
 /// </summary>
 public sealed class PiperVoiceManager
 {

--- a/src/OpenClaw.Shared/Capabilities/TtsCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/TtsCapability.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,6 +9,7 @@ namespace OpenClaw.Shared.Capabilities;
 public sealed class TtsCapability : NodeCapabilityBase
 {
     public const string SpeakCommand = "tts.speak";
+    public const string StatusCommand = "tts.status";
     public const string WindowsProvider = "windows";
     public const string ElevenLabsProvider = "elevenlabs";
     /// <summary>
@@ -17,12 +19,38 @@ public sealed class TtsCapability : NodeCapabilityBase
     public const string PiperProvider = "piper";
     public const int MaxTextLength = 5000;
 
-    private static readonly string[] _commands = [SpeakCommand];
+    // ============================================================
+    // Provider readiness reasons (PII-free; surfaced by tts.status and used
+    // by the fallback resolver below). Kept as string constants rather than
+    // an enum so the wire shape mirrors stt.status's readiness string.
+    // ============================================================
+
+    /// <summary>Provider can serve a speak call right now.</summary>
+    public const string ReadinessReady = "ready";
+    /// <summary>ElevenLabs selected but no API key is configured.</summary>
+    public const string ReadinessNeedsApiKey = "needs-api-key";
+    /// <summary>ElevenLabs selected with a key but no voice id is configured.</summary>
+    public const string ReadinessNeedsVoice = "needs-voice";
+    /// <summary>Piper selected but the chosen voice isn't downloaded yet.</summary>
+    public const string ReadinessVoiceNotDownloaded = "voice-not-downloaded";
+    /// <summary>Provider is unknown or otherwise unusable.</summary>
+    public const string ReadinessUnavailable = "unavailable";
+
+    /// <summary>All known providers, in catalog order (Piper is the default).</summary>
+    public static readonly string[] AllProviders = [PiperProvider, WindowsProvider, ElevenLabsProvider];
+
+    private static readonly string[] _commands = [SpeakCommand, StatusCommand];
 
     public override string Category => "tts";
     public override IReadOnlyList<string> Commands => _commands;
 
     public event Func<TtsSpeakArgs, CancellationToken, Task<TtsSpeakResult>>? SpeakRequested;
+
+    /// <summary>
+    /// Tray-side handler for <see cref="StatusCommand"/>: reports per-provider
+    /// readiness plus the configured/effective provider. Carries no PII.
+    /// </summary>
+    public event Func<CancellationToken, Task<TtsStatusResult>>? StatusRequested;
 
     public TtsCapability(IOpenClawLogger logger) : base(logger)
     {
@@ -39,6 +67,47 @@ public sealed class TtsCapability : NodeCapabilityBase
             : provider.Trim().ToLowerInvariant();
     }
 
+    /// <summary>
+    /// Resolve the provider that should actually serve a speak request given
+    /// the set of providers that are currently usable. The requested (then
+    /// configured, then default) provider wins when it is usable. Fallback to
+    /// Windows is limited to configured/default provider degradation; explicit
+    /// provider requests stay strict so callers can rely on provider selection.
+    /// When no provider is usable (should not happen because Windows is always
+    /// available) the preferred provider is returned unchanged so the caller's
+    /// downstream error stays meaningful.
+    /// </summary>
+    /// <param name="requestedProvider">Per-call provider override (may be null).</param>
+    /// <param name="configuredProvider">User's configured default provider.</param>
+    /// <param name="readyProviders">Lower-cased provider ids that can serve a call now.</param>
+    public static TtsProviderResolution ResolveEffectiveProvider(
+        string? requestedProvider,
+        string? configuredProvider,
+        IReadOnlySet<string> readyProviders,
+        bool allowFallback)
+    {
+        ArgumentNullException.ThrowIfNull(readyProviders);
+
+        var preferred = ResolveProvider(requestedProvider, configuredProvider);
+        if (readyProviders.Contains(preferred))
+            return new TtsProviderResolution(preferred, preferred, FellBack: false);
+
+        // Windows is the always-offline safety net for configured/default
+        // provider degradation. Explicit per-call provider requests stay
+        // strict and are not silently rerouted.
+        if (allowFallback
+            && !string.Equals(preferred, WindowsProvider, StringComparison.Ordinal)
+            && readyProviders.Contains(WindowsProvider))
+        {
+            return new TtsProviderResolution(preferred, WindowsProvider, FellBack: true);
+        }
+
+        // Nothing usable — surface the preferred provider so the dispatch
+        // layer's "not configured" error is about the provider the user asked
+        // for, not an arbitrary fallback.
+        return new TtsProviderResolution(preferred, preferred, FellBack: false);
+    }
+
     public override Task<NodeInvokeResponse> ExecuteAsync(NodeInvokeRequest request)
         => ExecuteAsync(request, CancellationToken.None);
 
@@ -46,6 +115,9 @@ public sealed class TtsCapability : NodeCapabilityBase
         NodeInvokeRequest request,
         CancellationToken cancellationToken)
     {
+        if (string.Equals(request.Command, StatusCommand, StringComparison.Ordinal))
+            return await HandleStatusAsync(cancellationToken).ConfigureAwait(false);
+
         if (!string.Equals(request.Command, SpeakCommand, StringComparison.Ordinal))
             return Error($"Unknown command: {request.Command}");
 
@@ -76,6 +148,8 @@ public sealed class TtsCapability : NodeCapabilityBase
             {
                 spoken = result.Spoken,
                 provider = result.Provider,
+                requestedProvider = result.RequestedProvider ?? result.Provider,
+                fellBack = result.FellBack,
                 contentType = result.ContentType,
                 durationMs = result.DurationMs
             });
@@ -97,6 +171,36 @@ public sealed class TtsCapability : NodeCapabilityBase
         }
     }
 
+    private async Task<NodeInvokeResponse> HandleStatusAsync(CancellationToken cancellationToken)
+    {
+        if (StatusRequested == null)
+            return Error("TTS status not available");
+
+        try
+        {
+            var result = await StatusRequested(cancellationToken).ConfigureAwait(false);
+            return Success(new
+            {
+                configuredProvider = result.ConfiguredProvider,
+                effectiveProvider = result.EffectiveProvider,
+                willFallBack = result.WillFallBack,
+                providers = result.Providers.Select(p => new
+                {
+                    provider = p.Provider,
+                    readiness = p.Readiness,
+                    isReady = p.IsReady
+                }).ToArray()
+            });
+        }
+        catch (Exception ex)
+        {
+            // Status must not leak provider internals (voice ids, key
+            // fragments, device names); carry only a fixed message.
+            Logger.Error("TTS status failed", ex);
+            return Error("Status failed");
+        }
+    }
+
     private static string? NormalizeOptional(string? value)
         => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 }
@@ -114,6 +218,65 @@ public sealed class TtsSpeakResult
 {
     public bool Spoken { get; set; } = true;
     public string Provider { get; set; } = TtsCapability.WindowsProvider;
+
+    /// <summary>
+    /// The provider that was originally requested/configured before any
+    /// fallback. Equals <see cref="Provider"/> when no fallback occurred.
+    /// Null is treated as "same as Provider" by the response surface.
+    /// </summary>
+    public string? RequestedProvider { get; set; }
+
+    /// <summary>
+    /// True when the requested/configured provider was not usable and the
+    /// service fell back to another provider (Windows) to serve the call.
+    /// </summary>
+    public bool FellBack { get; set; }
+
     public string? ContentType { get; set; }
     public int? DurationMs { get; set; }
+}
+
+/// <summary>
+/// Result of <see cref="TtsCapability.ResolveEffectiveProvider"/>: the
+/// provider originally preferred and the one that should actually serve the
+/// call after fallback.
+/// </summary>
+/// <param name="RequestedProvider">The resolved requested/configured provider before fallback.</param>
+/// <param name="EffectiveProvider">The provider that should serve the call.</param>
+/// <param name="FellBack">True when <paramref name="EffectiveProvider"/> differs from <paramref name="RequestedProvider"/> because the latter wasn't usable.</param>
+public readonly record struct TtsProviderResolution(
+    string RequestedProvider,
+    string EffectiveProvider,
+    bool FellBack);
+
+/// <summary>Per-provider readiness snapshot (PII-free) for <c>tts.status</c>.</summary>
+public sealed class TtsProviderStatus
+{
+    public string Provider { get; set; } = "";
+    /// <summary>
+    /// One of <see cref="TtsCapability.ReadinessReady"/>,
+    /// <see cref="TtsCapability.ReadinessNeedsApiKey"/>,
+    /// <see cref="TtsCapability.ReadinessNeedsVoice"/>,
+    /// <see cref="TtsCapability.ReadinessVoiceNotDownloaded"/>, or
+    /// <see cref="TtsCapability.ReadinessUnavailable"/>.
+    /// </summary>
+    public string Readiness { get; set; } = TtsCapability.ReadinessUnavailable;
+    public bool IsReady { get; set; }
+}
+
+/// <summary>
+/// Status surface for TTS, mirroring <c>stt.status</c>. Reports the
+/// configured default provider, the provider that would actually run now
+/// (after fallback), and per-provider readiness. The configured/effective
+/// view reflects the configured defaults only — a specific <c>tts.speak</c>
+/// call that supplies its own voiceId can still avoid a fallback that this
+/// snapshot reports. Carries no PII (no voice ids, no key fragments, no
+/// device names).
+/// </summary>
+public sealed class TtsStatusResult
+{
+    public string ConfiguredProvider { get; set; } = TtsCapability.PiperProvider;
+    public string EffectiveProvider { get; set; } = TtsCapability.PiperProvider;
+    public bool WillFallBack { get; set; }
+    public IReadOnlyList<TtsProviderStatus> Providers { get; set; } = Array.Empty<TtsProviderStatus>();
 }

--- a/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
+++ b/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
@@ -247,7 +247,9 @@ public class McpToolBridge
 
         // tts.*
         ["tts.speak"] =
-            "Speak text aloud on the Windows node. Args: text (string, required), provider ('piper'|'windows'|'elevenlabs', optional — falls back to the configured TtsProvider setting, default 'piper' for fresh installs), voiceId (string, optional — overrides the per-provider configured voice), model (string, optional, ElevenLabs only), interrupt (bool, default false — interrupts any in-progress playback). Returns { spoken, provider, contentType, durationMs }.",
+            "Speak text aloud on the Windows node. Args: text (string, required), provider ('piper'|'windows'|'elevenlabs', optional — omit to use the configured TtsProvider setting, default 'piper' for fresh installs), voiceId (string, optional — overrides the per-provider configured voice), model (string, optional, ElevenLabs only), interrupt (bool, default false — interrupts any in-progress playback). When provider is omitted and the configured provider isn't usable (no ElevenLabs key, Piper voice not downloaded), the node falls back to Windows TTS so playback still happens. Explicit provider requests stay strict and do not silently reroute. Returns { spoken, provider (the provider that actually spoke), requestedProvider, fellBack, contentType, durationMs }.",
+        ["tts.status"] =
+            "Report TTS provider readiness. No args. Returns { configuredProvider, effectiveProvider (the provider that would run now after fallback), willFallBack (bool), providers: [{ provider ('piper'|'windows'|'elevenlabs'), readiness ('ready'|'needs-api-key'|'needs-voice'|'voice-not-downloaded'|'unavailable'), isReady (bool) }] }. Carries no PII (no voice ids, no key fragments, no device names). Requires NodeTtsEnabled.",
 
         // app.*
         ["app.navigate"] =

--- a/src/OpenClaw.Shared/Models.cs
+++ b/src/OpenClaw.Shared/Models.cs
@@ -1160,6 +1160,7 @@ public static class CommandCenterCommandGroups
     public static readonly string[] DangerousCommands =
     [
         .. CommonDangerousCommands,
+        "tts.status",
         "stt.transcribe",
         "stt.listen",
         "stt.status"

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatCoordinator.cs
@@ -138,7 +138,9 @@ public sealed class OpenClawChatCoordinator : IDisposable
             var speakArgs = new TtsSpeakArgs
             {
                 Text = speakText,
-                Provider = _settings.TtsProvider ?? TtsCapability.PiperProvider,
+                // Leave provider unset so TextToSpeechService treats this as
+                // configured/default playback and can fall back when needed.
+                Provider = null,
                 Interrupt = true
             };
 

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -367,6 +367,7 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
             _textToSpeechService ??= new TextToSpeechService(_logger, settings);
             _ttsCapability = new TtsCapability(_logger);
             _ttsCapability.SpeakRequested += OnTtsSpeakAsync;
+            _ttsCapability.StatusRequested += OnTtsStatusAsync;
             Register(_ttsCapability);
         }
 
@@ -1866,6 +1867,14 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
             throw new InvalidOperationException("Text-to-speech service not available");
 
         return _textToSpeechService.SpeakAsync(args, cancellationToken);
+    }
+
+    private Task<TtsStatusResult> OnTtsStatusAsync(CancellationToken cancellationToken)
+    {
+        if (_textToSpeechService == null)
+            throw new InvalidOperationException("Text-to-speech service not available");
+
+        return Task.FromResult(_textToSpeechService.GetStatus());
     }
 
     // ============================================================

--- a/src/OpenClaw.Tray.WinUI/Services/TextToSpeech/TextToSpeechService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/TextToSpeech/TextToSpeechService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -50,8 +51,36 @@ public sealed class TextToSpeechService : IDisposable
 
     public async Task<TtsSpeakResult> SpeakAsync(TtsSpeakArgs args, CancellationToken cancellationToken = default)
     {
-        var provider = TtsCapability.ResolveProvider(args.Provider, _settings.TtsProvider);
+        // Resolve the provider that should actually serve this call. When the
+        // configured/default provider isn't usable (no ElevenLabs key, Piper
+        // voice not downloaded), fall back to Windows TTS so the assistant can
+        // still talk instead of failing the call outright. Explicit per-call
+        // provider requests stay strict so callers can rely on provider
+        // selection.
+        var readyProviders = BuildReadyProviderSet(args);
+        var allowFallback = string.IsNullOrWhiteSpace(args.Provider);
+        var resolution = TtsCapability.ResolveEffectiveProvider(
+            args.Provider, _settings.TtsProvider, readyProviders, allowFallback);
+        var provider = resolution.EffectiveProvider;
         var stopwatch = Stopwatch.StartNew();
+
+        if (resolution.FellBack)
+        {
+            // The per-call voiceId/model were meant for the originally
+            // requested provider; they're meaningless (and would throw, e.g.
+            // "Windows TTS voice '<piper-id>' was not found") on the fallback
+            // provider. Drop them so the fallback uses its own configured voice.
+            _logger.Info(
+                $"TTS provider '{resolution.RequestedProvider}' not usable; falling back to '{provider}'");
+            args = new TtsSpeakArgs
+            {
+                Text = args.Text,
+                Provider = provider,
+                VoiceId = null,
+                Model = null,
+                Interrupt = args.Interrupt
+            };
+        }
 
         if (string.Equals(provider, TtsCapability.WindowsProvider, StringComparison.OrdinalIgnoreCase))
         {
@@ -74,6 +103,8 @@ public sealed class TextToSpeechService : IDisposable
         return new TtsSpeakResult
         {
             Provider = provider,
+            RequestedProvider = resolution.RequestedProvider,
+            FellBack = resolution.FellBack,
             ContentType = string.Equals(provider, TtsCapability.ElevenLabsProvider, StringComparison.OrdinalIgnoreCase)
                 ? "audio/mpeg"
                 : "audio/wav",
@@ -81,22 +112,135 @@ public sealed class TextToSpeechService : IDisposable
         };
     }
 
+    /// <summary>
+    /// Snapshot per-provider readiness plus the configured/effective default
+    /// provider, for the <c>tts.status</c> surface and Settings UI. PII-free:
+    /// reports only readiness states, never voice ids or key fragments.
+    /// </summary>
+    public TtsStatusResult GetStatus()
+    {
+        var providers = new List<TtsProviderStatus>(TtsCapability.AllProviders.Length);
+        foreach (var p in TtsCapability.AllProviders)
+        {
+            var readiness = GetProviderReadiness(p, args: null);
+            providers.Add(new TtsProviderStatus
+            {
+                Provider = p,
+                Readiness = readiness,
+                IsReady = string.Equals(readiness, TtsCapability.ReadinessReady, StringComparison.Ordinal)
+            });
+        }
+
+        var ready = providers
+            .Where(s => s.IsReady)
+            .Select(s => s.Provider)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var configured = TtsCapability.ResolveProvider(null, _settings.TtsProvider);
+        var resolution = TtsCapability.ResolveEffectiveProvider(
+            null,
+            _settings.TtsProvider,
+            ready,
+            allowFallback: true);
+
+        return new TtsStatusResult
+        {
+            ConfiguredProvider = configured,
+            EffectiveProvider = resolution.EffectiveProvider,
+            WillFallBack = resolution.FellBack,
+            Providers = providers
+        };
+    }
+
+    /// <summary>
+    /// Build the set of providers that can serve a call right now, taking the
+    /// per-call <paramref name="args"/> into account (a per-call voiceId can
+    /// make ElevenLabs/Piper usable even when no default is configured).
+    /// </summary>
+    private HashSet<string> BuildReadyProviderSet(TtsSpeakArgs? args)
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var p in TtsCapability.AllProviders)
+        {
+            if (string.Equals(GetProviderReadiness(p, args), TtsCapability.ReadinessReady, StringComparison.Ordinal))
+                set.Add(p);
+        }
+        return set;
+    }
+
+    /// <summary>
+    /// Determine a single provider's readiness. <paramref name="args"/> is
+    /// honored when present so a per-call voiceId counts toward readiness;
+    /// pass null for the configured-defaults view used by <see cref="GetStatus"/>.
+    /// </summary>
+    private string GetProviderReadiness(string provider, TtsSpeakArgs? args)
+    {
+        if (string.Equals(provider, TtsCapability.WindowsProvider, StringComparison.OrdinalIgnoreCase))
+        {
+            // The OS speech stack always has at least the default system voice.
+            return TtsCapability.ReadinessReady;
+        }
+
+        if (string.Equals(provider, TtsCapability.ElevenLabsProvider, StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrWhiteSpace(_settings.TtsElevenLabsApiKey))
+                return TtsCapability.ReadinessNeedsApiKey;
+
+            var voiceId = !string.IsNullOrWhiteSpace(args?.VoiceId)
+                ? args!.VoiceId
+                : _settings.TtsElevenLabsVoiceId;
+            return string.IsNullOrWhiteSpace(voiceId)
+                ? TtsCapability.ReadinessNeedsVoice
+                : TtsCapability.ReadinessReady;
+        }
+
+        if (string.Equals(provider, TtsCapability.PiperProvider, StringComparison.OrdinalIgnoreCase))
+        {
+            var voiceId = !string.IsNullOrWhiteSpace(args?.VoiceId)
+                ? args!.VoiceId!
+                : _settings.TtsPiperVoiceId;
+            if (string.IsNullOrWhiteSpace(voiceId))
+                return TtsCapability.ReadinessNeedsVoice;
+            return _piperVoices.IsVoiceDownloaded(voiceId)
+                ? TtsCapability.ReadinessReady
+                : TtsCapability.ReadinessVoiceNotDownloaded;
+        }
+
+        return TtsCapability.ReadinessUnavailable;
+    }
+
     private async Task SpeakWithWindowsAsync(TtsSpeakArgs args, CancellationToken cancellationToken)
     {
         using var synthesizer = new SpeechSynthesizer();
-        var requestedVoice = string.IsNullOrWhiteSpace(args.VoiceId)
-            ? _settings.TtsWindowsVoiceId
-            : args.VoiceId;
+
+        // Distinguish an explicit per-call voice from the configured default.
+        // An explicit per-call voice that can't be resolved is a caller error
+        // and throws. A stale/removed *configured* voice must NOT throw — that
+        // would break the always-available fallback guarantee (a provider that
+        // fell back to Windows would still fail). In that case we silently use
+        // the synthesizer's system default voice.
+        var explicitVoice = !string.IsNullOrWhiteSpace(args.VoiceId);
+        var requestedVoice = explicitVoice ? args.VoiceId : _settings.TtsWindowsVoiceId;
         if (!string.IsNullOrWhiteSpace(requestedVoice))
         {
             requestedVoice = requestedVoice.Trim();
             var voice = SpeechSynthesizer.AllVoices.FirstOrDefault(v =>
                 string.Equals(v.Id, requestedVoice, StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(v.DisplayName, requestedVoice, StringComparison.OrdinalIgnoreCase));
-            if (voice == null)
+            if (voice != null)
+            {
+                synthesizer.Voice = voice;
+            }
+            else if (explicitVoice)
+            {
                 throw new InvalidOperationException($"Windows TTS voice '{requestedVoice}' was not found.");
-
-            synthesizer.Voice = voice;
+            }
+            else
+            {
+                // Configured voice no longer installed — fall through with the
+                // system default so playback still happens.
+                _logger.Info("Configured Windows TTS voice not found; using system default voice");
+            }
         }
 
         using var stream = await synthesizer

--- a/src/OpenClaw.WinNode.Cli/skill.md
+++ b/src/OpenClaw.WinNode.Cli/skill.md
@@ -272,13 +272,27 @@ Speak text aloud on the Windows node.
 ```
 {
   "text": "string",           // required
-  "provider": "piper|windows|elevenlabs",  // optional, falls back to TtsProvider setting
+  "provider": "piper|windows|elevenlabs",  // optional; omit to use TtsProvider setting
   "voiceId": "string",        // optional, overrides the per-provider configured voice
   "model": "string",          // optional, ElevenLabs only
   "interrupt": false          // default false; true cuts off any in-progress playback
 }
 ```
-Returns `{ spoken, provider, contentType, durationMs }`.
+When `provider` is omitted and the configured provider isn't usable (no
+ElevenLabs key, Piper voice not downloaded), the node falls back to Windows
+TTS so playback still happens. Explicit `provider` requests stay strict and
+do not silently reroute. Returns `{ spoken, provider, requestedProvider, fellBack, contentType, durationMs }`
+where `provider` is the provider that actually spoke.
+
+### tts.status
+TTS provider readiness. No params. Carries no PII (no voice ids, no key
+fragments, no device names).
+Returns `{ configuredProvider, effectiveProvider, willFallBack, providers[{ provider, readiness, isReady }] }`
+where `effectiveProvider` is what would run now after fallback and `readiness`
+∈ `"ready" | "needs-api-key" | "needs-voice" | "voice-not-downloaded" | "unavailable"`.
+The configured/effective view reflects configured defaults only; explicit
+`tts.speak` provider requests stay strict and may not match the default
+snapshot.
 
 ## App control (app.*)
 

--- a/tests/OpenClaw.SetupEngine.Tests/SetupConfigTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupConfigTests.cs
@@ -180,6 +180,7 @@ public class SetupConfigTests : IDisposable
 
         Assert.Contains("system.notify", commands);
         Assert.Contains("tts.speak", commands);
+        Assert.Contains("tts.status", commands);
         Assert.DoesNotContain("camera.snap", commands);
         Assert.DoesNotContain("stt.listen", commands);
         Assert.Equal(commands.Count, commands.Distinct(StringComparer.OrdinalIgnoreCase).Count());

--- a/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
@@ -3155,6 +3155,152 @@ public class TtsCapabilityTests
         Assert.False(res.Ok);
         Assert.Contains("Unknown command", res.Error);
     }
+
+    [Fact]
+    public void Commands_IncludeSpeakAndStatus()
+    {
+        var cap = new TtsCapability(NullLogger.Instance);
+
+        Assert.Contains(TtsCapability.SpeakCommand, cap.Commands);
+        Assert.Contains(TtsCapability.StatusCommand, cap.Commands);
+        Assert.True(cap.CanHandle("tts.status"));
+    }
+
+    [Theory]
+    // Preferred provider is ready → no fallback.
+    [InlineData("piper", "piper", "piper,windows", false, "piper", "piper", false)]
+    [InlineData("elevenlabs", "piper", "elevenlabs,windows", false, "elevenlabs", "elevenlabs", false)]
+    // Configured/default preferred provider not ready, Windows available → fall back to Windows.
+    [InlineData(null, "piper", "windows", true, "piper", "windows", true)]
+    [InlineData(null, "elevenlabs", "windows", true, "elevenlabs", "windows", true)]
+    // Explicit provider requests stay strict and do not silently reroute.
+    [InlineData("piper", "windows", "windows", false, "piper", "piper", false)]
+    [InlineData("elevenlabs", "windows", "windows", false, "elevenlabs", "elevenlabs", false)]
+    [InlineData("unknown-provider", "windows", "windows", false, "unknown-provider", "unknown-provider", false)]
+    // Preferred IS Windows but somehow not ready → no self-fallback.
+    [InlineData("windows", "windows", "piper", false, "windows", "windows", false)]
+    // Nothing ready → preferred returned unchanged so the dispatch error is meaningful.
+    [InlineData(null, "elevenlabs", "", true, "elevenlabs", "elevenlabs", false)]
+    public void ResolveEffectiveProvider_FallsBackToWindows(
+        string? requested,
+        string? configured,
+        string readyCsv,
+        bool allowFallback,
+        string expectedRequested,
+        string expectedEffective,
+        bool expectedFellBack)
+    {
+        var ready = readyCsv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var resolution = TtsCapability.ResolveEffectiveProvider(requested, configured, ready, allowFallback);
+
+        Assert.Equal(expectedRequested, resolution.RequestedProvider);
+        Assert.Equal(expectedEffective, resolution.EffectiveProvider);
+        Assert.Equal(expectedFellBack, resolution.FellBack);
+    }
+
+    [Fact]
+    public async Task Speak_Projection_IncludesRequestedProviderAndFellBack()
+    {
+        var cap = new TtsCapability(NullLogger.Instance);
+        cap.SpeakRequested += (_, _) => Task.FromResult(new TtsSpeakResult
+        {
+            Provider = TtsCapability.WindowsProvider,
+            RequestedProvider = TtsCapability.ElevenLabsProvider,
+            FellBack = true,
+            ContentType = "audio/wav",
+            DurationMs = 50
+        });
+
+        var res = await cap.ExecuteAsync(new NodeInvokeRequest
+        {
+            Id = "tts-fallback",
+            Command = "tts.speak",
+            Args = Parse("""{"text":"hello","provider":"elevenlabs"}""")
+        });
+
+        Assert.True(res.Ok);
+        var json = JsonSerializer.Serialize(res.Payload);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal("windows", root.GetProperty("provider").GetString());
+        Assert.Equal("elevenlabs", root.GetProperty("requestedProvider").GetString());
+        Assert.True(root.GetProperty("fellBack").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Status_ReturnsError_WhenNoHandler()
+    {
+        var cap = new TtsCapability(NullLogger.Instance);
+
+        var res = await cap.ExecuteAsync(new NodeInvokeRequest
+        {
+            Id = "tts-status-unavailable",
+            Command = "tts.status",
+            Args = Parse("""{}""")
+        });
+
+        Assert.False(res.Ok);
+        Assert.Contains("not available", res.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Status_ProjectsProviderReadiness()
+    {
+        var cap = new TtsCapability(NullLogger.Instance);
+        cap.StatusRequested += _ => Task.FromResult(new TtsStatusResult
+        {
+            ConfiguredProvider = TtsCapability.PiperProvider,
+            EffectiveProvider = TtsCapability.WindowsProvider,
+            WillFallBack = true,
+            Providers =
+            [
+                new TtsProviderStatus { Provider = TtsCapability.PiperProvider, Readiness = TtsCapability.ReadinessVoiceNotDownloaded, IsReady = false },
+                new TtsProviderStatus { Provider = TtsCapability.WindowsProvider, Readiness = TtsCapability.ReadinessReady, IsReady = true },
+                new TtsProviderStatus { Provider = TtsCapability.ElevenLabsProvider, Readiness = TtsCapability.ReadinessNeedsApiKey, IsReady = false }
+            ]
+        });
+
+        var res = await cap.ExecuteAsync(new NodeInvokeRequest
+        {
+            Id = "tts-status",
+            Command = "tts.status",
+            Args = Parse("""{}""")
+        });
+
+        Assert.True(res.Ok);
+        var json = JsonSerializer.Serialize(res.Payload);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal("piper", root.GetProperty("configuredProvider").GetString());
+        Assert.Equal("windows", root.GetProperty("effectiveProvider").GetString());
+        Assert.True(root.GetProperty("willFallBack").GetBoolean());
+        var providers = root.GetProperty("providers");
+        Assert.Equal(3, providers.GetArrayLength());
+        Assert.Equal("voice-not-downloaded", providers[0].GetProperty("readiness").GetString());
+        Assert.False(providers[0].GetProperty("isReady").GetBoolean());
+        Assert.True(providers[1].GetProperty("isReady").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Status_ReturnsSanitizedError_WhenHandlerThrows()
+    {
+        var cap = new TtsCapability(NullLogger.Instance);
+        cap.StatusRequested += _ => throw new InvalidOperationException("voice id secret-voice-xyz on device Mic-42");
+
+        var res = await cap.ExecuteAsync(new NodeInvokeRequest
+        {
+            Id = "tts-status-fail",
+            Command = "tts.status",
+            Args = Parse("""{}""")
+        });
+
+        Assert.False(res.Ok);
+        Assert.Equal("Status failed", res.Error);
+        Assert.DoesNotContain("secret-voice-xyz", res.Error);
+        Assert.DoesNotContain("Mic-42", res.Error);
+    }
 }
 
 public class LocationCapabilityTests

--- a/tests/OpenClaw.Shared.Tests/ModelsTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ModelsTests.cs
@@ -2003,6 +2003,16 @@ public class SessionInfoContextSummaryTests
     }
 
     [Fact]
+    public void DangerousCommands_IncludesTtsStatus()
+    {
+        // tts.status is gated behind NodeTtsEnabled alongside tts.speak so the
+        // readiness probe isn't advertised until TTS is explicitly enabled.
+        Assert.Contains("tts.speak", CommandCenterCommandGroups.DangerousCommands);
+        Assert.Contains("tts.status", CommandCenterCommandGroups.DangerousCommands);
+        Assert.Contains("tts.status", (IReadOnlySet<string>)CommandCenterCommandGroups.DangerousCommandSet);
+    }
+
+    [Fact]
     public void CommonDangerousCommands_StillIncludedInMacParity()
     {
         // Refactor invariant: the original camera/screen dangerous commands


### PR DESCRIPTION
## Summary

Adds resilient text-to-speech provider handling for the Windows node.

- `tts.speak` now falls back to Windows TTS when the configured/default provider is not usable.
- Explicit per-call provider requests stay strict, so callers can rely on provider selection.
- `tts.speak` reports `requestedProvider` and `fellBack` so callers can explain degraded playback.
- Adds a read-only `tts.status` command that reports provider readiness without exposing voice IDs, API keys, device names, or exception details.
- Wires `tts.status` through capability registration, MCP docs, `skill.md`, setup-generated allowlists, and tests.
- Removes a stale Piper checksum TODO now that asset hash verification is already implemented.

## Why

The Windows node already supports multiple TTS providers (`piper`, `windows`, `elevenlabs`), but the previous behavior failed hard when the configured provider was not ready. Examples:

- Piper is selected by default, but the voice model is not downloaded.
- ElevenLabs is selected by default, but no API key or voice ID is configured.
- The configured Windows voice ID is stale or no longer installed.

Windows TTS is the reliable local fallback for configured/default provider degradation, so this change keeps speech working and makes provider state observable for callers. Explicit provider requests remain strict to preserve the existing provider-selection contract.

## Behavior changes

### `tts.speak`

Before:

- Resolves the requested/configured provider.
- Throws if that provider is unavailable.
- Returns only `{ spoken, provider, contentType, durationMs }`.

After:

- Uses the requested/configured provider when ready.
- Falls back to Windows TTS only when the configured/default provider is not ready.
- Keeps explicit per-call provider requests strict. Explicit unavailable `piper`, explicit unavailable `elevenlabs`, and unsupported provider IDs do not silently reroute to Windows.
- Drops provider-specific `voiceId` / `model` when falling back so Windows does not reject a Piper/ElevenLabs voice ID.
- Treats a stale configured Windows voice as non-fatal and uses the system default voice.
- Still throws for an explicit invalid per-call Windows voice, because that is a caller error.
- Returns `{ spoken, provider, requestedProvider, fellBack, contentType, durationMs }`.

### `tts.status`

New read-only command returning:

```json
{
  "configuredProvider": "piper",
  "effectiveProvider": "windows",
  "willFallBack": true,
  "providers": [
    { "provider": "piper", "readiness": "voice-not-downloaded", "isReady": false },
    { "provider": "windows", "readiness": "ready", "isReady": true },
    { "provider": "elevenlabs", "readiness": "needs-api-key", "isReady": false }
  ]
}
```

Readiness values are fixed strings:

- `ready`
- `needs-api-key`
- `needs-voice`
- `voice-not-downloaded`
- `unavailable`

## Files of interest

| File | Change |
|---|---|
| `src/OpenClaw.Shared/Capabilities/TtsCapability.cs` | Adds `tts.status`, provider-readiness types, fallback resolver, and expanded speak result. |
| `src/OpenClaw.Tray.WinUI/Services/TextToSpeech/TextToSpeechService.cs` | Implements provider readiness checks, configured/default fallback behavior, strict explicit-provider handling, and status generation. |
| `src/OpenClaw.Tray.WinUI/Services/NodeService.cs` | Wires `TtsCapability.StatusRequested`. |
| `src/OpenClaw.Shared/Models.cs` | Adds `tts.status` to privacy-gated command grouping. |
| `src/OpenClaw.Shared/Mcp/McpToolBridge.cs` | Documents `tts.status` and updated `tts.speak` result shape. |
| `src/OpenClaw.WinNode.Cli/skill.md` | Keeps CLI capability docs in sync. |
| `src/OpenClaw.SetupEngine/SetupContext.cs` | Includes `tts.status` in setup-generated `gateway.nodes.allowCommands`. |
| `src/OpenClaw.Shared/Audio/PiperVoiceManager.cs` | Removes stale checksum TODO. |
| `tests/...` | Adds coverage for fallback resolution, explicit provider strictness, status projection, command grouping, and setup allowlist output. |

## Proof

Validated locally on branch head `a9fc0c62`, rebased onto current `origin/main`.

| Check | Result |
|---|---|
| `./build.ps1` | ✅ all 5 projects built |
| `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` | ✅ 2437 passed, 29 skipped |
| `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` | ✅ 1163 passed on rerun |
| `dotnet test ./tests/OpenClaw.WinNode.Cli.Tests/OpenClaw.WinNode.Cli.Tests.csproj --no-restore` | ✅ 120 passed |
| `dotnet test ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj --no-restore` | ✅ 282 passed |
| Targeted TTS/status tests | ✅ 29 passed |
| Docs/skill drift tests after wording fix | ✅ 120 passed |
| Exact failed CI WebSocket test | ✅ 1 passed locally |

### Runtime proof through the tray-local MCP path

I launched the actual Windows tray from this branch in an isolated data directory with:

- local MCP enabled
- node mode disabled
- TTS capability enabled
- configured TTS provider set to `elevenlabs`
- no ElevenLabs API key or voice ID configured
- Piper voice left undownloaded

Then I invoked the real local MCP endpoint through `winnode`. This exercises:

`winnode` → local MCP HTTP server → `NodeService` → `TtsCapability` → `TextToSpeechService`

Terminal output:

```text
=== winnode tools/list includes tts ===
      "name": "tts.speak",
      "name": "tts.status",

=== tts.status through live tray MCP ===
{
  "configuredProvider": "elevenlabs",
  "effectiveProvider": "windows",
  "willFallBack": true,
  "providers": [
    {
      "provider": "piper",
      "readiness": "voice-not-downloaded",
      "isReady": false
    },
    {
      "provider": "windows",
      "readiness": "ready",
      "isReady": true
    },
    {
      "provider": "elevenlabs",
      "readiness": "needs-api-key",
      "isReady": false
    }
  ]
}

=== tts.speak omitted-provider fallback through live tray MCP/TextToSpeechService ===
{
  "spoken": true,
  "provider": "windows",
  "requestedProvider": "elevenlabs",
  "fellBack": true,
  "contentType": "audio/wav",
  "durationMs": 4230
}

=== explicit provider remains strict (no fallback) ===
Speak failed
exit=1
```

This confirms the registered runtime tool surface, readiness payload, configured/default fallback through `TextToSpeechService`, and strict explicit-provider behavior.

Additional verification:

- PR is based on `main`, is 0 commits behind `origin/main`, and contains 1 commit / 11 files.
- GitHub reports the PR as mergeable (`UNSTABLE` means CI is pending or has a non-merge failure, not a conflict).

## Current CI note

The current red `test` job is not caused by this TTS change. The job log shows:

1. **Gateway LKG drift gate:** pinned `2026.6.9`, npm latest `2026.6.10`; the workflow explicitly says to run `gateway-lkg-update` to refresh the standing draft PR.
2. **Unrelated Shared test failure:** `WebSocketClientBaseTests.ReconnectBackoff_ReconnectsCurrentClosingSocket_WhenSupersededLoopIsActive` failed an `Assert.True` at `WebSocketClientBaseTests.cs:411`. This PR does not touch WebSocket client code, and the exact test passes locally as listed above.

## Notes / limits

- This does not add UI controls. It only makes TTS provider behavior resilient and observable.
- `tts.status.willFallBack` reflects configured defaults. A specific `tts.speak` call with its own `voiceId` stays strict and may not match the default snapshot.
- `tts.status` is grouped with the other voice commands behind `NodeTtsEnabled`.