### PR TITLE
feat: add semantic Windows exec approval prompts

### DIFF
--- a/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
@@ -301,6 +301,7 @@ public class SystemCapability : NodeCapabilityBase
         
         var command = argv[0];
         var rawCommand = GetStringArg(request.Args, "rawCommand");
+        var commandPreview = GetCommandPreviewArg(request.Args);
         var requestedShell = GetStringArg(request.Args, "shell");
         var effectiveShell = _commandRunner?.ResolveEffectiveShell(requestedShell)
             ?? ResolveDefaultEffectiveShell(requestedShell);
@@ -319,6 +320,7 @@ public class SystemCapability : NodeCapabilityBase
                 argv,
                 cwd,
                 rawCommand,
+                commandPreview,
                 requestedShell = string.IsNullOrWhiteSpace(requestedShell) ? null : requestedShell.Trim(),
                 effectiveShell,
                 agentId,
@@ -446,6 +448,7 @@ public class SystemCapability : NodeCapabilityBase
         
         var shell = GetStringArg(request.Args, "shell");
         var cwd = GetStringArg(request.Args, "cwd");
+        var commandPreview = GetCommandPreviewArg(request.Args);
         var sessionKey = request.SessionKey ?? GetStringArg(request.Args, "sessionKey");
         var timeoutMs = GetIntArg(request.Args, "timeoutMs",
             GetIntArg(request.Args, "timeout", DefaultRunTimeoutMs));
@@ -510,6 +513,7 @@ public class SystemCapability : NodeCapabilityBase
                 var approvalError = await EnsureCommandAndNestedTargetsApprovedAsync(
                     fullCommand,
                     effectiveShell,
+                    commandPreview,
                     sessionKey,
                     correlationId);
                 if (approvalError != null)
@@ -528,6 +532,7 @@ public class SystemCapability : NodeCapabilityBase
                     approvalError = await EnsureCommandAndNestedTargetsApprovedAsync(
                         fullCommand,
                         approvedHostFallbackShell,
+                        commandPreview,
                         sessionKey,
                         correlationId);
                     if (approvalError != null)
