### PR TITLE
chore: experiment with trimmed winnode publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,6 +525,57 @@ jobs:
         name: openclaw-tray-${{ matrix.rid }}
         path: publish/
 
+  build-winnode:
+    needs: [test]
+    runs-on: ${{ matrix.rid == 'win-arm64' && 'windows-11-arm' || 'windows-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rid: [win-x64, win-arm64]
+
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Setup .NET 10
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Cache NuGet packages
+      continue-on-error: true
+      uses: actions/cache@v6
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+        restore-keys: nuget-${{ runner.os }}-
+
+    - name: Restore WinNode CLI
+      run: dotnet restore src/OpenClaw.WinNode.Cli -r ${{ matrix.rid }}
+
+    - name: Publish Trimmed WinNode CLI
+      run: dotnet publish src/OpenClaw.WinNode.Cli -c Release -r ${{ matrix.rid }} --self-contained --no-restore -o publish-winnode
+
+    - name: Verify Shared Assembly Was Not Trimmed
+      shell: pwsh
+      run: |
+        $buildAssembly = "src\OpenClaw.Shared\bin\Release\net10.0\OpenClaw.Shared.dll"
+        $publishAssembly = "publish-winnode\OpenClaw.Shared.dll"
+        $buildHash = (Get-FileHash $buildAssembly -Algorithm SHA256).Hash
+        $publishHash = (Get-FileHash $publishAssembly -Algorithm SHA256).Hash
+        if ($buildHash -ne $publishHash) {
+          throw "OpenClaw.Shared.dll changed during trimmed winnode publish."
+        }
+
+    - name: Smoke Test Trimmed WinNode CLI
+      shell: pwsh
+      run: |
+        & .\publish-winnode\winnode.exe --help
+        if ($LASTEXITCODE -ne 0) {
+          throw "Trimmed winnode --help failed with exit code $LASTEXITCODE."
+        }
+
   build-msix:
     needs: [test, e2etests]
     if: false # Paused for alpha.4; ship Inno setup and portable ZIP artifacts only.

--- a/src/OpenClaw.WinNode.Cli/OpenClaw.WinNode.Cli.csproj
+++ b/src/OpenClaw.WinNode.Cli/OpenClaw.WinNode.Cli.csproj
@@ -6,6 +6,8 @@
     <RootNamespace>OpenClaw.WinNode.Cli</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,4 +24,17 @@
   <ItemGroup>
     <InternalsVisibleTo Include="OpenClaw.WinNode.Cli.Tests" />
   </ItemGroup>
+
+  <!-- Shared owns reflection-heavy tray/node code. Copy it unchanged until
+       those surfaces are independently trim-safe; only trim the CLI/framework. -->
+  <Target Name="PreserveOpenClawSharedDuringTrim"
+          BeforeTargets="_ComputeManagedAssemblyToLink"
+          Condition="'$(PublishTrimmed)' == 'true'">
+    <ItemGroup>
+      <ResolvedFileToPublish Update="@(ResolvedFileToPublish)"
+                             Condition="'%(Filename)' == 'OpenClaw.Shared'">
+        <PostprocessAssembly>false</PostprocessAssembly>
+      </ResolvedFileToPublish>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/OpenClaw.WinNode.Cli/Program.cs
+++ b/src/OpenClaw.WinNode.Cli/Program.cs
@@ -459,7 +459,15 @@ internal static class CliRunner
         RegexOptions.Compiled);
 
     internal static string PrettyPrint(JsonElement element)
-        => JsonSerializer.Serialize(element, new JsonSerializerOptions { WriteIndented = true });
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true }))
+        {
+            element.WriteTo(writer);
+        }
+
+        return Encoding.UTF8.GetString(stream.GetBuffer(), 0, checked((int)stream.Length));
+    }
 
     /// <summary>
     /// Build the tools/call JSON-RPC envelope. Returns the buffer + length so

