### PR TITLE
Make setup wizard resilient to richer gateway protocol steps

### DIFF
--- a/src/OpenClaw.SetupEngine.UI/Pages/WizardPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WizardPage.xaml.cs
@@ -17,9 +17,6 @@ public sealed partial class WizardPage : Page
     private const int MaxSameStepVisits = 3;
 
     // Bound progress polling separately from interactive wizard steps.
-    private const int MaxProgressPolls = 360;
-    private const int MaxTotalProgressPolls = 1200;
-    private static readonly TimeSpan ProgressPollDelay = TimeSpan.FromSeconds(1);
 
     private SetupConfig? _config;
     private OpenClawGatewayClient? _client;
@@ -252,19 +249,19 @@ public sealed partial class WizardPage : Page
 
                 _progressPolls++;
                 _totalProgressPolls++;
-                if (_progressPolls > MaxProgressPolls)
+                if (_progressPolls > WizardTimeouts.MaxProgressPollsPerStep)
                 {
-                    ShowError($"Gateway wizard progress step '{_stepId}' did not complete after {MaxProgressPolls} updates.");
+                    ShowError($"Gateway wizard progress step '{_stepId}' did not complete after {WizardTimeouts.MaxProgressPollsPerStep} updates.");
                     return;
                 }
-                if (_totalProgressPolls > MaxTotalProgressPolls)
+                if (_totalProgressPolls > WizardTimeouts.MaxTotalProgressPolls)
                 {
-                    ShowError($"Gateway wizard did not finish after {MaxTotalProgressPolls} progress updates.");
+                    ShowError($"Gateway wizard did not finish after {WizardTimeouts.MaxTotalProgressPolls} progress updates.");
                     return;
                 }
 
                 RenderProgressStep(title, message);
-                await Task.Delay(ProgressPollDelay);
+                await Task.Delay(WizardTimeouts.ProgressPollDelay);
                 if (generation != _operationGeneration || _errorState || _client == null)
                     return;
 

