### PR TITLE
Chat: inline /-triggered gateway command catalog menu (Mac parity)

### DIFF
--- a/src/OpenClaw.Chat/ChatModels.cs
+++ b/src/OpenClaw.Chat/ChatModels.cs
@@ -192,7 +192,9 @@ public record ChatDataSnapshot(
     string? ConnectionStatus,
     string[] AvailableModels,
     ChatComposeTarget ComposeTarget,
-    IReadOnlyList<ChatModelChoice>? ModelChoices = null);
+    IReadOnlyList<ChatModelChoice>? ModelChoices = null,
+    IReadOnlyList<OpenClaw.Shared.GatewayCommand>? AvailableCommands = null,
+    bool CommandsSupported = true);
 
 /// <summary>
 /// Describes where the UI may send the next chat message. Distinct from
@@ -275,4 +277,11 @@ public interface IChatDataProvider : IAsyncDisposable
             requestId,
             allow ? ChatPermissionActionKeys.AllowOnce : ChatPermissionActionKeys.Deny,
             cancellationToken);
+
+    /// <summary>
+    /// Requests a refresh of the gateway command catalog surfaced via
+    /// <see cref="ChatDataSnapshot.AvailableCommands"/>. Providers that have no
+    /// command catalog (e.g. previews/fakes) may treat this as a no-op.
+    /// </summary>
+    Task EnsureCommandCatalogAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
 }

--- a/src/OpenClaw.Shared/CommandCatalogPresentation.cs
+++ b/src/OpenClaw.Shared/CommandCatalogPresentation.cs
@@ -59,6 +59,44 @@ public static class GatewayCommandPresentation
         return command.RequiresArgs() ? token + " " : token;
     }
 
+    /// <summary>Inline argument template (e.g. "&lt;message&gt; [level]"), or "" when none.</summary>
+    public static string ArgTemplate(this GatewayCommand command)
+    {
+        if (command?.Args is null || command.Args.Count == 0) return "";
+        return string.Join(" ", command.Args
+            .Where(a => !string.IsNullOrWhiteSpace(a.Name))
+            .Select(a => a.Required ? $"<{a.Name}>" : $"[{a.Name}]"));
+    }
+
+    /// <summary>Static choice count on the first arg (for the "N options" badge); 0 when dynamic/none.</summary>
+    public static int OptionCount(this GatewayCommand command)
+    {
+        var first = command?.Args?.FirstOrDefault();
+        return first is { IsDynamic: false } ? first.Choices.Count : 0;
+    }
+
+    /// <summary>Static choices on the first declared arg (empty when dynamic or none).</summary>
+    public static IReadOnlyList<GatewayCommandArgChoice> FirstArgChoices(this GatewayCommand command)
+    {
+        var first = command?.Args?.FirstOrDefault();
+        return first is { IsDynamic: false } ? first.Choices : Array.Empty<GatewayCommandArgChoice>();
+    }
+
+    /// <summary>Composer text for a chosen arg value: "/name value".</summary>
+    public static string BuildArgInsertionText(this GatewayCommand command, string value) =>
+        command.DisplayName() + " " + (value ?? "").Trim();
+
+    /// <summary>True when <paramref name="name"/> (slash-stripped) matches this command's name/native/alias.</summary>
+    public static bool MatchesName(this GatewayCommand command, string name)
+    {
+        if (command is null || string.IsNullOrWhiteSpace(name)) return false;
+        var n = name.Trim().TrimStart('/');
+        bool Eq(string? a) => !string.IsNullOrWhiteSpace(a) &&
+            string.Equals(a!.Trim().TrimStart('/'), n, StringComparison.OrdinalIgnoreCase);
+        if (Eq(command.NativeName) || Eq(command.Name)) return true;
+        return command.TextAliases?.Any(Eq) ?? false;
+    }
+
     private static string Normalize(string value)
     {
         var v = (value ?? "").Trim();

--- a/src/OpenClaw.Shared/CommandCatalogPresentation.cs
+++ b/src/OpenClaw.Shared/CommandCatalogPresentation.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenClaw.Shared;
+
+// ── Command catalog presentation helpers ──
+//
+// The wire DTOs (GatewayCommand / GatewayCommandArg / CommandCatalog /
+// CommandCatalogQuery) and the gateway request API (ListCommandsAsync) live in
+// GatewayProtocolModels.cs + OpenClawGatewayClient.Protocol.cs. This file adds
+// only UI-facing presentation logic on top of those DTOs:
+//   • display / insertion helpers for a single GatewayCommand
+//   • ranked search + category grouping that the chat command palette needs
+//     (CommandCatalogQuery does boolean filtering only — no ranking or
+//     grouped output).
+// Nothing here duplicates a protocol DTO.
+
+/// <summary>Source/display/insertion presentation helpers for gateway commands.</summary>
+public static class GatewayCommandPresentation
+{
+    /// <summary>
+    /// Best slash/native string to show as the command's primary label. Prefers
+    /// the native name, then the first text alias, then a slash-prefixed name.
+    /// </summary>
+    public static string DisplayName(this GatewayCommand command)
+    {
+        if (command is null) return "";
+        if (!string.IsNullOrWhiteSpace(command.NativeName)) return Normalize(command.NativeName!);
+        var alias = command.TextAliases?.FirstOrDefault(a => !string.IsNullOrWhiteSpace(a));
+        if (!string.IsNullOrWhiteSpace(alias)) return Normalize(alias!);
+        return Normalize(command.Name);
+    }
+
+    /// <summary>Short, capitalized label for the command source ("native"→"Native").</summary>
+    public static string SourceLabel(this GatewayCommand command)
+    {
+        var s = command?.Source;
+        if (string.IsNullOrWhiteSpace(s)) return "";
+        var t = s!.Trim();
+        return char.ToUpperInvariant(t[0]) + (t.Length > 1 ? t[1..] : "");
+    }
+
+    /// <summary>True when the command needs argument input before it can run.</summary>
+    public static bool RequiresArgs(this GatewayCommand command)
+    {
+        if (command is null) return false;
+        return command.AcceptsArgs || (command.Args?.Any(a => a.Required) ?? false);
+    }
+
+    /// <summary>
+    /// Text to insert into the composer when the command is chosen. Commands
+    /// that take arguments get a trailing space so the user can immediately type
+    /// the value (we never inject placeholder text, which would be sent verbatim).
+    /// </summary>
+    public static string BuildInsertionText(this GatewayCommand command)
+    {
+        var token = command.DisplayName();
+        return command.RequiresArgs() ? token + " " : token;
+    }
+
+    private static string Normalize(string value)
+    {
+        var v = (value ?? "").Trim();
+        if (v.Length == 0) return v;
+        // Slash-style commands are the convention; only prefix bare identifiers
+        // (don't double a leading slash, and leave already-prefixed values alone).
+        return v[0] == '/' ? v : "/" + v;
+    }
+}
+
+/// <summary>A named group of commands sharing a category, in display order.</summary>
+public sealed record CommandCategoryGroup(string Category, IReadOnlyList<GatewayCommand> Commands);
+
+/// <summary>
+/// Ranked search + category grouping over a set of gateway commands for the chat
+/// command palette. Distinct from <see cref="CommandCatalogQuery"/> (a boolean
+/// filter mirroring the gateway's server-side filtering) — this adds relevance
+/// ranking and grouped output the UI needs. UI-only; lives in OpenClaw.Shared so
+/// it can be unit-tested directly.
+/// </summary>
+public sealed class ChatCommandCatalogView
+{
+    private readonly List<GatewayCommand> _commands;
+
+    public ChatCommandCatalogView(IEnumerable<GatewayCommand>? commands)
+    {
+        _commands = (commands ?? Enumerable.Empty<GatewayCommand>())
+            .Where(c => c is not null)
+            .ToList();
+    }
+
+    public IReadOnlyList<GatewayCommand> Commands => _commands;
+    public int Count => _commands.Count;
+
+    /// <summary>
+    /// Case-insensitive ranked search across display name, native name, text
+    /// aliases, canonical name, description and category. A leading slash in the
+    /// query is ignored so "/cl" and "cl" behave identically. An empty query
+    /// returns the full catalog in display order.
+    /// </summary>
+    public IReadOnlyList<GatewayCommand> Search(string? query)
+    {
+        var q = (query ?? "").Trim();
+        if (q.StartsWith("/", StringComparison.Ordinal)) q = q.TrimStart('/');
+        q = q.Trim();
+
+        if (q.Length == 0)
+            return Ordered(_commands).ToList();
+
+        var scored = new List<(GatewayCommand Cmd, int Score)>();
+        foreach (var cmd in _commands)
+        {
+            var score = ScoreMatch(cmd, q);
+            if (score > 0) scored.Add((cmd, score));
+        }
+
+        return scored
+            .OrderByDescending(t => t.Score)
+            .ThenBy(t => t.Cmd.DisplayName(), StringComparer.OrdinalIgnoreCase)
+            .Select(t => t.Cmd)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Groups commands by category (falling back to source label, then "Other"),
+    /// optionally filtered by the same search used in <see cref="Search"/>.
+    /// Groups and their members are returned in a stable, display-friendly order.
+    /// </summary>
+    public IReadOnlyList<CommandCategoryGroup> GroupByCategory(string? query = null)
+    {
+        var matched = Search(query);
+        return matched
+            .GroupBy(CategoryKey, StringComparer.OrdinalIgnoreCase)
+            .Select(g => new CommandCategoryGroup(g.Key, Ordered(g).ToList()))
+            .OrderBy(g => g.Category, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static string CategoryKey(GatewayCommand cmd)
+    {
+        if (!string.IsNullOrWhiteSpace(cmd.Category)) return cmd.Category!.Trim();
+        var src = cmd.SourceLabel();
+        if (!string.IsNullOrWhiteSpace(src)) return src;
+        return "Other";
+    }
+
+    private static IEnumerable<GatewayCommand> Ordered(IEnumerable<GatewayCommand> source) =>
+        source.OrderBy(c => c.DisplayName(), StringComparer.OrdinalIgnoreCase);
+
+    private static int ScoreMatch(GatewayCommand cmd, string q)
+    {
+        int best = 0;
+
+        void Consider(string? token, int exact, int prefix, int contains)
+        {
+            if (string.IsNullOrWhiteSpace(token)) return;
+            var t = token!.TrimStart('/');
+            if (t.Equals(q, StringComparison.OrdinalIgnoreCase)) best = Math.Max(best, exact);
+            else if (t.StartsWith(q, StringComparison.OrdinalIgnoreCase)) best = Math.Max(best, prefix);
+            else if (t.Contains(q, StringComparison.OrdinalIgnoreCase)) best = Math.Max(best, contains);
+        }
+
+        Consider(cmd.DisplayName(), 100, 80, 50);
+        Consider(cmd.NativeName, 100, 80, 50);
+        Consider(cmd.Name, 90, 70, 45);
+        foreach (var alias in cmd.TextAliases ?? Array.Empty<string>())
+            Consider(alias, 90, 70, 45);
+
+        if (best == 0 && !string.IsNullOrWhiteSpace(cmd.Description) &&
+            cmd.Description!.Contains(q, StringComparison.OrdinalIgnoreCase))
+            best = 20;
+
+        if (best == 0 && !string.IsNullOrWhiteSpace(cmd.Category) &&
+            cmd.Category!.Contains(q, StringComparison.OrdinalIgnoreCase))
+            best = 15;
+
+        return best;
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Chat/IChatGatewayBridge.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/IChatGatewayBridge.cs
@@ -36,6 +36,13 @@ public interface IChatGatewayBridge : IDisposable
 
     Task SendChatMessageAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null);
     Task<ChatSendResult> SendChatMessageForRunAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null);
+    /// <summary>
+    /// Fetches the gateway command catalog (<c>commands.list</c>) via the typed
+    /// protocol API. Returns a <see cref="CommandCatalog"/> whose
+    /// <see cref="CommandCatalog.IsSupported"/> is <c>false</c> when the gateway
+    /// does not implement the method. Request/response — no event subscription.
+    /// </summary>
+    Task<CommandCatalog> ListCommandsAsync(CommandCatalogQuery? query = null);
     Task PatchSessionModelAsync(string sessionKey, string model);
     /// <summary>
     /// Clears the session's model override (tri-state <c>sessions.patch</c> with
@@ -174,6 +181,9 @@ public sealed class GatewayClientChatBridge : IChatGatewayBridge
 
     public Task PatchSessionThinkingLevelAsync(string sessionKey, string thinkingLevel) =>
         _client.PatchSessionAsync(sessionKey, new SessionPatch { ThinkingLevel = thinkingLevel });
+
+    public Task<CommandCatalog> ListCommandsAsync(CommandCatalogQuery? query = null) =>
+        _client.ListCommandsAsync(query);
 
     public Task<ChatHistoryInfo> RequestChatHistoryAsync(string? sessionKey) =>
         _client.RequestChatHistoryAsync(sessionKey);

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -1054,7 +1054,10 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         CommandCatalog catalog;
         try
         {
-            catalog = await _bridge.ListCommandsAsync().ConfigureAwait(false)
+            // Chat composer slash completion can only insert text-invokable
+            // commands. Request the protocol's text scope so native-only
+            // commands never surface in the composer catalog.
+            catalog = await _bridge.ListCommandsAsync(new CommandCatalogQuery { Scope = "text" }).ConfigureAwait(false)
                       ?? new CommandCatalog { IsSupported = true };
         }
         catch (Exception ex)

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -1060,14 +1060,23 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         catch (Exception ex)
         {
             Logger.Warn($"[ChatProvider] EnsureCommandCatalogAsync failed: {ex.Message}");
+            var shouldPublishFallback = false;
             lock (_gate)
             {
-                // Only clear the flag if no status change has superseded this
-                // fetch (otherwise OnStatusChanged already reset it and a newer
-                // fetch may legitimately own the flag).
-                if (epoch == _commandsEpoch)
+                // Only publish a fallback if no status change superseded this
+                // fetch. A failure must still move the UI out of its "loading"
+                // state; otherwise slash-leading text would keep trapping Enter
+                // until reconnect. Treat the catalog as temporarily unavailable
+                // for this connection and let reconnect clear/refetch it.
+                if (epoch == _commandsEpoch && _status == ConnectionStatus.Connected)
+                {
                     _commandsFetchInFlight = false;
+                    _commandCatalog = new CommandCatalog { IsSupported = false };
+                    shouldPublishFallback = true;
+                }
             }
+            if (shouldPublishFallback)
+                PublishCommandCatalogIfFresh(epoch);
             return;
         }
 

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -164,6 +164,17 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     private bool _sessionsListReceived;
     private string[] _availableModels = Array.Empty<string>();
     private IReadOnlyList<ChatModelChoice> _modelChoices = Array.Empty<ChatModelChoice>();
+    // Gateway command catalog (commands.list), fetched on demand via the typed
+    // protocol API. Null until the first fetch completes so the UI can
+    // distinguish "still loading" from "loaded but empty". When the gateway
+    // reports the method unsupported the catalog carries IsSupported=false.
+    private CommandCatalog? _commandCatalog;
+    // Guards against overlapping in-flight commands.list fetches.
+    private bool _commandsFetchInFlight;
+    // Bumped on every transition out of Connected so a commands.list fetch that
+    // was already in flight at disconnect time is discarded on completion rather
+    // than resurrecting a catalog for a stale connection.
+    private int _commandsEpoch;
     private ConnectionStatus _status;
     private bool _disposed;
 
@@ -1014,6 +1025,95 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         await _bridge.PatchSessionThinkingLevelAsync(threadId, thinkingLevel);
     }
 
+    public async Task EnsureCommandCatalogAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        int epoch;
+        lock (_gate)
+        {
+            // Only fetch while connected — the command catalog is a property of
+            // the live gateway connection. A not-connected caller would just
+            // land in the catch below.
+            if (_status != ConnectionStatus.Connected)
+                return;
+            // Already loaded (or a fetch is running) → reuse the cached catalog
+            // rather than hammering commands.list every time the palette opens.
+            // A reconnect clears _commandCatalog (see OnStatusChanged), so a
+            // fresh fetch happens after reconnect.
+            if (_commandsFetchInFlight || _commandCatalog is not null)
+                return;
+            _commandsFetchInFlight = true;
+            // Capture the connection epoch BEFORE the await. If a disconnect (or
+            // reconnect) happens while ListCommandsAsync is in flight,
+            // OnStatusChanged bumps the epoch; the late result is then discarded
+            // rather than resurrecting a stale catalog for the new connection.
+            epoch = _commandsEpoch;
+        }
+
+        CommandCatalog catalog;
+        try
+        {
+            catalog = await _bridge.ListCommandsAsync().ConfigureAwait(false)
+                      ?? new CommandCatalog { IsSupported = true };
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"[ChatProvider] EnsureCommandCatalogAsync failed: {ex.Message}");
+            lock (_gate)
+            {
+                // Only clear the flag if no status change has superseded this
+                // fetch (otherwise OnStatusChanged already reset it and a newer
+                // fetch may legitimately own the flag).
+                if (epoch == _commandsEpoch)
+                    _commandsFetchInFlight = false;
+            }
+            return;
+        }
+
+        lock (_gate)
+        {
+            // Drop the result if the connection changed during the await.
+            if (epoch != _commandsEpoch || _status != ConnectionStatus.Connected)
+                return;
+            _commandsFetchInFlight = false;
+            _commandCatalog = catalog;
+        }
+        Logger.Info($"[ChatProvider] commands.list: supported={catalog.IsSupported} count={catalog.Commands.Count}");
+        // Re-validate freshness at UI-thread delivery time rather than
+        // publishing a snapshot captured under the lock above. This closes the
+        // window where a disconnect occurring between snapshot build and
+        // Publish could let a stale "connected + commands" snapshot arrive after
+        // the disconnect snapshot.
+        PublishCommandCatalogIfFresh(epoch);
+    }
+
+    /// <summary>
+    /// Publishes a freshly-built snapshot on the UI thread, but only if the
+    /// connection <paramref name="epoch"/> captured for this commands.list fetch
+    /// is still current when delivery runs. If a disconnect/reconnect superseded
+    /// the fetch in the meantime, the stale publish is dropped (the status
+    /// handler's own publish carries the authoritative state).
+    /// </summary>
+    private void PublishCommandCatalogIfFresh(int epoch)
+    {
+        void Deliver()
+        {
+            ChatDataSnapshot snapshot;
+            lock (_gate)
+            {
+                if (epoch != _commandsEpoch) return;
+                snapshot = BuildSnapshotLocked();
+            }
+            Changed?.Invoke(this, new ChatDataChangedEventArgs(snapshot));
+        }
+
+        if (_post is null)
+            Deliver();
+        else
+            _post(Deliver);
+    }
+
     public Task SetPermissionModeAsync(string threadId, bool allowAll, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -1336,6 +1436,18 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             // until the next sessions.list arrives.
             if (status != ConnectionStatus.Connected)
                 _sessionsListReceived = false;
+
+            // Drop the cached command catalog whenever we leave Connected so a
+            // reconnect re-fetches commands.list (the catalog can change across
+            // gateways / agent reconfigurations). Bumping the epoch invalidates
+            // any commands.list fetch still in flight so its late result is
+            // discarded instead of resurrecting a stale catalog.
+            if (status != ConnectionStatus.Connected)
+            {
+                _commandsEpoch++;
+                _commandCatalog = null;
+                _commandsFetchInFlight = false;
+            }
 
             // Reset the approval-dedupe LRU on every transition out of
             // Connected. IDs from a prior session must not block a fresh
@@ -4034,7 +4146,12 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             ConnectionStatus: connectionLabel,
             AvailableModels: _availableModels,
             ComposeTarget: composeTarget,
-            ModelChoices: _modelChoices);
+            ModelChoices: _modelChoices,
+            // Null until the first commands.list fetch completes so the UI can
+            // distinguish "loading" from "loaded but empty". IsSupported=false
+            // surfaces the unsupported state.
+            AvailableCommands: _commandCatalog?.Commands,
+            CommandsSupported: _commandCatalog?.IsSupported ?? true);
     }
 
     private string? ResolveDefaultThreadIdLocked()

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
@@ -591,7 +591,10 @@ public sealed class OpenClawChatRoot : Component
                     s_showToolCalls = visible;
                     ToolCallsVisibilityChanged?.Invoke(null, EventArgs.Empty);
                 },
