### PR TITLE
fix: connection telemetry test flakes under parallel execution

### DIFF
--- a/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
+++ b/tests/OpenClaw.Connection.Tests/GatewayConnectionManagerTests.cs
@@ -120,6 +120,74 @@ public class GatewayConnectionManagerTests : IDisposable
         Assert.Null(reconnectRoot.GetTagItem(OpenClawTelemetryTagKey.ErrorCategory.ToTelemetryName()));
     }
 
+    [Fact]
+    public async Task ActivityCollector_ExcludesActivitiesFromUnrelatedExecutionContext()
+    {
+        using var activities = new ActivityCollector();
+
+        var expected = OpenClawTelemetry.StartDetachedActivity("test.connection.expected");
+        Task unrelatedTask;
+        var flow = ExecutionContext.SuppressFlow();
+        try
+        {
+            unrelatedTask = Task.Run(() =>
+            {
+                var unrelated = OpenClawTelemetry.StartDetachedActivity("test.connection.unrelated");
+                OpenClawTelemetry.StopDetachedActivity(unrelated);
+            });
+        }
+        finally
+        {
+            flow.Undo();
+        }
+
+        await unrelatedTask;
+        OpenClawTelemetry.StopDetachedActivity(expected);
+
+        var activity = Assert.Single(activities.GetStopped());
+        Assert.Equal("test.connection.expected", activity.OperationName);
+    }
+
+    [Fact]
+    public void ActivityCollector_RejectsOutOfOrderDisposal()
+    {
+        using var outer = new ActivityCollector();
+        using var inner = new ActivityCollector();
+
+        var error = Assert.Throws<InvalidOperationException>(outer.Dispose);
+
+        Assert.Equal("Activity collectors must be disposed in reverse creation order.", error.Message);
+    }
+
+    [Fact]
+    public void ActivityCollector_DisposeIsIdempotent()
+    {
+        var collector = new ActivityCollector();
+
+        collector.Dispose();
+        collector.Dispose();
+    }
+
+    [Fact]
+    public void ActivityCollector_CapturesActivityWithStringParentId()
+    {
+        using var activities = new ActivityCollector();
+        using var source = new ActivitySource(OpenClawActivitySourceName.OpenClaw.ToTelemetryName());
+        var parentId = $"00-{ActivityTraceId.CreateRandom()}-{ActivitySpanId.CreateRandom()}-01";
+
+        var activity = source.StartActivity(
+            "test.connection.string_parent",
+            System.Diagnostics.ActivityKind.Internal,
+            parentId);
+
+        Assert.NotNull(activity);
+        activity.Stop();
+        activity.Dispose();
+        var captured = Assert.Single(activities.GetStopped());
+        Assert.Equal("test.connection.string_parent", captured.OperationName);
+        Assert.Equal(1, activities.StringParentSamples);
+    }
+
     /// <summary>
     /// Regression guard for the post-onboarding "don't cancel an in-flight reconnect"
     /// path in App.OnboardingCompleted. When the V2 GatewayWelcome wizard saves a new
