### PR TITLE
Chat: surface the full / command catalog, grouped by Mac buckets with styled rows

### DIFF
--- a/src/OpenClaw.Shared/CommandCatalogPresentation.cs
+++ b/src/OpenClaw.Shared/CommandCatalogPresentation.cs
@@ -161,16 +161,54 @@ public sealed class ChatCommandCatalogView
     }
 
     /// <summary>
-    /// Groups commands by category (falling back to source label, then "Other"),
-    /// optionally filtered by the same search used in <see cref="Search"/>.
-    /// Groups and their members are returned in a stable, display-friendly order.
+    /// Groups commands by their raw category (falling back to source label, then
+    /// "Other"), optionally filtered/ordered. See <see cref="GroupBy"/>.
     /// </summary>
-    public IReadOnlyList<CommandCategoryGroup> GroupByCategory(string? query = null)
+    public IReadOnlyList<CommandCategoryGroup> GroupByCategory(
+        string? query = null, IReadOnlyList<string>? categoryOrder = null)
+        => GroupBy(CategoryKey, query, categoryOrder);
+
+    /// <summary>
+    /// Groups commands using a caller-supplied category selector, optionally
+    /// filtered by the same search used in <see cref="Search"/>. Members within a
+    /// group preserve the relevance order produced by <see cref="Search"/>
+    /// (alphabetical when the query is empty), so the top match stays first. When
+    /// <paramref name="categoryOrder"/> is supplied, groups are ordered by that
+    /// sequence first (unlisted categories sort last, alphabetically); otherwise
+    /// groups are ordered alphabetically. The selector lets the palette group by a
+    /// mapped bucket (e.g. Mac's Session/Model/Tools/Agents) rather than the raw
+    /// wire category.
+    /// </summary>
+    public IReadOnlyList<CommandCategoryGroup> GroupBy(
+        Func<GatewayCommand, string> categorySelector,
+        string? query = null,
+        IReadOnlyList<string>? categoryOrder = null)
     {
         var matched = Search(query);
-        return matched
-            .GroupBy(CategoryKey, StringComparer.OrdinalIgnoreCase)
-            .Select(g => new CommandCategoryGroup(g.Key, Ordered(g).ToList()))
+        // GroupBy preserves source (relevance) order within each group; do NOT
+        // re-sort the members — that would demote a strong match below a weaker
+        // one and change the default Enter target.
+        var groups = matched
+            .GroupBy(categorySelector, StringComparer.OrdinalIgnoreCase)
+            .Select(g => new CommandCategoryGroup(g.Key, g.ToList()));
+
+        if (categoryOrder is { Count: > 0 })
+        {
+            int Rank(string category)
+            {
+                for (int i = 0; i < categoryOrder.Count; i++)
+                    if (string.Equals(categoryOrder[i], category, StringComparison.OrdinalIgnoreCase))
+                        return i;
+                return int.MaxValue;
+            }
+
+            return groups
+                .OrderBy(g => Rank(g.Category))
+                .ThenBy(g => g.Category, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        return groups
             .OrderBy(g => g.Category, StringComparer.OrdinalIgnoreCase)
             .ToList();
     }
@@ -214,5 +252,116 @@ public sealed class ChatCommandCatalogView
             best = 15;
 
         return best;
+    }
+}
+
+/// <summary>
+/// Mac/web parity for the slash command palette grouping (slash-commands.ts):
+/// maps each command into one of four display buckets — Session, Model, Tools,
+/// Agents — via per-command name overrides first, then a raw-category fallback
+/// (session→Session, options→Model, management→Tools, everything else→Tools).
+/// </summary>
+public static class CommandCategories
+{
+    /// <summary>Bucket display order, mirroring Mac's CATEGORY_ORDER.</summary>
+    public static readonly IReadOnlyList<string> DisplayOrder = new[]
+    {
+        "session", "model", "tools", "agents",
+    };
+
+    private static readonly Dictionary<string, string> Labels = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["session"] = "Session",
+        ["model"] = "Model",
+        ["tools"] = "Tools",
+        ["agents"] = "Agents",
+    };
+
+    // Per-command bucket overrides keyed by normalized command name. Mirrors
+    // Mac's CATEGORY_OVERRIDES, applied before the raw-category fallback so e.g.
+    // /usage (raw category "options") lands in Tools rather than Model. This is a
+    // deliberate SUPERSET of Mac's map: it additionally pins export/kill/focus/
+    // unfocus, which Mac leaves to its raw-category fallback.
+    private static readonly Dictionary<string, string> BucketOverrides = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["help"] = "tools",
+        ["commands"] = "tools",
+        ["tools"] = "tools",
+        ["skill"] = "tools",
+        ["status"] = "tools",
+        ["export_session"] = "tools",
+        ["export"] = "tools",
+        ["usage"] = "tools",
+        ["tts"] = "tools",
+        ["agents"] = "agents",
+        ["subagents"] = "agents",
+        ["kill"] = "agents",
+        ["steer"] = "agents",
+        ["redirect"] = "agents",
+        ["session"] = "session",
+        ["stop"] = "session",
+        ["reset"] = "session",
+        ["new"] = "session",
+        ["compact"] = "session",
+        ["focus"] = "session",
+        ["unfocus"] = "session",
+        ["model"] = "model",
+        ["models"] = "model",
+        ["think"] = "model",
+        ["verbose"] = "model",
+        ["fast"] = "model",
+        ["reasoning"] = "model",
+        ["elevated"] = "model",
+        ["queue"] = "model",
+    };
+
+    /// <summary>
+    /// Display bucket (session/model/tools/agents) for a command, mirroring Mac's
+    /// mapCategory: name override first, then raw-category fallback.
+    /// </summary>
+    public static string Bucket(GatewayCommand command)
+    {
+        if (command is null) return "tools";
+        var key = NormalizeKey(command);
+        if (!string.IsNullOrEmpty(key) && BucketOverrides.TryGetValue(key, out var bucket))
+            return bucket;
+
+        return (command.Category?.Trim().ToLowerInvariant()) switch
+        {
+            "session" => "session",
+            "options" => "model",
+            "management" => "tools",
+            _ => "tools",
+        };
+    }
+
+    /// <summary>Friendly heading for a bucket key; Title-cases unknowns.</summary>
+    public static string Label(string? bucket)
+    {
+        if (string.IsNullOrWhiteSpace(bucket)) return "Other";
+        var key = bucket!.Trim();
+        if (Labels.TryGetValue(key, out var label)) return label;
+        return char.ToUpperInvariant(key[0]) + (key.Length > 1 ? key[1..] : "");
+    }
+
+    // Normalizes a command name to an override key the way Mac's normalizeUiKey
+    // does (lowercase, strip a leading slash, ':' '.' '-' → '_'). Mac keys off
+    // command.key; the wire command carries no key here, and the catalog is
+    // requested with text scope, so the text-surface Name is the closest analog —
+    // fall back to the first text alias, then the native name.
+    private static string NormalizeKey(GatewayCommand command)
+    {
+        var raw = !string.IsNullOrWhiteSpace(command.Name)
+            ? command.Name
+            : command.TextAliases?.FirstOrDefault(a => !string.IsNullOrWhiteSpace(a));
+        if (string.IsNullOrWhiteSpace(raw)) raw = command.NativeName;
+        raw = (raw ?? "").Trim();
+        if (raw.Length == 0) return "";
+        if (raw[0] == '/') raw = raw[1..];
+        raw = raw.ToLowerInvariant();
+        var chars = raw.ToCharArray();
+        for (int i = 0; i < chars.Length; i++)
+            if (chars[i] is ':' or '.' or '-') chars[i] = '_';
+        return new string(chars);
     }
 }

