### PR TITLE
Improve Cron run history UX

### DIFF
--- a/src/OpenClaw.Shared/IOperatorGatewayClient.cs
+++ b/src/OpenClaw.Shared/IOperatorGatewayClient.cs
@@ -73,6 +73,7 @@ public interface IOperatorGatewayClient
     Task RequestCronListAsync();
     Task RequestCronStatusAsync();
     Task<bool> RunCronJobAsync(string jobId, bool force = true);
+    Task<CronRunRequestResult> RunCronJobDetailedAsync(string jobId, bool force = true, int timeoutMs = 12000);
     Task<bool> RemoveCronJobAsync(string jobId);
     Task<bool> AddCronJobAsync(object jobDefinition);
     Task<bool> UpdateCronJobAsync(string id, object patch);
@@ -141,4 +142,15 @@ public interface IOperatorGatewayClient
     /// <summary>Restore a session to a compaction checkpoint (<c>sessions.compaction.restore</c>).</summary>
     Task<SessionCompactionMutationResult> RestoreCompactionCheckpointAsync(string key, string checkpointId, int timeoutMs = 15000)
         => Task.FromResult(new SessionCompactionMutationResult { Key = key, CheckpointId = checkpointId, IsSupported = false });
+}
+
+public sealed record CronRunRequestResult(
+    bool Accepted,
+    bool Enqueued,
+    string? RunId,
+    string? Reason = null,
+    string? Error = null)
+{
+    public static CronRunRequestResult NotAccepted(string? error) =>
+        new(false, false, null, null, error);
 }

--- a/src/OpenClaw.Shared/IOperatorGatewayClient.cs
+++ b/src/OpenClaw.Shared/IOperatorGatewayClient.cs
@@ -73,7 +73,19 @@ public interface IOperatorGatewayClient
     Task RequestCronListAsync();
     Task RequestCronStatusAsync();
     Task<bool> RunCronJobAsync(string jobId, bool force = true);
-    Task<CronRunRequestResult> RunCronJobDetailedAsync(string jobId, bool force = true, int timeoutMs = 12000);
+    /// <summary>
+    /// Response-aware cron run request. Compatibility fallback for implementers
+    /// that only provide <see cref="RunCronJobAsync"/>; the fallback cannot
+    /// enforce <paramref name="timeoutMs"/> and implementers should not implement
+    /// <see cref="RunCronJobAsync"/> by delegating back to this method.
+    /// </summary>
+    async Task<CronRunRequestResult> RunCronJobDetailedAsync(string jobId, bool force = true, int timeoutMs = 12000)
+    {
+        var accepted = await RunCronJobAsync(jobId, force).ConfigureAwait(false);
+        return accepted
+            ? new CronRunRequestResult(true, true, null)
+            : CronRunRequestResult.NotAccepted(null);
+    }
     Task<bool> RemoveCronJobAsync(string jobId);
     Task<bool> AddCronJobAsync(object jobDefinition);
     Task<bool> UpdateCronJobAsync(string id, object patch);

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -801,11 +801,14 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         !string.IsNullOrWhiteSpace(message) &&
         message.Contains("invalid cron.run params", StringComparison.OrdinalIgnoreCase);
 
-    private static CronRunRequestResult ParseCronRunRequestResult(JsonElement payload)
+    internal static CronRunRequestResult ParseCronRunRequestResult(JsonElement payload)
     {
         var accepted = !payload.TryGetProperty("ok", out var okEl) || okEl.ValueKind != JsonValueKind.False;
-        var enqueued = payload.TryGetProperty("enqueued", out var enqEl) && enqEl.ValueKind == JsonValueKind.True;
-        var ran = payload.TryGetProperty("ran", out var ranEl)
+        var hasEnqueued = payload.TryGetProperty("enqueued", out var enqEl);
+        var enqueued = hasEnqueued && enqEl.ValueKind == JsonValueKind.True;
+        var enqueuedFalse = hasEnqueued && enqEl.ValueKind == JsonValueKind.False;
+        var hasRan = payload.TryGetProperty("ran", out var ranEl);
+        var ran = hasRan
             ? ranEl.ValueKind == JsonValueKind.True
             : (bool?)null;
         var runId = payload.TryGetProperty("runId", out var runIdEl) && runIdEl.ValueKind == JsonValueKind.String
@@ -817,7 +820,8 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
 
         return new CronRunRequestResult(
             accepted,
-            enqueued || !string.IsNullOrWhiteSpace(runId) || ran == true,
+            accepted && !enqueuedFalse && ran != false &&
+            (enqueued || !string.IsNullOrWhiteSpace(runId) || ran == true || (!hasEnqueued && !hasRan)),
             runId,
             reason);
     }

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -760,9 +760,66 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         await SendTrackedRequestAsync("cron.status");
     }
 
-    public Task<bool> RunCronJobAsync(string jobId, bool force = true)
+    public async Task<bool> RunCronJobAsync(string jobId, bool force = true)
     {
-        return TrySendTrackedRequestAsync("cron.run", new { id = jobId, force });
+        var result = await RunCronJobDetailedAsync(jobId, force);
+        return result.Accepted && result.Enqueued;
+    }
+
+    public async Task<CronRunRequestResult> RunCronJobDetailedAsync(string jobId, bool force = true, int timeoutMs = 12000)
+    {
+        if (string.IsNullOrWhiteSpace(jobId))
+            return CronRunRequestResult.NotAccepted("Job id is required.");
+
+        var payloads = new List<object>();
+        if (!force)
+            payloads.Add(new { jobId, mode = "due" });
+        payloads.Add(new { jobId });
+        payloads.Add(new { id = jobId, force });
+
+        string? lastError = null;
+        foreach (var requestPayload in payloads)
+        {
+            try
+            {
+                var payload = await SendWizardRequestAsync("cron.run", requestPayload, timeoutMs);
+                return ParseCronRunRequestResult(payload);
+            }
+            catch (Exception ex)
+            {
+                lastError = ex.Message;
+                if (!IsCronRunPayloadShapeError(ex.Message))
+                    break;
+            }
+        }
+
+        _logger.Warn($"cron.run request failed: {lastError}");
+        return CronRunRequestResult.NotAccepted(lastError);
+    }
+
+    private static bool IsCronRunPayloadShapeError(string? message) =>
+        !string.IsNullOrWhiteSpace(message) &&
+        message.Contains("invalid cron.run params", StringComparison.OrdinalIgnoreCase);
+
+    private static CronRunRequestResult ParseCronRunRequestResult(JsonElement payload)
+    {
+        var accepted = !payload.TryGetProperty("ok", out var okEl) || okEl.ValueKind != JsonValueKind.False;
+        var enqueued = payload.TryGetProperty("enqueued", out var enqEl) && enqEl.ValueKind == JsonValueKind.True;
+        var ran = payload.TryGetProperty("ran", out var ranEl)
+            ? ranEl.ValueKind == JsonValueKind.True
+            : (bool?)null;
+        var runId = payload.TryGetProperty("runId", out var runIdEl) && runIdEl.ValueKind == JsonValueKind.String
+            ? runIdEl.GetString()
+            : null;
+        var reason = payload.TryGetProperty("reason", out var reasonEl) && reasonEl.ValueKind == JsonValueKind.String
+            ? reasonEl.GetString()
+            : null;
+
+        return new CronRunRequestResult(
+            accepted,
+            enqueued || !string.IsNullOrWhiteSpace(runId) || ran == true,
+            runId,
+            reason);
     }
 
     public Task<bool> RemoveCronJobAsync(string jobId)

--- a/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml.cs
@@ -3,14 +3,17 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using OpenClaw.Shared;
+using OpenClawTray.Chat;
+using OpenClawTray.Chat.Markdown;
+using OpenClawTray.FunctionalUI.Hosting;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
+using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Windows.UI;
 
@@ -26,6 +29,9 @@ public sealed partial class CronPage : Page
     private HashSet<string> _runningJobIds = new(); // jobs currently being triggered
     private HashSet<string> _removedJobIds = new(); // jobs user explicitly removed (suppress auto-delete notification)
     private HashSet<string> _expandedJobIds = new(); // persisted expanded state
+    private readonly Dictionary<string, CancellationTokenSource> _runRefreshCts = new();
+    private readonly HashSet<string> _expandedRunFullResponseIds = new(); // persisted run response expansion state
+    private string? _lastHistoryRenderSignature = null;
     private CancellationTokenSource? _infoDismissCts = null; // auto-dismiss timer for InfoBar
     private readonly AsyncListLoadingState _cronLoading = new();
 
@@ -35,6 +41,7 @@ public sealed partial class CronPage : Page
         Unloaded += (_, _) =>
         {
             if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+            CancelAllRunRefreshLoops();
         };
     }
 
@@ -127,23 +134,30 @@ public sealed partial class CronPage : Page
         if (!_cronLoading.CanEdit) return;
         if (CurrentApp.GatewayClient == null) { ShowDisconnected(); return; }
         var vm = _jobs.Find(j => j.Id == jobId);
-        if (vm != null && !vm.IsEnabled) return;
+        if (_runningJobIds.Contains(jobId)) return;
         _runningJobIds.Add(jobId);
-        btn!.Content = LocalizationHelper.GetString("CronPage_Running");
-        btn.IsEnabled = false;
+        RefreshJobActionButtons(jobId);
 
-        CurrentApp.GatewayClient.RunCronJobAsync(jobId).ContinueWith(t =>
+        CurrentApp.GatewayClient.RunCronJobDetailedAsync(jobId).ContinueWith(t =>
         {
-            if (t.IsFaulted || (t.IsCompletedSuccessfully && !t.Result))
+            DispatcherQueue?.TryEnqueue(() =>
             {
-                // Request failed — clear running state immediately
-                DispatcherQueue?.TryEnqueue(() =>
+                var client = CurrentApp.GatewayClient;
+                var result = t.IsCompletedSuccessfully ? t.Result : null;
+                if (t.IsFaulted || result?.Enqueued != true)
                 {
-                    _runningJobIds.Remove(jobId);
-                    var client = CurrentApp.GatewayClient;
+                    // Request failed or gateway declined to enqueue the run.
+                    ClearRunningJob(jobId);
+                    ShowRunNotStartedNotification(vm?.Name ?? jobId, result?.Reason ?? result?.Error);
                     if (client != null) _ = client.RequestCronListAsync();
-                });
-            }
+                    return;
+                }
+
+                if (client != null)
+                {
+                    StartRunRefreshLoop(jobId);
+                }
+            });
         });
 
         // Safety timeout: clear running state after 90s if gateway never reports completion
@@ -154,12 +168,92 @@ public sealed partial class CronPage : Page
             {
                 DispatcherQueue?.TryEnqueue(() =>
                 {
-                    _runningJobIds.Remove(jobId);
+                    ClearRunningJob(jobId);
                     var client = CurrentApp.GatewayClient;
-                    if (client != null) _ = client.RequestCronListAsync();
+                    if (client != null)
+                    {
+                        _ = client.RequestCronListAsync();
+                        if (_historyJobId == jobId)
+                            _ = client.RequestCronRunsAsync(jobId, limit: 20, offset: 0);
+                    }
                 });
             }
         });
+    }
+
+    private void StartRunRefreshLoop(string jobId)
+    {
+        CancelRunRefreshLoop(jobId);
+        var cts = new CancellationTokenSource();
+        _runRefreshCts[jobId] = cts;
+        var token = cts.Token;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                for (var attempt = 0; attempt < 30; attempt++)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(3), token);
+                    DispatcherQueue?.TryEnqueue(() =>
+                    {
+                        if (token.IsCancellationRequested)
+                            return;
+                        if (!_runningJobIds.Contains(jobId))
+                        {
+                            CancelRunRefreshLoop(jobId);
+                            return;
+                        }
+
+                        var client = CurrentApp.GatewayClient;
+                        if (client == null) return;
+
+                        _ = client.RequestCronRunsAsync(jobId, limit: 20, offset: 0);
+                    });
+                }
+            }
+            catch (TaskCanceledException)
+            {
+                // Expected when the run completes, times out, or the page unloads.
+            }
+            finally
+            {
+                var dispatcher = DispatcherQueue;
+                if (dispatcher != null)
+                {
+                    dispatcher.TryEnqueue(() =>
+                    {
+                        if (_runRefreshCts.TryGetValue(jobId, out var current) && ReferenceEquals(current, cts))
+                            _runRefreshCts.Remove(jobId);
+                        cts.Dispose();
+                    });
+                }
+                else
+                {
+                    cts.Dispose();
+                }
+            }
+        });
+    }
+
+    private void ClearRunningJob(string jobId)
+    {
+        _runningJobIds.Remove(jobId);
+        CancelRunRefreshLoop(jobId);
+        RefreshJobActionButtons(jobId);
+    }
+
+    private void CancelRunRefreshLoop(string jobId)
+    {
+        if (_runRefreshCts.Remove(jobId, out var cts))
+            cts.Cancel();
+    }
+
+    private void CancelAllRunRefreshLoops()
+    {
+        foreach (var cts in _runRefreshCts.Values)
+            cts.Cancel();
+        _runRefreshCts.Clear();
     }
 
     private void OnRemoveClick(object sender, RoutedEventArgs e)
