### PR TITLE
improve(chat): make prose and simple lists one selectable text block

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Chat/Markdown/ChatMarkdownRenderer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/Markdown/ChatMarkdownRenderer.cs
@@ -51,30 +51,36 @@ public static class ChatMarkdownRenderer
         if (document.Blocks.Count == 0)
             return null;
 
-        // Coalesce maximal runs of consecutive text blocks (paragraphs +
-        // headings) into a single RichTextBlock so the whole prose run is one
-        // continuous text-selection scope. Non-text blocks (lists, tables, code,
-        // block quotes, rules) stay as their own selectable sibling controls —
-        // they are natural selection islands and keep their existing layout.
+        // Coalesce maximal runs of consecutive mergeable blocks (paragraphs,
+        // headings, and "simple" bullet/numbered lists) into a single
+        // RichTextBlock so the whole run is one continuous text-selection scope
+        // — a drag can select across paragraphs AND list items. Blocks that
+        // carry their own chrome (code cards, table grids, block-quote borders,
+        // rules) — and any list that contains such a block — stay as their own
+        // selectable sibling controls, keeping their existing layout.
         var blocks = document.Blocks;
         var segments = new List<Element?>(blocks.Count);
         int i = 0;
         while (i < blocks.Count)
         {
-            if (IsMergeableText(blocks[i]))
+            if (IsMergeable(blocks[i]))
             {
                 int start = i;
-                while (i < blocks.Count && IsMergeableText(blocks[i])) i++;
+                while (i < blocks.Count && IsMergeable(blocks[i])) i++;
                 int count = i - start;
-                if (count == 1)
+                if (count == 1 && blocks[start] is MdParagraph or MdHeading)
                 {
-                    // A lone text block keeps the lightweight single-TextBlock
-                    // shape (already internally selectable) — no behavior change.
+                    // A lone paragraph / heading keeps the lightweight
+                    // single-TextBlock shape (already internally selectable) —
+                    // no behavior change.
                     var single = RenderBlock(blocks[start]);
                     if (single is not null) segments.Add(single);
                 }
                 else
                 {
+                    // Multi-block prose runs — and any run containing a list —
+                    // become one continuous RichTextBlock so paragraphs,
+                    // headings, and list items share a single selection scope.
                     var run = new List<MdBlock>(count);
                     for (int j = start; j < i; j++) run.Add(blocks[j]);
                     segments.Add(TextRunRichBlock(run));
@@ -93,7 +99,27 @@ public static class ChatMarkdownRenderer
         return VStack(8.0, segments.ToArray());
     }
 
-    private static bool IsMergeableText(MdBlock block) => block is MdParagraph or MdHeading;
+    // Blocks that can flow into one continuous RichTextBlock: prose (paragraphs,
+    // headings) and "simple" lists whose items contain only more mergeable
+    // blocks. A list containing a code block, table, block quote, thematic
+    // break, or raw block is NOT mergeable — it keeps its own layout as a
+    // sibling island so that chrome (code cards, table grids) survives and the
+    // list's non-text children stay selectable in their native form.
+    private static bool IsMergeable(MdBlock block) => block switch
+    {
+        MdParagraph => true,
+        MdHeading => true,
+        MdList list => IsSimpleList(list),
+        _ => false,
+    };
+
+    private static bool IsSimpleList(MdList list)
+    {
+        foreach (var item in list.Items)
+            foreach (var child in item.Children)
+                if (!IsMergeable(child)) return false;
+        return true;
+    }
 
     public static Element? Render(string? markdown)
     {
@@ -310,12 +336,137 @@ public static class ChatMarkdownRenderer
         }
         s_blocksCache.AddOrUpdate(rtb, blocks);
         rtb.Blocks.Clear();
-        for (int i = 0; i < blocks.Count; i++)
+        foreach (var block in blocks)
         {
-            var paragraph = BuildParagraph(blocks[i]);
-            if (i > 0) paragraph.Margin = new Thickness(0, ParagraphSpacing, 0, 0);
-            rtb.Blocks.Add(paragraph);
+            switch (block)
+            {
+                case MdParagraph:
+                case MdHeading:
+                {
+                    var p = BuildParagraph(block);
+                    p.Margin = new Thickness(0, TopGap(rtb, ParagraphSpacing), 0, 0);
+                    rtb.Blocks.Add(p);
+                    break;
+                }
+                case MdList list:
+                    AppendList(rtb, list, level: 1);
+                    break;
+            }
         }
+    }
+
+    // Vertical gap before the next paragraph: none for the very first paragraph
+    // in the RichTextBlock, otherwise the supplied gap. Keeping this off the
+    // first paragraph avoids a leading blank strip at the top of the bubble.
+    private static double TopGap(RichTextBlock rtb, double gap) =>
+        rtb.Blocks.Count == 0 ? 0.0 : gap;
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Lists coalesced into the shared RichTextBlock (hanging-indent
+    //  paragraphs) — one continuous selection scope with the surrounding
+    //  prose. Only reached for "simple" lists (see IsSimpleList); lists that
+    //  carry chrome-bearing children render via RenderList as their own island.
+    // ────────────────────────────────────────────────────────────────────
+
+    private const double ListIndentPerLevel = 18.0;
+    private const double ListItemSpacing = 3.0;
+    // Fixed offset from a list item's marker column to its text/content column.
+    // Applied as a hanging indent (negative TextIndent on the marker line) so
+    // wrapped lines and continuation paragraphs align under the text rather than
+    // back at the marker — approximating the Grid path's Auto/Star columns with
+    // the flat Paragraph model (which has no per-item measured marker width).
+    private const double ListHangingIndent = 18.0;
+    // Marker → text separator. En space gives a stable, font-independent gap
+    // after the bullet / number without relying on tab stops (which Paragraph
+    // does not expose).
+    private const string ListMarkerGap = "\u2002";
+
+    private static void AppendList(RichTextBlock rtb, MdList list, int level)
+    {
+        bool ordered = list.Marker == MdListMarker.Ordered;
+        int number = ordered ? list.StartNumber : 0;
+        for (int idx = 0; idx < list.Items.Count; idx++)
+        {
+            var item = list.Items[idx];
+            string marker = item.TaskState switch
+            {
+                MdTaskState.Checked   => "\u2611",
+                MdTaskState.Unchecked => "\u2610",
+                _ => ordered ? $"{number}." : "\u2022",
+            };
+            if (ordered) number++;
+            // A top-level list's first item gets the fuller paragraph gap so the
+            // list separates from preceding prose; every other item uses the
+            // tighter inter-item gap.
+            double leadGap = (level == 1 && idx == 0) ? ParagraphSpacing : ListItemSpacing;
+            AppendListItem(rtb, item, marker, level, leadGap);
+        }
+    }
+
+    private static void AppendListItem(
+        RichTextBlock rtb, MdListItem item, string marker, int level, double leadGap)
+    {
+        double indent = ListIndentPerLevel * level;
+        bool markerEmitted = false;
+        foreach (var child in item.Children)
+        {
+            double gap = markerEmitted ? ListItemSpacing : leadGap;
+            switch (child)
+            {
+                case MdParagraph p:
+                    rtb.Blocks.Add(BuildListParagraph(
+                        rtb, p.Inlines, indent, markerEmitted ? null : marker, gap));
+                    markerEmitted = true;
+                    break;
+                case MdHeading h:
+                {
+                    int hidx = Math.Clamp(h.Level - 1, 0, HeadingFontSizes.Length - 1);
+                    rtb.Blocks.Add(BuildListParagraph(
+                        rtb, h.Inlines, indent, markerEmitted ? null : marker, gap,
+                        HeadingFontSizes[hidx], semiBold: true));
+                    markerEmitted = true;
+                    break;
+                }
+                case MdList nested:
+                    if (!markerEmitted)
+                    {
+                        rtb.Blocks.Add(BuildListParagraph(
+                            rtb, Array.Empty<MdInline>(), indent, marker, leadGap));
+                        markerEmitted = true;
+                    }
+                    AppendList(rtb, nested, level + 1);
+                    break;
+            }
+        }
+        if (!markerEmitted)
+        {
+            // Empty item — still emit the marker so numbering stays consistent.
+            rtb.Blocks.Add(BuildListParagraph(
+                rtb, Array.Empty<MdInline>(), indent, marker, leadGap));
+        }
+    }
+
+    private static Paragraph BuildListParagraph(
+        RichTextBlock rtb, IReadOnlyList<MdInline> inlines, double indent,
+        string? marker, double gap, double fontSize = BodyFontSize, bool semiBold = false)
+    {
+        var p = new Paragraph
+        {
+            FontSize = fontSize,
+            // Content column sits a fixed hanging offset past the marker indent
+            // so wrapped lines / continuation paragraphs align under the text.
+            Margin = new Thickness(indent + ListHangingIndent, TopGap(rtb, gap), 0, 0),
+        };
+        if (semiBold) p.FontWeight = MUIText.FontWeights.SemiBold;
+        if (marker is not null)
+        {
+            // Hanging indent: pull the marker line back to the marker column
+            // while wrapped lines stay at the content column set by Margin.
+            p.TextIndent = -ListHangingIndent;
+            p.Inlines.Add(new Run { Text = marker + ListMarkerGap });
+        }
+        AppendInlines(p.Inlines, inlines);
+        return p;
     }
 
     // Compare coalesced text runs structurally rather than via record equality.
@@ -341,8 +492,30 @@ public static class ChatMarkdownRenderer
     {
         (MdHeading ha, MdHeading hb) => ha.Level == hb.Level && ha.Inlines.SequenceEqual(hb.Inlines),
         (MdParagraph pa, MdParagraph pb) => pa.Inlines.SequenceEqual(pb.Inlines),
+        (MdList la, MdList lb) => ListEqual(la, lb),
         _ => a.Equals(b),
     };
+
+    // Structural list comparison mirroring BlockEqual's rationale: MdList /
+    // MdListItem records compare their child collections BY REFERENCE, so a
+    // re-parsed-but-identical list would otherwise force a Blocks rebuild and
+    // wipe the active selection. Recurse through items and their block children
+    // (nested lists included) comparing inline content by value.
+    private static bool ListEqual(MdList a, MdList b)
+    {
+        if (a.Marker != b.Marker || a.StartNumber != b.StartNumber) return false;
+        if (a.Items.Count != b.Items.Count) return false;
+        for (int i = 0; i < a.Items.Count; i++)
+        {
+            var ia = a.Items[i];
+            var ib = b.Items[i];
+            if (ia.TaskState != ib.TaskState) return false;
+            if (ia.Children.Count != ib.Children.Count) return false;
+            for (int j = 0; j < ia.Children.Count; j++)
+                if (!BlockEqual(ia.Children[j], ib.Children[j])) return false;
+        }
+        return true;
+    }
 
     private static Paragraph BuildParagraph(MdBlock block)
     {
@@ -366,7 +539,8 @@ public static class ChatMarkdownRenderer
                 return p;
             }
             default:
-                // Only text blocks (see IsMergeableText) reach this method.
+                // Only paragraphs / headings reach this method — lists flow
+                // through AppendList, other blocks render as sibling islands.
                 return new Paragraph { FontSize = BodyFontSize };
         }
     }

