### PR TITLE
fix: resolve WCAG accessibility violations across all app pages

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -1739,6 +1739,8 @@ public sealed partial class ConnectionPage : Page
             VerticalAlignment = VerticalAlignment.Center,
             Tag = row.Id,
         };
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(overflowBtn,
+            string.Format(LocalizationHelper.GetString("ConnectionPage_GatewayOptionsA11y"), row.DisplayName));
         overflowBtn.Content = new FontIcon
         {
             Glyph = Helpers.FluentIconCatalog.MoreOverflow,
@@ -1789,6 +1791,7 @@ public sealed partial class ConnectionPage : Page
         grid.Children.Add(overflowBtn);
 
         card.Child = grid;
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(card, row.DisplayName);
         return card;
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml
@@ -349,8 +349,8 @@
                         <TextBox Grid.Column="0" x:Uid="NewRulePattern" x:Name="NewRulePattern"
                                  PlaceholderText="Command pattern (e.g. echo *)"
                                  FontFamily="Consolas"/>
-                        <ComboBox Grid.Column="1" x:Name="NewRuleAction" MinWidth="100" SelectedIndex="0"
-                                  AutomationProperties.Name="Rule action">
+                        <ComboBox Grid.Column="1" x:Uid="PermissionsPage_NewRuleAction" x:Name="NewRuleAction"
+                                  MinWidth="100" SelectedIndex="0">
                            <ComboBoxItem x:Uid="PermissionsPage_ComboBoxItem_54" Content="Deny" Tag="deny"/>
                            <ComboBoxItem x:Uid="PermissionsPage_ComboBoxItem_55" Content="Allow" Tag="allow"/>
                            <ComboBoxItem x:Uid="PermissionsPage_ComboBoxItem_56" Content="Ask" Tag="prompt"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml
@@ -349,7 +349,8 @@
                         <TextBox Grid.Column="0" x:Uid="NewRulePattern" x:Name="NewRulePattern"
                                  PlaceholderText="Command pattern (e.g. echo *)"
                                  FontFamily="Consolas"/>
-                        <ComboBox Grid.Column="1" x:Name="NewRuleAction" MinWidth="100" SelectedIndex="0">
+                        <ComboBox Grid.Column="1" x:Name="NewRuleAction" MinWidth="100" SelectedIndex="0"
+                                  AutomationProperties.Name="Rule action">
                            <ComboBoxItem x:Uid="PermissionsPage_ComboBoxItem_54" Content="Deny" Tag="deny"/>
                            <ComboBoxItem x:Uid="PermissionsPage_ComboBoxItem_55" Content="Allow" Tag="allow"/>
                            <ComboBoxItem x:Uid="PermissionsPage_ComboBoxItem_56" Content="Ask" Tag="prompt"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml
@@ -125,8 +125,8 @@
                     <StackPanel Spacing="8" Margin="0,4,0,12">
                         <TextBlock x:Name="UnavailableActionMessage" TextWrapping="Wrap" />
                         <StackPanel Orientation="Horizontal" Spacing="8">
-                            <Button x:Name="UnavailablePrimaryButton" Click="OnUnavailableActionClick" Style="{ThemeResource AccentButtonStyle}"
-                                    AutomationProperties.Name="Sandbox action" />
+                            <Button x:Uid="SandboxPage_UnavailablePrimaryButton" x:Name="UnavailablePrimaryButton"
+                                    Click="OnUnavailableActionClick" Style="{ThemeResource AccentButtonStyle}" />
                             <HyperlinkButton x:Uid="SandboxPage_LearnMoreAboutMXC" Content="Learn more about MXC sandboxing"
                                              NavigateUri="https://github.com/microsoft/mxc" />
                         </StackPanel>
@@ -155,7 +155,7 @@
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
 
-                        <Button x:Name="PresetLockedButton"
+                        <Button x:Uid="SandboxPage_PresetLockedButton" x:Name="PresetLockedButton"
                                 Grid.Column="0"
                                 HorizontalAlignment="Stretch"
                                 HorizontalContentAlignment="Stretch"
@@ -164,8 +164,7 @@
                                 Padding="20,18"
                                 MinHeight="130"
                                 CornerRadius="8"
-                                Click="OnPresetLockedClick"
-                                AutomationProperties.Name="Locked Down preset: No internet, no clipboard, no standard user folders">
+                                Click="OnPresetLockedClick">
                             <StackPanel Spacing="8">
                                 <TextBlock x:Uid="SandboxPage_LockedDown" Text="🔒 Locked Down"
                                            FontSize="18"
@@ -177,7 +176,7 @@
                             </StackPanel>
                         </Button>
 
-                        <Button x:Name="PresetBalancedButton"
+                        <Button x:Uid="SandboxPage_PresetBalancedButton" x:Name="PresetBalancedButton"
                                 Grid.Column="1"
                                 HorizontalAlignment="Stretch"
                                 HorizontalContentAlignment="Stretch"
@@ -186,8 +185,7 @@
                                 Padding="20,18"
                                 MinHeight="130"
                                 CornerRadius="8"
-                                Click="OnPresetBalancedClick"
-                                AutomationProperties.Name="Recommended preset: Internet on, read-only on Documents, Downloads, Desktop">
+                                Click="OnPresetBalancedClick">
                             <StackPanel Spacing="8">
                                 <TextBlock x:Uid="SandboxPage_Recommended" Text="🛡 Recommended"
                                            FontSize="18"
@@ -199,7 +197,7 @@
                             </StackPanel>
                         </Button>
 
-                        <Button x:Name="PresetPermissiveButton"
+                        <Button x:Uid="SandboxPage_PresetPermissiveButton" x:Name="PresetPermissiveButton"
                                 Grid.Column="2"
                                 HorizontalAlignment="Stretch"
                                 HorizontalContentAlignment="Stretch"
@@ -208,8 +206,7 @@
                                 Padding="20,18"
                                 MinHeight="130"
                                 CornerRadius="8"
-                                Click="OnPresetPermissiveClick"
-                                AutomationProperties.Name="Unprotected preset: Internet on, read and write on Documents, Downloads, Desktop">
+                                Click="OnPresetPermissiveClick">
                             <StackPanel Spacing="8">
                                 <TextBlock x:Uid="SandboxPage_Unprotected" Text="⚠ Unprotected"
                                            FontSize="18"
@@ -257,9 +254,8 @@
                             </Grid.RowDefinitions>
 
                             <TextBlock x:Uid="SandboxPage_Documents" Grid.Row="0" Grid.Column="0" Text="Documents" VerticalAlignment="Center"/>
-                            <ComboBox x:Name="DocsAccessCombo" Grid.Row="0" Grid.Column="1"
+                            <ComboBox x:Uid="SandboxPage_DocsAccessCombo" x:Name="DocsAccessCombo" Grid.Row="0" Grid.Column="1"
                                       HorizontalAlignment="Stretch"
-                                      AutomationProperties.Name="Documents access level"
                                       SelectionChanged="OnDocsAccessChanged">
                                 <ComboBoxItem x:Uid="SandboxPage_Blocked" Content="Blocked" Tag="None" />
                                 <ComboBoxItem x:Uid="SandboxPage_ReadOnly" Content="Read only" Tag="ReadOnly" />
@@ -267,9 +263,8 @@
                             </ComboBox>
 
                             <TextBlock x:Uid="SandboxPage_Downloads" Grid.Row="1" Grid.Column="0" Text="Downloads" VerticalAlignment="Center"/>
-                            <ComboBox x:Name="DownloadsAccessCombo" Grid.Row="1" Grid.Column="1"
+                            <ComboBox x:Uid="SandboxPage_DownloadsAccessCombo" x:Name="DownloadsAccessCombo" Grid.Row="1" Grid.Column="1"
                                       HorizontalAlignment="Stretch"
-                                      AutomationProperties.Name="Downloads access level"
                                       SelectionChanged="OnDownloadsAccessChanged">
                                 <ComboBoxItem x:Uid="SandboxPage_Blocked2" Content="Blocked" Tag="None" />
                                 <ComboBoxItem x:Uid="SandboxPage_ReadOnly2" Content="Read only" Tag="ReadOnly" />
@@ -277,9 +272,8 @@
                             </ComboBox>
 
                             <TextBlock x:Uid="SandboxPage_Desktop" Grid.Row="2" Grid.Column="0" Text="Desktop" VerticalAlignment="Center"/>
-                            <ComboBox x:Name="DesktopAccessCombo" Grid.Row="2" Grid.Column="1"
+                            <ComboBox x:Uid="SandboxPage_DesktopAccessCombo" x:Name="DesktopAccessCombo" Grid.Row="2" Grid.Column="1"
                                       HorizontalAlignment="Stretch"
-                                      AutomationProperties.Name="Desktop access level"
                                       SelectionChanged="OnDesktopAccessChanged">
                                 <ComboBoxItem x:Uid="SandboxPage_Blocked3" Content="Blocked" Tag="None" />
                                 <ComboBoxItem x:Uid="SandboxPage_ReadOnly3" Content="Read only" Tag="ReadOnly" />

--- a/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml
@@ -125,7 +125,8 @@
                     <StackPanel Spacing="8" Margin="0,4,0,12">
                         <TextBlock x:Name="UnavailableActionMessage" TextWrapping="Wrap" />
                         <StackPanel Orientation="Horizontal" Spacing="8">
-                            <Button x:Name="UnavailablePrimaryButton" Click="OnUnavailableActionClick" Style="{ThemeResource AccentButtonStyle}" />
+                            <Button x:Name="UnavailablePrimaryButton" Click="OnUnavailableActionClick" Style="{ThemeResource AccentButtonStyle}"
+                                    AutomationProperties.Name="Sandbox action" />
                             <HyperlinkButton x:Uid="SandboxPage_LearnMoreAboutMXC" Content="Learn more about MXC sandboxing"
                                              NavigateUri="https://github.com/microsoft/mxc" />
                         </StackPanel>
@@ -163,7 +164,8 @@
                                 Padding="20,18"
                                 MinHeight="130"
                                 CornerRadius="8"
-                                Click="OnPresetLockedClick">
+                                Click="OnPresetLockedClick"
+                                AutomationProperties.Name="Locked Down preset: No internet, no clipboard, no standard user folders">
                             <StackPanel Spacing="8">
                                 <TextBlock x:Uid="SandboxPage_LockedDown" Text="🔒 Locked Down"
                                            FontSize="18"
@@ -184,7 +186,8 @@
                                 Padding="20,18"
                                 MinHeight="130"
                                 CornerRadius="8"
-                                Click="OnPresetBalancedClick">
+                                Click="OnPresetBalancedClick"
+                                AutomationProperties.Name="Recommended preset: Internet on, read-only on Documents, Downloads, Desktop">
                             <StackPanel Spacing="8">
                                 <TextBlock x:Uid="SandboxPage_Recommended" Text="🛡 Recommended"
                                            FontSize="18"
@@ -205,7 +208,8 @@
                                 Padding="20,18"
                                 MinHeight="130"
                                 CornerRadius="8"
-                                Click="OnPresetPermissiveClick">
+                                Click="OnPresetPermissiveClick"
+                                AutomationProperties.Name="Unprotected preset: Internet on, read and write on Documents, Downloads, Desktop">
                             <StackPanel Spacing="8">
                                 <TextBlock x:Uid="SandboxPage_Unprotected" Text="⚠ Unprotected"
                                            FontSize="18"
@@ -255,6 +259,7 @@
                             <TextBlock x:Uid="SandboxPage_Documents" Grid.Row="0" Grid.Column="0" Text="Documents" VerticalAlignment="Center"/>
                             <ComboBox x:Name="DocsAccessCombo" Grid.Row="0" Grid.Column="1"
                                       HorizontalAlignment="Stretch"
+                                      AutomationProperties.Name="Documents access level"
                                       SelectionChanged="OnDocsAccessChanged">
                                 <ComboBoxItem x:Uid="SandboxPage_Blocked" Content="Blocked" Tag="None" />
                                 <ComboBoxItem x:Uid="SandboxPage_ReadOnly" Content="Read only" Tag="ReadOnly" />
@@ -264,6 +269,7 @@
                             <TextBlock x:Uid="SandboxPage_Downloads" Grid.Row="1" Grid.Column="0" Text="Downloads" VerticalAlignment="Center"/>
                             <ComboBox x:Name="DownloadsAccessCombo" Grid.Row="1" Grid.Column="1"
                                       HorizontalAlignment="Stretch"
+                                      AutomationProperties.Name="Downloads access level"
                                       SelectionChanged="OnDownloadsAccessChanged">
                                 <ComboBoxItem x:Uid="SandboxPage_Blocked2" Content="Blocked" Tag="None" />
                                 <ComboBoxItem x:Uid="SandboxPage_ReadOnly2" Content="Read only" Tag="ReadOnly" />
@@ -273,6 +279,7 @@
                             <TextBlock x:Uid="SandboxPage_Desktop" Grid.Row="2" Grid.Column="0" Text="Desktop" VerticalAlignment="Center"/>
                             <ComboBox x:Name="DesktopAccessCombo" Grid.Row="2" Grid.Column="1"
                                       HorizontalAlignment="Stretch"
+                                      AutomationProperties.Name="Desktop access level"
                                       SelectionChanged="OnDesktopAccessChanged">
                                 <ComboBoxItem x:Uid="SandboxPage_Blocked3" Content="Blocked" Tag="None" />
                                 <ComboBoxItem x:Uid="SandboxPage_ReadOnly3" Content="Read only" Tag="ReadOnly" />

--- a/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml
@@ -168,9 +168,9 @@
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                        TextWrapping="Wrap"/>
                         </StackPanel>
-                        <ComboBox Grid.Column="1" x:Name="NotificationSoundComboBox" MinWidth="140"
-                                  AutomationProperties.AutomationId="SettingsPageSound"
-                                  AutomationProperties.Name="Notification sound">
+                        <ComboBox Grid.Column="1" x:Uid="SettingsPage_NotificationSoundComboBox"
+                                  x:Name="NotificationSoundComboBox" MinWidth="140"
+                                  AutomationProperties.AutomationId="SettingsPageSound">
                             <ComboBoxItem x:Uid="SettingsPage_ComboBoxItem_48" Content="Default" Tag="Default"/>
                             <ComboBoxItem x:Uid="SettingsPage_ComboBoxItem_49" Content="None" Tag="None"/>
                             <ComboBoxItem x:Uid="SettingsPage_ComboBoxItem_50" Content="Subtle" Tag="Subtle"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml
@@ -169,7 +169,8 @@
                                        TextWrapping="Wrap"/>
                         </StackPanel>
                         <ComboBox Grid.Column="1" x:Name="NotificationSoundComboBox" MinWidth="140"
-                                  AutomationProperties.AutomationId="SettingsPageSound">
+                                  AutomationProperties.AutomationId="SettingsPageSound"
+                                  AutomationProperties.Name="Notification sound">
                             <ComboBoxItem x:Uid="SettingsPage_ComboBoxItem_48" Content="Default" Tag="Default"/>
                             <ComboBoxItem x:Uid="SettingsPage_ComboBoxItem_49" Content="None" Tag="None"/>
                             <ComboBoxItem x:Uid="SettingsPage_ComboBoxItem_50" Content="Subtle" Tag="Subtle"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
@@ -37,20 +37,18 @@
                         <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Top">
                             <Button x:Uid="VoiceSettingsPage_AssistantRefreshButton"
                                     x:Name="AssistantRefreshButton" Click="OnAssistantRefreshClick" Padding="10,8"
-                                    ToolTipService.ToolTip="Refresh assistant status"
-                                    AutomationProperties.Name="Refresh voice assistant status">
+                                    ToolTipService.ToolTip="Refresh assistant status">
                                 <FontIcon Glyph="&#xE72C;" FontSize="14"/>
                             </Button>
-                            <Button x:Name="AssistantStartButton" Click="OnAssistantStartClick"
-                                    Style="{StaticResource AccentButtonStyle}"
-                                    AutomationProperties.Name="Start voice assistant">
+                            <Button x:Uid="VoiceSettingsPage_AssistantStartButton" x:Name="AssistantStartButton"
+                                    Click="OnAssistantStartClick" Style="{StaticResource AccentButtonStyle}">
                                 <StackPanel Orientation="Horizontal" Spacing="6">
                                     <FontIcon Glyph="&#xE768;" FontSize="14"/>
                                     <TextBlock x:Uid="VoiceSettingsPage_AssistantStartButtonText" Text="Start"/>
                                 </StackPanel>
                             </Button>
-                            <Button x:Name="AssistantStopButton" Click="OnAssistantStopClick"
-                                    AutomationProperties.Name="Stop voice assistant">
+                            <Button x:Uid="VoiceSettingsPage_AssistantStopButton" x:Name="AssistantStopButton"
+                                    Click="OnAssistantStopClick">
                                 <StackPanel Orientation="Horizontal" Spacing="6">
                                     <FontIcon Glyph="&#xE71A;" FontSize="14"/>
                                     <TextBlock x:Uid="VoiceSettingsPage_AssistantStopButtonText" Text="Stop"/>
@@ -195,8 +193,7 @@
                     BorderThickness="1" CornerRadius="8" Padding="16">
                 <StackPanel Spacing="8">
                     <TextBlock x:Uid="VoiceSettingsPage_LanguageHeader" x:Name="LanguageHeaderText" Text="Language" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                    <ComboBox x:Name="LanguageCombo"
-                              AutomationProperties.Name="Voice language"
+                    <ComboBox x:Uid="VoiceSettingsPage_LanguageCombo" x:Name="LanguageCombo"
                               SelectionChanged="OnLanguageChanged" Width="200">
                         <ComboBoxItem x:Uid="VoiceSettingsPage_LangAuto" Content="Auto-detect" Tag="auto"/>
                         <ComboBoxItem x:Uid="VoiceSettingsPage_LangEn"   Content="English"     Tag="en"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
@@ -37,17 +37,20 @@
                         <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Top">
                             <Button x:Uid="VoiceSettingsPage_AssistantRefreshButton"
                                     x:Name="AssistantRefreshButton" Click="OnAssistantRefreshClick" Padding="10,8"
-                                    ToolTipService.ToolTip="Refresh assistant status">
+                                    ToolTipService.ToolTip="Refresh assistant status"
+                                    AutomationProperties.Name="Refresh voice assistant status">
                                 <FontIcon Glyph="&#xE72C;" FontSize="14"/>
                             </Button>
                             <Button x:Name="AssistantStartButton" Click="OnAssistantStartClick"
-                                    Style="{StaticResource AccentButtonStyle}">
+                                    Style="{StaticResource AccentButtonStyle}"
+                                    AutomationProperties.Name="Start voice assistant">
                                 <StackPanel Orientation="Horizontal" Spacing="6">
                                     <FontIcon Glyph="&#xE768;" FontSize="14"/>
                                     <TextBlock x:Uid="VoiceSettingsPage_AssistantStartButtonText" Text="Start"/>
                                 </StackPanel>
                             </Button>
-                            <Button x:Name="AssistantStopButton" Click="OnAssistantStopClick">
+                            <Button x:Name="AssistantStopButton" Click="OnAssistantStopClick"
+                                    AutomationProperties.Name="Stop voice assistant">
                                 <StackPanel Orientation="Horizontal" Spacing="6">
                                     <FontIcon Glyph="&#xE71A;" FontSize="14"/>
                                     <TextBlock x:Uid="VoiceSettingsPage_AssistantStopButtonText" Text="Stop"/>
@@ -193,6 +196,7 @@
                 <StackPanel Spacing="8">
                     <TextBlock x:Uid="VoiceSettingsPage_LanguageHeader" x:Name="LanguageHeaderText" Text="Language" Style="{StaticResource BodyStrongTextBlockStyle}"/>
                     <ComboBox x:Name="LanguageCombo"
+                              AutomationProperties.Name="Voice language"
                               SelectionChanged="OnLanguageChanged" Width="200">
                         <ComboBoxItem x:Uid="VoiceSettingsPage_LangAuto" Content="Auto-detect" Tag="auto"/>
                         <ComboBoxItem x:Uid="VoiceSettingsPage_LangEn"   Content="English"     Tag="en"/>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -6765,4 +6765,46 @@ Make sure the gateway is running.</value>
   <data name="SettingsPage_GatewayInfoLabel_Uptime.Text" xml:space="preserve">
     <value>Uptime</value>
   </data>
+  <data name="PermissionsPage_NewRuleAction.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Rule action</value>
+  </data>
+  <data name="SandboxPage_UnavailablePrimaryButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Sandbox action</value>
+  </data>
+  <data name="SandboxPage_PresetLockedButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Locked Down preset: No internet, no clipboard, no standard user folders</value>
+  </data>
+  <data name="SandboxPage_PresetBalancedButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Recommended preset: Internet on, read-only on Documents, Downloads, Desktop</value>
+  </data>
+  <data name="SandboxPage_PresetPermissiveButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Unprotected preset: Internet on, read and write on Documents, Downloads, Desktop</value>
+  </data>
+  <data name="SandboxPage_DocsAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Documents access level</value>
+  </data>
+  <data name="SandboxPage_DownloadsAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Downloads access level</value>
+  </data>
+  <data name="SandboxPage_DesktopAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Desktop access level</value>
+  </data>
+  <data name="SettingsPage_NotificationSoundComboBox.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Notification sound</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantRefreshButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Refresh voice assistant status</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Start voice assistant</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Stop voice assistant</value>
+  </data>
+  <data name="VoiceSettingsPage_LanguageCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Voice language</value>
+  </data>
+  <data name="HubWindow_MainNavigation.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Main navigation</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -5307,6 +5307,9 @@ Make sure the gateway is running.</value>
   <data name="ConnectionPage_OpenDashboard" xml:space="preserve">
     <value>Open dashboard</value>
   </data>
+  <data name="ConnectionPage_GatewayOptionsA11y" xml:space="preserve">
+    <value>Options for {0}</value>
+  </data>
   <data name="ConnectionPage_DisconnectAction" xml:space="preserve">
     <value>Disconnect</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -6725,4 +6725,46 @@ Le binaire wxc-exec est introuvable. {1} S'il s'agit d'une build développeur, c
   <data name="SettingsPage_GatewayInfoLabel_Uptime.Text" xml:space="preserve">
     <value>Uptime</value>
   </data>
+  <data name="PermissionsPage_NewRuleAction.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Action de la règle</value>
+  </data>
+  <data name="SandboxPage_UnavailablePrimaryButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Action du bac à sable</value>
+  </data>
+  <data name="SandboxPage_PresetLockedButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Préréglage verrouillé : aucun accès Internet, aucun presse-papiers, aucun dossier utilisateur standard</value>
+  </data>
+  <data name="SandboxPage_PresetBalancedButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Préréglage recommandé : accès Internet activé, lecture seule pour Documents, Téléchargements et Bureau</value>
+  </data>
+  <data name="SandboxPage_PresetPermissiveButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Préréglage non protégé : accès Internet activé, lecture et écriture pour Documents, Téléchargements et Bureau</value>
+  </data>
+  <data name="SandboxPage_DocsAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Niveau d’accès aux Documents</value>
+  </data>
+  <data name="SandboxPage_DownloadsAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Niveau d’accès aux Téléchargements</value>
+  </data>
+  <data name="SandboxPage_DesktopAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Niveau d’accès au Bureau</value>
+  </data>
+  <data name="SettingsPage_NotificationSoundComboBox.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Son de notification</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantRefreshButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Actualiser l’état de l’assistant vocal</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Démarrer l’assistant vocal</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Arrêter l’assistant vocal</value>
+  </data>
+  <data name="VoiceSettingsPage_LanguageCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Langue vocale</value>
+  </data>
+  <data name="HubWindow_MainNavigation.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Navigation principale</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -5303,6 +5303,9 @@ Assurez-vous que la passerelle est en cours d'exécution.</value>
   <data name="ConnectionPage_OpenDashboard" xml:space="preserve">
     <value>Ouvrir le tableau de bord</value>
   </data>
+  <data name="ConnectionPage_GatewayOptionsA11y" xml:space="preserve">
+    <value>Options pour {0}</value>
+  </data>
   <data name="ConnectionPage_DisconnectAction" xml:space="preserve">
     <value>Déconnecter</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -6726,4 +6726,46 @@ Het binaire bestand wxc-exec is niet gevonden. {1} Als dit een ontwikkelaarsbuil
   <data name="SettingsPage_GatewayInfoLabel_Uptime.Text" xml:space="preserve">
     <value>Uptime</value>
   </data>
+  <data name="PermissionsPage_NewRuleAction.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Regelactie</value>
+  </data>
+  <data name="SandboxPage_UnavailablePrimaryButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Sandboxactie</value>
+  </data>
+  <data name="SandboxPage_PresetLockedButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Vergrendelde voorinstelling: Geen internet, geen klembord, geen standaardgebruikersmappen</value>
+  </data>
+  <data name="SandboxPage_PresetBalancedButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Aanbevolen voorinstelling: Internet aan, alleen-lezen voor Documenten, Downloads en Bureaublad</value>
+  </data>
+  <data name="SandboxPage_PresetPermissiveButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Onbeveiligde voorinstelling: Internet aan, lezen en schrijven voor Documenten, Downloads en Bureaublad</value>
+  </data>
+  <data name="SandboxPage_DocsAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Toegangsniveau voor Documenten</value>
+  </data>
+  <data name="SandboxPage_DownloadsAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Toegangsniveau voor Downloads</value>
+  </data>
+  <data name="SandboxPage_DesktopAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Toegangsniveau voor Bureaublad</value>
+  </data>
+  <data name="SettingsPage_NotificationSoundComboBox.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Meldingsgeluid</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantRefreshButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Status van spraakassistent vernieuwen</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Spraakassistent starten</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Spraakassistent stoppen</value>
+  </data>
+  <data name="VoiceSettingsPage_LanguageCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Spraaktaal</value>
+  </data>
+  <data name="HubWindow_MainNavigation.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Hoofdnavigatie</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -5304,6 +5304,9 @@ Controleer of de gateway actief is.</value>
   <data name="ConnectionPage_OpenDashboard" xml:space="preserve">
     <value>Dashboard openen</value>
   </data>
+  <data name="ConnectionPage_GatewayOptionsA11y" xml:space="preserve">
+    <value>Opties voor {0}</value>
+  </data>
   <data name="ConnectionPage_DisconnectAction" xml:space="preserve">
     <value>Verbinding verbreken</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -6725,4 +6725,46 @@
   <data name="SettingsPage_GatewayInfoLabel_Uptime.Text" xml:space="preserve">
     <value>Uptime</value>
   </data>
+  <data name="PermissionsPage_NewRuleAction.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>规则操作</value>
+  </data>
+  <data name="SandboxPage_UnavailablePrimaryButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>沙盒操作</value>
+  </data>
+  <data name="SandboxPage_PresetLockedButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>锁定预设：无互联网、无剪贴板、无标准用户文件夹</value>
+  </data>
+  <data name="SandboxPage_PresetBalancedButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>推荐预设：启用互联网，文档、下载和桌面为只读</value>
+  </data>
+  <data name="SandboxPage_PresetPermissiveButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>不受保护预设：启用互联网，可读写文档、下载和桌面</value>
+  </data>
+  <data name="SandboxPage_DocsAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>文档访问级别</value>
+  </data>
+  <data name="SandboxPage_DownloadsAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>下载访问级别</value>
+  </data>
+  <data name="SandboxPage_DesktopAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>桌面访问级别</value>
+  </data>
+  <data name="SettingsPage_NotificationSoundComboBox.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>通知声音</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantRefreshButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>刷新语音助手状态</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>启动语音助手</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>停止语音助手</value>
+  </data>
+  <data name="VoiceSettingsPage_LanguageCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>语音语言</value>
+  </data>
+  <data name="HubWindow_MainNavigation.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>主导航</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -5303,6 +5303,9 @@
   <data name="ConnectionPage_OpenDashboard" xml:space="preserve">
     <value>打开仪表板</value>
   </data>
+  <data name="ConnectionPage_GatewayOptionsA11y" xml:space="preserve">
+    <value>{0} 的选项</value>
+  </data>
   <data name="ConnectionPage_DisconnectAction" xml:space="preserve">
     <value>断开连接</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -6725,4 +6725,46 @@
   <data name="SettingsPage_GatewayInfoLabel_Uptime.Text" xml:space="preserve">
     <value>Uptime</value>
   </data>
+  <data name="PermissionsPage_NewRuleAction.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>規則動作</value>
+  </data>
+  <data name="SandboxPage_UnavailablePrimaryButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>沙箱動作</value>
+  </data>
+  <data name="SandboxPage_PresetLockedButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>鎖定預設：無網際網路、無剪貼簿、無標準使用者資料夾</value>
+  </data>
+  <data name="SandboxPage_PresetBalancedButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>建議預設：啟用網際網路，文件、下載和桌面為唯讀</value>
+  </data>
+  <data name="SandboxPage_PresetPermissiveButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>未受保護預設：啟用網際網路，可讀寫文件、下載和桌面</value>
+  </data>
+  <data name="SandboxPage_DocsAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>文件存取層級</value>
+  </data>
+  <data name="SandboxPage_DownloadsAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>下載存取層級</value>
+  </data>
+  <data name="SandboxPage_DesktopAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>桌面存取層級</value>
+  </data>
+  <data name="SettingsPage_NotificationSoundComboBox.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>通知音效</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantRefreshButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>重新整理語音助理狀態</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStartButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>啟動語音助理</value>
+  </data>
+  <data name="VoiceSettingsPage_AssistantStopButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>停止語音助理</value>
+  </data>
+  <data name="VoiceSettingsPage_LanguageCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>語音語言</value>
+  </data>
+  <data name="HubWindow_MainNavigation.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>主要導覽</value>
+  </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -5303,6 +5303,9 @@
   <data name="ConnectionPage_OpenDashboard" xml:space="preserve">
     <value>開啟儀表板</value>
   </data>
+  <data name="ConnectionPage_GatewayOptionsA11y" xml:space="preserve">
+    <value>{0} 的選項</value>
+  </data>
   <data name="ConnectionPage_DisconnectAction" xml:space="preserve">
     <value>中斷連線</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
@@ -367,8 +367,8 @@
             </Grid.Clip>
 
             <NavigationView
+                x:Uid="HubWindow_MainNavigation"
                 x:Name="NavView"
-                AutomationProperties.Name="Main navigation"
                 IsBackButtonVisible="Collapsed"
                 IsSettingsVisible="False"
                 IsPaneToggleButtonVisible="False"

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
@@ -368,6 +368,7 @@
 
             <NavigationView
                 x:Name="NavView"
+                AutomationProperties.Name="Main navigation"
                 IsBackButtonVisible="Collapsed"
                 IsSettingsVisible="False"
                 IsPaneToggleButtonVisible="False"
@@ -415,52 +416,52 @@
 
             <NavigationView.MenuItems>
                 <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_82" x:Name="NavChat" Tag="chat" Content="Chat">
-                    <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Chat_Icon}"/></NavigationViewItem.Icon>
+                    <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Chat_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                 </NavigationViewItem>
                 <NavigationViewItemSeparator/>
 
             <NavigationViewItemHeader x:Uid="HubWindow_NavigationViewItemHeader_87" x:Name="NavGatewayHeader" Content="Gateway"/>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_88" Tag="connection" Content="Connection">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Connection_Icon}"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Connection_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_91" x:Name="NavSessions" Tag="sessions" Content="Sessions">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Sessions_Icon}"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Sessions_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_97" x:Name="NavSkills" Tag="skills" Content="Skills">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Skills_Icon}"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Skills_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_109" x:Name="NavChannels" Tag="channels" Content="Channels">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Channels_Icon}"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Channels_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_112" x:Name="NavInstances" Tag="instances" Content="Instances">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Instances_Icon}"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Instances_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_124" x:Name="NavCron" Tag="cron" Content="Cron">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Cron_Icon}"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Cron_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <!-- Advanced — consolidates gateway-oriented pages -->
             <NavigationViewItem x:Uid="HubWindow_Advanced" x:Name="NavAdvanced" Content="Advanced" SelectsOnInvoked="False">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Advanced_Icon}"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Advanced_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                 <NavigationViewItem.MenuItems>
                     <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_94" Tag="agentevents" Content="Event Stream">
