### PR TITLE
Fix WhatsApp pairing to show actionable recovery instead of a raw exception (#957)

### DIFF
--- a/src/OpenClaw.Shared/ChannelsSnapshot.cs
+++ b/src/OpenClaw.Shared/ChannelsSnapshot.cs
@@ -246,6 +246,43 @@ public sealed class WebLoginStartResult
 
     /// <summary>Raw JSON of the gateway response (or stringified exception). Used by the diagnostic disclosure in the UI.</summary>
     public string? RawResponse { get; init; }
+
+    /// <summary>
+    /// True when the gateway rejected <c>web.login.start</c> because it has no
+    /// web-login (QR) provider loaded for the channel — the telltale
+    /// "web login provider is not available" (issue #957). This is a gateway-host
+    /// provider/plugin state we can't fix from the Windows node, so the page
+    /// upgrades its message to actionable recovery (install/enable the channel's
+    /// provider on the gateway host) instead of surfacing the relayed internal
+    /// exception.
+    ///
+    /// Distinct from <see cref="LooksLikeWebLoginUnsupported"/>: here the method
+    /// exists but the provider is missing, so "install the provider" is the right
+    /// guidance. Mirrors <see cref="ChannelStartResult.LooksLikeMissingPlugin"/>.
+    /// </summary>
+    public bool LooksLikeMissingWebLoginProvider
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(Error)) return false;
+            // Provider not loaded/registered on the gateway host. Require the
+            // "web login provider" phrase so unrelated errors don't match.
+            return Error.Contains("web login provider", System.StringComparison.OrdinalIgnoreCase)
+                || Error.Contains("web-login provider", System.StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    /// <summary>
+    /// True when the gateway doesn't implement the <c>web.login</c> RPC at all
+    /// ("unknown method: web.login…") — i.e. QR linking isn't supported by this
+    /// gateway version yet. Recovery here is to update/upgrade the gateway, NOT
+    /// to install a channel plugin (which wouldn't add the missing method), so
+    /// the page shows different guidance than
+    /// <see cref="LooksLikeMissingWebLoginProvider"/>.
+    /// </summary>
+    public bool LooksLikeWebLoginUnsupported =>
+        !string.IsNullOrEmpty(Error) &&
+        Error.Contains("unknown method: web.login", System.StringComparison.OrdinalIgnoreCase);
 }
 
 /// <summary>Result of <c>web.login.wait</c> — long-poll outcome.</summary>

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -1292,10 +1292,16 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
             // Return a populated result with the error so the UI can surface
             // it in the diagnostic disclosure. Returning null would lose the
             // gateway's actual reason for failing.
+            //
+            // Use ex.Message (the clean, gateway-relayed reason — e.g.
+            // "web login provider is not available") rather than ex.ToString():
+            // the latter leaks our own .NET stack trace with internal CI build
+            // paths into user-facing UI (issue #957). The message is the signal
+            // the page pattern-matches on and shows to the user.
             return new WebLoginStartResult
             {
                 Error = ex.Message,
-                RawResponse = ex.ToString(),
+                RawResponse = ex.Message,
             };
         }
     }
@@ -1321,10 +1327,12 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         catch (Exception ex)
         {
             _logger.Warn($"web.login.wait failed: {ex.Message}");
+            // ex.Message, not ex.ToString(): keep the clean gateway reason and
+            // avoid leaking an internal .NET stack trace into the UI (issue #957).
             return new WebLoginWaitResult
             {
                 Error = ex.Message,
-                RawResponse = ex.ToString(),
+                RawResponse = ex.Message,
             };
         }
     }

--- a/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs
@@ -1707,6 +1707,12 @@ public sealed partial class ChannelsPage : Page
         buttonsRow.Children.Add(showQrBtn);
         buttonsRow.Children.Add(relinkBtn);
 
+        // Collapsed recovery affordance — populated by StartLinkingAsync only when
+        // the gateway reports it has no web-login provider loaded for this channel
+        // (issue #957). Distinct from the raw diagnostic: this is the actionable,
+        // plain-language "here's how to fix it on your gateway host" panel.
+        var recoveryPanel = new StackPanel { Spacing = 10, Visibility = Visibility.Collapsed };
+
         // Re-entrancy lock: disable both buttons while a linking flow is in flight
         // so rapid Show QR / Relink clicks can't spawn parallel web.login.start calls.
         async Task RunLinking(bool force)