--- a/src/OpenClaw.SetupEngine.UI/Pages/WizardPage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WizardPage.xaml.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
@@ -16,15 +15,27 @@ public sealed partial class WizardPage : Page
 {
     private const int MaxWizardSteps = 50;
     private const int MaxSameStepVisits = 3;
+
+    // Bound progress polling separately from interactive wizard steps.
+    private const int MaxProgressPolls = 360;
+    private const int MaxTotalProgressPolls = 1200;
+    private static readonly TimeSpan ProgressPollDelay = TimeSpan.FromSeconds(1);
+
     private SetupConfig? _config;
     private OpenClawGatewayClient? _client;
     private string _sessionId = "";
     private string _stepId = "";
     private string _stepType = "";
+    private string _currentTitle = "";
+    private string _currentMessage = "";
+    private string _lastProgressStepId = "";
+    private WizardStepCategory _stepCategory = WizardStepCategory.Acknowledge;
     private bool _sensitive;
     private bool _errorState;
     private int _operationGeneration;
     private int _wizardStepCount;
+    private int _progressPolls;
+    private int _totalProgressPolls;
     private readonly Dictionary<string, int> _stepVisits = new(StringComparer.OrdinalIgnoreCase);
     private readonly List<WizardOptionValue> _options = [];
     // Tails the WSL gateway log and surfaces openclaw plugin console.log output
@@ -68,6 +79,9 @@ public sealed partial class WizardPage : Page
             ClearConsoleBanner();
             _sessionId = "";
             _wizardStepCount = 0;
+            _progressPolls = 0;
+            _totalProgressPolls = 0;
+            _lastProgressStepId = "";
             _stepVisits.Clear();
             SetBusy("Connecting to gateway...");
             _client = await ConnectClientAsync();
@@ -166,101 +180,185 @@ public sealed partial class WizardPage : Page
 
     private async Task ApplyPayloadAsync(JsonElement payload)
     {
-        if (payload.TryGetProperty("sessionId", out var sid))
-            _sessionId = sid.GetString() ?? _sessionId;
+        var generation = _operationGeneration;
 
-        if (payload.TryGetProperty("done", out var done) && done.ValueKind == JsonValueKind.True)
+        while (true)
         {
-            var error = payload.TryGetProperty("error", out var err) ? err.ToString() : "";
-            if (!string.IsNullOrWhiteSpace(error) && !error.Contains("this.prompt is not a function", StringComparison.OrdinalIgnoreCase))
+            if (payload.TryGetProperty("sessionId", out var sid))
+                _sessionId = sid.GetString() ?? _sessionId;
+
+            if (payload.TryGetProperty("done", out var done) && done.ValueKind == JsonValueKind.True)
             {
-                ShowError(error);
+                var error = payload.TryGetProperty("error", out var err) ? err.ToString() : "";
+                if (!string.IsNullOrWhiteSpace(error) && !error.Contains("this.prompt is not a function", StringComparison.OrdinalIgnoreCase))
+                {
+                    ShowError(error);
+                    return;
+                }
+
+                await DisconnectAsync();
+                if (generation != _operationGeneration || _errorState)
+                    return;
+
+                if (_config!.SkipPermissions)
+                    SetupWindow.Active?.NavigateToComplete(true, TimeSpan.Zero, _config.LogPath);
+                else
+                    SetupWindow.Active?.NavigateToPermissions();
                 return;
             }
 
-            await DisconnectAsync();
-            if (_config!.SkipPermissions)
-                SetupWindow.Active?.NavigateToComplete(true, TimeSpan.Zero, _config.LogPath);
-            else
-                SetupWindow.Active?.NavigateToPermissions();
+            if (!payload.TryGetProperty("step", out var step))
+            {
+                ShowError("Gateway wizard returned an invalid response.");
+                return;
+            }
+
+            _stepId = step.TryGetProperty("id", out var id) ? id.ToString() : "";
+            var rawType = step.TryGetProperty("type", out var type) ? type.ToString() : "note";
+            _stepType = string.IsNullOrWhiteSpace(rawType) ? "note" : rawType.Trim().ToLowerInvariant();
+            var stepIndex = payload.TryGetProperty("stepIndex", out var indexProperty) && indexProperty.TryGetInt32(out var index) ? index : 0;
+            _sensitive = step.TryGetProperty("sensitive", out var sensitive) && sensitive.ValueKind == JsonValueKind.True;
+            var title = step.TryGetProperty("title", out var titleProp) ? titleProp.ToString() : "";
+            var message = WizardPayloadHelpers.ExtractStepMessage(step);
+            var initial = step.TryGetProperty("initialValue", out var initialProp) ? initialProp : default;
+            var hasOptions = StepHasOptions(step);
+            _stepCategory = WizardStepClassifier.Categorize(_stepType, hasOptions);
+
+            if (_stepCategory == WizardStepCategory.RequiresAnswer
+                && hasOptions
+                && _stepType is not ("select" or "multiselect" or "text"))
+            {
+                _stepType = "select";
+            }
+
+            // Keep raw text for auth timeout selection; rendered URL/code rows are not TextBlocks.
+            _currentTitle = title;
+            _currentMessage = message;
+
+            if (string.IsNullOrWhiteSpace(_stepId))
+            {
+                ShowError("Gateway wizard step is missing an id.");
+                return;
+            }
+
+            // Progress carries no answer; poll until the gateway emits the next step.
+            if (_stepCategory == WizardStepCategory.Progress)
+            {
+                if (!string.Equals(_stepId, _lastProgressStepId, StringComparison.Ordinal))
+                {
+                    _lastProgressStepId = _stepId;
+                    _progressPolls = 0;
+                }
+
+                _progressPolls++;
+                _totalProgressPolls++;
+                if (_progressPolls > MaxProgressPolls)
+                {
+                    ShowError($"Gateway wizard progress step '{_stepId}' did not complete after {MaxProgressPolls} updates.");
+                    return;
+                }
+                if (_totalProgressPolls > MaxTotalProgressPolls)
+                {
+                    ShowError($"Gateway wizard did not finish after {MaxTotalProgressPolls} progress updates.");
+                    return;
+                }
+
+                RenderProgressStep(title, message);
+                await Task.Delay(ProgressPollDelay);
+                if (generation != _operationGeneration || _errorState || _client == null)
+                    return;
+
+                payload = await _client.SendWizardRequestAsync(
+                    "wizard.next",
+                    WizardNextPayload.Acknowledge(_sessionId, _stepId),
+                    timeoutMs: WizardTimeouts.ForStep(title, message));
+
+                if (generation != _operationGeneration || _errorState || _client == null)
+                    return;
+
+                continue;
+            }
+
+            _wizardStepCount++;
+            if (_wizardStepCount > MaxWizardSteps)
+            {
+                ShowError($"Gateway wizard exceeded {MaxWizardSteps} steps.");
+                return;
+            }
+
+            var visitKey = $"{_stepId}:{stepIndex}";
+            _stepVisits.TryGetValue(visitKey, out var visits);
+            _stepVisits[visitKey] = visits + 1;
+            if (_stepVisits[visitKey] > MaxSameStepVisits)
+            {
+                ShowError($"Gateway wizard repeated step '{_stepId}' too many times.");
+                return;
+            }
+
+            ResetInputs();
+            TitleText.Text = string.IsNullOrWhiteSpace(title) ? DisplayTitleFor(_stepType) : title;
+            RenderMessage(message);
+            StepCard.MinHeight = _stepType == "note" && string.IsNullOrWhiteSpace(message) ? 140 : 260;
+            ErrorText.Visibility = Visibility.Collapsed;
+            BusyRing.Visibility = Visibility.Collapsed;
+            BusyRing.IsActive = false;
+            ShowRecoveryActions();
+            StatusText.Text = "Answer the gateway setup question";
+            PrimaryButton.IsEnabled = !WizardSelection.RequiresAnswer(_stepType);
+            SecondaryButton.IsEnabled = true;
+            PrimaryButton.Content = _stepType == "confirm" ? "Yes" : "Continue";
+            SecondaryButton.Content = "No";
+            SecondaryButton.Visibility = _stepType == "confirm" ? Visibility.Visible : Visibility.Collapsed;
+
+            if (!BuildOptions(step, initial))
+                return;
+
+            if (_stepType == "text")
+            {
+                if (_sensitive)
+                {
+                    SecretInput.Visibility = Visibility.Visible;
+                    SecretInput.Password = initial.ValueKind == JsonValueKind.String ? initial.GetString() ?? "" : "";
+                }
+                else
+                {
+                    TextInput.Visibility = Visibility.Visible;
+                    TextInput.Text = initial.ValueKind == JsonValueKind.String ? initial.GetString() ?? "" : "";
+                }
+
+                UpdateContinueState();
+            }
+
+            if (_stepType == "note")
+            {
+                SecondaryButton.IsEnabled = false;
+                SecondaryButton.Visibility = Visibility.Collapsed;
+            }
+
             return;
         }
+    }
 
-        if (!payload.TryGetProperty("step", out var step))
-        {
-            ShowError("Gateway wizard returned an invalid response.");
-            return;
-        }
+    private static bool StepHasOptions(JsonElement step) =>
+        step.TryGetProperty("options", out var options)
+        && options.ValueKind == JsonValueKind.Array
+        && options.EnumerateArray().Any();
 
-        _stepId = step.TryGetProperty("id", out var id) ? id.ToString() : "";
-        _stepType = step.TryGetProperty("type", out var type) ? type.ToString() : "note";
-        var stepIndex = payload.TryGetProperty("stepIndex", out var indexProperty) && indexProperty.TryGetInt32(out var index) ? index : 0;
-        _sensitive = step.TryGetProperty("sensitive", out var sensitive) && sensitive.ValueKind == JsonValueKind.True;
-        var title = step.TryGetProperty("title", out var titleProp) ? titleProp.ToString() : "";
-        var message = WizardPayloadHelpers.ExtractStepMessage(step);
-        var initial = step.TryGetProperty("initialValue", out var initialProp) ? initialProp : default;
-
-        if (string.IsNullOrWhiteSpace(_stepId))
-        {
-            ShowError("Gateway wizard step is missing an id.");
-            return;
-        }
-
-        _wizardStepCount++;
-        if (_wizardStepCount > MaxWizardSteps)
-        {
-            ShowError($"Gateway wizard exceeded {MaxWizardSteps} steps.");
-            return;
-        }
-
-        var visitKey = $"{_stepId}:{stepIndex}";
-        _stepVisits.TryGetValue(visitKey, out var visits);
-        _stepVisits[visitKey] = visits + 1;
-        if (_stepVisits[visitKey] > MaxSameStepVisits)
-        {
-            ShowError($"Gateway wizard repeated step '{_stepId}' too many times.");
-            return;
-        }
-
+    private void RenderProgressStep(string title, string message)
+    {
         ResetInputs();
-        TitleText.Text = string.IsNullOrWhiteSpace(title) ? DisplayTitleFor(_stepType) : title;
+        TitleText.Text = string.IsNullOrWhiteSpace(title) ? "Working…" : title;
         RenderMessage(message);
-        StepCard.MinHeight = _stepType == "note" && string.IsNullOrWhiteSpace(message) ? 140 : 260;
+        StepCard.MinHeight = 200;
         ErrorText.Visibility = Visibility.Collapsed;
-        BusyRing.Visibility = Visibility.Collapsed;
-        BusyRing.IsActive = false;
+        BusyRing.Visibility = Visibility.Visible;
+        BusyRing.IsActive = true;
+        StatusText.Text = string.IsNullOrWhiteSpace(message) ? "Working…" : "Setting things up…";
+        PrimaryButton.IsEnabled = false;
+        PrimaryButton.Content = "Continue";
+        SecondaryButton.IsEnabled = false;
+        SecondaryButton.Visibility = Visibility.Collapsed;
         ShowRecoveryActions();
-        StatusText.Text = "Answer the gateway setup question";
-        PrimaryButton.IsEnabled = !WizardSelection.RequiresAnswer(_stepType);
-        SecondaryButton.IsEnabled = true;
-        PrimaryButton.Content = _stepType == "confirm" ? "Yes" : "Continue";
-        SecondaryButton.Content = "No";
-        SecondaryButton.Visibility = _stepType == "confirm" ? Visibility.Visible : Visibility.Collapsed;
-
-        if (!BuildOptions(step, initial))
-            return;
-
-        if (_stepType == "text")
-        {
-            if (_sensitive)
-            {
-                SecretInput.Visibility = Visibility.Visible;
-                SecretInput.Password = initial.ValueKind == JsonValueKind.String ? initial.GetString() ?? "" : "";
-            }
-            else
-            {
-                TextInput.Visibility = Visibility.Visible;
-                TextInput.Text = initial.ValueKind == JsonValueKind.String ? initial.GetString() ?? "" : "";
-            }
-
-            UpdateContinueState();
-        }
-
-        if (_stepType == "note")
-        {
-            SecondaryButton.IsEnabled = false;
-            SecondaryButton.Visibility = Visibility.Collapsed;
-        }
     }
 
     private bool BuildOptions(JsonElement step, JsonElement initial)
@@ -459,6 +557,10 @@ public sealed partial class WizardPage : Page
                     ? new { sessionId = _sessionId, answer = new { stepId = _stepId, value = false } }
                     : new { sessionId = _sessionId };
             }