-                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource AgentEvents_Icon}"/></NavigationViewItem.Icon>
+                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource AgentEvents_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                     </NavigationViewItem>
                     <NavigationViewItem x:Uid="AgentsNavItem" x:Name="AgentsNavItem" Content="Agents" SelectsOnInvoked="False" IsExpanded="True">
-                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Agents_Icon}"/></NavigationViewItem.Icon>
+                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Agents_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                         <NavigationViewItem.MenuItems>
                             <NavigationViewItem x:Uid="DefaultAgentNavItem" x:Name="DefaultAgentNavItem" Content="main" Tag="agent:main">
-                                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Agents_Icon}"/></NavigationViewItem.Icon>
+                                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Agents_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                             </NavigationViewItem>
                         </NavigationViewItem.MenuItems>
                     </NavigationViewItem>
                     <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_115" Tag="bindings" Content="Bindings">
-                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Bindings_Icon}"/></NavigationViewItem.Icon>
+                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Bindings_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                     </NavigationViewItem>
                     <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_118" Tag="config" Content="Config">
-                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Config_Icon}"/></NavigationViewItem.Icon>
+                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Config_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                     </NavigationViewItem>
                     <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_121" Tag="usage" Content="Usage">
-                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Usage_Icon}"/></NavigationViewItem.Icon>
+                        <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Usage_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
                     </NavigationViewItem>
                 </NavigationViewItem.MenuItems>
             </NavigationViewItem>
