### PR TITLE
Polish Windows-node proof validation guidance

### DIFF
--- a/.agents/skills/openclaw-proof-validation/SKILL.md
+++ b/.agents/skills/openclaw-proof-validation/SKILL.md
@@ -5,22 +5,18 @@ description: "Plan and collect OpenClaw Windows validation/proof: tests, rubber-
 
 # OpenClaw Proof and Validation
 
-Use this skill when a change touches any user-visible tray surface, Settings, onboarding, chat/canvas, Command Center, Windows node capability, local MCP server behavior, gateway pairing/connection behavior, permissions, diagnostics, or agent-facing skill/instruction surface.
+Use for changes that affect tray UX, Settings, onboarding, chat/canvas, Command Center, Windows node capabilities, local MCP, gateway connection/pairing, permissions, diagnostics, or agent-facing instructions.
 
-## Contract
+## Rules
 
-- Validate the behavior through the surface the user or agent will actually use.
-- Prefer an isolated tray data directory so validation does not mutate the user's normal `%APPDATA%\OpenClawTray` profile.
-- Use computer-use / desktop automation tools for visible WinUI behavior during a batched closeout proof pass by default, not continuously during normal development. Mid-development computer-use is still appropriate when the developer explicitly asks for extra validation or UI proof is necessary to unblock the work; ask first whether to run computer-use now or provide manual instructions so the developer can run the UI path and share screenshots/output. Code inspection and unit tests are not a substitute for exercising the UI, but repeated desktop acquisition can block the user's other work.
-- Use local MCP validation for node capability changes even when gateway validation is unavailable.
-- Treat local MCP as part of the contract for every new Windows node call. A command is not complete until it appears in MCP `tools/list`, works through `winnode` or a raw MCP `tools/call`, and is documented in the `winnode` skill reference.
-- Run rubber-duck review before PR publication for non-trivial UI, MCP, node-command, setup, pairing, security, permissions, or diagnostics changes; also use it mid-development when the developer wants extra design/testing validation.
-- Always enforce automated/focused tests. Do not ask whether to skip required validation.
-- Report blockers explicitly. Do not make success-shaped claims when a UI, permission, gateway, camera, screen, or MCP dependency could not be exercised.
+- Required automated/focused tests are mandatory. Do not ask to skip them.
+- Prefer isolated tray data so proof does not mutate `%APPDATA%\OpenClawTray`.
+- Computer-use is usually a batched closeout proof pass, not a continuous dev-loop tool. Mid-development use is fine when explicitly requested or needed to unblock work; ask first whether to run it or provide manual screenshot/output steps.
+- Local MCP is part of every Windows node command contract: command discovery and invocation must work through `winnode` or raw MCP JSON-RPC.
+- Rubber-duck review is required before PR publication for non-trivial UI/MCP/node-command/setup/pairing/security/permissions/diagnostics work; it is also useful mid-development when extra design/testing validation is requested.
+- Report blockers explicitly. Do not turn missing UI, MCP, gateway, camera, screen, or permission proof into success-shaped wording.
 
-## Required baseline
-
-Run the repo-required validation before closeout:
+## Required validation
 
 ```powershell
 $env:OPENCLAW_REPO_ROOT = (Get-Location).Path
@@ -29,129 +25,56 @@ dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-rest
 dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore
 ```
 
-In a fresh worktree, run each test project once without `--no-restore` or build it first so `dotnet test --no-restore` cannot no-op before `bin\` exists.
+Fresh worktrees may need a first run without `--no-restore`, or a project build first, so tests do not no-op before `bin\` exists.
 
-If the change touches `winnode`, command descriptions, or a new/renamed node command, also run:
+For `winnode`, command descriptions, or new/renamed node commands, also run:
 
 ```powershell
 dotnet test .\tests\OpenClaw.WinNode.Cli.Tests\OpenClaw.WinNode.Cli.Tests.csproj --no-restore
 ```
 
-## UI smoke checklist
+## Proof checklist
 
-Run this as one larger closeout pass after implementation and automated/focused tests are complete by default. Do not keep the desktop locked for iterative development unless the user explicitly asks for live UI pairing, wants extra validation, or the work is blocked without visible UI proof. When UI proof is useful mid-development, recommend it and ask whether to run computer-use now or provide manual steps/screenshots checklist.
+| Surface | Proof to collect |
+|---|---|
+| UI / WinUI | Launch `.\run-app-local.ps1 -Isolated`, exercise the changed path with computer-use or developer-provided screenshots/output, and include visible evidence or blocker. If the developer captures manually, provide exact steps and confirm screenshot/artifact links resolve after updating the PR body. |
+| Local MCP | Enable **Local MCP Server**, run `winnode --list-tools`, then invoke the changed command with `winnode --command <name> --params '<json-object>'`. |
+| Raw MCP HTTP | For protocol/server-shape changes, paste JSON-RPC `tools/list` and `tools/call` responses from `http://127.0.0.1:8765/`. |
+| Gateway path | When relevant and available, prove `openclaw nodes invoke --command <name> --params '<json-object>'`; otherwise state the gateway blocker. |
+| Rubber-duck | Ask a rubber-duck reviewer to inspect the final implementation/proof plan; verify any finding before changing code. |
 