@@ -1715,7 +1721,7 @@ public sealed partial class ChannelsPage : Page
             relinkBtn.IsEnabled = false;
             try
             {
-                await StartLinkingAsync(qrImage, messageBlock, diagnostic, diagnosticBody, record.Id, force);
+                await StartLinkingAsync(qrImage, messageBlock, diagnostic, diagnosticBody, recoveryPanel, record.Id, force);
             }
             finally
             {
@@ -1728,6 +1734,7 @@ public sealed partial class ChannelsPage : Page
 
         stack.Children.Add(qrImage);
         stack.Children.Add(messageBlock);
+        stack.Children.Add(recoveryPanel);
         stack.Children.Add(diagnostic);
         stack.Children.Add(buttonsRow);
         return stack;
@@ -1738,6 +1745,7 @@ public sealed partial class ChannelsPage : Page
         TextBlock messageBlock,
         Expander diagnostic,
         TextBlock diagnosticBody,
+        Panel recoveryPanel,
         string channelId,
         bool force)
     {
@@ -1769,12 +1777,103 @@ public sealed partial class ChannelsPage : Page
             diagnosticBody.Text = "";
         }
 
+        // Local helper: render the actionable "your gateway has no web-login
+        // provider loaded" recovery panel (issue #957). This is a gateway-host
+        // provider/plugin state we can't fix from the tray, so we show the exact
+        // CLI command to run on the gateway host plus a Copy button — mirroring
+        // BuildInstallPluginPanel's affordance.
+        void ShowProviderRecovery()
+        {
+            recoveryPanel.Children.Clear();
+
+            recoveryPanel.Children.Add(new TextBlock
+            {
+                Text = $"Your gateway can't start {channelId} QR linking yet — it doesn't have the {channelId} web-login provider loaded. Web/QR linking runs on the machine that hosts your gateway, so this is fixed there, not in the tray.",
+                TextWrapping = TextWrapping.Wrap,
+                Style = (Style)Application.Current.Resources["BodyTextBlockStyle"],
+                Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+            });
+
+            var cmd = $"openclaw plugins install @openclaw/{channelId}";
+            var cmdRow = new Grid();
+            cmdRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            cmdRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+            var cmdBox = new TextBox
+            {
+                Text = cmd,
+                IsReadOnly = true,
+                FontFamily = new FontFamily("Consolas, Cascadia Mono, monospace"),
+                Margin = new Thickness(0, 0, 8, 0),
+            };
+            Grid.SetColumn(cmdBox, 0);
+            cmdRow.Children.Add(cmdBox);
+
+            var copyBtn = new Button { Content = "Copy" };
+            Grid.SetColumn(copyBtn, 1);
+            copyBtn.Click += (_, _) =>
+            {
+                try
+                {
+                    var pkgData = new DataPackage();
+                    pkgData.SetText(cmd);
+                    Clipboard.SetContent(pkgData);
+                    copyBtn.Content = "Copied";
+                    _ = Task.Delay(1200).ContinueWith(_ =>
+                    {
+                        if (DispatcherQueue == null) return;
+                        DispatcherQueue.TryEnqueue(() => copyBtn.Content = "Copy");
+                    }, TaskScheduler.Default);
+                }
+                catch
+                {
+                    copyBtn.Content = "Copy failed";
+                }
+            };
+            cmdRow.Children.Add(copyBtn);
+            recoveryPanel.Children.Add(cmdRow);
+
+            recoveryPanel.Children.Add(new TextBlock
+            {
+                Text = "After installing the provider on your gateway host, come back and click Show QR again.",
+                TextWrapping = TextWrapping.Wrap,
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+            });
+
+            recoveryPanel.Visibility = Visibility.Visible;
+        }
+        // Local helper: the gateway doesn't implement web.login at all (older
+        // gateway). Installing a channel plugin won't add the missing RPC, so we
+        // guide the user to update the gateway instead of showing an install
+        // command they'd run to no effect.
+        void ShowUnsupportedRecovery()
+        {
+            recoveryPanel.Children.Clear();
+
+            recoveryPanel.Children.Add(new TextBlock
+            {
+                Text = $"This gateway version doesn't support QR linking for {channelId} yet. QR/web linking runs on the machine that hosts your gateway — update your gateway to a version that supports web login, then come back and click Show QR again.",
+                TextWrapping = TextWrapping.Wrap,
+                Style = (Style)Application.Current.Resources["BodyTextBlockStyle"],
+                Foreground = (Brush)Application.Current.Resources["TextFillColorSecondaryBrush"],
+            });
+
+            recoveryPanel.Visibility = Visibility.Visible;
+        }
+        void HideRecovery()
+        {
+            recoveryPanel.Visibility = Visibility.Collapsed;
+            recoveryPanel.Children.Clear();
+        }
+
         var client = CurrentApp.GatewayClient;
         if (client == null)
         {
             qrImage.Visibility = Visibility.Collapsed;
             messageBlock.Text = "Not connected to a gateway. Open Connection settings to connect first.";
             HideDiagnostic();
+            HideRecovery();
             return;
         }
 
