### PR TITLE
Redesign Hub title bar notifications and status

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
@@ -49,6 +49,7 @@ public static class FluentIconCatalog
     public const string Settings = "\uE713";       // Settings
     public const string Setup = "\uE825";          // Bank — Reconfigure / Setup wizard launcher
     public const string About = "\uE946";          // Info
+    public const string Notifications = "\uE7E7";   // Ringer — title-bar notifications bell
     public const string Exit = "\uE711";           // Cancel (X) — used for "Close" menu item
     public const string Add = "\uE710";            // Add — "+ Add gateway" header button
     public const string Back = "\uE72B";           // Back — leading chevron on Back hyperlink

--- a/src/OpenClaw.Tray.WinUI/Pages/NotificationsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/NotificationsPage.xaml.cs
@@ -1,11 +1,8 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using OpenClawTray.Helpers;
 using OpenClawTray.Services;
-using System;
+using OpenClawTray.ViewModels;
 using System.Collections.ObjectModel;
-using System.Globalization;
-using System.Linq;
 
 namespace OpenClawTray.Pages;
 
@@ -97,83 +94,5 @@ public sealed partial class NotificationsPage : Page
 
         ((IAppCommands)CurrentApp).Navigate(item.ActionRoute);
         _notificationService?.Dismiss(item.Id);
