### PR TITLE
Improve Node capability summary UX

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Helpers/WrapPanel.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/WrapPanel.cs
@@ -1,0 +1,74 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Windows.Foundation;
+
+namespace OpenClawTray.Helpers;
+
+/// <summary>
+/// Minimal left-to-right wrapping panel for compact chip rows.
+/// </summary>
+public sealed class WrapPanel : Panel
+{
+    public double HorizontalSpacing { get; set; }
+
+    public double VerticalSpacing { get; set; }
+
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        var available = double.IsInfinity(availableSize.Width)
+            ? double.PositiveInfinity
+            : availableSize.Width;
+
+        double lineWidth = 0, lineHeight = 0, totalHeight = 0, maxWidth = 0;
+
+        foreach (var child in Children)
+        {
+            child.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+            var size = child.DesiredSize;
+
+            if (lineWidth > 0 && lineWidth + HorizontalSpacing + size.Width > available)
+            {
+                totalHeight += lineHeight + VerticalSpacing;
+                maxWidth = Math.Max(maxWidth, lineWidth);
+                lineWidth = size.Width;
+                lineHeight = size.Height;
+            }
+            else
+            {
+                lineWidth += (lineWidth > 0 ? HorizontalSpacing : 0) + size.Width;
+                lineHeight = Math.Max(lineHeight, size.Height);
+            }
+        }
+
+        totalHeight += lineHeight;
+        maxWidth = Math.Max(maxWidth, lineWidth);
+
+        return new Size(
+            double.IsInfinity(available) ? maxWidth : Math.Min(maxWidth, available),
+            totalHeight);
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        double x = 0, y = 0, lineHeight = 0;
+
+        foreach (var child in Children)
+        {
+            var size = child.DesiredSize;
+
+            if (x > 0 && x + size.Width > finalSize.Width)
+            {
+                x = 0;
+                y += lineHeight + VerticalSpacing;
+                lineHeight = 0;
+            }
+
+            child.Arrange(new Rect(x, y, size.Width, size.Height));
+            x += size.Width + HorizontalSpacing;
+            lineHeight = Math.Max(lineHeight, size.Height);
+        }
+
+        return finalSize;
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
@@ -410,30 +410,52 @@
                                       Glyph="{x:Bind helpers:FluentIconCatalog.StatusOk, Mode=OneTime}"
                                       FontSize="14"
                                       Foreground="{ThemeResource SystemFillColorNeutralBrush}"
-                                      VerticalAlignment="Center" HorizontalAlignment="Center"
+                                      VerticalAlignment="Top" HorizontalAlignment="Center"
+                                      Margin="0,2,0,0"
                                       AutomationProperties.AccessibilityView="Raw"/>
-                            <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
+                            <StackPanel Grid.Column="1" Spacing="2">
                                 <TextBlock x:Uid="ConnectionPage_NodeModeDisabled" x:Name="NodeStatusText"
                                            Text="Node mode disabled"
                                            Style="{StaticResource BodyTextBlockStyle}"/>
-                                <!-- Canonical capability list per design naming.md:
-                                     "Providing N capabilities: browser, camera, …"
-                                     Replaces the prior chip strip. -->
+                                <!-- MCP-only reachability line. Active node uses pills below. -->
                                 <TextBlock x:Name="NodeCapabilityText"
                                            Style="{StaticResource CaptionTextBlockStyle}"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                            TextWrapping="Wrap"
                                            Visibility="Collapsed"/>
-                                <TextBlock x:Name="NodeCommandText"
-                                           Style="{StaticResource CaptionTextBlockStyle}"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                           TextWrapping="Wrap"
-                                           Visibility="Collapsed"/>
-                                <TextBlock x:Name="NodePermissionText"
-                                           Style="{StaticResource CaptionTextBlockStyle}"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                           TextWrapping="Wrap"
-                                           Visibility="Collapsed"/>
+                                <Border x:Name="NodeCapabilityPillsHost"
+                                        Margin="0,2,0,0"
+                                        Visibility="Collapsed"/>
+                                <Expander x:Name="NodeTechnicalDetailsExpander"
+                                          Margin="0,6,0,0"
+                                          HorizontalAlignment="Stretch"
+                                          HorizontalContentAlignment="Stretch"
+                                          IsExpanded="False"
+                                          Visibility="Collapsed">
+                                    <Expander.Header>
+                                        <TextBlock x:Uid="ConnectionPage_NodeTechnicalDetails" Text="Show technical details"
+                                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                   VerticalAlignment="Center"/>
+                                    </Expander.Header>
+                                    <StackPanel Spacing="6" Padding="0,4,0,0">
+                                        <TextBlock x:Name="NodeTechCapabilityText"
+                                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                   IsTextSelectionEnabled="True"
+                                                   TextWrapping="Wrap"/>
+                                        <TextBlock x:Name="NodeTechCommandText"
+                                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                   IsTextSelectionEnabled="True"
+                                                   TextWrapping="Wrap"/>
+                                        <TextBlock x:Name="NodeTechPermissionText"
+                                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                   IsTextSelectionEnabled="True"
+                                                   TextWrapping="Wrap"/>
+                                    </StackPanel>
+                                </Expander>
                                 <StackPanel x:Name="NodePendingDeclarationsPanel"
                                             Spacing="2"
                                             Visibility="Collapsed">
@@ -518,15 +540,6 @@
                                 Style="{StaticResource AccentButtonStyle}"
                                 Margin="0,4,0,0"
                                 AutomationProperties.AutomationId="NodeReconnect"/>
-
-                        <!-- Capability chips removed in favor of NodeCapabilityText
-                             above. Element kept for back-compat with code-behind
-                             that may still reference it (currently inert). -->
-                        <ItemsRepeater x:Name="NodeCapabilityChipsHost" Visibility="Collapsed">
-                            <ItemsRepeater.Layout>
-                                <StackLayout Orientation="Horizontal" Spacing="6"/>
-                            </ItemsRepeater.Layout>
-                        </ItemsRepeater>
 
                         <!-- Deep link to per-capability config -->
                         <StackPanel x:Name="NodeDeepLinks" Orientation="Horizontal" Spacing="12">

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -1288,6 +1288,7 @@ public sealed partial class ConnectionPage : Page
         AutomationProperties.SetAccessibilityView(capabilityIcon, AccessibilityView.Raw);
         content.Children.Add(capabilityIcon);
 
+        var stateText = LocalizationHelper.GetString(stateKey);
         var labelText = new TextBlock
         {
             Text = label,
@@ -1295,7 +1296,7 @@ public sealed partial class ConnectionPage : Page
             Foreground = textBrush,
             VerticalAlignment = VerticalAlignment.Center,
         };
-        AutomationProperties.SetAccessibilityView(labelText, AccessibilityView.Raw);
+        AutomationProperties.SetName(labelText, $"{label} — {stateText}");
         content.Children.Add(labelText);
 
         if (stateGlyph != null)
@@ -1312,7 +1313,6 @@ public sealed partial class ConnectionPage : Page
             content.Children.Add(stateIcon);
         }
 
