### PR TITLE
Fix workspace file previews

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/WorkspaceFilesModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/WorkspaceFilesModel.cs
@@ -7,11 +7,10 @@ using OpenClaw.Shared;
 namespace OpenClawTray.Pages;
 
 /// <summary>
-/// Pure projection layer for the Workspace page's session file rail. Adapts the
-/// typed gateway protocol DTOs (<see cref="SessionFileList"/> /
-/// <see cref="SessionFileContent"/> from <c>sessions.files.list/get</c>) into
-/// view rows and owns the search/sort/format logic so the code-behind stays a
-/// thin view.
+/// Pure projection layer for the Workspace page file rail. Adapts the current
+/// read-only agent workspace browser (<c>agents.workspace.list/get</c>) plus
+/// legacy/typed DTO shapes into view rows and owns the search/sort/format logic
+/// so the code-behind stays a thin view.
 ///
 /// This layer <i>consumes</i> the protocol DTOs — it does not re-parse wire JSON
 /// or redefine the protocol contract (that lives in
@@ -33,7 +32,7 @@ internal static class WorkspaceFilesModel
 
         /// <summary>
         /// The original path string from the gateway DTO — used verbatim when
-        /// requesting content via <c>sessions.files.get</c> so normalization
+        /// requesting content from the gateway so normalization
         /// never diverges from what the gateway expects.
         /// </summary>
         public required string RequestPath { get; init; }
@@ -50,7 +49,7 @@ internal static class WorkspaceFilesModel
         /// <summary>True when this row came from transcript/session relevance.</summary>
         public bool IsSessionFile { get; init; }
 
-        /// <summary>True when selecting this file may call <c>sessions.files.get</c>.</summary>
+        /// <summary>True when selecting this file may request a gateway preview.</summary>
         public bool CanPreview { get; init; }
 
         /// <summary>The agent wrote/modified this file during the session.</summary>
@@ -144,6 +143,48 @@ internal static class WorkspaceFilesModel
     }
 
     /// <summary>
+    /// Project the read-only <c>agents.workspace.list</c> payload into rows.
+    /// Unlike <c>sessions.files.*</c>, this is not limited to files mentioned
+    /// in the transcript, so every regular file row is previewable.
+    /// </summary>
+    public static WorkspaceListState FromAgentWorkspaceList(JsonElement payload)
+    {
+        if (payload.ValueKind != JsonValueKind.Object)
+            return new WorkspaceListState();
+
+        var entries = new List<WorkspaceFileEntry>();
+        if (payload.TryGetProperty("entries", out var entriesEl) &&
+            entriesEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var entryEl in entriesEl.EnumerateArray())
+            {
+                if (MapAgentWorkspaceEntry(entryEl) is { } entry)
+                    entries.Add(entry);
+            }
+        }
+
+        var path = NormalizeBrowserPath(GetString(payload, "path"));
+        var parentPathRaw = GetString(payload, "parentPath");
+        var totalEntries = GetLong(payload, "totalEntries");
+        var offset = GetLong(payload, "offset") ?? 0;
+        var truncated = totalEntries is { } total && offset + entries.Count < total;
+
+        return new WorkspaceListState
+        {
+            WorkspacePath = GetString(payload, "workspace") ??
+                            GetString(payload, "root") ??
+                            "Agent workspace",
+            Supported = true,
+            Entries = Sort(entries),
+            BrowserPath = path,
+            BrowserParentPath = parentPathRaw is not null
+                ? NormalizeBrowserPath(parentPathRaw)
+                : null,
+            BrowserTruncated = truncated,
+        };
+    }
+
+    /// <summary>
     /// Project the legacy <c>agents.files.list</c> payload used by older
     /// gateways. It does not support path browsing or session relevance badges,
     /// but the rows remain previewable through <c>agents.files.get</c>.
@@ -230,7 +271,7 @@ internal static class WorkspaceFilesModel
         };
     }
 