-1. Launch the tray from the current worktree:
-
-   ```powershell
-   .\run-app-local.ps1 -Isolated
-   ```
-
-2. Use computer-use / desktop automation to exercise the changed path:
-   - Open the tray or the target deep link, for example `openclaw://settings`, `openclaw://commandcenter`, or `openclaw://chat`.
-   - Verify labels, status, enabled/disabled states, error messages, and navigation match the intended behavior.
-   - Save/restart when persistence is part of the change.
-   - Capture enough visible evidence in the final report to show the UI path was actually exercised.
-
-3. Check logs when behavior depends on background services:
-
-   ```powershell
-   Get-Content "$env:LOCALAPPDATA\OpenClawTray\openclaw-tray.log" -Tail 80
-   ```
-
-## Rubber-duck closeout
-
-Before PR publication for non-trivial UI/MCP-sensitive work, ask a rubber-duck reviewer to look for logic gaps in the implementation and proof plan. It is also appropriate mid-development when the developer wants extra validation before continuing. Provide the reviewer with:
-
-1. The changed files and intended behavior.
-2. The automated validation commands and results.
-3. The planned UI/computer-use, MCP, raw MCP, and gateway proof.
-4. Any known blockers or intentionally out-of-scope proof.
-
-Treat rubber-duck output as advisory: verify any finding against the code and scope before making changes.
-
-## Local MCP smoke checklist
-
-1. In the tray Settings UI, enable **Local MCP Server** and save. MCP-only mode must work without requiring a gateway credential.
-2. Confirm the endpoint and token are available in Settings, or read the isolated token file written by the tray.
-3. If the tray was launched with `.\run-app-local.ps1 -Isolated`, copy the isolated data directory printed by the launch script and set it in every proof shell before calling `winnode` or reading the token:
-
-   ```powershell
-   $env:OPENCLAW_TRAY_DATA_DIR = '<isolated-data-dir-from-run-app-local>'
-   ```
-
-   Then read the raw MCP token from `$env:OPENCLAW_TRAY_DATA_DIR\mcp-token.txt`. Use `$env:APPDATA\OpenClawTray\mcp-token.txt` only for non-isolated runs.
-4. Verify the live tool surface. `winnode --list-tools` is the preferred operator-friendly proof:
-
-   ```powershell
-   winnode --list-tools
-   ```
-
-5. Invoke the changed command or the nearest representative command through `winnode`:
-
-   ```powershell
-   winnode --command system.notify --params '{"title":"OpenClaw validation","body":"MCP smoke succeeded"}'
-   ```
-
-6. Raw MCP server output is also valid proof, and is preferred for HTTP-level protocol changes. Include both `tools/list` and `tools/call` JSON-RPC output when the server shape itself is what changed:
-
-   ```powershell
-   $tokenPath = if ($env:OPENCLAW_TRAY_DATA_DIR) { Join-Path $env:OPENCLAW_TRAY_DATA_DIR 'mcp-token.txt' } else { Join-Path $env:APPDATA 'OpenClawTray\mcp-token.txt' }
-   $token = Get-Content $tokenPath -Raw
-   curl.exe -s http://127.0.0.1:8765/ -H "Authorization: Bearer $token"
-   curl.exe -s -X POST http://127.0.0.1:8765/ `
-     -H "Authorization: Bearer $token" `
-     -H "Content-Type: application/json" `
-     -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
-   curl.exe -s -X POST http://127.0.0.1:8765/ `
-     -H "Authorization: Bearer $token" `
-     -H "Content-Type: application/json" `
-     -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"system.notify","arguments":{"title":"OpenClaw validation","body":"Raw MCP smoke succeeded"}}}'
-   ```
-
-## New command / MCP update checklist
-
-Use this checklist whenever adding, renaming, or changing a Windows node command:
-
-1. Register the capability in the same `INodeCapability` path used by the gateway node.
-2. Ensure the command appears via local MCP `tools/list`; the bridge auto-discovers registered commands, but `McpToolBridge.CommandDescriptions` must still describe each command.
-3. Update `src/OpenClaw.WinNode.Cli/skill.md` with the command name, argument shape, output contract, side effects, and security/permission notes.
-4. Add/update tests for the capability, MCP bridge behavior, `winnode` invocation/argument parsing, and any WinUI or gateway-visible behavior.
-5. Run `winnode --list-tools` or raw MCP `tools/list` and paste the relevant command entry in PR proof.
-6. Run `winnode --command <changed-command> --params '<json-object>'` or raw MCP `tools/call` and paste the result or exact blocker in PR proof.
-7. If the command is gateway-mediated, also prove `openclaw nodes invoke --command <changed-command> --params '<json-object>'` when a gateway is available.
-
-## Gateway-path smoke checklist
-
-When the change affects gateway-mediated node behavior, validate the gateway path in addition to MCP when a gateway is available:
+For isolated tray runs, copy the data directory printed by `run-app-local.ps1 -Isolated` and set it before MCP proof commands:
 
 ```powershell
-openclaw nodes invoke --command <command-name> --params '<json-object>'
+$env:OPENCLAW_TRAY_DATA_DIR = '<isolated-data-dir-from-run-app-local>'
 ```
 
-If the gateway is unavailable, document that the gateway-path smoke was blocked and include the local MCP proof instead.
+Raw token lookup:
 
-## Closeout evidence
+```powershell
+$tokenPath = if ($env:OPENCLAW_TRAY_DATA_DIR) {
+    Join-Path $env:OPENCLAW_TRAY_DATA_DIR 'mcp-token.txt'
+} else {
+    Join-Path $env:APPDATA 'OpenClawTray\mcp-token.txt'
+}
+$token = Get-Content $tokenPath -Raw
+```
 
-Final status for UI/MCP-sensitive changes should include:
+## New Windows node command checklist
 
-| Evidence | Required detail |
-|---|---|
-| Automated validation | Build and test commands that passed, or exact blocker |
-| Rubber-duck review | Final implementation/proof reviewed for non-trivial UI/MCP-sensitive work, or why skipped |
-| Computer-use UI smoke | Batched closeout pass: surface opened and user-visible path exercised |
-| MCP smoke | `winnode --list-tools` plus changed command, or raw MCP `tools/list` plus `tools/call` JSON-RPC output |
-| Gateway smoke | Result when relevant and available, otherwise blocker |
+1. Register the command in the same `INodeCapability` path used by the gateway node.
+2. Add/update `McpToolBridge.CommandDescriptions`.
+3. Update `src/OpenClaw.WinNode.Cli/skill.md` with input shape, output shape, side effects, permissions, and examples.
+4. Add/update capability, MCP bridge, `winnode`, and UI/gateway tests as applicable.
+5. Prove discovery and invocation with `winnode` or raw MCP JSON-RPC.
+6. Prove the gateway path when the behavior is gateway-mediated and a gateway is available.
 
 ## PR proof package
 
-Before publishing or updating a PR, collect evidence in a shape reviewers and ClawSweeper can reuse:
+Before publishing or updating a PR, collect:
 
 1. `## Validation` with exact commands and pass/fail counts.
