### PR TITLE
Add opt-in OpenTelemetry diagnostics groundwork

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,17 @@ Every new Windows node call must be exposed, documented, and tested through MCP 
 4. Add/update capability, MCP bridge, `winnode`, and UI/gateway tests as appropriate.
 5. Run required validation plus `dotnet test .\tests\OpenClaw.WinNode.Cli.Tests\OpenClaw.WinNode.Cli.Tests.csproj --no-restore` when `winnode`, MCP output, or command docs change.
 
+## Telemetry Guardrails
+
+Read `docs/TELEMETRY.md` before adding or changing OpenTelemetry configuration, exporters, instrumentation helpers, span attributes, metric tags, or exported log fields.
+
+- Do not add OpenTelemetry SDK/exporter package references to `OpenClaw.Shared`; shared helpers may use `System.Diagnostics.ActivitySource`, `Activity`, and `System.Diagnostics.Metrics` only.
+- Do not export user content, prompts, screenshots, file contents, raw command input/output, credentials, API keys, gateway tokens, device tokens, or arbitrary existing local logs.
+- Keep telemetry opt-in: an empty endpoint must mean no OpenTelemetry export, and export must go only to the user-configured endpoint.
+- Prefer low-cardinality operational diagnostics: operation names, outcomes, durations, counts, protocol choices, and coarse error categories.
+- Add focused tests for new span names, metric names, tag keys, log categories, filtering behavior, and endpoint/protocol behavior.
+- For exporter or protocol changes, provide current-head collector proof for every affected signal and protocol, or document the blocker.
+
 ## Architecture Context for New Agents
 
 Start with these docs before changing connection, pairing, node, MCP, or tray UX behavior:

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -107,6 +107,8 @@ If users need authenticated collectors, prefer a local collector or proxy that h
 
 Plain `http://` endpoints are useful for local development collectors such as `localhost`. Prefer `https://` for remote collectors unless the user intentionally controls and trusts the network path.
 
+Automatic startup and settings application should deduplicate an unchanged endpoint. The diagnostics UI may offer an explicit resend action so users can repeat the bounded probe after a collector outage; local SDK flush completion must not be described as collector acknowledgement.
+
 ## Adding new instrumentation
 
 Before adding new exported telemetry:

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -1,0 +1,119 @@
+# Telemetry conventions
+
+OpenClaw telemetry exists to help users and developers diagnose the companion app, Windows node integration, gateway connectivity, and related setup flows. It must not become background consumer tracking.
+
+Telemetry support should be explicit, reviewable, and safe by default. A change that adds new exported telemetry is a product and privacy decision, not just an implementation detail.
+
+## User control
+
+- Export must be disabled by default.
+- Export must only start after the user configures an endpoint.
+- An empty endpoint must mean no OpenTelemetry export.
+- Export must go only to the endpoint the user configured.
+- UI copy should describe telemetry as diagnostics/observability, not analytics.
+
+## Signal ownership
+
+OpenClaw uses shared instrumentation names so traces, metrics, and logs can be correlated consistently:
+
+- tray service name: `openclaw-windows-tray`
+- Windows node service name: `openclaw-windows-node`
+- shared activity source name: `openclaw`
+- shared meter name: `openclaw`
+
+The tray app owns OpenTelemetry SDK and exporter setup. Shared libraries may define instrumentation helpers using `System.Diagnostics.ActivitySource`, `System.Diagnostics.Activity`, and `System.Diagnostics.Metrics`, but must not take a dependency on OpenTelemetry SDK or exporter packages.
+
+## Data boundary
+
+Telemetry fields should be low-cardinality operational diagnostics:
+
+- component or operation names
+- protocol choices
+- coarse status and outcome values
+- durations and counts
+- coarse error categories or exception type names
+
+Telemetry must not include:
+
+- user prompts, chat contents, or document contents
+- screenshots, camera frames, audio, clipboard contents, or raw UI text
+- file contents or raw document text
+- credentials, API keys, gateway tokens, bootstrap tokens, or device tokens
+- full command input/output unless a specific command contract has been reviewed for safe export
+- arbitrary existing local logs exported wholesale
+
+When in doubt, do not export the field. Prefer a coarse category over a raw value.
+
+## Traces
+
+Use traces for bounded operations where duration and outcome matter. Span names should be stable operation names, not dynamically generated strings. Do not put user input into span names.
+
+Recommended span attributes:
+
+- `openclaw.source`
+- `openclaw.outcome`
+- `openclaw.status`
+- `openclaw.reason`
+- `openclaw.error.category`
+- `error.type`
+
+Use local span attributes only when the values are reviewed as safe and useful for diagnostics.
+
+## Metrics
+
+Use metrics for counts and distributions that remain meaningful when aggregated. Metric names should be stable and low cardinality. Metric tags must follow the same data boundary as trace attributes.
+
+Do not use metric tags for identifiers that can explode cardinality, such as user IDs, file paths, URLs with user-controlled path segments, device IDs, or per-request IDs.
+
+## Logs
+
+OpenTelemetry logs should be structured and allowlisted. Exported logs should use explicit safe attributes instead of relying on formatted message text.
+
+The OpenTelemetry log pipeline should not export:
+
+- formatted messages that may contain interpolated values
+- logging scopes
+- arbitrary existing local file logs
+- categories outside reviewed telemetry namespaces
+
+If a new log category should be exported, add it deliberately and review the structured fields it can emit.
+
+## Endpoint handling
+
+The endpoint setting is a collector endpoint, not a credential or request-parameter store. Accept plain `http` and `https` collector URLs with optional path prefixes. Reject URLs with embedded user info, query strings, or fragments.
+
+Examples of acceptable endpoint shapes:
+
+```text
+http://localhost:4317
+https://collector.example.com:4318
+https://collector.example.com/otlp
+```
+
+Supported OTLP protocols:
+
+- OTLP/gRPC
+- OTLP/HTTP protobuf
+
+For gRPC, pass the configured endpoint to the exporter unchanged.
+
+For HTTP/protobuf, treat the configured endpoint as a collector base URL and derive signal-specific paths:
+
+- traces: `/v1/traces`
+- metrics: `/v1/metrics`
+- logs: `/v1/logs`
+
+If users need authenticated collectors, prefer a local collector or proxy that handles upstream authentication. Direct authenticated exporter support should be added as an explicit feature with appropriate secret storage and redaction, not by embedding credentials in the endpoint URL.
+
+Plain `http://` endpoints are useful for local development collectors such as `localhost`. Prefer `https://` for remote collectors unless the user intentionally controls and trusts the network path.
+
+## Adding new instrumentation
+
+Before adding new exported telemetry:
+
+1. Identify the diagnostic question the signal answers.
+2. List every attribute/tag/log field and classify why it is safe.
+3. Prefer enums, constants, or reviewed helper APIs for shared names.
+4. Add focused tests for names, outcomes, and filtering behavior.
+5. Update this document if the change creates a new convention or expands the telemetry boundary.
+6. Include validation and real behavior proof when the change affects user-visible configuration or exporter behavior.

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -57,7 +57,7 @@ Recommended span attributes:
 - `openclaw.error.category`
 - `error.type`
 
-Use local span attributes only when the values are reviewed as safe and useful for diagnostics.
+Use the named constants in `OpenClawTelemetryTagKey` for shared attributes instead of duplicating string literals. Use local span attributes only when the values are reviewed as safe and useful for diagnostics.
 
 ## Metrics
 

--- a/src/OpenClaw.Shared/SettingsData.cs
+++ b/src/OpenClaw.Shared/SettingsData.cs
@@ -136,6 +136,15 @@ public record class SettingsData
     public bool ShowCompletedSessions { get; set; } = false;
     public string AppTheme { get; set; } = "System";
     public bool? ShowDiagnostics { get; set; }
+    /// <summary>
+    /// Optional OTLP collector endpoint for diagnostic telemetry.
+    /// Null or empty means telemetry is disabled.
+    /// </summary>
+    public string? OpenTelemetryEndpoint { get; set; }
+    /// <summary>
+    /// OTLP transport protocol for the configured OpenTelemetry endpoint.
+    /// </summary>
+    public string OpenTelemetryProtocol { get; set; } = "grpc";
     public List<UserNotificationRule>? UserRules { get; set; }
 
     // ── MXC sandbox ─────────────────────────────────────────────────────

--- a/src/OpenClaw.Shared/Telemetry/OpenClawActivitySources.cs
+++ b/src/OpenClaw.Shared/Telemetry/OpenClawActivitySources.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+
+namespace OpenClaw.Shared.Telemetry;
+
+/// <summary>
+/// Stable ActivitySource names used by OpenClaw instrumentation.
+/// </summary>
+public static class OpenClawActivitySources
+{
+    public const string OpenClaw = "openclaw";
+
+    public static ActivitySource OpenClawSource { get; } = new(OpenClaw);
+
+    public static IReadOnlyList<string> ExportedNames { get; } = Array.AsReadOnly([OpenClaw]);
+}

--- a/src/OpenClaw.Shared/Telemetry/OpenClawActivitySources.cs
+++ b/src/OpenClaw.Shared/Telemetry/OpenClawActivitySources.cs
@@ -2,14 +2,29 @@ using System.Diagnostics;
 
 namespace OpenClaw.Shared.Telemetry;
 
+public enum OpenClawActivitySourceName
+{
+    OpenClaw
+}
+
 /// <summary>
 /// Stable ActivitySource names used by OpenClaw instrumentation.
 /// </summary>
 public static class OpenClawActivitySources
 {
-    public const string OpenClaw = "openclaw";
+    public static ActivitySource OpenClawSource { get; } = new(OpenClawActivitySourceName.OpenClaw.ToTelemetryName());
 
-    public static ActivitySource OpenClawSource { get; } = new(OpenClaw);
+    public static string ToTelemetryName(this OpenClawActivitySourceName source) =>
+        source switch
+        {
+            OpenClawActivitySourceName.OpenClaw => "openclaw",
+            _ => throw new ArgumentOutOfRangeException(nameof(source), source, "Unknown OpenClaw activity source.")
+        };
 
-    public static IReadOnlyList<string> ExportedNames { get; } = Array.AsReadOnly([OpenClaw]);
+    internal static ActivitySource ToActivitySource(this OpenClawActivitySourceName source) =>
+        source switch
+        {
+            OpenClawActivitySourceName.OpenClaw => OpenClawSource,
+            _ => throw new ArgumentOutOfRangeException(nameof(source), source, "Unknown OpenClaw activity source.")
+        };
 }

--- a/src/OpenClaw.Shared/Telemetry/OpenClawMeters.cs
+++ b/src/OpenClaw.Shared/Telemetry/OpenClawMeters.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics.Metrics;
+
+namespace OpenClaw.Shared.Telemetry;
+
+public enum OpenClawMeterName
+{
+    OpenClaw
+}
+
+/// <summary>
+/// Stable Meter names used by OpenClaw metrics.
+/// </summary>
+public static class OpenClawMeters
+{
+    public static Meter OpenClawMeter { get; } = new(OpenClawMeterName.OpenClaw.ToTelemetryName());
+
+    public static string ToTelemetryName(this OpenClawMeterName meter) =>
+        meter switch
+        {
+            OpenClawMeterName.OpenClaw => "openclaw",
+            _ => throw new ArgumentOutOfRangeException(nameof(meter), meter, "Unknown OpenClaw meter.")
+        };
+
+    internal static Meter ToMeter(this OpenClawMeterName meter) =>
+        meter switch
+        {
+            OpenClawMeterName.OpenClaw => OpenClawMeter,
+            _ => throw new ArgumentOutOfRangeException(nameof(meter), meter, "Unknown OpenClaw meter.")
+        };
+}

--- a/src/OpenClaw.Shared/Telemetry/OpenClawResourceNames.cs
+++ b/src/OpenClaw.Shared/Telemetry/OpenClawResourceNames.cs
@@ -1,10 +1,21 @@
 namespace OpenClaw.Shared.Telemetry;
 
+public enum OpenClawResourceName
+{
+    WindowsTray,
+    WindowsNode
+}
+
 /// <summary>
 /// Stable resource names used by OpenClaw telemetry exporters.
 /// </summary>
 public static class OpenClawResourceNames
 {
-    public const string Tray = "openclaw-windows-tray";
-    public const string WindowsNode = "openclaw-windows-node";
+    public static string ToServiceName(this OpenClawResourceName resource) =>
+        resource switch
+        {
+            OpenClawResourceName.WindowsTray => "openclaw-windows-tray",
+            OpenClawResourceName.WindowsNode => "openclaw-windows-node",
+            _ => throw new ArgumentOutOfRangeException(nameof(resource), resource, "Unknown OpenClaw resource name.")
+        };
 }

--- a/src/OpenClaw.Shared/Telemetry/OpenClawResourceNames.cs
+++ b/src/OpenClaw.Shared/Telemetry/OpenClawResourceNames.cs
@@ -1,0 +1,10 @@
+namespace OpenClaw.Shared.Telemetry;
+
+/// <summary>
+/// Stable resource names used by OpenClaw telemetry exporters.
+/// </summary>
+public static class OpenClawResourceNames
+{
+    public const string Tray = "openclaw-windows-tray";
+    public const string WindowsNode = "openclaw-windows-node";
+}

--- a/src/OpenClaw.Shared/Telemetry/OpenClawTelemetry.cs
+++ b/src/OpenClaw.Shared/Telemetry/OpenClawTelemetry.cs
@@ -1,0 +1,161 @@
+using System.Diagnostics;
+
+namespace OpenClaw.Shared.Telemetry;
+
+/// <summary>
+/// Small helpers for OpenClaw code paths that want to expose traced spans.
+/// Exporter configuration remains owned by the app process.
+/// </summary>
+public static class OpenClawTelemetry
+{
+    public static Activity? StartActivity(
+        ActivitySource source,
+        string spanName,
+        IEnumerable<OpenClawTelemetryTag>? tags = null,
+        System.Diagnostics.ActivityKind kind = System.Diagnostics.ActivityKind.Internal)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        if (string.IsNullOrWhiteSpace(spanName))
+            throw new ArgumentException("Span name cannot be empty.", nameof(spanName));
+
+        var activity = source.StartActivity(spanName, kind);
+        ApplyTags(activity, tags);
+        return activity;
+    }
+
+    public static void Trace(
+        ActivitySource source,
+        string spanName,
+        Action action,
+        IEnumerable<OpenClawTelemetryTag>? tags = null,
+        System.Diagnostics.ActivityKind kind = System.Diagnostics.ActivityKind.Internal)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        using var activity = StartActivity(source, spanName, tags, kind);
+
+        try
+        {
+            action();
+            MarkSuccess(activity);
+        }
+        catch (OperationCanceledException)
+        {
+            MarkCanceled(activity);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            MarkFailure(activity, ex);
+            throw;
+        }
+    }
+
+    public static T Trace<T>(
+        ActivitySource source,
+        string spanName,
+        Func<T> action,
+        IEnumerable<OpenClawTelemetryTag>? tags = null,
+        System.Diagnostics.ActivityKind kind = System.Diagnostics.ActivityKind.Internal)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        using var activity = StartActivity(source, spanName, tags, kind);
+
+        try
+        {
+            var result = action();
+            MarkSuccess(activity);
+            return result;
+        }
+        catch (OperationCanceledException)
+        {
+            MarkCanceled(activity);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            MarkFailure(activity, ex);
+            throw;
+        }
+    }
+
+    public static async Task TraceAsync(
+        ActivitySource source,
+        string spanName,
+        Func<CancellationToken, Task> action,
+        IEnumerable<OpenClawTelemetryTag>? tags = null,
+        System.Diagnostics.ActivityKind kind = System.Diagnostics.ActivityKind.Internal,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        using var activity = StartActivity(source, spanName, tags, kind);
+
+        try
+        {
+            await action(cancellationToken).ConfigureAwait(false);
+            MarkSuccess(activity);
+        }
+        catch (OperationCanceledException)
+        {
+            MarkCanceled(activity);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            MarkFailure(activity, ex);
+            throw;
+        }
+    }
+
+    public static async Task<T> TraceAsync<T>(
+        ActivitySource source,
+        string spanName,
+        Func<CancellationToken, Task<T>> action,
+        IEnumerable<OpenClawTelemetryTag>? tags = null,
+        System.Diagnostics.ActivityKind kind = System.Diagnostics.ActivityKind.Internal,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        using var activity = StartActivity(source, spanName, tags, kind);
+
+        try
+        {
+            var result = await action(cancellationToken).ConfigureAwait(false);
+            MarkSuccess(activity);
+            return result;
+        }
+        catch (OperationCanceledException)
+        {
+            MarkCanceled(activity);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            MarkFailure(activity, ex);
+            throw;
+        }
+    }
+
+    private static void ApplyTags(Activity? activity, IEnumerable<OpenClawTelemetryTag>? tags)
+    {
+        if (activity == null || tags == null)
+            return;
+
+        foreach (var tag in tags)
+            activity.SetTag(tag.Key, tag.Value);
+    }
+
+    private static void MarkSuccess(Activity? activity) =>
+        activity?.SetStatus(ActivityStatusCode.Ok);
+
+    private static void MarkCanceled(Activity? activity) =>
+        activity?.SetTag(OpenClawTelemetryTags.Outcome, "canceled");
+
+    private static void MarkFailure(Activity? activity, Exception ex)
+    {
+        if (activity == null)
+            return;
+
+        activity.SetStatus(ActivityStatusCode.Error, ex.GetType().Name);
+        activity.SetTag(OpenClawTelemetryTags.ErrorType, ex.GetType().FullName);
+    }
+}

--- a/src/OpenClaw.Shared/Telemetry/OpenClawTelemetry.cs
+++ b/src/OpenClaw.Shared/Telemetry/OpenClawTelemetry.cs
@@ -1,9 +1,10 @@
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 
 namespace OpenClaw.Shared.Telemetry;
 
 /// <summary>
-/// Small helpers for OpenClaw code paths that want to expose traced spans.
+/// Small helpers for OpenClaw code paths that want to expose traced spans and metrics.
 /// Exporter configuration remains owned by the app process.
 /// </summary>
 public static class OpenClawTelemetry
@@ -180,6 +181,68 @@ public static class OpenClawTelemetry
         }
     }
 
+    /// <summary>
+    /// Creates a long-lived counter instrument for monotonically increasing measurements.
+    /// </summary>
+    /// <remarks>
+    /// Store the returned counter in a static field near the instrumentation point and call
+    /// <see cref="Add(Counter{long}, long, IEnumerable{OpenClawTelemetryTag}?)"/> whenever an event occurs.
+    /// Use counters for counts such as attempts, completions, or probe sends.
+    /// </remarks>
+    public static Counter<long> CreateCounter(
+        string metricName,
+        string? unit = null,
+        string? description = null,
+        OpenClawMeterName meter = OpenClawMeterName.OpenClaw)
+    {
+        ValidateMetricName(metricName);
+        return meter.ToMeter().CreateCounter<long>(metricName, unit, description);
+    }
+
+    /// <summary>
+    /// Creates a long-lived histogram instrument for recording distributions.
+    /// </summary>
+    /// <remarks>
+    /// Store the returned histogram in a static field near the instrumentation point and call
+    /// <see cref="Record(Histogram{double}, double, IEnumerable{OpenClawTelemetryTag}?)"/> for each value.
+    /// Use histograms for durations, sizes, or other values where percentiles are useful.
+    /// </remarks>
+    public static Histogram<double> CreateHistogram(
+        string metricName,
+        string? unit = null,
+        string? description = null,
+        OpenClawMeterName meter = OpenClawMeterName.OpenClaw)
+    {
+        ValidateMetricName(metricName);
+        return meter.ToMeter().CreateHistogram<double>(metricName, unit, description);
+    }
+
+    /// <summary>
+    /// Adds a measurement to a counter instrument.
+    /// </summary>
+    public static void Add(
+        Counter<long> counter,
+        long delta = 1,
+        IEnumerable<OpenClawTelemetryTag>? tags = null)
+    {
+        ArgumentNullException.ThrowIfNull(counter);
+        var tagList = ToTagList(tags);
+        counter.Add(delta, in tagList);
+    }
+
+    /// <summary>
+    /// Records a value in a histogram instrument.
+    /// </summary>
+    public static void Record(
+        Histogram<double> histogram,
+        double value,
+        IEnumerable<OpenClawTelemetryTag>? tags = null)
+    {
+        ArgumentNullException.ThrowIfNull(histogram);
+        var tagList = ToTagList(tags);
+        histogram.Record(value, in tagList);
+    }
+
     private static void ApplyTags(Activity? activity, IEnumerable<OpenClawTelemetryTag>? tags)
     {
         if (activity == null || tags == null)
@@ -187,6 +250,24 @@ public static class OpenClawTelemetry
 
         foreach (var tag in tags)
             activity.SetTag(tag.Key, tag.Value);
+    }
+
+    private static TagList ToTagList(IEnumerable<OpenClawTelemetryTag>? tags)
+    {
+        var tagList = new TagList();
+        if (tags == null)
+            return tagList;
+
+        foreach (var tag in tags)
+            tagList.Add(tag.Key, tag.Value);
+
+        return tagList;
+    }
+
+    private static void ValidateMetricName(string metricName)
+    {
+        if (string.IsNullOrWhiteSpace(metricName))
+            throw new ArgumentException("Metric name cannot be empty.", nameof(metricName));
     }
 
     /// <summary>

--- a/src/OpenClaw.Shared/Telemetry/OpenClawTelemetry.cs
+++ b/src/OpenClaw.Shared/Telemetry/OpenClawTelemetry.cs
@@ -8,30 +8,53 @@ namespace OpenClaw.Shared.Telemetry;
 /// </summary>
 public static class OpenClawTelemetry
 {
+    private const string OutcomeSuccess = "success";
+    private const string OutcomeCanceled = "canceled";
+    private const string OutcomeFailure = "failure";
+
+    /// <summary>
+    /// Starts a span for work that needs manual lifetime control.
+    /// </summary>
+    /// <remarks>
+    /// Prefer <see cref="Trace(string, Action, IEnumerable{OpenClawTelemetryTag}?, System.Diagnostics.ActivityKind, OpenClawActivitySourceName)"/>
+    /// or <see cref="TraceAsync(string, Func{CancellationToken, Task}, IEnumerable{OpenClawTelemetryTag}?, System.Diagnostics.ActivityKind, CancellationToken, OpenClawActivitySourceName)"/>
+    /// when the span should cover a single function call. Use this method when a span must cross multiple calls,
+    /// has custom lifetime boundaries, or needs manual success/failure/cancellation marking.
+    /// <para>
+    /// The returned <see cref="Activity"/> can be <see langword="null"/> when no listener is recording this
+    /// source or the configured sampler drops the span. Callers should use null-safe disposal and mark helpers.
+    /// </para>
+    /// </remarks>
     public static Activity? StartActivity(
-        ActivitySource source,
         string spanName,
         IEnumerable<OpenClawTelemetryTag>? tags = null,
-        System.Diagnostics.ActivityKind kind = System.Diagnostics.ActivityKind.Internal)
+        System.Diagnostics.ActivityKind kind = System.Diagnostics.ActivityKind.Internal,
+        OpenClawActivitySourceName source = OpenClawActivitySourceName.OpenClaw)
     {
-        ArgumentNullException.ThrowIfNull(source);
         if (string.IsNullOrWhiteSpace(spanName))
             throw new ArgumentException("Span name cannot be empty.", nameof(spanName));
 
-        var activity = source.StartActivity(spanName, kind);
+        var activity = source.ToActivitySource().StartActivity(spanName, kind);
         ApplyTags(activity, tags);
         return activity;
     }
 
+    /// <summary>
+    /// Runs a synchronous action inside a span and automatically marks success, cancellation, or failure.
+    /// </summary>
+    /// <remarks>
+    /// Use this for the common case where a span should cover exactly one function call. Exceptions and
+    /// cancellations are rethrown unchanged after the span is annotated.
+    /// </remarks>
     public static void Trace(
-        ActivitySource source,
         string spanName,
         Action action,
         IEnumerable<OpenClawTelemetryTag>? tags = null,
-        System.Diagnostics.ActivityKind kind = System.Diagnostics.ActivityKind.Internal)
+        System.Diagnostics.ActivityKind kind = System.Diagnostics.ActivityKind.Internal,
+        OpenClawActivitySourceName source = OpenClawActivitySourceName.OpenClaw)
     {
         ArgumentNullException.ThrowIfNull(action);
-        using var activity = StartActivity(source, spanName, tags, kind);
+        using var activity = StartActivity(spanName, tags, kind, source);
 
         try
         {
@@ -50,15 +73,22 @@ public static class OpenClawTelemetry
         }
     }
 