-                IsCompact: _isCompact))
+                IsCompact: _isCompact,
+                AvailableCommands: snapshot.AvailableCommands,
+                CommandsSupported: snapshot.CommandsSupported,
+                OnCommandsRequested: () => RunFireAndForget(ct => _provider.EnsureCommandCatalogAsync(ct))))
             : (bodyIsSkeleton ? RenderSkeletonComposer() : Empty());
 
         var divider = Empty();

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
@@ -4,6 +4,7 @@ using OpenClawTray.Helpers;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
 using OpenClawTray.FunctionalUI;
 using OpenClawTray.FunctionalUI.Core;
@@ -69,7 +70,10 @@ public record OpenClawComposerProps(
     Action<bool>? OnShowToolCallsChanged = null,
     bool IsCompact = false,
     IReadOnlyList<ChatModelChoice>? ModelChoices = null,
-    Action? OnModelCleared = null);
+    Action? OnModelCleared = null,
+    IReadOnlyList<GatewayCommand>? AvailableCommands = null,
+    bool CommandsSupported = true,
+    Action? OnCommandsRequested = null);
 
 public sealed class OpenClawComposer : Component<OpenClawComposerProps>
 {
@@ -92,6 +96,11 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         // per compose cycle instead of one per keypress).
         var inputRef = UseRef("");
         var hasTextState = UseState(false, threadSafe: true);
+        // Slash-command menu state. Active when the composer holds a "/token"
+        // (a leading slash with no whitespace yet); Query is the text after the
+        // slash; Index is the highlighted row. Drives the inline command menu
+        // that mirrors the gateway/web "type / to open the command menu" UX.
+        var slashMenuState = UseState<(bool Active, string Query, int Index)>((false, "", 0), threadSafe: true);
 
         var composerCornerRadius = new CornerRadius(8);
         const double composerIconSize = 16;
@@ -108,6 +117,22 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         var voiceStoppedRef = UseRef(false);
         // TextBox reference for focusing after recording completes
         var textBoxRef = UseRef<TextBox?>(null);
+        // Slash-menu popup overlay (floats above the composer; does not push the
+        // input controls). Created once on first render, driven each render.
+        var slashPopupRef = UseRef<Microsoft.UI.Xaml.Controls.Primitives.Popup?>(null);
+        // Tear the popup down when the composer unmounts so it isn't left rooted
+        // to the XamlRoot (which would keep its row-button closures alive).
+        UseEffect((Func<Action>)(() => () =>
+        {
+            var p = slashPopupRef.Current;
+            if (p is not null)
+            {
+                p.IsOpen = false;
+                p.Child = null;
+                p.PlacementTarget = null;
+                slashPopupRef.Current = null;
+            }
+        }));
         // One-time hook flag for the TextBox Paste event so we don't re-attach
         // the handler on every re-render (Set() runs each render).
         var pasteHookedRef = UseRef(false);
@@ -189,6 +214,9 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
             Props.OnSend(msg ?? "", pendingAttachments.ToArray());
             inputRef.Current = "";
             hasTextState.Set(false);
+            // Clear any open slash menu so it doesn't re-open over the now-empty
+            // composer (programmatic text reset doesn't fire TextChanged).
+            slashMenuState.Set((false, "", 0));
             sendVersion.Set(sendVersion.Value + 1);
         };
         var sendActionRef = UseRef<Action>(sendAction);
@@ -399,10 +427,60 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
             ? recTranscript
             : inputRef.Current;
 
