### PR TITLE
fix: reject shell interpreters as approved exec targets

### DIFF
--- a/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
+++ b/src/OpenClaw.Shared/Capabilities/SystemCapability.cs
@@ -73,8 +73,6 @@ public class SystemCapability : NodeCapabilityBase
         "installutil",
         "msbuild",
         "wmic",
-        "cscript",
-        "wscript",
         "certutil",
         "bitsadmin",
         "curl",
@@ -1101,21 +1099,23 @@ public class SystemCapability : NodeCapabilityBase
             // A remote .set call should never be able to whitelist a specific binary
             // by path — that would be a two-step EoP (compromise MCP token → whitelist
             // attacker binary → invoke it). Legitimate rules name commands, not paths.
-            // Strip one layer of matching surrounding quotes first so quoted forms
-            // ("C:\evil.exe", 'C:\evil.exe') are caught alongside bare paths.
+            // Parse the executable token first so quoted paths remain one token even
+            // when the rule includes arguments.
             // Covers: drive-rooted paths (C:\, C:/), UNC/long-path (\\, //), and
             // forward-slash UNC namespace forms (//server/share, //?/C:/evil.exe).
-            var unquoted = normalized;
-            if (normalized.Length >= 2 &&
-                ((normalized[0] == '"' && normalized[^1] == '"') ||
-                 (normalized[0] == '\'' && normalized[^1] == '\'')))
-                unquoted = normalized[1..^1];
+            var executableToken = ExecCommandToken.ParseFirstToken(normalized);
+            if (executableToken is null)
+                return $"Allow rule must begin with a valid executable token: {pattern}";
 
-            if (unquoted.Length >= 3 &&
-                ((char.IsLetter(unquoted[0]) && unquoted[1] == ':' && (unquoted[2] == '\\' || unquoted[2] == '/')) ||
-                 unquoted.StartsWith(@"\\", StringComparison.Ordinal) ||
-                 unquoted.StartsWith("//", StringComparison.Ordinal)))
+            var pathToken = executableToken;
+            if (pathToken.Length >= 3 &&
+                ((char.IsLetter(pathToken[0]) && pathToken[1] == ':' && (pathToken[2] == '\\' || pathToken[2] == '/')) ||
+                 pathToken.StartsWith(@"\\", StringComparison.Ordinal) ||
+                 pathToken.StartsWith("//", StringComparison.Ordinal)))
                 return $"Absolute path allow rule is not permitted: {pattern}";
+
+            if (ExecCommandToken.IsIndirectCommandHost(executableToken))
+                return $"Allow rules cannot target shell interpreters or command hosts: {pattern}";
 
             foreach (var dangerous in DangerousAllowPatternFragments)
             {
@@ -1138,8 +1138,7 @@ public class SystemCapability : NodeCapabilityBase
             // * -> .* over the whole command line), e.g. "*.*", "*e*", "*.exe", "c*" — the broad-allow
             // class the earlier shape checks miss. Runs after the dangerous-fragment check so a
             // dangerous stem keeps its specific message. Legit rules pin the command ("git *").
-            var firstToken = normalized.Split(new[] { ' ', '\t' }, 2)[0];
-            if (firstToken.Contains('*') || firstToken.Contains('?'))
+            if (executableToken.Contains('*') || executableToken.Contains('?'))
                 return $"Allow rule must name a concrete command (no wildcard in the executable): {pattern}";
         }
 

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
@@ -253,6 +253,15 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
             || resolvedPath.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase))
             return null;
 
+        // Same failure mode one level up: a shell interpreter invoked directly
+        // (cmd.exe, powershell, bash -c, …) re-parses its own argument tail, so the
+        // approved argv would not reach a single process verbatim — the shell can run
+        // commands the user never saw approved. Argument quoting cannot be trusted to
+        // neutralize this (cmd.exe has its own splitting rules), so fail closed rather
+        // than execute a command whose real effect differs from the approved text.
+        if (ExecCommandToken.IsShellInterpreter(resolvedPath))
+            return null;
+
         // If any env wrapper in the chain carries modifiers (VAR=val assignments or
         // flags), the direct-argv payload cannot faithfully carry those semantics: the
         // modifier would be silently dropped, and the process would run in a different

--- a/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecApprovalsCoordinator.cs
@@ -99,6 +99,18 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
                 promptAttempted: false, fallbackUsed: false, canonical: context.DisplayCommand);
         if (pass1 is ExecHostPolicyDecision.AllowOutcome)
         {
+            // A stored executable-level rule must not authorize a command host whose
+            // argument tail selects a different command or script. Preserve the store
+            // verbatim, but refuse to consume that rule for this invocation.
+            if (context.Security == ExecSecurity.Allowlist
+                && context.AllowlistSatisfied
+                && IsIndirectCommandHost(identity))
+                return LogAndReturn(
+                    ExecApprovalV2Result.ValidationFailed(
+                        "persistent-approval-not-permitted-for-command-host"),
+                    correlationId, promptAttempted: false, fallbackUsed: false,
+                    canonical: context.DisplayCommand);
+
             // Pre-approved path (security=Full, ask=Off or allowlist satisfied): skip prompt.
             // Fail closed if the approved executable cannot be pinned to a resolved path.
             var preApprovedExecution = BuildApprovedExecution(identity, sanitizedEnv);
@@ -119,6 +131,7 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
         // Steps 5-8: prompt/fallback + second pass (critical section) + side effect flag
         bool promptAttempted = false;
         bool fallbackUsed = false;
+        bool fallbackAllowWasMatchDependent = false;
         bool persistAllowlistEntry = false;
 
         await _promptLock.WaitAsync().ConfigureAwait(false);
@@ -169,7 +182,10 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
             else
             {
                 fallbackUsed = true;
-                followupDecision = FallbackDecision(context, resolved.Defaults.AskFallback);
+                followupDecision = FallbackDecision(
+                    context,
+                    resolved.Defaults.AskFallback,
+                    out fallbackAllowWasMatchDependent);
             }
 
             // Step 7: second pass — must never return RequiresPrompt
@@ -198,6 +214,15 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
         if (execution is null)
             return LogAndReturn(ExecApprovalV2Result.InternalError("unresolved-executable-on-allow"),
                 correlationId, promptAttempted, fallbackUsed, canonical: context.DisplayCommand);
+
+        var durableCommandHostAuthorization =
+            persistAllowlistEntry || fallbackAllowWasMatchDependent;
+        if (durableCommandHostAuthorization && IsIndirectCommandHost(identity))
+            return LogAndReturn(
+                ExecApprovalV2Result.ValidationFailed(
+                    "persistent-approval-not-permitted-for-command-host"),
+                correlationId, promptAttempted, fallbackUsed,
+                canonical: context.DisplayCommand);
 
         // Step 9: side effects — only reached when the payload is valid.
         // Each side effect is independently best-effort so a failure in one does not skip the other.
@@ -253,15 +278,6 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
             || resolvedPath.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase))
             return null;
 
