### PR TITLE
fix: preserve full chat text for Tray TTS

### DIFF
--- a/src/OpenClaw.Shared/Models.cs
+++ b/src/OpenClaw.Shared/Models.cs
@@ -98,6 +98,7 @@ public class OpenClawNotification
 {
     public string Title { get; set; } = "";
     public string Message { get; set; } = "";
+    public string? FullMessage { get; set; }
     public string Type { get; set; } = "";
     public bool IsChat { get; set; } = false; // True if from chat response
 

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -3248,6 +3248,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         var notification = new OpenClawNotification
         {
             Message = displayText,
+            FullMessage = text,
             IsChat = true,
             SessionKey = sessionKey
         };

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -2747,6 +2747,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         // if the user enabled "Read responses aloud".
         if (notification.IsChat && !string.IsNullOrEmpty(notification.Message))
         {
+            var speechText = notification.FullMessage ?? notification.Message;
+
             // Suppress TTS/voice overlay when the user has aborted the response.
             if (ChatProvider?.IsResponseSuppressed == true)
                 return;
@@ -2767,7 +2769,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             // TTS: read response aloud whenever the toggle is on (any chat surface).
             if (_settings?.VoiceTtsEnabled == true)
             {
-                _ = (_chatCoordinator?.SpeakResponseAsync(notification.Message) ?? Task.CompletedTask);
+                _ = (_chatCoordinator?.SpeakResponseAsync(speechText) ?? Task.CompletedTask);
             }
         }
 

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -2747,7 +2747,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         // if the user enabled "Read responses aloud".
         if (notification.IsChat && !string.IsNullOrEmpty(notification.Message))
         {
-            var speechText = notification.FullMessage ?? notification.Message;
+            var speechText = ChatNotificationSpeechText.Resolve(notification);
 
             // Suppress TTS/voice overlay when the user has aborted the response.
             if (ChatProvider?.IsResponseSuppressed == true)

--- a/src/OpenClaw.Tray.WinUI/Services/ChatNotificationSpeechText.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ChatNotificationSpeechText.cs
@@ -1,0 +1,14 @@
+using OpenClaw.Shared;
+
+namespace OpenClawTray.Services;
+
+internal static class ChatNotificationSpeechText
+{
+    public static string Resolve(OpenClawNotification notification)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+        return string.IsNullOrEmpty(notification.FullMessage)
+            ? notification.Message
+            : notification.FullMessage;
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -991,6 +991,37 @@ public class OpenClawGatewayClientTests
     }
 
     [Fact]
+    public void ProcessRawMessage_SessionMessageAssistantNotification_PreservesFullMessage()
+    {
+        var helper = new GatewayClientTestHelper();
+        OpenClawNotification? notification = null;
+        helper.Client.NotificationReceived += (_, value) => notification = value;
+
+        var fullMessage = new string('x', 240);
+
+        helper.ProcessRawMessage($$"""
+        {
+          "type": "event",
+          "event": "session.message",
+          "payload": {
+            "sessionKey": "agent:main:whatsapp:direct:+15551234567",
+            "message": {
+              "role": "assistant",
+              "content": "{{fullMessage}}",
+              "timestamp": 1781631280633
+            },
+            "state": "final"
+          }
+        }
+        """);
+
+        Assert.NotNull(notification);
+        Assert.True(notification!.IsChat);
+        Assert.Equal(fullMessage[..200] + "…", notification.Message);
+        Assert.Equal(fullMessage, notification.FullMessage);
+    }
+
+    [Fact]
     public void ProcessRawMessage_AgentEventLogsRawLengthWithoutPayloadContent()
     {
         var logger = new TestLogger();

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ToastActivationRouter.cs" Link="Services\ToastActivationRouter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\AppNotificationService.cs" Link="Services\AppNotificationService.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\AppNotificationMapper.cs" Link="Services\AppNotificationMapper.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ChatNotificationSpeechText.cs" Link="Services\ChatNotificationSpeechText.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\AppNotificationPublisher.cs" Link="Services\AppNotificationPublisher.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ConnectionStatusPresenter.cs" Link="Services\ConnectionStatusPresenter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\McpRuntimeStatePolicy.cs" Link="Services\McpRuntimeStatePolicy.cs" />

--- a/tests/OpenClaw.Tray.Tests/Services/ChatNotificationSpeechTextTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Services/ChatNotificationSpeechTextTests.cs
@@ -1,0 +1,36 @@
+using OpenClaw.Shared;
+using OpenClawTray.Services;
+using Xunit;
+
+namespace OpenClaw.Tray.Tests.Services;
+
+public sealed class ChatNotificationSpeechTextTests
+{
+    [Fact]
+    public void Resolve_UsesFullMessageWhenPreviewWasTruncated()
+    {
+        var fullMessage = new string('x', 240);
+
+        var resolved = ChatNotificationSpeechText.Resolve(new OpenClawNotification
+        {
+            Message = fullMessage[..200] + "…",
+            FullMessage = fullMessage
+        });
+
+        Assert.Equal(fullMessage, resolved);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Resolve_FallsBackToPreviewWhenFullMessageIsUnavailable(string? fullMessage)
+    {
+        var resolved = ChatNotificationSpeechText.Resolve(new OpenClawNotification
+        {
+            Message = "Preview",
+            FullMessage = fullMessage
+        });
+
+        Assert.Equal("Preview", resolved);
+    }
+}


### PR DESCRIPTION
## Summary

- Preserve the complete assistant response alongside the 200-character notification preview.
- Use the complete response for Tray text-to-speech while keeping notifications/history compact.
- Fall back to the preview for legacy, null, or empty full-message values.

Thanks @ArtLupo for the contribution.

## Validation

Current head: `c4e0a4163719628d37c2c9f906357dd62d06da36`

- AutoReview: clean, patch correct (0.98).
- Windows 11 ARM64 VM: full repository build passed.
- Shared tests: 2,693 passed, 31 skipped.
- Tray tests: 1,541 passed.
- Focused coverage proves the gateway retains all 240 characters while the preview truncates, the Tray speaks the full value, and old/null/empty values fall back safely.
- Exact-head GitHub CI: green, including x64/ARM64 release builds and all WSL recovery/setup jobs: https://github.com/openclaw/openclaw-windows-node/actions/runs/28768655211

## Security and compatibility

- No new network, permission, command, or persistence surface.
- Notification and history text remain truncated; the full response stays in the existing in-process event object for TTS.
- Existing notification producers remain compatible because `FullMessage` is optional.
