### PR TITLE
Fix chat timeline render identity reuse

### DIFF
--- a/src/OpenClaw.Chat/ChatModels.cs
+++ b/src/OpenClaw.Chat/ChatModels.cs
@@ -194,7 +194,8 @@ public record ChatDataSnapshot(
     ChatComposeTarget ComposeTarget,
     IReadOnlyList<ChatModelChoice>? ModelChoices = null,
     IReadOnlyList<OpenClaw.Shared.GatewayCommand>? AvailableCommands = null,
-    bool CommandsSupported = true);
+    bool CommandsSupported = true,
+    IReadOnlyDictionary<string, long>? TimelineGenerations = null);
 
 /// <summary>
 /// Describes where the UI may send the next chat message. Distinct from

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -4136,6 +4136,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
 
         // Snapshot a defensive copy of the timeline dict.
         var timelinesCopy = new Dictionary<string, ChatTimelineState>(_timelines);
+        var timelineGenerationsCopy = new Dictionary<string, long>(_resetVersions);
 
         var defaultThreadId = ResolveDefaultThreadIdLocked();
 
@@ -4171,7 +4172,8 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             // distinguish "loading" from "loaded but empty". IsSupported=false
             // surfaces the unsupported state.
             AvailableCommands: _commandCatalog?.Commands,
-            CommandsSupported: _commandCatalog?.IsSupported ?? true);
+            CommandsSupported: _commandCatalog?.IsSupported ?? true,
+            TimelineGenerations: timelineGenerationsCopy);
     }
 
     private string? ResolveDefaultThreadIdLocked()

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
@@ -286,6 +286,13 @@ public sealed class OpenClawChatRoot : Component
         var timeline = effectiveThread is not null && snapshot.Timelines.TryGetValue(effectiveThread.Id, out var tl)
             ? tl
             : ChatTimelineState.Initial();
+        var timelineGeneration = 0L;
+        if (effectiveThread is not null
+            && snapshot.TimelineGenerations is { } generations
+            && generations.TryGetValue(effectiveThread.Id, out var generation))
+        {
+            timelineGeneration = generation;
+        }
 
         var entries = (IReadOnlyList<ChatTimelineItem>)timeline.Entries;
         var connectedRaw = snapshot.ConnectionStatus;
@@ -479,6 +486,7 @@ public sealed class OpenClawChatRoot : Component
                 HasMoreHistory: false,
                 OnLoadMoreHistory: null,
                 EntryMetadata: entryMeta,
+                TimelineGeneration: timelineGeneration,
                 UserSenderLabel: "OpenClaw Windows Tray",
                 AssistantSenderLabel: assistantSenderLabel,
                 DefaultModel: effectiveThread.Model,

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
@@ -44,6 +44,7 @@ public record OpenClawChatTimelineProps(
     bool HasMoreHistory,
     Action? OnLoadMoreHistory,
     IReadOnlyDictionary<string, ChatEntryMetadata>? EntryMetadata = null,
+    long TimelineGeneration = 0,
     string UserSenderLabel = "OpenClaw Windows Tray",
     string AssistantSenderLabel = "Field",
     string? DefaultModel = null,
@@ -787,6 +788,12 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
 
         ChatEntryMetadata? MetaFor(string id) =>
             meta is not null && meta.TryGetValue(id, out var m) ? m : null;
+
+        string RowKey(ChatTimelineItem entry) =>
+            $"thread:{Props.SessionId ?? "none"}|generation:{Props.TimelineGeneration}|kind:{entry.Kind}|id:{entry.Id}";
+
+        string SyntheticRowKey(string id, ChatTimelineItemKind kind) =>
+            $"thread:{Props.SessionId ?? "none"}|generation:{Props.TimelineGeneration}|kind:{kind}|synthetic:{id}";
 
         // Hover-revealed action icon (copy / read aloud / trash). Opacity 0
         // and not hit-testable until the entry is hovered, then fades in
@@ -2307,19 +2314,19 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
             {
                 if (!showToolCalls)
                 {
-                    renderedEntries[k] = Empty().WithKey(entry.Id);
+                    renderedEntries[k] = Empty().WithKey(RowKey(entry));
                     continue;
                 }
                 if (!startsBurst)
                 {
-                    renderedEntries[k] = Empty().WithKey(entry.Id);
+                    renderedEntries[k] = Empty().WithKey(RowKey(entry));
                     continue;
                 }
                 if (nestedConsumed.Contains(k))
                 {
                     // The assistant bubble above already rendered this burst
                     // inline as a child element — emit nothing here.
-                    renderedEntries[k] = Empty().WithKey(entry.Id);
+                    renderedEntries[k] = Empty().WithKey(RowKey(entry));
                     continue;
                 }
                 var burst = new System.Collections.Generic.List<ChatTimelineItem> { entry };
@@ -2329,7 +2336,7 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                     burst.Add(Props.Entries[orderedIdx[kj]]);
                     kj++;
                 }
-                renderedEntries[k] = RenderToolBurst(burst, showAvatar, currentBubbleSlot).WithKey(entry.Id);
+                renderedEntries[k] = RenderToolBurst(burst, showAvatar, currentBubbleSlot).WithKey(RowKey(entry));
                 continue;
             }
 