@@ -167,6 +261,7 @@ public sealed partial class CronPage : Page
         var jobId = (sender as Button)?.Tag as string;
         if (string.IsNullOrEmpty(jobId)) return;
         if (!_cronLoading.CanEdit) return;
+        if (_runningJobIds.Contains(jobId)) return;
         if (CurrentApp.GatewayClient == null) { ShowDisconnected(); return; }
         _removedJobIds.Add(jobId);
         // Gateway client's HandleKnownResponse refreshes the list automatically on cron.remove
@@ -183,6 +278,7 @@ public sealed partial class CronPage : Page
 
         var vm = _jobs.Find(j => j.Id == jobId);
         if (vm == null) return;
+        if (_runningJobIds.Contains(jobId)) return;
         if (ts.IsOn == vm.IsEnabled) return; // no-op (e.g., programmatic init)
         _ = CurrentApp.GatewayClient.UpdateCronJobAsync(jobId, new { enabled = ts.IsOn });
     }
@@ -209,7 +305,7 @@ public sealed partial class CronPage : Page
         if (!_cronLoading.CanEdit) return;
         if (CurrentApp.GatewayClient == null) { ShowDisconnected(); return; }
         var vm = _jobs.Find(j => j.Id == jobId);
-        if (vm == null || !vm.IsEnabled) return;
+        if (vm == null || _runningJobIds.Contains(jobId)) return;
 
         _editingJobId = jobId;
         FormTitle.Text = LocalizationHelper.GetString("CronPage_EditJob");
@@ -519,6 +615,27 @@ public sealed partial class CronPage : Page
 
         JobCompletedInfoBar.Title = LocalizationHelper.GetString("CronPage_JobCompleted");
         JobCompletedInfoBar.Message = LocalizationHelper.Format("CronPage_JobCompletedRanSuccessfully", jobName);
+        JobCompletedInfoBar.Severity = InfoBarSeverity.Success;
+        JobCompletedInfoBar.IsOpen = true;
+        DispatcherQueue?.TryEnqueue(async () =>
+        {
+            try { await Task.Delay(10000, cts.Token); } catch (TaskCanceledException) { return; }
+            JobCompletedInfoBar.IsOpen = false;
+        });
+    }
+
+    private void ShowRunNotStartedNotification(string jobName, string? reason)
+    {
+        _infoDismissCts?.Cancel();
+        _infoDismissCts?.Dispose();
+        _infoDismissCts = new CancellationTokenSource();
+        var cts = _infoDismissCts;
+
+        JobCompletedInfoBar.Title = LocalizationHelper.GetString("CronPage_RunNotStarted");
+        JobCompletedInfoBar.Message = string.IsNullOrWhiteSpace(reason)
+            ? LocalizationHelper.Format("CronPage_RunNotStartedGeneric", jobName)
+            : LocalizationHelper.Format("CronPage_RunNotStartedWithReason", jobName, reason);
+        JobCompletedInfoBar.Severity = InfoBarSeverity.Warning;
         JobCompletedInfoBar.IsOpen = true;
         DispatcherQueue?.TryEnqueue(async () =>
         {
@@ -773,19 +890,31 @@ public sealed partial class CronPage : Page
 
         DispatcherQueue?.TryEnqueue(() =>
         {
-            // Clear running state for jobs whose lastRunAtMs changed or runningAtMs is 0
+            var oldJobs = _jobs;
+            var hadRunningJobs = _runningJobIds.Count > 0;
+            var newIds = new HashSet<string>(jobs.Select(j => j.Id));
+            foreach (var runningJobId in _runningJobIds.ToArray())
+            {
+                if (!newIds.Contains(runningJobId))
+                    ClearRunningJob(runningJobId);
+            }
+
+            // Clear optimistic running state only after the gateway reports a completed run.
             foreach (var vm in jobs)
             {
                 if (_runningJobIds.Contains(vm.Id))
                 {
-                    var oldVm = _jobs.Find(j => j.Id == vm.Id);
-                    if (vm.RunningAtMs == 0 || oldVm == null || vm.LastRunAtMs != oldVm.LastRunAtMs)
-                        _runningJobIds.Remove(vm.Id);
+                    var oldVm = oldJobs.Find(j => j.Id == vm.Id);
+                    if (oldVm != null && vm.LastRunAtMs > 0 && vm.LastRunAtMs != oldVm.LastRunAtMs)
+                    {
+                        ClearRunningJob(vm.Id);
+                        if (_historyJobId == vm.Id && CurrentApp.GatewayClient != null)
+                            _ = CurrentApp.GatewayClient.RequestCronRunsAsync(vm.Id, limit: 20, offset: 0);
+                    }
                 }
             }
 
             // Detect one-shot jobs that disappeared (ran and deleted themselves)
-            var newIds = new HashSet<string>(jobs.Select(j => j.Id));
             foreach (var oldVm in _jobs)
             {
                 if (!newIds.Contains(oldVm.Id) && oldVm.DeleteAfterRun && !_removedJobIds.Contains(oldVm.Id))
@@ -795,6 +924,14 @@ public sealed partial class CronPage : Page
                 if (!newIds.Contains(oldVm.Id))
                     _removedJobIds.Remove(oldVm.Id);
             }
+
+            var oldIds = new HashSet<string>(oldJobs.Select(j => j.Id));
+            var sameJobSet = oldIds.SetEquals(newIds);
+            var shouldPreserveVisualTreeForRunningRefresh =
+                hadRunningJobs &&
+                _runningJobIds.Count > 0 &&
+                sameJobSet &&
+                _editingJobId == null;
 
             _jobs = jobs;
             _cronLoading.Complete(jobs.Count);
@@ -809,8 +946,20 @@ public sealed partial class CronPage : Page
             if (jobs.Count > 0)
             {
                 // Don't rebuild cards if we're currently editing inline (would lose the form)
-                if (_editingJobId == null)
-                    RebuildJobCards();
+                if (_editingJobId == null && !shouldPreserveVisualTreeForRunningRefresh)
+                {
+                    RebuildJobCards(preserveHistory: _historyJobId != null);
+                    if (_historyJobId != null && CurrentApp.GatewayClient != null)
+                    {
+                        ShowHistoryLoading(_historyJobId);
+                        _ = CurrentApp.GatewayClient.RequestCronRunsAsync(_historyJobId, limit: 20, offset: 0);
+                    }
+                }
+                else if (shouldPreserveVisualTreeForRunningRefresh)
+                {
+                    foreach (var runningJobId in _runningJobIds)
+                        RefreshJobActionButtons(runningJobId);
+                }
             }
             else
             {
@@ -1010,7 +1159,7 @@ public sealed partial class CronPage : Page
             var parent = fe;
             while (parent != null)
             {
-                if (parent is Button) return;
+                if (parent is Button or ToggleSwitch or Expander) return;
                 parent = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(parent) as FrameworkElement;
             }
         }
@@ -1105,9 +1254,24 @@ public sealed partial class CronPage : Page
 
     // --- Card building ---
 
-    private void RebuildJobCards()
+    private void RebuildJobCards(bool preserveHistory = false)
     {
-        _historyJobId = null; // history panel is destroyed on rebuild
+        var historyToRestore = preserveHistory ? _historyJobId : null;
+        if (historyToRestore != null)
+        {
+            var historyVm = _jobs.Find(j => j.Id == historyToRestore);
+            if (historyVm != null)
+            {
+                historyVm.IsExpanded = true;
+                _expandedJobIds.Add(historyToRestore);
+            }
+            else
+            {
+                historyToRestore = null;
+            }
+        }
+
+        _historyJobId = historyToRestore;
         JobsListPanel.Children.Clear();
         foreach (var vm in _jobs)
             JobsListPanel.Children.Add(BuildJobCard(vm));
@@ -1123,8 +1287,7 @@ public sealed partial class CronPage : Page
             CornerRadius = new CornerRadius(6),
             Background = (Brush)Application.Current.Resources["CardBackgroundFillColorDefaultBrush"],
             BorderBrush = (Brush)Application.Current.Resources["CardStrokeColorDefaultBrush"],
-            BorderThickness = new Thickness(1),
-            Opacity = vm.CardOpacity
+            BorderThickness = new Thickness(1)
         };
 
         var grid = new Grid();
@@ -1169,19 +1332,25 @@ public sealed partial class CronPage : Page
             headerGrid.Children.Add(resultBadge);
         }
 
-        // Show "Running" badge when job is in-progress
-        if (_runningJobIds.Contains(vm.Id))
+        var runningBadge = new Border
         {
-            var runningBadge = new Border
+            Tag = $"running_{vm.Id}",
+            Visibility = _runningJobIds.Contains(vm.Id) ? Visibility.Visible : Visibility.Collapsed,
+            CornerRadius = new CornerRadius(4),
+            Padding = new Thickness(6, 2, 6, 2),
+            Margin = new Thickness(4, 0, 0, 0),
+            VerticalAlignment = VerticalAlignment.Center,
+            Background = (Brush)Application.Current.Resources["SubtleFillColorSecondaryBrush"],
+            Child = new TextBlock
             {
-                CornerRadius = new CornerRadius(4), Padding = new Thickness(6, 2, 6, 2), Margin = new Thickness(4, 0, 0, 0),
-                VerticalAlignment = VerticalAlignment.Center,
-                Background = (Brush)Application.Current.Resources["SubtleFillColorSecondaryBrush"]
-            };
-            runningBadge.Child = new TextBlock { Text = "Running", FontSize = 10, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold, Foreground = (Brush)Application.Current.Resources["SystemFillColorAttentionBrush"] };
-            Grid.SetColumn(runningBadge, 3);
-            headerGrid.Children.Add(runningBadge);
-        }
+                Text = LocalizationHelper.GetString("CronPage_RunningBadge"),
+                FontSize = 10,
+                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+                Foreground = (Brush)Application.Current.Resources["SystemFillColorAttentionBrush"]
+            }
+        };
+        Grid.SetColumn(runningBadge, 3);
+        headerGrid.Children.Add(runningBadge);
 
         // Inline enabled/disabled toggle (right-aligned, before chevron).
         // Stop tapped from bubbling so the card doesn't toggle expand state.
@@ -1194,9 +1363,11 @@ public sealed partial class CronPage : Page
             MinWidth = 0,
             VerticalAlignment = VerticalAlignment.Center,
             Margin = new Thickness(8, 0, 8, 0),
-            IsEnabled = _cronLoading.CanEdit
+            IsEnabled = _cronLoading.CanEdit && !vm.IsCompletedOneShot && !_runningJobIds.Contains(vm.Id)
         };
-        ToolTipService.SetToolTip(enabledToggle, vm.IsEnabled ? "Disable job" : "Enable job");
+        ToolTipService.SetToolTip(enabledToggle, vm.IsCompletedOneShot
+            ? LocalizationHelper.GetString("CronPage_CompletedOneTimeJobTooltip")
+            : vm.IsEnabled ? LocalizationHelper.GetString("CronPage_DisableJobTooltip") : LocalizationHelper.GetString("CronPage_EnableJobTooltip"));
         enabledToggle.Toggled += OnEnabledToggleChanged;
         enabledToggle.Tapped += (s, ev) => { ev.Handled = true; };
         Grid.SetColumn(enabledToggle, 5);
@@ -1267,30 +1438,32 @@ public sealed partial class CronPage : Page
 
         // Action buttons
         var buttonsPanel = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 4 };
-        var jobDisabled = !vm.IsEnabled;
+        var isRunning = _runningJobIds.Contains(vm.Id);
+        var canRunOrEditJob = _cronLoading.CanEdit && !isRunning;
 
         // "Run Now" button — show running state if job is in the running set
