### PR TITLE
Mirror connection status dot onto lobster tray and desktop icons

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -760,7 +760,10 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         // Pre-create tray menu window at startup to avoid creation crashes later
         InitializeTrayMenuWindow();
         
-        var iconPath = IconHelper.GetStatusIconPath(ConnectionStatus.Disconnected);
+        // Start with the status-badged lobster (neutral/gray dot) so the tray icon
+        // mirrors the companion-app status from first paint, even before the first
+        // connection-state update arrives.
+        var iconPath = StatusBadgeIconFactory.GetBadgedIconPath(ConnectionStatusAccent.Neutral);
         _trayIcon = new TrayIcon(1, iconPath, BuildTrayTooltip());
         _trayIconCoordinator = new TrayIconCoordinator(
             _trayIcon,

--- a/src/OpenClaw.Tray.WinUI/Helpers/StatusBadgeIconFactory.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/StatusBadgeIconFactory.cs
@@ -11,10 +11,16 @@ using System.Runtime.Versioning;
 namespace OpenClawTray.Helpers;
 
 /// <summary>
-/// Builds application icons that mirror the companion-app connection status dot:
-/// the lobster mascot with a coloured status dot rendered in the bottom-right
-/// corner. Composed icons are cached per <see cref="ConnectionStatusAccent"/> and
-/// written to a temp folder as multi-resolution .ico files so both the tray icon
+/// Builds application icons that surface the connection status on the lobster
+/// mascot as a small badge in the bottom-right corner. To avoid a distracting
+/// always-on indicator, only attention states are badged:
+/// <list type="bullet">
+///   <item>disconnected / neutral → a grey dot,</item>
+///   <item>error → a red dot with a white "-" (minus) glyph.</item>
+/// </list>
+/// Healthy states (connected, connecting) render the plain lobster with no badge.
+/// Composed icons are cached per <see cref="ConnectionStatusAccent"/> and written
+/// to a temp folder as multi-resolution .ico files so both the tray icon
 /// (<see cref="WinUIEx.TrayIcon.SetIcon(string)"/>) and the desktop/taskbar window
 /// icon (<c>Window.SetIcon(string)</c>) can consume them.
 /// </summary>
@@ -64,6 +70,18 @@ internal static class StatusBadgeIconFactory
         _ => Color.FromArgb(158, 158, 158),                              // Gray   – disconnected / neutral
     };
 
+    /// <summary>
+    /// Whether <paramref name="accent"/> gets a status badge. Only attention states
+    /// are badged so the icon is quiet when everything is healthy: disconnected
+    /// (neutral) and error (critical). Connected/connecting render the plain lobster.
+    /// </summary>
+    public static bool ShouldBadge(ConnectionStatusAccent accent) =>
+        accent is ConnectionStatusAccent.Neutral or ConnectionStatusAccent.Critical;
+
+    /// <summary>Whether the badge carries the "-" (minus) glyph. Only the error state does.</summary>
+    public static bool HasDash(ConnectionStatusAccent accent) =>
+        accent is ConnectionStatusAccent.Critical;
+
     private static (string Path, bool IsFallback) Build(ConnectionStatusAccent accent)
     {
         var fallback = Path.Combine(AssetsPath, "openclaw.ico");
@@ -72,8 +90,12 @@ internal static class StatusBadgeIconFactory
             Directory.CreateDirectory(OutputDir);
             var outputPath = Path.Combine(OutputDir, $"openclaw-{accent}".ToLowerInvariant() + ".ico");
 
+            // Only attention states (neutral/critical) get a dot; healthy states
+            // render the plain lobster (null dot colour).
+            Color? dotColor = ShouldBadge(accent) ? DotColor(accent) : null;
+
             using var baseImage = LoadBaseImage();
-            File.WriteAllBytes(outputPath, CreateIcoBytes(baseImage, DotColor(accent), Sizes));
+            File.WriteAllBytes(outputPath, CreateIcoBytes(baseImage, dotColor, HasDash(accent), Sizes));
             return (outputPath, false);
         }
         catch (Exception ex)
@@ -84,15 +106,16 @@ internal static class StatusBadgeIconFactory
     }
 
     /// <summary>
-    /// Composes the badged lobster at every requested size and packs the frames
-    /// into a single multi-resolution .ico byte array. Exposed for testing.
+    /// Composes the (optionally badged) lobster at every requested size and packs
+    /// the frames into a single multi-resolution .ico byte array. A null
+    /// <paramref name="dotColor"/> renders the plain lobster. Exposed for testing.
     /// </summary>
