### PR TITLE
fix: wizard shutdown no longer reports a timeout

### DIFF
--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -621,22 +621,17 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         try
         {
             await SendRawAsync(SerializeRequest(requestId, method, parameters));
+            return await completion.Task.WaitAsync(TimeSpan.FromMilliseconds(timeoutMs), CancellationToken);
         }
-        catch
+        catch (TimeoutException ex)
+        {
+            throw new TimeoutException($"Timed out waiting for {method} response", ex);
+        }
+        finally
         {
             _pendingWizardResponses.TryRemove(requestId, out _);
             RemovePendingRequest(requestId);
-            throw;
         }
-
-        var completedTask = await Task.WhenAny(completion.Task, Task.Delay(timeoutMs, CancellationToken));
-        if (completedTask != completion.Task)
-        {
-            _pendingWizardResponses.TryRemove(requestId, out _);
-            throw new TimeoutException($"Timed out waiting for {method} response");
-        }
-
-        return await completion.Task;
     }
 
     /// <summary>Request session list from gateway.</summary>

--- a/tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj
+++ b/tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenClaw.Shared\OpenClaw.Shared.csproj" />
+    <ProjectReference Include="..\OpenClaw.TestSupport\OpenClaw.TestSupport.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -535,9 +535,11 @@ public class OpenClawGatewayClientTests
             }));
 
         var payload = await responseTask.WaitAsync(TimeSpan.FromSeconds(2));
-        client.Dispose();
 
         Assert.Equal("welcome", payload.GetProperty("stepId").GetString());
+        Assert.Equal((0, 0), helper.GetPendingRequestCounts());
+
+        client.Dispose();
         Assert.Equal((0, 0), helper.GetPendingRequestCounts());
     }
 
@@ -588,7 +590,55 @@ public class OpenClawGatewayClientTests
         var responseTask = client.SendWizardRequestAsync("wizard.status", timeoutMs: 250);
         await server.ReceiveTextAsync().WaitAsync(TimeSpan.FromSeconds(2));
 
-        await Assert.ThrowsAsync<TimeoutException>(async () => await responseTask);
+        var exception = await Assert.ThrowsAsync<TimeoutException>(async () => await responseTask);
+
+        Assert.Equal("Timed out waiting for wizard.status response", exception.Message);
+        Assert.Equal((0, 0), helper.GetPendingRequestCounts());
+    }
+
+    [Fact]
+    public async Task SendWizardRequestAsync_LateResponseAfterTimeout_DoesNotChangeOutcomeOrTracking()
+    {
+        using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("wizard-request-");
+        await server.StartAsync();
+        var helper = new GatewayClientTestHelper(
+            gatewayUrl: server.WebSocketUrl,
+            identityPath: identity.Path);
+        using var client = helper.Client;
+        await client.ConnectAsync();
+
+        var timedOutTask = client.SendWizardRequestAsync("wizard.status", timeoutMs: 250);
+        var timedOutRequest = await server.ReceiveTextAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        var timedOutRequestId = ReadRequestId(timedOutRequest);
+        var firstTimeout = await Assert.ThrowsAsync<TimeoutException>(async () => await timedOutTask);
+
+        await server.SendTextAsync(
+            JsonSerializer.Serialize(new
+            {
+                type = "res",
+                id = timedOutRequestId,
+                ok = true,
+                payload = new { stepId = "too-late" }
+            }));
+
+        var probeTask = client.SendWizardRequestAsync("wizard.status", timeoutMs: 10_000);
+        var probeRequest = await server.ReceiveTextAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        var probeRequestId = ReadRequestId(probeRequest);
+        await server.SendTextAsync(
+            JsonSerializer.Serialize(new
+            {
+                type = "res",
+                id = probeRequestId,
+                ok = true,
+                payload = new { stepId = "probe" }
+            }));
+
+        var probePayload = await probeTask.WaitAsync(TimeSpan.FromSeconds(2));
+        var repeatedTimeout = await Assert.ThrowsAsync<TimeoutException>(async () => await timedOutTask);
+
+        Assert.Equal("probe", probePayload.GetProperty("stepId").GetString());
+        Assert.Same(firstTimeout, repeatedTimeout);
         Assert.Equal((0, 0), helper.GetPendingRequestCounts());
     }
 

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.Json;
 using Xunit;
 using OpenClaw.Shared;
+using OpenClaw.TestSupport;
 
 namespace OpenClaw.Shared.Tests;
 
@@ -487,10 +488,138 @@ public class OpenClawGatewayClientTests
             _client.AuthenticationFailed += (_, msg) => events.Add(msg);
             return events;
         }
