### PR TITLE
Separate speech capability controls from voice settings

### DIFF
--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -2766,8 +2766,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             //     });
             // }
 
-            // TTS: read response aloud whenever the toggle is on (any chat surface).
-            if (_settings?.VoiceTtsEnabled == true)
+            // TTS: read response aloud whenever chat TTS is enabled and ready (any chat surface).
+            if (SpeechSetupReadiness.IsAutomaticChatTtsEnabled(_settings))
             {
                 _ = (_chatCoordinator?.SpeakResponseAsync(speechText) ?? Task.CompletedTask);
             }

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -942,22 +942,11 @@ public sealed partial class ChatPage : Page
 
     private async Task ShowTtsUnavailableDialogAsync()
     {
-        var settings = CurrentApp.Settings;
-        if (settings?.NodeTtsEnabled != true)
-        {
-            await ShowVoiceSettingsDialogAsync(
-                LocalizationHelper.GetString("ChatVoiceDialog_OutputOffTitle"),
-                LocalizationHelper.GetString("ChatVoiceDialog_OutputOffMessage"),
-                LocalizationHelper.GetString("ChatVoiceDialog_OpenPermissionsSettings"),
-                NavigateToPermissionsSettings);
-            return;
-        }
-
         await ShowVoiceSettingsDialogAsync(
-            LocalizationHelper.GetString("ChatVoiceDialog_TtsSetupRequiredTitle"),
-            LocalizationHelper.GetString("ChatVoiceDialog_TtsSetupRequiredMessage"),
-            LocalizationHelper.GetString("ChatVoiceDialog_OpenVoiceSettings"),
-            NavigateToVoiceSettings);
+            LocalizationHelper.GetString("ChatVoiceDialog_OutputOffTitle"),
+            LocalizationHelper.GetString("ChatVoiceDialog_OutputOffMessage"),
+            LocalizationHelper.GetString("ChatVoiceDialog_OpenPermissionsSettings"),
+            NavigateToPermissionsSettings);
     }
 
     private static bool ShouldStartSpeakerMuted(SettingsManager? settings)

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -33,6 +33,8 @@ public sealed partial class ChatPage : Page
     private bool _webViewInitialized;
     private bool _webViewMode;
     private bool _pageActive;
+    private readonly SemaphoreSlim _speakerMuteGate = new(1, 1);
+    private int _voiceSettingsDialogOpen;
     private bool _navigationStarted;
     private CancellationTokenSource? _navigationCts;
     private global::Windows.Foundation.TypedEventHandler<CoreWebView2, CoreWebView2NavigationCompletedEventArgs>? _navCompletedHandler;
@@ -232,7 +234,7 @@ public sealed partial class ChatPage : Page
 
         var app = App.Current as App;
         var provider = ResolveChatProvider(app);
-        Func<string, Task>? readAloud = app is null ? null : app.SpeakChatTextAsync;
+        Func<string, Task>? readAloud = app is null ? null : ReadChatTextAloudAsync;
 
         // Consume a pending session-key hand-off from SessionsPage or a
         // notification toast so the chat root mounts with that thread selected.
@@ -292,8 +294,8 @@ public sealed partial class ChatPage : Page
             onVoiceRequest: VoiceTranscribeAsync,
             onAttachClick: OnAttachClicked,
             onSettingsClick: () => _hub?.NavigateTo("voice"),
-            onSpeakerMuteChanged: muted => (App.Current as App)?.SetChatSpeakerMuted(muted),
-            initialMuted: CurrentApp.Settings?.VoiceTtsEnabled == false,
+            onSpeakerMuteChanged: muted => _ = OnSpeakerMuteChangedAsync(muted),
+            initialMuted: ShouldStartSpeakerMuted(CurrentApp.Settings),
             suppressAutoDispose: true);
         _mountedProvider = provider;
         _mountedThreadId = threadIdToMount;
@@ -883,8 +885,91 @@ public sealed partial class ChatPage : Page
         }
     }
 
+    private async Task ReadChatTextAloudAsync(string text)
+    {
+        if (!await EnsureTtsReadyForChatAsync())
+            return;
+
+        await CurrentApp.SpeakChatTextAsync(text);
+    }
+
+    private async Task OnSpeakerMuteChangedAsync(bool muted)
+    {
+        if (!await _speakerMuteGate.WaitAsync(0))
+            return;
+
+        try
+        {
+            if (muted)
+            {
+                (App.Current as App)?.SetChatSpeakerMuted(true);
+                return;
+            }
+
+            if (IsTtsReadyForChat())
+            {
+                (App.Current as App)?.SetChatSpeakerMuted(false);
+                return;
+            }
+
+            (App.Current as App)?.SetChatSpeakerMuted(true);
+            _functionalHost?.SetSpeakerMuted(true);
+            await ShowTtsUnavailableDialogAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Speaker mute change failed: {ex.Message}");
+        }
+        finally
+        {
+            _speakerMuteGate.Release();
+        }
+    }
+
+    private async Task<bool> EnsureTtsReadyForChatAsync()
+    {
+        if (IsTtsReadyForChat())
+            return true;
+
+        await ShowTtsUnavailableDialogAsync();
+        return false;
+    }
+
+    private static bool IsTtsReadyForChat()
+    {
+        return SpeechSetupReadiness.IsChatTtsPlaybackReady(CurrentApp.Settings);
+    }
+
+    private async Task ShowTtsUnavailableDialogAsync()
+    {
+        var settings = CurrentApp.Settings;
+        if (settings?.NodeTtsEnabled != true)
+        {
+            await ShowVoiceSettingsDialogAsync(
+                LocalizationHelper.GetString("ChatVoiceDialog_OutputOffTitle"),
+                LocalizationHelper.GetString("ChatVoiceDialog_OutputOffMessage"),
+                LocalizationHelper.GetString("ChatVoiceDialog_OpenPermissionsSettings"),
+                NavigateToPermissionsSettings);
+            return;
+        }
+
+        await ShowVoiceSettingsDialogAsync(
+            LocalizationHelper.GetString("ChatVoiceDialog_TtsSetupRequiredTitle"),
+            LocalizationHelper.GetString("ChatVoiceDialog_TtsSetupRequiredMessage"),
+            LocalizationHelper.GetString("ChatVoiceDialog_OpenVoiceSettings"),
+            NavigateToVoiceSettings);
+    }
+
+    private static bool ShouldStartSpeakerMuted(SettingsManager? settings)
+    {
+        return !SpeechSetupReadiness.IsAutomaticChatTtsEnabled(settings);
+    }
+
     private async Task ShowVoiceSettingsDialogAsync(string title, string message, string primaryButtonText, Action openSettings)
     {
+        if (Interlocked.Exchange(ref _voiceSettingsDialogOpen, 1) == 1)
+            return;
+
         var tcs = new TaskCompletionSource();
         if (DispatcherQueue is null || !DispatcherQueue.TryEnqueue(async () =>
         {
@@ -927,10 +1012,18 @@ public sealed partial class ChatPage : Page
             }
         }))
         {
+            Interlocked.Exchange(ref _voiceSettingsDialogOpen, 0);
             return;
         }
 
-        await tcs.Task;
+        try
+        {
+            await tcs.Task;
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _voiceSettingsDialogOpen, 0);
+        }
     }
 
     private void NavigateToVoiceSettings()

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -829,7 +829,8 @@ public sealed partial class ChatPage : Page
             await ShowVoiceSettingsDialogAsync(
                 LocalizationHelper.GetString("ChatVoiceDialog_InputOffTitle"),
                 LocalizationHelper.GetString("ChatVoiceDialog_InputOffMessage"),
-                NavigateToVoiceSettings);
+                LocalizationHelper.GetString("ChatVoiceDialog_OpenPermissionsSettings"),
+                NavigateToPermissionsSettings);
             return null;
         }
 
@@ -840,7 +841,8 @@ public sealed partial class ChatPage : Page
             await ShowVoiceSettingsDialogAsync(
                 LocalizationHelper.GetString("ChatVoiceDialog_InputOffTitle"),
                 LocalizationHelper.GetString("ChatVoiceDialog_InputOffMessage"),
-                NavigateToVoiceSettings);
+                LocalizationHelper.GetString("ChatVoiceDialog_OpenPermissionsSettings"),
+                NavigateToPermissionsSettings);
             return null;
         }
 
@@ -850,6 +852,7 @@ public sealed partial class ChatPage : Page
             await ShowVoiceSettingsDialogAsync(
                 LocalizationHelper.GetString("ChatVoiceDialog_ModelRequiredTitle"),
                 LocalizationHelper.GetString("ChatVoiceDialog_ModelRequiredMessage"),
+                LocalizationHelper.GetString("ChatVoiceDialog_OpenVoiceSettings"),
                 NavigateToVoiceSettings);
             return null;
         }
@@ -880,7 +883,7 @@ public sealed partial class ChatPage : Page
         }
     }
 
-    private async Task ShowVoiceSettingsDialogAsync(string title, string message, Action openVoiceSettings)
+    private async Task ShowVoiceSettingsDialogAsync(string title, string message, string primaryButtonText, Action openSettings)
     {
         var tcs = new TaskCompletionSource();
         if (DispatcherQueue is null || !DispatcherQueue.TryEnqueue(async () =>
@@ -891,7 +894,7 @@ public sealed partial class ChatPage : Page
                 {
                     Title = title,
                     Content = message,
-                    PrimaryButtonText = LocalizationHelper.GetString("ChatVoiceDialog_OpenVoiceSettings"),
+                    PrimaryButtonText = primaryButtonText,
                     CloseButtonText = LocalizationHelper.GetString("ChatVoiceDialog_Dismiss"),
                     DefaultButton = ContentDialogButton.Primary,
                     XamlRoot = Content?.XamlRoot
@@ -912,7 +915,7 @@ public sealed partial class ChatPage : Page
                 };
 
                 if (await dialog.ShowAsync() == ContentDialogResult.Primary)
-                    openVoiceSettings();
+                    openSettings();
             }
             catch (InvalidOperationException ex)
             {
@@ -936,6 +939,14 @@ public sealed partial class ChatPage : Page
             _hub.NavigateTo("voice");
         else
             (App.Current as App)?.ShowHub("voice");
+    }
+
+    private void NavigateToPermissionsSettings()
+    {
+        if (_hub is not null)
+            _hub.NavigateTo("permissions");
+        else
+            (App.Current as App)?.ShowHub("permissions");
     }
 
     private void OnAttachClicked()

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml
@@ -118,8 +118,7 @@
                                   Foreground="{ThemeResource SystemFillColorCautionBrush}"
                                   AutomationProperties.AccessibilityView="Raw"/>
                         <TextBlock x:Name="VoiceSettingsHelpText"
-                                   x:Uid="PermissionsPage_VoiceSettingsHelp"
-                                   Text="You may need to download or select a speech model or voice before these capabilities can work."
+                                   Text=""
                                    Style="{StaticResource CaptionTextBlockStyle}"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    TextWrapping="Wrap"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml
@@ -99,62 +99,17 @@
                 </ItemsRepeater.Layout>
             </ItemsRepeater>
 
-            <!-- ═════════ Speech-to-text engine details (only when STT capability is on) ═════════ -->
-            <Border x:Name="SttCard" Background="{ThemeResource SubtleFillColorSecondaryBrush}"
+            <!-- ═════════ Voice settings link (only when STT or TTS capability is on) ═════════ -->
+            <Border x:Name="VoiceSettingsCard" Background="{ThemeResource SubtleFillColorSecondaryBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1" CornerRadius="8" Padding="16,10,16,12" Margin="0,-4,0,0"
-                    Visibility="Collapsed">
-                <StackPanel Orientation="Horizontal" Spacing="10">
-                    <FontIcon Glyph="&#xE946;" FontSize="14" VerticalAlignment="Top" Margin="0,3,0,0"
-                              Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                    <StackPanel Spacing="4">
-                        <TextBlock x:Name="SttEngineHint"
-                                   Style="{StaticResource CaptionTextBlockStyle}"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap"/>
-                        <HyperlinkButton x:Name="SttMoreSettingsLink"
-                                         x:Uid="PermissionsPage_SttMoreSettingsLink"
-                                         Content="More voice settings…"
-                                         Click="OnSttMoreSettingsClick"
-                                         Padding="0"/>
-                    </StackPanel>
-                </StackPanel>
-            </Border>
-
-            <!-- ═════════ Text-to-speech engine details (only when TTS capability is on) ═════════ -->
-            <Border x:Name="TtsCard" Background="{ThemeResource SubtleFillColorSecondaryBrush}"
-                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                    BorderThickness="1" CornerRadius="8" Padding="16,10,16,12" Margin="0,-4,0,0"
-                    Visibility="Collapsed">
-                <StackPanel Spacing="8">
-                    <ComboBox x:Name="TtsProviderComboBox" x:Uid="PermissionsPage_TtsProviderComboBox" Header="Provider"
-                              SelectionChanged="OnTtsProviderSelectionChanged">
-                        <ComboBoxItem x:Uid="PermissionsPage_TtsProviderPiper" Content="Piper (local ML, recommended)" Tag="piper"/>
-                        <ComboBoxItem x:Uid="PermissionsPage_TtsProviderWindows" Content="Windows built-in speech" Tag="windows"/>
-                        <ComboBoxItem x:Uid="PermissionsPage_TtsProviderElevenLabs" Content="ElevenLabs" Tag="elevenlabs"/>
-                    </ComboBox>
-                    <StackPanel x:Name="TtsElevenLabsPanel" Spacing="6" Visibility="Collapsed">
-                        <PasswordBox x:Name="TtsElevenLabsApiKeyBox"
-                                     x:Uid="PermissionsPage_TtsElevenLabsApiKey"
-                                     Header="ElevenLabs API key"
-                                     LostFocus="OnTtsElevenLabsCommitted"/>
-                        <TextBox x:Name="TtsElevenLabsVoiceIdBox"
-                                 x:Uid="PermissionsPage_TtsElevenLabsVoiceId"
-                                 Header="ElevenLabs voice ID"
-                                 LostFocus="OnTtsElevenLabsCommitted"/>
-                        <TextBox x:Name="TtsElevenLabsModelBox"
-                                 x:Uid="PermissionsPage_TtsElevenLabsModel"
-                                 Header="ElevenLabs model"
-                                 PlaceholderText="eleven_multilingual_v2"
-                                 LostFocus="OnTtsElevenLabsCommitted"/>
-                        <TextBlock x:Uid="PermissionsPage_TtsElevenLabsHelp"
-                                   Text="API key is encrypted at rest with Windows DPAPI. Leave blank to keep the previously saved value when you change other fields."
-                                   Style="{StaticResource CaptionTextBlockStyle}"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap"/>
-                    </StackPanel>
-                    <TextBlock x:Name="TtsStatusText"
-                               Style="{StaticResource CaptionTextBlockStyle}"
-                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                </StackPanel>
+                    Visibility="Collapsed"
+                    AutomationProperties.AutomationId="PermissionsVoiceSettingsCard">
+                <HyperlinkButton x:Name="VoiceSettingsLink"
+                                 x:Uid="PermissionsPage_VoiceSettingsLink"
+                                 Content="Voice &amp; Audio settings"
+                                 Click="OnVoiceSettingsClick"
+                                 Padding="0"/>
             </Border>
 
             <!-- ═════════ Integrations ═════════ -->

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml
@@ -105,11 +105,31 @@
                     BorderThickness="1" CornerRadius="8" Padding="16,10,16,12" Margin="0,-4,0,0"
                     Visibility="Collapsed"
                     AutomationProperties.AutomationId="PermissionsVoiceSettingsCard">
-                <HyperlinkButton x:Name="VoiceSettingsLink"
-                                 x:Uid="PermissionsPage_VoiceSettingsLink"
-                                 Content="Voice &amp; Audio settings"
-                                 Click="OnVoiceSettingsClick"
-                                 Padding="0"/>
+                <StackPanel Spacing="6">
+                    <StackPanel x:Name="VoiceSettingsHelpPanel"
+                                Orientation="Horizontal"
+                                Spacing="8"
+                                Visibility="Collapsed">
+                        <FontIcon x:Name="VoiceSettingsWarningIcon"
+                                  Glyph="&#xE7BA;"
+                                  FontSize="14"
+                                  Margin="0,1,0,0"
+                                  VerticalAlignment="Top"
+                                  Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                                  AutomationProperties.AccessibilityView="Raw"/>
+                        <TextBlock x:Name="VoiceSettingsHelpText"
+                                   x:Uid="PermissionsPage_VoiceSettingsHelp"
+                                   Text="You may need to download or select a speech model or voice before these capabilities can work."
+                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   TextWrapping="Wrap"/>
+                    </StackPanel>
+                    <HyperlinkButton x:Name="VoiceSettingsLink"
+                                     x:Uid="PermissionsPage_VoiceSettingsLink"
+                                     Content="Voice &amp; Audio settings"
+                                     Click="OnVoiceSettingsClick"
+                                     Padding="0"/>
+                </StackPanel>
             </Border>
 
             <!-- ═════════ Integrations ═════════ -->

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
@@ -4,7 +4,6 @@ using Microsoft.UI.Xaml.Media;
 using OpenClaw.Connection;
 using OpenClaw.Shared;
 using OpenClaw.Shared.Audio;
-using OpenClaw.Shared.Capabilities;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using OpenClawTray.Windows;
@@ -290,7 +289,7 @@ public sealed partial class PermissionsPage : Page
     private static VoiceSetupRequirement GetVoiceSetupRequirement(SettingsManager settings)
     {
         var needsSpeechModel = settings.NodeSttEnabled && !IsConfiguredWhisperModelDownloaded(settings);
-        var needsVoiceSetup = settings.NodeTtsEnabled && IsConfiguredTtsProviderSetupRequired(settings);
+        var needsVoiceSetup = settings.NodeTtsEnabled && SpeechSetupReadiness.IsConfiguredTtsProviderSetupRequired(settings);
 
         return (needsSpeechModel, needsVoiceSetup) switch
         {
@@ -325,30 +324,6 @@ public sealed partial class PermissionsPage : Page
 
         var manager = new WhisperModelManager(SettingsManager.SettingsDirectoryPath, new AppLogger());
         return manager.IsModelDownloaded(modelName);
-    }
-
-    private static bool IsConfiguredTtsProviderSetupRequired(SettingsManager settings)
-    {
-        var provider = TtsCapability.ResolveProvider(null, settings.TtsProvider);
-        if (string.Equals(provider, TtsCapability.WindowsProvider, StringComparison.Ordinal))
-            return false;
-
-        if (string.Equals(provider, TtsCapability.PiperProvider, StringComparison.Ordinal))
-        {
-            if (string.IsNullOrWhiteSpace(settings.TtsPiperVoiceId))
-                return true;
-
-            var voices = new PiperVoiceManager(SettingsManager.SettingsDirectoryPath, new AppLogger());
-            return !voices.IsVoiceDownloaded(settings.TtsPiperVoiceId);
-        }
-
-        if (string.Equals(provider, TtsCapability.ElevenLabsProvider, StringComparison.Ordinal))
-        {
-            return string.IsNullOrWhiteSpace(settings.TtsElevenLabsApiKey) ||
-                string.IsNullOrWhiteSpace(settings.TtsElevenLabsVoiceId);
-        }
-
-        return true;
     }
 
     private void OnVoiceSettingsClick(object sender, RoutedEventArgs e)

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
@@ -3,7 +3,6 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using OpenClaw.Connection;
 using OpenClaw.Shared;
-using OpenClaw.Shared.Capabilities;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using OpenClawTray.Windows;
@@ -22,14 +21,9 @@ public sealed partial class PermissionsPage : Page
 {
     private static App CurrentApp => (App)Microsoft.UI.Xaml.Application.Current!;
     private bool _suppressMcpToggle;
-    private bool _suppressTtsProviderChange;
     private readonly List<ToggleSwitch> _featureToggles = new();
     private List<ExecPolicyRule> _policyRules = new();
     private const int BrowserProxyToggleIndex = 1;
-
-    // Sentinel rendered into the API key PasswordBox so the user can see
-    // that a key is already saved without us ever surfacing the plaintext.
-    private const string SavedApiKeySentinel = "••••••••";
 
     public PermissionsPage()
     {
@@ -45,8 +39,7 @@ public sealed partial class PermissionsPage : Page
         BindNodeModeMaster();
         BuildCapabilityToggles();
         UpdateMcpStatus();
-        UpdateSttCard();
-        UpdateTtsCard();
+        UpdateVoiceSettingsCard();
         UpdateNodeStatus();
         ApplyFeaturesEnabledState();
 
@@ -101,8 +94,7 @@ public sealed partial class PermissionsPage : Page
         ((IAppCommands)CurrentApp).NotifySettingsSaved();
         ApplyFeaturesEnabledState();
         UpdateNodeStatus();
-        UpdateSttCard();
-        UpdateTtsCard();
+        UpdateVoiceSettingsCard();
     }
 
     private void OnSettingsSaved(object? sender, EventArgs e)
@@ -115,8 +107,7 @@ public sealed partial class PermissionsPage : Page
             UpdateNodeStatus();
             ReloadFeatureToggleStates();
             UpdateMcpStatus();
-            UpdateSttCard();
-            UpdateTtsCard();
+            UpdateVoiceSettingsCard();
         });
     }
 
@@ -216,8 +207,7 @@ public sealed partial class PermissionsPage : Page
                 settings.Save();
                 ((IAppCommands)CurrentApp).NotifySettingsSaved();
                 capturedSideEffect?.Invoke(toggle.IsOn);
-                UpdateSttCard();
-                UpdateTtsCard();
+                UpdateVoiceSettingsCard();
                 UpdateNodeStatus();
             };
             _featureToggles.Add(toggle);