-    internal static byte[] CreateIcoBytes(Bitmap baseImage, Color dotColor, IReadOnlyList<int> sizes)
+    internal static byte[] CreateIcoBytes(Bitmap baseImage, Color? dotColor, bool withDash, IReadOnlyList<int> sizes)
     {
         var frames = new List<byte[]>(sizes.Count);
         foreach (var size in sizes)
         {
-            using var composed = Compose(baseImage, size, dotColor);
+            using var composed = Compose(baseImage, size, dotColor, withDash);
             using var ms = new MemoryStream();
             composed.Save(ms, ImageFormat.Png);
             frames.Add(ms.ToArray());
@@ -139,7 +162,7 @@ internal static class StatusBadgeIconFactory
         return maxFraction + (t * (minFraction - maxFraction));
     }
 
-    internal static Bitmap Compose(Bitmap baseImage, int size, Color dotColor)
+    internal static Bitmap Compose(Bitmap baseImage, int size, Color? dotColor, bool withDash = false)
     {
         var bmp = new Bitmap(size, size, PixelFormat.Format32bppArgb);
         bmp.SetResolution(96, 96);
@@ -152,6 +175,10 @@ internal static class StatusBadgeIconFactory
         g.Clear(Color.Transparent);
 
         g.DrawImage(baseImage, new Rectangle(0, 0, size, size));
+
+        // No badge for healthy states: render the plain lobster.
+        if (dotColor is not Color color)
+            return bmp;
 
         // Dot geometry: bottom-right corner with a white ring for contrast against
         // both the red mascot and arbitrary taskbar backgrounds. The dot scales by
@@ -167,8 +194,19 @@ internal static class StatusBadgeIconFactory
         using (var ringBrush = new SolidBrush(Color.White))
             g.FillEllipse(ringBrush, outerX, outerY, outer, outer);
 
-        using (var dotBrush = new SolidBrush(dotColor))
+        using (var dotBrush = new SolidBrush(color))
             g.FillEllipse(dotBrush, outerX + ring, outerY + ring, dot, dot);
+
+        // Error badge carries a white "-" (minus) glyph centred on the dot.
+        if (withDash)
+        {
+            float cx = outerX + ring + (dot / 2f);
+            float cy = outerY + ring + (dot / 2f);
+            float dashW = dot * 0.52f;
+            float dashH = Math.Max(2f, dot * 0.18f);
+            using var dashBrush = new SolidBrush(Color.White);
+            g.FillRectangle(dashBrush, cx - (dashW / 2f), cy - (dashH / 2f), dashW, dashH);
+        }
 
         return bmp;
     }

--- a/src/OpenClaw.Tray.WinUI/Helpers/StatusBadgeIconFactory.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/StatusBadgeIconFactory.cs
@@ -1,0 +1,187 @@
+using OpenClawTray.Services;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Runtime.Versioning;
+
+namespace OpenClawTray.Helpers;
+
+/// <summary>
+/// Builds application icons that mirror the companion-app connection status dot:
+/// the lobster mascot with a coloured status dot rendered in the bottom-right
+/// corner. Composed icons are cached per <see cref="ConnectionStatusAccent"/> and
+/// written to a temp folder as multi-resolution .ico files so both the tray icon
+/// (<see cref="WinUIEx.TrayIcon.SetIcon(string)"/>) and the desktop/taskbar window
+/// icon (<c>Window.SetIcon(string)</c>) can consume them.
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal static class StatusBadgeIconFactory
+{
+    private static readonly string AssetsPath = Path.Combine(AppContext.BaseDirectory, "Assets");
+    private static readonly string OutputDir = Path.Combine(Path.GetTempPath(), "OpenClawTray", "StatusIcons");
+    private static readonly object Gate = new();
+    private static readonly ConcurrentDictionary<ConnectionStatusAccent, string> Cache = new();
+
+    // Cover the sizes the shell requests for the tray (16-32 by DPI) and the
+    // taskbar/window (up to 256), so LoadImage always finds a crisp match.
+    private static readonly int[] Sizes = { 16, 20, 24, 32, 40, 48, 64, 128, 256 };
+
+    /// <summary>
+    /// Returns a filesystem path to a lobster icon badged with the status dot for
+    /// <paramref name="accent"/>. Falls back to the plain app icon on failure.
+    /// </summary>
+    public static string GetBadgedIconPath(ConnectionStatusAccent accent)
+    {
+        if (Cache.TryGetValue(accent, out var cached) && File.Exists(cached))
+            return cached;
+
+        lock (Gate)
+        {
+            if (Cache.TryGetValue(accent, out cached) && File.Exists(cached))
+                return cached;
+
+            var (path, isFallback) = Build(accent);
+
+            // Only cache successfully composed icons. Caching the fallback would
+            // permanently pin the un-badged icon after a transient GDI+ failure.
+            if (!isFallback)
+                Cache[accent] = path;
+
+            return path;
+        }
+    }
+
+    /// <summary>Maps a status accent to its dot colour (mirrors the companion-app dot).</summary>
+    public static Color DotColor(ConnectionStatusAccent accent) => accent switch
+    {
+        ConnectionStatusAccent.Success => Color.FromArgb(76, 175, 80),   // Green  – connected
+        ConnectionStatusAccent.Caution => Color.FromArgb(255, 193, 7),   // Amber  – connecting / attention
+        ConnectionStatusAccent.Critical => Color.FromArgb(244, 67, 54),  // Red    – error
+        _ => Color.FromArgb(158, 158, 158),                              // Gray   – disconnected / neutral
+    };
+
+    private static (string Path, bool IsFallback) Build(ConnectionStatusAccent accent)
+    {
+        var fallback = Path.Combine(AssetsPath, "openclaw.ico");
+        try
+        {
+            Directory.CreateDirectory(OutputDir);
+            var outputPath = Path.Combine(OutputDir, $"openclaw-{accent}".ToLowerInvariant() + ".ico");
+
+            using var baseImage = LoadBaseImage();
+            File.WriteAllBytes(outputPath, CreateIcoBytes(baseImage, DotColor(accent), Sizes));
+            return (outputPath, false);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Failed to build status-badged icon for {accent}: {ex.Message}");
+            return (fallback, true);
+        }
+    }
+
+    /// <summary>
+    /// Composes the badged lobster at every requested size and packs the frames
+    /// into a single multi-resolution .ico byte array. Exposed for testing.
+    /// </summary>
+    internal static byte[] CreateIcoBytes(Bitmap baseImage, Color dotColor, IReadOnlyList<int> sizes)
+    {
+        var frames = new List<byte[]>(sizes.Count);
+        foreach (var size in sizes)
+        {
+            using var composed = Compose(baseImage, size, dotColor);
+            using var ms = new MemoryStream();
+            composed.Save(ms, ImageFormat.Png);
+            frames.Add(ms.ToArray());
+        }
+
+        return BuildIco(frames, sizes);
+    }
+
+    /// <summary>The icon sizes baked into every composed .ico container.</summary>
+    internal static IReadOnlyList<int> IconSizes => Sizes;
+
+    private static Bitmap LoadBaseImage()
+    {
+        // Prefer the high-resolution unplated mascot PNG (transparent background)
+        // for crisp scaling; fall back to the multi-size app .ico.
+        var png = Path.Combine(AssetsPath, "Square44x44Logo.targetsize-256_altform-unplated.png");
+        if (File.Exists(png))
+            return new Bitmap(png);
+
+        var ico = Path.Combine(AssetsPath, "openclaw.ico");
+        using var icon = new Icon(ico, 256, 256);
+        return icon.ToBitmap();
+    }
+
+    internal static Bitmap Compose(Bitmap baseImage, int size, Color dotColor)
+    {
+        var bmp = new Bitmap(size, size, PixelFormat.Format32bppArgb);
+        bmp.SetResolution(96, 96);
+
+        using var g = Graphics.FromImage(bmp);
+        g.SmoothingMode = SmoothingMode.AntiAlias;
+        g.InterpolationMode = InterpolationMode.HighQualityBicubic;
+        g.PixelOffsetMode = PixelOffsetMode.HighQuality;
+        g.CompositingQuality = CompositingQuality.HighQuality;
+        g.Clear(Color.Transparent);
+
+        g.DrawImage(baseImage, new Rectangle(0, 0, size, size));
+
+        // Dot geometry: bottom-right corner with a white ring for contrast against
+        // both the red mascot and arbitrary taskbar backgrounds.
+        float ring = Math.Max(1f, size * 0.06f);
+        float pad = size * 0.02f;
+        float dot = size * 0.44f;
+        float outer = dot + (ring * 2f);
+        float outerX = size - outer - pad;
+        float outerY = size - outer - pad;
+
+        using (var ringBrush = new SolidBrush(Color.White))
+            g.FillEllipse(ringBrush, outerX, outerY, outer, outer);
+
+        using (var dotBrush = new SolidBrush(dotColor))
+            g.FillEllipse(dotBrush, outerX + ring, outerY + ring, dot, dot);
+
+        return bmp;
+    }
+
+    /// <summary>
+    /// Packs PNG frames into a Vista-style .ico container (PNG-compressed entries,
+    /// supported by LoadImage on Windows 10+).
+    /// </summary>
+    private static byte[] BuildIco(IReadOnlyList<byte[]> pngFrames, IReadOnlyList<int> sizes)
+    {
+        using var ms = new MemoryStream();
+        using var writer = new BinaryWriter(ms);
+
+        var count = (ushort)pngFrames.Count;
+        writer.Write((ushort)0); // idReserved
+        writer.Write((ushort)1); // idType = icon
+        writer.Write(count);     // idCount
+
+        var offset = 6 + (16 * count);
+        for (var i = 0; i < pngFrames.Count; i++)
+        {
+            var dim = (byte)(sizes[i] >= 256 ? 0 : sizes[i]); // 0 encodes 256
+            writer.Write(dim);              // bWidth
+            writer.Write(dim);              // bHeight
+            writer.Write((byte)0);          // bColorCount
+            writer.Write((byte)0);          // bReserved
+            writer.Write((ushort)1);        // wPlanes
+            writer.Write((ushort)32);       // wBitCount
+            writer.Write((uint)pngFrames[i].Length); // dwBytesInRes
+            writer.Write((uint)offset);     // dwImageOffset
+            offset += pngFrames[i].Length;
+        }
+
+        foreach (var frame in pngFrames)
+            writer.Write(frame);
+
+        writer.Flush();
+        return ms.ToArray();
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Helpers/StatusBadgeIconFactory.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/StatusBadgeIconFactory.cs
@@ -117,6 +117,28 @@ internal static class StatusBadgeIconFactory
         return icon.ToBitmap();
     }
 
+    /// <summary>
+    /// The dot diameter as a fraction of the icon size. Tiny tray icons need a
+    /// proportionally larger dot to stay legible at 16-32px, while large taskbar
+    /// / alt-tab icons look cleaner with a subtler corner dot. Interpolates
+    /// between the two extremes. Exposed for testing.
+    /// </summary>
+    internal static double DotFraction(int size)
+    {
+        const double maxFraction = 0.44; // <= 32px  (tray legibility)
+        const double minFraction = 0.26; // >= 256px (subtle corner dot)
+        const int minSize = 32;
+        const int maxSize = 256;
+
+        if (size <= minSize)
+            return maxFraction;
+        if (size >= maxSize)
+            return minFraction;
+
+        var t = (double)(size - minSize) / (maxSize - minSize);
+        return maxFraction + (t * (minFraction - maxFraction));
+    }
+
     internal static Bitmap Compose(Bitmap baseImage, int size, Color dotColor)
     {
         var bmp = new Bitmap(size, size, PixelFormat.Format32bppArgb);
@@ -132,10 +154,12 @@ internal static class StatusBadgeIconFactory
         g.DrawImage(baseImage, new Rectangle(0, 0, size, size));
 
         // Dot geometry: bottom-right corner with a white ring for contrast against
-        // both the red mascot and arbitrary taskbar backgrounds.
-        float ring = Math.Max(1f, size * 0.06f);
+        // both the red mascot and arbitrary taskbar backgrounds. The dot scales by
+        // size so it is legible on tiny tray icons yet subtle on large icons; the
+        // ring is tied to the dot so it shrinks proportionally too.
+        float dot = size * (float)DotFraction(size);
+        float ring = Math.Max(1f, dot * 0.14f);
         float pad = size * 0.02f;
-        float dot = size * 0.44f;
         float outer = dot + (ring * 2f);
         float outerX = size - outer - pad;
         float outerY = size - outer - pad;

--- a/src/OpenClaw.Tray.WinUI/Services/ConnectionStatusPresenter.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ConnectionStatusPresenter.cs
@@ -64,6 +64,26 @@ internal static class ConnectionStatusPresenter
         },
     };
 
+    /// <summary>
+    /// Resolves the status accent (Success/Caution/Critical/Neutral) used for the
+    /// companion-app status dot, so the tray and desktop icons can mirror it.
+    /// Prefers the richer <see cref="OverallConnectionState"/> when available and
+    /// falls back to the legacy <see cref="ConnectionStatus"/>.
+    /// </summary>
+    public static ConnectionStatusAccent Accent(OverallConnectionState? overall, ConnectionStatus fallback)
+    {
+        if (overall is OverallConnectionState state)
+            return Pill(state).Accent;
+
+        return fallback switch
+        {
+            ConnectionStatus.Connected => ConnectionStatusAccent.Success,
+            ConnectionStatus.Connecting => ConnectionStatusAccent.Caution,
+            ConnectionStatus.Error => ConnectionStatusAccent.Critical,
+            _ => ConnectionStatusAccent.Neutral,
+        };
+    }
+
     public static (string LabelKey, ConnectionStatusAccent Accent) Pill(OverallConnectionState overall) => overall switch
     {
         OverallConnectionState.Connected or OverallConnectionState.Ready =>

--- a/src/OpenClaw.Tray.WinUI/Services/TrayIconCoordinator.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/TrayIconCoordinator.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Dispatching;
+using OpenClawTray.Helpers;
 using System;
 using WinUIEx;
 
@@ -39,8 +40,10 @@ internal sealed class TrayIconCoordinator
         if (!_isAlive())
             return;
 
-        var iconPath = System.IO.Path.Combine(AppContext.BaseDirectory, "Assets", "openclaw.ico");
-        var tooltip = BuildTrayTooltip();
+        var snapshot = _captureSnapshot();
+        var accent = ConnectionStatusPresenter.Accent(snapshot.OverallState, snapshot.Status);
+        var iconPath = StatusBadgeIconFactory.GetBadgedIconPath(accent);
+        var tooltip = new TrayTooltipBuilder(snapshot).Build();
 
         try
         {
@@ -60,7 +63,4 @@ internal sealed class TrayIconCoordinator
 
         _trayIcon.Tooltip = tooltip;
     }
-
-    private string BuildTrayTooltip() =>
-        new TrayTooltipBuilder(_captureSnapshot()).Build();
 }

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -114,7 +114,7 @@ public sealed partial class HubWindow : WindowEx
 
         this.SetWindowSize(1000, 650);
         this.CenterOnScreen();
-        this.SetIcon(IconHelper.GetStatusIconPath(ConnectionStatus.Connected));
+        ApplyWindowStatusIcon(ConnectionStatusAccent.Neutral);
 
         RootGrid.SizeChanged += OnRootGridSizeChanged;
 
@@ -771,6 +771,7 @@ public sealed partial class HubWindow : WindowEx
         var (text, accent) = ComputePillState(status, snapshot);
         StatusPillText.Text = text;
         StatusPillDot.Fill = AccentBrush(accent);
+        ApplyWindowStatusIcon(accent);
     }
 
     internal void UpdateTitleBarStatus(GatewayConnectionSnapshot snapshot, ConnectionStatus status)
