### PR TITLE
Port mismerged MXC and pairing approval PRs to main

### DIFF
--- a/docs/CONNECTION_ARCHITECTURE.md
+++ b/docs/CONNECTION_ARCHITECTURE.md
@@ -168,6 +168,12 @@ Setup codes (from QR scan or paste) decode to `{ url, bootstrapToken }` via `Set
 
 **Approval boundaries**: `GatewayConnectionManager` leaves node-pair command-trust requests and reapproval pending for explicit operator approval. It may automatically approve and reconnect only an explicitly typed device-pair request used for a device role upgrade.
 
+## Inbound pairing approval (operator)
+
+When **another** device or node requests pairing, the gateway broadcasts `device.pair.requested` / `node.pair.requested` to operators with pairing scope. `OpenClawGatewayClient` refreshes the pending lists and raises `DevicePairListUpdated` / `NodePairListUpdated`, which `GatewayService` forwards via its `PairListsChanged` event.
+
+`PairingApprovalCoordinator` (tray) reconciles those snapshots through the pure `PairingApprovalQueue` (OpenClaw.Connection) into add/resolve deltas, de-duplicating, suppressing already-decided requests, and filtering out the local node's own pending request (handled by the auto-approve path above). For genuinely new requests — when `ShowPairingApprovalDialog` is enabled and the operator holds pairing scope — it raises `ApprovalRequested`, and the app presents a focused **`PairingApprovalDialog`** plus an awareness toast (with a "Review" action). The dialog shows the requester's identity and the **operator scopes being granted** (mapped to friendly text by `PairingScopeDescriptions`), with Approve / Reject / Decide-later. Approve is briefly disabled on each new request to prevent click-through. Approve/Reject call the `IOperatorGatewayClient.{Device,Node}Pair{Approve,Reject}Async` RPCs; the queue advances and the dialog closes when empty. The existing Connections-page "Pending approvals" banner remains as the passive fallback when the dialog is disabled. Pure queue/scope logic is unit-tested in `OpenClaw.Connection.Tests`.
+
 ## SSH tunnel integration
 
 `SshTunnelService` manages an SSH local port-forward process. `SshTunnelManager` wraps it behind `ISshTunnelManager` for the connection manager.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "openclaw-windows-node-mxc",
       "version": "0.0.0",
       "dependencies": {
-        "@microsoft/mxc-sdk": "^0.6.1"
+        "@microsoft/mxc-sdk": "^0.7.0"
       }
     },
     "node_modules/@microsoft/mxc-sdk": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/mxc-sdk/-/mxc-sdk-0.6.1.tgz",
-      "integrity": "sha512-jpbJU/xfF4qLWcNMplDTUX/q13m2A6vYao1QN3lkZaQlzsRce95H+iU0Qu0wlweJZ2gx6eY1PRQU+/bnQki/dw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/mxc-sdk/-/mxc-sdk-0.7.0.tgz",
+      "integrity": "sha512-EWhz2pKkcPluZHAOI1yneV+JK0NO/3hdh7nABBb0x4PjyUWMeSWPTBAjtIu+BhtMYOqlaijSPZMZ0Hs/J4ZL4A==",
       "license": "MIT",
       "dependencies": {
         "node-pty": "^1.2.0-beta.12",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "MXC sandbox dependency used by the OpenClaw tray build to copy wxc-exec.exe into the app output.",
   "dependencies": {
-    "@microsoft/mxc-sdk": "^0.6.1"
+    "@microsoft/mxc-sdk": "^0.7.0"
   }
 }

--- a/src/OpenClaw.Connection/PairingApprovalQueue.cs
+++ b/src/OpenClaw.Connection/PairingApprovalQueue.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenClaw.Shared;
+
+namespace OpenClaw.Connection;
+
+/// <summary>A pairing decision the gateway has now confirmed by removing it from the pending list.</summary>
+public sealed record PairingApprovalResolution(PendingApproval Approval, bool Approved);
+
+/// <summary>The result of reconciling a fresh pair-list snapshot against prior state.</summary>
+public sealed class PairingApprovalDelta
+{
+    /// <summary>Requests that are newly surfaced and prompt-worthy (not previously known, not awaiting resolution).</summary>
+    public IReadOnlyList<PendingApproval> Added { get; init; } = Array.Empty<PendingApproval>();
+
+    /// <summary>Keys (<see cref="PendingApproval.Key"/>) that were present last time but have now left the list.</summary>
+    public IReadOnlyList<string> ResolvedKeys { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Decisions the local user submitted that the gateway has now confirmed (the request left the
+    /// pending list). These — not the send-ack — are the source of truth for "approved/rejected".
+    /// </summary>
+    public IReadOnlyList<PairingApprovalResolution> ConfirmedDecisions { get; init; } = Array.Empty<PairingApprovalResolution>();
+
+    /// <summary>All currently actionable pending approvals (excludes ones awaiting resolution).</summary>
+    public IReadOnlyList<PendingApproval> Current { get; init; } = Array.Empty<PendingApproval>();
+
+    public bool HasChanges => Added.Count > 0 || ResolvedKeys.Count > 0 || ConfirmedDecisions.Count > 0;
+}
+
+/// <summary>
+/// Pure, UI-agnostic diff engine for inbound pairing approvals. Translates successive
+/// device/node pair-list snapshots (the gateway re-sends the full list on every
+/// <c>*.pair.requested</c>/<c>*.pair.resolved</c> event) into add/resolve deltas the
+/// presentation layer can act on without re-prompting for requests it has already shown
+/// or that are awaiting resolution of a submitted decision.
+///
+/// Responsibilities:
+/// <list type="bullet">
+///   <item>Merge device + node pending lists into a single ordered queue (oldest first). A null
+///         list for a kind means "no update for that kind" (its prior entries are carried forward),
+///         NOT "that kind is now empty" — so a partial snapshot never silently drops or confirms.</item>
+///   <item>Filter out the local node's own pairing request (handled by the auto-approve path)
+///         so the operator is never prompted to approve their own machine. Matches against any of
+///         the node's advertised identifiers (device id and/or gateway node id).</item>
+///   <item>Drop entries with no usable id and de-duplicate by <see cref="PendingApproval.Key"/>.</item>
+///   <item>Treat a submitted approve/reject as <em>optimistic-pending</em> — suppress it from the
+///         actionable set, but only report it <see cref="PairingApprovalDelta.ConfirmedDecisions">
+///         confirmed</see> once the gateway actually drops it from a provided list for that kind. If
+///         the gateway never acts within <see cref="SubmissionResolveTimeoutMs"/>, re-surface the
+///         request so a lost decision is retried rather than hidden forever.</item>
+/// </list>
+/// Not thread-safe; the coordinator marshals all calls onto a single dispatcher thread.
+/// </summary>
+public sealed class PairingApprovalQueue
+{
+    /// <summary>How long a submitted-but-unresolved decision is suppressed before it is re-surfaced.</summary>
+    public const long SubmissionResolveTimeoutMs = 10_000;
+
+    private readonly Dictionary<string, PendingApproval> _current = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Submission> _submitted = new(StringComparer.Ordinal);
+
+    private readonly record struct Submission(PendingApproval Approval, bool Approved, long SubmittedAtMs);
+
+    /// <summary>Snapshot of currently actionable approvals, oldest first.</summary>
+    public IReadOnlyList<PendingApproval> Current =>
+        _current.Values
+            .Where(a => !_submitted.ContainsKey(a.Key))
+            .OrderBy(a => a.Ts)
+            .ThenBy(a => a.Key, StringComparer.Ordinal)
+            .ToArray();
+
+    /// <summary>True when there are no actionable approvals.</summary>
+    public bool IsEmpty => Current.Count == 0;
+
+    /// <summary>
+    /// Reconcile a fresh snapshot. <paramref name="ownNodeDeviceIds"/>, when provided, filters out the
+    /// local Windows node's own pending node request (matched against any advertised id).
+    /// <paramref name="nowMs"/> is a monotonic timestamp (e.g. <see cref="Environment.TickCount64"/>)
+    /// used to expire stale submissions. A null <paramref name="devices"/> or <paramref name="nodes"/>
+    /// means that kind has no fresh snapshot: its existing entries are carried forward and its
+    /// submissions are neither confirmed nor expired this round.
+    /// </summary>
+    public PairingApprovalDelta Reconcile(
+        DevicePairingListInfo? devices,
+        PairingListInfo? nodes,
+        IReadOnlyCollection<string>? ownNodeDeviceIds = null,
+        long nowMs = 0)
+    {
+        var devicesProvided = devices is not null;
+        var nodesProvided = nodes is not null;
+        bool KindProvided(PairingApprovalKind kind) =>
+            kind == PairingApprovalKind.Device ? devicesProvided : nodesProvided;
+
+        var incoming = BuildIncoming(devices, nodes, ownNodeDeviceIds);
+        var incomingByKey = new Dictionary<string, PendingApproval>(StringComparer.Ordinal);
+        foreach (var item in incoming)
+            incomingByKey[item.Key] = item; // last wins on duplicate ids
+
+        // Carry forward prior entries whose kind had NO fresh snapshot — a missing list is "no
+        // update", not "now empty", so we never drop or resolve a kind we didn't actually hear about.
+        foreach (var kv in _current)
+            if (!KindProvided(kv.Value.Kind) && !incomingByKey.ContainsKey(kv.Key))
+                incomingByKey[kv.Key] = kv.Value;
+
+        // Confirmed resolutions: decisions we submitted whose request has now left a PROVIDED list.
+        // This — not the send-ack — is the authoritative "the gateway accepted it" signal.
+        var confirmed = new List<PairingApprovalResolution>();
+        foreach (var sub in _submitted.Values)
+            if (KindProvided(sub.Approval.Kind) && !incomingByKey.ContainsKey(sub.Approval.Key))
+                confirmed.Add(new PairingApprovalResolution(sub.Approval, sub.Approved));
+        foreach (var c in confirmed)
+            _submitted.Remove(c.Approval.Key);
+
+        // Expire submissions the gateway hasn't acted on in time (in a provided list) → drop
+        // suppression so they re-surface (a lost/rejected decision is retried, not hidden forever).
+        var expired = _submitted
+            .Where(kv => KindProvided(kv.Value.Approval.Kind)
+                && incomingByKey.ContainsKey(kv.Key)
+                && nowMs - kv.Value.SubmittedAtMs >= SubmissionResolveTimeoutMs)
+            .Select(kv => kv.Key)
+            .ToArray();
+        foreach (var k in expired)
+            _submitted.Remove(k);
+        var expiredSet = new HashSet<string>(expired, StringComparer.Ordinal);
+
+        // Added: genuinely new requests, plus expired-and-re-surfaced ones. Skip anything still
+        // awaiting resolution.
+        var added = new List<PendingApproval>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var item in incoming)
+        {
+            if (_submitted.ContainsKey(item.Key)) continue;                                   // awaiting resolution
+            if (_current.ContainsKey(item.Key) && !expiredSet.Contains(item.Key)) continue;   // already known
+            if (!seen.Add(item.Key)) continue;
+            added.Add(item);
+        }
+
+        var resolvedKeys = _current.Keys
+            .Where(key => !incomingByKey.ContainsKey(key))
+            .ToArray();
+
+        // Swap in the new snapshot (includes carried-forward entries for non-provided kinds).
+        _current.Clear();
+        foreach (var kvp in incomingByKey)
+            _current[kvp.Key] = kvp.Value;
+
+        return new PairingApprovalDelta
+        {
+            Added = added,
+            ResolvedKeys = resolvedKeys,
+            ConfirmedDecisions = confirmed,
+            Current = Current,
+        };
+    }
+
+    /// <summary>
+    /// Record that the local user submitted an approve/reject for a request. The request is suppressed
+    /// from the actionable set (so the UI advances) but remains tracked until the gateway confirms by
+    /// dropping it from the pending list, or until <see cref="SubmissionResolveTimeoutMs"/> elapses.
+    /// </summary>
+    public void MarkSubmitted(PendingApproval approval, bool approved, long nowMs)
+    {
+        if (approval is null || string.IsNullOrEmpty(approval.Key))
+            return;
+        _submitted[approval.Key] = new Submission(approval, approved, nowMs);
+    }
+
+    /// <summary>Look up a currently-actionable approval by its key (excludes ones awaiting resolution).</summary>
+    public PendingApproval? Find(string key) =>
+        !_submitted.ContainsKey(key) && _current.TryGetValue(key, out var value) ? value : null;
+
+    /// <summary>Clears all state (e.g. on disconnect / gateway switch).</summary>
+    public void Reset()
+    {
+        _current.Clear();
+        _submitted.Clear();
+    }
+
+    private static List<PendingApproval> BuildIncoming(
+        DevicePairingListInfo? devices,
+        PairingListInfo? nodes,
+        IReadOnlyCollection<string>? ownNodeDeviceIds)
+    {
+        var list = new List<PendingApproval>();
+
+        if (devices?.Pending is { Count: > 0 })
+        {
+            foreach (var req in devices.Pending)
+            {
+                var approval = PendingApproval.FromDevice(req);
+                if (approval.IsActionable)
+                    list.Add(approval);
+            }
+        }
+
+        if (nodes?.Pending is { Count: > 0 })
+        {
+            foreach (var req in nodes.Pending)
+            {
+                var approval = PendingApproval.FromNode(req);
+                if (!approval.IsActionable) continue;
+                if (IsOwnNode(approval, ownNodeDeviceIds)) continue;
+                list.Add(approval);
+            }
+        }
+
+        return list;
+    }
+
+    private static bool IsOwnNode(PendingApproval approval, IReadOnlyCollection<string>? ownNodeDeviceIds)
+    {
+        if (ownNodeDeviceIds is null || ownNodeDeviceIds.Count == 0) return false;
+        if (string.IsNullOrEmpty(approval.DeviceId)) return false;
+        foreach (var id in ownNodeDeviceIds)
+            if (!string.IsNullOrWhiteSpace(id) && approval.DeviceId.Equals(id, StringComparison.OrdinalIgnoreCase))
+                return true;
+        return false;
+    }
+}

--- a/src/OpenClaw.Connection/PairingApprovalQueue.cs
+++ b/src/OpenClaw.Connection/PairingApprovalQueue.cs
@@ -44,7 +44,8 @@ public sealed class PairingApprovalDelta
 ///   <item>Filter out the local node's own pairing request (handled by the auto-approve path)
 ///         so the operator is never prompted to approve their own machine. Matches against any of
 ///         the node's advertised identifiers (device id and/or gateway node id).</item>
-///   <item>Drop entries with no usable id and de-duplicate by <see cref="PendingApproval.Key"/>.</item>
+///   <item>Drop entries with no usable id and legacy fallback-id collisions that cannot be
+///         approved/rejected unambiguously, then de-duplicate by <see cref="PendingApproval.Key"/>.</item>
 ///   <item>Treat a submitted approve/reject as <em>optimistic-pending</em> — suppress it from the
 ///         actionable set, but only report it <see cref="PairingApprovalDelta.ConfirmedDecisions">
 ///         confirmed</see> once the gateway actually drops it from a provided list for that kind. If
@@ -94,6 +95,10 @@ public sealed class PairingApprovalQueue
             kind == PairingApprovalKind.DevicePair ? devicesProvided : nodesProvided;
 
         var incoming = BuildIncoming(devices, nodes, ownNodeDeviceIds);
+        var ambiguousFallbackKeys = FindAmbiguousFallbackKeys(incoming);
+        if (ambiguousFallbackKeys.Count > 0)
+            incoming = incoming.Where(a => !ambiguousFallbackKeys.Contains(a.Key)).ToList();
+
         var incomingByKey = new Dictionary<string, PendingApproval>(StringComparer.Ordinal);
         foreach (var item in incoming)
             incomingByKey[item.Key] = item; // last wins on duplicate ids
@@ -103,6 +108,11 @@ public sealed class PairingApprovalQueue
         foreach (var kv in _current)
             if (!KindProvided(kv.Value.Kind) && !incomingByKey.ContainsKey(kv.Key))
                 incomingByKey[kv.Key] = kv.Value;
+
+        // If a legacy fallback id becomes ambiguous, cancel any optimistic wait instead of treating
+        // its absence from the actionable queue as a confirmed gateway decision.
+        foreach (var key in _submitted.Keys.Where(ambiguousFallbackKeys.Contains).ToArray())
+            _submitted.Remove(key);
 
         // Confirmed resolutions: decisions we submitted whose request has now left a PROVIDED list.
         // This — not the send-ack — is the authoritative "the gateway accepted it" signal.
@@ -207,6 +217,16 @@ public sealed class PairingApprovalQueue
         }
 
         return list;
+    }
+
+    private static HashSet<string> FindAmbiguousFallbackKeys(IEnumerable<PendingApproval> incoming)
+    {
+        var ambiguous = incoming
+            .GroupBy(a => a.Key, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1 && g.Any(a => string.IsNullOrEmpty(a.RequestId)))
+            .Select(g => g.Key);
+
+        return new HashSet<string>(ambiguous, StringComparer.Ordinal);
     }
 
     private static bool IsOwnNode(PendingApproval approval, IReadOnlyCollection<string>? ownNodeDeviceIds)

--- a/src/OpenClaw.Connection/PairingApprovalQueue.cs
+++ b/src/OpenClaw.Connection/PairingApprovalQueue.cs
@@ -90,8 +90,8 @@ public sealed class PairingApprovalQueue
     {
         var devicesProvided = devices is not null;
         var nodesProvided = nodes is not null;
-        bool KindProvided(PendingApprovalKind kind) =>
-            kind == PendingApprovalKind.Device ? devicesProvided : nodesProvided;
+        bool KindProvided(PairingApprovalKind kind) =>
+            kind == PairingApprovalKind.DevicePair ? devicesProvided : nodesProvided;
 
         var incoming = BuildIncoming(devices, nodes, ownNodeDeviceIds);
         var incomingByKey = new Dictionary<string, PendingApproval>(StringComparer.Ordinal);

--- a/src/OpenClaw.Connection/PairingApprovalQueue.cs
+++ b/src/OpenClaw.Connection/PairingApprovalQueue.cs
@@ -90,8 +90,8 @@ public sealed class PairingApprovalQueue
     {
         var devicesProvided = devices is not null;
         var nodesProvided = nodes is not null;
-        bool KindProvided(PairingApprovalKind kind) =>
-            kind == PairingApprovalKind.Device ? devicesProvided : nodesProvided;
+        bool KindProvided(PendingApprovalKind kind) =>
+            kind == PendingApprovalKind.Device ? devicesProvided : nodesProvided;
 
         var incoming = BuildIncoming(devices, nodes, ownNodeDeviceIds);
         var incomingByKey = new Dictionary<string, PendingApproval>(StringComparer.Ordinal);

--- a/src/OpenClaw.Connection/PairingScopeDescriptions.cs
+++ b/src/OpenClaw.Connection/PairingScopeDescriptions.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenClaw.Connection;
+
+/// <summary>
+/// Maps gateway operator scope identifiers to short, human-readable descriptions so a person
+/// approving a pairing request understands what access they are granting — mirroring the
+/// friendly scope list shown by the macOS pairing prompt.
+///
+/// Returns canonical English fallbacks; the presentation layer may override any entry with a
+/// localized resource keyed by scope before falling back to <see cref="Describe"/>.
+/// </summary>
+public static class PairingScopeDescriptions
+{
+    private static readonly IReadOnlyDictionary<string, string> Map =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["operator.admin"] = "Admin access",
+            ["operator.read"] = "Read OpenClaw data",
+            ["operator.write"] = "Send messages and make changes",
+            ["operator.approvals"] = "Manage approvals",
+            ["operator.pairing"] = "Pair and repair devices",
+            ["operator.talk.secrets"] = "Use Talk credentials",
+        };
+
+    /// <summary>True when a friendly description exists for the scope; false for unknown scopes.</summary>
+    public static bool IsKnown(string scope) =>
+        !string.IsNullOrWhiteSpace(scope) && Map.ContainsKey(scope.Trim());
+
+    /// <summary>
+    /// Returns a friendly description for a scope, or the raw scope string (trimmed) when unknown
+    /// so the approver still sees exactly what was requested rather than nothing.
+    /// </summary>
+    public static string Describe(string scope)
+    {
+        if (string.IsNullOrWhiteSpace(scope)) return string.Empty;
+        var trimmed = scope.Trim();
+        return Map.TryGetValue(trimmed, out var friendly) ? friendly : trimmed;
+    }
+
+    /// <summary>Describes a set of scopes, dropping blanks and de-duplicating while preserving order.</summary>
+    public static IReadOnlyList<string> DescribeAll(IEnumerable<string>? scopes)
+    {
+        if (scopes == null) return Array.Empty<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = new List<string>();
+        foreach (var scope in scopes)
+        {
+            if (string.IsNullOrWhiteSpace(scope)) continue;
+            if (!seen.Add(scope.Trim())) continue;
+            result.Add(Describe(scope));
+        }
+        return result;
+    }
+}

--- a/src/OpenClaw.Connection/PendingApproval.cs
+++ b/src/OpenClaw.Connection/PendingApproval.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenClaw.Shared;
+
+namespace OpenClaw.Connection;
+
+/// <summary>Whether a pending pairing approval is for a device (operator-class client) or a node.</summary>
+public enum PairingApprovalKind
+{
+    Device,
+    Node,
+}
+
+/// <summary>
+/// Unified, UI-agnostic view of a single inbound pairing request that a local operator
+/// (with <c>operator.pairing</c>/<c>operator.admin</c> scope) can approve or reject.
+/// Built from either a <see cref="DevicePairingRequest"/> or a node <see cref="PairingRequest"/>
+/// so the presentation layer can render and act on both kinds uniformly.
+/// </summary>
+public sealed class PendingApproval
+{
+    public PairingApprovalKind Kind { get; init; }
+
+    /// <summary>Gateway request id used to approve/reject. May be empty on legacy gateways.</summary>
+    public string RequestId { get; init; } = "";
+
+    /// <summary>Device id (device requests) or node id (node requests).</summary>
+    public string DeviceId { get; init; } = "";
+
+    public string? DisplayName { get; init; }
+    public string? Platform { get; init; }
+    public string? Role { get; init; }
+
+    /// <summary>Requested operator scopes (device requests only; empty for nodes).</summary>
+    public IReadOnlyList<string> Scopes { get; init; } = Array.Empty<string>();
+
+    public string? RemoteIp { get; init; }
+    public string? Version { get; init; }
+    public bool IsRepair { get; init; }
+    public double Ts { get; init; }
+
+    /// <summary>
+    /// The id passed to the gateway approve/reject RPC. Prefers <see cref="RequestId"/> and
+    /// falls back to <see cref="DeviceId"/> so legacy gateways that omit a request id are still
+    /// actionable (mirrors the per-row fallback already used by the Connection page cards).
+    /// </summary>
+    public string DecisionId => string.IsNullOrEmpty(RequestId) ? DeviceId : RequestId;
+
+    /// <summary>Stable identity for dedup/diffing across list refreshes.</summary>
+    public string Key => $"{Kind}:{DecisionId}";
+
+    /// <summary>True when the request carries no usable id and therefore cannot be acted on.</summary>
+    public bool IsActionable => !string.IsNullOrEmpty(DecisionId);
+
+    public static PendingApproval FromDevice(DevicePairingRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return new PendingApproval
+        {
+            Kind = PairingApprovalKind.Device,
+            RequestId = request.RequestId,
+            DeviceId = request.DeviceId,
+            DisplayName = request.DisplayName,
+            Platform = request.Platform,
+            Role = string.IsNullOrWhiteSpace(request.Role) ? "operator" : request.Role,
+            Scopes = request.Scopes is { Length: > 0 }
+                ? request.Scopes.Where(s => !string.IsNullOrWhiteSpace(s)).ToArray()
+                : Array.Empty<string>(),
+            RemoteIp = NormalizeIp(request.RemoteIp),
+            IsRepair = request.IsRepair,
+            Ts = request.Ts,
+        };
+    }
+
+    public static PendingApproval FromNode(PairingRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return new PendingApproval
+        {
+            Kind = PairingApprovalKind.Node,
+            RequestId = request.RequestId,
+            DeviceId = request.NodeId,
+            DisplayName = request.DisplayName,
+            Platform = request.Platform,
+            Role = "node",
+            Scopes = Array.Empty<string>(),
+            RemoteIp = NormalizeIp(request.RemoteIp),
+            Version = request.Version,
+            IsRepair = request.IsRepair,
+            Ts = request.Ts,
+        };
+    }
+
+    /// <summary>Strips the IPv4-mapped IPv6 prefix the gateway sometimes emits (mirrors the Mac client).</summary>
+    private static string? NormalizeIp(string? ip)
+    {
+        if (string.IsNullOrWhiteSpace(ip)) return ip;
+        const string mappedPrefix = "::ffff:";
+        return ip.StartsWith(mappedPrefix, StringComparison.OrdinalIgnoreCase)
+            ? ip[mappedPrefix.Length..]
+            : ip;
+    }
+}

--- a/src/OpenClaw.Connection/PendingApproval.cs
+++ b/src/OpenClaw.Connection/PendingApproval.cs
@@ -5,13 +5,6 @@ using OpenClaw.Shared;
 
 namespace OpenClaw.Connection;
 
-/// <summary>Whether a pending pairing approval is for a device (operator-class client) or a node.</summary>
-public enum PendingApprovalKind
-{
-    Device,
-    Node,
-}
-
 /// <summary>
 /// Unified, UI-agnostic view of a single inbound pairing request that a local operator
 /// (with <c>operator.pairing</c>/<c>operator.admin</c> scope) can approve or reject.
@@ -20,7 +13,7 @@ public enum PendingApprovalKind
 /// </summary>
 public sealed class PendingApproval
 {
-    public PendingApprovalKind Kind { get; init; }
+    public PairingApprovalKind Kind { get; init; }
 
     /// <summary>Gateway request id used to approve/reject. May be empty on legacy gateways.</summary>
     public string RequestId { get; init; } = "";
@@ -58,7 +51,7 @@ public sealed class PendingApproval
         ArgumentNullException.ThrowIfNull(request);
         return new PendingApproval
         {
-            Kind = PendingApprovalKind.Device,
+            Kind = PairingApprovalKind.DevicePair,
             RequestId = request.RequestId,
             DeviceId = request.DeviceId,
             DisplayName = request.DisplayName,
@@ -78,7 +71,7 @@ public sealed class PendingApproval
         ArgumentNullException.ThrowIfNull(request);
         return new PendingApproval
         {
-            Kind = PendingApprovalKind.Node,
+            Kind = PairingApprovalKind.NodePair,
             RequestId = request.RequestId,
             DeviceId = request.NodeId,
             DisplayName = request.DisplayName,

--- a/src/OpenClaw.Connection/PendingApproval.cs
+++ b/src/OpenClaw.Connection/PendingApproval.cs
@@ -6,7 +6,7 @@ using OpenClaw.Shared;
 namespace OpenClaw.Connection;
 
 /// <summary>Whether a pending pairing approval is for a device (operator-class client) or a node.</summary>
-public enum PairingApprovalKind
+public enum PendingApprovalKind
 {
     Device,
     Node,
@@ -20,7 +20,7 @@ public enum PairingApprovalKind
 /// </summary>
 public sealed class PendingApproval
 {
-    public PairingApprovalKind Kind { get; init; }
+    public PendingApprovalKind Kind { get; init; }
 
     /// <summary>Gateway request id used to approve/reject. May be empty on legacy gateways.</summary>
     public string RequestId { get; init; } = "";
@@ -58,7 +58,7 @@ public sealed class PendingApproval
         ArgumentNullException.ThrowIfNull(request);
         return new PendingApproval
         {
-            Kind = PairingApprovalKind.Device,
+            Kind = PendingApprovalKind.Device,
             RequestId = request.RequestId,
             DeviceId = request.DeviceId,
             DisplayName = request.DisplayName,
@@ -78,7 +78,7 @@ public sealed class PendingApproval
         ArgumentNullException.ThrowIfNull(request);
         return new PendingApproval
         {
-            Kind = PairingApprovalKind.Node,
+            Kind = PendingApprovalKind.Node,
             RequestId = request.RequestId,
             DeviceId = request.NodeId,
             DisplayName = request.DisplayName,

--- a/src/OpenClaw.Shared/Mxc/DirectAppContainerExecutor.cs
+++ b/src/OpenClaw.Shared/Mxc/DirectAppContainerExecutor.cs
@@ -43,12 +43,18 @@ public sealed class DirectAppContainerExecutor : ISandboxExecutor
     /// </summary>
     private const int Base64ConfigCharLimit = 25_000;
 
-    private readonly MxcAvailability _availability;
+    private readonly Func<MxcAvailability> _availabilityProvider;
     private readonly IOpenClawLogger _logger;
 
-    public DirectAppContainerExecutor(MxcAvailability availability, IOpenClawLogger? logger = null)
+    /// <summary>
+    /// Resolves availability lazily via <paramref name="availabilityProvider"/> so the
+    /// executor always sees the current probe verdict. A fixed snapshot would freeze a
+    /// startup probe error for the executor's lifetime even after the host recovers
+    /// (the re-probe would update the caller's gate but not this executor).
+    /// </summary>
+    public DirectAppContainerExecutor(Func<MxcAvailability> availabilityProvider, IOpenClawLogger? logger = null)
     {
-        _availability = availability;
+        _availabilityProvider = availabilityProvider ?? throw new ArgumentNullException(nameof(availabilityProvider));
         _logger = logger ?? NullLogger.Instance;
     }
 
@@ -56,11 +62,15 @@ public sealed class DirectAppContainerExecutor : ISandboxExecutor
         SandboxExecutionRequest request,
         CancellationToken ct = default)
     {
-        if (!_availability.IsAppContainerAvailable)
-            throw new SandboxUnavailableException(
-                _availability.UnsupportedReasons.FirstOrDefault() ?? "AppContainer unavailable");
+        // Resolve the live availability for THIS invocation so a transient startup
+        // probe error that has since recovered doesn't permanently fail us closed.
+        var availability = _availabilityProvider();
 
-        if (!_availability.IsWxcExecResolvable || string.IsNullOrEmpty(_availability.WxcExecPath))
+        if (!availability.IsAppContainerAvailable)
+            throw new SandboxUnavailableException(
+                availability.UnsupportedReasons.FirstOrDefault() ?? "AppContainer unavailable");
+
+        if (!availability.IsWxcExecResolvable || string.IsNullOrEmpty(availability.WxcExecPath))
             throw new SandboxUnavailableException("wxc-exec.exe not found");
 
         var capBytes = request.MaxOutputBytes is > 0 ? request.MaxOutputBytes.Value : DefaultMaxOutputBytes;
@@ -78,16 +88,16 @@ public sealed class DirectAppContainerExecutor : ISandboxExecutor
                 : config.Process.Cwd;
 
             WarnIfUnsupportedVolume(config);
-            LogConfig(config, configJson, request);
+            LogConfig(config, configJson, request, availability.WxcExecPath);
 
             MxcExecutor executor;
             try
             {
-                executor = new MxcExecutor(_availability.WxcExecPath, stdoutCapBytes: capInt, stderrCapBytes: capInt);
+                executor = new MxcExecutor(availability.WxcExecPath, stdoutCapBytes: capInt, stderrCapBytes: capInt);
             }
             catch (FileNotFoundException ex)
             {
-                throw new SandboxUnavailableException($"wxc-exec.exe not found at {_availability.WxcExecPath}", ex);
+                throw new SandboxUnavailableException($"wxc-exec.exe not found at {availability.WxcExecPath}", ex);
             }
 
             // Local timeout + caller cancellation. Mirror the builder's
@@ -180,7 +190,7 @@ public sealed class DirectAppContainerExecutor : ISandboxExecutor
         catch (Exception ex) { Trace.WriteLine($"DirectAppContainerExecutor.TryDeleteDir '{path}' (best-effort) failed: {ex.Message}"); }
     }
 
-    private void LogConfig(MxcConfig config, string configJson, SandboxExecutionRequest request)
+    private void LogConfig(MxcConfig config, string configJson, SandboxExecutionRequest request, string? wxcExecPath)
     {
         // Default: redacted summary. Field counts only; no paths, no command line,
         // no env values. Useful for verifying Sandbox UI settings round-tripped
@@ -192,13 +202,13 @@ public sealed class DirectAppContainerExecutor : ISandboxExecutor
 
         var summary =
             "[mxc] wxc-exec config (redacted) " +
-            $"wxcExec={_availability.WxcExecPath}; configBytes={Encoding.UTF8.GetByteCount(configJson)}; " +
+            $"wxcExec={wxcExecPath}; configBytes={Encoding.UTF8.GetByteCount(configJson)}; " +
             $"containerId={config.ContainerId}; version={config.Version}; " +
             $"commandLineLength={config.Process.CommandLine?.Length ?? 0}; " +
             $"cwd={(string.IsNullOrEmpty(config.Process.Cwd) ? "<null>" : "<set>")}; " +
             $"envKeys=[{string.Join(",", envKeys)}]; " +
             $"timeoutMs={config.Process.TimeoutMs?.ToString() ?? "<null>"}; " +
-            $"capabilities=[{string.Join(",", config.AppContainer?.Capabilities ?? Array.Empty<string>())}]; " +
+            $"capabilities=[{string.Join(",", config.ProcessContainer?.Capabilities ?? Array.Empty<string>())}]; " +
             $"readonlyCount={config.Filesystem?.ReadonlyPaths?.Length ?? 0}; " +
             $"readwriteCount={config.Filesystem?.ReadwritePaths?.Length ?? 0}; " +
             $"deniedCount={config.Filesystem?.DeniedPaths?.Length ?? 0}; " +

--- a/src/OpenClaw.Shared/Mxc/MxcAvailability.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcAvailability.cs
@@ -1,16 +1,21 @@
-using Microsoft.Win32;
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
 
 namespace OpenClaw.Shared.Mxc;
 
 /// <summary>
-/// Per-backend availability probe for MXC. Cached for the process lifetime.
+/// Per-backend availability probe for MXC. <see cref="Probe"/> is intended to be
+/// called once and its result cached by the caller (see NodeService).
 /// </summary>
 /// <remarks>
 /// Backends checked:
 /// <list type="bullet">
-/// <item><see cref="IsAppContainerAvailable"/> — Windows 11 build 26300 with UBR &gt;= 8289, x64 / arm64.</item>
+/// <item><see cref="IsAppContainerAvailable"/> — the native <c>wxc-exec --probe</c>
+///   reports a usable isolation tier on this host. This is the source of truth
+///   for "does this machine support the sandbox".</item>
 /// <item><see cref="IsWxcExecResolvable"/> — wxc-exec.exe found in the shipped tray output layout or via override.</item>
-/// <item><see cref="IsIsolationSessionAvailable"/> — requires AppContainer plus IsolationProxy.exe in System32.</item>
+/// <item><see cref="IsIsolationSessionAvailable"/> — requires a supported host plus IsolationProxy.exe in System32.</item>
 /// </list>
 /// </remarks>
 public sealed class MxcAvailability
@@ -22,14 +27,18 @@ public sealed class MxcAvailability
     /// </summary>
     public const string WxcExecOverrideEnvVar = "OPENCLAW_WXC_EXEC";
 
-    private const int SupportedBuild = 26300;
-
-    // TODO: This is all temporary and a moment in time; feature gate this correctly ASAP.
     /// <summary>
-    /// Temporary MXC support table: only build 26300 with UBR 8289+ is enabled.
-    /// All other builds are blocked until validated and the table is updated.
+    /// Bound on how long we wait for <c>wxc-exec --probe</c> before treating the
+    /// host as unable to run the sandbox.
     /// </summary>
-    private const int MinSupportedUbr = 8289;
+    private const int ProbeTimeoutMs = 15_000;
+
+    /// <summary>
+    /// Minimum time allowed for draining stdout/stderr after the probe process
+    /// exits, so a process that exits right at the deadline doesn't false-timeout
+    /// while its (tiny) output is still being read.
+    /// </summary>
+    private const int MinReadDrainMs = 2_000;
 
     public bool IsAppContainerAvailable { get; }
     public bool IsIsolationSessionAvailable { get; }
@@ -37,10 +46,41 @@ public sealed class MxcAvailability
     public string? WxcExecPath { get; }
 
     /// <summary>
+    /// True when the availability verdict came from a <em>probe error</em>
+    /// (timeout, failure to launch <c>wxc-exec</c>, or unparseable output) rather
+    /// than a definitive answer (supported, or the host reporting unsupported).
+    /// Callers should treat an errored verdict as transient — re-probe instead of
+    /// caching it for the process lifetime — so a momentary glitch doesn't pin the
+    /// whole process to uncontained execution.
+    /// </summary>
+    public bool ProbeErrored { get; }
+
+    /// <summary>
+    /// Isolation tier the probe selected for this host (e.g. <c>base-container</c>,
+    /// <c>appcontainer-bfs</c>, <c>appcontainer-dacl</c>), or null when unsupported
+    /// / not probed. Informational; <see cref="IsDegradedContainment"/> is the
+    /// derived signal UX should react to.
+    /// </summary>
+    public string? IsolationTier { get; }
+
+    /// <summary>
+    /// True when the probe indicated the host needs host-DACL augmentation to
+    /// contain (a weaker, last-resort path).
+    /// </summary>
+    public bool NeedsDaclAugmentation { get; }
+
+    /// <summary>
     /// Human-readable list of reasons MXC may not be available. Empty when fully supported.
     /// Surface to UX so users know why the sandbox toggle is disabled.
     /// </summary>
     public IReadOnlyList<string> UnsupportedReasons { get; }
+
+    /// <summary>Tiers we consider full-strength containment. Anything else that
+    /// still contains (e.g. <c>appcontainer-dacl</c>, or an unrecognized future
+    /// tier string) is treated as degraded so UX can warn without dropping the
+    /// host all the way to uncontained.</summary>
+    private static readonly HashSet<string> FullStrengthTiers =
+        new(StringComparer.OrdinalIgnoreCase) { "base-container", "appcontainer-bfs" };
 
     /// <summary>True iff at least one MXC backend is supported AND
     /// <c>wxc-exec.exe</c> is resolvable. (Without wxc-exec the executor will refuse
@@ -49,25 +89,55 @@ public sealed class MxcAvailability
         (IsAppContainerAvailable || IsIsolationSessionAvailable)
         && IsWxcExecResolvable;
 
+    /// <summary>
+    /// True when MXC is available but only via a weaker, last-resort isolation tier
+    /// (DACL augmentation, or a tier we don't recognize as full-strength). Still
+    /// contained — surface as a warning, not a block; refusing would drop the host
+    /// to fully uncontained execution, which is strictly worse.
+    /// </summary>
+    public bool IsDegradedContainment =>
+        HasAnyBackend
+        && (NeedsDaclAugmentation
+            || string.IsNullOrEmpty(IsolationTier)
+            || !FullStrengthTiers.Contains(IsolationTier));
+
     public MxcAvailability(
         bool isAppContainerAvailable,
         bool isIsolationSessionAvailable,
         bool isWxcExecResolvable,
         string? wxcExecPath,
-        IReadOnlyList<string> unsupportedReasons)
+        IReadOnlyList<string> unsupportedReasons,
+        bool probeErrored = false,
+        string? isolationTier = null,
+        bool needsDaclAugmentation = false)
     {
         IsAppContainerAvailable = isAppContainerAvailable;
         IsIsolationSessionAvailable = isIsolationSessionAvailable;
         IsWxcExecResolvable = isWxcExecResolvable;
         WxcExecPath = wxcExecPath;
         UnsupportedReasons = unsupportedReasons;
+        ProbeErrored = probeErrored;
+        IsolationTier = isolationTier;
+        NeedsDaclAugmentation = needsDaclAugmentation;
     }
 
     /// <summary>
     /// Probe the running environment. Designed to be called once at app startup
-    /// and the result cached.
+    /// and the result cached. Host support is determined by the native
+    /// <c>wxc-exec --probe</c> command rather than a hardcoded build/UBR table,
+    /// so newer Windows builds light up automatically without a code change.
     /// </summary>
     public static MxcAvailability Probe(IOpenClawLogger? logger = null)
+        => Probe(logger, probeRunner: null);
+
+    /// <summary>
+    /// Test seam for <see cref="Probe(IOpenClawLogger?)"/>. <paramref name="probeRunner"/>
+    /// substitutes the <c>wxc-exec --probe</c> invocation; production passes
+    /// <c>null</c> to spawn the real process.
+    /// </summary>
+    internal static MxcAvailability Probe(
+        IOpenClawLogger? logger,
+        Func<string, WxcProbeInvocation>? probeRunner)
     {
         var log = logger ?? NullLogger.Instance;
         var reasons = new List<string>();
@@ -78,80 +148,269 @@ public sealed class MxcAvailability
             return new MxcAvailability(false, false, false, null, reasons);
         }
 
-        var (build, ubr) = ReadWindowsBuildAndUbr();
-        var windowsSupportReason = GetWindowsBuildUnsupportedReason(build, ubr);
-        if (windowsSupportReason is not null)
-            reasons.Add(windowsSupportReason);
-
-        var isAppContainerSupported = windowsSupportReason is null;
-
+        // wxc-exec is the source of truth for host support, so resolve it first.
+        // Without the binary we cannot probe and therefore report unavailable.
         var (wxcResolvable, wxcPath) = ResolveWxcExec();
-        if (!wxcResolvable)
+        if (!wxcResolvable || string.IsNullOrEmpty(wxcPath))
+        {
             reasons.Add($"wxc-exec.exe not found. Set {WxcExecOverrideEnvVar} or build the tray app to copy it into the output folder.");
+            return new MxcAvailability(false, false, false, null, reasons);
+        }
+
+        // Ask the native binary whether this host can run the sandbox and at what
+        // isolation tier.
+        WxcProbeInvocation invocation;
+        try
+        {
+            invocation = (probeRunner ?? RunWxcExecProbe)(wxcPath);
+        }
+        catch (Exception ex)
+        {
+            invocation = new WxcProbeInvocation(WxcProbeStatus.LaunchFailed, 0, string.Empty, $"Failed to launch wxc-exec --probe: {ex.Message}");
+        }
+
+        var probe = ParseProbeOutput(invocation.Status, invocation.ExitCode, invocation.StdOut, invocation.StdErr);
+        var isAppContainerSupported = probe.Supported;
+        if (!isAppContainerSupported)
+            reasons.Add(probe.FailureReason ?? "This Windows host does not support the MXC sandbox (wxc-exec --probe reported no usable tier).");
 
         // isolation_session additionally requires Feature_IsoBrokerSessionApis on the OS
         // and IsolationProxy.exe in System32. We currently only check file presence.
         var isolationProxyPath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.System),
             "IsolationProxy.exe");
-        var isIsolationSessionSupported = isAppContainerSupported
-            && wxcResolvable
-            && File.Exists(isolationProxyPath);
+        var isIsolationSessionSupported = isAppContainerSupported && File.Exists(isolationProxyPath);
+
+        var probeErrored = probe.Outcome == MxcProbeOutcome.ProbeError;
 
         log.Info(
-            $"[mxc] availability: appcontainer={isAppContainerSupported} " +
+            $"[mxc] availability: supported={isAppContainerSupported} " +
+            $"outcome={probe.Outcome} " +
+            $"tier={probe.Tier ?? "<none>"} needsDaclAugmentation={probe.NeedsDaclAugmentation} " +
             $"isolation_session={isIsolationSessionSupported} " +
-            $"wxc-exec={(wxcResolvable ? wxcPath : "<missing>")} " +
+            $"wxc-exec={wxcPath} " +
+            $"warnings=[{string.Join(", ", probe.Warnings)}] " +
             $"reasons=[{string.Join(", ", reasons)}]");
 
         return new MxcAvailability(
             isAppContainerSupported,
             isIsolationSessionSupported,
-            wxcResolvable,
+            isWxcExecResolvable: true,
             wxcPath,
-            reasons);
+            reasons,
+            probeErrored: probeErrored,
+            isolationTier: probe.Tier,
+            needsDaclAugmentation: probe.NeedsDaclAugmentation);
     }
 
-    internal static string? GetWindowsBuildUnsupportedReason(int build, int ubr)
+    /// <summary>
+    /// Parse the result of a <c>wxc-exec --probe</c> attempt into a support verdict,
+    /// classifying the outcome as <see cref="MxcProbeOutcome.Supported"/>,
+    /// <see cref="MxcProbeOutcome.UnsupportedHost"/> (the binary ran to completion and
+    /// reported no usable tier), or <see cref="MxcProbeOutcome.ProbeError"/> (we could
+    /// not get a verdict: timeout, launch failure, or a completed run with no usable
+    /// output). Probe errors are transient and should be re-probed, not cached.
+    /// Exposed for unit testing.
+    /// </summary>
+    internal static MxcProbeResult ParseProbeOutput(WxcProbeStatus status, int exitCode, string? stdout, string? stderr)
     {
-        if (build != SupportedBuild)
-            return $"Windows build {build} is not MXC supported build {SupportedBuild}.";
-
-        if (ubr < MinSupportedUbr)
+        // We never obtained a verdict — our own infrastructure failure, not a host
+        // decision. Always transient/retryable, regardless of any exit code.
+        if (status != WxcProbeStatus.Completed)
         {
-            return
-                $"Windows UBR {ubr} below MXC minimum {MinSupportedUbr} " +
-                $"(for build {SupportedBuild}). " +
-                "Install latest cumulative update.";
+            var detail = FirstNonEmpty(stderr, stdout);
+            var what = status == WxcProbeStatus.TimedOut ? "timed out" : "could not be launched";
+            return Error(
+                $"Could not determine MXC sandbox support (wxc-exec --probe {what}{(detail is null ? "" : $": {Summarize(detail)}")}).");
         }
 
-        return null;
-    }
-
-    private static (int build, int ubr) ReadWindowsBuildAndUbr()
-    {
-        var build = Environment.OSVersion.Version.Build;
-        var ubr = 0;
-        if (!OperatingSystem.IsWindows())
-            return (build, ubr);
+        // No/garbled output is a binary anomaly, not a clear answer —
+        // treat as a (retryable) probe error rather than silently "unsupported".
+        if (string.IsNullOrWhiteSpace(stdout))
+        {
+            var detail = FirstNonEmpty(stderr);
+            return Error(
+                $"Could not determine MXC sandbox support (wxc-exec --probe {(exitCode == 0 ? "returned no output" : $"exited {exitCode}")}{(detail is null ? "" : $": {Summarize(detail)}")}).");
+        }
 
         try
         {
-#pragma warning disable CA1416 // OperatingSystem.IsWindows() guard above; analyzer doesn't recognize it through callee.
-            using var key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
-            var value = key?.GetValue("UBR");
-            if (value is int ubrInt)
-                ubr = ubrInt;
-#pragma warning restore CA1416
+            using var doc = JsonDocument.Parse(stdout);
+            var root = doc.RootElement;
+            var warnings = ReadWarnings(root);
+
+            if (TryGetString(root, "error") is { } error)
+            {
+                return Unsupported(
+                    $"This Windows host does not support the MXC sandbox (wxc-exec --probe reported: {Summarize(error)}).",
+                    warnings);
+            }
+
+            if (root.TryGetProperty("supported", out var supportedEl)
+                && supportedEl.ValueKind == JsonValueKind.False)
+            {
+                return Unsupported(
+                    "This Windows host does not support the MXC sandbox (wxc-exec --probe reported no usable isolation tier).",
+                    warnings);
+            }
+
+            if (exitCode != 0)
+            {
+                var detail = FirstNonEmpty(stderr, stdout);
+                return Error(
+                    $"Could not determine MXC sandbox support (wxc-exec --probe exited {exitCode}{(detail is null ? "" : $": {Summarize(detail)}")}).");
+            }
+
+            if (root.ValueKind != JsonValueKind.Object
+                || !root.TryGetProperty("tier", out var tierEl)
+                || tierEl.ValueKind != JsonValueKind.String
+                || string.IsNullOrWhiteSpace(tierEl.GetString()))
+            {
+                return Error("Could not determine MXC sandbox support (wxc-exec --probe did not report an isolation tier).");
+            }
+
+            var needsDacl = root.TryGetProperty("needsDaclAugmentation", out var d)
+                && d.ValueKind == JsonValueKind.True;
+
+            return new MxcProbeResult(MxcProbeOutcome.Supported, tierEl.GetString(), needsDacl, warnings, null);
         }
-        // slopwatch-ignore: SW003 Audited non-critical fallback is intentional and the caller preserves safe behavior without this work.
-        catch
+        catch (JsonException ex)
         {
-            // Best-effort registry read; failure leaves ubr = 0 which fails the gate.
+            var detail = FirstNonEmpty(stderr, stdout);
+            return Error(
+                $"Could not determine MXC sandbox support (wxc-exec --probe {(exitCode == 0 ? "returned unparseable output" : $"exited {exitCode}")}: {Summarize(detail ?? ex.Message)}).");
         }
 
-        return (build, ubr);
+        static MxcProbeResult Unsupported(string reason, IReadOnlyList<string>? warnings = null) =>
+            new(MxcProbeOutcome.UnsupportedHost, null, false, warnings ?? Array.Empty<string>(), reason);
+
+        static MxcProbeResult Error(string reason) =>
+            new(MxcProbeOutcome.ProbeError, null, false, Array.Empty<string>(), reason);
+
+        static string? TryGetString(JsonElement root, string propertyName)
+        {
+            if (root.ValueKind != JsonValueKind.Object
+                || !root.TryGetProperty(propertyName, out var property)
+                || property.ValueKind != JsonValueKind.String)
+            {
+                return null;
+            }
+
+            var value = property.GetString();
+            return string.IsNullOrWhiteSpace(value) ? null : value;
+        }
+
+        static List<string> ReadWarnings(JsonElement root)
+        {
+            var warnings = new List<string>();
+            if (root.ValueKind != JsonValueKind.Object
+                || !root.TryGetProperty("warnings", out var w)
+                || w.ValueKind != JsonValueKind.Array)
+            {
+                return warnings;
+            }
+
+            foreach (var item in w.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.String) continue;
+                var s = item.GetString();
+                if (!string.IsNullOrWhiteSpace(s)) warnings.Add(s);
+            }
+
+            return warnings;
+        }
     }
+
+    private static string? FirstNonEmpty(params string?[] values)
+    {
+        foreach (var v in values)
+            if (!string.IsNullOrWhiteSpace(v)) return v!.Trim();
+        return null;
+    }
+
+    private static string Summarize(string text)
+    {
+        var collapsed = text.Replace("\r", " ").Replace("\n", " ").Trim();
+        return collapsed.Length <= 200 ? collapsed : collapsed[..200] + "…";
+    }
+
+    /// <summary>
+    /// Spawn <c>wxc-exec --probe</c> and capture its exit code and output.
+    /// Bounded by <see cref="ProbeTimeoutMs"/>; a timeout reports a non-zero exit.
+    /// </summary>
+    private static WxcProbeInvocation RunWxcExecProbe(string wxcExecPath)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = wxcExecPath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
+            },
+        };
+        process.StartInfo.ArgumentList.Add("--probe");
+
+        process.Start();
+        // Read both pipes async to avoid a full-pipe deadlock.
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+
+        var sw = Stopwatch.StartNew();
+        if (!process.WaitForExit(ProbeTimeoutMs))
+            return KillAndTimeout(process, stdoutTask, stderrTask);
+
+        // WaitForExit(int) returns as soon as the immediate child exits, but the
+        // async readers only complete once the WRITE end of each pipe closes. If
+        // wxc-exec spawned a descendant that inherited the redirected handles
+        // (the SDK ships sandbox daemon/guest helpers), the pipes can stay open
+        // after the child exits and an unbounded GetResult() would hang past the
+        // timeout. So bound the drain with whatever time is left in the budget
+        // (with a small floor so a near-deadline exit doesn't false-timeout).
+        var elapsedMs = (int)Math.Min(sw.ElapsedMilliseconds, ProbeTimeoutMs);
+        var drainBudgetMs = Math.Max(ProbeTimeoutMs - elapsedMs, MinReadDrainMs);
+        try
+        {
+            if (!Task.WhenAll(stdoutTask, stderrTask).Wait(drainBudgetMs))
+                return KillAndTimeout(process, stdoutTask, stderrTask);
+        }
+        catch (AggregateException)
+        {
+            // A pipe read faulted (e.g. stream disposed). Treat as no output;
+            // ParseProbeOutput classifies exit 0 with empty stdout as a (retryable)
+            // probe error, and surfaces stderr if the exit code was non-zero.
+        }
+
+        return new WxcProbeInvocation(
+            WxcProbeStatus.Completed,
+            process.ExitCode,
+            stdoutTask.Status == TaskStatus.RanToCompletion ? stdoutTask.Result : string.Empty,
+            stderrTask.Status == TaskStatus.RanToCompletion ? stderrTask.Result : string.Empty);
+    }
+
+    /// <summary>
+    /// Kill the probe process tree and return a timeout invocation. Observes the
+    /// abandoned read tasks so a later fault doesn't surface as an unobserved
+    /// task exception when the process/streams are disposed.
+    /// </summary>
+    private static WxcProbeInvocation KillAndTimeout(Process process, Task stdoutTask, Task stderrTask)
+    {
+        try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+        ObserveQuietly(stdoutTask);
+        ObserveQuietly(stderrTask);
+        return new WxcProbeInvocation(WxcProbeStatus.TimedOut, 0, string.Empty, "wxc-exec --probe timed out.");
+    }
+
+    private static void ObserveQuietly(Task task) =>
+        _ = task.ContinueWith(
+            static t => { _ = t.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
 
     private static (bool resolvable, string? path) ResolveWxcExec()
     {
@@ -195,4 +454,53 @@ public sealed class MxcAvailability
         System.Runtime.InteropServices.Architecture.X64 => "x64",
         _ => "x64",
     };
+}
+
+/// <summary>Outcome of attempting to run <c>wxc-exec --probe</c> (distinct from the
+/// host verdict it produces). Lets us tell our own infrastructure failures
+/// (timeout / launch failure) apart from a process that actually completed.</summary>
+internal enum WxcProbeStatus
+{
+    /// <summary>The process ran to completion; <c>ExitCode</c> and output are meaningful.</summary>
+    Completed,
+
+    /// <summary>The process did not exit within the timeout and was killed.</summary>
+    TimedOut,
+
+    /// <summary>The process could not be started at all.</summary>
+    LaunchFailed,
+}
+
+/// <summary>Raw result of invoking <c>wxc-exec --probe</c>. <c>ExitCode</c> is only
+/// meaningful when <c>Status</c> is <see cref="WxcProbeStatus.Completed"/>.</summary>
+internal readonly record struct WxcProbeInvocation(WxcProbeStatus Status, int ExitCode, string StdOut, string StdErr);
+
+/// <summary>
+/// Classification of a <c>wxc-exec --probe</c> attempt.
+/// </summary>
+internal enum MxcProbeOutcome
+{
+    /// <summary>The probe ran and reported a usable isolation tier.</summary>
+    Supported,
+
+    /// <summary>The probe ran and definitively reported the host cannot sandbox.</summary>
+    UnsupportedHost,
+
+    /// <summary>
+    /// We could not obtain a verdict (timeout, failure to launch, or exit 0 with
+    /// no usable output). Transient/indeterminate — should be re-probed, not cached.
+    /// </summary>
+    ProbeError,
+}
+
+/// <summary>Parsed host-support verdict derived from <c>wxc-exec --probe</c> output.</summary>
+internal sealed record MxcProbeResult(
+    MxcProbeOutcome Outcome,
+    string? Tier,
+    bool NeedsDaclAugmentation,
+    IReadOnlyList<string> Warnings,
+    string? FailureReason)
+{
+    /// <summary>Convenience: true only for <see cref="MxcProbeOutcome.Supported"/>.</summary>
+    public bool Supported => Outcome == MxcProbeOutcome.Supported;
 }

--- a/src/OpenClaw.Shared/Mxc/MxcCommandRunner.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcCommandRunner.cs
@@ -51,23 +51,24 @@ public sealed class MxcCommandRunner : ICommandRunner
     {
         var settings = _settingsProvider();
 
-        // When MXC sandboxing isn't available on this host (e.g. Windows 10,
-        // build != 26300, UBR < 8289, or missing wxc-exec.exe), fall back to the host runner
-        // so the agent can still execute commands instead of being completely
-        // blocked. The Sandbox page is read-only in that state and tells the
-        // user their commands are running uncontained.
+        if (!settings.SystemRunSandboxEnabled)
+        {
+            _logger.Info("[mxc] sandbox=disabled; routing system.run through host runner");
+            return await _hostFallback.RunAsync(request, ct);
+        }
+
+        // When MXC sandboxing isn't available on this host (e.g. Windows 10, an
+        // older build whose wxc-exec --probe reports no usable isolation tier, or
+        // missing wxc-exec.exe), fall back to the host runner so the agent can
+        // still execute commands instead of being completely blocked. The Sandbox
+        // page is read-only in that state and tells the user their commands are
+        // running uncontained.
         if (!_isSandboxAvailable())
         {
             _logger.Warn(
                 "[mxc] system.run UNCONTAINED: sandbox unavailable on this host. " +
                 "Commands will run on the host without containment. " +
                 "Update Windows to enable sandboxing.");
-            return await _hostFallback.RunAsync(request, ct);
-        }
-
-        if (!settings.SystemRunSandboxEnabled)
-        {
-            _logger.Info("[mxc] sandbox=disabled; routing system.run through host runner");
             return await _hostFallback.RunAsync(request, ct);
         }
 

--- a/src/OpenClaw.Shared/Mxc/MxcConfig.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcConfig.cs
@@ -22,9 +22,9 @@ public sealed record MxcConfig
     [JsonPropertyName("process")]
     public required MxcProcess Process { get; init; }
 
-    [JsonPropertyName("appContainer")]
+    [JsonPropertyName("processContainer")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public MxcAppContainer? AppContainer { get; init; }
+    public MxcProcessContainer? ProcessContainer { get; init; }
 
     [JsonPropertyName("filesystem")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -61,7 +61,7 @@ public sealed record MxcProcess
     public int? TimeoutMs { get; init; }
 }
 
-public sealed record MxcAppContainer
+public sealed record MxcProcessContainer
 {
     [JsonPropertyName("capabilities")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/OpenClaw.Shared/Mxc/MxcConfigBuilder.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcConfigBuilder.cs
@@ -116,7 +116,7 @@ public static class MxcConfigBuilder
             Injection = false,
         };
 
-        var appContainerUi = new MxcBaseProcessUi
+        var processContainerUi = new MxcBaseProcessUi
         {
             Isolation = "container",
             DesktopSystemControl = false,
@@ -129,7 +129,7 @@ public static class MxcConfigBuilder
             Version = MxcPolicyBuilder.SupportedPolicyVersion,
             ContainerId = containerId ?? Guid.NewGuid().ToString("N"),
             // Top-level "containment" is intentionally omitted; the SDK doesn't
-            // emit it either. Isolation lives in appContainer.ui.isolation.
+            // emit it either. Isolation lives in processContainer.ui.isolation.
             Process = new MxcProcess
             {
                 CommandLine = commandLine,
@@ -137,11 +137,11 @@ public static class MxcConfigBuilder
                 Env = env,
                 TimeoutMs = timeoutMs,
             },
-            AppContainer = new MxcAppContainer
+            ProcessContainer = new MxcProcessContainer
             {
                 LeastPrivilege = false,
                 Capabilities = capabilities.ToArray(),
-                Ui = appContainerUi,
+                Ui = processContainerUi,
             },
             Filesystem = new MxcFilesystem
             {

--- a/src/OpenClaw.Shared/Mxc/MxcPolicyBuilder.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcPolicyBuilder.cs
@@ -25,9 +25,9 @@ namespace OpenClaw.Shared.Mxc;
 public static class MxcPolicyBuilder
 {
     /// <summary>
-    /// Policy schema version. @microsoft/mxc-sdk 0.1.8 accepts 0.4.0-alpha
-    /// through 0.5.0-alpha; keep the documented 0.4.0-alpha schema until we
-    /// intentionally adopt a newer MXC policy contract.
+    /// Policy schema version. @microsoft/mxc-sdk 0.7.0 still lists 0.4.0-alpha as a
+    /// supported (stable) config schema; keep the documented 0.4.0-alpha schema
+    /// until we intentionally adopt a newer MXC policy contract.
     /// </summary>
     public const string SupportedPolicyVersion = "0.4.0-alpha";
 

--- a/src/OpenClaw.Shared/SettingsData.cs
+++ b/src/OpenClaw.Shared/SettingsData.cs
@@ -33,6 +33,12 @@ public record class SettingsData
     public bool NotifyBuild { get; set; } = true;
     public bool NotifyStock { get; set; } = true;
     public bool NotifyInfo { get; set; } = true;
+    /// <summary>
+    /// When true (default), inbound device/node pairing requests are surfaced as a focused
+    /// approval dialog plus an awareness toast. When false they appear only in the Connections
+    /// page "Pending approvals" banner (passive). Auto-approval of the local node is unaffected.
+    /// </summary>
+    public bool ShowPairingApprovalDialog { get; set; } = true;
     public bool EnableNodeMode { get; set; } = false;
     public bool NodeCanvasEnabled { get; set; } = true;
     public bool NodeScreenEnabled { get; set; } = true;

--- a/src/OpenClaw.Tray.WinUI/App.ToastActivation.cs
+++ b/src/OpenClaw.Tray.WinUI/App.ToastActivation.cs
@@ -36,7 +36,8 @@ public partial class App
                     _toastService!.ShowToast(new ToastContentBuilder()
                         .AddText(LocalizationHelper.GetString("Toast_PairingCommandCopied"))
                         .AddText(command));
-                }
+                },
+                ReviewPairing = ShowPairingApprovalDialog,
             }));
     }
 

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3056,7 +3056,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 dashboardPath: "connection",
                 details: name);
 
-            var bodyKey = approval.Kind == PendingApprovalKind.Node
+            var bodyKey = approval.Kind == PairingApprovalKind.NodePair
                 ? "Toast_PairingRequestBodyNode"
                 : "Toast_PairingRequestBody";
             _toastService?.ShowToast(new ToastContentBuilder()

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3056,7 +3056,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 dashboardPath: "connection",
                 details: name);
 
-            var bodyKey = approval.Kind == PairingApprovalKind.Node
+            var bodyKey = approval.Kind == PendingApprovalKind.Node
                 ? "Toast_PairingRequestBodyNode"
                 : "Toast_PairingRequestBody";
             _toastService?.ShowToast(new ToastContentBuilder()

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -149,6 +149,9 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     internal AppState? AppState => _appState;
     private UpdateCoordinator? _updateCoordinator;
     private GatewayService? _gatewayService;
+    private PairingApprovalCoordinator? _pairingApprovalCoordinator;
+    private OpenClawTray.Dialogs.PairingApprovalDialog? _pairingApprovalDialog;
+    private Microsoft.UI.Dispatching.DispatcherQueueTimer? _pairingApprovalPollTimer;
     private CancellationTokenSource? _deepLinkCts;
     private bool _isExiting;
     
@@ -476,6 +479,28 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         _diagnosticsClipboard = new DiagnosticsClipboardService(BuildCommandCenterState);
         _toastService = new ToastService(() => _settings);
         _appNotificationService = new AppNotificationService();
+
+        // Inbound pairing approvals: surface a focused dialog + awareness toast when another
+        // device/node requests pairing (Mac-parity). Getters are lazy so this can be created
+        // before the connection manager / node service exist.
+        _pairingApprovalCoordinator = new PairingApprovalCoordinator(
+            getClient: () => _connectionManager?.OperatorClient,
+            getOwnNodeIds: BuildOwnNodeIds,
+            isPromptEnabled: () => _settings?.ShowPairingApprovalDialog ?? true,
+            logger: new AppLogger());
+        _pairingApprovalCoordinator.ApprovalRequested += OnPairingApprovalRequested;
+        _pairingApprovalCoordinator.DecisionCompleted += OnPairingDecisionCompleted;
+        _gatewayService.PairListsChanged += OnPairListsChanged;
+
+        // Safety-net poll: the gateway broadcasts pair requests with dropIfSlow=true, so a busy
+        // socket can silently drop a "device wants to connect" event and the operator would never
+        // be prompted. A periodic reconcile recovers any missed request. RefreshFromGatewayAsync
+        // no-ops unless connected with approval scope, so this is idle-cheap.
+        _pairingApprovalPollTimer = _dispatcherQueue!.CreateTimer();
+        _pairingApprovalPollTimer.Interval = TimeSpan.FromSeconds(20);
+        _pairingApprovalPollTimer.IsRepeating = true;
+        _pairingApprovalPollTimer.Tick += (_, _) => _ = _pairingApprovalCoordinator?.RefreshFromGatewayAsync();
+        _pairingApprovalPollTimer.Start();
 
         DiagnosticsJsonlService.Write("app.start", new
         {
@@ -1724,6 +1749,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         else
         {
             _chatCoordinator?.SetOperatorClient(null);
+            _pairingApprovalCoordinator?.Reset();
         }
 
         RaiseChatProviderChanged();
@@ -2110,7 +2136,13 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private void OnPairingStatusChanged(object? sender, OpenClaw.Shared.PairingStatusEventArgs args)
     {
         Logger.Info($"Pairing status: {args.Status}");
-        
+
+        // The local node's own device id may have just become known. Re-run the
+        // approval reconcile so the own-node filter drops any self pairing request
+        // rather than prompting the operator to approve their own machine.
+        OnUiThread(() => _pairingApprovalCoordinator?.OnPairListsUpdated(
+            _appState?.DevicePairList, _appState?.NodePairList));
+
         try
         {
             if (args.Status == OpenClaw.Shared.PairingStatus.Pending)
@@ -2980,6 +3012,110 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         _connectionStatusWindow.Activate();
     }
 
+    // ─── Inbound pairing approvals ───────────────────────────────────────
+
+    /// <summary>Feeds fresh device/node pending pair-lists into the approval coordinator.</summary>
+    private void OnPairListsChanged(object? sender, EventArgs e)
+    {
+        _pairingApprovalCoordinator?.OnPairListsUpdated(_appState?.DevicePairList, _appState?.NodePairList);
+    }
+
+    /// <summary>
+    /// All identifiers the local Windows node may be known by in the gateway's pending node list,
+    /// so the approval coordinator never prompts the operator to approve their own machine. The node
+    /// advertises itself as <c>NodeId ?? FullDeviceId</c>; we offer both so the own-node filter is
+    /// robust to either identifier space.
+    /// </summary>
+    private IReadOnlyCollection<string> BuildOwnNodeIds()
+    {
+        var ids = new List<string>(2);
+        var fullDeviceId = _nodeService?.FullDeviceId;
+        if (!string.IsNullOrWhiteSpace(fullDeviceId)) ids.Add(fullDeviceId);
+        var nodeId = _nodeService?.NodeId;
+        if (!string.IsNullOrWhiteSpace(nodeId) && !ids.Contains(nodeId)) ids.Add(nodeId);
+        return ids;
+    }
+
+    /// <summary>A new inbound pairing request arrived — present the focused dialog and an awareness toast.</summary>
+    private void OnPairingApprovalRequested(object? sender, PendingApproval approval)
+    {
+        OnUiThread(() =>
+        {
+            // Only steal foreground when the dialog isn't already open. On a reconnect burst the
+            // gateway re-pushes every pending request at once; the first opens + foregrounds the
+            // dialog, the rest just enqueue into it without repeated focus-stealing.
+            var alreadyOpen = _pairingApprovalDialog is { IsClosed: false };
+            ShowPairingApprovalDialog(bringToFront: !alreadyOpen);
+
+            var name = string.IsNullOrWhiteSpace(approval.DisplayName)
+                ? approval.DeviceId
+                : approval.DisplayName!;
+            AddRecentActivity(
+                LocalizationHelper.GetString("Toast_PairingRequestTitle"),
+                category: "pairing",
+                dashboardPath: "connection",
+                details: name);
+
+            var bodyKey = approval.Kind == PairingApprovalKind.Node
+                ? "Toast_PairingRequestBodyNode"
+                : "Toast_PairingRequestBody";
+            _toastService?.ShowToast(new ToastContentBuilder()
+                .AddText(LocalizationHelper.GetString("Toast_PairingRequestTitle"))
+                .AddText(string.Format(LocalizationHelper.GetString(bodyKey), name))
+                .AddButton(new ToastButton()
+                    .SetContent(LocalizationHelper.GetString("Toast_PairingReview"))
+                    .AddArgument("action", "review_pairing")),
+                "pairing-request",
+                approval.DecisionId);
+        });
+    }
+
+    /// <summary>After a decision is confirmed by the gateway, surface a confirmation toast + activity entry.</summary>
+    private void OnPairingDecisionCompleted(object? sender, PairingDecisionResult result)
+    {
+        if (!result.Success) return; // defensive — the coordinator only raises this for confirmed decisions
+        OnUiThread(() =>
+        {
+            var name = string.IsNullOrWhiteSpace(result.Approval.DisplayName)
+                ? result.Approval.DeviceId
+                : result.Approval.DisplayName!;
+            var titleKey = result.Approved ? "Toast_PairingApprovedTitle" : "Toast_PairingRejectedTitle";
+            var bodyKey = result.Approved ? "Toast_PairingApprovedBody" : "Toast_PairingRejectedBody";
+            AddRecentActivity(
+                LocalizationHelper.GetString(titleKey),
+                category: "pairing",
+                dashboardPath: "connection",
+                details: name);
+            _toastService?.ShowToast(new ToastContentBuilder()
+                .AddText(LocalizationHelper.GetString(titleKey))
+                .AddText(string.Format(LocalizationHelper.GetString(bodyKey), name)),
+                "pairing-decided",
+                result.Approval.DecisionId);
+        });
+    }
+
+    /// <summary>Opens (or re-focuses) the inbound pairing approval dialog when there is something to decide.</summary>
+    private void ShowPairingApprovalDialog() => ShowPairingApprovalDialog(bringToFront: true);
+
+    private void ShowPairingApprovalDialog(bool bringToFront)
+    {
+        if (_pairingApprovalCoordinator == null) return;
+        if (_pairingApprovalCoordinator.Current.Count == 0)
+        {
+            ShowStatusDetail();
+            return;
+        }
+
+        if (_pairingApprovalDialog is { IsClosed: false } existing)
+        {
+            if (bringToFront) existing.ShowForeground();
+            return;
+        }
+
+        _pairingApprovalDialog = new OpenClawTray.Dialogs.PairingApprovalDialog(_pairingApprovalCoordinator);
+        _pairingApprovalDialog.ShowForeground();
+    }
+
     private void RestartSshTunnel()
     {
         if (_settings?.UseSshTunnel != true)
@@ -3823,6 +3959,14 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         {
             _sshTunnelService?.Dispose();
             _sshTunnelService = null;
+        });
+
+        SafeShutdownStep("pairing approval", () =>
+        {
+            _pairingApprovalPollTimer?.Stop();
+            _pairingApprovalPollTimer = null;
+            _pairingApprovalDialog?.Close();
+            _pairingApprovalDialog = null;
         });
 
         // Close windows explicitly for deterministic shutdown tracing.

--- a/src/OpenClaw.Tray.WinUI/Dialogs/PairingApprovalDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/PairingApprovalDialog.cs
@@ -1,0 +1,464 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using OpenClaw.Connection;
+using OpenClawTray.Helpers;
+using OpenClawTray.Services;
+using System;
+using System.Runtime.InteropServices;
+using WinUIEx;
+
+namespace OpenClawTray.Dialogs;
+
+/// <summary>
+/// Focused approval surface for inbound pairing requests (devices / nodes asking to join the
+/// gateway). Presents one request at a time with full identity + the operator scopes being
+/// granted, mirroring the macOS pairing prompt. Acts on the live <see cref="PairingApprovalCoordinator"/>
+/// and advances through the queue as decisions are made or requests are resolved elsewhere.
+///
+/// Security posture: Approve is never the default-focused button and stays disabled for a short
+/// delay after a request appears so the dialog cannot be "click-through" approved by a stray
+/// keypress/click. Reject and "Decide later" are always available.
+/// </summary>
+public sealed class PairingApprovalDialog : WindowEx
+{
+    [DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+    private static readonly IntPtr HWND_TOPMOST = new(-1);
+    private static readonly IntPtr HWND_NOTOPMOST = new(-2);
+    private const uint SWP_NOMOVE = 0x0002;
+    private const uint SWP_NOSIZE = 0x0001;
+
+    private static readonly TimeSpan ApproveArmDelay = TimeSpan.FromMilliseconds(1500);
+
+    private readonly PairingApprovalCoordinator _coordinator;
+    private readonly StackPanel _bodyPanel;
+    private readonly TextBlock _headingText;
+    private readonly TextBlock _queueChip;
+    private readonly Button _approveButton;
+    private readonly Button _rejectButton;
+    private readonly Button _laterButton;
+
+    private DispatcherTimer? _armTimer;
+    private string? _currentKey;
+    private bool _busy;
+
+    public bool IsClosed { get; private set; }
+
+    public PairingApprovalDialog(PairingApprovalCoordinator coordinator)
+    {
+        _coordinator = coordinator ?? throw new ArgumentNullException(nameof(coordinator));
+
+        Title = LocalizationHelper.GetString("PairingApproval_WindowTitle");
+        this.SetWindowSize(460, 460);
+        this.CenterOnScreen();
+        this.SetIcon("Assets\\openclaw.ico");
+        SystemBackdrop = new MicaBackdrop();
+        ExtendsContentIntoTitleBar = true;
+
+        // ── Custom title bar ──
+        var titleBar = new Grid { Height = 48, Padding = new Thickness(16, 0, 140, 0) };
+        titleBar.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        titleBar.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        var titleIcon = new TextBlock { Text = "🦞", FontSize = 16, VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(0, 0, 8, 0) };
+        Grid.SetColumn(titleIcon, 0);
+        titleBar.Children.Add(titleIcon);
+        var titleText = new TextBlock
+        {
+            Text = LocalizationHelper.GetString("PairingApproval_WindowTitle"),
+            FontSize = 13,
+            VerticalAlignment = VerticalAlignment.Center,
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+        };
+        Grid.SetColumn(titleText, 1);
+        titleBar.Children.Add(titleText);
+        SetTitleBar(titleBar);
+
+        // ── Layout: [title][header][scrollable body][buttons] ──
+        var outerGrid = new Grid();
+        outerGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(48) });
+        outerGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+        Grid.SetRow(titleBar, 0);
+        outerGrid.Children.Add(titleBar);
+
+        var root = new Grid { Padding = new Thickness(28, 8, 28, 24), RowSpacing = 14 };
+        root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto }); // header
+        root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }); // body
+        root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto }); // buttons
+
+        // Header: shield glyph + heading + queue chip
+        var header = new Grid { ColumnSpacing = 12 };
+        header.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        header.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        header.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var shield = new FontIcon
+        {
+            Glyph = "\uE72E", // shield
+            FontSize = 28,
+            Foreground = ResolveBrush("SystemFillColorCautionBrush"),
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        Grid.SetColumn(shield, 0);
+        header.Children.Add(shield);
+
+        _headingText = new TextBlock
+        {
+            Style = (Style)Application.Current.Resources["SubtitleTextBlockStyle"],
+            VerticalAlignment = VerticalAlignment.Center,
+            TextWrapping = TextWrapping.Wrap,
+        };
+        Grid.SetColumn(_headingText, 1);
+        header.Children.Add(_headingText);
+
+        _queueChip = new TextBlock
+        {
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            Foreground = ResolveBrush("TextFillColorSecondaryBrush"),
+            VerticalAlignment = VerticalAlignment.Center,
+            Visibility = Visibility.Collapsed,
+        };
+        Grid.SetColumn(_queueChip, 2);
+        header.Children.Add(_queueChip);
+
+        Grid.SetRow(header, 0);
+        root.Children.Add(header);
+
+        // Body (scrollable detail card)
+        _bodyPanel = new StackPanel { Spacing = 12 };
+        var scroll = new ScrollViewer
+        {
+            Content = _bodyPanel,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+        };
+        Grid.SetRow(scroll, 1);
+        root.Children.Add(scroll);
+
+        // Buttons: [Reject] [Decide later] ............ [Approve]
+        var buttonGrid = new Grid { ColumnSpacing = 8 };
+        buttonGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        buttonGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        buttonGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        buttonGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        _rejectButton = new Button { Content = BuildButtonContent("\uE711", "SystemFillColorCriticalBrush", LocalizationHelper.GetString("PairingApproval_Reject")) };
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(_rejectButton, "PairingRejectAction");
+        _rejectButton.Click += async (_, _) => await DecideAsync(approve: false);
+        Grid.SetColumn(_rejectButton, 0);
+        buttonGrid.Children.Add(_rejectButton);
+
+        _laterButton = new Button { Content = LocalizationHelper.GetString("PairingApproval_Later") };
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(_laterButton, "PairingLaterAction");
+        _laterButton.Click += (_, _) => Close(); // dismiss without deciding; request stays pending
+        Grid.SetColumn(_laterButton, 1);
+        buttonGrid.Children.Add(_laterButton);
+
+        _approveButton = new Button
+        {
+            Content = BuildButtonContent("\uE73E", null, LocalizationHelper.GetString("PairingApproval_Approve")),
+            Style = (Style)Application.Current.Resources["AccentButtonStyle"],
+        };
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(_approveButton, "PairingApproveAction");
+        _approveButton.Click += async (_, _) => await DecideAsync(approve: true);
+        Grid.SetColumn(_approveButton, 3);
+        buttonGrid.Children.Add(_approveButton);
+
+        Grid.SetRow(buttonGrid, 2);
+        root.Children.Add(buttonGrid);
+
+        Grid.SetRow(root, 1);
+        outerGrid.Children.Add(root);
+        Content = outerGrid;
+
+        _coordinator.ApprovalsChanged += OnApprovalsChanged;
+        Closed += OnWindowClosed;
+
+        Render();
+    }
+
+    /// <summary>Activates the dialog and forces it to the foreground (it may open from a background event).</summary>
+    public void ShowForeground()
+    {
+        Activate();
+        try
+        {
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            if (hwnd != IntPtr.Zero)
+            {
+                SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+                SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+                SetForegroundWindow(hwnd);
+            }
+        }
+        catch { /* best-effort */ }
+    }
+
+    private void OnApprovalsChanged(object? sender, EventArgs e)
+    {
+        if (IsClosed) return;
+        if (DispatcherQueue.HasThreadAccess) Render();
+        else DispatcherQueue.TryEnqueue(Render);
+    }
+
+    private void Render()
+    {
+        if (IsClosed) return;
+
+        var current = _coordinator.Current;
+        if (current.Count == 0)
+        {
+            // Nothing left to decide — close.
+            Close();
+            return;
+        }
+
+        var approval = current[0];
+        var keyChanged = !string.Equals(_currentKey, approval.Key, StringComparison.Ordinal);
+
+        // The queue chip always reflects the latest count, even when the
+        // front-of-queue request is unchanged.
+        if (current.Count > 1)
+        {
+            _queueChip.Text = string.Format(LocalizationHelper.GetString("PairingApproval_MoreWaiting"), current.Count - 1);
+            _queueChip.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            _queueChip.Visibility = Visibility.Collapsed;
+        }
+
+        // If the request at the front of the queue hasn't changed (an unrelated
+        // list refresh arrived), do NOT rebuild the card, reset the in-flight
+        // decision guard, or re-arm the approve delay — that would let a second
+        // click through while a decision is still in flight for this same request.
+        if (!keyChanged)
+            return;
+
+        _currentKey = approval.Key;
+        _headingText.Text = LocalizationHelper.GetString(
+            approval.Kind == PairingApprovalKind.Node ? "PairingApproval_NodeHeading" : "PairingApproval_DeviceHeading");
+
+        // Kind-aware approve label ("Approve device" / "Approve node") to reinforce intent.
+        _approveButton.Content = BuildButtonContent(
+            "\uE73E",
+            null,
+            LocalizationHelper.GetString(approval.Kind == PairingApprovalKind.Node
+                ? "PairingApproval_ApproveNode"
+                : "PairingApproval_ApproveDevice"));
+
+        _bodyPanel.Children.Clear();
+        _bodyPanel.Children.Add(BuildDetailCard(approval));
+
+        // Fresh request — reset interaction state and re-arm the approve guard.
+        _busy = false;
+        _rejectButton.IsEnabled = true;
+        _laterButton.IsEnabled = true;
+        ArmApproveGuard();
+    }
+
+    private Border BuildDetailCard(PendingApproval approval)
+    {
+        var card = new Border
+        {
+            Background = ResolveBrush("CardBackgroundFillColorDefaultBrush"),
+            BorderBrush = ResolveBrush("CardStrokeColorDefaultBrush"),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(8),
+            Padding = new Thickness(16),
+        };
+        var stack = new StackPanel { Spacing = 10 };
+
+        var name = string.IsNullOrWhiteSpace(approval.DisplayName)
+            ? (string.IsNullOrEmpty(approval.DeviceId)
+                ? LocalizationHelper.GetString("PairingApproval_UnknownDevice")
+                : approval.DeviceId)
+            : approval.DisplayName!;
+
+        stack.Children.Add(new TextBlock
+        {
+            Text = name,
+            Style = (Style)Application.Current.Resources["BodyStrongTextBlockStyle"],
+            TextWrapping = TextWrapping.Wrap,
+        });
+
+        var detailParts = new System.Collections.Generic.List<string>
+        {
+            string.IsNullOrWhiteSpace(approval.Platform)
+                ? LocalizationHelper.GetString("PairingApproval_UnknownPlatform")
+                : approval.Platform!,
+        };
+        if (!string.IsNullOrWhiteSpace(approval.Role)) detailParts.Add(approval.Role!);
+        if (!string.IsNullOrWhiteSpace(approval.Version)) detailParts.Add($"v{approval.Version}");
+        stack.Children.Add(new TextBlock
+        {
+            Text = string.Join("  ·  ", detailParts),
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            Foreground = ResolveBrush("TextFillColorSecondaryBrush"),
+            TextWrapping = TextWrapping.Wrap,
+        });
+
+        // Friendly scope list (device requests only).
+        if (approval.Scopes.Count > 0)
+        {
+            stack.Children.Add(new TextBlock
+            {
+                Text = LocalizationHelper.GetString("PairingApproval_AccessRequested"),
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                Foreground = ResolveBrush("TextFillColorSecondaryBrush"),
+                Margin = new Thickness(0, 4, 0, 0),
+            });
+            foreach (var label in PairingScopeDescriptions.DescribeAll(approval.Scopes))
+            {
+                var row = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+                row.Children.Add(new FontIcon
+                {
+                    Glyph = "\uE73E",
+                    FontSize = 12,
+                    Foreground = ResolveBrush("TextFillColorSecondaryBrush"),
+                    VerticalAlignment = VerticalAlignment.Center,
+                });
+                row.Children.Add(new TextBlock { Text = label, TextWrapping = TextWrapping.Wrap, VerticalAlignment = VerticalAlignment.Center });
+                stack.Children.Add(row);
+            }
+        }
+
+        // Repair badge.
+        if (approval.IsRepair)
+        {
+            stack.Children.Add(new TextBlock
+            {
+                Text = LocalizationHelper.GetString("PairingApproval_RepairBadge"),
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                Foreground = ResolveBrush("SystemFillColorCautionBrush"),
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 4, 0, 0),
+            });
+        }
+
+        // Footer: truncated id · ip (monospace, tertiary).
+        var footerParts = new System.Collections.Generic.List<string>();
+        if (!string.IsNullOrEmpty(approval.DeviceId))
+            footerParts.Add($"ID {TruncateId(approval.DeviceId)}");
+        if (!string.IsNullOrWhiteSpace(approval.RemoteIp))
+            footerParts.Add($"IP {approval.RemoteIp}");
+        if (footerParts.Count > 0)
+        {
+            stack.Children.Add(new TextBlock
+            {
+                Text = string.Join("  ·  ", footerParts),
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                Foreground = ResolveBrush("TextFillColorTertiaryBrush"),
+                FontFamily = new FontFamily("Consolas"),
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 6, 0, 0),
+            });
+        }
+
+        // Reassurance line.
+        stack.Children.Add(new TextBlock
+        {
+            Text = LocalizationHelper.GetString("PairingApproval_Subtitle"),
+            Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+            Foreground = ResolveBrush("TextFillColorSecondaryBrush"),
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(0, 8, 0, 0),
+        });
+
+        card.Child = stack;
+        return card;
+    }
+
+    private void ArmApproveGuard()
+    {
+        _armTimer?.Stop();
+        _approveButton.IsEnabled = false;
+        ToolTipService.SetToolTip(_approveButton, LocalizationHelper.GetString("PairingApproval_ApproveHint"));
+        _armTimer = new DispatcherTimer { Interval = ApproveArmDelay };
+        _armTimer.Tick += (_, _) =>
+        {
+            _armTimer?.Stop();
+            if (!_busy)
+            {
+                _approveButton.IsEnabled = true;
+                ToolTipService.SetToolTip(_approveButton, null);
+            }
+        };
+        _armTimer.Start();
+    }
+
+    private async System.Threading.Tasks.Task DecideAsync(bool approve)
+    {
+        if (_busy || _currentKey == null) return;
+        var decisionKey = _currentKey;
+        _busy = true;
+        _approveButton.IsEnabled = false;
+        _rejectButton.IsEnabled = false;
+        _laterButton.IsEnabled = false;
+
+        bool ok;
+        try
+        {
+            // Success drives a coordinator ApprovalsChanged -> Render() which advances or closes.
+            ok = approve
+                ? await _coordinator.ApproveAsync(decisionKey)
+                : await _coordinator.RejectAsync(decisionKey);
+        }
+        catch
+        {
+            ok = false;
+        }
+
+        // The window may have closed (disconnect -> Reset -> Close) or the queue may have advanced
+        // to a different request while the RPC was in flight. Only touch UI if we're still on a live
+        // window showing the same request — otherwise this stale continuation must not mutate state.
+        if (IsClosed || !string.Equals(_currentKey, decisionKey, StringComparison.Ordinal))
+            return;
+
+        if (!ok)
+        {
+            // Re-enable the secondary actions and RE-ARM the approve guard (don't force-enable
+            // Approve — that would defeat the anti-clickthrough delay on the retry).
+            _busy = false;
+            _rejectButton.IsEnabled = true;
+            _laterButton.IsEnabled = true;
+            ArmApproveGuard();
+        }
+        // On success, leave buttons disabled; the pending ApprovalsChanged -> Render() will advance
+        // to the next request (re-enabling) or close the dialog.
+    }
+
+    private void OnWindowClosed(object sender, WindowEventArgs args)
+    {
+        IsClosed = true;
+        _armTimer?.Stop();
+        _coordinator.ApprovalsChanged -= OnApprovalsChanged;
+        Closed -= OnWindowClosed;
+    }
+
+    private static StackPanel BuildButtonContent(string glyph, string? glyphBrushKey, string label)
+    {
+        var stack = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6, VerticalAlignment = VerticalAlignment.Center };
+        var icon = new FontIcon { Glyph = glyph, FontSize = 14, VerticalAlignment = VerticalAlignment.Center };
+        if (glyphBrushKey != null)
+            icon.Foreground = ResolveBrush(glyphBrushKey);
+        stack.Children.Add(icon);
+        stack.Children.Add(new TextBlock { Text = label, VerticalAlignment = VerticalAlignment.Center });
+        return stack;
+    }
+
+    private static string TruncateId(string id)
+    {
+        if (string.IsNullOrEmpty(id) || id.Length <= 20) return id;
+        return $"{id[..8]}…{id[^7..]}";
+    }
+
+    private static Brush ResolveBrush(string themeKey) =>
+        Application.Current.Resources.TryGetValue(themeKey, out var value) && value is Brush brush
+            ? brush
+            : new SolidColorBrush(Microsoft.UI.Colors.Transparent);
+}

--- a/src/OpenClaw.Tray.WinUI/Dialogs/PairingApprovalDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/PairingApprovalDialog.cs
@@ -241,13 +241,13 @@ public sealed class PairingApprovalDialog : WindowEx
 
         _currentKey = approval.Key;
         _headingText.Text = LocalizationHelper.GetString(
-            approval.Kind == PairingApprovalKind.Node ? "PairingApproval_NodeHeading" : "PairingApproval_DeviceHeading");
+            approval.Kind == PendingApprovalKind.Node ? "PairingApproval_NodeHeading" : "PairingApproval_DeviceHeading");
 
         // Kind-aware approve label ("Approve device" / "Approve node") to reinforce intent.
         _approveButton.Content = BuildButtonContent(
             "\uE73E",
             null,
-            LocalizationHelper.GetString(approval.Kind == PairingApprovalKind.Node
+            LocalizationHelper.GetString(approval.Kind == PendingApprovalKind.Node
                 ? "PairingApproval_ApproveNode"
                 : "PairingApproval_ApproveDevice"));
 

--- a/src/OpenClaw.Tray.WinUI/Dialogs/PairingApprovalDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/PairingApprovalDialog.cs
@@ -2,6 +2,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using OpenClaw.Connection;
+using OpenClaw.Shared;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using System;
@@ -241,13 +242,13 @@ public sealed class PairingApprovalDialog : WindowEx
 
         _currentKey = approval.Key;
         _headingText.Text = LocalizationHelper.GetString(
-            approval.Kind == PendingApprovalKind.Node ? "PairingApproval_NodeHeading" : "PairingApproval_DeviceHeading");
+            approval.Kind == PairingApprovalKind.NodePair ? "PairingApproval_NodeHeading" : "PairingApproval_DeviceHeading");
 
         // Kind-aware approve label ("Approve device" / "Approve node") to reinforce intent.
         _approveButton.Content = BuildButtonContent(
             "\uE73E",
             null,
-            LocalizationHelper.GetString(approval.Kind == PendingApprovalKind.Node
+            LocalizationHelper.GetString(approval.Kind == PairingApprovalKind.NodePair
                 ? "PairingApproval_ApproveNode"
                 : "PairingApproval_ApproveDevice"));
 

--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -89,6 +89,9 @@
     <MxcArch Condition="'$(MxcArch)' == '' And '$(PlatformTarget)' == 'ARM64'">arm64</MxcArch>
     <MxcArch Condition="'$(MxcArch)' == '' And '$(RuntimeIdentifier)' == ''">x64</MxcArch>
     <MxcSdkBinDir>$(OpenClawRepoRoot)node_modules\@microsoft\mxc-sdk\bin\$(MxcArch)\</MxcSdkBinDir>
+    <MxcSdkExpectedVersion>0.7.0</MxcSdkExpectedVersion>
+    <MxcSdkPackageJson>$(OpenClawRepoRoot)node_modules\@microsoft\mxc-sdk\package.json</MxcSdkPackageJson>
+    <MxcSdkRestoreStamp>$(OpenClawRepoRoot)node_modules\.openclaw-mxc-sdk-$(MxcSdkExpectedVersion).stamp</MxcSdkRestoreStamp>
   </PropertyGroup>
 
   <!--
@@ -200,9 +203,18 @@
           BeforeTargets="Build;Publish;CopyWxcExecToOutput;CopyWxcExecToPublish"
           Condition="'$(SkipMxcNodeBridgeRestore)' != 'true' And Exists('$(OpenClawRepoRoot)package-lock.json')"
           Inputs="$(OpenClawRepoRoot)package-lock.json"
-          Outputs="$(OpenClawRepoRoot)node_modules\.package-lock.json">
+          Outputs="$(MxcSdkRestoreStamp)">
     <Message Importance="high" Text="Restoring @microsoft/mxc-sdk to extract wxc-exec.exe ($(MxcArch))" />
     <Exec Command="npm ci --no-audit --no-fund" WorkingDirectory="$(OpenClawRepoRoot)" />
+    <Touch Files="$(MxcSdkRestoreStamp)" AlwaysCreate="true" />
+  </Target>
+
+  <Target Name="ValidateMxcSdkVersion"
+          BeforeTargets="CopyWxcExecToOutput;CopyWxcExecToPublish"
+          DependsOnTargets="RestoreMxcNodeBridge"
+          Condition="'$(SkipMxcNodeBridgeRestore)' != 'true' And Exists('$(OpenClawRepoRoot)package-lock.json')">
+    <Error Condition="!Exists('$(MxcSdkPackageJson)')" Text="@microsoft/mxc-sdk package.json missing at $(MxcSdkPackageJson). Run `npm ci` at $(OpenClawRepoRoot)." />
+    <Error Condition="Exists('$(MxcSdkPackageJson)') And !$([System.IO.File]::ReadAllText('$(MxcSdkPackageJson)').Contains('&quot;version&quot;: &quot;$(MxcSdkExpectedVersion)&quot;'))" Text="@microsoft/mxc-sdk version mismatch. Expected $(MxcSdkExpectedVersion) in $(MxcSdkPackageJson). Run `npm ci` at $(OpenClawRepoRoot)." />
   </Target>
 
   <!-- Copy ONLY wxc-exec.exe (and any sibling DLLs) for the active arch into

--- a/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml.cs
@@ -15,18 +15,57 @@ public sealed partial class SandboxPage : Page
     private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private bool _suppress;
     private bool _dialogOpen;
-    private OpenClaw.Shared.Mxc.MxcAvailability? _cachedAvailability;
 
     public ObservableCollection<CustomFolderRow> CustomFolders { get; } = new();
 
     /// <summary>
-    /// Cached MxcAvailability for the lifetime of this page instance. Probe() does
-    /// registry reads and filesystem walks; we don't need to repeat that work on every
-    /// toggle/preset change. The result is stable as long as the OS doesn't change
-    /// under us, which is fine for a settings page.
+    /// Cached MxcAvailability for the lifetime of this page instance, or null until
+    /// the first background probe completes. Probe() spawns <c>wxc-exec --probe</c>
+    /// (up to ~15s on a misbehaving host) plus filesystem walks, so we never run it
+    /// on the UI thread; <see cref="RefreshAvailabilityAsync"/> populates this
+    /// off-thread and re-renders. Availability-driven UI treats null as "checking".
     /// </summary>
-    private OpenClaw.Shared.Mxc.MxcAvailability GetAvailability()
-        => _cachedAvailability ??= OpenClaw.Shared.Mxc.MxcAvailability.Probe();
+    private OpenClaw.Shared.Mxc.MxcAvailability? _cachedAvailability;
+    private bool _availabilityProbeInFlight;
+
+    /// <summary>
+    /// Probe MXC availability off the UI thread (once), cache it, then refresh the
+    /// availability-driven UI. No-op once a definitive result is cached or while a
+    /// probe is already running.
+    /// </summary>
+    private async System.Threading.Tasks.Task RefreshAvailabilityAsync()
+    {
+        // Re-probe when we have no result yet, or the last one was a transient
+        // probe error. A definitive verdict (supported / host-unsupported) is kept
+        // for the page-instance lifetime.
+        if (_cachedAvailability is { ProbeErrored: false }) return;
+        if (_availabilityProbeInFlight) return;
+
+        _availabilityProbeInFlight = true;
+        try
+        {
+            _cachedAvailability = await System.Threading.Tasks.Task.Run(
+                static () => OpenClaw.Shared.Mxc.MxcAvailability.Probe());
+        }
+        catch (Exception)
+        {
+            // Probe() is designed not to throw, but never leave the page stuck in
+            // "Checking…": synthesize an errored result so the UI shows Retry.
+            _cachedAvailability = new OpenClaw.Shared.Mxc.MxcAvailability(
+                false, false, false, null,
+                new[] { "Couldn't check sandbox availability." }, probeErrored: true);
+        }
+        finally
+        {
+            _availabilityProbeInFlight = false;
+
+            // await resumed us on the UI thread (DispatcherQueue sync context), so it
+            // is safe to touch controls here. Always re-render — on both the happy
+            // path and the failure path — so the page never stays in "Checking…".
+            UpdateSandboxStatusCard();
+            UpdateControlsEnabledState();
+        }
+    }
 
     // ── Quick-preset definitions ─────────────────────────────────────
     //
@@ -90,6 +129,15 @@ public sealed partial class SandboxPage : Page
         LoadState();
         ProbeStatus();
         UpdateControlsEnabledState();
+
+        // Kick off the (potentially slow) MXC probe off the UI thread. The page
+        // renders a neutral "checking" state until it completes, then re-renders
+        // with the real availability — so the settings UI never blocks on
+        // wxc-exec --probe.
+        AsyncEventHandlerGuard.Run(
+            RefreshAvailabilityAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(RefreshAvailabilityAsync));
     }
 
     // ── Load + probe ─────────────────────────────────────────────────
@@ -150,12 +198,22 @@ public sealed partial class SandboxPage : Page
     /// </summary>
     private void UpdateSandboxStatusCard()
     {
-        var availability = GetAvailability();
+        var availability = _cachedAvailability;
         var enabled = SandboxEnabledToggle.IsOn;
-        var available = availability.HasAnyBackend;
 
         UpdateUnavailableActionBar(availability);
 
+        if (availability is null)
+        {
+            // Probe still running on the background thread — neutral interim state.
+            SandboxStatusIcon.Text = "⏳";
+            SandboxStatusTitle.Text = "Checking sandbox availability…";
+            SandboxStatusSubtext.Text = "Verifying that this PC can contain commands the agent runs.";
+            SandboxEnabledToggle.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        var available = availability.HasAnyBackend;
         if (!available)
         {
             SandboxStatusIcon.Text = "⚠";
@@ -170,8 +228,21 @@ public sealed partial class SandboxPage : Page
         if (enabled)
         {
             SandboxStatusIcon.Text = "🛡";
-            SandboxStatusTitle.Text = "Node Sandbox is on";
-            SandboxStatusSubtext.Text = "Programs the agent runs on this PC are contained.";
+            if (availability.IsDegradedContainment)
+            {
+                // Contained, but only via a weaker, last-resort isolation tier
+                // (e.g. DACL augmentation). Surface as a caution rather than a block.
+                SandboxStatusTitle.Text = "Node Sandbox is on — limited containment";
+                SandboxStatusSubtext.Text =
+                    "Programs the agent runs are contained, but this PC only supports a fallback isolation tier" +
+                    $"{(string.IsNullOrEmpty(availability.IsolationTier) ? "" : $" ({availability.IsolationTier})")}. " +
+                    "Containment is weaker than on a fully supported build; install the latest Windows updates to strengthen it.";
+            }
+            else
+            {
+                SandboxStatusTitle.Text = "Node Sandbox is on";
+                SandboxStatusSubtext.Text = "Programs the agent runs on this PC are contained.";
+            }
         }
         else
         {
@@ -184,13 +255,15 @@ public sealed partial class SandboxPage : Page
     /// <summary>
     /// Shows or hides the prominent "Sandbox unavailable" InfoBar based on availability,
     /// and categorizes the failure mode so we can suggest a relevant action:
-    ///   - Windows build/UBR too old → "Open Windows Update"
+    ///   - probe errored (transient) → "Retry"
+    ///   - host doesn't support sandboxing → "Open Windows Update"
     ///   - wxc-exec.exe missing → "Show install instructions"
     ///   - Anything else → no primary action, just the learn-more hyperlink
     /// </summary>
-    private void UpdateUnavailableActionBar(OpenClaw.Shared.Mxc.MxcAvailability availability)
+    private void UpdateUnavailableActionBar(OpenClaw.Shared.Mxc.MxcAvailability? availability)
     {
-        if (availability.HasAnyBackend)
+        // Null = still probing; hide the bar until we have a verdict.
+        if (availability is null || availability.HasAnyBackend)
         {
             UnavailableActionBar.IsOpen = false;
             return;
@@ -201,13 +274,30 @@ public sealed partial class SandboxPage : Page
             ? string.Join("  ·  ", reasons)
             : "MXC sandboxing primitives are not available on this machine.";
 
-        var isWindowsIssue = reasons.Any(r =>
-            r.Contains("Windows build", StringComparison.OrdinalIgnoreCase) ||
-            r.Contains("Windows UBR", StringComparison.OrdinalIgnoreCase));
+        // A transient probe error (timeout / couldn't launch / garbled output) is NOT
+        // the same as the host being unsupported — don't push the user at Windows
+        // Update. Offer a retry; the next probe may succeed.
+        var isProbeError = availability.ProbeErrored;
+
+        // wxc-exec is present and the probe gave a definitive negative → the Windows
+        // host itself doesn't support the sandbox (vs. a missing binary).
+        var isWindowsIssue = !isProbeError
+            && availability.IsWxcExecResolvable
+            && !availability.IsAppContainerAvailable;
 
         var isSetupIssue = !availability.IsWxcExecResolvable;
 
-        if (isWindowsIssue)
+        if (isProbeError)
+        {
+            UnavailableActionBar.Title = "Couldn't verify sandbox availability";
+            UnavailableActionMessage.Text =
+                $"{reasonText}\n\nThe sandbox capability check didn't complete, so commands run uncontained for now. " +
+                "This is usually transient (a slow or blocked check) — retry, and if it persists check whether security software is blocking wxc-exec.";
+            UnavailablePrimaryButton.Content = "Retry";
+            UnavailablePrimaryButton.Tag = "retry";
+            UnavailablePrimaryButton.Visibility = Visibility.Visible;
+        }
+        else if (isWindowsIssue)
         {
             UnavailableActionBar.Title = "Your Windows version doesn't support sandboxing yet";
             UnavailableActionMessage.Text =
@@ -248,6 +338,17 @@ public sealed partial class SandboxPage : Page
     {
         if (sender is not Button btn) return;
         var tag = btn.Tag as string;
+
+        // Transient probe error → clear the cached verdict and re-probe off-thread.
+        if (tag == "retry")
+        {
+            _cachedAvailability = null;
+            UpdateSandboxStatusCard();
+            UpdateControlsEnabledState();
+            await RefreshAvailabilityAsync();
+            return;
+        }
+
         try
         {
             var uri = tag switch
@@ -274,8 +375,9 @@ public sealed partial class SandboxPage : Page
     /// </summary>
     private void UpdateControlsEnabledState()
     {
-        var availability = GetAvailability();
-        var available = availability.HasAnyBackend;
+        // Null availability = still probing; treat as not-yet-active so the
+        // controls stay dimmed until the background probe resolves.
+        var available = _cachedAvailability?.HasAnyBackend ?? false;
         var sandboxOn = SandboxEnabledToggle.IsOn;
         var active = available && sandboxOn;
 

--- a/src/OpenClaw.Tray.WinUI/Services/GatewayService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/GatewayService.cs
@@ -23,6 +23,8 @@ internal sealed class GatewayService
     public event EventHandler<string>? AuthenticationFailed;
     public event EventHandler<SessionCommandResult>? SessionCommandCompleted;
     public event EventHandler<OpenClawNotification>? NotificationReceived;
+    /// <summary>Raised (on the UI thread) whenever the node or device pending pair-list changes.</summary>
+    public event EventHandler? PairListsChanged;
 
     // Throttle / dedup state (moved from App)
     private DateTime _lastPreviewRequestUtc = DateTime.MinValue;
@@ -190,6 +192,10 @@ internal sealed class GatewayService
             if (status == ConnectionStatus.Disconnected || status == ConnectionStatus.Error)
             {
                 _state.ClearCachedData();
+                // Pair lists were just cleared — notify the approval coordinator so it
+                // reconciles to empty (resolving any open approvals / closing the dialog)
+                // instead of leaving stale state until the operator client is swapped out.
+                PairListsChanged?.Invoke(this, EventArgs.Empty);
             }
 
             ConnectionStatusChanged?.Invoke(this, status);
@@ -492,13 +498,21 @@ internal sealed class GatewayService
     private void OnNodePairListUpdated(object? sender, PairingListInfo data)
     {
         if (sender != _currentClient) return;
-        EnqueueModelUpdate(() => _state.NodePairList = data);
+        EnqueueModelUpdate(() =>
+        {
+            _state.NodePairList = data;
+            PairListsChanged?.Invoke(this, EventArgs.Empty);
+        });
     }
 
     private void OnDevicePairListUpdated(object? sender, DevicePairingListInfo data)
     {
         if (sender != _currentClient) return;
-        EnqueueModelUpdate(() => _state.DevicePairList = data);
+        EnqueueModelUpdate(() =>
+        {
+            _state.DevicePairList = data;
+            PairListsChanged?.Invoke(this, EventArgs.Empty);
+        });
     }
 
     private void OnModelsListUpdated(object? sender, ModelsListInfo data)

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -558,11 +558,23 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
     /// </summary>
     private ICommandRunner BuildSystemRunRunner()
     {
-        var availability = _mxcAvailability ??= MxcAvailability.Probe(_logger);
         var hostRunner = new LocalCommandRunner(_logger);
-        var executor = new DirectAppContainerExecutor(availability, _logger);
+        var executor = new DirectAppContainerExecutor(GetOrProbeMxcAvailability, _logger);
 
-        if (availability.HasAnyBackend)
+        // Do NOT probe synchronously here: this runs while _capabilitiesLock is held
+        // (RegisterCapabilities), and a blocking wxc-exec --probe (~15s) would stall
+        // capability registration / reconnect. Log from a non-blocking peek; the
+        // first real probe happens lazily on the first system.run via the
+        // availability gate / executor provider below (off any of our locks).
+        var peeked = PeekMxcAvailability();
+        if (peeked is null)
+        {
+            _logger.Info(
+                $"[mxc] system.run runner = MxcCommandRunner " +
+                $"(executor={executor.Name}; MXC availability probe deferred to first use; " +
+                $"sandboxEnabled={(_settings?.SystemRunSandboxEnabled ?? true)})");
+        }
+        else if (peeked.HasAnyBackend)
         {
             _logger.Info(
                 $"[mxc] system.run runner = MxcCommandRunner " +
@@ -574,7 +586,7 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
             // !_isSandboxAvailable() guard will route to the host fallback
             // for every call; the executor is constructed only to satisfy
             // the constructor contract and is never invoked.
-            var reason = string.Join("; ", availability.UnsupportedReasons);
+            var reason = string.Join("; ", peeked.UnsupportedReasons);
             _logger.Info($"[mxc] system.run runner = MxcCommandRunner (MXC unavailable, commands will run uncontained: {reason})");
         }
 
@@ -584,10 +596,11 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
             hostRunner,
             () => SnapshotSettings(),
             () => settingsDirectory,
-            // Re-probe on demand if the cache was invalidated by a prior
-            // SandboxUnavailableException (see invalidateAvailability below).
-            () => (_mxcAvailability ??= MxcAvailability.Probe(_logger)).HasAnyBackend,
-            invalidateAvailability: () => _mxcAvailability = null,
+            // Re-probe on demand when sandbox availability is checked: returns the
+            // cached definitive verdict, or re-probes (single-flight) after a
+            // transient error / a prior SandboxUnavailableException-driven invalidation.
+            () => GetOrProbeMxcAvailability().HasAnyBackend,
+            invalidateAvailability: InvalidateMxcAvailability,
             _logger);
     }
 
@@ -626,6 +639,103 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
     }
 
     private MxcAvailability? _mxcAvailability;
+    private DateTime _mxcNextProbeAllowedAtUtc;
+    private Task<MxcAvailability>? _mxcProbeInFlight;
+    private readonly object _mxcAvailabilityLock = new();
+
+    /// <summary>
+    /// Minimum interval before re-probing after a transient probe error. Bounds the
+    /// cost of re-spawning <c>wxc-exec --probe</c> while a probe error persists,
+    /// while still letting a momentary glitch self-heal quickly.
+    /// </summary>
+    private static readonly TimeSpan MxcProbeRetryInterval = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Return the current MXC availability, probing if needed. Definitive verdicts
+    /// (supported / host-unsupported) are cached for the process lifetime; a transient
+    /// probe error (<see cref="MxcAvailability.ProbeErrored"/>) is NOT cached
+    /// permanently — once the retry window opens we re-probe so a momentary glitch
+    /// doesn't pin the whole process to uncontained execution.
+    /// </summary>
+    /// <remarks>
+    /// The blocking probe (<c>wxc-exec --probe</c>, up to ~15s) is NEVER run while
+    /// holding <see cref="_mxcAvailabilityLock"/>: concurrent callers share a single
+    /// in-flight probe (single-flight) and wait on it OUTSIDE the lock, so a slow
+    /// probe can't serialize unrelated callers or stall lock users. The retry window
+    /// opens only AFTER a probe completes, so a 15s timeout can't immediately permit a
+    /// back-to-back re-probe.
+    /// </remarks>
+    private MxcAvailability GetOrProbeMxcAvailability()
+    {
+        Task<MxcAvailability> probe;
+        lock (_mxcAvailabilityLock)
+        {
+            // Definitive verdict — cached for the process lifetime.
+            if (_mxcAvailability is { ProbeErrored: false } definitive)
+                return definitive;
+
+            // Transient error — keep serving it (routes to uncontained) until the
+            // retry window opens, so we don't re-probe on every command.
+            if (_mxcAvailability is { ProbeErrored: true } errored
+                && _mxcProbeInFlight is null
+                && DateTime.UtcNow < _mxcNextProbeAllowedAtUtc)
+                return errored;
+
+            // Start a probe if none is running, otherwise join the in-flight one.
+            probe = _mxcProbeInFlight ??= Task.Run(ProbeAndStoreMxcAvailability);
+        }
+
+        // Wait OUTSIDE the lock so other callers / lock users aren't blocked.
+        return probe.GetAwaiter().GetResult();
+    }
+
+    private MxcAvailability ProbeAndStoreMxcAvailability()
+    {
+        MxcAvailability result;
+        try
+        {
+            result = MxcAvailability.Probe(_logger);
+        }
+        catch (Exception ex)
+        {
+            // Probe() is designed not to throw, but never let an unexpected fault
+            // poison the single-flight slot or leak out of the shared task.
+            _logger.Warn($"[mxc] availability probe threw unexpectedly: {ex.GetType().Name}: {ex.Message}");
+            result = new MxcAvailability(
+                false, false, false, null,
+                new[] { "MXC availability probe failed unexpectedly." }, probeErrored: true);
+        }
+
+        lock (_mxcAvailabilityLock)
+        {
+            _mxcAvailability = result;
+            // Open the retry window only AFTER completion so a slow (timeout) probe
+            // doesn't immediately allow a back-to-back re-probe.
+            _mxcNextProbeAllowedAtUtc = DateTime.UtcNow + MxcProbeRetryInterval;
+            _mxcProbeInFlight = null;
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Non-blocking read of the cached MXC availability for diagnostics/logging.
+    /// Returns null when nothing has been probed yet. Never spawns or waits on a
+    /// probe, so it is safe to call while holding other locks (e.g. _capabilitiesLock).
+    /// </summary>
+    private MxcAvailability? PeekMxcAvailability()
+    {
+        lock (_mxcAvailabilityLock)
+            return _mxcAvailability;
+    }
+
+    private void InvalidateMxcAvailability()
+    {
+        lock (_mxcAvailabilityLock)
+        {
+            _mxcAvailability = null;
+            _mxcNextProbeAllowedAtUtc = default;
+        }
+    }
 
     private void StartMcpServer()
     {

--- a/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCoordinator.cs
@@ -236,10 +236,10 @@ public sealed class PairingApprovalCoordinator
             {
                 ok = (approval.Kind, approve) switch
                 {
-                    (PairingApprovalKind.Device, true) => await client.DevicePairApproveAsync(approval.DecisionId),
-                    (PairingApprovalKind.Device, false) => await client.DevicePairRejectAsync(approval.DecisionId),
-                    (PairingApprovalKind.Node, true) => await client.NodePairApproveAsync(approval.DecisionId),
-                    (PairingApprovalKind.Node, false) => await client.NodePairRejectAsync(approval.DecisionId),
+                    (PendingApprovalKind.Device, true) => await client.DevicePairApproveAsync(approval.DecisionId),
+                    (PendingApprovalKind.Device, false) => await client.DevicePairRejectAsync(approval.DecisionId),
+                    (PendingApprovalKind.Node, true) => await client.NodePairApproveAsync(approval.DecisionId),
+                    (PendingApprovalKind.Node, false) => await client.NodePairRejectAsync(approval.DecisionId),
                     _ => false,
                 };
             }
@@ -273,7 +273,7 @@ public sealed class PairingApprovalCoordinator
                 // Nudge the gateway to re-send the list so the resolved entry drops (and confirms) promptly.
                 try
                 {
-                    if (approval.Kind == PairingApprovalKind.Device)
+                    if (approval.Kind == PendingApprovalKind.Device)
                         await liveClient.RequestDevicePairListAsync();
                     else
                         await liveClient.RequestNodePairListAsync();

--- a/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCoordinator.cs
@@ -236,10 +236,10 @@ public sealed class PairingApprovalCoordinator
             {
                 ok = (approval.Kind, approve) switch
                 {
-                    (PendingApprovalKind.Device, true) => await client.DevicePairApproveAsync(approval.DecisionId),
-                    (PendingApprovalKind.Device, false) => await client.DevicePairRejectAsync(approval.DecisionId),
-                    (PendingApprovalKind.Node, true) => await client.NodePairApproveAsync(approval.DecisionId),
-                    (PendingApprovalKind.Node, false) => await client.NodePairRejectAsync(approval.DecisionId),
+                    (PairingApprovalKind.DevicePair, true) => await client.DevicePairApproveAsync(approval.DecisionId),
+                    (PairingApprovalKind.DevicePair, false) => await client.DevicePairRejectAsync(approval.DecisionId),
+                    (PairingApprovalKind.NodePair, true) => await client.NodePairApproveAsync(approval.DecisionId),
+                    (PairingApprovalKind.NodePair, false) => await client.NodePairRejectAsync(approval.DecisionId),
                     _ => false,
                 };
             }
@@ -273,7 +273,7 @@ public sealed class PairingApprovalCoordinator
                 // Nudge the gateway to re-send the list so the resolved entry drops (and confirms) promptly.
                 try
                 {
-                    if (approval.Kind == PendingApprovalKind.Device)
+                    if (approval.Kind == PairingApprovalKind.DevicePair)
                         await liveClient.RequestDevicePairListAsync();
                     else
                         await liveClient.RequestNodePairListAsync();

--- a/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/PairingApprovalCoordinator.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using OpenClaw.Connection;
+using OpenClaw.Shared;
+
+namespace OpenClawTray.Services;
+
+/// <summary>Outcome of a confirmed approve/reject decision, surfaced for confirmation toasts/activity.</summary>
+public sealed class PairingDecisionResult
+{
+    public required PendingApproval Approval { get; init; }
+
+    /// <summary>True when the user approved, false when rejected.</summary>
+    public required bool Approved { get; init; }
+
+    /// <summary>True when the gateway confirmed the decision (the request left the pending list).</summary>
+    public required bool Success { get; init; }
+}
+
+/// <summary>
+/// Orchestrates inbound pairing approvals (devices and nodes requesting to join the gateway).
+/// Bridges the pure <see cref="PairingApprovalQueue"/> to the live operator client and the tray
+/// presentation layer:
+/// <list type="bullet">
+///   <item>Consumes pair-list snapshots from <see cref="GatewayService"/>.</item>
+///   <item>Raises <see cref="ApprovalRequested"/> for genuinely new requests so the app can present
+///         the approval window + an awareness toast (gated by scope and the user setting).</item>
+///   <item>Raises <see cref="ApprovalsChanged"/> whenever the actionable set changes so an open
+///         window refreshes.</item>
+///   <item>Executes approve/reject via the operator client and, once the gateway confirms the
+///         decision (the request leaves the pending list), reports <see cref="DecisionCompleted"/>.</item>
+/// </list>
+/// All members are expected to be invoked on the UI dispatcher thread (the gateway service marshals
+/// list updates there), so no internal locking is required.
+/// </summary>
+public sealed class PairingApprovalCoordinator
+{
+    private readonly PairingApprovalQueue _queue = new();
+    private readonly HashSet<string> _inFlight = new(StringComparer.Ordinal);
+    private bool _pollInFlight;
+    private readonly Func<IOperatorGatewayClient?> _getClient;
+    private readonly Func<IReadOnlyCollection<string>?> _getOwnNodeIds;
+    private readonly Func<bool> _isPromptEnabled;
+    private readonly IOpenClawLogger _logger;
+
+    public PairingApprovalCoordinator(
+        Func<IOperatorGatewayClient?> getClient,
+        Func<IReadOnlyCollection<string>?> getOwnNodeIds,
+        Func<bool> isPromptEnabled,
+        IOpenClawLogger logger)
+    {
+        _getClient = getClient ?? throw new ArgumentNullException(nameof(getClient));
+        _getOwnNodeIds = getOwnNodeIds ?? throw new ArgumentNullException(nameof(getOwnNodeIds));
+        _isPromptEnabled = isPromptEnabled ?? throw new ArgumentNullException(nameof(isPromptEnabled));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>Raised for each newly-arrived, actionable request the user should be prompted to decide.</summary>
+    public event EventHandler<PendingApproval>? ApprovalRequested;
+
+    /// <summary>Raised whenever the actionable approval set changes (add, resolve, or decision).</summary>
+    public event EventHandler? ApprovalsChanged;
+
+    /// <summary>
+    /// Raised when a submitted approve/reject is CONFIRMED by the gateway (the request left the
+    /// pending list). This is the authoritative success signal — it does not fire on send-ack alone.
+    /// </summary>
+    public event EventHandler<PairingDecisionResult>? DecisionCompleted;
+
+    /// <summary>The current actionable approvals, oldest first.</summary>
+    public IReadOnlyList<PendingApproval> Current => _queue.Current;
+
+    /// <summary>
+    /// Feed a fresh device/node pair-list snapshot. Diffs against prior state and raises the
+    /// appropriate presentation events. A null list for a kind means "no fresh snapshot for that
+    /// kind" — its prior entries are carried forward rather than treated as resolved.
+    /// </summary>
+    public void OnPairListsUpdated(DevicePairingListInfo? devices, PairingListInfo? nodes)
+    {
+        // If we're not connected, an empty/missing list reflects lost visibility — NOT that
+        // requests resolved. Clearing silently here prevents a still-pending submitted decision
+        // from being mis-reported as a confirmed success on disconnect, and drops stale approvals.
+        var client = _getClient();
+        if (client is not { IsConnectedToGateway: true })
+        {
+            Reset();
+            return;
+        }
+
+        PairingApprovalDelta delta;
+        try
+        {
+            // A null list for a kind = no fresh snapshot (carried forward), not "now empty".
+            delta = _queue.Reconcile(devices, nodes, _getOwnNodeIds(), Environment.TickCount64);
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"[PairApproval] Reconcile failed: {ex.Message}");
+            return;
+        }
+
+        if (!delta.HasChanges)
+            return;
+
+        // A submitted decision the gateway has now confirmed (request left the pending list) is the
+        // authoritative success signal — report it so the app shows the "approved/rejected" toast.
+        foreach (var resolved in delta.ConfirmedDecisions)
+        {
+            try
+            {
+                DecisionCompleted?.Invoke(this, new PairingDecisionResult
+                {
+                    Approval = resolved.Approval,
+                    Approved = resolved.Approved,
+                    Success = true,
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn($"[PairApproval] DecisionCompleted handler threw: {ex.Message}");
+            }
+        }
+
+        ApprovalsChanged?.Invoke(this, EventArgs.Empty);
+
+        if (delta.Added.Count == 0)
+            return;
+
+        // Only prompt when the user hasn't opted out and we actually have the scope to act.
+        if (!_isPromptEnabled() || !CanApproveWith(client))
+            return;
+
+        foreach (var added in delta.Added)
+        {
+            try
+            {
+                ApprovalRequested?.Invoke(this, added);
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn($"[PairApproval] ApprovalRequested handler threw: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Safety-net refresh: asks the gateway to re-send the pending pair lists. The gateway
+    /// broadcasts pair requests with <c>dropIfSlow=true</c>, so a congested socket can silently
+    /// drop a "device wants to connect" event; a periodic refresh ensures the request is still
+    /// picked up (and the in-page banner stays current). No-op unless the operator is connected
+    /// with approval scope. <see cref="OpenClawGatewayClient"/> already short-circuits these
+    /// requests on gateways that don't support pair lists, so this is cheap on older gateways.
+    /// </summary>
+    public async Task RefreshFromGatewayAsync()
+    {
+        // Non-reentrant: if a wedged-but-"connected" transport makes a refresh hang, don't let the
+        // 20s timer stack up more tracked requests on top of it.
+        if (_pollInFlight)
+            return;
+
+        var client = _getClient();
+        if (!CanApproveWith(client))
+            return;
+
+        _pollInFlight = true;
+        try
+        {
+            try { await client!.RequestDevicePairListAsync(); }
+            catch (Exception ex) { _logger.Info($"[PairApproval] Device pair-list poll failed: {ex.Message}"); }
+
+            try { await client!.RequestNodePairListAsync(); }
+            catch (Exception ex) { _logger.Info($"[PairApproval] Node pair-list poll failed: {ex.Message}"); }
+        }
+        finally
+        {
+            _pollInFlight = false;
+        }
+    }
+
+    /// <summary>Approve the request identified by <paramref name="key"/> (<see cref="PendingApproval.Key"/>).</summary>
+    public Task<bool> ApproveAsync(string key) => DecideAsync(key, approve: true);
+
+    /// <summary>Reject the request identified by <paramref name="key"/>.</summary>
+    public Task<bool> RejectAsync(string key) => DecideAsync(key, approve: false);
+
+    /// <summary>Clear all tracked state (e.g. on disconnect or gateway switch).</summary>
+    public void Reset()
+    {
+        _queue.Reset();
+        _inFlight.Clear();
+        _pollInFlight = false;
+        ApprovalsChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private async Task<bool> DecideAsync(string key, bool approve)
+    {
+        var approval = _queue.Find(key);
+        if (approval == null)
+        {
+            _logger.Info($"[PairApproval] Decision for unknown or already-submitted key '{key}' ignored");
+            return false;
+        }
+
+        // Legacy gateways may omit a request id; DecisionId then falls back to the device/node id.
+        // The gateway may ignore that, but the confirmed-resolution model handles it gracefully: the
+        // request simply isn't confirmed, expires, and re-surfaces — no permanent hide, no false toast.
+        if (string.IsNullOrEmpty(approval.RequestId))
+            _logger.Info($"[PairApproval] No request id; submitting decision with device/node id fallback for '{key}'");
+
+        // Guard against a double decision for the same request — e.g. a stray
+        // second click that slips through while the approve/reject RPC is still
+        // in flight. Single-threaded (UI dispatcher), so a HashSet is sufficient.
+        if (!_inFlight.Add(key))
+        {
+            _logger.Info($"[PairApproval] Decision already in flight for '{key}'");
+            return false;
+        }
+
+        try
+        {
+            var client = _getClient();
+            // Re-check connection AND approval scope at decision time — the dialog may have been
+            // open while scope was revoked or the operator reconnected with fewer scopes. The
+            // approve/reject frame is "send-acknowledged" (not gateway-acked), so guarding here
+            // avoids attempting an out-of-scope decision the gateway would silently reject.
+            if (client is not { IsConnectedToGateway: true }
+                || !OperatorScopeHelper.CanApproveDevices(client.GrantedOperatorScopes))
+            {
+                _logger.Warn("[PairApproval] Operator can no longer approve pairings (disconnected or scope lost); decision aborted");
+                return false;
+            }
+
+            bool ok = false;
+            try
+            {
+                ok = (approval.Kind, approve) switch
+                {
+                    (PairingApprovalKind.Device, true) => await client.DevicePairApproveAsync(approval.DecisionId),
+                    (PairingApprovalKind.Device, false) => await client.DevicePairRejectAsync(approval.DecisionId),
+                    (PairingApprovalKind.Node, true) => await client.NodePairApproveAsync(approval.DecisionId),
+                    (PairingApprovalKind.Node, false) => await client.NodePairRejectAsync(approval.DecisionId),
+                    _ => false,
+                };
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn($"[PairApproval] {(approve ? "Approve" : "Reject")} RPC failed: {ex.Message}");
+                ok = false;
+            }
+
+            if (ok)
+            {
+                // Send-ack only means the frame left the socket, NOT that the gateway accepted it.
+                // But first re-validate the exact connection: a disconnect/reconnect may have raced
+                // the await (and already Reset() the queue). Recording a submission against a new
+                // client would strand a likely-dropped frame and risk a later false confirmation, so
+                // treat it as not completed instead — the request re-surfaces on reconnect for a
+                // clean retry.
+                var liveClient = _getClient();
+                if (!ReferenceEquals(liveClient, client) || !CanApproveWith(liveClient))
+                {
+                    _logger.Info("[PairApproval] Connection changed during decision; not recording optimistic submission");
+                    return false;
+                }
+
+                // Record the decision as optimistic-pending so the UI advances, but defer the
+                // success confirmation until the gateway drops the request from the pending list
+                // (surfaced as a ConfirmedDecision on a later reconcile). If it never does, the
+                // submission expires and the request re-surfaces for retry.
+                _queue.MarkSubmitted(approval, approve, Environment.TickCount64);
+
+                // Nudge the gateway to re-send the list so the resolved entry drops (and confirms) promptly.
+                try
+                {
+                    if (approval.Kind == PairingApprovalKind.Device)
+                        await liveClient.RequestDevicePairListAsync();
+                    else
+                        await liveClient.RequestNodePairListAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.Info($"[PairApproval] Post-decision list refresh failed: {ex.Message}");
+                }
+
+                ApprovalsChanged?.Invoke(this, EventArgs.Empty);
+            }
+
+            return ok;
+        }
+        finally
+        {
+            _inFlight.Remove(key);
+        }
+    }
+
+    private static bool CanApproveWith(IOperatorGatewayClient? client) =>
+        client is { IsConnectedToGateway: true }
+        && OperatorScopeHelper.CanApproveDevices(client.GrantedOperatorScopes);
+}

--- a/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
@@ -88,6 +88,8 @@ public class SettingsManager
 
     // Node mode(gateway WebSocket connection — separate from MCP)
     public bool EnableNodeMode { get => _data.EnableNodeMode; set => _data = _data with { EnableNodeMode = value }; }
+    /// <summary>Master switch for the focused inbound-pairing approval dialog + awareness toast.</summary>
+    public bool ShowPairingApprovalDialog { get => _data.ShowPairingApprovalDialog; set => _data = _data with { ShowPairingApprovalDialog = value }; }
     public bool NodeCanvasEnabled { get => _data.NodeCanvasEnabled; set => _data = _data with { NodeCanvasEnabled = value }; }
     public bool NodeScreenEnabled { get => _data.NodeScreenEnabled; set => _data = _data with { NodeScreenEnabled = value }; }
     public bool NodeCameraEnabled { get => _data.NodeCameraEnabled; set => _data = _data with { NodeCameraEnabled = value }; }

--- a/src/OpenClaw.Tray.WinUI/Services/ToastActivationRouter.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ToastActivationRouter.cs
@@ -8,6 +8,7 @@ public sealed class ToastActivationActions
     public required Action<string?> OpenChat { get; init; }
     public required Action OpenActivity { get; init; }
     public required Action<string> CopyPairingCommand { get; init; }
+    public required Action ReviewPairing { get; init; }
 }
 
 public static class ToastActivationRouter
@@ -44,6 +45,9 @@ public static class ToastActivationRouter
                 var command = getArgument("command");
                 if (!string.IsNullOrWhiteSpace(command))
                     actions.CopyPairingCommand(command);
+                break;
+            case "review_pairing":
+                actions.ReviewPairing();
                 break;
         }
     }

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -689,6 +689,75 @@ Use one of these options:
   <data name="Toast_PairingCommandCopied" xml:space="preserve">
     <value>Pairing command copied</value>
   </data>
+  <data name="Toast_PairingRequestTitle" xml:space="preserve">
+    <value>Pairing request</value>
+  </data>
+  <data name="Toast_PairingRequestBody" xml:space="preserve">
+    <value>{0} wants to connect</value>
+  </data>
+  <data name="Toast_PairingRequestBodyNode" xml:space="preserve">
+    <value>{0} wants to connect as a node</value>
+  </data>
+  <data name="Toast_PairingReview" xml:space="preserve">
+    <value>Review</value>
+  </data>
+  <data name="Toast_PairingApprovedTitle" xml:space="preserve">
+    <value>Pairing approved</value>
+  </data>
+  <data name="Toast_PairingApprovedBody" xml:space="preserve">
+    <value>{0} can now connect</value>
+  </data>
+  <data name="Toast_PairingRejectedTitle" xml:space="preserve">
+    <value>Pairing rejected</value>
+  </data>
+  <data name="Toast_PairingRejectedBody" xml:space="preserve">
+    <value>{0} was not allowed to connect</value>
+  </data>
+  <data name="PairingApproval_WindowTitle" xml:space="preserve">
+    <value>Pairing request</value>
+  </data>
+  <data name="PairingApproval_DeviceHeading" xml:space="preserve">
+    <value>A device wants to connect</value>
+  </data>
+  <data name="PairingApproval_NodeHeading" xml:space="preserve">
+    <value>A node wants to connect</value>
+  </data>
+  <data name="PairingApproval_Subtitle" xml:space="preserve">
+    <value>Only approve if you recognize this request. You can remove it later in Connection settings.</value>
+  </data>
+  <data name="PairingApproval_AccessRequested" xml:space="preserve">
+    <value>Access requested</value>
+  </data>
+  <data name="PairingApproval_RepairBadge" xml:space="preserve">
+    <value>Re-pair request — the device token will rotate.</value>
+  </data>
+  <data name="PairingApproval_Approve" xml:space="preserve">
+    <value>Approve</value>
+  </data>
+  <data name="PairingApproval_ApproveDevice" xml:space="preserve">
+    <value>Approve device</value>
+  </data>
+  <data name="PairingApproval_ApproveNode" xml:space="preserve">
+    <value>Approve node</value>
+  </data>
+  <data name="PairingApproval_Reject" xml:space="preserve">
+    <value>Reject</value>
+  </data>
+  <data name="PairingApproval_Later" xml:space="preserve">
+    <value>Decide later</value>
+  </data>
+  <data name="PairingApproval_MoreWaiting" xml:space="preserve">
+    <value>{0} more waiting</value>
+  </data>
+  <data name="PairingApproval_ApproveHint" xml:space="preserve">
+    <value>Approve becomes available in a moment</value>
+  </data>
+  <data name="PairingApproval_UnknownDevice" xml:space="preserve">
+    <value>Unknown device</value>
+  </data>
+  <data name="PairingApproval_UnknownPlatform" xml:space="preserve">
+    <value>Unknown platform</value>
+  </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ Node Paired!</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -648,6 +648,75 @@ Utilisez l'une de ces options :
   <data name="Toast_PairingCommandCopied" xml:space="preserve">
     <value>Commande de jumelage copiée</value>
   </data>
+  <data name="Toast_PairingRequestTitle" xml:space="preserve">
+    <value>Demande de jumelage</value>
+  </data>
+  <data name="Toast_PairingRequestBody" xml:space="preserve">
+    <value>{0} souhaite se connecter</value>
+  </data>
+  <data name="Toast_PairingRequestBodyNode" xml:space="preserve">
+    <value>{0} souhaite se connecter en tant que nœud</value>
+  </data>
+  <data name="Toast_PairingReview" xml:space="preserve">
+    <value>Examiner</value>
+  </data>
+  <data name="Toast_PairingApprovedTitle" xml:space="preserve">
+    <value>Jumelage approuvé</value>
+  </data>
+  <data name="Toast_PairingApprovedBody" xml:space="preserve">
+    <value>{0} peut désormais se connecter</value>
+  </data>
+  <data name="Toast_PairingRejectedTitle" xml:space="preserve">
+    <value>Jumelage refusé</value>
+  </data>
+  <data name="Toast_PairingRejectedBody" xml:space="preserve">
+    <value>{0} n'a pas été autorisé à se connecter</value>
+  </data>
+  <data name="PairingApproval_WindowTitle" xml:space="preserve">
+    <value>Demande de jumelage</value>
+  </data>
+  <data name="PairingApproval_DeviceHeading" xml:space="preserve">
+    <value>Un appareil souhaite se connecter</value>
+  </data>
+  <data name="PairingApproval_NodeHeading" xml:space="preserve">
+    <value>Un nœud souhaite se connecter</value>
+  </data>
+  <data name="PairingApproval_Subtitle" xml:space="preserve">
+    <value>N'approuvez que si vous reconnaissez cette demande. Vous pourrez la supprimer plus tard dans les paramètres de connexion.</value>
+  </data>
+  <data name="PairingApproval_AccessRequested" xml:space="preserve">
+    <value>Accès demandé</value>
+  </data>
+  <data name="PairingApproval_RepairBadge" xml:space="preserve">
+    <value>Demande de réappairage — le jeton de l'appareil sera renouvelé.</value>
+  </data>
+  <data name="PairingApproval_Approve" xml:space="preserve">
+    <value>Approuver</value>
+  </data>
+  <data name="PairingApproval_ApproveDevice" xml:space="preserve">
+    <value>Approuver l'appareil</value>
+  </data>
+  <data name="PairingApproval_ApproveNode" xml:space="preserve">
+    <value>Approuver le nœud</value>
+  </data>
+  <data name="PairingApproval_Reject" xml:space="preserve">
+    <value>Refuser</value>
+  </data>
+  <data name="PairingApproval_Later" xml:space="preserve">
+    <value>Décider plus tard</value>
+  </data>
+  <data name="PairingApproval_MoreWaiting" xml:space="preserve">
+    <value>{0} en attente</value>
+  </data>
+  <data name="PairingApproval_ApproveHint" xml:space="preserve">
+    <value>L'approbation sera disponible dans un instant</value>
+  </data>
+  <data name="PairingApproval_UnknownDevice" xml:space="preserve">
+    <value>Appareil inconnu</value>
+  </data>
+  <data name="PairingApproval_UnknownPlatform" xml:space="preserve">
+    <value>Plateforme inconnue</value>
+  </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ Noeud appairé!</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -649,6 +649,75 @@ Gebruik een van deze opties:
   <data name="Toast_PairingCommandCopied" xml:space="preserve">
     <value>Koppelingsopdracht gekopieerd</value>
   </data>
+  <data name="Toast_PairingRequestTitle" xml:space="preserve">
+    <value>Koppelingsverzoek</value>
+  </data>
+  <data name="Toast_PairingRequestBody" xml:space="preserve">
+    <value>{0} wil verbinding maken</value>
+  </data>
+  <data name="Toast_PairingRequestBodyNode" xml:space="preserve">
+    <value>{0} wil verbinding maken als node</value>
+  </data>
+  <data name="Toast_PairingReview" xml:space="preserve">
+    <value>Bekijken</value>
+  </data>
+  <data name="Toast_PairingApprovedTitle" xml:space="preserve">
+    <value>Koppeling goedgekeurd</value>
+  </data>
+  <data name="Toast_PairingApprovedBody" xml:space="preserve">
+    <value>{0} kan nu verbinding maken</value>
+  </data>
+  <data name="Toast_PairingRejectedTitle" xml:space="preserve">
+    <value>Koppeling geweigerd</value>
+  </data>
+  <data name="Toast_PairingRejectedBody" xml:space="preserve">
+    <value>{0} mocht geen verbinding maken</value>
+  </data>
+  <data name="PairingApproval_WindowTitle" xml:space="preserve">
+    <value>Koppelingsverzoek</value>
+  </data>
+  <data name="PairingApproval_DeviceHeading" xml:space="preserve">
+    <value>Een apparaat wil verbinding maken</value>
+  </data>
+  <data name="PairingApproval_NodeHeading" xml:space="preserve">
+    <value>Een node wil verbinding maken</value>
+  </data>
+  <data name="PairingApproval_Subtitle" xml:space="preserve">
+    <value>Keur dit alleen goed als je dit verzoek herkent. Je kunt het later verwijderen in de verbindingsinstellingen.</value>
+  </data>
+  <data name="PairingApproval_AccessRequested" xml:space="preserve">
+    <value>Gevraagde toegang</value>
+  </data>
+  <data name="PairingApproval_RepairBadge" xml:space="preserve">
+    <value>Verzoek om opnieuw te koppelen — het apparaattoken wordt vernieuwd.</value>
+  </data>
+  <data name="PairingApproval_Approve" xml:space="preserve">
+    <value>Goedkeuren</value>
+  </data>
+  <data name="PairingApproval_ApproveDevice" xml:space="preserve">
+    <value>Apparaat goedkeuren</value>
+  </data>
+  <data name="PairingApproval_ApproveNode" xml:space="preserve">
+    <value>Node goedkeuren</value>
+  </data>
+  <data name="PairingApproval_Reject" xml:space="preserve">
+    <value>Weigeren</value>
+  </data>
+  <data name="PairingApproval_Later" xml:space="preserve">
+    <value>Later beslissen</value>
+  </data>
+  <data name="PairingApproval_MoreWaiting" xml:space="preserve">
+    <value>Nog {0} in wachtrij</value>
+  </data>
+  <data name="PairingApproval_ApproveHint" xml:space="preserve">
+    <value>Goedkeuren komt zo beschikbaar</value>
+  </data>
+  <data name="PairingApproval_UnknownDevice" xml:space="preserve">
+    <value>Onbekend apparaat</value>
+  </data>
+  <data name="PairingApproval_UnknownPlatform" xml:space="preserve">
+    <value>Onbekend platform</value>
+  </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ Node gekoppeld!</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -648,6 +648,75 @@
   <data name="Toast_PairingCommandCopied" xml:space="preserve">
     <value>配对命令已复制</value>
   </data>
+  <data name="Toast_PairingRequestTitle" xml:space="preserve">
+    <value>配对请求</value>
+  </data>
+  <data name="Toast_PairingRequestBody" xml:space="preserve">
+    <value>{0} 想要连接</value>
+  </data>
+  <data name="Toast_PairingRequestBodyNode" xml:space="preserve">
+    <value>{0} 想要作为节点连接</value>
+  </data>
+  <data name="Toast_PairingReview" xml:space="preserve">
+    <value>查看</value>
+  </data>
+  <data name="Toast_PairingApprovedTitle" xml:space="preserve">
+    <value>配对已批准</value>
+  </data>
+  <data name="Toast_PairingApprovedBody" xml:space="preserve">
+    <value>{0} 现在可以连接</value>
+  </data>
+  <data name="Toast_PairingRejectedTitle" xml:space="preserve">
+    <value>配对已拒绝</value>
+  </data>
+  <data name="Toast_PairingRejectedBody" xml:space="preserve">
+    <value>{0} 未获允许连接</value>
+  </data>
+  <data name="PairingApproval_WindowTitle" xml:space="preserve">
+    <value>配对请求</value>
+  </data>
+  <data name="PairingApproval_DeviceHeading" xml:space="preserve">
+    <value>有设备想要连接</value>
+  </data>
+  <data name="PairingApproval_NodeHeading" xml:space="preserve">
+    <value>有节点想要连接</value>
+  </data>
+  <data name="PairingApproval_Subtitle" xml:space="preserve">
+    <value>仅在您认识此请求时才批准。稍后可在“连接”设置中将其移除。</value>
+  </data>
+  <data name="PairingApproval_AccessRequested" xml:space="preserve">
+    <value>请求的访问权限</value>
+  </data>
+  <data name="PairingApproval_RepairBadge" xml:space="preserve">
+    <value>重新配对请求——设备令牌将轮换。</value>
+  </data>
+  <data name="PairingApproval_Approve" xml:space="preserve">
+    <value>批准</value>
+  </data>
+  <data name="PairingApproval_ApproveDevice" xml:space="preserve">
+    <value>批准设备</value>
+  </data>
+  <data name="PairingApproval_ApproveNode" xml:space="preserve">
+    <value>批准节点</value>
+  </data>
+  <data name="PairingApproval_Reject" xml:space="preserve">
+    <value>拒绝</value>
+  </data>
+  <data name="PairingApproval_Later" xml:space="preserve">
+    <value>稍后决定</value>
+  </data>
+  <data name="PairingApproval_MoreWaiting" xml:space="preserve">
+    <value>还有 {0} 个等待</value>
+  </data>
+  <data name="PairingApproval_ApproveHint" xml:space="preserve">
+    <value>批准将在稍后可用</value>
+  </data>
+  <data name="PairingApproval_UnknownDevice" xml:space="preserve">
+    <value>未知设备</value>
+  </data>
+  <data name="PairingApproval_UnknownPlatform" xml:space="preserve">
+    <value>未知平台</value>
+  </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ 节点已配对！</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -648,6 +648,75 @@
   <data name="Toast_PairingCommandCopied" xml:space="preserve">
     <value>配對命令已複製</value>
   </data>
+  <data name="Toast_PairingRequestTitle" xml:space="preserve">
+    <value>配對要求</value>
+  </data>
+  <data name="Toast_PairingRequestBody" xml:space="preserve">
+    <value>{0} 想要連線</value>
+  </data>
+  <data name="Toast_PairingRequestBodyNode" xml:space="preserve">
+    <value>{0} 想要作為節點連線</value>
+  </data>
+  <data name="Toast_PairingReview" xml:space="preserve">
+    <value>檢視</value>
+  </data>
+  <data name="Toast_PairingApprovedTitle" xml:space="preserve">
+    <value>配對已核准</value>
+  </data>
+  <data name="Toast_PairingApprovedBody" xml:space="preserve">
+    <value>{0} 現在可以連線</value>
+  </data>
+  <data name="Toast_PairingRejectedTitle" xml:space="preserve">
+    <value>配對已拒絕</value>
+  </data>
+  <data name="Toast_PairingRejectedBody" xml:space="preserve">
+    <value>{0} 未獲允許連線</value>
+  </data>
+  <data name="PairingApproval_WindowTitle" xml:space="preserve">
+    <value>配對要求</value>
+  </data>
+  <data name="PairingApproval_DeviceHeading" xml:space="preserve">
+    <value>有裝置想要連線</value>
+  </data>
+  <data name="PairingApproval_NodeHeading" xml:space="preserve">
+    <value>有節點想要連線</value>
+  </data>
+  <data name="PairingApproval_Subtitle" xml:space="preserve">
+    <value>僅在您認得此要求時才核准。稍後可在「連線」設定中將其移除。</value>
+  </data>
+  <data name="PairingApproval_AccessRequested" xml:space="preserve">
+    <value>要求的存取權限</value>
+  </data>
+  <data name="PairingApproval_RepairBadge" xml:space="preserve">
+    <value>重新配對要求——裝置權杖將輪替。</value>
+  </data>
+  <data name="PairingApproval_Approve" xml:space="preserve">
+    <value>核准</value>
+  </data>
+  <data name="PairingApproval_ApproveDevice" xml:space="preserve">
+    <value>核准裝置</value>
+  </data>
+  <data name="PairingApproval_ApproveNode" xml:space="preserve">
+    <value>核准節點</value>
+  </data>
+  <data name="PairingApproval_Reject" xml:space="preserve">
+    <value>拒絕</value>
+  </data>
+  <data name="PairingApproval_Later" xml:space="preserve">
+    <value>稍後決定</value>
+  </data>
+  <data name="PairingApproval_MoreWaiting" xml:space="preserve">
+    <value>還有 {0} 個等待</value>
+  </data>
+  <data name="PairingApproval_ApproveHint" xml:space="preserve">
+    <value>核准將在稍後可用</value>
+  </data>
+  <data name="PairingApproval_UnknownDevice" xml:space="preserve">
+    <value>未知裝置</value>
+  </data>
+  <data name="PairingApproval_UnknownPlatform" xml:space="preserve">
+    <value>未知平台</value>
+  </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ 節點已配對！</value>
   </data>

--- a/tests/OpenClaw.Connection.Tests/PairingApprovalQueueTests.cs
+++ b/tests/OpenClaw.Connection.Tests/PairingApprovalQueueTests.cs
@@ -27,7 +27,7 @@ public class PendingApprovalTests
 
         var a = PendingApproval.FromDevice(req);
 
-        Assert.Equal(PendingApprovalKind.Device, a.Kind);
+        Assert.Equal(PairingApprovalKind.DevicePair, a.Kind);
         Assert.Equal("req-1", a.RequestId);
         Assert.Equal("dev-1", a.DeviceId);
         Assert.Equal("Bedroom iPad", a.DisplayName);
@@ -62,7 +62,7 @@ public class PendingApprovalTests
 
         var a = PendingApproval.FromNode(req);
 
-        Assert.Equal(PendingApprovalKind.Node, a.Kind);
+        Assert.Equal(PairingApprovalKind.NodePair, a.Kind);
         Assert.Equal("node-9", a.DeviceId);
         Assert.Equal("node", a.Role);
         Assert.Empty(a.Scopes);
@@ -258,14 +258,14 @@ public class PairingApprovalQueueTests
         Assert.Equal(2, first.Current.Count);
 
         // Submit the device decision (optimistic-pending).
-        var dev = first.Added.First(a => a.Kind == PendingApprovalKind.Device);
+        var dev = first.Added.First(a => a.Kind == PairingApprovalKind.DevicePair);
         q.MarkSubmitted(dev, approved: true, nowMs: 0);
 
         // A node-only update arrives (device list is null = no fresh device snapshot). The device
         // submission must NOT be confirmed by its absence, and the node entry must survive.
         var nodeOnly = q.Reconcile(null, Nodes(Node("n1")), nowMs: 100);
         Assert.Empty(nodeOnly.ConfirmedDecisions);
-        Assert.Contains(nodeOnly.Current, a => a.Kind == PendingApprovalKind.Node);
+        Assert.Contains(nodeOnly.Current, a => a.Kind == PairingApprovalKind.NodePair);
 
         // When the device list genuinely returns without the request, it confirms.
         var deviceResolved = q.Reconcile(Devices(), Nodes(Node("n1")), nowMs: 200);
@@ -281,7 +281,7 @@ public class PairingApprovalQueueTests
 
         // Device-only refresh (node list null): the node request must not vanish.
         var delta = q.Reconcile(Devices(Device("dev")), null);
-        Assert.Contains(delta.Current, a => a.Kind == PendingApprovalKind.Node && a.RequestId == "n1");
+        Assert.Contains(delta.Current, a => a.Kind == PairingApprovalKind.NodePair && a.RequestId == "n1");
         Assert.DoesNotContain("Node:n1", delta.ResolvedKeys);
     }
 

--- a/tests/OpenClaw.Connection.Tests/PairingApprovalQueueTests.cs
+++ b/tests/OpenClaw.Connection.Tests/PairingApprovalQueueTests.cs
@@ -136,7 +136,7 @@ public class PairingApprovalQueueTests
         var delta = q.Reconcile(Devices(), null);
 
         Assert.Single(delta.ResolvedKeys);
-        Assert.Equal("Device:a", delta.ResolvedKeys[0]);
+        Assert.Equal("DevicePair:a", delta.ResolvedKeys[0]);
         Assert.Empty(delta.Current);
     }
 
@@ -282,7 +282,47 @@ public class PairingApprovalQueueTests
         // Device-only refresh (node list null): the node request must not vanish.
         var delta = q.Reconcile(Devices(Device("dev")), null);
         Assert.Contains(delta.Current, a => a.Kind == PairingApprovalKind.NodePair && a.RequestId == "n1");
-        Assert.DoesNotContain("Node:n1", delta.ResolvedKeys);
+        Assert.DoesNotContain("NodePair:n1", delta.ResolvedKeys);
+    }
+
+    [Fact]
+    public void Reconcile_DropsAmbiguousLegacyFallbackIds()
+    {
+        var q = new PairingApprovalQueue();
+        var delta = q.Reconcile(Devices(
+            new DevicePairingRequest { RequestId = "", DeviceId = "legacy", DisplayName = "first" },
+            new DevicePairingRequest { RequestId = "", DeviceId = "legacy", DisplayName = "second" }), null);
+
+        Assert.Empty(delta.Added);
+        Assert.Empty(delta.Current);
+    }
+
+    [Fact]
+    public void Reconcile_DropsAmbiguousLegacyNodeFallbackIds()
+    {
+        var q = new PairingApprovalQueue();
+        var delta = q.Reconcile(null, Nodes(
+            new PairingRequest { RequestId = "", NodeId = "legacy-node", DisplayName = "first" },
+            new PairingRequest { RequestId = "", NodeId = "legacy-node", DisplayName = "second" }));
+
+        Assert.Empty(delta.Added);
+        Assert.Empty(delta.Current);
+    }
+
+    [Fact]
+    public void Reconcile_DoesNotConfirmSubmittedDecisionWhenFallbackIdBecomesAmbiguous()
+    {
+        var q = new PairingApprovalQueue();
+        var first = q.Reconcile(Devices(
+            new DevicePairingRequest { RequestId = "", DeviceId = "legacy", DisplayName = "first" }), null);
+        q.MarkSubmitted(first.Added[0], approved: true, nowMs: 0);
+
+        var delta = q.Reconcile(Devices(
+            new DevicePairingRequest { RequestId = "", DeviceId = "legacy", DisplayName = "first" },
+            new DevicePairingRequest { RequestId = "", DeviceId = "legacy", DisplayName = "second" }), null, nowMs: 100);
+
+        Assert.Empty(delta.ConfirmedDecisions);
+        Assert.Empty(delta.Current);
     }
 
     [Fact]

--- a/tests/OpenClaw.Connection.Tests/PairingApprovalQueueTests.cs
+++ b/tests/OpenClaw.Connection.Tests/PairingApprovalQueueTests.cs
@@ -27,7 +27,7 @@ public class PendingApprovalTests
 
         var a = PendingApproval.FromDevice(req);
 
-        Assert.Equal(PairingApprovalKind.Device, a.Kind);
+        Assert.Equal(PendingApprovalKind.Device, a.Kind);
         Assert.Equal("req-1", a.RequestId);
         Assert.Equal("dev-1", a.DeviceId);
         Assert.Equal("Bedroom iPad", a.DisplayName);
@@ -62,7 +62,7 @@ public class PendingApprovalTests
 
         var a = PendingApproval.FromNode(req);
 
-        Assert.Equal(PairingApprovalKind.Node, a.Kind);
+        Assert.Equal(PendingApprovalKind.Node, a.Kind);
         Assert.Equal("node-9", a.DeviceId);
         Assert.Equal("node", a.Role);
         Assert.Empty(a.Scopes);
@@ -258,14 +258,14 @@ public class PairingApprovalQueueTests
         Assert.Equal(2, first.Current.Count);
 
         // Submit the device decision (optimistic-pending).
-        var dev = first.Added.First(a => a.Kind == PairingApprovalKind.Device);
+        var dev = first.Added.First(a => a.Kind == PendingApprovalKind.Device);
         q.MarkSubmitted(dev, approved: true, nowMs: 0);
 
         // A node-only update arrives (device list is null = no fresh device snapshot). The device
         // submission must NOT be confirmed by its absence, and the node entry must survive.
         var nodeOnly = q.Reconcile(null, Nodes(Node("n1")), nowMs: 100);
         Assert.Empty(nodeOnly.ConfirmedDecisions);
-        Assert.Contains(nodeOnly.Current, a => a.Kind == PairingApprovalKind.Node);
+        Assert.Contains(nodeOnly.Current, a => a.Kind == PendingApprovalKind.Node);
 
         // When the device list genuinely returns without the request, it confirms.
         var deviceResolved = q.Reconcile(Devices(), Nodes(Node("n1")), nowMs: 200);
@@ -281,7 +281,7 @@ public class PairingApprovalQueueTests
 
         // Device-only refresh (node list null): the node request must not vanish.
         var delta = q.Reconcile(Devices(Device("dev")), null);
-        Assert.Contains(delta.Current, a => a.Kind == PairingApprovalKind.Node && a.RequestId == "n1");
+        Assert.Contains(delta.Current, a => a.Kind == PendingApprovalKind.Node && a.RequestId == "n1");
         Assert.DoesNotContain("Node:n1", delta.ResolvedKeys);
     }
 

--- a/tests/OpenClaw.Connection.Tests/PairingApprovalQueueTests.cs
+++ b/tests/OpenClaw.Connection.Tests/PairingApprovalQueueTests.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenClaw.Connection;
+using OpenClaw.Shared;
+using Xunit;
+
+namespace OpenClaw.Connection.Tests;
+
+public class PendingApprovalTests
+{
+    [Fact]
+    public void FromDevice_MapsAllFields_AndNormalizesIp()
+    {
+        var req = new DevicePairingRequest
+        {
+            RequestId = "req-1",
+            DeviceId = "dev-1",
+            DisplayName = "Bedroom iPad",
+            Platform = "iPadOS",
+            Role = "operator",
+            Scopes = new[] { "operator.read", "", "operator.admin" },
+            RemoteIp = "::ffff:192.168.1.50",
+            IsRepair = true,
+            Ts = 1234,
+        };
+
+        var a = PendingApproval.FromDevice(req);
+
+        Assert.Equal(PairingApprovalKind.Device, a.Kind);
+        Assert.Equal("req-1", a.RequestId);
+        Assert.Equal("dev-1", a.DeviceId);
+        Assert.Equal("Bedroom iPad", a.DisplayName);
+        Assert.Equal("iPadOS", a.Platform);
+        Assert.Equal("operator", a.Role);
+        Assert.Equal(new[] { "operator.read", "operator.admin" }, a.Scopes);
+        Assert.Equal("192.168.1.50", a.RemoteIp);
+        Assert.True(a.IsRepair);
+        Assert.Equal(1234, a.Ts);
+    }
+
+    [Fact]
+    public void FromDevice_DefaultsRoleToOperator_WhenMissing()
+    {
+        var a = PendingApproval.FromDevice(new DevicePairingRequest { RequestId = "r", DeviceId = "d" });
+        Assert.Equal("operator", a.Role);
+    }
+
+    [Fact]
+    public void FromNode_MapsFields_AndHasNoScopes()
+    {
+        var req = new PairingRequest
+        {
+            RequestId = "req-2",
+            NodeId = "node-9",
+            DisplayName = "Studio PC",
+            Platform = "windows",
+            Version = "1.2.3",
+            RemoteIp = "10.0.0.4",
+            Ts = 99,
+        };
+
+        var a = PendingApproval.FromNode(req);
+
+        Assert.Equal(PairingApprovalKind.Node, a.Kind);
+        Assert.Equal("node-9", a.DeviceId);
+        Assert.Equal("node", a.Role);
+        Assert.Empty(a.Scopes);
+        Assert.Equal("1.2.3", a.Version);
+    }
+
+    [Fact]
+    public void DecisionId_PrefersRequestId_FallsBackToDeviceId()
+    {
+        Assert.Equal("req", PendingApproval.FromDevice(new DevicePairingRequest { RequestId = "req", DeviceId = "dev" }).DecisionId);
+        Assert.Equal("dev", PendingApproval.FromDevice(new DevicePairingRequest { RequestId = "", DeviceId = "dev" }).DecisionId);
+    }
+
+    [Fact]
+    public void Key_IsKindScoped()
+    {
+        var device = PendingApproval.FromDevice(new DevicePairingRequest { RequestId = "same", DeviceId = "x" });
+        var node = PendingApproval.FromNode(new PairingRequest { RequestId = "same", NodeId = "y" });
+        Assert.NotEqual(device.Key, node.Key);
+    }
+
+    [Fact]
+    public void IsActionable_FalseWhenNoIds()
+    {
+        Assert.False(PendingApproval.FromNode(new PairingRequest { RequestId = "", NodeId = "" }).IsActionable);
+        Assert.True(PendingApproval.FromDevice(new DevicePairingRequest { RequestId = "", DeviceId = "d" }).IsActionable);
+    }
+}
+
+public class PairingApprovalQueueTests
+{
+    private static DevicePairingListInfo Devices(params DevicePairingRequest[] reqs) =>
+        new() { Pending = reqs.ToList() };
+
+    private static PairingListInfo Nodes(params PairingRequest[] reqs) =>
+        new() { Pending = reqs.ToList() };
+
+    private static DevicePairingRequest Device(string id, double ts = 0, string[]? scopes = null) =>
+        new() { RequestId = id, DeviceId = $"d-{id}", DisplayName = id, Ts = ts, Scopes = scopes };
+
+    private static PairingRequest Node(string id, string? nodeId = null, double ts = 0) =>
+        new() { RequestId = id, NodeId = nodeId ?? $"n-{id}", DisplayName = id, Ts = ts };
+
+    [Fact]
+    public void Reconcile_SurfacesNewDeviceAndNodeRequests()
+    {
+        var q = new PairingApprovalQueue();
+        var delta = q.Reconcile(Devices(Device("a")), Nodes(Node("b")));
+
+        Assert.Equal(2, delta.Added.Count);
+        Assert.Empty(delta.ResolvedKeys);
+        Assert.Equal(2, delta.Current.Count);
+    }
+
+    [Fact]
+    public void Reconcile_DoesNotReAddKnownRequest()
+    {
+        var q = new PairingApprovalQueue();
+        q.Reconcile(Devices(Device("a")), null);
+        var second = q.Reconcile(Devices(Device("a")), null);
+
+        Assert.Empty(second.Added);
+        Assert.Single(second.Current);
+    }
+
+    [Fact]
+    public void Reconcile_ReportsResolvedWhenRequestLeaves()
+    {
+        var q = new PairingApprovalQueue();
+        q.Reconcile(Devices(Device("a")), null);
+        var delta = q.Reconcile(Devices(), null);
+
+        Assert.Single(delta.ResolvedKeys);
+        Assert.Equal("Device:a", delta.ResolvedKeys[0]);
+        Assert.Empty(delta.Current);
+    }
+
+    [Fact]
+    public void Reconcile_FiltersOwnNodeRequest()
+    {
+        var q = new PairingApprovalQueue();
+        var delta = q.Reconcile(null, Nodes(Node("self", nodeId: "MY-NODE"), Node("other", nodeId: "OTHER")), ownNodeDeviceIds: new[] { "my-node" });
+
+        Assert.Single(delta.Added);
+        Assert.Equal("other", delta.Added[0].RequestId);
+    }
+
+    [Fact]
+    public void Reconcile_FiltersOwnNodeByAnyAdvertisedId()
+    {
+        var q = new PairingApprovalQueue();
+        // The own node may surface under its device id OR its gateway node id — both must filter.
+        var delta = q.Reconcile(
+            null,
+            Nodes(Node("a", nodeId: "device-fingerprint"), Node("b", nodeId: "gateway-node-id"), Node("c", nodeId: "remote")),
+            ownNodeDeviceIds: new[] { "device-fingerprint", "gateway-node-id" });
+
+        Assert.Single(delta.Added);
+        Assert.Equal("c", delta.Added[0].RequestId);
+    }
+
+    [Fact]
+    public void Reconcile_DropsUnactionableEntries()
+    {
+        var q = new PairingApprovalQueue();
+        var delta = q.Reconcile(null, Nodes(new PairingRequest { RequestId = "", NodeId = "" }));
+        Assert.Empty(delta.Added);
+    }
+
+    [Fact]
+    public void Reconcile_DedupsDuplicateIds()
+    {
+        var q = new PairingApprovalQueue();
+        var delta = q.Reconcile(Devices(Device("a"), Device("a")), null);
+        Assert.Single(delta.Added);
+    }
+
+    [Fact]
+    public void Reconcile_OrdersCurrentByTimestamp()
+    {
+        var q = new PairingApprovalQueue();
+        var delta = q.Reconcile(Devices(Device("late", ts: 200), Device("early", ts: 100)), null);
+        Assert.Equal("early", delta.Current[0].RequestId);
+        Assert.Equal("late", delta.Current[1].RequestId);
+    }
+
+    [Fact]
+    public void MarkSubmitted_SuppressesFromActionableSet()
+    {
+        var q = new PairingApprovalQueue();
+        var first = q.Reconcile(Devices(Device("a")), null);
+        q.MarkSubmitted(first.Added[0], approved: true, nowMs: 1000);
+
+        var second = q.Reconcile(Devices(Device("a")), null, nowMs: 1100); // gateway still echoes it
+        Assert.Empty(second.Added);
+        Assert.Empty(second.Current); // submitted => not actionable
+        Assert.Empty(second.ConfirmedDecisions); // not yet resolved
+    }
+
+    [Fact]
+    public void MarkSubmitted_ConfirmsDecisionWhenRequestLeavesList()
+    {
+        var q = new PairingApprovalQueue();
+        var first = q.Reconcile(Devices(Device("a")), null);
+        q.MarkSubmitted(first.Added[0], approved: true, nowMs: 1000);
+
+        // Gateway accepted -> request drops from the pending list -> confirmed.
+        var delta = q.Reconcile(Devices(), null, nowMs: 1200);
+        Assert.Single(delta.ConfirmedDecisions);
+        Assert.True(delta.ConfirmedDecisions[0].Approved);
+        Assert.Equal("a", delta.ConfirmedDecisions[0].Approval.RequestId);
+        Assert.True(delta.HasChanges);
+    }
+
+    [Fact]
+    public void MarkSubmitted_ConfirmsRejectionWithCorrectFlag()
+    {
+        var q = new PairingApprovalQueue();
+        var first = q.Reconcile(Devices(Device("a")), null);
+        q.MarkSubmitted(first.Added[0], approved: false, nowMs: 0);
+
+        var delta = q.Reconcile(Devices(), null, nowMs: 100);
+        Assert.Single(delta.ConfirmedDecisions);
+        Assert.False(delta.ConfirmedDecisions[0].Approved);
+    }
+
+    [Fact]
+    public void MarkSubmitted_ReSurfacesAfterTimeoutWhenGatewayNeverActs()
+    {
+        var q = new PairingApprovalQueue();
+        var first = q.Reconcile(Devices(Device("a")), null, nowMs: 0);
+        q.MarkSubmitted(first.Added[0], approved: true, nowMs: 0);
+
+        // Still echoed, before timeout: suppressed, not re-added.
+        var before = q.Reconcile(Devices(Device("a")), null, nowMs: PairingApprovalQueue.SubmissionResolveTimeoutMs - 1);
+        Assert.Empty(before.Added);
+        Assert.Empty(before.Current);
+        Assert.Empty(before.ConfirmedDecisions);
+
+        // Past timeout, still echoed: re-surfaced for retry, NOT confirmed.
+        var after = q.Reconcile(Devices(Device("a")), null, nowMs: PairingApprovalQueue.SubmissionResolveTimeoutMs + 1);
+        Assert.Single(after.Added);
+        Assert.Single(after.Current);
+        Assert.Empty(after.ConfirmedDecisions);
+    }
+
+    [Fact]
+    public void Reconcile_NullListForKind_CarriesForwardAndDoesNotConfirm()
+    {
+        var q = new PairingApprovalQueue();
+        // Two kinds present.
+        var first = q.Reconcile(Devices(Device("dev")), Nodes(Node("n1")), nowMs: 0);
+        Assert.Equal(2, first.Current.Count);
+
+        // Submit the device decision (optimistic-pending).
+        var dev = first.Added.First(a => a.Kind == PairingApprovalKind.Device);
+        q.MarkSubmitted(dev, approved: true, nowMs: 0);
+
+        // A node-only update arrives (device list is null = no fresh device snapshot). The device
+        // submission must NOT be confirmed by its absence, and the node entry must survive.
+        var nodeOnly = q.Reconcile(null, Nodes(Node("n1")), nowMs: 100);
+        Assert.Empty(nodeOnly.ConfirmedDecisions);
+        Assert.Contains(nodeOnly.Current, a => a.Kind == PairingApprovalKind.Node);
+
+        // When the device list genuinely returns without the request, it confirms.
+        var deviceResolved = q.Reconcile(Devices(), Nodes(Node("n1")), nowMs: 200);
+        Assert.Single(deviceResolved.ConfirmedDecisions);
+        Assert.Equal("dev", deviceResolved.ConfirmedDecisions[0].Approval.RequestId);
+    }
+
+    [Fact]
+    public void Reconcile_NullNodeList_DoesNotDropExistingNodeRequests()
+    {
+        var q = new PairingApprovalQueue();
+        q.Reconcile(Devices(Device("dev")), Nodes(Node("n1")));
+
+        // Device-only refresh (node list null): the node request must not vanish.
+        var delta = q.Reconcile(Devices(Device("dev")), null);
+        Assert.Contains(delta.Current, a => a.Kind == PairingApprovalKind.Node && a.RequestId == "n1");
+        Assert.DoesNotContain("Node:n1", delta.ResolvedKeys);
+    }
+
+    [Fact]
+    public void Find_ReturnsTrackedButNotSubmitted()
+    {
+        var q = new PairingApprovalQueue();
+        var delta = q.Reconcile(Devices(Device("a")), null);
+        var approval = delta.Added[0];
+
+        Assert.NotNull(q.Find(approval.Key));
+        q.MarkSubmitted(approval, approved: true, nowMs: 0);
+        Assert.Null(q.Find(approval.Key));
+    }
+
+    [Fact]
+    public void Reset_ClearsEverything()
+    {
+        var q = new PairingApprovalQueue();
+        q.Reconcile(Devices(Device("a")), null);
+        q.Reset();
+        Assert.True(q.IsEmpty);
+
+        // After reset the same request surfaces again.
+        var delta = q.Reconcile(Devices(Device("a")), null);
+        Assert.Single(delta.Added);
+    }
+}
+
+public class PairingScopeDescriptionsTests
+{
+    [Theory]
+    [InlineData("operator.admin", "Admin access")]
+    [InlineData("operator.read", "Read OpenClaw data")]
+    [InlineData("operator.write", "Send messages and make changes")]
+    [InlineData("operator.approvals", "Manage approvals")]
+    [InlineData("operator.pairing", "Pair and repair devices")]
+    [InlineData("operator.talk.secrets", "Use Talk credentials")]
+    [InlineData("OPERATOR.ADMIN", "Admin access")]
+    public void Describe_ReturnsFriendlyLabel_ForKnownScope(string scope, string expected)
+    {
+        Assert.Equal(expected, PairingScopeDescriptions.Describe(scope));
+    }
+
+    [Fact]
+    public void Describe_ReturnsRawScope_ForUnknown()
+    {
+        Assert.Equal("custom.scope", PairingScopeDescriptions.Describe(" custom.scope "));
+    }
+
+    [Fact]
+    public void Describe_ReturnsEmpty_ForBlank()
+    {
+        Assert.Equal(string.Empty, PairingScopeDescriptions.Describe("   "));
+    }
+
+    [Fact]
+    public void DescribeAll_DropsBlanksAndDeduplicates_PreservingOrder()
+    {
+        var result = PairingScopeDescriptions.DescribeAll(
+            new[] { "operator.admin", "", "operator.admin", "operator.read" });
+        Assert.Equal(new[] { "Admin access", "Read OpenClaw data" }, result);
+    }
+
+    [Fact]
+    public void DescribeAll_ReturnsEmpty_ForNull()
+    {
+        Assert.Empty(PairingScopeDescriptions.DescribeAll(null));
+    }
+
+    [Theory]
+    [InlineData("operator.admin", true)]
+    [InlineData("unknown.scope", false)]
+    [InlineData("", false)]
+    public void IsKnown_ReflectsMapMembership(string scope, bool expected)
+    {
+        Assert.Equal(expected, PairingScopeDescriptions.IsKnown(scope));
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/Mxc/DirectAppContainerExecutorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/DirectAppContainerExecutorTests.cs
@@ -36,7 +36,7 @@ public class DirectAppContainerExecutorTests
             isWxcExecResolvable: false,
             wxcExecPath: null,
             unsupportedReasons: new[] { "test reason" });
-        var executor = new DirectAppContainerExecutor(availability, NullLogger.Instance);
+        var executor = new DirectAppContainerExecutor(() => availability, NullLogger.Instance);
 
         var ex = await Assert.ThrowsAsync<SandboxUnavailableException>(() => executor.ExecuteAsync(NewRequest()));
         Assert.Contains("test reason", ex.Message);
@@ -51,7 +51,7 @@ public class DirectAppContainerExecutorTests
             isWxcExecResolvable: false,
             wxcExecPath: null,
             unsupportedReasons: Array.Empty<string>());
-        var executor = new DirectAppContainerExecutor(availability, NullLogger.Instance);
+        var executor = new DirectAppContainerExecutor(() => availability, NullLogger.Instance);
 
         var ex = await Assert.ThrowsAsync<SandboxUnavailableException>(() => executor.ExecuteAsync(NewRequest()));
         Assert.Contains("wxc-exec.exe not found", ex.Message);
@@ -66,17 +66,54 @@ public class DirectAppContainerExecutorTests
             isWxcExecResolvable: true,
             wxcExecPath: "C:\\does\\not\\exist\\wxc-exec.exe",
             unsupportedReasons: Array.Empty<string>());
-        var executor = new DirectAppContainerExecutor(availability, NullLogger.Instance);
+        var executor = new DirectAppContainerExecutor(() => availability, NullLogger.Instance);
 
         // MxcExecutor's ctor throws FileNotFoundException → wrapped in SandboxUnavailableException.
         await Assert.ThrowsAsync<SandboxUnavailableException>(() => executor.ExecuteAsync(NewRequest()));
     }
 
     [Fact]
+    public async Task ExecuteAsync_ResolvesAvailabilityPerCall_PicksUpRecovery()
+    {
+        // Simulates a transient startup probe error that later recovers. The executor
+        // must read the provider on each call, not freeze the first snapshot — else a
+        // momentary startup glitch would pin it to "unavailable" for its lifetime.
+        var calls = 0;
+        var unavailable = new MxcAvailability(
+            isAppContainerAvailable: false,
+            isIsolationSessionAvailable: false,
+            isWxcExecResolvable: true,
+            wxcExecPath: null,
+            unsupportedReasons: new[] { "transient probe error" },
+            probeErrored: true);
+        var recoveredButPathMissing = new MxcAvailability(
+            isAppContainerAvailable: true,
+            isIsolationSessionAvailable: false,
+            isWxcExecResolvable: true,
+            wxcExecPath: "C:\\does\\not\\exist\\wxc-exec.exe",
+            unsupportedReasons: Array.Empty<string>());
+
+        var executor = new DirectAppContainerExecutor(
+            () => { calls++; return calls == 1 ? unavailable : recoveredButPathMissing; },
+            NullLogger.Instance);
+
+        // First call: unavailable → throws with the transient reason.
+        var ex1 = await Assert.ThrowsAsync<SandboxUnavailableException>(() => executor.ExecuteAsync(NewRequest()));
+        Assert.Contains("transient probe error", ex1.Message);
+
+        // Second call: provider now reports available (path just doesn't exist on
+        // disk). The DIFFERENT failure proves the executor re-resolved availability
+        // instead of reusing the first (unavailable) snapshot.
+        var ex2 = await Assert.ThrowsAsync<SandboxUnavailableException>(() => executor.ExecuteAsync(NewRequest()));
+        Assert.Contains("wxc-exec.exe not found at", ex2.Message);
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
     public void Name_IsStableForTelemetry()
     {
         var availability = new MxcAvailability(false, false, false, null, Array.Empty<string>());
-        var executor = new DirectAppContainerExecutor(availability, NullLogger.Instance);
+        var executor = new DirectAppContainerExecutor(() => availability, NullLogger.Instance);
         Assert.Equal("mxc-direct-appc", executor.Name);
         Assert.True(executor.IsContained);
     }

--- a/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-balanced.json
+++ b/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-balanced.json
@@ -34,7 +34,7 @@
     "defaultPolicy": "allow",
     "enforcementMode": "capabilities"
   },
-  "appContainer": {
+  "processContainer": {
     "leastPrivilege": false,
     "capabilities": [
       "internetClient"

--- a/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-custom.json
+++ b/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-custom.json
@@ -33,7 +33,7 @@
     "defaultPolicy": "allow",
     "enforcementMode": "capabilities"
   },
-  "appContainer": {
+  "processContainer": {
     "leastPrivilege": false,
     "capabilities": [
       "internetClient"

--- a/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-locked-down.json
+++ b/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-locked-down.json
@@ -30,7 +30,7 @@
     "defaultPolicy": "block",
     "enforcementMode": "capabilities"
   },
-  "appContainer": {
+  "processContainer": {
     "leastPrivilege": false,
     "capabilities": [],
     "ui": {

--- a/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-permissive.json
+++ b/tests/OpenClaw.Shared.Tests/Mxc/Golden/sdk-config-permissive.json
@@ -33,7 +33,7 @@
     "defaultPolicy": "allow",
     "enforcementMode": "capabilities"
   },
-  "appContainer": {
+  "processContainer": {
     "leastPrivilege": false,
     "capabilities": [
       "internetClient"

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcAvailabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcAvailabilityTests.cs
@@ -64,30 +64,285 @@ public class MxcAvailabilityTests
         Assert.True(availability.HasAnyBackend);
     }
 
-    [Theory]
-    [InlineData(26299, 9999, "is not MXC supported build 26300")]
-    [InlineData(26300, 8288, "Windows UBR 8288 below MXC minimum 8289")]
-    [InlineData(26301, 9999, "is not MXC supported build 26300")]
-    [InlineData(27999, 9999, "is not MXC supported build 26300")]
-    [InlineData(28000, 9999, "is not MXC supported build 26300")]
-    public void GetWindowsBuildUnsupportedReason_RejectsUnsupportedBuilds(
-        int build,
-        int ubr,
-        string expectedReason)
+    [Fact]
+    public void ParseProbeOutput_ValidTier_ReportsSupported()
     {
-        var reason = MxcAvailability.GetWindowsBuildUnsupportedReason(build, ubr);
+        var result = MxcAvailability.ParseProbeOutput(
+            WxcProbeStatus.Completed,
+            exitCode: 0,
+            stdout: "{\"tier\":\"base-container\",\"needsDaclAugmentation\":false,\"warnings\":[]}",
+            stderr: "");
 
-        Assert.NotNull(reason);
-        Assert.Contains(expectedReason, reason);
+        Assert.Equal(MxcProbeOutcome.Supported, result.Outcome);
+        Assert.True(result.Supported);
+        Assert.Equal("base-container", result.Tier);
+        Assert.False(result.NeedsDaclAugmentation);
+        Assert.Empty(result.Warnings);
+        Assert.Null(result.FailureReason);
+    }
+
+    [Fact]
+    public void ParseProbeOutput_CapturesWarningsAndDaclFlag()
+    {
+        var result = MxcAvailability.ParseProbeOutput(
+            WxcProbeStatus.Completed,
+            exitCode: 0,
+            stdout: "{\"tier\":\"appcontainer-dacl\",\"needsDaclAugmentation\":true,\"warnings\":[\"fell back to dacl\"]}",
+            stderr: "");
+
+        Assert.Equal(MxcProbeOutcome.Supported, result.Outcome);
+        Assert.True(result.Supported);
+        Assert.Equal("appcontainer-dacl", result.Tier);
+        Assert.True(result.NeedsDaclAugmentation);
+        Assert.Equal(new[] { "fell back to dacl" }, result.Warnings);
+    }
+
+    [Fact]
+    public void ParseProbeOutput_CompletedNonZeroExit_ReportsProbeError()
+    {
+        var result = MxcAvailability.ParseProbeOutput(
+            WxcProbeStatus.Completed,
+            exitCode: 1,
+            stdout: "",
+            stderr: "unknown option --probe");
+
+        Assert.Equal(MxcProbeOutcome.ProbeError, result.Outcome);
+        Assert.False(result.Supported);
+        Assert.Null(result.Tier);
+        Assert.NotNull(result.FailureReason);
+        Assert.Contains("Could not determine", result.FailureReason!);
+    }
+
+    [Fact]
+    public void ParseProbeOutput_CompletedJsonError_ReportsUnsupportedHost()
+    {
+        var result = MxcAvailability.ParseProbeOutput(
+            WxcProbeStatus.Completed,
+            exitCode: 1,
+            stdout: "{\"error\":\"unsupported Windows build\",\"warnings\":[\"need newer host\"]}",
+            stderr: "");
+
+        Assert.Equal(MxcProbeOutcome.UnsupportedHost, result.Outcome);
+        Assert.False(result.Supported);
+        Assert.Null(result.Tier);
+        Assert.Equal(["need newer host"], result.Warnings);
+        Assert.NotNull(result.FailureReason);
+        Assert.Contains("unsupported Windows build", result.FailureReason!);
+    }
+
+    [Fact]
+    public void ParseProbeOutput_TimedOutStatus_ReportsProbeError()
+    {
+        // Timeout is our own infrastructure failure — transient, regardless of exit code.
+        var result = MxcAvailability.ParseProbeOutput(
+            WxcProbeStatus.TimedOut, exitCode: 0, stdout: "", stderr: "wxc-exec --probe timed out.");
+
+        Assert.Equal(MxcProbeOutcome.ProbeError, result.Outcome);
+        Assert.False(result.Supported);
+        Assert.NotNull(result.FailureReason);
+        Assert.Contains("Could not determine", result.FailureReason!);
+    }
+
+    [Fact]
+    public void ParseProbeOutput_LaunchFailedStatus_ReportsProbeError()
+    {
+        var result = MxcAvailability.ParseProbeOutput(
+            WxcProbeStatus.LaunchFailed, exitCode: 0, stdout: "", stderr: "Failed to launch wxc-exec --probe: access denied");
+
+        Assert.Equal(MxcProbeOutcome.ProbeError, result.Outcome);
+        Assert.False(result.Supported);
+        Assert.NotNull(result.FailureReason);
+        Assert.Contains("Could not determine", result.FailureReason!);
+    }
+
+    [Fact]
+    public void ParseProbeOutput_NonCompletedStatus_IgnoresExitCode()
+    {
+        // Even a "successful-looking" exit code must not flip a timeout/launch failure
+        // into a definitive verdict — the status wins.
+        var result = MxcAvailability.ParseProbeOutput(
+            WxcProbeStatus.TimedOut,
+            exitCode: 0,
+            stdout: "{\"tier\":\"base-container\"}",
+            stderr: "");
+
+        Assert.Equal(MxcProbeOutcome.ProbeError, result.Outcome);
+        Assert.Null(result.Tier);
     }
 
     [Theory]
-    [InlineData(26300, 8289)]
-    [InlineData(26300, 9999)]
-    public void GetWindowsBuildUnsupportedReason_AllowsSupportedBuilds(int build, int ubr)
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("{\"needsDaclAugmentation\":false}")]
+    [InlineData("{\"tier\":\"\"}")]
+    [InlineData("not json at all")]
+    public void ParseProbeOutput_CompletedExitZeroButNoUsableOutput_ReportsProbeError(string stdout)
     {
-        var reason = MxcAvailability.GetWindowsBuildUnsupportedReason(build, ubr);
+        // Exit 0 with missing/garbled output is a binary anomaly, not a clear
+        // "unsupported" verdict — treat as retryable probe error.
+        var result = MxcAvailability.ParseProbeOutput(WxcProbeStatus.Completed, exitCode: 0, stdout: stdout, stderr: "");
 
-        Assert.Null(reason);
+        Assert.Equal(MxcProbeOutcome.ProbeError, result.Outcome);
+        Assert.False(result.Supported);
+        Assert.Null(result.Tier);
+        Assert.NotNull(result.FailureReason);
+    }
+
+    [Theory]
+    [InlineData("base-container", false, false)]
+    [InlineData("appcontainer-bfs", false, false)]
+    [InlineData("appcontainer-dacl", false, true)]
+    [InlineData("base-container", true, true)]   // needsDaclAugmentation forces degraded
+    [InlineData("some-future-tier", false, true)] // unrecognized tier => degraded
+    public void IsDegradedContainment_ReflectsTierAndDaclFlag(string tier, bool needsDacl, bool expectedDegraded)
+    {
+        var availability = new MxcAvailability(
+            isAppContainerAvailable: true,
+            isIsolationSessionAvailable: false,
+            isWxcExecResolvable: true,
+            wxcExecPath: "C:\\fake\\wxc-exec.exe",
+            unsupportedReasons: Array.Empty<string>(),
+            isolationTier: tier,
+            needsDaclAugmentation: needsDacl);
+
+        Assert.True(availability.HasAnyBackend);
+        Assert.Equal(expectedDegraded, availability.IsDegradedContainment);
+    }
+
+    [Fact]
+    public void IsDegradedContainment_FalseWhenNoBackend()
+    {
+        var availability = new MxcAvailability(
+            isAppContainerAvailable: false,
+            isIsolationSessionAvailable: false,
+            isWxcExecResolvable: true,
+            wxcExecPath: "C:\\fake\\wxc-exec.exe",
+            unsupportedReasons: new[] { "nope" },
+            isolationTier: "appcontainer-dacl",
+            needsDaclAugmentation: true);
+
+        Assert.False(availability.HasAnyBackend);
+        Assert.False(availability.IsDegradedContainment);
+    }
+
+    [Fact]
+    public void Probe_WhenProbeReportsTier_ReportsAvailable()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var fakeExe = Path.Combine(Path.GetTempPath(), $"wxc-fake-{Guid.NewGuid():N}.exe");
+        File.WriteAllText(fakeExe, string.Empty);
+        try
+        {
+            Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, fakeExe);
+
+            var availability = MxcAvailability.Probe(
+                NullLogger.Instance,
+                _ => new WxcProbeInvocation(WxcProbeStatus.Completed, 0, "{\"tier\":\"base-container\",\"warnings\":[]}", string.Empty));
+
+            Assert.True(availability.IsAppContainerAvailable);
+            Assert.True(availability.IsWxcExecResolvable);
+            Assert.Equal(fakeExe, availability.WxcExecPath);
+            Assert.Empty(availability.UnsupportedReasons);
+            Assert.False(availability.ProbeErrored);
+            Assert.Equal("base-container", availability.IsolationTier);
+            Assert.False(availability.IsDegradedContainment);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, null);
+            try { File.Delete(fakeExe); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public void Probe_WhenProbeReportsNoTier_ReportsUnavailableWithReason()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var fakeExe = Path.Combine(Path.GetTempPath(), $"wxc-fake-{Guid.NewGuid():N}.exe");
+        File.WriteAllText(fakeExe, string.Empty);
+        try
+        {
+            Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, fakeExe);
+
+            var availability = MxcAvailability.Probe(
+                NullLogger.Instance,
+                _ => new WxcProbeInvocation(WxcProbeStatus.Completed, 1, string.Empty, "unsupported os build"));
+
+            Assert.True(availability.IsWxcExecResolvable);
+            Assert.False(availability.IsAppContainerAvailable);
+            Assert.False(availability.HasAnyBackend);
+            Assert.NotEmpty(availability.UnsupportedReasons);
+            Assert.True(availability.ProbeErrored);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, null);
+            try { File.Delete(fakeExe); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public void Probe_WhenProbeTimesOut_ReportsProbeErrored()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var fakeExe = Path.Combine(Path.GetTempPath(), $"wxc-fake-{Guid.NewGuid():N}.exe");
+        File.WriteAllText(fakeExe, string.Empty);
+        try
+        {
+            Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, fakeExe);
+
+            // TimedOut status → transient probe error.
+            var availability = MxcAvailability.Probe(
+                NullLogger.Instance,
+                _ => new WxcProbeInvocation(WxcProbeStatus.TimedOut, 0, string.Empty, "wxc-exec --probe timed out."));
+
+            Assert.True(availability.IsWxcExecResolvable);
+            Assert.False(availability.IsAppContainerAvailable);
+            Assert.False(availability.HasAnyBackend);
+            Assert.True(availability.ProbeErrored);
+            Assert.NotEmpty(availability.UnsupportedReasons);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, null);
+            try { File.Delete(fakeExe); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public void Probe_WhenProbeReportsDaclTier_ReportsDegraded()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var fakeExe = Path.Combine(Path.GetTempPath(), $"wxc-fake-{Guid.NewGuid():N}.exe");
+        File.WriteAllText(fakeExe, string.Empty);
+        try
+        {
+            Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, fakeExe);
+
+            var availability = MxcAvailability.Probe(
+                NullLogger.Instance,
+                _ => new WxcProbeInvocation(
+                    WxcProbeStatus.Completed,
+                    0,
+                    "{\"tier\":\"appcontainer-dacl\",\"needsDaclAugmentation\":true,\"warnings\":[\"fallback\"]}",
+                    string.Empty));
+
+            // Still contained (don't downgrade to uncontained), but flagged degraded.
+            Assert.True(availability.IsAppContainerAvailable);
+            Assert.True(availability.HasAnyBackend);
+            Assert.True(availability.IsDegradedContainment);
+            Assert.Equal("appcontainer-dacl", availability.IsolationTier);
+            Assert.True(availability.NeedsDaclAugmentation);
+            Assert.False(availability.ProbeErrored);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(MxcAvailability.WxcExecOverrideEnvVar, null);
+            try { File.Delete(fakeExe); } catch { /* best-effort */ }
+        }
     }
 }

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcCommandRunnerIntegrationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcCommandRunnerIntegrationTests.cs
@@ -50,7 +50,7 @@ public class MxcCommandRunnerIntegrationTests
             return null;
         }
 
-        var executor = new DirectAppContainerExecutor(availability, new ConsoleLogger());
+        var executor = new DirectAppContainerExecutor(() => availability, new ConsoleLogger());
 
         var settings = new SettingsData
         {

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcCommandRunnerTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcCommandRunnerTests.cs
@@ -61,12 +61,25 @@ public class MxcCommandRunnerTests
         {
             Result = new CommandResult { ExitCode = 0, Stdout = "host" },
         };
-        var runner = NewRunner(executor, fallback, NewSettings(sandboxEnabled: false));
+        var availabilityChecks = 0;
+        var runner = new MxcCommandRunner(
+            executor,
+            fallback,
+            () => NewSettings(sandboxEnabled: false),
+            () => "C:\\test\\settings",
+            () =>
+            {
+                availabilityChecks++;
+                return true;
+            },
+            invalidateAvailability: null,
+            NullLogger.Instance);
 
         var result = await runner.RunAsync(new CommandRequest { Command = "echo hi" });
 
         Assert.Equal("host", result.Stdout);
         Assert.NotNull(fallback.LastRequest);
+        Assert.Equal(0, availabilityChecks);
         // Executor must not have been touched.
         Assert.Null(executor.LastRequest);
     }
@@ -101,9 +114,8 @@ public class MxcCommandRunnerTests
     [Fact]
     public async Task RunAsync_MxcUnavailable_FallsBackToHost_WithSandboxToggleOn()
     {
-        // Same as the toggle-off variant — the !_isSandboxAvailable() short-circuit
-        // fires before either the toggle check or the executor path, and both
-        // routes lead to the host fallback.
+        // With sandboxing enabled, unavailable MXC is detected before the
+        // executor path and routes to the host fallback.
         var executor = new FakeSandboxExecutor { ThrowsUnavailable = true, UnavailableReason = "MXC missing" };
         var fallback = new FakeCommandRunner
         {

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcConfigBuilderTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcConfigBuilderTests.cs
@@ -173,7 +173,7 @@ public class MxcConfigBuilderTests
     {
         var policy = BalancedPolicy();
         var config = MxcConfigBuilder.Build(RequestFor(policy), P.Scratch, pathEnvVar: "");
-        Assert.Contains("internetClient", config.AppContainer!.Capabilities!);
+        Assert.Contains("internetClient", config.ProcessContainer!.Capabilities!);
         Assert.Equal("allow", config.Network!.DefaultPolicy);
     }
 
@@ -182,7 +182,7 @@ public class MxcConfigBuilderTests
     {
         var policy = LockedDownPolicy();
         var config = MxcConfigBuilder.Build(RequestFor(policy), P.Scratch, pathEnvVar: "");
-        Assert.DoesNotContain("internetClient", config.AppContainer!.Capabilities!);
+        Assert.DoesNotContain("internetClient", config.ProcessContainer!.Capabilities!);
         Assert.Equal("block", config.Network!.DefaultPolicy);
     }
 
@@ -430,14 +430,14 @@ public class MxcConfigBuilderTests
     {
         // commandLine/cwd/env/timeoutMs live under "process" — the SDK leaves
         // process empty when called with createConfigFromPolicy and we add
-        // these ourselves. appContainer.name is a per-invocation random hex
+        // these ourselves. processContainer.name is a per-invocation random hex
         // that we stripped from the goldens.
         return fullPath is
             "$.process.commandLine" or
             "$.process.cwd" or
             "$.process.env" or
             "$.process.timeoutMs" or
-            "$.appContainer.name";
+            "$.processContainer.name";
     }
 
     private static void AssertNodeEqual(object? expected, object? actual, string path)

--- a/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
@@ -175,7 +175,7 @@ public sealed class InstallerIssAssertionTests
 
         Assert.Contains("private ICommandRunner BuildSystemRunRunner()", nodeService);
         Assert.Contains("MxcAvailability.Probe(_logger)", nodeService);
-        Assert.Contains("new DirectAppContainerExecutor(availability, _logger)", nodeService);
+        Assert.Contains("new DirectAppContainerExecutor(GetOrProbeMxcAvailability, _logger)", nodeService);
         Assert.Contains("return new MxcCommandRunner(", nodeService);
     }
 

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\CommandCenterTopologyTunnelResolver.cs" Link="Services\CommandCenterTopologyTunnelResolver.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\CommandCenterTunnelInfoBuilder.cs" Link="Services\CommandCenterTunnelInfoBuilder.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\PortDiagnosticsService.cs" Link="Services\PortDiagnosticsService.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\PairingApprovalCoordinator.cs" Link="Services\PairingApprovalCoordinator.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ToastActivationRouter.cs" Link="Services\ToastActivationRouter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\AppNotificationService.cs" Link="Services\AppNotificationService.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\UsageCostApplicationPolicy.cs" Link="Services\UsageCostApplicationPolicy.cs" />

--- a/tests/OpenClaw.Tray.Tests/PairingApprovalCoordinatorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/PairingApprovalCoordinatorTests.cs
@@ -1,0 +1,177 @@
+using System.Text.Json;
+using OpenClaw.Shared;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class PairingApprovalCoordinatorTests
+{
+    [Fact]
+    public async Task ApproveAsync_WhenClientChangesBeforeAck_DoesNotMarkSubmitted()
+    {
+        var originalClient = new FakeOperatorGatewayClient();
+        var replacementClient = new FakeOperatorGatewayClient();
+        var approveGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        originalClient.DeviceApproveResult = approveGate.Task;
+        IOperatorGatewayClient? currentClient = originalClient;
+        var coordinator = NewCoordinator(() => currentClient);
+
+        coordinator.OnPairListsUpdated(Devices(Device("req-1")), null);
+        var approval = Assert.Single(coordinator.Current);
+
+        var approveTask = coordinator.ApproveAsync(approval.Key);
+        Assert.Equal(1, originalClient.DeviceApproveCalls);
+
+        currentClient = replacementClient;
+        approveGate.SetResult(true);
+        var result = await approveTask;
+
+        Assert.False(result);
+        Assert.Single(coordinator.Current);
+        Assert.Equal(0, originalClient.DeviceListRequests);
+        Assert.Equal(0, replacementClient.DeviceListRequests);
+    }
+
+    [Fact]
+    public async Task ApproveAsync_WhenSameClientAcks_RecordsSubmissionAndRefreshesList()
+    {
+        var client = new FakeOperatorGatewayClient();
+        var coordinator = NewCoordinator(() => client);
+
+        coordinator.OnPairListsUpdated(Devices(Device("req-1")), null);
+        var approval = Assert.Single(coordinator.Current);
+
+        var result = await coordinator.ApproveAsync(approval.Key);
+
+        Assert.True(result);
+        Assert.Empty(coordinator.Current);
+        Assert.Equal(1, client.DeviceApproveCalls);
+        Assert.Equal(1, client.DeviceListRequests);
+    }
+
+    private static PairingApprovalCoordinator NewCoordinator(Func<IOperatorGatewayClient?> getClient) =>
+        new(
+            getClient,
+            getOwnNodeIds: () => Array.Empty<string>(),
+            isPromptEnabled: () => true,
+            logger: NullLogger.Instance);
+
+    private static DevicePairingListInfo Devices(params DevicePairingRequest[] requests) =>
+        new() { Pending = requests.ToList() };
+
+    private static DevicePairingRequest Device(string requestId) =>
+        new()
+        {
+            RequestId = requestId,
+            DeviceId = $"device-{requestId}",
+            DisplayName = requestId,
+            Scopes = ["operator.read"],
+        };
+
+#pragma warning disable CS0067
+    private sealed class FakeOperatorGatewayClient : IOperatorGatewayClient
+    {
+        public Task<bool> DeviceApproveResult { get; set; } = Task.FromResult(true);
+        public int DeviceApproveCalls { get; private set; }
+        public int DeviceListRequests { get; private set; }
+        public string? OperatorDeviceId => "operator";
+        public IReadOnlyList<string> GrantedOperatorScopes { get; set; } = ["operator.admin"];
+        public bool IsConnectedToGateway { get; set; } = true;
+        public string? MainSessionKey => "main";
+        public bool HasHandshakeSnapshot => true;
+
+        public event EventHandler<OpenClawNotification>? NotificationReceived;
+        public event EventHandler<AgentActivity>? ActivityChanged;
+        public event EventHandler<ChannelHealth[]>? ChannelHealthUpdated;
+        public event EventHandler<SessionInfo[]>? SessionsUpdated;
+        public event EventHandler<GatewayUsageInfo>? UsageUpdated;
+        public event EventHandler<GatewayUsageStatusInfo>? UsageStatusUpdated;
+        public event EventHandler<GatewayCostUsageInfo>? UsageCostUpdated;
+        public event EventHandler<GatewayNodeInfo[]>? NodesUpdated;
+        public event EventHandler<SessionsPreviewPayloadInfo>? SessionPreviewUpdated;
+        public event EventHandler<SessionCommandResult>? SessionCommandCompleted;
+        public event EventHandler<GatewaySelfInfo>? GatewaySelfUpdated;
+        public event EventHandler<JsonElement>? CronListUpdated;
+        public event EventHandler<JsonElement>? CronStatusUpdated;
+        public event EventHandler<JsonElement>? CronRunsUpdated;
+        public event EventHandler<JsonElement>? SkillsStatusUpdated;
+        public event EventHandler<JsonElement>? ConfigUpdated;
+        public event EventHandler<JsonElement>? ConfigSchemaUpdated;
+        public event EventHandler<AgentEventInfo>? AgentEventReceived;
+        public event EventHandler<PairingListInfo>? NodePairListUpdated;
+        public event EventHandler<DevicePairingListInfo>? DevicePairListUpdated;
+        public event EventHandler<ModelsListInfo>? ModelsListUpdated;
+        public event EventHandler<PresenceEntry[]>? PresenceUpdated;
+        public event EventHandler<JsonElement>? AgentsListUpdated;
+        public event EventHandler<JsonElement>? AgentFilesListUpdated;
+        public event EventHandler<JsonElement>? AgentFileContentUpdated;
+        public event EventHandler<AgentEventInfo>? ChatEventReceived;
+        public event EventHandler<ConnectionStatus>? StatusChanged;
+        public event EventHandler<string>? AuthenticationFailed;
+        public event EventHandler<DeviceTokenReceivedEventArgs>? DeviceTokenReceived;
+        public event EventHandler? HandshakeSucceeded;
+
+        public void SetUserRules(IReadOnlyList<UserNotificationRule>? rules) { }
+        public void SetPreferStructuredCategories(bool value) { }
+        public Task SendChatMessageAsync(string message, string? sessionKey = null) => Task.CompletedTask;
+        public Task<ChatSendResult> SendChatMessageForRunAsync(string message, string? sessionKey = null) => Task.FromResult(new ChatSendResult());
+        public Task CheckHealthAsync() => Task.CompletedTask;
+        public Task RequestSessionsAsync(string? agentId = null) => Task.CompletedTask;
+        public Task RequestUsageAsync() => Task.CompletedTask;
+        public Task RequestNodesAsync() => Task.CompletedTask;
+        public Task RequestUsageStatusAsync() => Task.CompletedTask;
+        public Task RequestUsageCostAsync(int days = 30) => Task.CompletedTask;
+        public Task RequestSessionPreviewAsync(string[] keys, int limit = 12, int maxChars = 240) => Task.CompletedTask;
+        public Task<bool> PatchSessionAsync(string key, string? model = null, string? thinkingLevel = null, string? verboseLevel = null) => Task.FromResult(false);
+        public Task<bool> ResetSessionAsync(string key) => Task.FromResult(false);
+        public Task<bool> DeleteSessionAsync(string key, bool deleteTranscript = true) => Task.FromResult(false);
+        public Task<bool> CompactSessionAsync(string key, int maxLines = 400) => Task.FromResult(false);
+        public Task RequestCronListAsync() => Task.CompletedTask;
+        public Task RequestCronStatusAsync() => Task.CompletedTask;
+        public Task<bool> RunCronJobAsync(string jobId, bool force = true) => Task.FromResult(false);
+        public Task<bool> RemoveCronJobAsync(string jobId) => Task.FromResult(false);
+        public Task<bool> AddCronJobAsync(object jobDefinition) => Task.FromResult(false);
+        public Task<bool> UpdateCronJobAsync(string id, object patch) => Task.FromResult(false);
+        public Task RequestCronRunsAsync(string? id = null, int limit = 20, int offset = 0) => Task.CompletedTask;
+        public Task RequestSkillsStatusAsync(string? agentId = null) => Task.CompletedTask;
+        public Task<bool> InstallSkillAsync(string skillId) => Task.FromResult(false);
+        public Task<bool> SetSkillEnabledAsync(string skillKey, bool enabled) => Task.FromResult(false);
+        public Task RequestConfigAsync() => Task.CompletedTask;
+        public Task RequestConfigSchemaAsync() => Task.CompletedTask;
+        public Task<bool> SetConfigAsync(string path, object value) => Task.FromResult(false);
+        public Task<bool> PatchConfigAsync(JsonElement fullConfig, string? baseHash) => Task.FromResult(false);
+        public Task<ConfigPatchResult> PatchConfigDetailedAsync(JsonElement fullConfig, string? baseHash, int timeoutMs = 15000) =>
+            Task.FromResult(new ConfigPatchResult { Ok = false, Error = "stub" });
+        public Task RequestAgentsListAsync() => Task.CompletedTask;
+        public Task RequestAgentFilesListAsync(string agentId = "main") => Task.CompletedTask;
+        public Task RequestAgentFileGetAsync(string agentId, string name) => Task.CompletedTask;
+        public Task RequestModelsListAsync() => Task.CompletedTask;
+        public Task RequestNodePairListAsync() => Task.CompletedTask;
+        public Task<bool> NodePairApproveAsync(string requestId) => Task.FromResult(false);
+        public Task<bool> NodePairRejectAsync(string requestId) => Task.FromResult(false);
+        public Task<NodeForgetResult> NodePairRemoveAsync(string nodeId) => Task.FromResult(new NodeForgetResult(false, "stub"));
+        public Task<NodeRenameResult> NodeRenameAsync(string nodeId, string displayName) => Task.FromResult(new NodeRenameResult(false, ErrorMessage: "stub"));
+        public Task RequestDevicePairListAsync()
+        {
+            DeviceListRequests++;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> DevicePairApproveAsync(string requestId)
+        {
+            DeviceApproveCalls++;
+            return DeviceApproveResult;
+        }
+
+        public Task<bool> DevicePairRejectAsync(string requestId) => Task.FromResult(false);
+        public Task<bool> StartChannelAsync(string channelName) => Task.FromResult(false);
+        public Task<ChannelStartResult?> StartChannelDetailedAsync(string channelName, int timeoutMs = 12000) => Task.FromResult<ChannelStartResult?>(null);
+        public Task<bool> StopChannelAsync(string channelName) => Task.FromResult(false);
+        public Task<ChannelsStatusSnapshot?> GetChannelsStatusAsync(bool probe = false, int timeoutMs = 12000) => Task.FromResult<ChannelsStatusSnapshot?>(null);
+        public Task<bool> LogoutChannelAsync(string channelName, int timeoutMs = 12000) => Task.FromResult(false);
+        public Task<WebLoginStartResult?> WebLoginStartAsync(bool force = false, int timeoutMs = 30000) => Task.FromResult<WebLoginStartResult?>(null);
+        public Task<WebLoginWaitResult?> WebLoginWaitAsync(string? currentQrDataUrl = null, int timeoutMs = 30000) => Task.FromResult<WebLoginWaitResult?>(null);
+        public Task<JsonElement> SendWizardRequestAsync(string method, object? parameters = null, int timeoutMs = 30000) => Task.FromResult(default(JsonElement));
+    }
+#pragma warning restore CS0067
+}

--- a/tests/OpenClaw.Tray.Tests/ToastActivationRouterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ToastActivationRouterTests.cs
@@ -76,6 +76,19 @@ public sealed class ToastActivationRouterTests
     }
 
     [Fact]
+    public void Route_ReviewPairing_InvokesReviewAction()
+    {
+        var calls = new List<string>();
+
+        ToastActivationRouter.Route(
+            "review_pairing",
+            _ => null,
+            BuildActions(calls));
+
+        Assert.Equal(["review"], calls);
+    }
+
+    [Fact]
     public void Route_UnknownAction_NoOps()
     {
         var calls = new List<string>();
@@ -95,6 +108,7 @@ public sealed class ToastActivationRouterTests
         OpenSettings = () => calls.Add("settings"),
         OpenChat = key => calls.Add($"chat:{key ?? "(null)"}"),
         OpenActivity = () => calls.Add("activity"),
-        CopyPairingCommand = command => calls.Add($"copy:{command}")
+        CopyPairingCommand = command => calls.Add($"copy:{command}"),
+        ReviewPairing = () => calls.Add("review")
     };
 }


### PR DESCRIPTION
## What

Ports two PRs that were merged into `master` instead of `main`:

- #776 — `wxc-exec --probe` MXC host support and `@microsoft/mxc-sdk` 0.7.0
- #778 — inbound pairing approval dialog / coordinator flow

Also adapts the #778 port for newer `main` by reusing `OpenClaw.Shared.PairingApprovalKind` instead of carrying a duplicate connection-local enum.

## Why

`main` still has the stale MXC hardcoded build/UBR gate and does not include the inbound pairing approval surface. This branch brings the already-merged work onto the active target branch.

## Port notes

- Preserved `main`'s direct-argv fail-closed guard while bringing over the MXC probe path.
- Preserved `main`'s newer tray project/test links and toast `sessionKey` behavior while adding `review_pairing` routing.
- Reused `PairingApprovalKind.DevicePair` / `NodePair` for pending approval routing to align with `main`'s node pairing state model.

## Validation

- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`