@@ -228,12 +218,9 @@ public sealed partial class PermissionsPage : Page
     }
 
     private bool _isDownloadingWhisperModel;
-    private string? _whisperDownloadError;
 
     /// <summary>
-    /// Kicks off a Whisper model download if one isn't already on disk. Tracks state
-    /// page-locally so <see cref="UpdateSttEngineHint"/> can surface "downloading" /
-    /// failure copy that's accurate regardless of which code path started the download.
+    /// Kicks off a Whisper model download if one isn't already on disk.
     /// </summary>
     private void EnsureWhisperModelDownloadedAsync() =>
         AsyncEventHandlerGuard.Run(
@@ -255,13 +242,10 @@ public sealed partial class PermissionsPage : Page
             // concurrent writes to the same model file would otherwise be possible.
             if (CurrentApp.VoiceService?.IsWhisperDownloadingModel == true)
             {
-                if (IsLoaded) UpdateSttCard();
                 return;
             }
 
             _isDownloadingWhisperModel = true;
-            _whisperDownloadError = null;
-            if (IsLoaded) UpdateSttCard();
 
             try
             {
@@ -269,13 +253,11 @@ public sealed partial class PermissionsPage : Page
             }
             catch (Exception ex)
             {
-                _whisperDownloadError = ex.Message;
                 logger.Error($"[PermissionsPage] Whisper model download failed: {ex.Message}");
             }
             finally
             {
                 _isDownloadingWhisperModel = false;
-                if (IsLoaded) UpdateSttCard();
             }
         }
         catch (Exception ex)
@@ -332,159 +314,18 @@ public sealed partial class PermissionsPage : Page
         };
     }
 
-    // ── Speech-to-Text card ──────────────────────────────────────────
+    // ── Voice settings link ──────────────────────────────────────────
 
-    private void UpdateSttCard()
+    private void UpdateVoiceSettingsCard()
     {
-        var enabled = CurrentApp.Settings?.NodeSttEnabled == true;
-        SttCard.Visibility = enabled ? Visibility.Visible : Visibility.Collapsed;
-        if (!enabled || CurrentApp.Settings == null) return;
-        UpdateSttEngineHint();
+        var settings = CurrentApp.Settings;
+        var enabled = settings?.NodeSttEnabled == true || settings?.NodeTtsEnabled == true;
+        VoiceSettingsCard.Visibility = enabled ? Visibility.Visible : Visibility.Collapsed;
     }
 
-    private void UpdateSttEngineHint()
-    {
-        var modelName = CurrentApp.Settings?.SttModelName ?? "base";
-        var modelManager = new OpenClaw.Shared.Audio.WhisperModelManager(
-            SettingsManager.SettingsDirectoryPath, new AppLogger());
-        var modelDownloaded = modelManager.IsModelDownloaded(modelName);
-        var modelDownloading = _isDownloadingWhisperModel
-            || (CurrentApp.VoiceService?.IsWhisperDownloadingModel ?? false);
-
-        if (modelDownloaded)
-        {
-            SttEngineHint.Text = LocalizationHelper.GetString("PermissionsPage_SttHint_Ready");
-        }
-        else if (modelDownloading)
-        {
-            SttEngineHint.Text = LocalizationHelper.GetString("PermissionsPage_SttHint_Downloading");
-        }
-        else if (!string.IsNullOrWhiteSpace(_whisperDownloadError))
-        {
-            SttEngineHint.Text = LocalizationHelper.Format(
-                "PermissionsPage_SttHint_FailedFormat", _whisperDownloadError);
-        }
-        else
-        {
-            SttEngineHint.Text = LocalizationHelper.GetString("PermissionsPage_SttHint_NotDownloaded");
-        }
-    }
-
-    private void OnSttMoreSettingsClick(object sender, RoutedEventArgs e)
+    private void OnVoiceSettingsClick(object sender, RoutedEventArgs e)
     {
         ((IAppCommands)CurrentApp).Navigate("voice");
-    }
-
-    // ── Text-to-Speech card ──────────────────────────────────────────
-
-    private void UpdateTtsCard()
-    {
-        var enabled = CurrentApp.Settings?.NodeTtsEnabled == true;
-        TtsCard.Visibility = enabled ? Visibility.Visible : Visibility.Collapsed;
-        if (!enabled || CurrentApp.Settings == null) return;
-
-        var settings = CurrentApp.Settings;
-
-        _suppressTtsProviderChange = true;
-        TtsProviderComboBox.SelectedIndex = settings.TtsProvider switch
-        {
-            var p when string.Equals(p, TtsCapability.ElevenLabsProvider, StringComparison.OrdinalIgnoreCase) => 2,
-            var p when string.Equals(p, TtsCapability.WindowsProvider, StringComparison.OrdinalIgnoreCase)    => 1,
-            _ => 0
-        };
-        _suppressTtsProviderChange = false;
-
-        // Don't overwrite a field the user is currently editing — external Settings.Saved
-        // events can fire while the user has focus on these boxes (Permissions subscribes
-        // to the same event), and rewriting would lose their in-progress input.
-        if (TtsElevenLabsApiKeyBox.FocusState == FocusState.Unfocused)
-        {
-            TtsElevenLabsApiKeyBox.Password =
-                string.IsNullOrEmpty(settings.TtsElevenLabsApiKey) ? "" : SavedApiKeySentinel;
-        }
-        if (TtsElevenLabsVoiceIdBox.FocusState == FocusState.Unfocused)
-        {
-            TtsElevenLabsVoiceIdBox.Text = settings.TtsElevenLabsVoiceId;
-        }
-        if (TtsElevenLabsModelBox.FocusState == FocusState.Unfocused)
-        {
-            TtsElevenLabsModelBox.Text = settings.TtsElevenLabsModel;
-        }
-
-        UpdateTtsElevenLabsPanelVisibility();
-        // No unconditional TtsStatusText reset: this method is dispatched from
-        // OnSettingsSaved, which can fire one frame after a local handler set the
-        // status ("Default provider: x", "ElevenLabs settings saved.") — wiping it
-        // here would erase the auto-save toast. Status is left to the handlers that
-        // explicitly set or clear it.
-    }
-
-    private void UpdateTtsElevenLabsPanelVisibility()
-    {
-        var isEleven = (TtsProviderComboBox.SelectedItem is ComboBoxItem item)
-            && string.Equals(item.Tag as string, TtsCapability.ElevenLabsProvider, StringComparison.OrdinalIgnoreCase);
-        TtsElevenLabsPanel.Visibility = isEleven ? Visibility.Visible : Visibility.Collapsed;
-    }
-
-    private void OnTtsProviderSelectionChanged(object sender, SelectionChangedEventArgs e)
-    {
-        if (_suppressTtsProviderChange) return;
-        if (CurrentApp.Settings == null) return;
-
-        var newProvider = (TtsProviderComboBox.SelectedItem is ComboBoxItem item && item.Tag is string tag)
-            ? tag
-            : TtsCapability.WindowsProvider;
-
-        if (!string.Equals(CurrentApp.Settings.TtsProvider, newProvider, StringComparison.OrdinalIgnoreCase))
-        {
-            CurrentApp.Settings.TtsProvider = newProvider;
-            CurrentApp.Settings.Save();
-            TtsStatusText.Text = LocalizationHelper.Format(
-                "PermissionsPage_TtsStatus_DefaultProviderFormat", newProvider);
-        }
-
-        UpdateTtsElevenLabsPanelVisibility();
-    }
-
-    private void OnTtsElevenLabsCommitted(object sender, RoutedEventArgs e)
-    {
-        if (CurrentApp.Settings == null) return;
-        var settings = CurrentApp.Settings;
-
-        var changed = false;
-
-        var typedKey = TtsElevenLabsApiKeyBox.Password ?? "";
-        if (!string.Equals(typedKey, SavedApiKeySentinel, StringComparison.Ordinal))
-        {
-            var trimmedKey = typedKey.Trim();
-            if (!string.Equals(settings.TtsElevenLabsApiKey, trimmedKey, StringComparison.Ordinal))
-            {
-                settings.TtsElevenLabsApiKey = trimmedKey;
-                changed = true;
-            }
-        }
-
-        var voiceId = TtsElevenLabsVoiceIdBox.Text?.Trim() ?? "";
-        if (!string.Equals(settings.TtsElevenLabsVoiceId, voiceId, StringComparison.Ordinal))
-        {
-            settings.TtsElevenLabsVoiceId = voiceId;
-            changed = true;
-        }
-
-        var model = TtsElevenLabsModelBox.Text?.Trim() ?? "";
-        if (!string.Equals(settings.TtsElevenLabsModel, model, StringComparison.Ordinal))
-        {
-            settings.TtsElevenLabsModel = model;
-            changed = true;
-        }
-
-        if (changed)
-        {
-            settings.Save();
-            TtsElevenLabsApiKeyBox.Password =
-                string.IsNullOrEmpty(settings.TtsElevenLabsApiKey) ? "" : SavedApiKeySentinel;
-            TtsStatusText.Text = LocalizationHelper.GetString("PermissionsPage_TtsStatus_ElevenLabsSaved");
-        }
     }
 
     // ── Node status ──────────────────────────────────────────────────

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
@@ -268,18 +268,50 @@ public sealed partial class PermissionsPage : Page
     {
         var settings = CurrentApp.Settings;
         var enabled = settings?.NodeSttEnabled == true || settings?.NodeTtsEnabled == true;
+        var setupRequirement = settings == null
+            ? VoiceSetupRequirement.None
+            : GetVoiceSetupRequirement(settings);
+
         VoiceSettingsCard.Visibility = enabled ? Visibility.Visible : Visibility.Collapsed;
-        VoiceSettingsHelpPanel.Visibility = settings != null && IsVoiceSetupRequired(settings)
+        VoiceSettingsHelpPanel.Visibility = setupRequirement != VoiceSetupRequirement.None
             ? Visibility.Visible
             : Visibility.Collapsed;
+        VoiceSettingsHelpText.Text = GetVoiceSetupRequirementText(setupRequirement);
     }
 
-    private static bool IsVoiceSetupRequired(SettingsManager settings)
+    private enum VoiceSetupRequirement
     {
-        if (settings.NodeSttEnabled && !IsConfiguredWhisperModelDownloaded(settings))
-            return true;
+        None,
+        SpeechModel,
+        VoiceSetup,
+        SpeechModelAndVoiceSetup
+    }
 
-        return settings.NodeTtsEnabled && IsConfiguredTtsProviderSetupRequired(settings);
+    private static VoiceSetupRequirement GetVoiceSetupRequirement(SettingsManager settings)
+    {
+        var needsSpeechModel = settings.NodeSttEnabled && !IsConfiguredWhisperModelDownloaded(settings);
+        var needsVoiceSetup = settings.NodeTtsEnabled && IsConfiguredTtsProviderSetupRequired(settings);
+
+        return (needsSpeechModel, needsVoiceSetup) switch
+        {
+            (true, true) => VoiceSetupRequirement.SpeechModelAndVoiceSetup,
+            (true, false) => VoiceSetupRequirement.SpeechModel,
+            (false, true) => VoiceSetupRequirement.VoiceSetup,
+            _ => VoiceSetupRequirement.None
+        };
+    }
+
+    private static string GetVoiceSetupRequirementText(VoiceSetupRequirement requirement)
+    {
+        var key = requirement switch
+        {
+            VoiceSetupRequirement.SpeechModel => "PermissionsPage_VoiceSettingsHelp_SpeechModel",
+            VoiceSetupRequirement.VoiceSetup => "PermissionsPage_VoiceSettingsHelp_VoiceSetup",
+            VoiceSetupRequirement.SpeechModelAndVoiceSetup => "PermissionsPage_VoiceSettingsHelp_Both",
+            _ => ""
+        };
+
+        return string.IsNullOrEmpty(key) ? "" : LocalizationHelper.GetString(key);
     }
 
     private static bool IsConfiguredWhisperModelDownloaded(SettingsManager settings)

--- a/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/PermissionsPage.xaml.cs
@@ -3,6 +3,8 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using OpenClaw.Connection;
 using OpenClaw.Shared;
+using OpenClaw.Shared.Audio;
+using OpenClaw.Shared.Capabilities;
 using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using OpenClawTray.Windows;
@@ -150,47 +152,45 @@ public sealed partial class PermissionsPage : Page
         if (CurrentApp.Settings == null) return;
         var settings = CurrentApp.Settings;
 
-        // OnToggleSideEffect runs after the new value is persisted.
-        var capabilities = new (string Icon, string Label, string Description, bool Value, Action<bool> Setter, Action<bool>? OnToggleSideEffect)[]
+        var capabilities = new (string Icon, string Label, string Description, bool Value, Action<bool> Setter)[]
         {
             ("⚡",
                 LocalizationHelper.GetString("PermissionsPage_Cap_SystemRun_Label"),
                 LocalizationHelper.GetString("PermissionsPage_Cap_SystemRun_Description"),
-                settings.NodeSystemRunEnabled, v => settings.NodeSystemRunEnabled = v, null),
+                settings.NodeSystemRunEnabled, v => settings.NodeSystemRunEnabled = v),
             ("🌐",
                 LocalizationHelper.GetString("PermissionsPage_Cap_Browser_Label"),
                 LocalizationHelper.GetString("PermissionsPage_Cap_Browser_Description"),
-                settings.NodeBrowserProxyEnabled, v => settings.NodeBrowserProxyEnabled = v, null),
+                settings.NodeBrowserProxyEnabled, v => settings.NodeBrowserProxyEnabled = v),
             ("📷",
                 LocalizationHelper.GetString("PermissionsPage_Cap_Camera_Label"),
                 LocalizationHelper.GetString("PermissionsPage_Cap_Camera_Description"),
-                settings.NodeCameraEnabled, v => settings.NodeCameraEnabled = v, null),
+                settings.NodeCameraEnabled, v => settings.NodeCameraEnabled = v),
             ("🎨",
                 LocalizationHelper.GetString("PermissionsPage_Cap_Canvas_Label"),
                 LocalizationHelper.GetString("PermissionsPage_Cap_Canvas_Description"),
-                settings.NodeCanvasEnabled, v => settings.NodeCanvasEnabled = v, null),
+                settings.NodeCanvasEnabled, v => settings.NodeCanvasEnabled = v),
             ("🖥️",
                 LocalizationHelper.GetString("PermissionsPage_Cap_Screen_Label"),
                 LocalizationHelper.GetString("PermissionsPage_Cap_Screen_Description"),
-                settings.NodeScreenEnabled, v => settings.NodeScreenEnabled = v, null),
+                settings.NodeScreenEnabled, v => settings.NodeScreenEnabled = v),
             ("📍",
                 LocalizationHelper.GetString("PermissionsPage_Cap_Location_Label"),
                 LocalizationHelper.GetString("PermissionsPage_Cap_Location_Description"),
-                settings.NodeLocationEnabled, v => settings.NodeLocationEnabled = v, null),
+                settings.NodeLocationEnabled, v => settings.NodeLocationEnabled = v),
             ("🔊",
                 LocalizationHelper.GetString("PermissionsPage_Cap_Tts_Label"),
                 LocalizationHelper.GetString("PermissionsPage_Cap_Tts_Description"),
-                settings.NodeTtsEnabled, v => settings.NodeTtsEnabled = v, null),
+                settings.NodeTtsEnabled, v => settings.NodeTtsEnabled = v),
             ("🎤",
                 LocalizationHelper.GetString("PermissionsPage_Cap_Stt_Label"),
                 LocalizationHelper.GetString("PermissionsPage_Cap_Stt_Description"),
-                settings.NodeSttEnabled, v => settings.NodeSttEnabled = v,
-                v => { if (v) EnsureWhisperModelDownloadedAsync(); }),
+                settings.NodeSttEnabled, v => settings.NodeSttEnabled = v),
         };
 
         var items = new List<UIElement>();
         _featureToggles.Clear();
-        foreach (var (icon, label, description, value, setter, sideEffect) in capabilities)
+        foreach (var (icon, label, description, value, setter) in capabilities)
         {
             var toggle = new ToggleSwitch
             {
@@ -200,13 +200,11 @@ public sealed partial class PermissionsPage : Page
                 OffContent = "",
             };
             Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(toggle, label);
-            var capturedSideEffect = sideEffect;
             toggle.Toggled += (s, e) =>
             {
                 setter(toggle.IsOn);
                 settings.Save();
                 ((IAppCommands)CurrentApp).NotifySettingsSaved();
-                capturedSideEffect?.Invoke(toggle.IsOn);
                 UpdateVoiceSettingsCard();
                 UpdateNodeStatus();
             };
@@ -215,56 +213,6 @@ public sealed partial class PermissionsPage : Page
         }
 
         CapabilityRepeater.ItemsSource = items;
-    }
-
-    private bool _isDownloadingWhisperModel;
-
-    /// <summary>
-    /// Kicks off a Whisper model download if one isn't already on disk.
-    /// </summary>
-    private void EnsureWhisperModelDownloadedAsync() =>
-        AsyncEventHandlerGuard.Run(
-            EnsureWhisperModelDownloadedCoreAsync,
-            new OpenClawTray.AppLogger(),
-            nameof(EnsureWhisperModelDownloadedAsync));
-
-    private async Task EnsureWhisperModelDownloadedCoreAsync()
-    {
-        var logger = new AppLogger();
-        try
-        {
-            var modelName = CurrentApp.Settings?.SttModelName ?? "base";
-            var modelManager = new OpenClaw.Shared.Audio.WhisperModelManager(
-                SettingsManager.SettingsDirectoryPath, logger);
-
-            if (modelManager.IsModelDownloaded(modelName) || _isDownloadingWhisperModel) return;
-            // Also defer to a VoiceService-initiated download that may be in flight —
-            // concurrent writes to the same model file would otherwise be possible.
-            if (CurrentApp.VoiceService?.IsWhisperDownloadingModel == true)
-            {
-                return;
-            }
-
-            _isDownloadingWhisperModel = true;
-
-            try
-            {
-                await modelManager.DownloadModelAsync(modelName, progress: null, default).ConfigureAwait(true);
-            }
-            catch (Exception ex)
-            {
-                logger.Error($"[PermissionsPage] Whisper model download failed: {ex.Message}");
-            }
-            finally
-            {
-                _isDownloadingWhisperModel = false;
-            }
-        }
-        catch (Exception ex)
-        {
-            // Last-resort guard: log and swallow so background work can never crash the app.
-            logger.Error($"[PermissionsPage] EnsureWhisperModelDownloadedAsync unexpected failure: {ex}");
-        }
     }
 
     private static Border BuildCapabilityRow(string icon, string label, string description, ToggleSwitch toggle)
@@ -321,6 +269,54 @@ public sealed partial class PermissionsPage : Page
         var settings = CurrentApp.Settings;
         var enabled = settings?.NodeSttEnabled == true || settings?.NodeTtsEnabled == true;
         VoiceSettingsCard.Visibility = enabled ? Visibility.Visible : Visibility.Collapsed;