-2. `## Real behavior proof` with copied after-change live output. Prefer terminal output from real commands, JSON-RPC responses, copied diagnostics, or rendered UI state over prose-only claims.
-3. For non-trivial UI/MCP-sensitive changes, include rubber-duck review notes or the reason it was skipped.
-4. For UI changes, include visible proof from a batched closeout pass: agent-run computer-use screenshot/video, developer-provided screenshots, copied UI diagnostics from the changed surface, or a precise note explaining why visual proof was blocked.
-5. For runtime path changes, show the path explicitly, for example `Gateway -> node.invoke -> Windows node -> system.run -> result`.
-6. For MCP/node changes, include both tool discovery and invocation proof. `winnode --list-tools` plus `winnode --command ...` is preferred; raw MCP server `tools/list` plus `tools/call` JSON-RPC output is equally valid and better when proving protocol-level behavior.
-7. For security, network, auth, CSP, permission, camera, screen, or sandbox claims, include visible diagnostics or command output that demonstrates the gate.
-8. Fill the PR template's `Not verified / blocked` proof bullet when proof is intentionally focused or a gateway/hardware/permission dependency is unavailable.
+2. `## Real behavior proof` with current-head after-change evidence that directly shows the changed behavior: copied live output, screenshot/video, developer-provided screenshot, copied UI diagnostics, `winnode`, raw MCP JSON-RPC, gateway invoke output, redacted runtime log, or linked artifact. For UI changes, prefer screenshots/video of the active changed state, not only adjacent or empty UI.
+3. PR body proof must stay in sync with current behavior: remove stale screenshots/claims after design changes and verify embedded image/artifact links resolve.
+4. Rubber-duck notes for non-trivial UI/MCP-sensitive work, or why skipped.
+5. `Not verified / blocked` notes for focused proof or unavailable dependencies.

