### PR TITLE
Fix atomic device-key token clearing

### DIFF
--- a/src/OpenClaw.Connection/DeviceIdentityStore.cs
+++ b/src/OpenClaw.Connection/DeviceIdentityStore.cs
@@ -39,6 +39,13 @@ public sealed class DeviceIdentityStore : IDeviceIdentityStore
     /// </summary>
     public static void ClearStoredTokens(string identityDir, IOpenClawLogger? logger = null)
     {
-        DeviceIdentity.TryClearAllDeviceTokens(identityDir, logger);
+        try
+        {
+            DeviceIdentity.TryClearAllDeviceTokens(identityDir, logger);
+        }
+        catch (Exception ex)
+        {
+            logger?.Warn($"[IdentityStore] Failed to clear device tokens: {ex.Message}");
+        }
     }
 }

--- a/src/OpenClaw.Connection/DeviceIdentityStore.cs
+++ b/src/OpenClaw.Connection/DeviceIdentityStore.cs
@@ -34,35 +34,11 @@ public sealed class DeviceIdentityStore : IDeviceIdentityStore
     /// Clear stored device tokens from an identity file, keeping the keypair intact.
     /// Strips DeviceToken, DeviceTokenScopes, NodeDeviceToken, and NodeDeviceTokenScopes
     /// from the identity JSON while preserving keys, deviceId, algorithm, etc.
+    /// Writes atomically via temp-file + rename to prevent torn writes from
+    /// silently rotating device identity on crash/power-loss.
     /// </summary>
     public static void ClearStoredTokens(string identityDir, IOpenClawLogger? logger = null)
     {
-        var keyPath = Path.Combine(identityDir, "device-key-ed25519.json");
-        if (!File.Exists(keyPath)) return;
-        try
-        {
-            var json = File.ReadAllText(keyPath);
-            var doc = System.Text.Json.JsonDocument.Parse(json);
-            var root = doc.RootElement;
-
-            using var ms = new MemoryStream();
-            using var writer = new System.Text.Json.Utf8JsonWriter(ms, new System.Text.Json.JsonWriterOptions { Indented = true });
-            writer.WriteStartObject();
-            foreach (var prop in root.EnumerateObject())
-            {
-                if (prop.Name is "DeviceToken" or "DeviceTokenScopes" or "NodeDeviceToken" or "NodeDeviceTokenScopes")
-                    continue;
-                prop.WriteTo(writer);
-            }
-            writer.WriteEndObject();
-            writer.Flush();
-
-            File.WriteAllBytes(keyPath, ms.ToArray());
-            logger?.Info($"[IdentityStore] Cleared stored device tokens from {identityDir}");
-        }
-        catch (Exception ex)
-        {
-            logger?.Warn($"[IdentityStore] Failed to clear device tokens: {ex.Message}");
-        }
+        DeviceIdentity.TryClearAllDeviceTokens(identityDir, logger);
     }
 }

--- a/src/OpenClaw.Shared/DeviceIdentity.cs
+++ b/src/OpenClaw.Shared/DeviceIdentity.cs
@@ -115,8 +115,13 @@ public class DeviceIdentity
         try
         {
             var json = File.ReadAllText(keyPath);
-            var doc = JsonDocument.Parse(json);
+            using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                logger?.Warn("Failed to clear all device tokens: device-key-ed25519.json root is not a JSON object.");
+                return false;
+            }
 
             bool hadTokens = false;
             using var ms = new MemoryStream();

--- a/src/OpenClaw.Shared/DeviceIdentity.cs
+++ b/src/OpenClaw.Shared/DeviceIdentity.cs
@@ -95,6 +95,72 @@ public class DeviceIdentity
         TryClearDeviceTokenForRole(dataPath, "operator", logger);
 
     /// <summary>