+        VoiceSettingsHelpPanel.Visibility = settings != null && IsVoiceSetupRequired(settings)
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+    }
+
+    private static bool IsVoiceSetupRequired(SettingsManager settings)
+    {
+        if (settings.NodeSttEnabled && !IsConfiguredWhisperModelDownloaded(settings))
+            return true;
+
+        return settings.NodeTtsEnabled && IsConfiguredTtsProviderSetupRequired(settings);
+    }
+
+    private static bool IsConfiguredWhisperModelDownloaded(SettingsManager settings)
+    {
+        var modelName = settings.SttModelName;
+        if (!WhisperModelManager.AvailableModels.Any(m =>
+                string.Equals(m.Name, modelName, StringComparison.OrdinalIgnoreCase)))
+        {
+            return false;
+        }
+
+        var manager = new WhisperModelManager(SettingsManager.SettingsDirectoryPath, new AppLogger());
+        return manager.IsModelDownloaded(modelName);
+    }
+
+    private static bool IsConfiguredTtsProviderSetupRequired(SettingsManager settings)
+    {
+        var provider = TtsCapability.ResolveProvider(null, settings.TtsProvider);
+        if (string.Equals(provider, TtsCapability.WindowsProvider, StringComparison.Ordinal))
+            return false;
+
+        if (string.Equals(provider, TtsCapability.PiperProvider, StringComparison.Ordinal))
+        {
+            if (string.IsNullOrWhiteSpace(settings.TtsPiperVoiceId))
+                return true;
+
+            var voices = new PiperVoiceManager(SettingsManager.SettingsDirectoryPath, new AppLogger());
+            return !voices.IsVoiceDownloaded(settings.TtsPiperVoiceId);
+        }
+
+        if (string.Equals(provider, TtsCapability.ElevenLabsProvider, StringComparison.Ordinal))
+        {
+            return string.IsNullOrWhiteSpace(settings.TtsElevenLabsApiKey) ||
+                string.IsNullOrWhiteSpace(settings.TtsElevenLabsVoiceId);
+        }
+
+        return true;
     }
 
     private void OnVoiceSettingsClick(object sender, RoutedEventArgs e)

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
@@ -89,21 +89,6 @@
                 </StackPanel>
             </Border>
 
-            <!-- Enable STT -->
-            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                    BorderThickness="1" CornerRadius="8" Padding="16">
-                <StackPanel Spacing="8">
-                    <TextBlock x:Uid="VoiceSettingsPage_SttHeader" x:Name="SttHeaderText" Text="Speech-to-Text" Style="{StaticResource BodyStrongTextBlockStyle}"/>
-                    <TextBlock x:Uid="VoiceSettingsPage_SttDescription" x:Name="SttDescriptionText"
-                               Text="Enable voice input via microphone. Requires a Whisper model download."
-                               Style="{StaticResource CaptionTextBlockStyle}"
-                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap"/>
-                    <ToggleSwitch x:Uid="VoiceSettingsPage_SttEnabledToggle" x:Name="SttEnabledToggle" Toggled="OnSttToggled"
-                                  Header="Enable Voice Input"/>
-                </StackPanel>
-            </Border>
-
             <!-- Model Management -->
             <Border x:Name="ModelCard"
                     Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
@@ -111,6 +96,34 @@
                     BorderThickness="1" CornerRadius="8" Padding="16">
                 <StackPanel Spacing="12">
                     <TextBlock x:Uid="VoiceSettingsPage_ModelHeader" x:Name="ModelHeaderText" Text="Speech Model" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+                    <Border x:Name="SttCapabilityNotice"
+                            Background="{ThemeResource SubtleFillColorSecondaryBrush}"
+                            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                            BorderThickness="1"
+                            CornerRadius="8"
+                            Padding="12"
+                            Visibility="Collapsed">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <FontIcon x:Name="SttCapabilityNoticeIcon"
+                                      Glyph="&#xE7BA;"
+                                      FontSize="14"
+                                      Margin="0,1,0,0"
+                                      VerticalAlignment="Top"
+                                      Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                                      AutomationProperties.AccessibilityView="Raw"/>
+                            <StackPanel Spacing="6">
+                                <TextBlock x:Uid="VoiceSettingsPage_SttCapabilityDisabledNotice"
+                                           Text="Speech-to-text is disabled. Configure models here, then enable the capability in Permissions when you're ready."
+                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           TextWrapping="Wrap"/>
+                                <HyperlinkButton x:Uid="VoiceSettingsPage_OpenPermissionsLink"
+                                                 Content="Open Permissions"
+                                                 Click="OnOpenPermissionsClick"
+                                                 Padding="0"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
                     <TextBlock x:Uid="VoiceSettingsPage_ModelRequirementText" x:Name="ModelRequirementText"
                                Text="Voice input is not ready until at least one speech model is downloaded."
                                Style="{StaticResource CaptionTextBlockStyle}"
@@ -193,7 +206,8 @@
             </Border>
 
             <!-- Language -->
-            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            <Border x:Name="VoiceChatCard"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1" CornerRadius="8" Padding="16">
                 <StackPanel Spacing="8">
@@ -244,6 +258,34 @@
                                Text="Choose the voice used when reading responses aloud."
                                Style="{StaticResource CaptionTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" TextWrapping="Wrap"/>
+                    <Border x:Name="TtsCapabilityNotice"
+                            Background="{ThemeResource SubtleFillColorSecondaryBrush}"
+                            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                            BorderThickness="1"
+                            CornerRadius="8"
+                            Padding="12"
+                            Visibility="Collapsed">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <FontIcon x:Name="TtsCapabilityNoticeIcon"
+                                      Glyph="&#xE7BA;"
+                                      FontSize="14"
+                                      Margin="0,1,0,0"
+                                      VerticalAlignment="Top"
+                                      Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                                      AutomationProperties.AccessibilityView="Raw"/>
+                            <StackPanel Spacing="6">
+                                <TextBlock x:Uid="VoiceSettingsPage_TtsCapabilityDisabledNotice"
+                                           Text="Text-to-speech is disabled. Configure providers and voices here, then enable the capability in Permissions when you're ready."
+                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           TextWrapping="Wrap"/>
+                                <HyperlinkButton x:Uid="VoiceSettingsPage_OpenPermissionsLink"
+                                                 Content="Open Permissions"
+                                                 Click="OnOpenPermissionsClick"
+                                                 Padding="0"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
 
                     <ComboBox x:Uid="VoiceSettingsPage_TtsProviderCombo" x:Name="TtsProviderCombo" Header="Provider"
                               SelectionChanged="OnTtsProviderChanged" Width="360">

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml
@@ -206,8 +206,7 @@
             </Border>
 
             <!-- Language -->
-            <Border x:Name="VoiceChatCard"
-                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            <Border Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1" CornerRadius="8" Padding="16">
                 <StackPanel Spacing="8">

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
@@ -334,8 +334,6 @@ public sealed partial class VoiceSettingsPage : Page
         {
             var settings = CurrentApp.Settings;
 
-            SttEnabledToggle.IsOn = settings.NodeSttEnabled;
-
             // Select model in combo
             for (int i = 0; i < ModelCombo.Items.Count; i++)
             {
@@ -366,7 +364,7 @@ public sealed partial class VoiceSettingsPage : Page
 
             LoadTtsSettings(settings);
             UpdateModelStatus();
-            UpdateCardVisibility();
+            UpdateCapabilityState();
         }
         finally
         {
@@ -404,20 +402,29 @@ public sealed partial class VoiceSettingsPage : Page
         }
     }
 
-    private void UpdateCardVisibility()
+    private void UpdateCapabilityState()
     {
-        ModelCard.Opacity = SttEnabledToggle.IsOn ? 1.0 : 0.5;
-        ModelCard.IsHitTestVisible = SttEnabledToggle.IsOn;
-    }
+        var settings = CurrentApp.Settings;
+        if (settings == null)
+        {
+            SttCapabilityNotice.Visibility = Visibility.Collapsed;
+            TtsCapabilityNotice.Visibility = Visibility.Collapsed;
+            return;
+        }
 
-    private void OnSttToggled(object sender, RoutedEventArgs e)
-    {
-        if (_suppressEvents || CurrentApp.Settings == null) return;
-        CurrentApp.Settings.NodeSttEnabled = SttEnabledToggle.IsOn;
-        CurrentApp.Settings.Save();
-        UpdateCardVisibility();
-        UpdateModelStatus();
-        ((IAppCommands)CurrentApp).NotifySettingsSaved();
+        var sttEnabled = settings?.NodeSttEnabled == true;
+        var ttsEnabled = settings?.NodeTtsEnabled == true;
+
+        SttCapabilityNotice.Visibility = sttEnabled ? Visibility.Collapsed : Visibility.Visible;
+        TtsCapabilityNotice.Visibility = ttsEnabled ? Visibility.Collapsed : Visibility.Visible;
+
+        VoiceChatCard.Opacity = sttEnabled ? 1.0 : 0.5;
+        VoiceChatCard.IsHitTestVisible = sttEnabled;
+
+        TestVoiceButton.IsEnabled = sttEnabled;
+        InlineTestStartBtn.IsEnabled = sttEnabled;
+        PiperPreviewButton.IsEnabled = ttsEnabled && PiperPreviewButton.Visibility == Visibility.Visible;
+        PreviewVoiceButton.IsEnabled = ttsEnabled;
     }
 
     private void OnModelChanged(object sender, SelectionChangedEventArgs e)
@@ -549,6 +556,7 @@ public sealed partial class VoiceSettingsPage : Page
         {
             DownloadButton.IsEnabled = true;
             DownloadProgress.Visibility = Visibility.Collapsed;
+            UpdateCapabilityState();
         }
     }
 
@@ -821,6 +829,7 @@ public sealed partial class VoiceSettingsPage : Page
 
         UpdateTtsProviderVisibility();
         UpdatePiperVoiceState();
+        UpdateCapabilityState();
     }
 
     private void PopulatePiperVoices(SettingsManager settings)
@@ -886,6 +895,7 @@ public sealed partial class VoiceSettingsPage : Page
             PiperStatusText.Text = L("VoiceSettingsPage_PiperVoiceNotDownloaded");
         }
         PiperDownloadProgress.Visibility = Visibility.Collapsed;
+        UpdateCapabilityState();
     }
 
     private void OnPiperDownloadClick(object sender, RoutedEventArgs e) =>
@@ -960,6 +970,7 @@ public sealed partial class VoiceSettingsPage : Page
             PiperDownloadButton.IsEnabled = true;
             PiperDownloadButtonText.Text = L("VoiceSettingsPage_PiperButtonRetry");
             PiperDownloadProgress.Visibility = Visibility.Collapsed;
+            UpdateCapabilityState();
         }
     }
 
@@ -1017,9 +1028,9 @@ public sealed partial class VoiceSettingsPage : Page
         }
         finally
         {
-            PiperPreviewButton.IsEnabled = true;
             PiperPreviewIcon.Glyph = "\uE768";
             PiperPreviewLabel.Text = oldLabel;
+            UpdateCapabilityState();
         }
     }
 
@@ -1079,6 +1090,12 @@ public sealed partial class VoiceSettingsPage : Page
             CurrentApp.Settings.Save();
         }
         UpdateTtsProviderVisibility();
+        UpdateCapabilityState();
+    }
+
+    private void OnOpenPermissionsClick(object sender, RoutedEventArgs e)
+    {
+        ((IAppCommands)CurrentApp).Navigate("permissions");
     }
 
     private void OnWindowsVoiceChanged(object sender, SelectionChangedEventArgs e)
@@ -1134,9 +1151,9 @@ public sealed partial class VoiceSettingsPage : Page
         }
         finally
         {
-            PreviewVoiceButton.IsEnabled = true;
             PreviewVoiceIcon.Glyph = "\uE768";
             PreviewVoiceLabel.Text = L("VoiceSettingsPage_PreviewVoiceButtonContent");
+            UpdateCapabilityState();
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/VoiceSettingsPage.xaml.cs
@@ -29,6 +29,7 @@ public sealed partial class VoiceSettingsPage : Page
 
     private CancellationTokenSource? _whisperDownloadCts;
     private CancellationTokenSource? _piperDownloadCts;
+    private bool _piperPreviewInProgress;
 
     public VoiceSettingsPage()
     {
@@ -417,14 +418,6 @@ public sealed partial class VoiceSettingsPage : Page
 
         SttCapabilityNotice.Visibility = sttEnabled ? Visibility.Collapsed : Visibility.Visible;
         TtsCapabilityNotice.Visibility = ttsEnabled ? Visibility.Collapsed : Visibility.Visible;
-
-        VoiceChatCard.Opacity = sttEnabled ? 1.0 : 0.5;
-        VoiceChatCard.IsHitTestVisible = sttEnabled;
-
-        TestVoiceButton.IsEnabled = sttEnabled;
-        InlineTestStartBtn.IsEnabled = sttEnabled;
-        PiperPreviewButton.IsEnabled = ttsEnabled && PiperPreviewButton.Visibility == Visibility.Visible;
-        PreviewVoiceButton.IsEnabled = ttsEnabled;
     }
 
     private void OnModelChanged(object sender, SelectionChangedEventArgs e)
@@ -884,6 +877,7 @@ public sealed partial class VoiceSettingsPage : Page
         PiperDownloadIcon.Glyph = downloaded ? "\uE73E" : "\uE896";  // checkmark vs download arrow
         PiperDeleteButton.Visibility = downloaded ? Visibility.Visible : Visibility.Collapsed;
         PiperPreviewButton.Visibility = downloaded ? Visibility.Visible : Visibility.Collapsed;
+        PiperPreviewButton.IsEnabled = downloaded && !_piperPreviewInProgress;
 
         if (downloaded)
         {
@@ -1005,6 +999,7 @@ public sealed partial class VoiceSettingsPage : Page
         if (PiperVoiceCombo.SelectedItem is not ComboBoxItem item || item.Tag is not string voiceId) return;
 
         PiperPreviewButton.IsEnabled = false;
+        _piperPreviewInProgress = true;
         var oldLabel = PiperPreviewLabel.Text;
         PiperPreviewLabel.Text = L("VoiceSettingsPage_PreviewButtonPlaying");
 
@@ -1028,9 +1023,10 @@ public sealed partial class VoiceSettingsPage : Page
         }
         finally
         {
+            _piperPreviewInProgress = false;
             PiperPreviewIcon.Glyph = "\uE768";
             PiperPreviewLabel.Text = oldLabel;
-            UpdateCapabilityState();
+            UpdatePiperVoiceState();
         }
     }
 