@@ -2365,11 +2372,11 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                     }
                 }
 
-                renderedEntries[k] = RenderAssistantEntry(entry, startsBurst, endsBurst, showAvatar, currentBubbleSlot, nestedTool).WithKey(entry.Id);
+                renderedEntries[k] = RenderAssistantEntry(entry, startsBurst, endsBurst, showAvatar, currentBubbleSlot, nestedTool).WithKey(RowKey(entry));
                 continue;
             }
 
-            renderedEntries[k] = RenderEntry(entry, startsBurst, endsBurst, showAvatar).WithKey(entry.Id);
+            renderedEntries[k] = RenderEntry(entry, startsBurst, endsBurst, showAvatar).WithKey(RowKey(entry));
         }
 
         var thinkingNestedConsumed = new System.Collections.Generic.HashSet<int>();
@@ -2436,7 +2443,8 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                 nestedTool: thinkingNestedTool,
                 suppressFooter: true,
                 forceVisible: true)
-                .LiveRegion(Microsoft.UI.Xaml.Automation.Peers.AutomationLiveSetting.Polite);
+                .LiveRegion(Microsoft.UI.Xaml.Automation.Peers.AutomationLiveSetting.Polite)
+                .WithKey(SyntheticRowKey("__thinking__", ChatTimelineItemKind.Assistant));
         }
 
         // Build the final element list, splicing the thinking indicator

--- a/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
+++ b/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
@@ -1620,20 +1620,37 @@ internal sealed class UiRenderer(Action requestRender)
         var m = element.Modifiers;
         control.Tag = element;
         if (m.Margin is { } margin) control.Margin = margin;
+        else control.ClearValue(FrameworkElement.MarginProperty);
         if (m.Width is { } width) control.Width = width;
+        else control.ClearValue(FrameworkElement.WidthProperty);
         if (m.Height is { } height) control.Height = height;
+        else control.ClearValue(FrameworkElement.HeightProperty);
         if (m.MinWidth is { } minWidth) control.MinWidth = minWidth;
+        else control.ClearValue(FrameworkElement.MinWidthProperty);
         if (m.MaxWidth is { } maxWidth) control.MaxWidth = maxWidth;
+        else control.ClearValue(FrameworkElement.MaxWidthProperty);
         if (m.MinHeight is { } minHeight) control.MinHeight = minHeight;
+        else control.ClearValue(FrameworkElement.MinHeightProperty);
         if (m.MaxHeight is { } maxHeight) control.MaxHeight = maxHeight;
