### PR TITLE
fix(setup): sync Windows CA certificates to WSL before CLI install

### DIFF
--- a/src/OpenClaw.SetupEngine/CommandRunner.cs
+++ b/src/OpenClaw.SetupEngine/CommandRunner.cs
@@ -93,17 +93,25 @@ public sealed class CommandRunner : ICommandRunner
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
 
-        if (stdinInput != null)
-        {
-            await process.StandardInput.WriteAsync(stdinInput);
-            process.StandardInput.Close();
-        }
-
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         timeoutCts.CancelAfter(timeout);
 
         try
         {
+            if (stdinInput != null)
+            {
+                try
+                {
+                    await process.StandardInput.WriteAsync(stdinInput.AsMemory(), timeoutCts.Token);
+                    await process.StandardInput.FlushAsync(timeoutCts.Token);
+                    process.StandardInput.Close();
+                }
+                catch (IOException) when (process.HasExited)
+                {
+                    // The child exited before consuming all input. Preserve its exit status/output.
+                }
+            }
+
             await process.WaitForExitAsync(timeoutCts.Token);
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)

--- a/src/OpenClaw.SetupEngine/OpenClaw.SetupEngine.csproj
+++ b/src/OpenClaw.SetupEngine/OpenClaw.SetupEngine.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="OpenClaw.SetupEngine.Tests" />
     <ProjectReference Include="..\OpenClaw.Connection\OpenClaw.Connection.csproj" />
     <ProjectReference Include="..\OpenClaw.Shared\OpenClaw.Shared.csproj" />
   </ItemGroup>

--- a/src/OpenClaw.SetupEngine/SetupPipeline.cs
+++ b/src/OpenClaw.SetupEngine/SetupPipeline.cs
@@ -50,6 +50,7 @@ public static class SetupStepFactory
             new CreateWslInstanceStep(),
             new ConfigureWslInstanceStep(),
             new ValidateWslLockdownStep(),
+            new SyncWindowsCaCertsStep(),
             new InstallCliStep(),
             new ConfigureGatewayStep(),
             new InstallGatewayServiceStep(),

--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json;
@@ -1179,16 +1180,124 @@ public sealed class ValidateWslLockdownStep : SetupStep
 // ═══════════════════════════════════════════════════════════════════
 
 /// <summary>
-/// Exports Windows trusted root/intermediate CA certificates into the WSL
+/// Exports Windows trusted root CA certificates into the WSL
 /// distro's system trust store.  This resolves curl exit-60 failures that
 /// occur on corporate networks where a TLS-intercepting proxy injects a
 /// self-signed certificate that the WSL Ubuntu instance does not trust.
 /// The step is non-fatal: if the Windows store cannot be read or the WSL