@@ -1153,7 +1149,7 @@ public sealed partial class VoiceSettingsPage : Page
         {
             PreviewVoiceIcon.Glyph = "\uE768";
             PreviewVoiceLabel.Text = L("VoiceSettingsPage_PreviewVoiceButtonContent");
-            UpdateCapabilityState();
+            PreviewVoiceButton.IsEnabled = true;
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Services/SpeechSetupReadiness.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SpeechSetupReadiness.cs
@@ -1,0 +1,45 @@
+using OpenClaw.Shared.Audio;
+using OpenClaw.Shared.Capabilities;
+
+namespace OpenClawTray.Services;
+
+public static class SpeechSetupReadiness
+{
+    public static bool IsChatTtsPlaybackReady(SettingsManager? settings)
+    {
+        return settings?.NodeTtsEnabled == true &&
+            !IsConfiguredTtsProviderSetupRequired(settings);
+    }
+
+    public static bool IsAutomaticChatTtsEnabled(SettingsManager? settings)
+    {
+        return settings?.VoiceTtsEnabled == true &&
+            IsChatTtsPlaybackReady(settings);
+    }
+
+    public static bool IsConfiguredTtsProviderSetupRequired(SettingsManager settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        var provider = TtsCapability.ResolveProvider(null, settings.TtsProvider);
+        if (string.Equals(provider, TtsCapability.WindowsProvider, StringComparison.Ordinal))
+            return false;
+
+        if (string.Equals(provider, TtsCapability.PiperProvider, StringComparison.Ordinal))
+        {
+            if (string.IsNullOrWhiteSpace(settings.TtsPiperVoiceId))
+                return true;
+
+            var voices = new PiperVoiceManager(SettingsManager.SettingsDirectoryPath, new AppLogger());
+            return !voices.IsVoiceDownloaded(settings.TtsPiperVoiceId);
+        }
+
+        if (string.Equals(provider, TtsCapability.ElevenLabsProvider, StringComparison.Ordinal))
+        {
+            return string.IsNullOrWhiteSpace(settings.TtsElevenLabsApiKey) ||
+                string.IsNullOrWhiteSpace(settings.TtsElevenLabsVoiceId);
+        }
+
+        return true;
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/SpeechSetupReadiness.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SpeechSetupReadiness.cs
@@ -7,8 +7,7 @@ public static class SpeechSetupReadiness
 {
     public static bool IsChatTtsPlaybackReady(SettingsManager? settings)
     {
-        return settings?.NodeTtsEnabled == true &&
-            !IsConfiguredTtsProviderSetupRequired(settings);
+        return settings?.NodeTtsEnabled == true;
     }
 
     public static bool IsAutomaticChatTtsEnabled(SettingsManager? settings)

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2466,10 +2466,10 @@ Use one of these options:
     <value>Download a speech model before speech-to-text can work.</value>
   </data>
   <data name="PermissionsPage_VoiceSettingsHelp_VoiceSetup" xml:space="preserve">
-    <value>Select or download a voice before text-to-speech can work.</value>
+    <value>Your selected TTS provider still needs voice setup; chat read aloud can fall back to Windows speech.</value>
   </data>
   <data name="PermissionsPage_VoiceSettingsHelp_Both" xml:space="preserve">
-    <value>Download a speech model and select or download a voice before speech-to-text and text-to-speech can work.</value>
+    <value>Download a speech model for voice input. Your selected TTS provider also needs voice setup, though chat read aloud can fall back to Windows speech.</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
     <value>Voice &amp; Audio</value>
@@ -2734,12 +2734,6 @@ Use one of these options:
   </data>
   <data name="ChatVoiceDialog_OutputOffMessage" xml:space="preserve">
     <value>Text-to-speech is disabled. Enable the capability in Permissions before using read aloud in chat.</value>
-  </data>
-  <data name="ChatVoiceDialog_TtsSetupRequiredTitle" xml:space="preserve">
-    <value>Voice Setup Required</value>
-  </data>
-  <data name="ChatVoiceDialog_TtsSetupRequiredMessage" xml:space="preserve">
-    <value>Text-to-speech is on, but read aloud will not work until a voice or provider is configured.</value>
   </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
     <value>Open Voice &amp; Audio Settings</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2459,8 +2459,8 @@ Use one of these options:
   <data name="CronPageRemoveJobToolTip.Content" xml:space="preserve">
     <value>Remove job</value>
   </data>
-  <data name="PermissionsPage_SttMoreSettingsLink.Content" xml:space="preserve">
-    <value>More voice settings…</value>
+  <data name="PermissionsPage_VoiceSettingsLink.Content" xml:space="preserve">
+    <value>Voice &amp; Audio settings</value>
   </data>
   <data name="PermissionsPage_TtsElevenLabsApiKey.Header" xml:space="preserve">
     <value>ElevenLabs API key</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2721,7 +2721,7 @@ Use one of these options:
     <value>Voice Input Is Off</value>
   </data>
   <data name="ChatVoiceDialog_InputOffMessage" xml:space="preserve">
-    <value>Turn on Speech-to-Text in Voice settings, then download a speech model before using the microphone in chat.</value>
+    <value>Speech-to-text is disabled. Enable the capability in Permissions before using the microphone in chat.</value>
   </data>
   <data name="ChatVoiceDialog_ModelRequiredTitle" xml:space="preserve">
     <value>Speech Model Required</value>
@@ -2731,6 +2731,9 @@ Use one of these options:
   </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
     <value>Open Voice &amp; Audio Settings</value>
+  </data>
+  <data name="ChatVoiceDialog_OpenPermissionsSettings" xml:space="preserve">
+    <value>Open Permissions</value>
   </data>
   <data name="ChatVoiceDialog_Dismiss" xml:space="preserve">
     <value>Dismiss</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2462,8 +2462,14 @@ Use one of these options:
   <data name="PermissionsPage_VoiceSettingsLink.Content" xml:space="preserve">
     <value>Voice &amp; Audio settings</value>
   </data>
-  <data name="PermissionsPage_VoiceSettingsHelp.Text" xml:space="preserve">
-    <value>You may need to download or select a speech model or voice before these capabilities can work.</value>
+  <data name="PermissionsPage_VoiceSettingsHelp_SpeechModel" xml:space="preserve">
+    <value>Download a speech model before speech-to-text can work.</value>
+  </data>
+  <data name="PermissionsPage_VoiceSettingsHelp_VoiceSetup" xml:space="preserve">
+    <value>Select or download a voice before text-to-speech can work.</value>
+  </data>
+  <data name="PermissionsPage_VoiceSettingsHelp_Both" xml:space="preserve">
+    <value>Download a speech model and select or download a voice before speech-to-text and text-to-speech can work.</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
     <value>Voice &amp; Audio</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -3385,7 +3385,7 @@ Commands are blocked while sandboxing is unavailable because strict fallback blo
     <value>Speech-to-text</value>
   </data>
   <data name="PermissionsPage_Cap_Stt_Description" xml:space="preserve">
-    <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
+    <value>Lets agents transcribe microphone audio locally. Download a speech model in Voice &amp; Audio settings before first use.</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
     <value>System tools</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2729,6 +2729,18 @@ Use one of these options:
   <data name="ChatVoiceDialog_ModelRequiredMessage" xml:space="preserve">
     <value>Speech-to-Text is on, but voice input will not work until at least one speech model is downloaded.</value>
   </data>
+  <data name="ChatVoiceDialog_OutputOffTitle" xml:space="preserve">
+    <value>Voice Output Is Off</value>
+  </data>
+  <data name="ChatVoiceDialog_OutputOffMessage" xml:space="preserve">
+    <value>Text-to-speech is disabled. Enable the capability in Permissions before using read aloud in chat.</value>
+  </data>
+  <data name="ChatVoiceDialog_TtsSetupRequiredTitle" xml:space="preserve">
+    <value>Voice Setup Required</value>
+  </data>
+  <data name="ChatVoiceDialog_TtsSetupRequiredMessage" xml:space="preserve">
+    <value>Text-to-speech is on, but read aloud will not work until a voice or provider is configured.</value>
+  </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
     <value>Open Voice &amp; Audio Settings</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2462,32 +2462,8 @@ Use one of these options:
   <data name="PermissionsPage_VoiceSettingsLink.Content" xml:space="preserve">
     <value>Voice &amp; Audio settings</value>
   </data>
-  <data name="PermissionsPage_TtsElevenLabsApiKey.Header" xml:space="preserve">
-    <value>ElevenLabs API key</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsHelp.Text" xml:space="preserve">
-    <value>API key is encrypted at rest with Windows DPAPI. Leave blank to keep the previously saved value when you change other fields.</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsModel.Header" xml:space="preserve">
-    <value>ElevenLabs model</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsModel.PlaceholderText" xml:space="preserve">
-    <value>eleven_multilingual_v2</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsVoiceId.Header" xml:space="preserve">
-    <value>ElevenLabs voice ID</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderComboBox.Header" xml:space="preserve">
-    <value>Provider</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderElevenLabs.Content" xml:space="preserve">
-    <value>ElevenLabs</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderPiper.Content" xml:space="preserve">
-    <value>Piper (local ML, recommended)</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderWindows.Content" xml:space="preserve">
-    <value>Windows built-in speech</value>
+  <data name="PermissionsPage_VoiceSettingsHelp.Text" xml:space="preserve">
+    <value>You may need to download or select a speech model or voice before these capabilities can work.</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
     <value>Voice &amp; Audio</value>
@@ -3405,18 +3381,6 @@ Commands are blocked while sandboxing is unavailable because strict fallback blo
   <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
     <value>Lets agents run shell commands and scripts on this PC. Turn this off to block all command execution.</value>
   </data>
-  <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
-    <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>
-  </data>
-  <data name="PermissionsPage_SttHint_Downloading" xml:space="preserve">
-    <value>Whisper model is downloading. Speech-to-text will be available once it's ready.</value>
-  </data>
-  <data name="PermissionsPage_SttHint_FailedFormat" xml:space="preserve">
-    <value>Whisper model download failed: {0}. Toggle Speech-to-text off and back on to retry.</value>
-  </data>
-  <data name="PermissionsPage_SttHint_NotDownloaded" xml:space="preserve">
-    <value>Whisper model is not downloaded. Open More voice settings… to download it before using speech-to-text.</value>
-  </data>
   <data name="PermissionsPage_NodeStatus_Disabled" xml:space="preserve">
     <value>Node mode disabled</value>
   </data>
@@ -3482,12 +3446,6 @@ Commands are blocked while sandboxing is unavailable because strict fallback blo
   </data>
   <data name="PermissionsPage_Allowlist_ParseFailed" xml:space="preserve">
     <value>Failed to parse allowlist from config.</value>
-  </data>
-  <data name="PermissionsPage_TtsStatus_DefaultProviderFormat" xml:space="preserve">
-    <value>Default provider: {0}</value>
-  </data>
-  <data name="PermissionsPage_TtsStatus_ElevenLabsSaved" xml:space="preserve">
-    <value>ElevenLabs settings saved.</value>
   </data>
   <data name="PermissionsPage_McpStatus_TokenReadFailedFormat" xml:space="preserve">
     <value>Failed to read token: {0}</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2576,11 +2576,14 @@ Use one of these options:
   <data name="VoiceSettingsPage_SttDescription.Text" xml:space="preserve">
     <value>Enable voice input via microphone. Requires a Whisper model download.</value>
   </data>
-  <data name="VoiceSettingsPage_SttEnabledToggle.Header" xml:space="preserve">
-    <value>Enable Voice Input</value>
-  </data>
   <data name="VoiceSettingsPage_ModelHeader.Text" xml:space="preserve">
     <value>Speech Model</value>
+  </data>
+  <data name="VoiceSettingsPage_SttCapabilityDisabledNotice.Text" xml:space="preserve">
+    <value>Speech-to-text is disabled. Configure models here, then enable the capability in Permissions when you're ready.</value>
+  </data>
+  <data name="VoiceSettingsPage_OpenPermissionsLink.Content" xml:space="preserve">
+    <value>Open Permissions</value>
   </data>
   <data name="VoiceSettingsPage_ModelCombo.Header" xml:space="preserve">
     <value>Model Size</value>
@@ -2647,6 +2650,9 @@ Use one of these options:
   </data>
   <data name="VoiceSettingsPage_VoiceDescription.Text" xml:space="preserve">
     <value>Choose the voice used when reading responses aloud.</value>
+  </data>
+  <data name="VoiceSettingsPage_TtsCapabilityDisabledNotice.Text" xml:space="preserve">
+    <value>Text-to-speech is disabled. Configure providers and voices here, then enable the capability in Permissions when you're ready.</value>
   </data>
   <data name="VoiceSettingsPage_TtsProviderCombo.Header" xml:space="preserve">
     <value>Provider</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2682,6 +2682,18 @@ Utilisez l'une de ces options :
   <data name="ChatVoiceDialog_ModelRequiredMessage" xml:space="preserve">
     <value>La reconnaissance vocale est activée, mais la saisie vocale ne fonctionnera pas tant qu'au moins un modèle vocal n'aura pas été téléchargé.</value>
   </data>
+  <data name="ChatVoiceDialog_OutputOffTitle" xml:space="preserve">
+    <value>Sortie vocale désactivée</value>
+  </data>
+  <data name="ChatVoiceDialog_OutputOffMessage" xml:space="preserve">
+    <value>La synthèse vocale est désactivée. Activez la capacité dans Autorisations avant d'utiliser la lecture à voix haute dans le chat.</value>
+  </data>
+  <data name="ChatVoiceDialog_TtsSetupRequiredTitle" xml:space="preserve">
+    <value>Configuration vocale requise</value>
+  </data>
+  <data name="ChatVoiceDialog_TtsSetupRequiredMessage" xml:space="preserve">
+    <value>La synthèse vocale est activée, mais la lecture à voix haute ne fonctionnera pas tant qu'une voix ou un fournisseur n'aura pas été configuré.</value>
+  </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
     <value>Ouvrir les paramètres Voix et audio</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2419,10 +2419,10 @@ Utilisez l'une de ces options :
     <value>Téléchargez un modèle de reconnaissance vocale avant que la reconnaissance vocale puisse fonctionner.</value>
   </data>
   <data name="PermissionsPage_VoiceSettingsHelp_VoiceSetup" xml:space="preserve">
-    <value>Sélectionnez ou téléchargez une voix avant que la synthèse vocale puisse fonctionner.</value>
+    <value>Le fournisseur TTS sélectionné nécessite encore une configuration vocale ; la lecture à voix haute du chat peut utiliser la synthèse vocale Windows en secours.</value>
   </data>
   <data name="PermissionsPage_VoiceSettingsHelp_Both" xml:space="preserve">
-    <value>Téléchargez un modèle de reconnaissance vocale et sélectionnez ou téléchargez une voix avant que la reconnaissance vocale et la synthèse vocale puissent fonctionner.</value>
+    <value>Téléchargez un modèle de reconnaissance vocale pour la saisie vocale. Le fournisseur TTS sélectionné nécessite aussi une configuration vocale, même si la lecture à voix haute du chat peut utiliser la synthèse vocale Windows en secours.</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
     <value>Voix et audio</value>
@@ -2687,12 +2687,6 @@ Utilisez l'une de ces options :
   </data>
   <data name="ChatVoiceDialog_OutputOffMessage" xml:space="preserve">
     <value>La synthèse vocale est désactivée. Activez la capacité dans Autorisations avant d'utiliser la lecture à voix haute dans le chat.</value>
-  </data>
-  <data name="ChatVoiceDialog_TtsSetupRequiredTitle" xml:space="preserve">
-    <value>Configuration vocale requise</value>
-  </data>
-  <data name="ChatVoiceDialog_TtsSetupRequiredMessage" xml:space="preserve">
-    <value>La synthèse vocale est activée, mais la lecture à voix haute ne fonctionnera pas tant qu'une voix ou un fournisseur n'aura pas été configuré.</value>
   </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
     <value>Ouvrir les paramètres Voix et audio</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2412,8 +2412,8 @@ Utilisez l'une de ces options :
   <data name="CronPageRemoveJobToolTip.Content" xml:space="preserve">
     <value>Supprimer la tâche</value>
   </data>
-  <data name="PermissionsPage_SttMoreSettingsLink.Content" xml:space="preserve">
-    <value>Plus de paramètres vocaux…</value>
+  <data name="PermissionsPage_VoiceSettingsLink.Content" xml:space="preserve">
+    <value>Paramètres Voice &amp; Audio</value>
   </data>
   <data name="PermissionsPage_TtsElevenLabsApiKey.Header" xml:space="preserve">
     <value>Clé API ElevenLabs</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2413,34 +2413,10 @@ Utilisez l'une de ces options :
     <value>Supprimer la tâche</value>
   </data>
   <data name="PermissionsPage_VoiceSettingsLink.Content" xml:space="preserve">
-    <value>Paramètres Voice &amp; Audio</value>
+    <value>Paramètres Voix et audio</value>
   </data>
-  <data name="PermissionsPage_TtsElevenLabsApiKey.Header" xml:space="preserve">
-    <value>Clé API ElevenLabs</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsHelp.Text" xml:space="preserve">
-    <value>La clé API est chiffrée au repos avec Windows DPAPI. Laissez vide pour conserver la valeur précédente lorsque vous modifiez d'autres champs.</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsModel.Header" xml:space="preserve">
-    <value>Modèle ElevenLabs</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsModel.PlaceholderText" xml:space="preserve">
-    <value>eleven_multilingual_v2</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsVoiceId.Header" xml:space="preserve">
-    <value>ID de voix ElevenLabs</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderComboBox.Header" xml:space="preserve">
-    <value>Fournisseur</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderElevenLabs.Content" xml:space="preserve">
-    <value>ElevenLabs</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderPiper.Content" xml:space="preserve">
-    <value>Piper (ML local, recommandé)</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderWindows.Content" xml:space="preserve">
-    <value>Voix intégrée à Windows</value>
+  <data name="PermissionsPage_VoiceSettingsHelp.Text" xml:space="preserve">
+    <value>Vous devrez peut-être télécharger ou sélectionner un modèle vocal ou une voix avant que ces fonctionnalités puissent fonctionner.</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
     <value>Voix et audio</value>
@@ -3358,18 +3334,6 @@ Les commandes sont bloquées tant que le sandboxing est indisponible, car le blo
   <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
     <value>Lets agents run shell commands and scripts on this PC. Turn this off to block all command execution.</value>
   </data>
-  <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
-    <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>
-  </data>
-  <data name="PermissionsPage_SttHint_Downloading" xml:space="preserve">
-    <value>Whisper model is downloading. Speech-to-text will be available once it's ready.</value>
-  </data>
-  <data name="PermissionsPage_SttHint_FailedFormat" xml:space="preserve">
-    <value>Whisper model download failed: {0}. Toggle Speech-to-text off and back on to retry.</value>
-  </data>
-  <data name="PermissionsPage_SttHint_NotDownloaded" xml:space="preserve">
-    <value>Whisper model is not downloaded. Open More voice settings… to download it before using speech-to-text.</value>
-  </data>
   <data name="PermissionsPage_NodeStatus_Disabled" xml:space="preserve">
     <value>Node mode disabled</value>
   </data>
@@ -3435,12 +3399,6 @@ Les commandes sont bloquées tant que le sandboxing est indisponible, car le blo
   </data>
   <data name="PermissionsPage_Allowlist_ParseFailed" xml:space="preserve">
     <value>Failed to parse allowlist from config.</value>
-  </data>
-  <data name="PermissionsPage_TtsStatus_DefaultProviderFormat" xml:space="preserve">
-    <value>Default provider: {0}</value>
-  </data>
-  <data name="PermissionsPage_TtsStatus_ElevenLabsSaved" xml:space="preserve">
-    <value>ElevenLabs settings saved.</value>
   </data>
   <data name="PermissionsPage_McpStatus_TokenReadFailedFormat" xml:space="preserve">
     <value>Failed to read token: {0}</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2674,7 +2674,7 @@ Utilisez l'une de ces options :
     <value>La saisie vocale est désactivée</value>
   </data>
   <data name="ChatVoiceDialog_InputOffMessage" xml:space="preserve">
-    <value>Activez la reconnaissance vocale dans les paramètres Voix, puis téléchargez un modèle vocal avant d'utiliser le microphone dans le chat.</value>
+    <value>La reconnaissance vocale est désactivée. Activez la capacité dans les autorisations avant d'utiliser le microphone dans le chat.</value>
   </data>
   <data name="ChatVoiceDialog_ModelRequiredTitle" xml:space="preserve">
     <value>Modèle vocal requis</value>
@@ -2684,6 +2684,9 @@ Utilisez l'une de ces options :
   </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
     <value>Ouvrir les paramètres Voix et audio</value>
+  </data>
+  <data name="ChatVoiceDialog_OpenPermissionsSettings" xml:space="preserve">
+    <value>Ouvrir les autorisations</value>
   </data>
   <data name="ChatVoiceDialog_Dismiss" xml:space="preserve">
     <value>Fermer</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2529,11 +2529,14 @@ Utilisez l'une de ces options :
   <data name="VoiceSettingsPage_SttDescription.Text" xml:space="preserve">
     <value>Activer la saisie vocale via le microphone. Nécessite le téléchargement d'un modèle Whisper.</value>
   </data>
-  <data name="VoiceSettingsPage_SttEnabledToggle.Header" xml:space="preserve">
-    <value>Activer la saisie vocale</value>
-  </data>
   <data name="VoiceSettingsPage_ModelHeader.Text" xml:space="preserve">
     <value>Modèle vocal</value>
+  </data>
+  <data name="VoiceSettingsPage_SttCapabilityDisabledNotice.Text" xml:space="preserve">
+    <value>La reconnaissance vocale est désactivée. Configurez les modèles ici, puis activez la capacité dans Autorisations lorsque vous êtes prêt.</value>
+  </data>
+  <data name="VoiceSettingsPage_OpenPermissionsLink.Content" xml:space="preserve">
+    <value>Ouvrir les autorisations</value>
   </data>
   <data name="VoiceSettingsPage_ModelCombo.Header" xml:space="preserve">
     <value>Taille du modèle</value>
@@ -2600,6 +2603,9 @@ Utilisez l'une de ces options :
   </data>
   <data name="VoiceSettingsPage_VoiceDescription.Text" xml:space="preserve">
     <value>Choisissez la voix utilisée pour lire les réponses à voix haute.</value>
+  </data>
+  <data name="VoiceSettingsPage_TtsCapabilityDisabledNotice.Text" xml:space="preserve">
+    <value>La synthèse vocale est désactivée. Configurez les fournisseurs et les voix ici, puis activez la capacité dans Autorisations lorsque vous êtes prêt.</value>
   </data>
   <data name="VoiceSettingsPage_TtsProviderCombo.Header" xml:space="preserve">
     <value>Fournisseur</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -3338,7 +3338,7 @@ Les commandes sont bloquées tant que le sandboxing est indisponible, car le blo
     <value>Speech-to-text</value>
   </data>
   <data name="PermissionsPage_Cap_Stt_Description" xml:space="preserve">
-    <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
+    <value>Lets agents transcribe microphone audio locally. Download a speech model in Voice &amp; Audio settings before first use.</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
     <value>System tools</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2415,8 +2415,14 @@ Utilisez l'une de ces options :
   <data name="PermissionsPage_VoiceSettingsLink.Content" xml:space="preserve">
     <value>Paramètres Voix et audio</value>
   </data>
-  <data name="PermissionsPage_VoiceSettingsHelp.Text" xml:space="preserve">
-    <value>Vous devrez peut-être télécharger ou sélectionner un modèle vocal ou une voix avant que ces fonctionnalités puissent fonctionner.</value>
+  <data name="PermissionsPage_VoiceSettingsHelp_SpeechModel" xml:space="preserve">
+    <value>Téléchargez un modèle de reconnaissance vocale avant que la reconnaissance vocale puisse fonctionner.</value>
+  </data>
+  <data name="PermissionsPage_VoiceSettingsHelp_VoiceSetup" xml:space="preserve">
+    <value>Sélectionnez ou téléchargez une voix avant que la synthèse vocale puisse fonctionner.</value>
+  </data>
+  <data name="PermissionsPage_VoiceSettingsHelp_Both" xml:space="preserve">
+    <value>Téléchargez un modèle de reconnaissance vocale et sélectionnez ou téléchargez une voix avant que la reconnaissance vocale et la synthèse vocale puissent fonctionner.</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
     <value>Voix et audio</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2416,8 +2416,14 @@ Gebruik een van deze opties:
   <data name="PermissionsPage_VoiceSettingsLink.Content" xml:space="preserve">
     <value>Spraak- en audio-instellingen</value>
   </data>
-  <data name="PermissionsPage_VoiceSettingsHelp.Text" xml:space="preserve">
-    <value>Mogelijk moet je eerst een spraakmodel of stem downloaden of selecteren voordat deze mogelijkheden werken.</value>
+  <data name="PermissionsPage_VoiceSettingsHelp_SpeechModel" xml:space="preserve">
+    <value>Download een spraakmodel voordat spraak-naar-tekst kan werken.</value>
+  </data>
+  <data name="PermissionsPage_VoiceSettingsHelp_VoiceSetup" xml:space="preserve">
+    <value>Selecteer of download een stem voordat tekst-naar-spraak kan werken.</value>
+  </data>
+  <data name="PermissionsPage_VoiceSettingsHelp_Both" xml:space="preserve">
+    <value>Download een spraakmodel en selecteer of download een stem voordat spraak-naar-tekst en tekst-naar-spraak kunnen werken.</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
     <value>Spraak en audio</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2675,7 +2675,7 @@ Gebruik een van deze opties:
     <value>Spraakinvoer is uitgeschakeld</value>
   </data>
   <data name="ChatVoiceDialog_InputOffMessage" xml:space="preserve">
-    <value>Schakel Spraak-naar-tekst in bij Spraakinstellingen en download daarna een spraakmodel voordat u de microfoon in de chat gebruikt.</value>
+    <value>Spraak-naar-tekst is uitgeschakeld. Schakel de capaciteit in bij Machtigingen voordat u de microfoon in de chat gebruikt.</value>
   </data>
   <data name="ChatVoiceDialog_ModelRequiredTitle" xml:space="preserve">
     <value>Spraakmodel vereist</value>
@@ -2685,6 +2685,9 @@ Gebruik een van deze opties:
   </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
     <value>Spraak- en audio-instellingen openen</value>
+  </data>
+  <data name="ChatVoiceDialog_OpenPermissionsSettings" xml:space="preserve">
+    <value>Machtigingen openen</value>
   </data>
   <data name="ChatVoiceDialog_Dismiss" xml:space="preserve">
     <value>Sluiten</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2420,10 +2420,10 @@ Gebruik een van deze opties:
     <value>Download een spraakmodel voordat spraak-naar-tekst kan werken.</value>
   </data>
   <data name="PermissionsPage_VoiceSettingsHelp_VoiceSetup" xml:space="preserve">
-    <value>Selecteer of download een stem voordat tekst-naar-spraak kan werken.</value>
+    <value>De geselecteerde TTS-provider heeft nog spraakconfiguratie nodig; hardop voorlezen in chat kan terugvallen op Windows-spraak.</value>
   </data>
   <data name="PermissionsPage_VoiceSettingsHelp_Both" xml:space="preserve">
-    <value>Download een spraakmodel en selecteer of download een stem voordat spraak-naar-tekst en tekst-naar-spraak kunnen werken.</value>
+    <value>Download een spraakmodel voor spraakinvoer. De geselecteerde TTS-provider heeft ook spraakconfiguratie nodig, hoewel hardop voorlezen in chat kan terugvallen op Windows-spraak.</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
     <value>Spraak en audio</value>
@@ -2688,12 +2688,6 @@ Gebruik een van deze opties:
   </data>
   <data name="ChatVoiceDialog_OutputOffMessage" xml:space="preserve">
     <value>Tekst-naar-spraak is uitgeschakeld. Schakel de mogelijkheid in Machtigingen in voordat u hardop voorlezen in chat gebruikt.</value>
-  </data>
-  <data name="ChatVoiceDialog_TtsSetupRequiredTitle" xml:space="preserve">
-    <value>Spraakconfiguratie vereist</value>
-  </data>
-  <data name="ChatVoiceDialog_TtsSetupRequiredMessage" xml:space="preserve">
-    <value>Tekst-naar-spraak is ingeschakeld, maar hardop voorlezen werkt pas nadat een stem of provider is geconfigureerd.</value>
   </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
     <value>Spraak- en audio-instellingen openen</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2683,6 +2683,18 @@ Gebruik een van deze opties:
   <data name="ChatVoiceDialog_ModelRequiredMessage" xml:space="preserve">
     <value>Spraak-naar-tekst is ingeschakeld, maar spraakinvoer werkt pas nadat ten minste één spraakmodel is gedownload.</value>
   </data>
+  <data name="ChatVoiceDialog_OutputOffTitle" xml:space="preserve">
+    <value>Spraakuitvoer is uitgeschakeld</value>
+  </data>
+  <data name="ChatVoiceDialog_OutputOffMessage" xml:space="preserve">
+    <value>Tekst-naar-spraak is uitgeschakeld. Schakel de mogelijkheid in Machtigingen in voordat u hardop voorlezen in chat gebruikt.</value>
+  </data>
+  <data name="ChatVoiceDialog_TtsSetupRequiredTitle" xml:space="preserve">
+    <value>Spraakconfiguratie vereist</value>
+  </data>
+  <data name="ChatVoiceDialog_TtsSetupRequiredMessage" xml:space="preserve">
+    <value>Tekst-naar-spraak is ingeschakeld, maar hardop voorlezen werkt pas nadat een stem of provider is geconfigureerd.</value>
+  </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
     <value>Spraak- en audio-instellingen openen</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2414,34 +2414,10 @@ Gebruik een van deze opties:
     <value>Taak verwijderen</value>
   </data>
   <data name="PermissionsPage_VoiceSettingsLink.Content" xml:space="preserve">
-    <value>Instellingen voor Voice &amp; Audio</value>
+    <value>Spraak- en audio-instellingen</value>
   </data>
-  <data name="PermissionsPage_TtsElevenLabsApiKey.Header" xml:space="preserve">
-    <value>ElevenLabs API-sleutel</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsHelp.Text" xml:space="preserve">
-    <value>API-sleutel wordt versleuteld opgeslagen met Windows DPAPI. Laat leeg om de eerder opgeslagen waarde te behouden bij het wijzigen van andere velden.</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsModel.Header" xml:space="preserve">
-    <value>ElevenLabs-model</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsModel.PlaceholderText" xml:space="preserve">
-    <value>eleven_multilingual_v2</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsVoiceId.Header" xml:space="preserve">
-    <value>ElevenLabs stem-ID</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderComboBox.Header" xml:space="preserve">
-    <value>Aanbieder</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderElevenLabs.Content" xml:space="preserve">
-    <value>ElevenLabs</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderPiper.Content" xml:space="preserve">
-    <value>Piper (lokale ML, aanbevolen)</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderWindows.Content" xml:space="preserve">
-    <value>Ingebouwde Windows-spraak</value>
+  <data name="PermissionsPage_VoiceSettingsHelp.Text" xml:space="preserve">
+    <value>Mogelijk moet je eerst een spraakmodel of stem downloaden of selecteren voordat deze mogelijkheden werken.</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
     <value>Spraak en audio</value>
@@ -3359,18 +3335,6 @@ Opdrachten worden geblokkeerd zolang sandboxing niet beschikbaar is, omdat strik
   <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
     <value>Lets agents run shell commands and scripts on this PC. Turn this off to block all command execution.</value>
   </data>
-  <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
-    <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>
-  </data>
-  <data name="PermissionsPage_SttHint_Downloading" xml:space="preserve">
-    <value>Whisper model is downloading. Speech-to-text will be available once it's ready.</value>
-  </data>
-  <data name="PermissionsPage_SttHint_FailedFormat" xml:space="preserve">
-    <value>Whisper model download failed: {0}. Toggle Speech-to-text off and back on to retry.</value>
-  </data>
-  <data name="PermissionsPage_SttHint_NotDownloaded" xml:space="preserve">
-    <value>Whisper model is not downloaded. Open More voice settings… to download it before using speech-to-text.</value>
-  </data>
   <data name="PermissionsPage_NodeStatus_Disabled" xml:space="preserve">
     <value>Node mode disabled</value>
   </data>
@@ -3436,12 +3400,6 @@ Opdrachten worden geblokkeerd zolang sandboxing niet beschikbaar is, omdat strik
   </data>
   <data name="PermissionsPage_Allowlist_ParseFailed" xml:space="preserve">
     <value>Failed to parse allowlist from config.</value>
-  </data>
-  <data name="PermissionsPage_TtsStatus_DefaultProviderFormat" xml:space="preserve">
-    <value>Default provider: {0}</value>
-  </data>
-  <data name="PermissionsPage_TtsStatus_ElevenLabsSaved" xml:space="preserve">
-    <value>ElevenLabs settings saved.</value>
   </data>
   <data name="PermissionsPage_McpStatus_TokenReadFailedFormat" xml:space="preserve">
     <value>Failed to read token: {0}</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -3339,7 +3339,7 @@ Opdrachten worden geblokkeerd zolang sandboxing niet beschikbaar is, omdat strik
     <value>Speech-to-text</value>
   </data>
   <data name="PermissionsPage_Cap_Stt_Description" xml:space="preserve">
-    <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
+    <value>Lets agents transcribe microphone audio locally. Download a speech model in Voice &amp; Audio settings before first use.</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
     <value>System tools</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2413,8 +2413,8 @@ Gebruik een van deze opties:
   <data name="CronPageRemoveJobToolTip.Content" xml:space="preserve">
     <value>Taak verwijderen</value>
   </data>
-  <data name="PermissionsPage_SttMoreSettingsLink.Content" xml:space="preserve">
-    <value>Meer spraakinstellingen…</value>
+  <data name="PermissionsPage_VoiceSettingsLink.Content" xml:space="preserve">
+    <value>Instellingen voor Voice &amp; Audio</value>
   </data>
   <data name="PermissionsPage_TtsElevenLabsApiKey.Header" xml:space="preserve">
     <value>ElevenLabs API-sleutel</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2530,11 +2530,14 @@ Gebruik een van deze opties:
   <data name="VoiceSettingsPage_SttDescription.Text" xml:space="preserve">
     <value>Schakel spraakinvoer via microfoon in. Vereist een Whisper-modeldownload.</value>
   </data>
-  <data name="VoiceSettingsPage_SttEnabledToggle.Header" xml:space="preserve">
-    <value>Spraakinvoer inschakelen</value>
-  </data>
   <data name="VoiceSettingsPage_ModelHeader.Text" xml:space="preserve">
     <value>Spraakmodel</value>
+  </data>
+  <data name="VoiceSettingsPage_SttCapabilityDisabledNotice.Text" xml:space="preserve">
+    <value>Spraak-naar-tekst is uitgeschakeld. Configureer de modellen hier en schakel de mogelijkheid in Machtigingen in wanneer je klaar bent.</value>
+  </data>
+  <data name="VoiceSettingsPage_OpenPermissionsLink.Content" xml:space="preserve">
+    <value>Machtigingen openen</value>
   </data>
   <data name="VoiceSettingsPage_ModelCombo.Header" xml:space="preserve">
     <value>Modelgrootte</value>
@@ -2601,6 +2604,9 @@ Gebruik een van deze opties:
   </data>
   <data name="VoiceSettingsPage_VoiceDescription.Text" xml:space="preserve">
     <value>Kies de stem die wordt gebruikt bij het hardop voorlezen van antwoorden.</value>
+  </data>
+  <data name="VoiceSettingsPage_TtsCapabilityDisabledNotice.Text" xml:space="preserve">
+    <value>Tekst-naar-spraak is uitgeschakeld. Configureer de providers en stemmen hier en schakel de mogelijkheid in Machtigingen in wanneer je klaar bent.</value>
   </data>
   <data name="VoiceSettingsPage_TtsProviderCombo.Header" xml:space="preserve">
     <value>Aanbieder</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2415,8 +2415,14 @@
   <data name="PermissionsPage_VoiceSettingsLink.Content" xml:space="preserve">
     <value>语音和音频设置</value>
   </data>
-  <data name="PermissionsPage_VoiceSettingsHelp.Text" xml:space="preserve">
-    <value>你可能需要先下载或选择语音模型或语音，这些功能才能正常工作。</value>
+  <data name="PermissionsPage_VoiceSettingsHelp_SpeechModel" xml:space="preserve">
+    <value>请先下载语音模型，语音转文本才能正常工作。</value>
+  </data>
+  <data name="PermissionsPage_VoiceSettingsHelp_VoiceSetup" xml:space="preserve">
+    <value>请先选择或下载语音，文本转语音才能正常工作。</value>
+  </data>
+  <data name="PermissionsPage_VoiceSettingsHelp_Both" xml:space="preserve">
+    <value>请先下载语音模型并选择或下载语音，语音转文本和文本转语音才能正常工作。</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
     <value>语音和音频</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2413,34 +2413,10 @@
     <value>删除任务</value>
   </data>
   <data name="PermissionsPage_VoiceSettingsLink.Content" xml:space="preserve">
-    <value>Voice &amp; Audio 设置</value>
+    <value>语音和音频设置</value>
   </data>
-  <data name="PermissionsPage_TtsElevenLabsApiKey.Header" xml:space="preserve">
-    <value>ElevenLabs API 密钥</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsHelp.Text" xml:space="preserve">
-    <value>API 密钥使用 Windows DPAPI 加密保存。修改其他字段时如保持为空，则保留先前保存的值。</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsModel.Header" xml:space="preserve">
-    <value>ElevenLabs 模型</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsModel.PlaceholderText" xml:space="preserve">
-    <value>eleven_multilingual_v2</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsVoiceId.Header" xml:space="preserve">
-    <value>ElevenLabs 语音 ID</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderComboBox.Header" xml:space="preserve">
-    <value>提供程序</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderElevenLabs.Content" xml:space="preserve">
-    <value>ElevenLabs</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderPiper.Content" xml:space="preserve">
-    <value>Piper（本地 ML，推荐）</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderWindows.Content" xml:space="preserve">
-    <value>Windows 内置语音</value>
+  <data name="PermissionsPage_VoiceSettingsHelp.Text" xml:space="preserve">
+    <value>你可能需要先下载或选择语音模型或语音，这些功能才能正常工作。</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
     <value>语音和音频</value>
@@ -3358,18 +3334,6 @@
   <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
     <value>Lets agents run shell commands and scripts on this PC. Turn this off to block all command execution.</value>
   </data>
-  <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
-    <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>
-  </data>
-  <data name="PermissionsPage_SttHint_Downloading" xml:space="preserve">
-    <value>Whisper model is downloading. Speech-to-text will be available once it's ready.</value>
-  </data>
-  <data name="PermissionsPage_SttHint_FailedFormat" xml:space="preserve">
-    <value>Whisper model download failed: {0}. Toggle Speech-to-text off and back on to retry.</value>
-  </data>
-  <data name="PermissionsPage_SttHint_NotDownloaded" xml:space="preserve">
-    <value>Whisper model is not downloaded. Open More voice settings… to download it before using speech-to-text.</value>
-  </data>
   <data name="PermissionsPage_NodeStatus_Disabled" xml:space="preserve">
     <value>Node mode disabled</value>
   </data>
@@ -3435,12 +3399,6 @@
   </data>
   <data name="PermissionsPage_Allowlist_ParseFailed" xml:space="preserve">
     <value>Failed to parse allowlist from config.</value>
-  </data>
-  <data name="PermissionsPage_TtsStatus_DefaultProviderFormat" xml:space="preserve">
-    <value>Default provider: {0}</value>
-  </data>
-  <data name="PermissionsPage_TtsStatus_ElevenLabsSaved" xml:space="preserve">
-    <value>ElevenLabs settings saved.</value>
   </data>
   <data name="PermissionsPage_McpStatus_TokenReadFailedFormat" xml:space="preserve">
     <value>Failed to read token: {0}</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2682,6 +2682,18 @@
   <data name="ChatVoiceDialog_ModelRequiredMessage" xml:space="preserve">
     <value>语音转文字已开启，但至少下载一个语音模型后，语音输入才会工作。</value>
   </data>
+  <data name="ChatVoiceDialog_OutputOffTitle" xml:space="preserve">
+    <value>语音输出已关闭</value>
+  </data>
+  <data name="ChatVoiceDialog_OutputOffMessage" xml:space="preserve">
+    <value>文字转语音已禁用。请先在“权限”中启用该功能，然后再在聊天中使用朗读。</value>
+  </data>
+  <data name="ChatVoiceDialog_TtsSetupRequiredTitle" xml:space="preserve">
+    <value>需要语音设置</value>
+  </data>
+  <data name="ChatVoiceDialog_TtsSetupRequiredMessage" xml:space="preserve">
+    <value>文字转语音已开启，但需要先配置语音或提供程序后，朗读才会工作。</value>
+  </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
     <value>打开语音和音频设置</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2419,10 +2419,10 @@
     <value>请先下载语音模型，语音转文本才能正常工作。</value>
   </data>
   <data name="PermissionsPage_VoiceSettingsHelp_VoiceSetup" xml:space="preserve">
-    <value>请先选择或下载语音，文本转语音才能正常工作。</value>
+    <value>所选 TTS 提供程序仍需要语音设置；聊天朗读可以回退到 Windows 语音。</value>
   </data>
   <data name="PermissionsPage_VoiceSettingsHelp_Both" xml:space="preserve">
-    <value>请先下载语音模型并选择或下载语音，语音转文本和文本转语音才能正常工作。</value>
+    <value>请为语音输入下载语音模型。所选 TTS 提供程序也需要语音设置，但聊天朗读可以回退到 Windows 语音。</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
     <value>语音和音频</value>
@@ -2687,12 +2687,6 @@
   </data>
   <data name="ChatVoiceDialog_OutputOffMessage" xml:space="preserve">
     <value>文字转语音已禁用。请先在“权限”中启用该功能，然后再在聊天中使用朗读。</value>
-  </data>
-  <data name="ChatVoiceDialog_TtsSetupRequiredTitle" xml:space="preserve">
-    <value>需要语音设置</value>
-  </data>
-  <data name="ChatVoiceDialog_TtsSetupRequiredMessage" xml:space="preserve">
-    <value>文字转语音已开启，但需要先配置语音或提供程序后，朗读才会工作。</value>
   </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
     <value>打开语音和音频设置</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2412,8 +2412,8 @@
   <data name="CronPageRemoveJobToolTip.Content" xml:space="preserve">
     <value>删除任务</value>
   </data>
-  <data name="PermissionsPage_SttMoreSettingsLink.Content" xml:space="preserve">
-    <value>更多语音设置…</value>
+  <data name="PermissionsPage_VoiceSettingsLink.Content" xml:space="preserve">
+    <value>Voice &amp; Audio 设置</value>
   </data>
   <data name="PermissionsPage_TtsElevenLabsApiKey.Header" xml:space="preserve">
     <value>ElevenLabs API 密钥</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2529,11 +2529,14 @@
   <data name="VoiceSettingsPage_SttDescription.Text" xml:space="preserve">
     <value>通过麦克风启用语音输入。需要下载 Whisper 模型。</value>
   </data>
-  <data name="VoiceSettingsPage_SttEnabledToggle.Header" xml:space="preserve">
-    <value>启用语音输入</value>
-  </data>
   <data name="VoiceSettingsPage_ModelHeader.Text" xml:space="preserve">
     <value>语音模型</value>
+  </data>
+  <data name="VoiceSettingsPage_SttCapabilityDisabledNotice.Text" xml:space="preserve">
+    <value>语音转文本已禁用。请先在此配置模型，准备好后再在“权限”中启用此功能。</value>
+  </data>
+  <data name="VoiceSettingsPage_OpenPermissionsLink.Content" xml:space="preserve">
+    <value>打开权限</value>
   </data>
   <data name="VoiceSettingsPage_ModelCombo.Header" xml:space="preserve">
     <value>模型大小</value>
@@ -2600,6 +2603,9 @@
   </data>
   <data name="VoiceSettingsPage_VoiceDescription.Text" xml:space="preserve">
     <value>选择朗读响应时使用的语音。</value>
+  </data>
+  <data name="VoiceSettingsPage_TtsCapabilityDisabledNotice.Text" xml:space="preserve">
+    <value>文本转语音已禁用。请先在此配置提供程序和语音，准备好后再在“权限”中启用此功能。</value>
   </data>
   <data name="VoiceSettingsPage_TtsProviderCombo.Header" xml:space="preserve">
     <value>提供商</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2674,7 +2674,7 @@
     <value>语音输入已关闭</value>
   </data>
   <data name="ChatVoiceDialog_InputOffMessage" xml:space="preserve">
-    <value>请在语音设置中开启语音转文字，然后下载语音模型，才能在聊天中使用麦克风。</value>
+    <value>语音转文字已禁用。请先在“权限”中启用此功能，然后再在聊天中使用麦克风。</value>
   </data>
   <data name="ChatVoiceDialog_ModelRequiredTitle" xml:space="preserve">
     <value>需要语音模型</value>
@@ -2684,6 +2684,9 @@
   </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
     <value>打开语音和音频设置</value>
+  </data>
+  <data name="ChatVoiceDialog_OpenPermissionsSettings" xml:space="preserve">
+    <value>打开权限</value>
   </data>
   <data name="ChatVoiceDialog_Dismiss" xml:space="preserve">
     <value>关闭</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -3338,7 +3338,7 @@
     <value>Speech-to-text</value>
   </data>
   <data name="PermissionsPage_Cap_Stt_Description" xml:space="preserve">
-    <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
+    <value>Lets agents transcribe microphone audio locally. Download a speech model in Voice &amp; Audio settings before first use.</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
     <value>System tools</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2419,10 +2419,10 @@
     <value>請先下載語音模型，語音轉文字才能正常運作。</value>
   </data>
   <data name="PermissionsPage_VoiceSettingsHelp_VoiceSetup" xml:space="preserve">
-    <value>請先選取或下載語音，文字轉語音才能正常運作。</value>
+    <value>所選 TTS 提供者仍需要語音設定；聊天朗讀可以回退到 Windows 語音。</value>
   </data>
   <data name="PermissionsPage_VoiceSettingsHelp_Both" xml:space="preserve">
-    <value>請先下載語音模型並選取或下載語音，語音轉文字和文字轉語音才能正常運作。</value>
+    <value>請為語音輸入下載語音模型。所選 TTS 提供者也需要語音設定，但聊天朗讀可以回退到 Windows 語音。</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
     <value>語音與音訊</value>
@@ -2687,12 +2687,6 @@
   </data>
   <data name="ChatVoiceDialog_OutputOffMessage" xml:space="preserve">
     <value>文字轉語音已停用。請先在「權限」中啟用此功能，然後再在聊天中使用朗讀。</value>
-  </data>
-  <data name="ChatVoiceDialog_TtsSetupRequiredTitle" xml:space="preserve">
-    <value>需要語音設定</value>
-  </data>
-  <data name="ChatVoiceDialog_TtsSetupRequiredMessage" xml:space="preserve">
-    <value>文字轉語音已開啟，但需要先設定語音或提供者後，朗讀才會運作。</value>
   </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
     <value>開啟語音和音訊設定</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2674,7 +2674,7 @@
     <value>語音輸入已關閉</value>
   </data>
   <data name="ChatVoiceDialog_InputOffMessage" xml:space="preserve">
-    <value>請在語音設定中開啟語音轉文字，然後下載語音模型，才能在聊天中使用麥克風。</value>
+    <value>語音轉文字已停用。請先在「權限」中啟用此功能，然後再在聊天中使用麥克風。</value>
   </data>
   <data name="ChatVoiceDialog_ModelRequiredTitle" xml:space="preserve">
     <value>需要語音模型</value>
@@ -2684,6 +2684,9 @@
   </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
     <value>開啟語音和音訊設定</value>
+  </data>
+  <data name="ChatVoiceDialog_OpenPermissionsSettings" xml:space="preserve">
+    <value>開啟權限</value>
   </data>
   <data name="ChatVoiceDialog_Dismiss" xml:space="preserve">
     <value>關閉</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2413,34 +2413,10 @@
     <value>刪除工作</value>
   </data>
   <data name="PermissionsPage_VoiceSettingsLink.Content" xml:space="preserve">
-    <value>Voice &amp; Audio 設定</value>
+    <value>語音與音訊設定</value>
   </data>
-  <data name="PermissionsPage_TtsElevenLabsApiKey.Header" xml:space="preserve">
-    <value>ElevenLabs API 金鑰</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsHelp.Text" xml:space="preserve">
-    <value>API 金鑰會使用 Windows DPAPI 加密儲存。修改其他欄位時若保持空白，則保留先前儲存的值。</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsModel.Header" xml:space="preserve">
-    <value>ElevenLabs 模型</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsModel.PlaceholderText" xml:space="preserve">
-    <value>eleven_multilingual_v2</value>
-  </data>
-  <data name="PermissionsPage_TtsElevenLabsVoiceId.Header" xml:space="preserve">
-    <value>ElevenLabs 語音 ID</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderComboBox.Header" xml:space="preserve">
-    <value>提供者</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderElevenLabs.Content" xml:space="preserve">
-    <value>ElevenLabs</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderPiper.Content" xml:space="preserve">
-    <value>Piper（本機 ML，建議）</value>
-  </data>
-  <data name="PermissionsPage_TtsProviderWindows.Content" xml:space="preserve">
-    <value>Windows 內建語音</value>
+  <data name="PermissionsPage_VoiceSettingsHelp.Text" xml:space="preserve">
+    <value>你可能需要先下載或選取語音模型或語音，這些功能才能正常運作。</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
     <value>語音與音訊</value>
@@ -3358,18 +3334,6 @@
   <data name="PermissionsPage_Cap_SystemRun_Description" xml:space="preserve">
     <value>Lets agents run shell commands and scripts on this PC. Turn this off to block all command execution.</value>
   </data>
-  <data name="PermissionsPage_SttHint_Ready" xml:space="preserve">
-    <value>Whisper model is ready. Speech-to-text runs fully on this PC; no audio leaves the device.</value>
-  </data>
-  <data name="PermissionsPage_SttHint_Downloading" xml:space="preserve">
-    <value>Whisper model is downloading. Speech-to-text will be available once it's ready.</value>
-  </data>
-  <data name="PermissionsPage_SttHint_FailedFormat" xml:space="preserve">
-    <value>Whisper model download failed: {0}. Toggle Speech-to-text off and back on to retry.</value>
-  </data>
-  <data name="PermissionsPage_SttHint_NotDownloaded" xml:space="preserve">
-    <value>Whisper model is not downloaded. Open More voice settings… to download it before using speech-to-text.</value>
-  </data>
   <data name="PermissionsPage_NodeStatus_Disabled" xml:space="preserve">
     <value>Node mode disabled</value>
   </data>
@@ -3435,12 +3399,6 @@
   </data>
   <data name="PermissionsPage_Allowlist_ParseFailed" xml:space="preserve">
     <value>Failed to parse allowlist from config.</value>
-  </data>
-  <data name="PermissionsPage_TtsStatus_DefaultProviderFormat" xml:space="preserve">
-    <value>Default provider: {0}</value>
-  </data>
-  <data name="PermissionsPage_TtsStatus_ElevenLabsSaved" xml:space="preserve">
-    <value>ElevenLabs settings saved.</value>
   </data>
   <data name="PermissionsPage_McpStatus_TokenReadFailedFormat" xml:space="preserve">
     <value>Failed to read token: {0}</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2682,6 +2682,18 @@
   <data name="ChatVoiceDialog_ModelRequiredMessage" xml:space="preserve">
     <value>語音轉文字已開啟，但至少下載一個語音模型後，語音輸入才會運作。</value>
   </data>
+  <data name="ChatVoiceDialog_OutputOffTitle" xml:space="preserve">
+    <value>語音輸出已關閉</value>
+  </data>
+  <data name="ChatVoiceDialog_OutputOffMessage" xml:space="preserve">
+    <value>文字轉語音已停用。請先在「權限」中啟用此功能，然後再在聊天中使用朗讀。</value>
+  </data>
+  <data name="ChatVoiceDialog_TtsSetupRequiredTitle" xml:space="preserve">
+    <value>需要語音設定</value>
+  </data>
+  <data name="ChatVoiceDialog_TtsSetupRequiredMessage" xml:space="preserve">
+    <value>文字轉語音已開啟，但需要先設定語音或提供者後，朗讀才會運作。</value>
+  </data>
   <data name="ChatVoiceDialog_OpenVoiceSettings" xml:space="preserve">
     <value>開啟語音和音訊設定</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2415,8 +2415,14 @@
   <data name="PermissionsPage_VoiceSettingsLink.Content" xml:space="preserve">
     <value>語音與音訊設定</value>
   </data>
-  <data name="PermissionsPage_VoiceSettingsHelp.Text" xml:space="preserve">
-    <value>你可能需要先下載或選取語音模型或語音，這些功能才能正常運作。</value>
+  <data name="PermissionsPage_VoiceSettingsHelp_SpeechModel" xml:space="preserve">
+    <value>請先下載語音模型，語音轉文字才能正常運作。</value>
+  </data>
+  <data name="PermissionsPage_VoiceSettingsHelp_VoiceSetup" xml:space="preserve">
+    <value>請先選取或下載語音，文字轉語音才能正常運作。</value>
+  </data>
+  <data name="PermissionsPage_VoiceSettingsHelp_Both" xml:space="preserve">
+    <value>請先下載語音模型並選取或下載語音，語音轉文字和文字轉語音才能正常運作。</value>
   </data>
   <data name="VoiceSettingsPage_PageTitle.Text" xml:space="preserve">
     <value>語音與音訊</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2412,8 +2412,8 @@
   <data name="CronPageRemoveJobToolTip.Content" xml:space="preserve">
     <value>刪除工作</value>
   </data>
-  <data name="PermissionsPage_SttMoreSettingsLink.Content" xml:space="preserve">
-    <value>更多語音設定…</value>
+  <data name="PermissionsPage_VoiceSettingsLink.Content" xml:space="preserve">
+    <value>Voice &amp; Audio 設定</value>
   </data>
   <data name="PermissionsPage_TtsElevenLabsApiKey.Header" xml:space="preserve">
     <value>ElevenLabs API 金鑰</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2529,11 +2529,14 @@
   <data name="VoiceSettingsPage_SttDescription.Text" xml:space="preserve">
     <value>透過麥克風啟用語音輸入。需要下載 Whisper 模型。</value>
   </data>
-  <data name="VoiceSettingsPage_SttEnabledToggle.Header" xml:space="preserve">
-    <value>啟用語音輸入</value>
-  </data>
   <data name="VoiceSettingsPage_ModelHeader.Text" xml:space="preserve">
     <value>語音模型</value>
+  </data>
+  <data name="VoiceSettingsPage_SttCapabilityDisabledNotice.Text" xml:space="preserve">
+    <value>語音轉文字已停用。請先在此設定模型，準備好後再於「權限」中啟用此功能。</value>
+  </data>
+  <data name="VoiceSettingsPage_OpenPermissionsLink.Content" xml:space="preserve">
+    <value>開啟權限</value>
   </data>
   <data name="VoiceSettingsPage_ModelCombo.Header" xml:space="preserve">
     <value>模型大小</value>
@@ -2600,6 +2603,9 @@
   </data>
   <data name="VoiceSettingsPage_VoiceDescription.Text" xml:space="preserve">
     <value>選擇朗讀回應時使用的語音。</value>
+  </data>
+  <data name="VoiceSettingsPage_TtsCapabilityDisabledNotice.Text" xml:space="preserve">
+    <value>文字轉語音已停用。請先在此設定提供者和語音，準備好後再於「權限」中啟用此功能。</value>
   </data>
   <data name="VoiceSettingsPage_TtsProviderCombo.Header" xml:space="preserve">
     <value>提供者</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -3338,7 +3338,7 @@
     <value>Speech-to-text</value>
   </data>
   <data name="PermissionsPage_Cap_Stt_Description" xml:space="preserve">
-    <value>Lets agents transcribe microphone audio locally using Whisper. Turning this on downloads the Whisper model (~140 MB) on first use.</value>
+    <value>Lets agents transcribe microphone audio locally. Download a speech model in Voice &amp; Audio settings before first use.</value>
   </data>
   <data name="PermissionsPage_Cap_SystemRun_Label" xml:space="preserve">
     <value>System tools</value>

--- a/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
@@ -502,7 +502,8 @@ public sealed partial class ChatWindow : WindowEx
             await ShowVoiceSettingsDialogAsync(
                 LocalizationHelper.GetString("ChatVoiceDialog_InputOffTitle"),
                 LocalizationHelper.GetString("ChatVoiceDialog_InputOffMessage"),
-                () => app?.ShowHub("voice"));
+                LocalizationHelper.GetString("ChatVoiceDialog_OpenPermissionsSettings"),
+                () => app?.ShowHub("permissions"));
             return null;
         }
 
@@ -513,7 +514,8 @@ public sealed partial class ChatWindow : WindowEx
             await ShowVoiceSettingsDialogAsync(
                 LocalizationHelper.GetString("ChatVoiceDialog_InputOffTitle"),
                 LocalizationHelper.GetString("ChatVoiceDialog_InputOffMessage"),
-                () => app.ShowHub("voice"));
+                LocalizationHelper.GetString("ChatVoiceDialog_OpenPermissionsSettings"),
+                () => app.ShowHub("permissions"));
             return null;
         }
 
