### PR TITLE
Harden screen snapshot format handling

### DIFF
--- a/src/OpenClaw.Shared/Capabilities/ScreenCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/ScreenCapability.cs
@@ -46,7 +46,14 @@ public class ScreenCapability : NodeCapabilityBase
 
     private async Task<NodeInvokeResponse> HandleCaptureAsync(NodeInvokeRequest request)
     {
-        var format = GetStringArg(request.Args, "format", "png");
+        // The format is interpolated into the data URI, so validate it before
+        // invoking the capture backend.
+        var requestedFormat = GetStringArg(request.Args, "format", "png");
+        if (!TryNormalizeSnapshotFormat(requestedFormat, out var format))
+        {
+            return Error("Unsupported screen snapshot format. Supported formats: png, jpeg.");
+        }
+
         var maxWidth = Clamp(GetIntArg(request.Args, "maxWidth", 1920), MinDimension, MaxScreenWidth);
         var quality = Clamp(GetIntArg(request.Args, "quality", 80), MinQuality, MaxQuality);
         var monitor = GetIntArg(request.Args, "monitor", 0);
@@ -64,17 +71,18 @@ public class ScreenCapability : NodeCapabilityBase
         {
             var result = await CaptureRequested(new ScreenCaptureArgs
             {
-                Format = format ?? "png",
+                Format = format,
                 MaxWidth = maxWidth,
                 Quality = quality,
                 MonitorIndex = screenIndex,
                 IncludePointer = includePointer
             });
-            
-            var image = $"data:image/{result.Format.ToLowerInvariant()};base64,{result.Base64}";
+
+            // Use the validated format for the MIME type instead of the backend echo.
+            var image = $"data:image/{format};base64,{result.Base64}";
             return Success(new 
             { 
-                format = result.Format,
+                format,
                 width = result.Width,
                 height = result.Height,
                 base64 = result.Base64,
@@ -85,6 +93,30 @@ public class ScreenCapability : NodeCapabilityBase
         {
             Logger.Error("Screen capture failed", ex);
             return Error("Capture failed");
+        }
+    }
+
+    // Keep encoded bytes and advertised MIME type aligned.
+    internal static bool TryNormalizeSnapshotFormat(string? requested, out string normalized)
+    {
+        if (string.IsNullOrWhiteSpace(requested))
+        {
+            normalized = "png";
+            return true;
+        }
+
+        switch (requested.Trim().ToLowerInvariant())
+        {
+            case "png":
+                normalized = "png";
+                return true;
+            case "jpeg":
+            case "jpg":
+                normalized = "jpeg";
+                return true;
+            default:
+                normalized = "png";
+                return false;
         }
     }
 
@@ -196,4 +228,3 @@ public class ScreenRecordResult
     public int Height { get; set; }
     public bool HasAudio { get; set; }
 }
-

--- a/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
@@ -2561,6 +2561,114 @@ public class ScreenCapabilityTests
     }
 
     [Fact]
+    public async Task Capture_RejectsUnsupportedFormat()
+    {
+        // Reject before the capture handler runs so a caller-supplied format
+        // cannot reach the data URI MIME type.
+        var cap = new ScreenCapability(NullLogger.Instance);
+        var handlerCalled = false;
+        cap.CaptureRequested += (_) =>
+        {
+            handlerCalled = true;
+            return Task.FromResult(new ScreenCaptureResult { Format = "png", Base64 = "x" });
+        };
+
+        var req = new NodeInvokeRequest
+        {
+            Id = "sfmt1",
+            Command = "screen.snapshot",
+            Args = Parse("""{"format":"svg+xml"}""")
+        };
+
+        var res = await cap.ExecuteAsync(req);
+        Assert.False(res.Ok);
+        Assert.False(handlerCalled);
+        Assert.Contains("Unsupported screen snapshot format", res.Error);
+    }
+
+    [Fact]
+    public async Task Capture_NormalizesJpgToJpeg()
+    {
+        // Normalize the alias before invoking the capture handler.
+        var cap = new ScreenCapability(NullLogger.Instance);
+        ScreenCaptureArgs? received = null;
+        cap.CaptureRequested += (args) =>
+        {
+            received = args;
+            return Task.FromResult(new ScreenCaptureResult { Format = args.Format, Width = 10, Height = 10, Base64 = "data" });
+        };
+
+        var req = new NodeInvokeRequest
+        {
+            Id = "sfmt2",
+            Command = "screen.snapshot",
+            Args = Parse("""{"format":"jpg"}""")
+        };
+
+        var res = await cap.ExecuteAsync(req);
+        Assert.True(res.Ok);
+        Assert.NotNull(received);
+        Assert.Equal("jpeg", received!.Format);
+
+        var json = JsonSerializer.Serialize(res.Payload);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal("jpeg", root.GetProperty("format").GetString());
+        Assert.StartsWith("data:image/jpeg;base64,", root.GetProperty("image").GetString());
+    }
+
+    [Fact]
+    public async Task Capture_DataUri_IgnoresHandlerEchoedFormat()
+    {
+        // The response MIME type comes from the validated request format.
+        var cap = new ScreenCapability(NullLogger.Instance);
+        cap.CaptureRequested += (_) => Task.FromResult(new ScreenCaptureResult
+        {
+            Format = "svg+xml\";base64,evil",
+            Width = 1,
+            Height = 1,
+            Base64 = "abc123"
+        });
+
+        var req = new NodeInvokeRequest
+        {
+            Id = "sfmt3",
+            Command = "screen.snapshot",
+            Args = Parse("""{"format":"png"}""")
+        };
+
+        var res = await cap.ExecuteAsync(req);
+        Assert.True(res.Ok);
+
+        var json = JsonSerializer.Serialize(res.Payload);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal("png", root.GetProperty("format").GetString());
+        Assert.Equal("data:image/png;base64,abc123", root.GetProperty("image").GetString());
+    }
+
+    [Fact]
+    public void TryNormalizeSnapshotFormat_AllowsKnownFormats_RejectsOthers()
+    {
+        Assert.True(ScreenCapability.TryNormalizeSnapshotFormat("png", out var png));
+        Assert.Equal("png", png);
+        Assert.True(ScreenCapability.TryNormalizeSnapshotFormat("PNG", out var pngUpper));
+        Assert.Equal("png", pngUpper);
+        Assert.True(ScreenCapability.TryNormalizeSnapshotFormat("jpeg", out var jpeg));
+        Assert.Equal("jpeg", jpeg);
+        Assert.True(ScreenCapability.TryNormalizeSnapshotFormat("  JPG  ", out var jpg));
+        Assert.Equal("jpeg", jpg);
+        Assert.True(ScreenCapability.TryNormalizeSnapshotFormat(null, out var def));
+        Assert.Equal("png", def);
+        Assert.True(ScreenCapability.TryNormalizeSnapshotFormat("", out var empty));
+        Assert.Equal("png", empty);
+
+        Assert.False(ScreenCapability.TryNormalizeSnapshotFormat("webp", out _));
+        Assert.False(ScreenCapability.TryNormalizeSnapshotFormat("gif", out _));
+        Assert.False(ScreenCapability.TryNormalizeSnapshotFormat("png;base64,x", out _));
+    }
+
+    [Fact]
     public async Task Record_ReturnsError_WhenNoHandler()
     {
         var cap = new ScreenCapability(NullLogger.Instance);

--- a/tests/OpenClaw.Shared.Tests/README.md
+++ b/tests/OpenClaw.Shared.Tests/README.md
@@ -68,12 +68,16 @@ dotnet test --filter "FullyQualifiedName~AgentActivityTests"
 - ✅ device.status returns Mac-compatible status payload
 - ✅ Unknown command returns error
 
-#### ScreenCapabilityTests (9 tests)
+#### ScreenCapabilityTests (13 tests)
 - ✅ CanHandle screen.snapshot/screen.record and rejects non-gateway screen.capture/screen.list/start/stop commands
 - ✅ Capture returns error when no handler
 - ✅ Capture calls handler with parsed args (format, maxWidth, quality, screenIndex)
 - ✅ Capture returns error when handler throws
 - ✅ Capture includes data URI response
+- ✅ Capture rejects unsupported format (e.g. svg+xml) before invoking handler
+- ✅ Capture normalizes jpg → jpeg so encoded bytes and MIME type cannot diverge
+- ✅ Capture data URI derives MIME from validated format, not handler echo
+- ✅ TryNormalizeSnapshotFormat allows png/jpeg/jpg, rejects others
 - ✅ Record returns error when no handler
 - ✅ Record calls handler with Mac-compatible args
 - ✅ Record rejects unsupported non-mp4 format


### PR DESCRIPTION
## Summary

Harden `screen.snapshot` format handling before screen capture runs.

- Validate requested snapshot formats against `png`, `jpeg`, and `jpg` (normalized to `jpeg`).
- Reject unsupported formats before invoking the capture backend.
- Build the response `data:image/...` MIME type from the validated format instead of the backend echo.
- Add coverage for unsupported formats, alias normalization, and backend-echo hardening.

## Why

`screen.snapshot` includes a data URI in its response. Previously the requested/echoed format could flow into that MIME type, which could cause MIME confusion or advertise a format that did not match the encoded bytes. This keeps the advertised MIME type aligned with the supported encoder output.

## Behavioral proof

Real local proof using an isolated tray instance with the MCP server enabled, invoked through `winnode` against the live MCP endpoint on port 8766. Base64 image data is redacted.

```text
REAL MCP/WINNODE PROOF (isolated tray, port 8766)
Tray PID: 67880

STEP 1: live MCP tools include screen.snapshot
screen.snapshot advertised:       "name": "screen.snapshot",

STEP 2: unsupported format is rejected by real MCP call
Unsupported screen snapshot format. Supported formats: png, jpeg.

STEP 3: valid png snapshot returns png data URI (redacted)
ok=true
format=png
width=64
height=42
imagePrefix=data:image/png;base64,...
base64Length=3028
```

This proves the live MCP/winnode path rejects unsupported formats and returns a valid PNG data URI for supported snapshot requests.

## Validation

- `./build.ps1` ✅ all 5 projects
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj` ✅ 2426 passed / 0 failed
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj` ✅ 1163 passed / 0 failed

## Review

- Final rubber-duck review: no blocking, non-blocking, or suggested issues.
