### PR TITLE
Improve multi-gateway credential handling

### DIFF
--- a/docs/CONNECTION_ARCHITECTURE.md
+++ b/docs/CONNECTION_ARCHITECTURE.md
@@ -152,6 +152,8 @@ The invariant is that a paired device token always wins. Do not downgrade a pair
 
 **`CredentialResolver`** implements the precedence for WebSocket connections (operator and node roles). It also returns a detailed `GatewayCredentialResolution` so the active snapshot and diagnostics can distinguish `Resolved`, `Missing`, `Unreadable`, `Corrupt`, `FallbackUsed`, and `BootstrapRequired`. Shared-token-only gateways are a clean resolved state when no paired device token exists. If a stored per-gateway device token is unreadable or corrupt and the resolver falls back to a shared/bootstrap token, `GatewayConnectionSnapshot` preserves that fallback status instead of reporting only the token source.
 
+Unreadable/corrupt identity fallback is an explicit same-gateway recovery path, not a silent cross-gateway downgrade. A readable stored device token still always wins. When the per-gateway identity file cannot be read or parsed, fallback may use only credentials already stored on the same active `GatewayRecord`; the snapshot and diagnostics report `FallbackUsed` with `PrimaryStatus=Unreadable` or `Corrupt` so UI/diagnostics can prompt repair or re-pair. Credential reads never fall back to another gateway's identity directory.
+
 Node credential precedence follows the same invariant with a distinct stored token:
 
 1. **Stored node device token** in the per-gateway identity directory.

--- a/docs/CONNECTION_ARCHITECTURE.md
+++ b/docs/CONNECTION_ARCHITECTURE.md
@@ -135,6 +135,8 @@ Idle → Connecting → Connected
 
 Each `GatewayRecord` contains: `Id`, `Url`, `FriendlyName`, `SharedGatewayToken`, `BootstrapToken`, `LastConnected`, `SshTunnel` config, `IsLocal`, `RequiresV2Signature`, `SetupManagedDistroName`, and `BrowserControlPort`. The `IdentityDirName` property is computed from `Id`.
 
