### PR TITLE
Add gateway protocol client foundation (Mac/main parity)

### DIFF
--- a/src/OpenClaw.Shared/GatewayProtocolModels.cs
+++ b/src/OpenClaw.Shared/GatewayProtocolModels.cs
@@ -1,0 +1,532 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenClaw.Shared;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gateway protocol DTOs.
+//
+// These mirror the canonical upstream gateway protocol
+// (openclaw/openclaw, packages/gateway-protocol/src/schema) for:
+//   • commands.list           — the command catalog
+//   • sessions.patch          — the extended per-session preference field set
+//   • sessions.files.list/get — session workspace file rail + browser
+//   • sessions.compaction.*   — compaction checkpoint list/get/branch/restore
+//
+// Wire field names and value sets match the upstream TypeBox schemas exactly,
+// which use `additionalProperties: false` (strict) — so request payloads must
+// only carry known fields with the documented value sets.
+//
+// List/get/mutation result DTOs carry an `IsSupported` flag. Older gateways
+// that do not implement a method report "unknown method", which the client
+// surfaces as a typed result with `IsSupported = false` rather than throwing —
+// see OpenClawGatewayClient.Protocol.cs.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ── Command catalog (commands.list) ──
+
+/// <summary>A static argument choice: machine value plus a user-facing label.</summary>
+public sealed class GatewayCommandArgChoice
+{
+    public string Value { get; set; } = "";
+    public string Label { get; set; } = "";
+}
+
+/// <summary>A single declared argument for a gateway command.</summary>
+public sealed class GatewayCommandArg
+{
+    public string Name { get; set; } = "";
+
+    public string? Description { get; set; }
+
+    /// <summary>Declared argument type: "string", "number", or "boolean".</summary>
+    public string? Type { get; set; }
+
+    public bool Required { get; set; }
+
+    /// <summary>True when the choice set is resolved dynamically by the gateway at invocation time.</summary>
+    public bool IsDynamic { get; set; }
+
+    /// <summary>Static enumerated choices, when the gateway declares them.</summary>
+    public IReadOnlyList<GatewayCommandArgChoice> Choices { get; set; } = Array.Empty<GatewayCommandArgChoice>();
+}
+
+/// <summary>A single command entry from the gateway command catalog (commands.list).</summary>
+public sealed class GatewayCommand
+{
+    /// <summary>Catalog command name (the value the catalog advertises for this surface).</summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>Native/platform command name, when distinct from <see cref="Name"/>.</summary>
+    public string? NativeName { get; set; }
+
+    /// <summary>Alternate text triggers (slash-prefixed) that resolve to this command.</summary>
+    public IReadOnlyList<string> TextAliases { get; set; } = Array.Empty<string>();
+
+    public string? Description { get; set; }
+
+    /// <summary>UI grouping: session, options, status, management, media, tools, docks.</summary>
+    public string? Category { get; set; }
+
+    /// <summary>Contributing source system: "native", "skill", or "plugin".</summary>
+    public string? Source { get; set; }
+
+    /// <summary>Invocation surface: "text", "native", or "both".</summary>
+    public string? Scope { get; set; }
+
+    public bool AcceptsArgs { get; set; }
+
+    public IReadOnlyList<GatewayCommandArg> Args { get; set; } = Array.Empty<GatewayCommandArg>();
+}
+
+/// <summary>
+/// Typed result of <c>commands.list</c> (<c>{ commands: [...] }</c>). The gateway
+/// does not return facet lists, so <see cref="Categories"/>, <see cref="Scopes"/>
+/// and <see cref="Sources"/> are derived from the returned commands to give the
+/// UI a stable vocabulary.
+/// </summary>
+public sealed class CommandCatalog
+{
+    public IReadOnlyList<GatewayCommand> Commands { get; set; } = Array.Empty<GatewayCommand>();
+
+    public IReadOnlyList<string> Categories { get; set; } = Array.Empty<string>();
+
+    public IReadOnlyList<string> Scopes { get; set; } = Array.Empty<string>();
+
+    public IReadOnlyList<string> Sources { get; set; } = Array.Empty<string>();
+
+    /// <summary>False when the connected gateway does not implement <c>commands.list</c> (older gateway).</summary>
+    public bool IsSupported { get; set; } = true;
+
+    public int Count => Commands.Count;
+}
+
+/// <summary>
+/// Client-side filter applied over a <see cref="CommandCatalog"/>. The gateway's
+/// <c>commands.list</c> only accepts <c>scope</c>/<c>includeArgs</c>/<c>provider</c>/<c>agentId</c>
+/// server-side filters (no category/source/text search), so filtering locally
+/// covers all facets and keeps the full catalog cached for cheap re-filtering.
+/// </summary>
+public sealed class CommandCatalogQuery
+{
+    /// <summary>Match command category (session, options, status, management, media, tools, docks).</summary>
+    public string? Category { get; set; }
+
+    /// <summary>Match command source (native, skill, plugin).</summary>
+    public string? Source { get; set; }
+
+    /// <summary>Match command scope (text, native, both).</summary>
+    public string? Scope { get; set; }
+
+    /// <summary>Case-insensitive substring matched against name, native name, aliases, and description.</summary>
+    public string? Search { get; set; }
+
+    /// <summary>When set, only commands whose <see cref="GatewayCommand.AcceptsArgs"/> matches are kept.</summary>
+    public bool? AcceptsArgs { get; set; }
+
+    public bool HasFilter =>
+        !string.IsNullOrWhiteSpace(Category) ||
+        !string.IsNullOrWhiteSpace(Source) ||
+        !string.IsNullOrWhiteSpace(Scope) ||
+        !string.IsNullOrWhiteSpace(Search) ||
+        AcceptsArgs.HasValue;
+
+    public bool Matches(GatewayCommand command)
+    {
+        if (command is null) return false;
+
+        if (!string.IsNullOrWhiteSpace(Category) &&
+            !string.Equals(command.Category, Category, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (!string.IsNullOrWhiteSpace(Source) &&
+            !string.Equals(command.Source, Source, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (!string.IsNullOrWhiteSpace(Scope))
+        {
+            // Mirror gateway commands.list scope semantics: a "both" filter
+            // returns everything, and a "text" or "native" filter also includes
+            // commands available on "both" surfaces.
+            var wanted = Scope.Trim();
+            if (!string.Equals(wanted, "both", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(command.Scope, "both", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(command.Scope, wanted, StringComparison.OrdinalIgnoreCase))
+                return false;
+        }
+
+        if (AcceptsArgs.HasValue && command.AcceptsArgs != AcceptsArgs.Value)
+            return false;
+
+        if (!string.IsNullOrWhiteSpace(Search))
+        {
+            var needle = Search.Trim();
+            var inName = command.Name.Contains(needle, StringComparison.OrdinalIgnoreCase);
+            var inNative = command.NativeName?.Contains(needle, StringComparison.OrdinalIgnoreCase) ?? false;
+            var inDesc = command.Description?.Contains(needle, StringComparison.OrdinalIgnoreCase) ?? false;
+            var inAlias = command.TextAliases.Any(a => a.Contains(needle, StringComparison.OrdinalIgnoreCase));
+            if (!inName && !inNative && !inDesc && !inAlias)
+                return false;
+        }
+
+        return true;
+    }
+}
+
+// ── Session patch (sessions.patch) ──
+
+/// <summary>Fast-mode setting: off, on, or "auto" (gateway picks per turn).</summary>
+public enum SessionFastMode
+{
+    Off,
+    On,
+    Auto
+}
+
+/// <summary>Response-usage footer detail level (gateway <c>responseUsage</c>).</summary>
+public enum ResponseUsageMode
+{
+    Off,
+    Tokens,
+    Full,
+
+    /// <summary>Legacy alias the gateway still accepts for backward compatibility.</summary>
+    On
+}
+
+/// <summary>Per-session message send policy.</summary>
+public enum SessionSendPolicy
+{
+    Allow,
+    Deny
+}
+
+/// <summary>Group activation mode for multi-party sessions.</summary>
+public enum SessionGroupActivation
+{
+    Mention,
+    Always
+}
+
+/// <summary>
+/// Non-generic sentinel that clears any <see cref="PatchField{T}"/> — i.e. emits
+/// an explicit JSON <c>null</c> for that field, which the gateway treats as
+/// "remove this session override". Obtain it via <see cref="SessionPatch.Clear"/>.
+/// </summary>
+public readonly struct PatchFieldClear
+{
+}
+
+/// <summary>
+/// A tri-state patch field: <b>unset</b> (omitted from the request), <b>set</b>
+/// to a concrete value, or <b>cleared</b> (sent as explicit JSON <c>null</c> to
+/// remove the override). Implicitly converts from a value (<c>field = value</c>)
+/// and from <see cref="SessionPatch.Clear"/> (<c>field = SessionPatch.Clear</c>),
+/// so the common cases stay terse. The default value is <b>unset</b>.
+/// </summary>
+public readonly struct PatchField<T>
+{
+    private readonly T _value;
+
+    private PatchField(bool specified, bool clear, T value)
+    {
+        IsSpecified = specified;
+        IsClear = clear;
+        _value = value;
+    }
+
+    /// <summary>True when the field participates in the payload (either a value or an explicit null).</summary>
+    public bool IsSpecified { get; }
+
+    /// <summary>True when the field should be emitted as explicit JSON <c>null</c> (clear the override).</summary>
+    public bool IsClear { get; }
+
+    /// <summary>True when the field carries a concrete value to send.</summary>
+    public bool HasValue => IsSpecified && !IsClear;
+
+    /// <summary>The concrete value; only meaningful when <see cref="HasValue"/> is true.</summary>
+    public T Value => _value;
+
+    /// <summary>Sets the field to a concrete value. A null reference maps to unset.</summary>
+    public static PatchField<T> Set(T? value) => value is null ? default : new PatchField<T>(true, false, value);
+
+    /// <summary>A field cleared to explicit JSON <c>null</c>. Callers use <see cref="SessionPatch.Clear"/>.</summary>
+    private static PatchField<T> ClearField { get; } = new PatchField<T>(true, true, default!);
+
+    public static implicit operator PatchField<T>(T? value) => Set(value);
+
+    public static implicit operator PatchField<T>(PatchFieldClear _) => ClearField;
+}
+
+/// <summary>
+/// Extended <c>sessions.patch</c> field set. Each field is tri-state via
+/// <see cref="PatchField{T}"/>: leave it unset to omit it, assign a value to set
+/// it, or assign <see cref="Clear"/> to remove the session override (explicit
+/// JSON null). Field names and value sets match the upstream
+/// <c>SessionsPatchParamsSchema</c> exactly (see <see cref="ToPayload"/>), whose
+/// fields are <c>Union([&lt;value&gt;, Null])</c> — so null is a valid clear signal.
+/// </summary>
+public sealed class SessionPatch
+{
+    /// <summary>
+    /// Assign to any patch field to clear that session override (emits explicit
+    /// JSON <c>null</c>), e.g. <c>patch.Model = SessionPatch.Clear;</c>.
+    /// </summary>
+    public static PatchFieldClear Clear => default;
+
+    public PatchField<string> Model { get; set; }
+    public PatchField<string> ThinkingLevel { get; set; }
+    public PatchField<SessionFastMode> FastMode { get; set; }
+    public PatchField<string> VerboseLevel { get; set; }
+    public PatchField<string> TraceLevel { get; set; }
+    public PatchField<string> ReasoningLevel { get; set; }
+    public PatchField<ResponseUsageMode> ResponseUsage { get; set; }
+    public PatchField<string> ElevatedLevel { get; set; }
+    public PatchField<string> ExecHost { get; set; }
+    public PatchField<string> ExecSecurity { get; set; }
+    public PatchField<string> ExecAsk { get; set; }
+    public PatchField<string> ExecNode { get; set; }
+    public PatchField<SessionSendPolicy> SendPolicy { get; set; }
+    public PatchField<SessionGroupActivation> GroupActivation { get; set; }
+
+    /// <summary>
+    /// True when the patch would change something: any field cleared, or any
+    /// field set to a meaningful value (a blank string value produces nothing).
+    /// </summary>
+    public bool HasChanges =>
+        ProducesString(Model) || ProducesString(ThinkingLevel) || FastMode.IsSpecified ||
+        ProducesString(VerboseLevel) || ProducesString(TraceLevel) || ProducesString(ReasoningLevel) ||
+        ResponseUsage.IsSpecified || ProducesString(ElevatedLevel) || ProducesString(ExecHost) ||
+        ProducesString(ExecSecurity) || ProducesString(ExecAsk) || ProducesString(ExecNode) ||
+        SendPolicy.IsSpecified || GroupActivation.IsSpecified;
+
+    /// <summary>
+    /// Builds the <c>sessions.patch</c> request parameters: always includes
+    /// <c>key</c>, plus every field that participates. A cleared field is emitted
+    /// as explicit <c>null</c>; a set field uses the gateway's exact wire value.
+    /// String fields map to the schema's <c>NonEmptyString</c> value type, so a
+    /// blank/whitespace <i>value</i> is omitted (an empty string would be
+    /// rejected and fail the whole patch) — clearing always uses null instead.
+    /// </summary>
+    internal Dictionary<string, object?> ToPayload(string key)
+    {
+        var payload = new Dictionary<string, object?> { ["key"] = key };
+        AddString(payload, "model", Model);
+        AddString(payload, "thinkingLevel", ThinkingLevel);
+        AddEncoded(payload, "fastMode", FastMode, EncodeFastMode);
+        AddString(payload, "verboseLevel", VerboseLevel);
+        AddString(payload, "traceLevel", TraceLevel);
+        AddString(payload, "reasoningLevel", ReasoningLevel);
+        AddEncoded(payload, "responseUsage", ResponseUsage, EncodeResponseUsage);
+        AddString(payload, "elevatedLevel", ElevatedLevel);
+        AddString(payload, "execHost", ExecHost);
+        AddString(payload, "execSecurity", ExecSecurity);
+        AddString(payload, "execAsk", ExecAsk);
+        AddString(payload, "execNode", ExecNode);
+        AddEncoded(payload, "sendPolicy", SendPolicy, p => p == SessionSendPolicy.Allow ? "allow" : "deny");
+        AddEncoded(payload, "groupActivation", GroupActivation, g => g == SessionGroupActivation.Mention ? "mention" : "always");
+        return payload;
+    }
+
+    // A blank-value string Set produces nothing (consistent with NonEmptyString);
+    // a clear always produces an explicit null.
+    private static bool ProducesString(PatchField<string> field)
+        => field.IsClear || (field.HasValue && !string.IsNullOrWhiteSpace(field.Value));
+
+    private static void AddString(Dictionary<string, object?> payload, string name, PatchField<string> field)
+    {
+        if (field.IsClear)
+            payload[name] = null;
+        else if (field.HasValue && !string.IsNullOrWhiteSpace(field.Value))
+            payload[name] = field.Value;
+    }
+
+    private static void AddEncoded<TValue>(
+        Dictionary<string, object?> payload, string name, PatchField<TValue> field, Func<TValue, object> encode)
+    {
+        if (field.IsClear)
+            payload[name] = null;
+        else if (field.HasValue)
+            payload[name] = encode(field.Value);
+    }
+
+    // fastMode is a union of boolean | "auto" on the wire.
+    private static object EncodeFastMode(SessionFastMode mode) => mode switch
+    {
+        SessionFastMode.On => true,
+        SessionFastMode.Off => false,
+        _ => "auto"
+    };
+
+    private static object EncodeResponseUsage(ResponseUsageMode mode) => mode switch
+    {
+        ResponseUsageMode.Off => "off",
+        ResponseUsageMode.Tokens => "tokens",
+        ResponseUsageMode.Full => "full",
+        _ => "on"
+    };
+}
+
+// ── Session files (sessions.files.list / sessions.files.get) ──
+
+/// <summary>A file referenced by a session transcript.</summary>
+public sealed class SessionFileEntry
+{
+    public string Path { get; set; } = "";
+    public string Name { get; set; } = "";
+
+    /// <summary>Relevance: "modified" or "read".</summary>
+    public string? Kind { get; set; }
+
+    /// <summary>True when the referenced file no longer exists on disk.</summary>
+    public bool Missing { get; set; }
+
+    public long? Size { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+
+    /// <summary>File content (present on <c>sessions.files.get</c>; usually omitted in list results).</summary>
+    public string? Content { get; set; }
+}
+
+/// <summary>One file or folder in the session-rooted workspace browser.</summary>
+public sealed class SessionFileBrowserEntry
+{
+    public string Path { get; set; } = "";
+    public string Name { get; set; } = "";
+
+    /// <summary>"file" or "directory".</summary>
+    public string? Kind { get; set; }
+
+    /// <summary>Session relevance for this entry: "modified", "read", or "mixed".</summary>
+    public string? SessionKind { get; set; }
+
+    public long? Size { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+
+    public bool IsDirectory => string.Equals(Kind, "directory", StringComparison.OrdinalIgnoreCase);
+}
+
+/// <summary>Folder listing or search result rooted at the session workspace.</summary>
+public sealed class SessionFileBrowser
+{
+    public string Path { get; set; } = "";
+    public string? ParentPath { get; set; }
+    public string? Search { get; set; }
+    public IReadOnlyList<SessionFileBrowserEntry> Entries { get; set; } = Array.Empty<SessionFileBrowserEntry>();
+    public bool Truncated { get; set; }
+}
+
+/// <summary>Typed result of <c>sessions.files.list</c>.</summary>
+public sealed class SessionFileList
+{
+    public string Key { get; set; } = "";
+
+    /// <summary>Absolute workspace root reported by the gateway, when available.</summary>
+    public string? Root { get; set; }
+
+    public IReadOnlyList<SessionFileEntry> Files { get; set; } = Array.Empty<SessionFileEntry>();
+
+    /// <summary>Folder browser listing, present when a <c>path</c>/<c>search</c> was requested.</summary>
+    public SessionFileBrowser? Browser { get; set; }
+
+    /// <summary>False when the connected gateway does not implement the method (older gateway).</summary>
+    public bool IsSupported { get; set; } = true;
+}
+
+/// <summary>Typed result of <c>sessions.files.get</c>.</summary>
+public sealed class SessionFileContent
+{
+    public string Key { get; set; } = "";
+    public string? Root { get; set; }
+    public string Path { get; set; } = "";
+    public string? Name { get; set; }
+    public string? Kind { get; set; }
+    public string? Content { get; set; }
+    public long? Size { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+
+    /// <summary>True when the gateway reported the file as missing.</summary>
+    public bool Missing { get; set; }
+
+    /// <summary>True when readable content was returned.</summary>
+    public bool Found => !Missing && Content is not null;
+
+    /// <summary>False when the connected gateway does not implement the method (older gateway).</summary>
+    public bool IsSupported { get; set; } = true;
+}
+
+// ── Compaction checkpoints (sessions.compaction.*) ──
+
+/// <summary>Stored compaction checkpoint metadata for branching or restoring a session.</summary>
+public sealed class SessionCompactionCheckpoint
+{
+    /// <summary>Checkpoint id (gateway <c>checkpointId</c>).</summary>
+    public string Id { get; set; } = "";
+
+    public string? SessionKey { get; set; }
+    public string? SessionId { get; set; }
+    public DateTime? CreatedAt { get; set; }
+
+    /// <summary>Why the checkpoint was created: manual, auto-threshold, overflow-retry, timeout-retry.</summary>
+    public string? Reason { get; set; }
+
+    public long? TokensBefore { get; set; }
+    public long? TokensAfter { get; set; }
+    public string? Summary { get; set; }
+    public string? FirstKeptEntryId { get; set; }
+}
+
+/// <summary>Typed result of <c>sessions.compaction.list</c>.</summary>
+public sealed class SessionCompactionCheckpointList
+{
+    public string Key { get; set; } = "";
+    public IReadOnlyList<SessionCompactionCheckpoint> Checkpoints { get; set; } = Array.Empty<SessionCompactionCheckpoint>();
+
+    /// <summary>False when the connected gateway does not implement the method (older gateway).</summary>
+    public bool IsSupported { get; set; } = true;
+}
+
+/// <summary>Typed result of <c>sessions.compaction.get</c>.</summary>
+public sealed class SessionCompactionCheckpointResult
+{
+    public string Key { get; set; } = "";
+    public SessionCompactionCheckpoint? Checkpoint { get; set; }
+
+    /// <summary>True when a checkpoint was returned.</summary>
+    public bool Found => Checkpoint is not null;
+
+    /// <summary>False when the connected gateway does not implement the method (older gateway).</summary>
+    public bool IsSupported { get; set; } = true;
+}
+
+/// <summary>
+/// Typed result of a compaction mutation (<c>sessions.compaction.branch</c> or
+/// <c>sessions.compaction.restore</c>).
+/// </summary>
+public sealed class SessionCompactionMutationResult
+{
+    public bool Ok { get; set; }
+
+    /// <summary>The session key the caller acted on.</summary>
+    public string Key { get; set; } = "";
+
+    public string? CheckpointId { get; set; }
+
+    /// <summary>For branch: the original session key (gateway <c>sourceKey</c>).</summary>
+    public string? SourceKey { get; set; }
+
+    /// <summary>
+    /// The resulting session key: the newly created branch key for branch, or
+    /// the restored session key for restore (gateway <c>key</c>).
+    /// </summary>
+    public string? ResultSessionKey { get; set; }
+
+    public string? SessionId { get; set; }
+    public SessionCompactionCheckpoint? Checkpoint { get; set; }
+
+    public string? Error { get; set; }
+
+    /// <summary>False when the connected gateway does not implement the method (older gateway).</summary>
+    public bool IsSupported { get; set; } = true;
+}

--- a/src/OpenClaw.Shared/IOperatorGatewayClient.cs
+++ b/src/OpenClaw.Shared/IOperatorGatewayClient.cs
@@ -111,4 +111,34 @@ public interface IOperatorGatewayClient
     /// <summary>Long-poll for QR linking completion. Sends web.login.wait { currentQrDataUrl, timeoutMs }.</summary>
     Task<WebLoginWaitResult?> WebLoginWaitAsync(string? currentQrDataUrl = null, int timeoutMs = 30000);
     Task<JsonElement> SendWizardRequestAsync(string method, object? parameters = null, int timeoutMs = 30000);
+
+    // ─── Gateway protocol APIs ───
+    // These ship with default implementations so adding them does not source-break
+    // existing external implementers of this interface (e.g. test doubles). The
+    // real gateway client overrides them; defaults degrade gracefully to an
+    // "unsupported" typed result, matching older-gateway behavior.
+    /// <summary>Fetch the gateway command catalog (<c>commands.list</c>); applies <paramref name="query"/> client-side. Returns IsSupported=false on older gateways.</summary>
+    Task<CommandCatalog> ListCommandsAsync(CommandCatalogQuery? query = null, int timeoutMs = 15000)
+        => Task.FromResult(new CommandCatalog { IsSupported = false });
+    /// <summary>Apply an extended <see cref="SessionPatch"/> (rich field set) to a session.</summary>
+    Task<bool> PatchSessionAsync(string key, SessionPatch patch)
+        => Task.FromResult(false);
+    /// <summary>List session files, optionally scoped to a sub-path/search (<c>sessions.files.list</c>).</summary>
+    Task<SessionFileList> ListSessionFilesAsync(string key, string? path = null, string? search = null, int timeoutMs = 15000)
+        => Task.FromResult(new SessionFileList { Key = key, IsSupported = false });
+    /// <summary>Read a session file's content (<c>sessions.files.get</c>).</summary>
+    Task<SessionFileContent> GetSessionFileAsync(string key, string path, int timeoutMs = 15000)
+        => Task.FromResult(new SessionFileContent { Key = key, Path = path, IsSupported = false });
+    /// <summary>List compaction checkpoints for a session (<c>sessions.compaction.list</c>).</summary>
+    Task<SessionCompactionCheckpointList> ListCompactionCheckpointsAsync(string key, int timeoutMs = 15000)
+        => Task.FromResult(new SessionCompactionCheckpointList { Key = key, IsSupported = false });
+    /// <summary>Fetch a single compaction checkpoint's metadata (<c>sessions.compaction.get</c>).</summary>
+    Task<SessionCompactionCheckpointResult> GetCompactionCheckpointAsync(string key, string checkpointId, int timeoutMs = 15000)
+        => Task.FromResult(new SessionCompactionCheckpointResult { Key = key, IsSupported = false });
+    /// <summary>Branch a new session from a compaction checkpoint (<c>sessions.compaction.branch</c>).</summary>
+    Task<SessionCompactionMutationResult> BranchCompactionCheckpointAsync(string key, string checkpointId, int timeoutMs = 15000)
+        => Task.FromResult(new SessionCompactionMutationResult { Key = key, CheckpointId = checkpointId, IsSupported = false });
+    /// <summary>Restore a session to a compaction checkpoint (<c>sessions.compaction.restore</c>).</summary>
+    Task<SessionCompactionMutationResult> RestoreCompactionCheckpointAsync(string key, string checkpointId, int timeoutMs = 15000)
+        => Task.FromResult(new SessionCompactionMutationResult { Key = key, CheckpointId = checkpointId, IsSupported = false });
 }

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.Protocol.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.Protocol.cs
@@ -1,0 +1,573 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace OpenClaw.Shared;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gateway protocol client APIs.
+//
+// Typed client methods for the richer gateway protocol, matching the canonical
+// openclaw/openclaw schemas exactly:
+//   • commands.list             — command catalog
+//   • sessions.patch            — extended per-session field set
+//   • sessions.files.list/get   — workspace file rail + browser (param: sessionKey)
+//   • sessions.compaction.*     — compaction checkpoints (param: key, checkpointId)
+//
+// Backwards compatibility: read/list/get methods detect an "unknown method"
+// error from an older gateway and return a typed result with IsSupported = false
+// (logged at warn) instead of throwing. Genuine protocol errors are NOT
+// swallowed: read methods propagate the gateway error (e.g. not-found / too-large
+// on sessions.files.get), and mutation methods surface it in the result's Error
+// field. Timeouts propagate as TimeoutException from the request helper.
+//
+// Parsing is factored into internal static methods so the JSON contract is unit
+// testable directly (InternalsVisibleTo OpenClaw.Shared.Tests), reusing the
+// private static JsonElement helpers declared in OpenClawGatewayClient.cs.
+// ─────────────────────────────────────────────────────────────────────────────
+public partial class OpenClawGatewayClient
+{
+    // ── commands.list ──
+
+    /// <summary>
+    /// Fetches the gateway command catalog. When <paramref name="query"/> is
+    /// supplied it is applied as a client-side filter over the full catalog.
+    /// Returns a catalog with <see cref="CommandCatalog.IsSupported"/> = false
+    /// when the gateway does not implement <c>commands.list</c>.
+    /// Throws if the gateway connection is not open.
+    /// </summary>
+    public async Task<CommandCatalog> ListCommandsAsync(CommandCatalogQuery? query = null, int timeoutMs = 15000)
+    {
+        var payload = await TryRequestPayloadAsync("commands.list", null, timeoutMs).ConfigureAwait(false);
+        if (payload is null)
+            return new CommandCatalog { IsSupported = false };
+
+        var catalog = ParseCommandCatalog(payload.Value);
+        if (query is { HasFilter: true })
+            catalog = ApplyCommandQuery(catalog, query);
+        return catalog;
+    }
+
+    internal static CommandCatalog ApplyCommandQuery(CommandCatalog catalog, CommandCatalogQuery query)
+    {
+        var filtered = catalog.Commands.Where(query.Matches).ToList();
+        return new CommandCatalog
+        {
+            Commands = filtered,
+            Categories = catalog.Categories,
+            Scopes = catalog.Scopes,
+            Sources = catalog.Sources,
+            IsSupported = catalog.IsSupported
+        };
+    }
+
+    internal static CommandCatalog ParseCommandCatalog(JsonElement payload)
+    {
+        var commandsArray = payload.ValueKind == JsonValueKind.Array
+            ? payload
+            : TryGetArray(payload, "commands") ?? default;
+
+        var commands = new List<GatewayCommand>();
+        if (commandsArray.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in commandsArray.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.Object) continue;
+                var command = ParseCommand(item);
+                if (!string.IsNullOrEmpty(command.Name))
+                    commands.Add(command);
+            }
+        }
+
+        // The gateway result has no facet lists; derive them so callers always
+        // have the schema vocabulary available.
+        return new CommandCatalog
+        {
+            Commands = commands,
+            Categories = DistinctNonEmpty(commands.Select(c => c.Category)),
+            Scopes = DistinctNonEmpty(commands.Select(c => c.Scope)),
+            Sources = DistinctNonEmpty(commands.Select(c => c.Source)),
+            IsSupported = true
+        };
+    }
+
+    private static GatewayCommand ParseCommand(JsonElement item)
+    {
+        var args = new List<GatewayCommandArg>();
+        if (item.TryGetProperty("args", out var argsEl) && argsEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var arg in argsEl.EnumerateArray())
+            {
+                if (arg.ValueKind != JsonValueKind.Object) continue;
+                args.Add(ParseCommandArg(arg));
+            }
+        }
+
+        return new GatewayCommand
+        {
+            Name = GetString(item, "name") ?? "",
+            NativeName = GetString(item, "nativeName"),
+            TextAliases = GetStringArrayList(item, "textAliases"),
+            Description = GetString(item, "description"),
+            Category = GetString(item, "category"),
+            Source = GetString(item, "source"),
+            Scope = GetString(item, "scope"),
+            AcceptsArgs = GetOptionalBool(item, "acceptsArgs") ?? args.Count > 0,
+            Args = args
+        };
+    }
+
+    private static GatewayCommandArg ParseCommandArg(JsonElement arg)
+    {
+        var choices = new List<GatewayCommandArgChoice>();
+        if (arg.TryGetProperty("choices", out var choicesEl) && choicesEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var choice in choicesEl.EnumerateArray())
+            {
+                if (choice.ValueKind == JsonValueKind.Object)
+                {
+                    // value is a (possibly empty) string per schema; only skip
+                    // when the property is missing/non-string.
+                    if (!choice.TryGetProperty("value", out var valueEl) || valueEl.ValueKind != JsonValueKind.String)
+                        continue;
+                    var value = valueEl.GetString() ?? "";
+                    choices.Add(new GatewayCommandArgChoice
+                    {
+                        Value = value,
+                        Label = GetString(choice, "label") ?? value
+                    });
+                }
+                else if (choice.ValueKind == JsonValueKind.String)
+                {
+                    // Tolerate a bare-string choice form for forward/back compat.
+                    var value = choice.GetString();
+                    if (string.IsNullOrEmpty(value)) continue;
+                    choices.Add(new GatewayCommandArgChoice { Value = value!, Label = value! });
+                }
+            }
+        }
+
+        return new GatewayCommandArg
+        {
+            Name = GetString(arg, "name") ?? "",
+            Description = GetString(arg, "description"),
+            Type = GetString(arg, "type"),
+            Required = GetOptionalBool(arg, "required") ?? false,
+            IsDynamic = GetOptionalBool(arg, "dynamic") ?? false,
+            Choices = choices
+        };
+    }
+
+    // ── sessions.patch (extended field set) ──
+
+    /// <summary>
+    /// Applies an extended <see cref="SessionPatch"/> to a session. Only the
+    /// fields set on the patch are sent. Returns false (without sending) when
+    /// the key is blank or the patch has no changes. Completion is observed via
+    /// the existing <see cref="SessionCommandCompleted"/> event, like the legacy
+    /// <see cref="PatchSessionAsync(string, string?, string?, string?)"/>.
+    /// </summary>
+    public Task<bool> PatchSessionAsync(string key, SessionPatch patch)
+    {
+        if (string.IsNullOrWhiteSpace(key)) return Task.FromResult(false);
+        if (patch is null || !patch.HasChanges) return Task.FromResult(false);
+        return TrySendTrackedRequestAsync("sessions.patch", patch.ToPayload(key));
+    }
+
+    // ── sessions.files.list / sessions.files.get ──
+
+    /// <summary>
+    /// Lists files referenced by a session, optionally scoped to a sub-path or
+    /// search (powering the workspace file rail / browser). Returns a result
+    /// with <see cref="SessionFileList.IsSupported"/> = false when the gateway
+    /// does not implement the method. Throws if the connection is not open.
+    /// </summary>
+    public async Task<SessionFileList> ListSessionFilesAsync(string key, string? path = null, string? search = null, int timeoutMs = 15000)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            return new SessionFileList { Key = key ?? "" };
+
+        var @params = new Dictionary<string, object?> { ["sessionKey"] = key };
+        if (!string.IsNullOrEmpty(path)) @params["path"] = path;
+        if (!string.IsNullOrEmpty(search)) @params["search"] = search;
+
+        var payload = await TryRequestPayloadAsync("sessions.files.list", @params, timeoutMs).ConfigureAwait(false);
+        if (payload is null)
+            return new SessionFileList { Key = key, IsSupported = false };
+
+        return ParseSessionFileList(payload.Value, key);
+    }
+
+    /// <summary>
+    /// Reads the content of a single session file. Returns a result with
+    /// <see cref="SessionFileContent.IsSupported"/> = false when the gateway
+    /// does not implement the method. The gateway returns an error for a missing
+    /// or too-large file, which propagates as <see cref="InvalidOperationException"/>.
+    /// </summary>
+    public async Task<SessionFileContent> GetSessionFileAsync(string key, string path, int timeoutMs = 15000)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Session key is required", nameof(key));
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("File path is required", nameof(path));
+
+        var payload = await TryRequestPayloadAsync(
+            "sessions.files.get", new { sessionKey = key, path }, timeoutMs).ConfigureAwait(false);
+        if (payload is null)
+            return new SessionFileContent { Key = key, Path = path, IsSupported = false };
+
+        return ParseSessionFileContent(payload.Value, key, path);
+    }
+
+    internal static SessionFileList ParseSessionFileList(JsonElement payload, string key)
+    {
+        var files = new List<SessionFileEntry>();
+        var filesArray = TryGetArray(payload, "files");
+        if (filesArray is { ValueKind: JsonValueKind.Array })
+        {
+            foreach (var item in filesArray.Value.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.Object) continue;
+                var entry = ParseFileEntry(item);
+                if (!string.IsNullOrEmpty(entry.Path) || !string.IsNullOrEmpty(entry.Name))
+                    files.Add(entry);
+            }
+        }
+
+        SessionFileBrowser? browser = null;
+        if (payload.ValueKind == JsonValueKind.Object &&
+            payload.TryGetProperty("browser", out var browserEl) &&
+            browserEl.ValueKind == JsonValueKind.Object)
+        {
+            browser = ParseFileBrowser(browserEl);
+        }
+
+        return new SessionFileList
+        {
+            Key = FirstNonEmpty(GetStringSafe(payload, "sessionKey"), key) ?? key,
+            Root = GetStringSafe(payload, "root"),
+            Files = files,
+            Browser = browser,
+            IsSupported = true
+        };
+    }
+
+    internal static SessionFileContent ParseSessionFileContent(JsonElement payload, string key, string path)
+    {
+        // sessions.files.get wraps the entry under "file".
+        JsonElement file = default;
+        var hasFile = payload.ValueKind == JsonValueKind.Object &&
+                      payload.TryGetProperty("file", out file) &&
+                      file.ValueKind == JsonValueKind.Object;
+
+        if (!hasFile)
+        {
+            return new SessionFileContent { Key = key, Path = path, Missing = true, IsSupported = true };
+        }
+
+        return new SessionFileContent
+        {
+            Key = FirstNonEmpty(GetStringSafe(payload, "sessionKey"), key) ?? key,
+            Root = GetStringSafe(payload, "root"),
+            Path = FirstNonEmpty(GetString(file, "path"), path) ?? path,
+            Name = GetString(file, "name"),
+            Kind = GetString(file, "kind"),
+            Content = GetString(file, "content"),
+            Size = GetLongOrNull(file, "size"),
+            UpdatedAt = ParseUnixTimestampMs(file, "updatedAtMs"),
+            Missing = GetOptionalBool(file, "missing") ?? false,
+            IsSupported = true
+        };
+    }
+
+    private static SessionFileEntry ParseFileEntry(JsonElement item) => new()
+    {
+        Path = GetString(item, "path") ?? "",
+        Name = GetString(item, "name") ?? "",
+        Kind = GetString(item, "kind"),
+        Missing = GetOptionalBool(item, "missing") ?? false,
+        Size = GetLongOrNull(item, "size"),
+        UpdatedAt = ParseUnixTimestampMs(item, "updatedAtMs"),
+        Content = GetString(item, "content")
+    };
+
+    private static SessionFileBrowser ParseFileBrowser(JsonElement browserEl)
+    {
+        var entries = new List<SessionFileBrowserEntry>();
+        if (browserEl.TryGetProperty("entries", out var entriesEl) && entriesEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in entriesEl.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.Object) continue;
+                entries.Add(new SessionFileBrowserEntry
+                {
+                    Path = GetString(item, "path") ?? "",
+                    Name = GetString(item, "name") ?? "",
+                    Kind = GetString(item, "kind"),
+                    SessionKind = GetString(item, "sessionKind"),
+                    Size = GetLongOrNull(item, "size"),
+                    UpdatedAt = ParseUnixTimestampMs(item, "updatedAtMs")
+                });
+            }
+        }
+
+        return new SessionFileBrowser
+        {
+            Path = GetString(browserEl, "path") ?? "",
+            ParentPath = GetString(browserEl, "parentPath"),
+            Search = GetString(browserEl, "search"),
+            Entries = entries,
+            Truncated = GetOptionalBool(browserEl, "truncated") ?? false
+        };
+    }
+
+    // ── sessions.compaction.list / get / branch / restore ──
+
+    /// <summary>
+    /// Lists the compaction checkpoints for a session (powering the checkpoint
+    /// UX). Returns a result with <see cref="SessionCompactionCheckpointList.IsSupported"/>
+    /// = false when the gateway does not implement the method. Throws if the
+    /// connection is not open.
+    /// </summary>
+    public async Task<SessionCompactionCheckpointList> ListCompactionCheckpointsAsync(string key, int timeoutMs = 15000)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            return new SessionCompactionCheckpointList { Key = key ?? "" };
+
+        var payload = await TryRequestPayloadAsync("sessions.compaction.list", new { key }, timeoutMs).ConfigureAwait(false);
+        if (payload is null)
+            return new SessionCompactionCheckpointList { Key = key, IsSupported = false };
+
+        return ParseCompactionCheckpointList(payload.Value, key);
+    }
+
+    /// <summary>
+    /// Fetches a single compaction checkpoint's metadata. Returns a result with
+    /// <see cref="SessionCompactionCheckpointResult.IsSupported"/> = false when
+    /// the gateway does not implement the method.
+    /// </summary>
+    public async Task<SessionCompactionCheckpointResult> GetCompactionCheckpointAsync(string key, string checkpointId, int timeoutMs = 15000)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Session key is required", nameof(key));
+        if (string.IsNullOrWhiteSpace(checkpointId))
+            throw new ArgumentException("Checkpoint id is required", nameof(checkpointId));
+
+        var payload = await TryRequestPayloadAsync(
+            "sessions.compaction.get", new { key, checkpointId }, timeoutMs).ConfigureAwait(false);
+        if (payload is null)
+            return new SessionCompactionCheckpointResult { Key = key, IsSupported = false };
+
+        return ParseCompactionCheckpointResult(payload.Value, key);
+    }
+
+    /// <summary>
+    /// Branches a new session from a compaction checkpoint. The gateway error
+    /// (e.g. checkpoint not found) is surfaced in
+    /// <see cref="SessionCompactionMutationResult.Error"/> rather than thrown;
+    /// <see cref="SessionCompactionMutationResult.IsSupported"/> is false when
+    /// the gateway does not implement the method.
+    /// </summary>
+    public Task<SessionCompactionMutationResult> BranchCompactionCheckpointAsync(string key, string checkpointId, int timeoutMs = 15000)
+        => MutateCompactionAsync("sessions.compaction.branch", key, checkpointId, timeoutMs);
+
+    /// <summary>
+    /// Restores a session to a compaction checkpoint. The gateway error is
+    /// surfaced in <see cref="SessionCompactionMutationResult.Error"/> rather
+    /// than thrown; <see cref="SessionCompactionMutationResult.IsSupported"/> is
+    /// false when the gateway does not implement the method.
+    /// </summary>
+    public Task<SessionCompactionMutationResult> RestoreCompactionCheckpointAsync(string key, string checkpointId, int timeoutMs = 15000)
+        => MutateCompactionAsync("sessions.compaction.restore", key, checkpointId, timeoutMs);
+
+    private async Task<SessionCompactionMutationResult> MutateCompactionAsync(
+        string method, string key, string checkpointId, int timeoutMs)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            return new SessionCompactionMutationResult { Ok = false, CheckpointId = checkpointId, Error = "Session key is required" };
+        if (string.IsNullOrWhiteSpace(checkpointId))
+            return new SessionCompactionMutationResult { Ok = false, Key = key, Error = "Checkpoint id is required" };
+        if (!IsConnected)
+            return new SessionCompactionMutationResult { Ok = false, Key = key, CheckpointId = checkpointId, Error = "Gateway connection is not open" };
+
+        try
+        {
+            var payload = await SendWizardRequestAsync(method, new { key, checkpointId }, timeoutMs).ConfigureAwait(false);
+            return ParseCompactionMutation(payload, key, checkpointId);
+        }
+        catch (InvalidOperationException ex) when (IsUnknownMethodError(ex.Message))
+        {
+            _logger.Warn($"{method} unsupported on gateway");
+            return new SessionCompactionMutationResult
+            {
+                Ok = false,
+                Key = key,
+                CheckpointId = checkpointId,
+                Error = ex.Message,
+                IsSupported = false
+            };
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Genuine gateway error (e.g. checkpoint not found) — surface it,
+            // do not swallow.
+            _logger.Warn($"{method} failed: {ex.Message}");
+            return new SessionCompactionMutationResult
+            {
+                Ok = false,
+                Key = key,
+                CheckpointId = checkpointId,
+                Error = ex.Message
+            };
+        }
+    }
+
+    internal static SessionCompactionCheckpointList ParseCompactionCheckpointList(JsonElement payload, string key)
+    {
+        var array = TryGetArray(payload, "checkpoints");
+        var checkpoints = new List<SessionCompactionCheckpoint>();
+        if (array is { ValueKind: JsonValueKind.Array })
+        {
+            foreach (var item in array.Value.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.Object) continue;
+                var checkpoint = ParseCompactionCheckpoint(item);
+                if (!string.IsNullOrEmpty(checkpoint.Id))
+                    checkpoints.Add(checkpoint);
+            }
+        }
+
+        return new SessionCompactionCheckpointList
+        {
+            Key = FirstNonEmpty(GetStringSafe(payload, "key"), key) ?? key,
+            Checkpoints = checkpoints,
+            IsSupported = true
+        };
+    }
+
+    internal static SessionCompactionCheckpointResult ParseCompactionCheckpointResult(JsonElement payload, string key)
+    {
+        SessionCompactionCheckpoint? checkpoint = null;
+        if (payload.ValueKind == JsonValueKind.Object &&
+            payload.TryGetProperty("checkpoint", out var cpEl) &&
+            cpEl.ValueKind == JsonValueKind.Object)
+        {
+            var parsed = ParseCompactionCheckpoint(cpEl);
+            if (!string.IsNullOrEmpty(parsed.Id))
+                checkpoint = parsed;
+        }
+
+        return new SessionCompactionCheckpointResult
+        {
+            Key = FirstNonEmpty(GetStringSafe(payload, "key"), key) ?? key,
+            Checkpoint = checkpoint,
+            IsSupported = true
+        };
+    }
+
+    internal static SessionCompactionMutationResult ParseCompactionMutation(JsonElement payload, string key, string checkpointId)
+    {
+        SessionCompactionCheckpoint? checkpoint = null;
+        if (payload.ValueKind == JsonValueKind.Object &&
+            payload.TryGetProperty("checkpoint", out var cpEl) &&
+            cpEl.ValueKind == JsonValueKind.Object)
+        {
+            var parsed = ParseCompactionCheckpoint(cpEl);
+            if (!string.IsNullOrEmpty(parsed.Id))
+                checkpoint = parsed;
+        }
+
+        // branch returns { sourceKey, key=newBranchKey, ... }; restore returns { key, ... }.
+        return new SessionCompactionMutationResult
+        {
+            Ok = true,
+            Key = key,
+            CheckpointId = checkpointId,
+            SourceKey = GetStringSafe(payload, "sourceKey"),
+            ResultSessionKey = GetStringSafe(payload, "key"),
+            SessionId = GetStringSafe(payload, "sessionId"),
+            Checkpoint = checkpoint,
+            IsSupported = true
+        };
+    }
+
+    private static SessionCompactionCheckpoint ParseCompactionCheckpoint(JsonElement item) => new()
+    {
+        Id = FirstNonEmpty(GetString(item, "checkpointId"), GetString(item, "id")) ?? "",
+        SessionKey = GetString(item, "sessionKey"),
+        SessionId = GetString(item, "sessionId"),
+        CreatedAt = ParseUnixTimestampMs(item, "createdAt"),
+        Reason = GetString(item, "reason"),
+        TokensBefore = GetLongOrNull(item, "tokensBefore"),
+        TokensAfter = GetLongOrNull(item, "tokensAfter"),
+        Summary = GetString(item, "summary"),
+        FirstKeptEntryId = GetString(item, "firstKeptEntryId")
+    };
+
+    // ── Shared request + JSON helpers ──
+
+    /// <summary>
+    /// Sends a request/response RPC and returns its payload, or <c>null</c> when
+    /// the gateway reports the method is unknown (older gateway). All other
+    /// failures (connection not open, gateway error, timeout) propagate.
+    /// </summary>
+    private async Task<JsonElement?> TryRequestPayloadAsync(string method, object? parameters, int timeoutMs)
+    {
+        try
+        {
+            return await SendWizardRequestAsync(method, parameters, timeoutMs).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException ex) when (IsUnknownMethodError(ex.Message))
+        {
+            _logger.Warn($"{method} unsupported on gateway");
+            return null;
+        }
+    }
+
+    private static JsonElement? TryGetArray(JsonElement parent, string property)
+    {
+        if (parent.ValueKind == JsonValueKind.Object &&
+            parent.TryGetProperty(property, out var value) &&
+            value.ValueKind == JsonValueKind.Array)
+        {
+            return value;
+        }
+        return null;
+    }
+
+    // The shared GetString/GetOptionalBool helpers call TryGetProperty, which
+    // throws on a non-object element. A gateway payload is normally an object,
+    // but be defensive about bare arrays / null payloads.
+    private static string? GetStringSafe(JsonElement parent, string property)
+        => parent.ValueKind == JsonValueKind.Object ? GetString(parent, property) : null;
+
+    private static long? GetLongOrNull(JsonElement parent, string property)
+    {
+        if (parent.ValueKind != JsonValueKind.Object) return null;
+        if (!parent.TryGetProperty(property, out var value) || value.ValueKind != JsonValueKind.Number)
+            return null;
+        if (value.TryGetInt64(out var l)) return l;
+        if (value.TryGetDouble(out var d)) return (long)d;
+        return null;
+    }
+
+    private static List<string> GetStringArrayList(JsonElement parent, string property)
+        => parent.ValueKind == JsonValueKind.Object
+            ? GetStringArray(parent, property).ToList()
+            : new List<string>();
+
+    private static List<string> DistinctNonEmpty(IEnumerable<string?> values)
+    {
+        var result = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var value in values)
+        {
+            if (string.IsNullOrWhiteSpace(value)) continue;
+            if (seen.Add(value))
+                result.Add(value);
+        }
+        return result;
+    }
+}

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace OpenClaw.Shared;
 
