### PR TITLE
Fix user chat bubble text rendering

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
@@ -141,6 +141,9 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
     private const string MonoFontFamilySource = "Cascadia Code, Cascadia Mono, Consolas";
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<
         Microsoft.UI.Dispatching.DispatcherQueue, FontFamily> s_monoFontByDispatcher = new();
+    private const string ChatTextFontFamilySource = "Segoe UI Variable Text, Segoe UI";
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<
+        Microsoft.UI.Dispatching.DispatcherQueue, FontFamily> s_chatTextFontByDispatcher = new();
     private static FontFamily s_monoFontFamily
     {
         get
@@ -154,6 +157,23 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
             {
                 family = new FontFamily(MonoFontFamilySource);
                 s_monoFontByDispatcher.Add(dispatcher, family);
+            }
+            return family;
+        }
+    }
+    private static FontFamily s_chatTextFontFamily
+    {
+        get
+        {
+            var dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+            if (dispatcher is null)
+            {
+                return new FontFamily(ChatTextFontFamilySource);
+            }
+            if (!s_chatTextFontByDispatcher.TryGetValue(dispatcher, out var family))
+            {
+                family = new FontFamily(ChatTextFontFamilySource);
+                s_chatTextFontByDispatcher.Add(dispatcher, family);
             }
             return family;
         }
@@ -1117,6 +1137,14 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                             t.FontSize = 14;
                             t.Foreground = userBubbleFg;
                             t.IsTextSelectionEnabled = true;
+                            t.FontFamily = s_chatTextFontFamily;
+                            t.TextTrimming = TextTrimming.None;
+                            t.MaxLines = 0;
+                            t.LineHeight = 0;
+                            t.CharacterSpacing = 0;
+                            t.Width = double.NaN;
+                            t.MinWidth = 0;
+                            t.MaxWidth = double.PositiveInfinity;
                             // The default SelectionHighlightColor is the
                             // system accent — which equals the user bubble's
                             // background — so the highlight band is invisible

--- a/tests/OpenClaw.Tray.Tests/ChatUserBubbleTextContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatUserBubbleTextContractTests.cs
@@ -1,0 +1,26 @@
+using System.Text.RegularExpressions;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class ChatUserBubbleTextContractTests
+{
+    [Fact]
+    public void UserPromptText_ResetsStaleTextBlockVisualStateBeforeApplyingInlines()
+    {
+        var timeline = Read("src", "OpenClaw.Tray.WinUI", "Chat", "OpenClawChatTimeline.cs");
+
+        Assert.Contains("private const string ChatTextFontFamilySource", timeline);
+        Assert.Contains("TextBlock(string.Empty)", timeline);
+        Assert.Contains("t.FontFamily = s_chatTextFontFamily;", timeline);
+        Assert.Contains("t.TextTrimming = TextTrimming.None;", timeline);
+        Assert.Contains("t.MaxLines = 0;", timeline);
+        Assert.Contains("t.Width = double.NaN;", timeline);
+        Assert.Contains("t.MaxWidth = double.PositiveInfinity;", timeline);
+        Assert.Matches(
+            new Regex(@"t\.TextTrimming\s*=\s*TextTrimming\.None;[\s\S]*ApplyPlainSelectableInlines\(t,\s*messageText\);"),
+            timeline);
+    }
+
+    private static string Read(params string[] parts)
+        => File.ReadAllText(Path.Combine(new[] { TestRepositoryPaths.GetRepositoryRoot() }.Concat(parts).ToArray()));
+}


### PR DESCRIPTION
Fixes #880

## Summary
- Reset reused WinUI `TextBlock` visual state before applying selection-safe user prompt inlines.
- Cache the normal chat text `FontFamily` per dispatcher so user bubbles do not inherit stale glyph/trimming state from reused controls.
- Add a contract test covering the user-bubble reset before `ApplyPlainSelectableInlines(...)`.

## Validation
- `./build.ps1` — passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — passed: 2629 passed / 31 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — passed: 1433 passed
- `python .agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD` — clean: no accepted/actionable findings
- Rubber-duck review — no blocking findings

## Real behavior proof
- Rebuilt local Debug WinUI app from this branch and reopened the Chat view.
- Developer-provided current-head screenshot in the Copilot session shows the previously broken prompt now rendering as `yes file another bug` in the user bubble instead of a single glyph/dot.
- Computer-use UIA proof was blocked: the background engine listed the WinUI window but could not resolve it with `get_window_state`; manual screenshot proof was used instead.
