### PR TITLE
Fix setup-connect E2E pending approval leak

### DIFF
--- a/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
+++ b/tests/OpenClaw.E2ETests/Setup/SetupAndConnectTests.cs
@@ -312,56 +312,79 @@ public class SetupAndConnectTests
         var env = GatewayTokenEnv(gateway.SharedGatewayToken);
         var pendingBefore = await ReadPendingDeviceRequestIdsAsync();
         var pendingNodeBefore = await ReadPendingNodeRequestIdsAsync();
+        var handledDeviceRequestIds = new HashSet<string>(StringComparer.Ordinal);
+        var handledNodeRequestIds = new HashSet<string>(StringComparer.Ordinal);
         var setupCode = await MintRealGatewaySetupCodeAsync(env, "mint real gateway setup code for external-like tray");
+        IsolatedTrayInstance? externalTray = null;
+        Exception? testFailure = null;
 
-        await using var externalTray = await IsolatedTrayInstance.StartAsync(_fixture.ArtifactDir, "external-qr-only");
-        using var applyDoc = await externalTray.Client.CallToolExpectSuccessAsync(
-            "app.connection.applySetupCode",
-            new { setupCode });
-        var apply = applyDoc.RootElement;
-        Console.WriteLine($"[E2E] external-like applySetupCode response: {apply.GetRawText()}");
-        Assert.Equal("Success", apply.GetProperty("outcome").GetString());
-
-        var active = externalTray.ReadActiveGatewayRecord();
-        Assert.NotNull(active.GatewayUrl);
-        Assert.Contains($":{_fixture.GatewayPort}", active.GatewayUrl, StringComparison.Ordinal);
-        Assert.True(string.IsNullOrWhiteSpace(active.SharedGatewayToken),
-            "QR-only external-like onboarding must not invent or persist the shared gateway token.");
-
-        var credentials = externalTray.ReadCredentialState();
-        Assert.False(credentials.HasNodeToken, "QR-only external-like onboarding should wait for explicit device approval before persisting a node token.");
-        Assert.False(credentials.HasOperatorToken,
-            "Current LKG QR-only external-like onboarding does not provide an admin operator token.");
-        Assert.True(credentials.HasBootstrapToken,
-            "Bootstrap remains as recovery material while explicit approval is pending.");
-
-        using var statusDoc = await externalTray.Client.CallToolExpectSuccessAsync("app.status");
-        var status = statusDoc.RootElement;
-        var rawStatus = status.GetRawText();
-        Assert.False(status.GetProperty("nodeConnected").GetBoolean(), $"Expected nodeConnected=false before approval; status={rawStatus}");
-        Assert.False(status.GetProperty("nodePaired").GetBoolean(), $"Expected nodePaired=false before approval; status={rawStatus}");
-        Assert.True(status.TryGetProperty("operatorScopes", out var scopes), $"operatorScopes missing: {rawStatus}");
-        Assert.DoesNotContain(ReadStringArray(scopes), scope => string.Equals(scope, "operator.admin", StringComparison.OrdinalIgnoreCase));
-
-        var requestId = await WaitForFirstPendingDeviceRequestIdAsync(pendingBefore);
-        Assert.False(string.IsNullOrWhiteSpace(requestId));
-
-        using var dashboardDoc = await externalTray.Client.CallToolExpectSuccessAsync("app.dashboard.url");
-        var dashboard = dashboardDoc.RootElement;
-        Assert.Equal("record.BootstrapToken", dashboard.GetProperty("credentialSource").GetString());
-        Assert.False(dashboard.GetProperty("usesSharedGatewayToken").GetBoolean());
-        Assert.False(dashboard.GetProperty("hasTokenQuery").GetBoolean());
-
-        using var rejectDoc = await RejectDevicePairingFromConnectionPageAsync(requestId);
-        Console.WriteLine($"[E2E] rejected external-like pending device request via Connection page: {rejectDoc.RootElement.GetRawText()}");
-
-        var nodeRequests = await ReadNewPendingNodeApprovalsUntilAsync(
-            pendingNodeBefore,
-            TimeSpan.FromSeconds(10));
-        foreach (var nodeRequest in nodeRequests)
+        try
         {
-            using var rejectNodeDoc = await RejectNodePairingFromConnectionPageAsync(nodeRequest.RequestId);
-            Console.WriteLine($"[E2E] rejected external-like pending node-trust request via Connection page: {rejectNodeDoc.RootElement.GetRawText()}");
+            externalTray = await IsolatedTrayInstance.StartAsync(_fixture.ArtifactDir, "external-qr-only");
+            using var applyDoc = await externalTray.Client.CallToolExpectSuccessAsync(
+                "app.connection.applySetupCode",
+                new { setupCode });
+            var apply = applyDoc.RootElement;
+            Console.WriteLine($"[E2E] external-like applySetupCode response: {apply.GetRawText()}");
+            Assert.Equal("Success", apply.GetProperty("outcome").GetString());
+
+            var active = externalTray.ReadActiveGatewayRecord();
+            Assert.NotNull(active.GatewayUrl);
+            Assert.Contains($":{_fixture.GatewayPort}", active.GatewayUrl, StringComparison.Ordinal);
+            Assert.True(string.IsNullOrWhiteSpace(active.SharedGatewayToken),
+                "QR-only external-like onboarding must not invent or persist the shared gateway token.");
+
+            var credentials = externalTray.ReadCredentialState();
+            Assert.False(credentials.HasNodeToken, "QR-only external-like onboarding should wait for explicit device approval before persisting a node token.");
+            Assert.False(credentials.HasOperatorToken,
+                "Current LKG QR-only external-like onboarding does not provide an admin operator token.");
+            Assert.True(credentials.HasBootstrapToken,
+                "Bootstrap remains as recovery material while explicit approval is pending.");
+
+            using var statusDoc = await externalTray.Client.CallToolExpectSuccessAsync("app.status");
+            var status = statusDoc.RootElement;
+            var rawStatus = status.GetRawText();
+            Assert.False(status.GetProperty("nodeConnected").GetBoolean(), $"Expected nodeConnected=false before approval; status={rawStatus}");
+            Assert.False(status.GetProperty("nodePaired").GetBoolean(), $"Expected nodePaired=false before approval; status={rawStatus}");
+            Assert.True(status.TryGetProperty("operatorScopes", out var scopes), $"operatorScopes missing: {rawStatus}");
+            Assert.DoesNotContain(ReadStringArray(scopes), scope => string.Equals(scope, "operator.admin", StringComparison.OrdinalIgnoreCase));
+
+            var requestId = await WaitForFirstPendingDeviceRequestIdAsync(pendingBefore);
+            Assert.False(string.IsNullOrWhiteSpace(requestId));
+
+            using var dashboardDoc = await externalTray.Client.CallToolExpectSuccessAsync("app.dashboard.url");
+            var dashboard = dashboardDoc.RootElement;
+            Assert.Equal("record.BootstrapToken", dashboard.GetProperty("credentialSource").GetString());
+            Assert.False(dashboard.GetProperty("usesSharedGatewayToken").GetBoolean());
+            Assert.False(dashboard.GetProperty("hasTokenQuery").GetBoolean());
+
+            using var rejectDoc = await RejectDevicePairingFromConnectionPageAsync(requestId);
+            handledDeviceRequestIds.Add(requestId);
+            Console.WriteLine($"[E2E] rejected external-like pending device request via Connection page: {rejectDoc.RootElement.GetRawText()}");
+        }
+        catch (Exception ex)
+        {
+            testFailure = ex;
+            throw;
+        }
+        finally
+        {
+            if (externalTray is not null)
+                await externalTray.DisposeAsync();
+
+            try
+            {
+                await RejectNewPendingApprovalsUntilQuietAsync(
+                    pendingBefore,
+                    pendingNodeBefore,
+                    handledDeviceRequestIds,
+                    handledNodeRequestIds,
+                    TimeSpan.FromSeconds(45));
+            }
+            catch (Exception ex) when (testFailure is not null)
+            {
+                Console.WriteLine($"[E2E] Cleanup after failed external QR-only tray test also failed: {ex}");
+            }
         }
     }
 
