### PR TITLE
Fix setup triage quick wins

### DIFF
--- a/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
@@ -14,6 +14,8 @@ namespace OpenClaw.SetupEngine.UI.Pages;
 
 public sealed partial class WelcomePage : Page
 {
+    private const string InstallButtonText = "Install new WSL Gateway";
+    private const string CheckingButtonText = "Checking existing setup...";
     private SetupConfig? _config;
 
     public WelcomePage()
@@ -66,27 +68,50 @@ public sealed partial class WelcomePage : Page
 
     private async Task StartButtonClickAsync()
     {
+        var config = _config ?? throw new InvalidOperationException("Setup configuration has not been loaded.");
         var dataDir = Environment.GetEnvironmentVariable("OPENCLAW_TRAY_DATA_DIR")
             ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "OpenClawTray");
+        var setupWindow = SetupWindow.Active;
 
-        var existing = ExistingConfigDetector.Detect(dataDir, _config!.DistroName);
-        var summary = ExistingConfigDetector.BuildReplacementSummary(existing);
-
-        var dialog = new ContentDialog
+        StartButton.IsEnabled = false;
+        StartButton.Content = CheckingButtonText;
+        var navigating = false;
+        try
         {
-            Title = existing.HasLocalGateway || existing.HasDistro
-                ? "Replace existing WSL gateway?"
-                : "Install a new WSL gateway?",
-            Content = summary,
-            PrimaryButtonText = "Continue",
-            CloseButtonText = "Cancel",
-            DefaultButton = ContentDialogButton.Close,
-            XamlRoot = XamlRoot,
-        };
+            var existing = await Task.Run(() => ExistingConfigDetector.Detect(dataDir, config.DistroName));
+            var xamlRoot = XamlRoot;
+            if (setupWindow is null or { IsClosed: true } || xamlRoot is null)
+                return;
 
-        var result = await dialog.ShowAsync();
-        if (result == ContentDialogResult.Primary)
-            SetupWindow.Active?.NavigateToCapabilities();
+            var summary = ExistingConfigDetector.BuildReplacementSummary(existing);
+
+            var dialog = new ContentDialog
+            {
+                Title = existing.HasLocalGateway || existing.HasDistro
+                    ? "Replace existing WSL gateway?"
+                    : "Install a new WSL gateway?",
+                Content = summary,
+                PrimaryButtonText = "Continue",
+                CloseButtonText = "Cancel",
+                DefaultButton = ContentDialogButton.Close,
+                XamlRoot = xamlRoot,
+            };
+
+            var result = await dialog.ShowAsync();
+            if (result != ContentDialogResult.Primary)
+                return;
+
+            navigating = true;
+            setupWindow.NavigateToCapabilities();
+        }
+        finally
+        {
+            if (!navigating && setupWindow is { IsClosed: false })
+            {
+                StartButton.Content = InstallButtonText;
+                StartButton.IsEnabled = true;
+            }
+        }
     }
 
     private void AdvancedSetup_Click(object sender, RoutedEventArgs e)

--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -142,11 +142,15 @@ internal static class WslInstallSupport
         // virtualization enabled, even though `wsl --version` succeeds.
         if (Contains(text, "WSL2 is not supported with your current machine configuration"))
         {
+            var hardwareVirtualizationGuidance = architecture == Architecture.Arm64
+                ? "On ARM64 devices (including Surface), also make sure hardware virtualization is allowed by firmware or device-management policy; many devices do not expose a firmware toggle. "
+                : "If setup still reports virtualization disabled after enabling the Windows feature, enable VT-x/AMD-V (Intel VT or AMD SVM) in BIOS/UEFI. ";
             message = "WSL2 is not supported with the current machine configuration. "
                 + "Enable the Windows 'Virtual Machine Platform' support by running "
                 + "`wsl --install --no-distribution` from an elevated PowerShell (or enable "
-                + "'Virtual Machine Platform' under 'Turn Windows features on or off'), ensure "
-                + "hardware virtualization is enabled in BIOS/UEFI, reboot, then retry setup.";
+                + "'Virtual Machine Platform' under 'Turn Windows features on or off'). "
+                + hardwareVirtualizationGuidance
+                + "Reboot, then retry setup.";
             return true;
         }
 

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -708,11 +708,34 @@ public class SetupStepsTests : IDisposable
             + "Enable \"Virtual Machine Platform\" by running: wsl.exe --install --no-distribution\r\n\r\n"
             + "For information please visit https://aka.ms/enablevirtualization\r\n");
 
