### PR TITLE
feat: add Accessibility Insights CI tests using Axe.Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,13 +278,9 @@ jobs:
         --logger trx;LogFileName=OpenClaw.Tray.UITests.trx
         --filter Category!=Accessibility"
 
-    # Accessibility Insights CI pass: runs Axe.Windows scans against each app page.
-    # Uses continue-on-error so violations surface as a visible warning without
-    # blocking the build while the team remediates. Remove continue-on-error once
-    # all violations are resolved (see PR #921 for the initial fixes).
+    # Accessibility Insights CI pass: scans each page in the real app process.
     - name: Run Accessibility Tests (Axe.Windows)
       id: a11y
-      continue-on-error: true
       run: >
         dotnet test tests/OpenClaw.Tray.UITests
         --no-build
@@ -300,12 +296,10 @@ jobs:
       shell: pwsh
       run: |
         if ("${{ steps.a11y.outcome }}" -eq "failure") {
-          "### :warning: Accessibility violations detected" >> $env:GITHUB_STEP_SUMMARY
+          "### :x: Accessibility violations detected" >> $env:GITHUB_STEP_SUMMARY
           "" >> $env:GITHUB_STEP_SUMMARY
           "Axe.Windows scans found WCAG violations in one or more pages." >> $env:GITHUB_STEP_SUMMARY
           "See the `Accessibility.trx` artifact for details." >> $env:GITHUB_STEP_SUMMARY
-          "" >> $env:GITHUB_STEP_SUMMARY
-          "Fixes for known violations: [PR #921](https://github.com/${{ github.repository }}/pull/921)" >> $env:GITHUB_STEP_SUMMARY
         } else {
           "### :white_check_mark: Accessibility scans passed" >> $env:GITHUB_STEP_SUMMARY
           "" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,7 +275,42 @@ jobs:
         -r win-x64
         --verbosity normal
         --results-directory TestResults\TrayUI
-        --logger trx;LogFileName=OpenClaw.Tray.UITests.trx"
+        --logger trx;LogFileName=OpenClaw.Tray.UITests.trx
+        --filter Category!=Accessibility"
+
+    # Accessibility Insights CI pass: runs Axe.Windows scans against each app page.
+    # Uses continue-on-error so violations surface as a visible warning without
+    # blocking the build while the team remediates. Remove continue-on-error once
+    # all violations are resolved (see PR #921 for the initial fixes).
+    - name: Run Accessibility Tests (Axe.Windows)
+      id: a11y
+      continue-on-error: true
+      run: >
+        dotnet test tests/OpenClaw.Tray.UITests
+        --no-build
+        -c Debug
+        -r win-x64
+        --verbosity normal
+        --results-directory TestResults\Accessibility
+        --logger "trx;LogFileName=Accessibility.trx"
+        --filter Category=Accessibility
+
+    - name: Accessibility test summary
+      if: always() && steps.a11y.outcome != 'skipped'
+      shell: pwsh
+      run: |
+        if ("${{ steps.a11y.outcome }}" -eq "failure") {
+          "### :warning: Accessibility violations detected" >> $env:GITHUB_STEP_SUMMARY
+          "" >> $env:GITHUB_STEP_SUMMARY
+          "Axe.Windows scans found WCAG violations in one or more pages." >> $env:GITHUB_STEP_SUMMARY
+          "See the `Accessibility.trx` artifact for details." >> $env:GITHUB_STEP_SUMMARY
+          "" >> $env:GITHUB_STEP_SUMMARY
+          "Fixes for known violations: [PR #921](https://github.com/${{ github.repository }}/pull/921)" >> $env:GITHUB_STEP_SUMMARY
+        } else {
+          "### :white_check_mark: Accessibility scans passed" >> $env:GITHUB_STEP_SUMMARY
+          "" >> $env:GITHUB_STEP_SUMMARY
+          "All pages passed Axe.Windows accessibility validation." >> $env:GITHUB_STEP_SUMMARY
+        }
 
     - name: Upload Test Results
       if: always()

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -539,8 +539,9 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             useSshTunnel = _settings.UseSshTunnel
         });
 
-        // Register URI scheme on first run
-        DeepLinkHandler.RegisterUriScheme();
+        // Isolated test instances must not replace the user's installed protocol handler.
+        if (DataDirOverride is null)
+            DeepLinkHandler.RegisterUriScheme();
 
         // Anchor the WinUI runtime so transient windows (UpdateDialog,
         // setup wizard, etc.) don't terminate the process when closed.

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawComposer.cs
@@ -251,6 +251,9 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
                     HorizontalAlignment = HorizontalAlignment.Stretch,
                     VerticalAlignment = VerticalAlignment.Center,
                 };
+                Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(
+                    cb,
+                    LocalizationHelper.GetString("Chat_Composer_Accessibility_Session"));
 
                 ComboBoxItem? selectedItem = null;
                 foreach (var group in groups)
@@ -359,6 +362,9 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
                     HorizontalAlignment = HorizontalAlignment.Stretch,
                     VerticalAlignment = VerticalAlignment.Center,
                 };
+                Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(
+                    cb,
+                    LocalizationHelper.GetString("Chat_Composer_Accessibility_Model"));
 
                 ComboBoxItem? selectedItem = null;
                 for (int i = 0; i < modelEntries.Count; i++)