+    /// <summary>
+    /// Runs a synchronous function inside a span and returns its result.
+    /// </summary>
+    /// <remarks>
+    /// Use this for the common case where a span should cover exactly one value-returning function call.
+    /// Exceptions and cancellations are rethrown unchanged after the span is annotated.
+    /// </remarks>
     public static T Trace<T>(
-        ActivitySource source,
         string spanName,
         Func<T> action,
         IEnumerable<OpenClawTelemetryTag>? tags = null,
-        System.Diagnostics.ActivityKind kind = System.Diagnostics.ActivityKind.Internal)
+        System.Diagnostics.ActivityKind kind = System.Diagnostics.ActivityKind.Internal,
+        OpenClawActivitySourceName source = OpenClawActivitySourceName.OpenClaw)
     {
         ArgumentNullException.ThrowIfNull(action);
-        using var activity = StartActivity(source, spanName, tags, kind);
+        using var activity = StartActivity(spanName, tags, kind, source);
 
         try
         {
@@ -78,16 +108,23 @@ public static class OpenClawTelemetry
         }
     }
 
+    /// <summary>
+    /// Runs an asynchronous action inside a span and automatically marks success, cancellation, or failure.
+    /// </summary>
+    /// <remarks>
+    /// Use this for the common case where a span should cover exactly one asynchronous operation. The supplied
+    /// cancellation token is passed to <paramref name="action"/> and cancellations are rethrown unchanged.
+    /// </remarks>
     public static async Task TraceAsync(
-        ActivitySource source,
         string spanName,
         Func<CancellationToken, Task> action,
         IEnumerable<OpenClawTelemetryTag>? tags = null,
         System.Diagnostics.ActivityKind kind = System.Diagnostics.ActivityKind.Internal,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        OpenClawActivitySourceName source = OpenClawActivitySourceName.OpenClaw)
     {
         ArgumentNullException.ThrowIfNull(action);
-        using var activity = StartActivity(source, spanName, tags, kind);
+        using var activity = StartActivity(spanName, tags, kind, source);
 
         try
         {
@@ -106,16 +143,24 @@ public static class OpenClawTelemetry
         }
     }
 
+    /// <summary>
+    /// Runs an asynchronous function inside a span and returns its result.
+    /// </summary>
+    /// <remarks>
+    /// Use this for the common case where a span should cover exactly one value-returning asynchronous
+    /// operation. The supplied cancellation token is passed to <paramref name="action"/> and cancellations are
+    /// rethrown unchanged.
+    /// </remarks>
     public static async Task<T> TraceAsync<T>(
-        ActivitySource source,
         string spanName,
         Func<CancellationToken, Task<T>> action,
         IEnumerable<OpenClawTelemetryTag>? tags = null,
         System.Diagnostics.ActivityKind kind = System.Diagnostics.ActivityKind.Internal,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        OpenClawActivitySourceName source = OpenClawActivitySourceName.OpenClaw)
     {
         ArgumentNullException.ThrowIfNull(action);
-        using var activity = StartActivity(source, spanName, tags, kind);
+        using var activity = StartActivity(spanName, tags, kind, source);
 
         try
         {
@@ -144,18 +189,46 @@ public static class OpenClawTelemetry
             activity.SetTag(tag.Key, tag.Value);
     }
 
-    private static void MarkSuccess(Activity? activity) =>
-        activity?.SetStatus(ActivityStatusCode.Ok);
-
-    private static void MarkCanceled(Activity? activity) =>
-        activity?.SetTag(OpenClawTelemetryTags.Outcome, "canceled");
-
-    private static void MarkFailure(Activity? activity, Exception ex)
+    /// <summary>
+    /// Marks a manually-created span as successful.
+    /// </summary>
+    /// <remarks>
+    /// This method accepts a nullable activity because <see cref="StartActivity"/> may return
+    /// <see langword="null"/> when telemetry is not recording.
+    /// </remarks>
+    public static void MarkSuccess(Activity? activity)
     {
         if (activity == null)
             return;
 
-        activity.SetStatus(ActivityStatusCode.Error, ex.GetType().Name);
-        activity.SetTag(OpenClawTelemetryTags.ErrorType, ex.GetType().FullName);
+        activity.SetStatus(ActivityStatusCode.Ok);
+        activity.SetTag(OpenClawTelemetryTagKey.Outcome.ToTelemetryName(), OutcomeSuccess);
+    }
+
+    /// <summary>
+    /// Marks a manually-created span as canceled without setting error status.
+    /// </summary>
+    /// <remarks>
+    /// Use this for expected cancellation paths so observability backends do not count normal cancellation as
+    /// a failed operation.
+    /// </remarks>
+    public static void MarkCanceled(Activity? activity) =>
+        activity?.SetTag(OpenClawTelemetryTagKey.Outcome.ToTelemetryName(), OutcomeCanceled);
+
+    /// <summary>
+    /// Marks a manually-created span as failed and records the exception type.
+    /// </summary>
+    /// <remarks>
+    /// The exception message is intentionally not recorded to avoid leaking user content or secrets.
+    /// </remarks>
+    public static void MarkFailure(Activity? activity, Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        if (activity == null)
+            return;
+
+        activity.SetStatus(ActivityStatusCode.Error, exception.GetType().Name);
+        activity.SetTag(OpenClawTelemetryTagKey.Outcome.ToTelemetryName(), OutcomeFailure);
+        activity.SetTag(OpenClawTelemetryTagKey.ErrorType.ToTelemetryName(), exception.GetType().FullName);
     }
 }

--- a/src/OpenClaw.Shared/Telemetry/OpenClawTelemetryTag.cs
+++ b/src/OpenClaw.Shared/Telemetry/OpenClawTelemetryTag.cs
@@ -5,36 +5,37 @@ namespace OpenClaw.Shared.Telemetry;
 /// </summary>
 public sealed class OpenClawTelemetryTag
 {
-    private const int DefaultStringMaxLength = 128;
+    public OpenClawTelemetryTag(OpenClawTelemetryTagKey key, object? value)
+        : this(key.ToTelemetryName(), value)
+    {
+    }
 
-    public OpenClawTelemetryTag(string key, object? value)
+    private OpenClawTelemetryTag(string key, object? value)
     {
         if (string.IsNullOrWhiteSpace(key))
             throw new ArgumentException("Telemetry tag key cannot be empty.", nameof(key));
 
-        Key = key;
-        Value = value;
+        (Key, Value) = (key, value);
     }
 
     public string Key { get; }
     public object? Value { get; }
 
-    public static OpenClawTelemetryTag String(string key, string? value, int maxLength = DefaultStringMaxLength) =>
-        new(key, BoundString(value, maxLength));
-
-    public static OpenClawTelemetryTag Bool(string key, bool value) =>
+    public static OpenClawTelemetryTag String(OpenClawTelemetryTagKey key, string? value) =>
         new(key, value);
 
-    public static OpenClawTelemetryTag Number(string key, long value) =>
+    public static OpenClawTelemetryTag String(string localKey, string? value) =>
+        new(localKey, value);
+
+    public static OpenClawTelemetryTag Bool(OpenClawTelemetryTagKey key, bool value) =>
         new(key, value);
 
-    private static string? BoundString(string? value, int maxLength)
-    {
-        if (value == null)
-            return null;
-        if (maxLength <= 0)
-            throw new ArgumentOutOfRangeException(nameof(maxLength), "Maximum string length must be positive.");
+    public static OpenClawTelemetryTag Bool(string localKey, bool value) =>
+        new(localKey, value);
 
-        return value.Length <= maxLength ? value : value[..maxLength];
-    }
+    public static OpenClawTelemetryTag Number(OpenClawTelemetryTagKey key, long value) =>
+        new(key, value);
+
+    public static OpenClawTelemetryTag Number(string localKey, long value) =>
+        new(localKey, value);
 }

--- a/src/OpenClaw.Shared/Telemetry/OpenClawTelemetryTag.cs
+++ b/src/OpenClaw.Shared/Telemetry/OpenClawTelemetryTag.cs
@@ -1,0 +1,40 @@
+namespace OpenClaw.Shared.Telemetry;
+
+/// <summary>
+/// Explicit non-sensitive telemetry tag supplied by instrumentation call sites.
+/// </summary>
+public sealed class OpenClawTelemetryTag
+{
+    private const int DefaultStringMaxLength = 128;
+
+    public OpenClawTelemetryTag(string key, object? value)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Telemetry tag key cannot be empty.", nameof(key));
+
+        Key = key;
+        Value = value;
+    }
+
+    public string Key { get; }
+    public object? Value { get; }
+
+    public static OpenClawTelemetryTag String(string key, string? value, int maxLength = DefaultStringMaxLength) =>
+        new(key, BoundString(value, maxLength));
+
+    public static OpenClawTelemetryTag Bool(string key, bool value) =>
+        new(key, value);
+
+    public static OpenClawTelemetryTag Number(string key, long value) =>
+        new(key, value);
+
+    private static string? BoundString(string? value, int maxLength)
+    {
+        if (value == null)
+            return null;
+        if (maxLength <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxLength), "Maximum string length must be positive.");
+
+        return value.Length <= maxLength ? value : value[..maxLength];
+    }
+}

--- a/src/OpenClaw.Shared/Telemetry/OpenClawTelemetryTags.cs
+++ b/src/OpenClaw.Shared/Telemetry/OpenClawTelemetryTags.cs
@@ -1,17 +1,29 @@
 namespace OpenClaw.Shared.Telemetry;
 
+public enum OpenClawTelemetryTagKey
+{
+    Source,
+    Outcome,
+    ErrorCategory,
+    ErrorType,
+    Reason,
+    Status
+}
+
 /// <summary>
 /// Stable tag keys used by OpenClaw instrumentation.
 /// </summary>
 public static class OpenClawTelemetryTags
 {
-    public const string Source = "openclaw.source";
-    public const string Outcome = "openclaw.outcome";
-    public const string ErrorCategory = "openclaw.errorCategory";
-    public const string ErrorType = "error.type";
-    public const string Exporter = "openclaw.exporter";
-    public const string ExporterProtocol = "openclaw.exporter.protocol";
-    public const string Reason = "openclaw.reason";
-    public const string Signal = "openclaw.signal";
-    public const string Status = "openclaw.status";
+    public static string ToTelemetryName(this OpenClawTelemetryTagKey key) =>
+        key switch
+        {
+            OpenClawTelemetryTagKey.Source => "openclaw.source",
+            OpenClawTelemetryTagKey.Outcome => "openclaw.outcome",
+            OpenClawTelemetryTagKey.ErrorCategory => "openclaw.errorCategory",
+            OpenClawTelemetryTagKey.ErrorType => "error.type",
+            OpenClawTelemetryTagKey.Reason => "openclaw.reason",
+            OpenClawTelemetryTagKey.Status => "openclaw.status",
+            _ => throw new ArgumentOutOfRangeException(nameof(key), key, "Unknown OpenClaw telemetry tag key.")
+        };
 }

--- a/src/OpenClaw.Shared/Telemetry/OpenClawTelemetryTags.cs
+++ b/src/OpenClaw.Shared/Telemetry/OpenClawTelemetryTags.cs
@@ -20,7 +20,7 @@ public static class OpenClawTelemetryTags
         {
             OpenClawTelemetryTagKey.Source => "openclaw.source",
             OpenClawTelemetryTagKey.Outcome => "openclaw.outcome",
-            OpenClawTelemetryTagKey.ErrorCategory => "openclaw.errorCategory",
+            OpenClawTelemetryTagKey.ErrorCategory => "openclaw.error.category",
             OpenClawTelemetryTagKey.ErrorType => "error.type",
             OpenClawTelemetryTagKey.Reason => "openclaw.reason",
             OpenClawTelemetryTagKey.Status => "openclaw.status",

--- a/src/OpenClaw.Shared/Telemetry/OpenClawTelemetryTags.cs
+++ b/src/OpenClaw.Shared/Telemetry/OpenClawTelemetryTags.cs
@@ -1,0 +1,17 @@
+namespace OpenClaw.Shared.Telemetry;
+
+/// <summary>
+/// Stable tag keys used by OpenClaw instrumentation.
+/// </summary>
+public static class OpenClawTelemetryTags
+{
+    public const string Source = "openclaw.source";
+    public const string Outcome = "openclaw.outcome";
+    public const string ErrorCategory = "openclaw.errorCategory";
+    public const string ErrorType = "error.type";
+    public const string Exporter = "openclaw.exporter";
+    public const string ExporterProtocol = "openclaw.exporter.protocol";
+    public const string Reason = "openclaw.reason";
+    public const string Signal = "openclaw.signal";
+    public const string Status = "openclaw.status";
+}

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -1717,6 +1717,19 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             "[App] Failed to apply OpenTelemetry endpoint settings");
     }
 
+    private async Task<bool> ResendOpenTelemetryProbeAsync()
+    {
+        var connection = _openTelemetryConnection;
+        var settings = _settings;
+        if (connection == null || settings == null)
+            return false;
+
+        var options = OpenTelemetryEndpointOptions.FromSettings(settings);
+        await connection.ProbeAsync(options);
+        return connection.State == OpenTelemetryEndpointConnectionState.ProbeFlushed &&
+            connection.CurrentOptions == options;
+    }
+
     private OpenClaw.Connection.GatewayCredential? ResolveStartupOperatorCredential(
         GatewayRecord record,
         CredentialResolver resolver,
@@ -4021,6 +4034,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     void IAppCommands.ShowGatewayWizard() => _ = ShowGatewayWizardAsync();
     void IAppCommands.ShowConnectionStatus() => ShowConnectionStatusWindow();
     void IAppCommands.NotifySettingsSaved() => OnSettingsSaved(this, EventArgs.Empty);
+    Task<bool> IAppCommands.ResendOpenTelemetryProbeAsync() => ResendOpenTelemetryProbeAsync();
 
     private void ToggleChannel(string channelName) =>
         AsyncEventHandlerGuard.Run(

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -155,6 +155,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
 
     private SettingsManager? _settings;
     private ConnectionSettingsSnapshot? _previousSettingsSnapshot;
+    private OpenTelemetryEndpointConnection? _openTelemetryConnection;
     private SshTunnelService? _sshTunnelService;
     private GlobalHotkeyService? _globalHotkey;
     private Mutex? _mutex;
@@ -365,6 +366,16 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             try { Console.Error.WriteLine($"Process exiting (logger unavailable): {ex.GetType().Name}: {ex.Message}"); }
             catch (Exception) { /* Console.Error itself failed during process exit — nothing left to call. */ }
         }
+
+        try
+        {
+            Interlocked.Exchange(ref _openTelemetryConnection, null)?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            try { System.Diagnostics.Trace.WriteLine($"App.OnProcessExit: OpenTelemetry dispose failed: {ex.GetType().Name}: {ex.Message}"); }
+            catch (Exception) { }
+        }
     }
 
     private void OnUiThread(Microsoft.UI.Dispatching.DispatcherQueueHandler action) => _dispatcherQueue?.TryEnqueue(action);
@@ -484,6 +495,8 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         // Initialize settings before update check so skip selections can be remembered.
         _settings = new SettingsManager();
         _previousSettingsSnapshot = _settings.ToSettingsData().ToConnectionSnapshot();
+        _openTelemetryConnection = new OpenTelemetryEndpointConnection();
+        ApplyOpenTelemetryEndpointSettings();
         _chatCoordinator = new OpenClawTray.Chat.OpenClawChatCoordinator(
             _settings,
             () => _nodeService,
@@ -1689,6 +1702,19 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
                 TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
                 TaskScheduler.Default);
         }
+    }
+
+    private void ApplyOpenTelemetryEndpointSettings()
+    {
+        var connection = _openTelemetryConnection;
+        var settings = _settings;
+        if (connection == null || settings == null)
+            return;
+
+        var options = OpenTelemetryEndpointOptions.FromSettings(settings);
+        ObserveBackgroundFault(
+            connection.ApplyAsync(options),
+            "[App] Failed to apply OpenTelemetry endpoint settings");
     }
 
     private OpenClaw.Connection.GatewayCredential? ResolveStartupOperatorCredential(
@@ -3403,6 +3429,7 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         ObserveBackgroundFault(
             AutoStartManager.SetAutoStartAsync(_settings.AutoStart),
             "[App] Failed to apply auto-start setting");
+        ApplyOpenTelemetryEndpointSettings();
 
         // Apply UI-only settings and notify ad-hoc listeners. This public
         // entry point can be invoked from background work, while existing
@@ -4417,6 +4444,12 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         {
             _chatCoordinator?.Dispose();
             _chatCoordinator = null;
+        });
+
+        SafeShutdownStep("OpenTelemetry endpoint", () =>
+        {
+            _openTelemetryConnection?.Dispose();
+            _openTelemetryConnection = null;
         });
 
         // Dispose runtime services

--- a/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
+++ b/src/OpenClaw.Tray.WinUI/Helpers/FluentIconCatalog.cs
@@ -90,6 +90,7 @@ public static class FluentIconCatalog
     public const string Reset = "\uE72C";          // Refresh (alias) — Reconfigure / start over
     public const string Clear = "\uE74D";          // Delete — clear/reset a buffer
     public const string Develop = "\uE943";        // Code — engineering / explorations action
+    public const string Telemetry = "\uE9F5";      // Processing — ongoing telemetry endpoint/stream
     public const string AgentEvents = "\uE81C";    // History — agent events feed
     public const string Doctor = "\uE95E";         // Health — "Run gateway doctor" health-check action
 

--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -73,6 +73,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$(MicrosoftWindowsAppSDKVersion)" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$(MicrosoftWindowsSdkBuildToolsVersion)" />
+    <PackageReference Include="OpenTelemetry" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageReference Include="WinUIEx" Version="2.9.0" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.3.260402-preview2" />

--- a/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml
@@ -297,9 +297,73 @@
                                       Message="These tools may change app behavior, restart the app, or open experimental UI."
                                       Margin="0,0,0,4"/>
 
+                    <toolkit:SettingsExpander x:Uid="DiagnosticsPage_Expander_OpenTelemetry"
+                                            Header="OpenTelemetry connection"
+                                            Description="Sends a small diagnostic probe only to the OTLP collector endpoint you configure.">
+                       <toolkit:SettingsExpander.HeaderIcon>
+                           <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Telemetry, Mode=OneTime}"
+                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"/>
+                       </toolkit:SettingsExpander.HeaderIcon>
+                       <TextBlock x:Uid="DiagnosticsPage_OpenTelemetrySummary"
+                                  x:Name="OpenTelemetryEndpointSummary"
+                                  Text="Not configured"
+                                  Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                  TextTrimming="CharacterEllipsis"/>
+                       <toolkit:SettingsExpander.ItemsHeader>
+                           <StackPanel Spacing="8"
+                                       Padding="24,16,24,16"
+                                       HorizontalAlignment="Stretch">
+                               <TextBox x:Uid="DiagnosticsPage_OpenTelemetryEndpointBox"
+                                        x:Name="OpenTelemetryEndpointBox"
+                                        Header="Endpoint URL"
+                                        PlaceholderText="http://localhost:4317"
+                                        TextChanged="OnOpenTelemetryEndpointTextChanged"
+                                        AutomationProperties.AutomationId="DiagnosticsOpenTelemetryEndpoint"/>
+                               <StackPanel Spacing="4">
+                                   <TextBlock x:Uid="DiagnosticsPage_OpenTelemetryProtocolLabel"
+                                              Text="Protocol"
+                                              Style="{StaticResource CaptionTextBlockStyle}"
+                                              Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                   <StackPanel Orientation="Horizontal"
+                                               Spacing="16">
+                                       <RadioButton x:Uid="DiagnosticsPage_OpenTelemetryProtocolGrpc"
+                                                    x:Name="OpenTelemetryProtocolGrpcButton"
+                                                    Content="OTLP/gRPC"
+                                                    Checked="OnOpenTelemetryProtocolChanged"
+                                                    AutomationProperties.AutomationId="DiagnosticsOpenTelemetryProtocolGrpc"/>
+                                       <RadioButton x:Uid="DiagnosticsPage_OpenTelemetryProtocolHttp"
+                                                    x:Name="OpenTelemetryProtocolHttpButton"
+                                                    Content="OTLP/HTTP"
+                                                    Checked="OnOpenTelemetryProtocolChanged"
+                                                    AutomationProperties.AutomationId="DiagnosticsOpenTelemetryProtocolHttp"/>
+                                   </StackPanel>
+                               </StackPanel>
+                               <TextBlock x:Name="OpenTelemetryEndpointStatusText"
+                                          Text=""
+                                          TextWrapping="Wrap"
+                                          MinHeight="20"
+                                          Style="{StaticResource CaptionTextBlockStyle}"
+                                          Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                               <StackPanel Orientation="Horizontal"
+                                           Spacing="8">
+                                   <Button x:Uid="DiagnosticsPage_SaveOpenTelemetryEndpointButton"
+                                           x:Name="SaveOpenTelemetryEndpointButton"
+                                           Content="Save connection"
+                                           Click="OnSaveOpenTelemetryEndpoint"
+                                           AutomationProperties.AutomationId="DiagnosticsSaveOpenTelemetryEndpoint"/>
+                                   <Button x:Uid="DiagnosticsPage_ClearOpenTelemetryEndpointButton"
+                                           x:Name="ClearOpenTelemetryEndpointButton"
+                                           Content="Clear"
+                                           Click="OnClearOpenTelemetryEndpoint"
+                                           AutomationProperties.AutomationId="DiagnosticsClearOpenTelemetryEndpoint"/>
+                               </StackPanel>
+                           </StackPanel>
+                       </toolkit:SettingsExpander.ItemsHeader>
+                    </toolkit:SettingsExpander>
+
                     <toolkit:SettingsExpander x:Uid="DiagnosticsPage_Expander_ChatOverrides"
-                                              Header="Chat surface overrides"
-                                              Description="Per-surface override of the chat UI. Resets when OpenClaw restarts.">
+                                             Header="Chat surface overrides"
+                                             Description="Per-surface override of the chat UI. Resets when OpenClaw restarts.">
                         <toolkit:SettingsExpander.HeaderIcon>
                             <FontIcon Glyph="{x:Bind helpers:FluentIconCatalog.Chat, Mode=OneTime}"
                                       FontFamily="{ThemeResource SymbolThemeFontFamily}"/>

--- a/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml
@@ -351,6 +351,11 @@
                                            Content="Save connection"
                                            Click="OnSaveOpenTelemetryEndpoint"
                                            AutomationProperties.AutomationId="DiagnosticsSaveOpenTelemetryEndpoint"/>
+                                   <Button x:Uid="DiagnosticsPage_ResendOpenTelemetryProbeButton"
+                                           x:Name="ResendOpenTelemetryProbeButton"
+                                           Content="Send probe again"
+                                           Click="OnResendOpenTelemetryProbe"
+                                           AutomationProperties.AutomationId="DiagnosticsResendOpenTelemetryProbe"/>
                                    <Button x:Uid="DiagnosticsPage_ClearOpenTelemetryEndpointButton"
                                            x:Name="ClearOpenTelemetryEndpointButton"
                                            Content="Clear"

--- a/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
@@ -723,20 +723,21 @@ public sealed partial class DebugPage : Page
         if (CurrentApp.Settings == null)
             return;
 
-        OpenTelemetryEndpointBox.Text = string.Empty;
-        CurrentApp.Settings.OpenTelemetryEndpoint = string.Empty;
-        CurrentApp.Settings.OpenTelemetryProtocol = OpenTelemetryEndpointProtocol.Grpc;
-        CurrentApp.Settings.Save();
-        ((IAppCommands)CurrentApp).NotifySettingsSaved();
         _suppressOpenTelemetryEndpointChange = true;
         try
         {
+            OpenTelemetryEndpointBox.Text = string.Empty;
             SelectOpenTelemetryProtocol(OpenTelemetryEndpointProtocol.Grpc);
         }
         finally
         {
             _suppressOpenTelemetryEndpointChange = false;
         }
