### PR TITLE
Fix onboarding gateway choice layout and state

### DIFF
--- a/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml
@@ -22,8 +22,10 @@
                        Text="OpenClaw runs your agent through a gateway. Choose how to set it up on this PC. You can change this later." />
         </StackPanel>
 
-        <StackPanel Grid.Row="1" VerticalAlignment="Top" Margin="0,24,0,0" Spacing="12"
-                    MaxWidth="560" HorizontalAlignment="Stretch">
+        <ScrollViewer Grid.Row="1" Margin="0,24,0,0"
+                      VerticalScrollBarVisibility="Auto"
+                      HorizontalScrollBarVisibility="Disabled">
+            <StackPanel Spacing="12" MaxWidth="560" HorizontalAlignment="Stretch">
 
             <Border x:Name="InstallCard"
                     HorizontalAlignment="Stretch"
@@ -85,7 +87,8 @@
                 </Grid>
             </Border>
 
-        </StackPanel>
+            </StackPanel>
+        </ScrollViewer>
 
         <Grid Grid.Row="2" ColumnDefinitions="*,Auto" Margin="0,16,0,0">
             <StackPanel Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="8"

--- a/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml
@@ -23,71 +23,84 @@
         </StackPanel>
 
         <ScrollViewer Grid.Row="1" Margin="0,24,0,0"
+                      IsTabStop="False"
                       VerticalScrollBarVisibility="Auto"
                       HorizontalScrollBarVisibility="Disabled">
-            <StackPanel Spacing="12" MaxWidth="560" HorizontalAlignment="Stretch">
-
-            <Border x:Name="InstallCard"
-                    HorizontalAlignment="Stretch"
-                    Padding="16" CornerRadius="4"
-                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    BorderBrush="{ThemeResource AccentFillColorDefaultBrush}"
-                    BorderThickness="2"
-                    PointerPressed="InstallCard_Pressed"
-                    AutomationProperties.Name="Install a local gateway (WSL), recommended">
-                <Grid ColumnDefinitions="Auto,*" ColumnSpacing="16">
-                    <Border Grid.Column="0" Width="44" Height="44" CornerRadius="6"
-                            Background="{ThemeResource AccentFillColorDefaultBrush}" VerticalAlignment="Top">
-                        <FontIcon Glyph="&#xE756;" FontSize="20" IsTextScaleFactorEnabled="False"
-                                  Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
-                    </Border>
-                    <StackPanel Grid.Column="1" Spacing="3">
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <TextBlock x:Name="InstallTitle"
-                                       Text="Install a local gateway (WSL)"
-                                       Style="{StaticResource BodyStrongTextBlockStyle}"
-                                       VerticalAlignment="Center" />
-                            <Border CornerRadius="4" Padding="7,1" VerticalAlignment="Center"
-                                    BorderBrush="{ThemeResource AccentTextFillColorPrimaryBrush}" BorderThickness="1">
-                                <TextBlock Text="Recommended"
-                                           Style="{StaticResource CaptionTextBlockStyle}"
-                                           Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+            <RadioButtons x:Name="GatewayChoiceSelector"
+                          AutomationProperties.Name="Gateway setup method"
+                          MaxWidth="560"
+                          MaxColumns="1"
+                          HorizontalAlignment="Stretch"
+                          SelectionChanged="GatewayChoice_SelectionChanged">
+                <RadioButton x:Name="InstallChoice"
+                             AutomationProperties.AutomationId="WelcomeInstallLocalGatewayChoice"
+                             AutomationProperties.Name="Install a local gateway (WSL), recommended"
+                             Margin="0,0,0,12"
+                             HorizontalAlignment="Stretch"
+                             HorizontalContentAlignment="Stretch">
+                    <Border x:Name="InstallCard"
+                            HorizontalAlignment="Stretch"
+                            Padding="16" CornerRadius="4"
+                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            BorderBrush="{ThemeResource AccentFillColorDefaultBrush}"
+                            BorderThickness="2">
+                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="16">
+                            <Border Grid.Column="0" Width="44" Height="44" CornerRadius="6"
+                                    Background="{ThemeResource AccentFillColorDefaultBrush}" VerticalAlignment="Top">
+                                <FontIcon Glyph="&#xE756;" FontSize="20" IsTextScaleFactorEnabled="False"
+                                          Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
                             </Border>
