### PR TITLE
Add provider-aware chat model picker

### DIFF
--- a/src/OpenClaw.Chat/ChatModelChoice.cs
+++ b/src/OpenClaw.Chat/ChatModelChoice.cs
@@ -1,0 +1,244 @@
+namespace OpenClaw.Chat;
+
+using OpenClaw.Shared;
+
+/// <summary>
+/// Provider-rich description of a model exposed by <c>models.list</c>.
+/// </summary>
+/// <param name="Id">Wire model id (e.g. <c>claude-opus-4.8</c>).</param>
+/// <param name="DisplayName">Human-friendly label (falls back to <paramref name="Id"/>).</param>
+/// <param name="Provider">Owning provider (e.g. <c>OpenAI</c>, <c>Anthropic</c>), when known.</param>
+/// <param name="ContextWindow">Context-window size in tokens, when known.</param>
+/// <param name="IsConfigured">True when the provider is configured on the gateway.</param>
+/// <param name="IsAvailable">
+/// True when the model can be selected right now. When false the picker shows it
+/// but does not let the user switch to it.
+/// </param>
+/// <param name="RequiresAuth">
+/// True when the model's provider still needs authentication/credentials before
+/// the model is usable.
+/// </param>
+/// <param name="IsDefault">True when the gateway marks this model as the default.</param>
+public sealed record ChatModelChoice(
+    string Id,
+    string DisplayName,
+    string? Provider = null,
+    int? ContextWindow = null,
+    bool IsConfigured = true,
+    bool IsAvailable = true,
+    bool RequiresAuth = false,
+    bool IsDefault = false)
+{
+    /// <summary>
+    /// Provider-qualified identity used for picker tags and <c>sessions.patch</c>
+    /// model refs. Already-qualified ids are preserved.
+    /// </summary>
+    public string SelectionId => BuildSelectionId(Id, Provider);
+
+    /// <summary>
+    /// True when the user may switch the session to this model. Auth-needed
+    /// models remain selectable (selecting one routes the user toward the
+    /// gateway's provider-auth flow); only explicitly unavailable models are
+    /// blocked.
+    /// </summary>
+    public bool IsSelectable => IsAvailable;
+
+    /// <summary>
+    /// Maps gateway models into ordered, selection-deduplicated picker entries.
+    /// </summary>
+    public static IReadOnlyList<ChatModelChoice> FromModelsList(ModelsListInfo? info)
+    {
+        if (info?.Models is not { Count: > 0 }) return Array.Empty<ChatModelChoice>();
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var list = new List<ChatModelChoice>(info.Models.Count);
+        foreach (var m in info.Models)
+        {
+            if (m is null || string.IsNullOrEmpty(m.Id)) continue;
+            // Hide models whose provider is explicitly reported as not configured
+            // (the gateway sent configured:false) — they can't be used. Models
+            // that simply omit the flag are kept (HasConfiguredFlag == false).
+            if (m.HasConfiguredFlag && !m.IsConfigured) continue;
+            var choice = new ChatModelChoice(
+                Id: m.Id,
+                DisplayName: m.DisplayName,
+                Provider: m.Provider,
+                ContextWindow: m.ContextWindow,
+                IsConfigured: m.IsConfigured,
+                IsAvailable: m.IsAvailable,
+                RequiresAuth: m.RequiresAuth,
+                IsDefault: m.IsDefault);
+            if (!seen.Add(choice.SelectionId)) continue;
+            list.Add(choice);
+        }
+        return list;
+    }
+
+    public bool MatchesModel(string? modelId, string? provider = null)
+    {
+        var normalizedModel = NormalizeId(modelId);
+        if (normalizedModel is null) return false;
+
+        if (NormalizeId(provider) is { } normalizedProvider)
+        {
+            var providerQualified = BuildSelectionId(normalizedModel, normalizedProvider);
+            return string.Equals(SelectionId, providerQualified, StringComparison.Ordinal)
+                || (string.Equals(Id, normalizedModel, StringComparison.Ordinal)
+                    && string.Equals(NormalizeId(Provider), normalizedProvider, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return string.Equals(Id, normalizedModel, StringComparison.Ordinal)
+            || string.Equals(SelectionId, normalizedModel, StringComparison.Ordinal);
+    }
+
+    public static string BuildSelectionId(string modelId, string? provider)
+    {
+        var normalizedModel = NormalizeId(modelId) ?? string.Empty;
+        if (normalizedModel.Length == 0) return string.Empty;
+        var normalizedProvider = NormalizeId(provider);
+        if (normalizedProvider is null) return normalizedModel;
+
+        var prefix = normalizedProvider + "/";
+        return normalizedModel.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            ? normalizedModel
+            : $"{normalizedProvider}/{normalizedModel}";
+    }
+
+    public static string? ResolveSelectionId(
+        string? modelId,
+        string? provider,
+        IReadOnlyList<ChatModelChoice> choices)
+    {
+        var normalizedModel = NormalizeId(modelId);
+        if (normalizedModel is null) return null;
+
+        if (NormalizeId(provider) is not null)
+        {
+            var match = choices.FirstOrDefault(c => c.MatchesModel(normalizedModel, provider));
+            if (match is not null) return match.SelectionId;
+
+            var bareRawMatches = choices
+                .Where(c => c.Id == normalizedModel && string.IsNullOrWhiteSpace(c.Provider))
+                .Take(2)
+                .ToArray();
+            if (bareRawMatches.Length == 1) return bareRawMatches[0].SelectionId;
+
+            return BuildSelectionId(normalizedModel, provider);
+        }
+
+        var direct = choices.FirstOrDefault(c => c.SelectionId == normalizedModel);
+        if (direct is not null) return direct.SelectionId;
+
+        var rawMatches = choices.Where(c => c.Id == normalizedModel).Take(2).ToArray();
+        return rawMatches.Length == 1 ? rawMatches[0].SelectionId : normalizedModel;
+    }
+
+    private static string? NormalizeId(string? value)
+    {
+        var trimmed = value?.Trim();
+        return string.IsNullOrEmpty(trimmed) ? null : trimmed;
+    }
+}
+
+/// <summary>
+/// Pure label/formatting helpers for the model picker. Lives in
+/// <c>OpenClaw.Chat</c> (no WinUI dependency) so the display strings can be unit
+/// tested without spinning up the composer.
+/// </summary>
+public static class ChatModelLabels
+{
+    /// <summary>
+    /// True when <paramref name="modelId"/> represents "no explicit model
+    /// override" — i.e. the session is tracking the gateway/agent default.
+    /// This predicate only describes the <em>current</em> state, derived from an
+    /// empty/absent session model. Clearing an override (so a session tracks the
+    /// default again) is performed via the tri-state <c>SessionPatch.Clear</c>
+    /// (explicit JSON null), not by sending an empty model string.
+    /// </summary>
+    public static bool IsTrackingDefault(string? modelId) => string.IsNullOrEmpty(modelId);
+
+    /// <summary>
+    /// Compact token-count label: 272000 → "272K", 1_048_576 → "1M",
+    /// 200000 → "200K". Falls back to the raw number for small values.
+    /// </summary>
+    public static string FormatContextWindow(int contextWindow)
+    {
+        if (contextWindow <= 0) return string.Empty;
+        if (contextWindow >= 1_000_000)
+        {
+            var millions = contextWindow / 1_000_000.0;
+            // Trim a trailing ".0" so 2_000_000 → "2M" not "2.0M".
+            return millions == Math.Floor(millions)
+                ? $"{(int)millions}M"
+                : $"{millions:0.#}M";
+        }
+        if (contextWindow >= 1_000)
+        {
+            var thousands = contextWindow / 1_000.0;
+            return thousands == Math.Floor(thousands)
+                ? $"{(int)thousands}K"
+                : $"{thousands:0.#}K";
+        }
+        return contextWindow.ToString();
+    }
+
+    /// <summary>
+    /// Builds the secondary metadata segment ("OpenAI · 272K") from provider and
+    /// context window, or an empty string when neither is known.
+    /// </summary>
+    public static string BuildMetaSegment(ChatModelChoice choice)
+    {
+        var hasProvider = !string.IsNullOrWhiteSpace(choice.Provider);
+        var ctx = choice.ContextWindow is { } cw ? FormatContextWindow(cw) : string.Empty;
+        var hasCtx = ctx.Length > 0;
+
+        if (hasProvider && hasCtx) return $"{choice.Provider} · {ctx}";
+        if (hasProvider) return choice.Provider!;
+        if (hasCtx) return ctx;
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// Trailing state marker for a model: "default", "auth needed",
+    /// "unavailable", or empty. Unavailable takes precedence over auth-needed,
+    /// which takes precedence over default. Only explicit gateway signals drive
+    /// the markers — a missing <see cref="ChatModelChoice.IsConfigured"/> flag is
+    /// not treated as "auth needed" because the gateway's <c>configured</c> view
+    /// often omits the field entirely.
+    /// </summary>
+    public static string BuildStateMarker(ChatModelChoice choice)
+    {
+        if (!choice.IsAvailable) return "unavailable";
+        if (choice.RequiresAuth) return "auth needed";
+        if (choice.IsDefault) return "default";
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// Full menu/combo label, e.g. "Claude Opus 4.8 · Anthropic · 200K · default".
+    /// State marker is appended last so default/auth-needed/unavailable reads at
+    /// the end of the row.
+    /// </summary>
+    public static string BuildMenuLabel(ChatModelChoice choice)
+    {
+        var label = choice.DisplayName;
+        var meta = BuildMetaSegment(choice);
+        if (meta.Length > 0) label = $"{label} · {meta}";
+        var marker = BuildStateMarker(choice);
+        if (marker.Length > 0) label = $"{label} · {marker}";
+        return label;
+    }
+
+    /// <summary>
+    /// Label for the "clear to gateway default" picker entry. Selecting it clears
+    /// the session's explicit model override (the gateway falls back to its
+    /// agent/default model). When the default model is known its name is
+    /// surfaced, e.g. "Default (Claude Opus 4.8)".
+    /// </summary>
+    public static string BuildDefaultEntryLabel(ChatModelChoice? defaultChoice)
+    {
+        if (defaultChoice is not null && !string.IsNullOrWhiteSpace(defaultChoice.DisplayName))
+            return $"Default ({defaultChoice.DisplayName})";
+        return "Default";
+    }
+}

--- a/src/OpenClaw.Chat/ChatModelChoice.cs
+++ b/src/OpenClaw.Chat/ChatModelChoice.cs
@@ -55,10 +55,9 @@ public sealed record ChatModelChoice(
         foreach (var m in info.Models)
         {
             if (m is null || string.IsNullOrEmpty(m.Id)) continue;
-            // Hide models whose provider is explicitly reported as not configured
-            // (the gateway sent configured:false) — they can't be used. Models
-            // that simply omit the flag are kept (HasConfiguredFlag == false).
-            if (m.HasConfiguredFlag && !m.IsConfigured) continue;
+            // Hide explicitly unconfigured models unless the gateway reports an
+            // auth flow for them; auth-needed rows are useful picker actions.
+            if (m.HasConfiguredFlag && !m.IsConfigured && !m.RequiresAuth) continue;
             var choice = new ChatModelChoice(
                 Id: m.Id,
                 DisplayName: m.DisplayName,

--- a/src/OpenClaw.Chat/ChatModels.cs
+++ b/src/OpenClaw.Chat/ChatModels.cs
@@ -105,6 +105,7 @@ public record ChatThread
     public string? Compute { get; init; }
     public string? ProfileName { get; init; }
     public string? Model { get; init; }
+    public string? ModelProvider { get; init; }
     public string? ThinkingLevel { get; init; }
     public long InputTokens { get; init; }
     public long OutputTokens { get; init; }
@@ -190,7 +191,8 @@ public record ChatDataSnapshot(
     string? DefaultThreadId,
     string? ConnectionStatus,
     string[] AvailableModels,
-    ChatComposeTarget ComposeTarget);
+    ChatComposeTarget ComposeTarget,
+    IReadOnlyList<ChatModelChoice>? ModelChoices = null);
 
 /// <summary>
 /// Describes where the UI may send the next chat message. Distinct from
@@ -257,6 +259,13 @@ public interface IChatDataProvider : IAsyncDisposable
     Task SetThreadSuspendedAsync(string threadId, bool suspended, CancellationToken cancellationToken = default);
     Task DeleteThreadAsync(string threadId, CancellationToken cancellationToken = default);
     Task SetModelAsync(string threadId, string model, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Clears the session's explicit model override so it tracks the gateway's
+    /// agent/default model again. Providers that don't support clearing leave
+    /// the default no-op. Distinct from <see cref="SetModelAsync"/> because the
+    /// gateway models this as an explicit null (tri-state), not an empty string.
+    /// </summary>
+    Task ClearModelAsync(string threadId, CancellationToken cancellationToken = default) => Task.CompletedTask;
     Task SetThinkingLevelAsync(string threadId, string thinkingLevel, CancellationToken cancellationToken = default);
     Task SetPermissionModeAsync(string threadId, bool allowAll, CancellationToken cancellationToken = default);
     Task RespondToPermissionAsync(string threadId, string requestId, string action, CancellationToken cancellationToken = default);

--- a/src/OpenClaw.Shared/Models.cs
+++ b/src/OpenClaw.Shared/Models.cs
@@ -2075,8 +2075,27 @@ public class ModelInfo
     public string? Name { get; set; }
     public string? Provider { get; set; }
     public int? ContextWindow { get; set; }
+
+    /// <summary>True when the model's provider is configured on the gateway.</summary>
     public bool IsConfigured { get; set; }
     public bool HasConfiguredFlag { get; set; }
+
+    /// <summary>True when the gateway marks this model as the default choice.</summary>
+    public bool IsDefault { get; set; }
+
+    /// <summary>
+    /// True when the model can be selected/used right now. Defaults to
+    /// <c>true</c> so models lists from gateways that don't report availability
+    /// are treated as usable. The gateway may report <c>available:false</c> or
+    /// <c>unavailable:true</c> to mark a model as not selectable.
+    /// </summary>
+    public bool IsAvailable { get; set; } = true;
+
+    /// <summary>
+    /// True when the model's provider needs authentication/credentials before
+    /// it can be used (e.g. an API key has not been configured yet).
+    /// </summary>
+    public bool RequiresAuth { get; set; }
 
     public string DisplayName => Name ?? Id;
 }

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -4126,8 +4126,16 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
             {
                 foreach (var item in modelsArray.EnumerateArray())
                 {
+                    if (item.ValueKind != JsonValueKind.Object) continue;
+
+                    // Read readiness flags defensively; older gateways may omit
+                    // them, and the UI only uses them for labels/selectability.
                     var hasConfiguredFlag = item.TryGetProperty("configured", out var cfg)
                                             && (cfg.ValueKind == JsonValueKind.True || cfg.ValueKind == JsonValueKind.False);
+                    bool available = true;
+                    if (TryReadBool(item, out var av, "available")) available = av;
+                    else if (TryReadBool(item, out var un, "unavailable")) available = !un;
+
                     var model = new ModelInfo
                     {
                         Id = item.TryGetProperty("id", out var id) ? id.GetString() ?? "" : "",
@@ -4135,7 +4143,10 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
                         Provider = item.TryGetProperty("provider", out var prov) ? prov.GetString() : null,
                         ContextWindow = item.TryGetProperty("contextWindow", out var cw) && cw.ValueKind == JsonValueKind.Number ? cw.GetInt32() : null,
                         IsConfigured = hasConfiguredFlag && cfg.ValueKind == JsonValueKind.True,
-                        HasConfiguredFlag = hasConfiguredFlag
+                        HasConfiguredFlag = hasConfiguredFlag,
+                        IsDefault = ReadBool(item, "default", "isDefault"),
+                        IsAvailable = available,
+                        RequiresAuth = ReadBool(item, "requiresAuth", "authRequired", "needsAuth", "authNeeded")
                     };
                     if (!string.IsNullOrEmpty(model.Id))
                         info.Models.Add(model);
@@ -4147,6 +4158,25 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         {
             _logger.Warn($"Failed to parse models.list: {ex.Message}");
         }
+    }
+
+    // Reads the first present boolean property among <paramref name="keys"/>.
+    // Returns false when none are present (or are non-boolean).
+    private static bool ReadBool(JsonElement obj, params string[] keys) =>
+        TryReadBool(obj, out var value, keys) && value;
+
+    private static bool TryReadBool(JsonElement obj, out bool value, params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (obj.TryGetProperty(key, out var prop))
+            {
+                if (prop.ValueKind == JsonValueKind.True) { value = true; return true; }
+                if (prop.ValueKind == JsonValueKind.False) { value = false; return true; }
+            }
+        }
+        value = false;
+        return false;
     }
 
     private void ParseNodePairList(JsonElement payload)

--- a/src/OpenClaw.Tray.WinUI/Chat/IChatGatewayBridge.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/IChatGatewayBridge.cs
@@ -37,6 +37,13 @@ public interface IChatGatewayBridge : IDisposable
     Task SendChatMessageAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null);
     Task<ChatSendResult> SendChatMessageForRunAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null);
     Task PatchSessionModelAsync(string sessionKey, string model);
+    /// <summary>
+    /// Clears the session's model override (tri-state <c>sessions.patch</c> with
+    /// an explicit JSON null), reverting the session to the gateway/agent
+    /// default. Distinct from <see cref="PatchSessionModelAsync"/>, which sets a
+    /// concrete model.
+    /// </summary>
+    Task ClearSessionModelAsync(string sessionKey);
     Task PatchSessionThinkingLevelAsync(string sessionKey, string thinkingLevel);
     Task<ChatHistoryInfo> RequestChatHistoryAsync(string? sessionKey);
     Task SendChatAbortAsync(string runId, string? sessionKey = null);
@@ -160,10 +167,13 @@ public sealed class GatewayClientChatBridge : IChatGatewayBridge
         _client.SendChatMessageForRunAsync(message, sessionKey, sessionId, attachments);
 
     public Task PatchSessionModelAsync(string sessionKey, string model) =>
-        _client.PatchSessionAsync(sessionKey, model: model);
+        _client.PatchSessionAsync(sessionKey, new SessionPatch { Model = model });
+
+    public Task ClearSessionModelAsync(string sessionKey) =>
+        _client.PatchSessionAsync(sessionKey, new SessionPatch { Model = SessionPatch.Clear });
 
     public Task PatchSessionThinkingLevelAsync(string sessionKey, string thinkingLevel) =>
-        _client.PatchSessionAsync(sessionKey, thinkingLevel: thinkingLevel);
+        _client.PatchSessionAsync(sessionKey, new SessionPatch { ThinkingLevel = thinkingLevel });
 
     public Task<ChatHistoryInfo> RequestChatHistoryAsync(string? sessionKey) =>
         _client.RequestChatHistoryAsync(sessionKey);

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -1500,9 +1500,14 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     private static string[] ModelIdsFromChoices(IReadOnlyList<ChatModelChoice> choices)
     {
         if (choices.Count == 0) return Array.Empty<string>();
-        var ids = new string[choices.Count];
-        for (int i = 0; i < choices.Count; i++) ids[i] = choices[i].Id;
-        return ids;
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var ids = new List<string>(choices.Count);
+        foreach (var choice in choices)
+        {
+            if (seen.Add(choice.Id))
+                ids.Add(choice.Id);
+        }
+        return ids.ToArray();
     }
 
     // Rehydrate minimal choices from a cached id list (reconnect / pre-connect
@@ -1510,10 +1515,12 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     private static IReadOnlyList<ChatModelChoice> ChoicesFromIds(string[] ids)
     {
         if (ids.Length == 0) return Array.Empty<ChatModelChoice>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
         var list = new List<ChatModelChoice>(ids.Length);
         foreach (var id in ids)
         {
             if (string.IsNullOrEmpty(id)) continue;
+            if (!seen.Add(id)) continue;
             list.Add(new ChatModelChoice(id, id));
         }
         return list;

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -109,6 +109,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     private readonly Dictionary<string, string> _sessionIds = new();      // sessionKey → immutable sessionId
     private readonly HashSet<string> _historyLoaded = new();              // sessionKey
     private readonly HashSet<string> _historyInFlight = new();            // sessionKey
+    private readonly Dictionary<string, Task> _pendingModelPatches = new(); // sessionKey -> in-flight model set/clear
     private readonly Dictionary<string, long> _resetVersions = new(); // sessionKey -> reset generation
     private readonly Dictionary<string, long> _resetCutoffUtcMs = new(); // sessionKey -> local reset time
     private readonly HashSet<string> _resetAwaitingUserMessage = new(); // threads reset and waiting for first post-reset turn
@@ -162,6 +163,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     // false on disconnect alongside `_status`.
     private bool _sessionsListReceived;
     private string[] _availableModels = Array.Empty<string>();
+    private IReadOnlyList<ChatModelChoice> _modelChoices = Array.Empty<ChatModelChoice>();
     private ConnectionStatus _status;
     private bool _disposed;
 
@@ -211,11 +213,17 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         // that completed before the provider was constructed will have its
         // models.list snapshot cached on the bridge).
         if (bridge.GetCurrentModelsList() is { } seedModels)
-            _availableModels = ExtractModelNames(seedModels);
+        {
+            _modelChoices = ChatModelChoice.FromModelsList(seedModels);
+            _availableModels = ModelIdsFromChoices(_modelChoices);
+        }
         // Fall back to last-known models so the composer shows a real model
         // name while reconnecting instead of the generic "model" placeholder.
         else if (_lastChatState?.AvailableModels is { Length: > 0 } cached)
+        {
             _availableModels = cached;
+            _modelChoices = ChoicesFromIds(cached);
+        }
 
         _bridge.StatusChanged += OnStatusChanged;
         _bridge.SessionsUpdated += OnSessionsUpdated;
@@ -244,6 +252,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         {
             _sessions = sessions;
             EnsureTimelinesForSessionsLocked();
+            RememberLastSessionStateLocked();
             return Task.FromResult(BuildSnapshotLocked());
         }
     }
@@ -336,6 +345,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         // 2. Send to gateway.
         try
         {
+            await AwaitPendingModelPatchAsync(threadId, cancellationToken);
             var sendResult = await _bridge.SendChatMessageForRunAsync(trimmed, threadId, sessionId, attachments);
             bool sendStillCurrent;
             lock (_gate)
@@ -921,7 +931,81 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     public async Task SetModelAsync(string threadId, string model, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        await _bridge.PatchSessionModelAsync(threadId, model);
+        // The gateway's sessions.patch schema treats `model` as a non-empty
+        // string; a blank value here is a no-op rather than a clear. Use
+        // ClearModelAsync to revert a session to the gateway default.
+        if (string.IsNullOrWhiteSpace(model)) return;
+        await TrackModelPatchAsync(threadId, () => _bridge.PatchSessionModelAsync(threadId, model));
+    }
+
+    public async Task ClearModelAsync(string threadId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        // Tri-state clear: removes the session's model override (explicit null)
+        // so it tracks the gateway/agent default again.
+        await TrackModelPatchAsync(threadId, () => _bridge.ClearSessionModelAsync(threadId));
+    }
+
+    private async Task TrackModelPatchAsync(string threadId, Func<Task> patchOperation)
+    {
+        var startSignal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task? previous;
+        Task pending;
+        lock (_gate)
+        {
+            _pendingModelPatches.TryGetValue(threadId, out previous);
+            pending = RunModelPatchAsync(previous, patchOperation, startSignal.Task);
+            _pendingModelPatches[threadId] = pending;
+        }
+
+        startSignal.SetResult();
+        try
+        {
+            await pending;
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                if (_pendingModelPatches.TryGetValue(threadId, out var current)
+                    && ReferenceEquals(current, pending))
+                    _pendingModelPatches.Remove(threadId);
+            }
+        }
+    }
+
+    private static async Task RunModelPatchAsync(Task? previous, Func<Task> patchOperation, Task startSignal)
+    {
+        await startSignal;
+        if (previous is not null)
+        {
+            try { await previous; }
+            catch (Exception ex)
+            {
+                Logger.Debug($"ChatDataProvider: continuing model patch after previous patch failed: {ex.Message}");
+            }
+        }
+
+        await patchOperation();
+    }
+
+    private async Task AwaitPendingModelPatchAsync(string threadId, CancellationToken cancellationToken)
+    {
+        Task? pending;
+        lock (_gate)
+        {
+            _pendingModelPatches.TryGetValue(threadId, out pending);
+        }
+
+        if (pending is not null)
+        {
+            try { await pending.WaitAsync(cancellationToken); }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                Logger.Debug($"ChatDataProvider: continuing send after model patch failed: {ex.Message}");
+            }
+        }
     }
 
     public async Task SetThinkingLevelAsync(string threadId, string thinkingLevel, CancellationToken cancellationToken = default)
@@ -1336,6 +1420,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             SeedSessionIdsFromSessionsLocked(_sessions);
             _sessionsListReceived = true;
             EnsureTimelinesForSessionsLocked();
+            RememberLastSessionStateLocked();
             foreach (var s in _sessions)
             {
                 if (string.IsNullOrEmpty(s.Key)) continue;
@@ -1401,30 +1486,37 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         ChatDataSnapshot snapshot;
         lock (_gate)
         {
-            _availableModels = ExtractModelNames(info);
+            _modelChoices = ChatModelChoice.FromModelsList(info);
+            _availableModels = ModelIdsFromChoices(_modelChoices);
             snapshot = BuildSnapshotLocked();
         }
         Logger.Info($"[ChatBridge] OnModelsListUpdated: count={_availableModels.Length}");
         Publish(snapshot);
     }
 
-    private static string[] ExtractModelNames(ModelsListInfo info)
+    // Wire ids (e.g. "claude-opus-4.5") in gateway order, used by the composer
+    // to match against SessionInfo.Model. Kept as a parallel string[] for
+    // back-compat with callers/persistence that only need the id list.
+    private static string[] ModelIdsFromChoices(IReadOnlyList<ChatModelChoice> choices)
     {
-        if (info?.Models is null || info.Models.Count == 0) return Array.Empty<string>();
-        // Use model Id (wire format, e.g. "claude-opus-4.5") so the composer
-        // can match against SessionInfo.Model (which is also the wire Id).
-        // The ComboBox will show Ids directly; a future pass could introduce
-        // a separate display-name array if prettier labels are desired.
-        var seen = new HashSet<string>(StringComparer.Ordinal);
-        var list = new List<string>(info.Models.Count);
-        foreach (var m in info.Models)
+        if (choices.Count == 0) return Array.Empty<string>();
+        var ids = new string[choices.Count];
+        for (int i = 0; i < choices.Count; i++) ids[i] = choices[i].Id;
+        return ids;
+    }
+
+    // Rehydrate minimal choices from a cached id list (reconnect / pre-connect
+    // path) when richer gateway metadata isn't available yet.
+    private static IReadOnlyList<ChatModelChoice> ChoicesFromIds(string[] ids)
+    {
+        if (ids.Length == 0) return Array.Empty<ChatModelChoice>();
+        var list = new List<ChatModelChoice>(ids.Length);
+        foreach (var id in ids)
         {
-            if (m.HasConfiguredFlag && !m.IsConfigured) continue;
-            var id = m.Id;
             if (string.IsNullOrEmpty(id)) continue;
-            if (seen.Add(id)) list.Add(id);
+            list.Add(new ChatModelChoice(id, id));
         }
-        return list.ToArray();
+        return list;
     }
 
     private void OnChatMessageReceived(object? sender, ChatMessageInfo message)
@@ -3879,6 +3971,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                 Id = ck,
                 Title = _lastChatState?.ThreadTitle ?? "OpenClaw Windows Tray",
                 Model = _lastChatState?.Model,
+                ModelProvider = _lastChatState?.ModelProvider,
                 Status = ChatThreadStatus.Running,
                 Activity = ChatActivity.Idle,
             });
@@ -3896,6 +3989,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                 Status = ChatThreadStatus.Running,
                 Activity = ChatActivity.AwaitingPermission,
                 Model = _lastChatState?.Model,
+                ModelProvider = _lastChatState?.ModelProvider,
             });
         }
 
