### PR TITLE
Remember selected native chat session

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -94,6 +94,8 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     private readonly object _attachmentMetaSaveGate = new();
     private readonly string _toolMetaCacheFilePath;
     private readonly string _attachmentMetaCacheFilePath;
+    private readonly string _lastChatStateFilePath;
+    private readonly TimeSpan _lastChatStateSaveDelay;
     private System.Threading.Timer? _toolMetaSaveTimer; // debounce cache writes
     private long _toolMetaSaveVersion;
     private bool _toolMetaCacheDirty;
@@ -242,7 +244,9 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         IChatGatewayBridge bridge,
         Action<Action>? post,
         string toolMetaCacheFilePath,
-        string? attachmentMetaCacheFilePath = null)
+        string? attachmentMetaCacheFilePath = null,
+        string? lastChatStateFilePath = null,
+        TimeSpan? lastChatStateSaveDelay = null)
     {
         _bridge = bridge ?? throw new ArgumentNullException(nameof(bridge));
         _post = post;
@@ -252,11 +256,15 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         _attachmentMetaCacheFilePath = !string.IsNullOrWhiteSpace(attachmentMetaCacheFilePath)
             ? attachmentMetaCacheFilePath
             : DefaultAttachmentMetaCacheFilePath(_toolMetaCacheFilePath);
+        _lastChatStateFilePath = !string.IsNullOrWhiteSpace(lastChatStateFilePath)
+            ? lastChatStateFilePath
+            : LastChatStateFilePath;
+        _lastChatStateSaveDelay = lastChatStateSaveDelay ?? TimeSpan.FromSeconds(2);
         _status = bridge.CurrentStatus;
         _persistedAbortedIds = LoadAbortedIds();
         _toolMetaCache = LoadToolMetaCache(_toolMetaCacheFilePath);
         _attachmentMetaCache = LoadAttachmentMetaCache(_attachmentMetaCacheFilePath);
-        _lastChatState = LoadLastChatState();
+        _lastChatState = LoadLastChatState(_lastChatStateFilePath);
 
         // Seed models from whatever the bridge already knows about (a connect
         // that completed before the provider was constructed will have its
@@ -304,6 +312,34 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             RememberLastSessionStateLocked();
             return Task.FromResult(BuildSnapshotLocked());
         }
+    }
+
+    internal void RememberSelectedThread(string? threadId)
+    {
+        if (string.IsNullOrWhiteSpace(threadId))
+            return;
+
+        LastChatState? state;
+        lock (_gate)
+        {
+            if (!TryGetSessionLocked(threadId, out var session))
+                return;
+
+            state = new LastChatState
+            {
+                DefaultThreadId = threadId,
+                ThreadTitle = BuildSessionTitle(session),
+                Model = session.Model,
+                ModelProvider = session.Provider,
+                AvailableModels = _availableModels,
+            };
+            _lastChatState = state;
+            _lastChatStateSaveVersion++;
+            _lastChatStateSaveTimer?.Dispose();
+            _lastChatStateSaveTimer = null;
+        }
+
+        SaveLastChatState(state, _lastChatStateFilePath);
     }
 
     // Explicit interface implementation (no attachments).
@@ -5678,6 +5714,12 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
 
     private string? ResolveDefaultThreadIdLocked()
     {
+        if (_lastChatState?.DefaultThreadId is { Length: > 0 } rememberedThreadId)
+        {
+            if (TryGetSessionLocked(rememberedThreadId, out _) || !_sessionsListReceived)
+                return rememberedThreadId;
+        }
+
         // Prefer the gateway's canonical main session (IsMain on SessionInfo)
         // so we never have to guess from a literal like "main". Only fall back
         // to the compose target (pre-materialization) or the first available
@@ -5700,8 +5742,11 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
     private void RememberLastSessionStateLocked()
     {
         if (_sessions.Length == 0) return;
-        var session = _sessions.FirstOrDefault(s => s.IsMain && !string.IsNullOrEmpty(s.Key))
-            ?? _sessions.FirstOrDefault(s => !string.IsNullOrEmpty(s.Key));
+        var defaultThreadId = ResolveDefaultThreadIdLocked();
+        var session = defaultThreadId is { Length: > 0 } && TryGetSessionLocked(defaultThreadId, out var selected)
+            ? selected
+            : _sessions.FirstOrDefault(s => s.IsMain && !string.IsNullOrEmpty(s.Key))
+                ?? _sessions.FirstOrDefault(s => !string.IsNullOrEmpty(s.Key));
         if (session is null) return;
 
         _lastChatState = new LastChatState
@@ -5712,6 +5757,22 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             ModelProvider = session.Provider,
             AvailableModels = _availableModels,
         };
+    }
+
+    private bool TryGetSessionLocked(string threadId, out SessionInfo session)
+    {
+        for (int i = 0; i < _sessions.Length; i++)
+        {
+            var candidate = _sessions[i];
+            if (string.Equals(candidate.Key, threadId, StringComparison.Ordinal))
+            {
+                session = candidate;
+                return true;
+            }
+        }
+
+        session = default!;
+        return false;
     }
 
     private static ChatThread ToThread(SessionInfo s)
