### PR TITLE
Add MCP chat automation commands

### DIFF
--- a/src/OpenClaw.Shared/Capabilities/AppCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/AppCapability.cs
@@ -26,6 +26,9 @@ public class AppCapability : NodeCapabilityBase
         "app.menu",
         "app.search",
         "app.dashboard.url",
+        "app.chat.snapshot",
+        "app.chat.send",
+        "app.chat.reset",
     };
 
     public override IReadOnlyList<string> Commands => _commands;
@@ -42,6 +45,9 @@ public class AppCapability : NodeCapabilityBase
     public Func<object?>? MenuHandler;
     public Func<string, object?>? SearchHandler;
     public Func<string?, object?>? DashboardUrlHandler;
+    public Func<string?, Task<object?>>? ChatSnapshotHandler;
+    public Func<string?, string, Task<object?>>? ChatSendHandler;
+    public Func<string?, Task<object?>>? ChatResetHandler;
 
     public AppCapability(IOpenClawLogger logger) : base(logger) { }
 
@@ -60,6 +66,9 @@ public class AppCapability : NodeCapabilityBase
             "app.menu" => HandleMenu(),
             "app.search" => HandleSearch(request),
             "app.dashboard.url" => HandleDashboardUrl(request),
+            "app.chat.snapshot" => await HandleChatSnapshot(request),
+            "app.chat.send" => await HandleChatSend(request),
+            "app.chat.reset" => await HandleChatReset(request),
             _ => Error($"Unknown command: {request.Command}")
         };
     }
@@ -161,4 +170,39 @@ public class AppCapability : NodeCapabilityBase
             return Error("Dashboard URL handler not registered");
         return Success(DashboardUrlHandler(GetStringArg(request.Args, "path")));
     }
+
+    private async Task<NodeInvokeResponse> HandleChatSnapshot(NodeInvokeRequest request)
+    {
+        if (ChatSnapshotHandler == null)
+            return Error("Chat snapshot handler not registered");
+
+        var result = await ChatSnapshotHandler(GetOptionalThreadId(request));
+        return Success(result);
+    }
+
+    private async Task<NodeInvokeResponse> HandleChatSend(NodeInvokeRequest request)
+    {
+        if (ChatSendHandler == null)
+            return Error("Chat send handler not registered");
+
+        var message = GetStringArg(request.Args, "message");
+        if (string.IsNullOrWhiteSpace(message))
+            return Error("Missing required arg: message");
+
+        var result = await ChatSendHandler(GetOptionalThreadId(request), message);
+        return Success(result);
+    }
+
+    private async Task<NodeInvokeResponse> HandleChatReset(NodeInvokeRequest request)
+    {
+        if (ChatResetHandler == null)
+            return Error("Chat reset handler not registered");
+
+        var result = await ChatResetHandler(GetOptionalThreadId(request));
+        return Success(result);
+    }
+
+    private string? GetOptionalThreadId(NodeInvokeRequest request) =>
+        GetStringArg(request.Args, "threadId")
+        ?? GetStringArg(request.Args, "sessionKey");
 }

--- a/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
+++ b/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
@@ -274,6 +274,12 @@ public class McpToolBridge
             "Search the command palette and return matching commands. Args: query (string, required). Returns array of { Title, Subtitle, Icon }.",
         ["app.dashboard.url"] =
             "Build the same gateway dashboard URL the tray opens. Args: path (string, optional). Returns { url, credentialSource, usesSharedGatewayToken, hasTokenQuery }.",
+        ["app.chat.snapshot"] =
+            "READ-ALL: Return the current native chat snapshot for local automation. Args: threadId/sessionKey (string, optional). Returns connection state, compose target, thread summaries, and recent timeline entries including chat text.",
+        ["app.chat.send"] =
+            "Send a message through the native chat provider. Args: message (string, required), threadId/sessionKey (string, optional; defaults to the current compose/default thread). Returns { sent, threadId, entryCount, turnActive, error? }.",
+        ["app.chat.reset"] =
+            "Reset a chat session through the gateway sessions.reset path. Args: threadId/sessionKey (string, optional; defaults to the current compose/default thread, so no-arg reset clears the active chat). Returns { reset, threadId, error? }.",
 
         // location.*
         ["location.get"] =

--- a/src/OpenClaw.Tray.WinUI/App.CapabilityHandlers.cs
+++ b/src/OpenClaw.Tray.WinUI/App.CapabilityHandlers.cs
@@ -1,4 +1,5 @@
 using OpenClaw.Connection;
+using OpenClaw.Chat;
 using OpenClaw.Shared;
 using OpenClaw.Shared.Capabilities;
 using OpenClawTray.Helpers;