-/// filesystem cannot be reached, it logs a warning and continues so that
+/// trust store cannot be updated, it logs a warning and continues so that
 /// setups on non-proxied networks are not blocked.
 /// </summary>
 public sealed class SyncWindowsCaCertsStep : SetupStep
 {
+    private const string ManagedCertDirectory = "/usr/local/share/ca-certificates/openclaw-windows";
+    private const string InstallScript = """
+        set -euo pipefail
+
+        target=/usr/local/share/ca-certificates/openclaw-windows
+        parent=/usr/local/share/ca-certificates
+        backup_parent=/var/lib/openclaw-setup
+        backup="$backup_parent/windows-ca-certificates.backup"
+        install -d -m 0700 -o root -g root "$backup_parent"
+        staging="$(mktemp -d "$parent/.openclaw-windows.XXXXXX")"
+        chmod 0755 "$staging"
+        old_moved=0
+        new_installed=0
+
+        cleanup() {
+          rm -rf -- "$staging"
+          if [ "$new_installed" -eq 1 ]; then
+            rm -rf -- "$target"
+          fi
+          if [ "$old_moved" -eq 1 ] && [ -d "$backup" ]; then
+            mv -- "$backup" "$target"
+          fi
+          rm -rf -- "$backup"
+          if [ "$old_moved" -eq 1 ] || [ "$new_installed" -eq 1 ]; then
+            update-ca-certificates --fresh >/dev/null 2>&1 || true
+          fi
+        }
+        trap cleanup EXIT
+
+        if [ -d "$backup" ]; then
+          rm -rf -- "$target"
+          mv -- "$backup" "$target"
+          update-ca-certificates --fresh
+        fi
+
+        count=0
+        while IFS=$'\t' read -r fingerprint payload; do
+          if [ -z "$fingerprint" ] && [ -z "$payload" ]; then
+            continue
+          fi
+          case "$fingerprint" in
+            ''|*[!0-9A-Fa-f]*) echo "Invalid certificate fingerprint" >&2; exit 64 ;;
+          esac
+          if [ "${#fingerprint}" -ne 64 ]; then
+            echo "Invalid certificate fingerprint length" >&2
+            exit 64
+          fi
+          case "$payload" in
+            ''|*[!A-Za-z0-9+/=]*) echo "Invalid certificate payload" >&2; exit 64 ;;
+          esac
+
+          fingerprint="${fingerprint,,}"
+          cert_path="$staging/$fingerprint.crt"
+          {
+            printf '%s\n' '-----BEGIN CERTIFICATE-----'
+            printf '%s\n' "$payload" | fold -w 64
+            printf '%s\n' '-----END CERTIFICATE-----'
+          } > "$cert_path"
+          chmod 0644 "$cert_path"
+
+          if ! openssl x509 -in "$cert_path" -noout >/dev/null 2>&1; then
+            echo "Invalid X.509 certificate for $fingerprint" >&2
+            exit 65
+          fi
+          actual="$(openssl x509 -in "$cert_path" -outform DER | sha256sum | cut -d ' ' -f1)"
+          if [ "$actual" != "$fingerprint" ]; then
+            echo "Certificate fingerprint mismatch for $fingerprint" >&2
+            exit 65
+          fi
+          count=$((count + 1))
+        done
+
+        if [ "$count" -eq 0 ]; then
+          echo "No certificates received" >&2
+          exit 64
+        fi
+
+        if [ -d "$target" ]; then
+          mv -- "$target" "$backup"
+          old_moved=1
+        fi
+        mv -- "$staging" "$target"
+        new_installed=1
+        update-ca-certificates --fresh
+
+        rm -rf -- "$backup"
+        old_moved=0
+        new_installed=0
+        trap - EXIT
+        """;
+    private const string RollbackScript = """
+        set -e
+        target=/usr/local/share/ca-certificates/openclaw-windows
+        backup=/var/lib/openclaw-setup/windows-ca-certificates.backup
+        if [ -d "$target" ]; then
+          rm -rf -- "$target"
+          update-ca-certificates --fresh
+        fi
+        rm -rf -- "$backup"
+        """;
+
+    private readonly Func<WindowsCaCertificateExport> _exportCertificates;
+
+    public SyncWindowsCaCertsStep() : this(ExportWindowsTrustedRoots) { }
+
+    internal SyncWindowsCaCertsStep(Func<WindowsCaCertificateExport> exportCertificates)
+        => _exportCertificates = exportCertificates;
+
     public override string Id => "sync-ca-certs";
     public override string DisplayName => "Sync Windows CA certificates to WSL";
     public override bool CanRetry => false;
@@ -1197,10 +1306,10 @@ public sealed class SyncWindowsCaCertsStep : SetupStep
     {
         var distro = ctx.DistroName!;
 
-        string pemBundle;
+        WindowsCaCertificateExport export;
         try
         {
-            pemBundle = ExportWindowsCaCerts();
+            export = _exportCertificates();
         }
         catch (Exception ex)
         {
@@ -1208,77 +1317,100 @@ public sealed class SyncWindowsCaCertsStep : SetupStep
             return StepResult.Ok("Skipped: could not read Windows CA store");
         }
 
-        if (string.IsNullOrWhiteSpace(pemBundle))
+        foreach (var warning in export.Warnings)
+            ctx.Logger.Warn(warning);
+
+        if (export.CertificateCount == 0)
         {
             ctx.Logger.Warn("Windows CA store returned no certificates — skipping CA sync");
             return StepResult.Ok("Skipped: Windows CA store is empty");
         }
 
-        // Write directly to the WSL filesystem via the UNC share WSL exposes on Windows.
-        // This avoids needing stdin piping through RunInWslAsync.
-        var wslCertDir = $@"\\wsl$\{distro}\usr\local\share\ca-certificates";
-        try
-        {
-            Directory.CreateDirectory(wslCertDir);
-            File.WriteAllText(Path.Combine(wslCertDir, "windows-ca-bundle.crt"), pemBundle);
-        }
-        catch (Exception ex)
-        {
-            ctx.Logger.Warn($"Could not write CA bundle to WSL filesystem: {ex.Message} — skipping CA sync");
-            return StepResult.Ok("Skipped: could not write to WSL filesystem");
-        }
-
-        var result = await ctx.Commands.RunInWslAsync(
-            distro,
-            "update-ca-certificates",
-            TimeSpan.FromSeconds(30),
-            ct: ct,
-            user: "root");
+        var result = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["-d", distro, "-u", "root", "--", "bash", "-c", NormalizeShellScript(InstallScript)],
+            TimeSpan.FromSeconds(60),
+            workingDirectory: WslConstants.SafeWindowsWorkingDirectory,
+            stdinInput: export.Manifest,
+            ct: ct);
 
         if (result.ExitCode != 0)
         {
             ctx.Logger.Warn($"update-ca-certificates exited {result.ExitCode}: {result.Stderr.Trim()}");
-            // Non-fatal: the bundle is written; curl may still work depending on the error.
-            return StepResult.Ok($"CA bundle written but update-ca-certificates warned (exit {result.ExitCode})");
+            return StepResult.Ok($"Skipped: could not update WSL CA certificates (exit {result.ExitCode})");
         }
 
-        ctx.Logger.Info("Windows CA certificates synced to WSL trust store");
-        return StepResult.Ok("Windows CA certificates synced to WSL");
+        ctx.Logger.Info($"Synced {export.CertificateCount} Windows CA certificates to WSL trust store");
+        return StepResult.Ok($"Synced {export.CertificateCount} Windows CA certificates to WSL");
     }
 