@@ -778,6 +779,21 @@ public sealed partial class HubWindow : WindowEx
         var (text, accent) = ComputePillState(status, snapshot);
         StatusPillText.Text = text;
         StatusPillDot.Fill = AccentBrush(accent);
+        ApplyWindowStatusIcon(accent);
+    }
+
+    // Mirrors the companion-app status dot onto the desktop/taskbar window icon:
+    // the lobster with a coloured dot in the bottom-right corner.
+    private void ApplyWindowStatusIcon(ConnectionStatusAccent accent)
+    {
+        try
+        {
+            this.SetIcon(StatusBadgeIconFactory.GetBadgedIconPath(accent));
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Failed to update window status icon: {ex.Message}");
+        }
     }
 
     private static (string Text, ConnectionStatusAccent Accent) ComputePillState(

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -796,6 +796,34 @@ public sealed class AppRefactorContractTests
     }
 
     [Fact]
+    public void TrayCoordinator_UsesStatusBadgedLobsterIcon()
+    {
+        var method = ExtractMethod(ReadCoordinatorSource(), "UpdateTrayIcon");
+
+        // The tray lobster mirrors the companion-app status dot instead of the
+        // static openclaw.ico, so it must resolve the accent and the badged icon.
+        Assert.Contains("ConnectionStatusPresenter.Accent(", method);
+        Assert.Contains("StatusBadgeIconFactory.GetBadgedIconPath(", method);
+        Assert.DoesNotContain("\"openclaw.ico\"", method);
+    }
+
+    [Fact]
+    public void HubWindow_DesktopIconMirrorsStatusAccent()
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        var source = File.ReadAllText(Path.Combine(
+            root, "src", "OpenClaw.Tray.WinUI", "Windows", "HubWindow.xaml.cs"));
+
+        // The desktop/taskbar icon is refreshed from the same accent as the pill.
+        var apply = ExtractMethod(source, "ApplyWindowStatusIcon");
+        Assert.Contains("StatusBadgeIconFactory.GetBadgedIconPath(accent)", apply);
+
+        // Both status-update paths must repaint the window icon.
+        var update = ExtractMethod(source, "UpdateTitleBarStatus");
+        Assert.Contains("ApplyWindowStatusIcon(accent)", update);
+    }
+
+    [Fact]
     public void AppNotifications_ConnectionIssueUsesStableDedupeKey()
     {
         var source = ReadAppSources();

--- a/tests/OpenClaw.Tray.Tests/ConnectionStatusPresenterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ConnectionStatusPresenterTests.cs
@@ -32,6 +32,35 @@ public sealed class ConnectionStatusPresenterTests
     }
 
     [Theory]