@@ -3932,7 +4026,8 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             DefaultThreadId: defaultThreadId,
             ConnectionStatus: connectionLabel,
             AvailableModels: _availableModels,
-            ComposeTarget: composeTarget);
+            ComposeTarget: composeTarget,
+            ModelChoices: _modelChoices);
     }
 
     private string? ResolveDefaultThreadIdLocked()
@@ -3956,6 +4051,23 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         return null;
     }
 
+    private void RememberLastSessionStateLocked()
+    {
+        if (_sessions.Length == 0) return;
+        var session = _sessions.FirstOrDefault(s => s.IsMain && !string.IsNullOrEmpty(s.Key))
+            ?? _sessions.FirstOrDefault(s => !string.IsNullOrEmpty(s.Key));
+        if (session is null) return;
+
+        _lastChatState = new LastChatState
+        {
+            DefaultThreadId = session.Key,
+            ThreadTitle = BuildSessionTitle(session),
+            Model = session.Model,
+            ModelProvider = session.Provider,
+            AvailableModels = _availableModels,
+        };
+    }
+
     private static ChatThread ToThread(SessionInfo s)
     {
         var title = BuildSessionTitle(s);
@@ -3968,6 +4080,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             Activity = string.IsNullOrEmpty(s.CurrentActivity) ? ChatActivity.Idle : ChatActivity.Working,
             Workspace = s.Channel,
             Model = s.Model,
+            ModelProvider = s.Provider,
             ThinkingLevel = s.ThinkingLevel,
             InputTokens = s.InputTokens,
             OutputTokens = s.OutputTokens,
@@ -4059,6 +4172,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         public string? DefaultThreadId { get; set; }
         public string? ThreadTitle { get; set; }
         public string? Model { get; set; }
+        public string? ModelProvider { get; set; }
         public string[]? AvailableModels { get; set; }
     }
 
