### PR TITLE
Fix Discord bot token configuration

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
@@ -814,7 +814,7 @@ public sealed partial class ChannelsPage : Page
             stack.Children.Add(BuildLinkingPlaceholder(record));
 
         // Configuration section — inline credential form for channels we have
-        // explicit field definitions for (Telegram bot token, Discord webhook,
+        // explicit field definitions for (Telegram/Discord bot tokens,
         // Slack tokens, Google Chat webhook, Nostr key/relays).
         //
         // For configured channels the section header reads "Replace
@@ -1067,7 +1067,7 @@ public sealed partial class ChannelsPage : Page
             "whatsapp"   => (LocalizationHelper.GetString("ChannelsPage_HelpWhatsApp"),     "https://faq.whatsapp.com/378279004439436/"),
             "signal"     => (LocalizationHelper.GetString("ChannelsPage_HelpSignal"),       "https://support.signal.org/hc/en-us/articles/360007320551"),
             "telegram"   => (LocalizationHelper.GetString("ChannelsPage_HelpTelegram"),     "https://core.telegram.org/bots/features#botfather"),
-            "discord"    => (LocalizationHelper.GetString("ChannelsPage_HelpDiscord"),  "https://support.discord.com/hc/en-us/articles/228383668"),
+            "discord"    => (LocalizationHelper.GetString("ChannelsPage_HelpDiscord"),  "https://discord.com/developers/applications"),
             "googlechat" => (LocalizationHelper.GetString("ChannelsPage_HelpGoogleChat"), "https://developers.google.com/chat/how-tos/webhooks"),
             "slack"      => (LocalizationHelper.GetString("ChannelsPage_HelpSlack"),              "https://api.slack.com/apps"),
             "nostr"      => (LocalizationHelper.GetString("ChannelsPage_HelpNostr"),                      "https://nostr.com/"),
@@ -1160,7 +1160,7 @@ public sealed partial class ChannelsPage : Page
     /// Per-channel inline-form schema. Fields were validated against the
     /// gateway test fixtures (src/cli/config-cli.test.ts and related tests
     /// confirm channels.telegram.botToken, channels.slack.botToken/signingSecret,
-    /// channels.discord.webhookUrl, etc.). Returns null for channels without an
+    /// channels.discord.token, etc.). Returns null for channels without an
     /// inline form — those still get the "Open Config page" stub.
     /// </summary>
     private static IReadOnlyList<ConfigField>? ResolveConfigFields(string channelId) =>