-public class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
+public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatewayClient
 {
     private const string OperatorClientId = "cli";
     private const string OperatorClientDisplayName = "OpenClaw Windows Tray";

--- a/tests/OpenClaw.Shared.Tests/GatewayProtocolLiveRoundTripTests.cs
+++ b/tests/OpenClaw.Shared.Tests/GatewayProtocolLiveRoundTripTests.cs
@@ -1,0 +1,427 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenClaw.Shared;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OpenClaw.Shared.Tests;
+
+/// <summary>
+/// Real WebSocket round-trip proof for the gateway protocol client APIs.
+/// Unlike <see cref="GatewayProtocolModelsTests"/> (which exercise
+/// the parsers against crafted <see cref="JsonElement"/> payloads), these tests
+/// connect the <b>real</b> <see cref="OpenClawGatewayClient"/> over a <b>real</b>
+/// loopback WebSocket to a stub gateway, invoke each new typed method, and:
+///   1. capture the exact JSON request frame the client serialized onto the wire
+///      (proving it matches the upstream openclaw/openclaw schema — param names,
+///      method names, and the tri-state sessions.patch null/value encoding), and
+///   2. feed back schema-shaped responses and assert the typed DTOs parse.
+///
+/// This exercises the full method → SerializeRequest → socket send → server
+/// receive → response → parse → typed-DTO stack end-to-end. The captured frames
+/// are written to test output so they can serve as redacted behavior proof.
+/// </summary>
+public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly string _identityDir;
+
+    public GatewayProtocolLiveRoundTripTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _identityDir = Path.Combine(Path.GetTempPath(), "openclaw-rt-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_identityDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_identityDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task NewProtocolMethods_RealWebSocketRoundTrip_SendCorrectWireFramesAndParseResponses()
+    {
+        using var server = new LoopbackGatewayServer();
+        ConfigureResponders(server);
+
+        var logger = new TestLogger();
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", logger,
+            tokenIsBootstrapToken: false, bootstrapPairAsNode: false,
+            identityPath: _identityDir);
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+
+            const string key = "agent:main:main";
+            // Generous timeout: the happy path resolves as soon as the response
+            // arrives, but a large ceiling prevents load-induced flakiness on
+            // shared CI runners (the loopback server can be scheduling-starved
+            // when many test classes run in parallel).
+            const int rpc = 20000;
+
+            // ── 1. commands.list (typed catalog read) ──
+            var catalog = await client.ListCommandsAsync(timeoutMs: rpc);
+            Assert.True(catalog.IsSupported);
+            var cmd = Assert.Single(catalog.Commands);
+            Assert.Equal("model", cmd.Name);
+            var arg = Assert.Single(cmd.Args);
+            Assert.Equal("gpt-5", Assert.Single(arg.Choices).Value);
+
+            // ── 2. sessions.files.get (read; param must be sessionKey, response nested under "file") ──
+            var file = await client.GetSessionFileAsync(key, "src/a.cs", timeoutMs: rpc);
+            Assert.True(file.Found);
+            Assert.Equal("hello world", file.Content);
+            Assert.Contains("\"sessionKey\"", server.FrameFor("sessions.files.get"));
+
+            // ── 3. sessions.compaction.list + branch (param key/checkpointId; branch returns sourceKey + new key) ──
+            var checkpoints = await client.ListCompactionCheckpointsAsync(key, timeoutMs: rpc);
+            Assert.True(checkpoints.IsSupported);
+            Assert.Equal("cp1", Assert.Single(checkpoints.Checkpoints).Id);
+
+            var branch = await client.BranchCompactionCheckpointAsync(key, "cp1", timeoutMs: rpc);
+            Assert.True(branch.Ok);
+            Assert.Equal("agent:main:main", branch.SourceKey);
+            Assert.Equal("agent:main:branch-1", branch.ResultSessionKey);
+            Assert.Contains("\"checkpointId\"", server.FrameFor("sessions.compaction.branch"));
+
+            // ── 4. sessions.patch SET then CLEAR (the tri-state proof) ──
+            // PatchSessionAsync is fire-and-tracked (returns on send, not on
+            // response), so wait for the captured frame to arrive on the server.
+            var setOk = await client.PatchSessionAsync(key, new SessionPatch { Model = "gpt-5", FastMode = SessionFastMode.Auto });
+            Assert.True(setOk);
+            var setFrame = await server.WaitFrameAsync("sessions.patch", occurrence: 0, timeoutMs: rpc);
+            Assert.Contains("\"model\":\"gpt-5\"", setFrame);
+            Assert.Contains("\"fastMode\":\"auto\"", setFrame);
+
+            var clearOk = await client.PatchSessionAsync(key, new SessionPatch { Model = SessionPatch.Clear });
+            Assert.True(clearOk);
+            var clearFrame = await server.WaitFrameAsync("sessions.patch", occurrence: 1, timeoutMs: rpc);
+            Assert.Contains("\"model\":null", clearFrame);
+
+            PrintProof(server);
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
+    private static void ConfigureResponders(LoopbackGatewayServer server)
+    {
+        // NOTE: intentionally NO hello-ok responder. The new methods only require
+        // an open socket (IsConnectedToGateway), not the full handshake. Skipping
+        // hello-ok avoids the client's post-handshake auto-request storm
+        // (health/sessions.list/subscribe/usage/nodes/agents), keeping this test
+        // lightweight so it does not add scheduler/socket contention that could
+        // destabilize other timing-sensitive socket tests under parallel load.
+
+        server.OnMethod("commands.list", _ => new
+        {
+            commands = new object[]
+            {
+                new
+                {
+                    name = "model",
+                    description = "Change the active model",
+                    source = "native",
+                    scope = "both",
+                    acceptsArgs = true,
+                    args = new object[]
+                    {
+                        new
+                        {
+                            name = "id",
+                            description = "Model id",
+                            type = "string",
+                            choices = new object[] { new { value = "gpt-5", label = "GPT-5" } }
+                        }
+                    }
+                }
+            }
+        });
+
+        server.OnMethod("sessions.files.get", _ => new
+        {
+            sessionKey = "agent:main:main",
+            root = "/work/repo",
+            file = new
+            {
+                path = "src/a.cs",
+                name = "a.cs",
+                kind = "modified",
+                missing = false,
+                size = 11,
+                updatedAtMs = 1700000000000L,
+                content = "hello world"
+            }
+        });
+
+        server.OnMethod("sessions.compaction.list", _ => new
+        {
+            ok = true,
+            key = "agent:main:main",
+            checkpoints = new object[]
+            {
+                new { checkpointId = "cp1", sessionKey = "agent:main:main", sessionId = "sid-1", createdAt = 1700000000000L, reason = "manual" }
+            }
+        });
+
+        server.OnMethod("sessions.compaction.branch", _ => new
+        {
+            ok = true,
+            sourceKey = "agent:main:main",
+            key = "agent:main:branch-1",
+            sessionId = "sid-branch",
+            checkpoint = new { checkpointId = "cp1" }
+        });
+
+        // sessions.patch is a tracked (non-wizard) request; an ok response with a
+        // key payload completes it.
+        server.OnMethod("sessions.patch", _ => new { key = "agent:main:main" });
+    }
+
+    private static async Task ConnectAndWaitAsync(OpenClawGatewayClient client, LoopbackGatewayServer server)
+    {
+        var connected = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnStatus(object? _, ConnectionStatus s)
+        {
+            if (s == ConnectionStatus.Connected) connected.TrySetResult(true);
+        }
+        client.StatusChanged += OnStatus;
+        try
+        {
+            await client.ConnectAsync();
+            // The new methods only require an open socket (IsConnectedToGateway),
+            // not the full hello-ok handshake. Poll readiness with a generous
+            // ceiling so a load-starved runner doesn't cause a false failure;
+            // the loop exits as soon as the socket is open. The Connected event
+            // (hello-ok) is a fast-path signal but not required.
+            var deadline = DateTime.UtcNow.AddSeconds(20);
+            while (!client.IsConnectedToGateway && DateTime.UtcNow < deadline)
+            {
+                var completed = await Task.WhenAny(connected.Task, Task.Delay(100));
+                if (completed == connected.Task) break;
+            }
+            // Give the socket a final moment to flip to Open if the event fired.
+            for (var i = 0; i < 100 && !client.IsConnectedToGateway; i++)
+                await Task.Delay(50);
+            Assert.True(client.IsConnectedToGateway, "client did not reach connected state within timeout");
+        }
+        finally
+        {
+            client.StatusChanged -= OnStatus;
+        }
+    }
+
+    private void PrintProof(LoopbackGatewayServer server)
+    {
+        _output.WriteLine("===== Gateway protocol live round-trip: captured request frames =====");
+        foreach (var frame in server.AllFrames)
+        {
+            _output.WriteLine(frame);
+            Console.WriteLine("[gateway-rx] " + frame);
+        }
+        _output.WriteLine("====================================================================");
+    }
+
+    /// <summary>
+    /// Minimal real loopback WebSocket "gateway": accepts the client connection,
+    /// records every request frame, and replies with a per-method payload. Uses
+    /// the same HttpListener-on-127.0.0.1 pattern as the repo's other loopback
+    /// test servers (no admin/urlacl needed for an explicit loopback prefix).
+    /// </summary>
+    private sealed class LoopbackGatewayServer : IDisposable
+    {
+        private readonly HttpListener _listener;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _loop;
+        private readonly Dictionary<string, Func<JsonElement, object>> _responders = new(StringComparer.Ordinal);
+        private readonly ConcurrentQueue<(string Method, string Frame)> _frames = new();
+
+        public int Port { get; }
+        public string WebSocketUrl => $"ws://127.0.0.1:{Port}/";
+
+        public LoopbackGatewayServer()
+        {
+            // FindFreePort + HttpListener.Start has a TOCTOU race: another process
+            // can grab the port between probe and bind, especially when many test
+            // classes run in parallel. Retry on a fresh port a few times.
+            Exception? last = null;
+            for (var attempt = 0; attempt < 10; attempt++)
+            {
+                var candidate = FindFreePort();
+                var listener = new HttpListener();
+                listener.Prefixes.Add($"http://127.0.0.1:{candidate}/");
+                try
+                {
+                    listener.Start();
+                    _listener = listener;
+                    Port = candidate;
+                    _loop = Task.Run(AcceptLoopAsync);
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    last = ex;
+                    try { listener.Close(); } catch { /* ignore */ }
+                }
+            }
+            throw new InvalidOperationException("Could not bind a loopback HttpListener after multiple attempts", last);
+        }
+
+        public void OnMethod(string method, Func<JsonElement, object> responder) => _responders[method] = responder;
+
+        public IEnumerable<string> AllFrames
+        {
+            get
+            {
+                foreach (var f in _frames) yield return f.Frame;
+            }
+        }
+
+        /// <summary>Returns the captured request frame for the Nth occurrence of a method.</summary>
+        public string FrameFor(string method, int occurrence = 0)
+        {
+            if (TryGetFrame(method, occurrence, out var frame))
+                return frame;
+            throw new InvalidOperationException($"No captured frame for method '{method}' occurrence {occurrence}");
+        }
+
+        /// <summary>Waits for the Nth occurrence of a method's request frame to arrive.</summary>
+        public async Task<string> WaitFrameAsync(string method, int occurrence, int timeoutMs)
+        {
+            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+            while (DateTime.UtcNow < deadline)
+            {
+                if (TryGetFrame(method, occurrence, out var frame))
+                    return frame;
+                await Task.Delay(25);
+            }
+            throw new InvalidOperationException($"Timed out waiting for method '{method}' occurrence {occurrence}");
+        }
+
+        private bool TryGetFrame(string method, int occurrence, out string frame)
+        {
+            var seen = 0;
+            foreach (var f in _frames)
+            {
+                if (f.Method != method) continue;
+                if (seen == occurrence) { frame = f.Frame; return true; }
+                seen++;
+            }
+            frame = "";
+            return false;
+        }
+
+        private async Task AcceptLoopAsync()
+        {
+            while (!_cts.IsCancellationRequested && _listener.IsListening)
+            {
+                HttpListenerContext ctx;
+                try { ctx = await _listener.GetContextAsync(); }
+                catch { return; }
+
+                if (!ctx.Request.IsWebSocketRequest)
+                {
+                    ctx.Response.StatusCode = 400;
+                    ctx.Response.Close();
+                    continue;
+                }
+
+                _ = Task.Run(() => ServeAsync(ctx));
+            }
+        }
+
+        private async Task ServeAsync(HttpListenerContext ctx)
+        {
+            WebSocketContext wsCtx;
+            try { wsCtx = await ctx.AcceptWebSocketAsync(subProtocol: null); }
+            catch { return; }
+
+            var socket = wsCtx.WebSocket;
+            var buffer = new byte[16 * 1024];
+            var sb = new StringBuilder();
+
+            try
+            {
+                while (socket.State == WebSocketState.Open && !_cts.IsCancellationRequested)
+                {
+                    sb.Clear();
+                    WebSocketReceiveResult result;
+                    do
+                    {
+                        result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), _cts.Token);
+                        if (result.MessageType == WebSocketMessageType.Close)
+                        {
+                            await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None);
+                            return;
+                        }
+                        sb.Append(Encoding.UTF8.GetString(buffer, 0, result.Count));
+                    }
+                    while (!result.EndOfMessage);
+
+                    await HandleFrameAsync(socket, sb.ToString());
+                }
+            }
+            catch (OperationCanceledException) { /* shutting down */ }
+            catch { /* client closed */ }
+        }
+
+        private async Task HandleFrameAsync(WebSocket socket, string frame)
+        {
+            string? id = null, method = null;
+            JsonElement parameters = default;
+            try
+            {
+                using var doc = JsonDocument.Parse(frame);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("type", out var t) && t.GetString() != "req") return;
+                id = root.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+                method = root.TryGetProperty("method", out var mEl) ? mEl.GetString() : null;
+                if (root.TryGetProperty("params", out var p)) parameters = p.Clone();
+            }
+            catch { return; }
+
+            if (method is null || id is null) return;
+
+            _frames.Enqueue((method, frame));
+
+            object payload = _responders.TryGetValue(method, out var responder)
+                ? responder(parameters)
+                : new { };
+
+            var response = JsonSerializer.Serialize(new { type = "res", id, ok = true, payload });
+            var bytes = Encoding.UTF8.GetBytes(response);
+            await socket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, endOfMessage: true, CancellationToken.None);
+        }
+
+        private static int FindFreePort()
+        {
+            var l = new TcpListener(IPAddress.Loopback, 0);
+            l.Start();
+            var port = ((IPEndPoint)l.LocalEndpoint).Port;
+            l.Stop();
+            return port;
+        }
+
+        public void Dispose()
+        {
+            try { _cts.Cancel(); } catch { }
+            try { _listener.Stop(); } catch { }
+            try { _listener.Close(); } catch { }
+            try { _loop.Wait(TimeSpan.FromSeconds(2)); } catch { }
+            _cts.Dispose();
+        }
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/GatewayProtocolModelsTests.cs
+++ b/tests/OpenClaw.Shared.Tests/GatewayProtocolModelsTests.cs
@@ -1,0 +1,605 @@
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using OpenClaw.Shared;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+/// <summary>
+/// Unit tests for the gateway protocol DTOs and parsing. Exercises the internal static parse methods
+/// directly via crafted JsonElement payloads that mirror the canonical
+/// openclaw/openclaw gateway-protocol schemas, plus request payload shaping.
+/// </summary>
+public class GatewayProtocolModelsTests
+{
+    [Fact]
+    public void NewGatewayProtocolMembers_AreDefaultInterfaceMethods_SoTheyDoNotSourceBreakImplementers()
+    {
+        // Backwards-compat guard: the members added to IOperatorGatewayClient
+        // ship as default interface methods (non-abstract), so existing external
+        // implementers / test doubles keep compiling without implementing them.
+        // Looked up by exact signature because some names (e.g. PatchSessionAsync)
+        // have a pre-existing legacy overload that must remain.
+        var iface = typeof(IOperatorGatewayClient);
+        var newMembers = new (string Name, System.Type[] Args)[]
+        {
+            ("ListCommandsAsync", new[] { typeof(CommandCatalogQuery), typeof(int) }),
+            ("PatchSessionAsync", new[] { typeof(string), typeof(SessionPatch) }),
+            ("ListSessionFilesAsync", new[] { typeof(string), typeof(string), typeof(string), typeof(int) }),
+            ("GetSessionFileAsync", new[] { typeof(string), typeof(string), typeof(int) }),
+            ("ListCompactionCheckpointsAsync", new[] { typeof(string), typeof(int) }),
+            ("GetCompactionCheckpointAsync", new[] { typeof(string), typeof(string), typeof(int) }),
+            ("BranchCompactionCheckpointAsync", new[] { typeof(string), typeof(string), typeof(int) }),
+            ("RestoreCompactionCheckpointAsync", new[] { typeof(string), typeof(string), typeof(int) }),
+        };
+
+        foreach (var (name, args) in newMembers)
+        {
+            var method = iface.GetMethod(name, args);
+            Assert.NotNull(method);
+            Assert.False(method!.IsAbstract,
+                $"{name} must have a default implementation (non-abstract) to avoid source-breaking IOperatorGatewayClient implementers");
+        }
+    }
+
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+
+    // ── commands.list ──
+
+    [Fact]
+    public void ParseCommandCatalog_ParsesCommandsArgsAndObjectChoices()
+    {
+        var payload = Parse("""
+        {
+          "commands": [
+            {
+              "name": "model",
+              "nativeName": "Model",
+              "textAliases": ["/m", "/setmodel"],
+              "description": "Change the active model",
+              "category": "session",
+              "source": "native",
+              "scope": "both",
+              "acceptsArgs": true,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Model id",
+                  "type": "string",
+                  "required": true,
+                  "dynamic": true,
+                  "choices": [
+                    { "value": "gpt-5", "label": "GPT-5" },
+                    { "value": "claude", "label": "Claude" }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "help",
+              "description": "Show help",
+              "category": "status",
+              "source": "native",
+              "scope": "text",
+              "acceptsArgs": false
+            }
+          ]
+        }
+        """);
+
+        var catalog = OpenClawGatewayClient.ParseCommandCatalog(payload);
+
+        Assert.True(catalog.IsSupported);
+        Assert.Equal(2, catalog.Count);
+
+        var model = catalog.Commands[0];
+        Assert.Equal("model", model.Name);
+        Assert.Equal("Model", model.NativeName);
+        Assert.Equal(new[] { "/m", "/setmodel" }, model.TextAliases);
+        Assert.Equal("session", model.Category);
+        Assert.Equal("native", model.Source);
+        Assert.Equal("both", model.Scope);
+        Assert.True(model.AcceptsArgs);
+
+        var arg = Assert.Single(model.Args);
+        Assert.Equal("id", arg.Name);
+        Assert.Equal("string", arg.Type);
+        Assert.True(arg.Required);
+        Assert.True(arg.IsDynamic);
+        Assert.Equal(2, arg.Choices.Count);
+        Assert.Equal("gpt-5", arg.Choices[0].Value);
+        Assert.Equal("GPT-5", arg.Choices[0].Label);
+
+        // Facets derived from the commands (gateway returns no facet lists).
+        Assert.Equal(new[] { "session", "status" }, catalog.Categories);
+        Assert.Equal(new[] { "both", "text" }, catalog.Scopes);
+        Assert.Equal(new[] { "native" }, catalog.Sources);
+    }
+
+    [Fact]
+    public void ParseCommandCatalog_AcceptsTopLevelArray()
+    {
+        var payload = Parse("""[ { "name": "ping", "description": "", "source": "native", "scope": "text", "acceptsArgs": false } ]""");
+
+        var catalog = OpenClawGatewayClient.ParseCommandCatalog(payload);
+
+        var cmd = Assert.Single(catalog.Commands);
+        Assert.Equal("ping", cmd.Name);
+        Assert.False(cmd.AcceptsArgs);
+    }
+
+    [Fact]
+    public void CommandCatalogQuery_Matches_FiltersByCategorySourceScopeAndSearch()
+    {
+        var cmd = new GatewayCommand
+        {
+            Name = "model",
+            Description = "Change the model",
+            Category = "session",
+            Source = "native",
+            Scope = "both",
+            AcceptsArgs = true,
+            TextAliases = new[] { "/m" }
+        };
+
+        Assert.True(new CommandCatalogQuery { Category = "SESSION" }.Matches(cmd));
+        Assert.False(new CommandCatalogQuery { Category = "status" }.Matches(cmd));
+        Assert.True(new CommandCatalogQuery { Source = "native", Scope = "both" }.Matches(cmd));
+        Assert.True(new CommandCatalogQuery { Search = "change" }.Matches(cmd));
+        Assert.True(new CommandCatalogQuery { Search = "/m" }.Matches(cmd)); // alias
+        Assert.False(new CommandCatalogQuery { Search = "zzz" }.Matches(cmd));
+        Assert.True(new CommandCatalogQuery { AcceptsArgs = true }.Matches(cmd));
+        Assert.False(new CommandCatalogQuery { AcceptsArgs = false }.Matches(cmd));
+    }
+
+    [Fact]
+    public void ApplyCommandQuery_FiltersCatalogAndPreservesFacets()
+    {
+        var catalog = OpenClawGatewayClient.ParseCommandCatalog(Parse("""
+        {
+          "commands": [
+            { "name": "a", "description": "", "category": "session", "source": "native", "scope": "both", "acceptsArgs": false },
+            { "name": "b", "description": "", "category": "status", "source": "native", "scope": "both", "acceptsArgs": false }
+          ]
+        }
+        """));
+
+        var filtered = OpenClawGatewayClient.ApplyCommandQuery(catalog, new CommandCatalogQuery { Category = "session" });
+
+        Assert.Single(filtered.Commands);
+        Assert.Equal("a", filtered.Commands[0].Name);
+        Assert.Equal(new[] { "session", "status" }, filtered.Categories);
+    }
+
+    [Fact]
+    public void CommandCatalogQuery_HasFilter_TrueOnlyWhenSet()
+    {
+        Assert.False(new CommandCatalogQuery().HasFilter);
+        Assert.True(new CommandCatalogQuery { Search = "x" }.HasFilter);
+        Assert.True(new CommandCatalogQuery { AcceptsArgs = false }.HasFilter);
+    }
+
+    // ── sessions.patch payload shape ──
+
+    [Fact]
+    public void SessionPatch_ToPayload_EncodesEnumsAndWireNames()
+    {
+        var patch = new SessionPatch
+        {
+            Model = "gpt-5",
+            ThinkingLevel = "high",
+            FastMode = SessionFastMode.Auto,
+            ReasoningLevel = "medium",
+            ResponseUsage = ResponseUsageMode.Tokens,
+            ExecSecurity = "allowlist",
+            ExecNode = "worker-1",
+            SendPolicy = SessionSendPolicy.Allow,
+            GroupActivation = SessionGroupActivation.Mention
+        };
+
+        var payload = patch.ToPayload("agent:main");
+
+        Assert.Equal("agent:main", payload["key"]);
+        Assert.Equal("gpt-5", payload["model"]);
+        Assert.Equal("high", payload["thinkingLevel"]);
+        Assert.Equal("auto", payload["fastMode"]);
+        Assert.Equal("medium", payload["reasoningLevel"]);
+        Assert.Equal("tokens", payload["responseUsage"]);
+        Assert.Equal("allowlist", payload["execSecurity"]);
+        Assert.Equal("worker-1", payload["execNode"]);
+        Assert.Equal("allow", payload["sendPolicy"]);
+        Assert.Equal("mention", payload["groupActivation"]);
+
+        // Unset fields must not be present.
+        Assert.False(payload.ContainsKey("verboseLevel"));
+        Assert.False(payload.ContainsKey("traceLevel"));
+        Assert.False(payload.ContainsKey("elevatedLevel"));
+        Assert.False(payload.ContainsKey("execHost"));
+        Assert.False(payload.ContainsKey("execAsk"));
+    }
+
+    [Fact]
+    public void SessionPatch_ToPayload_FastModeBooleanAndResponseUsageVariants()
+    {
+        var on = new SessionPatch { FastMode = SessionFastMode.On, ResponseUsage = ResponseUsageMode.Off }.ToPayload("k");
+        Assert.Equal(true, on["fastMode"]);
+        Assert.Equal("off", on["responseUsage"]);
+
+        var off = new SessionPatch { FastMode = SessionFastMode.Off, ResponseUsage = ResponseUsageMode.Full }.ToPayload("k");
+        Assert.Equal(false, off["fastMode"]);
+        Assert.Equal("full", off["responseUsage"]);
+
+        var legacy = new SessionPatch { ResponseUsage = ResponseUsageMode.On, SendPolicy = SessionSendPolicy.Deny, GroupActivation = SessionGroupActivation.Always }.ToPayload("k");
+        Assert.Equal("on", legacy["responseUsage"]);
+        Assert.Equal("deny", legacy["sendPolicy"]);
+        Assert.Equal("always", legacy["groupActivation"]);
+    }
+
+    [Fact]
+    public void SessionPatch_ToPayload_SerializesFastModeAutoAsString()
+    {
+        var json = JsonSerializer.Serialize(new SessionPatch { FastMode = SessionFastMode.Auto }.ToPayload("k"));
+        Assert.Contains("\"fastMode\":\"auto\"", json);
+
+        var jsonOn = JsonSerializer.Serialize(new SessionPatch { FastMode = SessionFastMode.On }.ToPayload("k"));
+        Assert.Contains("\"fastMode\":true", jsonOn);
+    }
+
+    [Fact]
+    public void CommandCatalogQuery_Scope_IncludesBothSurfaceCommands()
+    {
+        var textCmd = new GatewayCommand { Name = "t", Scope = "text" };
+        var nativeCmd = new GatewayCommand { Name = "n", Scope = "native" };
+        var bothCmd = new GatewayCommand { Name = "b", Scope = "both" };
+
+        // Filtering "text" includes text + both; excludes native-only.
+        Assert.True(new CommandCatalogQuery { Scope = "text" }.Matches(textCmd));
+        Assert.True(new CommandCatalogQuery { Scope = "text" }.Matches(bothCmd));
+        Assert.False(new CommandCatalogQuery { Scope = "text" }.Matches(nativeCmd));
+
+        // Filtering "native" includes native + both; excludes text-only.
+        Assert.True(new CommandCatalogQuery { Scope = "native" }.Matches(nativeCmd));
+        Assert.True(new CommandCatalogQuery { Scope = "native" }.Matches(bothCmd));
+        Assert.False(new CommandCatalogQuery { Scope = "native" }.Matches(textCmd));
+
+        // Filtering "both" returns everything.
+        Assert.True(new CommandCatalogQuery { Scope = "both" }.Matches(textCmd));
+        Assert.True(new CommandCatalogQuery { Scope = "both" }.Matches(nativeCmd));
+        Assert.True(new CommandCatalogQuery { Scope = "both" }.Matches(bothCmd));
+    }
+
+    [Fact]
+    public void SessionPatch_ToPayload_OmitsBlankStringsAndNoChangeKeyOnly()
+    {
+        // Blank/whitespace NonEmptyString fields must not be sent (strict gateway rejects "").
+        var patch = new SessionPatch { Model = "  ", ExecHost = "", ThinkingLevel = "high" };
+        var payload = patch.ToPayload("k");
+
+        Assert.False(payload.ContainsKey("model"));
+        Assert.False(payload.ContainsKey("execHost"));
+        Assert.Equal("high", payload["thinkingLevel"]);
+
+        // A patch whose only string fields are blank reports no changes.
+        Assert.False(new SessionPatch { Model = "   " }.HasChanges);
+    }
+
+    [Fact]
+    public void SessionPatch_HasChanges_ReflectsSetState()
+    {
+        Assert.False(new SessionPatch().HasChanges);
+        Assert.True(new SessionPatch { Model = "x" }.HasChanges);
+        Assert.True(new SessionPatch { GroupActivation = SessionGroupActivation.Always }.HasChanges);
+        // A clear-only patch is a change (it removes an override).
+        Assert.True(new SessionPatch { Model = SessionPatch.Clear }.HasChanges);
+        Assert.True(new SessionPatch { FastMode = SessionPatch.Clear }.HasChanges);
+    }
+
+    [Fact]
+    public void SessionPatch_ToPayload_ClearEmitsExplicitNullForStringAndEnumFields()
+    {
+        var patch = new SessionPatch
+        {
+            Model = SessionPatch.Clear,
+            ExecNode = SessionPatch.Clear,
+            FastMode = SessionPatch.Clear,
+            ResponseUsage = SessionPatch.Clear,
+            SendPolicy = SessionPatch.Clear,
+            GroupActivation = SessionPatch.Clear
+        };
+
+        var payload = patch.ToPayload("agent:main");
+
+        // Cleared fields are present with an explicit null value (not omitted).
+        foreach (var name in new[] { "model", "execNode", "fastMode", "responseUsage", "sendPolicy", "groupActivation" })
+        {
+            Assert.True(payload.ContainsKey(name), $"expected '{name}' to be present");
+            Assert.Null(payload[name]);
+        }
+
+        // Untouched fields stay omitted.
+        Assert.False(payload.ContainsKey("thinkingLevel"));
+        Assert.False(payload.ContainsKey("execHost"));
+    }
+
+    [Fact]
+    public void SessionPatch_ToPayload_ClearSerializesToJsonNull()
+    {
+        var json = JsonSerializer.Serialize(new SessionPatch { Model = SessionPatch.Clear }.ToPayload("k"));
+        Assert.Contains("\"model\":null", json);
+
+        var fastJson = JsonSerializer.Serialize(new SessionPatch { FastMode = SessionPatch.Clear }.ToPayload("k"));
+        Assert.Contains("\"fastMode\":null", fastJson);
+    }
+
+    [Fact]
+    public void SessionPatch_ToPayload_MixesSetAndClearAndUnset()
+    {
+        // model set to value, execHost cleared, thinkingLevel left unset.
+        var payload = new SessionPatch
+        {
+            Model = "gpt-5",
+            ExecHost = SessionPatch.Clear
+        }.ToPayload("k");
+
+        Assert.Equal("gpt-5", payload["model"]);
+        Assert.True(payload.ContainsKey("execHost"));
+        Assert.Null(payload["execHost"]);
+        Assert.False(payload.ContainsKey("thinkingLevel"));
+    }
+
+    [Fact]
+    public void PatchField_TriStateFlags()
+    {
+        PatchField<string> unset = default;
+        Assert.False(unset.IsSpecified);
+        Assert.False(unset.IsClear);
+        Assert.False(unset.HasValue);
+
+        PatchField<string> set = "v";
+        Assert.True(set.IsSpecified);
+        Assert.False(set.IsClear);
+        Assert.True(set.HasValue);
+        Assert.Equal("v", set.Value);
+
+        PatchField<string> cleared = SessionPatch.Clear;
+        Assert.True(cleared.IsSpecified);
+        Assert.True(cleared.IsClear);
+        Assert.False(cleared.HasValue);
+
+        // A null reference assigned via implicit conversion is unset, not a clear.
+        PatchField<string> fromNull = (string?)null;
+        Assert.False(fromNull.IsSpecified);
+        Assert.False(fromNull.IsClear);
+    }
+
+    [Fact]
+    public void SessionPatch_ToPayload_EmitsOnlyKnownGatewaySchemaFields()
+    {
+        // Contract guard: every wire name must exist in the upstream
+        // SessionsPatchParamsSchema (additionalProperties:false). A single typo
+        // would cause the gateway to reject the whole patch, so pin the exact
+        // key set here. Set every modelled field so the full surface is covered.
+        var patch = new SessionPatch
+        {
+            Model = "m",
+            ThinkingLevel = "t",
+            FastMode = SessionFastMode.Auto,
+            VerboseLevel = "v",
+            TraceLevel = "tr",
+            ReasoningLevel = "r",
+            ResponseUsage = ResponseUsageMode.Full,
+            ElevatedLevel = "e",
+            ExecHost = "auto",
+            ExecSecurity = "allowlist",
+            ExecAsk = "on-miss",
+            ExecNode = "n",
+            SendPolicy = SessionSendPolicy.Allow,
+            GroupActivation = SessionGroupActivation.Mention
+        };
+
+        var keys = patch.ToPayload("agent:main").Keys.OrderBy(k => k).ToArray();
+
+        var expected = new[]
+        {
+            "elevatedLevel", "execAsk", "execHost", "execNode", "execSecurity",
+            "fastMode", "groupActivation", "key", "model", "reasoningLevel",
+            "responseUsage", "sendPolicy", "thinkingLevel", "traceLevel", "verboseLevel"
+        }.OrderBy(k => k).ToArray();
+
+        Assert.Equal(expected, keys);
+    }
+
+    // ── sessions.files.list / get ──
+
+    [Fact]
+    public void ParseSessionFileList_ParsesFilesAndBrowser()
+    {
+        var payload = Parse("""
+        {
+          "sessionKey": "agent:main:main",
+          "root": "/work/repo",
+          "files": [
+            { "path": "src/main.cs", "name": "main.cs", "kind": "modified", "missing": false, "size": 1234, "updatedAtMs": 1700000000000 },
+            { "path": "old.txt", "name": "old.txt", "kind": "read", "missing": true }
+          ],
+          "browser": {
+            "path": "src",
+            "parentPath": "",
+            "entries": [
+              { "path": "src/sub", "name": "sub", "kind": "directory", "sessionKind": "mixed" },
+              { "path": "src/main.cs", "name": "main.cs", "kind": "file", "size": 1234, "updatedAtMs": 1700000000000 }
+            ],
+            "truncated": false
+          }
+        }
+        """);
+
+        var list = OpenClawGatewayClient.ParseSessionFileList(payload, "agent:main:main");
+
+        Assert.True(list.IsSupported);
+        Assert.Equal("agent:main:main", list.Key);
+        Assert.Equal("/work/repo", list.Root);
+        Assert.Equal(2, list.Files.Count);
+
+        var file = list.Files[0];
+        Assert.Equal("src/main.cs", file.Path);
+        Assert.Equal("main.cs", file.Name);
+        Assert.Equal("modified", file.Kind);
+        Assert.False(file.Missing);
+        Assert.Equal(1234, file.Size);
+        Assert.NotNull(file.UpdatedAt);
+
+        Assert.True(list.Files[1].Missing);
+
+        Assert.NotNull(list.Browser);
+        Assert.Equal("src", list.Browser!.Path);
+        Assert.Equal(2, list.Browser.Entries.Count);
+        Assert.True(list.Browser.Entries[0].IsDirectory);
+        Assert.Equal("mixed", list.Browser.Entries[0].SessionKind);
+        Assert.False(list.Browser.Entries[1].IsDirectory);
+    }
+
+    [Fact]
+    public void ParseSessionFileContent_ParsesNestedFile()
+    {
+        var payload = Parse("""
+        {
+          "sessionKey": "agent:main:main",
+          "root": "/work/repo",
+          "file": {
+            "path": "notes.txt",
+            "name": "notes.txt",
+            "kind": "modified",
+            "missing": false,
+            "size": 11,
+            "updatedAtMs": 1700000000000,
+            "content": "hello world"
+          }
+        }
+        """);
+
+        var content = OpenClawGatewayClient.ParseSessionFileContent(payload, "agent:main:main", "notes.txt");
+
+        Assert.True(content.IsSupported);
+        Assert.True(content.Found);
+        Assert.False(content.Missing);
+        Assert.Equal("agent:main:main", content.Key);
+        Assert.Equal("/work/repo", content.Root);
+        Assert.Equal("notes.txt", content.Path);
+        Assert.Equal("hello world", content.Content);
+        Assert.Equal("modified", content.Kind);
+        Assert.Equal(11, content.Size);
+        Assert.NotNull(content.UpdatedAt);
+    }
+
+    [Fact]
+    public void ParseSessionFileContent_NoFileMeansMissing()
+    {
+        var payload = Parse("""{ "sessionKey": "agent:main:main" }""");
+
+        var content = OpenClawGatewayClient.ParseSessionFileContent(payload, "agent:main:main", "missing.txt");
+
+        Assert.True(content.Missing);
+        Assert.False(content.Found);
+        Assert.Null(content.Content);
+        Assert.Equal("missing.txt", content.Path);
+    }
+
+    // ── sessions.compaction.* ──
+
+    [Fact]
+    public void ParseCompactionCheckpointList_ParsesCheckpoints()
+    {
+        var payload = Parse("""
+        {
+          "ok": true,
+          "key": "agent:main:main",
+          "checkpoints": [
+            { "checkpointId": "cp1", "sessionKey": "agent:main:main", "sessionId": "sid-1", "createdAt": 1700000000000, "reason": "auto-threshold", "tokensBefore": 9000, "tokensAfter": 1200, "summary": "snapshot" },
+            { "checkpointId": "cp2", "sessionKey": "agent:main:main", "sessionId": "sid-2", "createdAt": 1700000001000, "reason": "manual" }
+          ]
+        }
+        """);
+
+        var list = OpenClawGatewayClient.ParseCompactionCheckpointList(payload, "agent:main:main");
+
+        Assert.True(list.IsSupported);
+        Assert.Equal("agent:main:main", list.Key);
+        Assert.Equal(2, list.Checkpoints.Count);
+
+        var cp = list.Checkpoints[0];
+        Assert.Equal("cp1", cp.Id);
+        Assert.Equal("sid-1", cp.SessionId);
+        Assert.Equal("auto-threshold", cp.Reason);
+        Assert.Equal(9000, cp.TokensBefore);
+        Assert.Equal(1200, cp.TokensAfter);
+        Assert.Equal("snapshot", cp.Summary);
+        Assert.NotNull(cp.CreatedAt);
+    }
+
+    [Fact]
+    public void ParseCompactionCheckpointResult_ParsesSingleCheckpoint()
+    {
+        var payload = Parse("""
+        {
+          "ok": true,
+          "key": "agent:main:main",
+          "checkpoint": { "checkpointId": "cp1", "sessionId": "sid-1", "reason": "manual" }
+        }
+        """);
+
+        var result = OpenClawGatewayClient.ParseCompactionCheckpointResult(payload, "agent:main:main");
+
+        Assert.True(result.IsSupported);
+        Assert.True(result.Found);
+        Assert.NotNull(result.Checkpoint);
+        Assert.Equal("cp1", result.Checkpoint!.Id);
+        Assert.Equal("manual", result.Checkpoint.Reason);
+    }
+
+    [Fact]
+    public void ParseCompactionMutation_BranchExtractsSourceAndNewKey()
+    {
+        var payload = Parse("""
+        {
+          "ok": true,
+          "sourceKey": "agent:main:main",
+          "key": "agent:main:branch-1",
+          "sessionId": "sid-branch",
+          "checkpoint": { "checkpointId": "cp1" }
+        }
+        """);
+
+        var result = OpenClawGatewayClient.ParseCompactionMutation(payload, "agent:main:main", "cp1");
+
+        Assert.True(result.Ok);
+        Assert.True(result.IsSupported);
+        Assert.Equal("agent:main:main", result.Key);
+        Assert.Equal("cp1", result.CheckpointId);
+        Assert.Equal("agent:main:main", result.SourceKey);
+        Assert.Equal("agent:main:branch-1", result.ResultSessionKey);
+        Assert.Equal("sid-branch", result.SessionId);
+        Assert.NotNull(result.Checkpoint);
+    }
+
+    [Fact]
+    public void ParseCompactionMutation_RestoreUsesKeyAsResult()
+    {
+        var payload = Parse("""
+        {
+          "ok": true,
+          "key": "agent:main:main",
+          "sessionId": "sid-restored",
+          "checkpoint": { "checkpointId": "cp1" }
+        }
+        """);
+
+        var result = OpenClawGatewayClient.ParseCompactionMutation(payload, "agent:main:main", "cp1");
+
+        Assert.True(result.Ok);
+        Assert.Null(result.SourceKey);
+        Assert.Equal("agent:main:main", result.ResultSessionKey);
+        Assert.Equal("sid-restored", result.SessionId);
+    }
+}


