### PR TITLE
Fix MXC binary restore and settings hotkey

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3500,7 +3500,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
     private void OnSettingsHotkeyPressed(object? sender, EventArgs e)
     {
-        OnUiThread(() => ShowHub("companion"));
+        OnUiThread(ShowSettings);
     }
 
     #endregion

--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -196,7 +196,7 @@
     <Error Text="Unsupported RuntimeIdentifier '$(RuntimeIdentifier)' for MXC sandbox. Only win-x64 and win-arm64 are supported. Override -p:MxcArch=x64 or -p:MxcArch=arm64 if you know what you are doing." />
   </Target>
 
-  <Target Name="RestoreMxcNodeBridge" BeforeTargets="Build;Publish;CopyWxcExecToOutput;CopyWxcExecToPublish" Condition="'$(SkipMxcNodeBridgeRestore)' != 'true' And Exists('$(OpenClawRepoRoot)package-lock.json') And !Exists('$(OpenClawRepoRoot)node_modules\@microsoft\mxc-sdk\package.json')">
+  <Target Name="RestoreMxcNodeBridge" BeforeTargets="Build;Publish;CopyWxcExecToOutput;CopyWxcExecToPublish" Condition="'$(SkipMxcNodeBridgeRestore)' != 'true' And Exists('$(OpenClawRepoRoot)package-lock.json')">
     <Message Importance="high" Text="Restoring @microsoft/mxc-sdk to extract wxc-exec.exe ($(MxcArch))" />
     <Exec Command="npm ci --no-audit --no-fund" WorkingDirectory="$(OpenClawRepoRoot)" />
   </Target>

--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -196,7 +196,11 @@
     <Error Text="Unsupported RuntimeIdentifier '$(RuntimeIdentifier)' for MXC sandbox. Only win-x64 and win-arm64 are supported. Override -p:MxcArch=x64 or -p:MxcArch=arm64 if you know what you are doing." />
   </Target>
 
-  <Target Name="RestoreMxcNodeBridge" BeforeTargets="Build;Publish;CopyWxcExecToOutput;CopyWxcExecToPublish" Condition="'$(SkipMxcNodeBridgeRestore)' != 'true' And Exists('$(OpenClawRepoRoot)package-lock.json')">
+  <Target Name="RestoreMxcNodeBridge"
+          BeforeTargets="Build;Publish;CopyWxcExecToOutput;CopyWxcExecToPublish"
+          Condition="'$(SkipMxcNodeBridgeRestore)' != 'true' And Exists('$(OpenClawRepoRoot)package-lock.json')"
+          Inputs="$(OpenClawRepoRoot)package-lock.json"
+          Outputs="$(OpenClawRepoRoot)node_modules\.package-lock.json">
     <Message Importance="high" Text="Restoring @microsoft/mxc-sdk to extract wxc-exec.exe ($(MxcArch))" />
     <Exec Command="npm ci --no-audit --no-fund" WorkingDirectory="$(OpenClawRepoRoot)" />
   </Target>


### PR DESCRIPTION
## Summary
- Always run `npm ci` before copying MXC helper binaries into the WinUI output so stale `wxc-exec.exe` is not reused.
- Fix the Settings hotkey to open the real Settings page instead of an invalid `companion` nav tag.

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`
