### PR TITLE
fix(localization): restore Dutch resource parity

### DIFF
--- a/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
+++ b/src/OpenClaw.Tray.WinUI/Strings/nl-nl/Resources.resw
@@ -3162,7 +3162,7 @@ Opdrachten worden geblokkeerd zolang sandboxing niet beschikbaar is, omdat strik
     <value>De gateway heeft de cron.run-aanvraag geweigerd.</value>
   </data>
   <data name="AppNotification_CronRunFailed_MessageFormat" xml:space="preserve">
-    <value>{0}: {1}</value>
+    <value>Kan {0} niet starten: {1}</value>
   </data>
   <data name="NotificationsPage_Title.Text" xml:space="preserve">
     <value>Meldingen</value>
@@ -6278,7 +6278,7 @@ Controleer of de gateway actief is.</value>
     <value>Validatiefouten oplossen</value>
   </data>
   <data name="ConfigPage_StatusValidationErrorMessageFormat" xml:space="preserve">
-    <value>{0}: {1}</value>
+    <value>Validatiefout bij {0}: {1}</value>
   </data>
   <data name="ConfigPage_StatusNotConnectedTitle" xml:space="preserve">
     <value>Niet verbonden</value>


### PR DESCRIPTION
## Summary

- Repair the localization parity regression introduced by #1037.
- Replace the two English-identical Dutch format values with natural Dutch messages.
- Preserve `{0}` and `{1}` exactly and keep the copy free of em dashes.

## Validation

- Passed: `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --filter "FullyQualifiedName~LocalizationValidationTests.Resources_AreTranslatedAllOrNoneAcrossNonEnglishLocales"` (1 passed).
- Passed: `.\build.ps1`.
- Passed: `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` (3,080 passed, 31 skipped).
- Passed: `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` (1,851 passed).
- Passed: `git diff --check`.

## Real behavior proof

- Current-head focused localization validation loads all five locale resource files and confirms both keys are no longer partially identical to English.
- Dutch runtime formats are now `Kan {0} niet starten: {1}` and `Validatiefout bij {0}: {1}`.
- Not visually captured: both messages require forcing separate cron-run and config-validation failure states under a Dutch Windows locale. The runtime formatting call sites are unchanged.

## Review notes

- Structured autoreview was blocked because its source-aware bundle included the full 624 KB resource file, exceeding the 180 KB safety limit; the actual patch is 1.1 KB across two values.
- Rubber-duck review was skipped because this is a trivial localization-only correction with no control-flow or contract changes.