### PR DESCRIPTION
## Summary

Adds typed Windows client support for newer OpenClaw gateway protocol APIs so UI and service code can consume protocol responses through stable DTOs instead of hand-parsing raw JSON.

This change adds client/DTO support only; it does not wire new UI surfaces. Wire shapes were verified against the canonical `openclaw/openclaw` gateway protocol schemas and covered by a real loopback WebSocket round-trip test.

## What's changing

### New typed APIs on `OpenClawGatewayClient` and `IOperatorGatewayClient`
| API | Gateway method | Purpose |
|-----|----------------|---------|
| `ListCommandsAsync(CommandCatalogQuery?)` | `commands.list` | Command catalog entries with names, aliases, descriptions, categories, sources, scopes, typed args, `{value,label}` choices, and dynamic flags. |
| `PatchSessionAsync(key, SessionPatch)` | `sessions.patch` | Extended per-session settings: model, thinking/verbose/trace/reasoning/elevated levels, fast mode, response usage, exec host/security/ask/node, send policy, and group activation. |
| `ListSessionFilesAsync(key, path?, search?)` / `GetSessionFileAsync(key, path)` | `sessions.files.list` / `get` | Files referenced by a session plus optional browser/folder data. |
| `ListCompactionCheckpointsAsync` / `GetCompactionCheckpointAsync` / `BranchCompactionCheckpointAsync` / `RestoreCompactionCheckpointAsync` | `sessions.compaction.*` | List, fetch, branch from, and restore compaction checkpoints. |