-        var stateText = LocalizationHelper.GetString(stateKey);
         var pill = new Border
         {
             CornerRadius = new CornerRadius(12),
@@ -1320,7 +1320,6 @@ public sealed partial class ConnectionPage : Page
             Background = fillBrush,
             Child = content,
         };
-        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(pill, $"{label} — {stateText}");
         ToolTipService.SetToolTip(pill, stateText);
         return pill;
     }

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -1,5 +1,8 @@
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Media;
 using OpenClaw.Connection;
 using OpenClaw.Shared;
@@ -35,6 +38,7 @@ public sealed partial class ConnectionPage : Page
     private IGatewayConnectionManager? _connectionManager;
     private GatewayRegistry? _gatewayRegistry;
     private GatewayDiscoveryService? _discoveryService;
+    private global::Windows.UI.ViewManagement.AccessibilitySettings? _accessibilitySettings;
     private IGatewayTerminalLauncher? _terminalLauncher;
     private WslGatewayController? _wslGatewayController;
 
@@ -79,14 +83,11 @@ public sealed partial class ConnectionPage : Page
     private bool _maskHasObservedTransient;
 
     // ─── Fingerprint caches ───
-    // ItemsSource swaps re-template every item even when the content is
-    // identical, which causes a visible flash on every snapshot tick.
-    // We stash a string fingerprint of the inputs and skip the swap when
-    // the rendered output would be identical. Keeps the page calm during
-    // the rapid-fire snapshot transitions a Node-mode toggle produces.
+    // Rebuilding rows/chips on every snapshot tick causes visible churn.
+    // Fingerprints let us update only when the rendered inputs change.
     private string? _savedGatewaysFingerprint;
     private string? _glanceChipsFingerprint;
-    private string? _capabilityChipsFingerprint;
+    private string? _capabilityPillsFingerprint;
 
     public ConnectionPage()
     {
@@ -125,6 +126,8 @@ public sealed partial class ConnectionPage : Page
         if (_gatewayRegistry != null)
             _gatewayRegistry.Changed += OnRegistryChanged;
 
+        ActualThemeChanged += OnPageActualThemeChanged;
+        TrySubscribeAccessibilitySettings();
         Unloaded += OnPageUnloaded;
 
         // Initialize Node mode toggle from settings (suppressed event)
@@ -168,6 +171,12 @@ public sealed partial class ConnectionPage : Page
             _connectionManager.StateChanged -= OnManagerStateChanged;
         if (_gatewayRegistry != null)
             _gatewayRegistry.Changed -= OnRegistryChanged;
+        ActualThemeChanged -= OnPageActualThemeChanged;
+        if (_accessibilitySettings != null)
+        {
+            _accessibilitySettings.HighContrastChanged -= OnHighContrastChanged;
+            _accessibilitySettings = null;
+        }
         _discoveryService?.Dispose();
         _discoveryService = null;
         if (_reconnectMaskTimer != null)
@@ -184,6 +193,38 @@ public sealed partial class ConnectionPage : Page
         }
         _gatewayHostActionInProgress = false;
         if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