--- a/.agents/skills/openclaw-proof-validation/SKILL.md
+++ b/.agents/skills/openclaw-proof-validation/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: openclaw-proof-validation
+description: "Plan and collect OpenClaw Windows validation/proof: tests, rubber-duck review, UI evidence, MCP output, and gateway runtime proof."
+---
+
+# OpenClaw Proof and Validation
+
+Use this skill when a change touches any user-visible tray surface, Settings, onboarding, chat/canvas, Command Center, Windows node capability, local MCP server behavior, gateway pairing/connection behavior, permissions, diagnostics, or agent-facing skill/instruction surface.
+
+## Contract
+
+- Validate the behavior through the surface the user or agent will actually use.
+- Prefer an isolated tray data directory so validation does not mutate the user's normal `%APPDATA%\OpenClawTray` profile.
+- Use computer-use / desktop automation tools for visible WinUI behavior during a batched closeout proof pass by default, not continuously during normal development. Mid-development computer-use is still appropriate when the developer explicitly asks for extra validation or UI proof is necessary to unblock the work; ask first whether to run computer-use now or provide manual instructions so the developer can run the UI path and share screenshots/output. Code inspection and unit tests are not a substitute for exercising the UI, but repeated desktop acquisition can block the user's other work.
+- Use local MCP validation for node capability changes even when gateway validation is unavailable.
+- Treat local MCP as part of the contract for every new Windows node call. A command is not complete until it appears in MCP `tools/list`, works through `winnode` or a raw MCP `tools/call`, and is documented in the `winnode` skill reference.
+- Run rubber-duck review before PR publication for non-trivial UI, MCP, node-command, setup, pairing, security, permissions, or diagnostics changes; also use it mid-development when the developer wants extra design/testing validation.
+- Always enforce automated/focused tests. Do not ask whether to skip required validation.
+- Report blockers explicitly. Do not make success-shaped claims when a UI, permission, gateway, camera, screen, or MCP dependency could not be exercised.
+
+## Required baseline
+
+Run the repo-required validation before closeout:
+
+```powershell
+$env:OPENCLAW_REPO_ROOT = (Get-Location).Path
+.\build.ps1
+dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore
+dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore
+```
+
+In a fresh worktree, run each test project once without `--no-restore` or build it first so `dotnet test --no-restore` cannot no-op before `bin\` exists.
+
+If the change touches `winnode`, command descriptions, or a new/renamed node command, also run:
+
+```powershell
+dotnet test .\tests\OpenClaw.WinNode.Cli.Tests\OpenClaw.WinNode.Cli.Tests.csproj --no-restore
+```
+
+## UI smoke checklist
+
+Run this as one larger closeout pass after implementation and automated/focused tests are complete by default. Do not keep the desktop locked for iterative development unless the user explicitly asks for live UI pairing, wants extra validation, or the work is blocked without visible UI proof. When UI proof is useful mid-development, recommend it and ask whether to run computer-use now or provide manual steps/screenshots checklist.
+
+1. Launch the tray from the current worktree:
+
+   ```powershell
+   .\run-app-local.ps1 -Isolated
+   ```
+
+2. Use computer-use / desktop automation to exercise the changed path:
+   - Open the tray or the target deep link, for example `openclaw://settings`, `openclaw://commandcenter`, or `openclaw://chat`.
+   - Verify labels, status, enabled/disabled states, error messages, and navigation match the intended behavior.
+   - Save/restart when persistence is part of the change.
+   - Capture enough visible evidence in the final report to show the UI path was actually exercised.
+
+3. Check logs when behavior depends on background services:
+
+   ```powershell
+   Get-Content "$env:LOCALAPPDATA\OpenClawTray\openclaw-tray.log" -Tail 80
+   ```
+
+## Rubber-duck closeout
+
+Before PR publication for non-trivial UI/MCP-sensitive work, ask a rubber-duck reviewer to look for logic gaps in the implementation and proof plan. It is also appropriate mid-development when the developer wants extra validation before continuing. Provide the reviewer with:
+
+1. The changed files and intended behavior.
+2. The automated validation commands and results.
+3. The planned UI/computer-use, MCP, raw MCP, and gateway proof.
+4. Any known blockers or intentionally out-of-scope proof.
+
+Treat rubber-duck output as advisory: verify any finding against the code and scope before making changes.
+
+## Local MCP smoke checklist
+
+1. In the tray Settings UI, enable **Local MCP Server** and save. MCP-only mode must work without requiring a gateway credential.
+2. Confirm the endpoint and token are available in Settings, or read the isolated token file written by the tray.
+3. If the tray was launched with `.\run-app-local.ps1 -Isolated`, copy the isolated data directory printed by the launch script and set it in every proof shell before calling `winnode` or reading the token:
+
+   ```powershell
+   $env:OPENCLAW_TRAY_DATA_DIR = '<isolated-data-dir-from-run-app-local>'
+   ```
+
+   Then read the raw MCP token from `$env:OPENCLAW_TRAY_DATA_DIR\mcp-token.txt`. Use `$env:APPDATA\OpenClawTray\mcp-token.txt` only for non-isolated runs.
+4. Verify the live tool surface. `winnode --list-tools` is the preferred operator-friendly proof:
+
+   ```powershell
+   winnode --list-tools
+   ```
+
+5. Invoke the changed command or the nearest representative command through `winnode`:
+
+   ```powershell
+   winnode --command system.notify --params '{"title":"OpenClaw validation","body":"MCP smoke succeeded"}'
+   ```
+
+6. Raw MCP server output is also valid proof, and is preferred for HTTP-level protocol changes. Include both `tools/list` and `tools/call` JSON-RPC output when the server shape itself is what changed:
+
+   ```powershell
+   $tokenPath = if ($env:OPENCLAW_TRAY_DATA_DIR) { Join-Path $env:OPENCLAW_TRAY_DATA_DIR 'mcp-token.txt' } else { Join-Path $env:APPDATA 'OpenClawTray\mcp-token.txt' }
+   $token = Get-Content $tokenPath -Raw
+   curl.exe -s http://127.0.0.1:8765/ -H "Authorization: Bearer $token"
+   curl.exe -s -X POST http://127.0.0.1:8765/ `
+     -H "Authorization: Bearer $token" `
+     -H "Content-Type: application/json" `
+     -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+   curl.exe -s -X POST http://127.0.0.1:8765/ `
+     -H "Authorization: Bearer $token" `
+     -H "Content-Type: application/json" `
+     -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"system.notify","arguments":{"title":"OpenClaw validation","body":"Raw MCP smoke succeeded"}}}'
+   ```
+
+## New command / MCP update checklist
+
+Use this checklist whenever adding, renaming, or changing a Windows node command:
+
+1. Register the capability in the same `INodeCapability` path used by the gateway node.
+2. Ensure the command appears via local MCP `tools/list`; the bridge auto-discovers registered commands, but `McpToolBridge.CommandDescriptions` must still describe each command.
+3. Update `src/OpenClaw.WinNode.Cli/skill.md` with the command name, argument shape, output contract, side effects, and security/permission notes.
+4. Add/update tests for the capability, MCP bridge behavior, `winnode` invocation/argument parsing, and any WinUI or gateway-visible behavior.
+5. Run `winnode --list-tools` or raw MCP `tools/list` and paste the relevant command entry in PR proof.
+6. Run `winnode --command <changed-command> --params '<json-object>'` or raw MCP `tools/call` and paste the result or exact blocker in PR proof.
+7. If the command is gateway-mediated, also prove `openclaw nodes invoke --command <changed-command> --params '<json-object>'` when a gateway is available.
+
+## Gateway-path smoke checklist
+
+When the change affects gateway-mediated node behavior, validate the gateway path in addition to MCP when a gateway is available:
+
+```powershell
+openclaw nodes invoke --command <command-name> --params '<json-object>'
+```
+
+If the gateway is unavailable, document that the gateway-path smoke was blocked and include the local MCP proof instead.
+
+## Closeout evidence
+
+Final status for UI/MCP-sensitive changes should include:
+
+| Evidence | Required detail |
+|---|---|
+| Automated validation | Build and test commands that passed, or exact blocker |
+| Rubber-duck review | Final implementation/proof reviewed for non-trivial UI/MCP-sensitive work, or why skipped |
+| Computer-use UI smoke | Batched closeout pass: surface opened and user-visible path exercised |
+| MCP smoke | `winnode --list-tools` plus changed command, or raw MCP `tools/list` plus `tools/call` JSON-RPC output |
+| Gateway smoke | Result when relevant and available, otherwise blocker |
+
+## PR proof package
+
+Before publishing or updating a PR, collect evidence in a shape reviewers and ClawSweeper can reuse:
+
+1. `## Validation` with exact commands and pass/fail counts.
+2. `## Real behavior proof` with copied after-change live output. Prefer terminal output from real commands, JSON-RPC responses, copied diagnostics, or rendered UI state over prose-only claims.
+3. For non-trivial UI/MCP-sensitive changes, include rubber-duck review notes or the reason it was skipped.
+4. For UI changes, include visible proof from a batched closeout pass: agent-run computer-use screenshot/video, developer-provided screenshots, copied UI diagnostics from the changed surface, or a precise note explaining why visual proof was blocked.
+5. For runtime path changes, show the path explicitly, for example `Gateway -> node.invoke -> Windows node -> system.run -> result`.
+6. For MCP/node changes, include both tool discovery and invocation proof. `winnode --list-tools` plus `winnode --command ...` is preferred; raw MCP server `tools/list` plus `tools/call` JSON-RPC output is equally valid and better when proving protocol-level behavior.
+7. For security, network, auth, CSP, permission, camera, screen, or sandbox claims, include visible diagnostics or command output that demonstrates the gate.
+8. Fill the PR template's `Not verified / blocked` proof bullet when proof is intentionally focused or a gateway/hardware/permission dependency is unavailable.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,85 @@
+## Summary
+
+<!-- Describe the problem and fix in 2-5 bullets. -->
+
+- Problem:
+- Why it matters:
+- What changed:
+- What did NOT change (scope boundary):
+
+## Change Type (select all)
+
+<!-- Select all that apply. -->
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Docs / instructions
+- [ ] Tests / validation
+- [ ] Security hardening
+- [ ] Chore / infra
+
+## Scope (select all touched areas)
+
+- [ ] Tray / WinUI UX
+- [ ] Windows node capability
+- [ ] Local MCP / `winnode`
+- [ ] Gateway / connection / pairing
+- [ ] Setup / onboarding
+- [ ] Permissions / privacy / security
+- [ ] Tests / CI / docs
+
+## Linked Issue/PR
+
+- Closes #
+- Related #
+- [ ] Related to a bug or regression
+
+## Validation
+
+<!-- Include exact commands and pass/fail counts. Baseline after code changes:
+- .\build.ps1
+- dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore
+- dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore
+Add focused tests when relevant, for example WinNode CLI tests for command/MCP docs changes.
+In fresh worktrees, make sure tests actually ran and report non-zero test counts.
+-->
+
+## Real behavior proof
+
+<!-- Paste at least one after-change proof item that demonstrates real behavior.
+Use whatever proof best matches the change: copied live output, screenshot/video,
+developer-provided screenshot, copied UI diagnostics, winnode output, raw MCP
+JSON-RPC tools/list + tools/call, gateway invoke output, redacted runtime log,
+or linked artifact. -->
+
+- Environment tested:
+- Exact steps or command run:
+- Evidence after fix:
+- Observed result:
+- Not verified / blocked:
+
+<!-- Optional: add rubber-duck review notes in addition to runtime proof above. -->
+
+## Security Impact (required)
+
+- New permissions/capabilities? (`Yes/No`)
+- Secrets/tokens handling changed? (`Yes/No`)
+- New/changed network calls? (`Yes/No`)
+- Command/tool execution surface changed? (`Yes/No`)
+- Data access scope changed? (`Yes/No`)
+- If any `Yes`, explain risk + mitigation:
+
+## Compatibility / Migration
+
+- Backward compatible? (`Yes/No`)
+- Config/env changes? (`Yes/No`)
+- Migration needed? (`Yes/No`)
+- If yes, exact upgrade steps:
+
+## Review Conversations
+
+- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
+- [ ] I left unresolved only conversations that still need reviewer or maintainer judgment.
+
+If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@
 - Problem:
 - Why it matters:
 - What changed:
+- User impact:
 - What did NOT change (scope boundary):
 
 ## Change Type (select all)
@@ -47,16 +48,19 @@ In fresh worktrees, make sure tests actually ran and report non-zero test counts
 
 ## Real behavior proof
 
-<!-- Paste at least one after-change proof item that demonstrates real behavior.
+<!-- Paste at least one current-head after-change proof item that directly demonstrates the changed behavior.
 Use whatever proof best matches the change: copied live output, screenshot/video,
 developer-provided screenshot, copied UI diagnostics, winnode output, raw MCP
 JSON-RPC tools/list + tools/call, gateway invoke output, redacted runtime log,
-or linked artifact. -->
+or linked artifact. For UI changes, prefer screenshots/video of the active
+changed state, not only adjacent or empty UI. -->
 
 - Environment tested:
+- PR head / commit tested:
 - Exact steps or command run:
 - Evidence after fix:
 - Observed result:
+- Screenshot/artifact links verified? (`Yes/No/N/A`)
 - Not verified / blocked:
 
 <!-- Optional: add rubber-duck review notes in addition to runtime proof above. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Notes:
 - If a build/test is blocked by an environmental lock (for example running executable locking output assemblies), stop/close the locking process and rerun.
 - **First-run gotcha**: `dotnet test --no-restore` silently no-ops in a fresh worktree where the test `bin/` doesn't exist yet (reports "Build succeeded in 0.5s" then exits 0 with no tests run). For first-run validation, either omit `--no-restore` OR run `dotnet build` on the test project first. Subsequent reruns honor `--no-restore` correctly.
 - In linked git worktrees, set `OPENCLAW_REPO_ROOT` to the worktree path before running tests that discover the repository root, for example:
-  - `$env:OPENCLAW_REPO_ROOT='D:\github\moltbot-windows-hub.<worktree-name>'`
+  - `$env:OPENCLAW_REPO_ROOT='D:\github\openclaw-windows-node.<worktree-name>'`
 - Tray tests must isolate `SettingsManager` from real user settings. Do not use `new SettingsManager()` in tests unless the test intentionally reads `%APPDATA%\OpenClawTray\settings.json`; pass a temp settings directory or set `OPENCLAW_TRAY_DATA_DIR` before the test process starts.
 - Prefer isolated worktrees for PR validation. Use `git-wt` for worktree workflows; `wt.exe` may resolve to WorkTrunk instead of Windows Terminal, so use the full Windows Terminal path when explicitly launching Terminal.
 - Do not claim completion without reporting validation results.
@@ -42,6 +42,29 @@ When changing MXC sandboxing, `system.run`, exec approvals, Windows node command
 ```
 
 The script sets `OPENCLAW_RUN_E2E` and `OPENCLAW_RUN_MXC_E2E` itself, then runs the real WSL Gateway -> Windows node -> `system.run` MXC E2E proofs. It fails if the MXC proof skips. Use `-AllowSkip` only to document that the current host is not MXC-capable; do not report an `-AllowSkip` run as merge validation for MXC-related work.
+
+## UI, MCP, and PR Proof
+
+Use `.agents/skills/openclaw-proof-validation/SKILL.md` when a change touches tray UX, Settings, onboarding, chat/canvas, Command Center, Windows node capabilities, MCP, gateway connection/pairing, permissions, diagnostics, or agent-facing instructions.
+
+Policy:
+
+- Required automated/focused tests are mandatory; do not ask to skip them.
+- Prefer computer-use as a batched closeout proof pass before PRs. If UI proof is useful mid-development, first ask whether to run computer-use now or provide manual steps so the developer can capture screenshots/output.
+- For UI claims, collect current-head visible proof of the active changed state: computer-use screenshot/video, developer-provided screenshot, copied UI diagnostics, or an explicit blocker.
+- If the developer captures UI proof manually, run or point them at the current isolated app, provide exact reproduction/capture steps, and verify any PR screenshot/artifact links after updating the PR body.
+- For node/MCP changes, prove discovery and invocation with `winnode --list-tools` plus `winnode --command ...`, or raw MCP JSON-RPC `tools/list` plus `tools/call`.
+- For gateway-mediated behavior, prove the real gateway path when available; otherwise state the blocker and keep MCP proof.
+- Run rubber-duck review before PR publication for non-trivial UI, MCP, node-command, setup, pairing, security, permissions, or diagnostics changes.
+- PRs should include `## Validation` and `## Real behavior proof`; proof must directly show the changed behavior from the current PR head. Fill `Not verified / blocked` for focused proof or unavailable dependencies.
+
+Every new Windows node call must be exposed, documented, and tested through MCP before completion:
+
+1. Register the capability/command in the tray node capability registry.
+2. Add/update `McpToolBridge.CommandDescriptions`.
+3. Update `src/OpenClaw.WinNode.Cli/skill.md`.
+4. Add/update capability, MCP bridge, `winnode`, and UI/gateway tests as appropriate.
+5. Run required validation plus `dotnet test .\tests\OpenClaw.WinNode.Cli.Tests\OpenClaw.WinNode.Cli.Tests.csproj --no-restore` when `winnode`, MCP output, or command docs change.
 
 ## Architecture Context for New Agents
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -23,9 +23,10 @@ A comprehensive guide for building, running, and contributing to the OpenClaw Wi
 
 ### For Testing
 
