### PR TITLE
Hide completed sessions by default

### DIFF
--- a/src/OpenClaw.Shared/SettingsData.cs
+++ b/src/OpenClaw.Shared/SettingsData.cs
@@ -127,6 +127,13 @@ public record class SettingsData
     /// "User interface" section.
     /// </summary>
     public bool UseLegacyWebChat { get; set; } = false;
+    /// <summary>
+    /// When false, the tray Sessions page hides clean completed sessions
+    /// (currently status <c>done</c> / <c>completed</c>) while keeping failed,
+    /// killed, timeout, and aborted runs visible. Default false reduces
+    /// completed ACP/subagent clutter for upgraded installs.
+    /// </summary>
+    public bool ShowCompletedSessions { get; set; } = false;
     public string AppTheme { get; set; } = "System";
     public bool? ShowDiagnostics { get; set; }
     public List<UserNotificationRule>? UserRules { get; set; }

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
@@ -23,6 +23,7 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
 
                     <SelectorBar x:Name="ChannelSelector" Grid.Column="0"
@@ -31,7 +32,14 @@
                         <SelectorBarItem x:Uid="SessionsPage_All" x:Name="AllTab" Text="All" IsSelected="True"/>
                     </SelectorBar>
 
-                    <Button x:Name="RefreshButton" Grid.Column="1"
+                    <ToggleSwitch x:Uid="SessionsPage_ShowCompleted" x:Name="ShowCompletedToggle" Grid.Column="1"
+                                  Header="Show completed"
+                                  MinWidth="0"
+                                  OnContent="" OffContent=""
+                                  Toggled="OnShowCompletedToggled"
+                                  AutomationProperties.AutomationId="SessionsPageShowCompleted"/>
+
+                    <Button x:Name="RefreshButton" Grid.Column="2"
                             Click="OnRefresh"
                             ToolTipService.ToolTip="Refresh sessions"
                             AutomationProperties.Name="Refresh sessions">

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -26,6 +26,7 @@ public sealed partial class SessionsPage : Page
     private readonly AsyncListLoadingState _sessionLoading = new();
     private IOperatorGatewayClient? _subscribedClient;
     private bool _unloaded;
