### PR TITLE
Add gateway protocol drift guard (sessions/files/commands/compaction)

### DIFF
--- a/docs/gateway-protocol-drift-guard.md
+++ b/docs/gateway-protocol-drift-guard.md
@@ -1,0 +1,233 @@
+# Gateway Protocol Drift Guard
+
+> Source of truth: [`openclaw/openclaw` — `packages/gateway-protocol/src/schema/{sessions,commands}.ts`](https://github.com/openclaw/openclaw/tree/main/packages/gateway-protocol/src/schema)
+
+## Why this exists
+
+The Windows companion can silently drift from the upstream OpenClaw gateway
+protocol — when methods or session fields change upstream but the Windows client
+(`OpenClawGatewayClient`) keeps sending the old shapes. Because the gateway
+tolerates unknown/extra fields, such drift ships without any test failing.
+
+The **drift guard** pins a hand-maintained mirror of the upstream gateway protocol
+for the `sessions` / `files` / `commands` / compaction surface and fails the test
+suite whenever the typed client and the pinned schema diverge.
+
+The typed client implements the richer protocol surface —
+`commands.list`, the extended `sessions.patch` field set, `sessions.files.list`/
+`get`, and `sessions.compaction.list`/`get`/`branch`/`restore` — across
+`OpenClawGatewayClient.Protocol.cs` and the DTO/payload builders in
+`GatewayProtocolModels.cs`. This guard pins that whole surface.
+
+It is intentionally **deterministic and repo-contained**: it requires neither a
+clone of the upstream `openclaw/openclaw` repo nor any network access, so it runs
+in the normal `OpenClaw.Shared.Tests` suite. It **complements** the behavioural
+parser tests in `GatewayProtocolModelsTests` (which parse sample JSON and assert
+DTO mapping) by statically guarding the method / request-field / response-envelope
+*surface*, so an upstream rename or a dropped API is caught even when the parser
+unit tests still pass on their fixed sample payloads.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `tests/OpenClaw.Shared.Tests/Protocol/gateway-protocol-snapshot.json` | The pinned canonical schema mirror. **Edit this when upstream changes.** |
+| `tests/OpenClaw.Shared.Tests/Protocol/GatewayProtocolDriftTests.cs` | The guard. Cross-checks the snapshot against `OpenClawGatewayClient*.cs` + `GatewayProtocolModels.cs`. |
+
+## What the guard checks
+
+1. **Method surface** (`ScopedMethodSurface_matches_snapshot`)
+   - Every in-scope method the client actually *wires* — request methods it
+     **dispatches** (a method literal passed as a call argument to any dispatcher,
+     e.g. `TrySendTrackedRequestAsync("sessions.patch", …)`,
+     `TryRequestPayloadAsync("commands.list", …)`, or the private
+     `MutateCompactionAsync("sessions.compaction.branch", …)` forwarder), plus
+     notifications it **handles** via `case "…":` — must be pinned in the snapshot.
+   - Every method pinned `windowsUsage: "used"` must still be wired in the way its
+     `kind` implies: a **request** must still be *dispatched* (a leftover `case`
+     label, a `method is "…"` predicate, or a log sentence is not enough), a
+     **notification** must still be *handled*. Dropping one is the classic
+     drift regression.
+   - A `planned` method must **not** already be wired — if the client starts using
+     it, the guard forces you to flip it to `used` and verify its response shape.
+     (None currently — the typed client wires the whole surface.)
+2. **`sessions.list` response shape** (`SessionsList_responseShape_matches_snapshot`)
+   - The session wire-fields the client parses (scoped to the two session-parsing
+     methods) must exactly equal the snapshot's `responseFields` (both directions).
+3. **Request parameters** (`RequestParameterNames_arePresentInConstructionRegion`)
+   - For each `used` request method, the set of wire keys the client actually
+     constructs in the request-construction region must **exactly equal** the pinned
+     `requestFields` (modulo a per-method `allowedExtraRequestFields` allowlist).
+     The comparison is **bidirectional**:
+     - **missing** (pinned − constructed): the client no longer sends a field the
+       schema expects — e.g. renaming a wire key while the old name survives as a
+       local/parameter (`new { sessionKey = key }` when `key` is still pinned) is
+       caught, because the check compares *constructed keys*, not token presence.
+     - **unexpected** (constructed − pinned − allowed): the client still constructs
+       a stale/extra key that is no longer in the schema. Strict gateways
+       (`additionalProperties:false`) reject the whole request on an unknown field,
+       so this is real drift. Set `allowedExtraRequestFields` on a method to declare
+       an intentional client-only extra the gateway tolerates.
+   - A constructed wire key is an anonymous-object member (`new { sessionKey = key,
+     path }`) or a dictionary string key (`payload["model"] = …`) in the region.
+   - The region is the enclosing block of an actual dispatch call, or — when the
+     payload is built by a helper rather than inline — the explicit
+     `requestFieldsSource` builder body (the extended `sessions.patch` fields are
+     checked against `SessionPatch.ToPayload`; the compaction `branch`/`restore`
+     params against `MutateCompactionAsync`). `requestFieldsSource` must resolve
+     **uniquely** to a body that actually constructs keys, and a dispatch from an
+     expression-bodied member (where the region would degrade to the whole type)
+     **fails closed** asking for a `requestFieldsSource`.
+4. **Response envelope** (`ResponseEnvelopes_areReadByClient`)
+   - For each `used` method that pins a `responseEnvelope`, the client must read
+     that property — `TryGetProperty("…")` **or** `TryGetArray(payload, "…")` —
+     **inside that method's own parser body** (pinned via `responseEnvelopeSource`),
+     so one parser reading the same property name (e.g. several read `"checkpoint"`)
+     cannot satisfy a different method's envelope. An upstream envelope rename forces
+     client reconciliation.
+5. **Snapshot integrity** (`Snapshot_isWellFormed_andCoversFoundationShapes`)
+   - The snapshot stays well-formed, keeps covering every protocol-foundation shape
+     (`commands.list`, `sessions.list`/`patch`/`compact`, `agents.files.list`/`get`,
+     `sessions.files.list`/`get`, `sessions.compaction.list`/`get`/`branch`/
+     `restore`), and keeps its honesty invariant: `provisionalResponseFields` may
+     only be set while `windowsUsage: "planned"`.
+6. **Tri-state clear contract** (`TriStateClearContract_isWiredInClient`)
+   - Upstream `SessionsPatchParamsSchema` types every `sessions.patch` field as
+     `Union([<value>, Null])`, where an explicit null **removes** a session
+     override. The client models this with a tri-state `PatchField<T>`: **unset**
+     (null reference) → omitted, a **value** → sent (blank string omitted), and
+     `SessionPatch.Clear` → **explicit JSON null**. For any method declaring
+     `requestFieldSemantics: "tristate-nullable"`, this guard statically verifies
+     the builder source still wires the clear→null routing, the blank-omit guard,
+     and the value-state gate, and that the `PatchField<T>` type still exposes its
+     three states — so a refactor that removes the machinery is caught structurally
+     here, independent of the behavioural emission tests. (Runtime emission is
+     covered by `GatewayProtocolModelsTests`.)
+
+> Extraction is intent-specific and resilient: request-method literals are read
+> from real dispatch call sites (excluding logging sinks) and notifications from
+> `case` labels — not comments, `method is "…"` predicates, or log strings. Each
+> source is preprocessed into two index-aligned views: a *code* view with comments
+> blanked (literal extraction, so commented-out code never counts) and a *masked*
+> view with comments **and** string/char literals blanked (brace structure, so
+> braces inside literals/comments cannot desync the matcher). A self-check asserts
+> the masked view stays brace-balanced.
+
+### Enforced vs. documentation-only fields
+
+Not every field in the snapshot is cross-checked against the client. Refreshers
+should know which edits are actually validated:
+
+| Snapshot field | Enforced against the client? |
+| --- | --- |
+| `methods[].method` (in-scope) | **Yes** — must match what the client dispatches/handles. |
+| `windowsUsage` (`used`/`planned`) | **Yes** — drives the dispatch/handle requirement and the planned-not-wired check. |
+| `sessions.list.responseFields` | **Yes** — exact set vs. the session parser. |
+| `requestFields` of `used` request methods | **Yes** — bidirectional: must exactly equal the wire keys constructed in the region (missing **and** unexpected both fail). |
+| `allowedExtraRequestFields` | **Yes** — exempts the listed client-only extras from the "unexpected" direction; everything else still fails. |
+| `requestFieldsSource` | **Yes** — must resolve uniquely to a body that constructs keys; that body is the region. |
+| `responseEnvelope` of `used` methods | **Yes** — must be read (`TryGetProperty`/`TryGetArray`) by the pinned parser. |
+| `responseEnvelopeSource` | **Yes** — required when `responseEnvelope` is pinned; must resolve uniquely to the parser body that reads the envelope (no whole-client fallback). |
+| `tristateContract` (markers + state members) | **Yes** — for `requestFieldSemantics: "tristate-nullable"`, the builder source must implement every marker and the `PatchField<T>` type must expose every state. |
+| `kind`, `scopePrefixes`, foundation coverage | **Yes** — snapshot-integrity invariants. |
+| `itemFields` (per-item descriptor fields) | **No** — documentation-only; behaviour covered by `GatewayProtocolModelsTests` parsers. |
+| `_comment`, `_note`, `_itemFieldsNote`, provenance | **No** — documentation-only. |
+
+
+## Tri-state clear contract (`sessions.patch`)
+
+Upstream `SessionsPatchParamsSchema` types every `sessions.patch` field as
+`Union([<value>, Null])`. A field can therefore be in one of three states, and the
+Windows client mirrors this with the tri-state `PatchField<T>`:
+
+| State | How the client expresses it | Wire result |
+| --- | --- | --- |
+| **unset** | leave the `PatchField<T>` default / assign a null reference | field **omitted** from the request |
+| **set** | assign a value (`patch.Model = "gpt-5"`) | field sent with the value (a **blank** string is omitted per `NonEmptyString`) |
+| **clear** | assign the sentinel (`patch.Model = SessionPatch.Clear`) | field sent as **explicit JSON `null`** (removes the session override) |
+
+The drift guard pins this contract in the snapshot under
+`sessions.patch.tristateContract` and checks it statically (Guard 6): the
+`SessionPatch` builder must keep the clear→null routing, the blank-omit guard, and
+the value-state gate, and `PatchField<T>` must keep its `IsSpecified`/`IsClear`/
+`HasValue` states. The actual JSON emission for each state is covered behaviourally
+by `GatewayProtocolModelsTests` (`SessionPatch_ToPayload_ClearEmitsExplicitNull*`,
+`…MixesSetAndClearAndUnset`, `PatchField_TriStateFlags`) and end-to-end by
+`GatewayProtocolLiveRoundTripTests` (a loopback-WebSocket test capturing the real
+wire frames) — the guard is the static, upstream-mirrored complement, not a duplicate.
+
+## `windowsUsage` semantics
+
+| Value | Meaning |
+| --- | --- |
+| `used` | The client dispatches/handles this method today. The guard **requires** it to remain wired up. |
+| `planned` | Defined upstream but not yet consumed by the Windows client. The shape is pinned so future adoption matches upstream, but the client is not required to use it yet. (None currently — the typed client wires the whole surface.) |
+
+## How to refresh the snapshot when upstream changes
+
+When the upstream gateway protocol changes (a new `sessions.*` method, a renamed
+session field, a new `commands.list` descriptor field, etc.):
+
+1. Open the upstream schema on `main`:
+   - `packages/gateway-protocol/src/schema/sessions.ts`
+   - `packages/gateway-protocol/src/schema/commands.ts`
+2. Update `tests/OpenClaw.Shared.Tests/Protocol/gateway-protocol-snapshot.json`:
+   - Add/rename/remove methods under `methods[]`.
+   - Update `requestFields` / `responseFields` / `responseEnvelope` to match the
+     wire field names. Field/method names may use letters, digits and underscores.
+   - When a method's request payload is built by a helper rather than inline at the
+     dispatch site (e.g. `SessionPatch.ToPayload`, `MutateCompactionAsync`), point
+     `requestFieldsSource` at a unique fragment of that builder's declaration so
+     Guard C searches the right body.
+   - When a method pins a `responseEnvelope`, also set `responseEnvelopeSource` to a
+     unique fragment of the parser body that reads it (Guard D requires it).
+   - If upstream changes a field's nullability semantics (e.g. a field becomes
+     `Union([<value>, Null])`, making explicit null a "clear" signal), update the
+     `tristateContract` markers for that method and confirm the client's tri-state
+     `PatchField<T>` builder still implements them (Guard 6).
+   - Bump `snapshotUpdated` to today's date and set `upstreamCommit` to the exact
+     upstream schema commit SHA you mirrored (so the pin is reproducible/auditable;
+     `upstreamRef: "main"` alone is not).
+   - For a method upstream added that the Windows client doesn't consume yet, set
+     `windowsUsage: "planned"`; pin its shape and, if the response fields are not
+     yet verified against upstream, set `provisionalResponseFields: true`.
+3. Run the guard:
+   ```powershell
+   $env:OPENCLAW_REPO_ROOT = (Get-Location).Path
+   dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --filter GatewayProtocolDriftTests
+   ```
+4. If the guard fails, reconcile the typed client (`OpenClawGatewayClient.cs`,
+   `OpenClawGatewayClient.Protocol.cs`, and the DTOs in `GatewayProtocolModels.cs` /
+   `SessionInfo` in `Models.cs`) with the new schema — that reconciliation is the
+   whole point of the guard. Update the snapshot only to reflect upstream, never to
+   silence a real client gap.
+
+## Known limitation: snapshot ↔ upstream staleness
+
+Every guard checks the client against the **snapshot**, not against upstream
+directly (a deliberate trade-off for the offline/repo-contained guarantee). If
+upstream changes and nobody refreshes the snapshot, the tests stay green while the
+client silently drifts from real upstream — the original regression class, moved
+up one level.
+
+Mitigations:
+
+- The snapshot records `upstreamVerified` (date + the exact `sessions.ts`/`commands.ts`
+  blob SHAs the pin was checked against) so each verification is auditable and
+  reproducible. **Last verified 2026-06-23** against `openclaw/openclaw` main:
+  all enforced request fields / response envelopes / the `sessions.patch` tri-state
+  nullable contract matched exactly; the snapshot is a deliberate subset (see the
+  `upstreamVerified.result` note for the upstream-only `sessions.patch` fields the
+  Windows client does not yet implement).
+- Treat a gateway-protocol bump in upstream as a trigger to re-verify and refresh,
+  the same way `docs/gateway-node-integration.md` is refreshed.
+- Re-verify by fetching `packages/gateway-protocol/src/schema/{sessions,commands}.ts`
+  from `openclaw/openclaw` main, diffing against the pinned methods/fields, and
+  updating `upstreamVerified` with the new blob SHAs.
+
+## Scope
+
+The guard deliberately covers only the `sessions` / `files` / `commands` /
+compaction surface (`scopePrefixes` in the snapshot), which is where the
+drift-critical session and command APIs live. Other gateway namespaces
+(`cron.*`, `config.*`, `device.pair.*`, …) are out of scope for this guard.