@@ -4088,12 +4202,14 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             : snapshot.Threads.Length > 0 ? snapshot.Threads[0] : null;
 
         if (defaultThread is null && snapshot.AvailableModels.Length == 0) return;
+        var previous = _lastChatState;
 
         var state = new LastChatState
         {
-            DefaultThreadId = snapshot.DefaultThreadId,
-            ThreadTitle = defaultThread?.Title,
-            Model = defaultThread?.Model,
+            DefaultThreadId = snapshot.DefaultThreadId ?? previous?.DefaultThreadId,
+            ThreadTitle = defaultThread?.Title ?? previous?.ThreadTitle,
+            Model = defaultThread?.Model ?? previous?.Model,
+            ModelProvider = defaultThread?.ModelProvider ?? previous?.ModelProvider,
             AvailableModels = snapshot.AvailableModels,
         };
 

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
@@ -260,6 +260,7 @@ public sealed class OpenClawChatRoot : Component
                 Id = composeKey,
                 Title = lastState?.ThreadTitle ?? "OpenClaw Windows Tray",
                 Model = lastState?.Model,
+                ModelProvider = lastState?.ModelProvider,
                 Status = ChatThreadStatus.Running,
                 Activity = ChatActivity.Idle,
             };
@@ -548,7 +549,9 @@ public sealed class OpenClawChatRoot : Component
                 AvailableChannels: channelGroups,
                 AvailableModels: snapshot.AvailableModels,
                 CurrentModel: composerThread.Model,