@@ -1996,26 +2064,60 @@ public class GatewayConnectionManagerTests : IDisposable
 
     private sealed class ActivityCollector : IDisposable
     {
+        private static readonly AsyncLocal<ActivityCollector?> Current = new();
         private readonly object _gate = new();
         private readonly ActivityListener _listener;
+        private readonly ActivityCollector? _previousCollector;
+        private readonly HashSet<Activity> _accepted = [];
         private readonly List<Activity> _stopped = [];
+        private bool _disposed;
+        private int _stringParentSamples;
 
         public ActivityCollector()
         {
+            _previousCollector = Current.Value;
+            Current.Value = this;
             _listener = new ActivityListener
             {
                 ShouldListenTo = source =>
                     source.Name == OpenClawActivitySourceName.OpenClaw.ToTelemetryName(),
                 Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
-                    ActivitySamplingResult.AllDataAndRecorded,
+                    SampleCurrentContext(),
+                SampleUsingParentId = (ref ActivityCreationOptions<string> _) =>
+                {
+                    var result = SampleCurrentContext();
+                    if (result != ActivitySamplingResult.None)
+                        Interlocked.Increment(ref _stringParentSamples);
+                    return result;
+                },
+                ActivityStarted = activity =>
+                {
+                    if (!ReferenceEquals(Current.Value, this))
+                        return;
+
+                    lock (_gate)
+                        _accepted.Add(activity);
+                },
                 ActivityStopped = activity =>
                 {
                     lock (_gate)
+                    {
+                        if (!_accepted.Remove(activity))
+                            return;
+
                         _stopped.Add(activity);
+                    }
                 }
             };
             ActivitySource.AddActivityListener(_listener);
         }
+
+        private ActivitySamplingResult SampleCurrentContext() =>
+            ReferenceEquals(Current.Value, this)
+                ? ActivitySamplingResult.AllDataAndRecorded
+                : ActivitySamplingResult.None;
+
+        public int StringParentSamples => Volatile.Read(ref _stringParentSamples);
 
         public Activity[] GetStopped()
         {
@@ -2023,7 +2125,24 @@ public class GatewayConnectionManagerTests : IDisposable
                 return [.. _stopped];
         }
 
-        public void Dispose() => _listener.Dispose();
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            if (!ReferenceEquals(Current.Value, this))
+                throw new InvalidOperationException(
+                    "Activity collectors must be disposed in reverse creation order.");
+
+            _disposed = true;
+            try
+            {
+                _listener.Dispose();
+            }
+            finally
+            {
+                Current.Value = _previousCollector;
+            }
+        }
     }
 
     private sealed class MockCredentialResolver : ICredentialResolver


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where developers running connection tests in parallel could see telemetry assertions fail when spans from unrelated test execution contexts were collected by the same process-wide listener.

## Why This Change Was Made

The test collector now scopes sampling to its owning execution context and records only activities it accepted at start time. It preserves independent production trace trees and strict span-count assertions, explicitly covers both structured and string parent IDs, and fails fast on invalid collector disposal order.

## User Impact

There is no product behavior change. Developers and CI should get deterministic connection telemetry results without disabling xUnit parallelism or weakening assertions.

## Evidence

- Before the fix, the deterministic contamination regression failed with `Assert.Single()` because the collector contained both the expected activity and an unrelated activity.
- After the fix, all five focused telemetry tests passed across 50 consecutive runs with zero failures.
- The complete 443-test connection suite passed across 10 consecutive runs with zero failures.
- Final independent Claude Opus and GPT Codex reviews reported no actionable correctness, race, or security issues.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `./build.ps1` — passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — 2,866 passed, 31 skipped, 0 failed
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — 1,742 passed, 0 failed
- `dotnet test ./tests/OpenClaw.Connection.Tests/OpenClaw.Connection.Tests.csproj --no-restore --no-build` — 443 passed, 0 failed
- Focused telemetry stress: 50 runs × 5 tests — 250 passed, 0 failed
- Full connection-suite stress: 10 runs × 443 tests — 4,430 passed, 0 failed
- One unrelated queued-chat Tray test failed once during an earlier closeout run, passed on immediate targeted rerun, and the subsequent complete required build/Shared/Tray validation passed.

## Real Behavior Proof

- Environment tested: Windows ARM64, .NET SDK 10.0.301
- PR head or commit tested: `7cd3f3828933d494ed1f11232077083504fd6ff1`
- Exact steps or command run: repeated the focused `ActivityCollector_*` tests plus `ConnectAndReconnect_EmitCompletedOperatorSpans` 50 times, then repeated the complete connection suite 10 times
- Evidence after fix: `focused_runs=50 tests_per_run=5 failures=0`; `connection_suite_runs=10 tests_per_run=443 failures=0`
- Observed result: unrelated execution-context activities were excluded while owned structured-parent and string-parent activities remained captured; strict root/phase assertions stayed green
- Screenshot or artifact links verified? (`Yes`/`No`/`N/A`): N/A
- Not verified or blocked: None

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No
- Secrets or tokens handling changed? (`Yes`/`No`): No
- New or changed network calls? (`Yes`/`No`): No
- Command or tool execution surface changed? (`Yes`/`No`): No
- Data access scope changed? (`Yes`/`No`): No
- If any answer is `Yes`, explain the risk and mitigation: N/A

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes
- Config or environment changes? (`Yes`/`No`): No
- Migration needed? (`Yes`/`No`): No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.