-        // Same failure mode one level up: a shell interpreter invoked directly
-        // (cmd.exe, powershell, bash -c, …) re-parses its own argument tail, so the
-        // approved argv would not reach a single process verbatim — the shell can run
-        // commands the user never saw approved. Argument quoting cannot be trusted to
-        // neutralize this (cmd.exe has its own splitting rules), so fail closed rather
-        // than execute a command whose real effect differs from the approved text.
-        if (ExecCommandToken.IsShellInterpreter(resolvedPath))
-            return null;
-
         // If any env wrapper in the chain carries modifiers (VAR=val assignments or
         // flags), the direct-argv payload cannot faithfully carry those semantics: the
         // modifier would be silently dropped, and the process would run in a different
@@ -281,6 +297,13 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
             argv[i] = effective[i];
 
         return new ExecApprovedExecution(argv, identity.Cwd, identity.TimeoutMs, sanitizedEnv);
+    }
+
+    private static bool IsIndirectCommandHost(CanonicalCommandIdentity identity)
+    {
+        var resolvedPath = identity.Resolution?.ResolvedPath;
+        return !string.IsNullOrWhiteSpace(resolvedPath)
+            && ExecCommandToken.IsIndirectCommandHost(resolvedPath);
     }
 
     // Persists allowAlways patterns after an AllowAlways prompt decision (non-empty only).
