### PR TITLE
fix(setup): cancel node pairing cleanly instead of a spurious timeout warning + wasted retry

### DIFF
--- a/src/OpenClaw.SetupEngine/SetupSteps.cs
+++ b/src/OpenClaw.SetupEngine/SetupSteps.cs
@@ -2257,6 +2257,13 @@ public sealed class PairNodeStep : SetupStep
 
             return StepResult.Fail($"Node connection failed: {outcome.Outcome}");
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Let a caller-driven cancel propagate so the pipeline reports Cancelled,
+            // not a Failed step — the catch-all below would otherwise convert it back
+            // into StepResult.Fail (same idiom as the other steps' cancel rethrow).
+            throw;
+        }
         catch (Exception ex)
         {
             return StepResult.Fail($"Node pairing failed: {ex.Message}", ex);
@@ -2387,8 +2394,11 @@ public sealed class PairNodeStep : SetupStep
             cts.CancelAfter(timeout);
             return await tcs.Task.WaitAsync(cts.Token);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
+            // Only the internal CancelAfter(timeout) firing is a Timeout; a caller
+            // (user aborting setup) cancelling `ct` must propagate so the pipeline
+            // reports Cancelled, rather than being misreported as a node timeout.
             return new NodeConnectionResult(NodeConnectionOutcome.Timeout);
         }
         finally