+
+        CurrentApp.Settings.OpenTelemetryEndpoint = string.Empty;
+        CurrentApp.Settings.OpenTelemetryProtocol = OpenTelemetryEndpointProtocol.Grpc;
+        CurrentApp.Settings.Save();
+        ((IAppCommands)CurrentApp).NotifySettingsSaved();
         UpdateOpenTelemetryEndpointStatus(cleared: true);
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
@@ -42,6 +42,7 @@ public sealed partial class DebugPage : Page
 
     private AppState? _appState;
     private bool _suppressOverrideChange;
+    private bool _suppressOpenTelemetryEndpointChange;
 
     private IGatewayTerminalLauncher? _terminalLauncher;
     private GatewayHostAccessPlan _doctorAccessPlan = GatewayHostAccessPlan.None();
@@ -115,6 +116,7 @@ public sealed partial class DebugPage : Page
         UpdateStatusInfoBar();
         UpdateGatewayDoctorCard();
         LoadDeviceIdentity();
+        LoadOpenTelemetryEndpoint();
         LoadChatSurfaceOverrides();
     }
 
@@ -134,6 +136,7 @@ public sealed partial class DebugPage : Page
     {
         UpdateStatusInfoBar();
         UpdateGatewayDoctorCard();
+        LoadOpenTelemetryEndpoint();
     }
 
     /// <summary>
@@ -665,6 +668,152 @@ public sealed partial class DebugPage : Page
     }
 
     // ── Section 3: Developer tools ───────────────────────────────────
+
+    private void LoadOpenTelemetryEndpoint()
+    {
+        _suppressOpenTelemetryEndpointChange = true;
+        try
+        {
+            OpenTelemetryEndpointBox.Text = CurrentApp.Settings?.OpenTelemetryEndpoint ?? string.Empty;
+            SelectOpenTelemetryProtocol(CurrentApp.Settings?.OpenTelemetryProtocol);
+            UpdateOpenTelemetryEndpointStatus();
+        }
+        finally
+        {
+            _suppressOpenTelemetryEndpointChange = false;
+        }
+    }
+
+    private void OnOpenTelemetryEndpointTextChanged(object sender, TextChangedEventArgs e)
+    {
+        if (_suppressOpenTelemetryEndpointChange)
+            return;
+
+        UpdateOpenTelemetryEndpointStatus();
+    }
+
+    private void OnOpenTelemetryProtocolChanged(object sender, RoutedEventArgs e)
+    {
+        if (_suppressOpenTelemetryEndpointChange)
+            return;
+
+        UpdateOpenTelemetryEndpointStatus();
+    }
+
+    private void OnSaveOpenTelemetryEndpoint(object sender, RoutedEventArgs e)
+    {
+        if (CurrentApp.Settings == null)
+            return;
+
+        if (!TryNormalizeOpenTelemetryEndpoint(OpenTelemetryEndpointBox.Text, out var endpoint, out _))
+        {
+            UpdateOpenTelemetryEndpointStatus();
+            return;
+        }
+
+        CurrentApp.Settings.OpenTelemetryEndpoint = endpoint ?? string.Empty;
+        CurrentApp.Settings.OpenTelemetryProtocol = GetSelectedOpenTelemetryProtocol();
+        CurrentApp.Settings.Save();
+        ((IAppCommands)CurrentApp).NotifySettingsSaved();
+        UpdateOpenTelemetryEndpointStatus(saved: true);
+    }
+
+    private void OnClearOpenTelemetryEndpoint(object sender, RoutedEventArgs e)
+    {
+        if (CurrentApp.Settings == null)
+            return;
+
+        OpenTelemetryEndpointBox.Text = string.Empty;
+        CurrentApp.Settings.OpenTelemetryEndpoint = string.Empty;
+        CurrentApp.Settings.Save();
+        ((IAppCommands)CurrentApp).NotifySettingsSaved();
+        _suppressOpenTelemetryEndpointChange = true;
+        try
+        {
+            SelectOpenTelemetryProtocol(CurrentApp.Settings.OpenTelemetryProtocol);
+        }
+        finally
+        {
+            _suppressOpenTelemetryEndpointChange = false;
+        }
+        UpdateOpenTelemetryEndpointStatus(cleared: true);
+    }
+
+    private void UpdateOpenTelemetryEndpointStatus(bool saved = false, bool cleared = false)
+    {
+        var current = CurrentApp.Settings?.OpenTelemetryEndpoint ?? string.Empty;
+        var currentProtocol = OpenTelemetryEndpointProtocol.Normalize(CurrentApp.Settings?.OpenTelemetryProtocol);
+        var selectedProtocol = GetSelectedOpenTelemetryProtocol();
+        var raw = OpenTelemetryEndpointBox.Text;
+        var valid = TryNormalizeOpenTelemetryEndpoint(raw, out var endpoint, out var error);
+        var endpointText = endpoint ?? string.Empty;
+        var hasEndpoint = !string.IsNullOrWhiteSpace(endpointText);
+        var dirty =
+            !string.Equals(current, endpointText, StringComparison.Ordinal) ||
+            !string.Equals(currentProtocol, selectedProtocol, StringComparison.Ordinal);
+
+        SaveOpenTelemetryEndpointButton.IsEnabled = valid && dirty;
+        ClearOpenTelemetryEndpointButton.IsEnabled = hasEndpoint || !string.IsNullOrWhiteSpace(current);
+        OpenTelemetryEndpointSummary.Text = string.IsNullOrWhiteSpace(current)
+            ? LocalizationHelper.GetString("DiagnosticsPage_OpenTelemetrySummary_NotConfigured")
+            : LocalizationHelper.GetString("DiagnosticsPage_OpenTelemetrySummary_Configured");
+
+        if (!valid)
+        {
+            OpenTelemetryEndpointStatusText.Foreground = WarnTextBrush;
+            OpenTelemetryEndpointStatusText.Text = error ?? LocalizationHelper.GetString("DiagnosticsPage_OpenTelemetryEndpointStatus_InvalidMessage");
+            return;
+        }
+
+        OpenTelemetryEndpointStatusText.Foreground = DimTextBrush;
+
+        if (cleared)
+        {
+            OpenTelemetryEndpointStatusText.Text = LocalizationHelper.GetString("DiagnosticsPage_OpenTelemetryEndpointStatus_ClearedTitle");
+            return;
+        }
+
+        if (saved && hasEndpoint)
+        {
+            OpenTelemetryEndpointStatusText.Text = LocalizationHelper.GetString("DiagnosticsPage_OpenTelemetryEndpointStatus_SavedTitle");
+            return;
+        }
+
+        OpenTelemetryEndpointStatusText.Text = dirty
+            ? LocalizationHelper.GetString("DiagnosticsPage_OpenTelemetryEndpointStatus_UnsavedMessage")
+            : string.Empty;
+    }
+
+    private void SelectOpenTelemetryProtocol(string? protocol)
+    {
+        var normalized = OpenTelemetryEndpointProtocol.Normalize(protocol);
+        OpenTelemetryProtocolGrpcButton.IsChecked = normalized == OpenTelemetryEndpointProtocol.Grpc;
+        OpenTelemetryProtocolHttpButton.IsChecked = normalized == OpenTelemetryEndpointProtocol.HttpProtobuf;
+    }
+
+    private string GetSelectedOpenTelemetryProtocol() =>
+        OpenTelemetryProtocolHttpButton.IsChecked == true
+            ? OpenTelemetryEndpointProtocol.HttpProtobuf
+            : OpenTelemetryEndpointProtocol.Grpc;
+
+    private static bool TryNormalizeOpenTelemetryEndpoint(string? raw, out string? endpoint, out string? error)
+    {
+        endpoint = string.IsNullOrWhiteSpace(raw) ? null : raw.Trim();
+        error = null;
+
+        if (endpoint == null)
+            return true;
+
+        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps) ||
+            string.IsNullOrWhiteSpace(uri.Host))
+        {
+            error = LocalizationHelper.GetString("DiagnosticsPage_OpenTelemetryEndpointStatus_InvalidMessage");
+            return false;
+        }
+
+        return true;
+    }
 
     private void LoadChatSurfaceOverrides()
     {

--- a/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
@@ -725,12 +725,13 @@ public sealed partial class DebugPage : Page
 
         OpenTelemetryEndpointBox.Text = string.Empty;
         CurrentApp.Settings.OpenTelemetryEndpoint = string.Empty;
+        CurrentApp.Settings.OpenTelemetryProtocol = OpenTelemetryEndpointProtocol.Grpc;
         CurrentApp.Settings.Save();
         ((IAppCommands)CurrentApp).NotifySettingsSaved();
         _suppressOpenTelemetryEndpointChange = true;
         try
         {
-            SelectOpenTelemetryProtocol(CurrentApp.Settings.OpenTelemetryProtocol);
+            SelectOpenTelemetryProtocol(OpenTelemetryEndpointProtocol.Grpc);
         }
         finally
         {
@@ -804,9 +805,7 @@ public sealed partial class DebugPage : Page
         if (endpoint == null)
             return true;
 
-        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var uri) ||
-            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps) ||
-            string.IsNullOrWhiteSpace(uri.Host))
+        if (!OpenTelemetryEndpointOptions.TryCreateEndpointUri(endpoint, out _))
         {
             error = LocalizationHelper.GetString("DiagnosticsPage_OpenTelemetryEndpointStatus_InvalidMessage");
             return false;

--- a/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml.cs
@@ -741,7 +741,30 @@ public sealed partial class DebugPage : Page
         UpdateOpenTelemetryEndpointStatus(cleared: true);
     }
 
-    private void UpdateOpenTelemetryEndpointStatus(bool saved = false, bool cleared = false)
+    private void OnResendOpenTelemetryProbe(object sender, RoutedEventArgs e) =>
+        AsyncEventHandlerGuard.Run(
+            ResendOpenTelemetryProbeAsync,
+            new OpenClawTray.AppLogger(),
+            nameof(OnResendOpenTelemetryProbe));
+
+    private async Task ResendOpenTelemetryProbeAsync()
+    {
+        ResendOpenTelemetryProbeButton.IsEnabled = false;
+        bool? probeFlushed = null;
+        try
+        {
+            probeFlushed = await ((IAppCommands)CurrentApp).ResendOpenTelemetryProbeAsync();
+        }
+        finally
+        {
+            UpdateOpenTelemetryEndpointStatus(probeFlushed: probeFlushed);
+        }
+    }
+
+    private void UpdateOpenTelemetryEndpointStatus(
+        bool saved = false,
+        bool cleared = false,
+        bool? probeFlushed = null)
     {
         var current = CurrentApp.Settings?.OpenTelemetryEndpoint ?? string.Empty;
         var currentProtocol = OpenTelemetryEndpointProtocol.Normalize(CurrentApp.Settings?.OpenTelemetryProtocol);
@@ -755,6 +778,7 @@ public sealed partial class DebugPage : Page
             !string.Equals(currentProtocol, selectedProtocol, StringComparison.Ordinal);
 
         SaveOpenTelemetryEndpointButton.IsEnabled = valid && dirty;
+        ResendOpenTelemetryProbeButton.IsEnabled = valid && hasEndpoint && !dirty;
         ClearOpenTelemetryEndpointButton.IsEnabled = hasEndpoint || !string.IsNullOrWhiteSpace(current);
         OpenTelemetryEndpointSummary.Text = string.IsNullOrWhiteSpace(current)
             ? LocalizationHelper.GetString("DiagnosticsPage_OpenTelemetrySummary_NotConfigured")
@@ -778,6 +802,17 @@ public sealed partial class DebugPage : Page
         if (saved && hasEndpoint)
         {
             OpenTelemetryEndpointStatusText.Text = LocalizationHelper.GetString("DiagnosticsPage_OpenTelemetryEndpointStatus_SavedTitle");
+            return;
+        }
+
+        if (probeFlushed.HasValue)
+        {
+            OpenTelemetryEndpointStatusText.Foreground =
+                probeFlushed.Value ? DimTextBrush : WarnTextBrush;
+            OpenTelemetryEndpointStatusText.Text = LocalizationHelper.GetString(
+                probeFlushed.Value
+                    ? "DiagnosticsPage_OpenTelemetryEndpointStatus_ProbeFlushedMessage"
+                    : "DiagnosticsPage_OpenTelemetryEndpointStatus_ProbeFailedMessage");
             return;
         }
 

--- a/src/OpenClaw.Tray.WinUI/Services/IAppCommands.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/IAppCommands.cs
@@ -18,4 +18,5 @@ internal interface IAppCommands
     void ShowGatewayWizard();
     void ShowConnectionStatus();
     void NotifySettingsSaved();
+    Task<bool> ResendOpenTelemetryProbeAsync();
 }

--- a/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
@@ -106,11 +106,11 @@ internal sealed class OpenTelemetryEndpointConnection : IDisposable
             {
                 newSink = _sinkFactory(options);
                 newSink.SendProbe(options);
-                if (!newSink.ForceFlush(3_000))
+                if (!newSink.ForceFlush(OpenTelemetryOtlpProbeSink.ProbeFlushTimeoutMilliseconds))
                 {
-                    newSink.Dispose();
+                    DisposeProbeSink(newSink, "discarding an unflushed OpenTelemetry probe sink");
                     State = OpenTelemetryEndpointConnectionState.Failed;
-                    LastError = "OpenTelemetry probe did not flush within 3000 ms.";
+                    LastError = $"OpenTelemetry probe did not flush within {OpenTelemetryOtlpProbeSink.ProbeFlushTimeoutMilliseconds} ms.";
                     _currentOptions = options;
                     _logWarn($"OpenTelemetry endpoint probe failed: {LastError}");
                     return;
@@ -118,10 +118,12 @@ internal sealed class OpenTelemetryEndpointConnection : IDisposable
 
                 if (IsStale(generation))
                 {
-                    newSink.Dispose();
+                    DisposeProbeSink(newSink, "discarding a stale OpenTelemetry probe sink");
                     return;
                 }
 
+                // ForceFlush confirms the SDK processed queued batches; OTLP does not provide
+                // a collector acknowledgment round-trip for this probe.
                 _sink = newSink;
                 newSink = null;
                 _currentOptions = options;
@@ -131,7 +133,7 @@ internal sealed class OpenTelemetryEndpointConnection : IDisposable
             }
             catch (Exception ex)
             {
-                newSink?.Dispose();
+                DisposeProbeSink(newSink, "discarding a failed OpenTelemetry probe sink");
                 State = OpenTelemetryEndpointConnectionState.Failed;
                 LastError = ex.Message;
                 _currentOptions = options;
@@ -165,7 +167,22 @@ internal sealed class OpenTelemetryEndpointConnection : IDisposable
     {
         var sink = _sink;
         _sink = null;
-        sink?.Dispose();
+        DisposeProbeSink(sink, "disposing the current OpenTelemetry probe sink");
+    }
+
+    private void DisposeProbeSink(IOpenTelemetryProbeSink? sink, string context)
+    {
+        if (sink == null)
+            return;
+
+        try
+        {
+            sink.Dispose();
+        }
+        catch (Exception ex)
+        {
+            _logWarn($"OpenTelemetry endpoint sink disposal failed while {context}: {ex.Message}");
+        }
     }
 
     private bool IsStale(long? generation) =>
@@ -175,6 +192,8 @@ internal sealed class OpenTelemetryEndpointConnection : IDisposable
 
 internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
 {
+    internal const int ProbeFlushTimeoutMilliseconds = 3_000;
+    private const int DisposeFlushTimeoutMilliseconds = 500;
     private const string ExporterTagKey = "openclaw.exporter";
     private const string ExporterProtocolTagKey = "openclaw.exporter.protocol";
     private const string SignalTagKey = "openclaw.signal";
@@ -279,12 +298,16 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
 
     public void Dispose()
     {
-        _tracerProvider.ForceFlush(2_000);
-        _meterProvider.ForceFlush(2_000);
-        _loggerPipeline.ForceFlush(2_000);
-        _tracerProvider.Dispose();
-        _meterProvider.Dispose();
-        _loggerPipeline.Dispose();
+        List<Exception>? errors = null;
+        TryDisposeStep(() => _tracerProvider.ForceFlush(DisposeFlushTimeoutMilliseconds), ref errors);
+        TryDisposeStep(() => _meterProvider.ForceFlush(DisposeFlushTimeoutMilliseconds), ref errors);
+        TryDisposeStep(() => _loggerPipeline.ForceFlush(DisposeFlushTimeoutMilliseconds), ref errors);
+        TryDisposeStep(_tracerProvider.Dispose, ref errors);
+        TryDisposeStep(_meterProvider.Dispose, ref errors);
+        TryDisposeStep(_loggerPipeline.Dispose, ref errors);
+
+        if (errors != null)
+            throw new AggregateException("OpenTelemetry endpoint sink disposal failed.", errors);
     }
 
     private static ResourceBuilder CreateResourceBuilder() =>
@@ -352,6 +375,19 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
         new(SignalTagKey, "logs"),
         new(ExporterProtocolTagKey, OpenTelemetryEndpointProtocol.ToTelemetryValue(options.Protocol))
     ];
+
+    private static void TryDisposeStep(Action step, ref List<Exception>? errors)
+    {
+        try
+        {
+            step();
+        }
+        catch (Exception ex)
+        {
+            errors ??= [];
+            errors.Add(ex);
+        }
+    }
 
     private sealed class OpenTelemetryLoggerPipeline : IDisposable
     {

--- a/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
@@ -1,7 +1,9 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Exporter;
+using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -176,6 +178,7 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
     private const string ExporterTagKey = "openclaw.exporter";
     private const string ExporterProtocolTagKey = "openclaw.exporter.protocol";
     private const string SignalTagKey = "openclaw.signal";
+    private static readonly EventId ExporterProbeLogEvent = new(1000, "OpenTelemetryExporterProbeSent");
     private static readonly Counter<long> ExporterProbeCounter = OpenClawTelemetry.CreateCounter(
         "openclaw.telemetry.exporter.probes",
         unit: "{probe}",
@@ -183,11 +186,18 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
 
     private readonly TracerProvider _tracerProvider;
     private readonly MeterProvider _meterProvider;
+    private readonly OpenTelemetryLoggerPipeline _loggerPipeline;
+    private readonly ILogger _probeLogger;
 
-    private OpenTelemetryOtlpProbeSink(TracerProvider tracerProvider, MeterProvider meterProvider)
+    private OpenTelemetryOtlpProbeSink(
+        TracerProvider tracerProvider,
+        MeterProvider meterProvider,
+        OpenTelemetryLoggerPipeline loggerPipeline)
     {
         _tracerProvider = tracerProvider;
         _meterProvider = meterProvider;
+        _loggerPipeline = loggerPipeline;
+        _probeLogger = loggerPipeline.CreateLogger(OpenTelemetryLogPolicy.TelemetryExporterCategory);
     }
 
     public static IOpenTelemetryProbeSink Create(OpenTelemetryEndpointOptions options)
@@ -197,6 +207,7 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
 
         TracerProvider? tracerProvider = null;
         MeterProvider? meterProvider = null;
+        OpenTelemetryLoggerPipeline? loggerPipeline = null;
 
         try
         {
@@ -212,15 +223,19 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
                 .AddOtlpExporter(exporter => ConfigureExporter(exporter, endpoint, options.Protocol))
                 .Build();
 
-            var sink = new OpenTelemetryOtlpProbeSink(tracerProvider, meterProvider);
+            loggerPipeline = CreateLoggerPipeline(endpoint, options.Protocol);
+
+            var sink = new OpenTelemetryOtlpProbeSink(tracerProvider, meterProvider, loggerPipeline);
             tracerProvider = null;
             meterProvider = null;
+            loggerPipeline = null;
             return sink;
         }
         finally
         {
             tracerProvider?.Dispose();
             meterProvider?.Dispose();
+            loggerPipeline?.Dispose();
         }
     }
 
@@ -234,6 +249,13 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
         OpenClawTelemetry.Add(
             ExporterProbeCounter,
             tags: CreateProbeTags(options, "metrics"));
+
+        _probeLogger.Log(
+            LogLevel.Information,
+            ExporterProbeLogEvent,
+            CreateProbeLogAttributes(options),
+            null,
+            static (_, _) => "OpenClaw telemetry exporter probe log sent.");
     }
 
     public bool ForceFlush(int timeoutMilliseconds)
@@ -242,22 +264,27 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
         {
             var tracesOk = _tracerProvider.ForceFlush(timeoutMilliseconds);
             var metricsOk = _meterProvider.ForceFlush(timeoutMilliseconds);
-            return tracesOk && metricsOk;
+            var logsOk = _loggerPipeline.ForceFlush(timeoutMilliseconds);
+            return tracesOk && metricsOk && logsOk;
         }
 
         var stopwatch = Stopwatch.StartNew();
         var tracesFlushed = _tracerProvider.ForceFlush(timeoutMilliseconds);
         var remainingMilliseconds = Math.Max(0, timeoutMilliseconds - (int)Math.Min(int.MaxValue, stopwatch.ElapsedMilliseconds));
         var metricsFlushed = _meterProvider.ForceFlush(remainingMilliseconds);
-        return tracesFlushed && metricsFlushed;
+        remainingMilliseconds = Math.Max(0, timeoutMilliseconds - (int)Math.Min(int.MaxValue, stopwatch.ElapsedMilliseconds));
+        var logsFlushed = _loggerPipeline.ForceFlush(remainingMilliseconds);
+        return tracesFlushed && metricsFlushed && logsFlushed;
     }
 
     public void Dispose()
     {
         _tracerProvider.ForceFlush(2_000);
         _meterProvider.ForceFlush(2_000);
+        _loggerPipeline.ForceFlush(2_000);
         _tracerProvider.Dispose();
         _meterProvider.Dispose();
+        _loggerPipeline.Dispose();
     }
 
     private static ResourceBuilder CreateResourceBuilder() =>
@@ -281,6 +308,31 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
             : OtlpExportProtocol.Grpc;
     }
 
+    private static OpenTelemetryLoggerPipeline CreateLoggerPipeline(Uri endpoint, string? protocol)
+    {
+        OpenTelemetrySdk? sdk = null;
+        try
+        {
+            sdk = OpenTelemetrySdk.Create(builder => builder.WithLogging(
+                logging => logging
+                    .SetResourceBuilder(CreateResourceBuilder())
+                    .AddOtlpExporter(exporter => ConfigureExporter(exporter, endpoint, protocol)),
+                options =>
+                {
+                    options.IncludeScopes = false;
+                    options.IncludeFormattedMessage = false;
+                    options.ParseStateValues = true;
+                }));
+            var pipeline = new OpenTelemetryLoggerPipeline(sdk, sdk.GetLoggerFactory());
+            sdk = null;
+            return pipeline;
+        }
+        finally
+        {
+            sdk?.Dispose();
+        }
+    }
+
     private static OpenClawTelemetryTag[] CreateProbeTags(OpenTelemetryEndpointOptions options, string signal) =>
     [
         OpenClawTelemetryTag.String(
@@ -293,4 +345,69 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
             ExporterProtocolTagKey,
             OpenTelemetryEndpointProtocol.ToTelemetryValue(options.Protocol))
     ];
+
+    private static KeyValuePair<string, object?>[] CreateProbeLogAttributes(OpenTelemetryEndpointOptions options) =>
+    [
+        new(ExporterTagKey, "tray-otel"),
+        new(SignalTagKey, "logs"),
+        new(ExporterProtocolTagKey, OpenTelemetryEndpointProtocol.ToTelemetryValue(options.Protocol))
+    ];
+
+    private sealed class OpenTelemetryLoggerPipeline : IDisposable
+    {
+        private readonly OpenTelemetrySdk _sdk;
+        private readonly ILoggerFactory _loggerFactory;
+
+        public OpenTelemetryLoggerPipeline(
+            OpenTelemetrySdk sdk,
+            ILoggerFactory loggerFactory)
+        {
+            _sdk = sdk;
+            _loggerFactory = loggerFactory;
+        }
+
+        public ILogger CreateLogger(string categoryName) =>
+            new PolicyLogger(categoryName, _loggerFactory.CreateLogger(categoryName));
+
+        public bool ForceFlush(int timeoutMilliseconds) =>
+            _sdk.LoggerProvider.ForceFlush(timeoutMilliseconds);
+
+        public void Dispose() =>
+            _sdk.Dispose();
+    }
+
+    private sealed class PolicyLogger : ILogger
+    {
+        private readonly string _categoryName;
+        private readonly ILogger _inner;
+
+        public PolicyLogger(string categoryName, ILogger inner)
+        {
+            _categoryName = categoryName;
+            _inner = inner;
+        }
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull =>
+            _inner.BeginScope(state);
+
+        public bool IsEnabled(LogLevel logLevel) =>
+            OpenTelemetryLogPolicy.ShouldExport(_categoryName, logLevel) && _inner.IsEnabled(logLevel);
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (!OpenTelemetryLogPolicy.ShouldExport(_categoryName, logLevel))
+                return;
+
+            if (!_inner.IsEnabled(logLevel))
+                return;
+
+            _inner.Log(logLevel, eventId, state, exception, formatter);
+        }
+    }
 }