@@ -740,6 +745,7 @@ public class SystemCapability : NodeCapabilityBase
     private async Task<ExecApprovalCheckResult> EnsureApprovedAsync(
         string command,
         string? shell,
+        string? commandPreview,
         ExecApprovalResult approval,
         string? sessionKey,
         string correlationId,
@@ -757,6 +763,7 @@ public class SystemCapability : NodeCapabilityBase
         var decision = await _promptHandler.RequestAsync(new ExecApprovalPromptRequest
         {
             Command = command,
+            CommandPreview = commandPreview,
             Shell = shell,
             MatchedPattern = approval.MatchedPattern,
             Reason = approval.Reason ?? "Command requires approval",
@@ -796,6 +803,7 @@ public class SystemCapability : NodeCapabilityBase
     private async Task<NodeInvokeResponse?> EnsureCommandAndNestedTargetsApprovedAsync(
         string fullCommand,
         string? shell,
+        string? commandPreview,
         string? sessionKey,
         string correlationId)
     {
@@ -820,7 +828,13 @@ public class SystemCapability : NodeCapabilityBase
         var approvalCheck = new ExecApprovalCheckResult(false, null);
         if (evaluateOuter)
         {
-            approvalCheck = await EnsureApprovedAsync(fullCommand, shell, approval, sessionKey, correlationId);
+            approvalCheck = await EnsureApprovedAsync(
+                fullCommand,
+                shell,
+                commandPreview,
+                approval,
+                sessionKey,
+                correlationId);
             if (!approvalCheck.Allowed)
             {
                 Logger.Warn($"system.run DENIED: {fullCommand} ({approval.Reason})");
@@ -851,6 +865,7 @@ public class SystemCapability : NodeCapabilityBase
             var innerApprovalCheck = await EnsureApprovedAsync(
                 target.Command,
                 target.Shell,
+                commandPreview,
                 innerApproval,
                 sessionKey,
                 correlationId);
@@ -876,6 +891,23 @@ public class SystemCapability : NodeCapabilityBase
     private static bool CanPersistExactAllowRule(string command) =>
         !string.IsNullOrWhiteSpace(command) &&
         command.IndexOfAny(['*', '?']) < 0;
+
+    private string? GetCommandPreviewArg(System.Text.Json.JsonElement args)
+    {
+        var preview = GetStringArg(args, "commandPreview");
+        if (!string.IsNullOrWhiteSpace(preview))
+            return preview;
+
+        if (args.ValueKind != System.Text.Json.JsonValueKind.Object ||
+            !args.TryGetProperty("systemRunPlan", out var plan) ||
+            plan.ValueKind != System.Text.Json.JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        preview = GetStringArg(plan, "commandPreview");
+        return string.IsNullOrWhiteSpace(preview) ? null : preview;
+    }
 
     private static bool IsExactAllowRuleForCommand(ExecApprovalResult approval, string command) =>
         approval.Allowed &&

--- a/src/OpenClaw.Shared/ExecApprovalPrompt.cs
+++ b/src/OpenClaw.Shared/ExecApprovalPrompt.cs
@@ -14,6 +14,12 @@ public enum ExecApprovalPromptDecisionKind
 public sealed class ExecApprovalPromptRequest
 {
     public string Command { get; init; } = "";
+    /// <summary>
+     /// Optional human-readable summary supplied through OpenClaw's canonical
+     /// <c>commandPreview</c> field. This is presentation context, not a policy
+    /// decision; <see cref="Command"/> remains the exact authoritative command.
+     /// </summary>
+    public string? CommandPreview { get; init; }
     public string? Shell { get; init; }
     public string? MatchedPattern { get; init; }
     public string Reason { get; init; } = "";

--- a/src/OpenClaw.Shared/ExecApprovalPromptText.cs
+++ b/src/OpenClaw.Shared/ExecApprovalPromptText.cs
@@ -1,0 +1,69 @@
+using System;
+using OpenClaw.Shared.ExecApprovals;
+
+namespace OpenClaw.Shared;
+
+/// <summary>
+/// Builds the native exec-approval explanation. The human-readable preview is
+/// explicitly labelled as agent-supplied context; the exact command remains
+/// visible and host policy remains authoritative.
+/// </summary>
+internal static class ExecApprovalPromptText
+{
+    internal static string Build(
+        ExecApprovalPromptRequest request,
+        bool german,
+        string displayName)
+    {
+        var command = Sanitize(request.Command, 4_000);
+        var preview = ExecApprovalContextDisplaySanitizer.Sanitize(request.CommandPreview);
+        var reason = Sanitize(request.Reason, 400);
+        var shell = Sanitize(request.Shell, 80);
+
+        if (german)
+        {
+            var summary = string.IsNullOrWhiteSpace(preview)
+                ? $"{displayName} hat keine verständliche Beschreibung mitgesendet. Wenn du unsicher bist, lehne ab und lass die Anfrage neu formulieren."
+                : preview;
+            return
+                $"{displayName} möchte etwas auf diesem Windows-PC ausführen.\r\n\r\n" +
+                "Technische Details:\r\n" +
+                (string.IsNullOrWhiteSpace(command) ? "(kein Befehl angegeben)" : command) +
+                "\r\n" +
+                $"Shell: {(string.IsNullOrWhiteSpace(shell) ? "automatisch" : shell)}" +
+                "\r\n" +
+                $"Policy: {(string.IsNullOrWhiteSpace(reason) ? "Freigabe erforderlich" : reason)}" +
+                "\r\n\r\n" +
+                $"Worum es geht (von {displayName} beschrieben):\r\n" +
+                summary +
+                "\r\n\r\n" +
+                "Sicherheitsgrenze: Policy und konfigurierte Sandbox-Regeln bleiben maßgeblich. Diese Beschreibung ersetzt nicht die technische Prüfung durch den Hub.";
+        }
+
+        var englishSummary = string.IsNullOrWhiteSpace(preview)
+            ? "The agent did not include a plain-language description. Deny if unsure and ask it to retry with a clearer summary."
+            : preview;
+        return
+            $"{displayName} needs approval before a remote agent can run something on this Windows machine.\r\n\r\n" +
+            "Technical details:\r\n" +
+            (string.IsNullOrWhiteSpace(command) ? "(no command supplied)" : command) +
+            "\r\n" +
+            $"Shell: {(string.IsNullOrWhiteSpace(shell) ? "auto" : shell)}" +
+            "\r\n" +
+            $"Policy: {(string.IsNullOrWhiteSpace(reason) ? "Approval required" : reason)}" +
+            "\r\n\r\n" +
+            "What this is for (described by the agent):\r\n" +
+            englishSummary +
+            "\r\n\r\n" +
+            "Security boundary: policy and configured sandbox controls remain authoritative. This description does not replace the Hub's technical checks.";
+    }
+
+    private static string Sanitize(string? value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return "";
+
+        var safe = ExecApprovalCommandDisplaySanitizer.Sanitize(value).Trim();
+        return safe.Length <= maxLength ? safe : safe[..(maxLength - 1)] + "…";
+    }
+}

--- a/src/OpenClaw.Shared/ExecApprovals/CanonicalCommandIdentity.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/CanonicalCommandIdentity.cs
@@ -41,6 +41,7 @@ public sealed class CanonicalCommandIdentity
     public IReadOnlyDictionary<string, string>? Env { get; }
     public string? AgentId { get; }
     public string? SessionKey { get; }
+    public string? CommandPreview { get; }
 
     internal CanonicalCommandIdentity(
         IReadOnlyList<string> command,
@@ -53,7 +54,8 @@ public sealed class CanonicalCommandIdentity
         int timeoutMs,
         IReadOnlyDictionary<string, string>? env,
         string? agentId,
-        string? sessionKey)
+        string? sessionKey,
+        string? commandPreview = null)
     {
         Command = command;
         DisplayCommand = displayCommand;
@@ -66,5 +68,6 @@ public sealed class CanonicalCommandIdentity
         Env = env;
         AgentId = agentId;
         SessionKey = sessionKey;
+        CommandPreview = commandPreview;
     }
 }

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalContextDisplaySanitizer.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalContextDisplaySanitizer.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+using System.Text;
+
+namespace OpenClaw.Shared.ExecApprovals;
+
+/// <summary>
+/// Sanitizes agent-supplied approval context while preserving intentional
+/// line breaks. Unlike command text, explanatory context is expected to be
+/// multi-line; other control, format, and separator characters are escaped.
+/// </summary>
+public static class ExecApprovalContextDisplaySanitizer
+{
+    public static string Sanitize(string? value, int maxLength = 1_200)
+    {
+        if (string.IsNullOrWhiteSpace(value) || maxLength <= 0)
+            return "";
+
+        var output = new StringBuilder(Math.Min(value.Length, maxLength));
+        foreach (var rune in value.EnumerateRunes())
+        {
+            var piece = rune.Value is '\r' or '\n' or '\t'
+                ? rune.ToString()
+                : Rune.GetUnicodeCategory(rune) is
+                    UnicodeCategory.Control or
+                    UnicodeCategory.Format or
+                    UnicodeCategory.LineSeparator or
+                    UnicodeCategory.ParagraphSeparator
+                    ? $@"\u{{{rune.Value:X}}}"
+                    : rune.ToString();
+
+            if (output.Length + piece.Length <= maxLength)
+            {
+                output.Append(piece);
+                continue;
+            }
+
+            if (output.Length >= maxLength)
+                output.Length = maxLength - 1;
+            output.Append('…');
+            break;
+        }
+
+        return output.ToString().Trim();
+    }
+}

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2InputValidator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2InputValidator.cs
@@ -78,7 +78,8 @@ public static class ExecApprovalV2InputValidator
             timeoutMs,
             env,
             TryGetString(request.Args, "agentId"),
-            TryGetString(request.Args, "sessionKey")));
+            TryGetString(request.Args, "sessionKey"),
+            TryGetCommandPreview(request.Args)));
     }
 
     private static ExecApprovalV2ValidationOutcome Deny(string reason)
@@ -133,5 +134,22 @@ public static class ExecApprovalV2InputValidator
             el.ValueKind != JsonValueKind.String)
             return null;
         return el.GetString();
