### PR TITLE
feat: enable the new exec approvals pipeline behind an opt-in setting

### DIFF
--- a/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
@@ -324,15 +324,29 @@ public class SystemCapability : NodeCapabilityBase
         {
             Logger.Info($"[system.run] corr={correlationId} path=v2");
             ExecApprovalV2Result v2Result;
-            try
+            if (_commandRunner is IDirectArgvSupportAwareCommandRunner argvAware
+                && !argvAware.CanExecuteDirectArgv())
             {
-                v2Result = await _v2Handler.HandleAsync(request, correlationId);
+                // Approved commands execute as a direct argv, which the active
+                // sandbox transport cannot carry yet. Fail closed before any
+                // evaluation or prompt so nothing gets approved that cannot
+                // execute. The sandbox is never bypassed or disabled from here.
+                v2Result = ExecApprovalV2Result.Unavailable(
+                    "sandboxed system.run cannot execute the approved command form yet; " +
+                    "keep the sandbox on and disable the new approvals path, or turn the sandbox off, to run commands");
             }
-            catch (Exception ex)
+            else
             {
-                // Rail 1: no silent fallback — handler exceptions become typed denies.
-                Logger.Error($"[system.run] corr={correlationId} path=v2 handler threw", ex);
-                v2Result = ExecApprovalV2Result.ValidationFailed("Handler exception");
+                try
+                {
+                    v2Result = await _v2Handler.HandleAsync(request, correlationId);
+                }
+                catch (Exception ex)
+                {
+                    // Rail 1: no silent fallback — handler exceptions become typed denies.
+                    Logger.Error($"[system.run] corr={correlationId} path=v2 handler threw", ex);
+                    v2Result = ExecApprovalV2Result.ValidationFailed("Handler exception");
+                }
             }
 
             Logger.Info($"[system.run] corr={correlationId} decision={v2Result.Code} reason={v2Result.Reason}");

--- a/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
@@ -336,9 +336,11 @@ public class SystemCapability : NodeCapabilityBase
             }
 
             Logger.Info($"[system.run] corr={correlationId} decision={v2Result.Code} reason={v2Result.Reason}");
-            // Rail 1: no silent fallback to legacy regardless of result code.
-            // In PR1 only ExecApprovalV2NullHandler exists (always unavailable); the real
-            // coordinator that can produce an allow decision is wired in PR7/PR8.
+            if (v2Result.IsAllow && v2Result.Execution is { } approvedExecution)
+                return await RunApprovedAsync(approvedExecution, correlationId);
+
+            // No fallback to legacy regardless of result code: any non-allow
+            // outcome from the approval handler is a terminal, typed error.
             return Error($"exec-approvals-v2: {v2Result.Code} ({v2Result.Reason})");
         }
 
@@ -479,6 +481,39 @@ public class SystemCapability : NodeCapabilityBase
         catch (Exception ex)
         {
             Logger.Error("system.run failed", ex);
+            return Error("Execution failed");
+        }
+    }
+
+    /// <summary>
+    /// Execute a command the V2 approval handler allowed. The request is built
+    /// from the approved payload only — validated argv plus sanitized env — so
+    /// the process receives exactly what was approved, with no shell re-parsing
+    /// and nothing re-derived from the raw request. The payload's constructor
+    /// already clamps the timeout to the system.run maximum.
+    /// </summary>
+    private async Task<NodeInvokeResponse> RunApprovedAsync(ExecApprovedExecution execution, string correlationId)
+    {
+        if (_commandRunner == null)
+            return Error("Command execution not available");
+
+        try
+        {
+            var result = await _commandRunner.RunAsync(execution.ToCommandRequest());
+            Logger.Info($"[system.run] corr={correlationId} path=v2 executed exit={result.ExitCode} timedOut={result.TimedOut}");
+            return Success(new
+            {
+                stdout = result.Stdout,
+                stderr = result.Stderr,
+                exitCode = result.ExitCode,
+                timedOut = result.TimedOut,
+                success = result.ExitCode == 0 && !result.TimedOut,
+                durationMs = result.DurationMs
+            });
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"[system.run] corr={correlationId} path=v2 execution failed", ex);
             return Error("Execution failed");
         }
     }

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
@@ -10,7 +10,7 @@ namespace OpenClaw.Shared.ExecApprovals;
 // Full coordinator pipeline: validate → normalize → buildContext → evaluate(pass1) →
 // prompt/fallback → evaluate(pass2) → side effects → final decision.
 // UI-free: no WinUI types. A SemaphoreSlim serializes the prompt+pass2 block.
-// Not wired in production src — verified by ProductionWiring_CoordinatorNotReferencedInSrc test.
+// Wired in production by NodeService behind an explicit opt-in setting, default off.
 // Must be registered as singleton when wired: the SemaphoreSlim is per-instance.
 public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
 {

--- a/src/OpenClaw.Shared/ICommandRunner.cs
+++ b/src/OpenClaw.Shared/ICommandRunner.cs
@@ -107,3 +107,20 @@ public interface IHostFallbackAwareCommandRunner : ICommandRunner
     /// </summary>
     string? ResolveHostFallbackShellForApproval(string? requestedShell, string effectiveShell);
 }
+
+/// <summary>
+/// Optional contract for runners whose active transport may not support the
+/// direct-argv execution form (<see cref="CommandRequest.Argv"/>). Callers that
+/// must deliver an already-approved argv verbatim probe this before submitting,
+/// so an incompatible transport produces an explicit up-front error instead of
+/// a rejected execution after approval.
+/// </summary>
+public interface IDirectArgvSupportAwareCommandRunner : ICommandRunner
+{
+    /// <summary>
+    /// True when a direct-argv request submitted now would reach a runner that
+    /// executes <see cref="CommandRequest.Argv"/> verbatim. False when the
+    /// active transport cannot carry an argv faithfully and would fail closed.
+    /// </summary>
+    bool CanExecuteDirectArgv();
+}

--- a/src/OpenClaw.Shared/Mxc/MxcCommandRunner.cs
+++ b/src/OpenClaw.Shared/Mxc/MxcCommandRunner.cs
@@ -18,7 +18,7 @@ namespace OpenClaw.Shared.Mxc;
 /// <item><c>false</c> — bypass MXC; route through the host runner.</item>
 /// </list>
 /// </remarks>