-                        </StackPanel>
-                        <TextBlock TextWrapping="Wrap"
-                                   Style="{StaticResource CaptionTextBlockStyle}"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                   Text="A private, self-hosted OpenClaw gateway in an isolated Ubuntu WSL instance. We'll show exactly what gets installed before anything runs." />
-                    </StackPanel>
-                </Grid>
-            </Border>
-
-            <Border x:Name="ConnectCard"
-                    HorizontalAlignment="Stretch"
-                    Padding="16" CornerRadius="4"
-                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                    BorderThickness="1"
-                    PointerPressed="ConnectCard_Pressed"
-                    AutomationProperties.Name="Connect to an existing gateway">
-                <Grid ColumnDefinitions="Auto,*" ColumnSpacing="16">
-                    <Border Grid.Column="0" Width="44" Height="44" CornerRadius="6"
-                            Background="{ThemeResource SubtleFillColorSecondaryBrush}" VerticalAlignment="Top">
-                        <FontIcon Glyph="&#xE71B;" FontSize="20" IsTextScaleFactorEnabled="False"
-                                  Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+                            <StackPanel Grid.Column="1" Spacing="3">
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <TextBlock x:Name="InstallTitle"
+                                               Text="Install a local gateway (WSL)"
+                                               Style="{StaticResource BodyStrongTextBlockStyle}"
+                                               VerticalAlignment="Center" />
+                                    <Border CornerRadius="4" Padding="7,1" VerticalAlignment="Center"
+                                            BorderBrush="{ThemeResource AccentTextFillColorPrimaryBrush}" BorderThickness="1">
+                                        <TextBlock Text="Recommended"
+                                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                                   Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+                                    </Border>
+                                </StackPanel>
+                                <TextBlock TextWrapping="Wrap"
+                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           Text="A private, self-hosted OpenClaw gateway in an isolated Ubuntu WSL instance. We'll show exactly what gets installed before anything runs." />
+                            </StackPanel>
+                        </Grid>
                     </Border>
-                    <StackPanel Grid.Column="1" Spacing="3">
-                        <TextBlock Text="Connect to an existing gateway"
-                                   Style="{StaticResource BodyStrongTextBlockStyle}" />
-                        <TextBlock TextWrapping="Wrap"
-                                   Style="{StaticResource CaptionTextBlockStyle}"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                   Text="Already run an OpenClaw gateway: here, on another machine, or remote? Pair without installing anything." />
-                    </StackPanel>
-                </Grid>
-            </Border>
+                </RadioButton>
 
-            </StackPanel>
+                <RadioButton x:Name="ConnectChoice"
+                             AutomationProperties.AutomationId="WelcomeConnectExistingGatewayChoice"
+                             AutomationProperties.Name="Connect to an existing gateway"
+                             HorizontalAlignment="Stretch"
+                             HorizontalContentAlignment="Stretch">
+                    <Border x:Name="ConnectCard"
+                            HorizontalAlignment="Stretch"
+                            Padding="16" CornerRadius="4"
+                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                            BorderThickness="1">
+                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="16">
+                            <Border Grid.Column="0" Width="44" Height="44" CornerRadius="6"
+                                    Background="{ThemeResource SubtleFillColorSecondaryBrush}" VerticalAlignment="Top">
+                                <FontIcon Glyph="&#xE71B;" FontSize="20" IsTextScaleFactorEnabled="False"
+                                          Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+                            </Border>
+                            <StackPanel Grid.Column="1" Spacing="3">
+                                <TextBlock Text="Connect to an existing gateway"
+                                           Style="{StaticResource BodyStrongTextBlockStyle}" />
+                                <TextBlock TextWrapping="Wrap"
+                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           Text="Already run an OpenClaw gateway: here, on another machine, or remote? Pair without installing anything." />
+                            </StackPanel>
+                        </Grid>
+                    </Border>
+                </RadioButton>
+            </RadioButtons>
         </ScrollViewer>
 
         <Grid Grid.Row="2" ColumnDefinitions="*,Auto" Margin="0,16,0,0">
@@ -101,10 +114,12 @@
                 <Border Width="8" Height="8" CornerRadius="4" VerticalAlignment="Center" Background="{ThemeResource SetupInactiveDotBrush}" />
                 <Border Width="8" Height="8" CornerRadius="4" VerticalAlignment="Center" Background="{ThemeResource SetupInactiveDotBrush}" />
             </StackPanel>
-            <Button x:Name="BackButton" Grid.Column="0" Content="Back"
+            <Button x:Name="BackButton" AutomationProperties.AutomationId="WelcomeBackButton"
+                    Grid.Column="0" Content="Back"
                     MinWidth="100" HorizontalAlignment="Left"
                     Click="Back_Click" />