-        Assert.True(WslInstallSupport.TryGetEnvironmentIssue(status, out var message));
+        Assert.True(WslInstallSupport.TryGetEnvironmentIssue(status, Architecture.X64, out var message));
         Assert.Contains("Virtual Machine Platform", message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("virtualization", message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("wsl --install --no-distribution", message);
+        Assert.Contains("VT-x", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("BIOS/UEFI", message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("reboot", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void WslInstallSupport_TryGetEnvironmentIssue_UsesArm64WordingForUnsupportedMachineConfiguration()
+    {
+        var status = NulSeparated("Default Version: 2\r\n\r\n"
+            + "WSL2 is not supported with your current machine configuration.\r\n\r\n"
+            + "Please enable the \"Virtual Machine Platform\" optional component and ensure virtualization is enabled in the BIOS.\r\n\r\n"
+            + "Enable \"Virtual Machine Platform\" by running: wsl.exe --install --no-distribution\r\n\r\n"
+            + "For information please visit https://aka.ms/enablevirtualization\r\n");
+
+        Assert.True(WslInstallSupport.TryGetEnvironmentIssue(status, Architecture.Arm64, out var message));
+        Assert.Contains("Virtual Machine Platform", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ARM64", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Surface", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("device-management policy", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("wsl --install --no-distribution", message);
+        Assert.DoesNotContain("BIOS", message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("VT-x", message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("AMD-V", message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("SVM", message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/OpenClaw.SetupEngine.Tests/WizardDefaultAnswerMatrixTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/WizardDefaultAnswerMatrixTests.cs
@@ -1,0 +1,125 @@
+using System.Text.Json;
+
+namespace OpenClaw.SetupEngine.Tests;
+
+public class WizardDefaultAnswerMatrixTests
+{
+    private static readonly string[] ProviderOptions =
+    [
+        "skip",
+        "github-copilot",
+        "lmstudio",
+        "lm-studio",
+        "openai",
+        "azure-openai",
+    ];
+
+    private static readonly string[] ChannelOptions =
+    [
+        "__skip__",
+        "teams",
+        "telegram",
+        "discord",
+        "whatsapp",
+    ];
+
+    [Fact]
+    public void DefaultConfig_CoversProviderChannelAndSearchWizardSteps()
+    {
+        var answers = LoadDefaultWizardAnswers();
+
+        AssertConfiguredSelect(answers, "model-auth-provider", ProviderOptions);
+        AssertConfiguredSelect(answers, "default-model", ["__keep__", "gpt-5.5", "gpt-5.4", "claude-sonnet-4.6"]);
+        AssertConfiguredMultiselect(answers, "select-channel-quickstart", ChannelOptions);
+        AssertConfiguredSelect(answers, "search-provider", ["__skip__", "tavily", "brave", "bing"]);
+
+        Assert.True(answers.TryGetValue("configure-skills-now-recommended", out var configureSkills));
+        Assert.False((bool)WizardAnswerBuilder.BuildWireValue("confirm", configureSkills, []));
+    }
+
+    [Theory]
+    [MemberData(nameof(RepresentativeProviderChannelMatrix))]
+    public void WizardAnswerBuilder_ValidatesRepresentativeProviderChannelCombinations(
+        string provider,
+        string channels)
+    {
+        var providerOptions = Options(ProviderOptions);
+        var channelOptions = Options(ChannelOptions);
+
+        Assert.True(WizardAnswerBuilder.TryFindOption(providerOptions, provider, out _));
+        Assert.True(WizardAnswerBuilder.TryResolveOptions(channelOptions, channels, out var selectedChannels));
+        Assert.NotEmpty(selectedChannels);
+
+        var providerWire = WizardAnswerBuilder.BuildWireValue("select", provider, providerOptions);
+        var channelsWire = WizardAnswerBuilder.BuildWireValue("multiselect", channels, channelOptions);
+
+        Assert.Equal(JsonSerializer.Serialize(provider), JsonSerializer.Serialize(providerWire));
+        Assert.StartsWith("[", JsonSerializer.Serialize(channelsWire), StringComparison.Ordinal);
+    }
+
+    public static IEnumerable<object[]> RepresentativeProviderChannelMatrix()
+    {
+        foreach (var provider in ProviderOptions)
+        {
+            yield return [provider, "__skip__"];
+            yield return [provider, "teams"];
+            yield return [provider, "telegram"];
+            yield return [provider, "discord,whatsapp"];
+        }
+    }
+
+    private static Dictionary<string, string> LoadDefaultWizardAnswers()
+    {
+        var configPath = Path.Combine(RepositoryRoot(), "src", "OpenClaw.SetupEngine", "default-config.json");
+        var config = SetupConfig.LoadFromFile(configPath);
+        return config.WizardAnswers ?? new Dictionary<string, string>();
+    }
+
+    private static void AssertConfiguredSelect(
+        Dictionary<string, string> answers,
+        string key,
+        IReadOnlyList<string> values)
+    {
+        Assert.True(answers.TryGetValue(key, out var answer), $"Missing WizardAnswers['{key}']");
+        Assert.True(WizardAnswerBuilder.TryFindOption(Options(values), answer, out _),
+            $"WizardAnswers['{key}'] value '{answer}' was not present in representative options.");
+    }
+
+    private static void AssertConfiguredMultiselect(
+        Dictionary<string, string> answers,
+        string key,
+        IReadOnlyList<string> values)
+    {
+        Assert.True(answers.TryGetValue(key, out var answer), $"Missing WizardAnswers['{key}']");
+        Assert.True(WizardAnswerBuilder.TryResolveOptions(Options(values), answer, out var selected),
+            $"WizardAnswers['{key}'] value '{answer}' could not be resolved from representative options.");
+        Assert.NotEmpty(selected);
+    }
+
+    private static IReadOnlyList<WizardOptionValue> Options(IReadOnlyList<string> values)
+    {
+        var json = JsonSerializer.Serialize(new
+        {
+            options = values.Select(value => new { label = value, value })
+        });
+        using var document = JsonDocument.Parse(json);
+        return WizardAnswerBuilder.ReadOptions(document.RootElement);
+    }
+
+    private static string RepositoryRoot()
+    {
+        if (Environment.GetEnvironmentVariable("OPENCLAW_REPO_ROOT") is { Length: > 0 } configured)
+            return configured;
+
+        var directory = AppContext.BaseDirectory;
+        while (!string.IsNullOrWhiteSpace(directory))
+        {
+            if (File.Exists(Path.Combine(directory, "src", "OpenClaw.SetupEngine", "default-config.json")))
+                return directory;
+
+            directory = Directory.GetParent(directory)?.FullName;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root for default-config.json.");
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -321,6 +321,29 @@ public sealed class AppRefactorContractTests
     }
 
     [Fact]
+    public void SetupWelcomePage_RunsExistingConfigDetectionOffUiThread()
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "WelcomePage.xaml.cs"));
+        var method = ExtractMethod(source, "StartButtonClickAsync");
+
+        Assert.Contains("StartButton.IsEnabled = false", method);
+        Assert.Contains("CheckingButtonText", method);
+        Assert.Contains("var setupWindow = SetupWindow.Active", method);
+        Assert.Contains("await Task.Run(() => ExistingConfigDetector.Detect", method);
+        Assert.Contains("setupWindow is null or { IsClosed: true } || xamlRoot is null", method);
+        Assert.Contains("setupWindow is { IsClosed: false }", method);
+        Assert.Contains("StartButton.IsEnabled = true", method);
+        AssertInOrder(
+            method,
+            "StartButton.IsEnabled = false",
+            "await Task.Run(() => ExistingConfigDetector.Detect",
+            "setupWindow is null or { IsClosed: true } || xamlRoot is null",
+            "dialog.ShowAsync()",
+            "setupWindow.NavigateToCapabilities()");
+    }
+
+    [Fact]
     public void TrayIcon_UpdateDelegatesToCoordinator()
     {
         var source = ReadAppSources();


### PR DESCRIPTION
## Summary

- Fixes #868 by making WSL unsupported-machine-configuration guidance architecture-aware: x64 keeps BIOS/UEFI + VT-x/AMD-V/SVM guidance, while ARM64 avoids misleading BIOS/VT wording and points to Windows virtualization features/device policy.
- Fixes #867 by moving existing setup detection off the setup UI thread, showing a busy/disabled install button while detection runs, and guarding the post-detection dialog/navigation path when the setup window is closed.
- Adds partial representative coverage toward #847 by validating default wizard answers plus provider/channel/search answer shaping without requiring live provider/channel authentication. This does not close the broader live provider/channel matrix unless maintainers decide this narrower coverage is sufficient.
- Handled #661 separately as issue hygiene: verified current parser coverage and closed it as already fixed.

## Validation

- `.\build.ps1`
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` — 2629 passed, 31 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` — 1433 passed
- `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --no-restore` — 361 passed
- Fresh-worktree note: the first `--no-restore` test command hit the expected missing `project.assets.json` restore condition; tests were restored once, then the required build and `--no-restore` validation commands above passed.
- Focused setup UI contract: `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore --filter FullyQualifiedName~SetupWelcomePage_RunsExistingConfigDetectionOffUiThread`
- Focused #661 parser proof before issue closure: `dotnet test .\tests\OpenClaw.SetupEngine.Tests\OpenClaw.SetupEngine.Tests.csproj --filter "FullyQualifiedName~WslInstallSupport_TryParseWslVersion"` — 33 passed
- PR CI: CodeQL, repo hygiene, unit tests, setup E2E slices, and x64/arm64 builds passed on #879.

## Real behavior proof

- Automated proof: setup detection now crosses an `await Task.Run(() => ExistingConfigDetector.Detect(...))` boundary before dialog/navigation, and the contract test pins the disabled/busy button state, async detection boundary, null/closed window guard, `XamlRoot` guard, and safe navigation path.
- Adversarial review proof: Codex (`gpt-5.3-codex`) and Opus (`claude-opus-4.6`) both flagged the same setup-window close race; fixed by capturing the setup window once, treating null/closed as unsafe to continue, guarding `XamlRoot`, and only restoring the button while the captured window remains open.
- Final structured review: `python .\.agents\skills\autoreview\scripts\autoreview --mode local --prompt "Scope baseline: review the current local changes for issues #847, #867, #868 and the review-triggered WelcomePage window lifecycle fix..."` reported no accepted/actionable findings.
- Partial visible UI proof: on current PR head `bf69a8b6`, the setup UI stayed responsive after clicking the setup path and reached a terminal **Setup failed** state rather than becoming Not Responding. The observed failure was unrelated to the UI-thread fix: `Step 'preflight-port' failed: Port 18789 is already in use for loopback bind (AddressAlreadyInUse)`.
- Not verified / blocked: the full confirmation-dialog/navigation proof was blocked because port 18789 was already occupied by existing `ssh.exe` loopback listeners on both `127.0.0.1:18789` and `[::1]:18789`. Those tunnels were intentionally left running, so the setup flow could not proceed past preflight in this proof pass.