### PR TITLE
Document operator and node concepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ This monorepo contains the Windows hub, shared client libraries, and CLI utiliti
 > **End-user installer?** Download the latest stable x64 or ARM64 installer from the [OpenClaw Windows docs](https://docs.openclaw.ai/platforms/windows), or see [docs/SETUP.md](docs/SETUP.md) for step-by-step installation (no build required).
 >
 > **Managed WSL gateway?** Local setup creates a locked-down app-owned `OpenClawGateway` distro. See [docs/WSL_GATEWAY_ADMIN.md](docs/WSL_GATEWAY_ADMIN.md) for editing `openclaw.json` as the `openclaw` user and using root for protected-file administration.
+>
+> **Operator or node?** Start with [Operator and node concepts](docs/OPERATOR_NODE_CONCEPTS.md) for the beginner-facing glossary of gateway, operator, node, pairing, reapproval, and allowlisted node capabilities.
 
 Direct downloads from the latest OpenClaw Windows release:
 
@@ -217,6 +219,8 @@ These features are available in Windows but not in the Mac app:
 | First-run onboarding | 6-screen guided setup wizard (Welcome → Connection → Wizard → Permissions → Chat → Ready) |
 
 ### 🔌 Node Mode (Agent Control)
+
+If the operator/node split is new to you, read [Operator and node concepts](docs/OPERATOR_NODE_CONCEPTS.md) before enabling Node Mode.
 
 When Node Mode is enabled in Settings, your Windows PC becomes a **node** that the OpenClaw agent can control - just like the Mac app! The agent can:
 

--- a/docs/OPERATOR_NODE_CONCEPTS.md
+++ b/docs/OPERATOR_NODE_CONCEPTS.md
@@ -61,7 +61,7 @@ so a new or changed node capability is visible before the gateway can use it.
 ## Capability Allowlist
 
 Node Mode advertises available Windows commands, but the gateway decides which
-commands it may call through `gateway.nodes[].allowCommands` in
+commands it may call through `gateway.nodes.allowCommands` in
 `~/.openclaw/openclaw.json`. Add exact command names such as `screen.snapshot`,
 `canvas.present`, or `system.run`; wildcard entries are not expanded by the
 gateway.

--- a/docs/OPERATOR_NODE_CONCEPTS.md
+++ b/docs/OPERATOR_NODE_CONCEPTS.md
@@ -1,0 +1,81 @@
+# Operator and Node Concepts
+
+OpenClaw Companion connects a Windows PC to an OpenClaw gateway in two separate
+roles. A new install can use both roles at once, but they have different jobs and
+different approval paths.
+
+## Quick Glossary
+
+| Term | Meaning |
+| --- | --- |
+| Gateway | The OpenClaw service that coordinates agents, channels, sessions, devices, and nodes. The Windows app talks to it over WebSocket. |
+| Local WSL gateway | A dedicated `OpenClawGateway` WSL distro installed by the Windows onboarding flow. It is app-owned and locked down rather than a general-purpose Ubuntu profile. |
+| Operator | The user-facing control role. The tray app uses the operator connection for Quick Send, chat, diagnostics, channel controls, setup, and approving pairing requests. |
+| Node | The controllable Windows machine role. When Node Mode is enabled, the tray app advertises Windows capabilities such as screenshots, canvas, camera, notifications, and approved command execution. |
+| Pairing | The gateway approval flow that turns a new device or node request into a trusted identity with a stored device token. |
+| Reapproval | A later approval request when a paired node asks for new or changed trust, such as command capability access. |
+| Allowlisted node capability | A node command the gateway is explicitly allowed to invoke, configured in the gateway `allowCommands` list. Windows-side settings and policies can still block the command. |
+
+## How the Roles Work Together
+
+The operator role is the control surface. It signs in to the gateway, sends chat
+messages, shows status, opens diagnostics, and approves device or node pairing
+requests when the gateway says approval is required.
+
+The node role is the Windows capability surface. It tells the gateway which
+Windows-native tools are available, then waits for approved gateway calls. Node
+Mode does not mean every tool can run automatically. A capability has to be
+enabled in Windows settings, allowed by the gateway, and in some cases approved
+by a local Windows policy prompt.
+
+A typical local setup uses this sequence:
+
+1. OpenClaw Companion installs or connects to a gateway.
+2. The tray app connects as an operator so you can send messages and manage setup.
+3. If Node Mode is enabled, the same Windows app also connects as a node.
+4. The gateway asks for pairing approval before trusting the new device or node.
+5. After approval, the gateway can invoke only the node capabilities that are
+   enabled locally and allowlisted by gateway policy.
+
+## Local WSL Gateway Versus Existing Gateway
+
+The default onboarding path installs a local WSL gateway for users who do not
+already have one. That gateway runs on the same Windows PC and is managed by the
+OpenClaw Companion setup flow.
+
+Advanced setup is for users who already have a local, remote, or manually
+managed gateway. In that case, the Windows app still uses the same operator and
+node roles; only the gateway location and credentials are different.
+
+## Pairing, Tokens, and Reapproval
+
+Pairing is gateway-owned. Setup codes, bootstrap tokens, and shared gateway
+tokens can help the app connect for the first time, but a paired device token
+takes precedence after approval. This keeps long-lived operator and node
+identity scoped to the gateway record that issued it.
+
+Some trust decisions are intentionally not automatic. Node command trust and
+capability reapproval stay pending until an operator explicitly approves them,
+so a new or changed node capability is visible before the gateway can use it.
+
+## Capability Allowlist
+
+Node Mode advertises available Windows commands, but the gateway decides which
+commands it may call through `gateway.nodes[].allowCommands` in
+`~/.openclaw/openclaw.json`. Add exact command names such as `screen.snapshot`,
+`canvas.present`, or `system.run`; wildcard entries are not expanded by the
+gateway.
+
+Privacy-sensitive commands, especially `screen.record`, `camera.*`,
+`stt.transcribe`, `tts.speak`, and `system.run`, should only be allowlisted when
+you want the gateway to be able to request that behavior. Windows permissions,
+Node Mode toggles, and the local exec policy can still add stricter checks.
+
+## Where to Go Next
+
+- Follow [Installation and setup](SETUP.md) for first-run onboarding and
+  troubleshooting.
+- See [Node Mode](../README.md#-node-mode-agent-control) for capability names
+  and allowlist examples.
+- Read [Connection architecture](CONNECTION_ARCHITECTURE.md) for contributor
+  details about token precedence, pairing, and connection lifecycle.

--- a/docs/OPERATOR_NODE_CONCEPTS.md
+++ b/docs/OPERATOR_NODE_CONCEPTS.md
@@ -66,10 +66,11 @@ commands it may call through `gateway.nodes.allowCommands` in
 `canvas.present`, or `system.run`; wildcard entries are not expanded by the
 gateway.
 
-Privacy-sensitive commands, especially `screen.record`, `camera.*`,
-`stt.transcribe`, `tts.speak`, and `system.run`, should only be allowlisted when
-you want the gateway to be able to request that behavior. Windows permissions,
-Node Mode toggles, and the local exec policy can still add stricter checks.
+Privacy-sensitive commands, especially `screen.record`, `camera.snap`,
+`camera.clip`, `stt.transcribe`, `tts.speak`, and `system.run`, should only be
+allowlisted when you want the gateway to be able to request that behavior.
+Windows permissions, Node Mode toggles, and the local exec policy can still add
+stricter checks.
 
 ## Where to Go Next
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -11,6 +11,8 @@ Before installing, make sure you have:
 
 You do **not** need a pre-existing local OpenClaw gateway before installing. On first launch, OpenClaw Companion can install a dedicated local WSL gateway for you, or you can use **Advanced setup** to connect to an existing local, remote, or manually configured gateway.
 
+New to the OpenClaw roles? Read [Operator and node concepts](OPERATOR_NODE_CONCEPTS.md) for a short glossary of gateway, local WSL gateway, operator, node, pairing, reapproval, and allowlisted node capabilities before starting setup.
+
 ## Step-by-Step Installation
 
 ### 1. Download the Installer
@@ -53,6 +55,8 @@ On first launch, Molty opens the onboarding wizard when there is no usable saved
 1. **Welcome** — A friendly greeting introducing OpenClaw and Molty. Click **Install new WSL Gateway** to install a new local WSL gateway.
 
    If you already have a local or remote gateway, choose **Advanced setup** instead. This opens the tray app's Connections tab, where you can connect with an existing gateway URL, token, or setup code without installing a new local WSL gateway.
+
+   For the role split behind these choices, see [Operator and node concepts](OPERATOR_NODE_CONCEPTS.md).
 
 2. **Capabilities** — Reviews the Windows node capabilities that can be enabled, such as system commands, canvas, screen capture, camera, location, browser automation, device controls, text-to-speech, and speech-to-text.
 


### PR DESCRIPTION
Closes #910.

Adds a beginner-facing glossary for gateway, local WSL gateway, operator, node, pairing, reapproval, and allowlisted node capabilities, then links it from setup and Node Mode docs.

Rendered Markdown proof:
```text
<h1 dir="auto">Operator and Node Concepts</h1>
<code class="notranslate">gateway.nodes.allowCommands</code>
<code class="notranslate">camera.snap</code>
<code class="notranslate">camera.clip</code>
<a href="SETUP.md">Installation and setup</a>
<a href="../README.md#-node-mode-agent-control">Node Mode</a>
<a href="CONNECTION_ARCHITECTURE.md">Connection architecture</a>
```

Validation: GitHub Actions `Build and Test` passed on the current head, including repo-hygiene, `test`, setup/network/revocation E2E jobs, and win-x64/win-arm64 builds.