+    [InlineData(OverallConnectionState.Connected, (int)ConnectionStatusAccent.Success)]
+    [InlineData(OverallConnectionState.Ready, (int)ConnectionStatusAccent.Success)]
+    [InlineData(OverallConnectionState.Connecting, (int)ConnectionStatusAccent.Caution)]
+    [InlineData(OverallConnectionState.Degraded, (int)ConnectionStatusAccent.Caution)]
+    [InlineData(OverallConnectionState.PairingRequired, (int)ConnectionStatusAccent.Caution)]
+    [InlineData(OverallConnectionState.Error, (int)ConnectionStatusAccent.Critical)]
+    [InlineData(OverallConnectionState.Idle, (int)ConnectionStatusAccent.Neutral)]
+    [InlineData(OverallConnectionState.Disconnecting, (int)ConnectionStatusAccent.Neutral)]
+    public void Accent_PrefersOverallState_MatchingPill(OverallConnectionState overall, int expectedAccent)
+    {
+        // The tray/desktop status dot must mirror the companion-app pill accent.
+        Assert.Equal((ConnectionStatusAccent)expectedAccent,
+            ConnectionStatusPresenter.Accent(overall, ConnectionStatus.Disconnected));
+        Assert.Equal(ConnectionStatusPresenter.Pill(overall).Accent,
+            ConnectionStatusPresenter.Accent(overall, ConnectionStatus.Disconnected));
+    }
+
+    [Theory]
+    [InlineData(ConnectionStatus.Connected, (int)ConnectionStatusAccent.Success)]
+    [InlineData(ConnectionStatus.Connecting, (int)ConnectionStatusAccent.Caution)]
+    [InlineData(ConnectionStatus.Error, (int)ConnectionStatusAccent.Critical)]
+    [InlineData(ConnectionStatus.Disconnected, (int)ConnectionStatusAccent.Neutral)]
+    public void Accent_FallsBackToLegacyStatus_WhenOverallNull(ConnectionStatus status, int expectedAccent)
+    {
+        Assert.Equal((ConnectionStatusAccent)expectedAccent,
+            ConnectionStatusPresenter.Accent(null, status));
+    }
+
+    [Theory]
     [InlineData(OverallConnectionState.Connected, ConnectionStatus.Connected)]
     [InlineData(OverallConnectionState.Ready, ConnectionStatus.Connected)]
     [InlineData(OverallConnectionState.Connecting, ConnectionStatus.Connecting)]

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -24,6 +24,7 @@
     <Compile Include="..\..\src\OpenClaw.Chat\ChatTimelineReducer.cs" Link="Chat\ChatTimelineReducer.cs" />
     <Using Include="System.Text.Json.Nodes" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.7" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="Zeroconf" Version="3.6.11" />
   </ItemGroup>
