### PR TITLE
Improve remote gateway setup and connection error recovery

### DIFF
--- a/src/OpenClaw.Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/GatewayConnectionManager.cs
@@ -518,7 +518,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         }
     }
 
-    public async Task<SetupCodeResult> ApplySetupCodeAsync(string setupCode)
+    public async Task<SetupCodeResult> ApplySetupCodeAsync(string setupCode, SshTunnelConfig? sshTunnel = null)
     {
         ThrowIfDisposed();
 
@@ -554,6 +554,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             Url = gatewayUrl,
             SharedGatewayToken = existing?.SharedGatewayToken, // preserve existing shared token if any
             BootstrapToken = decoded.Token ?? existing?.BootstrapToken,
+            SshTunnel = sshTunnel ?? existing?.SshTunnel,
         };
         _registry.AddOrUpdate(record);
         _registry.SetActive(recordId);

--- a/src/OpenClaw.Connection/IGatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/IGatewayConnectionManager.cs
@@ -46,7 +46,7 @@ public interface IGatewayConnectionManager : IDisposable, IAsyncDisposable
     Task EnsureNodeConnectedAsync(CancellationToken cancellationToken = default);
 
     // ─── Setup ───
-    Task<SetupCodeResult> ApplySetupCodeAsync(string setupCode);
+    Task<SetupCodeResult> ApplySetupCodeAsync(string setupCode, SshTunnelConfig? sshTunnel = null);
     Task<SetupCodeResult> ConnectWithSharedTokenAsync(string gatewayUrl, string token, SshTunnelConfig? sshTunnel = null);
 
     // ─── Operator Client Access ───

--- a/src/OpenClaw.Shared/GatewayErrorClassifier.cs
+++ b/src/OpenClaw.Shared/GatewayErrorClassifier.cs
@@ -1,0 +1,134 @@
+using System;
+
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Actionable classification of a gateway connection error. Lets the UI route a
+/// raw error string to a specific recovery path instead of a generic failure —
+/// distinguishing unauthorized, scope mismatch, token drift, pairing, TLS,
+/// tunnel, and server problems.
+/// </summary>
+public enum GatewayErrorKind
+{
+    /// <summary>No error text, or nothing recognizable.</summary>
+    Unknown,
+
+    /// <summary>Connection refused / unreachable / timed out.</summary>
+    Network,
+
+    /// <summary>Generic unauthorized / invalid-token rejection.</summary>
+    Auth,
+
+    /// <summary>
+    /// The stored device token is no longer recognized by the gateway (rotated,
+    /// revoked, or replaced) — the fix is to re-pair, not to retry.
+    /// </summary>
+    TokenDrift,
+
+    /// <summary>
+    /// Authenticated but missing a required operator/node scope (e.g. cannot
+    /// approve pairing or read config) — the fix is to re-pair for higher scopes.
+    /// </summary>
+    ScopeMismatch,
+
+    /// <summary>Device/node pairing approval is pending on the gateway host.</summary>
+    PairingRequired,
+
+    /// <summary>Pairing was explicitly rejected on the gateway host.</summary>
+    PairingRejected,
+
+    /// <summary>TLS/certificate/cleartext transport problem.</summary>
+    Tls,
+
+    /// <summary>SSH tunnel could not be established or dropped.</summary>
+    Tunnel,
+
+    /// <summary>Gateway returned a 5xx / internal error.</summary>
+    Server,
+
+    /// <summary>Rate limited by the gateway.</summary>
+    RateLimited,
+}
+
+/// <summary>
+/// Pure heuristic classifier for gateway error strings. Order is significant:
+/// the more specific kinds (scope, token drift) are matched before the generic
+/// auth bucket so a "re-pair" path wins over a plain "retry" path.
+/// </summary>
+public static class GatewayErrorClassifier
+{
+    public static GatewayErrorKind Classify(string? error)
+    {
+        if (string.IsNullOrWhiteSpace(error))
+            return GatewayErrorKind.Unknown;
+
+        var e = error.ToLowerInvariant();
+
+        if ((Contains(e, "rate") && Contains(e, "limit")) ||
+            Contains(e, "429") || Contains(e, "too many request"))
+            return GatewayErrorKind.RateLimited;
+
+        // SSH/tunnel first: SSH failures often read "Permission denied
+        // (publickey)" which would otherwise be mistaken for a scope problem.
+        if (Contains(e, "ssh") || Contains(e, "tunnel"))
+            return GatewayErrorKind.Tunnel;
+
+        // Transport security before pairing/auth: e.g. "certificate not
+        // approved by CA" must not be read as a pairing approval.
+        if (Contains(e, "tls") || Contains(e, "ssl") || Contains(e, "certificate") ||
+            Contains(e, "cert ") || Contains(e, "handshake") ||
+            Contains(e, "cleartext") || Contains(e, "insecure"))
+            return GatewayErrorKind.Tls;
+
+        // Scope/permission problems — authenticated but under-privileged.
+        if (Contains(e, "scope") ||
+            Contains(e, "insufficient priv") ||
+            Contains(e, "not permitted") ||
+            Contains(e, "permission denied") ||
+            (Contains(e, "forbidden") && Contains(e, "scope")))
+            return GatewayErrorKind.ScopeMismatch;
+
+        // Token drift — the device token specifically is stale/unknown.
+        if (Contains(e, "re-pair") || Contains(e, "repair token") ||
+            Contains(e, "token rotat") || Contains(e, "token revoked") ||
+            Contains(e, "token mismatch") || Contains(e, "token drift") ||
+            (Contains(e, "device token") &&
+                (Contains(e, "unknown") || Contains(e, "invalid") ||
+                 Contains(e, "expired") || Contains(e, "not recognized") ||
+                 Contains(e, "no longer"))))
+            return GatewayErrorKind.TokenDrift;
+
+        // Pairing lifecycle. Use specific tokens ("pairing"/"approval") so we
+        // don't match "repair" (contains "pair") or "approved by CA".
+        if (Contains(e, "pairing") || Contains(e, "approval"))
+        {
+            if (Contains(e, "reject") || Contains(e, "denied") || Contains(e, "declin"))
+                return GatewayErrorKind.PairingRejected;
+            return GatewayErrorKind.PairingRequired;
+        }
+
+        // Server (5xx) before the broad auth bucket: a transient
+        // "500 internal error: token validation failed" must not route the
+        // user to a re-pair flow.
+        if (Contains(e, "500") || Contains(e, "502") || Contains(e, "503") ||
+            Contains(e, "internal error") || Contains(e, "server error"))
+            return GatewayErrorKind.Server;
+
+        // Generic auth — after the more specific auth-adjacent kinds above.
+        if (Contains(e, "401") || Contains(e, "unauthor") || Contains(e, "forbid") ||
+            Contains(e, "auth") || Contains(e, "token") || Contains(e, "credential"))
+            return GatewayErrorKind.Auth;
+
+        // Network.
+        if (Contains(e, "refused") || Contains(e, "unreachable") ||
+            Contains(e, "timeout") || Contains(e, "timed out") ||
+            Contains(e, "network") || Contains(e, "no route") ||
+            Contains(e, "could not connect") || Contains(e, "connection closed"))
+            return GatewayErrorKind.Network;
+
+        return GatewayErrorKind.Unknown;
+    }
+
+    private static bool Contains(string haystack, string needle) =>
+        haystack.Contains(needle, StringComparison.Ordinal);
+}