@@ -5811,6 +5872,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         AppIdentity.ResolveLocalDataDirectory(), "last-chat-state.json");
 
     private System.Threading.Timer? _lastChatStateSaveTimer;
+    private long _lastChatStateSaveVersion;
 
     internal sealed class LastChatState
     {
@@ -5861,21 +5923,38 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         lock (_gate)
         {
             _lastChatState = state;
+            _lastChatStateSaveVersion++;
+            var saveVersion = _lastChatStateSaveVersion;
             _lastChatStateSaveTimer?.Dispose();
-            _lastChatStateSaveTimer = new System.Threading.Timer(_ => SaveLastChatState(state), null, 2000, Timeout.Infinite);
+            var path = _lastChatStateFilePath;
+            _lastChatStateSaveTimer = new System.Threading.Timer(_ => SaveLastChatStateIfCurrent(state, path, saveVersion), null, _lastChatStateSaveDelay, Timeout.InfiniteTimeSpan);
         }
     }
 
-    private static void SaveLastChatState(LastChatState state)
+    private void SaveLastChatStateIfCurrent(LastChatState state, string path, long saveVersion)
     {
+        lock (_gate)
+        {
+            if (saveVersion != _lastChatStateSaveVersion)
+                return;
+
+            SaveLastChatState(state, path);
+            _lastChatStateSaveTimer?.Dispose();
+            _lastChatStateSaveTimer = null;
+        }
+    }
+
+    private static void SaveLastChatState(LastChatState state, string? pathOverride = null)
+    {
+        var path = pathOverride ?? LastChatStateFilePath;
         try
         {
-            var dir = Path.GetDirectoryName(LastChatStateFilePath);
+            var dir = Path.GetDirectoryName(path);
             if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
             var json = System.Text.Json.JsonSerializer.Serialize(state);
-            var tmp = LastChatStateFilePath + ".tmp";
+            var tmp = path + ".tmp";
             File.WriteAllText(tmp, json);
-            File.Move(tmp, LastChatStateFilePath, overwrite: true);
+            File.Move(tmp, path, overwrite: true);
         }
         catch (Exception ex) { Logger.Debug($"ChatDataProvider: persist LastChatState failed: {ex.Message}"); }
     }

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
@@ -145,10 +145,11 @@ public sealed class OpenClawChatRoot : Component
         _scrollToBottomToken = () => scrollToBottomToken.Set(scrollToBottomToken.Value + 1);
         SetSpeakerMuted = muted => speakerMuted.Set(muted);
         var snapshotState = UseState<ChatDataSnapshot?>(null, threadSafe: true);
-        var selectedIdState = UseState<string?>(_initialThreadId, threadSafe: true);
+        var initialSelectedId = _initialThreadId ?? (_provider as OpenClawChatDataProvider)?.CachedLastChatState?.DefaultThreadId;
+        var selectedIdState = UseState<string?>(initialSelectedId, threadSafe: true);
         // UseRef tracks the selected ID across renders so that closures captured
         // inside UseEffect always read the latest value (UseState structs go stale).