-            <Button x:Name="NextButton" Grid.Column="1" Content="Next"
+            <Button x:Name="NextButton" AutomationProperties.AutomationId="WelcomeNextButton"
+                    Grid.Column="1" Content="Next"
                     MinWidth="100" HorizontalAlignment="Right"
                     Style="{StaticResource AccentButtonStyle}"
                     Click="Next_Click" />

--- a/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
@@ -29,6 +29,8 @@ public sealed partial class WelcomePage : Page
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
         _config = e.Parameter as SetupConfig ?? new SetupConfig();
+        _installSelected = SetupWindow.Active?.IsWelcomeInstallSelected ?? true;
+        UpdateCardSelection();
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
@@ -56,13 +58,18 @@ public sealed partial class WelcomePage : Page
 
     private void InstallCard_Pressed(object sender, PointerRoutedEventArgs e)
     {
-        _installSelected = true;
-        UpdateCardSelection();
+        SetInstallSelected(true);
     }
 
     private void ConnectCard_Pressed(object sender, PointerRoutedEventArgs e)
     {
-        _installSelected = false;
+        SetInstallSelected(false);
+    }
+
+    private void SetInstallSelected(bool installSelected)
+    {
+        _installSelected = installSelected;
+        SetupWindow.Active?.SetWelcomeInstallSelected(installSelected);
         UpdateCardSelection();
     }
 

--- a/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/Pages/WelcomePage.xaml.cs
@@ -2,7 +2,6 @@ using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Hosting;
-using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using OpenClaw.SetupEngine;
@@ -18,11 +17,13 @@ public sealed partial class WelcomePage : Page
     private const string CheckingButtonText = "Checking existing setup...";
     private SetupConfig? _config;
     private bool _installSelected = true; // default selection
+    private bool _suppressSelectionWrite;
 
     public WelcomePage()
     {
         InitializeComponent();
         Loaded += OnLoaded;
+        ActualThemeChanged += (_, _) => UpdateCardSelection();
         UpdateCardSelection();
     }
 
@@ -30,6 +31,15 @@ public sealed partial class WelcomePage : Page
     {
         _config = e.Parameter as SetupConfig ?? new SetupConfig();
         _installSelected = SetupWindow.Active?.IsWelcomeInstallSelected ?? true;
+        _suppressSelectionWrite = true;
+        try
+        {
+            GatewayChoiceSelector.SelectedIndex = _installSelected ? 0 : 1;
+        }
+        finally
+        {
+            _suppressSelectionWrite = false;
+        }
         UpdateCardSelection();
     }
 
@@ -56,14 +66,10 @@ public sealed partial class WelcomePage : Page
         visual.StartAnimation("Scale", pulse);
     }
 
-    private void InstallCard_Pressed(object sender, PointerRoutedEventArgs e)
+    private void GatewayChoice_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
-        SetInstallSelected(true);
-    }
-
-    private void ConnectCard_Pressed(object sender, PointerRoutedEventArgs e)
-    {
-        SetInstallSelected(false);
+        if (!_suppressSelectionWrite && GatewayChoiceSelector.SelectedIndex is 0 or 1)
+            SetInstallSelected(GatewayChoiceSelector.SelectedIndex == 0);
     }
 
     private void SetInstallSelected(bool installSelected)

--- a/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
@@ -93,7 +93,7 @@ public sealed partial class SetupWindow : Window
         var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
         var dpi = GetDpiForWindow(hwnd);
         var scale = dpi / 96.0;
-        AppWindow.Resize(new Windows.Graphics.SizeInt32((int)(720 * scale), (int)(820 * scale)));
+        AppWindow.Resize(new Windows.Graphics.SizeInt32((int)(720 * scale), (int)(560 * scale)));
 
         // Extend into title bar for modern look
         ExtendsContentIntoTitleBar = true;