@@ -318,15 +341,22 @@ public sealed class ExecApprovalsCoordinator : IExecApprovalV2Handler
     // ask=Always → Deny: human approval is a precondition; without UI the only safe outcome is deny.
     private static ExecApprovalDecision FallbackDecision(
         ExecApprovalEvaluation context,
-        ExecSecurity askFallback)
+        ExecSecurity askFallback,
+        out bool allowWasMatchDependent)
     {
+        allowWasMatchDependent = false;
         var effectiveFallback = (ExecSecurity)Math.Min((int)context.Security, (int)askFallback);
+        if (effectiveFallback == ExecSecurity.Allowlist
+            && context.AllAllowlistResolutionsMatched)
+        {
+            allowWasMatchDependent = true;
+            return ExecApprovalDecision.AllowOnce;
+        }
+
         return effectiveFallback switch
         {
             ExecSecurity.Full => ExecApprovalDecision.AllowOnce,
-            ExecSecurity.Allowlist => context.AllAllowlistResolutionsMatched
-                ? ExecApprovalDecision.AllowOnce
-                : ExecApprovalDecision.Deny,
+            ExecSecurity.Allowlist => ExecApprovalDecision.Deny,
             ExecSecurity.Deny => ExecApprovalDecision.Deny,
             _ => ExecApprovalDecision.Deny,  // defensive
         };

--- a/src/OpenClaw.Shared/ExecApprovals/ExecCommandResolution.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecCommandResolution.cs
@@ -67,7 +67,7 @@ internal static class ExecCommandResolver
             var resolutions = new List<ExecCommandResolution>(segments.Count);
             foreach (var segment in segments)
             {
-                var token = ParseFirstToken(segment);
+                var token = ExecCommandToken.ParseFirstToken(segment);
                 if (token is null) return [];
                 // -EncodedCommand and aliases in segment position: fail-closed.
                 if (SegmentUsesEncodedCommand(segment, token)) return [];
@@ -110,7 +110,7 @@ internal static class ExecCommandResolver
         // Prefer first token of evaluationRawCommand when present.
         if (!string.IsNullOrWhiteSpace(rawCommand))
         {
-            var token = ParseFirstToken(rawCommand);
+            var token = ExecCommandToken.ParseFirstToken(rawCommand);
             if (token is not null) return ResolveExecutable(token, cwd, env);
         }
         return Resolve(command, cwd, env);
@@ -227,30 +227,6 @@ internal static class ExecCommandResolver
         return null;
     }
 
-    // Extracts the first shell-tokenized word from a command string.
-    private static string? ParseFirstToken(string command)
-    {
-        var trimmed = command.Trim();
-        if (trimmed.Length == 0) return null;
-        var first = trimmed[0];
-        if (first == '"' || first == '\'')
-        {
-            var rest = trimmed.AsSpan(1);
-            var end = rest.IndexOf(first);
-            if (end < 0) return null; // unclosed quote — fail-closed; do not guess the token
-            var inner = rest[..end].ToString();
-            if (inner.Length == 0) return null;
-            // Preserve any suffix after the closing quote up to the next whitespace.
-            // Handles `"git".exe` → "git.exe" and `"C:\Program Files\Git\bin\git".exe` → *.exe.
-            var afterClose = rest[(end + 1)..];
-            var suffixEnd = afterClose.IndexOfAny(' ', '\t');
-            var suffix = suffixEnd >= 0 ? afterClose[..suffixEnd].ToString() : afterClose.ToString();
-            return suffix.Length > 0 ? inner + suffix : inner;
-        }
-        var space = trimmed.AsSpan().IndexOfAny(' ', '\t');
-        return space >= 0 ? trimmed[..space] : trimmed;
-    }
-
     // ── allowAlwaysPatterns collection ───────────────────────────────────────
 
     private static void CollectPatterns(
@@ -271,7 +247,7 @@ internal static class ExecCommandResolver
             foreach (var seg in segments)
             {
                 // allowAlwaysPatterns does NOT fail-closed on -EncodedCommand: it's UX only.
-                var token = ParseFirstToken(seg);
+                var token = ExecCommandToken.ParseFirstToken(seg);
                 if (token is null) continue;
                 var res = ResolveExecutable(token, cwd, env);
                 if (res is null) continue;

--- a/src/OpenClaw.Shared/ExecApprovals/ExecCommandToken.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecCommandToken.cs
@@ -11,6 +11,10 @@ internal static class ExecCommandToken
     {
         var trimmed = token.Trim();
         if (trimmed.Length == 0) return string.Empty;
+        if (trimmed.Length >= 2
+            && ((trimmed[0] == '"' && trimmed[^1] == '"')
+                || (trimmed[0] == '\'' && trimmed[^1] == '\'')))
+            trimmed = trimmed[1..^1];
         var name = Path.GetFileName(trimmed.Replace('\\', '/'));
         if (name.Length == 0) name = trimmed;
         return name.ToLowerInvariant();
@@ -26,17 +30,43 @@ internal static class ExecCommandToken
     internal static bool IsEnv(string token) =>
         NormalizedBasename(token) == "env";
 
-    // Shell interpreters re-parse their own argument tail (metacharacters like &, |, ;),
-    // so an approved argv passed to one of these does NOT reach a single process verbatim:
-    // the shell can split it into additional commands the user never saw. Any executable
-    // in this set therefore cannot honor the approve-what-you-see guarantee.
-    private static readonly System.Collections.Generic.HashSet<string> s_shellInterpreters =
+    // A durable allow rule for one of these hosts delegates future meaning to a
+    // second command language. The rule would approve the host executable, not the
+    // script or command it interprets, so later invocations could execute different
+    // commands without another approval.
+    private static readonly System.Collections.Generic.HashSet<string> s_indirectCommandHosts =
         new(StringComparer.Ordinal)
         {
             "sh", "bash", "zsh", "dash", "ash", "ksh", "fish",
             "cmd", "powershell", "pwsh",
+            "wsl", "cscript", "wscript",
         };
 
-    internal static bool IsShellInterpreter(string token) =>
-        s_shellInterpreters.Contains(NormalizedBasename(token));
+    internal static bool IsIndirectCommandHost(string token) =>
+        s_indirectCommandHosts.Contains(NormalizedBasename(token));
+
+    // Extracts the first shell-tokenized word from a command pattern. Quoted paths
+    // remain one token, and a suffix after the closing quote is preserved so
+    // `"git".exe` is classified as git.exe.
+    internal static string? ParseFirstToken(string command)
+    {
+        var trimmed = command.Trim();
+        if (trimmed.Length == 0) return null;
+        var first = trimmed[0];
+        if (first == '"' || first == '\'')
+        {
+            var rest = trimmed.AsSpan(1);
+            var end = rest.IndexOf(first);
+            if (end < 0) return null;
+            var inner = rest[..end].ToString();
+            if (inner.Length == 0) return null;
+            var afterClose = rest[(end + 1)..];
+            var suffixEnd = afterClose.IndexOfAny(' ', '\t');
+            var suffix = suffixEnd >= 0 ? afterClose[..suffixEnd].ToString() : afterClose.ToString();
+            return suffix.Length > 0 ? inner + suffix : inner;
+        }
+
+        var space = trimmed.AsSpan().IndexOfAny(' ', '\t');
+        return space >= 0 ? trimmed[..space] : trimmed;
+    }
 }

--- a/src/OpenClaw.Shared/ExecApprovals/ExecCommandToken.cs
+++ b/src/OpenClaw.Shared/ExecApprovals/ExecCommandToken.cs
@@ -25,4 +25,18 @@ internal static class ExecCommandToken
 
     internal static bool IsEnv(string token) =>
         NormalizedBasename(token) == "env";
+
+    // Shell interpreters re-parse their own argument tail (metacharacters like &, |, ;),
+    // so an approved argv passed to one of these does NOT reach a single process verbatim:
+    // the shell can split it into additional commands the user never saw. Any executable
+    // in this set therefore cannot honor the approve-what-you-see guarantee.
+    private static readonly System.Collections.Generic.HashSet<string> s_shellInterpreters =
+        new(StringComparer.Ordinal)
+        {
+            "sh", "bash", "zsh", "dash", "ash", "ksh", "fish",
+            "cmd", "powershell", "pwsh",
+        };
+
+    internal static bool IsShellInterpreter(string token) =>
+        s_shellInterpreters.Contains(NormalizedBasename(token));
 }

--- a/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
+++ b/tests/OpenClaw.Shared.Tests/CapabilityTests.cs
@@ -277,6 +277,46 @@ public class SystemCapabilityTests
     public async Task ExecApprovals_SpecificAllowPattern_IsAccepted(string pattern)
         => Assert.True(await TrySetAllowRuleAsync(pattern), $"specific allow pattern '{pattern}' must be accepted");
 
+    [Theory]
+    [InlineData("cmd /c echo ok")]
+    [InlineData("CMD.EXE /c echo ok")]
+    [InlineData(@"""cmd.exe"" /c echo ok")]
+    [InlineData(@".\cmd.exe /c echo ok")]
+    [InlineData("powershell.exe -Command Get-Date")]
+    [InlineData("pwsh -c Get-Date")]
+    [InlineData("wsl.exe --exec bash -c id")]
+    [InlineData("bash -c id")]
+    [InlineData("sh -c id")]
+    [InlineData("cscript.exe test.js")]
+    [InlineData("wscript test.vbs")]
+    public async Task ExecApprovals_CommandHostAllowRule_IsRejected(string pattern)
+        => Assert.False(
+            await TrySetAllowRuleAsync(pattern),
+            $"command host allow pattern '{pattern}' must be rejected");
+
+    [Theory]
+    [InlineData(@"""cmd /c echo ok")]
+    [InlineData(@"""C:\Program Files\Tools\evil.exe --run")]
+    [InlineData("'' --run")]
+    public async Task ExecApprovals_MalformedQuotedExecutable_IsRejected(string pattern)
+        => Assert.False(
+            await TrySetAllowRuleAsync(pattern),
+            $"malformed executable pattern '{pattern}' must be rejected");
+
+    [Theory]
+    [InlineData("mycmd.exe *")]
+    [InlineData("pwsh-helper.exe *")]
+    [InlineData("bashful.exe *")]
+    [InlineData("wsl-helper.exe *")]
+    [InlineData("cscript-runner.exe *")]
+    [InlineData("wscript-helper.exe *")]
+    [InlineData("node *.js")]
+    [InlineData("python *.py")]
+    public async Task ExecApprovals_CommandHostSubstring_IsAccepted(string pattern)
+        => Assert.True(
+            await TrySetAllowRuleAsync(pattern),
+            $"non-host executable pattern '{pattern}' must be accepted");
+
     [Fact]
     public async Task Run_GatewayCmdWrapper_ExplicitOuterDenyStillWins()
     {
@@ -894,6 +934,7 @@ public class SystemCapabilityTests
     [InlineData(@"\\server\share\tool.exe")]
     [InlineData(@"\\?\C:\evil.exe")]
     [InlineData(@"""C:\Users\Public\evil.exe""")]
+    [InlineData(@"""C:\Program Files\Tools\evil.exe"" --run")]
     [InlineData(@"'C:\Users\Public\evil.exe'")]
     [InlineData(@"""\\server\share\tool.exe""")]
     [InlineData(@"""\\?\C:\evil.exe""")]

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
@@ -38,13 +38,16 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         return doc.RootElement.Clone();
     }
 
-    // ["cmd","/c","echo","hello"] reliably resolves cmd.exe on Windows via WellKnownPaths.
-    // Shell wrapper form: singular resolution succeeds; allowlistResolutions=[] (echo is a builtin).
+    // ["where","hello"] reliably resolves where.exe from System32 on Windows and is a
+    // plain (non-shell) executable, so it is an approvable command whose argv reaches
+    // the process verbatim. Shell interpreters (cmd, powershell, …) are intentionally
+    // not approvable — they would re-parse their argument tail — so they are unsuitable
+    // as a stand-in for a generic allowable command here.
     private static NodeInvokeRequest Req(string argsJson)
         => new() { Id = "r1", Command = "system.run", Args = Parse(argsJson) };
 
     private static NodeInvokeRequest DefaultReq()
-        => Req("""{"command":["cmd","/c","echo","hello"]}""");
+        => Req("""{"command":["where","hello"]}""");
 
     private void WriteStoreFile(string json)
         => File.WriteAllText(Path.Combine(_dir, "exec-approvals.json"), json);
@@ -204,7 +207,7 @@ public class ExecApprovalsCoordinatorTests : IDisposable
     [Fact]
     public async Task SecurityAllowlist_EmptyList_ReturnsAllowlistMiss()
     {
-        // ["cmd","/c","echo","hello"] → shell wrapper → allowlistResolutions=[] → AllowlistSatisfied=false
+        // Empty allowlist → no entry can match → AllowlistSatisfied=false → miss.
         WriteStoreFile("""{"version":1,"defaults":{"security":"allowlist","ask":"off"}}""");
         var result = await MakeCoordinator().HandleAsync(DefaultReq(), "c12");
         Assert.Equal(ExecApprovalV2Code.AllowlistMiss, result.Code);
@@ -295,7 +298,7 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"off"}}""");
         var log = new CapturingLogger();
         await MakeCoordinator(logger: log)
-            .HandleAsync(Req("""{"command":["cmd","/c","x\r\n[EXEC-APPROVALS] [fake] FAKE"]}"""), "c19");
+            .HandleAsync(Req("""{"command":["where","x\r\n[EXEC-APPROVALS] [fake] FAKE"]}"""), "c19");
 
         // Should allow (security=full, ask=off)
         Assert.NotNull(log.LastInfo);
@@ -464,10 +467,10 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         var result = await MakeCoordinator().HandleAsync(DefaultReq(), "payload-pre");
         Assert.True(result.IsAllow);
         Assert.NotNull(result.Execution);
-        // argv[0] is the RESOLVED absolute path, not the raw "cmd".
+        // argv[0] is the RESOLVED absolute path, not the raw "where".
         Assert.True(Path.IsPathFullyQualified(result.Execution!.Argv[0]));
-        Assert.EndsWith("cmd.exe", result.Execution.Argv[0], StringComparison.OrdinalIgnoreCase);
-        Assert.Equal(new[] { "/c", "echo", "hello" }, result.Execution.Argv.Skip(1).ToArray());
+        Assert.EndsWith("where.exe", result.Execution.Argv[0], StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(new[] { "hello" }, result.Execution.Argv.Skip(1).ToArray());
         Assert.Null(result.Execution.Env); // DefaultReq carries no env
     }
 
@@ -476,7 +479,7 @@ public class ExecApprovalsCoordinatorTests : IDisposable
     {
         WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"off"}}""");
         // A non-blocked env variable must survive sanitization and reach the payload.
-        var req = Req("""{"command":["cmd","/c","echo","hello"],"env":{"FOO":"bar"}}""");
+        var req = Req("""{"command":["where","hello"],"env":{"FOO":"bar"}}""");
         var result = await MakeCoordinator().HandleAsync(req, "payload-env");
         Assert.True(result.IsAllow);
         Assert.NotNull(result.Execution!.Env);
@@ -494,8 +497,8 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         Assert.True(result.IsAllow);
         Assert.NotNull(result.Execution);
         Assert.True(Path.IsPathFullyQualified(result.Execution!.Argv[0]));
-        Assert.EndsWith("cmd.exe", result.Execution.Argv[0], StringComparison.OrdinalIgnoreCase);
-        Assert.Equal(new[] { "/c", "echo", "hello" }, result.Execution.Argv.Skip(1).ToArray());
+        Assert.EndsWith("where.exe", result.Execution.Argv[0], StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(new[] { "hello" }, result.Execution.Argv.Skip(1).ToArray());
     }
 
     // End-to-end handoff: coordinator payload → runner plan (no shell)
@@ -522,7 +525,7 @@ public class ExecApprovalsCoordinatorTests : IDisposable
 
         Assert.True(plan.IsDirectArgv);
         Assert.Null(plan.Arguments); // no shell-wrapped command line
-        Assert.EndsWith("cmd.exe", plan.FileName, StringComparison.OrdinalIgnoreCase);
+        Assert.EndsWith("where.exe", plan.FileName, StringComparison.OrdinalIgnoreCase);
     }
 
     // Allow payload is built from the RESOLVED path, fail-closed if unresolved
@@ -692,6 +695,26 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         Assert.Null(ExecApprovalsCoordinator.BuildApprovedExecution(identity, sanitizedEnv: null));
     }
 
+    [Theory]
+    [InlineData(@"C:\Windows\System32\cmd.exe")]
+    [InlineData(@"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe")]
+    [InlineData(@"C:\Program Files\PowerShell\7\pwsh.exe")]
+    [InlineData(@"C:\Program Files\Git\usr\bin\bash.exe")]
+    public void BuildApprovedExecution_ReturnsNull_WhenResolvedToShellInterpreter(string resolvedPath)
+    {
+        // A shell interpreter re-parses its own argument tail, so an approved argv would
+        // not reach a single process verbatim — the shell could run commands the user
+        // never saw. Fail closed rather than execute a command whose real effect can
+        // differ from the approved text.
+        var resolution = new ExecCommandResolution(
+            RawExecutable: System.IO.Path.GetFileNameWithoutExtension(resolvedPath),
+            ResolvedPath: resolvedPath,
+            ExecutableName: System.IO.Path.GetFileName(resolvedPath),
+            Cwd: null);
+        var identity = MakeIdentity(new[] { resolvedPath, "-c", "echo hi" }, resolution);
+        Assert.Null(ExecApprovalsCoordinator.BuildApprovedExecution(identity, sanitizedEnv: null));
+    }
+
     [Fact]
     public void V2Result_IsAllow_FalseForAllDenyCodes()
     {
@@ -811,13 +834,13 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         var result = await MakeCoordinator(
             canPresent: AlwaysCanPresentEvaluator.Instance,
             prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.AllowAlways))
-            .HandleAsync(Req("""{"command":["cmd"]}"""), "pr8-A");
+            .HandleAsync(Req("""{"command":["where"]}"""), "pr8-A");
 
         Assert.True(result.IsAllow);
         var resolved = new ExecApprovalsStore(_dir, NullLogger.Instance).ResolveReadOnly("main");
         Assert.Single(resolved.Allowlist);
         Assert.NotNull(resolved.Allowlist[0].Pattern);
-        Assert.Contains("cmd", resolved.Allowlist[0].Pattern, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("where", resolved.Allowlist[0].Pattern, StringComparison.OrdinalIgnoreCase);
     }
 
     // B. AllowAlways + security=full → guard fails, no allowlist entry written.
@@ -828,7 +851,7 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         var result = await MakeCoordinator(
             canPresent: AlwaysCanPresentEvaluator.Instance,
             prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.AllowAlways))
