### PR TITLE
Make dev app identity opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ dotnet build src/OpenClaw.Tray.WinUI -r win-x64 -p:PackageMsix=true    # x64 MSI
 # Run isolated from your normal tray settings so multiple worktrees can run together
 .\run-app-local.ps1 -Isolated
 
+# Opt into side-by-side dev identity (separate mutex, protocol, gateway distro, and port)
+.\run-app-local.ps1 -Dev -Isolated
+
 # Alpha update testing from a Release build
 .\run-app-local.ps1 -Configuration Release -Isolated -UpdateChannel alpha
 

--- a/build.ps1
+++ b/build.ps1
@@ -16,6 +16,10 @@
 .PARAMETER CheckOnly
     Only check prerequisites, don't build
 
+.PARAMETER DevBuild
+    Build the WinUI app with the side-by-side dev identity. Defaults off so
+    release identity remains the default for every configuration.
+
 .PARAMETER NoTrustRepository
     Do not automatically add this checkout to git safe.directory when GitVersion
     cannot read a repo owned by a different Windows account/group. The script
@@ -35,6 +39,8 @@ param(
     [string]$Configuration = "Debug",
     
     [switch]$CheckOnly,
+
+    [switch]$DevBuild,
 
     [switch]$NoTrustRepository
 )