--- a/src/OpenClaw.Tray.WinUI/Chat/Markdown/ChatMarkdownRenderer.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/Markdown/ChatMarkdownRenderer.cs
@@ -51,17 +51,49 @@ public static class ChatMarkdownRenderer
         if (document.Blocks.Count == 0)
             return null;
 
-        if (document.Blocks.Count == 1)
-            return RenderBlock(document.Blocks[0]);
-
-        var children = new List<Element?>(document.Blocks.Count);
-        foreach (var block in document.Blocks)
+        // Coalesce maximal runs of consecutive text blocks (paragraphs +
+        // headings) into a single RichTextBlock so the whole prose run is one
+        // continuous text-selection scope. Non-text blocks (lists, tables, code,
+        // block quotes, rules) stay as their own selectable sibling controls —
+        // they are natural selection islands and keep their existing layout.
+        var blocks = document.Blocks;
+        var segments = new List<Element?>(blocks.Count);
+        int i = 0;
+        while (i < blocks.Count)
         {
-            var rendered = RenderBlock(block);
-            if (rendered is not null) children.Add(rendered);
+            if (IsMergeableText(blocks[i]))
+            {
+                int start = i;
+                while (i < blocks.Count && IsMergeableText(blocks[i])) i++;
+                int count = i - start;
+                if (count == 1)
+                {
+                    // A lone text block keeps the lightweight single-TextBlock
+                    // shape (already internally selectable) — no behavior change.
+                    var single = RenderBlock(blocks[start]);
+                    if (single is not null) segments.Add(single);
+                }
+                else
+                {
+                    var run = new List<MdBlock>(count);
+                    for (int j = start; j < i; j++) run.Add(blocks[j]);
+                    segments.Add(TextRunRichBlock(run));
+                }
+            }
+            else
+            {
+                var rendered = RenderBlock(blocks[i]);
+                if (rendered is not null) segments.Add(rendered);
+                i++;
+            }
         }
-        return VStack(8.0, children.ToArray());
+
+        if (segments.Count == 0) return null;
+        if (segments.Count == 1) return segments[0];
+        return VStack(8.0, segments.ToArray());
     }
