### PR TITLE
Add Workspace session file rail

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/WorkspaceFilesModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/WorkspaceFilesModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using OpenClaw.Shared;
 
 namespace OpenClawTray.Pages;
@@ -142,6 +143,35 @@ internal static class WorkspaceFilesModel
         };
     }
 
+    /// <summary>
+    /// Project the legacy <c>agents.files.list</c> payload used by older
+    /// gateways. It does not support path browsing or session relevance badges,
+    /// but the rows remain previewable through <c>agents.files.get</c>.
+    /// </summary>
+    public static WorkspaceListState FromLegacyAgentFilesList(JsonElement payload)
+    {
+        var entries = new List<WorkspaceFileEntry>();
+        if (payload.ValueKind != JsonValueKind.Object)
+            return new WorkspaceListState();
+
+        if (payload.TryGetProperty("files", out var filesEl) &&
+            filesEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var fileEl in filesEl.EnumerateArray())
+            {
+                if (MapLegacyFileEntry(fileEl) is { } entry)
+                    entries.Add(entry);
+            }
+        }
+
+        return new WorkspaceListState
+        {
+            WorkspacePath = GetString(payload, "workspace") ?? GetString(payload, "root") ?? string.Empty,
+            Supported = true,
+            Entries = Sort(entries),
+        };
+    }
+
     private static WorkspaceFileEntry? MapFileEntry(SessionFileEntry f)
     {
         var requestPath = !string.IsNullOrEmpty(f.Path) ? f.Path : f.Name;
@@ -197,6 +227,31 @@ internal static class WorkspaceFilesModel
             Touched = touched,
             Read = read,
             ModifiedUtc = ToUtc(b.UpdatedAt),
+        };
+    }
+
+    private static WorkspaceFileEntry? MapLegacyFileEntry(JsonElement item)
+    {
+        if (item.ValueKind != JsonValueKind.Object) return null;
+
+        var requestPath = GetString(item, "path") ?? GetString(item, "name");
+        if (string.IsNullOrEmpty(requestPath)) return null;
+
+        var relative = NormalizePath(requestPath);
+        var name = GetString(item, "name") ?? LeafName(relative);
+        if (string.IsNullOrEmpty(name)) return null;
+
+        return new WorkspaceFileEntry
+        {
+            Name = name,
+            RelativePath = relative,
+            RequestPath = requestPath,
+            Size = GetLong(item, "size"),
+            Exists = GetBool(item, "exists") ?? !GetBool(item, "missing").GetValueOrDefault(),
+            IsDirectory = false,
+            IsSessionFile = true,
+            CanPreview = true,
+            ModifiedUtc = ToUtc(GetDateTime(item, "updatedAt") ?? GetDateTime(item, "modifiedAt")),
         };
     }
 
@@ -280,5 +335,38 @@ internal static class WorkspaceFilesModel
         return dt.Kind == DateTimeKind.Unspecified
             ? new DateTimeOffset(DateTime.SpecifyKind(dt, DateTimeKind.Utc))
             : new DateTimeOffset(dt.ToUniversalTime());