+    }
+
+    private void OnPageActualThemeChanged(FrameworkElement sender, object args)
+    {
+        RefreshAfterThemeVisualChange();
+    }
+
+    private void OnHighContrastChanged(
+        global::Windows.UI.ViewManagement.AccessibilitySettings sender,
+        object args)
+    {
+        DispatcherQueue?.TryEnqueue(RefreshAfterThemeVisualChange);
+    }
+
+    private void RefreshAfterThemeVisualChange()
+    {
+        _capabilityPillsFingerprint = null;
+        RefreshFromSnapshot(_lastSnapshot);
+    }
+
+    private void TrySubscribeAccessibilitySettings()
+    {
+        try
+        {
+            _accessibilitySettings = new global::Windows.UI.ViewManagement.AccessibilitySettings();
+            _accessibilitySettings.HighContrastChanged += OnHighContrastChanged;
+        }
+        catch (Exception ex)
+        {
+            Services.Logger.Warn($"[ConnectionPage] Could not subscribe to High Contrast changes: {ex.Message}");
+            _accessibilitySettings = null;
+        }
     }
 
     private void OnManagerStateChanged(object? sender, GatewayConnectionSnapshot snapshot)
@@ -860,8 +901,8 @@ public sealed partial class ConnectionPage : Page
             NodeCapabilityText.Visibility = Visibility.Visible;
             NodeCapabilityText.Text = LocalizationHelper.Format(
                 "ConnectionPage_NodeMcpOnlyReachable", NodeService.McpServerUrl);
-            NodeCommandText.Visibility = Visibility.Collapsed;
-            NodePermissionText.Visibility = Visibility.Collapsed;
+            NodeCapabilityPillsHost.Visibility = Visibility.Collapsed;
+            NodeTechnicalDetailsExpander.Visibility = Visibility.Collapsed;
             NodePendingDeclarationsPanel.Visibility = Visibility.Collapsed;
 
             var mcpError = CurrentApp.ActiveNodeService?.McpStartupError;
@@ -884,20 +925,55 @@ public sealed partial class ConnectionPage : Page
             bool showSurfaces = settings != null && plan.NodeCard != NodeCardState.Off
                                                  && plan.NodeCard != NodeCardState.Hidden
                                                  && plan.NodeCard != NodeCardState.OnNodeConnecting;
-            NodeCapabilityText.Visibility = showSurfaces ? Visibility.Visible : Visibility.Collapsed;
-            NodeCommandText.Visibility = showSurfaces ? Visibility.Visible : Visibility.Collapsed;
-            NodePermissionText.Visibility = showSurfaces ? Visibility.Visible : Visibility.Collapsed;
+
+            NodeCapabilityText.Visibility = Visibility.Collapsed;
+
+            if (showSurfaces && settings is not null)
+            {
+                var pillFp = BuildCapabilityPillFingerprint(
+                    plan.NodeCard,
+                    plan.NodeEffectiveCapabilities,
+                    plan.NodePendingDeclaredCapabilities,
+                    settings);
+                if (_capabilityPillsFingerprint != pillFp)
+                {
+                    _capabilityPillsFingerprint = pillFp;
+                    NodeCapabilityPillsHost.Child = BuildCapabilityPills(
+                        plan.NodeEffectiveCapabilities,
+                        plan.NodePendingDeclaredCapabilities,
+                        settings);
+                }
+
+                NodeCapabilityPillsHost.Visibility =
+                    NodeCapabilityPillsHost.Child is WrapPanel { Children.Count: > 0 }
+                        ? Visibility.Visible
+                        : Visibility.Collapsed;
+            }
+            else
+            {
+                NodeCapabilityPillsHost.Visibility = Visibility.Collapsed;
+                _capabilityPillsFingerprint = null;
+            }
+
+            bool hasTechnicalSurfaces = plan.NodeEffectiveCapabilities.Count > 0
+                                     || plan.NodeEffectiveCommands.Count > 0
+                                     || plan.NodeEffectivePermissions.Count > 0;
+            NodeTechnicalDetailsExpander.Visibility =
+                showSurfaces && hasTechnicalSurfaces ? Visibility.Visible : Visibility.Collapsed;
+            if (NodeTechnicalDetailsExpander.Visibility == Visibility.Collapsed)
+                NodeTechnicalDetailsExpander.IsExpanded = false;
+
             if (showSurfaces)
             {
-                NodeCapabilityText.Text = BuildNodeSurfaceListString(
+                SetSurfaceInlines(NodeTechCapabilityText,
                     "ConnectionPage_NodeEffectiveCapabilities",
-                    plan.NodeEffectiveCapabilities);
-                NodeCommandText.Text = BuildNodeSurfaceListString(
+                    FormatSurfaceList(plan.NodeEffectiveCapabilities));
+                SetSurfaceInlines(NodeTechCommandText,
                     "ConnectionPage_NodeEffectiveCommands",
-                    plan.NodeEffectiveCommands);
-                NodePermissionText.Text = BuildNodePermissionListString(
+                    FormatSurfaceList(plan.NodeEffectiveCommands));
+                SetSurfaceInlines(NodeTechPermissionText,
                     "ConnectionPage_NodeEffectivePermissions",
-                    plan.NodeEffectivePermissions);
+                    FormatPermissionList(plan.NodeEffectivePermissions));
             }
 
             var showPendingDeclarations = showSurfaces &&