-        var runNowBtn = MakeActionButton("\uE768", "Run Now", vm.Id, OnRunNowClick);
-        if (_runningJobIds.Contains(vm.Id))
+        var runNowBtn = MakeActionButton("\uE768", LocalizationHelper.GetString("CronPage_RunNow"), vm.Id, OnRunNowClick, "RunNow");
+        if (isRunning)
         {
-            runNowBtn.Content = "Running...";
+            runNowBtn.Content = LocalizationHelper.GetString("CronPage_Running");
             runNowBtn.IsEnabled = false;
         }
-        else if (jobDisabled)
+        else if (!canRunOrEditJob)
         {
-            runNowBtn.Opacity = 0.4;
+            runNowBtn.IsEnabled = false;
         }
         buttonsPanel.Children.Add(runNowBtn);
 
-        var editBtn = MakeActionButton("\uE70F", "Edit", vm.Id, OnEditJobClick);
-        if (jobDisabled) editBtn.Opacity = 0.4;
+        var editBtn = MakeActionButton("\uE70F", LocalizationHelper.GetString("CronPage_EditAction"), vm.Id, OnEditJobClick, "Edit");
+        editBtn.IsEnabled = canRunOrEditJob;
         buttonsPanel.Children.Add(editBtn);
 
-        var histBtn = MakeActionButton("\uE81C", "History", vm.Id, OnHistoryClick);
-        if (jobDisabled) histBtn.Opacity = 0.4;
+        var histBtn = MakeActionButton("\uE81C", LocalizationHelper.GetString("CronPage_HistoryAction"), vm.Id, OnHistoryClick, "History");
+        histBtn.IsEnabled = _cronLoading.CanEdit && vm.HasRunHistory;
         buttonsPanel.Children.Add(histBtn);
 
-        var removeBtn = MakeActionButton("\uE711", "Remove", vm.Id, OnRemoveClick);
+        var removeBtn = MakeActionButton("\uE711", LocalizationHelper.GetString("CronPage_RemoveAction"), vm.Id, OnRemoveClick, "Remove");
+        removeBtn.IsEnabled = _cronLoading.CanEdit && !isRunning;
         buttonsPanel.Children.Add(removeBtn);
 
         panel.Children.Add(buttonsPanel);
@@ -1326,15 +1499,174 @@ public sealed partial class CronPage : Page
         return chip;
     }
 
-    private Button MakeActionButton(string glyph, string text, string jobId, RoutedEventHandler handler)
+    private Button MakeActionButton(string glyph, string text, string jobId, RoutedEventHandler handler, string actionName)
     {
-        var btn = new Button { Tag = jobId, FontSize = 12, Padding = new Thickness(8, 4, 8, 4), IsEnabled = _cronLoading.CanEdit };
+        var btn = new Button
+        {
+            Name = actionName,
+            Tag = jobId,
+            FontSize = 12,
+            Padding = new Thickness(8, 4, 8, 4),
+            IsEnabled = _cronLoading.CanEdit
+        };
+        btn.Content = MakeActionButtonContent(glyph, text);
+        btn.Click += handler;
+        return btn;
+    }
+
+    private static StackPanel MakeActionButtonContent(string glyph, string text)
+    {
         var sp = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 4 };
         sp.Children.Add(new FontIcon { Glyph = glyph, FontSize = 12 });
         sp.Children.Add(new TextBlock { Text = text });
+        return sp;
+    }
+
+    private void RefreshJobActionButtons(string jobId)
+    {
+        var vm = _jobs.Find(j => j.Id == jobId);
+        var isRunning = _runningJobIds.Contains(jobId);
+
+        foreach (var button in FindVisualChildren<Button>(JobsListPanel))
+        {
+            if (button.Tag as string != jobId)
+                continue;
+
+            switch (button.Name)
+            {
+                case "RunNow":
+                    button.Content = isRunning
+                        ? LocalizationHelper.GetString("CronPage_Running")
+                        : MakeActionButtonContent("\uE768", LocalizationHelper.GetString("CronPage_RunNow"));
+                    button.IsEnabled = _cronLoading.CanEdit && !isRunning;
+                    break;
+                case "Edit":
+                    button.IsEnabled = _cronLoading.CanEdit && !isRunning;
+                    break;
+                case "History":
+                    button.IsEnabled = _cronLoading.CanEdit && vm?.HasRunHistory == true;
+                    break;
+                case "Remove":
+                    button.IsEnabled = _cronLoading.CanEdit && !isRunning;
+                    break;
+            }
+        }
+
+        foreach (var toggle in FindVisualChildren<ToggleSwitch>(JobsListPanel))
+        {
+            if (toggle.Tag as string == jobId)
+                toggle.IsEnabled = _cronLoading.CanEdit && vm?.IsCompletedOneShot != true && !isRunning;
+        }
+
+        foreach (var badge in FindVisualChildren<Border>(JobsListPanel))
+        {
+            if (badge.Tag as string == $"running_{jobId}")
+                badge.Visibility = isRunning ? Visibility.Visible : Visibility.Collapsed;
+        }
+    }
+
+    private static IEnumerable<T> FindVisualChildren<T>(DependencyObject parent) where T : DependencyObject
+    {
+        var count = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChildrenCount(parent);
+        for (var i = 0; i < count; i++)
+        {
+            var child = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChild(parent, i);
+            if (child is T typed)
+                yield return typed;
+
+            foreach (var descendant in FindVisualChildren<T>(child))
+                yield return descendant;
+        }
+    }
+
+    private UIElement BuildFullResponseExpander(string runEntryKey, string fullText, bool isError)
+    {
+        var expander = new Expander
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            Margin = new Thickness(0, 6, 0, 0),
+            IsExpanded = _expandedRunFullResponseIds.Contains(runEntryKey),
+            Header = new TextBlock
+            {
+                Text = LocalizationHelper.GetString("CronPage_FullResponse"),
+                FontSize = 11,
+                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+                Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]
+            }
+        };
+        expander.Expanding += (_, _) => _expandedRunFullResponseIds.Add(runEntryKey);
+        expander.Collapsed += (_, _) => _expandedRunFullResponseIds.Remove(runEntryKey);
+
+        UIElement content;
+
+        if (isError)
+        {
+            content = new TextBlock
+            {
+                Text = fullText,
+                FontFamily = new FontFamily("Consolas"),
+                FontSize = 11,
+                TextWrapping = TextWrapping.Wrap,
+                IsTextSelectionEnabled = true,
+                Foreground = new SolidColorBrush(Color.FromArgb(255, 224, 85, 69))
+            };
+        }
+        else
+        {
+            var markdown = ChatMarkdownSanitizer.Sanitize(fullText);
+            var host = new FunctionalHostControl
+            {
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Background = new SolidColorBrush(Colors.Transparent)
+            };
+            host.Mount(_ => ChatMarkdownRenderer.Render(markdown)
+                ?? OpenClawTray.FunctionalUI.Factories.TextBlock(markdown));
+            content = host;
+        }
+
+        expander.Content = new Border
+        {
+            Padding = new Thickness(10, 8, 10, 10),
+            Margin = new Thickness(0, 4, 0, 0),
+            CornerRadius = new CornerRadius(6),
+            Background = (Brush)Application.Current.Resources["CardBackgroundFillColorSecondaryBrush"],
+            BorderBrush = (Brush)Application.Current.Resources["CardStrokeColorDefaultBrush"],
+            BorderThickness = new Thickness(1),
+            Child = content
+        };
+
+        return expander;
+    }
+
+    private static Button MakeRunChatButton(string sessionKey)
+    {
+        var btn = new Button
+        {
+            Tag = sessionKey,
+            FontSize = 11,
+            Padding = new Thickness(8, 3, 8, 3),
+            Margin = new Thickness(0, 4, 0, 0),
+            HorizontalAlignment = HorizontalAlignment.Left
+        };
+        var sp = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 4 };
+        sp.Children.Add(new FontIcon { Glyph = "\uE8F2", FontSize = 11 });
+        sp.Children.Add(new TextBlock { Text = LocalizationHelper.GetString("CronPage_OpenChat") });
         btn.Content = sp;
-        btn.Click += handler;
+        btn.Click += OnOpenRunChatClick;
         return btn;
+    }
+
+    private static void OnOpenRunChatClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button { Tag: string sessionKey } || string.IsNullOrWhiteSpace(sessionKey))
+            return;
+
+        CurrentApp.PendingChatSessionKey = sessionKey;
+        if (CurrentApp.ActiveHubWindow is HubWindow hub)
+            hub.PendingChatSessionKey = sessionKey;
+
+        ((IAppCommands)CurrentApp).Navigate("chat");
     }
 
     // --- Run History ---
@@ -1346,7 +1678,7 @@ public sealed partial class CronPage : Page
         if (!_cronLoading.CanEdit) return;
         if (CurrentApp.GatewayClient == null) { ShowDisconnected(); return; }
         var vm = _jobs.Find(j => j.Id == jobId);
-        if (vm != null && !vm.IsEnabled) return;
+        if (vm != null && !vm.HasRunHistory) return;
         if (_historyJobId == jobId)
         {
             HideHistoryPanel(jobId);
@@ -1360,21 +1692,25 @@ public sealed partial class CronPage : Page
 
         _historyJobId = jobId;
 
-        // Show loading state
-        var histPanel = FindHistoryPanel(jobId);
-        if (histPanel != null)
-        {
-            histPanel.Children.Clear();
-            histPanel.Children.Add(new TextBlock
-            {
-                Text = "Loading run history...",
-                FontSize = 12,
-                Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]
-            });
-            histPanel.Visibility = Visibility.Visible;
-        }
+        ShowHistoryLoading(jobId);
 
         _ = CurrentApp.GatewayClient.RequestCronRunsAsync(jobId, limit: 20, offset: 0);
+    }
+
+    private void ShowHistoryLoading(string jobId)
+    {
+        var histPanel = FindHistoryPanel(jobId);
+        if (histPanel == null) return;
+
+        _lastHistoryRenderSignature = null;
+        histPanel.Children.Clear();
+        histPanel.Children.Add(new TextBlock
+        {
+            Text = LocalizationHelper.GetString("CronPage_LoadingRunHistory"),
+            FontSize = 12,
+            Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]
+        });
+        histPanel.Visibility = Visibility.Visible;
     }
 
     private void HideHistoryPanel(string jobId)
@@ -1382,6 +1718,7 @@ public sealed partial class CronPage : Page
         var panel = FindHistoryPanel(jobId);
         if (panel != null)
         {
+            _lastHistoryRenderSignature = null;
             panel.Children.Clear();
             panel.Visibility = Visibility.Collapsed;
         }
@@ -1416,17 +1753,23 @@ public sealed partial class CronPage : Page
     public void UpdateCronRuns(JsonElement data)
     {
         // data is the full response: { entries: [...], total, offset, limit, hasMore, ... }
-        if (_historyJobId == null) return;
+        if (data.TryGetProperty("entries", out var completionEntries) &&
+            completionEntries.ValueKind == JsonValueKind.Array)
+        {
+            DetectCompletedRunsFromHistory(completionEntries);
+        }
 
-        var histPanel = FindHistoryPanel(_historyJobId);
-        if (histPanel == null) return;
-        histPanel.Children.Clear();
+        if (_historyJobId == null) return;
 
         if (!data.TryGetProperty("entries", out var entries) || entries.ValueKind != JsonValueKind.Array)
         {
-            histPanel.Children.Add(new TextBlock
+            var emptyHistoryPanel = FindHistoryPanel(_historyJobId);
+            if (emptyHistoryPanel == null) return;
+            _lastHistoryRenderSignature = null;
+            emptyHistoryPanel.Children.Clear();
+            emptyHistoryPanel.Children.Add(new TextBlock
             {
-                Text = "No run history available.",
+                Text = LocalizationHelper.GetString("CronPage_NoRunHistoryAvailable"),
                 FontSize = 12,
                 Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]
             });
@@ -1434,6 +1777,16 @@ public sealed partial class CronPage : Page
         }
 
         var total = data.TryGetProperty("total", out var totalEl) && totalEl.ValueKind == JsonValueKind.Number ? totalEl.GetInt32() : 0;
+        var hasMore = data.TryGetProperty("hasMore", out var hmEl) && hmEl.ValueKind == JsonValueKind.True;
+        var signature = BuildHistoryRenderSignature(entries, total, hasMore);
+        if (_runningJobIds.Count > 0 && string.Equals(_lastHistoryRenderSignature, signature, StringComparison.Ordinal))
+            return;
+
+        _lastHistoryRenderSignature = signature;
+        var histPanel = FindHistoryPanel(_historyJobId);
+        if (histPanel == null) return;
+        histPanel.Children.Clear();
+
         var entryCount = 0;
 
         // Header
@@ -1443,7 +1796,7 @@ public sealed partial class CronPage : Page
 
         var headerText = new TextBlock
         {
-            Text = "Run History",
+            Text = LocalizationHelper.GetString("CronPage_RunHistory"),
             FontSize = 12,
             FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
             Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]
@@ -1467,16 +1820,17 @@ public sealed partial class CronPage : Page
         }
 
         // Update header with count