@@ -353,6 +359,9 @@ function Build-Project($name, $path, $useRid = $false) {
     if ($useRid) {
         $dotnetArgs += @("-r", $rid)
     }
+    if ($DevBuild -and ($name -eq "WinUI" -or $name -eq "Tray")) {
+        $dotnetArgs += "-p:DevBuild=true"
+    }
     $result = Invoke-DotNetCaptured $dotnetArgs
     $exitCode = $LASTEXITCODE
     
@@ -450,9 +459,11 @@ if ($failCount -eq 0) {
         if ($winUITargetFramework) {
             $winUIOutputDirectory = ".\$winUIProjectDirectory\bin\$Configuration\$winUITargetFramework\$rid"
             $winUIManifestPath = ".\$winUIProjectDirectory\Package.appxmanifest"
-            Write-Host "  WinUI:    .\run-app-local.ps1 -NoBuild" -ForegroundColor White
-            Write-Host "  Isolated: .\run-app-local.ps1 -NoBuild -Isolated" -ForegroundColor White
-            Write-Host "  WinApp:   .\run-app-local.ps1 -NoBuild -UseWinApp" -ForegroundColor White
+            $runIdentitySwitch = if ($DevBuild) { " -Dev" } else { "" }
+            Write-Host "  WinUI:    .\run-app-local.ps1 -NoBuild$runIdentitySwitch" -ForegroundColor White
+            Write-Host "  Isolated: .\run-app-local.ps1 -NoBuild -Isolated$runIdentitySwitch" -ForegroundColor White
+            Write-Host "  Dev:      .\run-app-local.ps1 -Dev" -ForegroundColor White
+            Write-Host "  WinApp:   .\run-app-local.ps1 -NoBuild -UseWinApp$runIdentitySwitch" -ForegroundColor White
             Write-Host "            Direct launch is default. -UseWinApp runs: winapp run `"$winUIOutputDirectory`" --manifest `"$winUIManifestPath`" --executable `"OpenClaw.Tray.WinUI.exe`" --debug-output" -ForegroundColor DarkGray
         } else {
             Write-Warning "Unable to determine WinUI target framework from $winUIProjectPath"

--- a/run-app-local.ps1
+++ b/run-app-local.ps1
@@ -9,8 +9,9 @@
     Use -UseWinApp when you specifically want Microsoft WinAppCLI (`winapp run`)
     to launch with Package.appxmanifest for packaged/MSIX-adjacent validation.
 
-    Use -Isolated (or -DataDir) to run multiple worktrees side-by-side without
-    sharing settings, logs, run markers, device identities, or mutex names.
+    Use -Isolated (or -DataDir) to avoid sharing settings, logs, run markers,
+    and device identities. Use -Dev to opt into the side-by-side dev app
+    identity with separate mutex, protocol, gateway distro, and gateway port.
 
     By default this helper refuses to run outside `main` to avoid accidentally
     launching a stale or experimental worktree. Use -AllowNonMain when you
@@ -21,6 +22,10 @@
 
 .PARAMETER Configuration
     Build/output configuration to use. Defaults to Debug.
+
+.PARAMETER Dev
+    Build and launch with the side-by-side dev app identity. Defaults off so
+    release identity remains the default local-launch behavior.
 
 .PARAMETER AllowNonMain
     Allow launching from a branch other than main.
@@ -60,6 +65,9 @@
     .\run-app-local.ps1 -Isolated
 
 .EXAMPLE
+    .\run-app-local.ps1 -Dev -Isolated
+
+.EXAMPLE
     .\run-app-local.ps1 -Configuration Release -Isolated -UpdateChannel alpha -AllowNonMain
 
 .EXAMPLE
@@ -71,6 +79,8 @@ param(
 
     [ValidateSet("Debug", "Release")]
     [string]$Configuration = "Debug",
+
+    [switch]$Dev,
 
     [switch]$AllowNonMain,
 
@@ -132,7 +142,12 @@ if ($branch -ne "main" -and -not $AllowNonMain) {
 }
 
 if (-not $NoBuild) {
-    & "$repoRoot\build.ps1" -Configuration $Configuration
+    $buildArgs = @("-Configuration", $Configuration)
+    if ($Dev) {
+        $buildArgs += "-DevBuild"
+    }
+
+    & "$repoRoot\build.ps1" @buildArgs
     if ($LASTEXITCODE -ne 0) {
         exit $LASTEXITCODE
     }
@@ -159,12 +174,22 @@ $runtimeIdentifier = switch ($architecture) {
 }
 $outputDir = Join-Path $repoRoot "src\OpenClaw.Tray.WinUI\bin\$Configuration\$targetFramework\$runtimeIdentifier"
 $exePath = Join-Path $outputDir "OpenClaw.Tray.WinUI.exe"
+$identityMarkerPath = Join-Path $outputDir "app-identity.txt"
 
 if (-not (Test-Path $outputDir)) {
     throw "Build output folder not found: $outputDir. Run without -NoBuild first."
 }
 if (-not (Test-Path $exePath)) {
     throw "Tray executable not found: $exePath. Run without -NoBuild first."
+}
+if (-not (Test-Path $identityMarkerPath)) {
+    throw "App identity marker not found: $identityMarkerPath. Run without -NoBuild first."
+}
+
+$expectedIdentity = if ($Dev) { "dev" } else { "release" }
+$actualIdentity = (Get-Content -LiteralPath $identityMarkerPath -Raw -Encoding UTF8).Trim()
+if ($actualIdentity -ne $expectedIdentity) {
+    throw "Build output identity '$actualIdentity' does not match requested '$expectedIdentity'. Run without -NoBuild or choose the matching -Dev option."
 }
 
 $winapp = $null
@@ -213,6 +238,7 @@ try {
     Write-Host "Launching OpenClaw Tray" -ForegroundColor Cyan
     Write-Host "  Branch:        $branch"
     Write-Host "  Configuration: $Configuration"
+    Write-Host "  Identity:      $(if ($actualIdentity -eq 'dev') { 'Dev (opt-in)' } else { 'Release (default)' })"
     Write-Host "  Runtime:       $runtimeIdentifier"
     Write-Host "  Output:        $outputDir"
     Write-Host "  Mode:          $(if ($UseWinApp) { 'WinAppCLI manifest activation' } else { 'Direct unpackaged executable' })"

--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -15,10 +15,7 @@
   </PropertyGroup>
 
   <!-- Dev build identity: allows side-by-side installation with Release.
-       Set DevBuild=true explicitly, or it defaults to true for Debug configuration. -->
-  <PropertyGroup Condition="'$(DevBuild)' == '' And '$(Configuration)' == 'Debug'">
-    <DevBuild>true</DevBuild>
-  </PropertyGroup>
+       Set DevBuild=true explicitly; release identity remains the default for every configuration. -->
   <PropertyGroup Condition="'$(DevBuild)' == 'true'">
     <DefineConstants>$(DefineConstants);DEV_BUILD</DefineConstants>
     <AppIdentityMarker>dev</AppIdentityMarker>
@@ -218,6 +215,14 @@
   <Target Name="WritePublishedAppIdentityMarker" AfterTargets="Publish">
     <WriteLinesToFile
       File="$(PublishDir)app-identity.txt"
+      Lines="$(AppIdentityMarker)"
+      Overwrite="true"
+      Encoding="UTF-8" />
+  </Target>
+
+  <Target Name="WriteBuildAppIdentityMarker" AfterTargets="Build">
+    <WriteLinesToFile
+      File="$(TargetDir)app-identity.txt"
       Lines="$(AppIdentityMarker)"
       Overwrite="true"
       Encoding="UTF-8" />

--- a/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
@@ -158,6 +158,8 @@ public sealed class InstallerIssAssertionTests
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();
         var script = File.ReadAllText(Path.Combine(root, "scripts", "build-inno-local.ps1"));
+        var runScript = File.ReadAllText(Path.Combine(root, "run-app-local.ps1"));
+        var buildScript = File.ReadAllText(Path.Combine(root, "build.ps1"));
         var project = File.ReadAllText(Path.Combine(
             root, "src", "OpenClaw.Tray.WinUI", "OpenClaw.Tray.WinUI.csproj"));
 
@@ -168,9 +170,19 @@ public sealed class InstallerIssAssertionTests
         Assert.Contains("Payload identity", script);
         Assert.Contains("2>&1 | Out-Host", script);
         Assert.Contains("$wingetExitCode = $LASTEXITCODE", script);
+        Assert.Contains("[switch]$Dev,", runScript);
+        Assert.Contains("$buildArgs += \"-DevBuild\"", runScript);
+        Assert.Contains("app-identity.txt", runScript);
+        Assert.Contains("does not match requested", runScript);
+        Assert.Contains("[switch]$DevBuild,", buildScript);
+        Assert.Contains("$dotnetArgs += \"-p:DevBuild=true\"", buildScript);
+        Assert.Contains("-UseWinApp$runIdentitySwitch", buildScript);
         Assert.Contains("WritePublishedAppIdentityMarker", project);
+        Assert.Contains("WriteBuildAppIdentityMarker", project);
         Assert.Contains("<AppIdentityMarker>dev</AppIdentityMarker>", project);
         Assert.Contains("<AppIdentityMarker>release</AppIdentityMarker>", project);
+        Assert.DoesNotContain("'$(Configuration)' == 'Debug'", project);
+        Assert.DoesNotContain("<DevBuild>true</DevBuild>", project);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- keep release app identity as the default for every build configuration
- add explicit dev identity opt-ins via `build.ps1 -DevBuild` and `run-app-local.ps1 -Dev`
- write and validate `app-identity.txt` for normal build output so `-NoBuild` cannot launch the wrong identity
- document the side-by-side dev launch path

## Validation
- `./build.ps1`
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — 2697 passed / 31 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — 1579 passed
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore --filter FullyQualifiedName~InstallerIssAssertionTests` — 12 passed
- `./build.ps1 -Project WinUI -DevBuild`

## Real behavior proof
- Default build/run path writes and accepts `app-identity.txt=release`; `./run-app-local.ps1 -NoBuild -DryRun` reports `Identity: Release (default)`.
- Dev build/run path writes and accepts `app-identity.txt=dev`; `./run-app-local.ps1 -NoBuild -Dev -DryRun` reports `Identity: Dev (opt-in)`.
- Mismatch proof: `./run-app-local.ps1 -NoBuild -Dev -DryRun` rejects release output, and `./run-app-local.ps1 -NoBuild -DryRun` rejects dev output with `Build output identity ... does not match requested ...`.
- Rubber-duck/code-review pass found no remaining blocking findings after the WinApp dev hint was fixed.