+            else if (_stepCategory == WizardStepCategory.NonInteractive)
+            {
+                parameters = WizardNextPayload.Acknowledge(_sessionId, _stepId);
+            }
             else
             {
                 parameters = new { sessionId = _sessionId, answer = new { stepId = _stepId, value = answerValue } };
@@ -542,17 +644,7 @@ public sealed partial class WizardPage : Page
             ErrorText.Visibility = Visibility.Collapsed;
     }
 
-    private int TimeoutForCurrentStep()
-    {
-        var text = $"{TitleText.Text} {string.Join(' ', MessagePanel.Children.OfType<TextBlock>().Select(t => t.Text))}";
-        return text.Contains("device", StringComparison.OrdinalIgnoreCase)
-            || text.Contains("authorize", StringComparison.OrdinalIgnoreCase)
-            || text.Contains("login", StringComparison.OrdinalIgnoreCase)
-            || text.Contains("sign in", StringComparison.OrdinalIgnoreCase)
-            || text.Contains("oauth", StringComparison.OrdinalIgnoreCase)
-            ? 300_000
-            : 30_000;
-    }
+    private int TimeoutForCurrentStep() => WizardTimeouts.ForStep(_currentTitle, _currentMessage);
 
     private void ResetInputs()
     {
@@ -577,29 +669,26 @@ public sealed partial class WizardPage : Page
     }
 
     // Renders a single line into a target panel, decorating URLs as hyperlinks