--- a/src/OpenClaw.Shared/RemoteGatewayClassifier.cs
+++ b/src/OpenClaw.Shared/RemoteGatewayClassifier.cs
@@ -1,0 +1,130 @@
+using System;
+
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// How the tray reaches a configured gateway. Drives remote-setup guidance and
+/// the cleartext-token warning in Connection settings.
+/// </summary>
+public enum GatewayConnectionTopology
+{
+    /// <summary>URL was empty or could not be parsed.</summary>
+    Unknown,
+
+    /// <summary>localhost / 127.0.0.1 / ::1 — reached directly on this machine.</summary>
+    Local,
+
+    /// <summary>
+    /// A loopback URL that actually fronts a remote gateway through a managed
+    /// SSH tunnel (the WebSocket talks to <c>ws://localhost:&lt;localPort&gt;</c>
+    /// but the bytes are encrypted by SSH end-to-end).
+    /// </summary>
+    SshTunnel,
+
+    /// <summary>Remote host over TLS (<c>wss://</c> or <c>https://</c>).</summary>
+    DirectSecure,
+
+    /// <summary>
+    /// Remote host over cleartext (<c>ws://</c> or <c>http://</c>) — the token
+    /// travels unencrypted across the network.
+    /// </summary>
+    DirectInsecure,
+}
+
+/// <summary>Whether the credential is protected in transit.</summary>
+public enum GatewayTransportSecurity
+{
+    /// <summary>Loopback only — no network exposure.</summary>
+    LocalLoopback,
+
+    /// <summary>Encrypted (TLS) or tunnelled (SSH) — token protected on the wire.</summary>
+    Encrypted,
+
+    /// <summary>Cleartext to a non-local host — token exposed on the wire.</summary>
+    Cleartext,
+}
+
+/// <summary>Immutable classification of a gateway endpoint for setup/repair UX.</summary>
+public sealed record RemoteGatewayProfile(
+    GatewayConnectionTopology Topology,
+    GatewayTransportSecurity Security,
+    string Host,
+    bool IsTls)
+{
+    public bool IsLocal => Topology == GatewayConnectionTopology.Local;
+
+    public bool IsRemote =>
+        Topology is GatewayConnectionTopology.DirectSecure
+                 or GatewayConnectionTopology.DirectInsecure
+                 or GatewayConnectionTopology.SshTunnel;
+
+    /// <summary>
+    /// True when a token would travel in cleartext over a network. The UI should
+    /// steer the user to TLS (<c>wss://</c>), an SSH tunnel, or a trusted proxy
+    /// (e.g. Tailscale) before saving such a gateway.
+    /// </summary>
+    public bool RecommendsTransportHardening =>
+        Security == GatewayTransportSecurity.Cleartext;
+}
+
+/// <summary>
+/// Pure classifier that maps a gateway URL (plus whether a managed SSH tunnel is
+/// configured) to a <see cref="RemoteGatewayProfile"/>. No I/O, no UI types.
+/// </summary>
+public static class RemoteGatewayClassifier
+{
+    public static RemoteGatewayProfile Classify(string? url, bool hasSshTunnel = false)
+    {
+        var trimmed = url?.Trim();
+        if (string.IsNullOrEmpty(trimmed) ||
+            !Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) ||
+            string.IsNullOrEmpty(uri.Host))
+        {
+            // Unparseable input is left to GatewayUrlHelper validation elsewhere;
+            // we surface no transport warning so half-typed URLs don't flicker a
+            // scary banner on every keystroke.
+            return new RemoteGatewayProfile(
+                GatewayConnectionTopology.Unknown,
+                GatewayTransportSecurity.LocalLoopback,
+                Host: string.Empty,
+                IsTls: false);
+        }
+
+        var host = uri.Host;
+        var scheme = uri.Scheme;
+        var isTls = scheme.Equals("wss", StringComparison.OrdinalIgnoreCase) ||
+                    scheme.Equals("https", StringComparison.OrdinalIgnoreCase);
+
+        // A managed SSH tunnel encrypts the hop even though the WebSocket URL is
+        // loopback. Treat it as a remote-but-encrypted endpoint.
+        if (hasSshTunnel)
+        {
+            return new RemoteGatewayProfile(
+                GatewayConnectionTopology.SshTunnel,
+                GatewayTransportSecurity.Encrypted,
+                host,
+                isTls);
+        }
+
+        if (LocalGatewayUrlClassifier.IsLocalGatewayUrl(trimmed))
+        {
+            return new RemoteGatewayProfile(
+                GatewayConnectionTopology.Local,
+                GatewayTransportSecurity.LocalLoopback,
+                host,
+                isTls);
+        }
+
+        return isTls
+            ? new RemoteGatewayProfile(
+                GatewayConnectionTopology.DirectSecure,
+                GatewayTransportSecurity.Encrypted,
+                host,
+                IsTls: true)
+            : new RemoteGatewayProfile(
+                GatewayConnectionTopology.DirectInsecure,
+                GatewayTransportSecurity.Cleartext,
+                host,
+                IsTls: false);
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
@@ -602,6 +602,11 @@
                                             Click="OnApplyRepairCode"
                                             AutomationProperties.AutomationId="RecoveryApplyRepair"/>
                                 </Grid>
+                                <TextBlock x:Name="RecoveryRepairResultText"
+                                           Visibility="Collapsed"
+                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                           TextWrapping="Wrap"
+                                           AutomationProperties.AutomationId="RecoveryRepairResult"/>
                             </StackPanel>
                         </Border>
 
@@ -946,11 +951,82 @@
                                  Header="Shared token"
                                  PlaceholderText="Paste shared gateway token"
                                  AutomationProperties.AutomationId="AddDirectToken"/>
+                        <TextBlock x:Uid="ConnectionPage_TokenOrPasswordHint" x:Name="DirectAuthHintText"
+                                   Text="Paste a shared gateway token, or leave it blank to pair with a setup code."
+                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   TextWrapping="Wrap"/>
                         <TextBox x:Uid="ConnectionPage_NameOptional" x:Name="DirectNameBox"
                                  Header="Name (optional)"
                                  PlaceholderText="My gateway"
                                  AutomationProperties.AutomationId="AddDirectName"/>
                     </StackPanel>
+
+                    <!-- Remote gateway setup help — a lightweight info link that
+                         opens a TeachingTip. Deliberately NOT an Expander so it
+                         reads as guidance and is visually distinct from the
+                         functional "Use SSH tunnel" input section below. -->
+                    <HyperlinkButton x:Name="AddRemoteHelpLink"
+                                     Padding="0" FontSize="13"
+                                     Click="OnRemoteHelpClick"
+                                     AutomationProperties.AutomationId="AddRemoteHelpLink">
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.About, Mode=OneTime}"
+                                      FontSize="14" VerticalAlignment="Center"
+                                      AutomationProperties.AccessibilityView="Raw"/>
+                            <TextBlock x:Uid="ConnectionPage_RemoteSetupHelpLink"
+                                       Text="How do I connect to a remote gateway?"
+                                       VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </HyperlinkButton>
+
+                    <TeachingTip x:Name="AddRemoteHelpTip"
+                                 Target="{x:Bind AddRemoteHelpLink}"
+                                 x:Uid="ConnectionPage_RemoteSetupHelpTip"
+                                 Title="Connecting to a remote gateway"
+                                 PreferredPlacement="Bottom"
+                                 IsLightDismissEnabled="True">
+                        <TeachingTip.Content>
+                            <StackPanel Spacing="12" Margin="0,8,0,0">
+                                <StackPanel Spacing="2">
+                                    <TextBlock x:Uid="ConnectionPage_RemoteSetupHelpDirectTitle"
+                                               Text="Direct (TLS)" FontWeight="SemiBold"/>
+                                    <TextBlock x:Uid="ConnectionPage_RemoteSetupHelpDirect"
+                                               Text="Connect to wss:// or https:// when the gateway has a trusted certificate. Your token is encrypted in transit after certificate validation."
+                                               Style="{StaticResource CaptionTextBlockStyle}"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                               TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <StackPanel Spacing="2">
+                                    <TextBlock x:Uid="ConnectionPage_RemoteSetupHelpTunnelTitle"
+                                               Text="SSH tunnel" FontWeight="SemiBold"/>
+                                    <TextBlock x:Uid="ConnectionPage_RemoteSetupHelpTunnel"
+                                               Text="When the gateway only listens on localhost, expand &quot;Use SSH tunnel&quot; below. The tray forwards a local port over SSH so traffic stays encrypted."
+                                               Style="{StaticResource CaptionTextBlockStyle}"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                               TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <StackPanel Spacing="2">
+                                    <TextBlock x:Uid="ConnectionPage_RemoteSetupHelpProxyTitle"
+                                               Text="Trusted proxy / Tailscale" FontWeight="SemiBold"/>
+                                    <TextBlock x:Uid="ConnectionPage_RemoteSetupHelpProxy"
+                                               Text="If a Tailscale or reverse proxy already encrypts the path, a plain ws:// URL over that private network is fine."
+                                               Style="{StaticResource CaptionTextBlockStyle}"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                               TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <StackPanel Spacing="2">
+                                    <TextBlock x:Uid="ConnectionPage_RemoteSetupHelpAuthTitle"
+                                               Text="Auth" FontWeight="SemiBold"/>
+                                    <TextBlock x:Uid="ConnectionPage_RemoteSetupHelpAuth"
+                                               Text="Paste a shared token, or leave it blank and pair with a setup code. Re-pairing also upgrades this device's scopes."
+                                               Style="{StaticResource CaptionTextBlockStyle}"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                               TextWrapping="Wrap"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </TeachingTip.Content>
+                    </TeachingTip>
 
                     <!-- Setup code pane -->
                     <StackPanel x:Name="AddSetupCodePane" Spacing="8" Visibility="Collapsed">
@@ -1013,10 +1089,20 @@
                                    Visibility="Collapsed"/>
                     </StackPanel>
 
+                    <!-- Transport-security advice — populated in code-behind
+                         from RemoteGatewayClassifier for the active method's
+                         URL (Direct field or decoded setup code). -->
+                    <InfoBar x:Name="AddSecurityAdviceBar"
+                             IsOpen="False" IsClosable="False"
+                             Severity="Informational"
+                             AutomationProperties.AutomationId="AddSecurityAdvice"/>
+
                     <!-- Per-gateway SSH tunnel — saved with the gateway record -->
                     <Expander x:Name="AddSshExpander"
                               HorizontalAlignment="Stretch"
                               HorizontalContentAlignment="Stretch"
+                              Expanding="OnAddSshExpanding"
+                              Collapsed="OnAddSshCollapsed"
                               IsExpanded="False">
                         <Expander.Header>
                             <TextBlock x:Uid="ConnectionPage_UseSSHTunnelOptional" Text="Use SSH tunnel (optional)"
@@ -1032,10 +1118,12 @@
                                 <TextBox x:Uid="ConnectionPage_SSHUser" Grid.Column="0"
                                          x:Name="AddSshUserBox"
                                          Header="SSH user"
+                                         TextChanged="OnAddSshFieldChanged"
                                          PlaceholderText="user"/>
                                 <TextBox x:Uid="ConnectionPage_SSHHost" Grid.Column="1"
                                          x:Name="AddSshHostBox"
                                          Header="SSH host"
+                                         TextChanged="OnAddSshFieldChanged"
                                          PlaceholderText="machine-name"/>
                             </Grid>
                             <Grid ColumnSpacing="8">

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -55,6 +55,10 @@ public sealed partial class ConnectionPage : Page
     // updates the original record instead of orphaning it as a duplicate.
     private string? _editingGatewayId;
 
+    // Last gateway URL decoded from a pasted setup code, used to drive the
+    // transport-security advice for the Setup-code method. Null when no valid
+    // code is decoded.
+    private string? _lastDecodedSetupUrl;
     // ─── Reconnect-mask state ───
     // Toggling Node mode forces the connection manager to tear down the
     // WS and rebuild it (so the gateway sees the role change). That brief
@@ -978,6 +982,7 @@ public sealed partial class ConnectionPage : Page
         RecoveryTunnelBlock.Visibility = Visibility.Collapsed;
         RecoveryAuthPasteBlock.Visibility = Visibility.Collapsed;
         RecoveryApproveCmdBlock.Visibility = Visibility.Collapsed;
+        RecoveryRepairResultText.Visibility = Visibility.Collapsed;
 
         RecoveryHelpHeaderText.Text = plan.Recovery switch
         {
@@ -985,6 +990,10 @@ public sealed partial class ConnectionPage : Page
             RecoveryCategory.Pairing => LocalizationHelper.GetString("ConnectionPage_RecoveryHeaderPairing"),
             RecoveryCategory.Tunnel => LocalizationHelper.GetString("ConnectionPage_RecoveryHeaderTunnel"),
             RecoveryCategory.Server => LocalizationHelper.GetString("ConnectionPage_RecoveryHeaderServer"),
+            RecoveryCategory.TokenDrift => LocalizationHelper.GetString("ConnectionPage_RecoveryHeaderTokenDrift"),
+            RecoveryCategory.Scope => LocalizationHelper.GetString("ConnectionPage_RecoveryHeaderScope"),
+            RecoveryCategory.Tls => LocalizationHelper.GetString("ConnectionPage_RecoveryHeaderTls"),
+            RecoveryCategory.RateLimited => LocalizationHelper.GetString("ConnectionPage_RecoveryHeaderRateLimited"),
             _ => LocalizationHelper.GetString("ConnectionPage_RecoveryHeaderServer"),
         };
 
@@ -1011,6 +1020,26 @@ public sealed partial class ConnectionPage : Page
                 LocalizationHelper.GetString("ConnectionPage_RecoveryServerBullet2"),
                 LocalizationHelper.GetString("ConnectionPage_RecoveryServerBullet3"),
             },
+            RecoveryCategory.TokenDrift => new[]
+            {
+                LocalizationHelper.GetString("ConnectionPage_RecoveryTokenDriftBullet1"),
+                LocalizationHelper.GetString("ConnectionPage_RecoveryTokenDriftBullet2"),
+            },
+            RecoveryCategory.Scope => new[]
+            {
+                LocalizationHelper.GetString("ConnectionPage_RecoveryScopeBullet1"),
+                LocalizationHelper.GetString("ConnectionPage_RecoveryScopeBullet2"),
+            },
+            RecoveryCategory.Tls => new[]
+            {
+                LocalizationHelper.GetString("ConnectionPage_RecoveryTlsBullet1"),
+                LocalizationHelper.GetString("ConnectionPage_RecoveryTlsBullet2"),
+            },
+            RecoveryCategory.RateLimited => new[]
+            {
+                LocalizationHelper.GetString("ConnectionPage_RecoveryRateLimitedBullet1"),
+                LocalizationHelper.GetString("ConnectionPage_RecoveryRateLimitedBullet2"),
+            },
             _ => new[]
             {
                 LocalizationHelper.GetString("ConnectionPage_RecoveryDefaultBullet1"),
@@ -1028,7 +1057,11 @@ public sealed partial class ConnectionPage : Page
             RecoveryTunnelBlock.Visibility = Visibility.Visible;
             RecoveryTunnelDetailText.Text = plan.RecoveryDetail ?? LocalizationHelper.GetString("ConnectionPage_SshTunnelIsDownText");
         }
