### PR TITLE
Fix run-app-local build argument forwarding

### DIFF
--- a/run-app-local.ps1
+++ b/run-app-local.ps1
@@ -142,9 +142,11 @@ if ($branch -ne "main" -and -not $AllowNonMain) {
 }
 
 if (-not $NoBuild) {
-    $buildArgs = @("-Configuration", $Configuration)
+    $buildArgs = @{
+        Configuration = $Configuration
+    }
     if ($Dev) {
-        $buildArgs += "-DevBuild"
+        $buildArgs["DevBuild"] = $true
     }
 
     & "$repoRoot\build.ps1" @buildArgs

--- a/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
@@ -171,7 +171,9 @@ public sealed class InstallerIssAssertionTests
         Assert.Contains("2>&1 | Out-Host", script);
         Assert.Contains("$wingetExitCode = $LASTEXITCODE", script);
         Assert.Contains("[switch]$Dev,", runScript);
-        Assert.Contains("$buildArgs += \"-DevBuild\"", runScript);
+        Assert.Contains("$buildArgs = @{", runScript);
+        Assert.Contains("Configuration = $Configuration", runScript);
+        Assert.Contains("$buildArgs[\"DevBuild\"] = $true", runScript);
         Assert.Contains("app-identity.txt", runScript);
         Assert.Contains("does not match requested", runScript);
         Assert.Contains("[switch]$DevBuild,", buildScript);


### PR DESCRIPTION
## Summary

- Fixes `run-app-local.ps1` so its default build path forwards `Configuration` to `build.ps1` by name instead of accidentally binding `-Configuration` as the positional `Project` argument.
- Keeps `-Dev` forwarding explicit through the existing `DevBuild` switch.
- Updates the existing source-contract test that guards local launcher identity wiring.

## Validation

- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore --filter "FullyQualifiedName~LocalInstallerBuild_UsesOneIdentitySwitchAndValidatesPayloadMarker"` — passed: 1.
- `.\run-app-local.ps1 -DryRun -Configuration Debug` — passed after stopping the previously launched tray process that locked the output assembly.
- `.\build.ps1` — passed.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` — passed: 2703 passed / 31 skipped.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` — passed: 1584 passed.

## Real behavior proof

- `run-app-local.ps1` default build path now invokes `build.ps1` successfully without mis-binding `-Configuration`.
- Non-isolated release/default local launch from `main` succeeded after the fix.