### PR TITLE
Add connection diagnostics MCP commands

### DIFF
--- a/docs/CONNECTION_ARCHITECTURE.md
+++ b/docs/CONNECTION_ARCHITECTURE.md
@@ -123,6 +123,29 @@ Idle → Connecting → Connected
 
 `GatewayConnectionSnapshot.NodeConnectionIntended` records the Node mode intent used by the manager's state machine. If Node mode is enabled but node startup is skipped, blocked, or missing a node credential, the manager publishes a blocked node snapshot (`NodeState=Error`, `NodeError=...`) instead of leaving the node idle and letting tray surfaces report a healthy connection.
 
+### Status projection and legacy ledger
+
+`GatewayConnectionManager.CurrentSnapshot` is the lifecycle truth. Tray/UI state
+must treat `AppState.Status` / `ConnectionStatus` as a derived compatibility
+projection only, produced from the manager snapshot by
+`ConnectionStatusPresenter`. New connection diagnostics should read
+`GatewayConnectionSnapshot`, `GatewayRegistry`, and `ConnectionDiagnostics`
+directly instead of writing a second runtime model.
+
+Current derived compatibility debt:
+
+| Surface | Status | Notes |
+|---|---|---|
+| `AppState.Status` | Derived read-side adapter | The only writer is the manager `StateChanged` handler, which maps the snapshot through `ConnectionStatusPresenter` for older UI consumers. |
+| `ConnectionStatus` enum | Retained | Still used by shared gateway/client and tray read-side surfaces. Do not remove it until protocol/client and UI consumers are separated in a smaller migration. |
+| Command Center / tray projections | Mixed | New diagnostics use snapshot-derived DTOs. Some older warnings still read `AppStateSnapshot.Status`; those reads are compatibility gates, not lifecycle ownership. |
+
+The local MCP `app.connection.status` command is the agent-facing projection of
+this model. It reports effective mode/state, active gateway metadata,
+operator/node credential resolution, MCP runtime state, browser-proxy caveats,
+pending approval actions, retry hints from diagnostics, and recent diagnostic
+events without exposing token values.
+
 ## Gateway registry and persistence
 
 `GatewayRegistry` is the source of truth for configured gateways:

--- a/docs/MCP_MODE.md
+++ b/docs/MCP_MODE.md
@@ -63,7 +63,7 @@ The capability list lives on `NodeService`, *not* on `WindowsNodeClient`. That s
 `OpenClaw.Shared/Mcp/McpToolBridge.cs` is transport-agnostic JSON-RPC 2.0. It implements:
 
 - `initialize` — protocol version `2024-11-05`, server info.
-- `tools/list` — flattens `_capabilities` into MCP tools. Tool name = command name (`"screen.snapshot"`); description = `"{category} capability: {command}"`; `inputSchema` is permissive.
+- `tools/list` — flattens `_capabilities` into MCP tools. Tool name = command name (`"screen.snapshot"`); known commands get curated descriptions from `McpToolBridge.CommandDescriptions`; unknown commands fall back to `"{category} capability: {command}"`. `inputSchema` is permissive.
 - `tools/call` — finds the capability via `INodeCapability.CanHandle(name)`, builds a `NodeInvokeRequest` (the same struct the gateway path uses), calls `ExecuteAsync`, wraps the result as MCP `content[].text`. Tool failures come back as `result.isError = true`, not JSON-RPC errors (per MCP spec — JSON-RPC errors are reserved for protocol issues).
 - `ping`, `notifications/initialized` — protocol housekeeping.
 
@@ -173,7 +173,15 @@ Local MCP-only app control commands currently include:
 
 - `app.navigate`, `app.status`, `app.sessions`, `app.agents`, `app.nodes`, `app.config.get`, `app.settings.get`, `app.settings.set`, `app.menu`, `app.search`, `app.dashboard.url`
 - Chat automation: `app.chat.snapshot`, `app.chat.send`, `app.chat.reset`
-- Connection automation: `app.connection.applySetupCode`, `app.connection.connectSharedToken`, `app.connection.pendingApprovals`, `app.connection.approveDevicePairing`, `app.connection.rejectDevicePairing`, `app.connection.approveNodePairing`, `app.connection.rejectNodePairing`, `app.connection.reconnect`, `app.connection.reconnectNode`
+- Connection diagnostics/automation: `app.connection.status`, `app.connection.gateways`, `app.connection.applySetupCode`, `app.connection.connectSharedToken`, `app.connection.pendingApprovals`, `app.connection.approveDevicePairing`, `app.connection.rejectDevicePairing`, `app.connection.approveNodePairing`, `app.connection.rejectNodePairing`, `app.connection.reconnect`, `app.connection.reconnectNode`
+
+For connection troubleshooting, prefer `app.connection.status` over the older
+`app.status` summary. It is read-only and returns the manager-owned
+operator/node snapshot, active gateway metadata, credential source/status,
+MCP listener state, browser-proxy shared-token caveat, pending approval commands,
+retry hints inferred from recent diagnostics, and recent diagnostic events.
+`app.connection.gateways` lists saved gateway records with credential presence
+booleans only; it never returns token values.
 
 Example chat automation smoke:
 

--- a/docs/WINDOWS_NODE_TESTING.md
+++ b/docs/WINDOWS_NODE_TESTING.md
@@ -104,7 +104,7 @@ When the node connects, it advertises these capabilities:
 - `tts` - Windows speech synthesis or ElevenLabs playback, when enabled in Settings
 - `stt` - Local speech-to-text via Whisper.net, when enabled in Settings
 
-Local MCP clients also see MCP-only `app.*` commands such as `app.navigate`, `app.status`, `app.chat.snapshot`/`app.chat.send`/`app.chat.reset`, and `app.chat.queue.list`/`app.chat.queue.cancel`. These are local testing and automation hooks registered with the tray's MCP server and are not advertised to the gateway WebSocket.
+Local MCP clients also see MCP-only `app.*` commands such as `app.navigate`, `app.status`, `app.chat.snapshot`/`app.chat.send`/`app.chat.reset`, and `app.chat.queue.list`/`app.chat.queue.cancel`. Connection diagnostics and setup tools live under `app.connection.*`; use `app.connection.status` to inspect active gateway, operator/node credential state, MCP runtime status, browser proxy caveat, pending approval commands, and recent diagnostics, and `app.connection.gateways` to list saved gateway records without token values. These are local testing and automation hooks registered with the tray's MCP server and are not advertised to the gateway WebSocket.
 
 ## Security Features
 

