### PR TITLE
fix: screen and camera capture continue after cancellation

### DIFF
--- a/docs/CONNECTION_ARCHITECTURE.md
+++ b/docs/CONNECTION_ARCHITECTURE.md
@@ -16,6 +16,14 @@ OpenClaw.Tray.WinUI (net10.0-windows) — UI app, tray icon, pages, windows
 
 **OpenClaw.Shared** owns the low-level gateway clients (`OpenClawGatewayClient`, `WindowsNodeClient`, `WebSocketClientBase`), device identity/signing (`DeviceIdentity`), protocol models, and the `IOperatorGatewayClient` interface.
 
+`WindowsNodeClient` also owns gateway invocation lifetime at the transport
+boundary. Active invokes are registered by invoke ID in a focused cancellation
+registry, linked to the node connection lifetime, and cancelled individually by
+the gateway `node.invoke.cancel` event. Active invocations atomically transition
+to cancelled or completed when capability execution returns; whichever
+transition wins determines the protocol outcome. Capability implementations
+remain responsible for cooperative cancellation of their own underlying work.
+
 **OpenClaw.Connection** owns all connection management: `GatewayConnectionManager`, `GatewayRegistry`, `CredentialResolver`, `ConnectionStateMachine`, `NodeConnector`, `SshTunnelService/Manager`, `SetupCodeDecoder`, and all connection interfaces/DTOs/enums. This project has zero WinUI dependencies and is independently testable.
 
 **OpenClaw.Tray.WinUI** consumes the connection layer through interfaces. It never creates gateway clients directly — `GatewayConnectionManager` owns that entirely.

--- a/docs/MCP_MODE.md
+++ b/docs/MCP_MODE.md
@@ -81,10 +81,13 @@ The capability list lives on `NodeService`, *not* on `WindowsNodeClient`. That s
   transport has no client identity, duplicate active IDs are allowed and
   cancellation is ignored when more than one active call matches; this prevents
   one local client from cancelling another client when the collision is already
-  observable. A tombstone cannot predict a later cross-client ID collision, so
-  it cancels the first matching registration; complete isolation would require
-  client identity in the transport. A recent completion guard also prevents a
-  late notification from poisoning immediate ID reuse.
+  observable. Request matching uses the decoded JSON string value or normalized
+  arbitrary-precision JSON number value, while preserving the distinction
+  between string and numeric IDs. A tombstone cannot predict a later
+  cross-client ID collision, so it cancels the first matching registration;
+  complete isolation would require client identity in the transport. A recent
+  completion guard also prevents a late notification from poisoning immediate
+  ID reuse.
 
 The bridge takes a `Func<IReadOnlyList<INodeCapability>>` rather than a snapshot. Every `tools/list` re-reads the live list. This is what guarantees zero-cost capability addition — register a new capability after server start and it appears on the next `tools/list`.
 

--- a/docs/MCP_MODE.md
+++ b/docs/MCP_MODE.md
@@ -70,10 +70,21 @@ The capability list lives on `NodeService`, *not* on `WindowsNodeClient`. That s
   supplied as `params.requestId`. A cancelled `tools/call` completes with an MCP
   tool error containing `cancelled`. If concurrent HTTP scheduling processes
   cancellation just before an already-sent call registers, the notification
-  waits briefly and retries. Because JSON-RPC IDs are client-scoped but this
-  stateless HTTP transport has no client identity, duplicate active IDs are
-  allowed and cancellation is ignored when more than one active call matches;
-  this prevents one local client from cancelling another client's call.
+  records a pending cancellation for five seconds. The first matching
+  registration atomically consumes that tombstone and returns `cancelled` before
+  capability execution begins, so correctness does not depend on scheduler
+  timing. Repeated notifications for the same pending ID do not extend its
+  original five-second lifetime. Pending cancellations and recent-completion
+  guards are each capped at 1,024 entries;
+  expired entries are pruned first and the oldest remaining entry is evicted at
+  capacity. Because JSON-RPC IDs are client-scoped but this stateless HTTP
+  transport has no client identity, duplicate active IDs are allowed and
+  cancellation is ignored when more than one active call matches; this prevents
+  one local client from cancelling another client when the collision is already
+  observable. A tombstone cannot predict a later cross-client ID collision, so
+  it cancels the first matching registration; complete isolation would require
+  client identity in the transport. A recent completion guard also prevents a
+  late notification from poisoning immediate ID reuse.
 
 The bridge takes a `Func<IReadOnlyList<INodeCapability>>` rather than a snapshot. Every `tools/list` re-reads the live list. This is what guarantees zero-cost capability addition — register a new capability after server start and it appears on the next `tools/list`.
 

--- a/docs/MCP_MODE.md
+++ b/docs/MCP_MODE.md
@@ -66,8 +66,22 @@ The capability list lives on `NodeService`, *not* on `WindowsNodeClient`. That s
 - `tools/list` — flattens `_capabilities` into MCP tools. Tool name = command name (`"screen.snapshot"`); known commands get curated descriptions from `McpToolBridge.CommandDescriptions`; unknown commands fall back to `"{category} capability: {command}"`. `inputSchema` is permissive.
 - `tools/call` — finds the capability via `INodeCapability.CanHandle(name)`, builds a `NodeInvokeRequest` (the same struct the gateway path uses), calls `ExecuteAsync`, wraps the result as MCP `content[].text`. Tool failures come back as `result.isError = true`, not JSON-RPC errors (per MCP spec — JSON-RPC errors are reserved for protocol issues).
 - `ping`, `notifications/initialized` — protocol housekeeping.
+- `notifications/cancelled` — cancels the active request whose JSON-RPC ID is
+  supplied as `params.requestId`. A cancelled `tools/call` completes with an MCP
+  tool error containing `cancelled`. If concurrent HTTP scheduling processes
+  cancellation just before an already-sent call registers, the notification
+  waits briefly and retries. Because JSON-RPC IDs are client-scoped but this
+  stateless HTTP transport has no client identity, duplicate active IDs are
+  allowed and cancellation is ignored when more than one active call matches;
+  this prevents one local client from cancelling another client's call.
 
 The bridge takes a `Func<IReadOnlyList<INodeCapability>>` rather than a snapshot. Every `tools/list` re-reads the live list. This is what guarantees zero-cost capability addition — register a new capability after server start and it appears on the next `tools/list`.
+
+Cancellation is cooperative and uses the same `CancellationToken` capability
+contract as the gateway transport. Screen and camera operations propagate the
+token through recording consent/countdown, camera admission, capture waits, and
+recording shutdown. The HTTP request deadline remains a separate safety bound;
+no command-specific transport deadlines are applied.
 
 ### HTTP transport
 

--- a/docs/WINDOWS_NODE_TESTING.md
+++ b/docs/WINDOWS_NODE_TESTING.md
@@ -91,6 +91,22 @@ These features need the gateway to send `node.invoke` commands:
 | `stt.listen` | Voice-activity microphone transcription | Returns when the user stops speaking or timeout expires |
 | `stt.status` | Speech-to-text readiness | Returns Whisper.net model download/readiness state |
 
+### Cancelling an invocation
+
+The gateway may send the `node.invoke.cancel` event with
+`payload.invokeId` matching an active `node.invoke.request`. The Windows node
+cancels only that invocation and completes its original result with
+`ok: false, error: "cancelled"`; unknown or already-completed IDs are ignored.
+The legacy `payload.requestId` spelling is also accepted for compatibility.
+Operation completion is the linearization point: once capability execution
+returns and atomically marks the invocation complete, later cancellation is too
+late and the completed result is preserved.
+
+For local MCP, send a JSON-RPC `notifications/cancelled` notification with
+`params.requestId` matching the active `tools/call` JSON-RPC ID. Cancellation
+must stop queued camera admission, recording delays/frame waits, and active
+recording cleanup rather than only abandoning the HTTP waiter.
+
 ## Capabilities Advertised
 
 When the node connects, it advertises these capabilities:

--- a/src/OpenClaw.Shared/Capabilities/CameraCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/CameraCapability.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace OpenClaw.Shared.Capabilities;
@@ -21,9 +22,9 @@ public class CameraCapability : NodeCapabilityBase
     public override IReadOnlyList<string> Commands => _commands;
     
     // Events for platform-specific implementation
-    public event Func<Task<CameraInfo[]>>? ListRequested;
-    public event Func<CameraSnapArgs, Task<CameraSnapResult>>? SnapRequested;
-    public event Func<CameraClipArgs, Task<CameraClipResult>>? ClipRequested;
+    public event Func<CancellationToken, Task<CameraInfo[]>>? ListRequested;
+    public event Func<CameraSnapArgs, CancellationToken, Task<CameraSnapResult>>? SnapRequested;
+    public event Func<CameraClipArgs, CancellationToken, Task<CameraClipResult>>? ClipRequested;
     
     public CameraCapability(IOpenClawLogger logger) : base(logger)
     {
@@ -32,18 +33,25 @@ public class CameraCapability : NodeCapabilityBase
     private static int Clamp(int value, int min, int max)
         => value < min ? min : (value > max ? max : value);
     
-    public override async Task<NodeInvokeResponse> ExecuteAsync(NodeInvokeRequest request)
+    public override Task<NodeInvokeResponse> ExecuteAsync(NodeInvokeRequest request)
+        => ExecuteAsync(request, CancellationToken.None);
+
+    public override async Task<NodeInvokeResponse> ExecuteAsync(
+        NodeInvokeRequest request,
+        CancellationToken cancellationToken)
     {
         return request.Command switch
         {
-            "camera.list" => await HandleListAsync(request),
-            "camera.snap" => await HandleSnapAsync(request),
-            "camera.clip" => await HandleClipAsync(request),
+            "camera.list" => await HandleListAsync(request, cancellationToken),
+            "camera.snap" => await HandleSnapAsync(request, cancellationToken),
+            "camera.clip" => await HandleClipAsync(request, cancellationToken),
             _ => Error($"Unknown command: {request.Command}")
         };
     }
     
-    private async Task<NodeInvokeResponse> HandleListAsync(NodeInvokeRequest request)
+    private async Task<NodeInvokeResponse> HandleListAsync(
+        NodeInvokeRequest request,
+        CancellationToken cancellationToken)
     {
         Logger.Info("camera.list");
         
@@ -54,8 +62,14 @@ public class CameraCapability : NodeCapabilityBase
         
         try
         {
-            var cameras = await ListRequested();
+            cancellationToken.ThrowIfCancellationRequested();
+            var cameras = await ListRequested(cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
             return Success(new { cameras });
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return Error("cancelled");
         }
         catch (Exception ex)
         {
@@ -71,7 +85,9 @@ public class CameraCapability : NodeCapabilityBase
     private const int MaxQuality = 100;
     private const int MaxClipDurationMs = 60_000;
 
-    private async Task<NodeInvokeResponse> HandleSnapAsync(NodeInvokeRequest request)
+    private async Task<NodeInvokeResponse> HandleSnapAsync(
+        NodeInvokeRequest request,
+        CancellationToken cancellationToken)
     {
         var deviceId = GetStringArg(request.Args, "deviceId");
         var format = GetStringArg(request.Args, "format", "jpeg");
@@ -87,13 +103,15 @@ public class CameraCapability : NodeCapabilityBase
         
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var result = await SnapRequested(new CameraSnapArgs
             {
                 DeviceId = deviceId,
                 Format = format ?? "jpeg",
                 MaxWidth = maxWidth,
                 Quality = quality
-            });
+            }, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
             
             return Success(new
             {
@@ -103,6 +121,10 @@ public class CameraCapability : NodeCapabilityBase
                 base64 = result.Base64
             });
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return Error("cancelled");
+        }
         catch (Exception ex)
         {
             Logger.Error("Camera snap failed", ex);
@@ -110,7 +132,9 @@ public class CameraCapability : NodeCapabilityBase
         }
     }
     
-    private async Task<NodeInvokeResponse> HandleClipAsync(NodeInvokeRequest request)
+    private async Task<NodeInvokeResponse> HandleClipAsync(
+        NodeInvokeRequest request,
+        CancellationToken cancellationToken)
     {
         var deviceId = GetStringArg(request.Args, "deviceId");
         // Floor at 100ms — anything shorter is meaningless and a 0/negative
@@ -128,13 +152,15 @@ public class CameraCapability : NodeCapabilityBase
         
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var result = await ClipRequested(new CameraClipArgs
             {
                 DeviceId = deviceId,
                 DurationMs = durationMs,
                 IncludeAudio = includeAudio,
                 Format = format
-            });
+            }, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
             
             return Success(new
             {
@@ -143,6 +169,10 @@ public class CameraCapability : NodeCapabilityBase
                 durationMs = result.DurationMs,
                 hasAudio = result.HasAudio
             });
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return Error("cancelled");
         }
         catch (Exception ex)
         {

--- a/src/OpenClaw.Shared/Capabilities/ScreenCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/ScreenCapability.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace OpenClaw.Shared.Capabilities;
@@ -20,19 +21,24 @@ public class ScreenCapability : NodeCapabilityBase
     public override IReadOnlyList<string> Commands => _commands;
     
     // Events for UI/platform-specific implementation
-    public event Func<ScreenCaptureArgs, Task<ScreenCaptureResult>>? CaptureRequested;
-    public event Func<ScreenRecordArgs, Task<ScreenRecordResult>>? RecordRequested;
+    public event Func<ScreenCaptureArgs, CancellationToken, Task<ScreenCaptureResult>>? CaptureRequested;
+    public event Func<ScreenRecordArgs, CancellationToken, Task<ScreenRecordResult>>? RecordRequested;
     
     public ScreenCapability(IOpenClawLogger logger) : base(logger)
     {
     }
     
-    public override async Task<NodeInvokeResponse> ExecuteAsync(NodeInvokeRequest request)
+    public override Task<NodeInvokeResponse> ExecuteAsync(NodeInvokeRequest request)
+        => ExecuteAsync(request, CancellationToken.None);
+
+    public override async Task<NodeInvokeResponse> ExecuteAsync(
+        NodeInvokeRequest request,
+        CancellationToken cancellationToken)
     {
         return request.Command switch
         {
-            "screen.snapshot" => await HandleCaptureAsync(request),
-            "screen.record" => await HandleRecordAsync(request),
+            "screen.snapshot" => await HandleCaptureAsync(request, cancellationToken),
+            "screen.record" => await HandleRecordAsync(request, cancellationToken),
             _ => Error($"Unknown command: {request.Command}")
         };
     }
@@ -44,7 +50,9 @@ public class ScreenCapability : NodeCapabilityBase
     private const int MaxQuality = 100;
     private const int MaxScreenIndex = 32;          // far above any plausible monitor count
 
-    private async Task<NodeInvokeResponse> HandleCaptureAsync(NodeInvokeRequest request)
+    private async Task<NodeInvokeResponse> HandleCaptureAsync(
+        NodeInvokeRequest request,
+        CancellationToken cancellationToken)
     {
         // The format is interpolated into the data URI, so validate it before
         // invoking the capture backend.
@@ -69,6 +77,7 @@ public class ScreenCapability : NodeCapabilityBase
         
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var result = await CaptureRequested(new ScreenCaptureArgs
             {
                 Format = format,
@@ -76,7 +85,8 @@ public class ScreenCapability : NodeCapabilityBase
                 Quality = quality,
                 MonitorIndex = screenIndex,
                 IncludePointer = includePointer
-            });
+            }, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
 
             // Use the validated format for the MIME type instead of the backend echo.
             var image = $"data:image/{format};base64,{result.Base64}";
@@ -88,6 +98,10 @@ public class ScreenCapability : NodeCapabilityBase
                 base64 = result.Base64,
                 image
             });
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return Error("cancelled");
         }
         catch (Exception ex)
         {
@@ -120,7 +134,9 @@ public class ScreenCapability : NodeCapabilityBase
         }
     }
 
-    private async Task<NodeInvokeResponse> HandleRecordAsync(NodeInvokeRequest request)
+    private async Task<NodeInvokeResponse> HandleRecordAsync(
+        NodeInvokeRequest request,
+        CancellationToken cancellationToken)
     {
         var format = GetStringArg(request.Args, "format", "mp4");
         if (!string.IsNullOrWhiteSpace(format) &&
@@ -144,6 +160,7 @@ public class ScreenCapability : NodeCapabilityBase
 
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var result = await RecordRequested(new ScreenRecordArgs
             {
                 DurationMs = durationMs,
@@ -151,7 +168,8 @@ public class ScreenCapability : NodeCapabilityBase
                 ScreenIndex = screenIndex,
                 Format = "mp4",
                 IncludeAudio = includeAudio
-            });
+            }, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
 
             return Success(new
             {
@@ -162,6 +180,10 @@ public class ScreenCapability : NodeCapabilityBase
                 screenIndex = result.ScreenIndex,
                 hasAudio = result.HasAudio
             });
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return Error("cancelled");
         }
         catch (Exception ex)
         {

--- a/src/OpenClaw.Shared/InvocationCancellationRegistry.cs
+++ b/src/OpenClaw.Shared/InvocationCancellationRegistry.cs
@@ -1,16 +1,74 @@
 namespace OpenClaw.Shared;
 
+internal enum InvocationCancellationResult
+{
+    NotFound,
+    Cancelled,
+    Pending,
+    Ambiguous,
+}
+
 internal sealed class InvocationCancellationRegistry
 {
     private readonly Dictionary<string, List<InvocationCancellation>> _active =
         new(StringComparer.Ordinal);
-    private readonly Dictionary<string, List<CancellationProbe>> _cancellationProbes =
+    private readonly Dictionary<string, ExpiringEntry> _pendingCancellations =
+        new(StringComparer.Ordinal);
+    private readonly Dictionary<string, ExpiringEntry> _recentCompletions =
         new(StringComparer.Ordinal);
     private readonly object _registrationGate = new();
     private readonly bool _allowDuplicateIds;
+    private readonly TimeSpan _pendingCancellationTtl;
+    private readonly int _maxPendingCancellations;
+    private readonly int _maxRecentCompletions;
+    private readonly TimeProvider _timeProvider;
+    private long _nextSequence;
 
-    public InvocationCancellationRegistry(bool allowDuplicateIds = false)
-        => _allowDuplicateIds = allowDuplicateIds;
+    public InvocationCancellationRegistry(
+        bool allowDuplicateIds = false,
+        TimeSpan? pendingCancellationTtl = null,
+        int maxPendingCancellations = 1_024,
+        int maxRecentCompletions = 1_024,
+        TimeProvider? timeProvider = null)
+    {
+        if (pendingCancellationTtl < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pendingCancellationTtl));
+        }
+
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxPendingCancellations);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxRecentCompletions);
+
+        _allowDuplicateIds = allowDuplicateIds;
+        _pendingCancellationTtl = pendingCancellationTtl ?? TimeSpan.Zero;
+        _maxPendingCancellations = maxPendingCancellations;
+        _maxRecentCompletions = maxRecentCompletions;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    internal int PendingCancellationCount
+    {
+        get
+        {
+            lock (_registrationGate)
+            {
+                PruneExpired(_timeProvider.GetUtcNow());
+                return _pendingCancellations.Count;
+            }
+        }
+    }
+
+    internal int RecentCompletionCount
+    {
+        get
+        {
+            lock (_registrationGate)
+            {
+                PruneExpired(_timeProvider.GetUtcNow());
+                return _recentCompletions.Count;
+            }
+        }
+    }
 
     public bool TryRegister(
         string requestId,
@@ -20,8 +78,10 @@ internal sealed class InvocationCancellationRegistry
         ArgumentException.ThrowIfNullOrWhiteSpace(requestId);
 
         var candidate = new InvocationCancellation(this, requestId, transportToken);
+        var cancelAfterRegistration = false;
         lock (_registrationGate)
         {
+            PruneExpired(_timeProvider.GetUtcNow());
             if (_active.TryGetValue(requestId, out var active))
             {
                 if (!_allowDuplicateIds)
@@ -40,110 +100,80 @@ internal sealed class InvocationCancellationRegistry
                 invocation = candidate;
             }
 
-            if (invocation != null &&
-                _cancellationProbes.TryGetValue(requestId, out var probes))
+            if (invocation != null)
             {
-                foreach (var probe in probes)
-                {
-                    probe.RegistrationCount++;
-                    probe.Candidate ??= candidate;
-                }
+                _recentCompletions.Remove(requestId);
+                cancelAfterRegistration = _pendingCancellations.Remove(requestId);
             }
         }
 
-        if (invocation != null)
+        if (invocation == null)
         {
-            return true;
-        }
-
-        candidate.DisposeDetached();
-        return false;
-    }
-
-    public bool TryCancel(string requestId) =>
-        TryCancel(requestId, out _);
-
-    public bool TryCancel(string requestId, out bool ambiguous)
-    {
-        ambiguous = false;
-        if (string.IsNullOrWhiteSpace(requestId))
-        {
+            candidate.DisposeDetached();
             return false;
         }
 
-        InvocationCancellation? invocation;
-        lock (_registrationGate)
+        if (cancelAfterRegistration)
         {
-            invocation = GetCancellationTarget(requestId, out ambiguous);
+            candidate.ApplyPendingCallerCancellation();
         }
 
-        return invocation?.CancelByCaller() == true;
+        return true;
     }
 