-    // and "Code: XXX" patterns as monospace rows with a copy button. Shared by
-    // RenderMessage and AppendConsoleLine.
+    // and "Code: XXX" patterns as monospace rows with a copy button.
     private void AppendLineTo(Panel target, string line, double fontSize, double opacity)
     {
-        var trimmed = line.TrimEnd('\r');
+        var segment = WizardMessageFormatting.ClassifyLine(line);
 
-        var codeMatch = Regex.Match(trimmed, @"^((?:Code|code|user_code|USER_CODE)\s*[:=]\s*)([A-Z0-9]{2,8}(?:-[A-Z0-9]{2,8})+|[A-Z0-9]{4,12})\b");
-        if (codeMatch.Success)
+        if (segment.Kind == WizardLineKind.Code)
         {
-            target.Children.Add(BuildCodeRow(codeMatch.Groups[1].Value, codeMatch.Groups[2].Value));
+            target.Children.Add(BuildCodeRow(segment.Prefix, segment.Highlight));
             return;
         }
 
-        var urlMatch = Regex.Match(trimmed, @"https?://[^\s\)\""]+", RegexOptions.IgnoreCase);
-        if (urlMatch.Success && Uri.TryCreate(urlMatch.Value.TrimEnd('.', ','), UriKind.Absolute, out var uri))
+        if (segment.Kind == WizardLineKind.Url && Uri.TryCreate(segment.Highlight, UriKind.Absolute, out var uri))
         {
-            target.Children.Add(BuildLinkLine(trimmed, urlMatch.Value, uri));
+            target.Children.Add(BuildLinkLine(segment.Text, segment.Highlight, uri));
             return;
         }
 
         target.Children.Add(new TextBlock
         {
-            Text = trimmed,
+            Text = segment.Text,
             FontSize = fontSize,
             FontFamily = new FontFamily("Consolas"),
             Opacity = opacity,
@@ -803,6 +892,8 @@ public sealed partial class WizardPage : Page
         if (_errorState)
             return;
 
+        // Invalidate in-flight wizard.next calls before tearing down the connection.
+        AdvanceOperationGeneration();
         _errorState = true;
         // Cancel the server-side wizard session before disconnecting so that
         // subsequent retries (Start wizard again / Skip wizard) don't hit a

--- a/src/OpenClaw.SetupEngine/SetupWizardRunner.cs
+++ b/src/OpenClaw.SetupEngine/SetupWizardRunner.cs
@@ -11,11 +11,8 @@ public sealed class SetupWizardRunner
     private const int MaxSameStepVisits = 3;
     private static readonly Regex s_normalizeKeyRegex = new("[^a-z0-9]+", RegexOptions.Compiled);
 
-    // Progress steps can repeat while background work runs; keep per-step and
-    // aggregate caps so setup fails with a diagnostic instead of hanging.
-    private const int MaxProgressPolls = 360;
-    private const int MaxTotalProgressPolls = 1200;
-    private static readonly TimeSpan ProgressPollDelay = TimeSpan.FromSeconds(1);
+    // Progress steps can repeat while background work runs; keep bounded caps
+    // so setup fails with a diagnostic instead of hanging.
 
     private readonly SetupContext _ctx;
 
@@ -182,17 +179,17 @@ public sealed class SetupWizardRunner
 
                     progressPolls++;
                     totalProgressPolls++;
-                    if (progressPolls > MaxProgressPolls)
-                        return StepResult.Fail($"Gateway wizard progress step '{parsed.StepId}' did not complete after {MaxProgressPolls} polls.");
-                    if (totalProgressPolls > MaxTotalProgressPolls)
-                        return StepResult.Fail($"Gateway wizard did not finish after {MaxTotalProgressPolls} progress updates.");
+                    if (progressPolls > WizardTimeouts.MaxProgressPollsPerStep)
+                        return StepResult.Fail($"Gateway wizard progress step '{parsed.StepId}' did not complete after {WizardTimeouts.MaxProgressPollsPerStep} polls.");
+                    if (totalProgressPolls > WizardTimeouts.MaxTotalProgressPolls)
+                        return StepResult.Fail($"Gateway wizard did not finish after {WizardTimeouts.MaxTotalProgressPolls} progress updates.");
 
                     var progressText = $"{parsed.Title} {parsed.Message}".Trim();
                     _ctx.Logger.Info(string.IsNullOrWhiteSpace(progressText)
                         ? $"Wizard progress step '{parsed.StepId}' — polling for next step"
                         : $"Wizard progress: {progressText}");
 
-                    await Task.Delay(ProgressPollDelay, ct);
+                    await Task.Delay(WizardTimeouts.ProgressPollDelay, ct);
                     payload = await SendWizardNextAsync(WizardNextPayload.Acknowledge(sessionId, parsed.StepId), TimeoutFor(parsed));
                     continue;
                 }

--- a/src/OpenClaw.SetupEngine/SetupWizardRunner.cs
+++ b/src/OpenClaw.SetupEngine/SetupWizardRunner.cs
@@ -10,6 +10,13 @@ public sealed class SetupWizardRunner
     private const int MaxWizardSteps = 50;
     private const int MaxSameStepVisits = 3;
     private static readonly Regex s_normalizeKeyRegex = new("[^a-z0-9]+", RegexOptions.Compiled);
+
+    // Progress steps can repeat while background work runs; keep per-step and
+    // aggregate caps so setup fails with a diagnostic instead of hanging.
+    private const int MaxProgressPolls = 360;
+    private const int MaxTotalProgressPolls = 1200;
+    private static readonly TimeSpan ProgressPollDelay = TimeSpan.FromSeconds(1);
+
     private readonly SetupContext _ctx;
 
     public SetupWizardRunner(SetupContext ctx)
@@ -84,7 +91,45 @@ public sealed class SetupWizardRunner
 
             var visits = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             var restartAttempts = 0;
-            for (var i = 0; i < MaxWizardSteps; i++)
+            var progressPolls = 0;
+            var totalProgressPolls = 0;
+            var lastProgressStepId = "";
+            var interactiveSteps = 0;
+
+            // A reconnect restarts the wizard session, so reset replay-scoped
+            // counters before processing the replacement start payload.
+            async Task<JsonElement> SendWizardNextAsync(object parameters, int timeoutMs)
+            {
+                try
+                {
+                    return await client!.SendWizardRequestAsync("wizard.next", parameters, timeoutMs);
+                }
+                catch (Exception ex) when (!ct.IsCancellationRequested && IsRestartLikeWizardDisconnect(ex) && restartAttempts < 2)
+                {
+                    restartAttempts++;
+                    _ctx.Logger.Warn($"Gateway restarted during wizard; reconnecting and replaying answers (attempt {restartAttempts}/2): {ex.Message}");
+
+                    try { await client!.DisconnectAsync(); } catch { }
+                    client!.Dispose();
+
+                    await Task.Delay(TimeSpan.FromSeconds(3), ct);
+                    client = CreateWizardClient(credential, identityPath, wsLogger);
+                    var reconnect = await PairOperatorStep.WaitForConnectionOrPairing(client, _ctx, TimeSpan.FromSeconds(30), ct);
+                    if (reconnect != PairOperatorStep.ConnectionOutcome.Connected)
+                        throw new WizardFatalException($"Gateway wizard reconnect failed after restart: {reconnect}");
+
+                    sessionId = "";
+                    visits.Clear();
+                    discoveredSteps.Clear();
+                    interactiveSteps = 0;
+                    progressPolls = 0;
+                    totalProgressPolls = 0;
+                    lastProgressStepId = "";
+                    return await client.SendWizardRequestAsync("wizard.start", timeoutMs: 30_000);
+                }
+            }
+
+            while (true)
             {
                 ct.ThrowIfCancellationRequested();
 
@@ -123,6 +168,39 @@ public sealed class SetupWizardRunner
                 if (string.IsNullOrWhiteSpace(parsed.StepId))
                     return StepResult.Fail("Gateway wizard step is missing an id.");
 
+                var category = WizardStepClassifier.Categorize(parsed.StepType, parsed.Options.Count > 0);
+
+                // Progress carries no answer; poll until the gateway emits the
+                // next interactive step or reaches a bounded failure.
+                if (category == WizardStepCategory.Progress)
+                {
+                    if (!string.Equals(parsed.StepId, lastProgressStepId, StringComparison.Ordinal))
+                    {
+                        lastProgressStepId = parsed.StepId;
+                        progressPolls = 0;
+                    }
+
+                    progressPolls++;
+                    totalProgressPolls++;
+                    if (progressPolls > MaxProgressPolls)
+                        return StepResult.Fail($"Gateway wizard progress step '{parsed.StepId}' did not complete after {MaxProgressPolls} polls.");
+                    if (totalProgressPolls > MaxTotalProgressPolls)
+                        return StepResult.Fail($"Gateway wizard did not finish after {MaxTotalProgressPolls} progress updates.");
+
+                    var progressText = $"{parsed.Title} {parsed.Message}".Trim();
+                    _ctx.Logger.Info(string.IsNullOrWhiteSpace(progressText)
+                        ? $"Wizard progress step '{parsed.StepId}' — polling for next step"
+                        : $"Wizard progress: {progressText}");
+
+                    await Task.Delay(ProgressPollDelay, ct);
+                    payload = await SendWizardNextAsync(WizardNextPayload.Acknowledge(sessionId, parsed.StepId), TimeoutFor(parsed));
+                    continue;
+                }
+
+                interactiveSteps++;
+                if (interactiveSteps > MaxWizardSteps)
+                    return StepResult.Fail($"Gateway wizard exceeded {MaxWizardSteps} steps.");
+
                 var visitKey = $"{parsed.StepId}:{parsed.StepIndex}";
                 visits.TryGetValue(visitKey, out var visitCount);
                 visits[visitKey] = visitCount + 1;
@@ -142,9 +220,9 @@ public sealed class SetupWizardRunner
 
                 _ctx.Logger.Info(answerResult.HasAnswer
                     ? $"Wizard step '{parsed.StepId}' ({parsed.StepType}, key={StableAnswerKey(parsed.Title, parsed.Message, parsed.StepId)}) answered with {(parsed.Sensitive ? "[sensitive]" : $"'{answerResult.Answer}'")}"
-                    : $"Wizard step '{parsed.StepId}' ({parsed.StepType}) continuing without explicit answer");
+                    : $"Wizard step '{parsed.StepId}' ({parsed.StepType}, {category}) continuing without explicit answer");
 
-                var parameters = answerResult.HasAnswer
+                object parameters = answerResult.HasAnswer
                     ? new
                     {
                         sessionId,
@@ -154,41 +232,20 @@ public sealed class SetupWizardRunner
                             value = AnswerValueForWire(parsed, answerResult.Answer)
                         }
                     }
-                    : (object)new { sessionId };
+                    : WizardNextPayload.Acknowledge(sessionId, parsed.StepId);
 
-                try
-                {
-                    payload = await client.SendWizardRequestAsync("wizard.next", parameters, timeoutMs: TimeoutFor(parsed));
-                }
-                catch (Exception ex) when (!ct.IsCancellationRequested && IsRestartLikeWizardDisconnect(ex) && restartAttempts < 2)
-                {
-                    restartAttempts++;
-                    _ctx.Logger.Warn($"Gateway restarted during wizard; reconnecting and replaying answers (attempt {restartAttempts}/2): {ex.Message}");
-
-                    // slopwatch-ignore: SW003 Cleanup is best-effort; failure cannot improve caller state and the original outcome is preserved.
-                    try { await client.DisconnectAsync(); } catch { }
-                    client.Dispose();
-
-                    await Task.Delay(TimeSpan.FromSeconds(3), ct);
-                    client = CreateWizardClient(credential, identityPath, wsLogger);
-                    var reconnect = await PairOperatorStep.WaitForConnectionOrPairing(client, _ctx, TimeSpan.FromSeconds(30), ct);
-                    if (reconnect != PairOperatorStep.ConnectionOutcome.Connected)
-                        return StepResult.Fail($"Gateway wizard reconnect failed after restart: {reconnect}");
-
-                    sessionId = "";
-                    visits.Clear();
-                    discoveredSteps.Clear();
-                    payload = await client.SendWizardRequestAsync("wizard.start", timeoutMs: 30_000);
-                }
+                payload = await SendWizardNextAsync(parameters, TimeoutFor(parsed));
             }
-
-            return StepResult.Fail($"Gateway wizard exceeded {MaxWizardSteps} steps.");
         }
         catch (OperationCanceledException)
         {
             if (client is not null && wizardStarted && !string.IsNullOrWhiteSpace(sessionId))
                 await TryCancelWizardAsync(client, sessionId);
             throw;
+        }
+        catch (WizardFatalException ex)
+        {
+            return StepResult.Fail(ex.Message, ex);
         }
         catch (Exception ex)
         {
@@ -225,6 +282,7 @@ public sealed class SetupWizardRunner
             _ctx.Logger.Warn("Cancelling gateway wizard session");
             await client.SendWizardRequestAsync("wizard.cancel", new { sessionId }, timeoutMs: 10_000);
         }
