### PR TITLE
Fix tray app display name branding

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -2,6 +2,7 @@
 ; Pass /DDevBuild=1 to produce a side-by-side dev installer.
 #ifdef DevBuild
   #define MyAppName "OpenClaw Companion (Dev)"
+  #define MyAppAumid "OpenClaw.Companion.Dev"
   #define MyAppId "{{M0LTB0T-TRAY-4PP1-DEV}"
   #define MyInstallDir "OpenClawTray-Dev"
   #define MyMutex "OpenClawTray-Dev"
@@ -12,6 +13,7 @@
   #define MyOutputSuffix "-Dev"
 #else
   #define MyAppName "OpenClaw Companion"
+  #define MyAppAumid "OpenClaw.Companion"
   #define MyAppId "{{M0LTB0T-TRAY-4PP1-D3N7}"
   #define MyInstallDir "OpenClawTray"
   #define MyMutex "OpenClawTray"
@@ -112,14 +114,14 @@ Root: HKCU; Subkey: "Software\Classes\{#MyProtocol}\DefaultIcon"; ValueType: str
 Root: HKCU; Subkey: "Software\Classes\{#MyProtocol}\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#MyAppExeName}"" ""%1"""
 
 [Icons]
-Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
-Name: "{group}\OpenClaw Gateway Setup"; Filename: "{app}\{#MyAppExeName}"; Parameters: "{#MyProtocol}://setup"; IconFilename: "{app}\{#MyAppExeName}"
-Name: "{group}\OpenClaw Companion Settings"; Filename: "{app}\{#MyAppExeName}"; Parameters: "{#MyProtocol}://commandcenter"; IconFilename: "{app}\{#MyAppExeName}"
-Name: "{group}\OpenClaw Chat"; Filename: "{app}\{#MyAppExeName}"; Parameters: "{#MyProtocol}://chat"; IconFilename: "{app}\{#MyAppExeName}"
-Name: "{group}\Check for Updates"; Filename: "{app}\{#MyAppExeName}"; Parameters: "{#MyProtocol}://check-updates"; IconFilename: "{app}\{#MyAppExeName}"
+Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; AppUserModelID: "{#MyAppAumid}"
+Name: "{group}\OpenClaw Gateway Setup"; Filename: "{app}\{#MyAppExeName}"; Parameters: "{#MyProtocol}://setup"; IconFilename: "{app}\{#MyAppExeName}"; AppUserModelID: "{#MyAppAumid}"
+Name: "{group}\OpenClaw Companion Settings"; Filename: "{app}\{#MyAppExeName}"; Parameters: "{#MyProtocol}://commandcenter"; IconFilename: "{app}\{#MyAppExeName}"; AppUserModelID: "{#MyAppAumid}"
+Name: "{group}\OpenClaw Chat"; Filename: "{app}\{#MyAppExeName}"; Parameters: "{#MyProtocol}://chat"; IconFilename: "{app}\{#MyAppExeName}"; AppUserModelID: "{#MyAppAumid}"
+Name: "{group}\Check for Updates"; Filename: "{app}\{#MyAppExeName}"; Parameters: "{#MyProtocol}://check-updates"; IconFilename: "{app}\{#MyAppExeName}"; AppUserModelID: "{#MyAppAumid}"
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
-Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
-Name: "{userstartup}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: startupicon
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon; AppUserModelID: "{#MyAppAumid}"
+Name: "{userstartup}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: startupicon; AppUserModelID: "{#MyAppAumid}"
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent; Check: ShouldLaunchTray

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -475,6 +475,12 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         // Store protocol URI for processing after setup
         _pendingProtocolUri = protocolUri;
 
+        var appUserModelIdRegistration = AppUserModelIdRegistrar.RegisterCurrentProcess(AppIdentity.AppUserModelId);
+        if (appUserModelIdRegistration.Attempted && appUserModelIdRegistration.HResult < 0)
+        {
+            Logger.Warn($"Failed to set AppUserModelID '{AppIdentity.AppUserModelId}' (HRESULT=0x{appUserModelIdRegistration.HResult:X8}); toast sender name may fall back to the executable name.");
+        }
+
         // Initialize settings before update check so skip selections can be remembered.
         _settings = new SettingsManager();
         _previousSettingsSnapshot = _settings.ToSettingsData().ToConnectionSnapshot();

--- a/src/OpenClaw.Tray.WinUI/AppIdentity.cs
+++ b/src/OpenClaw.Tray.WinUI/AppIdentity.cs
@@ -16,6 +16,9 @@ internal static class AppIdentity
     /// <summary>MSIX package identity name (must differ from release for side-by-side).</summary>
     public const string PackageIdentityName = "OpenClaw.Companion.Dev";
 
+    /// <summary>Win32 AppUserModelID used for notifications and shell grouping.</summary>
+    public const string AppUserModelId = PackageIdentityName;
+
     /// <summary>Windows Registry auto-start value name (must differ so both can auto-start).</summary>
     public const string AutoStartRegistryName = "OpenClawTray-Dev";
 
@@ -51,6 +54,9 @@ internal static class AppIdentity
 
     /// <summary>MSIX package identity name.</summary>
     public const string PackageIdentityName = "OpenClaw.Companion";
+
+    /// <summary>Win32 AppUserModelID used for notifications and shell grouping.</summary>
+    public const string AppUserModelId = PackageIdentityName;
 
     /// <summary>Windows Registry auto-start value name.</summary>
     public const string AutoStartRegistryName = "OpenClawTray";

--- a/src/OpenClaw.Tray.WinUI/Dialogs/PairingApprovalDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/PairingApprovalDialog.cs
@@ -54,7 +54,8 @@ public sealed class PairingApprovalDialog : WindowEx
     {
         _coordinator = coordinator ?? throw new ArgumentNullException(nameof(coordinator));
 
-        Title = LocalizationHelper.GetString("PairingApproval_WindowTitle");
+        var windowTitle = $"{AppIdentity.DisplayName} - {LocalizationHelper.GetString("PairingApproval_WindowTitle")}";
+        Title = windowTitle;
         this.SetWindowSize(460, 460);
         this.CenterOnScreen();
         this.SetIcon("Assets\\openclaw.ico");
@@ -70,7 +71,7 @@ public sealed class PairingApprovalDialog : WindowEx
         titleBar.Children.Add(titleIcon);
         var titleText = new TextBlock
         {
-            Text = LocalizationHelper.GetString("PairingApproval_WindowTitle"),
+            Text = windowTitle,
             FontSize = 13,
             VerticalAlignment = VerticalAlignment.Center,
             Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],

--- a/src/OpenClaw.Tray.WinUI/Dialogs/RecordingConsentDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/RecordingConsentDialog.cs
@@ -38,7 +38,8 @@ public sealed class RecordingConsentDialog : WindowEx
         var descriptionKey = isScreen ? "RecordingConsent_ScreenDescription" : "RecordingConsent_CameraDescription";
         var emoji = isScreen ? "🖥️" : "📷";
 
-        Title = LocalizationHelper.GetString("RecordingConsent_WindowTitle");
+        var windowTitle = $"{AppIdentity.DisplayName} - {LocalizationHelper.GetString("RecordingConsent_WindowTitle")}";
+        Title = windowTitle;
         this.SetWindowSize(460, 340);
         this.CenterOnScreen();
         this.SetIcon("Assets\\openclaw.ico");
@@ -67,7 +68,7 @@ public sealed class RecordingConsentDialog : WindowEx
 
         var titleText = new TextBlock
         {
-            Text = LocalizationHelper.GetString("RecordingConsent_WindowTitle"),
+            Text = windowTitle,
             FontSize = 13,
             VerticalAlignment = VerticalAlignment.Center,
             Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"]

--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -8,6 +8,9 @@
     <Nullable>enable</Nullable>
     <EnableMsixTooling>true</EnableMsixTooling>
     <ApplicationIcon>Assets\openclaw.ico</ApplicationIcon>
+    <AssemblyTitle>OpenClaw Companion</AssemblyTitle>
+    <FileDescription>OpenClaw Companion</FileDescription>
+    <Product>OpenClaw Companion</Product>
     <RootNamespace>OpenClawTray</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
     <Platforms>x64;ARM64</Platforms>
@@ -19,6 +22,9 @@
   <PropertyGroup Condition="'$(DevBuild)' == 'true'">
     <DefineConstants>$(DefineConstants);DEV_BUILD</DefineConstants>
     <AppIdentityMarker>dev</AppIdentityMarker>
+    <AssemblyTitle>OpenClaw Companion (Dev)</AssemblyTitle>
+    <FileDescription>OpenClaw Companion (Dev)</FileDescription>
+    <Product>OpenClaw Companion (Dev)</Product>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DevBuild)' != 'true'">
     <AppIdentityMarker>release</AppIdentityMarker>

--- a/src/OpenClaw.Tray.WinUI/Services/AppUserModelIdRegistrar.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AppUserModelIdRegistrar.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace OpenClawTray.Services;
+
+internal readonly record struct AppUserModelIdRegistrationResult(bool Attempted, int HResult);
+
+internal static class AppUserModelIdRegistrar
+{
+    private const int AppModelErrorNoPackage = 15700;
+    private const int ErrorInsufficientBuffer = 122;
+    private const int ErrorSuccess = 0;
+
+    public static AppUserModelIdRegistrationResult RegisterCurrentProcess(string appUserModelId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(appUserModelId);
+        if (HasPackageIdentity())
+            return new AppUserModelIdRegistrationResult(Attempted: false, HResult: ErrorSuccess);
+
+        return new AppUserModelIdRegistrationResult(
+            Attempted: true,
+            HResult: SetCurrentProcessExplicitAppUserModelID(appUserModelId));
+    }
+
+    private static bool HasPackageIdentity()
+    {
+        var packageFullNameLength = 0;
+        var result = GetCurrentPackageFullName(ref packageFullNameLength, null);
+        if (result == AppModelErrorNoPackage)
+            return false;
+
+        return result is ErrorSuccess or ErrorInsufficientBuffer;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+    private static extern int GetCurrentPackageFullName(
+        ref int packageFullNameLength,
+        [MarshalAs(UnmanagedType.LPWStr)] StringBuilder? packageFullName);
+
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+    private static extern int SetCurrentProcessExplicitAppUserModelID(
+        [MarshalAs(UnmanagedType.LPWStr)] string appID);
+}

--- a/src/OpenClaw.Tray.WinUI/Services/ExecApprovalPromptService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ExecApprovalPromptService.cs
@@ -15,6 +15,7 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
     private readonly IOpenClawLogger _logger;
     private readonly Func<OpenClawChatDataProvider?>? _chatProviderProvider;
     private readonly Func<string, bool>? _inlineApprovalAvailable;
+    private static string NativePromptTitle => $"{AppIdentity.DisplayName} - Approve local command?";
 
     public ExecApprovalPromptService(
         DispatcherQueue dispatcherQueue,
@@ -161,7 +162,7 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
     private static ExecApprovalPromptDecision ShowNativePrompt(ExecApprovalPromptRequest request)
     {
         var text =
-            "A remote agent wants to run a local command on this Windows machine." +
+            $"{AppIdentity.DisplayName} needs approval before a remote agent can run a local command on this Windows machine." +
             "\r\n\r\n" +
             request.Command +
             "\r\n\r\n" +
@@ -190,7 +191,7 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
         var result = MessageBoxW(
             IntPtr.Zero,
             fallbackText,
-            "Approve local command?",
+            NativePromptTitle,
             MessageBoxFlags.YesNoCancel |
             MessageBoxFlags.IconWarning |
             MessageBoxFlags.TopMost |
@@ -263,7 +264,7 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
             _hwnd = CreateWindowExW(
                 WindowExStyleTopMost | WindowExStyleDialogModalFrame,
                 WindowClassName,
-                "Approve local command?",
+                NativePromptTitle,
                 WindowStyleCaption | WindowStyleSystemMenu | WindowStyleVisible,
                 x,
                 y,
@@ -341,7 +342,7 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
         private void CreateControls(IntPtr hwnd)
         {
             var font = GetStockObject(DefaultGuiFont);
-            CreateChild(hwnd, "STATIC", "Approve local command?", 20, 18, 590, 24, StaticStyleLeft, 0, font);
+            CreateChild(hwnd, "STATIC", NativePromptTitle, 20, 18, 590, 24, StaticStyleLeft, 0, font);
             CreateChild(
                 hwnd,
                 "EDIT",

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -832,7 +832,7 @@ Use one of these options:
   </data>
   <!-- ==================== Recording Consent Dialog ==================== -->
   <data name="RecordingConsent_WindowTitle" xml:space="preserve">
-    <value>OpenClaw · Permission Request</value>
+    <value>Permission Request</value>
   </data>
   <data name="RecordingConsent_ScreenTitle" xml:space="preserve">
     <value>Allow screen recording?</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -789,7 +789,7 @@ Utilisez l'une de ces options :
   </data>
   <!-- ==================== Recording Consent Dialog ==================== -->
   <data name="RecordingConsent_WindowTitle" xml:space="preserve">
-    <value>OpenClaw · Demande d'autorisation</value>
+    <value>Demande d'autorisation</value>
   </data>
   <data name="RecordingConsent_ScreenTitle" xml:space="preserve">
     <value>Autoriser l'enregistrement d'écran ?</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -790,7 +790,7 @@ Gebruik een van deze opties:
   </data>
   <!-- ==================== Recording Consent Dialog ==================== -->
   <data name="RecordingConsent_WindowTitle" xml:space="preserve">
-    <value>OpenClaw · Toestemmingsverzoek</value>
+    <value>Toestemmingsverzoek</value>
   </data>
   <data name="RecordingConsent_ScreenTitle" xml:space="preserve">
     <value>Schermopname toestaan?</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -789,7 +789,7 @@
   </data>
   <!-- ==================== Recording Consent Dialog ==================== -->
   <data name="RecordingConsent_WindowTitle" xml:space="preserve">
-    <value>OpenClaw · 权限请求</value>
+    <value>权限请求</value>
   </data>
   <data name="RecordingConsent_ScreenTitle" xml:space="preserve">
     <value>允许屏幕录制？</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -789,7 +789,7 @@
   </data>
   <!-- ==================== Recording Consent Dialog ==================== -->
   <data name="RecordingConsent_WindowTitle" xml:space="preserve">
-    <value>OpenClaw · 權限請求</value>
+    <value>權限請求</value>
   </data>
   <data name="RecordingConsent_ScreenTitle" xml:space="preserve">
     <value>允許螢幕錄製？</value>

--- a/src/OpenClaw.Tray.WinUI/app.manifest
+++ b/src/OpenClaw.Tray.WinUI/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="OpenClaw.Tray.WinUI"/>
+  <assemblyIdentity version="1.0.0.0" name="OpenClaw.Companion"/>
   
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -28,6 +28,8 @@ public sealed class AppRefactorContractTests
 
         AssertInOrder(
             source,
+            "AppUserModelIdRegistrar.RegisterCurrentProcess(AppIdentity.AppUserModelId);",
+            "appUserModelIdRegistration.Attempted",
             "_settings = new SettingsManager();",
             "CheckForUpdatesAsync();",
             "ToastNotificationManagerCompat.OnActivated += OnToastActivated;",

--- a/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/InstallerIssAssertionTests.cs
@@ -46,14 +46,24 @@ public sealed class InstallerIssAssertionTests
         var iss = File.ReadAllText(Path.Combine(TestRepositoryPaths.GetRepositoryRoot(), "installer.iss"));
 
         Assert.Contains(@"#define MyAppName ""OpenClaw Companion""", iss);
+        Assert.Contains(@"#define MyAppAumid ""OpenClaw.Companion""", iss);
         Assert.Contains(@"#define MyCompression ""lzma""", iss);
         Assert.Contains(@"#define MySolidCompression ""yes""", iss);
         Assert.Contains("OutputBaseFilename=OpenClawCompanion{#MyOutputSuffix}-Setup-{#MyAppArch}", iss);
-        Assert.Contains(@"Name: ""{group}\{#MyAppName}""; Filename: ""{app}\{#MyAppExeName}""", iss);
-        Assert.Contains(@"Name: ""{group}\OpenClaw Gateway Setup""; Filename: ""{app}\{#MyAppExeName}""; Parameters: ""{#MyProtocol}://setup""", iss);
-        Assert.Contains(@"Name: ""{group}\OpenClaw Companion Settings""; Filename: ""{app}\{#MyAppExeName}""; Parameters: ""{#MyProtocol}://commandcenter""", iss);
-        Assert.Contains(@"Name: ""{group}\OpenClaw Chat""; Filename: ""{app}\{#MyAppExeName}""; Parameters: ""{#MyProtocol}://chat""", iss);
-        Assert.Contains(@"Name: ""{group}\Check for Updates""; Filename: ""{app}\{#MyAppExeName}""; Parameters: ""{#MyProtocol}://check-updates""", iss);
+        foreach (var iconEntry in new[]
+        {
+            @"Name: ""{group}\{#MyAppName}""; Filename: ""{app}\{#MyAppExeName}""; AppUserModelID: ""{#MyAppAumid}""",
+            @"Name: ""{group}\OpenClaw Gateway Setup""; Filename: ""{app}\{#MyAppExeName}""; Parameters: ""{#MyProtocol}://setup""; IconFilename: ""{app}\{#MyAppExeName}""; AppUserModelID: ""{#MyAppAumid}""",
+            @"Name: ""{group}\OpenClaw Companion Settings""; Filename: ""{app}\{#MyAppExeName}""; Parameters: ""{#MyProtocol}://commandcenter""; IconFilename: ""{app}\{#MyAppExeName}""; AppUserModelID: ""{#MyAppAumid}""",
+            @"Name: ""{group}\OpenClaw Chat""; Filename: ""{app}\{#MyAppExeName}""; Parameters: ""{#MyProtocol}://chat""; IconFilename: ""{app}\{#MyAppExeName}""; AppUserModelID: ""{#MyAppAumid}""",
+            @"Name: ""{group}\Check for Updates""; Filename: ""{app}\{#MyAppExeName}""; Parameters: ""{#MyProtocol}://check-updates""; IconFilename: ""{app}\{#MyAppExeName}""; AppUserModelID: ""{#MyAppAumid}""",
+            @"Name: ""{autodesktop}\{#MyAppName}""; Filename: ""{app}\{#MyAppExeName}""; Tasks: desktopicon; AppUserModelID: ""{#MyAppAumid}""",
+            @"Name: ""{userstartup}\{#MyAppName}""; Filename: ""{app}\{#MyAppExeName}""; Tasks: startupicon; AppUserModelID: ""{#MyAppAumid}"""
+        })
+        {
+            Assert.Contains(iconEntry, iss);
+        }
+        Assert.DoesNotContain("AppUserModelID: \"OpenClaw.Tray.WinUI\"", iss);
     }
 
     [Fact]
@@ -132,6 +142,7 @@ public sealed class InstallerIssAssertionTests
         var iss = File.ReadAllText(Path.Combine(TestRepositoryPaths.GetRepositoryRoot(), "installer.iss"));
 
         Assert.Contains(@"#define MyAppName ""OpenClaw Companion (Dev)""", iss);
+        Assert.Contains(@"#define MyAppAumid ""OpenClaw.Companion.Dev""", iss);
         Assert.Contains(@"#define MyInstallDir ""OpenClawTray-Dev""", iss);
         Assert.Contains(@"#define MyMutex ""OpenClawTray-Dev""", iss);
         Assert.Contains(@"#define MyProtocol ""openclaw-dev""", iss);

--- a/tests/OpenClaw.Tray.Tests/Services/AppUserModelIdIdentityTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Services/AppUserModelIdIdentityTests.cs
@@ -1,0 +1,91 @@
+using System.IO;
+using OpenClawTray;
+using Xunit;
+
+namespace OpenClaw.Tray.Tests.Services;
+
+public sealed class AppUserModelIdIdentityTests
+{
+    [Fact]
+    public void WinUiProject_UsesHumanReadableMetadataForNotificationSenderFallback()
+    {
+        var project = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "OpenClaw.Tray.WinUI.csproj"));
+
+        Assert.Contains("<AssemblyTitle>OpenClaw Companion</AssemblyTitle>", project);
+        Assert.Contains("<FileDescription>OpenClaw Companion</FileDescription>", project);
+        Assert.Contains("<Product>OpenClaw Companion</Product>", project);
+        Assert.Contains("<AssemblyTitle>OpenClaw Companion (Dev)</AssemblyTitle>", project);
+        Assert.Contains("<FileDescription>OpenClaw Companion (Dev)</FileDescription>", project);
+        Assert.Contains("<Product>OpenClaw Companion (Dev)</Product>", project);
+        Assert.DoesNotContain("<AssemblyTitle>OpenClaw.Tray.WinUI</AssemblyTitle>", project);
+    }
+
+    [Fact]
+    public void Registrar_SkipsExplicitAumidWhenMsixPackageIdentityExists()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Services",
+            "AppUserModelIdRegistrar.cs"));
+
+        Assert.Contains("GetCurrentPackageFullName", source);
+        Assert.Contains("AppModelErrorNoPackage", source);
+        Assert.Contains("HResult", source);
+        Assert.Contains("SetCurrentProcessExplicitAppUserModelID", source);
+    }
+
+    [Fact]
+    public void AppUserModelId_UsesCompanionIdentity()
+    {
+        Assert.Equal(AppIdentity.PackageIdentityName, AppIdentity.AppUserModelId);
+        Assert.DoesNotContain("OpenClaw.Tray.WinUI", AppIdentity.AppUserModelId);
+    }
+
+    [Fact]
+    public void InstallerAumid_MatchesRuntimeAppUserModelId()
+    {
+        var iss = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "installer.iss"));
+
+        Assert.Contains($@"#define MyAppAumid ""{AppIdentity.AppUserModelId}""", iss);
+        Assert.Contains(@"#define MyAppAumid ""OpenClaw.Companion.Dev""", iss);
+    }
+
+    [Fact]
+    public void UnpackagedManifest_UsesCompanionIdentityForSystemPrompts()
+    {
+        var manifest = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "app.manifest"));
+
+        Assert.Contains(@"<assemblyIdentity version=""1.0.0.0"" name=""OpenClaw.Companion""/>", manifest);
+        Assert.DoesNotContain(@"name=""OpenClaw.Tray.WinUI""", manifest);
+    }
+
+    [Fact]
+    public void ApprovalPopups_UseCompanionDisplayName()
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        var pairingDialog = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.Tray.WinUI", "Dialogs", "PairingApprovalDialog.cs"));
+        var recordingDialog = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.Tray.WinUI", "Dialogs", "RecordingConsentDialog.cs"));
+        var execPrompt = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.Tray.WinUI", "Services", "ExecApprovalPromptService.cs"));
+
+        Assert.Contains("AppIdentity.DisplayName", pairingDialog);
+        Assert.Contains("AppIdentity.DisplayName", recordingDialog);
+        Assert.Contains("AppIdentity.DisplayName", execPrompt);
+        Assert.DoesNotContain("OpenClaw · Permission Request", File.ReadAllText(Path.Combine(root, "src", "OpenClaw.Tray.WinUI", "Strings", "en-us", "Resources.resw")));
+        Assert.Contains("NativePromptTitle", execPrompt);
+        Assert.DoesNotContain("OpenClaw.Tray.WinUI", pairingDialog);
+        Assert.DoesNotContain("OpenClaw.Tray.WinUI", recordingDialog);
+        Assert.DoesNotContain("OpenClaw.Tray.WinUI", execPrompt);
+    }
+}