+
+    private static bool IsMergeableText(MdBlock block) => block is MdParagraph or MdHeading;
 
     public static Element? Render(string? markdown)
     {
@@ -244,6 +276,100 @@ public static class ChatMarkdownRenderer
 
     private static Element RenderParagraph(MdParagraph paragraph) =>
         InlinesTextBlock(paragraph.Inlines).FontSize(BodyFontSize);
+
+    // ────────────────────────────────────────────────────────────────────
+    //  Coalesced text run → single selectable RichTextBlock
+    // ────────────────────────────────────────────────────────────────────
+
+    private const double ParagraphSpacing = 8.0;
+
+    // Cache the block run applied to each RichTextBlock so re-renders with
+    // identical content skip the Blocks.Clear()+rebuild round trip. Clearing
+    // Blocks while the user has an active selection wipes it (same failure mode
+    // the TextBlock inline cache guards against). Equality is structural
+    // (see BlockRunsEqual) so it holds even after the bounded AST cache evicts
+    // and re-parses an unchanged message into fresh block instances.
+    private static readonly ConditionalWeakTable<RichTextBlock, IReadOnlyList<MdBlock>>
+        s_blocksCache = new();
+
+    private static RichTextBlockElement TextRunRichBlock(IReadOnlyList<MdBlock> blocks) =>
+        RichTextBlock().Set(rtb =>
+        {
+            rtb.TextWrapping = TextWrapping.Wrap;
+            rtb.IsTextSelectionEnabled = true;
+            ApplyBlocks(rtb, blocks);
+        });
+
+    private static void ApplyBlocks(RichTextBlock rtb, IReadOnlyList<MdBlock> blocks)
+    {
+        if (rtb.Blocks.Count > 0
+            && s_blocksCache.TryGetValue(rtb, out var cached)
+            && BlockRunsEqual(cached, blocks))
+        {
+            return;
+        }
+        s_blocksCache.AddOrUpdate(rtb, blocks);
+        rtb.Blocks.Clear();
+        for (int i = 0; i < blocks.Count; i++)
+        {
+            var paragraph = BuildParagraph(blocks[i]);
+            if (i > 0) paragraph.Margin = new Thickness(0, ParagraphSpacing, 0, 0);
+            rtb.Blocks.Add(paragraph);
+        }
+    }
+
+    // Compare coalesced text runs structurally rather than via record equality.
+    // MdParagraph / MdHeading records compare their MdInline lists by reference,
+    // so two equivalent-but-distinct block instances (produced when the bounded
+    // GetOrParse AST cache evicts and re-parses an unchanged message) would
+    // compare unequal and needlessly rebuild Blocks — wiping the active
+    // selection. MdInline subtypes are value-comparable, so comparing the inline
+    // sequences by value keeps the selection-preservation guarantee independent
+    // of parser-cache residency.
+    private static bool BlockRunsEqual(IReadOnlyList<MdBlock> a, IReadOnlyList<MdBlock> b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a.Count != b.Count) return false;
+        for (int i = 0; i < a.Count; i++)
+        {
+            if (!BlockEqual(a[i], b[i])) return false;
+        }
+        return true;
+    }
+
+    private static bool BlockEqual(MdBlock a, MdBlock b) => (a, b) switch
+    {
+        (MdHeading ha, MdHeading hb) => ha.Level == hb.Level && ha.Inlines.SequenceEqual(hb.Inlines),
+        (MdParagraph pa, MdParagraph pb) => pa.Inlines.SequenceEqual(pb.Inlines),
+        _ => a.Equals(b),
+    };
+
+    private static Paragraph BuildParagraph(MdBlock block)
+    {
+        switch (block)
+        {
+            case MdHeading heading:
+            {
+                int idx = Math.Clamp(heading.Level - 1, 0, HeadingFontSizes.Length - 1);
+                var p = new Paragraph
+                {
+                    FontSize = HeadingFontSizes[idx],
+                    FontWeight = MUIText.FontWeights.SemiBold,
+                };
+                AppendInlines(p.Inlines, heading.Inlines);
+                return p;
+            }
+            case MdParagraph paragraph:
+            {
+                var p = new Paragraph { FontSize = BodyFontSize };
+                AppendInlines(p.Inlines, paragraph.Inlines);
+                return p;
+            }
+            default:
+                // Only text blocks (see IsMergeableText) reach this method.
+                return new Paragraph { FontSize = BodyFontSize };
+        }
+    }
 
     private static Element RenderBlockQuote(MdBlockQuote quote)
     {

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatTimeline.cs
@@ -312,6 +312,28 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
             textBlock.Inlines.Add(new Run { Text = normalized });
     }
 
+    // RichTextBlock analog of the user-bubble plain-text cache. Selection lives
+    // on the RichTextBlock, so re-applying identical text must NOT clear Blocks
+    // (that wipes the active selection). Skip the rebuild when the run is
+    // unchanged and a paragraph is still present.
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<RichTextBlock, string>
+        s_userParagraphCache = new();
+
+    private static void ApplyPlainSelectableParagraph(RichTextBlock richTextBlock, string? text)
+    {
+        var normalized = text ?? string.Empty;
+        if (richTextBlock.Blocks.Count > 0
+            && s_userParagraphCache.TryGetValue(richTextBlock, out var cached)
+            && cached == normalized)
+            return;
+        s_userParagraphCache.AddOrUpdate(richTextBlock, normalized);
+        richTextBlock.Blocks.Clear();
+        var paragraph = new Paragraph();
+        if (normalized.Length > 0)
+            paragraph.Inlines.Add(new Run { Text = normalized });
+        richTextBlock.Blocks.Add(paragraph);
+    }
+
     // Cache parsed markdown text per TextBlock to avoid re-clearing and
     // rebuilding Inlines on every re-render when message content is stable.
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<TextBlock, string>
@@ -1155,7 +1177,7 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                 bool isHighContrast = TryDetectHighContrast();
                 var selectionHighlightBrush = GetUserBubbleSelectionBrush(isHighContrast);
                 bubbleChildren.Add(
-                    TextBlock(string.Empty)
+                    RichTextBlock()
                         .Set(t =>
                         {
                             t.TextWrapping = TextWrapping.Wrap;
@@ -1187,14 +1209,12 @@ public class OpenClawChatTimeline : Component<OpenClawChatTimelineProps>
                             // color the OS guarantees contrasts with both
                             // surfaces.
                             t.SelectionHighlightColor = selectionHighlightBrush;
-                            // Render through Inlines (a single Run) rather
-                            // than the .Text property. This matches the
-                            // assistant bubble's selection-safe path and
-                            // sidesteps a WinUI bug where setting Text on a
-                            // selection-enabled TextBlock during a re-render
-                            // triggered by the mouse-up that ends a drag-
-                            // select leaves the glyph layer visually empty.
-                            ApplyPlainSelectableInlines(t, messageText);
+                            // Render the message as a single Paragraph (one Run)
+                            // so the whole user message is one continuous
+                            // selection scope — matching the assistant bubble's
+                            // RichTextBlock append-block pattern. The plain-text
+                            // run keeps the bubble inert (no markdown / links).
+                            ApplyPlainSelectableParagraph(t, messageText);
                         }));
             }
             Element content;

--- a/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
+++ b/src/OpenClawTray.FunctionalUI/FunctionalUI.cs
@@ -185,6 +185,12 @@ public readonly record struct GridSize(double Value, GridUnitType Type)
 }
 
 public sealed record TextBlockElement(string Text) : Element;
+// A RichTextBlock host. Unlike TextBlockElement it carries no text of its own —
+// its Blocks (Paragraphs / InlineUIContainers) are populated imperatively by a
+// caller-supplied setter (see the Set(Action<RichTextBlock>) overload), exactly
+// as TextBlockElement's Inlines are. Used by the chat renderer to give a whole
+// message one continuous text-selection scope across multiple paragraphs.
+public sealed record RichTextBlockElement : Element;
 public sealed record TextFieldElement(string Value, Action<string>? OnChanged, string? Placeholder, string? Header) : Element;
 public sealed record PasswordBoxElement(string Password, Action<string>? OnChanged, string? Placeholder) : Element;
 public sealed record ButtonElement(string Label, Action? OnClick, Element? ContentElement = null) : Element