+Many gateway records may be saved, but only `ActiveId` in `gateways.json` is the effective gateway. Active gateway changes must be made through `GatewayRegistry.SetActive(...)` and saved immediately by connection flows that switch or apply credentials. `SetActive(...)` raises `GatewayRegistry.Changed`, so UI and diagnostics can observe a gateway switch even before the new connection finishes. Each active gateway resolves identity from `%APPDATA%\OpenClawTray\gateways\<id>\`; old gateway events are ignored by `GatewayConnectionManager` generation + gateway-id guards after a switch.
+
 `SettingsManager` still owns general tray settings (node mode, MCP mode, SSH tunnel toggles, notifications, UI preferences). It may read legacy `Token` / `BootstrapToken` JSON fields into memory for migration, but save must not write those legacy credential fields back.
 
 ## Credential precedence
@@ -148,7 +150,7 @@ Credential resolution order is intentionally strict:
 
 The invariant is that a paired device token always wins. Do not downgrade a paired operator or node to a shared/bootstrap token, because that can reduce scopes or trigger unnecessary re-pairing.
 
-**`CredentialResolver`** implements the precedence for WebSocket connections (operator and node roles).
+**`CredentialResolver`** implements the precedence for WebSocket connections (operator and node roles). It also returns a detailed `GatewayCredentialResolution` so the active snapshot and diagnostics can distinguish `Resolved`, `Missing`, `Unreadable`, `Corrupt`, `FallbackUsed`, and `BootstrapRequired`. Shared-token-only gateways are a clean resolved state when no paired device token exists. If a stored per-gateway device token is unreadable or corrupt and the resolver falls back to a shared/bootstrap token, `GatewayConnectionSnapshot` preserves that fallback status instead of reporting only the token source.
 
 Node credential precedence follows the same invariant with a distinct stored token:
 
@@ -157,7 +159,7 @@ Node credential precedence follows the same invariant with a distinct stored tok
 3. **`GatewayRecord.BootstrapToken`** — one-time setup, limited scopes.
 4. **No credential** — caller logs and skips node client init.
 
-**`InteractiveGatewayCredentialResolver`** resolves credentials for HTTP surfaces (chat URL `?token=` auth). It **prefers SharedGatewayToken** over DeviceToken because HTTP endpoints expect the shared token, not the per-device WebSocket token.
+**`InteractiveGatewayCredentialResolver`** resolves credentials for HTTP surfaces (chat URL `?token=` auth). It **prefers SharedGatewayToken** over DeviceToken because HTTP endpoints expect the shared token, not the per-device WebSocket token. Browser proxy diagnostics should treat the missing shared token as a browser-control caveat, not as proof that the operator or node gateway connection is disconnected.
 
 ## Client instance lifecycle
 

--- a/src/OpenClaw.Connection/ConnectionDiagnostics.cs
+++ b/src/OpenClaw.Connection/ConnectionDiagnostics.cs
@@ -54,6 +54,22 @@ public sealed class ConnectionDiagnostics
             Record("credential", $"Resolved: {credential.Source}", $"IsBootstrap={credential.IsBootstrapToken}");
     }
 
+    public void RecordCredentialResolutionResult(GatewayCredentialResolution resolution)
+    {
+        ArgumentNullException.ThrowIfNull(resolution);
+
+        if (resolution.Credential == null)
+        {
+            Record("credential", $"No credential resolved: {resolution.Status}", resolution.Detail);
+            return;
+        }
+
+        var detail = $"IsBootstrap={resolution.Credential.IsBootstrapToken}; Status={resolution.Status}; FallbackUsed={resolution.FallbackUsed}";
+        if (!string.IsNullOrWhiteSpace(resolution.Detail))
+            detail += $"; {resolution.Detail}";
+        Record("credential", $"Resolved: {resolution.Credential.Source}", detail);
+    }
+
     public void RecordWebSocketEvent(string eventName, string? detail = null)
     {
         Record("websocket", eventName, detail);

--- a/src/OpenClaw.Connection/ConnectionStateMachine.cs
+++ b/src/OpenClaw.Connection/ConnectionStateMachine.cs
@@ -15,6 +15,14 @@ internal sealed class ConnectionStateMachine
     private string? _nodeError;
     private string? _operatorCredentialSource;
     private string? _nodeCredentialSource;
+    private GatewayCredentialResolutionStatus? _operatorCredentialStatus;
+    private GatewayCredentialResolutionStatus? _nodeCredentialStatus;
+    private bool _operatorCredentialFallbackUsed;
+    private bool _nodeCredentialFallbackUsed;
+    private bool _operatorCredentialBootstrapRequired;
+    private bool _nodeCredentialBootstrapRequired;
+    private string? _operatorCredentialDetail;
+    private string? _nodeCredentialDetail;
     private bool _nodeEnabled;
 
     /// <summary>
@@ -127,6 +135,10 @@ internal sealed class ConnectionStateMachine
             _nodeState = RoleConnectionState.Disabled;
             _nodeError = null;
             _nodeCredentialSource = null;
+            _nodeCredentialStatus = null;
+            _nodeCredentialFallbackUsed = false;
+            _nodeCredentialBootstrapRequired = false;
+            _nodeCredentialDetail = null;
         }
         else if (_nodeState == RoleConnectionState.Disabled)
         {
@@ -145,6 +157,14 @@ internal sealed class ConnectionStateMachine
         _nodeError = null;
         _operatorCredentialSource = null;
         _nodeCredentialSource = null;
+        _operatorCredentialStatus = null;
+        _nodeCredentialStatus = null;
+        _operatorCredentialFallbackUsed = false;
+        _nodeCredentialFallbackUsed = false;
+        _operatorCredentialBootstrapRequired = false;
+        _nodeCredentialBootstrapRequired = false;
+        _operatorCredentialDetail = null;
+        _nodeCredentialDetail = null;
         RebuildSnapshot();
     }
 
@@ -168,6 +188,22 @@ internal sealed class ConnectionStateMachine
     internal void SetOperatorCredentialSource(string? source)
     {
         _operatorCredentialSource = source;
+        _operatorCredentialStatus = string.IsNullOrEmpty(source)
+            ? null
+            : GatewayCredentialResolutionStatus.Resolved;
+        _operatorCredentialFallbackUsed = false;
+        _operatorCredentialBootstrapRequired = false;
+        _operatorCredentialDetail = null;
+        RebuildSnapshot();
+    }
+
+    internal void SetOperatorCredentialResolution(GatewayCredentialResolution resolution)
+    {
+        _operatorCredentialSource = resolution.Credential?.Source;
+        _operatorCredentialStatus = resolution.Status;
+        _operatorCredentialFallbackUsed = resolution.FallbackUsed;
+        _operatorCredentialBootstrapRequired = resolution.BootstrapRequired;
+        _operatorCredentialDetail = resolution.Detail;
         RebuildSnapshot();
     }
 
@@ -203,15 +239,43 @@ internal sealed class ConnectionStateMachine
     internal void SetNodeCredentialSource(string? source)
     {
         _nodeCredentialSource = source;
+        _nodeCredentialStatus = string.IsNullOrEmpty(source)
+            ? null
+            : GatewayCredentialResolutionStatus.Resolved;
+        _nodeCredentialFallbackUsed = false;
+        _nodeCredentialBootstrapRequired = false;
+        _nodeCredentialDetail = null;
         RebuildSnapshot();
     }
 
-    internal void BlockNodeStart(string detail)
+    internal void SetNodeCredentialResolution(GatewayCredentialResolution resolution)
+    {
+        _nodeCredentialSource = resolution.Credential?.Source;
+        _nodeCredentialStatus = resolution.Status;
+        _nodeCredentialFallbackUsed = resolution.FallbackUsed;
+        _nodeCredentialBootstrapRequired = resolution.BootstrapRequired;
+        _nodeCredentialDetail = resolution.Detail;
+        RebuildSnapshot();
+    }
+
+    internal void BlockNodeStart(string detail, bool preserveCredentialResolution = false)
     {
         _nodeEnabled = true;
         _nodeState = RoleConnectionState.Error;
         _nodeError = detail;
         _nodeCredentialSource = null;
+        if (!preserveCredentialResolution)
+        {
+            _nodeCredentialStatus = null;
+            _nodeCredentialFallbackUsed = false;
+            _nodeCredentialBootstrapRequired = false;
+            _nodeCredentialDetail = null;
+        }
+        else
+        {
+            _nodeCredentialStatus ??= GatewayCredentialResolutionStatus.Missing;
+            _nodeCredentialDetail ??= detail;
+        }
         RebuildSnapshot();
     }
 
@@ -291,6 +355,14 @@ internal sealed class ConnectionStateMachine
                 _nodeError = null;
                 _operatorCredentialSource = null;
                 _nodeCredentialSource = null;
+                _operatorCredentialStatus = null;
+                _nodeCredentialStatus = null;
+                _operatorCredentialFallbackUsed = false;
+                _nodeCredentialFallbackUsed = false;
+                _operatorCredentialBootstrapRequired = false;
+                _nodeCredentialBootstrapRequired = false;
+                _operatorCredentialDetail = null;
+                _nodeCredentialDetail = null;
                 break;
 
             case ConnectionTrigger.ReconnectScheduled:
@@ -353,6 +425,10 @@ internal sealed class ConnectionStateMachine
             OperatorState = _operatorState,
             OperatorError = _operatorError,
             OperatorCredentialSource = _operatorCredentialSource,
+            OperatorCredentialStatus = _operatorCredentialStatus,
+            OperatorCredentialFallbackUsed = _operatorCredentialFallbackUsed,
+            OperatorCredentialBootstrapRequired = _operatorCredentialBootstrapRequired,
+            OperatorCredentialDetail = _operatorCredentialDetail,
             OperatorPairingRequired = _operatorState == RoleConnectionState.PairingRequired,
             // Clear requestId when no longer in PairingRequired to prevent stale reads
             OperatorPairingRequestId = _operatorState == RoleConnectionState.PairingRequired
@@ -361,6 +437,10 @@ internal sealed class ConnectionStateMachine
             NodeState = _nodeState,
             NodeError = _nodeError,
             NodeCredentialSource = _nodeCredentialSource,
+            NodeCredentialStatus = _nodeCredentialStatus,
+            NodeCredentialFallbackUsed = _nodeCredentialFallbackUsed,
+            NodeCredentialBootstrapRequired = _nodeCredentialBootstrapRequired,
+            NodeCredentialDetail = _nodeCredentialDetail,
             // Clear requestId when no longer in PairingRequired to prevent stale reads
             NodePairingRequestId = _nodeState == RoleConnectionState.PairingRequired
                 ? Current.NodePairingRequestId : null,

--- a/src/OpenClaw.Connection/CredentialResolver.cs
+++ b/src/OpenClaw.Connection/CredentialResolver.cs
@@ -28,43 +28,133 @@ public sealed class CredentialResolver : ICredentialResolver
         _identityReader = identityReader ?? throw new ArgumentNullException(nameof(identityReader));
     }
 
-    public GatewayCredential? ResolveOperator(GatewayRecord record, string identityPath)
+    public GatewayCredential? ResolveOperator(GatewayRecord record, string identityPath) =>
+        ResolveOperatorDetailed(record, identityPath).Credential;
+
+    public GatewayCredentialResolution ResolveOperatorDetailed(GatewayRecord record, string identityPath)
     {
         ArgumentNullException.ThrowIfNull(record);
 
-        // 1. Paired device token — highest priority, never downgrade
-        var storedToken = _identityReader.TryReadStoredDeviceToken(identityPath);
-        if (!string.IsNullOrWhiteSpace(storedToken))
-            return new GatewayCredential(storedToken!, false, SourceDeviceToken);
-
-        // 2. Shared gateway token — works for any device, full scopes
-        if (!string.IsNullOrWhiteSpace(record.SharedGatewayToken))
-            return new GatewayCredential(record.SharedGatewayToken!, false, SourceSharedGatewayToken);
-
-        // 3. Bootstrap token — one-time setup, limited scopes
-        if (!string.IsNullOrWhiteSpace(record.BootstrapToken))
-            return new GatewayCredential(record.BootstrapToken!, true, SourceBootstrapToken);
-
-        return null;
+        return ResolveRole(
+            _identityReader.ReadStoredDeviceToken(identityPath),
+            SourceDeviceToken,
+            record.SharedGatewayToken,
+            record.BootstrapToken);
     }
 
-    public GatewayCredential? ResolveNode(GatewayRecord record, string identityPath)
+    public GatewayCredential? ResolveNode(GatewayRecord record, string identityPath) =>
+        ResolveNodeDetailed(record, identityPath).Credential;
+
+    public GatewayCredentialResolution ResolveNodeDetailed(GatewayRecord record, string identityPath)
     {
         ArgumentNullException.ThrowIfNull(record);
 
-        // 1. Paired node token — highest priority
-        var storedToken = _identityReader.TryReadStoredNodeDeviceToken(identityPath);
-        if (!string.IsNullOrWhiteSpace(storedToken))
-            return new GatewayCredential(storedToken!, false, SourceNodeDeviceToken);
+        return ResolveRole(
+            _identityReader.ReadStoredNodeDeviceToken(identityPath),
+            SourceNodeDeviceToken,
+            record.SharedGatewayToken,
+            record.BootstrapToken);
+    }
 
-        // 2. Shared gateway token
-        if (!string.IsNullOrWhiteSpace(record.SharedGatewayToken))
-            return new GatewayCredential(record.SharedGatewayToken!, false, SourceSharedGatewayToken);
+    private static GatewayCredentialResolution ResolveRole(
+        DeviceTokenReadResult storedToken,
+        string deviceTokenSource,
+        string? sharedGatewayToken,
+        string? bootstrapToken)
+    {
+        if (storedToken.Status == DeviceTokenReadStatus.Resolved &&
+            !string.IsNullOrWhiteSpace(storedToken.Token))
+        {
+            var credential = new GatewayCredential(storedToken.Token!, false, deviceTokenSource);
+            return new GatewayCredentialResolution(credential, GatewayCredentialResolutionStatus.Resolved);
+        }
 
-        // 3. Bootstrap token
-        if (!string.IsNullOrWhiteSpace(record.BootstrapToken))
-            return new GatewayCredential(record.BootstrapToken!, true, SourceBootstrapToken);
+        var primaryStatus = MapPrimaryStatus(storedToken.Status);
+        if (!string.IsNullOrWhiteSpace(sharedGatewayToken))
+        {
+            var fallbackUsed = primaryStatus is GatewayCredentialResolutionStatus.Unreadable
+                or GatewayCredentialResolutionStatus.Corrupt;
+            var detail = fallbackUsed
+                ? BuildFallbackDetail(deviceTokenSource, primaryStatus, SourceSharedGatewayToken, storedToken.Detail)
+                : null;
+            var credential = new GatewayCredential(sharedGatewayToken!, false, SourceSharedGatewayToken)
+            {
+                ResolutionStatus = fallbackUsed
+                    ? GatewayCredentialResolutionStatus.FallbackUsed
+                    : GatewayCredentialResolutionStatus.Resolved,
+                FallbackUsed = fallbackUsed,
+                ResolutionDetail = detail
+            };
+            return new GatewayCredentialResolution(
+                credential,
+                fallbackUsed
+                    ? GatewayCredentialResolutionStatus.FallbackUsed
+                    : GatewayCredentialResolutionStatus.Resolved,
+                FallbackUsed: fallbackUsed,
+                BootstrapRequired: false,
+                Detail: detail,
+                PrimaryStatus: primaryStatus);
+        }
 
-        return null;
+        if (!string.IsNullOrWhiteSpace(bootstrapToken))
+        {
+            var fallbackUsed = storedToken.Status is DeviceTokenReadStatus.Unreadable or DeviceTokenReadStatus.Corrupt;
+            var detail = fallbackUsed
+                ? BuildFallbackDetail(deviceTokenSource, primaryStatus, SourceBootstrapToken, storedToken.Detail)
+                : "Using bootstrap token; pairing is required before a durable device token is available.";
+            var credential = new GatewayCredential(bootstrapToken!, true, SourceBootstrapToken)
+            {
+                ResolutionStatus = GatewayCredentialResolutionStatus.BootstrapRequired,
+                FallbackUsed = fallbackUsed,
+                ResolutionDetail = detail
+            };
+            return new GatewayCredentialResolution(
+                credential,
+                GatewayCredentialResolutionStatus.BootstrapRequired,
+                FallbackUsed: fallbackUsed,
+                BootstrapRequired: true,
+                Detail: detail,
+                PrimaryStatus: primaryStatus);
+        }
+
+        var missingDetail = storedToken.Status switch
+        {
+            DeviceTokenReadStatus.Unreadable => $"Stored {deviceTokenSource} is unreadable and no shared/bootstrap fallback is available. {storedToken.Detail}",
+            DeviceTokenReadStatus.Corrupt => $"Stored {deviceTokenSource} is corrupt and no shared/bootstrap fallback is available. {storedToken.Detail}",
+            _ => "No device, shared, or bootstrap credential is available."
+        };
+        return new GatewayCredentialResolution(
+            null,
+            primaryStatus == GatewayCredentialResolutionStatus.Resolved
+                ? GatewayCredentialResolutionStatus.Missing
+                : primaryStatus,
+            Detail: missingDetail,
+            PrimaryStatus: primaryStatus);
+    }
+
+    private static GatewayCredentialResolutionStatus MapPrimaryStatus(DeviceTokenReadStatus status) =>
+        status switch
+        {
+            DeviceTokenReadStatus.Resolved => GatewayCredentialResolutionStatus.Resolved,
+            DeviceTokenReadStatus.Unreadable => GatewayCredentialResolutionStatus.Unreadable,
+            DeviceTokenReadStatus.Corrupt => GatewayCredentialResolutionStatus.Corrupt,
+            _ => GatewayCredentialResolutionStatus.Missing
+        };
+
+    private static string BuildFallbackDetail(
+        string primarySource,
+        GatewayCredentialResolutionStatus primaryStatus,
+        string fallbackSource,
+        string? readDetail)
+    {
+        var reason = primaryStatus switch
+        {
+            GatewayCredentialResolutionStatus.Unreadable => $"{primarySource} is unreadable",
+            GatewayCredentialResolutionStatus.Corrupt => $"{primarySource} is corrupt",
+            _ => $"{primarySource} is missing"
+        };
+        return string.IsNullOrWhiteSpace(readDetail)
+            ? $"{reason}; using {fallbackSource}."
+            : $"{reason}; using {fallbackSource}. {readDetail}";
     }
 }

--- a/src/OpenClaw.Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/GatewayConnectionManager.cs
@@ -195,19 +195,29 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             if (!Directory.Exists(perGatewayIdentityDir))
                 Directory.CreateDirectory(perGatewayIdentityDir);
 
-            var credential = _credentialResolver.ResolveOperator(record, perGatewayIdentityDir);
+            var credentialResolution = _credentialResolver.ResolveOperatorDetailed(record, perGatewayIdentityDir);
+            var credential = credentialResolution.Credential;
             if (_forceBootstrapForGatewayRecordId == record.Id &&
                 !string.IsNullOrWhiteSpace(record.BootstrapToken))
             {
                 credential = new GatewayCredential(
                     record.BootstrapToken!,
                     IsBootstrapToken: true,
-                    CredentialResolver.SourceBootstrapToken);
+                    CredentialResolver.SourceBootstrapToken)
+                {
+                    ResolutionStatus = GatewayCredentialResolutionStatus.BootstrapRequired,
+                    ResolutionDetail = "Using setup-code bootstrap token for this connection."
+                };
+                credentialResolution = new GatewayCredentialResolution(
+                    credential,
+                    GatewayCredentialResolutionStatus.BootstrapRequired,
+                    BootstrapRequired: true,
+                    Detail: credential.ResolutionDetail);
                 _forceBootstrapForGatewayRecordId = null;
             }
             _activeConnectUsedBootstrapToken = credential?.IsBootstrapToken == true;
             _postBootstrapOperatorReconnectScheduled = false;
-            _diagnostics.RecordCredentialResolution(credential);
+            _diagnostics.RecordCredentialResolutionResult(credentialResolution);
             _activeIdentityPath = perGatewayIdentityDir;
             _activeGatewayRecordId = record.Id;
             _activeSshTunnel = record.SshTunnel;
@@ -219,8 +229,10 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
                 _logger.Warn("[ConnMgr] No credential available for gateway");
                 // Must go through Connecting → Error since AuthenticationFailed requires Connecting state
                 _stateMachine.TryTransition(ConnectionTrigger.ConnectRequested);
-                _stateMachine.SetOperatorCredentialSource(null);
-                _stateMachine.TryTransition(ConnectionTrigger.AuthenticationFailed, "No credential available");
+                _stateMachine.SetOperatorCredentialResolution(credentialResolution);
+                _stateMachine.TryTransition(
+                    ConnectionTrigger.AuthenticationFailed,
+                    BuildCredentialFailureMessage("operator", credentialResolution));
                 EmitStateChanged();
                 return;
             }
@@ -228,7 +240,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             // Transition to Connecting
             var prevState = _stateMachine.Current.OverallState;
             _stateMachine.TryTransition(ConnectionTrigger.ConnectRequested);
-            _stateMachine.SetOperatorCredentialSource(credential.Source);
+            _stateMachine.SetOperatorCredentialResolution(credentialResolution);
             _diagnostics.RecordStateChange(prevState, _stateMachine.Current.OverallState);
             EmitStateChanged();
 
@@ -277,41 +289,40 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
                 NewClient = lifecycle.DataClient
             });
 
-            // Subscribe to client events with generation guard
+            // Subscribe to client events with generation and gateway guards.
+            var subscribedGatewayId = record.Id;
             lifecycle.StatusChanged += (s, status) =>
             {
-                if (Interlocked.Read(ref _generation) != gen) return;
+                if (!IsCurrentGatewayAttempt(gen, subscribedGatewayId)) return;
                 _ = HandleOperatorStatusChangedAsync(status, gen);
             };
             lifecycle.AuthenticationFailed += (s, msg) =>
             {
-                if (Interlocked.Read(ref _generation) != gen) return;
+                if (!IsCurrentGatewayAttempt(gen, subscribedGatewayId)) return;
                 _ = HandleAuthenticationFailedAsync(msg, gen);
             };
             lifecycle.DataClient.HandshakeSucceeded += (s, e) =>
             {
-                if (Interlocked.Read(ref _generation) != gen) return;
+                if (!IsCurrentGatewayAttempt(gen, subscribedGatewayId)) return;
                 _ = HandleHandshakeSucceededAsync(gen);
             };
             lifecycle.DataClient.DeviceTokenReceived += (s, e) =>
             {
-                if (Interlocked.Read(ref _generation) != gen) return;
-                HandleDeviceTokenReceived(e);
+                _ = HandleDeviceTokenReceivedAsync(e, gen, subscribedGatewayId, perGatewayIdentityDir);
             };
             lifecycle.DataClient.PairingRequired += (s, requestId) =>
             {
-                if (Interlocked.Read(ref _generation) != gen) return;
+                if (!IsCurrentGatewayAttempt(gen, subscribedGatewayId)) return;
                 _ = HandlePairingRequiredAsync(requestId, gen);
             };
             lifecycle.DataClient.NodePairListUpdated += (s, list) =>
             {
-                if (Interlocked.Read(ref _generation) != gen) return;
+                if (!IsCurrentGatewayAttempt(gen, subscribedGatewayId)) return;
                 _ = HandleNodePairListUpdatedAsync(list, gen);
             };
-            lifecycle.DataClient.V2SignatureFallback += (s, _) =>
+            lifecycle.DataClient.V2SignatureFallback += (s, e) =>
             {
-                if (Interlocked.Read(ref _generation) != gen) return;
-                RememberGatewayNeedsV2Signature(record.Id);
+                _ = HandleV2SignatureFallbackAsync(gen, subscribedGatewayId);
             };
 
             // Local gateways only support v2 signatures — skip the v3 attempt entirely
@@ -372,9 +383,6 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             string.Equals(_activeGatewayRecordId, record.Id, StringComparison.Ordinal) &&
             string.Equals(_stateMachine.Current.GatewayUrl, record.Url, StringComparison.Ordinal) &&
             Equals(_activeSshTunnel, record.SshTunnel);
-        var operatorCredentialSource = preservesOperatorConnection
-            ? _stateMachine.Current.OperatorCredentialSource
-            : null;
         var gen = Interlocked.Read(ref _generation);
         if (!preservesOperatorConnection)
         {
@@ -400,24 +408,30 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         _stateMachine.StartNodeConnecting();
         _stateMachine.SetNodeCredentialSource(null);
 
-        var nodeCredential = _credentialResolver.ResolveNode(record, perGatewayIdentityDir);
+        var nodeCredentialResolution = _credentialResolver.ResolveNodeDetailed(record, perGatewayIdentityDir);
+        var nodeCredential = nodeCredentialResolution.Credential;
         if (nodeCredential == null)
         {
             _logger.Warn("[ConnMgr] No node credential available for node-only connect");
-            _diagnostics.Record("node", "No node credential available for node-only connect");
-            _stateMachine.BlockNodeStart(MissingNodeCredentialMessage);
+            _diagnostics.RecordCredentialResolutionResult(nodeCredentialResolution);
+            _stateMachine.SetNodeCredentialResolution(nodeCredentialResolution);
+            _stateMachine.BlockNodeStart(
+                BuildCredentialFailureMessage("node", nodeCredentialResolution),
+                preserveCredentialResolution: true);
             EmitStateChanged();
             return null;
         }
 
-        _diagnostics.RecordCredentialResolution(nodeCredential);
-        _stateMachine.SetOperatorCredentialSource(operatorCredentialSource);
+        _diagnostics.RecordCredentialResolutionResult(nodeCredentialResolution);
+        if (!preservesOperatorConnection)
+            _stateMachine.SetOperatorCredentialSource(null);
         _diagnostics.Record("node", $"Starting node-only connection to {record.Url}",
             $"Credential source: {nodeCredential.Source}");
 
         if (!preservesOperatorConnection && !await TryStartTunnelForNodeOnlyAsync(record))
         {
-            _stateMachine.BlockNodeStart(NodeTunnelStartFailedMessage);
+            _stateMachine.SetNodeCredentialResolution(nodeCredentialResolution);
+            _stateMachine.BlockNodeStart(NodeTunnelStartFailedMessage, preserveCredentialResolution: true);
             EmitStateChanged();
             return null;
         }
@@ -512,6 +526,28 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         await _transitionSemaphore.WaitAsync();
         try
         {
+            if (_registry.GetById(gatewayId) == null)
+            {
+                _logger.Warn($"[ConnMgr] Cannot switch gateway — record {gatewayId} not found");
+                _diagnostics.Record("state", "Switch gateway failed", $"Gateway record not found: {gatewayId}");
+                return;
+            }
+
+            var previousActiveId = _registry.ActiveGatewayId;
+            _diagnostics.Record("state", $"Switching active gateway to {gatewayId}");
+            _registry.SetActive(gatewayId);
+            try
+            {
+                _registry.Save();
+            }
+            catch (Exception ex)
+            {
+                _registry.SetActive(previousActiveId);
+                _logger.Warn($"[ConnMgr] Failed to persist active gateway switch: {ex.Message}");
+                _diagnostics.Record("state", "Switch gateway failed", $"Could not persist active gateway: {ex.Message}");
+                return;
+            }
+
             await DisconnectCoreAsync();
             // Stop tunnel when switching gateways — the new one may not need it.
             // Use a bounded timeout to avoid blocking all connection transitions.
@@ -526,7 +562,6 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
                 catch (Exception ex) { _logger.Warn($"[ConnMgr] Tunnel stop error on gateway switch: {ex.Message}"); }
             }
             _gatewayNeedsV2Signature = false; // new gateway might support v3
-            _registry.SetActive(gatewayId);
             await ConnectCoreAsync(gatewayId);
         }
         finally
@@ -550,47 +585,70 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         if (!GatewayUrlHelper.IsValidGatewayUrl(gatewayUrl))
             return new SetupCodeResult(SetupCodeOutcome.InvalidUrl, "Invalid gateway URL");
 
-        // 3. Disconnect current gateway if any
-        await DisconnectAsync();
-
-        var existing = _registry.FindByUrl(gatewayUrl);
-
-        // New gateway URL → reset v2 signature flag (new gateway might support v3)
-        var isNewGateway = existing == null;
-        if (isNewGateway)
-            _gatewayNeedsV2Signature = false;
-
-        // 4. Create or update gateway record
-        var recordId = existing?.Id ?? Guid.NewGuid().ToString();
-
-        // Setup codes from `openclaw qr` always provide bootstrap tokens.
-        // Store as BootstrapToken so the credential resolver passes IsBootstrapToken=true,
-        // causing the client to send auth.bootstrapToken (not auth.token).
-        var record = (existing ?? new GatewayRecord { Id = recordId }) with
+        await _transitionSemaphore.WaitAsync();
+        try
         {
-            Url = gatewayUrl,
-            SharedGatewayToken = existing?.SharedGatewayToken, // preserve existing shared token if any
-            BootstrapToken = decoded.Token ?? existing?.BootstrapToken,
-            SshTunnel = sshTunnel ?? existing?.SshTunnel,
-        };
-        _registry.AddOrUpdate(record);
-        _registry.SetActive(recordId);
-        _registry.Save();
+            var existing = _registry.FindByUrl(gatewayUrl);
 
-        // Ensure identity directory
-        var identityDir = _registry.GetIdentityDirectory(recordId);
-        if (!Directory.Exists(identityDir))
-            Directory.CreateDirectory(identityDir);
+            // New gateway URL → reset v2 signature flag (new gateway might support v3)
+            var isNewGateway = existing == null;
+            if (isNewGateway)
+                _gatewayNeedsV2Signature = false;
 
-        // Clear stored device tokens so we start fresh with the bootstrap token.
-        // The keypair (device ID) stays — only the tokens are wiped.
-        DeviceIdentityStore.ClearStoredTokens(identityDir, _logger);
-        _diagnostics.Record("setup", $"Setup code applied for {GatewayUrlHelper.SanitizeForDisplay(gatewayUrl)}");
+            // 4. Create or update gateway record
+            var recordId = existing?.Id ?? Guid.NewGuid().ToString();
 
-        // 5. Connect to new gateway
-        if (!string.IsNullOrWhiteSpace(decoded.Token))
-            _forceBootstrapForGatewayRecordId = recordId;
-        await ConnectAsync(recordId);
+            // Setup codes from `openclaw qr` always provide bootstrap tokens.
+            // Store as BootstrapToken so the credential resolver passes IsBootstrapToken=true,
+            // causing the client to send auth.bootstrapToken (not auth.token).
+            var record = (existing ?? new GatewayRecord { Id = recordId }) with
+            {
+                Url = gatewayUrl,
+                SharedGatewayToken = existing?.SharedGatewayToken, // preserve existing shared token if any
+                BootstrapToken = decoded.Token ?? existing?.BootstrapToken,
+                SshTunnel = sshTunnel ?? existing?.SshTunnel,
+            };
+            var previousRecord = existing;
+            var previousActiveId = _registry.ActiveGatewayId;
+            _registry.AddOrUpdate(record);
+            _registry.SetActive(recordId);
+            try
+            {
+                _registry.Save();
+            }
+            catch (Exception ex)
+            {
+                if (previousRecord == null)
+                    _registry.Remove(recordId);
+                else
+                    _registry.AddOrUpdate(previousRecord);
+                _registry.SetActive(previousActiveId);
+                _logger.Warn($"[ConnMgr] Failed to persist setup-code gateway update: {ex.Message}");
+                return new SetupCodeResult(SetupCodeOutcome.ConnectionFailed, ex.Message);
+            }
+
+            // 3. Disconnect current gateway only after the new active gateway is persisted.
+            await DisconnectCoreAsync();
+
+            // Ensure identity directory
+            var identityDir = _registry.GetIdentityDirectory(recordId);
+            if (!Directory.Exists(identityDir))
+                Directory.CreateDirectory(identityDir);
+
+            // Clear stored device tokens so we start fresh with the bootstrap token.
+            // The keypair (device ID) stays — only the tokens are wiped.
+            DeviceIdentityStore.ClearStoredTokens(identityDir, _logger);
+            _diagnostics.Record("setup", $"Setup code applied for {GatewayUrlHelper.SanitizeForDisplay(gatewayUrl)}");
+
+            // 5. Connect to new gateway
+            if (!string.IsNullOrWhiteSpace(decoded.Token))
+                _forceBootstrapForGatewayRecordId = recordId;
+            await ConnectCoreAsync(recordId);
+        }
+        finally
+        {
+            _transitionSemaphore.Release();
+        }
 
         return new SetupCodeResult(SetupCodeOutcome.Success, GatewayUrl: gatewayUrl);
     }
@@ -603,49 +661,70 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         if (!GatewayUrlHelper.IsValidGatewayUrl(gatewayUrl))
             return new SetupCodeResult(SetupCodeOutcome.InvalidUrl, "Invalid gateway URL");
 
-        // Find or create gateway record (dedup by URL)
-        var existing = _registry.FindByUrl(gatewayUrl);
-        var recordId = existing?.Id ?? Guid.NewGuid().ToString();
-        var identityDir = _registry.GetIdentityDirectory(recordId);
-        var hasDurableTokens =
-            DeviceIdentity.HasStoredDeviceTokenForRole(identityDir, "operator", _logger) ||
-            DeviceIdentity.HasStoredDeviceTokenForRole(identityDir, "node", _logger);
-
-        if (existing != null && hasDurableTokens)
-        {
-            var validation = await ValidateSharedTokenBeforeReplacementAsync(
-                gatewayUrl,
-                token,
-                identityDir,
-                existing);
-            if (validation.Outcome != SetupCodeOutcome.Success)
-                return validation;
-        }
-
-        // Disconnect current gateway only after replacement credentials have been validated.
-        await DisconnectAsync();
-
-        var record = (existing ?? new GatewayRecord { Id = recordId }) with
-        {
-            Url = gatewayUrl,
-            SharedGatewayToken = token,
-            BootstrapToken = null,
-            SshTunnel = sshTunnel,
-        };
-        _registry.AddOrUpdate(record);
-
-        // Clear stored device tokens so the shared token is used
-        if (!Directory.Exists(identityDir))
-            Directory.CreateDirectory(identityDir);
-        DeviceIdentityStore.ClearStoredTokens(identityDir, _logger);
-
-        _registry.SetActive(recordId);
-        _registry.Save();
-
-        // Connect to the gateway
         try
         {
-            await ConnectAsync(recordId);
+            await _transitionSemaphore.WaitAsync();
+            try
+            {
+                var existing = _registry.FindByUrl(gatewayUrl);
+                var recordId = existing?.Id ?? Guid.NewGuid().ToString();
+                var identityDir = _registry.GetIdentityDirectory(recordId);
+                var hasDurableTokens =
+                    DeviceIdentity.HasStoredDeviceTokenForRole(identityDir, "operator", _logger) ||
+                    DeviceIdentity.HasStoredDeviceTokenForRole(identityDir, "node", _logger);
+
+                if (existing != null && hasDurableTokens)
+                {
+                    var validation = await ValidateSharedTokenBeforeReplacementAsync(
+                        gatewayUrl,
+                        token,
+                        identityDir,
+                        existing);
+                    if (validation.Outcome != SetupCodeOutcome.Success)
+                        return validation;
+                }
+
+                var record = (existing ?? new GatewayRecord { Id = recordId }) with
+                {
+                    Url = gatewayUrl,
+                    SharedGatewayToken = token,
+                    BootstrapToken = null,
+                    SshTunnel = sshTunnel,
+                };
+                var previousRecord = existing;
+                var previousActiveId = _registry.ActiveGatewayId;
+                _registry.AddOrUpdate(record);
+                _registry.SetActive(recordId);
+                try
+                {
+                    _registry.Save();
+                }
+                catch (Exception ex)
+                {
+                    if (previousRecord == null)
+                        _registry.Remove(recordId);
+                    else
+                        _registry.AddOrUpdate(previousRecord);
+                    _registry.SetActive(previousActiveId);
+                    _logger.Warn($"[ConnMgr] Failed to persist shared-token gateway update: {ex.Message}");
+                    return new SetupCodeResult(SetupCodeOutcome.ConnectionFailed, ex.Message);
+                }
+
+                // Disconnect current gateway only after replacement credentials have been validated and persisted.
+                await DisconnectCoreAsync();
+
+                // Clear stored device tokens so the shared token is used.
+                if (!Directory.Exists(identityDir))
+                    Directory.CreateDirectory(identityDir);
+                DeviceIdentityStore.ClearStoredTokens(identityDir, _logger);
+
+                // Connect to the gateway
+                await ConnectCoreAsync(recordId);
+            }
+            finally
+            {
+                _transitionSemaphore.Release();
+            }
             return new SetupCodeResult(SetupCodeOutcome.Success, GatewayUrl: gatewayUrl);
         }
         catch (Exception ex)
@@ -897,39 +976,56 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         }
     }
 
-    private void HandleDeviceTokenReceived(DeviceTokenReceivedEventArgs e)
+    private async Task HandleDeviceTokenReceivedAsync(
+        DeviceTokenReceivedEventArgs e,
+        long gen,
+        string gatewayRecordId,
+        string identityPath)
     {
-        _diagnostics.Record("credential", $"Device token received for {e.Role}",
-            $"Scopes={string.Join(",", e.Scopes ?? [])}");
-
-        if (_identityStore != null && _activeIdentityPath != null)
+        await _transitionSemaphore.WaitAsync();
+        try
         {
-            try
-            {
-                _identityStore.StoreToken(_activeIdentityPath, e.Token, e.Scopes, e.Role);
-                _logger.Info($"[ConnMgr] Persisted {e.Role} device token via identity store");
-            }
-            catch (Exception ex)
-            {
-                _logger.Warn($"[ConnMgr] Failed to persist {e.Role} device token: {ex.Message}");
-            }
-        }
+            if (!IsCurrentGatewayAttempt(gen, gatewayRecordId))
+                return;
 
-        TryClearBootstrapTokenAfterDurablePairing();
-        TrySchedulePostBootstrapOperatorReconnect(e);
+            _diagnostics.Record("credential", $"Device token received for {e.Role}",
+                $"Scopes={string.Join(",", e.Scopes ?? [])}");
+
+            if (_identityStore != null)
+            {
+                try
+                {
+                    _identityStore.StoreToken(identityPath, e.Token, e.Scopes, e.Role);
+                    _logger.Info($"[ConnMgr] Persisted {e.Role} device token via identity store");
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warn($"[ConnMgr] Failed to persist {e.Role} device token: {ex.Message}");
+                }
+            }
+
+            TryClearBootstrapTokenAfterDurablePairing(gatewayRecordId, identityPath);
+            TrySchedulePostBootstrapOperatorReconnect(e, gen, gatewayRecordId, identityPath);
+        }
+        finally
+        {
+            _transitionSemaphore.Release();
+        }
     }
 
     private void TryClearBootstrapTokenAfterDurablePairing()
     {
-        if (_activeGatewayRecordId == null || _activeIdentityPath == null)
+        var activeGatewayRecordId = _activeGatewayRecordId;
+        var activeIdentityPath = _activeIdentityPath;
+        if (activeGatewayRecordId == null || activeIdentityPath == null)
             return;
 
-        var record = _registry.GetById(_activeGatewayRecordId);
+        var record = _registry.GetById(activeGatewayRecordId);
         if (record?.BootstrapToken == null)
             return;
 
-        var hasOperatorToken = DeviceIdentity.HasStoredDeviceTokenForRole(_activeIdentityPath, "operator", _logger);
-        var hasNodeToken = DeviceIdentity.HasStoredDeviceTokenForRole(_activeIdentityPath, "node", _logger);
+        var hasOperatorToken = DeviceIdentity.HasStoredDeviceTokenForRole(activeIdentityPath, "operator", _logger);
+        var hasNodeToken = DeviceIdentity.HasStoredDeviceTokenForRole(activeIdentityPath, "node", _logger);
         if (!hasOperatorToken || !hasNodeToken)
         {
             _diagnostics.Record(
@@ -939,24 +1035,71 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             return;
         }
 
-        _registry.AddOrUpdate(record with { BootstrapToken = null });
-        _registry.Save();
-        _diagnostics.Record("credential", "Cleared bootstrap token — operator and node tokens are durable");
+        var updated = _registry.Update(activeGatewayRecordId, r => r with { BootstrapToken = null });
+        if (updated == null)
+            return;
+
+        try
+        {
+            _registry.Save();
+            _diagnostics.Record("credential", "Cleared bootstrap token — operator and node tokens are durable");
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"[ConnMgr] Failed to persist cleared bootstrap token: {ex.Message}");
+            _diagnostics.Record("credential", "Failed to persist cleared bootstrap token", ex.Message);
+        }
     }
 
-    private void TrySchedulePostBootstrapOperatorReconnect(DeviceTokenReceivedEventArgs e)
+    private void TryClearBootstrapTokenAfterDurablePairing(string gatewayRecordId, string identityPath)
     {
-        if (!_activeConnectUsedBootstrapToken ||
-            _postBootstrapOperatorReconnectScheduled ||
-            _activeIdentityPath == null ||
-            _activeGatewayRecordId == null)
+        var record = _registry.GetById(gatewayRecordId);
+        if (record?.BootstrapToken == null)
+            return;
+
+        var hasOperatorToken = DeviceIdentity.HasStoredDeviceTokenForRole(identityPath, "operator", _logger);
+        var hasNodeToken = DeviceIdentity.HasStoredDeviceTokenForRole(identityPath, "node", _logger);
+        if (!hasOperatorToken || !hasNodeToken)
+        {
+            _diagnostics.Record(
+                "credential",
+                "Retaining bootstrap token until role tokens are durable",
+                $"operatorToken={hasOperatorToken}; nodeToken={hasNodeToken}");
+            return;
+        }
+
+        var updated = _registry.Update(gatewayRecordId, r => r with { BootstrapToken = null });
+        if (updated == null)
+            return;
+
+        try
+        {
+            _registry.Save();
+            _diagnostics.Record("credential", "Cleared bootstrap token — operator and node tokens are durable");
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"[ConnMgr] Failed to persist cleared bootstrap token: {ex.Message}");
+            _diagnostics.Record("credential", "Failed to persist cleared bootstrap token", ex.Message);
+        }
+    }
+
+    private void TrySchedulePostBootstrapOperatorReconnect(
+        DeviceTokenReceivedEventArgs e,
+        long gen,
+        string gatewayRecordId,
+        string identityPath)
+    {
+        if (!IsCurrentGatewayAttempt(gen, gatewayRecordId) ||
+            !_activeConnectUsedBootstrapToken ||
+            _postBootstrapOperatorReconnectScheduled)
         {
             return;
         }
 
         var hasOperatorToken = !string.IsNullOrWhiteSpace(
-            DeviceIdentity.TryReadStoredDeviceTokenForRole(_activeIdentityPath, "operator", _logger));
-        var record = _registry.GetById(_activeGatewayRecordId);
+            DeviceIdentity.TryReadStoredDeviceTokenForRole(identityPath, "operator", _logger));
+        var record = _registry.GetById(gatewayRecordId);
         var canReconnectWithSharedToken = !string.IsNullOrWhiteSpace(record?.SharedGatewayToken);
 
         if (!hasOperatorToken && !canReconnectWithSharedToken)
@@ -966,15 +1109,14 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             return;
 
         _postBootstrapOperatorReconnectScheduled = true;
-        var reconnectGeneration = Interlocked.Read(ref _generation);
         var detail = hasOperatorToken
             ? "using persisted operator device token"
             : "using preserved shared gateway token";
-        RememberGatewayNeedsV2Signature(_activeGatewayRecordId);
+        RememberGatewayNeedsV2Signature(gatewayRecordId, markActiveAttempt: true);
         _diagnostics.Record("credential", "Bootstrap handoff complete — reconnecting operator role", detail);
 
         ScheduleDelayedReconnect(
-            reconnectGeneration,
+            gen,
             "[ConnMgr] Post-bootstrap operator reconnect failed",
             ex => _diagnostics.Record("credential", "Post-bootstrap operator reconnect failed", ex.Message));
     }
@@ -1004,9 +1146,25 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         });
     }
 
-    private void RememberGatewayNeedsV2Signature(string? gatewayRecordId)
+    private async Task HandleV2SignatureFallbackAsync(long gen, string gatewayRecordId)
     {
-        _gatewayNeedsV2Signature = true;
+        await _transitionSemaphore.WaitAsync();
+        try
+        {
+            RememberGatewayNeedsV2Signature(
+                gatewayRecordId,
+                markActiveAttempt: IsCurrentGatewayAttempt(gen, gatewayRecordId));
+        }
+        finally
+        {
+            _transitionSemaphore.Release();
+        }
+    }
+
+    private void RememberGatewayNeedsV2Signature(string? gatewayRecordId, bool markActiveAttempt = true)
+    {
+        if (markActiveAttempt)
+            _gatewayNeedsV2Signature = true;
 
         if (string.IsNullOrWhiteSpace(gatewayRecordId))
             return;
@@ -1281,6 +1439,30 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         (!expectedNodeGeneration.HasValue ||
          Interlocked.Read(ref _nodeConnectionGeneration) == expectedNodeGeneration.Value);
 
+    private bool IsCurrentGatewayAttempt(long expectedGeneration, string expectedGatewayId) =>
+        !_disposed &&
+        Interlocked.Read(ref _generation) == expectedGeneration &&
+        string.Equals(_activeGatewayRecordId, expectedGatewayId, StringComparison.Ordinal);
+
+    private static string BuildCredentialFailureMessage(string role, GatewayCredentialResolution resolution)
+    {
+        var prefix = role.Equals("node", StringComparison.OrdinalIgnoreCase)
+            ? "No node credential available"
+            : "No operator credential available";
+        return resolution.Status switch
+        {
+            GatewayCredentialResolutionStatus.Corrupt =>
+                $"{prefix}: stored device token is corrupt. Re-pair this PC or add a shared/bootstrap gateway token.",
+            GatewayCredentialResolutionStatus.Unreadable =>
+                $"{prefix}: stored device token is unreadable. Check file permissions, re-pair this PC, or add a shared/bootstrap gateway token.",
+            _ when !string.IsNullOrWhiteSpace(resolution.Detail) =>
+                $"{prefix}. {resolution.Detail}",
+            _ => role.Equals("node", StringComparison.OrdinalIgnoreCase)
+                ? MissingNodeCredentialMessage
+                : $"{prefix}. Add a shared/bootstrap gateway token or re-pair this PC."
+        };
+    }
+
     private async Task BlockNodeStartAsync(
         string detail,
         CancellationToken cancellationToken,
@@ -1340,13 +1522,18 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             return false;
         }
 
-        if (_activeGatewayRecordId == null || _activeIdentityPath == null)
+        if (!IsExpectedNodeStartCurrent(expectedLifecycleGeneration, nodeGeneration))
+            return false;
+
+        var activeGatewayRecordId = _activeGatewayRecordId;
+        var activeIdentityPath = _activeIdentityPath;
+        if (activeGatewayRecordId == null || activeIdentityPath == null)
         {
             await BlockNodeStartAsync(MissingActiveGatewayForNodeMessage, cancellationToken, expectedLifecycleGeneration, nodeGeneration);
             return false;
         }
 
-        var record = _registry.GetById(_activeGatewayRecordId);
+        var record = _registry.GetById(activeGatewayRecordId);
         if (record == null)
         {
             _logger.Warn("[ConnMgr] Cannot start node — gateway record not found");
@@ -1375,13 +1562,28 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
             _transitionSemaphore.Release();
         }
 
-        // Use root identity path — clients always read/write from root, not per-gateway
-        var nodeCredential = _credentialResolver.ResolveNode(record, _activeIdentityPath!);
+        var nodeCredentialResolution = _credentialResolver.ResolveNodeDetailed(record, activeIdentityPath);
+        var nodeCredential = nodeCredentialResolution.Credential;
         if (nodeCredential == null)
         {
             _logger.Warn("[ConnMgr] No node credential available — skipping node connection");
-            _diagnostics.Record("node", "No node credential available");
-            await BlockNodeStartAsync(MissingNodeCredentialMessage, cancellationToken, expectedLifecycleGeneration, nodeGeneration);
+            _diagnostics.RecordCredentialResolutionResult(nodeCredentialResolution);
+            await _transitionSemaphore.WaitAsync(cancellationToken);
+            try
+            {
+                if (!IsExpectedNodeStartCurrent(expectedLifecycleGeneration, nodeGeneration))
+                    return false;
+
+                _stateMachine.SetNodeCredentialResolution(nodeCredentialResolution);
+                _stateMachine.BlockNodeStart(
+                    BuildCredentialFailureMessage("node", nodeCredentialResolution),
+                    preserveCredentialResolution: true);
+                EmitStateChanged();
+            }
+            finally
+            {
+                _transitionSemaphore.Release();
+            }
             return false;
         }
 
@@ -1392,6 +1594,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
                 return false;
 
             _stateMachine.SetNodeCredentialSource(nodeCredential.Source);
+            _stateMachine.SetNodeCredentialResolution(nodeCredentialResolution);
         }
         finally
         {
@@ -1413,7 +1616,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
 
         try
         {
-            await _nodeConnector.ConnectAsync(nodeConnectUrl, nodeCredential, _activeIdentityPath,
+            await _nodeConnector.ConnectAsync(nodeConnectUrl, nodeCredential, activeIdentityPath,
                 useV2Signature: _gatewayNeedsV2Signature,
                 cancellationToken: cancellationToken);
         }

--- a/src/OpenClaw.Connection/GatewayConnectionManager.cs
+++ b/src/OpenClaw.Connection/GatewayConnectionManager.cs
@@ -561,7 +561,6 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
                 }
                 catch (Exception ex) { _logger.Warn($"[ConnMgr] Tunnel stop error on gateway switch: {ex.Message}"); }
             }
-            _gatewayNeedsV2Signature = false; // new gateway might support v3
             await ConnectCoreAsync(gatewayId);
         }
         finally
@@ -589,11 +588,6 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         try
         {
             var existing = _registry.FindByUrl(gatewayUrl);
-
-            // New gateway URL → reset v2 signature flag (new gateway might support v3)
-            var isNewGateway = existing == null;
-            if (isNewGateway)
-                _gatewayNeedsV2Signature = false;
 
             // 4. Create or update gateway record
             var recordId = existing?.Id ?? Guid.NewGuid().ToString();
@@ -1020,35 +1014,7 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
         if (activeGatewayRecordId == null || activeIdentityPath == null)
             return;
 
-        var record = _registry.GetById(activeGatewayRecordId);
-        if (record?.BootstrapToken == null)
-            return;
-
-        var hasOperatorToken = DeviceIdentity.HasStoredDeviceTokenForRole(activeIdentityPath, "operator", _logger);
-        var hasNodeToken = DeviceIdentity.HasStoredDeviceTokenForRole(activeIdentityPath, "node", _logger);
-        if (!hasOperatorToken || !hasNodeToken)
-        {
-            _diagnostics.Record(
-                "credential",
-                "Retaining bootstrap token until role tokens are durable",
-                $"operatorToken={hasOperatorToken}; nodeToken={hasNodeToken}");
-            return;
-        }
-
-        var updated = _registry.Update(activeGatewayRecordId, r => r with { BootstrapToken = null });
-        if (updated == null)
-            return;
-
-        try
-        {
-            _registry.Save();
-            _diagnostics.Record("credential", "Cleared bootstrap token — operator and node tokens are durable");
-        }
-        catch (Exception ex)
-        {
-            _logger.Warn($"[ConnMgr] Failed to persist cleared bootstrap token: {ex.Message}");
-            _diagnostics.Record("credential", "Failed to persist cleared bootstrap token", ex.Message);
-        }
+        TryClearBootstrapTokenAfterDurablePairing(activeGatewayRecordId, activeIdentityPath);
     }
 
     private void TryClearBootstrapTokenAfterDurablePairing(string gatewayRecordId, string identityPath)
@@ -1455,6 +1421,9 @@ public sealed class GatewayConnectionManager : IGatewayConnectionManager
                 $"{prefix}: stored device token is corrupt. Re-pair this PC or add a shared/bootstrap gateway token.",
             GatewayCredentialResolutionStatus.Unreadable =>
                 $"{prefix}: stored device token is unreadable. Check file permissions, re-pair this PC, or add a shared/bootstrap gateway token.",
+            GatewayCredentialResolutionStatus.Missing => role.Equals("node", StringComparison.OrdinalIgnoreCase)
+                ? MissingNodeCredentialMessage
+                : $"{prefix}. Add a shared/bootstrap gateway token or re-pair this PC.",
             _ when !string.IsNullOrWhiteSpace(resolution.Detail) =>
                 $"{prefix}. {resolution.Detail}",
             _ => role.Equals("node", StringComparison.OrdinalIgnoreCase)

--- a/src/OpenClaw.Connection/GatewayConnectionSnapshot.cs
+++ b/src/OpenClaw.Connection/GatewayConnectionSnapshot.cs
@@ -15,6 +15,10 @@ public sealed record GatewayConnectionSnapshot
     public bool OperatorPairingRequired { get; init; }
     public string? OperatorDeviceId { get; init; }
     public string? OperatorCredentialSource { get; init; }
+    public GatewayCredentialResolutionStatus? OperatorCredentialStatus { get; init; }
+    public bool OperatorCredentialFallbackUsed { get; init; }
+    public bool OperatorCredentialBootstrapRequired { get; init; }
+    public string? OperatorCredentialDetail { get; init; }
     /// <summary>
     /// The requestId returned by the gateway when operator pairing is required.
     /// Used by setup flows to approve the specific pairing request via CLI.
@@ -28,6 +32,10 @@ public sealed record GatewayConnectionSnapshot
     public OpenClaw.Shared.PairingStatus NodePairingStatus { get; init; }
     public string? NodeDeviceId { get; init; }
     public string? NodeCredentialSource { get; init; }
+    public GatewayCredentialResolutionStatus? NodeCredentialStatus { get; init; }
+    public bool NodeCredentialFallbackUsed { get; init; }
+    public bool NodeCredentialBootstrapRequired { get; init; }
+    public string? NodeCredentialDetail { get; init; }
     /// <summary>
     /// The requestId returned by the gateway when node pairing is required.
     /// Used by the connection page to show the correct approval command.

--- a/src/OpenClaw.Connection/GatewayCredentialResolution.cs
+++ b/src/OpenClaw.Connection/GatewayCredentialResolution.cs
@@ -1,0 +1,31 @@
+namespace OpenClaw.Connection;
+
+public enum GatewayCredentialResolutionStatus
+{
+    Resolved,
+    Missing,
+    Unreadable,
+    Corrupt,
+    FallbackUsed,
+    BootstrapRequired
+}
+
+public sealed record GatewayCredentialResolution(
+    GatewayCredential? Credential,
+    GatewayCredentialResolutionStatus Status,
+    bool FallbackUsed = false,
+    bool BootstrapRequired = false,
+    string? Detail = null,
+    GatewayCredentialResolutionStatus? PrimaryStatus = null)
+{
+    public static GatewayCredentialResolution FromLegacy(GatewayCredential? credential) =>
+        credential is null
+            ? new(null, GatewayCredentialResolutionStatus.Missing)
+            : new(
+                credential,
+                credential.IsBootstrapToken
+                    ? GatewayCredentialResolutionStatus.BootstrapRequired
+                    : GatewayCredentialResolutionStatus.Resolved,
+                FallbackUsed: false,
+                BootstrapRequired: credential.IsBootstrapToken);
+}

--- a/src/OpenClaw.Connection/GatewayRegistry.cs
+++ b/src/OpenClaw.Connection/GatewayRegistry.cs
@@ -155,9 +155,9 @@ public sealed class GatewayRegistry
             // Atomic write: unique temp file then rename. Keep the registry lock
             // through the move so concurrent saves cannot publish stale snapshots.
             var tempPath = $"{_filePath}.{Guid.NewGuid():N}.tmp";
-            _fs.WriteAllText(tempPath, json);
             try
             {
+                _fs.WriteAllText(tempPath, json);
                 File.Move(tempPath, _filePath, overwrite: true);
             }
             catch

--- a/src/OpenClaw.Connection/GatewayRegistry.cs
+++ b/src/OpenClaw.Connection/GatewayRegistry.cs
@@ -74,6 +74,7 @@ public sealed class GatewayRegistry
     public GatewayRecord AddOrUpdate(GatewayRecord record)
     {
         List<GatewayRecord> snapshot;
+        string? activeId;
         lock (_lock)
         {
             var idx = _records.FindIndex(r => r.Id == record.Id);
@@ -82,26 +83,35 @@ public sealed class GatewayRegistry
             else
                 _records.Add(record);
             snapshot = _records.ToList();
+            activeId = _activeId;
         }
-        Changed?.Invoke(this, new GatewayRegistryChangedEventArgs(snapshot));
+        Changed?.Invoke(this, new GatewayRegistryChangedEventArgs(snapshot, activeId));
         return record;
     }
 
     public void Remove(string id)
     {
         List<GatewayRecord> snapshot;
+        string? activeId;
         lock (_lock)
         {
             _records.RemoveAll(r => r.Id == id);
             if (_activeId == id) _activeId = null;
             snapshot = _records.ToList();
+            activeId = _activeId;
         }
-        Changed?.Invoke(this, new GatewayRegistryChangedEventArgs(snapshot));
+        Changed?.Invoke(this, new GatewayRegistryChangedEventArgs(snapshot, activeId));
     }
 
-    public void SetActive(string gatewayId)
+    public void SetActive(string? gatewayId)
     {
-        lock (_lock) _activeId = gatewayId;
+        List<GatewayRecord> snapshot;
+        lock (_lock)
+        {
+            _activeId = gatewayId;
+            snapshot = _records.ToList();
+        }
+        Changed?.Invoke(this, new GatewayRegistryChangedEventArgs(snapshot, gatewayId));
     }
 
     /// <summary>
@@ -114,6 +124,7 @@ public sealed class GatewayRegistry
     {
         GatewayRecord? updated;
         List<GatewayRecord> snapshot;
+        string? activeId;
         lock (_lock)
         {
             var idx = _records.FindIndex(r => r.Id == id);
@@ -122,8 +133,9 @@ public sealed class GatewayRegistry
             ArgumentNullException.ThrowIfNull(updated, nameof(updater));
             _records[idx] = updated;
             snapshot = _records.ToList();
+            activeId = _activeId;
         }
-        Changed?.Invoke(this, new GatewayRegistryChangedEventArgs(snapshot));
+        Changed?.Invoke(this, new GatewayRegistryChangedEventArgs(snapshot, activeId));
         return updated;
     }
 
@@ -131,22 +143,42 @@ public sealed class GatewayRegistry
 
     public void Save()
     {
-        RegistryData data;
         lock (_lock)
         {
-            data = new RegistryData { Gateways = _records.ToList(), ActiveId = _activeId };
+            var data = new RegistryData { Gateways = _records.ToList(), ActiveId = _activeId };
+            var json = JsonSerializer.Serialize(data, s_jsonOptions);
+
+            var dir = Path.GetDirectoryName(_filePath);
+            if (dir != null && !_fs.DirectoryExists(dir))
+                _fs.CreateDirectory(dir);
+
+            // Atomic write: unique temp file then rename. Keep the registry lock
+            // through the move so concurrent saves cannot publish stale snapshots.
+            var tempPath = $"{_filePath}.{Guid.NewGuid():N}.tmp";
+            _fs.WriteAllText(tempPath, json);
+            try
+            {
+                File.Move(tempPath, _filePath, overwrite: true);
+            }
+            catch
+            {
+                TryDeleteTempFile(tempPath);
+                throw;
+            }
         }
-        var json = JsonSerializer.Serialize(data, s_jsonOptions);
+    }
 
-        var dir = Path.GetDirectoryName(_filePath);
-        if (dir != null && !_fs.DirectoryExists(dir))
-            _fs.CreateDirectory(dir);
-
-        // Atomic write: temp file then rename
-        var tempPath = _filePath + ".tmp";
-        _fs.WriteAllText(tempPath, json);
-        // On Windows, File.Move with overwrite works as atomic rename
-        File.Move(tempPath, _filePath, overwrite: true);
+    private void TryDeleteTempFile(string tempPath)
+    {
+        try
+        {
+            if (_fs.FileExists(tempPath))
+                _fs.DeleteFile(tempPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.Warn($"Failed to delete temporary gateway registry file '{tempPath}': {ex.Message}");
+        }
     }
 
     public void Load()
@@ -378,8 +410,10 @@ public sealed class GatewayRegistry
 public sealed class GatewayRegistryChangedEventArgs : EventArgs
 {
     public IReadOnlyList<GatewayRecord> Records { get; }
-    public GatewayRegistryChangedEventArgs(IReadOnlyList<GatewayRecord> records)
+    public string? ActiveGatewayId { get; }
+    public GatewayRegistryChangedEventArgs(IReadOnlyList<GatewayRecord> records, string? activeGatewayId = null)
     {
         Records = records;
+        ActiveGatewayId = activeGatewayId;
     }
 }

--- a/src/OpenClaw.Connection/ICredentialResolver.cs
+++ b/src/OpenClaw.Connection/ICredentialResolver.cs
@@ -5,7 +5,13 @@ namespace OpenClaw.Connection;
 /// <summary>
 /// Resolved gateway credential plus metadata about which source was used.
 /// </summary>
-public sealed record GatewayCredential(string Token, bool IsBootstrapToken, string Source);
+public sealed record GatewayCredential(string Token, bool IsBootstrapToken, string Source)
+{
+    public GatewayCredentialResolutionStatus ResolutionStatus { get; init; } =
+        GatewayCredentialResolutionStatus.Resolved;
+    public bool FallbackUsed { get; init; }
+    public string? ResolutionDetail { get; init; }
+}
 
 /// <summary>
 /// Resolves the best activation credential for connecting to a gateway.
@@ -20,8 +26,20 @@ public interface ICredentialResolver
     GatewayCredential? ResolveOperator(GatewayRecord record, string identityPath);
 
     /// <summary>
+    /// Resolve the operator credential and preserve missing/corrupt/fallback status.
+    /// </summary>
+    GatewayCredentialResolution ResolveOperatorDetailed(GatewayRecord record, string identityPath) =>
+        GatewayCredentialResolution.FromLegacy(ResolveOperator(record, identityPath));
+
+    /// <summary>
     /// Resolve the best node activation credential for the given gateway record.
     /// Returns null if no credential is available.
     /// </summary>
     GatewayCredential? ResolveNode(GatewayRecord record, string identityPath);
+
+    /// <summary>
+    /// Resolve the node credential and preserve missing/corrupt/fallback status.
+    /// </summary>
+    GatewayCredentialResolution ResolveNodeDetailed(GatewayRecord record, string identityPath) =>
+        GatewayCredentialResolution.FromLegacy(ResolveNode(record, identityPath));
 }

--- a/src/OpenClaw.Shared/DeviceIdentity.cs
+++ b/src/OpenClaw.Shared/DeviceIdentity.cs
@@ -33,20 +33,32 @@ public class DeviceIdentity
     public IReadOnlyList<string>? NodeDeviceTokenScopes => _nodeDeviceTokenScopes;
 
     public static string? TryReadStoredDeviceToken(string dataPath, IOpenClawLogger? logger = null) =>
-        TryReadStoredDeviceTokenForRole(dataPath, "operator", logger);
+        ReadStoredDeviceToken(dataPath, logger).Token;
 
-    public static string? TryReadStoredDeviceTokenForRole(string dataPath, string role, IOpenClawLogger? logger = null)
+    public static DeviceTokenReadResult ReadStoredDeviceToken(string dataPath, IOpenClawLogger? logger = null) =>
+        ReadStoredDeviceTokenForRole(dataPath, "operator", logger);
+
+    public static string? TryReadStoredDeviceTokenForRole(string dataPath, string role, IOpenClawLogger? logger = null) =>
+        ReadStoredDeviceTokenForRole(dataPath, role, logger).Token;
+
+    public static DeviceTokenReadResult ReadStoredDeviceTokenForRole(string dataPath, string role, IOpenClawLogger? logger = null)
     {
         var tokenRole = ParseDeviceTokenRole(role);
         var keyPath = Path.Combine(dataPath, "device-key-ed25519.json");
         if (!File.Exists(keyPath))
         {
-            return null;
+            return DeviceTokenReadResult.Missing("Identity file is missing.");
         }
 
         try
         {
             using var doc = JsonDocument.Parse(File.ReadAllText(keyPath));
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                logger?.Warn("Failed to read stored device token: device-key-ed25519.json root is not a JSON object.");
+                return DeviceTokenReadResult.Corrupt("Identity file root is not a JSON object.");
+            }
+
             var tokenPropertyName = tokenRole == DeviceTokenRole.Node
                 ? nameof(DeviceKeyData.NodeDeviceToken)
                 : nameof(DeviceKeyData.DeviceToken);
@@ -55,23 +67,33 @@ public class DeviceIdentity
                 deviceToken.ValueKind == JsonValueKind.String)
             {
                 var value = deviceToken.GetString();
-                return string.IsNullOrWhiteSpace(value) ? null : value;
+                return string.IsNullOrWhiteSpace(value)
+                    ? DeviceTokenReadResult.Missing($"No stored {role} device token.")
+                    : DeviceTokenReadResult.Resolved(value!);
             }
+
+            return DeviceTokenReadResult.Missing($"No stored {role} device token.");
         }
         catch (IOException ex)
         {
             logger?.Warn($"Failed to read stored device token: {ex.Message}");
+            return DeviceTokenReadResult.Unreadable(ex.Message);
         }
         catch (UnauthorizedAccessException ex)
         {
             logger?.Warn($"Failed to read stored device token: {ex.Message}");
+            return DeviceTokenReadResult.Unreadable(ex.Message);
         }
         catch (JsonException ex)
         {
             logger?.Warn($"Failed to read stored device token: {ex.Message}");
+            return DeviceTokenReadResult.Corrupt(ex.Message);
         }
-
-        return null;
+        catch (InvalidOperationException ex)
+        {
+            logger?.Warn($"Failed to read stored device token: {ex.Message}");
+            return DeviceTokenReadResult.Corrupt(ex.Message);
+        }
     }
 
     public static bool HasStoredDeviceToken(string dataPath, IOpenClawLogger? logger = null) =>

--- a/src/OpenClaw.Shared/DeviceIdentityFileReader.cs
+++ b/src/OpenClaw.Shared/DeviceIdentityFileReader.cs
@@ -11,6 +11,12 @@ public sealed class DeviceIdentityFileReader : IDeviceIdentityReader
     public string? TryReadStoredDeviceToken(string dataPath) =>
         DeviceIdentity.TryReadStoredDeviceToken(dataPath);
 
+    public DeviceTokenReadResult ReadStoredDeviceToken(string dataPath) =>
+        DeviceIdentity.ReadStoredDeviceToken(dataPath);
+
     public string? TryReadStoredNodeDeviceToken(string dataPath) =>
         DeviceIdentity.TryReadStoredDeviceTokenForRole(dataPath, "node");
+
+    public DeviceTokenReadResult ReadStoredNodeDeviceToken(string dataPath) =>
+        DeviceIdentity.ReadStoredDeviceTokenForRole(dataPath, "node");
 }

--- a/src/OpenClaw.Shared/DeviceTokenReadResult.cs
+++ b/src/OpenClaw.Shared/DeviceTokenReadResult.cs
@@ -1,0 +1,27 @@
+namespace OpenClaw.Shared;
+
+public enum DeviceTokenReadStatus
+{
+    Resolved,
+    Missing,
+    Unreadable,
+    Corrupt
+}
+
+public sealed record DeviceTokenReadResult(
+    string? Token,
+    DeviceTokenReadStatus Status,
+    string? Detail = null)
+{
+    public static DeviceTokenReadResult Resolved(string token) =>
+        new(token, DeviceTokenReadStatus.Resolved);
+
+    public static DeviceTokenReadResult Missing(string? detail = null) =>
+        new(null, DeviceTokenReadStatus.Missing, detail);
+
+    public static DeviceTokenReadResult Unreadable(string detail) =>
+        new(null, DeviceTokenReadStatus.Unreadable, detail);
+
+    public static DeviceTokenReadResult Corrupt(string detail) =>
+        new(null, DeviceTokenReadStatus.Corrupt, detail);
+}

--- a/src/OpenClaw.Shared/IDeviceIdentityReader.cs
+++ b/src/OpenClaw.Shared/IDeviceIdentityReader.cs
@@ -13,8 +13,30 @@ public interface IDeviceIdentityReader
     string? TryReadStoredDeviceToken(string dataPath);
 
     /// <summary>
+    /// Read the stored operator device token and preserve why it was unavailable.
+    /// </summary>
+    DeviceTokenReadResult ReadStoredDeviceToken(string dataPath)
+    {
+        var token = TryReadStoredDeviceToken(dataPath);
+        return string.IsNullOrWhiteSpace(token)
+            ? DeviceTokenReadResult.Missing()
+            : DeviceTokenReadResult.Resolved(token!);
+    }
+
+    /// <summary>
     /// Try to read the stored node device token from the identity file at the given path.
     /// Returns null if no token is stored or the file doesn't exist.
     /// </summary>
     string? TryReadStoredNodeDeviceToken(string dataPath);
+
+    /// <summary>
+    /// Read the stored node device token and preserve why it was unavailable.
+    /// </summary>
+    DeviceTokenReadResult ReadStoredNodeDeviceToken(string dataPath)
+    {
+        var token = TryReadStoredNodeDeviceToken(dataPath);
+        return string.IsNullOrWhiteSpace(token)
+            ? DeviceTokenReadResult.Missing()
+            : DeviceTokenReadResult.Resolved(token!);
+    }
 }

--- a/src/OpenClaw.Shared/IFileSystem.cs
+++ b/src/OpenClaw.Shared/IFileSystem.cs
@@ -11,6 +11,7 @@ public interface IFileSystem
     void CreateDirectory(string path);
     bool DirectoryExists(string path);
     void CopyFile(string source, string destination, bool overwrite);
+    void DeleteFile(string path);
 }
 
 /// <summary>
@@ -28,4 +29,5 @@ public sealed class RealFileSystem : IFileSystem
     public bool DirectoryExists(string path) => Directory.Exists(path);
     public void CopyFile(string source, string destination, bool overwrite) =>
         File.Copy(source, destination, overwrite);
+    public void DeleteFile(string path) => File.Delete(path);
 }

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -3684,6 +3684,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             EffectiveGatewayUrl = activeGateway?.Url ?? _settings?.GatewayUrl,
             EffectiveBrowserControlPort = activeGateway?.BrowserControlPort,
             HasActiveGatewayRecord = activeGateway != null,
+            ActiveGatewayHasSharedToken = !string.IsNullOrWhiteSpace(activeGateway?.SharedGatewayToken),
             ActiveGatewaySshTunnel = activeGateway?.SshTunnel
         };
     }

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPage.xaml.cs
@@ -1502,8 +1502,7 @@ public sealed partial class ConnectionPage : Page
     {
         if (isActive)
         {
-            var credentialLabel = ConnectionPagePlan.FormatCredentialSource(
-                snapshot.OperatorCredentialSource ?? snapshot.NodeCredentialSource);
+            var credentialLabel = ConnectionPagePlan.FormatCredentialSummary(snapshot);
             if (!string.IsNullOrEmpty(credentialLabel))
                 return credentialLabel;
 

--- a/src/OpenClaw.Tray.WinUI/Pages/ConnectionPagePlan.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ConnectionPagePlan.cs
@@ -784,7 +784,7 @@ internal sealed record ConnectionPagePlan
         var url = ConnectionCardPlanSanitizer.SanitizeGatewayUrl(rec?.Url);
         if (!string.IsNullOrEmpty(url)) bits.Add(url);
         if (rec?.SshTunnel != null) bits.Add("via SSH tunnel");
-        var credential = FormatCredentialSource(snap.OperatorCredentialSource ?? snap.NodeCredentialSource);
+        var credential = FormatCredentialSummary(snap);
         if (!string.IsNullOrEmpty(credential)) bits.Add(credential);
         if (!string.IsNullOrWhiteSpace(self?.ServerVersion)) bits.Add($"v{self!.ServerVersion}");
         if (self?.UptimeMs is long uptime && uptime > 0)
@@ -802,6 +802,25 @@ internal sealed record ConnectionPagePlan
             CredentialResolver.SourceBootstrapToken => "bootstrap token",
             _ => "",
         };
+    }
+
+    internal static string FormatCredentialSummary(GatewayConnectionSnapshot snap)
+    {
+        var useOperator = !string.IsNullOrEmpty(snap.OperatorCredentialSource);
+        var source = useOperator ? snap.OperatorCredentialSource : snap.NodeCredentialSource;
+        var label = FormatCredentialSource(source);
+        if (string.IsNullOrEmpty(label))
+            return "";
+
+        var status = useOperator ? snap.OperatorCredentialStatus : snap.NodeCredentialStatus;
+        var fallbackUsed = useOperator ? snap.OperatorCredentialFallbackUsed : snap.NodeCredentialFallbackUsed;
+        if (fallbackUsed || status == GatewayCredentialResolutionStatus.FallbackUsed)
+            return $"{label} (fallback)";
+        if (status == GatewayCredentialResolutionStatus.BootstrapRequired ||
+            (useOperator ? snap.OperatorCredentialBootstrapRequired : snap.NodeCredentialBootstrapRequired))
+            return $"{label} (pairing required)";
+
+        return label;
     }
 
     private static int CountEnabledCapabilities(SettingsManager s)

--- a/src/OpenClaw.Tray.WinUI/Services/AppStateSnapshot.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/AppStateSnapshot.cs
@@ -37,6 +37,7 @@ internal sealed record AppStateSnapshot
     /// <summary>True when a GatewayRecord is currently active. Distinguishes "active gateway
     /// has no tunnel" from "no active gateway (fall back to global settings)".</summary>
     public bool HasActiveGatewayRecord          { get; init; }
+    public bool ActiveGatewayHasSharedToken     { get; init; }
 
     /// <summary>SSH tunnel config from the active GatewayRecord. Null means this gateway is
     /// direct (no tunnel), NOT "unknown". Only meaningful when HasActiveGatewayRecord is true.</summary>

--- a/src/OpenClaw.Tray.WinUI/Services/CommandCenterBrowserProxyAuthWarningPolicy.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/CommandCenterBrowserProxyAuthWarningPolicy.cs
@@ -1,0 +1,23 @@
+using OpenClaw.Shared;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenClawTray.Services;
+
+internal static class CommandCenterBrowserProxyAuthWarningPolicy
+{
+    internal static bool ShouldShow(
+        bool nodeBrowserProxyEnabled,
+        bool activeGatewayHasSharedToken,
+        IReadOnlyList<NodeCapabilityHealthInfo> nodes)
+    {
+        if (!nodeBrowserProxyEnabled || activeGatewayHasSharedToken)
+            return false;
+
+        return nodes.Any(node =>
+            node.BrowserApprovedCommands.Contains("browser.proxy", StringComparer.OrdinalIgnoreCase) ||
+            node.UnverifiedDeclaredCommands.Contains("browser.proxy", StringComparer.OrdinalIgnoreCase) ||
+            node.LocalDeclaredCommands.Contains("browser.proxy", StringComparer.OrdinalIgnoreCase));
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/CommandCenterStateBuilder.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/CommandCenterStateBuilder.cs
@@ -272,11 +272,10 @@ internal sealed class CommandCenterStateBuilder
 
     private IEnumerable<GatewayDiagnosticWarning> BuildBrowserProxyAuthWarnings(IReadOnlyList<NodeCapabilityHealthInfo> nodes)
     {
-        if (_snapshot.Settings?.NodeBrowserProxyEnabled == false ||
-            !nodes.Any(node =>
-                node.BrowserApprovedCommands.Contains("browser.proxy", StringComparer.OrdinalIgnoreCase) ||
-                node.UnverifiedDeclaredCommands.Contains("browser.proxy", StringComparer.OrdinalIgnoreCase) ||
-                node.LocalDeclaredCommands.Contains("browser.proxy", StringComparer.OrdinalIgnoreCase)))
+        if (!CommandCenterBrowserProxyAuthWarningPolicy.ShouldShow(
+                _snapshot.Settings?.NodeBrowserProxyEnabled != false,
+                _snapshot.ActiveGatewayHasSharedToken,
+                nodes))
         {
             yield break;
         }

--- a/tests/OpenClaw.Connection.Tests/CredentialResolverTests.cs
+++ b/tests/OpenClaw.Connection.Tests/CredentialResolverTests.cs
@@ -56,6 +56,28 @@ public class CredentialResolverTests
     }
 
     [Fact]
+    public void ResolveOperatorDetailed_SharedTokenOnly_IsResolvedNotFallback()
+    {
+        var record = new GatewayRecord
+        {
+            Id = "gw-1",
+            Url = "wss://test",
+            SharedGatewayToken = "shared",
+            BootstrapToken = "boot"
+        };
+        _mockReader.OperatorToken = null;
+
+        var result = _resolver.ResolveOperatorDetailed(record, "/id");
+
+        Assert.NotNull(result.Credential);
+        Assert.Equal("shared", result.Credential!.Token);
+        Assert.Equal(CredentialResolver.SourceSharedGatewayToken, result.Credential.Source);
+        Assert.Equal(GatewayCredentialResolutionStatus.Resolved, result.Status);
+        Assert.False(result.FallbackUsed);
+        Assert.False(result.Credential.FallbackUsed);
+    }
+
+    [Fact]
     public void ResolveOperator_FallsToBootstrap_WhenNoDeviceOrShared()
     {
         var record = new GatewayRecord
@@ -83,6 +105,129 @@ public class CredentialResolverTests
         var result = _resolver.ResolveOperator(record, "/id");
 
         Assert.Null(result);
+    }
+
+    [Fact]
+    public void ResolveOperatorDetailed_ReturnsMissing_WhenNoCredentials()
+    {
+        var record = new GatewayRecord { Id = "gw-1", Url = "wss://test" };
+        _mockReader.OperatorToken = null;
+
+        var result = _resolver.ResolveOperatorDetailed(record, "/id");
+
+        Assert.Null(result.Credential);
+        Assert.Equal(GatewayCredentialResolutionStatus.Missing, result.Status);
+    }
+
+    [Fact]
+    public void ResolveOperatorDetailed_ReturnsCorrupt_WhenStoredTokenFileIsInvalidAndNoFallbackExists()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "openclaw-corrupt-token-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "device-key-ed25519.json"), "{ broken json");
+            var resolver = new CredentialResolver(DeviceIdentityFileReader.Instance);
+            var record = new GatewayRecord { Id = "gw-1", Url = "wss://test" };
+
+            var result = resolver.ResolveOperatorDetailed(record, tempDir);
+
+            Assert.Null(result.Credential);
+            Assert.Equal(GatewayCredentialResolutionStatus.Corrupt, result.Status);
+            Assert.Contains("corrupt", result.Detail, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("null")]
+    public void ResolveOperatorDetailed_ReturnsCorrupt_WhenStoredTokenFileHasWrongJsonShape(string json)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "openclaw-wrong-shape-token-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "device-key-ed25519.json"), json);
+            var resolver = new CredentialResolver(DeviceIdentityFileReader.Instance);
+            var record = new GatewayRecord { Id = "gw-1", Url = "wss://test" };
+
+            var result = resolver.ResolveOperatorDetailed(record, tempDir);
+
+            Assert.Null(result.Credential);
+            Assert.Equal(GatewayCredentialResolutionStatus.Corrupt, result.Status);
+            Assert.Contains("not a JSON object", result.Detail, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveOperatorDetailed_FallsBack_WhenStoredTokenFileHasWrongJsonShapeAndSharedTokenExists()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "openclaw-wrong-shape-fallback-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "device-key-ed25519.json"), "[]");
+            var resolver = new CredentialResolver(DeviceIdentityFileReader.Instance);
+            var record = new GatewayRecord
+            {
+                Id = "gw-1",
+                Url = "wss://test",
+                SharedGatewayToken = "shared"
+            };
+
+            var result = resolver.ResolveOperatorDetailed(record, tempDir);
+
+            Assert.NotNull(result.Credential);
+            Assert.Equal("shared", result.Credential!.Token);
+            Assert.Equal(GatewayCredentialResolutionStatus.FallbackUsed, result.Status);
+            Assert.Equal(GatewayCredentialResolutionStatus.Corrupt, result.PrimaryStatus);
+            Assert.True(result.FallbackUsed);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveOperatorDetailed_ReportsFallbackUsed_WhenStoredTokenIsCorruptAndSharedTokenExists()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "openclaw-fallback-token-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "device-key-ed25519.json"), "{ broken json");
+            var resolver = new CredentialResolver(DeviceIdentityFileReader.Instance);
+            var record = new GatewayRecord
+            {
+                Id = "gw-1",
+                Url = "wss://test",
+                SharedGatewayToken = "shared"
+            };
+
+            var result = resolver.ResolveOperatorDetailed(record, tempDir);
+
+            Assert.NotNull(result.Credential);
+            Assert.Equal("shared", result.Credential!.Token);
+            Assert.Equal(CredentialResolver.SourceSharedGatewayToken, result.Credential.Source);
+            Assert.Equal(GatewayCredentialResolutionStatus.FallbackUsed, result.Status);
+            Assert.Equal(GatewayCredentialResolutionStatus.Corrupt, result.PrimaryStatus);
+            Assert.True(result.FallbackUsed);
+            Assert.True(result.Credential.FallbackUsed);
+            Assert.Contains("corrupt", result.Detail, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]
@@ -160,6 +305,26 @@ public class CredentialResolverTests
         Assert.NotNull(result);
         Assert.Equal("boot", result.Token);
         Assert.True(result.IsBootstrapToken);
+    }
+
+    [Fact]
+    public void ResolveNodeDetailed_ReportsBootstrapRequired_WhenBootstrapTokenIsUsed()
+    {
+        var record = new GatewayRecord
+        {
+            Id = "gw-1",
+            Url = "wss://test",
+            BootstrapToken = "boot"
+        };
+        _mockReader.NodeToken = null;
+
+        var result = _resolver.ResolveNodeDetailed(record, "/id");
+
+        Assert.NotNull(result.Credential);
+        Assert.Equal("boot", result.Credential!.Token);
+        Assert.True(result.Credential.IsBootstrapToken);
+        Assert.Equal(GatewayCredentialResolutionStatus.BootstrapRequired, result.Status);
+        Assert.True(result.BootstrapRequired);
     }
 
     [Fact]

--- a/tests/OpenClaw.Connection.Tests/CredentialResolverTests.cs
+++ b/tests/OpenClaw.Connection.Tests/CredentialResolverTests.cs
@@ -231,6 +231,34 @@ public class CredentialResolverTests
     }
 
     [Fact]
+    public void ResolveOperatorDetailed_ReportsFallbackUsed_WhenStoredTokenIsUnreadableAndSharedTokenExists()
+    {
+        var reader = new MockDeviceIdentityReader
+        {
+            OperatorReadResult = DeviceTokenReadResult.Unreadable("access denied")
+        };
+        var resolver = new CredentialResolver(reader);
+        var record = new GatewayRecord
+        {
+            Id = "gw-1",
+            Url = "wss://test",
+            SharedGatewayToken = "shared"
+        };
+
+        var result = resolver.ResolveOperatorDetailed(record, "/id");
+
+        Assert.NotNull(result.Credential);
+        Assert.Equal("shared", result.Credential!.Token);
+        Assert.Equal(CredentialResolver.SourceSharedGatewayToken, result.Credential.Source);
+        Assert.Equal(GatewayCredentialResolutionStatus.FallbackUsed, result.Status);
+        Assert.Equal(GatewayCredentialResolutionStatus.Unreadable, result.PrimaryStatus);
+        Assert.True(result.FallbackUsed);
+        Assert.True(result.Credential.FallbackUsed);
+        Assert.Contains("unreadable", result.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("access denied", result.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void ResolveOperator_NeverDowngradesPairedDevice()
     {
         // Even if bootstrap is present, paired device token wins
@@ -393,8 +421,22 @@ public class CredentialResolverTests
     {
         public string? OperatorToken { get; set; }
         public string? NodeToken { get; set; }
+        public DeviceTokenReadResult? OperatorReadResult { get; set; }
+        public DeviceTokenReadResult? NodeReadResult { get; set; }
 
         public string? TryReadStoredDeviceToken(string dataPath) => OperatorToken;
         public string? TryReadStoredNodeDeviceToken(string dataPath) => NodeToken;
+        public DeviceTokenReadResult ReadStoredDeviceToken(string dataPath) =>
+            OperatorReadResult ?? IDeviceIdentityReaderExtensions.FromToken(OperatorToken);
+        public DeviceTokenReadResult ReadStoredNodeDeviceToken(string dataPath) =>
+            NodeReadResult ?? IDeviceIdentityReaderExtensions.FromToken(NodeToken);
+    }
+
+    private static class IDeviceIdentityReaderExtensions
+    {
+        public static DeviceTokenReadResult FromToken(string? token) =>
+            string.IsNullOrWhiteSpace(token)
+                ? DeviceTokenReadResult.Missing()
+                : DeviceTokenReadResult.Resolved(token!);
     }
 }

--- a/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
+++ b/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
@@ -169,6 +169,252 @@ public class GatewayConnectionManagerTests : IDisposable
     }
 
     [Fact]
+    public async Task SwitchGatewayAsync_PersistsActiveGatewayIdAfterReload()
+    {
+        SetupGateway("gw-1", "wss://test1");
+        SetupGateway("gw-2", "wss://test2");
+        _resolver.OperatorCredential = new GatewayCredential("tok", false, "test");
+
+        await _manager.ConnectAsync("gw-1");
+        await _manager.SwitchGatewayAsync("gw-2");
+
+        var reloaded = new GatewayRegistry(_tempDir);
+        reloaded.Load();
+
+        Assert.Equal("gw-2", reloaded.ActiveGatewayId);
+        Assert.Equal("gw-2", reloaded.GetActive()?.Id);
+    }
+
+    [Fact]
+    public async Task SwitchGatewayAsync_UnknownGateway_DoesNotPersistInvalidActiveId()
+    {
+        SetupGateway("gw-1", "wss://test1");
+        _registry.Save();
+        _resolver.OperatorCredential = new GatewayCredential("tok", false, "test");
+
+        await _manager.SwitchGatewayAsync("missing-gateway");
+
+        Assert.Equal("gw-1", _registry.ActiveGatewayId);
+        var reloaded = new GatewayRegistry(_tempDir);
+        reloaded.Load();
+        Assert.Equal("gw-1", reloaded.ActiveGatewayId);
+        Assert.Empty(_factory.CreatedClients);
+    }
+
+    [Fact]
+    public async Task SwitchGatewayAsync_SaveFailureWithNoPreviousActive_ClearsInMemoryActiveId()
+    {
+        var fs = new ThrowingWriteFileSystem();
+        var registry = new GatewayRegistry(_tempDir, fs);
+        registry.AddOrUpdate(new GatewayRecord { Id = "gw-1", Url = "wss://test1" });
+        var resolver = new MockCredentialResolver
+        {
+            OperatorCredential = new GatewayCredential("tok", false, "test")
+        };
+        var factory = new MockClientFactory();
+        using var manager = new GatewayConnectionManager(
+            resolver,
+            factory,
+            registry,
+            NullLogger.Instance);
+
+        await manager.SwitchGatewayAsync("gw-1");
+
+        Assert.Null(registry.ActiveGatewayId);
+        Assert.Empty(factory.CreatedClients);
+    }
+
+    [Fact]
+    public async Task SwitchGatewayAsync_SaveFailureWithPreviousActive_PreservesActiveGatewayAndLiveClient()
+    {
+        var fs = new ThrowingWriteFileSystem();
+        var registry = new GatewayRegistry(_tempDir, fs);
+        registry.AddOrUpdate(new GatewayRecord { Id = "gw-1", Url = "wss://test1" });
+        registry.AddOrUpdate(new GatewayRecord { Id = "gw-2", Url = "wss://test2" });
+        registry.SetActive("gw-1");
+        var resolver = new MockCredentialResolver
+        {
+            OperatorCredential = new GatewayCredential("tok", false, "test")
+        };
+        var factory = new MockClientFactory();
+        using var manager = new GatewayConnectionManager(
+            resolver,
+            factory,
+            registry,
+            NullLogger.Instance);
+        await manager.ConnectAsync("gw-1");
+        var activeLifecycle = Assert.Single(factory.CreatedClients);
+
+        await manager.SwitchGatewayAsync("gw-2");
+
+        Assert.Equal("gw-1", registry.ActiveGatewayId);
+        Assert.Same(activeLifecycle.DataClient, manager.OperatorClient);
+        Assert.False(activeLifecycle.IsDisposed);
+        Assert.Single(factory.CreatedClients);
+    }
+
+    [Fact]
+    public async Task ApplySetupCodeAsync_SaveFailure_PreservesActiveGatewayAndLiveClient()
+    {
+        var fs = new ThrowingWriteFileSystem();
+        var registry = new GatewayRegistry(_tempDir, fs);
+        registry.AddOrUpdate(new GatewayRecord { Id = "gw-1", Url = "wss://test1" });
+        registry.SetActive("gw-1");
+        var resolver = new MockCredentialResolver
+        {
+            OperatorCredential = new GatewayCredential("tok", false, "test")
+        };
+        var factory = new MockClientFactory();
+        using var manager = new GatewayConnectionManager(
+            resolver,
+            factory,
+            registry,
+            NullLogger.Instance);
+        await manager.ConnectAsync("gw-1");
+        var activeLifecycle = Assert.Single(factory.CreatedClients);
+        var setupCode = BuildSetupCode("wss://test2", "bootstrap-token");
+
+        var result = await manager.ApplySetupCodeAsync(setupCode);
+
+        Assert.Equal(SetupCodeOutcome.ConnectionFailed, result.Outcome);
+        Assert.Equal("gw-1", registry.ActiveGatewayId);
+        Assert.Same(activeLifecycle.DataClient, manager.OperatorClient);
+        Assert.False(activeLifecycle.IsDisposed);
+        Assert.Single(factory.CreatedClients);
+        Assert.Null(registry.FindByUrl("wss://test2"));
+    }
+
+    [Fact]
+    public async Task StaleOldGatewayHandshakeAfterSwitch_DoesNotMutateCurrentSnapshot()
+    {
+        SetupGateway("gw-1", "wss://test1");
+        SetupGateway("gw-2", "wss://test2");
+        _resolver.OperatorCredential = new GatewayCredential("tok", false, "test");
+
+        await _manager.ConnectAsync("gw-1");
+        var oldGatewayLifecycle = _factory.CreatedClients[0];
+        await _manager.SwitchGatewayAsync("gw-2");
+
+        oldGatewayLifecycle.SimulateHandshake();
+        // slopwatch-ignore: SW004 Bounded wait gives a wrongly accepted stale async event time to mutate state.
+        await Task.Delay(50);
+
+        Assert.Equal("gw-2", _manager.CurrentSnapshot.GatewayId);
+        Assert.Equal("wss://test2", _manager.CurrentSnapshot.GatewayUrl);
+        Assert.Equal(RoleConnectionState.Connecting, _manager.CurrentSnapshot.OperatorState);
+        Assert.Null(_registry.GetById("gw-1")?.LastConnected);
+    }
+
+    [Fact]
+    public async Task StaleOldGatewayDeviceTokenAfterSwitch_DoesNotPersistToCurrentIdentity()
+    {
+        var capturedTokens = new List<(string path, string token, string role)>();
+        var store = new CaptureIdentityStore(capturedTokens);
+        using var manager = new GatewayConnectionManager(
+            _resolver, _factory, _registry, NullLogger.Instance,
+            identityStore: store);
+        SetupGateway("gw-1", "wss://test1");
+        SetupGateway("gw-2", "wss://test2");
+        _resolver.OperatorCredential = new GatewayCredential("tok", false, "test");
+
+        await manager.ConnectAsync("gw-1");
+        var oldGatewayLifecycle = _factory.CreatedClients[0];
+        await manager.SwitchGatewayAsync("gw-2");
+
+        oldGatewayLifecycle.SimulateDeviceTokenReceived("old-gateway-token", "operator");
+        // slopwatch-ignore: SW004 Bounded wait gives a wrongly accepted stale async event time to persist credentials.
+        await Task.Delay(50);
+
+        Assert.DoesNotContain(capturedTokens, token => token.token == "old-gateway-token");
+        Assert.Equal("gw-2", manager.CurrentSnapshot.GatewayId);
+    }
+
+    [Fact]
+    public async Task StaleOldGatewayV2FallbackAfterSwitch_DoesNotMarkCurrentGatewayAsV2Required()
+    {
+        SetupGateway("gw-1", "wss://test1");
+        SetupGateway("gw-2", "wss://test2");
+        _resolver.OperatorCredential = new GatewayCredential("tok", false, "test");
+
+        await _manager.ConnectAsync("gw-1");
+        var oldGatewayLifecycle = _factory.CreatedClients[0];
+        await _manager.SwitchGatewayAsync("gw-2");
+
+        oldGatewayLifecycle.SimulateV2SignatureFallback();
+        await WaitUntilAsync(() => _registry.GetById("gw-1")?.RequiresV2Signature == true);
+
+        Assert.False(_registry.GetById("gw-2")?.RequiresV2Signature);
+        Assert.False(_factory.CreatedClients[1].DataClient.UseV2Signature);
+    }
+
+    [Fact]
+    public async Task ConnectWithSharedTokenAsync_RevalidatesDurableTokensUnderTransitionSemaphore()
+    {
+        _registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "gw-1",
+            Url = "ws://127.0.0.1:9",
+            SshTunnel = new SshTunnelConfig("user", "host.example", 18789, 45678)
+        });
+        _registry.SetActive("gw-1");
+        _resolver.OperatorCredential = new GatewayCredential("tok", false, "test");
+        var tunnel = new BlockingTunnelManager();
+        using var manager = new GatewayConnectionManager(
+            _resolver,
+            _factory,
+            _registry,
+            NullLogger.Instance,
+            tunnelManager: tunnel);
+        var connectTask = manager.ConnectAsync("gw-1");
+        await tunnel.Started.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var replaceTask = manager.ConnectWithSharedTokenAsync("ws://127.0.0.1:9", "bad-shared-token");
+        var identityDir = _registry.GetIdentityDirectory("gw-1");
+        var identity = new DeviceIdentity(identityDir, NullLogger.Instance);
+        identity.Initialize();
+        identity.StoreDeviceTokenForRole("operator", "operator-token");
+        tunnel.AllowStart.SetResult(true);
+        await connectTask.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var result = await replaceTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(SetupCodeOutcome.ConnectionFailed, result.Outcome);
+        Assert.Null(_registry.GetById("gw-1")?.SharedGatewayToken);
+        Assert.Equal("operator-token", DeviceIdentity.TryReadStoredDeviceToken(identityDir));
+    }
+
+    [Fact]
+    public async Task ConnectAsync_CorruptDeviceTokenWithSharedFallback_IsVisibleInSnapshot()
+    {
+        _registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "gw-1",
+            Url = "wss://test",
+            SharedGatewayToken = "shared-token"
+        });
+        _registry.SetActive("gw-1");
+        var identityDir = _registry.GetIdentityDirectory("gw-1");
+        Directory.CreateDirectory(identityDir);
+        File.WriteAllText(Path.Combine(identityDir, "device-key-ed25519.json"), "{ broken json");
+        var resolver = new CredentialResolver(DeviceIdentityFileReader.Instance);
+        var factory = new MockClientFactory();
+        using var manager = new GatewayConnectionManager(
+            resolver,
+            factory,
+            _registry,
+            NullLogger.Instance);
+
+        await manager.ConnectAsync("gw-1");
+
+        Assert.Single(factory.CreatedCredentials);
+        Assert.Equal("shared-token", factory.CreatedCredentials[0].Token);
+        Assert.Equal(CredentialResolver.SourceSharedGatewayToken, manager.CurrentSnapshot.OperatorCredentialSource);
+        Assert.Equal(GatewayCredentialResolutionStatus.FallbackUsed, manager.CurrentSnapshot.OperatorCredentialStatus);
+        Assert.True(manager.CurrentSnapshot.OperatorCredentialFallbackUsed);
+        Assert.Contains("corrupt", manager.CurrentSnapshot.OperatorCredentialDetail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task StateChanged_Fires_OnConnect()
     {
         SetupGateway("gw-1", "wss://test");
@@ -794,6 +1040,19 @@ public class GatewayConnectionManagerTests : IDisposable
         }
     }
 
+    private static string BuildSetupCode(string url, string bootstrapToken)
+    {
+        var json = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            url,
+            bootstrapToken
+        });
+        return Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(json))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
     // ─── EnsureNodeConnectedAsync tests ───
 
     [Fact]
@@ -937,13 +1196,23 @@ public class GatewayConnectionManagerTests : IDisposable
         Assert.True(manager.CurrentSnapshot.NodeConnectionIntended);
         Assert.Equal(OverallConnectionState.Degraded, manager.CurrentSnapshot.OverallState);
         Assert.Contains("no active gateway context", manager.CurrentSnapshot.NodeError, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(manager.CurrentSnapshot.NodeCredentialStatus);
     }
 
     [Fact]
     public async Task ConnectNodeOnlyAsync_PreservesConnectedOperatorForNodeListRefresh()
     {
         SetupGateway("gw-1", "wss://test");
-        _resolver.OperatorCredential = new GatewayCredential("operator-token", false, CredentialResolver.SourceSharedGatewayToken);
+        _resolver.OperatorResolution = new GatewayCredentialResolution(
+            new GatewayCredential("operator-token", false, CredentialResolver.SourceSharedGatewayToken)
+            {
+                ResolutionStatus = GatewayCredentialResolutionStatus.FallbackUsed,
+                FallbackUsed = true,
+                ResolutionDetail = "operator fallback"
+            },
+            GatewayCredentialResolutionStatus.FallbackUsed,
+            FallbackUsed: true,
+            Detail: "operator fallback");
         _resolver.NodeCredential = new GatewayCredential("node-token", false, CredentialResolver.SourceNodeDeviceToken);
         var node = new CountingNodeConnector();
         using var manager = new GatewayConnectionManager(
@@ -955,6 +1224,8 @@ public class GatewayConnectionManagerTests : IDisposable
 
         await manager.ConnectAsync("gw-1");
         Assert.Equal(CredentialResolver.SourceSharedGatewayToken, manager.CurrentSnapshot.OperatorCredentialSource);
+        Assert.Equal(GatewayCredentialResolutionStatus.FallbackUsed, manager.CurrentSnapshot.OperatorCredentialStatus);
+        Assert.True(manager.CurrentSnapshot.OperatorCredentialFallbackUsed);
         await InvokeHandshakeSucceededAsync(manager);
         Assert.Equal(CredentialResolver.SourceSharedGatewayToken, manager.CurrentSnapshot.OperatorCredentialSource);
         var operatorLifecycle = Assert.Single(_factory.CreatedClients);
@@ -967,6 +1238,8 @@ public class GatewayConnectionManagerTests : IDisposable
         Assert.Single(_factory.CreatedClients);
         Assert.Equal(1, node.ConnectCount);
         Assert.Equal(CredentialResolver.SourceSharedGatewayToken, manager.CurrentSnapshot.OperatorCredentialSource);
+        Assert.Equal(GatewayCredentialResolutionStatus.FallbackUsed, manager.CurrentSnapshot.OperatorCredentialStatus);
+        Assert.True(manager.CurrentSnapshot.OperatorCredentialFallbackUsed);
         Assert.Equal(CredentialResolver.SourceNodeDeviceToken, manager.CurrentSnapshot.NodeCredentialSource);
     }
 
@@ -1114,8 +1387,47 @@ public class GatewayConnectionManagerTests : IDisposable
         Assert.True(manager.CurrentSnapshot.NodeConnectionIntended);
         Assert.Equal(OverallConnectionState.Error, manager.CurrentSnapshot.OverallState);
         Assert.Contains("SSH tunnel", manager.CurrentSnapshot.NodeError, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(manager.CurrentSnapshot.NodeCredentialSource);
+        Assert.Equal(GatewayCredentialResolutionStatus.Resolved, manager.CurrentSnapshot.NodeCredentialStatus);
+        Assert.False(manager.CurrentSnapshot.NodeCredentialFallbackUsed);
+        Assert.False(manager.CurrentSnapshot.NodeCredentialBootstrapRequired);
         Assert.Contains(snapshots, snapshot => snapshot.NodeState == RoleConnectionState.Error);
         Assert.NotEqual(RoleConnectionState.Connecting, snapshots.Last().NodeState);
+    }
+
+    [Fact]
+    public async Task ConnectNodeOnlyAsync_TunnelStartFailure_PreservesFallbackCredentialFlags()
+    {
+        _registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "gw-ssh",
+            Url = "wss://remote.example",
+            SharedGatewayToken = "shared-token",
+            SshTunnel = new SshTunnelConfig("user", "host.example", 18789, 45678)
+        });
+        _registry.SetActive("gw-ssh");
+        var identityDir = _registry.GetIdentityDirectory("gw-ssh");
+        Directory.CreateDirectory(identityDir);
+        File.WriteAllText(Path.Combine(identityDir, "device-key-ed25519.json"), "{ broken json");
+        var resolver = new CredentialResolver(DeviceIdentityFileReader.Instance);
+        var node = new CountingNodeConnector();
+        var tunnel = new FailingTunnelManager();
+        using var manager = new GatewayConnectionManager(
+            resolver,
+            _factory,
+            _registry,
+            NullLogger.Instance,
+            nodeConnector: node,
+            tunnelManager: tunnel);
+
+        await manager.ConnectNodeOnlyAsync("gw-ssh");
+
+        Assert.Equal(0, node.ConnectCount);
+        Assert.Equal(RoleConnectionState.Error, manager.CurrentSnapshot.NodeState);
+        Assert.Null(manager.CurrentSnapshot.NodeCredentialSource);
+        Assert.Equal(GatewayCredentialResolutionStatus.FallbackUsed, manager.CurrentSnapshot.NodeCredentialStatus);
+        Assert.True(manager.CurrentSnapshot.NodeCredentialFallbackUsed);
+        Assert.False(manager.CurrentSnapshot.NodeCredentialBootstrapRequired);
     }
 
     [Fact]
@@ -1272,9 +1584,15 @@ public class GatewayConnectionManagerTests : IDisposable
     {
         public GatewayCredential? OperatorCredential { get; set; }
         public GatewayCredential? NodeCredential { get; set; }
+        public GatewayCredentialResolution? OperatorResolution { get; set; }
+        public GatewayCredentialResolution? NodeResolution { get; set; }
 
         public GatewayCredential? ResolveOperator(GatewayRecord record, string identityPath) => OperatorCredential;
         public GatewayCredential? ResolveNode(GatewayRecord record, string identityPath) => NodeCredential;
+        public GatewayCredentialResolution ResolveOperatorDetailed(GatewayRecord record, string identityPath) =>
+            OperatorResolution ?? GatewayCredentialResolution.FromLegacy(OperatorCredential);
+        public GatewayCredentialResolution ResolveNodeDetailed(GatewayRecord record, string identityPath) =>
+            NodeResolution ?? GatewayCredentialResolution.FromLegacy(NodeCredential);
     }
 
     private sealed class MockClientFactory : IGatewayClientFactory
@@ -1293,6 +1611,19 @@ public class GatewayConnectionManagerTests : IDisposable
             CreatedGatewayUrls.Add(gatewayUrl);
             return mock;
         }
+    }
+
+    private sealed class ThrowingWriteFileSystem : IFileSystem
+    {
+        public bool FileExists(string path) => File.Exists(path);
+        public string ReadAllText(string path) => File.ReadAllText(path);
+        public void WriteAllText(string path, string content) =>
+            throw new IOException("simulated save failure");
+        public void CreateDirectory(string path) => Directory.CreateDirectory(path);
+        public bool DirectoryExists(string path) => Directory.Exists(path);
+        public void CopyFile(string source, string destination, bool overwrite) =>
+            File.Copy(source, destination, overwrite);
+        public void DeleteFile(string path) => File.Delete(path);
     }
 
     internal sealed class MockLifecycle : IGatewayClientLifecycle
@@ -1792,6 +2123,24 @@ public class GatewayConnectionManagerTests : IDisposable
             return Task.CompletedTask;
         }
 
+        public void Dispose() { }
+    }
+
+    private sealed class BlockingTunnelManager : ISshTunnelManager
+    {
+        public TaskCompletionSource<bool> Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource<bool> AllowStart { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public bool IsActive => false;
+        public string? LocalTunnelUrl => null;
+
+        public async Task<string> StartAsync(SshTunnelConfig config, CancellationToken ct)
+        {
+            Started.SetResult(true);
+            await AllowStart.Task.WaitAsync(ct);
+            return $"ws://localhost:{config.LocalPort}";
+        }
+
+        public Task StopAsync() => Task.CompletedTask;
         public void Dispose() { }
     }
 

--- a/tests/OpenClaw.Connection.Tests/GatewayRegistryTests.cs
+++ b/tests/OpenClaw.Connection.Tests/GatewayRegistryTests.cs
@@ -79,6 +79,21 @@ public class GatewayRegistryTests : IDisposable
     }
 
     [Fact]
+    public void SetActive_FiresChangedWithActiveGatewayId()
+    {
+        _registry.AddOrUpdate(MakeRecord("gw-1", "wss://test1"));
+        _registry.AddOrUpdate(MakeRecord("gw-2", "wss://test2"));
+        GatewayRegistryChangedEventArgs? args = null;
+        _registry.Changed += (_, e) => args = e;
+
+        _registry.SetActive("gw-2");
+
+        Assert.NotNull(args);
+        Assert.Equal("gw-2", args!.ActiveGatewayId);
+        Assert.Equal(2, args.Records.Count);
+    }
+
+    [Fact]
     public void SaveAndLoad_RoundTrips()
     {
         var r1 = MakeRecord("gw-1", "wss://test1") with { FriendlyName = "Home" };
@@ -95,6 +110,22 @@ public class GatewayRegistryTests : IDisposable
         Assert.Equal("Home", registry2.GetById("gw-1")!.FriendlyName);
         Assert.Equal("tok-123", registry2.GetById("gw-2")!.SharedGatewayToken);
         Assert.Equal("gw-1", registry2.GetActive()!.Id);
+    }
+
+    [Fact]
+    public void Save_WhenMoveFails_RemovesTempFile()
+    {
+        var registryPath = Path.Combine(_tempDir, "gateways.json");
+        File.WriteAllText(registryPath, "{}");
+        using var lockFile = new FileStream(registryPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        _registry.AddOrUpdate(MakeRecord("gw-1", "wss://test1"));
+
+        var ex = Assert.ThrowsAny<Exception>(() => _registry.Save());
+
+        Assert.True(
+            ex is IOException or UnauthorizedAccessException,
+            $"Expected an IO/access failure, got {ex.GetType().FullName}: {ex.Message}");
+        Assert.Empty(Directory.GetFiles(_tempDir, "gateways.json.*.tmp"));
     }
 
     [Fact]
@@ -195,13 +226,16 @@ public class GatewayRegistryTests : IDisposable
     [Fact]
     public void Changed_FiresOnAddOrUpdate()
     {
+        _registry.AddOrUpdate(MakeRecord("active", "wss://active"));
+        _registry.SetActive("active");
         GatewayRegistryChangedEventArgs? args = null;
         _registry.Changed += (s, e) => args = e;
 
         _registry.AddOrUpdate(MakeRecord("gw-1", "wss://test1"));
 
         Assert.NotNull(args);
-        Assert.Single(args.Records);
+        Assert.Equal("active", args!.ActiveGatewayId);
+        Assert.Equal(2, args.Records.Count);
     }
 
     [Fact]

--- a/tests/OpenClaw.Connection.Tests/GatewayRegistryTests.cs
+++ b/tests/OpenClaw.Connection.Tests/GatewayRegistryTests.cs
@@ -129,6 +129,19 @@ public class GatewayRegistryTests : IDisposable
     }
 
     [Fact]
+    public void Save_WhenTempWriteFailsAfterCreatingFile_RemovesTempFile()
+    {
+        var fs = new FailingTempWriteFileSystem();
+        var registry = new GatewayRegistry(_tempDir, fs);
+        registry.AddOrUpdate(MakeRecord("gw-1", "wss://test1"));
+
+        var ex = Assert.Throws<IOException>(() => registry.Save());
+
+        Assert.Equal("simulated partial write failure", ex.Message);
+        Assert.Empty(Directory.GetFiles(_tempDir, "gateways.json.*.tmp"));
+    }
+
+    [Fact]
     public void Load_WithNoFile_DoesNotThrow()
     {
         var registry = new GatewayRegistry(Path.Combine(_tempDir, "nonexistent"));
@@ -437,5 +450,21 @@ public class GatewayRegistryTests : IDisposable
         public void Debug(string message) { }
         public void Warn(string message) => Warnings.Add(message);
         public void Error(string message, Exception? ex = null) { }
+    }
+
+    private sealed class FailingTempWriteFileSystem : IFileSystem
+    {
+        public bool FileExists(string path) => File.Exists(path);
+        public string ReadAllText(string path) => File.ReadAllText(path);
+        public void WriteAllText(string path, string content)
+        {
+            File.WriteAllText(path, content[..Math.Min(content.Length, 16)]);
+            throw new IOException("simulated partial write failure");
+        }
+        public void CreateDirectory(string path) => Directory.CreateDirectory(path);
+        public bool DirectoryExists(string path) => Directory.Exists(path);
+        public void CopyFile(string source, string destination, bool overwrite) =>
+            File.Copy(source, destination, overwrite);
+        public void DeleteFile(string path) => File.Delete(path);
     }
 }

--- a/tests/OpenClaw.Shared.Tests/DeviceIdentityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/DeviceIdentityTests.cs
@@ -335,6 +335,25 @@ public class DeviceIdentityIntegrationTests
         finally { Directory.Delete(dir, true); }
     }
 
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("null")]
+    public void ReadStoredDeviceToken_WrongJsonRoot_ReturnsCorrupt(string json)
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "device-key-ed25519.json"), json);
+
+            var result = DeviceIdentity.ReadStoredDeviceToken(dir);
+
+            Assert.Null(result.Token);
+            Assert.Equal(DeviceTokenReadStatus.Corrupt, result.Status);
+            Assert.Contains("not a JSON object", result.Detail, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
     [IntegrationFact]
     public void DifferentDirs_ProduceDifferentIdentities()
     {

--- a/tests/OpenClaw.Tray.Tests/AssistantBridgeServiceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AssistantBridgeServiceTests.cs
@@ -202,7 +202,7 @@ public sealed class AssistantBridgeServiceTests
                 NullLogger.Instance,
                 "owner",
                 () => launcher,
-                TimeSpan.FromSeconds(5));
+                TimeSpan.FromSeconds(10));
 
             var result = await service.StartListenServiceAsync();
 

--- a/tests/OpenClaw.Tray.Tests/CommandCenterStateBuilderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/CommandCenterStateBuilderTests.cs
@@ -1,0 +1,36 @@
+using OpenClaw.Shared;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class CommandCenterStateBuilderTests
+{
+    [Fact]
+    public void BrowserProxyAuthWarning_IsGatedByActiveGatewaySharedToken()
+    {
+        var nodes = new[]
+        {
+            new NodeCapabilityHealthInfo
+            {
+                BrowserApprovedCommands = ["browser.proxy"]
+            }
+        };
+
+        Assert.True(CommandCenterBrowserProxyAuthWarningPolicy.ShouldShow(
+            nodeBrowserProxyEnabled: true,
+            activeGatewayHasSharedToken: false,
+            nodes));
+        Assert.False(CommandCenterBrowserProxyAuthWarningPolicy.ShouldShow(
+            nodeBrowserProxyEnabled: true,
+            activeGatewayHasSharedToken: true,
+            nodes));
+        Assert.False(CommandCenterBrowserProxyAuthWarningPolicy.ShouldShow(
+            nodeBrowserProxyEnabled: false,
+            activeGatewayHasSharedToken: false,
+            nodes));
+        Assert.False(CommandCenterBrowserProxyAuthWarningPolicy.ShouldShow(
+            nodeBrowserProxyEnabled: true,
+            activeGatewayHasSharedToken: false,
+            []));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/ConnectionPageApproveCommandTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ConnectionPageApproveCommandTests.cs
@@ -128,22 +128,18 @@ public sealed class ConnectionPageApproveCommandTests
     [Fact]
     public void GatewayCredentialDisplay_PrefersOperatorCredentialOverNodeCredential()
     {
-        var planSource = ReadPlanSource();
-        var pageSource = ReadConnectionPageSource();
+        var snapshot = new GatewayConnectionSnapshot
+        {
+            OperatorCredentialSource = CredentialResolver.SourceSharedGatewayToken,
+            OperatorCredentialStatus = GatewayCredentialResolutionStatus.Resolved,
+            NodeCredentialSource = CredentialResolver.SourceNodeDeviceToken,
+            NodeCredentialStatus = GatewayCredentialResolutionStatus.FallbackUsed,
+            NodeCredentialFallbackUsed = true
+        };
 
-        Assert.Contains(
-            "snap.OperatorCredentialSource ?? snap.NodeCredentialSource",
-            planSource);
-        Assert.DoesNotContain(
-            "snap.NodeCredentialSource ?? snap.OperatorCredentialSource",
-            planSource);
+        var summary = ConnectionPagePlan.FormatCredentialSummary(snapshot);
 
-        Assert.Contains(
-            "snapshot.OperatorCredentialSource ?? snapshot.NodeCredentialSource",
-            pageSource);
-        Assert.DoesNotContain(
-            "snapshot.NodeCredentialSource ?? snapshot.OperatorCredentialSource",
-            pageSource);
+        Assert.Equal("shared token", summary);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/ConnectionPageNodeApprovalSourceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ConnectionPageNodeApprovalSourceTests.cs
@@ -10,6 +10,11 @@ public sealed class ConnectionPageNodeApprovalSourceTests
             "OpenClaw.Tray.WinUI",
             "Services",
             "CommandCenterStateBuilder.cs");
+        var browserProxyPolicySource = ReadSource(
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Services",
+            "CommandCenterBrowserProxyAuthWarningPolicy.cs");
         var appSource = ReadSource("src", "OpenClaw.Tray.WinUI", "App.xaml.cs");
 
         Assert.Contains("NodeCapabilityHealthInfo.FromLocalDeclarations(localNode)", builderSource);
@@ -28,8 +33,8 @@ public sealed class ConnectionPageNodeApprovalSourceTests
             "PairingApprovalKind.NodePair => CommandCenterDiagnostics.BuildNodeApprovalRepairCommand(_snapshot.NodePairingRequestId)",
             builderSource);
         Assert.Contains("_ => CommandCenterDiagnostics.BuildUnknownPairingDiscoveryCommands()", builderSource);
-        Assert.Contains("node.UnverifiedDeclaredCommands.Contains(\"browser.proxy\"", builderSource);
-        Assert.Contains("node.LocalDeclaredCommands.Contains(\"browser.proxy\"", builderSource);
+        Assert.Contains("node.UnverifiedDeclaredCommands.Contains(\"browser.proxy\"", browserProxyPolicySource);
+        Assert.Contains("node.LocalDeclaredCommands.Contains(\"browser.proxy\"", browserProxyPolicySource);
         Assert.Contains(
             "NodePairingApprovalKind = _connectionManager?.CurrentSnapshot.NodePairingApprovalKind",
             appSource);

--- a/tests/OpenClaw.Tray.Tests/ConnectionPagePlanApprovalBehaviorTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ConnectionPagePlanApprovalBehaviorTests.cs
@@ -270,6 +270,33 @@ public sealed class ConnectionPagePlanApprovalBehaviorTests : IDisposable
         Assert.Equal("No node credential available. Re-pair this PC.", plan.NodeErrorDetail);
     }
 
+    [Fact]
+    public void ActiveGatewayDetailLine_ShowsCredentialFallback()
+    {
+        var settings = new SettingsManager(_settingsDirectory)
+        {
+            EnableNodeMode = true
+        };
+        var plan = ConnectionPagePlan.Build(
+            new GatewayConnectionSnapshot
+            {
+                OverallState = OverallConnectionState.Ready,
+                OperatorState = RoleConnectionState.Connected,
+                NodeState = RoleConnectionState.Disabled,
+                GatewayId = "gw-1",
+                GatewayUrl = "wss://test",
+                OperatorCredentialSource = CredentialResolver.SourceSharedGatewayToken,
+                OperatorCredentialStatus = GatewayCredentialResolutionStatus.FallbackUsed,
+                OperatorCredentialFallbackUsed = true
+            },
+            activeRecord: new GatewayRecord { Id = "gw-1", Url = "wss://test" },
+            self: null,
+            settings: settings,
+            savedGatewayCount: 1);
+
+        Assert.Contains("shared token (fallback)", plan.ActiveGatewayDetailLine);
+    }
+
     private ConnectionPagePlan Build(
         PairingApprovalKind pairingApprovalKind,
         GatewayNodeInfo? localNode,

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\CommandCenterTopologyTunnelResolver.cs" Link="Services\CommandCenterTopologyTunnelResolver.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\CommandCenterTunnelInfoBuilder.cs" Link="Services\CommandCenterTunnelInfoBuilder.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\PortDiagnosticsService.cs" Link="Services\PortDiagnosticsService.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\CommandCenterBrowserProxyAuthWarningPolicy.cs" Link="Services\CommandCenterBrowserProxyAuthWarningPolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\PairingApprovalCoordinator.cs" Link="Services\PairingApprovalCoordinator.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ToastActivationRouter.cs" Link="Services\ToastActivationRouter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\AppNotificationService.cs" Link="Services\AppNotificationService.cs" />


### PR DESCRIPTION
## Summary
- Make active gateway switching validated, persisted, observable, and rollback-safe.
- Add detailed credential resolution states for missing/unreadable/corrupt/fallback/bootstrap outcomes and project them into connection diagnostics/UI.
- Harden stale old-gateway event handling by using generation + gateway-id checks with captured identity context.
- Protect shared-token and setup-code mutation paths against credential loss and persistence failures.
- Gate browser-proxy shared-token guidance on actual active gateway shared-token availability.

## Validation
- `./build.ps1` — passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` — passed: 2724 passed / 31 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` — passed: 1616 passed
- `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore` — passed: 422 passed

Notes: prior full validation attempts hit transient queued-chat / exec-approval timing failures; each failing test passed in isolation and the full suites passed on rerun.

## Real behavior proof
- Computer-use verified isolated setup launch: `OpenClaw Setup` window, `Welcome to OpenClaw`, security notice, and `Continue` button visible.
- Computer-use verified normal profile companion: `Connected`, `ws://localhost:18789/ • paired via device token • v2026.6.10`, saved gateway row `Local (OpenClawGateway)` with `paired via device token`, `Shared token`, and `Node active · 8 capabilities`.
- Local MCP proof via normal profile:
  - `winnode --list-tools --verbose` succeeded against `http://127.0.0.1:8765/` with bearer auth from token file.
  - `winnode --command system.which --params '{"bins":["git","node"]}' --verbose` returned paths for both `git` and `node`.