+
         catch (Exception ex)
         {
             _ctx.Logger.Warn($"Failed to cancel gateway wizard session: {ex.Message}");
@@ -291,19 +349,34 @@ public sealed class SetupWizardRunner
         if (TryGetConfiguredAnswer(step, configuredAnswers, out var configured))
             return ValidateAnswer(step, configured, configuredAnswer: true);
 
-        var inferred = step.StepType switch
+        var category = WizardStepClassifier.Categorize(step.StepType, step.Options.Count > 0);
+        if (WizardStepClassifier.ContinuesWithoutAnswer(category))
         {
-            "note" => "true",
-            "confirm" => InferConfirmAnswer(step),
-            "select" => InferOptionAnswer(step),
-            "multiselect" => InferOptionAnswer(step),
-            "text" => InferTextAnswer(step),
-            _ => !string.IsNullOrWhiteSpace(step.InitialValue) ? step.InitialValue : null
-        };
+            return AnswerResolution.Continue();
+        }
+
+        switch (category)
+        {
+            case WizardStepCategory.Acknowledge:
+                return AnswerResolution.Ok("true");
+
+            case WizardStepCategory.Confirm:
+                return ValidateAnswer(step, InferConfirmAnswer(step), configuredAnswer: false);
+        }
+
+        // Unknown types with options are choice prompts for wire-shaping purposes.
+        var inferred = step.Options.Count > 0 && step.StepType != "text"
+            ? InferOptionAnswer(step)
+            : step.StepType switch
+            {
+                "select" or "multiselect" => InferOptionAnswer(step),
+                "text" => InferTextAnswer(step),
+                _ => !string.IsNullOrWhiteSpace(step.InitialValue) ? step.InitialValue : null
+            };
 
         if (inferred == null)
         {
-            return AnswerResolution.Fail($"Gateway wizard step '{step.StepId}' ({step.StepType}) requires a text answer.");
+            return AnswerResolution.Fail($"Gateway wizard step '{step.StepId}' ({step.StepType}) requires a value that was not provided.");
         }
 
         return ValidateAnswer(step, inferred, configuredAnswer: false);
@@ -337,7 +410,11 @@ public sealed class SetupWizardRunner
 
     private static object AnswerValueForWire(WizardPayload step, string answer)
     {
-        return WizardAnswerBuilder.BuildWireValue(step.StepType, answer, step.Options);
+        // Preserve the selected option's raw JSON value for unknown choice-style steps.
+        var effectiveType = step.Options.Count > 0 && step.StepType is not ("select" or "multiselect" or "text")
+            ? "select"
+            : step.StepType;
+        return WizardAnswerBuilder.BuildWireValue(effectiveType, answer, step.Options);
     }
 
     private static string? InferTextAnswer(WizardPayload step)
@@ -404,17 +481,7 @@ public sealed class SetupWizardRunner
         return false;
     }
 
-    private static int TimeoutFor(WizardPayload step)
-    {
-        var text = $"{step.Title} {step.Message}";
-        return text.Contains("device", StringComparison.OrdinalIgnoreCase)
-            || text.Contains("authorize", StringComparison.OrdinalIgnoreCase)
-            || text.Contains("login", StringComparison.OrdinalIgnoreCase)
-            || text.Contains("sign in", StringComparison.OrdinalIgnoreCase)
-            || text.Contains("oauth", StringComparison.OrdinalIgnoreCase)
-            ? 300_000
-            : 30_000;
-    }
+    private static int TimeoutFor(WizardPayload step) => WizardTimeouts.ForStep(step.Title, step.Message);
 
     private static bool IsRestartLikeWizardDisconnect(Exception ex)
     {
@@ -434,7 +501,11 @@ public sealed class SetupWizardRunner
         {
             "select" => step.Options.FirstOrDefault()?.Value ?? "<select one option value>",
             "multiselect" => "<comma-separated option values>",
-            "text" => step.Sensitive ? "<sensitive value>" : "<text value>",
+            "text" => step.Sensitive
+                ? "<sensitive value>"
+                : step.AuthUrls.Count > 0
+                    ? $"<value obtained from: {step.AuthUrls[0]}>"
+                    : "<text value>",
             _ => step.SuggestedAnswer ?? "true"
         };
     }
@@ -461,7 +532,11 @@ public sealed class SetupWizardRunner
     {
         public static AnswerResolution Ok(string answer) => new(true, true, answer, null);
         public static AnswerResolution Fail(string error) => new(false, false, "", error);
+
+        public static AnswerResolution Continue() => new(true, false, "", null);
     }
+
+    private sealed class WizardFatalException(string message) : Exception(message);
 
     private sealed record WizardPayload(
         bool IsDone,
@@ -499,7 +574,8 @@ public sealed class SetupWizardRunner
                 if (!payload.TryGetProperty("step", out var step) || step.ValueKind != JsonValueKind.Object)
                     return ErrorPayload("Gateway wizard response is missing a step object.");
 
-                var type = step.TryGetProperty("type", out var typeProperty) ? typeProperty.ToString() : "note";
+                var rawType = step.TryGetProperty("type", out var typeProperty) ? typeProperty.ToString() : "note";
+                var type = string.IsNullOrWhiteSpace(rawType) ? "note" : rawType.Trim().ToLowerInvariant();
                 var title = step.TryGetProperty("title", out var titleProperty) ? titleProperty.ToString() : "";
                 var message = step.TryGetProperty("message", out var messageProperty) ? messageProperty.ToString() : "";
                 var stepId = step.TryGetProperty("id", out var idProperty) ? idProperty.ToString() : "";
@@ -530,7 +606,8 @@ public sealed class SetupWizardRunner
         string Message,
         bool Sensitive,
         string? SuggestedAnswer,
-        IReadOnlyList<WizardOptionValue> Options)
+        IReadOnlyList<WizardOptionValue> Options,
+        IReadOnlyList<string> AuthUrls)
     {
         public static WizardTemplateStep From(WizardPayload payload)
         {
@@ -549,7 +626,9 @@ public sealed class SetupWizardRunner
             if (payload.Sensitive && !string.IsNullOrWhiteSpace(suggested))
                 suggested = "<sensitive value>";
 
-            return new(payload.StepId, payload.StepType, payload.Title, payload.Message, payload.Sensitive, suggested, payload.Options);
+            var authUrls = WizardMessageFormatting.ExtractUrls($"{payload.Title}\n{payload.Message}");
+
+            return new(payload.StepId, payload.StepType, payload.Title, payload.Message, payload.Sensitive, suggested, payload.Options, authUrls);
         }
     }
 }