+                CurrentModelProvider: composerThread.ModelProvider,
                 CurrentThinkingLevel: composerThread.ThinkingLevel,
+                ModelChoices: snapshot.ModelChoices,
                 OnSend: (msg, attachments) =>
                 {
                     SetPendingAttachments(Array.Empty<ChatAttachment>());
@@ -560,7 +563,8 @@ public sealed class OpenClawChatRoot : Component
                     selectedIdState.Set(id);
                     selectedIdRef.Current = id;
                 },
-                OnModelChanged: model => RunFireAndForget(ct => _provider.SetModelAsync(composerThread.Id!, model, ct)),
+                OnModelChanged: model => ObserveFireAndForget(_provider.SetModelAsync(composerThread.Id!, model)),
+                OnModelCleared: () => ObserveFireAndForget(_provider.ClearModelAsync(composerThread.Id!)),
                 OnThinkingLevelChanged: level => RunFireAndForget(ct => _provider.SetThinkingLevelAsync(composerThread.Id!, level, ct)),
                 OnPermissionsChanged: allowAll => RunFireAndForget(ct => _provider.SetPermissionModeAsync(composerThread.Id!, allowAll, ct)),
                 OnVoiceRequest: _onVoiceRequest,
@@ -899,6 +903,19 @@ public sealed class OpenClawChatRoot : Component
             catch (OperationCanceledException) { /* expected */ }
             catch (Exception ex) { System.Diagnostics.Trace.WriteLine($"[chat] op failed: {ex}"); }
         });
+    }
+
+    private static void ObserveFireAndForget(Task task)
+    {
+        _ = ObserveAsync(task);
+
+        static async Task ObserveAsync(Task task)
+        {
+            try { await task; }
+            // slopwatch-ignore: SW003 Shutdown cancellation or disposal is expected and the caller already preserves the safe state.
+            catch (OperationCanceledException) { /* expected */ }
+            catch (Exception ex) { System.Diagnostics.Trace.WriteLine($"[chat] op failed: {ex}"); }
+        }
     }
 
     private static async Task LoadAsync(

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
@@ -46,6 +46,7 @@ public record OpenClawComposerProps(
     ChannelGroup[] AvailableChannels,
     string[] AvailableModels,
     string? CurrentModel,
+    string? CurrentModelProvider,
     string? CurrentThinkingLevel,
     Action<string, IReadOnlyList<ChatAttachment>> OnSend,
     Action OnStop,
@@ -66,10 +67,18 @@ public record OpenClawComposerProps(
     Action<ChatAttachment>? OnAttachmentPasted = null,
     bool ShowToolCalls = true,
     Action<bool>? OnShowToolCallsChanged = null,
-    bool IsCompact = false);
+    bool IsCompact = false,
+    IReadOnlyList<ChatModelChoice>? ModelChoices = null,
+    Action? OnModelCleared = null);
 
 public sealed class OpenClawComposer : Component<OpenClawComposerProps>
 {
+    // Distinct reference-equality sentinel used as the ComboBoxItem.Tag for the
+    // "Default" (clear model override) row, so it can never collide with a real
+    // model id string. Selecting it routes to OnModelCleared (tri-state clear)
+    // rather than OnModelChanged.
+    private static readonly object ClearModelTag = new();
+
     // Thinking levels matching the gateway's sessions.patch thinkingLevel values.
     // "medium" is the default when the session has no explicit thinkingLevel set.
     private static readonly string[] ThinkingLevelIds    = { "off", "minimal", "low", "medium", "high" };
@@ -257,26 +266,102 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
                 border.Child = cb;
             });
 
-        var models = Props.AvailableModels;
-        var modelIndex = models is { Length: > 0 } && Props.CurrentModel is { } cur
-            ? Array.IndexOf(models, cur) : -1;
-        if (modelIndex < 0 && models is { Length: > 0 }) modelIndex = 0;
-        var modelDisplay = models is { Length: > 0 } ? models : new[] { Props.CurrentModel ?? "model" };
+        // ── Model picker (provider-rich) ─────────────────────────────────
+        IReadOnlyList<ChatModelChoice> modelChoices = Props.ModelChoices is { Count: > 0 } mc
+            ? mc
+            : (Props.AvailableModels is { Length: > 0 } am
+                ? am.Select(id => new ChatModelChoice(id, id)).ToList()
+                : Array.Empty<ChatModelChoice>());
 