@@ -83,6 +84,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\TrayTooltipFormatter.cs" Link="Helpers\TrayTooltipFormatter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\GatewayDashboardUrlBuilder.cs" Link="Helpers\GatewayDashboardUrlBuilder.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\CommandCenterTextHelper.cs" Link="Helpers\CommandCenterTextHelper.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\StatusBadgeIconFactory.cs" Link="Helpers\StatusBadgeIconFactory.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\Win32FilePickerHelper.cs" Link="Helpers\Win32FilePickerHelper.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\AppIdentity.cs" Link="AppIdentity.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\TrayStateSnapshot.cs" Link="Services\TrayStateSnapshot.cs" />

--- a/tests/OpenClaw.Tray.Tests/StatusBadgeIconFactoryTests.cs
+++ b/tests/OpenClaw.Tray.Tests/StatusBadgeIconFactoryTests.cs
@@ -1,0 +1,93 @@
+using OpenClawTray.Helpers;
+using OpenClawTray.Services;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Runtime.Versioning;
+using Xunit;
+
+namespace OpenClaw.Tray.Tests;
+
+/// <summary>
+/// Verifies the lobster tray/desktop icon is composed with a status dot in the
+/// bottom-right corner, mirroring the companion-app connection status.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class StatusBadgeIconFactoryTests
+{
+    [Theory]
+    [InlineData((int)ConnectionStatusAccent.Success, 76, 175, 80)]
+    [InlineData((int)ConnectionStatusAccent.Caution, 255, 193, 7)]
+    [InlineData((int)ConnectionStatusAccent.Critical, 244, 67, 54)]
+    [InlineData((int)ConnectionStatusAccent.Neutral, 158, 158, 158)]
+    public void DotColor_MapsAccentToStatusColor(int accent, int r, int g, int b)
+    {
+        var color = StatusBadgeIconFactory.DotColor((ConnectionStatusAccent)accent);
+        Assert.Equal(Color.FromArgb(r, g, b), color);
+    }
+
+    [Fact]
+    public void Compose_DrawsDotInBottomRightCorner()
+    {
+        const int size = 64;
+        using var baseImage = new Bitmap(size, size, PixelFormat.Format32bppArgb);
+        // Fully transparent base so the only opaque pixels come from the dot.
+
+        using var composed = StatusBadgeIconFactory.Compose(
+            baseImage, size, StatusBadgeIconFactory.DotColor(ConnectionStatusAccent.Success));
+
+        // Bottom-right region carries the coloured dot.
+        var dotPixel = composed.GetPixel((int)(size * 0.85), (int)(size * 0.85));
+        Assert.True(dotPixel.A > 200, "Dot should be opaque in the bottom-right corner");
+        Assert.True(dotPixel.G > dotPixel.R && dotPixel.G > dotPixel.B, "Success dot should read green");
+
+        // Top-left stays transparent (no badge, base was empty).
+        var cornerPixel = composed.GetPixel(2, 2);
+        Assert.True(cornerPixel.A < 40, "Top-left corner should remain transparent");
+    }
+
+    [Fact]
+    public void Compose_UsesDistinctColorPerAccent()
+    {
+        const int size = 64;
+        using var baseImage = new Bitmap(size, size, PixelFormat.Format32bppArgb);
+        var px = (int)(size * 0.85);
+
+        using var success = StatusBadgeIconFactory.Compose(baseImage, size, StatusBadgeIconFactory.DotColor(ConnectionStatusAccent.Success));
+        using var critical = StatusBadgeIconFactory.Compose(baseImage, size, StatusBadgeIconFactory.DotColor(ConnectionStatusAccent.Critical));
+
+        var green = success.GetPixel(px, px);
+        var red = critical.GetPixel(px, px);
+        Assert.True(green.G > green.R, "Success dot is green-dominant");
+        Assert.True(red.R > red.G, "Critical dot is red-dominant");
+    }
+
+    [Fact]
+    public void CreateIcoBytes_ProducesValidMultiSizeIcon()
+    {
+        var sizes = new[] { 16, 32, 48 };
+        using var baseImage = new Bitmap(256, 256, PixelFormat.Format32bppArgb);
+
+        var bytes = StatusBadgeIconFactory.CreateIcoBytes(
+            baseImage, StatusBadgeIconFactory.DotColor(ConnectionStatusAccent.Caution), sizes);
+
+        // ICONDIR header: reserved=0, type=1 (icon), count=frames.
+        Assert.Equal(0, bytes[0] | bytes[1]);
+        Assert.Equal(1, bytes[2] | (bytes[3] << 8));
+        var count = bytes[4] | (bytes[5] << 8);
+        Assert.Equal(sizes.Length, count);
+
+        // The container round-trips back into a real icon.
+        using var stream = new MemoryStream(bytes);
+        using var icon = new Icon(stream);
+        Assert.NotNull(icon);
+    }
+
+    [Fact]
+    public void IconSizes_CoverTrayAndTaskbarResolutions()
+    {
+        Assert.Contains(16, StatusBadgeIconFactory.IconSizes);   // tray at 100% DPI
+        Assert.Contains(32, StatusBadgeIconFactory.IconSizes);   // tray at 200% DPI / taskbar
+        Assert.Contains(256, StatusBadgeIconFactory.IconSizes);  // high-DPI taskbar
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/StatusBadgeIconFactoryTests.cs
+++ b/tests/OpenClaw.Tray.Tests/StatusBadgeIconFactoryTests.cs
@@ -1,5 +1,6 @@
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
+using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
@@ -9,8 +10,9 @@ using Xunit;
 namespace OpenClaw.Tray.Tests;
 
 /// <summary>
-/// Verifies the lobster tray/desktop icon is composed with a status dot in the
-/// bottom-right corner, mirroring the companion-app connection status.
+/// Verifies the lobster tray/desktop icon badge policy: only attention states are
+/// badged (grey dot for disconnected, red dot with a "-" for error); healthy
+/// states (connected/connecting) render the plain lobster with no badge.
 /// </summary>
 [SupportedOSPlatform("windows")]
 public sealed class StatusBadgeIconFactoryTests
@@ -26,6 +28,26 @@ public sealed class StatusBadgeIconFactoryTests
         Assert.Equal(Color.FromArgb(r, g, b), color);
     }
 
+    [Theory]
+    [InlineData((int)ConnectionStatusAccent.Neutral, true)]
+    [InlineData((int)ConnectionStatusAccent.Critical, true)]
+    [InlineData((int)ConnectionStatusAccent.Success, false)]
+    [InlineData((int)ConnectionStatusAccent.Caution, false)]
+    public void ShouldBadge_OnlyNeutralAndCritical(int accent, bool expected)
+    {
+        Assert.Equal(expected, StatusBadgeIconFactory.ShouldBadge((ConnectionStatusAccent)accent));
+    }
+
+    [Theory]
+    [InlineData((int)ConnectionStatusAccent.Critical, true)]
+    [InlineData((int)ConnectionStatusAccent.Neutral, false)]
+    [InlineData((int)ConnectionStatusAccent.Success, false)]
+    [InlineData((int)ConnectionStatusAccent.Caution, false)]
+    public void HasDash_OnlyCritical(int accent, bool expected)
+    {
+        Assert.Equal(expected, StatusBadgeIconFactory.HasDash((ConnectionStatusAccent)accent));
+    }
+
     [Fact]
     public void Compose_DrawsDotInBottomRightCorner()
     {
@@ -34,16 +56,65 @@ public sealed class StatusBadgeIconFactoryTests
         // Fully transparent base so the only opaque pixels come from the dot.
 
         using var composed = StatusBadgeIconFactory.Compose(
-            baseImage, size, StatusBadgeIconFactory.DotColor(ConnectionStatusAccent.Success));
+            baseImage, size, StatusBadgeIconFactory.DotColor(ConnectionStatusAccent.Neutral));
 
-        // Bottom-right region carries the coloured dot.
+        // Bottom-right region carries the dot.
         var dotPixel = composed.GetPixel((int)(size * 0.80), (int)(size * 0.80));
         Assert.True(dotPixel.A > 200, "Dot should be opaque in the bottom-right corner");
-        Assert.True(dotPixel.G > dotPixel.R && dotPixel.G > dotPixel.B, "Success dot should read green");
 
         // Top-left stays transparent (no badge, base was empty).
         var cornerPixel = composed.GetPixel(2, 2);
         Assert.True(cornerPixel.A < 40, "Top-left corner should remain transparent");
+    }
+
+    [Fact]
+    public void Compose_NullColor_RendersPlainLobsterWithNoBadge()
+    {
+        const int size = 64;
+        using var baseImage = new Bitmap(size, size, PixelFormat.Format32bppArgb);
+        // Transparent base + null dot colour => the whole icon stays transparent.
+
+        using var composed = StatusBadgeIconFactory.Compose(baseImage, size, dotColor: null);
+
+        var dotPixel = composed.GetPixel((int)(size * 0.80), (int)(size * 0.80));
+        Assert.True(dotPixel.A < 40, "Healthy state should render no dot in the bottom-right corner");
+    }
+
+    [Fact]
+    public void Compose_ErrorState_DrawsRedDotWithWhiteDash()
+    {
+        const int size = 64;
+        using var baseImage = new Bitmap(size, size, PixelFormat.Format32bppArgb);
+
+        using var composed = StatusBadgeIconFactory.Compose(
+            baseImage, size, StatusBadgeIconFactory.DotColor(ConnectionStatusAccent.Critical), withDash: true);
+
+        var (cx, cy, dot) = DotCenter(size);
+
+        // Centre of the dot is covered by the white minus glyph.
+        var centre = composed.GetPixel((int)cx, (int)cy);
+        Assert.True(centre.R > 230 && centre.G > 230 && centre.B > 230, "Dash centre should be white");
+
+        // Below the dash (still inside the dot) reads red.
+        var belowDash = composed.GetPixel((int)cx, (int)(cy + dot * 0.30f));
+        Assert.True(belowDash.A > 200 && belowDash.R > belowDash.G && belowDash.R > belowDash.B,
+            "Dot around the dash should read red");
+    }
+
+    [Fact]
+    public void Compose_UsesDistinctColorPerAccent()
+    {
+        const int size = 64;
+        using var baseImage = new Bitmap(size, size, PixelFormat.Format32bppArgb);
+        var px = (int)(size * 0.80);
+
+        using var neutral = StatusBadgeIconFactory.Compose(baseImage, size, StatusBadgeIconFactory.DotColor(ConnectionStatusAccent.Neutral));
+        using var critical = StatusBadgeIconFactory.Compose(baseImage, size, StatusBadgeIconFactory.DotColor(ConnectionStatusAccent.Critical));
+
+        var gray = neutral.GetPixel(px, px);
+        var red = critical.GetPixel(px, px);
+        Assert.True(Math.Abs(gray.R - gray.G) < 20 && Math.Abs(gray.G - gray.B) < 20, "Neutral dot is grey");
+        Assert.True(red.R > red.G && red.R > red.B, "Critical dot is red-dominant");
     }
 
     [Fact]
