### PR TITLE
Remove Notifications from sidebar

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2288,9 +2288,6 @@ Use one of these options:
   <data name="HubWindow_NavigationViewItem_145.Content" xml:space="preserve">
     <value>Diagnostics</value>
   </data>
-<data name="HubWindow_NavigationViewItem_Notifications.Content" xml:space="preserve">
-  <value>Notifications</value>
-  </data>
 <data name="Onboarding_UnknownPage" xml:space="preserve">
   <value>Unknown page</value>
 </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2241,9 +2241,6 @@ Utilisez l'une de ces options :
   <data name="HubWindow_NavigationViewItem_145.Content" xml:space="preserve">
     <value>Débogage</value>
   </data>
-  <data name="HubWindow_NavigationViewItem_Notifications.Content" xml:space="preserve">
-    <value>Alertes</value>
-  </data>
   <data name="Onboarding_UnknownPage" xml:space="preserve">
     <value>Page inconnue</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2242,9 +2242,6 @@ Gebruik een van deze opties:
   <data name="HubWindow_NavigationViewItem_145.Content" xml:space="preserve">
     <value>Foutopsporing</value>
   </data>
-  <data name="HubWindow_NavigationViewItem_Notifications.Content" xml:space="preserve">
-    <value>Meldingen</value>
-  </data>
   <data name="Onboarding_UnknownPage" xml:space="preserve">
     <value>Onbekende pagina</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2241,9 +2241,6 @@
   <data name="HubWindow_NavigationViewItem_145.Content" xml:space="preserve">
     <value>调试</value>
   </data>
-  <data name="HubWindow_NavigationViewItem_Notifications.Content" xml:space="preserve">
-    <value>通知</value>
-  </data>
   <data name="Onboarding_UnknownPage" xml:space="preserve">
     <value>未知页面</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2241,9 +2241,6 @@
   <data name="HubWindow_NavigationViewItem_145.Content" xml:space="preserve">
     <value>偵錯</value>
   </data>
-  <data name="HubWindow_NavigationViewItem_Notifications.Content" xml:space="preserve">
-    <value>通知</value>
-  </data>
   <data name="Onboarding_UnknownPage" xml:space="preserve">
     <value>未知頁面</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml
@@ -410,7 +410,6 @@
                 <SvgImageSource x:Key="Permissions_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Permissions.svg"/>
                 <SvgImageSource x:Key="Sandbox_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Sandbox.svg"/>
                 <SvgImageSource x:Key="Activity_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Activity.svg"/>
-                <SvgImageSource x:Key="Notifications_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Notifications.svg"/>
                 <SvgImageSource x:Key="Debug_Icon" UriSource="ms-appx:///Assets/SidebarIcons/Debug.svg"/>
             </NavigationView.Resources>
 
@@ -483,9 +482,6 @@
         </NavigationView.MenuItems>
 
         <NavigationView.FooterMenuItems>
-            <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_Notifications" Tag="notifications" Content="Notifications">
-                <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Notifications_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
-            </NavigationViewItem>
             <NavigationViewItem x:Uid="HubWindow_NavigationViewItem_145" x:Name="NavDiagnostics" Tag="debug" Content="Debug">
                 <NavigationViewItem.Icon><ImageIcon Source="{StaticResource Debug_Icon}" AutomationProperties.AccessibilityView="Raw"/></NavigationViewItem.Icon>
             </NavigationViewItem>


### PR DESCRIPTION
## Summary
- Remove the footer/sidebar Notifications navigation item so notifications are exposed only through the title-bar bell.
- Remove the now-unused sidebar Notifications icon resource from `HubWindow.xaml`.
- Remove stale localized resource entries for the deleted navigation label.

## Validation
- `git diff --check` — passed
- `./build.ps1` — passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — passed: 2703 passed, 31 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — passed: 1586 passed

## Real behavior proof
Runtime launch from current head succeeded with isolated tray data and opened the Hub window:

```text
Branch:        bkudiess-remove-sidebar-notifications
Configuration: Debug
Runtime:       win-arm64
Mode:          Direct unpackaged executable
Data dir:      C:\Users\bakudies\AppData\Local\Temp\OpenClawTray\proof-pr-943-hub
Started OpenClaw Tray (PID: 24108)
Window title:  OpenClaw Companion
```

Copied current-head Hub UI evidence from computer-use accessibility inspection:

```text
15 AXButton Notifications ID: NotificationsBellButton
22 AXGroup Main navigation ID: NavView
25 AXGroup Main navigation ID: MenuItemsHost
  26 AXStaticText Gateway
  27 AXRow (selected) Connection
  29 AXStaticText This Computer
  30 AXRow (selectable) Voice & Audio
  32 AXRow (selectable) Permissions
  34 AXRow (selectable) Sandbox
  36 AXRow (selectable) Settings
38 AXScrollArea ID: FooterItemsScrollViewer
  39 AXGroup ID: FooterMenuItemsHost
    40 AXRow (selectable) Diagnostics ID: NavDiagnostics
```

This shows the title-bar Notifications bell is still present while the navigation rail/footer contains no Notifications row; only Diagnostics remains in the footer. The isolated proof instance used `OPENCLAW_TRAY_DATA_DIR` so real `%APPDATA%\OpenClawTray` settings were not mutated.