-        var modelCombo = ComboBox(modelDisplay, Math.Max(modelIndex, 0), idx =>
+        var currentModelId = Props.CurrentModel;
+        var currentSelectionId = ChatModelChoice.ResolveSelectionId(currentModelId, Props.CurrentModelProvider, modelChoices);
+        var trackingDefault = ChatModelLabels.IsTrackingDefault(currentModelId);
+        ChatModelChoice? currentChoice = null;
+        ChatModelChoice? defaultChoice = null;
+        foreach (var c in modelChoices)
         {
-            if (models is { Length: > 0 } && idx >= 0 && idx < models.Length)
-                Props.OnModelChanged(models[idx]);
-        }).Set(cb =>
+            if (defaultChoice is null && c.IsDefault) defaultChoice = c;
+            if (currentChoice is null && !trackingDefault
+                && string.Equals(c.SelectionId, currentSelectionId, StringComparison.Ordinal))
+                currentChoice = c;
+        }
+
+        // Keep stale/custom current models visible even if models.list omits them.
+        var effectiveChoices = modelChoices;
+        if (!trackingDefault && currentChoice is null && !string.IsNullOrWhiteSpace(currentModelId))
         {
-            cb.MinWidth = 0;
-            cb.Width = double.NaN;
-            cb.Height = 28;
-            cb.FontSize = 11;
-            cb.Padding = new Thickness(8, 0, 4, 0);
-            cb.CornerRadius = composerCornerRadius;
-            cb.HorizontalAlignment = HorizontalAlignment.Stretch;
-        }).VAlign(VerticalAlignment.Center);
+            var synthetic = new ChatModelChoice(currentModelId!, currentModelId!, Provider: Props.CurrentModelProvider);
+            currentChoice = synthetic;
+            var augmented = new List<ChatModelChoice>(modelChoices.Count + 1);
+            augmented.AddRange(modelChoices);
+            augmented.Add(synthetic);
+            effectiveChoices = augmented;
+            currentSelectionId = synthetic.SelectionId;
+        }
+
+        var modelEntries = new List<(string Label, object Tag, bool Selectable, bool IsCurrent)>();
+        if (effectiveChoices.Count > 0)
+            modelEntries.Add((ChatModelLabels.BuildDefaultEntryLabel(defaultChoice), ClearModelTag, true, trackingDefault));
+        foreach (var c in effectiveChoices)
+        {
+            var isCur = !trackingDefault && string.Equals(c.SelectionId, currentSelectionId, StringComparison.Ordinal);
+            modelEntries.Add((ChatModelLabels.BuildMenuLabel(c), c.SelectionId, c.IsSelectable, isCur));
+        }
+        if (modelEntries.Count == 0)
+        {
+            modelEntries.Add((Props.CurrentModel ?? "model", Props.CurrentModel ?? "", false, true));
+        }
+
+        var modelSelectedIndex = modelEntries.FindIndex(e => e.IsCurrent);
+
+        // Build directly so unavailable rows can be displayed but not selected.
+        var modelCombo = Border()
+            .Set(border =>
+            {
+                var cb = new ComboBox
+                {
+                    MinWidth = 0,
+                    Width = double.NaN,
+                    Height = 28,
+                    FontSize = 11,
+                    Padding = new Thickness(8, 0, 4, 0),
+                    CornerRadius = composerCornerRadius,
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    VerticalAlignment = VerticalAlignment.Center,
+                };
+
+                ComboBoxItem? selectedItem = null;
+                for (int i = 0; i < modelEntries.Count; i++)
+                {
+                    var entry = modelEntries[i];
+                    var item = new ComboBoxItem
+                    {
+                        Content = entry.Label,
+                        Tag = entry.Tag,
+                        IsEnabled = entry.Selectable,
+                        Padding = new Thickness(8, 4, 4, 4),
+                    };
+                    cb.Items.Add(item);
+                    if (i == modelSelectedIndex) selectedItem = item;
+                }
+
+                if (selectedItem != null)
+                    cb.SelectedItem = selectedItem;
+
+                var onModelChanged = Props.OnModelChanged;
+                var onModelCleared = Props.OnModelCleared;
+                cb.SelectionChanged += (_, _) =>
+                {
+                    if (cb.SelectedItem is not ComboBoxItem { IsEnabled: true } sel) return;
+                    if (ReferenceEquals(sel.Tag, ClearModelTag))
+                        onModelCleared?.Invoke();
+                    else if (sel.Tag is string id && !string.IsNullOrEmpty(id))
+                        onModelChanged(id);
+                };
+
+                border.Child = cb;
+            })
+            .VAlign(VerticalAlignment.Center);
 
         var thinkingLevel = Props.CurrentThinkingLevel ?? "medium";
         var thinkingIndex = Array.IndexOf(ThinkingLevelIds, thinkingLevel);

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -266,7 +266,7 @@ public class OpenClawGatewayClientTests
         public ModelsListInfo ParseModelsListPayload(string payloadJson)
         {
             ModelsListInfo? parsed = null;
-            EventHandler<ModelsListInfo> handler = (_, models) => parsed = models;
+            EventHandler<ModelsListInfo> handler = (_, info) => parsed = info;
             _client.ModelsListUpdated += handler;
 
             try
@@ -1683,6 +1683,97 @@ public class OpenClawGatewayClientTests
         var helper = new GatewayClientTestHelper();
         var nodes = helper.ParseNodeListPayload("""{ "nodes": [] }""");
         Assert.Empty(nodes);
+    }
+
+    [Fact]
+    public void ParseModelsList_PopulatesProviderRichMetadata()
+    {
+        var helper = new GatewayClientTestHelper();
+        var info = helper.ParseModelsListPayload("""
+            {
+              "models": [
+                {
+                  "id": "claude-opus-4.8",
+                  "name": "Claude Opus 4.8",
+                  "provider": "Anthropic",
+                  "contextWindow": 200000,
+                  "configured": true,
+                  "default": true
+                },
+                {
+                  "id": "gemini-3.1-pro",
+                  "name": "Gemini 3.1 Pro",
+                  "provider": "Google",
+                  "contextWindow": 1000000,
+                  "requiresAuth": true
+                },
+                {
+                  "id": "local-llama",
+                  "provider": "Ollama",
+                  "unavailable": true
+                }
+              ]
+            }
+            """);
+
+        Assert.Equal(3, info.Models.Count);
+
+        var opus = info.Models[0];
+        Assert.Equal("claude-opus-4.8", opus.Id);
+        Assert.Equal("Anthropic", opus.Provider);
+        Assert.Equal(200000, opus.ContextWindow);
+        Assert.True(opus.IsConfigured);
+        Assert.True(opus.IsDefault);
+        Assert.True(opus.IsAvailable);
+        Assert.False(opus.RequiresAuth);
+
+        var gemini = info.Models[1];
+        Assert.True(gemini.RequiresAuth);
+        Assert.False(gemini.IsDefault);
+        Assert.True(gemini.IsAvailable); // no availability signal → usable
+
+        var llama = info.Models[2];
+        Assert.False(llama.IsAvailable); // unavailable:true inverts to false
+        Assert.Equal("local-llama", llama.DisplayName); // name omitted → id
+    }
+
+    [Fact]
+    public void ParseModelsList_DefaultsAvailableTrue_WhenNoReadinessSignals()
+    {
+        var helper = new GatewayClientTestHelper();
+        var info = helper.ParseModelsListPayload("""
+            { "models": [ { "id": "gpt-5.5", "name": "GPT-5.5" } ] }
+            """);
+
+        var m = Assert.Single(info.Models);
+        Assert.True(m.IsAvailable);
+        Assert.False(m.RequiresAuth);
+        Assert.False(m.IsDefault);
+        Assert.False(m.IsConfigured);
+    }
+
+    [Fact]
+    public void ParseModelsList_AvailableFalse_MarksUnavailable()
+    {
+        var helper = new GatewayClientTestHelper();
+        var info = helper.ParseModelsListPayload("""
+            { "models": [ { "id": "x", "available": false } ] }
+            """);
+
+        Assert.False(Assert.Single(info.Models).IsAvailable);
+    }
+
+    [Fact]
+    public void ParseModelsList_AcceptsIsDefaultAndAuthNeededAliases()
+    {
+        var helper = new GatewayClientTestHelper();
+        var info = helper.ParseModelsListPayload("""
+            { "models": [ { "id": "x", "isDefault": true, "authNeeded": true } ] }
+            """);
+
+        var m = Assert.Single(info.Models);
+        Assert.True(m.IsDefault);
+        Assert.True(m.RequiresAuth);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/ChatModelChoiceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatModelChoiceTests.cs
@@ -1,0 +1,281 @@
+using OpenClaw.Chat;
+using OpenClaw.Shared;
+
+namespace OpenClaw.Tray.Tests;
+
+public class ChatModelChoiceTests
+{
+    // ── FromModelsList mapping ───────────────────────────────────────────
+
+    [Fact]
+    public void FromModelsList_MapsAllFields()
+    {
+        var info = new ModelsListInfo
+        {
+            Models =
+            {
+                new ModelInfo
+                {
+                    Id = "claude-opus-4.8",
+                    Name = "Claude Opus 4.8",
+                    Provider = "Anthropic",
+                    ContextWindow = 200000,
+                    IsConfigured = true,
+                    IsDefault = true,
+                    IsAvailable = true,
+                    RequiresAuth = false,
+                },
+            }
+        };
+
+        var choices = ChatModelChoice.FromModelsList(info);
+
+        var c = Assert.Single(choices);
+        Assert.Equal("claude-opus-4.8", c.Id);
+        Assert.Equal("Anthropic/claude-opus-4.8", c.SelectionId);
+        Assert.Equal("Claude Opus 4.8", c.DisplayName);
+        Assert.Equal("Anthropic", c.Provider);
+        Assert.Equal(200000, c.ContextWindow);
+        Assert.True(c.IsConfigured);
+        Assert.True(c.IsDefault);
+        Assert.True(c.IsAvailable);
+        Assert.True(c.IsSelectable);
+    }
+
+    [Fact]
+    public void FromModelsList_DedupesBySelectionId_FirstWins_SkipsEmptyIds()
+    {
+        var info = new ModelsListInfo
+        {
+            Models =
+            {
+                new ModelInfo { Id = "gpt-5.4", Name = "GPT-5.4", Provider = "openai" },
+                new ModelInfo { Id = "gpt-5.4", Name = "GPT-5.4 via OpenRouter", Provider = "openrouter" },
+                new ModelInfo { Id = "gpt-5.4", Name = "dupe", Provider = "openai" },
+                new ModelInfo { Id = "", Name = "blank" },
+            }
+        };
+
+        var choices = ChatModelChoice.FromModelsList(info);
+
+        Assert.Equal(2, choices.Count);
+        Assert.Equal("GPT-5.4", choices[0].DisplayName);
+        Assert.Equal("openai/gpt-5.4", choices[0].SelectionId);
+        Assert.Equal("GPT-5.4 via OpenRouter", choices[1].DisplayName);
+        Assert.Equal("openrouter/gpt-5.4", choices[1].SelectionId);
+    }
+
+    [Fact]
+    public void FromModelsList_NullOrEmpty_ReturnsEmpty()
+    {
+        Assert.Empty(ChatModelChoice.FromModelsList(null));
+        Assert.Empty(ChatModelChoice.FromModelsList(new ModelsListInfo()));
+    }
+
+    [Fact]
+    public void FromModelsList_FallsBackToIdWhenNameMissing()
+    {
+        var info = new ModelsListInfo { Models = { new ModelInfo { Id = "ollama-x" } } };
+        Assert.Equal("ollama-x", ChatModelChoice.FromModelsList(info)[0].DisplayName);
+    }
+
+    [Fact]
+    public void FromModelsList_HidesExplicitlyUnconfiguredModels()
+    {
+        var info = new ModelsListInfo
+        {
+            Models =
+            {
+                // Provider explicitly reported as not configured → hidden.
+                new ModelInfo { Id = "needs-key", HasConfiguredFlag = true, IsConfigured = false },
+                // Configured → kept.
+                new ModelInfo { Id = "ready", HasConfiguredFlag = true, IsConfigured = true },
+                // Flag omitted entirely → kept (we don't know, so don't hide).
+                new ModelInfo { Id = "unknown" },
+            }
+        };
+
+        var ids = ChatModelChoice.FromModelsList(info).Select(c => c.Id).ToArray();
+        Assert.Equal(new[] { "ready", "unknown" }, ids);
+    }
+
+    // ── Selectability ────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsSelectable_FalseOnlyWhenUnavailable()
+    {
+        Assert.True(new ChatModelChoice("x", "X").IsSelectable);
+        // Auth-needed stays selectable (routes to provider auth).
+        Assert.True(new ChatModelChoice("x", "X", RequiresAuth: true).IsSelectable);
+        Assert.False(new ChatModelChoice("x", "X", IsAvailable: false).IsSelectable);
+    }
+
+    [Theory]
+    [InlineData("gpt-5.4", "openai", "openai/gpt-5.4")]
+    [InlineData("openai/gpt-5.4", "openai", "openai/gpt-5.4")]
+    [InlineData("openai/gpt-5.4", "vercel-ai-gateway", "vercel-ai-gateway/openai/gpt-5.4")]
+    [InlineData("custom-model", null, "custom-model")]
+    public void SelectionId_ProviderQualifiesRawModelIds(string modelId, string? provider, string expected)
+    {
+        var c = new ChatModelChoice(modelId, modelId, Provider: provider);
+        Assert.Equal(expected, c.SelectionId);
+    }
+
+    [Fact]
+    public void ResolveSelectionId_UsesProviderToDisambiguateDuplicateRawModelIds()
+    {
+        var choices = new[]
+        {
+            new ChatModelChoice("gpt-5.4", "GPT-5.4", Provider: "openai"),
+            new ChatModelChoice("gpt-5.4", "GPT-5.4", Provider: "openrouter"),
+        };
+
+        Assert.Equal(
+            "openrouter/gpt-5.4",
+            ChatModelChoice.ResolveSelectionId("gpt-5.4", "openrouter", choices));
+        Assert.Equal("gpt-5.4", ChatModelChoice.ResolveSelectionId("gpt-5.4", null, choices));
+    }
+
+    [Fact]
+    public void ResolveSelectionId_MatchesProviderCaseInsensitively()
+    {
+        var choices = new[]
+        {
+            new ChatModelChoice("gpt-5.4", "GPT-5.4", Provider: "Anthropic"),
+        };
+
+        Assert.Equal(
+            "Anthropic/gpt-5.4",
+            ChatModelChoice.ResolveSelectionId("gpt-5.4", "anthropic", choices));
+    }
+
+    [Fact]
+    public void ResolveSelectionId_UsesBareCachedChoiceWhenProviderRichChoiceIsUnavailable()
+    {
+        var choices = new[]
+        {
+            new ChatModelChoice("gpt-5.4", "GPT-5.4"),
+        };
+
+        Assert.Equal("gpt-5.4", ChatModelChoice.ResolveSelectionId("gpt-5.4", "openrouter", choices));
+    }
+
+    // ── Tracking-default predicate ───────────────────────────────────────
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("", true)]
+    [InlineData("gpt-5.5", false)]
+    public void IsTrackingDefault_DetectsEmptyOrNull(string? id, bool expected) =>
+        Assert.Equal(expected, ChatModelLabels.IsTrackingDefault(id));
+
+    // ── Context-window formatting ────────────────────────────────────────
+
+    [Theory]
+    [InlineData(272000, "272K")]
+    [InlineData(200000, "200K")]
+    [InlineData(128000, "128K")]
+    [InlineData(1000000, "1M")]
+    [InlineData(2000000, "2M")]
+    [InlineData(1500000, "1.5M")]
+    [InlineData(8000, "8K")]
+    [InlineData(500, "500")]
+    [InlineData(0, "")]
+    public void FormatContextWindow_FormatsCompactly(int contextWindow, string expected) =>
+        Assert.Equal(expected, ChatModelLabels.FormatContextWindow(contextWindow));
+
+    // ── Meta segment ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildMetaSegment_CombinesProviderAndContext()
+    {
+        var c = new ChatModelChoice("x", "X", Provider: "OpenAI", ContextWindow: 272000);
+        Assert.Equal("OpenAI · 272K", ChatModelLabels.BuildMetaSegment(c));
+    }
+
+    [Fact]
+    public void BuildMetaSegment_ProviderOnly()
+    {
+        var c = new ChatModelChoice("x", "X", Provider: "OpenAI");
+        Assert.Equal("OpenAI", ChatModelLabels.BuildMetaSegment(c));
+    }
+
+    [Fact]
+    public void BuildMetaSegment_ContextOnly()
+    {
+        var c = new ChatModelChoice("x", "X", ContextWindow: 200000);
+        Assert.Equal("200K", ChatModelLabels.BuildMetaSegment(c));
+    }
+
+    [Fact]
+    public void BuildMetaSegment_NeitherKnown_ReturnsEmpty() =>
+        Assert.Equal("", ChatModelLabels.BuildMetaSegment(new ChatModelChoice("x", "X")));
+
+    // ── State markers ────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildStateMarker_Unavailable_TakesPrecedence()
+    {
+        var c = new ChatModelChoice("x", "X", IsAvailable: false, RequiresAuth: true, IsDefault: true);
+        Assert.Equal("unavailable", ChatModelLabels.BuildStateMarker(c));
+    }
+
+    [Fact]
+    public void BuildStateMarker_AuthNeeded_BeforeDefault()
+    {
+        var c = new ChatModelChoice("x", "X", RequiresAuth: true, IsDefault: true);
+        Assert.Equal("auth needed", ChatModelLabels.BuildStateMarker(c));
+    }
+
+    [Fact]
+    public void BuildStateMarker_Default()
+    {
+        var c = new ChatModelChoice("x", "X", IsDefault: true);
+        Assert.Equal("default", ChatModelLabels.BuildStateMarker(c));
+    }
+
+    [Fact]
+    public void BuildStateMarker_MissingConfiguredFlag_IsNotAuthNeeded()
+    {
+        // Gateway's "configured" view often omits the flag; absence must not be
+        // mistaken for an auth requirement.
+        var c = new ChatModelChoice("x", "X", IsConfigured: false);
+        Assert.Equal("", ChatModelLabels.BuildStateMarker(c));
+    }
+
+    // ── Full menu label ──────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildMenuLabel_Full()
+    {
+        var c = new ChatModelChoice("claude-opus-4.8", "Claude Opus 4.8", Provider: "Anthropic", ContextWindow: 200000, IsDefault: true);
+        Assert.Equal("Claude Opus 4.8 · Anthropic · 200K · default", ChatModelLabels.BuildMenuLabel(c));
+    }
+
+    [Fact]
+    public void BuildMenuLabel_AuthNeeded()
+    {
+        var c = new ChatModelChoice("gemini-3.1-pro", "Gemini 3.1 Pro", Provider: "Google", ContextWindow: 1000000, RequiresAuth: true);
+        Assert.Equal("Gemini 3.1 Pro · Google · 1M · auth needed", ChatModelLabels.BuildMenuLabel(c));
+    }
+
+    [Fact]
+    public void BuildMenuLabel_BareModel()
+    {
+        var c = new ChatModelChoice("custom-id", "custom-id");
+        Assert.Equal("custom-id", ChatModelLabels.BuildMenuLabel(c));
+    }
+
+    // ── Default (clear-to-default) entry label ───────────────────────────
+
+    [Fact]
+    public void BuildDefaultEntryLabel_NamesDefaultModelWhenKnown()
+    {
+        var def = new ChatModelChoice("claude-opus-4.8", "Claude Opus 4.8", IsDefault: true);
+        Assert.Equal("Default (Claude Opus 4.8)", ChatModelLabels.BuildDefaultEntryLabel(def));
+    }
+
+    [Fact]
+    public void BuildDefaultEntryLabel_PlainWhenDefaultUnknown() =>
+        Assert.Equal("Default", ChatModelLabels.BuildDefaultEntryLabel(null));
+}

