### PR TITLE
Fix Windows build detection without OS env var

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -54,6 +54,15 @@ function Write-Info($text) { Write-Host "   $text" -ForegroundColor Gray }
 # Track issues
 $issues = @()
 
+function Test-WindowsHost {
+    $isWindowsVariable = Get-Variable -Name IsWindows -ErrorAction SilentlyContinue
+    if ($isWindowsVariable) {
+        return [bool]$isWindowsVariable.Value
+    }
+
+    return [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+}
+
 function ConvertTo-GitSafeDirectoryPath($path) {
     return ([System.IO.Path]::GetFullPath($path).TrimEnd("\") -replace "\\", "/")
 }
@@ -143,7 +152,7 @@ Write-Host @"
 Write-Header "Checking Prerequisites"
 
 # Check OS
-if ($env:OS -ne "Windows_NT") {
+if (-not (Test-WindowsHost)) {
     Write-Error "This project requires Windows"
     exit 1
 }


### PR DESCRIPTION
## Summary

Fixes #821.

`build.ps1` no longer relies on the mutable `OS=Windows_NT` environment variable to decide whether it is running on Windows.

The script now uses:

- PowerShell's `$IsWindows` automatic variable when available.
- `[System.Environment]::OSVersion.Platform` as a Windows PowerShell-compatible fallback.

## Why

On a Windows Insider/preview host (`25H2`, build `26200.8737`), a PowerShell 7 process can run without `$env:OS` populated. In that case the previous check rejected a real Windows host with:

```text
This project requires Windows
```

## Validation

On Windows `25H2` build `26200.8737`:

- `./build.ps1 -CheckOnly` with `$env:OS = $null` passed and reported `Windows detected`.
- `./build.ps1` with `$env:OS = $null` passed.
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` passed: 2417 passed, 29 skipped.
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` passed: 1154 passed.
- `openclaw-autoreview` on the one-file diff reported no accepted/actionable findings.

Notes:

- In this fresh linked worktree, the first `--no-restore` test attempt hit the repository-documented first-run asset gotcha. I ran the same test projects once with restore to materialize assets, then reran the canonical `--no-restore` commands above.