-        headerText.Text = total > 0 ? $"Run History — showing {entryCount} of {total}" : $"Run History — {entryCount} runs";
+        headerText.Text = total > 0
+            ? LocalizationHelper.Format("CronPage_RunHistoryShowing", entryCount, total)
+            : LocalizationHelper.Format("CronPage_RunHistoryCount", entryCount);
 
         // "Load more" if there are more
-        var hasMore = data.TryGetProperty("hasMore", out var hmEl) && hmEl.ValueKind == JsonValueKind.True;
         if (hasMore)
         {
             var nextOffset = data.TryGetProperty("nextOffset", out var noEl) && noEl.ValueKind == JsonValueKind.Number ? noEl.GetInt32() : entryCount;
             var loadMoreBtn = new Button
             {
-                Content = $"Load older runs ({total - entryCount - (nextOffset - entryCount)} more)...",
+                Content = LocalizationHelper.Format("CronPage_LoadOlderRuns", total - entryCount - (nextOffset - entryCount)),
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 Margin = new Thickness(0, 6, 0, 0),
                 Padding = new Thickness(0, 6, 0, 6),
@@ -1487,9 +1841,9 @@ public sealed partial class CronPage : Page
             // Simple "load more" content
             var remaining = total - nextOffset;
             if (remaining > 0)
-                loadMoreBtn.Content = $"Load older runs ({remaining} more)...";
+                loadMoreBtn.Content = LocalizationHelper.Format("CronPage_LoadOlderRuns", remaining);
             else
-                loadMoreBtn.Content = "Load more runs...";
+                loadMoreBtn.Content = LocalizationHelper.GetString("CronPage_LoadMoreRuns");
 
             loadMoreBtn.Click += (s, args) =>
             {
@@ -1497,7 +1851,7 @@ public sealed partial class CronPage : Page
                 if (!string.IsNullOrEmpty(jid) && CurrentApp.GatewayClient != null)
                 {
                     loadMoreBtn.IsEnabled = false;
-                    loadMoreBtn.Content = "Loading...";
+                    loadMoreBtn.Content = LocalizationHelper.GetString("CronPage_Loading");
                     // For simplicity, reload with higher limit
                     _ = CurrentApp.GatewayClient.RequestCronRunsAsync(jid, limit: nextOffset + 20, offset: 0);
                 }
@@ -1508,31 +1862,73 @@ public sealed partial class CronPage : Page
         histPanel.Visibility = Visibility.Visible;
     }
 
-    // Redact tokens, secrets, and file paths from text before UI display
-    private static readonly Regex AbsolutePathPattern = new(
-        @"(?:[A-Za-z]:\\(?:Users|home|usr|var|tmp)\\[^\s""']+)|(?:/(?:home|Users|usr|var|tmp)/[^\s""']+)",
-        RegexOptions.Compiled);
-
-    private static string SanitizeForDisplay(string text)
+    private static string BuildHistoryRenderSignature(JsonElement entries, int total, bool hasMore)
     {
-        if (string.IsNullOrEmpty(text)) return text;
-        var sanitized = TokenSanitizer.Sanitize(text);
-        sanitized = AbsolutePathPattern.Replace(sanitized, m =>
+        var parts = new List<string> { total.ToString(), hasMore ? "more" : "done" };
+        foreach (var entry in entries.EnumerateArray())
         {
-            var sep = m.Value.Contains('\\') ? '\\' : '/';
-            var lastSep = m.Value.LastIndexOf(sep);
-            return lastSep >= 0 ? "…" + sep + m.Value[(lastSep + 1)..] : m.Value;
-        });
-        return sanitized;
+            if (entry.ValueKind != JsonValueKind.Object)
+                continue;
+
+            parts.Add(GetRunEntryKey(entry));
+            if (entry.TryGetProperty("summary", out var summaryEl) && summaryEl.ValueKind == JsonValueKind.String)
+                parts.Add((summaryEl.GetString()?.Length ?? 0).ToString());
+            if (entry.TryGetProperty("status", out var statusEl) && statusEl.ValueKind == JsonValueKind.String)
+                parts.Add(statusEl.GetString() ?? "");
+        }
+        return string.Join("|", parts);
+    }
+
+    private void DetectCompletedRunsFromHistory(JsonElement entries)
+    {
+        var completedJobIds = new HashSet<string>();
+        foreach (var entry in entries.EnumerateArray())
+        {
+            if (entry.ValueKind != JsonValueKind.Object)
+                continue;
+
+            if (!entry.TryGetProperty("jobId", out var jobIdEl) || jobIdEl.ValueKind != JsonValueKind.String)
+                continue;
+
+            var jobId = jobIdEl.GetString();
+            if (string.IsNullOrWhiteSpace(jobId) || !_runningJobIds.Contains(jobId))
+                continue;
+
+            var oldVm = _jobs.Find(j => j.Id == jobId);
+            if (oldVm == null)
+                continue;
+
+            var runAtMs = entry.TryGetProperty("runAtMs", out var runAtEl) && runAtEl.ValueKind == JsonValueKind.Number
+                ? runAtEl.GetInt64()
+                : (entry.TryGetProperty("ts", out var tsEl) && tsEl.ValueKind == JsonValueKind.Number ? tsEl.GetInt64() : 0);
+            if (runAtMs > oldVm.LastRunAtMs)
+                completedJobIds.Add(jobId);
+        }
+
+        if (completedJobIds.Count == 0)
+            return;
+
+        foreach (var jobId in completedJobIds)
+        {
+            ClearRunningJob(jobId);
+        }
+
+        var client = CurrentApp.GatewayClient;
+        if (client != null)
+        {
+            _ = client.RequestCronListAsync();
+            _ = client.RequestCronStatusAsync();
+        }
     }
 
     private Border BuildRunEntry(JsonElement entry)
     {
+        var runEntryKey = GetRunEntryKey(entry);
         var status = entry.TryGetProperty("status", out var sEl) ? sEl.GetString() ?? "" : "";
         var durationMs = entry.TryGetProperty("durationMs", out var dEl) && dEl.ValueKind == JsonValueKind.Number ? dEl.GetInt64() : 0;
-        var summary = SanitizeForDisplay(entry.TryGetProperty("summary", out var sumEl) ? sumEl.GetString() ?? "" : "");
-        var error = SanitizeForDisplay(entry.TryGetProperty("error", out var errEl) ? errEl.GetString() ?? "" : "");
         var model = entry.TryGetProperty("model", out var modEl) ? modEl.GetString() ?? "" : "";
+        var provider = entry.TryGetProperty("provider", out var providerEl) ? providerEl.GetString() ?? "" : "";
+        var sessionKey = entry.TryGetProperty("sessionKey", out var sessionEl) ? sessionEl.GetString() ?? "" : "";
         var tsMs = entry.TryGetProperty("runAtMs", out var tsEl) && tsEl.ValueKind == JsonValueKind.Number
             ? tsEl.GetInt64()
             : (entry.TryGetProperty("ts", out var ts2El) && ts2El.ValueKind == JsonValueKind.Number ? ts2El.GetInt64() : 0);
@@ -1549,6 +1945,7 @@ public sealed partial class CronPage : Page
 
         // Colors
         bool isError = status == "error" || status == "failed";
+        var text = CronRunHistoryDisplay.ExtractText(entry, isError);
         var statusBg = isError
             ? new SolidColorBrush(Color.FromArgb(40, 224, 85, 69))
             : new SolidColorBrush(Color.FromArgb(40, 76, 175, 80));
@@ -1582,10 +1979,12 @@ public sealed partial class CronPage : Page
 
         // Summary/error + metadata
         var contentPanel = new StackPanel { Margin = new Thickness(4, 0, 8, 0) };
-        var displayText = isError && !string.IsNullOrEmpty(error) ? error : summary;
+        var displayText = text.PreviewText;
         if (!string.IsNullOrEmpty(displayText))
         {
-            var truncated = displayText.Length > 120 ? displayText[..120] + "…" : displayText;
+            var truncated = displayText.Length > CronRunHistoryDisplay.PreviewMaxChars
+                ? displayText[..CronRunHistoryDisplay.PreviewMaxChars] + "…"
+                : displayText;
             contentPanel.Children.Add(new TextBlock
             {
                 Text = truncated,
@@ -1601,6 +2000,7 @@ public sealed partial class CronPage : Page
         // Meta line: model · tokens · delivery
         var metaParts = new List<string>();
         if (!string.IsNullOrEmpty(model)) metaParts.Add(model);
+        if (!string.IsNullOrEmpty(provider)) metaParts.Add(provider);
         if (totalTokens > 0) metaParts.Add($"{totalTokens:N0} tokens");
         if (delivered) metaParts.Add("delivered");
         else if (!string.IsNullOrEmpty(deliveryStatus)) metaParts.Add(deliveryStatus);
@@ -1615,6 +2015,10 @@ public sealed partial class CronPage : Page
                 Foreground = (Brush)Application.Current.Resources["TextFillColorTertiaryBrush"]
             });
         }
+        if (text.HasExpandableFullText)
+            contentPanel.Children.Add(BuildFullResponseExpander(runEntryKey, text.FullText!, isError));
+        if (!string.IsNullOrWhiteSpace(sessionKey))
+            contentPanel.Children.Add(MakeRunChatButton(sessionKey));
         Grid.SetColumn(contentPanel, 1);
         grid.Children.Add(contentPanel);
 
@@ -1658,6 +2062,24 @@ public sealed partial class CronPage : Page
 
         row.Child = grid;
         return row;
+    }
+
+    private static string GetRunEntryKey(JsonElement entry)
+    {
+        var runId = entry.TryGetProperty("runId", out var runIdEl) && runIdEl.ValueKind == JsonValueKind.String
+            ? runIdEl.GetString()
+            : null;
+        if (!string.IsNullOrWhiteSpace(runId))
+            return runId!;
+
+        var jobId = entry.TryGetProperty("jobId", out var jobIdEl) && jobIdEl.ValueKind == JsonValueKind.String
+            ? jobIdEl.GetString()
+            : "";
+        var runAtMs = entry.TryGetProperty("runAtMs", out var runAtEl) && runAtEl.ValueKind == JsonValueKind.Number
+            ? runAtEl.GetInt64()
+            : (entry.TryGetProperty("ts", out var tsEl) && tsEl.ValueKind == JsonValueKind.Number ? tsEl.GetInt64() : 0);
+
+        return $"{jobId}:{runAtMs}";
     }
 
     private static T? FindChild<T>(DependencyObject parent) where T : DependencyObject
@@ -1718,7 +2140,11 @@ public sealed partial class CronPage : Page
         public string Schedule { get; set; } = "";
         public bool IsEnabled { get; set; } = true;
         public bool IsExpanded { get; set; } = false;
-        public double CardOpacity => IsEnabled ? 1.0 : 0.5;
+        public bool IsCompletedOneShot =>
+            string.Equals(ScheduleKind, "at", StringComparison.OrdinalIgnoreCase) &&
+            LastRunAtMs > 0 &&
+            NextRunAtMs <= 0;
+        public bool HasRunHistory => LastRunAtMs > 0;
         public string LastRunTime { get; set; } = "—";
         public string LastResult { get; set; } = "";
         public SolidColorBrush ResultBadgeForeground { get; set; } = new(Colors.White);

--- a/src/OpenClaw.Tray.WinUI/Services/CronRunHistoryDisplay.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/CronRunHistoryDisplay.cs
@@ -1,0 +1,343 @@
+using OpenClaw.Shared;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace OpenClawTray.Services;
+
+internal readonly record struct CronRunDisplayText(string PreviewText, string? FullText)
+{
+    public bool HasExpandableFullText =>
+        !string.IsNullOrWhiteSpace(FullText) &&
+        (FullText!.Length > CronRunHistoryDisplay.PreviewMaxChars ||
+         FullText.Contains('\n') ||
+         FullText.Contains('\r') ||
+         !string.Equals(PreviewText, FullText, StringComparison.Ordinal));
+}
+
+internal static class CronRunHistoryDisplay
+{
+    public const int PreviewMaxChars = 120;
+
+    private static readonly string[] FullResponseKeys =
+    [
+        "fullResponse",
+        "full_response",
+        "assistantResponse",
+        "assistant_response",
+        "response",
+        "answer",
+        "output",
+        "result",
+        "content",
+        "text"
+    ];
+
+    private static readonly string[] TranscriptKeys =
+    [
+        "transcript",
+        "transcriptJsonl",
+        "transcript_jsonl",
+        "events",
+        "messages"
+    ];
+
+    private static readonly string[] TextKeys = ["text", "content", "message"];
+
+    private static readonly Regex AbsolutePathPattern = new(
+        @"(?:[A-Za-z]:\\(?:Users|home|usr|var|tmp)\\[^\s""']+)|(?:/(?:home|Users|usr|var|tmp)/[^\s""']+)",
+        RegexOptions.Compiled);
+
+    public static CronRunDisplayText ExtractText(JsonElement entry, bool isError)
+    {
+        var summary = SanitizeForDisplay(GetStringProperty(entry, "summary")) ?? string.Empty;
+        var error = SanitizeForDisplay(GetStringProperty(entry, "error")) ?? string.Empty;
+        var preview = isError && !string.IsNullOrWhiteSpace(error) ? error : summary;
+
+        var fullText = isError && !string.IsNullOrWhiteSpace(error)
+            ? error
+            : FindFullResponseText(entry) ?? FindTranscriptResponseText(entry) ?? summary;
+        fullText = SanitizeForDisplay(fullText);
+
+        if (string.IsNullOrWhiteSpace(preview) && !string.IsNullOrWhiteSpace(fullText))
+            preview = fullText!;
+
+        return new CronRunDisplayText(preview, string.IsNullOrWhiteSpace(fullText) ? null : fullText);
+    }
+
+    public static string? SanitizeForDisplay(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return text;
+        var sanitized = TokenSanitizer.Sanitize(text);
+        sanitized = AbsolutePathPattern.Replace(sanitized, m =>
+        {
+            var sep = m.Value.Contains('\\') ? '\\' : '/';
+            var lastSep = m.Value.LastIndexOf(sep);
+            return lastSep >= 0 ? "…" + sep + m.Value[(lastSep + 1)..] : m.Value;
+        });
+        return sanitized;
+    }
+
+    private static string? FindFullResponseText(JsonElement entry)
+    {
+        var direct = FindStringByKeys(entry, FullResponseKeys);
+        if (!string.IsNullOrWhiteSpace(direct))
+            return NormalizePotentialTranscript(direct);
+
+        if (entry.TryGetProperty("result", out var result) && result.ValueKind == JsonValueKind.Object)
+        {
+            var nested = FindStringByKeys(result, FullResponseKeys);
+            if (!string.IsNullOrWhiteSpace(nested))
+                return NormalizePotentialTranscript(nested);
+        }
+
+        if (entry.TryGetProperty("response", out var response) && response.ValueKind == JsonValueKind.Object)
+        {
+            var nested = FindStringByKeys(response, FullResponseKeys);
+            if (!string.IsNullOrWhiteSpace(nested))
+                return NormalizePotentialTranscript(nested);
+        }
+
+        return null;
+    }
+
+    private static string? FindTranscriptResponseText(JsonElement entry)
+    {
+        foreach (var key in TranscriptKeys)
+        {
+            if (!entry.TryGetProperty(key, out var value))
+                continue;
+
+            var extracted = value.ValueKind == JsonValueKind.String
+                ? TryExtractAssistantTextFromTranscript(value.GetString())
+                : TryExtractAssistantTextFromTranscript(value);
+            if (!string.IsNullOrWhiteSpace(extracted))
+                return extracted;
+        }
+
+        return null;
+    }
+
+    private static string? NormalizePotentialTranscript(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return text;
+        return TryExtractAssistantTextFromTranscript(text) ?? text;
+    }
+
+    private static string? TryExtractAssistantTextFromTranscript(string? transcript)
+    {
+        if (string.IsNullOrWhiteSpace(transcript)) return null;
+        var trimmed = transcript.Trim();
+
+        if (trimmed.StartsWith('{') || trimmed.StartsWith('['))
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(trimmed);
+                var extracted = TryExtractAssistantTextFromTranscript(doc.RootElement);
+                if (!string.IsNullOrWhiteSpace(extracted))
+                    return extracted;
+            }
+            catch (JsonException)
+            {
+                // Not a single JSON document; fall through to JSONL parsing.
+            }
+        }
+
+        if (!trimmed.Contains('\n')) return null;
+
+        var finalCandidates = new List<string>();
+        var deltas = new StringBuilder();
+        foreach (var line in trimmed.Split('\n'))
+        {
+            var lineTrimmed = line.Trim();
+            if (lineTrimmed.Length == 0 || lineTrimmed[0] != '{') continue;
+
+            try
+            {
+                using var doc = JsonDocument.Parse(lineTrimmed);
+                CollectAssistantText(doc.RootElement, finalCandidates, deltas);
+            }
+            catch (JsonException)
+            {
+                // Ignore non-JSONL lines in mixed diagnostic transcripts.
+            }
+        }
+
+        return BuildAssistantText(finalCandidates, deltas);
+    }
+
+    private static string? TryExtractAssistantTextFromTranscript(JsonElement transcript)
+    {
+        var finalCandidates = new List<string>();
+        var deltas = new StringBuilder();
+        CollectAssistantText(transcript, finalCandidates, deltas);
+        return BuildAssistantText(finalCandidates, deltas);
+    }
+
+    private static string? BuildAssistantText(List<string> finalCandidates, StringBuilder deltas)
+    {
+        if (finalCandidates.Count > 0)
+        {
+            var candidates = finalCandidates
+                .Select(c => c.Trim())
+                .Where(c => c.Length > 0)
+                .ToArray();
+            var retained = new List<string>();
+
+            for (var i = 0; i < candidates.Length; i++)
+            {
+                var candidate = candidates[i];
+                var appearsInLaterCandidate = candidates
+                    .Skip(i + 1)
+                    .Any(later => later.Contains(candidate, StringComparison.Ordinal));
+                if (!appearsInLaterCandidate && !retained.Contains(candidate, StringComparer.Ordinal))
+                    retained.Add(candidate);
+            }
+
+            if (retained.Count > 0)
+                return string.Join("\n\n", retained);
+        }
+
+        return deltas.Length > 0 ? deltas.ToString().Trim() : null;
+    }
+
+    private static void CollectAssistantText(
+        JsonElement element,
+        List<string> finalCandidates,
+        StringBuilder deltas)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Array:
+                foreach (var item in element.EnumerateArray())
+                    CollectAssistantText(item, finalCandidates, deltas);
+                return;
+            case JsonValueKind.Object:
+                break;
+            default:
+                return;
+        }
+
+        var stream = GetStringProperty(element, "stream");
+        var role = GetStringProperty(element, "role");
+        var type = GetStringProperty(element, "type");
+        var kind = GetStringProperty(element, "kind");
+        var assistantLike =
+            string.Equals(stream, "assistant", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(role, "assistant", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(kind, "assistant", StringComparison.OrdinalIgnoreCase) ||
+            (type?.Contains("assistant", StringComparison.OrdinalIgnoreCase) == true);
+
+        if (assistantLike)
+        {
+            AddAssistantTextFromObject(element, finalCandidates, deltas);
+            if (element.TryGetProperty("data", out var data) && data.ValueKind == JsonValueKind.Object)
+                AddAssistantTextFromObject(data, finalCandidates, deltas);
+        }
+
+        foreach (var key in new[] { "data", "event", "payload", "record" })
+        {
+            if (element.TryGetProperty(key, out var nested) && nested.ValueKind == JsonValueKind.Object)
+                CollectAssistantText(nested, finalCandidates, deltas);
+        }
+
+        foreach (var key in new[] { "events", "messages", "entries", "items" })
+        {
+            if (element.TryGetProperty(key, out var nested) && nested.ValueKind == JsonValueKind.Array)
+                CollectAssistantText(nested, finalCandidates, deltas);
+        }
+
+        if (element.TryGetProperty("message", out var message) && message.ValueKind == JsonValueKind.Object)
+            CollectAssistantText(message, finalCandidates, deltas);
+    }
+
+    private static void AddAssistantTextFromObject(
+        JsonElement obj,
+        List<string> finalCandidates,
+        StringBuilder deltas)
+    {
+        if (obj.TryGetProperty("delta", out var delta) && delta.ValueKind == JsonValueKind.String)
+        {
+            var deltaText = delta.GetString();
+            if (!string.IsNullOrEmpty(deltaText))
+                deltas.Append(deltaText);
+        }
+
+        foreach (var key in TextKeys)
+        {
+            if (!obj.TryGetProperty(key, out var value))
+                continue;
+
+            if (value.ValueKind == JsonValueKind.String)
+            {
+                var text = value.GetString();
+                if (!string.IsNullOrWhiteSpace(text))
+                    finalCandidates.Add(text);
+            }
+            else if (value.ValueKind == JsonValueKind.Array)
+            {
+                ExtractTextContentArray(value, finalCandidates);
+            }
+        }
+    }
+
+    private static void ExtractTextContentArray(JsonElement array, List<string> finalCandidates)
+    {
+        var parts = new List<string>();
+        foreach (var item in array.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String)
+            {
+                var value = item.GetString();
+                if (!string.IsNullOrEmpty(value)) parts.Add(value);
+                continue;
+            }
+
+            if (item.ValueKind == JsonValueKind.Object)
+            {
+                var text = GetStringProperty(item, "text");
+                if (!string.IsNullOrEmpty(text))
+                    parts.Add(text);
+            }
+        }
+
+        if (parts.Count > 0)
+            finalCandidates.Add(string.Concat(parts));
+    }
+
+    private static string? FindStringByKeys(JsonElement element, IReadOnlyList<string> keys)
+    {
+        foreach (var key in keys)
+        {
+            if (!element.TryGetProperty(key, out var value))
+                continue;
+
+            if (value.ValueKind == JsonValueKind.String)
+            {
+                var text = value.GetString();
+                if (!string.IsNullOrWhiteSpace(text))
+                    return text;
+            }
+
+            if (value.ValueKind == JsonValueKind.Object)
+            {
+                var nested = FindStringByKeys(value, TextKeys);
+                if (!string.IsNullOrWhiteSpace(nested))
+                    return nested;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? GetStringProperty(JsonElement element, string key) =>
+        element.ValueKind == JsonValueKind.Object &&
+        element.TryGetProperty(key, out var value) &&
+        value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+}

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -4847,6 +4847,60 @@ On your gateway host (Mac/Linux), run:
   <data name="CronPage_Running" xml:space="preserve">
     <value>Running...</value>
   </data>
+  <data name="CronPage_CompletedOneTimeJobTooltip" xml:space="preserve">
+    <value>Completed one-time job</value>
+  </data>
+  <data name="CronPage_EnableJobTooltip" xml:space="preserve">
+    <value>Enable job</value>
+  </data>
+  <data name="CronPage_DisableJobTooltip" xml:space="preserve">
+    <value>Disable job</value>
+  </data>
+  <data name="CronPage_FullResponse" xml:space="preserve">
+    <value>Full response</value>
+  </data>
+  <data name="CronPage_OpenChat" xml:space="preserve">
+    <value>Open chat</value>
+  </data>
+  <data name="CronPage_RunNow" xml:space="preserve">
+    <value>Run Now</value>
+  </data>
+  <data name="CronPage_EditAction" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="CronPage_HistoryAction" xml:space="preserve">
+    <value>History</value>
+  </data>
+  <data name="CronPage_RemoveAction" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="CronPage_RunningBadge" xml:space="preserve">
+    <value>Running</value>
+  </data>
+  <data name="CronPage_RunHistory" xml:space="preserve">
+    <value>Run History</value>
+  </data>
+  <data name="CronPage_RunHistoryShowing" xml:space="preserve">
+    <value>Run History - showing {0} of {1}</value>
+  </data>
+  <data name="CronPage_RunHistoryCount" xml:space="preserve">
+    <value>Run History - {0} runs</value>
+  </data>
+  <data name="CronPage_LoadingRunHistory" xml:space="preserve">
+    <value>Loading run history...</value>
+  </data>
+  <data name="CronPage_NoRunHistoryAvailable" xml:space="preserve">
+    <value>No run history available.</value>
+  </data>
+  <data name="CronPage_LoadOlderRuns" xml:space="preserve">
+    <value>Load older runs ({0} more)...</value>
+  </data>
+  <data name="CronPage_LoadMoreRuns" xml:space="preserve">
+    <value>Load more runs...</value>
+  </data>
+  <data name="CronPage_Loading" xml:space="preserve">
+    <value>Loading...</value>
+  </data>
   <data name="CronPage_SaveChanges" xml:space="preserve">
     <value>Save Changes</value>
   </data>
@@ -5907,6 +5961,15 @@ Check your connection settings and try again.</value>
   </data>
   <data name="CronPage_JobCompletedRanSuccessfully" xml:space="preserve">
     <value>&quot;{0}&quot; ran successfully and was removed.</value>
+  </data>
+  <data name="CronPage_RunNotStarted" xml:space="preserve">
+    <value>Run not started</value>
+  </data>
+  <data name="CronPage_RunNotStartedGeneric" xml:space="preserve">
+    <value>{0} was not started.</value>
+  </data>
+  <data name="CronPage_RunNotStartedWithReason" xml:space="preserve">
+    <value>{0} was not started: {1}</value>
   </data>
   <data name="GatewayHostAccess_NoTerminalAccess" xml:space="preserve">
     <value>This gateway does not have WSL or SSH terminal access.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -4799,6 +4799,60 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="CronPage_Running" xml:space="preserve">
     <value>Exécution...</value>
   </data>
+  <data name="CronPage_CompletedOneTimeJobTooltip" xml:space="preserve">
+    <value>Tâche ponctuelle terminée</value>
+  </data>
+  <data name="CronPage_EnableJobTooltip" xml:space="preserve">
+    <value>Activer la tâche</value>
+  </data>
+  <data name="CronPage_DisableJobTooltip" xml:space="preserve">
+    <value>Désactiver la tâche</value>
+  </data>
+  <data name="CronPage_FullResponse" xml:space="preserve">
+    <value>Réponse complète</value>
+  </data>
+  <data name="CronPage_OpenChat" xml:space="preserve">
+    <value>Ouvrir le chat</value>
+  </data>
+  <data name="CronPage_RunNow" xml:space="preserve">
+    <value>Exécuter maintenant</value>
+  </data>
+  <data name="CronPage_EditAction" xml:space="preserve">
+    <value>Modifier</value>
+  </data>
+  <data name="CronPage_HistoryAction" xml:space="preserve">
+    <value>Historique</value>
+  </data>
+  <data name="CronPage_RemoveAction" xml:space="preserve">
+    <value>Supprimer</value>
+  </data>
+  <data name="CronPage_RunningBadge" xml:space="preserve">
+    <value>Exécution</value>
+  </data>
+  <data name="CronPage_RunHistory" xml:space="preserve">
+    <value>Historique des exécutions</value>
+  </data>
+  <data name="CronPage_RunHistoryShowing" xml:space="preserve">
+    <value>Historique des exécutions - {0} sur {1} affichées</value>
+  </data>
+  <data name="CronPage_RunHistoryCount" xml:space="preserve">
+    <value>Historique des exécutions - {0} exécutions</value>
+  </data>
+  <data name="CronPage_LoadingRunHistory" xml:space="preserve">
+    <value>Chargement de l’historique des exécutions...</value>
+  </data>
+  <data name="CronPage_NoRunHistoryAvailable" xml:space="preserve">
+    <value>Aucun historique d’exécution disponible.</value>
+  </data>
+  <data name="CronPage_LoadOlderRuns" xml:space="preserve">
+    <value>Charger les exécutions plus anciennes ({0} restantes)...</value>
+  </data>
+  <data name="CronPage_LoadMoreRuns" xml:space="preserve">
+    <value>Charger plus d’exécutions...</value>
+  </data>
+  <data name="CronPage_Loading" xml:space="preserve">
+    <value>Chargement...</value>
+  </data>
   <data name="CronPage_SaveChanges" xml:space="preserve">
     <value>Enregistrer les modifications</value>
   </data>
@@ -5859,6 +5913,15 @@ Vérifiez vos paramètres de connexion et réessayez.</value>
   </data>
   <data name="CronPage_JobCompletedRanSuccessfully" xml:space="preserve">
     <value>&quot;{0}&quot; ran successfully and was removed.</value>
+  </data>
+  <data name="CronPage_RunNotStarted" xml:space="preserve">
+    <value>Exécution non démarrée</value>
+  </data>
+  <data name="CronPage_RunNotStartedGeneric" xml:space="preserve">
+    <value>{0} n’a pas été démarrée.</value>
+  </data>
+  <data name="CronPage_RunNotStartedWithReason" xml:space="preserve">
+    <value>{0} n’a pas été démarrée : {1}</value>
   </data>
   <data name="GatewayHostAccess_NoTerminalAccess" xml:space="preserve">
     <value>This gateway does not have WSL or SSH terminal access.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -4800,6 +4800,60 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="CronPage_Running" xml:space="preserve">
     <value>Uitvoeren...</value>
   </data>
+  <data name="CronPage_CompletedOneTimeJobTooltip" xml:space="preserve">
+    <value>Eenmalige taak voltooid</value>
+  </data>
+  <data name="CronPage_EnableJobTooltip" xml:space="preserve">
+    <value>Taak inschakelen</value>
+  </data>
+  <data name="CronPage_DisableJobTooltip" xml:space="preserve">
+    <value>Taak uitschakelen</value>
+  </data>
+  <data name="CronPage_FullResponse" xml:space="preserve">
+    <value>Volledig antwoord</value>
+  </data>
+  <data name="CronPage_OpenChat" xml:space="preserve">
+    <value>Chat openen</value>
+  </data>
+  <data name="CronPage_RunNow" xml:space="preserve">
+    <value>Nu uitvoeren</value>
+  </data>
+  <data name="CronPage_EditAction" xml:space="preserve">
+    <value>Bewerken</value>
+  </data>
+  <data name="CronPage_HistoryAction" xml:space="preserve">
+    <value>Geschiedenis</value>
+  </data>
+  <data name="CronPage_RemoveAction" xml:space="preserve">
+    <value>Verwijderen</value>
+  </data>
+  <data name="CronPage_RunningBadge" xml:space="preserve">
+    <value>Wordt uitgevoerd</value>
+  </data>
+  <data name="CronPage_RunHistory" xml:space="preserve">
+    <value>Uitvoeringsgeschiedenis</value>
+  </data>
+  <data name="CronPage_RunHistoryShowing" xml:space="preserve">
+    <value>Uitvoeringsgeschiedenis - {0} van {1} weergegeven</value>
+  </data>
+  <data name="CronPage_RunHistoryCount" xml:space="preserve">
+    <value>Uitvoeringsgeschiedenis - {0} uitvoeringen</value>
+  </data>
+  <data name="CronPage_LoadingRunHistory" xml:space="preserve">
+    <value>Uitvoeringsgeschiedenis laden...</value>
+  </data>
+  <data name="CronPage_NoRunHistoryAvailable" xml:space="preserve">
+    <value>Geen uitvoeringsgeschiedenis beschikbaar.</value>
+  </data>
+  <data name="CronPage_LoadOlderRuns" xml:space="preserve">
+    <value>Oudere uitvoeringen laden (nog {0})...</value>
+  </data>
+  <data name="CronPage_LoadMoreRuns" xml:space="preserve">
+    <value>Meer uitvoeringen laden...</value>
+  </data>
+  <data name="CronPage_Loading" xml:space="preserve">
+    <value>Laden...</value>
+  </data>
   <data name="CronPage_SaveChanges" xml:space="preserve">
     <value>Wijzigingen opslaan</value>
   </data>
@@ -5860,6 +5914,15 @@ Controleer uw verbindingsinstellingen en probeer het opnieuw.</value>
   </data>
   <data name="CronPage_JobCompletedRanSuccessfully" xml:space="preserve">
     <value>&quot;{0}&quot; ran successfully and was removed.</value>
+  </data>
+  <data name="CronPage_RunNotStarted" xml:space="preserve">
+    <value>Uitvoering niet gestart</value>
+  </data>
+  <data name="CronPage_RunNotStartedGeneric" xml:space="preserve">
+    <value>{0} is niet gestart.</value>
+  </data>
+  <data name="CronPage_RunNotStartedWithReason" xml:space="preserve">
+    <value>{0} is niet gestart: {1}</value>
   </data>
   <data name="GatewayHostAccess_NoTerminalAccess" xml:space="preserve">
     <value>This gateway does not have WSL or SSH terminal access.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -4800,6 +4800,60 @@
   <data name="CronPage_Running" xml:space="preserve">
     <value>正在运行...</value>
   </data>
+  <data name="CronPage_CompletedOneTimeJobTooltip" xml:space="preserve">
+    <value>一次性作业已完成</value>
+  </data>
+  <data name="CronPage_EnableJobTooltip" xml:space="preserve">
+    <value>启用作业</value>
+  </data>
+  <data name="CronPage_DisableJobTooltip" xml:space="preserve">
+    <value>禁用作业</value>
+  </data>
+  <data name="CronPage_FullResponse" xml:space="preserve">
+    <value>完整回复</value>
+  </data>
+  <data name="CronPage_OpenChat" xml:space="preserve">
+    <value>打开聊天</value>
+  </data>
+  <data name="CronPage_RunNow" xml:space="preserve">
+    <value>立即运行</value>
+  </data>
+  <data name="CronPage_EditAction" xml:space="preserve">
+    <value>编辑</value>
+  </data>
+  <data name="CronPage_HistoryAction" xml:space="preserve">
+    <value>历史记录</value>
+  </data>
+  <data name="CronPage_RemoveAction" xml:space="preserve">
+    <value>移除</value>
+  </data>
+  <data name="CronPage_RunningBadge" xml:space="preserve">
+    <value>正在运行</value>
+  </data>
+  <data name="CronPage_RunHistory" xml:space="preserve">
+    <value>运行历史记录</value>
+  </data>
+  <data name="CronPage_RunHistoryShowing" xml:space="preserve">
+    <value>运行历史记录 - 正在显示 {0}/{1}</value>
+  </data>
+  <data name="CronPage_RunHistoryCount" xml:space="preserve">
+    <value>运行历史记录 - {0} 次运行</value>
+  </data>
+  <data name="CronPage_LoadingRunHistory" xml:space="preserve">
+    <value>正在加载运行历史记录...</value>
+  </data>
+  <data name="CronPage_NoRunHistoryAvailable" xml:space="preserve">
+    <value>没有可用的运行历史记录。</value>
+  </data>
+  <data name="CronPage_LoadOlderRuns" xml:space="preserve">
+    <value>加载较早的运行（还有 {0} 个）...</value>
+  </data>
+  <data name="CronPage_LoadMoreRuns" xml:space="preserve">
+    <value>加载更多运行...</value>
+  </data>
+  <data name="CronPage_Loading" xml:space="preserve">
+    <value>正在加载...</value>
+  </data>
   <data name="CronPage_SaveChanges" xml:space="preserve">
     <value>保存更改</value>
   </data>
@@ -5860,6 +5914,15 @@
   </data>
   <data name="CronPage_JobCompletedRanSuccessfully" xml:space="preserve">
     <value>&quot;{0}&quot; ran successfully and was removed.</value>
+  </data>
+  <data name="CronPage_RunNotStarted" xml:space="preserve">
+    <value>运行未启动</value>
+  </data>
+  <data name="CronPage_RunNotStartedGeneric" xml:space="preserve">
+    <value>{0} 未启动。</value>
+  </data>
+  <data name="CronPage_RunNotStartedWithReason" xml:space="preserve">
+    <value>{0} 未启动：{1}</value>
   </data>
   <data name="GatewayHostAccess_NoTerminalAccess" xml:space="preserve">
     <value>This gateway does not have WSL or SSH terminal access.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -4800,6 +4800,60 @@
   <data name="CronPage_Running" xml:space="preserve">
     <value>正在執行...</value>
   </data>
+  <data name="CronPage_CompletedOneTimeJobTooltip" xml:space="preserve">
+    <value>一次性作業已完成</value>
+  </data>
+  <data name="CronPage_EnableJobTooltip" xml:space="preserve">
+    <value>啟用作業</value>
+  </data>
+  <data name="CronPage_DisableJobTooltip" xml:space="preserve">
+    <value>停用作業</value>
+  </data>
+  <data name="CronPage_FullResponse" xml:space="preserve">
+    <value>完整回覆</value>
+  </data>
+  <data name="CronPage_OpenChat" xml:space="preserve">
+    <value>開啟聊天</value>
+  </data>
+  <data name="CronPage_RunNow" xml:space="preserve">
+    <value>立即執行</value>
+  </data>
+  <data name="CronPage_EditAction" xml:space="preserve">
+    <value>編輯</value>
+  </data>
+  <data name="CronPage_HistoryAction" xml:space="preserve">
+    <value>歷史記錄</value>
+  </data>
+  <data name="CronPage_RemoveAction" xml:space="preserve">
+    <value>移除</value>
+  </data>
+  <data name="CronPage_RunningBadge" xml:space="preserve">
+    <value>正在執行</value>
+  </data>
+  <data name="CronPage_RunHistory" xml:space="preserve">
+    <value>執行歷史記錄</value>
+  </data>
+  <data name="CronPage_RunHistoryShowing" xml:space="preserve">
+    <value>執行歷史記錄 - 正在顯示 {0}/{1}</value>
+  </data>
+  <data name="CronPage_RunHistoryCount" xml:space="preserve">
+    <value>執行歷史記錄 - {0} 次執行</value>
+  </data>
+  <data name="CronPage_LoadingRunHistory" xml:space="preserve">
+    <value>正在載入執行歷史記錄...</value>
+  </data>
+  <data name="CronPage_NoRunHistoryAvailable" xml:space="preserve">
+    <value>沒有可用的執行歷史記錄。</value>
+  </data>
+  <data name="CronPage_LoadOlderRuns" xml:space="preserve">
+    <value>載入較早的執行（還有 {0} 個）...</value>
+  </data>
+  <data name="CronPage_LoadMoreRuns" xml:space="preserve">
+    <value>載入更多執行...</value>
+  </data>
+  <data name="CronPage_Loading" xml:space="preserve">
+    <value>正在載入...</value>
+  </data>
   <data name="CronPage_SaveChanges" xml:space="preserve">
     <value>儲存變更</value>
   </data>
@@ -5860,6 +5914,15 @@
   </data>
   <data name="CronPage_JobCompletedRanSuccessfully" xml:space="preserve">
     <value>&quot;{0}&quot; ran successfully and was removed.</value>
+  </data>
+  <data name="CronPage_RunNotStarted" xml:space="preserve">
+    <value>執行未啟動</value>
+  </data>
+  <data name="CronPage_RunNotStartedGeneric" xml:space="preserve">
+    <value>{0} 未啟動。</value>
+  </data>
+  <data name="CronPage_RunNotStartedWithReason" xml:space="preserve">
+    <value>{0} 未啟動：{1}</value>
   </data>
   <data name="GatewayHostAccess_NoTerminalAccess" xml:space="preserve">
     <value>This gateway does not have WSL or SSH terminal access.</value>

--- a/tests/OpenClaw.Shared.Tests/CronPayloadShapeTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CronPayloadShapeTests.cs
@@ -60,6 +60,42 @@ public class CronPayloadShapeTests
     }
 
     [Fact]
+    public void CronRun_Response_EmptyPayload_IsAcceptedLegacyAck()
+    {
+        var payload = Serialize(new { });
+
+        var result = OpenClawGatewayClient.ParseCronRunRequestResult(payload);
+
+        Assert.True(result.Accepted);
+        Assert.True(result.Enqueued);
+        Assert.Null(result.RunId);
+    }
+
+    [Fact]
+    public void CronRun_Response_DetailedEnqueue_PreservesRunId()
+    {
+        var payload = Serialize(new { ok = true, enqueued = true, runId = "manual:job:1" });
+
+        var result = OpenClawGatewayClient.ParseCronRunRequestResult(payload);
+
+        Assert.True(result.Accepted);
+        Assert.True(result.Enqueued);
+        Assert.Equal("manual:job:1", result.RunId);
+    }
+
+    [Fact]
+    public void CronRun_Response_ExplicitRanFalse_IsNotEnqueued()
+    {
+        var payload = Serialize(new { ok = true, ran = false, reason = "not-due" });
+
+        var result = OpenClawGatewayClient.ParseCronRunRequestResult(payload);
+
+        Assert.True(result.Accepted);
+        Assert.False(result.Enqueued);
+        Assert.Equal("not-due", result.Reason);
+    }
+
+    [Fact]
     public void CronRemove_Payload_Uses_Id()
     {
         // Mirrors the wire object built by RemoveCronJobAsync

--- a/tests/OpenClaw.Shared.Tests/CronPayloadShapeTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CronPayloadShapeTests.cs
@@ -47,16 +47,16 @@ public class CronPayloadShapeTests
     }
 
     [Fact]
-    public void CronRun_Payload_Uses_Id()
+    public void CronRun_Payload_Uses_JobId()
     {
         // Mirrors the wire object built by RunCronJobAsync
-        var payload = new { id = "job-789", force = true };
+        var payload = new { jobId = "job-789" };
         var el = Serialize(payload);
 
-        Assert.True(el.TryGetProperty("id", out var idProp));
+        Assert.True(el.TryGetProperty("jobId", out var idProp));
         Assert.Equal("job-789", idProp.GetString());
-        Assert.False(el.TryGetProperty("jobId", out _));
-        Assert.True(el.GetProperty("force").GetBoolean());
+        Assert.False(el.TryGetProperty("id", out _));
+        Assert.False(el.TryGetProperty("force", out _));
     }
 
     [Fact]

--- a/tests/OpenClaw.Shared.Tests/GatewayProtocolLiveRoundTripTests.cs
+++ b/tests/OpenClaw.Shared.Tests/GatewayProtocolLiveRoundTripTests.cs
@@ -117,6 +117,57 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
         }
     }
 
