### PR TITLE
Fix reset session dialog localization

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1247,8 +1247,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             Title = title,
             Content = body,
             PrimaryButtonText = actionLabel,
-            CloseButtonText = LocalizationHelper.GetString("CancelButton.Content"),
-            DefaultButton = ContentDialogButton.Close,
+            CloseButtonText = LocalizationHelper.GetString("SessionActionPrompt_CancelLabel"),
+            DefaultButton = ContentDialogButton.None,
             XamlRoot = root.XamlRoot
         };
         var result = await dialog.ShowAsync();

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -735,8 +735,8 @@ public sealed partial class SessionsPage : Page
             Title = localizedPrompt.Title,
             Content = localizedPrompt.Body,
             PrimaryButtonText = localizedPrompt.ConfirmLabel,
-            CloseButtonText = LocalizationHelper.GetString("CancelButton.Content"),
-            DefaultButton = ContentDialogButton.Close,
+            CloseButtonText = LocalizationHelper.GetString("SessionActionPrompt_CancelLabel"),
+            DefaultButton = ContentDialogButton.None,
             XamlRoot = XamlRoot,
         };
         if (localizedPrompt.IsDestructive)

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -4816,6 +4816,9 @@ Commands are blocked while sandboxing is unavailable because strict fallback blo
   <data name="SessionActionPrompt_Reset_ConfirmLabel" xml:space="preserve">
     <value>Reset</value>
   </data>
+  <data name="SessionActionPrompt_CancelLabel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
   <data name="SessionActionPrompt_Compact_Title" xml:space="preserve">
     <value>Compact session log?</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -4768,6 +4768,9 @@ Les commandes sont bloquées tant que le sandboxing est indisponible, car le blo
   <data name="SessionActionPrompt_Reset_ConfirmLabel" xml:space="preserve">
     <value>Réinitialiser</value>
   </data>
+  <data name="SessionActionPrompt_CancelLabel" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
   <data name="SessionActionPrompt_Compact_Title" xml:space="preserve">
     <value>Compacter le journal de session ?</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -4769,6 +4769,9 @@ Opdrachten worden geblokkeerd zolang sandboxing niet beschikbaar is, omdat strik
   <data name="SessionActionPrompt_Reset_ConfirmLabel" xml:space="preserve">
     <value>Resetten</value>
   </data>
+  <data name="SessionActionPrompt_CancelLabel" xml:space="preserve">
+    <value>Annuleren</value>
+  </data>
   <data name="SessionActionPrompt_Compact_Title" xml:space="preserve">
     <value>Sessielog compact maken?</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -4768,6 +4768,9 @@
   <data name="SessionActionPrompt_Reset_ConfirmLabel" xml:space="preserve">
     <value>重置</value>
   </data>
+  <data name="SessionActionPrompt_CancelLabel" xml:space="preserve">
+    <value>取消</value>
+  </data>
   <data name="SessionActionPrompt_Compact_Title" xml:space="preserve">
     <value>压缩会话日志？</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -4768,6 +4768,9 @@
   <data name="SessionActionPrompt_Reset_ConfirmLabel" xml:space="preserve">
     <value>重設</value>
   </data>
+  <data name="SessionActionPrompt_CancelLabel" xml:space="preserve">
+    <value>取消</value>
+  </data>
   <data name="SessionActionPrompt_Compact_Title" xml:space="preserve">
     <value>壓縮工作階段記錄？</value>
   </data>

--- a/tests/OpenClaw.Tray.Tests/SessionActionsWiringTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SessionActionsWiringTests.cs
@@ -24,6 +24,11 @@ public sealed class SessionActionsWiringTests
         Assert.Contains("RunSessionActionAsync(sender, SessionActionKind.Reset)", source);
         Assert.Contains("RunSessionActionAsync(sender, SessionActionKind.Compact)", source);
         Assert.Contains("RunSessionActionAsync(sender, SessionActionKind.Delete)", source);
+        // Runtime dialogs must not use XAML property resource keys; those can
+        // fall back to raw key text such as "CancelButton.Content".
+        Assert.Contains("SessionActionPrompt_CancelLabel", source);
+        Assert.DoesNotContain("LocalizationHelper.GetString(\"CancelButton.Content\")", source);
+        Assert.Contains("DefaultButton = ContentDialogButton.None", source);
     }
 
     [Fact]
