### PR TITLE
Suppress assistant NO_REPLY chat directives

### DIFF
--- a/src/OpenClaw.Shared/Models.cs
+++ b/src/OpenClaw.Shared/Models.cs
@@ -1767,6 +1767,12 @@ public static class ModelFormatting
 /// </summary>
 public class ChatMessageInfo
 {
+    public const string SilentAssistantDirective = "NO_REPLY";
+
+    public static bool IsSilentAssistantDirective(string? role, string? text) =>
+        string.Equals(role, "assistant", StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(text?.Trim(), SilentAssistantDirective, StringComparison.Ordinal);
+
     /// <summary>Session this message belongs to (e.g. "main").</summary>
     public string SessionKey { get; set; } = "";
 

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -547,6 +547,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
             string text = ExtractMessageText(m);
             if (string.IsNullOrEmpty(text)) continue;
             if (string.IsNullOrEmpty(role)) continue;
+            if (ChatMessageInfo.IsSilentAssistantDirective(role, text)) continue;
 
             var (inputTokens, outputTokens, responseTokens, contextPercent) = ExtractChatUsage(m);
             list.Add(new ChatMessageInfo
@@ -3068,6 +3069,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
 
             var text = ExtractMessageText(message);
             if (string.IsNullOrEmpty(text)) return;
+            if (ChatMessageInfo.IsSilentAssistantDirective(role, text)) return;
 
             EmitChatMessageReceived(sessionKey, role, text, state, tsMs, inTok, outTok, respTok, ctxPct);
 
@@ -3089,6 +3091,8 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
 
             if (!string.IsNullOrEmpty(text))
             {
+                if (ChatMessageInfo.IsSilentAssistantDirective(role, text)) return;
+
                 EmitChatMessageReceived(sessionKey, role, text, state, tsMs, inTok, outTok, respTok, ctxPct);
 
                 if (role == "assistant")
@@ -3154,6 +3158,9 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
     private void EmitChatMessageReceived(string sessionKey, string role, string text, string? state, long tsMs,
         int? inputTokens = null, int? outputTokens = null, int? responseTokens = null, int? contextPct = null)
     {
+        if (ChatMessageInfo.IsSilentAssistantDirective(role, text))
+            return;
+
         try
         {
             ChatMessageReceived?.Invoke(this, new ChatMessageInfo

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -646,6 +646,12 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
                             break;
 
                         case "assistant":
+                            if (ChatMessageInfo.IsSilentAssistantDirective(roleLower, text))
+                            {
+                                Logger.Debug("[ChatHistory]   → routed: SILENT assistant directive");
+                                break;
+                            }
+
                             // If this assistant response was aborted, show a placeholder
                             // instead of the actual (partial) content.
                             if (shouldMarkAborted)
@@ -1691,6 +1697,8 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         }
 
         if (roleLower != "assistant")
+            return;
+        if (ChatMessageInfo.IsSilentAssistantDirective(roleLower, message.Text))
             return;
         if (string.IsNullOrEmpty(message.Text))
             return;

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -124,6 +124,15 @@ public class OpenClawGatewayClientTests
             method!.Invoke(_client, new object[] { json });
         }
 
+        public ChatHistoryInfo ParseChatHistoryPayload(string payloadJson, string sessionKey = "main")
+        {
+            using var document = JsonDocument.Parse(payloadJson);
+            var method = typeof(OpenClawGatewayClient).GetMethod(
+                "ParseChatHistory",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            return (ChatHistoryInfo)method!.Invoke(null, new object[] { document.RootElement.Clone(), sessionKey })!;
+        }
+
         public long ExtractChatTimestampMs(string payloadJson)
         {
             using var document = JsonDocument.Parse(payloadJson);
@@ -843,6 +852,81 @@ public class OpenClawGatewayClientTests
         Assert.Equal("hello from assistant", received.Text);
         Assert.Equal("final", received.State);
         Assert.Equal(1781631280633, received.Ts);
+    }
+
+    [Fact]
+    public void ProcessRawMessage_SessionMessageAssistantNoReply_DropsFrame()
+    {
+        var helper = new GatewayClientTestHelper();
+        ChatMessageInfo? received = null;
+        OpenClawNotification? notification = null;
+        helper.Client.ChatMessageReceived += (_, message) => received = message;
+        helper.Client.NotificationReceived += (_, value) => notification = value;
+
+        helper.ProcessRawMessage("""
+        {
+          "type": "event",
+          "event": "session.message",
+          "payload": {
+            "sessionKey": "main",
+            "message": {
+              "role": "assistant",
+              "content": "  NO_REPLY\n",
+              "timestamp": 1781631280633
+            },
+            "state": "final"
+          }
+        }
+        """);
+
+        Assert.Null(received);
+        Assert.Null(notification);
+    }
+
+    [Fact]
+    public void ProcessRawMessage_SessionMessageUserNoReply_IsNotDropped()
+    {
+        var helper = new GatewayClientTestHelper();
+        ChatMessageInfo? received = null;
+        helper.Client.ChatMessageReceived += (_, message) => received = message;
+
+        helper.ProcessRawMessage("""
+        {
+          "type": "event",
+          "event": "session.message",
+          "payload": {
+            "sessionKey": "main",
+            "message": {
+              "role": "user",
+              "content": "NO_REPLY",
+              "timestamp": 1781631280633
+            },
+            "state": "final"
+          }
+        }
+        """);
+
+        Assert.NotNull(received);
+        Assert.Equal("user", received!.Role);
+        Assert.Equal("NO_REPLY", received.Text);
+    }
+
+    [Fact]
+    public void ParseChatHistoryPayload_AssistantNoReply_DropsTranscriptEntry()
+    {
+        var helper = new GatewayClientTestHelper();
+
+        var history = helper.ParseChatHistoryPayload("""
+        {
+          "messages": [
+            { "role": "user", "content": "before", "timestamp": 1 },
+            { "role": "assistant", "content": "NO_REPLY", "timestamp": 2 },
+            { "role": "assistant", "content": "visible reply", "timestamp": 3 }
+          ]
+        }
+        """);
+
+        Assert.Equal(["before", "visible reply"], history.Messages.Select(m => m.Text).ToArray());
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -238,6 +238,28 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
+    public async Task ChatMessageReceived_AssistantNoReply_IsSuppressed()
+    {
+        var (bridge, provider, snapshots, notifications) = CreateProvider(new[] { MainSession() });
+        await provider.LoadAsync();
+        snapshots.Clear();
+        notifications.Clear();
+
+        bridge.RaiseChat(new ChatMessageInfo
+        {
+            SessionKey = "main",
+            Role = "assistant",
+            Text = "NO_REPLY",
+            State = "final"
+        });
+
+        var timeline = (await provider.LoadAsync()).Timelines["main"];
+        Assert.Empty(snapshots);
+        Assert.Empty(timeline.Entries);
+        Assert.DoesNotContain(notifications, n => n.Kind == ChatProviderNotificationKind.TurnComplete);
+    }
+
+    [Fact]
     public async Task ChatMessageReceived_DeltaAssistant_AppendsAssistantWithoutEndingTurn()
     {
         // Block-streamed deltas carry cumulative assistant text and should
@@ -1489,6 +1511,29 @@ public class OpenClawChatDataProviderTests
         Assert.Equal("Hello!", timeline.Entries[1].Text);
         Assert.Equal(ChatTimelineItemKind.User, timeline.Entries[2].Kind);
         Assert.False(timeline.TurnActive);
+    }
+
+    [Fact]
+    public async Task LoadHistoryAsync_AssistantNoReply_IsSuppressed()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        bridge.HistoryBehavior = _ => Task.FromResult(new ChatHistoryInfo
+        {
+            SessionKey = "main",
+            Messages = new[]
+            {
+                new ChatMessageInfo { Role = "user", Text = "Hi", State = "final" },
+                new ChatMessageInfo { Role = "assistant", Text = "NO_REPLY", State = "final" },
+                new ChatMessageInfo { Role = "assistant", Text = "Visible", State = "final" }
+            }
+        });
+        await provider.LoadAsync();
+        snapshots.Clear();
+
+        await provider.LoadHistoryAsync("main");
+
+        var timeline = snapshots[^1].Timelines["main"];
+        Assert.Equal(["Hi", "Visible"], timeline.Entries.Select(e => e.Text).ToArray());
     }
 
     [Fact]


### PR DESCRIPTION
Closes #882.

Suppress assistant-only `NO_REPLY` chat directives in shared gateway live/history ingestion and tray chat hydration/live paths. User messages that literally say `NO_REPLY` still flow through.

## Validation

- GitHub Build and Test is green for this head.
- `.\build.ps1` — passed.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` — 2632 passed, 31 skipped.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` — 1435 passed.
- Fresh-worktree note: tests were restored once in the isolated validation worktree before rerunning the required `--no-restore` commands.

## Real behavior proof

- Upstream OpenClaw behavior confirmed: `openclaw/openclaw` defines `SILENT_REPLY_TOKEN = "NO_REPLY"` in `src/auto-reply/tokens.ts`; `normalize-reply.ts` drops exact silent replies; `reply-dispatcher.ts` logs exact `NO_REPLY` finals skipped before delivery; and `docs/platforms/mac/webchat.md` documents that `chat.history` omits exact `NO_REPLY` / `no_reply` assistant rows.
- Disposable console harness referencing `src/OpenClaw.Shared/OpenClaw.Shared.csproj` at `797c8be1` invoked the runtime gateway `ProcessMessage` path with assistant and user `session.message` frames.

Command: `dotnet run --project /tmp/openclaw-gateway-proof.BsT7VI/openclaw-gateway-proof.BsT7VI.csproj`

```text
assistant_NO_REPLY_events=0
total_events_after_user_literal=1
preserved_user_role=user
preserved_user_text=NO_REPLY
```