### PR TITLE
Dedupe connection error bars into a single thin top banner

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -200,7 +200,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private ToastService? _toastService;
     private AppNotificationService? _appNotificationService;
     internal AppNotificationService? AppNotifications => _appNotificationService;
-    private string? _lastAuthFailureNotificationMessage;
     private string? _lastConnectionIssueNotificationKey;
     private readonly Dictionary<string, string> _reportedChannelIssueSignatures = new(StringComparer.OrdinalIgnoreCase);
     private string? _lastSandboxRiskNotificationKey;
@@ -2332,6 +2331,37 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             id: BuildPairingRejectedNotificationId(deviceId));
     }
 
+    /// <summary>
+    /// Publishes an immediate connection-error banner using the single
+    /// connection-issue notification identity. Used for transient, page-driven
+    /// failures (e.g. a manual gateway switch that throws) where the snapshot
+    /// may be briefly silent. Because it reuses the connection-issue id/dedupe
+    /// key it occupies the same banner slot — it cannot produce a second bar —
+    /// and the snapshot-driven path will replace or dismiss it on the next tick.
+    /// </summary>
+    internal void ShowTransientConnectionError(string message)
+    {
+        var body = string.IsNullOrWhiteSpace(message)
+            ? LocalizationHelper.GetString("AppNotification_GatewayConnectionFailed_DefaultMessage")
+            : message;
+
+        // Keep the snapshot-driven publisher from immediately re-emitting a
+        // duplicate for the same underlying error.
+        _lastConnectionIssueNotificationKey = $"operator-error:{message}";
+
+        AppNotificationPublisher.Show(
+            _appNotificationService,
+            LocalizationHelper.GetString("AppNotification_GatewayConnectionFailed_Title"),
+            body,
+            "connection",
+            "lifecycle",
+            AppNotificationSeverity.Error,
+            ConnectionIssueNotificationDedupeKey,
+            "connection",
+            LocalizationHelper.GetString("AppNotification_ActionOpenConnection"),
+            id: ConnectionIssueNotificationId);
+    }
+
     private void UpdateConnectionIssueNotification(GatewayConnectionSnapshot snapshot)
     {
         if (!TryBuildConnectionIssueNotification(snapshot, out var title, out var message, out var severity, out var category, out var key))
@@ -2375,9 +2405,12 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         if (snapshot.OverallState == OverallConnectionState.Error)
         {
             title = LocalizationHelper.GetString("AppNotification_GatewayConnectionFailed_Title");
-            message = snapshot.OperatorError ?? LocalizationHelper.GetString("AppNotification_GatewayConnectionFailed_DefaultMessage");
+            var rawError = snapshot.OperatorError;
+            message = string.IsNullOrWhiteSpace(rawError)
+                ? LocalizationHelper.GetString("AppNotification_GatewayConnectionFailed_DefaultMessage")
+                : rawError;
             severity = AppNotificationSeverity.Error;
-            key = $"operator-error:{message}";
+            key = $"operator-error:{rawError ?? "default"}";
             return true;
         }
 
@@ -2663,8 +2696,6 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         if (status == ConnectionStatus.Connected && _appState != null)
         {
             _appState.AuthFailureMessage = null;
-            _lastAuthFailureNotificationMessage = null;
-            _appNotificationService?.Dismiss("connection:authentication-failed");
         }
 
         UpdateTrayIcon();
@@ -2714,27 +2745,18 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     {
         UpdateTrayIcon();
 
-        // Store auth failure in AppState — HubWindow observes it via PropertyChanged
+        // Store auth failure in AppState — observed for tray tooltip / status.
         if (_appState != null)
         {
             _appState.AuthFailureMessage = message;
         }
 
-        if (!string.Equals(_lastAuthFailureNotificationMessage, message, StringComparison.Ordinal))
-        {
-            _lastAuthFailureNotificationMessage = message;
-            AppNotificationPublisher.Show(
-                _appNotificationService,
-                LocalizationHelper.GetString("AppNotification_GatewayAuthenticationFailed_Title"),
-                message,
-                "connection",
-                "authentication",
-                AppNotificationSeverity.Error,
-                "connection:authentication-failed",
-                "connection",
-                LocalizationHelper.GetString("AppNotification_ActionOpenConnection"),
-                id: "connection:authentication-failed");
-        }
+        // The user-facing banner is published by the single connection-issue
+        // notification (UpdateConnectionIssueNotification), driven off the
+        // snapshot's Error state + OperatorError (same string surfaced here).
+        // Publishing a second "authentication failed" banner here produced a
+        // duplicate top bar and forced the action button to degrade to
+        // "Show more", so it is intentionally not raised from this handler.
     }
 
     private void OnGatewaySessionCommandCompleted(object? sender, SessionCommandResult result)

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
@@ -59,12 +59,6 @@
                  PINNED MODIFIERS — render across every mode
                  ═════════════════════════════════════════════════════════ -->
 
-            <!-- Auth error (legacy, kept) -->
-            <InfoBar x:Name="AuthErrorBar"
-                     x:Uid="AuthErrorBar"
-                     Title="Connection Error"
-                     Severity="Error" IsOpen="False" IsClosable="True"/>
-
             <!-- Pending approvals (others waiting on the user's decision) -->
             <Border x:Name="PendingApprovalsBanner"
                     Visibility="Collapsed"

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -299,18 +299,6 @@ public sealed partial class ConnectionPage : Page
         // background highlight reflects the live snapshot. Cheap — list is
         // typically < 10 entries and only re-runs on real state transitions.
         LoadSavedGateways();
-
-        // Bridge auth error (lives outside the plan as a transient modifier)
-        var authError = CurrentApp.AppState?.AuthFailureMessage;
-        if (!string.IsNullOrEmpty(authError))
-        {
-            AuthErrorBar.Message = GetAuthErrorGuidance(authError!);
-            AuthErrorBar.IsOpen = true;
-        }
-        else
-        {
-            AuthErrorBar.IsOpen = false;
-        }
     }
 
     private void ApplyPlan(ConnectionPagePlan plan)
@@ -2001,10 +1989,23 @@ public sealed partial class ConnectionPage : Page
             return;
         }
 