--- a/src/OpenClaw.Shared/CommandCatalogPresentation.cs
+++ b/src/OpenClaw.Shared/CommandCatalogPresentation.cs
@@ -111,6 +111,19 @@ public static class GatewayCommandPresentation
 public sealed record CommandCategoryGroup(string Category, IReadOnlyList<GatewayCommand> Commands);
 
 /// <summary>
+/// A grouped command palette: the display <see cref="Groups"/>; the same commands
+/// <see cref="Flattened"/> in group/display order (the keyboard-navigation list);
+/// and <see cref="DefaultSelectionIndex"/> — the index in <see cref="Flattened"/>
+/// of the GLOBAL best search match, i.e. the row keyboard selection should default
+/// to so that display grouping never demotes a strong later-bucket match behind a
+/// weak earlier-bucket one for Enter/Tab.
+/// </summary>
+public sealed record GroupedPalette(
+    IReadOnlyList<CommandCategoryGroup> Groups,
+    IReadOnlyList<GatewayCommand> Flattened,
+    int DefaultSelectionIndex);
+
+/// <summary>
 /// Ranked search + category grouping over a set of gateway commands for the chat
 /// command palette. Distinct from <see cref="CommandCatalogQuery"/> (a boolean
 /// filter mirroring the gateway's server-side filtering) — this adds relevance
@@ -211,6 +224,27 @@ public sealed class ChatCommandCatalogView
         return groups
             .OrderBy(g => g.Category, StringComparer.OrdinalIgnoreCase)
             .ToList();
+    }
+
+    /// <summary>
+    /// Groups commands for the chat command palette (visual grouping) and also
+    /// computes <see cref="GroupedPalette.DefaultSelectionIndex"/> — the index,
+    /// within the flattened group order, of the GLOBAL best <see cref="Search"/>
+    /// match. Display grouping orders by bucket, which can render a strong
+    /// later-bucket match after a weak earlier-bucket one; keyboard selection
+    /// should default to this index (not 0) to preserve the flat-search Enter/Tab
+    /// target.
+    /// </summary>
+    public GroupedPalette GroupForPalette(
+        Func<GatewayCommand, string> categorySelector,
+        string? query = null,
+        IReadOnlyList<string>? categoryOrder = null)
+    {
+        var groups = GroupBy(categorySelector, query, categoryOrder);
+        var flattened = groups.SelectMany(g => g.Commands).ToList();
+        var top = Search(query).FirstOrDefault();
+        var defaultIndex = top is null ? 0 : flattened.IndexOf(top);
+        return new GroupedPalette(groups, flattened, defaultIndex < 0 ? 0 : defaultIndex);
     }
 
     private static string CategoryKey(GatewayCommand cmd)

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
@@ -455,23 +455,22 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
 
         IReadOnlyList<GatewayCommand> slashResults = Array.Empty<GatewayCommand>();
         IReadOnlyList<CommandCategoryGroup> slashGroups = Array.Empty<CommandCategoryGroup>();
+        // Index (within the flattened group order) of the GLOBAL best search match
+        // — the default keyboard selection, so display grouping never demotes a
+        // strong later-bucket match behind a weak earlier-bucket one for Enter/Tab.
+        var slashDefaultIndex = 0;
         if (slashActive && !slash.ArgsMode && Props.AvailableCommands is { } slashCmds)
         {
             // Category-grouped palette (Mac/web parity): commands render under
-            // their Mac display bucket (Session, Model, Tools, Agents) instead of
-            // one flat alphabetical list — so the run options (verbose/reasoning/
-            // exec/…, bucketed under "Model") surface under their heading. Within
-            // a bucket the relevance order from Search is preserved, so the top
-            // match stays the default Enter target.
-            slashGroups = new ChatCommandCatalogView(slashCmds)
-                .GroupBy(CommandCategories.Bucket, slash.Query, CommandCategories.DisplayOrder);
-
-            // Flatten in group/display order for keyboard navigation; BuildSlashPopup
-            // walks the same groups with a running index, so rendered rows stay
-            // index-aligned with this list. No item cap — the popup's ScrollViewer
-            // bounds the height, so no bucket is silently dropped (the Windows wire
-            // catalog carries no tier data to hide "power" commands the way Mac does).
-            slashResults = slashGroups.SelectMany(g => g.Commands).ToList();
+            // their Mac display bucket (Session, Model, Tools, Agents). Within a
+            // bucket the relevance order from Search is preserved; Flattened drives
+            // keyboard navigation, and DefaultSelectionIndex pins the global top
+            // match as the default Enter/Tab target.
+            var palette = new ChatCommandCatalogView(slashCmds)
+                .GroupForPalette(CommandCategories.Bucket, slash.Query, CommandCategories.DisplayOrder);
+            slashGroups = palette.Groups;
+            slashResults = palette.Flattened;
+            slashDefaultIndex = palette.DefaultSelectionIndex;
         }
 
         // Args-mode: the command (parsed from the composer text) plus its static