-            .HandleAsync(Req("""{"command":["cmd"]}"""), "pr8-B");
+            .HandleAsync(Req("""{"command":["where"]}"""), "pr8-B");
 
         Assert.True(result.IsAllow);
         var json = File.ReadAllText(Path.Combine(_dir, "exec-approvals.json"));
@@ -846,12 +869,12 @@ public class ExecApprovalsCoordinatorTests : IDisposable
             "main": {
               "security": "allowlist",
               "ask": "off",
-              "allowlist": [{ "pattern": "**/cmd.exe" }]
+              "allowlist": [{ "pattern": "**/where.exe" }]
             }
           }
         }
         """);
-        var result = await MakeCoordinator().HandleAsync(Req("""{"command":["cmd"]}"""), "pr8-C");
+        var result = await MakeCoordinator().HandleAsync(Req("""{"command":["where"]}"""), "pr8-C");
 
         Assert.True(result.IsAllow);
         var resolved = new ExecApprovalsStore(_dir, NullLogger.Instance).ResolveReadOnly("main");
@@ -867,7 +890,7 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         var result = await MakeCoordinator(
             canPresent: AlwaysCanPresentEvaluator.Instance,
             prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.AllowOnce))
-            .HandleAsync(Req("""{"command":["cmd"]}"""), "pr8-D");
+            .HandleAsync(Req("""{"command":["where"]}"""), "pr8-D");
 
         Assert.True(result.IsAllow);
         var resolved = new ExecApprovalsStore(_dir, NullLogger.Instance).ResolveReadOnly("main");
@@ -883,8 +906,8 @@ public class ExecApprovalsCoordinatorTests : IDisposable
             canPresent: AlwaysCanPresentEvaluator.Instance,
             prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.AllowAlways));
 
-        await coordinator.HandleAsync(Req("""{"command":["cmd"]}"""), "pr8-E1");
-        await coordinator.HandleAsync(Req("""{"command":["cmd"]}"""), "pr8-E2");
+        await coordinator.HandleAsync(Req("""{"command":["where"]}"""), "pr8-E1");
+        await coordinator.HandleAsync(Req("""{"command":["where"]}"""), "pr8-E2");
 
         var resolved = new ExecApprovalsStore(_dir, NullLogger.Instance).ResolveReadOnly("main");
         Assert.Single(resolved.Allowlist);
@@ -902,7 +925,7 @@ public class ExecApprovalsCoordinatorTests : IDisposable
             "main": {
               "security": "allowlist",
               "ask": "always",
-              "allowlist": [{ "pattern": "**/cmd.exe" }]
+              "allowlist": [{ "pattern": "**/where.exe" }]
             }
           }
         }
@@ -910,7 +933,7 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         var result = await MakeCoordinator(
             canPresent: AlwaysCanPresentEvaluator.Instance,
             prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.AllowOnce))
-            .HandleAsync(Req("""{"command":["cmd"]}"""), "pr8-F");
+            .HandleAsync(Req("""{"command":["where"]}"""), "pr8-F");
 
         Assert.True(result.IsAllow);
         var resolved = new ExecApprovalsStore(_dir, NullLogger.Instance).ResolveReadOnly("main");
@@ -923,7 +946,7 @@ public class ExecApprovalsCoordinatorTests : IDisposable
     public async Task Fallback_AllowlistSatisfied_RecordsUse()
     {
         // askFallback=off → FallbackDecision=AllowOnce → pass2=Allow. AllowlistSatisfied=true
-        // because cmd.exe resolves and **/cmd.exe matches. RecordAllowlistUsageAsync must fire.
+        // because where.exe resolves and **/where.exe matches. RecordAllowlistUsageAsync must fire.
         WriteStoreFile("""
         {
           "version": 1,
@@ -932,13 +955,13 @@ public class ExecApprovalsCoordinatorTests : IDisposable
               "security": "allowlist",
               "ask": "always",
               "askFallback": "off",
-              "allowlist": [{ "pattern": "**/cmd.exe" }]
+              "allowlist": [{ "pattern": "**/where.exe" }]
             }
           }
         }
         """);
         // canPresent=false (default) → fallback path; askFallback=off → AllowOnce → Allow
-        var result = await MakeCoordinator().HandleAsync(Req("""{"command":["cmd"]}"""), "pr8-G");
+        var result = await MakeCoordinator().HandleAsync(Req("""{"command":["where"]}"""), "pr8-G");
 
         Assert.True(result.IsAllow);
         var resolved = new ExecApprovalsStore(_dir, NullLogger.Instance).ResolveReadOnly("main");
@@ -965,7 +988,7 @@ public class ExecApprovalsCoordinatorTests : IDisposable
             prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.AllowAlways));
 
         // Step 1: AllowAlways → entry persisted (no lastUsed* yet).
-        var first = await coordinator.HandleAsync(Req("""{"command":["cmd"]}"""), "proof-1");
+        var first = await coordinator.HandleAsync(Req("""{"command":["where"]}"""), "proof-1");
         Assert.True(first.IsAllow);
 
         _output.WriteLine("");
@@ -973,7 +996,7 @@ public class ExecApprovalsCoordinatorTests : IDisposable
         _output.WriteLine(File.ReadAllText(filePath));
 
         // Step 2: Same command again → allowlist hit, lastUsed* recorded.
-        var second = await coordinator.HandleAsync(Req("""{"command":["cmd"]}"""), "proof-2");
+        var second = await coordinator.HandleAsync(Req("""{"command":["where"]}"""), "proof-2");
         Assert.True(second.IsAllow);
 
         _output.WriteLine("");
@@ -1002,13 +1025,13 @@ public class ExecApprovalsCoordinatorTests : IDisposable
             "*": {
               "security": "allowlist",
               "ask": "off",
-              "allowlist": [{ "pattern": "**/cmd.exe" }]
+              "allowlist": [{ "pattern": "**/where.exe" }]
             }
           }
         }
         """);
 
