### PR TITLE
fix: avoid disconnect warnings during active WebSocket sends

### DIFF
--- a/src/OpenClaw.Shared/WebSocketClientBase.cs
+++ b/src/OpenClaw.Shared/WebSocketClientBase.cs
@@ -474,11 +474,26 @@ public abstract class WebSocketClientBase : IDisposable
         if (ws?.State != WebSocketState.Open)
             return;
 
-        await _sendLock.WaitAsync(_cts.Token);
+        try
+        {
+            await _sendLock.WaitAsync(_cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown canceled the wait; no close ownership was acquired.
+            return;
+        }
+        catch (ObjectDisposedException)
+        {
+            // Send lock or lifetime token was disposed during shutdown.
+            return;
+        }
+
         try
         {
             if (ws.State == WebSocketState.Open)
             {
+                // Preserve normal graceful close; concurrent Dispose aborts the socket and callers contain that failure.
                 await ws.CloseAsync(
                     WebSocketCloseStatus.NormalClosure,
                     "Disconnecting",

--- a/src/OpenClaw.Shared/WebSocketClientBase.cs
+++ b/src/OpenClaw.Shared/WebSocketClientBase.cs
@@ -471,9 +471,23 @@ public abstract class WebSocketClientBase : IDisposable
     protected async Task CloseWebSocketAsync()
     {
         var ws = _webSocket;
-        if (ws?.State == WebSocketState.Open)
+        if (ws?.State != WebSocketState.Open)
+            return;
+
+        await _sendLock.WaitAsync(_cts.Token);
+        try
         {
-            await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "Disconnecting", System.Threading.CancellationToken.None);
+            if (ws.State == WebSocketState.Open)
+            {
+                await ws.CloseAsync(
+                    WebSocketCloseStatus.NormalClosure,
+                    "Disconnecting",
+                    CancellationToken.None);
+            }
+        }
+        finally
+        {
+            _sendLock.Release();
         }
     }
 

--- a/tests/OpenClaw.Shared.Tests/WebSocketCloseSerializationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WebSocketCloseSerializationTests.cs
@@ -47,7 +47,7 @@ public sealed class WebSocketCloseSerializationTests
     }
 
     [Fact]
-    public async Task CloseWebSocketAsync_DisposeCancelsWaitBehindInFlightSend()
+    public async Task CloseWebSocketAsync_DisposeCompletesQueuedCloseWithoutException()
     {
         using var server = new LoopbackWebSocketServer();
         await server.StartAsync();
@@ -68,7 +68,8 @@ public sealed class WebSocketCloseSerializationTests
             client.Dispose();
 
             await sendTask.WaitAsync(TimeSpan.FromSeconds(2));
-            await WaitForCloseCompletionAsync(closeTask);
+            await closeTask.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.True(closeTask.IsCompletedSuccessfully);
         }
         finally
         {
@@ -97,14 +98,6 @@ public sealed class WebSocketCloseSerializationTests
                 CancellationToken.None);
             return receivedText;
         }
-    }
-
-    private static async Task WaitForCloseCompletionAsync(Task closeTask)
-    {
-        var closeCompletion = await Task.WhenAny(closeTask, Task.Delay(TimeSpan.FromSeconds(2)));
-        Assert.Same(closeTask, closeCompletion);
-        if (closeTask.IsFaulted)
-            Assert.IsAssignableFrom<OperationCanceledException>(closeTask.Exception!.GetBaseException());
     }
 
     private static SemaphoreSlim GetSendLock(WebSocketClientBase client) =>