-    public async Task<(bool Cancelled, bool Ambiguous)> TryCancelAfterRegistrationWindowAsync(
-        string requestId,
-        TimeSpan registrationWindow,
-        CancellationToken cancellationToken)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(requestId);
-        ArgumentOutOfRangeException.ThrowIfLessThan(registrationWindow, TimeSpan.Zero);
+    public bool TryCancel(string requestId) =>
+        TryCancelOrRemember(requestId) == InvocationCancellationResult.Cancelled;
 
-        CancellationProbe? probe = null;
+    public bool TryCancel(string requestId, out bool ambiguous)
+    {
+        var result = TryCancelOrRemember(requestId);
+        ambiguous = result == InvocationCancellationResult.Ambiguous;
+        return result == InvocationCancellationResult.Cancelled;
+    }
+
+    public InvocationCancellationResult TryCancelOrRemember(string requestId)
+    {
+        if (string.IsNullOrWhiteSpace(requestId))
+        {
+            return InvocationCancellationResult.NotFound;
+        }
+
         InvocationCancellation? invocation;
-        bool ambiguous;
         lock (_registrationGate)
         {
-            invocation = GetCancellationTarget(requestId, out ambiguous);
-            if (invocation == null && !ambiguous)
+            var now = _timeProvider.GetUtcNow();
+            PruneExpired(now);
+            invocation = GetCancellationTarget(requestId, out var ambiguous);
+            if (ambiguous)
             {
-                probe = new CancellationProbe();
-                if (!_cancellationProbes.TryGetValue(requestId, out var probes))
+                return InvocationCancellationResult.Ambiguous;
+            }
+
+            if (invocation == null)
+            {
+                if (_pendingCancellationTtl == TimeSpan.Zero ||
+                    _recentCompletions.ContainsKey(requestId))
                 {
-                    probes = [];
-                    _cancellationProbes.Add(requestId, probes);
+                    return InvocationCancellationResult.NotFound;
                 }
 
-                probes.Add(probe);
+                if (_pendingCancellations.ContainsKey(requestId))
+                {
+                    return InvocationCancellationResult.Pending;
+                }
+
+                AddBoundedEntry(
+                    _pendingCancellations,
+                    requestId,
+                    now + _pendingCancellationTtl,
+                    _maxPendingCancellations);
+                return InvocationCancellationResult.Pending;
             }
         }
 
-        if (invocation != null)
-        {
-            return (invocation.CancelByCaller(), false);
-        }
-
-        if (ambiguous)
-        {
-            return (false, true);
-        }
-
-        try
-        {
-            await Task.Delay(registrationWindow, cancellationToken);
-        }
-        finally
-        {
-            lock (_registrationGate)
-            {
-                if (_cancellationProbes.TryGetValue(requestId, out var probes))
-                {
-                    probes.Remove(probe!);
-                    if (probes.Count == 0)
-                    {
-                        _cancellationProbes.Remove(requestId);
-                    }
-                }
-            }
-        }
-
-        if (probe!.RegistrationCount > 1)
-        {
-            return (false, true);
-        }
-
-        return probe.Candidate == null
-            ? (false, false)
-            : (probe.Candidate.CancelByCaller(), false);
+        return invocation.CancelByCaller()
+            ? InvocationCancellationResult.Cancelled
+            : InvocationCancellationResult.NotFound;
     }
 
     public void CancelAll()
@@ -164,15 +194,28 @@ internal sealed class InvocationCancellationRegistry
     {
         lock (_registrationGate)
         {
+            var now = _timeProvider.GetUtcNow();
+            PruneExpired(now);
             if (!_active.TryGetValue(requestId, out var active))
             {
                 return;
             }
 
             active.Remove(invocation);
-            if (active.Count == 0)
+            if (active.Count > 0)
             {
-                _active.Remove(requestId);
+                return;
+            }
+
+            _active.Remove(requestId);
+            _pendingCancellations.Remove(requestId);
+            if (_pendingCancellationTtl > TimeSpan.Zero)
+            {
+                AddBoundedEntry(
+                    _recentCompletions,
+                    requestId,
+                    now + _pendingCancellationTtl,
+                    _maxRecentCompletions);
             }
         }
     }
@@ -199,11 +242,45 @@ internal sealed class InvocationCancellationRegistry
         return active[0];
     }
 
-    private sealed class CancellationProbe
+    private void AddBoundedEntry(
+        Dictionary<string, ExpiringEntry> entries,
+        string requestId,
+        DateTimeOffset expiresAt,
+        int maxEntries)
     {
-        public int RegistrationCount { get; set; }
-        public InvocationCancellation? Candidate { get; set; }
+        if (!entries.ContainsKey(requestId) && entries.Count >= maxEntries)
+        {
+            var oldest = entries
+                .OrderBy(entry => entry.Value.ExpiresAt)
+                .ThenBy(entry => entry.Value.Sequence)
+                .ThenBy(entry => entry.Key, StringComparer.Ordinal)
+                .First();
+            entries.Remove(oldest.Key);
+        }
+
+        entries[requestId] = new ExpiringEntry(expiresAt, _nextSequence++);
     }
+
+    private void PruneExpired(DateTimeOffset now)
+    {
+        PruneExpired(_pendingCancellations, now);
+        PruneExpired(_recentCompletions, now);
+    }
+
+    private static void PruneExpired(
+        Dictionary<string, ExpiringEntry> entries,
+        DateTimeOffset now)
+    {
+        foreach (var requestId in entries
+                     .Where(entry => entry.Value.ExpiresAt <= now)
+                     .Select(entry => entry.Key)
+                     .ToArray())
+        {
+            entries.Remove(requestId);
+        }
+    }
+
+    private sealed record ExpiringEntry(DateTimeOffset ExpiresAt, long Sequence);
 
     internal sealed class InvocationCancellation : IDisposable
     {
@@ -250,6 +327,23 @@ internal sealed class InvocationCancellationRegistry
                 _cancelledByCaller = true;
                 _cts.Cancel();
                 return true;
+            }
+        }
+
+        internal void ApplyPendingCallerCancellation()
+        {
+            lock (_gate)
+            {
+                if (_disposed || _completed)
+                {
+                    return;
+                }
+
+                _cancelledByCaller = true;
+                if (!_cts.IsCancellationRequested)
+                {
+                    _cts.Cancel();
+                }
             }
         }
 

--- a/src/OpenClaw.Shared/InvocationCancellationRegistry.cs
+++ b/src/OpenClaw.Shared/InvocationCancellationRegistry.cs
@@ -1,0 +1,311 @@
+namespace OpenClaw.Shared;
+
+internal sealed class InvocationCancellationRegistry
+{
+    private readonly Dictionary<string, List<InvocationCancellation>> _active =
+        new(StringComparer.Ordinal);
+    private readonly Dictionary<string, List<CancellationProbe>> _cancellationProbes =
+        new(StringComparer.Ordinal);
+    private readonly object _registrationGate = new();
+    private readonly bool _allowDuplicateIds;
+
+    public InvocationCancellationRegistry(bool allowDuplicateIds = false)
+        => _allowDuplicateIds = allowDuplicateIds;
+
+    public bool TryRegister(
+        string requestId,
+        CancellationToken transportToken,
+        out InvocationCancellation? invocation)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(requestId);
+
+        var candidate = new InvocationCancellation(this, requestId, transportToken);
+        lock (_registrationGate)
+        {
+            if (_active.TryGetValue(requestId, out var active))
+            {
+                if (!_allowDuplicateIds)
+                {
+                    invocation = null;
+                }
+                else
+                {
+                    active.Add(candidate);
+                    invocation = candidate;
+                }
+            }
+            else
+            {
+                _active.Add(requestId, [candidate]);
+                invocation = candidate;
+            }
+
+            if (invocation != null &&
+                _cancellationProbes.TryGetValue(requestId, out var probes))
+            {
+                foreach (var probe in probes)
+                {
+                    probe.RegistrationCount++;
+                    probe.Candidate ??= candidate;
+                }
+            }
+        }
+
+        if (invocation != null)
+        {
+            return true;
+        }
+
+        candidate.DisposeDetached();
+        return false;
+    }
+
+    public bool TryCancel(string requestId) =>
+        TryCancel(requestId, out _);
+
+    public bool TryCancel(string requestId, out bool ambiguous)
+    {
+        ambiguous = false;
+        if (string.IsNullOrWhiteSpace(requestId))
+        {
+            return false;
+        }
+
+        InvocationCancellation? invocation;
+        lock (_registrationGate)
+        {
+            invocation = GetCancellationTarget(requestId, out ambiguous);
+        }
+
+        return invocation?.CancelByCaller() == true;
+    }
+
+    public async Task<(bool Cancelled, bool Ambiguous)> TryCancelAfterRegistrationWindowAsync(
+        string requestId,
+        TimeSpan registrationWindow,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(requestId);
+        ArgumentOutOfRangeException.ThrowIfLessThan(registrationWindow, TimeSpan.Zero);
+
+        CancellationProbe? probe = null;
+        InvocationCancellation? invocation;
+        bool ambiguous;
+        lock (_registrationGate)
+        {
+            invocation = GetCancellationTarget(requestId, out ambiguous);
+            if (invocation == null && !ambiguous)
+            {
+                probe = new CancellationProbe();
+                if (!_cancellationProbes.TryGetValue(requestId, out var probes))
+                {
+                    probes = [];
+                    _cancellationProbes.Add(requestId, probes);
+                }
+
+                probes.Add(probe);
+            }
+        }
+
+        if (invocation != null)
+        {
+            return (invocation.CancelByCaller(), false);
+        }
+
+        if (ambiguous)
+        {
+            return (false, true);
+        }
+
+        try
+        {
+            await Task.Delay(registrationWindow, cancellationToken);
+        }
+        finally
+        {
+            lock (_registrationGate)
+            {
+                if (_cancellationProbes.TryGetValue(requestId, out var probes))
+                {
+                    probes.Remove(probe!);
+                    if (probes.Count == 0)
+                    {
+                        _cancellationProbes.Remove(requestId);
+                    }
+                }
+            }
+        }
+
+        if (probe!.RegistrationCount > 1)
+        {
+            return (false, true);
+        }
+
+        return probe.Candidate == null
+            ? (false, false)
+            : (probe.Candidate.CancelByCaller(), false);
+    }
+
+    public void CancelAll()
+    {
+        InvocationCancellation[] active;
+        lock (_registrationGate)
+        {
+            active = _active.Values.SelectMany(invocations => invocations).ToArray();
+        }
+
+        foreach (var invocation in active)
+        {
+            invocation.CancelFromTransport();
+        }
+    }
+
+    private void Remove(string requestId, InvocationCancellation invocation)
+    {
+        lock (_registrationGate)
+        {
+            if (!_active.TryGetValue(requestId, out var active))
+            {
+                return;
+            }
+
+            active.Remove(invocation);
+            if (active.Count == 0)
+            {
+                _active.Remove(requestId);
+            }
+        }
+    }
+
+    private void Complete(string requestId, InvocationCancellation invocation) =>
+        Remove(requestId, invocation);
+
+    private InvocationCancellation? GetCancellationTarget(
+        string requestId,
+        out bool ambiguous)
+    {
+        ambiguous = false;
+        if (!_active.TryGetValue(requestId, out var active) || active.Count == 0)
+        {
+            return null;
+        }
+
+        if (active.Count > 1)
+        {
+            ambiguous = true;
+            return null;
+        }
+
+        return active[0];
+    }
+
+    private sealed class CancellationProbe
+    {
+        public int RegistrationCount { get; set; }
+        public InvocationCancellation? Candidate { get; set; }
+    }
+
+    internal sealed class InvocationCancellation : IDisposable
+    {
+        private readonly InvocationCancellationRegistry _owner;
+        private readonly string _requestId;
+        private readonly CancellationTokenSource _cts;
+        private readonly object _gate = new();
+        private bool _disposed;
+        private bool _cancelledByCaller;
+        private bool _completed;
+
+        internal InvocationCancellation(
+            InvocationCancellationRegistry owner,
+            string requestId,
+            CancellationToken transportToken)
+        {
+            _owner = owner;
+            _requestId = requestId;
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(transportToken);
+        }
+
+        public CancellationToken Token => _cts.Token;
+
+        public bool CancelledByCaller
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _cancelledByCaller;
+                }
+            }
+        }
+
+        internal bool CancelByCaller()
+        {
+            lock (_gate)
+            {
+                if (_disposed || _completed || _cts.IsCancellationRequested)
+                {
+                    return false;
+                }
+
+                _cancelledByCaller = true;
+                _cts.Cancel();
+                return true;
+            }
+        }
+
+        public bool TryComplete()
+        {
+            lock (_gate)
+            {
+                if (_disposed || _completed || _cts.IsCancellationRequested)
+                {
+                    return false;
+                }
+
+                _completed = true;
+                _owner.Complete(_requestId, this);
+                return true;
+            }
+        }
+
+        internal void CancelFromTransport()
+        {
+            lock (_gate)
+            {
+                if (!_disposed)
+                {
+                    _cts.Cancel();
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                _owner.Remove(_requestId, this);
+                _cts.Dispose();
+            }
+        }
+
+        internal void DisposeDetached()
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                _cts.Dispose();
+            }
+        }
+    }
+}

--- a/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
+++ b/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Numerics;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -429,6 +431,7 @@ public class McpToolBridge
         }
 
         var executionToken = invocation?.Token ?? cancellationToken;
+        var cancelledByCaller = false;
         NodeInvokeResponse response;
         try
         {
@@ -456,6 +459,7 @@ public class McpToolBridge
         }
         finally
         {
+            cancelledByCaller = invocation?.CancelledByCaller == true;
             invocation?.Dispose();
         }
 
@@ -464,7 +468,7 @@ public class McpToolBridge
             var error = response.Error ?? "tool execution failed";
             if (error == "cancelled" &&
                 executionToken.IsCancellationRequested &&
-                invocation?.CancelledByCaller != true)
+                !cancelledByCaller)
             {
                 error = "request timed out";
             }
@@ -486,8 +490,56 @@ public class McpToolBridge
         };
     }
 