### Tri-state `SessionPatch`
`SessionPatch` fields use `PatchField<T>` so each setting can be **unset**, **set**, or **cleared**:
```csharp
patch.Model = "gpt-5";            // set    → "model":"gpt-5"
patch.Model = SessionPatch.Clear; // clear  → "model":null  (removes the session override)
// untouched                      // unset  → omitted
patch.Model = null;               // unset  (null reference = leave alone, NOT clear)
```
The gateway schema allows explicit `null` for patch fields to remove an override. Existing value assignments compile unchanged through implicit conversion. Blank string values are omitted because the gateway rejects empty `NonEmptyString` values; clearing always sends a JSON `null`.

### Compatibility behavior
- Older gateways that do not implement these methods return typed results with `IsSupported = false` when the gateway reports an unknown method.
- Genuine protocol errors are not swallowed: read methods propagate them; mutation methods surface them in `result.Error`.
- The new `IOperatorGatewayClient` members are default interface methods with unsupported defaults, so existing external implementers and test doubles do not source-break.
- The existing legacy `PatchSessionAsync(key, model:, thinkingLevel:, verboseLevel:)` overload remains unchanged.

## Files changed
| File | Change |
|------|--------|
| `src/OpenClaw.Shared/GatewayProtocolModels.cs` | DTOs, enums, `PatchField<T>` tri-state patch fields |
| `src/OpenClaw.Shared/OpenClawGatewayClient.Protocol.cs` | Client methods and parsers for command catalog, session files, session patch, and compaction checkpoints |
| `src/OpenClaw.Shared/OpenClawGatewayClient.cs` | Marks the client class as `partial` |
| `src/OpenClaw.Shared/IOperatorGatewayClient.cs` | Adds default-method declarations for the new protocol APIs |
| `tests/OpenClaw.Shared.Tests/GatewayProtocolModelsTests.cs` | Parser, payload, tri-state, and default-interface compatibility tests |
| `tests/OpenClaw.Shared.Tests/GatewayProtocolLiveRoundTripTests.cs` | Loopback WebSocket round-trip proof for actual serialized wire frames |