-public sealed class MxcCommandRunner : IHostFallbackAwareCommandRunner
+public sealed class MxcCommandRunner : IHostFallbackAwareCommandRunner, IDirectArgvSupportAwareCommandRunner
 {
     public string Name => "mxc";
     private const string DefaultSandboxShell = "cmd";
@@ -77,6 +77,30 @@ public sealed class MxcCommandRunner : IHostFallbackAwareCommandRunner
         return string.Equals(hostShell, effectiveShell, StringComparison.OrdinalIgnoreCase)
             ? null
             : hostShell;
+    }
+
+    /// <summary>
+    /// A direct-argv request can only be honored by the host runner: the sandbox
+    /// protocol carries the legacy command/shell/args fields and cannot transport
+    /// an argv faithfully yet. This reports which transport a request submitted
+    /// now would reach, so callers that must execute an approved argv verbatim
+    /// can fail closed up front instead of after approval. It never disables or
+    /// bypasses the sandbox: when the sandbox would run the request, the answer
+    /// is simply "not supported".
+    /// </summary>
+    public bool CanExecuteDirectArgv()
+    {
+        var settings = _settingsProvider();
+        if (!settings.SystemRunSandboxEnabled)
+            return true;
+
+        // Sandbox enabled but unavailable: the compatibility host fallback honors
+        // Argv, and the strict-blocking variant rejects every request with its own
+        // explicit denial, so neither case needs the up-front argv gate.
+        if (!_isSandboxAvailable())
+            return true;
+
+        return false;
     }
 
     public async Task<CommandResult> RunAsync(CommandRequest request, CancellationToken ct = default)

--- a/src/OpenClaw.Shared/SettingsData.cs
+++ b/src/OpenClaw.Shared/SettingsData.cs
@@ -177,6 +177,21 @@ public record class SettingsData
     /// legacy policy. Default <c>false</c>. When enabled, any failure inside
     /// the new pipeline produces a typed deny — it never falls back silently
     /// to the legacy path. No Settings UI yet; enabled by editing settings.json.
+    /// <para>
+    /// Interaction with <see cref="SystemRunSandboxEnabled"/> (intentional, not
+    /// a misconfiguration): the pipeline executes approved commands as a direct
+    /// argv, and the sandbox transport cannot carry that form yet, so
+    /// system.run behaves as follows while this setting is on:
+    /// <list type="bullet">
+    /// <item>sandbox enabled and available — every request returns a typed
+    /// unavailable error before evaluation; the sandbox is never bypassed.</item>
+    /// <item>sandbox enabled, unavailable, host fallback allowed — the approved
+    /// argv executes uncontained on the host.</item>
+    /// <item>sandbox enabled, unavailable, strict fallback blocking — the
+    /// sandbox settings deny execution, as they do for the legacy path.</item>
+    /// <item>sandbox disabled — the approved argv executes on the host.</item>
+    /// </list>
+    /// </para>
     /// </summary>
     public bool ExecApprovalsNewPathEnabled { get; set; } = false;
 

--- a/src/OpenClaw.Shared/SettingsData.cs
+++ b/src/OpenClaw.Shared/SettingsData.cs
@@ -173,6 +173,14 @@ public record class SettingsData
     public bool SystemRunAllowOutbound { get; set; } = false;
 
     /// <summary>
+    /// Route system.run through the new exec approvals pipeline instead of the
+    /// legacy policy. Default <c>false</c>. When enabled, any failure inside
+    /// the new pipeline produces a typed deny — it never falls back silently
+    /// to the legacy path. No Settings UI yet; enabled by editing settings.json.
+    /// </summary>
+    public bool ExecApprovalsNewPathEnabled { get; set; } = false;
+
+    /// <summary>
     /// Clipboard access policy inside the sandbox. Default <c>None</c> — the
     /// sandboxed payload cannot see or change the user's clipboard.
     /// </summary>

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -343,8 +343,13 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
         // New exec approvals path: explicit opt-in, default off.
         if (_settings?.ExecApprovalsNewPathEnabled == true)
         {
-            _execApprovalsV2Handler ??= BuildExecApprovalsV2Handler();
-            _systemCapability.SetV2Handler(_execApprovalsV2Handler);
+            // One coordinator per service lifetime (it serializes approvals with
+            // a per-instance semaphore), but a failed construction must not be
+            // sticky: only a real coordinator is cached, so the next capability
+            // rebuild retries a transient initialization fault instead of
+            // pinning the fail-closed handler until restart.
+            _execApprovalsV2Handler ??= TryBuildExecApprovalsV2Coordinator();
+            _systemCapability.SetV2Handler(_execApprovalsV2Handler ?? ExecApprovalV2NullHandler.Instance);
         }
 
         Register(_systemCapability);
@@ -600,7 +605,7 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
     /// wired yet, so prompt-required decisions resolve through the store's
     /// ask fallback.
     /// </summary>
-    private IExecApprovalV2Handler BuildExecApprovalsV2Handler()
+    private IExecApprovalV2Handler? TryBuildExecApprovalsV2Coordinator()
     {
         try
         {
@@ -616,8 +621,10 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
         }
         catch (Exception ex)
         {
-            _logger.Error("[EXEC-APPROVALS] new path enabled but coordinator unavailable; failing closed", ex);
-            return ExecApprovalV2NullHandler.Instance;
+            _logger.Error(
+                "[EXEC-APPROVALS] new path enabled but coordinator unavailable; " +
+                "failing closed until the next capability rebuild retries", ex);
+            return null;
         }
     }
 

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -79,6 +79,12 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
     
     // Capabilities
     private SystemCapability? _systemCapability;
+
+    // Created once per NodeService lifetime and reused across capability
+    // rebuilds. The coordinator serializes approvals with a per-instance
+    // semaphore, so a fresh instance per rebuild would let an in-flight
+    // approval on the old instance overlap with one on the new instance.
+    private IExecApprovalV2Handler? _execApprovalsV2Handler;
     private CanvasCapability? _canvasCapability;
     private ScreenCapability? _screenCapability;
     private CameraCapability? _cameraCapability;