-        AuthErrorBar.Title = title;
-        AuthErrorBar.Message = message;
-        AuthErrorBar.Severity = InfoBarSeverity.Error;
-        AuthErrorBar.IsOpen = true;
+        // No inline WSL-controls surface is available here (e.g. launching a
+        // terminal for a non-active saved gateway, where that card isn't shown).
+        // The in-page Connection Error bar was removed, so surface the failure as
+        // a transient top-bar notification rather than dropping it silently. This
+        // is a one-off action failure, not the persistent connection-issue banner,
+        // so it carries no "Open Connection" action.
+        AppNotificationPublisher.Show(
+            CurrentApp.AppNotifications,
+            title,
+            message,
+            "connection",
+            "gateway-host",
+            AppNotificationSeverity.Error,
+            $"gateway-host-action:{title}",
+            actionRoute: string.Empty,
+            actionLabel: string.Empty,
+            id: $"gateway-host-action:{title}");
     }
 
     private static string UppercaseFirst(string value)
@@ -2177,18 +2178,16 @@ public sealed partial class ConnectionPage : Page
         catch (Exception ex)
         {
             // Strip status will read the snapshot's terminal state next tick;
-            // surface the immediate error in the auth-error bar so the user
-            // gets feedback even if the snapshot is briefly silent.
+            // surface the immediate error in the single top connection banner so
+            // the user gets feedback (and an "Open Connection" action) even if
+            // the snapshot is briefly silent.
             try
             {
-                AuthErrorBar.Title = LocalizationHelper.GetString("ConnectionPage_ConnectFailed");
-                AuthErrorBar.Message = ex.Message;
-                AuthErrorBar.Severity = Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error;
-                AuthErrorBar.IsOpen = true;
+                CurrentApp.ShowTransientConnectionError(ex.Message);
             }
             catch (Exception uiEx)
             {
-                Logger.Warn($"ConnectionPage: Failed to surface connect failure in auth error bar: {uiEx.Message}");
+                Logger.Warn($"ConnectionPage: Failed to surface connect failure in connection banner: {uiEx.Message}");
             }
         }
         finally
@@ -3538,21 +3537,6 @@ public sealed partial class ConnectionPage : Page
         }
         card.Child = grid;
         return card;