+    }
+
+    private static string? TryGetCommandPreview(JsonElement args)
+    {
+        var preview = TryGetString(args, "commandPreview");
+        if (!string.IsNullOrWhiteSpace(preview))
+            return preview;
+
+        if (args.ValueKind != JsonValueKind.Object ||
+            !args.TryGetProperty("systemRunPlan", out var plan) ||
+            plan.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        preview = TryGetString(plan, "commandPreview");
+        return string.IsNullOrWhiteSpace(preview) ? null : preview;
     }
 }

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2NormalizationStep.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2NormalizationStep.cs
@@ -74,7 +74,8 @@ public static class ExecApprovalV2Normalizer
             request.TimeoutMs,
             env,
             request.AgentId,
-            request.SessionKey);
+            request.SessionKey,
+            request.CommandPreview);
 
         return ExecApprovalV2NormalizationOutcome.Ok(identity);
     }

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2PromptRequest.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2PromptRequest.cs
@@ -17,6 +17,11 @@ public sealed class ExecApprovalV2PromptRequest
     public required string AgentId { get; init; }
     public string? ResolvedPath { get; init; }
     /// <summary>
+    /// Optional agent-supplied explanation of the request. Presentation context
+    /// only; <see cref="DisplayCommand"/> remains authoritative.
+    /// </summary>
+    public string? CommandPreview { get; init; }
+    /// <summary>
     /// Opaque key scoping AllowOnce/AllowAlways decisions to a conversation session.
     /// Minted by the gateway per session; null means no session context is available.
     /// Not safe to display — internal identifier only.

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2UiPromptHandler.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalV2UiPromptHandler.cs
@@ -13,7 +13,10 @@ public sealed record ExecApprovalPromptView(
     string AgentLabel,
     string? CwdText,
     string? ExecutablePathText,
-    bool HasConfusableWarning);
+    bool HasConfusableWarning)
+{
+    public string? CommandPreviewText { get; init; }
+}
 
 /// <summary>
 /// Prompt-handler core behind the approval dialog. UI-free: the dispatcher hop and the
@@ -49,6 +52,9 @@ public sealed class ExecApprovalV2UiPromptHandler : IExecApprovalV2PromptHandler
             // including the agent label, so all of them go through the display sanitizer
             // before any UI binding to neutralize BiDi and control-character spoofing.
             var commandText = ExecApprovalCommandDisplaySanitizer.Sanitize(request.DisplayCommand);
+            var commandPreviewText = string.IsNullOrWhiteSpace(request.CommandPreview)
+                ? null
+                : ExecApprovalContextDisplaySanitizer.Sanitize(request.CommandPreview);
             var agentLabel = ExecApprovalCommandDisplaySanitizer.Sanitize(request.AgentId);
             var cwdText = request.Cwd is null ? null : ExecApprovalCommandDisplaySanitizer.Sanitize(request.Cwd);
             var pathText = request.ResolvedPath is null ? null : ExecApprovalCommandDisplaySanitizer.Sanitize(request.ResolvedPath);
@@ -58,10 +64,19 @@ public sealed class ExecApprovalV2UiPromptHandler : IExecApprovalV2PromptHandler
             // instead so the user knows the command may not read the way it looks.
             var hasConfusable =
                 ExecApprovalConfusableDetector.HasMixedScriptConfusable(commandText)
+                || ExecApprovalConfusableDetector.HasMixedScriptConfusable(commandPreviewText)
                 || ExecApprovalConfusableDetector.HasMixedScriptConfusable(cwdText)
                 || ExecApprovalConfusableDetector.HasMixedScriptConfusable(pathText);
 
-            var view = new ExecApprovalPromptView(commandText, agentLabel, cwdText, pathText, hasConfusable);
+            var view = new ExecApprovalPromptView(
+                commandText,
+                agentLabel,
+                cwdText,
+                pathText,
+                hasConfusable)
+            {
+                CommandPreviewText = commandPreviewText
+            };
 
             var tcs = new TaskCompletionSource<ExecApprovalPromptOutcome>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
@@ -127,4 +142,5 @@ public sealed class ExecApprovalV2UiPromptHandler : IExecApprovalV2PromptHandler
             tcs.TrySetResult(ExecApprovalPromptOutcome.Deny);
         }
     }
+
 }

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
@@ -374,6 +374,7 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
             Ask = context.Ask,
             AgentId = context.AgentId ?? "main",
             ResolvedPath = context.Resolution?.ResolvedPath,
+            CommandPreview = identity.CommandPreview,
             SessionKey = identity.SessionKey,
             CorrelationId = correlationId,
             // Host omitted (no gateway wiring yet)

--- a/src/OpenClaw.Shared/ExecApprovals/ValidatedRunRequest.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ValidatedRunRequest.cs
@@ -15,6 +15,7 @@ public sealed class ValidatedRunRequest
     public IReadOnlyDictionary<string, string>? Env { get; }
     public string? AgentId { get; }
     public string? SessionKey { get; }
+    public string? CommandPreview { get; }
 
     internal ValidatedRunRequest(
         string[] argv,
@@ -23,7 +24,8 @@ public sealed class ValidatedRunRequest
         int timeoutMs,
         IReadOnlyDictionary<string, string>? env,
         string? agentId,
-        string? sessionKey)
+        string? sessionKey,
+        string? commandPreview = null)
     {
         Argv = argv;
         Shell = shell;
@@ -32,6 +34,7 @@ public sealed class ValidatedRunRequest
         Env = env;
         AgentId = agentId;
         SessionKey = sessionKey;
+        CommandPreview = commandPreview;
     }
 }
 