--- a/src/OpenClaw.SetupEngine/WizardMessageFormatting.cs
+++ b/src/OpenClaw.SetupEngine/WizardMessageFormatting.cs
@@ -1,0 +1,90 @@
+using System.Text.RegularExpressions;
+
+namespace OpenClaw.SetupEngine;
+
+/// <summary>The kind of content a single wizard message line carries.</summary>
+public enum WizardLineKind
+{
+    /// <summary>Plain text.</summary>
+    Text,
+
+    /// <summary>Contains an http(s) URL (e.g. an OAuth/device-authorization link).</summary>
+    Url,
+
+    /// <summary>A "Code: XXXX" style device/pairing code the user must enter elsewhere.</summary>
+    Code,
+}
+
+/// <summary>A classified wizard message line with an optional highlighted URL or code.</summary>
+public sealed record WizardLineSegment(
+    WizardLineKind Kind,
+    string Text,
+    string Prefix,
+    string Highlight,
+    string Suffix);
+
+/// <summary>Detects actionable URLs and manual entry codes in wizard messages.</summary>
+public static class WizardMessageFormatting
+{
+    // "Code: ABCD-EFGH" / "user_code = ABC123" style manual entry codes.
+    private static readonly Regex s_codeRegex = new(
+        @"^((?:Code|code|user_code|USER_CODE|User Code)\s*[:=]\s*)([A-Z0-9]{2,8}(?:-[A-Z0-9]{2,8})+|[A-Z0-9]{4,12})\b",
+        RegexOptions.Compiled);
+
+    private static readonly Regex s_urlRegex = new(
+        @"https?://[^\s\)\""]+",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>Classifies a line as plain text, URL, or device-code text.</summary>
+    public static WizardLineSegment ClassifyLine(string? line)
+    {
+        var trimmed = (line ?? string.Empty).TrimEnd('\r');
+
+        var codeMatch = s_codeRegex.Match(trimmed);
+        if (codeMatch.Success)
+        {
+            return new WizardLineSegment(
+                WizardLineKind.Code,
+                trimmed,
+                Prefix: codeMatch.Groups[1].Value,
+                Highlight: codeMatch.Groups[2].Value,
+                Suffix: string.Empty);
+        }
+
+        var urlMatch = s_urlRegex.Match(trimmed);
+        if (urlMatch.Success)
+        {
+            var url = urlMatch.Value.TrimEnd('.', ',');
+            if (Uri.TryCreate(url, UriKind.Absolute, out _))
+            {
+                var index = trimmed.IndexOf(urlMatch.Value, StringComparison.Ordinal);
+                var prefix = index > 0 ? trimmed[..index] : string.Empty;
+                var suffix = trimmed[(index + urlMatch.Value.Length)..];
+                return new WizardLineSegment(WizardLineKind.Url, trimmed, prefix, url, suffix);
+            }
+        }
+
+        return new WizardLineSegment(WizardLineKind.Text, trimmed, trimmed, string.Empty, string.Empty);
+    }
+
+    /// <summary>Returns all distinct absolute http(s) URLs found in a message.</summary>
+    public static IReadOnlyList<string> ExtractUrls(string? message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            return Array.Empty<string>();
+
+        var urls = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (Match match in s_urlRegex.Matches(message))
+        {
+            var url = match.Value.TrimEnd('.', ',');
+            if (Uri.TryCreate(url, UriKind.Absolute, out _) && seen.Add(url))
+                urls.Add(url);
+        }
+
+        return urls;
+    }
+
+    /// <summary>True when the message contains at least one actionable auth URL.</summary>
+    public static bool ContainsAuthUrl(string? message) => ExtractUrls(message).Count > 0;
+}

--- a/src/OpenClaw.SetupEngine/WizardNextPayload.cs
+++ b/src/OpenClaw.SetupEngine/WizardNextPayload.cs
@@ -1,0 +1,11 @@
+namespace OpenClaw.SetupEngine;
+
+public sealed record WizardNextStepAnswer(string stepId);
+
+public sealed record WizardNextStepAcknowledgement(string sessionId, WizardNextStepAnswer answer);
+
+public static class WizardNextPayload
+{
+    public static WizardNextStepAcknowledgement Acknowledge(string sessionId, string stepId) =>
+        new(sessionId, new WizardNextStepAnswer(stepId));
+}

--- a/src/OpenClaw.SetupEngine/WizardStepClassifier.cs
+++ b/src/OpenClaw.SetupEngine/WizardStepClassifier.cs
@@ -1,0 +1,60 @@
+namespace OpenClaw.SetupEngine;
+
+/// <summary>How a gateway wizard step should be handled by the client.</summary>
+public enum WizardStepCategory
+{
+    /// <summary>Needs a concrete value (text) or a selected option (select/multiselect).</summary>
+    RequiresAnswer,
+
+    /// <summary>Yes/No acknowledgement with a safe default (confirm).</summary>
+    Confirm,
+
+    /// <summary>Informational acknowledgement-only step (note).</summary>
+    Acknowledge,
+
+    /// <summary>Non-interactive background/status step.</summary>
+    Progress,
+
+    /// <summary>Unrecognized or client-executed step with no answerable input.</summary>
+    NonInteractive,
+}
+
+/// <summary>Pure classification of gateway wizard step types.</summary>
+public static class WizardStepClassifier
+{
+    /// <summary>Step types that represent non-interactive background progress.</summary>
+    public static readonly IReadOnlySet<string> ProgressTypes =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "progress", "status", "working" };
+
+    public static bool IsProgress(string? stepType) =>
+        !string.IsNullOrWhiteSpace(stepType) && ProgressTypes.Contains(stepType.Trim());
+
+    /// <summary>Categorizes a step, preserving option-based prompts for unknown types.</summary>
+    public static WizardStepCategory Categorize(string? stepType, bool hasOptions)
+    {
+        var type = (stepType ?? string.Empty).Trim();
+
+        if (IsProgress(type))
+            return WizardStepCategory.Progress;
+
+        switch (type.ToLowerInvariant())
+        {
+            case "text":
+            case "select":
+            case "multiselect":
+                return WizardStepCategory.RequiresAnswer;
+            case "confirm":
+                return WizardStepCategory.Confirm;
+            case "note":
+                return WizardStepCategory.Acknowledge;
+        }
+
+        // Unknown types with options behave like choice prompts; input-less
+        // unknown types are treated as non-interactive protocol steps.
+        return hasOptions ? WizardStepCategory.RequiresAnswer : WizardStepCategory.NonInteractive;
+    }
+
+    /// <summary>True when the step advances without an answer payload.</summary>
+    public static bool ContinuesWithoutAnswer(WizardStepCategory category) =>
+        category is WizardStepCategory.Progress or WizardStepCategory.NonInteractive;
+}

--- a/src/OpenClaw.SetupEngine/WizardTimeouts.cs
+++ b/src/OpenClaw.SetupEngine/WizardTimeouts.cs
@@ -1,0 +1,30 @@
+namespace OpenClaw.SetupEngine;
+
+/// <summary>Selects the request timeout for a wizard step.</summary>
+public static class WizardTimeouts
+{
+    /// <summary>Default per-step wizard request timeout.</summary>
+    public const int DefaultTimeoutMs = 30_000;
+
+    /// <summary>Extended timeout for steps that wait on external auth.</summary>
+    public const int AuthTimeoutMs = 300_000;
+
+    private static readonly string[] s_authHints =
+    {
+        "device", "authorize", "login", "sign in", "oauth",
+        "browser", "authenticate", "verification",
+    };
+
+    /// <summary>Auth-style steps get <see cref="AuthTimeoutMs"/>; others get <see cref="DefaultTimeoutMs"/>.</summary>
+    public static int ForStep(string? title, string? message)
+    {
+        var text = $"{title} {message}";
+        foreach (var hint in s_authHints)
+        {
+            if (text.Contains(hint, StringComparison.OrdinalIgnoreCase))
+                return AuthTimeoutMs;
+        }
+
+        return DefaultTimeoutMs;
+    }
+}

--- a/src/OpenClaw.SetupEngine/WizardTimeouts.cs
+++ b/src/OpenClaw.SetupEngine/WizardTimeouts.cs
@@ -9,6 +9,15 @@ public static class WizardTimeouts
     /// <summary>Extended timeout for steps that wait on external auth.</summary>
     public const int AuthTimeoutMs = 300_000;
 