@@ -491,9 +490,13 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
 
         var inArgsMode = slash.ArgsMode && slashArgCmd is not null && slashArgResults.Count > 0;
         var slashSelectableCount = inArgsMode ? slashArgResults.Count : slashResults.Count;
+        // slash.Index < 0 means "not navigated yet": default to the global best
+        // command match (slashDefaultIndex) in command mode, or the first arg
+        // choice in args mode. Up/Down then make it a concrete index.
+        var slashDefault = inArgsMode ? 0 : slashDefaultIndex;
         var slashIndex = slashSelectableCount == 0
             ? 0
-            : Math.Clamp(slash.Index, 0, slashSelectableCount - 1);
+            : Math.Clamp(slash.Index < 0 ? slashDefault : slash.Index, 0, slashSelectableCount - 1);
 
         // Pushes a new composer value into the textbox and restores the caret to
         // the end (shared by command insertion and arg-choice insertion).
@@ -542,7 +545,9 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
                 var (active, query, argsMode) = ComputeSlashState(v, Props.AvailableCommands);
                 var cur = slashMenuState.Value;
                 if (active != cur.Active || query != cur.Query || argsMode != cur.ArgsMode)
-                    slashMenuState.Set((active, query, 0, argsMode));
+                    // -1 = "not navigated": selection resolves to the global best
+                    // match (see slashIndex) until the user presses Up/Down.
+                    slashMenuState.Set((active, query, -1, argsMode));
             })
             .Set(tb =>
             {
@@ -1096,12 +1101,13 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
             }
             else if (slashResults.Count == 0)
             {
-                slashPopupContent = BuildSlashHintPopup("No matching commands");
-                slashMenuVisible = true;
+                // No command matches the typed text — hide the palette entirely
+                // (no "no matches" hint) so the composer reads as normal.
+                slashMenuVisible = false;
             }
             else
             {
-                slashPopupContent = BuildSlashPopup(slashGroups, slashIndex, insertSlashCommand);
+                slashPopupContent = BuildSlashPopup(slashGroups, slashIndex, slash.Query, insertSlashCommand);
                 slashMenuVisible = true;
             }
         }
@@ -1310,7 +1316,7 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
     }
 
     private static Border BuildSlashPopup(
-        IReadOnlyList<CommandCategoryGroup> groups, int selectedIndex, Action<GatewayCommand> onPick)
+        IReadOnlyList<CommandCategoryGroup> groups, int selectedIndex, string query, Action<GatewayCommand> onPick)
     {
         var primary = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["TextFillColorPrimaryBrush"];
         var secondary = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["TextFillColorSecondaryBrush"];
@@ -1327,7 +1333,7 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
             list.Children.Add(SlashCategoryHeader(CommandCategories.Label(group.Category), headerBrush));
             foreach (var cmd in group.Commands)
             {
-                list.Children.Add(SlashRow(cmd, idx == selectedIndex, primary, secondary, selectedBg, onPick));
+                list.Children.Add(SlashRow(cmd, idx == selectedIndex, query, primary, secondary, selectedBg, onPick));
                 idx++;
             }
         }
@@ -1441,13 +1447,32 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         // Floating, opaque, elevated container for the slash menu. Uses the same
         // 8px corner radius + default surface stroke as the composer card, with a
         // soft shadow so the menu reads as a distinct layer over the chat content.
+        var res = Microsoft.UI.Xaml.Application.Current.Resources;
+
+        // Match the composer input's background, but OPAQUE. TextControlBackground
+        // is a semi-transparent overlay (fine over the solid composer card, but it
+        // would show chat content through this floating popup), so composite it
+        // over the base surface into a solid color.
+        Brush background;
+        if (res["TextControlBackground"] as SolidColorBrush is { } overlay
+            && res["SolidBackgroundFillColorBaseBrush"] as SolidColorBrush is { } baseBrush)
+        {
+            var a = overlay.Color.A / 255.0;
+            byte Mix(byte b, byte o) => (byte)Math.Round(b * (1 - a) + o * a);
+            var o = overlay.Color;
+            var b = baseBrush.Color;
+            background = new SolidColorBrush(
+                global::Windows.UI.Color.FromArgb(255, Mix(b.R, o.R), Mix(b.G, o.G), Mix(b.B, o.B)));
+        }
+        else
+        {
+            background = (Brush)res["SolidBackgroundFillColorBaseBrush"];
+        }
+
         var shell = new Border
         {
-            // Elevated flyout surface: Tertiary reads lighter than the chat
-            // background (in dark theme Secondary is actually darker than Base),
-            // so the menu lifts off the content instead of sinking into it.
-            Background = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["SolidBackgroundFillColorTertiaryBrush"],
-            BorderBrush = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["SurfaceStrokeColorDefaultBrush"],
+            Background = background,
+            BorderBrush = (Brush)res["SurfaceStrokeColorDefaultBrush"],
             BorderThickness = new Thickness(1),
             CornerRadius = new CornerRadius(8),
             Padding = new Thickness(4),
@@ -1458,8 +1483,49 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         return shell;
     }
 