+        else control.ClearValue(FrameworkElement.MaxHeightProperty);
         if (m.HorizontalAlignment is { } hAlign) control.HorizontalAlignment = hAlign;
+        else control.ClearValue(FrameworkElement.HorizontalAlignmentProperty);
         if (m.VerticalAlignment is { } vAlign) control.VerticalAlignment = vAlign;
+        else control.ClearValue(FrameworkElement.VerticalAlignmentProperty);
         if (m.Opacity is { } opacity) control.Opacity = opacity;
+        else control.ClearValue(UIElement.OpacityProperty);
         if (m.AutomationName is { } automationName) AutomationProperties.SetName(control, automationName);
+        else control.ClearValue(AutomationProperties.NameProperty);
         if (m.LiveRegion is { } liveRegion) AutomationProperties.SetLiveSetting(control, liveRegion);
+        else control.ClearValue(AutomationProperties.LiveSettingProperty);
         ApplyResourceOverrides(control, m.ResourceOverrides);
-        if (m.Disabled is { } disabled && control is Control disabledControl)
-            disabledControl.IsEnabled = !disabled;
+        if (control is Control disabledControl)
+        {
+            if (m.Disabled is { } disabled)
+                disabledControl.IsEnabled = !disabled;
+            else
+                disabledControl.ClearValue(Control.IsEnabledProperty);
+        }
 
         control.KeyDown -= ElementKeyDown;
         if (m.KeyDown is not null) control.KeyDown += ElementKeyDown;
@@ -1646,37 +1663,59 @@ internal sealed class UiRenderer(Action requestRender)
         {
             case TextBlock tb:
                 if (m.FontSize is { } textSize) tb.FontSize = textSize;
+                else tb.ClearValue(TextBlock.FontSizeProperty);
                 if (m.FontWeight is { } textWeight) tb.FontWeight = textWeight;
+                else tb.ClearValue(TextBlock.FontWeightProperty);
                 if (m.FontFamily is { } textFamily) tb.FontFamily = textFamily;
+                else tb.ClearValue(TextBlock.FontFamilyProperty);
                 if (m.TextWrapping is { } wrapping) tb.TextWrapping = wrapping;
+                else tb.ClearValue(TextBlock.TextWrappingProperty);
                 if (m.Padding is { } textPadding) tb.Padding = textPadding;
+                else tb.ClearValue(TextBlock.PaddingProperty);
                 if (m.ForegroundResourceKey is { } textFgResource) tb.Foreground = ThemeResources.ResolveBrush(textFgResource);
                 else if (m.Foreground is { } textFg) tb.Foreground = textFg;
+                else tb.ClearValue(TextBlock.ForegroundProperty);
+                tb.ClearValue(TextBlock.TextTrimmingProperty);
+                tb.ClearValue(TextBlock.MaxLinesProperty);
+                tb.ClearValue(TextBlock.LineHeightProperty);
+                tb.ClearValue(TextBlock.CharacterSpacingProperty);
                 break;
             case Control c:
                 if (m.Padding is { } controlPadding) c.Padding = controlPadding;
+                else c.ClearValue(Control.PaddingProperty);
                 if (m.FontSize is { } controlSize) c.FontSize = controlSize;
+                else c.ClearValue(Control.FontSizeProperty);
                 if (m.FontWeight is { } controlWeight) c.FontWeight = controlWeight;
+                else c.ClearValue(Control.FontWeightProperty);
                 if (m.FontFamily is { } controlFamily) c.FontFamily = controlFamily;
+                else c.ClearValue(Control.FontFamilyProperty);
                 if (m.ForegroundResourceKey is { } controlFgResource) c.Foreground = ThemeResources.ResolveBrush(controlFgResource);
                 else if (m.Foreground is { } controlFg) c.Foreground = controlFg;
+                else c.ClearValue(Control.ForegroundProperty);
                 if (m.BorderBrushResourceKey is { } controlBorderResource) c.BorderBrush = ThemeResources.ResolveBrush(controlBorderResource);
                 else if (m.BorderBrush is { } controlBorder) c.BorderBrush = controlBorder;
+                else c.ClearValue(Control.BorderBrushProperty);
                 if (m.BorderThickness is { } controlThickness) c.BorderThickness = controlThickness;
+                else c.ClearValue(Control.BorderThicknessProperty);
                 break;
             case Border b:
                 if (m.Padding is { } borderPadding) b.Padding = borderPadding;
+                else b.ClearValue(Border.PaddingProperty);
                 if (m.BackgroundResourceKey is { } backgroundResourceKey)
                     b.Background = ThemeResources.ResolveBrush(backgroundResourceKey);
                 else if (m.Background is { } bg)
                     b.Background = bg;
+                else b.ClearValue(Border.BackgroundProperty);
                 if (m.BorderBrushResourceKey is { } borderResourceKey)
                     b.BorderBrush = ThemeResources.ResolveBrush(borderResourceKey);
                 else if (m.BorderBrush is { } borderBrush)
                     b.BorderBrush = borderBrush;
+                else b.ClearValue(Border.BorderBrushProperty);
                 if (m.BorderThickness is { } borderThickness)
                     b.BorderThickness = borderThickness;
+                else b.ClearValue(Border.BorderThicknessProperty);
                 if (m.CornerRadius is { } radius) b.CornerRadius = radius;
+                else b.ClearValue(Border.CornerRadiusProperty);
                 break;
         }
     }