@@ -468,25 +469,25 @@
 
             <NavigationViewItemHeader x:Uid="HubWindow_NavigationViewItemHeader_129" Content="This Computer"/>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_Voice" Tag="voice" Content="Voice &amp; Audio">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Voice_Icon}"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Voice_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_136" Tag="permissions" Content="Permissions">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Permissions_Icon}"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Permissions_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_Sandbox" Tag="sandbox" Content="Sandbox">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Sandbox_Icon}"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Sandbox_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_133" Tag="settings" Content="Settings">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Settings_Icon}"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Settings_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
         </NavigationView.MenuItems>
 
         <NavigationView.FooterMenuItems>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_Notifications" Tag="notifications" Content="Notifications">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Notifications_Icon}"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Notifications_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_145" x:Name="NavDiagnostics" Tag="debug" Content="Debug">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Debug_Icon}"/></NavigationViewItem.Icon>
+                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Debug_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>
             </NavigationView.FooterMenuItems>
 

--- a/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
@@ -358,6 +358,24 @@ public class LocalizationValidationTests
         "Onboarding_Ready_Node_Notify_Sub",
     ];
 
+    private static readonly string[] RequiredLocalizedAccessibilityKeys =
+    [
+        "PermissionsPage_NewRuleAction.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name",
+        "SandboxPage_UnavailablePrimaryButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name",
+        "SandboxPage_PresetLockedButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name",
+        "SandboxPage_PresetBalancedButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name",
+        "SandboxPage_PresetPermissiveButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name",
+        "SandboxPage_DocsAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name",
+        "SandboxPage_DownloadsAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name",
+        "SandboxPage_DesktopAccessCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name",
+        "SettingsPage_NotificationSoundComboBox.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name",
+        "VoiceSettingsPage_AssistantRefreshButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name",
+        "VoiceSettingsPage_AssistantStartButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name",
+        "VoiceSettingsPage_AssistantStopButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name",
+        "VoiceSettingsPage_LanguageCombo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name",
+        "HubWindow_MainNavigation.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name",
+    ];
+
     private static readonly IReadOnlyDictionary<char, byte> Windows1252Bytes = BuildWindows1252ByteMap();
 
     private static readonly IReadOnlyDictionary<char, byte> CodePage437Bytes = BuildCodePage437ByteMap();