@@ -1179,12 +1179,12 @@ public sealed partial class ChannelsPage : Page
             "discord" => new[]
             {
                 new ConfigField(
-                    "channels.discord.webhookUrl",
-                    LocalizationHelper.GetString("ChannelsPage_FieldWebhookUrl"),
-                    "https://discord.com/api/webhooks/...",
+                    "channels.discord.token",
+                    LocalizationHelper.GetString("ChannelsPage_FieldDiscordBotToken"),
+                    LocalizationHelper.GetString("ChannelsPage_PlaceholderDiscordBotToken"),
                     Sensitive: true,
                     Required: true,
-                    HelpText: LocalizationHelper.GetString("ChannelsPage_HelpWebhookDiscord")),
+                    HelpText: LocalizationHelper.GetString("ChannelsPage_HelpDiscordBotToken")),
             },
             "googlechat" => new[]
             {
@@ -2357,7 +2357,7 @@ public sealed partial class ChannelsPage : Page
     {
         "whatsapp"   => "Link your phone — scan a QR to connect",
         "telegram"   => "Bot integration — paste your bot token to set up",
-        "discord"    => "Webhook integration — paste a Discord webhook URL",
+        "discord"    => "Bot integration — paste your Discord bot token",
         "googlechat" => "Webhook integration — paste a Google Chat webhook",
         "slack"      => "OAuth app — install a Slack app to connect",
         "signal"     => "Link your phone — scan a QR to connect",

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -5626,7 +5626,7 @@ Make sure the gateway is running.</value>
     <value>How to create a Telegram bot →</value>
   </data>
   <data name="ChannelsPage_HelpDiscord" xml:space="preserve">
-    <value>How to create a Discord webhook →</value>
+    <value>How to create a Discord bot →</value>
   </data>
   <data name="ChannelsPage_HelpGoogleChat" xml:space="preserve">
     <value>How to add a Google Chat webhook →</value>
@@ -5680,19 +5680,19 @@ Make sure the gateway is running.</value>
     <value>Click &quot;Save and start&quot;. The channel will start automatically.</value>
   </data>
   <data name="ChannelsPage_GuideDiscordHeadline" xml:space="preserve">
-    <value>Connect Discord via a webhook</value>
+    <value>Connect Discord via a bot</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep1" xml:space="preserve">
-    <value>Open your Discord server settings → Integrations → Webhooks.</value>
+    <value>Open the Discord Developer Portal, then create or select an application.</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep2" xml:space="preserve">
-    <value>Click &quot;New Webhook&quot;, give it a name, and copy the webhook URL.</value>
+    <value>Open Bot, add a bot if needed, then reset and copy its token.</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep3" xml:space="preserve">
-    <value>Paste the URL into the Configuration form below.</value>
+    <value>Paste the bot token into the Configuration form below.</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep4" xml:space="preserve">
-    <value>Click &quot;Save and start&quot;.</value>
+    <value>Click &quot;Save and start&quot;, then add the bot to your server with its OAuth2 installation link.</value>
   </data>
   <data name="ChannelsPage_GuideGoogleChatHeadline" xml:space="preserve">
     <value>Connect Google Chat via a webhook</value>
@@ -5766,6 +5766,12 @@ Make sure the gateway is running.</value>
   <data name="ChannelsPage_FieldBotToken" xml:space="preserve">
     <value>Bot token</value>
   </data>
+  <data name="ChannelsPage_FieldDiscordBotToken" xml:space="preserve">
+    <value>Discord Bot Token</value>
+  </data>
+  <data name="ChannelsPage_PlaceholderDiscordBotToken" xml:space="preserve">
+    <value>Paste Discord bot token</value>
+  </data>
   <data name="ChannelsPage_FieldWebhookUrl" xml:space="preserve">
     <value>Webhook URL</value>
   </data>
@@ -5781,8 +5787,8 @@ Make sure the gateway is running.</value>
   <data name="ChannelsPage_HelpBotToken" xml:space="preserve">
     <value>Get from @BotFather (/newbot).</value>
   </data>
-  <data name="ChannelsPage_HelpWebhookDiscord" xml:space="preserve">
-    <value>Server Settings → Integrations → Webhooks → New Webhook.</value>
+  <data name="ChannelsPage_HelpDiscordBotToken" xml:space="preserve">
+    <value>Copy from Discord Developer Portal → Bot → Reset Token.</value>
   </data>
   <data name="ChannelsPage_HelpWebhookGoogleChat" xml:space="preserve">
     <value>Open a space → Manage webhooks → Add webhook.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -5622,7 +5622,7 @@ Assurez-vous que la passerelle est en cours d'exécution.</value>
     <value>Comment créer un bot Telegram →</value>
   </data>
   <data name="ChannelsPage_HelpDiscord" xml:space="preserve">
-    <value>Comment créer un webhook Discord →</value>
+    <value>Comment créer un bot Discord →</value>
   </data>
   <data name="ChannelsPage_HelpGoogleChat" xml:space="preserve">
     <value>Comment ajouter un webhook Google Chat →</value>
@@ -5676,19 +5676,19 @@ Assurez-vous que la passerelle est en cours d'exécution.</value>
     <value>Cliquez sur "Save and start". Le canal démarrera automatiquement.</value>
   </data>
   <data name="ChannelsPage_GuideDiscordHeadline" xml:space="preserve">
-    <value>Connecter Discord via un webhook</value>
+    <value>Connecter Discord via un bot</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep1" xml:space="preserve">
-    <value>Ouvrez les paramètres de votre serveur Discord → Intégrations → Webhooks.</value>
+    <value>Ouvrez le portail des développeurs Discord, puis créez ou sélectionnez une application.</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep2" xml:space="preserve">
-    <value>Cliquez sur "New Webhook", donnez-lui un nom et copiez l’URL du webhook.</value>
+    <value>Ouvrez Bot, ajoutez un bot si nécessaire, puis réinitialisez et copiez son jeton.</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep3" xml:space="preserve">
-    <value>Collez l’URL dans le formulaire de configuration ci-dessous.</value>
+    <value>Collez le jeton du bot dans le formulaire de configuration ci-dessous.</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep4" xml:space="preserve">
-    <value>Cliquez sur "Save and start".</value>
+    <value>Cliquez sur "Save and start", puis ajoutez le bot à votre serveur avec son lien d’installation OAuth2.</value>
   </data>
   <data name="ChannelsPage_GuideGoogleChatHeadline" xml:space="preserve">
     <value>Connecter Google Chat via un webhook</value>
@@ -5762,6 +5762,12 @@ Assurez-vous que la passerelle est en cours d'exécution.</value>
   <data name="ChannelsPage_FieldBotToken" xml:space="preserve">
     <value>Jeton du bot</value>
   </data>
+  <data name="ChannelsPage_FieldDiscordBotToken" xml:space="preserve">
+    <value>Jeton du bot Discord</value>
+  </data>
+  <data name="ChannelsPage_PlaceholderDiscordBotToken" xml:space="preserve">
+    <value>Collez le jeton du bot Discord</value>
+  </data>
   <data name="ChannelsPage_FieldWebhookUrl" xml:space="preserve">
     <value>URL du webhook</value>
   </data>
@@ -5777,8 +5783,8 @@ Assurez-vous que la passerelle est en cours d'exécution.</value>
   <data name="ChannelsPage_HelpBotToken" xml:space="preserve">
     <value>Obtenez-le auprès de @BotFather (/newbot).</value>
   </data>
-  <data name="ChannelsPage_HelpWebhookDiscord" xml:space="preserve">
-    <value>Paramètres du serveur → Intégrations → Webhooks → New Webhook.</value>
+  <data name="ChannelsPage_HelpDiscordBotToken" xml:space="preserve">
+    <value>Copiez-le depuis le portail des développeurs Discord → Bot → Reset Token.</value>
   </data>
   <data name="ChannelsPage_HelpWebhookGoogleChat" xml:space="preserve">
     <value>Ouvrez un espace → Gérer les webhooks → Ajouter un webhook.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -5623,7 +5623,7 @@ Controleer of de gateway actief is.</value>
     <value>Een Telegram-bot aanmaken →</value>
   </data>
   <data name="ChannelsPage_HelpDiscord" xml:space="preserve">
-    <value>Een Discord-webhook aanmaken →</value>
+    <value>Een Discord-bot aanmaken →</value>
   </data>
   <data name="ChannelsPage_HelpGoogleChat" xml:space="preserve">
     <value>Een Google Chat-webhook toevoegen →</value>
@@ -5677,19 +5677,19 @@ Controleer of de gateway actief is.</value>
     <value>Klik op "Save and start". Het kanaal start automatisch.</value>
   </data>
   <data name="ChannelsPage_GuideDiscordHeadline" xml:space="preserve">
-    <value>Discord verbinden via een webhook</value>
+    <value>Discord verbinden via een bot</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep1" xml:space="preserve">
-    <value>Open uw Discord-serverinstellingen → Integraties → Webhooks.</value>
+    <value>Open de Discord Developer Portal en maak of selecteer een toepassing.</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep2" xml:space="preserve">
-    <value>Klik op "New Webhook", geef het een naam en kopieer de webhook-URL.</value>
+    <value>Open Bot, voeg zo nodig een bot toe en stel het token opnieuw in om het te kopiëren.</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep3" xml:space="preserve">
-    <value>Plak de URL in het configuratieformulier hieronder.</value>
+    <value>Plak het bottoken in het configuratieformulier hieronder.</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep4" xml:space="preserve">
-    <value>Klik op "Save and start".</value>
+    <value>Klik op "Save and start" en voeg de bot daarna toe aan uw server met de OAuth2-installatielink.</value>
   </data>
   <data name="ChannelsPage_GuideGoogleChatHeadline" xml:space="preserve">
     <value>Google Chat verbinden via een webhook</value>
@@ -5763,6 +5763,12 @@ Controleer of de gateway actief is.</value>
   <data name="ChannelsPage_FieldBotToken" xml:space="preserve">
     <value>Bot-token</value>
   </data>
+  <data name="ChannelsPage_FieldDiscordBotToken" xml:space="preserve">
+    <value>Discord-bottoken</value>
+  </data>
+  <data name="ChannelsPage_PlaceholderDiscordBotToken" xml:space="preserve">
+    <value>Plak het Discord-bottoken</value>
+  </data>
   <data name="ChannelsPage_FieldWebhookUrl" xml:space="preserve">
     <value>Webhook-URL</value>
   </data>
@@ -5778,8 +5784,8 @@ Controleer of de gateway actief is.</value>
   <data name="ChannelsPage_HelpBotToken" xml:space="preserve">
     <value>Verkrijg het via @BotFather (/newbot).</value>
   </data>
-  <data name="ChannelsPage_HelpWebhookDiscord" xml:space="preserve">
-    <value>Serverinstellingen → Integraties → Webhooks → New Webhook.</value>
+  <data name="ChannelsPage_HelpDiscordBotToken" xml:space="preserve">
+    <value>Kopieer uit de Discord Developer Portal → Bot → Token opnieuw instellen.</value>
   </data>
   <data name="ChannelsPage_HelpWebhookGoogleChat" xml:space="preserve">
     <value>Open een ruimte → Webhooks beheren → Webhook toevoegen.</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -5622,7 +5622,7 @@
     <value>如何创建 Telegram 机器人 →</value>
   </data>
   <data name="ChannelsPage_HelpDiscord" xml:space="preserve">
-    <value>如何创建 Discord webhook →</value>
+    <value>如何创建 Discord 机器人 →</value>
   </data>
   <data name="ChannelsPage_HelpGoogleChat" xml:space="preserve">
     <value>如何添加 Google Chat webhook →</value>
@@ -5676,19 +5676,19 @@
     <value>点击 "Save and start"。频道将自动启动。</value>
   </data>
   <data name="ChannelsPage_GuideDiscordHeadline" xml:space="preserve">
-    <value>通过 webhook 连接 Discord</value>
+    <value>通过机器人连接 Discord</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep1" xml:space="preserve">
-    <value>打开您的 Discord 服务器设置 → 集成 → Webhooks。</value>
+    <value>打开 Discord 开发者门户，然后创建或选择一个应用。</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep2" xml:space="preserve">
-    <value>点击 "New Webhook"，为其命名，然后复制 webhook URL。</value>
+    <value>打开 Bot，按需添加机器人，然后重置并复制其令牌。</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep3" xml:space="preserve">
-    <value>将 URL 粘贴到下方的配置表单中。</value>
+    <value>将机器人令牌粘贴到下方的配置表单中。</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep4" xml:space="preserve">
-    <value>点击 "Save and start"。</value>
+    <value>点击 "Save and start"，然后使用 OAuth2 安装链接将机器人添加到服务器。</value>
   </data>
   <data name="ChannelsPage_GuideGoogleChatHeadline" xml:space="preserve">
     <value>通过 webhook 连接 Google Chat</value>
@@ -5762,6 +5762,12 @@
   <data name="ChannelsPage_FieldBotToken" xml:space="preserve">
     <value>机器人令牌</value>
   </data>
+  <data name="ChannelsPage_FieldDiscordBotToken" xml:space="preserve">
+    <value>Discord 机器人令牌</value>
+  </data>
+  <data name="ChannelsPage_PlaceholderDiscordBotToken" xml:space="preserve">
+    <value>粘贴 Discord 机器人令牌</value>
+  </data>
   <data name="ChannelsPage_FieldWebhookUrl" xml:space="preserve">
     <value>Webhook 网址</value>
   </data>
@@ -5777,8 +5783,8 @@
   <data name="ChannelsPage_HelpBotToken" xml:space="preserve">
     <value>从 @BotFather (/newbot) 获取。</value>
   </data>
-  <data name="ChannelsPage_HelpWebhookDiscord" xml:space="preserve">
-    <value>服务器设置 → 集成 → Webhooks → New Webhook。</value>
+  <data name="ChannelsPage_HelpDiscordBotToken" xml:space="preserve">
+    <value>从 Discord 开发者门户 → Bot → Reset Token 复制。</value>
   </data>
   <data name="ChannelsPage_HelpWebhookGoogleChat" xml:space="preserve">
     <value>打开聊天室 → 管理 webhook → 添加 webhook。</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -5622,7 +5622,7 @@
     <value>如何建立 Telegram 機器人 →</value>
   </data>
   <data name="ChannelsPage_HelpDiscord" xml:space="preserve">
-    <value>如何建立 Discord webhook →</value>
+    <value>如何建立 Discord 機器人 →</value>
   </data>
   <data name="ChannelsPage_HelpGoogleChat" xml:space="preserve">
     <value>如何新增 Google Chat webhook →</value>
@@ -5676,19 +5676,19 @@
     <value>點擊 "Save and start"。頻道將自動啟動。</value>
   </data>
   <data name="ChannelsPage_GuideDiscordHeadline" xml:space="preserve">
-    <value>透過 webhook 連接 Discord</value>
+    <value>透過機器人連接 Discord</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep1" xml:space="preserve">
-    <value>開啟您的 Discord 伺服器設定 → 整合 → Webhooks。</value>
+    <value>開啟 Discord 開發者入口網站，然後建立或選取應用程式。</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep2" xml:space="preserve">
-    <value>點擊 "New Webhook"，為其命名，然後複製 webhook URL。</value>
+    <value>開啟 Bot，視需要新增機器人，然後重設並複製其權杖。</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep3" xml:space="preserve">
-    <value>將 URL 貼到下方的設定表單中。</value>
+    <value>將機器人權杖貼到下方的設定表單中。</value>
   </data>
   <data name="ChannelsPage_GuideDiscordStep4" xml:space="preserve">
-    <value>點擊 "Save and start"。</value>
+    <value>點擊 "Save and start"，然後使用 OAuth2 安裝連結將機器人新增到伺服器。</value>
   </data>
   <data name="ChannelsPage_GuideGoogleChatHeadline" xml:space="preserve">
     <value>透過 webhook 連接 Google Chat</value>
@@ -5762,6 +5762,12 @@
   <data name="ChannelsPage_FieldBotToken" xml:space="preserve">
     <value>機器人權杖</value>
   </data>
+  <data name="ChannelsPage_FieldDiscordBotToken" xml:space="preserve">
+    <value>Discord 機器人權杖</value>
+  </data>
+  <data name="ChannelsPage_PlaceholderDiscordBotToken" xml:space="preserve">
+    <value>貼上 Discord 機器人權杖</value>
+  </data>
   <data name="ChannelsPage_FieldWebhookUrl" xml:space="preserve">
     <value>Webhook 網址</value>
   </data>
@@ -5777,8 +5783,8 @@
   <data name="ChannelsPage_HelpBotToken" xml:space="preserve">
     <value>從 @BotFather (/newbot) 取得。</value>
   </data>
-  <data name="ChannelsPage_HelpWebhookDiscord" xml:space="preserve">
-    <value>伺服器設定 → 整合 → Webhooks → New Webhook。</value>
+  <data name="ChannelsPage_HelpDiscordBotToken" xml:space="preserve">
+    <value>從 Discord 開發者入口網站 → Bot → Reset Token 複製。</value>
   </data>
   <data name="ChannelsPage_HelpWebhookGoogleChat" xml:space="preserve">
     <value>開啟聊天室 → 管理 webhook → 新增 webhook。</value>

--- a/tests/OpenClaw.Shared.Tests/ChannelConfigPatchBuilderTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ChannelConfigPatchBuilderTests.cs
@@ -49,7 +49,7 @@ public class ChannelConfigPatchBuilderTests
         var existing = Json("""
             {
               "channels": {
-                "discord":  { "webhookUrl": "https://discord.com/api/webhooks/123/abc", "enabled": true },
+                "discord":  { "token": "discord-token", "enabled": true },
                 "telegram": { "botToken": "old-token", "enabled": false }
               }
             }
@@ -64,8 +64,8 @@ public class ChannelConfigPatchBuilderTests
         var channels = patch.GetProperty("channels");
         Assert.Equal("new-token", channels.GetProperty("telegram").GetProperty("botToken").GetString());
         Assert.True(channels.GetProperty("telegram").GetProperty("enabled").GetBoolean()); // forced to true
-        Assert.Equal("https://discord.com/api/webhooks/123/abc",
-            channels.GetProperty("discord").GetProperty("webhookUrl").GetString());
+        Assert.Equal("discord-token",
+            channels.GetProperty("discord").GetProperty("token").GetString());
         Assert.True(channels.GetProperty("discord").GetProperty("enabled").GetBoolean()); // untouched
     }
 
@@ -108,12 +108,12 @@ public class ChannelConfigPatchBuilderTests
 
         var result = ChannelConfigPatchBuilder.BuildPatch(
             empty, "discord",
-            Updates(("channels.discord.webhookUrl", "https://discord.com/api/webhooks/123/abc")));
+            Updates(("channels.discord.token", "discord-token")));
 
         Assert.Null(result.BlockedReason);
         var channels = result.Patch!.Value.GetProperty("channels");
-        Assert.Equal("https://discord.com/api/webhooks/123/abc",
-            channels.GetProperty("discord").GetProperty("webhookUrl").GetString());
+        Assert.Equal("discord-token",
+            channels.GetProperty("discord").GetProperty("token").GetString());
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/ChannelsPageDiscordConfigContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChannelsPageDiscordConfigContractTests.cs
@@ -1,0 +1,88 @@
+using System.Xml.Linq;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class ChannelsPageDiscordConfigContractTests
+{
+    private static readonly string[] DiscordResourceKeys =
+    [
+        "ChannelsPage_HelpDiscord",
+        "ChannelsPage_GuideDiscordHeadline",
+        "ChannelsPage_GuideDiscordStep1",
+        "ChannelsPage_GuideDiscordStep2",
+        "ChannelsPage_GuideDiscordStep3",
+        "ChannelsPage_GuideDiscordStep4",
+        "ChannelsPage_FieldDiscordBotToken",
+        "ChannelsPage_PlaceholderDiscordBotToken",
+        "ChannelsPage_HelpDiscordBotToken",
+    ];
+
+    [Fact]
+    public void DiscordInlineForm_UsesStrictSchemaBotTokenField()
+    {
+        var source = Read("src", "OpenClaw.Tray.WinUI", "Pages", "ChannelsPage.xaml.cs");
+
+        Assert.Contains("\"channels.discord.token\"", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("channels.discord.webhookUrl", source, StringComparison.Ordinal);
+        Assert.Contains("ChannelsPage_FieldDiscordBotToken", source, StringComparison.Ordinal);
+        Assert.Contains("ChannelsPage_PlaceholderDiscordBotToken", source, StringComparison.Ordinal);
+        Assert.Contains("ChannelsPage_HelpDiscordBotToken", source, StringComparison.Ordinal);
+
+        Assert.Contains("\"channels.googlechat.webhookUrl\"", source, StringComparison.Ordinal);
+        Assert.Contains("ChannelsPage_HelpWebhookGoogleChat", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DiscordSetupGuidance_UsesBotInstructionsInEveryLocale()
+    {
+        var stringsRoot = Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Strings");
+
+        foreach (var resourcePath in Directory.EnumerateFiles(stringsRoot, "Resources.resw", SearchOption.AllDirectories))
+        {
+            var resources = XDocument.Load(resourcePath)
+                .Root!
+                .Elements("data")
+                .ToDictionary(
+                    element => element.Attribute("name")!.Value,
+                    element => element.Element("value")!.Value,
+                    StringComparer.Ordinal);
+
+            foreach (var key in DiscordResourceKeys)
+            {
+                Assert.True(resources.TryGetValue(key, out var value), $"{resourcePath} is missing {key}.");
+                Assert.DoesNotContain("webhook", value!, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+    }
+
+    [Fact]
+    public void DiscordEnglishCopy_IdentifiesBotTokenAndDeveloperPortal()
+    {
+        var resourcePath = Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Strings",
+            "en-us",
+            "Resources.resw");
+        var resources = XDocument.Load(resourcePath)
+            .Root!
+            .Elements("data")
+            .ToDictionary(
+                element => element.Attribute("name")!.Value,
+                element => element.Element("value")!.Value,
+                StringComparer.Ordinal);
+
+        Assert.Equal("Discord Bot Token", resources["ChannelsPage_FieldDiscordBotToken"]);
+        Assert.Equal("Paste Discord bot token", resources["ChannelsPage_PlaceholderDiscordBotToken"]);
+        Assert.Contains("Discord Developer Portal", resources["ChannelsPage_HelpDiscordBotToken"], StringComparison.Ordinal);
+        Assert.Equal("Connect Discord via a bot", resources["ChannelsPage_GuideDiscordHeadline"]);
+    }
+
+    private static string Read(params string[] parts)
+        => File.ReadAllText(Path.Combine(new[] { TestRepositoryPaths.GetRepositoryRoot() }.Concat(parts).ToArray()));
+}


### PR DESCRIPTION
Fixes #958

## Summary
- write the Discord inline credential to `channels.discord.token` using a Discord Bot Token field
- replace webhook setup copy with Discord bot/Developer Portal guidance across all five locales
- keep Google Chat webhook configuration unchanged and add focused regressions for the schema path and localized guidance

## Validation
- `.\build.ps1` — passed; Shared, Cli, WinNodeCli, SetupEngine, and WinUI built successfully
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` — passed: 2,724; skipped: 31; failed: 0
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` — passed: 1,665; skipped: 0; failed: 0
- focused `ChannelsPageDiscordConfigContractTests` — passed: 3
- focused `ChannelConfigPatchBuilderTests` — passed: 22

## Real behavior proof
- Launched the current branch build with `.\run-app-local.ps1 -NoBuild -Isolated -AllowNonMain`; the isolated app started successfully from this worktree.
- **UI screenshot: Not verified / blocked.** Computer Use approval for the isolated OpenClaw window was declined, so the Discord form could not be navigated or captured without foregrounding the app. No screenshot is claimed.
- Regression proof directly checks that the Discord form emits `channels.discord.token`, rejects any return of `channels.discord.webhookUrl`, displays the Discord Bot Token label/placeholder/help, removes webhook guidance from every locale, and preserves `channels.googlechat.webhookUrl`.
- Rubber-duck review: `$env:PYTHONUTF8='1'; python .agents\skills\autoreview\scripts\autoreview --mode local` — clean; no accepted/actionable findings.