-        var result = await MakeCoordinator().HandleAsync(Req("""{"command":["cmd"]}"""), "wildcard-1");
+        var result = await MakeCoordinator().HandleAsync(Req("""{"command":["where"]}"""), "wildcard-1");
 
         Assert.True(result.IsAllow);
         var json = File.ReadAllText(Path.Combine(_dir, "exec-approvals.json"));

--- a/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
+++ b/tests/OpenClaw.Shared.Tests/ExecApprovalsCoordinatorTests.cs
@@ -696,23 +696,152 @@ public class ExecApprovalsCoordinatorTests : IDisposable
     }
 
     [Theory]
+    [InlineData("cmd")]
+    [InlineData("CMD.EXE")]
+    [InlineData(@"""C:\Windows\System32\cmd.exe""")]
+    [InlineData(@".\pwsh.exe")]
+    [InlineData(@"C:\Program Files\Git\usr\bin\bash.exe")]
+    [InlineData("/usr/bin/sh")]
+    [InlineData("wsl.exe")]
+    [InlineData("cscript.exe")]
+    [InlineData("wscript")]
+    public void IndirectCommandHost_RecognizesAliasesPathsQuotesAndCasing(string token)
+        => Assert.True(ExecCommandToken.IsIndirectCommandHost(token));
+
+    [Theory]
+    [InlineData("mycmd.exe")]
+    [InlineData("pwsh-helper.exe")]
+    [InlineData("bashful.exe")]
+    [InlineData("wsl-helper.exe")]
+    [InlineData("cscript-runner.exe")]
+    [InlineData("wscript-helper.exe")]
+    [InlineData("node.exe")]
+    [InlineData("python.exe")]
+    public void IndirectCommandHost_DoesNotMatchExecutableNameSubstrings(string token)
+        => Assert.False(ExecCommandToken.IsIndirectCommandHost(token));
+
+    [Theory]
     [InlineData(@"C:\Windows\System32\cmd.exe")]
     [InlineData(@"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe")]
     [InlineData(@"C:\Program Files\PowerShell\7\pwsh.exe")]
     [InlineData(@"C:\Program Files\Git\usr\bin\bash.exe")]