-- **A running OpenClaw gateway instance** - The gateway provides the backend for chat, sessions, and notifications
+- **A running OpenClaw gateway instance** - The gateway provides the backend for chat, sessions, and notifications when validating gateway-mediated flows
   - Default gateway URL: `ws://localhost:18789`
   - You'll need a valid authentication token from your OpenClaw instance
+- **Local MCP Server** - Windows node capabilities can also be validated without a gateway by enabling Local MCP Server in the tray Settings UI and using `winnode`
 
 ## Project Structure
 
@@ -423,6 +424,25 @@ In DEBUG builds, logs are also written to Visual Studio Output window via `Syste
 Sensitive data (authentication tokens) are never logged.
 
 ## Testing
+
+Required agent validation lives in [AGENTS.md](AGENTS.md). For changes touching
+tray UX, Settings, onboarding, chat/canvas, Command Center, Windows node
+capabilities, local MCP, gateway pairing/connection, permissions, or
+diagnostics, use the repo-local skill
+`.agents/skills/openclaw-proof-validation/SKILL.md`: run the build/tests,
+validate local MCP with `winnode --list-tools` plus the changed command, run
+rubber-duck review for non-trivial changes, then launch the tray from this
+worktree and drive the changed UI with computer-use / desktop automation as one
+batched closeout pass before PR publication. Mid-development rubber-duck,
+computer-use, or MCP validation is also appropriate when explicitly requested or
+needed to unblock the work; agents should ask whether to run computer-use or
+provide manual UI proof steps, while still enforcing required automated tests.
+
+PRs should include `## Validation` and `## Real behavior proof` sections. Paste concrete
+after-change output, visible UI evidence for visual changes, `winnode` output or
+raw MCP server JSON-RPC output for node commands, and gateway invoke output for
+gateway-mediated behavior when available; the default PR template includes these
+prompts.
 
 ### Running Unit Tests
 

--- a/docs/MCP_MODE.md
+++ b/docs/MCP_MODE.md
@@ -271,6 +271,34 @@ curl -s -X POST http://127.0.0.1:8765/ `
 For a simpler local CLI smoke test, run `winnode --list-tools`; it loads the
 same token file automatically.
 