-    private static WorkspaceFileEntry? MapLegacyFileEntry(JsonElement item)
+    private static WorkspaceFileEntry? MapAgentWorkspaceEntry(JsonElement item)
     {
         if (item.ValueKind != JsonValueKind.Object) return null;
 
@@ -241,11 +282,41 @@ internal static class WorkspaceFilesModel
         var name = GetString(item, "name") ?? LeafName(relative);
         if (string.IsNullOrEmpty(name)) return null;
 
+        var kind = GetString(item, "kind");
+        var isDirectory = string.Equals(kind, "directory", StringComparison.OrdinalIgnoreCase);
+
         return new WorkspaceFileEntry
         {
             Name = name,
             RelativePath = relative,
             RequestPath = requestPath,
+            Size = GetLong(item, "size"),
+            Exists = true,
+            IsDirectory = isDirectory,
+            IsSessionFile = false,
+            CanPreview = !isDirectory,
+            Touched = false,
+            Read = false,
+            ModifiedUtc = ToUtc(GetLong(item, "updatedAtMs")),
+        };
+    }
+
+    private static WorkspaceFileEntry? MapLegacyFileEntry(JsonElement item)
+    {
+        if (item.ValueKind != JsonValueKind.Object) return null;
+
+        var displayPath = GetString(item, "path") ?? GetString(item, "name");
+        if (string.IsNullOrEmpty(displayPath)) return null;
+
+        var relative = NormalizePath(displayPath);
+        var name = GetString(item, "name") ?? LeafName(relative);
+        if (string.IsNullOrEmpty(name)) return null;
+
+        return new WorkspaceFileEntry
+        {
+            Name = name,
+            RelativePath = relative,
+            RequestPath = name,
             Size = GetLong(item, "size"),
             Exists = GetBool(item, "exists") ?? !GetBool(item, "missing").GetValueOrDefault(),
             IsDirectory = false,
@@ -335,6 +406,19 @@ internal static class WorkspaceFilesModel
         return dt.Kind == DateTimeKind.Unspecified
             ? new DateTimeOffset(DateTime.SpecifyKind(dt, DateTimeKind.Utc))
             : new DateTimeOffset(dt.ToUniversalTime());
+    }
+
+    private static DateTimeOffset? ToUtc(long? unixTimeMilliseconds)
+    {
+        if (unixTimeMilliseconds is not { } value) return null;
+        try
+        {
+            return DateTimeOffset.FromUnixTimeMilliseconds(value);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return null;
+        }
     }
 
     private static string? GetString(JsonElement item, string name)

--- a/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml.cs
@@ -45,6 +45,9 @@ public sealed partial class WorkspacePage : Page
     private string _searchQuery = string.Empty;
     private bool _suppressSearchTextChanged;
     private bool _usingLegacyAgentFilesFallback;
+    private bool _workspaceListApiUnsupported;
+    private bool _workspaceGetApiUnsupported;
+    private IOperatorGatewayClient? _workspaceCapabilityClient;
     private bool _renderMarkdown = true;
 
     // Monotonic token guarding against out-of-order async results: a list/file
@@ -67,7 +70,7 @@ public sealed partial class WorkspacePage : Page
         _searchDebounceTimer.Tick += (_, _) =>
         {
             _searchDebounceTimer.Stop();
-            _ = LoadAsync();
+            ApplyFilter();
         };
     }
 
@@ -126,14 +129,64 @@ public sealed partial class WorkspacePage : Page
             return;
         }
 
