### PR TITLE
fix: make Gateway shell execution work on Windows nodes

### DIFF
--- a/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
@@ -547,18 +547,6 @@ public class SystemCapability : NodeCapabilityBase
         if (_approvalPolicy == null)
             return null;
 
-        var approval = _approvalPolicy.Evaluate(fullCommand, shell);
-        var approvalCheck = await EnsureApprovedAsync(fullCommand, shell, approval, sessionKey, correlationId);
-        if (!approvalCheck.Allowed)
-        {
-            Logger.Warn($"system.run DENIED: {fullCommand} ({approval.Reason})");
-            return Error($"Command denied by exec policy: {approval.Reason}");
-        }
-
-        var outerApprovalCoversNestedTargets =
-            approvalCheck.PromptDecisionKind != null ||
-            IsExactAllowRuleForCommand(approval, fullCommand);
-
         var parseResult = ExecShellWrapperParser.Expand(fullCommand, shell);
         if (!string.IsNullOrWhiteSpace(parseResult.Error))
         {
@@ -566,6 +554,28 @@ public class SystemCapability : NodeCapabilityBase
             return Error($"Command denied by exec policy: {parseResult.Error}");
         }
 
+        var approval = _approvalPolicy.Evaluate(fullCommand, shell);
+        var hasNestedTargets = parseResult.Targets.Count > 0;
+        var hasExplicitOuterRule = !string.IsNullOrWhiteSpace(approval.MatchedPattern);
+        var evaluateOuter = !hasNestedTargets || hasExplicitOuterRule || approval.Allowed;
+        var approvalCheck = new ExecApprovalCheckResult(false, null);
+        if (evaluateOuter)
+        {
+            approvalCheck = await EnsureApprovedAsync(fullCommand, shell, approval, sessionKey, correlationId);
+            if (!approvalCheck.Allowed)
+            {
+                Logger.Warn($"system.run DENIED: {fullCommand} ({approval.Reason})");
+                return Error($"Command denied by exec policy: {approval.Reason}");
+            }
+        }
+
+        var outerApprovalCoversNestedTargets =
+            approvalCheck.PromptDecisionKind != null ||
+            IsExactAllowRuleForCommand(approval, fullCommand);
+
+        // Gateway execution wraps Windows commands in cmd.exe. When no rule
+        // explicitly targets that wrapper, authorize every parsed payload so
+        // exact inner rules remain usable without granting a broad shell rule.
         foreach (var target in parseResult.Targets)
         {
             var innerApproval = _approvalPolicy.Evaluate(target.Command, target.Shell);
@@ -589,6 +599,15 @@ public class SystemCapability : NodeCapabilityBase
             {
                 Logger.Warn($"system.run DENIED: {target.Command} ({innerApproval.Reason})");
                 return Error($"Command denied by exec policy: {innerApproval.Reason}");
+            }
+
+            if (!evaluateOuter &&
+                innerApprovalCheck.PromptDecisionKind == null &&
+                !IsExactAllowRuleForCommand(innerApproval, target.Command))
+            {
+                const string reason = "Wrapped commands require an exact allow rule";
+                Logger.Warn($"system.run DENIED: {target.Command} ({reason})");
+                return Error($"Command denied by exec policy: {reason}");
             }
         }
 

--- a/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
@@ -472,6 +472,7 @@ public class SystemCapability : NodeCapabilityBase
                 stderr = result.Stderr,
                 exitCode = result.ExitCode,
                 timedOut = result.TimedOut,
+                success = result.ExitCode == 0 && !result.TimedOut,
                 durationMs = result.DurationMs
             });
         }

--- a/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
@@ -557,7 +557,11 @@ public class SystemCapability : NodeCapabilityBase
         var approval = _approvalPolicy.Evaluate(fullCommand, shell);
         var hasNestedTargets = parseResult.Targets.Count > 0;
         var hasExplicitOuterRule = !string.IsNullOrWhiteSpace(approval.MatchedPattern);