+        // ── Slash command menu (type "/" to discover gateway commands inline) ──
+        // The composer text box doubles as the menu's search field: when the
+        // input is a bare "/token" the menu opens and filters as the user types,
+        // matching the gateway/web Control UI's primary command surface.
+        var slash = slashMenuState.Value;
+        var slashActive = isConnected && slash.Active && !recording;
+
+        // Lazily fetch the catalog the first time the menu opens for this
+        // connection (EnsureCommandCatalogAsync is cached + in-flight guarded).
+        if (slashActive && Props.AvailableCommands is null)
+            Props.OnCommandsRequested?.Invoke();
+
+        IReadOnlyList<GatewayCommand> slashResults = Array.Empty<GatewayCommand>();
+        if (slashActive && Props.CommandsSupported && Props.AvailableCommands is { } slashCmds)
+            slashResults = new ChatCommandCatalogView(slashCmds)
+                .Search(slash.Query)
+                .Take(SlashMenuMaxItems)
+                .ToList();
+
+        var slashIndex = slashResults.Count == 0
+            ? 0
+            : Math.Clamp(slash.Index, 0, slashResults.Count - 1);
+
+        // Inserts the chosen command, replacing the "/token" the user was typing,
+        // then dismisses the menu. Arg-taking commands keep a trailing space so
+        // the user can type the value rather than sending immediately.
+        Action<GatewayCommand> insertSlashCommand = cmd =>
+        {
+            var insert = cmd.BuildInsertionText();
+            inputRef.Current = insert;
+            hasTextState.Set(!string.IsNullOrWhiteSpace(insert));
+            slashMenuState.Set((false, "", 0));
+            // Bump the send version so the updated ref value is pushed into the
+            // TextBox on the next render (same mechanism the voice path uses).
+            sendVersion.Set(sendVersion.Value + 1);
+
+            var tbox = textBoxRef.Current;
+            tbox?.DispatcherQueue?.TryEnqueue(() =>
+            {
+                tbox.Focus(FocusState.Programmatic);
+                var c = tbox.Text?.Length ?? 0;
+                tbox.SelectionStart = c;
+                tbox.SelectionLength = 0;
+            });
+        };
+
         var textbox = TextField(displayText, v =>
             {
                 inputRef.Current = v;
                 hasTextState.Set(!string.IsNullOrWhiteSpace(v));
+                var (active, query) = ComputeSlashTrigger(v);
+                var cur = slashMenuState.Value;
+                if (active != cur.Active || query != cur.Query)
+                    slashMenuState.Set((active, query, 0));
             })
             .Set(tb =>
             {
@@ -470,7 +548,55 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
             })
             .OnKeyDown((sender, e) =>
             {
-                if (e.Key == global::Windows.System.VirtualKey.Enter)
+                var key = e.Key;
+
+                // While the slash menu is open with results, the arrow keys
+                // navigate it and Enter/Tab autocompletes — instead of moving
+                // the caret or sending the message.
+                if (slashActive && slashResults.Count > 0)
+                {
+                    if (key == global::Windows.System.VirtualKey.Down)
+                    {
+                        e.Handled = true;
+                        slashMenuState.Set((slash.Active, slash.Query, Math.Min(slashIndex + 1, slashResults.Count - 1)));
+                        return;
+                    }
+                    if (key == global::Windows.System.VirtualKey.Up)
+                    {
+                        e.Handled = true;
+                        slashMenuState.Set((slash.Active, slash.Query, Math.Max(slashIndex - 1, 0)));
+                        return;
+                    }
+                    if (key == global::Windows.System.VirtualKey.Enter
+                        || key == global::Windows.System.VirtualKey.Tab)
+                    {
+                        e.Handled = true;
+                        insertSlashCommand(slashResults[slashIndex]);
+                        return;
+                    }
+                    if (key == global::Windows.System.VirtualKey.Escape)
+                    {
+                        e.Handled = true;
+                        slashMenuState.Set((false, "", 0));
+                        return;
+                    }
+                }
+                else if (slashActive)
+                {
+                    // Menu visible but loading / no matches: keep keyboard
+                    // behavior predictable while the popup is up. Escape or Tab
+                    // dismiss it (Tab must not silently move focus away while the
+                    // popup overlays), and selection keys are swallowed.
+                    if (key == global::Windows.System.VirtualKey.Escape
+                        || key == global::Windows.System.VirtualKey.Tab)
+                    {
+                        e.Handled = true;
+                        slashMenuState.Set((false, "", 0));
+                        return;
+                    }
+                }
+
+                if (key == global::Windows.System.VirtualKey.Enter)
                 {
                     var shift = Microsoft.UI.Input.InputKeyboardSource
                         .GetKeyStateForCurrentThread(global::Windows.System.VirtualKey.Shift);
@@ -858,6 +984,38 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
             () => Props.OnShowToolCallsChanged?.Invoke(!Props.ShowToolCalls))
             .Set(b => b.Opacity = showTools ? 1.0 : 0.55);
 
+        // ── Slash command menu (gateway commands.list discovery) ──
+        // Hosted in a floating Popup above the composer so the input controls
+        // never move; it overlays content like standard command menus. The
+        // textbox stays focused (light-dismiss off) so typing keeps filtering
+        // and ↑/↓/Enter/Tab/Esc drive the menu.
+        FrameworkElement? slashPopupContent = null;
+        var slashMenuVisible = false;
+        if (slashActive)
+        {
+            if (!Props.CommandsSupported)
+            {
+                // Gateway has no command catalog → don't get in the way; let the
+                // user keep typing their "/..." as ordinary text.
+                slashMenuVisible = false;
+            }
+            else if (Props.AvailableCommands is null)
+            {
+                slashPopupContent = BuildSlashHintPopup("Loading commands…");
+                slashMenuVisible = true;
+            }
+            else if (slashResults.Count == 0)
+            {
+                slashPopupContent = BuildSlashHintPopup("No matching commands");
+                slashMenuVisible = true;
+            }
+            else
+            {
+                slashPopupContent = BuildSlashPopup(slashResults, slashIndex, insertSlashCommand);
+                slashMenuVisible = true;
+            }
+        }
+
         // Send button — always present so the user can queue follow-up messages
         // even while the assistant is responding.
         var sendBrush = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["AccentFillColorDefaultBrush"];
@@ -962,11 +1120,17 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         // ── Optional working banner above the composer ──
         Element workingBanner2 = workingBanner;
 
+        var composerCore = VStack(8, dropdownsRow, composerInput, voiceIndicator, actionsRow.Margin(0, -8, 0, -4));
+
+        // Drive the floating slash-menu popup after the tree builds so it anchors
+        // above the (already mounted) textbox without shifting any controls.
+        var tbForPopup = textBoxRef.Current;
+        tbForPopup?.DispatcherQueue?.TryEnqueue(() =>
+            DriveSlashPopup(slashPopupRef, tbForPopup, slashPopupContent, slashMenuVisible));
+
         return VStack(0,
             workingBanner2,
-            Border(
-                VStack(8, dropdownsRow, composerInput, voiceIndicator, actionsRow.Margin(0, -8, 0, -4))
-            ).Padding(16, 12, 16, 12)
+            Border(composerCore).Padding(16, 12, 16, 12)
              .Set(b =>
              {
                  // Top divider only — mirrors Kenny's ChatShell ComposerBorder.
@@ -974,6 +1138,184 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
                  b.BorderBrush = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["SurfaceStrokeColorDefaultBrush"];
              })
         );
+    }
+
+    private const int SlashMenuMaxItems = 8;
+
+    /// <summary>
+    /// Decides whether the composer text should open the inline slash-command
+    /// menu. Active when the text is a single leading "/token" with no
+    /// whitespace yet (the user is still typing the command name). Returns the
+    /// query (text after the slash) so the menu can filter.
+    /// </summary>
+    private static (bool Active, string Query) ComputeSlashTrigger(string? text)
+    {
+        var t = text ?? string.Empty;
+        if (t.Length == 0 || t[0] != '/')
+            return (false, string.Empty);
+        for (int i = 1; i < t.Length; i++)
+        {
+            if (char.IsWhiteSpace(t[i]))
+                return (false, string.Empty);
+        }
+        return (true, t.Substring(1));
+    }
+
+    // ── Native slash-menu popup builders ──
+    // The menu is hosted in a WinUI Popup (overlay) so it floats above the
+    // composer without shifting controls. Content is built as native controls
+    // (not FunctionalUI elements) because it lives outside the functional tree.
+
+    private static readonly Microsoft.UI.Xaml.Media.FontFamily SlashBadgeFont = new("Segoe UI");
+
+    private static double SlashPopupWidth(double anchorWidth) =>
+        Math.Max(280, anchorWidth);
+
+    private static Border BuildSlashHintPopup(string text)
+    {
+        var label = new TextBlock
+        {
+            Text = text,
+            FontSize = 12,
+            Foreground = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["TextFillColorSecondaryBrush"],
+            Margin = new Thickness(8, 6, 8, 6),
+        };
+        return SlashShell(label);
+    }
+
+    private static Border BuildSlashPopup(
+        IReadOnlyList<GatewayCommand> results, int selectedIndex, Action<GatewayCommand> onPick)
+    {
+        var primary = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["TextFillColorPrimaryBrush"];
+        var secondary = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["TextFillColorSecondaryBrush"];
+        var selectedBg = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["SubtleFillColorSecondaryBrush"];
+
+        var list = new StackPanel { Orientation = Orientation.Vertical };
+        for (int i = 0; i < results.Count; i++)
+        {
+            var cmd = results[i];
+            list.Children.Add(SlashRow(cmd, i == selectedIndex, primary, secondary, selectedBg, onPick));
+        }
+        var scroll = new ScrollViewer
+        {
+            VerticalScrollBarVisibility = Microsoft.UI.Xaml.Controls.ScrollBarVisibility.Auto,
+            HorizontalScrollBarVisibility = Microsoft.UI.Xaml.Controls.ScrollBarVisibility.Disabled,
+            MaxHeight = 280,
+            Content = list,
+        };
+        return SlashShell(scroll);
+    }
+
+    private static Border SlashShell(UIElement child)
+    {
+        // Match the composer card's own surface so the menu reads as part of the
+        // app: same background + stroke as the input box, with a soft shadow for
+        // separation from the chat content beneath.
+        var shell = new Border
+        {
+            Background = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["SolidBackgroundFillColorSecondaryBrush"],
+            BorderBrush = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["SurfaceStrokeColorDefaultBrush"],
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(8),
+            Padding = new Thickness(4),
+            Child = child,
+        };
+        shell.Translation = new System.Numerics.Vector3(0, 0, 32);
+        shell.Shadow = new Microsoft.UI.Xaml.Media.ThemeShadow();
+        return shell;
+    }
+
+    private static Button SlashRow(
+        GatewayCommand cmd, bool selected, Brush primary, Brush secondary, Brush selectedBg, Action<GatewayCommand> onPick)
+    {
+        var row = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+        row.Children.Add(new TextBlock
+        {
+            Text = cmd.DisplayName(),
+            FontSize = 13,
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+            Foreground = primary,
+            VerticalAlignment = VerticalAlignment.Center,
+        });
+        if (!string.IsNullOrWhiteSpace(cmd.Description))
+        {
+            row.Children.Add(new TextBlock
+            {
+                Text = cmd.Description!,
+                FontSize = 12,
+                Foreground = secondary,
+                VerticalAlignment = VerticalAlignment.Center,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                MaxLines = 1,
+            });
+        }
+        var sourceLabel = cmd.SourceLabel();
+        if (!string.IsNullOrWhiteSpace(sourceLabel)) row.Children.Add(SlashBadge(sourceLabel, secondary));
+        if (cmd.RequiresArgs()) row.Children.Add(SlashBadge("args", secondary));
+
+        var btn = new Button
+        {
+            Content = row,
+            Padding = new Thickness(8, 4, 8, 4),
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalContentAlignment = HorizontalAlignment.Left,
+            CornerRadius = new CornerRadius(6),
+            Background = selected ? selectedBg : new SolidColorBrush(Colors.Transparent),
+            BorderThickness = new Thickness(0),
+        };
+        btn.Click += (_, _) => onPick(cmd);
+        return btn;
+    }
+
+    private static Border SlashBadge(string text, Brush foreground) => new()
+    {
+        Padding = new Thickness(5, 1, 5, 1),
+        CornerRadius = new CornerRadius(4),
+        Background = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["SubtleFillColorSecondaryBrush"],
+        BorderThickness = new Thickness(1),
+        BorderBrush = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["ControlStrokeColorDefaultBrush"],
+        VerticalAlignment = VerticalAlignment.Center,
+        Child = new TextBlock { Text = text, FontSize = 10, FontFamily = SlashBadgeFont, Foreground = foreground },
+    };
+
+    /// <summary>
+    /// Creates (once) and drives the floating slash-menu Popup so it overlays
+    /// just above the composer without affecting layout. Closed by clearing the
+    /// content or when the trigger is no longer active.
+    /// </summary>
+    private static void DriveSlashPopup(
+        Ref<Microsoft.UI.Xaml.Controls.Primitives.Popup?> popupRef,
+        TextBox anchor,
+        FrameworkElement? content,
+        bool visible)
+    {
+        var popup = popupRef.Current;
+        if (popup is null)
+        {
+            popup = new Microsoft.UI.Xaml.Controls.Primitives.Popup
+            {
+                IsLightDismissEnabled = false,
+                ShouldConstrainToRootBounds = true,
+            };
+            popupRef.Current = popup;
+        }
+
+        if (!visible || content is null || anchor.XamlRoot is null)
+        {
+            popup.IsOpen = false;
+            popup.Child = null;
+            popup.PlacementTarget = null;
+            return;
+        }
+
+        var width = SlashPopupWidth(anchor.ActualWidth > 0 ? anchor.ActualWidth : 360);
+        if (content is FrameworkElement fe) fe.Width = width;
+
+        popup.XamlRoot = anchor.XamlRoot;
+        popup.PlacementTarget = anchor;
+        popup.DesiredPlacement = Microsoft.UI.Xaml.Controls.Primitives.PopupPlacementMode.Top;
+        popup.Child = content;
+        popup.IsOpen = true;
     }
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
@@ -98,9 +98,11 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         var hasTextState = UseState(false, threadSafe: true);
         // Slash-command menu state. Active when the composer holds a "/token"
         // (a leading slash with no whitespace yet); Query is the text after the
-        // slash; Index is the highlighted row. Drives the inline command menu
-        // that mirrors the gateway/web "type / to open the command menu" UX.
-        var slashMenuState = UseState<(bool Active, string Query, int Index)>((false, "", 0), threadSafe: true);
+        // slash; Index is the highlighted row. ArgsMode flips the same popup into
+        // the argument-choice picker after a command with fixed choices is chosen
+        // (mirrors Mac's slashMenuMode "command" | "args"). Drives the inline
+        // command menu that mirrors the gateway/web "type / to open" UX.
+        var slashMenuState = UseState<(bool Active, string Query, int Index, bool ArgsMode)>((false, "", 0, false), threadSafe: true);
 
         var composerCornerRadius = new CornerRadius(8);
         const double composerIconSize = 16;
@@ -216,7 +218,7 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
             hasTextState.Set(false);
             // Clear any open slash menu so it doesn't re-open over the now-empty
             // composer (programmatic text reset doesn't fire TextChanged).
-            slashMenuState.Set((false, "", 0));
+            slashMenuState.Set((false, "", 0, false));
             sendVersion.Set(sendVersion.Value + 1);
         };
         var sendActionRef = UseRef<Action>(sendAction);