@@ -568,6 +574,7 @@ public static class Factories
 {
     public static BorderElement Empty() => new(null);
     public static TextBlockElement TextBlock(string text) => new(text);
+    public static RichTextBlockElement RichTextBlock() => new();
     public static TextBlockElement Caption(string text) => TextBlock(text).FontSize(12);
     public static TextFieldElement TextField(string value, Action<string>? onChanged = null, string? placeholder = null, string? header = null) =>
         new(value, onChanged, placeholder, header);
@@ -744,6 +751,7 @@ public static class ElementExtensions
         element.FontWeight(Microsoft.UI.Text.FontWeights.SemiBold);
 
     public static TextBlockElement Set(this TextBlockElement element, Action<TextBlock> setter) => element.AddSetter(setter);
+    public static RichTextBlockElement Set(this RichTextBlockElement element, Action<RichTextBlock> setter) => element.AddSetter(setter);
     public static TextFieldElement Set(this TextFieldElement element, Action<TextBox> setter) => element.AddSetter(setter);
     public static PasswordBoxElement Set(this PasswordBoxElement element, Action<PasswordBox> setter) => element.AddSetter(setter);
     public static ButtonElement Set(this ButtonElement element, Action<Button> setter) => element.AddSetter(setter);
@@ -964,6 +972,7 @@ internal sealed class UiRenderer(Action requestRender)
         var control = element switch
         {
             TextBlockElement e => ConfigureTextBlock(GetOrCreate<TextBlock>(path), e),
+            RichTextBlockElement e => ConfigureRichTextBlock(GetOrCreate<RichTextBlock>(path), e),
             TextFieldElement e => ConfigureTextBox(GetOrCreate<TextBox>(path), e),
             PasswordBoxElement e => ConfigurePasswordBox(GetOrCreate<PasswordBox>(path), e),
             ButtonElement e => ConfigureButton(GetOrCreate<Button>(path), e, path, effects),
@@ -1081,6 +1090,17 @@ internal sealed class UiRenderer(Action requestRender)
             if (control.Text != element.Text)
                 control.Text = element.Text;
         }
+        ApplyModifiers(control, element);
+        ApplySetters(control, element);
+        return control;
+    }
+
+    // RichTextBlock has no Text of its own; its Blocks are built entirely by the
+    // caller's setter (mirroring how ConfigureTextBlock leaves Inlines to the
+    // setter). We never touch Blocks here so an active text selection survives a
+    // modifier-only re-render.
+    private RichTextBlock ConfigureRichTextBlock(RichTextBlock control, RichTextBlockElement element)
+    {
         ApplyModifiers(control, element);
         ApplySetters(control, element);
         return control;
@@ -1956,6 +1976,25 @@ internal sealed class UiRenderer(Action requestRender)
                 tb.ClearValue(TextBlock.MaxLinesProperty);
                 tb.ClearValue(TextBlock.LineHeightProperty);
                 tb.ClearValue(TextBlock.CharacterSpacingProperty);
+                break;
+            case RichTextBlock rtb:
+                if (m.FontSize is { } richSize) rtb.FontSize = richSize;
+                else rtb.ClearValue(RichTextBlock.FontSizeProperty);
+                if (m.FontWeight is { } richWeight) rtb.FontWeight = richWeight;
+                else rtb.ClearValue(RichTextBlock.FontWeightProperty);
+                if (m.FontFamily is { } richFamily) rtb.FontFamily = richFamily;
+                else rtb.ClearValue(RichTextBlock.FontFamilyProperty);
+                if (m.TextWrapping is { } richWrapping) rtb.TextWrapping = richWrapping;
+                else rtb.ClearValue(RichTextBlock.TextWrappingProperty);
+                if (m.Padding is { } richPadding) rtb.Padding = richPadding;
+                else rtb.ClearValue(RichTextBlock.PaddingProperty);
+                if (m.ForegroundResourceKey is { } richFgResource) rtb.Foreground = ThemeResources.ResolveBrush(richFgResource);
+                else if (m.Foreground is { } richFg) rtb.Foreground = richFg;
+                else rtb.ClearValue(RichTextBlock.ForegroundProperty);
+                rtb.ClearValue(RichTextBlock.TextTrimmingProperty);
+                rtb.ClearValue(RichTextBlock.MaxLinesProperty);
+                rtb.ClearValue(RichTextBlock.LineHeightProperty);
+                rtb.ClearValue(RichTextBlock.CharacterSpacingProperty);
                 break;
             case Control c:
                 if (m.Padding is { } controlPadding) c.Padding = controlPadding;

--- a/tests/OpenClaw.Tray.Tests/ChatUserBubbleTextContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatUserBubbleTextContractTests.cs
@@ -5,19 +5,22 @@ namespace OpenClaw.Tray.Tests;
 public sealed class ChatUserBubbleTextContractTests
 {
     [Fact]
-    public void UserPromptText_ResetsStaleTextBlockVisualStateBeforeApplyingInlines()
+    public void UserPromptText_RendersSelectableRichTextBlockParagraph()
     {
         var timeline = Read("src", "OpenClaw.Tray.WinUI", "Chat", "OpenClawChatTimeline.cs");
 
         Assert.Contains("private const string ChatTextFontFamilySource", timeline);
-        Assert.Contains("TextBlock(string.Empty)", timeline);
+        // The user message renders through a single RichTextBlock (one
+        // Paragraph / one Run) so the whole message is one continuous
+        // selection scope, matching the assistant bubble append-block pattern.
+        Assert.Contains("RichTextBlock()", timeline);
         Assert.Contains("t.FontFamily = s_chatTextFontFamily;", timeline);
         Assert.Contains("t.TextTrimming = TextTrimming.None;", timeline);
         Assert.Contains("t.MaxLines = 0;", timeline);
         Assert.Contains("t.Width = double.NaN;", timeline);
         Assert.Contains("t.MaxWidth = double.PositiveInfinity;", timeline);
         Assert.Matches(
-            new Regex(@"t\.TextTrimming\s*=\s*TextTrimming\.None;[\s\S]*ApplyPlainSelectableInlines\(t,\s*messageText\);"),
+            new Regex(@"t\.TextTrimming\s*=\s*TextTrimming\.None;[\s\S]*ApplyPlainSelectableParagraph\(t,\s*messageText\);"),
             timeline);
     }
 

--- a/tests/OpenClaw.Tray.UITests/ChatBubbleSelectionScopeProofTests.cs
+++ b/tests/OpenClaw.Tray.UITests/ChatBubbleSelectionScopeProofTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
+using OpenClaw.Chat;
+using OpenClawTray.Chat;
+using OpenClawTray.FunctionalUI.Hosting;
+using Windows.Graphics;
+using static OpenClawTray.FunctionalUI.Factories;
+using static OpenClaw.Tray.UITests.TestSupport;
+
+namespace OpenClaw.Tray.UITests;
+
+/// <summary>
+/// Deterministic real-runtime proof of the chat-bubble selection-scope contract
+/// requested during review of the "one selectable text block" change. Unlike the
+/// record-level <see cref="MarkdownRendererCoalesceTests"/> (which assert Element
+/// shape with no WinUI runtime), this test mounts a real
+/// <see cref="OpenClawChatTimeline"/> through the shipping FunctionalUI reconciler
+/// on the live STA/WinRT UI thread, renders one assistant message that mixes every
+/// relevant block type, and walks the realized visual tree.
+///
+/// It pins two invariants of the shipped renderer, not a mock rendering path:
+///   1. Consecutive prose paragraphs, a simple list, and a trailing paragraph all
+///      land in ONE <see cref="RichTextBlock"/> — a single continuous drag-select
+///      / copy scope.
+///   2. A fenced code block and a table each remain their OWN island control, so
+///      their chrome survives and selection does not bleed prose text into them
+///      (their text is absent from the prose RichTextBlock and present in separate
+///      TextBlocks).
+///
+/// The live native drag gesture itself is a human/interactive artifact; this test
+/// is the automated, deterministic stand-in a maintainer can run on the PR head.
+/// </summary>
+[Collection(UICollection.Name)]
+public sealed class ChatBubbleSelectionScopeProofTests
+{
+    private readonly UIThreadFixture _ui;
+
+    public ChatBubbleSelectionScopeProofTests(UIThreadFixture ui) => _ui = ui;
+
+    // One assistant message: two prose paragraphs, a three-item bullet list, a
+    // trailing paragraph, a fenced code block, and a small table. Distinctive
+    // NATO tokens make the tree-walk assertions unambiguous.
+    private const string ContractMessage =
+        "Alpha paragraph one describing the change.\n" +
+        "\n" +
+        "Bravo paragraph two with more detail.\n" +
+        "\n" +
+        "- Charlie first list item\n" +
+        "- Delta second list item\n" +
+        "- Echo third list item\n" +
+        "\n" +
+        "Foxtrot trailing paragraph after the list.\n" +
+        "\n" +
+        "```csharp\n" +
+        "var golfCode = 1;\n" +
+        "```\n" +
+        "\n" +
+        "| Hotel | India |\n" +
+        "| ------ | ----- |\n" +
+        "| Juliet | Kilo |\n";
+
+    [Fact]
+    public async Task AssistantMessage_ProseAndListShareOneSelectableBlock_CodeAndTableStayIslands()
+    {
+        await _ui.ResetContainerAsync();
+
+        var props = new OpenClawChatTimelineProps(
+            SessionId: "ui-proof-selection-scope",
+            Entries: new List<ChatTimelineItem>
+            {
+                new(Id: "assistant-contract", Kind: ChatTimelineItemKind.Assistant, Text: ContractMessage),
+            },
+            HasMoreHistory: false,
+            OnLoadMoreHistory: null,
+            UserSenderLabel: "UI proof user",
+            AssistantSenderLabel: "UI proof assistant",
+            DefaultModel: "proof-model",
+            ShowToolCalls: true,
+            ScrollToBottomToken: 0);
+
+        FunctionalHostControl? host = null;
+
+        await _ui.RunOnUIAsync(() =>
+        {
+            TestApp.EnsureFluentBrushFallbacks(Application.Current.Resources);
+            _ui.TestWindow.AppWindow.MoveAndResize(new RectInt32(-32000, -32000, 960, 720));
+            _ui.Container.Width = 900;
+            _ui.Container.Height = 640;
+
+            host = new FunctionalHostControl
+            {
+                Width = 860,
+                Height = 560,
+                SuppressAutoDispose = true,
+            };
+            _ui.Container.Children.Add(host);
+            host.Mount(_ => Component<OpenClawChatTimeline, OpenClawChatTimelineProps>(props));
+        });
+
+        await DrainRenderQueueAsync();
+        await DrainRenderQueueAsync();
+
+        await _ui.RunOnUIAsync(() =>
+        {
+            var repeater = FindLogical<ItemsRepeater>(host!).Single();
+            Assert.NotNull(repeater.TryGetElement(0));
+
+            var richTextTexts = CollectRichTextBlockTexts(host!);
+            var textBlockTexts = FindDescendants<TextBlock>(host!)
+                .Select(tb => tb.Text ?? string.Empty)
+                .ToArray();
+
+            // (1) Prose + list + trailing paragraph coalesce into exactly ONE
+            // RichTextBlock — one continuous selection / copy scope.
+            var proseBlock = Assert.Single(
+                richTextTexts, t => t.Contains("Alpha paragraph one", StringComparison.Ordinal));
+
+            Assert.Contains("Bravo paragraph two", proseBlock, StringComparison.Ordinal);
+            Assert.Contains("Charlie first list item", proseBlock, StringComparison.Ordinal);
+            Assert.Contains("Delta second list item", proseBlock, StringComparison.Ordinal);
+            Assert.Contains("Echo third list item", proseBlock, StringComparison.Ordinal);
+            Assert.Contains("Foxtrot trailing paragraph", proseBlock, StringComparison.Ordinal);
+
+            // (2) The code block and table are NOT part of that prose selection
+            // scope: their text must not appear inside the prose RichTextBlock.
+            Assert.DoesNotContain("golfCode", proseBlock, StringComparison.Ordinal);
+            Assert.DoesNotContain("Juliet", proseBlock, StringComparison.Ordinal);
+            Assert.DoesNotContain("Kilo", proseBlock, StringComparison.Ordinal);
+
+            // ...but they ARE rendered, as their own selectable island controls
+            // (separate TextBlocks), so the chrome/boundary is preserved.
+            Assert.Contains(textBlockTexts, t => t.Contains("golfCode", StringComparison.Ordinal));
+            Assert.Contains(textBlockTexts, t => t.Contains("Juliet", StringComparison.Ordinal));
+
+            Console.WriteLine(
+                "CHAT_BUBBLE_SELECTION_SCOPE_PROOF " +
+                $"proseRichTextBlocks={richTextTexts.Count(t => t.Contains("Alpha paragraph one", StringComparison.Ordinal))} " +
+                "proseListTrailingContiguous=true " +
+                "codeIsland=separate " +
+                "tableIsland=separate");
+        });
+
+        await _ui.RunOnUIAsync(() => host!.Dispose());
+    }
+
+    // Returns the concatenated text of each RichTextBlock separately (one string
+    // per control), so a caller can assert which blocks share a single control.
+    private static string[] CollectRichTextBlockTexts(DependencyObject host)
+    {
+        var texts = new List<string>();
+        foreach (var rtb in FindDescendants<RichTextBlock>(host))
+        {
+            var sb = new System.Text.StringBuilder();
+            foreach (var block in rtb.Blocks)
+            {
+                if (block is Paragraph p)
+                {
+                    foreach (var inline in p.Inlines) AppendInlineText(inline, sb);
+                    sb.Append('\n');
+                }
+            }
+            texts.Add(sb.ToString());
+        }
+        return texts.ToArray();
+    }
+
+    private static void AppendInlineText(Inline inline, System.Text.StringBuilder sb)
+    {
+        switch (inline)
+        {
+            case Run run:
+                sb.Append(run.Text);
+                break;
+            case Span span:
+                foreach (var child in span.Inlines) AppendInlineText(child, sb);
+                break;
+            case LineBreak:
+                sb.Append('\n');
+                break;
+        }
+    }
+
+    private async Task DrainRenderQueueAsync()
+    {
+        await _ui.RunOnUIAsync(() => { });
+        await Task.Delay(50);
+        await _ui.RunOnUIAsync(() => _ui.Container.UpdateLayout());
+        await _ui.RunOnUIAsync(() => { });
+    }
+}

--- a/tests/OpenClaw.Tray.UITests/ChatTimelineVirtualizationProofTests.cs
+++ b/tests/OpenClaw.Tray.UITests/ChatTimelineVirtualizationProofTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
 using OpenClaw.Chat;
 using OpenClawTray.Chat;
 using OpenClawTray.FunctionalUI;
@@ -113,10 +114,7 @@ public sealed class ChatTimelineVirtualizationProofTests
             Assert.Same(stableItemsSource, repeater.ItemsSource);
             Assert.Same(stableItemTemplate, repeater.ItemTemplate);
 
-            var visibleText = FindDescendants<TextBlock>(host!)
-                .Select(t => t.Text)
-                .Where(t => !string.IsNullOrWhiteSpace(t))
-                .ToArray();
+            var visibleText = CollectVisibleText(host!);
             Assert.Contains(visibleText, text => text.Contains("revision 1", StringComparison.Ordinal));
         });
 