-    private static string GetRequestKey(JsonElement requestId)
-        => requestId.GetRawText();
+    private static string GetRequestKey(JsonElement requestId) =>
+        requestId.ValueKind switch
+        {
+            JsonValueKind.String => $"string:{requestId.GetString()}",
+            JsonValueKind.Number => $"number:{NormalizeJsonNumber(requestId.GetRawText())}",
+            _ => $"{requestId.ValueKind}:{requestId.GetRawText()}",
+        };
+
+    private static string NormalizeJsonNumber(string rawNumber)
+    {
+        var exponentIndex = rawNumber.IndexOfAny('e', 'E');
+        var mantissa = exponentIndex >= 0 ? rawNumber[..exponentIndex] : rawNumber;
+        var exponent = exponentIndex >= 0
+            ? BigInteger.Parse(
+                rawNumber.AsSpan(exponentIndex + 1),
+                NumberStyles.AllowLeadingSign,
+                CultureInfo.InvariantCulture)
+            : BigInteger.Zero;
+
+        var negative = mantissa[0] == '-';
+        if (negative)
+        {
+            mantissa = mantissa[1..];
+        }
+
+        var decimalIndex = mantissa.IndexOf('.');
+        var fractionalDigits = decimalIndex >= 0 ? mantissa.Length - decimalIndex - 1 : 0;
+        var digits = decimalIndex >= 0 ? mantissa.Remove(decimalIndex, 1) : mantissa;
+        exponent -= fractionalDigits;
+
+        digits = digits.TrimStart('0');
+        if (digits.Length == 0)
+        {
+            return "0";
+        }
+
+        var trailingZeros = 0;
+        while (digits.Length - trailingZeros > 1 && digits[^(trailingZeros + 1)] == '0')
+        {
+            trailingZeros++;
+        }
+
+        if (trailingZeros > 0)
+        {
+            digits = digits[..^trailingZeros];
+            exponent += trailingZeros;
+        }
+
+        return $"{(negative ? "-" : string.Empty)}{digits}e{exponent}";
+    }
 
     private static string WriteResult(JsonElement? id, object result)
     {

--- a/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
+++ b/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
@@ -15,13 +15,15 @@ namespace OpenClaw.Shared.Mcp;
 public class McpToolBridge
 {
     private const string ProtocolVersion = "2024-11-05";
+    private static readonly TimeSpan PendingCancellationTtl = TimeSpan.FromSeconds(5);
+    private const int MaxPendingCancellations = 1_024;
+    private const int MaxRecentCompletions = 1_024;
 
     private readonly Func<IReadOnlyList<INodeCapability>> _capabilityProvider;
     private readonly IOpenClawLogger _logger;
     private readonly string _serverName;
     private readonly string _serverVersion;
-    private readonly InvocationCancellationRegistry _activeRequests =
-        new(allowDuplicateIds: true);
+    private readonly InvocationCancellationRegistry _activeRequests;
 
     private static readonly JsonSerializerOptions PayloadJsonOptions = new()
     {
@@ -33,11 +35,32 @@ public class McpToolBridge
         IOpenClawLogger? logger = null,
         string serverName = "openclaw-tray-mcp",
         string serverVersion = "0.0.0")
+        : this(
+            capabilityProvider,
+            logger,
+            serverName,
+            serverVersion,
+            new InvocationCancellationRegistry(
+                allowDuplicateIds: true,
+                pendingCancellationTtl: PendingCancellationTtl,
+                maxPendingCancellations: MaxPendingCancellations,
+                maxRecentCompletions: MaxRecentCompletions,
+                timeProvider: TimeProvider.System))
+    {
+    }
+
+    internal McpToolBridge(
+        Func<IReadOnlyList<INodeCapability>> capabilityProvider,
+        IOpenClawLogger? logger,
+        string serverName,
+        string serverVersion,
+        InvocationCancellationRegistry activeRequests)
     {
         _capabilityProvider = capabilityProvider ?? throw new ArgumentNullException(nameof(capabilityProvider));
         _logger = logger ?? NullLogger.Instance;
         _serverName = serverName;
         _serverVersion = serverVersion;
+        _activeRequests = activeRequests ?? throw new ArgumentNullException(nameof(activeRequests));
     }
 
     /// <summary>
@@ -93,9 +116,7 @@ public class McpToolBridge
                     "initialize" => HandleInitialize(),
                     "ping" => new { },
                     "notifications/initialized" => null,
-                    "notifications/cancelled" => await HandleCancelledNotificationAsync(
-                        paramsElement,
-                        cancellationToken),
+                    "notifications/cancelled" => HandleCancelledNotification(paramsElement),
                     "tools/list" => HandleToolsList(),
                     "tools/call" => await HandleToolsCallAsync(
                         paramsElement,
@@ -123,13 +144,6 @@ public class McpToolBridge
                 return hasId
                     ? WriteToolError(idElement, ex.Message)
                     : null;
-            }
-            catch (OperationCanceledException) when (
-                method == "notifications/cancelled" &&
-                cancellationToken.IsCancellationRequested)
-            {
-                _logger.Debug("[MCP] Cancellation notification handling stopped");
-                return null;
             }
             catch (Exception ex)
             {
@@ -338,9 +352,7 @@ public class McpToolBridge
             "Proxy an HTTP request to the local OpenClaw browser control host (CDP server) running on gateway port + 2. Args: path (string, required — a local control path like '/json/list' or '/json/activate/<id>'), method ('GET'|'POST'|'DELETE', default 'GET'), body (JSON object, POST/DELETE only), query (object, appended as query params), profile (string, optional browser profile), timeoutMs (int, default 20000, max 120000). Returns { result, files? } where files is present if the response included local file paths. Requires the gateway URL to have an explicit port and the browser control host to be running.",
     };
 
-    private async Task<object?> HandleCancelledNotificationAsync(
-        JsonElement parameters,
-        CancellationToken cancellationToken)
+    private object? HandleCancelledNotification(JsonElement parameters)
     {
         if (parameters.ValueKind != JsonValueKind.Object ||
             !parameters.TryGetProperty("requestId", out var requestId) ||
@@ -351,17 +363,14 @@ public class McpToolBridge
         }
 
         var requestKey = GetRequestKey(requestId);
-        var (cancelled, ambiguous) =
-            await _activeRequests.TryCancelAfterRegistrationWindowAsync(
-                requestKey,
-                TimeSpan.FromMilliseconds(100),
-                cancellationToken);
-
-        _logger.Debug(cancelled
-            ? $"[MCP] Cancelled request {requestKey}"
-            : ambiguous
-                ? $"[MCP] Cancellation target is ambiguous: {requestKey}"
-                : $"[MCP] Cancellation target is not active: {requestKey}");
+        var result = _activeRequests.TryCancelOrRemember(requestKey);
+        _logger.Debug(result switch
+        {
+            InvocationCancellationResult.Cancelled => $"[MCP] Cancelled request {requestKey}",
+            InvocationCancellationResult.Pending => $"[MCP] Queued cancellation for request {requestKey}",
+            InvocationCancellationResult.Ambiguous => $"[MCP] Cancellation target is ambiguous: {requestKey}",
+            _ => $"[MCP] Cancellation target is not active: {requestKey}",
+        });
         return null;
     }
 
@@ -423,6 +432,11 @@ public class McpToolBridge
         NodeInvokeResponse response;
         try
         {
+            if (invocation?.CancelledByCaller == true)
+            {
+                throw new McpToolException("cancelled");
+            }
+
             response = await capability.ExecuteAsync(request, executionToken).WaitAsync(executionToken);
             if (invocation != null && !invocation.TryComplete())
             {

--- a/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
+++ b/src/OpenClaw.Shared/Mcp/McpToolBridge.cs
@@ -20,6 +20,8 @@ public class McpToolBridge
     private readonly IOpenClawLogger _logger;
     private readonly string _serverName;
     private readonly string _serverVersion;
+    private readonly InvocationCancellationRegistry _activeRequests =
+        new(allowDuplicateIds: true);
 
     private static readonly JsonSerializerOptions PayloadJsonOptions = new()
     {
@@ -49,8 +51,8 @@ public class McpToolBridge
     /// Dispatch a JSON-RPC request body, observing a cancellation token (used
     /// by the HTTP transport to enforce a per-request deadline). When the
     /// token fires during a tool dispatch, the call surfaces as a tool error
-    /// ("request timed out") so the slot is freed even if the underlying
-    /// capability work continues to run.
+    /// ("request timed out"). MCP <c>notifications/cancelled</c> messages
+    /// cancel the matching active request and surface as "cancelled".
     /// </summary>
     public async Task<string?> HandleRequestAsync(string requestBody, CancellationToken cancellationToken)
     {
@@ -82,6 +84,7 @@ public class McpToolBridge
 
             var method = methodProp.GetString()!;
             var paramsElement = root.TryGetProperty("params", out var p) ? p : default;
+            var requestKey = hasId ? GetRequestKey(idElement!.Value) : null;
 
             try
             {
@@ -90,8 +93,14 @@ public class McpToolBridge
                     "initialize" => HandleInitialize(),
                     "ping" => new { },
                     "notifications/initialized" => null,
+                    "notifications/cancelled" => await HandleCancelledNotificationAsync(
+                        paramsElement,
+                        cancellationToken),
                     "tools/list" => HandleToolsList(),
-                    "tools/call" => await HandleToolsCallAsync(paramsElement, cancellationToken),
+                    "tools/call" => await HandleToolsCallAsync(
+                        paramsElement,
+                        requestKey,
+                        cancellationToken),
                     // Some clients (notably Cursor) probe these on startup. Returning
                     // empty lists is friendlier than MethodNotFound — both feature sets
                     // are deferred but compatible by being absent rather than failing.
@@ -114,6 +123,13 @@ public class McpToolBridge
                 return hasId
                     ? WriteToolError(idElement, ex.Message)
                     : null;
+            }
+            catch (OperationCanceledException) when (
+                method == "notifications/cancelled" &&
+                cancellationToken.IsCancellationRequested)
+            {
+                _logger.Debug("[MCP] Cancellation notification handling stopped");
+                return null;
             }
             catch (Exception ex)
             {
@@ -322,7 +338,37 @@ public class McpToolBridge
             "Proxy an HTTP request to the local OpenClaw browser control host (CDP server) running on gateway port + 2. Args: path (string, required — a local control path like '/json/list' or '/json/activate/<id>'), method ('GET'|'POST'|'DELETE', default 'GET'), body (JSON object, POST/DELETE only), query (object, appended as query params), profile (string, optional browser profile), timeoutMs (int, default 20000, max 120000). Returns { result, files? } where files is present if the response included local file paths. Requires the gateway URL to have an explicit port and the browser control host to be running.",
     };
 
-    private async Task<object> HandleToolsCallAsync(JsonElement parameters, CancellationToken cancellationToken)
+    private async Task<object?> HandleCancelledNotificationAsync(
+        JsonElement parameters,
+        CancellationToken cancellationToken)
+    {
+        if (parameters.ValueKind != JsonValueKind.Object ||
+            !parameters.TryGetProperty("requestId", out var requestId) ||
+            requestId.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+        {
+            _logger.Warn("[MCP] notifications/cancelled has no requestId");
+            return null;
+        }
+
+        var requestKey = GetRequestKey(requestId);
+        var (cancelled, ambiguous) =
+            await _activeRequests.TryCancelAfterRegistrationWindowAsync(
+                requestKey,
+                TimeSpan.FromMilliseconds(100),
+                cancellationToken);
+
+        _logger.Debug(cancelled
+            ? $"[MCP] Cancelled request {requestKey}"
+            : ambiguous
+                ? $"[MCP] Cancellation target is ambiguous: {requestKey}"
+                : $"[MCP] Cancellation target is not active: {requestKey}");
+        return null;
+    }
+
+    private async Task<object> HandleToolsCallAsync(
+        JsonElement parameters,
+        string? requestKey,
+        CancellationToken cancellationToken)
     {
         if (parameters.ValueKind != JsonValueKind.Object)
             throw new McpToolException("Invalid params: expected object");
@@ -366,19 +412,51 @@ public class McpToolBridge
         // their underlying pipeline on timeout; legacy capabilities fall back
         // to the no-CT signature and still benefit from WaitAsync freeing the
         // bridge's handler slot.
+        InvocationCancellationRegistry.InvocationCancellation? invocation = null;
+        if (requestKey != null &&
+            !_activeRequests.TryRegister(requestKey, cancellationToken, out invocation))
+        {
+            throw new McpToolException("duplicate active request id");
+        }
+
+        var executionToken = invocation?.Token ?? cancellationToken;
         NodeInvokeResponse response;
         try
         {
-            response = await capability.ExecuteAsync(request, cancellationToken).WaitAsync(cancellationToken);
+            response = await capability.ExecuteAsync(request, executionToken).WaitAsync(executionToken);
+            if (invocation != null && !invocation.TryComplete())
+            {
+                throw new McpToolException(
+                    invocation.CancelledByCaller ? "cancelled" : "request timed out");
+            }
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (invocation?.CancelledByCaller == true)
+        {
+            _logger.Info($"[MCP] tools/call {name} cancelled");
+            throw new McpToolException("cancelled");
+        }
+        catch (OperationCanceledException) when (executionToken.IsCancellationRequested)
         {
             _logger.Warn($"[MCP] tools/call {name} timed out");
             throw new McpToolException("request timed out");
         }
+        finally
+        {
+            invocation?.Dispose();
+        }
 
         if (!response.Ok)
-            throw new McpToolException(response.Error ?? "tool execution failed");
+        {
+            var error = response.Error ?? "tool execution failed";
+            if (error == "cancelled" &&
+                executionToken.IsCancellationRequested &&
+                invocation?.CancelledByCaller != true)
+            {
+                error = "request timed out";
+            }
+
+            throw new McpToolException(error);
+        }
 
         var payloadJson = response.Payload is null
             ? "null"
@@ -393,6 +471,9 @@ public class McpToolBridge
             isError = false,
         };
     }
+
+    private static string GetRequestKey(JsonElement requestId)
+        => requestId.GetRawText();
 
     private static string WriteResult(JsonElement? id, object result)
     {

--- a/src/OpenClaw.Shared/WebSocketClientBase.cs
+++ b/src/OpenClaw.Shared/WebSocketClientBase.cs
@@ -406,7 +406,7 @@ public abstract class WebSocketClientBase : IDisposable
             or WebSocketState.Aborted;
 
     /// <summary>Send a text message over the WebSocket. Thread-safe.</summary>
-    protected async Task SendRawAsync(string message)
+    protected virtual async Task SendRawAsync(string message)
     {
         try
         {

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -60,6 +60,7 @@ public class WindowsNodeClient : WebSocketClientBase
     // Invocations are fire-and-forget off the receive loop; this semaphore caps concurrency
     // at 8. When full, the gateway receives an immediate "node busy, retry" error response.
     private readonly SemaphoreSlim _invokeSemaphore = new(8, 8);
+    private readonly InvocationCancellationRegistry _activeInvocations = new();
 
     // Events
     public event EventHandler<NodeInvokeRequest>? InvokeReceived;
@@ -322,6 +323,9 @@ public class WindowsNodeClient : WebSocketClientBase
             case "node.invoke.request":
                 await HandleNodeInvokeEventAsync(root);
                 break;
+            case "node.invoke.cancel":
+                await HandleNodeInvokeCancelAsync(root, "payload", responseId: null);
+                break;
             case "health":
                 if (root.TryGetProperty("payload", out var payload))
                 {
@@ -526,10 +530,21 @@ public class WindowsNodeClient : WebSocketClientBase
             return;
         }
 
-        var ct = CancellationToken;
+        if (!_activeInvocations.TryRegister(requestId, CancellationToken, out var invocation))
+        {
+            _invokeSemaphore.Release();
+            _logger.Warn($"[NODE] Duplicate active invoke ID: {requestId}");
+            await SendNodeInvokeResultAsync(requestId, false, null, "duplicate active request id");
+            RaiseInvokeCompleted(requestId, command, false, "duplicate active request id", TimeSpan.Zero);
+            return;
+        }
+
         _ = Task.Run(async () =>
         {
+            using var activeInvocation = invocation!;
+            var ct = activeInvocation.Token;
             var stopwatch = Stopwatch.StartNew();
+            var outcomeCommitted = false;
             try
             {
                 // Raise event for UI notification
@@ -539,22 +554,63 @@ public class WindowsNodeClient : WebSocketClientBase
                 var response = await capability.ExecuteAsync(request, ct);
                 response.Id = requestId;
 
-                await SendNodeInvokeResultAsync(requestId, response.Ok, response.Payload, response.Error);
+                if (!activeInvocation.TryComplete())
+                {
+                    if (activeInvocation.CancelledByCaller)
+                    {
+                        stopwatch.Stop();
+                        try { await SendNodeInvokeResultAsync(requestId, false, null, "cancelled"); }
+                        catch (Exception sendEx) { _logger.Debug($"[NODE] Failed to send cancellation response for {requestId}: {sendEx.Message}"); }
+                        RaiseInvokeCompleted(requestId, command, false, "cancelled", stopwatch.Elapsed);
+                    }
+
+                    return;
+                }
+
+                outcomeCommitted = true;
                 stopwatch.Stop();
                 RaiseInvokeCompleted(requestId, command, response.Ok, response.Error, stopwatch.Elapsed);
+                await SendNodeInvokeResultAsync(requestId, response.Ok, response.Payload, response.Error);
             }
             // slopwatch-ignore: SW003 Shutdown cancellation or disposal is expected and the caller already preserves the safe state.
+            catch (OperationCanceledException) when (activeInvocation.CancelledByCaller)
+            {
+                stopwatch.Stop();
+                try { await SendNodeInvokeResultAsync(requestId, false, null, "cancelled"); }
+                catch (Exception sendEx) { _logger.Debug($"[NODE] Failed to send cancellation response for {requestId}: {sendEx.Message}"); }
+                RaiseInvokeCompleted(requestId, command, false, "cancelled", stopwatch.Elapsed);
+            }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
                 // Client is shutting down; response is no longer needed
             }
             catch (Exception ex)
             {
+                if (outcomeCommitted)
+                {
+                    _logger.Debug($"[NODE] Failed to deliver completed invoke {requestId}: {ex.Message}");
+                    return;
+                }
+
+                if (!activeInvocation.TryComplete())
+                {
+                    if (activeInvocation.CancelledByCaller)
+                    {
+                        stopwatch.Stop();
+                        try { await SendNodeInvokeResultAsync(requestId, false, null, "cancelled"); }
+                        catch (Exception sendEx) { _logger.Debug($"[NODE] Failed to send cancellation response for {requestId}: {sendEx.Message}"); }
+                        RaiseInvokeCompleted(requestId, command, false, "cancelled", stopwatch.Elapsed);
+                    }
+
+                    return;
+                }
+
+                outcomeCommitted = true;
                 _logger.Error($"[NODE] Command execution failed: {command}", ex);
                 stopwatch.Stop();
+                RaiseInvokeCompleted(requestId, command, false, "Command execution failed", stopwatch.Elapsed);
                 try { await SendNodeInvokeResultAsync(requestId, false, null, "Command execution failed"); }
                 catch (Exception sendEx) { _logger.Debug($"[NODE] Failed to send error response for {requestId}: {sendEx.Message}"); }
-                RaiseInvokeCompleted(requestId, command, false, "Command execution failed", stopwatch.Elapsed);
             }
             finally
             {
@@ -1018,6 +1074,9 @@ public class WindowsNodeClient : WebSocketClientBase
             case "node.invoke":
                 await HandleNodeInvokeAsync(root, id);
                 break;
+            case "node.invoke.cancel":
+                await HandleNodeInvokeCancelAsync(root, "params", id);
+                break;
             case "ping":
                 await SendPongAsync(id);
                 break;
@@ -1099,10 +1158,21 @@ public class WindowsNodeClient : WebSocketClientBase
             return;
         }
 
-        var ct = CancellationToken;
+        if (!_activeInvocations.TryRegister(requestId, CancellationToken, out var invocation))
+        {
+            _invokeSemaphore.Release();
+            _logger.Warn($"Duplicate active invoke ID: {requestId}");
+            await SendErrorResponseAsync(requestId, "duplicate active request id");
+            RaiseInvokeCompleted(requestId, command, false, "duplicate active request id", TimeSpan.Zero);
+            return;
+        }
+
         _ = Task.Run(async () =>
         {
+            using var activeInvocation = invocation!;
+            var ct = activeInvocation.Token;
             var stopwatch = Stopwatch.StartNew();
+            var outcomeCommitted = false;
             try
             {
                 // Raise event for UI notification
@@ -1112,28 +1182,114 @@ public class WindowsNodeClient : WebSocketClientBase
                 var response = await capability.ExecuteAsync(request, ct);
                 response.Id = requestId;
 
-                await SendInvokeResponseAsync(response);
+                if (!activeInvocation.TryComplete())
+                {
+                    if (activeInvocation.CancelledByCaller)
+                    {
+                        stopwatch.Stop();
+                        try { await SendErrorResponseAsync(requestId, "cancelled"); }
+                        catch (Exception sendEx) { _logger.Debug($"[NODE] Failed to send cancellation response for {requestId}: {sendEx.Message}"); }
+                        RaiseInvokeCompleted(requestId, command, false, "cancelled", stopwatch.Elapsed);
+                    }
+
+                    return;
+                }
+
+                outcomeCommitted = true;
                 stopwatch.Stop();
                 RaiseInvokeCompleted(requestId, command, response.Ok, response.Error, stopwatch.Elapsed);
+                await SendInvokeResponseAsync(response);
             }
             // slopwatch-ignore: SW003 Shutdown cancellation or disposal is expected and the caller already preserves the safe state.
+            catch (OperationCanceledException) when (activeInvocation.CancelledByCaller)
+            {
+                stopwatch.Stop();
+                try { await SendErrorResponseAsync(requestId, "cancelled"); }
+                catch (Exception sendEx) { _logger.Debug($"[NODE] Failed to send cancellation response for {requestId}: {sendEx.Message}"); }
+                RaiseInvokeCompleted(requestId, command, false, "cancelled", stopwatch.Elapsed);
+            }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
                 // Client is shutting down; response is no longer needed
             }
             catch (Exception ex)
             {
+                if (outcomeCommitted)
+                {
+                    _logger.Debug($"[NODE] Failed to deliver completed invoke {requestId}: {ex.Message}");
+                    return;
+                }
+
+                if (!activeInvocation.TryComplete())
+                {
+                    if (activeInvocation.CancelledByCaller)
+                    {
+                        stopwatch.Stop();
+                        try { await SendErrorResponseAsync(requestId, "cancelled"); }
+                        catch (Exception sendEx) { _logger.Debug($"[NODE] Failed to send cancellation response for {requestId}: {sendEx.Message}"); }
+                        RaiseInvokeCompleted(requestId, command, false, "cancelled", stopwatch.Elapsed);
+                    }
+
+                    return;
+                }
+
+                outcomeCommitted = true;
                 _logger.Error($"Command execution failed: {command}", ex);
                 stopwatch.Stop();
+                RaiseInvokeCompleted(requestId, command, false, "Command execution failed", stopwatch.Elapsed);
                 try { await SendErrorResponseAsync(requestId, "Command execution failed"); }
                 catch (Exception sendEx) { _logger.Debug($"[NODE] Failed to send error response for {requestId}: {sendEx.Message}"); }
-                RaiseInvokeCompleted(requestId, command, false, "Command execution failed", stopwatch.Elapsed);
             }
             finally
             {
                 _invokeSemaphore.Release();
             }
         }, CancellationToken.None);
+    }
+
+    private async Task HandleNodeInvokeCancelAsync(
+        JsonElement root,
+        string containerName,
+        string? responseId)
+    {
+        if (!root.TryGetProperty(containerName, out var container) ||
+            container.ValueKind != JsonValueKind.Object ||
+            !TryGetCancellationTargetId(container, out var requestId))
+        {
+            _logger.Warn("[NODE] node.invoke.cancel has no invokeId/requestId");
+            if (responseId != null)
+            {
+                await SendErrorResponseAsync(responseId, "Missing invokeId");
+            }
+            return;
+        }
+
+        var cancelled = _activeInvocations.TryCancel(requestId);
+        _logger.Info(cancelled
+            ? $"[NODE] Cancelled node.invoke request: {requestId}"
+            : $"[NODE] node.invoke.cancel target is not active: {requestId}");
+
+        if (responseId != null)
+        {
+            await SendSuccessResponseAsync(responseId, new { cancelled });
+        }
+    }
+
+    private static bool TryGetCancellationTargetId(JsonElement container, out string requestId)
+    {
+        foreach (var propertyName in new[] { "invokeId", "requestId" })
+        {
+            if (container.TryGetProperty(propertyName, out var property) &&
+                property.ValueKind == JsonValueKind.String &&
+                !string.IsNullOrWhiteSpace(property.GetString()))
+            {
+                requestId = property.GetString()!;
+                return true;
+            }
+        }
+
+        requestId = "";
+        return false;
     }
 
     private static string? ExtractNodeInvokeSessionKey(JsonElement envelope, JsonElement args)
@@ -1197,6 +1353,19 @@ public class WindowsNodeClient : WebSocketClientBase
             error = new { message = error }
         };
         
+        await SendRawAsync(JsonSerializer.Serialize(msg));
+    }
+
+    private async Task SendSuccessResponseAsync(string requestId, object payload)
+    {
+        var msg = new
+        {
+            type = "res",
+            id = requestId,
+            ok = true,
+            payload
+        };
+
         await SendRawAsync(JsonSerializer.Serialize(msg));
     }
     
@@ -1273,6 +1442,7 @@ public class WindowsNodeClient : WebSocketClientBase
 
     protected override void OnDisconnected()
     {
+        _activeInvocations.CancelAll();
         _isConnected = false;
         // Don't reset pairing state when disconnected due to pairing — gateway
         // closes the socket after PAIRING_REQUIRED but we're still waiting for approval
@@ -1285,11 +1455,17 @@ public class WindowsNodeClient : WebSocketClientBase
 
     protected override void OnError(Exception ex)
     {
+        _activeInvocations.CancelAll();
         _isConnected = false;
         if (!_pairingBlocked)
         {
             _isPendingApproval = false;
             _isPaired = false;
         }
+    }
+
+    protected override void OnDisposing()
+    {
+        _activeInvocations.CancelAll();
     }
 }

--- a/src/OpenClaw.Shared/WindowsNodeClient.cs
+++ b/src/OpenClaw.Shared/WindowsNodeClient.cs
@@ -1316,7 +1316,11 @@ public class WindowsNodeClient : WebSocketClientBase
 
     private void RaiseInvokeCompleted(string requestId, string command, bool ok, string? error, TimeSpan duration)
     {
-        InvokeCompleted?.Invoke(this, new NodeInvokeCompletedEventArgs
+        var handlers = InvokeCompleted;
+        if (handlers is null)
+            return;
+
+        var args = new NodeInvokeCompletedEventArgs
         {
             RequestId = requestId,
             Command = command,
@@ -1324,7 +1328,21 @@ public class WindowsNodeClient : WebSocketClientBase
             Error = error,
             Duration = duration,
             NodeId = _nodeId ?? _deviceIdentity.DeviceId
-        });
+        };
+
+        foreach (var handler in handlers.GetInvocationList())
+        {
+            try
+            {
+                ((EventHandler<NodeInvokeCompletedEventArgs>)handler)(this, args);
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn(
+                    $"[NODE] InvokeCompleted subscriber " +
+                    $"{handler.Method.DeclaringType?.Name}.{handler.Method.Name} threw: {ex.Message}");
+            }
+        }
     }
     
     private async Task SendInvokeResponseAsync(NodeInvokeResponse response)

--- a/src/OpenClaw.Tray.WinUI/Dialogs/RecordingCountdownWindow.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/RecordingCountdownWindow.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using WinUIEx;
 
@@ -40,6 +41,7 @@ public sealed class RecordingCountdownWindow : WindowEx
     private readonly TextBlock _countdownText;
     private readonly DispatcherQueueTimer _timer;
     private int _remaining;
+    private bool _closeRequested;
 
     public RecordingCountdownWindow(int seconds = 3)
     {
@@ -94,17 +96,33 @@ public sealed class RecordingCountdownWindow : WindowEx
 
         if (_remaining <= 0)
         {
-            _timer.Stop();
-            Close();
+            CloseOnce();
             return;
         }
 
         _countdownText.Text = _remaining.ToString();
     }
 
-    public Task ShowCountdownAsync()
+    public async Task ShowCountdownAsync(CancellationToken cancellationToken)
     {
-        Closed += (s, e) => _tcs.TrySetResult();
+        Closed += (s, e) =>
+        {
+            _closeRequested = true;
+            _tcs.TrySetResult();
+        };
+        if (cancellationToken.IsCancellationRequested)
+        {
+            CloseOnce();
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        using var cancellationRegistration = cancellationToken.Register(() =>
+        {
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                CloseOnce();
+            });
+        });
 
         // Transparent window background so only the dark circle is visible
         SystemBackdrop = new TransparentTintBackdrop();
@@ -129,6 +147,19 @@ public sealed class RecordingCountdownWindow : WindowEx
 
         _timer.Start();
 
-        return _tcs.Task;
+        await _tcs.Task;
+        cancellationToken.ThrowIfCancellationRequested();
+    }
+
+    private void CloseOnce()
+    {
+        if (_closeRequested)
+        {
+            return;
+        }
+
+        _closeRequested = true;
+        _timer.Stop();
+        Close();
     }
 }

--- a/src/OpenClaw.Tray.WinUI/Services/CameraCaptureService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/CameraCaptureService.cs
@@ -22,7 +22,7 @@ namespace OpenClawTray.Services;
 public class CameraCaptureService : IDisposable
 {
     private readonly IOpenClawLogger _logger;
-    private readonly SemaphoreSlim _captureLock = new(1, 1);
+    private readonly CaptureOperationGate _captureGate = new();
     
     public CameraCaptureService(IOpenClawLogger logger)
     {
@@ -31,12 +31,14 @@ public class CameraCaptureService : IDisposable
     
     public void Dispose()
     {
-        _captureLock.Dispose();
+        _captureGate.Dispose();
     }
     
-    public async Task<CameraInfo[]> ListCamerasAsync()
+    public async Task<CameraInfo[]> ListCamerasAsync(CancellationToken cancellationToken)
     {
-        var devices = await DeviceInformation.FindAllAsync(DeviceClass.VideoCapture);
+        var devices = await DeviceInformation
+            .FindAllAsync(DeviceClass.VideoCapture)
+            .AsTask(cancellationToken);
         var result = new List<CameraInfo>();
         
         for (var i = 0; i < devices.Count; i++)
@@ -53,10 +55,12 @@ public class CameraCaptureService : IDisposable
         return result.ToArray();
     }
     
-    public async Task<CameraSnapResult> SnapAsync(CameraSnapArgs args)
+    public async Task<CameraSnapResult> SnapAsync(
+        CameraSnapArgs args,
+        CancellationToken cancellationToken)
     {
         _logger.Info($"camera.snap start: deviceId={args.DeviceId ?? "(default)"}, format={args.Format}, maxWidth={args.MaxWidth}, quality={args.Quality}");
-        await _captureLock.WaitAsync();
+        using var captureLease = await _captureGate.EnterAsync(cancellationToken);
         
         try
         {
@@ -73,41 +77,46 @@ public class CameraCaptureService : IDisposable
             };
             
             var initStart = DateTime.UtcNow;
-            await capture.InitializeAsync(settings);
+            await capture.InitializeAsync(settings).AsTask(cancellationToken);
             _logger.Info($"camera.snap: MediaCapture initialized in {(DateTime.UtcNow - initStart).TotalMilliseconds:0}ms");
             
             var photoCandidates = SelectPhotoEncodings(capture, format, args.MaxWidth);
             if (photoCandidates.Count == 0)
             {
                 _logger.Warn("camera.snap: no photo stream properties available; falling back to video frame");
-                return await CaptureVideoFallbackAsync(capture, format, args.MaxWidth, args.Quality);
+                return await CaptureVideoFallbackAsync(
+                    capture, format, args.MaxWidth, args.Quality, cancellationToken);
             }
             
             using var stream = new InMemoryRandomAccessStream();
             _logger.Info($"camera.snap: preferred encoding {photoCandidates[0].Subtype} {photoCandidates[0].Width}x{photoCandidates[0].Height}");
             
             var captureStart = DateTime.UtcNow;
-            var encoding = await CaptureWithFallbackAsync(capture, photoCandidates);
+            var encoding = await CaptureWithFallbackAsync(
+                capture, photoCandidates, cancellationToken);
             if (encoding == null)
             {
                 _logger.Warn("camera.snap: no supported photo encodings; falling back to video frame");
-                return await CaptureVideoFallbackAsync(capture, format, args.MaxWidth, args.Quality);
+                return await CaptureVideoFallbackAsync(
+                    capture, format, args.MaxWidth, args.Quality, cancellationToken);
             }
             
             try
             {
-                await capture.CapturePhotoToStreamAsync(encoding, stream);
+                await capture.CapturePhotoToStreamAsync(encoding, stream).AsTask(cancellationToken);
             }
             catch (Exception ex) when (IsInvalidMediaType(ex))
             {
                 _logger.Warn("camera.snap: photo capture unsupported; falling back to video frame");
-                return await CaptureVideoFallbackAsync(capture, format, args.MaxWidth, args.Quality);
+                return await CaptureVideoFallbackAsync(
+                    capture, format, args.MaxWidth, args.Quality, cancellationToken);
             }
             _logger.Info($"camera.snap: CapturePhotoToStreamAsync completed in {(DateTime.UtcNow - captureStart).TotalMilliseconds:0}ms");
             
             stream.Seek(0);
             var encodeStart = DateTime.UtcNow;
-            var result = await EncodeAsync(stream, format, args.MaxWidth, args.Quality);
+            var result = await EncodeAsync(
+                stream, format, args.MaxWidth, args.Quality, cancellationToken);
             _logger.Info($"camera.snap: encoded {result.Width}x{result.Height} ({result.Base64.Length} chars) in {(DateTime.UtcNow - encodeStart).TotalMilliseconds:0}ms");
             return result;
         }
@@ -116,25 +125,30 @@ public class CameraCaptureService : IDisposable
             _logger.Error("Camera access denied. Check Windows privacy settings.", ex);
             throw;
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.Error($"camera.snap failed (0x{ex.HResult:X8})", ex);
             throw;
         }
-        finally
-        {
-            _captureLock.Release();
-        }
     }
     
-    public async Task<CameraClipResult> ClipAsync(CameraClipArgs args)
+    public async Task<CameraClipResult> ClipAsync(
+        CameraClipArgs args,
+        CancellationToken cancellationToken)
     {
         _logger.Info($"camera.clip start: deviceId={args.DeviceId ?? "(default)"}, durationMs={args.DurationMs}, includeAudio={args.IncludeAudio}, format={args.Format}");
-        await _captureLock.WaitAsync();
+        using var captureLease = await _captureGate.EnterAsync(cancellationToken);
+        MediaCapture? capture = null;
+        var recordStartRequested = false;
+        var recordingStopped = false;
         
         try
         {
-            using var capture = new MediaCapture();
+            capture = new MediaCapture();
             
             var settings = new MediaCaptureInitializationSettings
             {
@@ -146,26 +160,29 @@ public class CameraCaptureService : IDisposable
             };
             
             var initStart = DateTime.UtcNow;
-            await capture.InitializeAsync(settings);
+            await capture.InitializeAsync(settings).AsTask(cancellationToken);
             _logger.Info($"camera.clip: MediaCapture initialized in {(DateTime.UtcNow - initStart).TotalMilliseconds:0}ms");
 
-            var recordProperties = await TryConfigureVideoRecordStreamAsync(capture);
+            var recordProperties = await TryConfigureVideoRecordStreamAsync(
+                capture, cancellationToken);
             using var stream = new InMemoryRandomAccessStream();
             var profile = CreateClipProfile(args.IncludeAudio, recordProperties);
             
             var recordStart = DateTime.UtcNow;
-            await capture.StartRecordToStreamAsync(profile, stream);
+            recordStartRequested = true;
+            await capture.StartRecordToStreamAsync(profile, stream).AsTask(cancellationToken);
             _logger.Info($"camera.clip: recording started");
             
-            await Task.Delay(args.DurationMs);
+            await Task.Delay(args.DurationMs, cancellationToken);
             
             await capture.StopRecordAsync();
+            recordingStopped = true;
             var elapsed = (DateTime.UtcNow - recordStart).TotalMilliseconds;
             _logger.Info($"camera.clip: recording stopped after {elapsed:0}ms");
             
             stream.Seek(0);
             using var reader = new DataReader(stream);
-            await reader.LoadAsync((uint)stream.Size);
+            await reader.LoadAsync((uint)stream.Size).AsTask(cancellationToken);
             var buffer = new byte[stream.Size];
             reader.ReadBytes(buffer);
             var base64 = Convert.ToBase64String(buffer);
@@ -185,6 +202,10 @@ public class CameraCaptureService : IDisposable
             _logger.Error("Camera access denied. Check Windows privacy settings.", ex);
             throw;
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.Error($"camera.clip failed (0x{ex.HResult:X8})", ex);
@@ -192,19 +213,34 @@ public class CameraCaptureService : IDisposable
         }
         finally
         {
-            _captureLock.Release();
+            if (capture != null && recordStartRequested && !recordingStopped)
+            {
+                try
+                {
+                    await capture.StopRecordAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.Debug($"camera.clip cancellation cleanup failed: {ex.Message}");
+                }
+            }
+
+            capture?.Dispose();
         }
     }
     
     private async Task<ImageEncodingProperties?> CaptureWithFallbackAsync(
         MediaCapture capture,
-        List<ImageEncodingProperties> candidates)
+        List<ImageEncodingProperties> candidates,
+        CancellationToken cancellationToken)
     {
         foreach (var candidate in candidates)
         {
             try
             {
-                await capture.VideoDeviceController.SetMediaStreamPropertiesAsync(MediaStreamType.Photo, candidate);
+                await capture.VideoDeviceController
+                    .SetMediaStreamPropertiesAsync(MediaStreamType.Photo, candidate)
+                    .AsTask(cancellationToken);
                 _logger.Info($"camera.snap: using photo encoding {candidate.Subtype} {candidate.Width}x{candidate.Height}");
                 return candidate;
             }
@@ -223,7 +259,9 @@ public class CameraCaptureService : IDisposable
         return ex.HResult == MfEInvalidMediaType;
     }
 
-    private async Task<VideoEncodingProperties?> TryConfigureVideoRecordStreamAsync(MediaCapture capture)
+    private async Task<VideoEncodingProperties?> TryConfigureVideoRecordStreamAsync(
+        MediaCapture capture,
+        CancellationToken cancellationToken)
     {
         var props = capture.VideoDeviceController
             .GetAvailableMediaStreamProperties(MediaStreamType.VideoRecord)
@@ -248,7 +286,9 @@ public class CameraCaptureService : IDisposable
         {
             try
             {
-                await capture.VideoDeviceController.SetMediaStreamPropertiesAsync(MediaStreamType.VideoRecord, candidate);
+                await capture.VideoDeviceController
+                    .SetMediaStreamPropertiesAsync(MediaStreamType.VideoRecord, candidate)
+                    .AsTask(cancellationToken);
                 _logger.Info($"camera.clip: using record stream {candidate.Subtype} {candidate.Width}x{candidate.Height}");
                 return candidate;
             }
@@ -352,11 +392,17 @@ public class CameraCaptureService : IDisposable
         MediaCapture capture,
         string format,
         int maxWidth,
-        int quality)
+        int quality,
+        CancellationToken cancellationToken)
     {
         try
         {
-            return await CaptureFrameReaderAsync(capture, format, maxWidth, quality);
+            return await CaptureFrameReaderAsync(
+                capture, format, maxWidth, quality, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -364,14 +410,16 @@ public class CameraCaptureService : IDisposable
         }
         
         _logger.Warn("camera.snap: frame reader unavailable; falling back to preview frame");
-        return await CapturePreviewFrameAsync(capture, format, maxWidth, quality);
+        return await CapturePreviewFrameAsync(
+            capture, format, maxWidth, quality, cancellationToken);
     }
     
     private async Task<CameraSnapResult> CaptureFrameReaderAsync(
         MediaCapture capture,
         string format,
         int maxWidth,
-        int quality)
+        int quality,
+        CancellationToken cancellationToken)
     {
         _logger.Info($"camera.snap: frame sources={capture.FrameSources.Count}");
         var sources = capture.FrameSources.Values
@@ -385,24 +433,29 @@ public class CameraCaptureService : IDisposable
         }
         
         MediaFrameReader? frameReader = null;
+        var frameReaderStarted = false;
         try
         {
             var selectedFormat = SelectFrameReaderFormat(source, maxWidth);
             if (selectedFormat != null)
             {
                 _logger.Info($"camera.snap: frame format {selectedFormat.Subtype} {selectedFormat.VideoFormat.Width}x{selectedFormat.VideoFormat.Height}");
-                await source.SetFormatAsync(selectedFormat);
+                await source.SetFormatAsync(selectedFormat).AsTask(cancellationToken);
             }
             
             try
             {
                 frameReader = selectedFormat != null
-                    ? await capture.CreateFrameReaderAsync(source, selectedFormat.Subtype)
-                    : await capture.CreateFrameReaderAsync(source);
+                    ? await capture.CreateFrameReaderAsync(source, selectedFormat.Subtype).AsTask(cancellationToken)
+                    : await capture.CreateFrameReaderAsync(source).AsTask(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch
             {
-                frameReader = await capture.CreateFrameReaderAsync(source);
+                frameReader = await capture.CreateFrameReaderAsync(source).AsTask(cancellationToken);
             }
             
             var tcs = new TaskCompletionSource<SoftwareBitmap>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -426,23 +479,40 @@ public class CameraCaptureService : IDisposable
             
             frameReader.FrameArrived += OnFrameArrived;
             
-            var status = await frameReader.StartAsync();
+            var status = await frameReader.StartAsync().AsTask(cancellationToken);
             if (status != MediaFrameReaderStartStatus.Success)
             {
                 throw new InvalidOperationException($"Frame reader start failed: {status}");
             }
+            frameReaderStarted = true;
             
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-            await using var reg = timeoutCts.Token.Register(() => tcs.TrySetCanceled());
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(2));
+            await using var reg = timeoutCts.Token.Register(
+                () => tcs.TrySetCanceled(timeoutCts.Token));
             
             var bitmap = await tcs.Task;
             frameReader.FrameArrived -= OnFrameArrived;
             await frameReader.StopAsync();
+            frameReaderStarted = false;
             
-            return await EncodeSoftwareBitmapAsync(bitmap, format, maxWidth, quality);
+            return await EncodeSoftwareBitmapAsync(
+                bitmap, format, maxWidth, quality, cancellationToken);
         }
         finally
         {
+            if (frameReader != null && frameReaderStarted)
+            {
+                try
+                {
+                    await frameReader.StopAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.Debug($"camera.snap frame reader cleanup failed: {ex.Message}");
+                }
+            }
+
             frameReader?.Dispose();
         }
     }
@@ -487,12 +557,15 @@ public class CameraCaptureService : IDisposable
         MediaCapture capture,
         string format,
         int maxWidth,
-        int quality)
+        int quality,
+        CancellationToken cancellationToken)
     {
         var previewEncoding = SelectPreviewEncoding(capture, maxWidth);
         if (previewEncoding != null)
         {
-            await capture.VideoDeviceController.SetMediaStreamPropertiesAsync(MediaStreamType.VideoPreview, previewEncoding);
+            await capture.VideoDeviceController
+                .SetMediaStreamPropertiesAsync(MediaStreamType.VideoPreview, previewEncoding)
+                .AsTask(cancellationToken);
             _logger.Info($"camera.snap: preview encoding {previewEncoding.Subtype} {previewEncoding.Width}x{previewEncoding.Height}");
         }
         else
@@ -500,11 +573,15 @@ public class CameraCaptureService : IDisposable
             _logger.Warn("camera.snap: no preview stream properties; using default preview settings");
         }
         
-        _logger.Info("camera.snap: starting preview");
-        await capture.StartPreviewAsync();
-        _logger.Info("camera.snap: preview started");
+        var previewStartRequested = false;
+        Exception? captureError = null;
         try
         {
+            _logger.Info("camera.snap: starting preview");
+            previewStartRequested = true;
+            await capture.StartPreviewAsync().AsTask(cancellationToken);
+            _logger.Info("camera.snap: preview started");
+
             var activePreview = capture.VideoDeviceController.GetMediaStreamProperties(MediaStreamType.VideoPreview) as VideoEncodingProperties;
             var width = (int)(activePreview?.Width ?? previewEncoding?.Width ?? 1280);
             var height = (int)(activePreview?.Height ?? previewEncoding?.Height ?? 720);
@@ -518,7 +595,7 @@ public class CameraCaptureService : IDisposable
             var pixelFormat = GetPreviewPixelFormat(subtype);
             _logger.Info($"camera.snap: grabbing preview frame {width}x{height} ({subtype ?? "default"})");
             using var frame = new VideoFrame(pixelFormat, width, height);
-            await capture.GetPreviewFrameAsync(frame);
+            await capture.GetPreviewFrameAsync(frame).AsTask(cancellationToken);
             var bitmap = frame.SoftwareBitmap ?? throw new InvalidOperationException("Preview frame missing bitmap");
             SoftwareBitmap? converted = null;
             if (bitmap.BitmapPixelFormat != BitmapPixelFormat.Bgra8)
@@ -528,17 +605,38 @@ public class CameraCaptureService : IDisposable
             }
             
             using var previewStream = new InMemoryRandomAccessStream();
-            var encoder = await BitmapEncoder.CreateAsync(BitmapEncoder.PngEncoderId, previewStream);
+            var encoder = await BitmapEncoder
+                .CreateAsync(BitmapEncoder.PngEncoderId, previewStream)
+                .AsTask(cancellationToken);
             encoder.SetSoftwareBitmap(bitmap);
-            await encoder.FlushAsync();
+            await encoder.FlushAsync().AsTask(cancellationToken);
             previewStream.Seek(0);
             
-            return await EncodeAsync(previewStream, format, maxWidth, quality);
+            return await EncodeAsync(
+                previewStream, format, maxWidth, quality, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            captureError = ex;
+            throw;
         }
         finally
         {
-            _logger.Info("camera.snap: stopping preview");
-            await capture.StopPreviewAsync();
+            if (previewStartRequested)
+            {
+                _logger.Info("camera.snap: stopping preview");
+                try
+                {
+                    await capture.StopPreviewAsync();
+                }
+                catch (Exception ex) when (
+                    captureError != null || cancellationToken.IsCancellationRequested)
+                {
+                    _logger.Debug($"camera.snap: preview stop cleanup failed: {ex.Message}");
+                }
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
         }
     }
     
@@ -546,7 +644,8 @@ public class CameraCaptureService : IDisposable
         SoftwareBitmap bitmap,
         string format,
         int maxWidth,
-        int quality)
+        int quality,
+        CancellationToken cancellationToken)
     {
         SoftwareBitmap? converted = null;
         if (bitmap.BitmapPixelFormat != BitmapPixelFormat.Bgra8)
@@ -556,12 +655,14 @@ public class CameraCaptureService : IDisposable
         }
         
         using var stream = new InMemoryRandomAccessStream();
