### PR TITLE
Add DI composition root and navigation/activation seam for tray view models

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,6 +54,9 @@ These are the canonical homes. Do not reintroduce private copies elsewhere.
 | Settings test data | `OpenClaw.TestSupport.SettingsDataBuilder` | authoritative |
 | JSON `JsonElement` coercion (non-nullable fallback family) | `JsonReadHelpers` | authoritative |
 | WSL/POSIX shell quoting | `WslShellQuoting` | authoritative |
+| UI-thread marshaling for presentation code | `IUiDispatcher` | authoritative |
+| Page view-model activation/deactivation + disposal lifetime | `NavigationScopeManager` | authoritative |
+| Presentation-layer DI composition root | `AppServiceRegistration` (root `ServiceProvider`, owned by `App`) | authoritative |
 | Capability UI metadata | `NodeCapabilityUiCatalog` (planned) | planned |
 | Capability registration/gating | `NodeCapabilityRegistrationPolicy` (planned) | planned |
 | Local MCP exposure policy | `McpCapabilityPolicy` (planned) | planned |
@@ -116,6 +119,9 @@ leading and trailing pipe. Columns, in order:
 | chat-send-queue | planned | src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs | send queue/admission/abort state | ChatSendQueue | - | queued send/abort/generation semantics preserved | none | review-only | extracted in Phase 4 |
 | gateway-pending-requests | planned | src/OpenClaw.Shared/OpenClawGatewayClient.cs | request-id -> method/completion tracking | PendingRequestRegistry | - | request ids never leak after disconnect; thread-safe | none | review-only | extracted in Phase 4 |
 | connect-envelope | planned | src/OpenClaw.Shared/OpenClawGatewayClient.cs + WindowsNodeClient.cs | connect message + auth precedence + signature version | ConnectEnvelopeBuilder | - | credential precedence never downgrades a device token; v3->v2 fallback preserved | none | review-only | extracted in Phase 4 |
+| ui-dispatcher | authoritative | src/OpenClaw.Tray.WinUI/App.xaml.cs | UI-thread marshaling abstraction for presentation code | IUiDispatcher | App and existing WinUI code may call DispatcherQueue directly until the view-model migration | presentation view models depend on IUiDispatcher not a concrete DispatcherQueue | UiDispatcherContractTests.PageViewModel_ReceivesRegisteredDispatcher | behavioral | - |
+| navigation-scope | authoritative | src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs | page view-model activation/deactivation and disposal lifetime | NavigationScopeManager | HubWindow keeps frame navigation back-stack and rail selection | transient page view models are activated on navigation and deactivated then disposed on navigate-away | NavigationScopeManagerTests.NavigatingAway_DeactivatesAndDisposesPreviousViewModel | behavioral | - |
+| composition-root | authoritative | src/OpenClaw.Tray.WinUI/App.xaml.cs | presentation-layer service construction and wiring | AppServiceRegistration | App remains the composition root and owns non-DI service lifetimes | one validated root ServiceProvider; App-owned singletons registered as instances are never disposed by the container | AppServiceRegistrationTests.Dispose_DoesNotDisposeAppOwnedInstanceSingletons | behavioral | - |
 <!-- LEDGER:END -->
 
 ## Deferred test builders

--- a/src/OpenClaw.Tray.WinUI/App.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/App.xaml.cs
@@ -13,6 +13,9 @@ using OpenClawTray.Helpers;
 using OpenClawTray.Services;
 using OpenClawTray.Windows;
 using OpenClaw.Connection;
+using Microsoft.Extensions.DependencyInjection;
+using OpenClawTray.Presentation;
+using OpenClawTray.Presentation.Adapters;
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
@@ -49,6 +52,29 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
     private GatewayConnectionManager? _connectionManager;
     private GatewayRegistry? _gatewayRegistry;
     private OpenClawTray.Chat.OpenClawChatCoordinator? _chatCoordinator;
+
+    /// <summary>
+    /// Root DI composition root, built once during startup and disposed during
+    /// shutdown. The container only owns the presentation infrastructure it creates
+    /// (navigation scope manager + any open page-view-model scope); App-owned
+    /// services are registered as pre-built instances, so the container never
+    /// disposes them and there is no double-dispose.
+    /// </summary>
+    private ServiceProvider? _services;
+
+    /// <summary>
+    /// Page type → view-model type map used by the navigation activation hook.
+    /// Currently empty: no page resolves a view model from DI yet, so the activation
+    /// hook is a runtime no-op. Entries are added here as pages adopt view models.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<Type, Type> PageViewModelMap =
+        new Dictionary<Type, Type>();
+
+    /// <summary>The root service provider, or null before startup / after shutdown.</summary>
+    internal IServiceProvider? Services => _services;
+
+    /// <summary>Resolves the page activator used by <c>HubWindow</c>'s navigation hook.</summary>
+    internal IPageActivator? PageActivator => _services?.GetService<IPageActivator>();
     /// <summary>
     /// Cached reference to the most recently constructed local-setup engine. Used by
     /// <see cref="OnPairingStatusChanged"/> to suppress the "copy pairing command" toast
@@ -403,6 +429,70 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         return null;
     }
 