--- a/src/OpenClaw.Shared/Capabilities/AppConnectionCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/AppConnectionCapability.cs
@@ -14,6 +14,8 @@ public sealed class AppConnectionCapability : NodeCapabilityBase
 
     private static readonly string[] s_commands =
     [
+        "app.connection.status",
+        "app.connection.gateways",
         "app.connection.applySetupCode",
         "app.connection.connectSharedToken",
         "app.connection.pendingApprovals",
@@ -29,6 +31,8 @@ public sealed class AppConnectionCapability : NodeCapabilityBase
 
     public Func<string, Task<object?>>? ApplySetupCodeHandler;
     public Func<string, string, Task<object?>>? ConnectSharedTokenHandler;
+    public Func<Task<object?>>? StatusHandler;
+    public Func<Task<object?>>? GatewaysHandler;
     public Func<Task<object?>>? PendingApprovalsHandler;
     public Func<string, Task<object?>>? ApproveDevicePairingHandler;
     public Func<string, Task<object?>>? RejectDevicePairingHandler;
@@ -43,6 +47,8 @@ public sealed class AppConnectionCapability : NodeCapabilityBase
     {
         return request.Command switch
         {
+            "app.connection.status" => await HandleStatus(),
+            "app.connection.gateways" => await HandleGateways(),
             "app.connection.applySetupCode" => await HandleApplySetupCode(request),
             "app.connection.connectSharedToken" => await HandleConnectSharedToken(request),
             "app.connection.pendingApprovals" => await HandlePendingApprovals(),
@@ -54,6 +60,22 @@ public sealed class AppConnectionCapability : NodeCapabilityBase
             "app.connection.reconnectNode" => await HandleReconnectNode(),
             _ => Error($"Unknown command: {request.Command}")
         };
+    }
+
+    private async Task<NodeInvokeResponse> HandleStatus()
+    {
+        if (StatusHandler == null)
+            return Error("Connection status handler not registered");
+        var result = await StatusHandler();
+        return Success(result);
+    }
+
+    private async Task<NodeInvokeResponse> HandleGateways()
+    {
+        if (GatewaysHandler == null)
+            return Error("Connection gateways handler not registered");
+        var result = await GatewaysHandler();
+        return Success(result);
     }
 
     private async Task<NodeInvokeResponse> HandleApplySetupCode(NodeInvokeRequest request)

--- a/src/OpenClaw.Shared/GatewayUrlHelper.cs
+++ b/src/OpenClaw.Shared/GatewayUrlHelper.cs
@@ -77,7 +77,9 @@ public static class GatewayUrlHelper
     }
 
     /// <summary>
-    /// Remove user-info credentials from a URL for safe logging and display.
+    /// Remove user-info credentials plus query/fragment data from a URL for safe
+    /// logging and display. Gateway URLs can carry token-like query parameters
+    /// even when the connection stack does not normally use them.
     /// </summary>
     public static string SanitizeForDisplay(string? gatewayUrl)
     {
@@ -86,7 +88,7 @@ public static class GatewayUrlHelper
             return gatewayUrl?.Trim() ?? string.Empty;
         }
 
-        return RemoveUserInfo(gatewayUrl.Trim());
+        return RemoveQueryAndFragment(RemoveUserInfo(gatewayUrl.Trim()));
     }
 
     public static bool TryNormalizeWebSocketUrl(string? gatewayUrl, out string normalizedUrl)
@@ -156,5 +158,18 @@ public static class GatewayUrlHelper
 
         return string.Concat(url.AsSpan(0, authorityStart), url.AsSpan(atIndex + 1));
     }
-}
 
+    private static string RemoveQueryAndFragment(string url)
+    {
+        var queryIndex = url.IndexOf('?');
+        var fragmentIndex = url.IndexOf('#');
+        var cutIndex = queryIndex switch
+        {
+            >= 0 when fragmentIndex >= 0 => Math.Min(queryIndex, fragmentIndex),
+            >= 0 => queryIndex,
+            _ => fragmentIndex
+        };
+
+        return cutIndex >= 0 ? url[..cutIndex] : url;
+    }
+}

--- a/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
+++ b/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
@@ -284,6 +284,28 @@ public class McpToolBridge
             "READ-ALL: List native chat outgoing queue entries. Args: threadId/sessionKey (string, optional; omit to return all queued threads). Returns { defaultThreadId, requestedThreadId, totalCount, selectedThread, threads: [{ threadId, count, messages: [{ id, text, createdAt, sendState, errorText, canCancel }] }] }.",
         ["app.chat.queue.cancel"] =
             "Cancel/remove one native chat outgoing queue entry before it is sent. Args: queuedMessageId (string, required), threadId/sessionKey (string, required; use the threadId returned by app.chat.queue.list or app.chat.snapshot). Only Queued/Failed entries can be removed; Sending entries may already have reached the gateway. Returns { canceled, threadId, queuedMessageId, remainingCount, error? }.",
+        ["app.connection.status"] =
+            "READ-ONLY local MCP connection diagnostics. No args. Returns effective mode/state, active gateway metadata, operator/node credential resolution, MCP runtime state, browser proxy caveat, pending approval actions, retry hints, and recent diagnostic events.",
+        ["app.connection.gateways"] =
+            "READ-ONLY saved gateway diagnostics. No args. Returns { activeGatewayId, count, gateways[] } with per-gateway id/name/url, active flag, lastConnected, credential presence booleans, SSH/browser-proxy configuration, and no token values.",
+        ["app.connection.applySetupCode"] =
+            "Apply a setup/QR code to create or update the active gateway record and connect. Args: setupCode (string, required). Local MCP-only; not advertised to the gateway node transport. Returns { outcome, error, gatewayUrl, connected }.",
+        ["app.connection.connectSharedToken"] =
+            "Connect the tray to a gateway using a shared token. Args: gatewayUrl (string, required), token (string, required). Persists the gateway record and active gateway. Local MCP-only. Returns { outcome, error, gatewayUrl, connected }.",
+        ["app.connection.pendingApprovals"] =
+            "READ-ONLY pending pairing approval snapshot from the connected gateway. No args. Returns { connected, error, totalPending, devicePending[], nodePending[] }.",
+        ["app.connection.approveDevicePairing"] =
+            "Approve a pending device pairing request through the connected operator client. Args: requestId or id (string, required). Local MCP-only. Returns the refreshed pending approvals payload plus decision metadata.",
+        ["app.connection.rejectDevicePairing"] =
+            "Reject a pending device pairing request through the connected operator client. Args: requestId or id (string, required). Local MCP-only. Returns the refreshed pending approvals payload plus decision metadata.",
+        ["app.connection.approveNodePairing"] =
+            "Approve a pending Windows node pairing or command-trust request through the connected operator client. Args: requestId or id (string, required). Local MCP-only. Returns the refreshed pending approvals payload plus decision metadata.",
+        ["app.connection.rejectNodePairing"] =
+            "Reject a pending Windows node pairing or command-trust request through the connected operator client. Args: requestId or id (string, required). Local MCP-only. Returns the refreshed pending approvals payload plus decision metadata.",
+        ["app.connection.reconnect"] =
+            "Reconnect the active gateway through GatewayConnectionManager. No args. Local MCP-only. Returns { reconnected, error? }.",
+        ["app.connection.reconnectNode"] =
+            "Reconnect only the Windows node role for the active gateway through GatewayConnectionManager. No args. Local MCP-only. Returns { reconnected, error? }.",
 
         // location.*
         ["location.get"] =

--- a/src/OpenClaw.Tray.WinUI/App.CapabilityHandlers.cs
+++ b/src/OpenClaw.Tray.WinUI/App.CapabilityHandlers.cs
@@ -233,6 +233,34 @@ public partial class App
         app.ChatQueueListHandler = ListQueuedChatMessagesForMcpAsync;
         app.ChatQueueCancelHandler = CancelQueuedChatMessageForMcpAsync;
 
