### PR TITLE
Gate MXC E2E on GitHub Actions

### DIFF
--- a/docs/WINDOWS_NODE_TESTING.md
+++ b/docs/WINDOWS_NODE_TESTING.md
@@ -132,6 +132,7 @@ When the node connects, it advertises these capabilities:
 ### Full Gateway `system.run` MXC runtime proof
 - The focused E2E below provisions a fresh WSL Gateway, starts an isolated tray instance, sets a local exec approval rule through MCP, invokes `system.run` through the real Gateway `node.invoke` path, and verifies tray MXC diagnostics show contained `mxc-direct-appc` execution for both allowed execution and denied writes to the tray data directory.
 - Run it when validating the Gateway/Windows node runtime path, not just direct MCP or shared library behavior.
+- GitHub-hosted Actions runners do not provide a working MXC/AppContainer runtime. The regular cloud E2E matrix should report these MXC proofs as skipped while still running the rest of setup-connect. Run the proof on a local MXC-enabled Windows machine. Only set `OPENCLAW_RUN_MXC_E2E=1` in GitHub Actions when using an MXC-enabled self-hosted runner.
 - When reproducing this manually against an existing Gateway, make sure `gateway.nodes.allowCommands` includes `system.run`, `system.run.prepare`, and `system.which`, then approve any `pending-reapproval` request with `openclaw nodes approve <pendingRequestId>`. The node can advertise `system.run` while the Gateway still blocks it until both gates are updated.
 
   ```powershell

--- a/tests/OpenClaw.E2ETests/E2EFactAttribute.cs
+++ b/tests/OpenClaw.E2ETests/E2EFactAttribute.cs
@@ -31,6 +31,8 @@ public sealed class MxcE2EFactAttribute : FactAttribute
 
 internal static class MxcE2ETestGate
 {
+    private const string GitHubActionsEnvVar = "GITHUB_ACTIONS";
+    private const string ExplicitGitHubActionsOptInEnvVar = "OPENCLAW_RUN_MXC_E2E";
     private static readonly Lazy<string?> s_skipReason = new(GetSkipReason);
 
     public static string? SkipReason => s_skipReason.Value;
@@ -39,6 +41,12 @@ internal static class MxcE2ETestGate
     {
         if (!E2ETestGate.IsEnabled)
             return $"E2E tests disabled. Set {E2ETestGate.EnvVar}=1 to enable.";
+
+        if (IsEnabled(GitHubActionsEnvVar) && !IsEnabled(ExplicitGitHubActionsOptInEnvVar))
+        {
+            return "MXC E2E test skipped in GitHub Actions because hosted runners do not provide a working MXC/AppContainer runtime. " +
+                $"Run on a local MXC-enabled Windows machine, or set {ExplicitGitHubActionsOptInEnvVar}=1 only on an MXC-enabled self-hosted runner.";
+        }
 
         try
         {
@@ -166,6 +174,11 @@ internal static class MxcE2ETestGate
         try { return !string.IsNullOrWhiteSpace(path) && File.Exists(path); }
         catch { return false; }
     }
+
+    private static bool IsEnabled(string envVar) =>
+        Environment.GetEnvironmentVariable(envVar) is { } value &&
+        (string.Equals(value, "1", StringComparison.OrdinalIgnoreCase) ||
+         string.Equals(value, "true", StringComparison.OrdinalIgnoreCase));
 
     private static string GetSdkArchString() => System.Runtime.InteropServices.RuntimeInformation.OSArchitecture switch
     {


### PR DESCRIPTION
## Summary
- Skip MXC-only E2E proofs in GitHub Actions unless `OPENCLAW_RUN_MXC_E2E=1` is explicitly set
- Preserve local MXC-enabled Windows validation via the existing `OPENCLAW_RUN_E2E=1` gate and runtime availability probe
- Document hosted Actions skip behavior and self-hosted opt-in guidance

## Validation
- `dotnet build .\tests\OpenClaw.E2ETests\OpenClaw.E2ETests.csproj -r win-x64`
- `dotnet test .\tests\OpenClaw.E2ETests\OpenClaw.E2ETests.csproj --no-build --no-restore --filter "FullyQualifiedName~MxcSetupAndConnectTests" --logger "trx;LogFileName=mxc-skip.trx" --results-directory <temp> -r win-x64` with `OPENCLAW_RUN_E2E=1`, `GITHUB_ACTIONS=true`, and no `OPENCLAW_RUN_MXC_E2E` confirmed both MXC tests report skipped / TRX `NotExecuted`
- `.\build.ps1`
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore`

## Review
- `python .agents\skills\autoreview\scripts\autoreview --mode local --engine copilot --model gpt-5.5` returned clean
- Default Codex helper could not start because the installed Codex CLI rejected `--ignore-user-config`; Claude helper could not start because installed Claude Code was below the helper's `--safe-mode` minimum