@@ -402,34 +425,66 @@ public class SetupAndConnectTests
         var sharedGatewayToken = RequireSharedGatewayToken(gateway.SharedGatewayToken);
         var pendingBefore = await ReadPendingDeviceRequestIdsAsync();
         var pendingNodeBefore = await ReadPendingNodeRequestIdsAsync();
+        var handledDeviceRequestIds = new HashSet<string>(StringComparer.Ordinal);
+        var handledNodeRequestIds = new HashSet<string>(StringComparer.Ordinal);
+        IsolatedTrayInstance? externalTray = null;
+        Exception? testFailure = null;
 
-        await using var externalTray = await IsolatedTrayInstance.StartAsync(_fixture.ArtifactDir, "external-shared-token");
-        using var connectDoc = await externalTray.Client.CallToolExpectSuccessAsync(
-            "app.connection.connectSharedToken",
-            new { gatewayUrl = gateway.GatewayUrl, token = sharedGatewayToken });
-        var connect = connectDoc.RootElement;
-        Console.WriteLine($"[E2E] external shared-token connect response: {connect.GetRawText()}");
-        Assert.Equal("Success", connect.GetProperty("outcome").GetString());
-
-        await ApproveNewPendingDeviceRequestsUntilReadyAsync(pendingBefore, externalTray);
-        var nodeRequest = Assert.Single(await ReadNewPendingNodeApprovalsUntilAsync(
-            pendingNodeBefore,
-            TimeSpan.FromSeconds(30)));
-        using (var approve = await ApproveNodePairingFromConnectionPageAsync(nodeRequest.RequestId))
+        try
         {
-            Console.WriteLine($"[E2E] explicitly approved external node-trust request via Connection page: {approve.RootElement.GetRawText()}");
-        }
+            externalTray = await IsolatedTrayInstance.StartAsync(_fixture.ArtifactDir, "external-shared-token");
+            using var connectDoc = await externalTray.Client.CallToolExpectSuccessAsync(
+                "app.connection.connectSharedToken",
+                new { gatewayUrl = gateway.GatewayUrl, token = sharedGatewayToken });
+            var connect = connectDoc.RootElement;
+            Console.WriteLine($"[E2E] external shared-token connect response: {connect.GetRawText()}");
+            Assert.Equal("Success", connect.GetProperty("outcome").GetString());
 