@@ -647,6 +665,22 @@ public class LocalizationValidationTests
                 $"Locale '{locale}' is missing {missing.Count} key(s): {string.Join(", ", missing.Take(10))}");
             Assert.True(extra.Count == 0,
                 $"Locale '{locale}' has {extra.Count} unexpected key(s): {string.Join(", ", extra.Take(10))}");
+        }
+    }
+
+    [Fact]
+    public void AccessibilityNames_ExistInEveryLocale()
+    {
+        foreach (var localeDir in Directory.GetDirectories(GetStringsDirectory()).OrderBy(p => p, StringComparer.Ordinal))
+        {
+            var locale = Path.GetFileName(localeDir);
+            var resources = LoadResw(Path.Combine(localeDir, "Resources.resw"));
+            var missing = RequiredLocalizedAccessibilityKeys
+                .Where(key => !resources.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value))
+                .ToList();
+
+            Assert.True(missing.Count == 0,
+                $"Locale '{locale}' is missing localized accessibility names: {string.Join(", ", missing)}");
         }
     }
 


### PR DESCRIPTION
## Motivation

A programmatic UI Automation accessibility scan found missing names on interactive controls and duplicate announcements from decorative navigation icons. Screen reader users could not reliably identify several buttons and combo boxes or navigate the sidebar.