--- a/tests/OpenClaw.Tray.Tests/ChatModelChoiceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatModelChoiceTests.cs
@@ -86,8 +86,10 @@ public class ChatModelChoiceTests
         {
             Models =
             {
-                // Provider explicitly reported as not configured → hidden.
-                new ModelInfo { Id = "needs-key", HasConfiguredFlag = true, IsConfigured = false },
+                // Provider explicitly reported as not configured with no auth path → hidden.
+                new ModelInfo { Id = "unconfigured", HasConfiguredFlag = true, IsConfigured = false },
+                // Auth-needed rows stay visible so users can choose the provider-auth path.
+                new ModelInfo { Id = "needs-key", HasConfiguredFlag = true, IsConfigured = false, RequiresAuth = true },
                 // Configured → kept.
                 new ModelInfo { Id = "ready", HasConfiguredFlag = true, IsConfigured = true },
                 // Flag omitted entirely → kept (we don't know, so don't hide).
@@ -95,8 +97,10 @@ public class ChatModelChoiceTests
             }
         };
 
-        var ids = ChatModelChoice.FromModelsList(info).Select(c => c.Id).ToArray();
-        Assert.Equal(new[] { "ready", "unknown" }, ids);
+        var choices = ChatModelChoice.FromModelsList(info);
+        Assert.Equal(new[] { "needs-key", "ready", "unknown" }, choices.Select(c => c.Id).ToArray());
+        Assert.True(choices[0].RequiresAuth);
+        Assert.True(choices[0].IsSelectable);
     }
 
     // ── Selectability ────────────────────────────────────────────────────

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -20,6 +20,7 @@
     <!-- Compile only the model-layer files directly so the tests can remain
          pure net10.0 while the tray app owns the native WinUI surface. -->
     <Compile Include="..\..\src\OpenClaw.Chat\ChatModels.cs" Link="Chat\ChatModels.cs" />