-    public void BuildApprovedExecution_ReturnsNull_WhenResolvedToShellInterpreter(string resolvedPath)
+    [InlineData(@"C:\Windows\System32\wsl.exe")]
+    [InlineData(@"C:\Windows\System32\cscript.exe")]
+    [InlineData(@"C:\Windows\System32\wscript.exe")]
+    public void BuildApprovedExecution_AllowsCommandHostAfterExplicitOneTimeApproval(string resolvedPath)
     {
-        // A shell interpreter re-parses its own argument tail, so an approved argv would
-        // not reach a single process verbatim — the shell could run commands the user
-        // never saw. Fail closed rather than execute a command whose real effect can
-        // differ from the approved text.
         var resolution = new ExecCommandResolution(
             RawExecutable: System.IO.Path.GetFileNameWithoutExtension(resolvedPath),
             ResolvedPath: resolvedPath,
             ExecutableName: System.IO.Path.GetFileName(resolvedPath),
             Cwd: null);
         var identity = MakeIdentity(new[] { resolvedPath, "-c", "echo hi" }, resolution);
-        Assert.Null(ExecApprovalsCoordinator.BuildApprovedExecution(identity, sanitizedEnv: null));
+        var execution = ExecApprovalsCoordinator.BuildApprovedExecution(identity, sanitizedEnv: null);
+        Assert.NotNull(execution);
+        Assert.Equal(resolvedPath, execution!.Argv[0]);
+    }
+
+    [Fact]
+    public async Task AllowOnce_CommandHost_RemainsAllowedWithoutPersistence()
+    {
+        const string initialStore =
+            """{"version":1,"defaults":{"security":"allowlist","ask":"always"}}""";
+        WriteStoreFile(initialStore);
+        var result = await MakeCoordinator(
+            canPresent: AlwaysCanPresentEvaluator.Instance,
+            prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.AllowOnce))
+            .HandleAsync(
+                Req("""{"command":["C:\\Windows\\System32\\wsl.exe","--exec","echo","ok"]}"""),
+                "command-host-once");
+
+        Assert.True(result.IsAllow);
+        Assert.Equal(initialStore, File.ReadAllText(Path.Combine(_dir, "exec-approvals.json")));
+    }
+
+    [Fact]
+    public async Task AllowAlways_CommandHost_IsDeniedWithoutPersistence()
+    {
+        const string initialStore =
+            """{"version":1,"defaults":{"security":"allowlist","ask":"always"}}""";
+        WriteStoreFile(initialStore);
+        var result = await MakeCoordinator(
+            canPresent: AlwaysCanPresentEvaluator.Instance,
+            prompt: new FixedDecisionPromptHandler(ExecApprovalPromptOutcome.AllowAlways))
+            .HandleAsync(
+                Req("""{"command":["C:\\Windows\\System32\\wsl.exe","--exec","echo","ok"]}"""),
+                "command-host-always");
+
+        Assert.Equal(ExecApprovalV2Code.ValidationFailed, result.Code);
+        Assert.Equal("persistent-approval-not-permitted-for-command-host", result.Reason);
+        Assert.Equal(initialStore, File.ReadAllText(Path.Combine(_dir, "exec-approvals.json")));
+    }
+
+    [Fact]
+    public async Task StoredAllowlist_CommandHost_IsDeniedWithoutMutatingPolicy()
+    {
+        const string initialStore =
+            """{"version":1,"defaults":{"security":"allowlist","ask":"off"},"agents":{"main":{"allowlist":[{"pattern":"**/wsl.exe"}]}}}""";
+        WriteStoreFile(initialStore);
+        var result = await MakeCoordinator().HandleAsync(
+            Req("""{"command":["C:\\Windows\\System32\\wsl.exe","--exec","echo","ok"]}"""),
+            "command-host-stored");
+
+        Assert.Equal(ExecApprovalV2Code.ValidationFailed, result.Code);
+        Assert.Equal("persistent-approval-not-permitted-for-command-host", result.Reason);
+        Assert.Equal(initialStore, File.ReadAllText(Path.Combine(_dir, "exec-approvals.json")));
+    }
+
+    [Fact]
+    public async Task HeadlessAllowlistFallback_CommandHost_IsDeniedWithoutMutatingPolicy()
+    {
+        const string initialStore =
+            """{"version":1,"defaults":{"security":"allowlist","ask":"always","askFallback":"allowlist"},"agents":{"main":{"allowlist":[{"pattern":"**/wsl.exe"}]}}}""";
+        WriteStoreFile(initialStore);
+        var result = await MakeCoordinator().HandleAsync(
+            Req("""{"command":["C:\\Windows\\System32\\wsl.exe","--exec","echo","ok"]}"""),
+            "command-host-fallback");
+
+        Assert.Equal(ExecApprovalV2Code.ValidationFailed, result.Code);
+        Assert.Equal("persistent-approval-not-permitted-for-command-host", result.Reason);
+        Assert.Equal(initialStore, File.ReadAllText(Path.Combine(_dir, "exec-approvals.json")));
+    }
+
+    [Fact]
+    public async Task HeadlessFullWithAllowlistFallback_CommandHost_IsDeniedWhenMatchDependent()
+    {
+        const string initialStore =
+            """{"version":1,"defaults":{"security":"full","ask":"always","askFallback":"allowlist"},"agents":{"main":{"allowlist":[{"pattern":"**/wsl.exe"}]}}}""";
+        WriteStoreFile(initialStore);
+        var result = await MakeCoordinator().HandleAsync(
+            Req("""{"command":["C:\\Windows\\System32\\wsl.exe","--exec","echo","ok"]}"""),
+            "command-host-full-allowlist-fallback");
+
+        Assert.Equal(ExecApprovalV2Code.ValidationFailed, result.Code);
+        Assert.Equal("persistent-approval-not-permitted-for-command-host", result.Reason);
+        Assert.Equal(initialStore, File.ReadAllText(Path.Combine(_dir, "exec-approvals.json")));
+    }
+
+    [Fact]
+    public async Task HeadlessFullFallback_CommandHost_RemainsAllowedWhenNotMatchDependent()
+    {
+        WriteStoreFile(
+            """{"version":1,"defaults":{"security":"full","ask":"always","askFallback":"full"}}""");
+        var result = await MakeCoordinator().HandleAsync(
+            Req("""{"command":["C:\\Windows\\System32\\wsl.exe","--exec","echo","ok"]}"""),
+            "command-host-full-fallback");
+
+        Assert.True(result.IsAllow);
+    }
+
+    [Fact]
+    public async Task SecurityFull_CommandHost_RemainsAllowed()
+    {
+        WriteStoreFile("""{"version":1,"defaults":{"security":"full","ask":"off"}}""");
+        var result = await MakeCoordinator().HandleAsync(
+            Req("""{"command":["C:\\Windows\\System32\\wsl.exe","--exec","echo","ok"]}"""),
+            "command-host-full");
+
+        Assert.True(result.IsAllow);
     }
 
     [Fact]