--- a/src/OpenClaw.Tray.WinUI/Dialogs/ExecApprovalDialog.cs
+++ b/src/OpenClaw.Tray.WinUI/Dialogs/ExecApprovalDialog.cs
@@ -152,6 +152,33 @@ public sealed class ExecApprovalDialog : WindowEx
             Child = commandText,
         });
 
+        // Agent-supplied context is additive and deliberately follows the exact
+        // command so an oversized or whitespace-heavy preview cannot displace the
+        // authoritative approval target from the initial viewport.
+        if (!string.IsNullOrWhiteSpace(view.CommandPreviewText))
+        {
+            var preview = new StackPanel { Spacing = 6 };
+            preview.Children.Add(new TextBlock
+            {
+                Text = LocalizationHelper.GetString("ExecApproval_RequestContextLabel"),
+                Style = (Style)Application.Current.Resources["CaptionTextBlockStyle"],
+                Foreground = ResolveBrush("TextFillColorSecondaryBrush"),
+            });
+            preview.Children.Add(new TextBlock
+            {
+                Text = view.CommandPreviewText,
+                TextWrapping = TextWrapping.Wrap,
+                IsTextSelectionEnabled = true,
+            });
+            body.Children.Add(new Border
+            {
+                Background = ResolveBrush("CardBackgroundFillColorDefaultBrush"),
+                CornerRadius = new CornerRadius(4),
+                Padding = new Thickness(10),
+                Child = preview,
+            });
+        }
+
         AddContextRow(body, "ExecApproval_AgentLabel", view.AgentLabel);
         AddContextRow(body, "ExecApproval_CwdLabel", view.CwdText);
         AddContextRow(body, "ExecApproval_ExecutableLabel", view.ExecutablePathText);

--- a/src/OpenClaw.Tray.WinUI/Services/ExecApprovalPromptService.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/ExecApprovalPromptService.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml;
 using OpenClaw.Shared;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,7 +16,11 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
     private readonly IOpenClawLogger _logger;
     private readonly Func<OpenClawChatDataProvider?>? _chatProviderProvider;
     private readonly Func<string, bool>? _inlineApprovalAvailable;