-        var evaluateOuter = !hasNestedTargets || hasExplicitOuterRule || approval.Allowed;
+        var evaluateOuter =
+            !hasNestedTargets ||
+            hasExplicitOuterRule ||
+            approval.Allowed ||
+            approval.Action == ExecApprovalAction.Prompt;
         var approvalCheck = new ExecApprovalCheckResult(false, null);
         if (evaluateOuter)
         {
@@ -573,9 +577,9 @@ public class SystemCapability : NodeCapabilityBase
             approvalCheck.PromptDecisionKind != null ||
             IsExactAllowRuleForCommand(approval, fullCommand);
 
-        // Gateway execution wraps Windows commands in cmd.exe. When no rule
-        // explicitly targets that wrapper, authorize every parsed payload so
-        // exact inner rules remain usable without granting a broad shell rule.
+        // Gateway execution wraps Windows commands in cmd.exe. Only an
+        // unmatched default deny may defer to exact parsed-payload rules;
+        // explicit/default prompts still show and persist the full wrapper.
         foreach (var target in parseResult.Targets)
         {
             var innerApproval = _approvalPolicy.Evaluate(target.Command, target.Shell);

--- a/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
+++ b/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
@@ -187,7 +187,7 @@ public class McpToolBridge
         ["system.notify"] =
             "Show a Windows toast notification on the node. Args: title (string, default 'OpenClaw'), body (string), subtitle (string), sound (bool, default true). Returns { sent: true }.",
         ["system.run"] =
-            "Execute a shell command on the Windows node host. Args: command (string or string[] argv, required), args (string[]), shell (string), cwd (string), timeoutMs (int, default 30000), env (object). Subject to the local exec approval policy. Returns { stdout, stderr, exitCode, timedOut, durationMs }.",
+            "Execute a shell command on the Windows node host. Args: command (string or string[] argv, required), args (string[]), shell (string), cwd (string), timeoutMs (int, default 30000), env (object). Subject to the local exec approval policy. Returns { stdout, stderr, exitCode, timedOut, success, durationMs }.",
         ["system.run.prepare"] =
             "Pre-flight a system.run invocation: returns the parsed execution plan (argv, cwd, rawCommand, agentId, sessionKey) without running anything. The gateway uses this to build its approval context before the actual run.",
         ["system.which"] =

--- a/src/OpenClaw.Shared/Mxc/MxcConfigBuilder.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcConfigBuilder.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Security.AccessControl;
 using System.Security.Principal;
+using System.Runtime.Versioning;
 
 namespace OpenClaw.Shared.Mxc;
 
@@ -22,9 +23,9 @@ namespace OpenClaw.Shared.Mxc;
 ///   launched shell. Explicit <c>process.env</c> injection is intentionally
 ///   disabled for the current Windows MXC 0.7 processcontainer backend because
 ///   non-empty env entries fail process creation.</item>
-/// <item>Cwd auto-grant — adds <c>request.Cwd</c> as readonly when not already
-///   covered by an allow grant. AppContainer does NOT auto-grant cwd, so this
-///   is required for commands to even start.</item>
+/// <item>Cwd handling — defaults omitted cwd to the writable per-run scratch
+///   directory, and adds an explicit request cwd as readonly when not already
+///   covered by an allow grant. AppContainer does NOT auto-grant cwd.</item>
 /// <item>Defensive re-filter of allow lists against the deny list.</item>
 /// <item>Shell command-line construction (cmd <c>/S /C</c>, powershell
 ///   <c>-EncodedCommand</c>).</item>
@@ -68,6 +69,7 @@ public static class MxcConfigBuilder
         var readonlyGrantIsBackendSafe = context.ReadonlyGrantIsBackendSafe ?? IsBackendSafeReadonlyGrant;
 
         var policy = request.Policy;
+        var workingDirectory = string.IsNullOrWhiteSpace(request.Cwd) ? scratchDir : request.Cwd;
         var args = ParseSystemRunArgs(request.Args);
         var shell = NormalizeSupportedShell(args.Shell);
         if (IsPowerShellFamilyShell(shell) && policy?.Ui?.AllowWindows != true)
@@ -171,7 +173,7 @@ public static class MxcConfigBuilder
             Process = new MxcProcess
             {
                 CommandLine = commandLine,
-                Cwd = string.IsNullOrWhiteSpace(request.Cwd) ? null : request.Cwd,
+                Cwd = workingDirectory,
                 Env = env,
                 TimeoutMs = timeoutMs,
             },
@@ -263,50 +265,70 @@ public static class MxcConfigBuilder
         if (!OperatingSystem.IsWindows())
             return true;
 
+        return CanMxcDaclFallbackPreparePathWindows(dir);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool CanMxcDaclFallbackPreparePathWindows(string dir)
+    {
         try
         {
             var identity = WindowsIdentity.GetCurrent();
-            var principals = new HashSet<SecurityIdentifier>();
-            if (identity.User is not null)
-                principals.Add(identity.User);
+            if (identity.User is null)
+                return false;
+
+            var tokenSids = new HashSet<SecurityIdentifier> { identity.User };
             if (identity.Groups is not null)
             {
-                foreach (var group in identity.Groups)
-                {
-                    if (group is SecurityIdentifier sid)
-                        principals.Add(sid);
-                }
+                foreach (var group in identity.Groups.OfType<SecurityIdentifier>())
+                    tokenSids.Add(group);
             }
-
-            if (principals.Count == 0)
-                return false;
 
             var rules = new DirectoryInfo(dir)
                 .GetAccessControl(AccessControlSections.Access)
                 .GetAccessRules(includeExplicit: true, includeInherited: true, targetType: typeof(SecurityIdentifier));
 
-            var allowed = false;
-            foreach (FileSystemAccessRule rule in rules)
-            {
-                if (rule.IdentityReference is not SecurityIdentifier sid || !principals.Contains(sid))
-                    continue;
-
-                if ((rule.FileSystemRights & (FileSystemRights.ChangePermissions | FileSystemRights.FullControl)) == 0)
-                    continue;
-
-                if (rule.AccessControlType == AccessControlType.Deny)
-                    return false;
-
-                if (rule.AccessControlType == AccessControlType.Allow)
-                    allowed = true;
-            }
-
-            return allowed;
+            return HasDirectUserChangePermissions(
+                rules.OfType<FileSystemAccessRule>(),
+                identity.User,
+                tokenSids.Contains);
         }
         catch
         {
             return false;
         }
+    }
+
+    [SupportedOSPlatform("windows")]
+    internal static bool HasDirectUserChangePermissions(
+        IEnumerable<FileSystemAccessRule> rules,
+        SecurityIdentifier userSid,
+        Func<SecurityIdentifier, bool> isTokenSid)
+    {
+        ArgumentNullException.ThrowIfNull(rules);
+        ArgumentNullException.ThrowIfNull(userSid);
+        ArgumentNullException.ThrowIfNull(isTokenSid);
+
+        var allowed = false;
+        foreach (var rule in rules)
+        {
+            if (rule.IdentityReference is not SecurityIdentifier sid)
+                continue;
+
+            if ((rule.FileSystemRights & FileSystemRights.ChangePermissions) == 0)
+                continue;
+
+            var isUser = sid.Equals(userSid);
+            if (rule.AccessControlType == AccessControlType.Deny && (isUser || isTokenSid(sid)))
+                return false;
+
+            // MXC's DACL fallback runs under a restricted token. An admin-group
+            // allow on the host does not grant that token WRITE_DAC.
+            if (rule.AccessControlType == AccessControlType.Allow && isUser)
+                allowed = true;
+        }
+
+        return allowed;
     }
 
     private static bool IsProtectedSystemPath(string dir)

--- a/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
@@ -110,6 +110,29 @@ public class SystemCapabilityTests
         Assert.True(res.Ok);
         Assert.Equal("echo", runner.LastRequest!.Command);
         Assert.Equal(new[] { "hello", "world" }, runner.LastRequest.Args);
+        var payload = JsonSerializer.SerializeToElement(res.Payload);
+        Assert.True(payload.GetProperty("success").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Run_ReportsUnsuccessfulExit()
+    {
+        var cap = new SystemCapability(NullLogger.Instance);
+        cap.SetCommandRunner(new FakeCommandRunner
+        {
+            Result = new CommandResult { ExitCode = 1, TimedOut = false }
+        });
+
+        var res = await cap.ExecuteAsync(new NodeInvokeRequest
+        {
+            Id = "r1-failed",
+            Command = "system.run",
+            Args = Parse("""{"command":["cmd.exe","/d","/s","/c","exit 1"]}""")
+        });
+
+        Assert.True(res.Ok);
+        var payload = JsonSerializer.SerializeToElement(res.Payload);
+        Assert.False(payload.GetProperty("success").GetBoolean());
     }
 
     [Fact]
@@ -927,6 +950,14 @@ public class SystemCapabilityTests
         public CommandRequest? LastRequest { get; private set; }
         public string? LastResolvedShell { get; private set; }
         public string? ForcedEffectiveShell { get; set; }
+        public CommandResult Result { get; set; } = new()
+        {
+            Stdout = "ok",
+            Stderr = "",
+            ExitCode = 0,
+            TimedOut = false,
+            DurationMs = 1
+        };
 
         public string ResolveEffectiveShell(string? requestedShell)
         {
@@ -949,14 +980,7 @@ public class SystemCapabilityTests
         public Task<CommandResult> RunAsync(CommandRequest request, CancellationToken ct = default)
         {
             LastRequest = request;
-            return Task.FromResult(new CommandResult
-            {
-                Stdout = "ok",
-                Stderr = "",
-                ExitCode = 0,
-                TimedOut = false,
-                DurationMs = 1
-            });
+            return Task.FromResult(Result);
         }
     }
 

--- a/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
@@ -134,6 +134,144 @@ public class SystemCapabilityTests
     }
 
     [Fact]
+    public async Task Run_GatewayCmdWrapper_UsesAllowedInnerCommand()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var cap = new SystemCapability(NullLogger.Instance);
+            var runner = new FakeCommandRunner();
+            cap.SetCommandRunner(runner);
+            cap.SetApprovalPolicy(new ExecApprovalPolicy(tempDir, NullLogger.Instance));
+
+            var req = new NodeInvokeRequest
+            {
+                Id = "gateway-cmd-wrapper",
+                Command = "system.run",
+                Args = Parse("""{"command":["cmd.exe","/d","/s","/c","hostname"],"rawCommand":"hostname"}""")
+            };
+
+            var res = await cap.ExecuteAsync(req);
+
+            Assert.True(res.Ok);
+            Assert.Equal("cmd.exe", runner.LastRequest!.Command);
+            Assert.Equal(new[] { "/d", "/s", "/c", "hostname" }, runner.LastRequest.Args);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task Run_GatewayCmdWrapper_ExplicitOuterDenyStillWins()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var cap = new SystemCapability(NullLogger.Instance);
+            var runner = new FakeCommandRunner();
+            var policy = new ExecApprovalPolicy(tempDir, NullLogger.Instance);
+            policy.InsertRule(0, new ExecApprovalRule
+            {
+                Pattern = "cmd.exe /d /s /c hostname",
+                Action = ExecApprovalAction.Deny,
+                Description = "Explicit wrapper deny"
+            });
+            cap.SetCommandRunner(runner);
+            cap.SetApprovalPolicy(policy);
+
+            var req = new NodeInvokeRequest
+            {
+                Id = "gateway-cmd-wrapper-deny",
+                Command = "system.run",
+                Args = Parse("""{"command":["cmd.exe","/d","/s","/c","hostname"],"rawCommand":"hostname"}""")
+            };
+
+            var res = await cap.ExecuteAsync(req);
+
+            Assert.False(res.Ok);
+            Assert.Contains("Explicit wrapper deny", res.Error);
+            Assert.Null(runner.LastRequest);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task Run_GatewayCmdWrapper_ExplicitInnerDenyStillWins()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var cap = new SystemCapability(NullLogger.Instance);
+            var runner = new FakeCommandRunner();
+            var policy = new ExecApprovalPolicy(tempDir, NullLogger.Instance);
+            policy.InsertRule(0, new ExecApprovalRule
+            {
+                Pattern = "hostname",
+                Action = ExecApprovalAction.Deny,
+                Description = "Explicit inner deny"
+            });
+            cap.SetCommandRunner(runner);
+            cap.SetApprovalPolicy(policy);
+
+            var req = new NodeInvokeRequest
+            {
+                Id = "gateway-cmd-inner-deny",
+                Command = "system.run",
+                Args = Parse("""{"command":["cmd.exe","/d","/s","/c","hostname"],"rawCommand":"hostname"}""")
+            };
+
+            var res = await cap.ExecuteAsync(req);
+
+            Assert.False(res.Ok);
+            Assert.Contains("Explicit inner deny", res.Error);
+            Assert.Null(runner.LastRequest);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task Run_GatewayCmdWrapper_BroadInnerAllowCannotHidePipeTarget()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var cap = new SystemCapability(NullLogger.Instance);
+            var runner = new FakeCommandRunner();
+            cap.SetCommandRunner(runner);
+            cap.SetApprovalPolicy(new ExecApprovalPolicy(tempDir, NullLogger.Instance));
+
+            var req = new NodeInvokeRequest
+            {
+                Id = "gateway-cmd-pipe-deny",
+                Command = "system.run",
+                Args = Parse("""{"command":["cmd.exe","/d","/s","/c","echo ok | del C:\\victim"],"rawCommand":"echo ok | del C:\\victim"}""")
+            };
+
+            var res = await cap.ExecuteAsync(req);
+
+            Assert.False(res.Ok);
+            Assert.Contains("exact allow rule", res.Error);
+            Assert.Null(runner.LastRequest);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public async Task Run_AcceptsCommandAsString()
     {
         var cap = new SystemCapability(NullLogger.Instance);

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcConfigBuilderTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcConfigBuilderTests.cs
@@ -1,3 +1,6 @@
+using System.Security.AccessControl;
+using System.Security.Principal;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Text.Json;
 using Xunit;
@@ -445,6 +448,57 @@ public class MxcConfigBuilderTests
             try { Directory.Delete(unsafeDir, true); } catch { }
             try { Directory.Delete(safeDir, true); } catch { }
         }
+    }
+
+    [Fact]
+    public void Build_DefaultsMissingCwdToWritableScratchDirectory()
+    {
+        var config = BuildConfig(RequestFor(LockedDownPolicy()), pathEnvVar: "");
+
+        Assert.Equal(P.Scratch, config.Process.Cwd);
+        Assert.Contains(P.Scratch, config.Filesystem!.ReadwritePaths!);
+    }
+
+    [Fact]
+    [SupportedOSPlatform("windows")]
+    public void HasDirectUserChangePermissions_IgnoresGroupOnlyAllow()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var administrators = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+        var user = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+        var rules = new[]
+        {
+            new FileSystemAccessRule(
+                administrators,
+                FileSystemRights.FullControl,
+                AccessControlType.Allow),
+        };
+
+        Assert.False(MxcConfigBuilder.HasDirectUserChangePermissions(rules, user, _ => true));
+
+        var readOnlyUserRule = new FileSystemAccessRule(
+            user,
+            FileSystemRights.Read,
+            AccessControlType.Allow);
+        Assert.False(MxcConfigBuilder.HasDirectUserChangePermissions([readOnlyUserRule], user, _ => false));
+
+        var directUserRule = new FileSystemAccessRule(
+            user,
+            FileSystemRights.ChangePermissions,
+            AccessControlType.Allow);
+        Assert.True(MxcConfigBuilder.HasDirectUserChangePermissions([directUserRule], user, _ => false));
+
+        var groupDenyRule = new FileSystemAccessRule(
+            administrators,
+            FileSystemRights.ChangePermissions,
+            AccessControlType.Deny);
+        Assert.False(
+            MxcConfigBuilder.HasDirectUserChangePermissions(
+                [directUserRule, groupDenyRule],
+                user,
+                sid => sid.Equals(administrators)));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Problem: Gateway `system.run` wraps Windows commands as `cmd.exe /d /s /c <command>`, but the Hub rejected the unmatched outer wrapper before checking the exact approved command. The MXC sandbox also treated an administrator-group ACL as usable by its restricted token, omitted a safe default cwd, and returned no `success` field for the agent exec projection.
- Why it matters: an operator could approve `hostname`, receive the correct stdout and exit code from the live Surface, yet the agent still saw a failed command.
- What changed: parse Gateway shell wrappers before approval; allow only exact approved nested targets; preserve explicit deny/prompt precedence; validate direct-user `WRITE_DAC`; default omitted cwd to the writable MXC scratch directory; return the shared `system.run.success` contract.
- User impact: exact approved Windows commands now execute through the Gateway and appear successful to the agent without granting a broad shell rule.
- What did NOT change: no new capability, default permission, network call, credential path, config surface, or release artifact.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs / instructions
- [x] Tests / validation
- [x] Security hardening
- [ ] Chore / infra

## Scope (select all touched areas)

- [ ] Tray / WinUI UX
- [x] Windows node capability
- [ ] Local MCP / `winnode`
- [x] Gateway / connection / pairing
- [ ] Setup / onboarding
- [x] Permissions / privacy / security
- [x] Tests / CI / docs

## Linked Issue/PR

- Closes #971
- Related openclaw/openclaw#104735
- [x] Related to a bug or regression

## Validation

- `./build.ps1` on Surface ARM64 — Shared, CLI, WinNode CLI, SetupEngine, and WinUI built.
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj -c Debug --no-build` — 2,739 passed, 31 skipped, 0 failed.
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — 1,669 passed, 0 failed.
- Focused wrapper, ACL, cwd, and result-contract regressions passed.
- Release ARM64 WinUI rebuild — 0 warnings, 0 errors.
- Fresh autoreview after both review repair cycles — no accepted/actionable findings.
- `./scripts/validate-mxc-e2e.ps1 -Configuration Release` — blocked before either MXC assertion: the isolated unpackaged WinUI host exited during startup with `0xC000027B`. Debug and Release both reproduce the pre-MCP harness crash; the production-data Release host runs and completes the real Gateway scenario below.

## Real behavior proof

- Environment: Surface ARM64, Windows 11 `10.0.26200`; live Gateway on `clawmac`.
- Exact tested head: `c98e695e`.
- Paired `Windows Node (STEIPETESURFACE)` to the live Gateway with its production node identity and an exact `hostname` allow rule.
- Direct `node.invoke system.run` using Gateway argv `cmd.exe /d /s /c hostname` returned `stdout: steipetesurface`, `exitCode: 0`, `timedOut: false`, `success: true`.
- Agent run `a42d77a0-848d-489b-95e5-c91b2859a32b` used `exec host=node`; result: `Hostname: steipetesurface`, `Exit status: Success`, one tool call, zero failures.
- Before the final result-contract fix, the same live command returned the correct stdout and zero exit code but the agent marked it failed because Windows omitted `success`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- Risk + mitigation: wrapped commands can use inner allow rules. Only an unmatched default-deny wrapper may defer; every parsed target must match an exact allow; parse errors fail closed; prompts and explicit outer/inner denies still win. MXC readonly preparation now requires a direct-user `WRITE_DAC` grant and respects every token SID deny.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only conversations that still need reviewer or maintainer judgment.