### PR DESCRIPTION
## What

Durable exec approval rules can safely name only executables whose argument vector retains its meaning. Shells and command hosts reinterpret arguments as another command language, so persisting the host executable would authorize different future commands.

This PR rejects durable authorization for exact indirect command hosts:

- Windows: `cmd`, `powershell`, `pwsh`, `wsl`, `cscript`, `wscript`
- POSIX and WSL: `sh`, `bash`, `zsh`, `dash`, `ash`, `ksh`, `fish`

Matching is by normalized executable basename, not string fragments. Aliases, casing, `.exe`, quoted tokens, full paths, relative paths, and resolved executable paths are covered. Names such as `mycmd.exe`, `bashful.exe`, `pwsh-helper.exe`, and `cscript-runner.exe` remain valid.

## Semantics

- Remote `system.execApprovals.set` cannot create an allow rule whose executable token is an indirect command host.
- V2 `AllowAlways` cannot persist an indirect command host.
- Existing stored host rules are preserved byte-for-byte but are not consumed for pre-approval or match-dependent headless fallback.
- Explicit interactive `AllowOnce` remains allowed and never persists.
- Explicit `security=full` behavior remains unchanged, including a pure Full headless fallback.
- Batch-script and modified `env` wrapper fail-closed behavior is unchanged.
- V2 remains opt-in and off by default.