@@ -1790,6 +1889,7 @@ public sealed partial class ChannelsPage : Page
 
         messageBlock.Text = "Requesting QR code from the gateway…";
         HideDiagnostic();
+        HideRecovery();
 
         var startParams = new { force, timeoutMs = 30000 };
         var start = await client.WebLoginStartAsync(force);
@@ -1807,6 +1907,34 @@ public sealed partial class ChannelsPage : Page
         if (!string.IsNullOrEmpty(start.Error))
         {
             qrImage.Visibility = Visibility.Collapsed;
+
+            var displayName = string.IsNullOrEmpty(channelId)
+                ? "This channel"
+                : $"{char.ToUpper(channelId[0])}{channelId[1..]}";
+
+            if (start.LooksLikeMissingWebLoginProvider)
+            {
+                // Known, recoverable state: the gateway has no web-login provider
+                // loaded for this channel. Show actionable recovery instead of the
+                // relayed internal error as the headline (issue #957). Keep the raw
+                // gateway detail available in the collapsed diagnostic.
+                messageBlock.Text = $"{displayName} linking isn't available on this gateway yet — see how to enable it below.";
+                ShowProviderRecovery();
+                ShowDiagnostic("web.login.start", startParams, start.Error, start.RawResponse);
+                return;
+            }
+
+            if (start.LooksLikeWebLoginUnsupported)
+            {
+                // Gateway is too old to implement web.login at all. Installing a
+                // plugin wouldn't add the method — guide the user to update the
+                // gateway instead.
+                messageBlock.Text = $"{displayName} linking isn't available on this gateway yet — see how to enable it below.";
+                ShowUnsupportedRecovery();
+                ShowDiagnostic("web.login.start", startParams, start.Error, start.RawResponse);
+                return;
+            }
+
             messageBlock.Text = $"Couldn't link {channelId}. The gateway returned an error — see details below.";
             ShowDiagnostic("web.login.start", startParams, start.Error, start.RawResponse);
             return;

--- a/tests/OpenClaw.Shared.Tests/ChannelResultTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ChannelResultTests.cs
@@ -39,6 +39,72 @@ public class ChannelStartResultTests
     }
 }
 
