### PR TITLE
fix(chat): show effective model context budget

### DIFF
--- a/src/OpenClaw.Chat/ChatModelChoice.cs
+++ b/src/OpenClaw.Chat/ChatModelChoice.cs
@@ -9,7 +9,8 @@ using OpenClaw.Shared;
 /// <param name="Id">Wire model id (e.g. <c>claude-opus-4.8</c>).</param>
 /// <param name="DisplayName">Human-friendly label (falls back to <paramref name="Id"/>).</param>
 /// <param name="Provider">Owning provider (e.g. <c>OpenAI</c>, <c>Anthropic</c>), when known.</param>
-/// <param name="ContextWindow">Context-window size in tokens, when known.</param>
+/// <param name="ContextWindow">Native/catalog context-window size in tokens, when known.</param>
+/// <param name="ContextTokens">Effective runtime context budget in tokens, when known.</param>
 /// <param name="IsConfigured">True when the provider is configured on the gateway.</param>
 /// <param name="IsAvailable">
 /// True when the model can be selected right now. When false the picker shows it
@@ -25,6 +26,7 @@ public sealed record ChatModelChoice(
     string DisplayName,
     string? Provider = null,
     int? ContextWindow = null,
+    int? ContextTokens = null,
     bool IsConfigured = true,
     bool IsAvailable = true,
     bool RequiresAuth = false,
@@ -64,6 +66,7 @@ public sealed record ChatModelChoice(
                 DisplayName: m.DisplayName,
                 Provider: m.Provider,
                 ContextWindow: m.ContextWindow,
+                ContextTokens: m.ContextTokens,
                 IsConfigured: m.IsConfigured,
                 IsAvailable: m.IsAvailable,
                 RequiresAuth: m.RequiresAuth,
@@ -183,13 +186,25 @@ public static class ChatModelLabels
     }
 
     /// <summary>
-    /// Builds the secondary metadata segment ("OpenAI · 272K") from provider and
-    /// context window, or an empty string when neither is known.
+    /// Builds the secondary metadata segment from provider and context metadata.
+    /// Runtime budget is shown first when available; a differing native/catalog
+    /// window follows it. Older gateways that only expose a context window keep
+    /// the original unqualified display.
     /// </summary>
     public static string BuildMetaSegment(ChatModelChoice choice)
     {
         var hasProvider = !string.IsNullOrWhiteSpace(choice.Provider);
-        var ctx = choice.ContextWindow is { } cw ? FormatContextWindow(cw) : string.Empty;
+        var runtime = choice.ContextTokens is { } ct ? FormatContextWindow(ct) : string.Empty;
+        var native = choice.ContextWindow is { } cw ? FormatContextWindow(cw) : string.Empty;
+        var ctx = runtime.Length > 0
+            ? $"{runtime} runtime"
+            : native;
+        if (runtime.Length > 0
+            && native.Length > 0
+            && !string.Equals(runtime, native, StringComparison.Ordinal))
+        {
+            ctx = $"{ctx} · {native} native";
+        }
         var hasCtx = ctx.Length > 0;
 
         if (hasProvider && hasCtx) return $"{choice.Provider} · {ctx}";

--- a/src/OpenClaw.Chat/ChatModelChoice.cs
+++ b/src/OpenClaw.Chat/ChatModelChoice.cs
@@ -164,7 +164,10 @@ public static class ChatModelLabels
     /// Compact token-count label: 272000 → "272K", 1_048_576 → "1M",
     /// 200000 → "200K". Falls back to the raw number for small values.
     /// </summary>
-    public static string FormatContextWindow(int contextWindow)
+    public static string FormatContextWindow(int contextWindow) =>
+        FormatContextWindow(contextWindow, "0.#");
+
+    private static string FormatContextWindow(int contextWindow, string fractionalFormat)
     {
         if (contextWindow <= 0) return string.Empty;
         if (contextWindow >= 1_000_000)
@@ -173,16 +176,35 @@ public static class ChatModelLabels
             // Trim a trailing ".0" so 2_000_000 → "2M" not "2.0M".
             return millions == Math.Floor(millions)
                 ? $"{(int)millions}M"
-                : $"{millions.ToString("0.#", CultureInfo.InvariantCulture)}M";
+                : $"{millions.ToString(fractionalFormat, CultureInfo.InvariantCulture)}M";
         }
         if (contextWindow >= 1_000)
         {
             var thousands = contextWindow / 1_000.0;
             return thousands == Math.Floor(thousands)
                 ? $"{(int)thousands}K"
-                : $"{thousands.ToString("0.#", CultureInfo.InvariantCulture)}K";
+                : $"{thousands.ToString(fractionalFormat, CultureInfo.InvariantCulture)}K";
         }
-        return contextWindow.ToString();
+        return contextWindow.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static (string Runtime, string Native) FormatDistinctContextValues(
+        int runtimeTokens,
+        int nativeTokens)
+    {
+        var runtime = FormatContextWindow(runtimeTokens);
+        var native = FormatContextWindow(nativeTokens);
+        if (!string.Equals(runtime, native, StringComparison.Ordinal))
+            return (runtime, native);
+
+        runtime = FormatContextWindow(runtimeTokens, "0.###");
+        native = FormatContextWindow(nativeTokens, "0.###");
+        if (!string.Equals(runtime, native, StringComparison.Ordinal))
+            return (runtime, native);
+
+        return (
+            runtimeTokens.ToString("N0", CultureInfo.InvariantCulture),
+            nativeTokens.ToString("N0", CultureInfo.InvariantCulture));
     }
 
     /// <summary>
@@ -194,16 +216,32 @@ public static class ChatModelLabels
     public static string BuildMetaSegment(ChatModelChoice choice)
     {
         var hasProvider = !string.IsNullOrWhiteSpace(choice.Provider);
-        var runtime = choice.ContextTokens is { } ct ? FormatContextWindow(ct) : string.Empty;
-        var native = choice.ContextWindow is { } cw ? FormatContextWindow(cw) : string.Empty;
-        var ctx = runtime.Length > 0
-            ? $"{runtime} runtime"
-            : native;
-        if (runtime.Length > 0
-            && native.Length > 0
-            && !string.Equals(runtime, native, StringComparison.Ordinal))
+        var runtimeTokens = choice.ContextTokens is > 0 ? choice.ContextTokens : null;
+        var nativeTokens = choice.ContextWindow is > 0 ? choice.ContextWindow : null;
+        string ctx;
+
+        if (runtimeTokens is { } runtime)
         {
-            ctx = $"{ctx} · {native} native";
+            if (nativeTokens is { } native)
+            {
+                if (runtime == native)
+                {
+                    ctx = FormatContextWindow(runtime);
+                }
+                else
+                {
+                    var labels = FormatDistinctContextValues(runtime, native);
+                    ctx = $"{labels.Runtime} runtime · {labels.Native} native";
+                }
+            }
+            else
+            {
+                ctx = $"{FormatContextWindow(runtime)} runtime";
+            }
+        }
+        else
+        {
+            ctx = nativeTokens is { } native ? FormatContextWindow(native) : string.Empty;
         }
         var hasCtx = ctx.Length > 0;
 

--- a/src/OpenClaw.Shared/Models.cs
+++ b/src/OpenClaw.Shared/Models.cs
@@ -2106,6 +2106,7 @@ public class ModelInfo
     public string? Name { get; set; }
     public string? Provider { get; set; }
     public int? ContextWindow { get; set; }
+    public int? ContextTokens { get; set; }
 
     /// <summary>True when the model's provider is configured on the gateway.</summary>
     public bool IsConfigured { get; set; }

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -4270,8 +4270,8 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
                         Id = item.TryGetProperty("id", out var id) ? id.GetString() ?? "" : "",
                         Name = item.TryGetProperty("name", out var name) ? name.GetString() : null,
                         Provider = item.TryGetProperty("provider", out var prov) ? prov.GetString() : null,
-                        ContextWindow = item.TryGetProperty("contextWindow", out var cw) && cw.ValueKind == JsonValueKind.Number ? cw.GetInt32() : null,
-                        ContextTokens = item.TryGetProperty("contextTokens", out var ct) && ct.ValueKind == JsonValueKind.Number ? ct.GetInt32() : null,
+                        ContextWindow = ReadPositiveInt32(item, "contextWindow"),
+                        ContextTokens = ReadPositiveInt32(item, "contextTokens"),
                         IsConfigured = hasConfiguredFlag && cfg.ValueKind == JsonValueKind.True,
                         HasConfiguredFlag = hasConfiguredFlag,
                         IsDefault = ReadBool(item, "default", "isDefault"),
@@ -4288,6 +4288,19 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
         {
             _logger.Warn($"Failed to parse models.list: {ex.Message}");
         }
+    }
+
+    private static int? ReadPositiveInt32(JsonElement obj, string key)
+    {
+        if (!obj.TryGetProperty(key, out var value)
+            || value.ValueKind != JsonValueKind.Number
+            || !value.TryGetInt32(out var parsed)
+            || parsed <= 0)
+        {
+            return null;
+        }
+
+        return parsed;
     }
 
     // Reads the first present boolean property among <paramref name="keys"/>.

--- a/src/OpenClaw.Shared/OpenClawGatewayClient.cs
+++ b/src/OpenClaw.Shared/OpenClawGatewayClient.cs
@@ -4271,6 +4271,7 @@ public partial class OpenClawGatewayClient : WebSocketClientBase, IOperatorGatew
                         Name = item.TryGetProperty("name", out var name) ? name.GetString() : null,
                         Provider = item.TryGetProperty("provider", out var prov) ? prov.GetString() : null,
                         ContextWindow = item.TryGetProperty("contextWindow", out var cw) && cw.ValueKind == JsonValueKind.Number ? cw.GetInt32() : null,
+                        ContextTokens = item.TryGetProperty("contextTokens", out var ct) && ct.ValueKind == JsonValueKind.Number ? ct.GetInt32() : null,
                         IsConfigured = hasConfiguredFlag && cfg.ValueKind == JsonValueKind.True,
                         HasConfiguredFlag = hasConfiguredFlag,
                         IsDefault = ReadBool(item, "default", "isDefault"),

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -2147,6 +2147,40 @@ public class OpenClawGatewayClientTests
     }
 
     [Fact]
+    public void ParseModelsList_PreservesRuntimeAndNativeContextMetadata()
+    {
+        var helper = new GatewayClientTestHelper();
+        var info = helper.ParseModelsListPayload("""
+            {
+              "models": [
+                {
+                  "id": "gpt-5.4",
+                  "contextWindow": 1000000,
+                  "contextTokens": 272000
+                },
+                {
+                  "id": "legacy-model",
+                  "contextWindow": 128000
+                }
+              ]
+            }
+            """);
+
+        Assert.Collection(
+            info.Models,
+            current =>
+            {
+                Assert.Equal(1000000, current.ContextWindow);
+                Assert.Equal(272000, current.ContextTokens);
+            },
+            legacy =>
+            {
+                Assert.Equal(128000, legacy.ContextWindow);
+                Assert.Null(legacy.ContextTokens);
+            });
+    }
+
+    [Fact]
     public void ParseModelsList_DefaultsAvailableTrue_WhenNoReadinessSignals()
     {
         var helper = new GatewayClientTestHelper();

--- a/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
+++ b/tests/OpenClaw.Shared.Tests/OpenClawGatewayClientTests.cs
@@ -2181,6 +2181,65 @@ public class OpenClawGatewayClientTests
     }
 
     [Fact]
+    public void ParseModelsList_InvalidContextMetadata_DoesNotDropModelsOrValidFields()
+    {
+        var helper = new GatewayClientTestHelper();
+        var info = helper.ParseModelsListPayload("""
+            {
+              "models": [
+                {
+                  "id": "valid-native",
+                  "contextWindow": 128000,
+                  "contextTokens": 128000.5
+                },
+                {
+                  "id": "valid-runtime",
+                  "contextWindow": 2147483648,
+                  "contextTokens": 272000
+                },
+                {
+                  "id": "non-positive",
+                  "contextWindow": 0,
+                  "contextTokens": -1
+                },
+                {
+                  "id": "unaffected",
+                  "contextWindow": 64000,
+                  "contextTokens": 32000
+                }
+              ]
+            }
+            """);
+
+        Assert.Collection(
+            info.Models,
+            native =>
+            {
+                Assert.Equal("valid-native", native.Id);
+                Assert.Equal(128000, native.ContextWindow);
+                Assert.Null(native.ContextTokens);
+            },
+            runtime =>
+            {
+                Assert.Equal("valid-runtime", runtime.Id);
+                Assert.Null(runtime.ContextWindow);
+                Assert.Equal(272000, runtime.ContextTokens);
+            },
+            nonPositive =>
+            {
+                Assert.Equal("non-positive", nonPositive.Id);
+                Assert.Null(nonPositive.ContextWindow);
+                Assert.Null(nonPositive.ContextTokens);
+            },
+            unaffected =>
+            {
+                Assert.Equal("unaffected", unaffected.Id);
+                Assert.Equal(64000, unaffected.ContextWindow);
+                Assert.Equal(32000, unaffected.ContextTokens);
+            });
+    }
+
+    [Fact]
     public void ParseModelsList_DefaultsAvailableTrue_WhenNoReadinessSignals()
     {
         var helper = new GatewayClientTestHelper();

--- a/tests/OpenClaw.Tray.Tests/ChatModelChoiceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatModelChoiceTests.cs
@@ -20,6 +20,7 @@ public class ChatModelChoiceTests
                     Name = "Claude Opus 4.8",
                     Provider = "Anthropic",
                     ContextWindow = 200000,
+                    ContextTokens = 180000,
                     IsConfigured = true,
                     IsDefault = true,
                     IsAvailable = true,
@@ -36,6 +37,7 @@ public class ChatModelChoiceTests
         Assert.Equal("Claude Opus 4.8", c.DisplayName);
         Assert.Equal("Anthropic", c.Provider);
         Assert.Equal(200000, c.ContextWindow);
+        Assert.Equal(180000, c.ContextTokens);
         Assert.True(c.IsConfigured);
         Assert.True(c.IsDefault);
         Assert.True(c.IsAvailable);
@@ -191,14 +193,53 @@ public class ChatModelChoiceTests
     // ── Meta segment ─────────────────────────────────────────────────────
 
     [Fact]
-    public void BuildMetaSegment_CombinesProviderAndContext()
+    public void BuildMetaSegment_DifferingRuntimeAndNative_ShowsRuntimeFirst()
+    {
+        var c = new ChatModelChoice(
+            "x",
+            "X",
+            Provider: "OpenAI",
+            ContextWindow: 1000000,
+            ContextTokens: 272000);
+
+        Assert.Equal("OpenAI · 272K runtime · 1M native", ChatModelLabels.BuildMetaSegment(c));
+    }
+
+    [Fact]
+    public void BuildMetaSegment_EqualRuntimeAndNative_ShowsRuntimeOnce()
+    {
+        var c = new ChatModelChoice(
+            "x",
+            "X",
+            Provider: "OpenAI",
+            ContextWindow: 272000,
+            ContextTokens: 272000);
+
+        Assert.Equal("OpenAI · 272K runtime", ChatModelLabels.BuildMetaSegment(c));
+    }
+
+    [Fact]
+    public void BuildMetaSegment_DifferentValuesWithSameCompactLabel_ShowsRuntimeOnce()
+    {
+        var c = new ChatModelChoice(
+            "x",
+            "X",
+            Provider: "OpenAI",
+            ContextWindow: 1049000,
+            ContextTokens: 1000001);
+
+        Assert.Equal("OpenAI · 1M runtime", ChatModelLabels.BuildMetaSegment(c));
+    }
+
+    [Fact]
+    public void BuildMetaSegment_RuntimeMissing_FallsBackToNativeWindow()
     {
         var c = new ChatModelChoice("x", "X", Provider: "OpenAI", ContextWindow: 272000);
         Assert.Equal("OpenAI · 272K", ChatModelLabels.BuildMetaSegment(c));
     }
 
     [Fact]
-    public void BuildMetaSegment_ProviderOnly()
+    public void BuildMetaSegment_BothContextsMissing_PreservesProviderOnly()
     {
         var c = new ChatModelChoice("x", "X", Provider: "OpenAI");
         Assert.Equal("OpenAI", ChatModelLabels.BuildMetaSegment(c));

--- a/tests/OpenClaw.Tray.Tests/ChatModelChoiceTests.cs
+++ b/tests/OpenClaw.Tray.Tests/ChatModelChoiceTests.cs
@@ -206,7 +206,20 @@ public class ChatModelChoiceTests
     }
 
     [Fact]
-    public void BuildMetaSegment_EqualRuntimeAndNative_ShowsRuntimeOnce()
+    public void BuildMetaSegment_RuntimeExceedsNative_DoesNotClampOrReorder()
+    {
+        var c = new ChatModelChoice(
+            "x",
+            "X",
+            Provider: "OpenAI",
+            ContextWindow: 272000,
+            ContextTokens: 1000000);
+
+        Assert.Equal("OpenAI · 1M runtime · 272K native", ChatModelLabels.BuildMetaSegment(c));
+    }
+
+    [Fact]
+    public void BuildMetaSegment_EqualRuntimeAndNative_ShowsUnqualifiedValueOnce()
     {
         var c = new ChatModelChoice(
             "x",
@@ -215,11 +228,11 @@ public class ChatModelChoiceTests
             ContextWindow: 272000,
             ContextTokens: 272000);
 
-        Assert.Equal("OpenAI · 272K runtime", ChatModelLabels.BuildMetaSegment(c));
+        Assert.Equal("OpenAI · 272K", ChatModelLabels.BuildMetaSegment(c));
     }
 
     [Fact]
-    public void BuildMetaSegment_DifferentValuesWithSameCompactLabel_ShowsRuntimeOnce()
+    public void BuildMetaSegment_DifferentValuesWithSameCompactLabel_UsesHigherPrecision()
     {
         var c = new ChatModelChoice(
             "x",
@@ -228,7 +241,29 @@ public class ChatModelChoiceTests
             ContextWindow: 1049000,
             ContextTokens: 1000001);
 
-        Assert.Equal("OpenAI · 1M runtime", ChatModelLabels.BuildMetaSegment(c));
+        Assert.Equal("OpenAI · 1M runtime · 1.049M native", ChatModelLabels.BuildMetaSegment(c));
+    }
+
+    [Fact]
+    public void BuildMetaSegment_DifferentValuesStillColliding_UsesExactInvariantValues()
+    {
+        var c = new ChatModelChoice(
+            "x",
+            "X",
+            Provider: "OpenAI",
+            ContextWindow: 1000002,
+            ContextTokens: 1000001);
+
+        Assert.Equal(
+            "OpenAI · 1,000,001 runtime · 1,000,002 native",
+            ChatModelLabels.BuildMetaSegment(c));
+    }
+
+    [Fact]
+    public void BuildMetaSegment_RuntimeOnly_QualifiesRuntimeValue()
+    {
+        var c = new ChatModelChoice("x", "X", Provider: "OpenAI", ContextTokens: 272000);
+        Assert.Equal("OpenAI · 272K runtime", ChatModelLabels.BuildMetaSegment(c));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #993

## Summary

- preserve optional Gateway `contextTokens` through the existing `ModelInfo` / `models.list` parsing path
- display raw-equal runtime/native budgets once as the existing unqualified compact value
- display every raw difference as `runtime · native`, escalating compact precision and then using invariant exact values when rounded labels collide
- parse invalid, fractional, overflowing, or non-positive optional context metadata as `null` per field/row instead of dropping the `models.list` payload
- preserve runtime-only, `contextWindow`-only, provider-only, and runtime-greater-than-native metadata without clamping

## Validation

- `./build.ps1` - passed
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore` - 2,927 passed, 31 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore` - 1,829 passed
- focused `OpenClawGatewayClientTests.ParseModelsList*` - 7 passed
- focused `ChatModelChoiceTests` - 44 passed
- rubber-duck follow-up review - no blocking or non-blocking findings

The structured autoreview helper was also attempted, but its Codex subprocess failed during temporary PATH/helper isolation before producing findings. The repository-required rubber-duck review completed cleanly.

## Real behavior proof

Production tests exercise the actual `ParseModelsList` event path and `ChatModelChoice` projection/label code, proving:

- differing values: `OpenAI · 272K runtime · 1M native`
- equal raw values: `OpenAI · 272K`
- runtime exceeds native without clamping: `OpenAI · 1M runtime · 272K native`
- compact collision with adaptive precision: `OpenAI · 1M runtime · 1.049M native`
- persistent collision with exact invariant fallback: `OpenAI · 1,000,001 runtime · 1,000,002 native`
- runtime-only: `OpenAI · 272K runtime`
- native-only: `OpenAI · 272K`
- neither context value: `OpenAI`
- fractional/overflow/non-positive metadata becomes `null` without dropping rows or an independently valid context field

**Isolated current-head picker capture: Not verified / blocked.** Current upstream `openclaw/openclaw` at `a52eb213` still exposes only positive `contextWindow` in the public `ModelChoiceSchema`, and its `models.list` test still asserts that `contextTokens` is not exposed. The isolated tray has no separate gateway/model fixture that emits both fields, so it cannot receive the runtime/native pair needed to visibly exercise this branch. This PR intentionally makes the Windows client compatible with Gateway versions/fixtures that do emit `contextTokens`; it does not change Gateway metadata.