@@ -976,22 +1052,6 @@ public sealed partial class ConnectionPage : Page
         else
         {
             NodeReconnectButton.Visibility = Visibility.Collapsed;
-        }
-
-        // Capability chips — skip the rebuild if the rendered output would
-        // be identical. Fingerprint includes the full capability list from
-        // the gateway (same source as tray/instances) so new capabilities
-        // trigger a rebuild automatically.
-        var capNames = string.Join(
-            ",",
-            plan.NodeEffectiveCapabilities.OrderBy(c => c, StringComparer.OrdinalIgnoreCase));
-        var capFp = $"{plan.NodeCard}|{capNames}";
-        if (_capabilityChipsFingerprint != capFp)
-        {
-            _capabilityChipsFingerprint = capFp;
-            NodeCapabilityChipsHost.ItemsSource = BuildCapabilityChips(
-                plan.NodeEffectiveCapabilities,
-                plan.NodeCard);
         }
 
         // Permissions link is always visible (entry point even when sharing is off);
@@ -1120,79 +1180,198 @@ public sealed partial class ConnectionPage : Page
         return new Border { Child = grid };
     }
 
-    private List<Border> BuildCapabilityChips(IReadOnlyList<string>? capabilities, NodeCardState state)
+    private enum CapabilityPillState { Active, Pending, Off }
+
+    private WrapPanel BuildCapabilityPills(
+        IReadOnlyList<string> effective,
+        IReadOnlyList<string> pendingDeclared,
+        SettingsManager settings)
     {
-        var chips = new List<Border>();
-        if (capabilities == null || capabilities.Count == 0) return chips;
-        if (state == NodeCardState.Off || state == NodeCardState.Hidden
-            || state == NodeCardState.OffMcpOnly || state == NodeCardState.OnNodeConnecting)
-            return chips;
+        var panel = new WrapPanel { HorizontalSpacing = 6, VerticalSpacing = 6 };
+        var effectiveSet = new HashSet<string>(
+            effective.Where(c => !string.IsNullOrWhiteSpace(c)),
+            StringComparer.OrdinalIgnoreCase);
+        var pendingSet = new HashSet<string>(
+            pendingDeclared.Where(c => !string.IsNullOrWhiteSpace(c)),
+            StringComparer.OrdinalIgnoreCase);
+        var isHighContrast = IsHighContrastEnabled();
 
-        void Add(string label, bool enabled, bool warn = false, bool error = false)
+        var canonical = new (string Name, string LabelKey, string Glyph, bool Enabled)[]
         {
-            string bgKey;
-            string fgKey;
-            string glyph;
-            if (error)
-            {
-                bgKey = "SystemFillColorCriticalBackgroundBrush";
-                fgKey = "SystemFillColorCriticalBrush";
-                glyph = Helpers.FluentIconCatalog.StatusErr;
-            }
-            else if (warn)
-            {
-                bgKey = "SystemFillColorCautionBackgroundBrush";
-                fgKey = "SystemFillColorCautionBrush";
-                glyph = Helpers.FluentIconCatalog.StatusWarn;
-            }
-            else if (enabled)
-            {
-                bgKey = "SystemFillColorSuccessBackgroundBrush";
-                fgKey = "SystemFillColorSuccessBrush";
-                glyph = Helpers.FluentIconCatalog.StatusOk;
-            }
-            else
-            {
-                bgKey = "SubtleFillColorSecondaryBrush";
-                fgKey = "TextFillColorSecondaryBrush";
-                glyph = Helpers.FluentIconCatalog.CapabilityOff;
-            }
+            ("browser",  "PermissionsPage_Cap_Browser_Label",  FluentIconCatalog.Browser,  settings.NodeBrowserProxyEnabled),
+            ("camera",   "PermissionsPage_Cap_Camera_Label",   FluentIconCatalog.Camera,   settings.NodeCameraEnabled),
+            ("canvas",   "PermissionsPage_Cap_Canvas_Label",   FluentIconCatalog.Canvas,   settings.NodeCanvasEnabled),
+            ("screen",   "PermissionsPage_Cap_Screen_Label",   FluentIconCatalog.Screen,   settings.NodeScreenEnabled),
+            ("location", "PermissionsPage_Cap_Location_Label", FluentIconCatalog.Location, settings.NodeLocationEnabled),
+            ("tts",      "PermissionsPage_Cap_Tts_Label",      FluentIconCatalog.Voice,    settings.NodeTtsEnabled),
+            ("stt",      "PermissionsPage_Cap_Stt_Label",      FluentIconCatalog.Speech,   settings.NodeSttEnabled),
+        };
 
-            var stack = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 4 };
-            stack.Children.Add(new FontIcon
-            {
-                Glyph = glyph,
-                FontSize = 11,
-                Foreground = ResolveBrush(fgKey),
-                VerticalAlignment = VerticalAlignment.Center,
-            });
-            stack.Children.Add(new TextBlock
-            {
-                Text = label,
-                FontSize = 11,
-                Foreground = ResolveBrush(fgKey),
-                VerticalAlignment = VerticalAlignment.Center,
-            });
-            chips.Add(new Border
-            {
-                CornerRadius = new CornerRadius(4),
-                Padding = new Thickness(6, 2, 6, 2),
-                Background = ResolveBrush(bgKey),
-                Child = stack,
-            });
+        var shown = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (name, labelKey, glyph, enabled) in canonical)
+        {
+            var state = effectiveSet.Contains(name)
+                ? CapabilityPillState.Active
+                : (pendingSet.Contains(name) || enabled)
+                    ? CapabilityPillState.Pending
+                    : CapabilityPillState.Off;
+            panel.Children.Add(MakeCapabilityPill(LocalizationHelper.GetString(labelKey), glyph, state, isHighContrast));
+            shown.Add(name);
         }
 