+For agent-driven validation, use the repo-local skill
+`.agents/skills/openclaw-proof-validation/SKILL.md`. It requires both a visible
+computer-use walkthrough for affected tray UI and a live MCP smoke (`winnode
+--list-tools` plus the changed command or representative JSON-RPC call) before
+claiming MCP/node changes are complete.
+
+## Adding or changing node commands
+
+Every new Windows node command must remain first-class over local MCP. The MCP
+bridge auto-discovers commands from registered `INodeCapability` instances, but
+command descriptions and agent-facing docs are intentionally drift-tested:
+
+1. Register the command in the capability path used by `NodeService`.
+2. Add/update `McpToolBridge.CommandDescriptions` so `tools/list` advertises a
+   useful description.
+3. Update `src/OpenClaw.WinNode.Cli/skill.md` with the command's input shape,
+   output shape, side effects, permissions, and examples.
+4. Add/update tests. `SkillMdDriftTests` fails when the command set drifts
+   between capabilities, MCP descriptions, and `winnode` docs.
+5. Validate locally with `winnode --list-tools` and
+   `winnode --command <changed-command> --params '<json-object>'`, or with
+   raw MCP server JSON-RPC output (`tools/list` and `tools/call`) when proving
+   HTTP/MCP protocol behavior directly.
+
+PR proof for a new command should paste the relevant `winnode` output or raw
+MCP server JSON-RPC output and, when gateway-mediated behavior changed, the
+real gateway invoke output as well.
+
 For Claude Code, drop this into `.mcp.json` at the repo root or `~/.claude.json`:
 
 ```json

--- a/docs/MCP_MODE.md
+++ b/docs/MCP_MODE.md
@@ -272,32 +272,20 @@ For a simpler local CLI smoke test, run `winnode --list-tools`; it loads the
 same token file automatically.
 
 For agent-driven validation, use the repo-local skill
-`.agents/skills/openclaw-proof-validation/SKILL.md`. It requires both a visible
-computer-use walkthrough for affected tray UI and a live MCP smoke (`winnode
---list-tools` plus the changed command or representative JSON-RPC call) before
-claiming MCP/node changes are complete.
+`.agents/skills/openclaw-proof-validation/SKILL.md`. MCP/node changes need live
+tool discovery plus invocation proof using `winnode` or raw MCP JSON-RPC.
 
 ## Adding or changing node commands
 
-Every new Windows node command must remain first-class over local MCP. The MCP
-bridge auto-discovers commands from registered `INodeCapability` instances, but
-command descriptions and agent-facing docs are intentionally drift-tested:
+Every new Windows node command must remain first-class over local MCP. Register
+it in the capability path used by `NodeService`, update
+`McpToolBridge.CommandDescriptions`, update
+`src/OpenClaw.WinNode.Cli/skill.md`, and add focused tests. `SkillMdDriftTests`
+guards against drift between capabilities, MCP descriptions, and `winnode` docs.
 
-1. Register the command in the capability path used by `NodeService`.
-2. Add/update `McpToolBridge.CommandDescriptions` so `tools/list` advertises a
-   useful description.
-3. Update `src/OpenClaw.WinNode.Cli/skill.md` with the command's input shape,
-   output shape, side effects, permissions, and examples.
-4. Add/update tests. `SkillMdDriftTests` fails when the command set drifts
-   between capabilities, MCP descriptions, and `winnode` docs.
-5. Validate locally with `winnode --list-tools` and
-   `winnode --command <changed-command> --params '<json-object>'`, or with
-   raw MCP server JSON-RPC output (`tools/list` and `tools/call`) when proving
-   HTTP/MCP protocol behavior directly.
-
-PR proof for a new command should paste the relevant `winnode` output or raw
-MCP server JSON-RPC output and, when gateway-mediated behavior changed, the
-real gateway invoke output as well.
+PR proof for a new command should paste `winnode --list-tools` plus the command
+invocation, or raw MCP `tools/list` plus `tools/call`; include gateway invoke
+output when gateway-mediated behavior changed and a gateway is available.
 
 For Claude Code, drop this into `.mcp.json` at the repo root or `~/.claude.json`:
 

--- a/docs/TEST_COVERAGE.md
+++ b/docs/TEST_COVERAGE.md
@@ -114,3 +114,14 @@ first so `dotnet test --no-restore` cannot no-op before `bin\` exists.
   and memory usage over multi-day sessions.
 - Manual visual acceptance for complex WinUI surfaces where screenshot
   comparison would be brittle.
+
+For these gaps, affected changes must include the manual UI/MCP smoke described
+in `AGENTS.md` and `.agents/skills/openclaw-proof-validation/SKILL.md`: launch
+the tray from the current worktree, use computer-use / desktop automation for
+visible WinUI paths, and validate local MCP with `winnode --list-tools` plus the
+changed command when node capabilities are involved.
+
+When node command surfaces change, include
+`OpenClaw.WinNode.Cli.Tests` in focused validation because `SkillMdDriftTests`
+guards the capability registry, MCP descriptions, and `winnode` skill reference
+from drifting apart.

--- a/docs/WINDOWS_NODE_TESTING.md
+++ b/docs/WINDOWS_NODE_TESTING.md
@@ -16,29 +16,13 @@ The Windows Node feature allows the tray app to receive commands from the OpenCl
 
 ### Agent-driven UI and MCP validation
 
-For any change that touches tray UX, Settings, onboarding, chat/canvas, Command Center, Windows node capabilities, local MCP, gateway pairing/connection, permissions, or diagnostics, agents should use the repo-local validation skill at `.agents/skills/openclaw-proof-validation/SKILL.md`.
+For changes touching tray UX, Settings, onboarding, chat/canvas, Command Center, Windows node capabilities, local MCP, gateway pairing/connection, permissions, or diagnostics, use `.agents/skills/openclaw-proof-validation/SKILL.md`.
 
-The expected flow is:
-
-1. Run the required build and test suites from `AGENTS.md`.
-2. After implementation and automated/focused tests are complete, run a larger closeout proof pass before publishing/updating a PR. Avoid repeated computer-use during normal development because it blocks the user's desktop; mid-development rubber-duck, computer-use, and MCP validation are fine when the developer explicitly wants extra validation or the task is blocked without it.
-3. Launch the tray from the current worktree, preferably with isolated settings, using `.\run-app-local.ps1 -Isolated`.
-4. Use computer-use / desktop automation to click through the changed UI path and verify visible state, not just code paths.
-5. If the change affects MCP or Windows node capabilities, enable **Local MCP Server** in Settings and validate with `winnode --list-tools` plus `winnode --command <changed-command> --params '<json-object>'`.
-   Raw MCP server JSON-RPC output is also valid proof, especially for HTTP/MCP protocol changes: paste `tools/list` plus `tools/call` responses from the local server.
-6. If the changed behavior is gateway-mediated, also validate the gateway path when available. If a gateway, permission prompt, or hardware dependency blocks the smoke, record the exact blocker.
-7. Run rubber-duck review before PR publication for non-trivial UI/MCP/node-command/setup/security/diagnostics work, or mid-development when extra design/testing validation is requested.
-8. When publishing a PR, include copied live output under `## Real behavior proof`. ClawSweeper gives stronger proof credit to concrete after-change output, visible UI/media evidence, and real runtime path proof than to prose-only claims.
+Short version: run required tests, collect a closeout proof pass with `.\run-app-local.ps1 -Isolated` when UI is involved, use computer-use or developer-provided screenshots/output for the active changed UI state, prove MCP with `winnode` or raw JSON-RPC, prove gateway paths when available, and include current-head concrete output under `## Real behavior proof`. Mid-development computer-use/MCP/rubber-duck validation is fine when explicitly requested or needed to unblock work.
 
 ### New command MCP contract
 
-Every new Windows node call must also be exposed through the local MCP server and `winnode` before it is considered complete:
-
-1. Register the capability command in the tray node capability registry.
-2. Update `McpToolBridge.CommandDescriptions`.
-3. Update `src/OpenClaw.WinNode.Cli/skill.md`.
-4. Add/update capability, MCP, `winnode`, and UI/gateway tests as applicable.
-5. Prove the command with `winnode --list-tools` and `winnode --command ...`, or raw MCP `tools/list` plus `tools/call` server output, in PR proof.
+Every new Windows node call must be exposed through local MCP and `winnode`: register the capability, update `McpToolBridge.CommandDescriptions`, update `src/OpenClaw.WinNode.Cli/skill.md`, add focused tests, and prove discovery/invocation with `winnode` or raw MCP JSON-RPC.
 
 ### 1. Settings Toggle
 - Verify the toggle appears in Settings under "ADVANCED"

--- a/docs/WINDOWS_NODE_TESTING.md
+++ b/docs/WINDOWS_NODE_TESTING.md
@@ -14,6 +14,32 @@ The Windows Node feature allows the tray app to receive commands from the OpenCl
 
 ## What You Can Test Now
 