@@ -523,6 +525,7 @@ public sealed partial class ChatWindow : WindowEx
             await ShowVoiceSettingsDialogAsync(
                 LocalizationHelper.GetString("ChatVoiceDialog_ModelRequiredTitle"),
                 LocalizationHelper.GetString("ChatVoiceDialog_ModelRequiredMessage"),
+                LocalizationHelper.GetString("ChatVoiceDialog_OpenVoiceSettings"),
                 () => app.ShowHub("voice"));
             return null;
         }
@@ -552,7 +555,7 @@ public sealed partial class ChatWindow : WindowEx
         }
     }
 
-    private async Task ShowVoiceSettingsDialogAsync(string title, string message, Action openVoiceSettings)
+    private async Task ShowVoiceSettingsDialogAsync(string title, string message, string primaryButtonText, Action openSettings)
     {
         var tcs = new TaskCompletionSource();
         if (DispatcherQueue is null || !DispatcherQueue.TryEnqueue(async () =>
@@ -563,7 +566,7 @@ public sealed partial class ChatWindow : WindowEx
                 {
                     Title = title,
                     Content = message,
-                    PrimaryButtonText = LocalizationHelper.GetString("ChatVoiceDialog_OpenVoiceSettings"),
+                    PrimaryButtonText = primaryButtonText,
                     CloseButtonText = LocalizationHelper.GetString("ChatVoiceDialog_Dismiss"),
                     DefaultButton = ContentDialogButton.Primary,
                     XamlRoot = Content?.XamlRoot
@@ -584,7 +587,7 @@ public sealed partial class ChatWindow : WindowEx
                 };
 
                 if (await dialog.ShowAsync() == ContentDialogResult.Primary)
-                    openVoiceSettings();
+                    openSettings();
             }
             catch (InvalidOperationException ex)
             {

--- a/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
@@ -30,6 +30,8 @@ public sealed partial class ChatWindow : WindowEx
     private bool _webViewInitialized;
     private bool _webViewMode;
     private bool _shownNearTray;
+    private readonly SemaphoreSlim _speakerMuteGate = new(1, 1);
+    private int _voiceSettingsDialogOpen;
     public bool IsClosed { get; private set; }
 
     [DllImport("user32.dll")] private static extern int GetWindowLong(IntPtr hWnd, int nIndex);
@@ -402,7 +404,7 @@ public sealed partial class ChatWindow : WindowEx
     {
         var app = App.Current as App;
         var provider = app?.ChatProvider;
-        Func<string, Task>? readAloud = app is null ? null : app.SpeakChatTextAsync;
+        Func<string, Task>? readAloud = app is null ? null : ReadChatTextAloudAsync;
 
         if (_functionalHost is not null && ReferenceEquals(_mountedProvider, provider))
         {
@@ -433,8 +435,8 @@ public sealed partial class ChatWindow : WindowEx
             onVoiceRequest: VoiceTranscribeAsync,
             onAttachClick: OnAttachClicked,
             onSettingsClick: () => appInstance?.ShowHub("voice"),
-            onSpeakerMuteChanged: muted => appInstance?.SetChatSpeakerMuted(muted),
-            initialMuted: appInstance?.Settings?.VoiceTtsEnabled == false,
+            onSpeakerMuteChanged: muted => _ = OnSpeakerMuteChangedAsync(muted),
+            initialMuted: ShouldStartSpeakerMuted(appInstance?.Settings),
             isCompact: true);
         _mountedProvider = provider;
         UpdateNativeChatSurfaceActive();
@@ -555,8 +557,94 @@ public sealed partial class ChatWindow : WindowEx
         }
     }
 
+    private async Task ReadChatTextAloudAsync(string text)
+    {
+        if (!await EnsureTtsReadyForChatAsync())
+            return;
+
+        if (App.Current is App app)
+            await app.SpeakChatTextAsync(text);
+    }
+
+    private async Task OnSpeakerMuteChangedAsync(bool muted)
+    {
+        if (!await _speakerMuteGate.WaitAsync(0))
+            return;
+
+        try
+        {
+            if (App.Current is not App app)
+                return;
+
+            if (muted)
+            {
+                app.SetChatSpeakerMuted(true);
+                return;
+            }
+
+            if (IsTtsReadyForChat(app.Settings))
+            {
+                app.SetChatSpeakerMuted(false);
+                return;
+            }
+
+            app.SetChatSpeakerMuted(true);
+            _functionalHost?.SetSpeakerMuted(true);
+            await ShowTtsUnavailableDialogAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Speaker mute change failed: {ex.Message}");
+        }
+        finally
+        {
+            _speakerMuteGate.Release();
+        }
+    }
+
+    private async Task<bool> EnsureTtsReadyForChatAsync()
+    {
+        if (App.Current is App app && IsTtsReadyForChat(app.Settings))
+            return true;
+
+        await ShowTtsUnavailableDialogAsync();
+        return false;
+    }
+
+    private static bool IsTtsReadyForChat(SettingsManager? settings)
+    {
+        return SpeechSetupReadiness.IsChatTtsPlaybackReady(settings);
+    }
+
+    private async Task ShowTtsUnavailableDialogAsync()
+    {
+        if (App.Current is not App app || app.Settings?.NodeTtsEnabled != true)
+        {
+            await ShowVoiceSettingsDialogAsync(
+                LocalizationHelper.GetString("ChatVoiceDialog_OutputOffTitle"),
+                LocalizationHelper.GetString("ChatVoiceDialog_OutputOffMessage"),
+                LocalizationHelper.GetString("ChatVoiceDialog_OpenPermissionsSettings"),
+                () => (App.Current as App)?.ShowHub("permissions"));
+            return;
+        }
+
+        await ShowVoiceSettingsDialogAsync(
+            LocalizationHelper.GetString("ChatVoiceDialog_TtsSetupRequiredTitle"),
+            LocalizationHelper.GetString("ChatVoiceDialog_TtsSetupRequiredMessage"),
+            LocalizationHelper.GetString("ChatVoiceDialog_OpenVoiceSettings"),
+            () => app.ShowHub("voice"));
+    }
+
+    private static bool ShouldStartSpeakerMuted(SettingsManager? settings)
+    {
+        return !SpeechSetupReadiness.IsAutomaticChatTtsEnabled(settings);
+    }
+
     private async Task ShowVoiceSettingsDialogAsync(string title, string message, string primaryButtonText, Action openSettings)
     {
+        if (Interlocked.Exchange(ref _voiceSettingsDialogOpen, 1) == 1)
+            return;
+
         var tcs = new TaskCompletionSource();
         if (DispatcherQueue is null || !DispatcherQueue.TryEnqueue(async () =>
         {
@@ -599,10 +687,18 @@ public sealed partial class ChatWindow : WindowEx
             }
         }))
         {
+            Interlocked.Exchange(ref _voiceSettingsDialogOpen, 0);
             return;
         }
 
-        await tcs.Task;
+        try
+        {
+            await tcs.Task;
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _voiceSettingsDialogOpen, 0);
+        }
     }
 
     private async Task PickAndAttachFileAsync()

