### PR TITLE
fix(gateway): isolate the SessionsUpdated snapshot from live tracked state

### DIFF
--- a/src/OpenClaw.Shared/Models.cs
+++ b/src/OpenClaw.Shared/Models.cs
@@ -253,6 +253,10 @@ public static class ChannelHealthParser
 
 public class SessionInfo
 {
+    /// <summary>Defensive copy so a snapshot handed to a SessionsUpdated subscriber does not
+    /// alias the live tracked instance (whose fields are mutated in place under _sessionsLock).</summary>
+    public SessionInfo Clone() => (SessionInfo)MemberwiseClone();
+
     public string Key { get; set; } = "";
     public bool IsMain { get; set; }
     public string Status { get; set; } = "unknown";

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -3397,6 +3397,9 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         // Avoids the intermediate List<T> that new List(collection).ToArray() would produce.
         var arr = new SessionInfo[_sessions.Count];
         _sessions.Values.CopyTo(arr, 0);
+        // Defensive copy: subscribers read the snapshot with no lock, and the tracked
+        // instances keep being mutated in place under _sessionsLock — hand out clones.
+        for (var i = 0; i < arr.Length; i++) arr[i] = arr[i].Clone();
         Array.Sort(arr, static (a, b) =>
         {
             // Main session first, then by last seen

--- a/tests/OpenClaw.Shared.Tests/SessionSnapshotIsolationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/SessionSnapshotIsolationTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using System.Reflection;
+using OpenClaw.Shared;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OpenClaw.Shared.Tests;
+
+/// <summary>
+/// Regression: the SessionInfo[] snapshot raised through SessionsUpdated (and returned by
+/// GetSessionList) must be isolated from the live tracked state. GetSessionListInternal
+/// copies the array but its elements were the very SessionInfo instances held in _sessions,
+/// which UpdateTrackedSession mutates in place under _sessionsLock — so a subscriber reading
+/// a snapshot with no lock could observe fields (CurrentActivity/LastSeen/Status) changing
+/// underneath it. Before the fix this test is red: a captured snapshot's CurrentActivity is
+/// overwritten by a later update.
+/// </summary>
+public sealed class SessionSnapshotIsolationTests : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly string _identityDir;
+
+    public SessionSnapshotIsolationTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _identityDir = Path.Combine(Path.GetTempPath(), "session-snap-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_identityDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_identityDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void SessionSnapshot_IsNotAliasedToLiveTrackedState()
+    {
+        using var client = new OpenClawGatewayClient(
+            "ws://127.0.0.1:1", "test-token", new TestLogger(), identityPath: _identityDir);
+
+        var update = typeof(OpenClawGatewayClient).GetMethod(
+            "UpdateTrackedSession", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        update.Invoke(client, new object[] { "agent:main:main", true, "compiling" });
+
+        var snapshot = client.GetSessionList();
+        var captured = Assert.Single(snapshot);
+        Assert.Equal("compiling", captured.CurrentActivity);
+
+        // A later update for the same session must not reach back through the earlier snapshot.
+        update.Invoke(client, new object[] { "agent:main:main", true, "running-tool" });
+
+        _output.WriteLine($"captured.CurrentActivity after later update = '{captured.CurrentActivity}'");
+        Assert.Equal("compiling", captured.CurrentActivity);
+    }
+}


### PR DESCRIPTION
Related: #1010

## What Problem This Solves

Fixes a data race where a `SessionInfo` snapshot delivered to `SessionsUpdated` subscribers is not isolated from the gateway client's live tracked state. A subscriber reading a session's fields (e.g. `CurrentActivity`, `LastSeen`, `Status`) can observe them changing underneath it while the message-receive thread updates the same session — so a consumer (the tray's session views) can read shifting/inconsistent values, e.g. a session's activity from one update mixed with its timestamp from the next.

**Severity — being precise:** this is a genuine unsynchronized read/write, but low-severity in practice. On x64 the individual field reads are atomic (`string` references and `DateTime`'s backing `ulong`), so the symptom is stale/mixed field values in the UI, not a torn read or crash. The fix is a cheap, standard hardening (hand out an immutable copy) rather than a fix for an observed corruption.

## Why This Change Was Made

`GetSessionListInternal` snapshots the *array* but copies the `SessionInfo` **references** straight out of the `_sessions` map (`_sessions.Values.CopyTo(arr, 0)`). `UpdateTrackedSession` then mutates those same objects in place under `_sessionsLock`, while `SessionsUpdated` subscribers read the snapshot with no lock. The delivered snapshot is therefore a live alias of mutable state. The fix hands out a defensive copy — `arr[i] = arr[i].Clone()` (a `SessionInfo.Clone()` via `MemberwiseClone`) — so a delivered snapshot is immutable with respect to later in-place updates.

## User Impact

Consumers of the sessions list (the tray's session views) now receive a stable, point-in-time snapshot rather than objects that can mutate mid-read. No user-facing behavior change beyond the removal of the race.

## Evidence

Focused red→green regression test `SessionSnapshotIsolationTests.SessionSnapshot_IsNotAliasedToLiveTrackedState`, plus the full Windows build+test matrix below.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [ ] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [ ] Tests, CI, or docs

## Validation

Full CI-matrix mirror on a Windows host (win-x64, .NET 10.0.301), HEAD `e36992fb` vs base `9fb1960e`. Every project built and **all 8 test suites passed (exit 0)**, including the changed `Shared.Tests`:

```
build all projects + all 8 test projects .......... exit 0
test Shared.Tests (contains the regression) ....... exit 0
test SetupEngine / Connection / WinNode.Cli ....... exit 0
test Tray.Tests / Tray.IntegrationTests ........... exit 0
test FunctionalUI.Tests / Tray.UITests ............ exit 0
```

(Note: this repo has two intermittent pre-existing flakes — `Connection.Tests.ConnectAndReconnect_EmitCompletedOperatorSpans` and `Tray.UITests.ChatTimelineVirtualizationProofTests` — neither of which fired in this run; both are on surfaces this Shared-only diff does not touch.)

## Real Behavior Proof

- Environment tested: Windows host, .NET SDK 10.0.301, win-x64 (full matrix); the focused test also on macOS 10.0.302
- PR head or commit tested: `e36992fb` (branch `fix/session-snapshot-isolation`)
- Exact steps or command run: `dotnet test tests/OpenClaw.Shared.Tests --filter "FullyQualifiedName~SessionSnapshotIsolation"`, run against base and HEAD. The test records a session with activity `"compiling"`, captures its snapshot via `GetSessionList()`, then issues a second update for the same key and asserts the earlier snapshot is unchanged.
- Evidence after fix: on base the captured snapshot's `CurrentActivity` flips to `"running-tool"` (the later update reaching back through the aliased object) → **fails**; on HEAD it stays `"compiling"` → **passes**.
- Observed result: base red, HEAD green; deterministic (no threads/timing — proves the aliasing directly).
- Screenshot or artifact links verified? `N/A` (non-UI shared-state logic; proof is the paired red/green test)
- Not verified or blocked: none

## Security Impact

- New permissions or capabilities? `No`
- Secrets or tokens handling changed? `No`
- New or changed network calls? `No`
- Command or tool execution surface changed? `No`
- Data access scope changed? `No`

## Compatibility and Migration

- Backward compatible? `Yes`
- Config or environment changes? `No`
- Migration needed? `No`

## Review History

Local review history (findings + dispositions per commit): https://gist.github.com/anagnorisis2peripeteia/30c18e621cc0d17539ed1362931f8fc6

## Review Conversations

- [ ] I replied to or resolved every bot review conversation addressed by this PR.
- [ ] I left unresolved only conversations that still need maintainer judgment.