--- a/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
+++ b/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
@@ -913,10 +913,19 @@ internal sealed class UiRenderer(Action requestRender)
     private readonly Dictionary<string, Component> _components = new();
     private readonly Dictionary<string, Flyout> _contentFlyouts = new();
     private readonly HashSet<string> _mountedPaths = new();
+    private readonly HashSet<string> _visitedControlPaths = new();
+    private readonly HashSet<string> _visitedComponentKeys = new();
+    private readonly HashSet<string> _visitedContentFlyoutPaths = new();
 
     public UIElement Render(Element element, string path, List<Action> effects)
     {
-        return RenderElement(element, path, effects);
+        _visitedControlPaths.Clear();
+        _visitedComponentKeys.Clear();
+        _visitedContentFlyoutPaths.Clear();
+
+        var rendered = RenderElement(element, path, effects);
+        PruneUnvisitedPaths();
+        return rendered;
     }
 
     public void Dispose()
@@ -993,6 +1002,8 @@ internal sealed class UiRenderer(Action requestRender)
 
     private T GetOrCreate<T>(string path) where T : UIElement, new()
     {
+        _visitedControlPaths.Add(path);
+
         if (_controls.TryGetValue(path, out var existing) && existing is T typed)
             return typed;
 
@@ -1020,6 +1031,8 @@ internal sealed class UiRenderer(Action requestRender)
     {
         var componentKey = GetComponentKey(element.ComponentType);
         var key = path + ":" + componentKey;
+        _visitedComponentKeys.Add(key);
+
         if (!_components.TryGetValue(key, out var component))
         {
             component = (Component)Activator.CreateInstance(element.ComponentType)!;
@@ -1378,6 +1391,8 @@ internal sealed class UiRenderer(Action requestRender)
 
     private Flyout CreateContentFlyout(ContentFlyoutElement element, string path, List<Action> effects)
     {
+        _visitedContentFlyoutPaths.Add(path);
+
         // Cache the Flyout instance per path so its identity is STABLE across
         // re-renders. ConfigureButton reassigns control.Flyout on every render,
         // and a full-root re-render fires on every state change (including the
@@ -1401,6 +1416,39 @@ internal sealed class UiRenderer(Action requestRender)
             flyout.Content = content;
         }
         return flyout;
+    }
+
+    private void PruneUnvisitedPaths()
+    {
+        foreach (var (key, component) in _components.ToArray())
+        {
+            if (_visitedComponentKeys.Contains(key))
+                continue;
+
+            component.Context.RunEffectCleanups();
+            _components.Remove(key);
+        }
+
+        foreach (var (path, flyout) in _contentFlyouts.ToArray())
+        {
+            if (_visitedContentFlyoutPaths.Contains(path))
+                continue;
+
+            flyout.Hide();
+            flyout.Content = null;
+            _contentFlyouts.Remove(path);
+        }
+
+        foreach (var (path, control) in _controls.ToArray())
+        {
+            if (_visitedControlPaths.Contains(path))
+                continue;
+
+            _mountedPaths.Remove(path);
+            DetachChildren(control);
+            RemoveFromParent(control);
+            _controls.Remove(path);
+        }
     }
 
     private static MenuFlyout CreateMenuFlyout(MenuFlyoutContentElement element)

--- a/tests/OpenClaw.Tray.Tests/ChatTimelineRenderIdentityContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatTimelineRenderIdentityContractTests.cs
@@ -1,0 +1,58 @@
+using System.Text.RegularExpressions;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class ChatTimelineRenderIdentityContractTests
+{
+    [Fact]
+    public void TimelineRows_UseGenerationQualifiedKindedKeys()
+    {
+        var timeline = Read("src", "OpenClaw.Tray.WinUI", "Chat", "OpenClawChatTimeline.cs");
+
+        Assert.Contains("long TimelineGeneration = 0", timeline);
+        Assert.Contains("string RowKey(ChatTimelineItem entry)", timeline);
+        Assert.Contains("Props.TimelineGeneration", timeline);
+        Assert.Contains("entry.Kind", timeline);
+        Assert.Contains("entry.Id", timeline);
+        Assert.DoesNotContain(".WithKey(entry.Id)", timeline);
+        Assert.Matches(
+            new Regex(@"WithKey\(RowKey\(entry\)\)"),
+            timeline);
+    }
+
+    [Fact]
+    public void ThinkingIndicator_UsesSyntheticGenerationQualifiedKey()
+    {
+        var timeline = Read("src", "OpenClaw.Tray.WinUI", "Chat", "OpenClawChatTimeline.cs");
+
+        Assert.Contains("string SyntheticRowKey(string id, ChatTimelineItemKind kind)", timeline);
+        Assert.Contains("SyntheticRowKey(\"__thinking__\", ChatTimelineItemKind.Assistant)", timeline);
+    }
+
+    [Fact]
+    public void TimelineGeneration_FlowsFromProviderSnapshotToTimelineProps()
+    {
+        var models = Read("src", "OpenClaw.Chat", "ChatModels.cs");
+        var provider = Read("src", "OpenClaw.Tray.WinUI", "Chat", "OpenClawChatDataProvider.cs");
+        var root = Read("src", "OpenClaw.Tray.WinUI", "Chat", "OpenClawChatRoot.cs");
+
+        Assert.Contains("IReadOnlyDictionary<string, long>? TimelineGenerations = null", models);
+        Assert.Contains("new Dictionary<string, long>(_resetVersions)", provider);
+        Assert.Contains("TimelineGenerations: timelineGenerationsCopy", provider);
+        Assert.Contains("snapshot.TimelineGenerations", root);
+        Assert.Contains("TimelineGeneration: timelineGeneration", root);
+    }
+
+    [Fact]
+    public void ResetClearPath_BumpsTimelineGenerationBeforeReusingEntryIds()
+    {
+        var provider = Read("src", "OpenClaw.Tray.WinUI", "Chat", "OpenClawChatDataProvider.cs");
+
+        Assert.Matches(
+            new Regex(@"private\s+ResetClearPersistence\s+ClearThreadHistoryAfterResetLocked\(string\s+threadId\)[\s\S]*_resetVersions\[threadId\]\s*=\s*GetResetVersionLocked\(threadId\)\s*\+\s*1;[\s\S]*_timelines\[threadId\]\s*=\s*ChatTimelineState\.Initial\(\)\s*with\s*\{\s*HistoryLoaded\s*=\s*true\s*\};"),
+            provider);
+    }
+
+    private static string Read(params string[] parts)
+        => File.ReadAllText(Path.Combine(new[] { TestRepositoryPaths.GetRepositoryRoot() }.Concat(parts).ToArray()));
+}

--- a/tests/OpenClaw.Tray.Tests/FunctionalUiModifierResetContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/FunctionalUiModifierResetContractTests.cs
@@ -32,6 +32,23 @@ public sealed class FunctionalUiModifierResetContractTests
         Assert.Contains("c.ClearValue(Control.BorderBrushProperty);", functionalUi);
     }
 
+    [Fact]
+    public void UiRenderer_PrunesUnvisitedCachesAfterRender()
+    {
+        var functionalUi = Read("src", "OpenClawTray.FunctionalUI", "FunctionalUI.cs");
+
+        Assert.Contains("private readonly HashSet<string> _visitedControlPaths = new();", functionalUi);
+        Assert.Contains("private readonly HashSet<string> _visitedComponentKeys = new();", functionalUi);
+        Assert.Contains("private readonly HashSet<string> _visitedContentFlyoutPaths = new();", functionalUi);
+        Assert.Contains("PruneUnvisitedPaths();", functionalUi);
+        Assert.Contains("component.Context.RunEffectCleanups();", functionalUi);
+        Assert.Contains("flyout.Hide();", functionalUi);
+        Assert.Contains("flyout.Content = null;", functionalUi);
+        Assert.Contains("_mountedPaths.Remove(path);", functionalUi);
+        Assert.Contains("DetachChildren(control);", functionalUi);
+        Assert.Contains("_controls.Remove(path);", functionalUi);
+    }
+
     private static string Read(params string[] parts)
         => File.ReadAllText(Path.Combine(new[] { TestRepositoryPaths.GetRepositoryRoot() }.Concat(parts).ToArray()));
 }