-        var encoder = await BitmapEncoder.CreateAsync(BitmapEncoder.PngEncoderId, stream);
+        var encoder = await BitmapEncoder
+            .CreateAsync(BitmapEncoder.PngEncoderId, stream)
+            .AsTask(cancellationToken);
         encoder.SetSoftwareBitmap(bitmap);
-        await encoder.FlushAsync();
+        await encoder.FlushAsync().AsTask(cancellationToken);
         stream.Seek(0);
         
-        return await EncodeAsync(stream, format, maxWidth, quality);
+        return await EncodeAsync(stream, format, maxWidth, quality, cancellationToken);
     }
     
     private static BitmapPixelFormat GetPreviewPixelFormat(string? subtype)
@@ -591,9 +692,10 @@ public class CameraCaptureService : IDisposable
         IRandomAccessStream input,
         string format,
         int maxWidth,
-        int quality)
+        int quality,
+        CancellationToken cancellationToken)
     {
-        var decoder = await BitmapDecoder.CreateAsync(input);
+        var decoder = await BitmapDecoder.CreateAsync(input).AsTask(cancellationToken);
         var width = decoder.PixelWidth;
         var height = decoder.PixelHeight;
         
@@ -617,11 +719,11 @@ public class CameraCaptureService : IDisposable
             BitmapAlphaMode.Ignore,
             transform,
             ExifOrientationMode.IgnoreExifOrientation,
-            ColorManagementMode.DoNotColorManage);
+            ColorManagementMode.DoNotColorManage).AsTask(cancellationToken);
         
         using var output = new InMemoryRandomAccessStream();
         var encoderId = format == "png" ? BitmapEncoder.PngEncoderId : BitmapEncoder.JpegEncoderId;