+    }
+
+    private static string? GetString(JsonElement item, string name)
+    {
+        return item.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+    }
+
+    private static bool? GetBool(JsonElement item, string name)
+    {
+        return item.TryGetProperty(name, out var value) && value.ValueKind is JsonValueKind.True or JsonValueKind.False
+            ? value.GetBoolean()
+            : null;
+    }
+
+    private static long? GetLong(JsonElement item, string name)
+    {
+        return item.TryGetProperty(name, out var value) &&
+               value.ValueKind == JsonValueKind.Number &&
+               value.TryGetInt64(out var result) &&
+               result >= 0
+            ? result
+            : null;
+    }
+
+    private static DateTime? GetDateTime(JsonElement item, string name)
+    {
+        return item.TryGetProperty(name, out var value) &&
+               value.ValueKind == JsonValueKind.String &&
+               DateTime.TryParse(value.GetString(), null, System.Globalization.DateTimeStyles.RoundtripKind, out var result)
+            ? result
+            : null;
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Pages/WorkspaceFilesModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/WorkspaceFilesModel.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenClaw.Shared;
+
+namespace OpenClawTray.Pages;
+
+/// <summary>
+/// Pure projection layer for the Workspace page's session file rail. Adapts the
+/// typed gateway protocol DTOs (<see cref="SessionFileList"/> /
+/// <see cref="SessionFileContent"/> from <c>sessions.files.list/get</c>) into
+/// view rows and owns the search/sort/format logic so the code-behind stays a
+/// thin view.
+///
+/// This layer <i>consumes</i> the protocol DTOs — it does not re-parse wire JSON
+/// or redefine the protocol contract (that lives in
+/// <c>OpenClaw.Shared.GatewayProtocolModels</c> /
+/// <c>OpenClawGatewayClient.Protocol</c>).
+/// </summary>
+internal static class WorkspaceFilesModel
+{
+    /// <summary>One row in the workspace file rail.</summary>
+    internal sealed record WorkspaceFileEntry
+    {
+        /// <summary>Display name (leaf name, never a path).</summary>
+        public required string Name { get; init; }
+
+        /// <summary>
+        /// Normalized workspace-relative path used for grouping/search/display.
+        /// </summary>
+        public required string RelativePath { get; init; }
+
+        /// <summary>
+        /// The original path string from the gateway DTO — used verbatim when
+        /// requesting content via <c>sessions.files.get</c> so normalization
+        /// never diverges from what the gateway expects.
+        /// </summary>
+        public required string RequestPath { get; init; }
+
+        /// <summary>Size in bytes; <c>null</c> when unknown.</summary>
+        public long? Size { get; init; }
+
+        /// <summary>False when the file is tracked but missing on disk.</summary>
+        public bool Exists { get; init; } = true;
+
+        /// <summary>True for browser/directory entries (not openable as text).</summary>
+        public bool IsDirectory { get; init; }
+
+        /// <summary>True when this row came from transcript/session relevance.</summary>
+        public bool IsSessionFile { get; init; }
+
+        /// <summary>True when selecting this file may call <c>sessions.files.get</c>.</summary>
+        public bool CanPreview { get; init; }
+
+        /// <summary>The agent wrote/modified this file during the session.</summary>
+        public bool Touched { get; init; }
+
+        /// <summary>The agent read this file during the session.</summary>
+        public bool Read { get; init; }
+
+        /// <summary>Last-modified time (UTC) when the gateway reports it.</summary>
+        public DateTimeOffset? ModifiedUtc { get; init; }
+    }
+
+    /// <summary>View state derived from a <see cref="SessionFileList"/>.</summary>
+    internal sealed record WorkspaceListState
+    {
+        /// <summary>Absolute workspace root, or empty when not reported.</summary>
+        public string WorkspacePath { get; init; } = string.Empty;
+
+        /// <summary>
+        /// False when the connected gateway does not implement the method
+        /// (older gateway). Mirrors <see cref="SessionFileList.IsSupported"/>.
+        /// </summary>
+        public bool Supported { get; init; } = true;
+
+        public IReadOnlyList<WorkspaceFileEntry> Entries { get; init; } =
+            Array.Empty<WorkspaceFileEntry>();
+
+        public string BrowserPath { get; init; } = string.Empty;
+
+        public string? BrowserParentPath { get; init; }
+
+        public string BrowserSearch { get; init; } = string.Empty;
+
+        public bool BrowserTruncated { get; init; }
+    }
+
+    /// <summary>
+    /// Project a typed <see cref="SessionFileList"/> into sorted view rows.
+    /// Merges the transcript-referenced <see cref="SessionFileList.Files"/> with
+    /// any optional <see cref="SessionFileList.Browser"/> entries (deduped by
+    /// path, preferring the richer file entry).
+    /// </summary>
+    public static WorkspaceListState FromSessionFileList(SessionFileList list)
+    {
+        if (list == null) return new WorkspaceListState();
+
+        if (!list.IsSupported)
+            return new WorkspaceListState { Supported = false, WorkspacePath = list.Root ?? string.Empty };
+
+        // Identity is case-sensitive: a gateway-backed workspace can contain
+        // distinct paths that differ only by case.
+        var byPath = new Dictionary<string, WorkspaceFileEntry>(StringComparer.Ordinal);
+        var order = new List<string>();
+
+        void Add(WorkspaceFileEntry entry)
+        {
+            if (!byPath.ContainsKey(entry.RelativePath))
+                order.Add(entry.RelativePath);
+            byPath[entry.RelativePath] = entry;
+        }
+
+        foreach (var f in list.Files ?? Array.Empty<SessionFileEntry>())
+        {
+            if (MapFileEntry(f) is { } entry) Add(entry);
+        }
+
+        // Browser entries (present only when a path/search was requested) fill in
+        // directory rows and any files not already referenced by the transcript.
+        foreach (var b in list.Browser?.Entries ?? Array.Empty<SessionFileBrowserEntry>())
+        {
+            if (MapBrowserEntry(b) is not { } entry) continue;
+            if (byPath.ContainsKey(entry.RelativePath)) continue; // file entry wins
+            Add(entry);
+        }
+
+        var entries = Sort(order.Select(p => byPath[p]).ToList());
+        var browser = list.Browser;
+
+        return new WorkspaceListState
+        {
+            WorkspacePath = list.Root ?? string.Empty,
+            Supported = true,
+            Entries = entries,
+            BrowserPath = NormalizeBrowserPath(browser?.Path),
+            BrowserParentPath = browser?.ParentPath is { Length: > 0 } parent
+                ? NormalizeBrowserPath(parent)
+                : browser?.ParentPath,
+            BrowserSearch = browser?.Search ?? string.Empty,
+            BrowserTruncated = browser?.Truncated ?? false,
+        };
+    }
+
+    private static WorkspaceFileEntry? MapFileEntry(SessionFileEntry f)
+    {
+        var requestPath = !string.IsNullOrEmpty(f.Path) ? f.Path : f.Name;
+        if (string.IsNullOrEmpty(requestPath)) return null;
+
+        var relative = NormalizePath(requestPath);
+        var name = !string.IsNullOrEmpty(f.Name) ? f.Name : LeafName(relative);
+        if (string.IsNullOrEmpty(name)) return null;
+
+        return new WorkspaceFileEntry
+        {
+            Name = name,
+            RelativePath = relative,
+            RequestPath = requestPath,
+            Size = f.Size is >= 0 ? f.Size : null,
+            Exists = !f.Missing,
+            IsDirectory = false,
+            IsSessionFile = true,
+            CanPreview = true,
+            Touched = string.Equals(f.Kind, "modified", StringComparison.OrdinalIgnoreCase),
+            Read = string.Equals(f.Kind, "read", StringComparison.OrdinalIgnoreCase),
+            ModifiedUtc = ToUtc(f.UpdatedAt),
+        };
+    }
+
+    private static WorkspaceFileEntry? MapBrowserEntry(SessionFileBrowserEntry b)
+    {
+        var requestPath = !string.IsNullOrEmpty(b.Path) ? b.Path : b.Name;
+        if (string.IsNullOrEmpty(requestPath)) return null;
+
+        var relative = NormalizePath(requestPath);
+        var name = !string.IsNullOrEmpty(b.Name) ? b.Name : LeafName(relative);
+        if (string.IsNullOrEmpty(name)) return null;
+
+        // SessionKind reflects relevance: "modified" / "read" / "mixed".
+        // Compare case-insensitively for consistency with MapFileEntry.
+        bool touched = string.Equals(b.SessionKind, "modified", StringComparison.OrdinalIgnoreCase)
+                       || string.Equals(b.SessionKind, "mixed", StringComparison.OrdinalIgnoreCase);
+        bool read = string.Equals(b.SessionKind, "read", StringComparison.OrdinalIgnoreCase);
+        bool isDirectory = b.IsDirectory;
+        bool isSessionFile = touched || read;
+
+        return new WorkspaceFileEntry
+        {
+            Name = name,
+            RelativePath = relative,
+            RequestPath = requestPath,
+            Size = b.Size is >= 0 ? b.Size : null,
+            Exists = true,
+            IsDirectory = isDirectory,
+            IsSessionFile = isSessionFile,
+            CanPreview = !isDirectory && isSessionFile,
+            Touched = touched,
+            Read = read,
+            ModifiedUtc = ToUtc(b.UpdatedAt),
+        };
+    }
+
+    /// <summary>
+    /// Filter entries by a free-text query matched (case-insensitive) against
+    /// the leaf name and the relative path. Whitespace-only queries return the
+    /// full list unchanged. Ordering is stable (input order preserved).
+    /// </summary>
+    public static IReadOnlyList<WorkspaceFileEntry> Filter(
+        IReadOnlyList<WorkspaceFileEntry> entries, string? query)
+    {
+        if (entries.Count == 0)
+            return entries;
+
+        var trimmed = query?.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+            return entries;
+
+        return entries
+            .Where(e =>
+                e.Name.Contains(trimmed, StringComparison.OrdinalIgnoreCase) ||
+                e.RelativePath.Contains(trimmed, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Default rail ordering: directories first, then files the agent edited,
+    /// then files it only read, then the rest; alphabetical by relative path
+    /// within each tier. Deterministic so the UI does not jitter between
+    /// refreshes.
+    /// </summary>
+    public static IReadOnlyList<WorkspaceFileEntry> Sort(
+        IReadOnlyList<WorkspaceFileEntry> entries)
+    {
+        return entries
+            .OrderBy(Rank)
+            .ThenBy(e => e.RelativePath, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        static int Rank(WorkspaceFileEntry e) =>
+            e.IsDirectory ? 0 : e.Touched ? 1 : e.Read ? 2 : 3;
+    }
+
+    /// <summary>Human-readable byte size (B / KB / MB).</summary>
+    public static string FormatSize(long? bytes)
+    {
+        if (bytes is not { } b || b < 0) return string.Empty;
+        if (b < 1024) return $"{b} B";
+        if (b < 1024 * 1024) return $"{b / 1024.0:F1} KB";
+        return $"{b / (1024.0 * 1024.0):F1} MB";
+    }
+
+    /// <summary>
+    /// The parent folder portion of a relative path, or empty when the file
+    /// sits at the workspace root. Used to render a subtle path caption.
+    /// </summary>
+    public static string DirectoryOf(string relativePath)
+    {
+        if (string.IsNullOrEmpty(relativePath)) return string.Empty;
+        var idx = relativePath.LastIndexOf('/');
+        return idx <= 0 ? string.Empty : relativePath[..idx];
+    }
+
+    public static string NormalizeBrowserPath(string? path) =>
+        string.IsNullOrWhiteSpace(path) ? string.Empty : NormalizePath(path.Trim()).TrimEnd('/');
+
+    private static string LeafName(string? path)
+    {
+        if (string.IsNullOrEmpty(path)) return string.Empty;
+        var normalized = path.Replace('\\', '/').TrimEnd('/');
+        var idx = normalized.LastIndexOf('/');
+        return idx < 0 ? normalized : normalized[(idx + 1)..];
+    }
+
+    private static string NormalizePath(string path) =>
+        path.Replace('\\', '/').TrimStart('/');
+
+    private static DateTimeOffset? ToUtc(DateTime? value)
+    {
+        if (value is not { } dt) return null;
+        return dt.Kind == DateTimeKind.Unspecified
+            ? new DateTimeOffset(DateTime.SpecifyKind(dt, DateTimeKind.Utc))
+            : new DateTimeOffset(dt.ToUniversalTime());
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml
@@ -113,7 +113,15 @@
                 <InfoBar x:Uid="FallbackInfoBar" x:Name="FallbackInfoBar"
                          IsOpen="False" IsClosable="False"
                          Severity="Informational"
-                         Title="Workspace files"/>
+                         Title="Workspace files">
+                    <InfoBar.ActionButton>
+                        <HyperlinkButton x:Name="RepairLink"
+                                         x:Uid="WorkspacePage_OpenConnectionSettings"
+                                         Content="Open Connection settings"
+                                         Visibility="Collapsed"
+                                         Click="RepairLink_Click"/>
+                    </InfoBar.ActionButton>
+                </InfoBar>
             </StackPanel>
 
             <Border x:Name="BodyGrid" Grid.Row="3" Visibility="Collapsed"
@@ -134,10 +142,16 @@
                     </Grid.RowDefinitions>
 
                     <Border Grid.Row="0" Grid.Column="0" Padding="16,12,16,12">
-                        <TextBlock x:Uid="WorkspacePage_FilesHeader"
-                                   Text="Files"
-                                   Style="{StaticResource BodyStrongTextBlockStyle}"
-                                   VerticalAlignment="Center"/>
+                        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                            <TextBlock x:Uid="WorkspacePage_FilesHeader"
+                                       Text="Files"
+                                       Style="{StaticResource BodyStrongTextBlockStyle}"
+                                       VerticalAlignment="Center"/>
+                            <TextBlock x:Name="FileCountText"
+                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       VerticalAlignment="Center"/>
+                        </StackPanel>
                     </Border>
 
                     <Grid Grid.Row="0" Grid.Column="2" Padding="16,8,12,8">
@@ -145,12 +159,20 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
-                        <TextBlock x:Name="SelectedFileText" Grid.Column="0"
-                                   Style="{StaticResource BodyStrongTextBlockStyle}"
-                                   VerticalAlignment="Center"
-                                   TextWrapping="NoWrap"
-                                   TextTrimming="CharacterEllipsis"/>
+                        <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="4">
+                            <TextBlock x:Name="SelectedFileText"
+                                       Style="{StaticResource BodyStrongTextBlockStyle}"
+                                       TextWrapping="NoWrap"
+                                       TextTrimming="CharacterEllipsis"/>
+                            <TextBlock x:Name="SelectedFileMeta"
+                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       TextWrapping="NoWrap"
+                                       TextTrimming="CharacterEllipsis"
+                                       Visibility="Collapsed"/>
+                        </StackPanel>
                         <controls:SelectorBar x:Name="ViewModeSelector" Grid.Column="1"
+                                              VerticalAlignment="Center"
                                               Visibility="Collapsed"
                                               SelectionChanged="ViewModeSelector_SelectionChanged">
                             <controls:SelectorBarItem x:Uid="WorkspacePage_ViewMode_Rendered"
@@ -168,20 +190,69 @@
                     <Border Grid.Row="2" Grid.Column="1"
                             Background="{ThemeResource CardStrokeColorDefaultBrush}"/>
 
-                    <ListView x:Name="FileList" Grid.Row="2" Grid.Column="0"
-                              SelectionMode="Single"
-                              SelectionChanged="FileList_SelectionChanged"
-                              ShowsScrollingPlaceholders="False"
-                              Padding="4,4,4,8">
-                        <ListView.ItemContainerStyle>
-                            <Style TargetType="ListViewItem">
-                                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                                <Setter Property="Padding" Value="12,8"/>
-                                <Setter Property="Margin" Value="0"/>
-                                <Setter Property="CornerRadius" Value="4"/>
-                            </Style>
-                        </ListView.ItemContainerStyle>
-                    </ListView>
+                    <Grid Grid.Row="2" Grid.Column="0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <Grid Grid.Row="0" Margin="8,8,8,0" ColumnSpacing="8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Button x:Name="ParentFolderButton"
+                                    x:Uid="WorkspacePage_ParentFolderButton"
+                                    Content="Up"
+                                    MinWidth="48"
+                                    Padding="8,4"
+                                    Click="ParentFolderButton_Click"/>
+                            <TextBlock x:Name="CurrentFolderText" Grid.Column="1"
+                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       VerticalAlignment="Center"
+                                       TextWrapping="NoWrap"
+                                       TextTrimming="CharacterEllipsis"/>
+                        </Grid>
+                        <AutoSuggestBox x:Name="SearchBox"
+                                        x:Uid="WorkspacePage_SearchBox"
+                                        Grid.Row="1"
+                                        Margin="8,4,8,4"
+                                        QueryIcon="Find"
+                                        PlaceholderText="Search files"
+                                        TextChanged="SearchBox_TextChanged"/>
+                        <TextBlock x:Name="BrowserNoticeText" Grid.Row="2"
+                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   TextWrapping="Wrap"
+                                   Margin="12,0,12,4"
+                                   Visibility="Collapsed"/>
+                        <ListView x:Name="FileList" Grid.Row="3"
+                                  SelectionMode="Single"
+                                  SelectionChanged="FileList_SelectionChanged"
+                                  ShowsScrollingPlaceholders="False"
+                                  Padding="4,0,4,8">
+                            <ListView.ItemContainerStyle>
+                                <Style TargetType="ListViewItem">
+                                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                    <Setter Property="Padding" Value="12,8"/>
+                                    <Setter Property="Margin" Value="0"/>
+                                    <Setter Property="CornerRadius" Value="4"/>
+                                </Style>
+                            </ListView.ItemContainerStyle>
+                        </ListView>
+                        <TextBlock x:Name="NoResultsText" Grid.Row="3"
+                                   x:Uid="WorkspacePage_NoSearchResults"
+                                   Text="No files match your search."
+                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   TextWrapping="Wrap"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   Margin="16"
+                                   Visibility="Collapsed"/>
+                    </Grid>
 
                     <ScrollViewer Grid.Row="2" Grid.Column="2"
                                   VerticalScrollBarVisibility="Auto"

--- a/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Media;
@@ -7,24 +8,44 @@ using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
+using System.Linq;
 using System.Text;
-using System.Text.Json;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.DataTransfer;
 
 namespace OpenClawTray.Pages;
 
 public sealed partial class WorkspacePage : Page
 {
     private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
-    private AppState? _appState;
 
-    // file name (case-insensitive) → its list item
-    private readonly Dictionary<string, ListViewItem> _fileItems = new(StringComparer.OrdinalIgnoreCase);
+    // All entries from the latest list result, in display (sorted) order.
+    private readonly List<WorkspaceFilesModel.WorkspaceFileEntry> _allEntries = new();
 
-    // file name → raw text content (null = missing on disk, absent = not loaded yet)
-    private readonly Dictionary<string, string?> _fileContent = new(StringComparer.OrdinalIgnoreCase);
+    // relativePath → entry, for selection lookup. Case-sensitive: workspace
+    // paths may differ only by case.
+    private readonly Dictionary<string, WorkspaceFilesModel.WorkspaceFileEntry> _entriesByPath =
+        new(StringComparer.Ordinal);
 
+    private enum FileBodyKind { Loaded, Missing }
+
+    // relativePath → resolved body. Only stable outcomes are cached (loaded
+    // content or confirmed-missing); transient/unavailable errors are NOT cached
+    // so re-selecting the file retries the fetch.
+    private readonly Dictionary<string, (FileBodyKind Kind, string? Content)> _fileContent =
+        new(StringComparer.Ordinal);
+
+    private readonly DispatcherTimer _searchDebounceTimer = new() { Interval = TimeSpan.FromMilliseconds(250) };
+
+    private string _browserPath = string.Empty;
+    private string? _browserParentPath;
+    private string _searchQuery = string.Empty;
+    private bool _suppressSearchTextChanged;
     private bool _renderMarkdown = true;
+
+    // Monotonic token guarding against out-of-order async results: a list/file
+    // load applies only when its token still matches the latest request.
+    private int _loadToken;
 
     /// <summary>Set by HubWindow before <see cref="Initialize"/> to specify the active agent scope.</summary>
     public string AgentId { get; set; } = "main";
@@ -33,9 +54,11 @@ public sealed partial class WorkspacePage : Page
     public WorkspacePage()
     {
         InitializeComponent();
-        Unloaded += (_, _) =>
+        Unloaded += (_, _) => _searchDebounceTimer.Stop();
+        _searchDebounceTimer.Tick += (_, _) =>
         {
-            if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+            _searchDebounceTimer.Stop();
+            _ = LoadAsync();
         };
     }
 
@@ -51,181 +74,488 @@ public sealed partial class WorkspacePage : Page
 
     public void Initialize()
     {
-        _appState = CurrentApp.AppState!;
-        _appState.PropertyChanged += OnAppStateChanged;
+        _ = LoadAsync();
+    }
 
-        if (_appState.TryGetCachedAgentFilesList(AgentId, out var cachedData))
+    /// <summary>
+    /// Resolve the gateway session key for the current agent. The typed
+    /// <c>sessions.files.*</c> API is keyed by session key (e.g.
+    /// <c>agent:main:main</c>), so map the agent to its canonical main session,
+    /// preferring the handshake-resolved key for the default agent. The
+    /// <c>agent:&lt;id&gt;:main</c> fallback assumes a simple slug agent id.
+    /// </summary>
+    private string? ResolveSessionKey()
+    {
+        var client = CurrentApp.GatewayClient;
+        if (client == null) return null;
+
+        var agentId = string.IsNullOrWhiteSpace(AgentId) ? "main" : AgentId.Trim();
+        if (string.Equals(agentId, "main", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(client.MainSessionKey))
         {
-            UpdateAgentFilesList(cachedData);
+            return client.MainSessionKey;
+        }
+        return $"agent:{agentId}:main";
+    }
+
+    private async Task LoadAsync()
+    {
+        // Invalidate any in-flight list/file loads up front — before the
+        // connected/key early-returns — so a stale result can never render
+        // after a newer (even failed) load.
+        var token = ++_loadToken;
+
+        var client = CurrentApp.GatewayClient;
+        var status = CurrentApp.AppState?.Status ?? ConnectionStatus.Disconnected;
+        if (client == null || status != ConnectionStatus.Connected)
+        {
+            ShowDisconnected();
             return;
         }
 
-        var hasMatchingCache = _appState?.AgentFilesList.HasValue == true &&
-            string.Equals(_appState?.AgentFilesListAgentId, AgentId, StringComparison.OrdinalIgnoreCase);
-        var status = CurrentApp.AppState?.Status ?? ConnectionStatus.Disconnected;
-        if (CurrentApp.GatewayClient != null && status == ConnectionStatus.Connected && !hasMatchingCache)
+        var key = ResolveSessionKey();
+        if (string.IsNullOrWhiteSpace(key))
         {
-            FallbackInfoBar.IsOpen = false;
-            LoadingRing.IsActive = true;
-            LoadingPanel.Visibility = Visibility.Visible;
-            ClearFiles();
-            _ = CurrentApp.GatewayClient.RequestAgentFilesListAsync(AgentId);
+            ShowDisconnected();
+            return;
         }
-        else if (hasMatchingCache)
+
+        BeginLoading();
+
+        SessionFileList result;
+        try
         {
-            UpdateAgentFilesList(_appState!.AgentFilesList!.Value);
+            var search = string.IsNullOrWhiteSpace(_searchQuery) ? null : _searchQuery.Trim();
+            var path = search is null ? _browserPath : string.Empty;
+            result = await client.ListSessionFilesAsync(key, path, search);
         }
-        else if (CurrentApp.GatewayClient == null || status != ConnectionStatus.Connected)
+        catch (Exception ex)
         {
-            FallbackInfoBar.IsOpen = true;
-            FallbackInfoBar.Message = LocalizationHelper.GetString("WorkspacePage_DisconnectedMessage");
+            if (token != _loadToken) return;
+            Services.Logger.Warn($"[WorkspacePage] sessions.files.list failed: {ex.Message}");
+            EndLoading();
+            if (CurrentApp.AppState?.Status == ConnectionStatus.Connected)
+                ShowLoadError();
+            else
+                ShowDisconnected();
+            return;
         }
+
+        if (token != _loadToken) return; // a newer load superseded this one
+        EndLoading();
+        ApplyListResult(result);
     }
 
-    private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
+    private void ApplyListResult(SessionFileList result)
     {
-        switch (e.PropertyName)
+        ClearFiles();
+
+        var state = WorkspaceFilesModel.FromSessionFileList(result);
+        WorkspacePathText.Text = state.WorkspacePath;
+        _browserPath = state.BrowserPath;
+        _browserParentPath = state.BrowserParentPath;
+        UpdateBrowserChrome(state);
+
+        if (!state.Supported)
         {
-            case nameof(AppState.AgentFilesList):
-                if (_appState!.AgentFilesList.HasValue) UpdateAgentFilesList(_appState.AgentFilesList.Value);
-                break;
-            case nameof(AppState.AgentFileContent):
-                if (_appState!.AgentFileContent.HasValue) UpdateAgentFileContent(_appState.AgentFileContent.Value);
-                break;
+            ShowUnsupported();
+            return;
         }
+
+        foreach (var entry in state.Entries)
+        {
+            _allEntries.Add(entry);
+            _entriesByPath[entry.RelativePath] = entry;
+        }
+
+        if (_allEntries.Count == 0 && string.IsNullOrWhiteSpace(_searchQuery) && string.IsNullOrEmpty(_browserPath))
+        {
+            ShowNoFiles();
+            return;
+        }
+
+        HideFallback();
+        BodyGrid.Visibility = Visibility.Visible;
+        ApplyFilter();
     }
 
-    public void UpdateAgentFilesList(JsonElement data)
+    private void BeginLoading()
+    {
+        HideFallback();
+        LoadingRing.IsActive = true;
+        LoadingPanel.Visibility = Visibility.Visible;
+        ClearFiles();
+        BrowserNoticeText.Visibility = Visibility.Collapsed;
+    }
+
+    private void EndLoading()
     {
         LoadingRing.IsActive = false;
         LoadingPanel.Visibility = Visibility.Collapsed;
-        ClearFiles();
+    }
 
-        if (data.TryGetProperty("workspace", out var workspaceEl))
+    private void ApplyFilter()
+    {
+        var filtered = WorkspaceFilesModel.Filter(_allEntries, _searchQuery);
+
+        FileList.SelectionChanged -= FileList_SelectionChanged;
+        FileList.Items.Clear();
+        foreach (var entry in filtered)
+            FileList.Items.Add(BuildFileRow(entry));
+        FileList.SelectionChanged += FileList_SelectionChanged;
+
+        FileCountText.Text = _allEntries.Count > 0
+            ? filtered.Count == _allEntries.Count ? $"({_allEntries.Count})" : $"({filtered.Count} of {_allEntries.Count})"
+            : string.Empty;
+
+        bool hasResults = filtered.Count > 0;
+        bool searching = !string.IsNullOrWhiteSpace(_searchQuery);
+        NoResultsText.Text = LocalizationHelper.GetString(searching
+            ? "WorkspacePage_NoSearchResults.Text"
+            : "WorkspacePage_NoFolderResults");
+        NoResultsText.Visibility = !hasResults ? Visibility.Visible : Visibility.Collapsed;
+
+        if (hasResults)
         {
-            var workspace = workspaceEl.GetString();
-            if (!string.IsNullOrEmpty(workspace))
-                WorkspacePathText.Text = workspace;
-        }
-
-        if (data.TryGetProperty("files", out var filesEl) && filesEl.ValueKind == JsonValueKind.Array)
-        {
-            foreach (var fileEl in filesEl.EnumerateArray())
-            {
-                var name = fileEl.TryGetProperty("name", out var nameEl) ? nameEl.GetString() ?? "" : "";
-                long size = fileEl.TryGetProperty("size", out var sizeEl) && sizeEl.ValueKind == JsonValueKind.Number ? sizeEl.GetInt64() : 0;
-                bool exists = !fileEl.TryGetProperty("exists", out var existsEl) || existsEl.ValueKind != JsonValueKind.False;
-
-                if (!string.IsNullOrEmpty(name) && exists)
-                    AddFileItem(name, size);
-            }
-        }
-
-        if (_fileItems.Count == 0)
-        {
-            FallbackInfoBar.IsOpen = true;
-            FallbackInfoBar.Message = LocalizationHelper.GetString("WorkspacePage_NoFilesMessage");
-            BodyGrid.Visibility = Visibility.Collapsed;
+            SelectInitialRow(filtered);
         }
         else
         {
-            BodyGrid.Visibility = Visibility.Visible;
-            FileList.SelectedIndex = 0;
-            RequestSelectedFileIfNeeded();
+            FileBodyPresenter.Content = null;
+            SelectedFileText.Text = string.Empty;
+            SelectedFileMeta.Visibility = Visibility.Collapsed;
+            ViewModeSelector.Visibility = Visibility.Collapsed;
         }
     }
 
-    public void UpdateAgentFileContent(JsonElement data)
+    private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
     {
-        if (!data.TryGetProperty("file", out var fileEl)) return;
-
-        var name = fileEl.TryGetProperty("name", out var nameEl) ? nameEl.GetString() ?? "" : "";
-        var content = fileEl.TryGetProperty("content", out var contentEl) ? contentEl.GetString() ?? "" : "";
-        bool missing = fileEl.TryGetProperty("missing", out var missingEl) && missingEl.ValueKind == JsonValueKind.True;
-
-        if (string.IsNullOrEmpty(name) || !_fileItems.ContainsKey(name)) return;
-
-        _fileContent[name] = missing ? null : content;
-
-        if (FileList.SelectedItem is ListViewItem selected &&
-            selected.Tag is string selectedName &&
-            string.Equals(selectedName, name, StringComparison.OrdinalIgnoreCase))
+        if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput &&
+            args.Reason != AutoSuggestionBoxTextChangeReason.ProgrammaticChange)
         {
-            RenderSelectedFile();
+            return;
         }
+        if (_suppressSearchTextChanged) return;
+        _searchQuery = sender.Text ?? string.Empty;
+        _searchDebounceTimer.Stop();
+        _searchDebounceTimer.Start();
     }
 
-    private void AddFileItem(string fileName, long size)
+    private void SelectInitialRow(IReadOnlyList<WorkspaceFilesModel.WorkspaceFileEntry> filtered)
     {
-        var stack = new StackPanel { Spacing = 2 };
+        int index = -1;
+        for (int i = 0; i < filtered.Count; i++)
+        {
+            if (filtered[i].CanPreview || !filtered[i].Exists)
+            {
+                index = i;
+                break;
+            }
+        }
+
+        if (index < 0)
+        {
+            FileList.SelectedIndex = -1;
+            SelectedFileText.Text = string.Empty;
+            SelectedFileMeta.Visibility = Visibility.Collapsed;
+            ViewModeSelector.Visibility = Visibility.Collapsed;
+            FileBodyPresenter.Content = null;
+            return;
+        }
+
+        FileList.SelectedIndex = index;
+    }
+
+    private ListViewItem BuildFileRow(WorkspaceFilesModel.WorkspaceFileEntry entry)
+    {
+        var row = new Grid { ColumnSpacing = 8 };
+        row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var glyph = new FontIcon
+        {
+            Glyph = entry.IsDirectory ? FluentIconCatalog.Folder : FluentIconCatalog.Document,
+            FontSize = 16,
+            VerticalAlignment = VerticalAlignment.Top,
+            Margin = new Thickness(0, 2, 0, 0),
+            IsTextScaleFactorEnabled = false,
+            Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+        };
+        Grid.SetColumn(glyph, 0);
+        row.Children.Add(glyph);
+
+        var stack = new StackPanel { Spacing = 4 };
+        Grid.SetColumn(stack, 1);
+
         stack.Children.Add(new TextBlock
         {
-            Text = fileName,
+            Text = entry.Name,
             TextTrimming = TextTrimming.CharacterEllipsis,
-            TextWrapping = TextWrapping.NoWrap
+            TextWrapping = TextWrapping.NoWrap,
         });
-        if (size > 0)
+
+        var meta = BuildRowMeta(entry);
+        if (!string.IsNullOrEmpty(meta))
         {
             stack.Children.Add(new TextBlock
             {
-                Text = FormatSize(size),
+                Text = meta,
                 Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
-                Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]
+                Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                TextWrapping = TextWrapping.NoWrap,
             });
         }
 
-        var item = new ListViewItem { Content = stack, Tag = fileName };
-        _fileItems[fileName] = item;
-        FileList.Items.Add(item);
+        row.Children.Add(stack);
+
+        var badges = BuildBadges(entry);
+        if (badges != null)
+        {
+            Grid.SetColumn(badges, 2);
+            row.Children.Add(badges);
+        }
+
+        var item = new ListViewItem { Content = row, Tag = entry.RelativePath };
+        AutomationProperties.SetName(item, BuildAutomationName(entry));
+        item.ContextFlyout = BuildRowContextFlyout(entry);
+        return item;
+    }
+
+    private MenuFlyout BuildRowContextFlyout(WorkspaceFilesModel.WorkspaceFileEntry entry)
+    {
+        var copyLabel = LocalizationHelper.GetString("WorkspacePage_CopyPath");
+        var copy = new MenuFlyoutItem
+        {
+            Text = copyLabel,
+            Tag = entry.RequestPath,
+            Icon = new FontIcon
+            {
+                Glyph = FluentIconCatalog.Copy,
+                FontSize = 16,
+                IsTextScaleFactorEnabled = false,
+            },
+        };
+        copy.Click += CopyPathButton_Click;
+
+        var menu = new MenuFlyout();
+        menu.Items.Add(copy);
+        return menu;
+    }
+
+    private static string BuildAutomationName(WorkspaceFilesModel.WorkspaceFileEntry entry)
+    {
+        var role = LocalizationHelper.GetString(entry.IsDirectory
+            ? "WorkspacePage_FileType_Folder"
+            : "WorkspacePage_FileType_File");
+        var parts = new List<string> { role, entry.Name };
+        var meta = BuildRowMeta(entry);
+        if (!string.IsNullOrEmpty(meta)) parts.Add(meta);
+        if (!entry.Exists) parts.Add(LocalizationHelper.GetString("WorkspacePage_Badge_Missing"));
+        if (entry.Touched) parts.Add(LocalizationHelper.GetString("WorkspacePage_Badge_Edited"));
+        else if (entry.Read) parts.Add(LocalizationHelper.GetString("WorkspacePage_Badge_Read"));
+        return string.Join(", ", parts);
+    }
+
+    // Second-line caption: parent folder · size. Modified time, when present,
+    // is shown in the detail header rather than crowding every row.
+    private static string BuildRowMeta(WorkspaceFilesModel.WorkspaceFileEntry entry)
+    {
+        var parts = new List<string>(2);
+        var dir = WorkspaceFilesModel.DirectoryOf(entry.RelativePath);
+        if (!string.IsNullOrEmpty(dir)) parts.Add(dir);
+        var size = WorkspaceFilesModel.FormatSize(entry.Size);
+        if (!string.IsNullOrEmpty(size)) parts.Add(size);
+        return string.Join(" · ", parts);
+    }
+
+    private StackPanel? BuildBadges(WorkspaceFilesModel.WorkspaceFileEntry entry)
+    {
+        var badges = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 4,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            VerticalAlignment = VerticalAlignment.Top,
+        };
+
+        if (!entry.Exists)
+            badges.Children.Add(BuildBadge("WorkspacePage_Badge_Missing", "SystemFillColorCautionBrush"));
+        if (entry.Touched)
+            badges.Children.Add(BuildBadge("WorkspacePage_Badge_Edited", "AccentTextFillColorPrimaryBrush"));
+        else if (entry.Read)
+            badges.Children.Add(BuildBadge("WorkspacePage_Badge_Read", "TextFillColorSecondaryBrush"));
+
+        return badges.Children.Count > 0 ? badges : null;
+    }
+
+    private static Border BuildBadge(string resKey, string foregroundBrushKey)
+    {
+        return new Border
+        {
+            Background = (Brush)Application.Current.Resources["ControlFillColorSecondaryBrush"],
+            CornerRadius = new CornerRadius(4),
+            Padding = new Thickness(8, 0, 8, 0),
+            Child = new TextBlock
+            {
+                Text = LocalizationHelper.GetString(resKey),
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                Foreground = (Brush)Application.Current.Resources[foregroundBrushKey],
+            },
+        };
     }
 
     private void ClearFiles()
     {
+        FileList.SelectionChanged -= FileList_SelectionChanged;
         FileList.Items.Clear();
-        _fileItems.Clear();
+        FileList.SelectionChanged += FileList_SelectionChanged;
+        _allEntries.Clear();
+        _entriesByPath.Clear();
         _fileContent.Clear();
         FileBodyPresenter.Content = null;
         SelectedFileText.Text = string.Empty;
+        SelectedFileMeta.Visibility = Visibility.Collapsed;
+        FileCountText.Text = string.Empty;
+        NoResultsText.Visibility = Visibility.Collapsed;
         BodyGrid.Visibility = Visibility.Collapsed;
         ViewModeSelector.Visibility = Visibility.Collapsed;
     }
 
+    private string? SelectedRelativePath() =>
+        FileList.SelectedItem is ListViewItem { Tag: string path } ? path : null;
+
     private void FileList_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
-        if (FileList.SelectedItem is not ListViewItem selected ||
-            selected.Tag is not string fileName)
+        if (SelectedRelativePath() is not string relativePath ||
+            !_entriesByPath.TryGetValue(relativePath, out var entry))
         {
             return;
         }
 
-        bool isMarkdown = IsMarkdown(fileName);
-        ViewModeSelector.Visibility = isMarkdown ? Visibility.Visible : Visibility.Collapsed;
-        SelectedFileText.Text = fileName;
+        SelectedFileText.Text = entry.Name;
+        UpdateDetailMeta(entry);
 
-        if (_fileContent.ContainsKey(fileName))
+        if (entry.IsDirectory)
+        {
+            ViewModeSelector.Visibility = Visibility.Collapsed;
+            BrowseToPath(entry.RequestPath);
+            return;
+        }
+
+        ViewModeSelector.Visibility = IsMarkdown(entry.Name) ? Visibility.Visible : Visibility.Collapsed;
+
+        if (!entry.CanPreview)
+        {
+            ViewModeSelector.Visibility = Visibility.Collapsed;
+            FileBodyPresenter.Content = BuildNoteBody(
+                LocalizationHelper.GetString("WorkspacePage_BrowserOnlyFileNote"));
+            return;
+        }
+
+        // Files the list already reported as missing on disk never need a fetch.
+        if (!entry.Exists)
+        {
+            _fileContent[relativePath] = (FileBodyKind.Missing, null);
+            RenderSelectedFile();
+            return;
+        }
+
+        if (_fileContent.ContainsKey(relativePath))
         {
             RenderSelectedFile();
         }
         else
         {
             ShowLoadingBody();
-            if (CurrentApp.GatewayClient != null)
-                _ = CurrentApp.GatewayClient.RequestAgentFileGetAsync(AgentId, fileName);
+            _ = LoadFileAsync(entry);
         }
     }
 
-    private void RequestSelectedFileIfNeeded()
+    private async Task LoadFileAsync(WorkspaceFilesModel.WorkspaceFileEntry entry)
     {
-        if (FileList.SelectedItem is not ListViewItem selected ||
-            selected.Tag is not string fileName ||
-            _fileContent.ContainsKey(fileName))
+        var client = CurrentApp.GatewayClient;
+        var key = ResolveSessionKey();
+        if (client == null || string.IsNullOrWhiteSpace(key))
         {
+            ShowFileUnavailable(entry.RelativePath);
             return;
         }
 
-        ShowLoadingBody();
-        if (CurrentApp.GatewayClient != null)
-            _ = CurrentApp.GatewayClient.RequestAgentFileGetAsync(AgentId, fileName);
+        var token = _loadToken;
+        try
+        {
+            // Use the gateway's original path string, not the normalized display
+            // path, so the request matches exactly what the gateway indexed.
+            var result = await client.GetSessionFileAsync(key, entry.RequestPath);
+            if (token != _loadToken) return; // list reloaded underneath us
+
+            if (!result.IsSupported)
+            {
+                // A gateway that lists but can't serve a single file is an
+                // inconsistent edge — surface it inline rather than tearing down
+                // the whole rail, and don't cache so re-selection can retry.
+                ShowFileUnavailable(entry.RelativePath);
+                return;
+            }
+
+            if (result.Missing)
+                SetFileBody(entry.RelativePath, FileBodyKind.Missing, null);
+            else if (result.Content is null)
+                ShowFileUnavailable(entry.RelativePath);
+            else
+                SetFileBody(entry.RelativePath, FileBodyKind.Loaded, result.Content);
+        }
+        catch (Exception ex)
+        {
+            if (token != _loadToken) return;
+            // The gateway returns an error for missing / too-large files. Show it
+            // inline without caching so the user can retry by reselecting.
+            Services.Logger.Warn($"[WorkspacePage] sessions.files.get failed for '{entry.RequestPath}': {ex.Message}");
+            ShowFileUnavailable(entry.RelativePath);
+        }
+    }
+
+    // Cache a stable body outcome (loaded content or confirmed-missing) and
+    // render it if the file is still selected.
+    private void SetFileBody(string relativePath, FileBodyKind kind, string? content)
+    {
+        _fileContent[relativePath] = (kind, content);
+        if (string.Equals(SelectedRelativePath(), relativePath, StringComparison.Ordinal))
+            RenderSelectedFile();
+    }
+
+    // Transient/unavailable error: shown inline but NOT cached, so re-selecting
+    // the file retries the fetch instead of permanently reading as "missing".
+    private void ShowFileUnavailable(string relativePath)
+    {
+        if (string.Equals(SelectedRelativePath(), relativePath, StringComparison.Ordinal))
+        {
+            FileBodyPresenter.Content = BuildNoteBody(
+                LocalizationHelper.GetString("WorkspacePage_FileUnavailable"));
+        }
+    }
+
+    private void UpdateDetailMeta(WorkspaceFilesModel.WorkspaceFileEntry entry)
+    {
+        var parts = new List<string>(3);
+        var size = WorkspaceFilesModel.FormatSize(entry.Size);
+        if (!string.IsNullOrEmpty(size)) parts.Add(size);
+        if (entry.ModifiedUtc is { } modified)
+            parts.Add(modified.ToLocalTime().ToString("g"));
+        if (!entry.Exists)
+            parts.Add(LocalizationHelper.GetString("WorkspacePage_Badge_Missing"));
+
+        if (parts.Count > 0)
+        {
+            SelectedFileMeta.Text = string.Join(" · ", parts);
+            SelectedFileMeta.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            SelectedFileMeta.Visibility = Visibility.Collapsed;
+        }
     }
 
     private void ViewModeSelector_SelectionChanged(SelectorBar sender, SelectorBarSelectionChangedEventArgs args)
@@ -252,39 +582,42 @@ public sealed partial class WorkspacePage : Page
         FileBodyPresenter.Content = loading;
     }
 
+    private static TextBlock BuildNoteBody(string text) => new()
+    {
+        Text = text,
+        Style = (Style)Application.Current.Resources["BodyTextBlockStyle"],
+        Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]
+    };
+
     private void RenderSelectedFile()
     {
-        if (FileList.SelectedItem is not ListViewItem selected ||
-            selected.Tag is not string fileName)
+        if (SelectedRelativePath() is not string relativePath)
         {
             FileBodyPresenter.Content = null;
             return;
         }
 
-        if (!_fileContent.TryGetValue(fileName, out var content))
+        if (!_fileContent.TryGetValue(relativePath, out var body))
         {
             ShowLoadingBody();
             return;
         }
 
-        if (content == null)
+        if (body.Kind == FileBodyKind.Missing || body.Content == null)
         {
-            FileBodyPresenter.Content = new TextBlock
-            {
-                Text = LocalizationHelper.GetString("WorkspacePage_MissingFile"),
-                Style = (Style)Application.Current.Resources["BodyTextBlockStyle"],
-                Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"]
-            };
+            FileBodyPresenter.Content = BuildNoteBody(
+                LocalizationHelper.GetString("WorkspacePage_MissingFile"));
             return;
         }
 
-        if (IsMarkdown(fileName) && _renderMarkdown)
+        var name = _entriesByPath.TryGetValue(relativePath, out var entry) ? entry.Name : relativePath;
+        if (IsMarkdown(name) && _renderMarkdown)
         {
-            FileBodyPresenter.Content = BuildMarkdownView(content);
+            FileBodyPresenter.Content = BuildMarkdownView(body.Content);
         }
         else
         {
-            FileBodyPresenter.Content = BuildRawView(content);
+            FileBodyPresenter.Content = BuildRawView(body.Content);
         }
     }
 
@@ -550,20 +883,122 @@ public sealed partial class WorkspacePage : Page
 
     private void RefreshButton_Click(object sender, RoutedEventArgs e)
     {
-        if (CurrentApp.GatewayClient != null)
+        _ = LoadAsync();
+    }
+
+    private void ParentFolderButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_browserParentPath is not null)
+            BrowseToPath(_browserParentPath);
+    }
+
+    private void CopyPathButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement { Tag: string path } || string.IsNullOrWhiteSpace(path))
+            return;
+
+        try
         {
-            LoadingRing.IsActive = true;
-            LoadingPanel.Visibility = Visibility.Visible;
-            FallbackInfoBar.IsOpen = false;
-            ClearFiles();
-            _ = CurrentApp.GatewayClient.RequestAgentFilesListAsync(AgentId);
+            var data = new DataPackage();
+            data.SetText(path);
+            Clipboard.SetContent(data);
+        }
+        catch (Exception ex)
+        {
+            Services.Logger.Warn($"[WorkspacePage] Clipboard copy failed: {ex.Message}");
+            BrowserNoticeText.Text = LocalizationHelper.GetString("WorkspacePage_CopyPathFailed");
+            BrowserNoticeText.Visibility = Visibility.Visible;
         }
     }
 
