### PR TITLE
Disambiguate duplicate session titles

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -328,7 +328,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             state = new LastChatState
             {
                 DefaultThreadId = threadId,
-                ThreadTitle = BuildSessionTitle(session),
+                ThreadTitle = SessionTitleFormatter.Format(session, _sessions),
                 Model = session.Model,
                 ModelProvider = session.Provider,
                 AvailableModels = _availableModels,
@@ -5608,8 +5608,9 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         // a usable composer even before the first session materializes server-
         // side (e.g. fresh install with zero sessions).
         var threadList = new List<ChatThread>(_sessions.Length + 1);
+        var threadTitles = SessionTitleFormatter.FormatUnique(_sessions);
         for (int i = 0; i < _sessions.Length; i++)
-            threadList.Add(ToThread(_sessions[i]));
+            threadList.Add(ToThread(_sessions[i], threadTitles[i]));
 
         var composeKey = _bridge.MainSessionKey;
         var composeReady = _bridge.HasHandshakeSnapshot
@@ -5752,7 +5753,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         _lastChatState = new LastChatState
         {
             DefaultThreadId = session.Key,
-            ThreadTitle = BuildSessionTitle(session),
+            ThreadTitle = SessionTitleFormatter.Format(session, _sessions),
             Model = session.Model,
             ModelProvider = session.Provider,
             AvailableModels = _availableModels,
@@ -5775,10 +5776,8 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         return false;
     }
 
-    private static ChatThread ToThread(SessionInfo s)
+    private static ChatThread ToThread(SessionInfo s, string title)
     {
-        var title = BuildSessionTitle(s);
-
         return new ChatThread
         {
             Id = s.Key ?? string.Empty,
@@ -5796,40 +5795,6 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
             CreatedAt = s.StartedAt is { } st ? ToOffset(st) : null,
             UpdatedAt = s.UpdatedAt is { } ut ? ToOffset(ut) : null,
         };
-    }
-
-    /// <summary>
-    /// Builds a human-readable title from the session key and display name.
-    /// Keys follow the pattern agent:{agentId}:{sessionSlot} (e.g. agent:main:main, agent:assistant:main).
-    /// When a DisplayName is set, we append the agent/slot as a qualifier to disambiguate
-    /// sessions that share the same DisplayName.
-    /// </summary>
-    private static string BuildSessionTitle(SessionInfo s)
-    {
-        var baseName = !string.IsNullOrWhiteSpace(s.DisplayName)
-            ? s.DisplayName!
-            : (s.IsMain ? "OpenClaw Windows Tray" : s.ShortKey);
-
-        // Parse agent:agentId:sessionSlot from the key
-        var parts = (s.Key ?? "").Split(':');
-        if (parts.Length >= 3 && parts[0] == "agent")
-        {
-            var agentId = parts[1];     // e.g. "main", "assistant"
-            var sessionSlot = parts[2]; // e.g. "main", "assistant", "cron"
-
-            // For the canonical main session (agent:main:main), just show the base name
-            if (agentId == "main" && sessionSlot == "main")
-                return baseName;
-
-            // Otherwise, qualify with agent/slot to distinguish
-            var qualifier = agentId == sessionSlot
-                ? agentId                       // e.g. "assistant" when both match
-                : $"{agentId}/{sessionSlot}";   // e.g. "assistant/main"
-
-            return $"{baseName} ({qualifier})";
-        }
-
-        return baseName;
     }
 
     private static DateTimeOffset ToOffset(DateTime dt)

--- a/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChatPage.xaml.cs
@@ -334,7 +334,9 @@ public sealed partial class ChatPage : Page
 
     private sealed class AccessibilityChatDataProvider : IChatDataProvider
     {
-        private const string ThreadId = "accessibility-main";
+        private const string DefaultThreadId = "accessibility-main";
+        private const string MainThreadId = "agent:main:main";
+        private const string ForkThreadId = "agent:main:fork";
         private static readonly ChatDataSnapshot Snapshot = CreateSnapshot();
 
         public string DisplayName => "Accessibility test chat";
@@ -389,15 +391,15 @@ public sealed partial class ChatPage : Page
 
         private static ChatDataSnapshot CreateSnapshot()
         {
-            var timeline = ChatTimelineState.Initial() with
+            static ChatTimelineState CreateTimeline(string id) => ChatTimelineState.Initial() with
             {
                 Entries = ChatTimelineState.Initial().Entries
                     .Add(new ChatTimelineItem(
-                        "accessibility-user",
+                        $"accessibility-user-{id}",
                         ChatTimelineItemKind.User,
                         "Verify the native chat surface."))
                     .Add(new ChatTimelineItem(
-                        "accessibility-assistant",
+                        $"accessibility-assistant-{id}",
                         ChatTimelineItemKind.Assistant,
                         "The timeline and composer are ready.")),
                 NextId = 3,
@@ -405,22 +407,42 @@ public sealed partial class ChatPage : Page
             };
 
             return new ChatDataSnapshot(
-                [new ChatThread
-                {
-                    Id = ThreadId,
-                    Title = "Accessibility session",
-                    Status = ChatThreadStatus.Running,
-                    Activity = ChatActivity.Idle,
-                    Model = "test-model",
-                }],
+                [
+                    new ChatThread
+                    {
+                        Id = DefaultThreadId,
+                        Title = "Accessibility session",
+                        Status = ChatThreadStatus.Running,
+                        Activity = ChatActivity.Idle,
+                        Model = "test-model",
+                    },
+                    new ChatThread
+                    {
+                        Id = MainThreadId,
+                        Title = $"Route target: {MainThreadId}",
+                        Status = ChatThreadStatus.Running,
+                        Activity = ChatActivity.Idle,
+                        Model = "test-model",
+                    },
+                    new ChatThread
+                    {
+                        Id = ForkThreadId,
+                        Title = $"Route target: {ForkThreadId}",
+                        Status = ChatThreadStatus.Running,
+                        Activity = ChatActivity.Idle,
+                        Model = "test-model",
+                    },
+                ],
                 new Dictionary<string, ChatTimelineState>
                 {
-                    [ThreadId] = timeline,
+                    [DefaultThreadId] = CreateTimeline(DefaultThreadId),
+                    [MainThreadId] = CreateTimeline(MainThreadId),
+                    [ForkThreadId] = CreateTimeline(ForkThreadId),
                 },
-                ThreadId,
+                DefaultThreadId,
                 "Connected (accessibility test)",
                 ["test-model"],
-                new ChatComposeTarget(ThreadId, IsReady: true));
+                new ChatComposeTarget(DefaultThreadId, IsReady: true));
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -55,6 +55,35 @@ public sealed partial class SessionsPage : Page
 
         var client = CurrentApp.GatewayClient;
 
+        // The real-process accessibility suite has no gateway. Give it an
+        // isolated, deterministic duplicate-name scenario so UI Automation can
+        // prove both the rendered titles and the row-to-chat key hand-off.
+        // Requiring the test data directory as well as the explicit flag keeps
+        // this path unreachable from a normal app launch.
+        if (Environment.GetEnvironmentVariable("OPENCLAW_ACCESSIBILITY_TEST_SESSIONS") == "1"
+            && Environment.GetEnvironmentVariable("OPENCLAW_TRAY_DATA_DIR") is { Length: > 0 })
+        {
+            UpdateSessions(
+            [
+                new SessionInfo
+                {
+                    Key = "agent:main:main",
+                    IsMain = true,
+                    Status = "active",
+                    DisplayName = "OpenClaw Windows Tray",
+                    UpdatedAt = DateTime.UtcNow,
+                },
+                new SessionInfo
+                {
+                    Key = "agent:main:fork",
+                    Status = "active",
+                    DisplayName = "OpenClaw Windows Tray",
+                    UpdatedAt = DateTime.UtcNow.AddSeconds(-1),
+                },
+            ]);
+            return;
+        }
+
         // Rebind when the client instance changes so a cached page never holds
         // a stale command-result subscription.
         if (_subscribedClient != client)
@@ -161,18 +190,23 @@ public sealed partial class SessionsPage : Page
             return;
         }
 
-        IEnumerable<SessionInfo> filtered = _allSessions ?? Array.Empty<SessionInfo>();
-        filtered = SessionVisibilityFilter.VisibleSessions(filtered, ShowCompletedSessions);
+        var activeSessions = SessionVisibilityFilter.VisibleSessions(
+                _allSessions ?? Array.Empty<SessionInfo>(),
+                ShowCompletedSessions)
+            .ToList();
+        var activeTitles = SessionTitleFormatter.FormatUnique(activeSessions);
+        IEnumerable<(SessionInfo Session, string Title)> filtered = activeSessions
+            .Select((session, index) => (Session: session, Title: activeTitles[index]));
 
         if (_activeChannel != "all")
         {
-            filtered = filtered.Where(s =>
-                string.Equals(s.Channel, _activeChannel, StringComparison.OrdinalIgnoreCase));
+            filtered = filtered.Where(item =>
+                string.Equals(item.Session.Channel, _activeChannel, StringComparison.OrdinalIgnoreCase));
         }
 
         var viewModels = filtered
-            .OrderByDescending(s => s.UpdatedAt ?? s.LastSeen)
-            .Select(s => ToViewModel(s))
+            .OrderByDescending(item => item.Session.UpdatedAt ?? item.Session.LastSeen)
+            .Select(item => ToViewModel(item.Session, item.Title))
             .ToList();
 
         if (viewModels.Count == 0)
@@ -232,7 +266,7 @@ public sealed partial class SessionsPage : Page
         }
     }
 