@@ -64,29 +135,13 @@ public sealed class StatusBadgeIconFactoryTests
     }
 
     [Fact]
-    public void Compose_UsesDistinctColorPerAccent()
-    {
-        const int size = 64;
-        using var baseImage = new Bitmap(size, size, PixelFormat.Format32bppArgb);
-        var px = (int)(size * 0.80);
-
-        using var success = StatusBadgeIconFactory.Compose(baseImage, size, StatusBadgeIconFactory.DotColor(ConnectionStatusAccent.Success));
-        using var critical = StatusBadgeIconFactory.Compose(baseImage, size, StatusBadgeIconFactory.DotColor(ConnectionStatusAccent.Critical));
-
-        var green = success.GetPixel(px, px);
-        var red = critical.GetPixel(px, px);
-        Assert.True(green.G > green.R, "Success dot is green-dominant");
-        Assert.True(red.R > red.G, "Critical dot is red-dominant");
-    }
-
-    [Fact]
     public void CreateIcoBytes_ProducesValidMultiSizeIcon()
     {
         var sizes = new[] { 16, 32, 48 };
         using var baseImage = new Bitmap(256, 256, PixelFormat.Format32bppArgb);
 
         var bytes = StatusBadgeIconFactory.CreateIcoBytes(
-            baseImage, StatusBadgeIconFactory.DotColor(ConnectionStatusAccent.Caution), sizes);
+            baseImage, StatusBadgeIconFactory.DotColor(ConnectionStatusAccent.Critical), withDash: true, sizes);
 
         // ICONDIR header: reserved=0, type=1 (icon), count=frames.
         Assert.Equal(0, bytes[0] | bytes[1]);