@@ -299,7 +305,11 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
     
     private void RegisterCapabilities()
     {
-        new ExecApprovalsStore(_dataPath, _logger).MigrateLegacyFileIfNeeded();
+        // With the new approvals path enabled the migration runs on the same
+        // store instance handed to the coordinator below; the legacy-file
+        // migration itself is independent of which path handles system.run.
+        if (_settings?.ExecApprovalsNewPathEnabled != true)
+            new ExecApprovalsStore(_dataPath, _logger).MigrateLegacyFileIfNeeded();
 
         // Hold the lock across the entire rebuild. The body is sync construction
         // (no awaits), so the lock is held briefly and an MCP tools/list arriving
@@ -329,6 +339,14 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
         execPrompt.InlineApprovalRequested += OnLocalExecApprovalRequested;
         execPrompt.Decided += OnLocalExecApprovalDecided;
         _systemCapability.SetPromptHandler(execPrompt);
+
+        // New exec approvals path: explicit opt-in, default off.
+        if (_settings?.ExecApprovalsNewPathEnabled == true)
+        {
+            _execApprovalsV2Handler ??= BuildExecApprovalsV2Handler();
+            _systemCapability.SetV2Handler(_execApprovalsV2Handler);
+        }
+
         Register(_systemCapability);
 
         if (NodeCapabilityGating.ShouldRegisterCanvas(_settings))
@@ -571,6 +589,36 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
         client.HealthReceived -= OnNodeHealthReceived;
         client.GatewaySelfUpdated -= OnGatewaySelfUpdated;
         client.InvokeCompleted -= OnNodeInvokeCompleted;
+    }
+
+    /// <summary>
+    /// Build the handler for the new exec approvals path. Fail closed: if the
+    /// coordinator cannot be built, return the null handler (typed unavailable
+    /// deny) rather than falling back silently to the legacy path. The result
+    /// is cached for the NodeService lifetime so the coordinator stays a
+    /// singleton across capability rebuilds. The approval prompt UI is not
+    /// wired yet, so prompt-required decisions resolve through the store's
+    /// ask fallback.
+    /// </summary>
+    private IExecApprovalV2Handler BuildExecApprovalsV2Handler()
+    {
+        try
+        {
+            var store = new ExecApprovalsStore(_dataPath, _logger);
+            store.MigrateLegacyFileIfNeeded();
+            var coordinator = new ExecApprovalsCoordinator(
+                store,
+                AlwaysCannotPresentEvaluator.Instance,
+                ExecApprovalV2NullPromptHandler.Instance,
+                _logger);
+            _logger.Info("[EXEC-APPROVALS] new path enabled (prompt UI not wired; fallback-only)");
+            return coordinator;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error("[EXEC-APPROVALS] new path enabled but coordinator unavailable; failing closed", ex);
+            return ExecApprovalV2NullHandler.Instance;
+        }
     }
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SettingsManager.cs
@@ -159,6 +159,8 @@ public class SettingsManager
     public bool SystemRunBlockHostFallbackWhenMxcUnavailable { get => _data.SystemRunBlockHostFallbackWhenMxcUnavailable; set => _data = _data with { SystemRunBlockHostFallbackWhenMxcUnavailable = value }; }
     /// <summary>When sandboxed, allow system.run commands to reach the public internet. Default false.</summary>
     public bool SystemRunAllowOutbound { get => _data.SystemRunAllowOutbound; set => _data = _data with { SystemRunAllowOutbound = value }; }
+    /// <summary>Route system.run through the new exec approvals pipeline. Default false; no Settings UI yet.</summary>
+    public bool ExecApprovalsNewPathEnabled { get => _data.ExecApprovalsNewPathEnabled; set => _data = _data with { ExecApprovalsNewPathEnabled = value }; }
 
     // ── MXC sandbox: additional knobs (Sandbox page) ─────────────────
     public SandboxClipboardMode SandboxClipboard { get => _data.SandboxClipboard; set => _data = _data with { SandboxClipboard = value }; }
@@ -281,6 +283,7 @@ public class SettingsManager
         SystemRunSandboxEnabled = true,
         SystemRunBlockHostFallbackWhenMxcUnavailable = false,
         SystemRunAllowOutbound = false,
+        ExecApprovalsNewPathEnabled = false,
         SandboxClipboard = SandboxClipboardMode.None,
         SandboxDocumentsAccess = null,
         SandboxDownloadsAccess = null,

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalV2PromptAdapterTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalV2PromptAdapterTests.cs
@@ -151,20 +151,6 @@ public class ExecApprovalV2PromptAdapterTests
         Assert.Equal("OpenClaw.Shared", asm);
     }
 
-    // Delete once real production wiring of IExecApprovalV2PromptHandler lands in src/.
-    [Fact]
-    public void ProductionWiring_NullPromptHandler_NotReferencedInSrc()
-    {
-        var violations = ProductionSourceFiles.All
-            .Where(f => !f.Path.EndsWith("ExecApprovalV2NullPromptHandler.cs",
-                                     StringComparison.OrdinalIgnoreCase))
-            .Where(f => f.Text.Contains("ExecApprovalV2NullPromptHandler", StringComparison.Ordinal))
-            .Select(f => f.Path)
-            .ToList();
-
-        Assert.Empty(violations);
-    }
-
     private static ExecApprovalV2PromptRequest MinimalRequest() =>
         new()
         {

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalV2RoutingTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalV2RoutingTests.cs
@@ -359,19 +359,90 @@ public class ExecApprovalV2RoutingTests
     }
 
     // -------------------------------------------------------------------------
-    // I-3. SetV2Handler not present in any production source file
+    // Approved execution: allow results execute the approved payload
     // -------------------------------------------------------------------------
 