-    private static string NativePromptTitle => $"{AppIdentity.DisplayName} - Approve local command?";
+    private static bool UseGerman =>
+        string.Equals(CultureInfo.CurrentUICulture.TwoLetterISOLanguageName, "de", StringComparison.OrdinalIgnoreCase);
+    private static string NativePromptTitle => UseGerman
+        ? $"{AppIdentity.DisplayName} – Zugriff freigeben?"
+        : $"{AppIdentity.DisplayName} - Approve local command?";
 
     public ExecApprovalPromptService(
         DispatcherQueue dispatcherQueue,
@@ -161,14 +166,7 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
 
     private static ExecApprovalPromptDecision ShowNativePrompt(ExecApprovalPromptRequest request)
     {
-        var text =
-            $"{AppIdentity.DisplayName} needs approval before a remote agent can run a local command on this Windows machine." +
-            "\r\n\r\n" +
-            request.Command +
-            "\r\n\r\n" +
-            $"Shell: {request.Shell ?? "auto"}" +
-            "\r\n" +
-            $"Reason: {request.Reason}";
+        var text = ExecApprovalPromptText.Build(request, UseGerman, AppIdentity.DisplayName);
 
         try
         {
@@ -184,9 +182,9 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
     {
         var fallbackText = text +
             Environment.NewLine + Environment.NewLine +
-            "Yes = Allow once" +
+            (UseGerman ? "Ja = Einmal erlauben" : "Yes = Allow once") +
             Environment.NewLine +
-            "No or Cancel = Deny";
+            (UseGerman ? "Nein oder Abbrechen = Ablehnen" : "No or Cancel = Deny");
 
         var result = MessageBoxW(
             IntPtr.Zero,
@@ -358,9 +356,9 @@ public sealed class ExecApprovalPromptService : IExecApprovalPromptHandler
 
             var totalButtonWidth = ButtonWidth * 3 + ButtonGap * 2;
             var firstLeft = WindowWidth - 20 - totalButtonWidth;
-            _allowOnceButtonHwnd = CreateChild(hwnd, "BUTTON", "Allow once", firstLeft, ButtonTop, ButtonWidth, ButtonHeight, ButtonStylePushButton, AllowOnceButtonId, font);
-            _alwaysAllowButtonHwnd = CreateChild(hwnd, "BUTTON", "Always allow", firstLeft + ButtonWidth + ButtonGap, ButtonTop, ButtonWidth, ButtonHeight, ButtonStylePushButton, AlwaysAllowButtonId, font);
-            _denyButtonHwnd = CreateChild(hwnd, "BUTTON", "Deny", firstLeft + (ButtonWidth + ButtonGap) * 2, ButtonTop, ButtonWidth, ButtonHeight, ButtonStyleDefaultPushButton, DenyButtonId, font);
+            _allowOnceButtonHwnd = CreateChild(hwnd, "BUTTON", UseGerman ? "Einmal erlauben" : "Allow once", firstLeft, ButtonTop, ButtonWidth, ButtonHeight, ButtonStylePushButton, AllowOnceButtonId, font);
+            _alwaysAllowButtonHwnd = CreateChild(hwnd, "BUTTON", UseGerman ? "Dauerhaft erlauben" : "Always allow", firstLeft + ButtonWidth + ButtonGap, ButtonTop, ButtonWidth, ButtonHeight, ButtonStylePushButton, AlwaysAllowButtonId, font);
+            _denyButtonHwnd = CreateChild(hwnd, "BUTTON", UseGerman ? "Ablehnen" : "Deny", firstLeft + (ButtonWidth + ButtonGap) * 2, ButtonTop, ButtonWidth, ButtonHeight, ButtonStyleDefaultPushButton, DenyButtonId, font);
             SetFocus(_denyButtonHwnd);
         }
 

--- a/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/en-us/Resources.resw
@@ -770,6 +770,9 @@ Use one of these options:
   <data name="ExecApproval_Body" xml:space="preserve">
     <value>The following command is requesting permission to run:</value>
   </data>
+  <data name="ExecApproval_RequestContextLabel" xml:space="preserve">
+    <value>Request context (provided by the agent)</value>
+  </data>
   <data name="ExecApproval_AgentLabel" xml:space="preserve">
     <value>Agent:</value>
   </data>
@@ -795,7 +798,7 @@ Use one of these options:
     <value>Scroll to the end of the command before allowing</value>
   </data>
   <data name="ExecApproval_ConfusableWarning" xml:space="preserve">
-    <value>This command mixes character sets and may not read the way it looks. Check it carefully.</value>
+    <value>The displayed content mixes character sets and may not read the way it looks. Check it carefully.</value>
   </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ Node Paired!</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/fr-fr/Resources.resw
@@ -729,6 +729,9 @@ Utilisez l'une de ces options :
   <data name="ExecApproval_Body" xml:space="preserve">
     <value>La commande suivante demande l'autorisation de s'exécuter :</value>
   </data>
+  <data name="ExecApproval_RequestContextLabel" xml:space="preserve">
+    <value>Contexte de la demande (fourni par l’agent)</value>
+  </data>
   <data name="ExecApproval_AgentLabel" xml:space="preserve">
     <value>Agent :</value>
   </data>
@@ -754,7 +757,7 @@ Utilisez l'une de ces options :
     <value>Faites défiler jusqu'à la fin de la commande avant d'autoriser</value>
   </data>
   <data name="ExecApproval_ConfusableWarning" xml:space="preserve">
-    <value>Cette commande mélange des jeux de caractères et peut ne pas être ce qu'elle paraît. Vérifiez-la attentivement.</value>
+    <value>Le contenu affiché mélange des jeux de caractères et peut ne pas être ce qu’il paraît. Vérifiez-le attentivement.</value>
   </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ Noeud appairé!</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -730,6 +730,9 @@ Gebruik een van deze opties:
   <data name="ExecApproval_Body" xml:space="preserve">
     <value>De volgende opdracht vraagt toestemming om te worden uitgevoerd:</value>
   </data>
+  <data name="ExecApproval_RequestContextLabel" xml:space="preserve">
+    <value>Context van het verzoek (aangeleverd door de AI-agent)</value>
+  </data>
   <data name="ExecApproval_AgentLabel" xml:space="preserve">
     <value>AI-agent:</value>
   </data>
@@ -755,7 +758,7 @@ Gebruik een van deze opties:
     <value>Scroll naar het einde van de opdracht voordat u toestaat</value>
   </data>
   <data name="ExecApproval_ConfusableWarning" xml:space="preserve">
-    <value>Deze opdracht mengt tekensets en is mogelijk niet wat het lijkt. Controleer hem zorgvuldig.</value>
+    <value>De weergegeven inhoud mengt tekensets en is mogelijk niet wat het lijkt. Controleer deze zorgvuldig.</value>
   </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ Node gekoppeld!</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-cn/Resources.resw
@@ -729,6 +729,9 @@
   <data name="ExecApproval_Body" xml:space="preserve">
     <value>以下命令请求运行权限：</value>
   </data>
+  <data name="ExecApproval_RequestContextLabel" xml:space="preserve">
+    <value>请求上下文（由代理提供）</value>
+  </data>
   <data name="ExecApproval_AgentLabel" xml:space="preserve">
     <value>代理：</value>
   </data>
@@ -754,7 +757,7 @@
     <value>请滚动到命令末尾后再允许</value>
   </data>
   <data name="ExecApproval_ConfusableWarning" xml:space="preserve">
-    <value>此命令混用了不同的字符集，可能与其外观不符。请仔细核对。</value>
+    <value>显示的内容混用了不同的字符集，可能与其外观不符。请仔细核对。</value>
   </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ 节点已配对！</value>

--- a/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/zh-tw/Resources.resw
@@ -729,6 +729,9 @@
   <data name="ExecApproval_Body" xml:space="preserve">
     <value>以下命令請求執行權限：</value>
   </data>
+  <data name="ExecApproval_RequestContextLabel" xml:space="preserve">
+    <value>要求內容（由代理提供）</value>
+  </data>
   <data name="ExecApproval_AgentLabel" xml:space="preserve">
     <value>代理：</value>
   </data>
@@ -754,7 +757,7 @@
     <value>請捲動至命令結尾後再允許</value>
   </data>
   <data name="ExecApproval_ConfusableWarning" xml:space="preserve">
-    <value>此命令混用了不同的字元集，可能與其外觀不符。請仔細核對。</value>
+    <value>顯示的內容混用了不同的字元集，可能與其外觀不符。請仔細核對。</value>
   </data>
   <data name="Toast_NodePaired" xml:space="preserve">
     <value>✅ 節點已配對！</value>

--- a/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
@@ -667,7 +667,15 @@ public class SystemCapabilityTests
         {
             Id = "p3",
             Command = "system.run.prepare",
-            Args = Parse("""{"command":["ls","-la"],"cwd":"/tmp","agentId":"agent1","sessionKey":"sk1"}""")
+            Args = Parse("""
+                {
+                    "command": ["ls", "-la"],
+                    "cwd": "/tmp",
+                    "agentId": "agent1",
+                    "sessionKey": "sk1",
+                    "commandPreview": "List directory contents without modifying them."
+                }
+                """)
         };
 
         var res = await cap.ExecuteAsync(req);
@@ -680,6 +688,9 @@ public class SystemCapabilityTests
         Assert.Equal("/tmp", cwd.GetString());
         Assert.True(plan.TryGetProperty("agentId", out var agentId));
         Assert.Equal("agent1", agentId.GetString());
+        Assert.Equal(
+            "List directory contents without modifying them.",
+            plan.GetProperty("commandPreview").GetString());
     }
 
     [Fact]

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalContextDisplaySanitizerTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalContextDisplaySanitizerTests.cs
@@ -1,0 +1,36 @@
+using OpenClaw.Shared.ExecApprovals;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class ExecApprovalContextDisplaySanitizerTests
+{
+    [Fact]
+    public void PreservesIntentionalMultilineContext()
+    {
+        var input = "Purpose: inspect state.\nRisk: low.\nRecommendation: allow once.";
+
+        Assert.Equal(input, ExecApprovalContextDisplaySanitizer.Sanitize(input));
+    }
+
+    [Fact]
+    public void EscapesBidirectionalAndZeroWidthFormatting()
+    {
+        var input = "Read only\u202Espoof\u200Bcontext";
+
+        Assert.Equal(
+            @"Read only\u{202E}spoof\u{200B}context",
+            ExecApprovalContextDisplaySanitizer.Sanitize(input));
+    }
+
+    [Fact]
+    public void BoundsRenderedContext()
+    {
+        var sanitized = ExecApprovalContextDisplaySanitizer.Sanitize(
+            new string('a', 1_500),
+            maxLength: 100);
+
+        Assert.Equal(100, sanitized.Length);
+        Assert.EndsWith("…", sanitized);
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalPolicyTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalPolicyTests.cs
@@ -1430,6 +1430,48 @@ public class SystemCapabilityExecApprovalsTests
             try { Directory.Delete(tempDir, true); } catch { }
         }
     }
+
+    [Fact]
+    public async Task SystemRun_PromptReceivesCanonicalCommandPreview()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var policy = new ExecApprovalPolicy(tempDir, _logger);
+            policy.SetRules(System.Array.Empty<ExecApprovalRule>(), ExecApprovalAction.Prompt);
+
+            var cap = CreateCapability(policy);
+            var prompt = new CapturingAllowOncePromptHandler();
+            cap.SetPromptHandler(prompt);
+
+            var request = new NodeInvokeRequest
+            {
+                Command = "system.run",
+                Args = JsonDocument.Parse("""
+                    {
+                      "command": "tasklist",
+                      "systemRunPlan": {
+                        "commandPreview": "Zweck: laufende Prozesse nur lesend prüfen."
+                      }
+                    }
+                    """).RootElement
+            };
+
+            var result = await cap.ExecuteAsync(request);
+
+            Assert.True(result.Ok);
+            Assert.NotNull(prompt.Request);
+            Assert.Equal(
+                "Zweck: laufende Prozesse nur lesend prüfen.",
+                prompt.Request!.CommandPreview);
+            Assert.Equal("tasklist", prompt.Request.Command);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { }
+        }
+    }
 }
 
 internal class AllowOncePromptHandler : IExecApprovalPromptHandler