@@ -201,6 +202,10 @@ public partial class App
             };
         };
 
+        app.ChatSnapshotHandler = BuildChatSnapshotForMcpAsync;
+        app.ChatSendHandler = SendChatMessageForMcpAsync;
+        app.ChatResetHandler = ResetChatSessionForMcpAsync;
+
         connection.ApplySetupCodeHandler = async setupCode =>
         {
             if (_connectionManager == null)
@@ -401,6 +406,153 @@ public partial class App
         }
 
         return payload;
+    }
+
+    private async Task<object?> BuildChatSnapshotForMcpAsync(string? threadId)
+    {
+        var provider = _chatCoordinator?.Provider;
+        if (provider == null)
+            return new { error = "Chat provider is not initialized" };
+
+        var snapshot = await provider.LoadAsync();
+        var resolvedThreadId = ResolveChatThreadId(snapshot, threadId);
+        return BuildChatSnapshotPayload(snapshot, resolvedThreadId);
+    }
+
+    private async Task<object?> SendChatMessageForMcpAsync(string? threadId, string message)
+    {
+        var provider = _chatCoordinator?.Provider;
+        if (provider == null)
+            return new { sent = false, error = "Chat provider is not initialized" };
+
+        var snapshot = await provider.LoadAsync();
+        var resolvedThreadId = ResolveChatThreadId(snapshot, threadId);
+        if (string.IsNullOrWhiteSpace(resolvedThreadId))
+            return new { sent = false, error = "Chat compose target is not ready" };
+
+        try
+        {
+            await provider.SendMessageAsync(resolvedThreadId, message);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"App: Chat send for '{resolvedThreadId}' failed: {ex.Message}");
+            return new { sent = false, threadId = resolvedThreadId, error = ex.Message };
+        }
+
+        var updated = await provider.LoadAsync();
+        var timeline = updated.Timelines.TryGetValue(resolvedThreadId, out var tl)
+            ? tl
+            : ChatTimelineState.Initial();
+
+        return new
+        {
+            sent = true,
+            threadId = resolvedThreadId,
+            entryCount = timeline.Entries.Count,
+            turnActive = timeline.TurnActive
+        };
+    }
+
+    private async Task<object?> ResetChatSessionForMcpAsync(string? threadId)
+    {
+        var client = GatewayClient;
+        if (client == null || !client.IsConnectedToGateway)
+            return new { reset = false, error = "Gateway client is not connected" };
+
+        var provider = _chatCoordinator?.Provider;
+        if (provider == null)
+            return new { reset = false, error = "Chat provider is not initialized" };
+
+        var snapshot = await provider.LoadAsync();
+        var resolvedThreadId = ResolveChatThreadId(snapshot, threadId);
+        if (string.IsNullOrWhiteSpace(resolvedThreadId))
+            return new { reset = false, error = "Chat compose target is not ready" };
+
+        var reset = await client.ResetSessionAsync(resolvedThreadId);
+        if (reset)
+            await WaitForAppStateUpdateAsync(nameof(AppState.Sessions), () => client.RequestSessionsAsync());
+
+        return new
+        {
+            reset,
+            threadId = resolvedThreadId,
+            error = reset ? null : "sessions.reset was rejected or unavailable"
+        };
+    }
+
+    private static string? ResolveChatThreadId(ChatDataSnapshot snapshot, string? requestedThreadId)
+    {
+        if (!string.IsNullOrWhiteSpace(requestedThreadId))
+            return requestedThreadId;
+
+        if (snapshot.ComposeTarget.IsReady && !string.IsNullOrWhiteSpace(snapshot.ComposeTarget.SessionKey))
+            return snapshot.ComposeTarget.SessionKey;
+
+        return snapshot.DefaultThreadId;
+    }
+
+    private static object BuildChatSnapshotPayload(ChatDataSnapshot snapshot, string? resolvedThreadId)
+    {
+        var selectedTimeline = resolvedThreadId is not null
+            && snapshot.Timelines.TryGetValue(resolvedThreadId, out var timeline)
+                ? timeline
+                : null;
+
+        return new
+        {
+            connectionStatus = snapshot.ConnectionStatus,
+            defaultThreadId = snapshot.DefaultThreadId,
+            requestedThreadId = resolvedThreadId,
+            composeTarget = new
+            {
+                sessionKey = snapshot.ComposeTarget.SessionKey,
+                isReady = snapshot.ComposeTarget.IsReady
+            },
+            threads = snapshot.Threads.Select(t => new
+            {
+                t.Id,
+                t.Title,
+                status = t.Status.ToString(),
+                activity = t.Activity.ToString(),
+                t.Model,
+                t.ModelProvider,
+                t.ThinkingLevel,
+                t.InputTokens,
+                t.OutputTokens,
+                t.TotalTokens,
+                t.ContextTokens
+            }).ToArray(),
+            selectedTimeline = selectedTimeline is null ? null : new
+            {
+                turnActive = selectedTimeline.TurnActive,
+                historyLoaded = selectedTimeline.HistoryLoaded,
+                pendingPermission = selectedTimeline.PendingPermission is null ? null : new
+                {
+                    selectedTimeline.PendingPermission.RequestId,
+                    selectedTimeline.PendingPermission.PermissionKind,
+                    selectedTimeline.PendingPermission.ToolName,
+                    selectedTimeline.PendingPermission.Detail,
+                    selectedTimeline.PendingPermission.Actions
+                },
+                entries = selectedTimeline.Entries
+                    .TakeLast(30)
+                    .Select(e => new
+                    {
+                        e.Id,
+                        kind = e.Kind.ToString(),
+                        e.Text,
+                        e.IsStreaming,
+                        e.ToolName,
+                        toolResult = e.ToolResult?.ToString(),
+                        e.IntentSummary,
+                        e.ToolCallId,
+                        e.PermissionRequestId,
+                        permissionDecision = e.PermissionDecision.ToString()
+                    })
+                    .ToArray()
+            }
+        };
     }
 
     private async Task WaitForAppStateUpdateAsync(string propertyName, Func<Task> requestAsync)