@@ -101,10 +156,36 @@ public sealed class StatusBadgeIconFactoryTests
     }
 
     [Fact]
+    public void CreateIcoBytes_NullColor_ProducesValidPlainIcon()
+    {
+        var sizes = new[] { 16, 32 };
+        using var baseImage = new Bitmap(256, 256, PixelFormat.Format32bppArgb);
+
+        var bytes = StatusBadgeIconFactory.CreateIcoBytes(baseImage, dotColor: null, withDash: false, sizes);
+
+        using var stream = new MemoryStream(bytes);
+        using var icon = new Icon(stream);
+        Assert.NotNull(icon);
+    }
+
+    [Fact]
     public void IconSizes_CoverTrayAndTaskbarResolutions()
     {
         Assert.Contains(16, StatusBadgeIconFactory.IconSizes);   // tray at 100% DPI
         Assert.Contains(32, StatusBadgeIconFactory.IconSizes);   // tray at 200% DPI / taskbar
         Assert.Contains(256, StatusBadgeIconFactory.IconSizes);  // high-DPI taskbar
+    }
+
+    // Mirrors the dot geometry in StatusBadgeIconFactory.Compose so tests can sample
+    // the dot centre precisely.
+    private static (float Cx, float Cy, float Dot) DotCenter(int size)
+    {
+        float dot = size * (float)StatusBadgeIconFactory.DotFraction(size);
+        float ring = Math.Max(1f, dot * 0.14f);
+        float pad = size * 0.02f;
+        float outer = dot + (ring * 2f);
+        float outerX = size - outer - pad;
+        float outerY = size - outer - pad;
+        return (outerX + ring + (dot / 2f), outerY + ring + (dot / 2f), dot);
     }
 }

--- a/tests/OpenClaw.Tray.Tests/StatusBadgeIconFactoryTests.cs
+++ b/tests/OpenClaw.Tray.Tests/StatusBadgeIconFactoryTests.cs
@@ -37,7 +37,7 @@ public sealed class StatusBadgeIconFactoryTests
             baseImage, size, StatusBadgeIconFactory.DotColor(ConnectionStatusAccent.Success));
 
         // Bottom-right region carries the coloured dot.
