### PR TITLE
Fix Tray UI test window hiding for release

### DIFF
--- a/tests/OpenClaw.Tray.UITests/UIThreadFixture.cs
+++ b/tests/OpenClaw.Tray.UITests/UIThreadFixture.cs
@@ -226,9 +226,9 @@ public sealed class UIThreadFixture : IDisposable
 
                     if (!IsSlow)
                     {
-                        // Default: hide the window so CI runs are silent.
-                        _startupPhase = "hiding test window";
-                        TryHide(TestWindow);
+                        // Default: keep the window live but off-screen so CI runs are silent.
+                        _startupPhase = "moving test window off-screen";
+                        MoveOffScreen(TestWindow);
                     }
 
                     _startupPhase = "ready";
@@ -248,17 +248,14 @@ public sealed class UIThreadFixture : IDisposable
         }
     }
 
-    private static void TryHide(Window w)
+    private static void MoveOffScreen(Window w)
     {
         try
         {
-            // WindowsAppSDK 1.5+ supports AppWindow.Hide via WinUIEx, but to keep
-            // deps minimal we just move the window off-screen. It's still a real
-            // Window — XamlRoot is attached, the visual tree lays out — but the
-            // user never sees it during tests.
-            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(w);
-            // SW_HIDE = 0
-            ShowWindow(hwnd, 0);
+            // Move off-screen so CI runs are silent while keeping the window
+            // live in the WinUI compositor. XamlRoot stays attached, the visual
+            // tree lays out, but the user never sees it during tests.
+            w.AppWindow.MoveAndResize(new Windows.Graphics.RectInt32(-32000, -32000, 1, 1));
         }
         // slopwatch-ignore: SW003 Test cleanup or fixture teardown is best-effort and must not hide the test outcome.
         catch
@@ -266,10 +263,6 @@ public sealed class UIThreadFixture : IDisposable
             // best-effort; tests still work even if the window briefly flashes.
         }
     }
-
-    [System.Runtime.InteropServices.DllImport("user32.dll")]
-    [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)]
-    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
 
     public void Dispose()
     {


### PR DESCRIPTION
## Summary

The v0.6.12 tag release failed in the `test` job because `OpenClaw.Tray.UITests.SmokeTests.Container_AcceptsTextBlockAndLaysOut` saw a null `XamlRoot` after the UI fixture hid its test window with `SW_HIDE`.

This changes the UI test fixture to keep the WinUI window live in the compositor and move it off-screen instead of hiding it. That matches the existing comment's intent and keeps `XamlRoot` attached while CI remains visually quiet.

## Validation

- `./build.ps1` - passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` - passed: 2686 passed, 31 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` - passed: 1449 passed
- `dotnet test ./tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj -c Debug -r win-x64 --no-restore` - passed: 76 passed
- `dotnet test ./tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj -c Debug -r win-x64 --no-restore --filter FullyQualifiedName~Container_AcceptsTextBlockAndLaysOut` - passed: 1 passed

## Real behavior proof

The previously failing release smoke test now passes locally on the same `win-x64` UI test path used by CI. The fixture no longer calls `ShowWindow(..., SW_HIDE)`; it uses `AppWindow.MoveAndResize` after activation, preserving the WinUI visual tree bridge while moving the window off-screen.

Rubber-duck review: no blocking issues.

## Release follow-up

After this lands, move/recreate tag `v0.6.12` on the new `main` tip to rerun the release workflow.
