### PR TITLE
fix: report gateway shutdown as a cancellation instead of chat/approval timeouts

### DIFF
--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -368,6 +368,8 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         if (completedTask != completion.Task)
         {
             RemovePendingChatSend(requestId);
+            // A cancelled delay is client shutdown, not an elapsed gateway timeout.
+            CancellationToken.ThrowIfCancellationRequested();
             throw new TimeoutException("Timed out waiting for chat.send response from gateway");
         }
 
@@ -503,6 +505,8 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         {
             _pendingApprovalResolves.TryRemove(requestId, out _);
             RemovePendingRequest(requestId);
+            // A cancelled delay is client shutdown, not an elapsed gateway timeout.
+            CancellationToken.ThrowIfCancellationRequested();
             throw new TimeoutException("Timed out waiting for exec.approval.resolve response from gateway");
         }
 

--- a/tests/OpenClaw.Shared.Tests/GatewayRequestShutdownClassificationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/GatewayRequestShutdownClassificationTests.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Net.WebSockets;
 using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using OpenClaw.TestSupport;
 using Xunit;
 
 namespace OpenClaw.Shared.Tests;
@@ -24,8 +24,9 @@ public sealed class GatewayRequestShutdownClassificationTests
     public async Task SendChatMessage_ShutdownDuringWait_SurfacesCancellationNotTimeout()
     {
         using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("gateway-shutdown-");
         await server.StartAsync();
-        using var client = CreateClient(server);
+        using var client = CreateClient(server, identity.Path);
         await ConnectAsync(client, server);
 
         // Start the request, then cancel the lifetime token only after the server has
@@ -46,8 +47,9 @@ public sealed class GatewayRequestShutdownClassificationTests
     public async Task ResolveExecApproval_ShutdownDuringWait_SurfacesCancellationNotTimeout()
     {
         using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("gateway-shutdown-");
         await server.StartAsync();
-        using var client = CreateClient(server);
+        using var client = CreateClient(server, identity.Path);
         await ConnectAsync(client, server);
 
         var requestTask = client.ResolveExecApprovalAsync("approval-1", "allow-once");
@@ -60,15 +62,32 @@ public sealed class GatewayRequestShutdownClassificationTests
             "shutdown must classify immediately instead of waiting out the 15s approval budget");
     }
 
-    private static OpenClawGatewayClient CreateClient(LoopbackWebSocketServer server)
+    // Guards the actual shutdown entry point: Dispose faults the pending completion
+    // via ClearPendingRequests before cancelling the lifetime token, and that path
+    // must never fabricate a gateway timeout either. The two tests above pin the
+    // residual register-after-clear window, which a real Dispose cannot reach
+    // deterministically precisely because of that ordering.
+    [Fact]
+    public async Task ResolveExecApproval_RealDisposeDuringWait_SurfacesCancellationNotTimeout()
     {
-        var identityPath = Path.Combine(
-            Path.GetTempPath(),
-            "GatewayRequestShutdownClassificationTests",
-            Guid.NewGuid().ToString("N"));
-        return new OpenClawGatewayClient(
-            server.WebSocketUrl, "test-token", new TestLogger(), identityPath: identityPath);
+        using var server = new LoopbackWebSocketServer();
+        using var identity = new TempDirectory("gateway-shutdown-");
+        await server.StartAsync();
+        using var client = CreateClient(server, identity.Path);
+        await ConnectAsync(client, server);
+
+        var requestTask = client.ResolveExecApprovalAsync("approval-1", "allow-once");
+        await WaitForFrameContainingAsync(server, "exec.approval.resolve", TimeSpan.FromSeconds(2));
+        client.Dispose();
+
+        var elapsed = Stopwatch.StartNew();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => requestTask);
+        Assert.True(elapsed.Elapsed < TimeSpan.FromSeconds(10),
+            "disposal must surface as cancellation instead of waiting out the 15s approval budget");
     }