-        var selectedIdRef = UseRef<string?>(_initialThreadId);
+        var selectedIdRef = UseRef<string?>(initialSelectedId);
         selectedIdRef.Current = selectedIdState.Value;
 
         UseEffect((Func<Action>)(() =>
@@ -581,6 +582,8 @@ public sealed class OpenClawChatRoot : Component
                 {
                     selectedIdState.Set(id);
                     selectedIdRef.Current = id;
+                    if (_provider is OpenClawChatDataProvider nativeProvider)
+                        nativeProvider.RememberSelectedThread(id);
                 },
                 OnModelChanged: model => ObserveFireAndForget(_provider.SetModelAsync(composerThread.Id!, model)),
                 OnModelCleared: () => ObserveFireAndForget(_provider.ClearModelAsync(composerThread.Id!)),

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -121,16 +121,23 @@ public class OpenClawChatDataProviderTests
     }
 
     private static (FakeBridge bridge, OpenClawChatDataProvider provider, List<ChatDataSnapshot> snapshots, List<ChatProviderNotification> notifications)
-        CreateProvider(SessionInfo[]? initial = null, string? toolMetaCachePath = null, string? attachmentMetaCachePath = null)
+        CreateProvider(
+            SessionInfo[]? initial = null,
+            string? toolMetaCachePath = null,
+            string? attachmentMetaCachePath = null,
+            string? lastChatStatePath = null,
+            TimeSpan? lastChatStateSaveDelay = null)
     {
         var bridge = new FakeBridge { Sessions = initial ?? Array.Empty<SessionInfo>() };
-        var provider = toolMetaCachePath is null && attachmentMetaCachePath is null
+        var provider = toolMetaCachePath is null && attachmentMetaCachePath is null && lastChatStatePath is null && lastChatStateSaveDelay is null
             ? new OpenClawChatDataProvider(bridge)
             : new OpenClawChatDataProvider(
                 bridge,
                 post: null,
                 toolMetaCacheFilePath: toolMetaCachePath ?? Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "tool-metadata.json"),
-                attachmentMetaCacheFilePath: attachmentMetaCachePath);
+                attachmentMetaCacheFilePath: attachmentMetaCachePath,
+                lastChatStateFilePath: lastChatStatePath,
+                lastChatStateSaveDelay: lastChatStateSaveDelay);
         var snapshots = new List<ChatDataSnapshot>();
         var notifications = new List<ChatProviderNotification>();
         provider.Changed += (_, e) => snapshots.Add(e.Snapshot);
@@ -6642,6 +6649,116 @@ public class OpenClawChatDataProviderTests
         });
         var snap = await provider.LoadAsync();
         Assert.Equal("agent:main:main", snap.DefaultThreadId);