--- a/tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj
+++ b/tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenClaw.SetupEngine\OpenClaw.SetupEngine.csproj" />
+    <ProjectReference Include="..\OpenClaw.TestSupport\OpenClaw.TestSupport.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/OpenClaw.SetupEngine.Tests/SetupNodeConnectCancellationTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupNodeConnectCancellationTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenClaw.Shared;
+using OpenClaw.TestSupport;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OpenClaw.SetupEngine.Tests;
+
+/// <summary>
+/// Helper-level coverage for the node-pairing cancellation fix. The durable end-to-end
+/// contract (Cancelled outcome + no retry warning + cancellation journal) is asserted at the
+/// pipeline level in <c>SetupStepsTests.SetupPipeline_CallerCancel_*</c>; these tests pin the
+/// two catch-filter boundaries directly: a caller cancel must propagate as an
+/// <see cref="OperationCanceledException"/>, while a genuine internal timeout must still map to
+/// <see cref="NodeConnectionOutcome.Timeout"/>.
+/// </summary>
+public sealed class SetupNodeConnectCancellationTests : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly string _dataDir;
+
+    public SetupNodeConnectCancellationTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _dataDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "setup-cancel-" + Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(_dataDir);
+    }
+
+    public void Dispose()
+    {
+        try { System.IO.Directory.Delete(_dataDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    // Bind by full signature (not just name) so a signature change fails loudly here rather than
+    // silently matching the wrong overload — per reviewer feedback on brittle reflection.
+    private static MethodInfo ResolveWaitForNodeConnection()
+    {
+        var candidates = typeof(SetupStep).Assembly.GetTypes()
+            .SelectMany(t => t.GetMethods(BindingFlags.NonPublic | BindingFlags.Static))
+            .Where(m => m.Name == "WaitForNodeConnection")
+            .Where(m =>
+            {
+                var p = m.GetParameters();
+                return p.Length == 4
+                    && p[0].ParameterType == typeof(WindowsNodeClient)
+                    && p[1].ParameterType == typeof(SetupContext)
+                    && p[2].ParameterType == typeof(TimeSpan)
+                    && p[3].ParameterType == typeof(CancellationToken);
+            })
+            .ToList();
+        Assert.True(candidates.Count == 1,
+            $"Expected exactly one private static WaitForNodeConnection(WindowsNodeClient, SetupContext, TimeSpan, " +
+            $"CancellationToken); found {candidates.Count}. If the signature moved, update this test.");
+        return candidates[0];
+    }
+
+    private SetupContext MakeContext()
+    {
+        var logger = new SetupLogger(filePath: null, LogLevel.Trace);
+        return new SetupContext(
+            new SetupConfig(), logger, new TransactionJournal(filePath: null),
+            new CommandRunner(logger), CancellationToken.None,
+            dataDir: _dataDir, localDataDir: _dataDir);
+    }
+
+    [Fact]
+    public async Task WaitForNodeConnection_CallerCancellation_PropagatesInsteadOfTimeout()
+    {
+        using var server = new SilentWebSocketServer();
+        var ctx = MakeContext();
+        using var client = new WindowsNodeClient($"ws://127.0.0.1:{server.Port}", "test-token-placeholder", _dataDir);
+
+        using var callerCts = new CancellationTokenSource();
+        // 15s internal timeout window; the caller cancels only AFTER the WS upgrade barrier, so
+        // the method is provably in its wait — not a 300ms guess about handshake timing.
+        var task = (Task)ResolveWaitForNodeConnection().Invoke(null,
+            new object[] { client, ctx, TimeSpan.FromSeconds(15), callerCts.Token })!;
+        await server.UpgradeCompleted;
+        callerCts.Cancel();
+
+        try
+        {
+            await task.WaitAsync(TimeSpan.FromSeconds(30));
+            var result = task.GetType().GetProperty("Result")!.GetValue(task)!;
+            var outcome = result.GetType().GetProperty("Outcome")!.GetValue(result)!.ToString();
+            Assert.Fail($"Caller cancellation was misclassified: returned Outcome={outcome} " +
+                        "(the 15s internal timeout never elapsed). Expected OperationCanceledException.");
+        }
+        catch (OperationCanceledException)
+        {
+            _output.WriteLine("caller cancellation propagated as OperationCanceledException");
+        }
+    }
+
+    [Fact]
+    public async Task WaitForNodeConnection_GenuineInternalTimeout_StillMapsToTimeout()
+    {
+        using var server = new SilentWebSocketServer();
+        var ctx = MakeContext();
+        using var client = new WindowsNodeClient($"ws://127.0.0.1:{server.Port}", "test-token-placeholder", _dataDir);
+
+        // No caller cancellation — the internal CancelAfter(timeout) is the only thing that fires.
+        // This must still be classified as Timeout (the fix only diverts caller-driven cancels).
+        var task = (Task)ResolveWaitForNodeConnection().Invoke(null,
+            new object[] { client, ctx, TimeSpan.FromMilliseconds(200), CancellationToken.None })!;
+
+        await task.WaitAsync(TimeSpan.FromSeconds(30));
+        var result = task.GetType().GetProperty("Result")!.GetValue(task)!;
+        var outcome = result.GetType().GetProperty("Outcome")!.GetValue(result)!.ToString();
+        _output.WriteLine($"genuine internal timeout → Outcome={outcome}");
+        Assert.Equal("Timeout", outcome);
+    }
+}

--- a/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
+++ b/tests/OpenClaw.SetupEngine.Tests/SetupStepsTests.cs
@@ -1,8 +1,10 @@
 using OpenClaw.Connection;
+using OpenClaw.TestSupport;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using Xunit.Abstractions;
 
 namespace OpenClaw.SetupEngine.Tests;
 
@@ -13,11 +15,13 @@ public class SetupStepsTests : IDisposable
     private readonly string _localTempDir;
     private readonly string? _prevDataDir;
     private readonly string? _prevLocalDataDir;
+    private readonly ITestOutputHelper _output;
     private const string DevicePairPluginNotFoundOutput = "plugins.entries.device-pair: plugin not found: device-pair";
     private const string OtherPluginNotFoundOutput = "plugins.entries.other-plugin: plugin not found: other-plugin";
 
-    public SetupStepsTests()
+    public SetupStepsTests(ITestOutputHelper output)
     {
+        _output = output;
         _tempDir = Path.Combine(Path.GetTempPath(), $"steps-test-{Guid.NewGuid():N}");
         _localTempDir = Path.Combine(Path.GetTempPath(), $"steps-local-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
@@ -2193,6 +2197,112 @@ public class SetupStepsTests : IDisposable
         ctx.DistroName = "test-distro";
         ctx.SharedGatewayToken = "shared-token";
         return ctx;
+    }
+
+    // Shared scenario for the node-pairing cancellation tests: a reachable gateway HTTP endpoint (so
+    // WindowsGatewayReachability.VerifyAsync passes), a silent WebSocket the node client parks against,
+    // a fake WSL runner whose approval drain is empty, and a seeded gateway registry record — enough to
+    // drive the REAL PairNodeStep to its node-connection wait. `ctxToken` becomes the SetupContext's
+    // CancellationToken (used by the pipeline); pass CancellationToken.None when cancelling the step call
+    // directly. The caller disposes the returned `ws`/`http`.
+    private (SetupContext ctx, SilentWebSocketServer ws, HttpListener http, SetupLogger logger)
+        BuildNodePairingScenario(CancellationToken ctxToken)
+    {
+        var httpPort = GetFreeTcpPort();
+        var http = new HttpListener();
+        http.Prefixes.Add($"http://localhost:{httpPort}/");
+        http.Start();
+        _ = Task.Run(async () =>
+        {
+            while (http.IsListening)
+            {
+                HttpListenerContext c;
+                try { c = await http.GetContextAsync(); }
+                catch { return; }
+                c.Response.StatusCode = 200;
+                c.Response.Close();
+            }
+        });
+
+        var ws = new SilentWebSocketServer();
+        var commands = new FakeCommandRunner(_ => Ok(), (_, _, _) => Ok(stdout: "No pending device approvals"));
+        var logger = new SetupLogger(filePath: null, LogLevel.Trace);
+        var ctx = new SetupContext(
+            new SetupConfig { GatewayPort = httpPort }, logger,
+            new TransactionJournal(filePath: null), commands, ctxToken);
+        ctx.DistroName = "test-distro";
+        ctx.SharedGatewayToken = "test-token-placeholder";
+        ctx.GatewayUrl = $"ws://127.0.0.1:{ws.Port}";
+        ctx.GatewayRecordId = "test-gw";
+
+        var registry = new GatewayRegistry(_tempDir);
+        registry.Load();
+        registry.AddOrUpdate(new GatewayRecord
+        {
+            Id = "test-gw",
+            Url = ctx.GatewayUrl,
+            IsLocal = true,
+            SetupManagedDistroName = ctx.DistroName,
+            SshTunnel = null,
+        });
+        registry.Save();
+        return (ctx, ws, http, logger);
+    }
+
+    // The step itself must rethrow a caller cancel rather than swallow it into StepResult.Fail.
+    [Fact]
+    public async Task PairNodeStep_CallerCancellation_PropagatesInsteadOfFailing()
+    {
+        var (ctx, ws, http, _) = BuildNodePairingScenario(CancellationToken.None);
+        using (ws)
+        using (http)
+        {
+            using var callerCts = new CancellationTokenSource();
+            var task = new PairNodeStep().ExecuteAsync(ctx, callerCts.Token);
+            await ws.UpgradeCompleted;   // deterministic barrier: the client is in its node-connection wait
+            callerCts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+        }
+    }
+
+    // Durable end-to-end contract (the user-visible behavior the PR promises): driving the REAL
+    // SetupPipeline with the real PairNodeStep and a caller cancel, the pipeline reports Cancelled/exit 3,
+    // emits NO "connection failed"/retry warning, and journals the abort as a cancellation — not a
+    // failed-step narrative. On base the step's retry masks the *outcome* to Cancelled too, so the
+    // log/journal assertions are what actually pin this fix.
+    [Fact]
+    public async Task SetupPipeline_CallerCancel_CancelsCleanlyWithoutFailureNarrative()
+    {
+        using var callerCts = new CancellationTokenSource();
+        var (ctx, ws, http, logger) = BuildNodePairingScenario(callerCts.Token);
+        using (ws)
+        using (http)
+        {
+            var logs = new List<LogEntry>();
+            logger.LogEmitted += (_, e) => { lock (logs) { logs.Add(e); } };
+
+            var pipeline = new SetupPipeline(new SetupStep[] { new PairNodeStep() }, rollbackOnFailureOverride: false);
+            var run = pipeline.RunAsync(ctx);
+            await ws.UpgradeCompleted;
+            callerCts.Cancel();
+            var result = await run;
+
+            _output.WriteLine($"SetupPipeline on caller-cancel → Outcome={result.Outcome}, ExitCode={result.ExitCode}");
+
+            // 1. user-observable outcome
+            Assert.Equal(PipelineOutcome.Cancelled, result.Outcome);
+            Assert.Equal(3, result.ExitCode);
+
+            // 2. no misleading connection-failure / retry warning for a user abort
+            List<LogEntry> snapshot;
+            lock (logs) { snapshot = logs.ToList(); }
+            Assert.DoesNotContain(snapshot, e => e.Message.Contains("Node connection failed", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(snapshot, e => e.Level == LogLevel.Warn && e.Message.Contains("retrying", StringComparison.OrdinalIgnoreCase));
+
+            // 3. journal records the cancellation, not a failed-step narrative
+            Assert.Contains(ctx.Journal.Entries, en => en.Event == "pipeline_cancelled");
+            Assert.DoesNotContain(ctx.Journal.Entries, en => en.Event == "pipeline_failed");
+        }
     }
 
     private sealed class FakeCommandRunner(

--- a/tests/OpenClaw.TestSupport/SilentWebSocketServer.cs
+++ b/tests/OpenClaw.TestSupport/SilentWebSocketServer.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace OpenClaw.TestSupport;
+
+/// <summary>
+/// Loopback WebSocket server that completes the upgrade handshake and then stays
+/// silent — the client connects successfully but never receives a message, so code
+/// that waits for a gateway challenge/response parks in its wait. Lets a test drive
+/// the real <c>ClientWebSocket</c> connect path and then exercise cancellation while
+/// the wait is in flight, without any running gateway. Shared single source so the
+/// helper can't drift across test projects.
+/// </summary>
+public sealed class SilentWebSocketServer : IDisposable
+{
+    private readonly TcpListener _listener;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly TaskCompletionSource _upgraded =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>The loopback port the server is listening on (use as <c>ws://127.0.0.1:{Port}</c>).</summary>
+    public int Port { get; }
+
+    /// <summary>Completes once the server has sent the WebSocket 101 upgrade to a client — a
+    /// deterministic barrier a test can await before cancelling, instead of guessing a delay.</summary>
+    public Task UpgradeCompleted => _upgraded.Task;
+
+    public SilentWebSocketServer()
+    {
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+        _ = AcceptLoopAsync();
+    }
+
+    private async Task AcceptLoopAsync()
+    {
+        while (!_cts.IsCancellationRequested)
+        {
+            TcpClient tcp;
+            try { tcp = await _listener.AcceptTcpClientAsync(_cts.Token); }
+            catch { return; }
+            _ = HandleAsync(tcp);
+        }
+    }
+
+    private async Task HandleAsync(TcpClient tcp)
+    {
+        try
+        {
+            var stream = tcp.GetStream();
+            var buf = new byte[16384];
+            var sb = new StringBuilder();
+            while (!sb.ToString().Contains("\r\n\r\n"))
+            {
+                var n = await stream.ReadAsync(buf, _cts.Token);
+                if (n <= 0) return;
+                sb.Append(Encoding.ASCII.GetString(buf, 0, n));
+            }
+            var key = sb.ToString().Split("\r\n")
+                .FirstOrDefault(l => l.StartsWith("Sec-WebSocket-Key:", StringComparison.OrdinalIgnoreCase))
+                ?.Split(':', 2)[1].Trim();
+            var accept = Convert.ToBase64String(SHA1.HashData(
+                Encoding.ASCII.GetBytes(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")));
+            var resp = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n" +
+                       "Connection: Upgrade\r\nSec-WebSocket-Accept: " + accept + "\r\n\r\n";
+            await stream.WriteAsync(Encoding.ASCII.GetBytes(resp), _cts.Token);
+            _upgraded.TrySetResult();
+            await Task.Delay(Timeout.Infinite, _cts.Token);
+        }
+        catch { /* torn down with the test */ }
+        finally { try { tcp.Dispose(); } catch { } }
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _listener.Stop();
+    }
+}


### PR DESCRIPTION
Related: #1010

## What Problem This Solves

When a user cancels node setup while the pairing step is waiting to connect, the cancellation isn't handled cleanly: the step logs a misleading `"Node connection failed: Timeout"` warning (implying a connection problem, not a user abort), then **burns a retry** — `Task.Delay(3s, ct)` on the pairing step's retry policy — before the cancellation finally surfaces. The pipeline does end up `Cancelled` either way, but only after a spurious error and a wasted retry delay, and the journal/log record a connection "failure" that never happened.

## Why This Change Was Made

`WaitForNodeConnection` links the caller's token with an internal `CancelAfter(timeout)` and catches *every* `OperationCanceledException` as `NodeConnectionOutcome.Timeout`; `PairNodeStep.ExecuteAsync`'s catch-all then turns that into `StepResult.Fail(...)`. So a user cancel is reported as a failed connection attempt, which the step's retry policy (`MaxAttempts: 3`) then retries — and only the retry's `Task.Delay(..., ct)` tripping on the cancelled token gets the pipeline to `Cancelled`.

The fix makes the cancellation propagate directly, using the file's existing cancel-rethrow idiom (`SetupSteps.cs:1725`, `:2044`): guard the `Timeout` mapping with `when (!ct.IsCancellationRequested)`, and add `catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }` ahead of `PairNodeStep`'s catch-all. The pipeline then maps the propagated OCE straight to `Cancelled` — no spurious "failed" log, no wasted retry. The genuine-timeout path is unchanged.

## Scope — what this does and doesn't change (traced end-to-end)

Being precise, because it's easy to overstate: **the final pipeline outcome is `Cancelled` (exit 3) with or without this change** — `PairNodeStep`'s retry policy means a caller-cancel trips the retry delay and surfaces as `Cancelled` regardless. What this PR changes is the *path* to that outcome on a user cancel:

- **Before:** `[Warn] Step 'pair-node' failed (attempt 1/3), retrying in 3s: Node connection failed: Timeout` → (retry delay) → `Cancelled`.
- **After:** cancellation surfaces immediately → `Cancelled`, no spurious warning, no retry delay.

So this is a cancellation-cleanliness / accurate-diagnostics fix, not an outcome change.

## User Impact

Cancelling node setup no longer emits a misleading "connection failed" warning to the log/journal or wastes a retry cycle — the abort is recorded and surfaced accurately and immediately. No change for a real connection timeout.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [ ] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [x] Setup or onboarding
- [ ] Permissions, privacy, or security
- [ ] Tests, CI, or docs

## Validation

Full Windows CI-matrix mirror (win-x64, .NET 10.0.301), HEAD `55f93df0` vs base `9fb1960e` — every project built and all 8 suites passed. Four focused regression tests (SetupEngine.Tests), on base vs HEAD:

```
dotnet test tests/OpenClaw.SetupEngine.Tests --filter \
  "PairNodeStep_CallerCancellation|WaitForNodeConnection_CallerCancellation|SetupPipeline_CallerCancel|WaitForNodeConnection_GenuineInternalTimeout"
Passed! - Failed: 0, Passed: 4   (HEAD)
Failed! - Failed: 3, Passed: 1   (base, SetupSteps.cs reverted to main)
```

- **`SetupPipeline_CallerCancel_CancelsCleanlyWithoutFailureNarrative`** — the durable end-to-end contract: drives the **real** `SetupPipeline` with the real `PairNodeStep` and asserts all three of Cancelled/exit 3, **no `"Node connection failed"`/retry warning**, and a `pipeline_cancelled` journal entry (not a failed-step narrative). This is what actually pins the fix — it's red on base (the retry-warning assertion fails) and green on HEAD.
- **`PairNodeStep_CallerCancellation`** + **`WaitForNodeConnection_CallerCancellation`** — the two catch boundaries, cancelled from a **deterministic WebSocket-upgrade barrier** (no timing guess).
- **`WaitForNodeConnection_GenuineInternalTimeout`** — a real internal timeout still maps to `Timeout` (passes on both base and HEAD; proves the fix only diverts caller cancels).

_This revision addresses the ClawSweeper / Copilot maintainer-assistant review: adds the deterministic pipeline-level contract, the genuine-timeout assertion, the upgrade barrier (replacing the 300 ms delay), and binds the reflection lookup by full signature with a clear failure message._

(Two intermittent pre-existing flakes exist in the full matrix — `Connection.Tests.ConnectAndReconnect_EmitCompletedOperatorSpans` and `Tray.UITests.ChatTimelineVirtualizationProofTests` — on surfaces this SetupEngine-only diff doesn't touch; neither is a regression here.)

## Real Behavior Proof

### Real gateway transcript

Driving the real `SetupPipeline`/`PairNodeStep` against a **live OpenClaw gateway** (a genuine `connect.challenge` handshake — node role, 9 capabilities, 30 commands, v2 signature), then cancelling while node pairing is waiting — the same `CancellationToken` the setup CLI's `Console.CancelKeyPress` (Ctrl+C) cancels. Base vs HEAD:

- **base** (fix reverted) — a spurious failure warning + retry before it cancels:
  ```
  [WS][HANDSHAKE] Received connect.challenge; → Sending connect: role=node, caps=9, commands=30, sig=v2
  [Warn] Step 'pair-node' failed (attempt 1/3), retrying in 3s: Node connection failed: Error
  === [user cancel] ===
  === PIPELINE RESULT: Outcome=Cancelled ExitCode=3 ===
  journal: pipeline_started → started pair-node → pipeline_cancelled
  ```
- **HEAD** (`55f93df0`) — clean immediate cancellation, no warning, no retry:
  ```
  [WS][HANDSHAKE] Received connect.challenge; → Sending connect: role=node, caps=9, commands=30, sig=v2
  === [user cancel] ===
  [WS] Node disconnected
  === PIPELINE RESULT: Outcome=Cancelled ExitCode=3 ===
  journal: pipeline_started → started pair-node → pipeline_cancelled
  ```

Same final outcome; on HEAD there is no `"Node connection failed"` warning and no retry. _Caveat: the pre-step WSL approval-drain is stubbed in this harness; the gateway WebSocket connection, the pairing wait, and the cancellation are all real._

### Deterministic pipeline coverage (in CI)

The same contract is asserted deterministically by `SetupPipeline_CallerCancel_CancelsCleanlyWithoutFailureNarrative` (loopback WS + upgrade barrier, no live gateway needed): Cancelled/exit 3, no `"Node connection failed"`/retry warning, `pipeline_cancelled` journal — red on base, green on HEAD.

- Environment tested: Windows host, .NET SDK 10.0.301, win-x64; live OpenClaw gateway on loopback (`ws://127.0.0.1:18789`)
- PR head / base tested: `55f93df0` / (fix hunks reverted)
- Screenshot or artifact links verified? `N/A` (non-UI setup/connection logic; proof is the real-gateway transcript + the paired red→green tests)

## Security Impact

- New permissions or capabilities? `No`
- Secrets or tokens handling changed? `No`
- New or changed network calls? `No`
- Command or tool execution surface changed? `No`
- Data access scope changed? `No`

## Compatibility and Migration

- Backward compatible? `Yes`
- Config or environment changes? `No`
- Migration needed? `No`

## Review History

Local review history (findings + dispositions per commit), including the correction from the original "reports Failed" framing to the accurate cancellation-cleanliness scope: https://gist.github.com/anagnorisis2peripeteia/0bdbede425c116811993f71fed9816b9

## Review Conversations

- [ ] I replied to or resolved every bot review conversation addressed by this PR.
- [ ] I left unresolved only conversations that still need maintainer judgment.