+
+        public (int WizardResponses, int RequestMethods) GetPendingRequestCounts()
+        {
+            var wizardField = typeof(OpenClawGatewayClient).GetField(
+                "_pendingWizardResponses",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var wizardResponses =
+                (System.Collections.Concurrent.ConcurrentDictionary<string, TaskCompletionSource<JsonElement>>)wizardField!.GetValue(_client)!;
+
+            var methodsField = typeof(OpenClawGatewayClient).GetField(
+                "_pendingRequestMethods",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var requestMethods = (Dictionary<string, string>)methodsField!.GetValue(_client)!;
+
+            return (wizardResponses.Count, requestMethods.Count);
+        }
     }
 
     private static string CreateTempIdentityPath() =>
         Path.Combine(Path.GetTempPath(), "OpenClawGatewayClientTests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task SendWizardRequestAsync_ResponseBeforeDispose_ReturnsPayloadAndCleansTracking()
+    {
+        using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("wizard-request-");
+        await server.StartAsync();
+        var helper = new GatewayClientTestHelper(
+            gatewayUrl: server.WebSocketUrl,
+            identityPath: identity.Path);
+        using var client = helper.Client;
+        await client.ConnectAsync();
+
+        var responseTask = client.SendWizardRequestAsync("wizard.start", timeoutMs: 10_000);
+        var request = await server.ReceiveTextAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        var requestId = ReadRequestId(request);
+
+        await server.SendTextAsync(
+            JsonSerializer.Serialize(new
+            {
+                type = "res",
+                id = requestId,
+                ok = true,
+                payload = new { stepId = "welcome" }
+            }));
+
+        var payload = await responseTask.WaitAsync(TimeSpan.FromSeconds(2));
+        client.Dispose();
+
+        Assert.Equal("welcome", payload.GetProperty("stepId").GetString());
+        Assert.Equal((0, 0), helper.GetPendingRequestCounts());
+    }
+
+    [Fact]
+    public async Task SendWizardRequestAsync_GatewayError_PropagatesUnchangedAndCleansTracking()
+    {
+        using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("wizard-request-");
+        await server.StartAsync();
+        var helper = new GatewayClientTestHelper(
+            gatewayUrl: server.WebSocketUrl,
+            identityPath: identity.Path);
+        using var client = helper.Client;
+        await client.ConnectAsync();
+
+        var responseTask = client.SendWizardRequestAsync("wizard.next", timeoutMs: 10_000);
+        var request = await server.ReceiveTextAsync().WaitAsync(TimeSpan.FromSeconds(2));
+        var requestId = ReadRequestId(request);
+
+        await server.SendTextAsync(
+            JsonSerializer.Serialize(new
+            {
+                type = "res",
+                id = requestId,
+                ok = false,
+                error = new { message = "wizard rejected" }
+            }));
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await responseTask.WaitAsync(TimeSpan.FromSeconds(2)));
+
+        Assert.Equal("wizard rejected", exception.Message);
+        Assert.Equal((0, 0), helper.GetPendingRequestCounts());
+    }
+
+    [Fact]
+    public async Task SendWizardRequestAsync_DeadlineExpires_ThrowsTimeoutAndCleansTracking()
+    {
+        using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("wizard-request-");
+        await server.StartAsync();
+        var helper = new GatewayClientTestHelper(
+            gatewayUrl: server.WebSocketUrl,
+            identityPath: identity.Path);
+        using var client = helper.Client;
+        await client.ConnectAsync();
+
+        var responseTask = client.SendWizardRequestAsync("wizard.status", timeoutMs: 250);
+        await server.ReceiveTextAsync().WaitAsync(TimeSpan.FromSeconds(2));
+
+        await Assert.ThrowsAsync<TimeoutException>(async () => await responseTask);
+        Assert.Equal((0, 0), helper.GetPendingRequestCounts());
+    }
+
+    [Fact]
+    public async Task SendWizardRequestAsync_DisposeBeforeResponse_ThrowsCancellationAndCleansTracking()
+    {
+        using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("wizard-request-");
+        await server.StartAsync();
+        var helper = new GatewayClientTestHelper(
+            gatewayUrl: server.WebSocketUrl,
+            identityPath: identity.Path);
+        using var client = helper.Client;
+        await client.ConnectAsync();
+
+        var responseTask = client.SendWizardRequestAsync("wizard.cancel", timeoutMs: 10_000);
+        await server.ReceiveTextAsync().WaitAsync(TimeSpan.FromSeconds(2));
+
+        client.Dispose();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await responseTask.WaitAsync(TimeSpan.FromSeconds(2)));
+        Assert.Equal((0, 0), helper.GetPendingRequestCounts());
+    }
+
+    private static string ReadRequestId(string request)
+    {
+        using var document = JsonDocument.Parse(request);
+        return document.RootElement.GetProperty("id").GetString()
+            ?? throw new InvalidOperationException("Gateway request did not include an id.");
+    }
 
     [Fact]
     public void ExtractChatTimestampMs_FallsBackFromInvalidTimestampToTs()