+    private bool _syncingShowCompletedToggle;
 
     public SessionsPage()
     {
@@ -50,6 +51,7 @@ public sealed partial class SessionsPage : Page
         if (_appState != null) _appState.PropertyChanged -= OnAppStateChanged;
         _appState = CurrentApp.AppState!;
         _appState.PropertyChanged += OnAppStateChanged;
+        SyncShowCompletedToggle();
 
         var client = CurrentApp.GatewayClient;
 
@@ -119,7 +121,8 @@ public sealed partial class SessionsPage : Page
     {
         if (_allSessions == null) return;
 
-        var channels = _allSessions
+        var visibleSessions = SessionVisibilityFilter.VisibleSessions(_allSessions, ShowCompletedSessions);
+        var channels = visibleSessions
             .Where(s => !string.IsNullOrWhiteSpace(s.Channel))
             .Select(s => s.Channel!)
             .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -150,6 +153,7 @@ public sealed partial class SessionsPage : Page
         }
 
         IEnumerable<SessionInfo> filtered = _allSessions ?? Array.Empty<SessionInfo>();
+        filtered = SessionVisibilityFilter.VisibleSessions(filtered, ShowCompletedSessions);
 
         if (_activeChannel != "all")
         {
@@ -178,6 +182,35 @@ public sealed partial class SessionsPage : Page
         LoadingState.Visibility = _sessionLoading.ShouldShowLoading ? Visibility.Visible : Visibility.Collapsed;
         RefreshButton.IsEnabled = CurrentApp.GatewayClient != null && _sessionLoading.CanEdit;
         ChannelSelector.IsEnabled = _sessionLoading.HasLoaded && _sessionLoading.CanEdit;
+    }
+
+    private bool ShowCompletedSessions => CurrentApp.Settings?.ShowCompletedSessions ?? false;
+
+    private void SyncShowCompletedToggle()
+    {
+        _syncingShowCompletedToggle = true;
+        try
+        {
+            ShowCompletedToggle.IsOn = ShowCompletedSessions;
+        }
+        finally
+        {
+            _syncingShowCompletedToggle = false;
+        }
+    }
+
+    private void OnShowCompletedToggled(object sender, RoutedEventArgs e)
+    {
+        if (_syncingShowCompletedToggle)
+            return;
+
+        if (CurrentApp.Settings is { } settings)
+        {
+            settings.ShowCompletedSessions = ShowCompletedToggle.IsOn;
+            settings.Save();
+        }
+        RebuildChannelTabs();
+        ApplyFilter();
     }
 
     private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -121,6 +121,7 @@ public sealed partial class SessionsPage : Page
     {
         if (_allSessions == null) return;
 
+        var requestedChannel = _activeChannel;
         var visibleSessions = SessionVisibilityFilter.VisibleSessions(_allSessions, ShowCompletedSessions);
         var channels = visibleSessions
             .Where(s => !string.IsNullOrWhiteSpace(s.Channel))
@@ -128,15 +129,23 @@ public sealed partial class SessionsPage : Page
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(c => c)
             .ToList();
+        var activeChannel = SessionVisibilityFilter.ResolveActiveChannel(requestedChannel, channels);
 
         // Keep "All" tab, clear dynamic tabs
         while (ChannelSelector.Items.Count > 1)
             ChannelSelector.Items.RemoveAt(ChannelSelector.Items.Count - 1);
 
+        SelectorBarItem selectedItem = AllTab;
         foreach (var ch in channels)
         {
-            ChannelSelector.Items.Add(new SelectorBarItem { Text = ch });
+            var item = new SelectorBarItem { Text = ch };
+            ChannelSelector.Items.Add(item);
+            if (string.Equals(ch, activeChannel, StringComparison.OrdinalIgnoreCase))
+                selectedItem = item;
         }
+
+        _activeChannel = activeChannel;
+        selectedItem.IsSelected = true;
     }
 
     private void ApplyFilter()

--- a/src/OpenClaw.Tray.WinUI/Services/SessionVisibilityFilter.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SessionVisibilityFilter.cs
@@ -1,0 +1,22 @@
+using OpenClaw.Shared;
+
+namespace OpenClawTray.Services;
+
+public static class SessionVisibilityFilter
+{
+    public static IEnumerable<SessionInfo> VisibleSessions(IEnumerable<SessionInfo> sessions, bool showCompleted)
+        => showCompleted ? sessions : sessions.Where(IsVisibleWhenCompletedHidden);
+
+    public static bool IsVisibleWhenCompletedHidden(SessionInfo session)
+        => !IsCleanCompleted(session);
+
+    public static bool IsCleanCompleted(SessionInfo session)
+    {
+        if (session.AbortedLastRun)
+            return false;
+
+        var status = session.Status?.Trim();
+        return string.Equals(status, "done", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(status, "completed", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/SessionVisibilityFilter.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SessionVisibilityFilter.cs
@@ -19,4 +19,15 @@ public static class SessionVisibilityFilter
         return string.Equals(status, "done", StringComparison.OrdinalIgnoreCase)
             || string.Equals(status, "completed", StringComparison.OrdinalIgnoreCase);
     }
+
+    public static string ResolveActiveChannel(string activeChannel, IEnumerable<string> visibleChannels)
+    {
+        if (!string.Equals(activeChannel, "all", StringComparison.OrdinalIgnoreCase)
+            && visibleChannels.Any(channel => string.Equals(channel, activeChannel, StringComparison.OrdinalIgnoreCase)))
+        {
+            return activeChannel;
+        }
+
+        return "all";
+    }
 }

--- a/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
@@ -89,6 +89,7 @@ public class SettingsManager
     /// Default false (native).
     /// </summary>
     public bool UseLegacyWebChat { get => _data.UseLegacyWebChat; set => _data = _data with { UseLegacyWebChat = value }; }
+    public bool ShowCompletedSessions { get => _data.ShowCompletedSessions; set => _data = _data with { ShowCompletedSessions = value }; }
     public string AppTheme { get => NormalizeAppTheme(_data.AppTheme); set => _data = _data with { AppTheme = NormalizeAppTheme(value) }; }
     public bool? ShowDiagnosticsOverride { get => _data.ShowDiagnostics; set => _data = _data with { ShowDiagnostics = value }; }
     public bool ShowDiagnosticsEffective => _data.ShowDiagnostics ?? OpenClawTray.Helpers.DiagnosticsGate.BuildDefault;
@@ -247,6 +248,7 @@ public class SettingsManager
         PreferStructuredCategories = true,
         UserRules = new(),
         UseLegacyWebChat = false,
+        ShowCompletedSessions = false,
         AppTheme = AppThemeSystem,
         EnableNodeMode = false,
         NodeCanvasEnabled = true,

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -4620,6 +4620,9 @@ Commands are blocked while sandboxing is unavailable because strict fallback blo
   <data name="SessionsPage_All.Text" xml:space="preserve">
     <value>All</value>
   </data>
+  <data name="SessionsPage_ShowCompleted.Header" xml:space="preserve">
+    <value>Show completed</value>
+  </data>
   <data name="SessionsPage_GatewayDisconnected.Title" xml:space="preserve">
     <value>Gateway disconnected</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -4573,6 +4573,9 @@ Les commandes sont bloquées tant que le sandboxing est indisponible, car le blo
   <data name="SessionsPage_All.Text" xml:space="preserve">
     <value>Tous</value>
   </data>
+  <data name="SessionsPage_ShowCompleted.Header" xml:space="preserve">
+    <value>Afficher les sessions terminées</value>
+  </data>
   <data name="SessionsPage_GatewayDisconnected.Title" xml:space="preserve">
     <value>Passerelle déconnectée</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -4574,6 +4574,9 @@ Opdrachten worden geblokkeerd zolang sandboxing niet beschikbaar is, omdat strik
   <data name="SessionsPage_All.Text" xml:space="preserve">
     <value>Alle</value>
   </data>
+  <data name="SessionsPage_ShowCompleted.Header" xml:space="preserve">
+    <value>Voltooide sessies tonen</value>
+  </data>
   <data name="SessionsPage_GatewayDisconnected.Title" xml:space="preserve">
     <value>Gateway losgekoppeld</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -4573,6 +4573,9 @@
   <data name="SessionsPage_All.Text" xml:space="preserve">
     <value>全部</value>
   </data>
+  <data name="SessionsPage_ShowCompleted.Header" xml:space="preserve">
+    <value>显示已完成的会话</value>
+  </data>
   <data name="SessionsPage_GatewayDisconnected.Title" xml:space="preserve">
     <value>网关已断开</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -4573,6 +4573,9 @@
   <data name="SessionsPage_All.Text" xml:space="preserve">
     <value>全部</value>
   </data>
+  <data name="SessionsPage_ShowCompleted.Header" xml:space="preserve">
+    <value>顯示已完成的工作階段</value>
+  </data>
   <data name="SessionsPage_GatewayDisconnected.Title" xml:space="preserve">
     <value>閘道已中斷</value>
   </data>

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\DiagnosticsLogTailReader.cs" Link="Services\DiagnosticsLogTailReader.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\DiagnosticsBundleBuilder.cs" Link="Services\DiagnosticsBundleBuilder.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SettingsManager.cs" Link="Services\SettingsManager.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SessionVisibilityFilter.cs" Link="Services\SessionVisibilityFilter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\OnboardingChatBootstrapper.cs" Link="Services\OnboardingChatBootstrapper.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\StartupSetupState.cs" Link="Services\StartupSetupState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SetupExistingGatewayClassifier.cs" Link="Services\SetupExistingGatewayClassifier.cs" />

--- a/tests/OpenClaw.Tray.Tests/SessionVisibilityFilterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SessionVisibilityFilterTests.cs
@@ -1,0 +1,82 @@
+using OpenClaw.Shared;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public class SessionVisibilityFilterTests
+{
+    [Theory]
+    [InlineData("done")]
+    [InlineData("DONE")]
+    [InlineData(" completed ")]
+    public void IsCleanCompleted_RecognizesSuccessfulCompletedStatuses(string status)
+    {
+        var session = new SessionInfo { Status = status };
+
+        Assert.True(SessionVisibilityFilter.IsCleanCompleted(session));
+        Assert.False(SessionVisibilityFilter.IsVisibleWhenCompletedHidden(session));
+    }
+
+    [Theory]
+    [InlineData("failed")]
+    [InlineData("killed")]
+    [InlineData("timeout")]
+    [InlineData("running")]
+    [InlineData("unknown")]
+    public void IsCleanCompleted_LeavesNonSuccessfulTerminalAndActiveStatusesVisible(string status)
+    {
+        var session = new SessionInfo { Status = status };
+
+        Assert.False(SessionVisibilityFilter.IsCleanCompleted(session));
+        Assert.True(SessionVisibilityFilter.IsVisibleWhenCompletedHidden(session));
+    }
+
+    [Fact]
+    public void IsCleanCompleted_KeepsAbortedDoneSessionsVisible()
+    {
+        var session = new SessionInfo
+        {
+            Status = "done",
+            AbortedLastRun = true,
+        };
+
+        Assert.False(SessionVisibilityFilter.IsCleanCompleted(session));
+        Assert.True(SessionVisibilityFilter.IsVisibleWhenCompletedHidden(session));
+    }
+
+    [Fact]
+    public void VisibleSessions_HidesOnlyCleanCompletedSessionsByDefault()
+    {
+        var sessions = new[]
+        {
+            new SessionInfo { Key = "done", Status = "done" },
+            new SessionInfo { Key = "failed", Status = "failed" },
+            new SessionInfo { Key = "killed", Status = "killed" },
+            new SessionInfo { Key = "timeout", Status = "timeout" },
+            new SessionInfo { Key = "aborted-done", Status = "done", AbortedLastRun = true },
+            new SessionInfo { Key = "running", Status = "running" },
+        };
+
+        var visible = SessionVisibilityFilter.VisibleSessions(sessions, showCompleted: false)
+            .Select(s => s.Key)
+            .ToArray();
+
+        Assert.Equal(new[] { "failed", "killed", "timeout", "aborted-done", "running" }, visible);
+    }
+
+    [Fact]
+    public void VisibleSessions_ShowCompletedPreservesAllSessions()
+    {
+        var sessions = new[]
+        {
+            new SessionInfo { Key = "done", Status = "done" },
+            new SessionInfo { Key = "failed", Status = "failed" },
+        };
+
+        var visible = SessionVisibilityFilter.VisibleSessions(sessions, showCompleted: true)
+            .Select(s => s.Key)
+            .ToArray();
+
+        Assert.Equal(new[] { "done", "failed" }, visible);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/SessionVisibilityFilterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SessionVisibilityFilterTests.cs
@@ -79,4 +79,16 @@ public class SessionVisibilityFilterTests
 
         Assert.Equal(new[] { "done", "failed" }, visible);
     }
+
+    [Theory]
+    [InlineData("all", "all")]
+    [InlineData("Slack", "Slack")]
+    [InlineData("slack", "slack")]
+    [InlineData("missing", "all")]
+    public void ResolveActiveChannel_PreservesOnlyVisibleChannels(string activeChannel, string expected)
+    {
+        var visibleChannels = new[] { "Slack", "WhatsApp" };
+
+        Assert.Equal(expected, SessionVisibilityFilter.ResolveActiveChannel(activeChannel, visibleChannels));
+    }
 }

--- a/tests/OpenClaw.Tray.Tests/SettingsRoundTripTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SettingsRoundTripTests.cs
@@ -58,6 +58,7 @@ public class SettingsRoundTripTests
             PreferStructuredCategories = true,
             AppTheme = "Dark",
             ShowDiagnostics = true,
+            ShowCompletedSessions = true,
             SystemRunSandboxEnabled = true,
             SystemRunBlockHostFallbackWhenMxcUnavailable = true,
             SystemRunAllowOutbound = true,
@@ -119,6 +120,7 @@ public class SettingsRoundTripTests
         Assert.Equal(original.PreferStructuredCategories, restored.PreferStructuredCategories);
         Assert.Equal(original.AppTheme, restored.AppTheme);
         Assert.Equal(original.ShowDiagnostics, restored.ShowDiagnostics);
+        Assert.Equal(original.ShowCompletedSessions, restored.ShowCompletedSessions);
         Assert.Equal(original.SystemRunSandboxEnabled, restored.SystemRunSandboxEnabled);
         Assert.Equal(original.SystemRunBlockHostFallbackWhenMxcUnavailable, restored.SystemRunBlockHostFallbackWhenMxcUnavailable);
         Assert.Equal(original.SystemRunAllowOutbound, restored.SystemRunAllowOutbound);
@@ -189,6 +191,7 @@ public class SettingsRoundTripTests
         Assert.True(settings.PreferStructuredCategories);
         Assert.Equal("System", settings.AppTheme);
         Assert.Null(settings.ShowDiagnostics);
+        Assert.False(settings.ShowCompletedSessions);
         Assert.True(settings.SystemRunSandboxEnabled);
         Assert.False(settings.SystemRunBlockHostFallbackWhenMxcUnavailable);
         Assert.False(settings.SystemRunAllowOutbound);


### PR DESCRIPTION
Addresses the tray UI portion of #881. ACP lifecycle/archive semantics and a cross-surface gateway config remain separate follow-up work in that issue.

Adds a persisted **Show completed** toggle on the Sessions page and hides clean completed sessions by default. Failed, killed, timed-out, running, unknown, and aborted sessions stay visible. The localized toggle restores completed sessions without changing gateway state.

Maintainer review also preserves the selected channel when session data or completed visibility rebuilds the tabs; selection falls back to **All** only when that channel no longer has a visible session.

## Validation

Validated on `499fd23a` in a Windows 11 Pro ARM64 Parallels VM:

- `build.ps1` ✅ Shared, CLI, WinNode CLI, SetupEngine, WinUI
- Focused visibility/settings tests ✅ **36 passed**
- Full `OpenClaw.Tray.Tests` ✅ **1531 passed**
- AutoReview ✅ no accepted/actionable findings (0.94 confidence)
- Existing GitHub Actions checks were green before the maintainer update; exact-head checks are rerunning.

## Real behavior proof

Windows UI Automation against the built Sessions page verified:

```json
{
  "default": {
    "name": "Show completed",
    "automationId": "SessionsPageShowCompleted",
    "enabled": true,
    "offscreen": false,
    "state": "Off"
  },
  "toggle": {
    "before": "Off",
    "after": "On",
    "persistedShowCompletedSessions": true
  },
  "restart": {
    "state": "On",
    "persistedShowCompletedSessions": true,
    "offscreen": false
  }
}
```

Focused behavior tests cover `done`/`completed` hidden by default; failed/killed/timeout/running/unknown/aborted sessions visible; **Show completed** restoring all sessions; and selected-channel preservation/fallback.