-    }
-
-    private sealed record NotificationItemViewModel(
-        string Id,
-        string SeverityGlyph,
-        string Title,
-        string Message,
-        string Metadata,
-        string? ActionLabel,
-        string? ActionRoute,
-        Visibility ActionVisibility,
-        string OccurrenceText,
-        Visibility OccurrenceVisibility,
-        string DismissAutomationName)
-    {
-        public static NotificationItemViewModel From(AppNotification notification)
-        {
-            var metadata = new[]
-                {
-                    LocalizeMetadataValue(notification.Source),
-                    LocalizeMetadataValue(notification.Category),
-                    notification.CreatedAt.ToLocalTime().ToString("g", CultureInfo.CurrentCulture)
-                }
-                .Where(value => !string.IsNullOrWhiteSpace(value));
-
-            var occurrenceText = LocalizationHelper.Format(
-                "AppNotification_RepeatedBadgeFormat",
-                notification.OccurrenceCount);
-
-            return new(
-                notification.Id,
-                ToSeverityGlyph(notification.Severity),
-                notification.Title,
-                notification.Message,
-                string.Join(" - ", metadata),
-                notification.ActionLabel,
-                notification.ActionRoute,
-                !string.IsNullOrWhiteSpace(notification.ActionLabel) &&
-                !string.IsNullOrWhiteSpace(notification.ActionRoute)
-                    ? Visibility.Visible
-                    : Visibility.Collapsed,
-                occurrenceText,
-                notification.OccurrenceCount > 1 ? Visibility.Visible : Visibility.Collapsed,
-                LocalizationHelper.Format("NotificationsPage_DismissAutomationNameFormat", notification.Title));
-        }
-
-        private static string ToSeverityGlyph(AppNotificationSeverity severity) => severity switch
-        {
-            AppNotificationSeverity.Success => "\uE930",
-            AppNotificationSeverity.Warning => "\uE7BA",
-            AppNotificationSeverity.Error => "\uE783",
-            _ => "\uE946"
-        };
-
-        private static string? LocalizeMetadataValue(string? value) => value switch
-        {
-            null or "" => null,
-            "authentication" => LocalizationHelper.GetString("NotificationsPage_MetadataAuthentication"),
-            "bindings" => LocalizationHelper.GetString("NotificationsPage_MetadataBindings"),
-            "channels" => LocalizationHelper.GetString("NotificationsPage_MetadataChannels"),
-            "config" => LocalizationHelper.GetString("NotificationsPage_MetadataConfig"),
-            "connection" => LocalizationHelper.GetString("NotificationsPage_MetadataConnection"),
-            "cron" => LocalizationHelper.GetString("NotificationsPage_MetadataCron"),
-            "exec-approval" => LocalizationHelper.GetString("NotificationsPage_MetadataSourceExecApproval"),
-            "gateway" => LocalizationHelper.GetString("NotificationsPage_MetadataGateway"),
-            "jobs" => LocalizationHelper.GetString("NotificationsPage_MetadataJobs"),
-            "load" => LocalizationHelper.GetString("NotificationsPage_MetadataLoad"),
-            "lifecycle" => LocalizationHelper.GetString("NotificationsPage_MetadataLifecycle"),
-            "local-gateway" => LocalizationHelper.GetString("NotificationsPage_MetadataLocalGateway"),
-            "node.invoke" => LocalizationHelper.GetString("NotificationsPage_MetadataCategoryNodeInvoke"),
-            "node" => LocalizationHelper.GetString("NotificationsPage_MetadataNode"),
-            "pairing" => LocalizationHelper.GetString("NotificationsPage_MetadataPairing"),
-            "sandbox" => LocalizationHelper.GetString("NotificationsPage_MetadataSandbox"),
-            "settings" => LocalizationHelper.GetString("NotificationsPage_MetadataSettings"),
-            "status" => LocalizationHelper.GetString("NotificationsPage_MetadataStatus"),
-            "system.run" => LocalizationHelper.GetString("NotificationsPage_MetadataSystemRun"),
-            _ => value
-        };
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Services/ConnectionStatusPresenter.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ConnectionStatusPresenter.cs
@@ -1,0 +1,74 @@
+using OpenClaw.Connection;
+
+namespace OpenClawTray.Services;
+
+internal enum ConnectionStatusAccent
+{
+    Neutral,
+    Success,
+    Caution,
+    Critical,
+}
+
+internal static class ConnectionStatusPresenter
+{
+    public static (string LabelKey, ConnectionStatusAccent Accent) Pill(OverallConnectionState overall) => overall switch
+    {
+        OverallConnectionState.Connected or OverallConnectionState.Ready =>
+            ("StatusDisplay_Connected", ConnectionStatusAccent.Success),
+        OverallConnectionState.Connecting =>
+            ("StatusDisplay_Connecting", ConnectionStatusAccent.Caution),
+        OverallConnectionState.Degraded =>
+            ("HubWindow_Pill_Degraded", ConnectionStatusAccent.Caution),
+        OverallConnectionState.PairingRequired =>
+            ("HubWindow_Pill_PairingRequired", ConnectionStatusAccent.Caution),
+        OverallConnectionState.Error =>
+            ("StatusDisplay_Error", ConnectionStatusAccent.Critical),
+        _ => ("StatusDisplay_Disconnected", ConnectionStatusAccent.Neutral),
+    };
+
+    public static ConnectionStatusAccent RoleAccent(RoleConnectionState state) => state switch
+    {
+        RoleConnectionState.Connected => ConnectionStatusAccent.Success,
+        RoleConnectionState.Connecting => ConnectionStatusAccent.Caution,
+        RoleConnectionState.PairingRequired => ConnectionStatusAccent.Caution,
+        RoleConnectionState.Error or
+        RoleConnectionState.PairingRejected or
+        RoleConnectionState.RateLimited => ConnectionStatusAccent.Critical,
+        _ => ConnectionStatusAccent.Neutral,
+    };
+
+    public static string RoleStateLabelKey(RoleConnectionState state) => state switch
+    {
+        RoleConnectionState.Connected => "StatusDisplay_Connected",
+        RoleConnectionState.Connecting => "StatusDisplay_Connecting",
+        RoleConnectionState.PairingRequired => "HubWindow_Role_PairingRequired",
+        RoleConnectionState.PairingRejected => "HubWindow_Role_PairingRejected",
+        RoleConnectionState.RateLimited => "HubWindow_Role_RateLimited",
+        RoleConnectionState.Error => "StatusDisplay_Error",
+        RoleConnectionState.Disabled => "HubWindow_Role_Disabled",
+        _ => "HubWindow_Role_Off",
+    };
+
+    public static (string LabelKey, ConnectionStatusAccent Accent) NodeRow(
+        GatewayConnectionSnapshot snapshot, bool nodeModeEnabled, int enabledCapabilityCount)
+    {
+        if (!nodeModeEnabled || snapshot.OperatorState != RoleConnectionState.Connected)
+            return ("HubWindow_Role_Disabled", ConnectionStatusAccent.Neutral);
+
+        return snapshot.NodeState switch
+        {
+            RoleConnectionState.PairingRequired => (RoleStateLabelKey(snapshot.NodeState), ConnectionStatusAccent.Caution),
+            RoleConnectionState.PairingRejected or
+            RoleConnectionState.RateLimited or
+            RoleConnectionState.Error => (RoleStateLabelKey(snapshot.NodeState), ConnectionStatusAccent.Critical),
+            _ when enabledCapabilityCount == 0 => ("HubWindow_Role_PermissionsIncomplete", ConnectionStatusAccent.Caution),
+            _ => (RoleStateLabelKey(snapshot.NodeState), RoleAccent(snapshot.NodeState)),
+        };
+    }
+
+    public static bool NodeNeedsApproval(GatewayConnectionSnapshot snapshot, bool nodeModeEnabled) =>
+        nodeModeEnabled
+        && snapshot.OperatorState == RoleConnectionState.Connected
+        && snapshot.NodeState == RoleConnectionState.PairingRequired;
+}

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2421,9 +2421,6 @@ On your gateway host (Mac/Linux), run:
   <data name="HubWindow_NavigationViewItem_136.Content" xml:space="preserve">
     <value>Permissions</value>
   </data>
-  <data name="HubWindow_NavigationViewItem_Notifications.Content" xml:space="preserve">
-    <value>Notifications</value>
-  </data>
   <data name="HubWindow_NavigationViewItem_145.Content" xml:space="preserve">
     <value>Diagnostics</value>
   </data>
@@ -5029,12 +5026,6 @@ Commands are blocked while sandboxing is unavailable because strict fallback blo
   <data name="HubWindow_Disconnected.Text" xml:space="preserve">
     <value>Disconnected</value>
   </data>
-  <data name="HubWindow_Op.Text" xml:space="preserve">
-    <value>Op</value>
-  </data>
-  <data name="HubWindow_Node.Text" xml:space="preserve">
-    <value>Node</value>
-  </data>
   <data name="HubWindow_Advanced.Content" xml:space="preserve">
     <value>Advanced</value>
   </data>
@@ -5064,9 +5055,6 @@ Commands are blocked while sandboxing is unavailable because strict fallback blo
   </data>
   <data name="VoiceSettingsPage_PreviewVoice.Text" xml:space="preserve">
     <value>Preview Voice</value>
-  </data>
-  <data name="HubWindow_TitleStatus.Text" xml:space="preserve">
-    <value>Disconnected</value>
   </data>
   <data name="SandboxPage_GatewayCommandsNote.Text" xml:space="preserve">
     <value>Commands the agent runs directly on the gateway aren't. If the gateway is on this PC they may still be able to reach your Windows files, clipboard, and network — check your gateway's configuration.</value>
@@ -6705,5 +6693,71 @@ Make sure the gateway is running.</value>
   </data>
   <data name="ConnectionPage_RemoteSetupHelpAuthTitle.Text" xml:space="preserve">
     <value>Auth</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_Title.Text" xml:space="preserve">
+    <value>Connection</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_OpenConnection.Content" xml:space="preserve">
+    <value>Open Connection</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_GatewayLabel.Text" xml:space="preserve">
+    <value>Gateway</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_Reconnect.Content" xml:space="preserve">
+    <value>Reconnect</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_OperatorLabel.Text" xml:space="preserve">
+    <value>Operator</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_NodeLabel.Text" xml:space="preserve">
+    <value>Node</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_Approve.Content" xml:space="preserve">
+    <value>Approve…</value>
+  </data>
+  <data name="HubWindow_StatusPill_Tooltip" xml:space="preserve">
+    <value>Connection status</value>
+  </data>
+  <data name="HubWindow_Bell_Tooltip" xml:space="preserve">
+    <value>Notifications</value>
+  </data>
+  <data name="HubWindow_Pill_Ready" xml:space="preserve">
+    <value>Ready</value>
+  </data>
+  <data name="HubWindow_Pill_PairingRequired" xml:space="preserve">
+    <value>Pairing required</value>
+  </data>
+  <data name="HubWindow_Pill_Degraded" xml:space="preserve">
+    <value>Degraded</value>
+  </data>
+  <data name="HubWindow_Role_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="HubWindow_Role_PairingRequired" xml:space="preserve">
+    <value>Pairing required</value>
+  </data>
+  <data name="HubWindow_Role_PairingRejected" xml:space="preserve">
+    <value>Pairing rejected</value>
+  </data>
+  <data name="HubWindow_Role_RateLimited" xml:space="preserve">
+    <value>Rate limited</value>
+  </data>
+  <data name="HubWindow_Role_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="NotificationsFlyout_ClearAll.Content" xml:space="preserve">
+    <value>Clear all</value>
+  </data>
+  <data name="NotificationsFlyout_EmptyTitle.Text" xml:space="preserve">
+    <value>No notifications</value>
+  </data>
+  <data name="NotificationsFlyout_OpenPage.Content" xml:space="preserve">
+    <value>Open notifications</value>
+  </data>
+  <data name="NotificationsFlyout_ActiveCountFormat" xml:space="preserve">
+    <value>{0} active</value>
+  </data>
+  <data name="HubWindow_Role_PermissionsIncomplete" xml:space="preserve">
+    <value>Permissions incomplete</value>
   </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2376,9 +2376,6 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="HubWindow_NavigationViewItem_145.Content" xml:space="preserve">
     <value>Débogage</value>
   </data>
-  <data name="HubWindow_NavigationViewItem_Notifications.Content" xml:space="preserve">
-    <value>Alertes</value>
-  </data>
   <data name="HubWindow_NavigationViewItem_148.Content" xml:space="preserve">
     <value>Informations</value>
   </data>
@@ -4981,12 +4978,6 @@ Les commandes sont bloquées tant que le sandboxing est indisponible, car le blo
   <data name="HubWindow_Disconnected.Text" xml:space="preserve">
     <value>Déconnecté</value>
   </data>
-  <data name="HubWindow_Op.Text" xml:space="preserve">
-    <value>Op.</value>
-  </data>
-  <data name="HubWindow_Node.Text" xml:space="preserve">
-    <value>Nœud</value>
-  </data>
   <data name="HubWindow_Advanced.Content" xml:space="preserve">
     <value>Avancé</value>
   </data>
@@ -5016,9 +5007,6 @@ Les commandes sont bloquées tant que le sandboxing est indisponible, car le blo
   </data>
   <data name="VoiceSettingsPage_PreviewVoice.Text" xml:space="preserve">
     <value>Aperçu de la voix</value>
-  </data>
-  <data name="HubWindow_TitleStatus.Text" xml:space="preserve">
-    <value>Déconnecté</value>
   </data>
   <data name="SandboxPage_GatewayCommandsNote.Text" xml:space="preserve">
     <value>Les commandes que l'agent exécute directement sur la passerelle ne le sont pas. Si la passerelle se trouve sur ce PC, elles peuvent toujours accéder à vos fichiers Windows, au presse-papiers et au réseau — vérifiez la configuration de votre passerelle.</value>
@@ -6657,5 +6645,71 @@ Assurez-vous que la passerelle est en cours d'exécution.</value>
   </data>
   <data name="ConnectionPage_RemoteSetupHelpAuthTitle.Text" xml:space="preserve">
     <value>Authentification</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_Title.Text" xml:space="preserve">
+    <value>Connection</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_OpenConnection.Content" xml:space="preserve">
+    <value>Open Connection</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_GatewayLabel.Text" xml:space="preserve">
+    <value>Gateway</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_Reconnect.Content" xml:space="preserve">
+    <value>Reconnect</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_OperatorLabel.Text" xml:space="preserve">
+    <value>Operator</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_NodeLabel.Text" xml:space="preserve">
+    <value>Node</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_Approve.Content" xml:space="preserve">
+    <value>Approve…</value>
+  </data>
+  <data name="HubWindow_StatusPill_Tooltip" xml:space="preserve">
+    <value>Connection status</value>
+  </data>
+  <data name="HubWindow_Bell_Tooltip" xml:space="preserve">
+    <value>Notifications</value>
+  </data>
+  <data name="HubWindow_Pill_Ready" xml:space="preserve">
+    <value>Ready</value>
+  </data>
+  <data name="HubWindow_Pill_PairingRequired" xml:space="preserve">
+    <value>Pairing required</value>
+  </data>
+  <data name="HubWindow_Pill_Degraded" xml:space="preserve">
+    <value>Degraded</value>
+  </data>
+  <data name="HubWindow_Role_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="HubWindow_Role_PairingRequired" xml:space="preserve">
+    <value>Pairing required</value>
+  </data>
+  <data name="HubWindow_Role_PairingRejected" xml:space="preserve">
+    <value>Pairing rejected</value>
+  </data>
+  <data name="HubWindow_Role_RateLimited" xml:space="preserve">
+    <value>Rate limited</value>
+  </data>
+  <data name="HubWindow_Role_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="NotificationsFlyout_ClearAll.Content" xml:space="preserve">
+    <value>Clear all</value>
+  </data>
+  <data name="NotificationsFlyout_EmptyTitle.Text" xml:space="preserve">
+    <value>No notifications</value>
+  </data>
+  <data name="NotificationsFlyout_OpenPage.Content" xml:space="preserve">
+    <value>Open notifications</value>
+  </data>
+  <data name="NotificationsFlyout_ActiveCountFormat" xml:space="preserve">
+    <value>{0} active</value>
+  </data>
+  <data name="HubWindow_Role_PermissionsIncomplete" xml:space="preserve">
+    <value>Permissions incomplete</value>
   </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2377,9 +2377,6 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="HubWindow_NavigationViewItem_145.Content" xml:space="preserve">
     <value>Foutopsporing</value>
   </data>
-  <data name="HubWindow_NavigationViewItem_Notifications.Content" xml:space="preserve">
-    <value>Meldingen</value>
-  </data>
   <data name="HubWindow_NavigationViewItem_148.Content" xml:space="preserve">
     <value>Informatie</value>
   </data>
@@ -4982,12 +4979,6 @@ Opdrachten worden geblokkeerd zolang sandboxing niet beschikbaar is, omdat strik
   <data name="HubWindow_Disconnected.Text" xml:space="preserve">
     <value>Niet verbonden</value>
   </data>
-  <data name="HubWindow_Op.Text" xml:space="preserve">
-    <value>Op.</value>
-  </data>
-  <data name="HubWindow_Node.Text" xml:space="preserve">
-    <value>Knooppunt</value>
-  </data>
   <data name="HubWindow_Advanced.Content" xml:space="preserve">
     <value>Geavanceerd</value>
   </data>
@@ -5017,9 +5008,6 @@ Opdrachten worden geblokkeerd zolang sandboxing niet beschikbaar is, omdat strik
   </data>
   <data name="VoiceSettingsPage_PreviewVoice.Text" xml:space="preserve">
     <value>Stemvoorbeeld</value>
-  </data>
-  <data name="HubWindow_TitleStatus.Text" xml:space="preserve">
-    <value>Niet verbonden</value>
   </data>
   <data name="SandboxPage_GatewayCommandsNote.Text" xml:space="preserve">
     <value>Opdrachten die de agent rechtstreeks op de gateway uitvoert, vallen hier niet onder. Als de gateway op deze pc staat, hebben ze mogelijk nog steeds toegang tot uw Windows-bestanden, klembord en netwerk — controleer de configuratie van uw gateway.</value>
@@ -6658,5 +6646,71 @@ Controleer of de gateway actief is.</value>
   </data>
   <data name="ConnectionPage_RemoteSetupHelpAuthTitle.Text" xml:space="preserve">
     <value>Verificatie</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_Title.Text" xml:space="preserve">
+    <value>Connection</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_OpenConnection.Content" xml:space="preserve">
+    <value>Open Connection</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_GatewayLabel.Text" xml:space="preserve">
+    <value>Gateway</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_Reconnect.Content" xml:space="preserve">
+    <value>Reconnect</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_OperatorLabel.Text" xml:space="preserve">
+    <value>Operator</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_NodeLabel.Text" xml:space="preserve">
+    <value>Node</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_Approve.Content" xml:space="preserve">
+    <value>Approve…</value>
+  </data>
+  <data name="HubWindow_StatusPill_Tooltip" xml:space="preserve">
+    <value>Connection status</value>
+  </data>
+  <data name="HubWindow_Bell_Tooltip" xml:space="preserve">
+    <value>Notifications</value>
+  </data>
+  <data name="HubWindow_Pill_Ready" xml:space="preserve">
+    <value>Ready</value>
+  </data>
+  <data name="HubWindow_Pill_PairingRequired" xml:space="preserve">
+    <value>Pairing required</value>
+  </data>
+  <data name="HubWindow_Pill_Degraded" xml:space="preserve">
+    <value>Degraded</value>
+  </data>
+  <data name="HubWindow_Role_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="HubWindow_Role_PairingRequired" xml:space="preserve">
+    <value>Pairing required</value>
+  </data>
+  <data name="HubWindow_Role_PairingRejected" xml:space="preserve">
+    <value>Pairing rejected</value>
+  </data>
+  <data name="HubWindow_Role_RateLimited" xml:space="preserve">
+    <value>Rate limited</value>
+  </data>
+  <data name="HubWindow_Role_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="NotificationsFlyout_ClearAll.Content" xml:space="preserve">
+    <value>Clear all</value>
+  </data>
+  <data name="NotificationsFlyout_EmptyTitle.Text" xml:space="preserve">
+    <value>No notifications</value>
+  </data>
+  <data name="NotificationsFlyout_OpenPage.Content" xml:space="preserve">
+    <value>Open notifications</value>
+  </data>
+  <data name="NotificationsFlyout_ActiveCountFormat" xml:space="preserve">
+    <value>{0} active</value>
+  </data>
+  <data name="HubWindow_Role_PermissionsIncomplete" xml:space="preserve">
+    <value>Permissions incomplete</value>
   </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2376,9 +2376,6 @@
   <data name="HubWindow_NavigationViewItem_145.Content" xml:space="preserve">
     <value>调试</value>
   </data>
-  <data name="HubWindow_NavigationViewItem_Notifications.Content" xml:space="preserve">
-    <value>通知</value>
-  </data>
   <data name="HubWindow_NavigationViewItem_148.Content" xml:space="preserve">
     <value>信息</value>
   </data>
@@ -4981,12 +4978,6 @@
   <data name="HubWindow_Disconnected.Text" xml:space="preserve">
     <value>已断开连接</value>
   </data>
-  <data name="HubWindow_Op.Text" xml:space="preserve">
-    <value>操作</value>
-  </data>
-  <data name="HubWindow_Node.Text" xml:space="preserve">
-    <value>节点</value>
-  </data>
   <data name="HubWindow_Advanced.Content" xml:space="preserve">
     <value>高级</value>
   </data>
@@ -5016,9 +5007,6 @@
   </data>
   <data name="VoiceSettingsPage_PreviewVoice.Text" xml:space="preserve">
     <value>语音预览</value>
-  </data>
-  <data name="HubWindow_TitleStatus.Text" xml:space="preserve">
-    <value>已断开连接</value>
   </data>
   <data name="SandboxPage_GatewayCommandsNote.Text" xml:space="preserve">
     <value>代理直接在网关上运行的命令不受此限制。如果网关在此电脑上，它们仍可能访问您的 Windows 文件、剪贴板和网络——请检查网关的配置。</value>
@@ -6658,5 +6646,71 @@
   </data>
   <data name="ConnectionPage_RemoteSetupHelpAuthTitle.Text" xml:space="preserve">
     <value>身份验证</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_Title.Text" xml:space="preserve">
+    <value>Connection</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_OpenConnection.Content" xml:space="preserve">
+    <value>Open Connection</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_GatewayLabel.Text" xml:space="preserve">
+    <value>Gateway</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_Reconnect.Content" xml:space="preserve">
+    <value>Reconnect</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_OperatorLabel.Text" xml:space="preserve">
+    <value>Operator</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_NodeLabel.Text" xml:space="preserve">
+    <value>Node</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_Approve.Content" xml:space="preserve">
+    <value>Approve…</value>
+  </data>
+  <data name="HubWindow_StatusPill_Tooltip" xml:space="preserve">
+    <value>Connection status</value>
+  </data>
+  <data name="HubWindow_Bell_Tooltip" xml:space="preserve">
+    <value>Notifications</value>
+  </data>
+  <data name="HubWindow_Pill_Ready" xml:space="preserve">
+    <value>Ready</value>
+  </data>
+  <data name="HubWindow_Pill_PairingRequired" xml:space="preserve">
+    <value>Pairing required</value>
+  </data>
+  <data name="HubWindow_Pill_Degraded" xml:space="preserve">
+    <value>Degraded</value>
+  </data>
+  <data name="HubWindow_Role_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="HubWindow_Role_PairingRequired" xml:space="preserve">
+    <value>Pairing required</value>
+  </data>
+  <data name="HubWindow_Role_PairingRejected" xml:space="preserve">
+    <value>Pairing rejected</value>
+  </data>
+  <data name="HubWindow_Role_RateLimited" xml:space="preserve">
+    <value>Rate limited</value>
+  </data>
+  <data name="HubWindow_Role_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="NotificationsFlyout_ClearAll.Content" xml:space="preserve">
+    <value>Clear all</value>
+  </data>
+  <data name="NotificationsFlyout_EmptyTitle.Text" xml:space="preserve">
+    <value>No notifications</value>
+  </data>
+  <data name="NotificationsFlyout_OpenPage.Content" xml:space="preserve">
+    <value>Open notifications</value>
+  </data>
+  <data name="NotificationsFlyout_ActiveCountFormat" xml:space="preserve">
+    <value>{0} active</value>
+  </data>
+  <data name="HubWindow_Role_PermissionsIncomplete" xml:space="preserve">
+    <value>Permissions incomplete</value>
   </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2376,9 +2376,6 @@
   <data name="HubWindow_NavigationViewItem_145.Content" xml:space="preserve">
     <value>偵錯</value>
   </data>
-  <data name="HubWindow_NavigationViewItem_Notifications.Content" xml:space="preserve">
-    <value>通知</value>
-  </data>
   <data name="HubWindow_NavigationViewItem_148.Content" xml:space="preserve">
     <value>資訊</value>
   </data>
@@ -4981,12 +4978,6 @@
   <data name="HubWindow_Disconnected.Text" xml:space="preserve">
     <value>已中斷連線</value>
   </data>
-  <data name="HubWindow_Op.Text" xml:space="preserve">
-    <value>操作</value>
-  </data>
-  <data name="HubWindow_Node.Text" xml:space="preserve">
-    <value>節點</value>
-  </data>
   <data name="HubWindow_Advanced.Content" xml:space="preserve">
     <value>進階</value>
   </data>
@@ -5016,9 +5007,6 @@
   </data>
   <data name="VoiceSettingsPage_PreviewVoice.Text" xml:space="preserve">
     <value>語音預覽</value>
-  </data>
-  <data name="HubWindow_TitleStatus.Text" xml:space="preserve">
-    <value>已中斷連線</value>
   </data>
   <data name="SandboxPage_GatewayCommandsNote.Text" xml:space="preserve">
     <value>代理直接在閘道上執行的命令不受此限制。如果閘道在此電腦上，它們仍可能存取您的 Windows 檔案、剪貼簿和網路——請檢查閘道的設定。</value>
@@ -6658,5 +6646,71 @@
   </data>
   <data name="ConnectionPage_RemoteSetupHelpAuthTitle.Text" xml:space="preserve">
     <value>驗證</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_Title.Text" xml:space="preserve">
+    <value>Connection</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_OpenConnection.Content" xml:space="preserve">
+    <value>Open Connection</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_GatewayLabel.Text" xml:space="preserve">
+    <value>Gateway</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_Reconnect.Content" xml:space="preserve">
+    <value>Reconnect</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_OperatorLabel.Text" xml:space="preserve">
+    <value>Operator</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_NodeLabel.Text" xml:space="preserve">
+    <value>Node</value>
+  </data>
+  <data name="HubWindow_StatusFlyout_Approve.Content" xml:space="preserve">
+    <value>Approve…</value>
+  </data>
+  <data name="HubWindow_StatusPill_Tooltip" xml:space="preserve">
+    <value>Connection status</value>
+  </data>
+  <data name="HubWindow_Bell_Tooltip" xml:space="preserve">
+    <value>Notifications</value>
+  </data>
+  <data name="HubWindow_Pill_Ready" xml:space="preserve">
+    <value>Ready</value>
+  </data>
+  <data name="HubWindow_Pill_PairingRequired" xml:space="preserve">
+    <value>Pairing required</value>
+  </data>
+  <data name="HubWindow_Pill_Degraded" xml:space="preserve">
+    <value>Degraded</value>
+  </data>
+  <data name="HubWindow_Role_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="HubWindow_Role_PairingRequired" xml:space="preserve">
+    <value>Pairing required</value>
+  </data>
+  <data name="HubWindow_Role_PairingRejected" xml:space="preserve">
+    <value>Pairing rejected</value>
+  </data>
+  <data name="HubWindow_Role_RateLimited" xml:space="preserve">
+    <value>Rate limited</value>
+  </data>
+  <data name="HubWindow_Role_Disabled" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="NotificationsFlyout_ClearAll.Content" xml:space="preserve">
+    <value>Clear all</value>
+  </data>
+  <data name="NotificationsFlyout_EmptyTitle.Text" xml:space="preserve">
+    <value>No notifications</value>
+  </data>
+  <data name="NotificationsFlyout_OpenPage.Content" xml:space="preserve">
+    <value>Open notifications</value>
+  </data>
+  <data name="NotificationsFlyout_ActiveCountFormat" xml:space="preserve">
+    <value>{0} active</value>
+  </data>
+  <data name="HubWindow_Role_PermissionsIncomplete" xml:space="preserve">
+    <value>Permissions incomplete</value>
   </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/ViewModels/NotificationItemViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/ViewModels/NotificationItemViewModel.cs
@@ -1,0 +1,90 @@
+using Microsoft.UI.Xaml;
+using OpenClawTray.Helpers;
+using OpenClawTray.Services;
+using System.Globalization;
+using System.Linq;
+
+namespace OpenClawTray.ViewModels;
+
+/// <summary>
+/// Presentation model for a single app notification card. Shared by the
+/// full <c>NotificationsPage</c> and the title-bar notifications bell flyout
+/// so severity glyphs and metadata localization stay defined in one place.
+/// </summary>
+internal sealed record NotificationItemViewModel(
+    string Id,
+    string SeverityGlyph,
+    string Title,
+    string Message,
+    string Metadata,
+    string? ActionLabel,
+    string? ActionRoute,
+    Visibility ActionVisibility,
+    string OccurrenceText,
+    Visibility OccurrenceVisibility,
+    string DismissAutomationName)
+{
+    public static NotificationItemViewModel From(AppNotification notification)
+    {
+        var metadata = new[]
+            {
+                LocalizeMetadataValue(notification.Source),
+                LocalizeMetadataValue(notification.Category),
+                notification.CreatedAt.ToLocalTime().ToString("g", CultureInfo.CurrentCulture)
+            }
+            .Where(value => !string.IsNullOrWhiteSpace(value));
+
+        var occurrenceText = LocalizationHelper.Format(
+            "AppNotification_RepeatedBadgeFormat",
+            notification.OccurrenceCount);
+
+        return new(
+            notification.Id,
+            ToSeverityGlyph(notification.Severity),
+            notification.Title,
+            notification.Message,
+            string.Join(" - ", metadata),
+            notification.ActionLabel,
+            notification.ActionRoute,
+            !string.IsNullOrWhiteSpace(notification.ActionLabel) &&
+            !string.IsNullOrWhiteSpace(notification.ActionRoute)
+                ? Visibility.Visible
+                : Visibility.Collapsed,
+            occurrenceText,
+            notification.OccurrenceCount > 1 ? Visibility.Visible : Visibility.Collapsed,
+            LocalizationHelper.Format("NotificationsPage_DismissAutomationNameFormat", notification.Title));
+    }
+
+    private static string ToSeverityGlyph(AppNotificationSeverity severity) => severity switch
+    {
+        AppNotificationSeverity.Success => "\uE930",
+        AppNotificationSeverity.Warning => "\uE7BA",
+        AppNotificationSeverity.Error => "\uE783",
+        _ => "\uE946"
+    };
+
+    private static string? LocalizeMetadataValue(string? value) => value switch
+    {
+        null or "" => null,
+        "authentication" => LocalizationHelper.GetString("NotificationsPage_MetadataAuthentication"),
+        "bindings" => LocalizationHelper.GetString("NotificationsPage_MetadataBindings"),
+        "channels" => LocalizationHelper.GetString("NotificationsPage_MetadataChannels"),
+        "config" => LocalizationHelper.GetString("NotificationsPage_MetadataConfig"),
+        "connection" => LocalizationHelper.GetString("NotificationsPage_MetadataConnection"),
+        "cron" => LocalizationHelper.GetString("NotificationsPage_MetadataCron"),
+        "exec-approval" => LocalizationHelper.GetString("NotificationsPage_MetadataSourceExecApproval"),
+        "gateway" => LocalizationHelper.GetString("NotificationsPage_MetadataGateway"),
+        "jobs" => LocalizationHelper.GetString("NotificationsPage_MetadataJobs"),
+        "load" => LocalizationHelper.GetString("NotificationsPage_MetadataLoad"),
+        "lifecycle" => LocalizationHelper.GetString("NotificationsPage_MetadataLifecycle"),
+        "local-gateway" => LocalizationHelper.GetString("NotificationsPage_MetadataLocalGateway"),
+        "node.invoke" => LocalizationHelper.GetString("NotificationsPage_MetadataCategoryNodeInvoke"),
+        "node" => LocalizationHelper.GetString("NotificationsPage_MetadataNode"),
+        "pairing" => LocalizationHelper.GetString("NotificationsPage_MetadataPairing"),
+        "sandbox" => LocalizationHelper.GetString("NotificationsPage_MetadataSandbox"),
+        "settings" => LocalizationHelper.GetString("NotificationsPage_MetadataSettings"),
+        "status" => LocalizationHelper.GetString("NotificationsPage_MetadataStatus"),
+        "system.run" => LocalizationHelper.GetString("NotificationsPage_MetadataSystemRun"),
+        _ => value
+    };
+}

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
@@ -90,26 +90,240 @@
                 </AutoSuggestBox.ItemTemplate>
             </AutoSuggestBox>
 
-            <!-- Status indicator on the right (clickable → navigates to Connection page) -->
-            <StackPanel Grid.Column="4" Orientation="Horizontal" Spacing="12" VerticalAlignment="Center"
-                        Tapped="OnTitleBarStatusTapped">
-                <StackPanel Orientation="Horizontal" Spacing="6">
-                    <Ellipse x:Name="TitleStatusDot" Width="8" Height="8" VerticalAlignment="Center" Fill="Gray"/>
-                    <TextBlock x:Uid="HubWindow_TitleStatus" x:Name="TitleStatusText" Text="Disconnected"
-                               FontSize="11" VerticalAlignment="Center" MinWidth="80"
-                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                </StackPanel>
-                <Border Background="{ThemeResource DividerStrokeColorDefaultBrush}" Width="1" Height="14" VerticalAlignment="Center"/>
-                <StackPanel Orientation="Horizontal" Spacing="4">
-                    <Ellipse x:Name="TitleOpDot" Width="6" Height="6" VerticalAlignment="Center" Fill="Gray"/>
-                    <TextBlock x:Uid="HubWindow_Op" x:Name="TitleOpLabel" Text="Op" FontSize="10" VerticalAlignment="Center"
-                               Foreground="{ThemeResource TextFillColorTertiaryBrush}"/>
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" Spacing="4">
-                    <Ellipse x:Name="TitleNodeDot" Width="6" Height="6" VerticalAlignment="Center" Fill="Gray"/>
-                    <TextBlock x:Uid="HubWindow_Node" x:Name="TitleNodeLabel" Text="Node" FontSize="10" VerticalAlignment="Center"
-                               Foreground="{ThemeResource TextFillColorTertiaryBrush}"/>
-                </StackPanel>
+            <StackPanel Grid.Column="4" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+
+                <Button x:Name="StatusPillButton"
+                        Height="30"
+                        Padding="11,0"
+                        CornerRadius="15"
+                        VerticalAlignment="Center"
+                        AutomationProperties.Name="Connection status">
+                    <StackPanel Orientation="Horizontal" Spacing="7" VerticalAlignment="Center">
+                        <Ellipse x:Name="StatusPillDot" Width="10" Height="10" VerticalAlignment="Center" Fill="Gray"/>
+                        <TextBlock x:Name="StatusPillText" Text="Disconnected"
+                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                   VerticalAlignment="Center"/>
+                        <FontIcon Glyph="&#xE70D;" FontSize="8" VerticalAlignment="Center"
+                                  Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                                  FontFamily="{ThemeResource SymbolThemeFontFamily}"/>
+                    </StackPanel>
+                    <Button.Flyout>
+                        <Flyout x:Name="StatusFlyout" Placement="Bottom" Opening="OnStatusFlyoutOpening">
+                            <StackPanel Width="304" Spacing="0">
+                                <Grid Padding="0,0,0,10" ColumnSpacing="11">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Ellipse x:Name="GatewayRowDot" Width="10" Height="10" VerticalAlignment="Center" Fill="Gray"/>
+                                    <StackPanel Grid.Column="1" Spacing="1">
+                                        <TextBlock x:Uid="HubWindow_StatusFlyout_GatewayLabel" Text="Gateway"
+                                                   Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                        <TextBlock x:Name="GatewayRowDetail" Text=""
+                                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                    </StackPanel>
+                                    <HyperlinkButton x:Name="GatewayRowAction" x:Uid="HubWindow_StatusFlyout_Reconnect"
+                                                     Grid.Column="2" Content="Reconnect"
+                                                     Padding="4,0" VerticalAlignment="Center"
+                                                     Visibility="Collapsed"
+                                                     Click="OnStatusFlyoutReconnectClick"/>
+                                </Grid>
+                                <Border Height="1" Background="{ThemeResource CardStrokeColorDefaultBrush}"/>
+
+                                <Grid Padding="0,10" ColumnSpacing="11">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Ellipse x:Name="OperatorRowDot" Width="10" Height="10" VerticalAlignment="Center" Fill="Gray"/>
+                                    <StackPanel Grid.Column="1" Spacing="1">
+                                        <TextBlock x:Uid="HubWindow_StatusFlyout_OperatorLabel" Text="Operator"
+                                                   Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                        <TextBlock x:Name="OperatorRowDetail" Text=""
+                                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                    </StackPanel>
+                                </Grid>
+                                <Border Height="1" Background="{ThemeResource CardStrokeColorDefaultBrush}"/>
+
+                                <Grid Padding="0,10" ColumnSpacing="11">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Ellipse x:Name="NodeRowDot" Width="10" Height="10" VerticalAlignment="Center" Fill="Gray"/>
+                                    <StackPanel Grid.Column="1" Spacing="1">
+                                        <TextBlock x:Uid="HubWindow_StatusFlyout_NodeLabel" Text="Node"
+                                                   Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                        <TextBlock x:Name="NodeRowDetail" Text=""
+                                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                    </StackPanel>
+                                    <HyperlinkButton x:Name="NodeRowAction" x:Uid="HubWindow_StatusFlyout_Approve"
+                                                     Grid.Column="2" Content="Approve…"
+                                                     Padding="4,0" VerticalAlignment="Center"
+                                                     Visibility="Collapsed"
+                                                     Click="OnStatusFlyoutNodeActionClick"/>
+                                </Grid>
+
+                                <Border Height="1" Background="{ThemeResource CardStrokeColorDefaultBrush}"/>
+                                <HyperlinkButton x:Uid="HubWindow_StatusFlyout_OpenConnection"
+                                                 Content="Open Connection"
+                                                 Margin="2,8,2,0" Padding="4,0"
+                                                 Click="OnStatusFlyoutOpenConnectionClick"/>
+                            </StackPanel>
+                        </Flyout>
+                    </Button.Flyout>
+                </Button>
+
+                <Button x:Name="NotificationsBellButton"
+                        MinWidth="36" Height="30"
+                        Padding="0"
+                        VerticalAlignment="Center"
+                        AutomationProperties.Name="Notifications">
+                    <Grid>
+                        <FontIcon Glyph="&#xE7E7;" FontSize="16"
+                                  FontFamily="{ThemeResource SymbolThemeFontFamily}"/>
+                        <InfoBadge x:Name="NotificationsBadge"
+                                   Value="0"
+                                   Visibility="Collapsed"
+                                   HorizontalAlignment="Right" VerticalAlignment="Top"
+                                   Margin="0,-6,-8,0"/>
+                    </Grid>
+                    <Button.Flyout>
+                        <Flyout x:Name="NotificationsFlyout" Placement="Bottom" Opening="OnNotificationsFlyoutOpening">
+                            <Grid Width="352" MaxHeight="440" RowSpacing="0">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+
+                                <Grid Grid.Row="0" Margin="2,0,2,8">
+                                    <HyperlinkButton x:Name="BellClearAllButton" x:Uid="NotificationsFlyout_ClearAll"
+                                                     Content="Clear all"
+                                                     HorizontalAlignment="Right"
+                                                     Padding="4,0" VerticalAlignment="Center"
+                                                     Click="OnBellClearAllClick"/>
+                                </Grid>
+
+                                <ListView x:Name="BellNotificationsList"
+                                          Grid.Row="1"
+                                          SelectionMode="None"
+                                          IsItemClickEnabled="False"
+                                          Padding="0"
+                                          Margin="-4,0">
+                                    <ListView.ItemContainerStyle>
+                                        <Style TargetType="ListViewItem">
+                                            <Setter Property="Padding" Value="0"/>
+                                            <Setter Property="Margin" Value="0"/>
+                                            <Setter Property="MinHeight" Value="0"/>
+                                            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                        </Style>
+                                    </ListView.ItemContainerStyle>
+                                    <ListView.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                                    BorderThickness="1"
+                                                    CornerRadius="8"
+                                                    Padding="12"
+                                                    Margin="4,4,4,4">
+                                                <Grid ColumnSpacing="11">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <FontIcon Grid.Column="0"
+                                                              Glyph="{Binding SeverityGlyph}"
+                                                              FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                              FontSize="16"
+                                                              VerticalAlignment="Top"
+                                                              Margin="0,2,0,0"/>
+                                                    <StackPanel Grid.Column="1" Spacing="3">
+                                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                                            <TextBlock Text="{Binding Title}"
+                                                                       Style="{StaticResource BodyStrongTextBlockStyle}"
+                                                                       TextWrapping="WrapWholeWords"/>
+                                                            <Border Visibility="{Binding OccurrenceVisibility}"
+                                                                    Background="{ThemeResource SystemFillColorCautionBackgroundBrush}"
+                                                                    CornerRadius="10"
+                                                                    Padding="7,1"
+                                                                    VerticalAlignment="Center">
+                                                                <TextBlock Text="{Binding OccurrenceText}"
+                                                                           Style="{StaticResource CaptionTextBlockStyle}"/>
+                                                            </Border>
+                                                        </StackPanel>
+                                                        <TextBlock Text="{Binding Message}"
+                                                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                                                   TextWrapping="WrapWholeWords"/>
+                                                        <TextBlock Text="{Binding Metadata}"
+                                                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                                    </StackPanel>
+                                                    <Button Grid.Column="2"
+                                                            Tag="{Binding Id}"
+                                                            AutomationProperties.Name="{Binding DismissAutomationName}"
+                                                            Padding="6"
+                                                            MinWidth="30" MinHeight="30"
+                                                            VerticalAlignment="Top"
+                                                            Background="Transparent"
+                                                            BorderThickness="0"
+                                                            Click="OnBellDismissNotificationClick">
+                                                        <FontIcon Glyph="&#xE711;"
+                                                                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                                  FontSize="11"/>
+                                                    </Button>
+                                                </Grid>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ListView.ItemTemplate>
+                                </ListView>
+
+                                <Border x:Name="BellEmptyState"
+                                        Grid.Row="1"
+                                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                        BorderThickness="1"
+                                        CornerRadius="8"
+                                        Padding="20"
+                                        Margin="0,4"
+                                        VerticalAlignment="Top">
+                                    <StackPanel Spacing="6">
+                                        <TextBlock x:Uid="NotificationsFlyout_EmptyTitle"
+                                                   Text="No notifications"
+                                                   Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                                        <TextBlock x:Uid="NotificationsPage_EmptyDescription"
+                                                   Text="New app notifications will appear here until you dismiss or clear them."
+                                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                   TextWrapping="WrapWholeWords"/>
+                                    </StackPanel>
+                                </Border>
+
+                                <Grid Grid.Row="2" Margin="2,8,2,0" ColumnSpacing="8">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <HyperlinkButton x:Uid="NotificationsFlyout_OpenPage"
+                                                     Content="Open notifications"
+                                                     Padding="4,0" VerticalAlignment="Center"
+                                                     Click="OnBellOpenPageClick"/>
+                                    <TextBlock x:Name="BellActiveCountText" Grid.Column="1" Text=""
+                                               Style="{StaticResource CaptionTextBlockStyle}"
+                                               Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                                               VerticalAlignment="Center"/>
+                                </Grid>
+                            </Grid>
+                        </Flyout>
+                    </Button.Flyout>
+                </Button>
             </StackPanel>
         </Grid>
 
@@ -269,9 +483,6 @@
         </NavigationView.MenuItems>
 
         <NavigationView.FooterMenuItems>
-            <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_Notifications" Tag="notifications" Content="Notifications">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Notifications_Icon}"/></NavigationViewItem.Icon>
-            </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_145" Tag="debug" Content="Debug">
                 <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Debug_Icon}"/></NavigationViewItem.Icon>
             </NavigationViewItem>

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -3,12 +3,16 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using OpenClaw.Connection;
 using OpenClaw.Shared;
 using OpenClawTray.Helpers;
 using OpenClawTray.Pages;
 using OpenClawTray.Services;
