### PR TITLE
chore: remove dead unused Process allocation in GetProcessCommandLine

### DIFF
--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -3615,7 +3615,6 @@ public sealed class StartKeepaliveStep : SetupStep
         try
         {
             // Use WMI to get the command line
-            var result = new System.Diagnostics.Process();
             var psi = new System.Diagnostics.ProcessStartInfo("powershell.exe",
                 $"-NoProfile -Command \"(Get-CimInstance Win32_Process -Filter 'ProcessId={pid}').CommandLine\"")
             {


### PR DESCRIPTION
Related: #1003

## What Problem This Solves

This is a small code-quality cleanup, not a user-facing fix. While auditing the node's disposal paths, `SetupSteps.GetProcessCommandLine` was found to allocate a `System.Diagnostics.Process` it never uses:

```csharp
// Use WMI to get the command line
var result = new System.Diagnostics.Process();   // never referenced again
var psi = new System.Diagnostics.ProcessStartInfo("powershell.exe", ...);
using var p = System.Diagnostics.Process.Start(psi);   // the method's real work
```

`result` is assigned once and never read — the method does everything through the separate, properly-`using`'d `p`. It's a leftover. (It's `IDisposable`, but since it's never `Start()`ed it holds no OS handle, so this is dead code, not a resource leak.)

## Why This Change Was Made

Delete the unused `result` allocation; keep the `// Use WMI` comment (it describes the actual query below it). No other change. Found with `klammerkrebs`, a Roslyn `IDisposable` analyzer (candidate surfaced by the tool, then confirmed by reading the method). Non-goal: the other candidates from the same audit are async-only `SemaphoreSlim`/`CTS` fields that are correct left as-is — see #1003 for the analysis.

## User Impact

None. `GetProcessCommandLine` behaves identically; the removed variable was never used.

## Evidence

One-line deletion:

```
 src/OpenClaw.SetupEngine/SetupSteps.cs | 1 -
 1 file changed, 1 deletion(-)
```

The project compiles clean after removal (proving `result` was unreferenced), and the affected project's tests pass. Details in Validation below.

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [ ] Tests or validation
- [ ] Security hardening
- [x] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [x] Setup or onboarding
- [ ] Permissions, privacy, or security
- [ ] Tests, CI, or docs

## Validation

Validated on macOS (dotnet 10.0.302); the Windows-only required steps (`./build.ps1`, `Tray.Tests`) and the full test matrix run on CI (`windows-latest`).

```
# build the affected project — compiles clean, confirming `result` was unreferenced
dotnet build src/OpenClaw.SetupEngine/OpenClaw.SetupEngine.csproj -c Debug
  → Build succeeded.

# affected project's tests
dotnet test tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj -c Debug
  → Failed: 1, Passed: 422, Total: 423

# required closeout (unaffected by this change; runs for contract compliance)
dotnet test tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj -c Debug
  → Failed: 28, Passed: 2835, Skipped: 31, Total: 2894
```

The failures are **pre-existing macOS-environment failures, not caused by this change**: the 1 SetupEngine failure asserts a hardcoded Windows path (`...\OpenClawTray` vs macOS `Path.Combine` `/`) and fails identically on the un-patched base; the 28 Shared failures are all exec-approval / executable-resolution / argv / command tests that require Windows behavior. This change is a one-line deletion in `OpenClaw.SetupEngine` and cannot affect `OpenClaw.Shared`. All are green on the Windows CI matrix.

## Real Behavior Proof

- Environment tested: macOS 15 (dotnet 10.0.302); Windows matrix via CI (`windows-latest`)
- PR head or commit tested: `4750440`
- Exact steps or command run: `dotnet build` + `dotnet test` on the affected project (above)
- Evidence after fix: project compiles with the line removed; `result` was the sole occurrence, so the deletion is behavior-preserving
- Observed result: no behavior change — `GetProcessCommandLine` still runs its query through `p`
- Screenshot or artifact links verified? `N/A` (no UI / no behavior change)
- Not verified or blocked: `./build.ps1` and the Windows-only test suites are not runnable on macOS; covered by upstream CI

## Security Impact

- New permissions or capabilities? `No`
- Secrets or tokens handling changed? `No`
- New or changed network calls? `No`
- Command or tool execution surface changed? `No` (the removed variable was never used; the actual `Process.Start(psi)` is untouched)
- Data access scope changed? `No`

## Compatibility and Migration

- Backward compatible? `Yes`
- Config or environment changes? `No`
- Migration needed? `No`

## Review Conversations

- [ ] I replied to or resolved every bot review conversation addressed by this PR.
- [ ] I left unresolved only conversations that still need maintainer judgment.