--- a/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/ChatWindow.xaml.cs
@@ -618,21 +618,11 @@ public sealed partial class ChatWindow : WindowEx
 
     private async Task ShowTtsUnavailableDialogAsync()
     {
-        if (App.Current is not App app || app.Settings?.NodeTtsEnabled != true)
-        {
-            await ShowVoiceSettingsDialogAsync(
-                LocalizationHelper.GetString("ChatVoiceDialog_OutputOffTitle"),
-                LocalizationHelper.GetString("ChatVoiceDialog_OutputOffMessage"),
-                LocalizationHelper.GetString("ChatVoiceDialog_OpenPermissionsSettings"),
-                () => (App.Current as App)?.ShowHub("permissions"));
-            return;
-        }
-
         await ShowVoiceSettingsDialogAsync(
-            LocalizationHelper.GetString("ChatVoiceDialog_TtsSetupRequiredTitle"),
-            LocalizationHelper.GetString("ChatVoiceDialog_TtsSetupRequiredMessage"),
-            LocalizationHelper.GetString("ChatVoiceDialog_OpenVoiceSettings"),
-            () => app.ShowHub("voice"));
+            LocalizationHelper.GetString("ChatVoiceDialog_OutputOffTitle"),
+            LocalizationHelper.GetString("ChatVoiceDialog_OutputOffMessage"),
+            LocalizationHelper.GetString("ChatVoiceDialog_OpenPermissionsSettings"),
+            () => (App.Current as App)?.ShowHub("permissions"));
     }
 
     private static bool ShouldStartSpeakerMuted(SettingsManager? settings)

--- a/tests/OpenClaw.Tray.Tests/CapabilitiesPageLocalizationCoverageTests.cs
+++ b/tests/OpenClaw.Tray.Tests/CapabilitiesPageLocalizationCoverageTests.cs
@@ -3,7 +3,7 @@ using System.Xml.Linq;
 namespace OpenClaw.Tray.Tests;
 
 /// <summary>