+using OpenClawTray.ViewModels;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using WinUIEx;
@@ -37,6 +41,9 @@ public sealed partial class HubWindow : WindowEx
     private AppNotification? _currentAppNotification;
     private bool _suppressAppNotificationClosed;
     private bool _appNotificationActionShowsMore;
+
+    private readonly ObservableCollection<NotificationItemViewModel> _bellItems = new();
+    private bool _bellListBound;
 
     // Legacy compatibility alias
     public string SelectedAgentId => _currentAgentId;
@@ -108,6 +115,9 @@ public sealed partial class HubWindow : WindowEx
         this.SetIcon(IconHelper.GetStatusIconPath(ConnectionStatus.Connected));
 
         RootGrid.SizeChanged += OnRootGridSizeChanged;
+
+        ToolTipService.SetToolTip(StatusPillButton, LocalizationHelper.GetString("HubWindow_StatusPill_Tooltip"));
+        ToolTipService.SetToolTip(NotificationsBellButton, LocalizationHelper.GetString("HubWindow_Bell_Tooltip"));
     }
 
     /// <summary>
@@ -150,12 +160,22 @@ public sealed partial class HubWindow : WindowEx
     private void RenderAppNotification(AppNotificationSnapshot snapshot)
     {
         _lastAppNotificationSnapshot = snapshot;
+
+        UpdateNotificationsBell(snapshot);
+
+        var bannerActive = snapshot.ActiveNotifications
+            .Where(n => IsBannerSeverity(n.Severity))
+            .ToList();
+        var bannerSnapshot = bannerActive.Count == snapshot.ActiveNotifications.Count
+            ? snapshot
+            : snapshot with { ActiveNotifications = bannerActive };
+
         var displayedNotificationWasRemoved = _currentAppNotification is not null
             && AppNotificationInfoBar.IsOpen
-            && !snapshot.ActiveNotifications.Any(notification =>
+            && !bannerSnapshot.ActiveNotifications.Any(notification =>
                 string.Equals(notification.Id, _currentAppNotification.Id, StringComparison.Ordinal));
         _currentAppNotification = _appNotificationBannerState.SelectVisibleNotification(
-            snapshot,
+            bannerSnapshot,
             revealHiddenIfNeeded: displayedNotificationWasRemoved);
         if (_currentAppNotification is null)
         {
@@ -169,11 +189,6 @@ public sealed partial class HubWindow : WindowEx
         AppNotificationInfoBar.Title = string.Empty;
         AppNotificationInfoBar.Message = string.Empty;
 
-        // Single-line compact banner: bold headline + regular detail on one
-        // line (e.g. "Gateway connection failed — Transport error"). The bold
-        // run gives the headline scannability without adding a second row.
-        // Full detail/troubleshooting still lives on the surface the action
-        // routes to (e.g. the Connection page).
         AppNotificationMessageText.Inlines.Clear();
         AppNotificationMessageText.Inlines.Add(new Run
         {
@@ -246,6 +261,197 @@ public sealed partial class HubWindow : WindowEx
         AppNotificationSeverity.Error => InfoBarSeverity.Error,
         _ => InfoBarSeverity.Informational
     };
+
+    private static bool IsBannerSeverity(AppNotificationSeverity severity) =>
+        severity is AppNotificationSeverity.Error or AppNotificationSeverity.Warning;
+
+    private void UpdateNotificationsBell(AppNotificationSnapshot snapshot)
+    {
+        var count = snapshot.ActiveNotifications.Count;
+
+        if (NotificationsBadge is not null)
+        {
+            NotificationsBadge.Value = count;
+            NotificationsBadge.Visibility = count > 0 ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        SyncBellItems(snapshot.ActiveNotifications.Select(NotificationItemViewModel.From).ToList());
+
+        SyncBellFlyoutEmptyState();
+    }
+
+    private void SyncBellItems(IReadOnlyList<NotificationItemViewModel> desiredItems)
+    {
+        var desiredIds = desiredItems
+            .Select(item => item.Id)
+            .ToHashSet(StringComparer.Ordinal);
+
+        for (var i = _bellItems.Count - 1; i >= 0; i--)
+        {
+            if (!desiredIds.Contains(_bellItems[i].Id))
+                _bellItems.RemoveAt(i);
+        }
+
+        for (var i = 0; i < desiredItems.Count; i++)
+        {
+            var item = desiredItems[i];
+            if (i < _bellItems.Count && string.Equals(_bellItems[i].Id, item.Id, StringComparison.Ordinal))
+            {
+                if (!_bellItems[i].Equals(item))
+                    _bellItems[i] = item;
+                continue;
+            }
+
+            var existingIndex = -1;
+            for (var j = i + 1; j < _bellItems.Count; j++)
+            {
+                if (string.Equals(_bellItems[j].Id, item.Id, StringComparison.Ordinal))
+                {
+                    existingIndex = j;
+                    break;
+                }
+            }
+
+            if (existingIndex >= 0)
+            {
+                _bellItems.Move(existingIndex, i);
+                if (!_bellItems[i].Equals(item))
+                    _bellItems[i] = item;
+            }
+            else
+            {
+                _bellItems.Insert(i, item);
+            }
+        }
+    }
+
+    private void SyncBellFlyoutEmptyState()
+    {
+        var hasItems = _bellItems.Count > 0;
+
+        if (BellNotificationsList is not null)
+            BellNotificationsList.Visibility = hasItems ? Visibility.Visible : Visibility.Collapsed;
+        if (BellEmptyState is not null)
+            BellEmptyState.Visibility = hasItems ? Visibility.Collapsed : Visibility.Visible;
+        if (BellClearAllButton is not null)
+            BellClearAllButton.Visibility = hasItems ? Visibility.Visible : Visibility.Collapsed;
+        if (BellActiveCountText is not null)
+            BellActiveCountText.Text = hasItems
+                ? LocalizationHelper.Format("NotificationsFlyout_ActiveCountFormat", _bellItems.Count)
+                : string.Empty;
+    }
+
+    private void OnNotificationsFlyoutOpening(object sender, object e)
+    {
+        if (BellNotificationsList is not null && !_bellListBound)
+        {
+            BellNotificationsList.ItemsSource = _bellItems;
+            _bellListBound = true;
+        }
+        SyncBellFlyoutEmptyState();
+    }
+
+    private void OnBellClearAllClick(object sender, RoutedEventArgs e)
+        => _appNotificationService?.ClearAll();
+
+    private void OnBellDismissNotificationClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { Tag: string notificationId })
+            _appNotificationService?.Dismiss(notificationId);
+    }
+
+    private void OnBellOpenPageClick(object sender, RoutedEventArgs e)
+    {
+        NotificationsFlyout.Hide();
+        NavigateTo("notifications");
+    }
+
+    private void OnStatusFlyoutOpening(object sender, object e)
+    {
+        var snapshot = CurrentApp.ConnectionManager?.CurrentSnapshot;
+        var settings = CurrentApp.Settings;
+        var nodeEnabled = settings?.EnableNodeMode == true;
+        var enabledCapabilities = CountEnabledCapabilities(settings);
+        var op = snapshot?.OperatorState ?? RoleConnectionState.Idle;
+
+        GatewayRowDot.Fill = AccentBrush(ConnectionStatusPresenter.RoleAccent(op));
+        GatewayRowDetail.Text = BuildGatewayDetail(snapshot);
+        GatewayRowAction.Visibility =
+            op is RoleConnectionState.Connected or RoleConnectionState.Connecting
+                ? Visibility.Collapsed
+                : Visibility.Visible;
+
+        OperatorRowDot.Fill = AccentBrush(ConnectionStatusPresenter.RoleAccent(op));
+        OperatorRowDetail.Text = LocalizationHelper.GetString(
+            ConnectionStatusPresenter.RoleStateLabelKey(op));
+
+        if (snapshot is not null)
+        {
+            var (nodeKey, nodeAccent) = ConnectionStatusPresenter.NodeRow(snapshot, nodeEnabled, enabledCapabilities);
+            NodeRowDot.Fill = AccentBrush(nodeAccent);
+            NodeRowDetail.Text = LocalizationHelper.GetString(nodeKey);
+            NodeRowAction.Visibility = ConnectionStatusPresenter.NodeNeedsApproval(snapshot, nodeEnabled)
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+        }
+        else
+        {
+            NodeRowDot.Fill = AccentBrush(ConnectionStatusAccent.Neutral);
+            NodeRowDetail.Text = LocalizationHelper.GetString("HubWindow_Role_Disabled");
+            NodeRowAction.Visibility = Visibility.Collapsed;
+        }
+    }
+
+    private string BuildGatewayDetail(GatewayConnectionSnapshot? snapshot)
+    {
+        var parts = new List<string>();
+        if (!string.IsNullOrWhiteSpace(snapshot?.GatewayName))
+            parts.Add(snapshot!.GatewayName!);
+        if (!string.IsNullOrWhiteSpace(snapshot?.GatewayUrl))
+            parts.Add(snapshot!.GatewayUrl!);
+        if (LastGatewaySelf is { ServerVersion: { Length: > 0 } ver })
+            parts.Add($"v{ver}");
+        return parts.Count > 0
+            ? string.Join(" · ", parts)
+            : LocalizationHelper.GetString("StatusDisplay_Disconnected");
+    }
+
+    private static int CountEnabledCapabilities(SettingsManager? settings)
+    {
+        if (settings is null) return 0;
+
+        var count = 0;
+        if (settings.NodeBrowserProxyEnabled) count++;
+        if (settings.NodeCameraEnabled) count++;
+        if (settings.NodeCanvasEnabled) count++;
+        if (settings.NodeScreenEnabled) count++;
+        if (settings.NodeLocationEnabled) count++;
+        if (settings.NodeTtsEnabled) count++;
+        if (settings.NodeSttEnabled) count++;
+        return count;
+    }
+
+    private void OnStatusFlyoutOpenConnectionClick(object sender, RoutedEventArgs e)
+    {
+        StatusFlyout.Hide();
+        NavigateTo("connection");
+    }
+
+    private void OnStatusFlyoutReconnectClick(object sender, RoutedEventArgs e)
+    {
+        StatusFlyout.Hide();
+        if (ReconnectAction is not null)
+            ReconnectAction.Invoke();
+        else
+            ConnectAction?.Invoke();
+    }
+
+    private void OnStatusFlyoutNodeActionClick(object sender, RoutedEventArgs e)
+    {
+        StatusFlyout.Hide();
+        NavigateTo("connection");
+    }
+
 
     private void OnAppNotificationInfoBarClosed(InfoBar sender, InfoBarClosedEventArgs args)
     {
@@ -364,11 +570,6 @@ public sealed partial class HubWindow : WindowEx
     private void OnNavContentHostSizeChanged(object sender, SizeChangedEventArgs e)
     {
         NavContentClip.Rect = new global::Windows.Foundation.Rect(0, 0, e.NewSize.Width, e.NewSize.Height);
-    }
-
-    private void OnTitleBarStatusTapped(object sender, Microsoft.UI.Xaml.Input.TappedRoutedEventArgs e)
-    {
-        NavigateTo("connection");
     }
 
     private void OnNavPaneToggleButtonClick(object sender, RoutedEventArgs e)
@@ -498,6 +699,14 @@ public sealed partial class HubWindow : WindowEx
             _syncingNavSelection = true;
             try { NavView.SelectedItem = item; }
             finally { _syncingNavSelection = false; }
+            return;
+        }
+
+        if (item == null && NavView.SelectedItem != null)
+        {
+            _syncingNavSelection = true;
+            try { NavView.SelectedItem = null; }
+            finally { _syncingNavSelection = false; }
         }
     }
 
@@ -535,51 +744,49 @@ public sealed partial class HubWindow : WindowEx
 
     private void UpdateTitleBarStatus(ConnectionStatus status)
     {
-        var color = status switch
-        {
-            ConnectionStatus.Connected => Microsoft.UI.Colors.LimeGreen,
-            ConnectionStatus.Connecting => Microsoft.UI.Colors.Orange,
-            ConnectionStatus.Error => Microsoft.UI.Colors.Red,
-            _ => Microsoft.UI.Colors.Gray
-        };
-
-        TitleStatusDot.Fill = new Microsoft.UI.Xaml.Media.SolidColorBrush(color);
-
-        // Build status text with version when connected
-        if (status == ConnectionStatus.Connected && LastGatewaySelf is { ServerVersion: { Length: > 0 } ver })
-            TitleStatusText.Text = $"v{ver}";
-        else
-            TitleStatusText.Text = LocalizationHelper.GetConnectionStatusText(status);
-
-        // Update role indicator dots
         var snapshot = CurrentApp.ConnectionManager?.CurrentSnapshot;
-        if (snapshot != null)
-        {
-            TitleOpDot.Fill = RoleDotBrush(snapshot.OperatorState);
-            TitleNodeDot.Fill = RoleDotBrush(snapshot.NodeState);
-        }
-        else
-        {
-            var gray = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Gray);
-            TitleOpDot.Fill = gray;
-            TitleNodeDot.Fill = gray;
-        }
+        var (text, accent) = ComputePillState(status, snapshot);
+        StatusPillText.Text = text;
+        StatusPillDot.Fill = AccentBrush(accent);
     }
 
-    private static Microsoft.UI.Xaml.Media.SolidColorBrush RoleDotBrush(OpenClaw.Connection.RoleConnectionState state) => state switch
+    private static (string Text, ConnectionStatusAccent Accent) ComputePillState(
+        ConnectionStatus status, GatewayConnectionSnapshot? snapshot)
     {
-        OpenClaw.Connection.RoleConnectionState.Connected =>
-            new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.LimeGreen),
-        OpenClaw.Connection.RoleConnectionState.Connecting =>
-            new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Orange),
-        OpenClaw.Connection.RoleConnectionState.PairingRequired =>
-            new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Orange),
-        OpenClaw.Connection.RoleConnectionState.Error or
-        OpenClaw.Connection.RoleConnectionState.PairingRejected or
-        OpenClaw.Connection.RoleConnectionState.RateLimited =>
-            new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Red),
-        _ => new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Gray),
+        if (snapshot is not null)
+        {
+            var (labelKey, accent) = ConnectionStatusPresenter.Pill(snapshot.OverallState);
+            return (LocalizationHelper.GetString(labelKey), accent);
+        }
+
+        return status switch
+        {
+            ConnectionStatus.Connected => (LocalizationHelper.GetString("StatusDisplay_Connected"), ConnectionStatusAccent.Success),
+            ConnectionStatus.Connecting => (LocalizationHelper.GetString("StatusDisplay_Connecting"), ConnectionStatusAccent.Caution),
+            ConnectionStatus.Error => (LocalizationHelper.GetString("StatusDisplay_Error"), ConnectionStatusAccent.Critical),
+            _ => (LocalizationHelper.GetString("StatusDisplay_Disconnected"), ConnectionStatusAccent.Neutral),
+        };
+    }
+
+    private static string AccentBrushKey(ConnectionStatusAccent accent) => accent switch
+    {
+        ConnectionStatusAccent.Success => "SystemFillColorSuccessBrush",
+        ConnectionStatusAccent.Caution => "SystemFillColorCautionBrush",
+        ConnectionStatusAccent.Critical => "SystemFillColorCriticalBrush",
+        _ => "SystemFillColorNeutralBrush",
     };
