### PR TITLE
docs: correct setup-code expiry contract

### DIFF
--- a/docs/gateway-node-integration.md
+++ b/docs/gateway-node-integration.md
@@ -207,7 +207,8 @@ explicit gateway policy matching the node's advertised commands.
 
 1. Calls `issueDeviceBootstrapToken()` on the gateway
 2. Generates a **short-lived, single-use** `bootstrapToken`
-3. Encodes `{ url, bootstrapToken, expiresAtMs }` as base64url
+3. Encodes `{ url, urls?, bootstrapToken }` as base64url. The gateway enforces
+   the 10-minute token lifetime; the payload does not include expiry metadata.
 4. Renders as QR code or pasteable setup code
 
 ### 4.2 bootstrapToken vs gateway.auth.token
@@ -238,7 +239,7 @@ The setup code and QR code are the same bootstrap concept in different packaging
 QR image
   -> decodes to setup code text
     -> decodes to JSON payload
-      -> contains gateway URL + bootstrapToken + expiry
+      -> contains gateway URL(s) + bootstrapToken
 ```
 
 Advanced users can drop into setup at any level:
@@ -255,7 +256,8 @@ The QR/setup-code path is preferred for first-time node onboarding because it av
 
 The Windows Setup Wizard:
 1. Accepts a QR image, clipboard QR image, pasteable setup code, or manual gateway URL/token.
-2. For QR/setup-code input, decodes `{ url, bootstrapToken, expiresAtMs }`.
+2. For QR/setup-code input, decodes `{ url, bootstrapToken }`; the optional
+   upstream `urls` fallback list is not used by the current decoder.
 3. Stores `bootstrapToken` in the active `GatewayRecord.BootstrapToken`; manual long-lived tokens are stored as `GatewayRecord.SharedGatewayToken`.
 4. Sends it as `auth.bootstrapToken` in the node connect handshake.
 
@@ -279,7 +281,7 @@ Windows stores `hello-ok.auth.deviceToken` in the per-gateway device identity fi
 ```
 1. User runs `openclaw qr` on gateway host
 2. User imports/scans QR image or pastes setup code into Windows Setup Wizard
-3. Wizard decodes → { url, bootstrapToken, expiresAtMs }
+3. Wizard decodes → { url, bootstrapToken }
 4. Node connects with: auth: { bootstrapToken: "<token>" }
 5. Gateway auto-approves pairing (bootstrap-token auth method)
 6. Gateway returns hello-ok with: auth: { deviceToken: "<token>" }
@@ -355,7 +357,6 @@ After changing either `gateway.nodes.allowCommands` or `gateway.nodes.denyComman
 - [x] Handle `hello-ok.auth.deviceToken` — save it for future connections
 - [x] Accept QR images and clipboard setup content as alternate ways to enter the same bootstrap payload
 - [x] Show "auto-paired!" vs "waiting for approval" based on auth method
-- [x] Handle bootstrap token expiry gracefully when setup code payloads include expiry metadata (`expiresAt`, `expires_at`, `expires`, `expiry`, or `exp`)
 - [x] Add Settings toggles for optional Windows node capability groups (`canvas`, `screen`, `camera`, `location`, `browser.proxy`)
 
 ### 5.4 Upstream Alignment


### PR DESCRIPTION
## Summary

- Problem: the gateway integration guide says official setup codes contain `expiresAtMs` and still lists support for a removed client-side expiry parser.
- Why it matters: Windows integration work can depend on a payload field that the Gateway never emits.
- What changed: document the upstream `{ url, urls?, bootstrapToken }` payload, the Windows-consumed `{ url, bootstrapToken }` shape, and the Gateway-owned 10-minute lifetime; remove the stale checklist item.
- User impact: setup and pairing documentation now matches both current Gateway and Windows implementations.
- What did NOT change (scope boundary): no runtime, protocol, credential, or pairing behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs / instructions
- [ ] Tests / validation
- [ ] Security hardening
- [ ] Chore / infra

## Scope (select all touched areas)

- [ ] Tray / WinUI UX
- [ ] Windows node capability
- [ ] Local MCP / `winnode`
- [x] Gateway / connection / pairing
- [x] Setup / onboarding
- [ ] Permissions / privacy / security
- [x] Tests / CI / docs

## Linked Issue/PR

- Closes #964
- Related openclaw/openclaw#103943
- [x] Related to a bug or regression

## Validation

- `./build.ps1` — PASS (Shared, Cli, WinNodeCli, SetupEngine, WinUI)
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — PASS (2,732 passed, 0 failed, 31 skipped; 2,763 total)
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — PASS (1,669 passed, 0 failed, 0 skipped)
- `git diff --check` — PASS
- Structured autoreview — PASS, no accepted/actionable findings

## Real behavior proof

- Environment tested: native Windows x64 (AWS Crabbox `cbx_334b40932fe4`, public networking, no Tailscale); source audit against OpenClaw Gateway and Windows decoder
- PR head / commit tested: `795b7b7a2856e6f0c82662612d45c767bfe48ae4`
- Exact steps or command run: inspected the Gateway setup payload type/builder and TTL constant, then inspected the current Windows setup-code decoder
- Evidence after fix: Gateway payload type is `{ url, urls?, bootstrapToken }`; `DEVICE_BOOTSTRAP_TOKEN_TTL_MS` is 10 minutes; Windows reads only `url` and `bootstrapToken`
- Observed result: all five stale expiry claims are removed or corrected without changing runtime behavior
- Screenshot/artifact links verified? (`Yes/No/N/A`): N/A
- Not verified / blocked: none

Source evidence:

- [Gateway payload type](https://github.com/openclaw/openclaw/blob/d395a8e6ec2789763b746b1e96ed5870c7795bd7/src/pairing/setup-code.ts#L37-L41)
- [Gateway payload builder](https://github.com/openclaw/openclaw/blob/d395a8e6ec2789763b746b1e96ed5870c7795bd7/src/pairing/setup-code.ts#L434-L445)
- [Gateway 10-minute TTL](https://github.com/openclaw/openclaw/blob/d395a8e6ec2789763b746b1e96ed5870c7795bd7/src/infra/device-bootstrap.ts#L25-L26)
- [Windows decoder](https://github.com/openclaw/openclaw-windows-node/blob/053501c6dfaefc17b9110ea5b622713f04a2b753/src/OpenClaw.Connection/SetupCodeDecoder.cs#L47-L77)

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only conversations that still need reviewer or maintainer judgment.
