### PR TITLE
test+doc: harden ForwardIfCurrent dispatch-under-lock invariant (#1010)

### DIFF
--- a/src/OpenClaw.Connection/NodeConnector.cs
+++ b/src/OpenClaw.Connection/NodeConnector.cs
@@ -221,6 +221,17 @@ public sealed class NodeConnector : INodeConnector, INodeConnectorTelemetryEvent
     // Validation and dispatch stay atomic so a retired client cannot publish after its
     // replacement. Subscribers must remain synchronous and must not block on connector
     // lifecycle work while this lock is held.
+    //
+    // Lock ordering: _connectSemaphore (async, serialises connect/disconnect) may be
+    // held when _clientLifecycleLock is acquired, but subscribers never acquire
+    // _connectSemaphore. Among monitor locks, _clientLifecycleLock is the outermost
+    // in the connector's acquisition graph. Subscribers may acquire their own locks
+    // (GatewayConnectionManager._telemetryLock, GatewayRegistry._lock,
+    // ConnectionDiagnostics._lock) but code holding those locks must not
+    // synchronously enter connector lifecycle operations, preserving a consistent
+    // acquisition order that prevents deadlock. Subscriber handlers must return
+    // promptly; current subscribers use fire-and-forget async dispatch for heavy
+    // work and perform only lightweight synchronous preambles.
     private void ForwardIfCurrent<T>(
         object? sender,
         long generation,

--- a/tests/OpenClaw.Connection.Tests/NodeConnectorTests.cs
+++ b/tests/OpenClaw.Connection.Tests/NodeConnectorTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using OpenClaw.Shared;
 using OpenClaw.Connection;
 
@@ -135,5 +136,106 @@ public class NodeConnectorTests
         var connector = new NodeConnector(new StubLogger());
         connector.Dispose();
         connector.Dispose(); // second call should not throw
+    }
+
+    [Fact]
+    public async Task Reconnect_SuppressesStatusFromRetiredClient()
+    {
+        using var connector = new NodeConnector(new StubLogger());
+        var statuses = new List<ConnectionStatus>();
+        connector.StatusChanged += (_, status) => statuses.Add(status);
+
+        await connector.ConnectAsync(
+            "ws://127.0.0.1:1",
+            new GatewayCredential("tok", false, "test"),
+            "id-path");
+        var clientA = connector.Client;
+        Assert.NotNull(clientA);
+
+        await connector.ConnectAsync(
+            "ws://127.0.0.1:2",
+            new GatewayCredential("tok2", false, "test"),
+            "id-path");
+        var clientB = connector.Client;
+        Assert.NotNull(clientB);
+        Assert.NotSame(clientA, clientB);
+        statuses.Clear();
+
+        // Retired client A — generation mismatch, must be suppressed.
+        RaiseClientStatus(clientA, ConnectionStatus.Connected);
+        Assert.Empty(statuses);
+
+        // Current client B — generation matches, must be forwarded.
+        RaiseClientStatus(clientB, ConnectionStatus.Connected);
+        Assert.Single(statuses);
+        Assert.Equal(ConnectionStatus.Connected, statuses[0]);
+    }
+
+    [Fact]
+    public async Task Disconnect_RetiresClient_SuppressesForwarding()
+    {
+        using var connector = new NodeConnector(new StubLogger());
+
+        await connector.ConnectAsync(
+            "ws://127.0.0.1:1",
+            new GatewayCredential("tok", false, "test"),
+            "id-path");
+        var retiredClient = connector.Client;
+        Assert.NotNull(retiredClient);
+
+        await connector.DisconnectAsync();
+
+        var forwardedConnected = false;
+        connector.StatusChanged += (_, status) =>
+            forwardedConnected |= status == ConnectionStatus.Connected;
+        RaiseClientStatus(retiredClient, ConnectionStatus.Connected);
+
+        Assert.Null(connector.Client);
+        Assert.Equal(NodeConnectionMode.Disabled, connector.Mode);
+        Assert.False(forwardedConnected);
+    }
+
+    [Fact]
+    public async Task CurrentClientStatusHandler_CanReadConnectorProperties_WithoutBlocking()
+    {
+        using var connector = new NodeConnector(new StubLogger());
+        bool? wasConnected = null;
+        PairingStatus? pairingStatus = null;
+        NodeConnectionMode? mode = null;
+        WindowsNodeClient? clientRef = null;
+
+        await connector.ConnectAsync(
+            "ws://127.0.0.1:1",
+            new GatewayCredential("tok", false, "test"),
+            "id-path");
+        var currentClient = connector.Client;
+        Assert.NotNull(currentClient);
+
+        connector.StatusChanged += (_, status) =>
+        {
+            if (status != ConnectionStatus.Connecting)
+                return;
+
+            wasConnected = connector.IsConnected;
+            pairingStatus = connector.PairingStatus;
+            mode = connector.Mode;
+            clientRef = connector.Client;
+        };
+
+        RaiseClientStatus(currentClient, ConnectionStatus.Connecting);
+
+        Assert.False(wasConnected);
+        Assert.Equal(PairingStatus.Unknown, pairingStatus);
+        Assert.Equal(NodeConnectionMode.Gateway, mode);
+        Assert.Same(currentClient, clientRef);
+    }
+
+    private static void RaiseClientStatus(WindowsNodeClient client, ConnectionStatus status)
+    {
+        var method = typeof(WebSocketClientBase).GetMethod(
+            "RaiseStatusChanged",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method.Invoke(client, [status]);
     }
 }


### PR DESCRIPTION
## Summary

Tests and documentation hardening for the `NodeConnector.ForwardIfCurrent` dispatch-under-lock invariant (issue #1010 hazard 2). **No production code behavior is changed.**

After thorough investigation of all lock ordering paths, subscriber behavior, and reentrancy scenarios, the conclusion is that `ForwardIfCurrent`'s current design is correct: it holds `_clientLifecycleLock` during validation+dispatch to prevent a TOCTOU race where a retired client could publish events after replacement. All subscribers are fast (µs synchronous preambles with fire-and-forget async dispatch), lock ordering is consistent with no reverse acquisitions, and no deadlock or reentrancy corruption is possible.

## Changes

### Tests (`NodeConnectorTests.cs`)

Three tests exercise the real `ForwardIfCurrent` event path using a reflection helper that invokes `WebSocketClientBase.RaiseStatusChanged` on captured `WindowsNodeClient` instances:

- **`Reconnect_SuppressesStatusFromRetiredClient`** — After reconnect, fires `StatusChanged` on retired client A → suppressed (generation mismatch). Then fires on current client B → forwarded. Proves both the negative and positive contract.
- **`Disconnect_RetiresClient_SuppressesForwarding`** — After disconnect, fires `StatusChanged` on the retired client → suppressed (generation mismatch + null `_client`).
- **`CurrentClientStatusHandler_CanReadConnectorProperties_WithoutBlocking`** — Fires `StatusChanged` on the current client through `ForwardIfCurrent`. Subscriber reads `IsConnected`, `PairingStatus`, `Mode`, `Client` and asserts exact values — proving no blocking and consistent state.

### Documentation (`NodeConnector.cs`)

Enhanced the `ForwardIfCurrent` comment to document:
- The atomicity invariant: validation+dispatch stay atomic under lock
- Lock ordering: `_connectSemaphore` (async) → `_clientLifecycleLock` (monitor, outermost among monitors) → subscriber-owned locks
- Subscriber contract: handlers must return promptly; current subscribers use fire-and-forget async dispatch

## Validation

| Suite | Result |
|---|---|
| `build.ps1` | ✅ All 5 projects |
| Connection.Tests (focused) | ✅ 14 passed |
| Shared.Tests | ✅ 2901 passed, 31 skipped |
| Tray.Tests | ✅ 1823 passed |

### Baseline disposition
`ReadmeValidationTests` failures are a pre-existing worktree environment issue (`OPENCLAW_REPO_ROOT` not set), not caused by this diff. Tests pass with `OPENCLAW_REPO_ROOT` set.

## Review

Rubber-duck review identified and addressed:
1. ✅ Lock ordering comment imprecision — fixed: documents `_connectSemaphore → _clientLifecycleLock` ordering
2. ✅ Reconnect test missing positive assertion — fixed: now fires on both retired A (suppressed) and current B (forwarded)
3. ⏭️ Concurrent lock-holding proof — deferred: would require fragile timing-dependent test; current tests prove the behavioral contract
4. ⏭️ Non-generic `EventHandler` overload coverage — follow-up: same `ForwardIfCurrent` logic, low risk

Ref: #1010