-        using var reconnectNode = await externalTray.Client.CallToolExpectSuccessAsync("app.connection.reconnectNode");
-        Assert.True(reconnectNode.RootElement.GetProperty("reconnected").GetBoolean());
-        await externalTray.WaitForConnectionReady(TimeSpan.FromSeconds(120));
-        await WaitForNodeEffectiveStateAsync(
-            externalTray.Client,
-            nodeRequest.NodeId,
-            new CapabilitiesConfig { Tts = false },
-            TimeSpan.FromSeconds(90));
-        AssertExternalTrayDurablePairing(externalTray);
-        await AssertGatewayCliStateHealthy();
+            await ApproveNewPendingDeviceRequestsUntilReadyAsync(pendingBefore, handledDeviceRequestIds, externalTray);
+            var nodeRequest = Assert.Single(await ReadNewPendingNodeApprovalsUntilAsync(
+                pendingNodeBefore,
+                TimeSpan.FromSeconds(30)));
+            using (var approve = await ApproveNodePairingFromConnectionPageAsync(nodeRequest.RequestId))
+            {
+                handledNodeRequestIds.Add(nodeRequest.RequestId);
+                Console.WriteLine($"[E2E] explicitly approved external node-trust request via Connection page: {approve.RootElement.GetRawText()}");
+            }
+
+            using var reconnectNode = await externalTray.Client.CallToolExpectSuccessAsync("app.connection.reconnectNode");
+            Assert.True(reconnectNode.RootElement.GetProperty("reconnected").GetBoolean());
+            await externalTray.WaitForConnectionReady(TimeSpan.FromSeconds(120));
+            await WaitForNodeEffectiveStateAsync(
+                externalTray.Client,
+                nodeRequest.NodeId,
+                new CapabilitiesConfig { Tts = false },
+                TimeSpan.FromSeconds(90));
+            AssertExternalTrayDurablePairing(externalTray);
+            await AssertGatewayCliStateHealthy();
+        }
+        catch (Exception ex)
+        {
+            testFailure = ex;
+            throw;
+        }
+        finally
+        {
+            if (externalTray is not null)
+                await externalTray.DisposeAsync();
+
+            try
+            {
+                await RejectNewPendingApprovalsUntilQuietAsync(
+                    pendingBefore,
+                    pendingNodeBefore,
+                    handledDeviceRequestIds,
+                    handledNodeRequestIds,
+                    TimeSpan.FromSeconds(45));
+            }
+            catch (Exception ex) when (testFailure is not null)
+            {
+                Console.WriteLine($"[E2E] Cleanup after failed external shared-token tray test also failed: {ex}");
+            }
+        }
     }
 
     [E2EFact]