--- a/tests/OpenClaw.Tray.Tests/FunctionalUiModifierResetContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/FunctionalUiModifierResetContractTests.cs
@@ -1,0 +1,37 @@
+namespace OpenClaw.Tray.Tests;
+
+public sealed class FunctionalUiModifierResetContractTests
+{
+    [Fact]
+    public void ApplyModifiers_ClearsStaleLayoutAndAutomationValues()
+    {
+        var functionalUi = Read("src", "OpenClawTray.FunctionalUI", "FunctionalUI.cs");
+
+        Assert.Contains("control.ClearValue(FrameworkElement.WidthProperty);", functionalUi);
+        Assert.Contains("control.ClearValue(FrameworkElement.HeightProperty);", functionalUi);
+        Assert.Contains("control.ClearValue(FrameworkElement.MaxWidthProperty);", functionalUi);
+        Assert.Contains("control.ClearValue(UIElement.OpacityProperty);", functionalUi);
+        Assert.Contains("control.ClearValue(AutomationProperties.NameProperty);", functionalUi);
+        Assert.Contains("control.ClearValue(AutomationProperties.LiveSettingProperty);", functionalUi);
+    }
+
+    [Fact]
+    public void ApplyModifiers_ClearsStaleBorderTextAndControlValues()
+    {
+        var functionalUi = Read("src", "OpenClawTray.FunctionalUI", "FunctionalUI.cs");
+
+        Assert.Contains("b.ClearValue(Border.BackgroundProperty);", functionalUi);
+        Assert.Contains("b.ClearValue(Border.PaddingProperty);", functionalUi);
+        Assert.Contains("b.ClearValue(Border.CornerRadiusProperty);", functionalUi);
+        Assert.Contains("tb.ClearValue(TextBlock.ForegroundProperty);", functionalUi);
+        Assert.Contains("tb.ClearValue(TextBlock.TextTrimmingProperty);", functionalUi);
+        Assert.Contains("tb.ClearValue(TextBlock.MaxLinesProperty);", functionalUi);
+        Assert.Contains("tb.ClearValue(TextBlock.LineHeightProperty);", functionalUi);
+        Assert.Contains("tb.ClearValue(TextBlock.CharacterSpacingProperty);", functionalUi);
+        Assert.Contains("c.ClearValue(Control.PaddingProperty);", functionalUi);
+        Assert.Contains("c.ClearValue(Control.BorderBrushProperty);", functionalUi);
+    }
+
+    private static string Read(params string[] parts)
+        => File.ReadAllText(Path.Combine(new[] { TestRepositoryPaths.GetRepositoryRoot() }.Concat(parts).ToArray()));
+}