@@ -432,37 +434,66 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         // input is a bare "/token" the menu opens and filters as the user types,
         // matching the gateway/web Control UI's primary command surface.
         var slash = slashMenuState.Value;
-        var slashActive = isConnected && slash.Active && !recording;
+        // The menu only engages on a connected gateway that actually advertises a
+        // command catalog. Gating on CommandsSupported here keeps the whole
+        // feature inert on gateways without commands.list: the popup stays hidden
+        // AND the slash key-handling branches below are skipped, so "/foo" behaves
+        // as ordinary text (Tab/Esc/Enter all keep their normal meaning).
+        var slashActive = isConnected && slash.Active && !recording && Props.CommandsSupported;
 
-        // Lazily fetch the catalog the first time the menu opens for this
-        // connection (EnsureCommandCatalogAsync is cached + in-flight guarded).
-        if (slashActive && Props.AvailableCommands is null)
-            Props.OnCommandsRequested?.Invoke();
+        // Lazily fetch the catalog when the menu opens without one. Keyed via
+        // UseEffect on the (open + missing-catalog) transition so the request
+        // fires once on that edge — not as a render side effect, and not on every
+        // keystroke while loading. If a fetch fails and the catalog stays null the
+        // deps don't change, so it won't retry until the menu is reopened.
+        // EnsureCommandCatalogAsync is itself cached + in-flight guarded.
+        var needsCatalog = slashActive && Props.AvailableCommands is null;
+        UseEffect(() =>
+        {
+            if (needsCatalog) Props.OnCommandsRequested?.Invoke();
+        }, needsCatalog);
 
         IReadOnlyList<GatewayCommand> slashResults = Array.Empty<GatewayCommand>();
-        if (slashActive && Props.CommandsSupported && Props.AvailableCommands is { } slashCmds)
+        if (slashActive && !slash.ArgsMode && Props.AvailableCommands is { } slashCmds)
+        {
+            // Relevance-ranked; index 0 is the top match and is what Enter inserts
+            // when the user hasn't navigated. (No category re-sort — that would
+            // demote an exact match below a weakly-matched command in an
+            // earlier-ordered category.)
             slashResults = new ChatCommandCatalogView(slashCmds)
                 .Search(slash.Query)
                 .Take(SlashMenuMaxItems)
                 .ToList();
+        }
 
-        var slashIndex = slashResults.Count == 0
-            ? 0
-            : Math.Clamp(slash.Index, 0, slashResults.Count - 1);
-
-        // Inserts the chosen command, replacing the "/token" the user was typing,
-        // then dismisses the menu. Arg-taking commands keep a trailing space so
-        // the user can type the value rather than sending immediately.
-        Action<GatewayCommand> insertSlashCommand = cmd =>
+        // Args-mode: the command (parsed from the composer text) plus its static
+        // choices filtered by what the user has typed after "/name ".
+        GatewayCommand? slashArgCmd = null;
+        IReadOnlyList<GatewayCommandArgChoice> slashArgResults = Array.Empty<GatewayCommandArgChoice>();
+        if (slashActive && slash.ArgsMode && Props.CommandsSupported && Props.AvailableCommands is { } argCmds)
         {
-            var insert = cmd.BuildInsertionText();
+            var (argName, _, _) = SplitSlashArgText(displayText);
+            slashArgCmd = argCmds.FirstOrDefault(c => c.MatchesName(argName));
+            if (slashArgCmd is not null)
+                slashArgResults = slashArgCmd.FirstArgChoices()
+                    .Where(ch => ChoiceMatches(ch, slash.Query))
+                    .Take(SlashMenuMaxItems)
+                    .ToList();
+        }
+
+        var inArgsMode = slash.ArgsMode && slashArgCmd is not null && slashArgResults.Count > 0;
+        var slashSelectableCount = inArgsMode ? slashArgResults.Count : slashResults.Count;
+        var slashIndex = slashSelectableCount == 0
+            ? 0
+            : Math.Clamp(slash.Index, 0, slashSelectableCount - 1);
+
+        // Pushes a new composer value into the textbox and restores the caret to
+        // the end (shared by command insertion and arg-choice insertion).
+        Action<string> commitSlashText = insert =>
+        {
             inputRef.Current = insert;
             hasTextState.Set(!string.IsNullOrWhiteSpace(insert));
-            slashMenuState.Set((false, "", 0));
-            // Bump the send version so the updated ref value is pushed into the
-            // TextBox on the next render (same mechanism the voice path uses).
             sendVersion.Set(sendVersion.Value + 1);
-
             var tbox = textBoxRef.Current;
             tbox?.DispatcherQueue?.TryEnqueue(() =>
             {
@@ -473,14 +504,37 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
             });
         };
 