-        if (plan.Recovery == RecoveryCategory.Auth)
+        // Auth, token drift, and scope problems are all repaired by pasting a
+        // fresh setup code (re-pair), which also upgrades scopes on the gateway.
+        if (plan.Recovery is RecoveryCategory.Auth
+                          or RecoveryCategory.TokenDrift
+                          or RecoveryCategory.Scope)
         {
             RecoveryAuthPasteBlock.Visibility = Visibility.Visible;
         }
@@ -1641,6 +1674,101 @@ public sealed partial class ConnectionPage : Page
         bool isFormMethod = (tag == "direct") || (tag == "setup");
         AddSshExpander.Visibility = isFormMethod ? Visibility.Visible : Visibility.Collapsed;
         AddSaveButton.Visibility = isFormMethod ? Visibility.Visible : Visibility.Collapsed;
+        AddRemoteHelpLink.Visibility = isFormMethod ? Visibility.Visible : Visibility.Collapsed;
+        if (!isFormMethod)
+            AddRemoteHelpTip.IsOpen = false;
+
+        UpdateRemoteSetupAdvice();
+    }
+
+    private void OnRemoteHelpClick(object sender, RoutedEventArgs e)
+    {
+        AddRemoteHelpTip.IsOpen = !AddRemoteHelpTip.IsOpen;
+    }
+
+    // ─── Remote setup transport-security advisory ─────────────────────
+    // Offline (no network) classification driven by RemoteGatewayClassifier.
+    // Steers users to TLS / SSH tunnel / trusted proxy before they save a
+    // gateway that would send the token in cleartext over the network.
+
+    private void OnAddSshExpanding(Expander sender, ExpanderExpandingEventArgs args) =>
+        UpdateRemoteSetupAdvice(sshExpandedOverride: true);
+
+    private void OnAddSshCollapsed(Expander sender, ExpanderCollapsedEventArgs args) =>
+        UpdateRemoteSetupAdvice(sshExpandedOverride: false);
+
+    private void OnAddSshFieldChanged(object sender, TextChangedEventArgs e) =>
+        UpdateRemoteSetupAdvice();
+
+    private void UpdateRemoteSetupAdvice(bool? sshExpandedOverride = null)
+    {
+        if (AddSecurityAdviceBar == null) return;
+
+        // The advice applies to the two form methods (Direct + Setup code).
+        // Pick the URL from whichever is active: the typed Direct URL, or the
+        // URL decoded from a pasted setup code.
+        string? url;
+        var tag = ActiveAddPaneTag();
+        if (tag == "direct")
+            url = DirectUrlBox.Text?.Trim();
+        else if (tag == "setup")
+            url = _lastDecodedSetupUrl;
+        else
+        {
+            AddSecurityAdviceBar.IsOpen = false;
+            return;
+        }
+
+        // The Expander.Expanding/Collapsed events fire before IsExpanded flips,
+        // so callers pass the post-transition state to avoid a one-frame flash
+        // of the cleartext warning.
+        bool sshExpanded = sshExpandedOverride ?? AddSshExpander.IsExpanded;
+        bool hasSshTunnel = sshExpanded
+                         && !string.IsNullOrWhiteSpace(AddSshUserBox.Text)
+                         && !string.IsNullOrWhiteSpace(AddSshHostBox.Text);
+
+        var profile = RemoteGatewayClassifier.Classify(url, hasSshTunnel);
+
+        InfoBarSeverity severity;
+        string title;
+        string message;
+        bool open = true;
+
+        switch (profile.Topology)
+        {
+            case GatewayConnectionTopology.DirectInsecure:
+                severity = InfoBarSeverity.Warning;
+                title = LocalizationHelper.GetString("ConnectionPage_AdviceCleartextTitle");
+                message = LocalizationHelper.GetString("ConnectionPage_AdviceCleartextMessage");
+                break;
+            case GatewayConnectionTopology.DirectSecure:
+                severity = InfoBarSeverity.Success;
+                title = LocalizationHelper.GetString("ConnectionPage_AdviceSecureTitle");
+                message = LocalizationHelper.GetString("ConnectionPage_AdviceSecureMessage");
+                break;
+            case GatewayConnectionTopology.SshTunnel:
+                severity = InfoBarSeverity.Success;
+                title = LocalizationHelper.GetString("ConnectionPage_AdviceTunnelTitle");
+                message = LocalizationHelper.GetString("ConnectionPage_AdviceTunnelMessage");
+                break;
+            default:
+                // Local or unparseable — no transport warning needed.
+                AddSecurityAdviceBar.IsOpen = false;
+                return;
+        }
+
+        // InfoBar does not reliably repaint its severity icon/accent when
+        // Severity changes while IsOpen stays true. When the severity actually
+        // changes (e.g. cleartext ws:// → TLS wss://), force a close before
+        // re-applying so the bar re-renders cleanly. Guard on change so we
+        // don't flicker on every keystroke within the same severity.
+        if (AddSecurityAdviceBar.IsOpen && AddSecurityAdviceBar.Severity != severity)
+            AddSecurityAdviceBar.IsOpen = false;
+
+        AddSecurityAdviceBar.Severity = severity;
+        AddSecurityAdviceBar.Title = title;
+        AddSecurityAdviceBar.Message = message;
+        AddSecurityAdviceBar.IsOpen = open;
     }
 
     private string ActiveAddPaneTag()
@@ -1949,16 +2077,24 @@ public sealed partial class ConnectionPage : Page
     {
         var code = RecoveryRepairCodeBox.Text?.Trim();
         if (string.IsNullOrEmpty(code) || _connectionManager == null) return;
+        void ShowResult(string text, bool error)
+        {
+            RecoveryRepairResultText.Text = text;
+            RecoveryRepairResultText.Foreground = (Brush)Application.Current.Resources[
+                error ? "SystemFillColorCriticalBrush" : "SystemFillColorSuccessBrush"];
+            RecoveryRepairResultText.Visibility = Visibility.Visible;
+        }
         try
         {
             var result = await _connectionManager.ApplySetupCodeAsync(code);
-            AddResultText.Text = result.Outcome == SetupCodeOutcome.Success
-                ? LocalizationHelper.GetString("ConnectionPage_RepairedReconnecting")
-                : $"✗ {result.ErrorMessage ?? LocalizationHelper.GetString("ConnectionPage_CouldNotApplyCode")}";
+            if (result.Outcome == SetupCodeOutcome.Success)
+                ShowResult(LocalizationHelper.GetString("ConnectionPage_RepairedReconnecting"), error: false);
+            else
+                ShowResult($"✗ {result.ErrorMessage ?? LocalizationHelper.GetString("ConnectionPage_CouldNotApplyCode")}", error: true);
         }
         catch (Exception ex)
         {
-            AddResultText.Text = $"✗ {ex.Message}";
+            ShowResult($"✗ {ex.Message}", error: true);
         }
     }
 
@@ -2107,6 +2243,7 @@ public sealed partial class ConnectionPage : Page
         var url = DirectUrlBox.Text?.Trim();
         ScheduleConnectivityTest(url);
         AutoFillTokenForUrl(url);
+        UpdateRemoteSetupAdvice();
     }
 
     private void OnDirectUrlLostFocus(object sender, RoutedEventArgs e)
@@ -2115,6 +2252,7 @@ public sealed partial class ConnectionPage : Page
         ScheduleConnectivityTest(url);
         // On focus-out, overwrite token even if already populated (user finished editing URL).
         AutoFillTokenForUrl(url, force: true);
+        UpdateRemoteSetupAdvice();
     }
 
     private void AutoFillTokenForUrl(string? url, bool force = false)
@@ -2263,43 +2401,12 @@ public sealed partial class ConnectionPage : Page
 
         url = GatewayUrlHelper.NormalizeForWebSocket(url);
 
-        // SSH tunnel — read from the Add form (per-gateway) if the expander is open
-        SshTunnelConfig? sshConfig = null;
-        bool useSsh = AddSshExpander.IsExpanded
-                   && !string.IsNullOrWhiteSpace(AddSshUserBox.Text)
-                   && !string.IsNullOrWhiteSpace(AddSshHostBox.Text);
-        if (useSsh)
+        if (!TryBuildAddSshTunnelConfig(out var sshConfig, out var sshError))
         {
-            var sshUser = AddSshUserBox.Text.Trim();
-            var sshHost = AddSshHostBox.Text.Trim();
-            var sshPortText = string.IsNullOrWhiteSpace(AddSshServerPortBox.Text) ? "22" : AddSshServerPortBox.Text;
-            if (!int.TryParse(sshPortText, out var sshPort) || sshPort is < 1 or > 65535)
-            {
-                AddResultText.Text = LocalizationHelper.GetString("ConnectionPage_SshServerPortInvalid");
-                return;
-            }
-            if (!int.TryParse(AddSshRemotePortBox.Text, out var remotePort) || remotePort is < 1 or > 65535)
-            {
-                AddResultText.Text = LocalizationHelper.GetString("ConnectionPage_SshRemotePortInvalid");
-                return;
-            }
-            if (!int.TryParse(AddSshLocalPortBox.Text, out var localPort) || localPort is < 1 or > 65535)
-            {
-                AddResultText.Text = LocalizationHelper.GetString("ConnectionPage_SshLocalPortInvalid");
-                return;
-            }
-            var includeBrowserProxyForward = BrowserProxySshTunnelForwardPolicy.ShouldInclude(
-                CurrentApp.Settings.NodeBrowserProxyEnabled,
-                remotePort,
-                localPort);
-            sshConfig = new SshTunnelConfig(
-                sshUser,
-                sshHost,
-                remotePort,
-                localPort,
-                IncludeBrowserProxyForward: includeBrowserProxyForward,
-                SshPort: sshPort);
+            AddResultText.Text = sshError;
+            return;
         }
+        bool useSsh = sshConfig != null;
 
         AddSaveButton.IsEnabled = false;
         AddResultText.Text = LocalizationHelper.GetString("ConnectionPage_Connecting");
@@ -2490,6 +2597,51 @@ public sealed partial class ConnectionPage : Page
         snapshot.OperatorState is RoleConnectionState.PairingRequired
             or RoleConnectionState.Error;
 