+    /// <summary>Polling delay for gateway progress/status wizard steps.</summary>
+    public static readonly TimeSpan ProgressPollDelay = TimeSpan.FromSeconds(1);
+
+    /// <summary>Total progress/status updates before setup fails as stalled.</summary>
+    public const int MaxTotalProgressPolls = 1200;
+
+    /// <summary>Per-step progress/status budget; allow a single long install to consume the total budget.</summary>
+    public const int MaxProgressPollsPerStep = MaxTotalProgressPolls;
+
     private static readonly string[] s_authHints =
     {
         "device", "authorize", "login", "sign in", "oauth",

--- a/tests/OpenClaw.SetupEngine.Tests/WizardMessageFormattingTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/WizardMessageFormattingTests.cs
@@ -1,0 +1,75 @@
+namespace OpenClaw.SetupEngine.Tests;
+
+public class WizardMessageFormattingTests
+{
+    [Fact]
+    public void PlainText_ClassifiesAsText()
+    {
+        var segment = WizardMessageFormatting.ClassifyLine("Just some instructions.");
+        Assert.Equal(WizardLineKind.Text, segment.Kind);
+        Assert.Equal("Just some instructions.", segment.Text);
+    }
+
+    [Fact]
+    public void Url_IsDetected_WithPrefixAndSuffix()
+    {
+        var segment = WizardMessageFormatting.ClassifyLine("Open https://example.com/auth to continue");
+        Assert.Equal(WizardLineKind.Url, segment.Kind);
+        Assert.Equal("https://example.com/auth", segment.Highlight);
+        Assert.Equal("Open ", segment.Prefix);
+        Assert.Equal(" to continue", segment.Suffix);
+    }
+
+    [Fact]
+    public void Url_TrailingPunctuation_IsTrimmed()
+    {
+        var segment = WizardMessageFormatting.ClassifyLine("Visit https://example.com/device.");
+        Assert.Equal(WizardLineKind.Url, segment.Kind);
+        Assert.Equal("https://example.com/device", segment.Highlight);
+    }
+
+    [Theory]
+    [InlineData("Code: ABCD-EFGH", "Code: ", "ABCD-EFGH")]
+    [InlineData("user_code = ABC123", "user_code = ", "ABC123")]
+    [InlineData("USER_CODE: WDJB-MJHT", "USER_CODE: ", "WDJB-MJHT")]
+    public void DeviceCode_IsDetected(string line, string expectedPrefix, string expectedCode)
+    {
+        var segment = WizardMessageFormatting.ClassifyLine(line);
+        Assert.Equal(WizardLineKind.Code, segment.Kind);
+        Assert.Equal(expectedPrefix, segment.Prefix);
+        Assert.Equal(expectedCode, segment.Highlight);
+    }
+
+    [Fact]
+    public void Null_ClassifiesAsEmptyText()
+    {
+        var segment = WizardMessageFormatting.ClassifyLine(null);
+        Assert.Equal(WizardLineKind.Text, segment.Kind);
+        Assert.Equal(string.Empty, segment.Text);
+    }
+
+    [Fact]
+    public void ExtractUrls_ReturnsDistinctAbsoluteUrls()
+    {
+        var message = "Go to https://example.com/a and https://example.com/b\nor retry https://example.com/a";
+        var urls = WizardMessageFormatting.ExtractUrls(message);
+
+        Assert.Equal(2, urls.Count);
+        Assert.Contains("https://example.com/a", urls);
+        Assert.Contains("https://example.com/b", urls);
+    }
+
+    [Fact]
+    public void ExtractUrls_EmptyForNoUrls()
+    {
+        Assert.Empty(WizardMessageFormatting.ExtractUrls("nothing to see here"));
+        Assert.Empty(WizardMessageFormatting.ExtractUrls(null));
+    }
+
+    [Fact]
+    public void ContainsAuthUrl_TrueOnlyWhenUrlPresent()
+    {
+        Assert.True(WizardMessageFormatting.ContainsAuthUrl("login at https://accounts.google.com/o/oauth2"));
+        Assert.False(WizardMessageFormatting.ContainsAuthUrl("paste your API key"));
+    }
+}

--- a/tests/OpenClaw.SetupEngine.Tests/WizardNextPayloadTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/WizardNextPayloadTests.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+
+namespace OpenClaw.SetupEngine.Tests;
+
+public class WizardNextPayloadTests
+{
+    [Fact]
+    public void Acknowledge_SerializesGatewayCompatibleAnswerEnvelope()
+    {
+        var payload = WizardNextPayload.Acknowledge("session-1", "step-progress");
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payload, SetupConfig.JsonOptions));
+        var root = doc.RootElement;
+
+        Assert.Equal("session-1", root.GetProperty("sessionId").GetString());
+        var answer = root.GetProperty("answer");
+        Assert.Equal("step-progress", answer.GetProperty("stepId").GetString());
+        Assert.False(answer.TryGetProperty("value", out _));
+    }
+
+    [Theory]
+    [InlineData("progress")]
+    [InlineData("action")]
+    public void Acknowledge_AdvancesGatewayCurrentStep_ForDriveThroughTypes(string stepType)
+    {
+        _ = stepType; // documents the drive-through categories this contract protects.
+        var session = new FakeWizardSession();
+
+        Assert.Equal("step-1", session.Next(new { sessionId = "session-1" }));
+        Assert.Equal("step-1", session.Next(new { sessionId = "session-1" }));
+        Assert.Equal("step-2", session.Next(WizardNextPayload.Acknowledge("session-1", "step-1")));
+        Assert.Equal("step-2", session.Next(new { sessionId = "session-1" }));
+    }
+
+    private sealed class FakeWizardSession
+    {
+        private string? _currentStepId = "step-1";
+        private bool _acknowledged;
+
+        public string? Next(object payload)
+        {
+            if (HasAnswer(payload))
+            {
+                _currentStepId = null;
+                _acknowledged = true;
+            }
+
+            _currentStepId ??= _acknowledged ? "step-2" : "step-1";
+            return _currentStepId;
+        }
+
+        private static bool HasAnswer(object payload)
+        {
+            using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payload, SetupConfig.JsonOptions));
+            return doc.RootElement.TryGetProperty("answer", out _);
+        }
+    }
+}