-        var encoder = await BitmapEncoder.CreateAsync(encoderId, output);
+        var encoder = await BitmapEncoder.CreateAsync(encoderId, output).AsTask(cancellationToken);
         
         encoder.SetPixelData(
             BitmapPixelFormat.Bgra8,
@@ -639,15 +741,15 @@ public class CameraCaptureService : IDisposable
             {
                 { "ImageQuality", new BitmapTypedValue(qualityValue, PropertyType.Single) }
             };
-            await encoder.BitmapProperties.SetPropertiesAsync(props);
+            await encoder.BitmapProperties.SetPropertiesAsync(props).AsTask(cancellationToken);
         }
         
-        await encoder.FlushAsync();
+        await encoder.FlushAsync().AsTask(cancellationToken);
         output.Seek(0);
         
         var bytes = new byte[output.Size];
         using var reader = new DataReader(output);
-        await reader.LoadAsync((uint)output.Size);
+        await reader.LoadAsync((uint)output.Size).AsTask(cancellationToken);
         reader.ReadBytes(bytes);
         
         return new CameraSnapResult

--- a/src/OpenClaw.Tray.WinUI/Services/CameraCaptureService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/CameraCaptureService.cs
@@ -636,7 +636,9 @@ public class CameraCaptureService : IDisposable
                 }
             }
 
-            cancellationToken.ThrowIfCancellationRequested();
+            CaptureCancellationPolicy.ThrowIfCancellationRequested(
+                captureError,
+                cancellationToken);
         }
     }
     

--- a/src/OpenClaw.Tray.WinUI/Services/CaptureCancellationPolicy.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/CaptureCancellationPolicy.cs
@@ -1,0 +1,14 @@
+namespace OpenClawTray.Services;
+
+internal static class CaptureCancellationPolicy
+{
+    public static void ThrowIfCancellationRequested(
+        Exception? primaryException,
+        CancellationToken cancellationToken)
+    {
+        if (primaryException == null)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/CaptureOperationGate.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/CaptureOperationGate.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenClawTray.Services;
+
+internal sealed class CaptureOperationGate : IDisposable
+{
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    public async ValueTask<IDisposable> EnterAsync(CancellationToken cancellationToken)
+    {
+        await _semaphore.WaitAsync(cancellationToken);
+        return new Lease(_semaphore);
+    }
+
+    public void Dispose() => _semaphore.Dispose();
+
+    private sealed class Lease : IDisposable
+    {
+        private SemaphoreSlim? _semaphore;
+
+        public Lease(SemaphoreSlim semaphore)
+        {
+            _semaphore = semaphore;
+        }
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _semaphore, null)?.Release();
+        }
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/NodeService.cs
@@ -1769,13 +1769,16 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
                 appNotification));
     }
     
-    private async Task<ScreenCaptureResult> OnScreenCapture(ScreenCaptureArgs args)
+    private async Task<ScreenCaptureResult> OnScreenCapture(
+        ScreenCaptureArgs args,
+        CancellationToken cancellationToken)
     {
         if (_screenCaptureService == null)
         {
             throw new InvalidOperationException("Screen capture service not available");
         }
         
+        cancellationToken.ThrowIfCancellationRequested();
         // Notify user that screen capture is happening (throttled to avoid spam)
         var now = DateTime.Now;
         if ((now - _lastScreenCaptureNotification).TotalSeconds > 10)
@@ -1787,18 +1790,21 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
                 "node:screen-captured");
         }
         
-        return await _screenCaptureService.CaptureAsync(args);
+        return await _screenCaptureService.CaptureAsync(args, cancellationToken);
     }
 