+    // Highlights every case-insensitive occurrence of the typed query inside a
+    // row TextBlock (command name / description) with a soft accent tint, so it's
+    // clear what the filter matched. Uses TextHighlighter (rectangular) because it
+    // is the only WinUI text-highlight that doesn't disturb the line layout —
+    // inline rounded "chip" elements (InlineUIContainer) render as superscript and
+    // break the baseline. No-op when the query is empty or shorter than the text.
+    private static void ApplyQueryHighlight(TextBlock tb, string? query)
+    {
+        tb.TextHighlighters.Clear();
+        var text = tb.Text ?? "";
+        var q = (query ?? "").Trim().TrimStart('/').Trim();
+        if (q.Length == 0 || text.Length < q.Length) return;
+
+        var accent = Microsoft.UI.Xaml.Application.Current.Resources["AccentFillColorDefaultBrush"] as SolidColorBrush
+            ?? new SolidColorBrush(Microsoft.UI.Colors.SteelBlue);
+        // IMPORTANT: TextHighlighter ignores SolidColorBrush.Opacity (unlike a
+        // normal element background), so the alpha must be baked into the Color
+        // itself — otherwise it renders the full, vivid accent. ~12% alpha gives
+        // the same soft, muted blue-grey the old padded chip had.
+        var ac = accent.Color;
+        var tint = global::Windows.UI.Color.FromArgb(31, ac.R, ac.G, ac.B);
+        var highlighter = new Microsoft.UI.Xaml.Documents.TextHighlighter
+        {
+            Background = new SolidColorBrush(tint),
+            // Make the matched text pop over the tint (white in dark theme, near-
+            // black in light) — theme-aware via the primary text brush.
+            Foreground = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["TextFillColorPrimaryBrush"],
+        };
+
+        var i = 0;
+        while (i <= text.Length - q.Length)
+        {
+            var found = text.IndexOf(q, i, StringComparison.OrdinalIgnoreCase);
+            if (found < 0) break;
+            highlighter.Ranges.Add(new Microsoft.UI.Xaml.Documents.TextRange { StartIndex = found, Length = q.Length });
+            i = found + q.Length;
+        }
+
+        if (highlighter.Ranges.Count > 0) tb.TextHighlighters.Add(highlighter);
+    }
+
     private static Button SlashRow(
-        GatewayCommand cmd, bool selected, Brush primary, Brush secondary, Brush selectedBg, Action<GatewayCommand> onPick)
+        GatewayCommand cmd, bool selected, string query, Brush primary, Brush secondary, Brush selectedBg, Action<GatewayCommand> onPick)
     {
         // Row layout mirrors Mac's .slash-menu-item: icon · /name · [args] on the
         // left; description + "N options" badge pushed to the right edge (the
@@ -1495,6 +1561,7 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         };
         Microsoft.UI.Xaml.Controls.Grid.SetColumn(name, 1);
         grid.Children.Add(name);
+        ApplyQueryHighlight(name, query);
 
         var args = cmd.ArgTemplate();
         if (!string.IsNullOrWhiteSpace(args))
@@ -1527,6 +1594,7 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
             };
             Microsoft.UI.Xaml.Controls.Grid.SetColumn(desc, 3);
             grid.Children.Add(desc);
+            ApplyQueryHighlight(desc, query);
         }
 
         var opts = cmd.OptionCount();

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
@@ -653,11 +653,11 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
                         return;
                     }
                 }
-                else if (slashActive)
+                else if (slashActive && Props.AvailableCommands is null)
                 {
-                    // Popup is up but nothing is selectable: either the catalog is
-                    // still loading or no command matches the typed text.
-                    var slashLoading = Props.AvailableCommands is null;
+                    // The loading popup is visible but nothing is selectable yet.
+                    // No-match input hides the popup, so it must fall through as
+                    // ordinary composer text instead of trapping Tab/Escape/arrows.
                     if (key == global::Windows.System.VirtualKey.Escape
                         || key == global::Windows.System.VirtualKey.Tab)
                     {
@@ -674,12 +674,10 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
                         e.Handled = true;
                         return;
                     }
-                    if (slashLoading && key == global::Windows.System.VirtualKey.Enter)
+                    if (key == global::Windows.System.VirtualKey.Enter)
                     {
                         // We don't yet know whether "/token" is a real command, so
                         // don't let Enter send it as raw text and race the fetch.
-                        // (Once loaded with no match it's not a command, so Enter
-                        // falls through below and sends as an ordinary message.)
                         e.Handled = true;
                         return;
                     }

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
@@ -454,16 +454,24 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         }, needsCatalog);
 
         IReadOnlyList<GatewayCommand> slashResults = Array.Empty<GatewayCommand>();
+        IReadOnlyList<CommandCategoryGroup> slashGroups = Array.Empty<CommandCategoryGroup>();
         if (slashActive && !slash.ArgsMode && Props.AvailableCommands is { } slashCmds)
         {
-            // Relevance-ranked; index 0 is the top match and is what Enter inserts
-            // when the user hasn't navigated. (No category re-sort — that would
-            // demote an exact match below a weakly-matched command in an
-            // earlier-ordered category.)
-            slashResults = new ChatCommandCatalogView(slashCmds)
-                .Search(slash.Query)
-                .Take(SlashMenuMaxItems)
-                .ToList();
+            // Category-grouped palette (Mac/web parity): commands render under
+            // their Mac display bucket (Session, Model, Tools, Agents) instead of
+            // one flat alphabetical list — so the run options (verbose/reasoning/
+            // exec/…, bucketed under "Model") surface under their heading. Within
+            // a bucket the relevance order from Search is preserved, so the top
+            // match stays the default Enter target.
+            slashGroups = new ChatCommandCatalogView(slashCmds)
+                .GroupBy(CommandCategories.Bucket, slash.Query, CommandCategories.DisplayOrder);
+
+            // Flatten in group/display order for keyboard navigation; BuildSlashPopup
+            // walks the same groups with a running index, so rendered rows stay
+            // index-aligned with this list. No item cap — the popup's ScrollViewer
+            // bounds the height, so no bucket is silently dropped (the Windows wire
+            // catalog carries no tier data to hide "power" commands the way Mac does).
+            slashResults = slashGroups.SelectMany(g => g.Commands).ToList();
         }
 
         // Args-mode: the command (parsed from the composer text) plus its static
@@ -1093,7 +1101,7 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
             }
             else
             {
-                slashPopupContent = BuildSlashPopup(slashResults, slashIndex, insertSlashCommand);
+                slashPopupContent = BuildSlashPopup(slashGroups, slashIndex, insertSlashCommand);
                 slashMenuVisible = true;
             }
         }