--- a/tests/OpenClaw.SetupEngine.Tests/WizardStepClassifierTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/WizardStepClassifierTests.cs
@@ -1,0 +1,85 @@
+namespace OpenClaw.SetupEngine.Tests;
+
+public class WizardStepClassifierTests
+{
+    [Theory]
+    [InlineData("text")]
+    [InlineData("select")]
+    [InlineData("multiselect")]
+    public void InteractiveTypes_RequireAnswer(string type)
+    {
+        Assert.Equal(WizardStepCategory.RequiresAnswer, WizardStepClassifier.Categorize(type, hasOptions: false));
+    }
+
+    [Fact]
+    public void Confirm_IsConfirm()
+    {
+        Assert.Equal(WizardStepCategory.Confirm, WizardStepClassifier.Categorize("confirm", hasOptions: false));
+    }
+
+    [Fact]
+    public void Note_IsAcknowledge()
+    {
+        Assert.Equal(WizardStepCategory.Acknowledge, WizardStepClassifier.Categorize("note", hasOptions: false));
+    }
+
+    [Theory]
+    [InlineData("progress")]
+    [InlineData("status")]
+    [InlineData("working")]
+    [InlineData("PROGRESS")]
+    [InlineData("  Progress ")]
+    public void ProgressTypes_AreProgress(string type)
+    {
+        Assert.True(WizardStepClassifier.IsProgress(type));
+        Assert.Equal(WizardStepCategory.Progress, WizardStepClassifier.Categorize(type, hasOptions: false));
+    }
+
+    [Fact]
+    public void ProgressWithOptions_StillProgress()
+    {
+        // A status step that happens to carry options is still a poll-through.
+        Assert.Equal(WizardStepCategory.Progress, WizardStepClassifier.Categorize("progress", hasOptions: true));
+    }
+
+    [Theory]
+    [InlineData("action")]
+    [InlineData("info")]
+    [InlineData("future-thing")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void UnknownWithoutOptions_IsNonInteractive(string? type)
+    {
+        Assert.Equal(WizardStepCategory.NonInteractive, WizardStepClassifier.Categorize(type, hasOptions: false));
+    }
+
+    [Theory]
+    [InlineData("action")]
+    [InlineData("future-choice")]
+    public void UnknownWithOptions_IsTreatedAsChoice(string type)
+    {
+        Assert.Equal(WizardStepCategory.RequiresAnswer, WizardStepClassifier.Categorize(type, hasOptions: true));
+    }
+
+    [Theory]
+    [InlineData("Text")]
+    [InlineData("SELECT")]
+    [InlineData("Confirm")]
+    [InlineData("NOTE")]
+    public void Categorization_IsCaseInsensitive(string type)
+    {
+        // Should not fall through to NonInteractive just because of casing.
+        Assert.NotEqual(WizardStepCategory.NonInteractive, WizardStepClassifier.Categorize(type, hasOptions: false));
+    }
+
+    [Theory]
+    [InlineData(WizardStepCategory.Progress, true)]
+    [InlineData(WizardStepCategory.NonInteractive, true)]
+    [InlineData(WizardStepCategory.RequiresAnswer, false)]
+    [InlineData(WizardStepCategory.Confirm, false)]
+    [InlineData(WizardStepCategory.Acknowledge, false)]
+    public void ContinuesWithoutAnswer_OnlyForDriveThrough(WizardStepCategory category, bool expected)
+    {
+        Assert.Equal(expected, WizardStepClassifier.ContinuesWithoutAnswer(category));
+    }
+}

--- a/tests/OpenClaw.SetupEngine.Tests/WizardTimeoutsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/WizardTimeoutsTests.cs
@@ -1,0 +1,32 @@
+namespace OpenClaw.SetupEngine.Tests;
+
+public class WizardTimeoutsTests
+{
+    [Theory]
+    [InlineData("Authorize device")]
+    [InlineData("Please sign in to continue")]
+    [InlineData("Complete the OAuth login")]
+    [InlineData("Open your browser to authenticate")]
+    [InlineData("Enter the verification code")]
+    public void AuthSteps_GetExtendedTimeout(string text)
+    {
+        Assert.Equal(WizardTimeouts.AuthTimeoutMs, WizardTimeouts.ForStep(text, string.Empty));
+    }
+
+    [Fact]
+    public void AuthHint_DetectedInMessage()
+    {
+        Assert.Equal(
+            WizardTimeouts.AuthTimeoutMs,
+            WizardTimeouts.ForStep("Setup", "Visit the device authorization page"));
+    }
+
+    [Theory]
+    [InlineData("Choose a connector")]
+    [InlineData("Enter a friendly name")]
+    [InlineData("")]
+    public void OrdinarySteps_GetDefaultTimeout(string text)
+    {
+        Assert.Equal(WizardTimeouts.DefaultTimeoutMs, WizardTimeouts.ForStep(text, string.Empty));
+    }
+}

--- a/tests/OpenClaw.SetupEngine.Tests/WizardTimeoutsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/WizardTimeoutsTests.cs
@@ -29,4 +29,14 @@ public class WizardTimeoutsTests
     {
         Assert.Equal(WizardTimeouts.DefaultTimeoutMs, WizardTimeouts.ForStep(text, string.Empty));
     }
+
+    [Fact]
+    public void ProgressPollBudget_AllowsSingleLongSetupStepToUseTotalBudget()
+    {
+        Assert.Equal(WizardTimeouts.MaxTotalProgressPolls, WizardTimeouts.MaxProgressPollsPerStep);
+        var totalBudget = TimeSpan.FromTicks(
+            WizardTimeouts.ProgressPollDelay.Ticks * WizardTimeouts.MaxTotalProgressPolls);
+        Assert.True(
+            totalBudget >= TimeSpan.FromMinutes(20));
+    }
 }


### PR DESCRIPTION
## Summary
- Make the gateway setup wizard handle progress/status and action-style protocol steps without getting stuck.
- Share step classification, URL/code formatting, and auth-aware timeout logic between headless setup and the WinUI wizard.
- Preserve raw option values for unknown choice-style steps and harden gateway restart replay.

## Fix details
- Progress and non-interactive steps now acknowledge the current step with `sessionId` + `answer.stepId`, matching the gateway `wizard.next` contract.
- Added `WizardNextPayload` plus regression tests showing that session-only polling repeats the current step, while acknowledgement advances it.
- Progress polling remains bounded by per-step and aggregate caps.

## Behavioral proof
I ran the branch locally through setup and the real gateway wizard. The machine's WSL online Ubuntu install path returned `TRUST_E_BAD_DIGEST`, so the proof run used a temporary uncommitted local-rootfs override to get past WSL distro creation. No rootfs override changes are included in this PR.

Observed live wizard flow:

```text
OpenClaw setup
Config handling
QuickStart
Model/auth provider
Default model
Model check
How channels work
Select channel (QuickStart)
Web search
Search provider
Skills status
Configure skills now? (recommended)
Hooks
Enable hooks?
Grant permissions
```

Representative live UI/log evidence:

```text
Docs: https://docs.openclaw.ai/channels/pairing
Live gateway output
Updated config: ~/.openclaw/openclaw.json
Workspace OK: ~/.openclaw/workspace
Sessions OK: ~/.openclaw/agents/main/sessions

[WS] hello-ok ... methods include wizard.start, wizard.next, wizard.cancel, wizard.status
step.completed: verify-e2e -> Success
Pipeline completed successfully in 166.2s
```

Screenshots captured locally for review artifacts:

```text
openclaw-live-wizard-first-step.png
openclaw-live-wizard-after-config-handling.png
openclaw-live-wizard-after-channel-info.png
openclaw-live-wizard-after-channel-skip.png
openclaw-live-wizard-after-search-skip.png
openclaw-live-wizard-after-hooks-skip.png
openclaw-live-final-permissions.png
```

## Focused protocol harness
A local harness also verified the protocol helper behavior directly:

```text
classify progress: Progress
progress continues without answer: True
classify action without options: NonInteractive
action without options continues: True
classify action with options: RequiresAnswer
url line kind: Url
url highlight: https://example.test/device
code line kind: Code
code highlight: WDJB-MJHT
auth timeout: 300000
ordinary timeout: 30000
unknown-with-options wire kind: Number
unknown-with-options wire value: 42
```

## Protocol/source proof
Checked against upstream OpenClaw gateway/macOS sources:

- `packages/gateway-protocol/src/schema/wizard.ts` defines `progress` and `action`, `options[].value` as `Unknown`, `initialValue` as `Unknown`, and optional `sensitive` / `executor`.
- `src/wizard/session.ts` exposes the runtime step union and uses `unknown` option values.
- `apps/macos/Sources/OpenClaw/OnboardingWizard.swift` consumes the same wizard start/next model and preserves selected option values through `AnyCodable`.

## Validation
- `./build.ps1` — all projects passed.
- `dotnet test ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj` — 331 passed.
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj` — 1163 passed.
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-build` — 2422 passed / 29 skipped on rerun.

## Notes
- The wizard protocol is forward-only; this PR does not add a back-step operation.
- The temporary local-rootfs setup override used for proof is not part of this PR.