@@ -713,9 +768,13 @@ public class SetupAndConnectTests
 
     private async Task ApproveNewPendingDeviceRequestsUntilReadyAsync(
         HashSet<string> ignoredRequestIds,
+        HashSet<string> approvedRequestIds,
         IsolatedTrayInstance tray)
     {
         var approved = new HashSet<string>(ignoredRequestIds, StringComparer.Ordinal);
+        foreach (var requestId in approvedRequestIds)
+            approved.Add(requestId);
+
         var deadline = DateTime.UtcNow.AddSeconds(90);
         string lastDevicesOutput = "<none>";
         while (DateTime.UtcNow < deadline)
@@ -741,6 +800,7 @@ public class SetupAndConnectTests
             {
                 using var approve = await ApproveDevicePairingFromConnectionPageAsync(requestId);
                 Console.WriteLine($"[E2E] approved external-like device request via Connection page: {approve.RootElement.GetRawText()}");
+                approvedRequestIds.Add(requestId);
                 approvedAny = true;
             }
 
@@ -763,6 +823,78 @@ public class SetupAndConnectTests
         }
 
         throw new TimeoutException($"Timed out waiting for clean external-like tray credentials. Last devices list: {lastDevicesOutput}");
+    }
+
+    private async Task RejectNewPendingApprovalsUntilQuietAsync(
+        HashSet<string> deviceRequestIdsBefore,
+        HashSet<string> nodeRequestIdsBefore,
+        HashSet<string> handledDeviceRequestIds,
+        HashSet<string> handledNodeRequestIds,
+        TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow.Add(timeout);
+        DateTime? quietSince = null;
+        string lastOutput = "<none>";
+
+        while (DateTime.UtcNow < deadline)
+        {
+            using var approvals = await ReadPendingApprovalsFromConnectionPageAsync();
+            lastOutput = approvals.RootElement.GetRawText();
+            var rejectedAny = false;
+            var handledRequestStillVisible = false;
+
+            foreach (var requestId in ReadPendingApprovalIds(approvals.RootElement, "devicePending", "RequestId", "DeviceId")
+                         .ToArray())
+            {
+                if (deviceRequestIdsBefore.Contains(requestId))
+                    continue;
+
+                if (handledDeviceRequestIds.Contains(requestId))
+                {
+                    handledRequestStillVisible = true;
+                    continue;
+                }
+
+                using var reject = await RejectDevicePairingFromConnectionPageAsync(requestId);
+                handledDeviceRequestIds.Add(requestId);
+                Console.WriteLine($"[E2E] cleaned up pending device request {requestId}: {reject.RootElement.GetRawText()}");
+                rejectedAny = true;
+            }
+
+            foreach (var request in ReadPendingNodeApprovals(approvals.RootElement)
+                         .ToArray())
+            {
+                if (nodeRequestIdsBefore.Contains(request.RequestId))
+                    continue;
+
+                if (handledNodeRequestIds.Contains(request.RequestId))
+                {
+                    handledRequestStillVisible = true;
+                    continue;
+                }
+
+                using var reject = await RejectNodePairingFromConnectionPageAsync(request.RequestId);
+                handledNodeRequestIds.Add(request.RequestId);
+                Console.WriteLine($"[E2E] cleaned up pending node-trust request {request.RequestId} for {request.NodeId}: {reject.RootElement.GetRawText()}");
+                rejectedAny = true;
+            }
+
+            if (rejectedAny || handledRequestStillVisible)
+            {
+                quietSince = null;
+            }
+            else
+            {
+                quietSince ??= DateTime.UtcNow;
+                if (DateTime.UtcNow - quietSince >= TimeSpan.FromSeconds(3))
+                    return;
+            }
+
+            await Task.Delay(500);
+        }
+
+        throw new TimeoutException(
+            $"Timed out waiting for external-tray pending approvals to remain clear. Last output: {lastOutput}");
     }
 
     private async Task<JsonDocument> ReadPendingApprovalsFromConnectionPageAsync()