+    /// <summary>
+    /// Builds the root DI composition root exactly once. Registers the WinUI-free
+    /// core (dispatcher/app-commands/settings as pre-built instances, the navigation
+    /// scope manager, and transient page view models) plus the WinUI-bound adapters
+    /// (navigation service + page activator). Built with scope and build-time
+    /// validation so wiring errors surface at startup rather than first use. No
+    /// registered service starts work in its constructor.
+    /// </summary>
+    private void InitializeServiceProvider()
+    {
+        if (_services is not null)
+        {
+            return;
+        }
+
+        if (_dispatcherQueue is null || _settings is null)
+        {
+            Logger.Warn("Skipping service provider init: dispatcher or settings not ready.");
+            return;
+        }
+
+        var dispatcher = new WinUIDispatcher(_dispatcherQueue);
+        var context = new AppServiceContext(dispatcher, this, _settings);
+
+        var services = new ServiceCollection();
+        services.AddOpenClawTrayCore(context);
+
+        // WinUI-bound registrations are added here (not in the pure core) so the core
+        // stays testable in a pure net10 project.
+        services.AddSingleton<INavigationService>(new AppNavigationService(
+            dispatcher,
+            navigate: tag => ((IAppCommands)this).Navigate(tag),
+            canGoBack: () => _hubWindow is { IsClosed: false } hub && hub.CanGoBack,
+            goBack: () =>
+            {
+                if (_hubWindow is { IsClosed: false } hub)
+                {
+                    hub.NavigateBack();
+                }
+            }));
+        services.AddSingleton<IPageActivator>(sp => new FramePageActivator(
+            sp.GetRequiredService<NavigationScopeManager>(),
+            PageViewModelMap));
+
+        try
+        {
+            _services = services.BuildServiceProvider(new ServiceProviderOptions
+            {
+                ValidateScopes = true,
+                ValidateOnBuild = true,
+            });
+            Logger.Info("Service provider initialized.");
+        }
+        catch (Exception ex)
+        {
+            // Additive plumbing must never take the tray down. A build/validation
+            // failure is logged and leaves _services null, so the navigation
+            // activation hook stays a no-op. Wiring regressions are caught by tests
+            // (AppServiceRegistrationTests builds with ValidateOnBuild).
+            _services = null;
+            Logger.Error($"Service provider initialization failed: {ex}");
+        }
+    }
+
     protected override void OnLaunched(LaunchActivatedEventArgs args) =>
         AsyncEventHandlerGuard.Run(
             () => OnLaunchedAsync(args),
@@ -606,6 +696,11 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         // before the tray ever initializes.
         InitializeTrayIcon();
         ShowSurfaceImprovementsTipIfNeeded();
+
+        // Build the DI composition root AFTER the tray is up, so additive plumbing
+        // can never delay or preempt tray initialization. It only needs the
+        // dispatcher + settings (created above) and failures are non-fatal.
+        InitializeServiceProvider();
 
         // Initialize connection manager before setup flow.
         _gatewayRegistry = new GatewayRegistry(SettingsManager.SettingsDirectoryPath, logger: new AppLogger());
@@ -3303,6 +3398,17 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
             {
                 _hubWindow.SettingsSaved -= OnSettingsSaved;
                 _hubWindow = null;
+
+                // Deactivate + dispose the current navigation scope so a page view model
+                // (once pages are mapped) does not outlive the window it belonged to.
+                try
+                {
+                    PageActivator?.Reset();
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warn($"[App] Navigation scope reset on hub close failed: {ex.Message}");
+                }
             };
 
             _hubWindow.BindToAppState();
@@ -4524,6 +4630,22 @@ public partial class App : Application, OpenClawTray.Services.IAppCommands
         _trayMenuWindow = null;
         SafeShutdownStep("keep alive window", () => CloseWindow(_keepAliveWindow));
         _keepAliveWindow = null;
+
+        // Dispose the DI composition root. The container only owns the presentation
+        // infrastructure it created (navigation scope manager + any open page-view-model
+        // scope). App-owned services were registered as pre-built instances, so this
+        // does not re-dispose them (no double-dispose). Null the field BEFORE awaiting
+        // disposal so a queued Frame.Navigated callback during shutdown cannot resolve
+        // the page activator against a disposing/disposed provider.
+        var services = _services;
+        _services = null;
+        if (services is not null)
+        {
+            await SafeShutdownStepAsync("service provider", async () =>
+            {
+                await services.DisposeAsync();
+            });
+        }
 
         // Dispose tray and mutex
         SafeShutdownStep("tray icon", () =>

--- a/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
+++ b/src/OpenClaw.Tray.WinUI/OpenClaw.Tray.WinUI.csproj
@@ -71,6 +71,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="$(MicrosoftWindowsAppSDKVersion)" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$(MicrosoftWindowsSdkBuildToolsVersion)" />
     <PackageReference Include="OpenTelemetry" Version="1.16.0" />

--- a/src/OpenClaw.Tray.WinUI/Presentation/Adapters/FramePageActivator.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/Adapters/FramePageActivator.cs
@@ -1,0 +1,52 @@
+using Microsoft.UI.Xaml;
+
+namespace OpenClawTray.Presentation.Adapters;
+
+/// <summary>
+/// WinUI adapter that implements <see cref="IPageActivator"/>. It maps a navigated
+/// page's type to its view-model type, resolves + activates the view model through
+/// <see cref="NavigationScopeManager"/>, and assigns it as the page's data context.
+/// </summary>
+/// <remarks>
+/// The page→view-model map is currently empty, so every navigation takes the
+/// "no view model" path: the scope manager only deactivates and disposes any prior
+/// view model, and a page's <c>DataContext</c> is never touched. This makes the
+/// activation hook a runtime no-op until pages adopt view models, at which point their
+/// entries are added to the map.
+/// </remarks>
+internal sealed class FramePageActivator : IPageActivator
+{
+    private readonly NavigationScopeManager _scopes;
+    private readonly IReadOnlyDictionary<Type, Type> _pageToViewModel;
+
+    public FramePageActivator(NavigationScopeManager scopes, IReadOnlyDictionary<Type, Type> pageToViewModel)
+    {
+        _scopes = scopes ?? throw new ArgumentNullException(nameof(scopes));
+        _pageToViewModel = pageToViewModel ?? throw new ArgumentNullException(nameof(pageToViewModel));
+    }
+
+    public void OnNavigatedTo(object page, object? parameter)
+    {
+        if (page is null)
+        {
+            return;
+        }
+
+        if (_pageToViewModel.TryGetValue(page.GetType(), out var viewModelType))
+        {
+            var viewModel = _scopes.Navigate(viewModelType, parameter);
+            if (page is FrameworkElement element)
+            {
+                element.DataContext = viewModel;
+            }
+        }
+        else
+        {
+            // No view model mapped for this page yet: advance the scope (deactivate +
+            // dispose any prior view model) without touching the page's data context.
+            _scopes.Navigate(null, parameter);
+        }
+    }
+
+    public void Reset() => _scopes.Reset();
+}

--- a/src/OpenClaw.Tray.WinUI/Presentation/Adapters/WinUIDispatcher.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/Adapters/WinUIDispatcher.cs
@@ -1,0 +1,27 @@
+using Microsoft.UI.Dispatching;
+
+namespace OpenClawTray.Presentation.Adapters;
+
+/// <summary>
+/// WinUI adapter that implements <see cref="IUiDispatcher"/> over the real
+/// <see cref="DispatcherQueue"/>. WinUI-bound; not compiled into the pure test
+/// project. The contract itself is covered by <c>IUiDispatcher</c> unit tests via a
+/// test double, and this adapter is covered by source-contract tests.
+/// </summary>
+internal sealed class WinUIDispatcher : IUiDispatcher
+{
+    private readonly DispatcherQueue _queue;
+
+    public WinUIDispatcher(DispatcherQueue queue)
+    {
+        _queue = queue ?? throw new ArgumentNullException(nameof(queue));
+    }
+
+    public bool HasThreadAccess => _queue.HasThreadAccess;
+
+    public bool TryEnqueue(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        return _queue.TryEnqueue(() => action());
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Presentation/AppNavigationService.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/AppNavigationService.cs
@@ -1,0 +1,65 @@
+namespace OpenClawTray.Presentation;
+
+/// <summary>
+/// Default <see cref="INavigationService"/> implementation. It forwards navigation
+/// requests to delegates supplied by <c>App</c>, which drive the existing
+/// <c>HubWindow</c> navigation path. This keeps HubWindow as the single owner of
+/// frame navigation, back-stack, and rail selection while giving future view models
+/// a WinUI-free navigation surface to depend on.
+/// </summary>
+/// <remarks>
+/// The documented UI-thread affinity is <b>enforced</b>, not just described: mutating
+/// operations (<see cref="Navigate"/>, <see cref="GoBack"/>) are marshaled onto the UI
+/// thread through <see cref="IUiDispatcher"/>, and the <see cref="CanGoBack"/> read fails
+/// fast when called off the UI thread. This prevents a future background view model from
+/// touching the WinUI frame off-thread.
+/// </remarks>
+internal sealed class AppNavigationService : INavigationService
+{
+    private readonly IUiDispatcher _dispatcher;
+    private readonly Action<string> _navigate;
+    private readonly Func<bool> _canGoBack;
+    private readonly Action _goBack;
+
+    public AppNavigationService(IUiDispatcher dispatcher, Action<string> navigate, Func<bool> canGoBack, Action goBack)
+    {
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _navigate = navigate ?? throw new ArgumentNullException(nameof(navigate));
+        _canGoBack = canGoBack ?? throw new ArgumentNullException(nameof(canGoBack));
+        _goBack = goBack ?? throw new ArgumentNullException(nameof(goBack));
+    }
+
+    public void Navigate(string tag) => RunOnUiThread(() => _navigate(tag));
+
+    public bool CanGoBack
+    {
+        get
+        {
+            if (!_dispatcher.HasThreadAccess)
+            {
+                throw new InvalidOperationException(
+                    "INavigationService.CanGoBack reflects live WinUI frame state and must be read on the UI thread.");
+            }
+
+            return _canGoBack();
+        }
+    }
+
+    public void GoBack() => RunOnUiThread(_goBack);
+
+    /// <summary>
+    /// Runs frame-touching work on the UI thread: directly when already on it, otherwise
+    /// marshaled through the dispatcher so the WinUI frame is never touched off-thread.
+    /// </summary>
+    private void RunOnUiThread(Action action)
+    {
+        if (_dispatcher.HasThreadAccess)
+        {
+            action();
+        }
+        else
+        {
+            _dispatcher.TryEnqueue(action);
+        }
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Presentation/AppServiceContext.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/AppServiceContext.cs
@@ -1,0 +1,23 @@
+using OpenClawTray.Services;
+
+namespace OpenClawTray.Presentation;
+
+/// <summary>
+/// Carries the already-constructed, App-owned singletons that the composition root
+/// registers as pre-built instances. Registering them as instances (rather than
+/// letting the container construct them) means the DI container never disposes them,
+/// so App keeps sole ownership of their lifetime and there is no double-dispose.
+/// </summary>
+internal sealed class AppServiceContext
+{
+    public AppServiceContext(IUiDispatcher dispatcher, IAppCommands appCommands, SettingsManager settings)
+    {
+        Dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        AppCommands = appCommands ?? throw new ArgumentNullException(nameof(appCommands));
+        Settings = settings ?? throw new ArgumentNullException(nameof(settings));
+    }
+
+    public IUiDispatcher Dispatcher { get; }
+    public IAppCommands AppCommands { get; }
+    public SettingsManager Settings { get; }
+}

--- a/src/OpenClaw.Tray.WinUI/Presentation/AppServiceRegistration.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/AppServiceRegistration.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.DependencyInjection;
+using OpenClawTray.Services;
+
+namespace OpenClawTray.Presentation;
+
+/// <summary>
+/// The WinUI-free core of the App composition root. Registers the presentation-layer
+/// infrastructure and the App-owned singletons that view models depend on.
+/// </summary>
+/// <remarks>
+/// Ownership rules encoded here:
+/// <list type="bullet">
+/// <item>App-owned singletons (<see cref="IUiDispatcher"/>, <see cref="IAppCommands"/>,
+/// <see cref="SettingsManager"/>) are registered as <b>pre-built instances</b>, so the
+/// container never disposes them — App remains their sole owner (no double-dispose).</item>
+/// <item><see cref="NavigationScopeManager"/> is a container-created singleton, so the
+/// container disposes it when the root provider is disposed.</item>
+/// <item>Page view models are transient and are resolved from a per-navigation scope,
+/// so they are disposed when navigation moves away.</item>
+/// </list>
+/// WinUI-bound registrations (the dispatcher/page-activator/navigation adapters) are
+/// added separately by App so this method stays unit-testable in a pure net10 project.
+/// </remarks>
+internal static class AppServiceRegistration
+{
+    public static IServiceCollection AddOpenClawTrayCore(this IServiceCollection services, AppServiceContext context)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(context);
+
+        // App-owned singletons: pre-built instances → container does not dispose them.
+        services.AddSingleton(context.Dispatcher);
+        services.AddSingleton(context.AppCommands);
+        services.AddSingleton(context.Settings);
+
+        // Container-owned navigation lifetime manager (disposed with the root provider).
+        services.AddSingleton<NavigationScopeManager>();
+
+        // Transient page view models resolved per navigation scope.
+        services.AddTransient<SettingsPageViewModel>();
+        services.AddTransient<PermissionsPageViewModel>();
+
+        return services;
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Presentation/INavigationAware.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/INavigationAware.cs
@@ -1,0 +1,24 @@
+namespace OpenClawTray.Presentation;
+
+/// <summary>
+/// Implemented by page view models that need to react to navigation. The
+/// navigation seam calls <see cref="Activate"/> when the owning page is navigated
+/// to and <see cref="Deactivate"/> immediately before the view model's navigation
+/// scope is disposed (i.e. when navigating away). This pair defines the lifetime
+/// during which a transient page view model may hold subscriptions or timers.
+/// </summary>
+public interface INavigationAware
+{
+    /// <summary>
+    /// Called when the page is navigated to. <paramref name="parameter"/> is the
+    /// navigation parameter (the same tag/argument passed to the frame), or null.
+    /// </summary>
+    void Activate(object? parameter);
+
+    /// <summary>
+    /// Called when navigating away, before the view model's scope is disposed.
+    /// Implementations must release subscriptions here; they must not schedule new
+    /// work, because the process may be shutting down.
+    /// </summary>
+    void Deactivate();
+}

--- a/src/OpenClaw.Tray.WinUI/Presentation/INavigationService.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/INavigationService.cs
@@ -1,0 +1,34 @@
+namespace OpenClawTray.Presentation;
+
+/// <summary>
+/// Navigation surface that future page view models depend on so they can request
+/// navigation without referencing <c>HubWindow</c> or any WinUI type.
+/// </summary>
+/// <remarks>
+/// <c>HubWindow</c> remains the single owner of frame navigation, back-stack, rail
+/// selection, and dedupe. This service forwards tag-based navigation to that existing
+/// path (via <c>IAppCommands</c>/HubWindow), so it is additive and does not change
+/// current navigation behavior.
+/// </remarks>
+public interface INavigationService
+{
+    /// <summary>
+    /// Navigate to the destination identified by <paramref name="tag"/>. Safe to call
+    /// from any thread: the implementation marshals frame navigation onto the UI thread,
+    /// so a background caller can never touch the WinUI frame off-thread. When already on
+    /// the UI thread the navigation runs synchronously.
+    /// </summary>
+    void Navigate(string tag);
+
+    /// <summary>
+    /// True when the navigation back-stack can go back. Must be read on the UI thread
+    /// (it reflects live WinUI frame state); reading it off the UI thread throws.
+    /// </summary>
+    bool CanGoBack { get; }
+
+    /// <summary>
+    /// Navigate back one entry when possible. Safe to call from any thread; the
+    /// implementation marshals onto the UI thread like <see cref="Navigate"/>.
+    /// </summary>
+    void GoBack();
+}

--- a/src/OpenClaw.Tray.WinUI/Presentation/IPageActivator.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/IPageActivator.cs
@@ -1,0 +1,30 @@
+namespace OpenClawTray.Presentation;
+
+/// <summary>
+/// Assigns a page's data context / view model from dependency injection when the
+/// page is navigated to. The concrete WinUI adapter maps the page type to its
+/// view-model type, resolves the view model through <see cref="NavigationScopeManager"/>
+/// (which owns the per-navigation scope + activation lifetime), and sets it as the
+/// page's <c>DataContext</c>.
+/// </summary>
+/// <remarks>
+/// No page is mapped to a view model yet, so <see cref="OnNavigatedTo"/> only advances
+/// the navigation scope (deactivating and disposing any prior view model) and never
+/// touches a page's data context. The seam therefore has no observable runtime effect
+/// today; it is proven by unit tests.
+/// </remarks>
+public interface IPageActivator
+{
+    /// <summary>
+    /// Called after the frame has navigated to <paramref name="page"/> with the
+    /// given navigation <paramref name="parameter"/>.
+    /// </summary>
+    void OnNavigatedTo(object page, object? parameter);
+
+    /// <summary>
+    /// Deactivates and disposes the current page view model and its navigation scope
+    /// without tearing down the activator itself. Called when the owning window closes
+    /// so page view models, subscriptions, and timers do not survive past the window.
+    /// </summary>
+    void Reset();
+}

--- a/src/OpenClaw.Tray.WinUI/Presentation/IUiDispatcher.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/IUiDispatcher.cs
@@ -1,0 +1,24 @@
+namespace OpenClawTray.Presentation;
+
+/// <summary>
+/// UI-thread marshaling abstraction. Presentation-layer view models and services
+/// depend on this instead of the concrete <c>Microsoft.UI.Dispatching.DispatcherQueue</c>
+/// so they stay unit-testable without a live WinUI dispatcher.
+/// </summary>
+/// <remarks>
+/// This is the canonical seam for "post work back to the UI thread". The WinUI
+/// adapter (<c>Presentation/Adapters/WinUIDispatcher</c>) wraps the real dispatcher
+/// queue; App and legacy WinUI code may still call the dispatcher directly until
+/// the view-model migration retires those call sites.
+/// </remarks>
+public interface IUiDispatcher
+{
+    /// <summary>True when the caller is already running on the UI thread.</summary>
+    bool HasThreadAccess { get; }
+
+    /// <summary>
+    /// Queues <paramref name="action"/> to run on the UI thread. Returns false when
+    /// the underlying queue could not accept the work (for example during shutdown).
+    /// </summary>
+    bool TryEnqueue(Action action);
+}

--- a/src/OpenClaw.Tray.WinUI/Presentation/NavigationScopeManager.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/NavigationScopeManager.cs
@@ -1,0 +1,178 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OpenClawTray.Presentation;
+
+/// <summary>
+/// Owns the lifetime of the current page's view model. Each navigation runs inside
+/// its own DI scope: navigating away deactivates the previous view model and disposes
+/// its scope (which disposes the transient view model), then the new page's view model
+/// is resolved from a fresh scope and activated.
+/// </summary>
+/// <remarks>
+/// This is the canonical owner of page view-model activation/deactivation and disposal.
+/// It is deliberately WinUI-free so the lifetime rules are unit-tested without a live
+/// frame. The WinUI <c>FramePageActivator</c> adapter maps page types to view-model
+/// types and drives this manager, then assigns the returned view model as the page's
+/// data context. Nothing is started in the constructor.
+/// </remarks>
+public sealed class NavigationScopeManager : IDisposable
+{
+    private readonly IServiceProvider _rootProvider;
+    private IServiceScope? _currentScope;
+    private object? _currentViewModel;
+    private bool _navigating;
+    private bool _disposed;
+
+    public NavigationScopeManager(IServiceProvider rootProvider)
+    {
+        _rootProvider = rootProvider ?? throw new ArgumentNullException(nameof(rootProvider));
+    }
+
+    /// <summary>The view model active for the current page, or null when none is active.</summary>
+    public object? CurrentViewModel => _currentViewModel;
+
+    /// <summary>True after <see cref="Dispose"/> has run.</summary>
+    public bool IsDisposed => _disposed;
+
+    /// <summary>
+    /// Advance navigation to the page whose view model is <paramref name="viewModelType"/>.
+    /// The previous view model (if any) is deactivated and its scope disposed first. When
+    /// <paramref name="viewModelType"/> is null (page has no registered view model), no new
+    /// scope is created and null is returned — this is the no-op path used for pages that
+    /// have no registered view model.
+    /// </summary>
+    /// <remarks>
+    /// Navigation is not re-entrant: calling <see cref="Navigate"/> from within a view
+    /// model's <see cref="INavigationAware.Activate"/> or <see cref="INavigationAware.Deactivate"/>
+    /// throws <see cref="InvalidOperationException"/>, so a nested navigation can never
+    /// overwrite or leak the scope the outer call is managing.
+    /// </remarks>
+    /// <returns>The resolved, activated view model, or null.</returns>
+    public object? Navigate(Type? viewModelType, object? parameter)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_navigating)
+        {
+            throw new InvalidOperationException(
+                "NavigationScopeManager.Navigate cannot be called re-entrantly " +
+                "(for example from a view model's Activate or Deactivate).");
+        }
+
+        _navigating = true;
+        try
+        {
+            DeactivateAndDisposeCurrent();
+
+            if (viewModelType is null)
+            {
+                return null;
+            }
+
+            var scope = _rootProvider.CreateScope();
+            object? viewModel;
+            try
+            {
+                viewModel = scope.ServiceProvider.GetService(viewModelType);
+            }
+            catch
+            {
+                scope.Dispose();
+                throw;
+            }
+
+            if (viewModel is null)
+            {
+                // Registered nowhere: don't leak an empty scope.
+                scope.Dispose();
+                return null;
+            }
+
+            _currentScope = scope;
+            _currentViewModel = viewModel;
+            try
+            {
+                (viewModel as INavigationAware)?.Activate(parameter);
+            }
+            catch
+            {
+                // Activation failed: don't leave a half-activated current or leak the scope.
+                _currentViewModel = null;
+                _currentScope = null;
+                scope.Dispose();
+                throw;
+            }
+
+            return viewModel;
+        }
+        finally
+        {
+            _navigating = false;
+        }
+    }
+
+    /// <summary>
+    /// Deactivates and disposes the current view model and its scope, returning the
+    /// manager to an empty state without disposing the manager itself. Used when the
+    /// owning window closes so a page view model does not outlive its window. Safe to
+    /// call when nothing is active. Not re-entrant with <see cref="Navigate"/>.
+    /// </summary>
+    public void Reset()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_navigating)
+        {
+            throw new InvalidOperationException(
+                "NavigationScopeManager.Reset cannot be called re-entrantly from Navigate " +
+                "or a view model's Activate/Deactivate.");
+        }
+
+        _navigating = true;
+        try
+        {
+            DeactivateAndDisposeCurrent();
+        }
+        finally
+        {
+            _navigating = false;
+        }
+    }
+
+    private void DeactivateAndDisposeCurrent()
+    {
+        var viewModel = _currentViewModel;
+        var scope = _currentScope;
+        _currentViewModel = null;
+        _currentScope = null;
+
+        try
+        {
+            (viewModel as INavigationAware)?.Deactivate();
+        }
+        finally
+        {
+            // Always dispose the scope (and its transient view model) even if a
+            // misbehaving view model throws from Deactivate, so it cannot leak a scope.
+            scope?.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        try
+        {
+            DeactivateAndDisposeCurrent();
+        }
+        // slopwatch-ignore: SW003 Disposal teardown must not throw; the scope is already
+        // disposed in DeactivateAndDisposeCurrent's finally, so a misbehaving view model's
+        // Deactivate cannot leak a scope or surface from Dispose.
+        catch (Exception)
+        {
+        }
+    }
+}

--- a/src/OpenClaw.Tray.WinUI/Presentation/PermissionsPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/PermissionsPageViewModel.cs
@@ -1,0 +1,32 @@
+using OpenClawTray.Services;
+
+namespace OpenClawTray.Presentation;
+
+/// <summary>
+/// Transient view-model placeholder for the Permissions page. Mirrors
+/// <see cref="SettingsPageViewModel"/>: it exercises DI construction, navigation
+/// activation/deactivation, and scope-driven disposal. It intentionally holds no
+/// behavior yet. Nothing is started in the constructor.
+/// </summary>
+internal sealed class PermissionsPageViewModel : INavigationAware, IDisposable
+{
+    public PermissionsPageViewModel(IAppCommands appCommands, SettingsManager settings, IUiDispatcher dispatcher)
+    {
+        AppCommands = appCommands ?? throw new ArgumentNullException(nameof(appCommands));
+        Settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        Dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+    }
+
+    internal IAppCommands AppCommands { get; }
+    internal SettingsManager Settings { get; }
+    internal IUiDispatcher Dispatcher { get; }
+
+    internal bool IsActive { get; private set; }
+    internal bool IsDisposed { get; private set; }
+
+    public void Activate(object? parameter) => IsActive = true;
+
+    public void Deactivate() => IsActive = false;
+
+    public void Dispose() => IsDisposed = true;
+}

--- a/src/OpenClaw.Tray.WinUI/Presentation/SettingsPageViewModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Presentation/SettingsPageViewModel.cs
@@ -1,0 +1,33 @@
+using OpenClawTray.Services;
+
+namespace OpenClawTray.Presentation;
+
+/// <summary>
+/// Transient view-model placeholder for the Settings page. It exercises the DI wiring
+/// end to end: it is constructor-injected with app services, participates in the
+/// navigation activation/deactivation lifetime, and is disposed when its navigation
+/// scope ends. It intentionally holds no behavior yet. Nothing is started in the
+/// constructor.
+/// </summary>
+internal sealed class SettingsPageViewModel : INavigationAware, IDisposable
+{
+    public SettingsPageViewModel(IAppCommands appCommands, SettingsManager settings, IUiDispatcher dispatcher)
+    {
+        AppCommands = appCommands ?? throw new ArgumentNullException(nameof(appCommands));
+        Settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        Dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+    }
+
+    internal IAppCommands AppCommands { get; }
+    internal SettingsManager Settings { get; }
+    internal IUiDispatcher Dispatcher { get; }
+
+    internal bool IsActive { get; private set; }
+    internal bool IsDisposed { get; private set; }
+
+    public void Activate(object? parameter) => IsActive = true;
+
+    public void Deactivate() => IsActive = false;
+
+    public void Dispose() => IsDisposed = true;
+}

--- a/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Windows/HubWindow.xaml.cs
@@ -606,6 +606,12 @@ public sealed partial class HubWindow : WindowEx
 
     private void OnBackRequested(object sender, RoutedEventArgs e) => GoBack();
 
+    /// <summary>True when the content frame's back-stack can navigate back.</summary>
+    public bool CanGoBack => ContentFrame?.CanGoBack ?? false;
+
+    /// <summary>Navigate back one entry when possible. Exposed for the navigation service.</summary>
+    public void NavigateBack() => GoBack();
+
     private void GoBack()
     {
         RemoveUnavailableGatewayBackStackEntries();
@@ -1019,6 +1025,24 @@ public sealed partial class HubWindow : WindowEx
         InitializeCurrentPage();
         UpdateAppNotificationActionEnabledState();
         ArmContentReady(e.Content as FrameworkElement);
+
+        // Navigation activation hook: resolve + assign a DI-backed view model for the
+        // navigated page. The page→view-model map is currently empty, so this only
+        // advances the navigation scope (deactivating any prior view model) and never
+        // touches a page's DataContext — a runtime no-op until pages adopt view models.
+        // Contained in a try/catch so a future misbehaving view model's activation
+        // cannot escape this XAML event handler and crash the app.
+        if (e.Content is { } content)
+        {
+            try
+            {
+                CurrentApp.PageActivator?.OnNavigatedTo(content, tag);
+            }
+            catch (Exception ex)
+            {
+                OpenClawTray.Services.Logger.Error($"[HubWindow] Page activation failed: {ex}");
+            }
+        }
     }
 
     private void OnContentFrameNavigationFailed(object sender, Microsoft.UI.Xaml.Navigation.NavigationFailedEventArgs e)

--- a/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
+++ b/tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <ProjectReference Include="..\..\src\OpenClaw.Shared\OpenClaw.Shared.csproj" />
     <ProjectReference Include="..\..\src\OpenClaw.Connection\OpenClaw.Connection.csproj" />
     <!-- Compile only the model-layer files directly so the tests can remain
@@ -120,6 +121,24 @@
     <!-- Pulled in for console-log tail tests. Pure logic, no WinUI deps. -->
     <Compile Include="..\..\src\OpenClaw.SetupEngine.UI\WizardConsoleTail.cs" Link="WizardConsoleTail.cs" />
     <Compile Include="..\..\src\OpenClaw.SetupEngine.UI\WizardPayloadHelpers.cs" Link="WizardPayloadHelpers.cs" />
+  </ItemGroup>
+
+  <!-- Phase 2 presentation seam: WinUI-free DI + navigation core, hand-linked so it
+       is unit-tested in this pure net10 project. WinUI-bound adapters
+       (Presentation/Adapters/*) are intentionally NOT linked; they are covered by
+       source-contract tests instead. -->
+  <ItemGroup>
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Services\IAppCommands.cs" Link="Services\IAppCommands.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\IUiDispatcher.cs" Link="Presentation\IUiDispatcher.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\INavigationAware.cs" Link="Presentation\INavigationAware.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\INavigationService.cs" Link="Presentation\INavigationService.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\IPageActivator.cs" Link="Presentation\IPageActivator.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\NavigationScopeManager.cs" Link="Presentation\NavigationScopeManager.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\AppNavigationService.cs" Link="Presentation\AppNavigationService.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\SettingsPageViewModel.cs" Link="Presentation\SettingsPageViewModel.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\PermissionsPageViewModel.cs" Link="Presentation\PermissionsPageViewModel.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\AppServiceContext.cs" Link="Presentation\AppServiceContext.cs" />
+    <Compile Include="..\..\src\OpenClaw.Tray.WinUI\Presentation\AppServiceRegistration.cs" Link="Presentation\AppServiceRegistration.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/OpenClaw.Tray.Tests/Presentation/AppNavigationServiceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/AppNavigationServiceTests.cs
@@ -1,0 +1,76 @@
+using OpenClawTray.Presentation;
+
+namespace OpenClaw.Tray.Tests.Presentation;
+
+/// <summary>
+/// Behavioral guard for the navigation service's UI-thread contract: mutating
+/// operations are marshaled onto the UI thread, and the back-stack read fails fast
+/// when called off the UI thread. This enforces the documented affinity rather than
+/// only describing it.
+/// </summary>
+public sealed class AppNavigationServiceTests
+{
+    [Fact]
+    public void Navigate_OnUiThread_InvokesSynchronously()
+    {
+        var dispatcher = new RecordingUiDispatcher { HasThreadAccess = true };
+        var tags = new List<string>();
+        var svc = new AppNavigationService(dispatcher, tags.Add, () => false, () => { });
+
+        svc.Navigate("connection");
+
+        Assert.Equal(new[] { "connection" }, tags);
+        Assert.Equal(0, dispatcher.EnqueuedCount);
+    }
+
+    [Fact]
+    public void Navigate_OffUiThread_MarshalsThroughDispatcher()
+    {
+        var dispatcher = new RecordingUiDispatcher { HasThreadAccess = false, RunEnqueuedImmediately = false };
+        var tags = new List<string>();
+        var svc = new AppNavigationService(dispatcher, tags.Add, () => false, () => { });
+
+        svc.Navigate("permissions");
+
+        // Off-thread: the frame is NOT touched inline — the work is queued to the UI thread.
+        Assert.Empty(tags);
+        Assert.Equal(1, dispatcher.EnqueuedCount);
+
+        dispatcher.FlushPending();
+        Assert.Equal(new[] { "permissions" }, tags);
+    }
+
+    [Fact]
+    public void GoBack_OffUiThread_MarshalsThroughDispatcher()
+    {
+        var dispatcher = new RecordingUiDispatcher { HasThreadAccess = false, RunEnqueuedImmediately = false };
+        var backCount = 0;
+        var svc = new AppNavigationService(dispatcher, _ => { }, () => true, () => backCount++);
+
+        svc.GoBack();
+
+        Assert.Equal(0, backCount);
+        Assert.Equal(1, dispatcher.EnqueuedCount);
+
+        dispatcher.FlushPending();
+        Assert.Equal(1, backCount);
+    }
+
+    [Fact]
+    public void CanGoBack_OffUiThread_Throws()
+    {
+        var dispatcher = new RecordingUiDispatcher { HasThreadAccess = false };
+        var svc = new AppNavigationService(dispatcher, _ => { }, () => true, () => { });
+
+        Assert.Throws<InvalidOperationException>(() => _ = svc.CanGoBack);
+    }
+
+    [Fact]
+    public void CanGoBack_OnUiThread_ReturnsUnderlyingValue()
+    {
+        var dispatcher = new RecordingUiDispatcher { HasThreadAccess = true };
+        var svc = new AppNavigationService(dispatcher, _ => { }, () => true, () => { });
+
+        Assert.True(svc.CanGoBack);
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/Presentation/AppServiceRegistrationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/AppServiceRegistrationTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.Extensions.DependencyInjection;
+using OpenClawTray.Presentation;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests.Presentation;
+
+/// <summary>
+/// Behavioral guard for the composition root. Locks build-time validation, singleton
+/// identity of App-owned instances, transient page-view-model lifetime, and — most
+/// importantly — that the container never disposes App-owned pre-built instances
+/// (no double-dispose) while it does dispose what it created.
+/// </summary>
+public sealed class AppServiceRegistrationTests
+{
+    private static ServiceProvider BuildProvider(
+        out RecordingUiDispatcher dispatcher,
+        out FakeAppCommands commands,
+        out SettingsManager settings,
+        out TempDir temp)
+    {
+        temp = new TempDir();
+        dispatcher = new RecordingUiDispatcher();
+        commands = new FakeAppCommands();
+        settings = new SettingsManager(temp.Path);
+
+        var services = new ServiceCollection();
+        services.AddOpenClawTrayCore(new AppServiceContext(dispatcher, commands, settings));
+        return services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+            ValidateOnBuild = true,
+        });
+    }
+
+    [Fact]
+    public void Build_ValidatesOnBuild_WithoutThrowing()
+    {
+        // Reaching this point means BuildServiceProvider(ValidateOnBuild: true) did not
+        // throw, i.e. every registration (including transient page view models) is
+        // constructable from the registered dependencies.
+        var provider = BuildProvider(out _, out _, out _, out var temp);
+        using (provider)
+        using (temp)
+        {
+            Assert.NotNull(provider);
+        }
+    }
+
+    [Fact]
+    public void AppOwnedSingletons_ResolveToTheProvidedInstances()
+    {
+        var provider = BuildProvider(out var dispatcher, out var commands, out var settings, out var temp);
+        using (provider)
+        using (temp)
+        {
+            Assert.Same(dispatcher, provider.GetRequiredService<IUiDispatcher>());
+            Assert.Same(commands, provider.GetRequiredService<IAppCommands>());
+            Assert.Same(settings, provider.GetRequiredService<SettingsManager>());
+        }
+    }
+
+    [Fact]
+    public void PageViewModels_AreTransient_AndReceiveInjectedServices()
+    {
+        var provider = BuildProvider(out var dispatcher, out var commands, out var settings, out var temp);
+        using (provider)
+        using (temp)
+        {
+            using var scope = provider.CreateScope();
+            var first = scope.ServiceProvider.GetRequiredService<SettingsPageViewModel>();
+            var second = scope.ServiceProvider.GetRequiredService<SettingsPageViewModel>();
+
+            Assert.NotSame(first, second);
+            Assert.Same(dispatcher, first.Dispatcher);
+            Assert.Same(commands, first.AppCommands);
+            Assert.Same(settings, first.Settings);
+        }
+    }
+
+    [Fact]
+    public void PageViewModel_ResolvedFromScope_IsDisposedWithScope()
+    {
+        var provider = BuildProvider(out _, out _, out _, out var temp);
+        using (provider)
+        using (temp)
+        {
+            SettingsPageViewModel vm;
+            using (var scope = provider.CreateScope())
+            {
+                vm = scope.ServiceProvider.GetRequiredService<SettingsPageViewModel>();
+                Assert.False(vm.IsDisposed);
+            }
+
+            Assert.True(vm.IsDisposed);
+        }
+    }
+
+    [Fact]
+    public void Dispose_DoesNotDisposeAppOwnedInstanceSingletons()
+    {
+        var provider = BuildProvider(out var dispatcher, out var commands, out _, out var temp);
+        using (temp)
+        {
+            var manager = provider.GetRequiredService<NavigationScopeManager>();
+
+            provider.Dispose();
+
+            // App-owned pre-built instances: the container must NOT dispose them, so App
+            // remains their sole owner and there is no double-dispose. Both the dispatcher
+            // and IAppCommands are IDisposable instance registrations, so asserting both
+            // proves the container never disposes an instance it did not create.
+            Assert.False(dispatcher.Disposed);
+            Assert.False(commands.Disposed);
+            // Container-created singleton: the container DOES dispose it.
+            Assert.True(manager.IsDisposed);
+        }
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/Presentation/NavigationIntegrationTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/NavigationIntegrationTests.cs
@@ -1,0 +1,119 @@
+using Microsoft.Extensions.DependencyInjection;
+using OpenClawTray.Presentation;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests.Presentation;
+
+/// <summary>
+/// Behavioral integration proof that composes the real composition root, the navigation
+/// scope manager, and the registered transient page view models — driving the full
+/// lifecycle (open → navigate A/B → close → reopen → shutdown) and asserting the
+/// ownership invariants end to end without hosting HubWindow.
+/// </summary>
+public sealed class NavigationIntegrationTests
+{
+    private static ServiceProvider BuildRealContainer(out TempDir temp)
+    {
+        temp = new TempDir();
+        var services = new ServiceCollection();
+        services.AddOpenClawTrayCore(new AppServiceContext(
+            new RecordingUiDispatcher(), new FakeAppCommands(), new SettingsManager(temp.Path)));
+        return services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+            ValidateOnBuild = true,
+        });
+    }
+
+    [Fact]
+    public void FullLifecycle_OpenNavigateCloseReopenShutdown_HonorsOwnership()
+    {
+        var provider = BuildRealContainer(out var temp);
+        using (temp)
+        {
+            var manager = provider.GetRequiredService<NavigationScopeManager>();
+
+            // open + navigate A (Settings)
+            var a = Assert.IsType<SettingsPageViewModel>(manager.Navigate(typeof(SettingsPageViewModel), "a"));
+            Assert.True(a.IsActive);
+
+            // navigate B (Permissions) — A deactivated + disposed before B is active
+            var b = Assert.IsType<PermissionsPageViewModel>(manager.Navigate(typeof(PermissionsPageViewModel), "b"));
+            Assert.False(a.IsActive);
+            Assert.True(a.IsDisposed);
+            Assert.True(b.IsActive);
+            Assert.False(b.IsDisposed);
+
+            // close (Hub close → Reset) — B deactivated + disposed, nothing current
+            manager.Reset();
+            Assert.False(b.IsActive);
+            Assert.True(b.IsDisposed);
+            Assert.Null(manager.CurrentViewModel);
+
+            // reopen — fresh A instance, not the disposed one
+            var a2 = Assert.IsType<SettingsPageViewModel>(manager.Navigate(typeof(SettingsPageViewModel), "a2"));
+            Assert.NotSame(a, a2);
+            Assert.True(a2.IsActive);
+
+            // shutdown — dispose the provider; the container disposes the manager it created,
+            // which tears down the current scope/view model.
+            provider.Dispose();
+            Assert.True(manager.IsDisposed);
+            Assert.True(a2.IsDisposed);
+        }
+    }
+
+    [Fact]
+    public void FrameHandlerSimulation_ContainsActivationException_AndDisposesScope()
+    {
+        // Mirror HubWindow.OnContentFrameNavigated: the activator call is wrapped in a
+        // try/catch so an activation throw cannot escape the frame-navigated handler.
+        var created = new List<ThrowingActivateViewModel>();
+        var services = new ServiceCollection();
+        services.AddTransient(_ =>
+        {
+            var vm = new ThrowingActivateViewModel();
+            created.Add(vm);
+            return vm;
+        });
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        using var manager = new NavigationScopeManager(provider);
+
+        void FrameHandler(Type vmType)
+        {
+            try
+            {
+                manager.Navigate(vmType, null);
+            }
+            catch
+            {
+                // Contained — mirrors the HubWindow try/catch-log around the activation hook.
+            }
+        }
+
+        var escaped = Record.Exception(() => FrameHandler(typeof(ThrowingActivateViewModel)));
+
+        Assert.Null(escaped);
+        // The half-activated scope was disposed, not leaked.
+        Assert.Null(manager.CurrentViewModel);
+        Assert.True(Assert.Single(created).Disposed);
+    }
+
+    [Fact]
+    public void AfterShutdown_LateNavigation_DoesNotResolveFromDisposedProvider()
+    {
+        var provider = BuildRealContainer(out var temp);
+        using (temp)
+        {
+            var manager = provider.GetRequiredService<NavigationScopeManager>();
+            manager.Navigate(typeof(SettingsPageViewModel), null);
+
+            provider.Dispose();
+
+            // The manager is disposed with the provider, so a late navigation cannot
+            // create a new scope / resolve a view model from the disposed provider.
+            Assert.True(manager.IsDisposed);
+            Assert.Throws<ObjectDisposedException>(() => manager.Navigate(typeof(SettingsPageViewModel), null));
+        }
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/Presentation/NavigationScopeManagerTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/NavigationScopeManagerTests.cs
@@ -1,0 +1,264 @@
+using Microsoft.Extensions.DependencyInjection;
+using OpenClawTray.Presentation;
+
+namespace OpenClaw.Tray.Tests.Presentation;
+
+/// <summary>
+/// Behavioral guard for the navigation-scope owner. Locks the activation /
+/// deactivation / scope-disposal lifetime of transient page view models.
+/// </summary>
+public sealed class NavigationScopeManagerTests
+{
+    private static ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<FakeViewModel>();
+        services.AddTransient<OtherFakeViewModel>();
+        return services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+            ValidateOnBuild = true,
+        });
+    }
+
+    [Fact]
+    public void Navigate_ResolvesAndActivatesViewModel()
+    {
+        using var provider = BuildProvider();
+        using var manager = new NavigationScopeManager(provider);
+
+        var vm = Assert.IsType<FakeViewModel>(manager.Navigate(typeof(FakeViewModel), "tag-a"));
+
+        Assert.Same(vm, manager.CurrentViewModel);
+        Assert.Equal(1, vm.ActivateCount);
+        Assert.Equal("tag-a", vm.LastParameter);
+        Assert.False(vm.Disposed);
+    }
+
+    [Fact]
+    public void NavigatingAway_DeactivatesAndDisposesPreviousViewModel()
+    {
+        using var provider = BuildProvider();
+        using var manager = new NavigationScopeManager(provider);
+
+        var first = Assert.IsType<FakeViewModel>(manager.Navigate(typeof(FakeViewModel), null));
+        var second = Assert.IsType<OtherFakeViewModel>(manager.Navigate(typeof(OtherFakeViewModel), null));
+
+        Assert.Equal(1, first.DeactivateCount);
+        Assert.True(first.Disposed);
+        Assert.Same(second, manager.CurrentViewModel);
+        Assert.Equal(1, second.ActivateCount);
+        Assert.False(second.Disposed);
+    }
+
+    [Fact]
+    public void Navigate_WithNullType_DeactivatesPreviousAndActivatesNothing()
+    {
+        using var provider = BuildProvider();
+        using var manager = new NavigationScopeManager(provider);
+
+        var first = Assert.IsType<FakeViewModel>(manager.Navigate(typeof(FakeViewModel), null));
+        var result = manager.Navigate(null, null);
+
+        Assert.Null(result);
+        Assert.Null(manager.CurrentViewModel);
+        Assert.Equal(1, first.DeactivateCount);
+        Assert.True(first.Disposed);
+    }
+
+    [Fact]
+    public void Dispose_DeactivatesAndDisposesCurrentViewModel()
+    {
+        using var provider = BuildProvider();
+        var manager = new NavigationScopeManager(provider);
+        var vm = Assert.IsType<FakeViewModel>(manager.Navigate(typeof(FakeViewModel), null));
+
+        manager.Dispose();
+
+        Assert.True(manager.IsDisposed);
+        Assert.Equal(1, vm.DeactivateCount);
+        Assert.True(vm.Disposed);
+    }
+
+    [Fact]
+    public void Navigate_AfterDispose_Throws()
+    {
+        using var provider = BuildProvider();
+        var manager = new NavigationScopeManager(provider);
+        manager.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => manager.Navigate(typeof(FakeViewModel), null));
+    }
+
+    [Fact]
+    public void NavigatingAway_DisposesScope_EvenWhenDeactivateThrows()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<ThrowingDeactivateViewModel>();
+        services.AddTransient<FakeViewModel>();
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+            ValidateOnBuild = true,
+        });
+        using var manager = new NavigationScopeManager(provider);
+
+        var vm = Assert.IsType<ThrowingDeactivateViewModel>(manager.Navigate(typeof(ThrowingDeactivateViewModel), null));
+
+        // Navigating away triggers the throwing Deactivate; the scope must still be
+        // disposed (finally), and the manager must not retain the failed view model.
+        Assert.Throws<InvalidOperationException>(() => manager.Navigate(typeof(FakeViewModel), null));
+
+        Assert.True(vm.Disposed);
+        Assert.Null(manager.CurrentViewModel);
+    }
+
+    [Fact]
+    public void Navigate_WhenActivateThrows_DisposesScopeAndClearsCurrent()
+    {
+        var created = new List<ThrowingActivateViewModel>();
+        var services = new ServiceCollection();
+        services.AddTransient(_ =>
+        {
+            var vm = new ThrowingActivateViewModel();
+            created.Add(vm);
+            return vm;
+        });
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+        });
+        using var manager = new NavigationScopeManager(provider);
+
+        var ex = Record.Exception(() => manager.Navigate(typeof(ThrowingActivateViewModel), null));
+
+        // Navigate must rethrow, must not retain a half-activated view model, and must
+        // have disposed the just-created scope (and its transient view model), so no
+        // half-activated scope leaks.
+        Assert.IsType<InvalidOperationException>(ex);
+        Assert.Null(manager.CurrentViewModel);
+        var vm = Assert.Single(created);
+        Assert.True(vm.Disposed);
+    }
+
+    [Fact]
+    public void Navigate_RejectsReentry_FromActivate()
+    {
+        NavigationScopeManager? manager = null;
+        var services = new ServiceCollection();
+        services.AddTransient<FakeViewModel>();
+        services.AddTransient(_ => new ReentrantViewModel(manager!, reenterOnActivate: true, reenterOnDeactivate: false));
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        manager = new NavigationScopeManager(provider);
+        using var _ = manager;
+
+        var vm = Assert.IsType<ReentrantViewModel>(manager.Navigate(typeof(ReentrantViewModel), null));
+
+        // The re-entrant Navigate from within Activate must be rejected, not silently
+        // installing an inner scope that the outer call would then leak.
+        Assert.IsType<InvalidOperationException>(vm.ActivateException);
+        Assert.Same(vm, manager.CurrentViewModel);
+    }
+
+    [Fact]
+    public void Navigate_RejectsReentry_FromDeactivate()
+    {
+        NavigationScopeManager? manager = null;
+        var services = new ServiceCollection();
+        services.AddTransient<FakeViewModel>();
+        services.AddTransient(_ => new ReentrantViewModel(manager!, reenterOnActivate: false, reenterOnDeactivate: true));
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        manager = new NavigationScopeManager(provider);
+        using var _ = manager;
+
+        var first = Assert.IsType<ReentrantViewModel>(manager.Navigate(typeof(ReentrantViewModel), null));
+        var second = Assert.IsType<FakeViewModel>(manager.Navigate(typeof(FakeViewModel), null));
+
+        // The re-entrant Navigate from within the first VM's Deactivate must be rejected,
+        // so the outer navigation to the second VM completes cleanly.
+        Assert.IsType<InvalidOperationException>(first.DeactivateException);
+        Assert.True(first.Disposed);
+        Assert.Same(second, manager.CurrentViewModel);
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow_WhenDeactivateThrows()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<ThrowingDeactivateViewModel>();
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        var manager = new NavigationScopeManager(provider);
+        var vm = Assert.IsType<ThrowingDeactivateViewModel>(manager.Navigate(typeof(ThrowingDeactivateViewModel), null));
+
+        // Dispose must swallow a misbehaving Deactivate and still dispose the scope.
+        manager.Dispose();
+
+        Assert.True(manager.IsDisposed);
+        Assert.True(vm.Disposed);
+    }
+
+    [Fact]
+    public void Navigate_AtoB_DeactivatesAndDisposesA_BeforeActivatingB()
+    {
+        var log = new List<string>();
+        var services = new ServiceCollection();
+        services.AddTransient(_ => new OrderRecordingViewModel(log, "A"));
+        // Distinguish B by a marker type so the map picks a different registration.
+        services.AddTransient<BViewModel>(_ => new BViewModel(log));
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        using var manager = new NavigationScopeManager(provider);
+
+        manager.Navigate(typeof(OrderRecordingViewModel), null);
+        manager.Navigate(typeof(BViewModel), null);
+
+        // A must be deactivated and disposed exactly once, and both must happen before B activates.
+        Assert.Equal(new[] { "activate:A", "deactivate:A", "dispose:A", "activate:B" }, log);
+        Assert.Single(log, e => e == "deactivate:A");
+        Assert.Single(log, e => e == "dispose:A");
+    }
+
+    [Fact]
+    public void Reset_DeactivatesAndDisposesCurrent_AndAllowsRenavigation()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<FakeViewModel>();
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        using var manager = new NavigationScopeManager(provider);
+
+        var first = Assert.IsType<FakeViewModel>(manager.Navigate(typeof(FakeViewModel), null));
+        manager.Reset();
+
+        // Reset (window-close analog) tears down the current view model/scope but keeps
+        // the manager usable.
+        Assert.Equal(1, first.DeactivateCount);
+        Assert.True(first.Disposed);
+        Assert.Null(manager.CurrentViewModel);
+        Assert.False(manager.IsDisposed);
+
+        var second = Assert.IsType<FakeViewModel>(manager.Navigate(typeof(FakeViewModel), null));
+        Assert.NotSame(first, second);
+        Assert.Equal(1, second.ActivateCount);
+    }
+
+    [Fact]
+    public void Reset_IsNoOp_WhenNothingActive()
+    {
+        using var provider = BuildProvider();
+        using var manager = new NavigationScopeManager(provider);
+
+        manager.Reset(); // must not throw
+
+        Assert.Null(manager.CurrentViewModel);
+        Assert.False(manager.IsDisposed);
+    }
+
+    [Fact]
+    public void Reset_AfterDispose_Throws()
+    {
+        using var provider = BuildProvider();
+        var manager = new NavigationScopeManager(provider);
+        manager.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => manager.Reset());
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/Presentation/PresentationSeamContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/PresentationSeamContractTests.cs
@@ -1,0 +1,205 @@
+using System.Text.RegularExpressions;
+
+namespace OpenClaw.Tray.Tests.Presentation;
+
+/// <summary>
+/// Source-contract guards for the WinUI-bound half of the presentation seam (the parts
+/// that cannot be compiled into this pure net10 test project): the App composition-root
+/// wiring/disposal, the HubWindow activation hook, and the WinUI-free boundary of the
+/// Presentation core.
+/// </summary>
+public sealed class PresentationSeamContractTests
+{
+    [Fact]
+    public void App_BuildsServiceProvider_WithScopeAndBuildValidation()
+    {
+        var source = ReadAppSources();
+
+        Assert.Contains("AddOpenClawTrayCore", source);
+        Assert.Contains("BuildServiceProvider", source);
+        Assert.Contains("ValidateScopes = true", source);
+        Assert.Contains("ValidateOnBuild = true", source);
+    }
+
+    [Fact]
+    public void App_DisposesServiceProvider_DuringShutdown()
+    {
+        var source = ReadAppSources();
+
+        Assert.Contains("\"service provider\"", source);
+        Assert.Contains("await services.DisposeAsync()", source);
+    }
+
+    [Fact]
+    public void App_NullsServiceProviderField_BeforeAwaitingDisposal()
+    {
+        var source = ReadAppSources();
+
+        // The shutdown must null _services before awaiting DisposeAsync so a queued
+        // Frame.Navigated callback cannot resolve the page activator against a disposing
+        // provider. Assert the field is nulled ahead of the disposal step.
+        var captureIdx = source.IndexOf("var services = _services;", StringComparison.Ordinal);
+        var disposeIdx = source.IndexOf("await services.DisposeAsync()", StringComparison.Ordinal);
+        Assert.True(captureIdx >= 0 && disposeIdx >= 0, "Expected shutdown disposal pattern not found.");
+
+        // The relevant null-assignment is the one after the capture (an earlier
+        // `_services = null;` also exists in the init failure path).
+        var nullIdx = source.IndexOf("_services = null;", captureIdx, StringComparison.Ordinal);
+        Assert.True(nullIdx >= 0, "Shutdown must null _services after capturing it.");
+        Assert.True(nullIdx < disposeIdx,
+            "App must set _services = null after capturing it and BEFORE awaiting DisposeAsync().");
+    }
+
+    [Fact]
+    public void HubWindow_ContainsActivationHook_InTryCatch()
+    {
+        var source = ReadHubWindowSource();
+
+        // The activation hook must be wrapped so a future view model's activation cannot
+        // escape the frame-navigated XAML handler.
+        var hookIdx = source.IndexOf("PageActivator?.OnNavigatedTo", StringComparison.Ordinal);
+        Assert.True(hookIdx >= 0, "Activation hook call not found in HubWindow.");
+
+        // Look at the surrounding block for a try/catch guarding the call.
+        var windowStart = Math.Max(0, hookIdx - 400);
+        var around = source.Substring(windowStart, Math.Min(source.Length - windowStart, 800));
+        Assert.Contains("try", around);
+        Assert.Contains("catch", around);
+        Assert.Contains("Page activation failed", source);
+    }
+
+    [Fact]
+    public void App_ResetsNavigationScope_OnHubClose()
+    {
+        var source = ReadAppSources();
+
+        // Closing the hub must reset the navigation scope so page view models do not
+        // outlive their window.
+        Assert.Contains("PageActivator?.Reset()", source);
+    }
+
+    [Fact]
+    public void HubWindow_InvokesPageActivator_OnNavigation()
+    {
+        var source = ReadHubWindowSource();
+
+        Assert.Contains("PageActivator", source);
+        Assert.Contains("OnNavigatedTo", source);
+    }
+
+    [Fact]
+    public void PresentationCore_IsWinUiFree()
+    {
+        // Scan the whole core recursively but exclude the intentionally WinUI-bound
+        // Adapters/ folder, so any future core code in a new subfolder is still covered.
+        var adaptersDir = Path.Combine(PresentationDir, "Adapters") + Path.DirectorySeparatorChar;
+        var files = Directory
+            .EnumerateFiles(PresentationDir, "*.cs", SearchOption.AllDirectories)
+            .Where(p => !p.StartsWith(adaptersDir, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        Assert.NotEmpty(files);
+
+        foreach (var file in files)
+        {
+            var offending = FindWinUiToken(File.ReadAllText(file));
+            Assert.True(offending is null,
+                $"{Path.GetFileName(file)} contains banned WinUI token '{offending}'; the Presentation core must stay " +
+                "WinUI-free (put WinUI-bound code in Presentation/Adapters/).");
+        }
+    }
+
+    [Fact]
+    public void WinUiFreeGuard_FlagsBannedTokensButIgnoresComments()
+    {
+        // The guard must have teeth: it flags WinUI usage in code (not just using
+        // directives) while ignoring line and block comments and lowercase prose.
+        Assert.Equal("Microsoft.UI", FindWinUiToken("using Microsoft.UI.Xaml;\nclass X {}"));
+        Assert.Equal("Application.Current", FindWinUiToken("var x = Application.Current;"));
+        Assert.Equal("Frame", FindWinUiToken("void M(Frame f) {}"));
+        Assert.Equal("Window", FindWinUiToken("Window w;"));
+
+        Assert.Null(FindWinUiToken("/// mentions Microsoft.UI.Dispatching.DispatcherQueue in a doc"));
+        Assert.Null(FindWinUiToken("// forwards to the existing frame navigation path"));
+        Assert.Null(FindWinUiToken("int frame = 0; // lowercase identifier is fine"));
+        Assert.Null(FindWinUiToken("/* Window Frame Brush Color Microsoft.UI in a block comment */"));
+        Assert.Null(FindWinUiToken("var s = new HubWindow();".Replace("HubWindow", "HubWidget")));
+    }
+
+    [Fact]
+    public void PresentationAdapters_StayWinUiBound_AndAreNotLinkedIntoPureTests()
+    {
+        var adaptersDir = Path.Combine(PresentationDir, "Adapters");
+        Assert.True(Directory.Exists(adaptersDir), "Expected Presentation/Adapters to hold the WinUI-bound implementations.");
+        Assert.NotEmpty(Directory.EnumerateFiles(adaptersDir, "*.cs", SearchOption.TopDirectoryOnly));
+
+        var csproj = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(), "tests", "OpenClaw.Tray.Tests", "OpenClaw.Tray.Tests.csproj"));
+
+        Assert.DoesNotContain("Presentation\\Adapters", csproj);
+        Assert.DoesNotContain("WinUIDispatcher", csproj);
+        Assert.DoesNotContain("FramePageActivator", csproj);
+    }
+
+    private static string PresentationDir =>
+        Path.Combine(TestRepositoryPaths.GetRepositoryRoot(), "src", "OpenClaw.Tray.WinUI", "Presentation");
+
+    private static readonly string[] BannedSubstrings =
+    {
+        "Microsoft.UI", "Windows.UI", "Microsoft.Extensions.Hosting", "Application.Current",
+    };
+
+    private static readonly Regex BannedTypeTokens =
+        new(@"\b(Window|Frame|Brush|Color)\b", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Returns the first banned WinUI token in <paramref name="source"/> (ignoring
+    /// comments), or null when the source is WinUI-free.
+    /// </summary>
+    private static string? FindWinUiToken(string source)
+    {
+        var code = StripComments(source);
+
+        foreach (var banned in BannedSubstrings)
+        {
+            if (code.Contains(banned, StringComparison.Ordinal))
+            {
+                return banned;
+            }
+        }
+
+        var match = BannedTypeTokens.Match(code);
+        return match.Success ? match.Value : null;
+    }
+
+    private static string StripComments(string source)
+    {
+        // Remove /* ... */ block comments first (may span lines), then // line comments.
+        var withoutBlocks = Regex.Replace(source, @"/\*.*?\*/", " ", RegexOptions.Singleline);
+
+        var builder = new System.Text.StringBuilder(withoutBlocks.Length);
+        foreach (var line in withoutBlocks.Split('\n'))
+        {
+            var commentIndex = line.IndexOf("//", StringComparison.Ordinal);
+            builder.Append(commentIndex >= 0 ? line[..commentIndex] : line).Append('\n');
+        }
+
+        return builder.ToString();
+    }
+
+    private static string ReadAppSources()
+    {
+        var appDir = Path.Combine(TestRepositoryPaths.GetRepositoryRoot(), "src", "OpenClaw.Tray.WinUI");
+        return string.Join(
+            "\n",
+            Directory
+                .EnumerateFiles(appDir, "App*.cs", SearchOption.TopDirectoryOnly)
+                .OrderBy(Path.GetFileName)
+                .Select(File.ReadAllText));
+    }
+
+    private static string ReadHubWindowSource()
+    {
+        return File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(), "src", "OpenClaw.Tray.WinUI", "Windows", "HubWindow.xaml.cs"));
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/Presentation/PresentationTestDoubles.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/PresentationTestDoubles.cs
@@ -1,0 +1,209 @@
+using OpenClawTray.Presentation;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests.Presentation;
+
+/// <summary>Shared test doubles for the presentation seam tests.</summary>
+internal sealed class RecordingUiDispatcher : IUiDispatcher, IDisposable
+{
+    private readonly List<Action> _pending = new();
+
+    public bool Disposed { get; private set; }
+    public int EnqueuedCount { get; private set; }
+
+    /// <summary>Settable so tests can simulate on-thread vs background callers.</summary>
+    public bool HasThreadAccess { get; set; } = true;
+
+    /// <summary>When false, enqueued actions are held until <see cref="FlushPending"/>.</summary>
+    public bool RunEnqueuedImmediately { get; set; } = true;
+
+    public bool TryEnqueue(Action action)
+    {
+        EnqueuedCount++;
+        if (RunEnqueuedImmediately)
+        {
+            action();
+        }
+        else
+        {
+            _pending.Add(action);
+        }
+
+        return true;
+    }
+
+    public void FlushPending()
+    {
+        var pending = _pending.ToList();
+        _pending.Clear();
+        foreach (var action in pending)
+        {
+            action();
+        }
+    }
+
+    public void Dispose() => Disposed = true;
+}
+
+internal sealed class FakeAppCommands : IAppCommands, IDisposable
+{
+    public List<string> Navigations { get; } = new();
+    public bool Disposed { get; private set; }
+
+    public void OpenDashboard(string? path = null) { }
+    public void Navigate(string pageTag) => Navigations.Add(pageTag);
+    public void Reconnect() { }
+    public void Disconnect() { }
+    public void ShowVoiceOverlay() { }
+    public void ShowChat() { }
+    public void CheckForUpdates() { }
+    public void ShowOnboarding() { }
+    public void ShowGatewayWizard() { }
+    public void ShowConnectionStatus() { }
+    public void NotifySettingsSaved() { }
+    public Task<bool> ResendOpenTelemetryProbeAsync() => Task.FromResult(true);
+
+    public void Dispose() => Disposed = true;
+}
+
+/// <summary>Fake navigation-aware, disposable view model for scope-lifetime tests.</summary>
+internal sealed class FakeViewModel : INavigationAware, IDisposable
+{
+    public int ActivateCount { get; private set; }
+    public int DeactivateCount { get; private set; }
+    public bool Disposed { get; private set; }
+    public object? LastParameter { get; private set; }
+
+    public void Activate(object? parameter)
+    {
+        ActivateCount++;
+        LastParameter = parameter;
+    }
+
+    public void Deactivate() => DeactivateCount++;
+
+    public void Dispose() => Disposed = true;
+}
+
+/// <summary>A second distinct view-model type for the manager tests.</summary>
+internal sealed class OtherFakeViewModel : INavigationAware, IDisposable
+{
+    public int ActivateCount { get; private set; }
+    public int DeactivateCount { get; private set; }
+    public bool Disposed { get; private set; }
+
+    public void Activate(object? parameter) => ActivateCount++;
+    public void Deactivate() => DeactivateCount++;
+    public void Dispose() => Disposed = true;
+}
+
+/// <summary>View model whose Deactivate throws, to prove the scope is still disposed.</summary>
+internal sealed class ThrowingDeactivateViewModel : INavigationAware, IDisposable
+{
+    public bool Disposed { get; private set; }
+
+    public void Activate(object? parameter) { }
+    public void Deactivate() => throw new InvalidOperationException("deactivate boom");
+    public void Dispose() => Disposed = true;
+}
+
+/// <summary>View model whose Activate throws, to prove no half-activated scope leaks.</summary>
+internal sealed class ThrowingActivateViewModel : INavigationAware, IDisposable
+{
+    public bool Disposed { get; private set; }
+
+    public void Activate(object? parameter) => throw new InvalidOperationException("activate boom");
+    public void Deactivate() { }
+    public void Dispose() => Disposed = true;
+}
+
+/// <summary>
+/// View model that calls back into the manager during Activate/Deactivate, to prove the
+/// manager rejects re-entrant navigation.
+/// </summary>
+internal sealed class ReentrantViewModel : INavigationAware, IDisposable
+{
+    private readonly NavigationScopeManager _manager;
+    private readonly bool _reenterOnActivate;
+    private readonly bool _reenterOnDeactivate;
+
+    public ReentrantViewModel(NavigationScopeManager manager, bool reenterOnActivate, bool reenterOnDeactivate)
+    {
+        _manager = manager;
+        _reenterOnActivate = reenterOnActivate;
+        _reenterOnDeactivate = reenterOnDeactivate;
+    }
+
+    public Exception? ActivateException { get; private set; }
+    public Exception? DeactivateException { get; private set; }
+    public bool Disposed { get; private set; }
+
+    public void Activate(object? parameter)
+    {
+        if (_reenterOnActivate)
+        {
+            ActivateException = Record.Exception(() => _manager.Navigate(typeof(FakeViewModel), null));
+        }
+    }
+
+    public void Deactivate()
+    {
+        if (_reenterOnDeactivate)
+        {
+            DeactivateException = Record.Exception(() => _manager.Navigate(typeof(FakeViewModel), null));
+        }
+    }
+
+    public void Dispose() => Disposed = true;
+}
+
+/// <summary>
+/// View model that appends labeled lifecycle events to a shared log, so tests can
+/// assert ordering across multiple navigations (e.g. A deactivates before B activates).
+/// </summary>
+internal sealed class OrderRecordingViewModel : INavigationAware, IDisposable
+{
+    private readonly List<string> _log;
+    private readonly string _label;
+
+    public OrderRecordingViewModel(List<string> log, string label)
+    {
+        _log = log;
+        _label = label;
+    }
+
+    public void Activate(object? parameter) => _log.Add($"activate:{_label}");
+    public void Deactivate() => _log.Add($"deactivate:{_label}");
+    public void Dispose() => _log.Add($"dispose:{_label}");
+}
+
+/// <summary>Second labeled recorder ("B") for cross-navigation ordering assertions.</summary>
+internal sealed class BViewModel : INavigationAware, IDisposable
+{
+    private readonly List<string> _log;
+
+    public BViewModel(List<string> log) => _log = log;
+
+    public void Activate(object? parameter) => _log.Add("activate:B");
+    public void Deactivate() => _log.Add("deactivate:B");
+    public void Dispose() => _log.Add("dispose:B");
+}
+
+internal sealed class TempDir : IDisposable
+{
+    public string Path { get; }
+
+    public TempDir()
+    {
+        Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"openclaw-tray-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(Path))
+        {
+            Directory.Delete(Path, true);
+        }
+    }
+}

--- a/tests/OpenClaw.Tray.Tests/Presentation/UiDispatcherContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/Presentation/UiDispatcherContractTests.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.DependencyInjection;
+using OpenClawTray.Presentation;
+using OpenClawTray.Services;
+
+namespace OpenClaw.Tray.Tests.Presentation;
+
+/// <summary>
+/// Behavioral guard for the UI-thread dispatcher abstraction. Confirms view models
+/// depend on <see cref="IUiDispatcher"/> via DI (not a concrete dispatcher queue) and
+/// locks the basic dispatcher contract.
+/// </summary>
+public sealed class UiDispatcherContractTests
+{
+    [Fact]
+    public void PageViewModel_ReceivesRegisteredDispatcher()
+    {
+        using var temp = new TempDir();
+        var dispatcher = new RecordingUiDispatcher();
+
+        var services = new ServiceCollection();
+        services.AddOpenClawTrayCore(new AppServiceContext(
+            dispatcher, new FakeAppCommands(), new SettingsManager(temp.Path)));
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+            ValidateOnBuild = true,
+        });
+
+        using var scope = provider.CreateScope();
+        var settingsVm = scope.ServiceProvider.GetRequiredService<SettingsPageViewModel>();
+        var permissionsVm = scope.ServiceProvider.GetRequiredService<PermissionsPageViewModel>();
+
+        Assert.Same(dispatcher, settingsVm.Dispatcher);
+        Assert.Same(dispatcher, permissionsVm.Dispatcher);
+    }
+
+    [Fact]
+    public void TryEnqueue_RunsActionAndReportsThreadAccess()
+    {
+        var dispatcher = new RecordingUiDispatcher();
+        var ran = false;
+
+        var queued = dispatcher.TryEnqueue(() => ran = true);
+
+        Assert.True(queued);
+        Assert.True(ran);
+        Assert.True(dispatcher.HasThreadAccess);
+        Assert.Equal(1, dispatcher.EnqueuedCount);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the dependency-injection and navigation plumbing that page view models will depend on: a root `ServiceProvider` owned by `App`, a navigation scope/activation seam, and a UI-thread dispatcher abstraction. This is **additive infrastructure only** — no page is converted to MVVM and no existing `App` behavior is moved. **Intended runtime behavior change: none.**

## What this adds

- **DI composition root.** Adds `Microsoft.Extensions.DependencyInjection` (10.0.0). `App` builds one root `ServiceProvider` with `ValidateScopes` + `ValidateOnBuild`, **after** tray initialization, and disposes it via an ordered shutdown step. App-owned services (`SettingsManager`, `IAppCommands`) are registered as **pre-built instances**, so the container never disposes them — `App` keeps sole ownership and there is **no double-dispose**. A build/validation failure is logged and leaves the provider null, so this plumbing can never prevent the tray from starting.
- **`Presentation/` WinUI-free core:** `IUiDispatcher`, `INavigationAware`, `INavigationService`, `IPageActivator`, `NavigationScopeManager` (owns the per-navigation DI scope and the view-model activate/deactivate/dispose lifetime; navigation is non-re-entrant and exception-safe), `AppNavigationService` (enforces UI-thread affinity — marshals `Navigate`/`GoBack` through `IUiDispatcher`, fails fast on off-thread `CanGoBack` reads), and transient `SettingsPageViewModel`/`PermissionsPageViewModel` placeholders. Hand-linked into the pure `net10` test project.
- **`Presentation/Adapters/` WinUI-bound:** `WinUIDispatcher`, `FramePageActivator`.
- **Navigation activation hook** in `HubWindow.OnContentFrameNavigated`. The page→view-model map is empty, so it is a **runtime no-op today**: it only advances the navigation scope and never touches a page's `DataContext`, navigation, back-stack, rail selection, or dedupe. HubWindow's existing navigation is untouched.

## Ownership / ledger

Adds three `authoritative` rows with behavioral guard tests — `ui-dispatcher` (`IUiDispatcher`), `navigation-scope` (`NavigationScopeManager`), `composition-root` (`AppServiceRegistration`) — plus matching single-source-owner entries.

## Validation

- `build.ps1`: pass (all projects)
- `dotnet test OpenClaw.Shared.Tests`: 2866 passed / 31 skipped (incl. architecture-ledger consistency)
- `dotnet test OpenClaw.Tray.Tests`: 1780 passed (incl. 38 presentation unit + integration + source-contract tests covering: no double-dispose of App-owned instances, transient view-model disposal with scope, non-re-entrant navigation, `Activate`/`Deactivate`-throws scope disposal, `Reset()` window-close teardown + re-navigation, A→B deactivate/dispose-before-activate ordering, UI-thread marshaling/fail-fast enforcement, full open→navigate→close→reopen→shutdown integration, `ValidateOnBuild`, the WinUI-free boundary, and the ordered shutdown-disposal step)

## Real behavior proof

Verified against a local Debug build of this branch (node reports `0.6.13-bkudiess-pr4-di-navigation-seam.1`), non-isolated tray, real gateway node.

- **Tray launch — DI root builds at runtime:** log emits `Service provider initialized.` on launch (observed across 3 launches). This is the `InitializeServiceProvider()` success line, proving `BuildServiceProvider(ValidateScopes + ValidateOnBuild)` succeeds in a real tray process after tray init, with no validation throw.
- **Node / MCP healthy on this build:** gateway handshake `caps=6, commands=25`; `winnode --list-tools` returns 52 tools; node connected in `node` mode.
- **Representative navigation:** multiple deep-link navigations handled and `ConnectionPage` rendered; `OnContentFrameNavigated` runs the new activation hook each time with no errors — confirming the hook is a safe no-op today.
- **Hub close / reopen (isolated current-head build, HEAD `4ed87980`):** on an isolated temp profile (`EnableMcpServer=true`; real `%APPDATA%` untouched):
  - Provider init across 2 launches: `[INFO] Service provider initialized.`; startup logs `[MCP] HTTP server listening on http://<host>:8765/`, `Started MCP-only node service without gateway connection`, `Application started (WinUI 3)`.
  - Hub **opened** via `winnode --command app.navigate {"page":"permissions"}` → `navigated:true` (Companion window present in `list_apps`).
  - Hub **closed** via a computer-use click on the title-bar Close button → window removed from `list_apps`, i.e. `HubWindow.Closed` fired and the `IPageActivator.Reset()` path ran, with **no exception logged**.
  - Hub **reopened** via `app.navigate {"page":"connection"}` → `navigated:true` (fresh navigation after `Reset()`), **no exception** (only a benign, unrelated `[WARN] [ConnectionPage] Could not subscribe to High Contrast changes`).
  - Full-log error scan: the only `[ERROR]` is `Previous session did not exit cleanly` (from an earlier `Stop-Process` kill of a prior probe instance, not PR code) — no `ObjectDisposedException`, no `failed disposing`, no lifecycle exceptions.
- **Clean shutdown — live-proven:** this PR adds `SafeShutdownStepAsync("service provider", …)` which nulls `_services` and then awaits `ServiceProvider.DisposeAsync()`. Captured live at current head (`4ed87980`) by clicking the tray Close on the isolated build:
  ```
  [2026-07-17 11:54:40.817] [INFO] Shutdown: disposing service provider
  [2026-07-17 11:54:40.820] [INFO] Shutdown: disposed service provider
  ```
  The full ordered sequence confirms the intended lifecycle: windows/services torn down first (OpenTelemetry endpoint, node service, ssh tunnel, pairing approval, chat window, setup window, tray menu window, keep-alive window) → **then** `service provider` → **then** tray icon → single-instance mutex → deep link token source → `Shutdown complete; calling Exit() now`. `disposed service provider` appears exactly **once** (no double-dispose), there is **no** `Shutdown: failed disposing` line and **no** `ObjectDisposedException`, and the `_services = null` before `await DisposeAsync()` fix ran cleanly (no late `Frame.Navigated` fault). Corroborated by `PresentationSeamContractTests.App_DisposesServiceProvider_DuringShutdown`, `App_NullsServiceProviderField_BeforeAwaitingDisposal`, and `AppServiceRegistrationTests.Dispose_DoesNotDisposeAppOwnedInstanceSingletons`.

## Follow-ups

- When pages gain view models, wrap the `OnContentFrameNavigated` activation-hook body in try/catch-and-log so a misbehaving view model `Activate`/`Deactivate` cannot surface as an unhandled exception in the frame-navigated handler.
- Reintroduce a shutdown-safe awaitable UI-marshaling method on `IUiDispatcher` if/when a consumer needs it.