-/// Pins that the STT/TTS card controls on PermissionsPage are localized (have an
+/// Pins that the voice settings card controls on PermissionsPage are localized (have an
 /// x:Uid) and that en-us\Resources.resw provides matching keys. LocalizationValidationTests
 /// catches drift between locales but not the case where a developer adds a control with
 /// hardcoded English text and never registers it.
@@ -14,6 +14,9 @@ public sealed class CapabilitiesPageLocalizationCoverageTests
 
     private static string GetCapabilitiesXamlPath() =>
         Path.Combine(TestRepositoryPaths.GetRepositoryRoot(), "src", "OpenClaw.Tray.WinUI", "Pages", "PermissionsPage.xaml");
+
+    private static string GetCapabilitiesCodeBehindPath() =>
+        Path.Combine(TestRepositoryPaths.GetRepositoryRoot(), "src", "OpenClaw.Tray.WinUI", "Pages", "PermissionsPage.xaml.cs");
 
     private static string GetEnUsReswPath() =>
         Path.Combine(TestRepositoryPaths.GetRepositoryRoot(), "src", "OpenClaw.Tray.WinUI", "Strings", "en-us", "Resources.resw");
@@ -37,37 +40,26 @@ public sealed class CapabilitiesPageLocalizationCoverageTests
     }
 
     /// <summary>
-    /// Contract for the STT/TTS surface. Each entry: x:Uid + the resw key suffixes that
-    /// MUST exist in en-us. The legacy STT/TTS card-header/description x:Uids are no
-    /// longer rendered in the merged Permissions page (they used to live on the standalone
-    /// CapabilitiesPage); the orphaned resw entries are left in place but not pinned here.
+    /// Contract for the shared voice settings link. Each entry: x:Uid + the resw key
+    /// suffixes that MUST exist in en-us. The dedicated Voice & Audio page owns provider,
+    /// model, and voice configuration; Permissions only deep-links to that surface.
     /// </summary>
-    public static IEnumerable<object[]> SttAndTtsCardUids => new[]
+    public static IEnumerable<object[]> VoiceSettingsCardUids => new[]
     {
-        // STT card (deep-link to dedicated voice settings)
-        new object[] { "PermissionsPage_SttMoreSettingsLink",  new[] { ".Content" } },
-        // TTS card (provider picker, ElevenLabs sub-panel)
-        new object[] { "PermissionsPage_TtsProviderComboBox",  new[] { ".Header" } },
-        new object[] { "PermissionsPage_TtsProviderPiper",     new[] { ".Content" } },
-        new object[] { "PermissionsPage_TtsProviderWindows",   new[] { ".Content" } },
-        new object[] { "PermissionsPage_TtsProviderElevenLabs",new[] { ".Content" } },
-        new object[] { "PermissionsPage_TtsElevenLabsApiKey",  new[] { ".Header" } },
-        new object[] { "PermissionsPage_TtsElevenLabsVoiceId", new[] { ".Header" } },
-        new object[] { "PermissionsPage_TtsElevenLabsModel",   new[] { ".Header", ".PlaceholderText" } },
-        new object[] { "PermissionsPage_TtsElevenLabsHelp",    new[] { ".Text" } },
+        new object[] { "PermissionsPage_VoiceSettingsLink", new[] { ".Content" } },
     };
 
     [Theory]
-    [MemberData(nameof(SttAndTtsCardUids))]
-    public void SttOrTtsControl_HasXUid_InCapabilitiesPageXaml(string uid, string[] _)
+    [MemberData(nameof(VoiceSettingsCardUids))]
+    public void VoiceSettingsControl_HasXUid_InCapabilitiesPageXaml(string uid, string[] _)
     {
         var uids = LoadXamlUids();
         Assert.Contains(uid, uids);
     }
 
     [Theory]
-    [MemberData(nameof(SttAndTtsCardUids))]
-    public void SttOrTtsControl_AllExpectedReswKeys_ExistInEnUs(string uid, string[] suffixes)
+    [MemberData(nameof(VoiceSettingsCardUids))]
+    public void VoiceSettingsControl_AllExpectedReswKeys_ExistInEnUs(string uid, string[] suffixes)
     {
         var keys = LoadReswKeys();
         var missing = suffixes
@@ -77,5 +69,29 @@ public sealed class CapabilitiesPageLocalizationCoverageTests
 
         Assert.True(missing.Count == 0,
             $"Missing en-us resw keys for x:Uid '{uid}': {string.Join(", ", missing)}");
+    }
+
+    [Fact]
+    public void PermissionsPage_UsesSharedVoiceSettingsCard_InsteadOfProviderControls()
+    {
+        var xaml = File.ReadAllText(GetCapabilitiesXamlPath());
+
+        Assert.Contains("x:Name=\"VoiceSettingsCard\"", xaml);
+        Assert.Contains("x:Name=\"VoiceSettingsLink\"", xaml);
+        Assert.DoesNotContain("x:Name=\"SttCard\"", xaml);
+        Assert.DoesNotContain("x:Name=\"TtsCard\"", xaml);
+        Assert.DoesNotContain("TtsProviderComboBox", xaml);
+        Assert.DoesNotContain("TtsElevenLabs", xaml);
+    }
+
+    [Fact]
+    public void PermissionsPage_ShowsSharedVoiceCard_WhenEitherSpeechCapabilityIsEnabled()
+    {
+        var source = File.ReadAllText(GetCapabilitiesCodeBehindPath());
+
+        Assert.Contains("settings?.NodeSttEnabled == true || settings?.NodeTtsEnabled == true", source);
+        Assert.Contains("VoiceSettingsCard.Visibility = enabled ? Visibility.Visible : Visibility.Collapsed;", source);
+        Assert.DoesNotContain("UpdateSttCard", source);
+        Assert.DoesNotContain("UpdateTtsCard", source);
     }
 }

--- a/tests/OpenClaw.Tray.Tests/CapabilitiesPageLocalizationCoverageTests.cs
+++ b/tests/OpenClaw.Tray.Tests/CapabilitiesPageLocalizationCoverageTests.cs
@@ -46,6 +46,7 @@ public sealed class CapabilitiesPageLocalizationCoverageTests
     /// </summary>
     public static IEnumerable<object[]> VoiceSettingsCardUids => new[]
     {
+        new object[] { "PermissionsPage_VoiceSettingsHelp", new[] { ".Text" } },
         new object[] { "PermissionsPage_VoiceSettingsLink", new[] { ".Content" } },
     };
 
@@ -77,6 +78,9 @@ public sealed class CapabilitiesPageLocalizationCoverageTests
         var xaml = File.ReadAllText(GetCapabilitiesXamlPath());
 
         Assert.Contains("x:Name=\"VoiceSettingsCard\"", xaml);
+        Assert.Contains("x:Name=\"VoiceSettingsHelpPanel\"", xaml);
+        Assert.Contains("x:Name=\"VoiceSettingsHelpText\"", xaml);
+        Assert.Contains("x:Name=\"VoiceSettingsWarningIcon\"", xaml);
         Assert.Contains("x:Name=\"VoiceSettingsLink\"", xaml);
         Assert.DoesNotContain("x:Name=\"SttCard\"", xaml);
         Assert.DoesNotContain("x:Name=\"TtsCard\"", xaml);
@@ -85,12 +89,19 @@ public sealed class CapabilitiesPageLocalizationCoverageTests
     }
 
     [Fact]
-    public void PermissionsPage_ShowsSharedVoiceCard_WhenEitherSpeechCapabilityIsEnabled()
+    public void PermissionsPage_ShowsSharedVoiceCard_WhenEitherSpeechCapabilityIsEnabled_AndSetupTextOnlyWhenNeeded()
     {
         var source = File.ReadAllText(GetCapabilitiesCodeBehindPath());
 
         Assert.Contains("settings?.NodeSttEnabled == true || settings?.NodeTtsEnabled == true", source);
         Assert.Contains("VoiceSettingsCard.Visibility = enabled ? Visibility.Visible : Visibility.Collapsed;", source);
+        Assert.Contains("VoiceSettingsHelpPanel.Visibility = settings != null && IsVoiceSetupRequired(settings)", source);
+        Assert.Contains("settings.NodeSttEnabled && !IsConfiguredWhisperModelDownloaded(settings)", source);
+        Assert.Contains("settings.NodeTtsEnabled && IsConfiguredTtsProviderSetupRequired(settings)", source);
+        Assert.Contains("TtsCapability.WindowsProvider", source);
+        Assert.Contains("TtsCapability.PiperProvider", source);
+        Assert.Contains("TtsCapability.ElevenLabsProvider", source);
+        Assert.DoesNotContain("EnsureWhisperModelDownloaded", source);
         Assert.DoesNotContain("UpdateSttCard", source);
         Assert.DoesNotContain("UpdateTtsCard", source);
     }

--- a/tests/OpenClaw.Tray.Tests/CapabilitiesPageLocalizationCoverageTests.cs
+++ b/tests/OpenClaw.Tray.Tests/CapabilitiesPageLocalizationCoverageTests.cs
@@ -45,6 +45,25 @@ public sealed class CapabilitiesPageLocalizationCoverageTests
             .ToHashSet(StringComparer.Ordinal);
     }
 
+    private static List<string> LoadVoiceSettingsXamlUids()
+    {
+        var doc = XDocument.Load(GetVoiceSettingsXamlPath());
+        return doc.Descendants()
+            .Select(e => e.Attribute(XNs + "Uid")?.Value)
+            .Where(v => !string.IsNullOrEmpty(v))
+            .Cast<string>()
+            .ToList();
+    }
+
+    private static string LoadReswValue(string key)
+    {
+        var doc = XDocument.Load(GetEnUsReswPath());
+        return doc.Descendants("data")
+            .Single(e => string.Equals(e.Attribute("name")?.Value, key, StringComparison.Ordinal))
+            .Element("value")!
+            .Value;
+    }
+
     /// <summary>
     /// Contract for the shared voice settings link. Each entry: x:Uid + the resw key
     /// suffixes that MUST exist in en-us. The dedicated Voice & Audio page owns provider,
@@ -118,6 +137,15 @@ public sealed class CapabilitiesPageLocalizationCoverageTests
     }
 
     [Fact]
+    public void PermissionsPage_SttDescription_DoesNotClaimCapabilityToggleDownloadsModel()
+    {
+        var description = LoadReswValue("PermissionsPage_Cap_Stt_Description");
+
+        Assert.DoesNotContain("Turning this on downloads", description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Download a speech model in Voice & Audio settings", description);
+    }
+
+    [Fact]
     public void PermissionsPage_VoiceSetupWarnings_HaveTailoredResources()
     {
         var keys = LoadReswKeys();
@@ -138,18 +166,20 @@ public sealed class CapabilitiesPageLocalizationCoverageTests
         Assert.Contains("x:Name=\"TtsCapabilityNotice\"", xaml);
         Assert.Contains("x:Name=\"SttCapabilityNoticeIcon\"", xaml);
         Assert.Contains("x:Name=\"TtsCapabilityNoticeIcon\"", xaml);
-        Assert.Contains("x:Name=\"VoiceChatCard\"", xaml);
         Assert.Contains("x:Uid=\"VoiceSettingsPage_SttCapabilityDisabledNotice\"", xaml);
         Assert.Contains("x:Uid=\"VoiceSettingsPage_TtsCapabilityDisabledNotice\"", xaml);
-        Assert.Contains("x:Uid=\"VoiceSettingsPage_OpenPermissionsLink\"", xaml);
+        Assert.Equal(2, LoadVoiceSettingsXamlUids().Count(uid =>
+            string.Equals(uid, "VoiceSettingsPage_OpenPermissionsLink", StringComparison.Ordinal)));
         Assert.DoesNotContain("SttEnabledToggle", xaml);
         Assert.DoesNotContain("OnSttToggled", source);
         Assert.Contains("((IAppCommands)CurrentApp).Navigate(\"permissions\")", source);
         Assert.Contains("SttCapabilityNotice.Visibility = sttEnabled ? Visibility.Collapsed : Visibility.Visible;", source);
         Assert.Contains("TtsCapabilityNotice.Visibility = ttsEnabled ? Visibility.Collapsed : Visibility.Visible;", source);
-        Assert.Contains("VoiceChatCard.IsHitTestVisible = sttEnabled;", source);
-        Assert.Contains("TestVoiceButton.IsEnabled = sttEnabled;", source);
-        Assert.Contains("PreviewVoiceButton.IsEnabled = ttsEnabled;", source);
+        Assert.DoesNotContain("IsHitTestVisible = sttEnabled", source);
+        Assert.DoesNotContain("TestVoiceButton.IsEnabled = sttEnabled", source);
+        Assert.DoesNotContain("InlineTestStartBtn.IsEnabled = sttEnabled", source);
+        Assert.DoesNotContain("PiperPreviewButton.IsEnabled = ttsEnabled", source);
+        Assert.DoesNotContain("PreviewVoiceButton.IsEnabled = ttsEnabled", source);
         Assert.Contains("VoiceSettingsPage_SttCapabilityDisabledNotice.Text", keys);
         Assert.Contains("VoiceSettingsPage_TtsCapabilityDisabledNotice.Text", keys);
         Assert.Contains("VoiceSettingsPage_OpenPermissionsLink.Content", keys);

--- a/tests/OpenClaw.Tray.Tests/CapabilitiesPageLocalizationCoverageTests.cs
+++ b/tests/OpenClaw.Tray.Tests/CapabilitiesPageLocalizationCoverageTests.cs
@@ -116,6 +116,12 @@ public sealed class CapabilitiesPageLocalizationCoverageTests
     public void PermissionsPage_ShowsSharedVoiceCard_WhenEitherSpeechCapabilityIsEnabled_AndSetupTextOnlyWhenNeeded()
     {
         var source = File.ReadAllText(GetCapabilitiesCodeBehindPath());
+        var readiness = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Services",
+            "SpeechSetupReadiness.cs"));
 
         Assert.Contains("settings?.NodeSttEnabled == true || settings?.NodeTtsEnabled == true", source);
         Assert.Contains("VoiceSettingsCard.Visibility = enabled ? Visibility.Visible : Visibility.Collapsed;", source);
@@ -124,13 +130,13 @@ public sealed class CapabilitiesPageLocalizationCoverageTests
         Assert.Contains("VoiceSetupRequirement.VoiceSetup", source);
         Assert.Contains("VoiceSetupRequirement.SpeechModelAndVoiceSetup", source);
         Assert.Contains("var needsSpeechModel = settings.NodeSttEnabled && !IsConfiguredWhisperModelDownloaded(settings)", source);
-        Assert.Contains("var needsVoiceSetup = settings.NodeTtsEnabled && IsConfiguredTtsProviderSetupRequired(settings)", source);
+        Assert.Contains("var needsVoiceSetup = settings.NodeTtsEnabled && SpeechSetupReadiness.IsConfiguredTtsProviderSetupRequired(settings)", source);
         Assert.Contains("PermissionsPage_VoiceSettingsHelp_SpeechModel", source);
         Assert.Contains("PermissionsPage_VoiceSettingsHelp_VoiceSetup", source);
         Assert.Contains("PermissionsPage_VoiceSettingsHelp_Both", source);
-        Assert.Contains("TtsCapability.WindowsProvider", source);
-        Assert.Contains("TtsCapability.PiperProvider", source);
-        Assert.Contains("TtsCapability.ElevenLabsProvider", source);
+        Assert.Contains("TtsCapability.WindowsProvider", readiness);
+        Assert.Contains("TtsCapability.PiperProvider", readiness);
+        Assert.Contains("TtsCapability.ElevenLabsProvider", readiness);
         Assert.DoesNotContain("EnsureWhisperModelDownloaded", source);
         Assert.DoesNotContain("UpdateSttCard", source);
         Assert.DoesNotContain("UpdateTtsCard", source);

--- a/tests/OpenClaw.Tray.Tests/CapabilitiesPageLocalizationCoverageTests.cs
+++ b/tests/OpenClaw.Tray.Tests/CapabilitiesPageLocalizationCoverageTests.cs
@@ -21,6 +21,12 @@ public sealed class CapabilitiesPageLocalizationCoverageTests
     private static string GetEnUsReswPath() =>
         Path.Combine(TestRepositoryPaths.GetRepositoryRoot(), "src", "OpenClaw.Tray.WinUI", "Strings", "en-us", "Resources.resw");
 
+    private static string GetVoiceSettingsXamlPath() =>
+        Path.Combine(TestRepositoryPaths.GetRepositoryRoot(), "src", "OpenClaw.Tray.WinUI", "Pages", "VoiceSettingsPage.xaml");
+
+    private static string GetVoiceSettingsCodeBehindPath() =>
+        Path.Combine(TestRepositoryPaths.GetRepositoryRoot(), "src", "OpenClaw.Tray.WinUI", "Pages", "VoiceSettingsPage.xaml.cs");
+
     private static HashSet<string> LoadReswKeys()
     {
         var doc = XDocument.Load(GetEnUsReswPath());
@@ -104,5 +110,33 @@ public sealed class CapabilitiesPageLocalizationCoverageTests
         Assert.DoesNotContain("EnsureWhisperModelDownloaded", source);
         Assert.DoesNotContain("UpdateSttCard", source);
         Assert.DoesNotContain("UpdateTtsCard", source);
+    }
+
+    [Fact]
+    public void VoiceSettingsPage_LinksToPermissions_InsteadOfOwningCapabilityToggles()
+    {
+        var xaml = File.ReadAllText(GetVoiceSettingsXamlPath());
+        var source = File.ReadAllText(GetVoiceSettingsCodeBehindPath());
+        var keys = LoadReswKeys();
+
+        Assert.Contains("x:Name=\"SttCapabilityNotice\"", xaml);
+        Assert.Contains("x:Name=\"TtsCapabilityNotice\"", xaml);
+        Assert.Contains("x:Name=\"SttCapabilityNoticeIcon\"", xaml);
+        Assert.Contains("x:Name=\"TtsCapabilityNoticeIcon\"", xaml);
+        Assert.Contains("x:Name=\"VoiceChatCard\"", xaml);
+        Assert.Contains("x:Uid=\"VoiceSettingsPage_SttCapabilityDisabledNotice\"", xaml);
+        Assert.Contains("x:Uid=\"VoiceSettingsPage_TtsCapabilityDisabledNotice\"", xaml);
+        Assert.Contains("x:Uid=\"VoiceSettingsPage_OpenPermissionsLink\"", xaml);
+        Assert.DoesNotContain("SttEnabledToggle", xaml);
+        Assert.DoesNotContain("OnSttToggled", source);
+        Assert.Contains("((IAppCommands)CurrentApp).Navigate(\"permissions\")", source);
+        Assert.Contains("SttCapabilityNotice.Visibility = sttEnabled ? Visibility.Collapsed : Visibility.Visible;", source);
+        Assert.Contains("TtsCapabilityNotice.Visibility = ttsEnabled ? Visibility.Collapsed : Visibility.Visible;", source);
+        Assert.Contains("VoiceChatCard.IsHitTestVisible = sttEnabled;", source);
+        Assert.Contains("TestVoiceButton.IsEnabled = sttEnabled;", source);
+        Assert.Contains("PreviewVoiceButton.IsEnabled = ttsEnabled;", source);
+        Assert.Contains("VoiceSettingsPage_SttCapabilityDisabledNotice.Text", keys);
+        Assert.Contains("VoiceSettingsPage_TtsCapabilityDisabledNotice.Text", keys);
+        Assert.Contains("VoiceSettingsPage_OpenPermissionsLink.Content", keys);
     }
 }

--- a/tests/OpenClaw.Tray.Tests/CapabilitiesPageLocalizationCoverageTests.cs
+++ b/tests/OpenClaw.Tray.Tests/CapabilitiesPageLocalizationCoverageTests.cs
@@ -52,7 +52,6 @@ public sealed class CapabilitiesPageLocalizationCoverageTests
     /// </summary>
     public static IEnumerable<object[]> VoiceSettingsCardUids => new[]
     {
-        new object[] { "PermissionsPage_VoiceSettingsHelp", new[] { ".Text" } },
         new object[] { "PermissionsPage_VoiceSettingsLink", new[] { ".Content" } },
     };
 
@@ -101,15 +100,31 @@ public sealed class CapabilitiesPageLocalizationCoverageTests
 
         Assert.Contains("settings?.NodeSttEnabled == true || settings?.NodeTtsEnabled == true", source);
         Assert.Contains("VoiceSettingsCard.Visibility = enabled ? Visibility.Visible : Visibility.Collapsed;", source);