### PR DESCRIPTION
## Summary

Fixes the setup-connect E2E order/race flake by cleaning up pending gateway approval requests created by the external-tray setup scenarios.

The external QR/shared-token tests now:
- snapshot pending device/node approval IDs before creating an external tray
- dispose the external tray before cleanup so it stops emitting delayed requests
- reject only newly-created unhandled pending approvals until the shared gateway stays quiet
- track requests already approved/rejected by the test body to avoid double decisions
- avoid masking the original test failure if best-effort cleanup also fails

This preserves the healthy-state checks that require no pending requests; it cleans up the source of the leak instead of weakening `AssertNoPendingRequests`.

## Prior failing job evidence

The flaky GitHub Actions setup-connect shard failed twice after PR #891 was patched in:

- `OpenClaw.E2ETests.Setup.SetupAndConnectTests.RealGateway_SharedTokenFlow_ReconnectsThroughTrayMcp`
- `OpenClaw.E2ETests.Setup.SetupAndConnectTests.RealGateway_BadSharedToken_DoesNotDestroyExistingPairing`

Both failures were from `AssertNoPendingRequests` expecting 0 pending requests and finding 1. The failing log also showed a negative shared-token connect response:

```json
{"outcome":"ConnectionFailed","error":"unauthorized: gateway token mismatch (set gateway.remote.token to match gateway.auth.token)"}
```

and a node list with two Windows node entries, one offline, consistent with an earlier external-tray scenario leaving shared gateway state behind.

## Validation

- `./build.ps1` - passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` - passed: 2659 passed, 31 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` - passed: 1443 passed

Initial `--no-restore` test attempts hit the documented fresh-worktree missing-assets case, so I ran the same test projects once without `--no-restore` to restore/build, then reran the required `--no-restore` commands above successfully.

## Real behavior proof

- Focused setup-connect E2E was attempted locally with:

```powershell
$env:OPENCLAW_REPO_ROOT=(Get-Location).Path
$env:OPENCLAW_RUN_E2E='1'
dotnet test ./tests/OpenClaw.E2ETests/OpenClaw.E2ETests.csproj -c Debug -r win-x64 --filter "FullyQualifiedName~OpenClaw.E2ETests.Setup.SetupAndConnectTests" --logger "console;verbosity=normal"
```

- Result: blocked before any setup-connect assertions ran. `E2ESetupFixture.InitializeAsync()` failed because the setup gateway could not become healthy due to `EADDRINUSE` on the randomly selected gateway port `59095` inside the local WSL distro:

```text
Gateway failed to start: gateway already running under systemd; existing gateway did not become healthy after 30000ms | another gateway instance is already listening on ws://<host>:59095/ | listen EADDRINUSE: address already in use <ip>:59095 | EADDRINUSE
SetupPipeline: Step 'start-gateway' failed: Gateway did not become healthy within 90s
```

This is a local environment/gateway startup blocker, not a failure in the modified pending-approval cleanup path. CI setup-connect remains the required end-to-end proof for this PR.

## Rubber-duck review

A rubber-duck review confirmed the root-cause direction: the reported failures do not create external trays themselves; they observe pending approval state leaked by earlier external-tray tests in the shared fixture. Review feedback led to two hardening changes in this PR: cleanup no longer masks the original scenario failure, and cleanup tracks already handled request IDs to avoid duplicate reject/approve races.