+        // Inserts the chosen command, replacing the "/token" the user was typing.
+        // When the command has fixed argument choices, the popup transitions into
+        // the arg-choice picker (Mac parity) instead of dismissing; otherwise the
+        // command text is inserted (with a trailing space when it takes args).
+        Action<GatewayCommand> insertSlashCommand = cmd =>
+        {
+            if (cmd.FirstArgChoices().Count > 0)
+            {
+                commitSlashText(cmd.DisplayName() + " ");
+                slashMenuState.Set((true, "", 0, true));
+                return;
+            }
+            commitSlashText(cmd.BuildInsertionText());
+            slashMenuState.Set((false, "", 0, false));
+        };
+
+        // Picks a static argument choice, filling "/name value" and closing.
+        Action<GatewayCommand, GatewayCommandArgChoice> insertSlashArg = (cmd, choice) =>
+        {
+            commitSlashText(cmd.BuildArgInsertionText(choice.Value));
+            slashMenuState.Set((false, "", 0, false));
+        };
+
         var textbox = TextField(displayText, v =>
             {
                 inputRef.Current = v;
                 hasTextState.Set(!string.IsNullOrWhiteSpace(v));
-                var (active, query) = ComputeSlashTrigger(v);
+                var (active, query, argsMode) = ComputeSlashState(v, Props.AvailableCommands);
                 var cur = slashMenuState.Value;
-                if (active != cur.Active || query != cur.Query)
-                    slashMenuState.Set((active, query, 0));
+                if (active != cur.Active || query != cur.Query || argsMode != cur.ArgsMode)
+                    slashMenuState.Set((active, query, 0, argsMode));
             })
             .Set(tb =>
             {
@@ -552,46 +606,68 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
 
                 // While the slash menu is open with results, the arrow keys
                 // navigate it and Enter/Tab autocompletes — instead of moving
-                // the caret or sending the message.
-                if (slashActive && slashResults.Count > 0)
+                // the caret or sending the message. Works for both the command
+                // list and the argument-choice picker (slashSelectableCount and
+                // the Enter/Tab branch dispatch on the active mode).
+                if (slashActive && slashSelectableCount > 0)
                 {
                     if (key == global::Windows.System.VirtualKey.Down)
                     {
                         e.Handled = true;
-                        slashMenuState.Set((slash.Active, slash.Query, Math.Min(slashIndex + 1, slashResults.Count - 1)));
+                        slashMenuState.Set((slash.Active, slash.Query, Math.Min(slashIndex + 1, slashSelectableCount - 1), slash.ArgsMode));
                         return;
                     }
                     if (key == global::Windows.System.VirtualKey.Up)
                     {
                         e.Handled = true;
-                        slashMenuState.Set((slash.Active, slash.Query, Math.Max(slashIndex - 1, 0)));
+                        slashMenuState.Set((slash.Active, slash.Query, Math.Max(slashIndex - 1, 0), slash.ArgsMode));
                         return;
                     }
                     if (key == global::Windows.System.VirtualKey.Enter
                         || key == global::Windows.System.VirtualKey.Tab)
                     {
                         e.Handled = true;
-                        insertSlashCommand(slashResults[slashIndex]);
+                        if (inArgsMode)
+                            insertSlashArg(slashArgCmd!, slashArgResults[slashIndex]);
+                        else
+                            insertSlashCommand(slashResults[slashIndex]);
                         return;
                     }
                     if (key == global::Windows.System.VirtualKey.Escape)
                     {
                         e.Handled = true;
-                        slashMenuState.Set((false, "", 0));
+                        slashMenuState.Set((false, "", 0, false));
                         return;
                     }
                 }
                 else if (slashActive)
                 {
-                    // Menu visible but loading / no matches: keep keyboard
-                    // behavior predictable while the popup is up. Escape or Tab
-                    // dismiss it (Tab must not silently move focus away while the
-                    // popup overlays), and selection keys are swallowed.
+                    // Popup is up but nothing is selectable: either the catalog is
+                    // still loading or no command matches the typed text.
+                    var slashLoading = Props.AvailableCommands is null;
                     if (key == global::Windows.System.VirtualKey.Escape
                         || key == global::Windows.System.VirtualKey.Tab)
                     {
+                        // Dismiss (Tab must not silently move focus while the popup
+                        // overlays the composer).
                         e.Handled = true;
-                        slashMenuState.Set((false, "", 0));
+                        slashMenuState.Set((false, "", 0, false));
+                        return;
+                    }
+                    if (key == global::Windows.System.VirtualKey.Up
+                        || key == global::Windows.System.VirtualKey.Down)
+                    {
+                        // Nothing to move through — swallow so the caret doesn't jump.
+                        e.Handled = true;
+                        return;
+                    }
+                    if (slashLoading && key == global::Windows.System.VirtualKey.Enter)
+                    {
+                        // We don't yet know whether "/token" is a real command, so
+                        // don't let Enter send it as raw text and race the fetch.
+                        // (Once loaded with no match it's not a command, so Enter
+                        // falls through below and sends as an ordinary message.)
+                        e.Handled = true;
                         return;
                     }
                 }
@@ -993,16 +1069,22 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         var slashMenuVisible = false;
         if (slashActive)
         {
-            if (!Props.CommandsSupported)
-            {
-                // Gateway has no command catalog → don't get in the way; let the
-                // user keep typing their "/..." as ordinary text.
-                slashMenuVisible = false;
-            }
-            else if (Props.AvailableCommands is null)
+            // slashActive already implies a connected, command-supporting gateway.
+            if (Props.AvailableCommands is null)
             {
                 slashPopupContent = BuildSlashHintPopup("Loading commands…");
                 slashMenuVisible = true;
+            }
+            else if (slash.ArgsMode)
+            {
+                // Arg-choice picker for the selected command (Mac parity). When
+                // nothing matches, ComputeSlashState has already cleared Active,
+                // so we only reach here with results to show.
+                if (inArgsMode)
+                {
+                    slashPopupContent = BuildSlashArgPopup(slashArgCmd!, slashArgResults, slashIndex, choice => insertSlashArg(slashArgCmd!, choice));
+                    slashMenuVisible = true;
+                }
             }
             else if (slashResults.Count == 0)
             {
@@ -1143,30 +1225,66 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
     private const int SlashMenuMaxItems = 8;
 
     /// <summary>
-    /// Decides whether the composer text should open the inline slash-command
-    /// menu. Active when the text is a single leading "/token" with no
-    /// whitespace yet (the user is still typing the command name). Returns the
-    /// query (text after the slash) so the menu can filter.
+    /// Decides whether the composer text should open the inline slash menu and
+    /// in which mode. Command mode: a single leading "/token" with no whitespace.
+    /// Args mode: "/name &lt;filter&gt;" where <paramref name="commands"/> contains a
+    /// command named <c>name</c> that declares static argument choices and at
+    /// least one choice matches the filter (mirrors Mac's slash-commands.ts).
     /// </summary>
-    private static (bool Active, string Query) ComputeSlashTrigger(string? text)
+    private static (bool Active, string Query, bool ArgsMode) ComputeSlashState(
+        string? text, IReadOnlyList<GatewayCommand>? commands)
     {
         var t = text ?? string.Empty;
         if (t.Length == 0 || t[0] != '/')
-            return (false, string.Empty);
+            return (false, string.Empty, false);
+
+        var (name, rest, hasSpace) = SplitSlashArgText(t);
+        if (!hasSpace)
+            return (true, t.Substring(1), false); // command mode: still typing the name
+
+        // The arg-choice picker filters on a single token. Once the user types
+        // whitespace within that token (e.g. completed "/model gpt-5 " and kept
+        // typing), they've moved past the picker — fall back to plain text so the
+        // menu doesn't keep trapping Enter/Tab on a value they've finished.
+        if (rest.Any(char.IsWhiteSpace))
+            return (false, string.Empty, false);
+
+        var cmd = commands?.FirstOrDefault(c => c.MatchesName(name));
+        if (cmd is not null)
+        {
+            var choices = cmd.FirstArgChoices();
+            if (choices.Count > 0 && choices.Any(ch => ChoiceMatches(ch, rest)))
+                return (true, rest, true);
+        }
+        return (false, string.Empty, false);
+    }
+
+    /// <summary>Splits "/name rest" into ("name", "rest", hasSpace). Without a space, remainder is "".</summary>
+    private static (string Name, string Remainder, bool HasSpace) SplitSlashArgText(string? text)
+    {
+        var t = text ?? string.Empty;
+        if (t.Length == 0 || t[0] != '/') return (string.Empty, string.Empty, false);
         for (int i = 1; i < t.Length; i++)
         {
             if (char.IsWhiteSpace(t[i]))
-                return (false, string.Empty);
+                return (t.Substring(1, i - 1), t.Substring(i + 1), true);
         }
-        return (true, t.Substring(1));
+        return (t.Substring(1), string.Empty, false);
+    }
+
+    /// <summary>Prefix match of a choice (value or label) against the typed filter, case-insensitive.</summary>
+    private static bool ChoiceMatches(GatewayCommandArgChoice choice, string? filter)
+    {
+        var f = (filter ?? string.Empty).Trim();
+        if (f.Length == 0) return true;
+        return (choice.Value?.StartsWith(f, StringComparison.OrdinalIgnoreCase) ?? false)
+            || (choice.Label?.StartsWith(f, StringComparison.OrdinalIgnoreCase) ?? false);
     }
 
     // ── Native slash-menu popup builders ──
     // The menu is hosted in a WinUI Popup (overlay) so it floats above the
     // composer without shifting controls. Content is built as native controls
     // (not FunctionalUI elements) because it lives outside the functional tree.
-
-    private static readonly Microsoft.UI.Xaml.Media.FontFamily SlashBadgeFont = new("Segoe UI");
 
     private static double SlashPopupWidth(double anchorWidth) =>
         Math.Max(280, anchorWidth);
@@ -1192,10 +1310,7 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
 
         var list = new StackPanel { Orientation = Orientation.Vertical };
         for (int i = 0; i < results.Count; i++)
-        {
-            var cmd = results[i];
-            list.Children.Add(SlashRow(cmd, i == selectedIndex, primary, secondary, selectedBg, onPick));
-        }
+            list.Children.Add(SlashRow(results[i], i == selectedIndex, primary, secondary, selectedBg, onPick));
         var scroll = new ScrollViewer
         {
             VerticalScrollBarVisibility = Microsoft.UI.Xaml.Controls.ScrollBarVisibility.Auto,
@@ -1206,14 +1321,96 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         return SlashShell(scroll);
     }
 
+    private static Border BuildSlashArgPopup(
+        GatewayCommand cmd, IReadOnlyList<GatewayCommandArgChoice> choices,
+        int selectedIndex, Action<GatewayCommandArgChoice> onPick)
+    {
+        var primary = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["TextFillColorPrimaryBrush"];
+        var secondary = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["TextFillColorSecondaryBrush"];
+        var selectedBg = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["SubtleFillColorSecondaryBrush"];
+
+        var list = new StackPanel { Orientation = Orientation.Vertical };
+        // Header echoes the chosen command + its argument description so the user
+        // keeps context while choosing a value. Falls back to the command's own
+        // description, then just the command name.
+        var argDesc = cmd.Args?.FirstOrDefault()?.Description;
+        var headerText = !string.IsNullOrWhiteSpace(argDesc)
+            ? $"{cmd.DisplayName()}  {argDesc}"
+            : !string.IsNullOrWhiteSpace(cmd.Description)
+                ? $"{cmd.DisplayName()}  {cmd.Description}"
+                : cmd.DisplayName();
+        list.Children.Add(new TextBlock
+        {
+            Text = headerText,
+            FontSize = 11,
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+            Foreground = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["TextFillColorTertiaryBrush"],
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            MaxLines = 1,
+            Margin = new Thickness(8, 6, 8, 2),
+        });
+        for (int i = 0; i < choices.Count; i++)
+            list.Children.Add(SlashArgRow(cmd, choices[i], i == selectedIndex, primary, secondary, selectedBg, onPick));
+
+        var scroll = new ScrollViewer
+        {
+            VerticalScrollBarVisibility = Microsoft.UI.Xaml.Controls.ScrollBarVisibility.Auto,
+            HorizontalScrollBarVisibility = Microsoft.UI.Xaml.Controls.ScrollBarVisibility.Disabled,
+            MaxHeight = 280,
+            Content = list,
+        };
+        return SlashShell(scroll);
+    }
+
+    private static Button SlashArgRow(
+        GatewayCommand cmd, GatewayCommandArgChoice choice, bool selected,
+        Brush primary, Brush secondary, Brush selectedBg, Action<GatewayCommandArgChoice> onPick)
+    {
+        var label = string.IsNullOrWhiteSpace(choice.Label) ? choice.Value : choice.Label;
+        var row = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+        row.Children.Add(new TextBlock
+        {
+            Text = label,
+            FontSize = 13,
+            FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+            Foreground = primary,
+            VerticalAlignment = VerticalAlignment.Center,
+        });
+        row.Children.Add(new TextBlock
+        {
+            Text = $"{cmd.DisplayName()} {choice.Value}",
+            FontSize = 12,
+            Foreground = secondary,
+            VerticalAlignment = VerticalAlignment.Center,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            MaxLines = 1,
+        });
+
+        var btn = new Button
+        {
+            Content = row,
+            Padding = new Thickness(8, 7, 8, 7),
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalContentAlignment = HorizontalAlignment.Left,
+            CornerRadius = new CornerRadius(6),
+            Background = selected ? selectedBg : new SolidColorBrush(Colors.Transparent),
+            BorderThickness = new Thickness(0),
+        };
+        btn.Click += (_, _) => onPick(choice);
+        return btn;
+    }
+
     private static Border SlashShell(UIElement child)
     {
-        // Match the composer card's own surface so the menu reads as part of the
-        // app: same background + stroke as the input box, with a soft shadow for
-        // separation from the chat content beneath.
+        // Floating, opaque, elevated container for the slash menu. Uses the same
+        // 8px corner radius + default surface stroke as the composer card, with a
+        // soft shadow so the menu reads as a distinct layer over the chat content.
         var shell = new Border
         {
-            Background = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["SolidBackgroundFillColorSecondaryBrush"],
+            // Elevated flyout surface: Tertiary reads lighter than the chat
+            // background (in dark theme Secondary is actually darker than Base),
+            // so the menu lifts off the content instead of sinking into it.
+            Background = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["SolidBackgroundFillColorTertiaryBrush"],
             BorderBrush = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["SurfaceStrokeColorDefaultBrush"],
             BorderThickness = new Thickness(1),
             CornerRadius = new CornerRadius(8),
@@ -1229,6 +1426,14 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         GatewayCommand cmd, bool selected, Brush primary, Brush secondary, Brush selectedBg, Action<GatewayCommand> onPick)
     {
         var row = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+        row.Children.Add(new FontIcon
+        {
+            FontFamily = (Microsoft.UI.Xaml.Media.FontFamily)Microsoft.UI.Xaml.Application.Current.Resources["SymbolThemeFontFamily"],
+            Glyph = SlashGlyph(cmd),
+            FontSize = 14,
+            Foreground = secondary,
+            VerticalAlignment = VerticalAlignment.Center,
+        });
         row.Children.Add(new TextBlock
         {
             Text = cmd.DisplayName(),
@@ -1237,6 +1442,17 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
             Foreground = primary,
             VerticalAlignment = VerticalAlignment.Center,
         });
+        var args = cmd.ArgTemplate();
+        if (!string.IsNullOrWhiteSpace(args))
+        {
+            row.Children.Add(new TextBlock
+            {
+                Text = args,
+                FontSize = 12,
+                Foreground = secondary,
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+        }
         if (!string.IsNullOrWhiteSpace(cmd.Description))
         {
             row.Children.Add(new TextBlock
@@ -1249,14 +1465,13 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
                 MaxLines = 1,
             });
         }
-        var sourceLabel = cmd.SourceLabel();
-        if (!string.IsNullOrWhiteSpace(sourceLabel)) row.Children.Add(SlashBadge(sourceLabel, secondary));
-        if (cmd.RequiresArgs()) row.Children.Add(SlashBadge("args", secondary));
+        var opts = cmd.OptionCount();
+        if (opts > 0) row.Children.Add(SlashBadge($"{opts} options", secondary));
 
         var btn = new Button
         {
             Content = row,
-            Padding = new Thickness(8, 4, 8, 4),
+            Padding = new Thickness(8, 7, 8, 7),
             HorizontalAlignment = HorizontalAlignment.Stretch,
             HorizontalContentAlignment = HorizontalAlignment.Left,
             CornerRadius = new CornerRadius(6),
@@ -1267,6 +1482,33 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         return btn;
     }
 
+    // Mirrors Mac's COMMAND_ICON_OVERRIDES (slash-commands.ts): icon keyed by
+    // normalized command name, defaulting to the command-prompt glyph. Lucide
+    // names are mapped to their nearest Segoe Fluent equivalents.
+    private static string SlashGlyph(GatewayCommand cmd)
+    {
+        var name = (cmd.NativeName ?? cmd.DisplayName()).Trim().TrimStart('/').ToLowerInvariant();
+        name = name.Replace(':', '_').Replace('.', '_').Replace('-', '_');
+        return name switch
+        {
+            "help" or "commands" => "\uE82D",        // book
+            "status" or "usage" => "\uE9D9",          // bar chart
+            "export" or "export_session" => "\uE896", // download
+            "skill" or "fast" => "\uE945",            // lightning (zap)
+            "model" or "models" or "think" => "\uE713", // model/options (brain→settings)
+            "new" => "\uE710",                         // plus
+            "reset" or "redirect" => "\uE72C",         // refresh
+            "compact" => "\uE9F3",                     // loader
+            "stop" => "\uE71A",                        // stop
+            "clear" => "\uE74D",                       // trash
+            "agents" => "\uE7F4",                      // monitor
+            "subagents" => "\uE8B7",                   // folder
+            "steer" => "\uE724",                       // send
+            "tts" => "\uE767",                         // volume
+            _ => "\uE756",                              // command prompt (terminal default)
+        };
+    }
+
     private static Border SlashBadge(string text, Brush foreground) => new()
     {
         Padding = new Thickness(5, 1, 5, 1),
@@ -1275,7 +1517,7 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         BorderThickness = new Thickness(1),
         BorderBrush = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["ControlStrokeColorDefaultBrush"],
         VerticalAlignment = VerticalAlignment.Center,
-        Child = new TextBlock { Text = text, FontSize = 10, FontFamily = SlashBadgeFont, Foreground = foreground },
+        Child = new TextBlock { Text = text, FontSize = 10, Foreground = foreground },
     };
 
     /// <summary>

--- a/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
+++ b/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
@@ -911,6 +911,7 @@ internal sealed class UiRenderer(Action requestRender)
 {
     private readonly Dictionary<string, UIElement> _controls = new();
     private readonly Dictionary<string, Component> _components = new();
+    private readonly Dictionary<string, Flyout> _contentFlyouts = new();
     private readonly HashSet<string> _mountedPaths = new();
 
     public UIElement Render(Element element, string path, List<Action> effects)
@@ -928,6 +929,7 @@ internal sealed class UiRenderer(Action requestRender)
 
         _components.Clear();
         _controls.Clear();
+        _contentFlyouts.Clear();
         _mountedPaths.Clear();
     }
 
@@ -1376,10 +1378,28 @@ internal sealed class UiRenderer(Action requestRender)
 
     private Flyout CreateContentFlyout(ContentFlyoutElement element, string path, List<Action> effects)
     {
-        var flyout = new Flyout { Placement = element.Placement };
+        // Cache the Flyout instance per path so its identity is STABLE across
+        // re-renders. ConfigureButton reassigns control.Flyout on every render,
+        // and a full-root re-render fires on every state change (including the
+        // flyout content's own search box). If we minted a `new Flyout()` each
+        // time, an already-open flyout would (a) become unreachable from
+        // control.Flyout (so callers' `Flyout.Hide()` would target an orphan and
+        // no-op) and (b) have its reused content control reparented out from
+        // under the visible popup. Reusing the same Flyout keeps it dismissable
+        // and stops the open popup from being torn apart mid-interaction.
+        if (!_contentFlyouts.TryGetValue(path, out var flyout))
+        {
+            flyout = new Flyout();
+            _contentFlyouts[path] = flyout;
+        }
+
+        flyout.Placement = element.Placement;
         var content = RenderElement(element.Content, path + ".content", effects);
-        RemoveFromParent(content);
-        flyout.Content = content;
+        if (!ReferenceEquals(flyout.Content, content))
+        {
+            RemoveFromParent(content);
+            flyout.Content = content;
+        }
         return flyout;
     }
 

--- a/tests/OpenClaw.Shared.Tests/CommandCatalogPresentationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CommandCatalogPresentationTests.cs
@@ -78,6 +78,91 @@ public class CommandCatalogPresentationTests
         Assert.Equal("/m ", withRequired.BuildInsertionText());
     }
 
+    // ── Mac-parity presentation helpers ──
+
+    [Fact]
+    public void ArgTemplate_FormatsRequiredAndOptionalArgs()
+    {
+        Assert.Equal("", new GatewayCommand { Name = "a" }.ArgTemplate());
+        var cmd = new GatewayCommand
+        {
+            Name = "a",
+            Args = new[]
+            {
+                new GatewayCommandArg { Name = "message", Required = true },
+                new GatewayCommandArg { Name = "level", Required = false },
+            },
+        };
+        Assert.Equal("<message> [level]", cmd.ArgTemplate());
+    }
+
+    [Fact]
+    public void OptionCount_CountsStaticChoicesOnFirstArgOnly()
+    {
+        Assert.Equal(0, new GatewayCommand { Name = "a" }.OptionCount());
+        var withChoices = new GatewayCommand
+        {
+            Name = "a",
+            Args = new[]
+            {
+                new GatewayCommandArg
+                {
+                    Name = "id",
+                    Choices = new[]
+                    {
+                        new GatewayCommandArgChoice { Value = "fast" },
+                        new GatewayCommandArgChoice { Value = "slow" },
+                    },
+                },
+            },
+        };
+        Assert.Equal(2, withChoices.OptionCount());
+        // Dynamic choices are not counted (resolved by the gateway at runtime).
+        var dynamic = new GatewayCommand
+        {
+            Name = "a",
+            Args = new[] { new GatewayCommandArg { Name = "id", IsDynamic = true, Choices = new[] { new GatewayCommandArgChoice { Value = "x" } } } },
+        };
+        Assert.Equal(0, dynamic.OptionCount());
+    }
+
+    [Fact]
+    public void FirstArgChoices_ReturnsStaticChoicesElseEmpty()
+    {
+        Assert.Empty(new GatewayCommand { Name = "a" }.FirstArgChoices());
+        var cmd = new GatewayCommand
+        {
+            Name = "a",
+            Args = new[]
+            {
+                new GatewayCommandArg { Name = "id", Choices = new[] { new GatewayCommandArgChoice { Value = "fast", Label = "Fast" } } },
+            },
+        };
+        Assert.Single(cmd.FirstArgChoices());
+        Assert.Equal("fast", cmd.FirstArgChoices()[0].Value);
+    }
+
+    [Fact]
+    public void BuildArgInsertionText_BuildsSlashNameValue()
+    {
+        var cmd = new GatewayCommand { Name = "model", NativeName = "/model" };
+        Assert.Equal("/model gpt-5", cmd.BuildArgInsertionText("gpt-5"));
+        Assert.Equal("/model gpt-5", cmd.BuildArgInsertionText("  gpt-5 "));
+    }
+
+    [Theory]
+    [InlineData("model", true)]
+    [InlineData("/model", true)]
+    [InlineData("MODEL", true)]
+    [InlineData("tldr", true)]   // text alias
+    [InlineData("nope", false)]
+    [InlineData("", false)]
+    public void MatchesName_MatchesNativeNameAndAliases(string probe, bool expected)
+    {
+        var cmd = new GatewayCommand { Name = "model", NativeName = "/model", TextAliases = new[] { "/tldr" } };
+        Assert.Equal(expected, cmd.MatchesName(probe));
+    }
+
     // ── ChatCommandCatalogView search ──
 
     [Fact]

--- a/tests/OpenClaw.Shared.Tests/CommandCatalogPresentationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CommandCatalogPresentationTests.cs
@@ -1,0 +1,184 @@
+using System.Linq;
+using OpenClaw.Shared;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+// Tests for the UI-facing presentation helpers layered on top of the
+// GatewayCommand DTO (GatewayCommandPresentation + the ranked
+// ChatCommandCatalogView). The wire DTOs / parsing / CommandCatalogQuery are
+// covered separately by GatewayProtocolModelsTests.
+public class CommandCatalogPresentationTests
+{
+    private static GatewayCommand[] Sample() => new[]
+    {
+        new GatewayCommand { Name = "clear", NativeName = "/clear", Description = "Clear the conversation", Category = "Session", Source = "native", Scope = "session" },
+        new GatewayCommand
+        {
+            Name = "model", NativeName = "/model", Description = "Switch the active model", Category = "Session",
+            Source = "native", Scope = "session", AcceptsArgs = true,
+            Args = new[] { new GatewayCommandArg { Name = "id", Required = true, Type = "string" } }
+        },
+        new GatewayCommand { Name = "summarize", TextAliases = new[] { "/summarize", "/tldr" }, Description = "Summarize the thread", Category = "Text", Source = "text" },
+        new GatewayCommand { Name = "deploy", Description = "Run the deploy skill", Source = "skill", Category = "Skills" },
+        new GatewayCommand { Name = "jira", NativeName = "/jira", Source = "plugin" },
+    };
+
+    // ── GatewayCommandPresentation ──
+
+    [Fact]
+    public void DisplayName_PrefersNativeThenAliasThenName()
+    {
+        Assert.Equal("/clear", new GatewayCommand { Name = "clear", NativeName = "/clear" }.DisplayName());
+        Assert.Equal("/tldr", new GatewayCommand { Name = "summarize", TextAliases = new[] { "/tldr" } }.DisplayName());
+        Assert.Equal("/bare", new GatewayCommand { Name = "bare" }.DisplayName());
+        // Already-prefixed names are not double-slashed.
+        Assert.Equal("/x", new GatewayCommand { Name = "/x" }.DisplayName());
+    }
+
+    [Theory]
+    [InlineData("native", "Native")]
+    [InlineData("skill", "Skill")]
+    [InlineData("plugin", "Plugin")]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void SourceLabel_CapitalizesSource(string? source, string expected)
+    {
+        Assert.Equal(expected, new GatewayCommand { Name = "x", Source = source }.SourceLabel());
+    }
+
+    [Fact]
+    public void RequiresArgs_TrueWhenAcceptsArgsOrRequiredArg()
+    {
+        Assert.False(new GatewayCommand { Name = "a" }.RequiresArgs());
+        Assert.True(new GatewayCommand { Name = "a", AcceptsArgs = true }.RequiresArgs());
+        Assert.True(new GatewayCommand
+        {
+            Name = "a",
+            Args = new[] { new GatewayCommandArg { Name = "x", Required = true } }
+        }.RequiresArgs());
+        // Optional-only arg, AcceptsArgs not set → no required input.
+        Assert.False(new GatewayCommand
+        {
+            Name = "a",
+            Args = new[] { new GatewayCommandArg { Name = "x", Required = false } }
+        }.RequiresArgs());
+    }
+
+    [Fact]
+    public void BuildInsertionText_AppendsSpaceOnlyWhenArgsNeeded()
+    {
+        Assert.Equal("/clear", new GatewayCommand { Name = "clear", NativeName = "/clear" }.BuildInsertionText());
+        Assert.Equal("/model ", new GatewayCommand { Name = "model", NativeName = "/model", AcceptsArgs = true }.BuildInsertionText());
+        var withRequired = new GatewayCommand
+        {
+            Name = "m", NativeName = "/m",
+            Args = new[] { new GatewayCommandArg { Name = "id", Required = true } }
+        };
+        Assert.Equal("/m ", withRequired.BuildInsertionText());
+    }
+
+    // ── ChatCommandCatalogView search ──
+
+    [Fact]
+    public void Search_EmptyQuery_ReturnsAllOrderedByDisplayName()
+    {
+        var view = new ChatCommandCatalogView(Sample());
+        var all = view.Search("");
+        Assert.Equal(5, all.Count);
+        var names = all.Select(c => c.DisplayName()).ToList();
+        Assert.Equal(names.OrderBy(n => n, System.StringComparer.OrdinalIgnoreCase).ToList(), names);
+    }
+
+    [Theory]
+    [InlineData("clear")]
+    [InlineData("CLE")]
+    [InlineData("/clear")]
+    public void Search_MatchesByNameNativeAndIsCaseInsensitive(string query)
+    {
+        var view = new ChatCommandCatalogView(Sample());
+        Assert.Contains(view.Search(query), c => c.Name == "clear");
+    }
+
+    [Fact]
+    public void Search_MatchesByAlias()
+    {
+        var view = new ChatCommandCatalogView(Sample());
+        Assert.Contains(view.Search("tldr"), c => c.Name == "summarize");
+    }
+
+    [Fact]
+    public void Search_MatchesByDescriptionAndCategory()
+    {
+        var view = new ChatCommandCatalogView(Sample());
+        Assert.Contains(view.Search("Switch the active"), c => c.Name == "model");
+        Assert.Contains(view.Search("Skills"), c => c.Name == "deploy");
+    }
+
+    [Fact]
+    public void Search_RanksPrefixMatchesAboveContainsMatches()
+    {
+        var view = new ChatCommandCatalogView(new[]
+        {
+            new GatewayCommand { Name = "preview", NativeName = "/preview" },
+            new GatewayCommand { Name = "view", NativeName = "/view" },
+        });
+        var results = view.Search("view");
+        // "/view" is a prefix match; "/preview" only a contains match → view first.
+        Assert.Equal("view", results[0].Name);
+    }
+
+    [Fact]
+    public void Search_NoMatch_ReturnsEmpty()
+    {
+        var view = new ChatCommandCatalogView(Sample());
+        Assert.Empty(view.Search("zzzznotacommand"));
+    }
+
+    // ── ChatCommandCatalogView grouping ──
+
+    [Fact]
+    public void GroupByCategory_GroupsAndOrders()
+    {
+        var view = new ChatCommandCatalogView(Sample());
+        var groups = view.GroupByCategory();
+        var categories = groups.Select(g => g.Category).ToList();
+        Assert.Contains("Session", categories);
+        Assert.Contains("Text", categories);
+        Assert.Contains("Skills", categories);
+        Assert.Equal(categories.OrderBy(c => c, System.StringComparer.OrdinalIgnoreCase).ToList(), categories);
+        var session = groups.Single(g => g.Category == "Session");
+        Assert.Equal(new[] { "/clear", "/model" }, session.Commands.Select(c => c.DisplayName()).ToArray());
+    }
+
+    [Fact]
+    public void GroupByCategory_FallsBackToSourceLabelThenOther()
+    {
+        var view = new ChatCommandCatalogView(new[]
+        {
+            new GatewayCommand { Name = "a", Source = "plugin" },  // no category → "Plugin"
+            new GatewayCommand { Name = "b" },                       // no category/source → "Other"
+        });
+        var categories = view.GroupByCategory().Select(g => g.Category).ToList();
+        Assert.Contains("Plugin", categories);
+        Assert.Contains("Other", categories);
+    }
+
+    [Fact]
+    public void GroupByCategory_RespectsSearchFilter()
+    {
+        var view = new ChatCommandCatalogView(Sample());
+        var all = view.GroupByCategory("model").SelectMany(g => g.Commands).ToList();
+        Assert.Single(all);
+        Assert.Equal("model", all[0].Name);
+    }
+
+    [Fact]
+    public void View_NullCommands_IsEmpty()
+    {
+        var view = new ChatCommandCatalogView(null);
+        Assert.Equal(0, view.Count);
+        Assert.Empty(view.Search("anything"));
+        Assert.Empty(view.GroupByCategory());
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -2057,6 +2057,29 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
+    public async Task EnsureCommandCatalogAsync_Exception_PublishesUnsupportedFallback()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        bridge.ListCommandsBehavior = _ => Task.FromException<CommandCatalog>(
+            new InvalidOperationException("catalog unavailable"));
+        await provider.LoadAsync();
+        bridge.RaiseStatus(ConnectionStatus.Connected);
+        snapshots.Clear();
+
+        await provider.EnsureCommandCatalogAsync();
+
+        var snap = snapshots[^1];
+        Assert.False(snap.CommandsSupported);
+        Assert.NotNull(snap.AvailableCommands);
+        Assert.Empty(snap.AvailableCommands!);
+
+        await provider.EnsureCommandCatalogAsync();
+        // The fallback is cached for this connection so reopening the menu does
+        // not retry immediately and put the composer back into "loading".
+        Assert.Equal(1, bridge.ListCommandsCallCount);
+    }
+
+    [Fact]
     public async Task EnsureCommandCatalogAsync_NotConnected_DoesNotFetch()
     {
         var (bridge, provider, _, _) = CreateProvider(new[] { MainSession() });

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -26,10 +26,21 @@ public class OpenClawChatDataProviderTests
         public Func<string, Task>? AbortBehavior { get; set; }
         public SessionInfo[] Sessions { get; set; } = Array.Empty<SessionInfo>();
         public ModelsListInfo? CurrentModels { get; set; }
+        // Configurable commands.list result + a call counter for the
+        // request/response protocol API.
+        public CommandCatalog CommandCatalogResult { get; set; } = new CommandCatalog { IsSupported = true };
+        public Func<CommandCatalogQuery?, Task<CommandCatalog>>? ListCommandsBehavior { get; set; }
+        public int ListCommandsCallCount { get; private set; }
 
         public SessionInfo[] GetSessionList() => Sessions;
         public ModelsListInfo? GetCurrentModelsList() => CurrentModels;
         public void StartProactiveBootstrap() { }
+
+        public Task<CommandCatalog> ListCommandsAsync(CommandCatalogQuery? query = null)
+        {
+            ListCommandsCallCount++;
+            return ListCommandsBehavior?.Invoke(query) ?? Task.FromResult(CommandCatalogResult);
+        }
 
         public Task SendChatMessageAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null)
             => SendChatMessageForRunAsync(message, sessionKey, sessionId, attachments);
@@ -2002,6 +2013,218 @@ public class OpenClawChatDataProviderTests
         Assert.Equal(2, snapshots[^1].AvailableModels.Length);
         Assert.Equal("gpt-5.4", snapshots[^1].AvailableModels[0]);
         Assert.Equal("gpt-5.4-mirror", snapshots[^1].AvailableModels[1]);
+    }
+
+    [Fact]
+    public async Task EnsureCommandCatalogAsync_PopulatesCatalogInSnapshot()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        bridge.CommandCatalogResult = new CommandCatalog
+        {
+            IsSupported = true,
+            Commands = new[]
+            {
+                new GatewayCommand { Name = "clear", NativeName = "/clear", Category = "Session" },
+                new GatewayCommand { Name = "model", NativeName = "/model", Category = "Session", AcceptsArgs = true },
+            }
+        };
+        await provider.LoadAsync();
+        bridge.RaiseStatus(ConnectionStatus.Connected);
+        snapshots.Clear();
+
+        await provider.EnsureCommandCatalogAsync();
+
+        var snap = snapshots[^1];
+        Assert.True(snap.CommandsSupported);
+        Assert.NotNull(snap.AvailableCommands);
+        Assert.Equal(2, snap.AvailableCommands!.Count);
+        Assert.Contains(snap.AvailableCommands, c => c.Name == "clear");
+    }
+
+    [Fact]
+    public async Task EnsureCommandCatalogAsync_Unsupported_FlipsSupportedFlag()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        bridge.CommandCatalogResult = new CommandCatalog { IsSupported = false };
+        await provider.LoadAsync();
+        bridge.RaiseStatus(ConnectionStatus.Connected);
+
+        await provider.EnsureCommandCatalogAsync();
+
+        var snap = snapshots[^1];
+        // The UI renders the "unsupported" state from this flag.
+        Assert.False(snap.CommandsSupported);
+    }
+
+    [Fact]
+    public async Task EnsureCommandCatalogAsync_NotConnected_DoesNotFetch()
+    {
+        var (bridge, provider, _, _) = CreateProvider(new[] { MainSession() });
+        bridge.CommandCatalogResult = new CommandCatalog { IsSupported = true };
+        await provider.LoadAsync();
+        // Provider starts Disconnected (FakeBridge default).
+
+        await provider.EnsureCommandCatalogAsync();
+
+        // The command catalog is a property of the live connection; no fetch
+        // should be issued while disconnected.
+        Assert.Equal(0, bridge.ListCommandsCallCount);
+    }
+
+    [Fact]
+    public async Task CommandCatalog_NullBeforeFetch_ThenEmptyNonNullWhenLoadedEmpty()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        bridge.CommandCatalogResult = new CommandCatalog { IsSupported = true };
+
+        // Before any commands.list fetch the catalog is null so the UI can
+        // distinguish "still loading" from "loaded but empty".
+        var initial = await provider.LoadAsync();
+        Assert.Null(initial.AvailableCommands);
+
+        bridge.RaiseStatus(ConnectionStatus.Connected);
+        await provider.EnsureCommandCatalogAsync();
+
+        var snap = snapshots[^1];
+        Assert.True(snap.CommandsSupported);
+        Assert.NotNull(snap.AvailableCommands);
+        Assert.Empty(snap.AvailableCommands!);
+    }
+
+    [Fact]
+    public async Task EnsureCommandCatalogAsync_FetchesOnceThenReusesCache()
+    {
+        var (bridge, provider, _, _) = CreateProvider(new[] { MainSession() });
+        bridge.CommandCatalogResult = new CommandCatalog
+        {
+            IsSupported = true,
+            Commands = new[] { new GatewayCommand { Name = "clear", NativeName = "/clear" } }
+        };
+        await provider.LoadAsync();
+        bridge.RaiseStatus(ConnectionStatus.Connected);
+
+        await provider.EnsureCommandCatalogAsync();
+        await provider.EnsureCommandCatalogAsync();
+
+        // The catalog is cached after the first successful fetch; a second
+        // palette-open does not re-hit commands.list.
+        Assert.Equal(1, bridge.ListCommandsCallCount);
+    }
+
+    [Fact]
+    public async Task EnsureCommandCatalogAsync_RefetchesAfterReconnect()
+    {
+        var (bridge, provider, _, _) = CreateProvider(new[] { MainSession() });
+        bridge.CommandCatalogResult = new CommandCatalog
+        {
+            IsSupported = true,
+            Commands = new[] { new GatewayCommand { Name = "clear", NativeName = "/clear" } }
+        };
+        await provider.LoadAsync();
+        bridge.RaiseStatus(ConnectionStatus.Connected);
+
+        await provider.EnsureCommandCatalogAsync();
+        Assert.Equal(1, bridge.ListCommandsCallCount);
+
+        // Leaving Connected clears the cached catalog; the next palette-open
+        // re-fetches it.
+        bridge.RaiseStatus(ConnectionStatus.Disconnected);
+        bridge.RaiseStatus(ConnectionStatus.Connected);
+
+        await provider.EnsureCommandCatalogAsync();
+        Assert.Equal(2, bridge.ListCommandsCallCount);
+    }
+
+    [Fact]
+    public async Task EnsureCommandCatalogAsync_DisconnectDuringFetch_DiscardsLateResult()
+    {
+        var (bridge, provider, _, _) = CreateProvider(new[] { MainSession() });
+
+        // Gate the fetch so we can disconnect while it is in flight.
+        var release = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        bridge.ListCommandsBehavior = async _ =>
+        {
+            await release.Task;
+            return new CommandCatalog
+            {
+                IsSupported = true,
+                Commands = new[] { new GatewayCommand { Name = "stale", NativeName = "/stale" } }
+            };
+        };
+        await provider.LoadAsync();
+        bridge.RaiseStatus(ConnectionStatus.Connected);
+
+        var fetch = provider.EnsureCommandCatalogAsync();
+
+        // Disconnect while the fetch is still awaiting — this bumps the epoch.
+        bridge.RaiseStatus(ConnectionStatus.Disconnected);
+
+        // Now let the in-flight fetch complete; its result must be discarded.
+        release.SetResult(true);
+        await fetch;
+
+        var snapshots2 = new List<ChatDataSnapshot>();
+        provider.Changed += (_, e) => snapshots2.Add(e.Snapshot);
+        // Reconnect and fetch fresh — the stale "/stale" catalog must not appear.
+        bridge.ListCommandsBehavior = null;
+        bridge.CommandCatalogResult = new CommandCatalog
+        {
+            IsSupported = true,
+            Commands = new[] { new GatewayCommand { Name = "fresh", NativeName = "/fresh" } }
+        };
+        bridge.RaiseStatus(ConnectionStatus.Connected);
+        await provider.EnsureCommandCatalogAsync();
+
+        var snap = snapshots2[^1];
+        Assert.NotNull(snap.AvailableCommands);
+        Assert.Single(snap.AvailableCommands!);
+        Assert.Equal("fresh", snap.AvailableCommands![0].Name);
+    }
+
+    [Fact]
+    public async Task EnsureCommandCatalogAsync_DisconnectBeforeDelivery_DropsStaleCommandSnapshot()
+    {
+        var bridge = new FakeBridge
+        {
+            Sessions = new[] { MainSession() },
+            CurrentStatus = ConnectionStatus.Connected,
+            CommandCatalogResult = new CommandCatalog
+            {
+                IsSupported = true,
+                Commands = new[] { new GatewayCommand { Name = "stale", NativeName = "/stale" } }
+            }
+        };
+        // Manually-pumped post queue so we can interleave a disconnect between
+        // the commands.list snapshot's marshaled delivery being enqueued and run.
+        var queued = new List<Action>();
+        var provider = new OpenClawChatDataProvider(bridge, post: a => queued.Add(a));
+        var delivered = new List<ChatDataSnapshot>();
+        provider.Changed += (_, e) => delivered.Add(e.Snapshot);
+
+        await provider.LoadAsync();
+        bridge.RaiseStatus(ConnectionStatus.Connected);
+
+        await provider.EnsureCommandCatalogAsync(); // enqueues the command-catalog delivery
+
+        // Disconnect runs and is itself enqueued; drain the queue in order. The
+        // command-catalog delivery re-checks the epoch and, finding it bumped by
+        // the disconnect, drops itself — so the last delivered snapshot reflects
+        // the disconnect (no stale commands), not "connected + /stale".
+        bridge.RaiseStatus(ConnectionStatus.Disconnected);
+        foreach (var action in queued.ToArray())
+            action();
+
+        Assert.NotEmpty(delivered);
+        // The command-catalog delivery re-checks the epoch (bumped by the
+        // disconnect) and drops itself, so no delivered snapshot ever surfaces
+        // the now-stale command — regardless of marshaled delivery ordering.
+        Assert.DoesNotContain(delivered, s =>
+            s.AvailableCommands is { Count: > 0 } cmds && cmds.Any(c => c.Name == "stale"));
+        var last = delivered[^1];
+        Assert.True(last.AvailableCommands is null || last.AvailableCommands.Count == 0,
+            "A stale connected+commands snapshot must not be delivered after disconnect.");
+
+        await provider.DisposeAsync();
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -31,6 +31,7 @@ public class OpenClawChatDataProviderTests
         public CommandCatalog CommandCatalogResult { get; set; } = new CommandCatalog { IsSupported = true };
         public Func<CommandCatalogQuery?, Task<CommandCatalog>>? ListCommandsBehavior { get; set; }
         public int ListCommandsCallCount { get; private set; }
+        public CommandCatalogQuery? LastListCommandsQuery { get; private set; }
 
         public SessionInfo[] GetSessionList() => Sessions;
         public ModelsListInfo? GetCurrentModelsList() => CurrentModels;
@@ -39,6 +40,7 @@ public class OpenClawChatDataProviderTests
         public Task<CommandCatalog> ListCommandsAsync(CommandCatalogQuery? query = null)
         {
             ListCommandsCallCount++;
+            LastListCommandsQuery = query;
             return ListCommandsBehavior?.Invoke(query) ?? Task.FromResult(CommandCatalogResult);
         }
 
@@ -2039,6 +2041,39 @@ public class OpenClawChatDataProviderTests
         Assert.NotNull(snap.AvailableCommands);
         Assert.Equal(2, snap.AvailableCommands!.Count);
         Assert.Contains(snap.AvailableCommands, c => c.Name == "clear");
+    }
+
+    [Fact]
+    public async Task EnsureCommandCatalogAsync_RequestsTextScopeAndExcludesNativeOnlyCommands()
+    {
+        var (bridge, provider, snapshots, _) = CreateProvider(new[] { MainSession() });
+        var mixedCatalog = new CommandCatalog
+        {
+            IsSupported = true,
+            Commands = new[]
+            {
+                new GatewayCommand { Name = "open-native-panel", NativeName = "open-native-panel", Scope = "native" },
+                new GatewayCommand { Name = "review", NativeName = "/review", Scope = "text" },
+                new GatewayCommand { Name = "model", NativeName = "/model", Scope = "both" },
+            }
+        };
+        bridge.ListCommandsBehavior = query => Task.FromResult(new CommandCatalog
+        {
+            IsSupported = mixedCatalog.IsSupported,
+            Commands = mixedCatalog.Commands.Where(c => query?.Matches(c) ?? true).ToArray(),
+        });
+        await provider.LoadAsync();
+        bridge.RaiseStatus(ConnectionStatus.Connected);
+        snapshots.Clear();
+
+        await provider.EnsureCommandCatalogAsync();
+
+        Assert.NotNull(bridge.LastListCommandsQuery);
+        Assert.Equal("text", bridge.LastListCommandsQuery!.Scope);
+        var commands = snapshots[^1].AvailableCommands!;
+        Assert.DoesNotContain(commands, c => c.Name == "open-native-panel");
+        Assert.Contains(commands, c => c.Name == "review");
+        Assert.Contains(commands, c => c.Name == "model");
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ToolMetaCacheTests.cs
@@ -363,6 +363,7 @@ public class ToolMetaCacheTests
         public SessionInfo[] GetSessionList() => Array.Empty<SessionInfo>();
         public ModelsListInfo? GetCurrentModelsList() => null;
         public void StartProactiveBootstrap() { }
+        public Task<CommandCatalog> ListCommandsAsync(CommandCatalogQuery? query = null) => Task.FromResult(new CommandCatalog { IsSupported = true });
         public Task SendChatMessageAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null) => Task.CompletedTask;
         public Task<ChatSendResult> SendChatMessageForRunAsync(string message, string? sessionKey, string? sessionId, IReadOnlyList<ChatAttachment>? attachments = null) => Task.FromResult(new ChatSendResult());
         public Task PatchSessionModelAsync(string sessionKey, string model) => Task.CompletedTask;


### PR DESCRIPTION
## Summary

- **Problem:** Windows chat had only hard-coded footer controls and a local/static app command palette — no discoverable gateway command search/autocomplete, unlike the Mac/main Control UI command surface.
- **Why it matters:** Mac/main parity gap. Users on Windows couldn't discover or invoke the gateway's `commands.list` catalog (native/text/skill/plugin commands, categories, args, choices) from chat.
- **What changed:** Added an inline, `/`-triggered floating command menu in the composer backed by the committed protocol-foundation `commands.list` DTOs/APIs (no duplicated protocol models). Includes search, categorized/relevance-ranked results, a Mac-style arg-choice follow-up picker, and full keyboard control.
- **User impact:** Type `/` in chat to discover and insert gateway commands, with argument-choice assistance — comparable to Mac/web.
- **What did NOT change (scope boundary):** No protocol/DTO changes (uses the committed foundation). Existing composer behavior (send, attachments, voice, Shift+Enter newline) is intact. No gateway/pairing/permissions/node changes.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs / instructions
- [x] Tests / validation
- [ ] Security hardening
- [ ] Chore / infra

## Scope (select all touched areas)

- [x] Tray / WinUI UX
- [ ] Windows node capability
- [ ] Local MCP / `winnode`
- [ ] Gateway / connection / pairing
- [ ] Setup / onboarding
- [ ] Permissions / privacy / security
- [x] Tests / CI / docs

## Linked Issue/PR

- Closes #
- Related # (Mac/main parity audit — PR lane 2)
- [ ] Related to a bug or regression

## Validation

`OPENCLAW_REPO_ROOT` set to the worktree per AGENTS.md. Baseline + after-change:

- `./build.ps1` — ✅ all 5 projects (Shared, Cli, WinNodeCli, SetupEngine, WinUI)
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj` — ✅ **Passed: 2659, Failed: 0, Skipped: 31**
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj` — ✅ **Passed: 1443, Failed: 0, Skipped: 0**
- Focused ClawSweeper fix: dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --filter EnsureCommandCatalogAsync_Exception_PublishesUnsupportedFallback — ✅ **Passed: 1, Failed: 0**

New/updated tests: `tests/OpenClaw.Shared.Tests/CommandCatalogPresentationTests.cs` (presentation helpers + ranked search), `tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs` (catalog fetch/cache/in-flight/epoch, failure fallback, and text-scope filtering).

## Real behavior proof

- **Environment tested:** Windows ARM64, .NET 10.0.301, local non-isolated run (`run-app-local.ps1 -AllowNonMain`).
- **PR head / commit tested:** `67da8055` (branch `bkudiess-chat-command-catalog`).
- **Exact steps or command run:** Built + launched the tray app; in chat composer typed `/` (full menu), typed `/mo` (filtered/relevance), selected a command with static first-arg choices (arg-choice picker), and exercised ↑/↓/Enter/Tab/Esc in both modes.
- **Evidence after fix:** `/` opens a floating opaque elevated popup over the composer with name-mapped Fluent icons, `/name`, inline arg templates, descriptions and `N options` badges; selecting a choice-bearing command transitions the same popup into an arg-choice picker that fills `/name value`.
- **Observed result:** Discovery + insertion + arg-choice flow behave as designed; loading/unsupported/disconnected states render correctly; on gateways without `commands.list` the menu stays inert and `/text` is ordinary input.
- **Product/UX decision:** Windows intentionally adopts the Mac/main default `/` autocomplete behavior on command-capable gateways; unmatched `/text` remains ordinary input after catalog load, and unsupported gateways stay inert.
- **Screenshot/artifact links verified?** `Yes` — current-head screenshots are embedded below and show the slash command menu / argument picker surface.
- **Not verified / blocked:** N/A
<img width="1038" height="648" alt="image" src="https://github.com/user-attachments/assets/be93d057-11c2-4d21-a17a-e0d253c754fc" />

<img width="1242" height="802" alt="image" src="https://github.com/user-attachments/assets/dc4586fb-9437-4ff7-a3d2-12d6fa1fffce" />

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — uses the existing `commands.list` gateway API via the committed protocol client; no new endpoints.
- Command/tool execution surface changed? `No` — the menu only inserts text into the composer; it never auto-sends or auto-executes. The user still presses Send.
- Data access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes` — additive UI; gracefully no-ops on gateways without `commands.list`.
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only conversations that still need reviewer or maintainer judgment.

🤖 Generated with [Copilot CLI](https://github.com/github/copilot-cli)