--- a/src/OpenClaw.Tray.WinUI/Services/NodeInvokeActivityFormatter.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeInvokeActivityFormatter.cs
@@ -31,7 +31,8 @@ internal static class NodeInvokeActivityFormatter
         if (string.IsNullOrEmpty(command)) return Metadata;
 
         if (command.StartsWith("stt.", StringComparison.OrdinalIgnoreCase) ||
-            command.StartsWith("tts.", StringComparison.OrdinalIgnoreCase))
+            command.StartsWith("tts.", StringComparison.OrdinalIgnoreCase) ||
+            command.StartsWith("app.chat.", StringComparison.OrdinalIgnoreCase))
         {
             return PrivacySensitive;
         }

--- a/src/OpenClaw.WinNode.Cli/skill.md
+++ b/src/OpenClaw.WinNode.Cli/skill.md
@@ -364,6 +364,33 @@ Build the same gateway dashboard URL the tray opens.
 ```
 Returns `{ url, credentialSource, usesSharedGatewayToken, hasTokenQuery }`.
 
+### app.chat.snapshot
+Read the current native chat snapshot for local automation and diagnostics.
+**READ-ALL:** returns recent chat text from the selected timeline.
+```
+{"threadId": "string"}       // optional; "sessionKey" alias also accepted
+```
+Returns `{ connectionStatus, defaultThreadId, composeTarget, threads, selectedTimeline }`.
+
+### app.chat.send
+Send a message through the same native chat provider used by the Chat UI.
+```
+{
+  "message": "string",       // required
+  "threadId": "string"       // optional; defaults to compose/default thread
+}
+```
+Returns `{ sent, threadId, entryCount, turnActive, error? }`.
+
+### app.chat.reset
+Reset the target chat session through the gateway `sessions.reset` path.
+```
+{"threadId": "string"}       // optional; "sessionKey" alias also accepted
+```
+When `threadId`/`sessionKey` is omitted this resets the current compose/default
+thread, which usually means the active chat session. Returns `{ reset, threadId,
+error? }`.
+
 ## Location (location.*)
 
 ### location.get

--- a/tests/OpenClaw.Shared.Tests/AppCapabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/AppCapabilityTests.cs
@@ -27,7 +27,8 @@ public class AppCapabilityTests
     {
         var cap = new AppCapability(NullLogger.Instance);
         var expected = new[] { "app.navigate", "app.status", "app.sessions", "app.agents",
-            "app.nodes", "app.config.get", "app.settings.get", "app.settings.set", "app.menu", "app.search" };
+            "app.nodes", "app.config.get", "app.settings.get", "app.settings.set", "app.menu", "app.search",
+            "app.dashboard.url", "app.chat.snapshot", "app.chat.send", "app.chat.reset" };
         foreach (var cmd in expected)
         {
             Assert.Contains(cmd, cap.Commands);
@@ -91,5 +92,75 @@ public class AppCapabilityTests
         var res = await cap.ExecuteAsync(req);
         Assert.False(res.Ok);
         Assert.Contains("Unknown", res.Error);
+    }
+
+    [Fact]
+    public async Task ChatSend_WithHandler_SendsMessageToDefaultThread()
+    {
+        var cap = new AppCapability(NullLogger.Instance);
+        string? capturedThreadId = "unset";
+        string? capturedMessage = null;
+        cap.ChatSendHandler = (threadId, message) =>
+        {
+            capturedThreadId = threadId;
+            capturedMessage = message;
+            return Task.FromResult<object?>(new { sent = true });
+        };
+
+        var req = new NodeInvokeRequest
+        {
+            Id = "1",
+            Command = "app.chat.send",
+            Args = ParseArgs("{\"message\":\"hello\"}")
+        };
+
+        var res = await cap.ExecuteAsync(req);
+
+        Assert.True(res.Ok);
+        Assert.Null(capturedThreadId);
+        Assert.Equal("hello", capturedMessage);
+    }
+
+    [Fact]
+    public async Task ChatSend_WithSessionKeyAlias_ForwardsThreadId()
+    {
+        var cap = new AppCapability(NullLogger.Instance);
+        string? capturedThreadId = null;
+        cap.ChatSendHandler = (threadId, message) =>
+        {
+            capturedThreadId = threadId;
+            return Task.FromResult<object?>(new { sent = true, message });
+        };
+
+        var req = new NodeInvokeRequest
+        {
+            Id = "1",
+            Command = "app.chat.send",
+            Args = ParseArgs("{\"sessionKey\":\"agent:main:default\",\"message\":\"hello\"}")
+        };
+
+        var res = await cap.ExecuteAsync(req);
+
+        Assert.True(res.Ok);
+        Assert.Equal("agent:main:default", capturedThreadId);
+    }
+
+    [Fact]
+    public async Task ChatSend_WithoutMessage_ReturnsError()
+    {
+        var cap = new AppCapability(NullLogger.Instance);
+        cap.ChatSendHandler = (_, _) => Task.FromResult<object?>(new { sent = true });
+
+        var req = new NodeInvokeRequest
+        {
+            Id = "1",
+            Command = "app.chat.send",
+            Args = ParseArgs("{}")
+        };
+
+        var res = await cap.ExecuteAsync(req);
+
+        Assert.False(res.Ok);
+        Assert.Contains("message", res.Error);
     }
 }

--- a/tests/OpenClaw.Tray.Tests/NodeInvokeActivityFormatterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/NodeInvokeActivityFormatterTests.cs
@@ -119,6 +119,9 @@ public sealed class NodeInvokeActivityFormatterTests : IDisposable
     [InlineData("device.status", "metadata")]
     [InlineData("tts.speak", "privacy-sensitive")] // TTS errors can leak ElevenLabs key fragments / device names
     [InlineData("tts.future-command", "privacy-sensitive")] // any future tts.* defaults privacy-sensitive
+    [InlineData("app.chat.send", "privacy-sensitive")]
+    [InlineData("app.chat.snapshot", "privacy-sensitive")]
+    [InlineData("app.chat.future-command", "privacy-sensitive")] // chat text can appear in payloads or errors
     [InlineData("", "metadata")]
     public void GetPrivacyClass_KnownCommands(string command, string expected)
     {


### PR DESCRIPTION
## Summary
- add MCP-only native chat automation commands: `app.chat.snapshot`, `app.chat.send`, and `app.chat.reset`
- wire the commands through the existing tray chat provider/gateway reset path for local #899 repro/proof workflows
- document the commands in `winnode` skill docs and MCP tool descriptions, with chat activity marked privacy-sensitive

## Validation
- `python .agents\skills\autoreview\scripts\autoreview --mode local` — clean, no accepted/actionable findings
- `.\build.ps1`
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` — 2689 passed, 31 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` — 1452 passed
- `dotnet test .\tests\OpenClaw.WinNode.Cli.Tests\OpenClaw.WinNode.Cli.Tests.csproj --no-restore` — 120 passed; existing OnnxRuntime version conflict warnings

## Real behavior proof
- launched the validated WinUI build locally and confirmed `winnode --list-tools` advertises `app.chat.snapshot`, `app.chat.send`, and `app.chat.reset`
- invoked `app.chat.reset`, then `app.chat.send` with `What's the weather in Redmond, WA`
- confirmed `app.chat.snapshot` contains the user entry text and weather tool calls
- captured LVT WinUI XML showing a `TextBlock` with `What's the weather in Redmond, WA` and normal bounds
- final proof artifacts are in the local session artifact folder under `files\issue-899-mcp-chat\`

CUA remains blocked for `OpenClaw.Tray.WinUI` approval on this host, so the current-head proof used MCP invocation plus LVT inspection instead.