--- a/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
@@ -12,6 +12,7 @@ namespace OpenClaw.SetupEngine.UI;
 public sealed partial class SetupWindow : Window
 {
     private SetupConfig _config = null!;
+    private bool _isWelcomeInstallSelected = true;
     private SetupRunLock? _setupLock;
     private readonly CancellationTokenSource _lifetimeCts = new();
     private Task<StepResult>? _contextApplyTask;
@@ -182,6 +183,8 @@ public sealed partial class SetupWindow : Window
 
     public void NavigateToSecurityNotice(bool back = false) => NavigateTo(typeof(SecurityNoticePage), _config, back);
     public void NavigateToWelcome(bool back = false) => NavigateTo(typeof(WelcomePage), _config, back);
+    public bool IsWelcomeInstallSelected => _isWelcomeInstallSelected;
+    public void SetWelcomeInstallSelected(bool installSelected) => _isWelcomeInstallSelected = installSelected;
     public void NavigateToAdvancedSetup() => NavigateTo(typeof(AdvancedSetupPage), _config);
     public void NavigateToCapabilities() => NavigateTo(typeof(CapabilitiesPage), _config);
     public void NavigateToProgress() => NavigateTo(typeof(ProgressPage), CreateProgressPageArgs(showMilestoneOnly: false));

--- a/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
+++ b/src/OpenClaw.SetupEngine.UI/SetupWindow.xaml.cs
@@ -93,7 +93,7 @@ public sealed partial class SetupWindow : Window
         var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
         var dpi = GetDpiForWindow(hwnd);
         var scale = dpi / 96.0;
-        AppWindow.Resize(new Windows.Graphics.SizeInt32((int)(720 * scale), (int)(560 * scale)));
+        AppWindow.Resize(new Windows.Graphics.SizeInt32((int)(720 * scale), (int)(820 * scale)));
 
         // Extend into title bar for modern look
         ExtendsContentIntoTitleBar = true;

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -816,7 +816,7 @@ public sealed class AppRefactorContractTests
     }
 
     [Fact]
-    public void SetupWelcomePage_ScrollsChoicesAndRestoresTheSelectedPath()
+    public void SetupWelcomePage_KeepsNavigationOutsideScrollableSemanticChoices()
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();
         var xaml = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "WelcomePage.xaml"));
@@ -825,6 +825,13 @@ public sealed class AppRefactorContractTests
 
         Assert.Contains("<ScrollViewer Grid.Row=\"1\"", xaml);
         Assert.Contains("VerticalScrollBarVisibility=\"Auto\"", xaml);
+        Assert.Contains("<RadioButtons x:Name=\"GatewayChoiceSelector\"", xaml);
+        Assert.Contains("AutomationProperties.AutomationId=\"WelcomeInstallLocalGatewayChoice\"", xaml);
+        Assert.Contains("AutomationProperties.AutomationId=\"WelcomeConnectExistingGatewayChoice\"", xaml);
+        Assert.DoesNotContain("PointerPressed=", xaml);
+        AssertInOrder(xaml, "<ScrollViewer Grid.Row=\"1\"", "</ScrollViewer>", "<Grid Grid.Row=\"2\"");
+        Assert.DoesNotContain("GatewayChoiceSelector.SelectedIndex = 0;", welcomePage);
+        Assert.Contains("_suppressSelectionWrite = true", welcomePage);
         Assert.Contains("SetupWindow.Active?.IsWelcomeInstallSelected ?? true", welcomePage);
         Assert.Contains("SetupWindow.Active?.SetWelcomeInstallSelected(installSelected)", welcomePage);
         Assert.Contains("private bool _isWelcomeInstallSelected = true", setupWindow);

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -829,7 +829,6 @@ public sealed class AppRefactorContractTests
         Assert.Contains("SetupWindow.Active?.SetWelcomeInstallSelected(installSelected)", welcomePage);
         Assert.Contains("private bool _isWelcomeInstallSelected = true", setupWindow);
         Assert.Contains("public bool IsWelcomeInstallSelected => _isWelcomeInstallSelected", setupWindow);
-        Assert.Contains("(int)(720 * scale), (int)(560 * scale)", setupWindow);
     }
 
     [Fact]

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -816,6 +816,22 @@ public sealed class AppRefactorContractTests
     }
 
     [Fact]