+    <Compile Include="..\..\src\OpenClaw.Chat\ChatModelChoice.cs" Link="Chat\ChatModelChoice.cs" />
     <Compile Include="..\..\src\OpenClaw.Chat\ChatTimelineReducer.cs" Link="Chat\ChatTimelineReducer.cs" />
     <Using Include="System.Text.Json.Nodes" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.0" />

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -2101,6 +2101,7 @@ public class OpenClawChatDataProviderTests
         Assert.Equal(2, choices.Count);
         Assert.Equal("openai/gpt-5.4", choices[0].SelectionId);
         Assert.Equal("openrouter/gpt-5.4", choices[1].SelectionId);
+        Assert.Equal(new[] { "gpt-5.4" }, snapshots[^1].AvailableModels);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -20,6 +20,8 @@ public class OpenClawChatDataProviderTests
         public Queue<ChatSendResult> SendResults { get; } = new();
         public List<string> AbortedRunIds { get; } = new();
         public Func<string, string?, string?, Task>? SendBehavior { get; set; }
+        public Func<string, string, Task>? PatchSessionModelBehavior { get; set; }
+        public Func<string, Task>? ClearSessionModelBehavior { get; set; }
         public Func<string?, Task<ChatHistoryInfo>>? HistoryBehavior { get; set; }
         public Func<string, Task>? AbortBehavior { get; set; }
         public SessionInfo[] Sessions { get; set; } = Array.Empty<SessionInfo>();
@@ -44,7 +46,20 @@ public class OpenClawChatDataProviderTests
             return SendResults.Count > 0 ? SendResults.Dequeue() : new ChatSendResult();
         }
 
-        public Task PatchSessionModelAsync(string sessionKey, string model) => Task.CompletedTask;
+        public Task PatchSessionModelAsync(string sessionKey, string model)
+        {
+            PatchedModelKeys.Add(sessionKey);
+            PatchedModels.Add(model);
+            return PatchSessionModelBehavior?.Invoke(sessionKey, model) ?? Task.CompletedTask;
+        }
+        public List<string> PatchedModelKeys { get; } = new();
+        public List<string> PatchedModels { get; } = new();
+        public Task ClearSessionModelAsync(string sessionKey)
+        {
+            ClearedModelKeys.Add(sessionKey);
+            return ClearSessionModelBehavior?.Invoke(sessionKey) ?? Task.CompletedTask;
+        }
+        public List<string> ClearedModelKeys { get; } = new();
         public Task PatchSessionThinkingLevelAsync(string sessionKey, string thinkingLevel) => Task.CompletedTask;
 
         public Task<ChatHistoryInfo> RequestChatHistoryAsync(string? sessionKey)
@@ -130,6 +145,20 @@ public class OpenClawChatDataProviderTests
         Assert.Equal("Main session", snapshot.Threads[0].Title);
         Assert.Equal("main", snapshot.DefaultThreadId);
         Assert.True(snapshot.Timelines.ContainsKey("main"));
+    }
+
+    [Fact]
+    public async Task LoadAsync_CarriesSessionModelProviderToThreads()
+    {
+        var session = MainSession();
+        session.Model = "gpt-5.4";
+        session.Provider = "openrouter";
+        var (_, provider, _, _) = CreateProvider(new[] { session });
+
+        var snapshot = await provider.LoadAsync();
+
+        Assert.Equal("gpt-5.4", snapshot.Threads[0].Model);
+        Assert.Equal("openrouter", snapshot.Threads[0].ModelProvider);
     }
 
     [Fact]
@@ -1991,7 +2020,219 @@ public class OpenClawChatDataProviderTests
         Assert.Equal(new[] { "x" }, snap.AvailableModels);
     }
 