@@ -1302,15 +1310,27 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
     }
 
     private static Border BuildSlashPopup(
-        IReadOnlyList<GatewayCommand> results, int selectedIndex, Action<GatewayCommand> onPick)
+        IReadOnlyList<CommandCategoryGroup> groups, int selectedIndex, Action<GatewayCommand> onPick)
     {
         var primary = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["TextFillColorPrimaryBrush"];
         var secondary = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["TextFillColorSecondaryBrush"];
         var selectedBg = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["SubtleFillColorSecondaryBrush"];
+        var headerBrush = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["TextFillColorTertiaryBrush"];
 
         var list = new StackPanel { Orientation = Orientation.Vertical };
-        for (int i = 0; i < results.Count; i++)
-            list.Children.Add(SlashRow(results[i], i == selectedIndex, primary, secondary, selectedBg, onPick));
+        // Each group leads with a non-interactive category subheading; command
+        // rows follow. A single running index across all groups keeps the
+        // rendered rows aligned with the flattened keyboard-navigation list.
+        var idx = 0;
+        foreach (var group in groups)
+        {
+            list.Children.Add(SlashCategoryHeader(CommandCategories.Label(group.Category), headerBrush));
+            foreach (var cmd in group.Commands)
+            {
+                list.Children.Add(SlashRow(cmd, idx == selectedIndex, primary, secondary, selectedBg, onPick));
+                idx++;
+            }
+        }
         var scroll = new ScrollViewer
         {
             VerticalScrollBarVisibility = Microsoft.UI.Xaml.Controls.ScrollBarVisibility.Auto,
@@ -1320,6 +1340,22 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         };
         return SlashShell(scroll);
     }
+
+    /// <summary>
+    /// Non-interactive category subheading for the slash palette: uppercase and
+    /// letter-spaced like Mac's .slash-menu-group__label, rendered in a muted
+    /// tone (Mac tints its label with the accent color; we keep it subdued to
+    /// match the reference design).
+    /// </summary>
+    private static TextBlock SlashCategoryHeader(string text, Brush foreground) => new()
+    {
+        Text = (text ?? "").ToUpperInvariant(),
+        FontSize = 11,
+        FontWeight = Microsoft.UI.Text.FontWeights.Bold,
+        CharacterSpacing = 60,   // ~0.06em (units are 1/1000 em)
+        Foreground = foreground,
+        Margin = new Thickness(8, 8, 8, 2),
+    };
 
     private static Border BuildSlashArgPopup(
         GatewayCommand cmd, IReadOnlyList<GatewayCommandArgChoice> choices,
@@ -1425,60 +1461,104 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
     private static Button SlashRow(
         GatewayCommand cmd, bool selected, Brush primary, Brush secondary, Brush selectedBg, Action<GatewayCommand> onPick)
     {
-        var row = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
-        row.Children.Add(new FontIcon
+        // Row layout mirrors Mac's .slash-menu-item: icon · /name · [args] on the
+        // left; description + "N options" badge pushed to the right edge (the
+        // description column is star-sized and right-aligned). Args use the mono
+        // font; the name keeps the default font (bold) for readability.
+        var mono = new Microsoft.UI.Xaml.Media.FontFamily("Consolas");
+
+        var grid = new Microsoft.UI.Xaml.Controls.Grid { ColumnSpacing = 8, VerticalAlignment = VerticalAlignment.Center };
+        grid.ColumnDefinitions.Add(new Microsoft.UI.Xaml.Controls.ColumnDefinition { Width = Microsoft.UI.Xaml.GridLength.Auto }); // icon
+        grid.ColumnDefinitions.Add(new Microsoft.UI.Xaml.Controls.ColumnDefinition { Width = Microsoft.UI.Xaml.GridLength.Auto }); // name
+        grid.ColumnDefinitions.Add(new Microsoft.UI.Xaml.Controls.ColumnDefinition { Width = Microsoft.UI.Xaml.GridLength.Auto }); // args
+        grid.ColumnDefinitions.Add(new Microsoft.UI.Xaml.Controls.ColumnDefinition { Width = new Microsoft.UI.Xaml.GridLength(1, Microsoft.UI.Xaml.GridUnitType.Star) }); // desc
+        grid.ColumnDefinitions.Add(new Microsoft.UI.Xaml.Controls.ColumnDefinition { Width = Microsoft.UI.Xaml.GridLength.Auto }); // badge
+
+        var icon = new FontIcon
         {
             FontFamily = (Microsoft.UI.Xaml.Media.FontFamily)Microsoft.UI.Xaml.Application.Current.Resources["SymbolThemeFontFamily"],
             Glyph = SlashGlyph(cmd),
             FontSize = 14,
             Foreground = secondary,
             VerticalAlignment = VerticalAlignment.Center,
-        });
-        row.Children.Add(new TextBlock
+        };
+        Microsoft.UI.Xaml.Controls.Grid.SetColumn(icon, 0);
+        grid.Children.Add(icon);
+
+        var name = new TextBlock
         {
             Text = cmd.DisplayName(),
             FontSize = 13,
             FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
             Foreground = primary,
             VerticalAlignment = VerticalAlignment.Center,
-        });
+        };
+        Microsoft.UI.Xaml.Controls.Grid.SetColumn(name, 1);
+        grid.Children.Add(name);
+
         var args = cmd.ArgTemplate();
         if (!string.IsNullOrWhiteSpace(args))
         {
-            row.Children.Add(new TextBlock
+            var argBlock = new TextBlock
             {
                 Text = args,
                 FontSize = 12,
+                FontFamily = mono,
                 Foreground = secondary,
+                Opacity = 0.75,
                 VerticalAlignment = VerticalAlignment.Center,
-            });
+            };
+            Microsoft.UI.Xaml.Controls.Grid.SetColumn(argBlock, 2);
+            grid.Children.Add(argBlock);
         }
+
         if (!string.IsNullOrWhiteSpace(cmd.Description))
         {
-            row.Children.Add(new TextBlock
+            var desc = new TextBlock
             {
                 Text = cmd.Description!,
                 FontSize = 12,
                 Foreground = secondary,
                 VerticalAlignment = VerticalAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                TextAlignment = Microsoft.UI.Xaml.TextAlignment.Right,
                 TextTrimming = TextTrimming.CharacterEllipsis,
                 MaxLines = 1,
-            });
+            };
+            Microsoft.UI.Xaml.Controls.Grid.SetColumn(desc, 3);
+            grid.Children.Add(desc);
         }
+
         var opts = cmd.OptionCount();
