### PR TITLE
Add DevBuild identity CI marker check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,25 @@ jobs:
           "All pages passed Axe.Windows accessibility validation." >> $env:GITHUB_STEP_SUMMARY
         }
 
+    - name: Verify DevBuild identity marker
+      shell: pwsh
+      run: |
+        dotnet build src/OpenClaw.Tray.WinUI -c Debug -r win-x64 -p:DevBuild=true --no-restore
+        $marker = Get-ChildItem -Path src\OpenClaw.Tray.WinUI\bin\Debug -Recurse -Filter app-identity.txt |
+          Where-Object { $_.FullName -like '*\win-x64\app-identity.txt' } |
+          Sort-Object LastWriteTimeUtc -Descending |
+          Select-Object -First 1
+        if ($null -eq $marker) {
+          throw "Dev identity marker was not produced by the DevBuild."
+        }
+
+        $identity = (Get-Content -LiteralPath $marker.FullName -Raw).Trim()
+        if ($identity -ne "dev") {
+          throw "Expected DevBuild identity marker 'dev' but found '$identity' at $($marker.FullName)."
+        }
+
+        Write-Host "DevBuild identity marker verified at $($marker.FullName): $identity"
+
     - name: Upload Test Results
       if: always()
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- Adds a CI guard that explicitly builds the WinUI tray app with `-p:DevBuild=true`.
- Verifies the generated `app-identity.txt` marker contains `dev`, so dev identity remains opt-in and covered.

Closes #934.

## Validation

- `.\build.ps1` — passed.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` — 2703 passed / 31 skipped.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` — 1584 passed.
- `dotnet build .\src\OpenClaw.Tray.WinUI -c Debug -r win-x64 -p:DevBuild=true --no-restore` plus marker assertion — `app-identity.txt: dev`.
- `git --no-pager diff --check` — passed.

## Real behavior proof

The new CI command was run locally and verified the DevBuild output marker at `src\OpenClaw.Tray.WinUI\bin\Debug\net10.0-windows10.0.22621.0\win-x64\app-identity.txt` contains `dev`.

## Notes

This does not change product behavior. It only adds CI coverage for the already-explicit DevBuild identity path.