--- a/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
@@ -1,8 +1,8 @@
-using System.Diagnostics;
 using OpenTelemetry;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using OpenClaw.Shared.Telemetry;
 
 namespace OpenClawTray.Services;
 
@@ -21,8 +21,6 @@ internal interface IOpenTelemetryProbeSink : IDisposable
 
 internal sealed class OpenTelemetryEndpointConnection : IDisposable
 {
-    internal const string ProbeActivityName = "openclaw.telemetry.probe";
-
     private readonly object _gate = new();
     private readonly Func<OpenTelemetryEndpointOptions, IOpenTelemetryProbeSink> _sinkFactory;
     private readonly Action<string> _logInfo;
@@ -172,8 +170,6 @@ internal sealed class OpenTelemetryEndpointConnection : IDisposable
 
 internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
 {
-    private const string ActivitySourceName = "OpenClaw.Companion.TelemetryProbe";
-    private static readonly ActivitySource s_activitySource = new(ActivitySourceName);
     private readonly TracerProvider _provider;
 
     private OpenTelemetryOtlpProbeSink(TracerProvider provider)
@@ -189,13 +185,13 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
         var provider = Sdk.CreateTracerProviderBuilder()
             .SetResourceBuilder(ResourceBuilder.CreateDefault()
                 .AddService(
-                    serviceName: "OpenClaw.Companion",
+                    serviceName: OpenClawResourceNames.Tray,
                     serviceVersion: typeof(OpenTelemetryOtlpProbeSink).Assembly.GetName().Version?.ToString())
                 .AddAttributes(new Dictionary<string, object>
                 {
                     ["process.pid"] = Environment.ProcessId
                 }))
-            .AddSource(ActivitySourceName)
+            .AddSource(OpenClawActivitySources.ExportedNames.ToArray())
             .AddOtlpExporter(exporter =>
             {
                 exporter.Endpoint = endpoint;
@@ -210,12 +206,21 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
 
     public void SendProbe(OpenTelemetryEndpointOptions options)
     {
-        using var activity = s_activitySource.StartActivity(
-            OpenTelemetryEndpointConnection.ProbeActivityName,
-            ActivityKind.Internal);
-        activity?.SetTag("openclaw.telemetry.protocol", OpenTelemetryEndpointProtocol.ToDisplayName(options.Protocol));
-        activity?.SetTag("openclaw.telemetry.probe", true);
-        activity?.SetStatus(ActivityStatusCode.Ok);
+        OpenClawTelemetry.Trace(
+            OpenClawActivitySources.OpenClawSource,
+            "openclaw.telemetry.exporter.probe",
+            static () => { },
+            [
+                OpenClawTelemetryTag.String(
+                    OpenClawTelemetryTags.Exporter,
+                    "tray-otel"),
+                OpenClawTelemetryTag.String(
+                    OpenClawTelemetryTags.Signal,
+                    "traces"),
+                OpenClawTelemetryTag.String(
+                    OpenClawTelemetryTags.ExporterProtocol,
+                    OpenTelemetryEndpointProtocol.ToTelemetryValue(options.Protocol))
+            ]);
     }
 
     public bool ForceFlush(int timeoutMilliseconds) => _provider.ForceFlush(timeoutMilliseconds);

--- a/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
@@ -14,7 +14,7 @@ namespace OpenClawTray.Services;
 internal enum OpenTelemetryEndpointConnectionState
 {
     Disabled,
-    Connected,
+    ProbeFlushed,
     Failed
 }
 
@@ -96,7 +96,7 @@ internal sealed class OpenTelemetryEndpointConnection : IDisposable
                 return;
             }
 
-            if (_sink != null && State == OpenTelemetryEndpointConnectionState.Connected && options == _currentOptions)
+            if (_sink != null && State == OpenTelemetryEndpointConnectionState.ProbeFlushed && options == _currentOptions)
                 return;
 
             DisposeSink();
@@ -127,7 +127,7 @@ internal sealed class OpenTelemetryEndpointConnection : IDisposable
                 _sink = newSink;
                 newSink = null;
                 _currentOptions = options;
-                State = OpenTelemetryEndpointConnectionState.Connected;
+                State = OpenTelemetryEndpointConnectionState.ProbeFlushed;
                 LastError = null;
                 _logInfo($"OpenTelemetry endpoint probe sent using {OpenTelemetryEndpointProtocol.ToDisplayName(options.Protocol)}.");
             }

--- a/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
@@ -194,6 +194,10 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
 {
     internal const int ProbeFlushTimeoutMilliseconds = 3_000;
     private const int DisposeFlushTimeoutMilliseconds = 500;
+    private const string HttpVersionPath = "v1";
+    private const string TraceHttpPath = "v1/traces";
+    private const string MetricHttpPath = "v1/metrics";
+    private const string LogHttpPath = "v1/logs";
     private const string ExporterTagKey = "openclaw.exporter";
     private const string ExporterProtocolTagKey = "openclaw.exporter.protocol";
     private const string SignalTagKey = "openclaw.signal";
@@ -202,6 +206,13 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
         "openclaw.telemetry.exporter.probes",
         unit: "{probe}",
         description: "Number of OpenClaw telemetry exporter probe metrics sent.");
+
+    internal enum OpenTelemetryOtlpSignal
+    {
+        Traces,
+        Metrics,
+        Logs
+    }
 
     private readonly TracerProvider _tracerProvider;
     private readonly MeterProvider _meterProvider;
@@ -233,13 +244,13 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
             tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .SetResourceBuilder(CreateResourceBuilder())
                 .AddSource(OpenClawActivitySourceName.OpenClaw.ToTelemetryName())
-                .AddOtlpExporter(exporter => ConfigureExporter(exporter, endpoint, options.Protocol))
+                .AddOtlpExporter(exporter => ConfigureExporter(exporter, endpoint, options.Protocol, OpenTelemetryOtlpSignal.Traces))
                 .Build();
 
             meterProvider = Sdk.CreateMeterProviderBuilder()
                 .SetResourceBuilder(CreateResourceBuilder())
                 .AddMeter(OpenClawMeterName.OpenClaw.ToTelemetryName())
-                .AddOtlpExporter(exporter => ConfigureExporter(exporter, endpoint, options.Protocol))
+                .AddOtlpExporter(exporter => ConfigureExporter(exporter, endpoint, options.Protocol, OpenTelemetryOtlpSignal.Metrics))
                 .Build();
 
             loggerPipeline = CreateLoggerPipeline(endpoint, options.Protocol);
@@ -323,12 +334,66 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
     private static void ConfigureExporter(
         OtlpExporterOptions exporter,
         Uri endpoint,
-        string? protocol)
+        string? protocol,
+        OpenTelemetryOtlpSignal signal)
     {
-        exporter.Endpoint = endpoint;
-        exporter.Protocol = protocol == OpenTelemetryEndpointProtocol.HttpProtobuf
+        var normalizedProtocol = OpenTelemetryEndpointProtocol.Normalize(protocol);
+        exporter.Endpoint = ResolveExporterEndpoint(endpoint, normalizedProtocol, signal);
+        exporter.Protocol = normalizedProtocol == OpenTelemetryEndpointProtocol.HttpProtobuf
             ? OtlpExportProtocol.HttpProtobuf
             : OtlpExportProtocol.Grpc;
+    }
+
+    // Explicitly resolve full signal endpoints for HTTP/protobuf so traces,
+    // metrics, and logs do not compete for one collector URL.
+    internal static Uri ResolveExporterEndpoint(
+        Uri endpoint,
+        string? protocol,
+        OpenTelemetryOtlpSignal signal) =>
+        OpenTelemetryEndpointProtocol.Normalize(protocol) == OpenTelemetryEndpointProtocol.HttpProtobuf
+            ? AppendHttpSignalPath(endpoint, signal)
+            : endpoint;
+
+    private static Uri AppendHttpSignalPath(Uri endpoint, OpenTelemetryOtlpSignal signal)
+    {
+        var prefix = TrimKnownHttpSignalSuffix(endpoint.AbsolutePath.Trim('/'));
+        var signalPath = signal switch
+        {
+            OpenTelemetryOtlpSignal.Traces => TraceHttpPath,
+            OpenTelemetryOtlpSignal.Metrics => MetricHttpPath,
+            OpenTelemetryOtlpSignal.Logs => LogHttpPath,
+            _ => throw new ArgumentOutOfRangeException(nameof(signal), signal, null)
+        };
+        var path = string.IsNullOrEmpty(prefix)
+            ? signalPath
+            : $"{prefix}/{signalPath}";
+
+        return new UriBuilder(endpoint)
+        {
+            Path = path,
+            Query = string.Empty,
+            Fragment = string.Empty
+        }.Uri;
+    }
+
+    private static string TrimKnownHttpSignalSuffix(string path)
+    {
+        foreach (var suffix in new[] { TraceHttpPath, MetricHttpPath, LogHttpPath })
+        {
+            if (string.Equals(path, suffix, StringComparison.OrdinalIgnoreCase))
+                return string.Empty;
+
+            if (path.EndsWith($"/{suffix}", StringComparison.OrdinalIgnoreCase))
+                return path[..^(suffix.Length + 1)];
+        }
+
+        if (string.Equals(path, HttpVersionPath, StringComparison.OrdinalIgnoreCase))
+            return string.Empty;
+
+        if (path.EndsWith($"/{HttpVersionPath}", StringComparison.OrdinalIgnoreCase))
+            return path[..^(HttpVersionPath.Length + 1)];
+
+        return path;
     }
 
     private static OpenTelemetryLoggerPipeline CreateLoggerPipeline(Uri endpoint, string? protocol)
@@ -339,7 +404,7 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
             sdk = OpenTelemetrySdk.Create(builder => builder.WithLogging(
                 logging => logging
                     .SetResourceBuilder(CreateResourceBuilder())
-                    .AddOtlpExporter(exporter => ConfigureExporter(exporter, endpoint, protocol)),
+                    .AddOtlpExporter(exporter => ConfigureExporter(exporter, endpoint, protocol, OpenTelemetryOtlpSignal.Logs)),
                 options =>
                 {
                     options.IncludeScopes = false;

--- a/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
@@ -61,20 +61,26 @@ internal sealed class OpenTelemetryEndpointConnection : IDisposable
         Apply(OpenTelemetryEndpointOptions.FromSettings(settings));
 
     public Task ApplyAsync(OpenTelemetryEndpointOptions options)
+        => ApplyAsync(options, forceProbe: false);
+
+    public Task ProbeAsync(OpenTelemetryEndpointOptions options)
+        => ApplyAsync(options, forceProbe: true);
+
+    private Task ApplyAsync(OpenTelemetryEndpointOptions options, bool forceProbe)
     {
         if (_disposed)
             return Task.CompletedTask;
 
         var generation = Interlocked.Increment(ref _applyGeneration);
-        return Task.Run(() => Apply(options, generation));
+        return Task.Run(() => Apply(options, generation, forceProbe));
     }
 
     internal void Apply(OpenTelemetryEndpointOptions options)
     {
-        Apply(options, generation: null);
+        Apply(options, generation: null, forceProbe: false);
     }
 
-    private void Apply(OpenTelemetryEndpointOptions options, long? generation)
+    private void Apply(OpenTelemetryEndpointOptions options, long? generation, bool forceProbe)
     {
         lock (_gate)
         {
@@ -96,7 +102,10 @@ internal sealed class OpenTelemetryEndpointConnection : IDisposable
                 return;
             }
 
-            if (_sink != null && State == OpenTelemetryEndpointConnectionState.ProbeFlushed && options == _currentOptions)
+            if (!forceProbe &&
+                _sink != null &&
+                State == OpenTelemetryEndpointConnectionState.ProbeFlushed &&
+                options == _currentOptions)
                 return;
 
             DisposeSink();

--- a/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
@@ -1,0 +1,228 @@
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace OpenClawTray.Services;
+
+internal enum OpenTelemetryEndpointConnectionState
+{
+    Disabled,
+    Connected,
+    Failed
+}
+
+internal interface IOpenTelemetryProbeSink : IDisposable
+{
+    void SendProbe(OpenTelemetryEndpointOptions options);
+    bool ForceFlush(int timeoutMilliseconds);
+}
+
+internal sealed class OpenTelemetryEndpointConnection : IDisposable
+{
+    internal const string ProbeActivityName = "openclaw.telemetry.probe";
+
+    private readonly object _gate = new();
+    private readonly Func<OpenTelemetryEndpointOptions, IOpenTelemetryProbeSink> _sinkFactory;
+    private readonly Action<string> _logInfo;
+    private readonly Action<string> _logWarn;
+    private IOpenTelemetryProbeSink? _sink;
+    private OpenTelemetryEndpointOptions _currentOptions = OpenTelemetryEndpointOptions.Disabled;
+    private long _applyGeneration;
+    private volatile bool _disposed;
+
+    public OpenTelemetryEndpointConnection()
+        : this(OpenTelemetryOtlpProbeSink.Create, Logger.Info, Logger.Warn)
+    {
+    }
+
+    internal OpenTelemetryEndpointConnection(
+        Func<OpenTelemetryEndpointOptions, IOpenTelemetryProbeSink> sinkFactory,
+        Action<string> logInfo,
+        Action<string> logWarn)
+    {
+        _sinkFactory = sinkFactory ?? throw new ArgumentNullException(nameof(sinkFactory));
+        _logInfo = logInfo ?? throw new ArgumentNullException(nameof(logInfo));
+        _logWarn = logWarn ?? throw new ArgumentNullException(nameof(logWarn));
+    }
+
+    public OpenTelemetryEndpointConnectionState State { get; private set; } =
+        OpenTelemetryEndpointConnectionState.Disabled;
+
+    public string? LastError { get; private set; }
+
+    public OpenTelemetryEndpointOptions CurrentOptions => _currentOptions;
+
+    public void Apply(SettingsManager? settings) =>
+        Apply(OpenTelemetryEndpointOptions.FromSettings(settings));
+
+    public Task ApplyAsync(OpenTelemetryEndpointOptions options)
+    {
+        if (_disposed)
+            return Task.CompletedTask;
+
+        var generation = Interlocked.Increment(ref _applyGeneration);
+        return Task.Run(() => Apply(options, generation));
+    }
+
+    internal void Apply(OpenTelemetryEndpointOptions options)
+    {
+        Apply(options, generation: null);
+    }
+
+    private void Apply(OpenTelemetryEndpointOptions options, long? generation)
+    {
+        lock (_gate)
+        {
+            if (IsStale(generation))
+                return;
+
+            if (!options.IsEnabled)
+            {
+                Disable();
+                return;
+            }
+
+            if (!options.TryGetEndpointUri(out _))
+            {
+                Disable();
+                State = OpenTelemetryEndpointConnectionState.Failed;
+                LastError = "OpenTelemetry endpoint must be an absolute HTTP or HTTPS URL.";
+                _logWarn($"OpenTelemetry endpoint configuration rejected: {LastError}");
+                return;
+            }
+
+            if (_sink != null && State == OpenTelemetryEndpointConnectionState.Connected && options == _currentOptions)
+                return;
+
+            DisposeSink();
+            IOpenTelemetryProbeSink? newSink = null;
+
+            try
+            {
+                newSink = _sinkFactory(options);
+                newSink.SendProbe(options);
+                if (!newSink.ForceFlush(3_000))
+                {
+                    newSink.Dispose();
+                    State = OpenTelemetryEndpointConnectionState.Failed;
+                    LastError = "OpenTelemetry probe did not flush within 3000 ms.";
+                    _currentOptions = options;
+                    _logWarn($"OpenTelemetry endpoint probe failed: {LastError}");
+                    return;
+                }
+
+                if (IsStale(generation))
+                {
+                    newSink.Dispose();
+                    return;
+                }
+
+                _sink = newSink;
+                newSink = null;
+                _currentOptions = options;
+                State = OpenTelemetryEndpointConnectionState.Connected;
+                LastError = null;
+                _logInfo($"OpenTelemetry endpoint probe sent using {OpenTelemetryEndpointProtocol.ToDisplayName(options.Protocol)}.");
+            }
+            catch (Exception ex)
+            {
+                newSink?.Dispose();
+                State = OpenTelemetryEndpointConnectionState.Failed;
+                LastError = ex.Message;
+                _currentOptions = options;
+                _logWarn($"OpenTelemetry endpoint probe failed: {ex.Message}");
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _disposed = true;
+        Interlocked.Increment(ref _applyGeneration);
+        lock (_gate)
+        {
+            DisposeSink();
+            State = OpenTelemetryEndpointConnectionState.Disabled;
+            LastError = null;
+            _currentOptions = OpenTelemetryEndpointOptions.Disabled;
+        }
+    }
+
+    private void Disable()
+    {
+        DisposeSink();
+        State = OpenTelemetryEndpointConnectionState.Disabled;
+        LastError = null;
+        _currentOptions = OpenTelemetryEndpointOptions.Disabled;
+    }
+
+    private void DisposeSink()
+    {
+        var sink = _sink;
+        _sink = null;
+        sink?.Dispose();
+    }
+
+    private bool IsStale(long? generation) =>
+        _disposed ||
+        (generation.HasValue && generation.Value != Volatile.Read(ref _applyGeneration));
+}
+
+internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
+{
+    private const string ActivitySourceName = "OpenClaw.Companion.TelemetryProbe";
+    private static readonly ActivitySource s_activitySource = new(ActivitySourceName);
+    private readonly TracerProvider _provider;
+
+    private OpenTelemetryOtlpProbeSink(TracerProvider provider)
+    {
+        _provider = provider;
+    }
+
+    public static IOpenTelemetryProbeSink Create(OpenTelemetryEndpointOptions options)
+    {
+        if (!options.TryGetEndpointUri(out var endpoint) || endpoint == null)
+            throw new InvalidOperationException("OpenTelemetry endpoint must be configured before creating the exporter.");
+
+        var provider = Sdk.CreateTracerProviderBuilder()
+            .SetResourceBuilder(ResourceBuilder.CreateDefault()
+                .AddService(
+                    serviceName: "OpenClaw.Companion",
+                    serviceVersion: typeof(OpenTelemetryOtlpProbeSink).Assembly.GetName().Version?.ToString())
+                .AddAttributes(new Dictionary<string, object>
+                {
+                    ["process.pid"] = Environment.ProcessId
+                }))
+            .AddSource(ActivitySourceName)
+            .AddOtlpExporter(exporter =>
+            {
+                exporter.Endpoint = endpoint;
+                exporter.Protocol = options.Protocol == OpenTelemetryEndpointProtocol.HttpProtobuf
+                    ? OtlpExportProtocol.HttpProtobuf
+                    : OtlpExportProtocol.Grpc;
+            })
+            .Build();
+
+        return new OpenTelemetryOtlpProbeSink(provider);
+    }
+
+    public void SendProbe(OpenTelemetryEndpointOptions options)
+    {
+        using var activity = s_activitySource.StartActivity(
+            OpenTelemetryEndpointConnection.ProbeActivityName,
+            ActivityKind.Internal);
+        activity?.SetTag("openclaw.telemetry.protocol", OpenTelemetryEndpointProtocol.ToDisplayName(options.Protocol));
+        activity?.SetTag("openclaw.telemetry.probe", true);
+        activity?.SetStatus(ActivityStatusCode.Ok);
+    }
+
+    public bool ForceFlush(int timeoutMilliseconds) => _provider.ForceFlush(timeoutMilliseconds);
+
+    public void Dispose()
+    {
+        _provider.ForceFlush(2_000);
+        _provider.Dispose();
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using OpenTelemetry;
 using OpenTelemetry.Exporter;
+using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using OpenClaw.Shared.Telemetry;
@@ -173,12 +176,18 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
     private const string ExporterTagKey = "openclaw.exporter";
     private const string ExporterProtocolTagKey = "openclaw.exporter.protocol";
     private const string SignalTagKey = "openclaw.signal";
+    private static readonly Counter<long> ExporterProbeCounter = OpenClawTelemetry.CreateCounter(
+        "openclaw.telemetry.exporter.probes",
+        unit: "{probe}",
+        description: "Number of OpenClaw telemetry exporter probe metrics sent.");
 
-    private readonly TracerProvider _provider;
+    private readonly TracerProvider _tracerProvider;
+    private readonly MeterProvider _meterProvider;
 
-    private OpenTelemetryOtlpProbeSink(TracerProvider provider)
+    private OpenTelemetryOtlpProbeSink(TracerProvider tracerProvider, MeterProvider meterProvider)
     {
-        _provider = provider;
+        _tracerProvider = tracerProvider;
+        _meterProvider = meterProvider;
     }
 
     public static IOpenTelemetryProbeSink Create(OpenTelemetryEndpointOptions options)
@@ -186,26 +195,33 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
         if (!options.TryGetEndpointUri(out var endpoint) || endpoint == null)
             throw new InvalidOperationException("OpenTelemetry endpoint must be configured before creating the exporter.");
 
-        var provider = Sdk.CreateTracerProviderBuilder()
-            .SetResourceBuilder(ResourceBuilder.CreateDefault()
-                .AddService(
-                    serviceName: OpenClawResourceName.WindowsTray.ToServiceName(),
-                    serviceVersion: typeof(OpenTelemetryOtlpProbeSink).Assembly.GetName().Version?.ToString())
-                .AddAttributes(new Dictionary<string, object>
-                {
-                    ["process.pid"] = Environment.ProcessId
-                }))
-            .AddSource(OpenClawActivitySourceName.OpenClaw.ToTelemetryName())
-            .AddOtlpExporter(exporter =>
-            {
-                exporter.Endpoint = endpoint;
-                exporter.Protocol = options.Protocol == OpenTelemetryEndpointProtocol.HttpProtobuf
-                    ? OtlpExportProtocol.HttpProtobuf
-                    : OtlpExportProtocol.Grpc;
-            })
-            .Build();
+        TracerProvider? tracerProvider = null;
+        MeterProvider? meterProvider = null;
 
-        return new OpenTelemetryOtlpProbeSink(provider);
+        try
+        {
+            tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .SetResourceBuilder(CreateResourceBuilder())
+                .AddSource(OpenClawActivitySourceName.OpenClaw.ToTelemetryName())
+                .AddOtlpExporter(exporter => ConfigureExporter(exporter, endpoint, options.Protocol))
+                .Build();
+
+            meterProvider = Sdk.CreateMeterProviderBuilder()
+                .SetResourceBuilder(CreateResourceBuilder())
+                .AddMeter(OpenClawMeterName.OpenClaw.ToTelemetryName())
+                .AddOtlpExporter(exporter => ConfigureExporter(exporter, endpoint, options.Protocol))
+                .Build();
+
+            var sink = new OpenTelemetryOtlpProbeSink(tracerProvider, meterProvider);
+            tracerProvider = null;
+            meterProvider = null;
+            return sink;
+        }
+        finally
+        {
+            tracerProvider?.Dispose();
+            meterProvider?.Dispose();
+        }
     }
 
     public void SendProbe(OpenTelemetryEndpointOptions options)
@@ -213,24 +229,68 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
         OpenClawTelemetry.Trace(
             "openclaw.telemetry.exporter.probe",
             static () => { },
-            [
-                OpenClawTelemetryTag.String(
-                    ExporterTagKey,
-                    "tray-otel"),
-                OpenClawTelemetryTag.String(
-                    SignalTagKey,
-                    "traces"),
-                OpenClawTelemetryTag.String(
-                    ExporterProtocolTagKey,
-                    OpenTelemetryEndpointProtocol.ToTelemetryValue(options.Protocol))
-            ]);
+            CreateProbeTags(options, "traces"));
+
+        OpenClawTelemetry.Add(
+            ExporterProbeCounter,
+            tags: CreateProbeTags(options, "metrics"));
     }
 
-    public bool ForceFlush(int timeoutMilliseconds) => _provider.ForceFlush(timeoutMilliseconds);
+    public bool ForceFlush(int timeoutMilliseconds)
+    {
+        if (timeoutMilliseconds < 0)
+        {
+            var tracesOk = _tracerProvider.ForceFlush(timeoutMilliseconds);
+            var metricsOk = _meterProvider.ForceFlush(timeoutMilliseconds);
+            return tracesOk && metricsOk;
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        var tracesFlushed = _tracerProvider.ForceFlush(timeoutMilliseconds);
+        var remainingMilliseconds = Math.Max(0, timeoutMilliseconds - (int)Math.Min(int.MaxValue, stopwatch.ElapsedMilliseconds));
+        var metricsFlushed = _meterProvider.ForceFlush(remainingMilliseconds);
+        return tracesFlushed && metricsFlushed;
+    }
 
     public void Dispose()
     {
-        _provider.ForceFlush(2_000);
-        _provider.Dispose();
+        _tracerProvider.ForceFlush(2_000);
+        _meterProvider.ForceFlush(2_000);
+        _tracerProvider.Dispose();
+        _meterProvider.Dispose();
     }
+
+    private static ResourceBuilder CreateResourceBuilder() =>
+        ResourceBuilder.CreateDefault()
+            .AddService(
+                serviceName: OpenClawResourceName.WindowsTray.ToServiceName(),
+                serviceVersion: typeof(OpenTelemetryOtlpProbeSink).Assembly.GetName().Version?.ToString())
+            .AddAttributes(new Dictionary<string, object>
+            {
+                ["process.pid"] = Environment.ProcessId
+            });
+
+    private static void ConfigureExporter(
+        OtlpExporterOptions exporter,
+        Uri endpoint,
+        string? protocol)
+    {
+        exporter.Endpoint = endpoint;
+        exporter.Protocol = protocol == OpenTelemetryEndpointProtocol.HttpProtobuf
+            ? OtlpExportProtocol.HttpProtobuf
+            : OtlpExportProtocol.Grpc;
+    }
+
+    private static OpenClawTelemetryTag[] CreateProbeTags(OpenTelemetryEndpointOptions options, string signal) =>
+    [
+        OpenClawTelemetryTag.String(
+            ExporterTagKey,
+            "tray-otel"),
+        OpenClawTelemetryTag.String(
+            SignalTagKey,
+            signal),
+        OpenClawTelemetryTag.String(
+            ExporterProtocolTagKey,
+            OpenTelemetryEndpointProtocol.ToTelemetryValue(options.Protocol))
+    ];
 }

--- a/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointConnection.cs
@@ -170,6 +170,10 @@ internal sealed class OpenTelemetryEndpointConnection : IDisposable
 
 internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
 {
+    private const string ExporterTagKey = "openclaw.exporter";
+    private const string ExporterProtocolTagKey = "openclaw.exporter.protocol";
+    private const string SignalTagKey = "openclaw.signal";
+
     private readonly TracerProvider _provider;
 
     private OpenTelemetryOtlpProbeSink(TracerProvider provider)
@@ -185,13 +189,13 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
         var provider = Sdk.CreateTracerProviderBuilder()
             .SetResourceBuilder(ResourceBuilder.CreateDefault()
                 .AddService(
-                    serviceName: OpenClawResourceNames.Tray,
+                    serviceName: OpenClawResourceName.WindowsTray.ToServiceName(),
                     serviceVersion: typeof(OpenTelemetryOtlpProbeSink).Assembly.GetName().Version?.ToString())
                 .AddAttributes(new Dictionary<string, object>
                 {
                     ["process.pid"] = Environment.ProcessId
                 }))
-            .AddSource(OpenClawActivitySources.ExportedNames.ToArray())
+            .AddSource(OpenClawActivitySourceName.OpenClaw.ToTelemetryName())
             .AddOtlpExporter(exporter =>
             {
                 exporter.Endpoint = endpoint;
@@ -207,18 +211,17 @@ internal sealed class OpenTelemetryOtlpProbeSink : IOpenTelemetryProbeSink
     public void SendProbe(OpenTelemetryEndpointOptions options)
     {
         OpenClawTelemetry.Trace(
-            OpenClawActivitySources.OpenClawSource,
             "openclaw.telemetry.exporter.probe",
             static () => { },
             [
                 OpenClawTelemetryTag.String(
-                    OpenClawTelemetryTags.Exporter,
+                    ExporterTagKey,
                     "tray-otel"),
                 OpenClawTelemetryTag.String(
-                    OpenClawTelemetryTags.Signal,
+                    SignalTagKey,
                     "traces"),
                 OpenClawTelemetryTag.String(
-                    OpenClawTelemetryTags.ExporterProtocol,
+                    ExporterProtocolTagKey,
                     OpenTelemetryEndpointProtocol.ToTelemetryValue(options.Protocol))
             ]);
     }

--- a/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointOptions.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointOptions.cs
@@ -1,0 +1,37 @@
+namespace OpenClawTray.Services;
+
+internal sealed record OpenTelemetryEndpointOptions(string? Endpoint, string Protocol)
+{
+    public bool IsEnabled => !string.IsNullOrWhiteSpace(Endpoint);
+
+    public static OpenTelemetryEndpointOptions FromSettings(SettingsManager? settings) =>
+        settings == null
+            ? Disabled
+            : Create(settings.OpenTelemetryEndpoint, settings.OpenTelemetryProtocol);
+
+    public static OpenTelemetryEndpointOptions Create(string? endpoint, string? protocol) =>
+        new(NormalizeEndpoint(endpoint), OpenTelemetryEndpointProtocol.Normalize(protocol));
+
+    public static OpenTelemetryEndpointOptions Disabled { get; } =
+        new(null, OpenTelemetryEndpointProtocol.Grpc);
+
+    public bool TryGetEndpointUri(out Uri? uri)
+    {
+        uri = null;
+        if (!IsEnabled)
+            return false;
+
+        if (!Uri.TryCreate(Endpoint, UriKind.Absolute, out var parsed) ||
+            (parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps) ||
+            string.IsNullOrWhiteSpace(parsed.Host))
+        {
+            return false;
+        }
+
+        uri = parsed;
+        return true;
+    }
+
+    private static string? NormalizeEndpoint(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointOptions.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointOptions.cs
@@ -17,13 +17,28 @@ internal sealed record OpenTelemetryEndpointOptions(string? Endpoint, string Pro
 
     public bool TryGetEndpointUri(out Uri? uri)
     {
-        uri = null;
         if (!IsEnabled)
+        {
+            uri = null;
+            return false;
+        }
+
+        return TryCreateEndpointUri(Endpoint, out uri);
+    }
+
+    internal static bool TryCreateEndpointUri(string? endpoint, out Uri? uri)
+    {
+        uri = null;
+        var normalized = NormalizeEndpoint(endpoint);
+        if (normalized == null)
             return false;
 
-        if (!Uri.TryCreate(Endpoint, UriKind.Absolute, out var parsed) ||
+        if (!Uri.TryCreate(normalized, UriKind.Absolute, out var parsed) ||
             (parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps) ||
-            string.IsNullOrWhiteSpace(parsed.Host))
+            string.IsNullOrWhiteSpace(parsed.Host) ||
+            !string.IsNullOrEmpty(parsed.UserInfo) ||
+            !string.IsNullOrEmpty(parsed.Query) ||
+            !string.IsNullOrEmpty(parsed.Fragment))
         {
             return false;
         }

--- a/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointProtocol.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointProtocol.cs
@@ -1,0 +1,22 @@
+namespace OpenClawTray.Services;
+
+internal static class OpenTelemetryEndpointProtocol
+{
+    public const string Grpc = "grpc";
+    public const string HttpProtobuf = "http/protobuf";
+
+    public static string Normalize(string? value)
+    {
+        if (string.Equals(value, HttpProtobuf, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "http", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "otlp/http", StringComparison.OrdinalIgnoreCase))
+        {
+            return HttpProtobuf;
+        }
+
+        return Grpc;
+    }
+
+    public static string ToDisplayName(string? value) =>
+        Normalize(value) == HttpProtobuf ? "OTLP/HTTP" : "OTLP/gRPC";
+}

--- a/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointProtocol.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryEndpointProtocol.cs
@@ -19,4 +19,6 @@ internal static class OpenTelemetryEndpointProtocol
 
     public static string ToDisplayName(string? value) =>
         Normalize(value) == HttpProtobuf ? "OTLP/HTTP" : "OTLP/gRPC";
+
+    public static string ToTelemetryValue(string? value) => Normalize(value);
 }

--- a/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryLogPolicy.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/OpenTelemetryLogPolicy.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.Logging;
+
+namespace OpenClawTray.Services;
+
+internal static class OpenTelemetryLogPolicy
+{
+    public const string TelemetryExporterCategory = "OpenClaw.Telemetry.Exporter";
+
+    public static bool ShouldExport(string? category, LogLevel level) =>
+        level is >= LogLevel.Information and < LogLevel.None &&
+        category is not null &&
+        category.StartsWith("OpenClaw.Telemetry.", StringComparison.Ordinal);
+}

--- a/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
@@ -93,6 +93,8 @@ public class SettingsManager
     public string AppTheme { get => NormalizeAppTheme(_data.AppTheme); set => _data = _data with { AppTheme = NormalizeAppTheme(value) }; }
     public bool? ShowDiagnosticsOverride { get => _data.ShowDiagnostics; set => _data = _data with { ShowDiagnostics = value }; }
     public bool ShowDiagnosticsEffective => _data.ShowDiagnostics ?? OpenClawTray.Helpers.DiagnosticsGate.BuildDefault;
+    public string OpenTelemetryEndpoint { get => _data.OpenTelemetryEndpoint ?? ""; set => _data = _data with { OpenTelemetryEndpoint = NormalizeOptionalString(value) }; }
+    public string OpenTelemetryProtocol { get => OpenTelemetryEndpointProtocol.Normalize(_data.OpenTelemetryProtocol); set => _data = _data with { OpenTelemetryProtocol = OpenTelemetryEndpointProtocol.Normalize(value) }; }
 
     // Node mode(gateway WebSocket connection — separate from MCP)
     public bool EnableNodeMode { get => _data.EnableNodeMode; set => _data = _data with { EnableNodeMode = value }; }
@@ -246,6 +248,8 @@ public class SettingsManager
         UseLegacyWebChat = false,
         ShowCompletedSessions = false,
         AppTheme = AppThemeSystem,
+        OpenTelemetryEndpoint = null,
+        OpenTelemetryProtocol = OpenTelemetryEndpointProtocol.Grpc,
         EnableNodeMode = false,
         NodeCanvasEnabled = true,
         NodeScreenEnabled = true,
@@ -313,6 +317,8 @@ public class SettingsManager
             PreferredGatewayId = loaded.PreferredGatewayId ?? defaults.PreferredGatewayId,
             AppTheme = NormalizeAppTheme(loaded.AppTheme),
             ShowDiagnostics = loaded.ShowDiagnostics,
+            OpenTelemetryEndpoint = NormalizeOptionalString(loaded.OpenTelemetryEndpoint),
+            OpenTelemetryProtocol = OpenTelemetryEndpointProtocol.Normalize(loaded.OpenTelemetryProtocol),
             UserRules = loaded.UserRules != null ? new List<UserNotificationRule>(loaded.UserRules) : new(),
             SandboxCustomFolders = CloneSandboxCustomFolders(loaded.SandboxCustomFolders),
             SystemRunBlockHostFallbackWhenMxcUnavailable = loaded.SystemRunBlockHostFallbackWhenMxcUnavailable,
@@ -398,6 +404,8 @@ public class SettingsManager
         TtsPiperVoiceId = TtsPiperVoiceId,
         AppTheme = AppTheme,
         ShowDiagnostics = ShowDiagnosticsOverride,
+        OpenTelemetryEndpoint = NormalizeOptionalString(OpenTelemetryEndpoint),
+        OpenTelemetryProtocol = OpenTelemetryEndpointProtocol.Normalize(OpenTelemetryProtocol),
         A2UIImageHosts = A2UIImageHosts.Count == 0 ? null : new List<string>(A2UIImageHosts),
         SkippedUpdateTag = string.IsNullOrWhiteSpace(SkippedUpdateTag) ? null : SkippedUpdateTag,
         PreferredGatewayId = string.IsNullOrWhiteSpace(PreferredGatewayId) ? null : PreferredGatewayId,
@@ -416,6 +424,9 @@ public class SettingsManager
             return AppThemeDark;
         return AppThemeSystem;
     }
+
+    private static string? NormalizeOptionalString(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     public void Save()
     {

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -3969,6 +3969,9 @@ Commands are blocked while sandboxing is unavailable because strict fallback blo
   <data name="DiagnosticsPage_SaveOpenTelemetryEndpointButton.Content" xml:space="preserve">
     <value>Save connection</value>
   </data>
+  <data name="DiagnosticsPage_ResendOpenTelemetryProbeButton.Content" xml:space="preserve">
+    <value>Send probe again</value>
+  </data>
   <data name="DiagnosticsPage_ClearOpenTelemetryEndpointButton.Content" xml:space="preserve">
     <value>Clear</value>
   </data>
@@ -4001,6 +4004,12 @@ Commands are blocked while sandboxing is unavailable because strict fallback blo
   </data>
   <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_UnsavedMessage" xml:space="preserve">
     <value>Save to apply this connection.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ProbeFlushedMessage" xml:space="preserve">
+    <value>Probe flushed locally; collector receipt is not confirmed.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ProbeFailedMessage" xml:space="preserve">
+    <value>Probe did not finish for the saved endpoint. Verify the settings and try again.</value>
   </data>
   <data name="DiagnosticsPage_Expander_ChatOverrides.Header" xml:space="preserve">
     <value>Chat surface overrides</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -3924,6 +3924,84 @@ Commands are blocked while sandboxing is unavailable because strict fallback blo
   <data name="DiagnosticsPage_DeveloperWarning.Message" xml:space="preserve">
     <value>These tools may change app behavior, restart the app, or open experimental UI.</value>
   </data>
+  <data name="DiagnosticsPage_Expander_OpenTelemetry.Header" xml:space="preserve">
+    <value>OpenTelemetry connection</value>
+  </data>
+  <data name="DiagnosticsPage_Expander_OpenTelemetry.Description" xml:space="preserve">
+    <value>Sends a small diagnostic probe only to the OTLP collector endpoint you configure.</value>
+  </data>
+  <data name="DiagnosticsPage_Card_OpenTelemetryEndpoint.Header" xml:space="preserve">
+    <value>OTel endpoint</value>
+  </data>
+  <data name="DiagnosticsPage_Card_OpenTelemetryEndpoint.Description" xml:space="preserve">
+    <value>Collector URL used by OpenClaw telemetry.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetrySummary.Text" xml:space="preserve">
+    <value>Not configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetrySummary_NotConfigured" xml:space="preserve">
+    <value>Not configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetrySummary_Configured" xml:space="preserve">
+    <value>Configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointBox.Header" xml:space="preserve">
+    <value>Endpoint URL</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointBox.PlaceholderText" xml:space="preserve">
+    <value>http://localhost:4317</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryProtocolLabel.Text" xml:space="preserve">
+    <value>Protocol</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryProtocolGrpc.Content" xml:space="preserve">
+    <value>OTLP/gRPC</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryProtocolHttp.Content" xml:space="preserve">
+    <value>OTLP/HTTP</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus.Title" xml:space="preserve">
+    <value>No telemetry endpoint</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus.Message" xml:space="preserve">
+    <value>No endpoint configured.</value>
+  </data>
+  <data name="DiagnosticsPage_SaveOpenTelemetryEndpointButton.Content" xml:space="preserve">
+    <value>Save connection</value>
+  </data>
+  <data name="DiagnosticsPage_ClearOpenTelemetryEndpointButton.Content" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_InvalidTitle" xml:space="preserve">
+    <value>Endpoint needs attention</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_InvalidMessage" xml:space="preserve">
+    <value>Enter an absolute HTTP or HTTPS OTLP collector URL, for example http://localhost:4317.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ClearedTitle" xml:space="preserve">
+    <value>Endpoint cleared</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_OffTitle" xml:space="preserve">
+    <value>No telemetry endpoint</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_OffMessage" xml:space="preserve">
+    <value>No endpoint configured.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_SavedTitle" xml:space="preserve">
+    <value>Endpoint saved</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_SavedMessageFormat" xml:space="preserve">
+    <value>Telemetry endpoint: {0}</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ConfiguredTitle" xml:space="preserve">
+    <value>Endpoint configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ConfiguredMessageFormat" xml:space="preserve">
+    <value>Telemetry endpoint: {0}</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_UnsavedMessage" xml:space="preserve">
+    <value>Save to apply this connection.</value>
+  </data>
   <data name="DiagnosticsPage_Expander_ChatOverrides.Header" xml:space="preserve">
     <value>Chat surface overrides</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -3877,6 +3877,84 @@ Les commandes sont bloquées tant que le sandboxing est indisponible, car le blo
   <data name="DiagnosticsPage_DeveloperWarning.Message" xml:space="preserve">
     <value>These tools may change app behavior, restart the app, or open experimental UI.</value>
   </data>
+  <data name="DiagnosticsPage_Expander_OpenTelemetry.Header" xml:space="preserve">
+    <value>OpenTelemetry connection</value>
+  </data>
+  <data name="DiagnosticsPage_Expander_OpenTelemetry.Description" xml:space="preserve">
+    <value>Sends a small diagnostic probe only to the OTLP collector endpoint you configure.</value>
+  </data>
+  <data name="DiagnosticsPage_Card_OpenTelemetryEndpoint.Header" xml:space="preserve">
+    <value>OTel endpoint</value>
+  </data>
+  <data name="DiagnosticsPage_Card_OpenTelemetryEndpoint.Description" xml:space="preserve">
+    <value>Collector URL used by OpenClaw telemetry.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetrySummary.Text" xml:space="preserve">
+    <value>Not configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetrySummary_NotConfigured" xml:space="preserve">
+    <value>Not configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetrySummary_Configured" xml:space="preserve">
+    <value>Configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointBox.Header" xml:space="preserve">
+    <value>Endpoint URL</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointBox.PlaceholderText" xml:space="preserve">
+    <value>http://localhost:4317</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryProtocolLabel.Text" xml:space="preserve">
+    <value>Protocol</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryProtocolGrpc.Content" xml:space="preserve">
+    <value>OTLP/gRPC</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryProtocolHttp.Content" xml:space="preserve">
+    <value>OTLP/HTTP</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus.Title" xml:space="preserve">
+    <value>No telemetry endpoint</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus.Message" xml:space="preserve">
+    <value>No endpoint configured.</value>
+  </data>
+  <data name="DiagnosticsPage_SaveOpenTelemetryEndpointButton.Content" xml:space="preserve">
+    <value>Save connection</value>
+  </data>
+  <data name="DiagnosticsPage_ClearOpenTelemetryEndpointButton.Content" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_InvalidTitle" xml:space="preserve">
+    <value>Endpoint needs attention</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_InvalidMessage" xml:space="preserve">
+    <value>Enter an absolute HTTP or HTTPS OTLP collector URL, for example http://localhost:4317.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ClearedTitle" xml:space="preserve">
+    <value>Endpoint cleared</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_OffTitle" xml:space="preserve">
+    <value>No telemetry endpoint</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_OffMessage" xml:space="preserve">
+    <value>No endpoint configured.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_SavedTitle" xml:space="preserve">
+    <value>Endpoint saved</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_SavedMessageFormat" xml:space="preserve">
+    <value>Telemetry endpoint: {0}</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ConfiguredTitle" xml:space="preserve">
+    <value>Endpoint configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ConfiguredMessageFormat" xml:space="preserve">
+    <value>Telemetry endpoint: {0}</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_UnsavedMessage" xml:space="preserve">
+    <value>Save to apply this connection.</value>
+  </data>
   <data name="DiagnosticsPage_Expander_ChatOverrides.Header" xml:space="preserve">
     <value>Chat surface overrides</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -3922,6 +3922,9 @@ Les commandes sont bloquées tant que le sandboxing est indisponible, car le blo
   <data name="DiagnosticsPage_SaveOpenTelemetryEndpointButton.Content" xml:space="preserve">
     <value>Save connection</value>
   </data>
+  <data name="DiagnosticsPage_ResendOpenTelemetryProbeButton.Content" xml:space="preserve">
+    <value>Send probe again</value>
+  </data>
   <data name="DiagnosticsPage_ClearOpenTelemetryEndpointButton.Content" xml:space="preserve">
     <value>Clear</value>
   </data>
@@ -3954,6 +3957,12 @@ Les commandes sont bloquées tant que le sandboxing est indisponible, car le blo
   </data>
   <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_UnsavedMessage" xml:space="preserve">
     <value>Save to apply this connection.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ProbeFlushedMessage" xml:space="preserve">
+    <value>Probe flushed locally; collector receipt is not confirmed.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ProbeFailedMessage" xml:space="preserve">
+    <value>Probe did not finish for the saved endpoint. Verify the settings and try again.</value>
   </data>
   <data name="DiagnosticsPage_Expander_ChatOverrides.Header" xml:space="preserve">
     <value>Chat surface overrides</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -3878,6 +3878,84 @@ Opdrachten worden geblokkeerd zolang sandboxing niet beschikbaar is, omdat strik
   <data name="DiagnosticsPage_DeveloperWarning.Message" xml:space="preserve">
     <value>These tools may change app behavior, restart the app, or open experimental UI.</value>
   </data>
+  <data name="DiagnosticsPage_Expander_OpenTelemetry.Header" xml:space="preserve">
+    <value>OpenTelemetry connection</value>
+  </data>
+  <data name="DiagnosticsPage_Expander_OpenTelemetry.Description" xml:space="preserve">
+    <value>Sends a small diagnostic probe only to the OTLP collector endpoint you configure.</value>
+  </data>
+  <data name="DiagnosticsPage_Card_OpenTelemetryEndpoint.Header" xml:space="preserve">
+    <value>OTel endpoint</value>
+  </data>
+  <data name="DiagnosticsPage_Card_OpenTelemetryEndpoint.Description" xml:space="preserve">
+    <value>Collector URL used by OpenClaw telemetry.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetrySummary.Text" xml:space="preserve">
+    <value>Not configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetrySummary_NotConfigured" xml:space="preserve">
+    <value>Not configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetrySummary_Configured" xml:space="preserve">
+    <value>Configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointBox.Header" xml:space="preserve">
+    <value>Endpoint URL</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointBox.PlaceholderText" xml:space="preserve">
+    <value>http://localhost:4317</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryProtocolLabel.Text" xml:space="preserve">
+    <value>Protocol</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryProtocolGrpc.Content" xml:space="preserve">
+    <value>OTLP/gRPC</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryProtocolHttp.Content" xml:space="preserve">
+    <value>OTLP/HTTP</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus.Title" xml:space="preserve">
+    <value>No telemetry endpoint</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus.Message" xml:space="preserve">
+    <value>No endpoint configured.</value>
+  </data>
+  <data name="DiagnosticsPage_SaveOpenTelemetryEndpointButton.Content" xml:space="preserve">
+    <value>Save connection</value>
+  </data>
+  <data name="DiagnosticsPage_ClearOpenTelemetryEndpointButton.Content" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_InvalidTitle" xml:space="preserve">
+    <value>Endpoint needs attention</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_InvalidMessage" xml:space="preserve">
+    <value>Enter an absolute HTTP or HTTPS OTLP collector URL, for example http://localhost:4317.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ClearedTitle" xml:space="preserve">
+    <value>Endpoint cleared</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_OffTitle" xml:space="preserve">
+    <value>No telemetry endpoint</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_OffMessage" xml:space="preserve">
+    <value>No endpoint configured.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_SavedTitle" xml:space="preserve">
+    <value>Endpoint saved</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_SavedMessageFormat" xml:space="preserve">
+    <value>Telemetry endpoint: {0}</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ConfiguredTitle" xml:space="preserve">
+    <value>Endpoint configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ConfiguredMessageFormat" xml:space="preserve">
+    <value>Telemetry endpoint: {0}</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_UnsavedMessage" xml:space="preserve">
+    <value>Save to apply this connection.</value>
+  </data>
   <data name="DiagnosticsPage_Expander_ChatOverrides.Header" xml:space="preserve">
     <value>Chat surface overrides</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -3923,6 +3923,9 @@ Opdrachten worden geblokkeerd zolang sandboxing niet beschikbaar is, omdat strik
   <data name="DiagnosticsPage_SaveOpenTelemetryEndpointButton.Content" xml:space="preserve">
     <value>Save connection</value>
   </data>
+  <data name="DiagnosticsPage_ResendOpenTelemetryProbeButton.Content" xml:space="preserve">
+    <value>Send probe again</value>
+  </data>
   <data name="DiagnosticsPage_ClearOpenTelemetryEndpointButton.Content" xml:space="preserve">
     <value>Clear</value>
   </data>
@@ -3955,6 +3958,12 @@ Opdrachten worden geblokkeerd zolang sandboxing niet beschikbaar is, omdat strik
   </data>
   <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_UnsavedMessage" xml:space="preserve">
     <value>Save to apply this connection.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ProbeFlushedMessage" xml:space="preserve">
+    <value>Probe flushed locally; collector receipt is not confirmed.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ProbeFailedMessage" xml:space="preserve">
+    <value>Probe did not finish for the saved endpoint. Verify the settings and try again.</value>
   </data>
   <data name="DiagnosticsPage_Expander_ChatOverrides.Header" xml:space="preserve">
     <value>Chat surface overrides</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -3922,6 +3922,9 @@
   <data name="DiagnosticsPage_SaveOpenTelemetryEndpointButton.Content" xml:space="preserve">
     <value>Save connection</value>
   </data>
+  <data name="DiagnosticsPage_ResendOpenTelemetryProbeButton.Content" xml:space="preserve">
+    <value>Send probe again</value>
+  </data>
   <data name="DiagnosticsPage_ClearOpenTelemetryEndpointButton.Content" xml:space="preserve">
     <value>Clear</value>
   </data>
@@ -3954,6 +3957,12 @@
   </data>
   <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_UnsavedMessage" xml:space="preserve">
     <value>Save to apply this connection.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ProbeFlushedMessage" xml:space="preserve">
+    <value>Probe flushed locally; collector receipt is not confirmed.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ProbeFailedMessage" xml:space="preserve">
+    <value>Probe did not finish for the saved endpoint. Verify the settings and try again.</value>
   </data>
   <data name="DiagnosticsPage_Expander_ChatOverrides.Header" xml:space="preserve">
     <value>Chat surface overrides</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -3877,6 +3877,84 @@
   <data name="DiagnosticsPage_DeveloperWarning.Message" xml:space="preserve">
     <value>These tools may change app behavior, restart the app, or open experimental UI.</value>
   </data>
+  <data name="DiagnosticsPage_Expander_OpenTelemetry.Header" xml:space="preserve">
+    <value>OpenTelemetry connection</value>
+  </data>
+  <data name="DiagnosticsPage_Expander_OpenTelemetry.Description" xml:space="preserve">
+    <value>Sends a small diagnostic probe only to the OTLP collector endpoint you configure.</value>
+  </data>
+  <data name="DiagnosticsPage_Card_OpenTelemetryEndpoint.Header" xml:space="preserve">
+    <value>OTel endpoint</value>
+  </data>
+  <data name="DiagnosticsPage_Card_OpenTelemetryEndpoint.Description" xml:space="preserve">
+    <value>Collector URL used by OpenClaw telemetry.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetrySummary.Text" xml:space="preserve">
+    <value>Not configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetrySummary_NotConfigured" xml:space="preserve">
+    <value>Not configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetrySummary_Configured" xml:space="preserve">
+    <value>Configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointBox.Header" xml:space="preserve">
+    <value>Endpoint URL</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointBox.PlaceholderText" xml:space="preserve">
+    <value>http://localhost:4317</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryProtocolLabel.Text" xml:space="preserve">
+    <value>Protocol</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryProtocolGrpc.Content" xml:space="preserve">
+    <value>OTLP/gRPC</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryProtocolHttp.Content" xml:space="preserve">
+    <value>OTLP/HTTP</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus.Title" xml:space="preserve">
+    <value>No telemetry endpoint</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus.Message" xml:space="preserve">
+    <value>No endpoint configured.</value>
+  </data>
+  <data name="DiagnosticsPage_SaveOpenTelemetryEndpointButton.Content" xml:space="preserve">
+    <value>Save connection</value>
+  </data>
+  <data name="DiagnosticsPage_ClearOpenTelemetryEndpointButton.Content" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_InvalidTitle" xml:space="preserve">
+    <value>Endpoint needs attention</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_InvalidMessage" xml:space="preserve">
+    <value>Enter an absolute HTTP or HTTPS OTLP collector URL, for example http://localhost:4317.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ClearedTitle" xml:space="preserve">
+    <value>Endpoint cleared</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_OffTitle" xml:space="preserve">
+    <value>No telemetry endpoint</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_OffMessage" xml:space="preserve">
+    <value>No endpoint configured.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_SavedTitle" xml:space="preserve">
+    <value>Endpoint saved</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_SavedMessageFormat" xml:space="preserve">
+    <value>Telemetry endpoint: {0}</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ConfiguredTitle" xml:space="preserve">
+    <value>Endpoint configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ConfiguredMessageFormat" xml:space="preserve">
+    <value>Telemetry endpoint: {0}</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_UnsavedMessage" xml:space="preserve">
+    <value>Save to apply this connection.</value>
+  </data>
   <data name="DiagnosticsPage_Expander_ChatOverrides.Header" xml:space="preserve">
     <value>Chat surface overrides</value>
   </data>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -3922,6 +3922,9 @@
   <data name="DiagnosticsPage_SaveOpenTelemetryEndpointButton.Content" xml:space="preserve">
     <value>Save connection</value>
   </data>
+  <data name="DiagnosticsPage_ResendOpenTelemetryProbeButton.Content" xml:space="preserve">
+    <value>Send probe again</value>
+  </data>
   <data name="DiagnosticsPage_ClearOpenTelemetryEndpointButton.Content" xml:space="preserve">
     <value>Clear</value>
   </data>
@@ -3954,6 +3957,12 @@
   </data>
   <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_UnsavedMessage" xml:space="preserve">
     <value>Save to apply this connection.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ProbeFlushedMessage" xml:space="preserve">
+    <value>Probe flushed locally; collector receipt is not confirmed.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ProbeFailedMessage" xml:space="preserve">
+    <value>Probe did not finish for the saved endpoint. Verify the settings and try again.</value>
   </data>
   <data name="DiagnosticsPage_Expander_ChatOverrides.Header" xml:space="preserve">
     <value>Chat surface overrides</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -3877,6 +3877,84 @@
   <data name="DiagnosticsPage_DeveloperWarning.Message" xml:space="preserve">
     <value>These tools may change app behavior, restart the app, or open experimental UI.</value>
   </data>
+  <data name="DiagnosticsPage_Expander_OpenTelemetry.Header" xml:space="preserve">
+    <value>OpenTelemetry connection</value>
+  </data>
+  <data name="DiagnosticsPage_Expander_OpenTelemetry.Description" xml:space="preserve">
+    <value>Sends a small diagnostic probe only to the OTLP collector endpoint you configure.</value>
+  </data>
+  <data name="DiagnosticsPage_Card_OpenTelemetryEndpoint.Header" xml:space="preserve">
+    <value>OTel endpoint</value>
+  </data>
+  <data name="DiagnosticsPage_Card_OpenTelemetryEndpoint.Description" xml:space="preserve">
+    <value>Collector URL used by OpenClaw telemetry.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetrySummary.Text" xml:space="preserve">
+    <value>Not configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetrySummary_NotConfigured" xml:space="preserve">
+    <value>Not configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetrySummary_Configured" xml:space="preserve">
+    <value>Configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointBox.Header" xml:space="preserve">
+    <value>Endpoint URL</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointBox.PlaceholderText" xml:space="preserve">
+    <value>http://localhost:4317</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryProtocolLabel.Text" xml:space="preserve">
+    <value>Protocol</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryProtocolGrpc.Content" xml:space="preserve">
+    <value>OTLP/gRPC</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryProtocolHttp.Content" xml:space="preserve">
+    <value>OTLP/HTTP</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus.Title" xml:space="preserve">
+    <value>No telemetry endpoint</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus.Message" xml:space="preserve">
+    <value>No endpoint configured.</value>
+  </data>
+  <data name="DiagnosticsPage_SaveOpenTelemetryEndpointButton.Content" xml:space="preserve">
+    <value>Save connection</value>
+  </data>
+  <data name="DiagnosticsPage_ClearOpenTelemetryEndpointButton.Content" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_InvalidTitle" xml:space="preserve">
+    <value>Endpoint needs attention</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_InvalidMessage" xml:space="preserve">
+    <value>Enter an absolute HTTP or HTTPS OTLP collector URL, for example http://localhost:4317.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ClearedTitle" xml:space="preserve">
+    <value>Endpoint cleared</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_OffTitle" xml:space="preserve">
+    <value>No telemetry endpoint</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_OffMessage" xml:space="preserve">
+    <value>No endpoint configured.</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_SavedTitle" xml:space="preserve">
+    <value>Endpoint saved</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_SavedMessageFormat" xml:space="preserve">
+    <value>Telemetry endpoint: {0}</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ConfiguredTitle" xml:space="preserve">
+    <value>Endpoint configured</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_ConfiguredMessageFormat" xml:space="preserve">
+    <value>Telemetry endpoint: {0}</value>
+  </data>
+  <data name="DiagnosticsPage_OpenTelemetryEndpointStatus_UnsavedMessage" xml:space="preserve">
+    <value>Save to apply this connection.</value>
+  </data>
   <data name="DiagnosticsPage_Expander_ChatOverrides.Header" xml:space="preserve">
     <value>Chat surface overrides</value>
   </data>

--- a/tests/OpenClaw.Shared.Tests/Telemetry/OpenClawTelemetryTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Telemetry/OpenClawTelemetryTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using OpenClaw.Shared.Telemetry;
 
 namespace OpenClaw.Shared.Tests.Telemetry;
@@ -10,6 +11,8 @@ public sealed class OpenClawTelemetryTests
     {
         Assert.Equal("openclaw", OpenClawActivitySourceName.OpenClaw.ToTelemetryName());
         Assert.Equal("openclaw", OpenClawActivitySources.OpenClawSource.Name);
+        Assert.Equal("openclaw", OpenClawMeterName.OpenClaw.ToTelemetryName());
+        Assert.Equal("openclaw", OpenClawMeters.OpenClawMeter.Name);
         Assert.Equal("openclaw-windows-tray", OpenClawResourceName.WindowsTray.ToServiceName());
         Assert.Equal("openclaw-windows-node", OpenClawResourceName.WindowsNode.ToServiceName());
         Assert.Equal("openclaw.source", OpenClawTelemetryTagKey.Source.ToTelemetryName());
@@ -180,6 +183,44 @@ public sealed class OpenClawTelemetryTests
     }
 
     [Fact]
+    public void CounterMetric_WithListener_RecordsMeasurementAndTags()
+    {
+        var metricName = $"test.counter.{Guid.NewGuid():N}";
+        using var collector = MetricCollector.Listen(OpenClawMeterName.OpenClaw.ToTelemetryName());
+        var counter = OpenClawTelemetry.CreateCounter(metricName, unit: "{event}");
+
+        OpenClawTelemetry.Add(
+            counter,
+            2,
+            [
+                OpenClawTelemetryTag.String(OpenClawTelemetryTagKey.Source, "unit-test"),
+                OpenClawTelemetryTag.Number("openclaw.test.count", 7)
+            ]);
+
+        var measurement = Assert.Single(collector.LongMeasurements, m => m.Name == metricName);
+        Assert.Equal(2, measurement.Value);
+        Assert.Contains(measurement.Tags, tag => tag.Key == OpenClawTelemetryTagKey.Source.ToTelemetryName() && (string?)tag.Value == "unit-test");
+        Assert.Contains(measurement.Tags, tag => tag.Key == "openclaw.test.count" && (long)tag.Value! == 7);
+    }
+
+    [Fact]
+    public void HistogramMetric_WithListener_RecordsMeasurementAndTags()
+    {
+        var metricName = $"test.histogram.{Guid.NewGuid():N}";
+        using var collector = MetricCollector.Listen(OpenClawMeterName.OpenClaw.ToTelemetryName());
+        var histogram = OpenClawTelemetry.CreateHistogram(metricName, unit: "ms");
+
+        OpenClawTelemetry.Record(
+            histogram,
+            42.5,
+            [OpenClawTelemetryTag.String(OpenClawTelemetryTagKey.Source, "unit-test")]);
+
+        var measurement = Assert.Single(collector.DoubleMeasurements, m => m.Name == metricName);
+        Assert.Equal(42.5, measurement.Value);
+        Assert.Contains(measurement.Tags, tag => tag.Key == OpenClawTelemetryTagKey.Source.ToTelemetryName() && (string?)tag.Value == "unit-test");
+    }
+
+    [Fact]
     public void MarkFailure_RequiresException()
     {
         Assert.Throws<ArgumentNullException>(() => OpenClawTelemetry.MarkFailure(null, null!));
@@ -206,4 +247,38 @@ public sealed class OpenClawTelemetryTests
 
         public void Dispose() => _listener.Dispose();
     }
+
+    private sealed class MetricCollector : IDisposable
+    {
+        private readonly MeterListener _listener;
+
+        private MetricCollector(string meterName)
+        {
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, listener) =>
+                {
+                    if (instrument.Meter.Name == meterName)
+                        listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+                LongMeasurements.Add(new MetricMeasurement<long>(instrument.Name, measurement, tags.ToArray())));
+            _listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _) =>
+                DoubleMeasurements.Add(new MetricMeasurement<double>(instrument.Name, measurement, tags.ToArray())));
+            _listener.Start();
+        }
+
+        public List<MetricMeasurement<long>> LongMeasurements { get; } = new();
+        public List<MetricMeasurement<double>> DoubleMeasurements { get; } = new();
+
+        public static MetricCollector Listen(string meterName) => new(meterName);
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    private sealed record MetricMeasurement<T>(
+        string Name,
+        T Value,
+        KeyValuePair<string, object?>[] Tags);
 }

--- a/tests/OpenClaw.Shared.Tests/Telemetry/OpenClawTelemetryTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Telemetry/OpenClawTelemetryTests.cs
@@ -1,0 +1,155 @@
+using System.Diagnostics;
+using OpenClaw.Shared.Telemetry;
+
+namespace OpenClaw.Shared.Tests.Telemetry;
+
+public sealed class OpenClawTelemetryTests
+{
+    [Fact]
+    public void Constants_AreStable()
+    {
+        Assert.Equal("openclaw", OpenClawActivitySources.OpenClaw);
+        Assert.Equal(["openclaw"], OpenClawActivitySources.ExportedNames);
+        Assert.Throws<NotSupportedException>(() => ((IList<string>)OpenClawActivitySources.ExportedNames)[0] = "changed");
+        Assert.Equal("openclaw-windows-tray", OpenClawResourceNames.Tray);
+        Assert.Equal("openclaw-windows-node", OpenClawResourceNames.WindowsNode);
+        Assert.Equal("openclaw.source", OpenClawTelemetryTags.Source);
+        Assert.Equal("openclaw.outcome", OpenClawTelemetryTags.Outcome);
+        Assert.Equal("openclaw.errorCategory", OpenClawTelemetryTags.ErrorCategory);
+        Assert.Equal("openclaw.exporter", OpenClawTelemetryTags.Exporter);
+        Assert.Equal("openclaw.exporter.protocol", OpenClawTelemetryTags.ExporterProtocol);
+        Assert.Equal("openclaw.reason", OpenClawTelemetryTags.Reason);
+        Assert.Equal("openclaw.signal", OpenClawTelemetryTags.Signal);
+        Assert.Equal("openclaw.status", OpenClawTelemetryTags.Status);
+        Assert.Equal("error.type", OpenClawTelemetryTags.ErrorType);
+    }
+
+    [Fact]
+    public void Trace_NoListener_RunsActionAndReturnsResult()
+    {
+        var ran = false;
+
+        var result = OpenClawTelemetry.Trace(
+            OpenClawActivitySources.OpenClawSource,
+            "test.no_listener",
+            () =>
+            {
+                ran = true;
+                return 42;
+            });
+
+        Assert.True(ran);
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void Trace_WithListener_RecordsSuccessAndTags()
+    {
+        using var collector = ActivityCollector.Listen(OpenClawActivitySources.OpenClaw);
+
+        OpenClawTelemetry.Trace(
+            OpenClawActivitySources.OpenClawSource,
+            "test.success",
+            () => { },
+            [
+                OpenClawTelemetryTag.String(OpenClawTelemetryTags.Source, "unit-test"),
+                OpenClawTelemetryTag.String(OpenClawTelemetryTags.Exporter, "tray-otel")
+            ]);
+
+        var activity = Assert.Single(collector.Stopped);
+        Assert.Equal("test.success", activity.OperationName);
+        Assert.Equal(ActivityStatusCode.Ok, activity.Status);
+        Assert.Contains(activity.Tags, tag => tag.Key == OpenClawTelemetryTags.Source && tag.Value == "unit-test");
+        Assert.Contains(activity.Tags, tag => tag.Key == OpenClawTelemetryTags.Exporter && tag.Value == "tray-otel");
+    }
+
+    [Fact]
+    public void Trace_Exception_MarksErrorAndRethrowsOriginal()
+    {
+        using var collector = ActivityCollector.Listen(OpenClawActivitySources.OpenClaw);
+        var expected = new InvalidOperationException("boom");
+
+        var thrown = Assert.Throws<InvalidOperationException>(() =>
+            OpenClawTelemetry.Trace(OpenClawActivitySources.OpenClawSource, "test.error", () => throw expected));
+
+        Assert.Same(expected, thrown);
+        var activity = Assert.Single(collector.Stopped);
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+        Assert.Equal(nameof(InvalidOperationException), activity.StatusDescription);
+        Assert.Contains(
+            activity.Tags,
+            tag => tag.Key == OpenClawTelemetryTags.ErrorType && tag.Value == typeof(InvalidOperationException).FullName);
+    }
+
+    [Fact]
+    public async Task TraceAsync_WithListener_RecordsSuccessAndReturnsResult()
+    {
+        using var collector = ActivityCollector.Listen(OpenClawActivitySources.OpenClaw);
+
+        var result = await OpenClawTelemetry.TraceAsync(
+            OpenClawActivitySources.OpenClawSource,
+            "test.async.success",
+            _ => Task.FromResult("ok"));
+
+        Assert.Equal("ok", result);
+        var activity = Assert.Single(collector.Stopped);
+        Assert.Equal("test.async.success", activity.OperationName);
+        Assert.Equal(ActivityStatusCode.Ok, activity.Status);
+    }
+
+    [Fact]
+    public async Task TraceAsync_CanceledTask_MarksCanceledAndPreservesCancellation()
+    {
+        using var collector = ActivityCollector.Listen(OpenClawActivitySources.OpenClaw);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<TaskCanceledException>(() =>
+            OpenClawTelemetry.TraceAsync(
+                OpenClawActivitySources.OpenClawSource,
+                "test.async.cancel",
+                token => Task.FromCanceled(token),
+                cancellationToken: cts.Token));
+
+        var activity = Assert.Single(collector.Stopped);
+        Assert.Equal(ActivityStatusCode.Unset, activity.Status);
+        Assert.Contains(activity.Tags, tag => tag.Key == OpenClawTelemetryTags.Outcome && tag.Value == "canceled");
+    }
+
+    [Fact]
+    public void StringTag_BoundsLongValues()
+    {
+        var tag = OpenClawTelemetryTag.String(OpenClawTelemetryTags.Source, "abcdef", maxLength: 3);
+
+        Assert.Equal("abc", tag.Value);
+    }
+
+    [Fact]
+    public void TelemetryTag_IsReferenceType_WithValidatedConstruction()
+    {
+        Assert.False(typeof(OpenClawTelemetryTag).IsValueType);
+        Assert.Throws<ArgumentException>(() => new OpenClawTelemetryTag("", "value"));
+    }
+
+    private sealed class ActivityCollector : IDisposable
+    {
+        private readonly ActivityListener _listener;
+
+        private ActivityCollector(string sourceName)
+        {
+            _listener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == sourceName,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = activity => Stopped.Add(activity)
+            };
+            ActivitySource.AddActivityListener(_listener);
+        }
+
+        public List<Activity> Stopped { get; } = new();
+
+        public static ActivityCollector Listen(string sourceName) => new(sourceName);
+
+        public void Dispose() => _listener.Dispose();
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/Telemetry/OpenClawTelemetryTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Telemetry/OpenClawTelemetryTests.cs
@@ -17,7 +17,7 @@ public sealed class OpenClawTelemetryTests
         Assert.Equal("openclaw-windows-node", OpenClawResourceName.WindowsNode.ToServiceName());
         Assert.Equal("openclaw.source", OpenClawTelemetryTagKey.Source.ToTelemetryName());
         Assert.Equal("openclaw.outcome", OpenClawTelemetryTagKey.Outcome.ToTelemetryName());
-        Assert.Equal("openclaw.errorCategory", OpenClawTelemetryTagKey.ErrorCategory.ToTelemetryName());
+        Assert.Equal("openclaw.error.category", OpenClawTelemetryTagKey.ErrorCategory.ToTelemetryName());
         Assert.Equal("openclaw.reason", OpenClawTelemetryTagKey.Reason.ToTelemetryName());
         Assert.Equal("openclaw.status", OpenClawTelemetryTagKey.Status.ToTelemetryName());
         Assert.Equal("error.type", OpenClawTelemetryTagKey.ErrorType.ToTelemetryName());

--- a/tests/OpenClaw.Shared.Tests/Telemetry/OpenClawTelemetryTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Telemetry/OpenClawTelemetryTests.cs
@@ -8,20 +8,16 @@ public sealed class OpenClawTelemetryTests
     [Fact]
     public void Constants_AreStable()
     {
-        Assert.Equal("openclaw", OpenClawActivitySources.OpenClaw);
-        Assert.Equal(["openclaw"], OpenClawActivitySources.ExportedNames);
-        Assert.Throws<NotSupportedException>(() => ((IList<string>)OpenClawActivitySources.ExportedNames)[0] = "changed");
-        Assert.Equal("openclaw-windows-tray", OpenClawResourceNames.Tray);
-        Assert.Equal("openclaw-windows-node", OpenClawResourceNames.WindowsNode);
-        Assert.Equal("openclaw.source", OpenClawTelemetryTags.Source);
-        Assert.Equal("openclaw.outcome", OpenClawTelemetryTags.Outcome);
-        Assert.Equal("openclaw.errorCategory", OpenClawTelemetryTags.ErrorCategory);
-        Assert.Equal("openclaw.exporter", OpenClawTelemetryTags.Exporter);
-        Assert.Equal("openclaw.exporter.protocol", OpenClawTelemetryTags.ExporterProtocol);
-        Assert.Equal("openclaw.reason", OpenClawTelemetryTags.Reason);
-        Assert.Equal("openclaw.signal", OpenClawTelemetryTags.Signal);
-        Assert.Equal("openclaw.status", OpenClawTelemetryTags.Status);
-        Assert.Equal("error.type", OpenClawTelemetryTags.ErrorType);
+        Assert.Equal("openclaw", OpenClawActivitySourceName.OpenClaw.ToTelemetryName());
+        Assert.Equal("openclaw", OpenClawActivitySources.OpenClawSource.Name);
+        Assert.Equal("openclaw-windows-tray", OpenClawResourceName.WindowsTray.ToServiceName());
+        Assert.Equal("openclaw-windows-node", OpenClawResourceName.WindowsNode.ToServiceName());
+        Assert.Equal("openclaw.source", OpenClawTelemetryTagKey.Source.ToTelemetryName());
+        Assert.Equal("openclaw.outcome", OpenClawTelemetryTagKey.Outcome.ToTelemetryName());
+        Assert.Equal("openclaw.errorCategory", OpenClawTelemetryTagKey.ErrorCategory.ToTelemetryName());
+        Assert.Equal("openclaw.reason", OpenClawTelemetryTagKey.Reason.ToTelemetryName());
+        Assert.Equal("openclaw.status", OpenClawTelemetryTagKey.Status.ToTelemetryName());
+        Assert.Equal("error.type", OpenClawTelemetryTagKey.ErrorType.ToTelemetryName());
     }
 
     [Fact]
@@ -30,7 +26,6 @@ public sealed class OpenClawTelemetryTests
         var ran = false;
 
         var result = OpenClawTelemetry.Trace(
-            OpenClawActivitySources.OpenClawSource,
             "test.no_listener",
             () =>
             {
@@ -43,51 +38,77 @@ public sealed class OpenClawTelemetryTests
     }
 
     [Fact]
+    public void MarkHelpers_AreSafeForNullActivities()
+    {
+        var exception = new InvalidOperationException("boom");
+
+        OpenClawTelemetry.MarkSuccess(null);
+        OpenClawTelemetry.MarkCanceled(null);
+        OpenClawTelemetry.MarkFailure(null, exception);
+    }
+
+    [Fact]
+    public void StartActivity_WithListener_AllowsManualMarking()
+    {
+        using var collector = ActivityCollector.Listen(OpenClawActivitySourceName.OpenClaw.ToTelemetryName());
+        using var activity = OpenClawTelemetry.StartActivity(
+            "test.manual",
+            [OpenClawTelemetryTag.String(OpenClawTelemetryTagKey.Source, "unit-test")]);
+
+        OpenClawTelemetry.MarkSuccess(activity);
+
+        Assert.NotNull(activity);
+        Assert.Equal(ActivityStatusCode.Ok, activity.Status);
+        Assert.Contains(activity.Tags, tag => tag.Key == OpenClawTelemetryTagKey.Source.ToTelemetryName() && tag.Value == "unit-test");
+        Assert.Contains(activity.Tags, tag => tag.Key == OpenClawTelemetryTagKey.Outcome.ToTelemetryName() && tag.Value == "success");
+    }
+
+    [Fact]
     public void Trace_WithListener_RecordsSuccessAndTags()
     {
-        using var collector = ActivityCollector.Listen(OpenClawActivitySources.OpenClaw);
+        using var collector = ActivityCollector.Listen(OpenClawActivitySourceName.OpenClaw.ToTelemetryName());
 
         OpenClawTelemetry.Trace(
-            OpenClawActivitySources.OpenClawSource,
             "test.success",
             () => { },
             [
-                OpenClawTelemetryTag.String(OpenClawTelemetryTags.Source, "unit-test"),
-                OpenClawTelemetryTag.String(OpenClawTelemetryTags.Exporter, "tray-otel")
+                OpenClawTelemetryTag.String(OpenClawTelemetryTagKey.Source, "unit-test"),
+                OpenClawTelemetryTag.String("openclaw.test.exporter", "tray-otel")
             ]);
 
         var activity = Assert.Single(collector.Stopped);
         Assert.Equal("test.success", activity.OperationName);
         Assert.Equal(ActivityStatusCode.Ok, activity.Status);
-        Assert.Contains(activity.Tags, tag => tag.Key == OpenClawTelemetryTags.Source && tag.Value == "unit-test");
-        Assert.Contains(activity.Tags, tag => tag.Key == OpenClawTelemetryTags.Exporter && tag.Value == "tray-otel");
+        Assert.Contains(activity.Tags, tag => tag.Key == OpenClawTelemetryTagKey.Source.ToTelemetryName() && tag.Value == "unit-test");
+        Assert.Contains(activity.Tags, tag => tag.Key == "openclaw.test.exporter" && tag.Value == "tray-otel");
+        Assert.Contains(activity.Tags, tag => tag.Key == OpenClawTelemetryTagKey.Outcome.ToTelemetryName() && tag.Value == "success");
     }
 
     [Fact]
     public void Trace_Exception_MarksErrorAndRethrowsOriginal()
     {
-        using var collector = ActivityCollector.Listen(OpenClawActivitySources.OpenClaw);
+        using var collector = ActivityCollector.Listen(OpenClawActivitySourceName.OpenClaw.ToTelemetryName());
         var expected = new InvalidOperationException("boom");
 
         var thrown = Assert.Throws<InvalidOperationException>(() =>
-            OpenClawTelemetry.Trace(OpenClawActivitySources.OpenClawSource, "test.error", () => throw expected));
+            OpenClawTelemetry.Trace("test.error", () => throw expected));
 
         Assert.Same(expected, thrown);
         var activity = Assert.Single(collector.Stopped);
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
         Assert.Equal(nameof(InvalidOperationException), activity.StatusDescription);
+        Assert.Contains(activity.Tags, tag => tag.Key == OpenClawTelemetryTagKey.Outcome.ToTelemetryName() && tag.Value == "failure");
         Assert.Contains(
             activity.Tags,
-            tag => tag.Key == OpenClawTelemetryTags.ErrorType && tag.Value == typeof(InvalidOperationException).FullName);
+            tag => tag.Key == OpenClawTelemetryTagKey.ErrorType.ToTelemetryName() && tag.Value == typeof(InvalidOperationException).FullName);
     }
 
     [Fact]
     public async Task TraceAsync_WithListener_RecordsSuccessAndReturnsResult()
     {
-        using var collector = ActivityCollector.Listen(OpenClawActivitySources.OpenClaw);
+        using var collector = ActivityCollector.Listen(OpenClawActivitySourceName.OpenClaw.ToTelemetryName());
 
         var result = await OpenClawTelemetry.TraceAsync(
-            OpenClawActivitySources.OpenClawSource,
             "test.async.success",
             _ => Task.FromResult("ok"));
 
@@ -95,40 +116,73 @@ public sealed class OpenClawTelemetryTests
         var activity = Assert.Single(collector.Stopped);
         Assert.Equal("test.async.success", activity.OperationName);
         Assert.Equal(ActivityStatusCode.Ok, activity.Status);
+        Assert.Contains(activity.Tags, tag => tag.Key == OpenClawTelemetryTagKey.Outcome.ToTelemetryName() && tag.Value == "success");
     }
 
     [Fact]
     public async Task TraceAsync_CanceledTask_MarksCanceledAndPreservesCancellation()
     {
-        using var collector = ActivityCollector.Listen(OpenClawActivitySources.OpenClaw);
+        using var collector = ActivityCollector.Listen(OpenClawActivitySourceName.OpenClaw.ToTelemetryName());
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
         await Assert.ThrowsAsync<TaskCanceledException>(() =>
             OpenClawTelemetry.TraceAsync(
-                OpenClawActivitySources.OpenClawSource,
                 "test.async.cancel",
                 token => Task.FromCanceled(token),
                 cancellationToken: cts.Token));
 
         var activity = Assert.Single(collector.Stopped);
         Assert.Equal(ActivityStatusCode.Unset, activity.Status);
-        Assert.Contains(activity.Tags, tag => tag.Key == OpenClawTelemetryTags.Outcome && tag.Value == "canceled");
+        Assert.Contains(activity.Tags, tag => tag.Key == OpenClawTelemetryTagKey.Outcome.ToTelemetryName() && tag.Value == "canceled");
     }
 
     [Fact]
-    public void StringTag_BoundsLongValues()
+    public void Trace_OperationCanceled_MarksCanceledAndRethrowsOriginal()
     {
-        var tag = OpenClawTelemetryTag.String(OpenClawTelemetryTags.Source, "abcdef", maxLength: 3);
+        using var collector = ActivityCollector.Listen(OpenClawActivitySourceName.OpenClaw.ToTelemetryName());
+        var expected = new OperationCanceledException();
 
-        Assert.Equal("abc", tag.Value);
+        var thrown = Assert.Throws<OperationCanceledException>(() =>
+            OpenClawTelemetry.Trace("test.sync.cancel", () => throw expected));
+
+        Assert.Same(expected, thrown);
+        var activity = Assert.Single(collector.Stopped);
+        Assert.Equal(ActivityStatusCode.Unset, activity.Status);
+        Assert.Contains(activity.Tags, tag => tag.Key == OpenClawTelemetryTagKey.Outcome.ToTelemetryName() && tag.Value == "canceled");
+    }
+
+    [Fact]
+    public void StringTag_PreservesStringValues()
+    {
+        const string value = "diagnostic-label";
+
+        var tag = OpenClawTelemetryTag.String(OpenClawTelemetryTagKey.Source, value);
+
+        Assert.Equal(value, tag.Value);
+    }
+
+    [Fact]
+    public void LocalStringTag_UsesLocalKey()
+    {
+        var tag = OpenClawTelemetryTag.String("openclaw.test.local", "value");
+
+        Assert.Equal("openclaw.test.local", tag.Key);
+        Assert.Equal("value", tag.Value);
     }
 
     [Fact]
     public void TelemetryTag_IsReferenceType_WithValidatedConstruction()
     {
         Assert.False(typeof(OpenClawTelemetryTag).IsValueType);
-        Assert.Throws<ArgumentException>(() => new OpenClawTelemetryTag("", "value"));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new OpenClawTelemetryTag((OpenClawTelemetryTagKey)999, "value"));
+        Assert.Throws<ArgumentException>(() => OpenClawTelemetryTag.String("", "value"));
+    }
+
+    [Fact]
+    public void MarkFailure_RequiresException()
+    {
+        Assert.Throws<ArgumentNullException>(() => OpenClawTelemetry.MarkFailure(null, null!));
     }
 
     private sealed class ActivityCollector : IDisposable

--- a/tests/OpenClaw.Tray.Tests/DiagnosticsPageContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/DiagnosticsPageContractTests.cs
@@ -32,6 +32,29 @@ public sealed class DiagnosticsPageContractTests
     }
 
     [Fact]
+    public void DebugPage_PutsOpenTelemetryEndpointInDiagnosticsDeveloperTools()
+    {
+        var xaml = Read("src", "OpenClaw.Tray.WinUI", "Pages", "DebugPage.xaml");
+        var cs = Read("src", "OpenClaw.Tray.WinUI", "Pages", "DebugPage.xaml.cs");
+
+        Assert.Contains("DiagnosticsPage_Expander_OpenTelemetry", xaml);
+        Assert.Contains("OpenTelemetry connection", xaml);
+        Assert.Contains("FluentIconCatalog.Telemetry", xaml);
+        Assert.Contains("DiagnosticsOpenTelemetryEndpoint", xaml);
+        Assert.Contains("DiagnosticsOpenTelemetryProtocolGrpc", xaml);
+        Assert.Contains("DiagnosticsOpenTelemetryProtocolHttp", xaml);
+        Assert.Contains("OTLP/gRPC", xaml);
+        Assert.Contains("OTLP/HTTP", xaml);
+        Assert.Contains("SettingsExpander.ItemsHeader", xaml);
+        Assert.DoesNotContain("DiagnosticsPage_Card_OpenTelemetryEndpoint", xaml);
+        Assert.Contains("Sends a small diagnostic probe only to the OTLP collector endpoint you configure.", xaml);
+        Assert.Contains("OpenTelemetryEndpoint", cs);
+        Assert.Contains("OpenTelemetryProtocol", cs);
+        Assert.Contains("TryNormalizeOpenTelemetryEndpoint", cs);
+        Assert.Contains("NotifySettingsSaved", cs);
+    }
+
+    [Fact]
     public void DebugPage_GatewayDoctorCard_IsGatedOnWslControlAndRunsDoctor()
     {
         var xaml = Read("src", "OpenClaw.Tray.WinUI", "Pages", "DebugPage.xaml");

--- a/tests/OpenClaw.Tray.Tests/DiagnosticsPageContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/DiagnosticsPageContractTests.cs
@@ -54,6 +54,11 @@ public sealed class DiagnosticsPageContractTests
         Assert.Contains("OpenTelemetryEndpointOptions.TryCreateEndpointUri", cs);
         Assert.Contains("CurrentApp.Settings.OpenTelemetryProtocol = OpenTelemetryEndpointProtocol.Grpc", cs);
         Assert.Contains("NotifySettingsSaved", cs);
+        Assert.Contains("DiagnosticsResendOpenTelemetryProbe", xaml);
+        Assert.Contains("Send probe again", xaml);
+        Assert.Contains("OnResendOpenTelemetryProbe", xaml);
+        Assert.Contains("ResendOpenTelemetryProbeAsync", cs);
+        Assert.Contains("probeFlushed.Value ? DimTextBrush : WarnTextBrush", cs);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/DiagnosticsPageContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/DiagnosticsPageContractTests.cs
@@ -51,6 +51,8 @@ public sealed class DiagnosticsPageContractTests
         Assert.Contains("OpenTelemetryEndpoint", cs);
         Assert.Contains("OpenTelemetryProtocol", cs);
         Assert.Contains("TryNormalizeOpenTelemetryEndpoint", cs);
+        Assert.Contains("OpenTelemetryEndpointOptions.TryCreateEndpointUri", cs);
+        Assert.Contains("CurrentApp.Settings.OpenTelemetryProtocol = OpenTelemetryEndpointProtocol.Grpc", cs);
         Assert.Contains("NotifySettingsSaved", cs);
     }
 

--- a/tests/OpenClaw.Tray.Tests/FluentIconCatalogTests.cs
+++ b/tests/OpenClaw.Tray.Tests/FluentIconCatalogTests.cs
@@ -25,7 +25,7 @@ public sealed class FluentIconCatalogTests
         "People", "Money", "ServerEnvironment", "CapabilityOff", "Channels",
         "ChevronR", "Check",
         // Diagnostics surface (see src/OpenClaw.Tray.WinUI/Pages/DebugPage.xaml).
-        "Bug", "Briefcase", "Folder", "Copy", "Document", "Refresh", "Reset", "Clear", "Develop",
+        "Bug", "Briefcase", "Folder", "Copy", "Document", "Refresh", "Reset", "Clear", "Develop", "Telemetry",
         // Workspace surface (see src/OpenClaw.Tray.WinUI/Pages/WorkspacePage.xaml).
         "Workspace",
     };

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -15,6 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="OpenTelemetry" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <ProjectReference Include="..\..\src\OpenClaw.Shared\OpenClaw.Shared.csproj" />
     <ProjectReference Include="..\..\src\OpenClaw.Connection\OpenClaw.Connection.csproj" />
     <!-- Compile only the model-layer files directly so the tests can remain
@@ -52,6 +54,9 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\DiagnosticsLogTailReader.cs" Link="Services\DiagnosticsLogTailReader.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\DiagnosticsBundleBuilder.cs" Link="Services\DiagnosticsBundleBuilder.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SettingsManager.cs" Link="Services\SettingsManager.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\OpenTelemetryEndpointProtocol.cs" Link="Services\OpenTelemetryEndpointProtocol.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\OpenTelemetryEndpointOptions.cs" Link="Services\OpenTelemetryEndpointOptions.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\OpenTelemetryEndpointConnection.cs" Link="Services\OpenTelemetryEndpointConnection.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SessionVisibilityFilter.cs" Link="Services\SessionVisibilityFilter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\OnboardingChatBootstrapper.cs" Link="Services\OnboardingChatBootstrapper.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\StartupSetupState.cs" Link="Services\StartupSetupState.cs" />

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SettingsManager.cs" Link="Services\SettingsManager.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\OpenTelemetryEndpointProtocol.cs" Link="Services\OpenTelemetryEndpointProtocol.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\OpenTelemetryEndpointOptions.cs" Link="Services\OpenTelemetryEndpointOptions.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\OpenTelemetryLogPolicy.cs" Link="Services\OpenTelemetryLogPolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\OpenTelemetryEndpointConnection.cs" Link="Services\OpenTelemetryEndpointConnection.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\SessionVisibilityFilter.cs" Link="Services\SessionVisibilityFilter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\OnboardingChatBootstrapper.cs" Link="Services\OnboardingChatBootstrapper.cs" />

--- a/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
@@ -1,4 +1,5 @@
 using OpenClawTray.Services;
+using OpenClaw.Shared.Telemetry;
 
 namespace OpenClaw.Tray.Tests;
 
@@ -22,6 +23,28 @@ public sealed class OpenTelemetryEndpointConnectionTests
         Assert.Equal(0, created);
         Assert.Equal(OpenTelemetryEndpointConnectionState.Disabled, connection.State);
         Assert.False(connection.CurrentOptions.IsEnabled);
+    }
+
+    [Fact]
+    public void Probe_UsesGatewayAlignedTelemetryConstants()
+    {
+        Assert.Contains(OpenClawActivitySources.OpenClaw, OpenClawActivitySources.ExportedNames);
+        Assert.Equal("openclaw-windows-tray", OpenClawResourceNames.Tray);
+        Assert.Equal("grpc", OpenTelemetryEndpointProtocol.ToTelemetryValue(OpenTelemetryEndpointProtocol.Grpc));
+        Assert.Equal("http/protobuf", OpenTelemetryEndpointProtocol.ToTelemetryValue(OpenTelemetryEndpointProtocol.HttpProtobuf));
+    }
+
+    [Fact]
+    public void ProviderRuntime_IsAppLevel_NotDebugPageOwned()
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        var app = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.Tray.WinUI", "App.xaml.cs"));
+        var debugPage = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.Tray.WinUI", "Pages", "DebugPage.xaml.cs"));
+
+        Assert.Contains("_openTelemetryConnection = new OpenTelemetryEndpointConnection();", app);
+        Assert.Contains("ApplyOpenTelemetryEndpointSettings();", app);
+        Assert.Contains("OnSettingsSaved", app);
+        Assert.DoesNotContain("new OpenTelemetryEndpointConnection", debugPage);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
@@ -29,6 +29,7 @@ public sealed class OpenTelemetryEndpointConnectionTests
     public void Probe_UsesGatewayAlignedTelemetryConstants()
     {
         Assert.Equal("openclaw", OpenClawActivitySourceName.OpenClaw.ToTelemetryName());
+        Assert.Equal("openclaw", OpenClawMeterName.OpenClaw.ToTelemetryName());
         Assert.Equal("openclaw-windows-tray", OpenClawResourceName.WindowsTray.ToServiceName());
         Assert.Equal("grpc", OpenTelemetryEndpointProtocol.ToTelemetryValue(OpenTelemetryEndpointProtocol.Grpc));
         Assert.Equal("http/protobuf", OpenTelemetryEndpointProtocol.ToTelemetryValue(OpenTelemetryEndpointProtocol.HttpProtobuf));

--- a/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
@@ -87,6 +87,28 @@ public sealed class OpenTelemetryEndpointConnectionTests
         }
     }
 
+    [Theory]
+    [InlineData("http://localhost:4317")]
+    [InlineData("https://collector.example.test:4318/otlp")]
+    public void EndpointOptions_AcceptsPlainCollectorUrls(string endpoint)
+    {
+        var options = OpenTelemetryEndpointOptions.Create(endpoint, OpenTelemetryEndpointProtocol.Grpc);
+
+        Assert.True(options.TryGetEndpointUri(out var uri));
+        Assert.NotNull(uri);
+    }
+
+    [Theory]
+    [InlineData("https://user:password@collector.example.test:4318")]
+    [InlineData("https://collector.example.test:4318/otlp?api_key=secret")]
+    [InlineData("https://collector.example.test:4318/#token=secret")]
+    public void EndpointOptions_RejectsCredentialOrParameterizedUrls(string endpoint)
+    {
+        var options = OpenTelemetryEndpointOptions.Create(endpoint, OpenTelemetryEndpointProtocol.Grpc);
+
+        Assert.False(options.TryGetEndpointUri(out _));
+    }
+
     [Fact]
     public void Apply_SendsOneProbeAndFlushes_ForConfiguredEndpoint()
     {
@@ -173,6 +195,33 @@ public sealed class OpenTelemetryEndpointConnectionTests
         Assert.Equal(1, sinks[0].SendProbeCount);
         Assert.Equal(1, sinks[1].SendProbeCount);
         Assert.Equal(OpenTelemetryEndpointProtocol.HttpProtobuf, connection.CurrentOptions.Protocol);
+    }
+
+    [Fact]
+    public void Apply_OldSinkDisposeFailure_StillAppliesNewOptionsAndLogsWarning()
+    {
+        var sinks = new List<FakeProbeSink>();
+        var warnings = new List<string>();
+        using var connection = new OpenTelemetryEndpointConnection(
+            _ =>
+            {
+                var sink = new FakeProbeSink();
+                sinks.Add(sink);
+                return sink;
+            },
+            _ => { },
+            warnings.Add);
+
+        connection.Apply(OpenTelemetryEndpointOptions.Create("http://localhost:4317", OpenTelemetryEndpointProtocol.Grpc));
+        sinks[0].ThrowOnDispose = true;
+        connection.Apply(OpenTelemetryEndpointOptions.Create("http://localhost:4318", OpenTelemetryEndpointProtocol.HttpProtobuf));
+
+        Assert.Equal(2, sinks.Count);
+        Assert.Equal(1, sinks[0].DisposeCount);
+        Assert.False(sinks[1].Disposed);
+        Assert.Equal(OpenTelemetryEndpointConnectionState.Connected, connection.State);
+        Assert.Equal("http://localhost:4318", connection.CurrentOptions.Endpoint);
+        Assert.Contains(warnings, warning => warning.Contains("sink disposal failed", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -273,6 +322,8 @@ public sealed class OpenTelemetryEndpointConnectionTests
         public bool ForceFlushResult { get; init; } = true;
         public Action? OnForceFlush { get; set; }
         public bool Disposed { get; private set; }
+        public int DisposeCount { get; private set; }
+        public bool ThrowOnDispose { get; set; }
         public OpenTelemetryEndpointOptions? LastProbeOptions { get; private set; }
 
         public void SendProbe(OpenTelemetryEndpointOptions options)
@@ -290,6 +341,10 @@ public sealed class OpenTelemetryEndpointConnectionTests
 
         public void Dispose()
         {
+            DisposeCount++;
+            if (ThrowOnDispose)
+                throw new InvalidOperationException("dispose failed");
+
             Disposed = true;
         }
     }

--- a/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
@@ -224,6 +224,36 @@ public sealed class OpenTelemetryEndpointConnectionTests
     }
 
     [Fact]
+    public async Task ProbeAsync_SameOptions_ResendsWithoutChangingAutomaticDeduplication()
+    {
+        var sinks = new List<FakeProbeSink>();
+        using var connection = new OpenTelemetryEndpointConnection(
+            _ =>
+            {
+                var sink = new FakeProbeSink();
+                sinks.Add(sink);
+                return sink;
+            },
+            _ => { },
+            _ => { });
+        var options = OpenTelemetryEndpointOptions.Create(
+            "http://localhost:4317",
+            OpenTelemetryEndpointProtocol.Grpc);
+
+        connection.Apply(options);
+        await connection.ProbeAsync(options);
+        connection.Apply(options);
+
+        Assert.Equal(2, sinks.Count);
+        Assert.True(sinks[0].Disposed);
+        Assert.False(sinks[1].Disposed);
+        Assert.Equal(1, sinks[0].SendProbeCount);
+        Assert.Equal(1, sinks[1].SendProbeCount);
+        Assert.Equal(OpenTelemetryEndpointConnectionState.ProbeFlushed, connection.State);
+        Assert.Equal(options, connection.CurrentOptions);
+    }
+
+    [Fact]
     public void Apply_NewOptions_DisposesOldSinkAndSendsNewProbe()
     {
         var sinks = new List<FakeProbeSink>();

--- a/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
@@ -28,8 +28,8 @@ public sealed class OpenTelemetryEndpointConnectionTests
     [Fact]
     public void Probe_UsesGatewayAlignedTelemetryConstants()
     {
-        Assert.Contains(OpenClawActivitySources.OpenClaw, OpenClawActivitySources.ExportedNames);
-        Assert.Equal("openclaw-windows-tray", OpenClawResourceNames.Tray);
+        Assert.Equal("openclaw", OpenClawActivitySourceName.OpenClaw.ToTelemetryName());
+        Assert.Equal("openclaw-windows-tray", OpenClawResourceName.WindowsTray.ToServiceName());
         Assert.Equal("grpc", OpenTelemetryEndpointProtocol.ToTelemetryValue(OpenTelemetryEndpointProtocol.Grpc));
         Assert.Equal("http/protobuf", OpenTelemetryEndpointProtocol.ToTelemetryValue(OpenTelemetryEndpointProtocol.HttpProtobuf));
     }

--- a/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
@@ -109,6 +109,57 @@ public sealed class OpenTelemetryEndpointConnectionTests
         Assert.False(options.TryGetEndpointUri(out _));
     }
 
+    [Theory]
+    [InlineData("http://localhost:4318", "http://localhost:4318/v1/traces", "http://localhost:4318/v1/metrics", "http://localhost:4318/v1/logs")]
+    [InlineData("http://localhost:4318/", "http://localhost:4318/v1/traces", "http://localhost:4318/v1/metrics", "http://localhost:4318/v1/logs")]
+    [InlineData("https://collector.example.test:4318/otlp", "https://collector.example.test:4318/otlp/v1/traces", "https://collector.example.test:4318/otlp/v1/metrics", "https://collector.example.test:4318/otlp/v1/logs")]
+    [InlineData("https://collector.example.test:4318/v1", "https://collector.example.test:4318/v1/traces", "https://collector.example.test:4318/v1/metrics", "https://collector.example.test:4318/v1/logs")]
+    [InlineData("https://collector.example.test:4318/otlp/v1", "https://collector.example.test:4318/otlp/v1/traces", "https://collector.example.test:4318/otlp/v1/metrics", "https://collector.example.test:4318/otlp/v1/logs")]
+    [InlineData("https://collector.example.test:4318/v1/traces", "https://collector.example.test:4318/v1/traces", "https://collector.example.test:4318/v1/metrics", "https://collector.example.test:4318/v1/logs")]
+    [InlineData("https://collector.example.test:4318/v1/metrics", "https://collector.example.test:4318/v1/traces", "https://collector.example.test:4318/v1/metrics", "https://collector.example.test:4318/v1/logs")]
+    [InlineData("https://collector.example.test:4318/v1/logs", "https://collector.example.test:4318/v1/traces", "https://collector.example.test:4318/v1/metrics", "https://collector.example.test:4318/v1/logs")]
+    [InlineData("https://collector.example.test:4318/otlp/V1/TrAcEs", "https://collector.example.test:4318/otlp/v1/traces", "https://collector.example.test:4318/otlp/v1/metrics", "https://collector.example.test:4318/otlp/v1/logs")]
+    public void ResolveExporterEndpoint_HttpProtobuf_UsesSignalSpecificPaths(
+        string configuredEndpoint,
+        string expectedTraceEndpoint,
+        string expectedMetricEndpoint,
+        string expectedLogEndpoint)
+    {
+        var endpoint = new Uri(configuredEndpoint);
+
+        Assert.Equal(
+            expectedTraceEndpoint,
+            OpenTelemetryOtlpProbeSink.ResolveExporterEndpoint(
+                endpoint,
+                OpenTelemetryEndpointProtocol.HttpProtobuf,
+                OpenTelemetryOtlpProbeSink.OpenTelemetryOtlpSignal.Traces).AbsoluteUri);
+        Assert.Equal(
+            expectedMetricEndpoint,
+            OpenTelemetryOtlpProbeSink.ResolveExporterEndpoint(
+                endpoint,
+                OpenTelemetryEndpointProtocol.HttpProtobuf,
+                OpenTelemetryOtlpProbeSink.OpenTelemetryOtlpSignal.Metrics).AbsoluteUri);
+        Assert.Equal(
+            expectedLogEndpoint,
+            OpenTelemetryOtlpProbeSink.ResolveExporterEndpoint(
+                endpoint,
+                OpenTelemetryEndpointProtocol.HttpProtobuf,
+                OpenTelemetryOtlpProbeSink.OpenTelemetryOtlpSignal.Logs).AbsoluteUri);
+    }
+
+    [Fact]
+    public void ResolveExporterEndpoint_Grpc_UsesConfiguredEndpoint()
+    {
+        var endpoint = new Uri("http://localhost:4317/collector");
+
+        var resolved = OpenTelemetryOtlpProbeSink.ResolveExporterEndpoint(
+            endpoint,
+            OpenTelemetryEndpointProtocol.Grpc,
+            OpenTelemetryOtlpProbeSink.OpenTelemetryOtlpSignal.Traces);
+
+        Assert.Same(endpoint, resolved);
+    }
+
     [Fact]
     public void Apply_SendsOneProbeAndFlushes_ForConfiguredEndpoint()
     {

--- a/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
@@ -175,7 +175,7 @@ public sealed class OpenTelemetryEndpointConnectionTests
 
         connection.Apply(options);
 
-        Assert.Equal(OpenTelemetryEndpointConnectionState.Connected, connection.State);
+        Assert.Equal(OpenTelemetryEndpointConnectionState.ProbeFlushed, connection.State);
         Assert.Equal("http://localhost:4318", connection.CurrentOptions.Endpoint);
         Assert.Equal(OpenTelemetryEndpointProtocol.HttpProtobuf, connection.CurrentOptions.Protocol);
         Assert.Equal(1, sink.SendProbeCount);
@@ -184,7 +184,7 @@ public sealed class OpenTelemetryEndpointConnectionTests
     }
 
     [Fact]
-    public void Apply_FailedFlush_DoesNotReportConnected()
+    public void Apply_FailedFlush_DoesNotReportProbeFlushed()
     {
         var sink = new FakeProbeSink { ForceFlushResult = false };
         using var connection = new OpenTelemetryEndpointConnection(
@@ -270,7 +270,7 @@ public sealed class OpenTelemetryEndpointConnectionTests
         Assert.Equal(2, sinks.Count);
         Assert.Equal(1, sinks[0].DisposeCount);
         Assert.False(sinks[1].Disposed);
-        Assert.Equal(OpenTelemetryEndpointConnectionState.Connected, connection.State);
+        Assert.Equal(OpenTelemetryEndpointConnectionState.ProbeFlushed, connection.State);
         Assert.Equal("http://localhost:4318", connection.CurrentOptions.Endpoint);
         Assert.Contains(warnings, warning => warning.Contains("sink disposal failed", StringComparison.Ordinal));
     }
@@ -331,7 +331,7 @@ public sealed class OpenTelemetryEndpointConnectionTests
         Assert.Equal(2, sinks.Count);
         Assert.True(sinks[0].Disposed);
         Assert.False(sinks[1].Disposed);
-        Assert.Equal(OpenTelemetryEndpointConnectionState.Connected, connection.State);
+        Assert.Equal(OpenTelemetryEndpointConnectionState.ProbeFlushed, connection.State);
         Assert.Equal(latest, connection.CurrentOptions);
     }
 

--- a/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
@@ -1,0 +1,255 @@
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests;
+
+public sealed class OpenTelemetryEndpointConnectionTests
+{
+    [Fact]
+    public void Apply_DoesNotCreateSink_WhenEndpointIsEmpty()
+    {
+        var created = 0;
+        using var connection = new OpenTelemetryEndpointConnection(
+            _ =>
+            {
+                created++;
+                return new FakeProbeSink();
+            },
+            _ => { },
+            _ => { });
+
+        connection.Apply(OpenTelemetryEndpointOptions.Create(null, OpenTelemetryEndpointProtocol.HttpProtobuf));
+
+        Assert.Equal(0, created);
+        Assert.Equal(OpenTelemetryEndpointConnectionState.Disabled, connection.State);
+        Assert.False(connection.CurrentOptions.IsEnabled);
+    }
+
+    [Fact]
+    public void FromSettings_DoesNotUsePlaceholderAsDefaultEndpoint()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "OpenClaw.Tray.Tests", Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            Directory.CreateDirectory(dir);
+            var settings = new SettingsManager(dir);
+
+            var options = OpenTelemetryEndpointOptions.FromSettings(settings);
+
+            Assert.False(options.IsEnabled);
+            Assert.Null(options.Endpoint);
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Apply_SendsOneProbeAndFlushes_ForConfiguredEndpoint()
+    {
+        var sink = new FakeProbeSink();
+        using var connection = new OpenTelemetryEndpointConnection(
+            _ => sink,
+            _ => { },
+            _ => { });
+
+        var options = OpenTelemetryEndpointOptions.Create(
+            " http://localhost:4318 ",
+            OpenTelemetryEndpointProtocol.HttpProtobuf);
+
+        connection.Apply(options);
+
+        Assert.Equal(OpenTelemetryEndpointConnectionState.Connected, connection.State);
+        Assert.Equal("http://localhost:4318", connection.CurrentOptions.Endpoint);
+        Assert.Equal(OpenTelemetryEndpointProtocol.HttpProtobuf, connection.CurrentOptions.Protocol);
+        Assert.Equal(1, sink.SendProbeCount);
+        Assert.Equal(1, sink.ForceFlushCount);
+        Assert.Equal(options, sink.LastProbeOptions);
+    }
+
+    [Fact]
+    public void Apply_FailedFlush_DoesNotReportConnected()
+    {
+        var sink = new FakeProbeSink { ForceFlushResult = false };
+        using var connection = new OpenTelemetryEndpointConnection(
+            _ => sink,
+            _ => { },
+            _ => { });
+
+        var options = OpenTelemetryEndpointOptions.Create(
+            "http://localhost:4318",
+            OpenTelemetryEndpointProtocol.HttpProtobuf);
+
+        connection.Apply(options);
+
+        Assert.Equal(OpenTelemetryEndpointConnectionState.Failed, connection.State);
+        Assert.Contains("did not flush", connection.LastError);
+        Assert.True(sink.Disposed);
+        Assert.Equal(options, connection.CurrentOptions);
+    }
+
+    [Fact]
+    public void Apply_SameOptions_DoNotSendDuplicateProbe()
+    {
+        var sink = new FakeProbeSink();
+        using var connection = new OpenTelemetryEndpointConnection(
+            _ => sink,
+            _ => { },
+            _ => { });
+        var options = OpenTelemetryEndpointOptions.Create(
+            "http://localhost:4317",
+            OpenTelemetryEndpointProtocol.Grpc);
+
+        connection.Apply(options);
+        connection.Apply(options);
+
+        Assert.Equal(1, sink.SendProbeCount);
+        Assert.False(sink.Disposed);
+    }
+
+    [Fact]
+    public void Apply_NewOptions_DisposesOldSinkAndSendsNewProbe()
+    {
+        var sinks = new List<FakeProbeSink>();
+        using var connection = new OpenTelemetryEndpointConnection(
+            _ =>
+            {
+                var sink = new FakeProbeSink();
+                sinks.Add(sink);
+                return sink;
+            },
+            _ => { },
+            _ => { });
+
+        connection.Apply(OpenTelemetryEndpointOptions.Create("http://localhost:4317", OpenTelemetryEndpointProtocol.Grpc));
+        connection.Apply(OpenTelemetryEndpointOptions.Create("http://localhost:4318", OpenTelemetryEndpointProtocol.HttpProtobuf));
+
+        Assert.Equal(2, sinks.Count);
+        Assert.True(sinks[0].Disposed);
+        Assert.False(sinks[1].Disposed);
+        Assert.Equal(1, sinks[0].SendProbeCount);
+        Assert.Equal(1, sinks[1].SendProbeCount);
+        Assert.Equal(OpenTelemetryEndpointProtocol.HttpProtobuf, connection.CurrentOptions.Protocol);
+    }
+
+    [Fact]
+    public void Apply_AfterDispose_DoesNotCreateSink()
+    {
+        var created = 0;
+        var connection = new OpenTelemetryEndpointConnection(
+            _ =>
+            {
+                created++;
+                return new FakeProbeSink();
+            },
+            _ => { },
+            _ => { });
+
+        connection.Dispose();
+        connection.Apply(OpenTelemetryEndpointOptions.Create("http://localhost:4317", OpenTelemetryEndpointProtocol.Grpc));
+
+        Assert.Equal(0, created);
+        Assert.Equal(OpenTelemetryEndpointConnectionState.Disabled, connection.State);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_StaleApply_DoesNotWinOverLatestSettings()
+    {
+        var firstFlushStarted = new ManualResetEventSlim();
+        var releaseFirstFlush = new ManualResetEventSlim();
+        var sinks = new List<FakeProbeSink>();
+        using var connection = new OpenTelemetryEndpointConnection(
+            _ =>
+            {
+                var sink = new FakeProbeSink();
+                if (sinks.Count == 0)
+                {
+                    sink.OnForceFlush = () =>
+                    {
+                        firstFlushStarted.Set();
+                        Assert.True(releaseFirstFlush.Wait(TimeSpan.FromSeconds(5)));
+                    };
+                }
+
+                sinks.Add(sink);
+                return sink;
+            },
+            _ => { },
+            _ => { });
+        var stale = OpenTelemetryEndpointOptions.Create("http://localhost:4317", OpenTelemetryEndpointProtocol.Grpc);
+        var latest = OpenTelemetryEndpointOptions.Create("http://localhost:4318", OpenTelemetryEndpointProtocol.HttpProtobuf);
+
+        var staleTask = connection.ApplyAsync(stale);
+        Assert.True(firstFlushStarted.Wait(TimeSpan.FromSeconds(5)));
+        var latestTask = connection.ApplyAsync(latest);
+        releaseFirstFlush.Set();
+        await Task.WhenAll(staleTask, latestTask);
+
+        Assert.Equal(2, sinks.Count);
+        Assert.True(sinks[0].Disposed);
+        Assert.False(sinks[1].Disposed);
+        Assert.Equal(OpenTelemetryEndpointConnectionState.Connected, connection.State);
+        Assert.Equal(latest, connection.CurrentOptions);
+    }
+
+    [Fact]
+    public void FromSettings_CarriesOnlyEndpointAndProtocol()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "OpenClaw.Tray.Tests", Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            Directory.CreateDirectory(dir);
+            var settings = new SettingsManager(dir)
+            {
+                GatewayUrl = "wss://gateway.example.test",
+                OpenTelemetryEndpoint = "http://collector.example.test:4317",
+                OpenTelemetryProtocol = OpenTelemetryEndpointProtocol.Grpc,
+                TtsElevenLabsApiKey = "secret-key"
+            };
+
+            var options = OpenTelemetryEndpointOptions.FromSettings(settings);
+
+            Assert.Equal("http://collector.example.test:4317", options.Endpoint);
+            Assert.Equal(OpenTelemetryEndpointProtocol.Grpc, options.Protocol);
+            var serialized = options.ToString().ToLowerInvariant();
+            Assert.DoesNotContain("gateway", serialized);
+            Assert.DoesNotContain("secret", serialized);
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    private sealed class FakeProbeSink : IOpenTelemetryProbeSink
+    {
+        public int SendProbeCount { get; private set; }
+        public int ForceFlushCount { get; private set; }
+        public bool ForceFlushResult { get; init; } = true;
+        public Action? OnForceFlush { get; set; }
+        public bool Disposed { get; private set; }
+        public OpenTelemetryEndpointOptions? LastProbeOptions { get; private set; }
+
+        public void SendProbe(OpenTelemetryEndpointOptions options)
+        {
+            SendProbeCount++;
+            LastProbeOptions = options;
+        }
+
+        public bool ForceFlush(int timeoutMilliseconds)
+        {
+            ForceFlushCount++;
+            OnForceFlush?.Invoke();
+            return ForceFlushResult;
+        }
+
+        public void Dispose()
+        {
+            Disposed = true;
+        }
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenTelemetryEndpointConnectionTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using OpenClawTray.Services;
 using OpenClaw.Shared.Telemetry;
 
@@ -31,8 +32,24 @@ public sealed class OpenTelemetryEndpointConnectionTests
         Assert.Equal("openclaw", OpenClawActivitySourceName.OpenClaw.ToTelemetryName());
         Assert.Equal("openclaw", OpenClawMeterName.OpenClaw.ToTelemetryName());
         Assert.Equal("openclaw-windows-tray", OpenClawResourceName.WindowsTray.ToServiceName());
+        Assert.Equal("OpenClaw.Telemetry.Exporter", OpenTelemetryLogPolicy.TelemetryExporterCategory);
         Assert.Equal("grpc", OpenTelemetryEndpointProtocol.ToTelemetryValue(OpenTelemetryEndpointProtocol.Grpc));
         Assert.Equal("http/protobuf", OpenTelemetryEndpointProtocol.ToTelemetryValue(OpenTelemetryEndpointProtocol.HttpProtobuf));
+    }
+
+    [Theory]
+    [InlineData("OpenClaw.Telemetry.Exporter", LogLevel.Information, true)]
+    [InlineData("OpenClaw.Telemetry.Connection", LogLevel.Warning, true)]
+    [InlineData("OpenClaw.Telemetry.Exporter", LogLevel.Debug, false)]
+    [InlineData("OpenClaw.Telemetry.Exporter", LogLevel.None, false)]
+    [InlineData("OpenClawTray.Services.GatewayService", LogLevel.Warning, false)]
+    [InlineData(null, LogLevel.Warning, false)]
+    public void OpenTelemetryLogPolicy_AllowsOnlySafeTelemetryCategories(
+        string? category,
+        LogLevel level,
+        bool expected)
+    {
+        Assert.Equal(expected, OpenTelemetryLogPolicy.ShouldExport(category, level));
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/SettingsRoundTripTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SettingsRoundTripTests.cs
@@ -58,6 +58,8 @@ public class SettingsRoundTripTests
             PreferStructuredCategories = true,
             AppTheme = "Dark",
             ShowDiagnostics = true,
+            OpenTelemetryEndpoint = "http://localhost:4317",
+            OpenTelemetryProtocol = OpenTelemetryEndpointProtocol.HttpProtobuf,
             ShowCompletedSessions = true,
             SystemRunSandboxEnabled = true,
             SystemRunBlockHostFallbackWhenMxcUnavailable = true,
@@ -120,6 +122,8 @@ public class SettingsRoundTripTests
         Assert.Equal(original.PreferStructuredCategories, restored.PreferStructuredCategories);
         Assert.Equal(original.AppTheme, restored.AppTheme);
         Assert.Equal(original.ShowDiagnostics, restored.ShowDiagnostics);
+        Assert.Equal(original.OpenTelemetryEndpoint, restored.OpenTelemetryEndpoint);
+        Assert.Equal(original.OpenTelemetryProtocol, restored.OpenTelemetryProtocol);
         Assert.Equal(original.ShowCompletedSessions, restored.ShowCompletedSessions);
         Assert.Equal(original.SystemRunSandboxEnabled, restored.SystemRunSandboxEnabled);
         Assert.Equal(original.SystemRunBlockHostFallbackWhenMxcUnavailable, restored.SystemRunBlockHostFallbackWhenMxcUnavailable);
@@ -191,6 +195,8 @@ public class SettingsRoundTripTests
         Assert.True(settings.PreferStructuredCategories);
         Assert.Equal("System", settings.AppTheme);
         Assert.Null(settings.ShowDiagnostics);
+        Assert.Null(settings.OpenTelemetryEndpoint);
+        Assert.Equal(OpenTelemetryEndpointProtocol.Grpc, settings.OpenTelemetryProtocol);
         Assert.False(settings.ShowCompletedSessions);
         Assert.True(settings.SystemRunSandboxEnabled);
         Assert.False(settings.SystemRunBlockHostFallbackWhenMxcUnavailable);
@@ -199,6 +205,35 @@ public class SettingsRoundTripTests
         // installs and for any settings file that predates the field).
         Assert.True(settings.HubNavPaneOpen);
         Assert.Null(settings.UserRules);
+    }
+
+    [Fact]
+    public void SettingsManager_OpenTelemetryEndpoint_TrimsAndClearsEmptyValues()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "OpenClaw.Tray.Tests", Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            Directory.CreateDirectory(dir);
+            var settings = new SettingsManager(dir)
+            {
+                OpenTelemetryEndpoint = "  http://localhost:4317  ",
+                OpenTelemetryProtocol = "otlp/http"
+            };
+
+            Assert.Equal("http://localhost:4317", settings.OpenTelemetryEndpoint);
+            Assert.Equal(OpenTelemetryEndpointProtocol.HttpProtobuf, settings.OpenTelemetryProtocol);
+
+            settings.OpenTelemetryEndpoint = "   ";
+            settings.OpenTelemetryProtocol = "not-a-protocol";
+            Assert.Equal(string.Empty, settings.OpenTelemetryEndpoint);
+            Assert.Equal(OpenTelemetryEndpointProtocol.Grpc, settings.OpenTelemetryProtocol);
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Adds an opt-in OpenTelemetry diagnostics endpoint setting in the companion app and lays the groundwork for future OTel instrumentation.

This does **not** start exporting general app behavior yet. The only data sent today is a small diagnostic probe when the user explicitly configures an OTLP endpoint: one sample trace span, one sample metric, and one sample structured log. If no endpoint is configured, no OpenTelemetry export is enabled.

This is intended for observability and debugging against an endpoint the user controls, not background consumer tracking. OTLP/gRPC and OTLP/HTTP are both supported; HTTP/protobuf derives the signal-specific trace, metric, and log endpoints from the configured collector base URL.

A maintainer follow-up adds an explicit **Send probe again** action for retrying unchanged saved settings after a collector outage. Automatic startup/settings application remains deduplicated, and the UI continues to distinguish local SDK flush completion from collector acknowledgement.

## Telemetry boundary

`docs/TELEMETRY.md` establishes the ongoing telemetry conventions for OpenClaw: export is opt-in, disabled by default, and sent only to the user-configured endpoint. Future instrumentation should stay limited to low-cardinality operational diagnostics, avoid user content and secrets, avoid arbitrary existing log export, and use the shared OpenClaw trace/metric/log conventions deliberately.

## Screenshots

### OpenClaw WinUI

<img width="741" height="483" alt="image" src="https://github.com/user-attachments/assets/87801e40-be51-459e-85a3-1ff0c11ecc6f" />
<img width="741" height="483" alt="Screenshot 2026-07-10 143045" src="https://github.com/user-attachments/assets/9e2bc39e-e724-442e-9295-4380f97d2554" />
<img width="741" height="483" alt="Screenshot 2026-07-10 143103" src="https://github.com/user-attachments/assets/597b3960-39e7-46c4-a08d-aeff782536a2" />
<img width="741" height="483" alt="image" src="https://github.com/user-attachments/assets/2aa1991d-0ea9-4e10-b9fc-d22fe4147742" />
<img width="741" height="483" alt="image" src="https://github.com/user-attachments/assets/df0631f7-b0fe-4e4b-8b53-94b651f26318" />

### OTLP/gRPC

<img width="1920" height="1044" alt="Screenshot 2026-07-10 123928" src="https://github.com/user-attachments/assets/ca4ab205-919a-4229-b188-5154c8a9b97f" />
<img width="1920" height="1044" alt="Screenshot 2026-07-10 123933" src="https://github.com/user-attachments/assets/ffb435e0-948b-45de-b401-a32434c16d60" />
<img width="1920" height="1044" alt="Screenshot 2026-07-10 123938" src="https://github.com/user-attachments/assets/9c7b8ec6-c174-44e3-9743-81e1e3b9ed3a" />
<img width="1920" height="1044" alt="Screenshot 2026-07-10 123944" src="https://github.com/user-attachments/assets/fb04e889-6a08-48e1-876c-dc9f9a356a2a" />
<img width="1920" height="1044" alt="Screenshot 2026-07-10 124000" src="https://github.com/user-attachments/assets/c837fe2c-6ca5-4e9d-991f-699edf991d7b" />
<img width="1920" height="1044" alt="Screenshot 2026-07-10 124005" src="https://github.com/user-attachments/assets/275e5532-c214-42e8-99dc-e7f19840d315" />

### OTLP/HTTP

<img width="1920" height="1044" alt="Screenshot 2026-07-10 142442" src="https://github.com/user-attachments/assets/f922d943-3cc5-4242-9ab5-1a01fedaa604" />
<img width="1920" height="1044" alt="Screenshot 2026-07-10 142453" src="https://github.com/user-attachments/assets/fa27c27c-97c8-4cf6-b59e-28a7d942ecda" />
<img width="1920" height="1044" alt="Screenshot 2026-07-10 142521" src="https://github.com/user-attachments/assets/071e00c7-f069-47fa-b2f3-8386262916d7" />

## Validation

- `.\build.ps1` — passed
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` — 2737 passed, 31 skipped
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` — 1685 passed
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore --filter "FullyQualifiedName~OpenTelemetryEndpointConnectionTests|FullyQualifiedName~DiagnosticsPageContractTests"` — 68 passed
- Failed-job GitHub Actions rerun on `05bb0d78` — all jobs passed, including the previously failing accessibility and WSL network-recovery shards
- Rubber-duck review completed; warning styling/message polish applied
- Autoreview command: `python .agents\skills\autoreview\scripts\autoreview --mode local --stream-engine-output` with UTF-8 environment — clean, no accepted/actionable findings

## Real behavior proof

- OTLP/gRPC and OTLP/HTTP dashboard screenshots above show the sample trace, metric, and structured log arriving at the configured collector.
- Export remains gated behind explicit user configuration: leaving the endpoint empty disables OpenTelemetry export.
- Current-head resend semantics are covered by the focused service test and diagnostics-page wiring contract above: explicit resend creates a new probe sink while later automatic application of unchanged settings still deduplicates.