-        if (opts > 0) row.Children.Add(SlashBadge($"{opts} options", secondary));
+        if (opts > 0)
+        {
+            var badge = SlashBadge($"{opts} options");
+            Microsoft.UI.Xaml.Controls.Grid.SetColumn(badge, 4);
+            grid.Children.Add(badge);
+        }
 
         var btn = new Button
         {
-            Content = row,
+            Content = grid,
             Padding = new Thickness(8, 7, 8, 7),
             HorizontalAlignment = HorizontalAlignment.Stretch,
-            HorizontalContentAlignment = HorizontalAlignment.Left,
+            // Stretch the content so the star-sized description column fills the
+            // row and its right-alignment actually pushes desc/badge to the edge.
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
             CornerRadius = new CornerRadius(6),
             Background = selected ? selectedBg : new SolidColorBrush(Colors.Transparent),
             BorderThickness = new Thickness(0),
         };
         btn.Click += (_, _) => onPick(cmd);
+        // Auto-scroll: when this is the keyboard-selected row, bring it into view
+        // once it mounts so arrow navigation past the visible fold follows the
+        // selection (the popup content is rebuilt each render, so Loaded fires per
+        // navigation step). No animation to keep keypress scrolling snappy.
+        if (selected)
+        {
+            btn.Loaded += (_, _) =>
+                btn.StartBringIntoView(new Microsoft.UI.Xaml.BringIntoViewOptions { AnimationDesired = false });
+        }
         return btn;
     }
 
@@ -1509,16 +1589,27 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         };
     }
 
-    private static Border SlashBadge(string text, Brush foreground) => new()
+    // Accent-tinted pill mirroring Mac's .slash-menu-badge (accent text on a
+    // ~14% accent fill).
+    private static Border SlashBadge(string text)
     {
-        Padding = new Thickness(5, 1, 5, 1),
-        CornerRadius = new CornerRadius(4),
-        Background = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["SubtleFillColorSecondaryBrush"],
-        BorderThickness = new Thickness(1),
-        BorderBrush = (Brush)Microsoft.UI.Xaml.Application.Current.Resources["ControlStrokeColorDefaultBrush"],
-        VerticalAlignment = VerticalAlignment.Center,
-        Child = new TextBlock { Text = text, FontSize = 10, Foreground = foreground },
-    };
+        var accent = Microsoft.UI.Xaml.Application.Current.Resources["AccentFillColorDefaultBrush"] as SolidColorBrush
+            ?? new SolidColorBrush(Microsoft.UI.Colors.SteelBlue);
+        return new Border
+        {
+            Padding = new Thickness(6, 1, 6, 1),
+            CornerRadius = new CornerRadius(4),
+            Background = new SolidColorBrush(accent.Color) { Opacity = 0.14 },
+            VerticalAlignment = VerticalAlignment.Center,
+            Child = new TextBlock
+            {
+                Text = text,
+                FontSize = 10,
+                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+                Foreground = accent,
+            },
+        };
+    }
 
     /// <summary>
     /// Creates (once) and drives the floating slash-menu Popup so it overlays

--- a/tests/OpenClaw.Shared.Tests/CommandCatalogPresentationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CommandCatalogPresentationTests.cs
@@ -259,6 +259,112 @@ public class CommandCatalogPresentationTests
     }
 
     [Fact]
+    public void GroupBy_WithExplicitCategoryOrder_OrdersBySequenceThenAlphabetical()
+    {
+        var view = new ChatCommandCatalogView(new[]
+        {
+            new GatewayCommand { Name = "verbose", NativeName = "/verbose", Category = "options" },
+            new GatewayCommand { Name = "stop", NativeName = "/stop", Category = "session" },
+            new GatewayCommand { Name = "send", NativeName = "/send", Category = "management" },
+            new GatewayCommand { Name = "zeta", NativeName = "/zeta", Category = "zzz-unknown" },
+        });
+
+        // Listed categories follow the supplied order; the unlisted one sorts last.
+        var order = new[] { "session", "options", "management" };
+        var categories = view.GroupByCategory(null, order).Select(g => g.Category).ToList();
+
+        Assert.Equal(new[] { "session", "options", "management", "zzz-unknown" }, categories);
+    }
+
+    [Fact]
+    public void GroupByCategory_NullCategoryOrder_StillOrdersAlphabetically()
+    {
+        var view = new ChatCommandCatalogView(Sample());
+        var categories = view.GroupByCategory(null, null).Select(g => g.Category).ToList();
+        Assert.Equal(categories.OrderBy(c => c, System.StringComparer.OrdinalIgnoreCase).ToList(), categories);
+    }
+
+    // ── CommandCategories: Mac 4-bucket mapping ──
+
+    [Fact]
+    public void GroupBy_MacBucket_GroupsRunOptionsUnderModel()
+    {
+        var view = new ChatCommandCatalogView(new[]
+        {
+            new GatewayCommand { Name = "verbose", NativeName = "/verbose", Category = "options" },
+            new GatewayCommand { Name = "exec", NativeName = "/exec", Category = "options" },
+            new GatewayCommand { Name = "usage", NativeName = "/usage", Category = "options" },   // override → tools
+            new GatewayCommand { Name = "stop", NativeName = "/stop", Category = "session" },
+            new GatewayCommand { Name = "send", NativeName = "/send", Category = "management" },   // → tools
+            new GatewayCommand { Name = "steer", NativeName = "/steer", Category = "tools" },      // override → agents
+        });
+
+        var groups = view.GroupBy(CommandCategories.Bucket, null, CommandCategories.DisplayOrder);
+        var keys = groups.Select(g => g.Category).ToList();
+
+        // Mac order: session, model, tools, agents.
+        Assert.Equal(new[] { "session", "model", "tools", "agents" }, keys);
+        Assert.Equal(new[] { "/exec", "/verbose" }, groups.Single(g => g.Category == "model").Commands.Select(c => c.DisplayName()).ToArray());
+        Assert.Contains(groups.Single(g => g.Category == "tools").Commands, c => c.Name == "usage");
+        Assert.Contains(groups.Single(g => g.Category == "tools").Commands, c => c.Name == "send");
+        Assert.Contains(groups.Single(g => g.Category == "agents").Commands, c => c.Name == "steer");
+    }
+
+    [Fact]
+    public void GroupBy_PreservesSearchRelevanceWithinGroup_NotAlphabetical()
+    {
+        // Both commands bucket under "model" (raw category options). For query
+        // "model", "model" is an exact match while "amodel" is only a contains
+        // match — relevance must keep "model" first even though "amodel" sorts
+        // first alphabetically. Guards against re-introducing a within-group sort.
+        var view = new ChatCommandCatalogView(new[]
+        {
+            new GatewayCommand { Name = "amodel", NativeName = "/amodel", Category = "options" },
+            new GatewayCommand { Name = "model", NativeName = "/model", Category = "options" },
+        });
+
+        var model = view.GroupBy(CommandCategories.Bucket, "model", CommandCategories.DisplayOrder)
+            .Single(g => g.Category == "model");
+
+        Assert.Equal(new[] { "/model", "/amodel" }, model.Commands.Select(c => c.DisplayName()).ToArray());
+    }
+
+    [Theory]
+    [InlineData("verbose", "options", "model")]   // run option → Model
+    [InlineData("exec", "options", "model")]
+    [InlineData("trace", "options", "model")]     // no override; raw "options" → model
+    [InlineData("usage", "options", "tools")]     // override wins over raw category
+    [InlineData("think", "options", "model")]
+    [InlineData("stop", "session", "session")]
+    [InlineData("send", "management", "tools")]    // raw "management" → tools
+    [InlineData("steer", "tools", "agents")]       // override → agents
+    [InlineData("mystery", "weirdcat", "tools")]   // unknown name + unknown category → tools
+    public void Bucket_MapsCommandToMacDisplayBucket(string name, string category, string expected)
+    {
+        var cmd = new GatewayCommand { Name = name, NativeName = "/" + name, Category = category };
+        Assert.Equal(expected, CommandCategories.Bucket(cmd));
+    }
+
+    [Theory]
+    [InlineData("session", "Session")]
+    [InlineData("model", "Model")]
+    [InlineData("tools", "Tools")]
+    [InlineData("agents", "Agents")]
+    [InlineData("custom", "Custom")]   // unknown → Title-cased
+    [InlineData("", "Other")]
+    [InlineData(null, "Other")]
+    public void CommandCategories_Label_MapsKnownAndTitleCasesUnknown(string? bucket, string expected)
+    {
+        Assert.Equal(expected, CommandCategories.Label(bucket));
+    }
+
+    [Fact]
+    public void CommandCategories_DisplayOrder_MatchesMac()
+    {
+        Assert.Equal(new[] { "session", "model", "tools", "agents" }, CommandCategories.DisplayOrder.ToArray());
+    }
+
+    [Fact]
     public void View_NullCommands_IsEmpty()
     {
         var view = new ChatCommandCatalogView(null);

--- a/tests/OpenClaw.Shared.Tests/CommandCatalogPresentationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CommandCatalogPresentationTests.cs
@@ -329,6 +329,53 @@ public class CommandCatalogPresentationTests
         Assert.Equal(new[] { "/model", "/amodel" }, model.Commands.Select(c => c.DisplayName()).ToArray());
     }
 