-        Assert.Contains("VoiceSettingsHelpPanel.Visibility = settings != null && IsVoiceSetupRequired(settings)", source);
-        Assert.Contains("settings.NodeSttEnabled && !IsConfiguredWhisperModelDownloaded(settings)", source);
-        Assert.Contains("settings.NodeTtsEnabled && IsConfiguredTtsProviderSetupRequired(settings)", source);
+        Assert.Contains("GetVoiceSetupRequirement(settings)", source);
+        Assert.Contains("VoiceSetupRequirement.SpeechModel", source);
+        Assert.Contains("VoiceSetupRequirement.VoiceSetup", source);
+        Assert.Contains("VoiceSetupRequirement.SpeechModelAndVoiceSetup", source);
+        Assert.Contains("var needsSpeechModel = settings.NodeSttEnabled && !IsConfiguredWhisperModelDownloaded(settings)", source);
+        Assert.Contains("var needsVoiceSetup = settings.NodeTtsEnabled && IsConfiguredTtsProviderSetupRequired(settings)", source);
+        Assert.Contains("PermissionsPage_VoiceSettingsHelp_SpeechModel", source);
+        Assert.Contains("PermissionsPage_VoiceSettingsHelp_VoiceSetup", source);
+        Assert.Contains("PermissionsPage_VoiceSettingsHelp_Both", source);
         Assert.Contains("TtsCapability.WindowsProvider", source);
         Assert.Contains("TtsCapability.PiperProvider", source);
         Assert.Contains("TtsCapability.ElevenLabsProvider", source);
         Assert.DoesNotContain("EnsureWhisperModelDownloaded", source);
         Assert.DoesNotContain("UpdateSttCard", source);
         Assert.DoesNotContain("UpdateTtsCard", source);
+    }
+
+    [Fact]
+    public void PermissionsPage_VoiceSetupWarnings_HaveTailoredResources()
+    {
+        var keys = LoadReswKeys();
+
+        Assert.Contains("PermissionsPage_VoiceSettingsHelp_SpeechModel", keys);
+        Assert.Contains("PermissionsPage_VoiceSettingsHelp_VoiceSetup", keys);
+        Assert.Contains("PermissionsPage_VoiceSettingsHelp_Both", keys);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/LocalizationValidationTests.cs
@@ -39,10 +39,6 @@ public class LocalizationValidationTests
         "Onboarding_Connection_Token",
         "WindowTitle_TrayMenu",
         "WindowTitle_Update",
-        // STT/TTS card invariants — these are protocol/brand identifiers
-        // not user-visible prose. They intentionally read the same in every
-        // locale: "eleven_multilingual_v2" is an ElevenLabs model
-        // identifier, "ElevenLabs" is a brand name.
         // VoiceOverlayWindow window-title key — matches the convention
         // for ChatWindow / HubWindow / CanvasWindow / TrayMenuWindow.
         "VoiceOverlayWindow_winexWindowEx_2.Title",
@@ -54,8 +50,6 @@ public class LocalizationValidationTests
         // Technical product term — "Gateway" is kept in English across
         // supported locales per onboarding terminology.
         "DiagnosticsPage_Section_Gateway.Text",
-        "PermissionsPage_TtsElevenLabsModel.PlaceholderText",
-        "PermissionsPage_TtsProviderElevenLabs.Content",
         // Sample IDs / brand identifiers — same across locales.
         "VoiceSettingsPage_ElevenLabsVoiceIdBox.PlaceholderText",
         "VoiceSettingsPage_ElevenLabsModelBox.PlaceholderText",
@@ -93,10 +87,6 @@ public class LocalizationValidationTests
         "PermissionsPage_Cap_Stt_Description",
         "PermissionsPage_Cap_SystemRun_Label",
         "PermissionsPage_Cap_SystemRun_Description",
-        "PermissionsPage_SttHint_Ready",
-        "PermissionsPage_SttHint_Downloading",
-        "PermissionsPage_SttHint_FailedFormat",
-        "PermissionsPage_SttHint_NotDownloaded",
         "PermissionsPage_NodeStatus_Disabled",
         // About / Gateway info strings added as part of the Windows-native
         // settings reorg are seeded in English across locales until the next
@@ -125,8 +115,6 @@ public class LocalizationValidationTests
         "PermissionsPage_Allowlist_NoConfig",
         "PermissionsPage_Allowlist_NoCommands",
         "PermissionsPage_Allowlist_ParseFailed",
-        "PermissionsPage_TtsStatus_DefaultProviderFormat",
-        "PermissionsPage_TtsStatus_ElevenLabsSaved",
         "PermissionsPage_McpStatus_TokenReadFailedFormat",
         // Session key display formatter: "{agent} / {slot}" intentionally
         // uses an invariant separator while the surrounding notification copy

--- a/tests/OpenClaw.Tray.Tests/SpeechInputContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SpeechInputContractTests.cs
@@ -51,7 +51,7 @@ public sealed class SpeechInputContractTests
     }
 
     [Fact]
-    public void ChatVoiceDialogs_RouteDisabledTtsCapabilityToPermissions_AndMissingSetupToVoiceSettings()
+    public void ChatVoiceDialogs_RouteDisabledTtsCapabilityToPermissions_AndPreserveFallbackForMissingSetup()
     {
         var chatPage = Read("src", "OpenClaw.Tray.WinUI", "Pages", "ChatPage.xaml.cs");
         var chatWindow = Read("src", "OpenClaw.Tray.WinUI", "Windows", "ChatWindow.xaml.cs");
@@ -69,10 +69,8 @@ public sealed class SpeechInputContractTests
         Assert.Contains("_functionalHost?.SetSpeakerMuted(true);\r\n            await ShowTtsUnavailableDialogAsync();", chatPage);
         Assert.Contains("ChatVoiceDialog_OutputOffTitle", chatPage);
         Assert.Contains("ChatVoiceDialog_OutputOffMessage", chatPage);
-        Assert.Contains("ChatVoiceDialog_TtsSetupRequiredTitle", chatPage);
-        Assert.Contains("ChatVoiceDialog_TtsSetupRequiredMessage", chatPage);
         Assert.Contains("NavigateToPermissionsSettings", chatPage);
-        Assert.Contains("NavigateToVoiceSettings", chatPage);
+        Assert.DoesNotContain("ChatVoiceDialog_TtsSetupRequired", chatPage);
 
         Assert.Contains("ReadChatTextAloudAsync", chatWindow);
         Assert.Contains("OnSpeakerMuteChangedAsync", chatWindow);
@@ -85,15 +83,14 @@ public sealed class SpeechInputContractTests
         Assert.Contains("_functionalHost?.SetSpeakerMuted(true);\r\n            await ShowTtsUnavailableDialogAsync();", chatWindow);
         Assert.Contains("ChatVoiceDialog_OutputOffTitle", chatWindow);
         Assert.Contains("ChatVoiceDialog_OutputOffMessage", chatWindow);
-        Assert.Contains("ChatVoiceDialog_TtsSetupRequiredTitle", chatWindow);
-        Assert.Contains("ChatVoiceDialog_TtsSetupRequiredMessage", chatWindow);
         Assert.Contains("ShowHub(\"permissions\")", chatWindow);
-        Assert.Contains("ShowHub(\"voice\")", chatWindow);
+        Assert.DoesNotContain("ChatVoiceDialog_TtsSetupRequired", chatWindow);
 
         Assert.Contains("SpeechSetupReadiness.IsConfiguredTtsProviderSetupRequired", permissionsPage);
         Assert.Contains("SpeechSetupReadiness.IsAutomaticChatTtsEnabled", Read("src", "OpenClaw.Tray.WinUI", "App.xaml.cs"));
         Assert.Contains("IsAutomaticChatTtsEnabled", Read("src", "OpenClaw.Tray.WinUI", "Services", "SpeechSetupReadiness.cs"));
+        Assert.Contains("return settings?.NodeTtsEnabled == true;", Read("src", "OpenClaw.Tray.WinUI", "Services", "SpeechSetupReadiness.cs"));
         Assert.Contains("Text-to-speech is disabled. Enable the capability in Permissions", resources);
-        Assert.Contains("Text-to-speech is on, but read aloud will not work until a voice or provider is configured.", resources);
+        Assert.DoesNotContain("ChatVoiceDialog_TtsSetupRequired", resources);
     }
 }

--- a/tests/OpenClaw.Tray.Tests/SpeechInputContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SpeechInputContractTests.cs
@@ -26,7 +26,7 @@ public sealed class SpeechInputContractTests
     }
 
     [Fact]
-    public void ChatVoiceDialogs_RouteDisabledCapabilityToPermissions_AndMissingModelToVoiceSettings()
+    public void ChatVoiceDialogs_RouteDisabledSttCapabilityToPermissions_AndMissingModelToVoiceSettings()
     {
         var chatPage = Read("src", "OpenClaw.Tray.WinUI", "Pages", "ChatPage.xaml.cs");
         var chatWindow = Read("src", "OpenClaw.Tray.WinUI", "Windows", "ChatWindow.xaml.cs");
@@ -48,5 +48,52 @@ public sealed class SpeechInputContractTests
         Assert.Contains("ChatVoiceDialog_OpenPermissionsSettings", resources);
         Assert.Contains("Open Permissions", resources);
         Assert.Contains("Speech-to-Text is on, but voice input will not work until at least one speech model is downloaded.", resources);
+    }
+
+    [Fact]
+    public void ChatVoiceDialogs_RouteDisabledTtsCapabilityToPermissions_AndMissingSetupToVoiceSettings()
+    {
+        var chatPage = Read("src", "OpenClaw.Tray.WinUI", "Pages", "ChatPage.xaml.cs");
+        var chatWindow = Read("src", "OpenClaw.Tray.WinUI", "Windows", "ChatWindow.xaml.cs");
+        var permissionsPage = Read("src", "OpenClaw.Tray.WinUI", "Pages", "PermissionsPage.xaml.cs");
+        var resources = Read("src", "OpenClaw.Tray.WinUI", "Strings", "en-us", "Resources.resw");
+
+        Assert.Contains("ReadChatTextAloudAsync", chatPage);
+        Assert.Contains("OnSpeakerMuteChangedAsync", chatPage);
+        Assert.Contains("EnsureTtsReadyForChatAsync", chatPage);
+        Assert.Contains("ShowTtsUnavailableDialogAsync", chatPage);
+        Assert.Contains("IsAutomaticChatTtsEnabled", chatPage);
+        Assert.Contains("IsChatTtsPlaybackReady", chatPage);
+        Assert.Contains("_speakerMuteGate.WaitAsync(0)", chatPage);
+        Assert.Contains("_voiceSettingsDialogOpen", chatPage);
+        Assert.Contains("_functionalHost?.SetSpeakerMuted(true);\r\n            await ShowTtsUnavailableDialogAsync();", chatPage);
+        Assert.Contains("ChatVoiceDialog_OutputOffTitle", chatPage);
+        Assert.Contains("ChatVoiceDialog_OutputOffMessage", chatPage);
+        Assert.Contains("ChatVoiceDialog_TtsSetupRequiredTitle", chatPage);
+        Assert.Contains("ChatVoiceDialog_TtsSetupRequiredMessage", chatPage);
+        Assert.Contains("NavigateToPermissionsSettings", chatPage);
+        Assert.Contains("NavigateToVoiceSettings", chatPage);
+
+        Assert.Contains("ReadChatTextAloudAsync", chatWindow);
+        Assert.Contains("OnSpeakerMuteChangedAsync", chatWindow);
+        Assert.Contains("EnsureTtsReadyForChatAsync", chatWindow);
+        Assert.Contains("ShowTtsUnavailableDialogAsync", chatWindow);
+        Assert.Contains("IsAutomaticChatTtsEnabled", chatWindow);
+        Assert.Contains("IsChatTtsPlaybackReady", chatWindow);
+        Assert.Contains("_speakerMuteGate.WaitAsync(0)", chatWindow);
+        Assert.Contains("_voiceSettingsDialogOpen", chatWindow);
+        Assert.Contains("_functionalHost?.SetSpeakerMuted(true);\r\n            await ShowTtsUnavailableDialogAsync();", chatWindow);
+        Assert.Contains("ChatVoiceDialog_OutputOffTitle", chatWindow);
+        Assert.Contains("ChatVoiceDialog_OutputOffMessage", chatWindow);
+        Assert.Contains("ChatVoiceDialog_TtsSetupRequiredTitle", chatWindow);
+        Assert.Contains("ChatVoiceDialog_TtsSetupRequiredMessage", chatWindow);
+        Assert.Contains("ShowHub(\"permissions\")", chatWindow);
+        Assert.Contains("ShowHub(\"voice\")", chatWindow);
+
+        Assert.Contains("SpeechSetupReadiness.IsConfiguredTtsProviderSetupRequired", permissionsPage);
+        Assert.Contains("SpeechSetupReadiness.IsAutomaticChatTtsEnabled", Read("src", "OpenClaw.Tray.WinUI", "App.xaml.cs"));
+        Assert.Contains("IsAutomaticChatTtsEnabled", Read("src", "OpenClaw.Tray.WinUI", "Services", "SpeechSetupReadiness.cs"));
+        Assert.Contains("Text-to-speech is disabled. Enable the capability in Permissions", resources);
+        Assert.Contains("Text-to-speech is on, but read aloud will not work until a voice or provider is configured.", resources);
     }
 }

--- a/tests/OpenClaw.Tray.Tests/SpeechInputContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SpeechInputContractTests.cs
@@ -24,4 +24,29 @@ public sealed class SpeechInputContractTests
         Assert.Contains("energy >= startThreshold", cs);
         Assert.Contains("energy >= stayThreshold", cs);
     }
+
+    [Fact]
+    public void ChatVoiceDialogs_RouteDisabledCapabilityToPermissions_AndMissingModelToVoiceSettings()
+    {
+        var chatPage = Read("src", "OpenClaw.Tray.WinUI", "Pages", "ChatPage.xaml.cs");
+        var chatWindow = Read("src", "OpenClaw.Tray.WinUI", "Windows", "ChatWindow.xaml.cs");
+        var resources = Read("src", "OpenClaw.Tray.WinUI", "Strings", "en-us", "Resources.resw");
+
+        Assert.Contains("ChatVoiceDialog_OpenPermissionsSettings", chatPage);
+        Assert.Contains("NavigateToPermissionsSettings", chatPage);
+        Assert.Contains("_hub.NavigateTo(\"permissions\")", chatPage);
+        Assert.Contains("ChatVoiceDialog_OpenVoiceSettings", chatPage);
+        Assert.Contains("NavigateToVoiceSettings", chatPage);
+        Assert.Contains("_hub.NavigateTo(\"voice\")", chatPage);
+
+        Assert.Contains("ChatVoiceDialog_OpenPermissionsSettings", chatWindow);
+        Assert.Contains("ShowHub(\"permissions\")", chatWindow);
+        Assert.Contains("ChatVoiceDialog_OpenVoiceSettings", chatWindow);
+        Assert.Contains("ShowHub(\"voice\")", chatWindow);
+
+        Assert.Contains("Speech-to-text is disabled. Enable the capability in Permissions", resources);
+        Assert.Contains("ChatVoiceDialog_OpenPermissionsSettings", resources);
+        Assert.Contains("Open Permissions", resources);
+        Assert.Contains("Speech-to-Text is on, but voice input will not work until at least one speech model is downloaded.", resources);
+    }
 }


### PR DESCRIPTION
## Summary

- Problem: Speech provider/model controls were split between Permissions and Voice & Audio, making Permissions feel like a duplicate configuration surface.
- Why it matters: Capabilities should gate agent access, while Voice & Audio should own model, provider, voice, and language setup.
- What changed: Removed speech provider setup from Permissions, added a conditional Voice & Audio link with tailored setup warnings, made Permissions the owner of STT/TTS capability toggles, and kept Voice & Audio settings interactive while showing capability notices.
- Chat recovery: Disabled STT now routes to Permissions while missing STT model routes to Voice & Audio. Disabled TTS routes to Permissions, but missing configured TTS provider/voice setup no longer blocks chat read-aloud because the existing Windows speech fallback is preserved.
- User impact: Users configure speech models/voices in Voice & Audio and enable or disable agent STT/TTS access in Permissions.
- What did NOT change (scope boundary): No MCP command shape, gateway behavior, persisted credential storage, or node capability registration changes.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs / instructions
- [x] Tests / validation
- [ ] Security hardening
- [ ] Chore / infra

## Scope (select all touched areas)

- [x] Tray / WinUI UX
- [ ] Windows node capability
- [ ] Local MCP / `winnode`
- [ ] Gateway / connection / pairing
- [ ] Setup / onboarding
- [x] Permissions / privacy / security
- [x] Tests / CI / docs

## Linked Issue/PR

- Closes #
- Related #
- [ ] Related to a bug or regression

## Validation

- Latest head `424b484b`: `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore --filter "SpeechInputContractTests|LocalizationValidationTests|CapabilitiesPageLocalizationCoverageTests"` — 26 passed, 0 skipped
- Latest head `424b484b`: `$env:OPENCLAW_REPO_ROOT=(Get-Location).Path; .\build.ps1` — all builds succeeded
- Latest head `424b484b`: `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` — 2703 passed, 31 skipped
- Latest head `424b484b`: `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` — 1577 passed, 0 skipped

## Real behavior proof

- Environment tested: Windows ARM64 local worktree
- Latest PR head / commit tested: `424b484b`
- Exact steps or command run: Validation commands above; UIA check against the active OpenClaw Companion window; manual screenshot proof added by PR author.
- Evidence after fix: Validation confirms localized Permissions/Voice & Audio contracts, warning copy, absence of duplicated provider controls, both Voice & Audio Permissions links, split chat microphone recovery, TTS disabled recovery, preserved chat TTS fallback for missing configured provider setup, and guarded speech dialogs.
- Observed result: Permissions owns STT/TTS capability toggles; Voice & Audio owns speech model/provider/voice setup and stays configurable while disabled-capability notices are shown. UIA verified pressing the chat Voice button entered `Listening…` and produced transcript text when STT was enabled/configured.

### Screenshots

- Permissions: TTS setup warning to download/select a voice. <img width="741" height="796" alt="image" src="https://github.com/user-attachments/assets/2eed142d-a5aa-4969-8a92-e0f1015cb4c5" />
- Permissions: STT setup warning to download a speech model. <img width="1500" height="1601" alt="centered-02-permissions-stt-model-warning" src="https://github.com/user-attachments/assets/ce15631f-a1e4-461a-a822-ad021347a3bb" />
- Permissions: combined warning when both STT model and TTS voice are missing. <img width="880" height="796" alt="image" src="https://github.com/user-attachments/assets/18ee8686-bf79-41de-b47a-e84bfccf1853" />
- Permissions: plain Voice & Audio link when enabled capabilities are fully configured. <img width="1500" height="1601" alt="centered-04-permissions-plain-link-configured" src="https://github.com/user-attachments/assets/a6eb03ab-1d9d-417a-b77d-4fecc084d0f9" />
- Permissions: no Voice & Audio link or warnings when both STT/TTS capabilities are disabled. <img width="1500" height="1601" alt="centered-05-permissions-both-disabled-no-link" src="https://github.com/user-attachments/assets/69d3f014-4307-4336-a873-bb11afb489a9" />
- Voice & Audio: warning notices that STT/TTS capabilities must be enabled in Permissions. <img width="1884" height="1601" alt="07-voice-audio-tts-capability-disabled-notice" src="https://github.com/user-attachments/assets/76910b22-60bb-4d77-b17d-96049d3a7a08" />

## Review notes / deferred scope

Dual-model adversarial review found no high-consensus correctness/security issues that need to expand this PR further. We intentionally deferred broader speech runtime-readiness work that predates this split:

- STT service lifecycle/transient readiness: if `VoiceServiceInstance` is temporarily unavailable or the model is still warming up, that should be handled by a future runtime-readiness UX pass rather than this capability/settings split.
- Custom/legacy STT model detection: warning behavior for valid-but-unlisted speech model names is out of scope for this UI ownership change.

The TTS fallback concern is not deferred: this PR preserves the existing chat read-aloud fallback to Windows speech when the configured provider/voice setup is incomplete, while Permissions still warns that the selected provider needs setup.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only conversations that still need reviewer or maintainer judgment.