-    public override Task RollbackAsync(SetupContext ctx, CancellationToken ct)
+    public override async Task RollbackAsync(SetupContext ctx, CancellationToken ct)
     {
         var distro = ctx.DistroName!;
-        var wslCertPath = $@"\\wsl$\{distro}\usr\local\share\ca-certificates\windows-ca-bundle.crt";
-        if (File.Exists(wslCertPath))
+        var result = await ctx.Commands.RunAsync(
+            WslConstants.WslExePath,
+            ["-d", distro, "-u", "root", "--", "bash", "-c", NormalizeShellScript(RollbackScript)],
+            TimeSpan.FromSeconds(30),
+            workingDirectory: WslConstants.SafeWindowsWorkingDirectory,
+            ct: ct);
+        if (result.ExitCode == 0)
         {
-            File.Delete(wslCertPath);
-            ctx.Logger.Info("[Rollback] Removed windows-ca-bundle.crt from WSL");
+            ctx.Logger.Info($"[Rollback] Removed {ManagedCertDirectory} from WSL trust store");
+            return;
         }
-        return Task.CompletedTask;
+
+        throw new InvalidOperationException(
+            $"Could not remove synced CA certificates (exit {result.ExitCode}): {result.Stderr.Trim()}");
     }
 
-    private static string ExportWindowsCaCerts()
+    internal static WindowsCaCertificateExport BuildCertificateManifest(
+        IEnumerable<byte[]> rawCertificates,
+        IReadOnlyList<string>? warnings = null)
     {
-        var sb = new StringBuilder();
-        var storeNames = new[] { StoreName.Root, StoreName.CertificateAuthority };
-
-        foreach (var storeName in storeNames)
+        var certificates = new SortedDictionary<string, string>(StringComparer.Ordinal);
+        foreach (var rawCertificate in rawCertificates)
         {
-            using var store = new X509Store(storeName, StoreLocation.LocalMachine);
-            store.Open(OpenFlags.ReadOnly);
+            var fingerprint = Convert.ToHexString(SHA256.HashData(rawCertificate)).ToLowerInvariant();
+            certificates.TryAdd(fingerprint, Convert.ToBase64String(rawCertificate));
+        }
 
-            foreach (var cert in store.Certificates)
+        var manifest = new StringBuilder();
+        foreach (var (fingerprint, payload) in certificates)
+            manifest.Append(fingerprint).Append('\t').Append(payload).Append('\n');
+
+        return new WindowsCaCertificateExport(manifest.ToString(), certificates.Count, warnings ?? []);
+    }
+
+    private static string NormalizeShellScript(string script)
+        => script.Replace("\r", "", StringComparison.Ordinal);
+
+    private static WindowsCaCertificateExport ExportWindowsTrustedRoots()
+    {
+        var rawCertificates = new List<byte[]>();
+        var warnings = new List<string>();
+        foreach (var location in new[] { StoreLocation.LocalMachine, StoreLocation.CurrentUser })
+        {
+            try
             {
-                sb.AppendLine("-----BEGIN CERTIFICATE-----");
-                sb.AppendLine(Convert.ToBase64String(cert.RawData, Base64FormattingOptions.InsertLineBreaks));
-                sb.AppendLine("-----END CERTIFICATE-----");
+                using var store = new X509Store(StoreName.Root, location);
+                store.Open(OpenFlags.ReadOnly);
+                foreach (var certificate in store.Certificates)
+                    rawCertificates.Add(certificate.RawData);
+            }
+            catch (Exception ex) when (ex is CryptographicException or UnauthorizedAccessException)
+            {
+                warnings.Add($"Could not read Windows {location} Root store: {ex.Message}");
             }
         }
 
-        return sb.ToString();
+        return BuildCertificateManifest(rawCertificates, warnings);
     }
 }