+    }
+
+    [Fact]
+    public async Task RememberSelectedThread_PrefersSelectionAfterReload()
+    {
+        using var temp = new TempDirectory();
+        var sessions = new[]
+        {
+            new SessionInfo { Key = "agent:main:main", IsMain = true, DisplayName = "Main" },
+            new SessionInfo { Key = "agent:main:review", IsMain = false, DisplayName = "Review", Model = "gpt-5.1", Provider = "openai" }
+        };
+        var (_, provider, _, _) = CreateProvider(
+            sessions,
+            lastChatStatePath: Path.Combine(temp.DirectoryPath, "last-chat-state.json"));
+
+        var first = await provider.LoadAsync();
+        Assert.Equal("agent:main:main", first.DefaultThreadId);
+
+        provider.RememberSelectedThread("agent:main:review");
+        var reloaded = await provider.LoadAsync();
+
+        Assert.Equal("agent:main:review", reloaded.DefaultThreadId);
+        Assert.Equal("agent:main:review", provider.CachedLastChatState?.DefaultThreadId);
+        Assert.Equal("Review (main/review)", provider.CachedLastChatState?.ThreadTitle);
+        Assert.Equal("gpt-5.1", provider.CachedLastChatState?.Model);
+        Assert.Equal("openai", provider.CachedLastChatState?.ModelProvider);
+    }
+
+    [Fact]
+    public async Task RememberSelectedThread_FallsBackWhenSelectionDisappears()
+    {
+        using var temp = new TempDirectory();
+        var main = new SessionInfo { Key = "agent:main:main", IsMain = true, DisplayName = "Main" };
+        var review = new SessionInfo { Key = "agent:main:review", IsMain = false, DisplayName = "Review" };
+        var (bridge, provider, snapshots, _) = CreateProvider(
+            new[] { main, review },
+            lastChatStatePath: Path.Combine(temp.DirectoryPath, "last-chat-state.json"));
+
+        await provider.LoadAsync();
+        provider.RememberSelectedThread("agent:main:review");
+        snapshots.Clear();
+
+        bridge.RaiseSessions(new[] { main });
+
+        Assert.Equal("agent:main:main", snapshots[^1].DefaultThreadId);
+        Assert.Equal("agent:main:main", provider.CachedLastChatState?.DefaultThreadId);
+    }
+
+    [Fact]
+    public async Task RememberSelectedThread_CancelsPendingDefaultStateSave()
+    {
+        using var temp = new TempDirectory();
+        var statePath = Path.Combine(temp.DirectoryPath, "last-chat-state.json");
+        var main = new SessionInfo { Key = "agent:main:main", IsMain = true, DisplayName = "Main" };
+        var review = new SessionInfo { Key = "agent:main:review", IsMain = false, DisplayName = "Review" };
+        var (bridge, provider, _, _) = CreateProvider(
+            new[] { main, review },
+            lastChatStatePath: statePath,
+            lastChatStateSaveDelay: TimeSpan.FromMilliseconds(25));
+
+        bridge.RaiseSessions(new[] { main, review });
+        provider.RememberSelectedThread("agent:main:review");
+
+        await Task.Delay(150);
+
+        var persisted = OpenClawChatDataProvider.LoadLastChatState(statePath);
+        Assert.Equal("agent:main:review", persisted?.DefaultThreadId);
+    }
+
+    [Fact]
+    public async Task RememberSelectedThread_ModelsBeforeSessionsKeepsSavedSelectionPending()
+    {
+        using var temp = new TempDirectory();
+        var statePath = Path.Combine(temp.DirectoryPath, "last-chat-state.json");
+        await File.WriteAllTextAsync(statePath, JsonSerializer.Serialize(new OpenClawChatDataProvider.LastChatState
+        {
+            DefaultThreadId = "agent:main:review",
+            ThreadTitle = "Review (main/review)",
+            Model = "gpt-5.1",
+            ModelProvider = "openai",
+            AvailableModels = new[] { "gpt-5.0" }
+        }));
+        var main = new SessionInfo { Key = "agent:main:main", IsMain = true, DisplayName = "Main" };
+        var review = new SessionInfo { Key = "agent:main:review", IsMain = false, DisplayName = "Review", Model = "gpt-5.1", Provider = "openai" };
+        var (bridge, provider, snapshots, _) = CreateProvider(
+            lastChatStatePath: statePath,
+            lastChatStateSaveDelay: TimeSpan.FromMilliseconds(25));
+
+        await provider.LoadAsync();
+        snapshots.Clear();
+
+        bridge.RaiseModels(new ModelsListInfo
+        {
+            Models = new List<ModelInfo>
+            {
+                new() { Id = "gpt-5.1", Name = "GPT-5.1" }
+            }
+        });
+
+        Assert.Equal("agent:main:review", snapshots[^1].DefaultThreadId);
+        Assert.Equal("agent:main:review", provider.CachedLastChatState?.DefaultThreadId);
+
+        await Task.Delay(150);
+        var persistedBeforeSessions = OpenClawChatDataProvider.LoadLastChatState(statePath);
+        Assert.Equal("agent:main:review", persistedBeforeSessions?.DefaultThreadId);
+
+        bridge.RaiseSessions(new[] { main, review });
+
+        Assert.Equal("agent:main:review", snapshots[^1].DefaultThreadId);
+        Assert.Equal("agent:main:review", provider.CachedLastChatState?.DefaultThreadId);
     }
 
     // ─── RespondToPermissionAsync routes through the RPC bridge ────────────


### PR DESCRIPTION
Closes #944.

Summary
- Persists the user-selected native chat session from the channel dropdown.
- Prefers the remembered session on remount when it still exists, and keeps it pending until sessions.list proves otherwise.
- Cancels stale debounced last-state writes so an older default cannot overwrite an explicit selection.
- Falls back to the main session when the saved selection disappears.

## Validation
- GitHub Actions passed on current head: repo-hygiene, test, setup/network/revocation E2E, win-x64 build, win-arm64 build, Socket, and CodeQL gate.
- Focused provider tests pass for remembered selection, stale fallback, stale debounce overwrite prevention, models.list-before-sessions.list bootstrap ordering, and the main-session default regression.
- Full macOS local build is blocked by the Windows-only build script and existing Windows-path assumptions in broader local suites.

## Real behavior proof
- Provider path exercised with session list reloads: selecting `agent:main:review` makes it the next snapshot default; removing that session reverts the default to `agent:main:main`.
- Bootstrap ordering proof: with saved `agent:main:review`, a models.list snapshot before sessions.list keeps `agent:main:review` as the default, preserves it in memory, and keeps the delayed `last-chat-state.json` write on that session.
- Persistence race proof: a pending debounced default save is armed, `agent:main:review` is selected, the debounce window elapses, and the persisted `last-chat-state.json` remains on `agent:main:review`.
- Manual Windows UI launch was not available on this macOS host; Windows CI is the authoritative build/runtime signal.