+    [Fact]
+    public void GroupForPalette_DefaultSelection_PinsGlobalBestAcrossBuckets()
+    {
+        // "exec" is an exact match in the Model bucket; "reexec" is only a contains
+        // match in the earlier Session bucket. Display grouping renders Session
+        // first, so the weak match is row 0 — but DefaultSelectionIndex must point
+        // at the global best (exec), so Enter/Tab still inserts the strongest match
+        // rather than the first visible row. Regression guard for grouped selection.
+        var view = new ChatCommandCatalogView(new[]
+        {
+            new GatewayCommand { Name = "reexec", NativeName = "/reexec", Category = "session" },
+            new GatewayCommand { Name = "exec", NativeName = "/exec", Category = "options" },
+        });
+
+        var palette = view.GroupForPalette(CommandCategories.Bucket, "exec", CommandCategories.DisplayOrder);
+
+        // Flattened (render/nav) order follows bucket order: weak Session match first.
+        Assert.Equal(new[] { "reexec", "exec" }, palette.Flattened.Select(c => c.Name).ToArray());
+        // But the default keyboard selection is the global best match, not row 0.
+        Assert.Equal(1, palette.DefaultSelectionIndex);
+        Assert.Equal("exec", palette.Flattened[palette.DefaultSelectionIndex].Name);
+    }
+
+    [Fact]
+    public void GroupForPalette_DefaultSelection_IsZeroWhenNoMatches()
+    {
+        var view = new ChatCommandCatalogView(new[]
+        {
+            new GatewayCommand { Name = "exec", NativeName = "/exec", Category = "options" },
+        });
+        var palette = view.GroupForPalette(CommandCategories.Bucket, "zzznope", CommandCategories.DisplayOrder);
+        Assert.Empty(palette.Flattened);
+        Assert.Equal(0, palette.DefaultSelectionIndex);
+    }
+
+    [Fact]
+    public void GroupForPalette_FlattenedMatchesGroupedOrder()
+    {
+        // Flattened must equal the groups concatenated in order, so the composer's
+        // running render index stays aligned with the keyboard-navigation list.
+        var view = new ChatCommandCatalogView(Sample());
+        var palette = view.GroupForPalette(CommandCategories.Bucket, null, CommandCategories.DisplayOrder);
+        Assert.Equal(
+            palette.Groups.SelectMany(g => g.Commands).Select(c => c.Name).ToArray(),
+            palette.Flattened.Select(c => c.Name).ToArray());
+    }
+
     [Theory]
     [InlineData("verbose", "options", "model")]   // run option → Model
     [InlineData("exec", "options", "model")]

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -447,6 +447,17 @@ public sealed class AppRefactorContractTests
         Assert.Contains("usable MXC backend", reject);
     }
 
+    [Fact]
+    public void ChatSlashPalette_HiddenNoMatchStateDoesNotTrapKeys()
+    {
+        var source = ReadOpenClawComposerSource();
+
+        Assert.Contains("else if (slashActive && Props.AvailableCommands is null)", source);
+        Assert.Contains("No-match input hides the popup", source);
+        Assert.Contains("ordinary composer text", source);
+        Assert.DoesNotContain("var slashLoading = Props.AvailableCommands is null;", source);
+    }
+
     private static string ReadCoordinatorSource()
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();
@@ -478,6 +489,13 @@ public sealed class AppRefactorContractTests
         var root = TestRepositoryPaths.GetRepositoryRoot();
         return File.ReadAllText(Path.Combine(
             root, "src", "OpenClaw.Tray.WinUI", "Pages", "SandboxPage.xaml.cs"));