-    private SessionViewModel ToViewModel(SessionInfo s)
+    private SessionViewModel ToViewModel(SessionInfo s, string displayName)
     {
         var parts = new List<string>(3);
         if (!string.IsNullOrWhiteSpace(s.Provider)) parts.Add(s.Provider!);
@@ -259,7 +293,7 @@ public sealed partial class SessionsPage : Page
         return new SessionViewModel
         {
             Key = s.Key,
-            DisplayName = !string.IsNullOrWhiteSpace(s.DisplayName) ? s.DisplayName! : s.Key,
+            DisplayName = displayName,
             AgeText = s.AgeText,
             DetailLine = parts.Count > 0 ? string.Join(" · ", parts) : "",
             StatusBrush = ResolveStatusBrush(s),

--- a/src/OpenClaw.Tray.WinUI/Services/SessionTitleFormatter.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SessionTitleFormatter.cs
@@ -1,0 +1,139 @@
+using OpenClaw.Shared;
+
+namespace OpenClawTray.Services;
+
+/// <summary>
+/// Builds stable, human-readable titles for gateway sessions.
+/// </summary>
+internal static class SessionTitleFormatter
+{
+    /// <summary>
+    /// Formats a session title and qualifies non-canonical agent sessions with
+    /// their agent and slot so identical gateway display names remain distinct.
+    /// </summary>
+    public static string Format(SessionInfo session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        var baseName = !string.IsNullOrWhiteSpace(session.DisplayName)
+            ? session.DisplayName!
+            : (session.IsMain ? "OpenClaw Windows Tray" : session.ShortKey);
+
+        // Keys follow agent:{agentId}:{sessionSlot}, for example
+        // agent:main:main or agent:assistant:review.
+        var parts = (session.Key ?? string.Empty).Split(':');
+        if (parts.Length < 3 || !string.Equals(parts[0], "agent", StringComparison.Ordinal))
+            return baseName;
+
+        var agentId = parts[1];
+        var sessionSlot = parts[2];
+
+        if (agentId == "main" && sessionSlot == "main")
+            return baseName;
+
+        var qualifier = agentId == sessionSlot
+            ? agentId
+            : $"{agentId}/{sessionSlot}";
+
+        return $"{baseName} ({qualifier})";
+    }
+
+    /// <summary>
+    /// Formats a collection of sessions and adds stable numeric suffixes only
+    /// when the normal key qualifier still leaves duplicate visible titles.
+    /// The returned titles are aligned with the input collection.
+    /// </summary>
+    public static IReadOnlyList<string> FormatUnique(IReadOnlyList<SessionInfo> sessions)
+    {
+        ArgumentNullException.ThrowIfNull(sessions);
+
+        if (sessions.Count == 0)
+            return Array.Empty<string>();
+
+        var baseTitles = new string[sessions.Count];
+        for (var i = 0; i < sessions.Count; i++)
+            baseTitles[i] = Format(sessions[i]);
+
+        // Reserve every natural title before adding counters so a generated
+        // title such as "Research (2)" cannot collide with another row whose
+        // actual display name is already "Research (2)".
+        var reservedTitles = new HashSet<string>(baseTitles, StringComparer.OrdinalIgnoreCase);
+        var assignedTitles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var results = new string[sessions.Count];
+
+        foreach (var group in Enumerable.Range(0, sessions.Count)
+                     .GroupBy(index => baseTitles[index], StringComparer.OrdinalIgnoreCase))
+        {
+            var orderedIndices = group
+                .OrderByDescending(index => IsCanonicalMain(sessions[index]))
+                .ThenBy(index => sessions[index].Key ?? string.Empty, StringComparer.Ordinal)
+                .ThenBy(index => index)
+                .ToArray();
+
+            var primaryTitle = baseTitles[orderedIndices[0]];
+            results[orderedIndices[0]] = primaryTitle;
+            assignedTitles.Add(primaryTitle);
+
+            var suffix = 2;
+            for (var i = 1; i < orderedIndices.Length; i++)
+            {
+                string candidate;
+                do
+                {
+                    candidate = $"{primaryTitle} ({suffix})";
+                    suffix++;
+                }
+                while (reservedTitles.Contains(candidate) || !assignedTitles.Add(candidate));
+
+                results[orderedIndices[i]] = candidate;
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Formats one session in the context of its active peers.
+    /// </summary>
+    public static string Format(SessionInfo session, IReadOnlyList<SessionInfo> sessions)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(sessions);
+
+        var index = -1;
+        for (var i = 0; i < sessions.Count; i++)
+        {
+            if (ReferenceEquals(session, sessions[i]))
+            {
+                index = i;
+                break;
+            }
+        }
+
+        if (index < 0)
+        {
+            for (var i = 0; i < sessions.Count; i++)
+            {
+                if (string.Equals(session.Key, sessions[i].Key, StringComparison.Ordinal))
+                {
+                    index = i;
+                    break;
+                }
+            }
+        }
+
+        return index >= 0 ? FormatUnique(sessions)[index] : Format(session);
+    }
+
+    private static bool IsCanonicalMain(SessionInfo session)
+    {
+        if (session.IsMain)
+            return true;
+
+        var parts = (session.Key ?? string.Empty).Split(':');
+        return parts.Length >= 3
+            && string.Equals(parts[0], "agent", StringComparison.Ordinal)
+            && string.Equals(parts[1], "main", StringComparison.Ordinal)
+            && string.Equals(parts[2], "main", StringComparison.Ordinal);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\DiagnosticsBundleBuilder.cs" Link="Services\DiagnosticsBundleBuilder.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SettingsManager.cs" Link="Services\SettingsManager.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SessionVisibilityFilter.cs" Link="Services\SessionVisibilityFilter.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SessionTitleFormatter.cs" Link="Services\SessionTitleFormatter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\OnboardingChatBootstrapper.cs" Link="Services\OnboardingChatBootstrapper.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\StartupSetupState.cs" Link="Services\StartupSetupState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SetupExistingGatewayClassifier.cs" Link="Services\SetupExistingGatewayClassifier.cs" />

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -175,6 +175,24 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
+    public async Task LoadAsync_DistinguishesDuplicateMultiSegmentSessionTitles()
+    {
+        var sessions = new[]
+        {
+            new SessionInfo { Key = "agent:main:subagent:uuid-b", DisplayName = "Research" },
+            new SessionInfo { Key = "agent:main:subagent:uuid-a", DisplayName = "Research" },
+        };
+        var (_, provider, _, _) = CreateProvider(sessions);
+
+        var snapshot = await provider.LoadAsync();
+
+        Assert.Equal(2, snapshot.Threads.Select(thread => thread.Title)
+            .Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        Assert.Equal("agent:main:subagent:uuid-b", snapshot.Threads[0].Id);
+        Assert.Equal("agent:main:subagent:uuid-a", snapshot.Threads[1].Id);
+    }
+
+    [Fact]
     public async Task LoadAsync_CarriesSessionModelProviderToThreads()
     {
         var session = MainSession();

--- a/tests/OpenClaw.Tray.Tests/SessionTitleFormatterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SessionTitleFormatterTests.cs
@@ -1,0 +1,148 @@
+using OpenClaw.Shared;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class SessionTitleFormatterTests
+{
+    [Fact]
+    public void Format_DistinguishesForkFromCanonicalSessionWithSameDisplayName()
+    {
+        var canonical = new SessionInfo
+        {
+            Key = "agent:main:main",
+            IsMain = true,
+            DisplayName = "OpenClaw Windows Tray",
+        };
+        var fork = new SessionInfo
+        {
+            Key = "agent:main:fork",
+            DisplayName = "OpenClaw Windows Tray",
+        };
+
+        var canonicalTitle = SessionTitleFormatter.Format(canonical);
+        var forkTitle = SessionTitleFormatter.Format(fork);
+
+        Assert.Equal("OpenClaw Windows Tray", canonicalTitle);
+        Assert.Equal("OpenClaw Windows Tray (main/fork)", forkTitle);
+        Assert.NotEqual(canonicalTitle, forkTitle);
+        Assert.Equal("agent:main:main", canonical.Key);
+        Assert.Equal("agent:main:fork", fork.Key);
+    }
+
+    [Theory]
+    [InlineData("agent:assistant:assistant", "Research", "Research (assistant)")]
+    [InlineData("agent:assistant:review", "Research", "Research (assistant/review)")]
+    [InlineData("legacy-session", "Research", "Research")]
+    public void Format_UsesStableKeyQualifier(string key, string displayName, string expected)
+    {
+        var session = new SessionInfo { Key = key, DisplayName = displayName };
+
+        Assert.Equal(expected, SessionTitleFormatter.Format(session));
+    }
+
+    [Fact]
+    public void Format_PreservesExistingMissingDisplayNameFallbacks()
+    {
+        var main = new SessionInfo { Key = "agent:main:main", IsMain = true };
+        var worker = new SessionInfo { Key = "agent:assistant:review" };
+
+        Assert.Equal("OpenClaw Windows Tray", SessionTitleFormatter.Format(main));
+        Assert.Equal("assistant (assistant/review)", SessionTitleFormatter.Format(worker));
+    }
+
+    [Fact]
+    public void FormatUnique_DistinguishesMultiSegmentKeysWithSamePrefix()
+    {
+        var sessions = new[]
+        {
+            new SessionInfo { Key = "agent:main:subagent:uuid-b", DisplayName = "Research" },
+            new SessionInfo { Key = "agent:main:subagent:uuid-a", DisplayName = "Research" },
+        };
+
+        var titles = SessionTitleFormatter.FormatUnique(sessions);
+
+        Assert.Equal("Research (main/subagent) (2)", titles[0]);
+        Assert.Equal("Research (main/subagent)", titles[1]);
+        Assert.Equal(2, titles.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+
+    [Fact]
+    public void FormatUnique_DistinguishesLegacyKeysWithoutExposingThem()
+    {
+        var sessions = new[]
+        {
+            new SessionInfo { Key = "legacy-b", DisplayName = "Research" },
+            new SessionInfo { Key = "legacy-a", DisplayName = "Research" },
+        };
+
+        var titles = SessionTitleFormatter.FormatUnique(sessions);
+
+        Assert.Equal("Research (2)", titles[0]);
+        Assert.Equal("Research", titles[1]);
+        Assert.DoesNotContain("legacy", string.Join(" ", titles), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void FormatUnique_DoesNotCollideWithNaturalNumberedTitle()
+    {
+        var sessions = new[]
+        {
+            new SessionInfo { Key = "legacy-a", DisplayName = "Research" },
+            new SessionInfo { Key = "legacy-b", DisplayName = "Research" },
+            new SessionInfo { Key = "legacy-c", DisplayName = "Research (2)" },
+        };
+
+        var titles = SessionTitleFormatter.FormatUnique(sessions);
+
+        Assert.Equal(new[] { "Research", "Research (3)", "Research (2)" }, titles);
+        Assert.Equal(3, titles.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+
+    [Fact]
+    public void FormatUnique_AssignmentRemainsStableWhenCallerFiltersSubset()
+    {
+        var sessions = new[]
+        {
+            new SessionInfo { Key = "legacy-a", DisplayName = "Research", Channel = "Slack" },
+            new SessionInfo { Key = "legacy-b", DisplayName = "Research", Channel = "WhatsApp" },
+        };
+        var titles = SessionTitleFormatter.FormatUnique(sessions);
+        var titledSessions = sessions
+            .Select((session, index) => (Session: session, Title: titles[index]));
+
+        var whatsAppTitle = titledSessions
+            .Single(item => item.Session.Channel == "WhatsApp")
+            .Title;
+
+        Assert.Equal("Research (2)", whatsAppTitle);
+    }
+
+    [Fact]
+    public void SessionsPage_UsesSharedSessionTitleFormatter()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Pages",
+            "SessionsPage.xaml.cs"));
+
+        var formatIndex = source.IndexOf("SessionTitleFormatter.FormatUnique(activeSessions)", StringComparison.Ordinal);
+        var channelFilterIndex = source.IndexOf("if (_activeChannel != \"all\")", StringComparison.Ordinal);
+
+        Assert.True(formatIndex >= 0);
+        Assert.True(channelFilterIndex > formatIndex);
+        Assert.Contains("ToViewModel(item.Session, item.Title)", source, StringComparison.Ordinal);
+        Assert.Contains("DisplayName = displayName", source, StringComparison.Ordinal);
+        Assert.Contains("Key = s.Key", source, StringComparison.Ordinal);
+
+        var xaml = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Pages",
+            "SessionsPage.xaml"));
+        Assert.Contains("Tag=\"{Binding Key}\"", xaml, StringComparison.Ordinal);
+    }
+}

--- a/tests/OpenClaw.Tray.UITests/AccessibilityAppFixture.cs
+++ b/tests/OpenClaw.Tray.UITests/AccessibilityAppFixture.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Imaging;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -15,6 +18,10 @@ namespace OpenClaw.Tray.UITests;
 public sealed class AccessibilityAppFixture : IDisposable
 {
     private const int ShowMaximized = 3;
+    private const int VirtualScreenLeft = 76;
+    private const int VirtualScreenTop = 77;
+    private const int VirtualScreenWidth = 78;
+    private const int VirtualScreenHeight = 79;
     private static readonly TimeSpan StartupTimeout = TimeSpan.FromSeconds(60);
     private static readonly TimeSpan DeepLinkTimeout = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan NavigationTimeout = TimeSpan.FromSeconds(10);
@@ -78,6 +85,76 @@ public sealed class AccessibilityAppFixture : IDisposable
         await WaitForPageMarkerAsync(pageTag, pageMarkerAutomationId);
     }
 
+    public string? CaptureHubScreenshotIfRequested()
+    {
+        var configuredPath = Environment.GetEnvironmentVariable("OPENCLAW_UI_SCREENSHOT_PATH");
+        if (string.IsNullOrWhiteSpace(configuredPath))
+            return null;
+
+        EnsureTargetIsAlive();
+        var foreground = false;
+        for (var attempt = 0; attempt < 20; attempt++)
+        {
+            _ = ShowWindow(HubWindowHandle, ShowMaximized);
+            _ = BringWindowToTop(HubWindowHandle);
+            _ = SetForegroundWindow(HubWindowHandle);
+            if (GetForegroundWindow() == HubWindowHandle)
+            {
+                foreground = true;
+                break;
+            }
+            Thread.Sleep(100);
+        }
+        if (!foreground)
+            throw new InvalidOperationException("Could not foreground the Hub window for screenshot capture.");
+        Thread.Sleep(500);
+
+        var bounds = AutomationElement.FromHandle(HubWindowHandle).Current.BoundingRectangle;
+        var screenLeft = GetSystemMetrics(VirtualScreenLeft);
+        var screenTop = GetSystemMetrics(VirtualScreenTop);
+        var screenRight = screenLeft + GetSystemMetrics(VirtualScreenWidth);
+        var screenBottom = screenTop + GetSystemMetrics(VirtualScreenHeight);
+        var left = Math.Max(screenLeft, (int)Math.Floor(bounds.Left));
+        var top = Math.Max(screenTop, (int)Math.Floor(bounds.Top));
+        var right = Math.Min(screenRight, (int)Math.Ceiling(bounds.Right));
+        var bottom = Math.Min(screenBottom, (int)Math.Ceiling(bounds.Bottom));
+        var width = right - left;
+        var height = bottom - top;
+        if (width <= 0 || height <= 0)
+            throw new InvalidOperationException($"Hub screenshot bounds were invalid: {width}x{height}.");
+
+        var path = Path.GetFullPath(configuredPath, Environment.CurrentDirectory);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        using var bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+        using (var graphics = Graphics.FromImage(bitmap))
+        {
+            graphics.CopyFromScreen(
+                left,
+                top,
+                0,
+                0,
+                new Size(width, height),
+                CopyPixelOperation.SourceCopy);
+        }
+
+        var sampledColors = new HashSet<int>();
+        var stepX = Math.Max(1, width / 32);
+        var stepY = Math.Max(1, height / 32);
+        for (var y = 0; y < height && sampledColors.Count < 8; y += stepY)
+        {
+            for (var x = 0; x < width && sampledColors.Count < 8; x += stepX)
+                sampledColors.Add(bitmap.GetPixel(x, y).ToArgb());
+        }
+        if (sampledColors.Count < 3)
+            throw new InvalidOperationException("Hub screenshot capture was blank or near-uniform.");
+
+        bitmap.Save(path, ImageFormat.Png);
+
+        if (new FileInfo(path).Length == 0)
+            throw new InvalidOperationException("Hub screenshot capture produced an empty file.");
+        return path;
+    }
+
     private async Task WaitForPageMarkerAsync(string pageTag, string automationId)
     {
         var stopwatch = Stopwatch.StartNew();
@@ -111,7 +188,9 @@ public sealed class AccessibilityAppFixture : IDisposable
         startInfo.Environment["OPENCLAW_TRAY_DATA_DIR"] = _dataDirectory;
         startInfo.Environment["OPENCLAW_SKIP_UPDATE_CHECK"] = "1";
         startInfo.Environment["OPENCLAW_FORCE_ONBOARDING"] = "0";
+        startInfo.Environment["OPENCLAW_LANGUAGE"] = "en-US";
         startInfo.Environment["OPENCLAW_ACCESSIBILITY_TEST_CHAT"] = "1";
+        startInfo.Environment["OPENCLAW_ACCESSIBILITY_TEST_SESSIONS"] = "1";
 
         return Process.Start(startInfo)
             ?? throw new InvalidOperationException("Failed to start the OpenClaw tray executable.");
@@ -174,4 +253,18 @@ public sealed class AccessibilityAppFixture : IDisposable
 
     [DllImport("user32.dll")]
     private static extern int ShowWindow(IntPtr windowHandle, int command);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetForegroundWindow(IntPtr windowHandle);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool BringWindowToTop(IntPtr windowHandle);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
+
+    [DllImport("user32.dll")]
+    private static extern int GetSystemMetrics(int index);
 }

--- a/tests/OpenClaw.Tray.UITests/SessionTitleBehaviorProofTests.cs
+++ b/tests/OpenClaw.Tray.UITests/SessionTitleBehaviorProofTests.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Automation;
+using Xunit.Abstractions;
+
+namespace OpenClaw.Tray.UITests;
+
+[Collection(AccessibilityCollection.Name)]
+public sealed class SessionTitleBehaviorProofTests
+{
+    private const string RawTitle = "OpenClaw Windows Tray";
+    private const string ForkTitle = "OpenClaw Windows Tray (main/fork)";
+    private static readonly TimeSpan UiTimeout = TimeSpan.FromSeconds(15);
+
+    private readonly AccessibilityAppFixture _app;
+    private readonly ITestOutputHelper _output;
+
+    public SessionTitleBehaviorProofTests(
+        AccessibilityAppFixture app,
+        ITestOutputHelper output)
+    {
+        _app = app;
+        _output = output;
+    }
+
+    [Fact]
+    [Trait("Category", "Accessibility")]
+    public async Task DuplicateTitles_RenderDistinctly_AndOpenChatUsesOriginalKeys()
+    {
+        var proof = new List<string>
+        {
+            $"head={Environment.GetEnvironmentVariable("OPENCLAW_UI_PROOF_HEAD") ?? "local"}",
+            $"input key=agent:main:main displayName=\"{RawTitle}\"",
+            $"input key=agent:main:fork displayName=\"{RawTitle}\"",
+        };
+
+        await _app.NavigateAsync("sessions", "SessionsPageMarker");
+        var observedMainTitle = WaitForTitleCount(RawTitle, expectedCount: 1);
+        var observedForkTitle = WaitForTitleCount(ForkTitle, expectedCount: 1);
+        proof.Add($"UIA title key=agent:main:main value=\"{observedMainTitle}\"");
+        proof.Add($"UIA title key=agent:main:fork value=\"{observedForkTitle}\"");
+        if (_app.CaptureHubScreenshotIfRequested() is { } screenshotPath)
+        {
+            proof.Add(
+                $"screenshot={Path.GetFileName(screenshotPath)} " +
+                $"bytes={new FileInfo(screenshotPath).Length}");
+        }
+
+        AssertOpenChatRoute(RawTitle, "agent:main:main", proof);
+        await _app.NavigateAsync("sessions", "SessionsPageMarker");
+        _ = WaitForTitleCount(ForkTitle, expectedCount: 1);
+        AssertOpenChatRoute(ForkTitle, "agent:main:fork", proof);
+
+        proof.Add("result=pass");
+        foreach (var line in proof)
+            _output.WriteLine(line);
+
+        WriteProofArtifactIfRequested(proof);
+    }
+
+    private void AssertOpenChatRoute(
+        string visibleTitle,
+        string expectedSessionKey,
+        ICollection<string> proof)
+    {
+        InvokeOpenChat(visibleTitle);
+        var routeTitle = $"Route target: {expectedSessionKey}";
+        var selectedRouteTitle = WaitForSelectedSession(routeTitle);
+        proof.Add(
+            $"UIA open-chat title=\"{visibleTitle}\" " +
+            $"selectedThread=\"{selectedRouteTitle}\" selectedKey={expectedSessionKey}");
+    }
+
+    private string WaitForTitleCount(string title, int expectedCount)
+    {
+        var condition = new AndCondition(
+            new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.Text),
+            new PropertyCondition(AutomationElement.NameProperty, title));
+
+        WaitUntil(() =>
+        {
+            var hub = AutomationElement.FromHandle(_app.HubWindowHandle);
+            return hub.FindAll(TreeScope.Descendants, condition).Count == expectedCount;
+        }, $"UIA title '{title}' to appear exactly {expectedCount} time(s)");
+
+        var finalHub = AutomationElement.FromHandle(_app.HubWindowHandle);
+        var matches = finalHub.FindAll(TreeScope.Descendants, condition);
+        Assert.Equal(expectedCount, matches.Count);
+        return Assert.Single(
+            Enumerable.Range(0, matches.Count)
+                .Select(index => matches[index].Current.Name));
+    }
+
+    private void InvokeOpenChat(string visibleTitle)
+    {
+        var titleCondition = new AndCondition(
+            new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.Text),
+            new PropertyCondition(AutomationElement.NameProperty, visibleTitle));
+        var hub = AutomationElement.FromHandle(_app.HubWindowHandle);
+        var titleElement = hub.FindFirst(TreeScope.Descendants, titleCondition);
+        Assert.NotNull(titleElement);
+
+        var row = FindAncestor(titleElement!, ControlType.ListItem);
+        Assert.NotNull(row);
+
+        var buttonCondition = new AndCondition(
+            new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.Button),
+            new PropertyCondition(AutomationElement.NameProperty, "Open in chat"));
+        var button = row!.FindFirst(TreeScope.Descendants, buttonCondition);
+        Assert.NotNull(button);
+        Assert.True(button!.TryGetCurrentPattern(InvokePattern.Pattern, out var pattern));
+        Assert.IsType<InvokePattern>(pattern).Invoke();
+    }
+
+    private string WaitForSelectedSession(string expectedRouteTitle)
+    {
+        var composerCondition = new PropertyCondition(
+            AutomationElement.AutomationIdProperty,
+            "ChatComposerInput");
+        var sessionSelectorCondition = new AndCondition(
+            new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.ComboBox),
+            new PropertyCondition(AutomationElement.NameProperty, "Session"));
+
+        string? selectedRouteTitle = null;
+        WaitUntil(() =>
+        {
+            var hub = AutomationElement.FromHandle(_app.HubWindowHandle);
+            if (hub.FindFirst(TreeScope.Descendants, composerCondition) is null)
+                return false;
+
+            var selector = hub.FindFirst(TreeScope.Descendants, sessionSelectorCondition);
+            if (selector is null
+                || !selector.TryGetCurrentPattern(SelectionPattern.Pattern, out var pattern)
+                || pattern is not SelectionPattern selection)
+            {
+                return false;
+            }
+
+            selectedRouteTitle = selection.Current.GetSelection()
+                .Select(item => item.Current.Name)
+                .SingleOrDefault();
+            return string.Equals(
+                selectedRouteTitle,
+                expectedRouteTitle,
+                StringComparison.Ordinal);
+        }, $"chat Session selector to choose '{expectedRouteTitle}'");
+
+        return Assert.IsType<string>(selectedRouteTitle);
+    }
+
+    private static AutomationElement? FindAncestor(
+        AutomationElement element,
+        ControlType controlType)
+    {
+        var walker = TreeWalker.ControlViewWalker;
+        var current = element;
+        for (var depth = 0; depth < 12; depth++)
+        {
+            if (current.Current.ControlType == controlType)
+                return current;
+            current = walker.GetParent(current);
+            if (current is null)
+                return null;
+        }
+        return null;
+    }
+
+    private static void WaitUntil(Func<bool> predicate, string description)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < UiTimeout)
+        {
+            try
+            {
+                if (predicate())
+                    return;
+            }
+            catch (ElementNotAvailableException)
+            {
+                // Navigation replaces the active automation subtree; retry it.
+            }
+
+            Thread.Sleep(100);
+        }
+
+        throw new TimeoutException(
+            $"Timed out waiting for {description} after {UiTimeout.TotalSeconds:0} seconds.");
+    }
+
+    private static void WriteProofArtifactIfRequested(IReadOnlyCollection<string> proof)
+    {
+        var configuredPath = Environment.GetEnvironmentVariable("OPENCLAW_UI_PROOF_PATH");
+        if (string.IsNullOrWhiteSpace(configuredPath))
+            return;
+
+        var path = Path.GetFullPath(configuredPath, Environment.CurrentDirectory);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllLines(path, proof);
+    }
+}


### PR DESCRIPTION
Closes #954.

This is the #955 app/test change set without the optional `.github/workflows/ci.yml` proof-summary plumbing, so it can be merged by maintainers whose token does not have `workflow` scope.

## Summary
- Reuse one session-title formatter across native Chat and the Sessions page.
- Add deterministic suffixes when key-derived qualifiers still collide, without exposing raw session keys.
- Preserve original keys for navigation and session actions.

## Validation
- Focused local test on this exact clean branch:
  - `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore --filter "SessionTitleFormatterTests|OpenClawChatDataProviderTests"` — passed: 234 passed.
- Original #955 exact-head Windows CI passed: Shared, Tray, Connection, CLI, Integration, Functional UI, SetupEngine, Tray UI, accessibility/real-process UI proof, E2E shards, win-x64 and win-arm64 builds.

## Real behavior proof
- Maintainer ran #955 locally against a real profile containing duplicate session titles and approved the behavior.
- Original #955 UIA proof showed duplicate `OpenClaw Windows Tray` sessions rendered distinctly and Open Chat preserved the original session keys.