### PR DESCRIPTION
## Summary

- Qualifies live chat timeline row keys by thread, reset generation, row kind, and entry id so reset/reorder/synthetic-row transitions cannot reuse stale visual subtrees.
- Adds explicit non-colliding keys for the synthetic assistant thinking row.
- Clears absent FunctionalUI modifier dependency-property values with `ClearValue(...)` so reused `Border`, `TextBlock`, and `Control` instances do not retain stale bubble layout/styling.
- Adds Tray contract coverage for render identity, reset generation, thinking keys, and modifier cleanup.

Fixes #899.

## Validation

- `./build.ps1` - passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` - passed: 2686 passed, 31 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` - passed: 1455 passed
- `python ./.agents/skills/autoreview/scripts/autoreview --mode local --engine copilot` - clean: no accepted/actionable findings

Codex autoreview could not run because the `codex` executable was not installed in this environment; the same project autoreview helper was run with the Copilot engine instead.

## Real behavior proof

- Launched the current-head packaged worktree app with:
  - `winapp run ".\\src\\OpenClaw.Tray.WinUI\\bin\\Debug\\net10.0-windows10.0.22621.0\\win-arm64" --manifest ".\\src\\OpenClaw.Tray.WinUI\\Package.appxmanifest" --executable "OpenClaw.Tray.WinUI.exe" --debug-output`