-    private static string FormatSize(long bytes)
+    private void BrowseToPath(string? path)
     {
-        if (bytes < 1024) return $"{bytes} B";
-        if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
-        return $"{bytes / (1024.0 * 1024.0):F1} MB";
+        _browserPath = WorkspaceFilesModel.NormalizeBrowserPath(path);
+        _suppressSearchTextChanged = true;
+        try
+        {
+            SearchBox.Text = string.Empty;
+            _searchQuery = string.Empty;
+        }
+        finally
+        {
+            _suppressSearchTextChanged = false;
+        }
+        _ = LoadAsync();
+    }
+
+    private void UpdateBrowserChrome(WorkspaceFilesModel.WorkspaceListState state)
+    {
+        bool searching = !string.IsNullOrWhiteSpace(state.BrowserSearch);
+        ParentFolderButton.IsEnabled = !searching && state.BrowserParentPath is not null;
+        CurrentFolderText.Text = searching
+            ? LocalizationHelper.Format("WorkspacePage_SearchResultsPath", state.BrowserSearch.Trim())
+            : string.IsNullOrEmpty(state.BrowserPath)
+                ? LocalizationHelper.GetString("WorkspacePage_RootFolder")
+                : state.BrowserPath;
+
+        if (state.BrowserTruncated)
+        {
+            BrowserNoticeText.Text = LocalizationHelper.GetString("WorkspacePage_BrowserTruncated");
+            BrowserNoticeText.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            BrowserNoticeText.Visibility = Visibility.Collapsed;
+        }
+    }
+
+    private void RepairLink_Click(object sender, RoutedEventArgs e)
+        => ((IAppCommands)CurrentApp).Navigate("connection");
+
+    private void HideFallback()
+    {
+        FallbackInfoBar.IsOpen = false;
+        RepairLink.Visibility = Visibility.Collapsed;
+    }
+
+    private void ShowLoadError()
+    {
+        EndLoading();
+        ClearFiles();
+        FallbackInfoBar.Severity = InfoBarSeverity.Warning;
+        FallbackInfoBar.Message = LocalizationHelper.GetString("WorkspacePage_LoadErrorMessage");
+        RepairLink.Visibility = Visibility.Collapsed;
+        FallbackInfoBar.IsOpen = true;
+    }
+
+    // Gateway unreachable: offer a one-tap route to Connection settings so the
+    // user can repair pairing instead of hitting a silent dead end.
+    private void ShowDisconnected()
+    {
+        EndLoading();
+        ClearFiles();
+        WorkspacePathText.Text = string.Empty;
+        FallbackInfoBar.Severity = InfoBarSeverity.Warning;
+        FallbackInfoBar.Message = LocalizationHelper.GetString("WorkspacePage_DisconnectedMessage");
+        RepairLink.Visibility = Visibility.Visible;
+        FallbackInfoBar.IsOpen = true;
+    }
+
+    // Connected gateway that doesn't implement sessions.files.list (older
+    // gateway) or errored serving it. Same repair affordance, distinct copy so
+    // the user knows it's a capability gap.
+    private void ShowUnsupported()
+    {
+        EndLoading();
+        FallbackInfoBar.Severity = InfoBarSeverity.Warning;
+        FallbackInfoBar.Message = LocalizationHelper.GetString("WorkspacePage_UnsupportedMessage");
+        RepairLink.Visibility = Visibility.Visible;
+        FallbackInfoBar.IsOpen = true;
+        BodyGrid.Visibility = Visibility.Collapsed;
+    }
+
+    private void ShowNoFiles()
+    {
+        FallbackInfoBar.Severity = InfoBarSeverity.Informational;
+        FallbackInfoBar.Message = LocalizationHelper.GetString("WorkspacePage_NoFilesMessage");
+        RepairLink.Visibility = Visibility.Collapsed;
+        FallbackInfoBar.IsOpen = true;
+        BodyGrid.Visibility = Visibility.Collapsed;
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml.cs
@@ -8,8 +8,10 @@ using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
 
@@ -18,6 +20,7 @@ namespace OpenClawTray.Pages;
 public sealed partial class WorkspacePage : Page
 {
     private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
+    private AppState? _appState;
 
     // All entries from the latest list result, in display (sorted) order.
     private readonly List<WorkspaceFilesModel.WorkspaceFileEntry> _allEntries = new();
@@ -41,6 +44,7 @@ public sealed partial class WorkspacePage : Page
     private string? _browserParentPath;
     private string _searchQuery = string.Empty;
     private bool _suppressSearchTextChanged;
+    private bool _usingLegacyAgentFilesFallback;
     private bool _renderMarkdown = true;
 
     // Monotonic token guarding against out-of-order async results: a list/file
@@ -54,7 +58,12 @@ public sealed partial class WorkspacePage : Page
     public WorkspacePage()
     {
         InitializeComponent();
-        Unloaded += (_, _) => _searchDebounceTimer.Stop();
+        Unloaded += (_, _) =>
+        {
+            _searchDebounceTimer.Stop();
+            if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+            _appState = null;
+        };
         _searchDebounceTimer.Tick += (_, _) =>
         {
             _searchDebounceTimer.Stop();
@@ -74,6 +83,9 @@ public sealed partial class WorkspacePage : Page
 
     public void Initialize()
     {
+        if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+        _appState = CurrentApp.AppState;
+        if (_appState != null) _appState.PropertyChanged += OnAppStateChanged;
         _ = LoadAsync();
     }
 
@@ -104,6 +116,7 @@ public sealed partial class WorkspacePage : Page
         // connected/key early-returns — so a stale result can never render
         // after a newer (even failed) load.
         var token = ++_loadToken;
+        _usingLegacyAgentFilesFallback = false;
 
         var client = CurrentApp.GatewayClient;
         var status = CurrentApp.AppState?.Status ?? ConnectionStatus.Disconnected;
@@ -142,8 +155,68 @@ public sealed partial class WorkspacePage : Page
         }
 
         if (token != _loadToken) return; // a newer load superseded this one
+        if (!result.IsSupported)
+        {
+            await StartLegacyAgentFilesFallbackAsync(token);
+            return;
+        }
+
         EndLoading();
         ApplyListResult(result);
+    }
+
+    private async Task StartLegacyAgentFilesFallbackAsync(int token)
+    {
+        if (token != _loadToken) return;
+        _usingLegacyAgentFilesFallback = true;
+
+        var appState = _appState ?? CurrentApp.AppState;
+        if (appState != null && appState.TryGetCachedAgentFilesList(AgentId, out var cachedData))
+        {
+            EndLoading();
+            ApplyLegacyAgentFilesList(cachedData);
+            return;
+        }
+
+        var client = CurrentApp.GatewayClient;
+        if (client == null)
+        {
+            ShowDisconnected();
+            return;
+        }
+
+        try
+        {
+            await client.RequestAgentFilesListAsync(AgentId);
+        }
+        catch (Exception ex)
+        {
+            if (token != _loadToken) return;
+            Services.Logger.Warn($"[WorkspacePage] agents.files.list fallback failed: {ex.Message}");
+            ShowUnsupported();
+        }
+    }
+
+    private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (!_usingLegacyAgentFilesFallback || _appState == null) return;
+
+        switch (e.PropertyName)
+        {
+            case nameof(AppState.AgentFilesList):
+                if (_appState.AgentFilesList.HasValue &&
+                    (string.IsNullOrEmpty(_appState.AgentFilesListAgentId) ||
+                     string.Equals(_appState.AgentFilesListAgentId, AgentId, StringComparison.OrdinalIgnoreCase)))
+                {
+                    EndLoading();
+                    ApplyLegacyAgentFilesList(_appState.AgentFilesList.Value);
+                }
+                break;
+            case nameof(AppState.AgentFileContent):
+                if (_appState.AgentFileContent.HasValue)
+                    ApplyLegacyAgentFileContent(_appState.AgentFileContent.Value);
+                break;
+        }
     }
 
     private void ApplyListResult(SessionFileList result)
@@ -169,6 +242,33 @@ public sealed partial class WorkspacePage : Page
         }
 
         if (_allEntries.Count == 0 && string.IsNullOrWhiteSpace(_searchQuery) && string.IsNullOrEmpty(_browserPath))
