### PR TITLE
fix(chat): hide completed sessions from picker

### DIFF
--- a/src/OpenClaw.Chat/ChatModels.cs
+++ b/src/OpenClaw.Chat/ChatModels.cs
@@ -4,7 +4,8 @@ public enum ChatThreadStatus
 {
     Created,
     Running,
-    Suspended
+    Suspended,
+    Completed
 }
 
 public enum ChatActivity

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatDataProvider.cs
@@ -6016,7 +6016,7 @@ public sealed class OpenClawChatDataProvider : IChatDataProvider
         {
             Id = s.Key ?? string.Empty,
             Title = title,
-            Status = ChatThreadStatus.Running,
+            Status = SessionVisibilityFilter.ToChatThreadStatus(s),
             Activity = string.IsNullOrEmpty(s.CurrentActivity) ? ChatActivity.Idle : ChatActivity.Working,
             Workspace = s.Channel,
             Model = s.Model,

--- a/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
+++ b/src/OpenClaw.Tray.WinUI/Chat/OpenClawChatRoot.cs
@@ -532,7 +532,7 @@ public sealed class OpenClawChatRoot : Component
         // Session list for the composer dropdown — grouped by agent, keyed by
         // ID so every session gets its own entry regardless of display name.
         // Exclude cron sessions which are automated/background.
-        var channelGroups = snapshot.Threads
+        var channelGroups = SessionVisibilityFilter.VisibleChatPickerThreads(snapshot.Threads)
             .Where(t => !string.IsNullOrEmpty(t.Title)
                      && !t.Id.Contains(":cron:", StringComparison.Ordinal))
             .GroupBy(t =>
@@ -560,7 +560,9 @@ public sealed class OpenClawChatRoot : Component
         // the slot/session-instance within that agent. When the key
         // doesn't match this layout we fall back to a generic "Main"
         // label rather than mis-parsing some other id shape.
-        if (effectiveThread is not null && !ChannelGroupsContain(channelGroups, effectiveThread.Id))
+        if (effectiveThread is not null
+            && SessionVisibilityFilter.IsVisibleInChatPicker(effectiveThread)
+            && !ChannelGroupsContain(channelGroups, effectiveThread.Id))
         {
             var parts = (effectiveThread.Id ?? "").Split(':');
             var agentId = parts.Length >= 3 && parts[0] == "agent" ? parts[1] : "main";

--- a/src/OpenClaw.Tray.WinUI/Services/SessionVisibilityFilter.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SessionVisibilityFilter.cs
@@ -1,3 +1,4 @@
+using OpenClaw.Chat;
 using OpenClaw.Shared;
 
 namespace OpenClawTray.Services;
@@ -19,6 +20,15 @@ public static class SessionVisibilityFilter
         return string.Equals(status, "done", StringComparison.OrdinalIgnoreCase)
             || string.Equals(status, "completed", StringComparison.OrdinalIgnoreCase);
     }
+
+    public static ChatThreadStatus ToChatThreadStatus(SessionInfo session)
+        => IsCleanCompleted(session) ? ChatThreadStatus.Completed : ChatThreadStatus.Running;
+
+    public static IEnumerable<ChatThread> VisibleChatPickerThreads(IEnumerable<ChatThread> threads)
+        => threads.Where(IsVisibleInChatPicker);
+
+    public static bool IsVisibleInChatPicker(ChatThread thread)
+        => thread.Status != ChatThreadStatus.Completed;
 
     public static string ResolveActiveChannel(string activeChannel, IEnumerable<string> visibleChannels)
     {

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -576,6 +576,36 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
+    public async Task LoadAsync_MapsOnlyCleanCompletedSessionsToCompletedThreads()
+    {
+        var sessions = new[]
+        {
+            new SessionInfo { Key = "done", DisplayName = "Done", Status = "done" },
+            new SessionInfo
+            {
+                Key = "aborted",
+                DisplayName = "Aborted",
+                Status = "done",
+                AbortedLastRun = true,
+            },
+            new SessionInfo { Key = "unknown", DisplayName = "Unknown", Status = "unknown" },
+        };
+        var (_, provider, _, _) = CreateProvider(sessions);
+
+        var snapshot = await provider.LoadAsync();
+
+        Assert.Equal(
+            ChatThreadStatus.Completed,
+            Assert.Single(snapshot.Threads, thread => thread.Id == "done").Status);
+        Assert.Equal(
+            ChatThreadStatus.Running,
+            Assert.Single(snapshot.Threads, thread => thread.Id == "aborted").Status);
+        Assert.Equal(
+            ChatThreadStatus.Running,
+            Assert.Single(snapshot.Threads, thread => thread.Id == "unknown").Status);
+    }
+
+    [Fact]
     public async Task LoadAsync_DistinguishesDuplicateMultiSegmentSessionTitles()
     {
         var sessions = new[]

--- a/tests/OpenClaw.Tray.Tests/SessionVisibilityFilterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SessionVisibilityFilterTests.cs
@@ -1,3 +1,4 @@
+using OpenClaw.Chat;
 using OpenClaw.Shared;
 using OpenClawTray.Services;
 
@@ -78,6 +79,42 @@ public class SessionVisibilityFilterTests
             .ToArray();
 
         Assert.Equal(new[] { "done", "failed" }, visible);
+    }
+
+    [Theory]
+    [InlineData("done", false, ChatThreadStatus.Completed)]
+    [InlineData("completed", false, ChatThreadStatus.Completed)]
+    [InlineData("done", true, ChatThreadStatus.Running)]
+    [InlineData("unknown", false, ChatThreadStatus.Running)]
+    public void ToChatThreadStatus_ReusesCleanCompletionSemantics(
+        string status,
+        bool abortedLastRun,
+        ChatThreadStatus expected)
+    {
+        var session = new SessionInfo
+        {
+            Status = status,
+            AbortedLastRun = abortedLastRun,
+        };
+
+        Assert.Equal(expected, SessionVisibilityFilter.ToChatThreadStatus(session));
+    }
+
+    [Fact]
+    public void VisibleChatPickerThreads_HidesCompletedThreads()
+    {
+        var threads = new[]
+        {
+            new ChatThread { Id = "running", Title = "Running", Status = ChatThreadStatus.Running },
+            new ChatThread { Id = "completed", Title = "Completed", Status = ChatThreadStatus.Completed },
+            new ChatThread { Id = "suspended", Title = "Suspended", Status = ChatThreadStatus.Suspended },
+        };
+
+        var visible = SessionVisibilityFilter.VisibleChatPickerThreads(threads)
+            .Select(thread => thread.Id)
+            .ToArray();
+
+        Assert.Equal(new[] { "running", "suspended" }, visible);
     }
 
     [Theory]


### PR DESCRIPTION
## What Problem This Solves

The main Chat composer session picker listed cleanly completed sessions even though the Sessions page hides those same sessions when **Show completed** is off. On the live gateway payload, 37 `done` sessions—including many 20–29 days old—were offered in the Chat picker.

## Why This Change Was Made

Reuse the existing `SessionVisibilityFilter.IsCleanCompleted` contract when projecting gateway `SessionInfo` into `ChatThread`, then exclude only `ChatThreadStatus.Completed` from the composer picker. Aborted, failed, killed, timeout, unknown, running, and suspended sessions remain visible. A currently selected completed conversation remains viewable but is not re-added to the dropdown.

## User Impact

The Chat session dropdown stays focused on sessions that may still need attention. The Sessions page and its **Show completed** toggle are unchanged.

## Evidence

- Live `app.sessions` payload: 61 rows — 37 `done`, 23 `unknown`, 1 `killed`.
- Current-head live WinUI visual tree: the open Chat picker contained exactly the eight non-cron survivors (7 `unknown`, 1 `killed`) and no `done` rows.
- LVT proof used the shipping WinUI/FunctionalUI picker against the existing user gateway data; screenshot and XML tree were captured locally.
- Independent rubber-duck review: **CLEAN**, including selected-completed-thread and synthetic-compose behavior.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `./build.ps1` — passed; Shared, CLI, WinNode CLI, SetupEngine, and WinUI built successfully.
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — 2,901 passed, 31 skipped, 0 failed.
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — 1,820 passed, 0 failed.
- Focused session visibility/provider selector — 21 passed, 0 failed.
- `git diff --check` — passed.
- Structured autoreview bundle was valid (14 KB), but local reviewer CLIs were unavailable before analysis: Codex refused its isolated `%TEMP%` helper runtime, installed Claude Code lacked required safe-mode support, and Pi returned a connection error. Independent rubber-duck review completed cleanly.

## Real Behavior Proof

- Environment tested: Windows 11, live existing gateway/user data, release/default app identity.
- PR head or commit tested: `f9d4a62a`.
- Exact steps or command run: launched `run-app-local.ps1 -NoBuild -AllowNonMain`, navigated to Chat through local MCP, opened the session picker, dumped the live visual tree with `lvt`, and compared picker rows with `winnode --command app.sessions`.
- Evidence after fix: 37 clean-completed rows were absent; the picker contained only non-cron `unknown`/`killed` rows from the live payload.
- Observed result: completed sessions no longer appear in the main Chat dropdown; the selected conversation remains visible.
- Screenshot or artifact links verified? `N/A` — copied live MCP/LVT diagnostics above; local screenshot captured but not uploaded.
- Not verified or blocked: no remaining behavior blocker.

## Security Impact

- New permissions or capabilities? `No`
- Secrets or tokens handling changed? `No`
- New or changed network calls? `No`
- Command or tool execution surface changed? `No`
- Data access scope changed? `No`

## Compatibility and Migration

- Backward compatible? `Yes`
- Config or environment changes? `No`
- Migration needed? `No`

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.