+    [Fact]
+    public async Task CronRunDetailed_FallsBackToLegacyIdPayload_WhenJobIdPayloadIsRejected()
+    {
+        using var server = new LoopbackGatewayServer();
+        var requestCount = 0;
+        var observedParameters = new ConcurrentQueue<JsonElement>();
+        server.OnMethod("cron.run", parameters =>
+        {
+            requestCount++;
+            observedParameters.Enqueue(parameters.Clone());
+            if (requestCount == 1)
+                return LoopbackResponse.Fail("invalid cron.run params: unexpected property jobId");
+
+            return new { ok = true, enqueued = true, runId = "manual:job-legacy:1" };
+        });
+
+        var logger = new TestLogger();
+        var client = new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", logger,
+            tokenIsBootstrapToken: false, bootstrapPairAsNode: false,
+            identityPath: _identityDir);
+
+        try
+        {
+            await ConnectAndWaitAsync(client, server);
+
+            var result = await client.RunCronJobDetailedAsync("job-legacy", timeoutMs: 20000);
+
+            Assert.True(result.Accepted);
+            Assert.True(result.Enqueued);
+            Assert.Equal("manual:job-legacy:1", result.RunId);
+            Assert.Equal(2, requestCount);
+            await server.WaitFrameAsync("cron.run", occurrence: 1, timeoutMs: 20000);
+
+            var payloads = observedParameters.ToArray();
+            Assert.Equal(2, payloads.Length);
+            Assert.True(payloads[0].TryGetProperty("jobId", out var jobId));
+            Assert.Equal("job-legacy", jobId.GetString());
+            Assert.False(payloads[0].TryGetProperty("id", out _));
+            Assert.True(payloads[1].TryGetProperty("id", out var id));
+            Assert.Equal("job-legacy", id.GetString());
+            Assert.True(payloads[1].TryGetProperty("force", out var force));
+            Assert.True(force.GetBoolean());
+            Assert.False(payloads[1].TryGetProperty("jobId", out _));
+        }
+        finally
+        {
+            await client.DisconnectAsync();
+        }
+    }
+
     private static void ConfigureResponders(LoopbackGatewayServer server)
     {
         // NOTE: intentionally NO hello-ok responder. The new methods only require
@@ -401,7 +452,11 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
                 ? responder(parameters)
                 : new { };
 
-            var response = JsonSerializer.Serialize(new { type = "res", id, ok = true, payload });
+            var response = payload is LoopbackResponse loopbackResponse
+                ? loopbackResponse.Ok
+                    ? JsonSerializer.Serialize(new { type = "res", id, ok = true, payload = loopbackResponse.Payload })
+                    : JsonSerializer.Serialize(new { type = "res", id, ok = false, error = loopbackResponse.Error })
+                : JsonSerializer.Serialize(new { type = "res", id, ok = true, payload });
             var bytes = Encoding.UTF8.GetBytes(response);
             await socket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, endOfMessage: true, CancellationToken.None);
         }