## Validation
- `./build.ps1` — all 5 projects build ✅
- `OpenClaw.Shared.Tests` — **2395 passed**, 29 skipped ✅
- `OpenClaw.Tray.Tests` — **1123 passed** ✅
- Round-trip proof test stability: **0 failures across 30+ isolated/full-suite runs** after hardening. Full-suite flakes observed during investigation were from pre-existing `WebSocketClientBaseTests.ReconnectBackoff_*` tests on the base branch, not this change.

## Proof — real WebSocket round-trip

`GatewayProtocolLiveRoundTripTests` connects the real `OpenClawGatewayClient` over a real loopback WebSocket to a stub gateway, invokes the new protocol methods, captures the exact JSON request frames, returns schema-shaped responses, and asserts the typed DTOs parse. This exercises the full client serialization and response parsing stack.

Captured request frames from the passing test:
```
{"type":"req","id":"…","method":"commands.list"}
{"type":"req","id":"…","method":"sessions.files.get","params":{"sessionKey":"agent:main:main","path":"src/a.cs"}}
{"type":"req","id":"…","method":"sessions.compaction.list","params":{"key":"agent:main:main"}}
{"type":"req","id":"…","method":"sessions.compaction.branch","params":{"key":"agent:main:main","checkpointId":"cp1"}}
{"type":"req","id":"…","method":"sessions.patch","params":{"key":"agent:main:main","model":"gpt-5","fastMode":"auto"}}
{"type":"req","id":"…","method":"sessions.patch","params":{"key":"agent:main:main","model":null}}
```

## Risks / known limitations
- The DTOs intentionally track the external gateway protocol schema. If that schema changes, this layer will need an update.
- Unknown-method downgrade relies on the existing gateway error text check.
- No product UI is wired in this PR; callers can build on the typed client surface in follow-up changes.
- `sessions.patch` response failures surface through the existing `SessionCommandCompleted` event path rather than the `Task<bool>` return, matching the legacy patch behavior.