- Gateway-mediated proof requested by maintainer:
  - `openclaw nodes list --json` from the `OpenClawGateway` WSL distro showed paired `Windows Node (PERSEID)` with commands including `system.which`.
  - `openclaw nodes invoke --node 'Windows Node (PERSEID)' --command system.which --params '{"bins":["git","node"]}' --json --invoke-timeout 30000` succeeded through the gateway and returned resolved `git` and `node` executable paths.
- Existing-profile smoke:
  - Normal profile `gateways.json` had `ActiveId=adceebb2401a4428`, one saved gateway, active URL `ws://localhost:18789`, friendly name `Local (OpenClawGateway)`, shared token present, bootstrap token absent.
  - The active per-gateway identity directory and `device-key-ed25519.json` existed under `%APPDATA%\OpenClawTray\gateways\adceebb2401a4428\`.

## Corrupt/unreadable device-token fallback decision
- This PR intentionally keeps corrupt/unreadable identity fallback as a visible same-gateway recovery path rather than silently downgrading durable credentials.
- Safety constraints:
  - A readable stored device token still always wins over shared/bootstrap credentials.
  - Fallback is only to credentials already stored on the same active `GatewayRecord`; credential reads never fall back to another gateway identity directory.
  - The snapshot/diagnostics preserve `GatewayCredentialResolutionStatus.FallbackUsed` with `PrimaryStatus=Unreadable` or `Corrupt`, so UI/diagnostics can make repair or re-pairing visible.
- Test coverage includes corrupt JSON, valid wrong-shape JSON (`[]` / `null`), and unreadable-token fallback cases.

## Review notes
- Completed five rubber-duck rounds, then multiple dual-model review passes.
- Fixed follow-up findings around stale event races, shared-token TOCTOU, registry save rollback/temp cleanup, non-object identity JSON handling, Command Center browser-proxy warning coverage, explicit unreadable/corrupt fallback coverage/rationale, and final suggested cleanup items.
- Latest cleanup: registry temp files are deleted on write or move failure; duplicate bootstrap-clear logic now delegates; dead V2 reset assignment and redundant missing-credential wording were removed.

## Not verified / blocked
- Isolated MCP proof was blocked because port `8765` was already in use by the normal profile MCP server; normal profile local MCP and gateway-mediated invoke proof were collected instead.