@@ -423,5 +478,10 @@ public sealed class GatewayProtocolLiveRoundTripTests : IDisposable
             try { _loop.Wait(TimeSpan.FromSeconds(2)); } catch { }
             _cts.Dispose();
         }
+    }
+
+    private sealed record LoopbackResponse(bool Ok, object? Payload = null, string? Error = null)
+    {
+        public static LoopbackResponse Fail(string error) => new(false, Error: error);
     }
 }

--- a/tests/OpenClaw.Shared.Tests/WebSocketClientBaseTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WebSocketClientBaseTests.cs
@@ -70,6 +70,7 @@ public class TestWebSocketClient : WebSocketClientBase
     public IOpenClawLogger TestLogger => _logger;
 }
 
+[Collection("WebSocketClientBase")]
 public class WebSocketClientBaseTests
 {
     private readonly TestLogger _logger = new();
@@ -425,6 +426,11 @@ public class WebSocketClientBaseTests
             await Task.Delay(25);
         }
     }
+}
+
+[CollectionDefinition("WebSocketClientBase", DisableParallelization = true)]
+public sealed class WebSocketClientBaseTestCollection
+{
 }
 
 internal sealed class BlockingFirstConnectClient : WebSocketClientBase

--- a/tests/OpenClaw.Tray.Tests/CronPageContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/CronPageContractTests.cs
@@ -1,0 +1,106 @@
+namespace OpenClaw.Tray.Tests;
+
+public sealed class CronPageContractTests
+{
+    [Fact]
+    public void CompletedOneTimeJobs_KeepHistoryAndRemoveActionable()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Pages",
+            "CronPage.xaml.cs"));
+
+        Assert.DoesNotContain("CardOpacity", source);
+        Assert.DoesNotContain(".Opacity = 0.4", source);
+        Assert.Contains("IsCompletedOneShot", source);
+        Assert.Contains("var canRunOrEditJob = _cronLoading.CanEdit && !isRunning;", source);
+        Assert.Contains("editBtn.IsEnabled = canRunOrEditJob;", source);
+        Assert.Contains("histBtn.IsEnabled = _cronLoading.CanEdit && vm.HasRunHistory;", source);
+        Assert.Contains("removeBtn.IsEnabled = _cronLoading.CanEdit && !isRunning;", source);
+        Assert.Contains("IsEnabled = _cronLoading.CanEdit && !vm.IsCompletedOneShot && !_runningJobIds.Contains(vm.Id)", source);
+        Assert.Contains("if (_runningJobIds.Contains(jobId)) return;", ExtractMethod(source, "OnRemoveClick"));
+        Assert.Contains("if (_runningJobIds.Contains(jobId)) return;", ExtractMethod(source, "OnEnabledToggleChanged"));
+        Assert.Contains("CancelAllRunRefreshLoops();", source);
+        Assert.Contains("CancelRunRefreshLoop(jobId);", source);
+        Assert.Contains("ClearRunningJob(jobId);", source);
+        Assert.Contains("Task.Delay(TimeSpan.FromSeconds(3), token)", source);
+        Assert.Contains("CronPage_DisableJobTooltip", source);
+        Assert.Contains("CronPage_EnableJobTooltip", source);
+        Assert.Contains("BuildFullResponseExpander", source);
+        Assert.Contains("CronRunHistoryDisplay.ExtractText(entry, isError)", source);
+        Assert.Contains("MakeRunChatButton(sessionKey)", source);
+        var runNowHandler = ExtractMethod(source, "OnRunNowClick");
+        Assert.DoesNotContain("if (vm != null && !vm.IsEnabled) return;", runNowHandler);
+        Assert.Contains("if (_runningJobIds.Contains(jobId)) return;", runNowHandler);
+        Assert.Contains("RunCronJobDetailedAsync(jobId)", runNowHandler);
+        Assert.Contains("result?.Enqueued != true", runNowHandler);
+        Assert.Contains("ShowRunNotStartedNotification", runNowHandler);
+        Assert.Contains("RefreshJobActionButtons(jobId);", runNowHandler);
+        Assert.Contains("StartRunRefreshLoop(jobId);", runNowHandler);
+        var refreshLoop = ExtractMethod(source, "StartRunRefreshLoop");
+        Assert.Contains("RequestCronRunsAsync(jobId, limit: 20, offset: 0)", refreshLoop);
+        Assert.DoesNotContain("RequestCronListAsync()", refreshLoop);
+        var parseCronList = ExtractMethod(source, "ParseCronList");
+        Assert.Contains("oldVm != null && vm.LastRunAtMs > 0 && vm.LastRunAtMs != oldVm.LastRunAtMs", parseCronList);
+        Assert.DoesNotContain("vm.RunningAtMs == 0 || oldVm == null || vm.LastRunAtMs != oldVm.LastRunAtMs", parseCronList);
+        Assert.Contains("shouldPreserveVisualTreeForRunningRefresh", parseCronList);
+        Assert.Contains("RefreshJobActionButtons(runningJobId);", parseCronList);
+        var editHandler = ExtractMethod(source, "OnEditJobClick");
+        Assert.DoesNotContain("if (vm == null || !vm.IsEnabled) return;", editHandler);
+        Assert.Contains("if (vm == null || _runningJobIds.Contains(jobId)) return;", editHandler);
+        var historyHandler = ExtractMethod(source, "OnHistoryClick");
+        Assert.DoesNotContain("if (vm != null && !vm.IsEnabled) return;", historyHandler);
+        Assert.Contains("if (vm != null && !vm.HasRunHistory) return;", historyHandler);
+        var cardTappedHandler = ExtractMethod(source, "OnCardTapped");
+        Assert.Contains("parent is Button or ToggleSwitch or Expander", cardTappedHandler);
+        Assert.DoesNotContain("or ScrollViewer", cardTappedHandler);
+        Assert.Contains("RebuildJobCards(preserveHistory: _historyJobId != null);", source);
+        Assert.Contains("ShowHistoryLoading(_historyJobId);", source);
+        Assert.Contains("Name = actionName", source);
+        Assert.Contains("LocalizationHelper.GetString(\"CronPage_OpenChat\")", source);
+        Assert.DoesNotContain("SessionsPage_OpenChatButton.Content", source);
+        Assert.Contains("Tag = $\"running_{vm.Id}\"", source);
+        Assert.Contains("badge.Visibility = isRunning ? Visibility.Visible : Visibility.Collapsed;", source);
+        Assert.Contains("_expandedRunFullResponseIds.Contains(runEntryKey)", source);
+        Assert.Contains("BuildHistoryRenderSignature(entries, total, hasMore)", source);
+        Assert.Contains("string.Equals(_lastHistoryRenderSignature, signature", source);
+        var fullResponseBuilder = ExtractMethod(source, "BuildFullResponseExpander");
+        Assert.DoesNotContain("VerticalScrollBarVisibility", fullResponseBuilder);
+        Assert.DoesNotContain("MaxHeight = 360", fullResponseBuilder);
+    }
+
+    private static string ExtractMethod(string source, string methodName)
+    {
+        var markers = new[]
+        {
+            $"private void {methodName}",
+            $"private UIElement {methodName}",
+            $"private static string {methodName}"
+        };
+        var marker = markers.FirstOrDefault(m => source.Contains(m, StringComparison.Ordinal));
+        Assert.NotNull(marker);
+
+        var start = source.IndexOf(marker!, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Could not find {methodName}.");
+
+        var brace = source.IndexOf('{', start);
+        Assert.True(brace >= 0, $"Could not find {methodName} body.");
+
+        var depth = 0;
+        for (var i = brace; i < source.Length; i++)
+        {
+            if (source[i] == '{') depth++;
+            else if (source[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                    return source[start..(i + 1)];
+            }
+        }
+
+        Assert.Fail($"Could not parse {methodName} body.");
+        return string.Empty;
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/CronRunHistoryDisplayTests.cs
+++ b/tests/OpenClaw.Tray.Tests/CronRunHistoryDisplayTests.cs
@@ -1,0 +1,101 @@
+using OpenClawTray.Services;
+using System.Text.Json;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class CronRunHistoryDisplayTests
+{
+    [Fact]
+    public void ExtractText_UsesSummaryAsExpandableFullResponse()
+    {
+        var response = string.Join("\n", new[]
+        {
+            "☀️ **Woodinville, WA — Wednesday, June 24**",
+            "",
+            "**Right now (11:08 AM):**",
+            "- **Sunny** — 74°F (23°C), feels like 77°F",
+            "- Humidity: 48%",
+            "- Wind: 2 mph SSW (light breeze)",
+            "",
+            "Stay hydrated!"
+        });
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(new
+        {
+            status = "ok",
+            summary = response
+        }));
+
+        var text = CronRunHistoryDisplay.ExtractText(doc.RootElement, isError: false);
+
+        Assert.Equal(response, text.PreviewText);
+        Assert.Equal(response, text.FullText);
+        Assert.True(text.HasExpandableFullText);
+    }
+
+    [Fact]
+    public void ExtractText_PrefersFullResponseWhenSummaryIsShort()
+    {
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(new
+        {
+            status = "ok",
+            summary = "☀️ **Woodinville, WA — Wednesday, June 24**",
+            fullResponse = "☀️ **Woodinville, WA — Wednesday, June 24**\n\nFull forecast details."
+        }));
+
+        var text = CronRunHistoryDisplay.ExtractText(doc.RootElement, isError: false);
+
+        Assert.Equal("☀️ **Woodinville, WA — Wednesday, June 24**", text.PreviewText);
+        Assert.Equal("☀️ **Woodinville, WA — Wednesday, June 24**\n\nFull forecast details.", text.FullText);
+        Assert.True(text.HasExpandableFullText);
+    }
+
+    [Fact]
+    public void ExtractText_MultilineSummaryIsExpandableEvenWhenShort()
+    {
+        const string response = "Line one\nLine two\nLine three";
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(new
+        {
+            status = "ok",
+            summary = response
+        }));
+
+        var text = CronRunHistoryDisplay.ExtractText(doc.RootElement, isError: false);
+
+        Assert.Equal(response, text.PreviewText);
+        Assert.Equal(response, text.FullText);
+        Assert.True(text.HasExpandableFullText);
+    }
+
+    [Fact]
+    public void ExtractText_CanRecoverAssistantTextFromTranscriptJsonl()
+    {
+        var transcript = string.Join('\n', new[]
+        {
+            """{"stream":"assistant","data":{"delta":"Hello "}}""",
+            """{"stream":"assistant","data":{"delta":"there"}}""",
+            """{"stream":"assistant","data":{"text":"Hello there\n\nFinal answer."}}"""
+        });
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(new
+        {
+            status = "ok",
+            summary = "Hello there",
+            transcript
+        }));
+
+        var text = CronRunHistoryDisplay.ExtractText(doc.RootElement, isError: false);
+
+        Assert.Equal("Hello there", text.PreviewText);
+        Assert.Equal("Hello there\n\nFinal answer.", text.FullText);
+        Assert.True(text.HasExpandableFullText);
+    }
+
+    [Fact]
+    public void SanitizeForDisplay_RedactsTokensAndPaths()
+    {
+        var input = "Auth failed at /home/openclaw/.openclaw/agents/main/sessions/abc.jsonl with Authorization: Bearer secret.token.value";
+
+        var result = CronRunHistoryDisplay.SanitizeForDisplay(input);
+
+        Assert.Equal("Auth failed at …/abc.jsonl with Authorization: Bearer [REDACTED]", result);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OnboardingChatBootstrapperTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OnboardingChatBootstrapperTests.cs
@@ -466,6 +466,8 @@ public sealed class OnboardingChatBootstrapperTests : IDisposable
         public Task RequestCronListAsync() => Task.CompletedTask;
         public Task RequestCronStatusAsync() => Task.CompletedTask;
         public Task<bool> RunCronJobAsync(string jobId, bool force = true) => Task.FromResult(false);
+        public Task<CronRunRequestResult> RunCronJobDetailedAsync(string jobId, bool force = true, int timeoutMs = 12000) =>
+            Task.FromResult(CronRunRequestResult.NotAccepted("not implemented"));
         public Task<bool> RemoveCronJobAsync(string jobId) => Task.FromResult(false);
         // Stubbed for interface compliance — not exercised by these tests.
         public Task<bool> AddCronJobAsync(object jobDefinition) => Task.FromResult(false);

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\GatewayConnectorInterfaces.cs" Link="Services\GatewayConnectorInterfaces.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ActivityStreamService.cs" Link="Services\ActivityStreamService.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\AsyncListLoadingState.cs" Link="Services\AsyncListLoadingState.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\CronRunHistoryDisplay.cs" Link="Services\CronRunHistoryDisplay.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\GatewayNavVisibilityDebouncePolicy.cs" Link="Services\GatewayNavVisibilityDebouncePolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeInvokeActivityFormatter.cs" Link="Services\NodeInvokeActivityFormatter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeCapabilityGating.cs" Link="Services\NodeCapabilityGating.cs" />

--- a/tests/OpenClaw.Tray.Tests/PairingApprovalCoordinatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/PairingApprovalCoordinatorTests.cs
@@ -129,6 +129,8 @@ public sealed class PairingApprovalCoordinatorTests
         public Task RequestCronListAsync() => Task.CompletedTask;
         public Task RequestCronStatusAsync() => Task.CompletedTask;
         public Task<bool> RunCronJobAsync(string jobId, bool force = true) => Task.FromResult(false);
+        public Task<CronRunRequestResult> RunCronJobDetailedAsync(string jobId, bool force = true, int timeoutMs = 12000) =>
+            Task.FromResult(CronRunRequestResult.NotAccepted("not implemented"));
         public Task<bool> RemoveCronJobAsync(string jobId) => Task.FromResult(false);
         public Task<bool> AddCronJobAsync(object jobDefinition) => Task.FromResult(false);
         public Task<bool> UpdateCronJobAsync(string id, object patch) => Task.FromResult(false);


### PR DESCRIPTION
## Why this matters

Cron jobs can produce rich, multi-paragraph LLM answers, but the Windows Cron History view was only useful as a short status summary. That made one-time runs feel lossy: users could see that a job succeeded, but not easily inspect the actual answer, navigate to the run chat, or confidently re-run the same task without the UI shifting underneath them.

This PR makes Cron History behave more like a real run transcript surface instead of a compact log row.

## What improved

- **Full run responses are now available in-place.** History rows keep a compact preview, but expose a **Full response** expander that renders the complete sanitized response, including Markdown structure such as headings, lists, and emphasis.
- **Run history stays stable while refreshing.** Expanded job cards and expanded full responses preserve their state while the page polls for a running job to finish, avoiding surprise collapses or focus jumps.
- **Run controls reflect the actual job state.** `Run Now`, `Edit`, `Remove`, and the enabled toggle are disabled while a run is active; `History` stays available so users can inspect prior/current results.
- **Manual run feedback is more reliable.** The tray now uses a response-aware `cron.run` path so it can distinguish “enqueued” from “declined” and show a visible warning instead of looking like the button did nothing.
- **Gateway compatibility is preserved.** The detailed run path uses the gateway-compatible `jobId` request shape with fallback for older schemas.
- **Run chat navigation is consistent.** Cron History now uses the same **Open chat** wording as the Sessions page when a run has a session key.
- **New display logic is covered by tests.** Full-response extraction, transcript fallback, sanitization, completed one-time job behavior, running-state affordances, and payload shape are covered by shared/tray tests.
- **All new user-facing strings are localized** across the existing resource locales.

## User-visible result

After this change, a user can run a one-time Cron task, watch the row enter a clear running state, keep focus where they put it, and then expand the run history to read the complete LLM answer without leaving the Cron page. If the run has a backing chat session, they can jump to it with **Open chat**.

## Validation

- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`
- `git diff --check`
- Autoreview clean with Copilot engine
- Hanselman dual-model review completed; accepted findings fixed

## Screenshots

UI while re-running a Cron task:
<img width="1730" height="1127" alt="image" src="https://github.com/user-attachments/assets/f6de5407-22b6-43cb-9b5d-a3b4abbe6f79" />

Showing the full LLM response in the UI:
<img width="1730" height="1888" alt="image" src="https://github.com/user-attachments/assets/a6c79e8c-c361-4160-928a-5469a574c359" />