+/// <summary>
+/// Tests for <see cref="WebLoginStartResult.LooksLikeMissingWebLoginProvider"/>,
+/// which turns the gateway's "no web-login provider loaded" signal (issue #957)
+/// into the actionable-recovery branch in the Channels linking flow.
+/// </summary>
+public class WebLoginStartResultTests
+{
+    [Theory]
+    [InlineData("web login provider is not available")]        // exact string from issue #957
+    [InlineData("Web Login Provider is not available")]         // case-insensitive
+    [InlineData("WEB LOGIN PROVIDER IS NOT AVAILABLE")]
+    [InlineData("web-login provider not loaded")]               // hyphenated variant
+    public void LooksLikeMissingWebLoginProvider_IsTrueForProviderSignals(string error)
+    {
+        var result = new WebLoginStartResult { Error = error };
+        Assert.True(result.LooksLikeMissingWebLoginProvider);
+        // Provider-missing must NOT be misclassified as an unsupported method.
+        Assert.False(result.LooksLikeWebLoginUnsupported);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("channel is not configured")]
+    [InlineData("timeout waiting for web.login.start response")]
+    [InlineData("gateway connection is not open")]
+    [InlineData("rate limited")]
+    [InlineData("unknown method: web.login.start")]             // unsupported method, not a missing provider
+    public void LooksLikeMissingWebLoginProvider_IsFalseForOtherErrors(string? error)
+    {
+        var result = new WebLoginStartResult { Error = error };
+        Assert.False(result.LooksLikeMissingWebLoginProvider);
+    }
+
+    [Theory]
+    [InlineData("unknown method: web.login.start")]            // older gateway with no web.login RPC
+    [InlineData("Unknown Method: web.login.start")]            // case-insensitive
+    public void LooksLikeWebLoginUnsupported_IsTrueForUnknownMethod(string error)
+    {
+        var result = new WebLoginStartResult { Error = error };
+        Assert.True(result.LooksLikeWebLoginUnsupported);
+        // Unsupported-method must NOT be misclassified as a missing provider
+        // (installing a plugin wouldn't add the RPC).
+        Assert.False(result.LooksLikeMissingWebLoginProvider);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("web login provider is not available")]
+    [InlineData("unknown method: usage.status")]              // different unknown method
+    public void LooksLikeWebLoginUnsupported_IsFalseForOtherErrors(string? error)
+    {
+        var result = new WebLoginStartResult { Error = error };
+        Assert.False(result.LooksLikeWebLoginUnsupported);
+    }
+
+    [Fact]
+    public void DetectionFlags_AreFalseOnSuccess()
+    {
+        var result = new WebLoginStartResult { QrDataUrl = "data:image/png;base64,AAAA" };
+        Assert.False(result.LooksLikeMissingWebLoginProvider);
+        Assert.False(result.LooksLikeWebLoginUnsupported);
+    }
+}
+
 public class ConfigPatchResultTests
 {
     [Theory]

--- a/tests/OpenClaw.Tray.Tests/ChannelsPageWebLoginRecoveryContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChannelsPageWebLoginRecoveryContractTests.cs
@@ -1,0 +1,90 @@
+using System.Linq;
+
+namespace OpenClaw.Tray.Tests;
+
+/// <summary>
+/// Source-contract tests for the WhatsApp/QR linking recovery flow (issue #957).
+///
+/// The Channels linking UI is WinUI code-behind that can't be unit-tested without
+/// a UI thread, so — following the ChannelsPageDiscordConfigContractTests
+/// convention — these assert the source wiring: the linking flow must branch on
+/// the gateway's "no web-login provider loaded" signal and surface actionable
+/// recovery (a copyable gateway-host install command) instead of leaking the
+/// relayed internal exception.
+/// </summary>
+public sealed class ChannelsPageWebLoginRecoveryContractTests
+{
+    private static string ReadChannelsPage() =>
+        Read("src", "OpenClaw.Tray.WinUI", "Pages", "ChannelsPage.xaml.cs");
+
+    [Fact]
+    public void LinkingFlow_BranchesOnMissingWebLoginProvider()
+    {
+        var source = ReadChannelsPage();
+
+        // The page must consult both detection properties rather than only
+        // echoing the raw gateway error — provider-missing and unsupported-method
+        // get different, correct recovery guidance.
+        Assert.Contains("LooksLikeMissingWebLoginProvider", source, StringComparison.Ordinal);
+        Assert.Contains("LooksLikeWebLoginUnsupported", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LinkingFlow_ShowsActionableRecoveryCommand()
+    {
+        var source = ReadChannelsPage();
+
+        // Recovery must offer the exact gateway-host command to load the provider,
+        // mirroring the existing missing-plugin recovery affordance.
+        Assert.Contains("openclaw plugins install @openclaw/", source, StringComparison.Ordinal);
+
+        // Recovery must be a distinct, copyable affordance with a Copy button.
+        Assert.Contains("recoveryPanel", source, StringComparison.Ordinal);
+        Assert.Contains("Clipboard.SetContent", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LinkingFlow_DoesNotSurfaceRawStackTraceAsHeadline()
+    {
+        var source = ReadChannelsPage();
+
+        // The missing-provider branch must not reuse the generic
+        // "returned an error — see details below" headline; it gets its own
+        // "isn't available on this gateway yet" actionable message.
+        Assert.Contains("isn't available on this gateway yet", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GatewayClient_DoesNotLeakStackTraceIntoWebLoginRawResponse()
+    {
+        // The relayed internal exception (with internal CI build paths) must not
+        // be dumped into the user-facing WebLoginStartResult/WaitResult. Both
+        // catch blocks assigned RawResponse = ex.ToString() (issue #957); the fix
+        // surfaces ex.Message instead. Scope the assertion to the web-login
+        // region so unrelated methods (and the fix's explanatory comments) don't
+        // affect the result.
+        var source = Read("src", "OpenClaw.Shared", "OpenClawGatewayClient.cs");
+        var region = ExtractWebLoginRegion(source);
+
+        Assert.DoesNotContain("RawResponse = ex.ToString()", region, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Slice covering both web-login methods: from the WebLoginStartAsync
+    /// signature to the start of the next unrelated method. Keeps the leak
+    /// assertion scoped without a full C# parser.
+    /// </summary>
+    private static string ExtractWebLoginRegion(string source)
+    {
+        var start = source.IndexOf("WebLoginStartAsync(bool force", StringComparison.Ordinal);
+        Assert.True(start >= 0, "Could not find WebLoginStartAsync in OpenClawGatewayClient.cs");
+
+        var end = source.IndexOf("SendConnectMessageAsync", start, StringComparison.Ordinal);
+        if (end < 0) end = source.Length;
+
+        return source.Substring(start, end - start);
+    }
+
+    private static string Read(params string[] parts)
+        => File.ReadAllText(Path.Combine(new[] { TestRepositoryPaths.GetRepositoryRoot() }.Concat(parts).ToArray()));
+}


### PR DESCRIPTION
Fixes #957.

## Problem

Starting WhatsApp QR pairing from the Channels page, against a connected gateway that has **no web-login provider loaded**, failed by dumping a raw `System.InvalidOperationException` plus a .NET stack trace containing internal CI build paths (`D:\a\openclaw-windows-node\...`) to a non-technical user — instead of actionable recovery.

## Root-cause ownership (verified — a real Windows-node UX defect, not a WhatsApp-API workaround)

- The string `"web login provider is not available"` exists **nowhere** in this repo — it is **gateway-generated** and only *relayed* by the node.
- Flow: the gateway replies `{ ok: false, error: "web login provider is not available" }`; `OpenClawGatewayClient` wraps that message in an `InvalidOperationException`; `WebLoginStartAsync` caught it and stored `RawResponse = ex.ToString()` — the full .NET stack trace with build-machine paths seen in the issue screenshot.
- WhatsApp QR/web-login runs entirely **gateway-side**, so provider-loading itself cannot be fixed from this repo. The two genuine **node-owned** defects fixed here are: (1) leaking a relayed internal exception + stack trace into user-facing UI, and (2) no translation of the known gateway signal into recovery.

## Changes

- **`OpenClaw.Shared/ChannelsSnapshot.cs`** — `WebLoginStartResult` gains two computed detection properties, mirroring the existing `ChannelStartResult.LooksLikeMissingPlugin` pattern:
  - `LooksLikeMissingWebLoginProvider` — provider not loaded → guide the user to install the provider on the gateway host.
  - `LooksLikeWebLoginUnsupported` — gateway doesn't implement the `web.login` RPC at all → guide the user to upgrade the gateway (installing a plugin wouldn't add the missing method).
- **`OpenClaw.Shared/OpenClawGatewayClient.cs`** — `WebLoginStartAsync`/`WebLoginWaitAsync` catch blocks now surface `ex.Message` (the clean gateway reason) instead of `ex.ToString()`, so no internal stack trace / CI build paths reach the UI.
- **`OpenClaw.Tray.WinUI/Pages/ChannelsPage.xaml.cs`** — the linking flow routes the two detected states to distinct, actionable recovery UIs (a copyable `openclaw plugins install @openclaw/<channelId>` command with a Copy button, or upgrade guidance) with a non-actionable-exception headline, and keeps the clean gateway detail available in the collapsed "Why isn't this working?" diagnostic.

## Validation

- `./build.ps1` ✅
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` ✅ (2772 passed, 31 skipped)
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` ✅ (1709 passed)
- New tests: `ChannelResultTests.WebLoginStartResultTests` (both detection properties, including cross-classification checks) and `ChannelsPageWebLoginRecoveryContractTests` (source-contract: both properties referenced, recovery-command affordance present, actionable headline present, and the web-login region contains no `RawResponse = ex.ToString()`).
- Adversarial closeout review (built-in code-review agent; codex/claude/pi CLIs are not installed on this host): no significant issues — confirmed no remaining stack-trace/CI-path leak, mutually-exclusive recovery routing, sound recovery-panel/clipboard/dispatcher lifecycle.

## Real behavior proof

- **Automated proof (current head):** the Shared detection tests exercise the exact issue string (`"web login provider is not available"`) and assert it maps to `LooksLikeMissingWebLoginProvider` and NOT `LooksLikeWebLoginUnsupported`; the Tray source-contract test asserts the linking flow renders the recovery affordance and that the web-login catch region no longer emits `ex.ToString()`.
- **Live-gateway UI capture: Not verified / blocked.** Rendering the actual WinUI recovery screen requires a live gateway that returns `web login provider is not available` for `web.login.start` — a gateway-host provider state that cannot be reproduced from this repo/host. Manual repro: connect the tray to a gateway whose WhatsApp web-login provider is not loaded, open **Channels → WhatsApp → Show QR**. Expected: headline "WhatsApp linking isn't available on this gateway yet — see how to enable it below.", a recovery panel with a copyable `openclaw plugins install @openclaw/whatsapp` command + Copy button, and the raw gateway detail available only under the collapsed diagnostic (no `System.InvalidOperationException` / stack trace / `D:\a\...` paths in the headline).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