-        // Render a chip for each capability reported by the gateway —
-        // same source as tray menu and instances page.
-        foreach (var cap in capabilities)
+        var extras = effective.Select(c => (Name: c, State: CapabilityPillState.Active))
+            .Concat(pendingDeclared.Select(c => (Name: c, State: CapabilityPillState.Pending)))
+            .Where(x => !string.IsNullOrWhiteSpace(x.Name) && !shown.Contains(x.Name));
+        foreach (var (name, state) in extras)
         {
-            if (string.IsNullOrEmpty(cap)) continue;
-            // Capitalize first letter for display (e.g. "browser" → "Browser")
-            var label = char.ToUpperInvariant(cap[0]) + cap[1..];
-            Add(label, enabled: true);
+            if (!shown.Add(name)) continue;
+            var (label, glyph) = name.Trim().ToLowerInvariant() switch
+            {
+                "device" => (LocalizationHelper.GetString("ConnectionPage_NodeCap_Device"), FluentIconCatalog.Devices),
+                "system" => (LocalizationHelper.GetString("ConnectionPage_NodeCap_System"), FluentIconCatalog.System),
+                _ => (HumanizeNodeToken(name), FluentIconCatalog.System),
+            };
+            panel.Children.Add(MakeCapabilityPill(label, glyph, state, isHighContrast));
         }
 