-    [Fact]
-    public void ProductionWiring_SetV2Handler_NotCalledInSrc()
-    {
-        var violations = ProductionSourceFiles.All
-            .Where(f => !f.Path.EndsWith("SystemCapability.cs", StringComparison.OrdinalIgnoreCase))
-            .Where(f => f.Text.Contains("SetV2Handler", StringComparison.Ordinal))
-            .Select(f => f.Path)
-            .ToList();
+    private static ExecApprovedExecution ApprovedEcho()
+        => new(new[] { "cmd", "/c", "echo hi" }, cwd: @"C:\work", timeoutMs: 5000,
+            env: new Dictionary<string, string> { ["FOO"] = "bar" });
 
-        Assert.Empty(violations);
+    [Fact]
+    public async Task V2Allow_ExecutesApprovedArgv_WithLegacyResponseShape()
+    {
+        var runner = new FakeRunner();
+        var logger = new CapturingLogger();
+        var cap = new SystemCapability(logger);
+        cap.SetCommandRunner(runner);
+        var approved = ApprovedEcho();
+        cap.SetV2Handler(new FixedResultHandler(ExecApprovalV2Result.Allow(approved)));
+
+        var res = await cap.ExecuteAsync(RunRequest());
+
+        Assert.True(res.Ok);
+        Assert.NotNull(runner.LastRequest);
+        Assert.Equal(approved.Argv, runner.LastRequest!.Argv);
+        Assert.Equal(approved.Cwd, runner.LastRequest.Cwd);
+        Assert.Equal(approved.TimeoutMs, runner.LastRequest.TimeoutMs);
+        Assert.Equal("bar", runner.LastRequest.Env!["FOO"]);
+        Assert.True(logger.HasInfoContaining("path=v2 executed exit=0"),
+            "execution outcome not logged on V2 path");
+    }
+
+    [Fact]
+    public async Task V2Allow_ShellAndLegacyFieldsDoNotTravel()
+    {
+        var runner = new FakeRunner();
+        var cap = new SystemCapability(NullLogger.Instance);
+        cap.SetCommandRunner(runner);
+        cap.SetV2Handler(new FixedResultHandler(ExecApprovalV2Result.Allow(ApprovedEcho())));
+
+        await cap.ExecuteAsync(RunRequest());
+
+        // The approved argv must reach the runner verbatim: no shell wrapper,
+        // no legacy command/args re-derivation from the raw request.
+        Assert.NotNull(runner.LastRequest);
+        Assert.Empty(runner.LastRequest!.Command);
+        Assert.Null(runner.LastRequest.Args);
+        Assert.Null(runner.LastRequest.Shell);
+    }
+
+    [Fact]
+    public async Task V2Allow_NullRunner_ReturnsNotAvailableError()
+    {
+        var cap = new SystemCapability(NullLogger.Instance);
+        cap.SetV2Handler(new FixedResultHandler(ExecApprovalV2Result.Allow(ApprovedEcho())));
+
+        var res = await cap.ExecuteAsync(RunRequest());
+
+        Assert.False(res.Ok);
+        Assert.Contains("not available", res.Error!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task V2Allow_RunnerException_ReturnsExecutionFailed()
+    {
+        var cap = new SystemCapability(NullLogger.Instance);
+        cap.SetCommandRunner(new ThrowingRunner());
+        cap.SetV2Handler(new FixedResultHandler(ExecApprovalV2Result.Allow(ApprovedEcho())));
+
+        var res = await cap.ExecuteAsync(RunRequest());
+
+        Assert.False(res.Ok);
+        Assert.Contains("Execution failed", res.Error!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task V2Deny_DoesNotInvokeRunner()
+    {
+        var runner = new FakeRunner();
+        var cap = new SystemCapability(NullLogger.Instance);
+        cap.SetCommandRunner(runner);
+        cap.SetV2Handler(new FixedResultHandler(ExecApprovalV2Result.SecurityDeny("blocked")));
+
+        var res = await cap.ExecuteAsync(RunRequest());
+
+        Assert.False(res.Ok);
+        Assert.Null(runner.LastRequest);
     }
 
     // -------------------------------------------------------------------------
@@ -388,6 +459,14 @@ public class ExecApprovalV2RoutingTests
             LastRequest = request;
             return Task.FromResult(new CommandResult { Stdout = "ok", ExitCode = 0 });
         }
+    }
+
+    private sealed class ThrowingRunner : ICommandRunner
+    {
+        public string Name => "throwing";
+
+        public Task<CommandResult> RunAsync(CommandRequest request, System.Threading.CancellationToken ct = default)
+            => throw new InvalidOperationException("runner exploded");
     }
 
     private sealed class TrackingHandler : IExecApprovalV2Handler

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalV2RoutingTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalV2RoutingTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 using OpenClaw.Shared;
 using OpenClaw.Shared.Capabilities;
 using OpenClaw.Shared.ExecApprovals;
+using OpenClaw.Shared.Mxc;
 
 namespace OpenClaw.Shared.Tests;
 
@@ -446,8 +447,191 @@ public class ExecApprovalV2RoutingTests
     }
 
     // -------------------------------------------------------------------------
+    // Sandbox flag matrix: the V2 path against the real MXC runner, driven by
+    // SystemRunSandboxEnabled / availability / strict fallback blocking.
+    // -------------------------------------------------------------------------
+
+    private static ExecApprovedExecution ApprovedEchoNoEnv()
+        => new(new[] { "cmd", "/c", "echo hi" }, cwd: @"C:\work", timeoutMs: 5000, env: null);
+
+    private static MxcCommandRunner BuildMxcRunner(
+        SettingsData settings,
+        bool sandboxAvailable,
+        FakeRunner hostFallback,
+        FakeSandboxExecutor sandboxExecutor)
+        => new(
+            sandboxExecutor,
+            hostFallback,
+            () => settings,
+            () => System.IO.Path.GetTempPath(),
+            () => sandboxAvailable);
+
+    [Theory]
+    [InlineData(false, false, false, true)]  // sandbox off → host runner honors argv
+    [InlineData(false, true, false, true)]
+    [InlineData(true, true, false, false)]   // sandbox on + available → no argv transport
+    [InlineData(true, true, true, false)]
+    [InlineData(true, false, false, true)]   // on + unavailable + fallback → host honors argv
+    [InlineData(true, false, true, true)]    // on + unavailable + strict → runner denies on its own
+    public void MxcRunner_CanExecuteDirectArgv_FollowsSandboxFlags(
+        bool sandboxEnabled, bool sandboxAvailable, bool strictBlock, bool expected)
+    {
+        var settings = new SettingsData
+        {
+            SystemRunSandboxEnabled = sandboxEnabled,
+            SystemRunBlockHostFallbackWhenMxcUnavailable = strictBlock,
+        };
+        var runner = BuildMxcRunner(settings, sandboxAvailable, new FakeRunner(), new FakeSandboxExecutor());
+
+        Assert.Equal(expected, runner.CanExecuteDirectArgv());
+    }
+
+    [Fact]
+    public async Task V2_SandboxEnabledAndAvailable_TypedUnavailable_NothingEvaluatesOrExecutes()
+    {
+        var settings = new SettingsData { SystemRunSandboxEnabled = true };
+        var host = new FakeRunner();
+        var sandbox = new FakeSandboxExecutor();
+        var handler = new TrackingHandler();
+        var logger = new CapturingLogger();
+        var cap = new SystemCapability(logger);
+        cap.SetCommandRunner(BuildMxcRunner(settings, sandboxAvailable: true, host, sandbox));
+        cap.SetV2Handler(handler);
+
+        var res = await cap.ExecuteAsync(RunRequest());
+
+        Assert.False(res.Ok);
+        Assert.Contains("Unavailable", res.Error!);
+        Assert.False(handler.WasCalled, "gate must fire before any evaluation or prompt");
+        Assert.Null(host.LastRequest);
+        Assert.Equal(0, sandbox.Calls);
+        Assert.True(logger.HasInfoContaining("decision=Unavailable"),
+            "typed gate outcome must flow through the standard decision log");
+    }
+
+    [Fact]
+    public async Task V2Allow_SandboxUnavailable_FallbackAllowed_ExecutesApprovedArgvOnHost()
+    {
+        var settings = new SettingsData
+        {
+            SystemRunSandboxEnabled = true,
+            SystemRunBlockHostFallbackWhenMxcUnavailable = false,
+        };
+        var host = new FakeRunner();
+        var sandbox = new FakeSandboxExecutor();
+        var approved = ApprovedEchoNoEnv();
+        var cap = new SystemCapability(NullLogger.Instance);
+        cap.SetCommandRunner(BuildMxcRunner(settings, sandboxAvailable: false, host, sandbox));
+        cap.SetV2Handler(new FixedResultHandler(ExecApprovalV2Result.Allow(approved)));
+
+        var res = await cap.ExecuteAsync(RunRequest());
+
+        Assert.True(res.Ok);
+        Assert.Equal(0, sandbox.Calls);
+        Assert.NotNull(host.LastRequest);
+        Assert.Equal(approved.Argv, host.LastRequest!.Argv);
+        Assert.Equal(approved.Cwd, host.LastRequest.Cwd);
+        Assert.Equal(approved.TimeoutMs, host.LastRequest.TimeoutMs);
+    }
+
+    [Fact]
+    public async Task V2Allow_SandboxUnavailable_StrictBlocking_DeniesWithoutExecuting()
+    {
+        var settings = new SettingsData
+        {
+            SystemRunSandboxEnabled = true,
+            SystemRunBlockHostFallbackWhenMxcUnavailable = true,
+        };
+        var host = new FakeRunner();
+        var sandbox = new FakeSandboxExecutor();
+        var cap = new SystemCapability(NullLogger.Instance);
+        cap.SetCommandRunner(BuildMxcRunner(settings, sandboxAvailable: false, host, sandbox));
+        cap.SetV2Handler(new FixedResultHandler(ExecApprovalV2Result.Allow(ApprovedEchoNoEnv())));
+
+        var res = await cap.ExecuteAsync(RunRequest());
+
+        // The strict sandbox settings deny execution with their own explicit
+        // result (exit -1), exactly as they do for the legacy path.
+        Assert.True(res.Ok);
+        Assert.Null(host.LastRequest);
+        Assert.Equal(0, sandbox.Calls);
+        var payload = JsonSerializer.Serialize(res.Payload);
+        Assert.Contains("\"exitCode\":-1", payload);
+    }
+
+    [Fact]
+    public async Task V2Allow_SandboxDisabled_ExecutesApprovedArgvOnHost_EnvIntact()
+    {
+        var settings = new SettingsData { SystemRunSandboxEnabled = false };
+        var host = new FakeRunner();
+        var sandbox = new FakeSandboxExecutor();
+        var approved = ApprovedEcho();
+        var cap = new SystemCapability(NullLogger.Instance);
+        cap.SetCommandRunner(BuildMxcRunner(settings, sandboxAvailable: true, host, sandbox));
+        cap.SetV2Handler(new FixedResultHandler(ExecApprovalV2Result.Allow(approved)));
+
+        var res = await cap.ExecuteAsync(RunRequest());
+
+        Assert.True(res.Ok);
+        Assert.Equal(0, sandbox.Calls);
+        Assert.NotNull(host.LastRequest);
+        Assert.Equal(approved.Argv, host.LastRequest!.Argv);
+        Assert.Equal("bar", host.LastRequest.Env!["FOO"]);
+    }
+
+    [Fact]
+    public async Task V2_RunnerWithoutArgvSupportContract_IsNeverGated()
+    {
+        // A plain ICommandRunner that does not implement the argv-support
+        // contract (e.g. the host-only LocalCommandRunner) must never trip the
+        // gate: the handler runs and the approved argv executes.
+        var runner = new FakeRunner();
+        var handler = new TrackingHandler();
+        var cap = new SystemCapability(NullLogger.Instance);
+        cap.SetCommandRunner(runner);
+        cap.SetV2Handler(handler);
+
+        await cap.ExecuteAsync(RunRequest());
+
+        Assert.True(handler.WasCalled);
+    }
+
+    [Fact]
+    public async Task V2Deny_WithRealMxcRunner_NeverReachesAnyTransport()
+    {
+        var settings = new SettingsData { SystemRunSandboxEnabled = true };
+        var host = new FakeRunner();
+        var sandbox = new FakeSandboxExecutor();
+        var cap = new SystemCapability(NullLogger.Instance);
+        // Sandbox unavailable + fallback allowed: the gate lets the handler run,
+        // and the deny must still stop before any transport is touched.
+        cap.SetCommandRunner(BuildMxcRunner(settings, sandboxAvailable: false, host, sandbox));
+        cap.SetV2Handler(new FixedResultHandler(ExecApprovalV2Result.SecurityDeny("blocked")));
+
+        var res = await cap.ExecuteAsync(RunRequest());
+
+        Assert.False(res.Ok);
+        Assert.Null(host.LastRequest);
+        Assert.Equal(0, sandbox.Calls);
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
+
+    private sealed class FakeSandboxExecutor : ISandboxExecutor
+    {
+        public int Calls { get; private set; }
+        public string Name => "fake-sandbox";
+        public bool IsContained => true;
+
+        public Task<SandboxExecutionResult> ExecuteAsync(
+            SandboxExecutionRequest request, System.Threading.CancellationToken ct = default)
+        {
+            Calls++;
+            return Task.FromResult(new SandboxExecutionResult(0, "sandboxed", "", false, 1, "fake"));
+        }
+    }
 
     private sealed class FakeRunner : ICommandRunner
     {

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
@@ -243,19 +243,6 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         Assert.Contains("promptAttempted=", msg, StringComparison.Ordinal);
     }
 
-    // ── 15. Coordinator not wired in production src ───────────────────────────
-
-    [Fact]
-    public void ProductionWiring_CoordinatorNotReferencedInSrc()
-    {
-        var violations = ProductionSourceFiles.All
-            .Where(f => !f.Path.EndsWith("ExecApprovalsCoordinator.cs", StringComparison.OrdinalIgnoreCase))
-            .Where(f => f.Text.Contains("ExecApprovalsCoordinator", StringComparison.Ordinal))
-            .Select(f => f.Path)
-            .ToList();
-        Assert.Empty(violations);
-    }
-
     // ── 16. Rail 10 — coordinator in OpenClaw.Shared, not Tray ───────────────
 
     [Fact]

--- a/tests/OpenClaw.Shared.Tests/Mxc/MxcCommandRunnerTests.cs
+++ b/tests/OpenClaw.Shared.Tests/Mxc/MxcCommandRunnerTests.cs
@@ -655,6 +655,158 @@ public class MxcCommandRunnerTests
         Assert.Null(executor.LastRequest);
     }
 
+    // -------------------------------------------------------------------------
+    // CanExecuteDirectArgv: the transport-capability probe the V2 path checks
+    // before approving. It must report false only in the one state where a
+    // submitted direct-argv request would reach MXC and hit the fail-closed
+    // block, and true wherever a runner actually honors Argv.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void CanExecuteDirectArgv_SandboxDisabled_True_RegardlessOfAvailability()
+    {
+        var whenAvailable = NewRunner(new FakeSandboxExecutor(), new FakeCommandRunner(),
+            NewSettings(sandboxEnabled: false), sandboxAvailable: true);
+        var whenUnavailable = NewRunner(new FakeSandboxExecutor(), new FakeCommandRunner(),
+            NewSettings(sandboxEnabled: false), sandboxAvailable: false);
+
+        Assert.True(whenAvailable.CanExecuteDirectArgv());
+        Assert.True(whenUnavailable.CanExecuteDirectArgv());
+    }
+
+    [Fact]
+    public void CanExecuteDirectArgv_SandboxEnabledAndAvailable_False()
+    {
+        var runner = NewRunner(new FakeSandboxExecutor(), new FakeCommandRunner(),
+            NewSettings(sandboxEnabled: true), sandboxAvailable: true);
+
+        Assert.False(runner.CanExecuteDirectArgv());
+    }
+
+    [Theory]
+    [InlineData(false)]  // compatibility host fallback honors argv
+    [InlineData(true)]   // strict blocking denies with its own explicit result
+    public void CanExecuteDirectArgv_SandboxEnabledButUnavailable_True(bool strictBlocking)
+    {
+        var runner = NewRunner(new FakeSandboxExecutor(), new FakeCommandRunner(),
+            NewSettings(sandboxEnabled: true, blockHostFallbackWhenMxcUnavailable: strictBlocking),
+            sandboxAvailable: false);
+
+        // Neither unavailable path reaches the sandbox argv block, so the
+        // up-front gate must not pre-empt them.
+        Assert.True(runner.CanExecuteDirectArgv());
+    }
+
+    [Fact]
+    public void CanExecuteDirectArgv_RereadsSandboxToggleLive()
+    {
+        var settings = NewSettings(sandboxEnabled: true);
+        var runner = NewRunner(new FakeSandboxExecutor(), new FakeCommandRunner(),
+            settings, sandboxAvailable: true);
+
+        Assert.False(runner.CanExecuteDirectArgv());
+        settings.SystemRunSandboxEnabled = false;
+        Assert.True(runner.CanExecuteDirectArgv());
+    }
+
+    [Fact]
+    public void CanExecuteDirectArgv_RereadsAvailabilityLive()
+    {
+        var available = true;
+        var runner = new MxcCommandRunner(
+            new FakeSandboxExecutor(), new FakeCommandRunner(),
+            () => NewSettings(sandboxEnabled: true),
+            () => "C:\\test\\settings",
+            () => available, invalidateAvailability: null, NullLogger.Instance);
+
+        Assert.False(runner.CanExecuteDirectArgv());
+        available = false;
+        Assert.True(runner.CanExecuteDirectArgv());
+    }
+
+    [Fact]
+    public void CanExecuteDirectArgv_ProbesAvailability_OnlyWhenSandboxEnabled()
+    {
+        var availabilityChecks = 0;
+        var enabled = new MxcCommandRunner(
+            new FakeSandboxExecutor(), new FakeCommandRunner(),
+            () => NewSettings(sandboxEnabled: true),
+            () => "C:\\test\\settings",
+            () => { availabilityChecks++; return true; },
+            invalidateAvailability: null, NullLogger.Instance);
+        enabled.CanExecuteDirectArgv();
+        Assert.Equal(1, availabilityChecks);
+
+        availabilityChecks = 0;
+        var disabled = new MxcCommandRunner(
+            new FakeSandboxExecutor(), new FakeCommandRunner(),
+            () => NewSettings(sandboxEnabled: false),
+            () => "C:\\test\\settings",
+            () => { availabilityChecks++; return true; },
+            invalidateAvailability: null, NullLogger.Instance);
+        disabled.CanExecuteDirectArgv();
+        Assert.Equal(0, availabilityChecks);
+    }
+
+    // -------------------------------------------------------------------------
+    // Availability flip between the gate probe and RunAsync (TOCTOU). Both
+    // interleavings must stay fail-closed: nothing escapes the sandbox, and
+    // nothing but the approved argv executes.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task DirectArgv_GateSaidTrueThenSandboxBecameAvailable_RunAsyncFailsClosed()
+    {
+        var available = false;
+        var executor = new FakeSandboxExecutor();
+        var fallback = new FakeCommandRunner { Result = new CommandResult { ExitCode = 0, Stdout = "host" } };
+        var runner = new MxcCommandRunner(
+            executor, fallback,
+            () => NewSettings(sandboxEnabled: true),
+            () => "C:\\test\\settings",
+            () => available, invalidateAvailability: null, NullLogger.Instance);
+
+        Assert.True(runner.CanExecuteDirectArgv());
+
+        available = true;
+        var result = await runner.RunAsync(new CommandRequest
+        {
+            Argv = new[] { @"C:\Windows\System32\whoami.exe" },
+        });
+
+        // Reaches the sandbox, which cannot carry argv, so it fails closed
+        // instead of running the request uncontained on the host.
+        Assert.Equal(-1, result.ExitCode);
+        Assert.Null(executor.LastRequest);
+        Assert.Null(fallback.LastRequest);
+    }
+
+    [Fact]
+    public async Task DirectArgv_GateSaidFalseThenSandboxDropped_RunAsyncHonorsApprovedArgvOnHost()
+    {
+        var available = true;
+        var executor = new FakeSandboxExecutor();
+        var fallback = new FakeCommandRunner { Result = new CommandResult { ExitCode = 0, Stdout = "host" } };
+        var runner = new MxcCommandRunner(
+            executor, fallback,
+            () => NewSettings(sandboxEnabled: true),
+            () => "C:\\test\\settings",
+            () => available, invalidateAvailability: null, NullLogger.Instance);
+
+        Assert.False(runner.CanExecuteDirectArgv());
+
+        available = false;
+        var argv = new[] { @"C:\Windows\System32\whoami.exe" };
+        var result = await runner.RunAsync(new CommandRequest { Argv = argv });
+
+        // The compatibility host fallback executes exactly the approved argv,
+        // never legacy fields re-derived from the raw request.
+        Assert.Equal("host", result.Stdout);
+        Assert.NotNull(fallback.LastRequest);
+        Assert.Same(argv, fallback.LastRequest!.Argv);
+        Assert.Null(executor.LastRequest);
+    }
+
     private sealed class FakeSandboxExecutor : ISandboxExecutor
     {
         public string Name => "fake";


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The new exec approvals pipeline (validator, normalizer, evaluator, store, coordinator) is fully merged but unreachable: nothing constructs the coordinator in production, and the `system.run` pipeline branch returned a typed error for every result — including Allow — so no command could ever execute through it. The pipeline could not be exercised or rolled out at all.

## Why This Change Was Made

Two narrow additions make the pipeline reachable without changing any default behavior. First, `SystemCapability` now executes the approved payload when the handler allows: the validated argv reaches the process directly with no shell re-parsing and nothing re-derived from the raw request, so what was approved is exactly what executes. Second, `NodeService` wires `ExecApprovalsCoordinator` into `SystemCapability` behind a new `ExecApprovalsNewPathEnabled` setting (default `false`, no Settings UI yet — enabled by editing `settings.json`). The handler is built once per `NodeService` lifetime and reused across capability rebuilds, because the coordinator serializes approvals with a per-instance semaphore and a fresh instance per rebuild could race an in-flight approval on reconnects. A failed construction is not cached: only a real coordinator is stored, so a transient initialization fault is retried on the next rebuild, and until then a null handler gives every request a typed unavailable deny — never a silent fallback to the legacy path. Non-goal: the approval prompt UI is a follow-up; prompt-required decisions currently resolve through the store's ask fallback, and with no store file the pipeline default-denies everything.

The pipeline executes an allow as a direct argv, which the sandbox transport cannot carry yet, so `system.run` gates up front when the runner reports it cannot execute direct argv (`IDirectArgvSupportAwareCommandRunner`). `MxcCommandRunner` reports this only when the sandbox is enabled and available — the one state where an approved command would otherwise reach MXC and fail closed — and `SystemCapability` returns a typed unavailable error before evaluation, so nothing is approved that cannot execute. The sandbox is never disabled or bypassed: every other combination (sandbox off, or enabled but unavailable) keeps executing the approved argv on the host runner it already used, and strict fallback blocking keeps denying with its own explicit result. This interaction is documented on the setting property.

## User Impact

No user-visible change by default. Operators who opt in can route `system.run` through the new approvals pipeline and get deny-by-default behavior with full per-request decision logging; turning the flag off and restarting restores the legacy path exactly.

## Evidence

See Real Behavior Proof below: all four states exercised live against a running tray instance (flag off, flag on with no approvals file, flag on with an allow-all store, and flag off again after restart).

## Change Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs or instructions
- [ ] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Windows node capability
- [x] Permissions, privacy, or security
- [ ] Tray or WinUI UX
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Tests, CI, or docs

## Validation

**Merge with current main (`93b645c9`, 2026-07-20):** merged cleanly (no conflicts; auto-merged overlapping `SettingsData.cs`, `NodeService.cs`, `SettingsManager.cs`). New head after merge: `0e914c28`.

| Suite | Result |
|-------|--------|
| `./build.ps1` | ✅ All 5 projects built (Shared, Cli, WinNodeCli, SetupEngine, WinUI) |
| `OpenClaw.Shared.Tests` | ✅ 2950 passed, 31 skipped, 0 failed |
| `OpenClaw.Tray.Tests` | ✅ 1834 passed, 0 failed |
| `OpenClaw.WinNode.Cli.Tests` | ✅ 126 passed, 0 failed |
| `OpenClaw.Connection.Tests` | ✅ 446 passed, 0 failed |
| `validate-mxc-e2e.ps1` | ⚠️ Infrastructure blocked — port 61112 EADDRINUSE from stale gateway on host (not caused by PR) |

**Security review (specialist):** No vulnerabilities found. Verified: no approval bypass, no sandbox bypass, no silent fallback, TOCTOU mitigated by defense-in-depth at MxcCommandRunner.RunAsync:146, settings race mitigated by re-reading at execution time, prompt serialization sound, immutable execution payload with defensive copies.

**Behavioral test coverage for the V2 flag matrix (exercises real runners, not fake shells):**
- V2 on + sandbox enabled/available → typed unavailable before evaluation; neither handler, sandbox executor, nor host fallback invoked
- V2 on + sandbox unavailable + fallback allowed → approved argv executes on host with argv/env/cwd/timeout intact
- V2 on + sandbox unavailable + strict fallback blocking → denies without executing
- V2 on + sandbox disabled → approved argv executes on host
- Legacy path byte-for-byte unchanged when V2 handler is null
- Handler exceptions → typed deny, no fallback
- NullHandler → typed unavailable (fail-safe)
- Prompt invariants: Allow plain → InternalError; prompt throws → UserDenied; prompt serialization enforced

## Real Behavior Proof

- Environment tested: Windows 11 Pro, isolated tray instance (`run-app-local.ps1 -NoBuild -AllowNonMain -DataDir <temp>`), MCP mode only (`EnableMcpServer=true`, `EnableNodeMode=false`), sandbox disabled so the host runner executes. Driven via `winnode --command system.run --params '{"command":["ping","-n","1","127.0.0.1"]}'`.
- PR head or commit tested: 04c87c6e9adb27f42124035f348ff405fa3620e7
- Exact steps or command run: four states, restarting the app between settings changes.

**1. Flag off (default) → legacy path, executes:**

```
{ "exitCode": 0, "timedOut": false, "success": true, ... }
```
```
[2026-07-13 22:36:59.797] [INFO] [system.run] corr=528ed8db path=legacy decision=legacy reason=legacy
```

**2. Flag on, no `exec-approvals.json` → typed deny, nothing executes (fail-closed first run):**

```
exec-approvals-v2: SecurityDeny (security=deny)
```
```
[2026-07-13 23:09:35.501] [INFO] [EXEC-APPROVALS] new path enabled (prompt UI not wired; fallback-only)
[2026-07-13 23:47:09.735] [INFO] [system.run] corr=410e63d8 path=v2
[2026-07-13 23:47:09.743] [WARN] [EXEC-APPROVALS] [410e63d8] path=new canonical="ping -n 1 <redacted>" decision=deny reason=security=deny fallbackUsed=False promptAttempted=False
```

**3. Flag on, store `{"version":1,"defaults":{"security":"full","ask":"off"}}` → allow, executes the approved argv:**

```
{ "exitCode": 0, "timedOut": false, "success": true, "durationMs": 39, ... }
```
```
[2026-07-13 23:55:38.920] [INFO] [system.run] corr=b4db9822 path=v2
[2026-07-13 23:55:38.941] [INFO] [EXEC-APPROVALS] [b4db9822] path=new canonical="ping -n 1 <redacted>" decision=allow reason=approved fallbackUsed=false promptAttempted=false
[2026-07-13 23:55:38.994] [INFO] [system.run] corr=b4db9822 path=v2 executed exit=0 timedOut=False
```

**4. Flag back off + restart → legacy resumes:**

```
[2026-07-14 00:24:10.363] [INFO] [system.run] corr=87a63c40 path=legacy decision=legacy reason=legacy
```

**Current-head proof of the sandbox gate (commit `83a8b8a`).** New path enabled **and** sandbox enabled, on this MXC-capable host (probe reports `supported=True`, tier `appcontainer-dacl`). Isolated tray in MCP mode, driven via `winnode --command system.run --params '{"command":["ping","-n","1","127.0.0.1"]}'`.

winnode response — typed unavailable, non-zero, nothing executed:

```
exec-approvals-v2: Unavailable (sandboxed system.run cannot execute the approved command form yet; keep the sandbox on and disable the new approvals path, or turn the sandbox off, to run commands)
```

Redacted tray log for the same request:

```
[INFO] [mxc] system.run runner = MxcCommandRunner (executor=mxc-direct-appc; sandboxEnabled=True)
[INFO] [EXEC-APPROVALS] new path enabled (prompt UI not wired; fallback-only)
[DEBUG] [MCP] tools/call system.run
[INFO] [system.run] corr=6571bc78 path=v2
[INFO] [mxc] availability: supported=True outcome=Supported tier=appcontainer-dacl
[INFO] [system.run] corr=6571bc78 decision=Unavailable reason=sandboxed system.run cannot execute the approved command form yet; ...
```

The gate fires before evaluation, returns the typed unavailable, and there is no `executed exit=` line: the command never ran, and the sandbox was not bypassed.

- Evidence after fix: outputs and redacted runtime log lines above, captured from the PR head build.
- Observed result: flag off is byte-for-byte legacy; flag on denies by default with full decision logging and executes only what the pipeline approves.
- Screenshot or artifact links verified? `N/A`
- Not verified or blocked: none remaining. **Update (2026-07-17):** the gateway/MXC proof was re-run against the sandbox-gate commit `83a8b8a` and both proofs pass again (`RealGateway_SystemRun_ExecutesThroughWindowsNodeMxcSandbox` and `RealGateway_SystemRun_BlocksWritesToTrayDataDirectoryInMxcSandbox`, 2/2, ~5 min). The earlier `.\scripts\validate-mxc-e2e.ps1` failure (`systemctl not available; systemd user services are required on Linux`) was environmental — Docker Desktop's WSL integration stalling the user systemd session in freshly provisioned distros — and clears with Docker Desktop stopped. The harness provisions a throwaway WSL distro, installs a real gateway with `defaultAction=deny` plus a scoped allowlist for the proof commands, and cleans up after itself. TRX (`OpenClaw.E2ETests.Mxc.trx`) and full redacted console/harness logs are available on request.

**Update (2026-07-20 merge validation):** After merging current main (`93b645c9`), local `validate-mxc-e2e.ps1` failed with EADDRINUSE on port 61112 (stale gateway process from prior E2E run on this host). This is an infrastructure issue unrelated to the PR code — the test script's gateway provisioning collided with an already-occupied port. The code path is unchanged; the earlier `83a8b8a` proof and the 2026-07-17 clean E2E run remain valid evidence.

## Security Impact

- New permissions or capabilities? `No`
- Secrets or tokens handling changed? `No`
- New or changed network calls? `No`
- Command or tool execution surface changed? `Yes`
- Data access scope changed? `No`
- If any answer is `Yes`, explain the risk and mitigation: with the flag on, `system.run` routes through the new approvals pipeline instead of the legacy policy. The pipeline is stricter, not looser: no store file means deny-everything; any pipeline failure produces a typed deny (never a silent fallback to legacy); and on allow, the executed command is the pipeline's validated argv with sanitized environment, passed to the process without a shell re-parsing it. With the flag off (the default), the execution surface is unchanged.

## Compatibility and Migration

- Backward compatible? `Yes`
- Config or environment changes? `Yes`
- Migration needed? `No`
- If yes, list the exact upgrade steps: the new `ExecApprovalsNewPathEnabled` setting is optional and defaults to `false`; existing `settings.json` files need no changes.

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>