### PR TITLE
fix: format compact metric counts with the invariant culture

### DIFF
--- a/src/OpenClaw.Chat/ChatModelChoice.cs
+++ b/src/OpenClaw.Chat/ChatModelChoice.cs
@@ -1,5 +1,6 @@
 namespace OpenClaw.Chat;
 
+using System.Globalization;
 using OpenClaw.Shared;
 
 /// <summary>
@@ -169,14 +170,14 @@ public static class ChatModelLabels
             // Trim a trailing ".0" so 2_000_000 → "2M" not "2.0M".
             return millions == Math.Floor(millions)
                 ? $"{(int)millions}M"
-                : $"{millions:0.#}M";
+                : $"{millions.ToString("0.#", CultureInfo.InvariantCulture)}M";
         }
         if (contextWindow >= 1_000)
         {
             var thousands = contextWindow / 1_000.0;
             return thousands == Math.Floor(thousands)
                 ? $"{(int)thousands}K"
-                : $"{thousands:0.#}K";
+                : $"{thousands.ToString("0.#", CultureInfo.InvariantCulture)}K";
         }
         return contextWindow.ToString();
     }

--- a/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/SessionsPage.xaml.cs
@@ -10,6 +10,7 @@ using OpenClawTray.Windows;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using Windows.Storage;
 using Windows.Storage.Pickers;
@@ -884,8 +885,8 @@ public sealed partial class SessionsPage : Page
 
     private static string FormatTokenCount(long n)
     {
-        if (n >= 1_000_000) return $"{n / 1_000_000.0:0.#}M";
-        if (n >= 1_000) return $"{n / 1_000.0:0.#}K";
+        if (n >= 1_000_000) return $"{(n / 1_000_000.0).ToString("0.#", CultureInfo.InvariantCulture)}M";
+        if (n >= 1_000) return $"{(n / 1_000.0).ToString("0.#", CultureInfo.InvariantCulture)}K";
         return n.ToString();
     }
 

--- a/src/OpenClaw.Tray.WinUI/Pages/WorkspaceFilesModel.cs
+++ b/src/OpenClaw.Tray.WinUI/Pages/WorkspaceFilesModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using OpenClaw.Shared;
@@ -300,8 +301,8 @@ internal static class WorkspaceFilesModel
     {
         if (bytes is not { } b || b < 0) return string.Empty;
         if (b < 1024) return $"{b} B";
-        if (b < 1024 * 1024) return $"{b / 1024.0:F1} KB";
-        return $"{b / (1024.0 * 1024.0):F1} MB";
+        if (b < 1024 * 1024) return $"{(b / 1024.0).ToString("F1", CultureInfo.InvariantCulture)} KB";
+        return $"{(b / (1024.0 * 1024.0)).ToString("F1", CultureInfo.InvariantCulture)} MB";
     }
 
     /// <summary>

--- a/src/OpenClaw.Tray.WinUI/Services/TrayDashboardSummary.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/TrayDashboardSummary.cs
@@ -261,8 +261,8 @@ internal sealed class TrayDashboardSummaryBuilder
 
     private static string FormatTokenCount(long n)
     {
-        if (n >= 1_000_000) return $"{n / 1_000_000.0:F1}M";
-        if (n >= 1_000) return $"{n / 1_000.0:F1}K";
+        if (n >= 1_000_000) return $"{(n / 1_000_000.0).ToString("F1", CultureInfo.InvariantCulture)}M";
+        if (n >= 1_000) return $"{(n / 1_000.0).ToString("F1", CultureInfo.InvariantCulture)}K";
         return n.ToString(CultureInfo.InvariantCulture);
     }
 

--- a/src/OpenClaw.Tray.WinUI/Services/TrayMenuStateBuilder.cs
+++ b/src/OpenClaw.Tray.WinUI/Services/TrayMenuStateBuilder.cs
@@ -348,8 +348,8 @@ internal sealed class TrayMenuStateBuilder
 
     private static string FormatTokenCount(long n)
     {
-        if (n >= 1_000_000) return $"{n / 1_000_000.0:F1}M";
-        if (n >= 1_000) return $"{n / 1_000.0:F1}K";
+        if (n >= 1_000_000) return $"{(n / 1_000_000.0).ToString("F1", CultureInfo.InvariantCulture)}M";
+        if (n >= 1_000) return $"{(n / 1_000.0).ToString("F1", CultureInfo.InvariantCulture)}K";
         return n.ToString();
     }
 


### PR DESCRIPTION
## Summary

Compact metric labels were interpolated with the current culture, so on a non-English Windows the decimal separator rendered as a comma (for example `2,5K tokens` or `2,0 KB`) while adjacent cost values already used the invariant culture. This forces the invariant culture on every compact count, keeping the rendered text consistent regardless of the OS locale.

Affected formatters:
- `TrayDashboardSummary.FormatTokenCount`
- `TrayMenuStateBuilder.FormatTokenCount`
- `SessionsPage.FormatTokenCount`
- `ChatModelChoice.FormatContextWindow`
- `WorkspaceFilesModel.FormatSize`

Cost formatting already used `CultureInfo.InvariantCulture`; the compact count paths next to it were the only ones left on the current culture. Behavior on an English host (and CI) is unchanged.

## Validation

- `./build.ps1` — green (all projects)
- `dotnet test ./tests/OpenClaw.Shared.Tests` — 2925 passed, 31 skipped, 0 failed
- `dotnet test ./tests/OpenClaw.Tray.Tests` — 1823 passed, 0 failed

## Real behavior proof

Live test output captured on a Spanish (`es-ES`, comma-decimal) Windows host, on the PR head, with no globalization override. The compact formatters render decimal-dot output on a comma-decimal locale. Note the runner's own total line prints `1,8377 Segundos` with a comma, confirming the host culture is comma-decimal.

```
CurrentCulture: es-ES

Passed ChatModelChoiceTests.FormatContextWindow_FormatsCompactly(contextWindow: 1500000, expected: "1.5M")
Passed WorkspaceFilesModelTests.FormatSize_ProducesHumanReadable(bytes: 2048, expected: "2.0 KB")
Passed WorkspaceFilesModelTests.FormatSize_ProducesHumanReadable(bytes: 5242880, expected: "5.0 MB")
Passed ChatModelChoiceTests.FormatContextWindow_FormatsCompactly(contextWindow: 200000, expected: "200K")
Passed TrayDashboardSummaryBuilderTests.MetricsLine_FormatsMillionsTokenCount
Passed TrayDashboardSummaryBuilderTests.MetricsLine_SubCentCost_FallsBackToTokens

Pruebas totales: 15
     Correcto: 15
 Tiempo total: 1,8377 Segundos
```

On the same host before the change these same cases failed, asserting decimal-dot labels against comma-formatted output (`2,5K`, `2,0 KB`). After the change all pass with no culture override.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