--- a/tests/OpenClaw.Shared.Tests/WebSocketCloseSerializationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/WebSocketCloseSerializationTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Net.WebSockets;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+[Collection("WebSocketClientBase")]
+public sealed class WebSocketCloseSerializationTests
+{
+    [Fact]
+    public async Task CloseWebSocketAsync_WaitsForInFlightSend()
+    {
+        using var server = new LoopbackWebSocketServer();
+        await server.StartAsync();
+        using var client = new CloseRaceTestClient(server.WebSocketUrl);
+
+        await client.ConnectAsync();
+        await WaitForConditionAsync(() => server.AcceptedCount == 1, TimeSpan.FromSeconds(2));
+
+        var sendLock = GetSendLock(client);
+        await sendLock.WaitAsync();
+        var lockHeld = true;
+        try
+        {
+            var serverTask = ReceiveUntilCloseAndAcknowledgeAsync(GetAcceptedSocket(server));
+            var sendTask = client.SendAsync("payload");
+            Assert.False(sendTask.IsCompleted);
+
+            var closeTask = client.CloseAsync();
+            var prematureClose = await Task.WhenAny(closeTask, Task.Delay(TimeSpan.FromMilliseconds(200)));
+            Assert.NotSame(closeTask, prematureClose);
+
+            sendLock.Release();
+            lockHeld = false;
+            await Task.WhenAll(sendTask, closeTask, serverTask).WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.True(await serverTask);
+        }
+        finally
+        {
+            if (lockHeld)
+                sendLock.Release();
+        }
+    }
+
+    [Fact]
+    public async Task CloseWebSocketAsync_DisposeCancelsWaitBehindInFlightSend()
+    {
+        using var server = new LoopbackWebSocketServer();
+        await server.StartAsync();
+        using var client = new CloseRaceTestClient(server.WebSocketUrl);
+
+        await client.ConnectAsync();
+        await WaitForConditionAsync(() => server.AcceptedCount == 1, TimeSpan.FromSeconds(2));
+
+        var sendLock = GetSendLock(client);
+        await sendLock.WaitAsync();
+        try
+        {
+            var sendTask = client.SendAsync("payload");
+            Assert.False(sendTask.IsCompleted);
+            var closeTask = client.CloseAsync();
+            Assert.False(closeTask.IsCompleted);
+
+            client.Dispose();
+
+            await sendTask.WaitAsync(TimeSpan.FromSeconds(2));
+            await WaitForCloseCompletionAsync(closeTask);
+        }
+        finally
+        {
+            sendLock.Release();
+        }
+    }
+
+    private static async Task<bool> ReceiveUntilCloseAndAcknowledgeAsync(WebSocket socket)
+    {
+        var buffer = new byte[8192];
+        var receivedText = false;
+        while (true)
+        {
+            var result = await socket.ReceiveAsync(
+                new ArraySegment<byte>(buffer),
+                CancellationToken.None);
+            if (result.MessageType != WebSocketMessageType.Close)
+            {
+                receivedText |= result.MessageType == WebSocketMessageType.Text;
+                continue;
+            }
+
+            await socket.CloseOutputAsync(
+                WebSocketCloseStatus.NormalClosure,
+                "test close",
+                CancellationToken.None);
+            return receivedText;
+        }
+    }
+
+    private static async Task WaitForCloseCompletionAsync(Task closeTask)
+    {
+        var closeCompletion = await Task.WhenAny(closeTask, Task.Delay(TimeSpan.FromSeconds(2)));
+        Assert.Same(closeTask, closeCompletion);
+        if (closeTask.IsFaulted)
+            Assert.IsAssignableFrom<OperationCanceledException>(closeTask.Exception!.GetBaseException());
+    }
+
+    private static SemaphoreSlim GetSendLock(WebSocketClientBase client) =>
+        (SemaphoreSlim)typeof(WebSocketClientBase)
+            .GetField("_sendLock", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(client)!;
+
+    private static WebSocket GetAcceptedSocket(LoopbackWebSocketServer server)
+    {
+        var sockets = (List<WebSocket>)typeof(LoopbackWebSocketServer)
+            .GetField("_acceptedSockets", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(server)!;
+        lock (sockets)
+        {
+            return sockets[0];
+        }
+    }
+
+    private static async Task WaitForConditionAsync(Func<bool> predicate, TimeSpan timeout)
+    {
+        var start = DateTime.UtcNow;
+        while (!predicate())
+        {
+            if (DateTime.UtcNow - start > timeout)
+                throw new TimeoutException("Condition was not met before the timeout.");
+
+            await Task.Delay(25);
+        }
+    }
+
+    private sealed class CloseRaceTestClient : WebSocketClientBase
+    {
+        public CloseRaceTestClient(string gatewayUrl)
+            : base(gatewayUrl, "test-value")
+        {
+        }
+
+        protected override int ReceiveBufferSize => 8192;
+        protected override string ClientRole => "close-race-test";
+        protected override bool ShouldAutoReconnect() => false;
+        protected override Task ProcessMessageAsync(string json) => Task.CompletedTask;
+
+        public Task SendAsync(string message) => SendRawAsync(message);
+        public Task CloseAsync() => CloseWebSocketAsync();
+    }
+}


### PR DESCRIPTION
Related: #1010

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users disconnecting a gateway, or a node refreshing its connection after pairing approval, could see a spurious shutdown warning when graceful WebSocket close raced an active send or when disposal canceled a close queued behind that send.

## Why This Change Was Made

Graceful close now uses the existing send semaphore, captures the intended socket before waiting, and rechecks that socket's state after entering the critical section. Acquisition mirrors `SendRawAsync`: lifetime cancellation or disposal returns quietly before lock ownership, while the release `finally` is reachable only after a successful acquire.

The actual `CloseAsync` retains `CancellationToken.None` to preserve the existing graceful handshake during normal disconnect. Concurrent disposal still bounds an in-progress close by disposing the captured socket; any resulting mid-close failure remains on the pre-existing caller-contained path rather than broadening this PR into close-operation error policy.

## User Impact

Gateway disconnect and pairing-refresh shutdown can now finish without `ClientWebSocket` rejecting a close that overlaps an active send, and routine disposal no longer turns a queued close-lock wait into a warning/error. No protocol, configuration, or public API changes.

## Evidence

- A deterministic loopback test holds the real send critical section, queues `SendRawAsync`, starts graceful close, and proves the close cannot overtake the send. The server must observe a text frame before the close frame.
- A second test disposes the client while send and close are queued, then requires both tasks to complete within two seconds and the close task to be `IsCompletedSuccessfully`.
- Red/green cancellation proof: without the acquire guard, `CloseWebSocketAsync_DisposeCompletesQueuedCloseWithoutException` fails with `OperationCanceledException` from `SemaphoreSlim.WaitAsync`; with the guard, both focused tests pass.
- Follow-up rubber-duck review found no blocking issue; its comment-accuracy suggestion was addressed. Final read-only code review found no significant issue.
- Structured autoreview bundle generation succeeded, but Codex CLI 0.137 produced no review result because its PATH hardening rejects the helper's isolated temporary `CODEX_HOME`; this is recorded as a tooling blocker rather than a clean autoreview claim.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

- `.\build.ps1` — passed; 5/5 projects built.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --filter "FullyQualifiedName~WebSocketCloseSerializationTests" --no-restore --logger "console;verbosity=minimal"` — passed 2, failed 0, skipped 0.
- `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore --logger "console;verbosity=minimal"` — passed 2,903, failed 0, skipped 31.
- `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore --logger "console;verbosity=minimal"` — passed 1,823, failed 0, skipped 0.
- `git diff --check` — passed.

## Real Behavior Proof

- Environment tested: Windows 11, .NET SDK 10.0.302, loopback `HttpListener`/`WebSocket` transport.
- PR head or commit tested: `5059a920abf34bfaa7c29b944d69606f391f3b38`.
- Exact steps or command run: focused `WebSocketCloseSerializationTests` command listed above.
- Evidence after fix: 2/2 focused tests pass; the live loopback server observes the queued text frame before acknowledging graceful close, and disposal completes both queued operations successfully within the bounded timeout.
- Observed result: close no longer overtakes an in-flight send; canceled/disposed semaphore acquisition returns quietly without deadlock, warning-shaped exception, or double-release.
- Screenshot or artifact links verified? (`Yes`/`No`/`N/A`): N/A.
- Not verified or blocked: Codex autoreview blocked by Codex CLI 0.137 rejecting autoreview's isolated temporary `CODEX_HOME`; no UI, MCP, or gateway runtime proof is applicable to this transport-level race.

## Security Impact

- New permissions or capabilities? (`Yes`/`No`): No.
- Secrets or tokens handling changed? (`Yes`/`No`): No.
- New or changed network calls? (`Yes`/`No`): No.
- Command or tool execution surface changed? (`Yes`/`No`): No.
- Data access scope changed? (`Yes`/`No`): No.
- If any answer is `Yes`, explain the risk and mitigation: N/A.

## Compatibility and Migration

- Backward compatible? (`Yes`/`No`): Yes.
- Config or environment changes? (`Yes`/`No`): No.
- Migration needed? (`Yes`/`No`): No.
- If yes, list the exact upgrade steps: N/A.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation addressed by this PR.
- [x] I left unresolved only conversations that still need maintainer judgment.