+        {
+            ShowNoFiles();
+            return;
+        }
+
+        HideFallback();
+        BodyGrid.Visibility = Visibility.Visible;
+        ApplyFilter();
+    }
+
+    private void ApplyLegacyAgentFilesList(JsonElement payload)
+    {
+        ClearFiles();
+
+        var state = WorkspaceFilesModel.FromLegacyAgentFilesList(payload);
+        WorkspacePathText.Text = state.WorkspacePath;
+        _browserPath = state.BrowserPath;
+        _browserParentPath = state.BrowserParentPath;
+        UpdateBrowserChrome(state);
+
+        foreach (var entry in state.Entries)
+        {
+            _allEntries.Add(entry);
+            _entriesByPath[entry.RelativePath] = entry;
+        }
+
+        if (_allEntries.Count == 0)
         {
             ShowNoFiles();
             return;
@@ -493,10 +593,7 @@ public sealed partial class WorkspacePage : Page
 
             if (!result.IsSupported)
             {
-                // A gateway that lists but can't serve a single file is an
-                // inconsistent edge — surface it inline rather than tearing down
-                // the whole rail, and don't cache so re-selection can retry.
-                ShowFileUnavailable(entry.RelativePath);
+                await StartLegacyAgentFileGetFallbackAsync(entry, token);
                 return;
             }
 
@@ -515,6 +612,62 @@ public sealed partial class WorkspacePage : Page
             Services.Logger.Warn($"[WorkspacePage] sessions.files.get failed for '{entry.RequestPath}': {ex.Message}");
             ShowFileUnavailable(entry.RelativePath);
         }
+    }
+
+    private async Task StartLegacyAgentFileGetFallbackAsync(
+        WorkspaceFilesModel.WorkspaceFileEntry entry,
+        int token)
+    {
+        var client = CurrentApp.GatewayClient;
+        if (client == null)
+        {
+            ShowFileUnavailable(entry.RelativePath);
+            return;
+        }
+
+        _usingLegacyAgentFilesFallback = true;
+        try
+        {
+            await client.RequestAgentFileGetAsync(AgentId, entry.RequestPath);
+        }
+        catch (Exception ex)
+        {
+            if (token != _loadToken) return;
+            Services.Logger.Warn($"[WorkspacePage] agents.files.get fallback failed for '{entry.RequestPath}': {ex.Message}");
+            ShowFileUnavailable(entry.RelativePath);
+        }
+    }
+
+    private void ApplyLegacyAgentFileContent(JsonElement payload)
+    {
+        if (payload.ValueKind != JsonValueKind.Object ||
+            !payload.TryGetProperty("file", out var fileEl) ||
+            fileEl.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        var name = GetString(fileEl, "path") ?? GetString(fileEl, "name");
+        if (string.IsNullOrEmpty(name)) return;
+
+        var entry = _entriesByPath.Values.FirstOrDefault(e =>
+            string.Equals(e.RequestPath, name, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(e.RelativePath, name, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(e.Name, name, StringComparison.OrdinalIgnoreCase));
+        if (entry == null) return;
+
+        bool missing = GetBool(fileEl, "missing") ?? false;
+        if (missing)
+        {
+            SetFileBody(entry.RelativePath, FileBodyKind.Missing, null);
+            return;
+        }
+
+        var content = GetString(fileEl, "content");
+        if (content is null)
+            ShowFileUnavailable(entry.RelativePath);
+        else
+            SetFileBody(entry.RelativePath, FileBodyKind.Loaded, content);
     }
 
     // Cache a stable body outcome (loaded content or confirmed-missing) and
@@ -1000,5 +1153,19 @@ public sealed partial class WorkspacePage : Page
         RepairLink.Visibility = Visibility.Collapsed;
         FallbackInfoBar.IsOpen = true;
         BodyGrid.Visibility = Visibility.Collapsed;
+    }
+
+    private static string? GetString(JsonElement item, string name)
+    {
+        return item.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+    }
+
+    private static bool? GetBool(JsonElement item, string name)
+    {
+        return item.TryGetProperty(name, out var value) && value.ValueKind is JsonValueKind.True or JsonValueKind.False
+            ? value.GetBoolean()
+            : null;
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2331,6 +2331,69 @@ On your gateway host (Mac/Linux), run:
   <data name="WorkspacePage_LoadingContent" xml:space="preserve">
     <value>Loading content…</value>
   </data>
+  <data name="WorkspacePage_SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Search files</value>
+  </data>
+  <data name="WorkspacePage_ParentFolderButton.Content" xml:space="preserve">
+    <value>Up</value>
+  </data>
+  <data name="WorkspacePage_OpenConnectionSettings.Content" xml:space="preserve">
+    <value>Open Connection settings</value>
+  </data>
+  <data name="WorkspacePage_NoSearchResults.Text" xml:space="preserve">
+    <value>No files match your search.</value>
+  </data>
+  <data name="WorkspacePage_NoFolderResults" xml:space="preserve">
+    <value>No files found in this folder.</value>
+  </data>
+  <data name="WorkspacePage_LoadErrorMessage" xml:space="preserve">
+    <value>Couldn't load workspace files. Try refreshing.</value>
+  </data>
+  <data name="WorkspacePage_UnsupportedMessage" xml:space="preserve">
+    <value>This gateway doesn't support listing workspace files.</value>
+  </data>
+  <data name="WorkspacePage_Badge_Missing" xml:space="preserve">
+    <value>Missing</value>
+  </data>
+  <data name="WorkspacePage_Badge_Edited" xml:space="preserve">
+    <value>Edited</value>
+  </data>
+  <data name="WorkspacePage_Badge_Read" xml:space="preserve">
+    <value>Read</value>
+  </data>
+  <data name="WorkspacePage_FolderNote" xml:space="preserve">
+    <value>This is a folder.</value>
+  </data>
+  <data name="WorkspacePage_FileUnavailable" xml:space="preserve">
+    <value>Couldn't load this file.</value>
+  </data>
+  <data name="WorkspacePage_BrowserOnlyFileNote" xml:space="preserve">
+    <value>Only files read or edited in this session can be previewed.</value>
+  </data>
+  <data name="WorkspacePage_OpenFolder" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="WorkspacePage_CopyPath" xml:space="preserve">
+    <value>Copy path</value>
+  </data>
+  <data name="WorkspacePage_CopyPathFailed" xml:space="preserve">
+    <value>Couldn't copy the path.</value>
+  </data>
+  <data name="WorkspacePage_FileType_File" xml:space="preserve">
+    <value>File</value>
+  </data>
+  <data name="WorkspacePage_FileType_Folder" xml:space="preserve">
+    <value>Folder</value>
+  </data>
+  <data name="WorkspacePage_RootFolder" xml:space="preserve">
+    <value>Root</value>
+  </data>
+  <data name="WorkspacePage_SearchResultsPath" xml:space="preserve">
+    <value>Search results for "{0}"</value>
+  </data>
+  <data name="WorkspacePage_BrowserTruncated" xml:space="preserve">
+    <value>Some results were omitted. Narrow your search or open a folder.</value>
+  </data>
   <data name="WorkspacePage_MissingFile" xml:space="preserve">
     <value>(file not found on disk)</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2283,6 +2283,69 @@ Sur votre hôte passerelle (Mac/Linux), exécutez :
   <data name="WorkspacePage_LoadingContent" xml:space="preserve">
     <value>Chargement du contenu…</value>
   </data>
+  <data name="WorkspacePage_SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Search files</value>
+  </data>
+  <data name="WorkspacePage_ParentFolderButton.Content" xml:space="preserve">
+    <value>Up</value>
+  </data>
+  <data name="WorkspacePage_OpenConnectionSettings.Content" xml:space="preserve">
+    <value>Open Connection settings</value>
+  </data>
+  <data name="WorkspacePage_NoSearchResults.Text" xml:space="preserve">
+    <value>No files match your search.</value>
+  </data>
+  <data name="WorkspacePage_NoFolderResults" xml:space="preserve">
+    <value>No files found in this folder.</value>
+  </data>
+  <data name="WorkspacePage_LoadErrorMessage" xml:space="preserve">
+    <value>Couldn't load workspace files. Try refreshing.</value>
+  </data>
+  <data name="WorkspacePage_UnsupportedMessage" xml:space="preserve">
+    <value>This gateway doesn't support listing workspace files.</value>
+  </data>
+  <data name="WorkspacePage_Badge_Missing" xml:space="preserve">
+    <value>Missing</value>
+  </data>
+  <data name="WorkspacePage_Badge_Edited" xml:space="preserve">
+    <value>Edited</value>
+  </data>
+  <data name="WorkspacePage_Badge_Read" xml:space="preserve">
+    <value>Read</value>
+  </data>
+  <data name="WorkspacePage_FolderNote" xml:space="preserve">
+    <value>This is a folder.</value>
+  </data>
+  <data name="WorkspacePage_FileUnavailable" xml:space="preserve">
+    <value>Couldn't load this file.</value>
+  </data>
+  <data name="WorkspacePage_BrowserOnlyFileNote" xml:space="preserve">
+    <value>Only files read or edited in this session can be previewed.</value>
+  </data>
+  <data name="WorkspacePage_OpenFolder" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="WorkspacePage_CopyPath" xml:space="preserve">
+    <value>Copy path</value>
+  </data>
+  <data name="WorkspacePage_CopyPathFailed" xml:space="preserve">
+    <value>Couldn't copy the path.</value>
+  </data>
+  <data name="WorkspacePage_FileType_File" xml:space="preserve">
+    <value>File</value>
+  </data>
+  <data name="WorkspacePage_FileType_Folder" xml:space="preserve">
+    <value>Folder</value>
+  </data>
+  <data name="WorkspacePage_RootFolder" xml:space="preserve">
+    <value>Root</value>
+  </data>
+  <data name="WorkspacePage_SearchResultsPath" xml:space="preserve">
+    <value>Search results for "{0}"</value>
+  </data>
+  <data name="WorkspacePage_BrowserTruncated" xml:space="preserve">
+    <value>Some results were omitted. Narrow your search or open a folder.</value>
+  </data>
   <data name="WorkspacePage_MissingFile" xml:space="preserve">
     <value>(fichier introuvable sur le disque)</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2284,6 +2284,69 @@ Voer op uw gateway-host (Mac/Linux) uit:
   <data name="WorkspacePage_LoadingContent" xml:space="preserve">
     <value>Inhoud laden…</value>
   </data>
+  <data name="WorkspacePage_SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Search files</value>
+  </data>
+  <data name="WorkspacePage_ParentFolderButton.Content" xml:space="preserve">
+    <value>Up</value>
+  </data>
+  <data name="WorkspacePage_OpenConnectionSettings.Content" xml:space="preserve">
+    <value>Open Connection settings</value>
+  </data>
+  <data name="WorkspacePage_NoSearchResults.Text" xml:space="preserve">
+    <value>No files match your search.</value>
+  </data>
+  <data name="WorkspacePage_NoFolderResults" xml:space="preserve">
+    <value>No files found in this folder.</value>
+  </data>
+  <data name="WorkspacePage_LoadErrorMessage" xml:space="preserve">
+    <value>Couldn't load workspace files. Try refreshing.</value>
+  </data>
+  <data name="WorkspacePage_UnsupportedMessage" xml:space="preserve">
+    <value>This gateway doesn't support listing workspace files.</value>
+  </data>
+  <data name="WorkspacePage_Badge_Missing" xml:space="preserve">
+    <value>Missing</value>
+  </data>
+  <data name="WorkspacePage_Badge_Edited" xml:space="preserve">
+    <value>Edited</value>
+  </data>
+  <data name="WorkspacePage_Badge_Read" xml:space="preserve">
+    <value>Read</value>
+  </data>
+  <data name="WorkspacePage_FolderNote" xml:space="preserve">
+    <value>This is a folder.</value>
+  </data>
+  <data name="WorkspacePage_FileUnavailable" xml:space="preserve">
+    <value>Couldn't load this file.</value>
+  </data>
+  <data name="WorkspacePage_BrowserOnlyFileNote" xml:space="preserve">
+    <value>Only files read or edited in this session can be previewed.</value>
+  </data>
+  <data name="WorkspacePage_OpenFolder" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="WorkspacePage_CopyPath" xml:space="preserve">
+    <value>Copy path</value>
+  </data>
+  <data name="WorkspacePage_CopyPathFailed" xml:space="preserve">
+    <value>Couldn't copy the path.</value>
+  </data>
+  <data name="WorkspacePage_FileType_File" xml:space="preserve">
+    <value>File</value>
+  </data>
+  <data name="WorkspacePage_FileType_Folder" xml:space="preserve">
+    <value>Folder</value>
+  </data>
+  <data name="WorkspacePage_RootFolder" xml:space="preserve">
+    <value>Root</value>
+  </data>
+  <data name="WorkspacePage_SearchResultsPath" xml:space="preserve">
+    <value>Search results for "{0}"</value>
+  </data>
+  <data name="WorkspacePage_BrowserTruncated" xml:space="preserve">
+    <value>Some results were omitted. Narrow your search or open a folder.</value>
+  </data>
   <data name="WorkspacePage_MissingFile" xml:space="preserve">
     <value>(bestand niet gevonden op schijf)</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2283,6 +2283,69 @@
   <data name="WorkspacePage_LoadingContent" xml:space="preserve">
     <value>正在加载内容…</value>
   </data>
+  <data name="WorkspacePage_SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Search files</value>
+  </data>
+  <data name="WorkspacePage_ParentFolderButton.Content" xml:space="preserve">
+    <value>Up</value>
+  </data>
+  <data name="WorkspacePage_OpenConnectionSettings.Content" xml:space="preserve">
+    <value>Open Connection settings</value>
+  </data>
+  <data name="WorkspacePage_NoSearchResults.Text" xml:space="preserve">
+    <value>No files match your search.</value>
+  </data>
+  <data name="WorkspacePage_NoFolderResults" xml:space="preserve">
+    <value>No files found in this folder.</value>
+  </data>
+  <data name="WorkspacePage_LoadErrorMessage" xml:space="preserve">
+    <value>Couldn't load workspace files. Try refreshing.</value>
+  </data>
+  <data name="WorkspacePage_UnsupportedMessage" xml:space="preserve">
+    <value>This gateway doesn't support listing workspace files.</value>
+  </data>
+  <data name="WorkspacePage_Badge_Missing" xml:space="preserve">
+    <value>Missing</value>
+  </data>
+  <data name="WorkspacePage_Badge_Edited" xml:space="preserve">
+    <value>Edited</value>
+  </data>
+  <data name="WorkspacePage_Badge_Read" xml:space="preserve">
+    <value>Read</value>
+  </data>
+  <data name="WorkspacePage_FolderNote" xml:space="preserve">
+    <value>This is a folder.</value>
+  </data>
+  <data name="WorkspacePage_FileUnavailable" xml:space="preserve">
+    <value>Couldn't load this file.</value>
+  </data>
+  <data name="WorkspacePage_BrowserOnlyFileNote" xml:space="preserve">
+    <value>Only files read or edited in this session can be previewed.</value>
+  </data>
+  <data name="WorkspacePage_OpenFolder" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="WorkspacePage_CopyPath" xml:space="preserve">
+    <value>Copy path</value>
+  </data>
+  <data name="WorkspacePage_CopyPathFailed" xml:space="preserve">
+    <value>Couldn't copy the path.</value>
+  </data>
+  <data name="WorkspacePage_FileType_File" xml:space="preserve">
+    <value>File</value>
+  </data>
+  <data name="WorkspacePage_FileType_Folder" xml:space="preserve">
+    <value>Folder</value>
+  </data>
+  <data name="WorkspacePage_RootFolder" xml:space="preserve">
+    <value>Root</value>
+  </data>
+  <data name="WorkspacePage_SearchResultsPath" xml:space="preserve">
+    <value>Search results for "{0}"</value>
+  </data>
+  <data name="WorkspacePage_BrowserTruncated" xml:space="preserve">
+    <value>Some results were omitted. Narrow your search or open a folder.</value>
+  </data>
   <data name="WorkspacePage_MissingFile" xml:space="preserve">
     <value>(磁盘上找不到文件)</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2283,6 +2283,69 @@
   <data name="WorkspacePage_LoadingContent" xml:space="preserve">
     <value>正在載入內容…</value>
   </data>
+  <data name="WorkspacePage_SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Search files</value>
+  </data>
+  <data name="WorkspacePage_ParentFolderButton.Content" xml:space="preserve">
+    <value>Up</value>
+  </data>
+  <data name="WorkspacePage_OpenConnectionSettings.Content" xml:space="preserve">
+    <value>Open Connection settings</value>
+  </data>
+  <data name="WorkspacePage_NoSearchResults.Text" xml:space="preserve">
+    <value>No files match your search.</value>
+  </data>
+  <data name="WorkspacePage_NoFolderResults" xml:space="preserve">
+    <value>No files found in this folder.</value>
+  </data>
+  <data name="WorkspacePage_LoadErrorMessage" xml:space="preserve">
+    <value>Couldn't load workspace files. Try refreshing.</value>
+  </data>
+  <data name="WorkspacePage_UnsupportedMessage" xml:space="preserve">
+    <value>This gateway doesn't support listing workspace files.</value>
+  </data>
+  <data name="WorkspacePage_Badge_Missing" xml:space="preserve">
+    <value>Missing</value>
+  </data>
+  <data name="WorkspacePage_Badge_Edited" xml:space="preserve">
+    <value>Edited</value>
+  </data>
+  <data name="WorkspacePage_Badge_Read" xml:space="preserve">
+    <value>Read</value>
+  </data>
+  <data name="WorkspacePage_FolderNote" xml:space="preserve">
+    <value>This is a folder.</value>
+  </data>
+  <data name="WorkspacePage_FileUnavailable" xml:space="preserve">
+    <value>Couldn't load this file.</value>
+  </data>
+  <data name="WorkspacePage_BrowserOnlyFileNote" xml:space="preserve">
+    <value>Only files read or edited in this session can be previewed.</value>
+  </data>
+  <data name="WorkspacePage_OpenFolder" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="WorkspacePage_CopyPath" xml:space="preserve">
+    <value>Copy path</value>
+  </data>
+  <data name="WorkspacePage_CopyPathFailed" xml:space="preserve">
+    <value>Couldn't copy the path.</value>
+  </data>
+  <data name="WorkspacePage_FileType_File" xml:space="preserve">
+    <value>File</value>
+  </data>
+  <data name="WorkspacePage_FileType_Folder" xml:space="preserve">
+    <value>Folder</value>
+  </data>
+  <data name="WorkspacePage_RootFolder" xml:space="preserve">
+    <value>Root</value>
+  </data>
+  <data name="WorkspacePage_SearchResultsPath" xml:space="preserve">
+    <value>Search results for "{0}"</value>
+  </data>
+  <data name="WorkspacePage_BrowserTruncated" xml:space="preserve">
+    <value>Some results were omitted. Narrow your search or open a folder.</value>
+  </data>
   <data name="WorkspacePage_MissingFile" xml:space="preserve">
     <value>(磁碟上找不到檔案)</value>
   </data>

--- a/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
@@ -302,6 +302,30 @@ public class LocalizationValidationTests
         "CommandCenter_NoLocalGatewayListener",
         "CommandCenter_BrowserProxySshForwardNotListening",
         "CommandCenter_BrowserProxyHostNotDetected",
+        // WorkspacePage session file rail strings — seeded English across all
+        // locales until translations land. Same deferred-translation precedent
+        // as the InstancesPage / ConnectionPage runtime keys above.
+        "WorkspacePage_SearchBox.PlaceholderText",
+        "WorkspacePage_ParentFolderButton.Content",
+        "WorkspacePage_OpenConnectionSettings.Content",
+        "WorkspacePage_NoSearchResults.Text",
+        "WorkspacePage_NoFolderResults",
+        "WorkspacePage_LoadErrorMessage",
+        "WorkspacePage_UnsupportedMessage",
+        "WorkspacePage_Badge_Missing",
+        "WorkspacePage_Badge_Edited",
+        "WorkspacePage_Badge_Read",
+        "WorkspacePage_FolderNote",
+        "WorkspacePage_FileUnavailable",
+        "WorkspacePage_BrowserOnlyFileNote",
+        "WorkspacePage_OpenFolder",
+        "WorkspacePage_CopyPath",
+        "WorkspacePage_CopyPathFailed",
+        "WorkspacePage_FileType_File",
+        "WorkspacePage_FileType_Folder",
+        "WorkspacePage_RootFolder",
+        "WorkspacePage_SearchResultsPath",
+        "WorkspacePage_BrowserTruncated",
     };
 
     private static readonly string[] RequiredRuntimeOnboardingKeys =

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Pages\ConnectionPageRowState.cs" Link="Imported\ConnectionPageRowState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Pages\ChatPagePanelStates.cs" Link="Imported\ChatPagePanelStates.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Pages\ExecPolicyRuleList.cs" Link="Pages\ExecPolicyRuleList.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Pages\WorkspaceFilesModel.cs" Link="Imported\WorkspaceFilesModel.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ConnectionManagerWindowsNodeConnector.cs" Link="Services\ConnectionManagerWindowsNodeConnector.cs" />
     <!-- Pulled in for console-log tail tests. Pure logic, no WinUI deps. -->
     <Compile Include="..\..\src\OpenClaw.SetupEngine.UI\WizardConsoleTail.cs" Link="WizardConsoleTail.cs" />

--- a/tests/OpenClaw.Tray.Tests/WorkspaceFilesModelTests.cs
+++ b/tests/OpenClaw.Tray.Tests/WorkspaceFilesModelTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json;
 using OpenClaw.Shared;
 using OpenClawTray.Pages;
 using Xunit;
@@ -228,6 +229,36 @@ public class WorkspaceFilesModelTests
             File("README.md")));
 
         Assert.Equal(2, state.Entries.Count);