- Opened chat with `openclaw://chat`.
- Sent proof prompt: `OpenClaw #899 render proof - please acknowledge briefly.`
- UIA proof found the full live user message text after send:
  - `lbl-openclaw899rend-26bd Text "OpenClaw #899 render proof - please acknowledge briefly."`
- Screenshot captured locally at current PR head: `C:\\Users\\t-edencaleb\\.copilot\\session-state\\059f92fb-1d9f-4e9c-ac3a-a6f28cb355bd\\files\\issue899-fix-chat-after-send.png`.

The original #899 symptom has not been reproduced deterministically. This PR is a best-effort fix for the observed live-render failure mode: correct message data/copy/reload behavior but stale/malformed WinUI visuals. The patch targets two plausible renderer causes found in the current code: weak live row identity during reset/synthetic-row transitions and stale dependency-property values on reused FunctionalUI controls.

Here is current-head proof of the reset path: after running `/new`, the next sent message renders as a full user bubble and the assistant transition renders without the stale gray/empty bubble artifact. This is not proof that the flaky #899 symptom is eliminated, because we have not found a deterministic repro. It is current-head smoke proof for the highest-risk path identified in the report: `/new` followed by a sent user message and assistant transition. The screenshot shows that this path still renders the full user bubble and does not show the stale gray/empty bubble artifact.

<img width="857" height="440" alt="image" src="https://github.com/user-attachments/assets/c529ede7-ac57-4873-aeb6-fb122aa67354" />


## Rubber-duck review

- Rubber-duck review with Claude Sonnet 5 found no blocking issues.
- Non-blocking feedback noted that source-text contracts are less strong than a behavioral render harness and that extra `/new` manual proof would be useful if a reliable repro path is available.