### PR TITLE
fix(sessions): classify terminal sessions as ended

### DIFF
--- a/src/OpenClaw.Chat/ChatModels.cs
+++ b/src/OpenClaw.Chat/ChatModels.cs
@@ -5,7 +5,7 @@ public enum ChatThreadStatus
     Created,
     Running,
     Suspended,
-    Completed
+    Ended
 }
 
 public enum ChatActivity

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml
@@ -34,7 +34,7 @@
                     </SelectorBar>
 
                     <ToggleSwitch x:Uid="SessionsPage_ShowCompleted" x:Name="ShowCompletedToggle" Grid.Column="1"
-                                  Header="Show completed"
+                                  Header="Show ended"
                                   MinWidth="0"
                                   OnContent="" OffContent=""
                                   Toggled="OnShowCompletedToggled"

--- a/src/OpenClaw.Tray.WinUI/Services/SessionVisibilityFilter.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/SessionVisibilityFilter.cs
@@ -5,30 +5,33 @@ namespace OpenClawTray.Services;
 
 public static class SessionVisibilityFilter
 {
-    public static IEnumerable<SessionInfo> VisibleSessions(IEnumerable<SessionInfo> sessions, bool showCompleted)
-        => showCompleted ? sessions : sessions.Where(IsVisibleWhenCompletedHidden);
+    public static IEnumerable<SessionInfo> VisibleSessions(IEnumerable<SessionInfo> sessions, bool showEnded)
+        => showEnded ? sessions : sessions.Where(IsVisibleWhenEndedHidden);
 
-    public static bool IsVisibleWhenCompletedHidden(SessionInfo session)
-        => !IsCleanCompleted(session);
+    public static bool IsVisibleWhenEndedHidden(SessionInfo session)
+        => !IsEnded(session);
 
-    public static bool IsCleanCompleted(SessionInfo session)
+    public static bool IsEnded(SessionInfo session)
     {
         if (session.AbortedLastRun)
             return false;
 
         var status = session.Status?.Trim();
         return string.Equals(status, "done", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(status, "completed", StringComparison.OrdinalIgnoreCase);
+            || string.Equals(status, "completed", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(status, "failed", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(status, "killed", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(status, "timeout", StringComparison.OrdinalIgnoreCase);
     }
 
     public static ChatThreadStatus ToChatThreadStatus(SessionInfo session)
-        => IsCleanCompleted(session) ? ChatThreadStatus.Completed : ChatThreadStatus.Running;
+        => IsEnded(session) ? ChatThreadStatus.Ended : ChatThreadStatus.Running;
 
     public static IEnumerable<ChatThread> VisibleChatPickerThreads(IEnumerable<ChatThread> threads)
         => threads.Where(IsVisibleInChatPicker);
 
     public static bool IsVisibleInChatPicker(ChatThread thread)
-        => thread.Status != ChatThreadStatus.Completed;
+        => thread.Status != ChatThreadStatus.Ended;
 
     public static string ResolveActiveChannel(string activeChannel, IEnumerable<string> visibleChannels)
     {

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -4729,7 +4729,7 @@ Commands are blocked while sandboxing is unavailable because strict fallback blo
     <value>All</value>
   </data>
   <data name="SessionsPage_ShowCompleted.Header" xml:space="preserve">
-    <value>Show completed</value>
+    <value>Show ended</value>
   </data>
   <data name="SessionsPage_GatewayDisconnected.Title" xml:space="preserve">
     <value>Gateway disconnected</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -4683,7 +4683,7 @@ Opdrachten worden geblokkeerd zolang sandboxing niet beschikbaar is, omdat strik
     <value>Alle</value>
   </data>
   <data name="SessionsPage_ShowCompleted.Header" xml:space="preserve">
-    <value>Voltooide sessies tonen</value>
+    <value>Beëindigde sessies tonen</value>
   </data>
   <data name="SessionsPage_GatewayDisconnected.Title" xml:space="preserve">
     <value>Gateway losgekoppeld</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -4682,7 +4682,7 @@
     <value>全部</value>
   </data>
   <data name="SessionsPage_ShowCompleted.Header" xml:space="preserve">
-    <value>显示已完成的会话</value>
+    <value>显示已结束的会话</value>
   </data>
   <data name="SessionsPage_GatewayDisconnected.Title" xml:space="preserve">
     <value>网关已断开</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -4682,7 +4682,7 @@
     <value>全部</value>
   </data>
   <data name="SessionsPage_ShowCompleted.Header" xml:space="preserve">
-    <value>顯示已完成的工作階段</value>
+    <value>顯示已結束的工作階段</value>
   </data>
   <data name="SessionsPage_GatewayDisconnected.Title" xml:space="preserve">
     <value>閘道已中斷</value>

--- a/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
+++ b/tests/OpenClaw.Tray.Tests/OpenClawChatDataProviderTests.cs
@@ -576,11 +576,12 @@ public class OpenClawChatDataProviderTests
     }
 
     [Fact]
-    public async Task LoadAsync_MapsOnlyCleanCompletedSessionsToCompletedThreads()
+    public async Task LoadAsync_MapsOnlyEndedSessionsToEndedThreads()
     {
         var sessions = new[]
         {
             new SessionInfo { Key = "done", DisplayName = "Done", Status = "done" },
+            new SessionInfo { Key = "killed", DisplayName = "Killed", Status = "killed" },
             new SessionInfo
             {
                 Key = "aborted",
@@ -595,8 +596,11 @@ public class OpenClawChatDataProviderTests
         var snapshot = await provider.LoadAsync();
 
         Assert.Equal(
-            ChatThreadStatus.Completed,
+            ChatThreadStatus.Ended,
             Assert.Single(snapshot.Threads, thread => thread.Id == "done").Status);
+        Assert.Equal(
+            ChatThreadStatus.Ended,
+            Assert.Single(snapshot.Threads, thread => thread.Id == "killed").Status);
         Assert.Equal(
             ChatThreadStatus.Running,
             Assert.Single(snapshot.Threads, thread => thread.Id == "aborted").Status);

--- a/tests/OpenClaw.Tray.Tests/SessionVisibilityFilterTests.cs
+++ b/tests/OpenClaw.Tray.Tests/SessionVisibilityFilterTests.cs
@@ -10,30 +10,30 @@ public class SessionVisibilityFilterTests
     [InlineData("done")]
     [InlineData("DONE")]
     [InlineData(" completed ")]
-    public void IsCleanCompleted_RecognizesSuccessfulCompletedStatuses(string status)
-    {
-        var session = new SessionInfo { Status = status };
-
-        Assert.True(SessionVisibilityFilter.IsCleanCompleted(session));
-        Assert.False(SessionVisibilityFilter.IsVisibleWhenCompletedHidden(session));
-    }
-
-    [Theory]
     [InlineData("failed")]
     [InlineData("killed")]
     [InlineData("timeout")]
-    [InlineData("running")]
-    [InlineData("unknown")]
-    public void IsCleanCompleted_LeavesNonSuccessfulTerminalAndActiveStatusesVisible(string status)
+    public void IsEnded_RecognizesTerminalStatuses(string status)
     {
         var session = new SessionInfo { Status = status };
 
-        Assert.False(SessionVisibilityFilter.IsCleanCompleted(session));
-        Assert.True(SessionVisibilityFilter.IsVisibleWhenCompletedHidden(session));
+        Assert.True(SessionVisibilityFilter.IsEnded(session));
+        Assert.False(SessionVisibilityFilter.IsVisibleWhenEndedHidden(session));
+    }
+
+    [Theory]
+    [InlineData("running")]
+    [InlineData("unknown")]
+    public void IsEnded_LeavesActiveAndUnknownStatusesVisible(string status)
+    {
+        var session = new SessionInfo { Status = status };
+
+        Assert.False(SessionVisibilityFilter.IsEnded(session));
+        Assert.True(SessionVisibilityFilter.IsVisibleWhenEndedHidden(session));
     }
 
     [Fact]
-    public void IsCleanCompleted_KeepsAbortedDoneSessionsVisible()
+    public void IsEnded_KeepsAbortedDoneSessionsVisible()
     {
         var session = new SessionInfo
         {
@@ -41,12 +41,12 @@ public class SessionVisibilityFilterTests
             AbortedLastRun = true,
         };
 
-        Assert.False(SessionVisibilityFilter.IsCleanCompleted(session));
-        Assert.True(SessionVisibilityFilter.IsVisibleWhenCompletedHidden(session));
+        Assert.False(SessionVisibilityFilter.IsEnded(session));
+        Assert.True(SessionVisibilityFilter.IsVisibleWhenEndedHidden(session));
     }
 
     [Fact]
-    public void VisibleSessions_HidesOnlyCleanCompletedSessionsByDefault()
+    public void VisibleSessions_HidesEndedSessionsByDefault()
     {
         var sessions = new[]
         {
@@ -58,15 +58,15 @@ public class SessionVisibilityFilterTests
             new SessionInfo { Key = "running", Status = "running" },
         };
 
-        var visible = SessionVisibilityFilter.VisibleSessions(sessions, showCompleted: false)
+        var visible = SessionVisibilityFilter.VisibleSessions(sessions, showEnded: false)
             .Select(s => s.Key)
             .ToArray();
 
-        Assert.Equal(new[] { "failed", "killed", "timeout", "aborted-done", "running" }, visible);
+        Assert.Equal(new[] { "aborted-done", "running" }, visible);
     }
 
     [Fact]
-    public void VisibleSessions_ShowCompletedPreservesAllSessions()
+    public void VisibleSessions_ShowEndedPreservesAllSessions()
     {
         var sessions = new[]
         {
@@ -74,7 +74,7 @@ public class SessionVisibilityFilterTests
             new SessionInfo { Key = "failed", Status = "failed" },
         };
 
-        var visible = SessionVisibilityFilter.VisibleSessions(sessions, showCompleted: true)
+        var visible = SessionVisibilityFilter.VisibleSessions(sessions, showEnded: true)
             .Select(s => s.Key)
             .ToArray();
 
@@ -82,11 +82,14 @@ public class SessionVisibilityFilterTests
     }
 
     [Theory]
-    [InlineData("done", false, ChatThreadStatus.Completed)]
-    [InlineData("completed", false, ChatThreadStatus.Completed)]
+    [InlineData("done", false, ChatThreadStatus.Ended)]
+    [InlineData("completed", false, ChatThreadStatus.Ended)]
+    [InlineData("failed", false, ChatThreadStatus.Ended)]
+    [InlineData("killed", false, ChatThreadStatus.Ended)]
+    [InlineData("timeout", false, ChatThreadStatus.Ended)]
     [InlineData("done", true, ChatThreadStatus.Running)]
     [InlineData("unknown", false, ChatThreadStatus.Running)]
-    public void ToChatThreadStatus_ReusesCleanCompletionSemantics(
+    public void ToChatThreadStatus_ReusesEndedSemantics(
         string status,
         bool abortedLastRun,
         ChatThreadStatus expected)
@@ -101,12 +104,12 @@ public class SessionVisibilityFilterTests
     }
 
     [Fact]
-    public void VisibleChatPickerThreads_HidesCompletedThreads()
+    public void VisibleChatPickerThreads_HidesEndedThreads()
     {
         var threads = new[]
         {
             new ChatThread { Id = "running", Title = "Running", Status = ChatThreadStatus.Running },
-            new ChatThread { Id = "completed", Title = "Completed", Status = ChatThreadStatus.Completed },
+            new ChatThread { Id = "ended", Title = "Ended", Status = ChatThreadStatus.Ended },
             new ChatThread { Id = "suspended", Title = "Suspended", Status = ChatThreadStatus.Suspended },
         };
 


### PR DESCRIPTION
## What Problem This Solves

The Sessions page toggle said **Show completed**, but the default filter hid only successful `done`/`completed` sessions. Failed, killed, and timed-out sessions remained mixed with active sessions even though they are terminal from a UI perspective.

## Why This Change Was Made

Rename the UI concept to **Show ended** and define ended sessions as `done`, `completed`, `failed`, `killed`, or `timeout`. Unknown, running, suspended, and `AbortedLastRun` sessions remain visible because they may still be valid or need attention. The existing persisted `ShowCompletedSessions` key, XAML names, automation ID, and resource key remain unchanged for compatibility.

## User Impact

With **Show ended** off, both the Sessions page and main Chat picker focus on active, unknown, suspended, or aborted sessions. Turning it on reveals all terminal outcomes.

## Evidence

- Live gateway payload previously contained 37 `done`, 23 `unknown`, and 1 `killed` session.
- Current-head native Sessions page visibly shows the new **Show ended** label.
- Focused tests cover all five terminal statuses, unknown/running visibility, aborted exemption, show-ended pass-through, Chat thread mapping, and picker filtering.
- Independent rubber-duck review: **CLEAN**.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [x] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [ ] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `./build.ps1` — passed; all five projects built.
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` — 2,901 passed, 31 skipped, 0 failed.
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` — 1,823 passed, 0 failed.
- Focused status/provider/localization selector — 39 passed, 0 failed.
- `git diff --check` — passed.

## Real Behavior Proof

- Environment tested: Windows 11, real existing gateway/user data, release/default identity.
- PR head or commit tested: `15c7b0a1`.
- Exact steps: launched `run-app-local.ps1 -NoBuild -AllowNonMain`, navigated to Sessions through local MCP, and inspected the native accessibility tree.
- Evidence after fix: toggle label is **Show ended**; tests confirm ended rows hide by default while unknown and aborted rows remain.
- Observed result: UI terminology and filtering now match the terminal lifecycle model.
- Screenshot or artifact links verified? `N/A`; copied native UI diagnostics above.
- Not verified or blocked: none.

## Security Impact

- New permissions or capabilities? `No`
- Secrets or tokens handling changed? `No`
- New or changed network calls? `No`
- Command or tool execution surface changed? `No`
- Data access scope changed? `No`

## Compatibility and Migration

- Backward compatible? `Yes`
- Config or environment changes? `No`; persisted setting key retained.
- Migration needed? `No`

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.