+    }
+
+    [Fact]
+    public void FromLegacyAgentFilesList_MapsExistingFilesAsPreviewableFallbackRows()
+    {
+        using var doc = JsonDocument.Parse("""
+            {
+              "workspace": "C:\\repo",
+              "files": [
+                { "name": "README.md", "size": 2048, "exists": true },
+                { "name": "gone.md", "missing": true }
+              ]
+            }
+            """);
+
+        var state = WorkspaceFilesModel.FromLegacyAgentFilesList(doc.RootElement);
+
+        Assert.True(state.Supported);
+        Assert.Equal(@"C:\repo", state.WorkspacePath);
+        Assert.Equal(2, state.Entries.Count);
+
+        var readme = Assert.Single(state.Entries, e => e.Name == "README.md");
+        Assert.True(readme.IsSessionFile);
+        Assert.True(readme.CanPreview);
+        Assert.True(readme.Exists);
+        Assert.Equal(2048, readme.Size);
+
+        var missing = Assert.Single(state.Entries, e => e.Name == "gone.md");
+        Assert.False(missing.Exists);
+        Assert.True(missing.CanPreview);
     }
 
     // ── Unsupported / null handling ─────────────────────────────────────

--- a/tests/OpenClaw.Tray.Tests/WorkspaceFilesModelTests.cs
+++ b/tests/OpenClaw.Tray.Tests/WorkspaceFilesModelTests.cs
@@ -1,0 +1,367 @@
+using System;
+using OpenClaw.Shared;
+using OpenClawTray.Pages;
+using Xunit;
+
+namespace OpenClaw.Tray.Tests;
+
+/// <summary>
+/// Unit coverage for <see cref="WorkspaceFilesModel"/> — the pure projection
+/// behind the Workspace page session file rail. Exercises the mapping from the
+/// typed gateway DTOs (<see cref="SessionFileList"/> / <see cref="SessionFileEntry"/>
+/// / <see cref="SessionFileBrowser"/>) into view rows, plus search/path,
+/// metadata (size/modified/missing), sort tiering, and unsupported/empty paths.
+/// </summary>
+public class WorkspaceFilesModelTests
+{
+    private static SessionFileEntry File(
+        string path, string? name = null, string? kind = null,
+        bool missing = false, long? size = null, DateTime? updatedAt = null) => new()
+    {
+        Path = path,
+        Name = name ?? "",
+        Kind = kind,
+        Missing = missing,
+        Size = size,
+        UpdatedAt = updatedAt,
+    };
+
+    private static SessionFileList List(params SessionFileEntry[] files) => new()
+    {
+        Key = "agent:main:main",
+        Root = "/home/agent/project",
+        Files = files,
+        IsSupported = true,
+    };
+
+    // ── File list mapping ───────────────────────────────────────────────
+
+    [Fact]
+    public void FromSessionFileList_MapsRootAndBasicFields()
+    {
+        var state = WorkspaceFilesModel.FromSessionFileList(List(
+            File("AGENTS.md", size: 2048),
+            File("plan.md", size: 512)));
+
+        Assert.True(state.Supported);
+        Assert.Equal("/home/agent/project", state.WorkspacePath);
+        Assert.Equal(2, state.Entries.Count);
+        var agents = Assert.Single(state.Entries, e => e.Name == "AGENTS.md");
+        Assert.Equal("AGENTS.md", agents.RelativePath);
+        Assert.Equal("AGENTS.md", agents.RequestPath);
+        Assert.Equal(2048, agents.Size);
+        Assert.True(agents.Exists);
+    }
+
+    [Fact]
+    public void FromSessionFileList_DerivesNameFromPathAndExposesDirectory()
+    {
+        var state = WorkspaceFilesModel.FromSessionFileList(List(
+            File("src/app/main.ts", size: 100)));
+
+        var entry = Assert.Single(state.Entries);
+        Assert.Equal("main.ts", entry.Name);
+        Assert.Equal("src/app/main.ts", entry.RelativePath);
+        Assert.Equal("src/app", WorkspaceFilesModel.DirectoryOf(entry.RelativePath));
+    }
+
+    [Fact]
+    public void FromSessionFileList_NormalizesBackslashForDisplayButKeepsRequestPath()
+    {
+        var state = WorkspaceFilesModel.FromSessionFileList(List(
+            File(@"src\app\main.ts", name: "main.ts")));
+
+        var entry = Assert.Single(state.Entries);
+        Assert.Equal("src/app/main.ts", entry.RelativePath);
+        // Request path stays verbatim so sessions.files.get matches the gateway.
+        Assert.Equal(@"src\app\main.ts", entry.RequestPath);
+    }
+
+    [Fact]
+    public void FromSessionFileList_KeepsMissingFiles()
+    {
+        var state = WorkspaceFilesModel.FromSessionFileList(List(
+            File("gone.md", missing: true),
+            File("here.md")));
+
+        Assert.Equal(2, state.Entries.Count);
+        Assert.False(Assert.Single(state.Entries, e => e.Name == "gone.md").Exists);
+        Assert.True(Assert.Single(state.Entries, e => e.Name == "here.md").Exists);
+    }
+
+    [Fact]
+    public void FromSessionFileList_MapsKindToTouchedAndRead()
+    {
+        var state = WorkspaceFilesModel.FromSessionFileList(List(
+            File("wrote.md", kind: "modified"),
+            File("saw.md", kind: "read")));
+
+        Assert.True(Assert.Single(state.Entries, e => e.Name == "wrote.md").Touched);
+        Assert.False(Assert.Single(state.Entries, e => e.Name == "wrote.md").Read);
+        Assert.True(Assert.Single(state.Entries, e => e.Name == "saw.md").Read);
+    }
+
+    [Fact]
+    public void FromSessionFileList_MapsUpdatedAtToUtc()
+    {
+        var state = WorkspaceFilesModel.FromSessionFileList(List(
+            File("a.md", updatedAt: new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc))));
+
+        var entry = Assert.Single(state.Entries);
+        Assert.Equal(
+            new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero),
+            entry.ModifiedUtc!.Value);
+    }
+
+    [Fact]
+    public void FromSessionFileList_NegativeSizeBecomesNull()
+    {
+        var state = WorkspaceFilesModel.FromSessionFileList(List(
+            File("a.md", size: -1),
+            File("b.md")));
+
+        Assert.Null(Assert.Single(state.Entries, e => e.Name == "a.md").Size);
+        Assert.Null(Assert.Single(state.Entries, e => e.Name == "b.md").Size);
+    }
+
+    [Fact]
+    public void FromSessionFileList_SkipsEntriesWithoutPathOrName()
+    {
+        var state = WorkspaceFilesModel.FromSessionFileList(List(
+            File(""),
+            File("valid.md")));
+
+        var entry = Assert.Single(state.Entries);
+        Assert.Equal("valid.md", entry.Name);
+    }
+
+    [Fact]
+    public void FromSessionFileList_MergesBrowserDirectoriesNotInFiles()
+    {
+        var list = new SessionFileList
+        {
+            Key = "agent:main:main",
+            Root = "/root",
+            Files = new[] { File("README.md", kind: "read") },
+            Browser = new SessionFileBrowser
+            {
+                Entries = new[]
+                {
+                    new SessionFileBrowserEntry { Path = "src", Name = "src", Kind = "directory", SessionKind = "modified" },
+                    // Duplicate of a file entry — the richer file entry wins.
+                    new SessionFileBrowserEntry { Path = "README.md", Name = "README.md", Kind = "file" },
+                },
+            },
+            IsSupported = true,
+        };
+
+        var state = WorkspaceFilesModel.FromSessionFileList(list);
+
+        Assert.Equal(2, state.Entries.Count);
+        var dir = Assert.Single(state.Entries, e => e.Name == "src");
+        Assert.True(dir.IsDirectory);
+        Assert.True(dir.Touched); // SessionKind "modified"
+        Assert.False(dir.CanPreview);
+    }
+
+    [Fact]
+    public void FromSessionFileList_MapsBrowserPathSearchAndTruncation()
+    {
+        var list = new SessionFileList
+        {
+            Key = "agent:main:main",
+            Root = "/root",
+            Browser = new SessionFileBrowser
+            {
+                Path = @"src\app\",
+                ParentPath = "src",
+                Search = "view",
+                Truncated = true,
+                Entries = Array.Empty<SessionFileBrowserEntry>(),
+            },
+            IsSupported = true,
+        };
+
+        var state = WorkspaceFilesModel.FromSessionFileList(list);
+
+        Assert.Equal("src/app", state.BrowserPath);
+        Assert.Equal("src", state.BrowserParentPath);
+        Assert.Equal("view", state.BrowserSearch);
+        Assert.True(state.BrowserTruncated);
+    }
+
+    [Fact]
+    public void FromSessionFileList_BrowserOnlyFileIsNotPreviewable()
+    {
+        var list = new SessionFileList
+        {
+            Key = "agent:main:main",
+            Browser = new SessionFileBrowser
+            {
+                Entries = new[]
+                {
+                    new SessionFileBrowserEntry { Path = "src/browser-only.ts", Name = "browser-only.ts", Kind = "file" },
+                    new SessionFileBrowserEntry { Path = "src/touched.ts", Name = "touched.ts", Kind = "file", SessionKind = "read" },
+                },
+            },
+            IsSupported = true,
+        };
+
+        var state = WorkspaceFilesModel.FromSessionFileList(list);
+
+        var browserOnly = Assert.Single(state.Entries, e => e.Name == "browser-only.ts");
+        Assert.False(browserOnly.IsSessionFile);
+        Assert.False(browserOnly.CanPreview);
+
+        var touched = Assert.Single(state.Entries, e => e.Name == "touched.ts");
+        Assert.True(touched.IsSessionFile);
+        Assert.True(touched.CanPreview);
+        Assert.True(touched.Read);
+    }
+
+    [Fact]
+    public void FromSessionFileList_PathIdentityIsCaseSensitive()
+    {
+        // Distinct paths differing only by case must not collide into one row.
+        var state = WorkspaceFilesModel.FromSessionFileList(List(
+            File("Readme.md"),
+            File("README.md")));
+
+        Assert.Equal(2, state.Entries.Count);
+    }
+
+    // ── Unsupported / null handling ─────────────────────────────────────
+
+    [Fact]
+    public void FromSessionFileList_UnsupportedResult_FlagsUnsupported()
+    {
+        var state = WorkspaceFilesModel.FromSessionFileList(
+            new SessionFileList { Key = "k", IsSupported = false });
+
+        Assert.False(state.Supported);
+        Assert.Empty(state.Entries);
+    }
+
+    [Fact]
+    public void FromSessionFileList_Null_ReturnsSupportedEmpty()
+    {
+        var state = WorkspaceFilesModel.FromSessionFileList(null!);
+
+        Assert.True(state.Supported);
+        Assert.Empty(state.Entries);
+        Assert.Equal(string.Empty, state.WorkspacePath);
+    }
+
+    [Fact]
+    public void FromSessionFileList_NullFilesCollection_DoesNotThrow()
+    {
+        var state = WorkspaceFilesModel.FromSessionFileList(
+            new SessionFileList { Key = "k", Root = "/r", Files = null!, IsSupported = true });
+
+        Assert.True(state.Supported);
+        Assert.Empty(state.Entries);
+        Assert.Equal("/r", state.WorkspacePath);
+    }
+
+    // ── Search / filter ─────────────────────────────────────────────────
+
+    private static System.Collections.Generic.IReadOnlyList<WorkspaceFilesModel.WorkspaceFileEntry> SampleEntries() =>
+        WorkspaceFilesModel.FromSessionFileList(List(
+            File("src/app/main.ts"),
+            File("src/app/utils.ts"),
+            File("README.md"))).Entries;
+
+    [Fact]
+    public void Filter_EmptyQuery_ReturnsAll()
+    {
+        var entries = SampleEntries();
+        Assert.Equal(3, WorkspaceFilesModel.Filter(entries, "  ").Count);
+        Assert.Equal(3, WorkspaceFilesModel.Filter(entries, null).Count);
+    }
+
+    [Fact]
+    public void Filter_MatchesNameAndPath_CaseInsensitive()
+    {
+        var entries = SampleEntries();
+
+        Assert.Single(WorkspaceFilesModel.Filter(entries, "readme"));
+        Assert.Equal(2, WorkspaceFilesModel.Filter(entries, "SRC/APP").Count);
+        Assert.Single(WorkspaceFilesModel.Filter(entries, "utils"));
+        Assert.Empty(WorkspaceFilesModel.Filter(entries, "nomatch"));
+    }
+
+    // ── Sort tiering ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Sort_EditedBeforeReadBeforeUntouched()
+    {
+        var entries = WorkspaceFilesModel.FromSessionFileList(List(
+            File("plain.md"),
+            File("seen.md", kind: "read"),
+            File("wrote.md", kind: "modified"))).Entries;
+
+        Assert.Equal("wrote.md", entries[0].Name);
+        Assert.Equal("seen.md", entries[1].Name);
+        Assert.Equal("plain.md", entries[2].Name);
+    }
+
+    [Fact]
+    public void Sort_DirectoriesFirst()
+    {
+        var list = new SessionFileList
+        {
+            Key = "k",
+            Files = new[] { File("zeta.md", kind: "modified") },
+            Browser = new SessionFileBrowser
+            {
+                Entries = new[]
+                {
+                    new SessionFileBrowserEntry { Path = "lib", Name = "lib", Kind = "directory" },
+                },
+            },
+            IsSupported = true,
+        };
+
+        var entries = WorkspaceFilesModel.FromSessionFileList(list).Entries;
+
+        Assert.True(entries[0].IsDirectory);
+        Assert.Equal("lib", entries[0].Name);
+        Assert.Equal("zeta.md", entries[1].Name);
+    }
+
+    // ── Formatting helpers ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0, "0 B")]
+    [InlineData(512, "512 B")]
+    [InlineData(2048, "2.0 KB")]
+    [InlineData(5_242_880, "5.0 MB")]
+    public void FormatSize_ProducesHumanReadable(long bytes, string expected)
+    {
+        Assert.Equal(expected, WorkspaceFilesModel.FormatSize(bytes));
+    }
+
+    [Fact]
+    public void FormatSize_NullOrNegative_IsEmpty()
+    {
+        Assert.Equal(string.Empty, WorkspaceFilesModel.FormatSize(null));
+        Assert.Equal(string.Empty, WorkspaceFilesModel.FormatSize(-5));
+    }
+
+    [Fact]
+    public void DirectoryOf_RootFile_IsEmpty()
+    {
+        Assert.Equal(string.Empty, WorkspaceFilesModel.DirectoryOf("README.md"));
+        Assert.Equal("a/b", WorkspaceFilesModel.DirectoryOf("a/b/c.md"));
+    }
+
+    [Theory]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    [InlineData(" /src/app/ ", "src/app")]
+    [InlineData(@"src\app", "src/app")]
+    public void NormalizeBrowserPath_NormalizesForGatewayPathState(string? input, string expected)
+    {
+        Assert.Equal(expected, WorkspaceFilesModel.NormalizeBrowserPath(input));
+    }
+}