@@ -78,6 +83,9 @@ public sealed class SessionActionsWiringTests
 
         Assert.Contains("SessionActionPlanner.BuildPrompt", source);
         Assert.Contains("SessionActionPlanner.IsAllowed", source);
+        Assert.Contains("SessionActionPrompt_CancelLabel", source);
+        Assert.DoesNotContain("LocalizationHelper.GetString(\"CancelButton.Content\")", source);
+        Assert.Contains("DefaultButton = ContentDialogButton.None", source);
         // The confirmation copy comes from the shared planner, not inline strings.
         Assert.DoesNotContain("Start a fresh session for '", source);
         Assert.DoesNotContain("Keep the latest log lines for '", source);
@@ -89,6 +97,7 @@ public sealed class SessionActionsWiringTests
         var source = ReadSource("src", "OpenClaw.Tray.WinUI", "Helpers", "SessionActionPromptLocalizer.cs");
         var requiredKeys = new[]
         {
+            "SessionActionPrompt_CancelLabel",
             "SessionActionPrompt_Reset_Title",
             "SessionActionPrompt_Reset_BodyFormat",
             "SessionActionPrompt_Reset_ConfirmLabel",


### PR DESCRIPTION
## Summary

- Problem: The Sessions reset confirmation rendered the cancel action as the raw resource key `CancelButton.Content`, and the dialog promoted Cancel with primary/default styling.
- Why it matters: Reset is destructive, so the confirmation needs clear localized choices and a visual hierarchy that emphasizes the destructive verb instead of Cancel.
- What changed: Session confirmations now use a runtime-scoped `SessionActionPrompt_CancelLabel` resource in every locale and use `ContentDialogButton.None` so Cancel is neutral.
- User impact: The reset dialog now shows `Reset` and localized `Cancel`, with Reset as the emphasized action.
- What did NOT change (scope boundary): No gateway, session mutation, or MCP behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs / instructions
- [x] Tests / validation
- [ ] Security hardening
- [ ] Chore / infra

## Scope (select all touched areas)

- [x] Tray / WinUI UX
- [ ] Windows node capability
- [ ] Local MCP / `winnode`
- [ ] Gateway / connection / pairing
- [ ] Setup / onboarding
- [ ] Permissions / privacy / security
- [x] Tests / CI / docs

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] Related to a bug or regression

## Validation

- `./build.ps1` - passed; Shared, Cli, WinNodeCli, SetupEngine, and WinUI all built successfully.
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` - passed: 2689 passed, 31 skipped, 2720 total.
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` - passed: 1452 passed, 0 skipped, 1452 total.

## Real behavior proof

- Environment tested: Windows ARM64 packaged WinUI app launched with `winapp run ".\src\OpenClaw.Tray.WinUI\bin\Debug\net10.0-windows10.0.22621.0\win-arm64" --manifest ".\src\OpenClaw.Tray.WinUI\Package.appxmanifest" --executable "OpenClaw.Tray.WinUI.exe" --debug-output`.
- PR head / commit tested: `92f750a1`.
- Exact steps or command run: Opened `openclaw://activity?filter=session`, invoked Sessions > More actions > Reset, then inspected the live ContentDialog with `winapp ui`.
- Evidence after fix:

```text
winapp ui search Cancel -w 2561132 --max 20
  CloseButton Button "Cancel" (1926,1146 349x48)
Found 1 matches

winapp ui search CancelButton.Content -w 2561132 --max 20
Found 0 matches

winapp ui inspect -w 2561132 --interactive
Window > Pane > Pane > Window
        PrimaryButton Button "Reset" (1564,1146 350x48)
        CloseButton Button "Cancel" (1926,1146 349x48)
```

- Observed result: The reset confirmation shows localized `Cancel` instead of `CancelButton.Content`; Reset remains the primary action while Cancel is not the default button.
- Screenshot/artifact links verified? N/A - GitHub user-attachment upload returned `Not Found`, so copied UIA proof is included instead.
- Not verified / blocked: Screenshot upload was blocked by the GitHub uploads API response above; live UIA proof was collected from the packaged app.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only conversations that still need reviewer or maintainer judgment.

N/A - no bot review conversations were addressed by this PR.

## Screenshots

Before:
<img width="404" height="163" alt="Screenshot 2026-07-01 163457" src="https://github.com/user-attachments/assets/106c44f1-5f2a-4876-9b67-e1d7964ab1a9" />
After:
<img width="391" height="152" alt="image" src="https://github.com/user-attachments/assets/66256f31-0aa3-4724-88bd-50330af1a430" />

