### PR TITLE
Virtualize chat timeline rows

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
@@ -466,7 +466,7 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
 
         var scrollViewRef = UseRef<Microsoft.UI.Xaml.Controls.ScrollViewer?>(null);
         var isFollowingRef = UseRef(true);
-        var contentRef = UseRef<Microsoft.UI.Xaml.Controls.StackPanel?>(null);
+        var contentRef = UseRef<FrameworkElement?>(null);
         var prevEntryCountRef = UseRef(0);
         var prevSessionIdRef = UseRef<string?>(null);
         var prevFirstEntryIdRef = UseRef<string?>(null);
@@ -509,7 +509,10 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
         if (prevShowToolCallsRef.Current != showToolCalls)
         {
             prevShowToolCallsRef.Current = showToolCalls;
-            contentRef.Current?.Children.Clear();
+            if (contentRef.Current is ItemsRepeater repeater)
+                repeater.ItemsSource = Array.Empty<object>();
+            else if (contentRef.Current is StackPanel stackPanel)
+                stackPanel.Children.Clear();
         }
 
         // Hover state — set of entry ids currently under the pointer. Used to
@@ -2490,12 +2493,12 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                     Grid([GridSize.Star()], [GridSize.Auto, GridSize.Auto, GridSize.Auto, GridSize.Auto],
                         loadMoreButton.Grid(row: 0, column: 0),
                         Border(Empty()).Height(20).Grid(row: 1, column: 0),
-                        VStack(2, timelineRows).Set(sp =>
+                        VirtualVStack(2, timelineRows).Set(host =>
                         {
-                            if (contentRef.Current != sp)
+                            if (contentRef.Current != host)
                             {
-                                contentRef.Current = (Microsoft.UI.Xaml.Controls.StackPanel)sp;
-                                sp.SizeChanged += (_, _) =>
+                                contentRef.Current = host;
+                                host.SizeChanged += (_, _) =>
                                 {
                                     if (scrollViewRef.Current is not { } sv) return;
 

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
@@ -75,6 +75,8 @@ public record OpenClawChatTimelineProps(
 public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
 {
     const double FollowThreshold = 60;
+    const int FollowToBottomMaxStabilizationPasses = 4;
+    const double FollowToBottomExtentEpsilon = 0.5;
 
     /// <summary>
     /// Static scroll-offset store shared across all timeline instances so that
@@ -639,15 +641,27 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
         void QueueScrollToBottom(Microsoft.UI.Xaml.Controls.ScrollViewer sv, string? sessionId, bool disableAnimation)
         {
             isFollowingRef.Current = true;
-            sv.DispatcherQueue.TryEnqueue(() =>
+
+            void QueuePass(int pass, double previousScrollableHeight, bool passDisableAnimation)
             {
-                var bottom = sv.ScrollableHeight;
-                sv.ChangeView(null, bottom, null, disableAnimation);
-                lastVerticalOffsetRef.Current = bottom;
-                lastScrollableHeightRef.Current = sv.ScrollableHeight;
-                isFollowingRef.Current = true;
-                StoreSessionOffset(sessionId, bottom);
-            });
+                sv.DispatcherQueue.TryEnqueue(() =>
+                {
+                    sv.UpdateLayout();
+                    var bottom = sv.ScrollableHeight;
+                    sv.ChangeView(null, bottom, null, passDisableAnimation);
+                    lastVerticalOffsetRef.Current = bottom;
+                    lastScrollableHeightRef.Current = sv.ScrollableHeight;
+                    isFollowingRef.Current = true;
+                    StoreSessionOffset(sessionId, bottom);
+
+                    var extentStable = Math.Abs(bottom - previousScrollableHeight) <= FollowToBottomExtentEpsilon;
+                    var atBottom = sv.ScrollableHeight - sv.VerticalOffset <= FollowThreshold;
+                    if (pass < FollowToBottomMaxStabilizationPasses && (!extentStable || !atBottom))
+                        QueuePass(pass + 1, sv.ScrollableHeight, passDisableAnimation: true);
+                });
+            }
+
+            QueuePass(0, double.NaN, disableAnimation);
         }
 
         void QueuePreservePrependOffset(Microsoft.UI.Xaml.Controls.ScrollViewer sv, string? sessionId, double oldOffset, double oldScrollableHeight)

--- a/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
+++ b/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
@@ -202,6 +202,7 @@ public sealed record ComboBoxElement(string[] Items, int SelectedIndex, Action<i
 public sealed record ImageElement(string Source) : Element;
 public sealed record BorderElement(Element? Child) : Element;
 public sealed record StackElement(Orientation Orientation, double Spacing, IReadOnlyList<Element?> Children) : Element;
+public sealed record VirtualStackElement(Orientation Orientation, double Spacing, IReadOnlyList<Element?> Children) : Element;
 public sealed record FlexRowElement(IReadOnlyList<Element?> Children) : Element
 {
     public double ColumnGap { get; init; }
@@ -597,6 +598,8 @@ public static class Factories
     public static StackElement VStack(double spacing, params Element?[] children) => new(Orientation.Vertical, spacing, children);
     public static StackElement HStack(params Element?[] children) => new(Orientation.Horizontal, 0, children);
     public static StackElement HStack(double spacing, params Element?[] children) => new(Orientation.Horizontal, spacing, children);
+    public static VirtualStackElement VirtualVStack(double spacing, params Element?[] children) => new(Orientation.Vertical, spacing, children);
+    public static VirtualStackElement VirtualHStack(double spacing, params Element?[] children) => new(Orientation.Horizontal, spacing, children);
     public static GridElement Grid(string[] columns, string[] rows, params Element?[] children) => new(columns, rows, children);
     public static GridElement Grid(GridSize[] columns, GridSize[] rows, params Element?[] children) =>
         new(columns.Select(c => c.ToString()).ToArray(), rows.Select(r => r.ToString()).ToArray(), children);
@@ -964,6 +967,7 @@ internal sealed class UiRenderer(Action requestRender)
             ImageElement e => ConfigureImage(GetOrCreate<Image>(path), e),
             BorderElement e => ConfigureBorder(GetOrCreate<Border>(path), e, path, effects),
             StackElement e => ConfigureStack(GetOrCreate<Border>(path), e, path, effects),
+            VirtualStackElement e => ConfigureVirtualStack(GetOrCreate<Border>(path), e, path),
             FlexRowElement e => ConfigureFlexRow(GetOrCreate<Border>(path), e, path, effects),
             GridElement e => ConfigureGrid(GetOrCreate<Border>(path), e, path, effects),
             ScrollViewElement e => ConfigureScrollView(GetOrCreate<ScrollViewer>(path), e, path, effects),
@@ -1277,6 +1281,56 @@ internal sealed class UiRenderer(Action requestRender)
         ApplyModifiers(wrapper, element);
         ApplySetters(panel, element);
         return wrapper;
+    }
+
+    private Border ConfigureVirtualStack(Border wrapper, VirtualStackElement element, string path)
+    {
+        var repeater = GetOrCreate<ItemsRepeater>(path + ".repeater");
+        if (repeater.Layout is not StackLayout layout)
+        {
+            layout = new StackLayout();
+            repeater.Layout = layout;
+        }
+        layout.Orientation = element.Orientation;
+        layout.Spacing = element.Spacing;
+
+        repeater.ItemsSource = element.Children
+            .Select((child, index) => child is null ? null : new VirtualStackItem(index, child))
+            .Where(item => item is not null)
+            .Cast<VirtualStackItem>()
+            .ToArray();
+        repeater.ItemTemplate = new VirtualStackItemTemplate(this, path);
+        repeater.HorizontalAlignment = HorizontalAlignment.Stretch;
+        repeater.VerticalAlignment = VerticalAlignment.Stretch;
+
+        SetChild(wrapper, repeater);
+        ApplyModifiers(wrapper, element);
+        ApplySetters(repeater, element);
+        return wrapper;
+    }
+
+    private sealed record VirtualStackItem(int Index, Element Element);
+
+    private sealed class VirtualStackItemTemplate(UiRenderer renderer, string path) : IElementFactory
+    {
+        public UIElement GetElement(ElementFactoryGetArgs args)
+        {
+            if (args.Data is not VirtualStackItem item)
+                return new Border();
+
+            var effects = new List<Action>();
+            var control = renderer.RenderElement(item.Element, ChildPath(path, item.Index, item.Element), effects);
+            foreach (var effect in effects)
+                effect();
+            return control;
+        }
+
+        public void RecycleElement(ElementFactoryRecycleArgs args)
+        {
+            // The renderer cache owns element identity by path. ItemsRepeater
+            // detaches recycled rows; re-realization asks for the same path and
+            // gets a refreshed control without rebuilding the whole list.
+        }
     }
 
     private Border ConfigureFlexRow(Border wrapper, FlexRowElement element, string path, List<Action> effects)

--- a/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
+++ b/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
@@ -816,6 +816,7 @@ public sealed class FunctionalHostControl : ContentControl, IDisposable
     /// survives page navigation.
     /// </summary>
     public bool SuppressAutoDispose { get; set; }
+    internal int CachedVirtualStackControlCount => _renderer.CachedVirtualStackControlCount;
 
     public FunctionalHostControl()
     {
@@ -921,6 +922,9 @@ internal sealed class UiRenderer(Action requestRender)
     private readonly HashSet<string> _visitedContentFlyoutPaths = new();
     private readonly HashSet<string> _visitedVirtualStackPaths = new();
     private readonly Dictionary<string, string[]> _virtualStackOwnedPathPrefixes = new();
+
+    internal int CachedVirtualStackControlCount =>
+        _controls.Keys.Count(IsOwnedByVirtualStack);
 
     public UIElement Render(Element element, string path, List<Action> effects)
     {
@@ -1345,10 +1349,12 @@ internal sealed class UiRenderer(Action requestRender)
     {
         foreach (var item in items)
         {
-            if (item.RealizedControl is null)
+            if (item.RealizedContainer is null)
                 continue;
 
-            item.RealizedControl = RenderElementCore(item.Element, item.Path, effects);
+            var child = RenderElementCore(item.Element, item.Path, effects);
+            SetChild(item.RealizedContainer, child);
+            PruneUnvisitedCachedSubtree(item.Path);
         }
     }
 
@@ -1361,6 +1367,14 @@ internal sealed class UiRenderer(Action requestRender)
         {
             if (!string.Equals(currentItems[i].Path, nextItems[i].Path, StringComparison.Ordinal))
                 return false;
+            if (currentItems[i].Element.GetType() != nextItems[i].Element.GetType())
+                return false;
+            if (currentItems[i].Element is ComponentElement currentComponent
+                && nextItems[i].Element is ComponentElement nextComponent
+                && currentComponent.ComponentType != nextComponent.ComponentType)
+            {
+                return false;
+            }
         }
 
         return true;
@@ -1371,11 +1385,13 @@ internal sealed class UiRenderer(Action requestRender)
         public int Index { get; set; } = index;
         public string Path { get; } = path;
         public Element Element { get; set; } = element;
-        public UIElement? RealizedControl { get; set; }
+        public Border? RealizedContainer { get; set; }
     }
 
     private sealed class VirtualStackItemTemplate(UiRenderer renderer, string path) : IElementFactory
     {
+        private readonly Dictionary<UIElement, VirtualStackItem> _realizedItems = new();
+
         public bool Matches(UiRenderer otherRenderer, string otherPath) =>
             ReferenceEquals(renderer, otherRenderer) && string.Equals(path, otherPath, StringComparison.Ordinal);
 
@@ -1384,19 +1400,86 @@ internal sealed class UiRenderer(Action requestRender)
             if (args.Data is not VirtualStackItem item)
                 return new Border();
 
+            var container = new Border { HorizontalAlignment = HorizontalAlignment.Stretch };
             var effects = new List<Action>();
-            var control = renderer.RenderElementCore(item.Element, item.Path, effects);
-            item.RealizedControl = control;
+            var child = renderer.RenderElementCore(item.Element, item.Path, effects);
+            renderer.SetChild(container, child);
+            item.RealizedContainer = container;
+            _realizedItems[container] = item;
             foreach (var effect in effects)
                 effect();
-            return control;
+            return container;
         }
 
         public void RecycleElement(ElementFactoryRecycleArgs args)
         {
-            // The renderer cache owns element identity by path. ItemsRepeater
-            // detaches recycled rows; re-realization asks for the same path and
-            // gets a refreshed control without rebuilding the whole list.
+            if (args.Element is not { } control || !_realizedItems.Remove(control, out var item))
+                return;
+
+            if (ReferenceEquals(item.RealizedContainer, control))
+                item.RealizedContainer = null;
+            renderer.RemoveCachedSubtree(item.Path);
+        }
+    }
+
+    private void PruneUnvisitedCachedSubtree(string prefix)
+    {
+        foreach (var (key, component) in _components
+                     .Where(pair => IsPathAtOrBelow(pair.Key, prefix) && !_visitedComponentKeys.Contains(pair.Key))
+                     .ToArray())
+        {
+            component.Context.RunEffectCleanups();
+            _components.Remove(key);
+        }
+
+        foreach (var (path, flyout) in _contentFlyouts
+                     .Where(pair => IsPathAtOrBelow(pair.Key, prefix) && !_visitedContentFlyoutPaths.Contains(pair.Key))
+                     .ToArray())
+        {
+            flyout.Hide();
+            flyout.Content = null;
+            _contentFlyouts.Remove(path);
+        }
+
+        foreach (var (path, cachedControl) in _controls
+                     .Where(pair => IsPathAtOrBelow(pair.Key, prefix) && !_visitedControlPaths.Contains(pair.Key))
+                     .OrderByDescending(pair => pair.Key.Length)
+                     .ToArray())
+        {
+            _mountedPaths.Remove(path);
+            DetachChildren(cachedControl);
+            RemoveFromParent(cachedControl);
+            _controls.Remove(path);
+        }
+    }
+
+    private void RemoveCachedSubtree(string prefix)
+    {
+        foreach (var (key, component) in _components
+                     .Where(pair => IsPathAtOrBelow(pair.Key, prefix))
+                     .ToArray())
+        {
+            component.Context.RunEffectCleanups();
+            _components.Remove(key);
+        }
+
+        foreach (var (path, flyout) in _contentFlyouts
+                     .Where(pair => IsPathAtOrBelow(pair.Key, prefix))
+                     .ToArray())
+        {
+            flyout.Hide();
+            _contentFlyouts.Remove(path);
+        }
+
+        foreach (var (path, cachedControl) in _controls
+                     .Where(pair => IsPathAtOrBelow(pair.Key, prefix))
+                     .OrderByDescending(pair => pair.Key.Length)
+                     .ToArray())
+        {
+            _mountedPaths.Remove(path);
+            DetachChildren(cachedControl);
+            RemoveFromParent(cachedControl);
+            _controls.Remove(path);
         }
     }
 

--- a/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
+++ b/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
@@ -919,12 +919,15 @@ internal sealed class UiRenderer(Action requestRender)
     private readonly HashSet<string> _visitedControlPaths = new();
     private readonly HashSet<string> _visitedComponentKeys = new();
     private readonly HashSet<string> _visitedContentFlyoutPaths = new();
+    private readonly HashSet<string> _visitedVirtualStackPaths = new();
+    private readonly Dictionary<string, string[]> _virtualStackOwnedPathPrefixes = new();
 
     public UIElement Render(Element element, string path, List<Action> effects)
     {
         _visitedControlPaths.Clear();
         _visitedComponentKeys.Clear();
         _visitedContentFlyoutPaths.Clear();
+        _visitedVirtualStackPaths.Clear();
 
         var rendered = RenderElement(element, path, effects);
         PruneUnvisitedPaths();
@@ -943,13 +946,17 @@ internal sealed class UiRenderer(Action requestRender)
         _controls.Clear();
         _contentFlyouts.Clear();
         _mountedPaths.Clear();
+        _visitedVirtualStackPaths.Clear();
+        _virtualStackOwnedPathPrefixes.Clear();
     }
 
     private UIElement RenderElement(Element element, string path, List<Action> effects)
     {
-        if (!string.IsNullOrEmpty(element.Key))
-            path += "#" + element.Key;
+        return RenderElementCore(element, ResolveElementPath(path, element), effects);
+    }
 
+    private UIElement RenderElementCore(Element element, string path, List<Action> effects)
+    {
         var control = element switch
         {
             TextBlockElement e => ConfigureTextBlock(GetOrCreate<TextBlock>(path), e),
@@ -967,7 +974,7 @@ internal sealed class UiRenderer(Action requestRender)
             ImageElement e => ConfigureImage(GetOrCreate<Image>(path), e),
             BorderElement e => ConfigureBorder(GetOrCreate<Border>(path), e, path, effects),
             StackElement e => ConfigureStack(GetOrCreate<Border>(path), e, path, effects),
-            VirtualStackElement e => ConfigureVirtualStack(GetOrCreate<Border>(path), e, path),
+            VirtualStackElement e => ConfigureVirtualStack(GetOrCreate<Border>(path), e, path, effects),
             FlexRowElement e => ConfigureFlexRow(GetOrCreate<Border>(path), e, path, effects),
             GridElement e => ConfigureGrid(GetOrCreate<Border>(path), e, path, effects),
             ScrollViewElement e => ConfigureScrollView(GetOrCreate<ScrollViewer>(path), e, path, effects),
@@ -980,6 +987,9 @@ internal sealed class UiRenderer(Action requestRender)
         QueueMount(control, element, path, effects);
         return control;
     }
+
+    private static string ResolveElementPath(string path, Element element) =>
+        string.IsNullOrEmpty(element.Key) ? path : path + "#" + element.Key;
 
     /// <summary>
     /// Renders a navigation host into a STABLE Border wrapper at <paramref name="path"/>
@@ -1283,9 +1293,10 @@ internal sealed class UiRenderer(Action requestRender)
         return wrapper;
     }
 
-    private Border ConfigureVirtualStack(Border wrapper, VirtualStackElement element, string path)
+    private Border ConfigureVirtualStack(Border wrapper, VirtualStackElement element, string path, List<Action> effects)
     {
         var repeater = GetOrCreate<ItemsRepeater>(path + ".repeater");
+        _visitedVirtualStackPaths.Add(path);
         if (repeater.Layout is not StackLayout layout)
         {
             layout = new StackLayout();
@@ -1294,12 +1305,33 @@ internal sealed class UiRenderer(Action requestRender)
         layout.Orientation = element.Orientation;
         layout.Spacing = element.Spacing;
 
-        repeater.ItemsSource = element.Children
-            .Select((child, index) => child is null ? null : new VirtualStackItem(index, child))
+        var items = element.Children
+            .Select((child, index) => child is null ? null : new VirtualStackItem(
+                index,
+                ResolveElementPath(ChildPath(path, index, child), child),
+                child))
             .Where(item => item is not null)
             .Cast<VirtualStackItem>()
             .ToArray();
-        repeater.ItemTemplate = new VirtualStackItemTemplate(this, path);
+        _virtualStackOwnedPathPrefixes[path] = items.Select(item => item.Path).ToArray();
+
+        if (repeater.ItemsSource is VirtualStackItem[] currentItems && VirtualStackItemsMatch(currentItems, items))
+        {
+            for (var i = 0; i < currentItems.Length; i++)
+            {
+                currentItems[i].Index = items[i].Index;
+                currentItems[i].Element = items[i].Element;
+            }
+            UpdateRealizedVirtualStackItems(currentItems, effects);
+        }
+        else
+        {
+            repeater.ItemsSource = items;
+        }
+
+        if (repeater.ItemTemplate is not VirtualStackItemTemplate template || !template.Matches(this, path))
+            repeater.ItemTemplate = new VirtualStackItemTemplate(this, path);
+
         repeater.HorizontalAlignment = HorizontalAlignment.Stretch;
         repeater.VerticalAlignment = VerticalAlignment.Stretch;
 
@@ -1309,17 +1341,52 @@ internal sealed class UiRenderer(Action requestRender)
         return wrapper;
     }
 
-    private sealed record VirtualStackItem(int Index, Element Element);
+    private void UpdateRealizedVirtualStackItems(IEnumerable<VirtualStackItem> items, List<Action> effects)
+    {
+        foreach (var item in items)
+        {
+            if (item.RealizedControl is null)
+                continue;
+
+            item.RealizedControl = RenderElementCore(item.Element, item.Path, effects);
+        }
+    }
+
+    private static bool VirtualStackItemsMatch(VirtualStackItem[] currentItems, VirtualStackItem[] nextItems)
+    {
+        if (currentItems.Length != nextItems.Length)
+            return false;
+
+        for (var i = 0; i < currentItems.Length; i++)
+        {
+            if (!string.Equals(currentItems[i].Path, nextItems[i].Path, StringComparison.Ordinal))
+                return false;
+        }
+
+        return true;
+    }
+
+    private sealed class VirtualStackItem(int index, string path, Element element)
+    {
+        public int Index { get; set; } = index;
+        public string Path { get; } = path;
+        public Element Element { get; set; } = element;
+        public UIElement? RealizedControl { get; set; }
+    }
 
     private sealed class VirtualStackItemTemplate(UiRenderer renderer, string path) : IElementFactory
     {
+        public bool Matches(UiRenderer otherRenderer, string otherPath) =>
+            ReferenceEquals(renderer, otherRenderer) && string.Equals(path, otherPath, StringComparison.Ordinal);
+
         public UIElement GetElement(ElementFactoryGetArgs args)
         {
             if (args.Data is not VirtualStackItem item)
                 return new Border();
 
             var effects = new List<Action>();
-            var control = renderer.RenderElement(item.Element, ChildPath(path, item.Index, item.Element), effects);
+            var control = renderer.RenderElementCore(item.Element, item.Path, effects);
+            item.RealizedControl = control;
             foreach (var effect in effects)
                 effect();
             return control;
@@ -1474,9 +1541,15 @@ internal sealed class UiRenderer(Action requestRender)
 
     private void PruneUnvisitedPaths()
     {
+        foreach (var path in _virtualStackOwnedPathPrefixes.Keys.ToArray())
+        {
+            if (!_visitedVirtualStackPaths.Contains(path))
+                _virtualStackOwnedPathPrefixes.Remove(path);
+        }
+
         foreach (var (key, component) in _components.ToArray())
         {
-            if (_visitedComponentKeys.Contains(key))
+            if (_visitedComponentKeys.Contains(key) || IsOwnedByVirtualStack(key))
                 continue;
 
             component.Context.RunEffectCleanups();
@@ -1485,7 +1558,7 @@ internal sealed class UiRenderer(Action requestRender)
 
         foreach (var (path, flyout) in _contentFlyouts.ToArray())
         {
-            if (_visitedContentFlyoutPaths.Contains(path))
+            if (_visitedContentFlyoutPaths.Contains(path) || IsOwnedByVirtualStack(path))
                 continue;
 
             flyout.Hide();
@@ -1495,7 +1568,7 @@ internal sealed class UiRenderer(Action requestRender)
 
         foreach (var (path, control) in _controls.ToArray())
         {
-            if (_visitedControlPaths.Contains(path))
+            if (_visitedControlPaths.Contains(path) || IsOwnedByVirtualStack(path))
                 continue;
 
             _mountedPaths.Remove(path);
@@ -1504,6 +1577,25 @@ internal sealed class UiRenderer(Action requestRender)
             _controls.Remove(path);
         }
     }
+
+    private bool IsOwnedByVirtualStack(string path)
+    {
+        foreach (var prefixes in _virtualStackOwnedPathPrefixes.Values)
+        {
+            foreach (var prefix in prefixes)
+            {
+                if (IsPathAtOrBelow(path, prefix))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsPathAtOrBelow(string path, string prefix) =>
+        string.Equals(path, prefix, StringComparison.Ordinal)
+        || path.StartsWith(prefix + ".", StringComparison.Ordinal)
+        || path.StartsWith(prefix + ":", StringComparison.Ordinal);
 
     private static MenuFlyout CreateMenuFlyout(MenuFlyoutContentElement element)
     {

--- a/src/OpenClawTray.FunctionalUI/OpenClawTray.FunctionalUI.csproj
+++ b/src/OpenClawTray.FunctionalUI/OpenClawTray.FunctionalUI.csproj
@@ -23,6 +23,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>OpenClawTray.FunctionalUI.Tests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>OpenClaw.Tray.UITests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
 </Project>

--- a/tests/OpenClaw.Tray.Tests/ChatTimelineVirtualizationContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelineVirtualizationContractTests.cs
@@ -19,6 +19,32 @@ public sealed class ChatTimelineVirtualizationContractTests
         Assert.Contains("IElementFactory", functionalUi);
     }
 
+    [Fact]
+    public void ProductionTimeline_StabilizesFollowToBottomForVirtualizedRows()
+    {
+        var timeline = Read("src", "OpenClaw.Tray.WinUI", "Chat", "OpenClawChatTimeline.cs");
+
+        Assert.Contains("FollowToBottomMaxStabilizationPasses", timeline);
+        Assert.Contains("FollowToBottomExtentEpsilon", timeline);
+        Assert.Contains("void QueuePass(", timeline);
+        Assert.Contains("sv.UpdateLayout();", timeline);
+        Assert.Contains("QueuePass(pass + 1", timeline);
+    }
+
+    [Fact]
+    public void FunctionalUiVirtualStack_IsPruneAwareAndStableAcrossRenderChurn()
+    {
+        var functionalUi = Read("src", "OpenClawTray.FunctionalUI", "FunctionalUI.cs");
+
+        Assert.Contains("_virtualStackOwnedPathPrefixes", functionalUi);
+        Assert.Contains("_visitedVirtualStackPaths", functionalUi);
+        Assert.Contains("IsOwnedByVirtualStack", functionalUi);
+        Assert.Contains("VirtualStackItemsMatch", functionalUi);
+        Assert.Contains("UpdateRealizedVirtualStackItems", functionalUi);
+        Assert.Contains("repeater.ItemTemplate is not VirtualStackItemTemplate", functionalUi);
+        Assert.Contains("PruneUnvisitedPaths();", functionalUi);
+    }
+
     private static string Read(params string[] parts)
         => File.ReadAllText(Path.Combine(new[] { TestRepositoryPaths.GetRepositoryRoot() }.Concat(parts).ToArray()));
 }

--- a/tests/OpenClaw.Tray.Tests/ChatTimelineVirtualizationContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelineVirtualizationContractTests.cs
@@ -1,0 +1,24 @@
+namespace OpenClaw.Tray.Tests;
+
+public sealed class ChatTimelineVirtualizationContractTests
+{
+    [Fact]
+    public void ProductionTimeline_UsesVirtualizedItemsRepeaterRows()
+    {
+        var timeline = Read("src", "OpenClaw.Tray.WinUI", "Chat", "OpenClawChatTimeline.cs");
+        var functionalUi = Read("src", "OpenClawTray.FunctionalUI", "FunctionalUI.cs");
+
+        Assert.Contains("VirtualVStack(2, timelineRows)", timeline);
+        Assert.DoesNotContain("                        VStack(2, timelineRows)", timeline);
+        Assert.Contains("UseRef<FrameworkElement?>", timeline);
+        Assert.Contains("ItemsRepeater repeater", timeline);
+
+        Assert.Contains("VirtualStackElement", functionalUi);
+        Assert.Contains("ItemsRepeater", functionalUi);
+        Assert.Contains("StackLayout", functionalUi);
+        Assert.Contains("IElementFactory", functionalUi);
+    }
+
+    private static string Read(params string[] parts)
+        => File.ReadAllText(Path.Combine(new[] { TestRepositoryPaths.GetRepositoryRoot() }.Concat(parts).ToArray()));
+}

--- a/tests/OpenClaw.Tray.Tests/ChatTimelineVirtualizationContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelineVirtualizationContractTests.cs
@@ -42,6 +42,9 @@ public sealed class ChatTimelineVirtualizationContractTests
         Assert.Contains("VirtualStackItemsMatch", functionalUi);
         Assert.Contains("UpdateRealizedVirtualStackItems", functionalUi);
         Assert.Contains("repeater.ItemTemplate is not VirtualStackItemTemplate", functionalUi);
+        Assert.Contains("RemoveCachedSubtree(item.Path)", functionalUi);
+        Assert.Contains("item.RealizedContainer = null", functionalUi);
+        Assert.Contains("PruneUnvisitedCachedSubtree(item.Path)", functionalUi);
         Assert.Contains("PruneUnvisitedPaths();", functionalUi);
     }
 

--- a/tests/OpenClaw.Tray.UITests/ChatTimelineVirtualizationProofTests.cs
+++ b/tests/OpenClaw.Tray.UITests/ChatTimelineVirtualizationProofTests.cs
@@ -69,13 +69,43 @@ public sealed class ChatTimelineVirtualizationProofTests
 
         await DrainRenderQueueAsync();
 
+        object? stableItemsSource = null;
+        object? stableItemTemplate = null;
+        props = BuildProps(InitialRows, scrollToBottomToken: 0, textRevision: 1);
+        await _ui.RunOnUIAsync(() =>
+        {
+            var repeater = FindLogical<ItemsRepeater>(host!).Single();
+            stableItemsSource = repeater.ItemsSource;
+            stableItemTemplate = repeater.ItemTemplate;
+
+            host!.Mount(_ => Component<OpenClawChatTimeline, OpenClawChatTimelineProps>(props));
+        });
+
+        await DrainRenderQueueAsync();
+
+        await _ui.RunOnUIAsync(() =>
+        {
+            var repeater = FindLogical<ItemsRepeater>(host!).Single();
+            Assert.NotNull(stableItemsSource);
+            Assert.NotNull(stableItemTemplate);
+            Assert.Same(stableItemsSource, repeater.ItemsSource);
+            Assert.Same(stableItemTemplate, repeater.ItemTemplate);
+
+            var visibleText = FindDescendants<TextBlock>(host!)
+                .Select(t => t.Text)
+                .Where(t => !string.IsNullOrWhiteSpace(t))
+                .ToArray();
+            Assert.Contains(visibleText, text => text.Contains("revision 1", StringComparison.Ordinal));
+        });
+
         var appendedRows = InitialRows + 1;
-        props = BuildProps(appendedRows, scrollToBottomToken: 1);
+        props = BuildProps(appendedRows, scrollToBottomToken: 1, textRevision: 1);
         await _ui.RunOnUIAsync(() =>
         {
             host!.Mount(_ => Component<OpenClawChatTimeline, OpenClawChatTimelineProps>(props));
         });
 
+        await DrainRenderQueueAsync();
         await DrainRenderQueueAsync();
 
         await _ui.RunOnUIAsync(() =>
@@ -93,7 +123,7 @@ public sealed class ChatTimelineVirtualizationProofTests
                 .Select(t => t.Text)
                 .Where(t => !string.IsNullOrWhiteSpace(t))
                 .ToArray();
-            Assert.Contains("User proof row 241", visibleText);
+            Assert.Contains(visibleText, text => text.Contains("User proof row 241", StringComparison.Ordinal));
 
             Console.WriteLine(
                 "CHAT_TIMELINE_VIRTUALIZATION_PROOF " +
@@ -102,6 +132,8 @@ public sealed class ChatTimelineVirtualizationProofTests
                 $"layout={((StackLayout)repeater.Layout).Orientation} " +
                 $"scrollableHeight={scrollViewer.ScrollableHeight:0.0} " +
                 $"verticalOffset={scrollViewer.VerticalOffset:0.0} " +
+                "variableHeight=true " +
+                "renderChurnStable=true " +
                 "newestRowVisible=true");
         });
 
@@ -116,10 +148,10 @@ public sealed class ChatTimelineVirtualizationProofTests
         await _ui.RunOnUIAsync(() => { });
     }
 
-    private static OpenClawChatTimelineProps BuildProps(int rows, int scrollToBottomToken) =>
+    private static OpenClawChatTimelineProps BuildProps(int rows, int scrollToBottomToken, int textRevision = 0) =>
         new(
             SessionId: "ui-proof-large-chat",
-            Entries: BuildEntries(rows),
+            Entries: BuildEntries(rows, textRevision),
             HasMoreHistory: false,
             OnLoadMoreHistory: null,
             UserSenderLabel: "UI proof user",
@@ -128,7 +160,7 @@ public sealed class ChatTimelineVirtualizationProofTests
             ShowToolCalls: true,
             ScrollToBottomToken: scrollToBottomToken);
 
-    private static IReadOnlyList<ChatTimelineItem> BuildEntries(int rows)
+    private static IReadOnlyList<ChatTimelineItem> BuildEntries(int rows, int textRevision)
     {
         var entries = new List<ChatTimelineItem>(rows);
         for (var i = 1; i <= rows; i++)
@@ -137,12 +169,22 @@ public sealed class ChatTimelineVirtualizationProofTests
             entries.Add(new ChatTimelineItem(
                 Id: $"proof-{i:000}",
                 Kind: isUser ? ChatTimelineItemKind.User : ChatTimelineItemKind.Assistant,
-                Text: isUser
-                    ? $"User proof row {i}"
-                    : $"Assistant proof row {i}"));
+                Text: FormatVariableHeightText(isUser ? "User" : "Assistant", i, textRevision)));
         }
 
         return entries;
+    }
+
+    private static string FormatVariableHeightText(string role, int row, int textRevision)
+    {
+        var detailLines = row % 4;
+        var details = string.Join(
+            Environment.NewLine,
+            Enumerable.Range(0, detailLines).Select(i => $"detail {row}-{i} revision {textRevision}"));
+        var heading = $"{role} proof row {row}";
+        return string.IsNullOrEmpty(details)
+            ? heading
+            : heading + Environment.NewLine + details;
     }
 
     private static int CountItems(object? itemsSource) =>

--- a/tests/OpenClaw.Tray.UITests/ChatTimelineVirtualizationProofTests.cs
+++ b/tests/OpenClaw.Tray.UITests/ChatTimelineVirtualizationProofTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using OpenClaw.Chat;
 using OpenClawTray.Chat;
@@ -32,6 +33,7 @@ public sealed class ChatTimelineVirtualizationProofTests
 
         await _ui.RunOnUIAsync(() =>
         {
+            TestApp.EnsureFluentBrushFallbacks(Application.Current.Resources);
             _ui.TestWindow.AppWindow.MoveAndResize(new RectInt32(-32000, -32000, 960, 720));
             _ui.Container.Width = 900;
             _ui.Container.Height = 640;

--- a/tests/OpenClaw.Tray.UITests/ChatTimelineVirtualizationProofTests.cs
+++ b/tests/OpenClaw.Tray.UITests/ChatTimelineVirtualizationProofTests.cs
@@ -7,6 +7,7 @@ using Microsoft.UI.Xaml.Controls;
 using OpenClaw.Chat;
 using OpenClawTray.Chat;
 using OpenClawTray.FunctionalUI;
+using OpenClawTray.FunctionalUI.Core;
 using OpenClawTray.FunctionalUI.Hosting;
 using Windows.Graphics;
 using static OpenClawTray.FunctionalUI.Factories;
@@ -30,6 +31,7 @@ public sealed class ChatTimelineVirtualizationProofTests
 
         var props = BuildProps(InitialRows, scrollToBottomToken: 0);
         FunctionalHostControl? host = null;
+        var initialCachedVirtualControls = 0;
 
         await _ui.RunOnUIAsync(() =>
         {
@@ -57,17 +59,31 @@ public sealed class ChatTimelineVirtualizationProofTests
             Assert.Equal(Orientation.Vertical, layout.Orientation);
             Assert.Equal(2, layout.Spacing);
             Assert.Equal(InitialRows, CountItems(repeater.ItemsSource));
+            var realizedRows = Enumerable.Range(0, InitialRows)
+                .Count(index => repeater.TryGetElement(index) is not null);
+            Assert.InRange(realizedRows, 1, InitialRows - 1);
+            initialCachedVirtualControls = host!.CachedVirtualStackControlCount;
+            Assert.True(initialCachedVirtualControls > 0);
 
             var scrollViewer = FindLogical<ScrollViewer>(host!).Single();
             _ui.Container.UpdateLayout();
             Assert.True(scrollViewer.ScrollableHeight > 0, "large chat timeline should overflow and become scrollable");
-
-            scrollViewer.ChangeView(null, scrollViewer.ScrollableHeight, null, disableAnimation: true);
-            _ui.Container.UpdateLayout();
-            Assert.True(scrollViewer.VerticalOffset > 0, "large chat timeline should scroll away from the top");
         });
 
-        await DrainRenderQueueAsync();
+        foreach (var fraction in new[] { 0.25, 0.5, 0.75, 1.0 })
+        {
+            await _ui.RunOnUIAsync(() =>
+            {
+                var scrollViewer = FindLogical<ScrollViewer>(host!).Single();
+                scrollViewer.ChangeView(
+                    null,
+                    scrollViewer.ScrollableHeight * fraction,
+                    null,
+                    disableAnimation: true);
+                _ui.Container.UpdateLayout();
+            });
+            await DrainRenderQueueAsync();
+        }
 
         object? stableItemsSource = null;
         object? stableItemTemplate = null;
@@ -75,6 +91,12 @@ public sealed class ChatTimelineVirtualizationProofTests
         await _ui.RunOnUIAsync(() =>
         {
             var repeater = FindLogical<ItemsRepeater>(host!).Single();
+            Assert.Null(repeater.TryGetElement(0));
+            Assert.NotNull(repeater.TryGetElement(InitialRows - 1));
+            Assert.InRange(
+                host!.CachedVirtualStackControlCount,
+                1,
+                initialCachedVirtualControls * 2);
             stableItemsSource = repeater.ItemsSource;
             stableItemTemplate = repeater.ItemTemplate;
 
@@ -140,6 +162,57 @@ public sealed class ChatTimelineVirtualizationProofTests
         await _ui.RunOnUIAsync(() => host!.Dispose());
     }
 
+    [Fact]
+    public async Task RealizedComponentRow_ReplacesRootAndPrunesRemovedEffects()
+    {
+        await _ui.ResetContainerAsync();
+        DisposableVirtualRow.CleanupCount = 0;
+
+        FunctionalHostControl? host = null;
+        ItemsRepeater? repeater = null;
+        UIElement? stableContainer = null;
+        var expandedCacheCount = 0;
+        var cleanupCountBeforeCollapse = 0;
+
+        await _ui.RunOnUIAsync(() =>
+        {
+            host = new FunctionalHostControl { Width = 600, Height = 400, SuppressAutoDispose = true };
+            _ui.Container.Children.Add(host);
+            host.Mount(_ => VirtualVStack(
+                0,
+                Component<SwappingVirtualRow, SwappingVirtualRowProps>(new SwappingVirtualRowProps(true))));
+        });
+        await DrainRenderQueueAsync();
+
+        await _ui.RunOnUIAsync(() =>
+        {
+            repeater = FindLogical<ItemsRepeater>(host!).Single();
+            stableContainer = repeater.TryGetElement(0);
+            Assert.IsType<Border>(stableContainer);
+            Assert.Contains(FindDescendants<TextBlock>(host!), text => text.Text == "expanded row");
+            Assert.Contains(FindDescendants<TextBlock>(host!), text => text.Text == "disposable child");
+            expandedCacheCount = host!.CachedVirtualStackControlCount;
+            Assert.True(expandedCacheCount > 1);
+            cleanupCountBeforeCollapse = DisposableVirtualRow.CleanupCount;
+
+            host.Mount(_ => VirtualVStack(
+                0,
+                Component<SwappingVirtualRow, SwappingVirtualRowProps>(new SwappingVirtualRowProps(false))));
+        });
+        await DrainRenderQueueAsync();
+
+        await _ui.RunOnUIAsync(() =>
+        {
+            Assert.Same(stableContainer, repeater!.TryGetElement(0));
+            Assert.Contains(FindDescendants<TextBlock>(host!), text => text.Text == "collapsed row");
+            Assert.DoesNotContain(FindDescendants<TextBlock>(host!), text => text.Text == "disposable child");
+            Assert.Equal(cleanupCountBeforeCollapse + 1, DisposableVirtualRow.CleanupCount);
+            Assert.InRange(host!.CachedVirtualStackControlCount, 1, expandedCacheCount - 1);
+        });
+
+        await _ui.RunOnUIAsync(() => host!.Dispose());
+    }
+
     private async Task DrainRenderQueueAsync()
     {
         await _ui.RunOnUIAsync(() => { });
@@ -191,4 +264,27 @@ public sealed class ChatTimelineVirtualizationProofTests
         itemsSource is System.Collections.IEnumerable enumerable
             ? enumerable.Cast<object>().Count()
             : 0;
+
+    private sealed record SwappingVirtualRowProps(bool Expanded);
+
+    private sealed class SwappingVirtualRow : Component<SwappingVirtualRowProps>
+    {
+        public override Element Render() => Props.Expanded
+            ? VStack(
+                0,
+                TextBlock("expanded row"),
+                Component<DisposableVirtualRow>())
+            : TextBlock("collapsed row");
+    }
+
+    private sealed class DisposableVirtualRow : Component
+    {
+        internal static int CleanupCount { get; set; }
+
+        public override Element Render()
+        {
+            UseEffect((Func<Action>)(() => () => CleanupCount++), Array.Empty<object>());
+            return TextBlock("disposable child");
+        }
+    }
 }

--- a/tests/OpenClaw.Tray.UITests/ChatTimelineVirtualizationProofTests.cs
+++ b/tests/OpenClaw.Tray.UITests/ChatTimelineVirtualizationProofTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using OpenClaw.Chat;
+using OpenClawTray.Chat;
+using OpenClawTray.FunctionalUI;
+using OpenClawTray.FunctionalUI.Hosting;
+using Windows.Graphics;
+using static OpenClawTray.FunctionalUI.Factories;
+using static OpenClaw.Tray.UITests.TestSupport;
+
+namespace OpenClaw.Tray.UITests;
+
+[Collection(UICollection.Name)]
+public sealed class ChatTimelineVirtualizationProofTests
+{
+    private const int InitialRows = 240;
+
+    private readonly UIThreadFixture _ui;
+
+    public ChatTimelineVirtualizationProofTests(UIThreadFixture ui) => _ui = ui;
+
+    [Fact]
+    public async Task LargeNativeChatTimeline_VirtualizesRowsAndFollowsNewMessages()
+    {
+        await _ui.ResetContainerAsync();
+
+        var props = BuildProps(InitialRows, scrollToBottomToken: 0);
+        FunctionalHostControl? host = null;
+
+        await _ui.RunOnUIAsync(() =>
+        {
+            _ui.TestWindow.AppWindow.MoveAndResize(new RectInt32(-32000, -32000, 960, 720));
+            _ui.Container.Width = 900;
+            _ui.Container.Height = 640;
+
+            host = new FunctionalHostControl
+            {
+                Width = 860,
+                Height = 560,
+                SuppressAutoDispose = true,
+            };
+            _ui.Container.Children.Add(host);
+            host.Mount(_ => Component<OpenClawChatTimeline, OpenClawChatTimelineProps>(props));
+        });
+
+        await DrainRenderQueueAsync();
+
+        await _ui.RunOnUIAsync(() =>
+        {
+            var repeater = FindLogical<ItemsRepeater>(host!).Single();
+            var layout = Assert.IsType<StackLayout>(repeater.Layout);
+            Assert.Equal(Orientation.Vertical, layout.Orientation);
+            Assert.Equal(2, layout.Spacing);
+            Assert.Equal(InitialRows, CountItems(repeater.ItemsSource));
+
+            var scrollViewer = FindLogical<ScrollViewer>(host!).Single();
+            _ui.Container.UpdateLayout();
+            Assert.True(scrollViewer.ScrollableHeight > 0, "large chat timeline should overflow and become scrollable");
+
+            scrollViewer.ChangeView(null, scrollViewer.ScrollableHeight, null, disableAnimation: true);
+            _ui.Container.UpdateLayout();
+            Assert.True(scrollViewer.VerticalOffset > 0, "large chat timeline should scroll away from the top");
+        });
+
+        await DrainRenderQueueAsync();
+
+        var appendedRows = InitialRows + 1;
+        props = BuildProps(appendedRows, scrollToBottomToken: 1);
+        await _ui.RunOnUIAsync(() =>
+        {
+            host!.Mount(_ => Component<OpenClawChatTimeline, OpenClawChatTimelineProps>(props));
+        });
+
+        await DrainRenderQueueAsync();
+
+        await _ui.RunOnUIAsync(() =>
+        {
+            var repeater = FindLogical<ItemsRepeater>(host!).Single();
+            Assert.Equal(appendedRows, CountItems(repeater.ItemsSource));
+
+            var scrollViewer = FindLogical<ScrollViewer>(host!).Single();
+            _ui.Container.UpdateLayout();
+            Assert.True(
+                scrollViewer.ScrollableHeight - scrollViewer.VerticalOffset <= 4,
+                $"chat follow should stay near the newest row; offset={scrollViewer.VerticalOffset:0.0}, height={scrollViewer.ScrollableHeight:0.0}");
+
+            var visibleText = FindDescendants<TextBlock>(host!)
+                .Select(t => t.Text)
+                .Where(t => !string.IsNullOrWhiteSpace(t))
+                .ToArray();
+            Assert.Contains("User proof row 241", visibleText);
+
+            Console.WriteLine(
+                "CHAT_TIMELINE_VIRTUALIZATION_PROOF " +
+                $"rows={appendedRows} " +
+                $"itemsRepeater={repeater.GetType().Name} " +
+                $"layout={((StackLayout)repeater.Layout).Orientation} " +
+                $"scrollableHeight={scrollViewer.ScrollableHeight:0.0} " +
+                $"verticalOffset={scrollViewer.VerticalOffset:0.0} " +
+                "newestRowVisible=true");
+        });
+
+        await _ui.RunOnUIAsync(() => host!.Dispose());
+    }
+
+    private async Task DrainRenderQueueAsync()
+    {
+        await _ui.RunOnUIAsync(() => { });
+        await Task.Delay(50);
+        await _ui.RunOnUIAsync(() => _ui.Container.UpdateLayout());
+        await _ui.RunOnUIAsync(() => { });
+    }
+
+    private static OpenClawChatTimelineProps BuildProps(int rows, int scrollToBottomToken) =>
+        new(
+            SessionId: "ui-proof-large-chat",
+            Entries: BuildEntries(rows),
+            HasMoreHistory: false,
+            OnLoadMoreHistory: null,
+            UserSenderLabel: "UI proof user",
+            AssistantSenderLabel: "UI proof assistant",
+            DefaultModel: "proof-model",
+            ShowToolCalls: true,
+            ScrollToBottomToken: scrollToBottomToken);
+
+    private static IReadOnlyList<ChatTimelineItem> BuildEntries(int rows)
+    {
+        var entries = new List<ChatTimelineItem>(rows);
+        for (var i = 1; i <= rows; i++)
+        {
+            var isUser = i % 2 == 1;
+            entries.Add(new ChatTimelineItem(
+                Id: $"proof-{i:000}",
+                Kind: isUser ? ChatTimelineItemKind.User : ChatTimelineItemKind.Assistant,
+                Text: isUser
+                    ? $"User proof row {i}"
+                    : $"Assistant proof row {i}"));
+        }
+
+        return entries;
+    }
+
+    private static int CountItems(object? itemsSource) =>
+        itemsSource is System.Collections.IEnumerable enumerable
+            ? enumerable.Cast<object>().Count()
+            : 0;
+}

--- a/tests/OpenClaw.Tray.UITests/TestApp.cs
+++ b/tests/OpenClaw.Tray.UITests/TestApp.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Markup;
@@ -50,9 +51,14 @@ internal sealed class TestApp : Application
     /// </summary>
     public void MergeStandardResources()
     {
+        if (!TryGetResources(out var resources))
+        {
+            return;
+        }
+
         try
         {
-            Resources.MergedDictionaries.Add(new Microsoft.UI.Xaml.Controls.XamlControlsResources());
+            resources.MergedDictionaries.Add(new Microsoft.UI.Xaml.Controls.XamlControlsResources());
         }
         // slopwatch-ignore: SW003 Test cleanup or fixture teardown is best-effort and must not hide the test outcome.
         catch
@@ -61,14 +67,17 @@ internal sealed class TestApp : Application
             // going — the renderers degrade gracefully without theme styles.
         }
 
-        TryAddResource("AccentButtonStyle",
+        TryAddResource(resources, "LobsterAccentBrush",
+            "<SolidColorBrush xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' Color='#E74C3C' />");
+
+        TryAddResource(resources, "AccentButtonStyle",
             "<Style xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' " +
             "TargetType='Button'>" +
             "<Setter Property='Foreground' Value='White' />" +
             "<Setter Property='CornerRadius' Value='4' />" +
             "</Style>");
 
-        EnsureFluentBrushFallbacks(Resources);
+        EnsureFluentBrushFallbacks(resources);
     }
 
     internal static void EnsureFluentBrushFallbacks(ResourceDictionary resources)
@@ -79,11 +88,31 @@ internal sealed class TestApp : Application
         }
     }
 
-    private void TryAddResource(string key, string xaml)
+    private bool TryGetResources(out ResourceDictionary resources)
+    {
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            try
+            {
+                resources = Resources;
+                return true;
+            }
+            // slopwatch-ignore: SW003 Test fixture resource setup is best-effort and must not hide the test outcome.
+            catch
+            {
+                Thread.Sleep(10);
+            }
+        }
+
+        resources = null!;
+        return false;
+    }
+
+    private static void TryAddResource(ResourceDictionary resources, string key, string xaml)
     {
         try
         {
-            Resources[key] = XamlReader.Load(xaml);
+            resources[key] = XamlReader.Load(xaml);
         }
         // slopwatch-ignore: SW003 Test cleanup or fixture teardown is best-effort and must not hide the test outcome.
         catch

--- a/tests/OpenClaw.Tray.UITests/TestApp.cs
+++ b/tests/OpenClaw.Tray.UITests/TestApp.cs
@@ -91,8 +91,7 @@ internal sealed class TestApp : Application
     {
         try
         {
-            if (!Resources.ContainsKey(key))
-                Resources[key] = new SolidColorBrush(color);
+            Resources[key] = new SolidColorBrush(color);
         }
         // slopwatch-ignore: SW003 Test cleanup or fixture teardown is best-effort and must not hide the test outcome.
         catch

--- a/tests/OpenClaw.Tray.UITests/TestApp.cs
+++ b/tests/OpenClaw.Tray.UITests/TestApp.cs
@@ -68,9 +68,14 @@ internal sealed class TestApp : Application
             "<Setter Property='CornerRadius' Value='4' />" +
             "</Style>");
 
+        EnsureFluentBrushFallbacks(Resources);
+    }
+
+    internal static void EnsureFluentBrushFallbacks(ResourceDictionary resources)
+    {
         foreach (var (key, color) in FluentBrushFallbacks)
         {
-            TryAddBrushResource(key, color);
+            TryAddBrushResource(resources, key, color);
         }
     }
 
@@ -87,11 +92,11 @@ internal sealed class TestApp : Application
         }
     }
 
-    private void TryAddBrushResource(string key, Windows.UI.Color color)
+    private static void TryAddBrushResource(ResourceDictionary resources, string key, Windows.UI.Color color)
     {
         try
         {
-            Resources[key] = new SolidColorBrush(color);
+            resources[key] = new SolidColorBrush(color);
         }
         // slopwatch-ignore: SW003 Test cleanup or fixture teardown is best-effort and must not hide the test outcome.
         catch

--- a/tests/OpenClaw.Tray.UITests/TestApp.cs
+++ b/tests/OpenClaw.Tray.UITests/TestApp.cs
@@ -1,6 +1,8 @@
 using System;
+using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Markup;
+using Microsoft.UI.Xaml.Media;
 
 namespace OpenClaw.Tray.UITests;
 
@@ -20,6 +22,27 @@ namespace OpenClaw.Tray.UITests;
 /// </summary>
 internal sealed class TestApp : Application
 {
+    private static readonly (string Key, Windows.UI.Color Color)[] FluentBrushFallbacks =
+    [
+        ("SolidBackgroundFillColorBaseBrush", Colors.White),
+        ("LayerFillColorDefaultBrush", Colors.White),
+        ("CardBackgroundFillColorDefaultBrush", Colors.White),
+        ("CardStrokeColorDefaultBrush", ColorHelper.FromArgb(0x33, 0x00, 0x00, 0x00)),
+        ("ControlFillColorTertiaryBrush", ColorHelper.FromArgb(0x0F, 0x00, 0x00, 0x00)),
+        ("ControlStrokeColorDefaultBrush", ColorHelper.FromArgb(0x33, 0x00, 0x00, 0x00)),
+        ("SubtleFillColorSecondaryBrush", ColorHelper.FromArgb(0x0F, 0x00, 0x00, 0x00)),
+        ("SubtleFillColorTertiaryBrush", ColorHelper.FromArgb(0x14, 0x00, 0x00, 0x00)),
+        ("AccentFillColorDefaultBrush", ColorHelper.FromArgb(0xFF, 0x00, 0x66, 0xCC)),
+        ("AccentFillColorSecondaryBrush", ColorHelper.FromArgb(0xCC, 0x00, 0x66, 0xCC)),
+        ("TextFillColorPrimaryBrush", Colors.Black),
+        ("TextFillColorSecondaryBrush", ColorHelper.FromArgb(0xE3, 0x00, 0x00, 0x00)),
+        ("TextFillColorTertiaryBrush", ColorHelper.FromArgb(0x99, 0x00, 0x00, 0x00)),
+        ("TextOnAccentFillColorPrimaryBrush", Colors.White),
+        ("SystemFillColorSuccessBrush", ColorHelper.FromArgb(0xFF, 0x0F, 0x7B, 0x0F)),
+        ("SystemFillColorCautionBrush", ColorHelper.FromArgb(0xFF, 0x9D, 0x5D, 0x00)),
+        ("SystemFillColorCriticalBrush", ColorHelper.FromArgb(0xFF, 0xC4, 0x2B, 0x1C)),
+    ];
+
     /// <summary>
     /// Merge XamlControlsResources + production App.xaml's custom keys so
     /// renderers that look them up resolve a real value. Call this ON THE UI
@@ -44,6 +67,11 @@ internal sealed class TestApp : Application
             "<Setter Property='Foreground' Value='White' />" +
             "<Setter Property='CornerRadius' Value='4' />" +
             "</Style>");
+
+        foreach (var (key, color) in FluentBrushFallbacks)
+        {
+            TryAddBrushResource(key, color);
+        }
     }
 
     private void TryAddResource(string key, string xaml)
@@ -51,6 +79,20 @@ internal sealed class TestApp : Application
         try
         {
             Resources[key] = XamlReader.Load(xaml);
+        }
+        // slopwatch-ignore: SW003 Test cleanup or fixture teardown is best-effort and must not hide the test outcome.
+        catch
+        {
+            // best-effort; missing key just means renderers fall back.
+        }
+    }
+
+    private void TryAddBrushResource(string key, Windows.UI.Color color)
+    {
+        try
+        {
+            if (!Resources.ContainsKey(key))
+                Resources[key] = new SolidColorBrush(color);
         }
         // slopwatch-ignore: SW003 Test cleanup or fixture teardown is best-effort and must not hide the test outcome.
         catch


### PR DESCRIPTION
Closes #860.

Thanks @TurboTheTurtle for the `ItemsRepeater`-backed virtual chat timeline.

This rebases the contribution onto current `main`, switches native chat rows from an eager `StackPanel` to a virtual stack, and preserves the existing history/follow-to-bottom behavior. Maintainer hardening adds stable row containers for component root changes, evicts renderer controls/components/flyouts when rows recycle, prunes removed descendants during in-place updates, and runs nested component effect cleanups instead of retaining every row ever visited.

## Validation

Current head: `e792f203026766321e36d2f9d079b882a719dfc6`

- AutoReview: clean after fixing recycled-row cache retention, stale component roots, and in-place descendant/effect retention.
- Windows 11 ARM64 VM: full repository build passed.
- Shared tests: 2,692 passed, 31 skipped.
- Tray tests: 1,538 passed.
- Focused native virtualization tests: 2 passed.
- Full native Tray UI suite: 96 passed.
- Exact-head GitHub CI: green, including the isolated network-recovery rerun: https://github.com/openclaw/openclaw-windows-node/actions/runs/28767061493/attempts/2

## Real behavior proof

The native WinUI proof mounts the production chat timeline with 241 variable-height rows, scrolls through four viewports, verifies the first row is recycled and the newest row is realized, bounds renderer cache growth, updates an onscreen row without replacing the `ItemsSource` or template, appends a message, and confirms follow-to-bottom:

`CHAT_TIMELINE_VIRTUALIZATION_PROOF rows=241 itemsRepeater=ItemsRepeater layout=Vertical scrollableHeight=26486.0 verticalOffset=26486.0 variableHeight=true renderChurnStable=true newestRowVisible=true`

A second native proof keeps the `ItemsRepeater` row container stable while a component changes its root control, then verifies removed nested UI disappears, renderer cache size drops, and the nested effect cleanup runs.