+    public void SetupWelcomePage_ScrollsChoicesAndRestoresTheSelectedPath()
+    {
+        var root = TestRepositoryPaths.GetRepositoryRoot();
+        var xaml = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "WelcomePage.xaml"));
+        var welcomePage = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "Pages", "WelcomePage.xaml.cs"));
+        var setupWindow = File.ReadAllText(Path.Combine(root, "src", "OpenClaw.SetupEngine.UI", "SetupWindow.xaml.cs"));
+
+        Assert.Contains("<ScrollViewer Grid.Row=\"1\"", xaml);
+        Assert.Contains("VerticalScrollBarVisibility=\"Auto\"", xaml);
+        Assert.Contains("SetupWindow.Active?.IsWelcomeInstallSelected ?? true", welcomePage);
+        Assert.Contains("SetupWindow.Active?.SetWelcomeInstallSelected(installSelected)", welcomePage);
+        Assert.Contains("private bool _isWelcomeInstallSelected = true", setupWindow);
+        Assert.Contains("public bool IsWelcomeInstallSelected => _isWelcomeInstallSelected", setupWindow);
+    }
+
+    [Fact]
     public void WizardErrorState_UsesMoreOptionsAndPreservesTranscriptOnGatewayRestart()
     {
         var root = TestRepositoryPaths.GetRepositoryRoot();

--- a/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
+++ b/tests/OpenClaw.Tray.Tests/AppRefactorContractTests.cs
@@ -829,6 +829,7 @@ public sealed class AppRefactorContractTests
         Assert.Contains("SetupWindow.Active?.SetWelcomeInstallSelected(installSelected)", welcomePage);
         Assert.Contains("private bool _isWelcomeInstallSelected = true", setupWindow);
         Assert.Contains("public bool IsWelcomeInstallSelected => _isWelcomeInstallSelected", setupWindow);
+        Assert.Contains("(int)(720 * scale), (int)(560 * scale)", setupWindow);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- keep Welcome-page gateway choices inside the available scroll region while Back and Next remain fixed
- use native `RadioButtons`/`RadioButton` semantics with stable automation IDs so pointer, arrow-key, Tab, and assistive-technology input select the same paths
- retain the selected gateway path when returning from Advanced Setup, while each new `SetupWindow` starts on local WSL setup
- refresh selection brushes when the effective theme changes
- merge current `origin/main` normally into the PR branch

## Validation

- `./build.ps1`: all projects passed (Shared, CLI, WinNode CLI, SetupEngine, WinUI)
- `dotnet test ./tests/OpenClaw.Shared.Tests/OpenClaw.Shared.Tests.csproj --no-restore`: 3161 passed, 31 skipped
- `dotnet test ./tests/OpenClaw.Tray.Tests/OpenClaw.Tray.Tests.csproj --no-restore`: 1863 passed
- `dotnet test ./tests/OpenClaw.SetupEngine.Tests/OpenClaw.SetupEngine.Tests.csproj --no-restore`: 697 passed
- focused Welcome contract tests: 2 passed
- `dotnet test ./tests/OpenClaw.Tray.UITests/OpenClaw.Tray.UITests.csproj --no-build -c Debug -r win-x64 --filter 'Category!=Accessibility'`: 93 passed
- Axe accessibility suite: 18 of 19 pages passed on the final rerun. The unrelated Chat page failed an existing transient `ClickablePointOnScreen` assertion for Attach/Unmute/Voice; this PR does not touch Chat. The onboarding window is not part of that suite and was inspected directly through its live accessibility tree.
- `git diff --check`: passed

## Real behavior proof

Current-head isolated preview (`OPENCLAW_SETUP_PREVIEW_PAGE=welcome`) was launched from this worktree with dedicated data directories.

- PID 73308: dark-theme, 150% DPI proof. Down Arrow moved native radio selection from local WSL to existing gateway. Tab moved from the radio group to Back, then Next. Next opened the existing-gateway instructions. Back recreated Welcome and Connect remained selected.
- The same window was resized from 1080x1230 physical pixels to 1080x810. The choices region exposed a vertical scrollbar while the step indicator, Back, and Next remained fully visible outside it.
- PID 74872: a new isolated wizard run opened with local WSL selected, proving selection does not leak across runs.
- The live accessibility tree exposed a named `Gateway setup method` radio group, selected/selectable radio states, stable IDs `WelcomeInstallLocalGatewayChoice` and `WelcomeConnectExistingGatewayChoice`, and stable Back/Next automation IDs.
- Both proof PIDs were stopped and confirmed absent after capture.
- Dark theme was visibly exercised. Light/high-contrast were not live-switched because setup follows the host OS theme and changing system accessibility settings would disturb the shared validation host. The controls use native radio selection plus WinUI `ThemeResource` brushes, so selection does not rely on accent-border color alone; `ActualThemeChanged` refreshes the custom border presentation.

## Review

Rubber-duck review found and fixed a blocking initialization-order bug where assigning the default radio index could overwrite the restored Connect choice before `OnNavigatedTo`. Programmatic restoration is now guarded from writing back. A proposed extra state object/test seam was removed so `SetupWindow` remains the single per-run state owner.