-        return chips;
+        return panel;
+    }
+
+    private const double CapabilityPillFillOpacity = 0.14;
+
+    private Border MakeCapabilityPill(string label, string glyph, CapabilityPillState state, bool isHighContrast)
+    {
+        var (fillBrush, iconBrush, textBrush, stateKey, stateGlyph) = state switch
+        {
+            CapabilityPillState.Active => (
+                TintBrush(
+                    "SystemFillColorSuccessBrush",
+                    "SystemFillColorSuccessBackgroundBrush",
+                    CapabilityPillFillOpacity,
+                    isHighContrast),
+                ResolveBrush("SystemFillColorSuccessBrush"),
+                ResolveBrush("SystemFillColorSuccessBrush"),
+                "ConnectionPage_NodePillState_Active",
+                null),
+            CapabilityPillState.Pending => (
+                TintBrush(
+                    "SystemFillColorCautionBrush",
+                    "SystemFillColorCautionBackgroundBrush",
+                    CapabilityPillFillOpacity,
+                    isHighContrast),
+                ResolveBrush("SystemFillColorCautionBrush"),
+                ResolveBrush("SystemFillColorCautionBrush"),
+                "ConnectionPage_NodePillState_Pending",
+                FluentIconCatalog.StatusWarn),
+            _ => (
+                ResolveBrush("SubtleFillColorTertiaryBrush"),
+                ResolveBrush("TextFillColorTertiaryBrush"),
+                ResolveBrush("TextFillColorSecondaryBrush"),
+                "ConnectionPage_NodePillState_Off",
+                null),
+        };
+
+        var content = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 5,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        var capabilityIcon = new FontIcon
+        {
+            Glyph = glyph,
+            FontSize = 12,
+            Foreground = iconBrush,
+            VerticalAlignment = VerticalAlignment.Center,
+            IsTextScaleFactorEnabled = false,
+        };
+        AutomationProperties.SetAccessibilityView(capabilityIcon, AccessibilityView.Raw);
+        content.Children.Add(capabilityIcon);
+
+        var labelText = new TextBlock
+        {
+            Text = label,
+            FontSize = 12,
+            Foreground = textBrush,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        AutomationProperties.SetAccessibilityView(labelText, AccessibilityView.Raw);
+        content.Children.Add(labelText);
+
+        if (stateGlyph != null)
+        {
+            var stateIcon = new FontIcon
+            {
+                Glyph = stateGlyph,
+                FontSize = 10,
+                Foreground = textBrush,
+                VerticalAlignment = VerticalAlignment.Center,
+                IsTextScaleFactorEnabled = false,
+            };
+            AutomationProperties.SetAccessibilityView(stateIcon, AccessibilityView.Raw);
+            content.Children.Add(stateIcon);
+        }
+
+        var stateText = LocalizationHelper.GetString(stateKey);
+        var pill = new Border
+        {
+            CornerRadius = new CornerRadius(12),
+            Padding = new Thickness(8, 3, 11, 3),
+            Background = fillBrush,
+            Child = content,
+        };
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(pill, $"{label} — {stateText}");
+        ToolTipService.SetToolTip(pill, stateText);
+        return pill;
+    }
+
+    private Brush TintBrush(string colorKey, string highContrastBrushKey, double opacity, bool isHighContrast)
+    {
+        if (isHighContrast)
+            return ResolveBrush(highContrastBrushKey);
+
+        var color = ResolveBrush(colorKey) is SolidColorBrush scb
+            ? scb.Color
+            : ((SolidColorBrush)ResolveBrush("TextFillColorPrimaryBrush")).Color;
+        return new SolidColorBrush(color) { Opacity = opacity };
+    }
+
+    private bool IsHighContrastEnabled()
+    {
+        if (_accessibilitySettings is null)
+            return false;
+
+        try { return _accessibilitySettings.HighContrast; }
+        catch (Exception ex)
+        {
+            Services.Logger.Warn($"[ConnectionPage] Could not read High Contrast state: {ex.Message}");
+            return false;
+        }
+    }
+
+    private static string BuildCapabilityPillFingerprint(
+        NodeCardState state,
+        IReadOnlyList<string> effective,
+        IReadOnlyList<string> pendingDeclared,
+        SettingsManager settings)
+    {
+        var eff = string.Join(
+            ",",
+            effective.Where(c => !string.IsNullOrWhiteSpace(c))
+                     .OrderBy(c => c, StringComparer.OrdinalIgnoreCase));
+        var pend = string.Join(
+            ",",
+            pendingDeclared.Where(c => !string.IsNullOrWhiteSpace(c))
+                           .OrderBy(c => c, StringComparer.OrdinalIgnoreCase));
+        var toggles = string.Concat(
+            settings.NodeBrowserProxyEnabled ? '1' : '0',
+            settings.NodeCameraEnabled ? '1' : '0',
+            settings.NodeCanvasEnabled ? '1' : '0',
+            settings.NodeScreenEnabled ? '1' : '0',
+            settings.NodeLocationEnabled ? '1' : '0',
+            settings.NodeTtsEnabled ? '1' : '0',
+            settings.NodeSttEnabled ? '1' : '0');
+        return $"{state}|{eff}|{pend}|{toggles}";
     }
 
     /// <summary>
@@ -1202,26 +1381,44 @@ public sealed partial class ConnectionPage : Page
     private static string BuildNodeSurfaceListString(
         string resourceKey,
         IReadOnlyList<string> values)
-    {
-        var display = values.Count == 0
+        => LocalizationHelper.Format(resourceKey, FormatSurfaceList(values));
+
+    private static string FormatSurfaceList(IReadOnlyList<string> values)
+        => values.Count == 0
             ? LocalizationHelper.GetString("ConnectionPage_NodeSurfaceNone")
             : string.Join(", ", values);
-        return LocalizationHelper.Format(resourceKey, display);
-    }
 
     private static string BuildNodePermissionListString(
         string resourceKey,
         IReadOnlyDictionary<string, bool> permissions)
-    {
-        var display = permissions.Count == 0
+        => LocalizationHelper.Format(resourceKey, FormatPermissionList(permissions));
+
+    private static string FormatPermissionList(IReadOnlyDictionary<string, bool> permissions)
+        => permissions.Count == 0
             ? LocalizationHelper.GetString("ConnectionPage_NodeSurfaceNone")
             : string.Join(", ", permissions
                 .OrderBy(permission => permission.Key, StringComparer.OrdinalIgnoreCase)
                 .Select(permission =>
                     $"{permission.Key}={permission.Value.ToString().ToLowerInvariant()}"));
-        return LocalizationHelper.Format(resourceKey, display);
+
+    private static void SetSurfaceInlines(TextBlock target, string resourceKey, string value)
+    {
+        var format = LocalizationHelper.GetString(resourceKey);
+        var idx = format.IndexOf("{0}", StringComparison.Ordinal);
+        var label = idx >= 0 ? format[..idx] : format;
+        var suffix = idx >= 0 ? format[(idx + 3)..] : string.Empty;
+
+        target.Inlines.Clear();
+        target.Inlines.Add(new Run { Text = label, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold });
+        target.Inlines.Add(new Run { Text = value + suffix });
     }
 
+    private static string HumanizeNodeToken(string token)
+    {
+        var spaced = token.Trim().Replace('.', ' ').Replace('_', ' ');
+        if (spaced.Length == 0) return spaced;
+        return char.ToUpperInvariant(spaced[0]) + spaced[1..];
+    }
 
     private Brush ResolveBrush(string themeKey)
     {

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -6658,6 +6658,24 @@ Make sure the gateway is running.</value>
   <data name="ConnectionPage_NodeSurfaceNone" xml:space="preserve">
     <value>none</value>
   </data>
+  <data name="ConnectionPage_NodeTechnicalDetails.Text" xml:space="preserve">
+    <value>Show technical details</value>
+  </data>
+  <data name="ConnectionPage_NodePillState_Active" xml:space="preserve">
+    <value>Sharing now</value>
+  </data>
+  <data name="ConnectionPage_NodePillState_Pending" xml:space="preserve">
+    <value>Enabled, not active yet</value>
+  </data>
+  <data name="ConnectionPage_NodePillState_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="ConnectionPage_NodeCap_Device" xml:space="preserve">
+    <value>Device info</value>
+  </data>
+  <data name="ConnectionPage_NodeCap_System" xml:space="preserve">
+    <value>System access</value>
+  </data>
   <data name="ConnectionPage_NodeEffectiveCapabilities" xml:space="preserve">
     <value>Approved/effective capabilities: {0}</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -6659,6 +6659,24 @@ Le binaire wxc-exec est introuvable. {1} S'il s'agit d'une build développeur, c
   <data name="ConnectionPage_NodeSurfaceNone" xml:space="preserve">
     <value>none</value>
   </data>
+  <data name="ConnectionPage_NodeTechnicalDetails.Text" xml:space="preserve">
+    <value>Show technical details</value>
+  </data>
+  <data name="ConnectionPage_NodePillState_Active" xml:space="preserve">
+    <value>Sharing now</value>
+  </data>
+  <data name="ConnectionPage_NodePillState_Pending" xml:space="preserve">
+    <value>Enabled, not active yet</value>
+  </data>
+  <data name="ConnectionPage_NodePillState_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="ConnectionPage_NodeCap_Device" xml:space="preserve">
+    <value>Device info</value>
+  </data>
+  <data name="ConnectionPage_NodeCap_System" xml:space="preserve">
+    <value>System access</value>
+  </data>
   <data name="ConnectionPage_NodeEffectiveCapabilities" xml:space="preserve">
     <value>Approved/effective capabilities: {0}</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -6660,6 +6660,24 @@ Het binaire bestand wxc-exec is niet gevonden. {1} Als dit een ontwikkelaarsbuil
   <data name="ConnectionPage_NodeSurfaceNone" xml:space="preserve">
     <value>none</value>
   </data>
+  <data name="ConnectionPage_NodeTechnicalDetails.Text" xml:space="preserve">
+    <value>Show technical details</value>
+  </data>
+  <data name="ConnectionPage_NodePillState_Active" xml:space="preserve">
+    <value>Sharing now</value>
+  </data>
+  <data name="ConnectionPage_NodePillState_Pending" xml:space="preserve">
+    <value>Enabled, not active yet</value>
+  </data>
+  <data name="ConnectionPage_NodePillState_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="ConnectionPage_NodeCap_Device" xml:space="preserve">
+    <value>Device info</value>
+  </data>
+  <data name="ConnectionPage_NodeCap_System" xml:space="preserve">
+    <value>System access</value>
+  </data>
   <data name="ConnectionPage_NodeEffectiveCapabilities" xml:space="preserve">
     <value>Approved/effective capabilities: {0}</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -6659,6 +6659,24 @@
   <data name="ConnectionPage_NodeSurfaceNone" xml:space="preserve">
     <value>none</value>
   </data>
+  <data name="ConnectionPage_NodeTechnicalDetails.Text" xml:space="preserve">
+    <value>Show technical details</value>
+  </data>
+  <data name="ConnectionPage_NodePillState_Active" xml:space="preserve">
+    <value>Sharing now</value>
+  </data>
+  <data name="ConnectionPage_NodePillState_Pending" xml:space="preserve">
+    <value>Enabled, not active yet</value>
+  </data>
+  <data name="ConnectionPage_NodePillState_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="ConnectionPage_NodeCap_Device" xml:space="preserve">
+    <value>Device info</value>
+  </data>
+  <data name="ConnectionPage_NodeCap_System" xml:space="preserve">
+    <value>System access</value>
+  </data>
   <data name="ConnectionPage_NodeEffectiveCapabilities" xml:space="preserve">
     <value>Approved/effective capabilities: {0}</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -6659,6 +6659,24 @@
   <data name="ConnectionPage_NodeSurfaceNone" xml:space="preserve">
     <value>none</value>
   </data>
+  <data name="ConnectionPage_NodeTechnicalDetails.Text" xml:space="preserve">
+    <value>Show technical details</value>
+  </data>
+  <data name="ConnectionPage_NodePillState_Active" xml:space="preserve">
+    <value>Sharing now</value>
+  </data>
+  <data name="ConnectionPage_NodePillState_Pending" xml:space="preserve">
+    <value>Enabled, not active yet</value>
+  </data>
+  <data name="ConnectionPage_NodePillState_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="ConnectionPage_NodeCap_Device" xml:space="preserve">
+    <value>Device info</value>
+  </data>
+  <data name="ConnectionPage_NodeCap_System" xml:space="preserve">
+    <value>System access</value>
+  </data>
   <data name="ConnectionPage_NodeEffectiveCapabilities" xml:space="preserve">
     <value>Approved/effective capabilities: {0}</value>
   </data>

--- a/tests/OpenClaw.Tray.Tests/ConnectionRegressionSourceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ConnectionRegressionSourceTests.cs
@@ -67,6 +67,18 @@ public sealed class ConnectionRegressionSourceTests
         Assert.Contains("AddSshHostBox.Text = \"\";", pageSource);
     }
 
+    [Fact]
+    public void NodeCapabilityPills_ExposeStateThroughReadableTextPeer()
+    {
+        var pageSource = ReadSource("src", "OpenClaw.Tray.WinUI", "Pages", "ConnectionPage.xaml.cs");
+
+        Assert.Contains("AutomationProperties.SetName(labelText", pageSource);
+        Assert.DoesNotContain(
+            "AutomationProperties.SetAccessibilityView(labelText, AccessibilityView.Raw);",
+            pageSource);
+        Assert.DoesNotContain("AutomationProperties.SetName(pill", pageSource);
+    }
+
     private static string ReadSource(params string[] relativePathParts)
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();

--- a/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
@@ -187,6 +187,14 @@ public class LocalizationValidationTests
         "ConnectionPage_NodePendingDeclaredCapabilities",
         "ConnectionPage_NodePendingDeclaredCommands",
         "ConnectionPage_NodePendingDeclaredPermissions",
+        // Node-card capability pills and technical-details disclosure — seeded
+        // English-only across all 5 locales using the deferred-translation pattern.
+        "ConnectionPage_NodeTechnicalDetails.Text",
+        "ConnectionPage_NodePillState_Active",
+        "ConnectionPage_NodePillState_Pending",
+        "ConnectionPage_NodePillState_Off",
+        "ConnectionPage_NodeCap_Device",
+        "ConnectionPage_NodeCap_System",
         "ConnectionStatusWindow.Title",
         // Hard-coded XAML strings resolved by issue #491 — seeded English-only across
         // all 5 locales using the deferred-translation pattern. Translations are a


### PR DESCRIPTION
## Summary

- Problem: The Connection page Node card exposed a dense raw capability / command / permission dump directly in the default UI.
- Why it matters: Users could not quickly understand what the node is sharing, and the raw gateway contract text made the primary settings surface look broken/noisy.
- What changed: Replaced the default dump with stateful capability pills, moved raw capability/command/permission details into a collapsed **Show technical details** expander, and improved theme/High Contrast/accessibility handling.
- User impact: The Node card is easier to scan, shows active/pending/off capability states, and still preserves technical debugging details on demand.
- What did NOT change (scope boundary): No gateway protocol, capability registration, approval semantics, settings storage, or node execution behavior changed.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs / instructions
- [x] Tests / validation
- [ ] Security hardening
- [ ] Chore / infra

## Scope (select all touched areas)

- [x] Tray / WinUI UX
- [x] Windows node capability
- [ ] Local MCP / `winnode`
- [x] Gateway / connection / pairing
- [ ] Setup / onboarding
- [ ] Permissions / privacy / security
- [x] Tests / CI / docs

## Linked Issue/PR

- Closes #
- Related #
- [ ] Related to a bug or regression

## Validation

- Maintainer patch `1e9aa5e3` — exposed Node capability pill state through the visible TextBlock automation peer.
- Maintainer validation: `./build.ps1` — ✅ all projects built after test-project restore for fresh worktree assets.
- Maintainer validation: `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — ✅ 2629 passed / 31 skipped.
- Maintainer validation: `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — ✅ 1433 passed.
- Maintainer rubber-duck review — ✅ no blocking findings.
- `./build.ps1` — ✅ all projects built
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — ✅ 1432 passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — ✅ 2629 passed / 31 skipped
- Rubber-duck review — ✅ no blocking findings after follow-up fixes
- Autoreview attempted with Codex — blocked by auth (`401 Unauthorized: Missing bearer or basic authentication`); fallback code-review agent found no significant issues.

## Real behavior proof

- Environment tested: Original UI proof on local Windows ARM64, non-isolated tray app using real settings/gateway state; maintainer patch validation on local Windows x64 isolated worktree.
- PR head / commit tested: `5637a479` visual proof plus maintainer accessibility patch `1e9aa5e3`.
- Exact steps or command run: Original proof used `./run-app-local.ps1 -NoBuild -AllowNonMain`, then opened Companion Settings → Connection. Maintainer patch used automated source regression test `NodeCapabilityPills_ExposeStateThroughReadableTextPeer` plus full required validation.
- Evidence after fix: Screenshot below shows the unchanged visual Node card capability pills and technical details expander; maintainer patch has no visual change and exposes each pill label/state through the visible TextBlock automation peer for screen readers.
- Observed result: Node card shows capability pills by state and raw gateway capability/command/permission details only inside **Show technical details**. The accessibility patch keeps decorative icons raw and moves the combined label/state automation name from the Border container to the readable TextBlock peer.
- Screenshot/artifact links verified? (`Yes/No/N/A`): Yes <img width="1114" height="852" alt="image" src="https://github.com/user-attachments/assets/a973051b-fb0c-4ec1-be93-24965b86c3b2" />
- Not verified / blocked: Manual screen-reader pass not separately captured; automation peer invariant is covered by the added source regression test.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.