-    private async Task<ScreenRecordResult> OnScreenRecord(ScreenRecordArgs args)
+    private async Task<ScreenRecordResult> OnScreenRecord(
+        ScreenRecordArgs args,
+        CancellationToken cancellationToken)
     {
         if (_screenRecordingService == null)
         {
             throw new InvalidOperationException("Screen recording service not available");
         }
 
-        await EnsureRecordingConsentAsync(RecordingType.Screen);
-        await ShowRecordingCountdownAsync();
+        await EnsureRecordingConsentAsync(RecordingType.Screen, cancellationToken);
+        await ShowRecordingCountdownAsync(cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
 
         SetRecordingState(RecordingType.Screen, true, args.DurationMs);
         try
@@ -1807,13 +1813,18 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
                 LocalizationHelper.GetString("Toast_ScreenRecordingStarted"),
                 LocalizationHelper.GetString("Toast_ScreenRecordingStartedDetail"),
                 "node:screen-recording-started");
-            var result = await _screenRecordingService.RecordAsync(args);
+            var result = await _screenRecordingService.RecordAsync(args, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
             RequestNodeToast(
                 LocalizationHelper.GetString("Toast_ScreenRecordingComplete"),
                 LocalizationHelper.GetString("Toast_ScreenRecordingCompleteDetail"),
                 "node:screen-recording-complete",
                 AppNotificationSeverity.Success);
             return result;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex) when (ex is not InvalidOperationException)
         {
@@ -1835,17 +1846,19 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
     
     #region Camera Capability Handlers
     
-    private Task<CameraInfo[]> OnCameraList()
+    private Task<CameraInfo[]> OnCameraList(CancellationToken cancellationToken)
     {
         if (_cameraCaptureService == null)
         {
             throw new InvalidOperationException("Camera capture service not available");
         }
         
-        return _cameraCaptureService.ListCamerasAsync();
+        return _cameraCaptureService.ListCamerasAsync(cancellationToken);
     }
     
-    private async Task<CameraSnapResult> OnCameraSnap(CameraSnapArgs args)
+    private async Task<CameraSnapResult> OnCameraSnap(
+        CameraSnapArgs args,
+        CancellationToken cancellationToken)
     {
         if (_cameraCaptureService == null)
         {
@@ -1854,7 +1867,7 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
         
         try
         {
-            return await _cameraCaptureService.SnapAsync(args);
+            return await _cameraCaptureService.SnapAsync(args, cancellationToken);
         }
         catch (UnauthorizedAccessException ex)
         {
@@ -1870,15 +1883,18 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
         }
     }
 
-    private async Task<CameraClipResult> OnCameraClip(CameraClipArgs args)
+    private async Task<CameraClipResult> OnCameraClip(
+        CameraClipArgs args,
+        CancellationToken cancellationToken)
     {
         if (_cameraCaptureService == null)
         {
             throw new InvalidOperationException("Camera capture service not available");
         }
 
-        await EnsureRecordingConsentAsync(RecordingType.Camera);
-        await ShowRecordingCountdownAsync();
+        await EnsureRecordingConsentAsync(RecordingType.Camera, cancellationToken);
+        await ShowRecordingCountdownAsync(cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
 
         SetRecordingState(RecordingType.Camera, true, args.DurationMs);
         try
@@ -1887,7 +1903,8 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
                 LocalizationHelper.GetString("Toast_CameraRecordingStarted"),
                 LocalizationHelper.GetString("Toast_CameraRecordingStartedDetail"),
                 "node:camera-recording-started");
-            var result = await _cameraCaptureService.ClipAsync(args);
+            var result = await _cameraCaptureService.ClipAsync(args, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
             RequestNodeToast(
                 LocalizationHelper.GetString("Toast_CameraRecordingComplete"),
                 LocalizationHelper.GetString("Toast_CameraRecordingCompleteDetail"),
@@ -2074,14 +2091,16 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
         });
     }
 
-    private async Task EnsureRecordingConsentAsync(RecordingType type)
+    private async Task EnsureRecordingConsentAsync(
+        RecordingType type,
+        CancellationToken cancellationToken)
     {
         if (HasRecordingConsent(type)) return;
 
         Task<bool>? existingConsentPrompt = null;
         TaskCompletionSource<bool>? ownedConsentPrompt = null;
 
-        await _consentLock.WaitAsync();
+        await _consentLock.WaitAsync(cancellationToken);
         try
         {
             // Re-check after acquiring lock: a prior caller may have resolved consent.
@@ -2105,18 +2124,35 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
 
         if (existingConsentPrompt != null)
         {
-            if (!await existingConsentPrompt)
+            if (!await existingConsentPrompt.WaitAsync(cancellationToken))
                 throw new InvalidOperationException("Recording denied: user has not given consent");
             return;
         }
 
+        var clearPrompt = true;
         try
         {
-            var consented = await ShowRecordingConsentDialogAsync(type);
+            var dialogTask = ShowRecordingConsentDialogAsync(type);
+            bool consented;
+            try
+            {
+                consented = await dialogTask.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                clearPrompt = false;
+                ObserveAbandonedConsentPrompt(dialogTask, type, ownedConsentPrompt!);
+                throw;
+            }
+
             ownedConsentPrompt!.TrySetResult(consented);
 
             if (!consented)
                 throw new InvalidOperationException("Recording denied: user has not given consent");
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch
         {
@@ -2125,16 +2161,54 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
         }
         finally
         {
-            await _consentLock.WaitAsync();
-            try
+            if (clearPrompt)
             {
-                if (ReferenceEquals(GetConsentPrompt(type), ownedConsentPrompt))
-                    SetConsentPrompt(type, null);
+                await ClearConsentPromptAsync(type, ownedConsentPrompt!);
             }
-            finally
-            {
-                _consentLock.Release();
-            }
+        }
+    }
+
+    private void ObserveAbandonedConsentPrompt(
+        Task<bool> dialogTask,
+        RecordingType type,
+        TaskCompletionSource<bool> consentPrompt)
+    {
+        _ = CompleteAbandonedConsentPromptAsync(dialogTask, type, consentPrompt);
+    }
+
+    private async Task CompleteAbandonedConsentPromptAsync(
+        Task<bool> dialogTask,
+        RecordingType type,
+        TaskCompletionSource<bool> consentPrompt)
+    {
+        try
+        {
+            consentPrompt.TrySetResult(await dialogTask);
+        }
+        catch (Exception ex)
+        {
+            _logger.Debug($"[RecordingConsent] Abandoned prompt completion failed: {ex.Message}");
+            consentPrompt.TrySetResult(false);
+        }
+        finally
+        {
+            await ClearConsentPromptAsync(type, consentPrompt);
+        }
+    }
+
+    private async Task ClearConsentPromptAsync(
+        RecordingType type,
+        TaskCompletionSource<bool> consentPrompt)
+    {
+        await _consentLock.WaitAsync();
+        try
+        {
+            if (ReferenceEquals(GetConsentPrompt(type), consentPrompt))
+                SetConsentPrompt(type, null);
+        }
+        finally
+        {
+            _consentLock.Release();
         }
     }
 
@@ -2195,7 +2269,7 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
         return dialogTcs.Task;
     }
 
-    private async Task ShowRecordingCountdownAsync()
+    private async Task ShowRecordingCountdownAsync(CancellationToken cancellationToken)
     {
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -2204,8 +2278,12 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
             try
             {
                 var countdown = new Dialogs.RecordingCountdownWindow(3);
-                await countdown.ShowCountdownAsync();
+                await countdown.ShowCountdownAsync(cancellationToken);
                 tcs.TrySetResult();
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                tcs.TrySetCanceled(cancellationToken);
             }
             catch (Exception ex)
             {
@@ -2218,7 +2296,7 @@ public sealed class NodeService : IDisposable, IAsyncDisposable
             return;
         }
 
-        await tcs.Task;
+        await tcs.Task.WaitAsync(cancellationToken);
     }
 
     #endregion

--- a/src/OpenClaw.Tray.WinUI/Services/ScreenCaptureService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ScreenCaptureService.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenClaw.Shared;
 using OpenClaw.Shared.Capabilities;
@@ -24,8 +25,11 @@ public class ScreenCaptureService
     /// <summary>
     /// Capture a screenshot
     /// </summary>
-    public Task<ScreenCaptureResult> CaptureAsync(ScreenCaptureArgs args)
+    public Task<ScreenCaptureResult> CaptureAsync(
+        ScreenCaptureArgs args,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         _logger.Info($"Capturing screen {args.MonitorIndex}, maxWidth={args.MaxWidth}");
         
         // Get screen bounds
@@ -83,12 +87,14 @@ public class ScreenCaptureService
         
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             hdcScreen = GetDC(IntPtr.Zero);
             hdcMem = CreateCompatibleDC(hdcScreen);
             hBitmap = CreateCompatibleBitmap(hdcScreen, width, height);
             hOld = SelectObject(hdcMem, hBitmap);
             
             BitBlt(hdcMem, 0, 0, width, height, hdcScreen, targetBounds.X, targetBounds.Y, SRCCOPY);
+            cancellationToken.ThrowIfCancellationRequested();
             
             // Optionally include mouse cursor
             if (args.IncludePointer)
@@ -115,6 +121,7 @@ public class ScreenCaptureService
                 width = newWidth;
                 height = newHeight;
             }
+            cancellationToken.ThrowIfCancellationRequested();
             
             // Encode to base64
             string base64;
@@ -143,6 +150,7 @@ public class ScreenCaptureService
                 
                 base64 = Convert.ToBase64String(ms.ToArray());
             }
+            cancellationToken.ThrowIfCancellationRequested();
             
             _logger.Info($"Screen captured: {width}x{height}, {base64.Length} bytes");
             

--- a/src/OpenClaw.Tray.WinUI/Services/ScreenRecordingService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ScreenRecordingService.cs
@@ -42,8 +42,11 @@ internal sealed class ScreenRecordingService : IDisposable
 
     // Public API
 
-    public async Task<ScreenRecordResult> RecordAsync(ScreenRecordArgs args)
+    public async Task<ScreenRecordResult> RecordAsync(
+        ScreenRecordArgs args,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var durationMs  = Math.Clamp(args.DurationMs, MinDurationMs, MaxDurationMs);
         var fps         = Math.Clamp((int)Math.Round(args.Fps), MinFps, MaxFps);
         var screenIndex = args.ScreenIndex;
@@ -92,9 +95,9 @@ internal sealed class ScreenRecordingService : IDisposable
             {
                 var waitMs = (int)(nextCapture - DateTime.UtcNow).TotalMilliseconds;
                 if (waitMs > 0)
-                    await Task.Delay(waitMs);
+                    await Task.Delay(waitMs, cancellationToken);
 
-                if (!await ready.WaitAsync(intervalMs * 2))
+                if (!await ready.WaitAsync(intervalMs * 2, cancellationToken))
                     continue;
 
                 var frame = Interlocked.Exchange(ref latestFrame, null);
@@ -110,8 +113,14 @@ internal sealed class ScreenRecordingService : IDisposable
 
                     try
                     {
-                        using var bmp = await SoftwareBitmap.CreateCopyFromSurfaceAsync(frame.Surface);
+                        using var bmp = await SoftwareBitmap
+                            .CreateCopyFromSurfaceAsync(frame.Surface)
+                            .AsTask(cancellationToken);
                         frames.Add(ExtractBitmapBytes(bmp));
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        throw;
                     }
                     catch (Exception ex)
                     {
@@ -132,7 +141,8 @@ internal sealed class ScreenRecordingService : IDisposable
 
         _logger.Info($"[ScreenRecording] Captured {frames.Count} frames, encoding...");
 
-        var base64 = await EncodeToMp4Async(frames, width, height, fps);
+        cancellationToken.ThrowIfCancellationRequested();
+        var base64 = await EncodeToMp4Async(frames, width, height, fps, cancellationToken);
         var actualDurationMs = (int)Math.Round(frames.Count * 1000.0 / fps);
 
         return new ScreenRecordResult
@@ -155,7 +165,11 @@ internal sealed class ScreenRecordingService : IDisposable
     // Encoding
 
     private static async Task<string> EncodeToMp4Async(
-        List<byte[]> frames, int width, int height, int fps)
+        List<byte[]> frames,
+        int width,
+        int height,
+        int fps,
+        CancellationToken cancellationToken)
     {
         if (frames.Count == 0)
             throw new InvalidOperationException("No frames to encode");
@@ -209,18 +223,19 @@ internal sealed class ScreenRecordingService : IDisposable
             try
             {
                 result = await transcoder
-                    .PrepareMediaStreamSourceTranscodeAsync(MakeMss(), output, MakeProfile());
+                    .PrepareMediaStreamSourceTranscodeAsync(MakeMss(), output, MakeProfile())
+                    .AsTask(cancellationToken);
             }
             catch (System.Runtime.InteropServices.COMException) when (hwEnabled)
             {
                 continue;
             }
             if (!result.CanTranscode) continue;
-            await result.TranscodeAsync();
+            await result.TranscodeAsync().AsTask(cancellationToken);
             var size = (uint)output.Size;
             if (size == 0) continue;
             var dr = new DataReader(output.GetInputStreamAt(0));
-            await dr.LoadAsync(size);
+            await dr.LoadAsync(size).AsTask(cancellationToken);
             var bytes = new byte[size];
             dr.ReadBytes(bytes);
             return Convert.ToBase64String(bytes);

--- a/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
@@ -2613,7 +2613,7 @@ public class ScreenCapabilityTests
     {
         var cap = new ScreenCapability(NullLogger.Instance);
         ScreenCaptureArgs? receivedArgs = null;
-        cap.CaptureRequested += (args) =>
+        cap.CaptureRequested += (args, _) =>
         {
             receivedArgs = args;
             return Task.FromResult(new ScreenCaptureResult { Format = "png", Width = 1920, Height = 1080, Base64 = "abc" });
@@ -2639,7 +2639,7 @@ public class ScreenCapabilityTests
     public async Task Capture_ReturnsError_WhenHandlerThrows()
     {
         var cap = new ScreenCapability(NullLogger.Instance);
-        cap.CaptureRequested += (args) => throw new InvalidOperationException("Display access denied");
+        cap.CaptureRequested += (args, _) => throw new InvalidOperationException("Display access denied");
 
         var req = new NodeInvokeRequest { Id = "s5", Command = "screen.snapshot", Args = Parse("""{}""") };
         var res = await cap.ExecuteAsync(req);
@@ -2651,7 +2651,7 @@ public class ScreenCapabilityTests
     public async Task Capture_ResponseIncludesDataUri()
     {
         var cap = new ScreenCapability(NullLogger.Instance);
-        cap.CaptureRequested += (args) => Task.FromResult(new ScreenCaptureResult
+        cap.CaptureRequested += (args, _) => Task.FromResult(new ScreenCaptureResult
         {
             Format = "png",
             Width = 1920,
@@ -2678,7 +2678,7 @@ public class ScreenCapabilityTests
         // downstream allocation (back-buffer sizes, image encoder buffers).
         var cap = new ScreenCapability(NullLogger.Instance);
         ScreenCaptureArgs? received = null;
-        cap.CaptureRequested += args =>
+        cap.CaptureRequested += (args, _) =>
         {
             received = args;
             return Task.FromResult(new ScreenCaptureResult { Format = "png", Width = 0, Height = 0, Base64 = "" });
@@ -2703,7 +2703,7 @@ public class ScreenCapabilityTests
     {
         var cap = new ScreenCapability(NullLogger.Instance);
         ScreenCaptureArgs? receivedArgs = null;
-        cap.CaptureRequested += (args) =>
+        cap.CaptureRequested += (args, _) =>
         {
             receivedArgs = args;
             return Task.FromResult(new ScreenCaptureResult { Format = "png", Width = 1920, Height = 1080, Base64 = "" });
@@ -2729,7 +2729,7 @@ public class ScreenCapabilityTests
         // cannot reach the data URI MIME type.
         var cap = new ScreenCapability(NullLogger.Instance);
         var handlerCalled = false;
-        cap.CaptureRequested += (_) =>
+        cap.CaptureRequested += (_, _) =>
         {
             handlerCalled = true;
             return Task.FromResult(new ScreenCaptureResult { Format = "png", Base64 = "x" });
@@ -2754,7 +2754,7 @@ public class ScreenCapabilityTests
         // Normalize the alias before invoking the capture handler.
         var cap = new ScreenCapability(NullLogger.Instance);
         ScreenCaptureArgs? received = null;
-        cap.CaptureRequested += (args) =>
+        cap.CaptureRequested += (args, _) =>
         {
             received = args;
             return Task.FromResult(new ScreenCaptureResult { Format = args.Format, Width = 10, Height = 10, Base64 = "data" });
@@ -2784,7 +2784,7 @@ public class ScreenCapabilityTests
     {
         // The response MIME type comes from the validated request format.
         var cap = new ScreenCapability(NullLogger.Instance);
-        cap.CaptureRequested += (_) => Task.FromResult(new ScreenCaptureResult
+        cap.CaptureRequested += (_, _) => Task.FromResult(new ScreenCaptureResult
         {
             Format = "svg+xml\";base64,evil",
             Width = 1,
@@ -2845,7 +2845,7 @@ public class ScreenCapabilityTests
     {
         var cap = new ScreenCapability(NullLogger.Instance);
         ScreenRecordArgs? receivedArgs = null;
-        cap.RecordRequested += (args) =>
+        cap.RecordRequested += (args, _) =>
         {
             receivedArgs = args;
             return Task.FromResult(new ScreenRecordResult
@@ -2881,7 +2881,7 @@ public class ScreenCapabilityTests
     {
         var cap = new ScreenCapability(NullLogger.Instance);
         var handlerCalled = false;
-        cap.RecordRequested += (args) =>
+        cap.RecordRequested += (args, _) =>
         {
             handlerCalled = true;
             return Task.FromResult(new ScreenRecordResult());
@@ -2904,7 +2904,7 @@ public class ScreenCapabilityTests
     public async Task Record_ReturnsMacCompatiblePayload()
     {
         var cap = new ScreenCapability(NullLogger.Instance);
-        cap.RecordRequested += (args) => Task.FromResult(new ScreenRecordResult
+        cap.RecordRequested += (args, _) => Task.FromResult(new ScreenRecordResult
         {
             Format = "mp4",
             Base64 = "abc123",
@@ -2945,7 +2945,7 @@ public class ScreenCapabilityTests
     {
         var cap = new ScreenCapability(NullLogger.Instance);
         ScreenRecordArgs? received = null;
-        cap.RecordRequested += (args) =>
+        cap.RecordRequested += (args, _) =>
         {
             received = args;
             return Task.FromResult(new ScreenRecordResult { Format = "mp4", Fps = args.Fps });
@@ -2969,7 +2969,7 @@ public class ScreenCapabilityTests
     {
         var cap = new ScreenCapability(NullLogger.Instance);
         ScreenRecordArgs? received = null;
-        cap.RecordRequested += (args) =>
+        cap.RecordRequested += (args, _) =>
         {
             received = args;
             return Task.FromResult(new ScreenRecordResult { Format = "mp4", Fps = args.Fps });
@@ -2992,12 +2992,40 @@ public class ScreenCapabilityTests
     public async Task Record_ReturnsError_WhenHandlerThrows()
     {
         var cap = new ScreenCapability(NullLogger.Instance);
-        cap.RecordRequested += (_) => throw new InvalidOperationException("Capture permission denied");
+        cap.RecordRequested += (_, _) => throw new InvalidOperationException("Capture permission denied");
 
         var req = new NodeInvokeRequest { Id = "s15", Command = "screen.record", Args = Parse("""{}""") };
         var res = await cap.ExecuteAsync(req);
         Assert.False(res.Ok);
         Assert.Equal("Recording failed", res.Error);
+    }
+
+    [Fact]
+    public async Task Record_PropagatesCancellationToken_AndReturnsCancelled()
+    {
+        var cap = new ScreenCapability(NullLogger.Instance);
+        var tokenObserved = false;
+        cap.RecordRequested += async (_, cancellationToken) =>
+        {
+            tokenObserved = cancellationToken.CanBeCanceled;
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return new ScreenRecordResult();
+        };
+        using var cts = new CancellationTokenSource();
+        var request = new NodeInvokeRequest
+        {
+            Id = "screen-cancel",
+            Command = "screen.record",
+            Args = Parse("""{"durationMs":10000}""")
+        };
+
+        var responseTask = cap.ExecuteAsync(request, cts.Token);
+        cts.Cancel();
+        var response = await responseTask;
+
+        Assert.True(tokenObserved);
+        Assert.False(response.Ok);
+        Assert.Equal("cancelled", response.Error);
     }
 }
 
@@ -3035,7 +3063,7 @@ public class CameraCapabilityTests
     public async Task List_ReturnsCameras_WhenHandler()
     {
         var cap = new CameraCapability(NullLogger.Instance);
-        cap.ListRequested += () => Task.FromResult(new[]
+        cap.ListRequested += _ => Task.FromResult(new[]
         {
             new CameraInfo { DeviceId = "cam-1", Name = "Front", IsDefault = true },
             new CameraInfo { DeviceId = "cam-2", Name = "Back", IsDefault = false }
@@ -3076,7 +3104,7 @@ public class CameraCapabilityTests
     {
         var cap = new CameraCapability(NullLogger.Instance);
         CameraSnapArgs? receivedArgs = null;
-        cap.SnapRequested += (args) =>
+        cap.SnapRequested += (args, _) =>
         {
             receivedArgs = args;
             return Task.FromResult(new CameraSnapResult { Format = "jpeg", Width = 640, Height = 480, Base64 = "img" });
@@ -3103,7 +3131,7 @@ public class CameraCapabilityTests
     {
         var cap = new CameraCapability(NullLogger.Instance);
         CameraSnapArgs? receivedArgs = null;
-        cap.SnapRequested += (args) =>
+        cap.SnapRequested += (args, _) =>
         {
             receivedArgs = args;
             return Task.FromResult(new CameraSnapResult { Format = "jpeg", Width = 640, Height = 480, Base64 = "img" });
@@ -3122,7 +3150,7 @@ public class CameraCapabilityTests
     public async Task Snap_ReturnsError_WhenHandlerThrows()
     {
         var cap = new CameraCapability(NullLogger.Instance);
-        cap.SnapRequested += (args) => throw new InvalidOperationException("Camera access blocked");
+        cap.SnapRequested += (args, _) => throw new InvalidOperationException("Camera access blocked");
 
         var req = new NodeInvokeRequest { Id = "cam6", Command = "camera.snap", Args = Parse("""{}""") };
         var res = await cap.ExecuteAsync(req);
@@ -3145,7 +3173,7 @@ public class CameraCapabilityTests
     {
         var cap = new CameraCapability(NullLogger.Instance);
         CameraClipArgs? receivedArgs = null;
-        cap.ClipRequested += (args) =>
+        cap.ClipRequested += (args, _) =>
         {
             receivedArgs = args;
             return Task.FromResult(new CameraClipResult { Format = "mp4", Base64 = "vid", DurationMs = args.DurationMs, HasAudio = true });
@@ -3169,7 +3197,7 @@ public class CameraCapabilityTests
     {
         var cap = new CameraCapability(NullLogger.Instance);
         CameraClipArgs? receivedArgs = null;
-        cap.ClipRequested += (args) =>
+        cap.ClipRequested += (args, _) =>
         {
             receivedArgs = args;
             return Task.FromResult(new CameraClipResult { Format = "mp4", Base64 = "vid", DurationMs = args.DurationMs, HasAudio = args.IncludeAudio });
@@ -3210,7 +3238,7 @@ public class CameraCapabilityTests
         // zero / negative seconds, which produced a degenerate file.
         var cap = new CameraCapability(NullLogger.Instance);
         CameraClipArgs? received = null;
-        cap.ClipRequested += args =>
+        cap.ClipRequested += (args, _) =>
         {
             received = args;
             return Task.FromResult(new CameraClipResult { Format = "mp4", Base64 = "", DurationMs = args.DurationMs, HasAudio = false });
@@ -3227,6 +3255,34 @@ public class CameraCapabilityTests
         Assert.NotNull(received);
         Assert.True(received!.DurationMs >= 100, $"duration not floor-clamped: {received.DurationMs}");
         Assert.True(received.DurationMs <= 60000);
+    }
+
+    [Fact]
+    public async Task Clip_PropagatesCancellationToken_AndReturnsCancelled()
+    {
+        var cap = new CameraCapability(NullLogger.Instance);
+        var tokenObserved = false;
+        cap.ClipRequested += async (_, cancellationToken) =>
+        {
+            tokenObserved = cancellationToken.CanBeCanceled;
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return new CameraClipResult();
+        };
+        using var cts = new CancellationTokenSource();
+        var request = new NodeInvokeRequest
+        {
+            Id = "camera-cancel",
+            Command = "camera.clip",
+            Args = Parse("""{"durationMs":10000}""")
+        };
+
+        var responseTask = cap.ExecuteAsync(request, cts.Token);
+        cts.Cancel();
+        var response = await responseTask;
+
+        Assert.True(tokenObserved);
+        Assert.False(response.Ok);
+        Assert.Equal("cancelled", response.Error);
     }
 }
 

--- a/tests/OpenClaw.Shared.Tests/InvocationCancellationRegistryTests.cs
+++ b/tests/OpenClaw.Shared.Tests/InvocationCancellationRegistryTests.cs
@@ -5,6 +5,15 @@ namespace OpenClaw.Shared.Tests;
 
 public sealed class InvocationCancellationRegistryTests
 {
+    private sealed class ManualTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = utcNow;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan duration) => _utcNow += duration;
+    }
+
     [Fact]
     public void TryCancel_CancelsOnlyMatchingInvocation()
     {
@@ -172,14 +181,125 @@ public sealed class InvocationCancellationRegistryTests
     }
 
     [Fact]
-    public async Task RegistrationWindow_RemainsAmbiguousWhenFirstDuplicateCompletes()
+    public void PendingCancellation_IsConsumedBeforeRegistrationReturns()
     {
-        var registry = new InvocationCancellationRegistry(allowDuplicateIds: true);
-        var cancellationTask = registry.TryCancelAfterRegistrationWindowAsync(
-            "request",
-            TimeSpan.FromMilliseconds(50),
-            CancellationToken.None);
+        var timeProvider = new ManualTimeProvider(DateTimeOffset.UnixEpoch);
+        var registry = new InvocationCancellationRegistry(
+            allowDuplicateIds: true,
+            pendingCancellationTtl: TimeSpan.FromSeconds(5),
+            timeProvider: timeProvider);
 
+        Assert.Equal(
+            InvocationCancellationResult.Pending,
+            registry.TryCancelOrRemember("request"));
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        Assert.True(registry.TryRegister("request", CancellationToken.None, out var invocationCandidate));
+        var invocation = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(invocationCandidate);
+        using (invocation)
+        {
+            Assert.True(invocation.CancelledByCaller);
+            Assert.True(invocation.Token.IsCancellationRequested);
+            Assert.False(invocation.TryComplete());
+        }
+    }
+
+    [Fact]
+    public void PendingCancellation_TakesPrecedenceOverAlreadyCancelledTransport()
+    {
+        using var transportCts = new CancellationTokenSource();
+        transportCts.Cancel();
+        var registry = new InvocationCancellationRegistry(
+            pendingCancellationTtl: TimeSpan.FromSeconds(5));
+
+        Assert.Equal(
+            InvocationCancellationResult.Pending,
+            registry.TryCancelOrRemember("request"));
+
+        Assert.True(registry.TryRegister("request", transportCts.Token, out var invocationCandidate));
+        var invocation = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(
+            invocationCandidate);
+        using (invocation)
+        {
+            Assert.True(invocation.CancelledByCaller);
+            Assert.True(invocation.Token.IsCancellationRequested);
+        }
+    }
+
+    [Fact]
+    public void PendingCancellation_WithDuplicateIdsCancelsFirstRegistrationOnly()
+    {
+        var registry = new InvocationCancellationRegistry(
+            allowDuplicateIds: true,
+            pendingCancellationTtl: TimeSpan.FromSeconds(5));
+
+        Assert.Equal(
+            InvocationCancellationResult.Pending,
+            registry.TryCancelOrRemember("request"));
+
+        Assert.True(registry.TryRegister("request", CancellationToken.None, out var firstCandidate));
+        Assert.True(registry.TryRegister("request", CancellationToken.None, out var secondCandidate));
+        using var first = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(
+            firstCandidate);
+        using var second = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(
+            secondCandidate);
+
+        Assert.True(first.CancelledByCaller);
+        Assert.False(second.CancelledByCaller);
+    }
+
+    [Fact]
+    public void PendingCancellation_ExpiresAfterTtl()
+    {
+        var timeProvider = new ManualTimeProvider(DateTimeOffset.UnixEpoch);
+        var registry = new InvocationCancellationRegistry(
+            pendingCancellationTtl: TimeSpan.FromSeconds(5),
+            timeProvider: timeProvider);
+
+        Assert.Equal(
+            InvocationCancellationResult.Pending,
+            registry.TryCancelOrRemember("request"));
+        timeProvider.Advance(TimeSpan.FromSeconds(5));
+
+        Assert.True(registry.TryRegister("request", CancellationToken.None, out var invocationCandidate));
+        var invocation = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(invocationCandidate);
+        using (invocation)
+        {
+            Assert.False(invocation.CancelledByCaller);
+            Assert.False(invocation.Token.IsCancellationRequested);
+        }
+    }
+
+    [Fact]
+    public void RepeatedPendingCancellation_DoesNotRefreshTtl()
+    {
+        var timeProvider = new ManualTimeProvider(DateTimeOffset.UnixEpoch);
+        var registry = new InvocationCancellationRegistry(
+            pendingCancellationTtl: TimeSpan.FromSeconds(5),
+            timeProvider: timeProvider);
+
+        Assert.Equal(
+            InvocationCancellationResult.Pending,
+            registry.TryCancelOrRemember("request"));
+        timeProvider.Advance(TimeSpan.FromSeconds(4));
+        Assert.Equal(
+            InvocationCancellationResult.Pending,
+            registry.TryCancelOrRemember("request"));
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        Assert.True(registry.TryRegister("request", CancellationToken.None, out var invocationCandidate));
+        using var invocation = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(
+            invocationCandidate);
+        Assert.False(invocation.CancelledByCaller);
+    }
+
+    [Fact]
+    public void LateCancellation_AfterCompletionDoesNotPoisonReuse()
+    {
+        var timeProvider = new ManualTimeProvider(DateTimeOffset.UnixEpoch);
+        var registry = new InvocationCancellationRegistry(
+            pendingCancellationTtl: TimeSpan.FromSeconds(5),
+            timeProvider: timeProvider);
         Assert.True(registry.TryRegister("request", CancellationToken.None, out var firstCandidate));
         var first = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(firstCandidate);
         using (first)
@@ -187,14 +307,71 @@ public sealed class InvocationCancellationRegistryTests
             Assert.True(first.TryComplete());
         }
 
-        Assert.True(registry.TryRegister("request", CancellationToken.None, out var secondCandidate));
-        var second = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(secondCandidate);
-        using (second)
+        Assert.Equal(
+            InvocationCancellationResult.NotFound,
+            registry.TryCancelOrRemember("request"));
+        Assert.Equal(0, registry.PendingCancellationCount);
+
+        Assert.True(registry.TryRegister("request", CancellationToken.None, out var replacementCandidate));
+        var replacement = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(replacementCandidate);
+        using (replacement)
         {
-            var result = await cancellationTask;
-            Assert.False(result.Cancelled);
-            Assert.True(result.Ambiguous);
-            Assert.False(second.Token.IsCancellationRequested);
+            Assert.False(replacement.CancelledByCaller);
+        }
+    }
+
+    [Fact]
+    public void PendingCancellationCap_EvictsOldestEntryDeterministically()
+    {
+        var timeProvider = new ManualTimeProvider(DateTimeOffset.UnixEpoch);
+        var registry = new InvocationCancellationRegistry(
+            pendingCancellationTtl: TimeSpan.FromSeconds(5),
+            maxPendingCancellations: 2,
+            timeProvider: timeProvider);
+
+        Assert.Equal(InvocationCancellationResult.Pending, registry.TryCancelOrRemember("first"));
+        Assert.Equal(InvocationCancellationResult.Pending, registry.TryCancelOrRemember("second"));
+        Assert.Equal(InvocationCancellationResult.Pending, registry.TryCancelOrRemember("third"));
+        Assert.Equal(2, registry.PendingCancellationCount);
+
+        Assert.True(registry.TryRegister("first", CancellationToken.None, out var firstCandidate));
+        Assert.True(registry.TryRegister("second", CancellationToken.None, out var secondCandidate));
+        Assert.True(registry.TryRegister("third", CancellationToken.None, out var thirdCandidate));
+        using var first = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(firstCandidate);
+        using var second = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(secondCandidate);
+        using var third = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(thirdCandidate);
+
+        Assert.False(first.CancelledByCaller);
+        Assert.True(second.CancelledByCaller);
+        Assert.True(third.CancelledByCaller);
+    }
+
+    [Fact]
+    public void RecentCompletionCap_EvictsOldestEntryDeterministically()
+    {
+        var timeProvider = new ManualTimeProvider(DateTimeOffset.UnixEpoch);
+        var registry = new InvocationCancellationRegistry(
+            pendingCancellationTtl: TimeSpan.FromSeconds(5),
+            maxRecentCompletions: 2,
+            timeProvider: timeProvider);
+
+        Complete("first");
+        Complete("second");
+        Complete("third");
+        Assert.Equal(2, registry.RecentCompletionCount);
+
+        Assert.Equal(InvocationCancellationResult.Pending, registry.TryCancelOrRemember("first"));
+        Assert.Equal(InvocationCancellationResult.NotFound, registry.TryCancelOrRemember("second"));
+        Assert.Equal(InvocationCancellationResult.NotFound, registry.TryCancelOrRemember("third"));
+
+        void Complete(string requestId)
+        {
+            Assert.True(registry.TryRegister(requestId, CancellationToken.None, out var candidate));
+            var invocation = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(candidate);
+            using (invocation)
+            {
+                Assert.True(invocation.TryComplete());
+            }
         }
     }
 }

--- a/tests/OpenClaw.Shared.Tests/InvocationCancellationRegistryTests.cs
+++ b/tests/OpenClaw.Shared.Tests/InvocationCancellationRegistryTests.cs
@@ -1,0 +1,200 @@
+using OpenClaw.Shared;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class InvocationCancellationRegistryTests
+{
+    [Fact]
+    public void TryCancel_CancelsOnlyMatchingInvocation()
+    {
+        var registry = new InvocationCancellationRegistry();
+        Assert.True(registry.TryRegister("first", CancellationToken.None, out var firstCandidate));
+        Assert.True(registry.TryRegister("second", CancellationToken.None, out var secondCandidate));
+        var first = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(firstCandidate);
+        var second = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(secondCandidate);
+        using (first)
+        using (second)
+        {
+            Assert.True(registry.TryCancel("first"));
+
+            Assert.True(first.Token.IsCancellationRequested);
+            Assert.True(first.CancelledByCaller);
+            Assert.False(second.Token.IsCancellationRequested);
+            Assert.False(second.CancelledByCaller);
+        }
+    }
+
+    [Fact]
+    public void TryRegister_RejectsDuplicateActiveId_AndAllowsReuseAfterCompletion()
+    {
+        var registry = new InvocationCancellationRegistry();
+        Assert.True(registry.TryRegister("same", CancellationToken.None, out var firstCandidate));
+        var first = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(firstCandidate);
+        using (first)
+        {
+            Assert.False(registry.TryRegister("same", CancellationToken.None, out var duplicate));
+            Assert.Null(duplicate);
+        }
+
+        Assert.True(registry.TryRegister("same", CancellationToken.None, out var replacementCandidate));
+        var replacement = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(replacementCandidate);
+        replacement.Dispose();
+    }
+
+    [Fact]
+    public void TransportCancellation_IsLinkedButNotMarkedAsCallerCancellation()
+    {
+        using var transportCts = new CancellationTokenSource();
+        var registry = new InvocationCancellationRegistry();
+        Assert.True(registry.TryRegister("request", transportCts.Token, out var invocationCandidate));
+        var invocation = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(invocationCandidate);
+        using (invocation)
+        {
+            transportCts.Cancel();
+
+            Assert.True(invocation.Token.IsCancellationRequested);
+            Assert.False(invocation.CancelledByCaller);
+        }
+    }
+
+    [Fact]
+    public void TryCancel_AfterTransportCancellation_DoesNotChangeCancellationReason()
+    {
+        using var transportCts = new CancellationTokenSource();
+        var registry = new InvocationCancellationRegistry();
+        Assert.True(registry.TryRegister("request", transportCts.Token, out var invocationCandidate));
+        var invocation = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(invocationCandidate);
+        using (invocation)
+        {
+            transportCts.Cancel();
+
+            Assert.False(registry.TryCancel("request"));
+            Assert.False(invocation.CancelledByCaller);
+        }
+    }
+
+    [Fact]
+    public void CancelAll_CancelsEveryActiveInvocation()
+    {
+        var registry = new InvocationCancellationRegistry();
+        Assert.True(registry.TryRegister("first", CancellationToken.None, out var firstCandidate));
+        Assert.True(registry.TryRegister("second", CancellationToken.None, out var secondCandidate));
+        var first = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(firstCandidate);
+        var second = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(secondCandidate);
+        using (first)
+        using (second)
+        {
+            registry.CancelAll();
+
+            Assert.True(first.Token.IsCancellationRequested);
+            Assert.True(second.Token.IsCancellationRequested);
+            Assert.False(first.CancelledByCaller);
+            Assert.False(second.CancelledByCaller);
+        }
+    }
+
+    [Fact]
+    public void TryCancel_UnknownOrCompletedId_IsHarmless()
+    {
+        var registry = new InvocationCancellationRegistry();
+        Assert.False(registry.TryCancel("missing"));
+
+        Assert.True(registry.TryRegister("done", CancellationToken.None, out var invocationCandidate));
+        var invocation = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(invocationCandidate);
+        invocation.Dispose();
+
+        Assert.False(registry.TryCancel("done"));
+    }
+
+    [Fact]
+    public void TryComplete_WinsAgainstLateCancellation()
+    {
+        var registry = new InvocationCancellationRegistry();
+        Assert.True(registry.TryRegister("request", CancellationToken.None, out var invocationCandidate));
+        var invocation = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(invocationCandidate);
+        using (invocation)
+        {
+            Assert.True(invocation.TryComplete());
+            Assert.False(registry.TryCancel("request"));
+            Assert.False(invocation.Token.IsCancellationRequested);
+        }
+    }
+
+    [Fact]
+    public void CallerCancellation_WinsAgainstLateCompletion()
+    {
+        var registry = new InvocationCancellationRegistry();
+        Assert.True(registry.TryRegister("request", CancellationToken.None, out var invocationCandidate));
+        var invocation = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(invocationCandidate);
+        using (invocation)
+        {
+            Assert.True(registry.TryCancel("request"));
+            Assert.False(invocation.TryComplete());
+            Assert.True(invocation.CancelledByCaller);
+        }
+    }
+
+    [Fact]
+    public void DuplicateIds_CanCoexistWhenEnabled_AndCancellationIsAmbiguous()
+    {
+        var registry = new InvocationCancellationRegistry(allowDuplicateIds: true);
+        Assert.True(registry.TryRegister("request", CancellationToken.None, out var firstCandidate));
+        Assert.True(registry.TryRegister("request", CancellationToken.None, out var secondCandidate));
+        var first = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(firstCandidate);
+        var second = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(secondCandidate);
+        using (first)
+        using (second)
+        {
+            Assert.False(registry.TryCancel("request", out var ambiguous));
+            Assert.True(ambiguous);
+            Assert.False(first.Token.IsCancellationRequested);
+            Assert.False(second.Token.IsCancellationRequested);
+        }
+    }
+
+    [Fact]
+    public void DuplicateIds_CanBeCancelledAfterOneCompletes()
+    {
+        var registry = new InvocationCancellationRegistry(allowDuplicateIds: true);
+        Assert.True(registry.TryRegister("request", CancellationToken.None, out var firstCandidate));
+        Assert.True(registry.TryRegister("request", CancellationToken.None, out var secondCandidate));
+        var first = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(firstCandidate);
+        var second = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(secondCandidate);
+        using (first)
+        using (second)
+        {
+            Assert.True(first.TryComplete());
+            Assert.True(registry.TryCancel("request", out var ambiguous));
+            Assert.False(ambiguous);
+            Assert.True(second.CancelledByCaller);
+        }
+    }
+
+    [Fact]
+    public async Task RegistrationWindow_RemainsAmbiguousWhenFirstDuplicateCompletes()
+    {
+        var registry = new InvocationCancellationRegistry(allowDuplicateIds: true);
+        var cancellationTask = registry.TryCancelAfterRegistrationWindowAsync(
+            "request",
+            TimeSpan.FromMilliseconds(50),
+            CancellationToken.None);
+
+        Assert.True(registry.TryRegister("request", CancellationToken.None, out var firstCandidate));
+        var first = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(firstCandidate);
+        using (first)
+        {
+            Assert.True(first.TryComplete());
+        }
+
+        Assert.True(registry.TryRegister("request", CancellationToken.None, out var secondCandidate));
+        var second = Assert.IsType<InvocationCancellationRegistry.InvocationCancellation>(secondCandidate);
+        using (second)
+        {
+            var result = await cancellationTask;
+            Assert.False(result.Cancelled);
+            Assert.True(result.Ambiguous);
+            Assert.False(second.Token.IsCancellationRequested);
+        }
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/McpToolBridgeTests.cs
+++ b/tests/OpenClaw.Shared.Tests/McpToolBridgeTests.cs
@@ -31,6 +31,53 @@ public class McpToolBridgeTests
                ?? Task.FromResult(new NodeInvokeResponse { Ok = true, Payload = new { echoed = request.Command } });
     }
 
+    private sealed class CancellableCapability : INodeCapability
+    {
+        private readonly TaskCompletionSource _entered =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _twoEntered =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _enteredCount;
+
+        public string Category => "slow";
+        public IReadOnlyList<string> Commands => ["slow.wait"];
+        public Task Entered => _entered.Task;
+        public Task TwoEntered => _twoEntered.Task;
+        public bool CanHandle(string command) => command == "slow.wait";
+
+        public Task<NodeInvokeResponse> ExecuteAsync(NodeInvokeRequest request)
+            => ExecuteAsync(request, CancellationToken.None);
+
+        public async Task<NodeInvokeResponse> ExecuteAsync(
+            NodeInvokeRequest request,
+            CancellationToken cancellationToken)
+        {
+            _entered.TrySetResult();
+            if (Interlocked.Increment(ref _enteredCount) == 2)
+            {
+                _twoEntered.TrySetResult();
+            }
+
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return new NodeInvokeResponse { Ok = true };
+        }
+    }
+
+    private sealed class CancellationResultCapability : INodeCapability
+    {
+        public string Category => "slow";
+        public IReadOnlyList<string> Commands => ["slow.result"];
+        public bool CanHandle(string command) => command == "slow.result";
+
+        public Task<NodeInvokeResponse> ExecuteAsync(NodeInvokeRequest request)
+            => ExecuteAsync(request, CancellationToken.None);
+
+        public Task<NodeInvokeResponse> ExecuteAsync(
+            NodeInvokeRequest request,
+            CancellationToken cancellationToken)
+            => Task.FromResult(new NodeInvokeResponse { Ok = false, Error = "cancelled" });
+    }
+
     private static McpToolBridge CreateBridge(IReadOnlyList<INodeCapability> caps)
         => new(() => caps);
 
@@ -179,6 +226,121 @@ public class McpToolBridgeTests
         var result = doc.RootElement.GetProperty("result");
         Assert.True(result.GetProperty("isError").GetBoolean());
         Assert.Contains("kaboom", result.GetProperty("content")[0].GetProperty("text").GetString());
+    }
+
+    [Fact]
+    public async Task CancellationNotification_CancelsMatchingToolsCall()
+    {
+        var capability = new CancellableCapability();
+        var bridge = CreateBridge([capability]);
+        var callTask = bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","id":"slow-1","method":"tools/call","params":{"name":"slow.wait","arguments":{}}}""");
+        await capability.Entered.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var notificationResponse = await bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":"slow-1","reason":"test"}}""");
+        Assert.Null(notificationResponse);
+
+        var response = await callTask.WaitAsync(TimeSpan.FromSeconds(5));
+        using var doc = JsonDocument.Parse(response!);
+        var result = doc.RootElement.GetProperty("result");
+        Assert.True(result.GetProperty("isError").GetBoolean());
+        Assert.Equal("cancelled", result.GetProperty("content")[0].GetProperty("text").GetString());
+    }
+
+    [Fact]
+    public async Task CancellationNotification_UnknownRequest_IsHarmless()
+    {
+        var bridge = CreateBridge([]);
+
+        var response = await bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":42}}""");
+
+        Assert.Null(response);
+    }
+
+    [Fact]
+    public async Task CancellationNotification_TransportCancellation_IsNotLoggedAsError()
+    {
+        var logger = new TestLogger();
+        var bridge = new McpToolBridge(() => [], logger);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var response = await bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":42}}""",
+            cts.Token);
+
+        Assert.Null(response);
+        Assert.DoesNotContain(logger.Logs, entry => entry.StartsWith("ERROR:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task CancellationNotification_BeforeRegistrationCancelsToolsCall()
+    {
+        var capability = new CancellableCapability();
+        var bridge = CreateBridge([capability]);
+
+        var notificationTask = bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":"pre-cancelled"}}""");
+        await Task.Delay(10);
+
+        var callTask = bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","id":"pre-cancelled","method":"tools/call","params":{"name":"slow.wait","arguments":{}}}""");
+        var notificationResponse = await notificationTask;
+        Assert.Null(notificationResponse);
+
+        var response = await callTask;
+        using var doc = JsonDocument.Parse(response!);
+        Assert.Equal(
+            "cancelled",
+            doc.RootElement.GetProperty("result").GetProperty("content")[0].GetProperty("text").GetString());
+    }
+
+    [Fact]
+    public async Task CancellationNotification_DuplicateActiveIds_AreNotCrossCancelled()
+    {
+        var capability = new CancellableCapability();
+        var bridge = CreateBridge([capability]);
+        using var transportCts = new CancellationTokenSource();
+        const string request =
+            """{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"slow.wait","arguments":{}}}""";
+
+        var firstCall = bridge.HandleRequestAsync(request, transportCts.Token);
+        var secondCall = bridge.HandleRequestAsync(request, transportCts.Token);
+        await capability.TwoEntered.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var notificationResponse = await bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1}}""");
+        Assert.Null(notificationResponse);
+        Assert.False(firstCall.IsCompleted);
+        Assert.False(secondCall.IsCompleted);
+
+        transportCts.Cancel();
+        await Task.WhenAll(firstCall, secondCall).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task CancellationNotification_PreservesNumericAndStringRequestIdIdentity()
+    {
+        var capability = new CancellableCapability();
+        var bridge = CreateBridge([capability]);
+        var callTask = bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","id":42,"method":"tools/call","params":{"name":"slow.wait","arguments":{}}}""");
+        await capability.Entered.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":"42"}}""");
+        Assert.False(callTask.IsCompleted);
+
+        await bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":42}}""");
+        var response = await callTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        using var doc = JsonDocument.Parse(response!);
+        Assert.Equal(
+            "cancelled",
+            doc.RootElement.GetProperty("result").GetProperty("content")[0].GetProperty("text").GetString());
     }
 
     [Fact]
@@ -333,6 +495,25 @@ public class McpToolBridgeTests
         var result = doc.RootElement.GetProperty("result");
         Assert.True(result.GetProperty("isError").GetBoolean());
         Assert.Contains("timed out", result.GetProperty("content")[0].GetProperty("text").GetString());
+    }
+
+    [Fact]
+    public async Task ToolsCall_TransportCancellationOverridesCapabilityCancelledResult()
+    {
+        var bridge = CreateBridge([new CancellationResultCapability()]);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var response = await bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"slow.result"}}""",
+            cts.Token);
+
+        using var doc = JsonDocument.Parse(response!);
+        var result = doc.RootElement.GetProperty("result");
+        Assert.True(result.GetProperty("isError").GetBoolean());
+        Assert.Equal(
+            "request timed out",
+            result.GetProperty("content")[0].GetProperty("text").GetString());
     }
 
     [Fact]

--- a/tests/OpenClaw.Shared.Tests/McpToolBridgeTests.cs
+++ b/tests/OpenClaw.Shared.Tests/McpToolBridgeTests.cs
@@ -12,6 +12,15 @@ namespace OpenClaw.Shared.Tests;
 
 public class McpToolBridgeTests
 {
+    private sealed class ManualTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = utcNow;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan duration) => _utcNow += duration;
+    }
+
     private sealed class FakeCapability : INodeCapability
     {
         public string Category { get; }
@@ -43,6 +52,7 @@ public class McpToolBridgeTests
         public IReadOnlyList<string> Commands => ["slow.wait"];
         public Task Entered => _entered.Task;
         public Task TwoEntered => _twoEntered.Task;
+        public int ExecuteCount => Volatile.Read(ref _enteredCount);
         public bool CanHandle(string command) => command == "slow.wait";
 
         public Task<NodeInvokeResponse> ExecuteAsync(NodeInvokeRequest request)
@@ -80,6 +90,11 @@ public class McpToolBridgeTests
 
     private static McpToolBridge CreateBridge(IReadOnlyList<INodeCapability> caps)
         => new(() => caps);
+
+    private static McpToolBridge CreateBridge(
+        IReadOnlyList<INodeCapability> caps,
+        InvocationCancellationRegistry registry)
+        => new(() => caps, null, "test-mcp", "1.0.0", registry);
 
     [Fact]
     public async Task Initialize_ReturnsProtocolAndServerInfo()
@@ -278,23 +293,51 @@ public class McpToolBridgeTests
     [Fact]
     public async Task CancellationNotification_BeforeRegistrationCancelsToolsCall()
     {
+        var timeProvider = new ManualTimeProvider(DateTimeOffset.UnixEpoch);
+        var registry = new InvocationCancellationRegistry(
+            allowDuplicateIds: true,
+            pendingCancellationTtl: TimeSpan.FromSeconds(5),
+            timeProvider: timeProvider);
         var capability = new CancellableCapability();
-        var bridge = CreateBridge([capability]);
+        var bridge = CreateBridge([capability], registry);
 
-        var notificationTask = bridge.HandleRequestAsync(
+        var notificationResponse = await bridge.HandleRequestAsync(
             """{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":"pre-cancelled"}}""");
-        await Task.Delay(10);
-
-        var callTask = bridge.HandleRequestAsync(
-            """{"jsonrpc":"2.0","id":"pre-cancelled","method":"tools/call","params":{"name":"slow.wait","arguments":{}}}""");
-        var notificationResponse = await notificationTask;
         Assert.Null(notificationResponse);
+        Assert.Equal(1, registry.PendingCancellationCount);
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
 
-        var response = await callTask;
+        var response = await bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","id":"pre-cancelled","method":"tools/call","params":{"name":"slow.wait","arguments":{}}}""");
         using var doc = JsonDocument.Parse(response!);
         Assert.Equal(
             "cancelled",
             doc.RootElement.GetProperty("result").GetProperty("content")[0].GetProperty("text").GetString());
+        Assert.Equal(0, capability.ExecuteCount);
+    }
+
+    [Fact]
+    public async Task PendingCancellation_IsReportedWhenTransportIsAlreadyCancelled()
+    {
+        var registry = new InvocationCancellationRegistry(
+            allowDuplicateIds: true,
+            pendingCancellationTtl: TimeSpan.FromSeconds(5));
+        var capability = new CancellableCapability();
+        var bridge = CreateBridge([capability], registry);
+        using var transportCts = new CancellationTokenSource();
+
+        await bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":"pre-cancelled"}}""");
+        transportCts.Cancel();
+
+        var response = await bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","id":"pre-cancelled","method":"tools/call","params":{"name":"slow.wait","arguments":{}}}""",
+            transportCts.Token);
+        using var doc = JsonDocument.Parse(response!);
+        Assert.Equal(
+            "cancelled",
+            doc.RootElement.GetProperty("result").GetProperty("content")[0].GetProperty("text").GetString());
+        Assert.Equal(0, capability.ExecuteCount);
     }
 
     [Fact]

--- a/tests/OpenClaw.Shared.Tests/McpToolBridgeTests.cs
+++ b/tests/OpenClaw.Shared.Tests/McpToolBridgeTests.cs
@@ -387,6 +387,44 @@ public class McpToolBridgeTests
     }
 
     [Fact]
+    public async Task CancellationNotification_MatchesEquivalentEscapedStringRequestId()
+    {
+        var capability = new CancellableCapability();
+        var bridge = CreateBridge([capability]);
+        var callTask = bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","id":"request","method":"tools/call","params":{"name":"slow.wait","arguments":{}}}""");
+        await capability.Entered.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":"\u0072equest"}}""");
+        var response = await callTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        using var doc = JsonDocument.Parse(response!);
+        Assert.Equal(
+            "cancelled",
+            doc.RootElement.GetProperty("result").GetProperty("content")[0].GetProperty("text").GetString());
+    }
+
+    [Fact]
+    public async Task CancellationNotification_MatchesEquivalentNumericRequestId()
+    {
+        var capability = new CancellableCapability();
+        var bridge = CreateBridge([capability]);
+        var callTask = bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","id":1.0e2,"method":"tools/call","params":{"name":"slow.wait","arguments":{}}}""");
+        await capability.Entered.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await bridge.HandleRequestAsync(
+            """{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":100}}""");
+        var response = await callTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        using var doc = JsonDocument.Parse(response!);
+        Assert.Equal(
+            "cancelled",
+            doc.RootElement.GetProperty("result").GetProperty("content")[0].GetProperty("text").GetString());
+    }
+
+    [Fact]
     public async Task UnknownMethod_ReturnsJsonRpcMethodNotFound()
     {
         var bridge = CreateBridge(new List<INodeCapability>());

--- a/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
@@ -1887,6 +1887,103 @@ public class WindowsNodeClientTests
     }
 
     [Fact]
+    public async Task CommandDispatch_RequestPath_ThrowingCompletionSubscriber_DoesNotSuppressResponse()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new CapturingWindowsNodeClient(
+                "ws://localhost:18789",
+                "test-token",
+                dataPath);
+            var capability = new MockCapability("mock", "mock.ping");
+            client.RegisterCapability(capability);
+            var laterSubscriberCalled = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            client.InvokeCompleted += (_, _) => throw new InvalidOperationException("subscriber failure");
+            client.InvokeCompleted += (_, args) =>
+            {
+                if (args.RequestId == "invoke-throw-request")
+                {
+                    laterSubscriberCalled.TrySetResult();
+                }
+            };
+
+            await InvokeProcessMessageAsync(
+                client,
+                BuildNodeInvokeRequest("invoke-throw-request", "mock.ping"));
+
+            await laterSubscriberCalled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            var responseJson = await WaitForSentMessageAsync(
+                client,
+                message => message.Contains("\"id\":\"invoke-throw-request\"", StringComparison.Ordinal));
+            using var response = JsonDocument.Parse(responseJson);
+            Assert.Equal("res", response.RootElement.GetProperty("type").GetString());
+            Assert.True(response.RootElement.GetProperty("ok").GetBoolean());
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public async Task CommandDispatch_EventPath_ThrowingCompletionSubscriber_DoesNotSuppressResult()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+
+        try
+        {
+            using var client = new CapturingWindowsNodeClient(
+                "ws://localhost:18789",
+                "test-token",
+                dataPath);
+            var capability = new MockCapability("mock", "mock.ping");
+            client.RegisterCapability(capability);
+            var laterSubscriberCalled = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            client.InvokeCompleted += (_, _) => throw new InvalidOperationException("subscriber failure");
+            client.InvokeCompleted += (_, args) =>
+            {
+                if (args.RequestId == "invoke-throw-event")
+                {
+                    laterSubscriberCalled.TrySetResult();
+                }
+            };
+
+            await InvokeProcessMessageAsync(client, """
+                {
+                  "type": "event",
+                  "event": "node.invoke.request",
+                  "payload": {
+                    "requestId": "invoke-throw-event",
+                    "command": "mock.ping",
+                    "args": {}
+                  }
+                }
+                """);
+
+            await laterSubscriberCalled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            var responseJson = await WaitForSentMessageAsync(
+                client,
+                message => message.Contains("\"method\":\"node.invoke.result\"", StringComparison.Ordinal) &&
+                           message.Contains("\"id\":\"invoke-throw-event\"", StringComparison.Ordinal));
+            using var response = JsonDocument.Parse(responseJson);
+            Assert.Equal("req", response.RootElement.GetProperty("type").GetString());
+            Assert.True(response.RootElement.GetProperty("params").GetProperty("ok").GetBoolean());
+        }
+        finally
+        {
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
     public async Task CommandDispatch_SlowCapability_DoesNotBlockNextInvoke()
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
@@ -2191,6 +2288,25 @@ public class WindowsNodeClientTests
         Assert.NotNull(processMethod);
         var task = (Task)processMethod!.Invoke(client, [json])!;
         await task;
+    }
+
+    private static async Task<string> WaitForSentMessageAsync(
+        CapturingWindowsNodeClient client,
+        Func<string, bool> predicate)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (!timeout.IsCancellationRequested)
+        {
+            var message = client.SentMessages.FirstOrDefault(predicate);
+            if (message != null)
+            {
+                return message;
+            }
+
+            await Task.Delay(10, timeout.Token);
+        }
+
+        throw new TimeoutException("Expected gateway response was not sent.");
     }
 
     private static string BuildNodeInvokeRequest(string requestId, string command)

--- a/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
@@ -1956,6 +1956,161 @@ public class WindowsNodeClientTests
     }
 
     [Fact]
+    public async Task CommandDispatch_RequestCancel_CancelsMatchingInvoke()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+        var blocking = new BlockingCapability("mock", "mock.slow");
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+            client.RegisterCapability(blocking);
+            var completedTcs = new TaskCompletionSource<NodeInvokeCompletedEventArgs>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            client.InvokeCompleted += (_, args) =>
+            {
+                if (args.RequestId == "inv-cancel")
+                {
+                    completedTcs.TrySetResult(args);
+                }
+            };
+
+            await InvokeProcessMessageAsync(client, BuildNodeInvokeRequest("inv-cancel", "mock.slow"));
+            await blocking.ExpectedEnteredTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await InvokeProcessMessageAsync(client, """
+                {
+                  "type": "req",
+                  "id": "cancel-request",
+                  "method": "node.invoke.cancel",
+                  "params": {
+                    "requestId": "inv-cancel"
+                  }
+                }
+                """);
+
+            await blocking.AllCompletedTask.WaitAsync(TimeSpan.FromSeconds(5));
+            var completed = await completedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.False(completed.Ok);
+            Assert.Equal("cancelled", completed.Error);
+        }
+        finally
+        {
+            blocking.Release();
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public async Task CommandDispatch_EventCancel_CancelsMatchingEventInvoke()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+        var blocking = new BlockingCapability("mock", "mock.slow");
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+            client.RegisterCapability(blocking);
+            var completedTcs = new TaskCompletionSource<NodeInvokeCompletedEventArgs>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            client.InvokeCompleted += (_, args) =>
+            {
+                if (args.RequestId == "event-cancel")
+                {
+                    completedTcs.TrySetResult(args);
+                }
+            };
+
+            await InvokeProcessMessageAsync(client, """
+                {
+                  "type": "event",
+                  "event": "node.invoke.request",
+                  "payload": {
+                    "requestId": "event-cancel",
+                    "command": "mock.slow",
+                    "args": {}
+                  }
+                }
+
+                """);
+            await blocking.ExpectedEnteredTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await InvokeProcessMessageAsync(client, """
+                {
+                  "type": "event",
+                  "event": "node.invoke.cancel",
+                  "payload": {
+                    "invokeId": "event-cancel"
+                  }
+                }
+                """);
+
+            await blocking.AllCompletedTask.WaitAsync(TimeSpan.FromSeconds(5));
+            var completed = await completedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.False(completed.Ok);
+            Assert.Equal("cancelled", completed.Error);
+        }
+        finally
+        {
+            blocking.Release();
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
+    public async Task CommandDispatch_RequestNotificationCancel_ReadsParamsWithoutResponseId()
+    {
+        var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataPath);
+        var blocking = new BlockingCapability("mock", "mock.slow");
+
+        try
+        {
+            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+            client.RegisterCapability(blocking);
+            var completedTcs = new TaskCompletionSource<NodeInvokeCompletedEventArgs>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            client.InvokeCompleted += (_, args) =>
+            {
+                if (args.RequestId == "notification-cancel")
+                {
+                    completedTcs.TrySetResult(args);
+                }
+            };
+
+            await InvokeProcessMessageAsync(
+                client,
+                BuildNodeInvokeRequest("notification-cancel", "mock.slow"));
+            await blocking.ExpectedEnteredTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await InvokeProcessMessageAsync(client, """
+                {
+                  "type": "req",
+                  "method": "node.invoke.cancel",
+                  "params": {
+                    "invokeId": "notification-cancel"
+                  }
+                }
+                """);
+
+            await blocking.AllCompletedTask.WaitAsync(TimeSpan.FromSeconds(5));
+            var completed = await completedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.False(completed.Ok);
+            Assert.Equal("cancelled", completed.Error);
+        }
+        finally
+        {
+            blocking.Release();
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+        }
+    }
+
+    [Fact]
     public async Task CommandDispatch_ArgsSurviveAfterProcessMessageReturns()
     {
         var dataPath = Path.Combine(Path.GetTempPath(), $"openclaw-node-test-{Guid.NewGuid():N}");

--- a/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WindowsNodeClientTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,6 +16,20 @@ namespace OpenClaw.Shared.Tests;
 [Collection(AppVersionInfoTestCollection.Name)]
 public class WindowsNodeClientTests
 {
+    private sealed class CapturingWindowsNodeClient(
+        string gatewayUrl,
+        string token,
+        string dataPath) : WindowsNodeClient(gatewayUrl, token, dataPath)
+    {
+        public ConcurrentQueue<string> SentMessages { get; } = new();
+
+        protected override Task SendRawAsync(string message)
+        {
+            SentMessages.Enqueue(message);
+            return Task.CompletedTask;
+        }
+    }
+
     [Theory]
     [InlineData("http://localhost:18789", "ws://localhost:18789")]
     [InlineData("https://host.tailnet.ts.net", "wss://host.tailnet.ts.net")]
@@ -1964,7 +1979,10 @@ public class WindowsNodeClientTests
 
         try
         {
-            using var client = new WindowsNodeClient("ws://localhost:18789", "test-token", dataPath);
+            using var client = new CapturingWindowsNodeClient(
+                "ws://localhost:18789",
+                "test-token",
+                dataPath);
             client.RegisterCapability(blocking);
             var completedTcs = new TaskCompletionSource<NodeInvokeCompletedEventArgs>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1989,6 +2007,18 @@ public class WindowsNodeClientTests
                   }
                 }
                 """);
+
+            var cancelResponseJson = Assert.Single(
+                client.SentMessages,
+                message => message.Contains("\"id\":\"cancel-request\"", StringComparison.Ordinal));
+            using var cancelResponse = JsonDocument.Parse(cancelResponseJson);
+            Assert.Equal("res", cancelResponse.RootElement.GetProperty("type").GetString());
+            Assert.True(cancelResponse.RootElement.GetProperty("ok").GetBoolean());
+            Assert.True(
+                cancelResponse.RootElement
+                    .GetProperty("payload")
+                    .GetProperty("cancelled")
+                    .GetBoolean());
 
             await blocking.AllCompletedTask.WaitAsync(TimeSpan.FromSeconds(5));
             var completed = await completedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\GatewayNavVisibilityDebouncePolicy.cs" Link="Services\GatewayNavVisibilityDebouncePolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeInvokeActivityFormatter.cs" Link="Services\NodeInvokeActivityFormatter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeCapabilityGating.cs" Link="Services\NodeCapabilityGating.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\CaptureOperationGate.cs" Link="Services\CaptureOperationGate.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\BrowserProxyTunnelState.cs" Link="Services\BrowserProxyTunnelState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\CommandCenterTopologyTunnelResolver.cs" Link="Services\CommandCenterTopologyTunnelResolver.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\CommandCenterTunnelInfoBuilder.cs" Link="Services\CommandCenterTunnelInfoBuilder.cs" />

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeInvokeActivityFormatter.cs" Link="Services\NodeInvokeActivityFormatter.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\NodeCapabilityGating.cs" Link="Services\NodeCapabilityGating.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\CaptureOperationGate.cs" Link="Services\CaptureOperationGate.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\CaptureCancellationPolicy.cs" Link="Services\CaptureCancellationPolicy.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\BrowserProxyTunnelState.cs" Link="Services\BrowserProxyTunnelState.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\CommandCenterTopologyTunnelResolver.cs" Link="Services\CommandCenterTopologyTunnelResolver.cs" />
     <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\CommandCenterTunnelInfoBuilder.cs" Link="Services\CommandCenterTunnelInfoBuilder.cs" />

--- a/tests/OpenClaw.Tray.Tests/Services/CaptureCancellationPolicyTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Services/CaptureCancellationPolicyTests.cs
@@ -1,0 +1,51 @@
+using OpenClawTray.Services;
+using Xunit;
+
+namespace OpenClaw.Tray.Tests.Services;
+
+public sealed class CaptureCancellationPolicyTests
+{
+    [Fact]
+    public void CaptureFailure_RemainsPrimaryWhenCancellationRaces()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var captureFailure = new InvalidOperationException("camera hardware failed");
+
+        var observed = Record.Exception(() => SimulateCaptureFinally(
+            captureFailure,
+            cancellation.Token));
+
+        Assert.Same(captureFailure, observed);
+    }
+
+    [Fact]
+    public void Cancellation_IsThrownWhenCaptureHasNoPrimaryFailure()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() =>
+            CaptureCancellationPolicy.ThrowIfCancellationRequested(
+                primaryException: null,
+                cancellation.Token));
+    }
+
+    private static void SimulateCaptureFinally(
+        Exception captureFailure,
+        CancellationToken cancellationToken)
+    {
+        Exception? primaryException = null;
+        try
+        {
+            primaryException = captureFailure;
+            throw captureFailure;
+        }
+        finally
+        {
+            CaptureCancellationPolicy.ThrowIfCancellationRequested(
+                primaryException,
+                cancellationToken);
+        }
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/Services/CaptureOperationGateTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Services/CaptureOperationGateTests.cs
@@ -1,0 +1,24 @@
+using OpenClawTray.Services;
+using Xunit;
+
+namespace OpenClaw.Tray.Tests.Services;
+
+public sealed class CaptureOperationGateTests
+{
+    [Fact]
+    public async Task EnterAsync_CancelledWaiter_DoesNotEnterLater()
+    {
+        using var gate = new CaptureOperationGate();
+        using var first = await gate.EnterAsync(CancellationToken.None);
+        using var cts = new CancellationTokenSource();
+
+        var queued = gate.EnterAsync(cts.Token).AsTask();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => queued);
+        first.Dispose();
+
+        using var next = await gate.EnterAsync(CancellationToken.None);
+        Assert.True(queued.IsCanceled);
+    }
+}


### PR DESCRIPTION
Related: #357

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where cancelled or timed-out screen and camera requests could continue capturing, and queued camera work could begin after its caller had already stopped waiting.

## Why This Change Was Made

This revisits the cancellation work attempted in closed PR #403 on top of the bounded concurrent dispatch architecture merged in #426. It preserves #426's receive loop and eight-invocation limit, keeps cancellation tokens outside serializable request DTOs, and supports both gateway `node.invoke.cancel` and MCP `notifications/cancelled` without adding transport deadline policy.

Cancellation propagates through consent, countdown, queued camera admission, native capture waits, recording, and cleanup. MCP cancellation that arrives before registration is retained as a bounded five-second tombstone and consumed before capability execution, replacing the previous scheduler-dependent 100 ms probe. JSON-RPC request IDs match by decoded string or normalized arbitrary-precision numeric value while preserving string-versus-number identity. Completion remains the linearization point: once execution commits completion, later cancellation is too late.

Duplicate simultaneously active MCP IDs remain fail-safe and cancel none. Because stateless MCP HTTP has no client identity, a pre-registration tombstone consumes the first later matching ID; complete cross-client isolation would require a transport/protocol identity change and is outside this fix.

Gateway completion notifications isolate each subscriber so a faulty event handler cannot suppress later subscribers or the already-committed wire response. MCP cancellation outcome state is captured before invocation registration disposal. When camera preview failure races cancellation, the primary capture/hardware exception is preserved for diagnosis; cancellation remains the outcome when no primary capture failure exists.

## User Impact

Cancelled screen recordings, camera clips, snapshots, consent waits, countdowns, and queued camera requests now stop cooperatively instead of continuing after the caller leaves. Gateway and local MCP callers receive a stable `cancelled` outcome when cancellation wins, equivalent JSON-RPC ID encodings cancel the same request, and completion observers cannot prevent gateway callers from receiving their response.

## Evidence

- Deterministic production-registry and JSON-RPC bridge tests cover pre-registration tombstones, five-second expiry, non-refreshing duplicate notifications, bounded eviction, completion/reuse protection, equivalent escaped-string and numeric IDs, string-versus-number identity, duplicate-active-ID ambiguity, cancellation classification, and capability short-circuiting.
- Gateway tests cover request/event cancellation, completion ordering, token propagation, request-form `{ cancelled: true }`, and response delivery when an `InvokeCompleted` subscriber throws.
- Focused camera tests prove the exact primary capture exception survives concurrent cancellation and that cancellation still throws when there is no primary failure.
- Current-head raw MCP proof sent cancellation with an escaped string ID, waited one second, and observed a semantically equivalent `camera.clip` call return `cancelled` before consent or hardware entry.
- Current-head Hanselman dual-model review found no substantive correctness, security, or race issues. One reviewer noted the intentional completion-event-before-wire-response ordering as a theoretical defense-in-depth consideration, while confirming subscriber isolation fully resolves the reported bug and recommending no change.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [x] Windows node capability
- [x] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [x] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `.\build.ps1` — passed; Shared, CLI, WinNode CLI, SetupEngine, and WinUI built successfully.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` — 2,898 passed, 31 skipped, 0 failed.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` — 1,720 passed, 0 skipped, 0 failed.
- Focused registry/MCP cancellation and gateway dispatch selector — 73 passed, 0 failed.
- `git diff --check` — passed.

## Real Behavior Proof

- Environment tested: Windows 11 ARM64, .NET SDK 10.0.301, isolated tray data directory, dynamically allocated loopback MCP port.
- PR head or commit tested: Current branch head.
- Exact steps or command run: launched the current build in MCP-only mode with isolated `OPENCLAW_TRAY_DATA_DIR` and `OPENCLAW_MCP_PORT`; completed `notifications/cancelled` using request ID `\u0072equest`; waited one second; sent `camera.clip` using the equivalent decoded ID `request`.
- Evidence after fix: cancellation HTTP status `204`; call HTTP status `200`; `IsError=true`; result text `cancelled`.
- Observed result: canonical request-ID matching consumed the pending cancellation before camera consent or hardware capture began.
- Screenshot or artifact links verified? (`Yes`/`No`/`N/A`): N/A
- Not verified or blocked: live upstream gateway cancellation and active physical-camera/screen-recording teardown were not exercised because the isolated profile had no configured gateway or active capture session.

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No
- Secrets or tokens handling changed? (`Yes`/`No`): No
- New or changed network calls? (`Yes`/`No`): No
- Command or tool execution surface changed? (`Yes`/`No`): No
- Data access scope changed? (`Yes`/`No`): No
- If any answer is `Yes`, explain the risk and mitigation: N/A

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes
- Config or environment changes? (`Yes`/`No`): No
- Migration needed? (`Yes`/`No`): No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.