## ClawSweeper review incorporation

ClawSweeper reviewed exact head `539d33c84cb6ef81173ff4a058cb9bd461e72efd` and identified `wsl.exe bash -c ...` as an indirect-shell bypass. Current head `553372908f45d9e0dfb45aa17e61d265c171f430` incorporates that finding by classifying `wsl` as an indirect command host and testing stored-rule, AllowAlways, and match-dependent fallback paths.

ClawSweeper then reviewed exact current head `553372908f45d9e0dfb45aa17e61d265c171f430` and reported:

- overall correctness: patch is correct;
- security review: cleared;
- code findings: none;
- confidence: 0.72;
- keep open solely for missing current-head gateway/MXC runtime proof.

Independent security and rubber-duck reviews also identified and verified both headless fallback quadrants:

- `security=allowlist` with an allowlist-backed fallback;
- `security=full` with `askFallback=allowlist`.

The coordinator records whether a fallback allow actually depended on a stored match and rejects durable host authorization on that basis. Final security and rubber-duck re-reviews reported no remaining findings.

## Validation

Current head: `553372908f45d9e0dfb45aa17e61d265c171f430`

| Command | Result |
|---|---|
| `.\build.ps1` | All 5 projects built successfully |
| Focused `ExecApprovalsCoordinatorTests` and `CapabilityTests` | 401 passed, 0 failed |
| `dotnet test .\tests\OpenClaw.Shared.Tests\OpenClaw.Shared.Tests.csproj --no-restore` | 3,161 passed, 31 skipped, 0 failed |
| `dotnet test .\tests\OpenClaw.Tray.Tests\OpenClaw.Tray.Tests.csproj --no-restore` with xUnit collections serialized | 1,862 passed, 0 failed |
| Hosted Build and Test run `29809912275` | All required jobs passed on current head |
| Independent security review | Clean after two verified fallback findings were fixed |
| Independent rubber-duck review | Clean after one verified fallback quadrant was fixed |
| ClawSweeper exact-head review | Patch correct, security cleared, no code findings |

The normal parallel local Tray run exposed an unrelated `DeviceIdentity` atomic-file race in `GatewayConnectionManagerConnectTests`; the exact failing test passed alone, and the complete serialized suite passed.

Hosted setup-connect E2E initially hit a transient WSL failure: the fresh distro did not register. The failed job was rerun once and passed; all build, test, setup-connect, network-recovery, and revocation-recovery jobs are green on the current head.

Structured autoreview is blocked by local Codex 0.137 refusing to create its isolated helper binaries. Three unchanged Sol review attempts produced no model result or code finding.

## Real behavior proof

Current-head focused tests execute the real coordinator, evaluator, resolver, matcher, and filesystem-backed approvals store. They prove:

- interactive `AllowOnce` for `wsl.exe` returns an execution payload and does not modify the store;
- `AllowAlways` for `wsl.exe` is denied and leaves the store unchanged;
- a stored `**/wsl.exe` rule is denied and remains byte-for-byte unchanged;
- headless Allowlist fallback and Full plus `askFallback=allowlist` cannot consume a stored host rule;
- pure Full fallback remains allowed;
- remote rule variants across quoting, paths, aliases, casing, and extensions are rejected;
- non-host substring names remain accepted.

Live gateway/MXC proof was not rerun. It is blocked on this host by the known upstream 2026.6.11 WSL gateway self-race, and the maintainer explicitly requested that this review not consume the WSL slot or retry MXC. ClawSweeper therefore keeps the PR open for proof sufficiency. The earlier PR-body MXC success claim has been removed from current-head proof.

## Security impact

This narrows durable command authorization without changing default-off V2 routing or explicit one-time approval. Stored policy files are not migrated, rewritten, or silently corrupted. Rejected requests return `persistent-approval-not-permitted-for-command-host`.