+
+    private static OpenClawGatewayClient CreateClient(LoopbackWebSocketServer server, string identityPath)
+        => new(server.WebSocketUrl, "test-token", new TestLogger(), identityPath: identityPath);
 
     private static async Task ConnectAsync(OpenClawGatewayClient client, LoopbackWebSocketServer server)
     {

--- a/tests/OpenClaw.Shared.Tests/GatewayRequestShutdownClassificationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/GatewayRequestShutdownClassificationTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net.WebSockets;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+/// <summary>
+/// Regression tests for the #1021 sibling sites: when the client-lifetime token is
+/// cancelled while a chat.send or exec.approval.resolve response is pending, the
+/// failure must surface as a cancellation, not as a gateway timeout. The
+/// wizard-request site has its own fix and tests (#1018).
+/// </summary>
+[Collection("WebSocketClientBase")]
+public sealed class GatewayRequestShutdownClassificationTests
+{
+    [Fact]
+    public async Task SendChatMessage_ShutdownDuringWait_SurfacesCancellationNotTimeout()
+    {
+        using var server = new LoopbackWebSocketServer();
+        await server.StartAsync();
+        using var client = CreateClient(server);
+        await ConnectAsync(client, server);
+
+        // Start the request, then cancel the lifetime token only after the server has
+        // observed the request frame — by then the request has passed its connectivity
+        // guards and is parked on the response wait, so the cancelled timeout delay is
+        // the only thing that can complete it.
+        var requestTask = client.SendChatMessageAsync("hello", sessionKey: "agent:main:test");
+        await WaitForFrameContainingAsync(server, "chat.send", TimeSpan.FromSeconds(2));
+        CancelLifetime(client);
+
+        var elapsed = Stopwatch.StartNew();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => requestTask);
+        Assert.True(elapsed.Elapsed < TimeSpan.FromSeconds(4),
+            "shutdown must classify immediately instead of waiting out the 5s chat.send budget");
+    }
+
+    [Fact]
+    public async Task ResolveExecApproval_ShutdownDuringWait_SurfacesCancellationNotTimeout()
+    {
+        using var server = new LoopbackWebSocketServer();
+        await server.StartAsync();
+        using var client = CreateClient(server);
+        await ConnectAsync(client, server);
+
+        var requestTask = client.ResolveExecApprovalAsync("approval-1", "allow-once");
+        await WaitForFrameContainingAsync(server, "exec.approval.resolve", TimeSpan.FromSeconds(2));
+        CancelLifetime(client);
+
+        var elapsed = Stopwatch.StartNew();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => requestTask);
+        Assert.True(elapsed.Elapsed < TimeSpan.FromSeconds(10),
+            "shutdown must classify immediately instead of waiting out the 15s approval budget");
+    }
+
+    private static OpenClawGatewayClient CreateClient(LoopbackWebSocketServer server)
+    {
+        var identityPath = Path.Combine(
+            Path.GetTempPath(),
+            "GatewayRequestShutdownClassificationTests",
+            Guid.NewGuid().ToString("N"));
+        return new OpenClawGatewayClient(
+            server.WebSocketUrl, "test-token", new TestLogger(), identityPath: identityPath);
+    }
+
+    private static async Task ConnectAsync(OpenClawGatewayClient client, LoopbackWebSocketServer server)
+    {
+        await client.ConnectAsync();
+        var start = DateTime.UtcNow;
+        while (server.AcceptedCount < 1)
+        {
+            if (DateTime.UtcNow - start > TimeSpan.FromSeconds(2))
+                throw new TimeoutException("Loopback server did not accept the connection.");
+
+            // slopwatch-ignore: SW004 Test delay is an intentional bounded async wait; replacing it would change the scenario under test.
+            await Task.Delay(25);
+        }
+    }
+
+    /// <summary>Reads server-side frames (skipping the connect handshake traffic) until
+    /// one contains the marker, proving the request frame reached the wire.</summary>
+    private static async Task WaitForFrameContainingAsync(
+        LoopbackWebSocketServer server, string marker, TimeSpan timeout)
+    {
+        var socket = GetAcceptedSocket(server);
+        var buffer = new byte[64 * 1024];
+        using var cts = new CancellationTokenSource(timeout);
+        while (true)
+        {
+            var message = new StringBuilder();
+            WebSocketReceiveResult result;
+            do
+            {
+                result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), cts.Token);
+                if (result.MessageType != WebSocketMessageType.Text)
+                    throw new InvalidOperationException($"Unexpected {result.MessageType} frame before '{marker}'.");
+
+                message.Append(Encoding.UTF8.GetString(buffer, 0, result.Count));
+            } while (!result.EndOfMessage);
+
+            if (message.ToString().Contains(marker, StringComparison.Ordinal))
+                return;
+        }
+    }
+
+    // Models the shutdown race from #1021: the lifetime token is cancelled while this
+    // request's pending completion has not been faulted — the state a request reaches
+    // when it registers after ClearPendingRequests has already swept the pending maps.
+    private static void CancelLifetime(OpenClawGatewayClient client)
+    {
+        var field = typeof(WebSocketClientBase).GetField(
+            "_cts", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        ((CancellationTokenSource)field!.GetValue(client)!).Cancel();
+    }
+
+    private static WebSocket GetAcceptedSocket(LoopbackWebSocketServer server)
+    {
+        var field = typeof(LoopbackWebSocketServer).GetField(
+            "_acceptedSockets", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        var sockets = (List<WebSocket>)field!.GetValue(server)!;
+        lock (sockets)
+        {
+            Assert.NotEmpty(sockets);
+            return sockets[0];
+        }
+    }
+}


### PR DESCRIPTION
Closes #1021
Related: #1010, #1018

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where shutting down or disposing the gateway client while a chat message send or an exec-approval resolve was still awaiting its response logged a gateway timeout that never happened — "Timed out waiting for chat.send response from gateway" / "Timed out waiting for exec.approval.resolve response from gateway" — instead of a cancellation. #1018 fixed this misclassification for wizard requests; these are the two remaining sites named in #1021.

## Why This Change Was Made

Both sites race the pending response against `Task.Delay(timeoutMs, CancellationToken)` on the client-lifetime token, and a cancelled delay completes `Task.WhenAny` exactly like an elapsed one. The fix classifies the cancelled-token case (`CancellationToken.ThrowIfCancellationRequested()`) immediately before each `TimeoutException` throw, the same disambiguation idiom as #1011/#1018. The exec-approval site's TryRemove-first and same-tick `IsCompleted` machinery is deliberately left untouched rather than restructured to #1018's `WaitAsync` shape — smallest reviewable diff, identical classification outcome; pending-map cleanup is unchanged on both exits.

## User Impact

Disconnect or shutdown during an in-flight chat send or approval resolve now surfaces as a cancellation, so diagnostics no longer report a phantom gateway timeout and callers that branch on `TimeoutException` are not misled. Genuine timeouts behave exactly as before (the added check is a no-op on an uncancelled token). Callers already catch broadly per the `ClearPendingRequests` caller contract, so the approval-banner retry path is preserved.

## Evidence

- Deterministic red/green regression tests (`GatewayRequestShutdownClassificationTests`): each classification test starts a real request against a loopback WebSocket gateway that never responds, waits until the server observes the request frame on the wire (so all connectivity guards have passed and the request is parked on its response wait), then cancels the lifetime token. Base: both fail with `TimeoutException` in under 100 ms — impossible for a real timeout (budgets are 5 s / 15 s), proving the misclassification. Head: both surface `OperationCanceledException` immediately. Test identities use the repository's disposable `OpenClaw.TestSupport.TempDirectory` fixture.
- A third test drives the **real `client.Dispose()` shutdown path** during the parked wait and proves it surfaces a cancellation, never a fabricated timeout. It is green on base and head by design: `Dispose` faults pending completions via `ClearPendingRequests` *before* cancelling the lifetime token, which is exactly why a real `Dispose` cannot deterministically reproduce the racy register-after-clear window — the reflection-modeled pair above pins that window, the `Dispose` test guards the real entry point.
- signalkrebs `dotnet-conc` concurrency gate over the diff: verdict **clean**, with lane liveness proven (planted sync-over-async and deadlock fixtures caught).
- Autoreview (local Qwen + OpenRouter cascade) findings dispositioned against source; escalation review by GPT-5.3-Codex-Spark at high effort on the exact patch: NO_DEFECTS_FOUND.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs or instructions
- [x] Tests or validation
- [ ] Security hardening
- [ ] Chore or infrastructure

## Scope

- [ ] Tray or WinUI UX
- [ ] Windows node capability
- [ ] Local MCP or `winnode`
- [x] Gateway, connection, or pairing
- [ ] Setup or onboarding
- [ ] Permissions, privacy, or security
- [x] Tests, CI, or docs

## Validation

Windows box at dff33f7 (`dotnet restore` + builds of `OpenClaw.Shared`, `OpenClaw.Shared.Tests`, `OpenClaw.Tray.Tests -r win-x64` all succeeded first):

- `dotnet test tests/OpenClaw.Shared.Tests --no-build -c Debug` (with `OPENCLAW_RUN_INTEGRATION=1`) — passed 2,971, failed 0, skipped 0, total 2,971.
- `dotnet test tests/OpenClaw.Tray.Tests --no-build -c Debug -r win-x64` — passed 1,823, failed 0, skipped 0, total 1,823.
- `dotnet test tests/OpenClaw.Shared.Tests --filter "FullyQualifiedName~GatewayRequestShutdownClassificationTests"` — passed 3, failed 0 (and repeated stability reruns).

## Real Behavior Proof

Interleaving-class defect: the misclassification (a cancelled delay indistinguishable from an elapsed one inside `Task.WhenAny`) has no deterministically observable live surface, so the deterministic demonstration is the real-behavior proof — with the real shutdown entry point additionally exercised by the `Dispose` test above.

Before (base 9b5ce4b — shutdown misreported as gateway timeout, in milliseconds; the real-Dispose invariant passes as expected):

```
Failed OpenClaw.Shared.Tests.GatewayRequestShutdownClassificationTests.SendChatMessage_ShutdownDuringWait_SurfacesCancellationNotTimeout
  ---- System.TimeoutException : Timed out waiting for chat.send response from gateway
Failed OpenClaw.Shared.Tests.GatewayRequestShutdownClassificationTests.ResolveExecApproval_ShutdownDuringWait_SurfacesCancellationNotTimeout
  ---- System.TimeoutException : Timed out waiting for exec.approval.resolve response from gateway
```

After (head dff33f7 — shutdown classified as cancellation, same scenario, all three tests):

```
Passed!  - Failed: 0, Passed: 3, Skipped: 0, Total: 3 - OpenClaw.Shared.Tests.dll (net10.0)
```

A recorded proof manifest (base/head revisions, identical before/after commands, SHA-256-hashed console artifacts) backs this in the local gate ledger.

## Review history

https://gist.github.com/anagnorisis2peripeteia/54cb9e32326a9e3bcc8239c3e63fb4a9