+    /// Atomically clears <em>all</em> device-token fields (DeviceToken,
+    /// DeviceTokenScopes, NodeDeviceToken, NodeDeviceTokenScopes) from
+    /// <c>device-key-ed25519.json</c> while preserving the Ed25519 keypair,
+    /// deviceId, algorithm, and all other properties. Uses raw JSON filtering
+    /// so unknown/extra fields are preserved, and writes atomically via
+    /// temp-file + rename.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if at least one token field was present and cleared;
+    /// <c>false</c> if the file was absent or already had no tokens.
+    /// </returns>
+    public static bool TryClearAllDeviceTokens(string dataPath, IOpenClawLogger? logger = null)
+    {
+        var keyPath = Path.Combine(dataPath, "device-key-ed25519.json");
+        if (!File.Exists(keyPath))
+            return false;
+
+        try
+        {
+            var json = File.ReadAllText(keyPath);
+            var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            bool hadTokens = false;
+            using var ms = new MemoryStream();
+            using (var writer = new System.Text.Json.Utf8JsonWriter(ms, new System.Text.Json.JsonWriterOptions { Indented = true }))
+            {
+                writer.WriteStartObject();
+                foreach (var prop in root.EnumerateObject())
+                {
+                    if (prop.Name is "DeviceToken" or "DeviceTokenScopes" or "NodeDeviceToken" or "NodeDeviceTokenScopes")
+                    {
+                        hadTokens = true;
+                        continue;
+                    }
+                    prop.WriteTo(writer);
+                }
+                writer.WriteEndObject();
+            }
+
+            if (!hadTokens)
+                return false;
+
+            var content = System.Text.Encoding.UTF8.GetString(ms.ToArray());
+            AtomicWriteKeyFileRaw(keyPath, content);
+            logger?.Info("All device tokens cleared from device-key-ed25519.json (keypair preserved).");
+            return true;
+        }
+        catch (IOException ex)
+        {
+            logger?.Warn($"Failed to clear all device tokens: {ex.Message}");
+            return false;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            logger?.Warn($"Failed to clear all device tokens: {ex.Message}");
+            return false;
+        }
+        catch (JsonException ex)
+        {
+            logger?.Warn($"Failed to clear all device tokens: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Sets the role-specific device token field to <c>null</c> in
     /// <c>device-key-ed25519.json</c> without deleting the file. Preserves the
     /// Ed25519 keypair and unrelated role tokens.
@@ -523,12 +589,22 @@ public class DeviceIdentity
     private static void AtomicWriteKeyFile(string path, DeviceKeyData data)
     {
         var json = JsonSerializer.Serialize(data, JsonSerializerOptionsCache.WriteIndented);
+        AtomicWriteKeyFileRaw(path, json);
+    }
+
+    /// <summary>
+    /// Atomically writes pre-serialized JSON content to a device-key file path
+    /// using temp-file + rename. Use this when restoring a backup or writing
+    /// content that is already serialized.
+    /// </summary>
+    public static void AtomicWriteKeyFileRaw(string path, string jsonContent)
+    {
         var dir = Path.GetDirectoryName(path);
         var tempDir = string.IsNullOrEmpty(dir) ? Environment.CurrentDirectory : dir;
         var tempPath = Path.Combine(tempDir, $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
         try
         {
-            File.WriteAllText(tempPath, json);
+            File.WriteAllText(tempPath, jsonContent);
             McpAuthToken.TryRestrictSensitiveFileAcl(tempPath);
             File.Move(tempPath, path, overwrite: true);
         }

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -2747,7 +2747,7 @@ public sealed partial class ConnectionPage : Page
                     fileUnchanged = true;
                 }
                 if (fileUnchanged)
-                    File.WriteAllText(identityKeyPath, identityBackup);
+                    DeviceIdentity.AtomicWriteKeyFileRaw(identityKeyPath, identityBackup);
                 // else: another writer touched the file; preserve it.
             }
             catch (Exception ex)

--- a/tests/OpenClaw.Connection.Tests/DeviceIdentityStoreTests.cs
+++ b/tests/OpenClaw.Connection.Tests/DeviceIdentityStoreTests.cs
@@ -112,6 +112,18 @@ public class DeviceIdentityStoreTests : IDisposable
     }
 
     [Fact]
+    public void ClearStoredTokens_WhenJsonRootIsNotObject_DoesNotThrow()
+    {
+        var path = Path.Combine(_tempDir, "device-key-ed25519.json");
+        File.WriteAllText(path, "[]");
+
+        var ex = Record.Exception(() => DeviceIdentityStore.ClearStoredTokens(_tempDir));
+
+        Assert.Null(ex);
+        Assert.Equal("[]", File.ReadAllText(path));
+    }
+
+    [Fact]
     public void ClearStoredTokens_WhenNoTokenFields_PreservesAllProperties()
     {
         WriteIdentityFile(new


### PR DESCRIPTION
## Summary

- Route `DeviceIdentityStore.ClearStoredTokens` through a shared atomic token-clear helper instead of rewriting `device-key-ed25519.json` with `File.WriteAllBytes`
- Preserve unknown identity JSON fields while stripping `DeviceToken`, `DeviceTokenScopes`, `NodeDeviceToken`, and `NodeDeviceTokenScopes`
- Add an atomic raw device-key writer and use it for the `ConnectionPage` rollback-restore path
- Preserve best-effort cleanup semantics for malformed/unexpected identity file cases

Fixes openclaw/openclaw-windows-node#888

## Validation

- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`
- Targeted `OpenClaw.Connection.Tests` `DeviceIdentityStore` tests

## Manual smoke

- Launched the branch with an isolated `OPENCLAW_TRAY_DATA_DIR`
- Paired/connected, captured identity snapshot before token clear
- Disconnected via the tray app, captured identity snapshot after token clear
- Compared snapshots to confirm `DeviceId`, `PublicKeyBase64`, and `PrivateKeyBase64` stayed unchanged while token fields were cleared

## Real behavior proof

Manual smoke run against this branch using an isolated `OPENCLAW_TRAY_DATA_DIR`.

<img width="1666" height="202" alt="image" src="https://github.com/user-attachments/assets/6e264d05-fa72-4c32-8b4e-990d1e529408" />

Proof screenshot shows:
- `deviceIdSame=True`
- `publicKeySame=True`
- `privateKeySame=True`
- `beforeHadDeviceToken=True`
- `afterHasDeviceToken=False`

This verifies token clearing removed the stored device token while preserving the device identity/keypair.