@@ -141,10 +139,7 @@ public sealed class ChatTimelineVirtualizationProofTests
                 scrollViewer.ScrollableHeight - scrollViewer.VerticalOffset <= 4,
                 $"chat follow should stay near the newest row; offset={scrollViewer.VerticalOffset:0.0}, height={scrollViewer.ScrollableHeight:0.0}");
 
-            var visibleText = FindDescendants<TextBlock>(host!)
-                .Select(t => t.Text)
-                .Where(t => !string.IsNullOrWhiteSpace(t))
-                .ToArray();
+            var visibleText = CollectVisibleText(host!);
             Assert.Contains(visibleText, text => text.Contains("User proof row 241", StringComparison.Ordinal));
 
             Console.WriteLine(
@@ -264,6 +259,52 @@ public sealed class ChatTimelineVirtualizationProofTests
         itemsSource is System.Collections.IEnumerable enumerable
             ? enumerable.Cast<object>().Count()
             : 0;
+
+    // Collects visible message text from both TextBlock (lone text blocks,
+    // tool rows) and RichTextBlock (coalesced prose + user bubbles), since chat
+    // messages now render their prose through a RichTextBlock per message.
+    private static string[] CollectVisibleText(DependencyObject host)
+    {
+        var texts = new List<string>();
+
+        foreach (var tb in FindDescendants<TextBlock>(host))
+        {
+            if (!string.IsNullOrWhiteSpace(tb.Text)) texts.Add(tb.Text);
+        }
+
+        foreach (var rtb in FindDescendants<RichTextBlock>(host))
+        {
+            var sb = new System.Text.StringBuilder();
+            foreach (var block in rtb.Blocks)
+            {
+                if (block is Paragraph p)
+                {
+                    foreach (var inline in p.Inlines) AppendInlineText(inline, sb);
+                    sb.Append('\n');
+                }
+            }
+            var s = sb.ToString();
+            if (!string.IsNullOrWhiteSpace(s)) texts.Add(s);
+        }
+
+        return texts.ToArray();
+    }
+
+    private static void AppendInlineText(Inline inline, System.Text.StringBuilder sb)
+    {
+        switch (inline)
+        {
+            case Run run:
+                sb.Append(run.Text);
+                break;
+            case Span span:
+                foreach (var child in span.Inlines) AppendInlineText(child, sb);
+                break;
+            case LineBreak:
+                sb.Append('\n');
+                break;
+        }
+    }
 
     private sealed record SwappingVirtualRowProps(bool Expanded);
 

--- a/tests/OpenClaw.Tray.UITests/MarkdownRendererCoalesceTests.cs
+++ b/tests/OpenClaw.Tray.UITests/MarkdownRendererCoalesceTests.cs
@@ -1,0 +1,63 @@
+using OpenClawTray.Chat.Markdown;
+using OpenClawTray.FunctionalUI;
+using OpenClawTray.FunctionalUI.Core;
+using Xunit;
+
+namespace OpenClaw.Tray.UITests;
+
+/// <summary>
+/// Tests for the assistant-bubble text coalescing behavior: consecutive
+/// paragraph / heading blocks merge into a single <see cref="RichTextBlockElement"/>
+/// so the whole prose run is one continuous, drag-selectable scope. Non-text
+/// blocks (lists, code, tables) stay as their own selectable sibling controls.
+///
+/// Assertions live at the FunctionalUI <see cref="Element"/> record level (no
+/// WinUI runtime): the Blocks of the RichTextBlock are populated imperatively
+/// by a setter at reconcile time, but the element shape is what pins the
+/// coalescing contract.
+/// </summary>
+public sealed class MarkdownRendererCoalesceTests
+{
+    [Fact]
+    public void SingleParagraph_StaysLightweightTextBlock()
+    {
+        var element = ChatMarkdownRenderer.Render("just one line of prose");
+
+        // A lone text block keeps the single-TextBlock shape (no RichTextBlock
+        // overhead) — it is already internally selectable.
+        Assert.IsType<TextBlockElement>(element);
+    }
+
+    [Fact]
+    public void ConsecutiveParagraphs_CoalesceIntoOneRichTextBlock()
+    {
+        var element = ChatMarkdownRenderer.Render("first paragraph\n\nsecond paragraph");
+
+        Assert.IsType<RichTextBlockElement>(element);
+    }
+
+    [Fact]
+    public void HeadingThenParagraph_CoalesceIntoOneRichTextBlock()
+    {
+        var element = ChatMarkdownRenderer.Render("# Title\n\nbody text under the title");
+
+        Assert.IsType<RichTextBlockElement>(element);
+    }
+
+    [Fact]
+    public void TextRunFollowedByList_KeepsListAsSeparateSibling()
+    {
+        // Paragraph + heading coalesce into a RichTextBlock; the list is a
+        // separate selectable island. Result is a vertical stack of the two.
+        var element = ChatMarkdownRenderer.Render(
+            "# Title\n\nintro paragraph\n\n- a bullet\n- another bullet");
+
+        var stack = Assert.IsType<StackElement>(element);
+        Assert.Equal(Microsoft.UI.Xaml.Controls.Orientation.Vertical, stack.Orientation);
+        Assert.Equal(2, stack.Children.Count);
+
+        Assert.IsType<RichTextBlockElement>(stack.Children[0]!);
+        // The list remains its own StackElement (unchanged rendering).
+        Assert.IsType<StackElement>(stack.Children[1]!);
+    }
+}

--- a/tests/OpenClaw.Tray.UITests/MarkdownRendererCoalesceTests.cs
+++ b/tests/OpenClaw.Tray.UITests/MarkdownRendererCoalesceTests.cs
@@ -7,9 +7,11 @@ namespace OpenClaw.Tray.UITests;
 
 /// <summary>
 /// Tests for the assistant-bubble text coalescing behavior: consecutive
-/// paragraph / heading blocks merge into a single <see cref="RichTextBlockElement"/>
-/// so the whole prose run is one continuous, drag-selectable scope. Non-text
-/// blocks (lists, code, tables) stay as their own selectable sibling controls.
+/// paragraph / heading blocks AND "simple" lists (whose items contain only
+/// more mergeable blocks) merge into a single <see cref="RichTextBlockElement"/>
+/// so the whole run is one continuous, drag-selectable scope. Blocks that carry
+/// their own chrome (code cards, table grids) — and any list that contains such
+/// a block — stay as their own selectable sibling controls.
 ///
 /// Assertions live at the FunctionalUI <see cref="Element"/> record level (no
 /// WinUI runtime): the Blocks of the RichTextBlock are populated imperatively
@@ -45,19 +47,64 @@ public sealed class MarkdownRendererCoalesceTests
     }
 
     [Fact]