@@ -1438,6 +1480,19 @@ internal class AllowOncePromptHandler : IExecApprovalPromptHandler
         ExecApprovalPromptRequest request,
         System.Threading.CancellationToken cancellationToken = default)
         => Task.FromResult(ExecApprovalPromptDecision.AllowOnce());
+}
+
+internal sealed class CapturingAllowOncePromptHandler : IExecApprovalPromptHandler
+{
+    public ExecApprovalPromptRequest? Request { get; private set; }
+
+    public Task<ExecApprovalPromptDecision> RequestAsync(
+        ExecApprovalPromptRequest request,
+        System.Threading.CancellationToken cancellationToken = default)
+    {
+        Request = request;
+        return Task.FromResult(ExecApprovalPromptDecision.AllowOnce());
+    }
 }
 
 /// <summary>Mock command runner that always succeeds</summary>

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalPromptTextTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalPromptTextTests.cs
@@ -1,0 +1,74 @@
+using OpenClaw.Shared;
+using Xunit;
+
+namespace OpenClaw.Shared.Tests;
+
+public sealed class ExecApprovalPromptTextTests
+{
+    [Fact]
+    public void GermanPrompt_LeadsWithPreviewAndKeepsExactCommandVisible()
+    {
+        var text = ExecApprovalPromptText.Build(new ExecApprovalPromptRequest
+        {
+            Command = "powershell.exe -NoProfile -Command Get-ComputerInfo",
+            CommandPreview = "Zweck: Systemzustand lesen.\nRisiko: niedrig.\nEmpfehlung: Einmal erlauben.",
+            Shell = "powershell",
+            Reason = "No matching rule; default policy applied"
+        }, german: true, displayName: "OpenClaw Companion");
+
+        Assert.Contains("Worum es geht (von OpenClaw Companion beschrieben)", text);
+        Assert.DoesNotContain("Otti", text);
+        Assert.Contains("Zweck: Systemzustand lesen.", text);
+        Assert.Contains("Technische Details", text);
+        Assert.Contains("powershell.exe -NoProfile -Command Get-ComputerInfo", text);
+        Assert.Contains("Policy und konfigurierte Sandbox-Regeln bleiben maßgeblich", text);
+        Assert.True(
+            text.IndexOf("powershell.exe -NoProfile -Command Get-ComputerInfo", StringComparison.Ordinal) <
+            text.IndexOf("Zweck: Systemzustand lesen.", StringComparison.Ordinal),
+            "The exact command must be visible before agent-supplied context.");
+    }
+
+    [Fact]
+    public void Prompt_StripsBidirectionalOverridesFromUntrustedText()
+    {
+        var text = ExecApprovalPromptText.Build(new ExecApprovalPromptRequest
+        {
+            Command = "safe.exe\u202Etxt.exe",
+            CommandPreview = "Read only\u2066spoof",
+            Reason = "approval"
+        }, german: false, displayName: "OpenClaw Companion");
+
+        Assert.DoesNotContain('\u202E', text);
+        Assert.DoesNotContain('\u2066', text);
+        Assert.Contains(@"safe.exe\u{202E}txt.exe", text);
+        Assert.Contains(@"Read only\u{2066}spoof", text);
+    }
+
+    [Fact]
+    public void PromptWithoutPreview_TellsUserToDenyAndRetry()
+    {
+        var text = ExecApprovalPromptText.Build(new ExecApprovalPromptRequest
+        {
+            Command = "hostname",
+            Reason = "approval"
+        }, german: true, displayName: "OpenClaw Companion");
+
+        Assert.Contains("Wenn du unsicher bist, lehne ab", text);
+        Assert.Contains("hostname", text);
+    }
+
+    [Fact]
+    public void GermanPrompt_UsesSuppliedDisplayName()
+    {
+        var text = ExecApprovalPromptText.Build(new ExecApprovalPromptRequest
+        {
+            Command = "hostname",
+            CommandPreview = "Zweck: Rechnernamen lesen.",
+            Reason = "approval"
+        }, german: true, displayName: "OpenClaw Companion");
+
+        Assert.Contains("OpenClaw Companion möchte", text);
+        Assert.Contains("von OpenClaw Companion beschrieben", text);
+        Assert.DoesNotContain("Otti", text);
+    }
+}

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalV2InputValidationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalV2InputValidationTests.cs
@@ -64,7 +64,8 @@ public class ExecApprovalV2InputValidationTests
                 "timeoutMs": 5000,
                 "env": {"MY_VAR": "value"},
                 "agentId": "agent-1",