+### Agent-driven UI and MCP validation
+
+For any change that touches tray UX, Settings, onboarding, chat/canvas, Command Center, Windows node capabilities, local MCP, gateway pairing/connection, permissions, or diagnostics, agents should use the repo-local validation skill at `.agents/skills/openclaw-proof-validation/SKILL.md`.
+
+The expected flow is:
+
+1. Run the required build and test suites from `AGENTS.md`.
+2. After implementation and automated/focused tests are complete, run a larger closeout proof pass before publishing/updating a PR. Avoid repeated computer-use during normal development because it blocks the user's desktop; mid-development rubber-duck, computer-use, and MCP validation are fine when the developer explicitly wants extra validation or the task is blocked without it.
+3. Launch the tray from the current worktree, preferably with isolated settings, using `.\run-app-local.ps1 -Isolated`.
+4. Use computer-use / desktop automation to click through the changed UI path and verify visible state, not just code paths.
+5. If the change affects MCP or Windows node capabilities, enable **Local MCP Server** in Settings and validate with `winnode --list-tools` plus `winnode --command <changed-command> --params '<json-object>'`.
+   Raw MCP server JSON-RPC output is also valid proof, especially for HTTP/MCP protocol changes: paste `tools/list` plus `tools/call` responses from the local server.
+6. If the changed behavior is gateway-mediated, also validate the gateway path when available. If a gateway, permission prompt, or hardware dependency blocks the smoke, record the exact blocker.
+7. Run rubber-duck review before PR publication for non-trivial UI/MCP/node-command/setup/security/diagnostics work, or mid-development when extra design/testing validation is requested.
+8. When publishing a PR, include copied live output under `## Real behavior proof`. ClawSweeper gives stronger proof credit to concrete after-change output, visible UI/media evidence, and real runtime path proof than to prose-only claims.
+
+### New command MCP contract
+
+Every new Windows node call must also be exposed through the local MCP server and `winnode` before it is considered complete:
+
+1. Register the capability command in the tray node capability registry.
+2. Update `McpToolBridge.CommandDescriptions`.
+3. Update `src/OpenClaw.WinNode.Cli/skill.md`.
+4. Add/update capability, MCP, `winnode`, and UI/gateway tests as applicable.
+5. Prove the command with `winnode --list-tools` and `winnode --command ...`, or raw MCP `tools/list` plus `tools/call` server output, in PR proof.
+
 ### 1. Settings Toggle
 - Verify the toggle appears in Settings under "ADVANCED"
 - Verify it saves and persists across app restarts
@@ -156,25 +182,25 @@ When the node connects, it advertises these capabilities:
 ## Remaining Work (Roadmap)
 
 1. ~~**system.run + exec approvals**~~ ✅ Implemented
-   - `system.run` with PowerShell/cmd support
-   - `system.run.prepare` pre-flight command
-   - `system.which` command lookup
-   - `system.execApprovals` allowlist flow with base-hash optimistic concurrency for remote edits
-   - `system.run` environment override sanitizer blocks path/toolchain injection and secret-looking variables
+    - `system.run` with PowerShell/cmd support
+    - `system.run.prepare` pre-flight command
+    - `system.which` command lookup
+    - `system.execApprovals` allowlist flow with base-hash optimistic concurrency for remote edits
+    - `system.run` environment override sanitizer blocks path/toolchain injection and secret-looking variables
 2. ~~**screen.record**~~ ✅ Implemented
-   - Graphics Capture video recording (MP4/base64)
+    - Graphics Capture video recording (MP4/base64)
 3. ~~**camera.clip**~~ ✅ Implemented
-   - Short webcam video capture (MediaCapture + encoding)
+    - Short webcam video capture (MediaCapture + encoding)
 4. ~~**A2UI pushJSONL alias + device status**~~ ✅ Implemented
-   - Legacy `canvas.a2ui.pushJSONL`
-   - Safe `device.info` / `device.status`
+    - Legacy `canvas.a2ui.pushJSONL`
+    - Safe `device.info` / `device.status`
 5. ~~**Command Center diagnostics**~~ ✅ Implemented
-   - Channel/node/usage/pairing/allowlist diagnostics and recent invoke timeline
+    - Channel/node/usage/pairing/allowlist diagnostics and recent invoke timeline
 6. **Packaging & consent prompts**
-   - MSIX packaging with camera/screen capabilities for system prompts
+    - MSIX packaging with camera/screen capabilities for system prompts
 7. **Test matrix & polish**
-   - Canvas/screen/camera regression tests
-   - Handle timeouts/disconnects, reduce verbose logging
+    - Canvas/screen/camera regression tests
+    - Handle timeouts/disconnects, reduce verbose logging
 
 ## Files Involved
 


### PR DESCRIPTION
## Summary

- Problem: repo guidance for validation/proof had become verbose and duplicated across AGENTS.md, docs, and the proof skill.
- Why it matters: agents and contributors need one clear path for required tests, current-head real behavior proof, UI screenshots, MCP/winnode proof, and gateway proof.
- What changed: polished AGENTS.md into short policy, shortened the proof-validation skill into a practical checklist, aligned the PR template closer to the main OpenClaw template, and trimmed duplicated MCP/Windows-node docs.
- User impact: future Windows-node PRs should have clearer validation/proof sections and less stale or insufficient proof.
- What did NOT change: no product/runtime behavior, capabilities, build logic, or tests changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs / instructions
- [x] Tests / validation
- [ ] Security hardening
- [ ] Chore / infra

## Scope (select all touched areas)

- [ ] Tray / WinUI UX
- [x] Windows node capability
- [x] Local MCP / `winnode`
- [x] Gateway / connection / pairing
- [ ] Setup / onboarding
- [x] Permissions / privacy / security
- [x] Tests / CI / docs

## Linked Issue/PR

- Closes #
- Related #
- [ ] Related to a bug or regression

## Validation

Current PR head tested: `0b991eee`

- `.uild.ps1` — passed; all 5 projects built successfully.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` — passed: 2567 passed, 31 skipped.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` — passed: 1279 passed.
- `dotnet test .\tests\OpenClaw.WinNode.Cli.Tests\OpenClaw.WinNode.Cli.Tests.csproj --no-restore` — passed: 120 passed.
- Rubber-duck review on the final instruction/template/skill diff — no high-signal issues found.

## Real behavior proof

- Environment tested: Windows ARM64 worktree `bkudiess-testing-guidance`, commit `0b991eee`.
- Exact steps or command run: rebased onto `origin/main`, resolved the `AGENTS.md` conflict by keeping the new main MXC targeted-validation path plus this PR's proof policy, force-pushed the fork branch, reopened this draft PR, then ran the validation commands above from this worktree with `OPENCLAW_REPO_ROOT` set to the repo path.
- Evidence after fix: the validation output above is current-head live output. Reference checks also found no stale `openclaw-ui-mcp-validation` references and confirmed `## Real behavior proof` is the PR template/guidance heading.
- Observed result: required build/tests pass, and the proof guidance now explicitly requires current-head proof that directly demonstrates changed behavior; UI screenshots/video remain first-class proof.
- Screenshot/artifact links verified? N/A — documentation/instruction-only PR; no visual artifact embedded.
- Not verified / blocked: no UI computer-use smoke was run because this PR does not change product UI/runtime behavior.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.