### PR TITLE
fix: keep winget output out of Inno path

### DIFF
--- a/scripts/build-inno-local.ps1
+++ b/scripts/build-inno-local.ps1
@@ -66,8 +66,9 @@ function Resolve-InnoCompiler {
 
     if ($InstallInno) {
         Write-Step "Installing Inno Setup with winget"
-        winget install --id JRSoftware.InnoSetup -e --accept-source-agreements --accept-package-agreements --disable-interactivity
-        if ($LASTEXITCODE -ne 0) {
+        winget install --id JRSoftware.InnoSetup -e --accept-source-agreements --accept-package-agreements --disable-interactivity 2>&1 | Out-Host
+        $wingetExitCode = $LASTEXITCODE
+        if ($wingetExitCode -ne 0) {
             throw "winget failed to install Inno Setup."
         }
         return Resolve-InnoCompiler

--- a/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
@@ -166,6 +166,8 @@ public sealed class InstallerIssAssertionTests
         Assert.Contains("$args += \"/DDevBuild=1\"", script);
         Assert.Contains("app-identity.txt", script);
         Assert.Contains("Payload identity", script);
+        Assert.Contains("2>&1 | Out-Host", script);
+        Assert.Contains("$wingetExitCode = $LASTEXITCODE", script);
         Assert.Contains("WritePublishedAppIdentityMarker", project);
         Assert.Contains("<AppIdentityMarker>dev</AppIdentityMarker>", project);
         Assert.Contains("<AppIdentityMarker>release</AppIdentityMarker>", project);


### PR DESCRIPTION
## Summary

- keep `winget` stdout/stderr visible without returning it from `Resolve-InnoCompiler`
- capture the native exit code before PowerShell runs another command
- pin the first-run install contract with installer build assertions

## Validation

- Windows 11 ARM64 VM: `InstallerIssAssertionTests` 12/12 passed
- AutoReview: clean; no accepted/actionable findings

Found while building a fresh side-by-side dev installer for the onboarding VM pass.