-    public void TextRunFollowedByList_KeepsListAsSeparateSibling()
+    public void ParagraphThenSimpleList_CoalesceIntoOneRichTextBlock()
     {
-        // Paragraph + heading coalesce into a RichTextBlock; the list is a
-        // separate selectable island. Result is a vertical stack of the two.
+        // A simple bullet list flows into the shared RichTextBlock with the
+        // preceding prose, so a single drag selects across both.
         var element = ChatMarkdownRenderer.Render(
             "# Title\n\nintro paragraph\n\n- a bullet\n- another bullet");
+
+        Assert.IsType<RichTextBlockElement>(element);
+    }
+
+    [Fact]
+    public void LoneSimpleList_BecomesRichTextBlock()
+    {
+        // Even by itself a simple list renders as a RichTextBlock (continuous
+        // selection across items) rather than the Grid-based island.
+        var element = ChatMarkdownRenderer.Render("- one\n- two\n- three");
+
+        Assert.IsType<RichTextBlockElement>(element);
+    }
+
+    [Fact]
+    public void OrderedSimpleList_BecomesRichTextBlock()
+    {
+        var element = ChatMarkdownRenderer.Render("1. first\n2. second");
+
+        Assert.IsType<RichTextBlockElement>(element);
+    }
+
+    [Fact]
+    public void NestedSimpleList_BecomesRichTextBlock()
+    {
+        // Nested simple lists are still simple (all children mergeable), so the
+        // whole tree flows into one RichTextBlock.
+        var element = ChatMarkdownRenderer.Render(
+            "- parent\n    - child one\n    - child two\n- sibling");
+
+        Assert.IsType<RichTextBlockElement>(element);
+    }
+
+    [Fact]
+    public void ListContainingNonTextBlock_StaysSeparateIsland()
+    {
+        // A list item with a block quote (any non-text child, e.g. a code block
+        // or table too) is NOT simple — it keeps the Grid-based island so the
+        // child's chrome survives. The intro prose stays its own sibling.
+        // A block quote is used here rather than a code block because it renders
+        // without eager WinRT activation, keeping this record-level test
+        // runtime-free.
+        var element = ChatMarkdownRenderer.Render(
+            "intro paragraph\n\n- item one\n\n- item two\n\n  > side note");
 
         var stack = Assert.IsType<StackElement>(element);
         Assert.Equal(Microsoft.UI.Xaml.Controls.Orientation.Vertical, stack.Orientation);
         Assert.Equal(2, stack.Children.Count);
 
-        Assert.IsType<RichTextBlockElement>(stack.Children[0]!);
-        // The list remains its own StackElement (unchanged rendering).
+        // Lone intro paragraph keeps the lightweight TextBlock shape.
+        Assert.IsType<TextBlockElement>(stack.Children[0]!);
+        // The complex list remains its own StackElement island.
         Assert.IsType<StackElement>(stack.Children[1]!);
     }
 }