### PR DESCRIPTION
## Summary

- Problem: The Windows Workspace page did not expose a session-scoped file rail/browser for files the active agent read or edited.
- Why it matters: Operators need a quick way to inspect the files involved in a session without treating the Workspace page as an unrestricted file explorer.
- What changed: Added a typed `sessions.files.list` / `sessions.files.get`-backed file rail with Edited/Read/Missing metadata, folder browsing, server-side search, truncation messaging, right-click copy path, safe previews, Markdown rendered/raw viewing, and a legacy `agents.files.list/get` fallback when the typed session-file APIs are unavailable.
- User impact: Companion Settings → Workspace now shows the active session's file context and lets users preview session-relevant files safely; older paired gateways keep the previous Workspace file viewing path.
- What did NOT change (scope boundary): Arbitrary browser-only file preview and artifact rows are not added here; browser-only rows are visible for navigation but not previewed unless the session read or edited them.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs / instructions
- [x] Tests / validation
- [ ] Security hardening
- [ ] Chore / infra

## Scope (select all touched areas)

- [x] Tray / WinUI UX
- [ ] Windows node capability
- [ ] Local MCP / `winnode`
- [x] Gateway / connection / pairing
- [ ] Setup / onboarding
- [x] Permissions / privacy / security
- [x] Tests / CI / docs