+    }
+
+    private static string ReadOpenClawComposerSource()
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        return File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.Tray.WinUI", "Chat", "OpenClawComposer.cs"));
     }
 
     private static string ExtractMethod(string source, string methodName)


### PR DESCRIPTION
## Summary

- **Problem:** The Windows chat `/` slash palette (added in #890) showed a flat, alphabetically-ordered list **capped at 8 items**, so most of the gateway command catalog was hidden — late-alphabet run options (`/verbose`, `/reasoning`, `/trace`, `/usage`) and many other commands were simply truncated off — and there were no category subheadings, diverging from Mac's grouped menu.
- **Why it matters:** Mac parity for discovering session/run controls via `/`. With only 8 of N commands ever visible, most commands (incl. the run options) were effectively unreachable from the palette unless you already knew their exact name.
- **What changed:**
  - **Surface the full command catalog** — removed the 8-item cap, so **every** command the gateway advertises is now reachable in the palette (it scrolls), instead of just the top 8 matches.
  - **Group by Mac buckets** — commands render under Mac's **Session / Model / Tools / Agents** subheadings (uppercase) with Mac-style rows (icon · `/name` · `[args]` · right-aligned description · accent-tinted `N options` badge). Run options appear under **MODEL**.
  - **Live filter + highlight** — the list filters/ranks as you type and the matched substring is highlighted (soft accent tint + white text) in the name and description.
  - **Selection & navigation** — the default Enter/Tab target is the **global best match across buckets**, and the keyboard-selected row **auto-scrolls** into view.
  - **Polish** — the flyout background matches the composer textbox (opaque), and the flyout **hides entirely when nothing matches**.
  - **No-match keyboard fallback** — when the catalog is loaded and no query matches, the hidden flyout no longer traps Tab/Escape/arrows/Enter; it behaves like ordinary composer text.
- **User impact:** Typing `/` now reveals the **whole command catalog** in a grouped, scrollable, Mac-faithful menu (previously you saw at most 8 rows). Run options live under **MODEL**; the list narrows/ranks/highlights as you type with the strongest match kept as the default Enter target.
- **What did NOT change (scope boundary):** This does not author any new command definitions — all commands come from the gateway `commands.list` catalog; the PR only changes how they are surfaced/grouped/selected. No custom "Run options" (•••) menu (Mac has none) and no `sessions.patch` UI plumbing. The arg-choice picker and loading-state Enter/Tab/Escape behavior from #890 are unchanged; loaded no-match text now falls through as ordinary composer input.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Docs / instructions
- [x] Tests / validation
- [ ] Security hardening
- [ ] Chore / infra

## Scope (select all touched areas)

- [x] Tray / WinUI UX
- [ ] Windows node capability
- [ ] Local MCP / `winnode`
- [ ] Gateway / connection / pairing
- [ ] Setup / onboarding
- [ ] Permissions / privacy / security
- [x] Tests / CI / docs

## Linked Issue/PR

- Closes #
- Related #890 (inline `/`-triggered gateway command catalog menu)
- [ ] Related to a bug or regression

## Validation

After code changes, on Windows ARM64 (`OPENCLAW_REPO_ROOT` set to the worktree):

- `./build.ps1` — ✅ all 5 projects built (Shared, Cli, WinNodeCli, SetupEngine, WinUI)
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — ✅ **Passed: 2683, Failed: 0, Skipped: 31**
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — ✅ **Passed: 1444, Failed: 0**

New focused tests in `CommandCatalogPresentationTests.cs` cover the Mac 4-bucket mapping (`Bucket`), bucket ordering (`GroupBy` with `DisplayOrder`), labels, within-group relevance preservation, and the **global-best default selection across buckets** (`GroupForPalette` / `GroupedPalette.DefaultSelectionIndex`, incl. a cross-bucket regression test). `AppRefactorContractTests.ChatSlashPalette_HiddenNoMatchStateDoesNotTrapKeys` covers the follow-up no-match key-trapping regression.

## Real behavior proof

- **Environment tested:** Windows ARM64, non-isolated local run (`./run-app-local.ps1 -NoBuild -AllowNonMain`), connected to a gateway exposing the `commands.list` catalog.
- **PR head / commit tested:** `824774ca`
- **Exact steps or command run:**
  1. Open Chat, type `/` — observe the grouped palette.
  2. Arrow-navigate (↑/↓) through the groups past the visible fold (selected row scrolls into view).
  3. Type `/reas` — observe live filtering down to `/reasoning` under **MODEL**, with the matched `reas` highlighted.
  4. Type a non-matching token (e.g. `/zzz`) — the flyout hides.
- **Observed result:** Palette renders uppercase **SESSION / MODEL / TOOLS / AGENTS** subheadings; run options (`/verbose`, `/reasoning`, `/exec`, `/think`, …) appear under **MODEL**; each row shows `icon · /name · [args] · right-aligned description · "N options"` badge; the matched substring is highlighted (soft tint + white text); the list filters and re-ranks as you type; the default Enter target is the global best match across buckets; the flyout background matches the textbox and hides on no match. The follow-up fix limits zero-selectable key trapping to the visible loading state so loaded hidden no-match input falls through as ordinary composer text.
- **Screenshot/artifact links verified?** `Yes`
<img width="1235" height="806" alt="image" src="https://github.com/user-attachments/assets/dc3e0b52-184c-493a-999e-3c4536e89d1f" />

- **Not verified / blocked:** N/A

> Rubber-duck review: dual review (GPT-5.5 + Claude Opus 4.8) — no blocking issues; consensus should-fixes addressed (removed the item cap so no bucket is silently dropped, preserved within-group relevance, `NormalizeKey` prefers the text-surface `Name`, defensive accent-brush cast).
> ClawSweeper/Codex review: P2 selection-order finding addressed — keyboard selection now pins the global best `Search` match across grouped buckets (via `GroupForPalette` / `GroupedPalette.DefaultSelectionIndex`) with a cross-bucket regression test. Follow-up no-match key-trapping finding addressed in `824774ca`. Re-validated green.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` (this is presentation/ordering only over the existing `commands.list` catalog; no new command is invoked)
- Data access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only conversations that still need reviewer or maintainer judgment.