--- a/tests/OpenClaw.Tray.UITests/MarkdownRendererListTests.cs
+++ b/tests/OpenClaw.Tray.UITests/MarkdownRendererListTests.cs
@@ -20,6 +20,13 @@ namespace OpenClaw.Tray.UITests;
 /// (<c>Auto</c> marker + <c>*</c> content). The Star column gives the content
 /// a finite measure width, so wrap works correctly.
 ///
+/// Note: as of the RichTextBlock coalescing change, "simple" lists (whose items
+/// contain only text) now flow into a <see cref="RichTextBlockElement"/> for
+/// continuous selection, and RichTextBlock wraps inherently. The Grid path below
+/// is therefore exercised by "complex" lists (an item carrying a code block,
+/// table, etc.), which still render as their own island — so these regression
+/// guards use complex-list fixtures.
+///
 /// These assertions live at the FunctionalUI <see cref="Element"/> record level
 /// (no WinUI runtime needed) because that's where the regression would surface:
 /// any change of the row container back to a horizontal stack would fail these
@@ -27,19 +34,30 @@ namespace OpenClaw.Tray.UITests;
 /// </summary>
 public sealed class MarkdownRendererListTests
 {
+    // A "complex" list forces the Grid island path: item two carries a block
+    // quote, so the list is not simple and does not coalesce into a
+    // RichTextBlock. A block quote renders without eager WinRT activation
+    // (unlike a fenced code block, whose FontFamily throws headless), so these
+    // record-level tests stay runtime-free. Item one's long bullet still
+    // exercises the wrap guard.
+    private const string ComplexUnorderedList =
+        "- This is an unusually long bullet that must wrap across multiple " +
+        "lines instead of being clipped at the right edge of the chat bubble.\n\n" +
+        "- second item\n\n  > side note";
+
+    private const string ComplexOrderedList =
+        "1. first item\n\n2. second item\n\n   > side note";
+
     [Fact]
     public void UnorderedListRow_IsGridWithAutoMarkerAndStarContent()
     {
-        const string longBullet =
-            "- This is an unusually long bullet that must wrap across multiple " +
-            "lines instead of being clipped at the right edge of the chat bubble.";
-
-        var element = ChatMarkdownRenderer.Render(longBullet);
+        var element = ChatMarkdownRenderer.Render(ComplexUnorderedList);
 
         var list = Assert.IsType<StackElement>(element);
         Assert.Equal(Microsoft.UI.Xaml.Controls.Orientation.Vertical, list.Orientation);
-        Assert.Single(list.Children);
+        Assert.Equal(2, list.Children.Count);
 
+        // Row 0 is the long-text bullet — the row whose wrapping issue #636 fixed.
         var row = Assert.IsType<GridElement>(list.Children[0]!);
         AssertListRowShape(row);
     }
@@ -47,13 +65,11 @@ public sealed class MarkdownRendererListTests
     [Fact]
     public void OrderedListRows_EachUseGridWithAutoMarkerAndStarContent()
     {
-        const string ordered = "1. first item\n2. second item\n3. third item";
-
-        var element = ChatMarkdownRenderer.Render(ordered);
+        var element = ChatMarkdownRenderer.Render(ComplexOrderedList);
 
         var list = Assert.IsType<StackElement>(element);
         Assert.Equal(Microsoft.UI.Xaml.Controls.Orientation.Vertical, list.Orientation);
-        Assert.Equal(3, list.Children.Count);
+        Assert.Equal(2, list.Children.Count);
 
         foreach (var child in list.Children)
         {
@@ -67,9 +83,7 @@ public sealed class MarkdownRendererListTests
     {
         // Direct guard against the original regression: if anyone reverts the
         // row container to HStack(...), this fails with a clear message.
-        const string bullet = "- something";
-
-        var element = ChatMarkdownRenderer.Render(bullet);
+        var element = ChatMarkdownRenderer.Render(ComplexUnorderedList);
 
         var list = Assert.IsType<StackElement>(element);
         var row = list.Children[0];
@@ -78,6 +92,19 @@ public sealed class MarkdownRendererListTests
                 $"List row regressed to a {stackRow.Orientation} StackElement. " +
                 "Issue #636 requires a GridElement so the content column gets " +
                 "a finite measure width and TextBlock wrap works.");
+    }
+
+    [Fact]
+    public void SimpleList_RendersAsRichTextBlockForContinuousSelection()
+    {
+        // A simple text-only list now coalesces into a RichTextBlock so it is
+        // one continuous selection scope with surrounding prose. RichTextBlock
+        // wraps inherently, so the issue #636 clipping does not recur here.
+        var element = ChatMarkdownRenderer.Render(
+            "- This is an unusually long bullet that must wrap across multiple " +
+            "lines instead of being clipped at the right edge of the chat bubble.");
+
+        Assert.IsType<RichTextBlockElement>(element);
     }
 
     private static void AssertListRowShape(GridElement row)

--- a/tests/OpenClawTray.FunctionalUI.Tests/RichTextBlockElementTests.cs
+++ b/tests/OpenClawTray.FunctionalUI.Tests/RichTextBlockElementTests.cs
@@ -1,0 +1,54 @@
+using OpenClawTray.FunctionalUI.Core;
+using static OpenClawTray.FunctionalUI.Factories;
+
+namespace OpenClawTray.FunctionalUI.Tests;
+
+/// <summary>
+/// Record-level tests for the <see cref="RichTextBlockElement"/> primitive.
+///
+/// The reconciler that materializes elements into WinUI controls needs a live
+/// dispatcher, so these tests assert the element-graph contract only: the
+/// factory shape, that <c>Set(Action&lt;RichTextBlock&gt;)</c> captures a
+/// setter, and that generic modifiers flow onto the element. The chat renderer
+/// relies on all three to give a whole message one continuous selection scope.
+/// </summary>
+public sealed class RichTextBlockElementTests
+{
+    [Fact]
+    public void RichTextBlock_Factory_CreatesRichTextBlockElement()
+    {
+        var element = RichTextBlock();
+
+        Assert.IsType<RichTextBlockElement>(element);
+        Assert.Empty(element.Setters);
+    }
+
+    [Fact]
+    public void Set_CapturesSetterDelegate_AndReturnsSameElementType()
+    {
+        var element = RichTextBlock().Set(_ => { });
+
+        Assert.IsType<RichTextBlockElement>(element);
+        Assert.Single(element.Setters);
+    }
+
+    [Fact]
+    public void Set_IsAdditive_PreservingSetterOrder()
+    {
+        var order = new List<int>();
+
+        var element = RichTextBlock()
+            .Set(_ => order.Add(1))
+            .Set(_ => order.Add(2));
+
+        Assert.Equal(2, element.Setters.Count);
+    }
+
+    [Fact]
+    public void Modifiers_FlowOntoRichTextBlockElement()
+    {
+        var element = RichTextBlock().FontSize(14);
+
+        Assert.Equal(14, element.Modifiers.FontSize);
+    }
+}


### PR DESCRIPTION
Related: #995
Related: #996

## What Problem This Solves

In the tray chat timeline, a message's text was fragmented into many separate text controls: each paragraph, heading, and list item was its own box. A user could not drag-select a whole assistant reply in one gesture, which was awkward and annoying when trying to copy part of an answer.

## Why This Change Was Made

Each chat message now renders through a single per-message `RichTextBlock`, and consecutive prose (paragraphs + headings) plus simple text-only lists (bullet / ordered / task, including nested) coalesce into that one control, so the whole run is one continuous drag-selection scope.

Blocks that need their own chrome stay as separate selectable islands: code blocks, tables, block quotes, thematic breaks, and any list whose items contain one of those. This split is a WinUI constraint, not a preference: `InlineUIContainer` is excluded from `SelectedText` and breaks selection at its boundary, and there is no built-in way to run one selection across multiple controls. So chrome-bearing content cannot be embedded inline without losing selection.

Supporting pieces:
- A `RichTextBlock` primitive added to the in-house `OpenClawTray.FunctionalUI` layer (factory, `Set`, modifiers).
- Simple lists render as hanging-indent paragraphs inside the shared `RichTextBlock` (per-item marker, fixed hanging indent so wrapped lines align at the content column, per-level nesting, heading formatting preserved).
- A structural block-equality cache so a re-render or AST cache reparse of unchanged content does not clear and rebuild the blocks, which would wipe the user's active selection.
- The existing per-message Copy button remains the whole-message grab across islands.

The larger follow-ups are tracked separately: a custom cross-control selection engine for whole-transcript selection (#995), and porting FunctionalUI to Reactor to stop hand-maintaining bespoke primitives (#996).

## User Impact

Users can drag-select an assistant reply's prose and bullet / numbered lists as one continuous selection instead of fighting per-line boxes. Code blocks and tables stay distinctly styled and individually selectable. No change to how messages are authored or sent.

## Evidence

Record-level renderer tests assert the Element shape directly: prose + a simple list collapses to one `RichTextBlockElement`, while a list containing a non-text block stays its own island. A live-runtime UI-thread test (`ChatBubbleSelectionScopeProofTests`) additionally proves the shipping renderer on a real WinRT thread. Full required suites plus focused renderer tests pass (counts below).

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

All run on branch head `d9e2b995` (ARM64 host, `-p:Platform=x64` for WinUI/UITests):

- `./build.ps1` -> all 5 projects built successfully
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj` -> Passed 2754, Skipped 31, Failed 0
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj` -> Passed 1705, Failed 0
- `dotnet test ./tests/OpenClawTray.FunctionalUI.Tests/...` -> Passed 14, Failed 0
- `dotnet test ./tests/OpenClaw.Tray.UITests/...` -> Passed 107, Failed 0 (adds the deterministic selection-scope proof on head `d9e2b995`)
- Focused: `--filter FullyQualifiedName~MarkdownRenderer` -> Passed 12, Failed 0

## Real Behavior Proof

<img width="1027" height="635" alt="image" src="https://github.com/user-attachments/assets/8bb0441a-380c-4483-ac22-26e684c51c6d" />

**Deterministic renderer proof (head `d9e2b995`).** `tests/OpenClaw.Tray.UITests/ChatBubbleSelectionScopeProofTests.cs` mounts the real `OpenClawChatTimeline` through the shipping FunctionalUI reconciler on a live WinRT UI thread and renders one assistant message (two prose paragraphs, a three-item bullet list, a trailing paragraph, a fenced code block, and a table). It asserts: prose + list + trailing paragraph land in ONE `RichTextBlock` (one continuous selection scope); the code and table text are absent from that `RichTextBlock`; and each renders in its own separate `TextBlock` island. Run: `dotnet test .\tests\OpenClaw.Tray.UITests\OpenClaw.Tray.UITests.csproj -p:Platform=x64 --filter FullyQualifiedName~ChatBubbleSelectionScopeProof` -> Passed 1/1. This is the automated stand-in for the interactive native drag recording, which is a human-captured artifact.

- Environment tested: isolated dev app (Release identity, ARM64 Debug) against the managed `OpenClawGateway` WSL distro; focused renderer tests headless; deterministic proof on a live WinRT UI-thread fixture.
- PR head or commit tested: `d9e2b995`
- Exact steps or command run: (1) `dotnet test --filter FullyQualifiedName~MarkdownRenderer -p:Platform=x64`; (2) `dotnet test --filter FullyQualifiedName~ChatBubbleSelectionScopeProof -p:Platform=x64`; (3) relaunched the isolated app (`run-app-local.ps1 -NoBuild -Isolated -AllowNonMain`) to drag-select a message containing prose + a bullet list + a fenced code block.
- Evidence after fix: `MarkdownRendererCoalesceTests` / `MarkdownRendererListTests` assert prose + simple list -> one `RichTextBlockElement`, lone simple list -> `RichTextBlockElement`, and a list containing a block quote -> separate `StackElement` island (12/12). `ChatBubbleSelectionScopeProofTests` proves the same contract end-to-end through the shipping renderer on a real UI thread including code/table islands (1/1).
- Observed result: prose and simple lists render into one selectable `RichTextBlock`; code blocks and tables stay their own styled islands; Copy button grabs the whole message.
- Screenshot or artifact links verified? Yes (screenshot above)
- Not verified or blocked: Live drag-selection video not captured in this automated session; the six-step recipe in the reviewer thread reproduces it manually and the deterministic UI-thread test is the automated substitute. Second-model `autoreview` could not run because `codex`/`claude`/`pi` CLIs are not installed in this environment; a rubber-duck review did run and both findings (heading-in-list formatting, true hanging indent) were fixed.

## Security Impact

- New permissions or capabilities? No
- Secrets or tokens handling changed? No
- New or changed network calls? No
- Command or tool execution surface changed? No
- Data access scope changed? No
- Inert-markdown posture preserved: no `Hyperlink` / `BitmapImage` introduced, `AppendInlines` unchanged, rendering stays non-interactive.

## Compatibility and Migration

- Backward compatible? Yes
- Config or environment changes? No
- Migration needed? No

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.