-    }
-
-    // ─── Auth error guidance (preserved) ─────────────────────────────
-
-    private static string GetAuthErrorGuidance(string error)
-    {
-        if (error.Contains("token", StringComparison.OrdinalIgnoreCase))
-            return string.Format(LocalizationHelper.GetString("ConnectionPage_AuthGuidanceToken"), error);
-        if (error.Contains("pairing", StringComparison.OrdinalIgnoreCase))
-            return string.Format(LocalizationHelper.GetString("ConnectionPage_AuthGuidancePairing"), error);
-        if (error.Contains("password", StringComparison.OrdinalIgnoreCase))
-            return string.Format(LocalizationHelper.GetString("ConnectionPage_AuthGuidancePassword"), error);
-        if (error.Contains("signature", StringComparison.OrdinalIgnoreCase))
-            return string.Format(LocalizationHelper.GetString("ConnectionPage_AuthGuidanceSignature"), error);
-        return string.Format(LocalizationHelper.GetString("ConnectionPage_AuthGuidanceDefault"), error);
     }
 
     private static string SanitizeUrl(string url)

--- a/src/OpenClaw.Tray.WinUI/Services/AppNotificationService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AppNotificationService.cs
@@ -70,21 +70,47 @@ internal static class AppNotificationActionRoutes
 
 internal sealed class AppNotificationBannerState
 {
+    private const string ConnectionSource = "connection";
     private readonly HashSet<string> _hiddenNotificationIds = new(StringComparer.Ordinal);
 
     public AppNotification? SelectVisibleNotification(AppNotificationSnapshot snapshot, bool revealHiddenIfNeeded = false)
     {
         PruneRemovedNotifications(snapshot);
-        var visible = snapshot.ActiveNotifications.FirstOrDefault(notification =>
-            !_hiddenNotificationIds.Contains(notification.Id));
+
+        var visibleCandidates = snapshot.ActiveNotifications
+            .Where(notification => !_hiddenNotificationIds.Contains(notification.Id))
+            .ToList();
+
+        // Connection issues are the most actionable banner (they route the user
+        // to the Connection page), so surface them ahead of any earlier,
+        // unrelated notification that happens to be current. Without this, a
+        // connection failure arriving while another notification is showing
+        // would be queued behind it and the user couldn't reach Connection.
+        // Among connection-source notifications, prefer one that actually has an
+        // action: an action-less connection notification (e.g. a transient
+        // gateway-host failure) must not mask a real connection error and
+        // degrade the banner to "Show more".
+        var visible = visibleCandidates.FirstOrDefault(IsActionableConnectionPriority)
+            ?? visibleCandidates.FirstOrDefault(IsConnectionPriority)
+            ?? visibleCandidates.FirstOrDefault();
         if (visible is not null || !revealHiddenIfNeeded)
             return visible;
 
-        var fallback = snapshot.ActiveNotifications.FirstOrDefault();
+        var fallback = snapshot.ActiveNotifications.FirstOrDefault(IsActionableConnectionPriority)
+            ?? snapshot.ActiveNotifications.FirstOrDefault(IsConnectionPriority)
+            ?? snapshot.ActiveNotifications.FirstOrDefault();
         if (fallback is not null)
             _hiddenNotificationIds.Remove(fallback.Id);
         return fallback;
     }
+
+    private static bool IsConnectionPriority(AppNotification notification) =>
+        string.Equals(notification.Source, ConnectionSource, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsActionableConnectionPriority(AppNotification notification) =>
+        IsConnectionPriority(notification)
+        && !string.IsNullOrWhiteSpace(notification.ActionLabel)
+        && !string.IsNullOrWhiteSpace(notification.ActionRoute);
 
     public void HideActiveNotifications(AppNotificationSnapshot snapshot)
     {

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -1815,9 +1815,6 @@ On your gateway host (Mac/Linux), run:
   <data name="ConnectionPage_TextBlock_11.Text" xml:space="preserve">
     <value>Gateway endpoint used by both the operator client and node service.</value>
   </data>
-  <data name="AuthErrorBar.Title" xml:space="preserve">
-    <value>Connection Error</value>
-  </data>
   <data name="StatusText.Text" xml:space="preserve">
     <value>Disconnected</value>
   </data>
@@ -3275,9 +3272,6 @@ On your gateway host (Mac/Linux), run:
   </data>
   <data name="AppNotification_ActionOpenCron" xml:space="preserve">
     <value>Open Cron</value>
-  </data>
-  <data name="AppNotification_GatewayAuthenticationFailed_Title" xml:space="preserve">
-    <value>Gateway authentication failed</value>
   </data>
   <data name="AppNotification_GatewayConnectionFailed_Title" xml:space="preserve">
     <value>Gateway connection failed</value>
@@ -5599,9 +5593,6 @@ Make sure the gateway is running.</value>
   <data name="ConnectionPage_CancelAction" xml:space="preserve">
     <value>Cancel</value>
   </data>
-  <data name="ConnectionPage_ConnectFailed" xml:space="preserve">
-    <value>Connect failed</value>
-  </data>
   <data name="ConnectionPage_GatewayConnectionFailed" xml:space="preserve">
     <value>Gateway connection failed.</value>
   </data>
@@ -5631,31 +5622,6 @@ Make sure the gateway is running.</value>
   </data>
   <data name="ConnectionPage_DenyPairingRequest" xml:space="preserve">
     <value>Deny pairing request</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidanceToken" xml:space="preserve">
-    <value>{0}
-
-Paste a new setup code from the Add Gateway flow.</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidancePairing" xml:space="preserve">
-    <value>{0}
-
-Your device needs approval on the gateway host.</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidancePassword" xml:space="preserve">
-    <value>{0}
-
-This gateway requires password authentication.</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidanceSignature" xml:space="preserve">
-    <value>{0}
-
-The gateway may require a different auth protocol version.</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidanceDefault" xml:space="preserve">
-    <value>{0}
-
-Check your connection settings and try again.</value>
   </data>
   <data name="ConnectionPage_AuthModeBootstrap" xml:space="preserve">
     <value>bootstrap</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -1767,9 +1767,6 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="ConnectionPage_TextBlock_11.Text" xml:space="preserve">
     <value>Point de terminaison de passerelle utilisé par le client opérateur et le service de nœud.</value>
   </data>
-  <data name="AuthErrorBar.Title" xml:space="preserve">
-    <value>Erreur de connexion</value>
-  </data>
   <data name="StatusText.Text" xml:space="preserve">
     <value>Déconnecté</value>
   </data>
@@ -3203,9 +3200,6 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   </data>
   <data name="AppNotification_ActionOpenCron" xml:space="preserve">
     <value>Ouvrir Cron</value>
-  </data>
-  <data name="AppNotification_GatewayAuthenticationFailed_Title" xml:space="preserve">
-    <value>Échec de l'authentification de la passerelle</value>
   </data>
   <data name="AppNotification_GatewayConnectionFailed_Title" xml:space="preserve">
     <value>Échec de la connexion à la passerelle</value>
@@ -5551,9 +5545,6 @@ Assurez-vous que la passerelle est en cours d'exécution.</value>
   <data name="ConnectionPage_CancelAction" xml:space="preserve">
     <value>Annuler</value>
   </data>
-  <data name="ConnectionPage_ConnectFailed" xml:space="preserve">
-    <value>Échec de la connexion</value>
-  </data>
   <data name="ConnectionPage_GatewayConnectionFailed" xml:space="preserve">
     <value>Échec de la connexion à la passerelle.</value>
   </data>
@@ -5583,31 +5574,6 @@ Assurez-vous que la passerelle est en cours d'exécution.</value>
   </data>
   <data name="ConnectionPage_DenyPairingRequest" xml:space="preserve">
     <value>Refuser la demande d’appairage</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidanceToken" xml:space="preserve">
-    <value>{0}
-
-Collez un nouveau code de configuration depuis le flux Ajouter une passerelle.</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidancePairing" xml:space="preserve">
-    <value>{0}
-
-Votre appareil nécessite une approbation sur l’hôte de la passerelle.</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidancePassword" xml:space="preserve">
-    <value>{0}
-
-Cette passerelle nécessite une authentification par mot de passe.</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidanceSignature" xml:space="preserve">
-    <value>{0}
-
-La passerelle pourrait nécessiter une version différente du protocole d’authentification.</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidanceDefault" xml:space="preserve">
-    <value>{0}
-
-Vérifiez vos paramètres de connexion et réessayez.</value>
   </data>
   <data name="ConnectionPage_AuthModeBootstrap" xml:space="preserve">
     <value>amorçage</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -1768,9 +1768,6 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="ConnectionPage_TextBlock_11.Text" xml:space="preserve">
     <value>Gateway-eindpunt dat door zowel de operatorclient als de knooppuntservice wordt gebruikt.</value>
   </data>
-  <data name="AuthErrorBar.Title" xml:space="preserve">
-    <value>Verbindingsfout</value>
-  </data>
   <data name="StatusText.Text" xml:space="preserve">
     <value>Verbinding verbroken</value>
   </data>
@@ -3204,9 +3201,6 @@ Voer op uw gateway-host (Mac/Linux) uit:
   </data>
   <data name="AppNotification_ActionOpenCron" xml:space="preserve">
     <value>Cron openen</value>
-  </data>
-  <data name="AppNotification_GatewayAuthenticationFailed_Title" xml:space="preserve">
-    <value>Gatewayverificatie mislukt</value>
   </data>
   <data name="AppNotification_GatewayConnectionFailed_Title" xml:space="preserve">
     <value>Gatewayverbinding mislukt</value>
@@ -5552,9 +5546,6 @@ Controleer of de gateway actief is.</value>
   <data name="ConnectionPage_CancelAction" xml:space="preserve">
     <value>Annuleren</value>
   </data>
-  <data name="ConnectionPage_ConnectFailed" xml:space="preserve">
-    <value>Verbinding mislukt</value>
-  </data>
   <data name="ConnectionPage_GatewayConnectionFailed" xml:space="preserve">
     <value>Gatewayverbinding mislukt.</value>
   </data>
@@ -5584,31 +5575,6 @@ Controleer of de gateway actief is.</value>
   </data>
   <data name="ConnectionPage_DenyPairingRequest" xml:space="preserve">
     <value>Koppelingverzoek weigeren</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidanceToken" xml:space="preserve">
-    <value>{0}
-
-Plak een nieuwe installatiecode vanuit het Gateway toevoegen-proces.</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidancePairing" xml:space="preserve">
-    <value>{0}
-
-Uw apparaat moet worden goedgekeurd op de gatewayhost.</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidancePassword" xml:space="preserve">
-    <value>{0}
-
-Deze gateway vereist wachtwoordverificatie.</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidanceSignature" xml:space="preserve">
-    <value>{0}
-
-De gateway vereist mogelijk een andere versie van het verificatieprotocol.</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidanceDefault" xml:space="preserve">
-    <value>{0}
-
-Controleer uw verbindingsinstellingen en probeer het opnieuw.</value>
   </data>
   <data name="ConnectionPage_AuthModeBootstrap" xml:space="preserve">
     <value>bootstrap-modus</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -1767,9 +1767,6 @@
   <data name="ConnectionPage_TextBlock_11.Text" xml:space="preserve">
     <value>操作员客户端和节点服务共同使用的网关终结点。</value>
   </data>
-  <data name="AuthErrorBar.Title" xml:space="preserve">
-    <value>连接错误</value>
-  </data>
   <data name="StatusText.Text" xml:space="preserve">
     <value>已断开连接</value>
   </data>
@@ -3203,9 +3200,6 @@
   </data>
   <data name="AppNotification_ActionOpenCron" xml:space="preserve">
     <value>打开 Cron</value>
-  </data>
-  <data name="AppNotification_GatewayAuthenticationFailed_Title" xml:space="preserve">
-    <value>网关身份验证失败</value>
   </data>
   <data name="AppNotification_GatewayConnectionFailed_Title" xml:space="preserve">
     <value>网关连接失败</value>
@@ -5552,9 +5546,6 @@
   <data name="ConnectionPage_CancelAction" xml:space="preserve">
     <value>取消</value>
   </data>
-  <data name="ConnectionPage_ConnectFailed" xml:space="preserve">
-    <value>连接失败</value>
-  </data>
   <data name="ConnectionPage_GatewayConnectionFailed" xml:space="preserve">
     <value>网关连接失败。</value>
   </data>
@@ -5584,31 +5575,6 @@
   </data>
   <data name="ConnectionPage_DenyPairingRequest" xml:space="preserve">
     <value>拒绝配对请求</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidanceToken" xml:space="preserve">
-    <value>{0}
-
-从添加网关流程中粘贴新的设置代码。</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidancePairing" xml:space="preserve">
-    <value>{0}
-
-您的设备需要在网关主机上获得批准。</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidancePassword" xml:space="preserve">
-    <value>{0}
-
-此网关需要密码身份验证。</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidanceSignature" xml:space="preserve">
-    <value>{0}
-
-网关可能需要不同版本的认证协议。</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidanceDefault" xml:space="preserve">
-    <value>{0}
-
-请检查您的连接设置并重试。</value>
   </data>
   <data name="ConnectionPage_AuthModeBootstrap" xml:space="preserve">
     <value>引导</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -1767,9 +1767,6 @@
   <data name="ConnectionPage_TextBlock_11.Text" xml:space="preserve">
     <value>操作員用戶端和節點服務共同使用的閘道端點。</value>
   </data>
-  <data name="AuthErrorBar.Title" xml:space="preserve">
-    <value>連線錯誤</value>
-  </data>
   <data name="StatusText.Text" xml:space="preserve">
     <value>已中斷連線</value>
   </data>
@@ -3203,9 +3200,6 @@
   </data>
   <data name="AppNotification_ActionOpenCron" xml:space="preserve">
     <value>開啟 Cron</value>
-  </data>
-  <data name="AppNotification_GatewayAuthenticationFailed_Title" xml:space="preserve">
-    <value>閘道驗證失敗</value>
   </data>
   <data name="AppNotification_GatewayConnectionFailed_Title" xml:space="preserve">
     <value>閘道連線失敗</value>
@@ -5552,9 +5546,6 @@
   <data name="ConnectionPage_CancelAction" xml:space="preserve">
     <value>取消</value>
   </data>
-  <data name="ConnectionPage_ConnectFailed" xml:space="preserve">
-    <value>連線失敗</value>
-  </data>
   <data name="ConnectionPage_GatewayConnectionFailed" xml:space="preserve">
     <value>閘道連線失敗。</value>
   </data>
@@ -5584,31 +5575,6 @@
   </data>
   <data name="ConnectionPage_DenyPairingRequest" xml:space="preserve">
     <value>拒絕配對請求</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidanceToken" xml:space="preserve">
-    <value>{0}
-
-從新增閘道流程中貼上新的設定碼。</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidancePairing" xml:space="preserve">
-    <value>{0}
-
-您的裝置需要在閘道主機上獲得核准。</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidancePassword" xml:space="preserve">
-    <value>{0}
-
-此閘道需要密碼驗證。</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidanceSignature" xml:space="preserve">
-    <value>{0}
-
-閘道可能需要不同版本的認證協定。</value>
-  </data>
-  <data name="ConnectionPage_AuthGuidanceDefault" xml:space="preserve">
-    <value>{0}
-
-請檢查您的連線設定並重試。</value>
   </data>
   <data name="ConnectionPage_AuthModeBootstrap" xml:space="preserve">
     <value>引導</value>

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
@@ -121,19 +121,25 @@
                  IsClosable="True"
                  Closed="OnAppNotificationInfoBarClosed">
             <InfoBar.Content>
-                <Grid ColumnSpacing="12" Margin="0,0,0,8">
+                <Grid ColumnSpacing="12" Margin="0,0,0,4" VerticalAlignment="Center">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
+                    <!-- Single-line message: bold headline + regular detail
+                         (Runs set in RenderAppNotification). Trims rather than
+                         wrapping so the banner stays one line tall. -->
                     <TextBlock x:Name="AppNotificationMessageText"
-                               TextWrapping="WrapWholeWords"
-                               VerticalAlignment="Center"/>
-                    <Button x:Name="AppNotificationActionButton"
-                           Grid.Column="1"
-                           Visibility="Collapsed"
-                           VerticalAlignment="Center"
-                           Click="OnAppNotificationActionButtonClick"/>
+                               VerticalAlignment="Center"
+                               TextWrapping="NoWrap"
+                               TextTrimming="CharacterEllipsis"/>
+                    <!-- Action sits at the far right of the banner, before the
+                         close button — mirrors the prior Connection-page bar. -->
+                    <HyperlinkButton x:Name="AppNotificationActionButton"
+                            Grid.Column="1"
+                            Visibility="Collapsed"
+                            VerticalAlignment="Center"
+                            Click="OnAppNotificationActionButtonClick"/>
                 </Grid>
             </InfoBar.Content>
         </InfoBar>

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -1,5 +1,7 @@
+using Microsoft.UI.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Input;
 using OpenClaw.Shared;
 using OpenClawTray.Helpers;
@@ -164,22 +166,45 @@ public sealed partial class HubWindow : WindowEx
         var notification = _currentAppNotification;
         AppNotificationInfoBar.Visibility = Visibility.Visible;
         AppNotificationInfoBar.Severity = ToInfoBarSeverity(notification.Severity);
-        AppNotificationInfoBar.Title = notification.Title;
+        AppNotificationInfoBar.Title = string.Empty;
         AppNotificationInfoBar.Message = string.Empty;
-        AppNotificationMessageText.Text = notification.Message;
 
-        if (snapshot.HasMultipleActiveNotifications)
+        // Single-line compact banner: bold headline + regular detail on one
+        // line (e.g. "Gateway connection failed — Transport error"). The bold
+        // run gives the headline scannability without adding a second row.
+        // Full detail/troubleshooting still lives on the surface the action
+        // routes to (e.g. the Connection page).
+        AppNotificationMessageText.Inlines.Clear();
+        AppNotificationMessageText.Inlines.Add(new Run
         {
-            _appNotificationActionShowsMore = true;
-            AppNotificationActionButton.Content = LocalizationHelper.GetString("AppNotification_ShowMore");
-            AppNotificationActionButton.Visibility = Visibility.Visible;
-            UpdateAppNotificationActionEnabledState();
+            Text = notification.Title,
+            FontWeight = FontWeights.SemiBold
+        });
+        if (!string.IsNullOrWhiteSpace(notification.Message))
+        {
+            AppNotificationMessageText.Inlines.Add(new Run
+            {
+                Text = $" — {notification.Message}"
+            });
         }
-        else if (!string.IsNullOrWhiteSpace(notification.ActionLabel) &&
+
+        // Action-button precedence: if the visible notification is itself
+        // actionable (e.g. a connection issue routes to the Connection page),
+        // surface that action so the user can act on the banner they're
+        // looking at. Only fall back to "Show more" when the visible
+        // notification has no action of its own but others are queued.
+        if (!string.IsNullOrWhiteSpace(notification.ActionLabel) &&
             !string.IsNullOrWhiteSpace(notification.ActionRoute))
         {
             _appNotificationActionShowsMore = false;
             AppNotificationActionButton.Content = notification.ActionLabel;
+            AppNotificationActionButton.Visibility = Visibility.Visible;
+            UpdateAppNotificationActionEnabledState();
+        }
+        else if (snapshot.HasMultipleActiveNotifications)
+        {
+            _appNotificationActionShowsMore = true;
+            AppNotificationActionButton.Content = LocalizationHelper.GetString("AppNotification_ShowMore");
             AppNotificationActionButton.Visibility = Visibility.Visible;
             UpdateAppNotificationActionEnabledState();
         }
@@ -200,7 +225,7 @@ public sealed partial class HubWindow : WindowEx
         AppNotificationInfoBar.Visibility = Visibility.Collapsed;
         AppNotificationInfoBar.Title = string.Empty;
         AppNotificationInfoBar.Message = string.Empty;
-        AppNotificationMessageText.Text = string.Empty;
+        AppNotificationMessageText.Inlines.Clear();
         AppNotificationActionButton.Visibility = Visibility.Collapsed;
         _appNotificationActionShowsMore = false;
         _currentAppNotification = null;

--- a/tests/OpenClaw.Tray.Tests/Services/AppNotificationServiceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Services/AppNotificationServiceTests.cs
@@ -66,6 +66,82 @@ public sealed class AppNotificationServiceTests
     }
 
     [Fact]
+    public void BannerState_PrioritizesConnectionIssueOverEarlierActionableNotification()
+    {
+        var service = new AppNotificationService();
+        var bannerState = new AppNotificationBannerState();
+
+        // An unrelated, actionable notification is current...
+        service.Show(Notification("Sandbox risk", "Review sandbox", source: "sandbox"));
+        // ...then a connection failure arrives and is queued behind it.
+        service.Show(Notification("Gateway connection failed", "unauthorized", source: "connection"));
+
+        // The connection issue must be the visible banner so the user can reach
+        // the Connection page, even though it wasn't the first/current item.
+        Assert.Equal(
+            "Gateway connection failed",
+            bannerState.SelectVisibleNotification(service.Snapshot)?.Title);
+    }
+
+    [Fact]
+    public void BannerState_HidingConnectionIssue_RevealsRemainingNotification()
+    {
+        var service = new AppNotificationService();
+        var bannerState = new AppNotificationBannerState();
+
+        service.Show(Notification("Sandbox risk", "Review sandbox", source: "sandbox"));
+        service.Show(Notification("Gateway connection failed", "unauthorized", source: "connection"));
+
+        // Dismissing the banner hides all active items; once the connection
+        // issue is removed, the remaining notification can surface again.
+        bannerState.HideActiveNotifications(service.Snapshot);
+        Assert.Null(bannerState.SelectVisibleNotification(service.Snapshot));
+
+        var connectionId = service.Snapshot.ActiveNotifications
+            .First(n => n.Source == "connection").Id;
+        service.Dismiss(connectionId);
+
+        Assert.Equal(
+            "Sandbox risk",
+            bannerState.SelectVisibleNotification(service.Snapshot, revealHiddenIfNeeded: true)?.Title);
+    }
+
+    [Fact]
+    public void BannerState_PrioritizesActionableConnectionOverActionlessConnection()
+    {
+        var service = new AppNotificationService();
+        var bannerState = new AppNotificationBannerState();
+
+        // An action-less connection notification (e.g. a transient gateway-host
+        // failure) is current...
+        service.Show(new AppNotification
+        {
+            Id = "gateway-host-action:Terminal failed",
+            Title = "Terminal failed",
+            Message = "Could not open the gateway terminal.",
+            Source = "connection",
+            Severity = AppNotificationSeverity.Error
+        });
+        // ...then a real connection error arrives with an "Open Connection" action.
+        service.Show(new AppNotification
+        {
+            Id = "connection:issue",
+            Title = "Gateway connection failed",
+            Message = "Transport error",
+            Source = "connection",
+            Severity = AppNotificationSeverity.Error,
+            ActionRoute = "connection",
+            ActionLabel = "Open Connection"
+        });
+
+        // The actionable connection error must win so the banner offers
+        // "Open Connection" rather than degrading to "Show more".
+        var visible = bannerState.SelectVisibleNotification(service.Snapshot);
+        Assert.Equal("Gateway connection failed", visible?.Title);
+        Assert.Equal("Open Connection", visible?.ActionLabel);
+    }
+
+    [Fact]
     public void BannerState_HideActiveNotifications_HidesExistingItemsUntilNewNotificationArrives()
     {
         var service = new AppNotificationService();


### PR DESCRIPTION
## Summary

A connection/auth failure rendered **two** error bars: the global top-window InfoBar **and** an in-page "Connection Error" InfoBar on the Connection page. The auth pipeline also published **two** global notifications for a single failure, which forced the banner's action to degrade to "Show more" instead of routing to Connection.

This consolidates everything into **one thin top banner** and removes the in-page bar, with no loss of states/messages.

### What changed
- **Removed the in-page `AuthErrorBar`** (XAML + all code paths) and its now-dead resw strings (`ConnectionPage_AuthGuidance*`, `ConnectionPage_ConnectFailed`) across all 5 locales.
- **One global banner** carries every state the in-page bar did (gateway connection failed, pairing required, Windows node failed/rate-limited, etc.).
- **Always routes to Connection** — connection notifications are prioritized as the visible banner, preferring an *actionable* one over an action-less transient, so the user always gets an **Open Connection** action (not "Show more").
- **Consolidated duplicate global notifications** — stopped publishing the separate `connection:authentication-failed` banner; the snapshot-driven `connection:issue` notification is the single source.
- **Re-homed transient errors** — WSL host-action failures use the inline WSL-card status (or a top notification when that card is hidden); connect/switch failures publish via `ShowTransientConnectionError` on the same banner id (cannot double-bank).
- **Windows-aligned, thinner design** — single line: **bold headline** + " — detail", with the action as a **right-aligned hyperlink**.

## Validation
- `./build.ps1` — all projects build
- Tray tests: **1218 passed** (incl. new banner-priority / dedupe regression tests)
- Shared tests: **2514 passed**
- Two adversarial rubber-duck reviews (GPT-5.5); all findings fixed.

## Screenshots
_Before:_ two bars (top "Gateway connection failed" + in-page "Connection Error").
<img width="1232" height="802" alt="image (1)" src="https://github.com/user-attachments/assets/5811ab8a-7044-425a-87c9-eaadb59c2ff4" />

_After:_ one thin banner — `⊗ Gateway connection failed — Transport error … Open Connection ✕` — with the Connection page showing only its own recovery card.
<img width="1843" height="1229" alt="06-banner-show-more" src="https://github.com/user-attachments/assets/d6ab7af4-86e4-45e9-954b-d83e0f6f0d5a" />
<img width="1843" height="1229" alt="04-redesigned-thin-banner" src="https://github.com/user-attachments/assets/91cc22f0-1e11-43dc-a8bf-7a61bec710c0" />