+
+internal sealed record WindowsCaCertificateExport(
+    string Manifest,
+    int CertificateCount,
+    IReadOnlyList<string> Warnings);
 
 public sealed class InstallCliStep : SetupStep
 {

--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -3,6 +3,8 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Text.Json;
 using OpenClaw.Connection;
 using OpenClaw.Shared;
@@ -1175,6 +1177,108 @@ public sealed class ValidateWslLockdownStep : SetupStep
 // ═══════════════════════════════════════════════════════════════════
 // GATEWAY INSTALL STEPS
 // ═══════════════════════════════════════════════════════════════════
+
+/// <summary>
+/// Exports Windows trusted root/intermediate CA certificates into the WSL
+/// distro's system trust store.  This resolves curl exit-60 failures that
+/// occur on corporate networks where a TLS-intercepting proxy injects a
+/// self-signed certificate that the WSL Ubuntu instance does not trust.
+/// The step is non-fatal: if the Windows store cannot be read or the WSL
+/// filesystem cannot be reached, it logs a warning and continues so that
+/// setups on non-proxied networks are not blocked.
+/// </summary>
+public sealed class SyncWindowsCaCertsStep : SetupStep
+{
+    public override string Id => "sync-ca-certs";
+    public override string DisplayName => "Sync Windows CA certificates to WSL";
+    public override bool CanRetry => false;
+
+    public override async Task<StepResult> ExecuteAsync(SetupContext ctx, CancellationToken ct)
+    {
+        var distro = ctx.DistroName!;
+
+        string pemBundle;
+        try
+        {
+            pemBundle = ExportWindowsCaCerts();
+        }
+        catch (Exception ex)
+        {
+            ctx.Logger.Warn($"Could not read Windows CA store: {ex.Message} — skipping CA sync");
+            return StepResult.Ok("Skipped: could not read Windows CA store");
+        }
+
+        if (string.IsNullOrWhiteSpace(pemBundle))
+        {
+            ctx.Logger.Warn("Windows CA store returned no certificates — skipping CA sync");
+            return StepResult.Ok("Skipped: Windows CA store is empty");
+        }
+
+        // Write directly to the WSL filesystem via the UNC share WSL exposes on Windows.
+        // This avoids needing stdin piping through RunInWslAsync.
+        var wslCertDir = $@"\\wsl$\{distro}\usr\local\share\ca-certificates";
+        try
+        {
+            Directory.CreateDirectory(wslCertDir);
+            File.WriteAllText(Path.Combine(wslCertDir, "windows-ca-bundle.crt"), pemBundle);
+        }
+        catch (Exception ex)
+        {
+            ctx.Logger.Warn($"Could not write CA bundle to WSL filesystem: {ex.Message} — skipping CA sync");
+            return StepResult.Ok("Skipped: could not write to WSL filesystem");
+        }
+
+        var result = await ctx.Commands.RunInWslAsync(
+            distro,
+            "update-ca-certificates",
+            TimeSpan.FromSeconds(30),
+            ct: ct,
+            user: "root");
+
+        if (result.ExitCode != 0)
+        {
+            ctx.Logger.Warn($"update-ca-certificates exited {result.ExitCode}: {result.Stderr.Trim()}");
+            // Non-fatal: the bundle is written; curl may still work depending on the error.
+            return StepResult.Ok($"CA bundle written but update-ca-certificates warned (exit {result.ExitCode})");
+        }
+
+        ctx.Logger.Info("Windows CA certificates synced to WSL trust store");
+        return StepResult.Ok("Windows CA certificates synced to WSL");
+    }
+
+    public override Task RollbackAsync(SetupContext ctx, CancellationToken ct)
+    {
+        var distro = ctx.DistroName!;
+        var wslCertPath = $@"\\wsl$\{distro}\usr\local\share\ca-certificates\windows-ca-bundle.crt";
+        if (File.Exists(wslCertPath))
+        {
+            File.Delete(wslCertPath);
+            ctx.Logger.Info("[Rollback] Removed windows-ca-bundle.crt from WSL");
+        }
+        return Task.CompletedTask;
+    }
+
+    private static string ExportWindowsCaCerts()
+    {
+        var sb = new StringBuilder();
+        var storeNames = new[] { StoreName.Root, StoreName.CertificateAuthority };
+
+        foreach (var storeName in storeNames)
+        {
+            using var store = new X509Store(storeName, StoreLocation.LocalMachine);
+            store.Open(OpenFlags.ReadOnly);
+
+            foreach (var cert in store.Certificates)
+            {
+                sb.AppendLine("-----BEGIN CERTIFICATE-----");
+                sb.AppendLine(Convert.ToBase64String(cert.RawData, Base64FormattingOptions.InsertLineBreaks));
+                sb.AppendLine("-----END CERTIFICATE-----");
+            }
+        }
+
+        return sb.ToString();
+    }
+}
 
 public sealed class InstallCliStep : SetupStep
 {

--- a/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/CommandRunnerTests.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+
+namespace OpenClaw.SetupEngine.Tests;
+
+public class CommandRunnerTests
+{
+    private static readonly string s_largeStdin = new('x', 8 * 1024 * 1024);
+
+    [Fact]
+    public async Task RunAsync_LargeStdinWriteObeysTimeout()
+    {
+        var runner = CreateRunner();
+        var (executable, arguments) = SleepingCommand();
+        var stopwatch = Stopwatch.StartNew();
+
+        var result = await runner.RunAsync(
+            executable,
+            arguments,
+            TimeSpan.FromMilliseconds(250),
+            stdinInput: s_largeStdin);
+
+        Assert.True(result.TimedOut);
+        Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task RunAsync_LargeStdinWriteObeysCallerCancellation()
+    {
+        var runner = CreateRunner();
+        var (executable, arguments) = SleepingCommand();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
+        var stopwatch = Stopwatch.StartNew();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => runner.RunAsync(
+            executable,
+            arguments,
+            TimeSpan.FromSeconds(30),
+            stdinInput: s_largeStdin,
+            ct: cts.Token));
+
+        Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(5));
+    }
+
+    private static CommandRunner CreateRunner()
+        => new(new SetupLogger(filePath: null, LogLevel.Trace));
+
+    private static (string Executable, string[] Arguments) SleepingCommand()
+        => OperatingSystem.IsWindows()
+            ? ("cmd.exe", ["/d", "/s", "/c", "ping 127.0.0.1 -n 30 >nul"])
+            : ("/bin/sh", ["-c", "sleep 30"]);
+}

--- a/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupPipelineTests.cs
@@ -60,12 +60,15 @@ public class SetupPipelineTests
     {
         var steps = SetupStepFactory.BuildDefaultSteps();
 
-        Assert.Equal(18, steps.Count);
+        Assert.Equal(19, steps.Count);
         Assert.IsType<PreflightOsStep>(steps[0]);
         Assert.IsType<PreflightWslStep>(steps[1]);
         Assert.IsType<CleanupStaleDistroStep>(steps[2]);
         Assert.IsType<CleanupStaleGatewayStep>(steps[3]);
         Assert.Contains(steps, s => s is ValidateWslLockdownStep);
+        var caSyncIndex = steps.FindIndex(s => s is SyncWindowsCaCertsStep);
+        var cliInstallIndex = steps.FindIndex(s => s is InstallCliStep);
+        Assert.Equal(cliInstallIndex - 1, caSyncIndex);
         Assert.Contains(steps, s => s is RunGatewayWizardStep);
         Assert.IsType<StartKeepaliveStep>(steps[^1]);
     }

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -1517,6 +1517,109 @@ public class SetupStepsTests : IDisposable
         Assert.Contains("not reachable", result.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    // ─── SyncWindowsCaCertsStep ───
+
+    [Fact]
+    public void SyncWindowsCaCerts_BuildCertificateManifest_DeduplicatesAndSortsCertificates()
+    {
+        byte[] first = [1, 2, 3];
+        byte[] second = [4, 5, 6];
+
+        var export = SyncWindowsCaCertsStep.BuildCertificateManifest([second, first, second]);
+        var lines = export.Manifest.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal(2, export.CertificateCount);
+        Assert.Equal(2, lines.Length);
+        Assert.Equal(lines.Order(StringComparer.Ordinal), lines);
+        Assert.All(lines, line => Assert.Equal(2, line.Split('\t').Length));
+    }
+
+    [Fact]
+    public async Task SyncWindowsCaCerts_InstallsIndividualCertificatesAsWslRoot()
+    {
+        var export = SyncWindowsCaCertsStep.BuildCertificateManifest([[1, 2, 3]]);
+        var commands = new FakeCommandRunner(_ => Ok());
+        var ctx = CreateContext(commands: commands);
+        ctx.DistroName = "test-distro";
+
+        var result = await new SyncWindowsCaCertsStep(() => export)
+            .ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var call = Assert.Single(commands.DetailedCalls);
+        Assert.Equal(WslConstants.WslExePath, call.Executable);
+        Assert.Equal(["-d", "test-distro", "-u", "root", "--", "bash", "-c"], call.Arguments[..7]);
+        Assert.Contains("openssl x509", call.Arguments[7], StringComparison.Ordinal);
+        Assert.Contains("backup_parent=/var/lib/openclaw-setup", call.Arguments[7], StringComparison.Ordinal);
+        Assert.Contains("chmod 0755 \"$staging\"", call.Arguments[7], StringComparison.Ordinal);
+        Assert.Contains("chmod 0644 \"$cert_path\"", call.Arguments[7], StringComparison.Ordinal);
+        Assert.Contains("update-ca-certificates --fresh", call.Arguments[7], StringComparison.Ordinal);
+        Assert.Contains("$fingerprint.crt", call.Arguments[7], StringComparison.Ordinal);
+        Assert.DoesNotContain('\r', call.Arguments[7]);
+        Assert.Equal(export.Manifest, call.StdinInput);
+    }
+
+    [Fact]
+    public async Task SyncWindowsCaCerts_FailureIsNonFatal()
+    {
+        var export = SyncWindowsCaCertsStep.BuildCertificateManifest([[1, 2, 3]]);
+        var commands = new FakeCommandRunner(_ => Fail("update failed"));
+        var ctx = CreateContext(commands: commands);
+        ctx.DistroName = "test-distro";
+
+        var result = await new SyncWindowsCaCertsStep(() => export)
+            .ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Contains("Skipped", result.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SyncWindowsCaCerts_EmptyStoreSkipsWslCall()
+    {
+        var commands = new FakeCommandRunner(_ => Ok());
+        var ctx = CreateContext(commands: commands);
+        ctx.DistroName = "test-distro";
+        var empty = new WindowsCaCertificateExport("", 0, []);
+
+        var result = await new SyncWindowsCaCertsStep(() => empty)
+            .ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(commands.DetailedCalls);
+    }
+
+    [Fact]
+    public async Task SyncWindowsCaCerts_RollbackRemovesManagedDirectoryAndRebuildsTrust()
+    {
+        var commands = new FakeCommandRunner(_ => Ok());
+        var ctx = CreateContext(commands: commands);
+        ctx.DistroName = "test-distro";
+
+        await new SyncWindowsCaCertsStep(() => new WindowsCaCertificateExport("", 0, []))
+            .RollbackAsync(ctx, CancellationToken.None);
+
+        var call = Assert.Single(commands.DetailedCalls);
+        Assert.Equal(["-d", "test-distro", "-u", "root", "--", "bash", "-c"], call.Arguments[..7]);
+        Assert.Contains("rm -rf -- \"$target\"", call.Arguments[7], StringComparison.Ordinal);
+        Assert.Contains("update-ca-certificates --fresh", call.Arguments[7], StringComparison.Ordinal);
+        Assert.DoesNotContain('\r', call.Arguments[7]);
+    }
+
+    [Fact]
+    public async Task SyncWindowsCaCerts_RollbackFailureIsPropagated()
+    {
+        var commands = new FakeCommandRunner(_ => Fail("remove failed"));
+        var ctx = CreateContext(commands: commands);
+        ctx.DistroName = "test-distro";
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            new SyncWindowsCaCertsStep(() => new WindowsCaCertificateExport("", 0, []))
+                .RollbackAsync(ctx, CancellationToken.None));
+
+        Assert.Contains("remove failed", error.Message, StringComparison.Ordinal);
+    }
+
     private static CommandResult Ok(string stdout = "", string stderr = "")
         => new(0, stdout, stderr, TimeSpan.Zero, TimedOut: false);
 
@@ -1548,6 +1651,7 @@ public class SetupStepsTests : IDisposable
         Func<string, string, TimeSpan, CommandResult>? runInWsl = null) : ICommandRunner
     {
         public List<(string Executable, string[] Arguments)> Calls { get; } = [];
+        public List<(string Executable, string[] Arguments, string? StdinInput)> DetailedCalls { get; } = [];
         public List<(string DistroName, string Command, TimeSpan Timeout)> WslCalls { get; } = [];
 
         public Task<CommandResult> RunAsync(
@@ -1560,6 +1664,7 @@ public class SetupStepsTests : IDisposable
             CancellationToken ct = default)
         {
             Calls.Add((executable, arguments));
+            DetailedCalls.Add((executable, arguments, stdinInput));
             return Task.FromResult(run(arguments));
         }
 


### PR DESCRIPTION
## Problem

On corporate/enterprise networks, a TLS-intercepting proxy can inject a certificate chain trusted by Windows but not by the fresh WSL Ubuntu instance. The gateway install then fails while downloading the OpenClaw CLI:

```
curl: (60) SSL certificate problem: self-signed certificate in certificate chain
```

## Fix

Add `SyncWindowsCaCertsStep` immediately before `InstallCliStep`:

1. Read the Windows `LocalMachine\Root` and `CurrentUser\Root` trust stores and deduplicate certificates by SHA-256.
2. Send a fingerprinted certificate manifest to `wsl.exe` over stdin; no privileged `\\wsl$` filesystem write.
3. As WSL root, validate every X.509 certificate and fingerprint, write one PEM certificate per `.crt` file with system-readable permissions, then rebuild the Debian trust store.
4. Replace the app-managed certificate directory transactionally. Crash recovery lives outside the CA scan tree, failed updates restore the previous trust state, and rollback removes the managed roots and rebuilds trust.

The sync step remains non-fatal so machines that cannot read or update the Windows-derived roots still proceed to the normal installer diagnostics. Command stdin writes now share the existing timeout/cancellation policy, preventing a wedged WSL launch from hanging setup indefinitely.

## Test plan

- [x] Windows 11 ARM64 VM: `OpenClaw.SetupEngine.Tests` — 375 passed
- [x] Windows 11 ARM64 VM: `build.ps1` — Shared, CLI, WinNodeCLI, SetupEngine, and WinUI green
- [x] AutoReview — clean after CRLF, permissions, timeout, stale-trust, and rollback-accounting fixes
- [x] [GitHub Windows CI](https://github.com/openclaw/openclaw-windows-node/actions/runs/28758267375) — setup/connect, network recovery, revocation recovery, x64, and ARM64 green on exact head

The local Apple ARM VM cannot start nested WSL2 (`HCS_E_HYPERV_NOT_INSTALLED`), so the repository's native Windows runner supplies the real WSL execution proof.

Co-authored-by: conanssam <jjoongoo@gmail.com>