+        ResetWorkspaceCapabilityProbeIfClientChanged(client);
+        BeginLoading();
+
+        if (_workspaceListApiUnsupported)
+        {
+            await StartSessionFilesFallbackAsync(token);
+            return;
+        }
+
+        JsonElement result;
+        try
+        {
+            result = await client.SendWizardRequestAsync(
+                "agents.workspace.list",
+                new
+                {
+                    agentId = AgentId,
+                    path = _browserPath,
+                    limit = 500
+                },
+                timeoutMs: 15000);
+        }
+        catch (Exception ex) when (IsUnknownWorkspaceMethod(ex))
+        {
+            if (token != _loadToken) return;
+            Services.Logger.Warn($"[WorkspacePage] agents.workspace.list unsupported; falling back to sessions.files.list: {ex.Message}");
+            _workspaceListApiUnsupported = true;
+            await StartSessionFilesFallbackAsync(token);
+            return;
+        }
+        catch (Exception ex)
+        {
+            if (token != _loadToken) return;
+            Services.Logger.Warn($"[WorkspacePage] agents.workspace.list failed: {ex.Message}");
+            EndLoading();
+            if (CurrentApp.AppState?.Status == ConnectionStatus.Connected)
+                ShowLoadError();
+            else
+                ShowDisconnected();
+            return;
+        }
+
+        if (token != _loadToken) return; // a newer load superseded this one
+        EndLoading();
+        ApplyWorkspaceListResult(result);
+    }
+
+    private async Task StartSessionFilesFallbackAsync(int token)
+    {
+        if (token != _loadToken) return;
+
+        var client = CurrentApp.GatewayClient;
         var key = ResolveSessionKey();
-        if (string.IsNullOrWhiteSpace(key))
+        if (client == null || string.IsNullOrWhiteSpace(key))
         {
             ShowDisconnected();
             return;
         }
-
-        BeginLoading();
 
         SessionFileList result;
         try
@@ -145,7 +198,7 @@ public sealed partial class WorkspacePage : Page
         catch (Exception ex)
         {
             if (token != _loadToken) return;
-            Services.Logger.Warn($"[WorkspacePage] sessions.files.list failed: {ex.Message}");
+            Services.Logger.Warn($"[WorkspacePage] sessions.files.list fallback failed: {ex.Message}");
             EndLoading();
             if (CurrentApp.AppState?.Status == ConnectionStatus.Connected)
                 ShowLoadError();
@@ -154,7 +207,7 @@ public sealed partial class WorkspacePage : Page
             return;
         }
 
-        if (token != _loadToken) return; // a newer load superseded this one
+        if (token != _loadToken) return;
         if (!result.IsSupported)
         {
             await StartLegacyAgentFilesFallbackAsync(token);
@@ -224,6 +277,39 @@ public sealed partial class WorkspacePage : Page
         ClearFiles();
 
         var state = WorkspaceFilesModel.FromSessionFileList(result);
+        WorkspacePathText.Text = state.WorkspacePath;
+        _browserPath = state.BrowserPath;
+        _browserParentPath = state.BrowserParentPath;
+        UpdateBrowserChrome(state);
+
+        if (!state.Supported)
+        {
+            ShowUnsupported();
+            return;
+        }
+
+        foreach (var entry in state.Entries)
+        {
+            _allEntries.Add(entry);
+            _entriesByPath[entry.RelativePath] = entry;
+        }
+
+        if (_allEntries.Count == 0 && string.IsNullOrWhiteSpace(_searchQuery) && string.IsNullOrEmpty(_browserPath))
+        {
+            ShowNoFiles();
+            return;
+        }
+
+        HideFallback();
+        BodyGrid.Visibility = Visibility.Visible;
+        ApplyFilter();
+    }
+
+    private void ApplyWorkspaceListResult(JsonElement result)
+    {
+        ClearFiles();
+
+        var state = WorkspaceFilesModel.FromAgentWorkspaceList(result);
         WorkspacePathText.Text = state.WorkspacePath;
         _browserPath = state.BrowserPath;
         _browserParentPath = state.BrowserParentPath;
@@ -576,6 +662,85 @@ public sealed partial class WorkspacePage : Page
     private async Task LoadFileAsync(WorkspaceFilesModel.WorkspaceFileEntry entry)
     {
         var client = CurrentApp.GatewayClient;
+        if (client == null)
+        {
+            ShowFileUnavailable(entry.RelativePath);
+            return;
+        }
+        ResetWorkspaceCapabilityProbeIfClientChanged(client);
+
+        var token = _loadToken;
+        if (_usingLegacyAgentFilesFallback)
+        {
+            await StartLegacyAgentFileGetFallbackAsync(entry, token);
+            return;
+        }
+
+        if (_workspaceGetApiUnsupported)
+        {
+            await StartSessionFileGetFallbackAsync(entry, token);
+            return;
+        }
+
+        try
+        {
+            // Use the gateway's original path string, not the normalized display
+            // path, so the request matches exactly what the gateway listed.
+            var result = await client.SendWizardRequestAsync(
+                "agents.workspace.get",
+                new { agentId = AgentId, path = entry.RequestPath },
+                timeoutMs: 15000);
+            if (token != _loadToken) return; // list reloaded underneath us
+
+            ApplyWorkspaceFileContent(result, entry);
+        }
+        catch (Exception ex) when (IsUnknownWorkspaceMethod(ex))
+        {
+            if (token != _loadToken) return;
+            Services.Logger.Warn($"[WorkspacePage] agents.workspace.get unsupported; falling back to sessions.files.get: {ex.Message}");
+            _workspaceGetApiUnsupported = true;
+            await StartSessionFileGetFallbackAsync(entry, token);
+        }
+        catch (Exception ex)
+        {
+            if (token != _loadToken) return;
+            // The gateway returns an error for missing / too-large files. Show it
+            // inline without caching so the user can retry by reselecting.
+            Services.Logger.Warn($"[WorkspacePage] agents.workspace.get failed for '{entry.RequestPath}': {ex.Message}");
+            ShowFileUnavailable(entry.RelativePath);
+        }
+    }
+
+    private void ApplyWorkspaceFileContent(JsonElement payload, WorkspaceFilesModel.WorkspaceFileEntry entry)
+    {
+        if (payload.ValueKind != JsonValueKind.Object ||
+            !payload.TryGetProperty("file", out var fileEl) ||
+            fileEl.ValueKind != JsonValueKind.Object)
+        {
+            ShowFileUnavailable(entry.RelativePath);
+            return;
+        }
+
+        bool missing = GetBool(fileEl, "missing") ?? false;
+        if (missing)
+        {
+            SetFileBody(entry.RelativePath, FileBodyKind.Missing, null);
+            return;
+        }
+
+        var content = GetString(fileEl, "content");
+        var encoding = GetString(fileEl, "encoding");
+        if (content is null || string.Equals(encoding, "base64", StringComparison.OrdinalIgnoreCase))
+            ShowFileUnavailable(entry.RelativePath);
+        else
+            SetFileBody(entry.RelativePath, FileBodyKind.Loaded, content);
+    }
+
+    private async Task StartSessionFileGetFallbackAsync(
+        WorkspaceFilesModel.WorkspaceFileEntry entry,
+        int token)
+    {
+        var client = CurrentApp.GatewayClient;
         var key = ResolveSessionKey();
         if (client == null || string.IsNullOrWhiteSpace(key))
         {
@@ -583,13 +748,10 @@ public sealed partial class WorkspacePage : Page
             return;
         }
 
-        var token = _loadToken;
         try
         {
-            // Use the gateway's original path string, not the normalized display
-            // path, so the request matches exactly what the gateway indexed.
             var result = await client.GetSessionFileAsync(key, entry.RequestPath);
-            if (token != _loadToken) return; // list reloaded underneath us
+            if (token != _loadToken) return;
 
             if (!result.IsSupported)
             {
@@ -607,9 +769,7 @@ public sealed partial class WorkspacePage : Page
         catch (Exception ex)
         {
             if (token != _loadToken) return;
-            // The gateway returns an error for missing / too-large files. Show it
-            // inline without caching so the user can retry by reselecting.
-            Services.Logger.Warn($"[WorkspacePage] sessions.files.get failed for '{entry.RequestPath}': {ex.Message}");
+            Services.Logger.Warn($"[WorkspacePage] sessions.files.get fallback failed for '{entry.RequestPath}': {ex.Message}");
             ShowFileUnavailable(entry.RelativePath);
         }
     }
@@ -628,7 +788,12 @@ public sealed partial class WorkspacePage : Page
         _usingLegacyAgentFilesFallback = true;
         try
         {
-            await client.RequestAgentFileGetAsync(AgentId, entry.RequestPath);
+            var payload = await client.SendWizardRequestAsync(
+                "agents.files.get",
+                new { agentId = AgentId, name = entry.RequestPath },
+                timeoutMs: 15000);
+            if (token != _loadToken) return;
+            ApplyLegacyAgentFileContent(payload);
         }
         catch (Exception ex)
         {
@@ -1104,6 +1269,14 @@ public sealed partial class WorkspacePage : Page
     private void RepairLink_Click(object sender, RoutedEventArgs e)
         => ((IAppCommands)CurrentApp).Navigate("connection");
 
+    private void ResetWorkspaceCapabilityProbeIfClientChanged(IOperatorGatewayClient client)
+    {
+        if (ReferenceEquals(_workspaceCapabilityClient, client)) return;
+        _workspaceCapabilityClient = client;
+        _workspaceListApiUnsupported = false;
+        _workspaceGetApiUnsupported = false;
+    }
+
     private void HideFallback()
     {
         FallbackInfoBar.IsOpen = false;
@@ -1133,9 +1306,9 @@ public sealed partial class WorkspacePage : Page
         FallbackInfoBar.IsOpen = true;
     }
 
-    // Connected gateway that doesn't implement sessions.files.list (older
-    // gateway) or errored serving it. Same repair affordance, distinct copy so
-    // the user knows it's a capability gap.
+    // Connected gateway that doesn't implement workspace/session file browsing
+    // or errored serving it. Same repair affordance, distinct copy so the user
+    // knows it's a capability gap.
     private void ShowUnsupported()
     {
         EndLoading();
@@ -1167,5 +1340,13 @@ public sealed partial class WorkspacePage : Page
         return item.TryGetProperty(name, out var value) && value.ValueKind is JsonValueKind.True or JsonValueKind.False
             ? value.GetBoolean()
             : null;
+    }
+
+    private static bool IsUnknownWorkspaceMethod(Exception ex)
+    {
+        var message = ex.Message;
+        return message.Contains("unknown method", StringComparison.OrdinalIgnoreCase) ||
+               message.Contains("method not found", StringComparison.OrdinalIgnoreCase) ||
+               message.Contains("-32601", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -2169,7 +2169,7 @@ Use one of these options:
     <value>Couldn't load this file.</value>
   </data>
   <data name="WorkspacePage_BrowserOnlyFileNote" xml:space="preserve">
-    <value>Only files read or edited in this session can be previewed.</value>
+    <value>Select a file to preview it. Some binary or oversized files may not load inline.</value>
   </data>
   <data name="WorkspacePage_OpenFolder" xml:space="preserve">
     <value>Open</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -2122,7 +2122,7 @@ Utilisez l'une de ces options :
     <value>Couldn't load this file.</value>
   </data>
   <data name="WorkspacePage_BrowserOnlyFileNote" xml:space="preserve">
-    <value>Only files read or edited in this session can be previewed.</value>
+    <value>Select a file to preview it. Some binary or oversized files may not load inline.</value>
   </data>
   <data name="WorkspacePage_OpenFolder" xml:space="preserve">
     <value>Open</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -2123,7 +2123,7 @@ Gebruik een van deze opties:
     <value>Couldn't load this file.</value>
   </data>
   <data name="WorkspacePage_BrowserOnlyFileNote" xml:space="preserve">
-    <value>Only files read or edited in this session can be previewed.</value>
+    <value>Select a file to preview it. Some binary or oversized files may not load inline.</value>
   </data>
   <data name="WorkspacePage_OpenFolder" xml:space="preserve">
     <value>Open</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -2122,7 +2122,7 @@
     <value>Couldn't load this file.</value>
   </data>
   <data name="WorkspacePage_BrowserOnlyFileNote" xml:space="preserve">
-    <value>Only files read or edited in this session can be previewed.</value>
+    <value>Select a file to preview it. Some binary or oversized files may not load inline.</value>
   </data>
   <data name="WorkspacePage_OpenFolder" xml:space="preserve">
     <value>Open</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -2122,7 +2122,7 @@
     <value>Couldn't load this file.</value>
   </data>
   <data name="WorkspacePage_BrowserOnlyFileNote" xml:space="preserve">
-    <value>Only files read or edited in this session can be previewed.</value>
+    <value>Select a file to preview it. Some binary or oversized files may not load inline.</value>
   </data>
   <data name="WorkspacePage_OpenFolder" xml:space="preserve">
     <value>Open</value>

--- a/tests/OpenClaw.Tray.Tests/WorkspaceFilesModelTests.cs
+++ b/tests/OpenClaw.Tray.Tests/WorkspaceFilesModelTests.cs
@@ -238,7 +238,7 @@ public class WorkspaceFilesModelTests
             {
               "workspace": "C:\\repo",
               "files": [
-                { "name": "README.md", "size": 2048, "exists": true },
+                { "path": "C:\\repo\\README.md", "name": "README.md", "size": 2048, "exists": true },
                 { "name": "gone.md", "missing": true }
               ]
             }
@@ -255,10 +255,76 @@ public class WorkspaceFilesModelTests
         Assert.True(readme.CanPreview);
         Assert.True(readme.Exists);
         Assert.Equal(2048, readme.Size);
+        Assert.Equal("README.md", readme.RequestPath);
 
         var missing = Assert.Single(state.Entries, e => e.Name == "gone.md");
         Assert.False(missing.Exists);
         Assert.True(missing.CanPreview);
+    }
+
+    [Fact]
+    public void FromAgentWorkspaceList_MapsAllWorkspaceFilesAsPreviewable()
+    {
+        using var doc = JsonDocument.Parse("""
+            {
+              "agentId": "main",
+              "path": "src",
+              "parentPath": "",
+              "entries": [
+                { "path": "src", "name": "src", "kind": "directory", "updatedAtMs": 1700000000000 },
+                { "path": "src/app.cs", "name": "app.cs", "kind": "file", "size": 42, "updatedAtMs": 1700000000123 },
+                { "path": "README.md", "name": "README.md", "kind": "file" }
+              ],
+              "totalEntries": 3,
+              "offset": 0
+            }
+            """);
+
+        var state = WorkspaceFilesModel.FromAgentWorkspaceList(doc.RootElement);
+
+        Assert.True(state.Supported);
+        Assert.Equal("Agent workspace", state.WorkspacePath);
+        Assert.Equal("src", state.BrowserPath);
+        Assert.Equal(string.Empty, state.BrowserParentPath);
+        Assert.False(state.BrowserTruncated);
+
+        var directory = Assert.Single(state.Entries, e => e.Name == "src");
+        Assert.True(directory.IsDirectory);
+        Assert.False(directory.CanPreview);
+        Assert.False(directory.IsSessionFile);
+
+        var app = Assert.Single(state.Entries, e => e.Name == "app.cs");
+        Assert.False(app.IsDirectory);
+        Assert.True(app.CanPreview);
+        Assert.False(app.IsSessionFile);
+        Assert.False(app.Read);
+        Assert.False(app.Touched);
+        Assert.Equal(42, app.Size);
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1700000000123), app.ModifiedUtc);
+
+        var readme = Assert.Single(state.Entries, e => e.Name == "README.md");
+        Assert.True(readme.CanPreview);
+    }
+
+    [Fact]
+    public void FromAgentWorkspaceList_DetectsPaginationTruncation()
+    {
+        using var doc = JsonDocument.Parse("""
+            {
+              "path": "src/app",
+              "parentPath": "src",
+              "entries": [
+                { "path": "src/app/a.txt", "name": "a.txt", "kind": "file" }
+              ],
+              "totalEntries": 5,
+              "offset": 0
+            }
+            """);
+
+        var state = WorkspaceFilesModel.FromAgentWorkspaceList(doc.RootElement);
+
+        Assert.True(state.BrowserTruncated);
+        Assert.Equal("src", state.BrowserParentPath);
     }
 
     // ── Unsupported / null handling ─────────────────────────────────────


### PR DESCRIPTION
## Summary

- Route the Workspace page through the read-only `agents.workspace.list` / `agents.workspace.get` APIs when the gateway supports full workspace browsing.
- Preserve stable-gateway behavior by falling back to `sessions.files.list` / `sessions.files.get`, then the narrow legacy `agents.files.*` managed-file fallback for older gateways.
- Update stale preview copy and add model tests for all-workspace entries, root parent navigation, pagination truncation, and legacy managed-file fallback request names.

## Validation

- `.uild.ps1` — passed
- `dotnet test .	estsdOpenClaw.Shared.TestsdOpenClaw.Shared.Tests.csproj --no-restore` — passed: 2722 passed, 31 skipped
- `dotnet test .	estsdOpenClaw.Tray.TestsdOpenClaw.Tray.Tests.csproj --no-restore` — passed: 1651 passed

## Real behavior proof

- Projection proof: `WorkspaceFilesModelTests.FromAgentWorkspaceList_MapsAllWorkspaceFilesAsPreviewable` verifies `agents.workspace.list` file rows are previewable even when they are not session-referenced/read/edited.
- Projection proof: `WorkspaceFilesModelTests.FromAgentWorkspaceList_MapsAllWorkspaceFilesAsPreviewable` verifies empty `parentPath` remains a root parent path so first-level folders can navigate back up.
- Stable-gateway proof: local gateway `2026.6.11` does not advertise `agents.workspace.*`; the page now falls back to `sessions.files.*` first and only then to `agents.files.*`.
- Not verified / blocked: live full-workspace preview requires a gateway build/channel that supports `agents.workspace.list/get`; the current stable gateway does not.

## Rubber-duck review

Dual rubber-duck review completed before PR creation. Fixed the first five findings: root parent navigation, split list/get capability fallback, missing-file semantics, capability reset on client change, and local search filtering. Also corrected the stable fallback chain to prefer `sessions.files.*` before `agents.files.*`.