## Approach

- Give the Voice, Sandbox, Permissions, Settings, Connection, and main navigation controls useful accessible names.
- Back every new static accessible name with `x:Uid` resources in all five supported locales instead of hard-coded English.
- Keep dynamic gateway-card and overflow-button names tied to the gateway display name.
- Mark the navigation `ImageIcon` elements as decorative so assistive technology announces the navigation item once.
- Add regression coverage requiring every new accessibility resource to remain present and non-empty in every locale.

## Validation

- AutoReview: clean; patch correct (0.98 confidence).
- Windows 11 ARM64 VM: full Release build passed for Shared, CLI, WinNode CLI, SetupEngine, and WinUI.
- Windows 11 ARM64 VM: `LocalizationValidationTests` passed 15/15.
- Live Windows UI Automation verified `Main navigation`, `Notification sound`, all three Sandbox preset names and folder-access combo names, `Rule action`, the three voice-assistant actions, and `Voice language` on the rendered app.
- Exact head `dd5d5e6b72ce70e1f6ad3fff824efd9f9090ddbe`: [Build and Test](https://github.com/openclaw/openclaw-windows-node/actions/runs/28759839229).

## Notes

- Custom-title-bar focus behavior is owned by WinUI; standard Windows shortcuts remain available.
- Color contrast and transient dialogs/flyouts are outside this scan. PR #923 adds ongoing Axe.Windows coverage.