--- a/tests/OpenClaw.Shared.Tests/ProductionSourceFiles.cs
+++ b/tests/OpenClaw.Shared.Tests/ProductionSourceFiles.cs
@@ -27,7 +27,7 @@ internal static class ProductionSourceFiles
         path.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar, StringComparison.Ordinal) ||
         path.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar, StringComparison.Ordinal);
 
-    private static string FindRepoRoot()
+    internal static string FindRepoRoot()
     {
         var envRoot = Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT");
         if (!string.IsNullOrWhiteSpace(envRoot) &&

--- a/tests/OpenClaw.Shared.Tests/Protocol/GatewayProtocolDriftTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Protocol/GatewayProtocolDriftTests.cs
@@ -1,0 +1,942 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests.Protocol;
+
+/// <summary>
+/// Protocol drift guard for the OpenClaw gateway <c>sessions</c> / <c>files</c> /
+/// <c>commands</c> / compaction surface.
+///
+/// The Windows companion can silently drift from the upstream
+/// <c>openclaw/openclaw</c> gateway protocol
+/// (<c>packages/gateway-protocol/src/schema/{sessions,commands}.ts</c>): because
+/// the gateway tolerates unknown/extra fields, a client sending stale shapes fails
+/// no existing test. This test pins a hand-maintained mirror of that schema in
+/// <c>Protocol/gateway-protocol-snapshot.json</c> and cross-checks it against what
+/// the typed client (<c>OpenClawGatewayClient</c> + its <c>.Protocol</c> partial,
+/// and the <c>SessionPatch</c>/DTO builders in <c>GatewayProtocolModels.cs</c>)
+/// actually <em>sends</em>, <em>handles</em>, and constructs — so any future
+/// divergence fails loudly in CI instead of shipping a drifted client.
+///
+/// This complements (does not duplicate) the behavioural parser tests in
+/// <c>GatewayProtocolModelsTests</c>: those parse sample JSON and assert DTO
+/// mapping; this guard statically pins the method / request-field / response-
+/// envelope <em>surface</em>, so an upstream rename or a dropped API is caught even
+/// when the parser unit tests still pass on their fixed samples.
+///
+/// The guard is deterministic and fully repo-contained: it does NOT require a
+/// clone of the upstream OpenClaw repository or any network access. When upstream
+/// changes, refresh the snapshot per <c>docs/gateway-protocol-drift-guard.md</c>.
+///
+/// Extraction is intent-specific and resilient. Two views of each source are kept,
+/// index-aligned: a <c>Code</c> view with comments blanked but string/char literals
+/// preserved (used for literal/identifier extraction, so commented-out code never
+/// counts), and a <c>Masked</c> view with comments AND literals blanked (used for
+/// brace structure, so literal/comment braces never desync the matcher).
+/// </summary>
+public class GatewayProtocolDriftTests
+{
+    // Identifier characters for wire field/method names. Wide enough to cover
+    // camelCase, digits, and underscores so a future field like `contextV2` or
+    // `started_at` is representable on both sides of the comparison.
+    private const string Ident = "[A-Za-z_][A-Za-z0-9_]*";
+
+    // Dispatcher-call identifiers that are logging/diagnostic sinks, not RPC
+    // dispatch. A method literal passed to one of these does not count as the
+    // client "sending" that method (avoids a false "used").
+    private static readonly HashSet<string> LoggingSinks = new(StringComparer.Ordinal)
+    {
+        "Warn", "Warning", "Info", "Information", "Error", "Debug", "Trace", "Log",
+        "LogWarning", "LogError", "LogInformation", "LogDebug", "LogTrace", "WriteLine",
+    };
+
+    /// <summary>
+    /// Guard A — method surface, intent-specific. Every in-scope method the client
+    /// actually wires (request methods it dispatches with a method literal, plus
+    /// notifications it handles via a <c>case</c> label) must be pinned in the
+    /// snapshot. Every method pinned <c>used</c> must still be wired the way its
+    /// <c>kind</c> implies. A <c>planned</c> method must not already be wired.
+    /// </summary>
+    [Fact]
+    public void ScopedMethodSurface_matches_snapshot()
+    {
+        var snapshot = LoadSnapshot();
+        var client = LoadClientSource();
+
+        var sent = ExtractDispatchedRequestMethods(client, snapshot.ScopePrefixes).Keys.ToHashSet(StringComparer.Ordinal);
+        var handled = ExtractHandledMethods(client.Code, snapshot.ScopePrefixes);
+        var wired = sent.Union(handled).ToHashSet(StringComparer.Ordinal);
+
+        var pinned = snapshot.Methods.Select(m => m.Method).ToHashSet(StringComparer.Ordinal);
+        var failures = new List<string>();
+
+        foreach (var method in wired.Except(pinned).OrderBy(s => s, StringComparer.Ordinal))
+            failures.Add($"client wires '{method}' but it is NOT pinned in the snapshot (refresh the snapshot or fix a typo)");
+
+        foreach (var method in snapshot.Methods)
+        {
+            var isWired = wired.Contains(method.Method);
+            if (method.WindowsUsage == "used")
+            {
+                var ok = method.Kind == "request" ? sent.Contains(method.Method) : handled.Contains(method.Method);
+                if (!ok)
+                {
+                    var how = method.Kind == "request" ? "dispatched with a method literal" : "handled via a 'case' label";
+                    failures.Add($"'{method.Method}' is pinned windowsUsage=\"used\" ({method.Kind}) but is no longer {how} by the client (the client stopped using a method it should still send)");
+                }
+            }
+            else if (method.WindowsUsage == "planned" && isWired)
+            {
+                failures.Add($"'{method.Method}' is pinned windowsUsage=\"planned\" but the client now wires it — flip it to \"used\" and verify/clear its response-field shape against upstream");
+            }
+        }
+
+        if (failures.Count > 0)
+            Assert.Fail("Gateway protocol method-surface drift detected:\n  - " + string.Join("\n  - ", failures) + "\nSee docs/gateway-protocol-drift-guard.md.");
+    }
+
+    /// <summary>
+    /// Guard B — <c>sessions.list</c> response shape. The session fields the legacy
+    /// session parser reads off the wire (scoped to the two session-parsing
+    /// methods) must exactly equal the snapshot's pinned <c>responseFields</c>.
+    /// </summary>
+    [Fact]
+    public void SessionsList_responseShape_matches_snapshot()
+    {
+        var snapshot = LoadSnapshot();
+        var client = LoadClientSource();
+
+        var pinned = snapshot.Methods.Single(m => m.Method == "sessions.list").ResponseFields.ToHashSet(StringComparer.Ordinal);
+
+        var signatures = new[] { "void PopulateSessionFromObject(", "string? ParseSessionItem(" };
+        var readByClient = new HashSet<string>(StringComparer.Ordinal);
+        var missingSignatures = new List<string>();
+
+        foreach (var sig in signatures)
+        {
+            var region = ExtractMethodBody(client, sig);
+            if (region is null)
+            {
+                missingSignatures.Add(sig);
+                continue;
+            }
+
+            foreach (Match m in Regex.Matches(region.Code, $"\\.TryGetProperty\\(\\s*\"({Ident})\""))
+                readByClient.Add(m.Groups[1].Value);
+            foreach (Match m in Regex.Matches(region.Code, $"(?:GetLong|GetString|GetBool|ParseUnixTimestampMs)\\(\\s*item\\s*,\\s*\"({Ident})\""))
+                readByClient.Add(m.Groups[1].Value);
+        }
+
+        Assert.True(
+            missingSignatures.Count == 0,
+            $"Could not locate session-parsing method(s): [{string.Join(", ", missingSignatures)}]. " +
+            "The extraction signatures in GatewayProtocolDriftTests likely need updating after a refactor (a test-maintenance issue, not protocol drift).");
+
+        var clientNotPinned = readByClient.Except(pinned).OrderBy(s => s, StringComparer.Ordinal).ToList();
+        var pinnedNotRead = pinned.Except(readByClient).OrderBy(s => s, StringComparer.Ordinal).ToList();
+
+        if (clientNotPinned.Count > 0 || pinnedNotRead.Count > 0)
+        {
+            Assert.Fail(
+                "sessions.list response shape drift detected.\n" +
+                $"  Fields parsed by the client but NOT in the snapshot (upstream renamed/removed, or refresh the snapshot): [{string.Join(", ", clientNotPinned)}]\n" +
+                $"  Fields pinned but no longer parsed by the client: [{string.Join(", ", pinnedNotRead)}]\n" +
+                "See docs/gateway-protocol-drift-guard.md.");
+        }
+    }
+
+    /// <summary>
+    /// Guard C — request shapes, scoped and <b>bidirectional</b>. For each
+    /// <c>used</c> request method, the set of wire keys the client actually
+    /// constructs in the request-construction region (the explicit
+    /// <c>requestFieldsSource</c> builder body when set, otherwise the enclosing
+    /// block of an actual dispatch call) must exactly equal the pinned
+    /// <c>requestFields</c>, modulo a per-method <c>allowedExtraRequestFields</c>
+    /// allowlist:
+    /// <list type="bullet">
+    /// <item><b>missing</b> = pinned − constructed: the client no longer sends a
+    /// field the schema expects (upstream rename/removal not reconciled, or stale
+    /// snapshot).</item>
+    /// <item><b>unexpected</b> = constructed − pinned − allowed: the client still
+    /// sends a stale/extra key after upstream removed or renamed it — strict
+    /// gateways (<c>additionalProperties:false</c>) reject the whole request.</item>
+    /// </list>
+    /// A constructed key is an anonymous-object member or dictionary string key in
+    /// the region (see <see cref="ExtractConstructedKeys"/>); the comparison is over
+    /// constructed keys, not token presence, so a rename where the old name survives
+    /// as a local/parameter is still caught.
+    /// </summary>
+    [Fact]
+    public void RequestParameterNames_arePresentInConstructionRegion()
+    {
+        var snapshot = LoadSnapshot();
+        var client = LoadClientSource();
+        var protocol = LoadProtocolSource();
+
+        var sentIndices = ExtractDispatchedRequestMethods(client, snapshot.ScopePrefixes);
+        var failures = new List<string>();
+
+        foreach (var method in snapshot.Methods.Where(m => m.WindowsUsage == "used" && m.Kind == "request" && m.RequestFields.Count > 0))
+        {
+            var regions = new List<Region>();
+
+            if (!string.IsNullOrEmpty(method.RequestFieldsSource))
+            {
+                var fragment = method.RequestFieldsSource!;
+                var occurrences = CountOccurrences(protocol.Masked, fragment);
+                if (occurrences == 0)
+                {
+                    failures.Add($"{method.Method}: requestFieldsSource '{fragment}' not found (refactor? update the snapshot/guard)");
+                    continue;
+                }
+                if (occurrences > 1)
+                {
+                    failures.Add($"{method.Method}: requestFieldsSource '{fragment}' is ambiguous (matches {occurrences} sites) — make it unique");
+                    continue;
+                }
+                var region = ExtractMethodBody(protocol, fragment);
+                if (region is null)
+                {
+                    failures.Add($"{method.Method}: requestFieldsSource '{fragment}' did not resolve to a body");
+                    continue;
+                }
+                if (ExtractConstructedKeys(region).Count == 0)
+                {
+                    failures.Add($"{method.Method}: requestFieldsSource '{fragment}' body constructs no request keys (new {{ … }} or [\"…\"]) — it is not a request builder");
+                    continue;
+                }
+                regions.Add(region);
+            }
+            else
+            {
+                if (!sentIndices.TryGetValue(method.Method, out var indices) || indices.Count == 0)
+                {
+                    failures.Add($"{method.Method}: no dispatch call site found to validate request fields");
+                    continue;
+                }
+
+                var degenerate = false;
+                foreach (var idx in indices)
+                {
+                    var (region, isTypeBody) = ExtractEnclosingBlock(client, idx);
+                    if (region is null) continue;
+                    if (isTypeBody)
+                    {
+                        degenerate = true;
+                        break;
+                    }
+                    regions.Add(region);
+                }
+
+                if (degenerate)
+                {
+                    failures.Add($"{method.Method}: dispatched from an expression-bodied member, so the construction region degrades to the whole type — add a 'requestFieldsSource' pointing at the real payload builder");
+                    continue;
+                }
+                if (regions.Count == 0)
+                {
+                    failures.Add($"{method.Method}: could not resolve the enclosing block of any dispatch call site");
+                    continue;
+                }
+            }
+
+            var constructedKeys = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var r in regions)
+                constructedKeys.UnionWith(ExtractConstructedKeys(r));
+
+            // Bidirectional comparison (both directions are real drift):
+            //   missing    = pinned fields the client no longer constructs (upstream
+            //                rename/removal not reconciled, or stale snapshot).
+            //   unexpected = wire keys the client still constructs that are NOT pinned
+            //                and NOT an explicitly-allowed extra — i.e. the client
+            //                sends a stale/extra key after upstream removed/renamed it.
+            // allowedExtraRequestFields lets a method declare intentional extras (e.g.
+            // a client-only param the strict gateway tolerates) without weakening the
+            // check for everything else.
+            var allowed = new HashSet<string>(method.AllowedExtraRequestFields, StringComparer.Ordinal);
+
+            var missing = method.RequestFields
+                .Where(f => !constructedKeys.Contains(f))
+                .OrderBy(s => s, StringComparer.Ordinal)
+                .ToList();
+            var unexpected = constructedKeys
+                .Where(k => !method.RequestFields.Contains(k) && !allowed.Contains(k))
+                .OrderBy(s => s, StringComparer.Ordinal)
+                .ToList();
+
+            foreach (var field in missing)
+                failures.Add($"{method.Method}.{field}: pinned but NOT constructed as a request wire key in the construction region (upstream rename not reconciled, or refresh the snapshot). Constructed keys: [{string.Join(", ", constructedKeys.OrderBy(s => s, StringComparer.Ordinal))}]");
+            foreach (var key in unexpected)
+                failures.Add($"{method.Method}.{key}: constructed as a request wire key but NOT pinned in the snapshot (client sends a stale/extra key after an upstream change — remove it, or add it to requestFields / allowedExtraRequestFields). Pinned: [{string.Join(", ", method.RequestFields.OrderBy(s => s, StringComparer.Ordinal))}]");
+        }
+
+        if (failures.Count > 0)
+            Assert.Fail("Gateway request-parameter drift detected:\n  - " + string.Join("\n  - ", failures.OrderBy(s => s, StringComparer.Ordinal)) + "\nSee docs/gateway-protocol-drift-guard.md.");
+    }
+
+    /// <summary>
+    /// Guard D — response envelope. For each <c>used</c> method that pins a
+    /// <c>responseEnvelope</c> property, the client must read that property
+    /// (<c>TryGetProperty("…")</c> or <c>TryGetArray(payload, "…")</c>) inside the
+    /// method's own parser body (pinned via <c>responseEnvelopeSource</c>), so one
+    /// parser reading the same property name cannot satisfy another method's
+    /// envelope, and an upstream envelope rename forces client reconciliation. Runs
+    /// over the comment-stripped view so commented-out reads don't count.
+    /// </summary>
+    [Fact]
+    public void ResponseEnvelopes_areReadByClient()
+    {
+        var snapshot = LoadSnapshot();
+        var client = LoadClientSource();
+
+        var failures = new List<string>();
+        foreach (var method in snapshot.Methods.Where(m => m.WindowsUsage == "used" && m.ResponseEnvelope.Count > 0))
+        {
+            // Symmetric with requestFieldsSource: a pinned envelope must name the
+            // specific parser body, and that fragment must resolve uniquely — no
+            // whole-client fallback (which would let any parser reading the same
+            // property name satisfy a different method's envelope).
+            if (string.IsNullOrEmpty(method.ResponseEnvelopeSource))
+            {
+                failures.Add($"{method.Method}: responseEnvelope is pinned but responseEnvelopeSource is missing — add the parser-body fragment so the envelope check is method-scoped");
+                continue;
+            }
+            var occurrences = CountOccurrences(client.Masked, method.ResponseEnvelopeSource!);
+            if (occurrences == 0)
+            {
+                failures.Add($"{method.Method}: responseEnvelopeSource '{method.ResponseEnvelopeSource}' not found (refactor? update the snapshot)");
+                continue;
+            }
+            if (occurrences > 1)
+            {
+                failures.Add($"{method.Method}: responseEnvelopeSource '{method.ResponseEnvelopeSource}' is ambiguous (matches {occurrences} sites) — make it unique");
+                continue;
+            }
+            var region = ExtractMethodBody(client, method.ResponseEnvelopeSource!);
+            if (region is null)
+            {
+                failures.Add($"{method.Method}: responseEnvelopeSource '{method.ResponseEnvelopeSource}' did not resolve to a body");
+                continue;
+            }
+
+            foreach (var envelope in method.ResponseEnvelope)
+            {
+                var pattern = $"TryGet(?:Property|Array)\\(\\s*(?:{Ident}\\s*,\\s*)?\"{Regex.Escape(envelope)}\"";
+                if (!Regex.IsMatch(region.Code, pattern))
+                    failures.Add($"{method.Method}: response envelope property \"{envelope}\" is never read (TryGetProperty/TryGetArray) by its parser");
+            }
+        }
+
+        if (failures.Count > 0)
+            Assert.Fail("Gateway response-envelope drift detected:\n  - " + string.Join("\n  - ", failures) + "\nSee docs/gateway-protocol-drift-guard.md.");
+    }
+
+    /// <summary>
+    /// Guard E — snapshot integrity. The pinned snapshot itself must stay
+    /// well-formed, keep covering the protocol-foundation shapes, and keep its
+    /// honesty invariant (provisional response fields only on <c>planned</c>
+    /// methods).
+    /// </summary>
+    [Fact]
+    public void Snapshot_isWellFormed_andCoversFoundationShapes()
+    {
+        var snapshot = LoadSnapshot();
+
+        Assert.NotEmpty(snapshot.Methods);
+        Assert.NotEmpty(snapshot.ScopePrefixes);
+
+        var validUsage = new HashSet<string>(StringComparer.Ordinal) { "used", "planned" };
+        var validKind = new HashSet<string>(StringComparer.Ordinal) { "request", "response", "notification" };
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var method in snapshot.Methods)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(method.Method), "Snapshot method name must not be blank.");
+            Assert.True(seen.Add(method.Method), $"Duplicate snapshot method entry: {method.Method}");
+            Assert.True(validUsage.Contains(method.WindowsUsage),
+                $"{method.Method}: invalid windowsUsage '{method.WindowsUsage}' (expected used|planned).");
+            Assert.True(validKind.Contains(method.Kind),
+                $"{method.Method}: invalid kind '{method.Kind}' (expected request|response|notification).");
+            Assert.True(snapshot.ScopePrefixes.Any(p => method.Method.StartsWith(p, StringComparison.Ordinal)),
+                $"{method.Method}: outside declared scopePrefixes [{string.Join(", ", snapshot.ScopePrefixes)}].");
+
+            if (method.ProvisionalResponseFields)
+                Assert.True(method.WindowsUsage == "planned",
+                    $"{method.Method}: provisionalResponseFields=true is only allowed while windowsUsage=\"planned\". " +
+                    "Verify the response fields against upstream and clear the flag before marking it used.");
+
+            // Tri-state contract honesty: the semantics tag and the contract object
+            // must co-exist, and a present contract must carry markers + states.
+            var isTriStateNullable = method.RequestFieldSemantics == "tristate-nullable";
+            Assert.True(isTriStateNullable == (method.TriState is not null),
+                $"{method.Method}: requestFieldSemantics=\"tristate-nullable\" and a 'tristateContract' object must be present together (one without the other is a snapshot mistake).");
+            if (method.TriState is not null)
+            {
+                Assert.NotEmpty(method.TriState.Markers);
+                Assert.NotEmpty(method.TriState.StateMembers);
+                Assert.False(string.IsNullOrWhiteSpace(method.TriState.BuilderSource), $"{method.Method}: tristateContract.builderSource must be set.");
+                Assert.False(string.IsNullOrWhiteSpace(method.TriState.StateTypeSource), $"{method.Method}: tristateContract.stateTypeSource must be set.");
+            }
+        }
+
+        foreach (var required in new[]
+                 {
+                     "commands.list",
+                     "sessions.list", "sessions.patch", "sessions.compact",
+                     "agents.files.list", "agents.files.get",
+                     "sessions.files.list", "sessions.files.get",
+                     "sessions.compaction.list", "sessions.compaction.get",
+                     "sessions.compaction.branch", "sessions.compaction.restore",
+                 })
+            Assert.True(seen.Contains(required), $"Snapshot is missing required foundation method: {required}");
+
+        Assert.NotEmpty(snapshot.Methods.Single(m => m.Method == "sessions.list").ResponseFields);
+        Assert.NotEmpty(snapshot.Methods.Single(m => m.Method == "commands.list").ResponseEnvelope);
+    }
+
+    /// <summary>
+    /// Guard F — tri-state clear contract (structural presence). Upstream
+    /// <c>SessionsPatchParamsSchema</c> types every field as
+    /// <c>Union([&lt;value&gt;, Null])</c>, where an explicit null removes a session
+    /// override; the client models this with a tri-state
+    /// <see cref="OpenClaw.Shared.PatchField{T}"/> (unset → omitted, value → sent
+    /// with blank omitted, <c>SessionPatch.Clear</c> → explicit JSON null).
+    ///
+    /// This guard pins the <em>structural presence</em> of that machinery for any
+    /// method declaring <c>requestFieldSemantics: "tristate-nullable"</c>: each
+    /// snapshot marker (a regex over a specific, uniquely-resolving source body)
+    /// must be present, and the <c>PatchField&lt;T&gt;</c> type must still publicly
+    /// expose its state members. It deliberately does NOT prove routing
+    /// <em>semantics</em> — a static presence check cannot see, e.g., a value sent
+    /// when blank, nor the <c>unset → omit</c> behaviour (the absence of an else
+    /// branch). Those, and the exact JSON emission for each state, are owned by the
+    /// behavioural tests in <c>GatewayProtocolModelsTests</c>. Guard F is the
+    /// complement that catches the machinery being removed/renamed/gutted.
+    /// </summary>
+    [Fact]
+    public void TriStateClearContract_isWiredInClient()
+    {
+        var snapshot = LoadSnapshot();
+        var protocol = LoadProtocolSource();
+
+        var failures = new List<string>();
+        foreach (var method in snapshot.Methods.Where(m => m.TriState is not null))
+        {
+            var contract = method.TriState!;
+
+            // Always resolve builderSource (and reuse it for markers that don't pin
+            // their own source) so it can never go stale/ambiguous unchecked, even
+            // if every marker specifies an explicit source.
+            if (!TryResolveUniqueBody(protocol, contract.BuilderSource, $"{method.Method}: builderSource", failures, out var builderRegion))
+                builderRegion = null;
+
+            // Each marker is checked inside its own uniquely-resolving source body
+            // (defaulting to builderSource) — so e.g. AddString regressing is caught
+            // even if AddEncoded is still correct.
+            foreach (var marker in contract.Markers)
+            {
+                Region? region;
+                if (string.IsNullOrEmpty(marker.Source))
+                {
+                    region = builderRegion;
+                    if (region is null) continue; // builderSource already reported as failed
+                }
+                else if (!TryResolveUniqueBody(protocol, marker.Source!, $"{method.Method}: marker '{marker.Name}' source", failures, out region))
+                {
+                    continue;
+                }
+                if (!Regex.IsMatch(region!.Code, marker.Pattern))
+                    failures.Add($"{method.Method}: tri-state contract marker '{marker.Name}' (/{marker.Pattern}/) is missing from '{(string.IsNullOrEmpty(marker.Source) ? contract.BuilderSource : marker.Source)}' — the tri-state routing drifted");
+            }
+
+            // The tri-state value type must still publicly expose all three states.
+            if (TryResolveUniqueBody(protocol, contract.StateTypeSource, $"{method.Method}: stateTypeSource", failures, out var stateType))
+            {
+                foreach (var state in contract.StateMembers)
+                {
+                    // Require a public member declaration (not a bare token), tolerating
+                    // common modifiers before the type so a future `public required T x`
+                    // / `public static …` doesn't false-fail.
+                    if (!Regex.IsMatch(stateType!.Code, $"public\\s+(?:(?:static|readonly|required|virtual|override|sealed|new)\\s+)*[A-Za-z_][\\w<>?]*\\s+{Regex.Escape(state)}\\b"))
+                        failures.Add($"{method.Method}: tri-state value type '{contract.StateTypeSource}' no longer publicly exposes state '{state}'");
+                }
+            }
+        }
+
+        if (failures.Count > 0)
+            Assert.Fail("Gateway tri-state clear-contract drift detected:\n  - " + string.Join("\n  - ", failures) + "\nSee docs/gateway-protocol-drift-guard.md.");
+    }
+
+    /// <summary>
+    /// Resolves a snapshot source fragment to a unique method/type body, mirroring
+    /// the uniqueness discipline of Guard C/D: a 0-match or &gt;1-match fragment is a
+    /// loud failure (recorded in <paramref name="failures"/>) rather than a silent
+    /// first-match bind.
+    /// </summary>
+    private static bool TryResolveUniqueBody(Source source, string fragment, string label, List<string> failures, out Region? region)
+    {
+        region = null;
+        var occurrences = CountOccurrences(source.Masked, fragment);
+        if (occurrences == 0)
+        {
+            failures.Add($"{label} '{fragment}' not found (refactor? update the snapshot)");
+            return false;
+        }
+        if (occurrences > 1)
+        {
+            failures.Add($"{label} '{fragment}' is ambiguous (matches {occurrences} sites) — make it unique");
+            return false;
+        }
+        region = ExtractMethodBody(source, fragment);
+        if (region is null)
+        {
+            failures.Add($"{label} '{fragment}' did not resolve to a body");
+            return false;
+        }
+        return true;
+    }
+
+    // --- request-key extraction ---------------------------------------------
+
+    /// <summary>
+    /// Extracts the request wire keys actually constructed in a region: the member
+    /// names of anonymous-object payloads (<c>new { key, sessionKey = x }</c>), the
+    /// string keys of dictionary payloads (<c>payload["key"] = …</c>,
+    /// <c>new Dictionary&lt;…&gt; { ["key"] = … }</c>), and the key literal of an
+    /// add-helper call whose first argument is the payload dictionary
+    /// (<c>AddString(payload, "key", …)</c> / <c>AddEncoded(payload, "key", …)</c>,
+    /// as the tri-state <c>SessionPatch.ToPayload</c> uses). Comparing pinned
+    /// request fields against the ACTUAL constructed keys (not mere token presence)
+    /// catches a client-side wire-key rename even when the old name survives as a
+    /// local or parameter — e.g. <c>new { sessionKey = key }</c> yields key
+    /// <c>sessionKey</c>, not <c>key</c>. Object initializers
+    /// (<c>new TypeName { Prop = … }</c>) are intentionally excluded — only
+    /// anonymous <c>new { … }</c> payloads count.
+    /// </summary>
+    private static HashSet<string> ExtractConstructedKeys(Region region)
+    {
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+
+        // Dictionary string keys: ["field"] — strings are preserved in the code view.
+        foreach (Match m in Regex.Matches(region.Code, $"\\[\\s*\"({Ident})\"\\s*\\]"))
+            keys.Add(m.Groups[1].Value);
+
+        // Add-helper calls: Add*(payload, "field", …) — the key is the second arg
+        // when the helper name starts with "Add" and the first arg is the payload
+        // dictionary. This covers the tri-state builder (ToPayload delegates to
+        // AddString/AddEncoded), while excluding unrelated 2-arg calls like
+        // Validate(payload, "x") or string.Equals(x, "y") that would otherwise
+        // inject spurious keys.
+        foreach (Match m in Regex.Matches(region.Code, $"\\bAdd[A-Za-z0-9_]*\\(\\s*payload\\s*,\\s*\"({Ident})\""))
+            keys.Add(m.Groups[1].Value);
+
+        // Anonymous-object members: each `new {` block (no type name between `new`
+        // and `{`). Parse the masked block so commas inside strings don't split.
+        foreach (Match m in Regex.Matches(region.Masked, "new\\s*\\{"))
+        {
+            var open = region.Masked.IndexOf('{', m.Index);
+            if (open < 0) continue;
+            var close = MatchBrace(region.Masked, open);
+            if (close < 0) continue;
+
+            var inner = region.Masked.Substring(open + 1, close - open - 1);
+            foreach (var segment in SplitTopLevel(inner))
+            {
+                var member = Regex.Match(segment.Trim(), $"^({Ident})");
+                if (member.Success)
+                    keys.Add(member.Groups[1].Value);
+            }
+        }
+
+        return keys;
+    }
+
+    /// <summary>Splits on top-level commas, ignoring commas nested in (), [], or {}.</summary>
+    private static IEnumerable<string> SplitTopLevel(string text)
+    {
+        var depth = 0;
+        var start = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (c is '(' or '[' or '{') depth++;
+            else if (c is ')' or ']' or '}') depth--;
+            else if (c == ',' && depth == 0)
+            {
+                yield return text.Substring(start, i - start);
+                start = i + 1;
+            }
+        }
+        if (start < text.Length)
+            yield return text.Substring(start);
+    }
+
+    // --- method-surface extraction -----------------------------------------
+
+    /// <summary>
+    /// Returns the in-scope request methods dispatched by the client, mapped to the
+    /// char offsets of each dispatch call. A dispatch call is any non-logging method
+    /// call whose first argument is a quote-bounded scoped method literal — e.g.
+    /// <c>TrySendTrackedRequestAsync("sessions.patch", …)</c>,
+    /// <c>TryRequestPayloadAsync("commands.list", …)</c>, or the private
+    /// <c>MutateCompactionAsync("sessions.compaction.branch", …)</c> forwarder.
+    /// This recognises new dispatcher wrappers automatically and excludes non-call
+    /// uses (<c>case "…":</c>, <c>method is "…"</c>, log sentences) which is the
+    /// false-"used" trap.
+    /// </summary>
+    private static Dictionary<string, List<int>> ExtractDispatchedRequestMethods(Source source, IReadOnlyList<string> scopePrefixes)
+    {
+        var scope = ScopeAlternation(scopePrefixes);
+        var rx = new Regex($"(?<![A-Za-z0-9_])({Ident})\\s*\\(\\s*\"((?:{scope})[A-Za-z0-9_.]+)\"", RegexOptions.CultureInvariant);
+        var map = new Dictionary<string, List<int>>(StringComparer.Ordinal);
+        foreach (Match m in rx.Matches(source.Code))
+        {
+            var dispatcher = m.Groups[1].Value;
+            if (LoggingSinks.Contains(dispatcher)) continue;
+            var name = m.Groups[2].Value;
+            if (!map.TryGetValue(name, out var list))
+                map[name] = list = new List<int>();
+            list.Add(m.Index);
+        }
+        return map;
+    }
+
+    /// <summary>Returns the in-scope methods handled by a <c>case "…":</c> label.</summary>
+    private static HashSet<string> ExtractHandledMethods(string code, IReadOnlyList<string> scopePrefixes)
+    {
+        var scope = ScopeAlternation(scopePrefixes);
+        var rx = new Regex($"case\\s*\"((?:{scope})[A-Za-z0-9_.]+)\"\\s*:", RegexOptions.CultureInvariant);
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        foreach (Match m in rx.Matches(code))
+            set.Add(m.Groups[1].Value);
+        return set;
+    }
+
+    private static string ScopeAlternation(IReadOnlyList<string> scopePrefixes) =>
+        string.Join("|", scopePrefixes.Select(p => Regex.Escape(p)));
+
+    // --- block extraction ---------------------------------------------------
+
+    /// <summary>
+    /// Returns the body (including braces) of the first method/block whose
+    /// declaration contains <paramref name="signatureFragment"/>, as both the
+    /// comment-stripped code view and the fully-masked view (same indices). Brace
+    /// matching uses the masked view. Returns null when the fragment is absent.
+    /// </summary>
+    private static Region? ExtractMethodBody(Source source, string signatureFragment)
+    {
+        var sigIndex = source.Masked.IndexOf(signatureFragment, StringComparison.Ordinal);
+        if (sigIndex < 0) return null;
+
+        var open = source.Masked.IndexOf('{', sigIndex);
+        if (open < 0) return null;
+        var close = MatchBrace(source.Masked, open);
+        if (close < 0) return null;
+        return Slice(source, open, close);
+    }
+
+    /// <summary>
+    /// Returns the innermost <c>{ … }</c> block enclosing <paramref name="position"/>
+    /// (both views) and a flag indicating whether that block is a type body rather
+    /// than a method body — which happens when the dispatch call is in an
+    /// expression-bodied member and the enclosing block degrades to the whole class.
+    /// </summary>
+    private static (Region? region, bool isTypeBody) ExtractEnclosingBlock(Source source, int position)
+    {
+        var masked = source.Masked;
+        var depth = 0;
+        var open = -1;
+        for (var i = Math.Min(position, masked.Length) - 1; i >= 0; i--)
+        {
+            var c = masked[i];
+            if (c == '}') depth++;
+            else if (c == '{')
+            {
+                if (depth == 0) { open = i; break; }
+                depth--;
+            }
+        }
+        if (open < 0) return (null, false);
+
+        var close = MatchBrace(masked, open);
+        if (close < 0) return (null, false);
+
+        var isTypeBody = IsTypeDeclarationBefore(masked, open);
+        return (Slice(source, open, close), isTypeBody);
+    }
+
+    /// <summary>
+    /// True when the <c>{</c> at <paramref name="openIndex"/> opens a type body —
+    /// i.e. the nearest declaration keyword immediately preceding it is
+    /// class/struct/record/interface <em>followed by a type name</em> (no
+    /// intervening <c>;</c>/<c>{</c>/<c>}</c>). Requiring the type name avoids a
+    /// false positive on a generic constraint such as <c>where T : class { … }</c>,
+    /// where the keyword is not introducing a type declaration.
+    /// </summary>
+    private static bool IsTypeDeclarationBefore(string masked, int openIndex)
+    {
+        var start = Math.Max(0, openIndex - 400);
+        var prefix = masked.Substring(start, openIndex - start);
+        return Regex.IsMatch(prefix, $"\\b(class|struct|record|interface)\\s+{Ident}[^;{{}}]*$");
+    }
+
+    private static Region Slice(Source source, int open, int close) =>
+        new(source.Code.Substring(open, close - open + 1), source.Masked.Substring(open, close - open + 1));
+
+    private static int MatchBrace(string masked, int openIndex)
+    {
+        var depth = 0;
+        for (var i = openIndex; i < masked.Length; i++)
+        {
+            if (masked[i] == '{') depth++;
+            else if (masked[i] == '}')
+            {
+                depth--;
+                if (depth == 0) return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        if (string.IsNullOrEmpty(needle)) return 0;
+        var count = 0;
+        var idx = 0;
+        while ((idx = haystack.IndexOf(needle, idx, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            idx += needle.Length;
+        }
+        return count;
+    }
+
+    // --- source preprocessing ----------------------------------------------
+
+    /// <summary>
+    /// Produces two index-aligned, equal-length views of <paramref name="source"/>:
+    /// <c>Code</c> blanks comments only (string/char literals preserved), and
+    /// <c>Masked</c> blanks comments AND string/char/verbatim/interpolated literals.
+    /// Newlines are preserved in both. A single lexer pass guarantees the two views
+    /// stay aligned. Precondition: interpolated-string holes in scanned regions do
+    /// not contain a closing quote inside the hole; the scanned OpenClaw methods
+    /// satisfy this.
+    /// </summary>
+    private static (string Code, string Masked) Preprocess(string source)
+    {
+        var code = new StringBuilder(source.Length);
+        var masked = new StringBuilder(source.Length);
+        var i = 0;
+
+        void Emit(char c) { code.Append(c); masked.Append(c); }
+        void Blank(int n) { code.Append(' ', n); masked.Append(' ', n); }            // comment: blank both
+        void Keep(char c) { code.Append(c); masked.Append(' '); }                    // literal char: keep in Code, blank in Masked
+        void NL() { code.Append('\n'); masked.Append('\n'); }
+
+        while (i < source.Length)
+        {
+            var c = source[i];
+            var next = i + 1 < source.Length ? source[i + 1] : '\0';
+
+            if (c == '/' && next == '/')
+            {
+                while (i < source.Length && source[i] != '\n') { if (source[i] == '\n') NL(); else Blank(1); i++; }
+                continue;
+            }
+            if (c == '/' && next == '*')
+            {
+                Blank(2); i += 2;
+                while (i < source.Length && !(source[i] == '*' && i + 1 < source.Length && source[i + 1] == '/'))
+                { if (source[i] == '\n') NL(); else Blank(1); i++; }
+                if (i < source.Length) { Blank(2); i += 2; }
+                continue;
+            }
+            if (c == '@' && next == '"')
+            {
+                Keep('@'); Keep('"'); i += 2;
+                while (i < source.Length)
+                {
+                    if (source[i] == '"')
+                    {
+                        if (i + 1 < source.Length && source[i + 1] == '"') { Keep('"'); Keep('"'); i += 2; continue; }
+                        Keep('"'); i++; break;
+                    }
+                    if (source[i] == '\n') NL(); else Keep(source[i]);
+                    i++;
+                }
+                continue;
+            }
+            if (c == '"' || (c == '$' && next == '"'))
+            {
+                if (c == '$') { Keep('$'); i++; }
+                Keep('"'); i++;
+                while (i < source.Length)
+                {
+                    if (source[i] == '\\') { Keep('\\'); if (i + 1 < source.Length) Keep(source[i + 1]); i += 2; continue; }
+                    if (source[i] == '"') { Keep('"'); i++; break; }
+                    if (source[i] == '\n') NL(); else Keep(source[i]);
+                    i++;
+                }
+                continue;
+            }
+            if (c == '\'')
+            {
+                Keep('\''); i++;
+                while (i < source.Length)
+                {
+                    if (source[i] == '\\') { Keep('\\'); if (i + 1 < source.Length) Keep(source[i + 1]); i += 2; continue; }
+                    if (source[i] == '\'') { Keep('\''); i++; break; }
+                    Keep(source[i]); i++;
+                }
+                continue;
+            }
+
+            if (c == '\n') NL(); else Emit(c);
+            i++;
+        }
+
+        return (code.ToString(), masked.ToString());
+    }
+
+    // --- loading ------------------------------------------------------------
+
+    /// <summary>The client dispatch surface: the OpenClawGatewayClient partial class files.</summary>
+    private static Source LoadClientSource() =>
+        ConcatSources(f => FileNameMatches(f.Path, "OpenClawGatewayClient", ".cs"),
+            "Could not locate OpenClawGatewayClient*.cs under src/.");
+
+    /// <summary>The client surface plus the DTO/payload builders (GatewayProtocolModels.cs).</summary>
+    private static Source LoadProtocolSource() =>
+        ConcatSources(
+            f => FileNameMatches(f.Path, "OpenClawGatewayClient", ".cs") || EndsWith(f.Path, "GatewayProtocolModels.cs"),
+            "Could not locate the gateway protocol source under src/.");
+
+    private static Source ConcatSources(Func<SourceFileSnapshot, bool> predicate, string notFound)
+    {
+        var files = ProductionSourceFiles.All
+            .Where(predicate)
+            .OrderBy(f => f.Path, StringComparer.Ordinal)
+            .ToList();
+        Assert.True(files.Count > 0, notFound);
+        // Join with a newline so per-file brace balance is preserved across the
+        // concatenation (each .cs is itself balanced, so blocks never span files).
+        var text = string.Join("\n", files.Select(f => f.Text));
+        var (code, masked) = Preprocess(text);
+
+        // Self-check: a desynced masker (e.g. an unhandled string/raw-string form
+        // leaving a brace "live") would make brace matching unreliable and could
+        // produce false passes. The masked view must keep brace balance.
+        var opens = masked.Count(ch => ch == '{');
+        var closes = masked.Count(ch => ch == '}');
+        Assert.True(opens == closes,
+            $"Literal/comment masker desynced on the gateway protocol source (masked braces {opens} open vs {closes} close). " +
+            "A new C# string form (e.g. a raw string literal) likely needs handling in Preprocess.");
+
+        return new Source(code, masked);
+    }
+
+    private static bool FileNameMatches(string path, string prefix, string suffix)
+    {
+        var name = Path.GetFileName(path);
+        return name.StartsWith(prefix, StringComparison.Ordinal) && name.EndsWith(suffix, StringComparison.Ordinal);
+    }
+
+    private static bool EndsWith(string path, string fileName) =>
+        string.Equals(Path.GetFileName(path), fileName, StringComparison.Ordinal);
+
+    private static ProtocolSnapshot LoadSnapshot()
+    {
+        var path = Path.Combine(ProductionSourceFiles.FindRepoRoot(), "tests", "OpenClaw.Shared.Tests", "Protocol", "gateway-protocol-snapshot.json");
+        Assert.True(File.Exists(path), $"Protocol snapshot fixture not found at {path}.");
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        var root = doc.RootElement;
+
+        var scopePrefixes = root.GetProperty("scopePrefixes").EnumerateArray().Select(e => e.GetString()!).ToList();
+
+        var methods = new List<ProtocolMethod>();
+        foreach (var m in root.GetProperty("methods").EnumerateArray())
+        {
+            methods.Add(new ProtocolMethod(
+                Method: m.GetProperty("method").GetString()!,
+                Kind: m.GetProperty("kind").GetString()!,
+                WindowsUsage: m.GetProperty("windowsUsage").GetString()!,
+                RequestFields: ReadStringArray(m, "requestFields"),
+                AllowedExtraRequestFields: ReadStringArray(m, "allowedExtraRequestFields"),
+                ResponseFields: ReadStringArray(m, "responseFields"),
+                ResponseEnvelope: ReadStringArray(m, "responseEnvelope"),
+                RequestFieldsSource: m.TryGetProperty("requestFieldsSource", out var s) && s.ValueKind == JsonValueKind.String ? s.GetString() : null,
+                ResponseEnvelopeSource: m.TryGetProperty("responseEnvelopeSource", out var es) && es.ValueKind == JsonValueKind.String ? es.GetString() : null,
+                RequestFieldSemantics: m.TryGetProperty("requestFieldSemantics", out var rs) && rs.ValueKind == JsonValueKind.String ? rs.GetString() : null,
+                TriState: ReadTriStateContract(m),
+                ProvisionalResponseFields: m.TryGetProperty("provisionalResponseFields", out var p) && p.ValueKind == JsonValueKind.True));
+        }
+
+        return new ProtocolSnapshot(scopePrefixes, methods);
+    }
+
+    private static IReadOnlyList<string> ReadStringArray(JsonElement obj, string property)
+    {
+        if (!obj.TryGetProperty(property, out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return Array.Empty<string>();
+        return arr.EnumerateArray().Select(e => e.GetString()!).ToList();
+    }
+
+    private static TriStateContract? ReadTriStateContract(JsonElement method)
+    {
+        if (!method.TryGetProperty("tristateContract", out var c) || c.ValueKind != JsonValueKind.Object)
+            return null;
+
+        var markers = new List<TriStateMarker>();
+        if (c.TryGetProperty("markers", out var ms) && ms.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var m in ms.EnumerateArray())
+            {
+                markers.Add(new TriStateMarker(
+                    Name: m.GetProperty("name").GetString()!,
+                    Pattern: m.GetProperty("pattern").GetString()!,
+                    Source: m.TryGetProperty("source", out var src) && src.ValueKind == JsonValueKind.String ? src.GetString() : null));
+            }
+        }
+
+        return new TriStateContract(
+            BuilderSource: c.GetProperty("builderSource").GetString()!,
+            Markers: markers,
+            StateTypeSource: c.GetProperty("stateTypeSource").GetString()!,
+            StateMembers: ReadStringArray(c, "stateMembers"));
+    }
+
+    private sealed record Source(string Code, string Masked);
+
+    private sealed record Region(string Code, string Masked);
+
+    private sealed record TriStateMarker(string Name, string Pattern, string? Source);
+
+    private sealed record TriStateContract(
+        string BuilderSource,
+        IReadOnlyList<TriStateMarker> Markers,
+        string StateTypeSource,
+        IReadOnlyList<string> StateMembers);
+
+    private sealed record ProtocolSnapshot(IReadOnlyList<string> ScopePrefixes, IReadOnlyList<ProtocolMethod> Methods);
+
+    private sealed record ProtocolMethod(
+        string Method,
+        string Kind,
+        string WindowsUsage,
+        IReadOnlyList<string> RequestFields,
+        IReadOnlyList<string> AllowedExtraRequestFields,
+        IReadOnlyList<string> ResponseFields,
+        IReadOnlyList<string> ResponseEnvelope,
+        string? RequestFieldsSource,
+        string? ResponseEnvelopeSource,
+        string? RequestFieldSemantics,
+        TriStateContract? TriState,
+        bool ProvisionalResponseFields);
+}

--- a/tests/OpenClaw.Shared.Tests/Protocol/GatewayProtocolDriftTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Protocol/GatewayProtocolDriftTests.cs
@@ -182,7 +182,7 @@ public class GatewayProtocolDriftTests
         var sentIndices = ExtractDispatchedRequestMethods(client, snapshot.ScopePrefixes);
         var failures = new List<string>();
 
-        foreach (var method in snapshot.Methods.Where(m => m.WindowsUsage == "used" && m.Kind == "request" && m.RequestFields.Count > 0))
+        foreach (var method in snapshot.Methods.Where(m => m.WindowsUsage == "used" && m.Kind == "request"))
         {
             var regions = new List<Region>();
 

--- a/tests/OpenClaw.Shared.Tests/Protocol/gateway-protocol-snapshot.json
+++ b/tests/OpenClaw.Shared.Tests/Protocol/gateway-protocol-snapshot.json
@@ -1,0 +1,228 @@
+{
+  "_comment": [
+    "CANONICAL MIRROR of the upstream OpenClaw gateway protocol schema for the",
+    "sessions / files / commands / compaction surface. This file is the pinned",
+    "reference that GatewayProtocolDriftTests checks the Windows companion against.",
+    "It is maintained BY HAND from upstream main. When upstream changes, refresh",
+    "this file (see docs/gateway-protocol-drift-guard.md) and the drift test will",
+    "force the Windows client to be reconciled.",
+    "",
+    "This guard complements — it does not duplicate — the behavioural parser tests",
+    "in GatewayProtocolModelsTests. Those parse sample JSON and assert DTO mapping;",
+    "this guard statically pins the method / request-field / response-envelope",
+    "SURFACE against the typed client so an upstream rename or a dropped API fails",
+    "loudly even if the parser unit tests still pass on their fixed samples.",
+    "",
+    "windowsUsage:",
+    "  used     - the client sends/handles this method today; the guard REQUIRES it",
+    "             to remain wired up (dropping it means the client stopped",
+    "             implementing a method it should send).",
+    "  planned  - defined upstream but not yet consumed by the client; the shape is",
+    "             pinned for future adoption but the client is not required to use",
+    "             it yet. (Currently none — the typed client wires the whole",
+    "             sessions/files/commands/compaction surface.)",
+    "",
+    "Per-method enforced fields (see docs 'Enforced vs documentation-only'):",
+    "  requestFields   - validated BIDIRECTIONALLY against the ACTUAL constructed wire",
+    "                    keys (anonymous-object members + dictionary string keys) in the",
+    "                    request-construction region (the send call site's enclosing",
+    "                    block, or requestFieldsSource): missing (pinned but not built)",
+    "                    AND unexpected (built but not pinned) both fail. So renaming a",
+    "                    wire key (old name surviving as a local) and leaving a stale",
+    "                    extra key are both caught.",
+    "  allowedExtraRequestFields - optional per-method allowlist exempting intentional",
+    "                    client-only extra wire keys from the 'unexpected' direction.",
+    "  responseEnvelope- the top-level container property the client must read",
+    "                    (TryGetProperty / TryGetArray), scoped to responseEnvelopeSource",
+    "                    (the specific parser body) so one parser reading the same",
+    "                    property name cannot satisfy another method's envelope.",
+    "  responseFields  - (sessions.list only) the exact session field set the legacy",
+    "                    session parser reads; cross-checked both directions.",
+    "  requestFieldsSource    - declaration-signature fragment whose body holds the",
+    "                    request-field construction, when it is NOT inline at the send",
+    "                    call site (e.g. SessionPatch.ToPayload, MutateCompactionAsync).",
+    "                    Must resolve uniquely to a body that actually constructs keys.",
+    "  responseEnvelopeSource - declaration-signature fragment of the parser body that",
+    "                    reads this method's response envelope."
+  ],
+  "upstreamSourceOfTruth": "openclaw/openclaw — packages/gateway-protocol/src/schema/{sessions,commands}.ts",
+  "upstreamRef": "main",
+  "upstreamVerified": {
+    "date": "2026-06-23",
+    "sessionsTsBlobSha": "d938f80f68cb285719e20801e83f74893aa04332",
+    "commandsTsBlobSha": "a24972162dfbe4f95e05bf19211097707d30f9bb",
+    "result": "All enforced request fields, response envelopes, and the sessions.patch tri-state nullable (Union([value, Null])) contract match upstream main exactly. The snapshot is a deliberate SUBSET: the Windows client does not yet implement these upstream sessions.patch fields — label, agentId, spawnedBy, spawnedWorkspaceDir, spawnedCwd, spawnDepth, subagentRole, subagentControlScope, inheritedToolAllow, inheritedToolDeny (spawn/subagent orchestration); nor the compaction checkpoint preCompaction/postCompaction references. These are upstream fields the client does not implement yet, not drift."
+  },
+  "clientFoundationCommit": "2cae69ba",
+  "_clientFoundationCommitNote": "The commit on main that introduced the typed gateway protocol client (OpenClawGatewayClient.Protocol.cs + GatewayProtocolModels.cs) this guard cross-checks.",
+  "snapshotUpdated": "2026-06-24",
+  "scopePrefixes": ["sessions.", "agents.files.", "commands."],
+  "methods": [
+    {
+      "method": "sessions.list",
+      "kind": "request",
+      "windowsUsage": "used",
+      "requestFields": ["agentId"],
+      "responseEnvelope": ["sessions"],
+      "responseEnvelopeSource": "TryGetSessionsPayload(JsonElement payload",
+      "responseFields": [
+        "key", "isMain", "status", "model", "channel", "displayName", "provider",
+        "subject", "room", "space", "sessionId", "thinkingLevel", "verboseLevel",
+        "systemSent", "abortedLastRun", "inputTokens", "outputTokens", "totalTokens",
+        "contextTokens", "updatedAt", "startedAt"
+      ]
+    },
+    {
+      "method": "sessions.subscribe",
+      "kind": "request",
+      "windowsUsage": "used",
+      "requestFields": []
+    },
+    {
+      "method": "sessions.changed",
+      "kind": "notification",
+      "windowsUsage": "used",
+      "requestFields": []
+    },
+    {
+      "method": "sessions.preview",
+      "kind": "request",
+      "windowsUsage": "used",
+      "requestFields": ["keys", "limit", "maxChars"]
+    },
+    {
+      "method": "sessions.patch",
+      "kind": "request",
+      "windowsUsage": "used",
+      "requestFields": [
+        "key", "model", "thinkingLevel", "fastMode", "verboseLevel", "traceLevel",
+        "reasoningLevel", "responseUsage", "elevatedLevel", "execHost", "execSecurity",
+        "execAsk", "execNode", "sendPolicy", "groupActivation"
+      ],
+      "requestFieldsSource": "ToPayload(string key",
+      "_note": "Extended field set built by SessionPatch.ToPayload (strict additionalProperties:false upstream). The exact wire key allowlist is also asserted at runtime by GatewayProtocolModelsTests.SessionPatch_ToPayload_EmitsOnlyKnownGatewaySchemaFields.",
+      "requestFieldSemantics": "tristate-nullable",
+      "tristateContract": {
+        "_doc": [
+          "Upstream SessionsPatchParamsSchema types every field as Union([<value>, Null]):",
+          "an explicit null REMOVES a session override. The Windows client models this as",
+          "a tri-state PatchField<T>: unset (null reference) -> omitted; a value -> sent",
+          "(blank string omitted per NonEmptyString); SessionPatch.Clear -> explicit JSON",
+          "null. This guard pins the STRUCTURAL PRESENCE of that machinery; the runtime",
+          "routing SEMANTICS (incl. unset->omit and value-when-blank) are owned by",
+          "GatewayProtocolModelsTests (ClearEmitsExplicitNull*, MixesSetAndClearAndUnset,",
+          "PatchField_TriStateFlags). Each marker is a regex over a specific source body;",
+          "'source' defaults to builderSource when omitted. Every source must resolve uniquely."
+        ],
+        "builderSource": "public sealed class SessionPatch",
+        "markers": [
+          { "name": "clear sentinel type referenced in builder", "pattern": "PatchFieldClear" },
+          { "name": "AddString has a clear branch", "source": "void AddString(", "pattern": "\\bIsClear\\b" },
+          { "name": "AddString emits explicit null on clear", "source": "void AddString(", "pattern": "payload\\[\\s*name\\s*\\]\\s*=\\s*null" },
+          { "name": "AddString omits blank string value", "source": "void AddString(", "pattern": "IsNullOrWhiteSpace" },
+          { "name": "AddEncoded has a clear branch", "source": "void AddEncoded", "pattern": "\\bIsClear\\b" },
+          { "name": "AddEncoded emits explicit null on clear", "source": "void AddEncoded", "pattern": "payload\\[\\s*name\\s*\\]\\s*=\\s*null" },
+          { "name": "AddEncoded gates emission on set value", "source": "void AddEncoded", "pattern": "\\bHasValue\\b" },
+          { "name": "unset (null reference) maps to default/unset", "source": "struct PatchField<T>", "pattern": "value is null\\s*\\?\\s*default" }
+        ],
+        "stateTypeSource": "struct PatchField<T>",
+        "stateMembers": ["IsSpecified", "IsClear", "HasValue"]
+      }
+    },
+    {
+      "method": "sessions.reset",
+      "kind": "request",
+      "windowsUsage": "used",
+      "requestFields": ["key"]
+    },
+    {
+      "method": "sessions.delete",
+      "kind": "request",
+      "windowsUsage": "used",
+      "requestFields": ["key", "deleteTranscript"]
+    },
+    {
+      "method": "sessions.compact",
+      "kind": "request",
+      "windowsUsage": "used",
+      "requestFields": ["key", "maxLines"]
+    },
+    {
+      "method": "agents.files.list",
+      "kind": "request",
+      "windowsUsage": "used",
+      "requestFields": ["agentId"]
+    },
+    {
+      "method": "agents.files.get",
+      "kind": "request",
+      "windowsUsage": "used",
+      "requestFields": ["agentId", "name"]
+    },
+    {
+      "method": "commands.list",
+      "kind": "request",
+      "windowsUsage": "used",
+      "requestFields": [],
+      "responseEnvelope": ["commands"],
+      "responseEnvelopeSource": "ParseCommandCatalog(JsonElement payload",
+      "itemFields": [
+        "name", "nativeName", "textAliases", "description", "category", "source",
+        "scope", "acceptsArgs", "args"
+      ],
+      "_itemFieldsNote": "Per-command descriptor fields parsed by ParseCommand; documentation-only (behaviour covered by GatewayProtocolModelsTests.ParseCommandCatalog_*)."
+    },
+    {
+      "method": "sessions.files.list",
+      "kind": "request",
+      "windowsUsage": "used",
+      "requestFields": ["sessionKey", "path", "search"],
+      "responseEnvelope": ["files"],
+      "responseEnvelopeSource": "ParseSessionFileList(JsonElement payload",
+      "itemFields": ["path", "name", "kind", "missing", "size", "updatedAtMs", "content"],
+      "_itemFieldsNote": "File entry fields parsed by ParseFileEntry; documentation-only (covered by GatewayProtocolModelsTests.ParseSessionFileList_*)."
+    },
+    {
+      "method": "sessions.files.get",
+      "kind": "request",
+      "windowsUsage": "used",
+      "requestFields": ["sessionKey", "path"],
+      "responseEnvelope": ["file"],
+      "responseEnvelopeSource": "ParseSessionFileContent(JsonElement payload",
+      "itemFields": ["path", "name", "kind", "content", "size", "updatedAtMs", "missing"],
+      "_itemFieldsNote": "Nested file fields parsed by ParseSessionFileContent; documentation-only."
+    },
+    {
+      "method": "sessions.compaction.list",
+      "kind": "request",
+      "windowsUsage": "used",
+      "requestFields": ["key"],
+      "responseEnvelope": ["checkpoints"],
+      "responseEnvelopeSource": "ParseCompactionCheckpointList(JsonElement payload",
+      "itemFields": ["checkpointId", "sessionKey", "sessionId", "createdAt", "reason", "tokensBefore", "tokensAfter", "summary", "firstKeptEntryId"],
+      "_itemFieldsNote": "Checkpoint fields parsed by ParseCompactionCheckpoint; documentation-only."
+    },
+    {
+      "method": "sessions.compaction.get",
+      "kind": "request",
+      "windowsUsage": "used",
+      "requestFields": ["key", "checkpointId"],
+      "responseEnvelope": ["checkpoint"],
+      "responseEnvelopeSource": "ParseCompactionCheckpointResult(JsonElement payload"
+    },
+    {
+      "method": "sessions.compaction.branch",
+      "kind": "request",
+      "windowsUsage": "used",
+      "requestFields": ["key", "checkpointId"],
+      "requestFieldsSource": "string method, string key, string checkpointId"
+    },
+    {
+      "method": "sessions.compaction.restore",
+      "kind": "request",
+      "windowsUsage": "used",
+      "requestFields": ["key", "checkpointId"],
+      "requestFieldsSource": "string method, string key, string checkpointId"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a **gateway protocol drift guard** so the Windows companion stops silently drifting from the upstream OpenClaw gateway protocol. It pins a hand-maintained, **upstream-verified** mirror of the `sessions` / `files` / `commands` / compaction surface and statically cross-checks it against the typed client, so future drift fails CI instead of shipping. Because the gateway tolerates unknown/extra fields, this kind of drift otherwise ships without any test failing.

## What it adds

- **`tests/OpenClaw.Shared.Tests/Protocol/gateway-protocol-snapshot.json`** — canonical pin of the protocol surface: methods, request wire-keys, response envelopes, `sessions.list` response shape, and the `sessions.patch` tri-state nullable clear contract.
- **`tests/OpenClaw.Shared.Tests/Protocol/GatewayProtocolDriftTests.cs`** — six guards:
  - method surface (dispatched requests vs handled notifications)
  - `sessions.list` response field set
  - request wire-keys (actual constructed keys, not token presence)
  - response envelope read, method-scoped
  - snapshot integrity + required-method coverage
  - tri-state clear contract (`SessionPatch.Clear` -> explicit JSON null; value -> sent; null reference -> omit; blank -> omit)
- **`docs/gateway-protocol-drift-guard.md`** — how it works, enforced-vs-doc-only table, refresh steps.
- `ProductionSourceFiles.FindRepoRoot` made `internal` for reuse.

Deterministic and **repo-contained**: no upstream clone, no network. It complements (does not duplicate) the behavioural `GatewayProtocolModelsTests` and `GatewayProtocolLiveRoundTripTests` — those assert runtime JSON emission / wire frames; this guards the static method/field/envelope surface.

## Upstream verification

Verified 2026-06-23 against `openclaw/openclaw` **main** (`packages/gateway-protocol/src/schema/sessions.ts` blob `d938f80f`, `commands.ts` blob `a2497216`). All enforced pins — request fields, response envelopes, and the `sessions.patch` `Union([value, Null])` tri-state contract — **match upstream exactly**. The snapshot is a deliberate subset: some upstream `sessions.patch` fields (`label`, `agentId`, spawn/subagent metadata) and compaction-checkpoint `preCompaction`/`postCompaction` references are not implemented by the client yet — recorded in the snapshot's `upstreamVerified` note as not-yet-implemented, not drift.

## Validation

- `./build.ps1` — all projects pass
- `OpenClaw.Shared.Tests` pass (incl. the 6 drift guards)
- `OpenClaw.Tray.Tests` pass

Builds on the typed gateway protocol client already merged to `main`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