+        connection.StatusHandler = () =>
+        {
+            var enableMcpServer = _settings?.EnableMcpServer == true;
+            var isMcpRunning = _nodeService?.IsMcpRunning == true;
+            var mcpPlan = McpRuntimeStatePolicy.PlanStartupNotification(
+                enableMcpServer,
+                isMcpRunning,
+                _nodeService?.McpStartupError);
+            var diagnostics = _connectionManager?.Diagnostics;
+            var recentDiagnostics = diagnostics?.GetRecent(50) ?? [];
+            return Task.FromResult<object?>(ConnectionDiagnosticsProjection.BuildStatus(
+                _connectionManager?.CurrentSnapshot,
+                _gatewayRegistry?.GetActive(),
+                enableNodeMode: _settings?.EnableNodeMode == true,
+                enableMcpServer: enableMcpServer,
+                isMcpRunning: isMcpRunning,
+                mcpError: mcpPlan.ShouldShow ? mcpPlan.Message : null,
+                nodeBrowserProxyEnabled: _settings?.NodeBrowserProxyEnabled != false,
+                recentDiagnostics: recentDiagnostics,
+                diagnosticEventCount: diagnostics?.Count ?? recentDiagnostics.Count));
+        };
+
+        connection.GatewaysHandler = () =>
+            Task.FromResult<object?>(ConnectionDiagnosticsProjection.BuildGateways(
+                _gatewayRegistry?.GetAll() ?? [],
+                _gatewayRegistry?.ActiveGatewayId,
+                nodeBrowserProxyEnabled: _settings?.NodeBrowserProxyEnabled != false));
+
         connection.ApplySetupCodeHandler = async setupCode =>
         {
             if (_connectionManager == null)

--- a/src/OpenClaw.Tray.WinUI/Services/ConnectionDiagnosticsProjection.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ConnectionDiagnosticsProjection.cs
@@ -1,0 +1,385 @@
+using OpenClaw.Connection;
+using OpenClaw.Shared;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace OpenClawTray.Services;
+
+internal static class ConnectionDiagnosticsProjection
+{
+    internal static ConnectionStatusDiagnostics BuildStatus(
+        GatewayConnectionSnapshot? currentSnapshot,
+        GatewayRecord? activeGateway,
+        bool enableNodeMode,
+        bool enableMcpServer,
+        bool isMcpRunning,
+        string? mcpError,
+        bool nodeBrowserProxyEnabled,
+        IReadOnlyList<ConnectionDiagnosticEvent> recentDiagnostics,
+        int diagnosticEventCount)
+    {
+        var snapshot = currentSnapshot ?? GatewayConnectionSnapshot.Idle;
+        var legacyStatus = ConnectionStatusPresenter.ToLegacyStatus(snapshot);
+        var pendingActions = BuildPendingActions(snapshot);
+        var recentEvents = recentDiagnostics
+            .TakeLast(12)
+            .Select(ToDiagnosticEvent)
+            .ToArray();
+
+        return new ConnectionStatusDiagnostics(
+            SchemaVersion: 1,
+            ConnectionState: snapshot.OverallState.ToString(),
+            EffectiveMode: GetEffectiveMode(enableNodeMode, enableMcpServer),
+            LegacyConnectionStatus: legacyStatus.ToString(),
+            Gateway: BuildGateway(activeGateway, snapshot, isActive: true, nodeBrowserProxyEnabled),
+            Operator: new OperatorConnectionDiagnostics(
+                State: snapshot.OperatorState.ToString(),
+                Connected: snapshot.OperatorState == RoleConnectionState.Connected,
+                Error: snapshot.OperatorError,
+                PairingRequired: snapshot.OperatorPairingRequired || snapshot.OperatorState == RoleConnectionState.PairingRequired,
+                PairingRequestId: snapshot.OperatorPairingRequestId,
+                Credential: BuildCredential(
+                    snapshot.OperatorCredentialSource,
+                    snapshot.OperatorCredentialStatus,
+                    snapshot.OperatorCredentialFallbackUsed,
+                    snapshot.OperatorCredentialBootstrapRequired,
+                    snapshot.OperatorCredentialDetail),
+                DeviceId: snapshot.OperatorDeviceId),
+            Node: new NodeConnectionDiagnostics(
+                Intended: snapshot.NodeConnectionIntended || enableNodeMode,
+                State: snapshot.NodeState.ToString(),
+                Connected: snapshot.NodeState == RoleConnectionState.Connected,
+                Paired: snapshot.NodePairingStatus == PairingStatus.Paired,
+                PendingApproval: snapshot.NodeState == RoleConnectionState.PairingRequired,
+                PairingStatus: snapshot.NodePairingStatus.ToString(),
+                PairingApprovalKind: snapshot.NodePairingApprovalKind.ToString(),
+                PairingRequestId: snapshot.NodePairingRequestId,
+                ApprovalCommand: BuildNodeApprovalCommand(snapshot),
+                Error: snapshot.NodeError,
+                Credential: BuildCredential(
+                    snapshot.NodeCredentialSource,
+                    snapshot.NodeCredentialStatus,
+                    snapshot.NodeCredentialFallbackUsed,
+                    snapshot.NodeCredentialBootstrapRequired,
+                    snapshot.NodeCredentialDetail),
+                DeviceId: snapshot.NodeDeviceId),
+            Mcp: new McpConnectionDiagnostics(
+                Enabled: enableMcpServer,
+                Running: isMcpRunning,
+                Error: mcpError),
+            BrowserProxy: BuildBrowserProxy(activeGateway, nodeBrowserProxyEnabled),
+            PendingActions: pendingActions,
+            Retry: BuildRetry(recentDiagnostics),
+            Diagnostics: BuildDiagnosticSummary(recentEvents, recentDiagnostics, diagnosticEventCount));
+    }
+
+    internal static GatewayListDiagnostics BuildGateways(
+        IReadOnlyList<GatewayRecord> gateways,
+        string? activeGatewayId,
+        bool nodeBrowserProxyEnabled)
+    {
+        var items = gateways
+            .OrderByDescending(g => string.Equals(g.Id, activeGatewayId, StringComparison.Ordinal))
+            .ThenBy(g => g.FriendlyName ?? g.Url, StringComparer.OrdinalIgnoreCase)
+            .Select(g => BuildGateway(
+                g,
+                currentSnapshot: null,
+                isActive: string.Equals(g.Id, activeGatewayId, StringComparison.Ordinal),
+                nodeBrowserProxyEnabled))
+            .OfType<GatewayDiagnostics>()
+            .ToArray();
+
+        return new GatewayListDiagnostics(
+            ActiveGatewayId: activeGatewayId,
+            Count: items.Length,
+            Gateways: items);
+    }
+
+    private static CredentialDiagnostics BuildCredential(
+        string? source,
+        GatewayCredentialResolutionStatus? status,
+        bool fallbackUsed,
+        bool bootstrapRequired,
+        string? detail) =>
+        new(
+            Source: source,
+            Status: status?.ToString(),
+            FallbackUsed: fallbackUsed,
+            BootstrapRequired: bootstrapRequired,
+            Detail: detail);
+
+    private static GatewayDiagnostics? BuildGateway(
+        GatewayRecord? gateway,
+        GatewayConnectionSnapshot? currentSnapshot,
+        bool isActive,
+        bool nodeBrowserProxyEnabled)
+    {
+        var id = gateway?.Id ?? currentSnapshot?.GatewayId;
+        var url = GatewayUrlHelper.SanitizeForDisplay(gateway?.Url ?? currentSnapshot?.GatewayUrl);
+        var name = gateway?.FriendlyName ?? currentSnapshot?.GatewayName;
+        if (string.IsNullOrWhiteSpace(id) &&
+            string.IsNullOrWhiteSpace(url) &&
+            string.IsNullOrWhiteSpace(name))
+        {
+            return null;
+        }
+
+        return new GatewayDiagnostics(
+            Id: id,
+            Name: name,
+            Url: url,
+            IsActive: isActive,
+            IsLocal: gateway?.IsLocal,
+            LastConnected: gateway?.LastConnected,
+            RequiresV2Signature: gateway?.RequiresV2Signature,
+            HasSharedGatewayToken: !string.IsNullOrWhiteSpace(gateway?.SharedGatewayToken),
+            HasBootstrapToken: !string.IsNullOrWhiteSpace(gateway?.BootstrapToken),
+            BrowserControlPort: gateway?.BrowserControlPort,
+            BrowserProxyCaveat: BuildBrowserProxyCaveat(gateway, nodeBrowserProxyEnabled, isActive),
+            SshTunnel: gateway?.SshTunnel is null ? null : new GatewaySshTunnelDiagnostics(
+                User: gateway.SshTunnel.User,
+                Host: gateway.SshTunnel.Host,
+                RemotePort: gateway.SshTunnel.RemotePort,
+                LocalPort: gateway.SshTunnel.LocalPort,
+                SshPort: gateway.SshTunnel.SshPort,
+                IncludeBrowserProxyForward: gateway.SshTunnel.IncludeBrowserProxyForward));
+    }
+
+    private static BrowserProxyDiagnostics BuildBrowserProxy(GatewayRecord? gateway, bool nodeBrowserProxyEnabled)
+    {
+        var hasSharedToken = !string.IsNullOrWhiteSpace(gateway?.SharedGatewayToken);
+        return new BrowserProxyDiagnostics(
+            Enabled: nodeBrowserProxyEnabled,
+            ActiveGatewayHasSharedToken: hasSharedToken,
+            BrowserControlPort: gateway?.BrowserControlPort,
+            SshBrowserProxyForward: gateway?.SshTunnel?.IncludeBrowserProxyForward == true,
+            Caveat: BuildBrowserProxyCaveat(gateway, nodeBrowserProxyEnabled, isActive: true));
+    }
+
+    private static string? BuildBrowserProxyCaveat(GatewayRecord? gateway, bool nodeBrowserProxyEnabled, bool isActive)
+    {
+        if (!isActive ||
+            !nodeBrowserProxyEnabled ||
+            gateway is null ||
+            !string.IsNullOrWhiteSpace(gateway.SharedGatewayToken))
+        {
+            return null;
+        }
+
+        return "browser.proxy may need a saved shared gateway token for browser-control authentication; QR/bootstrap pairing alone can leave this token absent.";
+    }
+
+    private static ConnectionPendingActionDiagnostics[] BuildPendingActions(GatewayConnectionSnapshot snapshot)
+    {
+        var actions = new List<ConnectionPendingActionDiagnostics>();
+        if (snapshot.OperatorPairingRequired || snapshot.OperatorState == RoleConnectionState.PairingRequired)
+        {
+            actions.Add(new ConnectionPendingActionDiagnostics(
+                Kind: "operatorDevicePairing",
+                State: snapshot.OperatorState.ToString(),
+                RequestId: snapshot.OperatorPairingRequestId,
+                Command: CommandCenterDiagnostics.BuildDeviceApprovalRepairCommand(snapshot.OperatorPairingRequestId),
+                Summary: "Approve the operator device pairing request for the active gateway."));
+        }
+
+        if (snapshot.NodeState == RoleConnectionState.PairingRequired)
+        {
+            var command = BuildNodeApprovalCommand(snapshot) ?? CommandCenterDiagnostics.BuildUnknownPairingDiscoveryCommands();
+            actions.Add(new ConnectionPendingActionDiagnostics(
+                Kind: "nodePairing",
+                State: snapshot.NodeState.ToString(),
+                RequestId: snapshot.NodePairingRequestId,
+                Command: command,
+                Summary: "Approve the Windows node pairing or command-trust request for the active gateway."));
+        }
+
+        return actions.ToArray();
+    }
+
+    private static string? BuildNodeApprovalCommand(GatewayConnectionSnapshot snapshot) =>
+        snapshot.NodeState != RoleConnectionState.PairingRequired
+            ? null
+            : snapshot.NodePairingApprovalKind switch
+            {
+                PairingApprovalKind.DevicePair => CommandCenterDiagnostics.BuildDeviceApprovalRepairCommand(snapshot.NodePairingRequestId),
+                PairingApprovalKind.NodePair => CommandCenterDiagnostics.BuildNodeApprovalRepairCommand(snapshot.NodePairingRequestId),
+                _ => CommandCenterDiagnostics.BuildUnknownPairingDiscoveryCommands()
+            };
+
+    private static RetryDiagnostics BuildRetry(IReadOnlyList<ConnectionDiagnosticEvent> recentDiagnostics)
+    {
+        var retryEvent = recentDiagnostics.LastOrDefault(evt =>
+            Contains(evt.Message, "retry") ||
+            Contains(evt.Message, "reconnect") ||
+            Contains(evt.Detail, "retry") ||
+            Contains(evt.Detail, "reconnect"));
+
+        return new RetryDiagnostics(
+            HasRecentRetrySignal: retryEvent is not null,
+            LastRetryAt: retryEvent?.Timestamp,
+            LastRetryMessage: retryEvent?.Message,
+            NextRetryAt: null,
+            PausedReason: null,
+            Detail: "Retry attempt and next-retry timestamps are not published as manager state; recent retry/reconnect diagnostics are surfaced when present.");
+    }
+
+    private static DiagnosticSummary BuildDiagnosticSummary(
+        IReadOnlyList<DiagnosticEventDiagnostics> recentEvents,
+        IReadOnlyList<ConnectionDiagnosticEvent> sourceEvents,
+        int eventCount)
+    {
+        var lastError = sourceEvents.LastOrDefault(evt =>
+            Contains(evt.Category, "error") ||
+            Contains(evt.Message, "error") ||
+            Contains(evt.Message, "failed") ||
+            Contains(evt.Detail, "error") ||
+            Contains(evt.Detail, "failed"));
+        var lastStateChange = sourceEvents.LastOrDefault(evt =>
+            string.Equals(evt.Category, "state", StringComparison.OrdinalIgnoreCase));
+
+        return new DiagnosticSummary(
+            EventCount: eventCount,
+            LastEventAt: sourceEvents.LastOrDefault()?.Timestamp,
+            LastStateChangeAt: lastStateChange?.Timestamp,
+            LastStateChange: lastStateChange?.Message,
+            LastErrorAt: lastError?.Timestamp,
+            LastError: lastError is null ? null : FormatDiagnostic(lastError),
+            RecentEvents: recentEvents);
+    }
+
+    private static DiagnosticEventDiagnostics ToDiagnosticEvent(ConnectionDiagnosticEvent evt) =>
+        new(evt.Timestamp, evt.Category, evt.Message, evt.Detail);
+
+    private static string FormatDiagnostic(ConnectionDiagnosticEvent evt) =>
+        string.IsNullOrWhiteSpace(evt.Detail)
+            ? $"{evt.Category}: {evt.Message}"
+            : $"{evt.Category}: {evt.Message} ({evt.Detail})";
+
+    private static string GetEffectiveMode(bool enableNodeMode, bool enableMcpServer) =>
+        (enableNodeMode, enableMcpServer) switch
+        {
+            (true, true) => "GatewayNodeAndLocalMcp",
+            (true, false) => "GatewayNode",
+            (false, true) => "LocalMcpOnly",
+            _ => "OperatorOnly"
+        };
+
+    private static bool Contains(string? value, string needle) =>
+        !string.IsNullOrEmpty(value) &&
+        value.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0;
+}
+
+internal sealed record ConnectionStatusDiagnostics(
+    [property: JsonPropertyName("schemaVersion")] int SchemaVersion,
+    [property: JsonPropertyName("connectionState")] string ConnectionState,
+    [property: JsonPropertyName("effectiveMode")] string EffectiveMode,
+    [property: JsonPropertyName("legacyConnectionStatus")] string LegacyConnectionStatus,
+    [property: JsonPropertyName("gateway")] GatewayDiagnostics? Gateway,
+    [property: JsonPropertyName("operator")] OperatorConnectionDiagnostics Operator,
+    [property: JsonPropertyName("node")] NodeConnectionDiagnostics Node,
+    [property: JsonPropertyName("mcp")] McpConnectionDiagnostics Mcp,
+    [property: JsonPropertyName("browserProxy")] BrowserProxyDiagnostics BrowserProxy,
+    [property: JsonPropertyName("pendingActions")] IReadOnlyList<ConnectionPendingActionDiagnostics> PendingActions,
+    [property: JsonPropertyName("retry")] RetryDiagnostics Retry,
+    [property: JsonPropertyName("diagnostics")] DiagnosticSummary Diagnostics);
+
+internal sealed record GatewayListDiagnostics(
+    [property: JsonPropertyName("activeGatewayId")] string? ActiveGatewayId,
+    [property: JsonPropertyName("count")] int Count,
+    [property: JsonPropertyName("gateways")] IReadOnlyList<GatewayDiagnostics> Gateways);
+
+internal sealed record GatewayDiagnostics(
+    [property: JsonPropertyName("id")] string? Id,
+    [property: JsonPropertyName("name")] string? Name,
+    [property: JsonPropertyName("url")] string? Url,
+    [property: JsonPropertyName("isActive")] bool IsActive,
+    [property: JsonPropertyName("isLocal")] bool? IsLocal,
+    [property: JsonPropertyName("lastConnected")] DateTime? LastConnected,
+    [property: JsonPropertyName("requiresV2Signature")] bool? RequiresV2Signature,
+    [property: JsonPropertyName("hasSharedGatewayToken")] bool HasSharedGatewayToken,
+    [property: JsonPropertyName("hasBootstrapToken")] bool HasBootstrapToken,
+    [property: JsonPropertyName("browserControlPort")] int? BrowserControlPort,
+    [property: JsonPropertyName("browserProxyCaveat")] string? BrowserProxyCaveat,
+    [property: JsonPropertyName("sshTunnel")] GatewaySshTunnelDiagnostics? SshTunnel);
+
+internal sealed record GatewaySshTunnelDiagnostics(
+    [property: JsonPropertyName("user")] string User,
+    [property: JsonPropertyName("host")] string Host,
+    [property: JsonPropertyName("remotePort")] int RemotePort,
+    [property: JsonPropertyName("localPort")] int LocalPort,
+    [property: JsonPropertyName("sshPort")] int SshPort,
+    [property: JsonPropertyName("includeBrowserProxyForward")] bool IncludeBrowserProxyForward);
+
+internal sealed record OperatorConnectionDiagnostics(
+    [property: JsonPropertyName("state")] string State,
+    [property: JsonPropertyName("connected")] bool Connected,
+    [property: JsonPropertyName("error")] string? Error,
+    [property: JsonPropertyName("pairingRequired")] bool PairingRequired,
+    [property: JsonPropertyName("pairingRequestId")] string? PairingRequestId,
+    [property: JsonPropertyName("credential")] CredentialDiagnostics Credential,
+    [property: JsonPropertyName("deviceId")] string? DeviceId);
+
+internal sealed record NodeConnectionDiagnostics(
+    [property: JsonPropertyName("intended")] bool Intended,
+    [property: JsonPropertyName("state")] string State,
+    [property: JsonPropertyName("connected")] bool Connected,
+    [property: JsonPropertyName("paired")] bool Paired,
+    [property: JsonPropertyName("pendingApproval")] bool PendingApproval,
+    [property: JsonPropertyName("pairingStatus")] string PairingStatus,
+    [property: JsonPropertyName("pairingApprovalKind")] string PairingApprovalKind,
+    [property: JsonPropertyName("pairingRequestId")] string? PairingRequestId,
+    [property: JsonPropertyName("approvalCommand")] string? ApprovalCommand,
+    [property: JsonPropertyName("error")] string? Error,
+    [property: JsonPropertyName("credential")] CredentialDiagnostics Credential,
+    [property: JsonPropertyName("deviceId")] string? DeviceId);
+
+internal sealed record CredentialDiagnostics(
+    [property: JsonPropertyName("source")] string? Source,
+    [property: JsonPropertyName("status")] string? Status,
+    [property: JsonPropertyName("fallbackUsed")] bool FallbackUsed,
+    [property: JsonPropertyName("bootstrapRequired")] bool BootstrapRequired,
+    [property: JsonPropertyName("detail")] string? Detail);
+
+internal sealed record McpConnectionDiagnostics(
+    [property: JsonPropertyName("enabled")] bool Enabled,
+    [property: JsonPropertyName("running")] bool Running,
+    [property: JsonPropertyName("error")] string? Error);
+
+internal sealed record BrowserProxyDiagnostics(
+    [property: JsonPropertyName("enabled")] bool Enabled,
+    [property: JsonPropertyName("activeGatewayHasSharedToken")] bool ActiveGatewayHasSharedToken,
+    [property: JsonPropertyName("browserControlPort")] int? BrowserControlPort,
+    [property: JsonPropertyName("sshBrowserProxyForward")] bool SshBrowserProxyForward,
+    [property: JsonPropertyName("caveat")] string? Caveat);
+
+internal sealed record ConnectionPendingActionDiagnostics(
+    [property: JsonPropertyName("kind")] string Kind,
+    [property: JsonPropertyName("state")] string State,
+    [property: JsonPropertyName("requestId")] string? RequestId,
+    [property: JsonPropertyName("command")] string Command,
+    [property: JsonPropertyName("summary")] string Summary);
+
+internal sealed record RetryDiagnostics(
+    [property: JsonPropertyName("hasRecentRetrySignal")] bool HasRecentRetrySignal,
+    [property: JsonPropertyName("lastRetryAt")] DateTime? LastRetryAt,
+    [property: JsonPropertyName("lastRetryMessage")] string? LastRetryMessage,
+    [property: JsonPropertyName("nextRetryAt")] DateTime? NextRetryAt,
+    [property: JsonPropertyName("pausedReason")] string? PausedReason,
+    [property: JsonPropertyName("detail")] string Detail);
+
+internal sealed record DiagnosticSummary(
+    [property: JsonPropertyName("eventCount")] int EventCount,
+    [property: JsonPropertyName("lastEventAt")] DateTime? LastEventAt,
+    [property: JsonPropertyName("lastStateChangeAt")] DateTime? LastStateChangeAt,
+    [property: JsonPropertyName("lastStateChange")] string? LastStateChange,
+    [property: JsonPropertyName("lastErrorAt")] DateTime? LastErrorAt,
+    [property: JsonPropertyName("lastError")] string? LastError,
+    [property: JsonPropertyName("recentEvents")] IReadOnlyList<DiagnosticEventDiagnostics> RecentEvents);
+
+internal sealed record DiagnosticEventDiagnostics(
+    [property: JsonPropertyName("timestamp")] DateTime Timestamp,
+    [property: JsonPropertyName("category")] string Category,
+    [property: JsonPropertyName("message")] string Message,
+    [property: JsonPropertyName("detail")] string? Detail);

--- a/src/OpenClaw.WinNode.Cli/skill.md
+++ b/src/OpenClaw.WinNode.Cli/skill.md
@@ -314,6 +314,7 @@ Returns `{ navigated, page }`.
 ### app.status
 Current connection / node state.
 No params. Returns `{ connectionStatus, overallState, operatorState, nodeState, nodeConnected, nodePaired, nodePendingApproval, nodeError, gatewayVersion, sessionCount, nodeCount }`.
+For agent-facing connection troubleshooting, prefer `app.connection.status`.
 
 ### app.sessions
 Active sessions, optionally filtered by agent.
@@ -368,6 +369,100 @@ Build the same gateway dashboard URL the tray opens.
 {"path": "string"}           // optional
 ```
 Returns `{ url, credentialSource, usesSharedGatewayToken, hasTokenQuery }`.
+
+## App connection diagnostics and setup (app.connection.*)
+
+Local MCP-only tools for connection diagnostics, setup, pairing approvals, and
+targeted reconnects. These tools are not advertised to the remote gateway node
+transport. Read-only diagnostics redact token values and expose credential
+presence/outcome only.
+
+### app.connection.status
+Read-only connection diagnostics for agents and CLIs. No params. Returns:
+`{ schemaVersion, connectionState, effectiveMode, legacyConnectionStatus, gateway, operator, node, mcp, browserProxy, pendingActions, retry, diagnostics }`.
+
+The payload includes the active gateway id/name/url, operator and node role
+states, credential sources/statuses, MCP enabled/running/error state, browser
+proxy shared-token caveat, pending approval commands, retry hints inferred from
+recent diagnostics, and recent connection diagnostic events. `effectiveMode`
+reflects Settings mode (`EnableNodeMode` / `EnableMcpServer`); `node.intended`
+reflects the manager snapshot plus current Node mode setting.
+
+### app.connection.gateways
+Read-only saved gateway diagnostics. No params. Returns:
+`{ activeGatewayId, count, gateways[] }`.
+
+Each gateway includes id/name/url, active flag, local/v2 flags, lastConnected,
+credential presence booleans (`hasSharedGatewayToken`, `hasBootstrapToken`),
+browser-control port/caveat, and SSH tunnel metadata. Token values are never
+returned.
+
+### app.connection.applySetupCode
+Apply a setup or QR code and connect the tray to that gateway.
+```
+{"setupCode": "string"}      // required
+```
+Returns `{ outcome, error, gatewayUrl, connected }`. Side effects: creates or
+updates a gateway record, sets it active, persists credentials from the setup
+code, and asks `GatewayConnectionManager` to connect.
+
+### app.connection.connectSharedToken
+Connect with a shared gateway token.
+```
+{
+  "gatewayUrl": "string",    // required
+  "token": "string"          // required
+}
+```
+Returns `{ outcome, error, gatewayUrl, connected }`. Side effects: creates or
+updates a gateway record, stores the shared token on that record, sets it active,
+and asks `GatewayConnectionManager` to connect.
+
+### app.connection.pendingApprovals
+Read pending device/node pairing approvals from the connected gateway. No params.
+Returns `{ connected, error, totalPending, devicePending[], nodePending[] }`.
+
+### app.connection.approveDevicePairing
+Approve a pending device pairing request.
+```
+{"requestId": "string"}      // required; "id" alias accepted
+```
+Returns the refreshed pending approvals payload plus `{ decision }`. Side effect:
+calls the connected operator client's device-pair approval RPC.
+
+### app.connection.rejectDevicePairing
+Reject a pending device pairing request.
+```
+{"requestId": "string"}      // required; "id" alias accepted
+```
+Returns the refreshed pending approvals payload plus `{ decision }`. Side effect:
+calls the connected operator client's device-pair rejection RPC.
+
+### app.connection.approveNodePairing
+Approve a pending Windows node pairing or command-trust request.
+```
+{"requestId": "string"}      // required; "id" alias accepted
+```
+Returns the refreshed pending approvals payload plus `{ decision }`. Side effect:
+calls the connected operator client's node-pair approval RPC.
+
+### app.connection.rejectNodePairing
+Reject a pending Windows node pairing or command-trust request.
+```
+{"requestId": "string"}      // required; "id" alias accepted
+```
+Returns the refreshed pending approvals payload plus `{ decision }`. Side effect:
+calls the connected operator client's node-pair rejection RPC.
+
+### app.connection.reconnect
+Reconnect the active gateway through `GatewayConnectionManager`. No params.
+Returns `{ reconnected, error? }`. Side effect: disconnects and reconnects the
+operator/node lifecycle for the active gateway.
+
+### app.connection.reconnectNode
+Reconnect only the Windows node role for the active gateway through
+`GatewayConnectionManager`. No params. Returns `{ reconnected, error? }`.
+Side effect: restarts node connection intent without changing the active gateway.
 
 ### app.chat.snapshot
 Read the current native chat snapshot for local automation and diagnostics.

--- a/tests/OpenClaw.Shared.Tests/AppConnectionCapabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/AppConnectionCapabilityTests.cs
@@ -1,0 +1,109 @@
+using OpenClaw.Shared.Capabilities;
+using System.Text.Json;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class AppConnectionCapabilityTests
+{
+    private static JsonElement ParseArgs(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+
+    [Fact]
+    public void Commands_ContainsConnectionDiagnosticsAndControls()
+    {
+        var cap = new AppConnectionCapability(NullLogger.Instance);
+        var expected = new[]
+        {
+            "app.connection.status",
+            "app.connection.gateways",
+            "app.connection.applySetupCode",
+            "app.connection.connectSharedToken",
+            "app.connection.pendingApprovals",
+            "app.connection.approveDevicePairing",
+            "app.connection.rejectDevicePairing",
+            "app.connection.approveNodePairing",
+            "app.connection.rejectNodePairing",
+            "app.connection.reconnect",
+            "app.connection.reconnectNode"
+        };
+
+        foreach (var command in expected)
+        {
+            Assert.Contains(command, cap.Commands);
+            Assert.True(cap.CanHandle(command), $"CanHandle should return true for '{command}'.");
+        }
+    }
+
+    [Fact]
+    public async Task Status_WithHandler_ReturnsData()
+    {
+        var cap = new AppConnectionCapability(NullLogger.Instance)
+        {
+            StatusHandler = () => Task.FromResult<object?>(new { connectionState = "Ready" })
+        };
+
+        var res = await cap.ExecuteAsync(new NodeInvokeRequest
+        {
+            Id = "1",
+            Command = "app.connection.status",
+            Args = ParseArgs("{}")
+        });
+
+        Assert.True(res.Ok);
+        Assert.NotNull(res.Payload);
+    }
+
+    [Fact]
+    public async Task Gateways_WithHandler_ReturnsData()
+    {
+        var cap = new AppConnectionCapability(NullLogger.Instance)
+        {
+            GatewaysHandler = () => Task.FromResult<object?>(new { count = 0 })
+        };
+
+        var res = await cap.ExecuteAsync(new NodeInvokeRequest
+        {
+            Id = "1",
+            Command = "app.connection.gateways",
+            Args = ParseArgs("{}")
+        });
+
+        Assert.True(res.Ok);
+        Assert.NotNull(res.Payload);
+    }
+
+    [Fact]
+    public async Task Status_WithNoHandler_ReturnsError()
+    {
+        var cap = new AppConnectionCapability(NullLogger.Instance);
+
+        var res = await cap.ExecuteAsync(new NodeInvokeRequest
+        {
+            Id = "1",
+            Command = "app.connection.status",
+            Args = ParseArgs("{}")
+        });
+
+        Assert.False(res.Ok);
+        Assert.Contains("status handler", res.Error);
+    }
+
+    [Fact]
+    public async Task Gateways_WithNoHandler_ReturnsError()
+    {
+        var cap = new AppConnectionCapability(NullLogger.Instance);
+
+        var res = await cap.ExecuteAsync(new NodeInvokeRequest
+        {
+            Id = "1",
+            Command = "app.connection.gateways",
+            Args = ParseArgs("{}")
+        });
+
+        Assert.False(res.Ok);
+        Assert.Contains("gateways handler", res.Error);
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/GatewayUrlHelperTests.cs
+++ b/tests/OpenClaw.Shared.Tests/GatewayUrlHelperTests.cs
@@ -138,6 +138,18 @@ public class GatewayUrlHelperTests
     }
 
     [Theory]
+    [InlineData("wss://example.com/path?token=secret", "wss://example.com/path")]
+    [InlineData("wss://example.com/path#access_token=secret", "wss://example.com/path")]
+    [InlineData("wss://user:pass@example.com/path?token=secret#access_token=fragment-secret", "wss://example.com/path")]
+    public void SanitizeForDisplay_RemovesQueryAndFragmentSecrets(string inputUrl, string expectedUrl)
+    {
+        var sanitized = GatewayUrlHelper.SanitizeForDisplay(inputUrl);
+
+        Assert.Equal(expectedUrl, sanitized);
+        Assert.DoesNotContain("secret", sanitized);
+    }
+
+    [Theory]
     [InlineData("ws://localhost:18789")]
     [InlineData("wss://host.tailnet.ts.net")]
     [InlineData("http://localhost:18789")]

--- a/tests/OpenClaw.Tray.Tests/ConnectionDiagnosticsProjectionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ConnectionDiagnosticsProjectionTests.cs
@@ -1,0 +1,149 @@
+using OpenClaw.Connection;
+using OpenClaw.Shared;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class ConnectionDiagnosticsProjectionTests
+{
+    [Fact]
+    public void BuildStatus_ExplainsActiveGatewayRolesCredentialsAndActions()
+    {
+        var gateway = new GatewayRecord
+        {
+            Id = "gw-1",
+            FriendlyName = "Local Gateway",
+            Url = "ws://127.0.0.1:18789",
+            IsLocal = true,
+            LastConnected = new DateTime(2026, 7, 9, 20, 0, 0, DateTimeKind.Utc),
+            BrowserControlPort = 18791,
+            SshTunnel = new SshTunnelConfig("dev", "host", 443, 18789, IncludeBrowserProxyForward: true)
+        };
+        var snapshot = new GatewayConnectionSnapshot
+        {
+            OverallState = OverallConnectionState.PairingRequired,
+            OperatorState = RoleConnectionState.Connected,
+            OperatorCredentialSource = "DeviceToken",
+            OperatorCredentialStatus = GatewayCredentialResolutionStatus.Resolved,
+            NodeConnectionIntended = true,
+            NodeState = RoleConnectionState.PairingRequired,
+            NodePairingStatus = PairingStatus.Pending,
+            NodePairingApprovalKind = PairingApprovalKind.NodePair,
+            NodePairingRequestId = "node-req-1",
+            NodeCredentialSource = "SharedGatewayToken",
+            NodeCredentialStatus = GatewayCredentialResolutionStatus.Resolved,
+            GatewayId = gateway.Id,
+            GatewayUrl = gateway.Url,
+            GatewayName = gateway.FriendlyName
+        };
+        var diagnostics = new[]
+        {
+            new ConnectionDiagnosticEvent(new DateTime(2026, 7, 9, 20, 1, 0, DateTimeKind.Utc), "state", "Connected -> PairingRequired", null),
+            new ConnectionDiagnosticEvent(new DateTime(2026, 7, 9, 20, 2, 0, DateTimeKind.Utc), "node", "Retrying device role-upgrade reconnect after repeated pending signal", "requestId=node-req-1"),
+            new ConnectionDiagnosticEvent(new DateTime(2026, 7, 9, 20, 3, 0, DateTimeKind.Utc), "websocket", "Node connect failed", "timeout")
+        };
+
+        var status = ConnectionDiagnosticsProjection.BuildStatus(
+            snapshot,
+            gateway,
+            enableNodeMode: true,
+            enableMcpServer: true,
+            isMcpRunning: false,
+            mcpError: "Local MCP failed",
+            nodeBrowserProxyEnabled: true,
+            recentDiagnostics: diagnostics,
+            diagnosticEventCount: 9);
+
+        Assert.Equal("PairingRequired", status.ConnectionState);
+        Assert.Equal("GatewayNodeAndLocalMcp", status.EffectiveMode);
+        Assert.Equal("Local Gateway", status.Gateway!.Name);
+        Assert.True(status.Operator.Connected);
+        Assert.Equal("DeviceToken", status.Operator.Credential.Source);
+        Assert.True(status.Node.PendingApproval);
+        Assert.Equal("openclaw nodes approve node-req-1", status.Node.ApprovalCommand);
+        Assert.Single(status.PendingActions);
+        Assert.Equal("nodePairing", status.PendingActions[0].Kind);
+        Assert.False(status.Mcp.Running);
+        Assert.Equal("Local MCP failed", status.Mcp.Error);
+        Assert.NotNull(status.BrowserProxy.Caveat);
+        Assert.True(status.Retry.HasRecentRetrySignal);
+        Assert.Equal(9, status.Diagnostics.EventCount);
+        Assert.Contains("failed", status.Diagnostics.LastError);
+    }
+
+    [Fact]
+    public void BuildGateways_RedactsTokensAndMarksBrowserProxyCaveat()
+    {
+        var active = new GatewayRecord
+        {
+            Id = "gw-active",
+            FriendlyName = "Active",
+            Url = "wss://user:password@active.example/path?token=secret#access_token=fragment-secret",
+            BootstrapToken = "bootstrap-secret"
+        };
+        var inactive = new GatewayRecord
+        {
+            Id = "gw-inactive",
+            FriendlyName = "Inactive",
+            Url = "wss://inactive.example",
+            SharedGatewayToken = "shared-secret"
+        };
+
+        var result = ConnectionDiagnosticsProjection.BuildGateways(
+            [inactive, active],
+            active.Id,
+            nodeBrowserProxyEnabled: true);
+
+        Assert.Equal(active.Id, result.ActiveGatewayId);
+        Assert.Equal(2, result.Count);
+        Assert.Equal(active.Id, result.Gateways[0].Id);
+        Assert.DoesNotContain("password", result.Gateways[0].Url);
+        Assert.DoesNotContain("secret", result.Gateways[0].Url);
+        Assert.Equal("wss://active.example/path", result.Gateways[0].Url);
+        Assert.True(result.Gateways[0].IsActive);
+        Assert.False(result.Gateways[0].HasSharedGatewayToken);
+        Assert.True(result.Gateways[0].HasBootstrapToken);
+        Assert.NotNull(result.Gateways[0].BrowserProxyCaveat);
+        Assert.True(result.Gateways[1].HasSharedGatewayToken);
+        Assert.Null(result.Gateways[1].BrowserProxyCaveat);
+    }
+
+    [Fact]
+    public void BuildGateways_DoesNotAttachBrowserProxyCaveatToInactiveGateways()
+    {
+        var inactiveWithoutToken = new GatewayRecord
+        {
+            Id = "gw-inactive",
+            FriendlyName = "Inactive",
+            Url = "wss://inactive.example"
+        };
+
+        var result = ConnectionDiagnosticsProjection.BuildGateways(
+            [inactiveWithoutToken],
+            activeGatewayId: "different-gateway",
+            nodeBrowserProxyEnabled: true);
+
+        Assert.False(result.Gateways[0].IsActive);
+        Assert.Null(result.Gateways[0].BrowserProxyCaveat);
+    }
+
+    [Fact]
+    public void BuildGateways_FiltersDegenerateGatewayRecords()
+    {
+        var valid = new GatewayRecord
+        {
+            Id = "gw-valid",
+            FriendlyName = "Valid",
+            Url = "wss://valid.example"
+        };
+
+        var result = ConnectionDiagnosticsProjection.BuildGateways(
+            [new GatewayRecord(), valid],
+            valid.Id,
+            nodeBrowserProxyEnabled: true);
+
+        Assert.Equal(1, result.Count);
+        Assert.Single(result.Gateways);
+        Assert.Equal(valid.Id, result.Gateways[0].Id);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ChatNotificationSpeechText.cs" Link="Services\ChatNotificationSpeechText.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\AppNotificationPublisher.cs" Link="Services\AppNotificationPublisher.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ConnectionStatusPresenter.cs" Link="Services\ConnectionStatusPresenter.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\ConnectionDiagnosticsProjection.cs" Link="Services\ConnectionDiagnosticsProjection.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\McpRuntimeStatePolicy.cs" Link="Services\McpRuntimeStatePolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\UsageCostApplicationPolicy.cs" Link="Services\UsageCostApplicationPolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Helpers\CanvasGatewayUrlRewriter.cs" Link="Helpers\CanvasGatewayUrlRewriter.cs" />

--- a/tests/OpenClaw.WinNode.Cli.Tests/SkillMdDriftTests.cs
+++ b/tests/OpenClaw.WinNode.Cli.Tests/SkillMdDriftTests.cs
@@ -80,6 +80,7 @@ public class SkillMdDriftTests
         var capabilities = new INodeCapability[]
         {
             new AppCapability(NullLogger.Instance),
+            new AppConnectionCapability(NullLogger.Instance),
             new BrowserProxyCapability(NullLogger.Instance, "ws://127.0.0.1:8080", bearerToken: null),
             new CameraCapability(NullLogger.Instance),
             new CanvasCapability(NullLogger.Instance),


### PR DESCRIPTION
## Summary

- Adds read-only local MCP diagnostics commands: `app.connection.status` and `app.connection.gateways`.
- Introduces a snapshot-derived `ConnectionDiagnosticsProjection` so agents can inspect active gateway, operator/node credential state, MCP runtime state, browser proxy caveats, pending approval actions, retry hints, and recent diagnostics without adding a competing connection truth model.
- Documents remaining `AppState.Status` / `ConnectionStatus` usage as derived compatibility debt.
- Updates MCP command descriptions and `winnode` skill docs, with drift and projection tests.
- Hardens gateway display URL sanitization so diagnostics remove userinfo, query strings, and fragments.

## Validation

- `.\build.ps1` ✅ all builds succeeded.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` ✅ 2732 passed, 31 skipped, 0 failed.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` ✅ 1669 passed, 0 failed.
- `dotnet test .\tests\OpenClaw.Connection.Tests\OpenClaw.Connection.Tests.csproj --no-restore` ✅ 422 passed, 0 failed.
- `dotnet test .\tests\OpenClaw.WinNode.Cli.Tests\OpenClaw.WinNode.Cli.Tests.csproj --no-restore` ✅ 126 passed, 0 failed.
- `git diff --check` ✅ no whitespace errors.

## Real behavior proof

Started an isolated tray with `EnableMcpServer=true`, `EnableNodeMode=false` using an isolated tray data directory:

```text
C:\Users\<user>\.copilot\session-state\<session-id>\files\mcp-proof-data
```

`winnode --list-tools` showed:

```text
"name": "app.connection.status"
"name": "app.connection.gateways"
"name": "app.connection.pendingApprovals"
```

`winnode --command app.connection.status --params '{}'` returned current-head diagnostics including:

```json
{
  "schemaVersion": 1,
  "connectionState": "Idle",
  "effectiveMode": "LocalMcpOnly",
  "legacyConnectionStatus": "Disconnected",
  "mcp": {
    "enabled": true,
    "running": true,
    "error": null
  },
  "pendingActions": [],
  "diagnostics": {
    "eventCount": 0,
    "recentEvents": []
  }
}
```

`winnode --command app.connection.gateways --params '{}'` returned:

```json
{
  "activeGatewayId": null,
  "count": 0,
  "gateways": []
}
```

The isolated tray process was stopped after proof collection.

## Review notes

- Rubber-duck review completed; fixed URL userinfo redaction finding before initial closeout.
- Dual-model review completed; fixed all findings:
  - strip token-like URL query/fragment data from diagnostics display URLs,
  - filter degenerate gateway projections defensively,
  - add regression tests for both cases.

## Follow-up risks

- Exact retry attempt / next retry timestamp is still not manager-published state. The new diagnostics expose recent retry/reconnect diagnostic events instead of inventing a parallel retry model.
- `AppState.Status` / `ConnectionStatus` remain documented as derived compatibility paths for older UI/protocol surfaces.