--- a/tests/OpenClaw.WinNode.Cli.Tests/PublishConfigurationTests.cs
+++ b/tests/OpenClaw.WinNode.Cli.Tests/PublishConfigurationTests.cs
@@ -1,0 +1,50 @@
+using System.Xml.Linq;
+
+namespace OpenClaw.WinNode.Cli.Tests;
+
+public class PublishConfigurationTests
+{
+    [Fact]
+    public void WinNode_publish_uses_conservative_partial_trimming()
+    {
+        var project = XDocument.Load(FindProjectFile());
+        var properties = project.Root!
+            .Elements("PropertyGroup")
+            .SelectMany(group => group.Elements())
+            .ToDictionary(element => element.Name.LocalName, element => element.Value);
+
+        Assert.Equal("true", properties["PublishTrimmed"]);
+        Assert.Equal("partial", properties["TrimMode"]);
+
+        var preserveTarget = Assert.Single(
+            project.Root!.Elements("Target"),
+            target => (string?)target.Attribute("Name") == "PreserveOpenClawSharedDuringTrim");
+        Assert.Equal("_ComputeManagedAssemblyToLink", (string?)preserveTarget.Attribute("BeforeTargets"));
+
+        var sharedUpdate = Assert.Single(
+            preserveTarget.Descendants("ResolvedFileToPublish"),
+            item => ((string?)item.Attribute("Condition"))?.Contains(
+                "OpenClaw.Shared",
+                StringComparison.Ordinal) == true);
+        Assert.Equal("false", sharedUpdate.Element("PostprocessAssembly")?.Value);
+    }
+
+    private static string FindProjectFile()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(
+                directory.FullName,
+                "src",
+                "OpenClaw.WinNode.Cli",
+                "OpenClaw.WinNode.Cli.csproj");
+            if (File.Exists(candidate))
+                return candidate;
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException("Could not locate OpenClaw.WinNode.Cli.csproj.");
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

This draft explores whether the standalone `winnode` CLI can be safely tree-trimmed before we decide to distribute it independently. Today, `winnode` is not included in the GitHub release installer or portable ZIP, so this experiment does **not** reduce current OpenClaw Companion release assets.

## Why This Change Was Made

The experiment enables conservative partial trimming for `winnode` while copying `OpenClaw.Shared.dll` unchanged. It removes the CLI's reflection-based JSON pretty-print call and adds an independent x64/ARM64 CI job that publishes the trimmed CLI, verifies the Shared assembly remains byte-identical, and smoke-runs the executable.

The WinNode CI job is separate from Tray artifact publishing and is not a dependency of the release job. This PR intentionally does not trim or otherwise alter the Tray application.

## User Impact

No current user-visible impact. This is an experiment for a possible future standalone `winnode` distribution.

Measured standalone x64 output:

| Variant | Folder | ZIP |
|---|---:|---:|
| Self-contained, untrimmed | 115.73 MiB | 50.87 MiB |
| Self-contained, partial trim | 60.24 MiB | 25.56 MiB |
| Savings | 55.49 MiB (47.9%) | 25.31 MiB (49.8%) |

Latest GitHub release v0.6.12 remains unchanged: x64 installer 114.12 MiB, ARM64 installer 99.90 MiB, x64 ZIP 141.64 MiB, ARM64 ZIP 133.04 MiB.

## Evidence

- x64 trimmed publish: 60.24 MiB, 112 files, `winnode.exe --help` exited 0.
- ARM64 trimmed publish: 61.71 MiB, 112 files, `winnode.exe --help` exited 0 on an ARM64 host.
- `OpenClaw.Shared.dll` SHA-256 matched its pre-link build output immediately after both publish sequences.
- Publish completed with trim diagnostics treated as errors; no trim warnings were suppressed.
- Final rubber-duck review found no blocking or non-blocking issues after the WinNode CI gate was separated from Tray publishing.

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [x] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [x] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `./build.ps1` — passed; Shared, CLI, WinNode CLI, SetupEngine, and WinUI built successfully for win-arm64.
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — 2,863 passed, 31 skipped, 0 failed.
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — 1,717 passed, 0 failed.
- `dotnet test ./tests/OpenClaw.WinNode.Cli.Tests/OpenClaw.WinNode.Cli.Tests.csproj --no-restore` — 127 passed, 0 failed.
- `dotnet publish ./src/OpenClaw.WinNode.Cli/OpenClaw.WinNode.Cli.csproj -c Release -r win-x64 --self-contained true` — passed; Shared hash matched; `--help` passed.
- `dotnet publish ./src/OpenClaw.WinNode.Cli/OpenClaw.WinNode.Cli.csproj -c Release -r win-arm64 --self-contained true` — passed; Shared hash matched; `--help` passed.

## Real Behavior Proof

- Environment tested: Windows 11 ARM64, .NET SDK 10.0.302; x64 publish exercised under Windows emulation and ARM64 publish exercised natively.
- PR head or commit tested: `af85963f`
- Exact steps or command run: publish each RID self-contained, compare SHA-256 of built and published `OpenClaw.Shared.dll`, then run the published `winnode.exe --help`.
- Evidence after fix: x64 60.24 MiB; ARM64 61.71 MiB; hash comparisons true; both executables exited 0.
- Observed result: conservative trimming removes about 48% of the standalone folder while preserving Shared byte-for-byte.
- Screenshot or artifact links verified? N/A
- Not verified or blocked: no live isolated-Tray MCP roundtrip was available locally. Before promotion from experiment, test the published binary on a clean second machine with no .NET SDK/runtime, run `winnode --list-tools`, and invoke a safe command such as `system.which` against an isolated Tray profile.

## Security Impact

- New permissions or capabilities? No
- Secrets or tokens handling changed? No
- New or changed network calls? No
- Command or tool execution surface changed? No
- Data access scope changed? No
- If any answer is `Yes`, explain the risk and mitigation: N/A

## Compatibility and Migration

- Backward compatible? Expected yes; still experimental pending clean-machine proof.
- Config or environment changes? No
- Migration needed? No
- If yes, list the exact upgrade steps: N/A

## Experiment Risks

- The preservation hook attaches to the SDK-private `_ComputeManagedAssemblyToLink` target; a future SDK update could change that ordering. CI therefore verifies `OpenClaw.Shared.dll` byte-for-byte on both RIDs.
- Existing unit tests execute the normal test assembly, not every path through the published executable.
- Future `winnode` code that calls additional Shared functionality may require new published-binary tests.
- The CLI still carries speech/ONNX/native assets inherited from `OpenClaw.Shared`; trimming does not solve that dependency-boundary problem.
- The structured autoreview helper could not run because its secret scanner treated the existing `OPENCLAW_MCP_TOKEN` identifier in `Program.cs` as secret-like content. No secrets were added or changed.

## Second-Machine Test Plan

1. Download or build the x64/ARM64 `publish-winnode` output on a clean Windows machine without the .NET runtime installed.
2. Run `winnode.exe --help`.
3. Launch the Tray with isolated data and enable Local MCP Server.
4. Set `OPENCLAW_TRAY_DATA_DIR` to that isolated profile.
5. Run `winnode.exe --list-tools`.
6. Run `winnode.exe --command system.which --params '{"bins":["git","node","powershell"]}'`.
7. Confirm output and exit codes match an untrimmed publish.

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.