--- a/tests/OpenClaw.Shared.Tests/WebSocketClientBaseTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WebSocketClientBaseTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.WebSockets;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -522,6 +523,8 @@ internal sealed class LoopbackWebSocketServer : IDisposable
     private readonly HttpListener _listener = new();
     private readonly CancellationTokenSource _cts = new();
     private readonly List<WebSocket> _acceptedSockets = new();
+    private readonly TaskCompletionSource<WebSocket> _firstAcceptedSocket =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
     private Task? _acceptLoop;
 
     public string WebSocketUrl { get; }
@@ -581,7 +584,29 @@ internal sealed class LoopbackWebSocketServer : IDisposable
             {
                 _acceptedSockets.Add(wsContext.WebSocket);
             }
+            _firstAcceptedSocket.TrySetResult(wsContext.WebSocket);
         }
+    }
+
+    public async Task<string> ReceiveTextAsync(CancellationToken cancellationToken = default)
+    {
+        var socket = await _firstAcceptedSocket.Task.WaitAsync(cancellationToken);
+        var buffer = new byte[64 * 1024];
+        var result = await socket.ReceiveAsync(buffer, cancellationToken);
+        if (result.MessageType != WebSocketMessageType.Text || !result.EndOfMessage)
+            throw new InvalidOperationException("Expected one complete WebSocket text message.");
+
+        return Encoding.UTF8.GetString(buffer, 0, result.Count);
+    }
+
+    public async Task SendTextAsync(string message, CancellationToken cancellationToken = default)
+    {
+        var socket = await _firstAcceptedSocket.Task.WaitAsync(cancellationToken);
+        await socket.SendAsync(
+            Encoding.UTF8.GetBytes(message),
+            WebSocketMessageType.Text,
+            endOfMessage: true,
+            cancellationToken);
     }
 
     public async Task CloseSocketAsync(int index)


### PR DESCRIPTION
Related: #1010

## What Problem This Solves

Fixes an issue where users running the gateway setup wizard could see a timeout when the client was actually shutting down or being disposed.

## Why This Change Was Made

The wizard request wait now uses the framework timeout-and-cancellation primitive so deadline expiry and client-lifetime cancellation remain distinct. Request completion and method tracking are cleaned in one terminal `finally` path without changing gateway response or error propagation.

## User Impact

Wizard shutdown and connection teardown now report cancellation rather than a misleading timeout. Real gateway deadlines still report `TimeoutException`.

## Evidence

Five loopback WebSocket behavioral tests exercise real request serialization, transport response handling, timeout, disposal ordering, and a late response after timeout. They prove response payloads and gateway errors propagate unchanged, timeout remains a timeout with the compatible message, disposal surfaces `OperationCanceledException`, late responses cannot replace a completed timeout, and both pending trackers are empty on every terminal path.

Rubber-duck closeout: clean; no blocking or non-blocking findings.

Structured autoreview was attempted with Codex (`gpt-5.6-sol`, high) and Claude. It was blocked before review by local reviewer tooling: Codex 0.137.0 refused helper binaries in the isolated temporary runtime, and Claude Code 2.1.156 is older than the helper's required 2.1.169 safe-mode version. No autoreview findings were produced.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [x] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `./build.ps1` - passed; 5/5 projects built
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` - passed; 2,906 passed, 31 skipped, 0 failed
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` - passed; 1,823 passed, 0 skipped, 0 failed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore --filter "FullyQualifiedName~OpenClawGatewayClientTests.SendWizardRequestAsync" --logger "console;verbosity=normal"` - passed; 5 passed, 0 failed

## Real Behavior Proof

- Environment tested: Windows 11, .NET SDK 10.0.302, in-process loopback WebSocket server
- PR head or commit tested: `1558aaaa`
- Exact steps or command run: focused `OpenClawGatewayClientTests.SendWizardRequestAsync*` filter above
- Evidence after fix: response-before-dispose returned the exact payload and observed both trackers empty before disposal; gateway `ok:false` preserved `InvalidOperationException("wizard rejected")`; a 250 ms unfulfilled request threw `TimeoutException("Timed out waiting for wizard.status response")`; dispose-before-response threw `OperationCanceledException`; a late response after timeout was processed ahead of a successful probe response but left the original task on the same timeout exception and both trackers empty
- Observed result: terminal classification, timeout compatibility, late-response ordering, and cleanup match the contract on the real WebSocket request/response path
- Screenshot or artifact links verified? (`Yes`/`No`/`N/A`): N/A
- Not verified or blocked: No live external gateway was used; protocol behavior is covered by the repository loopback WebSocket transport. Structured autoreview blocked as described above.

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No
- Secrets or tokens handling changed? (`Yes`/`No`): No
- New or changed network calls? (`Yes`/`No`): No
- Command or tool execution surface changed? (`Yes`/`No`): No
- Data access scope changed? (`Yes`/`No`): No
- If any answer is `Yes`, explain the risk and mitigation: N/A

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes
- Config or environment changes? (`Yes`/`No`): No
- Migration needed? (`Yes`/`No`): No
- If yes, list the exact upgrade steps: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.