-                "sessionKey": "sess-abc"
+                "sessionKey": "sess-abc",
+                "commandPreview": "Read the current repository status."
             }
             """));
 
@@ -77,6 +78,42 @@ public class ExecApprovalV2InputValidationTests
         Assert.Equal("value", r.Env!["MY_VAR"]);
         Assert.Equal("agent-1", r.AgentId);
         Assert.Equal("sess-abc", r.SessionKey);
+        Assert.Equal("Read the current repository status.", r.CommandPreview);
+    }
+
+    [Fact]
+    public void Valid_CommandPreviewFromSystemRunPlan_IsParsed()
+    {
+        var outcome = ExecApprovalV2InputValidator.Validate(Req("""
+            {
+                "command": ["git", "status"],
+                "systemRunPlan": {
+                    "commandPreview": "Inspect working-tree changes without modifying files."
+                }
+            }
+            """));
+
+        Assert.True(outcome.IsValid);
+        Assert.Equal(
+            "Inspect working-tree changes without modifying files.",
+            outcome.Request!.CommandPreview);
+    }
+
+    [Fact]
+    public void Valid_TopLevelCommandPreview_TakesPrecedenceOverPlanFallback()
+    {
+        var outcome = ExecApprovalV2InputValidator.Validate(Req("""
+            {
+                "command": ["git", "status"],
+                "commandPreview": "Top-level context",
+                "systemRunPlan": {
+                    "commandPreview": "Stale plan context"
+                }
+            }
+            """));
+
+        Assert.True(outcome.IsValid);
+        Assert.Equal("Top-level context", outcome.Request!.CommandPreview);
     }
 
     [Fact]
@@ -267,6 +304,7 @@ public class ExecApprovalV2InputValidationTests
         Assert.Null(r.Env);
         Assert.Null(r.AgentId);
         Assert.Null(r.SessionKey);
+        Assert.Null(r.CommandPreview);
     }
 
     // -------------------------------------------------------------------------

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalV2NormalizationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalV2NormalizationTests.cs
@@ -18,8 +18,9 @@ public class ExecApprovalV2NormalizationTests
         string? cwd = null,
         IReadOnlyDictionary<string, string>? env = null,
         string? agentId = null,
-        string? sessionKey = null) =>
-        new(argv, shell: null, cwd, timeoutMs: 30_000, env, agentId, sessionKey);
+        string? sessionKey = null,
+        string? commandPreview = null) =>
+        new(argv, shell: null, cwd, timeoutMs: 30_000, env, agentId, sessionKey, commandPreview);
 
     // ── ExecShellWrapperNormalizer ────────────────────────────────────────────
 
@@ -330,7 +331,13 @@ public class ExecApprovalV2NormalizationTests
     public void Normalize_ContextFieldsCarriedThrough()
     {
         var env = new Dictionary<string, string> { ["FOO"] = "bar" };
-        var req = Req(["echo"], cwd: @"C:\tmp", env: env, agentId: "a1", sessionKey: "s1");
+        var req = Req(
+            ["echo"],
+            cwd: @"C:\tmp",
+            env: env,
+            agentId: "a1",
+            sessionKey: "s1",
+            commandPreview: "Inspect environment");
         var outcome = ExecApprovalV2Normalizer.Normalize(req);
 
         Assert.True(outcome.IsResolved);
@@ -338,6 +345,7 @@ public class ExecApprovalV2NormalizationTests
         Assert.Equal(@"C:\tmp", id.Cwd);
         Assert.Equal("a1", id.AgentId);
         Assert.Equal("s1", id.SessionKey);
+        Assert.Equal("Inspect environment", id.CommandPreview);
         Assert.Equal(30_000, id.TimeoutMs);
         Assert.Equal("bar", id.Env!["FOO"]);
     }

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalV2PipelineIntegrationTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalV2PipelineIntegrationTests.cs
@@ -111,6 +111,30 @@ public class ExecApprovalV2PipelineIntegrationTests : IDisposable
     }
 
     [Fact]
+    public async Task CommandPreview_ReachesDialogAsAdditiveContext()
+    {
+        var request = Req("""
+            {
+                "command": ["where", "hello"],
+                "systemRunPlan": {
+                    "commandPreview": "Purpose: locate an executable. Risk: read-only."
+                }
+            }
+            """);
+
+        ExecApprovalPromptView? captured = null;
+        await MakeCoordinator(
+            dialog: _ => ExecApprovalPromptOutcome.Deny,
+            onView: v => captured = v).HandleAsync(request, "preview-1");
+
+        Assert.NotNull(captured);
+        Assert.Contains("where", captured!.CommandText);
+        Assert.Equal(
+            "Purpose: locate an executable. Risk: read-only.",
+            captured.CommandPreviewText);
+    }
+
+    [Fact]
     public async Task DialogDenies_ReturnsUserDenied()
     {
         var result = await MakeCoordinator(dialog: _ => ExecApprovalPromptOutcome.Deny)

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalV2UiPromptHandlerTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalV2UiPromptHandlerTests.cs
@@ -14,10 +14,11 @@ public class ExecApprovalV2UiPromptHandlerTests
 
     private static ExecApprovalV2PromptRequest Request(
         string command = "echo hello", string? cwd = null, string? resolvedPath = null,
-        string agentId = "agent-1") =>
+        string agentId = "agent-1", string? commandPreview = null) =>
         new()
         {
             DisplayCommand = command,
+            CommandPreview = commandPreview,
             Cwd = cwd,
             ResolvedPath = resolvedPath,
             Security = ExecSecurity.Full,
@@ -152,13 +153,38 @@ public class ExecApprovalV2UiPromptHandlerTests
         await handler.PromptAsync(Request(
             command: "echo " + U(0x202E) + "gpj.exe",
             cwd: "C:\\work" + U(0x200B) + "dir",
-            resolvedPath: "C:\\bin\\echo\nfake.exe"));
+            resolvedPath: "C:\\bin\\echo\nfake.exe",
+            commandPreview: "Read only" + U(0x2066) + "context"));
 
         Assert.NotNull(seen);
         Assert.Equal(@"echo \u{202E}gpj.exe", seen!.CommandText);
         Assert.Equal("agent-1", seen.AgentLabel);
         Assert.Equal(@"C:\work\u{200B}dir", seen.CwdText);
         Assert.Equal("C:\\bin\\echo" + @"\u{A}" + "fake.exe", seen.ExecutablePathText);
+        Assert.Equal(@"Read only\u{2066}context", seen.CommandPreviewText);
+    }
+
+    [Fact]
+    public async Task PreviewIsAdditive_ExactCommandRemainsAuthoritative()
+    {
+        ExecApprovalPromptView? seen = null;
+        var handler = Handler((view, _) =>
+        {
+            seen = view;
+            return Task.FromResult(ExecApprovalPromptOutcome.Deny);
+        });
+
+        await handler.PromptAsync(Request(
+            command: "powershell.exe -NoProfile -Command Get-ComputerInfo",
+            commandPreview: "Purpose: read system information. Risk: low."));
+
+        Assert.NotNull(seen);
+        Assert.Equal(
+            "powershell.exe -NoProfile -Command Get-ComputerInfo",
+            seen!.CommandText);
+        Assert.Equal(
+            "Purpose: read system information. Risk: low.",
+            seen.CommandPreviewText);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/ExecApprovalDialogContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ExecApprovalDialogContractTests.cs
@@ -1,0 +1,26 @@
+namespace OpenClaw.Tray.Tests;
+
+public sealed class ExecApprovalDialogContractTests
+{
+    [Fact]
+    public void ExactCommand_IsAddedBeforeAgentSuppliedContext()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            TestRepositoryPaths.GetRepositoryRoot(),
+            "src",
+            "OpenClaw.Tray.WinUI",
+            "Dialogs",
+            "ExecApprovalDialog.cs"));
+
+        var commandIndex = source.IndexOf("Text = view.CommandText", StringComparison.Ordinal);
+        var previewIndex = source.IndexOf(
+            "if (!string.IsNullOrWhiteSpace(view.CommandPreviewText))",
+            StringComparison.Ordinal);
+
+        Assert.True(commandIndex >= 0, "Exact command rendering must remain present.");
+        Assert.True(previewIndex >= 0, "Agent-supplied context rendering must remain present.");
+        Assert.True(
+            commandIndex < previewIndex,
+            "Exact command must be rendered before agent-supplied context.");
+    }
+}


### PR DESCRIPTION
## What changed

- carry OpenClaw's canonical `commandPreview` through `system.run.prepare`, the legacy approval path, and the current V2 approval pipeline
- preserve the existing `Command` / `DisplayCommand` contract as the exact authoritative command
- render the exact command first and the preview as separate, explicitly agent-provided context afterward
- sanitize explanatory context independently: preserve intentional line breaks, escape control/format/BiDi characters, and bound the rendered value
- use the supplied application display name instead of a hard-coded agent name
- keep **Deny** as the default-focused action and keep policy plus configured sandbox controls authoritative
- add the new request-context label across every currently shipped WinUI locale

## Why

The Windows approval prompt currently makes the raw command the operator's primary decision surface. OpenClaw already provides `commandPreview` as a human-readable explanation, but the Windows node did not preserve it through both approval pipelines.

The preview must remain presentation-only. It can help the operator understand purpose, impact, risk, and the recommended decision, but it must never replace the exact command used for policy, audit, or execution. This revision therefore keeps the exact command contract unchanged and adds the preview as a separate field and UI block.

## Security and compatibility

- policy evaluation and execution use only the canonical exact command/argv
- legacy prompt handlers continue to receive the exact command in `ExecApprovalPromptRequest.Command`
- V2 continues to derive `DisplayCommand` from canonical argv
- the preview is never used for policy, executable resolution, allowlist persistence, logging, or execution
- command text keeps the existing command sanitizer; explanatory context uses a separate bounded sanitizer that preserves multi-line structure while escaping spoofing characters
- both legacy and V2 prompts place the exact command before untrusted preview text, preventing newline-heavy context from displacing the approval target

## Validation

Passed locally on the rebased current head:

- `dotnet build src/OpenClaw.Shared/OpenClaw.Shared.csproj --no-restore -c Release` — 0 warnings, 0 errors
- 16 focused Shared regression tests — all passed
- 16 Tray contract/localization validation tests — all passed
- full Shared suite on Linux — 3,196 passed, 31 skipped; 37 Windows/platform or current-main environment failures
- full Tray suite on Linux — 1,942 passed, 2 skipped; 11 Windows/GDI+/current-main source-environment failures

## Real behavior proof

Not verified yet on the rebased head. The Linux container cannot execute `MakePri.exe` or `XamlCompiler.exe`, and the paired Windows validation node was offline during this revision.

Still required before marking ready for review:

- `./build.ps1`
- Shared and Tray test projects on Windows
- `./scripts/validate-mxc-e2e.ps1`
- a redacted current-head approval capture showing separate request context, the exact command, localized actions, and default Deny focus