-        var dotPixel = composed.GetPixel((int)(size * 0.85), (int)(size * 0.85));
+        var dotPixel = composed.GetPixel((int)(size * 0.80), (int)(size * 0.80));
         Assert.True(dotPixel.A > 200, "Dot should be opaque in the bottom-right corner");
         Assert.True(dotPixel.G > dotPixel.R && dotPixel.G > dotPixel.B, "Success dot should read green");
 
@@ -47,11 +47,28 @@ public sealed class StatusBadgeIconFactoryTests
     }
 
     [Fact]
+    public void DotFraction_ScalesLargerOnTinyIconsAndSubtlerOnLargeIcons()
+    {
+        // Tiny tray icons get the largest dot for legibility.
+        Assert.Equal(0.44, StatusBadgeIconFactory.DotFraction(16), 3);
+        Assert.Equal(0.44, StatusBadgeIconFactory.DotFraction(32), 3);
+
+        // Large taskbar / alt-tab icons get the subtlest dot.
+        Assert.Equal(0.26, StatusBadgeIconFactory.DotFraction(256), 3);
+
+        // Monotonically shrinks as the icon grows between the two extremes.
+        var f48 = StatusBadgeIconFactory.DotFraction(48);
+        var f128 = StatusBadgeIconFactory.DotFraction(128);
+        Assert.True(f48 < 0.44 && f48 > f128, "48px dot fraction sits between the extremes");
+        Assert.True(f128 > 0.26 && f128 < f48, "128px dot fraction is subtler than 48px but above the floor");
+    }
+
+    [Fact]
     public void Compose_UsesDistinctColorPerAccent()
     {
         const int size = 64;
         using var baseImage = new Bitmap(size, size, PixelFormat.Format32bppArgb);
-        var px = (int)(size * 0.85);
+        var px = (int)(size * 0.80);
 
         using var success = StatusBadgeIconFactory.Compose(baseImage, size, StatusBadgeIconFactory.DotColor(ConnectionStatusAccent.Success));
         using var critical = StatusBadgeIconFactory.Compose(baseImage, size, StatusBadgeIconFactory.DotColor(ConnectionStatusAccent.Critical));


### PR DESCRIPTION
## Summary

Surfaces the gateway connection status on the lobster **tray icon** and **desktop/taskbar (HubWindow) icon** as a small badge in the bottom-right corner.

Per group feedback (a constant green "connected" dot is distracting), the badge only appears for **attention states**:

- ⚪ **disconnected / neutral** → a grey dot
- 🔴 **error** → a red dot with a white **–** (minus) glyph
- **connected / connecting** → the plain lobster, **no badge**

### How it works

- New `StatusBadgeIconFactory` composes the unplated lobster PNG with the badge into cached, multi-resolution `.ico` files (16–256px) — written to `%TEMP%\OpenClawTray\StatusIcons`. Both `TrayIcon.SetIcon(path)` and `Window.SetIcon(path)` consume them.
- Badge policy lives in `ShouldBadge()` (neutral/critical only) and `HasDash()` (critical only). `Compose()` takes a nullable dot colour — `null` renders the plain lobster — plus an optional white minus glyph for the error state.
- The dot **scales by icon size**: 44% on tiny tray sizes (≤32px, for legibility) tapering to a subtle 26% on large taskbar / alt-tab icons (≥256px), with a white ring for contrast on any background.
- `ConnectionStatusPresenter.Accent(overall, status)` centralises the accent selection so the tray and desktop icons always agree with the visible HubWindow status pill.
- `TrayIconCoordinator.UpdateTrayIcon` and `HubWindow` (both `UpdateTitleBarStatus` overloads + initial setup) apply the icon; the tray icon starts on the neutral (disconnected) badge. The existing `_isAlive()` guard before `SetIcon` is preserved.
- Failure-safe: falls back to the plain app icon on any GDI+ error, without pinning the fallback in the cache (so a transient failure can retry).

Other transient windows (dialogs, ChatWindow, CanvasWindow, ConnectionStatusWindow) intentionally keep the static `openclaw.ico`.

## Validation

All required AGENTS.md closeout checks pass on this branch head:

- `./build.ps1` — ✅ all projects built (Shared, Cli, WinNodeCli, SetupEngine, WinUI)
- `dotnet test ./tests/OpenClaw.Shared.Tests` — ✅ 2697 passed, 31 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests` — ✅ 1613 passed

New/updated tests (`StatusBadgeIconFactoryTests`): dot colour mapping, badge policy (`ShouldBadge` neutral/critical only, `HasDash` critical only), bottom-right dot placement, plain-lobster rendering for healthy states, red-dot-with-white-dash for error, per-accent colour distinction, size-scaling curve (`DotFraction`), valid multi-size ICO (badged + plain), tray/taskbar size coverage. Plus `ConnectionStatusPresenterTests` (`Accent()` overall-state preference / legacy fallback) and `AppRefactorContractTests` (tray + HubWindow wiring; liveness-guard-before-SetIcon contract preserved).

A **rubber-duck review** was run earlier; both findings were fixed (initial tray icon starts badged; fallback path is not cached after a transient failure).

## Real behavior proof

The four states were rendered directly from the shipping `StatusBadgeIconFactory` badge policy on the real lobster asset, at both 256px (taskbar/alt-tab) and 32px (tray) sizes: disconnected shows a grey dot, connecting/connected show the plain lobster, and error shows a red dot with a white minus — legible at both sizes. Proof image is attached in the session artifacts (`status-badge-proof.png`).

**Live running-app proof:** current PR head was built locally and launched against the maintainer normal OpenClaw profile (`OPENCLAW_TRAY_DATA_DIR=%APPDATA%\OpenClawTray`) with the Hub opened to Connection. Maintainer visually confirmed the live tray/taskbar icon behavior looks good: connected/connecting shows the plain lobster with no badge, and the updated attention-state badge policy is acceptable.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