## Linked Issue/PR

- Closes #
- Related #871
- [ ] Related to a bug or regression

## Validation

- `./build.ps1` — passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — 2567 passed, 31 skipped, 2598 total
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — 1324 passed, 0 skipped, 1324 total

## Real behavior proof

- Environment tested: Windows ARM64, Debug build, non-isolated tray launch from this branch
- PR head / commit tested: `caffde45`
- Exact steps or command run: Opened OpenClaw tray app, navigated to Companion Settings → Workspace, exercised the session file rail and required validation commands above.
- Evidence after fix: Workspace page shows the file rail/browser with session file metadata, search/path browsing, preview pane, and row context menu copy path.
- Observed result: Session-relevant files can be previewed safely; browser-only files remain visible for navigation but are not previewed unless the session read or edited them. If `sessions.files.list/get` is unsupported, the page falls back to the existing `agents.files.list/get` Workspace transport.
- Screenshot/artifact links verified? (`Yes/No/N/A`): Yes
- Not verified / blocked: Artifact rows remain follow-up work.

<img width="1485" height="1065" alt="image" src="https://github.com/user-attachments/assets/4dfbe46b-0314-4b11-a56c-741f12df89d3" />

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): Yes
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation: The UI consumes existing typed session file list/get APIs and preserves the existing legacy Workspace transport as a compatibility fallback. Access remains session-scoped, browser-only files are not previewed unless the session read or edited them, and unavailable/too-large/missing content renders as an inline unavailable state instead of dumping content.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A. Older gateways that do not support `sessions.files.list/get` continue to use the existing `agents.files.list/get` Workspace path.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.