+
+    private static Brush AccentBrush(ConnectionStatusAccent accent)
+    {
+        var resources = Application.Current.Resources;
+        if (resources.TryGetValue(AccentBrushKey(accent), out var brush) && brush is Brush typed)
+            return typed;
+
+        if (resources.TryGetValue("SystemFillColorNeutralBrush", out var neutral) && neutral is Brush fallback)
+            return fallback;
+
+        return new SolidColorBrush(Microsoft.UI.Colors.Transparent);
+    }
 
     private void ScheduleGatewayNavVisibilityForStatus(ConnectionStatus status, bool debounceDisconnected)
     {

--- a/tests/OpenClaw.Tray.Tests/ConnectionStatusPresenterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ConnectionStatusPresenterTests.cs
@@ -1,0 +1,138 @@
+using OpenClaw.Connection;
+using OpenClawTray.Services;
+using System.Xml.Linq;
+using Xunit;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class ConnectionStatusPresenterTests
+{
+    [Theory]
+    [InlineData(OverallConnectionState.Connected, "StatusDisplay_Connected", (int)ConnectionStatusAccent.Success)]
+    [InlineData(OverallConnectionState.Ready, "StatusDisplay_Connected", (int)ConnectionStatusAccent.Success)]
+    [InlineData(OverallConnectionState.Connecting, "StatusDisplay_Connecting", (int)ConnectionStatusAccent.Caution)]
+    [InlineData(OverallConnectionState.Degraded, "HubWindow_Pill_Degraded", (int)ConnectionStatusAccent.Caution)]
+    [InlineData(OverallConnectionState.PairingRequired, "HubWindow_Pill_PairingRequired", (int)ConnectionStatusAccent.Caution)]
+    [InlineData(OverallConnectionState.Error, "StatusDisplay_Error", (int)ConnectionStatusAccent.Critical)]
+    [InlineData(OverallConnectionState.Idle, "StatusDisplay_Disconnected", (int)ConnectionStatusAccent.Neutral)]
+    [InlineData(OverallConnectionState.Disconnecting, "StatusDisplay_Disconnected", (int)ConnectionStatusAccent.Neutral)]
+    public void Pill_MapsOverallState(OverallConnectionState overall, string expectedKey, int expectedAccent)
+    {
+        var (labelKey, accent) = ConnectionStatusPresenter.Pill(overall);
+        Assert.Equal(expectedKey, labelKey);
+        Assert.Equal(expectedAccent, (int)accent);
+    }
+
+    [Fact]
+    public void Pill_ReadyAndConnected_BothReadConnected()
+    {
+        Assert.Equal(ConnectionStatusPresenter.Pill(OverallConnectionState.Connected),
+                     ConnectionStatusPresenter.Pill(OverallConnectionState.Ready));
+    }
+
+    [Fact]
+    public void NodeRow_NodeModeDisabled_ReadsDisabled_EvenWhenTransportConnected()
+    {
+        var snap = new GatewayConnectionSnapshot
+        {
+            OperatorState = RoleConnectionState.Connected,
+            NodeState = RoleConnectionState.Connected,
+        };
+
+        var (labelKey, accent) = ConnectionStatusPresenter.NodeRow(snap, nodeModeEnabled: false, enabledCapabilityCount: 7);
+
+        Assert.Equal("HubWindow_Role_Disabled", labelKey);
+        Assert.Equal(ConnectionStatusAccent.Neutral, accent);
+    }
+
+    [Fact]
+    public void NodeRow_OperatorNotConnected_ReadsDisabled()
+    {
+        var snap = new GatewayConnectionSnapshot
+        {
+            OperatorState = RoleConnectionState.Connecting,
+            NodeState = RoleConnectionState.Connected,
+        };
+
+        var (labelKey, accent) = ConnectionStatusPresenter.NodeRow(snap, nodeModeEnabled: true, enabledCapabilityCount: 7);
+
+        Assert.Equal("HubWindow_Role_Disabled", labelKey);
+        Assert.Equal(ConnectionStatusAccent.Neutral, accent);
+    }
+
+    [Fact]
+    public void NodeRow_NodeModeEnabledAndConnected_ReadsConnected()
+    {
+        var snap = new GatewayConnectionSnapshot
+        {
+            OperatorState = RoleConnectionState.Connected,
+            NodeState = RoleConnectionState.Connected,
+        };
+
+        var (labelKey, accent) = ConnectionStatusPresenter.NodeRow(snap, nodeModeEnabled: true, enabledCapabilityCount: 1);
+
+        Assert.Equal("StatusDisplay_Connected", labelKey);
+        Assert.Equal(ConnectionStatusAccent.Success, accent);
+    }
+
+    [Fact]
+    public void NodeRow_NodeModeEnabledConnectedAndNoCapabilities_ReadsPermissionsIncomplete()
+    {
+        var snap = new GatewayConnectionSnapshot
+        {
+            OperatorState = RoleConnectionState.Connected,
+            NodeState = RoleConnectionState.Connected,
+        };
+
+        var (labelKey, accent) = ConnectionStatusPresenter.NodeRow(snap, nodeModeEnabled: true, enabledCapabilityCount: 0);
+
+        Assert.Equal("HubWindow_Role_PermissionsIncomplete", labelKey);
+        Assert.Equal(ConnectionStatusAccent.Caution, accent);
+    }
+
+    [Fact]
+    public void NodeNeedsApproval_OnlyWhenEnabledOperatorConnectedAndPairing()
+    {
+        var pairing = new GatewayConnectionSnapshot
+        {
+            OperatorState = RoleConnectionState.Connected,
+            NodeState = RoleConnectionState.PairingRequired,
+        };
+
+        Assert.True(ConnectionStatusPresenter.NodeNeedsApproval(pairing, nodeModeEnabled: true));
+        Assert.False(ConnectionStatusPresenter.NodeNeedsApproval(pairing, nodeModeEnabled: false));
+    }
+
+    [Fact]
+    public void Presenter_ReturnedResourceKeys_ExistInEnUsResources()
+    {
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var overall in Enum.GetValues<OverallConnectionState>())
+            keys.Add(ConnectionStatusPresenter.Pill(overall).LabelKey);
+
+        foreach (var state in Enum.GetValues<RoleConnectionState>())
+            keys.Add(ConnectionStatusPresenter.RoleStateLabelKey(state));
+
+        var connected = new GatewayConnectionSnapshot
+        {
+            OperatorState = RoleConnectionState.Connected,
+            NodeState = RoleConnectionState.Connected,
+        };
+        keys.Add(ConnectionStatusPresenter.NodeRow(connected, nodeModeEnabled: false, enabledCapabilityCount: 0).LabelKey);
+        keys.Add(ConnectionStatusPresenter.NodeRow(connected, nodeModeEnabled: true, enabledCapabilityCount: 0).LabelKey);
+        keys.Add(ConnectionStatusPresenter.NodeRow(connected, nodeModeEnabled: true, enabledCapabilityCount: 1).LabelKey);
+
+        var reswPath = Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src", "OpenClaw.Tray.WinUI", "Strings", "en-us", "Resources.resw");
+        var resourceKeys = XDocument.Load(reswPath)
+            .Descendants("data")
+            .Select(e => (string?)e.Attribute("name"))
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var missing = keys.Where(key => !resourceKeys.Contains(key)).OrderBy(key => key).ToArray();
+        Assert.Empty(missing);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/FluentIconCatalogTests.cs
+++ b/tests/OpenClaw.Tray.Tests/FluentIconCatalogTests.cs
@@ -20,7 +20,7 @@ public sealed class FluentIconCatalogTests
         "Sessions", "Approvals", "Devices", "Hostname", "Permissions",
         "Browser", "Camera", "Canvas", "Screen", "Location", "Voice", "Speech", "System", "Terminal", "Operator",
         "Dashboard", "OpenInBrowser", "Chat", "CanvasAct", "VoiceAct", "Settings",
-        "Setup", "About", "Exit",
+        "Setup", "About", "Notifications", "Exit",
         "Add", "Back", "Sync", "Lock", "Plug", "MoreOverflow",
         "People", "Money", "ServerEnvironment", "CapabilityOff", "Channels",
         "ChevronR", "Check",

--- a/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
@@ -559,6 +559,15 @@ public class LocalizationValidationTests
         || key.StartsWith("ChannelsPage_", StringComparison.Ordinal)
         || key.StartsWith("DiagnosticsPage_", StringComparison.Ordinal)
         || key.StartsWith("SettingsRow_", StringComparison.Ordinal)
+        // Title-bar status pill + notifications bell flyout strings. Seeded
+        // English-only across all five .resw files using the deferred-translation
+        // pattern; translations land in a follow-up.
+        || key.StartsWith("HubWindow_StatusFlyout_", StringComparison.Ordinal)
+        || key.StartsWith("HubWindow_StatusPill_", StringComparison.Ordinal)
+        || key.StartsWith("HubWindow_Pill_", StringComparison.Ordinal)
+        || key.StartsWith("HubWindow_Role_", StringComparison.Ordinal)
+        || key.StartsWith("HubWindow_Bell_", StringComparison.Ordinal)
+        || key.StartsWith("NotificationsFlyout_", StringComparison.Ordinal)
         // V2 onboarding redesign strings (V2_*) are intentionally English-only at first
         // ship. They live in V2Strings.DefaultEnUs and the cutover seeded them into all
         // five .resw files with English values. Translations land in a follow-up.

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\PairingApprovalCoordinator.cs" Link="Services\PairingApprovalCoordinator.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ToastActivationRouter.cs" Link="Services\ToastActivationRouter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\AppNotificationService.cs" Link="Services\AppNotificationService.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ConnectionStatusPresenter.cs" Link="Services\ConnectionStatusPresenter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\UsageCostApplicationPolicy.cs" Link="Services\UsageCostApplicationPolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\CanvasGatewayUrlRewriter.cs" Link="Helpers\CanvasGatewayUrlRewriter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\TrayTooltipFormatter.cs" Link="Helpers\TrayTooltipFormatter.cs" />


### PR DESCRIPTION
## Summary
- Move Hub notifications from the footer rail into a title-bar bell flyout with badge, clear-all, dismiss, and open-page actions.
- Replace the title-bar gateway/operator/node dot cluster with a connection status pill and Gateway/Operator/Node detail flyout.
- Share notification card view-model logic between the Notifications page and bell flyout, and add a pure connection status presenter with tests so the pill/flyout stay aligned with the Connection page.
- Clean up removed navigation/title-bar resource keys and add localized keys across all supported locales.

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore -- xUnit parallelizeTestCollections=false`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore -- xUnit parallelizeTestCollections=false`


<img width="984" height="636" alt="Screenshot 2026-06-26 162916" src="https://github.com/user-attachments/assets/90ad8771-080f-4b6d-9a12-6890d5a97cbe" />
<img width="496" height="434" alt="Screenshot 2026-06-26 162947" src="https://github.com/user-attachments/assets/82e5404b-df41-4225-bba5-2eb85e61112b" />
<img width="558" height="398" alt="Screenshot 2026-06-26 163015" src="https://github.com/user-attachments/assets/0c5a73db-32c4-45b3-b9f0-14877dc5945e" />