### PR DESCRIPTION
## Summary
- Use `OpenClaw Companion` / `OpenClaw Companion (Dev)` as the visible app identity for toast sender fallback, unpackaged app metadata, and approval/permission popup titles.
- Align runtime AppUserModelID with installer shortcut AUMIDs so Windows does not fall back to `OpenClaw.Tray.WinUI` for notifications.
- Remove localized recording-consent `OpenClaw ·` prefixes to avoid double-branded titles.
- Add contract coverage for startup AUMID registration, installer shortcut AUMIDs, popup branding, manifest identity, and metadata.

## Validation
- `./build.ps1` — passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — passed (2703 passed, 31 skipped)
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — passed (1592 passed)

## Real behavior proof
- Built current-head WinUI executable reports:
  - `FileDescription: OpenClaw Companion`
  - `ProductName: OpenClaw Companion`
- Live current-head popup proof captured from an isolated tray run of this branch:
  - Process path: `C:\Projects\copilot-worktrees\openclaw-windows-node\bkudiess-symmetrical-carnival\src\OpenClaw.Tray.WinUI\bin\Debug\net10.0-windows10.0.22621.0\win-arm64\OpenClaw.Tray.WinUI.exe`
  - Trigger: `winnode --mcp-port 18766 --command system.run --params '{"command":"cmd","args":["/c","echo proof-current-head-unique-946"],"timeoutMs":30000}'`
  - Copied UI diagnostic transcript from the active native approval popup:

```text
Window: "OpenClaw Companion - Approve local command?", App: OpenClaw.Tray.WinUI.
  AXWindow OpenClaw Companion - Approve local command?
    AXStaticText OpenClaw Companion - Approve local command?
    AXScrollArea Value: OpenClaw Companion needs approval before a remote agent can run a local command on this Windows machine.
      cmd /c "echo proof-current-head-unique-946"
      Shell: cmd
      Reason: No matching rule; default policy applied
    AXButton Allow once
    AXButton Always allow
    AXButton Deny
    AXTitleBar Value: OpenClaw Companion - Approve local command?
```

- Current-head source/contract tests verify:
  - Runtime AppUserModelID uses `OpenClaw.Companion` / `OpenClaw.Companion.Dev`.
  - Installer Start Menu, setup, settings, chat, update, desktop, and startup shortcuts carry `{#MyAppAumid}`.
  - Pairing, recording consent, and local command approval popups use `AppIdentity.DisplayName`.
  - Recording consent localized titles no longer include `OpenClaw ·`, preventing double-branding.