@@ -404,6 +410,9 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
         })
             .Set(cb =>
             {
+                Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(
+                    cb,
+                    LocalizationHelper.GetString("Chat_Composer_Accessibility_Reasoning"));
                 cb.MinWidth = 0;
                 cb.Width = double.NaN;
                 cb.Height = 28;
@@ -552,6 +561,9 @@ public sealed class OpenClawComposer : Component<OpenClawComposerProps>
             .Set(tb =>
             {
                 textBoxRef.Current = tb;
+                Microsoft.UI.Xaml.Automation.AutomationProperties.SetAutomationId(
+                    tb,
+                    "ChatComposerInput");
                 tb.PlaceholderText = recording
                     ? LocalizationHelper.GetString("Chat_Voice_ListeningPrompt")
                     : placeholder;

--- a/src/OpenClaw.Tray.WinUI/Pages/AgentEventsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/AgentEventsPage.xaml
@@ -16,7 +16,9 @@
 
         <StackPanel Grid.Row="0" Spacing="4" Margin="0,0,0,12">
             <StackPanel Orientation="Horizontal" Spacing="8">
-                <TextBlock x:Uid="AgentEventsPage_TextBlock_18" Text="Event Stream" Style="{StaticResource TitleTextBlockStyle}"/>
+                <TextBlock x:Uid="AgentEventsPage_TextBlock_18" Text="Event Stream"
+                           AutomationProperties.AutomationId="AgentEventsPageMarker"
+                           Style="{StaticResource TitleTextBlockStyle}"/>
                 <Border x:Name="LiveBadge" CornerRadius="4" Padding="6,2,8,3" VerticalAlignment="Center"
                         Background="#20FF4444">
                     <StackPanel Orientation="Horizontal" Spacing="4">
@@ -48,11 +50,12 @@
                       SelectionChanged="OnAgentFilterComboChanged">
                 <ComboBoxItem x:Uid="AgentEventsPage_ComboBoxItem_26" Content="All Agents" Tag="" IsSelected="True"/>
             </ComboBox>
-            <Button x:Name="ClearButton" Grid.Column="2" Click="OnClear">
+            <Button x:Name="ClearButton" Grid.Column="2" Click="OnClear"
+                    AutomationProperties.LabeledBy="{Binding ElementName=ClearButtonLabel}">
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Clear, Mode=OneTime}"
                               FontSize="14" IsTextScaleFactorEnabled="False"/>
-                    <TextBlock x:Uid="AgentEventsPage_ClearButton" Text="Clear"/>
+                    <TextBlock x:Uid="AgentEventsPage_ClearButton" x:Name="ClearButtonLabel" Text="Clear"/>
                 </StackPanel>
             </Button>
         </Grid>

--- a/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/BindingsPage.xaml
@@ -15,6 +15,7 @@
                 </Grid.ColumnDefinitions>
                 <StackPanel Spacing="2">
                     <TextBlock x:Uid="BindingsPage_TextBlock_16" Text="Bindings"
+                               AutomationProperties.AutomationId="BindingsPageMarker"
                                Style="{StaticResource TitleTextBlockStyle}"/>
                     <TextBlock x:Uid="BindingsPage_TextBlock_17" Text="Message routing rules"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"

--- a/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml
@@ -37,6 +37,7 @@
                     </Grid.ColumnDefinitions>
                     <StackPanel Spacing="4">
                         <TextBlock x:Uid="ChannelsPage_Title" Text="Channels"
+                                   AutomationProperties.AutomationId="ChannelsPageMarker"
                                    Style="{StaticResource TitleTextBlockStyle}"/>
                         <TextBlock x:Name="MetaText"
                                    Style="{StaticResource CaptionTextBlockStyle}"

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -27,6 +27,7 @@ public sealed partial class ChatPage : Page
     private HubWindow? _hub;
     private MountedFunctionalChat? _functionalHost;
     private IChatDataProvider? _mountedProvider;
+    private IChatDataProvider? _accessibilityTestProvider;
     private string? _mountedThreadId;
     private string? _chatUrl;
     private bool _webViewInitialized;
@@ -230,7 +231,7 @@ public sealed partial class ChatPage : Page
         DevToolsButton.Visibility = Visibility.Collapsed;
 
         var app = App.Current as App;
-        var provider = app?.ChatProvider;
+        var provider = ResolveChatProvider(app);
         Func<string, Task>? readAloud = app is null ? null : app.SpeakChatTextAsync;
 
         // Consume a pending session-key hand-off from SessionsPage or a
@@ -308,6 +309,116 @@ public sealed partial class ChatPage : Page
             {
                 _functionalHost?.TriggerVoiceRecording();
             });
+        }
+    }
+
+    private IChatDataProvider? ResolveChatProvider(App? app)
+    {
+        if (app?.ChatProvider is { } liveProvider)
+            return liveProvider;
+
+        // The accessibility suite launches an isolated app process without a
+        // gateway. Mount a deterministic provider only under its explicit
+        // test flag so Axe scans the real FunctionalUI timeline and composer,
+        // not merely the disconnected page shell.
+        if (Environment.GetEnvironmentVariable("OPENCLAW_ACCESSIBILITY_TEST_CHAT") == "1"
+            && Environment.GetEnvironmentVariable("OPENCLAW_TRAY_DATA_DIR") is { Length: > 0 })
+        {
+            return _accessibilityTestProvider ??= new AccessibilityChatDataProvider();
+        }
+
+        return null;
+    }
+
+    private sealed class AccessibilityChatDataProvider : IChatDataProvider
+    {
+        private const string ThreadId = "accessibility-main";
+        private static readonly ChatDataSnapshot Snapshot = CreateSnapshot();
+
+        public string DisplayName => "Accessibility test chat";
+
+        public event EventHandler<ChatDataChangedEventArgs>? Changed
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<ChatProviderNotificationEventArgs>? NotificationRequested
+        {
+            add { }
+            remove { }
+        }
+
+        public Task<ChatDataSnapshot> LoadAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(Snapshot);
+
+        public Task SendMessageAsync(
+            string threadId,
+            string message,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task StopResponseAsync(string threadId, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task SetThreadSuspendedAsync(string threadId, bool suspended, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task DeleteThreadAsync(string threadId, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task SetModelAsync(string threadId, string model, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task SetThinkingLevelAsync(string threadId, string thinkingLevel, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task SetPermissionModeAsync(string threadId, bool allowAll, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task RespondToPermissionAsync(
+            string threadId,
+            string requestId,
+            string action,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        private static ChatDataSnapshot CreateSnapshot()
+        {
+            var timeline = ChatTimelineState.Initial() with
+            {
+                Entries = ChatTimelineState.Initial().Entries
+                    .Add(new ChatTimelineItem(
+                        "accessibility-user",
+                        ChatTimelineItemKind.User,
+                        "Verify the native chat surface."))
+                    .Add(new ChatTimelineItem(
+                        "accessibility-assistant",
+                        ChatTimelineItemKind.Assistant,
+                        "The timeline and composer are ready.")),
+                NextId = 3,
+                HistoryLoaded = true,
+            };
+
+            return new ChatDataSnapshot(
+                [new ChatThread
+                {
+                    Id = ThreadId,
+                    Title = "Accessibility session",
+                    Status = ChatThreadStatus.Running,
+                    Activity = ChatActivity.Idle,
+                    Model = "test-model",
+                }],
+                new Dictionary<string, ChatTimelineState>
+                {
+                    [ThreadId] = timeline,
+                },
+                ThreadId,
+                "Connected (accessibility test)",
+                ["test-model"],
+                new ChatComposeTarget(ThreadId, IsReady: true));
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConfigPage.xaml
@@ -27,6 +27,7 @@
                 </Grid.ColumnDefinitions>
                 <StackPanel Grid.Column="0" Spacing="4">
                     <TextBlock x:Uid="ConfigPage_TextBlock_17" Text="Config"
+                               AutomationProperties.AutomationId="ConfigPageMarker"
                                Style="{StaticResource TitleTextBlockStyle}"/>
                     <TextBlock x:Uid="ConfigSubtitle" x:Name="ConfigSubtitle"
                                Text="Edit gateway configuration (openclaw.json) with a schema-guided form."
@@ -40,10 +41,11 @@
                 </StackPanel>
                 <Button Grid.Column="1"
                         x:Name="RefreshButton" Click="OnRefresh"
+                        AutomationProperties.LabeledBy="{Binding ElementName=RefreshButtonLabel}"
                         VerticalAlignment="Center">
                     <StackPanel Orientation="Horizontal" Spacing="6">
                         <FontIcon Glyph="&#xE72C;" FontSize="14"/>
-                        <TextBlock x:Uid="ConfigPage_TextBlock_21" Text="Refresh"/>
+                        <TextBlock x:Uid="ConfigPage_TextBlock_21" x:Name="RefreshButtonLabel" Text="Refresh"/>
                     </StackPanel>
                 </Button>
             </Grid>
@@ -226,8 +228,11 @@
 
                     <toolkit:GridSplitter Grid.Column="3"
                                           x:Name="JsonPreviewSplitter"
+                                          x:Uid="JsonPreviewSplitter"
                                           ResizeDirection="Columns"
                                           ResizeBehavior="PreviousAndNext"
+                                          AutomationProperties.Name="Resize JSON preview"
+                                          AutomationProperties.LocalizedControlType="splitter"
                                           HorizontalAlignment="Stretch"
                                           VerticalAlignment="Stretch"
                                           Background="{ThemeResource CardStrokeColorDefaultBrush}"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml
@@ -133,6 +133,7 @@
                         <!-- Headline + sub + glance chips -->
                         <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
                             <TextBlock x:Uid="ConnectionPage_NotConnected" x:Name="StripHeadline" Text="Not connected"
+                                       AutomationProperties.AutomationId="ConnectionPageMarker"
                                        Style="{StaticResource SubtitleTextBlockStyle}"
                                        AutomationProperties.HeadingLevel="Level1"
                                        AutomationProperties.LiveSetting="Polite"

--- a/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/CronPage.xaml
@@ -26,7 +26,9 @@
                      <ColumnDefinition Width="Auto"/>
                      <ColumnDefinition Width="Auto"/>
                  </Grid.ColumnDefinitions>
-                 <TextBlock x:Uid="CronPage_CronJobs" Text="Cron Jobs" Style="{StaticResource TitleTextBlockStyle}" Grid.Column="0" VerticalAlignment="Center"/>
+                 <TextBlock x:Uid="CronPage_CronJobs" Text="Cron Jobs"
+                            AutomationProperties.AutomationId="CronPageMarker"
+                            Style="{StaticResource TitleTextBlockStyle}" Grid.Column="0" VerticalAlignment="Center"/>
                  <TextBlock x:Name="JobCountText" Text="(0)" VerticalAlignment="Center" Grid.Column="1" Margin="8,0,0,0"
                             Style="{StaticResource CaptionTextBlockStyle}"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml
@@ -53,6 +53,7 @@
                     <!-- Title block (in-stack, same column as cards). -->
                     <TextBlock x:Uid="DiagnosticsPage_Title"
                                Text="Diagnostics"
+                               AutomationProperties.AutomationId="DebugPageMarker"
                                Style="{StaticResource TitleTextBlockStyle}"
                                Margin="0,0,0,2"/>
                     <TextBlock x:Uid="DiagnosticsPage_Subtitle"

--- a/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/InstancesPage.xaml
@@ -14,6 +14,7 @@
                 <StackPanel Grid.Column="0" Spacing="4">
                     <TextBlock x:Uid="InstancesPage_Title"
                                Text="Instances"
+                               AutomationProperties.AutomationId="InstancesPageMarker"
                                Style="{StaticResource TitleTextBlockStyle}"/>
                     <TextBlock x:Uid="InstancesPage_Subtitle"
                                Text="Latest presence beacons from OpenClaw nodes."
@@ -24,6 +25,7 @@
                 <Button x:Name="RefreshButton"
                         Grid.Column="1"
                         Click="OnRefreshClicked"
+                        AutomationProperties.LabeledBy="{Binding ElementName=RefreshButtonLabel}"
                         VerticalAlignment="Top">
                     <StackPanel Orientation="Horizontal" Spacing="6">
                         <Grid Width="14" Height="14">
@@ -36,7 +38,7 @@
                                           Height="14"
                                           Visibility="Collapsed"/>
                         </Grid>
-                        <TextBlock x:Uid="InstancesPage_RefreshLabel" Text="Refresh"/>
+                        <TextBlock x:Uid="InstancesPage_RefreshLabel" x:Name="RefreshButtonLabel" Text="Refresh"/>
                     </StackPanel>
                 </Button>
             </Grid>

--- a/src/OpenClaw.Tray.WinUI/Pages/NotificationsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/NotificationsPage.xaml
@@ -19,6 +19,7 @@
                 <StackPanel Spacing="2">
                     <TextBlock x:Uid="NotificationsPage_Title"
                                Text="Notifications"
+                               AutomationProperties.AutomationId="NotificationsPageMarker"
                                Style="{StaticResource TitleTextBlockStyle}"/>
                     <TextBlock x:Uid="NotificationsPage_Subtitle"
                                Text="Review and clear active OpenClaw notifications."

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml
@@ -12,6 +12,7 @@
 
             <!-- ───────── Page header ───────── -->
             <TextBlock x:Uid="PermissionsPage_Permissions" Text="Permissions"
+                       AutomationProperties.AutomationId="PermissionsPageMarker"
                        Style="{StaticResource TitleTextBlockStyle}"
                        Margin="0,0,0,2"/>
             <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,0,0,2">

--- a/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SandboxPage.xaml
@@ -27,6 +27,7 @@
                 <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
                     <TextBlock x:Uid="SandboxPage_NodeSandboxIsOn" x:Name="SandboxStatusTitle"
                                Text="Node sandbox is on"
+                               AutomationProperties.AutomationId="SandboxPageMarker"
                                Style="{StaticResource TitleTextBlockStyle}"
                                TextWrapping="Wrap" />
                     <TextBlock x:Uid="SandboxPage_ProgramsTheAgentRuns" x:Name="SandboxStatusSubtext"
@@ -54,7 +55,9 @@
                  scope-clarity InfoBar and the separate "How sandboxing works"
                  ContentDialog — the architectural breakdown of which execution
                  paths are contained vs not is inline, on-demand. -->
-            <Expander HorizontalAlignment="Stretch"
+            <Expander x:Name="ScopeExpander"
+                      AutomationProperties.LabeledBy="{Binding ElementName=ScopeExpanderLabel}"
+                      HorizontalAlignment="Stretch"
                       HorizontalContentAlignment="Stretch"
                       IsExpanded="False">
                 <Expander.Header>
@@ -68,7 +71,7 @@
                                   Glyph="&#xE946;"
                                   VerticalAlignment="Center" />
                         <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
-                            <TextBlock x:Uid="SandboxPage_WhatGetsContained" Text="What gets contained"
+                            <TextBlock x:Uid="SandboxPage_WhatGetsContained" x:Name="ScopeExpanderLabel" Text="What gets contained"
                                        Style="{StaticResource BodyStrongTextBlockStyle}" />
                             <TextBlock x:Uid="SandboxPage_SeeWhichCommandsThis" Text="See which commands this page covers — and which need different controls."
                                        Style="{StaticResource CaptionTextBlockStyle}"

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
@@ -12,6 +12,7 @@
 
             <TextBlock x:Uid="SessionsPage_Sessions"
                            Text="Sessions"
+                           AutomationProperties.AutomationId="SessionsPageMarker"
                            Style="{StaticResource TitleTextBlockStyle}"
                            Margin="0,0,0,2"/>
                 <TextBlock x:Uid="SessionsPage_Subtitle" Text="Conversations this gateway is currently handling, grouped by channel."

--- a/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SettingsPage.xaml
@@ -27,6 +27,7 @@
 
                 <!-- Page header -->
                 <TextBlock x:Uid="SettingsPage_Settings" Text="Settings"
+                           AutomationProperties.AutomationId="SettingsPageMarker"
                            Style="{StaticResource TitleTextBlockStyle}"
                            Margin="0,0,0,8"/>
 

--- a/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SkillsPage.xaml
@@ -11,7 +11,9 @@
 
                 <!-- Header -->
                 <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,0,0,4">
-                    <TextBlock x:Uid="SkillsPage_Skills" Text="🧩 Skills" Style="{StaticResource TitleTextBlockStyle}"/>
+                    <TextBlock x:Uid="SkillsPage_Skills" Text="🧩 Skills"
+                               AutomationProperties.AutomationId="SkillsPageMarker"
+                               Style="{StaticResource TitleTextBlockStyle}"/>
                     <TextBlock x:Name="CountText" Text="" VerticalAlignment="Center"
                                Style="{StaticResource CaptionTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/UsagePage.xaml
@@ -8,7 +8,9 @@
     <Grid HorizontalAlignment="Stretch">
         <StackPanel Padding="24" Spacing="16" HorizontalAlignment="Stretch" MaxWidth="900">
 
-            <TextBlock x:Uid="UsagePage_TextBlock_10" Text="Usage &amp; Cost" Style="{StaticResource TitleTextBlockStyle}"/>
+            <TextBlock x:Uid="UsagePage_TextBlock_10" Text="Usage &amp; Cost"
+                       AutomationProperties.AutomationId="UsagePageMarker"
+                       Style="{StaticResource TitleTextBlockStyle}"/>
 
             <InfoBar x:Uid="UsagePage_GatewayDisconnected" x:Name="ConnectionInfoBar"
                      IsOpen="False" IsClosable="False" Severity="Warning"

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
@@ -9,7 +9,9 @@
     <Grid HorizontalAlignment="Stretch">
         <StackPanel Padding="24" Spacing="8" HorizontalAlignment="Stretch" MaxWidth="900">
 
-            <TextBlock x:Uid="VoiceSettingsPage_PageTitle" x:Name="PageTitleText" Text="Voice &amp; Audio" Style="{StaticResource TitleTextBlockStyle}"/>
+            <TextBlock x:Uid="VoiceSettingsPage_PageTitle" x:Name="PageTitleText" Text="Voice &amp; Audio"
+                       AutomationProperties.AutomationId="VoiceSettingsPageMarker"
+                       Style="{StaticResource TitleTextBlockStyle}"/>
             <TextBlock x:Uid="VoiceSettingsPage_PageDescription" x:Name="PageDescriptionText"
                        Text="Configure speech-to-text and voice interaction settings. All speech processing runs locally on your device."
                        Style="{StaticResource CaptionTextBlockStyle}"
@@ -124,6 +126,7 @@
 
                     <StackPanel Orientation="Horizontal" Spacing="12">
                         <Button x:Name="DownloadButton" Click="OnDownloadClick"
+                                AutomationProperties.LabeledBy="{Binding ElementName=DownloadButtonText}"
                                 Style="{StaticResource AccentButtonStyle}">
                             <StackPanel Orientation="Horizontal" Spacing="6">
                                 <FontIcon Glyph="&#xE896;" FontSize="14"/>
@@ -139,6 +142,7 @@
                                  Minimum="0" Maximum="100"/>
 
                     <Button x:Name="TestVoiceButton" Click="OnTestVoiceClick"
+                            AutomationProperties.LabeledBy="{Binding ElementName=TestVoiceButtonText}"
                             Visibility="Collapsed">
                         <StackPanel Orientation="Horizontal" Spacing="6">
                             <FontIcon x:Name="TestVoiceBtnIcon" Glyph="&#xE720;" FontSize="14"/>
@@ -171,6 +175,7 @@
                             <!-- Centered buttons -->
                             <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
                                 <Button x:Name="InlineTestStartBtn" Click="OnInlineTestStartClick"
+                                        AutomationProperties.LabeledBy="{Binding ElementName=InlineTestBtnLabel}"
                                         Style="{StaticResource AccentButtonStyle}" Padding="12,8">
                                     <StackPanel Orientation="Horizontal" Spacing="6">
                                         <FontIcon x:Name="InlineTestBtnIcon" Glyph="&#xE720;" FontSize="14"/>
@@ -253,6 +258,7 @@
                                   SelectionChanged="OnPiperVoiceChanged" Width="400"/>
                         <StackPanel Orientation="Horizontal" Spacing="8">
                             <Button x:Name="PiperDownloadButton" Click="OnPiperDownloadClick"
+                                    AutomationProperties.LabeledBy="{Binding ElementName=PiperDownloadButtonText}"
                                     Width="180" MinHeight="32">
                                 <StackPanel Orientation="Horizontal" Spacing="6">
                                     <FontIcon x:Name="PiperDownloadIcon" Glyph="&#xE896;" FontSize="14"/>
@@ -262,6 +268,7 @@
                             <Button x:Uid="VoiceSettingsPage_PiperDeleteButton" x:Name="PiperDeleteButton" Click="OnPiperDeleteClick"
                                     Content="Delete" Width="80" Visibility="Collapsed"/>
                             <Button x:Name="PiperPreviewButton" Click="OnPiperPreviewClick"
+                                    AutomationProperties.LabeledBy="{Binding ElementName=PiperPreviewLabel}"
                                     Width="100" Visibility="Collapsed">
                                 <StackPanel Orientation="Horizontal" Spacing="6">
                                     <FontIcon x:Name="PiperPreviewIcon" Glyph="&#xE768;" FontSize="14"/>
@@ -285,6 +292,7 @@
                         <ComboBox x:Uid="VoiceSettingsPage_WindowsVoiceCombo" x:Name="WindowsVoiceCombo" Header="Voice"
                                   SelectionChanged="OnWindowsVoiceChanged" Width="300"/>
                         <Button x:Name="PreviewVoiceButton" Click="OnPreviewVoiceClick"
+                                AutomationProperties.LabeledBy="{Binding ElementName=PreviewVoiceLabel}"
                                 Width="140">
                             <StackPanel Orientation="Horizontal" Spacing="6">
                                 <FontIcon x:Name="PreviewVoiceIcon" Glyph="&#xE768;" FontSize="14"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml
@@ -81,15 +81,17 @@
                 </Grid.ColumnDefinitions>
                 <TextBlock x:Uid="WorkspacePage_TextBlock_22" Grid.Column="0"
                            Text="Workspace"
+                           AutomationProperties.AutomationId="WorkspacePageMarker"
                            Style="{StaticResource TitleTextBlockStyle}"
                            VerticalAlignment="Center"/>
                 <Button x:Name="RefreshButton" Grid.Column="1" Click="RefreshButton_Click"
+                        AutomationProperties.LabeledBy="{Binding ElementName=RefreshButtonLabel}"
                         VerticalAlignment="Center">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Refresh, Mode=OneTime}"
                                   FontSize="16"
                                   IsTextScaleFactorEnabled="False"/>
-                        <TextBlock x:Uid="WorkspacePage_TextBlock_34" Text="Refresh"/>
+                        <TextBlock x:Uid="WorkspacePage_TextBlock_34" x:Name="RefreshButtonLabel" Text="Refresh"/>
                     </StackPanel>
                 </Button>
             </Grid>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -3002,6 +3002,15 @@ Use one of these options:
   <data name="Chat_Composer_Reasoning_Maximum" xml:space="preserve">
     <value>Maximum</value>
   </data>
+  <data name="Chat_Composer_Accessibility_Session" xml:space="preserve">
+    <value>Session</value>
+  </data>
+  <data name="Chat_Composer_Accessibility_Model" xml:space="preserve">
+    <value>Model</value>
+  </data>
+  <data name="Chat_Composer_Accessibility_Reasoning" xml:space="preserve">
+    <value>Reasoning</value>
+  </data>
   <data name="Chat_Composer_Placeholder_Connected" xml:space="preserve">
     <value>Message Assistant (Enter to send)</value>
   </data>
@@ -6806,5 +6815,11 @@ Make sure the gateway is running.</value>
   </data>
   <data name="HubWindow_MainNavigation.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Main navigation</value>
+  </data>
+  <data name="JsonPreviewSplitter.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Resize JSON preview</value>
+  </data>
+  <data name="JsonPreviewSplitter.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.LocalizedControlType" xml:space="preserve">
+    <value>splitter</value>
   </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2955,6 +2955,15 @@ Utilisez l'une de ces options :
   <data name="Chat_Composer_Reasoning_Maximum" xml:space="preserve">
     <value>Maximal</value>
   </data>
+  <data name="Chat_Composer_Accessibility_Session" xml:space="preserve">
+    <value>Conversation</value>
+  </data>
+  <data name="Chat_Composer_Accessibility_Model" xml:space="preserve">
+    <value>Modèle</value>
+  </data>
+  <data name="Chat_Composer_Accessibility_Reasoning" xml:space="preserve">
+    <value>Raisonnement</value>
+  </data>
   <data name="Chat_Composer_Placeholder_Connected" xml:space="preserve">
     <value>Envoyer un message à l'assistant (Entrée pour envoyer)</value>
   </data>
@@ -6766,5 +6775,11 @@ Le binaire wxc-exec est introuvable. {1} S'il s'agit d'une build développeur, c
   </data>
   <data name="HubWindow_MainNavigation.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Navigation principale</value>
+  </data>
+  <data name="JsonPreviewSplitter.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Redimensionner l’aperçu JSON</value>
+  </data>
+  <data name="JsonPreviewSplitter.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.LocalizedControlType" xml:space="preserve">
+    <value>séparateur</value>
   </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2956,6 +2956,15 @@ Gebruik een van deze opties:
   <data name="Chat_Composer_Reasoning_Maximum" xml:space="preserve">
     <value>Maximaal</value>
   </data>
+  <data name="Chat_Composer_Accessibility_Session" xml:space="preserve">
+    <value>Sessie</value>
+  </data>
+  <data name="Chat_Composer_Accessibility_Model" xml:space="preserve">
+    <value>Taalmodel</value>
+  </data>
+  <data name="Chat_Composer_Accessibility_Reasoning" xml:space="preserve">
+    <value>Redenering</value>
+  </data>
   <data name="Chat_Composer_Placeholder_Connected" xml:space="preserve">
     <value>Bericht aan assistent (Enter om te verzenden)</value>
   </data>
@@ -6767,5 +6776,11 @@ Het binaire bestand wxc-exec is niet gevonden. {1} Als dit een ontwikkelaarsbuil
   </data>
   <data name="HubWindow_MainNavigation.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Hoofdnavigatie</value>
+  </data>
+  <data name="JsonPreviewSplitter.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Formaat van JSON-voorbeeld wijzigen</value>
+  </data>
+  <data name="JsonPreviewSplitter.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.LocalizedControlType" xml:space="preserve">
+    <value>scheidingslijn</value>
   </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2955,6 +2955,15 @@
   <data name="Chat_Composer_Reasoning_Maximum" xml:space="preserve">
     <value>最大</value>
   </data>
+  <data name="Chat_Composer_Accessibility_Session" xml:space="preserve">
+    <value>会话</value>
+  </data>
+  <data name="Chat_Composer_Accessibility_Model" xml:space="preserve">
+    <value>模型</value>
+  </data>
+  <data name="Chat_Composer_Accessibility_Reasoning" xml:space="preserve">
+    <value>推理</value>
+  </data>
   <data name="Chat_Composer_Placeholder_Connected" xml:space="preserve">
     <value>给助手发送消息（按 Enter 发送）</value>
   </data>
@@ -6766,5 +6775,11 @@
   </data>
   <data name="HubWindow_MainNavigation.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>主导航</value>
+  </data>
+  <data name="JsonPreviewSplitter.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>调整 JSON 预览大小</value>
+  </data>
+  <data name="JsonPreviewSplitter.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.LocalizedControlType" xml:space="preserve">
+    <value>分隔条</value>
   </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2955,6 +2955,15 @@
   <data name="Chat_Composer_Reasoning_Maximum" xml:space="preserve">
     <value>最大</value>
   </data>
+  <data name="Chat_Composer_Accessibility_Session" xml:space="preserve">
+    <value>工作階段</value>
+  </data>
+  <data name="Chat_Composer_Accessibility_Model" xml:space="preserve">
+    <value>模型</value>
+  </data>
+  <data name="Chat_Composer_Accessibility_Reasoning" xml:space="preserve">
+    <value>推理</value>
+  </data>
   <data name="Chat_Composer_Placeholder_Connected" xml:space="preserve">
     <value>傳訊息給助理（按 Enter 傳送）</value>
   </data>
@@ -6766,5 +6775,11 @@
   </data>
   <data name="HubWindow_MainNavigation.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>主要導覽</value>
+  </data>
+  <data name="JsonPreviewSplitter.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>調整 JSON 預覽大小</value>
+  </data>
+  <data name="JsonPreviewSplitter.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.LocalizedControlType" xml:space="preserve">
+    <value>分隔線</value>
   </data>
 </root>

--- a/src/OpenClaw.Tray.WinUI/ViewModels/NotificationItemViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/ViewModels/NotificationItemViewModel.cs
@@ -24,6 +24,9 @@ internal sealed record NotificationItemViewModel(
     Visibility OccurrenceVisibility,
     string DismissAutomationName)
 {
+    // ListViewItem derives its default accessible name from the item string.
+    public override string ToString() => Title;
+
     public static NotificationItemViewModel From(AppNotification notification)
     {
         var metadata = new[]

--- a/tests/OpenClaw.Tray.UITests/AccessibilityAppFixture.cs
+++ b/tests/OpenClaw.Tray.UITests/AccessibilityAppFixture.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Automation;
+
+namespace OpenClaw.Tray.UITests;
+
+/// <summary>
+/// Owns one isolated OpenClaw process for the accessibility test collection.
+/// Navigation is sent through the same deep-link IPC path used by installed apps.
+/// </summary>
+public sealed class AccessibilityAppFixture : IDisposable
+{
+    private const int ShowMaximized = 3;
+    private static readonly TimeSpan StartupTimeout = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan DeepLinkTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan NavigationTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan NavigationSettleTime = TimeSpan.FromMilliseconds(1_000);
+
+    private readonly string _dataDirectory;
+    private readonly string _executablePath;
+    private readonly Process _process;
+
+    public IntPtr HubWindowHandle { get; }
+
+    public AccessibilityAppFixture()
+    {
+        _executablePath = Path.Combine(AppContext.BaseDirectory, "OpenClaw.Tray.WinUI.exe");
+        if (!File.Exists(_executablePath))
+        {
+            throw new FileNotFoundException(
+                "The real tray executable was not copied beside the UI test assembly.",
+                _executablePath);
+        }
+
+        _dataDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"OpenClaw.Tray.Axe.{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dataDirectory);
+        File.WriteAllText(
+            Path.Combine(_dataDirectory, "settings.json"),
+            """
+            {
+              "SettingsSchemaVersion": 1,
+              "EnableMcpServer": true,
+              "GlobalHotkeyEnabled": false,
+              "AutoStart": false
+            }
+            """);
+
+        _process = StartProcess("openclaw://hub/connection");
+        HubWindowHandle = WaitForHubWindow();
+        AxeHelper.Initialize(_process.Id);
+    }
+
+    public async Task NavigateAsync(string pageTag, string pageMarkerAutomationId)
+    {
+        EnsureTargetIsAlive();
+
+        using var sender = StartProcess($"openclaw://hub/{pageTag}");
+        using var timeout = new CancellationTokenSource(DeepLinkTimeout);
+        try
+        {
+            await sender.WaitForExitAsync(timeout.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            if (!sender.HasExited)
+                sender.Kill(entireProcessTree: true);
+            throw new TimeoutException(
+                $"Timed out forwarding the '{pageTag}' deep link to the accessibility app.");
+        }
+
+        EnsureTargetIsAlive();
+        await WaitForPageMarkerAsync(pageTag, pageMarkerAutomationId);
+    }
+
+    private async Task WaitForPageMarkerAsync(string pageTag, string automationId)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var condition = new PropertyCondition(
+            AutomationElement.AutomationIdProperty,
+            automationId);
+
+        while (stopwatch.Elapsed < NavigationTimeout)
+        {
+            EnsureTargetIsAlive();
+            var hub = AutomationElement.FromHandle(HubWindowHandle);
+            if (hub.FindFirst(TreeScope.Descendants, condition) != null)
+                return;
+
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException(
+            $"The '{pageTag}' page did not expose its '{automationId}' marker " +
+            $"within {NavigationTimeout.TotalSeconds:0} seconds.");
+    }
+
+    private Process StartProcess(string deepLink)
+    {
+        var startInfo = new ProcessStartInfo(_executablePath)
+        {
+            UseShellExecute = false,
+            WorkingDirectory = AppContext.BaseDirectory,
+        };
+        startInfo.ArgumentList.Add(deepLink);
+        startInfo.Environment["OPENCLAW_TRAY_DATA_DIR"] = _dataDirectory;
+        startInfo.Environment["OPENCLAW_SKIP_UPDATE_CHECK"] = "1";
+        startInfo.Environment["OPENCLAW_FORCE_ONBOARDING"] = "0";
+        startInfo.Environment["OPENCLAW_ACCESSIBILITY_TEST_CHAT"] = "1";
+
+        return Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start the OpenClaw tray executable.");
+    }
+
+    private IntPtr WaitForHubWindow()
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < StartupTimeout)
+        {
+            EnsureTargetIsAlive();
+            _process.Refresh();
+            if (_process.MainWindowHandle != IntPtr.Zero)
+            {
+                Thread.Sleep(NavigationSettleTime);
+                EnsureTargetIsAlive();
+                _process.Refresh();
+                if (_process.MainWindowHandle != IntPtr.Zero)
+                {
+                    _ = ShowWindow(_process.MainWindowHandle, ShowMaximized);
+                    Thread.Sleep(NavigationSettleTime);
+                    return _process.MainWindowHandle;
+                }
+            }
+
+            Thread.Sleep(100);
+        }
+
+        throw new TimeoutException(
+            $"OpenClaw did not expose its Hub window within {StartupTimeout.TotalSeconds:0} seconds.");
+    }
+
+    private void EnsureTargetIsAlive()
+    {
+        if (!_process.HasExited)
+            return;
+
+        var crashLogPath = Path.Combine(_dataDirectory, "crash.log");
+        var crashLog = File.Exists(crashLogPath)
+            ? $" Crash log: {File.ReadAllText(crashLogPath)}"
+            : string.Empty;
+        throw new InvalidOperationException(
+            $"OpenClaw exited unexpectedly with code {_process.ExitCode}.{crashLog}");
+    }
+
+    public void Dispose()
+    {
+        if (!_process.HasExited)
+        {
+            _process.Kill(entireProcessTree: true);
+            _process.WaitForExit(5_000);
+        }
+        _process.Dispose();
+
+        // slopwatch-ignore: SW003 Test-owned temporary data cleanup is best-effort after process teardown.
+        try { Directory.Delete(_dataDirectory, recursive: true); }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    [DllImport("user32.dll")]
+    private static extern int ShowWindow(IntPtr windowHandle, int command);
+}

--- a/tests/OpenClaw.Tray.UITests/AccessibilityScanTests.cs
+++ b/tests/OpenClaw.Tray.UITests/AccessibilityScanTests.cs
@@ -1,129 +1,74 @@
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Axe.Windows.Core.Enums;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using Xunit;
 
 namespace OpenClaw.Tray.UITests;
 
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class AccessibilityCollection : ICollectionFixture<AccessibilityAppFixture>
+{
+    public const string Name = "Accessibility app";
+}
+
 /// <summary>
-/// Data-driven accessibility tests that scan each page in the OpenClaw app for
-/// WCAG violations using Axe.Windows. Modeled after WinUI-Gallery's
-/// AxeScanAllTests pattern.
-///
-/// Each page is instantiated in the <see cref="UIThreadFixture"/>'s hidden window
-/// and scanned via the UIA tree. New pages added to the app should be registered
-/// in <see cref="PageTestData"/> to be automatically included in CI scans.
-///
-/// See PR #921 for fixes to the low-hanging accessibility violations discovered
-/// by these tests.
+/// Scans every native Hub page in the real OpenClaw process. The test process
+/// remains separate because Axe.Windows drives the target through UI Automation.
 /// </summary>
-[Collection(UICollection.Name)]
+[Collection(AccessibilityCollection.Name)]
 public sealed class AccessibilityScanTests
 {
-    private readonly UIThreadFixture _ui;
+    private readonly AccessibilityAppFixture _app;
 
-    public AccessibilityScanTests(UIThreadFixture ui)
+    public AccessibilityScanTests(AccessibilityAppFixture app)
     {
-        _ui = ui;
+        _app = app;
     }
 
-    /// <summary>
-    /// Pages that are completely excluded from scanning because they crash Axe
-    /// or require infrastructure unavailable in CI (e.g. WebView2, live connections).
-    /// </summary>
-    private static readonly HashSet<string> ExcludedPages =
-    [
-        // ChatPage hosts CefSharp/WebView2 which causes Axe to traverse the
-        // Chromium UIA tree and throw NullReferenceException (same root cause as
-        // WinUI-Gallery's WebView2 exclusion: axe-windows/issues/662).
-        "ChatPage",
-    ];
-
-    /// <summary>
-    /// Per-page rule exclusions for known issues specific to certain pages.
-    /// Add entries here when a page has violations caused by WinUI framework
-    /// limitations or third-party controls that cannot be fixed in app code.
-    /// Document the reason with a link to the upstream issue.
-    /// </summary>
-    private static readonly Dictionary<string, RuleId[]> PageRuleExclusions = new()
-    {
-        // ConnectionPage: gateway row cards use dynamic binding for accessible name;
-        // when no gateways are configured the template has empty Name.
-        // Fixed in PR #921; keep exclusion in case tests run without that PR.
-        ["ConnectionPage"] = [RuleId.NameNotNull],
-    };
-
-    /// <summary>
-    /// Enumerates all app pages for data-driven testing. Each entry is
-    /// [pageName, pageType]. New pages are automatically picked up when added here.
-    /// </summary>
-    public static IEnumerable<object[]> PageTestData()
-    {
-        var pages = new (string Name, Type Type)[]
+    private static readonly IReadOnlyDictionary<string, RuleId[]> PageRuleExclusions =
+        new Dictionary<string, RuleId[]>
         {
-            ("AgentEventsPage", typeof(OpenClawTray.Pages.AgentEventsPage)),
-            ("BindingsPage", typeof(OpenClawTray.Pages.BindingsPage)),
-            ("ChannelsPage", typeof(OpenClawTray.Pages.ChannelsPage)),
-            ("ConfigPage", typeof(OpenClawTray.Pages.ConfigPage)),
-            ("ConnectionPage", typeof(OpenClawTray.Pages.ConnectionPage)),
-            ("CronPage", typeof(OpenClawTray.Pages.CronPage)),
-            ("DebugPage", typeof(OpenClawTray.Pages.DebugPage)),
-            ("InstancesPage", typeof(OpenClawTray.Pages.InstancesPage)),
-            ("NotificationsPage", typeof(OpenClawTray.Pages.NotificationsPage)),
-            ("PermissionsPage", typeof(OpenClawTray.Pages.PermissionsPage)),
-            ("SandboxPage", typeof(OpenClawTray.Pages.SandboxPage)),
-            ("SessionsPage", typeof(OpenClawTray.Pages.SessionsPage)),
-            ("SettingsPage", typeof(OpenClawTray.Pages.SettingsPage)),
-            ("SkillsPage", typeof(OpenClawTray.Pages.SkillsPage)),
-            ("UsagePage", typeof(OpenClawTray.Pages.UsagePage)),
-            ("VoiceSettingsPage", typeof(OpenClawTray.Pages.VoiceSettingsPage)),
-            ("WorkspacePage", typeof(OpenClawTray.Pages.WorkspacePage)),
+            // The public GridSplitter has an app-supplied localized name/type. Its
+            // CommunityToolkit SizerBase child peer still reports both types as
+            // "custom" and cannot be configured by the consuming XAML page.
+            ["ConfigPage"] = [RuleId.LocalizedControlTypeNotCustom],
         };
 
-        foreach (var (name, type) in pages)
-        {
-            if (!ExcludedPages.Contains(name))
-                yield return [name, type];
-        }
+    public static IEnumerable<object[]> PageTestData()
+    {
+        yield return ["AgentEventsPage", "agentevents", "AgentEventsPageMarker"];
+        yield return ["BindingsPage", "bindings", "BindingsPageMarker"];
+        yield return ["ChannelsPage", "channels", "ChannelsPageMarker"];
+        yield return ["ChatPage", "chat", "ChatComposerInput"];
+        yield return ["ConfigPage", "config", "ConfigPageMarker"];
+        yield return ["ConnectionPage", "connection", "ConnectionPageMarker"];
+        yield return ["CronPage", "cron", "CronPageMarker"];
+        yield return ["DebugPage", "debug", "DebugPageMarker"];
+        yield return ["InstancesPage", "instances", "InstancesPageMarker"];
+        yield return ["NotificationsPage", "notifications", "NotificationsPageMarker"];
+        yield return ["PermissionsPage", "permissions", "PermissionsPageMarker"];
+        yield return ["SandboxPage", "sandbox", "SandboxPageMarker"];
+        yield return ["SessionsPage", "sessions", "SessionsPageMarker"];
+        yield return ["SettingsPage", "settings", "SettingsPageMarker"];
+        yield return ["SkillsPage", "skills", "SkillsPageMarker"];
+        yield return ["UsagePage", "usage", "UsagePageMarker"];
+        yield return ["VoiceSettingsPage", "voice", "VoiceSettingsPageMarker"];
+        yield return ["WorkspacePage", "workspace", "WorkspacePageMarker"];
     }
 
-    /// <summary>
-    /// Instantiates each page in the test window and scans for accessibility
-    /// violations using Axe.Windows. Failures include the rule ID, element
-    /// control type, name, and automation ID for actionability.
-    /// </summary>
     [Theory]
     [Trait("Category", "Accessibility")]
     [MemberData(nameof(PageTestData))]
-    public async Task Page_PassesAccessibilityScan(string pageName, Type pageType)
+    public async Task Page_PassesAccessibilityScan(
+        string pageName,
+        string pageTag,
+        string pageMarkerAutomationId)
     {
-        await _ui.ResetContainerAsync();
-
-        await _ui.RunOnUIAsync(() =>
-        {
-            // Initialize Axe scanner on first use (attaches to current process)
-            AxeHelper.Initialize();
-
-            // Instantiate the page and host it in the test container
-            var page = (UIElement)Activator.CreateInstance(pageType)!;
-
-            _ui.Container.Children.Clear();
-            _ui.Container.Children.Add(page);
-
-            // Force layout so the UIA tree is fully populated
-            _ui.Container.UpdateLayout();
-        });
-
-        // Allow any async UI initialization (bindings, loaded events) to settle
-        await Task.Delay(500);
-
-        await _ui.RunOnUIAsync(() =>
-        {
-            PageRuleExclusions.TryGetValue(pageName, out var ruleExclusions);
-            AxeHelper.AssertNoAccessibilityErrors(ruleExclusions, pageName);
-        });
+        await _app.NavigateAsync(pageTag, pageMarkerAutomationId);
+        PageRuleExclusions.TryGetValue(pageName, out var exclusions);
+        AxeHelper.AssertNoAccessibilityErrors(
+            _app.HubWindowHandle,
+            exclusions,
+            context: pageName);
     }
 }

--- a/tests/OpenClaw.Tray.UITests/AccessibilityScanTests.cs
+++ b/tests/OpenClaw.Tray.UITests/AccessibilityScanTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Axe.Windows.Core.Enums;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Xunit;
+
+namespace OpenClaw.Tray.UITests;
+
+/// <summary>
+/// Data-driven accessibility tests that scan each page in the OpenClaw app for
+/// WCAG violations using Axe.Windows. Modeled after WinUI-Gallery's
+/// AxeScanAllTests pattern.
+///
+/// Each page is instantiated in the <see cref="UIThreadFixture"/>'s hidden window
+/// and scanned via the UIA tree. New pages added to the app should be registered
+/// in <see cref="PageTestData"/> to be automatically included in CI scans.
+///
+/// See PR #921 for fixes to the low-hanging accessibility violations discovered
+/// by these tests.
+/// </summary>
+[Collection(UICollection.Name)]
+public sealed class AccessibilityScanTests
+{
+    private readonly UIThreadFixture _ui;
+
+    public AccessibilityScanTests(UIThreadFixture ui)
+    {
+        _ui = ui;
+    }
+
+    /// <summary>
+    /// Pages that are completely excluded from scanning because they crash Axe
+    /// or require infrastructure unavailable in CI (e.g. WebView2, live connections).
+    /// </summary>
+    private static readonly HashSet<string> ExcludedPages =
+    [
+        // ChatPage hosts CefSharp/WebView2 which causes Axe to traverse the
+        // Chromium UIA tree and throw NullReferenceException (same root cause as
+        // WinUI-Gallery's WebView2 exclusion: axe-windows/issues/662).
+        "ChatPage",
+    ];
+
+    /// <summary>
+    /// Per-page rule exclusions for known issues specific to certain pages.
+    /// Add entries here when a page has violations caused by WinUI framework
+    /// limitations or third-party controls that cannot be fixed in app code.
+    /// Document the reason with a link to the upstream issue.
+    /// </summary>
+    private static readonly Dictionary<string, RuleId[]> PageRuleExclusions = new()
+    {
+        // ConnectionPage: gateway row cards use dynamic binding for accessible name;
+        // when no gateways are configured the template has empty Name.
+        // Fixed in PR #921; keep exclusion in case tests run without that PR.
+        ["ConnectionPage"] = [RuleId.NameNotNull],
+    };
+
+    /// <summary>
+    /// Enumerates all app pages for data-driven testing. Each entry is
+    /// [pageName, pageType]. New pages are automatically picked up when added here.
+    /// </summary>
+    public static IEnumerable<object[]> PageTestData()
+    {
+        var pages = new (string Name, Type Type)[]
+        {
+            ("AgentEventsPage", typeof(OpenClawTray.Pages.AgentEventsPage)),
+            ("BindingsPage", typeof(OpenClawTray.Pages.BindingsPage)),
+            ("ChannelsPage", typeof(OpenClawTray.Pages.ChannelsPage)),
+            ("ConfigPage", typeof(OpenClawTray.Pages.ConfigPage)),
+            ("ConnectionPage", typeof(OpenClawTray.Pages.ConnectionPage)),
+            ("CronPage", typeof(OpenClawTray.Pages.CronPage)),
+            ("DebugPage", typeof(OpenClawTray.Pages.DebugPage)),
+            ("InstancesPage", typeof(OpenClawTray.Pages.InstancesPage)),
+            ("NotificationsPage", typeof(OpenClawTray.Pages.NotificationsPage)),
+            ("PermissionsPage", typeof(OpenClawTray.Pages.PermissionsPage)),
+            ("SandboxPage", typeof(OpenClawTray.Pages.SandboxPage)),
+            ("SessionsPage", typeof(OpenClawTray.Pages.SessionsPage)),
+            ("SettingsPage", typeof(OpenClawTray.Pages.SettingsPage)),
+            ("SkillsPage", typeof(OpenClawTray.Pages.SkillsPage)),
+            ("UsagePage", typeof(OpenClawTray.Pages.UsagePage)),
+            ("VoiceSettingsPage", typeof(OpenClawTray.Pages.VoiceSettingsPage)),
+            ("WorkspacePage", typeof(OpenClawTray.Pages.WorkspacePage)),
+        };
+
+        foreach (var (name, type) in pages)
+        {
+            if (!ExcludedPages.Contains(name))
+                yield return [name, type];
+        }
+    }
+
+    /// <summary>
+    /// Instantiates each page in the test window and scans for accessibility
+    /// violations using Axe.Windows. Failures include the rule ID, element
+    /// control type, name, and automation ID for actionability.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Accessibility")]
+    [MemberData(nameof(PageTestData))]
+    public async Task Page_PassesAccessibilityScan(string pageName, Type pageType)
+    {
+        await _ui.ResetContainerAsync();
+
+        await _ui.RunOnUIAsync(() =>
+        {
+            // Initialize Axe scanner on first use (attaches to current process)
+            AxeHelper.Initialize();
+
+            // Instantiate the page and host it in the test container
+            var page = (UIElement)Activator.CreateInstance(pageType)!;
+
+            _ui.Container.Children.Clear();
+            _ui.Container.Children.Add(page);
+
+            // Force layout so the UIA tree is fully populated
+            _ui.Container.UpdateLayout();
+        });
+
+        // Allow any async UI initialization (bindings, loaded events) to settle
+        await Task.Delay(500);
+
+        await _ui.RunOnUIAsync(() =>
+        {
+            PageRuleExclusions.TryGetValue(pageName, out var ruleExclusions);
+            AxeHelper.AssertNoAccessibilityErrors(ruleExclusions, pageName);
+        });
+    }
+}

--- a/tests/OpenClaw.Tray.UITests/AxeHelper.cs
+++ b/tests/OpenClaw.Tray.UITests/AxeHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Axe.Windows.Automation;
+using Axe.Windows.Automation.Data;
 using Axe.Windows.Core.Enums;
 using Xunit;
 
@@ -11,8 +12,8 @@ namespace OpenClaw.Tray.UITests;
 /// Wraps Axe.Windows scanner to validate the live UI Automation tree for
 /// accessibility violations. Modeled after the WinUI-Gallery AxeHelper pattern.
 ///
-/// The scanner attaches to the current process (which hosts the WinUI3 test window
-/// via <see cref="UIThreadFixture"/>) and inspects the UIA tree for WCAG violations.
+/// The scanner attaches to the separately launched OpenClaw process and inspects
+/// only its visible Hub window's UIA subtree.
 /// </summary>
 public static class AxeHelper
 {
@@ -36,10 +37,10 @@ public static class AxeHelper
     ];
 
     /// <summary>
-    /// Initialize the Axe.Windows scanner for the current process.
+    /// Initialize the Axe.Windows scanner for the target app process.
     /// Thread-safe; subsequent calls are no-ops.
     /// </summary>
-    public static void Initialize()
+    public static void Initialize(int processId)
     {
         if (_scanner != null) return;
 
@@ -47,14 +48,16 @@ public static class AxeHelper
         {
             if (_scanner != null) return;
 
-            var processId = Environment.ProcessId;
-            var config = Config.Builder.ForProcessId(processId).Build();
+            var config = Config.Builder
+                .ForProcessId(processId)
+                .WithOutputFileFormat(OutputFileFormat.None)
+                .Build();
             _scanner = ScannerFactory.CreateScanner(config);
         }
     }
 
     /// <summary>
-    /// Scan the current window's UIA tree and assert no accessibility violations exist.
+    /// Scan the Hub window's UIA tree and assert no accessibility violations exist.
     /// </summary>
     /// <param name="pageRuleExclusions">
     /// Optional per-page rule exclusions for known issues specific to a page.
@@ -63,6 +66,7 @@ public static class AxeHelper
     /// Optional context string (e.g. page name) included in failure messages.
     /// </param>
     public static void AssertNoAccessibilityErrors(
+        IntPtr hubWindowHandle,
         IEnumerable<RuleId>? pageRuleExclusions = null,
         string? context = null)
     {
@@ -74,7 +78,7 @@ public static class AxeHelper
         if (pageRuleExclusions != null)
             excludedRules.UnionWith(pageRuleExclusions);
 
-        var scanOutput = _scanner.Scan(null);
+        var scanOutput = _scanner.Scan(new ScanOptions(context, hubWindowHandle));
 
         var errors = scanOutput.WindowScanOutputs
             .SelectMany(output => output.Errors)

--- a/tests/OpenClaw.Tray.UITests/AxeHelper.cs
+++ b/tests/OpenClaw.Tray.UITests/AxeHelper.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Axe.Windows.Automation;
+using Axe.Windows.Core.Enums;
+using Xunit;
+
+namespace OpenClaw.Tray.UITests;
+
+/// <summary>
+/// Wraps Axe.Windows scanner to validate the live UI Automation tree for
+/// accessibility violations. Modeled after the WinUI-Gallery AxeHelper pattern.
+///
+/// The scanner attaches to the current process (which hosts the WinUI3 test window
+/// via <see cref="UIThreadFixture"/>) and inspects the UIA tree for WCAG violations.
+/// </summary>
+public static class AxeHelper
+{
+    private static IScanner? _scanner;
+    private static readonly object _lock = new();
+
+    /// <summary>
+    /// Rules excluded globally due to known WinUI framework bugs that are not
+    /// fixable in application code. These mirror the WinUI-Gallery exclusions.
+    /// </summary>
+    private static readonly HashSet<RuleId> GloballyExcludedRules =
+    [
+        // WinUI framework generates non-informative names for some built-in controls
+        RuleId.NameIsInformative,
+        // Framework includes control type in auto-generated accessible names
+        RuleId.NameExcludesControlType,
+        // Same as above, localized variant
+        RuleId.NameExcludesLocalizedControlType,
+        // WinUI framework repeats sibling names in some control patterns
+        RuleId.SiblingUniqueAndFocusable,
+    ];
+
+    /// <summary>
+    /// Initialize the Axe.Windows scanner for the current process.
+    /// Thread-safe; subsequent calls are no-ops.
+    /// </summary>
+    public static void Initialize()
+    {
+        if (_scanner != null) return;
+
+        lock (_lock)
+        {
+            if (_scanner != null) return;
+
+            var processId = Environment.ProcessId;
+            var config = Config.Builder.ForProcessId(processId).Build();
+            _scanner = ScannerFactory.CreateScanner(config);
+        }
+    }
+
+    /// <summary>
+    /// Scan the current window's UIA tree and assert no accessibility violations exist.
+    /// </summary>
+    /// <param name="pageRuleExclusions">
+    /// Optional per-page rule exclusions for known issues specific to a page.
+    /// </param>
+    /// <param name="context">
+    /// Optional context string (e.g. page name) included in failure messages.
+    /// </param>
+    public static void AssertNoAccessibilityErrors(
+        IEnumerable<RuleId>? pageRuleExclusions = null,
+        string? context = null)
+    {
+        if (_scanner == null)
+            throw new InvalidOperationException(
+                "AxeHelper.Initialize() must be called before scanning.");
+
+        var excludedRules = new HashSet<RuleId>(GloballyExcludedRules);
+        if (pageRuleExclusions != null)
+            excludedRules.UnionWith(pageRuleExclusions);
+
+        var scanOutput = _scanner.Scan(null);
+
+        var errors = scanOutput.WindowScanOutputs
+            .SelectMany(output => output.Errors)
+            .Where(error => !excludedRules.Contains(error.Rule.ID))
+            .ToList();
+
+        if (errors.Count == 0) return;
+
+        var errorMessages = errors.Select(error =>
+        {
+            var controlType = error.Element.Properties.TryGetValue("ControlType", out var ct)
+                ? ct : "Unknown";
+            var name = error.Element.Properties.TryGetValue("Name", out var n)
+                ? n : "(no name)";
+            var automationId = error.Element.Properties.TryGetValue("AutomationId", out var aid)
+                ? aid : "(no id)";
+            return $"  [{error.Rule.ID}] Element '{controlType}' " +
+                   $"(Name='{name}', AutomationId='{automationId}') " +
+                   $"violated rule: {error.Rule.Description}";
+        });
+
+        var header = string.IsNullOrEmpty(context)
+            ? $"Accessibility scan found {errors.Count} violation(s):"
+            : $"Accessibility scan of '{context}' found {errors.Count} violation(s):";
+
+        Assert.Fail($"{header}\r\n{string.Join("\r\n", errorMessages)}");
+    }
+}

--- a/tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj
+++ b/tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj
@@ -30,17 +30,18 @@
     <!-- System.Drawing.Common 4.7.0 advisory comes in transitively via the
          Tray.WinUI ProjectReference. The main project warns; we don't want it
          to escalate to an error here just because tests/Directory.Build.props
-         sets TreatWarningsAsErrors=true.
-         NU1903 also fires for System.IO.Packaging 8.0.0 from Axe.Windows
-         (GHSA-f32c-w444-8ppv, GHSA-qj66-m88j-hmgj); the scanner runs in-process
-         during tests only — not shipped — so the advisory is not actionable. -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1904;NU1903</WarningsNotAsErrors>
+         sets TreatWarningsAsErrors=true. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Axe.Windows" Version="2.4.1" />
+    <PackageReference Include="Axe.Windows" Version="2.4.2" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$(MicrosoftWindowsAppSDKVersion)" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$(MicrosoftWindowsSdkBuildToolsVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.WindowsDesktop.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj
+++ b/tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj
@@ -30,11 +30,15 @@
     <!-- System.Drawing.Common 4.7.0 advisory comes in transitively via the
          Tray.WinUI ProjectReference. The main project warns; we don't want it
          to escalate to an error here just because tests/Directory.Build.props
-         sets TreatWarningsAsErrors=true. -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1904</WarningsNotAsErrors>
+         sets TreatWarningsAsErrors=true.
+         NU1903 also fires for System.IO.Packaging 8.0.0 from Axe.Windows
+         (GHSA-f32c-w444-8ppv, GHSA-qj66-m88j-hmgj); the scanner runs in-process
+         during tests only — not shipped — so the advisory is not actionable. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1904;NU1903</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Axe.Windows" Version="2.4.1" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$(MicrosoftWindowsAppSDKVersion)" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$(MicrosoftWindowsSdkBuildToolsVersion)" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Add a blocking Windows accessibility gate that launches the real `OpenClaw.Tray.WinUI.exe` process and scans all 18 native pages with Axe.Windows, including the FunctionalUI Chat timeline and composer.

Thanks @karkarl for the initial Axe integration.

## What changed

- Launch a separate packaged-app build with an isolated `OPENCLAW_TRAY_DATA_DIR`; use the real single-instance IPC path for page navigation.
- Wait for a page-specific UI Automation marker before every scan, preventing a navigation failure from scanning the previous page.
- Mount deterministic native Chat data during isolated accessibility runs, including user/assistant messages and an enabled real composer.
- Upgrade Axe.Windows to 2.4.2 and remove the vulnerable transitive package suppression.
- Make the accessibility workflow blocking; keep the Markdown summary and TRX artifact publication under `always()`.
- Add stable automation metadata and localized accessible names for page headings, Chat selectors, refresh/clear actions, Sandbox scope, Voice controls, the Config splitter, and notification items.
- Keep only the global WinUI framework exclusions plus one scoped `ConfigPage` exclusion for the inaccessible CommunityToolkit internal `SizerBase` peer. The public splitter peer is named and exposed correctly.

## Why the original green run was insufficient

The [original workflow run](https://github.com/openclaw/openclaw-windows-node/actions/runs/28627389894) was green only because its accessibility step used `continue-on-error`. Its [test job](https://github.com/openclaw/openclaw-windows-node/actions/runs/28627389894/job/84896813614) had all 17 scans fail during synthetic in-process page construction with `XamlParseException`; Chat was excluded. This revision removes the soft-fail path and exercises the actual app process.

## Validation

Current-head Windows 11 ARM64 Parallels VM:

- `dotnet build tests\OpenClaw.Tray.UITests\OpenClaw.Tray.UITests.csproj -c Debug -r win-arm64 --no-restore`: 0 warnings, 0 errors.
- Real-process Axe suite: 18/18 passed in 32.8 seconds, including native Chat with `ChatComposerInput` inside the mounted FunctionalUI composer.
- Full UI suite: 94/94 passed.
- `build.ps1`: Shared 2691 passed / 31 skipped; Tray 1532 passed; all projects built successfully.
- The test output contains the adjacent app executable and PRI resources, and the scanner launches that executable rather than constructing page objects in the test process.

## Review

AutoReview identified two valid gaps in the initial rewrite: native Chat coverage and positive proof that each deep link reached its target. Both were fixed. A later pass caught that Chat still rendered only its disconnected placeholder; the deterministic provider and real composer marker fixed that. Final review after validation and localization corrections: no accepted or actionable findings.