+    private bool TryBuildAddSshTunnelConfig(out SshTunnelConfig? sshConfig, out string? error)
+    {
+        sshConfig = null;
+        error = null;
+
+        if (!AddSshExpander.IsExpanded ||
+            string.IsNullOrWhiteSpace(AddSshUserBox.Text) ||
+            string.IsNullOrWhiteSpace(AddSshHostBox.Text))
+        {
+            return true;
+        }
+
+        var sshUser = AddSshUserBox.Text.Trim();
+        var sshHost = AddSshHostBox.Text.Trim();
+        var sshPortText = string.IsNullOrWhiteSpace(AddSshServerPortBox.Text) ? "22" : AddSshServerPortBox.Text;
+        if (!int.TryParse(sshPortText, out var sshPort) || sshPort is < 1 or > 65535)
+        {
+            error = LocalizationHelper.GetString("ConnectionPage_SshServerPortInvalid");
+            return false;
+        }
+        if (!int.TryParse(AddSshRemotePortBox.Text, out var remotePort) || remotePort is < 1 or > 65535)
+        {
+            error = LocalizationHelper.GetString("ConnectionPage_SshRemotePortInvalid");
+            return false;
+        }
+        if (!int.TryParse(AddSshLocalPortBox.Text, out var localPort) || localPort is < 1 or > 65535)
+        {
+            error = LocalizationHelper.GetString("ConnectionPage_SshLocalPortInvalid");
+            return false;
+        }
+
+        var includeBrowserProxyForward = BrowserProxySshTunnelForwardPolicy.ShouldInclude(
+            CurrentApp.Settings.NodeBrowserProxyEnabled,
+            remotePort,
+            localPort);
+        sshConfig = new SshTunnelConfig(
+            sshUser,
+            sshHost,
+            remotePort,
+            localPort,
+            IncludeBrowserProxyForward: includeBrowserProxyForward,
+            SshPort: sshPort);
+        return true;
+    }
+
     private static GatewayConnectionSnapshot EnsureDirectConnectSucceeded(GatewayConnectionSnapshot snapshot)
     {
         if (snapshot.OperatorState == RoleConnectionState.Error)
@@ -2576,6 +2728,11 @@ public sealed partial class ConnectionPage : Page
             AddResultText.Text = LocalizationHelper.GetString("ConnectionPage_PleaseEnterSetupCode");
             return;
         }
+        if (!TryBuildAddSshTunnelConfig(out var sshConfig, out var sshError))
+        {
+            AddResultText.Text = sshError;
+            return;
+        }
 
         AddSaveButton.IsEnabled = false;
         AddResultText.Text = LocalizationHelper.GetString("ConnectionPage_Applying");