-    // ── Iteration 4: per-entry metadata (timestamp + model) ──
+    [Fact]
+    public async Task ModelsListUpdated_PopulatesProviderRichChoices()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        await provider.LoadAsync();
+        snapshots.Clear();
+
+        bridge.RaiseModels(new ModelsListInfo
+        {
+            Models = new List<ModelInfo>
+            {
+                new() { Id = "claude-opus-4.8", Name = "Claude Opus 4.8", Provider = "Anthropic", ContextWindow = 200000, IsDefault = true },
+                new() { Id = "gemini-3.1-pro", Name = "Gemini 3.1 Pro", Provider = "Google", ContextWindow = 1000000, RequiresAuth = true },
+                new() { Id = "local-llama", Provider = "Ollama", IsAvailable = false },
+            }
+        });
+
+        var choices = snapshots[^1].ModelChoices;
+        Assert.NotNull(choices);
+        Assert.Equal(3, choices!.Count);
+
+        Assert.Equal("claude-opus-4.8", choices[0].Id);
+        Assert.Equal("Anthropic/claude-opus-4.8", choices[0].SelectionId);
+        Assert.Equal("Claude Opus 4.8", choices[0].DisplayName);
+        Assert.Equal("Anthropic", choices[0].Provider);
+        Assert.Equal(200000, choices[0].ContextWindow);
+        Assert.True(choices[0].IsDefault);
+
+        Assert.True(choices[1].RequiresAuth);
+        Assert.False(choices[2].IsAvailable);
+        Assert.False(choices[2].IsSelectable);
+
+        // AvailableModels stays a parallel id list for back-compat.
+        Assert.Equal(new[] { "claude-opus-4.8", "gemini-3.1-pro", "local-llama" }, snapshots[^1].AvailableModels);
+    }
+
+    [Fact]
+    public async Task ModelsListUpdated_DedupesChoicesById()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        await provider.LoadAsync();
+        snapshots.Clear();
+
+        bridge.RaiseModels(new ModelsListInfo
+        {
+            Models = new List<ModelInfo>
+            {
+                new() { Id = "gpt-5.4", Name = "GPT-5.4" },
+                new() { Id = "gpt-5.4", Name = "GPT-5.4 (dupe)" },
+                new() { Id = "", Name = "no id" },
+            }
+        });
+
+        var choices = snapshots[^1].ModelChoices!;
+        Assert.Single(choices);
+        Assert.Equal("gpt-5.4", choices[0].Id);
+        Assert.Equal("GPT-5.4", choices[0].DisplayName); // first wins
+    }
+
+    [Fact]
+    public async Task ModelsListUpdated_KeepsDuplicateRawModelIdsFromDifferentProviders()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        await provider.LoadAsync();
+        snapshots.Clear();
+
+        bridge.RaiseModels(new ModelsListInfo
+        {
+            Models = new List<ModelInfo>
+            {
+                new() { Id = "gpt-5.4", Name = "GPT-5.4", Provider = "openai" },
+                new() { Id = "gpt-5.4", Name = "GPT-5.4 via OpenRouter", Provider = "openrouter" },
+            }
+        });
+
+        var choices = snapshots[^1].ModelChoices!;
+        Assert.Equal(2, choices.Count);
+        Assert.Equal("openai/gpt-5.4", choices[0].SelectionId);
+        Assert.Equal("openrouter/gpt-5.4", choices[1].SelectionId);
+    }
+
+    [Fact]
+    public async Task SetModelAsync_ForwardsModelToBridge()
+    {
+        var (bridge, provider, _, _) = CreateProvider(new[] { MainSession() });
+        await provider.LoadAsync();
+
+        await provider.SetModelAsync("main", "claude-opus-4.8");
+
+        Assert.Equal(new[] { "main" }, bridge.PatchedModelKeys);
+        Assert.Equal(new[] { "claude-opus-4.8" }, bridge.PatchedModels);
+    }
+
+    [Fact]
+    public async Task SetModelAsync_EmptyModel_IsNoOp_NotSent()
+    {
+        var (bridge, provider, _, _) = CreateProvider(new[] { MainSession() });
+        await provider.LoadAsync();
+
+        // The gateway's sessions.patch schema rejects an empty model (NonEmpty
+        // string); a blank Set is a no-op. Clearing goes through ClearModelAsync.
+        await provider.SetModelAsync("main", "");
+        await provider.SetModelAsync("main", "   ");
+
+        Assert.Empty(bridge.PatchedModels);
+        Assert.Empty(bridge.ClearedModelKeys);
+    }
+
+    [Fact]
+    public async Task ClearModelAsync_ClearsOverrideViaBridge()
+    {
+        var (bridge, provider, _, _) = CreateProvider(new[] { MainSession() });
+        await provider.LoadAsync();
+
+        // The picker's "Default" entry clears the session's model override
+        // (tri-state sessions.patch null) — distinct from a Set.
+        await provider.ClearModelAsync("main");
+
+        Assert.Equal(new[] { "main" }, bridge.ClearedModelKeys);
+        Assert.Empty(bridge.PatchedModels);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_WaitsForInFlightModelPatchBeforeGatewaySend()
+    {
+        var patchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePatch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        bridge.PatchSessionModelBehavior = (_, _) =>
+        {
+            patchStarted.TrySetResult();
+            return releasePatch.Task;
+        };
+        await provider.LoadAsync();
+        snapshots.Clear();
+
+        var modelTask = provider.SetModelAsync("main", "openai/gpt-5.4");
+        var sendTask = provider.SendMessageAsync("main", "Hello");
+        await Task.Delay(50);
+
+        Assert.Single(snapshots);
+        Assert.Empty(bridge.SentMessages);
+
+        await patchStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        releasePatch.SetResult();
+        await Task.WhenAll(modelTask, sendTask);
+
+        Assert.Equal(new[] { "openai/gpt-5.4" }, bridge.PatchedModels);
+        Assert.Equal(new[] { "Hello" }, bridge.SentMessages);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_ContinuesWhenInFlightModelPatchFails()
+    {
+        var patchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePatch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        bridge.PatchSessionModelBehavior = async (_, _) =>
+        {
+            patchStarted.SetResult();
+            await releasePatch.Task;
+            throw new InvalidOperationException("patch failed");
+        };
+        await provider.LoadAsync();
+        snapshots.Clear();
+
+        var modelTask = provider.SetModelAsync("main", "openai/gpt-5.4");
+        await patchStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        var sendTask = provider.SendMessageAsync("main", "Hello");
+        await Task.Delay(50);
+
+        Assert.Empty(bridge.SentMessages);
+        releasePatch.SetResult();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => modelTask);
+        await sendTask;
+
+        Assert.Equal(new[] { "openai/gpt-5.4" }, bridge.PatchedModels);
+        Assert.Equal(new[] { "Hello" }, bridge.SentMessages);
+        Assert.DoesNotContain(
+            snapshots.SelectMany(s => s.Timelines["main"].Entries),
+            e => e.Kind == ChatTimelineItemKind.Status && e.Text.Contains("patch failed"));
+    }
+
+    [Fact]
+    public async Task ModelPatches_AreSerializedSoLatestSelectionCannotBeOvertaken()
+    {
+        var releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (bridge, provider, _, _) = CreateProvider(new[] { MainSession() });
+        bridge.PatchSessionModelBehavior = (_, model) =>
+        {
+            if (model == "openai/gpt-5.4")
+                return releaseFirst.Task;
+            if (model == "openai/gpt-5.4-pro")
+                secondStarted.SetResult();
+            return Task.CompletedTask;
+        };
+        await provider.LoadAsync();
+
+        var firstTask = provider.SetModelAsync("main", "openai/gpt-5.4");
+        var secondTask = provider.SetModelAsync("main", "openai/gpt-5.4-pro");
+        await Task.Delay(50);
+
+        Assert.False(secondStarted.Task.IsCompleted);
+
+        releaseFirst.SetResult();
+        await Task.WhenAll(firstTask, secondTask);
+
+        Assert.True(secondStarted.Task.IsCompleted);
+        Assert.Equal(new[] { "openai/gpt-5.4", "openai/gpt-5.4-pro" }, bridge.PatchedModels);
+    }
+
 
     [Fact]
     public async Task LoadHistoryAsync_CapturesPerEntryTimestamps()
@@ -3864,6 +4105,37 @@ public class OpenClawChatDataProviderTests
             e.Kind == ChatTimelineItemKind.Status &&
             e.Text.Contains("Always allow", StringComparison.Ordinal) &&
             e.Text.Contains("del \"E:\\Temp\\sample.txt\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task LocalExecApproval_SyntheticThreadUsesCachedModelProvider()
+    {
+        var session = MainSession();
+        session.Model = "gpt-5.4";
+        session.Provider = "openrouter";
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { session });
+        await provider.LoadAsync();
+        Assert.Equal("gpt-5.4", provider.CachedLastChatState?.Model);
+        Assert.Equal("openrouter", provider.CachedLastChatState?.ModelProvider);
+        bridge.RaiseSessions(Array.Empty<SessionInfo>());
+        Assert.Equal("gpt-5.4", provider.CachedLastChatState?.Model);
+        Assert.Equal("openrouter", provider.CachedLastChatState?.ModelProvider);
+        snapshots.Clear();
+
+        var promptTask = provider.RequestLocalExecApprovalAsync(new ExecApprovalPromptRequest
+        {
+            Command = "tasklist",
+            Shell = "cmd",
+            SessionKey = "main",
+            CorrelationId = "provider-context"
+        });
+
+        var synthetic = Assert.Single(snapshots[^1].Threads, t => t.Id == "main");
+        Assert.Equal("gpt-5.4", synthetic.Model);
+        Assert.Equal("openrouter", synthetic.ModelProvider);
+
+        await provider.RespondToPermissionAsync("main", "local-provider-context", ChatPermissionActionKeys.Deny);
+        await promptTask;
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -1972,13 +1972,15 @@ public class OpenClawChatDataProviderTests
             {
                 new() { Id = "gpt-5.4", IsConfigured = true, HasConfiguredFlag = true },
                 new() { Id = "gpt-5.5", IsConfigured = false, HasConfiguredFlag = true },
+                new() { Id = "needs-auth", IsConfigured = false, HasConfiguredFlag = true, RequiresAuth = true },
                 new() { Id = "legacy-gateway-model" }
             }
         });
 
         Assert.Equal(
-            new[] { "gpt-5.4", "legacy-gateway-model" },
+            new[] { "gpt-5.4", "needs-auth", "legacy-gateway-model" },
             snapshots[^1].AvailableModels);
+        Assert.True(snapshots[^1].ModelChoices!.Single(c => c.Id == "needs-auth").RequiresAuth);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
@@ -366,6 +366,7 @@ public class ToolMetaCacheTests
         public Task SendChatMessageAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null) => Task.CompletedTask;
         public Task<ChatSendResult> SendChatMessageForRunAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null) => Task.FromResult(new ChatSendResult());
         public Task PatchSessionModelAsync(string sessionKey, string model) => Task.CompletedTask;
+        public Task ClearSessionModelAsync(string sessionKey) => Task.CompletedTask;
         public Task PatchSessionThinkingLevelAsync(string sessionKey, string thinkingLevel) => Task.CompletedTask;
         public Task<ChatHistoryInfo> RequestChatHistoryAsync(string? sessionKey) => Task.FromResult(History);
         public Task SendChatAbortAsync(string runId, string? sessionKey = null) => Task.CompletedTask;


### PR DESCRIPTION
## Summary

- Problem: Windows chat showed model choices as flat model ids, which made provider, default/current state, readiness, and context-window details hard to distinguish.
- Why it matters: Duplicate model ids across providers and fast model switches could make the picker ambiguous or send with a stale model.
- What changed: Added provider-rich model choices, provider-qualified picker identity, readiness/default labels, clear-to-default through explicit session patch clear, and send ordering behind in-flight model changes.
- User impact: Users get clearer model choices and model switches are preserved more reliably across duplicate providers, reconnects, and fast sends.
- What did NOT change (scope boundary): No new permissions, no credential/storage behavior changes, and no new command execution surface.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs / instructions
- [x] Tests / validation
- [ ] Security hardening
- [ ] Chore / infra

## Scope (select all touched areas)

- [x] Tray / WinUI UX
- [ ] Windows node capability
- [ ] Local MCP / `winnode`
- [x] Gateway / connection / pairing
- [ ] Setup / onboarding
- [ ] Permissions / privacy / security
- [x] Tests / CI / docs

## Linked Issue/PR

- Closes #
- Related #
- [ ] Related to a bug or regression

## Validation

- `.\build.ps1` — Passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` — Passed, 2571 passed / 31 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` — Passed, 1328 passed
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --filter "FullyQualifiedName~ChatModelChoiceTests|FullyQualifiedName~OpenClawChatDataProviderTests"` — Passed, 190 passed

## Real behavior proof

- Environment tested: Windows ARM64, local non-isolated OpenClaw Tray build from this branch.
- PR head / commit tested: `7b02ebff`
- Exact steps or command run:
  - Launched `OpenClaw.Tray.WinUI.exe` from the branch build output.
  - Ran focused model-picker/provider tests covering duplicate provider ids, clear-to-default, unavailable/auth-needed states, send-after-switch ordering, failed model-patch fallback, reconnect cache matching, and synthetic-thread provider context.
- Evidence after fix:
  - Focused tests passed: 190 tests.
  - Full tray tests passed: 1328 tests.
  - Full shared tests passed: 2571 tests / 31 skipped.
- Observed result: Model picker behavior is provider-aware, preserves provider identity across duplicate model ids, clears to default with explicit null, and waits for model changes before sends.
<img width="937" height="317" alt="image" src="https://github.com/user-attachments/assets/52a2b8d0-6634-4803-a398-25f43b4046b2" />


## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only conversations that still need reviewer or maintainer judgment.