@@ -2583,7 +2740,7 @@ public sealed partial class ConnectionPage : Page
         {
             if (_connectionManager != null)
             {
-                var result = await _connectionManager.ApplySetupCodeAsync(code);
+                var result = await _connectionManager.ApplySetupCodeAsync(code, sshConfig);
                 AddResultText.Text = result.Outcome switch
                 {
                     SetupCodeOutcome.Success => $"✓ {string.Format(LocalizationHelper.GetString("ConnectionPage_AppliedGateway"), SanitizeUrl(result.GatewayUrl ?? ""))}",
@@ -2634,6 +2791,8 @@ public sealed partial class ConnectionPage : Page
         if (string.IsNullOrEmpty(code) || code.Length < 10)
         {
             AddSetupCodePreviewPanel.Visibility = Visibility.Collapsed;
+            _lastDecodedSetupUrl = null;
+            UpdateRemoteSetupAdvice();
             return;
         }
         var decoded = SetupCodeDecoder.Decode(code);
@@ -2648,10 +2807,15 @@ public sealed partial class ConnectionPage : Page
             // Auto-test connectivity with the decoded URL
             if (!string.IsNullOrEmpty(decoded.Url))
                 ScheduleConnectivityTest(decoded.Url);
+            // Warn if the decoded URL would send the bootstrap token in cleartext.
+            _lastDecodedSetupUrl = decoded.Url;
+            UpdateRemoteSetupAdvice();
         }
         else
         {
             AddSetupCodePreviewPanel.Visibility = Visibility.Collapsed;
+            _lastDecodedSetupUrl = null;
+            UpdateRemoteSetupAdvice();
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -1604,6 +1604,7 @@ public sealed partial class ConnectionPage : Page
     {
         _editingGatewayId = null;
         _userIntent = UserIntent.AddingGateway;
+        ClearAddGatewaySshFields();
         // Direct is default — make sure the selector is on Direct.
         // Pre-fill the most common local gateway URL.
         DirectUrlBox.Text = "ws://127.0.0.1:18789";
@@ -1619,6 +1620,7 @@ public sealed partial class ConnectionPage : Page
     {
         _editingGatewayId = null;
         _userIntent = UserIntent.AddingGateway;
+        ClearAddGatewaySshFields();
         ShowAddPane("direct");
         AddDirectItem.IsSelected = true;
         RefreshFromSnapshot(_lastSnapshot);
@@ -1628,6 +1630,7 @@ public sealed partial class ConnectionPage : Page
     {
         _editingGatewayId = null;
         _userIntent = UserIntent.AddingGateway;
+        ClearAddGatewaySshFields();
         ShowAddPane("setup");
         AddSetupCodeItem.IsSelected = true;
         RefreshFromSnapshot(_lastSnapshot);
@@ -1648,6 +1651,7 @@ public sealed partial class ConnectionPage : Page
         AddResultText.Text = "";
         AddSetupCodeBox.Text = "";
         AddSetupCodePreviewPanel.Visibility = Visibility.Collapsed;
+        ClearAddGatewaySshFields();
         AddScanStatusText.Text = LocalizationHelper.GetString("ConnectionPage_PressScan");
         AddScanProgressBar.Visibility = Visibility.Collapsed;
         AddScanResultsPanel.Children.Clear();
@@ -1679,6 +1683,16 @@ public sealed partial class ConnectionPage : Page
             AddRemoteHelpTip.IsOpen = false;
 
         UpdateRemoteSetupAdvice();
+    }
+
+    private void ClearAddGatewaySshFields()
+    {
+        AddSshExpander.IsExpanded = false;
+        AddSshUserBox.Text = "";
+        AddSshHostBox.Text = "";
+        AddSshServerPortBox.Text = "";
+        AddSshRemotePortBox.Text = "";
+        AddSshLocalPortBox.Text = "";
     }
 
     private void OnRemoteHelpClick(object sender, RoutedEventArgs e)

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPagePlan.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPagePlan.cs
@@ -105,6 +105,14 @@ internal enum RecoveryCategory
     Network,
     Server,
     Tunnel,
+    /// <summary>Authenticated but missing a required scope — re-pair for higher scopes.</summary>
+    Scope,
+    /// <summary>Stored device token rotated/revoked — re-pair to repair.</summary>
+    TokenDrift,
+    /// <summary>TLS/cleartext transport problem — switch to wss:// or a tunnel.</summary>
+    Tls,
+    /// <summary>Gateway is temporarily rate-limiting this client.</summary>
+    RateLimited,
 }
 
 /// <summary>
@@ -449,6 +457,85 @@ internal sealed record ConnectionPagePlan
                 RelevantGatewayId = rec?.Id,
             },
 
+            // Stored device token rotated/revoked — the fix is to re-pair, not
+            // retry. Same paste-setup-code affordance as Auth, clearer copy.
+            RecoveryCategory.TokenDrift => new ConnectionPagePlan
+            {
+                Mode = ConnectionPageMode.Recovery,
+                Recovery = RecoveryCategory.TokenDrift,
+                StripGlyph = OpenClawTray.Helpers.FluentIconCatalog.StatusErr,
+                StripAccent = ConnectionAccent.Critical,
+                StripHeadline = "Device needs re-pairing",
+                StripSub = string.IsNullOrEmpty(err)
+                    ? $"The saved device token for {name} is no longer trusted by the gateway."
+                    : err,
+                StripPrimaryLabel = null,
+                StripPrimaryAction = ConnectionPrimaryAction.None,
+                ActiveGatewayDisplayName = name,
+                ActiveGatewayDetailLine = url,
+                ActiveGatewayHasSshTunnel = rec?.SshTunnel != null,
+                RelevantGatewayId = rec?.Id,
+            },
+
+            // Authenticated but under-privileged — re-pair to request the scopes
+            // this device needs (e.g. operator.admin / operator.pairing).
+            RecoveryCategory.Scope => new ConnectionPagePlan
+            {
+                Mode = ConnectionPageMode.Recovery,
+                Recovery = RecoveryCategory.Scope,
+                StripGlyph = OpenClawTray.Helpers.FluentIconCatalog.Lock,
+                StripAccent = ConnectionAccent.Critical,
+                StripHeadline = "Not enough access",
+                StripSub = string.IsNullOrEmpty(err)
+                    ? $"This device is connected but lacks the scopes it needs on {name}."
+                    : err,
+                StripPrimaryLabel = null,
+                StripPrimaryAction = ConnectionPrimaryAction.None,
+                ActiveGatewayDisplayName = name,
+                ActiveGatewayDetailLine = url,
+                ActiveGatewayHasSshTunnel = rec?.SshTunnel != null,
+                RelevantGatewayId = rec?.Id,
+            },
+
+            // TLS/cleartext transport problem — steer toward wss:// or a tunnel.
+            RecoveryCategory.Tls => new ConnectionPagePlan
+            {
+                Mode = ConnectionPageMode.Recovery,
+                Recovery = RecoveryCategory.Tls,
+                StripGlyph = OpenClawTray.Helpers.FluentIconCatalog.StatusErr,
+                StripAccent = ConnectionAccent.Critical,
+                StripHeadline = "Secure connection failed",
+                StripSub = string.IsNullOrEmpty(err)
+                    ? "The gateway's transport could not be secured."
+                    : err,
+                StripPrimaryLabel = "Retry",
+                StripPrimaryAction = ConnectionPrimaryAction.Retry,
+                RecoveryDetail = err,
+                ActiveGatewayDisplayName = name,
+                ActiveGatewayDetailLine = url,
+                ActiveGatewayHasSshTunnel = rec?.SshTunnel != null,
+                RelevantGatewayId = rec?.Id,
+            },
+
+            RecoveryCategory.RateLimited => new ConnectionPagePlan
+            {
+                Mode = ConnectionPageMode.Recovery,
+                Recovery = RecoveryCategory.RateLimited,
+                StripGlyph = OpenClawTray.Helpers.FluentIconCatalog.StatusWarn,
+                StripAccent = ConnectionAccent.Caution,
+                StripHeadline = "Too many failed attempts",
+                StripSub = string.IsNullOrEmpty(err)
+                    ? "The gateway is temporarily limiting connection attempts from this client."
+                    : err,
+                StripPrimaryLabel = null,
+                StripPrimaryAction = ConnectionPrimaryAction.None,
+                RecoveryDetail = err,
+                ActiveGatewayDisplayName = name,
+                ActiveGatewayDetailLine = url,
+                ActiveGatewayHasSshTunnel = rec?.SshTunnel != null,
+                RelevantGatewayId = rec?.Id,
+            },
+
             RecoveryCategory.Tunnel => new ConnectionPagePlan
             {
                 Mode = ConnectionPageMode.Recovery,
@@ -708,20 +795,24 @@ internal sealed record ConnectionPagePlan
 
     private static RecoveryCategory ClassifyError(string err)
     {
-        if (string.IsNullOrEmpty(err)) return RecoveryCategory.Network;
-        var e = err.ToLowerInvariant();
-
-        if (e.Contains("auth") || e.Contains("token") || e.Contains("unauthor") || e.Contains("forbid"))
-            return RecoveryCategory.Auth;
-
-        if (e.Contains("ssh") || e.Contains("tunnel"))
-            return RecoveryCategory.Tunnel;
-
-        if (e.Contains("500") || e.Contains("502") || e.Contains("503") ||
-            e.Contains("internal") || e.Contains("server"))
-            return RecoveryCategory.Server;
-
-        return RecoveryCategory.Network;
+        // Delegate the heuristic matching to the pure, unit-tested Shared
+        // classifier so the same kinds drive both setup and recovery copy.
+        return OpenClaw.Shared.GatewayErrorClassifier.Classify(err) switch
+        {
+            OpenClaw.Shared.GatewayErrorKind.ScopeMismatch => RecoveryCategory.Scope,
+            OpenClaw.Shared.GatewayErrorKind.TokenDrift => RecoveryCategory.TokenDrift,
+            OpenClaw.Shared.GatewayErrorKind.Auth => RecoveryCategory.Auth,
+            OpenClaw.Shared.GatewayErrorKind.Tls => RecoveryCategory.Tls,
+            OpenClaw.Shared.GatewayErrorKind.Tunnel => RecoveryCategory.Tunnel,
+            OpenClaw.Shared.GatewayErrorKind.Server => RecoveryCategory.Server,
+            OpenClaw.Shared.GatewayErrorKind.RateLimited => RecoveryCategory.RateLimited,
+            OpenClaw.Shared.GatewayErrorKind.PairingRejected => RecoveryCategory.Auth,
+            // PairingRequired is normally driven by snapshot state, not the
+            // error string; if it surfaces here, the Auth re-pair path is the
+            // closest actionable fit. Network / Unknown → Network.
+            OpenClaw.Shared.GatewayErrorKind.PairingRequired => RecoveryCategory.Auth,
+            _ => RecoveryCategory.Network,
+        };
     }
 
     private static string FormatUptime(long uptimeMs)

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -6629,4 +6629,91 @@ Check your connection settings and try again.</value>
   <data name="ConnectionPage_NodePendingDeclaredPermissions" xml:space="preserve">
     <value>Pending declared permissions: {0}</value>
   </data>
+  <data name="ConnectionPage_AdviceCleartextTitle" xml:space="preserve">
+    <value>Unencrypted connection</value>
+  </data>
+  <data name="ConnectionPage_AdviceCleartextMessage" xml:space="preserve">
+    <value>This remote gateway uses ws:// — your token would be sent in cleartext. Use wss:// (TLS), an SSH tunnel, or a trusted proxy / Tailscale.</value>
+  </data>
+  <data name="ConnectionPage_AdviceSecureTitle" xml:space="preserve">
+    <value>Encrypted (TLS)</value>
+  </data>
+  <data name="ConnectionPage_AdviceSecureMessage" xml:space="preserve">
+    <value>This gateway uses TLS. Your token is protected in transit when the certificate validates.</value>
+  </data>
+  <data name="ConnectionPage_AdviceTunnelTitle" xml:space="preserve">
+    <value>SSH tunnel</value>
+  </data>
+  <data name="ConnectionPage_AdviceTunnelMessage" xml:space="preserve">
+    <value>Traffic to this gateway is encrypted through the SSH tunnel.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderTokenDrift" xml:space="preserve">
+    <value>Re-pair this device:</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderScope" xml:space="preserve">
+    <value>Upgrade this device's access:</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderTls" xml:space="preserve">
+    <value>Fix the secure connection:</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTokenDriftBullet1" xml:space="preserve">
+    <value>The gateway no longer trusts this device's saved token (it was rotated or revoked).</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTokenDriftBullet2" xml:space="preserve">
+    <value>Get a fresh setup code from the gateway host and paste it below to re-pair.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryScopeBullet1" xml:space="preserve">
+    <value>This device is authenticated but is missing the scopes it needs (for example operator.admin or operator.pairing).</value>
+  </data>
+  <data name="ConnectionPage_RecoveryScopeBullet2" xml:space="preserve">
+    <value>Re-pair with a fresh setup code to request the required scopes, or approve the higher scopes on the gateway host.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTlsBullet1" xml:space="preserve">
+    <value>The gateway's TLS/secure transport could not be established.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTlsBullet2" xml:space="preserve">
+    <value>Verify the certificate on the gateway host, or connect over wss:// or an SSH tunnel.</value>
+  </data>
+  <data name="ConnectionPage_TokenOrPasswordHint.Text" xml:space="preserve">
+    <value>Paste a shared gateway token, or leave it blank to pair with a setup code.</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpDirect.Text" xml:space="preserve">
+    <value>Connect to wss:// or https:// when the gateway has a trusted certificate. Your token is encrypted in transit after certificate validation.</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpTunnel.Text" xml:space="preserve">
+    <value>When the gateway only listens on localhost, expand "Use SSH tunnel" below. The tray forwards a local port over SSH so traffic stays encrypted.</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpProxy.Text" xml:space="preserve">
+    <value>If a Tailscale or reverse proxy already encrypts the path, a plain ws:// URL over that private network is fine.</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpAuth.Text" xml:space="preserve">
+    <value>Paste a shared token, or leave it blank and pair with a setup code. Re-pairing also upgrades this device's scopes.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderRateLimited" xml:space="preserve">
+    <value>Wait before reconnecting:</value>
+  </data>
+  <data name="ConnectionPage_RecoveryRateLimitedBullet1" xml:space="preserve">
+    <value>The gateway is rate-limiting this client after repeated failed attempts.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryRateLimitedBullet2" xml:space="preserve">
+    <value>Stop retrying for a moment, then reconnect after correcting the token, password, or pairing state.</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpLink.Text" xml:space="preserve">
+    <value>How do I connect to a remote gateway?</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpTip.Title" xml:space="preserve">
+    <value>Connecting to a remote gateway</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpDirectTitle.Text" xml:space="preserve">
+    <value>Direct (TLS)</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpTunnelTitle.Text" xml:space="preserve">
+    <value>SSH tunnel</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpProxyTitle.Text" xml:space="preserve">
+    <value>Trusted proxy / Tailscale</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpAuthTitle.Text" xml:space="preserve">
+    <value>Auth</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -6581,4 +6581,91 @@ Vérifiez vos paramètres de connexion et réessayez.</value>
   <data name="ConnectionPage_NodePendingDeclaredPermissions" xml:space="preserve">
     <value>Pending declared permissions: {0}</value>
   </data>
+  <data name="ConnectionPage_AdviceCleartextTitle" xml:space="preserve">
+    <value>Connexion non chiffrée</value>
+  </data>
+  <data name="ConnectionPage_AdviceCleartextMessage" xml:space="preserve">
+    <value>Cette gateway distante utilise ws:// — votre token serait envoyé en clair. Utilisez wss:// (TLS), un tunnel SSH, ou un proxy de confiance / Tailscale.</value>
+  </data>
+  <data name="ConnectionPage_AdviceSecureTitle" xml:space="preserve">
+    <value>Chiffré (TLS)</value>
+  </data>
+  <data name="ConnectionPage_AdviceSecureMessage" xml:space="preserve">
+    <value>Cette gateway utilise TLS. Votre token est protégé en transit lorsque le certificat est validé.</value>
+  </data>
+  <data name="ConnectionPage_AdviceTunnelTitle" xml:space="preserve">
+    <value>Tunnel SSH</value>
+  </data>
+  <data name="ConnectionPage_AdviceTunnelMessage" xml:space="preserve">
+    <value>Le trafic vers cette gateway est chiffré via le tunnel SSH.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderTokenDrift" xml:space="preserve">
+    <value>Réappairer cet appareil :</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderScope" xml:space="preserve">
+    <value>Mettre à niveau l'accès de cet appareil :</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderTls" xml:space="preserve">
+    <value>Corriger la connexion sécurisée :</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTokenDriftBullet1" xml:space="preserve">
+    <value>La gateway ne fait plus confiance au token enregistré de cet appareil (il a été renouvelé ou révoqué).</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTokenDriftBullet2" xml:space="preserve">
+    <value>Obtenez un nouveau code de configuration depuis l'hôte de la gateway et collez-le ci-dessous pour réappairer.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryScopeBullet1" xml:space="preserve">
+    <value>Cet appareil est authentifié mais il manque les scopes nécessaires (par exemple operator.admin ou operator.pairing).</value>
+  </data>
+  <data name="ConnectionPage_RecoveryScopeBullet2" xml:space="preserve">
+    <value>Réappairez avec un nouveau code de configuration pour demander les scopes requis, ou approuvez les scopes supérieurs sur l'hôte de la gateway.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTlsBullet1" xml:space="preserve">
+    <value>Le transport TLS/sécurisé de la gateway n'a pas pu être établi.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTlsBullet2" xml:space="preserve">
+    <value>Vérifiez le certificat sur l'hôte de la gateway, ou connectez-vous via wss:// ou un tunnel SSH.</value>
+  </data>
+  <data name="ConnectionPage_TokenOrPasswordHint.Text" xml:space="preserve">
+    <value>Collez un token de gateway partagé, ou laissez-le vide pour appairer avec un code de configuration.</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpDirect.Text" xml:space="preserve">
+    <value>Connectez-vous à wss:// ou https:// lorsque la gateway possède un certificat de confiance. Votre token est chiffré en transit après validation du certificat.</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpTunnel.Text" xml:space="preserve">
+    <value>Lorsque la gateway n'écoute que sur localhost, développez « Utiliser un tunnel SSH » ci-dessous. La tray transfère un port local via SSH afin que le trafic reste chiffré.</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpProxy.Text" xml:space="preserve">
+    <value>Si Tailscale ou un reverse proxy chiffre déjà le chemin, une simple URL ws:// sur ce réseau privé convient.</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpAuth.Text" xml:space="preserve">
+    <value>Collez un token partagé, ou laissez-le vide et appairez avec un code de configuration. Le réappairage met aussi à niveau les scopes de cet appareil.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderRateLimited" xml:space="preserve">
+    <value>Attendez avant de vous reconnecter :</value>
+  </data>
+  <data name="ConnectionPage_RecoveryRateLimitedBullet1" xml:space="preserve">
+    <value>La gateway limite temporairement ce client après plusieurs tentatives échouées.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryRateLimitedBullet2" xml:space="preserve">
+    <value>Arrêtez les nouvelles tentatives un moment, puis reconnectez-vous après avoir corrigé le token, le mot de passe ou l’état d’appairage.</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpLink.Text" xml:space="preserve">
+    <value>Comment me connecter à une gateway distante ?</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpTip.Title" xml:space="preserve">
+    <value>Se connecter à une gateway distante</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpDirectTitle.Text" xml:space="preserve">
+    <value>Connexion directe (TLS)</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpTunnelTitle.Text" xml:space="preserve">
+    <value>Tunnel SSH</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpProxyTitle.Text" xml:space="preserve">
+    <value>Proxy de confiance / Tailscale</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpAuthTitle.Text" xml:space="preserve">
+    <value>Authentification</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -6582,4 +6582,91 @@ Controleer uw verbindingsinstellingen en probeer het opnieuw.</value>
   <data name="ConnectionPage_NodePendingDeclaredPermissions" xml:space="preserve">
     <value>Pending declared permissions: {0}</value>
   </data>
+  <data name="ConnectionPage_AdviceCleartextTitle" xml:space="preserve">
+    <value>Niet-versleutelde verbinding</value>
+  </data>
+  <data name="ConnectionPage_AdviceCleartextMessage" xml:space="preserve">
+    <value>Deze externe gateway gebruikt ws:// — uw token zou onversleuteld worden verzonden. Gebruik wss:// (TLS), een SSH-tunnel of een vertrouwde proxy / Tailscale.</value>
+  </data>
+  <data name="ConnectionPage_AdviceSecureTitle" xml:space="preserve">
+    <value>Versleuteld (TLS)</value>
+  </data>
+  <data name="ConnectionPage_AdviceSecureMessage" xml:space="preserve">
+    <value>Deze gateway gebruikt TLS. Uw token is beschermd tijdens het transport wanneer het certificaat wordt gevalideerd.</value>
+  </data>
+  <data name="ConnectionPage_AdviceTunnelTitle" xml:space="preserve">
+    <value>SSH-tunnel</value>
+  </data>
+  <data name="ConnectionPage_AdviceTunnelMessage" xml:space="preserve">
+    <value>Verkeer naar deze gateway wordt versleuteld via de SSH-tunnel.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderTokenDrift" xml:space="preserve">
+    <value>Koppel dit apparaat opnieuw:</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderScope" xml:space="preserve">
+    <value>Werk de toegang van dit apparaat bij:</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderTls" xml:space="preserve">
+    <value>Herstel de beveiligde verbinding:</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTokenDriftBullet1" xml:space="preserve">
+    <value>De gateway vertrouwt het opgeslagen token van dit apparaat niet meer (het is gewijzigd of ingetrokken).</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTokenDriftBullet2" xml:space="preserve">
+    <value>Haal een nieuwe installatiecode op van de gateway-host en plak deze hieronder om opnieuw te koppelen.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryScopeBullet1" xml:space="preserve">
+    <value>Dit apparaat is geverifieerd maar mist de benodigde scopes (bijvoorbeeld operator.admin of operator.pairing).</value>
+  </data>
+  <data name="ConnectionPage_RecoveryScopeBullet2" xml:space="preserve">
+    <value>Koppel opnieuw met een nieuwe installatiecode om de vereiste scopes aan te vragen, of keur de hogere scopes goed op de gateway-host.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTlsBullet1" xml:space="preserve">
+    <value>Het TLS-/beveiligde transport van de gateway kon niet tot stand worden gebracht.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTlsBullet2" xml:space="preserve">
+    <value>Controleer het certificaat op de gateway-host, of maak verbinding via wss:// of een SSH-tunnel.</value>
+  </data>
+  <data name="ConnectionPage_TokenOrPasswordHint.Text" xml:space="preserve">
+    <value>Plak een gedeeld gateway-token, of laat het leeg om te koppelen met een installatiecode.</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpDirect.Text" xml:space="preserve">
+    <value>Maak verbinding met wss:// of https:// wanneer de gateway een vertrouwd certificaat heeft. Uw token wordt tijdens het transport versleuteld na certificaatvalidatie.</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpTunnel.Text" xml:space="preserve">
+    <value>Wanneer de gateway alleen op localhost luistert, vouwt u "SSH-tunnel gebruiken" hieronder uit. De tray stuurt een lokale poort door via SSH zodat het verkeer versleuteld blijft.</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpProxy.Text" xml:space="preserve">
+    <value>Als Tailscale of een reverse proxy het pad al versleutelt, is een gewone ws://-URL over dat privénetwerk prima.</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpAuth.Text" xml:space="preserve">
+    <value>Plak een gedeeld token, of laat het leeg en koppel met een installatiecode. Opnieuw koppelen werkt ook de scopes van dit apparaat bij.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderRateLimited" xml:space="preserve">
+    <value>Wacht voordat u opnieuw verbinding maakt:</value>
+  </data>
+  <data name="ConnectionPage_RecoveryRateLimitedBullet1" xml:space="preserve">
+    <value>De gateway beperkt deze client tijdelijk na herhaalde mislukte pogingen.</value>
+  </data>
+  <data name="ConnectionPage_RecoveryRateLimitedBullet2" xml:space="preserve">
+    <value>Stop even met opnieuw proberen en verbind opnieuw nadat het token, wachtwoord of de koppelingsstatus is gecorrigeerd.</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpLink.Text" xml:space="preserve">
+    <value>Hoe maak ik verbinding met een externe gateway?</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpTip.Title" xml:space="preserve">
+    <value>Verbinding maken met een externe gateway</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpDirectTitle.Text" xml:space="preserve">
+    <value>Directe verbinding (TLS)</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpTunnelTitle.Text" xml:space="preserve">
+    <value>SSH-tunnel</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpProxyTitle.Text" xml:space="preserve">
+    <value>Vertrouwde proxy / Tailscale</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpAuthTitle.Text" xml:space="preserve">
+    <value>Verificatie</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -6582,4 +6582,91 @@
   <data name="ConnectionPage_NodePendingDeclaredPermissions" xml:space="preserve">
     <value>Pending declared permissions: {0}</value>
   </data>
+  <data name="ConnectionPage_AdviceCleartextTitle" xml:space="preserve">
+    <value>未加密的连接</value>
+  </data>
+  <data name="ConnectionPage_AdviceCleartextMessage" xml:space="preserve">
+    <value>此远程 gateway 使用 ws:// — 您的 token 将以明文发送。请使用 wss://（TLS）、SSH 隧道或受信任的代理 / Tailscale。</value>
+  </data>
+  <data name="ConnectionPage_AdviceSecureTitle" xml:space="preserve">
+    <value>已加密 (TLS)</value>
+  </data>
+  <data name="ConnectionPage_AdviceSecureMessage" xml:space="preserve">
+    <value>此 gateway 使用 TLS。证书验证通过后，您的 token 在传输过程中受到保护。</value>
+  </data>
+  <data name="ConnectionPage_AdviceTunnelTitle" xml:space="preserve">
+    <value>SSH 隧道</value>
+  </data>
+  <data name="ConnectionPage_AdviceTunnelMessage" xml:space="preserve">
+    <value>到此 gateway 的流量通过 SSH 隧道加密。</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderTokenDrift" xml:space="preserve">
+    <value>重新配对此设备：</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderScope" xml:space="preserve">
+    <value>升级此设备的访问权限：</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderTls" xml:space="preserve">
+    <value>修复安全连接：</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTokenDriftBullet1" xml:space="preserve">
+    <value>gateway 不再信任此设备保存的 token（它已被轮换或吊销）。</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTokenDriftBullet2" xml:space="preserve">
+    <value>从 gateway 主机获取新的设置代码，并粘贴到下方以重新配对。</value>
+  </data>
+  <data name="ConnectionPage_RecoveryScopeBullet1" xml:space="preserve">
+    <value>此设备已通过身份验证，但缺少所需的 scope（例如 operator.admin 或 operator.pairing）。</value>
+  </data>
+  <data name="ConnectionPage_RecoveryScopeBullet2" xml:space="preserve">
+    <value>使用新的设置代码重新配对以请求所需的 scope，或在 gateway 主机上批准更高的 scope。</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTlsBullet1" xml:space="preserve">
+    <value>无法建立 gateway 的 TLS/安全传输。</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTlsBullet2" xml:space="preserve">
+    <value>验证 gateway 主机上的证书，或通过 wss:// 或 SSH 隧道连接。</value>
+  </data>
+  <data name="ConnectionPage_TokenOrPasswordHint.Text" xml:space="preserve">
+    <value>粘贴共享 gateway token，或将其留空以使用设置代码配对。</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpDirect.Text" xml:space="preserve">
+    <value>当 gateway 拥有受信任证书时，连接到 wss:// 或 https://。证书验证通过后，您的 token 会在传输过程中加密。</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpTunnel.Text" xml:space="preserve">
+    <value>当 gateway 仅在 localhost 上侦听时，请展开下方的“使用 SSH 隧道”。tray 会通过 SSH 转发本地端口，使流量保持加密。</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpProxy.Text" xml:space="preserve">
+    <value>如果 Tailscale 或反向代理已加密路径，则在该专用网络上使用普通 ws:// URL 即可。</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpAuth.Text" xml:space="preserve">
+    <value>粘贴共享 token，或将其留空并使用设置代码配对。重新配对还会升级此设备的 scope。</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderRateLimited" xml:space="preserve">
+    <value>请稍后再重新连接：</value>
+  </data>
+  <data name="ConnectionPage_RecoveryRateLimitedBullet1" xml:space="preserve">
+    <value>gateway 在多次失败尝试后正在对此客户端限速。</value>
+  </data>
+  <data name="ConnectionPage_RecoveryRateLimitedBullet2" xml:space="preserve">
+    <value>暂时停止重试，然后在修正 token、密码或配对状态后重新连接。</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpLink.Text" xml:space="preserve">
+    <value>如何连接到远程 gateway？</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpTip.Title" xml:space="preserve">
+    <value>连接到远程 gateway</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpDirectTitle.Text" xml:space="preserve">
+    <value>直连 (TLS)</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpTunnelTitle.Text" xml:space="preserve">
+    <value>SSH 隧道</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpProxyTitle.Text" xml:space="preserve">
+    <value>受信任代理 / Tailscale</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpAuthTitle.Text" xml:space="preserve">
+    <value>身份验证</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -6582,4 +6582,91 @@
   <data name="ConnectionPage_NodePendingDeclaredPermissions" xml:space="preserve">
     <value>Pending declared permissions: {0}</value>
   </data>
+  <data name="ConnectionPage_AdviceCleartextTitle" xml:space="preserve">
+    <value>未加密的連線</value>
+  </data>
+  <data name="ConnectionPage_AdviceCleartextMessage" xml:space="preserve">
+    <value>此遠端 gateway 使用 ws:// — 您的 token 將以明文傳送。請使用 wss://（TLS）、SSH 通道或受信任的 Proxy / Tailscale。</value>
+  </data>
+  <data name="ConnectionPage_AdviceSecureTitle" xml:space="preserve">
+    <value>已加密 (TLS)</value>
+  </data>
+  <data name="ConnectionPage_AdviceSecureMessage" xml:space="preserve">
+    <value>此 gateway 使用 TLS。憑證驗證通過後，您的 token 在傳輸過程中受到保護。</value>
+  </data>
+  <data name="ConnectionPage_AdviceTunnelTitle" xml:space="preserve">
+    <value>SSH 通道</value>
+  </data>
+  <data name="ConnectionPage_AdviceTunnelMessage" xml:space="preserve">
+    <value>到此 gateway 的流量透過 SSH 通道加密。</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderTokenDrift" xml:space="preserve">
+    <value>重新配對此裝置：</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderScope" xml:space="preserve">
+    <value>升級此裝置的存取權限：</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderTls" xml:space="preserve">
+    <value>修復安全連線：</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTokenDriftBullet1" xml:space="preserve">
+    <value>gateway 不再信任此裝置儲存的 token（它已被輪換或撤銷）。</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTokenDriftBullet2" xml:space="preserve">
+    <value>從 gateway 主機取得新的設定代碼，並貼到下方以重新配對。</value>
+  </data>
+  <data name="ConnectionPage_RecoveryScopeBullet1" xml:space="preserve">
+    <value>此裝置已通過驗證，但缺少所需的 scope（例如 operator.admin 或 operator.pairing）。</value>
+  </data>
+  <data name="ConnectionPage_RecoveryScopeBullet2" xml:space="preserve">
+    <value>使用新的設定代碼重新配對以請求所需的 scope，或在 gateway 主機上核准更高的 scope。</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTlsBullet1" xml:space="preserve">
+    <value>無法建立 gateway 的 TLS/安全傳輸。</value>
+  </data>
+  <data name="ConnectionPage_RecoveryTlsBullet2" xml:space="preserve">
+    <value>驗證 gateway 主機上的憑證，或透過 wss:// 或 SSH 通道連線。</value>
+  </data>
+  <data name="ConnectionPage_TokenOrPasswordHint.Text" xml:space="preserve">
+    <value>貼上共用 gateway token，或將其留空以使用設定代碼配對。</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpDirect.Text" xml:space="preserve">
+    <value>當 gateway 擁有受信任憑證時，連線到 wss:// 或 https://。憑證驗證通過後，您的 token 會在傳輸過程中加密。</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpTunnel.Text" xml:space="preserve">
+    <value>當 gateway 僅在 localhost 上接聽時，請展開下方的「使用 SSH 通道」。tray 會透過 SSH 轉發本機連接埠，使流量保持加密。</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpProxy.Text" xml:space="preserve">
+    <value>如果 Tailscale 或反向 Proxy 已加密路徑，則在該私人網路上使用一般 ws:// URL 即可。</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpAuth.Text" xml:space="preserve">
+    <value>貼上共用 token，或將其留空並使用設定代碼配對。重新配對也會升級此裝置的 scope。</value>
+  </data>
+  <data name="ConnectionPage_RecoveryHeaderRateLimited" xml:space="preserve">
+    <value>請稍後再重新連線：</value>
+  </data>
+  <data name="ConnectionPage_RecoveryRateLimitedBullet1" xml:space="preserve">
+    <value>gateway 在多次失敗嘗試後正在對此用戶端限速。</value>
+  </data>
+  <data name="ConnectionPage_RecoveryRateLimitedBullet2" xml:space="preserve">
+    <value>暫時停止重試，然後在修正 token、密碼或配對狀態後重新連線。</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpLink.Text" xml:space="preserve">
+    <value>如何連線到遠端 gateway？</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpTip.Title" xml:space="preserve">
+    <value>連線到遠端 gateway</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpDirectTitle.Text" xml:space="preserve">
+    <value>直連 (TLS)</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpTunnelTitle.Text" xml:space="preserve">
+    <value>SSH 通道</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpProxyTitle.Text" xml:space="preserve">
+    <value>受信任 Proxy / Tailscale</value>
+  </data>
+  <data name="ConnectionPage_RemoteSetupHelpAuthTitle.Text" xml:space="preserve">
+    <value>驗證</value>
+  </data>
 </root>

--- a/tests/OpenClaw.Connection.Tests/OperatorScopeHelperTests.cs
+++ b/tests/OpenClaw.Connection.Tests/OperatorScopeHelperTests.cs
@@ -173,7 +173,7 @@ public class ChatNavigationReadinessTests
         public Task ReconnectAsync() => Task.CompletedTask;
         public Task SwitchGatewayAsync(string gatewayId) => Task.CompletedTask;
         public Task EnsureNodeConnectedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
-        public Task<SetupCodeResult> ApplySetupCodeAsync(string setupCode) => Task.FromResult(new SetupCodeResult(SetupCodeOutcome.InvalidCode));
+        public Task<SetupCodeResult> ApplySetupCodeAsync(string setupCode, SshTunnelConfig? sshTunnel = null) => Task.FromResult(new SetupCodeResult(SetupCodeOutcome.InvalidCode));
         public Task<SetupCodeResult> ConnectWithSharedTokenAsync(string gatewayUrl, string token, SshTunnelConfig? sshTunnel = null) => Task.FromResult(new SetupCodeResult(SetupCodeOutcome.InvalidCode));
         public void Dispose() { }
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/tests/OpenClaw.Connection.Tests/SetupCodeFlowTests.cs
+++ b/tests/OpenClaw.Connection.Tests/SetupCodeFlowTests.cs
@@ -103,6 +103,34 @@ public class SetupCodeFlowTests : IDisposable
     }
 
     [Fact]
+    public async Task ApplySetupCode_WithSshTunnel_PersistsTunnelConfig()
+    {
+        var json = """{"url":"ws://gateway.example.com:18789","bootstrapToken":"boot-tok-ssh"}""";
+        var code = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(json));
+        var sshTunnel = new SshTunnelConfig(
+            "operator",
+            "ssh.example.com",
+            RemotePort: 18789,
+            LocalPort: 18791,
+            IncludeBrowserProxyForward: true,
+            SshPort: 2222);
+
+        var resolver = new CredentialResolver(new FakeIdentityReader());
+        var factory = new RecordingClientFactory();
+        var manager = new GatewayConnectionManager(
+            resolver, factory, _registry, NullLogger.Instance);
+
+        var result = await manager.ApplySetupCodeAsync(code, sshTunnel);
+
+        Assert.Equal(SetupCodeOutcome.Success, result.Outcome);
+        var active = _registry.GetActive();
+        Assert.NotNull(active);
+        Assert.Equal(sshTunnel, active.SshTunnel);
+
+        manager.Dispose();
+    }
+
+    [Fact]
     public async Task ApplySetupCode_WithExistingCredential_ForcesBootstrapForImmediatePairing()
     {
         // First, apply a setup code to create the gateway record

--- a/tests/OpenClaw.Shared.Tests/GatewayErrorClassifierTests.cs
+++ b/tests/OpenClaw.Shared.Tests/GatewayErrorClassifierTests.cs
@@ -1,0 +1,159 @@
+using OpenClaw.Shared;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+public class GatewayErrorClassifierTests
+{
+    [Theory]
+    [InlineData(null, GatewayErrorKind.Unknown)]
+    [InlineData("", GatewayErrorKind.Unknown)]
+    [InlineData("   ", GatewayErrorKind.Unknown)]
+    public void Classify_Empty_IsUnknown(string? error, GatewayErrorKind expected)
+    {
+        Assert.Equal(expected, GatewayErrorClassifier.Classify(error));
+    }
+
+    [Theory]
+    [InlineData("Insufficient scope: operator.admin required")]
+    [InlineData("Forbidden — missing scope operator.pairing")]
+    [InlineData("permission denied for this operation")]
+    [InlineData("client is not permitted to approve devices")]
+    public void Classify_ScopeProblems_AreScopeMismatch(string error)
+    {
+        Assert.Equal(GatewayErrorKind.ScopeMismatch, GatewayErrorClassifier.Classify(error));
+    }
+
+    [Theory]
+    [InlineData("Device token no longer recognized by gateway")]
+    [InlineData("device token invalid — please re-pair")]
+    [InlineData("token rotated on the server")]
+    [InlineData("token revoked")]
+    [InlineData("device token unknown")]
+    public void Classify_TokenDrift_IsTokenDrift(string error)
+    {
+        Assert.Equal(GatewayErrorKind.TokenDrift, GatewayErrorClassifier.Classify(error));
+    }
+
+    [Theory]
+    [InlineData("Pairing approval pending on the gateway host")]
+    [InlineData("device pairing required")]
+    public void Classify_PairingPending_IsPairingRequired(string error)
+    {
+        Assert.Equal(GatewayErrorKind.PairingRequired, GatewayErrorClassifier.Classify(error));
+    }
+
+    [Theory]
+    [InlineData("Pairing request was rejected")]
+    [InlineData("approval denied by operator")]
+    public void Classify_PairingRejected_IsPairingRejected(string error)
+    {
+        Assert.Equal(GatewayErrorKind.PairingRejected, GatewayErrorClassifier.Classify(error));
+    }
+
+    [Theory]
+    [InlineData("TLS handshake failed")]
+    [InlineData("certificate validation error")]
+    [InlineData("server requires a secure (non-cleartext) connection")]
+    public void Classify_Tls_IsTls(string error)
+    {
+        Assert.Equal(GatewayErrorKind.Tls, GatewayErrorClassifier.Classify(error));
+    }
+
+    [Theory]
+    [InlineData("ssh tunnel exited unexpectedly")]
+    [InlineData("tunnel could not bind local port")]
+    public void Classify_Tunnel_IsTunnel(string error)
+    {
+        Assert.Equal(GatewayErrorKind.Tunnel, GatewayErrorClassifier.Classify(error));
+    }
+
+    [Theory]
+    [InlineData("401 Unauthorized")]
+    [InlineData("invalid credential supplied")]
+    [InlineData("authentication failed")]
+    public void Classify_GenericAuth_IsAuth(string error)
+    {
+        Assert.Equal(GatewayErrorKind.Auth, GatewayErrorClassifier.Classify(error));
+    }
+
+    [Theory]
+    [InlineData("500 internal error")]
+    [InlineData("gateway returned a server error")]
+    public void Classify_Server_IsServer(string error)
+    {
+        Assert.Equal(GatewayErrorKind.Server, GatewayErrorClassifier.Classify(error));
+    }
+
+    [Theory]
+    [InlineData("connection refused")]
+    [InlineData("host unreachable")]
+    [InlineData("connect timed out")]
+    public void Classify_Network_IsNetwork(string error)
+    {
+        Assert.Equal(GatewayErrorKind.Network, GatewayErrorClassifier.Classify(error));
+    }
+
+    [Theory]
+    [InlineData("rate limit exceeded")]
+    [InlineData("429 Too Many Requests")]
+    [InlineData("too many requests, slow down")]
+    public void Classify_RateLimited_IsRateLimited(string error)
+    {
+        Assert.Equal(GatewayErrorKind.RateLimited, GatewayErrorClassifier.Classify(error));
+    }
+
+    [Fact]
+    public void Classify_SshPermissionDenied_IsTunnel_NotScope()
+    {
+        // SSH failures read "Permission denied (publickey)" — must not be
+        // mistaken for a scope problem (tunnel detection runs first).
+        Assert.Equal(
+            GatewayErrorKind.Tunnel,
+            GatewayErrorClassifier.Classify("SSH tunnel failed: Permission denied (publickey)"));
+    }
+
+    [Fact]
+    public void Classify_ServerErrorMentioningToken_IsServer_NotAuth()
+    {
+        // A transient 5xx that merely mentions a token must not route to the
+        // re-pair (Auth) path.
+        Assert.Equal(
+            GatewayErrorKind.Server,
+            GatewayErrorClassifier.Classify("500 internal error: token validation failed"));
+    }
+
+    [Fact]
+    public void Classify_CertificateNotApproved_IsTls_NotPairing()
+    {
+        Assert.Equal(
+            GatewayErrorKind.Tls,
+            GatewayErrorClassifier.Classify("certificate not approved by CA"));
+    }
+
+    [Fact]
+    public void Classify_RepairWord_DoesNotMatchPairing()
+    {
+        // "repair" contains "pair" — must not be classified as pairing.
+        Assert.NotEqual(
+            GatewayErrorKind.PairingRequired,
+            GatewayErrorClassifier.Classify("could not repair connection to gateway"));
+    }
+
+    [Fact]
+    public void Classify_ScopeWins_OverGenericAuthKeywords()
+    {
+        // Contains both "unauthorized" and "scope" — scope is the actionable kind.
+        Assert.Equal(
+            GatewayErrorKind.ScopeMismatch,
+            GatewayErrorClassifier.Classify("Unauthorized: insufficient scope operator.write"));
+    }
+
+    [Fact]
+    public void Classify_TokenDriftWins_OverGenericAuthKeywords()
+    {
+        Assert.Equal(
+            GatewayErrorKind.TokenDrift,
+            GatewayErrorClassifier.Classify("auth failed: device token no longer valid, re-pair required"));
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/RemoteGatewayClassifierTests.cs
+++ b/tests/OpenClaw.Shared.Tests/RemoteGatewayClassifierTests.cs
@@ -1,0 +1,89 @@
+using OpenClaw.Shared;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+public class RemoteGatewayClassifierTests
+{
+    [Theory]
+    [InlineData("ws://localhost:18789")]
+    [InlineData("wss://127.0.0.1:18789")]
+    [InlineData("http://[::1]:18789")]
+    public void Classify_LoopbackHosts_AreLocalLoopback(string url)
+    {
+        var profile = RemoteGatewayClassifier.Classify(url);
+
+        Assert.Equal(GatewayConnectionTopology.Local, profile.Topology);
+        Assert.Equal(GatewayTransportSecurity.LocalLoopback, profile.Security);
+        Assert.True(profile.IsLocal);
+        Assert.False(profile.IsRemote);
+        Assert.False(profile.RecommendsTransportHardening);
+    }
+
+    [Theory]
+    [InlineData("wss://gateway.example.com:18789")]
+    [InlineData("https://gateway.example.com")]
+    public void Classify_RemoteTls_IsDirectSecure(string url)
+    {
+        var profile = RemoteGatewayClassifier.Classify(url);
+
+        Assert.Equal(GatewayConnectionTopology.DirectSecure, profile.Topology);
+        Assert.Equal(GatewayTransportSecurity.Encrypted, profile.Security);
+        Assert.True(profile.IsRemote);
+        Assert.True(profile.IsTls);
+        Assert.False(profile.RecommendsTransportHardening);
+    }
+
+    [Theory]
+    [InlineData("ws://gateway.example.com:18789")]
+    [InlineData("http://10.0.0.5:18789")]
+    [InlineData("ws://machine-name:18789")]
+    public void Classify_RemoteCleartext_IsDirectInsecure_AndWarns(string url)
+    {
+        var profile = RemoteGatewayClassifier.Classify(url);
+
+        Assert.Equal(GatewayConnectionTopology.DirectInsecure, profile.Topology);
+        Assert.Equal(GatewayTransportSecurity.Cleartext, profile.Security);
+        Assert.True(profile.IsRemote);
+        Assert.False(profile.IsTls);
+        Assert.True(profile.RecommendsTransportHardening);
+    }
+
+    [Fact]
+    public void Classify_WithSshTunnel_IsEncryptedTunnel_EvenForLoopbackUrl()
+    {
+        // The WebSocket talks to localhost but the bytes are SSH-encrypted to a
+        // remote host — treat as remote-but-encrypted, never warn.
+        var profile = RemoteGatewayClassifier.Classify("ws://localhost:18789", hasSshTunnel: true);
+
+        Assert.Equal(GatewayConnectionTopology.SshTunnel, profile.Topology);
+        Assert.Equal(GatewayTransportSecurity.Encrypted, profile.Security);
+        Assert.True(profile.IsRemote);
+        Assert.False(profile.IsLocal);
+        Assert.False(profile.RecommendsTransportHardening);
+    }
+
+    [Fact]
+    public void Classify_SshTunnel_TakesPrecedenceOverCleartextRemoteUrl()
+    {
+        var profile = RemoteGatewayClassifier.Classify("ws://gateway.example.com:18789", hasSshTunnel: true);
+
+        Assert.Equal(GatewayConnectionTopology.SshTunnel, profile.Topology);
+        Assert.False(profile.RecommendsTransportHardening);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    [InlineData("not a url")]
+    [InlineData("ws://")]
+    public void Classify_UnparseableInput_IsUnknown_AndDoesNotWarn(string? url)
+    {
+        var profile = RemoteGatewayClassifier.Classify(url);
+
+        Assert.Equal(GatewayConnectionTopology.Unknown, profile.Topology);
+        Assert.False(profile.RecommendsTransportHardening);
+        Assert.False(profile.IsRemote);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/ConnectionRegressionSourceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ConnectionRegressionSourceTests.cs
@@ -55,6 +55,18 @@ public sealed class ConnectionRegressionSourceTests
         Assert.Contains("Node list refresh failed after local node trust request", managerSource);
     }
 
+    [Fact]
+    public void SetupCodeEntry_ClearsStaleSshTunnelFields()
+    {
+        var pageSource = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", "ConnectionPage.xaml.cs");
+
+        Assert.Contains("private void ClearAddGatewaySshFields()", pageSource);
+        Assert.Contains("ClearAddGatewaySshFields();\r\n        ShowAddPane(\"setup\");", pageSource);
+        Assert.Contains("AddSshExpander.IsExpanded = false;", pageSource);
+        Assert.Contains("AddSshUserBox.Text = \"\";", pageSource);
+        Assert.Contains("AddSshHostBox.Text = \"\";", pageSource);
+    }
+
     private static string ReadSource(params string[] relativePathParts)
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();


### PR DESCRIPTION
## Summary

- Problem: Remote gateway setup in Connection settings did not explain cleartext token risk, SSH tunnel/trusted-proxy options, or which recovery path applies when auth/transport fails. The earlier "Remote gateway setup help" used the same Expander chrome as the functional "Use SSH tunnel" input section, so guidance read like another form field.
- Why it matters: Remote users need actionable setup and repair guidance before sending credentials over the network or retrying with stale/insufficient credentials — and help content should be visually distinct from inputs.
- What changed: Added shared URL/error classifiers; ConnectionPage setup guidance; a cleartext/TLS/SSH transport-security InfoBar that reliably refreshes when the URL changes; recovery copy for token drift, scope mismatch, TLS, tunnel, pairing/auth, and rate-limited states; setup-code SSH persistence. The setup help is now a lightweight info link that opens a TeachingTip (guidance popup) instead of an Expander, so it is clearly distinct from the SSH tunnel input section.
- What did NOT change (scope boundary): No new gateway protocol, node capability, credential precedence, TLS fingerprint pinning, persisted password storage, or MCP server behavior.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs / instructions
- [x] Tests / validation
- [x] Security hardening
- [ ] Chore / infra

## Scope (select all touched areas)

- [x] Tray / WinUI UX
- [ ] Windows node capability
- [ ] Local MCP / `winnode`
- [x] Gateway / connection / pairing
- [x] Setup / onboarding
- [x] Permissions / privacy / security
- [x] Tests / CI / docs

## Linked Issue/PR

- Closes #
- Related #
- [ ] Related to a bug or regression

## Validation

- `./build.ps1`
  - Passed: all projects built successfully (`Shared`, `Cli`, `WinNodeCli`, `SetupEngine`, `WinUI`).
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj`
  - Passed: 1215 passed / 0 skipped / 1215 total.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj`
  - Passed: 2566 passed / 31 skipped / 2597 total (one integration test flaked on first run, passed on rerun).
- `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj`
  - Passed: 374 passed / 0 skipped / 374 total (includes the new setup-code SSH-persistence test).
- Focused proof tests:
  - `... OpenClaw.Shared.Tests --filter "FullyQualifiedName~Classifier"` → 78 passed / 0 skipped.
  - `... OpenClaw.Connection.Tests --filter "FullyQualifiedName~SetupCodeFlowTests"` → 15 passed / 0 skipped.

## Real behavior proof

- Environment tested: Windows ARM64 isolated tray profile from worktree `bkudiess-stunning-funicular`, branch `bkudiess-remote-gateway-parity` (Connection → Add gateway → Direct).
- Exact steps run:
  - Launched the rebuilt isolated tray app, opened Connection → Add gateway → Direct.
  - Clicked the "How do I connect to a remote gateway?" link to open the TeachingTip.
  - Typed `ws://gateway.example.com:18789` (cleartext warning), then `wss://gateway.example.com:18789` (TLS green) to confirm the InfoBar updates when severity changes.
  - Ran the focused classifier and setup-code tests below.

**Evidence after fix — captured live from the running tray app:**

1. Setup help is now a link (ⓘ "How do I connect to a remote gateway?"), visually distinct from the "Use SSH tunnel (optional)" input expander below it.

<img width="1000" height="650" alt="01-help-link-vs-ssh-expander" src="https://github.com/user-attachments/assets/b2e728d5-cc7e-4c7b-840b-4a223d707fdd" />

2. The help link opens a TeachingTip — a read-only guidance popup (Direct/TLS, SSH tunnel, trusted proxy/Tailscale, auth) — not an input form.

<img width="1000" height="650" alt="02-remote-help-teachingtip" src="https://github.com/user-attachments/assets/f30ea2a6-cf04-4a2c-b089-ea63852bb6d1" />


3. A remote `ws://` URL shows the yellow "Unencrypted connection" InfoBar (token would be sent in cleartext).

<img width="1858" height="1195" alt="03-direct-cleartext-warning" src="https://github.com/user-attachments/assets/5f7223ba-6704-4ccf-b2bd-cad0c915f127" />

4. Switching to `wss://` flips the InfoBar to green "Encrypted (TLS)" — confirming the refresh fix.

<img width="1858" height="1195" alt="04-direct-tls-encrypted" src="https://github.com/user-attachments/assets/b743158a-37c1-4949-8453-7b4950c72e26" />


**Test evidence:**
- Classifier proof: `Passed! - Failed: 0, Passed: 78, Skipped: 0, Total: 78`.
- Setup-code proof: `Passed! - Failed: 0, Passed: 15, Skipped: 0, Total: 15`.

- MCP server logs: Not applicable — this PR does not modify the local MCP server, MCP transport, node capabilities, `winnode`, or MCP tool schemas. No MCP-server log is produced by this UI-only path.
- Not verified / blocked: No live gateway. Recovery-state copy (token drift / scope / rate-limit) is covered by unit/focused tests because reproducing those real gateway states requires a configured gateway fixture.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Setup guidance warns before a remote cleartext `ws://` would send a token unencrypted.
  - Setup-code SSH tunnel config is persisted when supplied, so the saved connection matches the encrypted-transport advice shown to the user.
  - Token drift/scope/auth recovery copy routes users to re-pair or replace credentials instead of repeated retries.
  - TLS copy says protection applies when the certificate validates; this does not add TLS fingerprint pinning.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only conversations that still need reviewer or maintainer judgment.